### PR TITLE
feat: Adding Post Actions, Computed type to Global Functions along with CSV Support

### DIFF
--- a/app/ai/voice/agents/breeze_buddy/agent/__init__.py
+++ b/app/ai/voice/agents/breeze_buddy/agent/__init__.py
@@ -737,6 +737,7 @@ class Agent:
                 transport=self.transport,
                 flow_builder=self.flow_builder,
                 template=self.template,
+                bot_instance=self,
             )
             self._register_event_handlers()
 

--- a/app/ai/voice/agents/breeze_buddy/agent/flow.py
+++ b/app/ai/voice/agents/breeze_buddy/agent/flow.py
@@ -51,6 +51,7 @@ def setup_flow_manager(
     transport: Any,
     flow_builder: FlowConfigBuilder,
     template: TemplateModel,
+    bot_instance: Any = None,
 ) -> FlowManager:
     """Set up the flow manager with global functions.
 
@@ -61,11 +62,14 @@ def setup_flow_manager(
         transport: Transport instance
         flow_builder: Flow config builder
         template: Template model
+        bot_instance: Bot instance for post-action context creation
 
     Returns:
         Configured FlowManager
     """
-    global_functions = flow_builder.build_global_functions(flow=template.flow)
+    global_functions = flow_builder.build_global_functions(
+        flow=template.flow, bot_instance=bot_instance
+    )
     if global_functions:
         logger.info(
             f"Registering {len(global_functions)} global functions with FlowManager"

--- a/app/ai/voice/agents/breeze_buddy/handlers/transport/utils/computed_fields.py
+++ b/app/ai/voice/agents/breeze_buddy/handlers/transport/utils/computed_fields.py
@@ -1,0 +1,148 @@
+"""
+Computed Field Functions for Dynamic Value Resolution
+
+Provides a registry of computed functions that can be used in field resolution
+with source="computed". These functions are pure (no side effects) and return
+string values at invocation time.
+
+Usage in template JSON:
+    "expected_fields": {
+        "from_date": { "source": "computed", "value": "utc_now_minus_hours:1" },
+        "to_date": { "source": "computed", "value": "utc_now" }
+    }
+
+Supported functions:
+    - utc_now: Current UTC time as ISO 8601 string
+    - utc_now_minus_hours:N: UTC time minus N hours (N must be positive integer)
+    - ist_now: Current IST time as ISO 8601 string with timezone
+    - utc_today_start: Start of today in UTC (00:00:00Z)
+    - utc_today_end: End of today in UTC (23:59:59.999Z)
+"""
+
+import inspect
+from datetime import datetime, timedelta, timezone
+from typing import Callable, Dict
+
+from app.core.logger import logger
+
+IST_OFFSET = timezone(timedelta(hours=5, minutes=30))
+
+
+def utc_now() -> str:
+    """Return current UTC time as ISO 8601 string."""
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def utc_now_minus_hours(hours: int) -> str:
+    """Return UTC time minus specified hours as ISO 8601 string."""
+    if hours < 0:
+        raise ValueError(f"hours must be non-negative, got {hours}")
+    result = datetime.now(timezone.utc) - timedelta(hours=hours)
+    return result.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def ist_now() -> str:
+    """Return current IST time as ISO 8601 string with timezone offset."""
+    return datetime.now(IST_OFFSET).strftime("%Y-%m-%dT%H:%M:%S%z")
+
+
+def utc_today_start() -> str:
+    """Return start of today in UTC (00:00:00Z) as ISO 8601 string."""
+    today = datetime.now(timezone.utc).date()
+    return datetime.combine(today, datetime.min.time(), tzinfo=timezone.utc).strftime(
+        "%Y-%m-%dT%H:%M:%SZ"
+    )
+
+
+def utc_today_end() -> str:
+    """Return end of today in UTC (23:59:59.999Z) as ISO 8601 string."""
+    today = datetime.now(timezone.utc).date()
+    end_time = datetime.combine(today, datetime.max.time(), tzinfo=timezone.utc)
+    return end_time.strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "Z"
+
+
+COMPUTED_FUNCTIONS: Dict[str, Callable] = {
+    "utc_now": utc_now,
+    "utc_now_minus_hours": utc_now_minus_hours,
+    "ist_now": ist_now,
+    "utc_today_start": utc_today_start,
+    "utc_today_end": utc_today_end,
+}
+
+
+def resolve_computed_value(expression: str) -> str:
+    """
+    Resolve a computed field expression to its value.
+
+    Expression format: "function_name" or "function_name:arg"
+
+    Args:
+        expression: The computed expression to resolve
+
+    Returns:
+        The computed string value
+
+    Raises:
+        ValueError: If the function is unknown or arguments are invalid
+
+    Examples:
+        resolve_computed_value("utc_now") -> "2026-03-17T10:30:00Z"
+        resolve_computed_value("utc_now_minus_hours:1") -> "2026-03-17T09:30:00Z"
+    """
+    if not expression:
+        raise ValueError("Computed expression cannot be empty")
+
+    if ":" in expression:
+        func_name, arg_str = expression.split(":", 1)
+        func_name = func_name.strip()
+        arg_str = arg_str.strip()
+    else:
+        func_name = expression.strip()
+        arg_str = None
+
+    if func_name not in COMPUTED_FUNCTIONS:
+        available = list(COMPUTED_FUNCTIONS.keys())
+        raise ValueError(
+            f"Unknown computed function: '{func_name}'. "
+            f"Available functions: {available}"
+        )
+
+    func = COMPUTED_FUNCTIONS[func_name]
+
+    # Arity check: verify argument matches function signature
+    sig = inspect.signature(func)
+    params = [
+        p for p in sig.parameters.values() if p.default is inspect.Parameter.empty
+    ]
+    expects_arg = len(params) > 0
+
+    if arg_str is not None and not expects_arg:
+        raise ValueError(
+            f"Function '{func_name}' takes no arguments but got '{arg_str}'"
+        )
+    if arg_str is None and expects_arg:
+        raise ValueError(
+            f"Function '{func_name}' requires an argument but none provided"
+        )
+
+    try:
+        if arg_str is not None:
+            if func_name == "utc_now_minus_hours":
+                try:
+                    hours = int(arg_str)
+                    result = func(hours)
+                except ValueError as e:
+                    raise ValueError(
+                        f"Invalid argument for '{func_name}': expected integer, got '{arg_str}'"
+                    ) from e
+            else:
+                result = func(arg_str)
+        else:
+            result = func()
+
+        logger.debug(f"Resolved computed expression '{expression}' -> '{result}'")
+        return result
+
+    except Exception as e:
+        logger.error(f"Error resolving computed expression '{expression}': {e}")
+        raise

--- a/app/ai/voice/agents/breeze_buddy/handlers/transport/utils/field_resolver.py
+++ b/app/ai/voice/agents/breeze_buddy/handlers/transport/utils/field_resolver.py
@@ -2,7 +2,7 @@
 Field Resolver for Hooks and Global Functions
 
 Resolves field values from different sources for hooks and global HTTP functions.
-Supports simplified field resolution with STATIC and LLM sources only.
+Supports field resolution with STATIC, LLM, and COMPUTED sources.
 
 Example:
     # Static value (literal)
@@ -16,11 +16,18 @@ Example:
     # LLM value
     config = FieldConfig(source="llm", value="order_id")
     resolver.resolve_value(config)  # Returns args["order_id"]
+
+    # Computed value (dynamic at invocation time)
+    config = FieldConfig(source="computed", value="utc_now_minus_hours:1")
+    resolver.resolve_value(config)  # Returns "2026-03-17T09:30:00Z"
 """
 
 import re
 from typing import Any, Dict, List, Optional
 
+from app.ai.voice.agents.breeze_buddy.handlers.transport.utils.computed_fields import (
+    resolve_computed_value,
+)
 from app.ai.voice.agents.breeze_buddy.template.context import TemplateContext
 from app.ai.voice.agents.breeze_buddy.template.types import (
     FieldConfig,
@@ -133,10 +140,12 @@ class FieldResolver:
             return self._resolve_static(config)
         elif config.source == FieldSource.LLM:
             return self._resolve_llm(config, field_name=field_name)
+        elif config.source == FieldSource.COMPUTED:
+            return self._resolve_computed(config)
         else:
             raise ValueError(
                 f"Unsupported field source: {config.source}. "
-                f"Only STATIC and LLM sources are supported."
+                f"Supported sources: STATIC, LLM, COMPUTED."
             )
 
     def resolve_dict(self, template: Dict[str, Any]) -> Dict[str, Any]:
@@ -246,3 +255,43 @@ class FieldResolver:
             logger.debug(f"Resolved LLM field '{arg_name}' successfully")
 
         return value
+
+    def _resolve_computed(self, config: FieldConfig) -> str:
+        """
+        Resolve a computed value that is dynamically generated at invocation time.
+
+        Computed values use a function expression syntax:
+            - "utc_now" -> current UTC timestamp
+            - "utc_now_minus_hours:1" -> UTC timestamp minus 1 hour
+            - "ist_now" -> current IST timestamp
+
+        Args:
+            config: Field configuration where config.value is the computed expression
+
+        Returns:
+            The computed string value
+
+        Raises:
+            ValueError: If the computed expression is invalid or function is unknown
+        """
+        expression = config.value
+
+        if not expression:
+            raise ValueError(
+                "COMPUTED source requires a 'value' field with the function expression"
+            )
+
+        if not isinstance(expression, str):
+            raise ValueError(
+                f"COMPUTED source value must be a string expression, got {type(expression).__name__}"
+            )
+
+        logger.debug(f"Resolving COMPUTED field with expression: '{expression}'")
+
+        try:
+            result = resolve_computed_value(expression)
+            logger.debug(f"Resolved COMPUTED expression '{expression}' -> '{result}'")
+            return result
+        except ValueError as e:
+            logger.error(f"Failed to resolve COMPUTED expression '{expression}': {e}")
+            raise

--- a/app/ai/voice/agents/breeze_buddy/services/inbound_policy.py
+++ b/app/ai/voice/agents/breeze_buddy/services/inbound_policy.py
@@ -249,7 +249,7 @@ async def log_blocked_call(
             template_id=template_id,
             merchant_id=merchant_id,
             next_attempt_at=None,
-            payload=None,
+            payload={"customer_mobile_number": from_number},
             meta_data=meta_data,
             call_initiated_time=datetime.now(),
             call_end_time=datetime.now(),

--- a/app/ai/voice/agents/breeze_buddy/template/builder.py
+++ b/app/ai/voice/agents/breeze_buddy/template/builder.py
@@ -145,7 +145,9 @@ class FlowConfigBuilder:
             "expected_callback_response_schema": template.expected_callback_response_schema,
         }
 
-    def build_global_functions(self, flow: Dict[str, Any]) -> List[FlowsFunctionSchema]:
+    def build_global_functions(
+        self, flow: Dict[str, Any], bot_instance: Any = None
+    ) -> List[FlowsFunctionSchema]:
         """
         Build global functions from template flow config using registered adapters.
 
@@ -159,13 +161,16 @@ class FlowConfigBuilder:
 
         Args:
             flow: Flow configuration dict containing optional 'global_functions' array
+            bot_instance: Bot instance for post-action context creation
 
         Returns:
             List of FlowsFunctionSchema objects to pass to FlowManager(global_functions=[...])
         """
         # Pass entire handler_map - each adapter will pick the handler it needs
         # All handlers are already wrapped with with_context(bot_instance) in agent.py
-        return GlobalFunctionRegistry.build(flow, handler_map=self.handler_map)
+        return GlobalFunctionRegistry.build(
+            flow, handler_map=self.handler_map, bot_instance=bot_instance
+        )
 
     def _build_node(self, node: FlowNodeModel) -> NodeConfig:
         """

--- a/app/ai/voice/agents/breeze_buddy/template/func_action_handlers.py
+++ b/app/ai/voice/agents/breeze_buddy/template/func_action_handlers.py
@@ -1,0 +1,176 @@
+"""
+Function-level pre/post action handlers for global functions.
+
+This module maintains all func_pre_action and func_post_action handlers in one place.
+Each handler receives (context, response_data, action_args) and performs
+a side-effect (e.g., updating payload in DB).
+"""
+
+import re
+from typing import Any, Callable, Dict, List
+
+from app.ai.voice.agents.breeze_buddy.handlers.transport.utils.field_resolver import (
+    replace_placeholders,
+)
+from app.ai.voice.agents.breeze_buddy.template.context import TemplateContext
+from app.ai.voice.agents.breeze_buddy.template.types import FlowAction
+from app.core.logger import logger
+from app.database.accessor.breeze_buddy.lead_call_tracker import update_lead_payload
+
+# ---------------------------------------------------------------------------
+# Post-action handler registry
+# ---------------------------------------------------------------------------
+
+FUNC_POST_ACTION_HANDLERS: Dict[str, Callable] = {}
+
+
+async def _handle_update_payload(
+    context: TemplateContext,
+    response_data: Dict[str, Any],
+    action_args: Dict[str, Any],
+) -> None:
+    """
+    Post-action handler that updates lead payload fields from API response data.
+
+    Resolves field_mapping templates against response data and persists the
+    resolved values to lead_call_tracker.payload (JSON merge), context.lead.payload
+    (in-memory), and context.bot.template_vars (for template variable substitution).
+
+    Args:
+        context: TemplateContext with access to lead and bot
+        response_data: The 'data' field from the API response
+        action_args: Must contain 'field_mapping' dict, e.g.
+                     {"customer_name": "{firstName} {lastName}"}
+    """
+    field_mapping = action_args.get("field_mapping")
+    if not field_mapping:
+        logger.warning("update_payload post-action called without field_mapping")
+        return
+
+    # Flatten response data for placeholder resolution.
+    # response_data is the raw API response body (already parsed JSON).
+    if not isinstance(response_data, dict):
+        logger.warning(
+            f"update_payload: response_data is not a dict, got {type(response_data)}"
+        )
+        return
+
+    # Filter out None values from response data so placeholders for missing
+    # fields remain unresolved (e.g. {lastName} stays as-is when lastName is null)
+    clean_data = {k: v for k, v in response_data.items() if v is not None}
+
+    # Resolve each field_mapping template against response data
+    resolved: Dict[str, Any] = {}
+    for field_name, template in field_mapping.items():
+        if isinstance(template, str):
+            resolved_value = replace_placeholders(template, clean_data)
+            # Strip any remaining unreplaced {placeholder} tokens (field was None)
+            resolved_value = re.sub(r"\{[^}]+\}", "", resolved_value).strip()
+            if not resolved_value:
+                logger.info(
+                    f"update_payload: skipping field '{field_name}' — "
+                    f"all placeholders resolved to None"
+                )
+                continue
+            resolved[field_name] = resolved_value
+        else:
+            # Non-string values are passed through as-is
+            resolved[field_name] = template
+
+    if not resolved:
+        logger.warning("update_payload: no fields resolved from field_mapping")
+        return
+
+    logger.info(f"update_payload: resolved fields: {list(resolved.keys())}")
+
+    # 1. Update in-memory payload on context.lead
+    lead = context.lead
+    if lead and lead.payload:
+        lead.payload.update(resolved)
+    elif lead:
+        lead.payload = resolved
+
+    # 2. Update template_vars so {customer_name} substitution works immediately
+    context.bot.template_vars.update(resolved)
+
+    # 3. Persist to DB
+    if lead and lead.id:
+        await update_lead_payload(lead.id, resolved)
+
+
+# Register the update_payload handler
+FUNC_POST_ACTION_HANDLERS["update_payload"] = _handle_update_payload
+
+
+# ---------------------------------------------------------------------------
+# Post-action execution engine
+# ---------------------------------------------------------------------------
+
+
+async def execute_func_post_actions(
+    bot_instance: Any,
+    result: Any,
+    post_actions: List[FlowAction],
+    function_name: str,
+) -> None:
+    """
+    Execute func_post_actions for a global function in a fire-and-forget manner.
+
+    Only executes when the function response indicates success.
+    Errors are logged but never propagated.
+
+    Args:
+        bot_instance: Bot instance for creating TemplateContext
+        result: The (response_dict, None) tuple returned by the handler
+        post_actions: List of FlowAction configs to execute
+        function_name: Name of the global function (for logging)
+    """
+    try:
+        # Unpack the result tuple — handlers return (response_dict, None)
+        response = result[0] if isinstance(result, tuple) else result
+
+        # Only execute post-actions on success
+        if not isinstance(response, dict) or response.get("status") != "success":
+            logger.debug(
+                f"Skipping func_post_actions for '{function_name}': "
+                f"response status is not 'success'"
+            )
+            return
+
+        context = TemplateContext(bot_instance)
+
+        for action in post_actions:
+            if action.type != "function":
+                logger.warning(
+                    f"Unsupported func_post_action type '{action.type}' "
+                    f"for global function '{function_name}'"
+                )
+                continue
+
+            handler_name = action.handler
+            if not handler_name:
+                logger.warning(
+                    f"func_post_action for '{function_name}' has no handler specified"
+                )
+                continue
+
+            handler = FUNC_POST_ACTION_HANDLERS.get(handler_name)
+            if not handler:
+                logger.warning(
+                    f"func_post_action handler '{handler_name}' not found in "
+                    f"FUNC_POST_ACTION_HANDLERS for function '{function_name}'. "
+                    f"Available: {list(FUNC_POST_ACTION_HANDLERS.keys())}"
+                )
+                continue
+
+            logger.info(
+                f"Executing func_post_action '{handler_name}' "
+                f"for global function '{function_name}'"
+            )
+            await handler(context, response.get("data", {}), action.args or {})
+
+    except Exception as e:
+        logger.error(
+            f"Error executing func_post_actions for global function '{function_name}': {e}",
+            exc_info=True,
+        )

--- a/app/ai/voice/agents/breeze_buddy/template/global_function.py
+++ b/app/ai/voice/agents/breeze_buddy/template/global_function.py
@@ -10,10 +10,14 @@ The adapters follow the same context injection pattern as normal functions:
 - This eliminates the need for _bot_instance storage in flow_manager.state
 """
 
+import asyncio
 from typing import Any, Callable, Dict, List, Optional, Protocol, runtime_checkable
 
 from pipecat_flows import FlowsFunctionSchema
 
+from app.ai.voice.agents.breeze_buddy.template.func_action_handlers import (
+    execute_func_post_actions,
+)
 from app.ai.voice.agents.breeze_buddy.template.types import (
     GlobalBuiltinFunction,
     GlobalFunctionType,
@@ -62,6 +66,7 @@ class GlobalFunctionAdapter(Protocol):
         self,
         config: Dict[str, Any],
         wrapped_handler: Callable,
+        bot_instance: Any = None,
     ) -> FlowsFunctionSchema:
         """
         Build a FlowsFunctionSchema from the config.
@@ -69,6 +74,7 @@ class GlobalFunctionAdapter(Protocol):
         Args:
             config: Raw function configuration dict
             wrapped_handler: Handler already wrapped with with_context(bot_instance)
+            bot_instance: Bot instance for creating TemplateContext in func_post_actions
 
         Returns:
             FlowsFunctionSchema ready for FlowManager
@@ -125,6 +131,7 @@ class HttpGlobalFunctionAdapter:
         self,
         config: Dict[str, Any],
         wrapped_handler: Callable,
+        bot_instance: Any = None,
     ) -> FlowsFunctionSchema:
         """
         Build FlowsFunctionSchema for HTTP global function.
@@ -132,6 +139,7 @@ class HttpGlobalFunctionAdapter:
         Args:
             config: Raw function configuration dict
             wrapped_handler: http_function_handler wrapped with with_context(bot_instance)
+            bot_instance: Bot instance for creating TemplateContext in func_post_actions
 
         Returns:
             FlowsFunctionSchema with handler that passes function_config via kwargs
@@ -153,7 +161,9 @@ class HttpGlobalFunctionAdapter:
 
         # Create outer wrapper that passes function_config via kwargs
         # This follows the same pattern as normal functions passing transition_to, hooks, etc.
-        def create_wrapper(captured_func: GlobalHttpFunction):
+        def create_wrapper(
+            captured_func: GlobalHttpFunction, captured_bot_instance: Any
+        ):
             async def wrapper_handler(llm_args, flow_manager):
                 """
                 Outer wrapper for global HTTP function.
