### PR TITLE
feat: Add inbound call support for Exotel telephony

### DIFF
--- a/app/ai/voice/agents/breeze_buddy/agent.py
+++ b/app/ai/voice/agents/breeze_buddy/agent.py
@@ -1,5 +1,6 @@
 import asyncio
 import json
+import uuid
 from datetime import datetime, timezone
 from typing import Optional
 
@@ -78,10 +79,17 @@ from app.database.accessor import (
     update_lead_call_initiated_time,
 )
 from app.database.accessor.breeze_buddy.lead_call_tracker import (
+    create_lead_call_tracker,
     update_lead_call_initiated_time_by_id,
 )
-from app.database.accessor.breeze_buddy.template import get_template_by_merchant
-from app.schemas import CallProvider
+from app.database.accessor.breeze_buddy.outbound_number import (
+    get_outbound_number_by_number,
+)
+from app.database.accessor.breeze_buddy.template import (
+    get_template_by_merchant,
+    get_template_by_outbound_number_id,
+)
+from app.schemas import CallDirection, CallProvider, LeadCallStatus
 
 
 class Agent:
@@ -306,14 +314,80 @@ class Agent:
                 start_data = call_data.get("start", {})
                 self.call_sid = start_data.get("call_sid")
 
-            await update_lead_call_initiated_time(self.call_sid, call_initiated_time)
             lead = await get_lead_by_call_id(self.call_sid)
+
             if not lead:
-                logger.error(f"Could not find lead for call_sid: {self.call_sid}")
-                return
+                # This is an inbound call - only supported for Exotel
+                if self.provider == CallProvider.TWILIO:
+                    logger.warning(
+                        f"Inbound calls not supported for Twilio. call_sid: {self.call_sid}"
+                    )
+                    return
+
+                logger.info(
+                    f"No lead found for call_sid: {self.call_sid} - treating as inbound call"
+                )
+
+                # Get the "to" and "from" numbers from Exotel call data
+                to_number = start_data.get("to") or call_data.get("to")
+                from_number = start_data.get("from") or call_data.get("from", "unknown")
+
+                if not to_number:
+                    logger.error(
+                        "Could not determine 'to' number from call data for inbound call"
+                    )
+                    return
+
+                logger.info(f"Inbound call to: {to_number}, from: {from_number}")
+
+                # Look up outbound number by phone number
+                outbound_number = await get_outbound_number_by_number(to_number)
+                if not outbound_number:
+                    logger.error(f"No outbound number found for to_number: {to_number}")
+                    return
+
+                # Look up template by outbound_number_id (only inbound-enabled templates)
+                template = await get_template_by_outbound_number_id(
+                    outbound_number.id, enable_inbound_only=True
+                )
+                if not template:
+                    logger.error(
+                        f"No inbound-enabled template found for outbound_number_id: {outbound_number.id}"
+                    )
+                    return
+
+                # Create lead on-the-fly for inbound call (with call_id set upfront)
+                lead_id = str(uuid.uuid4())
+                lead = await create_lead_call_tracker(
+                    id=lead_id,
+                    merchant_id=template.merchant_id,
+                    template=template.name,
+                    template_id=str(template.id),
+                    shop_identifier=template.shop_identifier,
+                    next_attempt_at=None,
+                    payload={"caller_number": from_number},
+                    call_initiated_time=call_initiated_time,
+                    status=LeadCallStatus.PROCESSING,
+                    call_id=self.call_sid,
+                    outbound_number_id=outbound_number.id,
+                    call_direction=CallDirection.INBOUND,
+                )
+
+                if not lead:
+                    logger.error("Failed to create lead for inbound call")
+                    return
+
+                logger.info(
+                    f"Created lead for inbound call: {lead.id}, call_sid: {self.call_sid}"
+                )
+            else:
+                # Outbound call - update call initiated time
+                await update_lead_call_initiated_time(
+                    self.call_sid, call_initiated_time
+                )
 
             self.lead = lead
