### PR TITLE
 Context Summarization for Breeze Buddy

### DIFF
--- a/app/ai/voice/agents/breeze_buddy/agent/pipeline.py
+++ b/app/ai/voice/agents/breeze_buddy/agent/pipeline.py
@@ -19,6 +19,7 @@ from pipecat.processors.aggregators.llm_response import LLMUserAggregatorParams
 from pipecat.processors.aggregators.openai_llm_context import OpenAILLMContext
 from pipecat.services.azure.llm import AzureLLMService
 
+from app.ai.voice.agents.breeze_buddy.features.summarizer import ContextSummarizer
 from app.ai.voice.agents.breeze_buddy.observability.tracing_setup import setup_tracing
 from app.ai.voice.agents.breeze_buddy.processors import (
     ResponseStateGate,
@@ -132,7 +133,38 @@ async def build_pipeline(
     Returns:
         Tuple of (pipeline, context, context_aggregator)
     """
-    context = OpenAILLMContext()
+    # Create context with summarization support
+    # Context summarization is ONLY enabled when explicitly configured in template
+    template_summarization_config = getattr(
+        configurations, "context_summarization", None
+    )
+
+    if template_summarization_config and template_summarization_config.enabled:
+        # Use template-level configuration
+        max_turns = template_summarization_config.max_turns_before_summary
+        keep_turns = template_summarization_config.keep_recent_turns
+        logger.info(
+            f"Template context summarization ENABLED: "
+            f"max_turns={max_turns}, keep_turns={keep_turns}"
+        )
+        context = ContextSummarizer(
+            messages=[],
+            tools=None,
+            llm_service=llm,
+            max_turns_before_summary=max_turns,
+            keep_recent_turns=keep_turns,
+            enable_summarization=True,
+        )
+    else:
+        # No template config or disabled - use standard context without summarization
+        if template_summarization_config:
+            logger.info("Template context summarization explicitly disabled")
+        else:
+            logger.info(
+                "No template context summarization config - using standard context"
+            )
+        context = OpenAILLMContext()
+
     context_aggregator = llm.create_context_aggregator(
         context,
         user_params=LLMUserAggregatorParams(

--- a/app/ai/voice/agents/breeze_buddy/features/summarizer/__init__.py
+++ b/app/ai/voice/agents/breeze_buddy/features/summarizer/__init__.py
@@ -1,0 +1,7 @@
+"""Context summarization for Breeze Buddy conversations."""
+
+from app.ai.voice.agents.breeze_buddy.features.summarizer.context_summarizer import (
+    ContextSummarizer,
+)
+
+__all__ = ["ContextSummarizer"]

--- a/app/ai/voice/agents/breeze_buddy/features/summarizer/context_summarizer.py
+++ b/app/ai/voice/agents/breeze_buddy/features/summarizer/context_summarizer.py
@@ -1,0 +1,254 @@
+import asyncio
+from typing import Any, Dict, List, Optional, cast
+
+from openai.types.chat import ChatCompletionMessageParam
+from pipecat.adapters.services.open_ai_adapter import OpenAILLMInvocationParams
+from pipecat.processors.aggregators.openai_llm_context import OpenAILLMContext
+
+from app.core.config.static import KEEP_RECENT_TURNS, MAX_TURNS_BEFORE_SUMMARY
+from app.core.logger import logger
+
+
+class ContextSummarizer(OpenAILLMContext):
+    """
+    Extended OpenAI LLM Context that automatically summarizes conversation
+    after a specified number of turns to maintain context window efficiency.
+
+    This implementation is specifically tailored for Breeze Buddy voice agents
+    to handle longer conversations efficiently by summarizing older messages
+    while preserving recent context.
+    """
+
+    def __init__(
+        self,
+        messages: List[Dict[str, Any]],
+        tools: Optional[List[Dict[str, Any]]] = None,
+        max_turns_before_summary: int = MAX_TURNS_BEFORE_SUMMARY,
+        keep_recent_turns: int = KEEP_RECENT_TURNS,
+        enable_summarization: bool = True,
+        llm_service=None,
+    ):
+        # Cast messages to the expected type for the parent class
+        super().__init__(cast(List[ChatCompletionMessageParam], messages), tools)  # type: ignore
+        self._max_turns_before_summary = max_turns_before_summary
+        self._keep_recent_turns = keep_recent_turns
+        self._enable_summarization = enable_summarization
+        self._turn_count = 0
+        self._llm_service = llm_service
+        self._is_summarizing = False
+        self._original_system_message = (
+            messages[0] if messages and messages[0]["role"] == "system" else None
+        )
+
+    def add_message(self, message: ChatCompletionMessageParam):
+        """Adds a message to the context and increments the turn count if it's a user message."""
+        super().add_message(message)
+        message_dict = cast(Dict[str, Any], message)
+        if message_dict.get("role") == "user":
+            self._turn_count += 1
+            logger.debug(
+                f"--- Breeze Buddy Summarizer: Turn count incremented to: {self._turn_count} ---"
+            )
+            asyncio.create_task(self._check_if_summary_needed())
+
+    async def _check_if_summary_needed(self):
+        """Checks if the turn count has reached the threshold to trigger summarization."""
+        if (
+            self._enable_summarization
+            and not self._is_summarizing
+            and self._turn_count >= self._max_turns_before_summary
+        ):
+            await self._summarize_context()
+
+    async def _summarize_context(self):
+        """Performs the summarization of the conversation history."""
+        self._is_summarizing = True
+        try:
+            # Separate system messages from conversation messages
+            system_messages = [msg for msg in self._messages if msg["role"] == "system"]
+            conversation_messages = [
+                msg
+                for msg in self._messages
+                if msg["role"] in ["user", "assistant", "tool"]
+            ]
+            if len(conversation_messages) < self._keep_recent_turns * 2:
+                return
+
+            # Log context BEFORE summarization
+            logger.info(f"=== BREEZE BUDDY SUMMARIZATION START ===")
+            logger.info(
+                f"Total messages in context BEFORE summarization: {len(self._messages)}"
+            )
+            logger.info(
+                f"System messages: {len(system_messages)}, Conversation messages: {len(conversation_messages)}"
+            )
+            logger.debug(f"Context BEFORE summarization:\n{self._messages}")
+
+            # Determine which messages to keep and which to summarize
+            messages_to_keep: List[ChatCompletionMessageParam] = []
+            user_turns_to_keep = 0
+            for msg in reversed(conversation_messages):
+                messages_to_keep.insert(0, cast(ChatCompletionMessageParam, msg))
+                if msg["role"] == "user":
+                    user_turns_to_keep += 1
+                    if user_turns_to_keep >= self._keep_recent_turns:
+                        break
+
+            messages_to_summarize = [
+                msg for msg in conversation_messages if msg not in messages_to_keep
+            ]
+            if not messages_to_summarize:
+                logger.info(
+                    f"No messages to summarize (need at least {self._keep_recent_turns * 2} conversation messages)"
+                )
+                return
+
+            logger.info(
+                f"Messages to summarize: {len(messages_to_summarize)}, Messages to keep: {len(messages_to_keep)}"
+            )
+
+            # Find previous summary
+            previous_summary = ""
+            for msg in self._messages:
+                if msg["role"] == "system":
+                    content = msg.get("content", "")
+                    # Handle both string and iterable content types
+                    if (
+                        isinstance(content, str)
+                        and "Previous conversation summary:" in content
+                    ):
+                        previous_summary = content.replace(
+                            "Previous conversation summary:", ""
+                        ).strip()
+                        break
+
+            # Create summarization prompt
+            prompt_parts: List[str] = []
+            if previous_summary:
+                prompt_parts.append(
+                    f"Current summary of the conversation so far:\n{previous_summary}\n\nPlease create a new, updated summary that incorporates the following new messages:\n"
+                )
+            else:
+                prompt_parts.append(
+                    "Summarize the key points of this conversation, focusing on customer responses, order details, address confirmations, and important outcomes. Conversation:\n"
+                )
+
+            for msg in messages_to_summarize:
+                role = "User" if msg["role"] == "user" else "Assistant"
+                content = msg.get("content", "")
+                if not isinstance(content, str):
+                    # Handle tool calls - safely extract tool name
+                    tool_calls = msg.get("tool_calls", [])
+                    if (
+                        tool_calls
+                        and isinstance(tool_calls, list)
+                        and len(tool_calls) > 0
+                    ):
+                        first_tool = tool_calls[0]
+                        if isinstance(first_tool, dict):
+                            function_name = first_tool.get("function", {}).get(
+                                "name", "tool call"
+                            )
+                            content = f"[{function_name}]"
+                        else:
+                            content = "[tool call]"
+                    else:
+                        content = "[tool call]"
+                if content:
+                    prompt_parts.append(f"\n{role}: {content}")
+
+            summary_messages: List[Dict[str, str]] = [
+                {
+                    "role": "system",
+                    "content": """You are a call summarization assistant for an automated calling system.
+
+Summarize the conversation while preserving ALL critical details EXACTLY (names, phone numbers, emails, order IDs, booking IDs, addresses, dates, prices). Do NOT paraphrase these.
+
+Rules:
+- Summarize only non-essential dialogue.
+- If information is not mentioned, do not invent it.
+- If something is unclear, mark it as "Not provided".
+- Do NOT assume or hallucinate.
+- Clearly capture the customer’s final intent or disposition.
+- Keep the summary concise but complete enough for another agent to continue the conversation without asking the customer to repeat information.
+- Maintain a professional call-center tone and structured clarity.
+
+IMPORTANT:
+- Be EXACT with names, numbers, and addresses - do not paraphrase critical details
+- Always address the person by their name respectfully when continuing the conversation
+- Preserve ALL important details so the conversation can continue seamlessly without asking for repeated information
+- The summary should enable the AI to remember everything important about this person and their requests""",
+                },
+                {"role": "user", "content": "".join(prompt_parts)},
+            ]
+
+            # Get summary from LLM
+            if self._llm_service is None:
+                logger.warning(
+                    "Breeze Buddy Summarizer: LLM service not available for summarization."
+                )
+                return
+
+            from openai import NOT_GIVEN
+
+            params_from_context = OpenAILLMInvocationParams(
+                messages=cast(List[ChatCompletionMessageParam], summary_messages),
+                tools=NOT_GIVEN,
+                tool_choice=NOT_GIVEN,
+            )
+            chunks = await self._llm_service.get_chat_completions(params_from_context)
+            summary_parts: List[str] = [
+                chunk.choices[0].delta.content or ""
+                async for chunk in chunks
+                if chunk.choices
+                and chunk.choices[0].delta
+                and chunk.choices[0].delta.content
+            ]
+            summary = "".join(summary_parts)
+
+            if not summary:
+                logger.warning(
+                    "Breeze Buddy Summarizer: Summary generation resulted in empty content."
+                )
+                return
+
+            logger.info(f"✅ Generated summary ({len(summary)} characters):\n{summary}")
+
+            # Reconstruct messages - preserve ALL system messages and add summary
+            new_messages: List[ChatCompletionMessageParam] = []
+
+            # Keep all system messages (they contain template instructions and flow guidance)
+            for system_msg in system_messages:
+                new_messages.append(cast(ChatCompletionMessageParam, system_msg))
+
+            # Add the conversation summary as a new system message
+            new_messages.append(
+                {
+                    "role": "system",
+                    "content": f"Previous conversation summary: {summary}",
+                }
+            )
+
+            # Add recent conversation messages
+            new_messages.extend(messages_to_keep)
+
+            # Log context AFTER summarization
+            logger.info(f"=== BREEZE BUDDY SUMMARIZATION COMPLETE ===")
+            logger.info(
+                f"Total messages in context AFTER summarization: {len(new_messages)}"
+            )
+            logger.info(
+                f"Messages reduced from {len(self._messages)} to {len(new_messages)}"
+            )
+            logger.info(
+                f"Space saved: {len(self._messages) - len(new_messages)} messages"
+            )
+            logger.debug(f"Context AFTER summarization:\n{new_messages}")
+            logger.info(f"Turn counter reset from {self._turn_count} to 0")
+
+            self._messages = cast(List[ChatCompletionMessageParam], new_messages)  # type: ignore
+            self._turn_count = 0
+        except Exception as e:
+            logger.error(f"Breeze Buddy Summarizer: Error during summarization: {e}")
+        finally:
+            self._is_summarizing = False

--- a/app/ai/voice/agents/breeze_buddy/template/types.py
+++ b/app/ai/voice/agents/breeze_buddy/template/types.py
@@ -89,6 +89,32 @@ class UserIdleHandlingConfig(BaseModel):
     )
 
 
+class ContextSummarizationConfig(BaseModel):
+    """Configuration for automatic conversation context summarization.
+
+    Context summarization is ONLY enabled when explicitly configured in the template
+    with enabled=True. By default, summarization is disabled.
+
+    When enabled, older conversation messages are automatically condensed into
+    a summary after a specified number of turns to prevent context window overflow.
+    """
+
+    enabled: bool = Field(
+        False,
+        description="Enable/disable automatic context summarization for this template. Defaults to False - must be explicitly enabled.",
+    )
+    max_turns_before_summary: int = Field(
+        10,
+        ge=1,
+        description="Number of user turns after which summarization is triggered",
+    )
+    keep_recent_turns: int = Field(
+        2,
+        ge=1,
+        description="Number of recent conversation turns to keep in full detail after summarization",
+    )
+
+
 class ConfigurationModel(BaseModel):
     tts_voice_name: Optional[TTSVoiceName] = None
     mira_voice_id: Optional[str] = (
@@ -122,6 +148,9 @@ class ConfigurationModel(BaseModel):
     enable_inbound: bool = False  # Whether this template can handle inbound calls
     user_idle_configuration: Optional[UserIdleHandlingConfig] = (
         None  # User idle handling config
+    )
+    context_summarization: Optional[ContextSummarizationConfig] = (
+        None  # Context summarization config (must be explicitly enabled)
     )
 
 

--- a/app/core/config/dynamic.py
+++ b/app/core/config/dynamic.py
@@ -280,3 +280,31 @@ async def BB_NOISE_CANCELLATION_LEVEL() -> int:
 async def BB_ENABLE_ELEVENLABS_INDIAN_RESIDENCY() -> bool:
     """Returns BB_ENABLE_ELEVENLABS_INDIAN_RESIDENCY from Redis"""
     return await get_config("BB_ENABLE_ELEVENLABS_INDIAN_RESIDENCY", True, bool)
+
+
+# --- Breeze Buddy Context Summarization Configuration ---
+async def ENABLE_BB_SUMMARIZATION() -> bool:
+    """Returns ENABLE_BB_SUMMARIZATION from Redis.
+
+    When True, enables automatic conversation context summarization after a specified
+    number of turns to maintain context window efficiency while preserving conversation memory.
+    """
+    return await get_config("ENABLE_BB_SUMMARIZATION", False, bool)
+
+
+async def BB_MAX_TURNS_BEFORE_SUMMARY() -> int:
+    """Returns BB_MAX_TURNS_BEFORE_SUMMARY from Redis.
+
+    Number of user turns after which the conversation context will be automatically
+    summarized to prevent context window overflow.
+    """
+    return await get_config("BB_MAX_TURNS_BEFORE_SUMMARY", 5, int)
+
+
+async def BB_KEEP_RECENT_TURNS() -> int:
+    """Returns BB_KEEP_RECENT_TURNS from Redis.
+
+    Number of recent conversation turns to keep in full detail after summarization.
+    Older turns will be condensed into a summary.
+    """
+    return await get_config("BB_KEEP_RECENT_TURNS", 2, int)

--- a/docs/BREEZE_BUDDY_CONTEXT_SUMMARIZATION.md
+++ b/docs/BREEZE_BUDDY_CONTEXT_SUMMARIZATION.md
@@ -1,0 +1,270 @@
+# Breeze Buddy Context Summarization
+
+## Overview
+
+Context summarization has been implemented for Breeze Buddy to automatically manage conversation context and prevent context window overflow in long conversations. 
+
+**Important:** Context summarization is **opt-in only**. It is **NOT enabled by default** and must be **explicitly configured in the template** to be active.
+
+## What is Context Summarization?
+
+Context summarization automatically condenses older conversation messages into a summary after a specified number of user turns, while keeping recent messages in full detail. This allows the AI to maintain conversation memory without exceeding token limits.
+
+## Configuration (Template-Level Only)
+
+Context summarization is configured **exclusively at the template level**. Add to your template's `configurations` object:
+
+```json
+{
+  "configurations": {
+    "context_summarization": {
+      "enabled": true,
+      "max_turns_before_summary": 10,
+      "keep_recent_turns": 2
+    }
+  }
+}
+```
+
+**Parameters:**
+- `enabled` (boolean, default: `false`) - **Must be explicitly set to `true`** to enable summarization
+- `max_turns_before_summary` (integer, default: `10`) - Number of user turns after which summarization is triggered
+- `keep_recent_turns` (integer, default: `2`) - Number of recent conversation turns to keep in full detail
+
+**No Configuration = No Summarization**
+
+If `context_summarization` is not specified in the template configurations, the feature will **NOT be enabled**. This is intentional to give templates full control over their behavior.
+
+**Example Configurations:**
+
+```json
+// Enable with default settings
+{
+  "context_summarization": {
+    "enabled": true
+  }
+}
+
+// Short feedback collection - aggressive summarization
+{
+  "context_summarization": {
+    "enabled": true,
+    "max_turns_before_summary": 5,
+    "keep_recent_turns": 1
+  }
+}
+
+// Complex troubleshooting - keep more context
+{
+  "context_summarization": {
+    "enabled": true,
+    "max_turns_before_summary": 20,
+    "keep_recent_turns": 5
+  }
+}
+
+// Explicitly disable (same as not configuring at all)
+{
+  "context_summarization": {
+    "enabled": false
+  }
+}
+```
+
+## How It Works
+
+### Workflow
+
+1. **Turn Tracking**: Each time a user message is added to the context, the turn counter increments
+2. **Threshold Check**: When the turn count reaches the configured threshold, summarization is triggered
+3. **Message Separation**: 
+   - Recent messages (last `keep_recent_turns` user-assistant pairs) are preserved in full
+   - Older messages are sent to the LLM for summarization
+4. **Summary Generation**: The LLM generates a comprehensive summary focusing on:
+   - Customer's NAME (never forget - it is critical)
+   - ORDER DETAILS (IDs, products, quantities, prices)
+   - CUSTOMER DETAILS (preferences, requests, complaints)
+   - ADDRESSES (complete delivery/pickup addresses)
+   - Contact INFORMATION (phone, email)
+   - Dates, times, and SCHEDULES
+   - CONFIRMATIONS and VERIFICATIONS
+   - PROMISES and COMMITMENTS
+   - ISSUES and CONCERNS
+   - RESOLUTIONS and actions taken
+5. **Context Reconstruction**: 
+   - All system messages preserved (template instructions, flow steps)
+   - Summary added as a new system message
+   - Recent messages kept in full detail
+6. **Turn Reset**: Turn counter resets to 0 for the next summarization cycle
+
+### Enhanced Summarization Prompt
+
+The summarizer uses an enhanced prompt that ensures:
+
+- ✅ **Customer name is ALWAYS preserved** - never forget the person's name
+- ✅ **Order details are kept intact** - IDs, products, quantities, prices
+- ✅ **Complete addresses are maintained** - delivery/pickup addresses
+- ✅ **Contact information is saved** - phone, email
+- ✅ **Dates, times, and schedules are preserved**
+- ✅ **Confirmations and verifications are noted**
+- ✅ **Promises and commitments are recorded**
+- ✅ **Issues and concerns are documented**
+- ✅ **Resolutions and actions taken are captured**
+
+### Example
+
+For a conversation with 12 user turns and `max_turns_before_summary=10`, `keep_recent_turns=2`:
+
+**Before Summarization (12 messages):**
+```
+[System] You are Rhea from Freshbus...
+[System] Politely greet the customer using their name Yugesh...
+[User 1] Hi, I placed an order
+[Assistant 1] Great! Can you provide your order ID?
+[User 2] It's ORDER123
+[Assistant 2] Thank you. Let me verify...
+...
+[User 10] Yes, that's correct
+[Assistant 10] Perfect. Your address is 123 Main St, Apt 4B
+[User 11] Can you repeat the delivery time?
+[Assistant 11] It will arrive tomorrow at 2 PM
+[User 12] Great, thank you
+```
+
+**After Summarization (6 messages):**
+```
+[System] You are Rhea from Freshbus...
+[System] Politely greet the customer using their name Yugesh...
+[System Summary] Customer Yugesh placed order ORDER123. Delivery address verified as 123 Main St, Apt 4B. Customer confirmed delivery time of tomorrow at 2 PM. Customer was polite and appreciative.
+[User 11] Can you repeat the delivery time?
+[Assistant 11] It will arrive tomorrow at 2 PM
+[User 12] Great, thank you
+```
+
+## Implementation Details
+
+### Files Created
+
+1. **`app/ai/voice/agents/breeze_buddy/features/summarizer/context_summarizer.py`**
+   - Main implementation of the `ContextSummarizer` class
+   - Extends `OpenAILLMContext` from Pipecat
+   - Automatically tracks user turns and triggers summarization
+   - Uses enhanced prompt to preserve all critical details
+   - Keeps ALL system messages (template instructions, flow guidance)
+
+2. **`app/ai/voice/agents/breeze_buddy/features/summarizer/__init__.py`**
+   - Module initialization file
+   - Exports `ContextSummarizer` for easy imports
+
+### Files Modified
+
+1. **`app/ai/voice/agents/breeze_buddy/template/types.py`**
+   - Added `ContextSummarizationConfig` class for template-level configuration
+   - Added `context_summarization` field to `ConfigurationModel`
+   - Default `enabled` is `False` - must be explicitly enabled
+
+2. **`app/ai/voice/agents/breeze_buddy/agent/pipeline.py`**
+   - Imported `ContextSummarizer`
+   - Modified `build_pipeline()` to:
+     - Only enable summarization when `context_summarization.enabled=true` in template config
+     - No fallback to global config - opt-in only
+   - Added logging for summarization configuration status
+
+## Monitoring and Logging
+
+The implementation includes detailed logging:
+
+```python
+# Configuration status
+"Template context summarization ENABLED: max_turns=10, keep_turns=2"
+"No template context summarization config - using standard context"
+
+# Before summarization
+"=== BREEZE BUDDY SUMMARIZATION START ==="
+"Total messages in context BEFORE summarization: 22"
+"System messages: 4, Conversation messages: 18"
+"Messages to summarize: 14, Messages to keep: 4"
+
+# After summarization
+"✅ Generated summary (245 characters): Customer Yugesh..."
+"=== BREEZE BUDDY SUMMARIZATION COMPLETE ==="
+"Total messages in context AFTER summarization: 9"
+"Messages reduced from 22 to 9"
+"Space saved: 13 messages"
+"Turn counter reset from 10 to 0"
+
+# Turn tracking
+"--- Breeze Buddy Summarizer: Turn count incremented to: 5 ---"
+
+# Errors
+"Breeze Buddy Summarizer: Error during summarization: <error>"
+"Breeze Buddy Summarizer: Summary generation resulted in empty content."
+```
+
+## Benefits
+
+1. **Extended Conversations**: Supports much longer conversations without context window overflow
+2. **Complete Memory Preservation**: Critical information (names, orders, addresses) is retained via enhanced prompt
+3. **Respectful Tone Maintained**: Summary ensures AI remembers to be polite and respectful
+4. **Token Efficiency**: Reduces token usage while maintaining conversation coherence
+5. **Performance**: Prevents slowdowns from excessively long context windows
+6. **Cost Optimization**: Lower token usage means reduced API costs
+7. **Template Flexibility**: Different templates can have different summarization strategies
+
+## Testing Recommendations
+
+1. **Basic Functionality**
+   - Create a long conversation (>10 turns)
+   - Verify summarization triggers at the correct turn count
+   - Check that recent messages are preserved
+   - Verify ALL system messages are preserved
+
+2. **Data Preservation**
+   - Verify customer name is always in the summary
+   - Check order details are preserved accurately
+   - Confirm addresses are maintained completely
+   - Ensure phone numbers and emails are kept
+
+3. **Configuration**
+   - Test with template-level config
+   - Test with summarization disabled
+   - Test with different turn thresholds
+
+4. **Edge Cases**
+   - Very short conversations (< keep_recent_turns * 2)
+   - Rapid-fire messages
+   - Multiple system messages (template flow steps)
+   - Conversations with many tool calls
+
+## Troubleshooting
+
+### Summarization Not Triggering
+
+1. Check template config exists: `configurations.context_summarization`
+2. Verify `enabled` is set to `true`: `configurations.context_summarization.enabled = true`
+3. Check logs for configuration status message
+4. Verify turn count in logs
+5. Ensure conversation has enough messages (at least `keep_recent_turns * 2`)
+
+### Missing Information in Summary
+
+1. Check LLM service connectivity
+2. Verify the summarization prompt is using enhanced version
+3. Review logs for summary content
+4. Check if critical details are in messages being summarized
+
+### System Messages Being Lost
+
+1. Verify you're using the latest implementation
+2. Check logs for "System messages: X" count
+3. Ensure all system messages are preserved after summarization
+
+## Future Enhancements
+
+Potential improvements for future iterations:
+
+1. **Incremental Summarization**: Update summaries rather than regenerating
+2. **Summary Quality Metrics**: Track and score summary quality automatically
+3. **Domain-Specific Prompts**: Customize summary prompts per industry/use case
+4. **Summary Caching**: Cache summaries to avoid redundant LLM calls
+5. **Multi-Level Summaries**: Hierarchical summaries for very long conversations


### PR DESCRIPTION
 - Added context summarizer based on env
 - We can configure after how many turns we should summarize the context
 - We can also configure how many recent turns we need to keep in context without summarizing them

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Breeze Buddy gains automatic conversation context summarization: it condenses older turns after a configurable number of user turns while preserving recent and system messages.
  * New template-level settings to enable/disable summarization and tune thresholds (max turns before summary, recent turns to keep).

* **Documentation**
  * Added comprehensive docs covering behavior, configuration, examples, monitoring, and troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->