### PR TITLE
Block chart generation after actionable operations

### DIFF
--- a/app/agents/voice/automatic/features/charts/chart_tools.py
+++ b/app/agents/voice/automatic/features/charts/chart_tools.py
@@ -30,10 +30,16 @@ class ChartTurnManager:
     def __init__(self):
         self._pending_chart_emissions: Dict[str, List[Dict[str, Any]]] = {}
         self._chart_turn_counts: Dict[str, int] = {}
+        self._session_has_hitl: Dict[str, bool] = {}
 
-    def reset_chart_turn_count(self, session_id: str) -> None:
-        """Reset the chart count for a new LLM turn."""
+    def reset_turn_state(self, session_id: str) -> None:
+        """Reset chart count and HITL flag for a new LLM turn."""
         self._chart_turn_counts[session_id] = 0
+        self._session_has_hitl[session_id] = False
+
+    def mark_hitl_operation(self, session_id: str) -> None:
+        """Mark that a HITL operation occurred in this turn."""
+        self._session_has_hitl[session_id] = True
 
     def register_pending_chart_emission(
         self, session_id: str, component_data: Dict[str, Any]
@@ -43,6 +49,14 @@ class ChartTurnManager:
         """
         if session_id not in self._chart_turn_counts:
             self._chart_turn_counts[session_id] = 0
+
+        # Check if any tool result in this turn was a HITL operation
+        if self._session_has_hitl.get(session_id, False):
+            logger.warning(
+                f"[{session_id}] Silently rejecting chart '{component_data.get('props', {}).get('title', 'Unknown')}' - "
+                f"HITL operation detected in current turn"
+            )
+            return
 
         if self._chart_turn_counts[session_id] >= config.MAX_CHARTS_PER_TURN:
             logger.warning(
@@ -89,9 +103,14 @@ def get_pending_ui_components(session_id: str) -> List[UIComponentEvent]:
         return []
 
 
-def reset_chart_turn_count(session_id: str) -> None:
-    """Reset the chart count for a new LLM turn."""
-    _default_chart_turn_manager.reset_chart_turn_count(session_id)
+def reset_chart_turn_state(session_id: str) -> None:
+    """Reset chart count and actionable flag for a new LLM turn."""
+    _default_chart_turn_manager.reset_turn_state(session_id)
+
+
+def mark_hitl_operation(session_id: str) -> None:
+    """Mark that a HITL operation occurred in this turn."""
+    _default_chart_turn_manager.mark_hitl_operation(session_id)
 
 
 def _register_pending_chart_emission(

--- a/app/agents/voice/automatic/processors/llm_spy.py
+++ b/app/agents/voice/automatic/processors/llm_spy.py
@@ -23,9 +23,11 @@ from pipecat.processors.frame_processor import FrameDirection, FrameProcessor
 from pipecat.processors.frameworks.rtvi import RTVIProcessor, RTVIServerMessageFrame
 
 from app.agents.voice.automatic.features.charts.chart_tools import (
-    reset_chart_turn_count,
+    mark_hitl_operation,
+    reset_chart_turn_state,
 )
 from app.agents.voice.automatic.features.charts.rtvi.rtvi import emit_chart_components
+from app.agents.voice.automatic.features.hitl.utils import is_dangerous_operation
 from app.agents.voice.automatic.rtvi.rtvi import emit_rtvi_event
 from app.agents.voice.automatic.utils.conversation_manager import (
     get_conversation_manager,
@@ -170,7 +172,7 @@ class LLMSpyProcessor(FrameProcessor):
                 await self.push_frame(frame, direction)
 
         elif isinstance(frame, UserStartedSpeakingFrame) and self._enable_charts:
-            reset_chart_turn_count(self._session_id)
+            reset_chart_turn_state(self._session_id)
             await self.push_frame(frame, direction)
 
         # LLM Response Start - begin collecting text and start conversation turn
@@ -284,6 +286,16 @@ class LLMSpyProcessor(FrameProcessor):
             await self.push_frame(frame, direction)
 
             if self._enable_charts:
+                # Check if this is a dangerous/HITL operation
+                try:
+                    if is_dangerous_operation(frame.function_name):
+                        mark_hitl_operation(self._session_id)
+                        logger.debug(
+                            f"[{self._session_id}] Marked HITL operation for tool: {frame.function_name}"
+                        )
+                except Exception as e:
+                    logger.debug(f"Error checking dangerous operation: {e}")
+
                 # Track in conversation via ConversationManager (may complete turn)
                 events = await self._conversation_manager.add_tool_result_with_events(
                     self._session_id,

--- a/app/agents/voice/automatic/prompts/system/charts.py
+++ b/app/agents/voice/automatic/prompts/system/charts.py
@@ -1,4 +1,4 @@
-from app.core.config import ENABLE_CHARTS
+from app.core.config import ENABLE_CHARTS, HITL_ENABLE
 
 
 def get_chart_visualization_instructions() -> str:
@@ -6,7 +6,22 @@ def get_chart_visualization_instructions() -> str:
     Returns chart visualization instructions if charts are enabled.
     """
     if ENABLE_CHARTS:
-        return """
+        # Conditionally include HITL rule as last rule
+        hitl_rule = ""
+
+        if HITL_ENABLE:
+            hitl_rule = """
+    LAST RULE: HITL OPERATIONS RESTRICTION
+        1. Charts are automatically blocked after ANY HITL (Human-in-the-Loop) operation in the same turn
+        2. HITL operations include: creating offers, updating settings, deleting data, or any operation that modifies system state
+        3. When a HITL operation occurs, charts will be silently rejected by the system
+        4. In these cases, focus your response on confirming the action taken and its results
+        5. Do not attempt to generate charts after HITL operations - provide clear voice responses about what was accomplished instead
+        6. This restriction applies in addition to the one-chart-per-turn limit
+        7. This rule overrides the "Absolute Law" for the current turn when a HITL operation occurs
+"""
+
+        return f"""
     🔒 AUTOMATIC DATA VISUALIZATION (MANDATORY)
 
     Absolute Law: Every single data response must have a chart — no exceptions.
@@ -54,7 +69,6 @@ def get_chart_visualization_instructions() -> str:
         4. Focus on the primary data visualization that best answers the user's core question
         5. Mention other data points in your voice response without creating additional charts
 
-
     RULE 7: NARRATION HIGHLIGHTING
 
         1. Always wrap category mentions in <highlight> XML tags
@@ -64,6 +78,6 @@ def get_chart_visualization_instructions() -> str:
         5. Importance = highest value (for totals) OR biggest change (for trends)
         6. Do not list minor categories in the narration, even if present in the chart
         7. Voice descriptions must stay short (2–3 sentences max), focusing on key insights
-
+{hitl_rule}
         """
     return ""


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Blocks chart generation for a turn after any actionable operation, prioritizing confirming the action/results over visuals.
  - One-chart-per-turn limit remains enforced.
  - More reliable turn-state handling when a user starts speaking, improving consistency of chart emission.

- Documentation
  - Updated charting rules to include the actionable-operations restriction.
  - Expanded narration guidelines with clearer examples for concise, high-impact voice highlights.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->