### PR TITLE
enforcing one chart per turn from system

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -66,6 +66,8 @@ ENABLE_BREEZE_MCP=true
 # If SHOPS_FOR_BREEZE_MCP is empty, MCP client runs for ALL shops when ENABLE_BREEZE_MCP=true
 # If SHOPS_FOR_BREEZE_MCP has values, MCP client runs only for those specific shops
 SHOPS_FOR_BREEZE_MCP="d2cstore-beta"
+# Chart Generation Configuration
+MAX_CHARTS_PER_TURN=1
 
 BREEZE_MCP_ENDPOINT_PATH="/ai/neurolink"
 TWILIO_ACCOUNT_SID=""

--- a/app/agents/voice/automatic/features/charts/chart_tools.py
+++ b/app/agents/voice/automatic/features/charts/chart_tools.py
@@ -16,14 +16,56 @@ from app.agents.voice.automatic.features.charts.utils.highlight_parser import (
     HighlightTagParser,
 )
 from app.agents.voice.automatic.utils.session_context import get_current_session_id
+from app.core import config
 from app.core.logger import logger
 
 # Color constants matching MCP implementation
 DEFAULT_COLORS = ["#1f77b4", "#ff7f0e", "#2ca02c", "#d62728", "#9467bd", "#8c564b"]
 DONUT_COLORS = ["#ff7f0e", "#2ca02c", "#d62728", "#9467bd", "#8c564b", "#e377c2"]
 
-# Global registry for pending chart emissions
-_pending_chart_emissions: Dict[str, List[Dict[str, Any]]] = {}
+
+class ChartTurnManager:
+    """Manages chart emission tracking per session to enforce turn limits."""
+
+    def __init__(self):
+        self._pending_chart_emissions: Dict[str, List[Dict[str, Any]]] = {}
+        self._chart_turn_counts: Dict[str, int] = {}
+
+    def reset_chart_turn_count(self, session_id: str) -> None:
+        """Reset the chart count for a new LLM turn."""
+        self._chart_turn_counts[session_id] = 0
+
+    def register_pending_chart_emission(
+        self, session_id: str, component_data: Dict[str, Any]
+    ) -> None:
+        """
+        Register a chart component for RTVI emission.
+        """
+        if session_id not in self._chart_turn_counts:
+            self._chart_turn_counts[session_id] = 0
+
+        if self._chart_turn_counts[session_id] >= config.MAX_CHARTS_PER_TURN:
+            logger.warning(
+                f"[{session_id}] Silently rejecting chart '{component_data.get('props', {}).get('title', 'Unknown')}' - "
+                f"maximum {config.MAX_CHARTS_PER_TURN} charts per turn exceeded (count: {self._chart_turn_counts[session_id] + 1})"
+            )
+            return
+
+        self._chart_turn_counts[session_id] += 1
+
+        if session_id not in self._pending_chart_emissions:
+            self._pending_chart_emissions[session_id] = []
+        self._pending_chart_emissions[session_id].append(component_data)
+
+    def get_pending_chart_emissions(self, session_id: str) -> List[Dict[str, Any]]:
+        """Get and clear pending chart emissions for a session."""
+        charts = self._pending_chart_emissions.get(session_id, [])
+        if session_id in self._pending_chart_emissions:
+            del self._pending_chart_emissions[session_id]
+        return charts
+
+
+_default_chart_turn_manager = ChartTurnManager()
 
 
 def generate_chart_id(chart_type: str) -> str:
@@ -47,21 +89,23 @@ def get_pending_ui_components(session_id: str) -> List[UIComponentEvent]:
         return []
 
 
-def _register_pending_chart_emission(session_id: str, component_data: Dict[str, Any]):
-    """Register a chart component for RTVI emission"""
-    global _pending_chart_emissions
-    if session_id not in _pending_chart_emissions:
-        _pending_chart_emissions[session_id] = []
-    _pending_chart_emissions[session_id].append(component_data)
+def reset_chart_turn_count(session_id: str) -> None:
+    """Reset the chart count for a new LLM turn."""
+    _default_chart_turn_manager.reset_chart_turn_count(session_id)
+
+
+def _register_pending_chart_emission(
+    session_id: str, component_data: Dict[str, Any]
+) -> None:
+    """Register a chart component for RTVI emission."""
+    _default_chart_turn_manager.register_pending_chart_emission(
+        session_id, component_data
+    )
 
 
 def get_pending_chart_emissions(session_id: str) -> List[Dict[str, Any]]:
