### PR TITLE
feat: add configurable blocking toggle for outbound rate limiting

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -195,3 +195,8 @@ ENABLE_BB_LANGFUSE_MONITORING_LOOP=false  # Enable/disable Langfuse score monito
 SCORE_CHECK_INTERVAL_SECONDS=600  # Check interval for Langfuse scores (10 minutes)
 
 DAILY_SUMMARY_HOUR = "21" # Hour of the day (0-23) to send daily summary alerts (default: 21 for 9 PM)
+
+# Outbound Rate Limiting (sliding window per phone number)
+OUTBOUND_RATE_LIMIT_MAX_CALLS=7
+OUTBOUND_RATE_LIMIT_WINDOW_SECONDS=3600
+# OUTBOUND_RATE_LIMIT_BLOCK_ENABLED is a dynamic config key (set via Redis, default: false)

--- a/app/ai/voice/agents/breeze_buddy/managers/calls.py
+++ b/app/ai/voice/agents/breeze_buddy/managers/calls.py
@@ -13,6 +13,9 @@ from app.ai.voice.agents.breeze_buddy.managers.utils import (
 from app.ai.voice.agents.breeze_buddy.services.agent_router.client import (
     safe_release_pod,
 )
+from app.ai.voice.agents.breeze_buddy.services.call_limiter import (
+    check_outbound_rate_limit_and_alert,
+)
 from app.ai.voice.agents.breeze_buddy.services.telephony.exotel.recording import (
     download_call_recording as download_call_recording_exotel,
 )
@@ -452,15 +455,21 @@ async def process_backlog_leads():
                     )
                     await release_lock_on_lead_by_id(locked_lead.id)
                     continue
