### PR TITLE
Make interruption behavior configurable per-template

### DIFF
--- a/app/ai/voice/agents/breeze_buddy/agent/pipeline.py
+++ b/app/ai/voice/agents/breeze_buddy/agent/pipeline.py
@@ -39,10 +39,12 @@ from app.ai.voice.agents.breeze_buddy.processors import (
     create_user_idle_processor,
 )
 from app.ai.voice.agents.breeze_buddy.stt import get_stt_service
-from app.ai.voice.agents.breeze_buddy.template.types import ConfigurationModel
+from app.ai.voice.agents.breeze_buddy.template.types import (
+    ConfigurationModel,
+    InterruptionMode,
+)
 from app.ai.voice.agents.breeze_buddy.tts import get_tts_service
 from app.core.config.dynamic import (
-    BB_ENABLE_RESPONSE_GATE,
     BREEZE_BUDDY_AZURE_MAX_COMPLETION_TOKENS,
     BREEZE_BUDDY_AZURE_TEMPERATURE,
 )
@@ -225,7 +227,11 @@ async def build_pipeline(
         ),
     )
 
-    response_gate = ResponseStateGate() if await BB_ENABLE_RESPONSE_GATE() else None
+    interruption_config = getattr(configurations, "interruption_config", None)
+    interruption_mode = (
+        interruption_config.mode if interruption_config else InterruptionMode.ENABLED
+    )
+    response_gate = ResponseStateGate(interruption_mode=interruption_mode)
 
     # TranscriptionGateProcessor is always in the pipeline.
     # It is a transparent passthrough when neither mute nor keyword filter is active.
@@ -276,8 +282,7 @@ async def build_pipeline(
     ]
 
     insert_idx = 3  # Position after transport.input(), stt, transcription_gate
-    if response_gate:
-        pipeline_parts.insert(insert_idx, response_gate)
+    pipeline_parts.insert(insert_idx, response_gate)
 
     # Insert user idle processor before user_aggregator to monitor user activity
     if user_idle:

--- a/app/ai/voice/agents/breeze_buddy/processors/response_gate.py
+++ b/app/ai/voice/agents/breeze_buddy/processors/response_gate.py
@@ -1,19 +1,18 @@
 """
 Response State Gate Processor - V2
 
-Handles ALL interruption scenarios to prevent double-speaking:
+Handles interruption scenarios based on the configured InterruptionMode:
 
-1. STT arrives → LLM processing → New STT arrives
-   → Cancel LLM, buffer new STT, process new STT
+Mode: ENABLED (default)
+  User speaks while bot is active → interrupt bot, buffer & process user speech.
 
-2. LLM + TTS both processing → New STT arrives
-   → Cancel both, buffer new STT, process new STT
+Mode: DISABLED_WITH_STORE
+  User speaks while bot is active → do NOT interrupt, buffer user speech,
+  flush it downstream once the bot finishes speaking.
 
-3. TTS is speaking → New STT arrives
-   → Stop TTS, buffer new STT, process new STT
-
-4. LLM processing (no TTS yet) → New STT arrives
-   → Cancel LLM, buffer new STT, process new STT
+Mode: DISABLED_WITHOUT_STORE
+  User speaks while bot is active → do NOT interrupt, silently discard
+  user speech.
 """
 
 from enum import Enum, auto
@@ -28,6 +27,7 @@ from pipecat.frames.frames import (
 )
 from pipecat.processors.frame_processor import FrameDirection, FrameProcessor
 
+from app.ai.voice.agents.breeze_buddy.template.types import InterruptionMode
 from app.core.logger import logger
 
 
@@ -42,17 +42,25 @@ class ResponseState(Enum):
 
 class ResponseStateGate(FrameProcessor):
     """
-    State machine that tracks LLM/TTS state and handles ALL interruptions.
+    State machine that tracks LLM/TTS state and handles interruptions
+    according to the configured InterruptionMode.
 
-    Key insight: When interrupting, we must BUFFER the new transcription
-    until the interruption completes, then process ONLY the buffered frame.
+    - ENABLED: interrupt bot, buffer new transcription, process after interruption.
+    - DISABLED_WITH_STORE: don't interrupt, buffer transcription, flush when bot goes IDLE.
+    - DISABLED_WITHOUT_STORE: don't interrupt, drop transcription silently.
     """
 
