### PR TITLE
Add per-template ElevenLabs voice configuration support

### DIFF
--- a/app/ai/voice/agents/breeze_buddy/agent/pipeline.py
+++ b/app/ai/voice/agents/breeze_buddy/agent/pipeline.py
@@ -104,10 +104,21 @@ async def create_services(
             f"Using Cartesia voice configurations from template: {cartesia_voice_config}"
         )
 
+    # Extract ElevenLabs voice configurations from template
+    elevenlabs_voice_config = getattr(
+        configurations, "elevenlabs_voice_configurations", None
+    )
+
+    if elevenlabs_voice_config:
+        logger.info(
+            f"Using ElevenLabs voice configurations from template: {elevenlabs_voice_config}"
+        )
+
     tts = await get_tts_service(
         voice_name=getattr(configurations, "tts_voice_name", None),
         mira_voice_id=legacy_mira_voice_id,
         cartesia_voice_configurations=cartesia_voice_config,
+        elevenlabs_voice_configurations=elevenlabs_voice_config,
     )
 
     return stt, llm, tts

--- a/app/ai/voice/agents/breeze_buddy/examples/templates/elevenlabs-voice-config-example.json
+++ b/app/ai/voice/agents/breeze_buddy/examples/templates/elevenlabs-voice-config-example.json
@@ -1,0 +1,127 @@
+{
+  "merchant": "breeze",
+  "template_name": "elevenlabs-voice-config-example",
+  "identifier": "elevenlabs-demo",
+  "is_active": true,
+  "description": "Example template demonstrating ElevenLabs voice configuration parameters",
+  "expected_payload_schema": {
+    "customer_name": {
+      "type": "string"
+    },
+    "order_id": {
+      "type": "string"
+    }
+  },
+  "configurations": {
+    "tts_voice_name": "rhea",
+    "stt_language": "en",
+    "elevenlabs_voice_configurations": {
+      "voice_id": "fG9s0SXJb213f4UxVHyG",
+      "model_id": "eleven_flash_v2_5",
+      "speed": 1.2,
+      "language": "en"
+    },
+    "enable_background_sound": false,
+    "background_sound_volume": 2.0
+  },
+  "expected_callback_response_schema": {
+    "status": {
+      "type": "string"
+    }
+  },
+  "flow": {
+    "initial_node": "greeting",
+    "end_conversation_callbacks": ["service_callback"],
+    "nodes": [
+      {
+        "node_name": "greeting",
+        "task_messages": [
+          {
+            "role": "system",
+            "content": "Greet the customer warmly:\n\"Hello {customer_name}! Your order #{order_id} has been confirmed. Would you like me to share the order details?\""
+          }
+        ],
+        "role_messages": [
+          {
+            "role": "system",
+            "content": "You are a friendly customer service representative.\n\nIMPORTANT: This template demonstrates ElevenLabs voice configuration:\n- Voice ID: Custom voice for this template\n- Model: eleven_flash_v2_5 (low-latency model)\n- Speed: 1.2 (slightly faster for efficiency)\n- Language: en (English TTS)\n\nThese settings override the global Redis defaults for this specific template.\n\nSpeak naturally in English. Keep responses concise and friendly."
+          }
+        ],
+        "pre_actions": [
+          {
+            "type": "function",
+            "handler": "mute_stt"
+          }
+        ],
+        "post_actions": [
+          {
+            "type": "function",
+            "handler": "unmute_stt"
+          }
+        ],
+        "functions": [
+          {
+            "function_name": "user_wants_details",
+            "description": "Call when user wants to hear order details",
+            "properties": {},
+            "required": [],
+            "transition_to": "order_details",
+            "hooks": []
+          },
+          {
+            "function_name": "user_not_interested",
+            "description": "Call when user doesn't want to continue",
+            "properties": {},
+            "required": [],
+            "transition_to": "end_call",
+            "hooks": []
+          }
+        ]
+      },
+      {
+        "node_name": "order_details",
+        "task_messages": [
+          {
+            "role": "system",
+            "content": "Provide order details:\n\"Your order will be delivered in 2-3 business days. Thank you!\""
+          }
+        ],
+        "role_messages": [
+          {
+            "role": "system",
+            "content": "Provide the delivery information and thank the customer."
+          }
+        ],
+        "pre_actions": [],
+        "post_actions": [
+          {
+            "type": "end_conversation"
+          }
+        ],
+        "functions": []
+      },
+      {
+        "node_name": "end_call",
+        "task_messages": [
+          {
+            "role": "system",
+            "content": "End the call politely:\n\"Alright, thank you! Have a great day.\""
+          }
+        ],
+        "role_messages": [
+          {
+            "role": "system",
+            "content": "Thank the customer and end the call."
+          }
+        ],
+        "pre_actions": [],
+        "post_actions": [
+          {
+            "type": "end_conversation"
+          }
+        ],
+        "functions": []
+      }
+    ]
+  }
+}

