### PR TITLE
(feat): send-alerts-to-slack-for-evaluations-with-low-score

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -190,3 +190,15 @@ REDIS_PORT=6379
 
 # Optional: For Redis cluster setup
 REDIS_CLUSTER_NODES=redis1:6379,redis2:6380,redis3:6381
+
+LANGFUSE_EVALUATORS="breeze buddy outcome correctness, latency evaluator" # name of the evaluator
+SLACK_WEBHOOK_URL="" # slack webhook url to send alerts
+SLACK_TAG_USERS="@john.doe,@jane.smith,@dev.team" # comma-separated list of users to tag in Slack alerts
+
+# Background Tasks Configuration
+ENABLE_BACKGROUND_TASKS=true  # Enable/disable the entire background task scheduler (default: true)
+BACKGROUND_TASKS_LOOP_INTERVAL_SECONDS=60  # How often the scheduler checks for tasks to run (in seconds, default: 60)
+
+# Langfuse Score Monitoring Configuration
+ENABLE_BB_LANGFUSE_MONITORING_LOOP=false  # Enable/disable Langfuse score monitoring task only (default: false)
+SCORE_CHECK_INTERVAL_SECONDS=600  # Check interval for Langfuse scores (10 minutes)

--- a/app/core/background_tasks/__init__.py
+++ b/app/core/background_tasks/__init__.py
@@ -1,0 +1,15 @@
+"""
+Background task scheduler with distributed locking support.
+
+This module provides a generic framework for running background tasks
+across multiple pods with Redis-based distributed locking to ensure
+only one pod executes each task at a time.
+"""
+
+from app.core.background_tasks.task import BackgroundTask
+from app.core.background_tasks.scheduler import BackgroundTaskScheduler
+
+__all__ = [
+    "BackgroundTaskScheduler",
+    "BackgroundTask",
+]

--- a/app/core/background_tasks/scheduler.py
+++ b/app/core/background_tasks/scheduler.py
@@ -1,0 +1,210 @@
+"""
+Generic background task scheduler with distributed locking.
+
+Provides a reusable scheduler that runs background tasks periodically
+with Redis-based distributed locking to ensure only one pod executes
+each task at a time.
+"""
+
+import asyncio
+import time
+import uuid
+from typing import Callable, Dict, Optional
+
+from app.core.background_tasks.task import BackgroundTask
+from app.core.logger import logger
+from app.services.redis import get_redis_service, is_redis_configured
+
+
+class BackgroundTaskScheduler:
+    """
+    Scheduler for running background tasks with distributed locking.
+
+    The scheduler runs a loop every minute in all pods, but uses distributed
+    locking to ensure only one pod executes each task. Tasks can have different
+    execution intervals (e.g., every 1 minute, every 5 minutes, etc.).
+
+    Example:
+        ```python
+        scheduler = BackgroundTaskScheduler()
+
+        # Register tasks
+        scheduler.register_task(
+            name="langfuse_score_monitor",
+            func=score_monitor.check_and_alert,
+            interval_seconds=600,  # Every 10 minutes
+            lock_key="langfuse:score_monitor:lock"
+        )
+
+        scheduler.register_task(
+            name="cleanup_old_sessions",
+            func=cleanup_sessions,
+            interval_seconds=300,  # Every 5 minutes
+            lock_key="background:cleanup_sessions:lock"
+        )
+
+        # Start scheduler
+        asyncio.create_task(scheduler.start())
+        ```
+    """
+
+    def __init__(self, loop_interval_seconds: int = 60):
+        """
+        Initialize the background task scheduler.
+
+        Args:
+            loop_interval_seconds: How often the main loop runs (default: 60 seconds)
+        """
+        self.loop_interval_seconds = loop_interval_seconds
+        self.tasks: Dict[str, BackgroundTask] = {}
+        self._running = False
+        self._task: Optional[asyncio.Task] = None
+
+    def register_task(
+        self,
+        name: str,
+        func: Callable,
+        interval_seconds: int,
+    ) -> str:
+        """
+        Register a new background task.
+
+        Args:
+            name: Human-readable name for the task (for logging/debugging)
+                 This will be used to generate the Redis lock key
+            func: Async function to execute
+            interval_seconds: How often to run the task
+
+        Returns:
+            Unique task ID (UUID) for the registered task
+        """
+        # Validate that task name is unique
+        for existing_task in self.tasks.values():
+            if existing_task.name == name:
+                raise ValueError(
+                    f"Task with name '{name}' already registered. "
+                    f"Each task must have a unique name to prevent conflicts in multi-pod scenarios."
+                )
+
+        # Generate unique ID for the task
+        task_id = str(uuid.uuid4())
+
+        task = BackgroundTask(
+            name=name,
+            func=func,
+            interval_seconds=interval_seconds,
+        )
+
+        self.tasks[task_id] = task
+        
+        # Generate lock key from task name for logging
+        lock_key = f"background:task:{name.lower().replace(' ', '_')}:lock"
+        logger.info(
+            f"Registered background task '{name}' with ID {task_id} "
+            f"(interval: {interval_seconds}s, lock_key: {lock_key})"
+        )
+
+        return task_id
+
+    async def _execute_task(self, task: BackgroundTask) -> None:
+        """
+        Execute a single task with distributed locking.
+
+        The Redis lock's TTL determines when the task is due to run again.
+        All pods attempt to acquire the lock, but only one succeeds.
+
+        Args:
+            task: The task to execute
+        """
+        # Generate lock key from task name
+        lock_key = f"background:task:{task.name.lower().replace(' ', '_')}:lock"
+        
+        # Try to acquire distributed lock using Redis SET NX EX
+        try:
+            redis_service = await get_redis_service()
+            lock_acquired = await redis_service.set(
+                key=lock_key,
+                value="locked",
+                nx=True,
+                ex=task.interval_seconds,
+            )
+        except Exception as e:
+            logger.error(
+                f"Redis error for task '{task.name}': {e}. Skipping task."
+            )
+            return
+
+        if not lock_acquired:
+            logger.debug(f"Task '{task.name}' lock already held, skipping...")
+            return
+
+        logger.info(f"Acquired lock for task '{task.name}', executing...")
+
+        # Execute the task
+        try:
+            await task.func()
+            logger.info(f"Task '{task.name}' completed successfully")
+        except Exception as e:
+            logger.error(f"Error executing task '{task.name}': {e}", exc_info=True)
+
+    async def _run_loop(self) -> None:
+        """Main scheduler loop that runs every minute."""
+        logger.info(
+            f"Background task scheduler started "
+            f"(loop interval: {self.loop_interval_seconds}s, "
+            f"registered tasks: {len(self.tasks)})"
+        )
+
+        while self._running:
+            try:
+                # Execute all tasks
+                for task in self.tasks.values():
+                    try:
+                        await self._execute_task(task)
+                    except Exception as e:
+                        logger.error(
+                            f"Error in task '{task.name}': {e}",
+                            exc_info=True,
+                        )
+
+                # Wait for next loop iteration
+                await asyncio.sleep(self.loop_interval_seconds)
+
+            except asyncio.CancelledError:
+                logger.info("Background task scheduler cancelled, shutting down...")
+                break
+            except Exception as e:
+                logger.error(f"Error in scheduler loop: {e}", exc_info=True)
+                # Wait before retrying on error
+                await asyncio.sleep(60)
+
+        logger.info("Background task scheduler stopped")
+
+    async def start(self) -> None:
+        """Start the background task scheduler."""
+        if self._running:
+            logger.warning("Background task scheduler is already running")
+            return
+
+        if not self.tasks:
+            logger.warning("No tasks registered, scheduler will not start")
+            return
+
+        self._running = True
+        self._task = asyncio.create_task(self._run_loop())
+        logger.info("Background task scheduler starting...")
+
+    async def stop(self) -> None:
+        """Stop the background task scheduler."""
+        if not self._running:
+            return
+
+        logger.info("Stopping background task scheduler...")
+        self._running = False
+
+        if self._task and not self._task.done():
+            self._task.cancel()
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                logger.info("Background task scheduler stopped successfully")

--- a/app/core/background_tasks/task.py
+++ b/app/core/background_tasks/task.py
@@ -1,0 +1,40 @@
+"""
+Data models for background task scheduler.
+"""
+
+import inspect
+from dataclasses import dataclass
+from typing import Callable
+
+
+@dataclass
+class BackgroundTask:
+    """
+    Represents a background task that runs periodically with distributed locking.
+
+    The Redis lock key is automatically generated from the task name.
+
+    Attributes:
+        name: Unique identifier for the task (e.g., "langfuse_score_monitor")
+              Used to generate Redis lock key: background:task:{name}:lock
+        func: Async function to execute
+        interval_seconds: How often to run the task (e.g., 60 for every minute)
+    """
+
+    name: str
+    func: Callable
+    interval_seconds: int
+
+    def __post_init__(self):
+        """Validate task configuration."""
+        if not self.name:
+            raise ValueError("Task name cannot be empty")
+        if not callable(self.func):
+            raise ValueError(f"Task '{self.name}' func must be callable")
+        if not inspect.iscoroutinefunction(self.func):
+            raise ValueError(
+                f"Task '{self.name}' func must be an async function (coroutine). "
+                f"Use 'async def' to define the function."
+            )
+        if self.interval_seconds <= 0:
+            raise ValueError(f"Task '{self.name}' interval_seconds must be positive")

