### PR TITLE
Add backlog calls section in breeze buddy dashboard

### DIFF
--- a/app/api/routers/breeze_buddy.py
+++ b/app/api/routers/breeze_buddy.py
@@ -466,7 +466,9 @@ async def get_analytics(
     )
 
     analytics = {
-        "calls_attempted": len(trackers),
+        "calls_attempted": len(
+            [t for t in trackers if t.status and t.status.value == "FINISHED"]
+        ),
         "no_answer": len(
             [t for t in trackers if t.outcome and t.outcome.value == "NO_ANSWER"]
         ),
@@ -481,6 +483,9 @@ async def get_analytics(
         ),
         "address_updated": len(
             [t for t in trackers if t.outcome and t.outcome.value == "ADDRESS_UPDATED"]
+        ),
+        "backlog_calls": len(
+            [t for t in trackers if t.status and t.status.value == "BACKLOG"]
         ),
     }
     return JSONResponse(content=analytics)


### PR DESCRIPTION
<img width="1711" height="1029" alt="Screenshot 2025-10-15 at 1 45 19 AM" src="https://github.com/user-attachments/assets/804a2e74-308d-4fdc-88d8-78a236512edc" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “Backlog Calls” analytics metric to display the number of calls in backlog.

* **Bug Fixes**
  * Corrected the “Calls Attempted” metric to count only completed calls, improving accuracy of analytics reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->