### PR TITLE
feat: register end_conversation as a builtin global function

### DIFF
--- a/app/ai/voice/agents/breeze_buddy/handlers/internal/builtin_dispatcher.py
+++ b/app/ai/voice/agents/breeze_buddy/handlers/internal/builtin_dispatcher.py
@@ -19,6 +19,9 @@ from pipecat.frames.frames import (
     TTSSpeakFrame,
 )
 
+from app.ai.voice.agents.breeze_buddy.handlers.internal.end_conversation_global import (
+    end_conversation_global,
+)
 from app.ai.voice.agents.breeze_buddy.handlers.internal.get_current_time import (
     get_current_time,
 )
@@ -38,6 +41,7 @@ from app.core.logger import logger
 # To add a new built-in function, import it and add an entry here.
 BUILTIN_HANDLERS: Dict[str, Callable] = {
     "connect_to_live_agent": connect_to_live_agent,
+    "end_conversation": end_conversation_global,
     "get_current_time": get_current_time,
 }
 

--- a/app/ai/voice/agents/breeze_buddy/handlers/internal/end_conversation_global.py
+++ b/app/ai/voice/agents/breeze_buddy/handlers/internal/end_conversation_global.py
@@ -1,0 +1,70 @@
+"""
+End Conversation Global Function Handler
+
+Thin wrapper around end_conversation that ensures an outcome is always set
+before the call is finalized. If a prior function/hook already set an outcome,
+it is preserved. Otherwise, the outcome defaults to BUSY.
+
+When the template defines a "reason" property, the LLM provides a reason for
+ending the call (e.g., "user said goodbye", "issue resolved") which is stored
+in metadata as call_end_reason.
+"""
+
+from typing import Any, Dict
+
+from app.ai.voice.agents.breeze_buddy.handlers.internal.end_conversation import (
+    end_conversation,
+)
+from app.ai.voice.agents.breeze_buddy.template.context import TemplateContext
+from app.core.logger import logger
+
+DEFAULT_OUTCOME = "BUSY"
+
+
+async def end_conversation_global(
+    context: TemplateContext,
+    args: Dict[str, Any],
+) -> Dict[str, Any]:
+    """
+    End the conversation via the global function path.
+
+    Ensures an outcome is set before delegating to the core end_conversation
+    handler. Preserves any outcome already set by a prior function or hook.
+
+    If the LLM provides a "reason" argument (configured via template properties),
+    it is stored in metadata as call_end_reason.
+
+    Args:
+        context: Handler context with bot state access
+        args: LLM function arguments. May contain "reason" if the template
+              defines it as a property.
+
+    Returns:
+        Result from end_conversation (empty dict)
+    """
+    if context.lead:
+        if context.lead.metaData is None:
+            context.lead.metaData = {}
+
+        # Capture the LLM-provided reason only if call_end_reason is not already
+        # set by a prior path (e.g., user_idle_timeout, client_disconnected).
+        if "call_end_reason" not in context.lead.metaData:
+            reason = args.get("reason", "end_conversation_global_function")
+            context.lead.metaData["call_end_reason"] = reason
+        else:
+            reason = context.lead.metaData["call_end_reason"]
+
+        if context.lead.outcome is None:
+            context.lead.outcome = DEFAULT_OUTCOME
+            logger.info(
+                f"[end_conversation_global] No outcome set for call {context.call_sid}, "
+                f"defaulting to '{DEFAULT_OUTCOME}' (reason: {reason})"
+            )
+        else:
+            logger.info(
+                f"[end_conversation_global] Preserving existing outcome "
+                f"'{context.lead.outcome}' for call {context.call_sid} "
+                f"(reason: {reason})"
+            )
+
+    return await end_conversation(context, args)

