### PR TITLE
refactor: unify voice configuration into single VoiceConfig model

### DIFF
--- a/app/ai/voice/agents/breeze_buddy/agent/__init__.py
+++ b/app/ai/voice/agents/breeze_buddy/agent/__init__.py
@@ -69,7 +69,8 @@ from app.ai.voice.agents.breeze_buddy.template.context import with_context
 from app.ai.voice.agents.breeze_buddy.template.types import (
     ConfigurationModel,
     TemplateModel,
-    TTSVoiceName,
+    TTSProvider,
+    VoiceConfig,
 )
 from app.ai.voice.agents.breeze_buddy.utils.common import (
     create_background_sound_mixer,
@@ -676,19 +677,30 @@ class Agent:
                 if not await self._setup_telephony_transport():
                     return
 
-            # Override TTS voice name if LLM-based selection was done at lead push time
+            # Override TTS provider if LLM-based selection was done at lead push time.
+            # resolve_voice_config() will pick per-provider settings from
+            # voice_config_overrides if available, else Redis defaults.
             if self.lead and self.lead.payload:
-                payload_voice = self.lead.payload.get("tts_voice_name")
-                if payload_voice and self.configurations:
+                payload_provider = self.lead.payload.get("tts_provider")
+                if payload_provider and self.configurations:
                     try:
-                        voice_enum = TTSVoiceName(payload_voice)
+                        provider_enum = TTSProvider(payload_provider)
                         logger.info(
-                            f"Overriding TTS voice from payload: {voice_enum.value}"
+                            f"Overriding TTS provider from payload: {provider_enum.value}"
                         )
-                        self.configurations.tts_voice_name = voice_enum
+                        existing = self.configurations.voice_config
+                        if existing and existing.provider == provider_enum:
+                            # Same provider — keep existing template settings
+                            pass
+                        else:
+                            # Different provider — create minimal config;
+                            # resolve_voice_config will fill from overrides/defaults
+                            self.configurations.voice_config = VoiceConfig(
+                                provider=provider_enum
+                            )
                     except ValueError:
                         logger.warning(
-                            f"Invalid TTS voice '{payload_voice}' in payload, keeping existing config"
+                            f"Invalid TTS provider '{payload_provider}' in payload, keeping existing config"
                         )
 
             # Create services and pipeline

--- a/app/ai/voice/agents/breeze_buddy/agent/ivr.py
+++ b/app/ai/voice/agents/breeze_buddy/agent/ivr.py
@@ -29,7 +29,8 @@ from app.ai.voice.agents.breeze_buddy.services.inbound_policy import (
 from app.ai.voice.agents.breeze_buddy.services.telephony.base_provider import (
     VoiceCallProvider,
 )
-from app.ai.voice.agents.breeze_buddy.tts import generate_audio
+from app.ai.voice.agents.breeze_buddy.template.types import VoiceConfig
+from app.ai.voice.agents.breeze_buddy.tts import generate_audio, resolve_voice_config
 from app.ai.voice.agents.breeze_buddy.utils.transport.websockets import (
     close_websocket_safely,
     send_message,
@@ -304,14 +305,19 @@ async def _run_ivr_menu(
 
         ivr_config = json.loads(ivr_config_json)
         ivr_options = ivr_config["options"]
-        voice_name = ivr_config.get("voice_name", "sara")
         ivr_greeting = ivr_config.get("ivr_greeting")
         ivr_goodbye = ivr_config.get("ivr_goodbye")
+
+        # Resolve IVR voice config from stored dict (or fall back to defaults)
+        voice_config_dict = ivr_config.get("voice_config")
+        voice_config = VoiceConfig(**voice_config_dict) if voice_config_dict else None
+        resolved_voice = await resolve_voice_config(voice_config)
 
         logger.info(
             f"[IVR] Fetched config from Redis - "
             f"{len(ivr_options)} options: {[o['name'] for o in ivr_options]}, "
-            f"voice={voice_name!r}, greeting={ivr_greeting!r}, goodbye={ivr_goodbye!r}"
+            f"voice_provider={resolved_voice.provider.value!r}, "
+            f"greeting={ivr_greeting!r}, goodbye={ivr_goodbye!r}"
         )
 
         # Handle IVR menu - speak options and wait for DTMF
@@ -320,7 +326,7 @@ async def _run_ivr_menu(
             stream_sid=stream_sid,
             ivr_options=ivr_options,
             provider=provider,
-            voice_name=voice_name,
+            voice_config=resolved_voice,
             ivr_greeting=ivr_greeting,
             ivr_goodbye=ivr_goodbye,
         )
@@ -340,7 +346,7 @@ async def handle_ivr_menu(
     stream_sid: str,
     ivr_options: List[Dict[str, Optional[str]]],
     provider: str,
-    voice_name: str = "sara",
+    voice_config: VoiceConfig,
     ivr_greeting: Optional[str] = None,
     ivr_goodbye: Optional[str] = None,
 ) -> Optional[str]:
@@ -356,7 +362,7 @@ async def handle_ivr_menu(
         stream_sid: Stream ID for sending audio
         ivr_options: List of {"id": str, "name": str}
         provider: "twilio" or "exotel"
-        voice_name: TTS voice to use (default "sara")
+        voice_config: Resolved VoiceConfig for IVR TTS
         ivr_greeting: Full IVR audio text including greeting and menu options
         ivr_goodbye: Goodbye message when no input received (default: English fallback)
 
@@ -368,8 +374,8 @@ async def handle_ivr_menu(
         return None
 
     # Get cached/generated audio once (reuse for retries)
-    menu_audio = await prepare_ivr_menu_audio(provider, voice_name, ivr_greeting)
-    goodbye_audio = await prepare_goodbye_audio(provider, voice_name, ivr_goodbye)
+    menu_audio = await prepare_ivr_menu_audio(provider, ivr_greeting, voice_config)
+    goodbye_audio = await prepare_goodbye_audio(provider, ivr_goodbye, voice_config)
 
     if not menu_audio:
         logger.error("[IVR] Failed to prepare menu audio")
@@ -411,37 +417,37 @@ async def handle_ivr_menu(
 
 async def prepare_ivr_menu_audio(
     provider: str,
-    voice_name: str = "sara",
     ivr_greeting: Optional[str] = None,
+    voice_config: Optional[VoiceConfig] = None,
 ) -> Optional[bytes]:
     """
     Prepare IVR menu audio - from cache or generate new.
 
-    Similar pattern to prepare_initial_greeting_payload.
-    Stores as mulaw in Redis, converts to provider format on retrieval.
-
     Args:
         provider: "twilio", "exotel", or "plivo"
-        voice_name: TTS voice to use (default "sara")
         ivr_greeting: Full IVR audio text including greeting and menu options
+        voice_config: Resolved VoiceConfig for IVR TTS
 
     Returns:
         Audio bytes ready to send, or None if failed
     """
-    # ivr_greeting is required - it contains the full menu text defined by the user
     if not ivr_greeting:
         logger.error(
             "[IVR] No ivr_greeting provided - cannot generate menu audio. "
-            "Please define ivr_greeting in template configurations with the full menu text."
+            "Please define ivr_config.greeting in template configurations."
         )
         return None
 
     try:
         redis = await get_redis_service()
 
-        # Generate cache key from ivr_greeting text and voice
-        # MD5 hash ensures constant key size regardless of input length
-        cache_components = f"greeting:{ivr_greeting}|voice:{voice_name}"
+        # Cache key includes voice provider+id so different configs get different audio
+        voice_key = (
+            f"{voice_config.provider.value}:{voice_config.voice_id}"
+            if voice_config
+            else "default"
+        )
+        cache_components = f"greeting:{ivr_greeting}|voice:{voice_key}"
         cache_key = f"{IVR_AUDIO_CACHE_PREFIX}{hashlib.md5(cache_components.encode()).hexdigest()}"
 
         # Check cache first
@@ -455,10 +461,9 @@ async def prepare_ivr_menu_audio(
                 f"[IVR] Cache MISS - generating menu audio for: {ivr_greeting!r}"
             )
 
-            mulaw_data = await _generate_tts_audio_mulaw(ivr_greeting, voice_name)
+            mulaw_data = await _generate_tts_audio_mulaw(ivr_greeting, voice_config)
 
             if mulaw_data:
-                # Cache for future calls
                 await redis.setex(
                     cache_key,
                     base64.b64encode(mulaw_data).decode("utf-8"),
@@ -469,7 +474,6 @@ async def prepare_ivr_menu_audio(
                 logger.error("[IVR] Failed to generate menu audio")
                 return None
 
-        # Convert format based on provider (same as greeting)
         return _convert_audio_for_provider(mulaw_data, provider)
 
     except Exception as e:
@@ -479,16 +483,16 @@ async def prepare_ivr_menu_audio(
 
 async def prepare_goodbye_audio(
     provider: str,
-    voice_name: str = "sara",
     ivr_goodbye: Optional[str] = None,
+    voice_config: Optional[VoiceConfig] = None,
 ) -> Optional[bytes]:
     """
     Get cached goodbye audio or generate it.
 
     Args:
         provider: "twilio" or "exotel"
-        voice_name: TTS voice to use (default "sara")
         ivr_goodbye: Custom goodbye message (default: English fallback)
+        voice_config: Resolved VoiceConfig for IVR TTS
 
     Returns:
         Audio bytes ready to send, or None if failed
@@ -496,12 +500,14 @@ async def prepare_goodbye_audio(
     try:
         redis = await get_redis_service()
 
-        # Use provided goodbye message or fall back to English default
         goodbye_text = ivr_goodbye or IVR_DEFAULT_GOODBYE
 
-        # Generate cache key from goodbye text and voice name
-        # MD5 hash ensures constant key size regardless of input length
-        cache_components = f"goodbye:{goodbye_text}|voice:{voice_name}"
+        voice_key = (
+            f"{voice_config.provider.value}:{voice_config.voice_id}"
+            if voice_config
+            else "default"
+        )
+        cache_components = f"goodbye:{goodbye_text}|voice:{voice_key}"
         cache_key = f"{IVR_GOODBYE_CACHE_PREFIX}{hashlib.md5(cache_components.encode()).hexdigest()}"
 
         cached = await redis.get(cache_key)
@@ -511,7 +517,7 @@ async def prepare_goodbye_audio(
         else:
             # Generate
             logger.info(f"[IVR] Generating goodbye audio: {goodbye_text!r}")
-            mulaw_data = await _generate_tts_audio_mulaw(goodbye_text, voice_name)
+            mulaw_data = await _generate_tts_audio_mulaw(goodbye_text, voice_config)
 
             if mulaw_data:
                 await redis.setex(
@@ -532,18 +538,15 @@ async def prepare_goodbye_audio(
 async def prepare_block_audio(
     block_message: str,
     provider: str,
-    voice_name: str = "sara",
+    voice_config: Optional[VoiceConfig] = None,
 ) -> Optional[bytes]:
     """
     Get cached block message audio or generate and cache it.
 
-    Uses MD5 hash of text+voice as cache key. Same message text reuses cached audio.
-    Different text regenerates and caches. TTL: 24 hours.
-
     Args:
         block_message: The block/reject message text to synthesize
         provider: "twilio", "exotel", or "plivo"
-        voice_name: TTS voice to use (default "sara")
+        voice_config: Optional VoiceConfig for TTS (defaults to system default)
 
     Returns:
         Audio bytes ready to send (provider-specific format), or None if failed
@@ -551,8 +554,12 @@ async def prepare_block_audio(
     try:
         redis = await get_redis_service()
 
-        # Generate cache key from block message text and voice
-        cache_components = f"block:{block_message}|voice:{voice_name}"
+        voice_key = (
+            f"{voice_config.provider.value}:{voice_config.voice_id}"
+            if voice_config
+            else "default"
+        )
+        cache_components = f"block:{block_message}|voice:{voice_key}"
         cache_key = f"{IVR_BLOCK_AUDIO_CACHE_PREFIX}{hashlib.md5(cache_components.encode()).hexdigest()}"
 
         cached = await redis.get(cache_key)
@@ -561,7 +568,7 @@ async def prepare_block_audio(
             mulaw_data = base64.b64decode(cached)
         else:
             logger.info(f"[IVR] Generating block audio: {block_message!r}")
-            mulaw_data = await _generate_tts_audio_mulaw(block_message, voice_name)
+            mulaw_data = await _generate_tts_audio_mulaw(block_message, voice_config)
 
             if mulaw_data:
                 await redis.setex(
@@ -582,20 +589,20 @@ async def prepare_block_audio(
 
 
 async def _generate_tts_audio_mulaw(
-    text: str, voice_name: str = "sara"
+    text: str, voice_config: Optional[VoiceConfig] = None
 ) -> Optional[bytes]:
     """
-    Generate TTS audio using existing TTS abstraction.
+    Generate TTS audio using the voice configuration.
 
     Args:
         text: Text to synthesize
-        voice_name: TTS voice to use (default "sara")
+        voice_config: VoiceConfig to use. If None, resolve_voice_config picks system defaults.
 
     Returns:
         Audio bytes in mulaw format, or None if failed
     """
     try:
-        mulaw_data = await generate_audio(text=text, voice_name=voice_name)
+        mulaw_data = await generate_audio(text=text, voice_config=voice_config)
         logger.info(f"[IVR] Generated TTS audio: {len(mulaw_data)} bytes mulaw")
         return mulaw_data
     except Exception as e:

--- a/app/ai/voice/agents/breeze_buddy/agent/pipeline.py
+++ b/app/ai/voice/agents/breeze_buddy/agent/pipeline.py
@@ -40,7 +40,7 @@ from app.ai.voice.agents.breeze_buddy.processors import (
 )
 from app.ai.voice.agents.breeze_buddy.stt import get_stt_service
 from app.ai.voice.agents.breeze_buddy.template.types import ConfigurationModel
-from app.ai.voice.agents.breeze_buddy.tts import get_tts_service
+from app.ai.voice.agents.breeze_buddy.tts import get_tts_service, resolve_voice_config
 from app.core.config.dynamic import (
     BB_ENABLE_RESPONSE_GATE,
     BREEZE_BUDDY_AZURE_MAX_COMPLETION_TOKENS,
@@ -118,33 +118,13 @@ async def create_services(
         ),
     )
 
-    # Extract Cartesia voice configurations from template
-    cartesia_voice_config = getattr(
-        configurations, "cartesia_voice_configurations", None
+    template_voice_config = getattr(configurations, "voice_config", None)
+    voice_config_overrides = getattr(configurations, "voice_config_overrides", None)
+    voice_config = await resolve_voice_config(
+        template_voice_config, voice_config_overrides
     )
-    legacy_mira_voice_id = getattr(configurations, "mira_voice_id", None)
-
-    if cartesia_voice_config:
-        logger.info(
-            f"Using Cartesia voice configurations from template: {cartesia_voice_config}"
-        )
-
-    # Extract ElevenLabs voice configurations from template
-    elevenlabs_voice_config = getattr(
-        configurations, "elevenlabs_voice_configurations", None
-    )
-
-    if elevenlabs_voice_config:
-        logger.info(
-            f"Using ElevenLabs voice configurations from template: {elevenlabs_voice_config}"
-        )
-
-    tts = await get_tts_service(
-        voice_name=getattr(configurations, "tts_voice_name", None),
-        mira_voice_id=legacy_mira_voice_id,
-        cartesia_voice_configurations=cartesia_voice_config,
-        elevenlabs_voice_configurations=elevenlabs_voice_config,
-    )
+    logger.info(f"Resolved voice config: provider={voice_config.provider.value}")
+    tts = await get_tts_service(voice_config)
 
     return stt, llm, tts
 

--- a/app/ai/voice/agents/breeze_buddy/examples/templates/cartesia-voice-config-example.json
+++ b/app/ai/voice/agents/breeze_buddy/examples/templates/cartesia-voice-config-example.json
@@ -13,15 +13,15 @@
     }
   },
   "configurations": {
-    "tts_voice_name": "mira",
-    "stt_language": "en",
-    "cartesia_voice_configurations": {
+    "voice_config": {
+      "provider": "cartesia",
       "voice_id": "248be419-c632-4f23-adf1-5324ed7dbf1d",
       "volume": 1.8,
       "speed": 1.2,
       "emotion": "excited",
       "language": "hi"
     },
+    "stt_language": "en",
     "enable_background_sound": false,
     "background_sound_volume": 2.0
   },

--- a/app/ai/voice/agents/breeze_buddy/examples/templates/elevenlabs-voice-config-example.json
+++ b/app/ai/voice/agents/breeze_buddy/examples/templates/elevenlabs-voice-config-example.json
@@ -13,14 +13,14 @@
     }
   },
   "configurations": {
-    "tts_voice_name": "rhea",
-    "stt_language": "en",
-    "elevenlabs_voice_configurations": {
+    "voice_config": {
+      "provider": "elevenlabs",
       "voice_id": "fG9s0SXJb213f4UxVHyG",
-      "model_id": "eleven_flash_v2_5",
+      "model": "eleven_flash_v2_5",
       "speed": 1.2,
       "language": "en"
     },
+    "stt_language": "en",
     "enable_background_sound": false,
     "background_sound_volume": 2.0
   },

--- a/app/ai/voice/agents/breeze_buddy/examples/templates/order-confirmation-2.json
+++ b/app/ai/voice/agents/breeze_buddy/examples/templates/order-confirmation-2.json
@@ -36,7 +36,9 @@
     }
   },
   "configurations": {
-    "tts_voice_name": "rhea",
+    "voice_config": {
+      "provider": "elevenlabs"
+    },
     "stt_language": "en",
     "payload_based_language_selection": true
   },

--- a/app/ai/voice/agents/breeze_buddy/examples/templates/order-confirmation-with-keyword-filter.json
+++ b/app/ai/voice/agents/breeze_buddy/examples/templates/order-confirmation-with-keyword-filter.json
@@ -25,7 +25,9 @@
         }
     },
     "configurations": {
-        "tts_voice_name": "rhea",
+        "voice_config": {
+            "provider": "elevenlabs"
+        },
         "keyword_filter": {
             "enabled": true,
             "keywords": ["hello", "hmm", "okay", "ok", "haan", "ha", "ji"],

--- a/app/ai/voice/agents/breeze_buddy/examples/templates/order-confirmation-with-vad.json
+++ b/app/ai/voice/agents/breeze_buddy/examples/templates/order-confirmation-with-vad.json
@@ -25,7 +25,9 @@
         }
     },
     "configurations": {
-        "tts_voice_name": "rhea",
+        "voice_config": {
+            "provider": "elevenlabs"
+        },
         "vad_config": {
             "confidence": 0.5,
             "start_secs": 0.1,

--- a/app/ai/voice/agents/breeze_buddy/examples/templates/order-confirmation.json
+++ b/app/ai/voice/agents/breeze_buddy/examples/templates/order-confirmation.json
@@ -202,14 +202,16 @@
     }
   },
   "configurations": {
-    "tts_voice_name": "mira",
-    "mira_voice_id": null,
-    "cartesia_voice_configurations": null,
-    "elevenlabs_voice_configurations": {
-      "voice_id": "81xnrLNObbKDEs179emP",
-      "model_id": "eleven_flash_v2_5",
-      "speed": 1.0,
-      "language": "en"
+    "voice_config": {
+      "provider": "cartesia"
+    },
+    "voice_config_overrides": {
+      "elevenlabs": {
+        "voice_id": "81xnrLNObbKDEs179emP",
+        "model": "eleven_flash_v2_5",
+        "speed": 1.0,
+        "language": "en"
+      }
     },
     "tts_selection_config": {
       "enabled": true,
@@ -222,9 +224,7 @@
     "stt_language": null,
     "payload_based_language_selection": false,
     "initial_greeting": "Hi {customer_name}, I'm Priyanka from {shop_name}. Um, I'm calling to confirm your order. Is this a good time to talk?",
-    "ivr_greeting": null,
-    "ivr_goodbye": null,
-    "ivr_priority": null,
+    "ivr_config": null,
     "vad_config": null,
     "enable_inbound": false,
     "user_idle_configuration": {

--- a/app/ai/voice/agents/breeze_buddy/examples/templates/trip-feedback-with-builtin-global-functions.json
+++ b/app/ai/voice/agents/breeze_buddy/examples/templates/trip-feedback-with-builtin-global-functions.json
@@ -26,7 +26,9 @@
   },
   "configurations": {
     "stt_language": "en",
-    "tts_voice_name": "rhea",
+    "voice_config": {
+      "provider": "elevenlabs"
+    },
     "transfer_number": "+1234567890",
     "payload_based_language_selection": false
   },

--- a/app/ai/voice/agents/breeze_buddy/examples/templates/trip-feedback-with-http.json
+++ b/app/ai/voice/agents/breeze_buddy/examples/templates/trip-feedback-with-http.json
@@ -29,7 +29,9 @@
   },
   "configurations": {
     "stt_language": "en",
-    "tts_voice_name": "rhea",
+    "voice_config": {
+      "provider": "elevenlabs"
+    },
     "background_sound_volume": 2.0,
     "enable_background_sound": false,
     "payload_based_language_selection": false

--- a/app/ai/voice/agents/breeze_buddy/examples/templates/trip_feedback_with_transfer.json
+++ b/app/ai/voice/agents/breeze_buddy/examples/templates/trip_feedback_with_transfer.json
@@ -13,7 +13,9 @@
     }
   },
   "configurations": {
-    "tts_voice_name": "rhea",
+    "voice_config": {
+      "provider": "elevenlabs"
+    },
     "stt_language": "en",
     "payload_based_language_selection": false,
     "transfer_number": "+1234567890"

--- a/app/ai/voice/agents/breeze_buddy/managers/utils.py
+++ b/app/ai/voice/agents/breeze_buddy/managers/utils.py
@@ -4,7 +4,11 @@ import base64
 import json
 from typing import Optional
 
-from app.ai.voice.agents.breeze_buddy.template.types import TemplateModel, TTSVoiceName
+from app.ai.voice.agents.breeze_buddy.template.types import (
+    TemplateModel,
+    TTSProvider,
+    VoiceConfig,
+)
 from app.ai.voice.agents.breeze_buddy.tts import generate_audio
 from app.ai.voice.agents.breeze_buddy.utils.common import greeting_has_variables
 from app.core.logger import logger
@@ -70,37 +74,30 @@ async def prepare_and_store_initial_greeting(
                         placeholder, str(value)
                     )
 
-            # Get voice name: check payload first (set during push lead), then template config, then default
-            voice_name = None
-            payload_voice = (payload or {}).get("tts_voice_name")
-            if payload_voice:
+            # Build voice config: check payload override first, then template config
+            voice_config = None
+            payload_provider = (payload or {}).get("tts_provider")
+            if payload_provider:
                 try:
-                    voice_name = TTSVoiceName(payload_voice).value
+                    voice_config = VoiceConfig(provider=TTSProvider(payload_provider))
                     logger.info(
-                        f"Using TTS voice '{voice_name}' from payload for greeting (lead {lead_id})"
+                        f"Using TTS provider '{payload_provider}' from payload for greeting (lead {lead_id})"
                     )
                 except ValueError:
                     logger.warning(
-                        f"Invalid TTS voice '{payload_voice}' in payload, falling back to template config"
+                        f"Invalid TTS provider '{payload_provider}' in payload, falling back to template config"
                     )
 
-            # Fall back to template config or default
-            if not voice_name:
-                if template.configurations.tts_voice_name:
-                    voice_name = (
-                        template.configurations.tts_voice_name.value
-                        if hasattr(template.configurations.tts_voice_name, "value")
-                        else str(template.configurations.tts_voice_name)
-                    )
-                else:
-                    voice_name = "rhea"
+            # Fall back to template voice_config (resolve_voice_config handles None)
+            if not voice_config and template.configurations.voice_config:
+                voice_config = template.configurations.voice_config
 
             logger.info(
                 f"Synthesizing dynamic greeting for lead {lead_id}: {resolved_greeting[:50]}..."
             )
             greeting_audio = await generate_audio(
                 text=resolved_greeting,
-                voice_name=voice_name,
+                voice_config=voice_config,
                 configurations=template.configurations,
             )
 
@@ -128,21 +125,12 @@ async def prepare_and_store_initial_greeting(
                 # For static greetings, the greeting text is the initial_greeting itself
                 return initial_greeting
 
-            # Synthesize and store as template audio (persistent, not deleted after use)
-            voice_name = "rhea"
-            if template.configurations.tts_voice_name:
-                voice_name = (
-                    template.configurations.tts_voice_name.value
-                    if hasattr(template.configurations.tts_voice_name, "value")
-                    else str(template.configurations.tts_voice_name)
-                )
-
             logger.info(
                 f"Synthesizing static greeting for template {template.id}: {initial_greeting[:50]}..."
             )
             greeting_audio = await generate_audio(
                 text=initial_greeting,
-                voice_name=voice_name,
+                voice_config=template.configurations.voice_config,
                 configurations=template.configurations,
             )
             await redis.set(

--- a/app/ai/voice/agents/breeze_buddy/template/types.py
+++ b/app/ai/voice/agents/breeze_buddy/template/types.py
@@ -5,7 +5,7 @@ Pydantic models for the dynamic workflow engine.
 from enum import Enum
 from typing import Any, Dict, List, Optional
 
-from pydantic import BaseModel, ConfigDict, Field, SecretStr
+from pydantic import BaseModel, ConfigDict, Field, SecretStr, model_validator
 
 
 class ActionType(str, Enum):
@@ -46,70 +46,71 @@ class NoiseFilterConfig(BaseModel):
     )
 
 
-class CartesiaVoiceConfiguration(BaseModel):
-    """Cartesia voice configuration parameters for template-level customization.
-
-    Allows per-template override of Cartesia TTS parameters.
-    Values specified here take precedence over global Redis defaults.
-
-    TODO: Add validation for emotion strings against known Cartesia emotions
-    TODO: Add validation for language codes
-    """
-
-    voice_id: Optional[str] = Field(None, description="Cartesia voice ID (e.g., UUID)")
-    volume: Optional[float] = Field(
-        None,
-        ge=0.5,
-        le=2.0,
-        description="Volume multiplier (Cartesia range: 0.5-2.0)",
-    )
-    speed: Optional[float] = Field(
-        None,
-        ge=0.6,
-        le=1.5,
-        description="Speed multiplier (Cartesia range: 0.6-1.5)",
-    )
-    emotion: Optional[str] = Field(
-        None, description="Voice emotion (e.g., 'neutral', 'excited', 'happy')"
-    )
-    language: Optional[str] = Field(
-        None, description="TTS language code (e.g., 'en', 'hi')"
-    )
-
-
-class ElevenLabsVoiceConfiguration(BaseModel):
-    """ElevenLabs voice configuration parameters for template-level customization.
-
-    Allows per-template override of ElevenLabs TTS parameters.
-    Values specified here take precedence over global Redis defaults.
-    """
-
-    voice_id: Optional[str] = Field(None, description="ElevenLabs voice ID")
-    model_id: Optional[str] = Field(
-        None, description="ElevenLabs model ID (e.g., 'eleven_flash_v2_5')"
-    )
-    speed: Optional[float] = Field(
-        None,
-        ge=0.7,
-        le=1.2,
-        description="Speed multiplier (ElevenLabs range: 0.7-1.2, where 1.0 is default)",
-    )
-    language: Optional[str] = Field(
-        None, description="TTS language code (e.g., 'en', 'hi')"
-    )
-
-
-class TTSVoiceName(str, Enum):
-    RHEA = "rhea"
-    SARA = "sara"
-    MIRA = "mira"
-
-
 class TTSProvider(str, Enum):
-    """Supported TTS providers for intelligent selection."""
+    """Supported TTS providers."""
 
     ELEVENLABS = "elevenlabs"
     CARTESIA = "cartesia"
+    SARVAM = "sarvam"
+
+
+class VoiceConfig(BaseModel):
+    """Unified voice configuration — provider + provider-specific settings.
+
+    Template-level values override global Redis defaults.
+    Provider-specific fields (e.g. emotion for Cartesia, pitch for Sarvam)
+    are silently ignored when irrelevant to the chosen provider.
+
+    Example (Cartesia):
+        {
+            "provider": "cartesia",
+            "voice_id": "248be419-c632-4f23-adf1-5324ed7dbf1d",
+            "volume": 1.8,
+            "speed": 1.2,
+            "emotion": "excited",
+            "language": "hi"
+        }
+
+    Example (ElevenLabs):
+        {
+            "provider": "elevenlabs",
+            "voice_id": "fG9s0SXJb213f4UxVHyG",
+            "model": "eleven_flash_v2_5",
+            "speed": 1.2,
+            "language": "en"
+        }
+
+    Example (Sarvam):
+        {
+            "provider": "sarvam",
+            "voice_id": "manisha",
+            "model": "bulbul:v2",
+            "language": "en-IN",
+            "speed": 0.9,
+            "pitch": 0.0
+        }
+    """
+
+    provider: TTSProvider = Field(
+        ..., description="TTS provider (elevenlabs, cartesia, sarvam)"
+    )
+    voice_id: Optional[str] = Field(None, description="Provider-specific voice ID")
+    model: Optional[str] = Field(
+        None,
+        description="Provider model (e.g. 'eleven_flash_v2_5', 'sonic-3', 'bulbul:v2')",
+    )
+    language: Optional[str] = Field(
+        None, description="TTS language code (e.g. 'en', 'hi', 'en-IN')"
+    )
+    speed: Optional[float] = Field(None, description="Speed/pace multiplier")
+    volume: Optional[float] = Field(
+        None, description="Volume multiplier (Cartesia only, range 0.5-2.0)"
+    )
+    emotion: Optional[str] = Field(
+        None,
+        description="Voice emotion (Cartesia only, e.g. 'neutral', 'excited', 'happy')",
+    )
+    pitch: Optional[float] = Field(None, description="Pitch adjustment (Sarvam only)")
 
 
 class TTSSelectionConfig(BaseModel):
@@ -200,17 +201,82 @@ class UserIdleHandlingConfig(BaseModel):
     )
 
 
+class IvrConfig(BaseModel):
+    """IVR-specific configuration — voice, greeting, goodbye, priority.
+
+    When a template is part of an inbound IVR menu, these settings control
+    the IVR experience. voice_config overrides the main voice_config for
+    IVR audio only (greeting, goodbye, block messages).
+
+    Example:
+        {
+            "voice_config": {"provider": "sarvam", "language": "hi"},
+            "greeting": "Welcome. Press 1 for billing, press 2 for support.",
+            "goodbye": "We didn't receive your input. Goodbye.",
+            "priority": 1
+        }
+    """
+
+    voice_config: Optional[VoiceConfig] = Field(
+        None,
+        description="Voice config for IVR audio. Falls back to the template's main voice_config if not set.",
+    )
+    greeting: Optional[str] = Field(
+        None,
+        description="Full IVR audio text including greeting and menu options.",
+    )
+    goodbye: Optional[str] = Field(
+        None,
+        description="Goodbye message when no input received.",
+    )
+    priority: Optional[int] = Field(
+        None,
+        ge=1,
+        description="Priority order for IVR menu (lower = earlier). Gaps allowed.",
+    )
+
+
 class ConfigurationModel(BaseModel):
-    tts_voice_name: Optional[TTSVoiceName] = None
-    mira_voice_id: Optional[str] = (
-        None  # DEPRECATED: Use cartesia_voice_configurations.voice_id instead
+    voice_config: Optional[VoiceConfig] = None  # Unified voice configuration
+    voice_config_overrides: Optional[Dict[str, VoiceConfig]] = Field(
+        None,
+        description="Per-provider voice overrides keyed by provider name. "
+        "Provider is auto-filled from the key — no need to repeat it. "
+        'E.g. {"elevenlabs": {"voice_id": "...", "speed": 1.0}}',
     )
-    cartesia_voice_configurations: Optional[CartesiaVoiceConfiguration] = (
-        None  # Cartesia voice configuration (overrides global defaults)
-    )
-    elevenlabs_voice_configurations: Optional[ElevenLabsVoiceConfiguration] = (
-        None  # ElevenLabs voice configuration (overrides global defaults)
-    )
+
+    @model_validator(mode="before")
+    @classmethod
+    def _pre_validate(cls, data: Any) -> Any:
+        """Pre-validation: auto-fill override providers + migrate flat IVR fields."""
+        if not isinstance(data, dict):
+            return data
+
+        # Auto-set provider on each voice_config_overrides entry from its key
+        overrides = data.get("voice_config_overrides")
+        if overrides and isinstance(overrides, dict):
+            for key, cfg in overrides.items():
+                if isinstance(cfg, dict):
+                    cfg.setdefault("provider", key)
+
+        # Migrate flat ivr_* fields into ivr_config (backward compatibility)
+        if not data.get("ivr_config"):
+            greeting = data.get("ivr_greeting")
+            goodbye = data.get("ivr_goodbye")
+            priority = data.get("ivr_priority")
+            if greeting or goodbye or priority:
+                data["ivr_config"] = {
+                    k: v
+                    for k, v in [
+                        ("greeting", greeting),
+                        ("goodbye", goodbye),
+                        ("priority", priority),
+                    ]
+                    if v is not None
+                }
+
+        return data
+
     tts_selection_config: Optional[TTSSelectionConfig] = (
         None  # LLM-based TTS provider selection config
     )
@@ -226,17 +292,11 @@ class ConfigurationModel(BaseModel):
     initial_greeting: Optional[str] = (
         None  # Initial greeting text template with variables (e.g., "Hi {customer_name}")
     )
-    ivr_greeting: Optional[str] = (
-        None  # Full IVR audio text including greeting and menu options (e.g., "Welcome to support. Press 1 for billing, press 2 for technical support")
-    )
-    ivr_goodbye: Optional[str] = (
-        None  # Goodbye message when no input received (default: "We didn't receive your input. Goodbye.")
-    )
-    ivr_priority: Optional[int] = Field(
-        None,
-        ge=1,
-        description="Priority order for IVR menu (lower number = earlier in menu). Gaps allowed (e.g., 1, 3, 4).",
-    )
+    ivr_config: Optional[IvrConfig] = None  # IVR-specific configuration
+    # DEPRECATED: Use ivr_config.greeting / ivr_config.goodbye / ivr_config.priority
+    ivr_greeting: Optional[str] = None
+    ivr_goodbye: Optional[str] = None
+    ivr_priority: Optional[int] = Field(None, ge=1)
     transfer_number: Optional[str] = Field(
         None, description="Phone number to transfer the call to"
     )

--- a/app/ai/voice/agents/breeze_buddy/tts/__init__.py
+++ b/app/ai/voice/agents/breeze_buddy/tts/__init__.py
@@ -4,9 +4,9 @@ from pipecat.services.cartesia.tts import GenerationConfig
 from pipecat.transcriptions.language import Language
 
 from app.ai.voice.agents.breeze_buddy.template.types import (
-    CartesiaVoiceConfiguration,
     ConfigurationModel,
-    ElevenLabsVoiceConfiguration,
+    TTSProvider,
+    VoiceConfig,
 )
 from app.ai.voice.agents.breeze_buddy.utils.common import convert_to_mulaw
 from app.ai.voice.tts import (
@@ -21,25 +21,11 @@ from app.ai.voice.tts.cartesia import _generate_cartesia_audio
 from app.ai.voice.tts.elevenlabs import _generate_elevenlabs_audio
 from app.ai.voice.tts.sarvam import _generate_sarvam_audio
 from app.core.config.dynamic import (
-    BB_CARTESIA_AGGREGATE_SENTENCES,
-    BB_CARTESIA_GENERATION_EMOTION,
-    BB_CARTESIA_GENERATION_SPEED,
-    BB_CARTESIA_GENERATION_VOLUME,
-    BB_CARTESIA_LANGUAGE,
-    BB_CARTESIA_MODEL,
-    BB_CARTESIA_VOICE_ID,
-    BB_ELEVENLABS_AGGREGATE_SENTENCES,
-    BB_ELEVENLABS_MODEL_ID,
-    BB_ELEVENLABS_VOICE_ID,
-    BB_ELEVENLABS_VOICE_SPEED,
+    BB_AGGREGATE_SENTENCES,
     BB_ENABLE_ELEVENLABS_INDIAN_RESIDENCY,
     BB_SARVAM_TTS_ENABLE_PREPROCESSING,
-    BB_SARVAM_TTS_LANGUAGE_CODE,
-    BB_SARVAM_TTS_MODEL,
-    BB_SARVAM_TTS_PACE,
-    BB_SARVAM_TTS_PITCH,
-    BB_SARVAM_TTS_VOICE_ID,
     BB_TTS_SERVICE,
+    BB_VOICE_PROVIDER_DEFAULTS,
 )
 from app.core.config.static import (
     CARTESIA_API_KEY,
@@ -50,367 +36,211 @@ from app.core.config.static import (
 )
 from app.core.logger import logger
 
-
-async def get_cartesia_tts_service(
-    voice_id: str | None = None,
-    cartesia_config: CartesiaVoiceConfiguration | None = None,
-):
-    """
-    Returns a Cartesia TTS service instance based on the Breeze Buddy configuration.
-
-    Template-level values (if provided) override global Redis defaults.
-
-    Args:
-        voice_id: DEPRECATED - Optional custom voice ID from legacy template configuration.
-                  Use cartesia_config.voice_id instead.
-        cartesia_config: Template-level Cartesia voice configuration. Values specified here
-                        override global Redis defaults. If None or specific fields are None,
-                        falls back to Redis configuration.
-    """
-    # Load global Redis defaults
-    default_voice_id = await BB_CARTESIA_VOICE_ID()
-    default_model = await BB_CARTESIA_MODEL()
-    default_language = await BB_CARTESIA_LANGUAGE()
-    default_volume = await BB_CARTESIA_GENERATION_VOLUME()
-    default_speed = await BB_CARTESIA_GENERATION_SPEED()
-    default_emotion = await BB_CARTESIA_GENERATION_EMOTION()
-    default_aggregate_sentences = await BB_CARTESIA_AGGREGATE_SENTENCES()
-
-    # Template overrides Redis (priority: cartesia_config.voice_id > legacy voice_id > default)
-    final_voice_id = default_voice_id
-    if cartesia_config and cartesia_config.voice_id:
-        final_voice_id = cartesia_config.voice_id
-    elif voice_id:
-        final_voice_id = voice_id
-
-    # Template overrides for generation parameters (or fall back to defaults)
-    final_volume = (
-        cartesia_config.volume
-        if cartesia_config and cartesia_config.volume is not None
-        else default_volume
-    )
-    final_speed = (
-        cartesia_config.speed
-        if cartesia_config and cartesia_config.speed is not None
-        else default_speed
-    )
-    final_emotion = (
-        cartesia_config.emotion
-        if cartesia_config and cartesia_config.emotion is not None
-        else default_emotion
-    )
-    final_language_code = (
-        cartesia_config.language
-        if cartesia_config and cartesia_config.language is not None
-        else default_language
-    )
-
-    # Build generation config with final values
-    generation_config = GenerationConfig(
-        volume=final_volume,
-        speed=final_speed,
-        emotion=final_emotion,
-    )
-
-    # Map language code string to Language enum
-    # The language code from config is like "en", "hi", etc.
-    # We'll use Language.EN as default and let Cartesia handle the language string directly
-    language = Language.EN
-    if final_language_code:
-        # Try to get the language enum by uppercasing the code
-        try:
-            language = Language[final_language_code.upper().replace("-", "_")]
-        except KeyError:
-            logger.warning(
-                f"Language code '{final_language_code}' not found in Language enum, using EN"
-            )
-
-    if not CARTESIA_API_KEY:
-        raise ValueError("CARTESIA_API_KEY is required for Cartesia TTS")
-
-    logger.info(
-        f"Building Cartesia TTS with: voice_id={final_voice_id}, "
-        f"volume={final_volume}, speed={final_speed}, emotion={final_emotion}, language={final_language_code}"
-    )
-
-    return build_cartesia_tts(
-        CartesiaConfig(
-            api_key=CARTESIA_API_KEY,
-            voice_id=final_voice_id,
-            model=default_model,
-            language=language,
-            generation_config=generation_config,
-            aggregate_sentences=default_aggregate_sentences,
-        )
-    )
+_VOICE_CONFIG_FIELDS = (
+    "voice_id",
+    "model",
+    "language",
+    "speed",
+    "volume",
+    "emotion",
+    "pitch",
+)
 
 
-async def get_sarvam_tts_service():
-    """
-    Returns a Sarvam TTS service instance based on the Breeze Buddy configuration.
-    """
-    bb_sarvam_tts_model = await BB_SARVAM_TTS_MODEL()
-    bb_sarvam_tts_voice_id = await BB_SARVAM_TTS_VOICE_ID()
-    bb_sarvam_tts_language_code = await BB_SARVAM_TTS_LANGUAGE_CODE()
-    bb_sarvam_tts_pitch = await BB_SARVAM_TTS_PITCH()
-    bb_sarvam_tts_pace = await BB_SARVAM_TTS_PACE()
-    bb_sarvam_tts_enable_preprocessing = await BB_SARVAM_TTS_ENABLE_PREPROCESSING()
+async def resolve_voice_config(
+    template_voice_config: VoiceConfig | None = None,
+    overrides: dict[str, VoiceConfig] | None = None,
+) -> VoiceConfig:
+    """Merge template-level VoiceConfig with Redis/hardcoded defaults.
 
-    if not SARVAM_API_KEY:
-        raise ValueError("SARVAM_API_KEY is not set")
-
-    return build_sarvam_tts(
-        SarvamTTSConfig(
-            api_key=SARVAM_API_KEY,
-            model=bb_sarvam_tts_model,
-            voice_id=bb_sarvam_tts_voice_id,
-            language_code=bb_sarvam_tts_language_code,
-            pitch=bb_sarvam_tts_pitch,
-            pace=bb_sarvam_tts_pace,
-            enable_preprocessing=bb_sarvam_tts_enable_preprocessing,
-        )
-    )
-
-
-async def get_elevenlabs_tts_service(
-    elevenlabs_config: ElevenLabsVoiceConfiguration | None = None,
-):
-    """
-    Returns an ElevenLabs TTS service instance based on the Breeze Buddy configuration.
-
-    Template-level values (if provided) override global Redis defaults.
+    Resolution order for a given provider:
+      1. voice_config_overrides[provider]  (per-provider template settings)
+      2. voice_config                      (default template settings, if same provider)
+      3. BB_VOICE_PROVIDER_DEFAULTS        (Redis / hardcoded)
 
     Args:
-        elevenlabs_config: Template-level ElevenLabs voice configuration. Values specified here
-                          override global Redis defaults. If None or specific fields are None,
-                          falls back to Redis configuration.
+        template_voice_config: The template's default voice_config.
+        overrides: Per-provider voice configs (from voice_config_overrides).
     """
-    use_indian_residency = await BB_ENABLE_ELEVENLABS_INDIAN_RESIDENCY()
-    if use_indian_residency and not ELEVENLABS_INDIAN_RESIDENCY_API_KEY:
-        raise ValueError(
-            "ELEVENLABS_INDIAN_RESIDENCY_API_KEY is required when BB_ENABLE_ELEVENLABS_INDIAN_RESIDENCY is True"
-        )
-
-    if not use_indian_residency and not ELEVENLABS_API_KEY:
-        raise ValueError("ELEVENLABS_API_KEY is not set")
-
-    # Load global Redis defaults
-    default_voice_id = await BB_ELEVENLABS_VOICE_ID()
-    default_model_id = await BB_ELEVENLABS_MODEL_ID()
-    default_speed = await BB_ELEVENLABS_VOICE_SPEED()
-    default_aggregate_sentences = await BB_ELEVENLABS_AGGREGATE_SENTENCES()
-
-    # Template overrides Redis defaults
-    final_voice_id = (
-        elevenlabs_config.voice_id
-        if elevenlabs_config and elevenlabs_config.voice_id
-        else default_voice_id
-    )
-    final_model_id = (
-        elevenlabs_config.model_id
-        if elevenlabs_config and elevenlabs_config.model_id
-        else default_model_id
-    )
-    final_speed = (
-        elevenlabs_config.speed
-        if elevenlabs_config and elevenlabs_config.speed is not None
-        else default_speed
-    )
-
-    # Map language code string to Language enum
-    language = Language.EN_IN
-    if elevenlabs_config and elevenlabs_config.language:
-        try:
-            language = Language[elevenlabs_config.language.upper().replace("-", "_")]
-        except KeyError:
-            logger.warning(
-                f"Language code '{elevenlabs_config.language}' not found in Language enum, using EN_IN"
-            )
-
-    logger.info(
-        f"Building ElevenLabs TTS with: voice_id={final_voice_id}, "
-        f"model_id={final_model_id}, speed={final_speed}, language={language}"
-    )
-
-    return build_elevenlabs_tts(
-        ElevenLabsConfig(
-            api_key=(
-                ELEVENLABS_INDIAN_RESIDENCY_API_KEY
-                if use_indian_residency
-                else ELEVENLABS_API_KEY
-            )
-            or "",
-            url=(
-                ELEVENLABS_INDIAN_RESIDENCY_WEBSOCKET_URL
-                if use_indian_residency
-                else "wss://api.elevenlabs.io"
-            ),
-            voice_id=final_voice_id,
-            model=final_model_id,
-            speed=final_speed,
-            language=language,
-            aggregate_sentences=default_aggregate_sentences,
-        )
-    )
-
-
-async def get_tts_service(
-    voice_name: str | None = None,
-    mira_voice_id: str | None = None,
-    cartesia_voice_configurations: CartesiaVoiceConfiguration | None = None,
-    elevenlabs_voice_configurations: ElevenLabsVoiceConfiguration | None = None,
-):
-    """
-    Returns a TTS service instance based on the environment configuration.
-
-    Supports the following voice names:
-    - "sara": Sarvam TTS (multilingual Indian voices)
-    - "rhea": ElevenLabs TTS (high-quality English)
-    - "mira": Cartesia TTS (customizable with emotions and speed)
-
-    Args:
-        voice_name: The TTS voice to use ("sara", "rhea", or "mira")
-        mira_voice_id: DEPRECATED - Optional custom Cartesia voice ID from legacy template configuration.
-                      Use cartesia_voice_configurations.voice_id instead.
-        cartesia_voice_configurations: Template-level Cartesia voice configuration (volume, speed, emotion, language).
-                                       Only used when voice_name is "mira" or tts_service is "cartesia".
-        elevenlabs_voice_configurations: Template-level ElevenLabs voice configuration (voice_id, model_id, speed, language).
-                                         Only used when voice_name is "rhea" or tts_service is "elevenlabs".
-    """
-
-    if voice_name is not None:
-        logger.info(f"Using specified TTS voice: {voice_name}")
-        if voice_name.lower() == "sara":
-            if not SARVAM_API_KEY:
-                raise ValueError("SARVAM_API_KEY is required for Sara voice")
-
-            logger.info("Using Sarvam TTS service for Sara voice")
-            return await get_sarvam_tts_service()
-
-        elif voice_name.lower() == "rhea":
-            logger.info("Using ElevenLabs TTS service for Rhea voice")
-            return await get_elevenlabs_tts_service(
-                elevenlabs_config=elevenlabs_voice_configurations,
-            )
-
-        elif voice_name.lower() == "mira":
-            if not CARTESIA_API_KEY:
-                raise ValueError("CARTESIA_API_KEY is required for Mira voice")
-
-            logger.info("Using Cartesia TTS service for Mira voice")
-            return await get_cartesia_tts_service(
-                voice_id=mira_voice_id,
-                cartesia_config=cartesia_voice_configurations,
-            )
+    if template_voice_config:
+        provider = template_voice_config.provider.value
     else:
-        logger.info("No TTS voice specified, using default from config")
+        provider = await BB_TTS_SERVICE()
 
-    tts_service = await BB_TTS_SERVICE()
-    if tts_service == "sarvam":
-        if not SARVAM_API_KEY:
+    # Validate provider early — bad Redis value shouldn't crash call startup
+    try:
+        provider_enum = TTSProvider(provider)
+    except ValueError:
+        logger.warning(f"Unknown TTS provider '{provider}', falling back to elevenlabs")
+        provider = "elevenlabs"
+        provider_enum = TTSProvider.ELEVENLABS
+
+    # Pick the most specific config for this provider
+    effective_config = (overrides or {}).get(provider) or template_voice_config
+
+    defaults = await BB_VOICE_PROVIDER_DEFAULTS(provider)
+
+    if not effective_config:
+        return VoiceConfig(provider=provider_enum, **defaults)
+
+    # Merge: effective_config fields win over defaults for non-None values
+    merged = {}
+    for field in _VOICE_CONFIG_FIELDS:
+        val = getattr(effective_config, field, None)
+        merged[field] = val if val is not None else defaults.get(field)
+
+    return VoiceConfig(provider=effective_config.provider, **merged)
+
+
+def _parse_language(code: str | None, fallback: Language = Language.EN) -> Language:
+    """Convert a language code string to a pipecat Language enum."""
+    if not code:
+        return fallback
+    try:
+        return Language[code.upper().replace("-", "_")]
+    except KeyError:
+        logger.warning(
+            f"Language code '{code}' not found in Language enum, using {fallback}"
+        )
+        return fallback
+
+
+async def get_tts_service(voice_config: VoiceConfig):
+    """Build a TTS service from a resolved VoiceConfig."""
+    provider = voice_config.provider.value
+
+    logger.info(
+        f"Building TTS service: provider={provider}, voice_id={voice_config.voice_id}, "
+        f"model={voice_config.model}, speed={voice_config.speed}, language={voice_config.language}"
+    )
+
+    if provider == "elevenlabs":
+        use_indian_residency = await BB_ENABLE_ELEVENLABS_INDIAN_RESIDENCY()
+        if use_indian_residency and not ELEVENLABS_INDIAN_RESIDENCY_API_KEY:
             raise ValueError(
-                "SARVAM_API_KEY is required when BREEZE_BUDDY_TTS_SERVICE=sarvam"
+                "ELEVENLABS_INDIAN_RESIDENCY_API_KEY is required when BB_ENABLE_ELEVENLABS_INDIAN_RESIDENCY is True"
             )
+        if not use_indian_residency and not ELEVENLABS_API_KEY:
+            raise ValueError("ELEVENLABS_API_KEY is not set")
 
-        logger.info("Using Sarvam TTS service for Breeze Buddy voice")
-        return await get_sarvam_tts_service()
+        aggregate = await BB_AGGREGATE_SENTENCES("elevenlabs")
 
-    elif tts_service == "elevenlabs":
-        logger.info("Using ElevenLabs TTS service for Breeze Buddy voice")
-        return await get_elevenlabs_tts_service(
-            elevenlabs_config=elevenlabs_voice_configurations,
+        return build_elevenlabs_tts(
+            ElevenLabsConfig(
+                api_key=(
+                    ELEVENLABS_INDIAN_RESIDENCY_API_KEY
+                    if use_indian_residency
+                    else ELEVENLABS_API_KEY
+                )
+                or "",
+                url=(
+                    ELEVENLABS_INDIAN_RESIDENCY_WEBSOCKET_URL
+                    if use_indian_residency
+                    else "wss://api.elevenlabs.io"
+                ),
+                voice_id=voice_config.voice_id or "",
+                model=voice_config.model or "eleven_flash_v2_5",
+                speed=voice_config.speed or 1.0,
+                language=_parse_language(voice_config.language, Language.EN_IN),
+                aggregate_sentences=aggregate,
+            )
         )
 
-    elif tts_service == "cartesia":
+    elif provider == "cartesia":
         if not CARTESIA_API_KEY:
-            raise ValueError(
-                "CARTESIA_API_KEY is required when BREEZE_BUDDY_TTS_SERVICE=cartesia"
-            )
+            raise ValueError("CARTESIA_API_KEY is required for Cartesia TTS")
 
-        logger.info("Using Cartesia TTS service for Breeze Buddy voice")
-        return await get_cartesia_tts_service(
-            voice_id=mira_voice_id,
-            cartesia_config=cartesia_voice_configurations,
+        aggregate = await BB_AGGREGATE_SENTENCES("cartesia")
+
+        generation_config = GenerationConfig(
+            volume=voice_config.volume or 1.5,
+            speed=voice_config.speed or 1.0,
+            emotion=voice_config.emotion or "neutral",
+        )
+
+        return build_cartesia_tts(
+            CartesiaConfig(
+                api_key=CARTESIA_API_KEY,
+                voice_id=voice_config.voice_id or "",
+                model=voice_config.model or "sonic-3",
+                language=_parse_language(voice_config.language),
+                generation_config=generation_config,
+                aggregate_sentences=aggregate,
+            )
+        )
+
+    elif provider == "sarvam":
+        if not SARVAM_API_KEY:
+            raise ValueError("SARVAM_API_KEY is required for Sarvam TTS")
+
+        enable_preprocessing = await BB_SARVAM_TTS_ENABLE_PREPROCESSING()
+
+        return build_sarvam_tts(
+            SarvamTTSConfig(
+                api_key=SARVAM_API_KEY,
+                model=voice_config.model or "bulbul:v2",
+                voice_id=voice_config.voice_id or "manisha",
+                language_code=voice_config.language or "en-IN",
+                pitch=voice_config.pitch or 0.0,
+                pace=voice_config.speed or 0.9,
+                enable_preprocessing=enable_preprocessing,
+            )
         )
 
     else:
-        raise ValueError(f"Unsupported BREEZE_BUDDY_TTS_SERVICE: {tts_service}")
+        raise ValueError(f"Unsupported TTS provider: {provider}")
 
 
 async def generate_audio(
-    text: str, voice_name: str, configurations: ConfigurationModel | None = None
+    text: str,
+    voice_config: VoiceConfig | None = None,
+    configurations: ConfigurationModel | None = None,
 ) -> bytes:
-    """
-    Synthesize text to audio bytes using the specified TTS voice.
+    """Synthesize text to audio bytes using the resolved voice configuration.
 
     Args:
         text: The text to synthesize
-        voice_name: The TTS voice to use ("sara", "rhea", or "mira")
-        configurations: Optional configuration model containing voice configurations.
-                       For ElevenLabs (rhea): uses voice_id and model_id if provided.
-                       For Cartesia (mira): uses voice_id and model if provided.
-                       Falls back to default values from static config if None.
+        voice_config: Resolved VoiceConfig. If None, resolves from configurations or defaults.
+        configurations: Template configuration model (used to extract voice_config if not provided directly).
 
     Returns:
         Audio bytes in mulaw format (8kHz, mono) ready to send via Twilio
-
-    Raises:
-        ValueError: If voice_name is invalid or required API keys are missing
-        Exception: If synthesis fails
     """
-    voice_name_lower = voice_name.lower()
+    if not voice_config and configurations:
+        voice_config = configurations.voice_config
 
-    if voice_name_lower == "sara":
-        audio_data = await _generate_sarvam_audio(text)
+    overrides = configurations.voice_config_overrides if configurations else None
+    resolved = await resolve_voice_config(voice_config, overrides)
+    provider = resolved.provider.value
+
+    if provider == "sarvam":
+        audio_data = await _generate_sarvam_audio(
+            text=text,
+            voice_id=resolved.voice_id,
+            model=resolved.model,
+            language=resolved.language,
+            speed=resolved.speed,
+            pitch=resolved.pitch,
+        )
         input_format = "raw"
-    elif voice_name_lower == "rhea":
-        # Extract ElevenLabs config if available
-        elevenlabs_config = (
-            configurations.elevenlabs_voice_configurations if configurations else None
-        )
-        voice_id = (
-            elevenlabs_config.voice_id
-            if elevenlabs_config and elevenlabs_config.voice_id
-            else None
-        )
-        model_id = (
-            elevenlabs_config.model_id
-            if elevenlabs_config and elevenlabs_config.model_id
-            else None
-        )
-
-        # Check if Indian residency should be used (default to True from dynamic config)
+    elif provider == "elevenlabs":
         use_indian_residency = await BB_ENABLE_ELEVENLABS_INDIAN_RESIDENCY()
-
         audio_data = await _generate_elevenlabs_audio(
             text=text,
-            voice_id=voice_id,
-            model_id=model_id,
+            voice_id=resolved.voice_id,
+            model_id=resolved.model,
             use_indian_residency=use_indian_residency,
         )
         input_format = "ulaw"
-    elif voice_name_lower == "mira":
-        # Extract Cartesia config if available (only voice_id is configurable at template level)
-        cartesia_config = (
-            configurations.cartesia_voice_configurations if configurations else None
-        )
-        voice_id = (
-            cartesia_config.voice_id
-            if cartesia_config and cartesia_config.voice_id
-            else None
-        )
-
+    elif provider == "cartesia":
         audio_data = await _generate_cartesia_audio(
             text=text,
-            voice_id=voice_id,
-            # model uses default from BB_CARTESIA_MODEL (not configurable at template level)
+            voice_id=resolved.voice_id,
+            model=resolved.model,
         )
         input_format = "raw"
     else:
-        raise ValueError(
-            f"Invalid voice_name: {voice_name}. Must be 'sara', 'rhea', or 'mira'"
-        )
+        raise ValueError(f"Unsupported TTS provider: {provider}")
 
-    # Convert to Twilio-compatible format (8kHz, mono, mulaw)
     mulaw_audio = convert_to_mulaw(audio_data, input_format=input_format)
     return mulaw_audio

--- a/app/ai/voice/agents/breeze_buddy/utils/tts_utils/tts_provider_selector.py
+++ b/app/ai/voice/agents/breeze_buddy/utils/tts_utils/tts_provider_selector.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, List, Optional
 from pipecat.processors.aggregators.llm_context import LLMContext
 from pipecat.services.google.llm import GoogleLLMService
 
-from app.ai.voice.agents.breeze_buddy.template.types import TTSProvider, TTSVoiceName
+from app.ai.voice.agents.breeze_buddy.template.types import TTSProvider
 from app.core.config.static import GEMINI_API_KEY
 from app.core.logger import logger
 
@@ -16,12 +16,6 @@ GEMINI_TTS_SELECTION_MODEL = "gemini-2.5-flash"
 
 # Timeout for LLM inference calls (in seconds)
 LLM_INFERENCE_TIMEOUT_SECS = 10
-
-# Mapping from TTS provider to existing voice name
-TTS_PROVIDER_TO_VOICE_NAME: Dict[str, TTSVoiceName] = {
-    TTSProvider.ELEVENLABS.value: TTSVoiceName.RHEA,
-    TTSProvider.CARTESIA.value: TTSVoiceName.MIRA,
-}
 
 
 async def detect_tts_provider_from_payload(
@@ -110,17 +104,16 @@ Do not return anything else. Just the provider name."""
         return None
 
 
-async def determine_tts_voice_for_call(
-    template_configurations,
+async def determine_tts_provider_for_call(
+    template_configurations: Any,
     payload: Dict[str, Any],
     request_id: str = "unknown",
-) -> Optional[TTSVoiceName]:
+) -> Optional[TTSProvider]:
     """
-    Determine the TTS voice name for a call based on template config and payload.
+    Determine the TTS provider for a call based on template config and payload.
 
     Checks if payload-based TTS selection is enabled in the template configuration,
-    and if so, uses LLM to select the optimal provider, then maps it to the
-    corresponding voice name (e.g., elevenlabs → rhea, cartesia → mira).
+    and if so, uses LLM to select the optimal provider.
 
     Args:
         template_configurations: Template configurations object
@@ -129,8 +122,8 @@ async def determine_tts_voice_for_call(
         request_id: Request ID for logging purposes
 
     Returns:
-        TTSVoiceName (e.g., RHEA, MIRA) or None if selection is disabled
-        or detection fails (caller should fall back to existing logic)
+        TTSProvider or None if selection is disabled or detection fails
+        (caller should fall back to existing logic)
     """
     if not template_configurations:
         logger.debug(
@@ -149,28 +142,27 @@ async def determine_tts_voice_for_call(
 
     logger.info(f"Attempting LLM-based TTS provider selection for request {request_id}")
 
-    provider = await detect_tts_provider_from_payload(
+    provider_name = await detect_tts_provider_from_payload(
         payload=payload,
         prompt=tts_selection_config.prompt,
         allowed_providers=tts_selection_config.providers,
     )
 
-    if not provider:
+    if not provider_name:
         logger.info(
             f"Could not determine TTS provider from payload for request {request_id}, "
             f"will fall back to template/default config"
         )
         return None
 
-    voice_name = TTS_PROVIDER_TO_VOICE_NAME.get(provider)
-    if voice_name:
+    try:
+        provider = TTSProvider(provider_name)
         logger.info(
-            f"LLM selected TTS provider '{provider}' → voice '{voice_name.value}' "
-            f"for request {request_id}"
+            f"LLM selected TTS provider '{provider.value}' for request {request_id}"
         )
-    else:
+        return provider
+    except ValueError:
         logger.warning(
-            f"No voice name mapping for provider '{provider}', request {request_id}"
+            f"No TTSProvider mapping for '{provider_name}', request {request_id}"
         )
-
-    return voice_name
+        return None

--- a/app/ai/voice/tts/cartesia.py
+++ b/app/ai/voice/tts/cartesia.py
@@ -7,11 +7,7 @@ import httpx
 from pipecat.services.cartesia.tts import CartesiaTTSService, GenerationConfig
 from pipecat.transcriptions.language import Language
 
-from app.core.config.dynamic import (
-    BB_CARTESIA_LANGUAGE,
-    BB_CARTESIA_MODEL,
-    BB_CARTESIA_VOICE_ID,
-)
+from app.core.config.dynamic import BB_VOICE_PROVIDER_DEFAULTS
 from app.core.config.static import CARTESIA_API_KEY
 from app.core.logger import logger
 
@@ -89,12 +85,10 @@ async def _generate_cartesia_audio(
         raise ValueError("CARTESIA_API_KEY is required for Mira voice")
 
     # Use provided values or fall back to defaults
-    default_voice_id = await BB_CARTESIA_VOICE_ID()
-    default_model = await BB_CARTESIA_MODEL()
-    language = await BB_CARTESIA_LANGUAGE()
-
-    final_voice_id = voice_id if voice_id else default_voice_id
-    final_model = model if model else default_model
+    defaults = await BB_VOICE_PROVIDER_DEFAULTS("cartesia")
+    final_voice_id = voice_id if voice_id else defaults.get("voice_id", "")
+    final_model = model if model else defaults.get("model", "sonic-3")
+    language = defaults.get("language")
 
     url = "https://api.cartesia.ai/tts/bytes"
     headers = {

--- a/app/ai/voice/tts/sarvam.py
+++ b/app/ai/voice/tts/sarvam.py
@@ -14,11 +14,7 @@ from pipecat.transcriptions.language import Language
 
 from app.core.config.dynamic import (
     BB_SARVAM_TTS_ENABLE_PREPROCESSING,
-    BB_SARVAM_TTS_LANGUAGE_CODE,
-    BB_SARVAM_TTS_MODEL,
-    BB_SARVAM_TTS_PACE,
-    BB_SARVAM_TTS_PITCH,
-    BB_SARVAM_TTS_VOICE_ID,
+    BB_VOICE_PROVIDER_DEFAULTS,
 )
 from app.core.config.static import SARVAM_API_KEY
 from app.core.logger import logger
@@ -202,16 +198,33 @@ class LanguageAwareSarvamTTS(SarvamTTSService):
             yield frame
 
 
-async def _generate_sarvam_audio(text: str) -> bytes:
-    """Synthesize audio using Sarvam TTS API."""
+async def _generate_sarvam_audio(
+    text: str,
+    voice_id: str | None = None,
+    model: str | None = None,
+    language: str | None = None,
+    speed: float | None = None,
+    pitch: float | None = None,
+) -> bytes:
+    """Synthesize audio using Sarvam TTS API.
+
+    Args:
+        text: The text to synthesize
+        voice_id: Optional voice ID override.
+        model: Optional model override.
+        language: Optional language code override.
+        speed: Optional pace override.
+        pitch: Optional pitch override.
+    """
     if not SARVAM_API_KEY:
         raise ValueError("SARVAM_API_KEY is required for Sara voice")
 
-    model = await BB_SARVAM_TTS_MODEL()
-    voice_id = await BB_SARVAM_TTS_VOICE_ID()
-    language_code = await BB_SARVAM_TTS_LANGUAGE_CODE()
-    pitch = await BB_SARVAM_TTS_PITCH()
-    pace = await BB_SARVAM_TTS_PACE()
+    defaults = await BB_VOICE_PROVIDER_DEFAULTS("sarvam")
+    model = model or defaults.get("model", "bulbul:v2")
+    voice_id = voice_id or defaults.get("voice_id", "manisha")
+    language_code = language or defaults.get("language", "en-IN")
+    pitch = pitch if pitch is not None else defaults.get("pitch", 0.0)
+    pace = speed if speed is not None else defaults.get("speed", 0.9)
     enable_preprocessing = await BB_SARVAM_TTS_ENABLE_PREPROCESSING()
 
     url = "https://api.sarvam.ai/text-to-speech"

--- a/app/api/routers/breeze_buddy/leads/handlers.py
+++ b/app/api/routers/breeze_buddy/leads/handlers.py
@@ -31,7 +31,7 @@ from app.ai.voice.agents.breeze_buddy.utils.language_utils.language_detector imp
     determine_language_for_call,
 )
 from app.ai.voice.agents.breeze_buddy.utils.tts_utils.tts_provider_selector import (
-    determine_tts_voice_for_call,
+    determine_tts_provider_for_call,
 )
 from app.core.logger import logger
 from app.database.accessor import (
@@ -201,14 +201,14 @@ async def push_lead_handler(req: PushLeadRequest, current_user: UserInfo) -> Dic
         # Add language name to payload for use during call (agent.py uses this)
         lead_payload["language_name"] = language_name
 
-        # Determine TTS voice using LLM if payload-based selection is enabled
-        tts_voice_name = await determine_tts_voice_for_call(
+        # Determine TTS provider using LLM if payload-based selection is enabled
+        tts_provider = await determine_tts_provider_for_call(
             template.configurations if template else None,
             lead_payload,
             req.request_id,
         )
-        if tts_voice_name:
-            lead_payload["tts_voice_name"] = tts_voice_name.value
+        if tts_provider:
+            lead_payload["tts_provider"] = tts_provider.value
 
         # Insert lead call tracker record with both template name and template_id
         lead_call_tracker = await create_lead_call_tracker(

--- a/app/api/routers/breeze_buddy/telephony/answer/handlers.py
+++ b/app/api/routers/breeze_buddy/telephony/answer/handlers.py
@@ -29,7 +29,7 @@ INBOUND (customer calls us):
 import asyncio
 import json
 from html import escape as html_escape
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 from urllib.parse import quote
 
 from fastapi import Request, Response
@@ -52,6 +52,7 @@ from app.ai.voice.agents.breeze_buddy.services.inbound_policy import (
 from app.ai.voice.agents.breeze_buddy.services.telephony.plivo.recording import (
     start_call_recording,
 )
+from app.ai.voice.agents.breeze_buddy.template.types import VoiceConfig
 from app.core.config.dynamic import (
     BB_NOISE_CANCELLATION_ENABLED,
     BB_NOISE_CANCELLATION_LEVEL,
@@ -83,7 +84,7 @@ async def resolve_call_templates(
     2. If outbound: look up template from lead
     3. If inbound: look up outbound_number by to_number, get all templates
     4. Build template_list with IVR descriptions
-    5. Resolve voice_name and ivr_greeting from template configurations
+    5. Resolve IVR config (voice, greeting, goodbye) from template configurations
 
     Args:
         call_sid: Unique call identifier (Exotel CallSid / Plivo CallUUID)
@@ -97,8 +98,9 @@ async def resolve_call_templates(
             merchant_id: Optional[str]         (merchant ID for pod allocation)
             templates: List[TemplateModel]      (inbound: all matched templates)
             template_list: List[dict]           (inbound: [{id, name, description}])
-            voice_name: str                     (IVR voice, default "sara")
+            ivr_voice_config: Optional[dict]   (IVR voice config dict)
             ivr_greeting: Optional[str]         (IVR greeting text)
+            ivr_goodbye: Optional[str]          (IVR goodbye text)
             error: Optional[str]               (if lookup failed)
             error_status: Optional[int]        (HTTP status for error)
     """
@@ -153,28 +155,47 @@ async def resolve_call_templates(
         for t in templates
     ]
 
-    # Resolve voice_name, ivr_greeting, and ivr_goodbye from template configurations
-    voice_name = "sara"  # Default voice
-    ivr_greeting = None
-    ivr_goodbye = None
-
+    # Resolve IVR config from templates — first non-None ivr_config wins for each field
     first_template = templates[0]
-    if first_template.configurations and first_template.configurations.tts_voice_name:
-        voice_name = first_template.configurations.tts_voice_name.value
+    ivr_greeting: Optional[str] = None
+    ivr_goodbye: Optional[str] = None
+    ivr_voice_config_dict: Optional[Dict[str, Any]] = None
 
     for template in templates:
-        if template.configurations:
-            if not ivr_greeting and template.configurations.ivr_greeting:
-                ivr_greeting = template.configurations.ivr_greeting
-            if not ivr_goodbye and template.configurations.ivr_goodbye:
-                ivr_goodbye = template.configurations.ivr_goodbye
-            if ivr_greeting and ivr_goodbye:
-                break
+        cfg = template.configurations
+        if not cfg:
+            continue
+        ivr = cfg.ivr_config
+        if ivr:
+            if not ivr_greeting and ivr.greeting:
+                ivr_greeting = ivr.greeting
+            if not ivr_goodbye and ivr.goodbye:
+                ivr_goodbye = ivr.goodbye
+            if not ivr_voice_config_dict and ivr.voice_config:
+                ivr_voice_config_dict = ivr.voice_config.model_dump(exclude_none=True)
+        # Backward compat: flat fields (already migrated into ivr_config by validator,
+        # but check directly in case raw DB data hasn't been re-saved)
+        if not ivr_greeting and cfg.ivr_greeting:
+            ivr_greeting = cfg.ivr_greeting
+        if not ivr_goodbye and cfg.ivr_goodbye:
+            ivr_goodbye = cfg.ivr_goodbye
+        if ivr_greeting and ivr_goodbye:
+            break
 
-    # Warn if IVR mode (multiple templates) but no ivr_greeting configured
+    # Fall back to main voice_config for IVR voice if no ivr-specific one
+    if not ivr_voice_config_dict:
+        vc = (
+            first_template.configurations.voice_config
+            if first_template.configurations
+            else None
+        )
+        if vc:
+            ivr_voice_config_dict = vc.model_dump(exclude_none=True)
+
+    # Warn if IVR mode but no greeting configured
     if len(templates) > 1 and ivr_greeting is None:
         logger.warning(
-            f"[Answer] IVR mode with {len(templates)} templates but no ivr_greeting configured "
+            f"[Answer] IVR mode with {len(templates)} templates but no ivr greeting configured "
             f"for outbound_number: {to_number}"
         )
 
@@ -182,7 +203,7 @@ async def resolve_call_templates(
         "is_outbound": False,
         "templates": templates,
         "template_list": template_list,
-        "voice_name": voice_name,
+        "ivr_voice_config": ivr_voice_config_dict,
         "ivr_greeting": ivr_greeting,
         "ivr_goodbye": ivr_goodbye,
         "reseller_id": first_template.reseller_id if first_template else None,
@@ -432,20 +453,26 @@ async def _build_provider_response(
         return await make_response(ws_url)
 
     # Multiple templates - IVR mode
-    voice_name = result["voice_name"]
+    ivr_voice_config_dict = result.get("ivr_voice_config")
     ivr_greeting = result["ivr_greeting"]
     ivr_goodbye = result.get("ivr_goodbye")
 
-    logger.info(f"[{tag}] IVR mode - {len(templates)} templates, voice={voice_name}")
+    # Convert dict to VoiceConfig for IVR helpers (they access .provider.value etc.)
+    ivr_voice = VoiceConfig(**ivr_voice_config_dict) if ivr_voice_config_dict else None
+
+    logger.info(
+        f"[{tag}] IVR mode - {len(templates)} templates, "
+        f"voice_provider={ivr_voice.provider.value if ivr_voice else 'default'}"
+    )
 
     # Pre-generate IVR audio (checks cache first)
-    await prepare_ivr_menu_audio(provider, voice_name, ivr_greeting)
-    await prepare_goodbye_audio(provider, voice_name, ivr_goodbye)
+    await prepare_ivr_menu_audio(provider, ivr_greeting, ivr_voice)
+    await prepare_goodbye_audio(provider, ivr_goodbye, ivr_voice)
 
     # Store IVR config in Redis
     ivr_config = {
         "options": template_list,
-        "voice_name": voice_name,
+        "voice_config": ivr_voice_config_dict,
         "ivr_greeting": ivr_greeting,
         "ivr_goodbye": ivr_goodbye,
     }

--- a/app/core/config/dynamic.py
+++ b/app/core/config/dynamic.py
@@ -1,4 +1,9 @@
+import json
+import logging
+
 from app.services.live_config.store import get_config
+
+logger = logging.getLogger(__name__)
 
 # -----------------------
 # Dynamic runtime configs
@@ -107,29 +112,59 @@ async def BB_SARVAM_STT_HIGH_VAD_SENSITIVITY() -> bool:
     return await get_config("BB_SARVAM_STT_HIGH_VAD_SENSITIVITY", False, bool)
 
 
-async def BB_SARVAM_TTS_MODEL() -> str:
-    """Returns BB_SARVAM_TTS_MODEL from Redis"""
-    return await get_config("BB_SARVAM_TTS_MODEL", "bulbul:v2", str)
+async def BB_TTS_SERVICE() -> str:
+    """Returns BREEZE_BUDDY_TTS_SERVICE from Redis (default provider name)"""
+    return await get_config("BREEZE_BUDDY_TTS_SERVICE", "elevenlabs", str)
 
 
-async def BB_SARVAM_TTS_VOICE_ID() -> str:
-    """Returns BB_SARVAM_TTS_VOICE_ID from Redis"""
-    return await get_config("BB_SARVAM_TTS_VOICE_ID", "manisha", str)
+# --- Per-provider voice defaults (Redis-backed, overridable at runtime) ---
+# Each provider has a dict of defaults. Template-level VoiceConfig fields
+# override these; fields left as None in VoiceConfig fall back here.
+
+BB_PROVIDER_DEFAULTS: dict[str, dict] = {
+    "elevenlabs": {
+        "voice_id": "fG9s0SXJb213f4UxVHyG",
+        "model": "eleven_flash_v2_5",
+        "speed": 1.15,
+        "language": "en",
+    },
+    "cartesia": {
+        "voice_id": "bec003e2-3cb3-429c-8468-206a393c67ad",
+        "model": "sonic-3",
+        "speed": 1.0,
+        "volume": 1.5,
+        "emotion": "neutral",
+        "language": None,
+    },
+    "sarvam": {
+        "voice_id": "manisha",
+        "model": "bulbul:v2",
+        "language": "en-IN",
+        "speed": 0.9,
+        "pitch": 0.0,
+    },
+}
 
 
-async def BB_SARVAM_TTS_LANGUAGE_CODE() -> str:
-    """Returns BB_SARVAM_TTS_LANGUAGE_CODE from Redis"""
-    return await get_config("BB_SARVAM_TTS_LANGUAGE_CODE", "en-IN", str)
+async def BB_VOICE_PROVIDER_DEFAULTS(provider: str) -> dict:
+    """Returns merged provider defaults: Redis overrides > hardcoded defaults.
 
-
-async def BB_SARVAM_TTS_PITCH() -> float:
-    """Returns BB_SARVAM_TTS_PITCH from Redis"""
-    return await get_config("BB_SARVAM_TTS_PITCH", 0.0, float)
-
-
-async def BB_SARVAM_TTS_PACE() -> float:
-    """Returns BB_SARVAM_TTS_PACE from Redis"""
-    return await get_config("BB_SARVAM_TTS_PACE", 0.9, float)
+    Redis key: BB_VOICE_DEFAULTS_<PROVIDER> (JSON string).
+    Falls back to BB_PROVIDER_DEFAULTS[provider] for any missing keys.
+    Null values in Redis are treated as "unset" and filtered out.
+    """
+    hardcoded = BB_PROVIDER_DEFAULTS.get(provider, {})
+    redis_key = f"BB_VOICE_DEFAULTS_{provider.upper()}"
+    redis_json = await get_config(redis_key, None, str)
+    if redis_json:
+        try:
+            redis_overrides = json.loads(redis_json)
+            # Filter out None values — treat them as "unset, use hardcoded default"
+            filtered = {k: v for k, v in redis_overrides.items() if v is not None}
+            return {**hardcoded, **filtered}
+        except (json.JSONDecodeError, TypeError) as e:
+            logger.warning(f"Failed to parse {redis_key} from Redis: {e}")
+    return dict(hardcoded)
 
 
 async def BB_SARVAM_TTS_ENABLE_PREPROCESSING() -> bool:
@@ -137,47 +172,10 @@ async def BB_SARVAM_TTS_ENABLE_PREPROCESSING() -> bool:
     return await get_config("BB_SARVAM_TTS_ENABLE_PREPROCESSING", True, bool)
 
 
-async def BB_TTS_SERVICE() -> str:
-    """Returns BREEZE_BUDDY_TTS_SERVICE from Redis"""
-    return await get_config("BREEZE_BUDDY_TTS_SERVICE", "elevenlabs", str)
-
-
-# --- Breeze Buddy Cartesia TTS Configuration ---
-async def BB_CARTESIA_VOICE_ID() -> str:
-    """Returns BB_CARTESIA_VOICE_ID from Redis"""
-    return await get_config(
-        "BB_CARTESIA_VOICE_ID", "bec003e2-3cb3-429c-8468-206a393c67ad", str
-    )
-
-
-async def BB_CARTESIA_MODEL() -> str:
-    """Returns BB_CARTESIA_MODEL from Redis"""
-    return await get_config("BB_CARTESIA_MODEL", "sonic-3", str)
-
-
-async def BB_CARTESIA_LANGUAGE() -> str:
-    """Returns BB_CARTESIA_LANGUAGE from Redis (language code like 'en', 'es', 'hi')"""
-    return await get_config("BB_CARTESIA_LANGUAGE", None, str)
-
-
-async def BB_CARTESIA_GENERATION_VOLUME() -> float:
-    """Returns BB_CARTESIA_GENERATION_VOLUME from Redis (range: 0.5-2.0)"""
-    return await get_config("BB_CARTESIA_GENERATION_VOLUME", 1.5, float)
-
-
-async def BB_CARTESIA_GENERATION_SPEED() -> float:
-    """Returns BB_CARTESIA_GENERATION_SPEED from Redis (range: 0.6-1.5)"""
-    return await get_config("BB_CARTESIA_GENERATION_SPEED", 1.0, float)
-
-
-async def BB_CARTESIA_GENERATION_EMOTION() -> str:
-    """Returns BB_CARTESIA_GENERATION_EMOTION from Redis"""
-    return await get_config("BB_CARTESIA_GENERATION_EMOTION", "neutral", str)
-
-
-async def BB_CARTESIA_AGGREGATE_SENTENCES() -> bool:
-    """Returns BB_CARTESIA_AGGREGATE_SENTENCES from Redis"""
-    return await get_config("BB_CARTESIA_AGGREGATE_SENTENCES", True, bool)
+async def BB_AGGREGATE_SENTENCES(provider: str) -> bool:
+    """Returns aggregate_sentences setting for a provider from Redis."""
+    key = f"BB_{provider.upper()}_AGGREGATE_SENTENCES"
+    return await get_config(key, True, bool)
 
 
 async def SHOPS_FOR_TEMPLATE_FLOW() -> list[str]:
@@ -282,22 +280,6 @@ async def BB_ENABLE_ELEVENLABS_INDIAN_RESIDENCY() -> bool:
     return await get_config("BB_ENABLE_ELEVENLABS_INDIAN_RESIDENCY", True, bool)
 
 
-# --- Breeze Buddy ElevenLabs TTS Configuration ---
-async def BB_ELEVENLABS_VOICE_ID() -> str:
-    """Returns BB_ELEVENLABS_VOICE_ID from Redis"""
-    return await get_config("BB_ELEVENLABS_VOICE_ID", "fG9s0SXJb213f4UxVHyG", str)
-
-
-async def BB_ELEVENLABS_MODEL_ID() -> str:
-    """Returns BB_ELEVENLABS_MODEL_ID from Redis"""
-    return await get_config("BB_ELEVENLABS_MODEL_ID", "eleven_flash_v2_5", str)
-
-
-async def BB_ELEVENLABS_VOICE_SPEED() -> float:
-    """Returns BB_ELEVENLABS_VOICE_SPEED from Redis"""
-    return await get_config("BB_ELEVENLABS_VOICE_SPEED", 1.15, float)
-
-
 # --- Breeze Buddy Transfer Configuration ---
 async def BB_TRANSFER_CONFERENCE_TIMEOUT() -> int:
     """Seconds to wait for agent to join conference"""
@@ -317,11 +299,6 @@ async def BB_TRANSFER_MAX_RETRIES() -> int:
 async def BB_TRANSFER_RETRY_DELAY() -> float:
     """Seconds between retries"""
     return await get_config("BB_TRANSFER_RETRY_DELAY", 2.0, float)
-
-
-async def BB_ELEVENLABS_AGGREGATE_SENTENCES() -> bool:
-    """Returns BB_ELEVENLABS_AGGREGATE_SENTENCES from Redis (True = wait for full sentence, False = stream tokens immediately)"""
-    return await get_config("BB_ELEVENLABS_AGGREGATE_SENTENCES", True, bool)
 
 
 async def BREEZE_BUDDY_ENABLE_VAD() -> bool:

--- a/app/database/decoder/breeze_buddy/template.py
+++ b/app/database/decoder/breeze_buddy/template.py
@@ -3,7 +3,7 @@ Decoder functions for templates.
 """
 
 import json
-from typing import List, Optional
+from typing import Any, Dict, List, Optional
 
 import asyncpg
 
@@ -11,6 +11,108 @@ from app.ai.voice.agents.breeze_buddy.template.types import (
     ConfigurationModel,
     TemplateModel,
 )
+from app.core.logger import logger
+
+# Map legacy voice names to provider strings for backward compat
+_LEGACY_VOICE_TO_PROVIDER = {
+    "rhea": "elevenlabs",
+    "mira": "cartesia",
+    "sara": "sarvam",
+}
+
+
+def _to_provider_config(provider: str, raw: Dict[str, Any]) -> Dict[str, Any]:
+    """Build a voice_config dict from a legacy provider-specific config."""
+    cfg: Dict[str, Any] = {"provider": provider}
+    if provider == "cartesia":
+        cfg["voice_id"] = raw.get("voice_id")
+        cfg["volume"] = raw.get("volume")
+        cfg["speed"] = raw.get("speed")
+        cfg["emotion"] = raw.get("emotion")
+        cfg["language"] = raw.get("language")
+    elif provider == "elevenlabs":
+        cfg["voice_id"] = raw.get("voice_id")
+        cfg["model"] = raw.get("model_id")
+        cfg["speed"] = raw.get("speed")
+        cfg["language"] = raw.get("language")
+    return {k: v for k, v in cfg.items() if v is not None}
+
+
+def _migrate_legacy_voice_config(data: Dict[str, Any]) -> Dict[str, Any]:
+    """Convert old-format voice fields to the new unified voice_config.
+
+    Handles templates stored with the old schema:
+      - tts_voice_name: "rhea" / "mira" / "sara"
+      - mira_voice_id: str
+      - cartesia_voice_configurations: {...}
+      - elevenlabs_voice_configurations: {...}
+
+    Transforms them into voice_config + voice_config_overrides.
+    Already-migrated templates (with voice_config) pass through unchanged.
+    """
+    if "voice_config" in data and data["voice_config"]:
+        # Already in new format — strip old fields if present
+        for old_key in [
+            "tts_voice_name",
+            "mira_voice_id",
+            "cartesia_voice_configurations",
+            "elevenlabs_voice_configurations",
+        ]:
+            data.pop(old_key, None)
+        return data
+
+    # Determine default provider from tts_voice_name
+    old_voice_name = data.pop("tts_voice_name", None)
+    default_provider = None
+    if old_voice_name:
+        name = (
+            old_voice_name.lower()
+            if isinstance(old_voice_name, str)
+            else old_voice_name
+        )
+        default_provider = _LEGACY_VOICE_TO_PROVIDER.get(name)
+
+    # Extract provider-specific configs
+    old_cartesia = data.pop("cartesia_voice_configurations", None)
+    old_elevenlabs = data.pop("elevenlabs_voice_configurations", None)
+    old_mira_voice_id = data.pop("mira_voice_id", None)
+
+    provider_configs: Dict[str, Dict[str, Any]] = {}
+
+    if old_cartesia and isinstance(old_cartesia, dict):
+        provider_configs["cartesia"] = _to_provider_config("cartesia", old_cartesia)
+    if old_elevenlabs and isinstance(old_elevenlabs, dict):
+        provider_configs["elevenlabs"] = _to_provider_config(
+            "elevenlabs", old_elevenlabs
+        )
+
+    # Legacy mira_voice_id → cartesia voice_id fallback
+    if old_mira_voice_id:
+        cartesia_cfg = provider_configs.setdefault("cartesia", {"provider": "cartesia"})
+        cartesia_cfg.setdefault("voice_id", old_mira_voice_id)
+
+    # Build voice_config from default provider
+    if not default_provider:
+        # Infer from whichever provider config exists
+        default_provider = next(iter(provider_configs), None)
+
+    if default_provider:
+        # Use the default provider's config as voice_config
+        data["voice_config"] = provider_configs.pop(
+            default_provider, {"provider": default_provider}
+        )
+        # Remaining provider configs become overrides
+        if provider_configs:
+            data["voice_config_overrides"] = provider_configs
+            logger.debug(
+                f"Migrated legacy voice config with overrides: {list(provider_configs.keys())}"
+            )
+        else:
+            logger.debug(f"Migrated legacy voice config: provider={default_provider}")
+    else:
+        data["voice_config"] = None
+
+    return data
 
 
 def decode_template(result: asyncpg.Record) -> Optional[TemplateModel]:
@@ -55,6 +157,9 @@ def decode_template(result: asyncpg.Record) -> Optional[TemplateModel]:
         if isinstance(configurations_data, str):
             # If it's a string, parse it
             configurations_data = json.loads(configurations_data)
+
+        # Migrate old voice fields to new unified voice_config
+        configurations_data = _migrate_legacy_voice_config(configurations_data)
 
         # Create ConfigurationModel from the parsed data
         configurations = ConfigurationModel(**configurations_data)


### PR DESCRIPTION
Replace scattered voice config (CartesiaVoiceConfiguration, ElevenLabsVoiceConfiguration, TTSVoiceName, mira_voice_id) with a single VoiceConfig model containing provider + provider-specific settings. Consolidate ~25 individual Redis functions into per-provider defaults dict. Add backward-compatible DB decoder that migrates old template format on read.

https://claude.ai/code/session_01TLKeadJBhwSpqVMG5i5Wqz

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Unified voice-configuration model enabling selection of TTS provider via payload and IVR flows.
  * IVR and call flows now use provider-driven voice settings for audio generation.

* **Refactor**
  * Consolidated per-provider settings into a single voice_config with provider defaults and overrides.
  * Added migration/fallback for legacy voice settings to the new schema.

* **Documentation**
  * Updated example templates to reflect the new voice_config schema.

* **Bug Fixes**
  * Invalid provider values now log a warning and fall back to existing config.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->