-            call_payload = lead.payload
+            call_payload = lead.payload or {}
             self.reporting_webhook_url = call_payload.get("reporting_webhook_url")
 
             logger.info(

--- a/app/ai/voice/agents/breeze_buddy/managers/calls.py
+++ b/app/ai/voice/agents/breeze_buddy/managers/calls.py
@@ -40,6 +40,7 @@ from app.database.accessor import (
     update_outbound_number_status,
 )
 from app.schemas import (
+    CallDirection,
     CallExecutionConfig,
     CallProvider,
     LeadCallStatus,
@@ -260,6 +261,7 @@ async def _retry_call(
                     else False
                 )
             },
+            call_direction=lead.call_direction,  # Inherit call direction from parent lead
         )
 
 
@@ -303,8 +305,9 @@ async def _cleanup_stuck_leads():
             if outbound_number:
                 await _release_number(outbound_number.id, outbound_number.provider)
 
+            # Only retry outbound calls - inbound calls should not be retried
             config = await _get_lead_config(locked_lead)
-            if config:
+            if config and locked_lead.call_direction == CallDirection.OUTBOUND:
                 await _retry_call(locked_lead, config)
 
         except Exception as e:
@@ -665,7 +668,11 @@ async def handle_call_completion(
         call_end_time=call_end_time,
     )
 
-    if outcome in ["BUSY", "NO_ANSWER"]:
+    # Only retry outbound calls - inbound calls should not be retried
+    if (
+        outcome in ["BUSY", "NO_ANSWER"]
+        and lead.call_direction == CallDirection.OUTBOUND
+    ):
         await _retry_call(lead, config, outcome)
 
     return updated_lead

--- a/app/ai/voice/agents/breeze_buddy/template/types.py
+++ b/app/ai/voice/agents/breeze_buddy/template/types.py
@@ -57,6 +57,7 @@ class ConfigurationModel(BaseModel):
     vad_config: Optional[VadConfig] = Field(
         None, description="Default VAD configuration for the template"
     )
+    enable_inbound: bool = False  # Whether this template can handle inbound calls
 
 
 class FlowAction(BaseModel):

