### PR TITLE
stt fallback using circuit breaker

### DIFF
--- a/app/ai/voice/agents/breeze_buddy/agent/__init__.py
+++ b/app/ai/voice/agents/breeze_buddy/agent/__init__.py
@@ -1,0 +1,1059 @@
+"""Voice agent for handling conversations via Daily or telephony transports."""
+
+import asyncio
+from datetime import datetime, timezone
+from typing import Any, Callable, Dict, List, Optional
+
+from fastapi import WebSocket
+from opentelemetry import trace
+from pipecat.audio.vad.silero import SileroVADAnalyzer
+from pipecat.audio.vad.vad_analyzer import VADParams
+from pipecat.frames.frames import EndFrame, LLMMessagesAppendFrame
+from pipecat.pipeline.runner import PipelineRunner
+from pipecat.pipeline.service_switcher import ManuallySwitchServiceFrame
+from pipecat.pipeline.task import PipelineTask
+from pipecat.processors.aggregators.llm_context import LLMContext
+from pipecat.runner.types import RunnerArguments
+from pipecat.runner.utils import (
+    _create_telephony_transport,
+    create_transport,
+    parse_telephony_websocket,
+)
+from pipecat_flows import FlowManager
+
+from app.ai.voice.agents.breeze_buddy.agent.flow import (
+    build_flow_config,
+    load_template_config,
+    prepare_initial_node,
+    setup_flow_manager,
+)
+from app.ai.voice.agents.breeze_buddy.agent.inbound import (
+    create_lead_from_template_id,
+    handle_inbound_call,
+)
+from app.ai.voice.agents.breeze_buddy.agent.ivr import (
+    BLOCK_MESSAGE_PLAY_SECONDS,
+    _send_audio,
+    get_template_id_from_call,
+    prepare_block_audio,
+)
+from app.ai.voice.agents.breeze_buddy.agent.pipeline import (
+    build_pipeline,
+    create_pipeline_task,
+    create_services,
+    generate_conversation_id,
+)
+from app.ai.voice.agents.breeze_buddy.agent.transport import (
+    TRANSPORT_TYPE_DAILY,
+    get_transport_params,
+)
+from app.ai.voice.agents.breeze_buddy.agent.utils import (
+    end_call_with_errors,
+    send_initial_greeting,
+)
+from app.ai.voice.agents.breeze_buddy.agent.vad import create_vad_analyzer
+from app.ai.voice.agents.breeze_buddy.handlers.internal.end_conversation import (
+    end_conversation,
+)
+from app.ai.voice.agents.breeze_buddy.observability.tracing_setup import (
+    create_root_span,
+)
+from app.ai.voice.agents.breeze_buddy.services.inbound_policy import (
+    get_block_redirect,
+)
+from app.ai.voice.agents.breeze_buddy.services.telephony.base_provider import (
+    VoiceCallProvider,
+)
+from app.ai.voice.agents.breeze_buddy.template import TemplateContext
+from app.ai.voice.agents.breeze_buddy.template.builder import FlowConfigBuilder
+from app.ai.voice.agents.breeze_buddy.template.context import with_context
+from app.ai.voice.agents.breeze_buddy.template.types import (
+    ConfigurationModel,
+    TemplateModel,
+    TTSVoiceName,
+)
+from app.ai.voice.agents.breeze_buddy.utils.common import (
+    create_background_sound_mixer,
+    track_error,
+)
+from app.ai.voice.agents.breeze_buddy.utils.transport.websockets import (
+    close_websocket_safely,
+)
+from app.ai.voice.agents.breeze_buddy.utils.warm_transfer import set_transfer_flag
+from app.core.config.static import (
+    ENABLE_BREEZE_BUDDY_STT_FALLBACK,
+    ENABLE_BREEZE_BUDDY_TRACING,
+)
+from app.core.logger import logger
+from app.core.logger.context import (
+    clear_log_context,
+    set_log_context,
+    update_log_context,
+)
+from app.database.accessor import update_lead_call_initiated_time
+from app.database.accessor.breeze_buddy.lead_call_tracker import (
+    update_lead_call_initiated_time_by_id,
+)
+from app.schemas import CallProvider
+from app.schemas.breeze_buddy.core import LeadCallTracker
+from app.services.slack import slack_alert
+
+DEFAULT_OUTCOME = "BUSY"
+
+# Background task references to prevent premature GC of fire-and-forget tasks
+_background_tasks: set[asyncio.Task] = set()
+
+
+def _fire_and_forget(coro) -> None:
+    """Schedule a coroutine as a fire-and-forget task, preventing GC."""
+    task = asyncio.create_task(coro)
+    _background_tasks.add(task)
+    task.add_done_callback(_background_tasks.discard)
+
+
+class Agent:
+    """Voice agent that handles conversations via Daily or telephony transports."""
+
+    def __init__(
+        self,
+        transport_type: str,
+        ws: Optional[WebSocket] = None,
+        aiohttp_session: Any = None,
+        completion_function: Optional[Callable] = None,
+        provider: Optional[str] = None,
+        telephony_service: Optional[VoiceCallProvider] = None,
+    ):
+        # Transport configuration
+        self.transport_type = transport_type
+        self.ws = ws
+        self.aiohttp_session = aiohttp_session
+        self.provider = provider
+        self.completion_function = completion_function
+        self.telephony_service = telephony_service
+
+        # Runtime state
+        self.task: Optional[PipelineTask] = None
+        self.context: Optional[LLMContext] = None
+        self.conversation_ended = False
+        self.call_sid: Optional[str] = None
+        self.stream_sid: Optional[str] = None
+        self.vad_analyzer: Optional[SileroVADAnalyzer] = None
+        self.transport: Any = None
+        self.lead: Optional[LeadCallTracker] = None
+        self.root_span: Any = None
+        self.flow_manager: Optional[FlowManager] = None
+        self.conversation_id: Optional[str] = None
+
+        # Template configuration
+        self.flow_builder: Any = None
+        self.template: Optional[TemplateModel] = None
+        self.configurations: Optional[ConfigurationModel] = None
+        self.flow_config: Optional[Dict[str, Any]] = None
+        self.end_conversation_callbacks: List = []
+        self.expected_callback_response_schema: Any = None
+        self.greeting_source: Optional[str] = None
+        self.greeting_text: Optional[str] = (
+            None  # Resolved greeting text for LLM context
+        )
+        self.default_vad_params: Optional[VADParams] = None
+
+        # User idle handling
+        self._user_idle_callback_handler: Any = None
+        self._context_aggregator: Any = None
+
+        # Post-greeting idle detection
+        self._post_greeting_task: Optional[asyncio.Task] = None
+        self._user_spoke: bool = False
+
+        # Transcription gate processor (always present in pipeline)
+        self.speech_gate: Any = None
+
+        # STT provider tracking (for mid-call error attribution)
+        self.stt_provider: str = "soniox"
+
+        # Mid-call STT fallback (ServiceSwitcher)
+        self.fallback_stt: Optional[Any] = None
+        self.stt_switched: bool = False
+        self.is_probe_call: bool = False
+        self._stt_failure_recorded: bool = False
+
+        # Error tracking
+        self.errors: List[Dict[str, Any]] = []
+
+    @property
+    def is_daily_mode(self) -> bool:
+        return self.transport_type == TRANSPORT_TYPE_DAILY
+
+    async def _handle_user_idle_timeout(self, idle_retry_count: int) -> None:
+        """Handle user idle timeout by ending call with BUSY outcome.
+
+        This is passed as a callback to the user idle processor to trigger
+        the full end_conversation flow which collects transcription, errors,
+        and other metadata.
+
+        Args:
+            idle_retry_count: Number of idle retries that occurred
+        """
+        if self.conversation_ended:
+            logger.debug(
+                "Conversation already ended, skipping _handle_user_idle_timeout"
+            )
+            return
+
+        # Don't set conversation_ended here - let end_conversation handler do it
+        # This prevents end_conversation from skipping finalization
+
+        if self.lead:
+            self.lead.outcome = "BUSY"
+            if self.lead.metaData is None:
+                self.lead.metaData = {}
+            self.lead.metaData["call_ended_by"] = "system"
+            self.lead.metaData["call_end_reason"] = "user_idle_timeout"
+            self.lead.metaData["idle_retry_count"] = idle_retry_count
+
+        logger.info(
+            f"Ending call as BUSY due to user idle timeout "
+            f"(retries: {idle_retry_count})"
+        )
+
+        context = TemplateContext(self)
+        await end_conversation(context, {})
+
+    async def _handle_post_greeting_idle(self, user_idle_config) -> None:
+        """Handle post-greeting idle detection before user speaks for the first time.
+
+        This runs as an asyncio task that waits for the idle timeout and triggers
+        the first idle prompt if the user hasn't spoken yet.
+        """
+        try:
+            # Wait for greeting to finish (~5s) + idle timeout before checking
+            initial_delay = 5.0  # Estimated greeting duration
+            await asyncio.sleep(initial_delay + user_idle_config.timeout)
+
+            # If user never spoke, trigger first idle prompt
+            if not self._user_spoke and self.task:
+                logger.info("Post-greeting idle detected. Triggering first prompt.")
+                await self.task.queue_frames(
+                    [
+                        LLMMessagesAppendFrame(
+                            [
+                                {
+                                    "role": "system",
+                                    "content": user_idle_config.idle_message,
+                                }
+                            ],
+                            run_llm=True,
+                        )
+                    ]
+                )
+        except asyncio.CancelledError:
+            logger.debug("Post-greeting idle timer cancelled.")
+            return
+
+    async def _send_mid_call_stt_alert(self, processor: str, error_msg: str) -> None:
+        """Send Slack alert when STT fails and the call is terminated."""
+        call_sid = self.call_sid or "unknown"
+        lead_id = str(self.lead.id) if self.lead else "unknown"
+        # Tailor the message based on whether fallback was used
+        if self.stt_switched:
+            what_happened = (
+                f"Both STT providers (Soniox and Deepgram) failed during an active call. "
+                f"The call was terminated.\n"
+                f"```{error_msg[:500]}```"
+            )
+        else:
+            what_happened = (
+                f"STT provider `{self.stt_provider}` failed during an active call. "
+                f"No fallback was available so the call was terminated.\n"
+                f"```{error_msg[:500]}```"
+            )
+        try:
+            await slack_alert.send(
+                title="🚨 STT Failed — Call Ended (Breeze Buddy)",
+                fields=[
+                    {"name": "Provider", "value": self.stt_provider},
+                    {"name": "Processor", "value": processor},
+                    {"name": "Call SID", "value": call_sid},
+                    {"name": "Lead ID", "value": lead_id},
+                ],
+                sections=[
+                    {
+                        "title": "What Happened",
+                        "text": what_happened,
+                    },
+                ],
+                fallback_text=f"STT failed — call ended: {self.stt_provider} — call {call_sid}",
+            )
+        except Exception as alert_err:
+            logger.warning(f"Failed to send mid-call STT Slack alert: {alert_err}")
+
+    async def _send_stt_fallback_activated_alert(
+        self, failed_provider: str, processor: str, error_msg: str
+    ) -> None:
+        """Send Slack alert when Soniox fails mid-call and Deepgram takes over."""
+        call_sid = self.call_sid or "unknown"
+        lead_id = str(self.lead.id) if self.lead else "unknown"
+        try:
+            await slack_alert.send(
+                title="⚠️ Soniox Failed — Switched to Deepgram Mid-Call (Breeze Buddy)",
+                fields=[
+                    {"name": "Failed Provider", "value": failed_provider},
+                    {"name": "Switched To", "value": "deepgram"},
+                    {"name": "Processor", "value": processor},
+                    {"name": "Call SID", "value": call_sid},
+                    {"name": "Lead ID", "value": lead_id},
+                ],
+                sections=[
+                    {
+                        "title": "What Happened",
+                        "text": (
+                            f"Soniox failed during an active call. "
+                            f"Deepgram was activated as fallback — call is continuing.\n"
+                            f"```{error_msg[:500]}```"
+                        ),
+                    },
+                ],
+                fallback_text=f"Soniox failed mid-call — switched to Deepgram — call {call_sid}",
+            )
+        except Exception as alert_err:
+            logger.warning(
+                f"Failed to send STT fallback activation Slack alert: {alert_err}"
+            )
+
+    async def _setup_daily_transport(self, runner_args: RunnerArguments) -> None:
+        """Initialize transport for Daily mode."""
+        if not runner_args or not runner_args.body:
+            raise ValueError("runner_args with body is required for Daily mode")
+
+        lead_id = runner_args.body.get("lead_id")
+        if not lead_id:
+            raise ValueError("lead_id is required in runner_args.body for Daily mode")
+
+        # Set lead_id context immediately - all subsequent logs will include it
+        set_log_context(lead_id=str(lead_id))
+
+        call_initiated_time = datetime.now(timezone.utc)
+        self.lead = await update_lead_call_initiated_time_by_id(
+            lead_id, call_initiated_time
+        )
+        if not self.lead:
+            raise ValueError(f"Lead not found for lead_id: {lead_id}")
+
+        # Update context with call_sid (lead_id already set above)
+        self.call_sid = (
+            self.lead.call_id or f"daily-{datetime.now().strftime('%Y%m%d%H%M%S')}"
+        )
+        update_log_context(call_sid=self.call_sid)
+
+        logger.info(
+            f"Starting Daily bot for lead_id: {lead_id}, call_sid: {self.call_sid}"
+        )
+
+        self.flow_builder = FlowConfigBuilder()
+
+        for handler_name, handler_func in self.flow_builder.handler_map.items():
+            self.flow_builder.handler_map[handler_name] = with_context(self)(
+                handler_func
+            )
+
+        try:
+            (
+                self.template,
+                self.configurations,
+                self.template_vars,
+            ) = await load_template_config(self.lead)
+        except ValueError as e:
+            logger.error(f"Failed to load template config for Daily mode: {e}")
+            raise
+
+        self.vad_analyzer, self.default_vad_params = await create_vad_analyzer(
+            is_daily_mode=True
+        )
+
+        # Daily transport does not support audio_out_mixer, so we pass None
+        # Note: VAD is configured in the aggregator (via UserTurnStrategies), not the transport
+        transport_params = get_transport_params(None, self.configurations)
+        self.transport = await create_transport(runner_args, transport_params)
+
+    async def _setup_telephony_transport(self) -> bool:
+        """Initialize transport for telephony mode. Returns False if setup fails."""
+        logger.info("Starting WebSocket bot")
+        if not self.ws:
+            logger.error("WebSocket not initialized")
+            return False
+        await self.ws.accept()
+        call_initiated_time = datetime.now(timezone.utc)
+
+        # Parse WebSocket messages to get transport type and call data
+        transport_type, call_data = await parse_telephony_websocket(self.ws)
+
+        self.call_sid = call_data.get("call_id")
+        self.stream_sid = call_data.get("stream_id")
+
+        if not self.stream_sid or not self.call_sid:
+            logger.error(
+                f"Missing required call identifiers: stream_sid={self.stream_sid}, call_id={self.call_sid}"
+            )
+            return False
+
+        # Set call_sid context early for log isolation
+        set_log_context(call_sid=self.call_sid)
+
+        logger.info(
+            f"Parsed WebSocket: transport_type={transport_type}, "
+            f"call_sid: {self.call_sid}, stream_sid: {self.stream_sid}"
+        )
+
+        # Check for Exotel block-redirect (set at answer-time when inbound
+        # policy blocks with REDIRECT action). Play message, set transfer
+        # flag, close WS. Exotel applet handles the redirect via /dial-up.
+        if await self._handle_block_redirect(transport_type):
+            clear_log_context()
+            return False
+
+        self.lead = await update_lead_call_initiated_time(
+            self.call_sid, call_initiated_time
+        )
+        if not self.lead:
+            # Extract URL query params for Plivo inbound (contains from_number, to_number)
+            url_query_params = dict(self.ws.query_params) if self.ws else {}
+            from_number = call_data.get("from") or url_query_params.get(
+                "from_number", ""
+            )
+
+            # Inbound call - extract template_id (handles IVR mode if enabled)
+            (
+                template_id_from_query,
+                error_reason,
+                _was_ivr,
+            ) = await get_template_id_from_call(
+                ws=self.ws,
+                stream_sid=self.stream_sid,
+                call_sid=self.call_sid,
+                call_data=call_data,
+                provider=self.provider or "",
+                telephony_service=self.telephony_service,
+                from_number=from_number,
+            )
+
+            # Check if there was an error (IVR failed or invalid template_id)
+            if error_reason:
+                # WebSocket already closed by get_template_id_from_call
+                clear_log_context()
+                return False
+
+            # Handle inbound call - create lead on-the-fly
+            if template_id_from_query:
+                # Template ID from IVR selection or query param
+                self.lead, error_reason = await create_lead_from_template_id(
+                    template_id=template_id_from_query,
+                    call_sid=self.call_sid,
+                    call_data=call_data,
+                    call_initiated_time=call_initiated_time,
+                    url_query_params=url_query_params,
+                )
+                if not self.lead:
+                    error_msg = f"Inbound call handling failed (IVR): {error_reason}"
+                    logger.info(error_msg)
+                    track_error(self.errors, error_msg)
+                    await close_websocket_safely(
+                        self.ws,
+                        code=4000,
+                        reason=error_reason or "Failed to create lead from template",
+                    )
+                    clear_log_context()
+                    return False
+            else:
+                # Standard inbound handling (no IVR, no template_id in params)
+                self.lead, error_reason = await handle_inbound_call(
+                    call_sid=self.call_sid,
+                    call_data=call_data,
+                    call_initiated_time=call_initiated_time,
+                    provider=self.provider or "",
+                    url_query_params=url_query_params,
+                )
+                if not self.lead:
+                    error_msg = f"Inbound call handling failed: {error_reason}"
+                    logger.info(error_msg)
+                    track_error(self.errors, error_msg)
+                    await close_websocket_safely(
+                        self.ws,
+                        code=4000,
+                        reason=error_reason or "Failed to handle inbound call",
+                    )
+                    clear_log_context()
+                    return False
+
+        # Update context with lead_id (call_sid already set above)
+        update_log_context(lead_id=str(self.lead.id))
+
+        try:
+            (
+                self.template,
+                self.configurations,
+                self.template_vars,
+            ) = await load_template_config(self.lead)
+        except ValueError as e:
+            error_msg = f"Template loading failed: {str(e)}"
+            logger.error(error_msg)
+            track_error(self.errors, error_msg)
+            if self.completion_function:
+                await end_call_with_errors(
+                    lead=self.lead,
+                    errors=self.errors,
+                    completion_function=self.completion_function,
+                    transport_type=self.transport_type,
+                    call_sid=self.call_sid,
+                )
+            await close_websocket_safely(self.ws, code=4000, reason=str(e))
+            clear_log_context()
+            return False
+        except Exception as e:
+            error_msg = f"Unexpected error loading template: {str(e)}"
+            logger.error(error_msg)
+            track_error(self.errors, error_msg)
+            if self.completion_function:
+                await end_call_with_errors(
+                    lead=self.lead,
+                    errors=self.errors,
+                    completion_function=self.completion_function,
+                    transport_type=self.transport_type,
+                    call_sid=self.call_sid,
+                )
+            await close_websocket_safely(
+                self.ws, code=4000, reason="Template load error"
+            )
+            clear_log_context()
+            return False
+
+        self.flow_builder = FlowConfigBuilder()
+        for handler_name, handler_func in self.flow_builder.handler_map.items():
+            self.flow_builder.handler_map[handler_name] = with_context(self)(
+                handler_func
+            )
+
+        # Safe access for required attributes after lead check above
+        if not self.ws or not self.stream_sid or not self.lead or not self.template:
+            logger.error("Missing required attributes after setup")
+            clear_log_context()
+            return False
+
+        greeting_result = await send_initial_greeting(
+            ws=self.ws,
+            stream_sid=self.stream_sid,
+            lead=self.lead,
+            template=self.template,
+            provider=self.provider or "",
+            errors=self.errors,
+        )
+        self.greeting_source = greeting_result.source
+        self.greeting_text = greeting_result.text
+
+        # Start post-greeting idle timer if greeting was sent
+        if self.greeting_source and self.configurations:
+            user_idle_config = getattr(
+                self.configurations, "user_idle_configuration", None
+            )
+            if user_idle_config and user_idle_config.enabled:
+                self._post_greeting_task = asyncio.create_task(
+                    self._handle_post_greeting_idle(user_idle_config)
+                )
+
+        self.vad_analyzer, self.default_vad_params = await create_vad_analyzer(
+            is_daily_mode=False,
+            template=self.template,
+        )
+
+        # Create background sound mixer if configured in template
+        audio_out_mixer = create_background_sound_mixer(self.template)
+
+        # Get transport params using the detected transport type
+        # Note: VAD is configured in the aggregator (via UserTurnStrategies), not the transport
+        transport_params = get_transport_params(audio_out_mixer, self.configurations)
+        params = transport_params[transport_type]()
+
+        # Create transport with the call data
+        self.transport = await _create_telephony_transport(
+            self.ws, params, transport_type, call_data
+        )
+
+        logger.info(f"Created transport: {self.transport.__class__.__name__}")
+        return True
+
+    async def _handle_block_redirect(self, transport_type: str) -> bool:
+        """Handle Exotel block-redirect set at answer-time.
+
+        When inbound policy blocks a call with REDIRECT action on Exotel,
+        the answer handler accepts the call but stores redirect info in Redis.
+        This method detects that, plays the block message, sets the transfer
+        flag (so Exotel /dial-up callback returns the redirect number), and
+        closes the WebSocket.
+
+        Returns True if the call was handled (caller should return False from setup).
+        """
+        if not self.call_sid:
+            return False
+
+        redirect_info = await get_block_redirect(self.call_sid)
+        if not redirect_info:
+            return False
+
+        redirect_number = redirect_info.get("redirect_number")
+        block_message = redirect_info.get("message")
+        reseller_id = redirect_info.get("reseller_id")
+        merchant_id = redirect_info.get("merchant_id")
+
+        logger.info(
+            f"[BLOCK_REDIRECT] Call {self.call_sid} blocked with redirect to {redirect_number}"
+        )
+
+        # Play block message if available (with caching)
+        if block_message and self.ws and self.stream_sid:
+            try:
+                audio = await prepare_block_audio(block_message, self.provider or "")
+                if audio:
+                    await _send_audio(
+                        self.ws, self.stream_sid, audio, self.provider or ""
+                    )
+                    await asyncio.sleep(BLOCK_MESSAGE_PLAY_SECONDS)
+            except Exception as e:
+                logger.warning(f"[BLOCK_REDIRECT] Failed to play block message: {e}")
+
+        # Set transfer flag so Exotel /dial-up callback returns the redirect number
+        if redirect_number:
+            await set_transfer_flag(
+                call_sid=self.call_sid,
+                reseller_id=reseller_id or "",
+                merchant_id=merchant_id or "",
+                transfer_number=redirect_number,
+            )
+
+        # Close WebSocket — Exotel applet detects stream end and calls /dial-up
+        if self.ws:
+            await close_websocket_safely(self.ws, code=1000, reason="Block redirect")
+        return True
+
+    def _register_event_handlers(self) -> None:
+        """Register transport and task event handlers."""
+        if not self.transport or not self.task:
+            logger.error("Transport or task not initialized")
+            return
+
+        @self.task.event_handler("on_pipeline_error")
+        async def on_pipeline_error(task, error):
+            """Capture TTS/STT/LLM pipeline failures.
+
+            For STT errors with circuit breaker enabled:
+            - Probe calls (HALF-OPEN): swap via ServiceSwitcher, record failure,
+              release probe lock. Call survives.
+            - Non-probe calls (CLOSED): end call gracefully, record failure.
+              Circuit breaker protects future calls.
+            """
+            processor = getattr(error, "processor", "unknown")
+            error_msg = getattr(error, "error", str(error))
+            detailed_msg = f"[PIPELINE] {processor}: {error_msg}"
+            logger.info(f"[PIPELINE_ERROR] {detailed_msg}")
+            track_error(self.errors, detailed_msg)
+
+            # Detect STT-specific failures by processor name
+            processor_name = str(processor).lower()
+            stt_keywords = ("soniox", "deepgram", "stt", "transcri")
+            if any(kw in processor_name for kw in stt_keywords):
+                failed_provider = self.stt_provider
+
+                # --- Probe call: swap via ServiceSwitcher + record failure ---
+                if self.fallback_stt and not self.stt_switched and self.task:
+                    logger.warning(
+                        f"Mid-call STT failure (provider={failed_provider}, "
+                        f"processor={processor}). Switching to Deepgram fallback."
+                    )
+                    # Push switch frame to ServiceSwitcher
+                    await self.task.queue_frame(
+                        ManuallySwitchServiceFrame(service=self.fallback_stt)
+                    )
+                    self.stt_provider = "deepgram"
+                    self.stt_switched = True
+
+                    # Fire-and-forget Slack alert (fallback activated)
+                    _fire_and_forget(
+                        self._send_stt_fallback_activated_alert(
+                            failed_provider, str(processor), str(error_msg)
+                        )
+                    )
+                    # Mark lead metadata for analytics
+                    if self.lead:
+                        if self.lead.metaData is None:
+                            self.lead.metaData = {}
+                        self.lead.metaData["stt_fallback_triggered"] = True
+                        self.lead.metaData["stt_original_provider"] = failed_provider
+                        self.lead.metaData["stt_provider"] = "deepgram"
+
+                    # Record failure in circuit breaker + release probe lock
+                    if ENABLE_BREEZE_BUDDY_STT_FALLBACK and self.is_probe_call:
+                        from app.ai.voice.agents.breeze_buddy.stt.fallback import (
+                            stt_circuit_breaker,
+                        )
+
+                        await stt_circuit_breaker.record_failure()
+                        await stt_circuit_breaker.release_probe()
+                    return  # Call continues with Deepgram
+
+                # --- Guard: ignore stale errors from the old provider ---
+                if self.stt_switched and "deepgram" not in processor_name:
+                    logger.info(
+                        f"Ignoring stale STT error from old provider "
+                        f"(processor={processor}) — already switched to Deepgram."
+                    )
+                    return
+
+                # --- No fallback available or already exhausted ---
+                logger.error(
+                    f"Mid-call STT failure (provider={failed_provider}, "
+                    f"processor={processor}). "
+                    + (
+                        "Both providers failed."
+                        if self.stt_switched
+                        else "No fallback available."
+                    )
+                    + " Ending call gracefully."
+                )
+                # Fire-and-forget Slack alert (total failure)
+                _fire_and_forget(
+                    self._send_mid_call_stt_alert(str(processor), str(error_msg))
+                )
+                # Mark lead metadata for post-call analytics
+                if self.lead:
+                    if self.lead.metaData is None:
+                        self.lead.metaData = {}
+                    self.lead.metaData["call_ended_by"] = "system"
+                    self.lead.metaData["call_end_reason"] = (
+                        "stt_both_providers_failed"
+                        if self.stt_switched
+                        else "stt_mid_call_failure"
+                    )
+                    self.lead.metaData["stt_provider"] = self.stt_provider
+
+                # Record failure in circuit breaker (non-probe path).
+                # Guard with _stt_failure_recorded to avoid double-counting
+                # when Soniox emits a second error during pipeline teardown.
+                # Only count Soniox failures — Deepgram failures (when circuit
+                # is OPEN) should not increment the Soniox failure counter.
+                if (
+                    ENABLE_BREEZE_BUDDY_STT_FALLBACK
+                    and not self.stt_switched
+                    and not self._stt_failure_recorded
+                    and failed_provider == "soniox"
+                ):
+                    self._stt_failure_recorded = True
+                    from app.ai.voice.agents.breeze_buddy.stt.fallback import (
+                        stt_circuit_breaker,
+                    )
+
+                    await stt_circuit_breaker.record_failure()
+
+                # Kill the call immediately — no greeting or goodbye.
+                # EndFrame stops all pipeline processing and disconnects
+                # the transport. Cleanup runs via on_client_disconnected.
+                if self.task:
+                    await self.task.queue_frame(EndFrame())
+
+        @self.transport.event_handler("on_client_connected")
+        async def on_client_connected(transport, client):
+            logger.info(f"Client connected: {client}")
+            await self._handle_client_connected()
+
+        @self.transport.event_handler("on_client_disconnected")
+        async def on_client_disconnected(transport, client):
+            logger.info(f"Client disconnected: {client}")
+            # Cancel post-greeting idle task if still running
+            if self._post_greeting_task and not self._post_greeting_task.done():
+                self._post_greeting_task.cancel()
+                self._post_greeting_task = None
+                logger.info(
+                    "Cancelling the post greeting task due to client disconnect"
+                )
+
+            # Circuit breaker: record successful probe if Soniox didn't fail
+            if (
+                ENABLE_BREEZE_BUDDY_STT_FALLBACK
+                and self.is_probe_call
+                and not self.stt_switched
+            ):
+                from app.ai.voice.agents.breeze_buddy.stt.fallback import (
+                    stt_circuit_breaker,
+                )
+
+                await stt_circuit_breaker.record_success()
+                await stt_circuit_breaker.release_probe()
+
+            await self._handle_unexpected_disconnect("client_disconnected")
+
+        @self.task.event_handler("on_idle_timeout")
+        async def on_idle_timeout(task):
+            logger.info("Idle timeout detected.")
+            await self._handle_unexpected_disconnect("idle_timeout")
+
+        # Register user turn started event to reset idle retry counter
+        if self._context_aggregator and self._user_idle_callback_handler:
+            user_aggregator = self._context_aggregator.user()
+
+            @user_aggregator.event_handler("on_user_turn_started")
+            async def on_user_turn_started(aggregator, strategy):
+                """Reset idle retry counter when user starts speaking."""
+                # Detect first user speech and cancel post-greeting timer
+                if not self._user_spoke:
+                    self._user_spoke = True
+                    if self._post_greeting_task:
+                        self._post_greeting_task.cancel()
+                        self._post_greeting_task = None
+                        logger.debug("Post-greeting timer cancelled - user spoke")
+                self._user_idle_callback_handler.reset_retry_count()
+
+    async def _handle_client_connected(self) -> None:
+        """Handle client connection and initialize flow."""
+        if (
+            not self.flow_builder
+            or not self.template
+            or not self.lead
+            or not self.flow_manager
+        ):
+            logger.error("Required attributes not initialized for client connection")
+            return
+
+        (
+            self.flow_config,
+            self.end_conversation_callbacks,
+            self.expected_callback_response_schema,
+        ) = build_flow_config(self.flow_builder, self.template)
+
+        lead_payload = self.lead.payload or {}
+        initial_node_config = prepare_initial_node(
+            flow_config=self.flow_config,
+            lead_payload=lead_payload,
+            configurations=self.configurations,
+            has_greeting_source=bool(self.greeting_source),
+            greeting_text=self.greeting_text,
+        )
+
+        # Initialize node traversal tracking
+        if self.lead.metaData is None:
+            self.lead.metaData = {}
+        self.lead.metaData["node_traversal"] = []
+
+        await self.flow_manager.initialize(initial_node_config)
+
+        # Record initial node entry after FlowManager is initialized
+        initial_node_name = self.flow_config["initial_node"]
+        context = TemplateContext(self)
+        context.record_node_entry(initial_node_name)
+        logger.info(
+            f"FlowManager initialized with initial node: {self.flow_config['initial_node']}"
+        )
+
+    async def _run_with_tracing(self, runner: PipelineRunner) -> None:
+        """Run the pipeline with OpenTelemetry tracing."""
+        if not self.lead or not self.task:
+            logger.error("Lead or task not initialized for tracing")
+            return
+
+        lead_payload = self.lead.payload or {}
+        self.root_span = create_root_span(
+            conversation_id=self.conversation_id or "unknown",
+            transport_type=self.transport_type,
+            customer_name=lead_payload.get("customer_name", "unknown"),
+            shop_name=lead_payload.get("shop_name", "unknown"),
+            call_sid=self.call_sid or "unknown",
+            order_id=self.lead.request_id or "unknown",
+            provider=self.provider or "",
+            template_type=self.lead.template,
+        )
+        try:
+            with trace.use_span(self.root_span, end_on_exit=True):
+                await runner.run(self.task)
+        except Exception as e:
+            error_msg = f"Error during traced pipeline execution: {e}"
+            logger.error(error_msg)
+            track_error(self.errors, error_msg)
+            self.root_span.end()
+
+    async def run(self, runner_args: Optional[RunnerArguments] = None) -> None:
+        """Main entry point for running the agent.
+
+        Args:
+            runner_args: Required for Daily mode, contains room info and lead data
+        """
+        try:
+            # Setup transport based on mode
+            if self.is_daily_mode:
+                if not runner_args:
+                    logger.error("runner_args is required for Daily mode")
+                    return
+                await self._setup_daily_transport(runner_args)
+            else:
+                if not await self._setup_telephony_transport():
+                    return
+
+            # Override TTS voice name if LLM-based selection was done at lead push time
+            if self.lead and self.lead.payload:
+                payload_voice = self.lead.payload.get("tts_voice_name")
+                if payload_voice and self.configurations:
+                    try:
+                        voice_enum = TTSVoiceName(payload_voice)
+                        logger.info(
+                            f"Overriding TTS voice from payload: {voice_enum.value}"
+                        )
+                        self.configurations.tts_voice_name = voice_enum
+                    except ValueError:
+                        logger.warning(
+                            f"Invalid TTS voice '{payload_voice}' in payload, keeping existing config"
+                        )
+
+            # Create services and pipeline
+            # VAD analyzer is passed to build_pipeline where it's configured inside the
+            # LLMUserAggregator. This enables UserTurnStrategies (VAD + Transcription fallback).
+            stt_result, llm, tts = await create_services(self.configurations)
+            self.stt_provider = stt_result.provider
+            self.is_probe_call = stt_result.is_probe_call
+            if stt_result.is_fallback:
+                logger.warning(
+                    f"Call starting with fallback STT provider: {stt_result.provider}"
+                )
+            (
+                pipeline,
+                self.context,
+                context_aggregator,
+                user_idle_callback_handler,
+                self.speech_gate,
+                fallback_stt_ref,
+            ) = await build_pipeline(
+                self.transport,
+                stt_result.service,
+                llm,
+                tts,
+                self.vad_analyzer,
+                self.configurations,
+                on_user_idle_timeout=self._handle_user_idle_timeout,
+                stt_provider=stt_result.provider,
+                fallback_stt=stt_result.fallback_service,
+            )
+            self.fallback_stt = fallback_stt_ref
+
+            # Store callback handler for resetting retry count on user activity
+            self._user_idle_callback_handler = user_idle_callback_handler
+
+            # Store context aggregator for user turn event registration
+            self._context_aggregator = context_aggregator
+
+            # Generate conversation ID and update context
+            lead_payload = self.lead.payload if self.lead else None
+            self.conversation_id = generate_conversation_id(lead_payload)
+            update_log_context(conversation_id=self.conversation_id)
+
+            self.task = await create_pipeline_task(pipeline, self.conversation_id)
+
+            # Validate required attributes for flow setup
+            if not self.template:
+                logger.error("Template is not set, cannot setup flow manager")
+                return
+
+            # Setup flow management
+            self.flow_manager = setup_flow_manager(
+                task=self.task,
+                llm=llm,
+                context_aggregator=context_aggregator,
+                transport=self.transport,
+                flow_builder=self.flow_builder,
+                template=self.template,
+                bot_instance=self,
+            )
+            self._register_event_handlers()
+
+            # Run the pipeline
+            runner = PipelineRunner(handle_sigint=False, force_gc=True)
+
+            try:
+                if ENABLE_BREEZE_BUDDY_TRACING:
+                    await self._run_with_tracing(runner)
+                else:
+                    logger.info(
+                        f"Running pipeline without tracing for conversation: {self.conversation_id}"
+                    )
+                    await runner.run(self.task)
+            except asyncio.CancelledError:
+                logger.info("Pipeline task cancelled. Exiting gracefully.")
+        finally:
+            # Safety net: always clear log context when run() exits, regardless of how.
+            # This handles crashes, cancellations, and any exit path missed above.
+            # Double-clearing (if end_conversation already cleared) is harmless.
+            clear_log_context()
+
+    async def _handle_unexpected_disconnect(self, reason: str) -> None:
+        """Handle unexpected disconnection and cleanup."""
+        if self.conversation_ended:
+            return
+
+        logger.info(f"{reason}. Updating call status.")
+
+        if self.lead:
+            if self.lead.outcome is None:
+                self.lead.outcome = DEFAULT_OUTCOME
+
+            if self.lead.metaData is None:
+                self.lead.metaData = {}
+
+            # Simple mapping - we control these exact strings from our event handlers
+            if reason == "idle_timeout":
+                self.lead.metaData["call_ended_by"] = "system"
+            elif reason == "client_disconnected":
+                self.lead.metaData["call_ended_by"] = "customer"
+            else:
+                # Shouldn't happen, but safe fallback
+                self.lead.metaData["call_ended_by"] = "agent"
+                logger.warning(f"Unexpected disconnect reason: {reason}")
+
+        context = TemplateContext(self)
+        await end_conversation(context, {})
+
+
+async def telephony_bot(
+    ws: WebSocket,
+    aiohttp_session: Any,
+    completion_function: Optional[Callable],
+    provider: CallProvider,
+    telephony_service: Optional[VoiceCallProvider] = None,
+) -> None:
+    """Entry point for telephony-based agents (Twilio/Exotel)."""
+    agent = Agent(
+        transport_type=provider,
+        ws=ws,
+        aiohttp_session=aiohttp_session,
+        completion_function=completion_function,
+        provider=provider,
+        telephony_service=telephony_service,
+    )
+    await agent.run()
+
+
+async def daily_bot(
+    runner_args: RunnerArguments,
+    completion_function: Callable,
+    aiohttp_session: Any,
+) -> None:
+    """Entry point for Daily-based agents (web/mobile frontends).
+
+    Args:
+        runner_args: RunnerArguments containing Daily room info and lead data
+        completion_function: Callback function to handle call completion
+        aiohttp_session: aiohttp session for HTTP requests
+    """
+    agent = Agent(
+        transport_type=TRANSPORT_TYPE_DAILY,
+        aiohttp_session=aiohttp_session,
+        completion_function=completion_function,
+    )
+    try:
+        await agent.run(runner_args)
+    finally:
+        if aiohttp_session:
+            await aiohttp_session.close()
+            logger.info("[DAILY_MODE] Closed aiohttp session")

