### PR TITLE
feat: Add node-level interruption control (Phase 2)

### DIFF
--- a/app/ai/voice/agents/breeze_buddy/agent/__init__.py
+++ b/app/ai/voice/agents/breeze_buddy/agent/__init__.py
@@ -68,6 +68,7 @@ from app.ai.voice.agents.breeze_buddy.template.builder import FlowConfigBuilder
 from app.ai.voice.agents.breeze_buddy.template.context import with_context
 from app.ai.voice.agents.breeze_buddy.template.types import (
     ConfigurationModel,
+    InterruptionConfig,
     TemplateModel,
     TTSVoiceName,
 )
@@ -141,6 +142,7 @@ class Agent:
             None  # Resolved greeting text for LLM context
         )
         self.default_vad_params: Optional[VADParams] = None
+        self.default_interruption_config: Optional[InterruptionConfig] = None
 
         # User idle handling
         self._user_idle_callback_handler: Any = None
@@ -715,7 +717,14 @@ class Agent:
             self._user_idle_callback_handler = user_idle_callback_handler
 
             # Store context aggregator for user turn event registration
+            # and dynamic strategy switching during node transitions (Phase 2)
             self._context_aggregator = context_aggregator
+
+            # Store default interruption config for reset-on-transition
+            self.default_interruption_config = (
+                getattr(self.configurations, "interruption", None)
+                or InterruptionConfig()
+            )
 
             # Generate conversation ID and update context
             lead_payload = self.lead.payload if self.lead else None

--- a/app/ai/voice/agents/breeze_buddy/examples/templates/interruption-config-example.json
+++ b/app/ai/voice/agents/breeze_buddy/examples/templates/interruption-config-example.json
@@ -3,7 +3,7 @@
   "template_name": "interruption-config-example",
   "identifier": "interruption-demo",
   "is_active": true,