-    def __init__(self, **kwargs):
+    def __init__(
+        self,
+        interruption_mode: InterruptionMode = InterruptionMode.ENABLED,
+        **kwargs,
+    ):
         super().__init__(**kwargs)
         self._state = ResponseState.IDLE
         self._buffered_transcription = None  # Hold transcription during interruption
         self._interruption_in_progress = False
+        self._interruption_mode = interruption_mode
+        logger.info(f"ResponseGate: initialized with mode={interruption_mode.value}")
 
     @property
     def state(self) -> ResponseState:
@@ -105,6 +113,21 @@ class ResponseStateGate(FrameProcessor):
             if self._state == ResponseState.BOTH:
                 self._state = ResponseState.TTS_SPEAKING
                 logger.debug("ResponseGate: TTS_SPEAKING (LLM finished)")
+            elif self._state == ResponseState.LLM_PROCESSING:
+                # LLM finished without TTS (e.g. empty response) → back to IDLE
+                self._state = ResponseState.IDLE
+                logger.debug("ResponseGate: IDLE (LLM finished, no TTS)")
+
+                if (
+                    self._interruption_mode == InterruptionMode.DISABLED_WITH_STORE
+                    and self._buffered_transcription
+                ):
+                    logger.info(
+                        "ResponseGate: LLM finished without TTS, flushing stored transcription"
+                    )
+                    await self.push_frame(frame, direction)
+                    await self._flush_buffered_transcription(FrameDirection.DOWNSTREAM)
+                    return
 
         # Track TTS/Output state
         elif isinstance(frame, BotStartedSpeakingFrame):
@@ -123,31 +146,58 @@ class ResponseStateGate(FrameProcessor):
                 self._state = ResponseState.LLM_PROCESSING
                 logger.debug("ResponseGate: LLM_PROCESSING (TTS stopped)")
 
+            # DISABLED_WITH_STORE: flush buffered transcription when bot goes idle
+            if (
+                self._state == ResponseState.IDLE
+                and self._interruption_mode == InterruptionMode.DISABLED_WITH_STORE
+                and self._buffered_transcription
+            ):
+                logger.info(
+                    "ResponseGate: Bot finished speaking, flushing stored transcription"
+                )
+                # Forward the BotStoppedSpeakingFrame first so downstream
+                # processors see the bot-stopped event before the new
+                # transcription arrives.
+                await self.push_frame(frame, direction)
+                await self._flush_buffered_transcription(FrameDirection.DOWNSTREAM)
+                return
+
         # Handle new transcription - THE KEY INTERRUPTION LOGIC
         elif isinstance(frame, TranscriptionFrame):
             if self._state != ResponseState.IDLE:
-                # We have an active response, need to interrupt
-                logger.debug(
-                    f"ResponseGate: Interrupting state={self._state.name} "
-                    f"for new transcription (id={id(frame)})"
-                )
-                # Push interruption to cancel current LLM/TTS
-                self._interruption_in_progress = True
-                # Buffer this frame BEFORE starting interruption
-                # Any later frames will overwrite this buffer during the await
-                self._buffered_transcription = frame
-                await self.push_interruption_task_frame_and_wait()
+                # Bot is active — behaviour depends on mode
+                if self._interruption_mode == InterruptionMode.ENABLED:
+                    # Interrupt bot: cancel LLM/TTS and process user speech
+                    logger.debug(
+                        f"ResponseGate: Interrupting state={self._state.name} "
+                        f"for new transcription (id={id(frame)})"
+                    )
+                    self._interruption_in_progress = True
+                    self._buffered_transcription = frame
+                    await self.push_interruption_task_frame_and_wait()
 
-                # Interruption complete - DON'T overwrite buffer!
-                # The buffer already contains the latest transcription (if any
-                # arrived during the await, it would have overwritten the buffer)
-                self._interruption_in_progress = False
-                self._state = ResponseState.IDLE
+                    self._interruption_in_progress = False
+                    self._state = ResponseState.IDLE
 
-                # Flush whatever is currently buffered (may be the original
-                # frame or a newer one that arrived during the await)
-                await self._flush_buffered_transcription(direction)
-                return
+                    await self._flush_buffered_transcription(direction)
+                    return
+
+                elif self._interruption_mode == InterruptionMode.DISABLED_WITH_STORE:
+                    # Don't interrupt, but keep the latest transcription for later
+                    self._buffered_transcription = frame
+                    logger.debug(
+                        f"ResponseGate: Storing transcription while bot active "
+                        f"(mode=disabled_with_store, state={self._state.name})"
+                    )
+                    return
+
+                else:
+                    # DISABLED_WITHOUT_STORE — silently discard
+                    logger.debug(
+                        f"ResponseGate: Discarding transcription while bot active "
+                        f"(mode=disabled_without_store, state={self._state.name})"
+                    )
+                    return
 
             # No active response, just process normally
             await self._handle_transcription_frame(frame, direction)

