### PR TITLE
feat: add optional duration param to mute_stt

### DIFF
--- a/app/ai/voice/agents/breeze_buddy/handlers/internal/stt.py
+++ b/app/ai/voice/agents/breeze_buddy/handlers/internal/stt.py
@@ -8,16 +8,41 @@ async def mute_stt(context: TemplateContext, args, transition_to=None):
     Mute STT input.
 
     Routes to the appropriate mute mechanism:
-    - VAD enabled: delegates to mute_vad (sets confidence=1.0)
+    - VAD enabled: delegates to mute_vad (duration arg is ignored)
     - VAD disabled: engages TranscriptionGateProcessor hard mute
+
+    Accepts an optional ``duration`` (seconds) in *args*. When provided and
+    the TranscriptionGate path is active, the mute is automatically released
+    after that many seconds. Without it the mute is indefinite until an
+    explicit ``unmute_stt`` call. The duration arg is ignored on the VAD path.
+
+    Example JSON action with duration::
+
+        {
+            "type": "function",
+            "handler": "mute_stt",
+            "args": {"duration": 5}
+        }
     """
-    logger.debug(f"mute_stt called for call {context.call_sid}")
+    duration = args.get("duration") if args else None
+    logger.debug(
+        f"mute_stt called for call {context.call_sid} " f"(duration={duration})"
+    )
+
     if context.vad_analyzer:
+        if duration is not None:
+            logger.debug(
+                f"duration arg ignored for VAD path on call {context.call_sid}"
+            )
         mute_vad(context)
     elif context.speech_gate:
-        context.speech_gate.mute()
+        if duration is not None:
+            context.speech_gate.mute_for(float(duration))
+        else:
+            context.speech_gate.mute()
         logger.info(
-            f"STT muted via TranscriptionGate for call {context.call_sid} (VAD disabled)"
+            f"STT muted via TranscriptionGate for call {context.call_sid} "
+            f"(VAD disabled, duration={duration})"
         )
     else:
         logger.warning(
@@ -32,6 +57,9 @@ async def unmute_stt(context: TemplateContext, args, transition_to=None):
     Routes to the appropriate unmute mechanism:
     - VAD enabled: delegates to unmute_vad (restores stored/default params)
     - VAD disabled: releases TranscriptionGateProcessor hard mute
+
+    Also cancels any pending timed-unmute task so that an explicit unmute
+    takes precedence over a previously scheduled auto-unmute.
     """
     logger.debug(f"unmute_stt called for call {context.call_sid}")
     if context.vad_analyzer:

--- a/app/ai/voice/agents/breeze_buddy/processors/transcription_gate.py
+++ b/app/ai/voice/agents/breeze_buddy/processors/transcription_gate.py
@@ -31,6 +31,7 @@ This processor is always inserted in the pipeline. When neither mode is active
 it is a transparent passthrough with negligible overhead.
 """
 
+import asyncio
 import unicodedata
 from typing import Optional
 
@@ -67,6 +68,7 @@ class TranscriptionGateProcessor(FrameProcessor):
 
         # --- Hard mute state ---
         self._muted: bool = False
+        self._timed_unmute_task: Optional[asyncio.Task] = None
 
         # --- Keyword filter state ---
         if keyword_filter_config and keyword_filter_config.enabled:
@@ -94,13 +96,44 @@ class TranscriptionGateProcessor(FrameProcessor):
 
     def mute(self) -> None:
         """Drop ALL TranscriptionFrames until unmute() is called."""
+        self._cancel_timed_unmute()
         self._muted = True
         logger.info("TranscriptionGate: hard mute engaged")
 
     def unmute(self) -> None:
         """Resume normal passthrough (keyword filter still applies if configured)."""
+        self._cancel_timed_unmute()
         self._muted = False
         logger.info("TranscriptionGate: hard mute released")
+
+    def mute_for(self, duration: float) -> None:
+        """Drop ALL TranscriptionFrames for *duration* seconds, then auto-unmute.
+
+        Any previous timed-unmute task is cancelled before scheduling a new one.
+        An explicit call to unmute() (or another mute/mute_for) also cancels the
+        pending timer.
+        """
+        self._cancel_timed_unmute()
+        self._muted = True
+        self._timed_unmute_task = asyncio.create_task(self._auto_unmute(duration))
+        logger.info(f"TranscriptionGate: hard mute engaged for {duration}s")
+
+    def _cancel_timed_unmute(self) -> None:
+        """Cancel any pending timed-unmute task."""
+        if self._timed_unmute_task and not self._timed_unmute_task.done():
+            self._timed_unmute_task.cancel()
+            logger.debug("TranscriptionGate: cancelled pending timed unmute")
+        self._timed_unmute_task = None
+
+    async def _auto_unmute(self, duration: float) -> None:
+        """Sleep for *duration* seconds then release the hard mute."""
+        try:
+            await asyncio.sleep(duration)
+            self._muted = False
+            self._timed_unmute_task = None
+            logger.info(f"TranscriptionGate: hard mute auto-released after {duration}s")
+        except asyncio.CancelledError:
+            pass
 
     @property
     def is_muted(self) -> bool:


### PR DESCRIPTION
## Summary
- Adds an optional `duration` (seconds) parameter to `mute_stt` handler via action `args`
- When `duration` is provided on the TranscriptionGate path, STT auto-unmutes after the specified time
- Without `duration`, behavior is unchanged (indefinite mute until explicit `unmute_stt`)
- On the VAD path, `duration` is silently ignored (logged at debug level)
- Adds `mute_for()`, `_cancel_timed_unmute()`, and `_auto_unmute()` to `TranscriptionGateProcessor`
- Explicit `mute()`, `unmute()`, or subsequent `mute_for()` calls cancel any pending timed unmute

### Usage
```json
{ "type": "function", "handler": "mute_stt", "args": { "duration": 5 } }
```

## Test plan
- [ ] Verify `mute_stt` without args still mutes indefinitely (TranscriptionGate path)
- [ ] Verify `mute_stt` with `{"duration": 5}` auto-unmutes after 5 seconds
- [ ] Verify explicit `unmute_stt` cancels a pending timed unmute
- [ ] Verify rapid successive `mute_for` calls cancel the previous timer
- [ ] Verify VAD path ignores duration and mutes normally
- [ ] Verify all CI checks pass (black, isort, autoflake, pyrefly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)