### PR TITLE
fix: tool call trace nesting fix

### DIFF
--- a/app/agents/voice/automatic/processors/llm_spy.py
+++ b/app/agents/voice/automatic/processors/llm_spy.py
@@ -21,8 +21,8 @@ from pipecat.frames.frames import (
 )
 from pipecat.processors.frame_processor import FrameDirection, FrameProcessor
 from pipecat.processors.frameworks.rtvi import RTVIProcessor, RTVIServerMessageFrame
-from pipecat.utils.tracing.conversation_context_provider import (
-    get_current_conversation_context,
+from pipecat.utils.tracing.turn_context_provider import (
+    get_current_turn_context,
 )
 
 from app.agents.voice.automatic.features.charts.chart_tools import (
@@ -217,13 +217,15 @@ class LLMSpyProcessor(FrameProcessor):
         # Function Call Start - emit RTVI event and track in conversation
         elif isinstance(frame, FunctionCallInProgressFrame):
             if self._tracer:
-                # Use Pipecat's conversation context for proper tool call nesting
-                conversation_context = get_current_conversation_context()
+                # Use turn context directly for tool calls to be nested in turn span
+                turn_context = get_current_turn_context()
+
                 span = self._tracer.start_span(
                     f"Tool: {frame.function_name}",
                     kind=trace.SpanKind.CLIENT,
-                    context=conversation_context,
+                    context=turn_context,
                 )
+
                 span.set_attributes(
                     {
                         "tool.name": frame.function_name,


### PR DESCRIPTION
### Problem:
Tool calls in Langfuse traces were not properly nested within the conversation hierarchy. They needed to be positioned correctly within turn spans and LLM nodes for better trace organization and debugging.

### What was done:

  1. Fixed tool call nesting within turns: Modified LLMSpyProcessor to use get_current_turn_context() instead of conversation context when creating tool call spans, ensuring they nest properly within turn spans rather than floating at
  conversation level.
  2. Removed unnecessary LLM Turn span creation: Eliminated custom LLM Turn span management code that was creating extra nesting layers. This simplified the hierarchy and allowed Pipecat's native LLM spans to handle the structure properly.
  3. Improved STT/TTS span nesting: As a side effect of the context changes, STT and TTS spans now also nest properly within turn spans instead of escaping to higher levels.

### Technical changes:
  - Updated tool call span creation to use turn_context from get_current_turn_context()
  - Removed _current_llm_span, _llm_response_complete tracking variables
  - Removed _maybe_complete_llm_turn_span() method
  - Simplified LLM response start/end frame handling
  - Removed unnecessary TurnContextProvider import

### Dev Proof
<img width="1037" height="988" alt="image" src="https://github.com/user-attachments/assets/76e2bd96-6e23-4a0c-9865-bb7b81c013f2" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None.
- Bug Fixes
  - Improves stability and consistency of voice interactions and tool-call events when charts are disabled.
  - Preserves existing behavior when charts are enabled.
- Refactor
  - Streamlines handling of LLM response start/end when charts are off, avoiding unnecessary tracing overhead.
  - Aligns tool-call tracking with the active turn context for more reliable event emission.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->