### PR TITLE
 Voice mode for GCP merchants

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -112,3 +112,6 @@ AUTOMATIC_LANGFUSE_SYSTEM_PROMPT_LABEL=automatic_system_langfuse_prompt
 # Mem0 Configuration
 MEM0_API_KEY=""
 MEM0_ENABLED=false 
+
+AWS_BREEZE_PORTAL_URL="http://localhost:5173"
+GCP_BREEZE_PORTAL_URL="http://localhost:5174"

--- a/app/agents/voice/automatic/__init__.py
+++ b/app/agents/voice/automatic/__init__.py
@@ -25,6 +25,7 @@ from app.services.mem0.memory import ImprovedMem0MemoryService
 from app.core import config
 from app.agents.voice.automatic.utils.session_context import create_session_context, set_current_session_id
 from app.agents.voice.automatic.services.mcp.automatic_client import MCPClient
+from app.utils.common import get_breeze_portal_url
 from .processors import LLMSpyProcessor
 from .processors.ptt_vad_filter import PTTVADFilter
 from .prompts import get_system_prompt
@@ -73,6 +74,7 @@ async def main():
     parser.add_argument("--voice-name", type=str, help="Voice name to use")
     parser.add_argument("--merchant-id", type=str, help="Merchant Id of the Shop")
     parser.add_argument("--platform-integrations",type=str, nargs="+", help="Platform Integrations that are supported by the shop (string array)")
+    parser.add_argument("--reseller-id", type=str, help="Reseller ID")
     args = parser.parse_args()
 
     # Configure logger with session ID and client session ID for all logs in this subprocess
@@ -156,13 +158,15 @@ async def main():
                 merchant_id=args.merchant_id,
                 session_id=args.client_sid,  # Pass client_sid instead of session_id
                 user_id=args.user_name,
-                user_email=args.user_email
+                user_email=args.user_email,
+                reseller_id=args.reseller_id
             )
         else:
             tools, tool_functions = initialize_tools(
                 mode=mode.value,
                 merchant_id=args.merchant_id,
                 session_id=args.client_sid,  # Pass client_sid instead of session_id
+                reseller_id=args.reseller_id
             )
             
         for name, function in tool_functions.items():
@@ -183,8 +187,12 @@ async def main():
             "merchantId": args.merchant_id,
             "platformIntegrations": args.platform_integrations
         }
