### PR TITLE
Baner Background colour configurable with offer HITL fix

### DIFF
--- a/app/agents/voice/automatic/features/hitl/hitl.py
+++ b/app/agents/voice/automatic/features/hitl/hitl.py
@@ -148,7 +148,7 @@ class HITLManager:
             "confirmation_id": confirmation_id,
             "action_type": action_type,
             "function_name": function_name,
-            "arguments": display_arguments,
+            "arguments": display_arguments if len(display_arguments) > 0 else arguments,
             "timestamp": datetime.now().isoformat(),
         }
 

--- a/app/agents/voice/automatic/tools/breeze/configuration.py
+++ b/app/agents/voice/automatic/tools/breeze/configuration.py
@@ -519,6 +519,7 @@ async def manage_announcement_banner(params: FunctionCallParams):
     try:
         action = params.arguments.get("action")
         description = params.arguments.get("description")
+        background_color = params.arguments.get("background_color", "#714acd")
 
         # Validate action
         if not action:
@@ -628,7 +629,9 @@ async def manage_announcement_banner(params: FunctionCallParams):
 
         if action == BannerAction.ADD or action == BannerAction.UPDATE:
             # Format the description with HTML styling
-            formatted_description = format_announcement_html(description)
+            formatted_description = format_announcement_html(
+                description, background_color
+            )
 
             # Update both announcement types with the same formatted content
             config_to_patch[login_page_key] = formatted_description
@@ -717,6 +720,11 @@ All announcements are formatted with HTML styling for consistent appearance.""",
         "description": {
             "type": "string",
             "description": "The content of the banner. Required when creating or updating a banner. Emojis are allowed.",
+        },
+        "background_color": {
+            "type": "string",
+            "description": "The background color of the announcement banner. Default is #714acd (Light Purple).",
+            "default": "#714acd",
         },
     },
     required=["action"],

--- a/app/agents/voice/automatic/tools/breeze/utils.py
+++ b/app/agents/voice/automatic/tools/breeze/utils.py
@@ -192,17 +192,20 @@ async def patch_shop_config(
         }
 
 
-def format_announcement_html(description: str) -> str:
+def format_announcement_html(
+    description: str, background_color: str = "#714acd"
+) -> str:
     """
     Formats the announcement text with HTML styling.
 
     Args:
         description: The announcement text to format
+        background_color: The background color of the announcement banner
 
     Returns:
         HTML formatted announcement text
     """
-    return f"<div style='text-align: center; width: 100vw;background: #714acd;color: white;padding:8px 0px;font-size:13px;'>{description}</div>"
+    return f"<div style='text-align: center; width: 100vw;background: {background_color};color: white;padding:8px 0px;font-size:13px;'>{description}</div>"
 
 
 def remove_html_tags(html_text: str) -> str:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Announcement banners now support a customizable background color (default remains #714acd) when adding or updating banners, enabling more flexible styling.

- Bug Fixes
  - Confirmation prompts now show original details when no display-specific information is available, avoiding empty or missing argument displays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->