### PR TITLE
Support for updating address in shopify notes attributes

### DIFF
--- a/app/agents/voice/breeze_buddy/workflows/order_confirmation/utils.py
+++ b/app/agents/voice/breeze_buddy/workflows/order_confirmation/utils.py
@@ -1,3 +1,5 @@
+import json
+
 from pipecat.services.google.stt import GoogleSTTService
 from pipecat.services.openai.stt import OpenAISTTService
 from pipecat.services.soniox.stt import SonioxInputParams, SonioxSTTService
@@ -116,3 +118,51 @@ def indian_number_to_speech(number: int) -> str:
         parts[-1] = h_part
 
     return " ".join(parts) + " rupees"
+
+
+def _extract_value_from_input(input_value, expected_key: str = None):
+    """Extract value from JSON-like input, dict object, or return the value directly"""
+    try:
+        # Handle dict objects directly (when LLM passes dict instead of string)
+        if isinstance(input_value, dict):
+            if expected_key and expected_key in input_value:
+                return str(input_value[expected_key]).strip()
+            # Otherwise, get the first value
+            elif input_value:
+                return str(list(input_value.values())[0]).strip()
+            else:
+                return ""
+
+        # Handle string inputs
+        if isinstance(input_value, str):
+            # Try to parse as JSON if it looks like JSON
+            if input_value.strip().startswith("{") and input_value.strip().endswith(
+                "}"
+            ):
+                try:
+                    # Parse the JSON-like string
+                    parsed = json.loads(input_value)
+                    if isinstance(parsed, dict):
+                        # If we have a specific key to look for, use it
+                        if expected_key and expected_key in parsed:
+                            return str(parsed[expected_key]).strip()
+                        # Otherwise, get the first value
+                        elif parsed:
+                            return str(list(parsed.values())[0]).strip()
+                except json.JSONDecodeError:
+                    # If JSON parsing fails, return the original stripped value
+                    return input_value.strip()
+
+            # If not JSON or parsing failed, return the original value
+            return input_value.strip()
+
+        # For any other type, convert to string and strip
+        return str(input_value).strip()
+
+    except (AttributeError, TypeError):
+        # If anything fails, convert to string and strip
+        return (
+            str(input_value).strip()
+            if hasattr(input_value, "strip")
+            else str(input_value)
+        )

--- a/app/agents/voice/breeze_buddy/workflows/order_confirmation/websocket_bot.py
+++ b/app/agents/voice/breeze_buddy/workflows/order_confirmation/websocket_bot.py
@@ -26,6 +26,7 @@ from pydub import AudioSegment
 from app.agents.voice.breeze_buddy.workflows.order_confirmation.types import OrderData
 from app.agents.voice.breeze_buddy.workflows.order_confirmation.utils import (
     OUTCOME_TO_ENUM,
+    _extract_value_from_input,
     get_stt_service,
     indian_number_to_speech,
 )
@@ -502,6 +503,7 @@ class OrderConfirmationBot:
                 summary_data = {
                     "callSid": self.call_sid,
                     "outcome": OUTCOME_TO_ENUM.get(self.outcome),
+                    "updatedAddress": self.updated_address,
                     "orderId": self.order_id,
                 }
                 logger.info(f"Call summary data: {summary_data}")
@@ -800,37 +802,59 @@ class OrderConfirmationBot:
         logger.info("Address incorrect. Proceeding to update address.")
         return {}, self._create_node_from_config("update_address")
 
+    def _update_address_part(self, part_type: str, new_value):
+        """
+        Update a specific part of an address while preserving all other parts.
+        Parts: street, locality, landmark, city, pincode
+        """
+        # Extract clean value from input
+        extracted_value = _extract_value_from_input(new_value, part_type)
+
+        logger.info(f"Updating {part_type} with value: {extracted_value}")
+
+        # Split current address into parts (use updated_address if available)
+        parts = [
+            p.strip() for p in (self.updated_address or self.address or "").split(",")
+        ]
+
+        # Ensure at least 5 parts
+        while len(parts) < 5:
+            parts.append("")
+
+        # Mapping of part_type → index in parts list
+        mapping = {"street": 0, "locality": 1, "landmark": 2, "city": 3, "pincode": 4}
+
+        # Update the specified part
+        if part_type in mapping:
+            parts[mapping[part_type]] = extracted_value
+
+        # Remove empty parts and join with comma (no spaces for webhook format)
+        final_parts = [p for p in parts if p.strip()]
+        self.updated_address = ",".join(final_parts)
+
+        logger.info(f"Final updated address: {self.updated_address}")
+
     async def _handle_landmark(self, landmark: str):
         logger.info(f"Updating landmark to: {landmark}")
-        self.updated_address = self.updated_address or self.address
-        self.updated_address = f"{self.updated_address.split(',')[0]}, {landmark}, {', '.join(self.updated_address.split(',')[2:])}"
+        self._update_address_part("landmark", landmark)
         self.outcome = "address_updated"
         return {}, self._create_node_from_config("confirm_address_update")
 
     async def _handle_pincode(self, pincode: str):
         logger.info(f"Updating pincode to: {pincode}")
-        self.updated_address = self.updated_address or self.address
-        self.updated_address = (
-            f"{', '.join(self.updated_address.split(',')[:-1])}, {pincode}"
-        )
+        self._update_address_part("pincode", pincode)
         self.outcome = "address_updated"
         return {}, self._create_node_from_config("confirm_address_update")
 
     async def _handle_city(self, city: str):
         logger.info(f"Updating city to: {city}")
-        self.updated_address = self.updated_address or self.address
-        parts = self.updated_address.split(",")
-        parts[-2] = f" {city}"
-        self.updated_address = ",".join(parts)
+        self._update_address_part("city", city)
         self.outcome = "address_updated"
         return {}, self._create_node_from_config("confirm_address_update")
 
     async def _handle_locality(self, locality: str):
         logger.info(f"Updating locality to: {locality}")
-        self.updated_address = self.updated_address or self.address
-        parts = self.updated_address.split(",")
-        parts[1] = f" {locality}"
-        self.updated_address = ",".join(parts)
+        self._update_address_part("locality", locality)
         self.outcome = "address_updated"
         return {}, self._create_node_from_config("confirm_address_update")
 


### PR DESCRIPTION
Added support for updating address in Shopify notes attributes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * End-of-conversation webhook payload now includes the updated delivery address.
* **Bug Fixes**
  * More reliable updates to address fields (landmark, pincode, city, locality) from varied input formats.
  * Updates preserve unchanged address parts and ensure consistent formatting, reducing errors in confirmations and orders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->