--- a/app/ai/voice/agents/breeze_buddy/managers/calls.py
+++ b/app/ai/voice/agents/breeze_buddy/managers/calls.py
@@ -816,9 +816,9 @@ async def handle_call_completion(
     if not config:
         return
 
-    # Override outcome to "transferred" for transfer calls
+    # Override outcome to "TRANSFERRED" for transfer calls
     if is_transfer:
-        outcome = "transferred"
+        outcome = "TRANSFERRED"
 
     updated_lead = await update_lead_call_completion_details(
         id=lead.id,

--- a/app/ai/voice/agents/breeze_buddy/template/hooks.py
+++ b/app/ai/voice/agents/breeze_buddy/template/hooks.py
@@ -232,16 +232,16 @@ class UpdateOutcomeInDatabaseHook(Hook):
                     f"No additional properties found in final data for lead {context.lead.id}"
                 )
 
-            # Guard: if a transfer is in progress, preserve "transferred" outcome
+            # Guard: if a transfer is in progress, preserve "TRANSFERRED" outcome
             # instead of the LLM's value (e.g., "RESOLVED") to avoid a race
             # condition with handle_call_completion's transfer override.
             if meta_data.get("transfer", {}).get("status") == "success":
                 logger.info(
                     f"Transfer detected for lead {context.lead.id}. "
-                    f"Overriding outcome from '{outcome}' to 'transferred' "
+                    f"Overriding outcome from '{outcome}' to 'TRANSFERRED' "
                     f"(function: '{function_name}')"
                 )
-                outcome = "transferred"
+                outcome = "TRANSFERRED"
 
             # Update lead in database with outcome
             logger.info(


### PR DESCRIPTION
## Summary
- Registers `end_conversation` as a builtin global function so the LLM can terminate the call from **any node**
- Adds `end_conversation_global` wrapper that guarantees an outcome before finalization:
  - **If outcome already set** (by a prior function/hook) → preserved, not overridden
  - **If no outcome set** → defaults to `BUSY`
- **Captures LLM reason in metadata**: the `call_end_reason` field in metadata always records why the call ended — either from the LLM's `reason` argument (when template defines it as a property) or falls back to `"end_conversation_global_function"`
- **Normalizes transfer outcome**: changes lowercase `"transferred"` → `"TRANSFERRED"` for consistency with all other uppercase outcomes (`BUSY`, `CONFIRM`, `CANCEL`, etc.)

### Template usage

Without reason (LLM handles farewell, reason defaults to `"end_conversation_global_function"`):
```json
{
  "type": "builtin",
  "name": "end_conversation",
  "handler": "end_conversation",
  "description": "End the current conversation and hang up the call."
}
```

With LLM-provided reason:
```json
{
  "type": "builtin",
  "name": "end_conversation",
  "handler": "end_conversation",
  "description": "End the current conversation and hang up the call.",
  "properties": {
    "reason": {
      "type": "string",
      "description": "The reason for ending the conversation (e.g., 'user said goodbye', 'issue resolved')"
    }
  },
  "required": ["reason"]
}
```

`pre_tts_message` is also supported and optional.

### Files changed
- `handlers/internal/end_conversation_global.py` — **New**: wrapper with outcome + reason logic
- `handlers/internal/builtin_dispatcher.py` — Register `end_conversation` in `BUILTIN_HANDLERS`
- `managers/calls.py` — Normalize `"transferred"` → `"TRANSFERRED"`
- `template/hooks.py` — Normalize `"transferred"` → `"TRANSFERRED"`

## Test plan
- [ ] Verify existing `END_CONVERSATION` action-based flows still work (no regression)
- [ ] Add `end_conversation` as a builtin global function and confirm LLM can end the call from any node
- [ ] Test with and without `pre_tts_message`
- [ ] Confirm outcome is preserved when already set by a prior hook/function
- [ ] Confirm outcome defaults to `BUSY` with `call_end_reason` metadata when no prior outcome exists
- [ ] Verify LLM-provided `reason` is stored in `metaData["call_end_reason"]`
- [ ] Verify transfer outcome now appears as `TRANSFERRED` (uppercase) in DB and callbacks
- [ ] Check analytics dashboards still correctly count transferred calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for tracking call end reasons when conversations are terminated.
  * Improved handling of conversation endings with metadata initialization.

* **Bug Fixes**
  * Standardized call outcome reporting format for transferred calls across the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->