### PR TITLE
integration of elevenLabs stt provider

### DIFF
--- a/app/agents/voice/automatic/stt/__init__.py
+++ b/app/agents/voice/automatic/stt/__init__.py
@@ -226,16 +226,16 @@ def get_stt_service(voice_name: Optional[str] = None):
             vad_force_turn_endpoint=config.SONIOX_VAD_FORCE_TURN_ENDPOINT,
         )
     elif config.STT_PROVIDER == "elevenlabs":
-        if not config.ELEVENLABS_API_KEY:
+        if not config.ELEVENLABS_STT_API_KEY:
             raise ValueError(
-                "ELEVENLABS_API_KEY is required when STT_PROVIDER=elevenlabs"
+                "ELEVENLABS_STT_API_KEY is required when STT_PROVIDER=elevenlabs"
             )
 
         logger.info(
             f"Using ElevenLabs Realtime STT service with model: {config.ELEVENLABS_STT_MODEL}"
         )
         return ElevenLabsRealtimeSTTService(
-            api_key=config.ELEVENLABS_API_KEY,
+            api_key=config.ELEVENLABS_STT_API_KEY,
             model=config.ELEVENLABS_STT_MODEL,
             params=ElevenLabsRealtimeSTTService.InputParams(
                 language_code=config.ELEVENLABS_STT_LANGUAGE,

--- a/app/agents/voice/automatic/stt/__init__.py
+++ b/app/agents/voice/automatic/stt/__init__.py
@@ -4,6 +4,7 @@ from typing import Optional
 from deepgram import LiveOptions
 from pipecat.services.assemblyai.stt import AssemblyAISTTService
 from pipecat.services.deepgram.stt import DeepgramSTTService
+from pipecat.services.elevenlabs.stt import CommitStrategy, ElevenLabsRealtimeSTTService
 from pipecat.services.google.stt import GoogleSTTService
 from pipecat.services.openai.stt import OpenAISTTService
 from pipecat.services.soniox.stt import (
@@ -223,6 +224,29 @@ def get_stt_service(voice_name: Optional[str] = None):
             api_key=config.SONIOX_API_KEY,
             params=soniox_params,
             vad_force_turn_endpoint=config.SONIOX_VAD_FORCE_TURN_ENDPOINT,
+        )
+    elif config.STT_PROVIDER == "elevenlabs":
+        if not config.ELEVENLABS_API_KEY:
+            raise ValueError(
+                "ELEVENLABS_API_KEY is required when STT_PROVIDER=elevenlabs"
+            )
+
+        logger.info(
+            f"Using ElevenLabs Realtime STT service with model: {config.ELEVENLABS_STT_MODEL}"
+        )
+        return ElevenLabsRealtimeSTTService(
+            api_key=config.ELEVENLABS_API_KEY,
+            model=config.ELEVENLABS_STT_MODEL,
+            params=ElevenLabsRealtimeSTTService.InputParams(
+                language_code=config.ELEVENLABS_STT_LANGUAGE,
+                commit_strategy=(
+                    CommitStrategy.VAD
+                    if config.ELEVENLABS_STT_COMMIT_STRATEGY == "vad"
+                    else CommitStrategy.MANUAL
+                ),
+                vad_silence_threshold_secs=config.ELEVENLABS_STT_VAD_SILENCE_THRESHOLD,
+                vad_threshold=config.ELEVENLABS_STT_VAD_THRESHOLD,
+            ),
         )
     else:  # Default to Google STT
         logger.info("Using Google STT service with VAD-based turn detection")

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -176,18 +176,15 @@ ELEVENLABS_STT_MODEL = os.environ.get(
 ELEVENLABS_STT_LANGUAGE = os.environ.get(
     "ELEVENLABS_STT_LANGUAGE", "en"
 )  # Language code for transcription
-ELEVENLABS_STT_USE_REALTIME = (
-    os.environ.get("ELEVENLABS_STT_USE_REALTIME", "false").lower() == "true"
-)  # Use real-time WebSocket API (true) or file-based API (false)
 ELEVENLABS_STT_COMMIT_STRATEGY = os.environ.get(
     "ELEVENLABS_STT_COMMIT_STRATEGY", "manual"
-).lower()  # "manual" (Pipecat VAD) or "vad" (ElevenLabs VAD) - Only used with real-time API
+).lower()  # "manual" (Pipecat VAD) or "vad" (ElevenLabs VAD)
 ELEVENLABS_STT_VAD_SILENCE_THRESHOLD = float(
     os.environ.get("ELEVENLABS_STT_VAD_SILENCE_THRESHOLD", "1.0")
-)  # Seconds of silence before VAD commits (0.3-3.0) - Only used with real-time API
+)  # Seconds of silence before VAD commits (0.3-3.0)
 ELEVENLABS_STT_VAD_THRESHOLD = float(
     os.environ.get("ELEVENLABS_STT_VAD_THRESHOLD", "0.5")
-)  # VAD sensitivity (0.1-0.9, lower is more sensitive) - Only used with real-time API
+)  # VAD sensitivity (0.1-0.9, lower is more sensitive)
 
 # --- Deepgram STT Configuration ---
 DEEPGRAM_API_KEY = os.getenv(

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -155,7 +155,7 @@ GEMINI_SEARCH_RESULT_API_MODEL = os.environ.get(
 # --- STT Configuration ---
 STT_PROVIDER = os.environ.get(
     "STT_PROVIDER", "google"
-).lower()  # "google", "assemblyai", "openai", "deepgram", or "soniox"
+).lower()  # "google", "assemblyai", "openai", "deepgram", "soniox", or "elevenlabs"
 ASSEMBLYAI_API_KEY = os.getenv("ASSEMBLYAI_API_KEY")
 OPENAI_STT_API_KEY = os.getenv("OPENAI_STT_API_KEY")
 OPENAI_STT_MODEL = os.environ.get(
@@ -165,6 +165,29 @@ ENFORCED_OPENAI_STT_MODEL = os.environ.get("ENFORCED_OPENAI_STT_MODEL", "whisper
 ENABLE_OPENAI_FOR_MIA = (
     os.environ.get("ENABLE_OPENAI_FOR_MIA", "false").lower() == "true"
 )
+
+# --- ElevenLabs STT Configuration ---
+ELEVENLABS_STT_API_KEY = (
+    os.getenv("ELEVENLABS_STT_API_KEY") or ELEVENLABS_API_KEY
+)  # Use STT-specific key or fallback to main API key
+ELEVENLABS_STT_MODEL = os.environ.get(
+    "ELEVENLABS_STT_MODEL", "scribe_v2_realtime"
+)  # ElevenLabs STT model (scribe_v1, scribe_v2_realtime)
+ELEVENLABS_STT_LANGUAGE = os.environ.get(
+    "ELEVENLABS_STT_LANGUAGE", "en"
+)  # Language code for transcription
+ELEVENLABS_STT_USE_REALTIME = (
+    os.environ.get("ELEVENLABS_STT_USE_REALTIME", "false").lower() == "true"
+)  # Use real-time WebSocket API (true) or file-based API (false)
+ELEVENLABS_STT_COMMIT_STRATEGY = os.environ.get(
+    "ELEVENLABS_STT_COMMIT_STRATEGY", "manual"
+).lower()  # "manual" (Pipecat VAD) or "vad" (ElevenLabs VAD) - Only used with real-time API
+ELEVENLABS_STT_VAD_SILENCE_THRESHOLD = float(
+    os.environ.get("ELEVENLABS_STT_VAD_SILENCE_THRESHOLD", "1.0")
+)  # Seconds of silence before VAD commits (0.3-3.0) - Only used with real-time API
+ELEVENLABS_STT_VAD_THRESHOLD = float(
+    os.environ.get("ELEVENLABS_STT_VAD_THRESHOLD", "0.5")
+)  # VAD sensitivity (0.1-0.9, lower is more sensitive) - Only used with real-time API
 
 # --- Deepgram STT Configuration ---
 DEEPGRAM_API_KEY = os.getenv(

--- a/memory-bank/decisionLog.md
+++ b/memory-bank/decisionLog.md
@@ -6,6 +6,20 @@ This file records architectural and implementation decisions using a list format
 *
 
 ## Decision
+*   [2025-11-20 16:18:00] - Integrate ElevenLabs Realtime STT Service.
+
+## Rationale
+*   To provide an alternative to Google STT, offering potentially lower latency and different performance characteristics.
+*   The integration allows switching STT providers via environment configuration.
+
+## Implementation Details
+*   Modified `app/agents/voice/automatic/stt/__init__.py`:
+    *   Added `ElevenLabsRealtimeSTTService` to the `get_stt_service` function.
+    *   The service is selected when `config.STT_PROVIDER` is set to `"elevenlabs"`.
+    *   Configuration for the service, including API key, model, and other parameters, is drawn from `app.core.config`.
+*
+
+## Decision
 *   [2025-08-20 14:42:00] - Embed Dynamic Date Directly into SYSTEM_PROMPT F-String.
 
 ## Rationale

--- a/memory-bank/techContext.md
+++ b/memory-bank/techContext.md
@@ -12,6 +12,7 @@
 
 - **Daily:** The transport layer service used for handling real-time audio/video communication and managing rooms.
 - **Google STT (Speech-to-Text):** The service used to transcribe user audio into text.
+- **ElevenLabs STT (Speech-to-Text):** The service used to transcribe user audio into text.
 - **Azure OpenAI:** The LLM provider used for natural language understanding, conversational logic, and function calling.
 - **TTS Services:** The agent is designed to be flexible with Text-to-Speech providers, with specific implementations for services like Google TTS.
 


### PR DESCRIPTION
This pull request integrates the ElevenLabs Realtime STT service as a new speech-to-text provider.

Key changes include:

- **STT Provider Integration**: Added `ElevenLabsRealtimeSTTService` to the `get_stt_service` function in `app/agents/voice/automatic/stt/__init__.py`. The service is now available as an STT provider and can be enabled by setting the `STT_PROVIDER` environment variable to `"elevenlabs"`.

- **Configuration**: Introduced new environment variables in `app/core/config.py` to manage ElevenLabs STT settings, including API key, model, language, and VAD parameters.

- **Memory Bank Update**: Updated `memory-bank/techContext.md` and `memory-bank/decisionLog.md` to reflect the integration of the new service.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ElevenLabs as a new Speech-to-Text (STT) provider option, enabling users to switch between multiple STT providers via environment configuration.
  * Introduced new configuration parameters to customize ElevenLabs STT, including API key, model selection, language preference, and voice activity detection settings.

* **Documentation**
  * Updated service documentation to reflect ElevenLabs STT as an available provider.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->