@@ -162,17 +172,27 @@ class HttpGlobalFunctionAdapter:
                 via kwargs. The with_context wrapper will extract function_config and
                 pass it to http_function_handler.
                 """
-                return await wrapped_handler(
+                result = await wrapped_handler(
                     llm_args,
                     function_config=captured_func,
                 )
+                if captured_func.func_post_actions and captured_bot_instance:
+                    asyncio.create_task(
+                        execute_func_post_actions(
+                            captured_bot_instance,
+                            result,
+                            captured_func.func_post_actions,
+                            captured_func.name,
+                        )
+                    )
+                return result
 
             return wrapper_handler
 
         return FlowsFunctionSchema(
             name=func.name,
             description=enhanced_description,
-            handler=create_wrapper(func),
+            handler=create_wrapper(func, bot_instance),
             properties=func.properties,
             required=func.required,
         )
@@ -217,6 +237,7 @@ class BuiltinGlobalFunctionAdapter:
         self,
         config: Dict[str, Any],
         wrapped_handler: Callable,
+        bot_instance: Any = None,
     ) -> FlowsFunctionSchema:
         """
         Build FlowsFunctionSchema for a built-in global function.
@@ -224,6 +245,7 @@ class BuiltinGlobalFunctionAdapter:
         Args:
             config: Raw function configuration dict with 'handler' field
             wrapped_handler: builtin_function_dispatcher wrapped with with_context
