### PR TITLE
(feat): enforce english for Sana and multilingual for other voice agents

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -102,6 +102,7 @@ LIGHTHOUSE_APP_URL='http://localhost:5173'
 ENABLE_ALL_METRICS_FROM_CKH='true'
 BREEZE_DEFAULT_SALES_TAB='SALES'
 # STT Prompt Configuration
+ENFORCED_OPENAI_STT_MODEL="whisper-1"
 AUTOMATIC_OPENAI_STT_PROMPT="Transcribe Indian languages accurately. Recognize and render Indian numbers (lakhs, crores, etc.) in their natural spoken form. Ensure business and financial terms are captured with precision. Always include proper names, numbers, and technical terms exactly as spoken, without modification."
 
 # MCP Write Access Control Configuration

--- a/app/agents/voice/automatic/stt/__init__.py
+++ b/app/agents/voice/automatic/stt/__init__.py
@@ -20,10 +20,10 @@ def get_stt_service(voice_name: Optional[str] = None):
         if not config.OPENAI_STT_API_KEY:
             raise ValueError("OPENAI_STT_API_KEY is required when ENABLE_OPENAI_FOR_MIA=true and voice is MIA")
         
-        logger.info("Using OpenAI STT service for MIA voice (override enabled)")
+        logger.info(f"Using OpenAI STT service for MIA voice (override enabled) with model: {config.ENFORCED_OPENAI_STT_MODEL}")
         return OpenAISTTService(
             api_key=config.OPENAI_STT_API_KEY,
-            model=config.OPENAI_STT_MODEL,
+            model=config.ENFORCED_OPENAI_STT_MODEL,
             language=Language.EN,
             # Optimized prompt for business analytics voice agent
             prompt=config.AUTOMATIC_OPENAI_STT_PROMPT, 

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -101,6 +101,7 @@ STT_PROVIDER = os.environ.get("STT_PROVIDER", "google").lower()  # "google", "as
 ASSEMBLYAI_API_KEY = os.getenv("ASSEMBLYAI_API_KEY")
 OPENAI_STT_API_KEY = os.getenv("OPENAI_STT_API_KEY")
 OPENAI_STT_MODEL = os.environ.get("OPENAI_STT_MODEL", "gpt-4o-transcribe")  # or "whisper-1"
+ENFORCED_OPENAI_STT_MODEL = os.environ.get("ENFORCED_OPENAI_STT_MODEL", "whisper-1")
 ENABLE_OPENAI_FOR_MIA = os.environ.get("ENABLE_OPENAI_FOR_MIA", "false").lower() == "true"
 
 logger.info(f"Using Gemini model: {GEMINI_MODEL}")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support to enforce a specific OpenAI Speech-to-Text model via a new configuration option (default: whisper-1).
  * Logs now display the active Speech-to-Text model for improved transparency.

* **Documentation**
  * Updated environment example to include ENFORCED_OPENAI_STT_MODEL, enabling easy configuration of the enforced model.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->