### PR TITLE
BZ-43903: feat: Add support to get all tabs data from CKH in clairvo…

### DIFF
--- a/app/agents/voice/automatic/tools/breeze/analytics.py
+++ b/app/agents/voice/automatic/tools/breeze/analytics.py
@@ -63,7 +63,7 @@ async def _make_breeze_request(params: FunctionCallParams, operational_tab: str)
         "operationalTab": operational_tab,
         "granularityFilter": {"timeGranularity": "DAILY", "paymentMethods": "ALL"},
         "shopType": shop_type,
-        "getAllMetricsFromCKH": ENABLE_ALL_METRICS_FROM_CKH and operational_tab == "OVERVIEW"
+        "getAllMetricsFromCKH": ENABLE_ALL_METRICS_FROM_CKH
     }
     headers = {
         "Content-Type": "application/json",

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -26,7 +26,7 @@ The primary focus of recent development has been to enable the voice agent to us
     4. Two types of banners are supported: login page announcements and payment page announcements.
     5. The tool interacts with the shop configuration API to manage these banners.
 
-- **Enhanced Analytics Metrics:** The Breeze analytics tools have been updated to include the `getAllMetricsFromCKH` parameter. This parameter is set to `True` when the `operational_tab` is 'OVERVIEW' to fetch a more comprehensive set of metrics.
+- **Enhanced Analytics Metrics:** The Breeze analytics tools have been updated to include the `getAllMetricsFromCKH` parameter. This parameter is set to `True` for all the operational tabs
 
 ## 3. Next Steps & Considerations
 

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -10,7 +10,7 @@
 - **Date-Preserving Summaries:** The summarization prompt has been updated to ensure that dates and time ranges are preserved in conversation summaries.
 - **Banner Management Tool:** The new banner management tool is functional. It allows the voice agent to create, update, and remove announcement banners on login and payment pages. The tool includes comprehensive error handling and logging, and integrates with the shop configuration API.
 - **Shop Configuration Utilities:** The utility functions for shop configuration management are working correctly. They provide a robust foundation for future tools that need to interact with shop configurations.
-- **Enhanced Analytics:** The Breeze analytics tools now fetch more comprehensive metrics for the 'OVERVIEW' tab by utilizing the `getAllMetricsFromCKH` parameter.
+- **Enhanced Analytics:** The Breeze analytics tools now fetch more comprehensive metrics for all the tabs by utilizing the `getAllMetricsFromCKH` parameter.
 - **Markdown Sanitization for TTS:** The system now correctly sanitizes AI-generated text to remove markdown formatting before sending it to the Text-to-Speech (TTS) service. This is handled in the `LLMSpyProcessor` by modifying the `TextFrame` in-place, which is a stable and performant solution.
 
 ## 2. What's Left to Build


### PR DESCRIPTION
- Added support to get SALES tab data from CKH in clairvoyance

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Expanded Enhanced Analytics to the SALES tab. Metrics previously available only in OVERVIEW are now fetched for SALES as well, providing broader insights across both tabs with no user action required.

- Documentation
  - Updated references to Enhanced Analytics to indicate support for both OVERVIEW and SALES tabs.
  - Clarified that metric aggregation now applies across these tabs while retaining existing behavior elsewhere.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->