--- a/app/ai/voice/agents/breeze_buddy/stt/__init__.py
+++ b/app/ai/voice/agents/breeze_buddy/stt/__init__.py
@@ -1,0 +1,407 @@
+import asyncio
+from dataclasses import dataclass
+from typing import Optional
+
+from pipecat.transcriptions.language import Language
+
+from app.ai.voice.stt import (
+    DeepgramConfig,
+    SarvamConfig,
+    SonioxConfig,
+    build_deepgram_stt,
+    build_google_stt,
+    build_openai_stt,
+    build_sarvam_stt,
+    build_soniox_stt,
+)
+from app.core.config.dynamic import (
+    BB_SARVAM_STT_HIGH_VAD_SENSITIVITY,
+    BB_SARVAM_STT_LANGUAGE_CODE,
+    BB_SARVAM_STT_MODEL,
+    BB_SARVAM_STT_PROMPT,
+    BB_SARVAM_STT_VAD_SIGNALS,
+)
+from app.core.config.static import (
+    BREEZE_BUDDY_DEEPGRAM_AUTO_DETECT_LANGUAGE,
+    BREEZE_BUDDY_DEEPGRAM_DIARIZE,
+    BREEZE_BUDDY_DEEPGRAM_ENDPOINTING,
+    BREEZE_BUDDY_DEEPGRAM_INTERIM_RESULTS,
+    BREEZE_BUDDY_DEEPGRAM_LANGUAGE,
+    BREEZE_BUDDY_DEEPGRAM_MODEL,
+    BREEZE_BUDDY_DEEPGRAM_NO_DELAY,
+    BREEZE_BUDDY_DEEPGRAM_NUMERALS,
+    BREEZE_BUDDY_DEEPGRAM_PROFANITY_FILTER,
+    BREEZE_BUDDY_DEEPGRAM_PUNCTUATE,
+    BREEZE_BUDDY_DEEPGRAM_SMART_FORMAT,
+    BREEZE_BUDDY_DEEPGRAM_UTTERANCE_END_MS,
+    BREEZE_BUDDY_DEEPGRAM_VAD_EVENTS,
+    BREEZE_BUDDY_SONIOX_CONTEXT,
+    BREEZE_BUDDY_SONIOX_ENABLE_NON_FINAL_TOKENS,
+    BREEZE_BUDDY_SONIOX_LANGUAGE_HINTS,
+    BREEZE_BUDDY_SONIOX_MAX_ENDPOINT_DELAY_MS,
+    BREEZE_BUDDY_SONIOX_MAX_NON_FINAL_TOKENS_DURATION_MS,
+    BREEZE_BUDDY_SONIOX_MODEL,
+    BREEZE_BUDDY_SONIOX_VAD_FORCE_TURN_ENDPOINT,
+    BREEZE_BUDDY_STT_SERVICE,
+    DEEPGRAM_API_KEY,
+    ENABLE_BREEZE_BUDDY_STT_FALLBACK,
+    GOOGLE_CREDENTIALS_JSON,
+    OPENAI_STT_API_KEY,
+    OPENAI_STT_MODEL,
+    SAMPLE_RATE,
+    SARVAM_API_KEY,
+    SONIOX_API_KEY,
+)
+from app.core.logger import logger
+from app.services.slack import slack_alert
+
+# Background task references to prevent premature GC of fire-and-forget tasks
+_background_tasks: set[asyncio.Task] = set()
+
+
+def _fire_and_forget(coro) -> None:
+    """Schedule a coroutine as a fire-and-forget task, preventing GC."""
+    task = asyncio.create_task(coro)
+    _background_tasks.add(task)
+    task.add_done_callback(_background_tasks.discard)
+
+
+@dataclass
+class STTServiceResult:
+    """Result of STT service initialization.
+
+    Attributes:
+        service: The primary STT service instance
+        provider: Name of the active STT provider ("soniox", "deepgram", "sarvam", "openai", "google")
+        is_fallback: True if this provider was selected as a fallback due to primary provider failure
+        fallback_service: Pre-built Deepgram STT for mid-call hot-swap via ServiceSwitcher.
+                         Only populated for HALF-OPEN probe calls.
+        is_probe_call: True if this call is a HALF-OPEN circuit breaker probe.
+                      The agent must call record_success()/release_probe() on completion.
+    """
+
+    service: object
+    provider: str
+    is_fallback: bool = False
+    fallback_service: Optional[object] = None
+    is_probe_call: bool = False
+
+
+def _build_deepgram_fallback(*, vad_events: Optional[bool] = None) -> object:
+    """Build Deepgram STT service using Breeze Buddy-specific config.
+
+    Args:
+        vad_events: Override for Deepgram server-side VAD events.
+                    When None, uses the BREEZE_BUDDY_DEEPGRAM_VAD_EVENTS env var.
+                    Set to False for mid-call ServiceSwitcher fallback to prevent
+                    spurious InterruptionTaskFrames that cancel the greeting.
+
+    Returns:
+        Deepgram STT service instance
+
+    Raises:
+        ValueError: If DEEPGRAM_API_KEY is not configured
+    """
+    if not DEEPGRAM_API_KEY:
+        raise ValueError("DEEPGRAM_API_KEY is required for Deepgram STT fallback")
+
+    effective_vad_events = (
+        vad_events if vad_events is not None else BREEZE_BUDDY_DEEPGRAM_VAD_EVENTS
+    )
+
+    return build_deepgram_stt(
+        DeepgramConfig(
+            api_key=DEEPGRAM_API_KEY,
+            model=BREEZE_BUDDY_DEEPGRAM_MODEL,
+            language=BREEZE_BUDDY_DEEPGRAM_LANGUAGE,
+            auto_detect_language=BREEZE_BUDDY_DEEPGRAM_AUTO_DETECT_LANGUAGE,
+            smart_format=BREEZE_BUDDY_DEEPGRAM_SMART_FORMAT,
+            punctuate=BREEZE_BUDDY_DEEPGRAM_PUNCTUATE,
+            endpointing=BREEZE_BUDDY_DEEPGRAM_ENDPOINTING,
+            vad_events=effective_vad_events,
+            utterance_end_ms=BREEZE_BUDDY_DEEPGRAM_UTTERANCE_END_MS,
+            no_delay=BREEZE_BUDDY_DEEPGRAM_NO_DELAY,
+            interim_results=BREEZE_BUDDY_DEEPGRAM_INTERIM_RESULTS,
+            profanity_filter=BREEZE_BUDDY_DEEPGRAM_PROFANITY_FILTER,
+            numerals=BREEZE_BUDDY_DEEPGRAM_NUMERALS,
+            diarize=BREEZE_BUDDY_DEEPGRAM_DIARIZE,
+        )
+    )
+
+
+def _build_soniox(
+    language_hints: Optional[str] = None,
+    soniox_context: Optional[str] = None,
+) -> object:
+    """Build Soniox STT service using Breeze Buddy-specific config.
+
+    Extracted to avoid duplication between CLOSED and HALF-OPEN probe paths.
+    Disables reconnect_on_error when fallback is enabled so a single error
+    triggers immediate circuit breaker recording instead of 3× retry (12s dead air).
+    """
+    effective_context = (
+        soniox_context if soniox_context is not None else BREEZE_BUDDY_SONIOX_CONTEXT
+    )
+    if soniox_context:
+        logger.info("Using template-specific Soniox context")
+
+    # SONIOX_API_KEY is validated by the caller before invoking _build_soniox,
+    # but assert here for type narrowing (pyrefly/mypy).
+    assert SONIOX_API_KEY is not None, "SONIOX_API_KEY must be set"
+
+    return build_soniox_stt(
+        SonioxConfig(
+            api_key=SONIOX_API_KEY,
+            model=BREEZE_BUDDY_SONIOX_MODEL,
+            vad_force_turn_endpoint=BREEZE_BUDDY_SONIOX_VAD_FORCE_TURN_ENDPOINT,
+            language_hints=(
+                language_hints
+                if language_hints is not None
+                else BREEZE_BUDDY_SONIOX_LANGUAGE_HINTS
+            ),
+            context_json=effective_context,
+            enable_non_final_tokens=BREEZE_BUDDY_SONIOX_ENABLE_NON_FINAL_TOKENS,
+            max_non_final_tokens_duration_ms=BREEZE_BUDDY_SONIOX_MAX_NON_FINAL_TOKENS_DURATION_MS,
+            max_endpoint_delay_ms=BREEZE_BUDDY_SONIOX_MAX_ENDPOINT_DELAY_MS,
+            log_context="Breeze Buddy",
+            language_hints_strict=True if language_hints else False,
+            # Disable auto-reconnect when fallback is enabled AND Deepgram
+            # is actually configured, so a single error triggers immediate
+            # recording instead of retrying 3× (12s dead air) before a
+            # fatal ErrorFrame. If DEEPGRAM_API_KEY is missing, keep
+            # Soniox resilient with auto-reconnect.
+            reconnect_on_error=not (
+                ENABLE_BREEZE_BUDDY_STT_FALLBACK and DEEPGRAM_API_KEY
+            ),
+        )
+    )
+
+
+async def _send_soniox_failure_alert(error: Exception, fallback_used: str) -> None:
+    """Send Slack alert when Soniox STT fails at startup. Fire-and-forget."""
+    try:
+        await slack_alert.send(
+            title="🚨 Soniox Failed at Startup (Breeze Buddy)",
+            fields=[
+                {"name": "Fallback", "value": fallback_used.capitalize()},
+            ],
+            sections=[
+                {
+                    "title": "What Happened",
+                    "text": (
+                        f"Soniox STT failed to initialize for a Breeze Buddy call. "
+                        f"This call is using {fallback_used.capitalize()} instead.\n"
+                        f"```{str(error)[:500]}```"
+                    ),
+                }
+            ],
+            fallback_text=f"Soniox startup failure — {fallback_used} used for this call",
+        )
+    except Exception as alert_err:
+        logger.warning(f"Failed to send Soniox failure Slack alert: {alert_err}")
+
+
+async def get_stt_service(
+    language_hints: Optional[str] = None, soniox_context: Optional[str] = None
+) -> STTServiceResult:
+    """
+    Returns an STT service instance based on the environment configuration,
+    with automatic Deepgram fallback when Soniox fails.
+
+    Args:
+        language_hints: Optional language codes (e.g., "en,hi") for STT language recognition.
+                       Used with soniox STT service.
+        soniox_context: Optional Soniox STT context for speech recognition domain adaptation.
+                       If provided, overrides BREEZE_BUDDY_SONIOX_CONTEXT env var.
+
+    Returns:
+        STTServiceResult with the service instance, provider name, and fallback status.
+        When ENABLE_BREEZE_BUDDY_STT_FALLBACK is true and primary is Soniox,
+        fallback_service will contain a pre-built Deepgram STT for mid-call hot-swap.
+    """
+    if BREEZE_BUDDY_STT_SERVICE == "sarvam":
+        if not SARVAM_API_KEY:
+            raise ValueError(
+                "SARVAM_API_KEY is required when BREEZE_BUDDY_STT_SERVICE=sarvam"
+            )
+
+        # Get Breeze Buddy-specific dynamic config values from Redis
+        bb_sarvam_stt_model = await BB_SARVAM_STT_MODEL()
+        bb_sarvam_stt_language_code = await BB_SARVAM_STT_LANGUAGE_CODE()
+        bb_sarvam_stt_prompt = await BB_SARVAM_STT_PROMPT()
+        bb_sarvam_stt_vad_signals = await BB_SARVAM_STT_VAD_SIGNALS()
+        bb_sarvam_stt_high_vad_sensitivity = await BB_SARVAM_STT_HIGH_VAD_SENSITIVITY()
+
+        # Pass raw config values - model-specific logic is handled internally by build_sarvam_stt
+        return STTServiceResult(
+            service=build_sarvam_stt(
+                SarvamConfig(
+                    api_key=SARVAM_API_KEY,
+                    model=bb_sarvam_stt_model,
+                    sample_rate=SAMPLE_RATE,
+                    language_code=bb_sarvam_stt_language_code,
+                    prompt=bb_sarvam_stt_prompt,
+                    vad_signals=bb_sarvam_stt_vad_signals,
+                    high_vad_sensitivity=bb_sarvam_stt_high_vad_sensitivity,
+                )
+            ),
+            provider="sarvam",
+        )
+    elif BREEZE_BUDDY_STT_SERVICE == "openai":
+        if not OPENAI_STT_API_KEY:
+            raise ValueError(
+                "OPENAI_STT_API_KEY is required when BREEZE_BUDDY_STT_SERVICE=openai"
+            )
+        logger.info("Using OpenAI STT service for Breeze Buddy voice")
+        return STTServiceResult(
+            service=build_openai_stt(
+                api_key=OPENAI_STT_API_KEY,
+                model=OPENAI_STT_MODEL,
+                language=Language.EN,
+                temperature=0.0,
+            ),
+            provider="openai",
+        )
+    elif BREEZE_BUDDY_STT_SERVICE == "soniox":
+        if not SONIOX_API_KEY:
+            raise ValueError(
+                "SONIOX_API_KEY is required when BREEZE_BUDDY_STT_SERVICE=soniox"
+            )
+
+        # ── Circuit breaker routing (when fallback is enabled) ────────────
+        # OPEN     → Deepgram only (skip Soniox entirely)
+        # HALF-OPEN → probe call gets ServiceSwitcher; others get Deepgram
+        # CLOSED   → Soniox only (no idle Deepgram WS)
+        if ENABLE_BREEZE_BUDDY_STT_FALLBACK:
+            from app.ai.voice.agents.breeze_buddy.stt.fallback import (
+                CircuitState,
+                stt_circuit_breaker,
+            )
+
+            circuit_state = await stt_circuit_breaker.get_state()
+            logger.info(f"STT circuit breaker state: {circuit_state.value}")
+
+            # ── OPEN: Deepgram only, skip Soniox entirely ─────────────
+            if circuit_state == CircuitState.OPEN:
+                logger.info("Circuit breaker OPEN — using Deepgram as primary STT")
+                try:
+                    return STTServiceResult(
+                        service=_build_deepgram_fallback(vad_events=False),
+                        provider="deepgram",
+                        is_fallback=True,
+                    )
+                except Exception as dg_err:
+                    logger.error(f"Deepgram init failed while circuit OPEN: {dg_err}")
+                    raise
+
+            # ── HALF-OPEN: single probe call with ServiceSwitcher ─────
+            if circuit_state == CircuitState.HALF_OPEN:
+                probe_acquired = await stt_circuit_breaker.try_acquire_probe()
+                if not probe_acquired:
+                    # Another call is already probing — use Deepgram
+                    logger.info(
+                        "Circuit breaker HALF-OPEN but probe lock held — "
+                        "using Deepgram for this call"
+                    )
+                    try:
+                        return STTServiceResult(
+                            service=_build_deepgram_fallback(vad_events=False),
+                            provider="deepgram",
+                            is_fallback=True,
+                        )
+                    except Exception as dg_err:
+                        logger.error(f"Deepgram init failed during HALF-OPEN: {dg_err}")
+                        raise
+
+                # Probe call: Soniox primary + Deepgram fallback in ServiceSwitcher
+                logger.info(
+                    "Circuit breaker HALF-OPEN probe — building Soniox + Deepgram"
+                )
+                try:
+                    stt_service = _build_soniox(language_hints, soniox_context)
+                    fallback = _build_deepgram_fallback(vad_events=False)
+                    logger.info(
+                        "Probe call: Soniox primary + Deepgram fallback "
+                        "(ServiceSwitcher, vad_events=False)"
+                    )
+                    return STTServiceResult(
+                        service=stt_service,
+                        provider="soniox",
+                        fallback_service=fallback,
+                        is_probe_call=True,
+                    )
+                except Exception as probe_err:
+                    logger.error(
+                        f"Probe call Soniox init failed: {probe_err}. "
+                        f"Recording failure and falling back to Deepgram."
+                    )
+                    # Init-time failure during probe: record + release lock
+                    _fire_and_forget(_send_soniox_failure_alert(probe_err, "deepgram"))
+                    await stt_circuit_breaker.record_failure()
+                    await stt_circuit_breaker.release_probe()
+                    try:
+                        return STTServiceResult(
+                            service=_build_deepgram_fallback(vad_events=False),
+                            provider="deepgram",
+                            is_fallback=True,
+                        )
+                    except Exception as dg_err:
+                        raise probe_err from dg_err
+
+        # ── CLOSED (or fallback disabled): Soniox only ────────────────
+        try:
+            stt_service = _build_soniox(language_hints, soniox_context)
+
+            return STTServiceResult(
+                service=stt_service,
+                provider="soniox",
+            )
+
+        except Exception as soniox_err:
+            logger.error(
+                f"Soniox STT initialization failed, falling back to Deepgram: {soniox_err}"
+            )
+
+            # Fire-and-forget Slack alert
+            _fire_and_forget(_send_soniox_failure_alert(soniox_err, "deepgram"))
+
+            # Record failure in circuit breaker (may trip for future calls)
+            if ENABLE_BREEZE_BUDDY_STT_FALLBACK:
+                from app.ai.voice.agents.breeze_buddy.stt.fallback import (
+                    stt_circuit_breaker,
+                )
+
+                await stt_circuit_breaker.record_failure()
+
+            # Fallback to Deepgram
+            try:
+                deepgram_service = _build_deepgram_fallback(vad_events=False)
+                logger.info(
+                    "Successfully initialized Deepgram STT as fallback for Soniox failure"
+                )
+                return STTServiceResult(
+                    service=deepgram_service,
+                    provider="deepgram",
+                    is_fallback=True,
+                )
+            except Exception as deepgram_err:
+                logger.error(
+                    f"Deepgram fallback also failed: {deepgram_err}. "
+                    f"Original Soniox error: {soniox_err}"
+                )
+                # Re-raise the original Soniox error — both providers are down
+                raise soniox_err from deepgram_err
+
+    elif BREEZE_BUDDY_STT_SERVICE == "deepgram":
+        # Direct Deepgram selection (not as fallback)
+        logger.info("Using Deepgram STT service for Breeze Buddy voice")
+        return STTServiceResult(
+            service=_build_deepgram_fallback(vad_events=False),
+            provider="deepgram",
+        )
+    else:
+        logger.info("Using Google STT service with VAD-based turn detection")
+        return STTServiceResult(
+            service=build_google_stt(credentials_json=GOOGLE_CREDENTIALS_JSON),
+            provider="google",
+        )

