### PR TITLE
(feat): add support to enable/disable ringing sound in template

### DIFF
--- a/app/ai/voice/agents/breeze_buddy/agent/utils.py
+++ b/app/ai/voice/agents/breeze_buddy/agent/utils.py
@@ -51,12 +51,16 @@ async def send_initial_greeting(
             template=template,
             provider=provider,
         )
-        if not greeting_result:
+        if greeting_result is None:
             logger.warning("Failed to prepare greeting payload, skipping initial audio")
             track_error(
                 errors, "Failed to prepare greeting payload, skipping initial audio"
             )
             return GreetingResult(source=None, text=None)
+
+        if greeting_result.get("greeting_source") == "disabled":
+            logger.info("Initial audio intentionally skipped (ringing sound disabled)")
+            return GreetingResult(source="disabled", text=None)
 
         greeting_source = greeting_result["greeting_source"]
         greeting_text = greeting_result.get("greeting_text")

--- a/app/ai/voice/agents/breeze_buddy/template/types.py
+++ b/app/ai/voice/agents/breeze_buddy/template/types.py
@@ -181,6 +181,9 @@ class ConfigurationModel(BaseModel):
     enable_background_sound: bool = False
     background_sound_file: Optional[BackgroundSoundFile] = None
     background_sound_volume: float = 2.0
+    enable_ringing_sound: bool = (
+        True  # Whether to play ringing/dial tone sound during initial setup
+    )
     initial_greeting: Optional[str] = (
         None  # Initial greeting text template with variables (e.g., "Hi {customer_name}")
     )

--- a/app/ai/voice/agents/breeze_buddy/utils/common.py
+++ b/app/ai/voice/agents/breeze_buddy/utils/common.py
@@ -506,8 +506,10 @@ async def prepare_initial_greeting_payload(
 
     Returns:
         Dictionary with "payload" (base64 encoded audio), "greeting_source",
-        and "greeting_text" (the resolved greeting text for LLM context),
-        or None if preparation failed
+        and "greeting_text" (the resolved greeting text for LLM context).
+        If ringing sound is disabled and no greeting exists, returns
+        {"payload": None, "greeting_source": "disabled"}.
+        Returns None only if preparation failed
     """
     try:
         logger.info("Preparing initial greeting audio payload.")
@@ -564,18 +566,32 @@ async def prepare_initial_greeting_payload(
                         f"Deleted dynamic greeting from Redis for lead {lead.id}"
                     )
 
-        # 3. Fall back to dial tone if no greeting audio found
+        # 3. Fall back to dial tone if no greeting audio found (and ringing sound is enabled)
         if not mulaw_data:
-            logger.info("No greeting audio found, using dial tone")
-            wav_file_path = (
-                "app/ai/voice/agents/breeze_buddy/static/audio/dial-tone.wav"
-            )
+            # Check if ringing sound is enabled in template configuration
+            enable_ringing_sound = True  # Default to enabled for backward compatibility
+            if template and template.configurations:
+                enable_ringing_sound = getattr(
+                    template.configurations, "enable_ringing_sound", True
+                )
 
-            # Load and convert audio
-            audio = AudioSegment.from_wav(wav_file_path)
-            audio = audio.set_frame_rate(8000).set_channels(1).set_sample_width(2)
-            pcm_data: bytes = audio.raw_data  # type: ignore[assignment]
-            mulaw_data = audioop.lin2ulaw(pcm_data, 2)
+            if enable_ringing_sound:
+                logger.info("No greeting audio found, using dial tone")
+                wav_file_path = (
+                    "app/ai/voice/agents/breeze_buddy/static/audio/dial-tone.wav"
+                )
+
+                # Load and convert audio
+                audio = AudioSegment.from_wav(wav_file_path)
+                audio = audio.set_frame_rate(8000).set_channels(1).set_sample_width(2)
+                pcm_data: bytes = audio.raw_data  # type: ignore[assignment]
+                mulaw_data = audioop.lin2ulaw(pcm_data, 2)
+                greeting_source = "dial_tone"
+            else:
+                logger.info(
+                    "No greeting audio found and ringing sound is disabled, skipping initial audio"
+                )
+                return {"payload": None, "greeting_source": "disabled"}
 
         logger.info(f"Prepared initial greeting audio from source: {greeting_source}")
 


### PR DESCRIPTION
- added configuration to control initial rigning sound

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configuration option to enable/disable the ringing/dial-tone during initial voice-agent setup (defaults to enabled).
* **Behavior Changes**
  * When ringing is disabled, the agent now skips dial-tone fallback and returns a disabled greeting payload; greeting text is still provided when available.
* **Bug Fixes**
  * Improved handling of missing greeting payloads with clearer early exits and logs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->