### PR TITLE
add time range validation for calling

### DIFF
--- a/app/agents/voice/breeze_buddy/managers/calls.py
+++ b/app/agents/voice/breeze_buddy/managers/calls.py
@@ -60,6 +60,31 @@ async def process_backlog_leads():
                         )
                         continue
 
+                    # FIRST STEP: Check if current time is within allowed calling hours (handles overnight windows)
+                    current_time = datetime.now(timezone.utc).time()
+                    if config.call_start_time <= config.call_end_time:
+                        # Normal case (e.g., 09:00–17:00)
+                        within_hours = (
+                            config.call_start_time
+                            <= current_time
+                            <= config.call_end_time
+                        )
+                    else:
+                        # Overnight case (e.g., 22:00–06:00)
+                        within_hours = (
+                            current_time >= config.call_start_time
+                            or current_time <= config.call_end_time
+                        )
+
+                    if not within_hours:
+                        logger.info(
+                            f"Skipping lead {lead.id} - outside calling hours. "
+                            f"Current time: {current_time}, "
+                            f"Allowed window: {config.call_start_time} - {config.call_end_time}"
+                        )
+                        continue
+
+                    # Only proceed if within calling hours
                     numbers = await get_outbound_number_based_on_status_and_provider(
                         OutboundNumberStatus.AVAILABLE, config.calling_provider
                     )

--- a/scripts/create_tables.py
+++ b/scripts/create_tables.py
@@ -206,7 +206,7 @@ def main():
 
             asyncio.run(list_tables())
         else:
-            print("Usage: python -m app.scripts.create_tables [create|list]")
+            print("Usage: python -m scripts.create_tables [create|list]")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Backlog dialing now respects configurable calling hours: calls are only attempted within the defined start/end times (UTC). Leads outside the window are deferred automatically.
  * Prevents off-hours outreach, improving user experience and compliance with calling policies.
  * Normal call routing, provider selection, and status updates continue unchanged during allowed hours.
  * Clear informational logging when leads are skipped outside the allowed window, aiding monitoring and operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->