### PR TITLE
BZ-44079: Update pipecat version nltk fix and reapply aic filter

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,8 @@ FROM python:3.11-slim
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
     PYTHONPATH=/app \
-    PORT=8000
+    PORT=8000 \
+    NLTK_DATA=/usr/local/nltk_data
 
 # Install system dependencies required for audio processing and compilation
 # Removed 'git' and 'curl' as they are not required for the build
@@ -29,6 +30,10 @@ COPY requirements.txt .
 RUN pip install --no-cache-dir --upgrade pip && \
     pip install --no-cache-dir -r requirements.txt
 
+# Create NLTK data directory and download required data
+RUN mkdir -p /usr/local/nltk_data && \
+    python -m nltk.downloader punkt punkt_tab -d /usr/local/nltk_data
+
 # Copy application code
 COPY . .
 
@@ -37,7 +42,8 @@ RUN chmod +x run.py
 
 # Create non-root user for security
 RUN groupadd -r appuser && useradd -r -g appuser appuser
-RUN chown -R appuser:appuser /app
+RUN chown -R appuser:appuser /app && \
+    chown -R appuser:appuser /usr/local/nltk_data
 USER appuser
 
 # Expose port

--- a/app/agents/voice/automatic/__init__.py
+++ b/app/agents/voice/automatic/__init__.py
@@ -9,6 +9,7 @@ from app.core.logger import logger, configure_session_logger
 from pipecat.audio.vad.silero import SileroVADAnalyzer
 from pipecat.audio.vad.vad_analyzer import VADParams
 from pipecat.audio.filters.noisereduce_filter import NoisereduceFilter
+from pipecat.audio.filters.aic_filter import AICFilter
 from pipecat.pipeline.pipeline import Pipeline
 from pipecat.pipeline.runner import PipelineRunner
 from pipecat.pipeline.task import PipelineParams, PipelineTask
@@ -116,22 +117,22 @@ async def main():
         vad_analyzer=vad_analyzer,
     )
     
+            
     # Audio filter configuration
-    # if config.ENABLE_AIC_FILTER and config.AICOUSTICS_LICENSE_KEY:
-    #     try:
-    #         aic_filter = AICFilter(
-    #             license_key=config.AICOUSTICS_LICENSE_KEY,
-    #             enhancement_level=config.AIC_ENHANCEMENT_LEVEL,
-    #             voice_gain=config.AIC_VOICE_GAIN,
-    #             noise_gate_enable=config.AIC_NOISE_GATE_ENABLE,
-    #         )
-    #         daily_params.audio_in_filter = aic_filter
-    #         logger.info(f"AIC Filter: ENABLED (enhancement_level={config.AIC_ENHANCEMENT_LEVEL}, voice_gain={config.AIC_VOICE_GAIN}, noise_gate={config.AIC_NOISE_GATE_ENABLE})")
+    if config.ENABLE_AIC_FILTER and config.AICOUSTICS_LICENSE_KEY:
+        try:
+            aic_filter = AICFilter(
+                license_key=config.AICOUSTICS_LICENSE_KEY,
+                enhancement_level=config.AIC_ENHANCEMENT_LEVEL,
+                voice_gain=config.AIC_VOICE_GAIN,
+                noise_gate_enable=config.AIC_NOISE_GATE_ENABLE,
+            )
+            daily_params.audio_in_filter = aic_filter
+            logger.info(f"AIC Filter: ENABLED (enhancement_level={config.AIC_ENHANCEMENT_LEVEL}, voice_gain={config.AIC_VOICE_GAIN}, noise_gate={config.AIC_NOISE_GATE_ENABLE})")
             
-    #     except Exception as e:
-    #         logger.error(f"AIC Filter failed: {e}")
-            
-    if config.ENABLE_NOISE_REDUCE_FILTER:
+        except Exception as e:
+            logger.error(f"AIC Filter failed: {e}")
+    elif config.ENABLE_NOISE_REDUCE_FILTER:
         daily_params.audio_in_filter = NoisereduceFilter()
         logger.info("Audio Filter: NoiseReduce Enabled")
     else:

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,8 @@ uvicorn==0.34.2
 aiohttp>=3.8.4
 
 # Google Generative AI
-google-genai>=1.14.0,<1.15.0
+# Commenting out to avoid dependency conflicts with pipecat-ai latest version
+# google-genai>=1.14.0,<1.15.0
 
 # Additional utilities
 pytz==2025.2
@@ -19,7 +20,7 @@ starlette>=0.27.0
 # Logging and environment
 python-dotenv>=1.0.0
 
-pipecat-ai[daily,google,assembly,silero,openai,azure,elevenlabs,noisereduce,mem0]
+pipecat-ai[daily,google,assembly,silero,openai,azure,elevenlabs,noisereduce,mem0,aic,anthropic]
 pipecat-ai-flows
 
 # Google Cloud Speech


### PR DESCRIPTION
## Description:

- AIC noise reduction filter requires pipecat version 0.84
- pipecat 0.84 requires anthropic-sdk and nltk that were causing issue in prod due to lack permission but working in local
- Added nltk installation step to dockerfile to avoid permission issue during runtime

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added optional AIC-based audio input filtering with configurable enhancement, voice gain, and noise gate.
  - Preserves optional noise reduction filtering path.

- Chores
  - Docker image now includes NLTK data and uses an environment variable for port exposure.
  - Updated dependencies: expanded provider extras and temporarily disabled Google GenAI to prevent conflicts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->