### PR TITLE
feat: add outbound rate limit alerting per phone number

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -206,3 +206,7 @@ ENABLE_BB_LANGFUSE_MONITORING_LOOP=false  # Enable/disable Langfuse score monito
 SCORE_CHECK_INTERVAL_SECONDS=600  # Check interval for Langfuse scores (10 minutes)
 
 DAILY_SUMMARY_HOUR = "21" # Hour of the day (0-23) to send daily summary alerts (default: 21 for 9 PM)
+
+# Outbound Rate Limiting (sliding window per phone number)
+OUTBOUND_RATE_LIMIT_MAX_CALLS=7
+OUTBOUND_RATE_LIMIT_WINDOW_SECONDS=3600

--- a/app/ai/voice/agents/breeze_buddy/managers/calls.py
+++ b/app/ai/voice/agents/breeze_buddy/managers/calls.py
@@ -2,6 +2,7 @@
 Cron manager for handling background tasks.
 """
 
+import asyncio
 import uuid
 from datetime import datetime, timedelta, timezone
 from typing import Optional
@@ -12,6 +13,9 @@ from app.ai.voice.agents.breeze_buddy.managers.utils import (
 )
 from app.ai.voice.agents.breeze_buddy.services.agent_router.client import (
     safe_release_pod,
+)
+from app.ai.voice.agents.breeze_buddy.services.rate_limiter import (
+    process_outbound_rate_limit_alert,
 )
 from app.ai.voice.agents.breeze_buddy.services.telephony.exotel.recording import (
     download_call_recording as download_call_recording_exotel,
@@ -436,15 +440,16 @@ async def process_backlog_leads():
                     )
                     await release_lock_on_lead_by_id(locked_lead.id)
                     continue
-                # Check if customer phone number is blacklisted
-                blacklist_phone = (locked_lead.payload or {}).get(
+
+                customer_phone = (locked_lead.payload or {}).get(
                     "customer_mobile_number"
                 )
-                if blacklist_phone and await is_number_blacklisted(
-                    blacklist_phone, locked_lead.reseller_id
+
+                if customer_phone and await is_number_blacklisted(
+                    customer_phone, locked_lead.reseller_id
                 ):
                     logger.info(
-                        f"Skipping lead {locked_lead.id} - phone number {blacklist_phone} is blacklisted"
+                        f"Skipping lead {locked_lead.id} - phone number {customer_phone} is blacklisted"
                     )
                     await update_lead_call_completion_details(
                         id=locked_lead.id,
@@ -525,6 +530,13 @@ async def process_backlog_leads():
                     await _release_number(number_to_use.id, number_to_use.provider)
                     await release_lock_on_lead_by_id(locked_lead.id)
                     continue
+                _rate_limit_task = asyncio.create_task(
+                    process_outbound_rate_limit_alert(
+                        customer_phone=customer_mobile,
+                        lead_id=str(locked_lead.id),
+                        reseller_id=locked_lead.reseller_id,
+                    )
+                )
                 call = call_provider.make_call(
                     customer_mobile,
                     number_to_use.number,

--- a/app/ai/voice/agents/breeze_buddy/services/rate_limiter.py
+++ b/app/ai/voice/agents/breeze_buddy/services/rate_limiter.py
@@ -1,0 +1,110 @@
+import time
+from typing import Tuple
+
+from app.core.config import dynamic as dyn_cfg
+from app.core.logger import logger
+from app.services.redis.client import get_redis_service, is_redis_configured
+from app.services.slack.alert import slack_alert
+
+OUTBOUND_RATE_LIMIT_LUA = """
+local key    = KEYS[1]
+local now    = tonumber(ARGV[1])
+local window = tonumber(ARGV[2])
+local limit  = tonumber(ARGV[3]) -- reserved for Phase 2 blocking
+local member = ARGV[4]
+
+redis.call('ZREMRANGEBYSCORE', key, 0, now - window)
+local count = redis.call('ZCARD', key)
+redis.call('ZADD', key, now, member)
+redis.call('EXPIRE', key, window)
+return count
+"""
+
+
+async def check_outbound_rate_limit(
+    customer_mobile_number: str,
+    lead_id: str,
+) -> Tuple[bool, int]:
+    """
+    Track an outbound call and check if the rate limit is exceeded.
+
+    Always records the call in the sliding window. Returns whether the limit
+    has been exceeded and the count of calls already in the window (before
+    this one).
+
+    Returns:
+        (exceeded, count_before) — exceeded is True when count_before >= limit.
+    """
+    if not is_redis_configured():
+        return False, 0
+
+    try:
+        max_calls = await dyn_cfg.OUTBOUND_RATE_LIMIT_MAX_CALLS()
+        window_seconds = await dyn_cfg.OUTBOUND_RATE_LIMIT_WINDOW_SECONDS()
+
+        redis = await get_redis_service()
+        key = f"breeze_buddy:outbound_rate_limit:{customer_mobile_number}"
+        now = time.time()
+        member = f"{now}:{lead_id}"
+        count_before = await redis.eval_script(
+            OUTBOUND_RATE_LIMIT_LUA,
+            keys=[key],
+            args=[
+                now,
+                window_seconds,
+                max_calls,
+                member,
+            ],
+        )
+        exceeded = int(count_before) >= max_calls
+        return exceeded, int(count_before)
+    except Exception as e:
+        logger.warning(f"[OUTBOUND_RATE_LIMIT] Redis error: {e}")
+        return False, 0
+
+
+async def process_outbound_rate_limit_alert(
+    customer_phone: str,
+    lead_id: str,
+    reseller_id: str,
+) -> None:
+    """
+    Fire-and-forget: track an outbound call and send a Slack alert if the
+    rate limit is exceeded. Callers should wrap this in asyncio.create_task().
+    """
+    try:
+        max_calls = await dyn_cfg.OUTBOUND_RATE_LIMIT_MAX_CALLS()
+        window_seconds = await dyn_cfg.OUTBOUND_RATE_LIMIT_WINDOW_SECONDS()
+
+        exceeded, count = await check_outbound_rate_limit(
+            customer_mobile_number=customer_phone,
+            lead_id=lead_id,
+        )
+        if exceeded:
+            masked_phone = (
+                f"***{customer_phone[-4:]}" if len(customer_phone) >= 4 else "***"
+            )
+            logger.warning(
+                f"[OUTBOUND_RATE_LIMIT] Limit exceeded for "
+                f"{masked_phone} - {count + 1}/{max_calls} "
+                f"calls in {window_seconds}s "
+                f"(lead: {lead_id})"
+            )
+            await slack_alert.send(
+                title="Outbound Rate Limit Exceeded",
+                fields=[
+                    {"name": "Phone (last 4)", "value": masked_phone},
+                    {
+                        "name": "Calls in window",
+                        "value": f"{count + 1}/{max_calls}",
+                    },
+                    {
+                        "name": "Window",
+                        "value": f"{window_seconds}s",
+                    },
+                    {"name": "Lead ID", "value": lead_id},
+                    {"name": "Reseller", "value": reseller_id},
+                ],
+            )
+    except Exception as e:
+        logger.warning(f"[OUTBOUND_RATE_LIMIT] Error in background alert task: {e}")

--- a/app/core/config/dynamic.py
+++ b/app/core/config/dynamic.py
@@ -317,3 +317,14 @@ async def BREEZE_BUDDY_ENABLE_VAD() -> bool:
     When True, VAD is enabled and used for voice activity detection and turn management.
     """
     return await get_config("BREEZE_BUDDY_ENABLE_VAD", False, bool)
