### PR TITLE
pass arguments in initialize tools

### DIFF
--- a/app/agents/voice/automatic/tools/__init__.py
+++ b/app/agents/voice/automatic/tools/__init__.py
@@ -24,6 +24,7 @@ def initialize_tools(
     merchant_id: str | None = None,
     session_id: str | None = None,
     user_id: str | None = None,
+    user_email: str | None = None,
 ):
     """
     Initializes tools based on the operating mode and available tokens.

--- a/app/agents/voice/breeze_buddy/call_providers/twillio.py
+++ b/app/agents/voice/breeze_buddy/call_providers/twillio.py
@@ -17,8 +17,6 @@ class TwilioProvider(VoiceCallProvider):
             pass
     def __init__(self, aiohttp_session):
         super().__init__(config, aiohttp_session)
-        if not all([self.config.TWILIO_ACCOUNT_SID, self.config.TWILIO_AUTH_TOKEN, self.config.TWILIO_FROM_NUMBER]):
-            raise ValueError("Twilio credentials are not configured.")
         self.client = Client(self.config.TWILIO_ACCOUNT_SID, self.config.TWILIO_AUTH_TOKEN)
 
     def hangup_call(self, call_sid: str):

--- a/app/main.py
+++ b/app/main.py
@@ -229,7 +229,7 @@ async def bot_connect(request: AutomaticVoiceUserConnectRequest) -> Dict[str, An
     shop_url = request.shopUrl
     shop_id = request.shopId
     shop_type = request.shopType
-    user_email = request.userEmail
+    user_email = request.email
     user_name = request.userName
     tts_provider = request.ttsService.ttsProvider.value if request.ttsService else None
     voice_name = request.ttsService.voiceName.value if request.ttsService else None


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Updated API to use “email” instead of “userEmail” in voice connection requests; clients must update payloads.
- Bug Fixes
  - Improved call setup reliability by removing strict startup credential checks for the telephony provider, supporting environments where credentials load dynamically.
- Chores
  - Added support for an optional user email parameter in internal tool initialization (no behavioral change).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->