### PR TITLE
 Shopify Order Cancellation lead management

### DIFF
--- a/app/ai/voice/agents/breeze_buddy/types/models.py
+++ b/app/ai/voice/agents/breeze_buddy/types/models.py
@@ -42,3 +42,12 @@ class LeadData(BaseModel):
 class LoginRequest(BaseModel):
     username: str
     password: str
+
+
+class LeadCancellation(BaseModel):
+    lead_id: str
+    cancellation_reason: str
+
+
+class CancelLeadRequest(BaseModel):
+    leads: List[LeadCancellation]

--- a/app/api/routers/breeze_buddy/leads/__init__.py
+++ b/app/api/routers/breeze_buddy/leads/__init__.py
@@ -7,6 +7,7 @@ Leads represent individual call attempts to customers.
 Endpoints:
 - POST   /leads              - Push new lead for processing
 - GET    /leads/{id}         - Get lead details by ID
+- DELETE /leads/{id}         - Delete (abort) a lead by ID
 - GET    /leads/recording/{call_sid} - Get call recording audio
 
 For backward compatibility, old endpoints are available in deprecated/leads.py
@@ -15,13 +16,17 @@ For backward compatibility, old endpoints are available in deprecated/leads.py
 from fastapi import APIRouter, Depends, HTTPException, status
 from fastapi.responses import StreamingResponse
 