+
+
+# --- Outbound Rate Limit Configuration ---
+async def OUTBOUND_RATE_LIMIT_MAX_CALLS() -> int:
+    """Returns OUTBOUND_RATE_LIMIT_MAX_CALLS from Redis"""
+    return await get_config("OUTBOUND_RATE_LIMIT_MAX_CALLS", 7, int)
+
+
+async def OUTBOUND_RATE_LIMIT_WINDOW_SECONDS() -> int:
+    """Returns OUTBOUND_RATE_LIMIT_WINDOW_SECONDS from Redis"""
+    return await get_config("OUTBOUND_RATE_LIMIT_WINDOW_SECONDS", 3600, int)

--- a/app/core/config/static.py
+++ b/app/core/config/static.py
@@ -496,6 +496,7 @@ REDIS_PORT = os.getenv("REDIS_PORT", "")
 REDIS_CLUSTER_NODES = os.getenv("REDIS_CLUSTER_NODES", "")
 REDIS_TTL = int(os.getenv("REDIS_TTL", "3600"))  # Default TTL in seconds (1 hour)
 BLACKLIST_CACHE_TTL = int(os.getenv("BLACKLIST_CACHE_TTL", "300"))  # 5 minutes
+
 # ─────────────────────────────────────────────────────────────────────────────
 # Voice Agent Pod Isolation Configuration (1-pod-1-call architecture)
 # ─────────────────────────────────────────────────────────────────────────────

