### PR TITLE
feat: config based mcp client timeout

### DIFF
--- a/app/agents/voice/automatic/services/mcp/automatic_client.py
+++ b/app/agents/voice/automatic/services/mcp/automatic_client.py
@@ -3,6 +3,7 @@ import json
 import base64
 from typing import Dict, Any, Optional, Callable
 
+from app.core.config import MCP_CLIENT_TIMEOUT
 from app.core.logger import logger
 from pipecat.adapters.schemas.tools_schema import ToolsSchema
 from pipecat.adapters.schemas.function_schema import FunctionSchema
@@ -22,7 +23,7 @@ class StreamableHTTPTransport:
         self._server_url = server_url.strip()
         self._auth_token = auth_token
         self._context_b64 = base64.b64encode(json.dumps(context).encode()).decode()
-        self._client = httpx.AsyncClient(timeout=15)
+        self._client = httpx.AsyncClient(timeout=MCP_CLIENT_TIMEOUT)
         self._demo_mode = context.get("enableDemoMode", False)
 
     async def post(self, method: str, params: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
@@ -43,7 +44,9 @@ class StreamableHTTPTransport:
         try:
             logger.info(f"Attempting to POST to: {self._server_url} with payload: {json_rpc_payload} and headers: {headers}")
             async with self._client.stream("POST", self._server_url, headers=headers, json=json_rpc_payload, params=query_params) as response:
-                response.raise_for_status()
+                if response.is_error:
+                    await response.aread()
+                    response.raise_for_status()
 
                 async for line in response.aiter_lines():
                     if line.startswith("data:"):
@@ -68,10 +71,10 @@ class StreamableHTTPTransport:
 
         except httpx.HTTPStatusError as e:
             logger.error(f"HTTP error on method {method}: {e.response.status_code} - {e.response.text}")
-            raise RuntimeError(f"HTTP Error: {e.response.status_code}")
+            raise RuntimeError(f"HTTP Error: {e.response.status_code}") from e
         except httpx.RequestError as e:
             logger.error(f"Network request error on method {method}: {e}")
-            raise RuntimeError(f"Network Error: {e}")
+            raise RuntimeError(f"Network Error: {e}") from e
         except Exception as e:
             logger.error(f"An unexpected transport error occurred on method {method}: {e}")
             raise

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -79,6 +79,7 @@ logger.info(f"Using Gemini search result model: {GEMINI_SEARCH_RESULT_API_MODEL}
 #Automatic MCP Tool Server
 AUTOMATIC_MCP_TOOL_SERVER_USAGE=os.environ.get("AUTOMATIC_MCP_TOOL_SERVER_USAGE", "false").lower() == "true"
 AUTOMATIC_TOOL_MCP_SERVER_URL=os.environ.get("AUTOMATIC_TOOL_MCP_SERVER_URL", "https://portal.breeze.in/ai/mcp")
+MCP_CLIENT_TIMEOUT = int(os.environ.get("MCP_CLIENT_TIMEOUT", 30)) #seconds
 
 _shops_for_mcp_str = os.environ.get("SHOPS_FOR_AUTOMATIC_MCP_SERVER", "")
 SHOPS_FOR_AUTOMATIC_MCP_SERVER = [shop.strip() for shop in _shops_for_mcp_str.split(',') if shop.strip()]

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -8,7 +8,7 @@ The primary focus of recent development has been to enable the voice agent to us
 
 - **`MCPClient` Relocated and Refactored:** The `MCPClient` service was moved to a more appropriate location at `app/agents/voice/automatic/services/mcp/automatic_client.py`. Its associated Pydantic models were also moved to `app/agents/voice/automatic/types/models.py` to improve code organization.
 
-- **Robust `StreamableHTTPTransport`:** The transport layer was significantly refactored for robustness. It now uses the relocated Pydantic models to validate all incoming responses against the official MCP specification. This prevents crashes from malformed data. The streaming logic now processes data line-by-line and handles various network and HTTP errors gracefully. The Pydantic models were specifically updated to handle cases where a tool call returns a plain text error message instead of a JSON object, preventing validation crashes.
+- **Robust `StreamableHTTPTransport`:** The transport layer was significantly refactored for robustness. It now uses the relocated Pydantic models to validate all incoming responses against the official MCP specification. The streaming logic now correctly handles HTTP errors by reading the response body before raising an exception, preventing crashes from race conditions on closed streams. The client timeout has also been made configurable via the `MCP_CLIENT_TIMEOUT` environment variable, defaulting to 30 seconds.
 
 - **Dynamic Tool Registration:** The voice agent, when `AUTOMATIC_MCP_TOOL_SERVER_USAGE` is true, now uses the `MCPClient` to:
     1.  Fetch the list of available tools from the remote server at startup.
@@ -21,5 +21,4 @@ The primary focus of recent development has been to enable the voice agent to us
 ## 3. Next Steps & Considerations
 
 - **Security Analysis:** An analysis was performed to identify how sensitive data is exposed. Key risks include the direct exposure of tool schemas and results to the LLM. The `mcp_context` is not directly exposed, but it defines the permissions for the tools the LLM can use.
-- **Memory Bank Update:** The current task is to bring the project's memory bank up to date to reflect the recent refactoring.
 - **Future Work:** Potential future work could involve creating a sanitization layer to filter or redact sensitive information passing between the remote server and the LLM, or expanding the Pydantic models to support more `ToolResult` content types like images or audio.

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -5,7 +5,7 @@
 - **Remote Tool Integration:** The integration of the `MCPClient` is functional. The voice agent can successfully connect to the remote MCP server, fetch the list of tools, and register them with the LLM.
 - **Dynamic Tool Calling:** The agent can correctly identify when a user's request requires a remote tool and can execute the `tools/call` method, passing the necessary arguments and context.
 - **Robust Streaming and Parsing:** The `StreamableHTTPTransport` has been refactored to be highly resilient. It now processes streams line-by-line, uses Pydantic for strict data validation against the MCP spec, and correctly parses nested JSON in tool call results.
-- **Improved Error Handling:** The transport layer and client now gracefully handle a wide range of exceptions. This includes network errors, HTTP status code errors, and data validation errors. Specifically, the Pydantic models were updated to correctly parse both successful tool results (with nested JSON) and tool error results (with plain text), preventing crashes on server-side errors.
+- **Improved Error Handling:** The transport layer and client now gracefully handle a wide range of exceptions. This includes network errors, HTTP status code errors, and data validation errors. The streaming logic now correctly manages the stream lifecycle during HTTP errors, preventing crashes from race conditions. The client timeout is also now configurable.
 - **Context-Aware Sessions:** The system for passing session-specific data (`mcp_context`) via HTTP headers is in place and functional, allowing for authenticated and contextual tool execution.
 - **Date-Preserving Summaries:** The summarization prompt has been updated to ensure that dates and time ranges are preserved in conversation summaries.
 


### PR DESCRIPTION
- added an env config MCP_CLIENT_TIMEOUT for timeout of tools/list, tool/call, defaulting to 30s.
- improved the error handling incase of 4xx or 5xx, to populate the actual error message before closing the stream.