### PR TITLE
Centralize voice STT integrations for reuse

### DIFF
--- a/app/ai/voice/agents/automatic/stt/__init__.py
+++ b/app/ai/voice/agents/automatic/stt/__init__.py
@@ -1,25 +1,18 @@
-import json
 from typing import Optional
 
-from deepgram import LiveOptions
-from pipecat.services.assemblyai.stt import AssemblyAISTTService
-from pipecat.services.deepgram.stt import DeepgramSTTService
-from pipecat.services.google.stt import GoogleSTTService
-from pipecat.services.openai.stt import OpenAISTTService
-from pipecat.services.sarvam.stt import SarvamSTTService
-from pipecat.services.soniox.stt import (
-    SonioxContextGeneralItem,
-    SonioxContextObject,
-    SonioxContextTranslationTerm,
-    SonioxInputParams,
-    SonioxSTTService,
-)
 from pipecat.transcriptions.language import Language
 
 from app.ai.voice.agents.automatic.types import VoiceName
-from app.ai.voice.agents.automatic.utils.common import (
-    SarvamServiceType,
-    get_sarvam_language,
+from app.ai.voice.stt import (
+    DeepgramConfig,
+    SarvamConfig,
+    SonioxConfig,
+    build_assemblyai_stt,
+    build_deepgram_stt,
+    build_google_stt,
+    build_openai_stt,
+    build_sarvam_stt,
+    build_soniox_stt,
 )
 from app.core.config.dynamic import (
     SARVAM_STT_HIGH_VAD_SENSITIVITY,
@@ -63,76 +56,6 @@ from app.core.config.static import (
 from app.core.logger import logger
 
 
-def parse_soniox_context() -> Optional[SonioxContextObject]:
-    """
-    Parse Soniox context from JSON environment variable into SonioxContextObject.
-
-    Expected JSON structure:
-    {
-        "general": [{"key": "organisation", "value": "Juspay"}, ...],
-        "text": "User Persona: D2C ecommerce merchants...",
-        "terms": ["Juspay", "Breeze Automatic", "PSR", ...],
-        "translation_terms": [{"source": "...", "target": "..."}, ...]
-    }
-
-    Returns:
-        SonioxContextObject if parsing succeeds, None otherwise
-    """
-    if not SONIOX_CONTEXT:
-        return None
-
-    try:
-        # Parse JSON from environment variable
-        context_data = json.loads(SONIOX_CONTEXT)
-
-        # Extract fields from JSON
-        general_items = context_data.get("general", [])
-        text = context_data.get("text")
-        terms = context_data.get("terms", [])
-        translation_terms_items = context_data.get("translation_terms", [])
-
-        # Convert general items to SonioxContextGeneralItem objects
-        general_objects = None
-        if general_items:
-            general_objects = [
-                SonioxContextGeneralItem(key=item["key"], value=item["value"])
-                for item in general_items
-            ]
-
-        # Convert translation_terms items to SonioxContextTranslationTerm objects
-        translation_terms_objects = None
-        if translation_terms_items:
-            translation_terms_objects = [
-                SonioxContextTranslationTerm(
-                    source=item["source"], target=item["target"]
-                )
-                for item in translation_terms_items
-            ]
-
-        # Create and return SonioxContextObject
-        context_object = SonioxContextObject(
-            general=general_objects if general_objects else None,
-            text=text,
-            terms=terms if terms else None,
-            translation_terms=(
-                translation_terms_objects if translation_terms_objects else None
-            ),
-        )
-
-        logger.info(
-            f"Successfully parsed Soniox context with {len(general_objects or [])} general items, "
-            f"{len(terms) if terms else 0} terms, "
-            f"{len(translation_terms_objects or [])} translation terms"
-        )
-        return context_object
-
-    except Exception as e:
-        logger.warning(
-            f"Failed to parse SONIOX_CONTEXT: {e}. Falling back to None context."
-        )
-        return None
-
-
 async def get_stt_service(voice_name: Optional[str] = None):
     """
     Returns an STT service instance based on the environment configuration.
@@ -150,13 +73,12 @@ async def get_stt_service(voice_name: Optional[str] = None):
         logger.info(
             f"Using OpenAI STT service for MIA voice (override enabled) with model: {ENFORCED_OPENAI_STT_MODEL}"
         )
-        return OpenAISTTService(
+        return build_openai_stt(
             api_key=OPENAI_STT_API_KEY,
             model=ENFORCED_OPENAI_STT_MODEL,
             language=Language.EN,
-            # Optimized prompt for business analytics voice agent
             prompt=AUTOMATIC_OPENAI_STT_PROMPT,
-            temperature=0.0,  # Deterministic output for consistency
+            temperature=0.0,
         )
 
     # Check for RHEA voice or Sarvam STT provider
@@ -171,37 +93,17 @@ async def get_stt_service(voice_name: Optional[str] = None):
         sarvam_stt_vad_signals = await SARVAM_STT_VAD_SIGNALS()
         sarvam_stt_high_vad_sensitivity = await SARVAM_STT_HIGH_VAD_SENSITIVITY()
 
-        # Initialize parameters based on model type
-        prompt_param = None
-        language_param = None
-
-        if "saaras" in sarvam_stt_model.lower():
-            # STT-Translate model: accepts prompt, no language (auto-detects)
-            prompt_param = sarvam_stt_prompt if sarvam_stt_prompt else None
-        else:
-            # saarika (pure STT) model: accepts language, no prompt
-            language_param = get_sarvam_language(
+        # Pass raw config values - model-specific logic is handled internally by build_sarvam_stt
+        return build_sarvam_stt(
+            SarvamConfig(
+                api_key=SARVAM_API_KEY,
+                model=sarvam_stt_model,
+                sample_rate=SAMPLE_RATE,
                 language_code=sarvam_stt_language_code,
-                service_type=SarvamServiceType.STT,
-            )
-
-        logger.info(
-            f"Using Sarvam STT service with model={sarvam_stt_model}, "
-            f"language={'set' if language_param else 'none'}, "
-            f"prompt={'set' if prompt_param else 'none'}, "
-            f"vad_signals={sarvam_stt_vad_signals}, high_vad_sensitivity={sarvam_stt_high_vad_sensitivity}"
-        )
-
-        return SarvamSTTService(
-            api_key=SARVAM_API_KEY,
-            model=sarvam_stt_model,
-            sample_rate=SAMPLE_RATE,
-            params=SarvamSTTService.InputParams(
-                language=language_param,
-                prompt=prompt_param,
+                prompt=sarvam_stt_prompt,
                 vad_signals=sarvam_stt_vad_signals,
                 high_vad_sensitivity=sarvam_stt_high_vad_sensitivity,
-            ),
+            )
         )
 
     # Default behavior - use configured STT provider
@@ -211,13 +113,7 @@ async def get_stt_service(voice_name: Optional[str] = None):
                 "ASSEMBLYAI_API_KEY is required when STT_PROVIDER=assemblyai"
             )
 
-        logger.info("Using AssemblyAI STT service with Silero VAD-based turn detection")
-        return AssemblyAISTTService(
-            api_key=ASSEMBLYAI_API_KEY,
-            # Use Silero VAD for turn detection instead of AssemblyAI's built-in turn detection
-            vad_force_turn_endpoint=True,
-            # No connection_params needed since we're using VAD for turn detection
-        )
+        return build_assemblyai_stt(api_key=ASSEMBLYAI_API_KEY)
     elif STT_PROVIDER == "openai":
         if not OPENAI_STT_API_KEY:
             raise ValueError(
@@ -227,91 +123,54 @@ async def get_stt_service(voice_name: Optional[str] = None):
         logger.info(
             f"Using OpenAI STT service ({OPENAI_STT_MODEL}) with Silero VAD-based turn detection"
         )
-        return OpenAISTTService(
+        return build_openai_stt(
             api_key=OPENAI_STT_API_KEY,
             model=OPENAI_STT_MODEL,
             language=Language.EN,
-            # Optimized prompt for business analytics voice agent
             prompt=AUTOMATIC_OPENAI_STT_PROMPT,
-            temperature=0.0,  # Deterministic output for consistency
+            temperature=0.0,
         )
     elif STT_PROVIDER == "deepgram":
         if not DEEPGRAM_API_KEY:
             raise ValueError("DEEPGRAM_API_KEY is required when STT_PROVIDER=deepgram")
 
-        # Determine language configuration based on settings
-        if DEEPGRAM_AUTO_DETECT_LANGUAGE:
-            language_config = "multi"  # Automatic detection
-        else:
-            language_config = DEEPGRAM_LANGUAGE  # Single language (current behavior)
-
-        # Configure Deepgram with smart turn detection and audio enhancement
-        live_options = LiveOptions(
-            model=DEEPGRAM_MODEL,
-            language=language_config,
-            smart_format=DEEPGRAM_SMART_FORMAT,
-            punctuate=DEEPGRAM_PUNCTUATE,
-            endpointing=DEEPGRAM_ENDPOINTING,  # Smart turn detection
-            vad_events=DEEPGRAM_VAD_EVENTS,  # Built-in VAD
-            utterance_end_ms=DEEPGRAM_UTTERANCE_END_MS,
-            no_delay=DEEPGRAM_NO_DELAY,  # Real-time processing
-            interim_results=True,
-            profanity_filter=DEEPGRAM_PROFANITY_FILTER,
-            # Enhanced for Indian English and business terms
-            numerals=DEEPGRAM_NUMERALS,  # Better number recognition
-            diarize=DEEPGRAM_DIARIZE,  # Speaker identification
+        # Pass raw config values - language configuration is handled internally by build_deepgram_stt
+        return build_deepgram_stt(
+            DeepgramConfig(
+                api_key=DEEPGRAM_API_KEY,
+                model=DEEPGRAM_MODEL,
+                language=DEEPGRAM_LANGUAGE,
+                auto_detect_language=DEEPGRAM_AUTO_DETECT_LANGUAGE,
+                smart_format=DEEPGRAM_SMART_FORMAT,
+                punctuate=DEEPGRAM_PUNCTUATE,
+                endpointing=DEEPGRAM_ENDPOINTING,
+                vad_events=DEEPGRAM_VAD_EVENTS,
+                utterance_end_ms=DEEPGRAM_UTTERANCE_END_MS,
+                no_delay=DEEPGRAM_NO_DELAY,
+                interim_results=True,
+                profanity_filter=DEEPGRAM_PROFANITY_FILTER,
+                numerals=DEEPGRAM_NUMERALS,
+                diarize=DEEPGRAM_DIARIZE,
+            )
         )
-
-        logger.info(
-            f"Using Deepgram STT service with model: {DEEPGRAM_MODEL}, "
-            f"language: {language_config} "
-            f"(VAD: {DEEPGRAM_VAD_EVENTS}, Endpointing: {DEEPGRAM_ENDPOINTING})"
-        )
-        return DeepgramSTTService(api_key=DEEPGRAM_API_KEY, live_options=live_options)
     elif STT_PROVIDER == "soniox":
         if not SONIOX_API_KEY:
             raise ValueError("SONIOX_API_KEY is required when STT_PROVIDER=soniox")
 
-        # Parse language hints from comma-separated string
-        language_hints = None
-        if SONIOX_LANGUAGE_HINTS:
-            lang_list = [lang.strip() for lang in SONIOX_LANGUAGE_HINTS.split(",")]
-            language_hints = [Language(lang) for lang in lang_list if lang]
-
-        # Parse context from JSON environment variable
-        context = parse_soniox_context()
-
-        # Configure Soniox with supported parameters only
-        soniox_params = SonioxInputParams(
-            model=SONIOX_MODEL,
-            language_hints=language_hints,
-            context=context,
-            enable_non_final_tokens=SONIOX_ENABLE_NON_FINAL_TOKENS,
-            max_non_final_tokens_duration_ms=(
-                SONIOX_MAX_NON_FINAL_TOKENS_DURATION_MS
-                if SONIOX_MAX_NON_FINAL_TOKENS_DURATION_MS > 0
-                else None
-            ),
-            client_reference_id=None,
-        )
-
-        logger.info(
-            f"Using Soniox STT service with model: {SONIOX_MODEL}, "
-            f"language_hints: {SONIOX_LANGUAGE_HINTS}, "
-            f"VAD force endpoint: {SONIOX_VAD_FORCE_TURN_ENDPOINT}, "
-            f"non_final_tokens: {SONIOX_ENABLE_NON_FINAL_TOKENS}"
-        )
-        return SonioxSTTService(
-            api_key=SONIOX_API_KEY,
-            params=soniox_params,
-            vad_force_turn_endpoint=SONIOX_VAD_FORCE_TURN_ENDPOINT,
+        # Pass raw config values - language hints parsing is handled internally by build_soniox_stt
+        return build_soniox_stt(
+            SonioxConfig(
+                api_key=SONIOX_API_KEY,
+                model=SONIOX_MODEL,
+                vad_force_turn_endpoint=SONIOX_VAD_FORCE_TURN_ENDPOINT,
+                language_hints=SONIOX_LANGUAGE_HINTS,
+                context_json=SONIOX_CONTEXT,
+                enable_non_final_tokens=SONIOX_ENABLE_NON_FINAL_TOKENS,
+                max_non_final_tokens_duration_ms=SONIOX_MAX_NON_FINAL_TOKENS_DURATION_MS,
+                log_context="Automatic",
+            )
         )
     else:  # Default to Google STT
         logger.info("Using Google STT service with VAD-based turn detection")
 
-        return GoogleSTTService(
-            params=GoogleSTTService.InputParams(
-                languages=[Language.EN_US, Language.EN_IN], enable_interim_results=False
-            ),
-            credentials=GOOGLE_CREDENTIALS_JSON,
-        )
+        return build_google_stt(credentials_json=GOOGLE_CREDENTIALS_JSON)

--- a/app/ai/voice/agents/breeze_buddy/stt/__init__.py
+++ b/app/ai/voice/agents/breeze_buddy/stt/__init__.py
@@ -1,17 +1,20 @@
-import json
-from typing import Optional
-
-from pipecat.services.google.stt import GoogleSTTService
-from pipecat.services.openai.stt import OpenAISTTService
-from pipecat.services.soniox.stt import (
-    SonioxContextGeneralItem,
-    SonioxContextObject,
-    SonioxContextTranslationTerm,
-    SonioxInputParams,
-    SonioxSTTService,
-)
 from pipecat.transcriptions.language import Language
 
+from app.ai.voice.stt import (
+    SarvamConfig,
+    SonioxConfig,
+    build_google_stt,
+    build_openai_stt,
+    build_sarvam_stt,
+    build_soniox_stt,
+)
+from app.core.config.dynamic import (
+    BB_SARVAM_STT_HIGH_VAD_SENSITIVITY,
+    BB_SARVAM_STT_LANGUAGE_CODE,
+    BB_SARVAM_STT_MODEL,
+    BB_SARVAM_STT_PROMPT,
+    BB_SARVAM_STT_VAD_SIGNALS,
+)
 from app.core.config.static import (
     BREEZE_BUDDY_SONIOX_CONTEXT,
     BREEZE_BUDDY_SONIOX_ENABLE_NON_FINAL_TOKENS,
@@ -23,129 +26,64 @@ from app.core.config.static import (
     GOOGLE_CREDENTIALS_JSON,
     OPENAI_STT_API_KEY,
     OPENAI_STT_MODEL,
+    SAMPLE_RATE,
+    SARVAM_API_KEY,
     SONIOX_API_KEY,
 )
 from app.core.logger import logger
 
 
-def parse_breeze_buddy_soniox_context() -> Optional[SonioxContextObject]:
-    """
-    Parse Breeze Buddy Soniox context from JSON environment variable into SonioxContextObject.
-
-    Expected JSON structure:
-    {
-        "general": [{"key": "organisation", "value": "Juspay"}, ...],
-        "text": "Breeze Buddy is an automated voice agent...",
-        "terms": ["Juspay", "Breeze Buddy", "COD", ...],
-        "translation_terms": [{"source": "...", "target": "..."}, ...]
-    }
-
-    Returns:
-        SonioxContextObject if parsing succeeds, None otherwise
-    """
-    if not BREEZE_BUDDY_SONIOX_CONTEXT:
-        return None
-
-    try:
-        # Parse JSON from environment variable
-        context_data = json.loads(BREEZE_BUDDY_SONIOX_CONTEXT)
-
-        # Extract fields from JSON
-        general_items = context_data.get("general", [])
-        text = context_data.get("text")
-        terms = context_data.get("terms", [])
-        translation_terms_items = context_data.get("translation_terms", [])
-
-        # Convert general items to SonioxContextGeneralItem objects
-        general_objects = None
-        if general_items:
-            general_objects = [
-                SonioxContextGeneralItem(key=item["key"], value=item["value"])
-                for item in general_items
-            ]
-
-        # Convert translation_terms items to SonioxContextTranslationTerm objects
-        translation_terms_objects = None
-        if translation_terms_items:
-            translation_terms_objects = [
-                SonioxContextTranslationTerm(
-                    source=item["source"], target=item["target"]
-                )
-                for item in translation_terms_items
-            ]
-
-        # Create and return SonioxContextObject
-        context_object = SonioxContextObject(
-            general=general_objects if general_objects else None,
-            text=text,
-            terms=terms if terms else None,
-            translation_terms=(
-                translation_terms_objects if translation_terms_objects else None
-            ),
-        )
-
-        logger.info(
-            f"Successfully parsed Breeze Buddy Soniox context with {len(general_objects or [])} general items, "
-            f"{len(terms) if terms else 0} terms, "
-            f"{len(translation_terms_objects or [])} translation terms"
-        )
-        return context_object
-
-    except Exception as e:
-        logger.warning(
-            f"Failed to parse BREEZE_BUDDY_SONIOX_CONTEXT: {e}. Falling back to None context."
-        )
-        return None
-
-
-def get_stt_service():
+async def get_stt_service():
     """
     Returns an STT service instance based on the environment configuration.
     """
-    if BREEZE_BUDDY_STT_SERVICE == "openai":
+    if BREEZE_BUDDY_STT_SERVICE == "sarvam":
+        if not SARVAM_API_KEY:
+            raise ValueError(
+                "SARVAM_API_KEY is required when BREEZE_BUDDY_STT_SERVICE=sarvam"
+            )
+
+        # Get Breeze Buddy-specific dynamic config values from Redis
+        bb_sarvam_stt_model = await BB_SARVAM_STT_MODEL()
+        bb_sarvam_stt_language_code = await BB_SARVAM_STT_LANGUAGE_CODE()
+        bb_sarvam_stt_prompt = await BB_SARVAM_STT_PROMPT()
+        bb_sarvam_stt_vad_signals = await BB_SARVAM_STT_VAD_SIGNALS()
+        bb_sarvam_stt_high_vad_sensitivity = await BB_SARVAM_STT_HIGH_VAD_SENSITIVITY()
+
+        # Pass raw config values - model-specific logic is handled internally by build_sarvam_stt
+        return build_sarvam_stt(
+            SarvamConfig(
+                api_key=SARVAM_API_KEY,
+                model=bb_sarvam_stt_model,
+                sample_rate=SAMPLE_RATE,
+                language_code=bb_sarvam_stt_language_code,
+                prompt=bb_sarvam_stt_prompt,
+                vad_signals=bb_sarvam_stt_vad_signals,
+                high_vad_sensitivity=bb_sarvam_stt_high_vad_sensitivity,
+            )
+        )
+    elif BREEZE_BUDDY_STT_SERVICE == "openai":
         logger.info("Using OpenAI STT service for Breeze Buddy voice")
-        return OpenAISTTService(
+        return build_openai_stt(
             api_key=OPENAI_STT_API_KEY,
             model=OPENAI_STT_MODEL,
             language=Language.EN,
             temperature=0.0,
         )
     elif BREEZE_BUDDY_STT_SERVICE == "soniox":
-        language_hints = None
-        if BREEZE_BUDDY_SONIOX_LANGUAGE_HINTS:
-            lang_list = [
-                lang.strip() for lang in BREEZE_BUDDY_SONIOX_LANGUAGE_HINTS.split(",")
-            ]
-            language_hints = [Language(lang) for lang in lang_list if lang]
-
-        # Parse context from JSON environment variable
-        context = parse_breeze_buddy_soniox_context()
-
-        # Configure Soniox with supported parameters only
-        soniox_params = SonioxInputParams(
-            model=BREEZE_BUDDY_SONIOX_MODEL,
-            language_hints=language_hints,
-            context=context,
-            enable_non_final_tokens=BREEZE_BUDDY_SONIOX_ENABLE_NON_FINAL_TOKENS,
-            max_non_final_tokens_duration_ms=(
-                BREEZE_BUDDY_SONIOX_MAX_NON_FINAL_TOKENS_DURATION_MS
-                if BREEZE_BUDDY_SONIOX_MAX_NON_FINAL_TOKENS_DURATION_MS > 0
-                else None
-            ),
-            client_reference_id=None,
+        # Pass raw config values - language hints parsing is handled internally by build_soniox_stt
+        return build_soniox_stt(
+            SonioxConfig(
+                api_key=SONIOX_API_KEY,
+                model=BREEZE_BUDDY_SONIOX_MODEL,
+                vad_force_turn_endpoint=BREEZE_BUDDY_SONIOX_VAD_FORCE_TURN_ENDPOINT,
+                language_hints=BREEZE_BUDDY_SONIOX_LANGUAGE_HINTS,
+                context_json=BREEZE_BUDDY_SONIOX_CONTEXT,
+                enable_non_final_tokens=BREEZE_BUDDY_SONIOX_ENABLE_NON_FINAL_TOKENS,
+                max_non_final_tokens_duration_ms=BREEZE_BUDDY_SONIOX_MAX_NON_FINAL_TOKENS_DURATION_MS,
+                log_context="Breeze Buddy",
+            )
         )
-
-        return SonioxSTTService(
-            api_key=SONIOX_API_KEY,
-            params=soniox_params,
-            vad_force_turn_endpoint=BREEZE_BUDDY_SONIOX_VAD_FORCE_TURN_ENDPOINT,
-        )
-
     else:
         logger.info("Using Google STT service with VAD-based turn detection")
-        return GoogleSTTService(
-            params=GoogleSTTService.InputParams(
-                languages=[Language.EN_US, Language.EN_IN], enable_interim_results=False
-            ),
-            credentials=GOOGLE_CREDENTIALS_JSON,
-        )
+        return build_google_stt(credentials_json=GOOGLE_CREDENTIALS_JSON)

--- a/app/ai/voice/agents/breeze_buddy/workflows/order_confirmation/websocket_bot.py
+++ b/app/ai/voice/agents/breeze_buddy/workflows/order_confirmation/websocket_bot.py
@@ -256,7 +256,7 @@ class OrderConfirmationBot:
             ),
         )
 
-        stt = get_stt_service()
+        stt = await get_stt_service()
         llm = AzureLLMService(
             api_key=AZURE_OPENAI_API_KEY,
             endpoint=AZURE_OPENAI_ENDPOINT,

--- a/app/ai/voice/stt/__init__.py
+++ b/app/ai/voice/stt/__init__.py
@@ -1,0 +1,33 @@
+"""Shared Speech-to-Text (STT) utilities for voice agents.
+
+This package centralizes STT integrations so that multiple voice agents can
+reuse the same provider-specific setup logic.
+"""
+
+from __future__ import annotations
+
+from .assemblyai import build_assemblyai_stt
+from .deepgram import DeepgramConfig, build_deepgram_stt
+from .google import build_google_stt
+from .openai import build_openai_stt
+from .sarvam import SarvamConfig, build_sarvam_stt, get_sarvam_language
+from .soniox import SonioxConfig, build_soniox_stt
+
+__all__ = [
+    # AssemblyAI
+    "build_assemblyai_stt",
+    # Deepgram
+    "DeepgramConfig",
+    "build_deepgram_stt",
+    # Google
+    "build_google_stt",
+    # OpenAI
+    "build_openai_stt",
+    # Sarvam
+    "SarvamConfig",
+    "build_sarvam_stt",
+    "get_sarvam_language",
+    # Soniox
+    "SonioxConfig",
+    "build_soniox_stt",
+]

--- a/app/ai/voice/stt/assemblyai.py
+++ b/app/ai/voice/stt/assemblyai.py
@@ -1,0 +1,19 @@
+"""AssemblyAI STT builder."""
+
+from __future__ import annotations
+
+from pipecat.services.assemblyai.stt import AssemblyAISTTService
+
+from app.core.logger import logger
+
+__all__ = ["build_assemblyai_stt"]
+
+
+def build_assemblyai_stt(api_key: str):
+    """Create an AssemblyAI STT service with Silero VAD-based turn detection."""
+
+    logger.info("Using AssemblyAI STT service with Silero VAD-based turn detection")
+    return AssemblyAISTTService(
+        api_key=api_key,
+        vad_force_turn_endpoint=True,
+    )

--- a/app/ai/voice/stt/deepgram.py
+++ b/app/ai/voice/stt/deepgram.py
@@ -1,0 +1,77 @@
+"""Deepgram STT config and builder."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from deepgram import LiveOptions
+from pipecat.services.deepgram.stt import DeepgramSTTService
+
+from app.core.logger import logger
+
+__all__ = ["DeepgramConfig", "build_deepgram_stt"]
+
+
+@dataclass
+class DeepgramConfig:
+    """Configuration for Deepgram STT.
+
+    Language configuration is determined automatically:
+    - If auto_detect_language is True: uses "multi" for automatic detection
+    - If auto_detect_language is False: uses the specified language code
+    """
+
+    api_key: str
+    model: str
+    language: str
+    auto_detect_language: bool
+    smart_format: bool
+    punctuate: bool
+    endpointing: int
+    vad_events: bool
+    utterance_end_ms: int
+    no_delay: bool
+    interim_results: bool
+    profanity_filter: bool
+    numerals: bool
+    diarize: bool
+
+
+def build_deepgram_stt(config: DeepgramConfig):
+    """Create a Deepgram STT service.
+
+    Automatically determines language configuration:
+    - If auto_detect_language is True: uses "multi" for automatic detection
+    - Otherwise: uses the configured language code
+    """
+    # Determine language configuration based on settings
+    if config.auto_detect_language:
+        language_config = "multi"  # Automatic detection
+        logger.debug("Deepgram language auto-detection enabled (multi)")
+    else:
+        language_config = config.language  # Single language
+        logger.debug(f"Deepgram using single language: {language_config}")
+
+    live_options = LiveOptions(
+        model=config.model,
+        language=language_config,
+        smart_format=config.smart_format,
+        punctuate=config.punctuate,
+        endpointing=config.endpointing,
+        vad_events=config.vad_events,
+        utterance_end_ms=config.utterance_end_ms,
+        no_delay=config.no_delay,
+        interim_results=config.interim_results,
+        profanity_filter=config.profanity_filter,
+        numerals=config.numerals,
+        diarize=config.diarize,
+    )
+
+    logger.info(
+        "Using Deepgram STT service with model: %s, language: %s (VAD: %s, Endpointing: %s)",
+        config.model,
+        language_config,
+        config.vad_events,
+        config.endpointing,
+    )
+    return DeepgramSTTService(api_key=config.api_key, live_options=live_options)

--- a/app/ai/voice/stt/google.py
+++ b/app/ai/voice/stt/google.py
@@ -1,0 +1,20 @@
+"""Google STT builder."""
+
+from __future__ import annotations
+
+from pipecat.services.google.stt import GoogleSTTService
+from pipecat.transcriptions.language import Language
+
+__all__ = ["build_google_stt"]
+
+
+def build_google_stt(credentials_json: str):
+    """Create a Google STT service with default language hints."""
+
+    return GoogleSTTService(
+        params=GoogleSTTService.InputParams(
+            languages=[Language.EN_US, Language.EN_IN],
+            enable_interim_results=False,
+        ),
+        credentials=credentials_json,
+    )

--- a/app/ai/voice/stt/openai.py
+++ b/app/ai/voice/stt/openai.py
@@ -1,0 +1,28 @@
+"""OpenAI STT builder."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from pipecat.services.openai.stt import OpenAISTTService
+from pipecat.transcriptions.language import Language
+
+__all__ = ["build_openai_stt"]
+
+
+def build_openai_stt(
+    api_key: str,
+    model: str,
+    language: Language,
+    prompt: Optional[str] = None,
+    temperature: float = 0.0,
+):
+    """Create an OpenAI STT service instance."""
+
+    return OpenAISTTService(
+        api_key=api_key,
+        model=model,
+        language=language,
+        prompt=prompt,
+        temperature=temperature,
+    )

--- a/app/ai/voice/stt/sarvam.py
+++ b/app/ai/voice/stt/sarvam.py
@@ -1,0 +1,104 @@
+"""Sarvam STT helpers and builder."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+from pipecat.services.sarvam.stt import SarvamSTTService
+from pipecat.transcriptions.language import Language
+
+from app.core.logger import logger
+
+__all__ = [
+    "SarvamConfig",
+    "get_sarvam_language",
+    "build_sarvam_stt",
+]
+
+
+@dataclass
+class SarvamConfig:
+    """Configuration for Sarvam STT.
+
+    The model type determines which parameters are used:
+    - 'saaras' models (STT-Translate): use prompt parameter, auto-detect language
+    - 'saarika' models (pure STT): use language parameter, ignore prompt
+    """
+
+    api_key: str
+    model: str
+    sample_rate: int
+    language_code: Optional[str] = None
+    prompt: Optional[str] = None
+    vad_signals: Optional[str] = None
+    high_vad_sensitivity: Optional[bool] = None
+
+
+def get_sarvam_language(language_code: Optional[str]) -> Optional[Language]:
+    """
+    Convert SARVAM language code to :class:`Language` for STT.
+
+    Args:
+        language_code: Language code string (e.g., "en-IN", "hi-IN").
+
+    Returns:
+        Language enum value, or None if invalid/not provided.
+    """
+    if language_code:
+        try:
+            return Language(language_code)
+        except ValueError:
+            logger.warning(
+                "Invalid STT language code: %s, returning None", language_code
+            )
+            return None
+
+    logger.debug("No SARVAM STT language code provided, returning None")
+    return None
+
+
+def build_sarvam_stt(config: SarvamConfig):
+    """Create a Sarvam STT service.
+
+    Automatically determines which parameters to use based on the model type:
+    - 'saaras' models (STT-Translate): accepts prompt, auto-detects language
+    - 'saarika' models (pure STT): accepts language, ignores prompt
+    """
+    # Initialize parameters based on model type
+    prompt_param = None
+    language_param = None
+
+    if "saaras" in config.model.lower():
+        # STT-Translate model: accepts prompt, no language (auto-detects)
+        prompt_param = config.prompt if config.prompt else None
+        logger.debug(
+            f"Saaras model detected: using prompt={'set' if prompt_param else 'none'}, language auto-detection enabled"
+        )
+    else:
+        # saarika (pure STT) model: accepts language, no prompt
+        language_param = get_sarvam_language(language_code=config.language_code)
+        logger.debug(
+            f"Saarika model detected: using language={'set' if language_param else 'none'}, prompt disabled"
+        )
+
+    logger.info(
+        "Using Sarvam STT service with model=%s, language=%s, prompt=%s, vad_signals=%s, high_vad_sensitivity=%s",
+        config.model,
+        "set" if language_param else "none",
+        "set" if prompt_param else "none",
+        config.vad_signals,
+        config.high_vad_sensitivity,
+    )
+
+    return SarvamSTTService(
+        api_key=config.api_key,
+        model=config.model,
+        sample_rate=config.sample_rate,
+        params=SarvamSTTService.InputParams(
+            language=language_param,
+            prompt=prompt_param,
+            vad_signals=config.vad_signals,
+            high_vad_sensitivity=config.high_vad_sensitivity,
+        ),
+    )

--- a/app/ai/voice/stt/soniox.py
+++ b/app/ai/voice/stt/soniox.py
@@ -1,0 +1,173 @@
+"""Soniox STT config and builder."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Iterable, Optional
+
+from pipecat.services.soniox.stt import (
+    SonioxContextGeneralItem,
+    SonioxContextObject,
+    SonioxContextTranslationTerm,
+    SonioxInputParams,
+    SonioxSTTService,
+)
+from pipecat.transcriptions.language import Language
+
+from app.core.logger import logger
+
+__all__ = ["SonioxConfig", "build_soniox_stt"]
+
+
+@dataclass
+class SonioxConfig:
+    """Configuration for Soniox STT.
+
+    Language hints can be provided as:
+    - A comma-separated string (e.g., "en,es,fr") - will be parsed automatically
+    - An iterable of strings (e.g., ["en", "es", "fr"])
+    - None (no language hints)
+    """
+
+    api_key: str
+    model: str
+    vad_force_turn_endpoint: bool
+    language_hints: Optional[str | Iterable[str]] = None
+    context_json: Optional[str] = None
+    enable_non_final_tokens: bool = False
+    max_non_final_tokens_duration_ms: Optional[int] = None
+    client_reference_id: Optional[str] = None
+    log_context: str = "Soniox"
+
+
+def _parse_soniox_context(
+    context_json: Optional[str], log_context: str
+) -> Optional[SonioxContextObject]:
+    """Parse Soniox context JSON into :class:`SonioxContextObject`."""
+
+    if not context_json:
+        return None
+
+    try:
+        context_data = json.loads(context_json)
+
+        general_items = context_data.get("general", [])
+        text = context_data.get("text")
+        terms = context_data.get("terms", [])
+        translation_terms_items = context_data.get("translation_terms", [])
+
+        general_objects = (
+            [
+                SonioxContextGeneralItem(key=item["key"], value=item["value"])
+                for item in general_items
+            ]
+            if general_items
+            else None
+        )
+
+        translation_terms_objects = (
+            [
+                SonioxContextTranslationTerm(
+                    source=item["source"], target=item["target"]
+                )
+                for item in translation_terms_items
+            ]
+            if translation_terms_items
+            else None
+        )
+
+        context_object = SonioxContextObject(
+            general=general_objects if general_objects else None,
+            text=text,
+            terms=terms if terms else None,
+            translation_terms=(
+                translation_terms_objects if translation_terms_objects else None
+            ),
+        )
+
+        logger.info(
+            "Successfully parsed %s Soniox context with %d general items, %d terms, %d translation terms",
+            log_context,
+            len(general_objects or []),
+            len(terms) if terms else 0,
+            len(translation_terms_objects or []),
+        )
+        return context_object
+
+    except Exception as exc:  # pragma: no cover - defensive logging
+        logger.warning(
+            "Failed to parse %s Soniox context: %s. Falling back to None context.",
+            log_context,
+            exc,
+        )
+        return None
+
+
+def build_soniox_stt(config: SonioxConfig):
+    """Create a Soniox STT service.
+
+    Automatically handles language hints parsing:
+    - If provided as a comma-separated string, it will be split and parsed
+    - If provided as an iterable, it will be used directly
+    - Empty/whitespace-only values are filtered out
+    """
+    # Parse language hints - handle both string and iterable formats
+    language_hints = None
+    if config.language_hints:
+        if isinstance(config.language_hints, str):
+            # Parse comma-separated string
+            parsed_hints = [
+                lang.strip()
+                for lang in config.language_hints.split(",")
+                if lang.strip()
+            ]
+            logger.debug(
+                f"Parsed {len(parsed_hints)} language hints from comma-separated string"
+            )
+        else:
+            # Already an iterable
+            parsed_hints = list(config.language_hints)
+            logger.debug(f"Using {len(parsed_hints)} language hints from iterable")
+
+        if parsed_hints:
+            language_hints = [Language(lang) for lang in parsed_hints if lang]
+
+    context = _parse_soniox_context(config.context_json, config.log_context)
+
+    soniox_params = SonioxInputParams(
+        model=config.model,
+        language_hints=language_hints,
+        context=context,
+        enable_non_final_tokens=config.enable_non_final_tokens,
+        max_non_final_tokens_duration_ms=(
+            config.max_non_final_tokens_duration_ms
+            if config.max_non_final_tokens_duration_ms
+            and config.max_non_final_tokens_duration_ms > 0
+            else None
+        ),
+        client_reference_id=config.client_reference_id,
+    )
+
+    # Format language hints for logging
+    hints_display = ""
+    if config.language_hints:
+        if isinstance(config.language_hints, str):
+            hints_display = config.language_hints
+        else:
+            hints_display = ",".join(config.language_hints)
+
+    logger.info(
+        "Using %s Soniox STT service with model: %s, language_hints: %s, VAD force endpoint: %s, non_final_tokens: %s",
+        config.log_context,
+        config.model,
+        hints_display,
+        config.vad_force_turn_endpoint,
+        config.enable_non_final_tokens,
+    )
+
+    return SonioxSTTService(
+        api_key=config.api_key,
+        params=soniox_params,
+        vad_force_turn_endpoint=config.vad_force_turn_endpoint,
+    )

--- a/app/core/config/dynamic.py
+++ b/app/core/config/dynamic.py
@@ -79,3 +79,29 @@ async def SARVAM_TTS_PITCH() -> float:
 async def SARVAM_TTS_PACE() -> float:
     """Returns SARVAM_TTS_PACE from Redis"""
     return await get_config("SARVAM_TTS_PACE", 1.0, float)
+
+
+# --- Breeze Buddy Sarvam STT Configuration ---
+async def BB_SARVAM_STT_MODEL() -> str:
+    """Returns BB_SARVAM_STT_MODEL from Redis"""
+    return await get_config("BB_SARVAM_STT_MODEL", "saarika:v2.5", str)
+
+
+async def BB_SARVAM_STT_LANGUAGE_CODE() -> str:
+    """Returns BB_SARVAM_STT_LANGUAGE_CODE from Redis"""
+    return await get_config("BB_SARVAM_STT_LANGUAGE_CODE", "", str)
+
+
+async def BB_SARVAM_STT_PROMPT() -> str:
+    """Returns BB_SARVAM_STT_PROMPT from Redis"""
+    return await get_config("BB_SARVAM_STT_PROMPT", "", str)
+
+
+async def BB_SARVAM_STT_VAD_SIGNALS() -> bool:
+    """Returns BB_SARVAM_STT_VAD_SIGNALS from Redis"""
+    return await get_config("BB_SARVAM_STT_VAD_SIGNALS", True, bool)
+
+
+async def BB_SARVAM_STT_HIGH_VAD_SENSITIVITY() -> bool:
+    """Returns BB_SARVAM_STT_HIGH_VAD_SENSITIVITY from Redis"""
+    return await get_config("BB_SARVAM_STT_HIGH_VAD_SENSITIVITY", False, bool)


### PR DESCRIPTION
## Summary
- add a shared `app/ai/voice/stt` module that encapsulates common STT provider setup logic
- update Automatic and Breeze Buddy agents to build STT services through the shared helpers

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6937cd5b07848330925cee5f09f540a7)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized speech-to-text integrations to a builder/config-driven design with unified provider configs and normalized language-hint handling.
  * Soniox context is now supplied as JSON via config; public STT API surface preserved.

* **Chores**
  * Converted STT setup to async where needed and added dynamic Breeze Buddy STT configuration accessors for model, language, prompt, and VAD settings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->