### PR TITLE
feat: add update_call_outcome builtin global function for mid-conversation outcome tracking

### DIFF
--- a/app/ai/voice/agents/breeze_buddy/handlers/internal/__init__.py
+++ b/app/ai/voice/agents/breeze_buddy/handlers/internal/__init__.py
@@ -18,6 +18,9 @@ from app.ai.voice.agents.breeze_buddy.handlers.internal.stt import (
     mute_stt,
     unmute_stt,
 )
+from app.ai.voice.agents.breeze_buddy.handlers.internal.update_outcome import (
+    update_outcome,
+)
 from app.ai.voice.agents.breeze_buddy.handlers.internal.warm_transfer import (
     connect_to_live_agent,
 )
@@ -30,4 +33,5 @@ __all__ = [
     "mute_stt",
     "play_audio_sound",
     "unmute_stt",
+    "update_outcome",
 ]

--- a/app/ai/voice/agents/breeze_buddy/handlers/internal/builtin_dispatcher.py
+++ b/app/ai/voice/agents/breeze_buddy/handlers/internal/builtin_dispatcher.py
@@ -29,6 +29,9 @@ from app.ai.voice.agents.breeze_buddy.handlers.internal.stt import (
     mute_stt,
     unmute_stt,
 )
+from app.ai.voice.agents.breeze_buddy.handlers.internal.update_outcome import (
+    update_outcome,
+)
 from app.ai.voice.agents.breeze_buddy.handlers.internal.warm_transfer import (
     connect_to_live_agent,
 )
@@ -43,6 +46,7 @@ BUILTIN_HANDLERS: Dict[str, Callable] = {
     "connect_to_live_agent": connect_to_live_agent,
     "end_conversation": end_conversation_global,
     "get_current_time": get_current_time,
+    "update_outcome": update_outcome,
 }
 
 

--- a/app/ai/voice/agents/breeze_buddy/handlers/internal/update_outcome.py
+++ b/app/ai/voice/agents/breeze_buddy/handlers/internal/update_outcome.py
@@ -1,0 +1,66 @@
+"""
+Update Outcome Handler
+
+A built-in global function that allows the LLM to update the lead's call outcome
+in the database at any point during the conversation — independent of node transitions.
+
+Reuses the existing update_outcome_in_database hook (fire-and-forget via asyncio.create_task).
+The handler returns immediately with {"status": "success"} so the LLM experiences
+near-zero latency. The actual DB write happens in the background.
+"""
+
+import asyncio
+from typing import Any, Dict
+
+from app.ai.voice.agents.breeze_buddy.template.context import TemplateContext
+from app.ai.voice.agents.breeze_buddy.template.hooks import HookRegistry
+from app.ai.voice.agents.breeze_buddy.template.types import HookConfig
+from app.core.logger import logger
+
+
+async def update_outcome(
+    context: TemplateContext,
+    args: Dict[str, Any],
+) -> Dict[str, Any]:
+    """
+    Update the lead's outcome in the database (fire-and-forget).
+
+    Delegates to the existing update_outcome_in_database hook with no
+    expected_fields — the hook's fallback path uses args directly.
+    Whatever the LLM passes (outcome, driver_id, driver_name, etc.)
+    flows through the same hook logic that node-level functions use.
+
+    Args:
+        context: Handler context with bot state access
+        args: LLM function arguments. Must include "outcome" (str).
+              Any additional fields are stored in meta_data.outcome.*.
+
+    Returns:
+        Dict with status "success" (always, since DB write is async)
+    """
+    outcome = args.get("outcome")
+    if not outcome:
+        logger.warning("[update_outcome] No outcome provided in args, skipping")
+        return {"status": "error", "error": "outcome argument is required"}
+
+    hook = HookRegistry.get("update_outcome_in_database")
+    if not hook:
+        logger.error(
+            "[update_outcome] update_outcome_in_database hook not found in registry"
+        )
+        return {"status": "error", "error": "hook not found"}
+
+    # Empty expected_fields → hook falls back to using args directly
+    hook_config = HookConfig(name="update_outcome_in_database")
+
+    logger.info(
+        f"[update_outcome] Scheduling background outcome update: "
+        f"outcome='{outcome}' for lead {context.lead.id if context.lead else 'unknown'}"
+    )
+
+    asyncio.create_task(
+        hook.safe_execute(context, args, "update_call_outcome", hook_config),
+        name=f"update_outcome_{context.lead.id if context.lead else 'unknown'}_{outcome}",
+    )
+
+    return {"status": "success", "outcome": outcome}

--- a/app/database/queries/breeze_buddy/analytics.py
+++ b/app/database/queries/breeze_buddy/analytics.py
@@ -78,6 +78,7 @@ def build_analytics_where_clause(
     filters: Dict[str, Any],
     value_offset: int = 0,
     filter_execution_mode: bool = True,
+    date_column: str = "call_initiated_time",
 ) -> Tuple[List[str], List[Any]]:
     """
     Build WHERE clause conditions and values from generic filters.
@@ -86,6 +87,8 @@ def build_analytics_where_clause(
         filters: Dictionary of filter key-value pairs
         value_offset: Starting index for parameterized query values
         filter_execution_mode: If True, only include TELEPHONY execution_mode (exclude tests)
+        date_column: Column to use for date range filtering (default: call_initiated_time).
+                     Use "created_at" for queries that need to include leads without calls (e.g. BACKLOG).
 
     Returns:
         Tuple of (conditions list, values list)
@@ -104,7 +107,7 @@ def build_analytics_where_clause(
             values.append(date_from)
         else:
             values.append(datetime.combine(date_from, datetime.min.time()))
-        conditions.append(f"lct.call_initiated_time >= ${len(values) + value_offset}")
+        conditions.append(f"lct.{date_column} >= ${len(values) + value_offset}")
 
     if "date_to" in filters and filters["date_to"]:
         date_to = filters["date_to"]
@@ -112,7 +115,7 @@ def build_analytics_where_clause(
             values.append(date_to)
         else:
             values.append(datetime.combine(date_to, datetime.max.time()))
-        conditions.append(f"lct.call_initiated_time < ${len(values) + value_offset}")
+        conditions.append(f"lct.{date_column} < ${len(values) + value_offset}")
 
     # Standard column filters
     # Template filter - supports BOTH template name and template_id for backward compatibility
@@ -830,7 +833,7 @@ def get_analytics_lead_status_counts_query(
         Tuple of (query_string, values_list)
     """
     conditions, values = build_analytics_where_clause(
-        filters, filter_execution_mode=True
+        filters, filter_execution_mode=True, date_column="created_at"
     )
 
     # Add search conditions for reseller_id
@@ -887,7 +890,7 @@ def get_analytics_lead_status_counts_total_query(
         Tuple of (query_string, values_list)
     """
     conditions, values = build_analytics_where_clause(
-        filters, filter_execution_mode=True
+        filters, filter_execution_mode=True, date_column="created_at"
     )
 
     # Add search conditions for reseller_id


### PR DESCRIPTION
- Adds a new builtin global function `update_call_outcome` that allows the LLM to update lead outcomes mid-conversation (e.g., TEST_RIDE_CONFIRMED, DUES_NOTIFICATION_SENT) without requiring a node transition. Reuses existing UpdateOutcomeInDatabaseHook via fire-and-forget asyncio.create_task.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added dynamic call outcome tracking. The system can now update and record lead call outcomes in real-time during conversations, providing more flexible result management throughout the interaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->