### PR TITLE
Fix calling time to IST

### DIFF
--- a/app/agents/voice/breeze_buddy/managers/calls.py
+++ b/app/agents/voice/breeze_buddy/managers/calls.py
@@ -62,7 +62,8 @@ async def process_backlog_leads():
                         continue
 
                     # FIRST STEP: Check if current time is within allowed calling hours (handles overnight windows)
-                    current_time = datetime.now(timezone.utc).time()
+                    IST = timezone(timedelta(hours=5, minutes=30))
+                    current_time = datetime.now(IST).time()
                     if config.call_start_time <= config.call_end_time:
                         # Normal case (e.g., 09:00–17:00)
                         within_hours = (


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Calling-hour checks now use Indian Standard Time (UTC+5:30), ensuring calls are placed only during allowed hours for users in India.
  - Correct handling of both daytime and overnight calling windows under IST.
  - Improves consistency and compliance with regional calling schedules without requiring any user action.
  - Reduces unexpected out-of-hours call attempts and missed in-hours opportunities for IST users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->