### PR TITLE
adding the support to provide write actions for merchants

### DIFF
--- a/app/agents/voice/automatic/tools/utils.py
+++ b/app/agents/voice/automatic/tools/utils.py
@@ -3,11 +3,14 @@ from typing import Any, Dict, List, Optional
 from app.core.config import (
     AUTOMATIC_ACTIONS_REQUIRE_AUTH,
     AUTOMATIC_WRITE_ACTIONS_AUTHORIZED_USERS,
+    ENABLE_WRITE_ACTIONS_FOR_MERCHANTS,
 )
 from app.core.logger import logger
 
 
 def is_user_authorized_for_actions(email: Optional[str]) -> bool:
+    if ENABLE_WRITE_ACTIONS_FOR_MERCHANTS and email and "@juspay.in" not in email:
+        return True
     if not AUTOMATIC_WRITE_ACTIONS_AUTHORIZED_USERS:
         return True
     return bool(email and email in AUTOMATIC_WRITE_ACTIONS_AUTHORIZED_USERS)

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -258,6 +258,10 @@ AUTOMATIC_WRITE_ACTIONS_AUTHORIZED_USERS = [
     if email.strip()
 ]
 
+ENABLE_WRITE_ACTIONS_FOR_MERCHANTS = (
+    os.environ.get("ENABLE_WRITE_ACTIONS_FOR_MERCHANTS", "false").lower() == "true"
+)
+
 # Get write actions from environment, split and normalize
 AUTOMATIC_ACTIONS_REQUIRE_AUTH = [
     action.strip().lower()


### PR DESCRIPTION
- adding the support to provide write actions for merchants

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Optional ability to grant write actions to merchant users (non-company emails) via a feature toggle. When enabled, eligible users can perform write operations without individual whitelisting, while the existing allowlist continues to work.

- Chores
  - Added a configuration toggle to control merchant write access (default: off). No behavioral change for existing users unless explicitly enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->