### PR TITLE
feat(logging): Add contextual bound logging for lead/merchant/phone context

### DIFF
--- a/app/ai/voice/agents/breeze_buddy/agent/__init__.py
+++ b/app/ai/voice/agents/breeze_buddy/agent/__init__.py
@@ -67,7 +67,7 @@ from app.ai.voice.agents.breeze_buddy.utils.common import (
     track_error,
 )
 from app.core.config.static import ENABLE_BREEZE_BUDDY_TRACING
-from app.core.logger import logger
+from app.core.logger import get_bound_logger, logger, set_log_context
 from app.database.accessor import update_lead_call_initiated_time
 from app.database.accessor.breeze_buddy.lead_call_tracker import (
     update_lead_call_initiated_time_by_id,
@@ -107,6 +107,7 @@ class Agent:
         self.vad_analyzer: Optional[SileroVADAnalyzer] = None
         self.transport: Any = None
         self.lead: Optional[LeadCallTracker] = None
+        self.logger = logger  # unbound at construction; bound after lead is resolved
         self.root_span: Any = None
         self.flow_manager: Optional[FlowManager] = None
         self.conversation_id: Optional[str] = None
@@ -147,7 +148,7 @@ class Agent:
         if not self.lead:
             raise ValueError(f"Lead not found for lead_id: {lead_id}")
 
-        logger.info(f"Starting Daily bot for lead_id: {lead_id}")
+        self.logger.info(f"Starting Daily bot for lead_id: {lead_id}")
 
         self.flow_builder = FlowConfigBuilder()
 
@@ -169,11 +170,31 @@ class Agent:
         transport_params = get_transport_params(None, self.configurations)
         self.transport = await create_transport(runner_args, transport_params)
 
+        # Set async-task-scoped call context — propagates to ALL logs in this task,
+        # including DB accessors, template handlers, webhooks, and library logs.
+        set_log_context(
+            lead_id=self.lead.id,
+            merchant_id=self.lead.merchant_id,
+            template=self.lead.template,
+            phone_number=(self.lead.payload or {}).get("customer_mobile_number"),
+            call_sid=self.lead.call_id,
+        )
+        self.logger = get_bound_logger(
+            lead_id=self.lead.id,
+            merchant_id=self.lead.merchant_id,
+            template=self.lead.template,
+            phone_number=(self.lead.payload or {}).get("customer_mobile_number"),
+            call_sid=self.lead.call_id,
+        )
+        self.logger.info(
+            f"Call context set for Daily bot: lead={self.lead.id}, merchant={self.lead.merchant_id}, template={self.lead.template}"
+        )
+
     async def _setup_telephony_transport(self) -> bool:
         """Initialize transport for telephony mode. Returns False if setup fails."""
-        logger.info("Starting WebSocket bot")
+        self.logger.info("Starting WebSocket bot")
         if not self.ws:
-            logger.error("WebSocket not initialized")
+            self.logger.error("WebSocket not initialized")
             return False
         await self.ws.accept()
         call_initiated_time = datetime.now(timezone.utc)
@@ -185,12 +206,12 @@ class Agent:
         self.stream_sid = call_data.get("stream_id")
 
         if not self.stream_sid or not self.call_sid:
-            logger.error(
+            self.logger.error(
                 f"Missing required call identifiers: stream_sid={self.stream_sid}, call_id={self.call_sid}"
             )
             return False
 
-        logger.info(
+        self.logger.info(
             f"Parsed WebSocket: transport_type={transport_type}, "
             f"call_sid: {self.call_sid}, stream_sid: {self.stream_sid}"
         )
@@ -224,7 +245,7 @@ class Agent:
                 )
                 if not self.lead:
                     error_msg = f"Inbound call handling failed (IVR): {error_reason}"
-                    logger.info(error_msg)
+                    self.logger.info(error_msg)
                     track_error(self.errors, error_msg)
                     await close_websocket_safely(
                         self.ws,
@@ -242,7 +263,7 @@ class Agent:
                 )
                 if not self.lead:
                     error_msg = f"Inbound call handling failed: {error_reason}"
-                    logger.info(error_msg)
+                    self.logger.info(error_msg)
                     track_error(self.errors, error_msg)
                     await close_websocket_safely(
                         self.ws,
@@ -257,7 +278,7 @@ class Agent:
             )
         except ValueError as e:
             error_msg = f"Template loading failed: {str(e)}"
-            logger.error(error_msg)
+            self.logger.error(error_msg)
             track_error(self.errors, error_msg)
             if self.completion_function:
                 await end_call_with_errors(
@@ -271,7 +292,7 @@ class Agent:
             return False
         except Exception as e:
             error_msg = f"Unexpected error loading template: {str(e)}"
-            logger.error(error_msg)
+            self.logger.error(error_msg)
             track_error(self.errors, error_msg)
             if self.completion_function:
                 await end_call_with_errors(
@@ -294,7 +315,7 @@ class Agent:
 
         # Safe access for required attributes after lead check above
         if not self.ws or not self.stream_sid or not self.lead or not self.template:
-            logger.error("Missing required attributes after setup")
+            self.logger.error("Missing required attributes after setup")
             return False
 
         greeting_result = await send_initial_greeting(
@@ -326,13 +347,29 @@ class Agent:
             self.ws, params, transport_type, call_data
         )
 
-        logger.info(f"Created transport: {self.transport.__class__.__name__}")
+        # Set async-task-scoped call context — propagates to ALL logs in this task,
+        # including DB accessors, template handlers, webhooks, and library logs.
+        set_log_context(
+            lead_id=self.lead.id,
+            merchant_id=self.lead.merchant_id,
+            template=self.lead.template,
+            phone_number=(self.lead.payload or {}).get("customer_mobile_number"),
+            call_sid=self.call_sid,
+        )
+        self.logger = get_bound_logger(
+            lead_id=self.lead.id,
+            merchant_id=self.lead.merchant_id,
+            template=self.lead.template,
+            phone_number=(self.lead.payload or {}).get("customer_mobile_number"),
+            call_sid=self.call_sid,
+        )
+        self.logger.info(f"Created transport: {self.transport.__class__.__name__}")
         return True
 
     def _register_event_handlers(self) -> None:
         """Register transport and task event handlers."""
         if not self.transport or not self.task:
-            logger.error("Transport or task not initialized")
+            self.logger.error("Transport or task not initialized")
             return
 
         @self.task.event_handler("on_pipeline_error")
@@ -341,22 +378,22 @@ class Agent:
             processor = getattr(error, "processor", "unknown")
             error_msg = getattr(error, "error", str(error))
             detailed_msg = f"[PIPELINE] {processor}: {error_msg}"
-            logger.info(f"[PIPELINE_ERROR] {detailed_msg}")
+            self.logger.info(f"[PIPELINE_ERROR] {detailed_msg}")
             track_error(self.errors, detailed_msg)
 
         @self.transport.event_handler("on_client_connected")
         async def on_client_connected(transport, client):
-            logger.info(f"Client connected: {client}")
+            self.logger.info(f"Client connected: {client}")
             await self._handle_client_connected()
 
         @self.transport.event_handler("on_client_disconnected")
         async def on_client_disconnected(transport, client):
-            logger.info(f"Client disconnected: {client}")
+            self.logger.info(f"Client disconnected: {client}")
             await self._handle_unexpected_disconnect("client_disconnected")
 
         @self.task.event_handler("on_idle_timeout")
         async def on_idle_timeout(task):
-            logger.info("Idle timeout detected.")
+            self.logger.info("Idle timeout detected.")
             await self._handle_unexpected_disconnect("idle_timeout")
 
     async def _handle_client_connected(self) -> None:
@@ -367,7 +404,9 @@ class Agent:
             or not self.lead
             or not self.flow_manager
         ):
-            logger.error("Required attributes not initialized for client connection")
+            self.logger.error(
+                "Required attributes not initialized for client connection"
+            )
             return
 
         (
@@ -386,14 +425,14 @@ class Agent:
         )
 
         await self.flow_manager.initialize(initial_node_config)
-        logger.info(
+        self.logger.info(
             f"FlowManager initialized with initial node: {self.flow_config['initial_node']}"
         )
 
     async def _run_with_tracing(self, runner: PipelineRunner) -> None:
         """Run the pipeline with OpenTelemetry tracing."""
         if not self.lead or not self.task:
-            logger.error("Lead or task not initialized for tracing")
+            self.logger.error("Lead or task not initialized for tracing")
             return
 
         lead_payload = self.lead.payload or {}
@@ -412,7 +451,7 @@ class Agent:
                 await runner.run(self.task)
         except Exception as e:
             error_msg = f"Error during traced pipeline execution: {e}"
-            logger.error(error_msg)
+            self.logger.error(error_msg)
             track_error(self.errors, error_msg)
             self.root_span.end()
 
@@ -425,7 +464,7 @@ class Agent:
         # Setup transport based on mode
         if self.is_daily_mode:
             if not runner_args:
-                logger.error("runner_args is required for Daily mode")
+                self.logger.error("runner_args is required for Daily mode")
                 return
             await self._setup_daily_transport(runner_args)
         else:
@@ -438,12 +477,12 @@ class Agent:
             if payload_voice and self.configurations:
                 try:
                     voice_enum = TTSVoiceName(payload_voice)
-                    logger.info(
+                    self.logger.info(
                         f"Overriding TTS voice from payload: {voice_enum.value}"
                     )
                     self.configurations.tts_voice_name = voice_enum
                 except ValueError:
-                    logger.warning(
+                    self.logger.warning(
                         f"Invalid TTS voice '{payload_voice}' in payload, keeping existing config"
                     )
 
@@ -462,7 +501,7 @@ class Agent:
 
         # Validate required attributes for flow setup
         if not self.template:
-            logger.error("Template is not set, cannot setup flow manager")
+            self.logger.error("Template is not set, cannot setup flow manager")
             return
 
         # Setup flow management
@@ -483,19 +522,19 @@ class Agent:
             if ENABLE_BREEZE_BUDDY_TRACING:
                 await self._run_with_tracing(runner)
             else:
-                logger.info(
+                self.logger.info(
                     f"Running pipeline without tracing for conversation: {self.conversation_id}"
                 )
                 await runner.run(self.task)
         except asyncio.CancelledError:
-            logger.info("Pipeline task cancelled. Exiting gracefully.")
+            self.logger.info("Pipeline task cancelled. Exiting gracefully.")
 
     async def _handle_unexpected_disconnect(self, reason: str) -> None:
         """Handle unexpected disconnection and cleanup."""
         if self.conversation_ended:
             return
 
-        logger.info(f"{reason}. Updating call status.")
+        self.logger.info(f"{reason}. Updating call status.")
 
         if self.lead:
             if self.lead.outcome is None:
@@ -512,7 +551,7 @@ class Agent:
             else:
                 # Shouldn't happen, but safe fallback
                 self.lead.metaData["call_ended_by"] = "agent"
-                logger.warning(f"Unexpected disconnect reason: {reason}")
+                self.logger.warning(f"Unexpected disconnect reason: {reason}")
 
         context = TemplateContext(self)
         await end_conversation(context, {})

--- a/app/ai/voice/agents/breeze_buddy/managers/calls.py
+++ b/app/ai/voice/agents/breeze_buddy/managers/calls.py
@@ -22,7 +22,7 @@ from app.ai.voice.agents.breeze_buddy.services.telephony.utils import get_voice_
 from app.ai.voice.agents.breeze_buddy.template.types import TemplateModel
 from app.ai.voice.agents.breeze_buddy.utils.common import send_webhook_with_retry
 from app.core.config.static import UPLOAD_BREEZE_BUDDY_CALL_RECORDINGS_TO_CLOUD
-from app.core.logger import logger
+from app.core.logger import get_bound_logger, logger, set_log_context
 from app.core.transport.http_client import create_aiohttp_session
 from app.database.accessor import (
     acquire_lock_on_lead_by_id,
@@ -291,7 +291,19 @@ async def _cleanup_stuck_leads():
                 )
                 continue
 
-            logger.info(f"Successfully locked stuck lead {lead.id} for cleanup.")
+            set_log_context(
+                lead_id=locked_lead.id,
+                merchant_id=locked_lead.merchant_id,
+                template=locked_lead.template,
+            )
+            lead_logger = get_bound_logger(
+                lead_id=locked_lead.id,
+                merchant_id=locked_lead.merchant_id,
+                template=locked_lead.template,
+            )
+            lead_logger.info(
+                f"Successfully locked stuck lead {locked_lead.id} for cleanup."
+            )
 
             # Close the stuck record so it won't be picked again
             await update_lead_call_completion_details(
@@ -345,8 +357,29 @@ async def process_backlog_leads():
                     )
                     continue
 
+                # Set call context so ALL logs within this iteration (including DB calls,
+                # webhooks etc.) automatically carry lead/merchant/phone context.
+                set_log_context(
+                    lead_id=locked_lead.id,
+                    merchant_id=locked_lead.merchant_id,
+                    template=locked_lead.template,
+                    phone_number=(locked_lead.payload or {}).get(
+                        "customer_mobile_number"
+                    ),
+                )
+                lead_logger = get_bound_logger(
+                    lead_id=locked_lead.id,
+                    merchant_id=locked_lead.merchant_id,
+                    template=locked_lead.template,
+                    phone_number=(locked_lead.payload or {}).get(
+                        "customer_mobile_number", "unknown"
+                    ),
+                )
+
                 # Now we have exclusive access to this lead
-                logger.info(f"Successfully locked lead {lead.id} for processing.")
+                lead_logger.info(
+                    f"Successfully locked lead {locked_lead.id} for processing."
+                )
 
                 config = await _get_lead_config(locked_lead)
                 if not config:
@@ -354,14 +387,14 @@ async def process_backlog_leads():
                     continue
 
                 if not config.enable_calling:
-                    logger.info(
+                    lead_logger.info(
                         f"Skipping lead {locked_lead.id} - calling is disabled for merchant {locked_lead.merchant_id}, template {locked_lead.template}"
                     )
                     await release_lock_on_lead_by_id(locked_lead.id)
                     continue
 
                 if not _is_within_calling_hours(config):
-                    logger.info(
+                    lead_logger.info(
                         f"Skipping lead {locked_lead.id} - outside calling hours. "
                         f"Current time: {datetime.now(timezone(timedelta(hours=5, minutes=30))).time()}, "
                         f"Allowed window: {config.call_start_time} - {config.call_end_time}"
@@ -375,7 +408,7 @@ async def process_backlog_leads():
                     name=config.template,
                 )
 
-                logger.info(
+                lead_logger.info(
                     f"Lead {locked_lead.id} , template found: {template is not None}"
                 )
 
@@ -394,7 +427,7 @@ async def process_backlog_leads():
 
                 acquired = await _acquire_number(number_to_use)
                 if not acquired:
-                    logger.warning(
+                    lead_logger.warning(
                         f"Failed to acquire number {number_to_use.id} for lead {locked_lead.id} - "
                         "number may be at maximum capacity"
                     )
@@ -411,7 +444,7 @@ async def process_backlog_leads():
                     "customer_mobile_number"
                 )
                 if not customer_mobile or not isinstance(customer_mobile, str):
-                    logger.error(
+                    lead_logger.error(
                         f"Invalid customer_mobile_number for lead {locked_lead.id}"
                     )
                     await _release_number(number_to_use.id, number_to_use.provider)
@@ -431,13 +464,13 @@ async def process_backlog_leads():
                         number_to_use.id,
                     )
                 else:
-                    logger.error(
+                    lead_logger.error(
                         f"Failed to initiate call for lead {locked_lead.id}. Call response: {call}"
                     )
                     await _release_number(number_to_use.id, number_to_use.provider)
 
                     if template and template.outbound_number_id:
-                        logger.info(
+                        lead_logger.info(
                             f"Not retrying call for lead {locked_lead.id} as outbound_number_id is set in template."
                         )
                         await update_lead_call_completion_details(
@@ -463,7 +496,7 @@ async def process_backlog_leads():
                                 "failureReason": "Failed to initiate call, no retry due to fixed outbound number.",
                                 "orderId": locked_lead.request_id,
                             }
-                            logger.info(
+                            lead_logger.info(
                                 f"Sending failure webhook for lead {locked_lead.id} to {reporting_webhook_url}"
                             )
                             try:
@@ -471,7 +504,7 @@ async def process_backlog_leads():
                                     session, reporting_webhook_url, webhook_data
                                 )
                             except Exception as e:
-                                logger.error(
+                                lead_logger.error(
                                     f"Error sending failure webhook for lead {locked_lead.id}: {e}"
                                 )
 
@@ -485,7 +518,7 @@ async def process_backlog_leads():
                         retry_calling_provider = CallProvider.EXOTEL
                     elif number_to_use.provider == CallProvider.EXOTEL:
                         if not config.enable_international_call:
-                            logger.warning(
+                            lead_logger.warning(
                                 f"International calls disabled for merchant {locked_lead.merchant_id}. Skipping retry with Twilio."
                             )
                             await update_lead_call_completion_details(
@@ -511,7 +544,7 @@ async def process_backlog_leads():
                                     "failureReason": "Failed to initiate call due to NCPR, international calling disabled.",
                                     "orderId": locked_lead.request_id,
                                 }
-                                logger.info(
+                                lead_logger.info(
                                     f"Sending failure webhook for lead {locked_lead.id} to {reporting_webhook_url}"
                                 )
                                 try:
@@ -519,7 +552,7 @@ async def process_backlog_leads():
                                         session, reporting_webhook_url, webhook_data
                                     )
                                 except Exception as e:
-                                    logger.error(
+                                    lead_logger.error(
                                         f"Error sending failure webhook for lead {locked_lead.id}: {e}"
                                     )
 
@@ -566,7 +599,7 @@ async def process_backlog_leads():
 
                     retry_acquired = await _acquire_number(retry_number_to_use)
                     if not retry_acquired:
-                        logger.warning(
+                        lead_logger.warning(
                             f"Failed to acquire retry number {retry_number_to_use.id} for lead {locked_lead.id} - "
                             "number may be at maximum capacity"
                         )
@@ -584,7 +617,7 @@ async def process_backlog_leads():
                     if not retry_customer_mobile or not isinstance(
                         retry_customer_mobile, str
                     ):
-                        logger.error(
+                        lead_logger.error(
                             f"Invalid customer_mobile_number for retry lead {locked_lead.id}"
                         )
                         await _release_number(
@@ -606,7 +639,7 @@ async def process_backlog_leads():
                             retry_number_to_use.id,
                         )
                     else:
-                        logger.error(
+                        lead_logger.error(
                             f"Failed to initiate retry call for lead {locked_lead.id}. Call response: {retry_call}"
                         )
                         await update_lead_call_completion_details(
@@ -635,7 +668,7 @@ async def process_backlog_leads():
                                 "failureReason": "Failed to initiate call with both providers.",
                                 "orderId": locked_lead.request_id,
                             }
-                            logger.info(
+                            lead_logger.info(
                                 f"Sending failure webhook for lead {locked_lead.id} to {reporting_webhook_url}"
                             )
                             try:
@@ -643,14 +676,16 @@ async def process_backlog_leads():
                                     session, reporting_webhook_url, webhook_data
                                 )
                             except Exception as e:
-                                logger.error(
+                                lead_logger.error(
                                     f"Error sending failure webhook for lead {locked_lead.id}: {e}"
                                 )
 
                 await release_lock_on_lead_by_id(locked_lead.id)
 
             except Exception as e:
-                logger.error(f"Error processing lead {lead.id}: {e}")
+                logger.error(
+                    f"Error processing lead {lead.id}: {e}"
+                )  # no lead_logger here — may not be bound yet
 
 
 async def handle_call_completion(
@@ -668,16 +703,29 @@ async def handle_call_completion(
         logger.error(f"Could not find lead for call_id: {call_id}")
         return
 
+    set_log_context(
+        lead_id=lead.id,
+        merchant_id=lead.merchant_id,
+        template=lead.template,
+        call_sid=call_id,
+    )
+    call_logger = get_bound_logger(
+        lead_id=lead.id,
+        merchant_id=lead.merchant_id,
+        template=lead.template,
+        call_sid=call_id,
+    )
+
     if lead.outbound_number_id:
         outbound_number = await get_outbound_number_by_id(lead.outbound_number_id)
         if outbound_number:
             await _release_number(outbound_number.id, outbound_number.provider)
         else:
-            logger.error(
+            call_logger.error(
                 f"Could not find outbound number with id: {lead.outbound_number_id} to release."
             )
     else:
-        logger.info(f"No outbound number id for lead: {lead.id}")
+        call_logger.info(f"No outbound number id for lead: {lead.id}")
 
     config = await _get_lead_config(lead)
     if not config:
@@ -711,14 +759,27 @@ async def handle_unanswered_calls(call_id: str):
         logger.error(f"Could not find lead for call_id: {call_id}")
         return
 
+    set_log_context(
+        lead_id=lead.id,
+        merchant_id=lead.merchant_id,
+        template=lead.template,
+        call_sid=call_id,
+    )
+    call_logger = get_bound_logger(
+        lead_id=lead.id,
+        merchant_id=lead.merchant_id,
+        template=lead.template,
+        call_sid=call_id,
+    )
+
     # Clean up greeting audio from Redis if it exists for unanswered calls
     try:
         redis = await get_redis_service()
         greeting_key = f"greeting:{lead.id}"
         await redis.delete(greeting_key)
-        logger.info(f"Deleted greeting audio from Redis for lead {lead.id}")
+        call_logger.info(f"Deleted greeting audio from Redis for lead {lead.id}")
     except Exception as e:
-        logger.warning(
+        call_logger.warning(
             f"Failed to delete greeting audio from Redis for lead {lead.id}: {e}"
         )
 
@@ -727,11 +788,11 @@ async def handle_unanswered_calls(call_id: str):
         if outbound_number:
             await _release_number(outbound_number.id, outbound_number.provider)
         else:
-            logger.error(
+            call_logger.error(
                 f"Could not find outbound number with id: {lead.outbound_number_id} to release."
             )
     else:
-        logger.info(f"No outbound number id for lead: {lead.id}")
+        call_logger.info(f"No outbound number id for lead: {lead.id}")
 
     config = await _get_lead_config(lead)
     if not config:
@@ -776,10 +837,23 @@ async def update_call_recording(
         logger.error(f"Could not find lead for call_id: {call_id}")
         return
 
+    set_log_context(
+        lead_id=lead.id,
+        merchant_id=lead.merchant_id,
+        template=lead.template,
+        call_sid=call_id,
+    )
+    call_logger = get_bound_logger(
+        lead_id=lead.id,
+        merchant_id=lead.merchant_id,
+        template=lead.template,
+        call_sid=call_id,
+    )
+
     try:
         # If cloud upload is disabled, just store the provider URL in DB
         if not UPLOAD_BREEZE_BUDDY_CALL_RECORDINGS_TO_CLOUD:
-            logger.info(
+            call_logger.info(
                 f"Cloud upload disabled. Storing provider recording URL in DB for call_id: {call_id}"
             )
             await update_lead_call_recording_url(call_id, provider_recording_url)
@@ -799,11 +873,11 @@ async def update_call_recording(
                 provider_recording_url, call_id
             )
         else:
-            logger.error(f"Unsupported provider: {provider}")
+            call_logger.error(f"Unsupported provider: {provider}")
             return
 
         if not audio_file:
-            logger.error(f"Failed to download recording for call_id: {call_id}")
+            call_logger.error(f"Failed to download recording for call_id: {call_id}")
             await update_lead_call_recording_url(call_id, provider_recording_url)
             return
 
@@ -828,13 +902,15 @@ async def update_call_recording(
         )
 
         if gcs_url:
-            logger.info(f"Successfully uploaded recording to GCS: {gcs_url}")
+            call_logger.info(f"Successfully uploaded recording to GCS: {gcs_url}")
             await update_lead_call_recording_url(call_id, gcs_url)
         else:
-            logger.error(f"Failed to upload recording to GCS for call_id: {call_id}")
+            call_logger.error(
+                f"Failed to upload recording to GCS for call_id: {call_id}"
+            )
             await update_lead_call_recording_url(call_id, provider_recording_url)
 
     except Exception as e:
-        logger.error(
+        call_logger.error(
             f"Error processing call recording for call_id {call_id}: {e}", exc_info=True
         )

--- a/app/core/logger/__init__.py
+++ b/app/core/logger/__init__.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import sys
+from contextvars import ContextVar
 from typing import Optional
 
 from loguru import logger
@@ -10,6 +11,77 @@ logger.remove()
 
 # Use environment variables directly to avoid circular import
 from app.core.config.static import ENVIRONMENT, PROD_LOG_LEVEL
+
+# ---------------------------------------------------------------------------
+# Generic per-async-task log context
+#
+# A single ContextVar holds an arbitrary dict of key-value pairs. Set it once
+# at the entry point of any async task (agent, background job, request handler)
+# and every log in that task — including DB accessors, template handlers,
+# webhooks, and third-party library logs intercepted by Loguru — automatically
+# carries those fields without any changes to downstream code.
+#
+# Concurrency safe: each asyncio Task owns its own copy of ContextVar state.
+# Setting context in one task has zero effect on any other concurrent task.
+# ---------------------------------------------------------------------------
+_log_context: ContextVar[dict] = ContextVar("log_context", default={})
+
+
+def set_log_context(**kwargs: Optional[str]) -> None:
+    """
+    Set arbitrary key-value pairs as log context for the current async task.
+
+    Every subsequent log call anywhere in the same async task — including DB
+    accessors, template handlers, webhook senders, and third-party library
+    logs intercepted by Loguru — will automatically carry these fields.
+
+    Callers decide which fields are relevant; core logger has no opinion on
+    field names. Examples of what callers might pass:
+
+        # Breeze Buddy agent after lead is resolved:
+        set_log_context(
+            lead_id=self.lead.id,
+            merchant_id=self.lead.merchant_id,
+            template=self.lead.template,
+            phone_number=(self.lead.payload or {}).get("customer_mobile_number", ""),
+            call_sid=self.call_sid or "",
+        )
+
+        # Automatic agent subprocess after session is established:
+        set_log_context(session_id=args.session_id, client_sid=args.client_sid)
+
+        # Any future agent or background worker with its own relevant fields:
+        set_log_context(job_id=job.id, queue=job.queue_name)
+    """
+    _log_context.set(kwargs)
+
+
+def clear_log_context() -> None:
+    """
+    Clear the log context for the current async task.
+
+    Optional — asyncio Tasks discard their ContextVar state automatically
+    when they complete, so explicit clearing is only needed if you reuse a
+    long-lived coroutine across multiple logical operations.
+    """
+    _log_context.set({})
+
+
+def _log_context_patcher(record: dict) -> None:  # type: ignore[type-arg]
+    """
+    Loguru patcher: injects the current async-task's log context into every
+    log record's extra dict before it reaches any sink.
+
+    Only non-empty string values are added, so logs that fire outside of a
+    task context (e.g. startup, scheduler ticks) are not polluted with empty
+    fields.
+    """
+    ctx = _log_context.get()
+    if ctx:
+        extra = record["extra"]
+        for key, value in ctx.items():
+            if value:
+                extra[key] = value
 
 
 def json_sink(message):
@@ -179,9 +251,41 @@ def configure_session_logger(session_id: str, client_sid: Optional[str] = None):
     if client_sid:
         extra_context["client_sid"] = client_sid
 
-    logger.configure(extra=extra_context)
+    logger.configure(extra=extra_context, patcher=_log_context_patcher)  # type: ignore[arg-type]
     # Also set up logging interception for session-based logging
     setup_logging_interception()
+
+
+def get_bound_logger(**context):
+    """
+    Return a Loguru bound logger enriched with the provided context fields.
+
+    All keyword arguments are added as structured extra fields on every log
+    entry emitted through the returned logger. Use this whenever you need
+    per-call / per-request log context without polluting the process-global
+    logger state.
+
+    Safe for concurrent async usage in the same process: logger.bind() returns
+    a new logger instance and does NOT mutate any global state.
+
+    Examples:
+        # In an Agent class after the lead is resolved:
+        self.logger = get_bound_logger(
+            lead_id=self.lead.id,
+            merchant_id=self.lead.merchant_id,
+            template=self.lead.template,
+            phone_number=(self.lead.payload or {}).get("customer_mobile_number"),
+            call_sid=self.call_sid,
+        )
+
+        # In a background task loop:
+        lead_logger = get_bound_logger(
+            lead_id=locked_lead.id,
+            merchant_id=locked_lead.merchant_id,
+            template=locked_lead.template,
+        )
+    """
+    return logger.bind(**context)
 
 
 def setup_logging_interception():
@@ -203,11 +307,19 @@ def setup_logging_interception():
     logging.getLogger("daily_core").disabled = True
 
 
-# Initial logger configuration
+# Initial logger configuration — register the patcher so log context flows
+# into every log record from the very first import.
 _setup_logger_sinks(include_session_id=False)
+logger.configure(patcher=_log_context_patcher)  # type: ignore[arg-type]
 
 # Set up logging interception for unified logging
 setup_logging_interception()
 
 # Export the configured logger for use throughout the application.
-__all__ = ["logger", "configure_session_logger"]
+__all__ = [
+    "logger",
+    "configure_session_logger",
+    "get_bound_logger",
+    "set_log_context",
+    "clear_log_context",
+]


### PR DESCRIPTION
## Summary

- Adds `get_bound_logger(**context)` to `app/core/logger` — a generic, concurrency-safe factory that wraps `logger.bind()`. Any agent or service can call it with any context fields; no agent-specific code in core.
- **Breeze Buddy Agent**: `self.logger` starts unbound at construction; once the lead is resolved (after transport setup), it is bound with `lead_id`, `merchant_id`, `template`, `phone_number`, `call_sid`. All ~25 log calls in instance methods now carry full call context automatically.
- **calls.py**: per-iteration `lead_logger` in the backlog processing and stuck-lead cleanup loops; per-call `call_logger` in `handle_call_completion`, `handle_unanswered_calls`, `update_call_recording` — bound after lead lookup.

**Concurrency safe**: `logger.bind()` returns a new instance without mutating global state, so concurrent calls never bleed context into each other (unlike `logger.configure(extra=...)`).

## Test plan

- [ ] Make a test call (telephony or Daily) and confirm logs show `lead_id`, `merchant_id`, `template`, `phone_number`, `call_sid` as structured JSON keys in production / as extra context in dev
- [ ] Verify two simultaneous calls produce logs with only their own context (no cross-call bleeding)
- [ ] Confirm `automatic` agent still logs `session_id`/`client_sid` correctly (untouched)
- [ ] Check backlog processing logs — each lead's logs should carry that lead's `lead_id`, `merchant_id`, `template`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new bound logger API for contextual logging across calls and requests.

* **Improvements**
  * Enhanced logging throughout the voice agent system with call and lead-specific context for improved traceability and debugging during operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->