-  "description": "Demonstrates interruption control modes. Mode 'enabled' (default) allows normal interruptions. Mode 'disabled_discard' prevents interruptions and discards user speech while the bot is speaking. The optional 'min_words' setting requires the user to speak N words before an interruption triggers (only with mode='enabled').",
+  "description": "Demonstrates interruption control at template and node level. Template-level 'min_words=3' is the default. The 'closing' node overrides with 'disabled_discard' so the confirmation message cannot be interrupted. On transition back to other nodes, strategies reset to template defaults.",
   "expected_payload_schema": {
     "customer_name": {
       "type": "string"
@@ -57,6 +57,9 @@
       },
       {
         "node_name": "closing",
+        "interruption": {
+          "mode": "disabled_discard"
+        },
         "task_messages": [
           {
             "role": "system",
@@ -66,7 +69,7 @@
         "role_messages": [
           {
             "role": "system",
-            "content": "Deliver the closing message clearly."
+            "content": "Deliver the closing message clearly. Interruptions are disabled on this node so the confirmation is always heard in full."
           }
         ],
         "post_actions": [

--- a/app/ai/voice/agents/breeze_buddy/template/builder.py
+++ b/app/ai/voice/agents/breeze_buddy/template/builder.py
@@ -241,6 +241,14 @@ class FlowConfigBuilder:
             cast(Dict[str, Any], node_config)["vad_config"] = node.vad_config
             logger.info(f"Attached VAD config to node {node.node_name}")
 
+        # Attach node-specific interruption config for transition handler to use
+        if node.interruption:
+            cast(Dict[str, Any], node_config)["interruption"] = node.interruption
+            logger.info(
+                f"Attached interruption config to node {node.node_name}: "
+                f"mode={node.interruption.mode.value}, min_words={node.interruption.min_words}"
+            )
+
         return node_config
 
     def _build_function_schema(self, func: FlowFunction) -> FlowsFunctionSchema:

--- a/app/ai/voice/agents/breeze_buddy/template/interruption.py
+++ b/app/ai/voice/agents/breeze_buddy/template/interruption.py
@@ -1,0 +1,189 @@
+"""
+Interruption Configuration Utilities — Phase 2: Node-Level Switching
+
+This module handles dynamic interruption strategy switching during node transitions:
+1. Storing the default (template-level) interruption config on the bot
+2. Resetting interruption strategies to template defaults on node exit
+3. Applying node-specific interruption overrides on node entry
+
+Mirrors the pattern established by vad.py for VAD config management.
+
+For template-level (Phase 1) interruption wiring at pipeline creation time,
+see agent/pipeline.py.
+"""
+
+from pipecat.turns.user_mute import AlwaysUserMuteStrategy
+from pipecat.turns.user_start import (
+    BaseUserTurnStartStrategy,
+    MinWordsUserTurnStartStrategy,
+    TranscriptionUserTurnStartStrategy,
+    VADUserTurnStartStrategy,
+)
+from pipecat.turns.user_stop import SpeechTimeoutUserTurnStopStrategy
+from pipecat.turns.user_turn_strategies import UserTurnStrategies
+
+from app.ai.voice.agents.breeze_buddy.template.context import TemplateContext
+from app.ai.voice.agents.breeze_buddy.template.types import (
+    InterruptionConfig,
+    InterruptionMode,
+)
+from app.core.logger import logger
+
+
+async def reset_interruption_to_default(context: TemplateContext):
+    """Reset interruption strategies to the template-level default config.
+
+    Called at the start of every node transition (before applying node overrides),
+    mirroring reset_vad_to_default().
+    """
+    bot = context.bot
+    default_config = getattr(bot, "default_interruption_config", None)
+    if default_config is None:
+        return
+
+    user_aggregator = _get_user_aggregator(bot)
+    if user_aggregator is None:
+        return
+
+    await _apply_interruption_config(
+        user_aggregator,
+        default_config,
+        has_vad=bot.vad_analyzer is not None,
+        call_sid=context.call_sid or "unknown",
+        label="default",
+        bot=bot,
+    )
+
+
+async def apply_node_interruption_config(context: TemplateContext, node_name: str):
+    """Apply node-specific interruption config if it exists.
+
+    Called after reset_interruption_to_default() during a node transition,
+    mirroring apply_node_vad_config().
+    """
+    bot = context.bot
+    if not hasattr(bot, "flow_config") or not bot.flow_config:
+        return
+
+    nodes = bot.flow_config.get("nodes", {})
+    if node_name not in nodes:
+        return
+
+    node_config = nodes[node_name]
+    interruption_config = node_config.get("interruption")
+    if interruption_config is None:
+        return
+
+    # interruption_config may be an InterruptionConfig object or a dict
+    if isinstance(interruption_config, dict):
+        interruption_config = InterruptionConfig.model_validate(interruption_config)
+
+    user_aggregator = _get_user_aggregator(bot)
+    if user_aggregator is None:
+        return
+
+    await _apply_interruption_config(
+        user_aggregator,
+        interruption_config,
+        has_vad=bot.vad_analyzer is not None,
+        call_sid=context.call_sid or "unknown",
+        label=f"node:{node_name}",
+        bot=bot,
+    )
+
+
+def _get_user_aggregator(bot):
+    """Get the LLMUserAggregator from the bot's context aggregator."""
+    aggregator_pair = getattr(bot, "_context_aggregator", None)
+    if aggregator_pair is None:
+        logger.warning(
+            "No context aggregator on bot; cannot switch interruption config"
+        )
+        return None
+    return aggregator_pair.user()
+
+
+def _config_matches_active(bot, config: InterruptionConfig) -> bool:
+    """Check if the given config matches the currently active one."""
+    active = getattr(bot, "_active_interruption_config", None)
+    if active is None:
+        return False
+    return active.mode == config.mode and active.min_words == config.min_words
+
+
+async def _apply_interruption_config(
+    user_aggregator,
+    config: InterruptionConfig,
+    has_vad: bool,
+    call_sid: str,
+    label: str,
+    bot=None,
+):
+    """Build and apply interruption strategies from an InterruptionConfig.
+
+    This updates both:
+    1. Turn start strategies via UserTurnController.update_strategies()
+    2. Mute strategies via direct _params.user_mute_strategies manipulation
+
+    Skips the update if the requested config already matches the active one.
+
+    Args:
+        user_aggregator: LLMUserAggregator instance from the pipeline
+        config: The InterruptionConfig to apply
+        has_vad: Whether a VAD analyzer is active
+        call_sid: Call SID for logging
+        label: Label for log messages (e.g., "default", "node:greeting")
+        bot: Bot instance for tracking active config (skip-if-unchanged)
+    """
+    # Short-circuit when the requested config is already active
+    if bot is not None and _config_matches_active(bot, config):
+        logger.debug(
+            f"Interruption config unchanged [{label}] for call {call_sid}, skipping"
+        )
+        return
+
+    # --- 1. Rebuild and update turn start/stop strategies ---
+    start_strategies: list[BaseUserTurnStartStrategy] = []
+    if has_vad:
+        start_strategies.append(VADUserTurnStartStrategy())
+
+    if config.min_words and config.mode == InterruptionMode.ENABLED:
+        start_strategies.append(
+            MinWordsUserTurnStartStrategy(min_words=config.min_words, use_interim=True)
+        )
+    else:
+        start_strategies.append(TranscriptionUserTurnStartStrategy(use_interim=True))
+
+    new_strategies = UserTurnStrategies(
+        start=start_strategies,
+        stop=[SpeechTimeoutUserTurnStopStrategy(user_speech_timeout=0.0)],
+    )
+
+    await user_aggregator._user_turn_controller.update_strategies(new_strategies)
+
+    # --- 2. Update mute strategies ---
+    old_mute = user_aggregator._params.user_mute_strategies
+
+    # Cleanup existing mute strategies
+    for s in old_mute:
+        await s.cleanup()
+    old_mute.clear()
+
+    if config.mode == InterruptionMode.DISABLED_DISCARD:
+        mute_strategy = AlwaysUserMuteStrategy()
+        await mute_strategy.setup(user_aggregator.task_manager)
+        old_mute.append(mute_strategy)
+    else:
+        # When switching from muted → unmuted, clear the mute flag so frames
+        # aren't suppressed until the next process_frame cycle naturally clears it.
+        user_aggregator._user_is_muted = False
+
+    # Track the active config so subsequent calls can short-circuit
+    if bot is not None:
+        bot._active_interruption_config = config
+
+    logger.info(
+        f"Interruption config applied [{label}] for call {call_sid}: "
+        f"mode={config.mode.value}, min_words={config.min_words}, "
+        f"mute_strategies={len(old_mute)}"
+    )

--- a/app/ai/voice/agents/breeze_buddy/template/transition.py
+++ b/app/ai/voice/agents/breeze_buddy/template/transition.py
@@ -12,6 +12,10 @@ from typing import Any, Dict, List, Optional
 from app.ai.voice.agents.breeze_buddy.observability.tracing_setup import auto_trace
 from app.ai.voice.agents.breeze_buddy.template.context import TemplateContext
 from app.ai.voice.agents.breeze_buddy.template.hooks import HookRegistry
+from app.ai.voice.agents.breeze_buddy.template.interruption import (
+    apply_node_interruption_config,
+    reset_interruption_to_default,
+)
 from app.ai.voice.agents.breeze_buddy.template.types import HookConfig
 from app.ai.voice.agents.breeze_buddy.template.vad import (
     apply_node_vad_config,
@@ -76,6 +80,12 @@ async def transition_handler(
 
         # Get node-specific VAD config and apply it
         apply_node_vad_config(context, transition_to)
+
+        # Reset interruption strategies to default before applying node-specific config
+        await reset_interruption_to_default(context)
+
+        # Get node-specific interruption config and apply it
+        await apply_node_interruption_config(context, transition_to)
 
         next_node = context.create_node_from_template(transition_to)
 

--- a/app/ai/voice/agents/breeze_buddy/template/types.py
+++ b/app/ai/voice/agents/breeze_buddy/template/types.py
@@ -505,6 +505,10 @@ class FlowNodeModel(BaseModel):
     vad_config: Optional[VadConfig] = Field(
         None, description="Node-specific VAD configuration (overrides template VAD)"
     )
+    interruption: Optional[InterruptionConfig] = Field(
+        None,
+        description="Node-specific interruption configuration (overrides template interruption)",
+    )
 
 
 class TemplateModel(BaseModel):

--- a/docs/INTERRUPTION_CONTROL.md
+++ b/docs/INTERRUPTION_CONTROL.md
@@ -166,22 +166,24 @@ def __init__(self, *, enable_interruptions=True, enable_user_speaking_frames=Tru
 2. `app/ai/voice/agents/breeze_buddy/agent/pipeline.py` — wire strategies based on config
 3. Example templates — add examples showing new config
 
-### Phase 2: Node-Level Switching
+### Phase 2: Node-Level Switching ✅
 
 **Scope:**
-- Add `interruption_mode` and `min_words` to `FlowNodeModel`
+- Add `interruption` (InterruptionConfig) to `FlowNodeModel`
 - On node transition, dynamically switch mute strategies and turn start strategies
 - Hook into existing node transition system (`template/transition.py`)
 
-**Challenge:**
-- PipeCat strategies are set at pipeline creation
-- Need to dynamically add/remove `AlwaysUserMuteStrategy` and swap turn start strategies at runtime
-- Options: (a) use PipeCat's `update_settings()` if available, (b) create a custom wrapper processor that gates based on current node config
+**Approach — PipeCat runtime strategy switching:**
+- **Turn start/stop strategies**: `UserTurnController.update_strategies()` replaces all start/stop strategies at runtime (cleanup → replace → setup lifecycle)
+- **Mute strategies**: Direct manipulation of `LLMUserAggregator._params.user_mute_strategies` list with proper cleanup/setup lifecycle calls
+- **Reset pattern**: Same as VAD — reset to template defaults first, then apply node override
 
-**Files to modify:**
-1. `app/ai/voice/agents/breeze_buddy/template/types.py` — add fields to `FlowNodeModel`
-2. `app/ai/voice/agents/breeze_buddy/template/transition.py` — apply config on transition
-3. New processor or extend existing one for dynamic strategy switching
+**Files modified:**
+1. `app/ai/voice/agents/breeze_buddy/template/types.py` — added `interruption` field to `FlowNodeModel`
+2. `app/ai/voice/agents/breeze_buddy/template/builder.py` — attach interruption config to NodeConfig
+3. `app/ai/voice/agents/breeze_buddy/template/interruption.py` — **new** dynamic strategy switching module
+4. `app/ai/voice/agents/breeze_buddy/template/transition.py` — call reset + apply on transitions
+5. `app/ai/voice/agents/breeze_buddy/agent/__init__.py` — store `default_interruption_config` on bot
 
 ### Phase 3: Mode 2 — Buffered Speech
 
@@ -291,3 +293,87 @@ context_aggregator = LLMContextAggregatorPair(
   }
 }
 ```
+
+---
+
+## Phase 2 — Detailed Design
+
+### Node-Level Config
+
+`FlowNodeModel` gains an optional `interruption` field:
+```python
+class FlowNodeModel(BaseModel):
+    # ... existing fields ...
+    interruption: Optional[InterruptionConfig] = Field(
+        None,
+        description="Node-specific interruption configuration (overrides template interruption)",
+    )
+```
+
+### Template Example (Node-Level)
+
+```json
+{
+  "configurations": {
+    "interruption": { "mode": "enabled", "min_words": 3 }
+  },
+  "flow": {
+    "initial_node": "greeting",
+    "nodes": [
+      {
+        "node_name": "greeting",
+        "task_messages": [...]
+      },
+      {
+        "node_name": "legal_disclaimer",
+        "interruption": { "mode": "disabled_discard" },
+        "task_messages": [...]
+      },
+      {
+        "node_name": "conversation",
+        "interruption": { "mode": "enabled", "min_words": 1 },
+        "task_messages": [...]
+      }
+    ]
+  }
+}
+```
+
+- `greeting` — inherits template default (`enabled`, min_words=3)
+- `legal_disclaimer` — node override disables interruption, discards speech
+- `conversation` — node override re-enables with min_words=1
+
+### Dynamic Switching Module (`template/interruption.py`)
+
+**Reset → Apply pattern** (mirrors `template/vad.py`):
+
+```
+transition_handler()
+  ├─ reset_vad_to_default(context)
+  ├─ apply_node_vad_config(context, node_name)
+  ├─ await reset_interruption_to_default(context)   ← NEW
+  └─ await apply_node_interruption_config(context, node_name)  ← NEW
+```
+
+**`reset_interruption_to_default(context)`**:
+1. Reads `bot.default_interruption_config` (stored at pipeline creation)
+2. Calls `_apply_interruption_config()` with template defaults
+
+**`apply_node_interruption_config(context, node_name)`**:
+1. Looks up `nodes[node_name]["interruption"]` from `flow_config`
+2. If present, calls `_apply_interruption_config()` with node override
+
+**`_apply_interruption_config(user_aggregator, config, ...)`**:
+1. Rebuilds `UserTurnStrategies` (start + stop) from config
+2. Calls `user_aggregator._user_turn_controller.update_strategies(new_strategies)`
+   - PipeCat handles cleanup → replace → setup lifecycle internally
+3. Cleans up existing mute strategies, clears the list
+4. If `disabled_discard` → creates new `AlwaysUserMuteStrategy`, calls `setup()`, appends
+5. If switching to unmuted → explicitly sets `_user_is_muted = False`
+
+### Lifecycle Considerations
+
+- **Async**: Strategy switching is async (setup/cleanup are coroutines), so transition_handler `await`s
+- **Race safety**: `_user_is_muted` is explicitly cleared when removing mute strategies to prevent stale mute state
+- **No-op on same config**: When node has no override, reset to default is the only operation (effectively a no-op if already at default)
+- **VAD independence**: VAD reset/apply is synchronous; interruption reset/apply is async — they don't interfere


### PR DESCRIPTION
## Summary

- Adds `interruption` field to `FlowNodeModel` for per-node interruption mode/min_words overrides
- New `template/interruption.py` module dynamically switches PipeCat turn-start and mute strategies at runtime via `UserTurnController.update_strategies()` and direct `_params.user_mute_strategies` manipulation
- Wired into `transition_handler` with the same reset-then-apply pattern as VAD config management
- Stores `default_interruption_config` on the Agent for reset-on-transition baseline

## Files changed

| File | Change |
|------|--------|
| `template/types.py` | Added `interruption` to `FlowNodeModel` |
| `template/builder.py` | Attaches node interruption config to `NodeConfig` |
| **`template/interruption.py`** | **New** — dynamic strategy switching module |
| `template/transition.py` | Calls reset + apply interruption on transitions |
| `agent/__init__.py` | Stores `default_interruption_config` on bot |
| `examples/.../interruption-config-example.json` | Node-level override demo |
| `docs/INTERRUPTION_CONTROL.md` | Phase 2 marked complete with design details |

## Test plan

- [ ] Deploy to beta and verify template-level interruption still works (no regression from Phase 1)
- [ ] Test node with `"interruption": {"mode": "disabled_discard"}` — bot speech should not be interruptible on that node
- [ ] Test transition from disabled_discard node back to enabled node — interruptions should resume
- [ ] Test node with `"interruption": {"mode": "enabled", "min_words": 1}` overriding template default of min_words=3
- [ ] Verify no race conditions: rapid node transitions should not leave stale mute state

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced node-level interruption configuration, enabling per-node overrides of template-level interruption settings.
  * Interruption behavior now dynamically adjusts during node transitions, allowing fine-grained control over interruption handling at each conversation node.

* **Documentation**
  * Updated interruption control guide to document new node-level configuration capabilities and dynamic switching patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->