### PR TITLE
handling the single and cluster node redis implementation

### DIFF
--- a/app/api/routers/systems.py
+++ b/app/api/routers/systems.py
@@ -1,0 +1,187 @@
+"""
+System Health Check Router
+
+Endpoints for monitoring system health including Redis connectivity.
+"""
+
+import time
+from typing import Any, Dict
+
+from fastapi import APIRouter
+from fastapi.responses import JSONResponse
+
+from app.core.logger import logger
+from app.database import get_db_connection
+from app.services.redis.client import get_redis_service
+
+router = APIRouter()
+
+
+@router.get("/health/redis")
+async def redis_health_check():
+    """
+    Redis health check - tests PING, SET, GET, DELETE operations.
+    """
+    health_status = {
+        "status": "healthy",
+        "timestamp": time.time(),
+        "checks": {},
+        "cluster_info": None,
+    }
+
+    test_key = "health:check:test"
+    test_value = f"test-{int(time.time())}"
+
+    try:
+        redis_service = await get_redis_service()
+        client = await redis_service.get_client()
+
+        # Check 1: PING
+        try:
+            start = time.time()
+            await client.ping()
+            health_status["checks"]["ping"] = {
+                "status": "ok",
+                "latency_ms": round((time.time() - start) * 1000, 2),
+            }
+        except Exception as e:
+            health_status["status"] = "unhealthy"
+            health_status["checks"]["ping"] = {"status": "failed", "error": str(e)}
+            raise
+
+        # Check 2: SET
+        try:
+            start = time.time()
+            await client.set(test_key, test_value)
+            health_status["checks"]["set"] = {
+                "status": "ok",
+                "latency_ms": round((time.time() - start) * 1000, 2),
+            }
+        except Exception as e:
+            health_status["status"] = "unhealthy"
+            health_status["checks"]["set"] = {"status": "failed", "error": str(e)}
+            raise
+
+        # Check 3: GET
+        try:
+            start = time.time()
+            retrieved_value = await client.get(test_key)
+            latency = round((time.time() - start) * 1000, 2)
+
+            if retrieved_value == test_value:
+                health_status["checks"]["get"] = {
+                    "status": "ok",
+                    "latency_ms": latency,
+                    "value_match": True,
+                }
+            else:
+                health_status["status"] = "degraded"
+                health_status["checks"]["get"] = {
+                    "status": "warning",
+                    "latency_ms": latency,
+                    "value_match": False,
+                    "expected": test_value,
+                    "actual": retrieved_value,
+                }
+        except Exception as e:
+            health_status["status"] = "unhealthy"
+            health_status["checks"]["get"] = {"status": "failed", "error": str(e)}
+            raise
+
+        # Check 4: DELETE
+        try:
+            start = time.time()
+            deleted_count = await client.delete(test_key)
+            health_status["checks"]["delete"] = {
+                "status": "ok",
+                "latency_ms": round((time.time() - start) * 1000, 2),
+                "keys_deleted": deleted_count,
+            }
+        except Exception as e:
+            health_status["status"] = "unhealthy"
+            health_status["checks"]["delete"] = {"status": "failed", "error": str(e)}
+
+        # Check 5: Cluster Info
+        if hasattr(client, "get_nodes"):
+            try:
+                nodes = client.get_nodes()
+                health_status["cluster_info"] = {
+                    "mode": "cluster",
+                    "node_count": len(nodes),
+                    "nodes": [
+                        {
+                            "host": node.host,
+                            "port": node.port,
+                            "name": (
+                                node.name
+                                if hasattr(node, "name")
+                                else f"{node.host}:{node.port}"
+                            ),
+                        }
+                        for node in nodes
+                    ],
+                }
+            except Exception as e:
+                health_status["cluster_info"] = {"mode": "cluster", "error": str(e)}
+        else:
+            health_status["cluster_info"] = {"mode": "single-node"}
+
+        status_code = 200 if health_status["status"] != "unhealthy" else 503
+        return JSONResponse(status_code=status_code, content=health_status)
+
+    except Exception as e:
+        logger.error(f"Redis health check failed: {e}")
+        health_status["status"] = "unhealthy"
+        health_status["error"] = str(e)
+        return JSONResponse(status_code=503, content=health_status)
+
+
+@router.get("/health")
+async def health_check():
+    """Basic health check endpoint."""
+    logger.info("Health check endpoint called")
+    return JSONResponse({"status": "healthy"})
+
+
+@router.get("/health/database")
+async def database_health_check():
+    """Check database connectivity and health."""
+    logger.info("Database health check endpoint called")
+    try:
+        async for conn in get_db_connection():
+            result = await conn.fetchval("SELECT 1")
+            if result == 1:
+                return JSONResponse(
+                    {
+                        "status": "healthy",
+                        "database": "connected",
+                        "message": "Database connection is healthy",
+                    }
+                )
+            else:
+                return JSONResponse(
+                    status_code=400,
+                    content={
+                        "status": "unhealthy",
+                        "database": "error",
+                        "message": "Database query returned unexpected result",
+                    },
+                )
+    except Exception as e:
+        logger.error(f"Database health check failed: {e}")
+        return JSONResponse(
+            status_code=400,
+            content={
+                "status": "unhealthy",
+                "database": "disconnected",
+                "message": f"Database connection failed: {str(e)}",
+            },
+        )
+
+
+@router.get("/version")
+async def get_version():
+    """Get application version."""
+    from app import __version__
+
+    return JSONResponse({"version": __version__})

