### PR TITLE
Set outcome to busy only if the call did'nt move to another node during call hangup

### DIFF
--- a/app/agents/voice/breeze_buddy/workflows/order_confirmation/websocket_bot.py
+++ b/app/agents/voice/breeze_buddy/workflows/order_confirmation/websocket_bot.py
@@ -442,7 +442,8 @@ class OrderConfirmationBot:
         if not self.conversation_ended:
             self.conversation_ended = True
             logger.info(f"{reason}. Updating call status directly.")
-            self.outcome = "busy"
+            if self.outcome == "unknown":
+                self.outcome = "busy"
             await self._finalize_call()
 
     async def _finalize_call(self):


### PR DESCRIPTION
g

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of unexpected disconnections in order confirmation to better preserve transaction state and ensure accurate order status tracking during connection issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->