### PR TITLE
(feat): move call initiation to background task scheduler

### DIFF
--- a/app/ai/voice/agents/breeze_buddy/managers/tasks.py
+++ b/app/ai/voice/agents/breeze_buddy/managers/tasks.py
@@ -1,0 +1,61 @@
+"""
+Breeze Buddy Background Task Initialization
+
+This module provides functionality to initialize Breeze Buddy background tasks,
+specifically the call initiation task that processes backlog leads.
+"""
+
+from app.ai.voice.agents.breeze_buddy.managers.calls import process_backlog_leads
+from app.core.config.dynamic import (
+    CALL_INITIATION_INTERVAL_SECONDS,
+    ENABLE_BB_CALL_INITIATION_LOOP,
+)
+from app.core.logger import logger
+
+
+async def initialize_call_initiation_tasks(scheduler) -> bool:
+    """
+    Initialize Breeze Buddy call initiation background tasks if properly configured.
+
+    Args:
+        scheduler: BackgroundTaskScheduler instance to register tasks with
+
+    Returns:
+        bool: True if tasks were registered successfully, False if skipped
+    """
+
+    # Check if call initiation loop is enabled (dynamic config from Redis)
+    if not await ENABLE_BB_CALL_INITIATION_LOOP():
+        logger.debug(
+            "Call initiation tasks skipped - ENABLE_BB_CALL_INITIATION_LOOP is disabled"
+        )
+        return False
+
+    try:
+        # Get interval from dynamic config
+        interval_seconds = await CALL_INITIATION_INTERVAL_SECONDS()
+
+        # Validate interval to prevent hot loops
+        if not interval_seconds or interval_seconds <= 0:
+            logger.error(
+                f"Invalid CALL_INITIATION_INTERVAL_SECONDS value: {interval_seconds}. "
+                "Must be a positive integer. Skipping task registration."
+            )
+            return False
+
+        # Register call initiation task
+        scheduler.register_task(
+            name="breeze_buddy_call_initiation",
+            func=process_backlog_leads,
+            interval_seconds=interval_seconds,
+        )
+        logger.info(
+            f"Registered breeze_buddy_call_initiation background task "
+            f"(interval: {interval_seconds}s)"
+        )
+
+        return True
+
+    except Exception as e:
+        logger.error(f"Failed to register call initiation background tasks: {e}")
+        return False

--- a/app/api/routers/breeze_buddy/cron.py
+++ b/app/api/routers/breeze_buddy/cron.py
@@ -1,11 +1,13 @@
 """
 Cron job endpoints for Breeze Buddy.
 Handles scheduled tasks and background job triggers.
+
+DEPRECATED: Call initiation is now handled by the background task scheduler.
+See: app/ai/voice/agents/breeze_buddy/managers/tasks.py
 """
 
-from fastapi import APIRouter, BackgroundTasks, Depends
+from fastapi import APIRouter, Depends
 
-from app.ai.voice.agents.breeze_buddy.managers.calls import process_backlog_leads
 from app.core.logger import logger
 from app.core.security.jwt import get_current_user
 from app.schemas import TokenData
@@ -15,12 +17,18 @@ router = APIRouter()
 
 @router.get("/cron/initiate")
 async def initiate_cron(
-    background_tasks: BackgroundTasks,
     current_user: TokenData = Depends(get_current_user),
 ):
     """
-    Initiates the cron job to process backlog leads.
+    DEPRECATED: This endpoint is no longer functional.
+    Call initiation is now handled automatically by the background task scheduler.
+    This endpoint is kept for backward compatibility and returns a 200 OK response.
     """
-    logger.info(f"Authenticated user {current_user.user_id} initiating cron job")
-    background_tasks.add_task(process_backlog_leads)
-    return {"status": "success", "message": "Lead processing initiated"}
+    logger.warning(
+        f"Deprecated /cron/initiate called by user {current_user.user_id}. "
+        "Call initiation is now handled by background task scheduler."
+    )
+    return {
+        "status": "ok",
+        "message": "Deprecated: Call initiation is now handled by background task scheduler",
+    }

--- a/app/core/config/dynamic.py
+++ b/app/core/config/dynamic.py
@@ -191,6 +191,17 @@ async def SHOPS_FOR_TEMPLATE_FLOW() -> list[str]:
     return [shop.strip() for shop in config_value.split(",") if shop.strip()]
 
 
+# --- Breeze Buddy Call Initiation Configuration ---
+async def ENABLE_BB_CALL_INITIATION_LOOP() -> bool:
+    """Returns ENABLE_BB_CALL_INITIATION_LOOP from Redis"""
+    return await get_config("ENABLE_BB_CALL_INITIATION_LOOP", True, bool)
+
+
+async def CALL_INITIATION_INTERVAL_SECONDS() -> int:
+    """Returns CALL_INITIATION_INTERVAL_SECONDS from Redis (default: 58 seconds)"""
+    return await get_config("CALL_INITIATION_INTERVAL_SECONDS", 58, int)
+
+
 # --- Breeze Buddy Azure LLM Configuration ---
 async def BREEZE_BUDDY_AZURE_MAX_COMPLETION_TOKENS() -> int:
     """Returns BREEZE_BUDDY_AZURE_MAX_COMPLETION_TOKENS from Redis"""

--- a/app/main.py
+++ b/app/main.py
@@ -14,6 +14,9 @@ from fastapi.responses import JSONResponse
 from pipecat.transports.daily.utils import DailyRESTHelper
 
 from app import __version__
+from app.ai.voice.agents.breeze_buddy.managers.tasks import (
+    initialize_call_initiation_tasks,
+)
 from app.api.routers import automatic, breeze_buddy, devcycle, systems
 
 # Import background task scheduler
@@ -164,7 +167,8 @@ async def lifespan(_app: FastAPI):
             # Initialize Langfuse tasks (if configured)
             await initialize_langfuse_tasks(_background_scheduler)
 
-            ### Register new tasks here
+            # Initialize Breeze Buddy call initiation tasks (if configured)
+            await initialize_call_initiation_tasks(_background_scheduler)
 
             # Start the scheduler only if tasks are registered
             if _background_scheduler.tasks:


### PR DESCRIPTION
- move the call initiation to background tasj scheduler

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Call initiation now runs automatically via background task scheduler with configurable interval settings.

* **Deprecations**
  * The manual call initiation endpoint is deprecated; call initiation is handled automatically by the scheduler.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->