--- a/app/core/config/dynamic.py
+++ b/app/core/config/dynamic.py
@@ -1,8 +1,20 @@
 from app.services.live_config.store import get_config
 
-# automatic -smart turn
-ENABLE_FAL_SMART_TURN = get_config("ENABLE_FAL_SMART_TURN", False, bool)
+# -----------------------
+# Dynamic runtime configs
+# -----------------------
 
 
-# automatic - mcp
-BREEZE_MCP_ENDPOINT_PATH = get_config("BREEZE_MCP_ENDPOINT_PATH", "/ai/neurolink", str)
+async def ENABLE_FAL_SMART_TURN() -> bool:
+    """Returns ENABLE_FAL_SMART_TURN from Redis"""
+    return await get_config("ENABLE_FAL_SMART_TURN", False, bool)
+
+
+async def BREEZE_MCP_ENDPOINT_PATH() -> str:
+    """Returns BREEZE_MCP_ENDPOINT_PATH from Redis"""
+    return await get_config("BREEZE_MCP_ENDPOINT_PATH", "/ai/neurolink", str)
+
+
+async def ENABLE_BACKGROUND_TASKS() -> bool:
+    """Returns ENABLE_BACKGROUND_TASKS from Redis"""
+    return await get_config("ENABLE_BACKGROUND_TASKS", "false", bool)

