### PR TITLE
feat: add KeywordFilterProcessor to suppress acknowledgement words during bot activity

### DIFF
--- a/app/ai/voice/agents/breeze_buddy/agent/pipeline.py
+++ b/app/ai/voice/agents/breeze_buddy/agent/pipeline.py
@@ -32,6 +32,7 @@ from pipecat.turns.user_turn_strategies import UserTurnStrategies
 
 from app.ai.voice.agents.breeze_buddy.observability.tracing_setup import setup_tracing
 from app.ai.voice.agents.breeze_buddy.processors import (
+    KeywordFilterProcessor,
     ResponseStateGate,
     UserIdleCallbackHandler,
     create_user_idle_processor,
@@ -207,6 +208,19 @@ async def build_pipeline(
 
     response_gate = ResponseStateGate() if await BB_ENABLE_RESPONSE_GATE() else None
 
+    # Create keyword filter processor from template configuration
+    keyword_filter_config = getattr(configurations, "keyword_filter", None)
+    keyword_filter = (
+        KeywordFilterProcessor(config=keyword_filter_config)
+        if keyword_filter_config is not None and keyword_filter_config.enabled
+        else None
+    )
+    if keyword_filter_config is not None and keyword_filter:
+        logger.info(
+            f"Keyword filter enabled: {len(keyword_filter_config.keywords)} keyword(s), "
+            f"match_type={keyword_filter_config.match_type.value}"
+        )
+
     # Create user idle processor from template configuration
     user_idle_config = getattr(configurations, "user_idle_configuration", None)
     user_idle_result = (
@@ -238,8 +252,16 @@ async def build_pipeline(
         context_aggregator.assistant(),
     ]
 
+    # Insert keyword_filter before response_gate (both sit between stt and user_aggregator).
+    # Order: stt → keyword_filter → response_gate → user_aggregator
+    # This ensures filtered frames never reach the gate's interruption logic.
+    insert_idx = 2  # Position after transport.input() and stt
+    if keyword_filter:
+        pipeline_parts.insert(insert_idx, keyword_filter)
+        insert_idx += 1
+
     if response_gate:
-        pipeline_parts.insert(2, response_gate)
+        pipeline_parts.insert(insert_idx, response_gate)
 
     # Insert user idle processor before user_aggregator (context_aggregator.user()) to monitor user activity
     if user_idle:

--- a/app/ai/voice/agents/breeze_buddy/examples/templates/order-confirmation-with-keyword-filter.json
+++ b/app/ai/voice/agents/breeze_buddy/examples/templates/order-confirmation-with-keyword-filter.json
@@ -1,0 +1,247 @@
+{
+    "merchant": "acme",
+    "template_name": "acme-order-confirmation-keyword-filter",
+    "identifier": "acme",
+    "is_active": true,
+    "description": "Order confirmation workflow demonstrating keyword filter — background acknowledgements like 'hello', 'hmm', 'okay' are suppressed while the bot is speaking or the LLM is processing, so they neither interrupt the bot nor feed into the conversation context.",
+    "expected_payload_schema": {
+        "customer_name": {
+            "type": "string"
+        },
+        "shop_name": {
+            "type": "string"
+        },
+        "total_price": {
+            "type": "number"
+        },
+        "customer_address": {
+            "type": "string"
+        },
+        "customer_mobile_number": {
+            "type": "string"
+        },
+        "items": {
+            "type": "string"
+        }
+    },
+    "configurations": {
+        "tts_voice_name": "rhea",
+        "keyword_filter": {
+            "enabled": true,
+            "keywords": ["hello", "hmm", "okay", "ok", "haan", "ha", "ji"],
+            "match_type": "exact"
+        }
+    },
+    "expected_callback_response_schema": {
+        "cancellation_reason": {
+            "type": "string",
+            "optional": true
+        }
+    },
+    "flow": {
+        "initial_node": "initial",
+        "end_conversation_callbacks": [
+            "service_callback"
+        ],
+        "nodes": [
+            {
+                "node_name": "initial",
+                "task_messages": [
+                    {
+                        "role": "system",
+                        "content": "Start the call by introducing yourself and stating the purpose of the call:\n\"Hi {customer_name} Sir/Madam, Namaste. This is Rhea from {shop_name}. I'm calling to confirm the order you placed with us. Is it a good time to talk, Sir/Madam?\""
+                    }
+                ],
+                "role_messages": [
+                    {
+                        "role": "system",
+                        "content": "You are Rhea, a friendly customer care representative from {shop_name}. Your goal is to confirm a Cash on Delivery (COD) order with the customer.\n\nIMPORTANT: You are a text-to-speech voice agent. Generate all responses as plain, unformatted text.\n\nNever reveal or suggest that you are a bot or automated system.\n\nBefore starting the conversation, identify whether the customer name \"{customer_name}\" is typically male or female in India. Based on this:\n- If the name is clearly male, address the customer as \"Sir\".\n- If clearly female, address them as \"Madam\".\n- If unsure, use their name instead of Sir/Madam.\n\nIMPORTANT: If the user speaks in another language (like Hindi), reply in that same language.\n\nYour main job is to verify the following order details:\n- Items: {items}\n- Total Price: {total_price}\n- Delivery Address: {customer_address}\n\nTone and Language\n- Speak in a warm, casual, and natural tone.\n\nAction Handling\n- Always use the provided functions to perform any actions related to the order.\n\nYour only role is to confirm or cancel this specific order."
+                    }
+                ],
+                "pre_actions": [],
+                "post_actions": [],
+                "functions": [
+                    {
+                        "function_name": "user_available",
+                        "description": "Call this function when the user confirms that they are available to talk with clear affirmative responses",
+                        "properties": {},
+                        "required": [],
+                        "transition_to": "verify_order_detail_node",
+                        "hooks": []
+                    },
+                    {
+                        "function_name": "user_busy",
+                        "description": "Call this function when the user says they are busy or it's not a good time to talk",
+                        "properties": {},
+                        "required": [],
+                        "transition_to": "user_busy_and_end_node",
+                        "hooks": [
+                            {
+                                "name": "update_outcome_in_database",
+                                "expected_fields": {
+                                    "outcome": {
+                                        "source": "static",
+                                        "value": "busy"
+                                    }
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "function_name": "cancel_order",
+                        "description": "Call this function if the customer explicitly asks to cancel the order. If the user gives a reason for cancellation, pass it.",
+                        "properties": {
+                            "cancellation_reason": {
+                                "type": "string",
+                                "description": "The reason for cancelling the order."
+                            }
+                        },
+                        "required": [
+                            "cancellation_reason"
+                        ],
+                        "transition_to": "order_cancellation_and_end_node",
+                        "hooks": [
+                            {
+                                "name": "update_outcome_in_database",
+                                "expected_fields": {
+                                    "outcome": {
+                                        "source": "static",
+                                        "value": "cancelled"
+                                    },
+                                    "cancellation_reason": {
+                                        "source": "llm"
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "node_name": "verify_order_detail_node",
+                "task_messages": [
+                    {
+                        "role": "system",
+                        "content": "Now verify the order details with the customer. The order contains {items}. The total price is {total_price} rupees. The delivery address is {customer_address}. Ask for confirmation of the order."
+                    }
+                ],
+                "pre_actions": [],
+                "post_actions": [],
+                "functions": [
+                    {
+                        "function_name": "confirm_order",
+                        "description": "Call this function if the customer agrees/confirms the order details (items, price, and address)",
+                        "properties": {},
+                        "required": [],
+                        "transition_to": "order_confirmation_and_end_node",
+                        "hooks": [
+                            {
+                                "name": "update_outcome_in_database",
+                                "expected_fields": {
+                                    "outcome": {
+                                        "source": "static",
+                                        "value": "confirmed"
+                                    }
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "function_name": "cancel_order",
+                        "description": "Call this function if the customer explicitly asks to cancel the order",
+                        "properties": {
+                            "cancellation_reason": {
+                                "type": "string",
+                                "description": "The reason for cancelling the order."
+                            }
+                        },
+                        "required": [
+                            "cancellation_reason"
+                        ],
+                        "transition_to": "order_cancellation_and_end_node",
+                        "hooks": [
+                            {
+                                "name": "update_outcome_in_database",
+                                "expected_fields": {
+                                    "outcome": {
+                                        "source": "static",
+                                        "value": "cancelled"
+                                    },
+                                    "cancellation_reason": {
+                                        "source": "llm"
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "node_name": "order_confirmation_and_end_node",
+                "task_messages": [
+                    {
+                        "role": "system",
+                        "content": "Thank you for confirming your order. Your order will be delivered soon. Have a good day."
+                    }
+                ],
+                "pre_actions": [
+                    {
+                        "type": "function",
+                        "handler": "mute_stt"
+                    }
+                ],
+                "post_actions": [
+                    {
+                        "type": "function",
+                        "handler": "end_conversation"
+                    }
+                ],
+                "functions": []
+            },
+            {
+                "node_name": "order_cancellation_and_end_node",
+                "task_messages": [
+                    {
+                        "role": "system",
+                        "content": "I understand you don't want to proceed with this order. I am cancelling your order. Thank you for your time."
+                    }
+                ],
+                "pre_actions": [
+                    {
+                        "type": "function",
+                        "handler": "mute_stt"
+                    }
+                ],
+                "post_actions": [
+                    {
+                        "type": "function",
+                        "handler": "end_conversation"
+                    }
+                ],
+                "functions": []
+            },
+            {
+                "node_name": "user_busy_and_end_node",
+                "task_messages": [
+                    {
+                        "role": "system",
+                        "content": "I understand. I will call you back later. Thank you for your time."
+                    }
+                ],
+                "pre_actions": [
+                    {
+                        "type": "function",
+                        "handler": "mute_stt"
+                    }
+                ],
+                "post_actions": [
+                    {
+                        "type": "function",
+                        "handler": "end_conversation"
+                    }
+                ],
+                "functions": []
+            }
+        ]
+    }
+}

--- a/app/ai/voice/agents/breeze_buddy/processors/__init__.py
+++ b/app/ai/voice/agents/breeze_buddy/processors/__init__.py
@@ -1,5 +1,8 @@
 """Breeze Buddy custom processors for pipeline control."""
 
+from app.ai.voice.agents.breeze_buddy.processors.keyword_filter import (
+    KeywordFilterProcessor,
+)
 from app.ai.voice.agents.breeze_buddy.processors.response_gate import (
     ResponseStateGate,
 )
@@ -8,4 +11,9 @@ from app.ai.voice.agents.breeze_buddy.processors.user_idle import (
     create_user_idle_processor,
 )
 
-__all__ = ["ResponseStateGate", "UserIdleCallbackHandler", "create_user_idle_processor"]
+__all__ = [
+    "KeywordFilterProcessor",
+    "ResponseStateGate",
+    "UserIdleCallbackHandler",
+    "create_user_idle_processor",
+]

--- a/app/ai/voice/agents/breeze_buddy/processors/keyword_filter.py
+++ b/app/ai/voice/agents/breeze_buddy/processors/keyword_filter.py
@@ -1,0 +1,131 @@
+"""
+Keyword Filter Processor
+
+Intercepts TranscriptionFrames while the bot is active (LLM processing or TTS
+speaking) and silently drops them when the transcribed text matches any of the
+configured keywords.
+
+This prevents two things:
+ 1. The filtered transcription from reaching the LLM context.
+ 2. The filtered transcription from triggering a user interruption.
+
+The processor must be placed BEFORE the ResponseStateGate in the pipeline so that
+matching frames are consumed before the gate's interruption logic sees them.
+
+Pipeline position:
+    transport.input()
+    → stt
+    → KeywordFilterProcessor   ← here
+    → ResponseStateGate
+    → user_aggregator (VAD / turn strategies)
+    → llm
+    ...
+"""
+
+import unicodedata
+
+from pipecat.frames.frames import (
+    BotStartedSpeakingFrame,
+    BotStoppedSpeakingFrame,
+    Frame,
+    LLMFullResponseEndFrame,
+    LLMFullResponseStartFrame,
+    TranscriptionFrame,
+)
+from pipecat.processors.frame_processor import FrameDirection, FrameProcessor
+
+from app.ai.voice.agents.breeze_buddy.template.types import (
+    KeywordFilterConfig,
+    KeywordMatchType,
+)
+from app.core.logger import logger
+
+
+class KeywordFilterProcessor(FrameProcessor):
+    """Drop transcription frames whose text matches configured keywords while
+    the bot is actively processing or speaking.
+
+    When the bot is IDLE (neither LLM processing nor TTS speaking) every
+    transcription passes through normally — the filter only engages during
+    bot activity to suppress accidental speech like a background "hello" or
+    acknowledgement words that would otherwise cancel the bot's response.
+    """
+
+    def __init__(self, config: KeywordFilterConfig, **kwargs):
+        super().__init__(**kwargs)
+        self._enabled = config.enabled
+        self._match_type = config.match_type
+        # Normalise keywords once at construction time for fast matching.
+        # Uses the same _normalise pipeline as incoming transcriptions so both
+        # sides are always comparable.
+        self._keywords: list[str] = [
+            norm for kw in config.keywords if (norm := self._normalise(kw))
+        ]
+
+        # Track LLM and TTS activity separately — mirrors ResponseStateGate's
+        # full state machine so we stay active during BOTH → LLM_PROCESSING
+        # transitions (i.e. TTS stops but LLM is still running).
+        self._llm_active: bool = False
+        self._tts_active: bool = False
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _is_bot_active(self) -> bool:
+        return self._llm_active or self._tts_active
+
+    @staticmethod
+    def _normalise(text: str) -> str:
+        """Strip surrounding whitespace and remove punctuation/symbols, preserving
+        Unicode letters, digits, and combining marks so multilingual keywords
+        (Indic, Arabic, etc.) round-trip correctly without vowel-sign collisions."""
+        cleaned = "".join(
+            c
+            for c in text.strip().lower()
+            if unicodedata.category(c)[0] not in ("P", "S")
+        )
+        return cleaned.strip()
+
+    def _matches(self, text: str) -> bool:
+        """Return True if *text* matches any configured keyword."""
+        normalised = self._normalise(text)
+        if self._match_type == KeywordMatchType.EXACT:
+            return normalised in self._keywords
+        # INCLUDES
+        return any(kw in normalised for kw in self._keywords)
+
+    # ------------------------------------------------------------------
+    # FrameProcessor implementation
+    # ------------------------------------------------------------------
+
+    async def process_frame(self, frame: Frame, direction: FrameDirection):
+        await super().process_frame(frame, direction)
+
+        # ---- Track bot activity state --------------------------------
+        # Track LLM and TTS independently so that the BOTH → LLM_PROCESSING
+        # transition (TTS stops but LLM still running) keeps the filter active.
+        if isinstance(frame, LLMFullResponseStartFrame):
+            self._llm_active = True
+
+        elif isinstance(frame, LLMFullResponseEndFrame):
+            self._llm_active = False
+
+        elif isinstance(frame, BotStartedSpeakingFrame):
+            self._tts_active = True
+
+        elif isinstance(frame, BotStoppedSpeakingFrame):
+            self._tts_active = False
+
+        # ---- Keyword filtering ---------------------------------------
+        elif isinstance(frame, TranscriptionFrame):
+            if self._enabled and self._is_bot_active() and self._keywords:
+                if self._matches(frame.text):
+                    logger.info(
+                        f"KeywordFilter: dropping transcription '{frame.text}' "
+                        f"(match_type={self._match_type.value}, bot_active=True)"
+                    )
+                    return  # Silently drop — do NOT call push_frame
+
+        # Pass everything else (and non-matching transcriptions) downstream
+        await self.push_frame(frame, direction)

--- a/app/ai/voice/agents/breeze_buddy/template/types.py
+++ b/app/ai/voice/agents/breeze_buddy/template/types.py
@@ -147,6 +147,39 @@ class BackgroundSoundFile(str, Enum):
     OFFICE_AMBIENCE = "office-ambience"
 
 
+class KeywordMatchType(str, Enum):
+    """Match strategy for keyword filtering."""
+
+    EXACT = "exact"  # Transcription must equal the keyword (case-insensitive, trimmed)
+    INCLUDES = "includes"  # Transcription must contain the keyword (case-insensitive)
+
+
+class KeywordFilterConfig(BaseModel):
+    """Configuration for filtering out specific transcriptions during bot activity.
+
+    When the bot is actively speaking (TTS) or the LLM is processing a response,
+    user speech matching these keywords is silently dropped — it is neither forwarded
+    to the LLM nor treated as an interruption.
+
+    Example:
+        {
+            "enabled": true,
+            "keywords": ["hello", "yes", "okay"],
+            "match_type": "exact"
+        }
+    """
+
+    enabled: bool = False
+    keywords: List[str] = Field(
+        default_factory=list,
+        description="Keywords to filter out while bot is active.",
+    )
+    match_type: KeywordMatchType = Field(
+        KeywordMatchType.EXACT,
+        description="Whether the transcription must exactly equal or just contain a keyword.",
+    )
+
+
 class UserIdleHandlingConfig(BaseModel):
     """Configuration for user idle detection and handling."""
 
@@ -209,6 +242,10 @@ class ConfigurationModel(BaseModel):
     )
     noise_filter: Optional[NoiseFilterConfig] = Field(
         None, description="Noise filter configuration for audio input processing"
+    )
+    keyword_filter: Optional[KeywordFilterConfig] = Field(
+        None,
+        description="Keyword filter to suppress specific transcriptions while bot is active",
     )
 
 

--- a/docs/KEYWORD_FILTER.md
+++ b/docs/KEYWORD_FILTER.md
@@ -1,0 +1,174 @@
+# Keyword Filter in Templates
+
+## Overview
+
+Templates can now configure a keyword filter that silently suppresses specific user transcriptions
+**while the bot is actively speaking or the LLM is processing a response**.
+
+This solves a common problem in telephony calls: a customer saying a background word like *"hello"*,
+*"hmm"*, or *"haan"* while the bot is mid-sentence causes an unnecessary interruption — the bot
+stops, the LLM re-processes, and the conversation feels broken. The keyword filter drops those
+frames before they ever reach the interruption logic or the LLM context.
+
+When the bot is **idle** (not speaking, not processing), transcriptions always pass through normally
+— the filter only engages during bot activity.
+
+---
+
+## Configuration Structure
+
+Add `keyword_filter` to the template's `configurations` object:
+
+```json
+{
+  "configurations": {
+    "keyword_filter": {
+      "enabled": true,
+      "keywords": ["hello", "hmm", "okay", "ok", "haan", "ha", "ji"],
+      "match_type": "exact"
+    }
+  }
+}
+```
+
+---
+
+## Parameters
+
+### `enabled`
+- **Type:** `boolean`
+- **Default:** `false`
+- **Description:** Master switch. Set to `true` to activate the filter.
+
+### `keywords`
+- **Type:** `string[]`
+- **Default:** `[]`
+- **Description:** List of words or phrases to suppress. Matching is always case-insensitive and
+  leading/trailing whitespace is ignored. An empty list disables filtering even when `enabled` is `true`.
+
+### `match_type`
+- **Type:** `"exact"` | `"includes"`
+- **Default:** `"exact"`
+- **Description:** Controls how the transcription is compared against each keyword.
+
+  | Value | Behaviour | Example — keyword `"okay"` |
+  |-------|-----------|---------------------------|
+  | `exact` | The entire transcription must equal the keyword | `"okay"` → filtered · `"okay sure"` → **not** filtered |
+  | `includes` | The transcription only needs to *contain* the keyword | `"okay"` → filtered · `"okay sure"` → filtered |
+
+  Use `exact` (the default) to avoid accidentally dropping meaningful speech. Use `includes` when
+  you want to catch phrases that embed the keyword, e.g. `"oh okay sure"`.
+
+---
+
+## How It Works
+
+The `KeywordFilterProcessor` sits in the pipeline **before** the `ResponseStateGate`:
+
+```
+transport.input()
+  → stt
+  → KeywordFilterProcessor    ← filters here
+  → ResponseStateGate         ← interruption logic never sees filtered frames
+  → user_aggregator (VAD / turn strategies)
+  → llm
+  → tts
+  → transport.output()
+```
+
+The processor independently tracks bot state by listening to the same Pipecat frames that the
+`ResponseStateGate` uses:
+
+| Frame | Effect on filter |
+|-------|-----------------|
+| `LLMFullResponseStartFrame` | Bot becomes active — filter engages |
+| `BotStartedSpeakingFrame` | Bot becomes active — filter engages |
+| `BotStoppedSpeakingFrame` | Bot becomes idle — filter disengages |
+
+A matching `TranscriptionFrame` is silently dropped (`return` without `push_frame`). No interruption
+is triggered, and the text never reaches the LLM context.
+
+---
+
+## Example Use Cases
+
+### Use Case 1: Suppress common Hindi/English acknowledgements (exact match)
+
+```json
+{
+  "configurations": {
+    "keyword_filter": {
+      "enabled": true,
+      "keywords": ["hello", "hmm", "okay", "ok", "haan", "ha", "ji", "uh", "yeah"],
+      "match_type": "exact"
+    }
+  }
+}
+```
+
+A customer murmuring *"haan"* or *"hmm"* while the bot reads out order details will not interrupt
+the bot.
+
+### Use Case 2: Suppress phrases containing a word (includes match)
+
+```json
+{
+  "configurations": {
+    "keyword_filter": {
+      "enabled": true,
+      "keywords": ["hello"],
+      "match_type": "includes"
+    }
+  }
+}
+```
+
+Any transcription containing the word *"hello"* — such as *"oh hello"* or *"hello hello"* — is
+dropped while the bot is active.
+
+### Use Case 3: Combined with VAD config
+
+Keyword filter and VAD config are independent and can be used together:
+
+```json
+{
+  "configurations": {
+    "tts_voice_name": "rhea",
+    "vad_config": {
+      "confidence": 0.5,
+      "stop_secs": 0.3
+    },
+    "keyword_filter": {
+      "enabled": true,
+      "keywords": ["hello", "hmm", "okay", "haan"],
+      "match_type": "exact"
+    }
+  }
+}
+```
+
+---
+
+## Full Template Example
+
+See [`examples/templates/order-confirmation-with-keyword-filter.json`](../app/ai/voice/agents/breeze_buddy/examples/templates/order-confirmation-with-keyword-filter.json)
+for a complete working template that uses the keyword filter.
+
+---
+
+## Implementation Details
+
+### Files
+
+| File | Change |
+|------|--------|
+| `app/ai/voice/agents/breeze_buddy/template/types.py` | Added `KeywordMatchType` enum, `KeywordFilterConfig` model, and `keyword_filter` field on `ConfigurationModel` |
+| `app/ai/voice/agents/breeze_buddy/processors/keyword_filter.py` | New `KeywordFilterProcessor` (Pipecat `FrameProcessor`) |
+| `app/ai/voice/agents/breeze_buddy/processors/__init__.py` | Exports `KeywordFilterProcessor` |
+| `app/ai/voice/agents/breeze_buddy/agent/pipeline.py` | Instantiates and inserts the processor into the pipeline |
+
+### Backward Compatibility
+
+- Field is optional on `ConfigurationModel` — existing templates are unaffected.
+- When `keyword_filter` is absent or `enabled: false`, no processor is inserted and the pipeline
+  behaves exactly as before.


### PR DESCRIPTION
## Summary

- Adds `KeywordFilterProcessor`, a new Pipecat `FrameProcessor` that silently drops `TranscriptionFrame`s matching configured keywords while the LLM is processing or TTS is speaking
- Adds `KeywordFilterConfig` and `KeywordMatchType` to `ConfigurationModel` — fully optional, zero impact on existing templates
- Wires the processor into the pipeline at position `stt → KeywordFilter → ResponseStateGate` so filtered frames never reach the interruption logic

## Problem Solved

Short background utterances ("hello", "hmm", "haan") from the customer while the bot is mid-response cause unnecessary interruptions — the bot stops, the LLM reprocesses, and the conversation feels broken. This filter suppresses those frames before they reach `ResponseStateGate`.

## Key Technical Decisions

**Dual activity flags (not a single bool)**
The filter tracks `_llm_active` and `_tts_active` independently, mirroring `ResponseStateGate`'s full state machine. This correctly handles the `BOTH → LLM_PROCESSING` transition: when TTS stops but LLM is still running, the filter stays engaged. A single `_bot_active` flag would have incorrectly disengaged here.

**Unicode-aware normalisation**
`re.sub(r"[^\w\s]", "", text.strip().lower(), flags=re.UNICODE)` removes punctuation/symbols while preserving Unicode letters and digits from any script (Hindi, Telugu, Arabic, etc.). Applied symmetrically at construction time for keywords and at match time for transcriptions.

**Exact vs includes match**
- `exact`: entire transcription must equal the keyword — safe default, avoids dropping meaningful speech
- `includes`: transcription only needs to contain the keyword — useful for catching embedded words like "oh okay sure"

## Test Plan

- [ ] Deploy to beta with a template using `"keyword_filter": {"enabled": true, "keywords": ["hello", "hmm", "haan", "okay"], "match_type": "exact"}`
- [ ] Verify that saying a filtered word while bot is speaking produces a `KeywordFilter: dropping transcription` log and no interruption
- [ ] Verify that saying the same word while bot is idle passes through normally and is processed by the LLM
- [ ] Verify existing templates without `keyword_filter` in config are unaffected
- [ ] Verify multilingual keywords (e.g. Hindi: `हेलो`, `हाँ`) are matched correctly

## Files Changed

| File | Change |
|------|--------|
| `app/ai/voice/agents/breeze_buddy/processors/keyword_filter.py` | New `KeywordFilterProcessor` |
| `app/ai/voice/agents/breeze_buddy/processors/__init__.py` | Export `KeywordFilterProcessor` |
| `app/ai/voice/agents/breeze_buddy/template/types.py` | `KeywordMatchType`, `KeywordFilterConfig`, field on `ConfigurationModel` |
| `app/ai/voice/agents/breeze_buddy/agent/pipeline.py` | Instantiate and wire into pipeline |
| `app/ai/voice/agents/breeze_buddy/examples/templates/order-confirmation-with-keyword-filter.json` | Example template |
| `docs/KEYWORD_FILTER.md` | Feature documentation |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Keyword Filter feature for voice templates with configurable keywords and two match types (exact or includes)
  * Keywords normalized with case-insensitive matching and automatic whitespace handling
  * New template example and comprehensive documentation provided

<!-- end of auto-generated comment: release notes by coderabbit.ai -->