### PR TITLE
Set ElevenLabs STT for the Rhea Voice Assistant

### DIFF
--- a/app/agents/voice/automatic/stt/__init__.py
+++ b/app/agents/voice/automatic/stt/__init__.py
@@ -226,16 +226,16 @@ def get_stt_service(voice_name: Optional[str] = None):
             vad_force_turn_endpoint=config.SONIOX_VAD_FORCE_TURN_ENDPOINT,
         )
     elif config.STT_PROVIDER == "elevenlabs":
-        if not config.ELEVENLABS_API_KEY:
+        if not config.ELEVENLABS_STT_API_KEY:
             raise ValueError(
-                "ELEVENLABS_API_KEY is required when STT_PROVIDER=elevenlabs"
+                "ELEVENLABS_STT_API_KEY is required when STT_PROVIDER=elevenlabs"
             )
 
         logger.info(
             f"Using ElevenLabs Realtime STT service with model: {config.ELEVENLABS_STT_MODEL}"
         )
         return ElevenLabsRealtimeSTTService(
-            api_key=config.ELEVENLABS_API_KEY,
+            api_key=config.ELEVENLABS_STT_API_KEY,
             model=config.ELEVENLABS_STT_MODEL,
             params=ElevenLabsRealtimeSTTService.InputParams(
                 language_code=config.ELEVENLABS_STT_LANGUAGE,

--- a/app/agents/voice/automatic/stt/__init__.py
+++ b/app/agents/voice/automatic/stt/__init__.py
@@ -98,6 +98,11 @@ def get_stt_service(voice_name: Optional[str] = None):
     Args:
         voice_name: Voice name to determine STT provider override for specific voices
     """
+    # Determine the effective STT provider
+    effective_stt_provider = config.STT_PROVIDER
+    if voice_name == VoiceName.RHEA.value:
+        effective_stt_provider = config.RHEA_STT_PROVIDER
+
     # Check for MIA voice with OpenAI override
     if voice_name == VoiceName.MIA.value and config.ENABLE_OPENAI_FOR_MIA:
         if not config.OPENAI_STT_API_KEY:
@@ -118,7 +123,7 @@ def get_stt_service(voice_name: Optional[str] = None):
         )
 
     # Default behavior - use configured STT provider
-    if config.STT_PROVIDER == "assemblyai":
+    if effective_stt_provider == "assemblyai":
         if not config.ASSEMBLYAI_API_KEY:
             raise ValueError(
                 "ASSEMBLYAI_API_KEY is required when STT_PROVIDER=assemblyai"
@@ -131,7 +136,7 @@ def get_stt_service(voice_name: Optional[str] = None):
             vad_force_turn_endpoint=True,
             # No connection_params needed since we're using VAD for turn detection
         )
-    elif config.STT_PROVIDER == "openai":
+    elif effective_stt_provider == "openai":
         if not config.OPENAI_STT_API_KEY:
             raise ValueError(
                 "OPENAI_STT_API_KEY or OPENAI_API_KEY is required when STT_PROVIDER=openai"
@@ -148,7 +153,7 @@ def get_stt_service(voice_name: Optional[str] = None):
             prompt=config.AUTOMATIC_OPENAI_STT_PROMPT,
             temperature=0.0,  # Deterministic output for consistency
         )
-    elif config.STT_PROVIDER == "deepgram":
+    elif effective_stt_provider == "deepgram":
         if not config.DEEPGRAM_API_KEY:
             raise ValueError("DEEPGRAM_API_KEY is required when STT_PROVIDER=deepgram")
 
@@ -185,7 +190,7 @@ def get_stt_service(voice_name: Optional[str] = None):
         return DeepgramSTTService(
             api_key=config.DEEPGRAM_API_KEY, live_options=live_options
         )
-    elif config.STT_PROVIDER == "soniox":
+    elif effective_stt_provider == "soniox":
         if not config.SONIOX_API_KEY:
             raise ValueError("SONIOX_API_KEY is required when STT_PROVIDER=soniox")
 
@@ -225,7 +230,7 @@ def get_stt_service(voice_name: Optional[str] = None):
             params=soniox_params,
             vad_force_turn_endpoint=config.SONIOX_VAD_FORCE_TURN_ENDPOINT,
         )
-    elif config.STT_PROVIDER == "elevenlabs":
+    elif effective_stt_provider == "elevenlabs":
         if not config.ELEVENLABS_STT_API_KEY:
             raise ValueError(
                 "ELEVENLABS_STT_API_KEY is required when STT_PROVIDER=elevenlabs"

--- a/app/agents/voice/automatic/stt/__init__.py
+++ b/app/agents/voice/automatic/stt/__init__.py
@@ -4,6 +4,7 @@ from typing import Optional
 from deepgram import LiveOptions
 from pipecat.services.assemblyai.stt import AssemblyAISTTService
 from pipecat.services.deepgram.stt import DeepgramSTTService
+from pipecat.services.elevenlabs.stt import CommitStrategy, ElevenLabsRealtimeSTTService
 from pipecat.services.google.stt import GoogleSTTService
 from pipecat.services.openai.stt import OpenAISTTService
 from pipecat.services.soniox.stt import (
@@ -223,6 +224,29 @@ def get_stt_service(voice_name: Optional[str] = None):
             api_key=config.SONIOX_API_KEY,
             params=soniox_params,
             vad_force_turn_endpoint=config.SONIOX_VAD_FORCE_TURN_ENDPOINT,
+        )
+    elif config.STT_PROVIDER == "elevenlabs":
+        if not config.ELEVENLABS_API_KEY:
+            raise ValueError(
+                "ELEVENLABS_API_KEY is required when STT_PROVIDER=elevenlabs"
+            )
+
+        logger.info(
+            f"Using ElevenLabs Realtime STT service with model: {config.ELEVENLABS_STT_MODEL}"
+        )
+        return ElevenLabsRealtimeSTTService(
+            api_key=config.ELEVENLABS_API_KEY,
+            model=config.ELEVENLABS_STT_MODEL,
+            params=ElevenLabsRealtimeSTTService.InputParams(
+                language_code=config.ELEVENLABS_STT_LANGUAGE,
+                commit_strategy=(
+                    CommitStrategy.VAD
+                    if config.ELEVENLABS_STT_COMMIT_STRATEGY == "vad"
+                    else CommitStrategy.MANUAL
+                ),
+                vad_silence_threshold_secs=config.ELEVENLABS_STT_VAD_SILENCE_THRESHOLD,
+                vad_threshold=config.ELEVENLABS_STT_VAD_THRESHOLD,
+            ),
         )
     else:  # Default to Google STT
         logger.info("Using Google STT service with VAD-based turn detection")

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -81,6 +81,7 @@ ELEVENLABS_TTS_SPEED = float(os.environ.get("ELEVENLABS_TTS_SPEED", "1.10"))
 ELEVENLABS_BB_VOICE_ID = os.environ.get(
     "ELEVENLABS_BB_VOICE_ID", "fG9s0SXJb213f4UxVHyG"
 )
+RHEA_STT_PROVIDER = os.environ.get("RHEA_STT_PROVIDER", "google").lower()
 GOOGLE_BRET_VOICE = os.environ.get("GOOGLE_BRET_VOICE", "en-IN-Chirp3-HD-Sadaltager")
 GOOGLE_MIA_VOICE = os.environ.get("GOOGLE_MIA_VOICE", "en-IN-Chirp3-HD-Despina")
 
@@ -180,10 +181,10 @@ ELEVENLABS_STT_COMMIT_STRATEGY = os.environ.get(
     "ELEVENLABS_STT_COMMIT_STRATEGY", "manual"
 ).lower()  # "manual" (Pipecat VAD) or "vad" (ElevenLabs VAD)
 ELEVENLABS_STT_VAD_SILENCE_THRESHOLD = float(
-    os.environ.get("ELEVENLABS_STT_VAD_SILENCE_THRESHOLD", "1.0")
+    os.environ.get("ELEVENLABS_STT_VAD_SILENCE_THRESHOLD", "1.5")
 )  # Seconds of silence before VAD commits (0.3-3.0)
 ELEVENLABS_STT_VAD_THRESHOLD = float(
-    os.environ.get("ELEVENLABS_STT_VAD_THRESHOLD", "0.5")
+    os.environ.get("ELEVENLABS_STT_VAD_THRESHOLD", "0.4")
 )  # VAD sensitivity (0.1-0.9, lower is more sensitive)
 
 # --- Deepgram STT Configuration ---

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -176,18 +176,15 @@ ELEVENLABS_STT_MODEL = os.environ.get(
 ELEVENLABS_STT_LANGUAGE = os.environ.get(
     "ELEVENLABS_STT_LANGUAGE", "en"
 )  # Language code for transcription
-ELEVENLABS_STT_USE_REALTIME = (
-    os.environ.get("ELEVENLABS_STT_USE_REALTIME", "false").lower() == "true"
-)  # Use real-time WebSocket API (true) or file-based API (false)
 ELEVENLABS_STT_COMMIT_STRATEGY = os.environ.get(
     "ELEVENLABS_STT_COMMIT_STRATEGY", "manual"
-).lower()  # "manual" (Pipecat VAD) or "vad" (ElevenLabs VAD) - Only used with real-time API
+).lower()  # "manual" (Pipecat VAD) or "vad" (ElevenLabs VAD)
 ELEVENLABS_STT_VAD_SILENCE_THRESHOLD = float(
     os.environ.get("ELEVENLABS_STT_VAD_SILENCE_THRESHOLD", "1.0")
-)  # Seconds of silence before VAD commits (0.3-3.0) - Only used with real-time API
+)  # Seconds of silence before VAD commits (0.3-3.0)
 ELEVENLABS_STT_VAD_THRESHOLD = float(
     os.environ.get("ELEVENLABS_STT_VAD_THRESHOLD", "0.5")
-)  # VAD sensitivity (0.1-0.9, lower is more sensitive) - Only used with real-time API
+)  # VAD sensitivity (0.1-0.9, lower is more sensitive)
 
 # --- Deepgram STT Configuration ---
 DEEPGRAM_API_KEY = os.getenv(

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -155,7 +155,7 @@ GEMINI_SEARCH_RESULT_API_MODEL = os.environ.get(
 # --- STT Configuration ---
 STT_PROVIDER = os.environ.get(
     "STT_PROVIDER", "google"
-).lower()  # "google", "assemblyai", "openai", "deepgram", or "soniox"
+).lower()  # "google", "assemblyai", "openai", "deepgram", "soniox", or "elevenlabs"
 ASSEMBLYAI_API_KEY = os.getenv("ASSEMBLYAI_API_KEY")
 OPENAI_STT_API_KEY = os.getenv("OPENAI_STT_API_KEY")
 OPENAI_STT_MODEL = os.environ.get(
@@ -165,6 +165,29 @@ ENFORCED_OPENAI_STT_MODEL = os.environ.get("ENFORCED_OPENAI_STT_MODEL", "whisper
 ENABLE_OPENAI_FOR_MIA = (
     os.environ.get("ENABLE_OPENAI_FOR_MIA", "false").lower() == "true"
 )
+
+# --- ElevenLabs STT Configuration ---
+ELEVENLABS_STT_API_KEY = (
+    os.getenv("ELEVENLABS_STT_API_KEY") or ELEVENLABS_API_KEY
+)  # Use STT-specific key or fallback to main API key
+ELEVENLABS_STT_MODEL = os.environ.get(
+    "ELEVENLABS_STT_MODEL", "scribe_v2_realtime"
+)  # ElevenLabs STT model (scribe_v1, scribe_v2_realtime)
+ELEVENLABS_STT_LANGUAGE = os.environ.get(
+    "ELEVENLABS_STT_LANGUAGE", "en"
+)  # Language code for transcription
+ELEVENLABS_STT_USE_REALTIME = (
+    os.environ.get("ELEVENLABS_STT_USE_REALTIME", "false").lower() == "true"
+)  # Use real-time WebSocket API (true) or file-based API (false)
+ELEVENLABS_STT_COMMIT_STRATEGY = os.environ.get(
+    "ELEVENLABS_STT_COMMIT_STRATEGY", "manual"
+).lower()  # "manual" (Pipecat VAD) or "vad" (ElevenLabs VAD) - Only used with real-time API
+ELEVENLABS_STT_VAD_SILENCE_THRESHOLD = float(
+    os.environ.get("ELEVENLABS_STT_VAD_SILENCE_THRESHOLD", "1.0")
+)  # Seconds of silence before VAD commits (0.3-3.0) - Only used with real-time API
+ELEVENLABS_STT_VAD_THRESHOLD = float(
+    os.environ.get("ELEVENLABS_STT_VAD_THRESHOLD", "0.5")
+)  # VAD sensitivity (0.1-0.9, lower is more sensitive) - Only used with real-time API
 
 # --- Deepgram STT Configuration ---
 DEEPGRAM_API_KEY = os.getenv(

--- a/memory-bank/decisionLog.md
+++ b/memory-bank/decisionLog.md
@@ -6,6 +6,20 @@ This file records architectural and implementation decisions using a list format
 *
 
 ## Decision
+*   [2025-11-20 16:18:00] - Integrate ElevenLabs Realtime STT Service.
+
+## Rationale
+*   To provide an alternative to Google STT, offering potentially lower latency and different performance characteristics.
+*   The integration allows switching STT providers via environment configuration.
+
+## Implementation Details
+*   Modified `app/agents/voice/automatic/stt/__init__.py`:
+    *   Added `ElevenLabsRealtimeSTTService` to the `get_stt_service` function.
+    *   The service is selected when `config.STT_PROVIDER` is set to `"elevenlabs"`.
+    *   Configuration for the service, including API key, model, and other parameters, is drawn from `app.core.config`.
+*
+
+## Decision
 *   [2025-08-20 14:42:00] - Embed Dynamic Date Directly into SYSTEM_PROMPT F-String.
 
 ## Rationale

--- a/memory-bank/decisionLog.md
+++ b/memory-bank/decisionLog.md
@@ -6,6 +6,21 @@ This file records architectural and implementation decisions using a list format
 *
 
 ## Decision
+*   [2025-11-24 12:04:00] - Implement voice-specific STT provider configuration.
+
+## Rationale
+*   To allow assigning a specific STT provider to a particular voice ("Rhea") while other voices use a global default. This provides greater flexibility in managing STT services for different voice personas.
+
+## Implementation Details
+*   Added `RHEA_STT_PROVIDER` to `app/core/config.py` to define a dedicated STT provider for the Rhea voice.
+*   Modified `app/agents/voice/automatic/stt/__init__.py`:
+    *   The `get_stt_service` function now checks for the `RHEA_STT_PROVIDER` setting when the voice is "Rhea".
+    *   If the setting is present, it initializes the specified STT service for Rhea.
+    *   Otherwise, it falls back to the global `STT_PROVIDER` setting.
+    *   The `.env` file was updated to set `RHEA_STT_PROVIDER` to `"elevenlabs"` and the default `STT_PROVIDER` to `"google"`.
+*
+
+## Decision
 *   [2025-11-20 16:18:00] - Integrate ElevenLabs Realtime STT Service.
 
 ## Rationale

--- a/memory-bank/techContext.md
+++ b/memory-bank/techContext.md
@@ -12,6 +12,7 @@
 
 - **Daily:** The transport layer service used for handling real-time audio/video communication and managing rooms.
 - **Google STT (Speech-to-Text):** The service used to transcribe user audio into text.
+- **ElevenLabs STT (Speech-to-Text):** The service used to transcribe user audio into text.
 - **Azure OpenAI:** The LLM provider used for natural language understanding, conversational logic, and function calling.
 - **TTS Services:** The agent is designed to be flexible with Text-to-Speech providers, with specific implementations for services like Google TTS.
 


### PR DESCRIPTION
This pull request introduces a voice-specific STT (Speech-to-Text) provider configuration, allowing the "Rhea" voice to use ElevenLabs while all other voices default to Google.

### Key Changes:

*   **Voice-Specific STT Provider**:
    *   Added a `RHEA_STT_PROVIDER` environment variable in `app/core/config.py` to allow a dedicated STT service for the Rhea voice.
    *   Updated the `get_stt_service` function in `app/agents/voice/automatic/stt/__init__.py` to check for the `RHEA_STT_PROVIDER` setting and initialize the appropriate STT service.
    *   Set the default `STT_PROVIDER` to `"google"` and `RHEA_STT_PROVIDER` to `"elevenlabs"` in the `.env` file.

*   **Bug Fix**:
    *   Corrected an issue where the `get_stt_service` function was referencing the wrong API key for ElevenLabs, which bypassed the intended STT-specific configuration.

*   **Configuration Cleanup**:
    *   Removed the unused `ELEVENLABS_STT_USE_REALTIME` environment variable and its related comments from `app/core/config.py` to align the configuration with the implementation.

*   **Memory Bank Update**:
    *   Updated `memory-bank/decisionLog.md` to document the new voice-specific STT provider configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ElevenLabs Realtime STT as a speech-to-text provider option with customizable configuration for transcription quality and language
  * Introduced voice-specific STT provider configuration, enabling different transcription services for individual voices while maintaining system-wide defaults

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->