### PR TITLE
Extract call provider from number instead of config

### DIFF
--- a/app/ai/voice/agents/breeze_buddy/managers/calls.py
+++ b/app/ai/voice/agents/breeze_buddy/managers/calls.py
@@ -421,7 +421,7 @@ async def process_backlog_leads():
                     continue
 
                 call_provider = get_voice_provider(
-                    config.calling_provider,
+                    number_to_use.provider,
                     session,
                     use_template_flow,
                 )


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected outbound call routing to use the voice provider associated with the selected phone number, ensuring proper call handling and retry paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->