### PR TITLE
Use explicit None checks instead of implicit truthiness checks

### DIFF
--- a/app/database/accessor/breeze_buddy/template.py
+++ b/app/database/accessor/breeze_buddy/template.py
@@ -105,19 +105,23 @@ async def create_template(
         # Convert flow to JSON string
         flow_json = json.dumps(flow)
         expected_payload_schema_json = (
-            json.dumps(expected_payload_schema) if expected_payload_schema else None
+            json.dumps(expected_payload_schema)
+            if expected_payload_schema is not None
+            else None
         )
         expected_callback_response_schema_json = (
             json.dumps(expected_callback_response_schema)
-            if expected_callback_response_schema
+            if expected_callback_response_schema is not None
             else None
         )
 
         # Convert configurations to JSON string
-        configurations_json = json.dumps(configurations) if configurations else None
+        configurations_json = (
+            json.dumps(configurations) if configurations is not None else None
+        )
 
         # Convert secrets to JSON string
-        secrets_json = json.dumps(secrets) if secrets else None
+        secrets_json = json.dumps(secrets) if secrets is not None else None
 
         query, values = create_template_query(
             template_id,
@@ -332,19 +336,23 @@ async def replace_template(
         # Convert flow to JSON string
         flow_json = json.dumps(flow)
         expected_payload_schema_json = (
-            json.dumps(expected_payload_schema) if expected_payload_schema else None
+            json.dumps(expected_payload_schema)
+            if expected_payload_schema is not None
+            else None
         )
         expected_callback_response_schema_json = (
             json.dumps(expected_callback_response_schema)
-            if expected_callback_response_schema
+            if expected_callback_response_schema is not None
             else None
         )
 
         # Convert configurations to JSON string
-        configurations_json = json.dumps(configurations) if configurations else None
+        configurations_json = (
+            json.dumps(configurations) if configurations is not None else None
+        )
 
         # Convert secrets to JSON string
-        secrets_json = json.dumps(secrets) if secrets else None
+        secrets_json = json.dumps(secrets) if secrets is not None else None
 
         query, values = replace_template_query(
             template_id,


### PR DESCRIPTION
## Summary
Updated conditional checks in the template accessor to use explicit `is not None` comparisons instead of implicit truthiness checks. This improves code clarity and prevents potential bugs with falsy values.

## Key Changes
- Replaced implicit truthiness checks with explicit `is not None` comparisons in `create_template()` method for:
  - `expected_payload_schema`
  - `expected_callback_response_schema`
  - `configurations`
  - `secrets`

- Applied the same changes to `replace_template()` method for consistency

## Implementation Details
The changes ensure that only `None` values are treated as "no value" conditions, while other falsy values (empty dicts, empty lists, etc.) are properly serialized to JSON. This is important because:
- Empty dictionaries `{}` and lists `[]` are valid JSON values that should be serialized
- Using implicit truthiness checks would incorrectly skip serialization for these valid empty structures
- Explicit `is not None` checks make the intent clearer and align with Python best practices

https://claude.ai/code/session_01N3rCYzU3puAwWKG1mszpHh