### PR TITLE
BZ-43794: feat: Skip VAD when ptt is active

### DIFF
--- a/app/agents/voice/automatic/__init__.py
+++ b/app/agents/voice/automatic/__init__.py
@@ -15,7 +15,7 @@ from pipecat.pipeline.task import PipelineParams, PipelineTask
 from app.agents.voice.automatic.services.llm_wrapper import LLMServiceWrapper
 from pipecat.services.azure.llm import AzureLLMService
 from pipecat.transcriptions.language import Language
-from pipecat.frames.frames import TTSSpeakFrame, BotSpeakingFrame, LLMFullResponseEndFrame
+from pipecat.frames.frames import TTSSpeakFrame, BotSpeakingFrame, LLMFullResponseEndFrame, EmulateUserStartedSpeakingFrame, EmulateUserStoppedSpeakingFrame
 from pipecat.transports.services.daily import DailyParams, DailyTransport
 from pipecat.processors.frameworks.rtvi import RTVIConfig, RTVIProcessor
 from pipecat.services.google.rtvi import GoogleRTVIObserver
@@ -24,6 +24,7 @@ from app.core import config
 from app.agents.voice.automatic.utils.session_context import create_session_context, set_current_session_id
 from app.agents.voice.automatic.services.mcp.automatic_client import MCPClient
 from .processors import LLMSpyProcessor
+from .processors.ptt_vad_filter import PTTVADFilter
 from .prompts import get_system_prompt
 from .tools import initialize_tools, shopify_buddy_test, breeze_buddy
 from .tts import get_tts_service
@@ -235,19 +236,30 @@ async def main():
     # Add custom LLMSpyProcessor for streaming function call events (RTVI and TTS created earlier)
     tool_call_processor = LLMSpyProcessor(rtvi, args.session_id, config.ENABLE_CHARTS, "LLMSpyProcessor")
 
-    pipeline = Pipeline(
-        [
-            transport.input(),
-            stt,
-            rtvi,
-            context_aggregator.user(),
-            llm,
-            tool_call_processor,
-            tts,
-            transport.output(),
-            context_aggregator.assistant(),
-        ]
-    )
+
+    # Build pipeline components list
+    pipeline_components = [
+        transport.input(),
+        stt,
+    ]
+    
+    # Add PTT VAD filter only if it's enabled
+    if config.DISABLE_VAD_FOR_PTT:
+        ptt_vad_filter = PTTVADFilter("PTTVADFilter")
+        pipeline_components.append(ptt_vad_filter)  # Filter VAD frames after STT
+    
+    # Add remaining components
+    pipeline_components.extend([
+        rtvi,
+        context_aggregator.user(),
+        llm,
+        tool_call_processor,
+        tts,
+        transport.output(),
+        context_aggregator.assistant(),
+    ])
+    
+    pipeline = Pipeline(pipeline_components)
 
     user_name = args.user_name or "guest"
     shopId = "euler" if args.euler_token and not args.shop_id else args.shop_id or "dummy"
@@ -276,23 +288,59 @@ async def main():
 
     @rtvi.event_handler("on_client_message")
     async def on_client_message(rtvi, message):
-        """Handle incoming messages from RTVI client, including function confirmation responses"""
+        """Handle incoming messages from RTVI client, including function confirmation responses and PTT events"""
         try:
-            if isinstance(message, dict) and message.get("type") == "function-confirmation-response":
-
-                confirmation_id = message.get("confirmationId")
-                approved = message.get("approved", False)
-                reason = message.get("reason", "")
+            if isinstance(message, dict):
+                message_type = message.get("type")
                 
