### PR TITLE
(fix): increase s2s tokens expiration limit

### DIFF
--- a/app/schemas/breeze_buddy/auth.py
+++ b/app/schemas/breeze_buddy/auth.py
@@ -85,7 +85,7 @@ class S2STokenRequest(BaseModel):
     username: str
     password: str
     token_lifetime_days: int = Field(
-        default=365, ge=1, le=365, description="Token lifetime in days (1-365)"
+        default=365, ge=1, le=365000, description="Token lifetime in days (1-365000)"
     )
 
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Extended the maximum token lifetime limit, allowing tokens to remain valid for longer periods (increased from 1-365 days to 1-365,000 days).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->