### PR TITLE
feat: Add back-channel acknowledgments during input collection (Phase 2)

### DIFF
--- a/app/ai/voice/agents/breeze_buddy/agent/__init__.py
+++ b/app/ai/voice/agents/breeze_buddy/agent/__init__.py
@@ -155,6 +155,9 @@ class Agent:
         # Transcription gate processor (always present in pipeline)
         self.speech_gate: Any = None
 
+        # Back-channel processor (always present in pipeline, enabled per-node)
+        self.back_channel: Any = None
+
         # Error tracking
         self.errors: List[Dict[str, Any]] = []
 
@@ -703,6 +706,7 @@ class Agent:
                 context_aggregator,
                 user_idle_callback_handler,
                 self.speech_gate,
+                self.back_channel,
             ) = await build_pipeline(
                 self.transport,
                 stt,

--- a/app/ai/voice/agents/breeze_buddy/agent/pipeline.py
+++ b/app/ai/voice/agents/breeze_buddy/agent/pipeline.py
@@ -34,6 +34,7 @@ from pipecat.turns.user_turn_strategies import UserTurnStrategies
 
 from app.ai.voice.agents.breeze_buddy.observability.tracing_setup import setup_tracing
 from app.ai.voice.agents.breeze_buddy.processors import (
+    BackChannelProcessor,
     TranscriptionGateProcessor,
     UserIdleCallbackHandler,
     create_user_idle_processor,
@@ -169,6 +170,7 @@ async def build_pipeline(
     Any,
     Optional[UserIdleCallbackHandler],
     TranscriptionGateProcessor,
+    BackChannelProcessor,
 ]:
     """Build the processing pipeline.
 
@@ -282,6 +284,10 @@ async def build_pipeline(
             f"match_type={keyword_filter_config.match_type.value}"
         )
 
+    # BackChannelProcessor is always in the pipeline.
+    # It is a transparent passthrough when not enabled for the current node.
+    back_channel = BackChannelProcessor()
+
     # Create user idle processor from template configuration
     user_idle_config = getattr(configurations, "user_idle_configuration", None)
     user_idle_result = (
@@ -303,13 +309,14 @@ async def build_pipeline(
     # Store reference to user aggregator for position lookup
     user_aggregator = context_aggregator.user()
 
-    # Order: stt → transcription_gate → user_aggregator → llm → tts
+    # Order: stt → transcription_gate → back_channel → user_aggregator → llm → tts
     # Pipecat's LLMUserAggregator natively handles interruptions via
     # UserTurnStrategies — no custom response gate needed.
     pipeline_parts = [
         transport.input(),
         stt,
         transcription_gate,
+        back_channel,
         user_aggregator,
         llm,
         tts,
@@ -335,6 +342,7 @@ async def build_pipeline(
         context_aggregator,
         user_idle_callback_handler,
         transcription_gate,
+        back_channel,
     )
 
 

--- a/app/ai/voice/agents/breeze_buddy/examples/templates/input-collection-example.json
+++ b/app/ai/voice/agents/breeze_buddy/examples/templates/input-collection-example.json
@@ -17,7 +17,13 @@
         ],
         "input_collection": {
           "enabled": true,
-          "user_speech_timeout": 3.0
+          "user_speech_timeout": 3.0,
+          "back_channel": {
+            "enabled": true,
+            "delay_secs": 1.5,
+            "min_interval_secs": 3.0,
+            "messages": ["okay", "got it", "go on"]
+          }
         },
         "functions": [
           {
@@ -67,5 +73,5 @@
       }
     ]
   },
-  "_comment": "This template demonstrates input collection mode for multi-segment input. The collect_number node has input_collection.enabled=true with user_speech_timeout=3.0s, meaning the system waits 3 seconds after the last speech segment before ending the user's turn. This allows users to dictate numbers naturally with pauses (e.g., '9 8 7 ... 6 5 4 ... 3 2 1 0') without the agent interrupting after each segment. The LLM receives all segments as a single accumulated message."
+  "_comment": "This template demonstrates input collection mode for multi-segment input. The collect_number node has input_collection.enabled=true with user_speech_timeout=3.0s, meaning the system waits 3 seconds after the last speech segment before ending the user's turn. This allows users to dictate numbers naturally with pauses (e.g., '9 8 7 ... 6 5 4 ... 3 2 1 0') without the agent interrupting after each segment. The LLM receives all segments as a single accumulated message. Back-channel acknowledgments ('okay', 'got it', 'go on') are sent via direct TTS after 1.5s of silence between segments so the user knows the agent is still listening."
 }

--- a/app/ai/voice/agents/breeze_buddy/processors/__init__.py
+++ b/app/ai/voice/agents/breeze_buddy/processors/__init__.py
@@ -1,5 +1,8 @@
 """Breeze Buddy custom processors for pipeline control."""
 
+from app.ai.voice.agents.breeze_buddy.processors.back_channel import (
+    BackChannelProcessor,
+)
 from app.ai.voice.agents.breeze_buddy.processors.transcription_gate import (
     TranscriptionGateProcessor,
 )
@@ -9,6 +12,7 @@ from app.ai.voice.agents.breeze_buddy.processors.user_idle import (
 )
 
 __all__ = [
+    "BackChannelProcessor",
     "TranscriptionGateProcessor",
     "UserIdleCallbackHandler",
     "create_user_idle_processor",

--- a/app/ai/voice/agents/breeze_buddy/processors/back_channel.py
+++ b/app/ai/voice/agents/breeze_buddy/processors/back_channel.py
@@ -1,0 +1,167 @@
+"""
+Back-Channel Processor
+
+A lightweight FrameProcessor that sends soft audio acknowledgments ("okay",
+"got it") during input collection accumulation windows. This reassures the
+user that the agent is still listening while they dictate multi-segment input
+(phone numbers, addresses, etc.) with natural pauses.
+
+The processor is always in the pipeline but is a transparent passthrough when
+disabled. It is enabled/disabled per-node by the transition handler based on
+the node's input_collection.back_channel configuration.
+
+Pipeline position:
+    stt
+    -> TranscriptionGateProcessor
+    -> BackChannelProcessor         <- here
+    -> [UserIdleProcessor]
+    -> user_aggregator
+    -> llm
+    -> tts
+    ...
+
+When enabled:
+1. Finalized TranscriptionFrame arrives -> schedule a back-channel timer
+2. If InterimTranscriptionFrame arrives -> cancel timer (user resumed speaking)
+3. If LLMFullResponseStartFrame arrives -> cancel timer (turn ended, LLM processing)
+4. When timer fires -> check min_interval throttle -> push TTSSpeakFrame downstream
+5. TTSSpeakFrame flows through user_aggregator/llm (both pass it through) to TTS
+6. append_to_context=False prevents LLM context pollution
+"""
+
+import asyncio
+import random
+import time
+from typing import Optional
+
+from pipecat.frames.frames import (
+    Frame,
+    InterimTranscriptionFrame,
+    LLMFullResponseStartFrame,
+    TranscriptionFrame,
+    TTSSpeakFrame,
+)
+from pipecat.processors.frame_processor import FrameDirection, FrameProcessor
+
+from app.ai.voice.agents.breeze_buddy.template.types import BackChannelConfig
+from app.core.logger import logger
+
+
+class BackChannelProcessor(FrameProcessor):
+    """Sends soft back-channel acknowledgments during input collection.
+
+    Transparent passthrough when disabled. Enable/disable via the public API
+    during node transitions.
+    """
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self._enabled: bool = False
+        self._delay_secs: float = 1.5
+        self._min_interval_secs: float = 3.0
+        self._messages: list[str] = []
+        self._pending_timer: Optional[asyncio.Task] = None
+        self._last_back_channel_time: float = 0.0
+
+    # ------------------------------------------------------------------
+    # Public API (called from transition handler)
+    # ------------------------------------------------------------------
+
+    def enable(self, config: BackChannelConfig) -> None:
+        """Activate back-channeling with the given configuration."""
+        self._cancel_timer()
+        self._delay_secs = config.delay_secs
+        self._min_interval_secs = config.min_interval_secs
+        self._messages = list(config.messages) if config.messages else []
+        if not self._messages:
+            logger.warning(
+                "BackChannel: enabled but messages list is empty, staying disabled"
+            )
+            self._enabled = False
+            return
+        self._enabled = True
+        logger.info(
+            f"BackChannel: enabled (delay={self._delay_secs}s, "
+            f"min_interval={self._min_interval_secs}s, "
+            f"messages={self._messages})"
+        )
+
+    def disable(self) -> None:
+        """Deactivate back-channeling and cancel any pending timer."""
+        if self._enabled:
+            logger.info("BackChannel: disabled")
+        self._cancel_timer()
+        self._enabled = False
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _cancel_timer(self) -> None:
+        """Cancel the pending back-channel timer if any."""
+        if self._pending_timer and not self._pending_timer.done():
+            self._pending_timer.cancel()
+            logger.debug("BackChannel: timer cancelled")
+        self._pending_timer = None
+
+    def _schedule_back_channel(self) -> None:
+        """Cancel any existing timer and schedule a new one."""
+        self._cancel_timer()
+        self._pending_timer = asyncio.create_task(self._fire_back_channel())
+
+    async def _fire_back_channel(self) -> None:
+        """Wait delay_secs then push a TTSSpeakFrame if throttle allows."""
+        try:
+            await asyncio.sleep(self._delay_secs)
+
+            # Check min_interval throttle
+            now = time.monotonic()
+            elapsed = now - self._last_back_channel_time
+            if elapsed < self._min_interval_secs:
+                logger.debug(
+                    f"BackChannel: throttled (elapsed={elapsed:.1f}s < "
+                    f"min_interval={self._min_interval_secs}s)"
+                )
+                return
+
+            if not self._enabled or not self._messages:
+                return
+
+            message = random.choice(self._messages)
+            self._last_back_channel_time = now
+            logger.info(f"BackChannel: sending '{message}'")
+
+            await self.push_frame(
+                TTSSpeakFrame(text=message, append_to_context=False),
+                FrameDirection.DOWNSTREAM,
+            )
+        except asyncio.CancelledError:
+            pass
+
+    # ------------------------------------------------------------------
+    # FrameProcessor implementation
+    # ------------------------------------------------------------------
+
+    async def process_frame(self, frame: Frame, direction: FrameDirection):
+        await super().process_frame(frame, direction)
+
+        if self._enabled:
+            if isinstance(frame, TranscriptionFrame):
+                # Finalized transcript -> schedule back-channel timer
+                self._schedule_back_channel()
+
+            elif isinstance(frame, InterimTranscriptionFrame):
+                # User resumed speaking -> cancel pending back-channel
+                self._cancel_timer()
+
+        # Turn ended, LLM is processing -> cancel any pending back-channel
+        if isinstance(frame, LLMFullResponseStartFrame):
+            self._cancel_timer()
+
+        # Always pass all frames through unchanged
+        await self.push_frame(frame, direction)
+
+    async def cleanup(self):
+        """Cancel pending timer on pipeline shutdown."""
+        self._cancel_timer()
+        await super().cleanup()

--- a/app/ai/voice/agents/breeze_buddy/template/context.py
+++ b/app/ai/voice/agents/breeze_buddy/template/context.py
@@ -56,6 +56,15 @@ class TemplateContext:
         return getattr(self.bot, "speech_gate", None)
 
     @property
+    def back_channel(self):
+        """Get BackChannelProcessor instance.
+
+        Returns None if the pipeline has not been built yet. Callers should
+        guard with ``if context.back_channel:`` before use.
+        """
+        return getattr(self.bot, "back_channel", None)
+
+    @property
     def aiohttp_session(self):
         """Get AIO Http Session instance"""
         return self.bot.aiohttp_session

--- a/app/ai/voice/agents/breeze_buddy/template/input_collection.py
+++ b/app/ai/voice/agents/breeze_buddy/template/input_collection.py
@@ -14,8 +14,13 @@ this to a higher value (e.g., 3.0s) so that multiple speech segments separated
 by natural pauses are accumulated into a single user turn.
 """
 
+from typing import Optional
+
 from app.ai.voice.agents.breeze_buddy.template.context import TemplateContext
-from app.ai.voice.agents.breeze_buddy.template.types import InputCollectionConfig
+from app.ai.voice.agents.breeze_buddy.template.types import (
+    BackChannelConfig,
+    InputCollectionConfig,
+)
 from app.core.logger import logger
 
 # Default user_speech_timeout used for all non-collection nodes.
@@ -62,3 +67,52 @@ def get_node_user_speech_timeout(context: TemplateContext, node_name: str) -> fl
         f"(call: {context.call_sid or 'unknown'})"
     )
     return collection_config.user_speech_timeout
+
+
+def get_node_back_channel_config(
+    context: TemplateContext, node_name: str
+) -> Optional[BackChannelConfig]:
+    """Get the BackChannelConfig for a node, or None if not configured/enabled.
+
+    Returns the BackChannelConfig only when the node has input_collection
+    enabled AND back_channel enabled. Returns None otherwise.
+
+    Args:
+        context: Template context with bot state access
+        node_name: Name of the target node
+
+    Returns:
+        BackChannelConfig if enabled, None otherwise
+    """
+    bot = context.bot
+    if not hasattr(bot, "flow_config") or not bot.flow_config:
+        return None
+
+    nodes = bot.flow_config.get("nodes", {})
+    if node_name not in nodes:
+        return None
+
+    node_config = nodes[node_name]
+    collection_config = node_config.get("input_collection")
+    if collection_config is None:
+        return None
+
+    # collection_config may be an InputCollectionConfig object or a dict
+    if isinstance(collection_config, dict):
+        collection_config = InputCollectionConfig.model_validate(collection_config)
+
+    if not collection_config.enabled:
+        return None
+
+    back_channel = collection_config.back_channel
+    if back_channel is None or not back_channel.enabled:
+        return None
+
+    logger.info(
+        f"Back-channel enabled for node '{node_name}': "
+        f"delay={back_channel.delay_secs}s, "
+        f"min_interval={back_channel.min_interval_secs}s, "
+        f"messages={back_channel.messages} "
+        f"(call: {context.call_sid or 'unknown'})"
+    )
+    return back_channel

--- a/app/ai/voice/agents/breeze_buddy/template/transition.py
+++ b/app/ai/voice/agents/breeze_buddy/template/transition.py
@@ -13,6 +13,7 @@ from app.ai.voice.agents.breeze_buddy.observability.tracing_setup import auto_tr
 from app.ai.voice.agents.breeze_buddy.template.context import TemplateContext
 from app.ai.voice.agents.breeze_buddy.template.hooks import HookRegistry
 from app.ai.voice.agents.breeze_buddy.template.input_collection import (
+    get_node_back_channel_config,
     get_node_user_speech_timeout,
 )
 from app.ai.voice.agents.breeze_buddy.template.interruption import (
@@ -99,6 +100,14 @@ async def transition_handler(
         await apply_node_interruption_config(
             context, transition_to, user_speech_timeout=user_speech_timeout
         )
+
+        # --- Back-channel configuration ---
+        # Disable from previous node first, then enable if new node has it configured.
+        if context.back_channel:
+            context.back_channel.disable()
+            bc_config = get_node_back_channel_config(context, transition_to)
+            if bc_config:
+                context.back_channel.enable(bc_config)
 
         next_node = context.create_node_from_template(transition_to)
 

--- a/app/ai/voice/agents/breeze_buddy/template/types.py
+++ b/app/ai/voice/agents/breeze_buddy/template/types.py
@@ -220,6 +220,43 @@ class InterruptionConfig(BaseModel):
     )
 
 
+class BackChannelConfig(BaseModel):
+    """Configuration for back-channel acknowledgments during input accumulation.
+
+    When enabled alongside input collection, the agent sends soft audio
+    acknowledgments ("okay", "got it") during the user_speech_timeout wait
+    window so the user knows the agent is still listening. Back-channels are
+    spoken via direct TTS without involving the LLM or polluting LLM context.
+
+    The delay_secs timer starts after each finalized transcript. If the user
+    resumes speaking (interim transcript arrives), the timer is cancelled.
+    min_interval_secs prevents rapid-fire acknowledgments.
+    """
+
+    enabled: bool = Field(
+        False,
+        description="Whether back-channel acknowledgments are active.",
+    )
+    delay_secs: float = Field(
+        1.5,
+        ge=0.1,
+        le=10.0,
+        description="Seconds to wait after a finalized transcript before sending "
+        "a back-channel. Must be less than user_speech_timeout to fire during "
+        "accumulation, not after the turn ends.",
+    )
+    min_interval_secs: float = Field(
+        3.0,
+        ge=0.5,
+        description="Minimum seconds between consecutive back-channel messages "
+        "to avoid rapid-fire acknowledgments.",
+    )
+    messages: List[str] = Field(
+        default_factory=lambda: ["okay", "got it", "go on"],
+        description="Pool of back-channel messages to randomly select from.",
+    )
+
+
 class InputCollectionConfig(BaseModel):
     """Configuration for multi-segment input collection at node level.
 
@@ -241,6 +278,10 @@ class InputCollectionConfig(BaseModel):
 
         Address dictation (wait longer):
             {"enabled": true, "user_speech_timeout": 4.0}
+
+        With back-channel acknowledgments:
+            {"enabled": true, "user_speech_timeout": 3.0,
+             "back_channel": {"enabled": true, "delay_secs": 1.5}}
     """
 
     enabled: bool = Field(
@@ -255,6 +296,13 @@ class InputCollectionConfig(BaseModel):
         "segments. In no-VAD mode (production), the timer resets on each new "
         "transcript, so segments within this window are accumulated into one turn. "
         "Total silence before bot responds = Soniox max_endpoint_delay_ms + this value.",
+    )
+    back_channel: Optional[BackChannelConfig] = Field(
+        None,
+        description="Back-channel acknowledgment configuration during input "
+        "accumulation. When enabled, the agent sends soft audio acknowledgments "
+        "('okay', 'got it') between speech segments so the user knows the agent "
+        "is still listening.",
     )
 
 

--- a/docs/INPUT_COLLECTION_MODE.md
+++ b/docs/INPUT_COLLECTION_MODE.md
@@ -561,7 +561,7 @@ if node.input_collection:
 
 ---
 
-### Phase 2: Back-Channeling During Accumulation
+### Phase 2: Back-Channeling During Accumulation ✅ IMPLEMENTED
 
 **Goal:** During the `user_speech_timeout` wait window, give soft audio acknowledgments so the user knows the agent is listening.
 
@@ -575,13 +575,16 @@ A lightweight `FrameProcessor` inserted in the pipeline that:
 2. Starts a short timer (`back_channel_delay`, e.g., 1.5s — less than `user_speech_timeout`)
 3. If timer fires (user paused but not done), pushes `TTSSpeakFrame("okay", append_to_context=False)`
 4. If user resumes speaking (new interim transcript), cancels the timer
-5. Limits frequency via `min_interval_secs` to avoid rapid-fire acknowledgments
+5. If `LLMFullResponseStartFrame` arrives (turn ended), cancels the timer
+6. Limits frequency via `min_interval_secs` to avoid rapid-fire acknowledgments
 
 #### Pipeline Position
 
 ```
-stt → TranscriptionGate → [BackChannelProcessor] → [InputCollectionProcessor if needed] → user_aggregator
+stt → TranscriptionGate → BackChannelProcessor → [UserIdleProcessor] → user_aggregator → llm → tts
 ```
+
+TTSSpeakFrame pushed downstream flows through user_aggregator and llm (both pass it through) to tts where it is spoken.
 
 #### Config Extension
 
@@ -605,11 +608,18 @@ stt → TranscriptionGate → [BackChannelProcessor] → [InputCollectionProcess
 - `append_to_context=False` — back-channels don't pollute LLM context
 - Back-channel audio may overlap with user's next segment — this is natural and expected (like human back-channeling)
 - Timer is always less than `user_speech_timeout` to fire during accumulation, not after
+- No STT muting during back-channel — overlap is natural
+- Random message selection from the configured pool
+- Timer cleanup via three paths: `disable()` on node transition, `LLMFullResponseStartFrame` detection, `cleanup()` on pipeline shutdown
 
-#### Estimated Scope
-- ~80-100 lines for BackChannelProcessor
-- Config model additions (~10 lines)
-- Pipeline wiring (~5 lines)
+#### Implementation Files
+- `processors/back_channel.py` — BackChannelProcessor (~90 lines)
+- `template/types.py` — BackChannelConfig model nested under InputCollectionConfig
+- `template/input_collection.py` — `get_node_back_channel_config()` helper
+- `agent/pipeline.py` — Processor wiring and 6-tuple return
+- `agent/__init__.py` — `self.back_channel` storage
+- `template/context.py` — `back_channel` property
+- `template/transition.py` — Enable/disable on node transitions
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds `BackChannelProcessor` — a new PipeCat `FrameProcessor` that sends soft TTS acknowledgments ("okay", "got it", "go on") during multi-segment input accumulation, so users know the agent is still listening
- Back-channel is configurable per node via `input_collection.back_channel` in template JSON (delay, throttle interval, message pool)
- Timer-based: fires after configurable silence delay, cancelled on interim speech or LLM turn start; uses `TTSSpeakFrame(append_to_context=False)` to avoid LLM context pollution

## Changes

- **New**: `processors/back_channel.py` — `BackChannelProcessor` with enable/disable API, timer lifecycle, throttling
- **Modified**: `template/types.py` — `BackChannelConfig` model nested in `InputCollectionConfig`
- **Modified**: `template/input_collection.py` — `get_node_back_channel_config()` helper
- **Modified**: `agent/pipeline.py` — inserted `BackChannelProcessor` in pipeline, 6-tuple return
- **Modified**: `agent/__init__.py` — stores `back_channel` reference, unpacks 6-tuple
- **Modified**: `template/context.py` — `back_channel` property on `TemplateContext`
- **Modified**: `template/transition.py` — disable/enable back-channel on node transitions
- **Updated**: example template and docs

## Test plan

- [ ] Manual test: call agent with input-collection template, dictate number in segments, verify audible "okay" between segments
- [ ] Verify back-channel is cancelled when user resumes speaking (no overlap with user turn)
- [ ] Verify back-channel stops when LLM starts processing (turn end)
- [ ] Verify `min_interval_secs` throttle prevents rapid-fire acknowledgments
- [ ] Verify LLM context is not polluted with back-channel text
- [ ] Verify nodes without `input_collection.back_channel` have no back-channeling

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - Back-channel acknowledgments: Automated soft acknowledgments (e.g., "okay", "got it") sent during input collection pauses, with configurable delay, interval timing, and custom message pools per conversation node.

* **Documentation**
  - Updated documentation describing the back-channel feature implementation and configuration guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->