### PR TITLE
Support for storing twillio recording url

### DIFF
--- a/app/agents/voice/breeze_buddy/services/telephony/twilio/twilio.py
+++ b/app/agents/voice/breeze_buddy/services/telephony/twilio/twilio.py
@@ -81,6 +81,10 @@ class TwilioProvider(VoiceCallProvider):
                 from_=outbound_number,
                 twiml=str(voice_call_payload),
                 record=True,
+                recording_status_callback=(
+                    self.config.APP_BASE_URL
+                    + "/agent/voice/breeze-buddy/twilio/callback/details"
+                ),
                 status_callback=(
                     self.config.APP_BASE_URL
                     + "/agent/voice/breeze-buddy/twilio/callback/status"

--- a/app/api/routers/breeze_buddy.py
+++ b/app/api/routers/breeze_buddy.py
@@ -50,13 +50,18 @@ async def callback_status(request: Request, provider: str):
     query_params = dict(request.query_params)
     logger.info(f"Received call-details with {provider} query params: {query_params}")
 
-    if provider.lower() != "exotel":
+    if provider.lower() != "exotel" and provider.lower() != "twilio":
         raise HTTPException(
             status_code=404, detail="Feature not supported for this service provider"
         )
 
-    recording_url = query_params.get("Stream[RecordingUrl]")
     call_sid = query_params.get("CallSid")
+    recording_url = None
+
+    if provider.lower() == "twilio":
+        recording_url = query_params.get("RecordingUrl")
+    elif provider.lower() == "exotel":
+        recording_url = query_params.get("Stream[RecordingUrl]")
 
     if recording_url and call_sid:
         logger.info(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Twilio recording status callbacks for Breeze Buddy voice calls.
  * Expanded provider validation to allow both Twilio and Exotel.
  * Implemented provider-aware recording URL handling to reliably capture recording links for Twilio and Exotel.
  * Improved callback processing to proceed only when both recording URL and call SID are present, reducing invalid processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->