+            bot_instance: Bot instance for creating TemplateContext in func_post_actions
 
         Returns:
             FlowsFunctionSchema with handler that passes function_config to dispatcher
@@ -240,7 +262,9 @@ class BuiltinGlobalFunctionAdapter:
             f"Building builtin global function: {func.name}, handler={func.handler}"
         )
 
-        def create_wrapper(captured_func: GlobalBuiltinFunction):
+        def create_wrapper(
+            captured_func: GlobalBuiltinFunction, captured_bot_instance: Any
+        ):
             async def wrapper_handler(llm_args, flow_manager):
                 """
                 Outer wrapper for built-in global function.
@@ -249,17 +273,27 @@ class BuiltinGlobalFunctionAdapter:
                 The with_context wrapper extracts function_config and passes
                 it to builtin_function_dispatcher.
                 """
-                return await wrapped_handler(
+                result = await wrapped_handler(
                     llm_args,
                     function_config=captured_func,
                 )
+                if captured_func.func_post_actions and captured_bot_instance:
+                    asyncio.create_task(
+                        execute_func_post_actions(
+                            captured_bot_instance,
+                            result,
+                            captured_func.func_post_actions,
+                            captured_func.name,
+                        )
+                    )
+                return result
 
             return wrapper_handler
 
         return FlowsFunctionSchema(
             name=func.name,
             description=enhanced_description,
-            handler=create_wrapper(func),
+            handler=create_wrapper(func, bot_instance),
             properties=func.properties,
             required=func.required,
         )
@@ -322,6 +356,7 @@ class GlobalFunctionRegistry:
         cls,
         flow: Dict[str, Any],
         handler_map: Dict[str, Callable],
+        bot_instance: Any = None,
     ) -> List[FlowsFunctionSchema]:
         """
         Build all global functions from flow config using registered adapters.
@@ -334,6 +369,7 @@ class GlobalFunctionRegistry:
             handler_map: Dictionary mapping handler names to wrapped handlers.
                         Handlers should already be wrapped with with_context(bot_instance).
                         Example: {"http_function_handler": wrapped_http_handler, ...}
+            bot_instance: Bot instance for creating TemplateContext in func_post_actions
 
         Returns:
             List of FlowsFunctionSchema objects to pass to FlowManager
@@ -348,7 +384,7 @@ class GlobalFunctionRegistry:
         result: List[FlowsFunctionSchema] = []
 
         for func_config in global_functions_config:
-            schema = cls._build_one(func_config, handler_map)
+            schema = cls._build_one(func_config, handler_map, bot_instance)
             if schema:
                 result.append(schema)
 
@@ -360,6 +396,7 @@ class GlobalFunctionRegistry:
         cls,
         func_config: Dict[str, Any],
         handler_map: Dict[str, Callable],
+        bot_instance: Any = None,
     ) -> Optional[FlowsFunctionSchema]:
         """
         Build a single global function using matching adapter.
