### PR TITLE
Fix : Remove registration of local charts tool for MCP

### DIFF
--- a/app/agents/voice/automatic/services/mcp/breeze_mcp_client.py
+++ b/app/agents/voice/automatic/services/mcp/breeze_mcp_client.py
@@ -8,9 +8,6 @@ from pipecat.services.mcp_service import MCPClient as PipecatMCPClient
 
 from app.agents.voice.automatic.services.mcp.utils import create_chart_aware_wrapper
 from app.agents.voice.automatic.tools import initialize_tools
-from app.agents.voice.automatic.tools.charts import (
-    tool_functions as chart_tool_functions,
-)
 from app.agents.voice.automatic.types import Mode
 from app.core import config
 from app.core.logger import logger
@@ -68,21 +65,13 @@ async def init_breeze_mcp_tools(
             if original_register_function is not None:
                 llm.register_function = original_register_function
 
-        # register chart tools if enabled
-        if config.ENABLE_CHARTS:
-            for name, function in chart_tool_functions.items():
-                logger.info(f"Registering essential chart tool: {name}")
-                llm.register_function(name, function)
-
         # Log registration success
         if tools:
             logger.info(
                 f"Successfully registered MCP tools via pure Pipecat MCP client"
             )
         else:
-            logger.warning(
-                f"MCP client returned None or empty tools object - but essential tools are still registered"
-            )
+            logger.warning(f"MCP client returned None or empty tools object")
 
         return tools
 


### PR DESCRIPTION
- Removed the registration of local charts tool when the pipecat MCP client is used .
- MCP already have the charts tool in it 
- Duplicate charts tool were causing conflicts while calling/showing the charts
### Dev proof
[https://drive.google.com/file/d/1VvYIqomO_bQ3SDg1GQnkcLnGr9omHqxN/view?usp=sharing](url)
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Simplified chart tool registration logic in voice agent services, removing unnecessary conditional handling and streamlining diagnostic logging to improve system clarity and reduce complexity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->