-                if confirmation_id:
-                    response = {
-                        "approved": approved,
-                        "reason": reason
-                    }
-                    handle_confirmation_response(confirmation_id, response)
-                    logger.info(f"Processed function confirmation response: {confirmation_id} -> {approved}")
-                else:
-                    logger.warning("Received function confirmation response without confirmationId")
+                if message_type == "function-confirmation-response":
+                    confirmation_id = message.get("confirmationId")
+                    approved = message.get("approved", False)
+                    reason = message.get("reason", "")
+                    
+                    if confirmation_id:
+                        response = {
+                            "approved": approved,
+                            "reason": reason
+                        }
+                        handle_confirmation_response(confirmation_id, response)
+                        logger.info(f"Processed function confirmation response: {confirmation_id} -> {approved}")
+                    else:
+                        logger.warning("Received function confirmation response without confirmationId")
+                
+                elif message_type == "ptt-start":
+                    # Handle PTT start event
+                    logger.debug("PTT started - activating VAD filter")
+                    ptt_vad_filter.set_ptt_active(True)
+                    # Send emulated user started speaking frame
+                    await task.queue_frames([EmulateUserStartedSpeakingFrame()])
+
+                    
+                elif message_type == "ptt-end":
+                    # Handle PTT end event
+                    logger.debug("PTT ended - deactivating VAD filter and sending stop frame")
+                    ptt_vad_filter.set_ptt_active(False)
+                    # Send emulated user stopped speaking frame
+                    await task.queue_frames([EmulateUserStoppedSpeakingFrame()])
+                    
+                elif message_type == "ptt-sync":
+                    # Handle PTT state synchronization from client
+                    client_ptt_state = message.get("data", {}).get("ptt_active", False)
+                    current_state = ptt_vad_filter._ptt_active
+                    
+                    if client_ptt_state != current_state:
+                        logger.warning(f"PTT state mismatch! client: {client_ptt_state}, server: {current_state}")
+                        # Sync to client state (client is authoritative)
+                        ptt_vad_filter.set_ptt_active(client_ptt_state)
+                        logger.info(f"PTT state synchronized to: {client_ptt_state}")
+                        
+                        # Send appropriate frames for state change
+                        if client_ptt_state:
+                            await task.queue_frames([EmulateUserStartedSpeakingFrame()])
+                        else:
+                            await task.queue_frames([EmulateUserStoppedSpeakingFrame()])
+                    else:
+                        logger.debug(f"PTT state sync: states match (current_state: {current_state})")
                     
         except Exception as e:
             logger.error(f"Error handling RTVI client message: {e}")
@@ -315,13 +363,16 @@ async def main():
     @transport.event_handler("on_app_message")
     async def on_app_message(transport, message, sender):
         """Route function confirmation messages from Daily transport to RTVI"""
-        # Check if this is a function confirmation message and route to RTVI
-        if isinstance(message, dict) and message.get("type") == "function-confirmation-response":
-            # Manually trigger the RTVI handler since it might not be getting the message
-            try:
-                await on_client_message(rtvi, message)
-            except Exception as e:
-                logger.error(f"Error manually routing message to RTVI: {e}")
+        
+        # Check if this is a function confirmation message or PTT message and route to RTVI
+        if isinstance(message, dict):
+            message_type = message.get("type")
+            if message_type == "function-confirmation-response" or (config.DISABLE_VAD_FOR_PTT and message_type in ["ptt-start", "ptt-end", "ptt-sync"]):
+                # Manually trigger the RTVI handler since it might not be getting the message
+                try:
+                    await on_client_message(rtvi, message)
+                except Exception as e:
+                    logger.error(f"Error manually routing message to RTVI: {e}")
 
     @task.event_handler("on_pipeline_cancelled")
     async def on_pipeline_cancelled(task, frame):

