### PR TITLE
Fix Automatic Voice request schema

### DIFF
--- a/app/schemas.py
+++ b/app/schemas.py
@@ -70,7 +70,7 @@ class AutomaticVoiceUserConnectRequest(BaseModel):
     shopId: Optional[str] = None
     shopType: Optional[str] = None
     userName: Optional[str] = None
-    userEmail: Optional[str] = None
+    email: Optional[str] = None
     ttsService: Optional[AutomaticVoiceTTSServiceConfig] = None
     merchantId: Optional[str] = None
     platformIntegrations: Optional[List[str]] = None


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Renamed an API request parameter from “userEmail” to “email” for the user connection request to improve naming consistency.
  - The field remains optional; behavior and other fields are unchanged.
  - Action required: Update client integrations to use “email” instead of “userEmail”.
  - Note: Requests using the old parameter name may fail or be ignored depending on client/server validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->