--- a/app/core/config/static.py
+++ b/app/core/config/static.py
@@ -481,3 +481,30 @@ REDIS_TTL = int(os.getenv("REDIS_TTL", "3600"))  # Default TTL in seconds (1 hou
 # DevCycle Configuration
 DEVCYCLE_WEBHOOK_SECRET = os.getenv("DEVCYCLE_WEBHOOK_SECRET", "")
 DEVCYCLE_SERVER_KEY = os.getenv("DEVCYCLE_SERVER_KEY", "")
+
+# Langfuse Score Monitoring Configuration
+LANGFUSE_EVALUATORS = [
+    name.strip()
+    for name in os.environ.get("LANGFUSE_EVALUATORS", "").split(",")
+    if name.strip()
+]
+
+# Slack Webhook Configuration
+SLACK_WEBHOOK_URL = os.environ.get("SLACK_WEBHOOK_URL", "")
+SLACK_TAG_USERS = os.environ.get("SLACK_TAG_USERS", "narsimha.reddy")
+
+# Background Tasks Configuration
+ENABLE_BACKGROUND_TASKS = (
+    os.environ.get("ENABLE_BACKGROUND_TASKS", "false").lower() == "true"
+)
+BACKGROUND_TASKS_LOOP_INTERVAL_SECONDS = int(
+    os.environ.get("BACKGROUND_TASKS_LOOP_INTERVAL_SECONDS", "60")
+)  # How often the scheduler checks tasks (in seconds)
+
+# Langfuse Score Monitoring Configuration
+ENABLE_BB_LANGFUSE_MONITORING_LOOP = (
+    os.environ.get("ENABLE_BB_LANGFUSE_MONITORING_LOOP", "false").lower() == "true"
+)
+SCORE_CHECK_INTERVAL_SECONDS = int(
+    os.environ.get("SCORE_CHECK_INTERVAL_SECONDS", "600")
+)  # 10 minutes

--- a/app/main.py
+++ b/app/main.py
@@ -17,13 +17,18 @@ from pipecat.transports.daily.utils import DailyRESTHelper
 
 from app import __version__
 from app.api.routers import automatic, breeze_buddy, devcycle
