### PR TITLE
Add feature flag to disable Redis dynamic config lookups

### DIFF
--- a/app/core/config/static.py
+++ b/app/core/config/static.py
@@ -501,6 +501,12 @@ REDIS_PORT = os.getenv("REDIS_PORT", "")
 REDIS_CLUSTER_NODES = os.getenv("REDIS_CLUSTER_NODES", "")
 REDIS_TTL = int(os.getenv("REDIS_TTL", "3600"))  # Default TTL in seconds (1 hour)
 
+# When True (default), dynamic config keys are fetched from Redis first, then fall back to env/default.
+# When False, Redis is skipped entirely for dynamic config — all keys resolve from env/default directly.
+ENABLE_REDIS_DYNAMIC_CONFIG = (
+    os.getenv("ENABLE_REDIS_DYNAMIC_CONFIG", "true").lower() == "true"
+)
+
 # DevCycle Configuration
 DEVCYCLE_WEBHOOK_SECRET = os.getenv("DEVCYCLE_WEBHOOK_SECRET", "")
 DEVCYCLE_SERVER_KEY = os.getenv("DEVCYCLE_SERVER_KEY", "")

--- a/app/services/live_config/store.py
+++ b/app/services/live_config/store.py
@@ -14,7 +14,7 @@ from typing import Any, Dict, Optional
 import aiohttp
 
 # Get basic environment variables directly (to avoid circular imports)
-from app.core.config.static import DEVCYCLE_SERVER_KEY
+from app.core.config.static import DEVCYCLE_SERVER_KEY, ENABLE_REDIS_DYNAMIC_CONFIG
 from app.core.logger import logger
 from app.services.live_config.utils import (
     build_variable_mapping,
@@ -209,22 +209,31 @@ async def get_all_flags() -> Dict[str, Any]:
 
 
 async def get_config(key: str, default_value: Any, return_type: type = str) -> Any:
-    """Unified: Redis → Environment → Default (async version)"""
+    """Unified: Redis → Environment → Default (async version)
 
-    # Always try Redis first (don't check _INITIALIZED to support cross-process reads)
-    try:
-        val = await _get_flag_from_redis(key)
-        if val is not None:
-            converted = convert_type(val, return_type)
-            if converted is not None:
-                logger.debug(f"get_config({key}): Retrieved from Redis -> {converted}")
-                return converted
-        else:
-            logger.debug(f"get_config({key}): Not found in Redis, checking environment")
-    except Exception as e:
-        logger.warning(
-            f"get_config({key}): Redis lookup failed: {e}, falling back to environment"
-        )
+    When ENABLE_REDIS_DYNAMIC_CONFIG is False, the Redis step is skipped entirely
+    and config resolves from Environment → Default only.
+    """
+
+    # Try Redis first, unless Redis dynamic config is disabled
+    if ENABLE_REDIS_DYNAMIC_CONFIG:
+        try:
+            val = await _get_flag_from_redis(key)
+            if val is not None:
+                converted = convert_type(val, return_type)
+                if converted is not None:
+                    logger.debug(
+                        f"get_config({key}): Retrieved from Redis -> {converted}"
+                    )
+                    return converted
+            else:
+                logger.debug(
+                    f"get_config({key}): Not found in Redis, checking environment"
+                )
+        except Exception as e:
+            logger.warning(
+                f"get_config({key}): Redis lookup failed: {e}, falling back to environment"
+            )
 
     env_val = get_env_value(key, return_type)
     if env_val is not None:

--- a/run.py
+++ b/run.py
@@ -9,7 +9,13 @@ import asyncio
 import uvicorn
 
 # STEP 3: Now safe to import config and logger
-from app.core.config.static import HOST, PORT, UVICORN_LOG_LEVEL, UVICORN_RELOAD
+from app.core.config.static import (
+    ENABLE_REDIS_DYNAMIC_CONFIG,
+    HOST,
+    PORT,
+    UVICORN_LOG_LEVEL,
+    UVICORN_RELOAD,
+)
 from app.core.logger import logger
 from app.services.live_config.store import initialize_feature_flags
 from app.services.redis import (
@@ -26,7 +32,12 @@ async def initialize_devcycle():
     without needing to call DevCycle API themselves.
     """
     try:
-        if is_redis_configured():
+        if not ENABLE_REDIS_DYNAMIC_CONFIG:
+            logger.info(
+                "Parent process: ENABLE_REDIS_DYNAMIC_CONFIG is False - "
+                "skipping Redis/DevCycle init, all dynamic config will use environment variables only"
+            )
+        elif is_redis_configured():
             # Initialize Redis connection
             redis_service = await get_redis_service()
             await redis_service.get_client()  # Initialize the client


### PR DESCRIPTION
## Summary
This PR introduces a new configuration flag `ENABLE_REDIS_DYNAMIC_CONFIG` that allows operators to completely bypass Redis for dynamic configuration lookups, falling back to environment variables and defaults only.

## Key Changes
- **New config variable**: Added `ENABLE_REDIS_DYNAMIC_CONFIG` environment variable (defaults to `true`) in `app/core/config/static.py`
- **Updated `get_config()` function**: Modified the async config resolution logic in `app/services/live_config/store.py` to conditionally skip Redis lookups when the flag is disabled
- **Updated initialization**: Modified `run.py` to check the flag during startup and log when Redis/DevCycle initialization is being skipped
- **Improved documentation**: Updated docstring for `get_config()` to clarify the new behavior

## Implementation Details
- When `ENABLE_REDIS_DYNAMIC_CONFIG=false`, the Redis lookup step is completely skipped, and config resolution follows: Environment → Default only
- When `ENABLE_REDIS_DYNAMIC_CONFIG=true` (default), the existing behavior is preserved: Redis → Environment → Default
- The flag is checked at startup to inform operators about the configuration mode
- All existing functionality remains unchanged when the flag is enabled (default behavior)

This change provides flexibility for deployments that want to operate without Redis or need to temporarily disable dynamic config updates from Redis.

https://claude.ai/code/session_01X2ryNTv2GbNV5iDaCKvVa9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new environment variable to customize dynamic configuration resolution. When enabled (default), configurations prioritize Redis sources with fallback to environment defaults. When disabled, configuration resolution entirely bypasses Redis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->