-    """Get and clear pending chart emissions for a session"""
-    global _pending_chart_emissions
-    charts = _pending_chart_emissions.get(session_id, [])
-    if session_id in _pending_chart_emissions:
-        del _pending_chart_emissions[session_id]
-    return charts
+    """Get and clear pending chart emissions for a session."""
+    return _default_chart_turn_manager.get_pending_chart_emissions(session_id)
 
 
 async def generate_bar_chart(params) -> None:

--- a/app/agents/voice/automatic/processors/llm_spy.py
+++ b/app/agents/voice/automatic/processors/llm_spy.py
@@ -17,10 +17,14 @@ from pipecat.frames.frames import (
     LLMFullResponseStartFrame,
     LLMTextFrame,
     TextFrame,
+    UserStartedSpeakingFrame,
 )
 from pipecat.processors.frame_processor import FrameDirection, FrameProcessor
 from pipecat.processors.frameworks.rtvi import RTVIProcessor, RTVIServerMessageFrame
 
+from app.agents.voice.automatic.features.charts.chart_tools import (
+    reset_chart_turn_count,
+)
 from app.agents.voice.automatic.features.charts.rtvi.rtvi import emit_chart_components
 from app.agents.voice.automatic.rtvi.rtvi import emit_rtvi_event
 from app.agents.voice.automatic.utils.conversation_manager import (
@@ -164,6 +168,10 @@ class LLMSpyProcessor(FrameProcessor):
                 )
             else:
                 await self.push_frame(frame, direction)
+
+        elif isinstance(frame, UserStartedSpeakingFrame) and self._enable_charts:
+            reset_chart_turn_count(self._session_id)
+            await self.push_frame(frame, direction)
 
         # LLM Response Start - begin collecting text and start conversation turn
         elif isinstance(frame, LLMFullResponseStartFrame) and self._enable_charts:

--- a/app/agents/voice/automatic/prompts/system/charts.py
+++ b/app/agents/voice/automatic/prompts/system/charts.py
@@ -31,8 +31,10 @@ def get_chart_visualization_instructions() -> str:
         1. Payment method breakdown → Donut chart
         2. Sales by channel/product/category → Donut chart
         3. Time trends (daily, weekly, monthly) → Line chart
-        4. Comparisons between items → Bar chart
-        5. Single metric → Single-stat chart
+        4. Single metric → Single-stat chart
+        5. Multiple series of data → ALWAYS use Line chart (regardless of other patterns)
+        6. Comparisons between items → Line chart
+
 
     RULE 4: FUNCTION RESULT SCANNING
         SCAN EVERY function result for: arrays, categories, values, percentages
@@ -44,6 +46,14 @@ def get_chart_visualization_instructions() -> str:
         1. Always attempt a chart first
         2. If chart generation fails or is not meaningful, provide a clear text response instead
         3. Never leave the user without an answer
+
+    RULE 6: CHART LIMIT PER USER TURN
+        1. Only ONE chart is allowed per user interaction/turn
+        2. If a user requests multiple charts (e.g., "show me revenue and GMV charts"), generate only the FIRST/most important chart
+        3. Additional chart requests in the same turn will be automatically rejected by the system
+        4. Focus on the primary data visualization that best answers the user's core question
+        5. Mention other data points in your voice response without creating additional charts
+
 
     RULE 7: NARRATION HIGHLIGHTING
 

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -334,6 +334,7 @@ HITL_ACTIONS = [
 
 # Chart Generation Configuration
 ENABLE_CHARTS = os.environ.get("ENABLE_CHARTS", "false").lower() == "true"
+MAX_CHARTS_PER_TURN = int(os.environ.get("MAX_CHARTS_PER_TURN", "1"))
 
 # PTT VAD Filter Configuration
 DISABLE_VAD_FOR_PTT = os.environ.get("DISABLE_VAD_FOR_PTT", "true").lower() == "true"


### PR DESCRIPTION
POT : 

https://github.com/user-attachments/assets/d44a5d36-5d74-4425-b23e-d45be4687ad2

Enforcing one chart per turn and silently failing as giving penalty might force llm to start apologizing in the final response

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Enforces a one-chart-per-user-turn limit by default, preventing extra charts in the same turn.
  - Chart count resets when the user starts speaking, ensuring fresh limits each turn.
  - Updated voice guidance to prioritize a single primary chart and reference additional insights verbally.

- Configuration
  - Added MAX_CHARTS_PER_TURN environment variable (default: 1) to control per-turn chart output.

- Documentation
  - Updated .env.example with the new chart generation configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->