@@ -367,6 +404,7 @@ class GlobalFunctionRegistry:
         Args:
             func_config: Raw function configuration from template JSON
             handler_map: Dictionary of handler_name -> wrapped_handler
+            bot_instance: Bot instance for creating TemplateContext in func_post_actions
 
         Returns:
             FlowsFunctionSchema or None if no adapter found or build failed
@@ -384,7 +422,9 @@ class GlobalFunctionRegistry:
                     return None
 
                 try:
-                    return adapter.build_schema(func_config, handler)
+                    return adapter.build_schema(
+                        func_config, handler, bot_instance=bot_instance
+                    )
                 except Exception as e:
                     logger.error(
                         f"Failed to build global function from config: {str(e)}",

--- a/app/ai/voice/agents/breeze_buddy/template/hooks.py
+++ b/app/ai/voice/agents/breeze_buddy/template/hooks.py
@@ -15,6 +15,9 @@ from typing import Any, Dict, Optional
 from app.ai.voice.agents.breeze_buddy.handlers.transport.http_requester import (
     HttpRequestExecutor,
 )
+from app.ai.voice.agents.breeze_buddy.handlers.transport.utils.computed_fields import (
+    resolve_computed_value,
+)
 from app.ai.voice.agents.breeze_buddy.handlers.transport.utils.field_resolver import (
     FieldResolver,
 )
@@ -129,14 +132,12 @@ class UpdateOutcomeInDatabaseHook(Hook):
         if expected_fields:
             for field_name, field_config in expected_fields.items():
                 if field_config.source == FieldSource.STATIC:
-                    # Use the enforced value from configuration
                     final_data[field_name] = field_config.value
                     logger.debug(
                         f"Field '{field_name}': using enforced value '{field_config.value}' "
                         f"for function '{function_name}'"
                     )
                 elif field_config.source == FieldSource.LLM:
-                    # Use the value from LLM arguments
                     value = args.get(field_name)
                     if value is not None:
                         final_data[field_name] = value
@@ -148,6 +149,25 @@ class UpdateOutcomeInDatabaseHook(Hook):
                         logger.warning(
                             f"Field '{field_name}': type is 'llm' but no value found in args "
                             f"for function '{function_name}'. Args: {args}"
+                        )
+                elif field_config.source == FieldSource.COMPUTED:
+                    if field_config.value:
+                        try:
+                            computed_value = resolve_computed_value(field_config.value)
+                            final_data[field_name] = computed_value
+                            logger.debug(
+                                f"Field '{field_name}': using computed value '{computed_value}' "
+                                f"for function '{function_name}'"
+                            )
+                        except ValueError as e:
+                            logger.error(
+                                f"Field '{field_name}': failed to resolve computed value "
+                                f"'{field_config.value}' for function '{function_name}': {e}"
+                            )
+                    else:
+                        logger.warning(
+                            f"Field '{field_name}': COMPUTED source requires 'value' field "
+                            f"for function '{function_name}'"
                         )
         else:
             # Fallback to old behavior if no expected_fields provided
@@ -211,6 +231,17 @@ class UpdateOutcomeInDatabaseHook(Hook):
                 logger.debug(
                     f"No additional properties found in final data for lead {context.lead.id}"
                 )
+
+            # Guard: if a transfer is in progress, preserve "transferred" outcome
+            # instead of the LLM's value (e.g., "RESOLVED") to avoid a race
+            # condition with handle_call_completion's transfer override.
+            if meta_data.get("transfer", {}).get("status") == "success":
+                logger.info(
+                    f"Transfer detected for lead {context.lead.id}. "
+                    f"Overriding outcome from '{outcome}' to 'transferred' "
+                    f"(function: '{function_name}')"
+                )
+                outcome = "transferred"
 
             # Update lead in database with outcome
             logger.info(

--- a/app/ai/voice/agents/breeze_buddy/template/types.py
+++ b/app/ai/voice/agents/breeze_buddy/template/types.py
@@ -274,10 +274,12 @@ class FieldSource(str, Enum):
     Used by both hooks (fire-and-forget) and global HTTP functions (wait for response).
     - STATIC: Value is a literal or contains {template_var} placeholders
     - LLM: Value comes from LLM function arguments
+    - COMPUTED: Value is dynamically computed at invocation time (e.g., timestamps)
     """
 
     STATIC = "static"
     LLM = "llm"
+    COMPUTED = "computed"
 
 
 class HttpMethod(str, Enum):
@@ -332,12 +334,13 @@ class FieldConfig(BaseModel):
     """Configuration for a single field in hooks or global HTTP functions.
 
     Defines how to resolve a field value:
-    - source: Where the value comes from (STATIC or LLM)
+    - source: Where the value comes from (STATIC, LLM, or COMPUTED)
     - value: For STATIC, the literal value or {template_var} placeholder.
              For LLM, the name of the argument from LLM function call.
+             For COMPUTED, the function expression (e.g., "utc_now_minus_hours:1").
     """
 
-    source: FieldSource  # "static" or "llm"
+    source: FieldSource
     value: Optional[Any] = None
 
 
@@ -370,13 +373,21 @@ class BaseGlobalFunction(BaseModel):
     """Base model for all global function types.
 
     Subclasses should define their specific configuration fields.
+
+    Note: func_pre_actions / func_post_actions use aliases so that existing
+    JSON templates with 'pre_actions' / 'post_actions' keys on global functions
+    continue to work. In Python code, always use the func_ prefixed names.
     """
+
+    model_config = ConfigDict(populate_by_name=True)
 
     type: GlobalFunctionType
     name: str
     description: str
     properties: Dict[str, Any] = {}
     required: List[str] = []
+    func_pre_actions: List[FlowAction] = Field(default=[], alias="pre_actions")
+    func_post_actions: List[FlowAction] = Field(default=[], alias="post_actions")
 
 
 class GlobalHttpFunction(BaseGlobalFunction):

--- a/app/api/routers/breeze_buddy/analytics/__init__.py
+++ b/app/api/routers/breeze_buddy/analytics/__init__.py
@@ -15,6 +15,7 @@ from app.schemas import (
 )
 
 from .handlers import (
+    download_call_details,
     get_call_based_analytics,
     get_call_details_analytics,
     get_conversion_analytics,
@@ -28,7 +29,11 @@ from .rbac import apply_hierarchical_filters
 router = APIRouter()
 
 
-@router.post("/analytics", response_model=AnalyticsResponse)
+@router.post(
+    "/analytics",
+    response_model=AnalyticsResponse,
+    responses={200: {"content": {"text/csv": {}}}},
+)
 async def get_analytics(
     request: AnalyticsRequest,
     current_user: UserInfo = Depends(get_current_user_with_rbac),
@@ -82,6 +87,8 @@ async def get_analytics(
             data = await get_call_based_analytics(filters, options, current_user)
         elif request.type == AnalyticsType.CALL_DETAILS:
             data = await get_call_details_analytics(filters, options, current_user)
+        elif request.type == AnalyticsType.CALL_DETAILS_DOWNLOAD:
+            return await download_call_details(filters, options, current_user)
         elif request.type == AnalyticsType.LEAD_BASED:
             data = await get_lead_based_analytics(filters, options, current_user)
         elif request.type == AnalyticsType.LEAD_STATUS_COUNTS:

--- a/app/api/routers/breeze_buddy/analytics/handlers.py
+++ b/app/api/routers/breeze_buddy/analytics/handlers.py
@@ -3,12 +3,17 @@ Analytics handlers for different analytics types.
 All handlers use database-level filtering for optimal scalability.
 """
 
+import csv
+import io
 import json
 from datetime import datetime, timedelta
 from typing import Any, Dict
 
+from starlette.responses import StreamingResponse
+
 from app.database.accessor.breeze_buddy.analytics import (
     get_analytics_count_from_db,
+    get_call_detail_records,
     get_call_details_from_db,
     get_inbound_count_from_db,
     get_lead_based_analytics_from_db,
@@ -180,7 +185,7 @@ async def get_call_details_analytics(
     """
     page = options.get("page", 1)
     limit = options.get("limit", 50)
-    sort_by = options.get("sort_by", "created_at")
+    sort_by = options.get("sort_by", "call_initiated_time")
     sort_order = options.get("sort_order", "desc")
 
     offset = (page - 1) * limit
@@ -756,3 +761,116 @@ async def get_lead_status_counts(
         "pagination": result["pagination"],
         "results": formatted_results,
     }
+
+
+async def download_call_details(
+    filters: Dict[str, Any], options: Dict[str, Any], current_user: UserInfo
+) -> StreamingResponse:
+    """
+    Generate a CSV file download of all call details matching the filters.
+    Returns a StreamingResponse that streams CSV rows in batches to avoid
+    loading the entire result set into memory.
+    """
+    sort_by = options.get("sort_by", "call_initiated_time")
+    sort_order = options.get("sort_order", "desc")
+
+    BATCH_SIZE = 1000
+
+    async def generate_csv():
+        output = io.StringIO()
+        writer = csv.writer(output)
+
+        # Write header row
+        headers = [
+            "Call ID",
+            "Lead ID",
+            "Template",
+            "Driver Name",
+            "Caller Number",
+            "Start Time",
+            "End Time",
+            "Duration (seconds)",
+            "Outcome",
+        ]
+        writer.writerow(headers)
+        yield output.getvalue()
+        output.seek(0)
+        output.truncate(0)
+
+        offset = 0
+        while True:
+            trackers = await get_call_detail_records(
+                filters=filters,
+                sort_by=sort_by,
+                sort_order=sort_order,
+                limit=BATCH_SIZE,
+                offset=offset,
+            )
+
+            if not trackers:
+                break
+
+            for tracker in trackers:
+                payload = parse_json(tracker, "payload")
+
+                # Calculate duration
+                duration = None
+                if tracker.get("call_initiated_time") and tracker.get("call_end_time"):
+                    duration = int(
+                        (
+                            tracker["call_end_time"] - tracker["call_initiated_time"]
+                        ).total_seconds()
+                    )
+
+                # Format timestamps
+                start_time = (
+                    tracker["call_initiated_time"].strftime("%Y-%m-%d %H:%M:%S")
+                    if tracker.get("call_initiated_time")
+                    else ""
+                )
+                end_time = (
+                    tracker["call_end_time"].strftime("%Y-%m-%d %H:%M:%S")
+                    if tracker.get("call_end_time")
+                    else ""
+                )
+
+                # Extract caller number from payload
+                caller_number = ""
+                if payload:
+                    caller_number = (
+                        payload.get("customer_mobile_number")
+                        or payload.get("phone")
+                        or ""
+                    )
+
+                writer.writerow(
+                    [
+                        tracker.get("call_id", ""),
+                        tracker.get("id", ""),
+                        tracker.get("template", ""),
+                        payload.get("customer_name", "") if payload else "",
+                        caller_number,
+                        start_time,
+                        end_time,
+                        duration if duration is not None else "",
+                        tracker.get("outcome") or "N/A",
+                    ]
+                )
+
+            yield output.getvalue()
+            output.seek(0)
+            output.truncate(0)
+
+            if len(trackers) < BATCH_SIZE:
+                break
+
+            offset += BATCH_SIZE
+
+    # Generate filename with current date
+    filename = f"call_details_{datetime.now().strftime('%Y-%m-%d')}.csv"
+
+    return StreamingResponse(
+        generate_csv(),
+        media_type="text/csv",
+        headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+    )

--- a/app/database/accessor/breeze_buddy/analytics.py
+++ b/app/database/accessor/breeze_buddy/analytics.py
@@ -18,6 +18,7 @@ from app.database.queries.breeze_buddy.analytics import (
     get_analytics_outbound_numbers_query,
     get_analytics_summary_query,
     get_analytics_trends_query,
+    get_call_details_records_query,
 )
 
 
@@ -158,6 +159,38 @@ async def get_call_details_from_db(
 
     except Exception as e:
         logger.error(f"Error getting call details: {e}", exc_info=True)
+        raise
+
+
+async def get_call_detail_records(
+    filters: Dict[str, Any],
+    sort_by: str = "call_initiated_time",
+    sort_order: str = "desc",
+    limit: int = 0,
+    offset: int = 0,
+) -> List[Dict[str, Any]]:
+    """
+    Get call details matching filters for CSV download.
+    When limit > 0, fetches a single batch (for streaming).
+    When limit == 0, fetches all matching records.
+
+    Returns:
+        List of matching call detail records
+    """
+    logger.info(f"[Analytics DB] Getting call details download with filters: {filters}")
+
+    try:
+        query_text, values = get_call_details_records_query(
+            filters, sort_by, sort_order, limit, offset
+        )
+        result = await run_parameterized_query(query_text, values)
+        logger.info(
+            f"[Analytics DB] Call details download returned {len(result) if result else 0} records"
+        )
+        return [dict(row) for row in result] if result else []
+
+    except Exception as e:
+        logger.error(f"Error getting call details download: {e}", exc_info=True)
         raise
 
 

--- a/app/database/accessor/breeze_buddy/lead_call_tracker.py
+++ b/app/database/accessor/breeze_buddy/lead_call_tracker.py
@@ -28,6 +28,7 @@ from app.database.queries.breeze_buddy.lead_call_tracker import (
     update_lead_call_initiated_time_by_id_query,
     update_lead_call_initiated_time_query,
     update_lead_call_recording_url_query,
+    update_lead_payload_query,
 )
 from app.schemas import (
     CallDirection,
@@ -542,4 +543,33 @@ async def handle_lead_abort(
 
     except Exception as e:
         logger.error(f"Error aborting lead {lead_id}: {e}")
+        return None
+
+
+async def update_lead_payload(
+    lead_id: str, payload_updates: Dict[str, Any]
+) -> Optional[LeadCallTracker]:
+    """
+    Update specific fields in the payload JSON column for a lead.
+    Merges the provided updates into the existing payload without
+    overwriting other fields.
+    """
+    logger.info(
+        f"Updating lead payload for ID: {lead_id}, keys: {list(payload_updates.keys())}"
+    )
+
+    try:
+        query_text, values = update_lead_payload_query(lead_id, payload_updates)
+        result = await run_parameterized_query(query_text, values)
+
+        if result and get_row_count(result) > 0:
+            decoded_result = decode_lead_call_tracker(result[0])
+            logger.info(f"Lead payload updated successfully for ID: {lead_id}")
+            return decoded_result
+
+        logger.error(f"Failed to update lead payload for ID: {lead_id}")
+        return None
+
+    except Exception as e:
+        logger.error(f"Error updating lead payload for ID {lead_id}: {e}")
         return None

--- a/app/database/queries/breeze_buddy/analytics.py
+++ b/app/database/queries/breeze_buddy/analytics.py
@@ -326,7 +326,7 @@ def get_analytics_call_details_query(
     filters: Dict[str, Any],
     limit: int = 50,
     offset: int = 0,
-    sort_by: str = "created_at",
+    sort_by: str = "call_initiated_time",
     sort_order: str = "desc",
 ) -> Tuple[str, List[Any]]:
     """
@@ -348,9 +348,9 @@ def get_analytics_call_details_query(
     ]
     if sort_by not in allowed_sort_columns:
         logger.warning(
-            f"[Analytics Query] Invalid sort column '{sort_by}', defaulting to 'created_at'"
+            f"[Analytics Query] Invalid sort column '{sort_by}', defaulting to 'call_initiated_time'"
         )
-        sort_by = "created_at"
+        sort_by = "call_initiated_time"
 
     sort_direction = "DESC" if sort_order.lower() == "desc" else "ASC"
 
@@ -367,6 +367,60 @@ def get_analytics_call_details_query(
     """
 
     values.extend([limit, offset])
+
+    return text, values
+
+
+def get_call_details_records_query(
+    filters: Dict[str, Any],
+    sort_by: str = "call_initiated_time",
+    sort_order: str = "desc",
+    limit: int = 0,
+    offset: int = 0,
+) -> Tuple[str, List[Any]]:
+    """
+    Generate query for call details download.
+    When limit > 0, applies LIMIT/OFFSET for batched streaming.
+    When limit == 0, returns all matching records.
+    """
+    conditions, values = build_analytics_where_clause(
+        filters, filter_execution_mode=True
+    )
+    where_clause = " WHERE " + " AND ".join(conditions) if conditions else ""
+
+    # Validate sort column to prevent SQL injection
+    allowed_sort_columns = [
+        "created_at",
+        "call_initiated_time",
+        "call_end_time",
+        "updated_at",
+    ]
+    if sort_by not in allowed_sort_columns:
+        sort_by = "call_initiated_time"
+
+    sort_direction = "DESC" if sort_order.lower() == "desc" else "ASC"
+
+    pagination_clause = ""
+    if limit > 0:
+        pagination_clause = f"LIMIT ${len(values) + 1} OFFSET ${len(values) + 2}"
+        values.extend([limit, offset])
+
+    text = f"""
+        SELECT
+            lct.id,
+            lct.call_id,
+            lct.template,
+            lct.payload,
+            lct.call_initiated_time,
+            lct.call_end_time,
+            lct.outcome,
+            ou.provider as calling_provider
+        FROM "{LEAD_CALL_TRACKER_TABLE}" lct
+        LEFT JOIN "{OUTBOUND_NUMBER_TABLE}" ou ON lct.outbound_number_id = ou.id
+        {where_clause}
+        ORDER BY lct.{sort_by} {sort_direction}
+        {pagination_clause};
+    """
 
     return text, values
 

--- a/app/database/queries/breeze_buddy/lead_call_tracker.py
+++ b/app/database/queries/breeze_buddy/lead_call_tracker.py
@@ -517,3 +517,31 @@ def abort_lead_by_id_query(
         LeadCallStatus.RETRY.value,
     ]
     return text, values
+
+
+def update_lead_payload_query(
+    lead_id: str, payload_updates: Dict[str, Any]
+) -> Tuple[str, List[Any]]:
+    """
+    Update specific fields in the payload JSON column for a lead.
+
+    Uses jsonb merge (||) to update only the specified fields without
+    overwriting existing payload data.
+
+    Args:
+        lead_id: Lead UUID
+        payload_updates: Dictionary of fields to merge into the existing payload
+
+    Returns:
+        Tuple of (query_text, values)
+    """
+    text = f"""
+        UPDATE "{LEAD_CALL_TRACKER_TABLE}"
+        SET
+            "payload" = COALESCE("payload", '{{}}')::jsonb || $1::jsonb,
+            "updated_at" = NOW()
+        WHERE "id" = $2
+        RETURNING *;
+    """
+    values = [json.dumps(payload_updates), lead_id]
+    return text, values

--- a/app/schemas/breeze_buddy/analytics.py
+++ b/app/schemas/breeze_buddy/analytics.py
@@ -17,6 +17,7 @@ class AnalyticsType(str, Enum):
     OUTBOUND_NUMBERS = "outbound-numbers"
     CONVERSION = "conversion"
     PERFORMANCE = "performance"
+    CALL_DETAILS_DOWNLOAD = "call-details-download"
 
 
 class TimeGranularity(str, Enum):


### PR DESCRIPTION
- Added a new COMPUTED field source type to the field resolution system so HTTP functions can auto-compute values (like timestamps) at call time, instead of relying on the LLM or static template vars.

-   Added post actions support to global functions

-   Changed payload=None to payload={"customer_mobile_number": from_number} in inbound_policy.py so blocked inbound calls store the caller's phone number in the database.

-  Built a full backend CSV export feature: new CALL_DETAILS_DOWNLOAD analytics type, a no-limit optimized SQL query (only fetches needed columns), a DB accessor, and a handler that generates a CSV with 8 columns (Call ID, Lead ID, Driver Name, Caller Number, Start Time, End Time, Duration, Outcome) served as a StreamingResponse. Wired into the existing /analytics POST endpoint with autom    atic RBAC enforcement.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CSV download for call details with sortable columns and dynamic filenames.
  * Computed field support for runtime datetime/value expressions in templates.
  * Post-action hooks for global functions to run follow-up operations after successful calls.

* **Enhancements**
  * Field resolution updated to handle computed sources.
  * Blocked call tracking logs richer payload data.

* **Bug Fixes**
  * Mitigated a transfer/update race during outcome persistence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->