--- a/app/services/redis/client.py
+++ b/app/services/redis/client.py
@@ -290,6 +290,26 @@ class RedisService:
             logger.error(f"Redis EXPIRE error for key {key}: {e}")
             return False
 
+    async def eval_script(self, script: str, keys: List[str], args: List[Any]) -> Any:
+        """Evaluate a Lua script on Redis."""
+        try:
+            client = await self.get_client()
+            result = client.eval(script, len(keys), *keys, *args)  # type: ignore[union-attr]
+            if hasattr(result, "__await__"):
+                return await cast(Awaitable[Any], result)
+            return result
+        except RedisError as e:
+            logger.error(
+                f"Redis EVAL error for script: {script!r}, keys: {keys}, args_len: {len(args)}: {e}"
+            )
+            return None
+        except Exception as e:
+            logger.error(
+                f"Unexpected Redis EVAL error for script: {script!r}, keys: {keys}, args_len: {len(args)}: {e}",
+                exc_info=True,
+            )
+            return None
+
     async def close(self) -> None:
         """Close Redis connections"""
         if self._factory:

--- a/docs/breeze_buddy/calling_rate_limiter.md
+++ b/docs/breeze_buddy/calling_rate_limiter.md
@@ -1,0 +1,100 @@
+# Redis Sliding Window Rate Limiter
+
+Implementation guide for outbound call frequency tracking.
+
+## Status
+
+Phase 1 — **alert only**. Calls are tracked and Slack alerts fire when the limit is exceeded, but no calls are blocked. Rate limiting (blocking) is not yet implemented.
+
+## Overview
+
+Tracks outbound calls per destination phone number using Redis sorted sets within a configurable rolling window. Default: 7 calls per 3600 seconds.
+
+## Configuration
+
+Environment variables (global, applies to all resellers/templates):
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `OUTBOUND_RATE_LIMIT_MAX_CALLS` | `7` | Max calls per window before alerting |
+| `OUTBOUND_RATE_LIMIT_WINDOW_SECONDS` | `3600` | Sliding window duration in seconds |
+
+## Data Structure
+
+Each phone number gets a Redis sorted set. Member = `{timestamp}:{lead_id}` (avoids collisions), Score = timestamp float. Redis keeps members sorted by score, enabling fast range queries by time.
+
+```text
+Key:    breeze_buddy:outbound_rate_limit:+919876543210
+Type:   Sorted Set (ZSET)
+
+Members (score = timestamp):
+  "1711441200.45:lead_abc"  →  score: 1711441200.45
+  "1711442800.12:lead_def"  →  score: 1711442800.12
+```
+
+## Lua Script
+
+Runs atomically inside Redis — no race conditions across multiple pods/workers. Four operations in one atomic step:
+
+| Command | What it does | Complexity |
+|---------|-------------|------------|
+| ZREMRANGEBYSCORE | Remove entries older than `now - window`. Slides the window. | O(log n + k) |
+| ZCARD | Count remaining entries (calls in current window). | O(1) |
+| ZADD | Insert this call attempt (score = now). | O(log n) |
+| EXPIRE | Set TTL to window seconds — auto-cleans key if number is never called again. | O(1) |
+
+The script always inserts the call (we're tracking, not blocking) and returns the count *before* insertion. If `count >= limit`, the limit is exceeded.
+
+```lua
+local key    = KEYS[1]
+local now    = tonumber(ARGV[1])
+local window = tonumber(ARGV[2])
+local limit  = tonumber(ARGV[3])
+local member = ARGV[4]
+
+redis.call('ZREMRANGEBYSCORE', key, 0, now - window)
+local count = redis.call('ZCARD', key)
+redis.call('ZADD', key, now, member)
+redis.call('EXPIRE', key, window)
+return count
+```
+
+## Integration
+
+The check runs in `process_backlog_leads()` just before `make_call()`, after all pre-call validations (blacklist, calling hours, pre-checks, phone validation) have passed. On limit exceeded: logs a warning and sends a Slack alert. The call proceeds regardless.
+
+## Key Decisions
+
+### Window
+
+`ZREMRANGEBYSCORE` trims entries older than `now - OUTBOUND_RATE_LIMIT_WINDOW_SECONDS`. Configurable via env var.
+
+### Limit
+
+`count >= OUTBOUND_RATE_LIMIT_MAX_CALLS` triggers an alert. Default 7 means the 8th call in the window triggers the alert. Configurable via env var.
+
+### TTL
+
+EXPIRE resets on every call. Key survives for `window` seconds after last activity, then auto-deletes.
+
+### Why Lua over Pipeline
+
+The app runs on multiple pods. A pipeline is not atomic — two workers checking the same phone number simultaneously can both read `count=6` and both allow. The Lua script runs atomically inside Redis, eliminating this race.
+
+### Fail-open
+
+If Redis is down, the check is skipped. No alert, call proceeds.
+
+## Pipeline vs Lua — when to use which
+
+- Single calling process or low concurrency → use pipeline
+- Multiple parallel workers calling the same contacts → use Lua
+- Need maximum throughput with acceptable tiny race risk → use pipeline
+- Need strict correctness at any scale → use Lua
+
+## Redis Docs Reference
+
+- Sorted sets overview: https://redis.io/docs/latest/develop/data-types/sorted-sets/
+- ZREMRANGEBYSCORE: https://redis.io/docs/latest/commands/zremrangebyscore/
+- Pipeline: https://redis.io/docs/latest/develop/use/pipelining/
+- Lua scripting: https://redis.io/docs/latest/develop/interact/programmability/eval-intro/


### PR DESCRIPTION
## Summary
Phase 1 (alert-only) outbound rate limiter that tracks calls per destination phone number using a Redis sliding-window pattern. When a configurable limit is exceeded, it logs a warning and sends a Slack alert. No calls are blocked — blocking is deferred to a future phase.
## Changes
- **`app/ai/voice/agents/breeze_buddy/services/rate_limiter.py`** (new) — Core rate limiter service: atomic Lua script (ZREMRANGEBYSCORE → ZCARD → ZADD → EXPIRE), `check_outbound_rate_limit()`, and `process_outbound_rate_limit_alert()` fire-and-forget wrapper
- **`app/ai/voice/agents/breeze_buddy/managers/calls.py`** — Fires `asyncio.create_task(process_outbound_rate_limit_alert(...))` for every outbound call attempt, non-blocking
- **`app/services/redis/client.py`** — Added `eval_script()` method to `RedisService` for Lua script execution
- **`app/core/config/static.py`** — Added `OUTBOUND_RATE_LIMIT_MAX_CALLS` (default 7) and `OUTBOUND_RATE_LIMIT_WINDOW_SECONDS` (default 3600) env vars
- **`.env.example`** — Documented new env vars
- **`docs/breeze_buddy/calling_rate_limiter.md`** (rewritten) — Design doc reflecting actual implementation
## Design decisions
- **Key is "to" phone number only** — `outbound_rate_limit:{customer_mobile_number}`, global across all resellers/templates
- **Config via env vars, not DB** — simple, no per-reseller/per-template config needed for Phase 1
- **Lua script over pipeline** — app runs on multiple pods, atomicity matters
- **Fail-open** — if Redis is down, log warning, no alert, call proceeds
- **Slack alerts fire every time** — no debouncing; every exceeded-limit event triggers an alert
- **Async fire-and-forget** — rate limit check never blocks lead processing
## How to test
1. Set `OUTBOUND_RATE_LIMIT_MAX_CALLS=2` and `OUTBOUND_RATE_LIMIT_WINDOW_SECONDS=60`
2. Trigger 3+ outbound calls to the same phone number within 60 seconds
3. Verify Slack alert fires on the 3rd call and logs show warning
4. Verify all calls still proceed (no blocking)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added outbound call rate limiting to track calls per phone number with configurable thresholds (7 calls per hour by default).
  * Rate limit violations trigger Slack alerts with call details to notify administrators.
  * Calls proceed normally when limits are exceeded (alert-only mode); blocking enforcement planned for future releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


<img width="662" height="671" alt="Screenshot 2026-03-30 at 12 07 18 PM" src="https://github.com/user-attachments/assets/7fe14dde-5e4f-4a40-ae1c-7f78bebfa636" />
