### PR TITLE
Add custom Soniox STT with endpoint detection timeout for telephony

### DIFF
--- a/app/ai/voice/agents/breeze_buddy/agent/__init__.py
+++ b/app/ai/voice/agents/breeze_buddy/agent/__init__.py
@@ -165,7 +165,8 @@ class Agent:
         )
 
         # Daily transport does not support audio_out_mixer, so we pass None
-        transport_params = await get_transport_params(self.vad_analyzer, None)
+        # Note: VAD is configured in the aggregator (via UserTurnStrategies), not the transport
+        transport_params = await get_transport_params(None)
         self.transport = await create_transport(runner_args, transport_params)
 
     async def _setup_telephony_transport(self) -> bool:
@@ -316,9 +317,8 @@ class Agent:
         audio_out_mixer = create_background_sound_mixer(self.template)
 
         # Get transport params using the detected transport type
-        transport_params = await get_transport_params(
-            self.vad_analyzer, audio_out_mixer
-        )
+        # Note: VAD is configured in the aggregator (via UserTurnStrategies), not the transport
+        transport_params = await get_transport_params(audio_out_mixer)
         params = transport_params[transport_type]()
 
         # Create transport with the call data
@@ -448,9 +448,11 @@ class Agent:
                     )
 
         # Create services and pipeline
+        # VAD analyzer is passed to build_pipeline where it's configured inside the
+        # LLMUserAggregator. This enables UserTurnStrategies (VAD + Transcription fallback).
         stt, llm, tts = await create_services(self.configurations)
         pipeline, self.context, context_aggregator = await build_pipeline(
-            self.transport, stt, llm, tts, self.configurations
+            self.transport, stt, llm, tts, self.vad_analyzer, self.configurations
         )
 
         # Generate conversation ID and create task

--- a/app/ai/voice/agents/breeze_buddy/agent/pipeline.py
+++ b/app/ai/voice/agents/breeze_buddy/agent/pipeline.py
@@ -27,6 +27,7 @@ from pipecat.turns.user_start import (
     TranscriptionUserTurnStartStrategy,
     VADUserTurnStartStrategy,
 )
+from pipecat.turns.user_stop import SpeechTimeoutUserTurnStopStrategy
 from pipecat.turns.user_turn_strategies import UserTurnStrategies
 
 from app.ai.voice.agents.breeze_buddy.observability.tracing_setup import setup_tracing
