### PR TITLE
fix: demo data not getting fetched in voice mode

### DIFF
--- a/app/ai/voice/agents/automatic/__init__.py
+++ b/app/ai/voice/agents/automatic/__init__.py
@@ -447,7 +447,7 @@ async def run_normal_mode(args):
             "shopType": getattr(args, "shop_type", None),
             "userId": getattr(args, "user_name", None),
             "userEmail": getattr(args, "user_email", None),
-            "enableDemoMode": mode != Mode.LIVE,
+            "demoMode": mode != Mode.LIVE,
             "merchantId": getattr(args, "merchant_id", None),
             "platformIntegrations": getattr(args, "platform_integrations", None),
             "customerId": getattr(args, "customer_id", None),


### PR DESCRIPTION
Lighthouse expects field demoData where as clairvoyance is sending enableDemoData field
Due to this even for tools where we have support for demo data, we are still not displaying demo data

Dev proof: https://drive.google.com/file/d/1-BHC8XDybKxxFVXDjOZdOvKm5aC5ZeKK/view?usp=sharing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal configuration field naming in AI voice agent initialization to align with system conventions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->