--- a/app/ai/voice/agents/breeze_buddy/template/types.py
+++ b/app/ai/voice/agents/breeze_buddy/template/types.py
@@ -62,6 +62,28 @@ class CartesiaVoiceConfiguration(BaseModel):
     )
 
 
+class ElevenLabsVoiceConfiguration(BaseModel):
+    """ElevenLabs voice configuration parameters for template-level customization.
+
+    Allows per-template override of ElevenLabs TTS parameters.
+    Values specified here take precedence over global Redis defaults.
+    """
+
+    voice_id: Optional[str] = Field(None, description="ElevenLabs voice ID")
+    model_id: Optional[str] = Field(
+        None, description="ElevenLabs model ID (e.g., 'eleven_flash_v2_5')"
+    )
+    speed: Optional[float] = Field(
+        None,
+        ge=0.7,
+        le=1.2,
+        description="Speed multiplier (ElevenLabs range: 0.7-1.2, where 1.0 is default)",
+    )
+    language: Optional[str] = Field(
+        None, description="TTS language code (e.g., 'en', 'hi')"
+    )
+
+
 class TTSVoiceName(str, Enum):
     RHEA = "rhea"
     SARA = "sara"
@@ -96,6 +118,9 @@ class ConfigurationModel(BaseModel):
     )
     cartesia_voice_configurations: Optional[CartesiaVoiceConfiguration] = (
         None  # Cartesia voice configuration (overrides global defaults)
+    )
+    elevenlabs_voice_configurations: Optional[ElevenLabsVoiceConfiguration] = (
+        None  # ElevenLabs voice configuration (overrides global defaults)
     )
     stt_language: Optional[str] = None
     payload_based_language_selection: bool = False

--- a/app/ai/voice/agents/breeze_buddy/tts/__init__.py
+++ b/app/ai/voice/agents/breeze_buddy/tts/__init__.py
@@ -3,7 +3,10 @@
 from pipecat.services.cartesia.tts import GenerationConfig
 from pipecat.transcriptions.language import Language
 
