### PR TITLE
api for fetching score per id

### DIFF
--- a/app/database/accessor/breeze_buddy/lead_call_tracker.py
+++ b/app/database/accessor/breeze_buddy/lead_call_tracker.py
@@ -21,6 +21,7 @@ from app.database.queries.breeze_buddy.lead_call_tracker import (
     get_leads_by_status_and_time_before_query,
     insert_lead_call_tracker_query,
     release_lock_on_lead_by_id_query,
+    update_langfuse_scores_query,
     update_lead_call_completion_details_query,
     update_lead_call_details_query,
     update_lead_call_initiated_time_query,
@@ -425,3 +426,30 @@ async def get_lead_based_analytics(
     except Exception as e:
         logger.error(f"Error getting lead-based analytics: {e}", exc_info=True)
         return []
+
+
+async def update_langfuse_scores(
+    call_id: str, langfuse_scores: Dict[str, Any]
+) -> Optional[LeadCallTracker]:
+    """
+    Update the langfuse_scores column for a specific call_id.
+
+    Args:
+        call_id: The call identifier (call_sid)
+        langfuse_scores: JSON object containing Langfuse evaluation scores
+
+    Returns:
+        Updated LeadCallTracker record if successful, None otherwise
+    """
+    logger.debug(f"Updating langfuse_scores for call_id: {call_id}")
+
+    try:
+        query_text, values = update_langfuse_scores_query(call_id, langfuse_scores)
+        result = await run_parameterized_query(query_text, values)
+        if result and get_row_count(result) > 0:
+            decoded_result = decode_lead_call_tracker(result[0])
+            return decoded_result
+        return None
+    except Exception as e:
+        logger.error(f"Error updating langfuse_scores for call_id {call_id}: {e}")
+        return None

--- a/app/database/decoder/breeze_buddy/lead_call_tracker.py
+++ b/app/database/decoder/breeze_buddy/lead_call_tracker.py
@@ -39,6 +39,7 @@ def decode_lead_call_tracker(row: asyncpg.Record) -> Optional[LeadCallTracker]:
         call_end_time=row["call_end_time"],
         cost=row["cost"],
         is_locked=row.get("is_locked", False),
+        langfuse_scores=parse_json(row, "langfuse_scores"),
         created_at=row["created_at"],
         updated_at=row["updated_at"],
     )

--- a/app/database/migrations/010_add_langfuse_scores_column.sql
+++ b/app/database/migrations/010_add_langfuse_scores_column.sql
@@ -1,0 +1,33 @@
+-- Migration: Add langfuse_scores column to lead_call_tracker
+-- Description: Store Langfuse evaluation scores for each call
+
+-- Add langfuse_scores column to store evaluation results
+ALTER TABLE lead_call_tracker 
+ADD COLUMN IF NOT EXISTS langfuse_scores JSONB DEFAULT NULL;
+
+-- Add index for querying records with/without scores
+CREATE INDEX IF NOT EXISTS idx_lead_call_tracker_langfuse_scores_null 
+    ON lead_call_tracker ((langfuse_scores IS NULL));
+
+-- Example structure of langfuse_scores:
+-- {
+--   "trace_id": "488464e5170c95c6ac770f158a73e48e",
+--   "trace_url": "https://periscope.breeze.in/trace/488464e5...",
+--   "scores": [
+--     {
+--       "id": "ed32b7e7-989b-4ead-afbe-33f2b1fdc9ed",
+--       "name": "HIGH LATENCY",
+--       "value": 1,
+--       "comment": "No latency issues detected",
+--       "timestamp": "2025-12-24T10:59:26.396Z"
+--     },
+--     {
+--       "id": "5c0fe7a6-c163-4000-9da1-7ca9aa767f8a",
+--       "name": "OUTCOME MISMATCH",
+--       "value": 1,
+--       "comment": "Outcome matches user intent",
+--       "timestamp": "2025-12-24T10:59:21.079Z"
+--     }
+--   ],
+--   "fetched_at": "2025-12-24T10:59:33Z"
+-- }

--- a/app/database/queries/breeze_buddy/lead_call_tracker.py
+++ b/app/database/queries/breeze_buddy/lead_call_tracker.py
@@ -407,3 +407,26 @@ def get_lead_based_analytics_query(
         GROUP BY request_id;
     """
     return text, values
+
+
+def update_langfuse_scores_query(
+    call_id: str, langfuse_scores: Dict[str, Any]
+) -> Tuple[str, List[Any]]:
+    """
+    Update the langfuse_scores column for a specific call_id.
+
+    Args:
+        call_id: The call identifier (call_sid)
+        langfuse_scores: JSON object containing Langfuse evaluation scores
+
+    Returns:
+        Tuple of (query_text, values)
+    """
+    text = f"""
+        UPDATE "{LEAD_CALL_TRACKER_TABLE}"
+        SET langfuse_scores = $1::jsonb, updated_at = NOW()
+        WHERE call_id = $2
+        RETURNING *;
+    """
+    values = [json.dumps(langfuse_scores), call_id]
+    return text, values

--- a/app/schemas/breeze_buddy/core.py
+++ b/app/schemas/breeze_buddy/core.py
@@ -52,6 +52,7 @@ class LeadCallTracker(BaseModel):
     call_end_time: Optional[datetime] = None
     cost: Optional[float] = None
     is_locked: bool = False
+    langfuse_scores: Optional[Dict[str, Any]] = None
     created_at: Optional[datetime] = None
     updated_at: Optional[datetime] = None
 

--- a/app/services/langfuse/tasks/score_monitor/score.py
+++ b/app/services/langfuse/tasks/score_monitor/score.py
@@ -20,6 +20,7 @@ from app.database.accessor.breeze_buddy.lead_call_tracker import (
     get_all_lead_call_trackers,
     get_lead_based_analytics,
     get_lead_by_call_id,
+    update_langfuse_scores,
 )
 from app.services.langfuse.client import langfuse_readonly_client
 from app.services.langfuse.trace import fetch_trace
@@ -781,7 +782,8 @@ class ScoreMonitor:
             logger.warning("No evaluators configured")
             return
 
-        # Fetch zero scores for all configured evaluators
+        # Fetch ALL scores for all configured evaluators and group by traceId
+        all_scores = []
         zero_scores_by_evaluator = {}
         total_zero_scores = 0
 
@@ -794,7 +796,10 @@ class ScoreMonitor:
                     to_timestamp=to_time,
                 )
 
-                # Filter for zero scores (failures)
+                # Collect all scores for DB storage
+                all_scores.extend(scores)
+
+                # Filter for zero scores (failures) for alerting
                 zero_scores = [s for s in scores if self._is_zero_score(s)]
                 zero_scores_by_evaluator[evaluator_name] = zero_scores
                 total_zero_scores += len(zero_scores)
@@ -810,6 +815,55 @@ class ScoreMonitor:
                     f"Error fetching scores for evaluator '{evaluator_name}': {e}"
                 )
                 zero_scores_by_evaluator[evaluator_name] = []
+
+        # ====================================================================
+        # Step 1: Group all scores by traceId
+        # ====================================================================
+        scores_by_trace: Dict[str, List[Dict[str, Any]]] = {}
+        for score in all_scores:
+            trace_id = score.get("trace_id")
+            if trace_id:
+                if trace_id not in scores_by_trace:
+                    scores_by_trace[trace_id] = []
+                scores_by_trace[trace_id].append(score)
+
+        logger.info(
+            f"Grouped {len(all_scores)} scores into {len(scores_by_trace)} unique traces"
+        )
+
+        # ====================================================================
+        # Step 2: Fetch trace details ONCE per unique trace and build mapping
+        # ====================================================================
+        trace_details_cache: Dict[str, Dict[str, Any]] = {}
+        trace_to_call_sid: Dict[str, str] = {}
+
+        for trace_id in scores_by_trace.keys():
+            try:
+                trace_details = await self.get_trace_details(trace_id)
+                if trace_details:
+                    trace_details_cache[trace_id] = trace_details
+                    # Extract call_sid from trace metadata
+                    metadata = trace_details.get("metadata", {})
+                    attributes = (
+                        metadata.get("attributes", {})
+                        if isinstance(metadata, dict)
+                        else {}
+                    )
+                    call_sid = attributes.get("call_sid")
+                    if call_sid:
+                        trace_to_call_sid[trace_id] = call_sid
+            except Exception as e:
+                logger.error(f"Error fetching trace details for {trace_id}: {e}")
+
+        logger.info(
+            f"Fetched trace details for {len(trace_details_cache)} traces, "
+            f"found call_sid for {len(trace_to_call_sid)} traces"
+        )
+
+        # ====================================================================
+        # Step 3: Store scores in database using cached trace_id -> call_sid mapping
+        # ====================================================================
+        await self._store_scores(scores_by_trace, trace_to_call_sid)
 
         # Update last check time BEFORE processing alerts
         # This ensures timestamp is saved even if alert sending fails/crashes
@@ -834,16 +888,15 @@ class ScoreMonitor:
             f"{len(zero_scores_by_evaluator)} evaluators, sending Slack alerts..."
         )
 
-        # Send individual alerts for each zero score
+        # Send individual alerts for each zero score using cached trace details
         for evaluator_name, zero_scores in zero_scores_by_evaluator.items():
             for score in zero_scores:
                 try:
-                    # Get trace details for additional context
                     trace_id = score.get("trace_id")
-                    trace_details = None
-
-                    if trace_id:
-                        trace_details = await self.get_trace_details(trace_id)
+                    # Use cached trace details instead of fetching again
+                    trace_details = (
+                        trace_details_cache.get(trace_id) if trace_id else None
+                    )
 
                     # Send Slack alert
                     await self.send_score_alert(
@@ -857,6 +910,69 @@ class ScoreMonitor:
                         f"Error sending Slack alert for trace {score.get('trace_id')}: "
                         f"{alert_error}"
                     )
+
+    async def _store_scores(
+        self,
+        scores_by_trace: Dict[str, List[Dict[str, Any]]],
+        trace_to_call_sid: Dict[str, str],
+    ) -> None:
+        """
+        Store scores in database using pre-computed trace_id -> call_sid mapping.
+
+        Args:
+            scores_by_trace: Dictionary mapping trace_id to list of scores
+            trace_to_call_sid: Dictionary mapping trace_id to call_sid
+        """
+        if not scores_by_trace:
+            logger.info("No scores to store in database")
+            return
+
+        # Process each trace and store scores
+        stored_count = 0
+        for trace_id, scores in scores_by_trace.items():
+            try:
+                # Get call_sid from pre-computed mapping
+                call_sid = trace_to_call_sid.get(trace_id)
+                if not call_sid:
+                    logger.info(f"No call_sid mapping found for trace {trace_id}")
+                    continue
+
+                # Build langfuse_scores object
+                langfuse_data = {
+                    "trace_id": trace_id,
+                    "trace_url": f"{LANGFUSE_BASEURL}/trace/{trace_id}",
+                    "scores": scores,
+                    "fetched_at": datetime.now(timezone.utc).isoformat(),
+                }
+
+                # Log what we're trying to store
+                scores_summary = ", ".join(
+                    f"{s.get('name')}={s.get('value')}" for s in scores
+                )
+                logger.info(
+                    f"Storing langfuse_scores for call_sid: {call_sid}, "
+                    f"trace_id: {trace_id}, scores_count: {len(scores)}, "
+                    f"scores: [{scores_summary}]"
+                )
+
+                # Store in database
+                result = await update_langfuse_scores(call_sid, langfuse_data)
+                if result:
+                    stored_count += 1
+                    logger.info(
+                        f"Langfuse scores updated successfully for call_sid: {call_sid}"
+                    )
+                else:
+                    logger.warning(
+                        f"Failed to store scores for call_sid: {call_sid} (not found in DB)"
+                    )
+
+            except Exception as e:
+                logger.error(f"Error storing scores for trace {trace_id}: {e}")
+
+        logger.info(
+            f"Stored Langfuse scores for {stored_count}/{len(scores_by_trace)} traces"
+        )
 
 
 # Global instance


### PR DESCRIPTION
- api for fetching score per id

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Store and retrieve Langfuse evaluation scores for lead calls and conversation traces.
  * Add persistent schema support for langfuse_scores with index for efficient queries.
  * Aggregate and persist evaluator scores by trace, reducing redundant lookups and improving performance.
  * Improve trace-detail caching and error handling during score processing and storage.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->