### PR TITLE
Fix VAD - Allow users to interuppt in between

### DIFF
--- a/app/agents/voice/breeze_buddy/workflows/order_confirmation/websocket_bot.py
+++ b/app/agents/voice/breeze_buddy/workflows/order_confirmation/websocket_bot.py
@@ -12,6 +12,7 @@ from pipecat.audio.vad.vad_analyzer import VADParams
 from pipecat.pipeline.pipeline import Pipeline
 from pipecat.pipeline.runner import PipelineRunner
 from pipecat.pipeline.task import PipelineParams, PipelineTask
+from pipecat.processors.aggregators.llm_response import LLMUserAggregatorParams
 from pipecat.processors.aggregators.openai_llm_context import OpenAILLMContext
 from pipecat.processors.filters.stt_mute_filter import (
     STTMuteConfig,
@@ -269,7 +270,10 @@ class OrderConfirmationBot:
         )
 
         self.context = OpenAILLMContext(messages)
-        context_aggregator = llm.create_context_aggregator(self.context)
+        user_params = LLMUserAggregatorParams(enable_emulated_vad_interruptions=True)
+        context_aggregator = llm.create_context_aggregator(
+            self.context, user_params=user_params
+        )
 
         pipeline = Pipeline(
             [
@@ -445,6 +449,8 @@ class OrderConfirmationBot:
             - Items: {order_summary}
             - Total Price: {total_price_words}
             - Delivery Address: {address}
+
+            When reading the delivery address, if it contains a pincode (a 6-digit number), you must read it out digit by digit. For example, if the pincode is 123456, say "Pincode is one two three four five six".
 
             Speak in a warm, casual, and human-like tone. Avoid robotic language.
 

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -427,7 +427,7 @@ BREEZE_BUDDY_SONIOX_LANGUAGE_HINTS = os.environ.get(
 )
 BREEZE_BUDDY_SONIOX_CONTEXT = os.environ.get(
     "BREEZE_BUDDY_SONIOX_CONTEXT",
-    "State, Yes, Yeah, Good, Time, Yep, Later, Available, Busy, Confirm, Cancel, Repeat",
+    "State, Yes, Yeah, Good, Time, Yep, Later, Available, Busy, Confirm, Repeat, What, Order",
 )
 BREEZE_BUDDY_SONIOX_ENABLE_NON_FINAL_TOKENS = (
     os.environ.get("BREEZE_BUDDY_SONIOX_ENABLE_NON_FINAL_TOKENS", "false").lower()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The voice assistant now supports natural interruptions while it’s speaking, letting you interject and be recognized faster during order confirmation.
  * Expanded default language context improves understanding of “what” and “order” phrases, enhancing recognition and accuracy without additional setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->