### PR TITLE
feat: add ivr_priority field to control IVR menu order

### DIFF
--- a/app/ai/voice/agents/breeze_buddy/agent/ivr.py
+++ b/app/ai/voice/agents/breeze_buddy/agent/ivr.py
@@ -273,7 +273,7 @@ async def prepare_ivr_menu_audio(
 
         # Generate cache key from template names, voice, and greeting
         # MD5 hash ensures constant key size regardless of input length
-        cache_components = "|".join(sorted([t["name"] or "" for t in templates]))
+        cache_components = "|".join([t["name"] or "" for t in templates])
         cache_components += f"|voice:{voice_name}|greeting:{ivr_greeting or 'default'}"
         cache_key = f"{IVR_AUDIO_CACHE_PREFIX}{hashlib.md5(cache_components.encode()).hexdigest()}"
 

--- a/app/ai/voice/agents/breeze_buddy/template/types.py
+++ b/app/ai/voice/agents/breeze_buddy/template/types.py
@@ -60,6 +60,11 @@ class ConfigurationModel(BaseModel):
     ivr_description: Optional[str] = (
         None  # Description for IVR menu (e.g., "Trip feedback in English")
     )
+    ivr_priority: Optional[int] = Field(
+        None,
+        ge=1,
+        description="Priority order for IVR menu (lower number = earlier in menu). Gaps allowed (e.g., 1, 3, 4).",
+    )
     vad_config: Optional[VadConfig] = Field(
         None, description="Default VAD configuration for the template"
     )

--- a/app/database/queries/breeze_buddy/template.py
+++ b/app/database/queries/breeze_buddy/template.py
@@ -210,7 +210,9 @@ def get_all_templates_by_outbound_number_id_query(
         WHERE outbound_number_id = $1
         AND is_active = TRUE
         AND COALESCE((configurations->>'enable_inbound')::boolean, FALSE) = TRUE
-        ORDER BY name ASC
+        ORDER BY 
+            COALESCE((configurations->>'ivr_priority')::integer, 999999) ASC,
+            name ASC
     """
     return query, [outbound_number_id]
 


### PR DESCRIPTION
Added ivr_priority support to templates inside configurations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
* **IVR Menu Priority Ordering**: Users can now assign priority values to templates to control their sequence in IVR menus. Lower priority numbers appear earlier, with flexible numbering that allows gaps in the sequence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->