### PR TITLE
Fix: Chart Instruction correction and search_web

### DIFF
--- a/app/agents/voice/automatic/prompts/system/charts.py
+++ b/app/agents/voice/automatic/prompts/system/charts.py
@@ -24,7 +24,7 @@ def get_chart_visualization_instructions() -> str:
         return f"""
     🔒 AUTOMATIC DATA VISUALIZATION (MANDATORY)
 
-    Absolute Law: Every single data response must have a chart — no exceptions.
+    Absolute Law: Analytics and metrics data responses must have a chart — configuration and management operations should not generate charts.
 
     RULE 1: MANDATORY SEQUENCE
         1. Receive analytics data
@@ -39,7 +39,7 @@ def get_chart_visualization_instructions() -> str:
     RULE 2: COVERAGE
         1. Multiple categories/percentages/time series → Donut, bar, or line chart
         2. Single numeric value (e.g., "₹12,000 sales today") → Single-stat chart
-        3. Absolutely no text-only responses without a chart
+        3. Analytics and metrics responses must include a chart; configuration and management operations may provide text-only responses
 
     RULE 3: PATTERN TRIGGERS
 
@@ -58,9 +58,10 @@ def get_chart_visualization_instructions() -> str:
         If you see componentType: 'LINE_CHART' → MANDATORY generate_line_chart call
 
     RULE 5: FLEXIBLE HANDLING
-        1. Always attempt a chart first
-        2. If chart generation fails or is not meaningful, provide a clear text response instead
-        3. Never leave the user without an answer
+        1. For analytics and metrics data, always attempt a chart first
+        2. For configuration and management operations, provide a clear text response without attempting chart generation
+        3. If chart generation fails or is not meaningful, provide a clear text response instead
+        4. Never leave the user without an answer
 
     RULE 6: CHART LIMIT PER USER TURN
         1. Only ONE chart is allowed per user interaction/turn

--- a/app/agents/voice/automatic/services/mcp/breeze_mcp_client.py
+++ b/app/agents/voice/automatic/services/mcp/breeze_mcp_client.py
@@ -8,6 +8,7 @@ from pipecat.services.mcp_service import MCPClient as PipecatMCPClient
 
 from app.agents.voice.automatic.services.mcp.utils import create_chart_aware_wrapper
 from app.agents.voice.automatic.tools import initialize_tools
+from app.agents.voice.automatic.tools.internet import tool_functions as internet_tool_functions
 from app.agents.voice.automatic.types import Mode
 from app.core.config.static import BREEZE_MCP_ENDPOINT_PATH, MCP_CLIENT_TIMEOUT
 from app.core.logger import logger
@@ -57,9 +58,15 @@ async def init_breeze_mcp_tools(
             )
 
         try:
+            # Pre-register search_web with the same chart-aware wrapper before MCP tools
+            if ENABLE_SEARCH_GROUNDING:
+                create_chart_aware_wrapper(original_register_function)("search_web", internet_tool_functions["search_web"])
+                logger.info("Pre-registered search_web with chart-aware wrapper")
+            
+            # Register MCP tools (which will use the same wrapper infrastructure)
             tools = await asyncio.wait_for(
                 mcp_client.register_tools(llm), timeout=MCP_CLIENT_TIMEOUT
-            )
+            )         
         finally:
             # Restore original register_function
             if original_register_function is not None:
@@ -70,6 +77,7 @@ async def init_breeze_mcp_tools(
             logger.info(
                 f"Successfully registered MCP tools via pure Pipecat MCP client"
             )
+            logger.info("search_web has been registered alongside MCP tools ")
         else:
             logger.warning(f"MCP client returned None or empty tools object")
 

--- a/app/agents/voice/automatic/tools/__init__.py
+++ b/app/agents/voice/automatic/tools/__init__.py
@@ -42,6 +42,8 @@ def initialize_tools(
     :param session_id: The client session ID for tool calls (now receives client_sid).
     :param merchant_id: The merchant ID, if available.
     :param user_id: The user ID, if available.
+    :param user_email: The user email, if available.
+    :param reseller_id: The reseller ID, if available.
     """
     providers = []
     if breeze_token:
@@ -59,7 +61,7 @@ def initialize_tools(
     all_tool_functions.update(system_tool_functions)
     logger.info(f"Loaded {len(system_tools.standard_tools)} system tools.")
 
-    # Internet tools are always available
+    # Internet tools are available when search grounding is enabled
     if ENABLE_SEARCH_GROUNDING:
         all_tools.extend(internet.tools.standard_tools)
         all_tool_functions.update(internet.tool_functions)


### PR DESCRIPTION
#### The chart visualization instructions were too broad, requiring charts for ALL data responses including configuration and management operations, which was causing unnecessary chart generation for non-analytical operations.
#### Essential registration fo search_web tool -> with both MCP tool and local tools
### Solution :
Updated the chart visualization logic to be more selective:

- __Modified chart instruction rule__: Changed from "Every single data response must have a chart" to "Analytics and metrics data responses must have a chart — configuration and management operations should not generate charts"
- __Scope refinement__: Charts are now only generated for actual analytics/metrics data, not for configuration or management operations

### 📁 __Files Changed__

- `app/agents/voice/automatic/prompts/system/charts.py` - Updated chart visualization instructions
- 'app/agents/voice/automatic/services/mcp/breeze_mcp_client.py' - search_web tool registration 




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced voice assistant to generate charts for analytics and metrics queries, while excluding chart generation for configuration and management operations for more appropriate responses.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->