+
+# Import background task scheduler
+from app.core.background_tasks import BackgroundTaskScheduler
 from app.core.config.static import (
+    BACKGROUND_TASKS_LOOP_INTERVAL_SECONDS,
     BOT_MAX_DRAIN_SECONDS,
     DAILY_API_KEY,
     DAILY_API_URL,
     DAILY_ROOM_MAX_POOL_SIZE,
     DAILY_ROOM_POOL_SIZE,
     ENABLE_AUTOMATIC_DAILY_RECORDING,
+    ENABLE_BACKGROUND_TASKS,
     ENABLE_SIGTERM_HANDLER,
     HOST,
     MAX_DAILY_SESSION_LIMIT,
@@ -58,6 +63,7 @@ from app.helpers.automatic.session_manager import (
 from app.schemas import (
     AutomaticVoiceUserConnectRequest,
 )
+from app.services.langfuse.tasks.task import initialize_langfuse_tasks
 from app.services.redis import (
     close_redis_connections,
     get_redis_service,
@@ -69,6 +75,9 @@ daily_helpers = {}
 
 # Flag to indicate if pod is draining (no new connections accepted)
 _is_draining = False
+
+# Background task scheduler
+_background_scheduler = None
 
 
 async def room_cleanup_callback(session_id: str):
@@ -138,9 +147,41 @@ async def lifespan(_app: FastAPI):
     except Exception as e:
         logger.error(f"Failed to initialize voice agent pool: {e}")
 
+    # Start background task scheduler if enabled
+    global _background_scheduler
+    if ENABLE_BACKGROUND_TASKS:
+        try:
+            # Create scheduler instance with configurable loop interval
+            _background_scheduler = BackgroundTaskScheduler(
+                loop_interval_seconds=BACKGROUND_TASKS_LOOP_INTERVAL_SECONDS
+            )
+
+            # Initialize Langfuse tasks (if configured)
+            await initialize_langfuse_tasks(_background_scheduler)
+
+            ### Register new tasks here
+
+            # Start the scheduler only if tasks are registered
+            if _background_scheduler.tasks:
+                await _background_scheduler.start()
+                logger.info("Background task scheduler started")
+            else:
+                logger.info("No background tasks registered, scheduler not started")
+        except Exception as e:
+            logger.error(f"Failed to start background task scheduler: {e}")
+    else:
+        logger.info(
+            "Background task scheduler disabled (ENABLE_BACKGROUND_TASKS=false)"
+        )
+
     yield
 
     logger.info("Application shutdown event triggered...")
+
+    # Stop background task scheduler if running
+    if _background_scheduler:
+        logger.info("Stopping background task scheduler...")
+        await _background_scheduler.stop()
 
     # Graceful drain period - wait for active sessions to complete if enabled
     if ENABLE_SIGTERM_HANDLER and _is_draining:

--- a/app/services/langfuse/client.py
+++ b/app/services/langfuse/client.py
@@ -1,0 +1,84 @@
+"""
+LangFuse service initialization.
+Handles LangFuse client setup and configuration.
+"""
+
+from datetime import datetime
+from typing import Any, Dict, Optional
+
+import aiohttp
+from langfuse import Langfuse
+
+from app.core.config.static import (
+    LANGFUSE_BASEURL,
+    LANGFUSE_PUBLIC_KEY,
+    LANGFUSE_SECRET_KEY,
+)
+from app.core.logger import logger
+
+
+
+
+class LangFuseReadOnlyClient:
+    """
+    Read-only LangFuse client for score monitoring using REST API.
+
+    This client uses the Langfuse REST API directly to fetch scores and traces.
+    It does NOT use the SDK's tracing functionality, avoiding conflicts with
+    the existing OTEL→Periscope→Langfuse tracing pipeline.
+
+    SDK v3.8.1 is OpenTelemetry-based and doesn't have fetch_scores/fetch_trace
+    methods, so we use the REST API instead.
+    """
+
+    def __init__(self):
+        self.base_url: Optional[str] = None
+        self.auth: Optional[aiohttp.BasicAuth] = None
+        self.initialized = False
+        self._http_client: Optional[aiohttp.ClientSession] = None
+
+        self._initialize_client()
+
+    def _initialize_client(self) -> None:
+        """Initialize the read-only LangFuse client with error handling."""
+        try:
+            if not LANGFUSE_SECRET_KEY or not LANGFUSE_PUBLIC_KEY:
+                logger.warning(
+                    "Langfuse credentials not found. Score monitoring will not be available."
+                )
+                return
+
+            # Set up REST API access
+            self.base_url = LANGFUSE_BASEURL.rstrip("/")
+            # Use Basic Auth with public_key:secret_key
+            self.auth = aiohttp.BasicAuth(LANGFUSE_PUBLIC_KEY, LANGFUSE_SECRET_KEY)
+
+            # Create async HTTP client
+            timeout = aiohttp.ClientTimeout(total=30.0)
+            self._http_client = aiohttp.ClientSession(
+                base_url=self.base_url,
+                auth=self.auth,
+                timeout=timeout,
+            )
+
+            self.initialized = True
+            logger.info(
+                f"Langfuse read-only client initialized (base URL: {self.base_url})"
+            )
+
+        except Exception as e:
+            logger.error(
+                f"Failed to initialize Langfuse read-only client: {e}", exc_info=True
+            )
+            self.initialized = False
+
+
+    async def close(self):
+        """Close the async HTTP client."""
+        if self._http_client:
+            await self._http_client.close()
+            logger.debug("Async HTTP client closed")
+
+
+# Global client instances
+langfuse_readonly_client = LangFuseReadOnlyClient()

--- a/app/services/langfuse/tasks/score_monitor/score.py
+++ b/app/services/langfuse/tasks/score_monitor/score.py
@@ -1,0 +1,461 @@
+"""
+Langfuse Score Monitoring Service
+
+This module provides functionality to poll Langfuse for LLM-as-a-judge scores
+and identify failures (score = 0) for alerting purposes.
+"""
+
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, List, Optional
+
+import aiohttp
+
+from app.core.config.static import LANGFUSE_BASEURL, LANGFUSE_EVALUATORS
+from app.core.logger import logger
+from app.database.accessor.breeze_buddy.lead_call_tracker import get_lead_by_call_id
+from app.services.langfuse.client import langfuse_readonly_client
+from app.services.langfuse.trace import fetch_trace
+from app.services.redis import get_redis_service, is_redis_configured
+from app.services.slack.alert import slack_alert
+
+
+class ScoreMonitor:
+    """Monitor Langfuse scores and identify failures"""
+
+    def __init__(self):
+        # Use the LangFuseReadOnlyClient instance directly (not get_client())
+        self.client = langfuse_readonly_client
+        # Redis key for storing last check time (shared across all pods)
+        self.redis_key_last_check = "langfuse:score_monitor:last_check_time"
+        if not self.client.initialized:
+            logger.warning(
+                "Langfuse read-only client not initialized for score monitoring"
+            )
+
+
+    async def fetch_scores(
+        self,
+        http_client: aiohttp.ClientSession,
+        evaluator_name: Optional[str] = None,
+        from_timestamp: Optional[datetime] = None,
+        to_timestamp: Optional[datetime] = None,
+        limit: int = 100,
+    ) -> Dict[str, Any]:
+        """
+        Fetch scores from Langfuse via REST API.
+
+        Args:
+            http_client: Initialized aiohttp client session with auth and base URL
+            evaluator_name: Filter by evaluator name
+            from_timestamp: Filter scores after this timestamp
+            to_timestamp: Filter scores before this timestamp
+            limit: Maximum number of scores to return
+
+        Returns:
+            Dictionary with 'data' key containing list of scores
+
+        Raises:
+            aiohttp.ClientResponseError: If API request fails
+        """
+        # Build query parameters - using correct parameter names from API spec
+        params = {"limit": limit}
+        if evaluator_name:
+            params["name"] = evaluator_name
+        if from_timestamp:
+            # API expects 'fromTimestamp' in ISO 8601 format
+            params["fromTimestamp"] = from_timestamp.isoformat()
+        if to_timestamp:
+            # API expects 'toTimestamp' in ISO 8601 format
+            params["toTimestamp"] = to_timestamp.isoformat()
+
+        logger.debug(f"Fetching scores with params: {params}")
+
+        # Make API request to v2 scores endpoint
+        try:
+            async with http_client.get(
+                "/api/public/v2/scores", params=params
+            ) as response:
+                logger.debug(f"Response status: {response.status}")
+                logger.debug(f"Response headers: {dict(response.headers)}")
+
+                response.raise_for_status()
+
+                result = await response.json()
+                logger.debug(
+                    f"Response body keys: {result.keys() if isinstance(result, dict) else 'not a dict'}"
+                )
+                return result
+
+        except aiohttp.ClientResponseError as e:
+            logger.error(f"HTTP {e.status} error from Langfuse API")
+            logger.error(f"Request URL: {e.request_info.url}")
+            logger.error(f"Response body: {e.message}")
+            raise
+
+    async def _fetch_scores_for_evaluator(
+        self,
+        evaluator_name: str,
+        from_timestamp: datetime,
+        to_timestamp: datetime,
+    ) -> List[Dict[str, Any]]:
+        """
+        Fetch scores for a specific evaluator from Langfuse.
+
+        Args:
+            evaluator_name: Name of the evaluator
+            from_timestamp: Start time
+            to_timestamp: End time
+
+        Returns:
+            List of score dictionaries
+        """
+        try:
+            # Fetch scores using Langfuse REST API via our own method
+            scores_response = await self.fetch_scores(
+                http_client=self.client._http_client,
+                evaluator_name=evaluator_name,
+                from_timestamp=from_timestamp,
+                to_timestamp=to_timestamp,
+            )
+
+            # Response is a dictionary with 'data' key containing list of scores
+            scores_data = scores_response.get("data", [])
+
+            # Convert to list of dictionaries (already in dict format from REST API)
+            scores = []
+            for score in scores_data:
+                score_dict = {
+                    "id": score.get("id"),
+                    "name": score.get("name"),
+                    "value": score.get("value"),
+                    "trace_id": score.get("traceId"),
+                    "observation_id": score.get("observationId"),
+                    "timestamp": score.get("timestamp"),
+                    "comment": score.get("comment"),
+                    "source": score.get("source"),
+                }
+                scores.append(score_dict)
+
+            return scores
+
+        except Exception as e:
+            logger.error(f"Error in _fetch_scores_for_evaluator: {e}", exc_info=True)
+            return []
+
+    def _is_zero_score(self, score: Dict[str, Any]) -> bool:
+        """
+        Check if a score represents a failure (value = 0).
+
+        Args:
+            score: Score dictionary
+
+        Returns:
+            True if score value is 0, False otherwise
+        """
+        try:
+            value = score.get("value")
+            if value is None:
+                return False
+
+            # Check if value is exactly 0 or 0.0
+            return float(value) == 0.0
+
+        except (ValueError, TypeError):
+            logger.warning(f"Invalid score value: {score.get('value')}")
+            return False
+
+    async def _get_last_check_time(self) -> Optional[datetime]:
+        """
+        Get last check time from Redis (shared across all pods).
+
+        Returns:
+            Last check time as datetime, or None if not found or Redis unavailable
+        """
+
+        try:
+            redis_service = await get_redis_service()
+            timestamp_str = await redis_service.get(self.redis_key_last_check)
+
+            if timestamp_str:
+                # Parse ISO format timestamp
+                last_check = datetime.fromisoformat(timestamp_str)
+                logger.debug(
+                    f"Retrieved last check time from Redis: {last_check.isoformat()}"
+                )
+                return last_check
+
+            logger.debug("No last check time found in Redis")
+            return None
+
+        except Exception as e:
+            logger.warning(f"Failed to get last check time from Redis: {e}")
+            return None
+
+    async def _set_last_check_time(self, timestamp: datetime) -> None:
+        """
+        Store last check time in Redis (shared across all pods).
+
+        Args:
+            timestamp: The timestamp to store
+        """
+
+        try:
+            redis_service = await get_redis_service()
+            # Store as ISO format string
+            await redis_service.set(self.redis_key_last_check, timestamp.isoformat())
+            logger.debug(f"Updated last check time in Redis: {timestamp.isoformat()}")
+
+        except Exception as e:
+            logger.error(f"Failed to set last check time in Redis: {e}")
+
+    async def send_score_alert(
+        self,
+        evaluator_name: str,
+        score: Dict[str, Any],
+        trace_details: Optional[Dict[str, Any]] = None,
+    ) -> bool:
+        """
+        Send a Slack alert for a zero score (failure).
+        Uses the generic send_slack_alert() function from slack_webhook.
+
+        Args:
+            evaluator_name: Name of the evaluator that produced the score
+            score: Score dictionary with details
+            trace_details: Optional trace metadata
+
+        Returns:
+            True if alert was sent successfully, False otherwise
+        """
+        # Extract data from score and trace_details
+        trace_id = score.get("trace_id", "unknown")
+        timestamp = score.get("timestamp")
+        comment = score.get("comment", "")
+
+        # Format timestamp
+        if timestamp:
+            try:
+                if isinstance(timestamp, str):
+                    dt = datetime.fromisoformat(timestamp.replace("Z", "+00:00"))
+                else:
+                    dt = timestamp
+                time_str = dt.strftime("%Y-%m-%d %H:%M:%S UTC")
+            except Exception:
+                time_str = str(timestamp)
+        else:
+            time_str = "N/A"
+
+        # Build trace URL
+        trace_url = f"{LANGFUSE_BASEURL}/trace/{trace_id}"
+
+        # Extract call_sid from trace metadata and get recording_url from database
+        call_sid = None
+        recording_url = None
+
+        if trace_details:
+            # Get metadata from trace
+            metadata = trace_details.get("metadata", {})
+
+            # Extract call_sid from nested metadata.attributes
+            if isinstance(metadata, dict):
+                attributes = metadata.get("attributes", {})
+                call_sid = attributes.get("call_sid")
+
+            # If we have a call_sid, query the database for the recording_url
+            if call_sid:
+                try:
+                    lead = await get_lead_by_call_id(call_sid)
+                    if lead and lead.recording_url:
+                        recording_url = lead.recording_url
+                except Exception as e:
+                    logger.error(f"Error querying database for recording_url: {e}")
+
+        # Build fields for the alert
+        fields = [
+            {"name": "Score", "value": "0.0 (FAILURE)"},
+            {"name": "Timestamp", "value": time_str},
+            {"name": "Trace ID", "value": f"`{trace_id}`"},
+            {"name": "Call SID", "value": f"`{call_sid or 'N/A'}`"},
+            {
+                "name": "Recording",
+                "value": (
+                    f"<{recording_url}|Listen to Recording>" if recording_url else "N/A"
+                ),
+            },
+        ]
+
+        # Build sections for failure reason (if available)
+        sections = []
+        if comment:
+            sections.append({"title": "Failure Reason", "text": comment})
+
+        # Build links
+        links = [{"text": "View Trace in Langfuse", "url": trace_url}]
+
+        # Use the generic send function
+        return await slack_alert.send(
+            title=f"🔴 Breeze Buddy - {evaluator_name}",
+            fields=fields,
+            sections=sections if sections else None,
+            links=links,
+            fallback_text=f"LLM Judge Failure: {evaluator_name} - Score 0.0",
+        )
+
+    async def get_trace_details(self, trace_id: str) -> Optional[Dict[str, Any]]:
+        """
+        Fetch detailed information about a trace.
+
+        Args:
+            trace_id: The trace ID to fetch
+
+        Returns:
+            Dictionary with trace details or None if not found
+        """
+        if not self.client.initialized:
+            return None
+
+        try:
+            # Fetch trace using REST API (returns a dictionary)
+            trace = await fetch_trace(self.client._http_client, trace_id)
+
+            # Extract relevant metadata (trace is already a dict from REST API)
+            trace_details = {
+                "id": trace.get("id"),
+                "name": trace.get("name"),
+                "timestamp": trace.get("timestamp"),
+                "metadata": trace.get("metadata", {}),
+                "tags": trace.get("tags", []),
+                "user_id": trace.get("userId"),
+                "session_id": trace.get("sessionId"),
+                "input": trace.get("input"),
+                "output": trace.get("output"),
+            }
+
+            return trace_details
+
+        except Exception as e:
+            logger.error(f"Error fetching trace {trace_id}: {e}")
+            return None
+
+    async def check_and_alert(self) -> None:
+        """
+        Check for zero scores and send Slack alerts.
+
+        This is the main entry point for score monitoring, called by the background
+        task scheduler in app/main.py (when ENABLE_SCORE_MONITORING_LOOP=true).
+
+        Uses Redis-based state management to ensure continuous coverage across pods:
+        - Stores last check time in Redis (shared across all pods)
+        - First run: checks last 10 minutes
+        - Subsequent runs: checks from last check's end time to now
+        - Prevents duplicate checks when different pods win the distributed lock
+        """
+        # Set end time to now
+        to_time = datetime.now(timezone.utc)
+
+        # Get last check time from Redis (shared across all pods)
+        last_check_time = await self._get_last_check_time()
+
+        # Use last check time if available, otherwise look back 10 minutes
+        if last_check_time:
+            from_time = last_check_time
+            logger.info(f"Continuing from last check at {from_time.isoformat()}")
+        else:
+            from_time = to_time - timedelta(minutes=10)
+            logger.info("First check or Redis unavailable, looking back 10 minutes")
+
+        logger.info(
+            f"Checking Langfuse scores from {from_time.isoformat()} "
+            f"to {to_time.isoformat()}"
+        )
+
+        # Check if client is available
+        if not self.client:
+            logger.error("Langfuse client not available")
+            return
+
+        # Use evaluators from config
+        evaluators = LANGFUSE_EVALUATORS
+        if not evaluators:
+            logger.warning("No evaluators configured")
+            return
+
+        # Fetch zero scores for all configured evaluators
+        zero_scores_by_evaluator = {}
+        total_zero_scores = 0
+
+        for evaluator_name in evaluators:
+            try:
+                # Fetch scores for this evaluator
+                scores = await self._fetch_scores_for_evaluator(
+                    evaluator_name=evaluator_name,
+                    from_timestamp=from_time,
+                    to_timestamp=to_time,
+                )
+
+                # Filter for zero scores (failures)
+                zero_scores = [s for s in scores if self._is_zero_score(s)]
+                zero_scores_by_evaluator[evaluator_name] = zero_scores
+                total_zero_scores += len(zero_scores)
+
+                logger.info(
+                    f"Evaluator '{evaluator_name}': "
+                    f"Found {len(scores)} total scores, "
+                    f"{len(zero_scores)} zero scores"
+                )
+
+            except Exception as e:
+                logger.error(
+                    f"Error fetching scores for evaluator '{evaluator_name}': {e}"
+                )
+                zero_scores_by_evaluator[evaluator_name] = []
+
+        # Update last check time BEFORE processing alerts
+        # This ensures timestamp is saved even if alert sending fails/crashes
+        try:
+            await self._set_last_check_time(to_time)
+            logger.info(f"Updated last check time to {to_time.isoformat()}")
+        except Exception as e:
+            logger.critical(
+                f"CRITICAL: Failed to update last check time in Redis: {e}. "
+                f"Aborting alert processing to prevent duplicate checks with stale timestamp."
+            )
+            # Return early to prevent processing with stale timestamp
+            # This ensures we don't send duplicate alerts in multi-pod scenarios
+            return
+
+        if total_zero_scores == 0:
+            logger.info("No zero scores found in this check")
+            return
+
+        logger.info(
+            f"Found {total_zero_scores} zero scores across "
+            f"{len(zero_scores_by_evaluator)} evaluators, sending Slack alerts..."
+        )
+
+        # Send individual alerts for each zero score
+        for evaluator_name, zero_scores in zero_scores_by_evaluator.items():
+            for score in zero_scores:
+                try:
+                    # Get trace details for additional context
+                    trace_id = score.get("trace_id")
+                    trace_details = None
+
+                    if trace_id:
+                        trace_details = await self.get_trace_details(trace_id)
+
+                    # Send Slack alert
+                    await self.send_score_alert(
+                        evaluator_name=evaluator_name,
+                        score=score,
+                        trace_details=trace_details,
+                    )
+
+                except Exception as alert_error:
+                    logger.error(
+                        f"Error sending Slack alert for trace {score.get('trace_id')}: "
+                        f"{alert_error}"
+                    )
+
+
+# Global instance
+score_monitor = ScoreMonitor()

--- a/app/services/langfuse/tasks/task.py
+++ b/app/services/langfuse/tasks/task.py
@@ -1,0 +1,55 @@
+"""
+Langfuse Background Task Initialization, Score Fetching, and Score Monitoring
+
+This module provides functionality to initialize Langfuse background tasks,
+fetch scores from Langfuse via REST API, and monitor for failures.
+"""
+
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, List, Optional
+
+import aiohttp
+
+from app.core.config.static import (
+    ENABLE_BB_LANGFUSE_MONITORING_LOOP,
+    LANGFUSE_EVALUATORS, 
+    SLACK_WEBHOOK_URL,
+    SCORE_CHECK_INTERVAL_SECONDS,
+)
+from app.core.logger import logger
+from app.services.langfuse.tasks.score_monitor.score import score_monitor
+
+
+async def initialize_langfuse_tasks(scheduler) -> bool:
+    """
+    Initialize all Langfuse background tasks if properly configured.
+    
+    Args:
+        scheduler: BackgroundTaskScheduler instance to register tasks with
+        
+    Returns:
+        bool: True if tasks were registered successfully, False if skipped
+    """
+    
+    # Check if all required configuration is present
+    if not (ENABLE_BB_LANGFUSE_MONITORING_LOOP and LANGFUSE_EVALUATORS and SLACK_WEBHOOK_URL):
+        logger.debug("Langfuse tasks skipped - missing required configuration")
+        return False
+        
+    try:
+        # Register Langfuse score monitoring task
+        scheduler.register_task(
+            name="langfuse_score_monitor",
+            func=score_monitor.check_and_alert,
+            interval_seconds=SCORE_CHECK_INTERVAL_SECONDS,
+        )
+        logger.info("Registered langfuse_score_monitor background task")
+        
+        # Future Langfuse tasks can be registered here
+        # scheduler.register_task(...)
+        
+        return True
+        
+    except Exception as e:
+        logger.error(f"Failed to register Langfuse background tasks: {e}")
+        return False

--- a/app/services/langfuse/trace.py
+++ b/app/services/langfuse/trace.py
@@ -1,0 +1,39 @@
+"""
+Langfuse Trace Fetching
+
+This module provides functionality to fetch trace data from Langfuse via REST API.
+"""
+
+from typing import Any, Dict
+
+import aiohttp
+
+from app.core.logger import logger
+
+
+async def fetch_trace(http_client: aiohttp.ClientSession, trace_id: str) -> Dict[str, Any]:
+    """
+    Fetch a trace from Langfuse via REST API.
+
+    Args:
+        http_client: Initialized aiohttp client session with auth and base URL
+        trace_id: The ID of the trace to fetch
+
+    Returns:
+        Dictionary with trace data
+
+    Raises:
+        aiohttp.ClientResponseError: If API request fails
+    """
+    logger.debug(f"Fetching trace: {trace_id}")
+
+    # Make API request
+    try:
+        async with http_client.get(f"/api/public/traces/{trace_id}") as response:
+            response.raise_for_status()
+            return await response.json()
+    except aiohttp.ClientResponseError as e:
+        logger.error(f"HTTP {e.status} error fetching trace {trace_id}")
+        logger.error(f"Request URL: {e.request_info.url}")
+        logger.error(f"Response body: {e.message}")
+        raise

--- a/app/services/redis/client.py
+++ b/app/services/redis/client.py
@@ -167,11 +167,24 @@ class RedisService:
             logger.error(f"Redis GET error for key {key}: {e}")
             return None
 
-    async def set(self, key: str, value: str) -> bool:
-        """Set value in Redis"""
+    async def set(
+        self, key: str, value: str, nx: bool = False, ex: Optional[int] = None
+    ) -> bool:
+        """
+        Set value in Redis with optional NX (only if not exists) and EX (expiration).
+
+        Args:
+            key: Redis key
+            value: Value to set
+            nx: Only set if key doesn't exist (default: False)
+            ex: Expiration time in seconds (default: None)
+
+        Returns:
+            True if key was set, False otherwise
+        """
         try:
             client = await self.get_client()
-            result = await client.set(key, value)
+            result = await client.set(key, value, nx=nx, ex=ex)
             return bool(result)
         except RedisError as e:
             logger.error(f"Redis SET error for key {key}: {e}")
@@ -191,6 +204,7 @@ class RedisService:
         except RedisError as e:
             logger.error(f"Redis SETEX error for key {key}: {e}")
             return False
+
 
     async def delete(self, key: str) -> bool:
         """Delete key from Redis"""

--- a/app/services/slack/__init__.py
+++ b/app/services/slack/__init__.py
@@ -1,0 +1,11 @@
+"""
+Slack Services Module
+
+Provides Slack webhook integration for sending alerts and notifications.
+"""
+
+from .alert import Alert, slack_alert
+
+__all__ = [
+    "slack_alert",
+]

--- a/app/services/slack/alert.py
+++ b/app/services/slack/alert.py
@@ -1,0 +1,167 @@
+"""
+Slack Alert Integration
+
+This module provides functionality to send alerts to Slack via webhooks.
+"""
+
+import json
+from typing import Dict, List, Optional
+
+import aiohttp
+
+from app.core.config.static import SLACK_WEBHOOK_URL, SLACK_TAG_USERS
+from app.core.logger import logger
+
+
+class Alert:
+    """Send alerts to Slack via webhook"""
+
+    def __init__(self):
+        self.webhook_url = SLACK_WEBHOOK_URL
+
+    async def send(
+        self,
+        title: str,
+        fields: Optional[List[Dict[str, str]]] = None,
+        sections: Optional[List[Dict[str, str]]] = None,
+        links: Optional[List[Dict[str, str]]] = None,
+        fallback_text: Optional[str] = None,
+    ) -> bool:
+        """
+        Generic function to send Slack alerts with customizable content.
+
+        Args:
+            title: Alert title/header (displayed with emoji)
+            fields: Optional list of field dicts with 'name' and 'value' keys
+            sections: Optional list of section dicts with 'title' and 'text' keys
+            links: Optional list of link dicts with 'text' and 'url' keys
+            fallback_text: Optional fallback text for notifications (defaults to title)
+
+        Returns:
+            True if sent successfully, False otherwise
+        """
+        if not self.webhook_url:
+            logger.warning("Slack webhook URL not configured")
+            return False
+
+        try:
+            # Build blocks
+            blocks = [
+                {
+                    "type": "header",
+                    "text": {
+                        "type": "plain_text",
+                        "text": title,
+                        "emoji": True,
+                    },
+                }
+            ]
+
+            # Add fields section if provided
+            if fields:
+                # Slack fields are displayed in 2 columns, so we group them
+                field_items = []
+                for field in fields:
+                    field_items.append(
+                        {
+                            "type": "mrkdwn",
+                            "text": f"*{field.get('name', '')}:*\n{field.get('value', '')}",
+                        }
+                    )
+
+                blocks.append({"type": "section", "fields": field_items})
+
+            # Add custom sections if provided
+            if sections:
+                for section in sections:
+                    section_block = {
+                        "type": "section",
+                        "text": {
+                            "type": "mrkdwn",
+                            "text": f"*{section.get('title', '')}:*\n{section.get('text', '')}",
+                        },
+                    }
+                    blocks.append(section_block)
+
+            # Add links if provided
+            if links:
+                for link in links:
+                    blocks.append(
+                        {
+                            "type": "section",
+                            "text": {
+                                "type": "mrkdwn",
+                                "text": f"🔗 <{link.get('url', '')}|{link.get('text', 'Link')}>",
+                            },
+                        }
+                    )
+
+            # Add notifications section if users are configured for tagging
+            if SLACK_TAG_USERS:
+                # Parse comma-separated usernames and filter out empty ones
+                users = [user.strip() for user in SLACK_TAG_USERS.split(",") if user.strip()]
+                if users:
+                    # Format users as proper Slack mentions with angle brackets
+                    mentions = []
+                    for user in users:
+                        # Remove @ if present and wrap in Slack mention format
+                        clean_user = user.strip().lstrip("@")
+                        mentions.append(f"<@{clean_user}>")
+                    
+                    # Join mentions with spaces
+                    mentions_text = " ".join(mentions)
+                    
+                    # Add notifications section
+                    blocks.append(
+                        {
+                            "type": "section",
+                            "text": {
+                                "type": "mrkdwn",
+                                "text": f"cc: {mentions_text}",
+                            },
+                        }
+                    )
+
+            # Build final message
+            message = {
+                "blocks": blocks,
+                "text": fallback_text or title,  # Fallback text for notifications
+            }
+
+            # Log outgoing request
+            logger.info(f"Sending Slack alert: {title}")
+
+            # Send to Slack with timeout to prevent hanging
+            timeout = aiohttp.ClientTimeout(total=30)  # 30 second timeout
+            async with aiohttp.ClientSession(timeout=timeout) as session:
+                async with session.post(
+                    self.webhook_url,
+                    json=message,
+                    headers={"Content-Type": "application/json"},
+                ) as response:
+                    response_text = await response.text()
+
+                    # Log response details
+                    logger.info(
+                        f"Slack API response - Status: {response.status}, "
+                        f"Body: {response_text}"
+                    )
+
+                    # Slack webhooks return "ok" on success
+                    if response.status == 200 and response_text.lower() == "ok":
+                        logger.info(f"Slack alert sent successfully: {title}")
+                        return True
+                    else:
+                        logger.error(
+                            f"Failed to send Slack alert - Status: {response.status}, "
+                            f"Response: {response_text}, Title: {title}"
+                        )
+                        return False
+
+        except Exception as e:
+            logger.error(f"Error sending Slack alert: {e}")
+            return False
+
+
+# Global instance
+slack_alert = Alert()

--- a/docs/LANGFUSE_AUTO_EVALUATION_AND_ALERTING.md
+++ b/docs/LANGFUSE_AUTO_EVALUATION_AND_ALERTING.md
@@ -1,0 +1,945 @@
+# Langfuse Auto Evaluation and Alerting System
+
+This document describes the automated Langfuse evaluation monitoring system that continuously polls LLM-as-a-judge evaluation scores and sends Slack alerts for failures.
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Architecture](#architecture)
+- [System Flow](#system-flow)
+- [Core Components](#core-components)
+- [Distributed Locking](#distributed-locking)
+- [Deduplication Logic](#deduplication-logic)
+- [Time Window Handling](#time-window-handling)
+- [Configuration](#configuration)
+- [Guarantees](#guarantees)
+- [Edge Cases](#edge-cases)
+
+## Overview
+
+The auto evaluation and alerting system runs as a **background task** managed by the `BackgroundTaskScheduler` that:
+
+1. Continuously polls Langfuse for LLM-as-a-judge evaluation scores
+2. Identifies failures (score = 0) across multiple evaluators
+3. Sends detailed Slack alerts with call context and recording URLs
+4. Uses Redis distributed locking for multi-pod deployments
+5. Implements deduplication to prevent duplicate alerts
+6. Ensures 100% coverage with no missed evaluations
+
+**Key Design Principles:**
+- **Scheduler-Based**: Runs via generic `BackgroundTaskScheduler` framework
+- **Distributed Safety**: Only one pod checks scores at a time (Redis locking)
+- **No Duplicates**: Redis-based deduplication prevents repeat alerts
+- **No Missed Scores**: Overlapping time windows ensure complete coverage
+- **Graceful Shutdown**: Handles SIGTERM for clean pod termination
+- **Extensible**: Easy to add new background tasks using the same framework
+
+**Production Configuration:**
+- Scheduler Loop: **60 seconds** (checks all tasks every minute)
+- Score Check Interval: **10 minutes** (600 seconds)
+- Lookback Window: **10 minutes** (overlapping)
+- Deduplication TTL: **60 minutes**
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                    Kubernetes Deployment                         │
+│  ┌──────────────┐  ┌──────────────┐  ┌──────────────┐          │
+│  │   Pod 1      │  │   Pod 2      │  │   Pod 3      │          │
+│  │              │  │              │  │              │          │
+│  │ ┌──────────┐ │  │ ┌──────────┐ │  │ ┌──────────┐ │          │
+│  │ │ FastAPI  │ │  │ │ FastAPI  │ │  │ │ FastAPI  │ │          │
+│  │ │ Lifespan │ │  │ │ Lifespan │ │  │ │ Lifespan │ │          │
+│  │ └────┬─────┘ │  │ └────┬─────┘ │  │ └────┬─────┘ │          │
+│  │      │       │  │      │       │  │      │       │          │
+│  │      ▼       │  │      ▼       │  │      ▼       │          │
+│  │ ┌──────────┐ │  │ ┌──────────┐ │  │ ┌──────────┐ │          │
+│  │ │ Monitor  │ │  │ │ Monitor  │ │  │ │ Monitor  │ │          │
+│  │ │  Loop    │ │  │ │  Loop    │ │  │ │  Loop    │ │          │
+│  │ │(10 min)  │ │  │ │(10 min)  │ │  │ │(10 min)  │ │          │
+│  │ └────┬─────┘ │  │ └────┬─────┘ │  │ └────┬─────┘ │          │
+│  └──────┼───────┘  └──────┼───────┘  └──────┼───────┘          │
+│         │                 │                 │                   │
+│         └─────────────────┼─────────────────┘                   │
+│                           │                                     │
+└───────────────────────────┼─────────────────────────────────────┘
+                            │
+                            ▼
+                    ┌───────────────┐
+                    │  Redis Cache  │
+                    │               │
+                    │ Distributed   │
+                    │ Lock:         │
+                    │ "langfuse:    │
+                    │  score_       │
+                    │  monitor:     │
+                    │  lock"        │
+                    │ TTL: 600s     │
+                    │               │
+                    │ Dedup Keys:   │
+                    │ "langfuse:    │
+                    │  alert_sent:  │
+                    │  {call_sid}"  │
+                    │ TTL: 3600s    │
+                    └───────┬───────┘
+                            │
+        ┌───────────────────┼───────────────────┐
+        │                   │                   │
+        ▼                   ▼                   ▼
+┌───────────────┐   ┌──────────────┐   ┌──────────────┐
+│   Langfuse    │   │  PostgreSQL  │   │    Slack     │
+│               │   │              │   │              │
+│ GET /api/     │   │ Get Call     │   │ Send Alert   │
+│ public/v2/    │   │ Recording    │   │ Webhook      │
+│ scores        │   │ URL          │   │              │
+│               │   │              │   │              │
+│ GET /api/     │   │              │   │              │
+│ public/       │   │              │   │              │
+│ traces/{id}   │   │              │   │              │
+└───────────────┘   └──────────────┘   └──────────────┘
+```
+
+## System Flow
+
+### Startup Sequence
+
+1. **Application Startup** (`app/main.py` lifespan)
+   ```python
+   @asynccontextmanager
+   async def lifespan(_app: FastAPI):
+       # Initialize database, Redis, etc.
+       
+       # Start score monitoring loop if enabled
+       if ENABLE_SCORE_MONITORING_LOOP:
+           _score_monitoring_task = asyncio.create_task(
+               run_score_monitoring_loop()
+           )
+   ```
+
+2. **Configuration Validation**
+   - Checks `LANGFUSE_EVALUATORS` is configured
+   - Checks `SLACK_WEBHOOK_URL` is configured
+   - Logs errors if configuration is incomplete
+   - Only starts loop if all required config is present
+
+3. **Loop Initialization**
+   - Creates background asyncio task
+   - Runs independently of HTTP request handling
+   - Continues until pod shutdown (SIGTERM)
+
+### Monitoring Loop Cycle
+
+Each cycle (every **10 minutes** in production):
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│ 1. Try to Acquire Distributed Lock                          │
+│    Redis: SET "langfuse:score_monitor:lock" "locked"        │
+│           NX (only if not exists)                            │
+│           EX 600 (TTL = 10 minutes)                          │
+│                                                              │
+│    ✓ Lock acquired → Proceed to step 2                      │
+│    ✗ Lock exists → Skip this cycle (another pod checking)   │
+└─────────────────────────────────────────────────────────────┘
+                            │
+                            ▼
+┌─────────────────────────────────────────────────────────────┐
+│ 2. Fetch Scores from Langfuse                               │
+│    - Time window: Last 10 minutes (overlapping)             │
+│    - For each evaluator in LANGFUSE_EVALUATORS         │
+│    - Filter for score == 0.0 (failures only)                │
+│                                                              │
+│    Example: 15 total scores, 2 zero scores found            │
+└─────────────────────────────────────────────────────────────┘
+                            │
+                            ▼
+┌─────────────────────────────────────────────────────────────┐
+│ 3. Process Each Zero Score                                  │
+│    For each failure:                                         │
+│    a) Fetch trace details from Langfuse                     │
+│    b) Extract call_sid from metadata.attributes.call_sid    │
+│    c) Check deduplication (see next section)                │
+│    d) Query database for recording_url                      │
+│    e) Send Slack alert                                      │
+│    f) Mark call_sid as alerted in Redis (60 min TTL)        │
+└─────────────────────────────────────────────────────────────┘
+                            │
+                            ▼
+┌─────────────────────────────────────────────────────────────┐
+│ 4. Wait for Next Cycle                                      │
+│    await asyncio.sleep(600)  # 10 minutes                   │
+│                                                              │
+│    Lock automatically expires after 10 minutes               │
+│    Next pod can acquire lock and repeat cycle               │
+└─────────────────────────────────────────────────────────────┘
+```
+
+### Deduplication Flow
+
+For each zero score found:
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│ Extract call_sid from trace metadata                        │
+│   trace.metadata.attributes.call_sid                        │
+└─────────────────────────────────────────────────────────────┘
+                            │
+                            ▼
+┌─────────────────────────────────────────────────────────────┐
+│ Check Redis for existing alert                              │
+│   Key: "langfuse:alert_sent:{call_sid}"                     │
+│   Command: EXISTS key                                        │
+└─────────────────────────────────────────────────────────────┘
+                            │
+                ┌───────────┴───────────┐
+                │                       │
+                ▼                       ▼
+        ┌──────────────┐        ┌──────────────┐
+        │ Key EXISTS   │        │ Key NOT      │
+        │ (already     │        │ EXISTS       │
+        │  alerted)    │        │ (new alert)  │
+        └──────┬───────┘        └──────┬───────┘
+               │                       │
+               ▼                       ▼
+        ┌──────────────┐        ┌──────────────┐
+        │ Skip Alert   │        │ Send Alert   │
+        │ Log: "Alert  │        │ to Slack     │
+        │ already sent"│        └──────┬───────┘
+        └──────────────┘               │
+                                       ▼
+                                ┌──────────────┐
+                                │ Mark as      │
+                                │ Alerted      │
+                                │ SETEX key    │
+                                │ "1" 3600     │
+                                │ (60 min TTL) │
+                                └──────────────┘
+```
+
+### Shutdown Sequence
+
+1. **SIGTERM Received** (Kubernetes pod termination)
+   ```python
+   # In lifespan shutdown
+   if _score_monitoring_task and not _score_monitoring_task.done():
+       _score_monitoring_task.cancel()
+       await _score_monitoring_task  # Wait for cancellation
+   ```
+
+2. **Graceful Cancellation**
+   ```python
+   # In run_score_monitoring_loop()
+   except asyncio.CancelledError:
+       logger.info("Score monitoring loop cancelled, shutting down...")
+       break
+   ```
+
+3. **Lock Auto-Expiry**
+   - Redis lock expires after 10 minutes (TTL)
+   - Other pods can immediately acquire lock
+   - No manual cleanup needed
+
+## Core Components
+
+### 1. Score Monitor Service
+
+**File:** `app/services/langfuse/score_monitor.py`
+
+**Class:** `ScoreMonitor`
+
+**Key Methods:**
+
+- `check_and_alert()` - Main entry point, orchestrates entire check cycle
+- `fetch_recent_scores()` - Fetches scores for all evaluators
+- `_fetch_scores_for_evaluator()` - Calls Langfuse REST API
+- `_is_zero_score()` - Checks if score value == 0.0
+- `get_trace_details()` - Fetches trace metadata for context
+
+**Example Usage:**
+```python
+from app.services.langfuse.score_monitor import score_monitor
+
+# Called by infinite loop in app/main.py
+await score_monitor.check_and_alert()
+```
+
+### 2. Slack Webhook Service
+
+**File:** `app/services/slack/webhook.py`
+
+**Class:** `SlackWebhook`
+
+**Key Methods:**
+
+- `send_score_alert()` - Sends formatted alert to Slack
+- `_build_alert_message()` - Constructs Slack message payload
+
+**Alert Format:**
+```
+🔴 LLM Judge Failure - Breeze Buddy
+
+Evaluator: breeze buddy outcome correctness
+Score: 0.0 (FAILURE)
+Trace ID: trace-abc-123
+Timestamp: 2025-11-25 12:10:45 UTC
+
+Call Details:
+• Call SID: CA1234567890abcdef
+• Merchant: shop_12345
+• Outcome: confirmed
+• Language: hi
+
+Failure Reason: Customer said "cancel" but system marked as "confirmed"
+
+🔗 View Trace | 🎧 Listen to Recording
+```
+
+### 3. Redis Service
+
+**File:** `app/services/redis/client.py`
+
+**Class:** `RedisService`
+
+**Key Methods:**
+
+- `get_client()` - Returns underlying Redis client for advanced operations
+- `exists(key)` - Check if key exists
+- `setex(key, value, ttl_seconds)` - Set key with TTL
+
+**Distributed Lock Usage:**
+```python
+redis_service = await get_redis_service()
+client = await redis_service.get_client()
+
+# Atomic lock acquisition (10 minute TTL in production)
+lock_acquired = await client.set(
+    "langfuse:score_monitor:lock",
+    "locked",
+    nx=True,  # Only set if not exists
+    ex=600    # TTL: 10 minutes
+)
+```
+
+### 4. Database Accessor
+
+**File:** `app/database/accessor/breeze_buddy/lead_call_tracker.py`
+
+**Function:** `get_call_recording_url(call_sid: str)`
+
+**Purpose:** Fetch recording URL for Slack alert links
+
+## Distributed Locking
+
+### Why Distributed Locking?
+
+In a multi-pod Kubernetes deployment, without locking:
+- All 3 pods would check scores simultaneously
+- Each pod would send duplicate alerts
+- Langfuse API would receive 3x the requests
+
+With distributed locking:
+- Only 1 pod checks scores at a time
+- No duplicate alerts
+- Efficient API usage
+
+### How It Works
+
+**Atomic Operation:**
+```python
+lock_acquired = await client.set(
+    lock_key,
+    "locked",
+    nx=True,  # NX = "Not eXists" - only set if key doesn't exist
+    ex=600    # EX = "EXpire" - TTL: 10 minutes (production)
+)
+```
+
+**Redis Guarantees:**
+- `SET` with `NX` and `EX` is a **single atomic operation**
+- Only ONE client can successfully set the key
+- All other clients receive `False` (lock not acquired)
+- No race conditions possible
+
+**Timeline Example (Production - 10 minute intervals):**
+
+```
+Time    Pod 1                Pod 2                Pod 3
+────────────────────────────────────────────────────────────
+00:00   SET lock NX EX 600   SET lock NX EX 600   SET lock NX EX 600
+        → TRUE ✓             → FALSE ✗            → FALSE ✗
+        
+00:00   Checking scores...   Skipping cycle       Skipping cycle
+00:02   Sending alerts...    (waiting)            (waiting)
+00:05   Completed            (waiting)            (waiting)
+00:05   Sleep 10 min         (waiting)            (waiting)
+        
+10:00   Lock expired         SET lock NX EX 600   SET lock NX EX 600
+        SET lock NX EX 600   → TRUE ✓             → FALSE ✗
+        → FALSE ✗
+        
+10:00   Skipping cycle       Checking scores...   Skipping cycle
+```
+
+### Lock Properties
+
+- **Key:** `langfuse:score_monitor:lock`
+- **Value:** `"locked"` (arbitrary, not used)
+- **TTL:** **600 seconds (10 minutes)** - matches check interval
+- **Auto-Expiry:** Lock automatically expires, no manual cleanup needed
+- **Failure Handling:** If pod crashes, lock expires naturally
+
+## Deduplication Logic
+
+### Why Deduplication?
+
+**Problem:** Overlapping time windows can see the same score multiple times
+
+```
+Check 1: 12:00 - 12:10 (finds score at 12:05)
+Check 2: 12:10 - 12:20 (finds same score at 12:05)
+```
+
+Without deduplication: 2 alerts for the same failure ❌
+
+With deduplication: 1 alert only ✓
+
+### Implementation
+
+**Redis Key Pattern:**
+```
+langfuse:alert_sent:{call_sid}
+```
+
+**Example:**
+```
+langfuse:alert_sent:CA1234567890abcdef
+```
+
+**TTL:** 60 minutes (3600 seconds)
+
+**Flow:**
+```python
+# Check if already alerted
+redis_key = f"langfuse:alert_sent:{call_sid}"
+already_alerted = await redis_service.exists(redis_key)
+
+if already_alerted:
+    logger.info(f"Alert already sent for call_sid '{call_sid}', skipping")
+    continue
+
+# Send alert
+await slack_webhook.send_score_alert(...)
+
+# Mark as alerted (60 min TTL)
+await redis_service.setex(redis_key, "1", ttl_seconds=3600)
+```
+
+### Why 60 Minutes TTL?
+
+- Langfuse scores are typically created within minutes of call completion
+- 60 minutes ensures we don't re-alert for the same call
+- After 60 minutes, key expires and Redis memory is freed
+- Covers 6 check cycles (6 × 10 min = 60 min)
+- If a new score appears for the same call_sid after 60 min, it's likely a different issue
+
+### Edge Case: Missing call_sid
+
+If `call_sid` is not found in trace metadata:
+```python
+if not call_sid:
+    logger.warning(
+        f"No call_sid found for trace {trace_id}, "
+        f"cannot prevent duplicate alerts"
+    )
+    # Still send alert, but can't deduplicate
+```
+
+## Time Window Handling
+
+### Overlapping Windows Strategy
+
+**Production Configuration:**
+- Check Interval: **10 minutes** (600 seconds)
+- Lookback Window: **10 minutes** (hardcoded in `check_and_alert()`)
+
+**Why Overlapping?**
+
+Ensures **100% coverage** with no missed scores:
+
+```
+Timeline (Production - 10 minute intervals):
+────────────────────────────────────────────────────────────
+12:00   Check 1: 11:50 - 12:00 ████████████
+12:10   Check 2: 12:00 - 12:10  ████████████
+12:20   Check 3: 12:10 - 12:20   ████████████
+12:30   Check 4: 12:20 - 12:30    ████████████
+
+Score created at 12:05:
+- Caught by Check 2 (12:00-12:10) ✓
+- Caught by Check 3 (12:10-12:20) ✓ (deduplicated)
+```
+
+**Benefits:**
+- **No Missed Scores:** Even if one check fails, next check catches it
+- **Resilient to Failures:** Pod crashes don't cause gaps
+- **Deduplication Handles Overlap:** Redis prevents duplicate alerts
+- **Efficient:** 10-minute intervals reduce API load while maintaining coverage
+
+### UTC Timestamp Handling
+
+All timestamps use UTC timezone:
+
+```python
+from datetime import datetime, timezone
+
+to_time = datetime.now(timezone.utc)
+from_time = to_time - timedelta(minutes=10)
+```
+
+**Why UTC?**
+- Langfuse stores timestamps in UTC
+- Avoids timezone conversion issues
+- Consistent across all pods regardless of location
+
+## Configuration
+
+### Environment Variables
+
+**Production Configuration:**
+
+```bash
+# Langfuse Configuration
+LANGFUSE_SECRET_KEY=sk-lf-your-secret-key
+LANGFUSE_PUBLIC_KEY=pk-lf-your-public-key
+LANGFUSE_BASEURL=https://periscope.breeze.in
+
+# Score Monitoring
+LANGFUSE_EVALUATORS="breeze buddy outcome correctness,transcript_quality"
+SLACK_WEBHOOK_URL=https://hooks.slack.com/services/YOUR/WEBHOOK/URL
+
+# Enable/Disable Monitoring
+ENABLE_SCORE_MONITORING_LOOP=true
+
+# Check Interval (10 minutes in production)
+SCORE_CHECK_INTERVAL_SECONDS=600
+```
+
+**Optional:**
+
+```bash
+# Redis Configuration (for distributed locking)
+REDIS_HOST=localhost
+REDIS_PORT=6379
+REDIS_DB=0
+REDIS_PASSWORD=your-password  # if required
+```
+
+### Configuration Validation
+
+On startup, the system validates:
+
+```python
+config_errors = []
+if not LANGFUSE_EVALUATORS:
+    config_errors.append("LANGFUSE_EVALUATORS is empty")
+if not SLACK_WEBHOOK_URL:
+    config_errors.append("SLACK_WEBHOOK_URL is not configured")
+
+if config_errors:
+    logger.error("Score monitoring will NOT start due to configuration errors")
+    # Loop does not start
+```
+
+### Evaluator Names
+
+**Format:** Comma-separated list (case-sensitive)
+
+```bash
+LANGFUSE_EVALUATORS="evaluator1,evaluator2,evaluator3"
+```
+
+**Example:**
+```bash
+LANGFUSE_EVALUATORS="breeze buddy outcome correctness,transcript quality,address verification"
+```
+
+**Important:** Names must match exactly what's in Langfuse (case-sensitive)
+
+## Guarantees
+
+### 1. No Missed Evaluations ✓
+
+**Guarantee:** Every score created in Langfuse will be checked
+
+**How:**
+- Overlapping 10-minute windows
+- Checks every 10 minutes
+- Each score appears in at least 2 consecutive checks
+- Even if 1 check fails, next check catches it
+
+**Example:**
+```
+Score created at 12:05:30
+
+Will be caught by checks at:
+12:10 (12:00-12:10) ✓
+12:20 (12:10-12:20) ✓ (deduplicated)
+```
+
+### 2. No Duplicate Alerts ✓
+
+**Guarantee:** Each failure generates exactly one Slack alert
+
+**How:**
+- Redis-based deduplication using `call_sid`
+- 60-minute TTL on deduplication keys (covers 6 check cycles)
+- Atomic check-and-set pattern
+
+**Example:**
+```
+Score for call_sid "CA123" found in 2 consecutive checks:
+
+Check 1 (12:10): Alert sent ✓, Redis key set
+Check 2 (12:20): Key exists, skip ✗
+
+Result: 1 alert sent, 1 skipped
+```
+
+### 3. Distributed Safety ✓
+
+**Guarantee:** Only one pod checks scores at a time
+
+**How:**
+- Redis distributed lock with atomic SET NX EX
+- Lock TTL = check interval (10 minutes)
+- Auto-expiry on pod crash
+
+**Example:**
+```
+3 pods running:
+
+Pod 1: Acquires lock ✓, checks scores
+Pod 2: Lock exists ✗, skips cycle
+Pod 3: Lock exists ✗, skips cycle
+
+10 minutes later:
+
+Pod 1: Lock expired, tries to acquire ✗
+Pod 2: Acquires lock ✓, checks scores
+Pod 3: Lock exists ✗, skips cycle
+```
+
+### 4. Graceful Shutdown ✓
+
+**Guarantee:** Clean shutdown on pod termination
+
+**How:**
+- FastAPI lifespan handles SIGTERM
+- Cancels monitoring task gracefully
+- No orphaned processes or locks
+
+## Edge Cases
+
+### 1. Pod Crashes During Check
+
+**Scenario:** Pod crashes while checking scores
+
+**Impact:**
+- Lock remains in Redis with TTL
+- Lock expires after 10 minutes
+- Next pod acquires lock and continues
+
+**Result:** No impact, system self-heals ✓
+
+### 2. Redis Unavailable
+
+**Scenario:** Redis is down or unreachable (production has Redis configured)
+
+**Behavior:**
+```python
+# Production always has Redis configured
+try:
+    client = await redis_service.get_client()
+    lock_acquired = await client.set(
+        lock_key, "locked", nx=True, ex=SCORE_CHECK_INTERVAL_SECONDS
+    )
+    
+    if lock_acquired:
+        await score_monitor.check_and_alert()
+    else:
+        logger.debug("Another pod is monitoring scores, skipping...")
+except Exception as e:
+    # Redis connection failed
+    logger.error(f"Error in score monitoring loop: {e}")
+    await asyncio.sleep(60)  # Wait 1 minute before retrying
+    # Does NOT proceed with check - skips to next cycle
+```
+
+**Impact (Production - Redis configured but down):**
+- ✓ System **STOPS checking scores** (fail-safe behavior)
+- ✓ Logs error and retries every 1 minute
+- ✓ **No duplicate alerts** (check is skipped)
+- ✓ Resumes automatically when Redis recovers
+- ⚠️ Scores may be missed during Redis downtime (but caught by next check due to overlapping windows)
+
+**Why Fail-Safe Design:**
+- Better to **miss one check cycle** than send **duplicate alerts**
+- Overlapping time windows ensure scores are caught when Redis recovers
+- Prevents alert fatigue from duplicate notifications
+
+**Monitoring Recommendations:**
+- Set up Redis health monitoring and alerts
+- Monitor Redis uptime to ensure continuous operation
+- Track "Error in score monitoring loop" logs to detect Redis issues
+- Ensure Redis has proper failover/HA setup in production
+
+### 3. Langfuse API Failure
+
+**Scenario:** Langfuse API returns error or timeout
+
+**Behavior:**
+```python
+try:
+    scores = self._fetch_scores_for_evaluator(...)
+except Exception as e:
+    logger.error(f"Error fetching scores: {e}")
+    results[evaluator_name] = []  # Empty list, no alerts
+```
+
+**Impact:**
+- Current check fails
+- Next check (10 min later) retries
+- Overlapping windows ensure score is caught
+
+**Result:** Temporary failure, self-healing ✓
+
+### 4. Slack Webhook Failure
+
+**Scenario:** Slack webhook returns error
+
+**Behavior:**
+```python
+alert_sent = await slack_webhook.send_score_alert(...)
+if alert_sent:
+    # Mark as alerted in Redis
+    await redis_service.setex(redis_key, "1", ttl_seconds=3600)
+else:
+    # Alert failed, don't mark as alerted
+    logger.error("Failed to send Slack alert")
+```
+
+**Impact:**
+- Alert not sent
+- Not marked in Redis
+- Next check retries sending alert
+
+**Result:** Retry on next check ✓
+
+### 5. Missing call_sid in Metadata
+
+**Scenario:** Trace doesn't have `call_sid` in metadata
+
+**Behavior:**
+```python
+if not call_sid:
+    logger.warning("No call_sid found, cannot prevent duplicates")
+    # Still send alert, but can't deduplicate
+```
+
+**Impact:**
+- Alert sent successfully
+- Cannot deduplicate (no Redis key)
+- May receive duplicate alerts if score appears in multiple checks
+
+**Mitigation:** Ensure all traces include `call_sid` in metadata
+
+## Monitoring
+
+To monitor the health and performance of the Langfuse auto evaluation and alerting system, watch for these key indicators:
+
+### Log Messages to Monitor
+
+**Successful Operation:**
+```
+INFO: Score monitoring loop started
+INFO: Checking Langfuse scores from 2025-11-25T12:00:00+00:00 to 2025-11-25T12:10:00+00:00
+INFO: Evaluator 'breeze buddy outcome correctness': Found 15 total scores, 2 zero scores
+INFO: ✓ Slack alert sent successfully for evaluator 'breeze buddy outcome correctness', trace_id: trace-abc-123
+INFO: Alert summary: 2 sent, 0 skipped (duplicates)
+```
+
+**Warning Signs:**
+```
+WARNING: Redis not available for deduplication: Connection refused
+WARNING: No call_sid found for trace trace-xyz-789, cannot prevent duplicate alerts
+WARNING: Redis check failed for call_sid 'CA123': timeout, proceeding with alert
+```
+
+**Error Conditions:**
+```
+ERROR: Error in score monitoring loop: HTTPStatusError 401 Unauthorized
+ERROR: Failed to send Slack alert - Status: 500, Response: Internal Server Error
+ERROR: Error fetching scores for evaluator 'evaluator_name': Connection timeout
+```
+
+### Metrics to Track
+
+1. **Alert Volume**: Number of alerts sent per check cycle
+2. **Duplicate Rate**: Ratio of skipped alerts to total zero scores found
+3. **API Latency**: Time taken to fetch scores from Langfuse
+4. **Redis Availability**: Uptime of Redis for distributed locking
+5. **Slack Success Rate**: Percentage of successful webhook deliveries
+
+### Health Checks
+
+Monitor these system components:
+- **Langfuse API**: Ensure credentials are valid and API is responsive
+- **Redis**: Verify connection and distributed lock acquisition
+- **Slack Webhook**: Test webhook URL is accessible and accepting requests
+- **Database**: Check PostgreSQL connection for recording URL lookups
+
+## Troubleshooting
+
+### Common Issues and Solutions
+
+#### 1. No Alerts Being Sent
+
+**Symptoms:**
+- Log shows "No zero scores found in this check"
+- Or no log messages at all
+
+**Possible Causes:**
+- `ENABLE_SCORE_MONITORING_LOOP=false` in environment
+- `LANGFUSE_EVALUATORS` not configured or empty
+- Langfuse credentials invalid or missing
+- No actual failures in the time window
+
+**Solutions:**
+```bash
+# Verify configuration
+echo $ENABLE_SCORE_MONITORING_LOOP  # Should be "true"
+echo $LANGFUSE_EVALUATORS           # Should have evaluator names
+echo $LANGFUSE_SECRET_KEY           # Should be set
+echo $SLACK_WEBHOOK_URL             # Should be set
+
+# Check logs for initialization errors
+grep "Score monitoring will NOT start" logs/app.log
+grep "Langfuse credentials not found" logs/app.log
+```
+
+#### 2. Duplicate Alerts
+
+**Symptoms:**
+- Same failure generates multiple Slack messages
+- Log shows alerts sent but not skipped
+
+**Possible Causes:**
+- Redis not configured or unavailable
+- `call_sid` missing from trace metadata
+- Deduplication TTL expired (>60 minutes between checks)
+
+**Solutions:**
+```bash
+# Verify Redis configuration
+echo $REDIS_HOST  # Should be set
+echo $REDIS_PORT  # Should be set
+
+# Check Redis connectivity
+redis-cli -h $REDIS_HOST -p $REDIS_PORT ping
+
+# Verify trace metadata includes call_sid
+# Check Langfuse UI for trace structure
+```
+
+#### 3. Distributed Lock Conflicts
+
+**Symptoms:**
+- Log shows "Another pod is monitoring scores, skipping..."
+- Multiple pods trying to acquire lock simultaneously
+
+**Possible Causes:**
+- This is normal behavior in multi-pod deployments
+- Lock TTL too short (should match check interval)
+
+**Solutions:**
+- No action needed - this is expected behavior
+- Verify `SCORE_CHECK_INTERVAL_SECONDS` matches lock TTL (600 seconds)
+- Check that only one pod successfully processes scores per cycle
+
+#### 4. Langfuse API Errors
+
+**Symptoms:**
+- HTTP 401 Unauthorized errors
+- HTTP 429 Rate Limit errors
+- Connection timeouts
+
+**Possible Causes:**
+- Invalid or expired credentials
+- API rate limits exceeded
+- Network connectivity issues
+
+**Solutions:**
+```bash
+# Test Langfuse API manually
+curl -u "$LANGFUSE_PUBLIC_KEY:$LANGFUSE_SECRET_KEY" \
+  "$LANGFUSE_BASEURL/api/public/v2/scores?limit=1"
+
+# Verify credentials are correct
+# Check Langfuse dashboard for API key status
+# Reduce check frequency if hitting rate limits
+```
+
+#### 5. Slack Webhook Failures
+
+**Symptoms:**
+- Log shows "Failed to send Slack alert"
+- HTTP 404 or 500 errors from Slack
+
+**Possible Causes:**
+- Invalid webhook URL
+- Webhook deleted or disabled
+- Slack service outage
+
+**Solutions:**
+```bash
+# Test webhook manually
+curl -X POST $SLACK_WEBHOOK_URL \
+  -H 'Content-Type: application/json' \
+  -d '{"text":"Test message"}'
+
+# Verify webhook URL in Slack settings
+# Check Slack status page for outages
+```
+
+#### 6. Missing Scores in Time Window
+
+**Symptoms:**
+- Scores exist in Langfuse but not detected
+- Gaps in coverage despite overlapping windows
+
+**Possible Causes:**
+- Pod restarts during check cycle
+- Execution time longer than check interval
+- Time zone mismatch
+
+**Solutions:**
+- Check pod restart logs and timing
+- Verify `last_check_time` tracking is working
+- Ensure all timestamps use UTC
+- Review execution time vs check interval (should be <10 minutes)
+
+### Debug Mode
+
+To enable detailed logging for troubleshooting:
+
+```bash
+# Set log level to DEBUG
+export PROD_LOG_LEVEL=DEBUG
+
+# Restart application
+# Check logs for detailed API requests/responses
+grep "Fetching scores with params" logs/app.log
+grep "Response status" logs/app.log
+grep "Response body keys" logs/app.log
+```


### PR DESCRIPTION
- send alerts to slack for evaluation with low score
- add new evaluators using env
- added support for lifecycle task to automatically get scores every 10 mins
- added slack support to send alerts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Langfuse auto-evaluation and alerting: Monitor LLM-as-a-judge scores and receive Slack notifications when evaluations fail
  * Background task scheduler with distributed safety for multi-pod environments

* **Documentation**
  * Added comprehensive guide covering Langfuse auto-evaluation setup, monitoring, alerting, error handling, and troubleshooting

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->