### PR TITLE
feat(BZ-601): pass metaAdAccountIds through voice mode pipeline

### DIFF
--- a/app/ai/voice/agents/automatic/__init__.py
+++ b/app/ai/voice/agents/automatic/__init__.py
@@ -1,0 +1,717 @@
+import argparse
+import asyncio
+import json
+import os
+import random
+import sys
+import wave
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+from langfuse import get_client
+from opentelemetry import trace
+from pipecat.audio.filters.aic_filter import AICFilter
+from pipecat.audio.vad.silero import SileroVADAnalyzer
+from pipecat.audio.vad.vad_analyzer import VADParams
+from pipecat.frames.frames import (
+    BotSpeakingFrame,
+    EmulateUserStartedSpeakingFrame,
+    EmulateUserStoppedSpeakingFrame,
+    LLMFullResponseEndFrame,
+    LLMRunFrame,
+    OutputAudioRawFrame,
+    TTSSpeakFrame,
+)
+from pipecat.pipeline.pipeline import Pipeline
+from pipecat.pipeline.runner import PipelineRunner
+from pipecat.pipeline.task import PipelineParams, PipelineTask
+from pipecat.processors.filters.stt_mute_filter import (
+    STTMuteConfig,
+    STTMuteFilter,
+    STTMuteStrategy,
+)
+from pipecat.processors.frameworks.rtvi import (
+    RTVIConfig,
+    RTVIProcessor,
+    RTVIServerMessageFrame,
+)
+from pipecat.services.azure.llm import AzureLLMService
+from pipecat.services.google.rtvi import GoogleRTVIObserver
+from pipecat.transports.daily.transport import DailyParams, DailyTransport
+from pipecat.utils.tracing.conversation_context_provider import (
+    ConversationContextProvider,
+)
+
+from app.ai.voice.agents.automatic.features.llm_wrapper import LLMServiceWrapper
+from app.ai.voice.agents.automatic.processors.llm_spy import (
+    handle_confirmation_response,
+)
+from app.ai.voice.agents.automatic.services.mcp import init_breeze_mcp_tools
+
+# Commented out to avoid crash when mem0ai package is not installed (removed from dependencies in PR-582)
+# from app.ai.voice.agents.automatic.services.mem0.memory import ImprovedMem0MemoryService
+from app.ai.voice.agents.automatic.types import (
+    Mode,
+    TTSProvider,
+    decode_mode,
+    decode_tts_provider,
+    decode_voice_name,
+)
+from app.ai.voice.agents.automatic.types.models import VoiceName
+from app.ai.voice.agents.automatic.utils.session_context import (
+    create_session_context,
+    set_current_session_id,
+)
+from app.core.config import static
+from app.core.config.dynamic import ENABLE_BREEZE_MCP
+from app.core.logger import configure_session_logger, logger
+
+from .processors import LLMSpyProcessor
+from .processors.ptt_vad_filter import PTTVADFilter
+from .prompts import get_system_prompt
+from .stt import get_stt_service
+from .tools import initialize_tools
+from .tts import get_tts_service
+
+# Load tool call sound
+tool_call_sound = None
+if static.ENABLE_TOOL_CALL_SOUND and os.path.exists(static.TOOL_CALL_SOUND_FILE):
+    with wave.open(static.TOOL_CALL_SOUND_FILE) as audio_file:
+        tool_call_sound = OutputAudioRawFrame(
+            audio_file.readframes(-1),
+            audio_file.getframerate(),
+            audio_file.getnchannels(),
+        )
+
+
+# import setup_tracing from tracing_setup.py file
+from app.ai.voice.agents.automatic.analytics.tracing_setup import setup_tracing
+from app.ai.voice.agents.automatic.analytics.utils import (
+    generate_open_observer_url_for_session_id,
+)
+
+
+async def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-u", "--url", type=str, help="URL of the Daily room")
+    parser.add_argument("-t", "--token", type=str, help="Daily token")
+    parser.add_argument("--mode", type=str, help="Mode (TEST or LIVE)")
+    parser.add_argument("--session-id", type=str, help="Session ID for logging")
+    parser.add_argument("--client-sid", type=str, help="Client session ID for logging")
+    parser.add_argument("--euler-token", type=str, help="Euler token for live mode")
+    parser.add_argument("--breeze-token", type=str, help="Breeze token for live mode")
+    parser.add_argument("--shop-url", type=str, help="Shop URL for live mode")
+    parser.add_argument("--shop-id", type=str, help="Shop ID for live mode")
+    parser.add_argument("--shop-type", type=str, help="Shop type for live mode")
+    parser.add_argument("--user-name", type=str, help="User's name")
+    parser.add_argument("--user-email", type=str, help="User's email address")
+    parser.add_argument("--tts-provider", type=str, help="TTS provider to use")
+    parser.add_argument("--voice-name", type=str, help="Voice name to use")
+    parser.add_argument("--merchant-id", type=str, help="Merchant Id of the Shop")
+    parser.add_argument(
+        "--platform-integrations",
+        type=str,
+        nargs="+",
+        help="Platform Integrations that are supported by the shop (string array)",
+    )
+    parser.add_argument("--reseller-id", type=str, help="Reseller ID")
+    parser.add_argument("--customer-id", type=str, help="Customer ID from breeze token")
+    parser.add_argument(
+        "--shopify-connected-shop", type=str, help="Shopify connected shop domain"
+    )
+    # BZ-601: Accept Meta ad account IDs to populate tool execution context in voice mode
+    parser.add_argument(
+        "--meta-ad-account-ids",
+        type=str,
+        nargs="+",
+        help="Meta ad account IDs for Meta tool context (e.g. get_campaign)",
+    )
+
+    # Pool mode arguments
+    parser.add_argument("--pool-mode", action="store_true", help="Run in pool mode")
+    parser.add_argument("--process-id", type=str, help="Process ID for pool mode")
+
+    args = parser.parse_args()
+
+    # Validate arguments
+    if args.pool_mode and (not args.process_id or not args.process_id.strip()):
+        parser.error("--process-id is required when --pool-mode is used.")
+
+    if args.pool_mode:
+        await run_pool_mode(args)
+    else:
+        await run_normal_mode(args)
+
+
+async def run_pool_mode(args):
+    """Run in pool mode - wait for session assignments"""
+    logger.info(f"Voice agent process {args.process_id} starting in pool mode")
+
+    try:
+        await pre_initialize_services()
+        print("READY", flush=True)
+
+        # Wait for session assignments
+        while True:
+            try:
+                # Run the blocking readline call in a separate thread
+                line = await asyncio.to_thread(sys.stdin.readline)
+
+                # An empty string from readline indicates EOF
+                if line == "":
+                    logger.info("Pool process received EOF, shutting down")
+                    break
+
+                if line.strip():
+                    try:
+                        session_config = json.loads(line.strip())
+                        await handle_session(session_config)
+                    except json.JSONDecodeError as json_err:
+                        logger.error(f"Failed to decode session config: {json_err}")
+                        # Don't break the worker, just log and continue
+                        continue
+
+            except Exception as e:
+                logger.error(
+                    f"An unexpected error occurred in pool mode: {e}", exc_info=True
+                )
+                break
+
+    except Exception as e:
+        logger.error(f"Failed to initialize pool mode: {e}")
+        print(f"ERROR: {e}", flush=True)
+
+    logger.info("Pool process shutting down")
+
+
+async def pre_initialize_services():
+    """Pre-load heavy services for faster session startup"""
+    logger.info("Pre-initializing services for pool mode")
+
+    try:
+        # Pre-initialize Silero VAD model
+        await _pre_init_silero_vad()
+
+        logger.info("Services pre-initialized successfully")
+
+    except Exception as e:
+        logger.error(f"Error during service pre-initialization: {e}")
+        # Don't fail the process - fallback to normal initialization
+        logger.info("Continuing with normal initialization fallback")
+
+
+async def _pre_init_silero_vad():
+    """Pre-initialize Silero VAD model"""
+    try:
+        # Pre-load the Silero VAD model
+        vad_params = VADParams(
+            confidence=static.VAD_CONFIDENCE,
+            start_secs=static.VAD_START_SECS,
+            stop_secs=static.VAD_STOP_SECS,
+            min_volume=static.VAD_MIN_VOLUME,
+        )
+
+        # Store in global cache for reuse
+        global _silero_vad_cache
+        _silero_vad_cache = {
+            "sample_rate": static.SAMPLE_RATE,
+            "params": vad_params,
+        }
+
+        logger.info("Silero VAD model pre-loaded")
+
+    except Exception as e:
+        logger.debug(f"Silero VAD pre-init failed (will fallback): {e}")
+
+
+# Global caches for pre-initialized services
+_silero_vad_cache = None
+
+
+async def handle_session(session_config):
+    """Handle a session with the given configuration"""
+    session_id = session_config.get("session_id")
+
+    # Simple args object from session config
+    class SessionArgs:
+        def __init__(self, config):
+            for key, value in config.items():
+                setattr(self, key.replace("-", "_"), value)
+            # Map room_url to url for compatibility
+            self.url = config.get("room_url")
+
+    session_args = SessionArgs(session_config)
+
+    try:
+        await run_normal_mode(session_args)
+    except Exception as e:
+        logger.error(f"Session {session_id} ended with error: {e}")
+    finally:
+        logger.info(f"Session {session_id} completed, process ready for next session")
+        print("SESSION_ENDED", flush=True)
+
+
+async def run_normal_mode(args):
+    """Run the normal voice agent mode"""
+    # Validate required arguments for normal mode
+    if not args.url or not args.token or not args.session_id:
+        logger.error("Missing required arguments for normal mode")
+        return
+
+    # Configure logger with session ID and client session ID for all logs in this subprocess
+    configure_session_logger(args.session_id, args.client_sid)
+    logger.info(
+        f"Voice agent started with session ID: {args.session_id}, client session ID: {args.client_sid}"
+    )
+
+    # Create session context for passing to components
+    create_session_context(args.session_id)
+
+    # Set global session ID for chart tools
+    set_current_session_id(args.session_id)
+
+    # Decode TTS parameters
+    tts_provider = decode_tts_provider(args.tts_provider)
+    voice_name = decode_voice_name(args.voice_name)
+    mode = decode_mode(args.mode)
+
+    # Initialize tools based on the mode and provided tokens
+    # Only pass tokens if in live mode
+
+    # Get dynamic config value from Redis (same pattern as ENABLE_BACKGROUND_TASKS in main.py)
+    enable_breeze_mcp = await ENABLE_BREEZE_MCP()
+
+    use_breeze_mcp_server = enable_breeze_mcp and (
+        not static.SHOPS_FOR_BREEZE_MCP  # Empty list = all shops
+        or args.shop_id in static.SHOPS_FOR_BREEZE_MCP  # Specific shops only
+    )
+
+    use_breeze_mcp_server_for_bret = static.ENABLE_BREEZE_MCP_FOR_BRET and (
+        voice_name == VoiceName.BRET
+        and (
+            not static.SHOPS_FOR_BREEZE_MCP
+            or args.shop_id in static.SHOPS_FOR_BREEZE_MCP
+        )
+    )
+
+    # Personalize the system prompt if a user name is provided
+    system_prompt = get_system_prompt(args.user_name, tts_provider, args.shop_id)
+
+    # Configure VAD - use pre-initialized model if available
+    global _silero_vad_cache
+    if _silero_vad_cache:
+        logger.info("Using pre-initialized Silero VAD model")
+        vad_analyzer = SileroVADAnalyzer(
+            sample_rate=_silero_vad_cache["sample_rate"],
+            params=_silero_vad_cache["params"],
+        )
+    else:
+        # Fallback to normal initialization
+        logger.info("Using fallback Silero VAD initialization")
+        vad_params = VADParams(
+            confidence=static.VAD_CONFIDENCE,
+            start_secs=static.VAD_START_SECS,
+            stop_secs=static.VAD_STOP_SECS,  # Use normal timeout - Smart Turn will intercept and decide
+            min_volume=static.VAD_MIN_VOLUME,
+        )
+
+        vad_analyzer = SileroVADAnalyzer(
+            sample_rate=static.SAMPLE_RATE,
+            params=vad_params,
+        )
+
+    daily_params = DailyParams(
+        audio_in_enabled=True,
+        audio_out_enabled=True,
+        vad_analyzer=None if static.DISABLE_SILERO_VAD else vad_analyzer,
+    )
+
+    # Audio filter configuration
+    if static.ENABLE_AIC_FILTER and static.AICOUSTICS_LICENSE_KEY:
+        try:
+            aic_filter = AICFilter(
+                license_key=static.AICOUSTICS_LICENSE_KEY,
+                enhancement_level=static.AIC_ENHANCEMENT_LEVEL,
+                voice_gain=static.AIC_VOICE_GAIN,
+                noise_gate_enable=static.AIC_NOISE_GATE_ENABLE,
+            )
+            daily_params.audio_in_filter = aic_filter
+            logger.info(
+                f"AIC Filter: ENABLED (enhancement_level={static.AIC_ENHANCEMENT_LEVEL}, voice_gain={static.AIC_VOICE_GAIN}, noise_gate={static.AIC_NOISE_GATE_ENABLE})"
+            )
+
+        except Exception as e:
+            logger.error(f"AIC Filter failed: {e}")
+    else:
+        logger.info("No Audio Filter enabled")
+
+    transport = DailyTransport(
+        args.url,
+        args.token,
+        "Breeze Automatic Voice Agent",
+        daily_params,
+    )
+
+    stt = await get_stt_service(voice_name=voice_name.value)
+
+    tts = await get_tts_service(
+        tts_provider=tts_provider.value,
+        voice_name=voice_name.value,
+        session_id=args.session_id,
+        enable_chart_text_filter=static.ENABLE_CHARTS,
+    )
+
+    llm = LLMServiceWrapper(
+        AzureLLMService(
+            api_key=static.AZURE_OPENAI_API_KEY,
+            endpoint=static.AZURE_OPENAI_ENDPOINT,
+            model=static.AZURE_OPENAI_MODEL,
+            run_in_parallel=True,
+        )
+    )
+
+    # BZ-601: Retrieve meta_ad_account_ids from args (passed via session_params or CLI)
+    meta_ad_account_ids = getattr(args, "meta_ad_account_ids", None) or []
+
+    if not use_breeze_mcp_server and not use_breeze_mcp_server_for_bret:
+        # Initialize tools normally
+        if mode == Mode.LIVE:
+            tools, tool_functions = initialize_tools(
+                mode=mode.value,
+                breeze_token=args.breeze_token,
+                euler_token=args.euler_token,
+                shop_url=args.shop_url,
+                shop_id=args.shop_id,
+                shop_type=args.shop_type,
+                merchant_id=args.merchant_id,
+                session_id=args.client_sid,  # Pass client_sid instead of session_id
+                user_id=args.user_name,
+                user_email=args.user_email,
+                reseller_id=args.reseller_id,
+                meta_ad_account_ids=meta_ad_account_ids,
+            )
+        else:
+            tools, tool_functions = initialize_tools(
+                mode=mode.value,
+                shop_id=args.shop_id,
+                merchant_id=args.merchant_id,
+                session_id=args.client_sid,  # Pass client_sid instead of session_id
+                reseller_id=args.reseller_id,
+            )
+
+        for name, function in tool_functions.items():
+            logger.info("Initializing the default function tools")
+            llm.register_function(name, function)
+    else:
+        logger.info(f"Initializing tools from remote MCP server")
+
+        mcp_context = {
+            "sessionId": args.client_sid,  # Pass client_sid instead of session_id
+            "juspayToken": getattr(args, "euler_token", None),
+            "breezeToken": getattr(args, "breeze_token", None),
+            "shopUrl": getattr(args, "shop_url", None),
+            "shopId": getattr(args, "shop_id", None),
+            "shopType": getattr(args, "shop_type", None),
+            "userId": getattr(args, "user_name", None),
+            "userEmail": getattr(args, "user_email", None),
+            "demoMode": mode != Mode.LIVE,
+            "merchantId": getattr(args, "merchant_id", None),
+            "platformIntegrations": getattr(args, "platform_integrations", None),
+            "customerId": getattr(args, "customer_id", None),
+            "shopifyConnectedShop": getattr(args, "shopify_connected_shop", None),
+        }
+
+        tools = await init_breeze_mcp_tools(
+            llm=llm,
+            mcp_context=mcp_context,
+            breeze_token=args.breeze_token,
+            reseller_id=args.reseller_id,
+            mode=mode,
+            args=args,
+        )
+
+    rtvi = RTVIProcessor(config=RTVIConfig(config=[]))
+
+    # Simplified event handler for TTS feedback
+    @llm.event_handler("on_function_calls_started")
+    async def on_function_calls_started(service, function_calls):
+        # Only play the "checking" message if using Google TTS
+        if tts_provider == TTSProvider.GOOGLE:
+            for function_call in function_calls:
+                # Skip "checking" message for instant functions and chart tools
+                instant_functions = [
+                    "get_current_time",
+                    "utility__getCurrentTime",  # NeuroLink equivalent
+                    "utility__generateTimestamp",  # NeuroLink timestamp tool
+                    "generate_bar_chart",
+                    "generate_line_chart",
+                    "generate_donut_chart",
+                    "generate_single_stat_card",
+                    "tool_execution_rules",
+                ]
+                if function_call.function_name not in instant_functions:
+                    # Play tool call sound if enabled, otherwise use phrases
+                    if tool_call_sound:
+                        await transport.send_audio(tool_call_sound)
+                    else:
+                        phrases = [
+                            "Let me check on that.",
+                            "Give me a moment to do that.",
+                            "I'll get right on that.",
+                            "Working on that for you.",
+                            "One moment — I'm on it",
+                            "One second, boss.",
+                            "On it, boss!",
+                            "Just a second, captain.",
+                        ]
+                        await tts.queue_frame(TTSSpeakFrame(random.choice(phrases)))
+                    break
+
+    messages = [
+        {"role": "system", "content": system_prompt},
+    ]
+
+    context = llm.create_summarizing_context(
+        messages,
+        tools,
+    )
+
+    context_aggregator = llm.create_context_aggregator(context)
+
+    # Initialize processors and pipeline components
+    stt_mute_filter = None
+    tool_call_processor = None
+
+    # Build pipeline components list
+    pipeline_components = [
+        transport.input(),
+    ]
+
+    # Add PTT VAD filter only if it's enabled
+    if static.DISABLE_VAD_FOR_PTT:
+        ptt_vad_filter = PTTVADFilter("PTTVADFilter")
+        pipeline_components.append(ptt_vad_filter)  # Filter VAD frames after STT
+
+    pipeline_components.append(stt)
+
+    if static.ENABLE_MUTE_UNTIL_FIRST_BOT_COMPLETE:
+        stt_mute_filter = STTMuteFilter(
+            config=STTMuteConfig(
+                strategies={
+                    STTMuteStrategy.MUTE_UNTIL_FIRST_BOT_COMPLETE,
+                }
+            )
+        )
+        tool_call_processor = LLMSpyProcessor(
+            rtvi,
+            args.session_id,
+            static.ENABLE_CHARTS,
+            stt_mute_filter,
+            "LLMSpyProcessor",
+        )
+        pipeline_components.extend([stt_mute_filter])
+    else:
+        tool_call_processor = LLMSpyProcessor(
+            rtvi, args.session_id, static.ENABLE_CHARTS, None, "LLMSpyProcessor"
+        )
+
+    pipeline_components.extend([rtvi, context_aggregator.user()])
+
+    # Add remaining components
+    pipeline_components.extend(
+        [
+            llm,
+            tool_call_processor,
+            tts,
+            transport.output(),
+            context_aggregator.assistant(),
+        ]
+    )
+
+    pipeline = Pipeline(pipeline_components)
+
+    user_name = args.user_name or "guest"
+    shopId = (
+        "euler" if args.euler_token and not args.shop_id else args.shop_id or "dummy"
+    )
+    ist_time = datetime.now(ZoneInfo("Asia/Kolkata"))
+    timestamp = ist_time.strftime("%Y-%m-%d_%H-%M-%S")
+    conversation_id = f"{user_name}-{shopId}-{timestamp}"
+
+    task_params = {
+        "idle_timeout_secs": static.AUTOMATIC_SESSION_INACTIVITY_TIMEOUT,
+        "idle_timeout_frames": (BotSpeakingFrame, LLMFullResponseEndFrame),
+        "params": PipelineParams(allow_interruptions=True),
+        "cancel_on_idle_timeout": True,
+        "observers": [GoogleRTVIObserver(rtvi)],
+    }
+
+    if static.ENABLE_TRACING:
+        setup_tracing("breeze-voice-agent")
+        task_params["conversation_id"] = conversation_id
+        task_params["enable_tracing"] = True
+
+    task = PipelineTask(pipeline, **task_params)
+
+    @rtvi.event_handler("on_client_ready")
+    async def on_client_ready(rtvi):
+        await rtvi.push_frame(RTVIServerMessageFrame(data={"type": "bot-ready"}))
+
+    @rtvi.event_handler("on_client_message")
+    async def on_client_message(rtvi, message):
+        """Handle incoming messages from RTVI client, including function confirmation responses and PTT events"""
+        try:
+            if isinstance(message, dict):
+                message_type = message.get("type")
+
+                if message_type == "function-confirmation-response":
+                    confirmation_id = message.get("confirmationId")
+                    approved = message.get("approved", False)
+                    reason = message.get("reason", "")
+
+                    if confirmation_id:
+                        response = {"approved": approved, "reason": reason}
+                        handle_confirmation_response(confirmation_id, response)
+                        logger.info(
+                            f"Processed function confirmation response: {confirmation_id} -> {approved}"
+                        )
+                    else:
+                        logger.warning(
+                            "Received function confirmation response without confirmationId"
+                        )
+
+                elif message_type == "ptt-start":
+                    # Handle PTT start event
+                    logger.debug("PTT started - activating VAD filter")
+                    ptt_vad_filter.set_ptt_active(True)
+                    # Send emulated user started speaking frame
+                    await task.queue_frames([EmulateUserStartedSpeakingFrame()])
+
+                elif message_type == "ptt-end":
+                    # Handle PTT end event
+                    logger.debug(
+                        "PTT ended - deactivating VAD filter and sending stop frame"
+                    )
+                    ptt_vad_filter.set_ptt_active(False)
+                    # Send emulated user stopped speaking frame
+                    await task.queue_frames([EmulateUserStoppedSpeakingFrame()])
+
+                elif message_type == "ptt-sync":
+                    # Handle PTT state synchronization from client
+                    client_ptt_state = message.get("data", {}).get("ptt_active", False)
+                    current_state = ptt_vad_filter._ptt_active
+
+                    if client_ptt_state != current_state:
+                        logger.warning(
+                            f"PTT state mismatch! client: {client_ptt_state}, server: {current_state}"
+                        )
+                        # Sync to client state (client is authoritative)
+                        ptt_vad_filter.set_ptt_active(client_ptt_state)
+                        logger.info(f"PTT state synchronized to: {client_ptt_state}")
+
+                        # Send appropriate frames for state change
+                        if client_ptt_state:
+                            await task.queue_frames([EmulateUserStartedSpeakingFrame()])
+                        else:
+                            await task.queue_frames([EmulateUserStoppedSpeakingFrame()])
+                    else:
+                        logger.debug(
+                            f"PTT state sync: states match (current_state: {current_state})"
+                        )
+
+        except Exception as e:
+            logger.error(f"Error handling RTVI client message: {e}")
+
+    @transport.event_handler("on_first_participant_joined")
+    async def on_first_participant_joined(transport, participant):
+        logger.info(f"First participant joined: {participant['id']}")
+        if static.ENABLE_AUTOMATIC_DAILY_RECORDING:
+            await transport.start_recording()
+
+        await task.queue_frames([LLMRunFrame()])
+
+    @transport.event_handler("on_participant_left")
+    async def on_participant_left(transport, participant, reason):
+        logger.info(f"Participant left: {participant['id']}")
+        if static.ENABLE_AUTOMATIC_DAILY_RECORDING:
+            await transport.stop_recording()
+        await task.cancel()
+
+    # Route Daily transport messages to RTVI for function confirmations
+    @transport.event_handler("on_app_message")
+    async def on_app_message(transport, message, sender):
+        """Route function confirmation messages from Daily transport to RTVI"""
+
+        # Check if this is a function confirmation message or PTT message and route to RTVI
+        if isinstance(message, dict):
+            message_type = message.get("type")
+            if message_type == "function-confirmation-response" or (
+                static.DISABLE_VAD_FOR_PTT
+                and message_type in ["ptt-start", "ptt-end", "ptt-sync"]
+            ):
+                # Manually trigger the RTVI handler since it might not be getting the message
+                try:
+                    await on_client_message(rtvi, message)
+                except Exception as e:
+                    logger.error(f"Error manually routing message to RTVI: {e}")
+
+    @task.event_handler("on_pipeline_finished")
+    async def on_pipeline_finished(task, frame):
+        logger.info("Pipeline task cancelled. Cancelling main task.")
+        main_task = asyncio.current_task()
+        main_task.cancel()
+
+    runner = PipelineRunner()
+
+    async def run_pipeline():
+        try:
+            await runner.run(task)
+        except asyncio.CancelledError:
+            logger.info("Main task cancelled. Exiting gracefully.")
+        except Exception as e:
+            logger.error(f"Pipeline runner error: {e}")
+
+    if static.ENABLE_TRACING:
+        langfuse_client = get_client()
+        tracer = trace.get_tracer(__name__)
+        with tracer.start_as_current_span(conversation_id) as root_span:
+            logger.info(
+                f"Starting current span with conversation ID: {conversation_id}"
+            )
+            root_span.set_attribute("conversation_id", conversation_id)
+            root_span.set_attribute("conversation_type", "voice")
+            root_span.set_attribute("user_name", user_name)
+            root_span.set_attribute("shop_id", args.shop_id)
+            root_span.set_attribute("shop_type", args.shop_type)
+            root_span.set_attribute("shop_url", args.shop_url)
+            root_span.set_attribute("merchant_id", args.merchant_id)
+            root_span.set_attribute("service.name", "breeze-voice-agent")
+            root_span.set_attribute("client_sid", args.client_sid)
+            root_span.set_attribute(
+                "application_logs",
+                generate_open_observer_url_for_session_id(args.client_sid),
+            )
+            langfuse_client.update_current_trace(
+                user_id=args.user_email,
+                session_id=args.session_id,
+                tags=[
+                    (
+                        voice_name.value
+                        if hasattr(voice_name, "value")
+                        else str(voice_name)
+                    )
+                ],
+            )
+
+            # Set Pipecat conversation context for proper tool call nesting
+            provider = ConversationContextProvider.get_instance()
+            provider.set_current_conversation_context(
+                root_span.get_span_context(), conversation_id
+            )
+            logger.info(
+                f"Set Pipecat conversation context with span ID: {root_span.get_span_context().span_id}"
+            )
+
+            await run_pipeline()
+    else:
+        await run_pipeline()