--- a/app/database/accessor/breeze_buddy/lead_call_tracker.py
+++ b/app/database/accessor/breeze_buddy/lead_call_tracker.py
@@ -29,6 +29,7 @@ from app.database.queries.breeze_buddy.lead_call_tracker import (
     update_lead_call_recording_url_query,
 )
 from app.schemas import (
+    CallDirection,
     ExecutionMode,
     LeadCallStatus,
     LeadCallTracker,
@@ -58,6 +59,9 @@ async def create_lead_call_tracker(
     template_id: Optional[str] = None,
     execution_mode: ExecutionMode = ExecutionMode.TELEPHONY,
     status: LeadCallStatus = LeadCallStatus.BACKLOG,  # Status with default for backward compatibility
+    call_id: Optional[str] = None,  # For inbound calls where call_sid is known upfront
+    outbound_number_id: Optional[str] = None,  # For inbound calls
+    call_direction: CallDirection = CallDirection.OUTBOUND,  # Direction of call
 ) -> Optional[LeadCallTracker]:
     """
     Create a new lead call tracker record.
@@ -66,6 +70,9 @@ async def create_lead_call_tracker(
         template_id: UUID of the template (preferred, for referential integrity)
         template: Name of the template (kept for backward compatibility)
         execution_mode: Execution mode (TELEPHONY, TELEPHONY_TEST, DAILY, DAILY_TEST)
+        call_id: Call SID (optional, used for inbound calls where call_sid is known upfront)
+        outbound_number_id: Outbound number ID (optional, used for inbound calls)
+        call_direction: Direction of call (INBOUND or OUTBOUND, defaults to OUTBOUND)
     """
     logger.info(f"Creating lead call tracker for merchant ID: {merchant_id}")
 
@@ -86,6 +93,9 @@ async def create_lead_call_tracker(
             request_id=request_id,
             execution_mode=execution_mode,
             status=status,  # Pass status (defaults to BACKLOG for backward compatibility)
+            call_id=call_id,
+            outbound_number_id=outbound_number_id,
+            call_direction=call_direction,
         )
 
         result = await run_parameterized_query(query_text, values)

--- a/app/database/accessor/breeze_buddy/outbound_number.py
+++ b/app/database/accessor/breeze_buddy/outbound_number.py
@@ -20,6 +20,7 @@ from app.database.queries.breeze_buddy.outbound_number import (
     get_all_outbound_numbers_with_call_count_query,
     get_outbound_number_based_on_status_and_provider_query,
     get_outbound_number_by_id_query,
+    get_outbound_number_by_number_query,
     increment_outbound_number_channels_query,
     insert_outbound_number_query,
     update_outbound_number_status_query,
@@ -294,3 +295,26 @@ async def get_outbound_number_based_on_status_and_provider(
     except Exception as e:
         logger.error(f"Error getting outbound numbers: {e}")
         return []
+
+
+async def get_outbound_number_by_number(number: str) -> Optional[OutboundNumber]:
+    """
+    Get outbound number by phone number.
+    """
+    logger.info(f"Getting outbound number by phone number: {number}")
+
+    try:
+        query_text, values = get_outbound_number_by_number_query(number)
+        result = await run_parameterized_query(query_text, values)
+
+        if result and get_row_count(result) > 0:
+            decoded_result = decode_outbound_number(result)
+            logger.info(f"Outbound number found: {decoded_result}")
+            return decoded_result
+
+        logger.info(f"No outbound number found with number: {number}")
+        return None
+
+    except Exception as e:
+        logger.error(f"Error getting outbound number by number: {e}")
+        return None

--- a/app/database/accessor/breeze_buddy/template.py
+++ b/app/database/accessor/breeze_buddy/template.py
@@ -20,6 +20,7 @@ from app.database.queries.breeze_buddy.template import (
     create_template_query,
     get_template_by_id_query,
     get_template_by_merchant_query,
+    get_template_by_outbound_number_id_query,
     get_templates_list_query,
     replace_template_query,
 )
@@ -360,4 +361,42 @@ async def replace_template(
 
     except Exception as e:
         logger.error(f"Error updating template: {e}", exc_info=True)
+        return None
+
+
+async def get_template_by_outbound_number_id(
+    outbound_number_id: str,
+    enable_inbound_only: bool = False,
+) -> Optional[TemplateModel]:
+    """
+    Get a template by outbound_number_id.
+
+    Args:
+        outbound_number_id: Outbound number UUID
+        enable_inbound_only: If True, only return templates with
+                             configurations.enable_inbound = true
+
+    Returns:
+        TemplateModel if found, None otherwise
+    """
+    logger.info(f"Getting template by outbound_number_id: {outbound_number_id}")
+
+    try:
+        query, values = get_template_by_outbound_number_id_query(
+            outbound_number_id, enable_inbound_only
+        )
+        result = await run_parameterized_query(query, values)
+
+        if result and get_row_count(result) > 0:
+            decoded_result = decode_template(result[0])
+            logger.info(f"Template found: {decoded_result.id}")
+            return decoded_result
+
+        logger.info(f"No template found with outbound_number_id: {outbound_number_id}")
+        return None
+
+    except Exception as e:
+        logger.error(
+            f"Error getting template by outbound_number_id: {e}", exc_info=True
+        )
         return None

--- a/app/database/decoder/breeze_buddy/lead_call_tracker.py
+++ b/app/database/decoder/breeze_buddy/lead_call_tracker.py
@@ -7,6 +7,7 @@ from typing import Optional
 import asyncpg
 
 from app.schemas import (
+    CallDirection,
     ExecutionMode,
     LeadCallStatus,
     LeadCallTracker,
@@ -42,6 +43,7 @@ def decode_lead_call_tracker(row: asyncpg.Record) -> Optional[LeadCallTracker]:
         is_locked=row.get("is_locked", False),
         langfuse_scores=parse_json(row, "langfuse_scores"),
         execution_mode=ExecutionMode(row.get("execution_mode", "TELEPHONY")),
+        call_direction=CallDirection(row.get("call_direction", "OUTBOUND")),
         created_at=row["created_at"],
         updated_at=row["updated_at"],
     )

--- a/app/database/migrations/012_add_call_direction_column.sql
+++ b/app/database/migrations/012_add_call_direction_column.sql
@@ -1,0 +1,18 @@
+-- Migration: Add call_direction column to lead_call_tracker
+-- Description: Tracks whether call was inbound or outbound
+--              OUTBOUND = We called customer
+--              INBOUND = Customer called us
+-- Note: DEFAULT 'OUTBOUND' will automatically set all existing rows to 'OUTBOUND'
+
+-- Add call_direction column with default value
+ALTER TABLE lead_call_tracker
+ADD COLUMN call_direction VARCHAR(20) DEFAULT 'OUTBOUND' NOT NULL;
+
+-- Add CHECK constraint for valid values
+ALTER TABLE lead_call_tracker
+ADD CONSTRAINT lead_call_tracker_call_direction_check
+CHECK (call_direction IN ('INBOUND', 'OUTBOUND'));
+
+-- Create index for efficient filtering
+CREATE INDEX idx_lead_call_tracker_call_direction
+ON lead_call_tracker (call_direction);

--- a/app/database/queries/breeze_buddy/lead_call_tracker.py
+++ b/app/database/queries/breeze_buddy/lead_call_tracker.py
@@ -6,7 +6,7 @@ import json
 from datetime import datetime
 from typing import Any, Dict, List, Optional, Tuple
 
-from app.schemas import ExecutionMode, LeadCallStatus
+from app.schemas import CallDirection, ExecutionMode, LeadCallStatus
 
 # Table names
 LEAD_CALL_TRACKER_TABLE = "lead_call_tracker"
@@ -30,6 +30,9 @@ def insert_lead_call_tracker_query(
     template_id: Optional[str] = None,
     execution_mode: ExecutionMode = ExecutionMode.TELEPHONY,
     status: LeadCallStatus = LeadCallStatus.BACKLOG,  # Status with default for backward compatibility
+    call_id: Optional[str] = None,  # For inbound calls where call_sid is known upfront
+    outbound_number_id: Optional[str] = None,  # For inbound calls
+    call_direction: CallDirection = CallDirection.OUTBOUND,  # Direction of call
 ) -> Tuple[str, List[Any]]:
     """
     Generate query to insert lead call tracker record.
@@ -38,6 +41,9 @@ def insert_lead_call_tracker_query(
         template_id: UUID of the template (preferred, for referential integrity)
         template: Name of the template (kept for backward compatibility)
         execution_mode: Execution mode (TELEPHONY, TELEPHONY_TEST, DAILY, DAILY_TEST)
+        call_id: Call SID (optional, used for inbound calls where call_sid is known upfront)
+        outbound_number_id: Outbound number ID (optional, used for inbound calls)
+        call_direction: Direction of call (INBOUND or OUTBOUND)
     """
     text = f"""
         INSERT INTO "{LEAD_CALL_TRACKER_TABLE}"
@@ -57,10 +63,13 @@ def insert_lead_call_tracker_query(
             "attempt_count",
             "cost",
             "execution_mode",
+            "call_id",
+            "outbound_number_id",
+            "call_direction",
             "created_at",
             "updated_at"
         )
-        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17) RETURNING *;
+        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20) RETURNING *;
     """
 
     values = [
@@ -79,6 +88,9 @@ def insert_lead_call_tracker_query(
         attempt_count,
         cost,
         execution_mode.value,
+        call_id,
+        outbound_number_id,
+        call_direction.value,
         datetime.now(),
         datetime.now(),
     ]

--- a/app/database/queries/breeze_buddy/outbound_number.py
+++ b/app/database/queries/breeze_buddy/outbound_number.py
@@ -197,3 +197,12 @@ def get_outbound_number_based_on_status_and_provider_query(
     """
     values = [status.value, provider.value]
     return text, values
+
+
+def get_outbound_number_by_number_query(number: str) -> Tuple[str, List[Any]]:
+    """
+    Generate query to get outbound number by phone number.
+    """
+    text = f'SELECT * FROM "{OUTBOUND_NUMBER_TABLE}" WHERE "number" = $1;'
+    values = [number]
+    return text, values

--- a/app/database/queries/breeze_buddy/template.py
+++ b/app/database/queries/breeze_buddy/template.py
@@ -149,6 +149,36 @@ def get_template_by_id_query(template_id: str) -> Tuple[str, List[Any]]:
     return query, [template_id]
 
 
+def get_template_by_outbound_number_id_query(
+    outbound_number_id: str,
+    enable_inbound_only: bool = False,
+) -> Tuple[str, List[Any]]:
+    """
+    Generate query to get a template by outbound_number_id.
+
+    Args:
+        outbound_number_id: Outbound number UUID
+        enable_inbound_only: If True, only return templates with
+                             configurations.enable_inbound = true
+    """
+    conditions = ["outbound_number_id = $1"]
+
+    if enable_inbound_only:
+        # Filter by enable_inbound in configurations JSON
+        # COALESCE ensures missing key defaults to FALSE
+        conditions.append(
+            "COALESCE((configurations->>'enable_inbound')::boolean, FALSE) = TRUE"
+        )
+
+    query = f"""
+        SELECT id, merchant_id, shop_identifier, name, flow, expected_payload_schema, expected_callback_response_schema, configurations, secrets, outbound_number_id, is_active, created_at, updated_at
+        FROM {TEMPLATE_TABLE}
+        WHERE {' AND '.join(conditions)}
+        LIMIT 1
+    """
+    return query, [outbound_number_id]
+
+
 def replace_template_query(
     template_id: str,
     name: str,

--- a/app/schemas/__init__.py
+++ b/app/schemas/__init__.py
@@ -47,6 +47,7 @@ from app.schemas.breeze_buddy.auth import (
 )
 from app.schemas.breeze_buddy.connection import BreezeBuddyDailyConnectRequest
 from app.schemas.breeze_buddy.core import (
+    CallDirection,
     CallExecutionConfig,
     CallProvider,
     CreateCallExecutionConfigRequest,
@@ -88,6 +89,7 @@ __all__ = [
     "TimeGranularity",
     "TrendDataPoint",
     # Core
+    "CallDirection",
     "CallExecutionConfig",
     "CallProvider",
     "CreateCallExecutionConfigRequest",

--- a/app/schemas/breeze_buddy/core.py
+++ b/app/schemas/breeze_buddy/core.py
@@ -40,6 +40,13 @@ class ExecutionMode(str, Enum):
     DAILY_TEST = "DAILY_TEST"  # Test Daily (web) calls
 
 
+class CallDirection(str, Enum):
+    """Direction of the call - inbound or outbound"""
+
+    INBOUND = "INBOUND"  # Customer called us
+    OUTBOUND = "OUTBOUND"  # We called customer
+
+
 class LeadCallTracker(BaseModel):
     """Lead call tracking model"""
 
@@ -63,6 +70,7 @@ class LeadCallTracker(BaseModel):
     is_locked: bool = False
     langfuse_scores: Optional[Dict[str, Any]] = None
     execution_mode: ExecutionMode = ExecutionMode.TELEPHONY
+    call_direction: CallDirection = CallDirection.OUTBOUND
     created_at: Optional[datetime] = None
     updated_at: Optional[datetime] = None
 


### PR DESCRIPTION
  Inbound Call Detection & Lead Creation:
   - Detect inbound calls when no existing lead is found for call_sid
   - Look up outbound number by the "to" phone number
   - Retrieve template configuration via outbound_number_id
   - Create lead on-the-fly with call_id and outbound_number_id set upfront

  New Database Accessors:
   - Add get_outbound_number_by_number to find outbound number by phone number
   - Add get_template_by_outbound_number_id to find template linked to an outbound number

  Call Direction Tracking:
   - Add CallDirection enum (INBOUND/OUTBOUND) to distinguish call types
   - Create migration to add call_direction column with DEFAULT 'OUTBOUND'
   - Update decoder, query, and accessor to support call_direction parameter
   - Mark inbound calls with CallDirection.INBOUND during lead creation

  Retry Logic Updates:
   - Skip retry attempts for inbound calls (BUSY/NO_ANSWER)
   - Apply check in handle_call_completion, handle_unanswered_calls, and _cleanup_stuck_leads
   - Inherit call_direction from parent lead when creating retry leads

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Inbound calls without existing leads are now auto-created as leads (with caller context and template selection) for supported providers.
  * Templates can opt in to inbound handling.

* **Improvements**
  * Calls are now classified as inbound or outbound; retry and scheduling logic only retries outbound calls.
  * Safer handling of call payloads and lifecycle logging.

* **Database**
  * Added call-direction column with validation and index to improve call filtering and tracking.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->