-from app.ai.voice.agents.breeze_buddy.types.models import PushLeadRequest
+from app.ai.voice.agents.breeze_buddy.types.models import (
+    CancelLeadRequest,
+    PushLeadRequest,
+)
 from app.api.security.breeze_buddy.rbac_token import get_current_user_with_rbac
 from app.core.logger import logger
 from app.database.accessor import get_lead_by_id
 from app.schemas import UserInfo
 
 from .handlers import (
+    delete_lead_handler,
     get_call_recording_handler,
     get_lead_handler,
     push_lead_handler,
@@ -163,3 +168,76 @@ async def get_call_recording(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=f"Internal server error while fetching recording: {str(e)}",
         ) from e
+
+
+@router.post("/lead/abort", status_code=status.HTTP_200_OK)
+async def delete_lead(
+    request: CancelLeadRequest,
+    current_user: UserInfo = Depends(get_current_user_with_rbac),
+):
+    """
+    Delete (abort) multiple leads by IDs with individual cancellation reasons.
+
+    This endpoint aborts leads by setting their status to FINISHED and outcome to ABORT.
+    Each lead can have its own cancellation reason.
+    The lead records are not physically deleted but marked as aborted in the database.
+
+    Request Body:
+    {
+        "leads": [
+            {
+                "lead_id": "uuid1",
+                "cancellation_reason": "Customer requested cancellation"
+            },
+            {
+                "lead_id": "uuid2",
+                "cancellation_reason": "Duplicate order"
+            }
+        ]
+    }
+
+    RBAC:
+    - Admin: Can delete any lead
+    - Merchant: Can only delete leads for own merchants/shops
+
+    Returns:
+        {
+            "status": "success",
+            "message": "Processed N lead(s)",
+            "results": [
+                {
+                    "lead_id": "uuid1",
+                    "status": "aborted",
+                    "outcome": "ABORT",
+                    "cancellation_reason": "Customer requested cancellation",
+                    "message": "Lead uuid1 has been aborted"
+                },
+                {
+                    "lead_id": "uuid2",
+                    "status": "aborted",
+                    "outcome": "ABORT",
+                    "cancellation_reason": "Duplicate order",
+                    "message": "Lead uuid2 has been aborted"
+                }
+            ],
+            "errors": [
+                {
+                    "lead_id": "uuid3",
+                    "error": "Lead not found for ID: uuid3"
+                }
+            ]
+        }
+
+    Raises:
+        404 if not found or access denied
+        500 if abort operation fails
+    """
+    # Validate RBAC for each lead
+    for lead_cancellation in request.leads:
+        lead = await get_lead_by_id(lead_cancellation.lead_id)
+        if lead:
+            # RBAC: Check access (returns 404 to avoid leaking existence)
+            validate_lead_read_access(current_user, lead, operation="delete")
+
+    # Delete (abort) the leads
+    return await delete_lead_handler(request.leads, current_user)

--- a/app/api/routers/breeze_buddy/leads/handlers.py
+++ b/app/api/routers/breeze_buddy/leads/handlers.py
@@ -16,7 +16,10 @@ from app.ai.voice.agents.breeze_buddy.services.telephony.exotel.recording import
 from app.ai.voice.agents.breeze_buddy.services.telephony.twilio.recording import (
     download_call_recording as download_call_recording_twilio,
 )
-from app.ai.voice.agents.breeze_buddy.types.models import PushLeadRequest
+from app.ai.voice.agents.breeze_buddy.types.models import (
+    LeadCancellation,
+    PushLeadRequest,
+)
 from app.ai.voice.agents.breeze_buddy.utils.common import (
     get_validation_error_message,
     validate_payload,
@@ -32,6 +35,7 @@ from app.database.accessor import (
     get_lead_by_id,
     get_outbound_number_by_id,
     get_template_by_merchant,
+    handle_lead_abort,
 )
 from app.schemas import ExecutionMode, LeadCallStatus, UserInfo
 
@@ -303,3 +307,108 @@ async def get_call_recording_handler(call_sid: str, current_user: UserInfo) -> B
 
     audio_file.seek(0)
     return audio_file
+
+
+async def delete_lead_handler(
+    leads: list[LeadCancellation], current_user: UserInfo
+) -> Dict:
+    """
+    Delete (abort) multiple leads by IDs with individual cancellation reasons.
+
+    This handler:
+    1. Fetches each lead to validate it exists
+    2. Checks if lead is already aborted
+    3. Calls handle_lead_abort to set status to FINISHED and outcome to ABORT
+    4. Stores the cancellation reason in metadata if provided
+
+    Args:
+        leads: List of LeadCancellation objects containing lead_id and cancellation_reason pairs
+        current_user: Current authenticated user
+
+    Returns:
+        Success message with aborted lead details for all leads
+
+    Raises:
+        HTTPException: 404 if not found, 500 on abort failure
+    """
+    lead_ids = [lead.lead_id for lead in leads]
+    logger.info(
+        f"User {current_user.username} (role: {current_user.role}) requesting to delete leads: {lead_ids}"
+    )
+
+    results = []
+    errors = []
+
+    try:
+        for lead_cancellation in leads:
+            lead_id = lead_cancellation.lead_id
+            cancellation_reason = lead_cancellation.cancellation_reason
+
+            try:
+                # Get lead to validate existence (will be used for RBAC validation)
+                lead = await get_lead_by_id(lead_id)
+
+                if not lead:
+                    errors.append(
+                        {
+                            "lead_id": lead_id,
+                            "error": f"Lead not found for ID: {lead_id}",
+                        }
+                    )
+                    continue
+
+                # Check if lead is already aborted
+                if lead.status.value == "FINISHED" and lead.outcome == "ABORT":
+                    logger.info(f"Lead {lead_id} is already aborted")
+                    results.append(
+                        {
+                            "lead_id": lead_id,
+                            "status": "already_aborted",
+                            "outcome": lead.outcome,
+                            "cancellation_reason": cancellation_reason,
+                            "message": f"Lead {lead_id} is already aborted",
+                        }
+                    )
+                    continue
+
+                # Abort the lead using existing function with cancellation reason
+                aborted_lead = await handle_lead_abort(lead_id, cancellation_reason)
+
+                if not aborted_lead:
+                    logger.error(f"Failed to abort lead {lead_id}")
+                    errors.append(
+                        {"lead_id": lead_id, "error": f"Failed to abort lead {lead_id}"}
+                    )
+                    continue
+
+                logger.info(
+                    f"Lead {lead_id} successfully aborted by user {current_user.username}"
+                )
+
+                results.append(
+                    {
+                        "lead_id": lead_id,
+                        "status": "aborted",
+                        "outcome": aborted_lead.outcome,
+                        "cancellation_reason": cancellation_reason,
+                        "message": f"Lead {lead_id} has been aborted",
+                    }
+                )
+
+            except Exception as e:
+                logger.error(f"Error deleting lead {lead_id}: {e}", exc_info=True)
+                errors.append({"lead_id": lead_id, "error": str(e)})
+
+        return {
+            "status": "success" if results else "failed",
+            "message": f"Processed {len(leads)} lead(s)",
+            "results": results,
+            "errors": errors if errors else None,
+        }
+
+    except Exception as e:
+        logger.error(f"Error deleting leads: {e}", exc_info=True)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Unexpected error while deleting leads: {str(e)}",
+        )

--- a/app/database/accessor/__init__.py
+++ b/app/database/accessor/__init__.py
@@ -22,6 +22,7 @@ from .breeze_buddy.lead_call_tracker import (
     get_lead_call_trackers_count,
     get_leads_based_on_status_and_next_attempt,
     get_leads_by_status_and_time_before,
+    handle_lead_abort,
     release_lock_on_lead_by_id,
     update_lead_call_completion_details,
     update_lead_call_details,
@@ -77,4 +78,5 @@ __all__ = [
     "get_lead_based_analytics",
     "get_lead_call_trackers_count",
     "get_leads_by_status_and_time_before",
+    "handle_lead_abort",
 ]

--- a/app/database/accessor/breeze_buddy/lead_call_tracker.py
+++ b/app/database/accessor/breeze_buddy/lead_call_tracker.py
@@ -11,6 +11,7 @@ from app.core.logger import logger
 from app.database.decoder.breeze_buddy.lead_call_tracker import decode_lead_call_tracker
 from app.database.queries import run_parameterized_query
 from app.database.queries.breeze_buddy.lead_call_tracker import (
+    abort_lead_by_id_query,
     acquire_lock_on_lead_by_id_query,
     get_all_lead_call_trackers_query,
     get_lead_based_analytics_query,
@@ -486,4 +487,27 @@ async def update_langfuse_scores(
         return None
     except Exception as e:
         logger.error(f"Error updating langfuse_scores for call_id {call_id}: {e}")
+        return None
+
+
+async def handle_lead_abort(
+    lead_id: str, cancellation_reason: str
+) -> Optional[LeadCallTracker]:
+    """
+    Abort a lead by lead ID.
+    Sets status to FINISHED and outcome to ABORT.
+    """
+    try:
+        query_text, values = abort_lead_by_id_query(lead_id, cancellation_reason)
+        result = await run_parameterized_query(query_text, values)
+
+        if result and get_row_count(result) > 0:
+            decoded_result = decode_lead_call_tracker(result[0])
+            return decoded_result
+
+        logger.error("Failed to abort lead")
+        return None
+
+    except Exception as e:
+        logger.error(f"Error aborting lead {lead_id}: {e}")
         return None

--- a/app/database/queries/breeze_buddy/lead_call_tracker.py
+++ b/app/database/queries/breeze_buddy/lead_call_tracker.py
@@ -423,6 +423,7 @@ def get_lead_based_analytics_query(
             COUNT(*) FILTER (WHERE status = 'FINISHED') AS finished_calls,
             COUNT(*) FILTER (WHERE outcome = 'CONFIRM') AS confirmed_calls,
             COUNT(*) FILTER (WHERE outcome = 'CANCEL') AS cancelled_calls,
+            COUNT(*) FILTER (WHERE outcome = 'ABORT') AS aborted_calls,
             COUNT(*) FILTER (WHERE outcome = 'ADDRESS_UPDATED') AS address_update_calls,
             COUNT(*) FILTER (WHERE outcome = 'BUSY') AS busy_calls,
             COUNT(*) FILTER (WHERE outcome = 'NO_ANSWER') AS no_answer_calls
@@ -453,4 +454,45 @@ def update_langfuse_scores_query(
         RETURNING *;
     """
     values = [json.dumps(langfuse_scores), call_id]
+    return text, values
+
+
+def abort_lead_by_id_query(
+    lead_id: str, cancellation_reason: str
+) -> Tuple[str, List[Any]]:
+    """
+    Generate query to abort a lead by lead ID.
+    Sets status to FINISHED and outcome to ABORT.
+
+    Args:
+        lead_id: Lead UUID
+        cancellation_reason: Optional reason for cancellation
+    """
+    text = f"""
+        UPDATE "{LEAD_CALL_TRACKER_TABLE}"
+        SET 
+            "status" = $1, 
+            "outcome" = $2, 
+            "updated_at" = NOW(),
+            "meta_data" = COALESCE("meta_data", '{{}}')::jsonb || $3::jsonb
+        WHERE 
+            "id" = $4
+            AND "status" IN ($5, $6)
+            AND ("outcome" IS NULL OR "outcome" = '')
+        RETURNING *;
+    """
+
+    metadata = {
+        "aborted_at": datetime.now().isoformat(),
+        "outcome": {"abort_reason": cancellation_reason},
+    }
+
+    values = [
+        LeadCallStatus.FINISHED.value,
+        "ABORT",  # Outcome string literal
+        json.dumps(metadata),
+        lead_id,
+        LeadCallStatus.BACKLOG.value,
+        LeadCallStatus.RETRY.value,
+    ]
     return text, values


### PR DESCRIPTION
 - We implemented new endpoint /call/abort which updates the status to FINISHED and outcome to ABORT whenever gets triggered
 - It requires lead_id in request

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ability to abort or cancel leads via a new REST API endpoint.
  * Leads can now be marked as finished with an abort outcome when cancelled.
  * Aborted leads are tracked and included in analytics dashboards for reporting purposes.
  * Endpoint enforces proper authorization controls and includes comprehensive error handling for all operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->