+        # Calculate MCP URL based on reseller_id
+        base_url = get_breeze_portal_url(args.reseller_id)
+        mcp_url = f"{base_url}/ai/mcp"
+        
         mcp_client = MCPClient(
-            server_url=config.AUTOMATIC_TOOL_MCP_SERVER_URL,
+            server_url=mcp_url,
             auth_token=args.breeze_token,
             context=mcp_context,
             session_context=session_context,

--- a/app/agents/voice/automatic/tools/__init__.py
+++ b/app/agents/voice/automatic/tools/__init__.py
@@ -25,6 +25,7 @@ def initialize_tools(
     session_id: str | None = None,
     user_id: str | None = None,
     user_email: str | None = None,
+    reseller_id: str | None = None,
 ):
     """
     Initializes tools based on the operating mode and available tokens.
@@ -97,6 +98,7 @@ def initialize_tools(
             breeze.analytics.shop_url = shop_url
             breeze.analytics.shop_type = shop_type
             breeze.analytics.sessionId = session_id
+            breeze.analytics.reseller_id = reseller_id
             all_tools.extend(breeze.tools.standard_tools)
             all_tool_functions.update(breeze.tool_functions)
             logger.info(f"Loaded {len(breeze.tools.standard_tools)} real-time Breeze analytics tools.")

--- a/app/agents/voice/automatic/tools/breeze/analytics.py
+++ b/app/agents/voice/automatic/tools/breeze/analytics.py
@@ -5,6 +5,7 @@ import pytz
 
 from app.core.logger import logger
 from app.core.config import ENABLE_ALL_METRICS_FROM_CKH, BREEZE_DEFAULT_SALES_TAB
+from app.utils.common import get_breeze_portal_url
 from pipecat.services.llm_service import FunctionCallParams
 from pipecat.adapters.schemas.function_schema import FunctionSchema
 from pipecat.adapters.schemas.tools_schema import ToolsSchema
@@ -15,6 +16,7 @@ shop_id: str | None = None
 shop_url: str | None = None
 shop_type: str | None = None
 sessionId: str | None = None
+reseller_id: str | None = None
 
 async def _make_breeze_request(params: FunctionCallParams, operational_tab: str):
     """Generic helper to make requests to the Breeze analytics API."""
@@ -54,7 +56,9 @@ async def _make_breeze_request(params: FunctionCallParams, operational_tab: str)
         await params.result_callback({"error": f"Invalid time format. Please use 'YYYY-MM-DD HH:MM:SS'. Error: {e}"})
         return
 
-    api_url = "https://portal.breeze.in/analytics"
+    base_url = get_breeze_portal_url(reseller_id)
+    api_url = f"{base_url}/analytics"
+        
     payload = {
         "shopIds": [shop_id],
         "shops": [shop_url],
@@ -147,7 +151,9 @@ async def get_breeze_marketing_data(params: FunctionCallParams):
         await params.result_callback({"error": f"Invalid time format. Please use 'YYYY-MM-DD HH:MM:SS'. Error: {e}"})
         return
 
-    api_url = "https://portal.breeze.in/analytics/marketing"
+    base_url = get_breeze_portal_url(reseller_id)
+    api_url = f"{base_url}/analytics/marketing"
+        
     payload = {
         "shopIds": [shop_id],
         "shops": [shop_url],
@@ -215,7 +221,9 @@ async def get_breeze_address_data(params: FunctionCallParams):
         await params.result_callback({"error": f"Invalid time format. Please use 'YYYY-MM-DD HH:MM:SS'. Error: {e}"})
         return
 
-    api_url = "https://portal.breeze.in/analytics/address"
+    base_url = get_breeze_portal_url(reseller_id)
+    api_url = f"{base_url}/analytics/address"
+        
     payload = {
         "shopIds": [shop_id],
         "shops": [shop_url],

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -181,6 +181,10 @@ ENABLE_CHARTS = os.environ.get("ENABLE_CHARTS", "false").lower() == "true"
 DISABLE_VAD_FOR_PTT = os.environ.get("DISABLE_VAD_FOR_PTT", "true").lower() == "true"
 
 BREEZE_DEFAULT_SALES_TAB = os.environ.get("BREEZE_DEFAULT_SALES_TAB", "SALES")
+
+# Breeze Portal URLs
+AWS_BREEZE_PORTAL_URL = os.environ.get("AWS_BREEZE_PORTAL_URL", "https://portal.breeze.in")
+GCP_BREEZE_PORTAL_URL = os.environ.get("GCP_BREEZE_PORTAL_URL", "https://portal.breezesdk.store")
 AUTOMATIC_OPENAI_STT_PROMPT = os.environ.get(
     "AUTOMATIC_OPENAI_STT_PROMPT", 
     ""

--- a/app/main.py
+++ b/app/main.py
@@ -138,6 +138,7 @@ async def bot_connect(request: AutomaticVoiceUserConnectRequest) -> Dict[str, An
     voice_name = request.ttsService.voiceName.value if request.ttsService else None
     merchant_id = request.merchantId
     platform_integrations = request.platformIntegrations
+    reseller_id = request.resellerId
 
     # 2. Create room + token
     
@@ -208,6 +209,9 @@ async def bot_connect(request: AutomaticVoiceUserConnectRequest) -> Dict[str, An
         cmd += ["--merchant-id", merchant_id]
     if platform_integrations:
         cmd += ["--platform-integrations"] + platform_integrations
+    
+    if reseller_id:
+        cmd += ["--reseller-id", reseller_id]
 
     # 5. Launch subprocess without shell
     logger.bind(session_id=session_id).info(f"Launching subprocess with command: {' '.join(cmd)}")

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -125,6 +125,7 @@ class AutomaticVoiceUserConnectRequest(BaseModel):
     ttsService: Optional[AutomaticVoiceTTSServiceConfig] = None
     merchantId: Optional[str] = None
     platformIntegrations: Optional[List[str]] = None
+    resellerId: Optional[str] = None
 
 class TokenData(BaseModel):
     """Token data model for JWT payload"""

--- a/app/utils/common.py
+++ b/app/utils/common.py
@@ -2,6 +2,7 @@ from datetime import datetime
 from typing import Optional, Dict, Any
 import json
 from app.core.logger import logger
+from app.core.config import AWS_BREEZE_PORTAL_URL, GCP_BREEZE_PORTAL_URL
 
 def parse_iso_datetime(iso_string: Optional[str]) -> Optional[datetime]:
     """
@@ -48,3 +49,20 @@ def parse_iso_datetime(iso_string: Optional[str]) -> Optional[datetime]:
 
 def parse_json(row, key) -> Optional[Dict[str, Any]]:
     return row[key] if isinstance(row[key], dict) else json.loads(row[key]) if row[key] else None
+
+
+def get_breeze_portal_url(reseller_id: str | None = None) -> str:
+    """
+    Get the appropriate Breeze portal base URL based on reseller ID.
+    
+    Args:
+        reseller_id: The reseller identifier. If "super_reseller", returns the SDK store URL.
+                    Otherwise, returns the standard portal URL.
+    
+    Returns:
+        str: The base URL for the Breeze portal
+    """
+    if reseller_id == "super_reseller":
+        return GCP_BREEZE_PORTAL_URL
+    else:
+        return AWS_BREEZE_PORTAL_URL


### PR DESCRIPTION
- We now check the resellerId passed from lighthouse and based on that we decide lighthouse url
 - If super_reseller we use GCP lighthouse URL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added reseller-aware routing: the system now selects the appropriate service endpoint automatically based on reseller identity.
  * Reseller context is propagated into analytics for more accurate reporting.
  * Command-line usage supports overriding the MCP server URL.

* API Changes
  * Incoming connection requests now accept an optional resellerId field.
  * New CLI flags available: --mcp-url and --reseller-id for customized connections and environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->