@@ -153,7 +154,9 @@ async def build_pipeline(
     Uses the new universal LLMContextAggregatorPair with UserTurnStrategies:
     - Start: VADUserTurnStartStrategy (primary, ~100ms) + TranscriptionUserTurnStartStrategy
       (fallback for soft speech VAD misses, uses interim transcriptions)
-    - Stop: Default pipecat stop strategies (TurnAnalyzerUserTurnStopStrategy)
+    - Stop: SpeechTimeoutUserTurnStopStrategy (user_speech_timeout=0.0) — triggers
+      immediately when custom Soniox sends a finalized transcript. Soniox's own 500ms
+      endpoint timeout after VAD stop is the sole timing mechanism.
     - VAD runs inside the aggregator (not the transport)
 
     Args:
@@ -184,7 +187,9 @@ async def build_pipeline(
             VADUserTurnStartStrategy(),
             TranscriptionUserTurnStartStrategy(use_interim=True),
         ],
-        # stop: uses pipecat default (TurnAnalyzerUserTurnStopStrategy with SmartTurnAnalyzerV3)
+        stop=[
+            SpeechTimeoutUserTurnStopStrategy(user_speech_timeout=0.0),
+        ],
     )
 
     context_aggregator = LLMContextAggregatorPair(

--- a/app/ai/voice/agents/breeze_buddy/agent/pipeline.py
+++ b/app/ai/voice/agents/breeze_buddy/agent/pipeline.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from typing import Any, Optional
 from zoneinfo import ZoneInfo
 
+from pipecat.audio.vad.silero import SileroVADAnalyzer
 from pipecat.observers.loggers.llm_log_observer import LLMLogObserver
 from pipecat.observers.loggers.metrics_log_observer import MetricsLogObserver
 from pipecat.observers.loggers.transcription_log_observer import (
@@ -15,10 +16,18 @@ from pipecat.observers.loggers.user_bot_latency_log_observer import (
 from pipecat.observers.turn_tracking_observer import TurnTrackingObserver
 from pipecat.pipeline.pipeline import Pipeline
 from pipecat.pipeline.task import PipelineParams, PipelineTask
-from pipecat.processors.aggregators.llm_response import LLMUserAggregatorParams
+from pipecat.processors.aggregators.llm_response_universal import (
+    LLMContextAggregatorPair,
+    LLMUserAggregatorParams,
+)
 from pipecat.processors.aggregators.openai_llm_context import OpenAILLMContext
 from pipecat.services.azure.llm import AzureLLMService
 from pipecat.services.openai.base_llm import BaseOpenAILLMService
+from pipecat.turns.user_start import (
+    TranscriptionUserTurnStartStrategy,
+    VADUserTurnStartStrategy,
+)
+from pipecat.turns.user_turn_strategies import UserTurnStrategies
 
 from app.ai.voice.agents.breeze_buddy.observability.tracing_setup import setup_tracing
 from app.ai.voice.agents.breeze_buddy.processors import (
@@ -32,14 +41,12 @@ from app.core.config.dynamic import (
     BB_ENABLE_RESPONSE_GATE,
     BREEZE_BUDDY_AZURE_MAX_COMPLETION_TOKENS,
     BREEZE_BUDDY_AZURE_TEMPERATURE,
-    BREEZE_BUDDY_LLM_AGGREGATION_TIMEOUT,
 )
 from app.core.config.static import (
     AZURE_BREEZE_BUDDY_OPENAI_MODEL,
     AZURE_OPENAI_API_KEY,
     AZURE_OPENAI_ENDPOINT,
     ENABLE_BREEZE_BUDDY_TRACING,
-    ENABLE_BREEZE_BUDDY_USER_INTERRUPTION,
     ENVIRONMENT,
 )
 from app.core.logger import logger
@@ -138,15 +145,23 @@ async def build_pipeline(
     stt: Any,
     llm: AzureLLMService,
     tts: Any,
+    vad_analyzer: Optional[SileroVADAnalyzer] = None,
     configurations: Optional[ConfigurationModel] = None,
 ) -> tuple[Pipeline, OpenAILLMContext, Any]:
     """Build the processing pipeline.
+
+    Uses the new universal LLMContextAggregatorPair with UserTurnStrategies:
+    - Start: VADUserTurnStartStrategy (primary, ~100ms) + TranscriptionUserTurnStartStrategy
+      (fallback for soft speech VAD misses, uses interim transcriptions)
+    - Stop: Default pipecat stop strategies (TurnAnalyzerUserTurnStopStrategy)
+    - VAD runs inside the aggregator (not the transport)
 
     Args:
         transport: The transport instance
         stt: Speech-to-text service
         llm: LLM service
         tts: Text-to-speech service
+        vad_analyzer: SileroVADAnalyzer instance for voice activity detection
         configurations: Template configuration model
 
     Returns:
@@ -156,11 +171,27 @@ async def build_pipeline(
     # Pipecat does not provide built-in summarization; implement one under
     # app/ai/voice/agents/breeze_buddy/ to manage long conversation contexts.
     context = OpenAILLMContext()
-    context_aggregator = llm.create_context_aggregator(
+    context.set_llm_adapter(llm.get_llm_adapter())
+
+    # User turn strategies:
+    # 1. VADUserTurnStartStrategy: Primary detector, fires on VAD speech detection (~100ms).
+    #    First-one-wins semantics — if VAD fires first, transcription fallback is skipped.
+    # 2. TranscriptionUserTurnStartStrategy: Fallback for soft speech that VAD misses.
+    #    With use_interim=True, triggers on any interim transcription from Soniox,
+    #    catching cases where VAD fails at 8kHz but STT still picks up speech.
+    user_turn_strategies = UserTurnStrategies(
+        start=[
+            VADUserTurnStartStrategy(),
+            TranscriptionUserTurnStartStrategy(use_interim=True),
+        ],
+        # stop: uses pipecat default (TurnAnalyzerUserTurnStopStrategy with SmartTurnAnalyzerV3)
+    )
+
+    context_aggregator = LLMContextAggregatorPair(
         context,
         user_params=LLMUserAggregatorParams(
-            aggregation_timeout=await BREEZE_BUDDY_LLM_AGGREGATION_TIMEOUT(),
-            enable_emulated_vad_interruptions=ENABLE_BREEZE_BUDDY_USER_INTERRUPTION,
+            user_turn_strategies=user_turn_strategies,
+            vad_analyzer=vad_analyzer,
         ),
     )
 

--- a/app/ai/voice/agents/breeze_buddy/agent/transport.py
+++ b/app/ai/voice/agents/breeze_buddy/agent/transport.py
@@ -1,4 +1,9 @@
-"""Transport configuration for voice agents."""
+"""Transport configuration for voice agents.
+
+Note: VAD (Voice Activity Detection) is configured in the LLMUserAggregator
+(via UserTurnStrategies), NOT in the transport. The transport only handles
+audio I/O, sample rates, and optional audio filters/mixers.
+"""
 
 from pathlib import Path
 from typing import Optional
@@ -6,7 +11,6 @@ from typing import Optional
 from pipecat.audio.filters.aic_filter import AICFilter
 from pipecat.audio.filters.base_audio_filter import BaseAudioFilter
 from pipecat.audio.mixers.soundfile_mixer import SoundfileMixer
-from pipecat.audio.vad.silero import SileroVADAnalyzer
 from pipecat.transports.daily.transport import DailyParams
 from pipecat.transports.websocket.fastapi import FastAPIWebsocketParams
 
@@ -47,13 +51,14 @@ async def _create_audio_input_filter() -> Optional[BaseAudioFilter]:
 
 
 async def get_transport_params(
-    vad_analyzer: Optional[SileroVADAnalyzer],
     audio_out_mixer: Optional[SoundfileMixer] = None,
 ) -> dict:
     """Get transport parameters dictionary for all transport types.
 
+    VAD is no longer configured here — it lives in the LLMUserAggregator
+    (via the vad_analyzer parameter) where it feeds UserTurnStrategies.
+
     Args:
-        vad_analyzer: The VAD analyzer instance to use
         audio_out_mixer: Optional audio mixer for background sounds (only used by telephony transports)
 
     Returns:
@@ -65,14 +70,12 @@ async def get_transport_params(
         "daily": lambda: DailyParams(
             audio_in_enabled=True,
             audio_out_enabled=True,
-            vad_analyzer=vad_analyzer,
             audio_in_filter=audio_in_filter,
             # Note: DailyParams does not support audio_out_mixer
         ),
         "twilio": lambda: FastAPIWebsocketParams(
             audio_in_enabled=True,
             audio_out_enabled=True,
-            vad_analyzer=vad_analyzer,
             audio_in_sample_rate=TELEPHONY_SAMPLE_RATE,
             audio_out_sample_rate=TELEPHONY_SAMPLE_RATE,
             audio_out_mixer=audio_out_mixer,
@@ -81,7 +84,6 @@ async def get_transport_params(
         "exotel": lambda: FastAPIWebsocketParams(
             audio_in_enabled=True,
             audio_out_enabled=True,
-            vad_analyzer=vad_analyzer,
             audio_in_sample_rate=TELEPHONY_SAMPLE_RATE,
             audio_out_sample_rate=TELEPHONY_SAMPLE_RATE,
             audio_out_mixer=audio_out_mixer,
@@ -90,7 +92,6 @@ async def get_transport_params(
         "telnyx": lambda: FastAPIWebsocketParams(
             audio_in_enabled=True,
             audio_out_enabled=True,
-            vad_analyzer=vad_analyzer,
             audio_in_sample_rate=TELEPHONY_SAMPLE_RATE,
             audio_out_sample_rate=TELEPHONY_SAMPLE_RATE,
             audio_out_mixer=audio_out_mixer,
@@ -99,7 +100,6 @@ async def get_transport_params(
         "plivo": lambda: FastAPIWebsocketParams(
             audio_in_enabled=True,
             audio_out_enabled=True,
-            vad_analyzer=vad_analyzer,
             audio_in_sample_rate=TELEPHONY_SAMPLE_RATE,
             audio_out_sample_rate=TELEPHONY_SAMPLE_RATE,
             audio_out_mixer=audio_out_mixer,

--- a/app/ai/voice/agents/breeze_buddy/stt/__init__.py
+++ b/app/ai/voice/agents/breeze_buddy/stt/__init__.py
@@ -1,8 +1,10 @@
 from pipecat.transcriptions.language import Language
 
 from app.ai.voice.stt import (
+    CustomSonioxConfig,
     SarvamConfig,
     SonioxConfig,
+    build_custom_soniox_stt,
     build_google_stt,
     build_openai_stt,
     build_sarvam_stt,
@@ -17,7 +19,9 @@ from app.core.config.dynamic import (
 )
 from app.core.config.static import (
     BREEZE_BUDDY_SONIOX_CONTEXT,
+    BREEZE_BUDDY_SONIOX_ENABLE_ENDPOINT_DETECTION,
     BREEZE_BUDDY_SONIOX_ENABLE_NON_FINAL_TOKENS,
+    BREEZE_BUDDY_SONIOX_ENDPOINT_TIMEOUT,
     BREEZE_BUDDY_SONIOX_LANGUAGE_HINTS,
     BREEZE_BUDDY_SONIOX_MAX_NON_FINAL_TOKENS_DURATION_MS,
     BREEZE_BUDDY_SONIOX_MODEL,
@@ -83,20 +87,21 @@ async def get_stt_service(language_hints: str | None = None):
             raise ValueError(
                 "SONIOX_API_KEY is required when BREEZE_BUDDY_STT_SERVICE=soniox"
             )
-        # Pass raw config values - language hints parsing is handled internally by build_soniox_stt
-        return build_soniox_stt(
-            SonioxConfig(
+        # Use custom Soniox with endpoint detection timeout for telephony.
+        # This waits a configurable delay after VAD stop before finalizing,
+        # preventing mid-sentence cutoffs from brief pauses in 8kHz audio.
+        return build_custom_soniox_stt(
+            CustomSonioxConfig(
                 api_key=SONIOX_API_KEY,
                 model=BREEZE_BUDDY_SONIOX_MODEL,
-                vad_force_turn_endpoint=BREEZE_BUDDY_SONIOX_VAD_FORCE_TURN_ENDPOINT,
+                endpoint_timeout=BREEZE_BUDDY_SONIOX_ENDPOINT_TIMEOUT,
+                enable_soniox_endpoint_detection=BREEZE_BUDDY_SONIOX_ENABLE_ENDPOINT_DETECTION,
                 language_hints=(
                     language_hints
                     if language_hints is not None
                     else BREEZE_BUDDY_SONIOX_LANGUAGE_HINTS
                 ),
                 context_json=BREEZE_BUDDY_SONIOX_CONTEXT,
-                enable_non_final_tokens=BREEZE_BUDDY_SONIOX_ENABLE_NON_FINAL_TOKENS,
-                max_non_final_tokens_duration_ms=BREEZE_BUDDY_SONIOX_MAX_NON_FINAL_TOKENS_DURATION_MS,
                 log_context="Breeze Buddy",
                 language_hints_strict=True if language_hints else False,
             )

--- a/app/ai/voice/stt/__init__.py
+++ b/app/ai/voice/stt/__init__.py
@@ -12,7 +12,7 @@ from .deepgram import DeepgramConfig, build_deepgram_stt
 from .google import build_google_stt
 from .openai import build_openai_stt
 from .sarvam import SarvamConfig, build_sarvam_stt, get_sarvam_language
-from .soniox import SonioxConfig, build_soniox_stt
+from .soniox import CustomSonioxConfig, SonioxConfig, build_custom_soniox_stt, build_soniox_stt
 
 __all__ = [
     # AssemblyAI
@@ -31,4 +31,7 @@ __all__ = [
     # Soniox
     "SonioxConfig",
     "build_soniox_stt",
+    # Soniox (Custom - with endpoint detection timeout)
+    "CustomSonioxConfig",
+    "build_custom_soniox_stt",
 ]

--- a/app/ai/voice/stt/custom_soniox.py
+++ b/app/ai/voice/stt/custom_soniox.py
@@ -1,0 +1,425 @@
+"""Custom Soniox STT service with endpoint detection timeout for telephony.
+
+This module provides a custom Soniox STT implementation that extends pipecat's
+SonioxSTTService with a configurable endpoint detection timeout. Instead of
+immediately finalizing transcription when VAD detects silence, we wait for a
+configurable delay (default 500ms) before sending the finalize message.
+
+This prevents mid-sentence cutoffs common in telephony (8kHz mulaw audio) where
+brief pauses between words trigger premature finalization.
+
+Additionally, this service enables Soniox's native endpoint detection alongside
+VAD-driven finalization (hybrid mode), allowing Soniox to also detect natural
+endpoints for longer pauses.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+from typing import AsyncGenerator, List, Optional
+
+from loguru import logger
+from pydantic import BaseModel
+
+from pipecat.frames.frames import (
+    CancelFrame,
+    EndFrame,
+    Frame,
+    InterimTranscriptionFrame,
+    StartFrame,
+    TranscriptionFrame,
+    VADUserStartedSpeakingFrame,
+    VADUserStoppedSpeakingFrame,
+)
+from pipecat.processors.frame_processor import FrameDirection
+from pipecat.services.stt_service import WebsocketSTTService
+from pipecat.transcriptions.language import Language
+from pipecat.utils.time import time_now_iso8601
+
+try:
+    from websockets.asyncio.client import connect as websocket_connect
+    from websockets.protocol import State
+except ModuleNotFoundError as e:
+    logger.error(f"Exception: {e}")
+    logger.error("In order to use Soniox, you need to `pip install pipecat-ai[soniox]`.")
+    raise Exception(f"Missing module: {e}")
+
+
+KEEPALIVE_MESSAGE = '{"type": "keepalive"}'
+FINALIZE_MESSAGE = '{"type": "finalize"}'
+END_TOKEN = "<end>"
+FINALIZED_TOKEN = "<fin>"
+
+# Default endpoint detection timeout in seconds.
+# After VAD detects silence, wait this long before finalizing.
+# If user resumes speaking within this window, the finalize is cancelled.
+DEFAULT_ENDPOINT_TIMEOUT = 0.5
+
+
+class CustomSonioxInputParams(BaseModel):
+    """Real-time transcription settings for custom Soniox STT.
+
+    See Soniox WebSocket API documentation for more details:
+    https://soniox.com/docs/speech-to-text/api-reference/websocket-api
+    """
+
+    model: str = "stt-rt-v3"
+    audio_format: Optional[str] = "pcm_s16le"
+    num_channels: Optional[int] = 1
+    language_hints: Optional[List[Language]] = None
+    language_hints_strict: Optional[bool] = None
+    context: Optional[dict | str] = None
+    enable_speaker_diarization: Optional[bool] = False
+    enable_language_identification: Optional[bool] = False
+    client_reference_id: Optional[str] = None
+    enable_non_final_tokens: Optional[bool] = True
+    max_non_final_tokens_duration_ms: Optional[int] = None
+
+
+def _is_end_token(token: dict) -> bool:
+    """Determine if a token is an end/finalized token."""
+    return token["text"] == END_TOKEN or token["text"] == FINALIZED_TOKEN
+
+
+def _language_to_soniox(language: Language) -> str:
+    """Convert pipecat Language to Soniox language code."""
+    lang_str = str(language.value).lower()
+    if "-" in lang_str:
+        return lang_str.split("-")[0]
+    return lang_str
+
+
+def _prepare_language_hints(
+    language_hints: Optional[List[Language]],
+) -> Optional[List[str]]:
+    if language_hints is None:
+        return None
+    prepared = [_language_to_soniox(lang) for lang in language_hints]
+    return list(set(prepared))
+
+
+class CustomSonioxSTTService(WebsocketSTTService):
+    """Custom Soniox STT with endpoint detection timeout for telephony.
+
+    Key differences from pipecat's SonioxSTTService:
+
+    1. **Endpoint detection timeout**: On VAD stop, waits `endpoint_timeout`
+       seconds (default 500ms) before sending FINALIZE_MESSAGE. If VAD start
+       arrives within that window, the finalize is cancelled. This prevents
+       mid-sentence cutoffs from brief pauses.
+
+    2. **Hybrid endpoint detection**: Enables Soniox's native endpoint detection
+       alongside VAD-driven finalization. Soniox can detect natural endpoints
+       for longer pauses even without VAD triggering.
+
+    3. **Optimized for 8kHz telephony**: Works correctly with low-amplitude
+       telephony audio where Silero VAD confidence is lower.
+    """
+
+    def __init__(
+        self,
+        *,
+        api_key: str,
+        url: str = "wss://stt-rt.soniox.com/transcribe-websocket",
+        sample_rate: Optional[int] = None,
+        params: Optional[CustomSonioxInputParams] = None,
+        endpoint_timeout: float = DEFAULT_ENDPOINT_TIMEOUT,
+        enable_soniox_endpoint_detection: bool = True,
+        **kwargs,
+    ):
+        """Initialize the custom Soniox STT service.
+
+        Args:
+            api_key: Soniox API key.
+            url: Soniox WebSocket API URL.
+            sample_rate: Audio sample rate.
+            params: Transcription configuration parameters.
+            endpoint_timeout: Seconds to wait after VAD stop before finalizing.
+                If user resumes speaking within this window, finalize is cancelled.
+                Set to 0 to finalize immediately (same as pipecat default).
+                Defaults to 0.5 seconds.
+            enable_soniox_endpoint_detection: If True, also enables Soniox's
+                native endpoint detection (hybrid mode). Defaults to True.
+            **kwargs: Additional arguments passed to WebsocketSTTService.
+        """
+        super().__init__(
+            sample_rate=sample_rate,
+            keepalive_timeout=1,
+            keepalive_interval=5,
+            **kwargs,
+        )
+        params = params or CustomSonioxInputParams()
+
+        self._api_key = api_key
+        self._url = url
+        self.set_model_name(params.model)
+        self._params = params
+        self._endpoint_timeout = endpoint_timeout
+        self._enable_soniox_endpoint_detection = enable_soniox_endpoint_detection
+
+        self._final_transcription_buffer: list = []
+        self._last_tokens_received: Optional[float] = None
+
+        self._receive_task = None
+        self._endpoint_timeout_task: Optional[asyncio.Task] = None
+
+    async def start(self, frame: StartFrame):
+        await super().start(frame)
+        await self._connect()
+
+    async def stop(self, frame: EndFrame):
+        await super().stop(frame)
+        await self._cancel_endpoint_timeout()
+        await self._send_stop_recording()
+        await self._disconnect()
+
+    async def cancel(self, frame: CancelFrame):
+        await super().cancel(frame)
+        await self._cancel_endpoint_timeout()
+        await self._disconnect()
+
+    async def run_stt(self, audio: bytes) -> AsyncGenerator[Frame, None]:
+        """Send audio data to Soniox."""
+        await self.start_processing_metrics()
+        if self._websocket and self._websocket.state is State.OPEN:
+            await self._websocket.send(audio)
+        await self.stop_processing_metrics()
+        yield None
+
+    async def process_frame(self, frame: Frame, direction: FrameDirection):
+        """Process frames with endpoint detection timeout logic.
+
+        On VAD stop: start a timer instead of immediately finalizing.
+        On VAD start: cancel any pending finalize timer.
+        """
+        await super().process_frame(frame, direction)
+
+        if isinstance(frame, VADUserStartedSpeakingFrame):
+            # User resumed speaking — cancel any pending finalize
+            if self._endpoint_timeout_task:
+                logger.debug(
+                    "User resumed speaking, cancelling pending endpoint finalize"
+                )
+                await self._cancel_endpoint_timeout()
+
+        elif isinstance(frame, VADUserStoppedSpeakingFrame):
+            if self._endpoint_timeout <= 0:
+                # No timeout configured — finalize immediately (pipecat default behavior)
+                await self._send_finalize()
+            else:
+                # Start endpoint detection timeout
+                await self._cancel_endpoint_timeout()
+                self._endpoint_timeout_task = asyncio.ensure_future(
+                    self._endpoint_timeout_handler()
+                )
+                logger.debug(
+                    f"VAD stop detected, starting {self._endpoint_timeout}s endpoint timeout"
+                )
+
+    async def _endpoint_timeout_handler(self):
+        """Wait for endpoint timeout, then finalize if not cancelled."""
+        try:
+            await asyncio.sleep(self._endpoint_timeout)
+            logger.debug(
+                f"Endpoint timeout ({self._endpoint_timeout}s) expired, sending finalize"
+            )
+            await self._send_finalize()
+        except asyncio.CancelledError:
+            pass
+        finally:
+            self._endpoint_timeout_task = None
+
+    async def _cancel_endpoint_timeout(self):
+        """Cancel any pending endpoint detection timeout."""
+        if self._endpoint_timeout_task:
+            self._endpoint_timeout_task.cancel()
+            try:
+                await self._endpoint_timeout_task
+            except asyncio.CancelledError:
+                pass
+            self._endpoint_timeout_task = None
+
+    async def _send_finalize(self):
+        """Send finalize message to Soniox to get final tokens."""
+        if self._websocket and self._websocket.state is State.OPEN:
+            await self._websocket.send(FINALIZE_MESSAGE)
+            logger.debug("Sent finalize message to Soniox")
+
+    async def _send_stop_recording(self):
+        """Send stop recording message to Soniox."""
+        if self._websocket and self._websocket.state is State.OPEN:
+            await self._websocket.send("")
+
+    async def _connect(self):
+        await self._connect_websocket()
+        await super()._connect()
+        if self._websocket and not self._receive_task:
+            self._receive_task = self.create_task(
+                self._receive_task_handler(self._report_error)
+            )
+
+    async def _disconnect(self):
+        await super()._disconnect()
+        if self._receive_task:
+            await self.cancel_task(self._receive_task)
+            self._receive_task = None
+        await self._disconnect_websocket()
+
+    async def _connect_websocket(self):
+        """Establish websocket connection with hybrid endpoint detection config."""
+        try:
+            if self._websocket and self._websocket.state is State.OPEN:
+                return
+
+            logger.debug("Connecting to Soniox STT (custom)")
+
+            self._websocket = await websocket_connect(self._url)
+
+            if not self._websocket:
+                await self.push_error(
+                    error_msg=f"Unable to connect to Soniox API at {self._url}"
+                )
+                raise Exception(f"Unable to connect to Soniox API at {self._url}")
+
+            # Hybrid mode: enable Soniox's native endpoint detection alongside
+            # our VAD-driven finalization with timeout.
+            enable_endpoint_detection = self._enable_soniox_endpoint_detection
+
+            context = self._params.context
+            if isinstance(context, BaseModel):
+                context = context.model_dump()
+
+            config = {
+                "api_key": self._api_key,
+                "model": self._model_name,
+                "audio_format": self._params.audio_format,
+                "num_channels": self._params.num_channels or 1,
+                "enable_endpoint_detection": enable_endpoint_detection,
+                "sample_rate": self.sample_rate,
+                "language_hints": _prepare_language_hints(self._params.language_hints),
+                "language_hints_strict": self._params.language_hints_strict,
+                "context": context,
+                "enable_speaker_diarization": self._params.enable_speaker_diarization,
+                "enable_language_identification": self._params.enable_language_identification,
+                "client_reference_id": self._params.client_reference_id,
+            }
+
+            await self._websocket.send(json.dumps(config))
+
+            await self._call_event_handler("on_connected")
+            logger.debug(
+                f"Connected to Soniox STT (custom) - "
+                f"endpoint_timeout={self._endpoint_timeout}s, "
+                f"soniox_endpoint_detection={enable_endpoint_detection}"
+            )
+        except Exception as e:
+            await self.push_error(
+                error_msg=f"Unable to connect to Soniox: {e}", exception=e
+            )
+            raise
+
+    async def _disconnect_websocket(self):
+        try:
+            if self._websocket:
+                logger.debug("Disconnecting from Soniox STT (custom)")
+                await self._websocket.close()
+        except Exception as e:
+            await self.push_error(
+                error_msg=f"Error closing websocket: {e}", exception=e
+            )
+        finally:
+            self._websocket = None
+            await self._call_event_handler("on_disconnected")
+
+    def _get_websocket(self):
+        if self._websocket:
+            return self._websocket
+        raise Exception("Websocket not connected")
+
+    async def _receive_messages(self):
+        """Receive and process Soniox websocket messages."""
+        self._final_transcription_buffer = []
+
+        async def send_endpoint_transcript():
+            if self._final_transcription_buffer:
+                text = "".join(
+                    token["text"] for token in self._final_transcription_buffer
+                )
+                await self.push_frame(
+                    TranscriptionFrame(
+                        text=text,
+                        user_id=self._user_id,
+                        timestamp=time_now_iso8601(),
+                        result=self._final_transcription_buffer,
+                        finalized=True,
+                    )
+                )
+                await self.stop_processing_metrics()
+                self._final_transcription_buffer = []
+
+        async for message in self._get_websocket():
+            try:
+                content = json.loads(message)
+                tokens = content["tokens"]
+
+                if tokens:
+                    if len(tokens) == 1 and tokens[0]["text"] == FINALIZED_TOKEN:
+                        # Ignore lone finalized token to prevent auto-finalize cycling
+                        pass
+                    else:
+                        self._last_tokens_received = time.time()
+
+                non_final_transcription = []
+
+                for token in tokens:
+                    if token["is_final"]:
+                        if _is_end_token(token):
+                            await send_endpoint_transcript()
+                        else:
+                            self._final_transcription_buffer.append(token)
+                    else:
+                        non_final_transcription.append(token)
+
+                if self._final_transcription_buffer or non_final_transcription:
+                    final_text = "".join(
+                        token["text"]
+                        for token in self._final_transcription_buffer
+                    )
+                    non_final_text = "".join(
+                        token["text"] for token in non_final_transcription
+                    )
+
+                    await self.push_frame(
+                        InterimTranscriptionFrame(
+                            text=final_text + non_final_text,
+                            user_id=self._user_id,
+                            timestamp=time_now_iso8601(),
+                            result=self._final_transcription_buffer
+                            + non_final_transcription,
+                        )
+                    )
+
+                error_code = content.get("error_code")
+                error_message = content.get("error_message")
+                if error_code or error_message:
+                    await send_endpoint_transcript()
+                    await self.push_error(
+                        error_msg=f"Soniox error: {error_code} - {error_message}"
+                    )
+
+                finished = content.get("finished")
+                if finished:
+                    await send_endpoint_transcript()
+                    logger.debug("Soniox transcription finished.")
+                    return
+
+            except json.JSONDecodeError:
+                logger.warning(f"Received non-JSON message from Soniox: {message}")
+            except Exception as e:
+                logger.warning(f"Error processing Soniox message: {e}")
+
+    async def _send_keepalive(self, silence: bytes):
+        """Send Soniox protocol-level keepalive."""
+        await self._websocket.send(KEEPALIVE_MESSAGE)

--- a/app/ai/voice/stt/soniox.py
+++ b/app/ai/voice/stt/soniox.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import json
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Iterable, Optional
 
 from pipecat.services.soniox.stt import (
@@ -15,9 +15,15 @@ from pipecat.services.soniox.stt import (
 )
 from pipecat.transcriptions.language import Language
 
+from app.ai.voice.stt.custom_soniox import CustomSonioxInputParams, CustomSonioxSTTService
 from app.core.logger import logger
 
-__all__ = ["SonioxConfig", "build_soniox_stt"]
+__all__ = [
+    "SonioxConfig",
+    "build_soniox_stt",
+    "CustomSonioxConfig",
+    "build_custom_soniox_stt",
+]
 
 
 @dataclass
@@ -172,4 +178,83 @@ def build_soniox_stt(config: SonioxConfig):
         api_key=config.api_key,
         params=soniox_params,
         vad_force_turn_endpoint=config.vad_force_turn_endpoint,
+    )
+
+
+@dataclass
+class CustomSonioxConfig:
+    """Configuration for Custom Soniox STT with endpoint detection timeout.
+
+    Extends SonioxConfig with endpoint detection timeout and hybrid mode settings
+    optimized for telephony (8kHz) environments where VAD is less reliable.
+    """
+
+    api_key: str
+    model: str
+    endpoint_timeout: float = 0.5
+    enable_soniox_endpoint_detection: bool = True
+    language_hints: Optional[str | Iterable[str]] = None
+    context_json: Optional[str] = None
+    client_reference_id: Optional[str] = None
+    log_context: str = "Soniox (Custom)"
+    language_hints_strict: bool = False
+
+
+def build_custom_soniox_stt(config: CustomSonioxConfig) -> CustomSonioxSTTService:
+    """Create a Custom Soniox STT service with endpoint detection timeout.
+
+    This builder creates a CustomSonioxSTTService that waits a configurable
+    delay after VAD stop before sending finalize to Soniox. This prevents
+    mid-sentence cutoffs in telephony (8kHz) where brief pauses trigger
+    premature finalization.
+    """
+    # Parse language hints
+    language_hints = None
+    if config.language_hints:
+        if isinstance(config.language_hints, str):
+            parsed_hints = [
+                lang.strip()
+                for lang in config.language_hints.split(",")
+                if lang.strip()
+            ]
+        else:
+            parsed_hints = list(config.language_hints)
+
+        if parsed_hints:
+            language_hints = [Language(lang) for lang in parsed_hints if lang]
+
+    context = _parse_soniox_context(config.context_json, config.log_context)
+
+    custom_params = CustomSonioxInputParams(
+        model=config.model,
+        language_hints=language_hints,
+        context=context,
+        language_hints_strict=config.language_hints_strict,
+        client_reference_id=config.client_reference_id,
+        enable_non_final_tokens=True,
+    )
+
+    # Format language hints for logging
+    hints_display = ""
+    if config.language_hints:
+        if isinstance(config.language_hints, str):
+            hints_display = config.language_hints
+        else:
+            hints_display = ",".join(config.language_hints)
+
+    logger.info(
+        "Using %s STT service with model: %s, language_hints: %s, "
+        "endpoint_timeout: %ss, soniox_endpoint_detection: %s",
+        config.log_context,
+        config.model,
+        hints_display,
+        config.endpoint_timeout,
+        config.enable_soniox_endpoint_detection,
+    )
+
+    return CustomSonioxSTTService(
+        api_key=config.api_key,
+        params=custom_params,
+        endpoint_timeout=config.endpoint_timeout,
+        enable_soniox_endpoint_detection=config.enable_soniox_endpoint_detection,
     )

--- a/app/core/config/static.py
+++ b/app/core/config/static.py
@@ -472,6 +472,13 @@ BREEZE_BUDDY_SONIOX_VAD_FORCE_TURN_ENDPOINT = (
     os.environ.get("BREEZE_BUDDY_SONIOX_VAD_FORCE_TURN_ENDPOINT", "true").lower()
     == "true"
 )
+BREEZE_BUDDY_SONIOX_ENDPOINT_TIMEOUT = float(
+    os.environ.get("BREEZE_BUDDY_SONIOX_ENDPOINT_TIMEOUT", "0.5")
+)  # Seconds to wait after VAD stop before finalizing (0 = immediate, like pipecat default)
+BREEZE_BUDDY_SONIOX_ENABLE_ENDPOINT_DETECTION = (
+    os.environ.get("BREEZE_BUDDY_SONIOX_ENABLE_ENDPOINT_DETECTION", "true").lower()
+    == "true"
+)  # Enable Soniox's native endpoint detection alongside VAD-driven finalization
 
 ENABLE_BREEZE_BUDDY_USER_INTERRUPTION = (
     os.environ.get("ENABLE_BREEZE_BUDDY_USER_INTERRUPTION", "false").lower() == "true"

--- a/app/core/config/static.py
+++ b/app/core/config/static.py
@@ -360,17 +360,17 @@ LIGHTHOUSE_JWT_SECRET = os.getenv("LIGHTHOUSE_JWT_SECRET", "")
 ENABLE_LIGHTHOUSE_AUTH = os.getenv("ENABLE_LIGHTHOUSE_AUTH", "false").lower() == "true"
 
 BREEZE_BUDDY_VAD_CONFIDENCE = float(
-    os.getenv("BREEZE_BUDDY_VAD_CONFIDENCE", "0.5")
-)  # Require stronger confidence
+    os.getenv("BREEZE_BUDDY_VAD_CONFIDENCE", "0.35")
+)  # Lower for 8kHz telephony where Silero VAD confidence is reduced
 BREEZE_BUDDY_VAD_START_SECS = float(
-    os.getenv("BREEZE_BUDDY_VAD_START_SECS", "0.1")
-)  # Pick up quicker
+    os.getenv("BREEZE_BUDDY_VAD_START_SECS", "0.2")
+)  # Slightly slower to avoid noise triggering speech start
 BREEZE_BUDDY_VAD_STOP_SECS = float(
-    os.getenv("BREEZE_BUDDY_VAD_STOP_SECS", "0.3")
-)  # Allow small pauses
+    os.getenv("BREEZE_BUDDY_VAD_STOP_SECS", "0.5")
+)  # Allow natural pauses in telephony speech
 BREEZE_BUDDY_VAD_MIN_VOLUME = float(
-    os.getenv("BREEZE_BUDDY_VAD_MIN_VOLUME", "0.4")
-)  # More tolerant for soft voice
+    os.getenv("BREEZE_BUDDY_VAD_MIN_VOLUME", "0.15")
+)  # Much lower for 8kHz mulaw which produces lower amplitude values
 BREEZE_BUDDY_STT_SERVICE = os.getenv(
     "BREEZE_BUDDY_STT_SERVICE", "soniox"
 ).lower()  # "google" or "openai"


### PR DESCRIPTION
## Summary

Introduces a custom Soniox STT service optimized for telephony environments (8kHz mulaw audio) that implements an endpoint detection timeout mechanism. Instead of immediately finalizing transcription when VAD detects silence, the service waits a configurable delay (default 500ms) before sending the finalize message. If the user resumes speaking within that window, the finalize is cancelled, preventing mid-sentence cutoffs from brief pauses common in low-quality telephony audio.

## Key Changes

- **New CustomSonioxSTTService** (`app/ai/voice/stt/custom_soniox.py`):
  - Extends pipecat's WebsocketSTTService with configurable endpoint detection timeout
  - Implements hybrid endpoint detection: combines VAD-driven finalization with Soniox's native endpoint detection
  - Cancels pending finalize if user resumes speaking within the timeout window
  - Optimized for 8kHz telephony where Silero VAD confidence is lower and brief pauses are common

- **Configuration and builder** (`app/ai/voice/stt/soniox.py`):
  - Added `CustomSonioxConfig` dataclass with `endpoint_timeout` and `enable_soniox_endpoint_detection` parameters
  - Added `build_custom_soniox_stt()` factory function to instantiate the custom service

- **Updated Breeze Buddy pipeline** (`app/ai/voice/agents/breeze_buddy/agent/pipeline.py`):
  - Migrated to new universal `LLMContextAggregatorPair` with `UserTurnStrategies`
  - Implements dual user turn start strategies: VAD-based (primary) + transcription-based (fallback for soft speech)
  - Uses `SpeechTimeoutUserTurnStopStrategy` with zero timeout to rely on Soniox's endpoint detection
  - VAD now runs inside the aggregator (not the transport) where it feeds turn strategies

- **VAD tuning for telephony** (`app/core/config/static.py`):
  - Lowered `BREEZE_BUDDY_VAD_CONFIDENCE` from 0.5 to 0.35 for 8kHz audio
  - Increased `BREEZE_BUDDY_VAD_STOP_SECS` from 0.3 to 0.5 to allow natural pauses
  - Lowered `BREEZE_BUDDY_VAD_MIN_VOLUME` from 0.4 to 0.15 for low-amplitude mulaw audio
  - Added new config variables: `BREEZE_BUDDY_SONIOX_ENDPOINT_TIMEOUT` and `BREEZE_BUDDY_SONIOX_ENABLE_ENDPOINT_DETECTION`

- **Transport refactoring** (`app/ai/voice/agents/breeze_buddy/agent/transport.py`):
  - Removed VAD configuration from transport layer (now handled in aggregator)
  - Updated docstring to clarify VAD lives in LLMUserAggregator, not transport

- **STT service integration** (`app/ai/voice/agents/breeze_buddy/stt/__init__.py`):
  - Updated to use `build_custom_soniox_stt()` instead of standard `build_soniox_stt()`
  - Passes endpoint timeout and endpoint detection settings from config

## Implementation Details

The endpoint detection timeout works by:
1. On `VADUserStoppedSpeakingFrame`: Start an async timer instead of immediately finalizing
2. On `VADUserStartedSpeakingFrame`: Cancel any pending finalize timer
3. If timer expires without interruption: Send finalize message to Soniox
4. If user resumes speaking: Timer is cancelled, preventing premature finalization

This hybrid approach combines VAD-driven finalization with Soniox's native endpoint detection, providing robust handling of both brief pauses within utterances and natural endpoints for longer silences.

https://claude.ai/code/session_01JRZAceS7dsdknzgcWvK5Yi

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Integrated enhanced voice activity detection capabilities throughout the voice processing pipeline.

* **Configuration Updates**
  * Adjusted voice activity detection sensitivity thresholds for optimal performance.
  * Introduced endpoint detection timeout setting for the speech-to-text service.
  * Enhanced voice endpoint detection for improved speech recognition in telephony scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->