### PR TITLE
(fix): update offer tool is failing because of incorrect currency payload

### DIFF
--- a/app/agents/voice/automatic/tools/juspay/analytics.py
+++ b/app/agents/voice/automatic/tools/juspay/analytics.py
@@ -1381,9 +1381,7 @@ async def update_euler_offer(params: FunctionCallParams):
                         .get("order", {})
                         .get("min_order_amount", "1")
                     ),
-                    "currency": existing_offer.get("rule_dsl", {})
-                    .get("order", {})
-                    .get("currency", "INR"),
+                    "currency": "INR",
                     "amount_info": existing_offer.get("rule_dsl", {})
                     .get("order", {})
                     .get("amount_info", []),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized currency handling for offer updates to consistently use INR.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->