### PR TITLE
feat: Add pre-tts-message to builtin global functions

### DIFF
--- a/app/ai/voice/agents/breeze_buddy/handlers/internal/builtin_dispatcher.py
+++ b/app/ai/voice/agents/breeze_buddy/handlers/internal/builtin_dispatcher.py
@@ -10,10 +10,21 @@ To add a new built-in global function:
 3. Use it in templates with: {"type": "builtin", "handler": "<handler_key>", ...}
 """
 
+import asyncio
 from typing import Any, Callable, Dict, Optional, Tuple
+
+from pipecat.frames.frames import (
+    BotStartedSpeakingFrame,
+    BotStoppedSpeakingFrame,
+    TTSSpeakFrame,
+)
 
 from app.ai.voice.agents.breeze_buddy.handlers.internal.get_current_time import (
     get_current_time,
+)
+from app.ai.voice.agents.breeze_buddy.handlers.internal.stt import (
+    mute_stt,
+    unmute_stt,
 )
 from app.ai.voice.agents.breeze_buddy.handlers.internal.warm_transfer import (
     connect_to_live_agent,
@@ -29,6 +40,59 @@ BUILTIN_HANDLERS: Dict[str, Callable] = {
     "connect_to_live_agent": connect_to_live_agent,
     "get_current_time": get_current_time,
 }
+
+
+async def _speak_and_wait(context: TemplateContext, message: str) -> None:
+    """Push a TTS message and wait for it to be fully spoken, uninterrupted.
+
+    Mutes STT/VAD before speaking to prevent user interruptions, then uses a
+    two-phase wait (BotStartedSpeaking → BotStoppedSpeaking) to ensure we only
+    return after OUR TTS has finished, not a stale BotStoppedSpeakingFrame from
+    a previous utterance (e.g., the LLM's own text response).
+
+    This is safe to call alongside ActionManager because:
+    - add_event_handler() APPENDS handlers (does not replace)
+    - add_reached_downstream_filter() ADDS to the existing filter set
+    """
+    task = context.task
+    bot_started = False
+    bot_stopped_event = asyncio.Event()
+
+    async def _on_frame_reached_downstream(task, frame):
+        nonlocal bot_started
+        if bot_stopped_event.is_set():
+            return  # This handler's job is done; avoid stale reactions
+        if isinstance(frame, BotStartedSpeakingFrame):
+            bot_started = True
+        elif isinstance(frame, BotStoppedSpeakingFrame) and bot_started:
+            bot_stopped_event.set()
+
+    # Add BotStartedSpeakingFrame to the downstream filter so we receive it.
+    # BotStoppedSpeakingFrame is already in the filter (set by ActionManager).
+    # add_reached_downstream_filter uses .update() — safe, doesn't replace.
+    task.add_reached_downstream_filter((BotStartedSpeakingFrame,))
+    task.add_event_handler("on_frame_reached_downstream", _on_frame_reached_downstream)
+
+    # Mute STT/VAD so user speech cannot interrupt pre_tts_message
+    await mute_stt(context, {})
+
+    try:
+        logger.info(
+            f"[builtin_dispatcher] Speaking pre_tts_message: '{message[:50]}...'"
+        )
+        await task.queue_frame(TTSSpeakFrame(text=message))
+        timeout_seconds = 15
+        try:
+            await asyncio.wait_for(bot_stopped_event.wait(), timeout=timeout_seconds)
+            logger.info("[builtin_dispatcher] pre_tts_message finished speaking")
+        except asyncio.TimeoutError:
+            logger.warning(
+                "[builtin_dispatcher] Timeout waiting for pre_tts_message to finish "
+                f"speaking after {timeout_seconds} seconds; continuing anyway"
+            )
+    finally:
+        # Always restore STT/VAD, even if something goes wrong
+        await unmute_stt(context, {})
 
 
 async def builtin_function_dispatcher(
@@ -76,6 +140,13 @@ async def builtin_function_dispatcher(
     )
 
     try:
+        # If pre_tts_message is configured, speak it and wait for TTS completion
+        # before executing the handler. This guarantees the message is heard even
+        # if the handler terminates the pipeline (e.g., connect_to_live_agent
+        # pushes EndFrame which kills TTS mid-sentence).
+        if function_config.pre_tts_message:
+            await _speak_and_wait(context, function_config.pre_tts_message)
+
         result = await handler(context, args)
         # Ensure consistent return format (result, None) for global functions
         if isinstance(result, tuple):

--- a/app/ai/voice/agents/breeze_buddy/template/types.py
+++ b/app/ai/voice/agents/breeze_buddy/template/types.py
@@ -432,6 +432,12 @@ class GlobalBuiltinFunction(BaseGlobalFunction):
         ...,
         description="Key in the builtin handler registry (e.g., 'connect_to_live_agent', 'get_current_time')",
     )
+    pre_tts_message: Optional[str] = Field(
+        None,
+        description="TTS message to speak and wait for completion BEFORE executing the handler. "
+        "Useful for handlers that terminate the pipeline (e.g., transfer) where the LLM's "
+        "generated text may get cut off.",
+    )
 
 
 class FlowNodeModel(BaseModel):

--- a/app/api/routers/breeze_buddy/telephony/callbacks/handlers.py
+++ b/app/api/routers/breeze_buddy/telephony/callbacks/handlers.py
@@ -86,8 +86,10 @@ async def handle_call_transfer(
     if action == "dial-up":
         return await _handle_transfer_dial_up(request, provider_lower)
     elif action in ("conclude", "conference-end"):
-        # future scope: to be implemented
-        return Response(status_code=200)
+        return HTMLResponse(
+            content='<?xml version="1.0" encoding="UTF-8"?><Response><Hangup/></Response>',
+            media_type="application/xml",
+        )
     else:
         logger.warning(f"[TRANSFER] Unknown callback: {provider}/{action}")
         return Response(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Handlers can play a configurable pre-TTS message and wait for speech to complete before executing, ensuring LLM output isn't cut off during transitions.

* **Bug Fixes**
  * Call transfer and call-conclusion flows now return an XML hangup response to properly signal the telephony system.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->