-                # Check if customer phone number is blacklisted
-                blacklist_phone = (locked_lead.payload or {}).get(
+
+                customer_phone = (locked_lead.payload or {}).get(
                     "customer_mobile_number"
                 )
-                if blacklist_phone and await is_number_blacklisted(
-                    blacklist_phone, locked_lead.reseller_id
+
+                if customer_phone and await is_number_blacklisted(
+                    customer_phone, locked_lead.reseller_id
                 ):
+                    masked_phone = (
+                        f"***{customer_phone[-4:]}"
+                        if len(customer_phone) >= 4
+                        else "***"
+                    )
                     logger.info(
-                        f"Skipping lead {locked_lead.id} - phone number {blacklist_phone} is blacklisted"
+                        f"Skipping lead {locked_lead.id} - phone number {masked_phone} is blacklisted"
                     )
                     await update_lead_call_completion_details(
                         id=locked_lead.id,
@@ -541,6 +550,18 @@ async def process_backlog_leads():
                     logger.error(
                         f"Invalid customer_mobile_number for lead {locked_lead.id}"
                     )
+                    await _release_number(number_to_use.id, number_to_use.provider)
+                    await release_lock_on_lead_by_id(locked_lead.id)
+                    continue
+                rate_limit_allowed = await check_outbound_rate_limit_and_alert(
+                    customer_phone=customer_mobile,
+                    lead_id=str(locked_lead.id),
+                    reseller_id=locked_lead.reseller_id,
+                )
+                if not rate_limit_allowed:
+                    # TODO: advance next_attempt_at by the rate-limit window so
+                    # the scheduler does not immediately re-pick this lead and
+                    # re-trigger the alert on the next cycle.
                     await _release_number(number_to_use.id, number_to_use.provider)
                     await release_lock_on_lead_by_id(locked_lead.id)
                     continue

--- a/app/ai/voice/agents/breeze_buddy/services/call_limiter.py
+++ b/app/ai/voice/agents/breeze_buddy/services/call_limiter.py
@@ -1,0 +1,141 @@
+import asyncio
+import hashlib
+import time
+from typing import Tuple
+
+from app.core.config import dynamic as dyn_cfg
+from app.core.logger import logger
+from app.services.redis.client import get_redis_service, is_redis_configured
+from app.services.slack.alert import slack_alert
+
+OUTBOUND_RATE_LIMIT_LUA = """
+local key    = KEYS[1]
+local now    = tonumber(ARGV[1])
+local window = tonumber(ARGV[2])
+local limit  = tonumber(ARGV[3]) -- reserved for Phase 2 blocking
+local member = ARGV[4]
+
+redis.call('ZREMRANGEBYSCORE', key, 0, now - window)
+local count = redis.call('ZCARD', key)
+redis.call('ZADD', key, now, member)
+redis.call('EXPIRE', key, window)
+return count
+"""
+
+
+def _token_for_phone(phone: str) -> str:
+    """Return a deterministic one-way token for a phone number to avoid
+    storing raw PII in Redis keys."""
+    return hashlib.sha256(phone.encode()).hexdigest()
+
+
+async def check_outbound_limit_for_number(
+    customer_mobile_number: str,
+    lead_id: str,
+    max_calls: int,
+    window_seconds: int,
+) -> Tuple[bool, int]:
+    """
+    Track an outbound call and check if the rate limit is exceeded.
+
+    Always records the call in the sliding window. Returns whether the limit
+    has been exceeded and the count of calls already in the window (before
+    this one).
+
+    Returns:
+        (exceeded, count_before) — exceeded is True when count_before >= limit.
+    """
+    if not is_redis_configured():
+        return False, 0
+
+    try:
+        redis = await get_redis_service()
+        token = _token_for_phone(customer_mobile_number)
+        key = f"breeze_buddy:outbound_rate_limit:{token}"
+        now = time.time()
+        member = f"{now}:{lead_id}"
+        count_before = await redis.run_script(
+            OUTBOUND_RATE_LIMIT_LUA,
+            keys=[key],
+            args=[
+                now,
+                window_seconds,
+                max_calls,
+                member,
+            ],
+        )
+        exceeded = int(count_before) >= max_calls
+        return exceeded, int(count_before)
+    except Exception as e:
+        logger.warning(f"[OUTBOUND_RATE_LIMIT] Redis error: {e}")
+        return False, 0
+
+
+async def check_outbound_rate_limit_and_alert(
+    customer_phone: str,
+    lead_id: str,
+    reseller_id: str,
+) -> bool:
+    """
+    Track an outbound call and check if the rate limit is exceeded.
+
+    Returns False if the call should be blocked (block enabled + limit exceeded).
+    Returns True if the call may proceed.
+    Always sends a Slack alert when the limit is exceeded.
+
+    The block/allow decision is made before the Slack alert is sent so that
+    any Slack failure never causes a call to be blocked or allowed
+    unexpectedly.
+    """
+    try:
+        block_enabled, max_calls, window_seconds = await asyncio.gather(
+            dyn_cfg.OUTBOUND_RATE_LIMIT_BLOCK_ENABLED(),
+            dyn_cfg.OUTBOUND_RATE_LIMIT_MAX_CALLS(),
+            dyn_cfg.OUTBOUND_RATE_LIMIT_WINDOW_SECONDS(),
+        )
+
+        exceeded, count = await check_outbound_limit_for_number(
+            customer_mobile_number=customer_phone,
+            lead_id=lead_id,
+            max_calls=max_calls,
+            window_seconds=window_seconds,
+        )
+        if exceeded:
+            masked_phone = (
+                f"***{customer_phone[-4:]}" if len(customer_phone) >= 4 else "***"
+            )
+            action = "BLOCKED" if block_enabled else "ALERT_ONLY"
+            logger.warning(
+                f"[OUTBOUND_RATE_LIMIT] Limit exceeded for "
+                f"{masked_phone} - {count + 1}/{max_calls} "
+                f"calls in {window_seconds}s "
+                f"(lead: {lead_id}, action: {action})"
+            )
+            # Determine allow/block BEFORE sending the Slack alert so that any
+            # Slack exception cannot affect the call decision.
+            allow = not block_enabled
+            try:
+                await slack_alert.send(
+                    title=f"Outbound Rate Limit Exceeded ({action})",
+                    fields=[
+                        {"name": "Phone (last 4)", "value": masked_phone},
+                        {
+                            "name": "Calls in window",
+                            "value": f"{count + 1}/{max_calls}",
+                        },
+                        {
+                            "name": "Window",
+                            "value": f"{window_seconds}s",
+                        },
+                        {"name": "Lead ID", "value": lead_id},
+                        {"name": "Reseller", "value": reseller_id},
+                        {"name": "Action", "value": action},
+                    ],
+                )
+            except Exception as slack_exc:
+                logger.warning(f"[OUTBOUND_RATE_LIMIT] Slack alert failed: {slack_exc}")
+            return allow
+        return True
+    except Exception as e:
+        logger.warning(f"[OUTBOUND_RATE_LIMIT] Error in rate limit check: {e}")
+        return True

--- a/app/core/config/dynamic.py
+++ b/app/core/config/dynamic.py
@@ -328,3 +328,19 @@ async def BREEZE_BUDDY_ENABLE_VAD() -> bool:
     When True, VAD is enabled and used for voice activity detection and turn management.
     """
     return await get_config("BREEZE_BUDDY_ENABLE_VAD", False, bool)
+
+
+# --- Outbound Rate Limit Configuration ---
+async def OUTBOUND_RATE_LIMIT_MAX_CALLS() -> int:
+    """Returns OUTBOUND_RATE_LIMIT_MAX_CALLS from Redis"""
+    return await get_config("OUTBOUND_RATE_LIMIT_MAX_CALLS", 7, int)
+
+
+async def OUTBOUND_RATE_LIMIT_WINDOW_SECONDS() -> int:
+    """Returns OUTBOUND_RATE_LIMIT_WINDOW_SECONDS from Redis"""
+    return await get_config("OUTBOUND_RATE_LIMIT_WINDOW_SECONDS", 3600, int)
+
+
+async def OUTBOUND_RATE_LIMIT_BLOCK_ENABLED() -> bool:
+    """Returns OUTBOUND_RATE_LIMIT_BLOCK_ENABLED from Redis"""
+    return await get_config("OUTBOUND_RATE_LIMIT_BLOCK_ENABLED", False, bool)

--- a/app/core/config/static.py
+++ b/app/core/config/static.py
@@ -462,6 +462,7 @@ REDIS_PORT = os.getenv("REDIS_PORT", "")
 REDIS_CLUSTER_NODES = os.getenv("REDIS_CLUSTER_NODES", "")
 REDIS_TTL = int(os.getenv("REDIS_TTL", "3600"))  # Default TTL in seconds (1 hour)
 BLACKLIST_CACHE_TTL = int(os.getenv("BLACKLIST_CACHE_TTL", "300"))  # 5 minutes
+
 # ─────────────────────────────────────────────────────────────────────────────
 # Voice Agent Pod Isolation Configuration (1-pod-1-call architecture)
 # ─────────────────────────────────────────────────────────────────────────────

--- a/app/services/redis/client.py
+++ b/app/services/redis/client.py
@@ -290,6 +290,23 @@ class RedisService:
             logger.error(f"Redis EXPIRE error for key {key}: {e}")
             return False
 
+    async def run_script(self, script: str, keys: List[str], args: List[Any]) -> Any:
+        """Evaluate a Lua script on Redis."""
+        try:
+            client = await self.get_client()
+            return await client.execute_command("EVAL", script, len(keys), *keys, *args)
+        except RedisError as e:
+            logger.error(
+                f"Redis EVAL error for script: {script!r}, keys: {keys}, args_len: {len(args)}: {e}"
+            )
+            return None
+        except Exception as e:
+            logger.error(
+                f"Unexpected Redis EVAL error for script: {script!r}, keys: {keys}, args_len: {len(args)}: {e}",
+                exc_info=True,
+            )
+            return None
+
     async def close(self) -> None:
         """Close Redis connections"""
         if self._factory:

--- a/docs/breeze_buddy/calling_rate_limiter.md
+++ b/docs/breeze_buddy/calling_rate_limiter.md
@@ -1,0 +1,101 @@
+# Redis Sliding Window Rate Limiter
+
+Implementation guide for outbound call frequency tracking.
+
+## Status
+
+Phase 2 — **configurable blocking**. When `OUTBOUND_RATE_LIMIT_BLOCK_ENABLED` is `True` (default: `False`), calls exceeding the rate limit are blocked. When `False`, the system operates in Phase 1 alert-only mode — calls are tracked and Slack alerts fire when the limit is exceeded, but no calls are blocked.
+
+## Overview
+
+Tracks outbound calls per destination phone number using Redis sorted sets within a configurable rolling window. Default: 7 calls per 3600 seconds.
+
+## Configuration
+
+Environment variables (global, applies to all resellers/templates):
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `OUTBOUND_RATE_LIMIT_MAX_CALLS` | `7` | Max calls per window before alerting/blocking |
+| `OUTBOUND_RATE_LIMIT_WINDOW_SECONDS` | `3600` | Sliding window duration in seconds |
+| `OUTBOUND_RATE_LIMIT_BLOCK_ENABLED` | `False` | When `True`, block calls exceeding limit. When `False`, alert only. |
+
+## Data Structure
+
+Each phone number gets a Redis sorted set. Member = `{timestamp}:{lead_id}` (avoids collisions), Score = timestamp float. Redis keeps members sorted by score, enabling fast range queries by time.
+
+```text
+Key:    breeze_buddy:outbound_rate_limit:+919876543210
+Type:   Sorted Set (ZSET)
+
+Members (score = timestamp):
+  "1711441200.45:lead_abc"  →  score: 1711441200.45
+  "1711442800.12:lead_def"  →  score: 1711442800.12
+```
+
+## Lua Script
+
+Runs atomically inside Redis — no race conditions across multiple pods/workers. Four operations in one atomic step:
+
+| Command | What it does | Complexity |
+|---------|-------------|------------|
+| ZREMRANGEBYSCORE | Remove entries older than `now - window`. Slides the window. | O(log n + k) |
+| ZCARD | Count remaining entries (calls in current window). | O(1) |
+| ZADD | Insert this call attempt (score = now). | O(log n) |
+| EXPIRE | Set TTL to window seconds — auto-cleans key if number is never called again. | O(1) |
+
+The script always records the call attempt and returns the count *before* insertion. If `count >= limit`, the limit is exceeded. Blocking or alert-only behaviour is then enforced in application code after the script returns — the script itself never blocks a call.
+
+```lua
+local key    = KEYS[1]
+local now    = tonumber(ARGV[1])
+local window = tonumber(ARGV[2])
+local limit  = tonumber(ARGV[3])
+local member = ARGV[4]
+
+redis.call('ZREMRANGEBYSCORE', key, 0, now - window)
+local count = redis.call('ZCARD', key)
+redis.call('ZADD', key, now, member)
+redis.call('EXPIRE', key, window)
+return count
+```
+
+## Integration
+
+The check runs in `process_backlog_leads()` just before `make_call()`, after all pre-call validations (blacklist, calling hours, pre-checks, phone validation) have passed. On limit exceeded: logs a warning and sends a Slack alert. If `OUTBOUND_RATE_LIMIT_BLOCK_ENABLED` is `True`, the call is skipped and the lead is released. Otherwise, the call proceeds.
+
+## Key Decisions
+
+### Window
+
+`ZREMRANGEBYSCORE` trims entries older than `now - OUTBOUND_RATE_LIMIT_WINDOW_SECONDS`. Configurable via env var.
+
+### Limit
+
+`count >= OUTBOUND_RATE_LIMIT_MAX_CALLS` triggers an alert. Default 7 means the 8th call in the window triggers the alert. Configurable via env var.
+
+### TTL
+
+EXPIRE resets on every call. Key survives for `window` seconds after last activity, then auto-deletes.
+
+### Why Lua over Pipeline
+
+The app runs on multiple pods. A pipeline is not atomic — two workers checking the same phone number simultaneously can both read `count=6` and both allow. The Lua script runs atomically inside Redis, eliminating this race.
+
+### Fail-open
+
+If Redis is down, the check is skipped. No alert, call proceeds.
+
+## Pipeline vs Lua — when to use which
+
+- Single calling process or low concurrency → use pipeline
+- Multiple parallel workers calling the same contacts → use Lua
+- Need maximum throughput with acceptable tiny race risk → use pipeline
+- Need strict correctness at any scale → use Lua
+
+## Redis Docs Reference
+
+- Sorted sets overview: https://redis.io/docs/latest/develop/data-types/sorted-sets/
+- ZREMRANGEBYSCORE: https://redis.io/docs/latest/commands/zremrangebyscore/
+- Pipeline: https://redis.io/docs/latest/develop/use/pipelining/
+- Lua scripting: https://redis.io/docs/latest/develop/interact/programmability/eval-intro/


### PR DESCRIPTION
## Summary
- Add `OUTBOUND_RATE_LIMIT_BLOCK_ENABLED` global config variable (default: `False`) to toggle between alert-only and blocking modes for outbound rate limiting
- When `True`, calls exceeding the per-phone-number rate limit are blocked (skipped + lead released)
- When `False` (default), existing alert-only behavior is preserved — calls proceed regardless

## Changes
- **`app/core/config/dynamic.py`** — Added `OUTBOUND_RATE_LIMIT_BLOCK_ENABLED()` dynamic config
- **`app/ai/voice/agents/breeze_buddy/services/rate_limiter.py`** — Renamed `process_outbound_rate_limit_alert` → `check_outbound_rate_limit_and_alert`, returns `bool` indicating whether call should proceed
- **`app/ai/voice/agents/breeze_buddy/managers/calls.py`** — Changed from fire-and-forget to `await`, skips call when blocked
- **`docs/breeze_buddy/calling_rate_limiter.md`** — Updated to reflect Phase 2 configurable blocking

## Config
| Variable | Default | Description |
|----------|---------|-------------|
| `OUTBOUND_RATE_LIMIT_BLOCK_ENABLED` | `False` | `True` = block calls, `False` = alert only |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implemented per-phone-number outbound call rate limiting with configurable call limits and time windows.
  * Added Slack alerts when rate limits are exceeded.
  * Added option to block calls when rate limits are exceeded (configurable).

* **Documentation**
  * Added documentation for the call rate limiting system.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->