--- a/app/agents/voice/automatic/processors/ptt_vad_filter.py
+++ b/app/agents/voice/automatic/processors/ptt_vad_filter.py
@@ -1,0 +1,87 @@
+"""
+PTT VAD Filter Processor
+
+Implements a belt-and-suspenders approach to drop VAD frames while PTT is active
+and for a small cooldown period after PTT release.
+"""
+
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+from pipecat.frames.frames import (
+    Frame,
+    VADUserStartedSpeakingFrame, 
+    VADUserStoppedSpeakingFrame,
+    UserStartedSpeakingFrame, 
+    UserStoppedSpeakingFrame
+)
+from pipecat.processors.frame_processor import FrameDirection, FrameProcessor
+from app.core.logger import logger
+
+# PTT cooldown configuration (in seconds)
+PTT_COOLDOWN_SECS = 0.5
+# PTT timeout configuration (maximum PTT duration before auto-reset)
+PTT_MAX_DURATION_SECS = 60
+
+class PTTVADFilter(FrameProcessor):
+    """
+    PTT-aware VAD filter that drops VAD frames during PTT active periods
+    and cooldown after PTT release. Includes timeout safety to prevent
+    stuck PTT states.
+    """
+    
+    def __init__(self, name: str = "PTTVADFilter"):
+        super().__init__(name=name)
+        self._ptt_active = False
+        self._ptt_cooldown_until: Optional[datetime] = None
+        self._ptt_start_time: Optional[datetime] = None
+        
+    def set_ptt_active(self, active: bool) -> None:
+        """Set PTT active state"""
+        self._ptt_active = active
+        
+        if active:
+            self._ptt_start_time = datetime.now(timezone.utc)
+            self._ptt_cooldown_until = None
+            logger.debug("PTT activated")
+        else:
+            self._ptt_start_time = None
+            self._ptt_cooldown_until = datetime.now(timezone.utc) + timedelta(seconds=PTT_COOLDOWN_SECS)
+            logger.debug("PTT released")
+    
+    def _should_pass_frame(self, frame: Frame) -> bool:
+        """Determine if frame should pass through the filter"""
+
+        # Auto-recovery from stuck PTT state (timeout safety)
+        if self._ptt_active and self._ptt_start_time:
+            duration = datetime.now(timezone.utc) - self._ptt_start_time
+            if duration.total_seconds() > PTT_MAX_DURATION_SECS:
+                logger.warning(f"PTT timeout after {duration.total_seconds():.1f}s - auto-clearing stuck state")
+                self._ptt_active = False
+                self._ptt_start_time = None
+                self._ptt_cooldown_until = None
+
+        # Allow emulated frames with explicit flag
+        if isinstance(frame, (UserStartedSpeakingFrame, UserStoppedSpeakingFrame)):
+            if getattr(frame, "emulated", False):
+                return True
+
+        # Drop VAD-originated frames if PTT is active or during cooldown
+        if isinstance(frame, (VADUserStartedSpeakingFrame, VADUserStoppedSpeakingFrame, UserStartedSpeakingFrame, UserStoppedSpeakingFrame)):
+            if self._ptt_active:
+                logger.debug(f"Dropping {type(frame).__name__} - PTT active")
+                return False
+            if self._ptt_cooldown_until and datetime.now(timezone.utc) < self._ptt_cooldown_until:
+                logger.debug(f"Dropping {type(frame).__name__} - PTT cooldown active")
+                return False
+        
+        return True
+
+    async def process_frame(self, frame: Frame, direction: FrameDirection):
+        """Process frames and filter VAD frames based on PTT state"""
+        await super().process_frame(frame, direction)
+            
+        if self._should_pass_frame(frame):
+            await self.push_frame(frame, direction)
+        else:
+            # Frame is dropped, don't pass it along
+            return

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -168,6 +168,9 @@ HITL_ACTIONS = [action.strip().lower() for action in _hitl_actions_str.split(","
 # Chart Generation Configuration
 ENABLE_CHARTS = os.environ.get("ENABLE_CHARTS", "false").lower() == "true"
 
+# PTT VAD Filter Configuration
+DISABLE_VAD_FOR_PTT = os.environ.get("DISABLE_VAD_FOR_PTT", "true").lower() == "true"
+
 BREEZE_DEFAULT_SALES_TAB = os.environ.get("BREEZE_DEFAULT_SALES_TAB", "SALES")
 AUTOMATIC_OPENAI_STT_PROMPT = os.environ.get(
     "AUTOMATIC_OPENAI_STT_PROMPT", 


### PR DESCRIPTION
Skip VAD when PTT is active as user is having control.

How to test: In normal mode when you ask a question and give gap bot will start responding due to VAD, but in PTT mode until user releases mic button bot should not start speaking. With this change we can ask multiple questions or correct what we have said even with gaps.

Lighthouse pr: https://bitbucket.juspay.net/projects/BZ/repos/lighthouse/pull-requests/3049/overview

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Push-to-talk (PTT) support: start, end, and sync events are now recognized and kept in sync between client and server.
  * Smarter voice detection: VAD is temporarily suppressed during and shortly after PTT to avoid false triggers, with seamless emulated speech start/stop for smoother turn-taking.
  * Improved interoperability: PTT events are routed in RTVI/Daily sessions for consistent behavior.
* **Documentation**
  * Updated messaging docs to include PTT event handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->