--- a/app/ai/voice/agents/breeze_buddy/template/types.py
+++ b/app/ai/voice/agents/breeze_buddy/template/types.py
@@ -180,6 +180,33 @@ class KeywordFilterConfig(BaseModel):
     )
 
 
+class InterruptionMode(str, Enum):
+    """Controls how user speech is handled while the bot is speaking.
+
+    - ENABLED: Interrupt the bot and process user speech immediately (default).
+    - DISABLED_WITH_STORE: Don't interrupt the bot; buffer user speech and
+      process it after the bot finishes speaking.
+    - DISABLED_WITHOUT_STORE: Don't interrupt the bot; discard user speech
+      entirely while the bot is speaking.
+    """
+
+    ENABLED = "enabled"
+    DISABLED_WITH_STORE = "disabled_with_store"
+    DISABLED_WITHOUT_STORE = "disabled_without_store"
+
+
+class InterruptionConfig(BaseModel):
+    """Per-template configuration for interruption behavior.
+
+    Example:
+        {
+            "mode": "disabled_with_store"
+        }
+    """
+
+    mode: InterruptionMode = InterruptionMode.ENABLED
+
+
 class UserIdleHandlingConfig(BaseModel):
     """Configuration for user idle detection and handling."""
 
@@ -253,6 +280,12 @@ class ConfigurationModel(BaseModel):
     keyword_filter: Optional[KeywordFilterConfig] = Field(
         None,
         description="Keyword filter to suppress specific transcriptions while bot is active",
+    )
+    interruption_config: Optional[InterruptionConfig] = Field(
+        None,
+        description="Per-template interruption behavior: enabled (interrupt bot), "
+        "disabled_with_store (buffer user speech, process after bot finishes), "
+        "or disabled_without_store (discard user speech while bot speaks)",
     )
 
 

--- a/app/core/config/dynamic.py
+++ b/app/core/config/dynamic.py
@@ -256,16 +256,6 @@ async def LANGFUSE_EVALUATORS() -> dict[str, int]:
     return evaluators
 
 
-# --- Response Gate Configuration ---
-async def BB_ENABLE_RESPONSE_GATE() -> bool:
-    """Returns BB_ENABLE_RESPONSE_GATE from Redis.
-
-    When True, enables ResponseGateTracker and AudioInterruptionProcessor
-    to prevent double speaking by interrupting old responses when new input arrives.
-    """
-    return await get_config("BB_ENABLE_RESPONSE_GATE", True, bool)
-
-
 # --- Noise Cancellation Configuration ---
 async def BB_NOISE_CANCELLATION_ENABLED() -> bool:
     """Returns BB_NOISE_CANCELLATION_ENABLED from Redis"""

--- a/docs/response-gate.md
+++ b/docs/response-gate.md
@@ -207,40 +207,40 @@ T1: push_frame(new_stt) ✅ ONLY NEW REQUEST
 
 ## Configuration
 
-### Redis Control
+### Template Configuration
 
-| Key | Type | Default | Description |
-|-----|------|---------|-------------|
-| `BB_ENABLE_RESPONSE_GATE` | bool | `True` | Enable/disable the response gate |
+Interruption behavior is controlled per-template via `interruption_config`:
 
-```bash
-# Enable (default)
-BB_ENABLE_RESPONSE_GATE=True
-
-# Disable
-BB_ENABLE_RESPONSE_GATE=False
-```
+| Mode | JSON value | Behavior |
+|------|------------|----------|
+| `ENABLED` (default) | `"enabled"` | Interrupt bot, buffer user speech, process after interruption |
+| `DISABLED_WITH_STORE` | `"disabled_with_store"` | Don't interrupt; buffer user speech, flush when bot finishes |
+| `DISABLED_WITHOUT_STORE` | `"disabled_without_store"` | Don't interrupt; silently discard user speech |
 
 ### Code Configuration
 
 ```python
 from app.ai.voice.agents.breeze_buddy.processors import ResponseStateGate
+from app.ai.voice.agents.breeze_buddy.template.types import InterruptionMode
 
-# In agent.py:
-response_gate = ResponseStateGate() if await BB_ENABLE_RESPONSE_GATE() else None
+# The response gate is always active, driven by the template's interruption_config.
+interruption_config = getattr(configurations, "interruption_config", None)
+interruption_mode = (
+    interruption_config.mode if interruption_config else InterruptionMode.ENABLED
+)
+response_gate = ResponseStateGate(interruption_mode=interruption_mode)
 
 pipeline_parts = [
     transport.input(),
     stt,
+    transcription_gate,
+    response_gate,
     context_aggregator.user(),
     llm,
     tts,
     transport.output(),
     context_aggregator.assistant(),
 ]
-
-if response_gate:
-    pipeline_parts.insert(2, response_gate)  # After stt
 
 pipeline = Pipeline(pipeline_parts)
 ```