--- a/app/ai/voice/agents/breeze_buddy/stt/fallback.py
+++ b/app/ai/voice/agents/breeze_buddy/stt/fallback.py
@@ -1,0 +1,416 @@
+"""Redis-backed circuit breaker for STT provider fallback.
+
+Tracks Soniox failures across pods via Redis. When failures exceed a
+configurable threshold within a time window, the circuit trips OPEN and
+all new calls use Deepgram directly — no Soniox init, no idle WebSocket.
+
+After a cooldown (OPEN_DURATION), the circuit enters HALF-OPEN: a single
+probe call (protected by ServiceSwitcher) tests Soniox. If the probe
+succeeds, the circuit closes. If it fails, it re-trips.
+
+State machine::
+
+                  failure_count >= FAILURE_THRESHOLD
+   ┌─────────┐  ─────────────────────────────────►  ┌──────────┐
+   │ CLOSED  │                                       │   OPEN   │
+   │(Soniox) │                                       │(Deepgram)│
+   └─────────┘                                       └──────────┘
+       ▲                                                  │
+       │ success        TTL expires (30 min)              │
+       │            ┌────────────┐                        │
+       └────────────│ HALF-OPEN  │◄───────────────────────┘
+                    │(probe call)│  failure >= RETRIP_THRESHOLD
+                    └────────────┘──── → re-trip to OPEN
+
+Redis keys (all under ``stt:cb:`` prefix):
+    - ``failure_count``  - atomic counter, TTL = FAILURE_WINDOW_SECS
+    - ``open``           - presence flag, TTL = OPEN_DURATION_SECS
+    - ``half_open``      - recovery signal, TTL = OPEN_DURATION + PROBE_LOCK_TTL + 60
+    - ``probe_lock``     - NX lock, TTL = PROBE_LOCK_TTL_SECS
+"""
+
+from __future__ import annotations
+
+import asyncio
+import enum
+
+from app.core.config.static import (
+    ENABLE_BREEZE_BUDDY_STT_FALLBACK,
+    STT_CIRCUIT_BREAKER_FAILURE_THRESHOLD,
+    STT_CIRCUIT_BREAKER_FAILURE_WINDOW_SECS,
+    STT_CIRCUIT_BREAKER_OPEN_DURATION_SECS,
+    STT_CIRCUIT_BREAKER_PROBE_LOCK_TTL_SECS,
+    STT_CIRCUIT_BREAKER_RETRIP_THRESHOLD,
+)
+from app.core.logger import logger
+from app.services.redis import get_redis_service
+from app.services.slack import slack_alert
+
+# ---------------------------------------------------------------------------
+# Redis key constants
+# ---------------------------------------------------------------------------
+_KEY_FAILURE_COUNT = "stt:cb:failure_count"
+_KEY_OPEN = "stt:cb:open"
+_KEY_HALF_OPEN = "stt:cb:half_open"
+_KEY_PROBE_LOCK = "stt:cb:probe_lock"
+
+# Background task references to prevent premature GC of fire-and-forget tasks
+_background_tasks: set[asyncio.Task] = set()
+
+
+def _fire_and_forget(coro) -> None:
+    """Schedule a coroutine as a fire-and-forget task, preventing GC."""
+    task = asyncio.create_task(coro)
+    _background_tasks.add(task)
+    task.add_done_callback(_background_tasks.discard)
+
+
+class CircuitState(enum.Enum):
+    """Circuit breaker states."""
+
+    CLOSED = "closed"
+    OPEN = "open"
+    HALF_OPEN = "half_open"
+
+
+class STTCircuitBreaker:
+    """Redis-backed circuit breaker for Soniox → Deepgram STT fallback.
+
+    All state lives in Redis so the breaker is shared across pods.
+    Methods are safe to call concurrently — Redis operations are atomic.
+
+    Usage::
+
+        from app.ai.voice.agents.breeze_buddy.stt.fallback import stt_circuit_breaker
+
+        state = await stt_circuit_breaker.get_state()
+        if state == CircuitState.OPEN:
+            # Use Deepgram directly
+            ...
+    """
+
+    # -----------------------------------------------------------------------
+    # State queries
+    # -----------------------------------------------------------------------
+
+    async def get_state(self) -> CircuitState:
+        """Return the current circuit state by inspecting Redis keys.
+
+        - ``stt:cb:open`` exists      → OPEN
+        - ``stt:cb:half_open`` exists  → HALF_OPEN  (``open`` has expired)
+        - neither                      → CLOSED
+        """
+        if not ENABLE_BREEZE_BUDDY_STT_FALLBACK:
+            return CircuitState.CLOSED
+
+        try:
+            redis = await get_redis_service()
+
+            if await redis.exists(_KEY_OPEN):
+                return CircuitState.OPEN
+
+            # ``stt:cb:open`` expired — check the dedicated half-open flag
+            # set during ``_trip()``.  Its longer TTL guarantees a probe
+            # window after the open period ends.
+            if await redis.exists(_KEY_HALF_OPEN):
+                return CircuitState.HALF_OPEN
+
+            return CircuitState.CLOSED
+        except Exception as exc:
+            logger.warning(
+                f"Circuit breaker state check failed (defaulting to CLOSED): {exc}"
+            )
+            return CircuitState.CLOSED
+
+    async def is_open(self) -> bool:
+        """Convenience: ``True`` when circuit is OPEN."""
+        return (await self.get_state()) == CircuitState.OPEN
+
+    # -----------------------------------------------------------------------
+    # Failure recording
+    # -----------------------------------------------------------------------
+
+    async def record_failure(self) -> None:
+        """Record an STT failure and trip the circuit if threshold is reached.
+
+        In HALF-OPEN state, uses ``RETRIP_THRESHOLD`` (typically 1) so a
+        single probe failure immediately re-trips the circuit.
+        """
+        if not ENABLE_BREEZE_BUDDY_STT_FALLBACK:
+            return
+
+        try:
+            redis = await get_redis_service()
+            state = await self.get_state()
+
+            # Increment failure counter
+            count = await redis.incr(_KEY_FAILURE_COUNT)
+
+            # Set TTL on the counter only on the first failure (count == 1)
+            # so the window starts fresh. Subsequent failures within the
+            # window just increment without resetting the TTL.
+            if count == 1:
+                await redis.expire(
+                    _KEY_FAILURE_COUNT, STT_CIRCUIT_BREAKER_FAILURE_WINDOW_SECS
+                )
+
+            # Determine threshold based on current state
+            threshold = (
+                STT_CIRCUIT_BREAKER_RETRIP_THRESHOLD
+                if state == CircuitState.HALF_OPEN
+                else STT_CIRCUIT_BREAKER_FAILURE_THRESHOLD
+            )
+
+            logger.info(
+                f"STT circuit breaker: failure recorded "
+                f"(count={count}, threshold={threshold}, state={state.value})"
+            )
+
+            if count >= threshold:
+                await self._trip(state)
+        except Exception as exc:
+            # Circuit breaker is best-effort — never block the call path
+            logger.warning(f"Circuit breaker record_failure failed: {exc}")
+
+    async def _trip(self, previous_state: CircuitState) -> None:
+        """Trip the circuit to OPEN state.
+
+        Uses SET NX on the open key so that only the first caller in a
+        concurrent burst actually trips the circuit and sends the alert.
+        Subsequent callers see NX fail and skip — preventing duplicate alerts.
+        """
+        try:
+            redis = await get_redis_service()
+
+            # Atomically set open flag — only proceeds if key didn't exist
+            newly_tripped = await redis.set(
+                _KEY_OPEN,
+                "1",
+                nx=True,
+                ex=STT_CIRCUIT_BREAKER_OPEN_DURATION_SECS,
+            )
+
+            if not newly_tripped:
+                # Another pod/call already tripped — skip duplicate work
+                logger.info(
+                    "STT circuit breaker: _trip called but circuit already OPEN "
+                    "(another caller tripped first). Skipping."
+                )
+                return
+
+            # Set dedicated half-open flag with a longer TTL so that
+            # HALF_OPEN is reachable after the open period expires.
+            # TTL = open_duration + probe_lock_ttl + 60s safety buffer.
+            half_open_ttl = (
+                STT_CIRCUIT_BREAKER_OPEN_DURATION_SECS
+                + STT_CIRCUIT_BREAKER_PROBE_LOCK_TTL_SECS
+                + 60
+            )
+            await redis.set(
+                _KEY_HALF_OPEN,
+                "1",
+                ex=half_open_ttl,
+            )
+
+            # Reset failure counter for clean HALF-OPEN start
+            await redis.delete(_KEY_FAILURE_COUNT)
+
+            action = (
+                "re-tripped (probe failed)"
+                if previous_state == CircuitState.HALF_OPEN
+                else "tripped"
+            )
+            logger.warning(
+                f"STT circuit breaker {action} → OPEN for "
+                f"{STT_CIRCUIT_BREAKER_OPEN_DURATION_SECS}s. "
+                f"All calls will use Deepgram."
+            )
+
+            # Non-blocking Slack alert
+            cooldown_min = STT_CIRCUIT_BREAKER_OPEN_DURATION_SECS // 60
+
+            async def _send_trip_alert():
+                try:
+                    await slack_alert.send(
+                        title="🔴 Soniox STT Down — Switched to Deepgram (Breeze Buddy)",
+                        fields=[
+                            {"name": "Status", "value": action.capitalize()},
+                            {
+                                "name": "Cooldown",
+                                "value": f"{cooldown_min} min",
+                            },
+                        ],
+                        sections=[
+                            {
+                                "title": "What Happened",
+                                "text": (
+                                    "Soniox STT failed repeatedly. "
+                                    "All Breeze Buddy calls are now using Deepgram.\n"
+                                    f"Soniox will be automatically retested after {cooldown_min} minutes."
+                                ),
+                            }
+                        ],
+                        fallback_text=(
+                            f"Soniox STT down — Deepgram active for {cooldown_min} min"
+                        ),
+                    )
+                except Exception as alert_err:
+                    logger.warning(
+                        f"Failed to send Soniox-down Slack alert: {alert_err}"
+                    )
+
+            _fire_and_forget(_send_trip_alert())
+        except Exception as exc:
+            logger.warning(f"Circuit breaker _trip failed: {exc}")
+
+    # -----------------------------------------------------------------------
+    # Success recording (HALF-OPEN → CLOSED)
+    # -----------------------------------------------------------------------
+
+    async def record_success(self) -> None:
+        """Record a successful Soniox call, closing the circuit if HALF-OPEN.
+
+        Only meaningful in HALF-OPEN state. In CLOSED state this is a no-op
+        (avoids unnecessary Redis writes on the happy path).
+        """
+        if not ENABLE_BREEZE_BUDDY_STT_FALLBACK:
+            return
+
+        try:
+            state = await self.get_state()
+            if state != CircuitState.HALF_OPEN:
+                return
+
+            redis = await get_redis_service()
+
+            # Clear all circuit breaker keys → CLOSED
+            await redis.delete(_KEY_FAILURE_COUNT)
+            await redis.delete(_KEY_OPEN)
+            await redis.delete(_KEY_HALF_OPEN)
+
+            logger.info(
+                "STT circuit breaker: probe succeeded → CLOSED. "
+                "Soniox restored for all calls."
+            )
+
+            # Non-blocking Slack alert
+            async def _send_recovery_alert():
+                try:
+                    await slack_alert.send(
+                        title="🟢 Soniox STT Recovered (Breeze Buddy)",
+                        fields=[
+                            {"name": "Status", "value": "Recovered"},
+                        ],
+                        sections=[
+                            {
+                                "title": "What Happened",
+                                "text": (
+                                    "Soniox test call completed successfully. "
+                                    "All Breeze Buddy calls will now use Soniox again."
+                                ),
+                            }
+                        ],
+                        fallback_text="Soniox STT recovered — all calls back to Soniox",
+                    )
+                except Exception as alert_err:
+                    logger.warning(
+                        f"Failed to send Soniox recovery Slack alert: {alert_err}"
+                    )
+
+            _fire_and_forget(_send_recovery_alert())
+        except Exception as exc:
+            logger.warning(f"Circuit breaker record_success failed: {exc}")
+
+    # -----------------------------------------------------------------------
+    # Probe lock management (HALF-OPEN single-caller guard)
+    # -----------------------------------------------------------------------
+
+    async def try_acquire_probe(self) -> bool:
+        """Attempt to acquire the probe lock (NX).
+
+        Returns ``True`` if this call won the lock and should probe Soniox
+        with ServiceSwitcher. Returns ``False`` if another call is already
+        probing — the caller should use Deepgram directly.
+
+        The lock auto-expires after ``PROBE_LOCK_TTL_SECS`` (default 420s /
+        7 min) as a safety net if the probe call crashes without releasing.
+        """
+        if not ENABLE_BREEZE_BUDDY_STT_FALLBACK:
+            return False
+
+        try:
+            redis = await get_redis_service()
+            acquired = await redis.set(
+                _KEY_PROBE_LOCK,
+                "1",
+                nx=True,
+                ex=STT_CIRCUIT_BREAKER_PROBE_LOCK_TTL_SECS,
+            )
+
+            if acquired:
+                logger.info(
+                    "STT circuit breaker: probe lock acquired — "
+                    "this call will test Soniox with Deepgram fallback."
+                )
+
+                # Non-blocking Slack alert
+                async def _send_probe_alert():
+                    try:
+                        await slack_alert.send(
+                            title="🟡 Testing Soniox Recovery (Breeze Buddy)",
+                            fields=[
+                                {"name": "Status", "value": "Testing"},
+                            ],
+                            sections=[
+                                {
+                                    "title": "What Happened",
+                                    "text": (
+                                        "Cooldown period has ended. "
+                                        "A single call is now testing whether Soniox has recovered. "
+                                        "Other calls continue using Deepgram."
+                                    ),
+                                }
+                            ],
+                            fallback_text="Testing Soniox recovery — one call probing",
+                        )
+                    except Exception as alert_err:
+                        logger.warning(
+                            f"Failed to send Soniox recovery test Slack alert: {alert_err}"
+                        )
+
+                _fire_and_forget(_send_probe_alert())
+            else:
+                logger.info(
+                    "STT circuit breaker: probe lock not acquired — "
+                    "another call is already probing. Using Deepgram."
+                )
+
+            return acquired
+        except Exception as exc:
+            logger.warning(
+                f"Circuit breaker try_acquire_probe failed "
+                f"(defaulting to no probe): {exc}"
+            )
+            return False
+
+    async def release_probe(self) -> None:
+        """Release the probe lock.
+
+        Called after a probe call completes (success or failure) so the
+        next HALF-OPEN window can immediately start a new probe.
+        """
+        if not ENABLE_BREEZE_BUDDY_STT_FALLBACK:
+            return
+
+        try:
+            redis = await get_redis_service()
+            await redis.delete(_KEY_PROBE_LOCK)
+            logger.info("STT circuit breaker: probe lock released.")
+        except Exception as exc:
+            logger.warning(f"Circuit breaker release_probe failed: {exc}")
+
+
+# ---------------------------------------------------------------------------
+# Module-level singleton (like slack_alert)
+# ---------------------------------------------------------------------------
+stt_circuit_breaker = STTCircuitBreaker()

