### PR TITLE
fix: reliable multi-turn input collection in no-VAD mode

### DIFF
--- a/app/ai/voice/agents/breeze_buddy/agent/pipeline.py
+++ b/app/ai/voice/agents/breeze_buddy/agent/pipeline.py
@@ -30,7 +30,6 @@ from pipecat.turns.user_start import (
     TranscriptionUserTurnStartStrategy,
     VADUserTurnStartStrategy,
 )
-from pipecat.turns.user_stop import SpeechTimeoutUserTurnStopStrategy
 from pipecat.turns.user_turn_strategies import UserTurnStrategies
 
 from app.ai.voice.agents.breeze_buddy.observability.tracing_setup import setup_tracing
@@ -40,6 +39,9 @@ from app.ai.voice.agents.breeze_buddy.processors import (
     create_user_idle_processor,
 )
 from app.ai.voice.agents.breeze_buddy.stt import get_stt_service
+from app.ai.voice.agents.breeze_buddy.template.interruption import (
+    AccumulatingSpeechTimeoutStrategy,
+)
 from app.ai.voice.agents.breeze_buddy.template.types import (
     ConfigurationModel,
     InterruptionConfig,
@@ -173,7 +175,7 @@ async def build_pipeline(
     Uses the universal LLMContextAggregatorPair with UserTurnStrategies:
     - Start: VADUserTurnStartStrategy (primary, ~100ms) + TranscriptionUserTurnStartStrategy
       (fallback for soft speech VAD misses, uses interim transcriptions)
-    - Stop: SpeechTimeoutUserTurnStopStrategy (user_speech_timeout=0.0) — triggers
+    - Stop: AccumulatingSpeechTimeoutStrategy (user_speech_timeout=0.0) — triggers
       immediately when Soniox sends a finalized transcript (after its own
       max_endpoint_delay_ms semantic endpoint detection).
     - VAD runs inside the aggregator (not the transport)
@@ -218,7 +220,7 @@ async def build_pipeline(
     #    With use_interim=True, triggers on any interim transcription from Soniox.
     # 3. MinWordsUserTurnStartStrategy: Replaces Transcription strategy when min_words is set.
     #    Requires N words before triggering interruption while bot speaks; 1 word when bot is silent.
-    # 4. SpeechTimeoutUserTurnStopStrategy(0.0): Triggers immediately when Soniox
+    # 4. AccumulatingSpeechTimeoutStrategy(0.0): Triggers immediately when Soniox
     #    sends a finalized transcript with <end> token (native semantic endpoint detection).
     start_strategies: list[BaseUserTurnStartStrategy] = []
     if vad_analyzer is not None:
@@ -242,7 +244,7 @@ async def build_pipeline(
     user_turn_strategies = UserTurnStrategies(
         start=start_strategies,
         stop=[
-            SpeechTimeoutUserTurnStopStrategy(user_speech_timeout=0.0),
+            AccumulatingSpeechTimeoutStrategy(user_speech_timeout=0.0),
         ],
     )
 

--- a/app/ai/voice/agents/breeze_buddy/template/interruption.py
+++ b/app/ai/voice/agents/breeze_buddy/template/interruption.py
@@ -8,7 +8,7 @@ This module handles dynamic interruption strategy switching during node transiti
 
 Mirrors the pattern established by vad.py for VAD config management.
 
-The user_speech_timeout parameter controls how long PipeCat waits after the
+The user_speech_timeout parameter controls how long Pipecat waits after the
 last finalized transcript before ending the user's turn. Default is 0.0
 (immediate). Input collection nodes override this to accumulate multi-segment
 input (see template/input_collection.py).
@@ -26,6 +26,7 @@ from pipecat.turns.user_start import (
 )
 from pipecat.turns.user_stop import SpeechTimeoutUserTurnStopStrategy
 from pipecat.turns.user_turn_strategies import UserTurnStrategies
+from pipecat.utils.asyncio.task_manager import BaseTaskManager
 
 from app.ai.voice.agents.breeze_buddy.template.context import TemplateContext
 from app.ai.voice.agents.breeze_buddy.template.types import (
@@ -33,6 +34,56 @@ from app.ai.voice.agents.breeze_buddy.template.types import (
     InterruptionMode,
 )
 from app.core.logger import logger
+
+# Duration for the sentinel timer (24 hours). This timer exists solely to keep
+# _timeout_task non-None so Pipecat's fallback check (line 201 in
+# speech_timeout_user_turn_stop_strategy.py) doesn't fire immediately.
+_SENTINEL_DURATION_SECS = 86400
+
+
+class AccumulatingSpeechTimeoutStrategy(SpeechTimeoutUserTurnStopStrategy):
+    """Stop strategy that reliably supports multi-turn input collection.
+
+    Pipecat's SpeechTimeoutUserTurnStopStrategy has a bug in the no-VAD
+    fallback path: after a turn completes (timer fires → finally block sets
+    _timeout_task = None), the NEXT turn's first finalized transcript hits:
+
+        if self._timeout_task is None:
+            await self.trigger_user_turn_stopped()      # line 201
+
+    This triggers immediately, ignoring user_speech_timeout. The Phase 1
+    sentinel hack only protected the first turn after update_strategies().
+
+    Fix: override setup() and reset() to always re-seed a long-duration
+    sentinel timer when user_speech_timeout > 0, guaranteeing _timeout_task
+    is never None at the start of any turn. The sentinel is harmlessly
+    cancelled and replaced by the real timer on the first transcript.
+
+    When user_speech_timeout == 0, behaves identically to the base class
+    (immediate trigger on finalized transcript is the desired behavior).
+    """
+
+    async def setup(self, task_manager: BaseTaskManager):
+        await super().setup(task_manager)
+        self._seed_sentinel()
+
+    async def reset(self):
+        await super().reset()
+        self._seed_sentinel()
+
+    def _seed_sentinel(self):
+        """Seed a long-duration sentinel timer to keep _timeout_task non-None.
+
+        Only seeds when user_speech_timeout > 0 (collection mode) and no
+        timer is already running. The sentinel sleeps for 24 hours and is
+        cancelled by the fallback code in _handle_transcription() on the
+        first real transcript, which replaces it with the actual timer.
+        """
+        if self._user_speech_timeout > 0 and self._timeout_task is None:
+            self._timeout_task = self.task_manager.create_task(
+                self._timeout_handler(_SENTINEL_DURATION_SECS),
+                f"{self}::sentinel_timeout",
+            )
 
 
 async def reset_interruption_to_default(
@@ -222,37 +273,17 @@ async def _apply_interruption_config(
     else:
         start_strategies.append(TranscriptionUserTurnStartStrategy(use_interim=True))
 
+    # Use AccumulatingSpeechTimeoutStrategy which re-seeds the sentinel
+    # timer after every reset(), fixing the multi-turn _timeout_task=None bug.
+    # For user_speech_timeout=0, it behaves identically to the base class.
     new_strategies = UserTurnStrategies(
         start=start_strategies,
         stop=[
-            SpeechTimeoutUserTurnStopStrategy(user_speech_timeout=user_speech_timeout)
+            AccumulatingSpeechTimeoutStrategy(user_speech_timeout=user_speech_timeout)
         ],
     )
 
     await user_aggregator._user_turn_controller.update_strategies(new_strategies)
-
-    # --- Workaround for PipeCat first-transcript bug ---
-    # A brand-new SpeechTimeoutUserTurnStopStrategy has _timeout_task=None.
-    # In _handle_transcription(), _maybe_trigger_user_turn_stopped() is called
-    # BEFORE the fallback path creates a timer. It checks:
-    #     if self._timeout_task is None: trigger_user_turn_stopped()
-    # This fires immediately on the first finalized transcript, ignoring the
-    # configured user_speech_timeout entirely. Subsequent turns work because
-    # the fallback path's timer persists across reset() (which doesn't clear
-    # _timeout_task). Fix: seed _timeout_task with a sentinel timer that gets
-    # cancelled and replaced by the real timer on the first transcript.
-    # Only needed when user_speech_timeout > 0 (collection mode); for 0.0
-    # the immediate trigger is the desired behavior.
-    if user_speech_timeout > 0.0:
-        for stop_strategy in new_strategies.stop or []:
-            if (
-                isinstance(stop_strategy, SpeechTimeoutUserTurnStopStrategy)
-                and stop_strategy._timeout_task is None
-            ):
-                stop_strategy._timeout_task = stop_strategy.task_manager.create_task(
-                    stop_strategy._timeout_handler(86400),
-                    f"{stop_strategy}::sentinel_timeout",
-                )
 
     # --- 2. Update mute strategies ---
     old_mute = user_aggregator._params.user_mute_strategies


### PR DESCRIPTION
## Summary

Fixes input collection (`user_speech_timeout`) only working on the **first turn** after a node transition, then breaking intermittently on subsequent turns.

## Why it didn't work

PipeCat's `SpeechTimeoutUserTurnStopStrategy` has a bug in the **no-VAD fallback path** (production, where `BREEZE_BUDDY_ENABLE_VAD=false`). The turn-stop decision at line 201 is:

```python
if self._timeout_task is None:
    await self.trigger_user_turn_stopped()
```

This conflates two meanings of `_timeout_task is None`:
1. **"No timer started yet"** (initial state) — should NOT trigger
2. **"Timer completed"** (timer fired, `finally` block ran) — SHOULD trigger

After a turn's timer fires, the `finally` block in `_timeout_handler` sets `_timeout_task = None`. The controller then calls `reset()` which clears `_text` but **NOT** `_timeout_task`. So the next turn's first finalized transcript sees `_timeout_task is None` and triggers immediately — completely ignoring `user_speech_timeout`.

### Why it was intermittent

After the premature trigger, fallback code (line 141) creates an "orphaned" timer. If the user spoke within that timer's window (~10s), `_timeout_task` was non-None and the next turn worked. If the user waited longer, the orphaned timer fired, `_timeout_task` went back to None, and the next turn failed again.

### Why the Phase 1 sentinel hack was incomplete

The inline sentinel seeding after `update_strategies()` only protected the **first turn** after a strategy switch. After that turn completed via timeout, `_timeout_task` reverted to None and all subsequent turns were vulnerable.

## Why it works now

Introduced `AccumulatingSpeechTimeoutStrategy`, a subclass that overrides both `setup()` and `reset()` to **re-seed a 24-hour sentinel timer** whenever `user_speech_timeout > 0`. This guarantees `_timeout_task` is **never None** at the start of any turn:

- **`setup()`**: Seeds sentinel after initial strategy setup (protects first turn)
- **`reset()`**: Re-seeds sentinel after every turn completion (protects all subsequent turns)

The sentinel is harmlessly cancelled and replaced by the real timer on the first transcript of each turn. For `user_speech_timeout=0` (non-collection nodes), sentinel is not seeded — behavior is identical to the base class, zero regression risk.

### Execution path safety (VAD disabled)

| Scenario | Before | After |
|---|---|---|
| First turn in collection node | ✅ Sentinel from Phase 1 hack | ✅ Sentinel from `setup()` |
| Second+ turn in same node | ❌ `_timeout_task=None` → immediate trigger | ✅ Sentinel from `reset()` |
| Long gap (>10s) between turns | ❌ Orphaned timer expired | ✅ Sentinel survives (24h) |
| Transition to non-collection node | ✅ Immediate trigger (timeout=0) | ✅ No sentinel seeded |
| Race between finally block and re-seed | N/A | ✅ Synchronous event chain, no interleaving |

## Test plan

- [ ] Deploy to staging and test with `ask_correct_number_node` (has `input_collection.user_speech_timeout=10`)
- [ ] Verify phone number dictation across multiple segments accumulates correctly on **first turn**
- [ ] Verify **second turn** in same node (e.g., user confirms then is asked again) also accumulates correctly
- [ ] Verify non-collection nodes (e.g., `initial`, `introduce_and_verify_number_node`) still respond immediately on finalized transcript
- [ ] Verify transition from collection → non-collection node restores immediate response behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced speech timeout handling to reliably maintain timeout behavior across multiple conversation turns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->