### PR TITLE
feat: gate VAD behind BREEZE_BUDDY_ENABLE_VAD flag (default off)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,6 @@ logs/
 Thumbs.db
 
 logs
+
+# Claude
+.claude

--- a/app/ai/voice/agents/breeze_buddy/agent/pipeline.py
+++ b/app/ai/voice/agents/breeze_buddy/agent/pipeline.py
@@ -24,6 +24,7 @@ from pipecat.processors.aggregators.llm_response_universal import (
 from pipecat.services.azure.llm import AzureLLMService
 from pipecat.services.openai.base_llm import BaseOpenAILLMService
 from pipecat.turns.user_start import (
+    BaseUserTurnStartStrategy,
     TranscriptionUserTurnStartStrategy,
     VADUserTurnStartStrategy,
 )
@@ -182,17 +183,20 @@ async def build_pipeline(
 
     # User turn strategies:
     # 1. VADUserTurnStartStrategy: Primary detector, fires on VAD speech detection (~100ms).
+    #    Only included when vad_analyzer is provided (BREEZE_BUDDY_ENABLE_VAD=true).
     #    First-one-wins semantics — if VAD fires first, transcription fallback is skipped.
-    # 2. TranscriptionUserTurnStartStrategy: Fallback for soft speech that VAD misses.
-    #    With use_interim=True, triggers on any interim transcription from Soniox,
-    #    catching cases where VAD fails at 8kHz but STT still picks up speech.
+    # 2. TranscriptionUserTurnStartStrategy: Used as sole start strategy when VAD is disabled,
+    #    or as fallback for soft speech that VAD misses when VAD is enabled.
+    #    With use_interim=True, triggers on any interim transcription from Soniox.
     # 3. SpeechTimeoutUserTurnStopStrategy(0.0): Triggers immediately when Soniox
     #    sends a finalized transcript with <end> token (native semantic endpoint detection).
+    start_strategies: list[BaseUserTurnStartStrategy] = []
+    if vad_analyzer is not None:
+        start_strategies.append(VADUserTurnStartStrategy())
+    start_strategies.append(TranscriptionUserTurnStartStrategy(use_interim=True))
+
     user_turn_strategies = UserTurnStrategies(
-        start=[
-            VADUserTurnStartStrategy(),
-            TranscriptionUserTurnStartStrategy(use_interim=True),
-        ],
+        start=start_strategies,
         stop=[
             SpeechTimeoutUserTurnStopStrategy(user_speech_timeout=0.0),
         ],

--- a/app/ai/voice/agents/breeze_buddy/agent/vad.py
+++ b/app/ai/voice/agents/breeze_buddy/agent/vad.py
@@ -12,7 +12,9 @@ from app.core.config.dynamic import (
     BB_DAILY_VAD_MIN_VOLUME,
     BB_DAILY_VAD_START_SECS,
     BB_DAILY_VAD_STOP_SECS,
+    BREEZE_BUDDY_ENABLE_VAD,
 )
+from app.core.logger import logger
 
 # Constants
 TELEPHONY_SAMPLE_RATE = 8000
@@ -32,16 +34,23 @@ async def create_daily_vad_params() -> VADParams:
 async def create_vad_analyzer(
     is_daily_mode: bool,
     template: Optional[TemplateModel] = None,
-) -> tuple[SileroVADAnalyzer, Optional[VADParams]]:
+) -> tuple[Optional[SileroVADAnalyzer], Optional[VADParams]]:
     """Create VAD analyzer with appropriate parameters.
+
+    VAD is gated behind BREEZE_BUDDY_ENABLE_VAD (default False).
+    When disabled, returns (None, None) and all VAD-related functionality is skipped.
 
     Args:
         is_daily_mode: Whether this is Daily mode
         template: Template model for telephony mode VAD params
 
     Returns:
-        Tuple of (SileroVADAnalyzer, default_vad_params for telephony or None for Daily)
+        Tuple of (SileroVADAnalyzer or None, default_vad_params for telephony or None)
     """
+    if not await BREEZE_BUDDY_ENABLE_VAD():
+        logger.info("VAD disabled (BREEZE_BUDDY_ENABLE_VAD=false)")
+        return None, None
+
     if is_daily_mode:
         params = await create_daily_vad_params()
         return SileroVADAnalyzer(sample_rate=DAILY_SAMPLE_RATE, params=params), None

--- a/app/core/config/dynamic.py
+++ b/app/core/config/dynamic.py
@@ -301,3 +301,13 @@ async def BB_ELEVENLABS_VOICE_SPEED() -> float:
 async def BB_ELEVENLABS_AGGREGATE_SENTENCES() -> bool:
     """Returns BB_ELEVENLABS_AGGREGATE_SENTENCES from Redis (True = wait for full sentence, False = stream tokens immediately)"""
     return await get_config("BB_ELEVENLABS_AGGREGATE_SENTENCES", True, bool)
+
+
+async def BREEZE_BUDDY_ENABLE_VAD() -> bool:
+    """Returns BREEZE_BUDDY_ENABLE_VAD from Redis.
+
+    When False (default), VAD (SileroVADAnalyzer) is disabled for Breeze Buddy agent.
+    All VAD-related functionality is gated behind this flag.
+    When True, VAD is enabled and used for voice activity detection and turn management.
+    """
+    return await get_config("BREEZE_BUDDY_ENABLE_VAD", False, bool)


### PR DESCRIPTION
## Summary

- Adds `BREEZE_BUDDY_ENABLE_VAD` dynamic config key (Redis, default `False`) to gate all Silero VAD functionality in the Breeze Buddy agent
- When disabled, `create_vad_analyzer` returns `(None, None)`, `VADController` is never created, and `VADUserTurnStartStrategy` is not added to the pipeline
- When disabled, `TranscriptionUserTurnStartStrategy(use_interim=True)` serves as the sole turn-start detector (fires on Soniox interim transcripts), maintaining full idle detection, turn management, and mute/unmute correctness
- Set `BREEZE_BUDDY_ENABLE_VAD=true` in Redis to restore previous VAD-enabled behavior exactly

## Behavioral changes when flag is off

| Feature | VAD on | VAD off |
|---|---|---|
| Turn start detection | Silero (~100ms local) | Soniox interim (~200–500ms network) |
| CPU per call | ~3% of one core + 1 thread | None |
| Idle detection | ✅ via `UserStartedSpeakingFrame` | ✅ same frame, transcription path |
| `mute_stt` / `unmute_stt` | mutes VAD | silent no-op (safe) |
| `_user_speaking` tracking | via `VADUserStartedSpeakingFrame` | via `UserStartedSpeakingFrame` |

## Test plan

- [ ] Deploy with `BREEZE_BUDDY_ENABLE_VAD` unset (defaults to `false`) — verify calls work with transcription-only turn detection
- [ ] Set `BREEZE_BUDDY_ENABLE_VAD=true` in Redis — verify VAD-based turn detection is restored
- [ ] Verify user idle timeout still triggers after `max_retries` in both modes
- [ ] Verify `mute_stt` during bot speech does not crash when VAD is off

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Voice Activity Detection (VAD) is now disabled by default and can be configured to enable on demand.
  * Added configuration option to control VAD functionality in voice processing.

* **Improvements**
  * Voice agent now dynamically selects transcription strategies based on VAD configuration state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->