### PR TITLE
BZ-43740: feat: Add support for application logs in span attribute

### DIFF
--- a/app/agents/voice/automatic/__init__.py
+++ b/app/agents/voice/automatic/__init__.py
@@ -50,6 +50,7 @@ load_dotenv(override=True)
 
 # import setup_tracing from tracing_setup.py file
 from app.agents.voice.automatic.analytics.tracing_setup import setup_tracing
+from app.agents.voice.automatic.analytics.utils import generate_open_observer_url_for_session_id
 
 async def main():
     parser = argparse.ArgumentParser()
@@ -64,6 +65,7 @@ async def main():
     parser.add_argument("--shop-id", type=str, help="Shop ID for live mode")
     parser.add_argument("--shop-type", type=str, help="Shop type for live mode")
     parser.add_argument("--user-name", type=str, help="User's name")
+    parser.add_argument("--user-email", type=str, help="User's email address")
     parser.add_argument("--tts-provider", type=str, help="TTS provider to use")
     parser.add_argument("--voice-name", type=str, help="Voice name to use")
     parser.add_argument("--merchant-id", type=str, help="Merchant Id of the Shop")
@@ -151,6 +153,7 @@ async def main():
                 merchant_id=args.merchant_id,
                 session_id=args.client_sid,  # Pass client_sid instead of session_id
                 user_id=args.user_name,
+                user_email=args.user_email
             )
         else:
             tools, tool_functions = initialize_tools(
@@ -172,6 +175,7 @@ async def main():
             "shopId": args.shop_id,
             "shopType": args.shop_type,
             "userId": args.user_name,
+            "userEmail": args.user_email,
             "enableDemoMode": mode != Mode.LIVE,
             "merchantId": args.merchant_id,
             "platformIntegrations": args.platform_integrations
@@ -344,14 +348,21 @@ async def main():
         tracer = trace.get_tracer(__name__)
         with tracer.start_as_current_span(conversation_id) as root_span:
             logger.info(f"Starting current span with conversation ID: {conversation_id}")
-            root_span.set_attribute("conversation.id", conversation_id)
-            root_span.set_attribute("conversation.type", "voice")
-            root_span.set_attribute("user.name", user_name)
+            root_span.set_attribute("conversation_id", conversation_id)
+            root_span.set_attribute("conversation_type", "voice")
+            root_span.set_attribute("user_name", user_name)
+            root_span.set_attribute("shop_id", args.shop_id)
+            root_span.set_attribute("shop_type", args.shop_type)
+            root_span.set_attribute("shop_url", args.shop_url)
+            root_span.set_attribute("merchant_id", args.merchant_id)
             root_span.set_attribute("service.name", "breeze-voice-agent")
             root_span.set_attribute("client_sid", args.client_sid)
-            langfuse_client.update_current_trace(user_id=user_name)
-            langfuse_client.update_current_trace(session_id=args.session_id)
-            langfuse_client.update_current_trace(tags=[voice_name])
+            root_span.set_attribute("application_logs", generate_open_observer_url_for_session_id(args.client_sid))
+            langfuse_client.update_current_trace(
+                user_id=args.user_email,
+                session_id=args.session_id,
+                tags=[voice_name.value if hasattr(voice_name, 'value') else str(voice_name)]
+            )
             await run_pipeline()
     else:
         await run_pipeline()

--- a/app/agents/voice/automatic/analytics/utils.py
+++ b/app/agents/voice/automatic/analytics/utils.py
@@ -1,0 +1,25 @@
+import base64
+from urllib.parse import urlencode
+from app.core import config
+
+
+def generate_open_observer_url_for_session_id(session_id: str) -> str:
+    """Generate OpenObserve URL for a specific session ID"""
+    query_string = f"sessionid='{session_id}'"
+    encoded_query = base64.b64encode(query_string.encode('utf-8')).decode('utf-8')
+    base_url = f"{config.OPEN_OBSERVE_BASE_URL}/web/logs"
+    
+    params = {
+        'stream_type': 'logs',
+        'stream': 'clairvoyance_logs', 
+        'period': '1d',
+        'refresh': '0',
+        'sql_mode': 'false',
+        'query': encoded_query,
+        'defined_schemas': 'user_defined_schema',
+        'org_identifier': 'default',
+        'quick_mode': 'false',
+        'show_histogram': 'true'
+    }
+    
+    return f"{base_url}?{urlencode(params)}"

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -68,6 +68,7 @@ VAD_STOP_SECS = float(os.environ.get("VAD_STOP_SECS", 1.00))
 
 # Tracing
 ENABLE_TRACING = os.environ.get("ENABLE_TRACING", "false").lower() == "true"
+OPEN_OBSERVE_BASE_URL = os.environ.get("OPEN_OBSERVE_BASE_URL", "https://periscope.breeze.in")
 
 # Text sanitization
 SANITIZE_TEXT_FOR_TTS = os.environ.get("SANITIZE_TEXT_FOR_TTS", "false").lower() == "true"

--- a/app/main.py
+++ b/app/main.py
@@ -241,6 +241,7 @@ async def bot_connect(request: AutomaticVoiceUserConnectRequest) -> Dict[str, An
     shop_url = request.shopUrl
     shop_id = request.shopId
     shop_type = request.shopType
+    user_email = request.userEmail
     user_name = request.userName
     tts_provider = request.ttsService.ttsProvider.value if request.ttsService else None
     voice_name = request.ttsService.voiceName.value if request.ttsService else None
@@ -296,6 +297,8 @@ async def bot_connect(request: AutomaticVoiceUserConnectRequest) -> Dict[str, An
     # Add user_name and tts_service regardless of mode
     if user_name:
         cmd += ["--user-name", user_name]
+    if user_email:
+        cmd += ["--user-email", user_email]
     if tts_provider:
         cmd += ["--tts-provider", tts_provider]
     if voice_name:

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -70,6 +70,7 @@ class AutomaticVoiceUserConnectRequest(BaseModel):
     shopId: Optional[str] = None
     shopType: Optional[str] = None
     userName: Optional[str] = None
+    userEmail: Optional[str] = None
     ttsService: Optional[AutomaticVoiceTTSServiceConfig] = None
     merchantId: Optional[str] = None
     platformIntegrations: Optional[List[str]] = None


### PR DESCRIPTION
  - Added userEmail support in API call
  - Added generate_open_observer_url_for_session_id function
  - Unified the span name
  - Included application_logs attribute in span
  - Added env OPEN_OBSERVE_BASE_URL
  - dev proof: https://drive.google.com/file/d/1ohfz0-JCpyuxpy_Y7GSenBdy5LY2c8th/view?usp=drive_link

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Support passing a user’s email end-to-end: new API field (userEmail) and CLI flag (--user-email). The email is propagated to tools and tracing for personalized and auditable sessions.

- Chores
  - Enhanced observability: richer tracing attributes (conversation, shop, merchant), improved tag handling, and a direct link to application logs per session.
  - New configuration for the observability base URL, allowing environment-based customization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->