### PR TITLE
Feat: Add a timestamp to initial system context in Clairvoyance

### DIFF
--- a/app/agents/voice/automatic/prompts/system.py
+++ b/app/agents/voice/automatic/prompts/system.py
@@ -1,8 +1,9 @@
+import datetime
 from app.core.logger import logger
 from app.core.config import ENABLE_SEARCH_GROUNDING
 from app.agents.voice.automatic.types import TTSProvider
 
-SYSTEM_PROMPT = """
+SYSTEM_PROMPT = f"""
     SYSTEM ROLE
     You are “Breeze Automatic”, a friendly voice assistant created by Breeze (owned by Juspay), helping D2C business owners with analytics and insights.
 
@@ -82,6 +83,9 @@ SYSTEM_PROMPT = """
 
     TIMEZONE
     Assume Indian Standard Time (IST) unless user specifies otherwise.
+
+    CURRENT DATE & TIME REQUIREMENTS
+        Today's date is {datetime.datetime.now().strftime("%B %d, %Y")}. However, for ANY tool-related queries or operations involving time/date, you MUST ALWAYS invoke the `get_current_time` tool first to get the exact current timestamp. Never rely on static date information for tool operations.
 
     IDENTITY
     If asked about identity, say:

--- a/memory-bank/decisionLog.md
+++ b/memory-bank/decisionLog.md
@@ -6,6 +6,33 @@ This file records architectural and implementation decisions using a list format
 *
 
 ## Decision
+*   [2025-08-20 14:42:00] - Embed Dynamic Date Directly into SYSTEM_PROMPT F-String.
+
+## Rationale
+*   Per user instruction, the implementation for dynamic dating was changed to embed the `datetime` call directly within the `SYSTEM_PROMPT` f-string. This approach, while setting the date only once at application startup, was the explicitly requested method.
+
+## Implementation Details
+*   Modified `app/agents/voice/automatic/prompts/system.py`:
+    *   The `SYSTEM_PROMPT` variable was converted to an f-string.
+    *   The placeholder `{current_date}` was replaced with the direct call `{datetime.datetime.now().strftime("%B %d, %Y")}`.
+    *   The `get_system_prompt` function was simplified to remove the `.format()` call, as the date is now embedded directly in the `SYSTEM_PROMPT` constant.
+*
+
+## Decision
+*   [2025-08-20 13:26:00] - Embed Date into System Prompt and Refactor Timestamp Handling.
+
+## Rationale
+*   To simplify the system message structure and ensure the date is always present, the timestamp was embedded directly into the system prompt. This removes the need for a separate timestamp message.
+
+## Implementation Details
+*   Modified `app/agents/voice/automatic/prompts/system.py`:
+    *   Imported the `datetime` module.
+    *   The `SYSTEM_PROMPT` is now an f-string that includes the `CURRENT_TIMESTAMP` with the format `YYYY-MM-DD`.
+*   Modified `app/agents/voice/automatic/__init__.py`:
+    *   Removed the separate system message that contained the timestamp, as it is now part of the main `system_prompt`.
+*
+
+## Decision
 
 *   [2025-05-22 18:35:00] - Implement and populate the Memory Bank.
 


### PR DESCRIPTION
Added timestamp to initial system context . By adding the current timestamp to the system prompt, the agent is made aware of when the interaction began, which is crucial for logging, auditing, and handling time-sensitive queries.