### PR TITLE
Add configurable recording time limit for Plivo calls

### DIFF
--- a/app/ai/voice/agents/breeze_buddy/services/telephony/plivo/recording.py
+++ b/app/ai/voice/agents/breeze_buddy/services/telephony/plivo/recording.py
@@ -8,7 +8,12 @@ from typing import Optional
 import aiohttp
 import plivo
 
-from app.core.config.static import APP_BASE_URL, PLIVO_AUTH_ID, PLIVO_AUTH_TOKEN
+from app.core.config.static import (
+    APP_BASE_URL,
+    PLIVO_AUTH_ID,
+    PLIVO_AUTH_TOKEN,
+    PLIVO_RECORDING_TIME_LIMIT,
+)
 from app.core.logger import logger
 from app.core.transport.http_client import get_proxy_config
 
@@ -31,7 +36,10 @@ def start_call_recording(call_uuid: str) -> bool:
         # Start recording the call with callback URL
         callback_url = f"{APP_BASE_URL}/agent/voice/breeze-buddy/plivo/callback/details"
         response = client.calls.record(
-            call_uuid=call_uuid, callback_url=callback_url, callback_method="POST"
+            call_uuid=call_uuid,
+            callback_url=callback_url,
+            callback_method="POST",
+            time_limit=PLIVO_RECORDING_TIME_LIMIT,
         )
 
         logger.info(f"Plivo recording started successfully: {response}")

--- a/app/core/config/static.py
+++ b/app/core/config/static.py
@@ -432,6 +432,9 @@ EXOTEL_TEMPLATE_APPLET_APP_ID = os.getenv("EXOTEL_TEMPLATE_APPLET_APP_ID", "")
 # Plivo Configuration
 PLIVO_AUTH_ID = os.getenv("PLIVO_AUTH_ID", "")
 PLIVO_AUTH_TOKEN = os.getenv("PLIVO_AUTH_TOKEN", "")
+PLIVO_RECORDING_TIME_LIMIT = int(
+    os.getenv("PLIVO_RECORDING_TIME_LIMIT", "14400")
+)  # Default: 4 hours (14400 seconds)
 
 # Proxy Configuration
 AWS_PROXY_HOST = os.environ.get("AWS_PROXY_HOST")


### PR DESCRIPTION
## Summary
This PR adds support for configurable recording time limits when recording calls through Plivo's telephony service. Previously, calls were recorded without a time limit constraint, which could lead to unexpectedly long recordings.

## Changes
- **Configuration**: Added `PLIVO_RECORDING_TIME_LIMIT` environment variable to `app/core/config/static.py` with a default value of 14400 seconds (4 hours)
- **Recording Service**: Updated `start_call_recording()` in the Plivo recording service to pass the `time_limit` parameter when initiating call recordings
- **Imports**: Reorganized imports in the recording module to include the new configuration constant

## Implementation Details
- The time limit is configurable via the `PLIVO_RECORDING_TIME_LIMIT` environment variable
- Default limit is set to 4 hours (14400 seconds), which aligns with typical call recording requirements
- The parameter is passed directly to Plivo's `calls.record()` API method
- Import statements were reformatted for better readability following PEP 8 conventions

https://claude.ai/code/session_01VRsMb9D14dFYY6au5oczNp

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Implemented a recording time limit for voice calls to prevent indefinite recordings. Default maximum duration is set to 4 hours and is configurable via environment variables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->