### PR TITLE
Convert to float before adding the numbers in donut chart

### DIFF
--- a/app/agents/voice/automatic/features/charts/chart_tools.py
+++ b/app/agents/voice/automatic/features/charts/chart_tools.py
@@ -335,7 +335,9 @@ async def generate_donut_chart(params) -> None:
             colors = DONUT_COLORS[: len(categories)]
 
         # Calculate and format total based on data type (matching MCP logic)
-        total_value = sum(data)
+        float_data = [float(n) for n in data]
+
+        total_value = sum(float_data)
         formatted_total = None
 
         if data_type == "currency":


### PR DESCRIPTION
At times, the input data contains combination of strings and numbers instead of just numbers, causing error while calculating sum. 
Made a change to convert these to float before calculating sum

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved numeric consistency in donut chart total value calculations for currency and numerical data types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->