### PR TITLE
Enable Breeze MCP for Bret

### DIFF
--- a/app/agents/voice/automatic/__init__.py
+++ b/app/agents/voice/automatic/__init__.py
@@ -57,6 +57,7 @@ from app.agents.voice.automatic.types import (
     decode_tts_provider,
     decode_voice_name,
 )
+from app.agents.voice.automatic.types.models import VoiceName
 from app.agents.voice.automatic.utils.session_context import (
     create_session_context,
     set_current_session_id,
@@ -271,6 +272,14 @@ async def run_normal_mode(args):
         or args.shop_id in config.SHOPS_FOR_BREEZE_MCP  # Specific shops only
     )
 
+    use_breeze_mcp_server_for_bret = config.ENABLE_BREEZE_MCP_FOR_BRET and (
+        voice_name == VoiceName.BRET
+        and (
+            not config.SHOPS_FOR_BREEZE_MCP
+            or args.shop_id in config.SHOPS_FOR_BREEZE_MCP
+        )
+    )
+
     # Personalize the system prompt if a user name is provided
     system_prompt = get_system_prompt(args.user_name, tts_provider, args.shop_id)
 
@@ -389,7 +398,7 @@ async def run_normal_mode(args):
         )
     )
 
-    if not use_breeze_mcp_server:
+    if not use_breeze_mcp_server and not use_breeze_mcp_server_for_bret:
         # Initialize tools normally
         if mode == Mode.LIVE:
             tools, tool_functions = initialize_tools(

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -233,6 +233,9 @@ ENABLE_SMART_TURN = os.getenv("ENABLE_SMART_TURN", "false").lower() == "true"
 
 # Automatic MCP Tool Server
 ENABLE_BREEZE_MCP = os.environ.get("ENABLE_BREEZE_MCP", "false").lower() == "true"
+ENABLE_BREEZE_MCP_FOR_BRET = (
+    os.environ.get("ENABLE_BREEZE_MCP_FOR_BRET", "false").lower() == "true"
+)
 MCP_CLIENT_TIMEOUT = int(os.environ.get("MCP_CLIENT_TIMEOUT", 30))  # seconds
 BREEZE_MCP_ENDPOINT_PATH = os.environ.get("BREEZE_MCP_ENDPOINT_PATH", "/ai/neurolink")
 shops_for_mcp = os.environ.get("SHOPS_FOR_BREEZE_MCP", "")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Optional Breeze MCP routing for tool initialization when using the BRET voice.
  - Support for a configurable list of shops to use with Breeze MCP.

- Configuration
  - Added ENABLE_BREEZE_MCP_FOR_BRET environment flag (default: off) to control MCP usage with BRET.
  - Added SHOPS_FOR_BREEZE_MCP environment variable to define a comma-separated allowlist of shops.

- Behavior Changes
  - Tool initialization now conditionally selects normal or MCP mode based on the new flag and chosen voice.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->