-from app.ai.voice.agents.breeze_buddy.template.types import CartesiaVoiceConfiguration
+from app.ai.voice.agents.breeze_buddy.template.types import (
+    CartesiaVoiceConfiguration,
+    ElevenLabsVoiceConfiguration,
+)
 from app.ai.voice.agents.breeze_buddy.utils.common import convert_to_mulaw
 from app.ai.voice.tts import (
     CartesiaConfig,
@@ -24,6 +27,9 @@ from app.core.config.dynamic import (
     BB_CARTESIA_LANGUAGE,
     BB_CARTESIA_MODEL,
     BB_CARTESIA_VOICE_ID,
+    BB_ELEVENLABS_MODEL_ID,
+    BB_ELEVENLABS_VOICE_ID,
+    BB_ELEVENLABS_VOICE_SPEED,
     BB_ENABLE_ELEVENLABS_INDIAN_RESIDENCY,
     BB_SARVAM_TTS_ENABLE_PREPROCESSING,
     BB_SARVAM_TTS_LANGUAGE_CODE,
@@ -36,11 +42,8 @@ from app.core.config.dynamic import (
 from app.core.config.static import (
     CARTESIA_API_KEY,
     ELEVENLABS_API_KEY,
-    ELEVENLABS_BB_VOICE_ID,
     ELEVENLABS_INDIAN_RESIDENCY_API_KEY,
     ELEVENLABS_INDIAN_RESIDENCY_WEBSOCKET_URL,
-    ELEVENLABS_MODEL_ID,
-    ELEVENLABS_VOICE_SPEED,
     SARVAM_API_KEY,
 )
 from app.core.logger import logger
@@ -167,11 +170,19 @@ async def get_sarvam_tts_service():
     )
 
 
-async def get_elevenlabs_tts_service():
+async def get_elevenlabs_tts_service(
+    elevenlabs_config: ElevenLabsVoiceConfiguration | None = None,
+):
     """
     Returns an ElevenLabs TTS service instance based on the Breeze Buddy configuration.
-    """
 
+    Template-level values (if provided) override global Redis defaults.
+
+    Args:
+        elevenlabs_config: Template-level ElevenLabs voice configuration. Values specified here
+                          override global Redis defaults. If None or specific fields are None,
+                          falls back to Redis configuration.
+    """
     use_indian_residency = await BB_ENABLE_ELEVENLABS_INDIAN_RESIDENCY()
     if use_indian_residency and not ELEVENLABS_INDIAN_RESIDENCY_API_KEY:
         raise ValueError(
@@ -180,6 +191,43 @@ async def get_elevenlabs_tts_service():
 
     if not use_indian_residency and not ELEVENLABS_API_KEY:
         raise ValueError("ELEVENLABS_API_KEY is not set")
+
+    # Load global Redis defaults
+    default_voice_id = await BB_ELEVENLABS_VOICE_ID()
+    default_model_id = await BB_ELEVENLABS_MODEL_ID()
+    default_speed = await BB_ELEVENLABS_VOICE_SPEED()
+
+    # Template overrides Redis defaults
+    final_voice_id = (
+        elevenlabs_config.voice_id
+        if elevenlabs_config and elevenlabs_config.voice_id
+        else default_voice_id
+    )
+    final_model_id = (
+        elevenlabs_config.model_id
+        if elevenlabs_config and elevenlabs_config.model_id
+        else default_model_id
+    )
+    final_speed = (
+        elevenlabs_config.speed
+        if elevenlabs_config and elevenlabs_config.speed is not None
+        else default_speed
+    )
+
+    # Map language code string to Language enum
+    language = Language.EN_IN
+    if elevenlabs_config and elevenlabs_config.language:
+        try:
+            language = Language[elevenlabs_config.language.upper().replace("-", "_")]
+        except KeyError:
+            logger.warning(
+                f"Language code '{elevenlabs_config.language}' not found in Language enum, using EN_IN"
+            )
+
+    logger.info(
+        f"Building ElevenLabs TTS with: voice_id={final_voice_id}, "
+        f"model_id={final_model_id}, speed={final_speed}, language={language}"
+    )
 
     return build_elevenlabs_tts(
         ElevenLabsConfig(
@@ -194,10 +242,10 @@ async def get_elevenlabs_tts_service():
                 if use_indian_residency
                 else "wss://api.elevenlabs.io"
             ),
-            voice_id=ELEVENLABS_BB_VOICE_ID,
-            model_id=ELEVENLABS_MODEL_ID,
-            speed=ELEVENLABS_VOICE_SPEED,
-            language=Language.EN_IN,
+            voice_id=final_voice_id,
+            model_id=final_model_id,
+            speed=final_speed,
+            language=language,
         )
     )
 
@@ -206,6 +254,7 @@ async def get_tts_service(
     voice_name: str | None = None,
     mira_voice_id: str | None = None,
     cartesia_voice_configurations: CartesiaVoiceConfiguration | None = None,
+    elevenlabs_voice_configurations: ElevenLabsVoiceConfiguration | None = None,
 ):
     """
     Returns a TTS service instance based on the environment configuration.
@@ -221,6 +270,8 @@ async def get_tts_service(
                       Use cartesia_voice_configurations.voice_id instead.
         cartesia_voice_configurations: Template-level Cartesia voice configuration (volume, speed, emotion, language).
                                        Only used when voice_name is "mira" or tts_service is "cartesia".
+        elevenlabs_voice_configurations: Template-level ElevenLabs voice configuration (voice_id, model_id, speed, language).
+                                         Only used when voice_name is "rhea" or tts_service is "elevenlabs".
     """
 
     if voice_name is not None:
@@ -233,11 +284,10 @@ async def get_tts_service(
             return await get_sarvam_tts_service()
 
         elif voice_name.lower() == "rhea":
-            if not ELEVENLABS_API_KEY:
-                raise ValueError("ELEVENLABS_API_KEY is required for Rhea voice")
-
             logger.info("Using ElevenLabs TTS service for Rhea voice")
-            return await get_elevenlabs_tts_service()
+            return await get_elevenlabs_tts_service(
+                elevenlabs_config=elevenlabs_voice_configurations,
+            )
 
         elif voice_name.lower() == "mira":
             if not CARTESIA_API_KEY:
@@ -262,13 +312,10 @@ async def get_tts_service(
         return await get_sarvam_tts_service()
 
     elif tts_service == "elevenlabs":
-        if not ELEVENLABS_API_KEY:
-            raise ValueError(
-                "ELEVENLABS_API_KEY is required when BREEZE_BUDDY_TTS_SERVICE=elevenlabs"
-            )
-
         logger.info("Using ElevenLabs TTS service for Breeze Buddy voice")
-        return await get_elevenlabs_tts_service()
+        return await get_elevenlabs_tts_service(
+            elevenlabs_config=elevenlabs_voice_configurations,
+        )
 
     elif tts_service == "cartesia":
         if not CARTESIA_API_KEY:

--- a/app/core/config/dynamic.py
+++ b/app/core/config/dynamic.py
@@ -280,3 +280,19 @@ async def BB_NOISE_CANCELLATION_LEVEL() -> int:
 async def BB_ENABLE_ELEVENLABS_INDIAN_RESIDENCY() -> bool:
     """Returns BB_ENABLE_ELEVENLABS_INDIAN_RESIDENCY from Redis"""
     return await get_config("BB_ENABLE_ELEVENLABS_INDIAN_RESIDENCY", True, bool)
+
+
+# --- Breeze Buddy ElevenLabs TTS Configuration ---
+async def BB_ELEVENLABS_VOICE_ID() -> str:
+    """Returns BB_ELEVENLABS_VOICE_ID from Redis"""
+    return await get_config("BB_ELEVENLABS_VOICE_ID", "fG9s0SXJb213f4UxVHyG", str)
+
+
+async def BB_ELEVENLABS_MODEL_ID() -> str:
+    """Returns BB_ELEVENLABS_MODEL_ID from Redis"""
+    return await get_config("BB_ELEVENLABS_MODEL_ID", "eleven_flash_v2_5", str)
+
+
+async def BB_ELEVENLABS_VOICE_SPEED() -> float:
+    """Returns BB_ELEVENLABS_VOICE_SPEED from Redis"""
+    return await get_config("BB_ELEVENLABS_VOICE_SPEED", 1.15, float)


### PR DESCRIPTION
Mirrors the existing Cartesia per-template voice configuration pattern for ElevenLabs.
Templates can now override global ElevenLabs defaults (voice_id, model_id, speed, language)
via the elevenlabs_voice_configurations field when tts_voice_name is set to "rhea".

https://claude.ai/code/session_01SidiTLNSAi1erMLrtvfjQS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added template-level ElevenLabs voice configuration support, allowing per-template overrides for voice ID, model selection, speech speed, and language settings.
  * Introduced example template demonstrating ElevenLabs voice configuration with structured flow and interaction nodes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->