### PR TITLE
Handling the cluster and single node for redis

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -193,3 +193,7 @@ REDIS_PORT=6379
 
 # Optional: For Redis cluster setup
 REDIS_CLUSTER_NODES=redis1:6379,redis2:6380,redis3:6381
+
+# Force cluster mode even with single node (use when REDIS_HOST points to a cluster node)
+# Set to "true" if your Redis is a cluster but you only have one endpoint
+REDIS_IS_CLUSTER=false

--- a/app/agents/voice/automatic/processors/llm_spy.py
+++ b/app/agents/voice/automatic/processors/llm_spy.py
@@ -227,7 +227,7 @@ class LLMSpyProcessor(FrameProcessor):
             if self._tracer:
                 # Use turn context directly for tool calls to be nested in turn span
                 turn_context = get_current_turn_context()
-                
+
                 span = self._tracer.start_span(
                     f"Tool: {frame.function_name}",
                     kind=trace.SpanKind.CLIENT,

--- a/app/api/routers/devcycle.py
+++ b/app/api/routers/devcycle.py
@@ -88,26 +88,25 @@ async def devcycle_webhook(
     try:
         # Fetch fresh configuration from DevCycle API and update store
         refresh_success = await fetch_and_update_feature_flags()
-        webhook_processing_time = time.time() - webhook_start_time
 
         if not refresh_success:
-            logger.error(
-                f"DevCycle webhook failed to refresh feature flags from {client_ip} "
-                f"in {webhook_processing_time*1000:.2f}ms"
+            logger.error("DevCycle webhook failed to refresh feature flags")
+            return JSONResponse(
+                status_code=500,
+                content={
+                    "status": "error",
+                    "message": "Failed to refresh feature flags",
+                },
             )
-        else:
-            # Extract webhook trigger info for logging
-            webhook_key = webhook_data.get("key", "unknown")
-            webhook_type = webhook_data.get("type", "unknown")
 
-            logger.info(
-                f"DevCycle webhook processed successfully: refreshed {await get_flag_count()} flags "
-                f"triggered by {webhook_type} event for {webhook_key} in {webhook_processing_time*1000:.2f}ms"
-            )
+        logger.info("DevCycle webhook processed successfully")
+        return JSONResponse(
+            status_code=200,
+            content={"status": "success", "message": "Feature flags updated"},
+        )
 
     except Exception as e:
-        webhook_processing_time = time.time() - webhook_start_time
-        logger.error(
-            f"Failed to process DevCycle webhook from {client_ip}: {e}. "
-            f"Processing time: {webhook_processing_time*1000:.2f}ms"
+        logger.error(f"Failed to process DevCycle webhook: {e}")
+        return JSONResponse(
+            status_code=500, content={"status": "error", "message": str(e)}
         )

--- a/app/core/config/dynamic.py
+++ b/app/core/config/dynamic.py
@@ -1,5 +1,8 @@
 from app.services.live_config.store import get_config
 
-# Smart Turn Configuration - These will be loaded lazily to avoid circular imports
+# automatic -smart turn
 ENABLE_FAL_SMART_TURN = get_config("ENABLE_FAL_SMART_TURN", False, bool)
+
+
+# automatic - mcp
 BREEZE_MCP_ENDPOINT_PATH = get_config("BREEZE_MCP_ENDPOINT_PATH", "/ai/neurolink", str)

--- a/app/core/config/static.py
+++ b/app/core/config/static.py
@@ -489,6 +489,9 @@ BOT_MAX_DRAIN_SECONDS = int(os.environ.get("BOT_MAX_DRAIN_SECONDS", "25"))
 REDIS_HOST = os.getenv("REDIS_HOST", "")
 REDIS_PORT = os.getenv("REDIS_PORT", "")
 REDIS_CLUSTER_NODES = os.getenv("REDIS_CLUSTER_NODES", "")
+REDIS_IS_CLUSTER = (
+    os.getenv("REDIS_IS_CLUSTER", "").lower() == "true"
+)  # Force cluster mode
 REDIS_TTL = int(os.getenv("REDIS_TTL", "3600"))  # Default TTL in seconds (1 hour)
 
 # DevCycle Configuration

--- a/app/services/live_config/store.py
+++ b/app/services/live_config/store.py
@@ -1,11 +1,6 @@
 """
 DevCycle Feature Flag Store with Redis
-
-Redis-based feature flag storage:
-1. One API call to DevCycle at startup
-2. Store all flags in Redis
-3. Fast Redis lookup for flag access
-4. Fallback: Redis -> environment -> default
+Cluster-safe, no pipelines, supports single node + cluster.
 """
 
 import asyncio
@@ -15,7 +10,6 @@ from typing import Any, Dict, Optional
 
 import aiohttp
 
-# Get basic environment variables directly (to avoid circular imports)
 from app.core.config.static import ENVIRONMENT
 from app.core.logger import logger
 from app.services.live_config.utils import (
@@ -31,16 +25,22 @@ from app.services.redis.client import get_redis_service
 FEATURE_FLAGS_PREFIX = "devcycle:flags:"
 DEVCYCLE_SERVER_KEY = os.getenv("DEVCYCLE_SERVER_KEY", "")
 
-# Global state
+# Init state
 _INITIALIZED = False
 
 
-async def process_feature_variables(
-    feature: dict, variable_mapping: Dict[str, Dict[str, str]], flag_setter_func
-) -> None:
-    """Extract and store variables from the primary variation of a feature."""
+# ---------------------------------------------------------------------------
+#  PROCESS INDIVIDUAL FEATURE VARIABLES
+# ---------------------------------------------------------------------------
 
-    # Get target distribution → find primary variation → exit early if any missing
+
+async def process_feature_variables(
+    feature: dict,
+    variable_mapping: Dict[str, Dict[str, str]],
+    setter,
+) -> None:
+    """Extract variables from the highest-percentage variation."""
+
     targets = feature.get("configuration", {}).get("targets") or []
     if not targets:
         return
@@ -49,330 +49,270 @@ async def process_feature_variables(
     if not distribution:
         return
 
-    # Find highest-percentage variation
-    primary_variation_id = max(distribution, key=lambda d: d.get("percentage", 0)).get(
+    # Highest weight variation
+    primary_var_id = max(distribution, key=lambda d: d.get("percentage", 0)).get(
         "_variation"
     )
-    if not primary_variation_id:
+    if not primary_var_id:
         return
 
-    # Get matching variation
+    # Find variation object
     variations = feature.get("variations") or []
-    primary_variation = next(
-        (v for v in variations if v.get("_id") == primary_variation_id), None
-    )
-    if not primary_variation:
+    primary = next((v for v in variations if v.get("_id") == primary_var_id), None)
+    if not primary:
         return
 
-    # Extract all variables
-    for var in primary_variation.get("variables") or []:
+    for var in primary.get("variables") or []:
         var_id = var.get("_var")
-        var_value = var.get("value")
         if not var_id or var_id not in variable_mapping:
             continue
 
         info = variable_mapping[var_id]
-        normalized_key = normalize_key(info["key"])
-        processed_value = process_devcycle_value(var_value, info["type"])
-        await flag_setter_func(normalized_key, processed_value)
+        key = normalize_key(info["key"])
+        processed_val = process_devcycle_value(var.get("value"), info["type"])
+
+        await setter(key, processed_val)
+
+
+# ---------------------------------------------------------------------------
+#  FETCH + UPDATE FLAGS
+# ---------------------------------------------------------------------------
 
 
 async def fetch_and_update_feature_flags() -> bool:
-    """Fetch DevCycle configuration and update Redis store with diff-based updates."""
+    """Fetch DevCycle config and update Redis (cluster safe)."""
+
     if not DEVCYCLE_SERVER_KEY:
-        logger.warning("DEVCYCLE_SERVER_KEY not configured")
+        logger.warning("DEVCYCLE_SERVER_KEY missing")
         return False
 
     url = f"https://config-cdn.devcycle.com/config/v1/server/{DEVCYCLE_SERVER_KEY}.json"
     timeout = aiohttp.ClientTimeout(total=30)
 
     try:
-        logger.debug(f"Fetching DevCycle config: {url}")
-
-        # ----- Fetch DevCycle JSON -----
         async with aiohttp.ClientSession(timeout=timeout) as session:
-            async with session.get(
-                url, headers={"Content-Type": "application/json"}
-            ) as resp:
+            async with session.get(url) as resp:
                 if resp.status != 200:
-                    logger.error(f"DevCycle CDN error: {resp.status}")
-                    logger.error(f"Response: {await resp.text()}")
+                    logger.error(
+                        f"DevCycle CDN error {resp.status}: {await resp.text()}"
+                    )
                     return False
                 data = await resp.json()
+        logger.debug("DevCycle config fetched successfully")
+        variables = data.get("variables") or []
+        features = data.get("features") or []
 
-        # ----- Validate Base Payload -----
-        if not isinstance(data, dict):
-            logger.error("DevCycle response is not a dictionary")
-            return False
-
-        # ----- Extract and Validate Variables & Features -----
-        variables = data.get("variables")
-        if not isinstance(variables, list):
-            logger.warning(
-                f"Invalid 'variables' format ({type(variables)}). Expected list."
-            )
-            variables = []
-
-        features = data.get("features")
-        if not isinstance(features, list):
-            logger.warning(
-                f"Invalid 'features' format ({type(features)}). Expected list."
-            )
-            features = []
-
-        # ----- EARLY EXIT — nothing to process -----
         if not variables or not features:
-            logger.info(
-                "No variables or features found. Skipping feature-flag processing."
-            )
+            logger.info("DevCycle response contains no features/variables")
             return False
-
-        # ----- Build New Flags -----
-        new_flags: dict[str, Any] = {}
-
         variable_map = build_variable_mapping(variables)
 
-        async def set_flag(key: str, value: Any) -> bool:
-            new_flags[key] = value
-            return True
+        new_flags: Dict[str, Any] = {}
 
-        for feature in features:
-            if isinstance(feature, dict) and "key" in feature:
-                await process_feature_variables(feature, variable_map, set_flag)
+        async def stash_flag(k, v):
+            new_flags[k] = v
 
-        # ----- Load Old Flags -----
+        for feat in features:
+            if isinstance(feat, dict):
+                await process_feature_variables(feat, variable_map, stash_flag)
+
+        # Load existing from Redis
         old_flags = await _get_all_flags_from_redis()
+        logger.debug(
+            f"Loaded {len(old_flags)} existing flags from Redis: {list(old_flags.keys())}"
+        )
+        logger.debug(
+            f"Built {len(new_flags)} new flags from DevCycle: {list(new_flags.keys())}"
+        )
 
+        # Detect differences
         old_keys = set(old_flags.keys())
         new_keys = set(new_flags.keys())
 
-        # Diff
-        keys_to_update = {
-            k for k in old_keys & new_keys if old_flags[k] != new_flags[k]
-        }
-        keys_to_add = new_keys - old_keys
-        keys_to_delete = old_keys - new_keys
+        to_add = new_keys - old_keys
+        to_delete = old_keys - new_keys
+        to_update = {k for k in old_keys & new_keys if old_flags[k] != new_flags[k]}
 
-        total_changes = len(keys_to_update) + len(keys_to_add) + len(keys_to_delete)
+        changes = len(to_add) + len(to_delete) + len(to_update)
 
-        # ----- Nothing Changed -----
-        if total_changes == 0:
-            logger.info(f"No flag changes detected ({len(new_flags)} total flags)")
+        if changes == 0:
+            logger.info("No DevCycle changes detected")
             return True
 
-        # ----- Apply Redis Updates -----
-        redis_service = await get_redis_service()
-        redis_client = await redis_service.get_client()
-        pipe = redis_client.pipeline(transaction=False)
+        redis = await get_redis_service()
+        client = await redis.get_client()
 
-        # Add/update
-        for key in keys_to_update | keys_to_add:
-            pipe.set(f"{FEATURE_FLAGS_PREFIX}{key}", json.dumps(new_flags[key]))
+        # ---- APPLY CHANGES (NO PIPELINE) ----
 
-        # Delete
-        for key in keys_to_delete:
-            pipe.delete(f"{FEATURE_FLAGS_PREFIX}{key}")
+        for key in to_add | to_update:
+            try:
+                await client.set(
+                    f"{FEATURE_FLAGS_PREFIX}{key}", json.dumps(new_flags[key])
+                )
+            except Exception as e:
+                logger.error(f"FAILED to SET key '{key}': {type(e).__name__}: {e}")
+                raise
 
-        await pipe.execute()
+        for key in to_delete:
+            try:
+                await client.delete(f"{FEATURE_FLAGS_PREFIX}{key}")
+            except Exception as e:
+                logger.error(f"FAILED to DELETE key '{key}': {type(e).__name__}: {e}")
+                raise
 
-        # ----- Log Summary -----
         logger.info(
-            f"DevCycle flags updated: old={len(old_flags)}, new={len(new_flags)}, "
-            f"updated={len(keys_to_update)}, added={len(keys_to_add)}, deleted={len(keys_to_delete)}"
+            f"DevCycle Flags Updated → added={len(to_add)}, "
+            f"updated={len(to_update)}, deleted={len(to_delete)}, total={len(new_flags)}"
         )
 
         return True
 
+    except aiohttp.ClientError as e:
+        logger.error(f"DevCycle HTTP request failed: {type(e).__name__}: {e}")
+        return False
     except Exception as e:
-        logger.exception(f"Error fetching DevCycle feature flags: {e}")
+        logger.error(f"DevCycle update failed at unknown step: {type(e).__name__}: {e}")
+        logger.exception("Full traceback:")
         return False
 
-    except aiohttp.ClientError as e:
-        logger.error(f"DevCycle API request failed: {e}")
-        return False
-    except Exception as e:
-        logger.error(f"DevCycle flag update failed: {e}")
-        return False
+
+# ---------------------------------------------------------------------------
+#  INITIALIZE
+# ---------------------------------------------------------------------------
 
 
 async def initialize_feature_flags() -> None:
-    """Initialize feature flag store from DevCycle API"""
     global _INITIALIZED
-
     if _INITIALIZED:
         return
 
-    # DevCycle can be used in any environment when server key is available
-    if not DEVCYCLE_SERVER_KEY:
-        logger.info(
-            f"DevCycle initialization skipped for environment: {ENVIRONMENT} (no server key)"
-        )
-        logger.info("Using environment variables only when DevCycle is not configured")
-        _INITIALIZED = True
-        return
-
-    logger.info("Initializing DevCycle feature flags...")
+    logger.info("Initializing DevCycle feature flags…")
 
     try:
-        if not DEVCYCLE_SERVER_KEY:
-            logger.info(
-                "No DEVCYCLE_SERVER_KEY found, using environment variables only"
-            )
-        else:
-            success = await fetch_and_update_feature_flags()
-            if success:
-                flag_count = await get_flag_count()
-                store = await get_all_flags()
-                logger.info(f"DevCycle initialized with {flag_count} feature flags")
-                logger.info(f"Store: {store}")
+        if DEVCYCLE_SERVER_KEY:
+            response = await fetch_and_update_feature_flags()
+            if response:
+                logger.info(
+                    f"DevCycle initialized successfully ({await get_flag_count()} flags)"
+                )
             else:
                 logger.error(
-                    "DevCycle initialization failed, using environment variables only"
+                    "DevCycle init failed → falling back to environment variables"
                 )
-
+        else:
+            logger.info("DevCycle disabled (no server key)")
     except Exception as e:
-        logger.error(f"Feature flag initialization failed: {e}")
+        logger.error(f"DevCycle init error: {e}")
 
     _INITIALIZED = True
-    flag_count = await get_flag_count()
-    logger.info(f"Feature flag initialization completed ({flag_count} flags)")
 
 
-async def get_all_flags() -> Dict[str, Any]:
-    """Get all loaded feature flags"""
-    return await _get_all_flags_from_redis()
+# ---------------------------------------------------------------------------
+#  PUBLIC GETTERS
+# ---------------------------------------------------------------------------
 
 
 def is_initialized() -> bool:
-    """Check if feature flags have been initialized"""
     return _INITIALIZED
 
 
 async def get_flag_count() -> int:
-    """Get number of loaded flags"""
-    flags = await _get_all_flags_from_redis()
-    return len(flags)
+    return len(await _get_all_flags_from_redis())
+
+
+async def get_all_flags() -> Dict[str, Any]:
+    return await _get_all_flags_from_redis()
 
 
 async def get_config(key: str, default_value: Any, return_type: type = str) -> Any:
-    """Unified configuration getter with feature flag -> env var -> default fallback"""
-    try:
-        # Only attempt Redis lookup if DevCycle is initialized
-        if not _INITIALIZED:
-            env_result = get_env_value(key, return_type)
-            return env_result if env_result is not None else default_value
+    """Unified: Redis → Environment → Default"""
 
-        # Try Redis lookup using existing service
-        flag_value = await _get_flag_from_redis(key)
-        if flag_value is not None:
-            converted = convert_type(flag_value, return_type)
-            if converted is not None:
-                return converted
-    except Exception as e:
-        logger.debug(f"Redis lookup failed for {key}, using env fallback: {e}")
+    if _INITIALIZED:
+        try:
+            val = await _get_flag_from_redis(key)
+            if val is not None:
+                converted = convert_type(val, return_type)
+                if converted is not None:
+                    return converted
+        except Exception:
+            pass
 
-    # Fallback to environment variables
-    env_result = get_env_value(key, return_type)
-    return env_result if env_result is not None else default_value
+    env_val = get_env_value(key, return_type)
+    return env_val if env_val is not None else default_value
+
+
+# ---------------------------------------------------------------------------
+#  REDIS OPERATIONS (CLUSTER SAFE)
+# ---------------------------------------------------------------------------
 
 
 async def _get_flag_from_redis(key: str) -> Optional[Any]:
-    """Get a single feature flag from Redis"""
     try:
-        redis_service = await get_redis_service()
-        if not redis_service:
-            return None
-        value_str = await redis_service.get(f"{FEATURE_FLAGS_PREFIX}{key}")
-        return json.loads(value_str) if value_str else None
+        redis = await get_redis_service()
+        client = await redis.get_client()
+
+        raw = await client.get(f"{FEATURE_FLAGS_PREFIX}{key}")
+        return json.loads(raw) if raw else None
     except Exception as e:
-        logger.error(f"Error getting flag {key} from Redis: {e}")
+        logger.error(f"Redis get error for {key}: {e}")
         return None
 
 
-async def _set_flag_in_redis(key: str, value: Any) -> bool:
-    """Set a feature flag in Redis"""
-    try:
-        redis_service = await get_redis_service()
-        if not redis_service:
-            return False
-        return await redis_service.set(
-            f"{FEATURE_FLAGS_PREFIX}{key}", json.dumps(value)
-        )
-    except Exception as e:
-        logger.error(f"Error setting flag {key} in Redis: {e}")
-        return False
-
-
-async def _delete_flag_from_redis(key: str) -> bool:
-    """Delete a feature flag from Redis"""
-    try:
-        redis_service = await get_redis_service()
-        if not redis_service:
-            return False
-
-        redis_client = await redis_service.get_client()
-        await redis_client.delete(f"{FEATURE_FLAGS_PREFIX}{key}")
-        return True
-    except Exception as e:
-        logger.error(f"Error deleting flag {key} from Redis: {e}")
-        return False
-
-
 async def _get_all_flags_from_redis() -> Dict[str, Any]:
-    """Get all feature flags from Redis"""
+    """Load all flags from cluster (iterate all nodes for KEYS)."""
     try:
-        redis_service = await get_redis_service()
-        if not redis_service:
-            return {}
+        redis = await get_redis_service()
+        client = await redis.get_client()
 
-        redis_client = await redis_service.get_client()
+        # For cluster mode, KEYS only returns keys from one node
+        # We need to scan all nodes
+        all_keys = set()
 
-        keys = await redis_client.keys(f"{FEATURE_FLAGS_PREFIX}*")
-        if not keys:
-            return {}
+        # Check if this is a cluster client
+        if hasattr(client, "get_nodes"):
+            # Cluster mode: query each node individually using execute_command
+            nodes = client.get_nodes()
+            logger.debug(f"Scanning {len(nodes)} cluster nodes for keys...")
 
-        values = await redis_client.mget(keys)
-        result = {}
-
-        for key, value in zip(keys, values):
-            if value:
-                flag_key = key.replace(FEATURE_FLAGS_PREFIX, "")
+            for node in nodes:
                 try:
-                    result[flag_key] = json.loads(value)
-                except json.JSONDecodeError:
-                    logger.error(f"Error parsing flag value for {flag_key}")
+                    # Execute KEYS command on specific node
+                    node_keys = await client.execute_command(
+                        "KEYS", f"{FEATURE_FLAGS_PREFIX}*", target_nodes=[node]
+                    )
+                    if node_keys:
+                        all_keys.update(node_keys)
+                        logger.debug(
+                            f"Found {len(node_keys)} keys on node {node.host}:{node.port}"
+                        )
+                except Exception as e:
+                    logger.warning(f"Failed to scan node {node.host}:{node.port}: {e}")
+                    continue
+        else:
+            # Single node mode
+            all_keys = set(await client.keys(f"{FEATURE_FLAGS_PREFIX}*"))
 
-        return result
+        logger.debug(f"Total keys found across cluster: {len(all_keys)}")
+
+        if not all_keys:
+            return {}
+
+        # Fetch each key individually (cluster-safe)
+        flags = {}
+        for key in all_keys:
+            try:
+                val = await client.get(key)
+                if val:
+                    clean = key.replace(FEATURE_FLAGS_PREFIX, "")
+                    flags[clean] = json.loads(val)
+            except json.JSONDecodeError:
+                logger.error(f"Invalid JSON for flag {key}")
+            except Exception as e:
+                logger.warning(f"Failed to get key {key}: {e}")
+                continue
+
+        return flags
+
     except Exception as e:
-        logger.error(f"Error getting all flags from Redis: {e}")
+        logger.error(f"Error loading all flags: {e}")
         return {}
-
-
-async def _clear_all_flags_in_redis() -> bool:
-    """Clear all feature flags from Redis"""
-    try:
-        redis_service = await get_redis_service()
-        if not redis_service:
-            return False
-
-        redis_client = await redis_service.get_client()
-
-        keys = await redis_client.keys(f"{FEATURE_FLAGS_PREFIX}*")
-        if keys:
-            await redis_client.delete(*keys)
-        return True
-    except Exception as e:
-        logger.error(f"Error clearing flags from Redis: {e}")
-        return False
-
-
-async def _restore_flags_to_redis(flags: Dict[str, Any]) -> bool:
-    """Restore flags to Redis (rollback on failure)"""
-    try:
-        await _clear_all_flags_in_redis()
-        for key, value in flags.items():
-            await _set_flag_in_redis(key, value)
-        return True
-    except Exception as e:
-        logger.error(f"Error restoring flags to Redis: {e}")
-        return False

--- a/app/services/live_config/store.py
+++ b/app/services/live_config/store.py
@@ -22,7 +22,8 @@ from app.services.live_config.utils import (
     build_variable_mapping,
     convert_type,
     get_env_value,
-    process_feature_variables,
+    normalize_key,
+    process_devcycle_value,
 )
 from app.services.redis.client import get_redis_service
 
@@ -34,77 +35,163 @@ DEVCYCLE_SERVER_KEY = os.getenv("DEVCYCLE_SERVER_KEY", "")
 _INITIALIZED = False
 
 
+async def process_feature_variables(
+    feature: dict, variable_mapping: Dict[str, Dict[str, str]], flag_setter_func
+) -> None:
+    """Extract and store variables from the primary variation of a feature."""
+
+    # Get target distribution → find primary variation → exit early if any missing
+    targets = feature.get("configuration", {}).get("targets") or []
+    if not targets:
+        return
+
+    distribution = targets[0].get("distribution") or []
+    if not distribution:
+        return
+
+    # Find highest-percentage variation
+    primary_variation_id = max(distribution, key=lambda d: d.get("percentage", 0)).get(
+        "_variation"
+    )
+    if not primary_variation_id:
+        return
+
+    # Get matching variation
+    variations = feature.get("variations") or []
+    primary_variation = next(
+        (v for v in variations if v.get("_id") == primary_variation_id), None
+    )
+    if not primary_variation:
+        return
+
+    # Extract all variables
+    for var in primary_variation.get("variables") or []:
+        var_id = var.get("_var")
+        var_value = var.get("value")
+        if not var_id or var_id not in variable_mapping:
+            continue
+
+        info = variable_mapping[var_id]
+        normalized_key = normalize_key(info["key"])
+        processed_value = process_devcycle_value(var_value, info["type"])
+        await flag_setter_func(normalized_key, processed_value)
+
+
 async def fetch_and_update_feature_flags() -> bool:
-    """Fetch DevCycle configuration and update Redis store"""
+    """Fetch DevCycle configuration and update Redis store with diff-based updates."""
     if not DEVCYCLE_SERVER_KEY:
         logger.warning("DEVCYCLE_SERVER_KEY not configured")
         return False
 
+    url = f"https://config-cdn.devcycle.com/config/v1/server/{DEVCYCLE_SERVER_KEY}.json"
+    timeout = aiohttp.ClientTimeout(total=30)
+
     try:
-        # Fetch DevCycle configuration
-        url = f"https://config-cdn.devcycle.com/config/v1/server/{DEVCYCLE_SERVER_KEY}.json"
-        timeout = aiohttp.ClientTimeout(total=10)
+        logger.debug(f"Fetching DevCycle config: {url}")
 
-        logger.debug(f"Fetching DevCycle config from: {url}")
-
+        # ----- Fetch DevCycle JSON -----
         async with aiohttp.ClientSession(timeout=timeout) as session:
             async with session.get(
                 url, headers={"Content-Type": "application/json"}
-            ) as response:
-                if response.status != 200:
-                    logger.error(f"DevCycle CDN failed: {response.status}")
-                    logger.error(f"Response: {await response.text()}")
+            ) as resp:
+                if resp.status != 200:
+                    logger.error(f"DevCycle CDN error: {resp.status}")
+                    logger.error(f"Response: {await resp.text()}")
                     return False
+                data = await resp.json()
 
-                try:
-                    data = await response.json()
-                except json.JSONDecodeError as e:
-                    logger.error(f"Failed to parse DevCycle response: {e}")
-                    return False
+        # ----- Validate Base Payload -----
+        if not isinstance(data, dict):
+            logger.error("DevCycle response is not a dictionary")
+            return False
 
-        # Store old flags for comparison and clear existing
+        # ----- Extract and Validate Variables & Features -----
+        variables = data.get("variables")
+        if not isinstance(variables, list):
+            logger.warning(
+                f"Invalid 'variables' format ({type(variables)}). Expected list."
+            )
+            variables = []
+
+        features = data.get("features")
+        if not isinstance(features, list):
+            logger.warning(
+                f"Invalid 'features' format ({type(features)}). Expected list."
+            )
+            features = []
+
+        # ----- EARLY EXIT — nothing to process -----
+        if not variables or not features:
+            logger.info(
+                "No variables or features found. Skipping feature-flag processing."
+            )
+            return False
+
+        # ----- Build New Flags -----
+        new_flags: dict[str, Any] = {}
+
+        variable_map = build_variable_mapping(variables)
+
+        async def set_flag(key: str, value: Any) -> bool:
+            new_flags[key] = value
+            return True
+
+        for feature in features:
+            if isinstance(feature, dict) and "key" in feature:
+                await process_feature_variables(feature, variable_map, set_flag)
+
+        # ----- Load Old Flags -----
         old_flags = await _get_all_flags_from_redis()
-        await _clear_all_flags_in_redis()
 
-        # Process DevCycle data
-        variables = data.get("variables", [])
-        features = data.get("features", [])
+        old_keys = set(old_flags.keys())
+        new_keys = set(new_flags.keys())
 
-        if isinstance(variables, list) and isinstance(features, list):
-            variable_mapping = build_variable_mapping(variables)
+        # Diff
+        keys_to_update = {
+            k for k in old_keys & new_keys if old_flags[k] != new_flags[k]
+        }
+        keys_to_add = new_keys - old_keys
+        keys_to_delete = old_keys - new_keys
 
-            for feature in features:
-                if isinstance(feature, dict) and "key" in feature:
-                    await process_feature_variables(
-                        feature, variable_mapping, _set_flag_in_redis
-                    )
+        total_changes = len(keys_to_update) + len(keys_to_add) + len(keys_to_delete)
 
-        # Log changes
-        new_flags = await _get_all_flags_from_redis()
-        logger.info(f"DevCycle flags updated: {len(old_flags)} -> {len(new_flags)}")
+        # ----- Nothing Changed -----
+        if total_changes == 0:
+            logger.info(f"No flag changes detected ({len(new_flags)} total flags)")
+            return True
 
-        changes = [
-            f"{k}: {old_flags.get(k)} -> {v}"
-            for k, v in new_flags.items()
-            if old_flags.get(k) != v
-        ]
+        # ----- Apply Redis Updates -----
+        redis_service = await get_redis_service()
+        redis_client = await redis_service.get_client()
+        pipe = redis_client.pipeline(transaction=False)
 
-        if changes:
-            logger.info(f"Changes: {changes}")
-        else:
-            logger.info("No flag value changes")
+        # Add/update
+        for key in keys_to_update | keys_to_add:
+            pipe.set(f"{FEATURE_FLAGS_PREFIX}{key}", json.dumps(new_flags[key]))
+
+        # Delete
+        for key in keys_to_delete:
+            pipe.delete(f"{FEATURE_FLAGS_PREFIX}{key}")
+
+        await pipe.execute()
+
+        # ----- Log Summary -----
+        logger.info(
+            f"DevCycle flags updated: old={len(old_flags)}, new={len(new_flags)}, "
+            f"updated={len(keys_to_update)}, added={len(keys_to_add)}, deleted={len(keys_to_delete)}"
+        )
 
         return True
 
+    except Exception as e:
+        logger.exception(f"Error fetching DevCycle feature flags: {e}")
+        return False
+
     except aiohttp.ClientError as e:
         logger.error(f"DevCycle API request failed: {e}")
-        if "old_flags" in locals():
-            await _restore_flags_to_redis(old_flags)
         return False
     except Exception as e:
         logger.error(f"DevCycle flag update failed: {e}")
-        if "old_flags" in locals():
-            await _restore_flags_to_redis(old_flags)
         return False
 
 
@@ -213,6 +300,21 @@ async def _set_flag_in_redis(key: str, value: Any) -> bool:
         )
     except Exception as e:
         logger.error(f"Error setting flag {key} in Redis: {e}")
+        return False
+
+
+async def _delete_flag_from_redis(key: str) -> bool:
+    """Delete a feature flag from Redis"""
+    try:
+        redis_service = await get_redis_service()
+        if not redis_service:
+            return False
+
+        redis_client = await redis_service.get_client()
+        await redis_client.delete(f"{FEATURE_FLAGS_PREFIX}{key}")
+        return True
+    except Exception as e:
+        logger.error(f"Error deleting flag {key} from Redis: {e}")
         return False
 
 

--- a/app/services/live_config/utils.py
+++ b/app/services/live_config/utils.py
@@ -68,39 +68,3 @@ def build_variable_mapping(variables: list) -> Dict[str, Dict[str, str]]:
                 "type": variable.get("type", "String"),
             }
     return mapping
-
-
-async def process_feature_variables(
-    feature: dict, variable_mapping: Dict[str, Dict[str, str]], flag_setter_func
-) -> None:
-    """Process and store variables from a feature"""
-    targets = feature.get("configuration", {}).get("targets", [])
-    if not targets:
-        return
-
-    # Find primary variation (highest percentage)
-    distribution = targets[0].get("distribution", [])
-    if not distribution:
-        return
-
-    primary_variation_id = max(distribution, key=lambda d: d.get("percentage", 0)).get(
-        "_variation"
-    )
-    if not primary_variation_id:
-        return
-
-    # Process variables in primary variation
-    for variation in feature.get("variations", []):
-        if variation.get("_id") == primary_variation_id:
-            for var in variation.get("variables", []):
-                var_id = var.get("_var")
-                var_value = var.get("value")
-
-                if var_id in variable_mapping:
-                    var_info = variable_mapping[var_id]
-                    normalized_key = normalize_key(var_info["key"])
-                    processed_value = process_devcycle_value(
-                        var_value, var_info["type"]
-                    )
-                    await flag_setter_func(normalized_key, processed_value)
-            break

--- a/app/services/redis/client.py
+++ b/app/services/redis/client.py
@@ -8,13 +8,14 @@ import os
 from typing import Any, Dict, List, Optional
 
 from redis.asyncio import Redis
-from redis.asyncio.cluster import RedisCluster
+from redis.asyncio.cluster import ClusterNode, RedisCluster
 from redis.exceptions import ConnectionError as RedisConnectionError
 from redis.exceptions import RedisError
 
 from app.core.config.static import (
     REDIS_CLUSTER_NODES,
     REDIS_HOST,
+    REDIS_IS_CLUSTER,
     REDIS_PORT,
     REDIS_TTL,
 )
@@ -58,10 +59,35 @@ class RedisFactory:
         try:
             startup_nodes = self._get_startup_nodes()
 
-            # Single node - use Redis client
-            if len(startup_nodes) == 1:
+            # Determine if we should use cluster mode
+            # Use cluster if: explicitly set OR multiple nodes configured
+            use_cluster = REDIS_IS_CLUSTER or len(startup_nodes) > 1
+
+            if use_cluster:
+                # CLUSTER MODE
+                logger.info(f"Creating Redis CLUSTER with {len(startup_nodes)} node(s)")
+
+                # Convert dict nodes to ClusterNode objects
+                cluster_nodes = [
+                    ClusterNode(host=node["host"], port=node["port"])
+                    for node in startup_nodes
+                ]
+
+                self._cluster_client = RedisCluster(
+                    startup_nodes=cluster_nodes,
+                    decode_responses=True,  # Decode bytes to strings automatically
+                )
+
+                # Test connection
+                await self._cluster_client.ping()
+                logger.info("Redis cluster connection established")
+
+            else:
+                # SINGLE NODE MODE
                 node = startup_nodes[0]
-                logger.info(f"Creating Redis client: {node['host']}:{node['port']}")
+                logger.info(
+                    f"Creating Redis SINGLE NODE client: {node['host']}:{node['port']}"
+                )
 
                 self._single_client = Redis(
                     host=node["host"],
@@ -71,20 +97,7 @@ class RedisFactory:
 
                 # Test connection
                 await self._single_client.ping()
-                logger.info("Redis connection established")
-
-            # Multiple nodes - use Redis cluster
-            else:
-                logger.info(f"Creating Redis cluster with {len(startup_nodes)} nodes")
-
-                self._cluster_client = RedisCluster(
-                    startup_nodes=startup_nodes,
-                    decode_responses=True,  # Decode bytes to strings automatically
-                )
-
-                # Test connection
-                await self._cluster_client.ping()
-                logger.info("Redis cluster connection established")
+                logger.info("Redis single-node connection established")
 
         except Exception as e:
             logger.error(f"Failed to create Redis client: {e}")


### PR DESCRIPTION
  1. Single endpoint assumption bug - Code assumed single host:port meant standalone Redis, but production had a cluster behind single endpoint
  2. MOVED redirect errors - Keys were failing with "MOVED 6090 127.0.0.1:7001" because single-node client couldn't handle cluster redirects
  3. ClusterNode type mismatch - RedisCluster expected ClusterNode objects but we were passing dictionaries, causing "'dict' object has no attribute 'host'"
  4. MGET fails across cluster nodes - Batch GET operations failed when keys were on different cluster nodes/slots
  5. KEYS command only scans one node - In cluster mode, KEYS pattern only returned keys from current node, not all nodes, breaking our diff logic
  6. Cluster topology not auto-discovered - Client wasn't discovering all cluster nodes, causing routing failures
  7. Broad error handling masked root cause - Generic exception handling made it impossible to identify which operation was failing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Redis cluster mode support with automatic detection and configuration options.
  * Introduced configurable MCP endpoint path for advanced system integration.

* **Chores**
  * Improved feature flag management to support distributed environments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->