--- a/app/ai/voice/agents/automatic/tools/__init__.py
+++ b/app/ai/voice/agents/automatic/tools/__init__.py
@@ -45,7 +45,7 @@ def initialize_tools(
     :param user_id: The user ID, if available.
     :param user_email: The user email, if available.
     :param reseller_id: The reseller ID, if available.
-    :param meta_ad_account_ids: List of Meta ad account IDs for Meta tool context (BZ-601).
+    :param meta_ad_account_ids: Meta ad account IDs for Meta tools, if available.
     """
     providers = []
     if breeze_token:
@@ -55,9 +55,6 @@ def initialize_tools(
 
     logger.info(f"Initializing tools in '{mode}' mode with providers: {providers}")
     logger.info(f"Shop context: id={shop_id}, url={shop_url}, type={shop_type}")
-    logger.info(
-        f"Meta ad account IDs provided: {len(meta_ad_account_ids) if meta_ad_account_ids else 0}"
-    )
     all_tools = []
     all_tool_functions = {}
 
@@ -112,13 +109,14 @@ def initialize_tools(
             breeze.analytics.shop_type = shop_type
             breeze.analytics.sessionId = session_id
             breeze.analytics.reseller_id = reseller_id
-            # BZ-601: Wire Meta ad account IDs into breeze analytics context so
-            # Meta tools (e.g. get_campaign) have access to the correct account IDs.
             breeze.analytics.meta_ad_account_ids = meta_ad_account_ids or []
             all_tools.extend(breeze.tools.standard_tools)
             all_tool_functions.update(breeze.tool_functions)
             logger.info(
                 f"Loaded {len(breeze.tools.standard_tools)} real-time Breeze analytics tools."
+            )
+            logger.info(
+                f"Meta ad account IDs provided: {len(meta_ad_account_ids or [])}"
             )
         if (
             "breeze" in providers

--- a/app/ai/voice/agents/automatic/tools/__init__.py
+++ b/app/ai/voice/agents/automatic/tools/__init__.py
@@ -45,7 +45,7 @@ def initialize_tools(
     :param user_id: The user ID, if available.
     :param user_email: The user email, if available.
     :param reseller_id: The reseller ID, if available.
-    :param meta_ad_account_ids: Meta ad account IDs for Meta tools, if available.
+    :param meta_ad_account_ids: Meta ad account IDs for Meta tools (e.g. get_campaign).
     """
     providers = []
     if breeze_token:

--- a/app/ai/voice/agents/automatic/tools/__init__.py
+++ b/app/ai/voice/agents/automatic/tools/__init__.py
@@ -1,0 +1,157 @@
+from pipecat.adapters.schemas.tools_schema import ToolsSchema
+
+from app.ai.voice.agents.automatic.tools.utils import filter_tools_by_authorization
+from app.ai.voice.agents.automatic.types import Mode
+from app.core.config.static import (
+    AUTOMATIC_WRITE_ACTIONS_AUTHORIZED_USERS,
+    ENABLE_CHARTS,
+    ENABLE_SEARCH_GROUNDING,
+)
+from app.core.logger import logger
+
+from . import breeze, charts, internet, juspay
+from .dummy import tool_functions as dummy_tool_functions
+from .dummy import tools as dummy_tools
+from .dummy.acme_analytics import acme_tool_functions, acme_tools
+from .system import tool_functions as system_tool_functions
+from .system import tools as system_tools
+
+
+def initialize_tools(
+    mode: str,
+    breeze_token: str | None = None,
+    euler_token: str | None = None,
+    shop_url: str | None = None,
+    shop_id: str | None = None,
+    shop_type: str | None = None,
+    merchant_id: str | None = None,
+    session_id: str | None = None,
+    user_id: str | None = None,
+    user_email: str | None = None,
+    reseller_id: str | None = None,
+    meta_ad_account_ids: list[str] | None = None,
+):
+    """
+    Initializes tools based on the operating mode and available tokens.
+
+    :param mode: The mode of operation, "test" or "live".
+    :param breeze_token: The Breeze token, if available.
+    :param euler_token: The Euler token, if available.
+    :param shop_url: The shop URL, if available.
+    :param shop_id: The shop ID, if available.
+    :param shop_type: The shop type, if available.
+    :param session_id: The client session ID for tool calls (now receives client_sid).
+    :param merchant_id: The merchant ID, if available.
+    :param user_id: The user ID, if available.
+    :param user_email: The user email, if available.
+    :param reseller_id: The reseller ID, if available.
+    :param meta_ad_account_ids: List of Meta ad account IDs for Meta tool context (BZ-601).
+    """
+    providers = []
+    if breeze_token:
+        providers.append("breeze")
+    if euler_token:
+        providers.append("euler")
+
+    logger.info(f"Initializing tools in '{mode}' mode with providers: {providers}")
+    logger.info(f"Shop context: id={shop_id}, url={shop_url}, type={shop_type}")
+    logger.info(
+        f"Meta ad account IDs provided: {len(meta_ad_account_ids) if meta_ad_account_ids else 0}"
+    )
+    all_tools = []
+    all_tool_functions = {}
+
+    # System tools are always available
+    all_tools.extend(system_tools.standard_tools)
+    all_tool_functions.update(system_tool_functions)
+    logger.info(f"Loaded {len(system_tools.standard_tools)} system tools.")
+
+    # Internet tools are available when search grounding is enabled
+    if ENABLE_SEARCH_GROUNDING:
+        all_tools.extend(internet.tools.standard_tools)
+        all_tool_functions.update(internet.tool_functions)
+        logger.info(f"Loaded {len(internet.tools.standard_tools)} internet tools.")
+    else:
+        logger.info("Internet search tools are disabled.")
+
+    if ENABLE_CHARTS:
+        all_tools.extend(charts.generate_ui.standard_tools)
+        all_tool_functions.update(charts.tool_functions)
+        logger.info(f"Loaded {len(charts.tool_functions)} chart tools.")
+
+    # Dummy tools are only available in test mode
+    if mode == Mode.TEST.value:
+        # Check if this is the ACME store demo and load specialized tools
+        if shop_id == "acme-store-demo":
+            all_tools.extend(acme_tools.standard_tools)
+            all_tool_functions.update(acme_tool_functions)
+            logger.info(
+                f"Loaded {len(acme_tools.standard_tools)} ACME analytics tools with time range support."
+            )
+        else:
+            all_tools.extend(dummy_tools.standard_tools)
+            all_tool_functions.update(dummy_tool_functions)
+            logger.info(
+                f"Loaded {len(dummy_tools.standard_tools)} dummy tools for test mode."
+            )
+    else:
+        logger.info("Skipping dummy tools in live mode.")
+        if "euler" in providers:
+            juspay.analytics.euler_token = euler_token
+            juspay.analytics.merchant_id = merchant_id
+            all_tools.extend(juspay.tools.standard_tools)
+            all_tool_functions.update(juspay.tool_functions)
+            logger.info(
+                f"Loaded {len(juspay.tools.standard_tools)} real-time Juspay tools."
+            )
+            logger.info(f"Set merchant_id for Juspay tools: {merchant_id}")
+        if "breeze" in providers and shop_id and shop_url and shop_type:
+            breeze.analytics.breeze_token = breeze_token
+            breeze.analytics.shop_id = shop_id
+            breeze.analytics.shop_url = shop_url
+            breeze.analytics.shop_type = shop_type
+            breeze.analytics.sessionId = session_id
+            breeze.analytics.reseller_id = reseller_id
+            # BZ-601: Wire Meta ad account IDs into breeze analytics context so
+            # Meta tools (e.g. get_campaign) have access to the correct account IDs.
+            breeze.analytics.meta_ad_account_ids = meta_ad_account_ids or []
+            all_tools.extend(breeze.tools.standard_tools)
+            all_tool_functions.update(breeze.tool_functions)
+            logger.info(
+                f"Loaded {len(breeze.tools.standard_tools)} real-time Breeze analytics tools."
+            )
+        if (
+            "breeze" in providers
+            and breeze_token
+            and shop_id
+            and shop_url
+            and merchant_id
+        ):
+            breeze.configuration.shop_id = shop_id
+            breeze.configuration.shop_url = shop_url
+            breeze.configuration.merchant_id = merchant_id
+            breeze.configuration.user_id = user_id or "unknown"
+            breeze.configuration.breeze_token = breeze_token
+            all_tools.extend(breeze.configuration_tools.standard_tools)
+            all_tool_functions.update(breeze.configuration_tool_functions)
+            logger.info(
+                f"Loaded {len(breeze.configuration_tools.standard_tools)} real-time Breeze configuration tools."
+            )
+
+    tools = ToolsSchema(standard_tools=all_tools)
+
+    if AUTOMATIC_WRITE_ACTIONS_AUTHORIZED_USERS:
+        logger.info(f"Total tools before filtering: {len(all_tools)}")
+
+        filtered_tools, filtered_tool_functions = filter_tools_by_authorization(
+            all_tools, all_tool_functions, user_email
+        )
+
+        logger.info(f"Total tools after filtering: {len(filtered_tools)}")
+        return ToolsSchema(standard_tools=filtered_tools), filtered_tool_functions
+
+    logger.info(f"Total tools initialized: {len(all_tools)}")
+    return tools, all_tool_functions
+
+
+__all__ = ["initialize_tools"]

--- a/app/main.py
+++ b/app/main.py
@@ -3,24 +3,35 @@ import json
 import subprocess
 import uuid
 from contextlib import asynccontextmanager
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict
 
 import uvicorn
 from fastapi import Depends, FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import FileResponse, JSONResponse
-from fastapi.staticfiles import StaticFiles
+from fastapi.responses import JSONResponse
 from pipecat.transports.daily.utils import DailyRESTHelper
 
 from app import __version__
-from app.api.routers import automatic, breeze_buddy
-from app.core.config import (
+from app.ai.voice.agents.breeze_buddy.services.agent_router.client import (
+    close_smart_router_client,
+)
+from app.api.routers import automatic, breeze_buddy, devcycle, systems
+
+# Import background task scheduler
+from app.core.background_tasks import BackgroundTaskScheduler
+from app.core.config.dynamic import ENABLE_BACKGROUND_TASKS
+from app.core.config.static import (
+    BACKGROUND_TASKS_LOOP_INTERVAL_SECONDS,
+    BOT_MAX_DRAIN_SECONDS,
+    CORS_ALLOWED_ORIGINS,
     DAILY_API_KEY,
     DAILY_API_URL,
     DAILY_ROOM_MAX_POOL_SIZE,
     DAILY_ROOM_POOL_SIZE,
     ENABLE_AUTOMATIC_DAILY_RECORDING,
+    ENABLE_SIGTERM_HANDLER,
     HOST,
     MAX_DAILY_SESSION_LIMIT,
     PORT,
@@ -34,7 +45,7 @@ from app.core.security.jwt import validate_automatic_request
 from app.core.transport.http_client import create_aiohttp_session
 
 # Database imports
-from app.database import close_db_pool, get_db_connection, init_db_pool
+from app.database import close_db_pool, init_db_pool
 from app.helpers.automatic.daily_room_pool import (
     cleanup_room_pool,
     get_room_pool,
@@ -54,9 +65,21 @@ from app.helpers.automatic.session_manager import (
 from app.schemas import (
     AutomaticVoiceUserConnectRequest,
 )
+from app.services.langfuse.tasks.task import initialize_langfuse_tasks
+from app.services.redis import (
+    close_redis_connections,
+    get_redis_service,
+    is_redis_configured,
+)
 
 # Store Daily API helpers and room pool
 daily_helpers = {}
+
+# Flag to indicate if pod is draining (no new connections accepted)
+_is_draining = False
+
+# Background task scheduler
+_background_scheduler = None
 
 
 async def room_cleanup_callback(session_id: str):
@@ -75,6 +98,22 @@ async def lifespan(_app: FastAPI):
         await init_db_pool()
     except Exception as e:
         logger.error(f"Failed to initialize database: {e}")
+    # Initialize Redis client
+    try:
+        if is_redis_configured():
+            redis_service = await get_redis_service()
+            await redis_service.get_client()  # Initialize the client
+            logger.info("Redis client initialized successfully")
+        else:
+            logger.info("Redis not configured - skipping Redis initialization")
+    except Exception as e:
+        logger.error(f"Failed to initialize Redis client: {e}")
+
+    # DevCycle feature flags are initialized by parent process (run.py) before uvicorn starts
+    # Worker processes only need to read from Redis using get_config()
+    logger.info(
+        "Worker process: DevCycle flags pre-loaded by parent process, reading from Redis"
+    )
 
     # Initialize aiohttp session with proxy support for Daily API
     aiohttp_session = create_aiohttp_session()
@@ -116,9 +155,55 @@ async def lifespan(_app: FastAPI):
     except Exception as e:
         logger.error(f"Failed to initialize voice agent pool: {e}")
 
+    # Start background task scheduler if enabled
+    global _background_scheduler
+    if await ENABLE_BACKGROUND_TASKS():
+        try:
+            # Create scheduler instance with configurable loop interval
+            _background_scheduler = BackgroundTaskScheduler(
+                loop_interval_seconds=BACKGROUND_TASKS_LOOP_INTERVAL_SECONDS
+            )
+
+            # Initialize Langfuse tasks (if configured)
+            await initialize_langfuse_tasks(_background_scheduler)
+
+            ### Register new tasks here
+
+            # Start the scheduler only if tasks are registered
+            if _background_scheduler.tasks:
+                await _background_scheduler.start()
+                logger.info("Background task scheduler started")
+            else:
+                logger.info("No background tasks registered, scheduler not started")
+        except Exception as e:
+            logger.error(f"Failed to start background task scheduler: {e}")
+    else:
+        logger.info(
+            "Background task scheduler disabled (ENABLE_BACKGROUND_TASKS=false)"
+        )
+
     yield
 
     logger.info("Application shutdown event triggered...")
+
+    # Stop background task scheduler if running
+    if _background_scheduler:
+        logger.info("Stopping background task scheduler...")
+        await _background_scheduler.stop()
+
+    # Graceful drain period - wait for active sessions to complete if enabled
+    if ENABLE_SIGTERM_HANDLER and _is_draining:
+        logger.info(
+            f"Drain mode active. Waiting {BOT_MAX_DRAIN_SECONDS}s for active sessions to complete..."
+        )
+        await asyncio.sleep(BOT_MAX_DRAIN_SECONDS)
+        logger.info(
+            f"Drain period ({BOT_MAX_DRAIN_SECONDS}s) complete. Proceeding with cleanup."
+        )
+
+    # Close Smart Router client (release HTTP connection pool)
+    await close_smart_router_client()
+
     # Cleanup room pool
     await cleanup_room_pool()
     # Cleanup voice agent pool
@@ -127,6 +212,8 @@ async def lifespan(_app: FastAPI):
     await cleanup_bot_processes()
     # Close database pool
     await close_db_pool()
+    # Close Redis connections
+    await close_redis_connections()
     # Close aiohttp session
     await aiohttp_session.close()
     logger.info("Aiohttp session closed.")
@@ -137,14 +224,11 @@ app = FastAPI(title="Breeze Automatic Server", version=__version__, lifespan=lif
 # Add CORS middleware
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],  # Allows all origins
+    allow_origins=CORS_ALLOWED_ORIGINS,
     allow_credentials=True,
     allow_methods=["*"],  # Allows all methods
     allow_headers=["*"],  # Allows all headers
 )
-
-# Mount static files directory
-app.mount("/static", StaticFiles(directory="static"), name="static")
 
 app.include_router(
     breeze_buddy.router, prefix="/agent/voice/breeze-buddy", tags=["Breeze Buddy"]
@@ -152,6 +236,10 @@ app.include_router(
 app.include_router(
     automatic.router, prefix="/agent/voice/automatic", tags=["Automatic Agent"]
 )
+app.include_router(devcycle.router, prefix="", tags=["DevCycle"])
+
+# System health endpoints
+app.include_router(systems.router, prefix="", tags=["Systems"])
 
 
 # Pipecat bot endpoint
@@ -188,6 +276,10 @@ async def bot_connect(
         "merchant_id": request.merchantId,
         "platform_integrations": request.platformIntegrations,
         "reseller_id": request.resellerId,
+        "customer_id": request.customerId,
+        "shopify_connected_shop": request.shopifyConnectedShop,
+        # BZ-601: Pass Meta ad account IDs so the voice agent can enrich tool context
+        "meta_ad_account_ids": request.metaAdAccountIds,
     }
 
     # 2. Get room from Daily room pool
@@ -228,6 +320,10 @@ async def bot_connect(
                 **session_params,
             }
 
+            if not voice_process.process.stdin:
+                logger.error("Process stdin is not available")
+                raise RuntimeError("Process stdin is not available")
+
             config_json = json.dumps(session_config) + "\n"
             voice_process.process.stdin.write(config_json.encode("utf-8"))
             await voice_process.process.stdin.drain()
@@ -260,7 +356,7 @@ async def bot_connect(
         )
 
         # 5. Fallback: Launch subprocess directly
-        bot_file = "app.agents.voice.automatic"
+        bot_file = "app.ai.voice.agents.automatic"
         cmd = [
             "python3",
             "-m",
@@ -290,13 +386,22 @@ async def bot_connect(
             "merchant_id": "--merchant-id",
             "platform_integrations": "--platform-integrations",
             "reseller_id": "--reseller-id",
+            "customer_id": "--customer-id",
+            "shopify_connected_shop": "--shopify-connected-shop",
+            "meta_ad_account_ids": "--meta-ad-account-ids",
         }
 
         for key, value in session_params.items():
             if value is not None:
                 arg_name = arg_map.get(key)
+                if arg_name is None:
+                    continue
                 if isinstance(value, list):
-                    cmd.extend([arg_name] + value)
+                    list_values = [str(v) for v in value if v is not None]
+                    if not list_values:
+                        continue
+                    cmd.extend([arg_name, *list_values])
+
                 else:
                     cmd.extend([arg_name, str(value)])
 
@@ -316,61 +421,30 @@ async def bot_connect(
         return {"room_url": room_url, "token": token, "session_id": session_id}
 
 
-# Serve client.html at the root
+# Root endpoint - health check
 @app.get("/")
-async def get_client_html():
-    return FileResponse("static/home.html")
-
-
-# Health check endpoint
-@app.get("/health")
 async def health_check():
-    logger.info("Health check endpoint called")
-    return JSONResponse({"status": "healthy"})
+    """
+    Root endpoint - health check.
+
+    Returns basic service information and status.
+    """
+    return {
+        "service": "Clairvoyance API",
+        "version": __version__,
+        "status": "healthy",
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+    }
 
 
-# Database health check endpoint
-@app.get("/health/database")
-async def database_health_check():
-    """Check database connectivity and health."""
-    logger.info("Database health check endpoint called")
-    try:
-        async for conn in get_db_connection():
-            result = await conn.fetchval("SELECT 1")
-            if result == 1:
-                return JSONResponse(
-                    {
-                        "status": "healthy",
-                        "database": "connected",
-                        "message": "Database connection is healthy",
-                    }
-                )
-            else:
-                return JSONResponse(
-                    status_code=400,
-                    content={
-                        "status": "unhealthy",
-                        "database": "error",
-                        "message": "Database query returned unexpected result",
-                    },
-                )
-    except Exception as e:
-        logger.error(f"Database health check failed: {e}")
-        return JSONResponse(
-            status_code=400,
-            content={
-                "status": "unhealthy",
-                "database": "disconnected",
-                "message": f"Database connection failed: {str(e)}",
-            },
-        )
-
-
-# Version endpoint
-@app.get("/version")
-async def get_version():
-    """Get application version."""
-    return JSONResponse({"version": __version__})
+# Drain endpoint for Kubernetes preStop hook
+@app.get("/drain")
+async def drain():
+    """Called by Kubernetes preStop hook before sending SIGTERM"""
+    global _is_draining
+    logger.info("Drain endpoint called by Kubernetes - marking pod as draining")
+    _is_draining = True
+    return JSONResponse({"status": "draining"})
 
 
 # The main block is now only for direct execution, which is not the recommended way.

--- a/app/main.py
+++ b/app/main.py
@@ -278,7 +278,6 @@ async def bot_connect(
         "reseller_id": request.resellerId,
         "customer_id": request.customerId,
         "shopify_connected_shop": request.shopifyConnectedShop,
-        # BZ-601: Pass Meta ad account IDs so the voice agent can enrich tool context
         "meta_ad_account_ids": request.metaAdAccountIds,
     }
 

--- a/app/schemas/automatic_voice/connection.py
+++ b/app/schemas/automatic_voice/connection.py
@@ -1,0 +1,35 @@
+"""Automatic Voice connection and configuration schemas."""
+
+from typing import List, Optional
+
+from pydantic import BaseModel
+
+from app.ai.voice.agents.automatic.types.models import TTSProvider, VoiceName
+
+
+class AutomaticVoiceTTSServiceConfig(BaseModel):
+    """TTS service configuration for Automatic Voice agent"""
+
+    ttsProvider: TTSProvider
+    voiceName: VoiceName
+
+
+class AutomaticVoiceUserConnectRequest(BaseModel):
+    """User connection request for Automatic Voice agent"""
+
+    sessionId: Optional[str] = None
+    mode: Optional[str] = None
+    eulerToken: Optional[str] = None
+    breezeToken: Optional[str] = None
+    shopUrl: Optional[str] = None
+    shopId: Optional[str] = None
+    shopType: Optional[str] = None
+    userName: Optional[str] = None
+    email: Optional[str] = None
+    ttsService: Optional[AutomaticVoiceTTSServiceConfig] = None
+    merchantId: Optional[str] = None
+    platformIntegrations: Optional[List[str]] = None
+    resellerId: Optional[str] = None
+    customerId: Optional[str] = None
+    shopifyConnectedShop: Optional[str] = None
+    metaAdAccountIds: Optional[List[str]] = None


### PR DESCRIPTION
## JIRA: [BZ-601](https://juspay.atlassian.net/browse/BZ-601)

## What is the problem?
Meta tools like `get_campaign` require `metaAdAccountIds` in the `ToolExecutionContext`. In Chat Mode, `/ai/chat` fetches these and enriches the tool context. In Voice Mode, `metaAdAccountIds` was never passed through the pipeline — causing Meta tools to silently fail during voice conversations.

## Solution
Thread `metaAdAccountIds` through the existing voice mode pipeline by making minimal additions to **4 existing files** — no new files created.

### Changes (existing files only)

| File | Change |
|------|--------|
| `app/schemas/automatic_voice/connection.py` | +1 field: `metaAdAccountIds: Optional[List[str]] = None` to `AutomaticVoiceUserConnectRequest` |
| `app/main.py` | +1 key in `session_params` dict + +1 entry in `arg_map` dict |
| `app/ai/voice/agents/automatic/__init__.py` | +1 argparse `--meta-ad-account-ids` arg + `getattr(args, "meta_ad_account_ids", None) or []` + pass to `initialize_tools()` |
| `app/ai/voice/agents/automatic/tools/__init__.py` | +1 param `meta_ad_account_ids` to `initialize_tools()` + `breeze.analytics.meta_ad_account_ids = meta_ad_account_ids or []` |

### Data flow
```
Lighthouse sends metaAdAccountIds in RTVIClient requestData
  → POST /agent/voice/automatic
  → connection.py schema accepts metaAdAccountIds
  → main.py puts it in session_params (pool mode) + arg_map (subprocess fallback)
  → automatic/__init__.py reads from args, passes to initialize_tools()
  → tools/__init__.py sets breeze.analytics.meta_ad_account_ids
  → Meta tools (get_campaign etc.) now have correct account IDs ✅
```

## Steps for testing / Areas of Impact
1. Start a voice session with a merchant that has META in `platformIntegrations`
2. Verify `metaAdAccountIds` is sent in the POST body to `/agent/voice/automatic`
3. During voice conversation, invoke a Meta tool (e.g. "Get my Meta campaigns")
4. Verify the tool executes successfully (previously would silently fail)
5. Test without META integration — verify `meta_ad_account_ids` defaults to `[]` gracefully

**Impacted areas:** Voice Mode Meta Tools, RTVIClient → Clairvoyance pipeline

## Related PR
- Lighthouse: https://bitbucket.juspay.net/projects/BZ/repos/lighthouse/pull-requests/4579

[BZ-601]: https://juspay.atlassian.net/browse/BZ-601?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