--- a/app/core/config/static.py
+++ b/app/core/config/static.py
@@ -496,10 +496,6 @@ LANGFUSE_EVALUATORS = [
 SLACK_WEBHOOK_URL = os.environ.get("SLACK_WEBHOOK_URL", "")
 SLACK_TAG_USERS = os.environ.get("SLACK_TAG_USERS", "narsimha.reddy")
 
-# Background Tasks Configuration
-ENABLE_BACKGROUND_TASKS = (
-    os.environ.get("ENABLE_BACKGROUND_TASKS", "false").lower() == "true"
-)
 BACKGROUND_TASKS_LOOP_INTERVAL_SECONDS = int(
     os.environ.get("BACKGROUND_TASKS_LOOP_INTERVAL_SECONDS", "60")
 )  # How often the scheduler checks tasks (in seconds)

--- a/app/main.py
+++ b/app/main.py
@@ -16,10 +16,11 @@ from fastapi.staticfiles import StaticFiles
 from pipecat.transports.daily.utils import DailyRESTHelper
 
 from app import __version__
-from app.api.routers import automatic, breeze_buddy, devcycle
+from app.api.routers import automatic, breeze_buddy, devcycle, systems
 
 # Import background task scheduler
 from app.core.background_tasks import BackgroundTaskScheduler
+from app.core.config.dynamic import ENABLE_BACKGROUND_TASKS
 from app.core.config.static import (
     BACKGROUND_TASKS_LOOP_INTERVAL_SECONDS,
     BOT_MAX_DRAIN_SECONDS,
@@ -28,7 +29,6 @@ from app.core.config.static import (
     DAILY_ROOM_MAX_POOL_SIZE,
     DAILY_ROOM_POOL_SIZE,
     ENABLE_AUTOMATIC_DAILY_RECORDING,
-    ENABLE_BACKGROUND_TASKS,
     ENABLE_SIGTERM_HANDLER,
     HOST,
     MAX_DAILY_SESSION_LIMIT,
@@ -100,12 +100,18 @@ async def lifespan(_app: FastAPI):
     try:
         if is_redis_configured():
             redis_service = await get_redis_service()
-            await redis_service.ping()  # Test the connection
+            await redis_service.get_client()  # Initialize the client
             logger.info("Redis client initialized successfully")
         else:
             logger.info("Redis not configured - skipping Redis initialization")
     except Exception as e:
         logger.error(f"Failed to initialize Redis client: {e}")
+
+    # DevCycle feature flags are initialized by parent process (run.py) before uvicorn starts
+    # Worker processes only need to read from Redis using get_config()
+    logger.info(
+        "Worker process: DevCycle flags pre-loaded by parent process, reading from Redis"
+    )
 
     # Initialize aiohttp session with proxy support for Daily API
     aiohttp_session = create_aiohttp_session()
@@ -149,7 +155,7 @@ async def lifespan(_app: FastAPI):
 
     # Start background task scheduler if enabled
     global _background_scheduler
-    if ENABLE_BACKGROUND_TASKS:
+    if await ENABLE_BACKGROUND_TASKS():
         try:
             # Create scheduler instance with configurable loop interval
             _background_scheduler = BackgroundTaskScheduler(
@@ -229,6 +235,9 @@ app.include_router(
     automatic.router, prefix="/agent/voice/automatic", tags=["Automatic Agent"]
 )
 app.include_router(devcycle.router, prefix="", tags=["DevCycle"])
+
+# System health endpoints
+app.include_router(systems.router, prefix="", tags=["Systems"])
 
 
 # Pipecat bot endpoint
@@ -397,57 +406,6 @@ async def bot_connect(
 @app.get("/")
 async def get_client_html():
     return FileResponse("static/home.html")
-
-
-# Health check endpoint
-@app.get("/health")
-async def health_check():
-    logger.info("Health check endpoint called")
-    return JSONResponse({"status": "healthy"})
-
-
-# Database health check endpoint
-@app.get("/health/database")
-async def database_health_check():
-    """Check database connectivity and health."""
-    logger.info("Database health check endpoint called")
-    try:
-        async for conn in get_db_connection():
-            result = await conn.fetchval("SELECT 1")
-            if result == 1:
-                return JSONResponse(
-                    {
-                        "status": "healthy",
-                        "database": "connected",
-                        "message": "Database connection is healthy",
-                    }
-                )
-            else:
-                return JSONResponse(
-                    status_code=400,
-                    content={
-                        "status": "unhealthy",
-                        "database": "error",
-                        "message": "Database query returned unexpected result",
-                    },
-                )
-    except Exception as e:
-        logger.error(f"Database health check failed: {e}")
-        return JSONResponse(
-            status_code=400,
-            content={
-                "status": "unhealthy",
-                "database": "disconnected",
-                "message": f"Database connection failed: {str(e)}",
-            },
-        )
-
-
-# Version endpoint
-@app.get("/version")
-async def get_version():
-    """Get application version."""
-    return JSONResponse({"version": __version__})
 
 
 # Drain endpoint for Kubernetes preStop hook

--- a/app/services/live_config/store.py
+++ b/app/services/live_config/store.py
@@ -26,18 +26,24 @@ from app.services.live_config.utils import (
 from app.services.redis.client import get_redis_service
 
 # Constants
-FEATURE_FLAGS_PREFIX = "devcycle:flags:"
+FEATURE_FLAGS_KEY = "devcycle:flags"
 
-# Global state
+# Init state
 _INITIALIZED = False
 
 
-async def process_feature_variables(
-    feature: dict, variable_mapping: Dict[str, Dict[str, str]], flag_setter_func
-) -> None:
-    """Extract and store variables from the primary variation of a feature."""
+# ---------------------------------------------------------------------------
+#  PROCESS INDIVIDUAL FEATURE VARIABLES
+# ---------------------------------------------------------------------------
 
-    # Get target distribution → find primary variation → exit early if any missing
+
+async def process_feature_variables(
+    feature: dict,
+    variable_mapping: Dict[str, Dict[str, str]],
+    setter,
+) -> None:
+    """Extract variables from the highest-percentage variation."""
+
     targets = feature.get("configuration", {}).get("targets") or []
     if not targets:
         return
@@ -46,330 +52,222 @@ async def process_feature_variables(
     if not distribution:
         return
 
-    # Find highest-percentage variation
-    primary_variation_id = max(distribution, key=lambda d: d.get("percentage", 0)).get(
+    # Highest weight variation
+    primary_var_id = max(distribution, key=lambda d: d.get("percentage", 0)).get(
         "_variation"
     )
-    if not primary_variation_id:
+    if not primary_var_id:
         return
 
-    # Get matching variation
+    # Find variation object
     variations = feature.get("variations") or []
-    primary_variation = next(
-        (v for v in variations if v.get("_id") == primary_variation_id), None
-    )
-    if not primary_variation:
+    primary = next((v for v in variations if v.get("_id") == primary_var_id), None)
+    if not primary:
         return
 
-    # Extract all variables
-    for var in primary_variation.get("variables") or []:
+    for var in primary.get("variables") or []:
         var_id = var.get("_var")
-        var_value = var.get("value")
         if not var_id or var_id not in variable_mapping:
             continue
 
         info = variable_mapping[var_id]
-        normalized_key = normalize_key(info["key"])
-        processed_value = process_devcycle_value(var_value, info["type"])
-        await flag_setter_func(normalized_key, processed_value)
+        key = normalize_key(info["key"])
+        processed_val = process_devcycle_value(var.get("value"), info["type"])
+
+        await setter(key, processed_val)
+
+
+# ---------------------------------------------------------------------------
+#  FETCH + UPDATE FLAGS
+# ---------------------------------------------------------------------------
 
 
 async def fetch_and_update_feature_flags() -> bool:
-    """Fetch DevCycle configuration and update Redis store with diff-based updates."""
+    """Fetch DevCycle config and update Redis (cluster safe)."""
+
     if not DEVCYCLE_SERVER_KEY:
-        logger.warning("DEVCYCLE_SERVER_KEY not configured")
+        logger.warning("DEVCYCLE_SERVER_KEY missing")
         return False
 
     url = f"https://config-cdn.devcycle.com/config/v1/server/{DEVCYCLE_SERVER_KEY}.json"
     timeout = aiohttp.ClientTimeout(total=30)
 
     try:
-        logger.debug(f"Fetching DevCycle config: {url}")
-
-        # ----- Fetch DevCycle JSON -----
         async with aiohttp.ClientSession(timeout=timeout) as session:
-            async with session.get(
-                url, headers={"Content-Type": "application/json"}
-            ) as resp:
+            async with session.get(url) as resp:
                 if resp.status != 200:
-                    logger.error(f"DevCycle CDN error: {resp.status}")
-                    logger.error(f"Response: {await resp.text()}")
+                    logger.error(
+                        f"DevCycle CDN error {resp.status}: {await resp.text()}"
+                    )
                     return False
                 data = await resp.json()
+        logger.debug("DevCycle config fetched successfully")
+        variables = data.get("variables") or []
+        features = data.get("features") or []
 
-        # ----- Validate Base Payload -----
-        if not isinstance(data, dict):
-            logger.error("DevCycle response is not a dictionary")
-            return False
-
-        # ----- Extract and Validate Variables & Features -----
-        variables = data.get("variables")
-        if not isinstance(variables, list):
-            logger.warning(
-                f"Invalid 'variables' format ({type(variables)}). Expected list."
-            )
-            variables = []
-
-        features = data.get("features")
-        if not isinstance(features, list):
-            logger.warning(
-                f"Invalid 'features' format ({type(features)}). Expected list."
-            )
-            features = []
-
-        # ----- EARLY EXIT — nothing to process -----
         if not variables or not features:
-            logger.info(
-                "No variables or features found. Skipping feature-flag processing."
-            )
+            logger.info("DevCycle response contains no features/variables")
             return False
-
-        # ----- Build New Flags -----
-        new_flags: dict[str, Any] = {}
-
         variable_map = build_variable_mapping(variables)
 
-        async def set_flag(key: str, value: Any) -> bool:
-            new_flags[key] = value
-            return True
+        new_flags: Dict[str, Any] = {}
 
-        for feature in features:
-            if isinstance(feature, dict) and "key" in feature:
-                await process_feature_variables(feature, variable_map, set_flag)
+        async def stash_flag(k, v):
+            new_flags[k] = v
 
-        # ----- Load Old Flags -----
+        for feat in features:
+            if isinstance(feat, dict):
+                await process_feature_variables(feat, variable_map, stash_flag)
+
+        # Load existing from Redis
         old_flags = await _get_all_flags_from_redis()
+        logger.info(f"Old flags from Redis: {old_flags}")
+        logger.debug(
+            f"Loaded {len(old_flags)} existing flags from Redis: {list(old_flags.keys())}"
+        )
+        logger.debug(
+            f"Built {len(new_flags)} new flags from DevCycle: {list(new_flags.keys())}"
+        )
 
-        old_keys = set(old_flags.keys())
-        new_keys = set(new_flags.keys())
-
-        # Diff
-        keys_to_update = {
-            k for k in old_keys & new_keys if old_flags[k] != new_flags[k]
-        }
-        keys_to_add = new_keys - old_keys
-        keys_to_delete = old_keys - new_keys
-
-        total_changes = len(keys_to_update) + len(keys_to_add) + len(keys_to_delete)
-
-        # ----- Nothing Changed -----
-        if total_changes == 0:
-            logger.info(f"No flag changes detected ({len(new_flags)} total flags)")
+        # Check if there are any changes
+        if old_flags == new_flags:
+            logger.info("No DevCycle changes detected")
             return True
 
-        # ----- Apply Redis Updates -----
-        redis_service = await get_redis_service()
-        redis_client = await redis_service.get_client()
-        pipe = redis_client.pipeline(transaction=False)
+        # Store all flags as a single JSON in Redis
+        redis = await get_redis_service()
+        client = await redis.get_client()
 
-        # Add/update
-        for key in keys_to_update | keys_to_add:
-            pipe.set(f"{FEATURE_FLAGS_PREFIX}{key}", json.dumps(new_flags[key]))
-
-        # Delete
-        for key in keys_to_delete:
-            pipe.delete(f"{FEATURE_FLAGS_PREFIX}{key}")
-
-        await pipe.execute()
-
-        # ----- Log Summary -----
-        logger.info(
-            f"DevCycle flags updated: old={len(old_flags)}, new={len(new_flags)}, "
-            f"updated={len(keys_to_update)}, added={len(keys_to_add)}, deleted={len(keys_to_delete)}"
-        )
+        try:
+            await client.set(FEATURE_FLAGS_KEY, json.dumps(new_flags))
+            logger.info(
+                f"DevCycle Flags Updated total={len(new_flags)} flags stored in Redis"
+            )
+        except Exception as e:
+            logger.error(
+                f"FAILED to update feature flags in Redis: {type(e).__name__}: {e}"
+            )
+            raise
 
         return True
 
+    except aiohttp.ClientError as e:
+        logger.error(f"DevCycle HTTP request failed: {type(e).__name__}: {e}")
+        return False
     except Exception as e:
-        logger.exception(f"Error fetching DevCycle feature flags: {e}")
+        logger.error(f"DevCycle update failed at unknown step: {type(e).__name__}: {e}")
+        logger.exception("Full traceback:")
         return False
 
-    except aiohttp.ClientError as e:
-        logger.error(f"DevCycle API request failed: {e}")
-        return False
-    except Exception as e:
-        logger.error(f"DevCycle flag update failed: {e}")
-        return False
+
+# ---------------------------------------------------------------------------
+#  INITIALIZE
+# ---------------------------------------------------------------------------
 
 
 async def initialize_feature_flags() -> None:
-    """Initialize feature flag store from DevCycle API"""
     global _INITIALIZED
-
     if _INITIALIZED:
         return
 
-    # DevCycle can be used in any environment when server key is available
-    if not DEVCYCLE_SERVER_KEY:
-        logger.info(
-            f"DevCycle initialization skipped for environment: {ENVIRONMENT} (no server key)"
-        )
-        logger.info("Using environment variables only when DevCycle is not configured")
-        _INITIALIZED = True
-        return
-
-    logger.info("Initializing DevCycle feature flags...")
+    logger.info("Initializing DevCycle feature flags…")
 
     try:
-        if not DEVCYCLE_SERVER_KEY:
-            logger.info(
-                "No DEVCYCLE_SERVER_KEY found, using environment variables only"
-            )
-        else:
-            success = await fetch_and_update_feature_flags()
-            if success:
-                flag_count = await get_flag_count()
-                store = await get_all_flags()
-                logger.info(f"DevCycle initialized with {flag_count} feature flags")
-                logger.info(f"Store: {store}")
+        if DEVCYCLE_SERVER_KEY:
+            response = await fetch_and_update_feature_flags()
+            if response:
+                logger.info(
+                    f"DevCycle initialized successfully ({await get_flag_count()} flags)"
+                )
             else:
                 logger.error(
-                    "DevCycle initialization failed, using environment variables only"
+                    "DevCycle init failed → falling back to environment variables"
                 )
-
+        else:
+            logger.info("DevCycle disabled (no server key)")
     except Exception as e:
-        logger.error(f"Feature flag initialization failed: {e}")
+        logger.error(f"DevCycle init error: {e}")
 
     _INITIALIZED = True
-    flag_count = await get_flag_count()
-    logger.info(f"Feature flag initialization completed ({flag_count} flags)")
 
 
-async def get_all_flags() -> Dict[str, Any]:
-    """Get all loaded feature flags"""
-    return await _get_all_flags_from_redis()
+# ---------------------------------------------------------------------------
+#  PUBLIC GETTERS
+# ---------------------------------------------------------------------------
 
 
 def is_initialized() -> bool:
-    """Check if feature flags have been initialized"""
     return _INITIALIZED
 
 
 async def get_flag_count() -> int:
-    """Get number of loaded flags"""
-    flags = await _get_all_flags_from_redis()
-    return len(flags)
+    return len(await _get_all_flags_from_redis())
+
+
+async def get_all_flags() -> Dict[str, Any]:
+    return await _get_all_flags_from_redis()
 
 
 async def get_config(key: str, default_value: Any, return_type: type = str) -> Any:
-    """Unified configuration getter with feature flag -> env var -> default fallback"""
+    """Unified: Redis → Environment → Default (async version)"""
+
+    # Always try Redis first (don't check _INITIALIZED to support cross-process reads)
     try:
-        # Only attempt Redis lookup if DevCycle is initialized
-        if not _INITIALIZED:
-            env_result = get_env_value(key, return_type)
-            return env_result if env_result is not None else default_value
-
-        # Try Redis lookup using existing service
-        flag_value = await _get_flag_from_redis(key)
-        if flag_value is not None:
-            converted = convert_type(flag_value, return_type)
+        val = await _get_flag_from_redis(key)
+        if val is not None:
+            converted = convert_type(val, return_type)
             if converted is not None:
+                logger.debug(f"get_config({key}): Retrieved from Redis -> {converted}")
                 return converted
+        else:
+            logger.debug(f"get_config({key}): Not found in Redis, checking environment")
     except Exception as e:
-        logger.debug(f"Redis lookup failed for {key}, using env fallback: {e}")
+        logger.warning(
+            f"get_config({key}): Redis lookup failed: {e}, falling back to environment"
+        )
 
-    # Fallback to environment variables
-    env_result = get_env_value(key, return_type)
-    return env_result if env_result is not None else default_value
+    env_val = get_env_value(key, return_type)
+    if env_val is not None:
+        logger.debug(f"get_config({key}): Retrieved from environment -> {env_val}")
+        return env_val
+
+    logger.debug(f"get_config({key}): Using default value -> {default_value}")
+    return default_value
+
+
+# ---------------------------------------------------------------------------
+#  REDIS OPERATIONS (CLUSTER SAFE)
+# ---------------------------------------------------------------------------
 
 
 async def _get_flag_from_redis(key: str) -> Optional[Any]:
-    """Get a single feature flag from Redis"""
     try:
-        redis_service = await get_redis_service()
-        if not redis_service:
+        redis = await get_redis_service()
+        client = await redis.get_client()
+
+        raw = await client.get(FEATURE_FLAGS_KEY)
+        if not raw:
             return None
-        value_str = await redis_service.get(f"{FEATURE_FLAGS_PREFIX}{key}")
-        return json.loads(value_str) if value_str else None
+
+        all_flags = json.loads(raw)
+        return all_flags.get(key)
     except Exception as e:
-        logger.error(f"Error getting flag {key} from Redis: {e}")
+        logger.error(f"Redis get error for {key}: {e}")
         return None
 
 
-async def _set_flag_in_redis(key: str, value: Any) -> bool:
-    """Set a feature flag in Redis"""
-    try:
-        redis_service = await get_redis_service()
-        if not redis_service:
-            return False
-        return await redis_service.set(
-            f"{FEATURE_FLAGS_PREFIX}{key}", json.dumps(value)
-        )
-    except Exception as e:
-        logger.error(f"Error setting flag {key} in Redis: {e}")
-        return False
-
-
-async def _delete_flag_from_redis(key: str) -> bool:
-    """Delete a feature flag from Redis"""
-    try:
-        redis_service = await get_redis_service()
-        if not redis_service:
-            return False
-
-        redis_client = await redis_service.get_client()
-        await redis_client.delete(f"{FEATURE_FLAGS_PREFIX}{key}")
-        return True
-    except Exception as e:
-        logger.error(f"Error deleting flag {key} from Redis: {e}")
-        return False
-
-
 async def _get_all_flags_from_redis() -> Dict[str, Any]:
-    """Get all feature flags from Redis"""
+    """Load all flags from single Redis key."""
     try:
-        redis_service = await get_redis_service()
-        if not redis_service:
+        redis = await get_redis_service()
+        client = await redis.get_client()
+
+        raw = await client.get(FEATURE_FLAGS_KEY)
+        if not raw:
             return {}
 
-        redis_client = await redis_service.get_client()
+        return json.loads(raw)
 
-        keys = await redis_client.keys(f"{FEATURE_FLAGS_PREFIX}*")
-        if not keys:
-            return {}
-
-        values = await redis_client.mget(keys)
-        result = {}
-
-        for key, value in zip(keys, values):
-            if value:
-                flag_key = key.replace(FEATURE_FLAGS_PREFIX, "")
-                try:
-                    result[flag_key] = json.loads(value)
-                except json.JSONDecodeError:
-                    logger.error(f"Error parsing flag value for {flag_key}")
-
-        return result
     except Exception as e:
-        logger.error(f"Error getting all flags from Redis: {e}")
+        logger.error(f"Error loading all flags: {e}")
         return {}
-
-
-async def _clear_all_flags_in_redis() -> bool:
-    """Clear all feature flags from Redis"""
-    try:
-        redis_service = await get_redis_service()
-        if not redis_service:
-            return False
-
-        redis_client = await redis_service.get_client()
-
-        keys = await redis_client.keys(f"{FEATURE_FLAGS_PREFIX}*")
-        if keys:
-            await redis_client.delete(*keys)
-        return True
-    except Exception as e:
-        logger.error(f"Error clearing flags from Redis: {e}")
-        return False
-
-
-async def _restore_flags_to_redis(flags: Dict[str, Any]) -> bool:
-    """Restore flags to Redis (rollback on failure)"""
-    try:
-        await _clear_all_flags_in_redis()
-        for key, value in flags.items():
-            await _set_flag_in_redis(key, value)
-        return True
-    except Exception as e:
-        logger.error(f"Error restoring flags to Redis: {e}")
-        return False

--- a/app/services/redis/client.py
+++ b/app/services/redis/client.py
@@ -8,7 +8,7 @@ import os
 from typing import Any, Dict, List, Optional
 
 from redis.asyncio import Redis
-from redis.asyncio.cluster import RedisCluster
+from redis.asyncio.cluster import ClusterNode, RedisCluster
 from redis.exceptions import ConnectionError as RedisConnectionError
 from redis.exceptions import RedisError
 
@@ -58,10 +58,37 @@ class RedisFactory:
         try:
             startup_nodes = self._get_startup_nodes()
 
-            # Single node - use Redis client
-            if len(startup_nodes) == 1:
+            # Determine if we should use cluster mode
+            # Use cluster if: explicitly set OR multiple nodes configured
+            use_cluster = len(startup_nodes) and REDIS_CLUSTER_NODES
+
+            if use_cluster:
+                # CLUSTER MODE
+                logger.info(
+                    f"Initializing Redis CLUSTER with {len(startup_nodes)} node(s): {startup_nodes}"
+                )
+
+                # Convert dict nodes to ClusterNode objects
+                cluster_nodes = [
+                    ClusterNode(host=node["host"], port=node["port"])
+                    for node in startup_nodes
+                ]
+
+                self._cluster_client = RedisCluster(
+                    startup_nodes=cluster_nodes,
+                    decode_responses=True,  # Decode bytes to strings automatically
+                )
+
+                # Test connection
+                await self._cluster_client.ping()
+                logger.info("Redis cluster connection established successfully")
+
+            else:
+                # SINGLE NODE MODE
                 node = startup_nodes[0]
-                logger.info(f"Creating Redis client: {node['host']}:{node['port']}")
+                logger.info(
+                    f"Initializing Redis SINGLE NODE at {node['host']}:{node['port']}"
+                )
 
                 self._single_client = Redis(
                     host=node["host"],
@@ -71,23 +98,16 @@ class RedisFactory:
 
                 # Test connection
                 await self._single_client.ping()
-                logger.info("Redis connection established")
+                logger.info("Redis single-node connection established successfully")
 
-            # Multiple nodes - use Redis cluster
-            else:
-                logger.info(f"Creating Redis cluster with {len(startup_nodes)} nodes")
-
-                self._cluster_client = RedisCluster(
-                    startup_nodes=startup_nodes,
-                    decode_responses=True,  # Decode bytes to strings automatically
-                )
-
-                # Test connection
-                await self._cluster_client.ping()
-                logger.info("Redis cluster connection established")
-
+        except RedisConnectionError as e:
+            logger.error(f"Redis connection failed: {e}", exc_info=True)
+            raise
+        except ValueError as e:
+            logger.error(f"Redis configuration error: {e}")
+            raise
         except Exception as e:
-            logger.error(f"Failed to create Redis client: {e}")
+            logger.error(f"Unexpected error creating Redis client: {e}", exc_info=True)
             raise RedisConnectionError(f"Cannot connect to Redis: {e}") from e
 
     def _get_startup_nodes(self) -> List[Dict[str, Any]]:
@@ -130,15 +150,20 @@ class RedisFactory:
 
     async def close(self) -> None:
         """Close Redis connections"""
-        if self._cluster_client:
-            await self._cluster_client.aclose()
+        try:
+            if self._cluster_client:
+                await self._cluster_client.aclose()
+                self._cluster_client = None
+
+            if self._single_client:
+                await self._single_client.aclose()
+                self._single_client = None
+
+            logger.info("Redis connections closed")
+        except Exception as e:
+            logger.error(f"Error closing Redis connections: {e}", exc_info=True)
             self._cluster_client = None
-
-        if self._single_client:
-            await self._single_client.aclose()
             self._single_client = None
-
-        logger.info("Redis connections closed")
 
 
 class RedisService:
@@ -262,5 +287,5 @@ async def close_redis_connections():
             await _redis_service.close()
             _redis_service = None
         except Exception as e:
-            logger.error(f"Error closing Redis connections: {e}")
+            logger.error(f"Error closing Redis connections: {e}", exc_info=True)
             _redis_service = None  # Reset even if close fails

--- a/run.py
+++ b/run.py
@@ -9,16 +9,56 @@ import os
 
 import uvicorn
 
-# STEP 3: Initialize DevCycle feature flags (after env loaded)
-from app.services.live_config.store import initialize_feature_flags
-
-asyncio.run(initialize_feature_flags())
-
-# STEP 4: Now safe to import config and logger (after feature flags initialized)
+# STEP 3: Now safe to import config and logger
 from app.core.config.static import HOST, PORT, UVICORN_LOG_LEVEL, UVICORN_RELOAD
 from app.core.logger import logger
+from app.services.live_config.store import initialize_feature_flags
+from app.services.redis import (
+    close_redis_connections,
+    get_redis_service,
+    is_redis_configured,
+)
+
+
+async def initialize_devcycle():
+    """Initialize DevCycle and populate Redis before uvicorn starts.
+
+    This ensures all worker processes and subprocesses can read flags from Redis
+    without needing to call DevCycle API themselves.
+    """
+    try:
+        if is_redis_configured():
+            # Initialize Redis connection
+            redis_service = await get_redis_service()
+            await redis_service.get_client()  # Initialize the client
+            logger.info("Parent process: Redis connection established")
+
+            # Initialize DevCycle and populate Redis
+            await initialize_feature_flags()
+            logger.info(
+                "Parent process: DevCycle feature flags initialized and stored in Redis"
+            )
+
+            # Close Redis connection (workers will create their own)
+            await close_redis_connections()
+            logger.info(
+                "Parent process: Redis connection closed (workers will create new connections)"
+            )
+        else:
+            logger.warning(
+                "Parent process: Redis not configured - DevCycle flags will use environment variables only"
+            )
+    except Exception as e:
+        logger.error(f"Parent process: Failed to initialize DevCycle: {e}")
+        logger.warning("Parent process: Continuing with environment variable fallback")
+
 
 if __name__ == "__main__":
+    # STEP 4: Initialize DevCycle in parent process before starting uvicorn
+    logger.info("Parent process: Initializing DevCycle before starting workers...")
+    asyncio.run(initialize_devcycle())
+
+    # STEP 5: Start uvicorn server (will spawn worker processes)
     logger.info(f"Starting Uvicorn server on {HOST}:{PORT}")
     logger.info(f"Reload enabled: {UVICORN_RELOAD}")
     logger.info(f"Log level: {UVICORN_LOG_LEVEL}")


### PR DESCRIPTION
  1. Single endpoint assumption bug - Code assumed single host:port meant standalone Redis, but production had a cluster behind single endpoint
  2. MOVED redirect errors - Keys were failing with "MOVED 6090 127.0.0.1:7001" because single-node client couldn't handle cluster redirects
  3. ClusterNode type mismatch - RedisCluster expected ClusterNode objects but we were passing dictionaries, causing "'dict' object has no attribute 'host'"
  4. MGET fails across cluster nodes - Batch GET operations failed when keys were on different cluster nodes/slots
  5. KEYS command only scans one node - In cluster mode, KEYS pattern only returned keys from current node, not all nodes, breaking our diff logic
  6. Cluster topology not auto-discovered - Client wasn't discovering all cluster nodes, causing routing failures
  7. Broad error handling masked root cause - Generic exception handling made it impossible to identify which operation was failing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Redis cluster mode configuration

* **Improvements**
  * Enhanced Redis client to support both cluster and single-node deployment modes
  * Improved live configuration and feature flag handling

* **Chores**
  * Code cleanup and formatting adjustments

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->