--- a/app/core/config/static.py
+++ b/app/core/config/static.py
@@ -1,0 +1,692 @@
+import os
+
+# --- Configuration ---
+
+
+# Environment
+ENVIRONMENT = os.environ.get("ENVIRONMENT", "production")
+PROD_LOG_LEVEL = os.environ.get("PROD_LOG_LEVEL", "INFO")
+APP_BASE_URL = os.environ.get("APP_BASE_URL", "")
+
+# Uvicorn
+PORT = int(os.environ.get("PORT", 8000))
+HOST = os.environ.get("HOST", "0.0.0.0")
+UVICORN_RELOAD = os.environ.get("UVICORN_RELOAD", "true").lower() == "true"
+UVICORN_LOG_LEVEL = os.environ.get("UVICORN_LOG_LEVEL", "info")
+
+# Gemini Proxy Configuration
+GEMINI_API_KEY = os.environ.get("GEMINI_API_KEY", "")
+
+# Pipecat Agent Configuration
+AUTOMATIC_CONNECT_BLOCKED_ORIGINS = [
+    item.strip()
+    for item in os.environ.get("AUTOMATIC_CONNECT_BLOCKED_ORIGINS", "").split(",")
+    if item.strip()
+]
+DAILY_API_KEY = os.environ.get("DAILY_API_KEY", "")
+DAILY_API_URL = os.environ.get("DAILY_API_URL", "https://api.daily.co/v1")
+# Breeze Buddy Daily API Configuration - falls back to DAILY_API_KEY and DAILY_API_URL if not set
+BREEZE_BUDDY_DAILY_API_KEY = (
+    os.environ.get("BREEZE_BUDDY_DAILY_API_KEY") or DAILY_API_KEY
+)
+BREEZE_BUDDY_DAILY_API_URL = (
+    os.environ.get("BREEZE_BUDDY_DAILY_API_URL") or DAILY_API_URL
+)
+AZURE_OPENAI_API_KEY = os.environ.get("AZURE_OPENAI_API_KEY", "")
+AZURE_OPENAI_ENDPOINT = os.environ.get("AZURE_OPENAI_ENDPOINT", "")
+AZURE_OPENAI_MODEL = os.environ.get("AZURE_OPENAI_MODEL", "gpt-4o-automatic")
+GOOGLE_CREDENTIALS_JSON = os.environ.get("GOOGLE_CREDENTIALS_JSON", "")
+
+# GCS Configuration
+GCS_CREDENTIALS_JSON = os.environ.get("GCS_CREDENTIALS_JSON", "")
+GCS_BUCKET = os.environ.get("GCS_BUCKET", "atoms-sdk")
+
+ENABLE_AIC_FILTER = os.environ.get("ENABLE_AIC_FILTER", "false").lower() == "true"
+AICOUSTICS_LICENSE_KEY = os.environ.get("AICOUSTICS_LICENSE_KEY", "")
+# Breeze Buddy AIC License Key
+BREEZE_BUDDY_AICOUSTICS_LICENSE_KEY = os.environ.get(
+    "BREEZE_BUDDY_AICOUSTICS_LICENSE_KEY", ""
+)
+
+# AIC Filter Parameters (simplified for tuning)
+AIC_ENHANCEMENT_LEVEL = float(os.environ.get("AIC_ENHANCEMENT_LEVEL", "1.0"))
+AIC_VOICE_GAIN = float(os.environ.get("AIC_VOICE_GAIN", "1.2"))
+AIC_NOISE_GATE_ENABLE = (
+    os.environ.get("AIC_NOISE_GATE_ENABLE", "true").lower() == "true"
+)
+
+# AIC Model Path Configuration
+AIC_MODEL_PATH = os.environ.get(
+    "AIC_MODEL_PATH", "/app/models/voice/aic/quail_l_8khz.aicmodel"
+)
+
+# TTS Configuration
+ELEVENLABS_API_KEY = os.environ.get("ELEVENLABS_API_KEY")
+ELEVENLABS_INDIAN_RESIDENCY_API_KEY = os.environ.get(
+    "ELEVENLABS_INDIAN_RESIDENCY_API_KEY"
+)
+ELEVENLABS_VOICE_ID = os.environ.get(
+    "ELEVENLABS_VOICE_ID", "bQQWtYx9EodAqMdkrNAc"
+)  # bQQWtYx9EodAqMdkrNAc
+ELEVENLABS_RHEA_VOICE_ID = os.environ.get(
+    "ELEVENLABS_RHEA_VOICE_ID", "bQQWtYx9EodAqMdkrNAc"
+)
+ELEVENLABS_MODEL_ID = os.environ.get("ELEVENLABS_MODEL_ID", "eleven_flash_v2_5")
+ELEVENLABS_VOICE_SPEED = float(os.environ.get("ELEVENLABS_VOICE_SPEED", 1.15))
+ELEVENLABS_TTS_SPEED = float(os.environ.get("ELEVENLABS_TTS_SPEED", "1.10"))
+ELEVENLABS_BB_VOICE_ID = os.environ.get(
+    "ELEVENLABS_BB_VOICE_ID", "fG9s0SXJb213f4UxVHyG"
+)
+ELEVENLABS_INDIAN_RESIDENCY_WEBSOCKET_URL = os.environ.get(
+    "ELEVENLABS_INDIAN_RESIDENCY_WEBSOCKET_URL", "wss://api.in.residency.elevenlabs.io"
+)
+GOOGLE_BRET_VOICE = os.environ.get("GOOGLE_BRET_VOICE", "en-IN-Chirp3-HD-Sadaltager")
+GOOGLE_MIA_VOICE = os.environ.get("GOOGLE_MIA_VOICE", "en-IN-Chirp3-HD-Despina")
+
+# Cartesia TTS Configuration
+CARTESIA_API_KEY = os.environ.get("CARTESIA_API_KEY")
+
+# Tool Call Sound Configuration
+ENABLE_TOOL_CALL_SOUND = (
+    os.environ.get("ENABLE_TOOL_CALL_SOUND", "false").lower() == "true"
+)
+TOOL_CALL_SOUND_FILE = os.environ.get(
+    "TOOL_CALL_SOUND_FILE", "assets/sounds/think2.wav"
+)
+
+# WebSocket keepalive settings
+PING_INTERVAL = int(os.environ.get("WS_PING_INTERVAL", 5))  # seconds
+PING_TIMEOUT = int(os.environ.get("WS_PING_TIMEOUT", 10))  # seconds
+
+# Juspay API configuration
+GENIUS_API_URL = "https://portal.juspay.in/api/q/query?api-type=genius-query"
+EULER_DASHBOARD_API_URL = os.environ.get(
+    "EULER_DASHBOARD_API_URL", "https://portal.juspay.in"
+)
+
+# VAD & framing for client-side audio chunking
+SAMPLE_RATE = 16000
+FRAME_DURATION = 30  # ms
+FRAME_SIZE = (
+    int(SAMPLE_RATE * FRAME_DURATION / 1000) * 2
+)  # bytes per frame (16-bit PCM)
+VAD_CONFIDENCE = float(os.environ.get("VAD_CONFIDENCE", 0.85))
+VAD_MIN_VOLUME = float(os.environ.get("VAD_MIN_VOLUME", 0.75))
+VAD_START_SECS = float(os.environ.get("VAD_START_SECS", 0.30))
+VAD_STOP_SECS = float(os.environ.get("VAD_STOP_SECS", 1.00))
+DISABLE_SILERO_VAD = (
+    os.environ.get("DISABLE_SILERO_VAD", "false").lower() == "true"
+)  # Disable Silero VAD (use when STT provider has built-in VAD)
+
+ENABLE_MUTE_UNTIL_FIRST_BOT_COMPLETE = (
+    os.environ.get("ENABLE_MUTE_UNTIL_FIRST_BOT_COMPLETE", "false").lower() == "true"
+)
+
+# Mem0 Configuration
+MEM0_API_KEY = os.getenv("MEM0_API_KEY", "")
+MEM0_ENABLED = os.getenv("MEM0_ENABLED", "false").lower() == "true"
+MEM0_MAX_FAILURES = int(os.getenv("MEM0_MAX_FAILURES", "3"))
+MEM0_RETRY_INTERVAL = int(os.getenv("MEM0_RETRY_INTERVAL", "300"))
+MEM0_SESSION_TIMEOUT = int(os.getenv("MEM0_SESSION_TIMEOUT", "3600"))
+MEM0_MIN_MESSAGE_LENGTH = int(os.getenv("MEM0_MIN_MESSAGE_LENGTH", "10"))
+
+# Tracing
+ENABLE_TRACING = os.environ.get("ENABLE_TRACING", "false").lower() == "true"
+OPEN_OBSERVE_BASE_URL = os.environ.get(
+    "OPEN_OBSERVE_BASE_URL", "https://periscope.breeze.in"
+)
+
+# Text sanitization
+SANITIZE_TEXT_FOR_TTS = (
+    os.environ.get("SANITIZE_TEXT_FOR_TTS", "false").lower() == "true"
+)
+
+# Audio recording
+ENABLE_AUTOMATIC_DAILY_RECORDING = (
+    os.environ.get("ENABLE_AUTOMATIC_DAILY_RECORDING", "false").lower() == "true"
+)
+
+# Search
+ENABLE_SEARCH_GROUNDING = (
+    os.environ.get("ENABLE_SEARCH_GROUNDING", "true").lower() == "true"
+)
+GEMINI_SEARCH_RESULT_API_MODEL = os.environ.get(
+    "GEMINI_SEARCH_RESULT_API_MODEL", "gemini-2.5-flash-lite-preview-06-17"
+)
+
+# --- STT Configuration ---
+STT_PROVIDER = os.environ.get(
+    "STT_PROVIDER", "google"
+).lower()  # "google", "assemblyai", "openai", "deepgram", "soniox", "elevenlabs", or "sarvam"
+ASSEMBLYAI_API_KEY = os.getenv("ASSEMBLYAI_API_KEY")
+OPENAI_STT_API_KEY = os.getenv("OPENAI_STT_API_KEY")
+OPENAI_STT_MODEL = os.environ.get(
+    "OPENAI_STT_MODEL", "gpt-4o-transcribe"
+)  # or "whisper-1"
+ENFORCED_OPENAI_STT_MODEL = os.environ.get("ENFORCED_OPENAI_STT_MODEL", "whisper-1")
+ENABLE_OPENAI_FOR_MIA = (
+    os.environ.get("ENABLE_OPENAI_FOR_MIA", "false").lower() == "true"
+)
+
+# --- Deepgram STT Configuration ---
+DEEPGRAM_API_KEY = os.getenv(
+    "DEEPGRAM_API_KEY"
+)  # Required API key for Deepgram authentication
+DEEPGRAM_MODEL = os.environ.get(
+    "DEEPGRAM_MODEL", "nova-3-general"
+)  # Deepgram model (nova-3-general recommended for balanced accuracy/speed)
+DEEPGRAM_LANGUAGE = os.environ.get(
+    "DEEPGRAM_LANGUAGE", "en"
+)  # Language code for transcription (en, en-US, en-IN, etc.)
+DEEPGRAM_ENDPOINTING = (
+    os.environ.get("DEEPGRAM_ENDPOINTING", "true").lower() == "true"
+)  # Enable smart endpointing for automatic turn detection
+DEEPGRAM_VAD_EVENTS = (
+    os.environ.get("DEEPGRAM_VAD_EVENTS", "true").lower() == "true"
+)  # Enable Voice Activity Detection events (SpeechStarted/UtteranceEnd)
+DEEPGRAM_UTTERANCE_END_MS = int(
+    os.environ.get("DEEPGRAM_UTTERANCE_END_MS", "1000")
+)  # Milliseconds to wait before considering utterance ended
+DEEPGRAM_NO_DELAY = (
+    os.environ.get("DEEPGRAM_NO_DELAY", "true").lower() == "true"
+)  # Enable real-time processing with minimal delay
+DEEPGRAM_SMART_FORMAT = (
+    os.environ.get("DEEPGRAM_SMART_FORMAT", "true").lower() == "true"
+)  # Apply smart formatting (phone numbers, dates, currency)
+DEEPGRAM_PUNCTUATE = (
+    os.environ.get("DEEPGRAM_PUNCTUATE", "true").lower() == "true"
+)  # Add punctuation to transcription for readability
+DEEPGRAM_NUMERALS = (
+    os.environ.get("DEEPGRAM_NUMERALS", "true").lower() == "true"
+)  # Convert spoken numbers to numerals (critical for Indian lakhs/crores)
+DEEPGRAM_PROFANITY_FILTER = (
+    os.environ.get("DEEPGRAM_PROFANITY_FILTER", "false").lower() == "true"
+)  # Filter profanity (disabled for business context)
+DEEPGRAM_DIARIZE = (
+    os.environ.get("DEEPGRAM_DIARIZE", "false").lower() == "true"
+)  # Enable speaker diarization (disabled for single-speaker voice agent)
+# Language detection options (streaming API only supports 'multi' for auto-detection or single language)
+DEEPGRAM_AUTO_DETECT_LANGUAGE = (
+    os.environ.get("DEEPGRAM_AUTO_DETECT_LANGUAGE", "false").lower() == "true"
+)  # Enable automatic language detection (uses 'multi' parameter)
+
+# --- Sarvam STT & TTS Configuration ---
+SARVAM_API_KEY = os.getenv("SARVAM_API_KEY")
+
+# --- Soniox STT Configuration ---
+# Soniox is optimized to solve the 0.5-second speech pause issue experienced with Deepgram
+SONIOX_API_KEY = os.getenv(
+    "SONIOX_API_KEY"
+)  # Required API key for Soniox authentication
+
+
+SONIOX_MODEL = os.environ.get(
+    "SONIOX_MODEL", "stt-rt-v4"
+)  # Soniox model optimized for real-time conversation
+SONIOX_LANGUAGE_HINTS = os.environ.get(
+    "SONIOX_LANGUAGE_HINTS", "en"
+)  # Language hints for transcription (comma-separated: en,hi,es)
+SONIOX_CONTEXT = os.environ.get(
+    "SONIOX_CONTEXT",
+    '{ "general": [ {"key": "organisation", "value": "Juspay"}, {"key": "company", "value": "Breeze"}, {"key": "product", "value": "Breeze Automatic"}, {"key": "related_product", "value": "Breeze Checkout"}, {"key": "domain", "value": "D2C ecommerce analytics and business intelligence"}, {"key": "service_type", "value": "AI chatbot for merchant data analysis"}, {"key": "data_sources", "value": "Shopify, payment gateways, Meta Ads, Google Ads, Google Analytics"}, {"key": "user", "value": "D2C merchant, brand owner, or marketing manager"}, {"key": "conversation_type", "value": "performance analysis, metrics review, optimization insights"} ], "text": "User Persona: D2C ecommerce merchants and marketing managers running Shopify stores who need quick, actionable insights from their business data. They are results-focused, time-constrained, and prefer asking natural questions over building complex reports. They monitor key metrics like revenue, conversion rates, CAC, and ROAS daily, making rapid decisions about budget allocation and optimization strategies.Breeze Automatic is an AI-powered analytics conversational chatbot designed specifically for direct-to-consumer ecommerce merchants. It collates and analyzes data from multiple sources including Shopify stores, payment gateways, Meta advertising platforms, Google Ads campaigns, and Google Analytics to provide comprehensive business insights. Merchants use Breeze Automatic to understand their checkout performance, advertising return on investment, conversion funnel optimization, and overall business health. Common conversational patterns include asking about daily or weekly revenue performance, comparing current metrics to previous time periods like month-over-month or year-over-year, investigating drops in conversion rates or spikes in customer acquisition costs, analyzing which advertising channels are performing best, understanding customer behavior and segmentation, tracking checkout abandonment rates, evaluating the effectiveness of marketing campaigns across Meta and Google platforms, and identifying opportunities to improve profitability. Merchants often inquire about their top-performing products, customer lifetime value trends, retention metrics, and how their ad spend efficiency compares across different channels. The chatbot helps answer questions like how todays sales compare to yesterday, which ad campaigns are driving the highest return on ad spend, why checkout conversion might be declining, what the blended customer acquisition cost is across all channels, and how to allocate budget between Meta Ads and Google Ads for maximum return. Users discuss payment success rates, failed transactions, refund patterns, and fraud indicators. They ask about traffic sources, landing page performance, and which marketing touchpoints contribute most to conversions. Breeze Automatic enables merchants to make data-driven decisions by translating complex analytics into actionable insights through natural conversation.", "terms": [ "Juspay", "Breeze Automatic", "Breeze Checkout", "Shopify", "Razorpay", "Cashfree", "PayU", "Easebuzz", "Meta Ads", "Google Ads", "Google Analytics", "D2C", "PSR", "GMV", "UPI", "ROAS", "AOV", "RTO", "COD", "CAC", "LTV", "CPC", "CPM", "CTR", "NDR", "AWB", "SKU", "Sales", "Cart", "Abandonment", "Split", "Yesterday", "Dispatches", "Orders", "Fulfillment", "Processing", "Shipped", "Delivered", "In-transit", "Return", "Exchange", "Refund", "Settlement", "Payout", "Transaction", "Failed payment", "Payment pending", "Chargeback", "Disputed transaction", "Payment success rate", "Non-delivery report", "Undelivered", "Pin code", "Serviceable", "New customer", "Returning customer", "Repeat purchase", "Customer cohort", "Customer segment", "First-time buyer", "Repeat buyer", "Campaign", "Ad set", "Creative", "Cost per click", "Cost per mille", "Click-through rate", "Impression", "Reach", "Engagement", "Conversion", "Pixel", "Attribution", "Conversion rate", "Bounce rate", "Sessions", "Pageviews", "Unique visitors", "Add-to-cart rate", "Checkout drop-off", "blended CAC", "checkout abandonment", "conversion funnel", "ad spend", "Google Ads Spend", "customer acquisition cost", "return on ad spend", "month-over-month", "year-over-year", "payment gateway", "customer lifetime value", "marketing touchpoints", "landing page performance", "traffic sources", "checkout conversion", "refund patterns", "fraud indicators", "retention metrics", "budget allocation", "ecommerce", "direct-to-consumer", "Out of stock", "Inventory turnover" ], "translation_terms": [ {"source": "Juspay", "target": "Juspay"}, {"source": "Breeze", "target": "Breeze"}, {"source": "Shopify", "target": "Shopify"}, {"source": "Razorpay", "target": "Razorpay"}, {"source": "Cashfree", "target": "Cashfree"}, {"source": "PayU", "target": "PayU"}, {"source": "Easebuzz", "target": "Easebuzz"}, {"source": "Meta Ads", "target": "Meta Ads"}, {"source": "Google Ads", "target": "Google Ads"}, {"source": "ROAS", "target": "ROAS"}, {"source": "CAC", "target": "CAC"}, {"source": "D2C", "target": "D2C"}, {"source": "PSR", "target": "PSR"}, {"source": "GMV", "target": "GMV"}, {"source": "UPI", "target": "UPI"}, {"source": "AOV", "target": "AOV"}, {"source": "RTO", "target": "RTO"}, {"source": "COD", "target": "COD"} ] }',
+)  # Business context for better transcription of domain-specific terms
+SONIOX_ENABLE_NON_FINAL_TOKENS = (
+    os.environ.get("SONIOX_ENABLE_NON_FINAL_TOKENS", "false").lower() == "true"
+)  # Enable interim/non-final tokens for real-time feedback
+SONIOX_MAX_NON_FINAL_TOKENS_DURATION_MS = int(
+    os.environ.get("SONIOX_MAX_NON_FINAL_TOKENS_DURATION_MS", "0")
+)  # Maximum duration for non-final tokens (0 = no limit)
+SONIOX_VAD_FORCE_TURN_ENDPOINT = (
+    os.environ.get("SONIOX_VAD_FORCE_TURN_ENDPOINT", "false").lower() == "true"
+)  # CRITICAL: false = Use Soniox intelligent endpoint detection
+# true = Use external VAD (Silero)
+SONIOX_MAX_ENDPOINT_DELAY_MS = int(
+    os.environ.get("SONIOX_MAX_ENDPOINT_DELAY_MS", "500")
+)  # Max delay (ms) for Soniox native endpoint detection (500-3000, default 500)
+
+# Automatic MCP Tool Server
+ENABLE_BREEZE_MCP_FOR_BRET = (
+    os.environ.get("ENABLE_BREEZE_MCP_FOR_BRET", "false").lower() == "true"
+)
+
+BREEZE_MCP_ENDPOINT_PATH = os.environ.get("BREEZE_MCP_ENDPOINT_PATH", "/ai/mcp/v2")
+
+MCP_CLIENT_TIMEOUT = int(os.environ.get("MCP_CLIENT_TIMEOUT", 30))  # seconds
+shops_for_mcp = os.environ.get("SHOPS_FOR_BREEZE_MCP", "")
+SHOPS_FOR_BREEZE_MCP = [
+    shop.strip() for shop in shops_for_mcp.split(",") if shop.strip()
+]
+
+# Shops for performance directives
+shops_for_performance_directives_str = os.environ.get(
+    "SHOPS_FOR_PERFORMANCE_DIRECTIVES", ""
+)
+SHOPS_FOR_PERFORMANCE_DIRECTIVES = [
+    shop.strip()
+    for shop in shops_for_performance_directives_str.split(",")
+    if shop.strip()
+]
+
+LIGHTHOUSE_APP_URL = os.environ.get("LIGHTHOUSE_APP_URL", "http://localhost:5173")
+ENABLE_ALL_METRICS_FROM_CKH = (
+    os.environ.get("ENABLE_ALL_METRICS_FROM_CKH", "true").lower() == "true"
+)
+
+# Get authorized users from environment, split and normalize
+AUTOMATIC_WRITE_ACTIONS_AUTHORIZED_USERS = [
+    email.strip().lower()
+    for email in os.environ.get("AUTOMATIC_WRITE_ACTIONS_AUTHORIZED_USERS", "").split(
+        ","
+    )
+    if email.strip()
+]
+
+ENABLE_WRITE_ACTIONS_FOR_MERCHANTS = (
+    os.environ.get("ENABLE_WRITE_ACTIONS_FOR_MERCHANTS", "false").lower() == "true"
+)
+
+# Get write actions from environment, split and normalize
+AUTOMATIC_ACTIONS_REQUIRE_AUTH = [
+    action.strip().lower()
+    for action in os.environ.get("AUTOMATIC_ACTIONS_REQUIRE_AUTH", "").split(",")
+    if action.strip()
+]
+
+# Context Summarization Configuration
+ENABLE_SUMMARIZATION = os.environ.get("ENABLE_SUMMARIZATION", "true").lower() == "true"
+MAX_TURNS_BEFORE_SUMMARY = int(os.environ.get("MAX_TURNS_BEFORE_SUMMARY", 10))
+KEEP_RECENT_TURNS = int(os.environ.get("KEEP_RECENT_TURNS", 2))
+
+AZURE_BREEZE_BUDDY_OPENAI_MODEL = os.environ.get(
+    "AZURE_BREEZE_BUDDY_OPENAI_MODEL", "gpt-4o-automatic"
+)
+
+# Twilio settings
+TWILIO_ACCOUNT_SID = os.getenv("TWILIO_ACCOUNT_SID", "")
+TWILIO_AUTH_TOKEN = os.getenv("TWILIO_AUTH_TOKEN", "")
+TWILIO_TEMPLATE_WEBSOCKET_URL = os.getenv("TWILIO_TEMPLATE_WEBSOCKET_URL", "")
+# Webhook Authentication
+ORDER_CONFIRMATION_WEBHOOK_SECRET_KEY = os.getenv(
+    "ORDER_CONFIRMATION_WEBHOOK_SECRET_KEY", ""
+)
+ORDER_CONFIRMATION_TOKEN = os.getenv("ORDER_CONFIRMATION_TOKEN", "")
+
+# PostgreSQL Database Configuration
+POSTGRES_USER = os.getenv("POSTGRES_USER", "")
+POSTGRES_PASSWORD = os.getenv("POSTGRES_PASSWORD", "")
+POSTGRES_HOST = os.getenv("POSTGRES_HOST", "")
+POSTGRES_PORT = os.getenv("POSTGRES_PORT", "")
+POSTGRES_DB = os.getenv("POSTGRES_DB", "")
+
+# Connection pool settings
+POSTGRES_POOL_SIZE = int(os.getenv("POSTGRES_POOL_SIZE", "5"))
+POSTGRES_MAX_OVERFLOW = int(os.getenv("POSTGRES_MAX_OVERFLOW", "10"))
+POSTGRES_POOL_RECYCLE = int(os.getenv("POSTGRES_POOL_RECYCLE", "3600"))  # 1 hour
+
+# KMS Configuration
+SKIP_KMS_DECRYPT = os.getenv("SKIP_KMS_DECRYPT", "false").lower() == "true"
+AWS_REGION = os.getenv("AWS_REGION", "us-east-1")
+AWS_ACCESS_KEY_ID = os.getenv("AWS_ACCESS_KEY_ID", "")
+AWS_SECRET_ACCESS_KEY = os.getenv("AWS_SECRET_ACCESS_KEY", "")
+
+# Credential Encryption (AES-256-GCM)
+# Base64-encoded 32-byte key. Generate with:
+#   python -c "import os,base64; print(base64.urlsafe_b64encode(os.urandom(32)).decode())"
+# When empty, credentials are stored as plain JSON (acceptable for dev/local).
+CREDENTIAL_ENCRYPTION_KEY = os.getenv("CREDENTIAL_ENCRYPTION_KEY", "")
+
+# JWT Authentication Configuration
+JWT_SECRET_KEY = os.getenv("JWT_SECRET_KEY", "")
+JWT_ALGORITHM = os.getenv("JWT_ALGORITHM", "")
+JWT_ACCESS_TOKEN_EXPIRE_MINUTES = int(
+    os.getenv("JWT_ACCESS_TOKEN_EXPIRE_MINUTES", "60")
+)
+LIGHTHOUSE_JWT_SECRET = os.getenv("LIGHTHOUSE_JWT_SECRET", "")
+ENABLE_LIGHTHOUSE_AUTH = os.getenv("ENABLE_LIGHTHOUSE_AUTH", "false").lower() == "true"
+
+BREEZE_BUDDY_VAD_CONFIDENCE = float(
+    os.getenv("BREEZE_BUDDY_VAD_CONFIDENCE", "0.5")
+)  # Require stronger confidence
+BREEZE_BUDDY_VAD_START_SECS = float(
+    os.getenv("BREEZE_BUDDY_VAD_START_SECS", "0.1")
+)  # Pick up quicker
+BREEZE_BUDDY_VAD_STOP_SECS = float(
+    os.getenv("BREEZE_BUDDY_VAD_STOP_SECS", "0.3")
+)  # Allow small pauses
+BREEZE_BUDDY_VAD_MIN_VOLUME = float(
+    os.getenv("BREEZE_BUDDY_VAD_MIN_VOLUME", "0.4")
+)  # More tolerant for soft voice
+BREEZE_BUDDY_STT_SERVICE = os.getenv(
+    "BREEZE_BUDDY_STT_SERVICE", "soniox"
+).lower()  # "google" or "openai"
+
+# Session inactivity timeout
+AUTOMATIC_SESSION_INACTIVITY_TIMEOUT = float(
+    os.environ.get("AUTOMATIC_SESSION_INACTIVITY_TIMEOUT", 900.0)
+)
+MAX_DAILY_SESSION_LIMIT = int(os.environ.get("MAX_DAILY_SESSION_LIMIT", 1800))
+
+# Pool Configuration
+VOICE_AGENT_POOL_SIZE = int(os.environ.get("VOICE_AGENT_POOL_SIZE", 1))
+VOICE_AGENT_MAX_POOL_SIZE = int(os.environ.get("VOICE_AGENT_MAX_POOL_SIZE", 3))
+DAILY_ROOM_POOL_SIZE = int(os.environ.get("DAILY_ROOM_POOL_SIZE", 1))
+DAILY_ROOM_MAX_POOL_SIZE = int(os.environ.get("DAILY_ROOM_MAX_POOL_SIZE", 5))
+
+# Human-in-the-Loop (HITL) Configuration
+HITL_ENABLE = os.environ.get("HITL_ENABLE", "true").lower() == "true"
+FUNCTION_CONFIRMATION_TIMEOUT = int(
+    os.environ.get("FUNCTION_CONFIRMATION_TIMEOUT", "30")
+)
+
+# HITL Actions Configuration
+_hitl_actions_str = os.environ.get("HITL_ACTIONS", "delete")
+HITL_ACTIONS = [
+    action.strip().lower() for action in _hitl_actions_str.split(",") if action.strip()
+]
+
+# Chart Generation Configuration
+ENABLE_CHARTS = os.environ.get("ENABLE_CHARTS", "false").lower() == "true"
+MAX_CHARTS_PER_TURN = int(os.environ.get("MAX_CHARTS_PER_TURN", "1"))
+
+# PTT VAD Filter Configuration
+DISABLE_VAD_FOR_PTT = os.environ.get("DISABLE_VAD_FOR_PTT", "true").lower() == "true"
+
+BREEZE_DEFAULT_SALES_TAB = os.environ.get("BREEZE_DEFAULT_SALES_TAB", "SALES")
+
+# Breeze Portal URLs
+AWS_BREEZE_PORTAL_URL = os.environ.get(
+    "AWS_BREEZE_PORTAL_URL", "https://portal.breeze.in"
+)
+GCP_BREEZE_PORTAL_URL = os.environ.get(
+    "GCP_BREEZE_PORTAL_URL", "https://portal.breezesdk.store"
+)
+AUTOMATIC_OPENAI_STT_PROMPT = os.environ.get("AUTOMATIC_OPENAI_STT_PROMPT", "")
+
+# Announcement Banner Configuration
+DEFAULT_ANNOUNCEMENT_BANNER_TEXT_COLOR = os.environ.get(
+    "DEFAULT_ANNOUNCEMENT_BANNER_TEXT_COLOR", "white"
+)
+DEFAULT_ANNOUNCEMENT_BANNER_BACKGROUND_COLOR = os.environ.get(
+    "DEFAULT_ANNOUNCEMENT_BANNER_BACKGROUND_COLOR", "#714acd"
+)
+
+EXOTEL_ACCOUNT_SID = os.getenv("EXOTEL_ACCOUNT_SID", "")
+EXOTEL_API_KEY = os.getenv("EXOTEL_API_KEY", "")
+EXOTEL_API_TOKEN = os.getenv("EXOTEL_API_TOKEN", "")
+# Exotel Webhook Authentication - required for inbound webhook security
+EXOTEL_WEBHOOK_AUTH_TOKEN = os.getenv("EXOTEL_WEBHOOK_AUTH_TOKEN", "")
+AWS_VAYU_URL = os.environ.get("AWS_VAYU_URL")
+AWS_VAYU_READ_API_KEY = os.environ.get("AWS_VAYU_READ_API_KEY")
+AWS_VAYU_WRITE_API_KEY = os.environ.get("AWS_VAYU_WRITE_API_KEY")
+EXOTEL_SUBDOMAIN = os.getenv("EXOTEL_SUBDOMAIN", "api.exotel.com")
+EXOTEL_TEMPLATE_APPLET_APP_ID = os.getenv("EXOTEL_TEMPLATE_APPLET_APP_ID", "")
+
+# Plivo Configuration
+PLIVO_AUTH_ID = os.getenv("PLIVO_AUTH_ID", "")
+PLIVO_AUTH_TOKEN = os.getenv("PLIVO_AUTH_TOKEN", "")
+PLIVO_RECORDING_TIME_LIMIT = int(
+    os.getenv("PLIVO_RECORDING_TIME_LIMIT", "14400")
+)  # Default: 4 hours (14400 seconds)
+
+# Proxy Configuration
+AWS_PROXY_HOST = os.environ.get("AWS_PROXY_HOST")
+AWS_PROXY_PORT = os.environ.get("AWS_PROXY_PORT")
+CLOUD_ENVIRONMENT = os.environ.get("CLOUD_ENVIRONMENT", "GCP")  # AWS, GCP, AZURE, etc.
+
+# LangFuse Configuration (for OpenTelemetry tracing only)
+LANGFUSE_SECRET_KEY = os.environ.get("LANGFUSE_SECRET_KEY", "")
+LANGFUSE_PUBLIC_KEY = os.environ.get("LANGFUSE_PUBLIC_KEY", "")
+LANGFUSE_BASEURL = os.environ.get("LANGFUSE_BASEURL", "https://us.cloud.langfuse.com")
+
+BREEZE_BUDDY_SONIOX_MODEL = os.environ.get("BREEZE_BUDDY_SONIOX_MODEL", "stt-rt-v4")
+BREEZE_BUDDY_SONIOX_LANGUAGE_HINTS = os.environ.get(
+    "BREEZE_BUDDY_SONIOX_LANGUAGE_HINTS", "en,hi"
+)
+BREEZE_BUDDY_SONIOX_CONTEXT = os.environ.get(
+    "BREEZE_BUDDY_SONIOX_CONTEXT",
+    '{ "general": [ {"key": "organisation", "value": "Juspay"}, {"key": "company", "value": "Breeze"}, {"key": "product", "value": "Breeze Buddy"}, {"key": "domain", "value": "E-commerce Customer Service"}, {"key": "service_type", "value": "Order Confirmation and Address Verification"}, {"key": "conversation_type", "value": "Outbound automated voice call"}, {"key": "purpose", "value": "Cash on Delivery order confirmation"}, {"key": "user", "value": "Customer"}, {"key": "languages", "value": "Hindi, English, Tamil, Telugu, Kannada, Malayalam, Bengali, Marathi, Gujarati, and other Indian languages"}, {"key": "region", "value": "India"} ], "text": "Breeze Buddy is an automated voice agent that contacts customers across India who have placed Cash on Delivery orders. Customers may respond in any Indian language including Hindi, English, Tamil, Telugu, Kannada, Malayalam, Bengali, Marathi, Gujarati, or other regional languages. The agent confirms order details including product information, delivery address, contact number, and expected delivery date. The conversation involves verifying the customer\'s identity, confirming their order items and quantities, validating the complete delivery address including landmark details, and ensuring the customer will be available to receive the order. The agent handles common queries about order modifications, cancellations, and payment methods. Customers may use code-mixed language or switch between languages during the conversation.", "terms": [ "Juspay", "Breeze Buddy", "Shopify", "COD", "Cash on Delivery", "order confirmation", "delivery address", "pincode", "landmark", "order ID", "SKU", "order cancellation", "reschedule delivery", "prepaid", "payment gateway", "order tracking", "estimated delivery", "shipping address", "billing address", "State", "Yes", "Yeah", "Good", "Time", "Yep", "Later", "Available", "Busy", "Confirm", "Repeat", "What", "Order", "Hello", "Okay", "Sir", "Madam", "Namaste", "Address", "Price", "Delivery", "Rupees", "District", "Correct", "Fine", "Right", "Details", "Continue", "Item", "Total", "Cancel", "कौनसा", "ठीक है", "हाँ", "धन्यवाद", "ऑर्डर", "पता", "समय", "फोन", "संख्या", "बदलना", "सही है", "हेलो", "बोलिए", "जी", "मैडम", "नमस्ते", "कन्फर्म", "डिलीवरी", "पिनकोड", "रुपये", "कीमत", "राशि", "बराबर", "करेक्ट", "ओके" ], "translation_terms": [ {"source": "Juspay", "target": "Juspay"}, {"source": "Breeze", "target": "Breeze"}, {"source": "Breeze Buddy", "target": "Breeze Buddy"}, {"source": "Shopify", "target": "Shopify"}, {"source": "COD", "target": "COD"}, {"source": "Cash on Delivery", "target": "Cash on Delivery"}, {"source": "order ID", "target": "order ID"}, {"source": "Rhea", "target": "Rhea"}, {"source": "रिया", "target": "Rhea"} ] }',
+)
+BREEZE_BUDDY_SONIOX_ENABLE_NON_FINAL_TOKENS = (
+    os.environ.get("BREEZE_BUDDY_SONIOX_ENABLE_NON_FINAL_TOKENS", "true").lower()
+    == "true"
+)
+BREEZE_BUDDY_SONIOX_MAX_NON_FINAL_TOKENS_DURATION_MS = int(
+    os.environ.get("BREEZE_BUDDY_SONIOX_MAX_NON_FINAL_TOKENS_DURATION_MS", "0")
+)
+BREEZE_BUDDY_SONIOX_VAD_FORCE_TURN_ENDPOINT = (
+    os.environ.get("BREEZE_BUDDY_SONIOX_VAD_FORCE_TURN_ENDPOINT", "false").lower()
+    == "true"
+)
+BREEZE_BUDDY_SONIOX_MAX_ENDPOINT_DELAY_MS = int(
+    os.environ.get("BREEZE_BUDDY_SONIOX_MAX_ENDPOINT_DELAY_MS", "500")
+)  # Max delay (ms) for Soniox native endpoint detection (500-3000, default 500)
+
+# --- Breeze Buddy STT Fallback Configuration ---
+# When enabled, pre-loads Deepgram alongside Soniox using ServiceSwitcher.
+# If Soniox fails mid-call, audio is hot-swapped to Deepgram with ~0ms delay.
+ENABLE_BREEZE_BUDDY_STT_FALLBACK = (
+    os.environ.get("ENABLE_BREEZE_BUDDY_STT_FALLBACK", "false").lower() == "true"
+)  # Gate for mid-call STT fallback via ServiceSwitcher
+
+# Deepgram STT configuration for Breeze Buddy fallback
+BREEZE_BUDDY_DEEPGRAM_MODEL = os.environ.get(
+    "BREEZE_BUDDY_DEEPGRAM_MODEL", "nova-3-general"
+)  # Deepgram model for Breeze Buddy fallback
+BREEZE_BUDDY_DEEPGRAM_LANGUAGE = os.environ.get(
+    "BREEZE_BUDDY_DEEPGRAM_LANGUAGE", "multi"
+)  # Language code ("multi" for auto-detection across Indian languages)
+BREEZE_BUDDY_DEEPGRAM_SMART_FORMAT = (
+    os.environ.get("BREEZE_BUDDY_DEEPGRAM_SMART_FORMAT", "true").lower() == "true"
+)
+BREEZE_BUDDY_DEEPGRAM_PUNCTUATE = (
+    os.environ.get("BREEZE_BUDDY_DEEPGRAM_PUNCTUATE", "true").lower() == "true"
+)
+BREEZE_BUDDY_DEEPGRAM_ENDPOINTING = int(
+    os.environ.get("BREEZE_BUDDY_DEEPGRAM_ENDPOINTING", "300")
+)  # Endpointing delay in ms (lower = faster turn detection)
+BREEZE_BUDDY_DEEPGRAM_VAD_EVENTS = (
+    os.environ.get("BREEZE_BUDDY_DEEPGRAM_VAD_EVENTS", "true").lower() == "true"
+)
+BREEZE_BUDDY_DEEPGRAM_UTTERANCE_END_MS = int(
+    os.environ.get("BREEZE_BUDDY_DEEPGRAM_UTTERANCE_END_MS", "1000")
+)
+BREEZE_BUDDY_DEEPGRAM_NO_DELAY = (
+    os.environ.get("BREEZE_BUDDY_DEEPGRAM_NO_DELAY", "true").lower() == "true"
+)
+BREEZE_BUDDY_DEEPGRAM_INTERIM_RESULTS = (
+    os.environ.get("BREEZE_BUDDY_DEEPGRAM_INTERIM_RESULTS", "true").lower() == "true"
+)
+BREEZE_BUDDY_DEEPGRAM_NUMERALS = (
+    os.environ.get("BREEZE_BUDDY_DEEPGRAM_NUMERALS", "true").lower() == "true"
+)
+BREEZE_BUDDY_DEEPGRAM_PROFANITY_FILTER = (
+    os.environ.get("BREEZE_BUDDY_DEEPGRAM_PROFANITY_FILTER", "false").lower() == "true"
+)
+BREEZE_BUDDY_DEEPGRAM_DIARIZE = (
+    os.environ.get("BREEZE_BUDDY_DEEPGRAM_DIARIZE", "false").lower() == "true"
+)
+BREEZE_BUDDY_DEEPGRAM_AUTO_DETECT_LANGUAGE = (
+    os.environ.get("BREEZE_BUDDY_DEEPGRAM_AUTO_DETECT_LANGUAGE", "true").lower()
+    == "true"
+)  # Auto language detection enabled by default for Breeze Buddy (multi-lingual calls)
+
+# --- STT Circuit Breaker Configuration ---
+# Redis-backed circuit breaker that tracks Soniox failures across pods.
+# After FAILURE_THRESHOLD failures within FAILURE_WINDOW_SECS, the circuit
+# trips OPEN for OPEN_DURATION_SECS — all calls use Deepgram directly.
+# After cooldown, a single probe call (protected by ServiceSwitcher) tests
+# Soniox. If it fails, re-trips with RETRIP_THRESHOLD.
+STT_CIRCUIT_BREAKER_FAILURE_THRESHOLD = int(
+    os.environ.get("STT_CIRCUIT_BREAKER_FAILURE_THRESHOLD", "2")
+)  # Number of failures within window to trip the circuit
+STT_CIRCUIT_BREAKER_RETRIP_THRESHOLD = int(
+    os.environ.get("STT_CIRCUIT_BREAKER_RETRIP_THRESHOLD", "1")
+)  # Failures to re-trip from HALF-OPEN (1 = single probe failure re-trips)
+STT_CIRCUIT_BREAKER_OPEN_DURATION_SECS = int(
+    os.environ.get("STT_CIRCUIT_BREAKER_OPEN_DURATION_SECS", "1800")
+)  # Cooldown period in OPEN state (default 30 minutes)
+STT_CIRCUIT_BREAKER_FAILURE_WINDOW_SECS = int(
+    os.environ.get("STT_CIRCUIT_BREAKER_FAILURE_WINDOW_SECS", "240")
+)  # Sliding window for failure counter TTL (default 4 minutes)
+STT_CIRCUIT_BREAKER_PROBE_LOCK_TTL_SECS = int(
+    os.environ.get("STT_CIRCUIT_BREAKER_PROBE_LOCK_TTL_SECS", "420")
+)  # NX lock TTL for HALF-OPEN probe call (default 7 min, > max call duration)
+
+ENABLE_BREEZE_BUDDY_USER_INTERRUPTION = (
+    os.environ.get("ENABLE_BREEZE_BUDDY_USER_INTERRUPTION", "false").lower() == "true"
+)
+
+# Dashboard Authentication
+BREEZE_BUDDY_DASHBOARD_USERNAME = os.getenv("BREEZE_BUDDY_DASHBOARD_USERNAME", "")
+BREEZE_BUDDY_DASHBOARD_PASSWORD = os.getenv("BREEZE_BUDDY_DASHBOARD_PASSWORD", "")
+BREEZE_BUDDY_SESSION_SECRET_KEY = os.getenv("BREEZE_BUDDY_SESSION_SECRET_KEY", "")
+
+ENABLE_BREEZE_BUDDY_TRACING = (
+    os.getenv("ENABLE_BREEZE_BUDDY_TRACING", "false").lower() == "true"
+)
+BUDDY_OTEL_EXPORTER_OTLP_TRACES_ENDPOINT = os.getenv(
+    "BUDDY_OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", ""
+)
+BUDDY_OTEL_EXPORTER_OTLP_TRACES_HEADERS = os.getenv(
+    "BUDDY_OTEL_EXPORTER_OTLP_TRACES_HEADERS", ""
+)
+UPLOAD_BREEZE_BUDDY_CALL_RECORDINGS_TO_CLOUD = (
+    os.getenv("UPLOAD_BREEZE_BUDDY_CALL_RECORDINGS_TO_CLOUD", "false").lower() == "true"
+)
+
+# Graceful Shutdown Configuration
+# NOTE: BOT_MAX_DRAIN_SECONDS should be less than Kubernetes terminationGracePeriodSeconds
+# to allow time for cleanup. Recommended: terminationGracePeriodSeconds - 20 seconds
+# For a 45s termination grace period, use 25s drain + ~5s cleanup = 30s total
+ENABLE_SIGTERM_HANDLER = (
+    os.environ.get("ENABLE_SIGTERM_HANDLER", "false").lower() == "true"
+)
+BOT_MAX_DRAIN_SECONDS = int(os.environ.get("BOT_MAX_DRAIN_SECONDS", "25"))
+
+# Redis Configuration
+REDIS_HOST = os.getenv("REDIS_HOST", "")
+REDIS_PORT = os.getenv("REDIS_PORT", "")
+REDIS_CLUSTER_NODES = os.getenv("REDIS_CLUSTER_NODES", "")
+REDIS_TTL = int(os.getenv("REDIS_TTL", "3600"))  # Default TTL in seconds (1 hour)
+BLACKLIST_CACHE_TTL = int(os.getenv("BLACKLIST_CACHE_TTL", "300"))  # 5 minutes
+# ─────────────────────────────────────────────────────────────────────────────
+# Voice Agent Pod Isolation Configuration (1-pod-1-call architecture)
+# ─────────────────────────────────────────────────────────────────────────────
+# Enable pod isolation mode (when True, uses 1-pod-1-call architecture)
+ENABLE_VOICE_AGENT_POD_ISOLATION = (
+    os.environ.get("ENABLE_VOICE_AGENT_POD_ISOLATION", "false").lower() == "true"
+)
+
+# Pod identity (injected by Kubernetes StatefulSet)
+# POD_NAME is the unique identifier like "voice-agent-0"
+VOICE_AGENT_POD_NAME = os.environ.get("POD_NAME", "")
+VOICE_AGENT_POD_IP = os.environ.get("POD_IP", "")
+
+
+# =============================================================================
+# Smart Router Configuration
+# =============================================================================
+# Smart Router is an external service that handles pod allocation and pool management
+# When enabled, allocation logic moves from Python to Smart Router service
+
+# Base URL for Smart Router API
+SMART_ROUTER_BASE_URL = os.environ.get(
+    "SMART_ROUTER_BASE_URL", "http://smart-router:8080"
+)
+
+# API Key for Smart Router authentication (if required)
+SMART_ROUTER_API_KEY = os.environ.get("SMART_ROUTER_API_KEY", "")
+
+# Timeout for Smart Router API calls (milliseconds)
+SMART_ROUTER_TIMEOUT_MS = int(os.environ.get("SMART_ROUTER_TIMEOUT_MS", "3000"))
+
+# Number of retry attempts for failed allocations
+SMART_ROUTER_RETRY_ATTEMPTS = int(os.environ.get("SMART_ROUTER_RETRY_ATTEMPTS", "3"))
+
+# Circuit Breaker Configuration
+# Number of consecutive failures before opening circuit
+SMART_ROUTER_CB_FAILURE_THRESHOLD = int(
+    os.environ.get("SMART_ROUTER_CB_FAILURE_THRESHOLD", "5")
+)
+# Seconds to wait before trying to recover from open circuit
+SMART_ROUTER_CB_RECOVERY_TIMEOUT = int(
+    os.environ.get("SMART_ROUTER_CB_RECOVERY_TIMEOUT", "30")
+)
+# Number of successful calls in half-open state before closing circuit
+SMART_ROUTER_CB_HALF_OPEN_MAX_CALLS = int(
+    os.environ.get("SMART_ROUTER_CB_HALF_OPEN_MAX_CALLS", "3")
+)
+
+# When True (default), dynamic config keys are fetched from Redis first, then fall back to env/default.
+# When False, Redis is skipped entirely for dynamic config — all keys resolve from env/default directly.
+ENABLE_REDIS_DYNAMIC_CONFIG = (
+    os.getenv("ENABLE_REDIS_DYNAMIC_CONFIG", "true").lower() == "true"
+)
+
+# DevCycle Configuration
+DEVCYCLE_WEBHOOK_SECRET = os.getenv("DEVCYCLE_WEBHOOK_SECRET", "")
+DEVCYCLE_SERVER_KEY = os.getenv("DEVCYCLE_SERVER_KEY", "")
+
+# Slack Webhook Configuration
+SLACK_WEBHOOK_URL = os.environ.get("SLACK_WEBHOOK_URL", "")
+SLACK_TAG_USERS = os.environ.get("SLACK_TAG_USERS", "narsimha.reddy")
+
+BACKGROUND_TASKS_LOOP_INTERVAL_SECONDS = int(
+    os.environ.get("BACKGROUND_TASKS_LOOP_INTERVAL_SECONDS", "60")
+)  # How often the scheduler checks tasks (in seconds)
+
+# Langfuse Score Monitoring Configuration
+ENABLE_BB_LANGFUSE_MONITORING_LOOP = (
+    os.environ.get("ENABLE_BB_LANGFUSE_MONITORING_LOOP", "false").lower() == "true"
+)
+SCORE_CHECK_INTERVAL_SECONDS = int(
+    os.environ.get("SCORE_CHECK_INTERVAL_SECONDS", "600")
+)  # 10 minutes
+
+# CORS Configuration
+CORS_ALLOWED_ORIGINS = [
+    origin.strip()
+    for origin in os.environ.get(
+        "CORS_ALLOWED_ORIGINS",
+        "https://buddy.breezelabs.app,https://portal.breeze.in,https://portal.breezesdk.store",
+    ).split(",")
+    if origin.strip()
+]
+
+GLOBAL_FUNCTION_DESCRIPTION_SUFFIX = os.environ.get(
+    "GLOBAL_FUNCTION_DESCRIPTION_SUFFIX",
+    "After providing the answer, continue the conversation from where it was interrupted, reminding the user of the current step or asking the next relevant question.",
+)
+
+# HTTP Request Security Configuration (for hooks and global functions)
+# Maximum response size in bytes to prevent downloading huge files
+HTTP_REQUEST_MAX_RESPONSE_BYTES = int(
+    os.environ.get("HTTP_REQUEST_MAX_RESPONSE_BYTES", str(100 * 1024))  # 100KB default
+)
+
+# Content types that are blocked to prevent downloading executables/scripts
+# Comma-separated list, can be customized via environment variable
+_default_blocked_content_types = (
+    "application/x-executable,"
+    "application/x-sh,"
+    "application/x-bash,"
+    "application/octet-stream,"
+    "application/x-msdownload,"
+    "application/x-msdos-program,"
+    "application/x-binary,"
+    "application/zip,"
+    "application/x-tar,"
+    "application/x-gzip,"
+    "application/x-rar-compressed,"
+    "application/x-7z-compressed"
+)
+HTTP_REQUEST_BLOCKED_CONTENT_TYPES = [
+    ct.strip().lower()
+    for ct in os.environ.get(
+        "HTTP_REQUEST_BLOCKED_CONTENT_TYPES", _default_blocked_content_types
+    ).split(",")
+    if ct.strip()
+]
+
+# Maximum number of redirects to follow (0 to disable redirects)
+HTTP_REQUEST_MAX_REDIRECTS = int(os.environ.get("HTTP_REQUEST_MAX_REDIRECTS", "3"))


