### PR TITLE
Fix webhook payload parameter in breeze_buddy webhook retry

### DIFF
--- a/app/ai/voice/agents/breeze_buddy/utils/common.py
+++ b/app/ai/voice/agents/breeze_buddy/utils/common.py
@@ -137,7 +137,7 @@ async def send_webhook_with_retry(
     for attempt in range(1, max_retries + 1):
         try:
             logger.info(f"Webhook attempt {attempt}/{max_retries} to {url}")
-            async with session.post(url, json=data, headers=headers) as response:
+            async with session.post(url, data=payload, headers=headers) as response:
                 if response.status == 200:
                     logger.info(f"Webhook succeeded on attempt {attempt}")
                     return True


### PR DESCRIPTION
## Summary
Fixed incorrect parameter usage in the webhook retry function where `json=data` was being passed instead of `data=payload` to the POST request.

## Key Changes
- Changed `session.post(url, json=data, headers=headers)` to `session.post(url, data=payload, headers=headers)` in the `send_webhook_with_retry` function
- This ensures the correct payload variable is being sent with the webhook request

## Implementation Details
The webhook retry logic was referencing an undefined `data` parameter instead of the `payload` variable that should be sent. This fix aligns the actual parameter being passed with the intended payload variable, ensuring webhooks are sent with the correct data.

https://claude.ai/code/session_01FHsmrqUd6bgJBhgJ73uPe7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved webhook retry mechanism to ensure reliable request delivery with proper payload formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->