### PR TITLE
feat: Send webhook for BUSY/NO_ANSWER calls on all attempts

### DIFF
--- a/app/ai/voice/agents/breeze_buddy/managers/calls.py
+++ b/app/ai/voice/agents/breeze_buddy/managers/calls.py
@@ -191,9 +191,50 @@ async def _retry_call(
     lead: LeadCallTracker, config: CallExecutionConfig, outcome: Optional[str] = None
 ):
     """
-    Schedules a retry for a call.
+    Schedules a retry for a call and sends webhook for NO_ANSWER outcomes.
     """
-    if lead.attempt_count < config.max_retry - 1:
+    is_last_attempt = lead.attempt_count >= config.max_retry - 1
+
+    # Send webhook for NO_ANSWER on every attempt
+    if outcome == "NO_ANSWER":
+        reporting_webhook_url = lead.payload.get("reporting_webhook_url")
+        if reporting_webhook_url:
+            call_duration = None
+            if lead.call_initiated_time:
+                call_initiated_time_utc = lead.call_initiated_time.astimezone(
+                    timezone.utc
+                )
+                call_duration = (
+                    datetime.now(timezone.utc) - call_initiated_time_utc
+                ).total_seconds()
+
+            summary_data = {
+                "callSid": lead.call_id,
+                "outcome": outcome,
+                "attemptCount": lead.attempt_count + 1,
+                "callDuration": call_duration,
+                "orderId": lead.payload.get("order_id"),
+                "isLastAttempt": is_last_attempt,
+            }
+
+            try:
+                async with create_aiohttp_session() as session:
+                    success = await send_webhook_with_retry(
+                        session, reporting_webhook_url, summary_data, max_retries=3
+                    )
+                    if success:
+                        logger.info(
+                            f"Successfully sent call summary webhook on no_answer (attempt {lead.attempt_count + 1}, isLastAttempt: {is_last_attempt})."
+                        )
+                    else:
+                        logger.error(
+                            "Failed to send call summary webhook on no_answer after all retries."
+                        )
+            except Exception as e:
+                logger.error(f"Error sending webhook on no_answer: {e}")
+
+    # Schedule retry if not the last attempt
+    if not is_last_attempt:
         next_attempt_at = datetime.now(timezone.utc) + timedelta(
             seconds=config.retry_offset
         )
@@ -214,42 +255,6 @@ async def _retry_call(
                 )
             },
         )
-    else:
-        if outcome == "NO_ANSWER":
-            reporting_webhook_url = lead.payload.get("reporting_webhook_url")
-            if reporting_webhook_url:
-                call_duration = None
-                if lead.call_initiated_time:
-                    call_initiated_time_utc = lead.call_initiated_time.astimezone(
-                        timezone.utc
-                    )
-                    call_duration = (
-                        datetime.now(timezone.utc) - call_initiated_time_utc
-                    ).total_seconds()
-
-                summary_data = {
-                    "callSid": lead.call_id,
-                    "outcome": outcome,
-                    "attemptCount": lead.attempt_count + 1,
-                    "callDuration": call_duration,
-                    "orderId": lead.payload.get("order_id"),
-                }
-
-                try:
-                    async with create_aiohttp_session() as session:
-                        success = await send_webhook_with_retry(
-                            session, reporting_webhook_url, summary_data, max_retries=3
-                        )
-                        if success:
-                            logger.info(
-                                "Successfully sent call summary webhook on no_answer."
-                            )
-                        else:
-                            logger.error(
-                                "Failed to send call summary webhook on no_answer after all retries."
-                            )
-                except Exception as e:
-                    logger.error(f"Error sending webhook on no_answer: {e}")
 
 
 async def _cleanup_stuck_leads():
@@ -638,7 +643,7 @@ async def handle_call_completion(
     )
 
     if outcome in ["BUSY", "NO_ANSWER"]:
-        await _retry_call(lead, config)
+        await _retry_call(lead, config, outcome)
 
     return updated_lead
 

--- a/app/ai/voice/agents/breeze_buddy/websocket_bot.py
+++ b/app/ai/voice/agents/breeze_buddy/websocket_bot.py
@@ -56,7 +56,6 @@ from app.core.config.static import (
 )
 from app.core.logger import logger
 from app.database.accessor import (
-    get_call_execution_config_by_merchant_id,
     get_lead_by_call_id,
     update_lead_call_initiated_time,
 )
@@ -600,40 +599,12 @@ class OrderConfirmationBot:
                 except Exception as e:
                     logger.error(f"Error updating span with evaluation data: {e}")
 
-            # Check if this is the last retry attempt
-            is_last_attempt = False
-            if self.lead:
-                try:
-                    configs = await get_call_execution_config_by_merchant_id(
-                        self.lead.merchant_id, self.lead.shop_identifier
-                    )
-                    if configs:
-                        config = next(
-                            (c for c in configs if c.template == self.lead.template),
-                            None,
-                        )
-                        if config:
-                            current_attempt = self.lead.attempt_count + 1
-                            is_last_attempt = current_attempt >= config.max_retry
-                            logger.debug(
-                                f"Call {self.call_sid}: attempt {current_attempt}/{config.max_retry}, "
-                                f"is_last_attempt={is_last_attempt}"
-                            )
-                except Exception as e:
-                    logger.error(
-                        f"Error checking max retry for call {self.call_sid}: {e}",
-                        exc_info=True,
-                    )
-
-            # Send webhook - skip BUSY/NO_ANSWER unless it's the last attempt
-            should_send_webhook = self.reporting_webhook_url and (
-                self.outcome != "BUSY" or is_last_attempt
-            )
+            # Send webhook for all outcomes including BUSY/NO_ANSWER
+            should_send_webhook = self.reporting_webhook_url is not None
 
             if should_send_webhook:
                 logger.info(
                     f"Sending webhook for call {self.call_sid} with outcome {self.outcome}"
-                    + (" (last attempt)" if is_last_attempt else "")
                 )
                 try:
                     success = await send_webhook_with_retry(


### PR DESCRIPTION
DEV PROOF:
<img width="3456" height="2234" alt="image" src="https://github.com/user-attachments/assets/7ccf49e6-a4a8-463c-8190-6ee8012f3001" />
<img width="3456" height="2234" alt="image" src="https://github.com/user-attachments/assets/1b4e0efa-a348-4213-910a-8a53d97b34fc" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Webhook notifications are now sent more consistently for call outcomes (including NO_ANSWER and BUSY) whenever a reporting webhook URL is configured.
  * NO_ANSWER notifications are sent on every retry and include an isLastAttempt indicator and attempt count.

* **Bug Fixes**
  * Simplified final call logic so webhooks are reliably attempted for all outcomes, removing special-case last-attempt handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->