### PR DESCRIPTION
…reaker

Redis-backed circuit breaker (CLOSED/OPEN/HALF_OPEN) shared across pods:
- CLOSED: Soniox only (no idle Deepgram WS cost)
- OPEN: Deepgram only, Soniox skipped entirely
- HALF_OPEN: single probe call tests Soniox via ServiceSwitcher

Key features:
- Atomic failure counting with configurable threshold and sliding window
- SET NX-based trip dedup prevents duplicate alerts under concurrency
- Non-blocking Slack alerts via asyncio.create_task (6 plain-language alerts)
- vad_events=False on all Deepgram-as-primary paths (prevents greeting cancel)
- Double-fire guard prevents over-counting failures per call
- Immediate call termination on STT failure (EndFrame, no greeting)
- Error attribution: only Soniox failures increment circuit breaker counter
- reconnect_on_error disabled only when Deepgram is actually configured
- 20 unit tests covering state machine transitions and probe lock logic

Config: ENABLE_BREEZE_BUDDY_STT_FALLBACK + 5 circuit breaker env vars
        + 13 Breeze Buddy Deepgram config vars

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Breeze Buddy voice agent supporting Daily and telephony platforms with improved conversation management.
  * Implemented multi-provider Speech-to-Text with automatic fallback and circuit breaker for enhanced reliability.
  * Added idle timeout handling and post-greeting prompt capabilities.

* **Chores**
  * Added comprehensive configuration management for voice agent settings and service integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->