### PR TITLE
Fix callduration in case of NO_ANSWER

### DIFF
--- a/app/ai/voice/agents/breeze_buddy/managers/calls.py
+++ b/app/ai/voice/agents/breeze_buddy/managers/calls.py
@@ -213,20 +213,11 @@ async def _retry_call(
     if outcome == "NO_ANSWER":
         reporting_webhook_url = (lead.payload or {}).get("reporting_webhook_url")
         if reporting_webhook_url:
-            call_duration = None
-            if lead.call_initiated_time:
-                call_initiated_time_utc = lead.call_initiated_time.astimezone(
-                    timezone.utc
-                )
-                call_duration = (
-                    datetime.now(timezone.utc) - call_initiated_time_utc
-                ).total_seconds()
-
             summary_data = {
                 "callSid": lead.call_id,
                 "outcome": outcome,
                 "attemptCount": lead.attempt_count + 1,
-                "callDuration": call_duration,
+                "callDuration": 0.0,
                 "orderId": lead.request_id,
                 "isLastAttempt": is_last_attempt,
             }


### PR DESCRIPTION
Sending callDuration as 0 in case of NO_ANSWER to nautilus

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated call duration reporting for no-answer calls to consistently report 0.0 in webhook payloads instead of computed values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->