@@ -358,8 +358,8 @@ The response gate intercepts new transcriptions that would otherwise trigger sep
 
 ### Double Speaking Still Occurring
 
-1. Check `BB_ENABLE_RESPONSE_GATE=True` in Redis
-2. Verify response_gate is in the pipeline
+1. Verify response_gate is in the pipeline
+2. Check the template's `interruption_config.mode` is set correctly
 3. Check logs for "Interrupting state=..." messages
 4. Ensure no other processor is bypassing the gate
 
@@ -382,6 +382,6 @@ Buffer should flush immediately after interruption. If not:
 | File | Purpose |
 |------|---------|
 | `app/ai/voice/agents/breeze_buddy/processors/response_gate.py` | Main processor implementation |
-| `app/ai/voice/agents/breeze_buddy/agent.py` | Pipeline integration |
-| `app/core/config/dynamic.py` | `BB_ENABLE_RESPONSE_GATE` config |
+| `app/ai/voice/agents/breeze_buddy/agent/pipeline.py` | Pipeline integration |
+| `app/ai/voice/agents/breeze_buddy/template/types.py` | `InterruptionMode` and `InterruptionConfig` definitions |
 | `docs/aggregation-timeout.md` | Related: aggregation timeout explanation |


### PR DESCRIPTION
## Summary
Refactored the response gate interruption logic to be configurable per-template via `InterruptionMode` instead of a global Redis flag. This allows different templates to have different interruption behaviors while keeping the response gate always active in the pipeline.

## Key Changes

- **Added `InterruptionMode` enum** with three modes:
  - `ENABLED` (default): Interrupt bot and process user speech immediately
  - `DISABLED_WITH_STORE`: Buffer user speech, process after bot finishes
  - `DISABLED_WITHOUT_STORE`: Silently discard user speech while bot is active

- **Added `InterruptionConfig` model** to `template/types.py` for per-template configuration

- **Updated `ResponseStateGate` processor**:
  - Now accepts `interruption_mode` parameter in constructor
  - Implements mode-specific behavior in transcription frame handling
  - Added logic to flush buffered transcriptions when bot transitions to IDLE (for `DISABLED_WITH_STORE` mode)

- **Removed global Redis configuration**:
  - Deleted `BB_ENABLE_RESPONSE_GATE` from `dynamic.py`
  - Response gate is now always instantiated in the pipeline

- **Updated pipeline integration** in `agent/pipeline.py`:
  - Reads `interruption_config` from template configuration
  - Passes `interruption_mode` to `ResponseStateGate` constructor
  - Removed conditional pipeline insertion logic

- **Updated documentation** in `docs/response-gate.md`:
  - Replaced Redis configuration section with template configuration details
  - Updated code examples to show new configuration approach
  - Updated troubleshooting section to reference template config instead of Redis

## Implementation Details

The response gate now handles three distinct scenarios based on the configured mode:
1. **ENABLED**: Existing interrupt-and-process behavior with buffering
2. **DISABLED_WITH_STORE**: Stores transcriptions during bot activity and flushes them when the bot returns to IDLE state
3. **DISABLED_WITHOUT_STORE**: Early return without storing, effectively discarding user input

This design maintains backward compatibility (ENABLED is the default) while providing flexibility for templates that need different interruption semantics.

https://claude.ai/code/session_01U17hDTLDAU5ANu6f1Kix2T

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added per-template interruption mode configuration with three options to control how user input is handled while the bot is speaking.

* **Refactor**
  * Replaced global interruption control flag with per-template configuration approach for more granular control.

* **Documentation**
  * Updated interruption behavior documentation to reflect new per-template configuration model and mode options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->