### PR TITLE
Fixed weekly comparison in linechart

### DIFF
--- a/app/agents/voice/automatic/prompts/system/charts.py
+++ b/app/agents/voice/automatic/prompts/system/charts.py
@@ -78,6 +78,11 @@ def get_chart_visualization_instructions() -> str:
         5. Importance = highest value (for totals) OR biggest change (for trends)
         6. Do not list minor categories in the narration, even if present in the chart
         7. Voice descriptions must stay short (2–3 sentences max), focusing on key insights
+
+    RULE 8: WEEKLY COMPARISON X-AXIS STANDARDIZATION
+        For weekly trend comparisons or weekly data analysis:
+        1. ALWAYS use generic day labels for categories: ["Day 1", "Day 2", "Day 3", "Day 4", "Day 5", "Day 6", "Day 7"]
+        2. NEVER use actual dates (e.g., "2024-01-01", "Jan 1") for weekly comparisons
 {hitl_rule}
         """
     return ""


### PR DESCRIPTION
<img width="423" height="889" alt="Screenshot 2025-10-01 at 5 29 58 PM" src="https://github.com/user-attachments/assets/2d8f34cc-8e79-49ed-b87e-1be18704937f" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Standardized weekly comparison x-axis labels in chart narration: voice summaries now use generic day names (e.g., Mon–Sun) instead of specific dates for weekly trends, improving clarity and comparability across weeks. Applies wherever weekly trend analyses are presented. No changes to other chart behaviors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->