### PR TITLE
feat: added get partial payment tool support

### DIFF
--- a/app/agents/voice/automatic/tools/__init__.py
+++ b/app/agents/voice/automatic/tools/__init__.py
@@ -100,6 +100,12 @@ def initialize_tools(
             all_tool_functions.update(breeze.configuration_tool_functions)
             logger.info(f"Loaded {len(breeze.configuration_tools.standard_tools)} real-time Breeze configuration tools.")
 
+            breeze.partial_payment.shop_id = shop_id
+            breeze.partial_payment.breeze_token = breeze_token
+            all_tools.extend(breeze.partial_payment_tools.standard_tools)
+            all_tool_functions.update(breeze.partial_payment_tool_functions)
+            logger.info(f"Loaded {len(breeze.partial_payment_tools.standard_tools)} real-time Breeze partial payment tools.")
+
     tools = ToolsSchema(standard_tools=all_tools)
 
     if AUTOMATIC_WRITE_ACTIONS_AUTHORIZED_USERS:

--- a/app/agents/voice/automatic/tools/breeze/__init__.py
+++ b/app/agents/voice/automatic/tools/breeze/__init__.py
@@ -1,4 +1,5 @@
 from .analytics import tools, tool_functions, breeze_token, shop_id, shop_url, shop_type
 from .configuration import tools as configuration_tools, tool_functions as configuration_tool_functions
+from .partial_payment import tools as partial_payment_tools, tool_functions as partial_payment_tool_functions
 
-__all__ = ["tools", "tool_functions", "breeze_token", "shop_id", "shop_url", "shop_type", "configuration_tools", "configuration_tool_functions"]
+__all__ = ["tools", "tool_functions", "breeze_token", "shop_id", "shop_url", "shop_type", "configuration_tools", "configuration_tool_functions", "partial_payment_tools", "partial_payment_tool_functions"]

--- a/app/agents/voice/automatic/tools/breeze/partial_payment.py
+++ b/app/agents/voice/automatic/tools/breeze/partial_payment.py
@@ -1,0 +1,56 @@
+import httpx
+import json
+from typing import List, Dict, Any, Optional
+
+from app.core.logger import logger
+from app.core.config import AWS_VAYU_URL, AWS_VAYU_READ_API_KEY
+from pipecat.services.llm_service import FunctionCallParams
+from pipecat.adapters.schemas.function_schema import FunctionSchema
+from pipecat.adapters.schemas.tools_schema import ToolsSchema
+
+# These will be set by the initializer
+breeze_token: str | None = None
+shop_id: str | None = None
+
+async def get_partial_payment_rules(params: FunctionCallParams):
+    """
+    Retrieves the complete set of partial payment rules configured for the current shop.
+    """
+    if not shop_id:
+        await params.result_callback({"success": False, "error": "Missing shop information in context. Shop ID is required."})
+        return
+
+    headers = {
+        "Content-Type": "application/json",
+        "Authorization": AWS_VAYU_READ_API_KEY
+    }
+    
+    endpoint = f"{AWS_VAYU_URL}/payment/partial/rule?shopId={shop_id}"
+    
+    logger.info(f"Requesting partial payment rules from: {endpoint}")
+
+    try:
+        async with httpx.AsyncClient() as client:
+            response = await client.get(endpoint, headers=headers)
+            response.raise_for_status()
+            result = response.json()
+            logger.info(f"Received partial payment rules response status: {response.status_code}, data: {json.dumps(result)}")
+            await params.result_callback({"success": True, "data": result.get("partialPaymentRule", [])})
+    except httpx.HTTPStatusError as e:
+        logger.error(f"HTTP error fetching partial payment rules: {e.response.status_code} - {e.response.text}")
+        await params.result_callback({"success": False, "error": f"API error: {e.response.status_code}", "details": e.response.text})
+    except Exception as e:
+        logger.error(f"Unexpected error fetching partial payment rules: {e}")
+        await params.result_callback({"success": False, "error": f"An unexpected error occurred: {e}"})
+
+get_partial_payment_rules_function = FunctionSchema(
+    name="get_partial_payment_rules",
+    description="""Retrieves the complete set of partial payment rules configured for the current shop.""",
+    properties={},
+    required=[]
+)
+
+tools = ToolsSchema(standard_tools=[get_partial_payment_rules_function])
+tool_functions = {
+    "get_partial_payment_rules": get_partial_payment_rules
+}

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -216,6 +216,9 @@ EXOTEL_API_TOKEN = os.getenv("EXOTEL_API_TOKEN", "")
 EXOTEL_SUBDOMAIN = os.getenv("EXOTEL_SUBDOMAIN", "api.exotel.com")
 EXOTEL_APPLET_APP_ID = os.getenv("EXOTEL_APPLET_APP_ID", "1044183")
 
+# Vayu Configuration
+AWS_VAYU_URL = get_required_env("AWS_VAYU_URL")
+AWS_VAYU_READ_API_KEY = get_required_env("AWS_VAYU_READ_API_KEY")
 
 # LangFuse Configuration
 ENABLE_LANGFUSE_PROMPTS = os.environ.get("ENABLE_LANGFUSE_PROMPTS", "false").lower() == "true"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Adds partial payment support to Breeze-powered voice tools.
  - Retrieves partial payment rules from the backend when configured, with a demo mode available in test environments.

- Configuration
  - Requires two new environment variables for backend access: VAYU_URL and VAYU_READ_API_KEY.
  - Breeze partial payment features initialize automatically when shop context and credentials are provided.

- Chores
  - Expanded Breeze toolset exports to include partial payment tools for broader availability within the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->