### PR TITLE
feat: add Deepgram Nova-3 STT with SmartTurn and template-level STT configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -126,25 +126,14 @@ STT_PROVIDER="google"  # Options: google, assemblyai, openai, deepgram, soniox
 ENFORCED_OPENAI_STT_MODEL="whisper-1"
 AUTOMATIC_OPENAI_STT_PROMPT="Transcribe Indian languages accurately. Recognize and render Indian numbers (lakhs, crores, etc.) in their natural spoken form. Ensure business and financial terms are captured with precision. Always include proper names, numbers, and technical terms exactly as spoken, without modification."
 
-# Deepgram STT Configuration (when STT_PROVIDER=deepgram)
+# Deepgram STT Configuration
 DEEPGRAM_API_KEY=  # Your Deepgram API key
-DEEPGRAM_MODEL="nova-3-general"  # Deepgram model (nova-3-general recommended)
-DEEPGRAM_LANGUAGE="en"  # Single language for transcription (used when multi-language options are disabled)
-DEEPGRAM_ENDPOINTING=true  # Smart turn detection
-DEEPGRAM_VAD_EVENTS=true  # Voice activity detection events
-DEEPGRAM_UTTERANCE_END_MS=1000  # Wait time before utterance end (ms)
-DEEPGRAM_NO_DELAY=true  # Real-time processing
-DEEPGRAM_SMART_FORMAT=true  # Smart formatting (phones, dates, currency)
-DEEPGRAM_PUNCTUATE=true  # Add punctuation
-DEEPGRAM_NUMERALS=true  # Convert numbers to numerals (important for Indian numbers)
-DEEPGRAM_PROFANITY_FILTER=false  # Filter profanity (disabled for business)
-DEEPGRAM_DIARIZE=false  # Speaker identification (disabled for single speaker)
-
-# Language Detection (streaming API supports only 'multi' for auto-detection or single language)
-DEEPGRAM_AUTO_DETECT_LANGUAGE=false  # Auto-detect any language (uses 'multi' parameter)
+# All Deepgram tuning params (model, endpointing, language, etc.) are configured
+# via template-level stt_configuration.deepgram settings with sensible defaults.
+# See DeepgramSTTConfig in app/ai/voice/agents/breeze_buddy/template/types.py
 
 # Soniox STT Configuration (when STT_PROVIDER=soniox)
-# 🔥 SOLVES 0.5-SECOND PAUSE ISSUE: Soniox intelligent endpoint detection prevents mid-sentence cutoffs
+# SOLVES 0.5-SECOND PAUSE ISSUE: Soniox intelligent endpoint detection prevents mid-sentence cutoffs
 SONIOX_API_KEY=  # Your Soniox API key (required)
 SONIOX_MODEL="stt-rt-preview"  # Real-time optimized model
 SONIOX_LANGUAGE_HINTS="en"  # Language hints (comma-separated: en,hi for Indian English)

--- a/app/ai/voice/agents/automatic/stt/__init__.py
+++ b/app/ai/voice/agents/automatic/stt/__init__.py
@@ -25,18 +25,6 @@ from app.core.config.static import (
     ASSEMBLYAI_API_KEY,
     AUTOMATIC_OPENAI_STT_PROMPT,
     DEEPGRAM_API_KEY,
-    DEEPGRAM_AUTO_DETECT_LANGUAGE,
-    DEEPGRAM_DIARIZE,
-    DEEPGRAM_ENDPOINTING,
-    DEEPGRAM_LANGUAGE,
-    DEEPGRAM_MODEL,
-    DEEPGRAM_NO_DELAY,
-    DEEPGRAM_NUMERALS,
-    DEEPGRAM_PROFANITY_FILTER,
-    DEEPGRAM_PUNCTUATE,
-    DEEPGRAM_SMART_FORMAT,
-    DEEPGRAM_UTTERANCE_END_MS,
-    DEEPGRAM_VAD_EVENTS,
     ENABLE_OPENAI_FOR_MIA,
     ENFORCED_OPENAI_STT_MODEL,
     GOOGLE_CREDENTIALS_JSON,
@@ -135,23 +123,18 @@ async def get_stt_service(voice_name: Optional[str] = None):
         if not DEEPGRAM_API_KEY:
             raise ValueError("DEEPGRAM_API_KEY is required when STT_PROVIDER=deepgram")
 
-        # Pass raw config values - language configuration is handled internally by build_deepgram_stt
+        # Defaults match DeepgramSTTConfig in template types
         return build_deepgram_stt(
             DeepgramConfig(
                 api_key=DEEPGRAM_API_KEY,
-                model=DEEPGRAM_MODEL,
-                language=DEEPGRAM_LANGUAGE,
-                auto_detect_language=DEEPGRAM_AUTO_DETECT_LANGUAGE,
-                smart_format=DEEPGRAM_SMART_FORMAT,
-                punctuate=DEEPGRAM_PUNCTUATE,
-                endpointing=DEEPGRAM_ENDPOINTING,
-                vad_events=DEEPGRAM_VAD_EVENTS,
-                utterance_end_ms=DEEPGRAM_UTTERANCE_END_MS,
-                no_delay=DEEPGRAM_NO_DELAY,
+                model="nova-3-general",
+                language="en",
+                endpointing=25,
+                no_delay=True,
+                smart_format=True,
+                punctuate=True,
+                numerals=True,
                 interim_results=True,
-                profanity_filter=DEEPGRAM_PROFANITY_FILTER,
-                numerals=DEEPGRAM_NUMERALS,
-                diarize=DEEPGRAM_DIARIZE,
             )
         )
     elif STT_PROVIDER == "soniox":

--- a/app/ai/voice/agents/automatic/tools/internet/search.py
+++ b/app/ai/voice/agents/automatic/tools/internet/search.py
@@ -13,11 +13,15 @@ from app.core.logger import logger
 search_tool = {"google_search": {}}
 tools_list = [search_tool]
 
-gemini_llm = GoogleLLMService(
-    api_key=GEMINI_API_KEY,
-    model=GEMINI_SEARCH_RESULT_API_MODEL,
-    tools=tools_list,
-)
+gemini_llm: GoogleLLMService | None = None
+if GEMINI_API_KEY:
+    gemini_llm = GoogleLLMService(
+        api_key=GEMINI_API_KEY,
+        model=GEMINI_SEARCH_RESULT_API_MODEL,
+        tools=tools_list,
+    )
+else:
+    logger.warning("GEMINI_API_KEY not set — web search tool will be unavailable")
 
 
 # ---------- 2. Define a function that uses Gemini to perform web search ----------
@@ -26,6 +30,11 @@ async def gemini_search_fn(params: FunctionCallParams):
     if not query or not query.strip():
         logger.warning("Gemini search called with an empty query.")
         await params.result_callback({"error": "Search query cannot be empty."})
+        return
+
+    if gemini_llm is None:
+        logger.warning("Gemini search unavailable — GEMINI_API_KEY not configured")
+        await params.result_callback({"error": "Web search is not configured."})
         return
 
     logger.info(f"Performing Gemini search for query: {query}")

--- a/app/ai/voice/agents/breeze_buddy/agent/pipeline.py
+++ b/app/ai/voice/agents/breeze_buddy/agent/pipeline.py
@@ -4,7 +4,12 @@ from datetime import datetime
 from typing import Any, Callable, Optional
 from zoneinfo import ZoneInfo
 
+from pipecat.audio.turn.smart_turn.base_smart_turn import SmartTurnParams
+from pipecat.audio.turn.smart_turn.local_smart_turn_v3 import (
+    LocalSmartTurnAnalyzerV3,
+)
 from pipecat.audio.vad.silero import SileroVADAnalyzer
+from pipecat.audio.vad.vad_analyzer import VADParams
 from pipecat.observers.loggers.llm_log_observer import LLMLogObserver
 from pipecat.observers.loggers.metrics_log_observer import MetricsLogObserver
 from pipecat.observers.loggers.transcription_log_observer import (
@@ -32,8 +37,13 @@ from pipecat.turns.user_start import (
     TranscriptionUserTurnStartStrategy,
     VADUserTurnStartStrategy,
 )
+from pipecat.turns.user_stop import (
+    BaseUserTurnStopStrategy,
+    TurnAnalyzerUserTurnStopStrategy,
+)
 from pipecat.turns.user_turn_strategies import UserTurnStrategies
 
+from app.ai.voice.agents.breeze_buddy.agent.vad import TELEPHONY_SAMPLE_RATE
 from app.ai.voice.agents.breeze_buddy.llm import get_llm_service
 from app.ai.voice.agents.breeze_buddy.observability.tracing_setup import setup_tracing
 from app.ai.voice.agents.breeze_buddy.processors import (
@@ -49,6 +59,8 @@ from app.ai.voice.agents.breeze_buddy.template.types import (
     ConfigurationModel,
     InterruptionConfig,
     InterruptionMode,
+    SmartTurnConfig,
+    TurnDetectionMode,
 )
 from app.ai.voice.agents.breeze_buddy.tts import get_tts_service
 from app.core.config.static import (
@@ -94,19 +106,26 @@ async def create_services(
     Returns:
         Tuple of (stt_service, llm_service, tts_service)
     """
-    stt_language = getattr(configurations, "stt_language", None)
-    # Normalize list to comma-separated string for downstream compatibility
-    if isinstance(stt_language, list):
-        stt_language = ",".join(stt_language)
-    soniox_context = getattr(configurations, "soniox_context", None)
-    if stt_language:
-        logger.info(f"Using STT language from template: {stt_language}")
-    if soniox_context:
-        logger.info(f"Using Soniox context from template")
+    stt_configuration = getattr(configurations, "stt_configuration", None)
 
-    stt = await get_stt_service(
-        language_hints=stt_language, soniox_context=soniox_context
-    )
+    if stt_configuration:
+        logger.info(
+            f"Using template STT configuration: provider={stt_configuration.provider.value}"
+        )
+        stt = await get_stt_service(stt_configuration=stt_configuration)
+    else:
+        # Legacy path: build from scattered fields
+        stt_language = getattr(configurations, "stt_language", None)
+        if isinstance(stt_language, list):
+            stt_language = ",".join(stt_language)
+        soniox_context = getattr(configurations, "soniox_context", None)
+        if stt_language:
+            logger.info(f"Using STT language from template: {stt_language}")
+        if soniox_context:
+            logger.info("Using Soniox context from template")
+        stt = await get_stt_service(
+            language_hints=stt_language, soniox_context=soniox_context
+        )
 
     llm_config = getattr(configurations, "llm_configurations", None)
     llm = await get_llm_service(llm_config)
@@ -198,17 +217,32 @@ async def build_pipeline(
         getattr(configurations, "interruption", None) or InterruptionConfig()
     )
 
-    # User turn start strategies:
-    # 1. VADUserTurnStartStrategy: Primary detector, fires on VAD speech detection (~100ms).
-    #    Only included when vad_analyzer is provided (BREEZE_BUDDY_ENABLE_VAD=true).
-    #    First-one-wins semantics — if VAD fires first, transcription fallback is skipped.
-    # 2. TranscriptionUserTurnStartStrategy: Used as sole start strategy when VAD is disabled,
-    #    or as fallback for soft speech that VAD misses when VAD is enabled.
-    #    With use_interim=True, triggers on any interim transcription from Soniox.
-    # 3. MinWordsUserTurnStartStrategy: Replaces Transcription strategy when min_words is set.
-    #    Requires N words before triggering interruption while bot speaks; 1 word when bot is silent.
-    # 4. AccumulatingSpeechTimeoutStrategy(0.0): Triggers immediately when Soniox
-    #    sends a finalized transcript with <end> token (native semantic endpoint detection).
+    # --- Turn detection (from stt_configuration) ---
+    stt_config = getattr(configurations, "stt_configuration", None)
+    turn_detection_mode = (
+        stt_config.turn_detection if stt_config else TurnDetectionMode.STT_NATIVE
+    )
+    # STT_NATIVE fires immediately (0.0s). Only TIMEOUT honours configured value.
+    # The STTConfiguration validator already enforces this, but be explicit here.
+    user_speech_timeout = (
+        stt_config.user_speech_timeout
+        if stt_config and turn_detection_mode == TurnDetectionMode.TIMEOUT
+        else 0.0
+    )
+
+    # SmartTurn mode: auto-create Silero VAD (stop_secs=0.2) as trigger if no
+    # external VAD was provided.  SmartTurn needs is_speech signal from VAD.
+    # When no external VAD exists this is the telephony path (8 kHz sample rate).
+    if turn_detection_mode == TurnDetectionMode.SMART_TURN and vad_analyzer is None:
+        vad_analyzer = SileroVADAnalyzer(
+            sample_rate=TELEPHONY_SAMPLE_RATE,
+            params=VADParams(stop_secs=0.2),
+        )
+        logger.info(
+            "SmartTurn mode: auto-created Silero VAD (stop_secs=0.2) as trigger"
+        )
+
+    # --- User turn start strategies ---
     start_strategies: list[BaseUserTurnStartStrategy] = []
     if vad_analyzer is not None:
         start_strategies.append(VADUserTurnStartStrategy())
@@ -228,11 +262,47 @@ async def build_pipeline(
     else:
         start_strategies.append(TranscriptionUserTurnStartStrategy(use_interim=True))
 
+    # --- User turn stop strategy (driven by stt_configuration.turn_detection) ---
+    stop_strategies: list[BaseUserTurnStopStrategy] = []
+    if turn_detection_mode == TurnDetectionMode.SMART_TURN:
+        st = (
+            stt_config.smart_turn
+            if stt_config and stt_config.smart_turn
+            else SmartTurnConfig()
+        )
+        smart_turn_analyzer = LocalSmartTurnAnalyzerV3(
+            cpu_count=st.cpu_count,
+            params=SmartTurnParams(
+                stop_secs=st.stop_secs,
+                pre_speech_ms=st.pre_speech_ms,
+                max_duration_secs=st.max_duration_secs,
+            ),
+        )
+        stop_strategies = [
+            TurnAnalyzerUserTurnStopStrategy(turn_analyzer=smart_turn_analyzer)
+        ]
+        logger.info(
+            "Turn detection: SmartTurn ML (stop_secs={}, pre_speech_ms={}, "
+            "max_duration_secs={}, cpu_count={})",
+            st.stop_secs,
+            st.pre_speech_ms,
+            st.max_duration_secs,
+            st.cpu_count,
+        )
+    else:
+        # TIMEOUT and STT_NATIVE are the same strategy — only the timeout differs.
+        # STT_NATIVE uses 0.0 (fires immediately on finalized transcript, e.g. Soniox <end> token).
+        # TIMEOUT uses user_speech_timeout (waits after last transcript, resets on each new one).
+        stop_strategies = [
+            AccumulatingSpeechTimeoutStrategy(user_speech_timeout=user_speech_timeout)
+        ]
+        logger.info(
+            f"Turn detection: {turn_detection_mode.value} (user_speech_timeout={user_speech_timeout}s)"
+        )
+
     user_turn_strategies = UserTurnStrategies(
         start=start_strategies,
-        stop=[
-            AccumulatingSpeechTimeoutStrategy(user_speech_timeout=0.0),
-        ],
+        stop=stop_strategies,
     )
 
     # User mute strategies:

--- a/app/ai/voice/agents/breeze_buddy/stt/__init__.py
+++ b/app/ai/voice/agents/breeze_buddy/stt/__init__.py
@@ -1,8 +1,27 @@
+"""Breeze Buddy STT service creation.
+
+Central routing: accepts a normalized ``STTConfiguration`` from the template
+and casts it to the provider-specific builder config. Defaults are baked into
+the Pydantic models — no env/dynamic config needed (except API keys).
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
 from pipecat.transcriptions.language import Language
 
+from app.ai.voice.agents.breeze_buddy.template.types import (
+    DeepgramSTTConfig,
+    SonioxSTTConfig,
+    STTConfiguration,
+    STTProvider,
+)
 from app.ai.voice.stt import (
+    DeepgramConfig,
     SarvamConfig,
     SonioxConfig,
+    build_deepgram_stt,
     build_google_stt,
     build_openai_stt,
     build_sarvam_stt,
@@ -24,6 +43,7 @@ from app.core.config.static import (
     BREEZE_BUDDY_SONIOX_MODEL,
     BREEZE_BUDDY_SONIOX_VAD_FORCE_TURN_ENDPOINT,
     BREEZE_BUDDY_STT_SERVICE,
+    DEEPGRAM_API_KEY,
     GOOGLE_CREDENTIALS_JSON,
     OPENAI_STT_API_KEY,
     OPENAI_STT_MODEL,
@@ -34,88 +54,165 @@ from app.core.config.static import (
 from app.core.logger import logger
 
 
-async def get_stt_service(
-    language_hints: str | None = None, soniox_context: str | None = None
-):
-    """
-    Returns an STT service instance based on the environment configuration.
+def _normalize_language(language: str | list[str] | None) -> str | None:
+    """Normalize language to comma-separated string (for Soniox language_hints)."""
+    if language is None:
+        return None
+    if isinstance(language, list):
+        return ",".join(language)
+    return language
 
-    Args:
-        language_hints: Optional list of language codes (e.g., ["en", "hi"]) to help STT recognize specific languages.
-                       Only used with soniox STT service.
-        soniox_context: Optional Soniox STT context for speech recognition domain adaptation.
-                       If provided, overrides BREEZE_BUDDY_SONIOX_CONTEXT env var.
+
+def _deepgram_language(language: str | list[str] | None) -> str:
+    """Normalize language for Deepgram (single code only, not CSV).
+
+    Deepgram's ``language`` option accepts a single code (e.g. ``"en"``)
+    or ``"multi"`` for auto-detection — not comma-separated lists.
     """
-    if BREEZE_BUDDY_STT_SERVICE == "sarvam":
-        if not SARVAM_API_KEY:
-            raise ValueError(
-                "SARVAM_API_KEY is required when BREEZE_BUDDY_STT_SERVICE=sarvam"
+    if language is None:
+        return "en"
+    if isinstance(language, list):
+        if len(language) > 1:
+            logger.warning(
+                "Deepgram supports only a single language code; "
+                "using first value '{}' from {}",
+                language[0],
+                language,
             )
+        return language[0] if language else "en"
+    return language
 
-        # Get Breeze Buddy-specific dynamic config values from Redis
-        bb_sarvam_stt_model = await BB_SARVAM_STT_MODEL()
-        bb_sarvam_stt_language_code = await BB_SARVAM_STT_LANGUAGE_CODE()
-        bb_sarvam_stt_prompt = await BB_SARVAM_STT_PROMPT()
-        bb_sarvam_stt_vad_signals = await BB_SARVAM_STT_VAD_SIGNALS()
-        bb_sarvam_stt_high_vad_sensitivity = await BB_SARVAM_STT_HIGH_VAD_SENSITIVITY()
 
-        # Pass raw config values - model-specific logic is handled internally by build_sarvam_stt
+async def create_stt_from_config(config: STTConfiguration):
+    """Create STT service from normalized STTConfiguration.
+
+    Central routing: reads ``config.provider`` and casts the normalized
+    config to the provider-specific builder config. All tuning params
+    come from the template config with sensible defaults baked in.
+    """
+    if config.provider == STTProvider.DEEPGRAM:
+        if not DEEPGRAM_API_KEY:
+            raise ValueError("DEEPGRAM_API_KEY is required for deepgram STT")
+
+        # All defaults are in DeepgramSTTConfig — no env/dynamic lookup needed
+        dg = config.deepgram or DeepgramSTTConfig()
+
+        logger.info("Using Deepgram Nova-3 STT service for Breeze Buddy")
+        return build_deepgram_stt(
+            DeepgramConfig(
+                api_key=DEEPGRAM_API_KEY,
+                model=dg.model,
+                language=_deepgram_language(config.language),
+                auto_detect_language=dg.auto_detect_language,
+                smart_format=dg.smart_format,
+                punctuate=dg.punctuate,
+                endpointing=dg.endpointing_ms,
+                utterance_end_ms=dg.utterance_end_ms,  # None = disabled
+                no_delay=dg.no_delay,
+                interim_results=True,
+                profanity_filter=dg.profanity_filter,
+                numerals=dg.numerals,
+                diarize=dg.diarize,
+            )
+        )
+
+    if config.provider == STTProvider.SONIOX:
+        if not SONIOX_API_KEY:
+            raise ValueError("SONIOX_API_KEY is required for soniox STT")
+
+        sx = config.soniox
+        effective_context = (
+            sx.context if sx and sx.context else BREEZE_BUDDY_SONIOX_CONTEXT
+        )
+        effective_model = sx.model if sx and sx.model else BREEZE_BUDDY_SONIOX_MODEL
+
+        if sx and sx.context:
+            logger.info("Using template-specific Soniox context")
+
+        language = _normalize_language(config.language)
+        return build_soniox_stt(
+            SonioxConfig(
+                api_key=SONIOX_API_KEY,
+                model=effective_model,
+                vad_force_turn_endpoint=BREEZE_BUDDY_SONIOX_VAD_FORCE_TURN_ENDPOINT,
+                language_hints=language or BREEZE_BUDDY_SONIOX_LANGUAGE_HINTS,
+                context_json=effective_context,
+                enable_non_final_tokens=BREEZE_BUDDY_SONIOX_ENABLE_NON_FINAL_TOKENS,
+                max_non_final_tokens_duration_ms=BREEZE_BUDDY_SONIOX_MAX_NON_FINAL_TOKENS_DURATION_MS,
+                max_endpoint_delay_ms=BREEZE_BUDDY_SONIOX_MAX_ENDPOINT_DELAY_MS,
+                log_context="Breeze Buddy",
+                language_hints_strict=bool(language),
+            )
+        )
+
+    if config.provider == STTProvider.SARVAM:
+        if not SARVAM_API_KEY:
+            raise ValueError("SARVAM_API_KEY is required for sarvam STT")
+
+        sv = config.sarvam
+        bb_model = sv.model if sv and sv.model else await BB_SARVAM_STT_MODEL()
+        bb_lang = (
+            sv.language_code
+            if sv and sv.language_code
+            else await BB_SARVAM_STT_LANGUAGE_CODE()
+        )
+
         return build_sarvam_stt(
             SarvamConfig(
                 api_key=SARVAM_API_KEY,
-                model=bb_sarvam_stt_model,
+                model=bb_model,
                 sample_rate=SAMPLE_RATE,
-                language_code=bb_sarvam_stt_language_code,
-                prompt=bb_sarvam_stt_prompt,
-                vad_signals=bb_sarvam_stt_vad_signals,
-                high_vad_sensitivity=bb_sarvam_stt_high_vad_sensitivity,
+                language_code=bb_lang,
+                prompt=await BB_SARVAM_STT_PROMPT(),
+                vad_signals=await BB_SARVAM_STT_VAD_SIGNALS(),
+                high_vad_sensitivity=await BB_SARVAM_STT_HIGH_VAD_SENSITIVITY(),
             )
         )
-    elif BREEZE_BUDDY_STT_SERVICE == "openai":
+
+    if config.provider == STTProvider.OPENAI:
         if not OPENAI_STT_API_KEY:
-            raise ValueError(
-                "OPENAI_STT_API_KEY is required when BREEZE_BUDDY_STT_SERVICE=openai"
-            )
-        logger.info("Using OpenAI STT service for Breeze Buddy voice")
+            raise ValueError("OPENAI_STT_API_KEY is required for openai STT")
+        logger.info("Using OpenAI STT service for Breeze Buddy")
         return build_openai_stt(
             api_key=OPENAI_STT_API_KEY,
             model=OPENAI_STT_MODEL,
             language=Language.EN,
             temperature=0.0,
         )
-    elif BREEZE_BUDDY_STT_SERVICE == "soniox":
-        if not SONIOX_API_KEY:
-            raise ValueError(
-                "SONIOX_API_KEY is required when BREEZE_BUDDY_STT_SERVICE=soniox"
-            )
-        # Priority: Template context > Env context > None
-        effective_context = (
-            soniox_context
-            if soniox_context is not None
-            else BREEZE_BUDDY_SONIOX_CONTEXT
-        )
-        if soniox_context:
-            logger.info("Using template-specific Soniox context")
 
-        # Pass raw config values - language hints parsing is handled internally by build_soniox_stt
-        return build_soniox_stt(
-            SonioxConfig(
-                api_key=SONIOX_API_KEY,
-                model=BREEZE_BUDDY_SONIOX_MODEL,
-                vad_force_turn_endpoint=BREEZE_BUDDY_SONIOX_VAD_FORCE_TURN_ENDPOINT,
-                language_hints=(
-                    language_hints
-                    if language_hints is not None
-                    else BREEZE_BUDDY_SONIOX_LANGUAGE_HINTS
-                ),
-                context_json=effective_context,
-                enable_non_final_tokens=BREEZE_BUDDY_SONIOX_ENABLE_NON_FINAL_TOKENS,
-                max_non_final_tokens_duration_ms=BREEZE_BUDDY_SONIOX_MAX_NON_FINAL_TOKENS_DURATION_MS,
-                max_endpoint_delay_ms=BREEZE_BUDDY_SONIOX_MAX_ENDPOINT_DELAY_MS,
-                log_context="Breeze Buddy",
-                language_hints_strict=True if language_hints else False,
-            )
-        )
-    else:
-        logger.info("Using Google STT service with VAD-based turn detection")
-        return build_google_stt(credentials_json=GOOGLE_CREDENTIALS_JSON)
+    # Default: Google
+    logger.info("Using Google STT service for Breeze Buddy")
+    return build_google_stt(credentials_json=GOOGLE_CREDENTIALS_JSON)
+
+
+async def get_stt_service(
+    language_hints: str | None = None,
+    soniox_context: str | None = None,
+    stt_configuration: Optional[STTConfiguration] = None,
+):
+    """Returns an STT service instance.
+
+    If ``stt_configuration`` is provided (from template), routes through
+    :func:`create_stt_from_config`. Otherwise falls back to env-var-based
+    provider selection (legacy path).
+    """
+    # --- New path: template-level STTConfiguration ---
+    if stt_configuration is not None:
+        return await create_stt_from_config(stt_configuration)
+
+    # --- Legacy path: env var BREEZE_BUDDY_STT_SERVICE ---
+    provider_map = {
+        "soniox": STTProvider.SONIOX,
+        "deepgram": STTProvider.DEEPGRAM,
+        "sarvam": STTProvider.SARVAM,
+        "openai": STTProvider.OPENAI,
+        "google": STTProvider.GOOGLE,
+    }
+    provider = provider_map.get(BREEZE_BUDDY_STT_SERVICE, STTProvider.GOOGLE)
+
+    legacy_config = STTConfiguration(
+        provider=provider,
+        language=language_hints,
+        soniox=SonioxSTTConfig(context=soniox_context) if soniox_context else None,
+    )
+    return await create_stt_from_config(legacy_config)

--- a/app/ai/voice/agents/breeze_buddy/template/types.py
+++ b/app/ai/voice/agents/breeze_buddy/template/types.py
@@ -5,9 +5,10 @@ Pydantic models for the dynamic workflow engine.
 from enum import Enum
 from typing import Any, Dict, List, Optional
 
-from pydantic import BaseModel, ConfigDict, Field, SecretStr
+from pydantic import BaseModel, ConfigDict, Field, SecretStr, model_validator
 
 from app.ai.voice.llm.types import LLMConfiguration
+from app.core.deprecation import log_deprecated_fields
 
 
 class ActionType(str, Enum):
@@ -31,6 +32,214 @@ class VadConfig(BaseModel):
     min_volume: Optional[float] = Field(
         None, ge=0.0, description="Minimum volume threshold for VAD"
     )
+
+
+# ---------------------------------------------------------------------------
+# STT Configuration (normalized, provider-agnostic)
+# ---------------------------------------------------------------------------
+
+
+class STTProvider(str, Enum):
+    """Supported STT providers."""
+
+    SONIOX = "soniox"
+    DEEPGRAM = "deepgram"
+    SARVAM = "sarvam"
+    OPENAI = "openai"
+    GOOGLE = "google"
+
+
+class SonioxSTTConfig(BaseModel):
+    """Soniox-specific STT settings."""
+
+    context: Optional[str] = Field(
+        None,
+        description="Soniox context JSON for domain adaptation "
+        "(business terms, product names). Overrides env default if set.",
+    )
+    model: Optional[str] = Field(
+        None, description="Soniox model (e.g. 'stt-rt-v4'). Defaults from env."
+    )
+
+
+class DeepgramSTTConfig(BaseModel):
+    """Deepgram-specific STT settings.
+
+    All params have sensible defaults — only override what you need.
+    """
+
+    model: str = Field("nova-3-general", description="Deepgram model.")
+    endpointing_ms: bool | int = Field(
+        25,
+        description="Silence threshold before endpointing fires. "
+        "Integer for exact ms (e.g. 25), True for Deepgram default (10ms), "
+        "False to disable. Low values (25ms) are ideal with SmartTurn.",
+    )
+    utterance_end_ms: Optional[int] = Field(
+        None,
+        ge=1000,
+        description="Max silence (ms) after last word before UtteranceEnd event. "
+        "None = disabled (recommended with SmartTurn). "
+        "Deepgram minimum is 1000ms when enabled.",
+    )
+    no_delay: bool = Field(True, description="Real-time processing with minimal delay.")
+    smart_format: bool = Field(
+        True, description="Smart formatting (phone numbers, dates, currency)."
+    )
+    punctuate: bool = Field(True, description="Add punctuation to transcription.")
+    numerals: bool = Field(
+        True,
+        description="Convert spoken numbers to numerals (critical for Indian lakhs/crores).",
+    )
+    profanity_filter: bool = Field(
+        False, description="Filter profanity (disabled for business context)."
+    )
+    diarize: bool = Field(
+        False, description="Speaker diarization (disabled for single-speaker)."
+    )
+    auto_detect_language: bool = Field(
+        False, description="Auto-detect language (uses 'multi' parameter)."
+    )
+
+
+class SarvamSTTConfig(BaseModel):
+    """Sarvam-specific STT settings."""
+
+    model: Optional[str] = Field(
+        None, description="Sarvam model (e.g. 'saarika:v2.5'). Defaults from env."
+    )
+    language_code: Optional[str] = Field(
+        None, description="Sarvam language code. Defaults from env."
+    )
+
+
+class SmartTurnConfig(BaseModel):
+    """SmartTurn ML turn-detection settings.
+
+    Controls the ONNX-based Whisper model that analyzes audio prosody and
+    intonation to predict when the user is done speaking.  Only used when
+    ``turn_detection='smart_turn'``.
+    """
+
+    stop_secs: float = Field(
+        3.0,
+        ge=0.0,
+        description="Max silence (seconds) before forcing turn end even if "
+        "the ML model hasn't triggered. Safety timeout.",
+    )
+    pre_speech_ms: float = Field(
+        500.0,
+        ge=0.0,
+        description="Milliseconds of audio to include before speech starts, "
+        "giving the ML model extra context for better predictions.",
+    )
+    max_duration_secs: float = Field(
+        8.0,
+        ge=1.0,
+        description="Max audio segment duration (seconds) fed to the ONNX model. "
+        "Longer segments give more context but increase inference time.",
+    )
+    cpu_count: int = Field(
+        1,
+        ge=1,
+        description="Number of CPUs for ONNX Runtime inference. "
+        "Keep at 1 for single-CPU deployments.",
+    )
+
+
+class TurnDetectionMode(str, Enum):
+    """How the pipeline detects when the user is done speaking.
+
+    STT_NATIVE:  Provider handles endpoint detection natively.
+                 Soniox sends <end> token; pipeline fires immediately.
+                 Default — matches current production behavior.
+    SMART_TURN:  SmartTurn ML model (Whisper-based, 8 MB ONNX) analyzes audio
+                 prosody / intonation to predict turn completion.
+                 Auto-enables Silero VAD (stop_secs=0.2) as trigger.
+                 Best for Deepgram Nova-3.
+    TIMEOUT:     Simple timer after last finalized transcript.  Resets on each
+                 new transcript.  Configurable via user_speech_timeout.
+    """
+
+    STT_NATIVE = "stt_native"
+    SMART_TURN = "smart_turn"
+    TIMEOUT = "timeout"
+
+
+class STTConfiguration(BaseModel):
+    """Template-level STT configuration.
+
+    Normalized, provider-agnostic model. Provider-specific settings go in the
+    matching nested config (``soniox``, ``deepgram``, ``sarvam``).
+    Turn detection mode is included here because it's tightly coupled to the
+    provider choice (soniox → stt_native, deepgram → smart_turn).
+
+    When not set on a template, falls back to BREEZE_BUDDY_STT_SERVICE env var
+    and provider-specific env defaults.
+
+    Examples::
+
+        # Deepgram Nova-3 with SmartTurn
+        {"provider": "deepgram", "language": "en",
+         "turn_detection": "smart_turn",
+         "deepgram": {"model": "nova-3-general"}}
+
+        # Soniox with domain context (default turn detection)
+        {"provider": "soniox", "language": ["en", "hi"],
+         "soniox": {"context": "{...}"}}
+
+        # Deepgram with simple timeout
+        {"provider": "deepgram", "turn_detection": "timeout",
+         "user_speech_timeout": 0.5}
+
+        # Minimal — all defaults from env
+        {"provider": "soniox"}
+    """
+
+    provider: STTProvider = Field(
+        STTProvider.SONIOX,
+        description="STT provider to use for this template.",
+    )
+    language: Optional[str | list[str]] = Field(
+        None,
+        description="Language code(s) for STT. String or list "
+        "(e.g. 'en', ['en', 'hi']). Provider-specific handling.",
+    )
+    payload_based_language_selection: bool = Field(
+        False,
+        description="Use LLM to detect language from lead payload.",
+    )
+    turn_detection: TurnDetectionMode = Field(
+        TurnDetectionMode.STT_NATIVE,
+        description="Turn detection strategy. stt_native for Soniox, "
+        "smart_turn for Deepgram Nova-3 (ML-based), timeout for simple timer.",
+    )
+    user_speech_timeout: float = Field(
+        0.3,
+        ge=0.0,
+        description="Seconds to wait after last finalized transcript before "
+        "ending turn. Only used when turn_detection='timeout'.",
+    )
+
+    # Provider-specific — only the matching one is used at runtime
+    soniox: Optional[SonioxSTTConfig] = None
+    deepgram: Optional[DeepgramSTTConfig] = None
+    sarvam: Optional[SarvamSTTConfig] = None
+
+    # SmartTurn ML config — only used when turn_detection='smart_turn'
+    smart_turn: Optional[SmartTurnConfig] = None
+
+    @model_validator(mode="after")
+    def _normalize_user_speech_timeout(self) -> "STTConfiguration":
+        """Force user_speech_timeout=0.0 for non-TIMEOUT modes.
+
+        STT_NATIVE fires immediately on finalized transcript (0.0s).
+        SMART_TURN uses its own ML-based detection (timeout irrelevant).
+        Only TIMEOUT mode honors the configured user_speech_timeout.
+        """
+        if self.turn_detection != TurnDetectionMode.TIMEOUT:
+            self.user_speech_timeout = 0.0
+        return self
 
 
 class NoiseFilterType(str, Enum):
@@ -281,6 +490,28 @@ class UserIdleHandlingConfig(BaseModel):
 
 
 class ConfigurationModel(BaseModel):
+    # --- STT (provider + turn detection) ---
+    stt_configuration: Optional[STTConfiguration] = Field(
+        None,
+        description="STT provider, language, turn detection, and provider-specific "
+        "config. When set, takes priority over legacy stt_language / soniox_context fields.",
+    )
+
+    # --- Legacy STT fields (backward compat — prefer stt_configuration) ---
+    stt_language: Optional[str | list[str]] = Field(
+        None,
+        description="DEPRECATED: Use stt_configuration.language instead.",
+    )
+    soniox_context: Optional[str] = Field(
+        None,
+        description="DEPRECATED: Use stt_configuration.soniox.context instead.",
+    )
+    payload_based_language_selection: bool = Field(
+        False,
+        description="DEPRECATED: Use stt_configuration.payload_based_language_selection instead.",
+    )
+
+    # --- TTS ---
     tts_voice_name: Optional[TTSVoiceName] = None
     mira_voice_id: Optional[str] = (
         None  # DEPRECATED: Use cartesia_voice_configurations.voice_id instead
@@ -294,12 +525,8 @@ class ConfigurationModel(BaseModel):
     tts_selection_config: Optional[TTSSelectionConfig] = (
         None  # LLM-based TTS provider selection config
     )
-    stt_language: Optional[str | list[str]] = None
-    soniox_context: Optional[str] = Field(
-        None,
-        description="Soniox STT context for speech recognition domain adaptation (e.g., business terms, product names). Overrides BREEZE_BUDDY_SONIOX_CONTEXT env var if set.",
-    )
-    payload_based_language_selection: bool = False
+
+    # --- Audio ---
     enable_background_sound: bool = False
     background_sound_file: Optional[BackgroundSoundFile] = None
     background_sound_volume: float = 2.0
@@ -342,6 +569,46 @@ class ConfigurationModel(BaseModel):
         None,
         description="LLM provider and model configuration",
     )
+
+    @model_validator(mode="after")
+    def _backfill_legacy_from_stt_config(self):
+        """Mirror stt_configuration values to legacy fields for backward compat.
+
+        Legacy consumers (flow.py, language_detector.py) read top-level
+        stt_language / payload_based_language_selection. When stt_configuration
+        is set but legacy fields are not explicitly provided, backfill so
+        those consumers keep working.
+        """
+        if self.stt_configuration is None:
+            return self
+        stt = self.stt_configuration
+        if "stt_language" not in self.model_fields_set and stt.language is not None:
+            self.stt_language = stt.language
+        if (
+            "soniox_context" not in self.model_fields_set
+            and stt.soniox is not None
+            and stt.soniox.context is not None
+        ):
+            self.soniox_context = stt.soniox.context
+        if (
+            "payload_based_language_selection" not in self.model_fields_set
+            and stt.payload_based_language_selection
+        ):
+            self.payload_based_language_selection = stt.payload_based_language_selection
+        return self
+
+    @model_validator(mode="after")
+    def _warn_deprecated_fields(self):
+        log_deprecated_fields(
+            self,
+            {
+                "stt_language": "stt_configuration.language",
+                "soniox_context": "stt_configuration.soniox.context",
+                "payload_based_language_selection": "stt_configuration.payload_based_language_selection",
+                "mira_voice_id": "cartesia_voice_configurations.voice_id",
+            },
+        )
+        return self
 
 
 class FlowAction(BaseModel):

--- a/app/ai/voice/stt/deepgram.py
+++ b/app/ai/voice/stt/deepgram.py
@@ -1,8 +1,14 @@
-"""Deepgram STT config and builder."""
+"""Deepgram STT config and builder.
+
+Uses pipecat's DeepgramSTTService with Nova-3 model.
+VAD is handled by Silero in the pipeline — Deepgram's built-in vad_events
+is deprecated (pipecat v0.0.99+) and not used here.
+"""
 
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Union
 
 from deepgram import LiveOptions
 from pipecat.services.deepgram.stt import DeepgramSTTService
@@ -14,35 +20,44 @@ __all__ = ["DeepgramConfig", "build_deepgram_stt"]
 
 @dataclass
 class DeepgramConfig:
-    """Configuration for Deepgram STT.
+    """Configuration for Deepgram STT (Nova-3).
 
     Language configuration is determined automatically:
     - If auto_detect_language is True: uses "multi" for automatic detection
     - If auto_detect_language is False: uses the specified language code
+
+    Latency-critical parameters:
+    - endpointing: ms of silence before Deepgram finalises a transcript.
+      Integer for exact ms (e.g. 25), True for Deepgram default (~480ms),
+      False to disable.
+    - utterance_end_ms: additional silence window (ms) after endpointing
+      before UtteranceEnd event fires. None = disabled (no UtteranceEnd events).
     """
 
     api_key: str
-    model: str
-    language: str
-    auto_detect_language: bool
-    smart_format: bool
-    punctuate: bool
-    endpointing: int
-    vad_events: bool
-    utterance_end_ms: int
-    no_delay: bool
-    interim_results: bool
-    profanity_filter: bool
-    numerals: bool
-    diarize: bool
+    model: str = "nova-3-general"
+    language: str = "en"
+    auto_detect_language: bool = False
+    smart_format: bool = False
+    punctuate: bool = True
+    endpointing: Union[int, bool] = True
+    utterance_end_ms: int | None = None
+    no_delay: bool = True
+    interim_results: bool = True
+    profanity_filter: bool = False
+    numerals: bool = True
+    diarize: bool = False
 
 
-def build_deepgram_stt(config: DeepgramConfig):
+def build_deepgram_stt(config: DeepgramConfig) -> DeepgramSTTService:
     """Create a Deepgram STT service.
 
     Automatically determines language configuration:
     - If auto_detect_language is True: uses "multi" for automatic detection
     - Otherwise: uses the configured language code
+
+    Note: vad_events is intentionally omitted — deprecated in pipecat v0.0.99.
+    Pipeline-level Silero VAD handles voice activity detection instead.
     """
     # Determine language configuration based on settings
     if config.auto_detect_language:
@@ -52,26 +67,27 @@ def build_deepgram_stt(config: DeepgramConfig):
         language_config = config.language  # Single language
         logger.debug(f"Deepgram using single language: {language_config}")
 
-    live_options = LiveOptions(
+    live_opts: dict = dict(
         model=config.model,
         language=language_config,
         smart_format=config.smart_format,
         punctuate=config.punctuate,
         endpointing=config.endpointing,
-        vad_events=config.vad_events,
-        utterance_end_ms=str(config.utterance_end_ms),
         no_delay=config.no_delay,
         interim_results=config.interim_results,
         profanity_filter=config.profanity_filter,
         numerals=config.numerals,
         diarize=config.diarize,
     )
+    if config.utterance_end_ms is not None:
+        live_opts["utterance_end_ms"] = str(config.utterance_end_ms)
+    live_options = LiveOptions(**live_opts)
 
     logger.info(
-        "Using Deepgram STT service with model: %s, language: %s (VAD: %s, Endpointing: %s)",
+        "Using Deepgram STT service with model: {}, language: {}, endpointing: {}, utterance_end_ms: {}",
         config.model,
         language_config,
-        config.vad_events,
         config.endpointing,
+        config.utterance_end_ms,
     )
     return DeepgramSTTService(api_key=config.api_key, live_options=live_options)

--- a/app/core/config/static.py
+++ b/app/core/config/static.py
@@ -168,47 +168,10 @@ ENABLE_OPENAI_FOR_MIA = (
     os.environ.get("ENABLE_OPENAI_FOR_MIA", "false").lower() == "true"
 )
 
-# --- Deepgram STT Configuration ---
-DEEPGRAM_API_KEY = os.getenv(
-    "DEEPGRAM_API_KEY"
-)  # Required API key for Deepgram authentication
-DEEPGRAM_MODEL = os.environ.get(
-    "DEEPGRAM_MODEL", "nova-3-general"
-)  # Deepgram model (nova-3-general recommended for balanced accuracy/speed)
-DEEPGRAM_LANGUAGE = os.environ.get(
-    "DEEPGRAM_LANGUAGE", "en"
-)  # Language code for transcription (en, en-US, en-IN, etc.)
-DEEPGRAM_ENDPOINTING = (
-    os.environ.get("DEEPGRAM_ENDPOINTING", "true").lower() == "true"
-)  # Enable smart endpointing for automatic turn detection
-DEEPGRAM_VAD_EVENTS = (
-    os.environ.get("DEEPGRAM_VAD_EVENTS", "true").lower() == "true"
-)  # Enable Voice Activity Detection events (SpeechStarted/UtteranceEnd)
-DEEPGRAM_UTTERANCE_END_MS = int(
-    os.environ.get("DEEPGRAM_UTTERANCE_END_MS", "1000")
-)  # Milliseconds to wait before considering utterance ended
-DEEPGRAM_NO_DELAY = (
-    os.environ.get("DEEPGRAM_NO_DELAY", "true").lower() == "true"
-)  # Enable real-time processing with minimal delay
-DEEPGRAM_SMART_FORMAT = (
-    os.environ.get("DEEPGRAM_SMART_FORMAT", "true").lower() == "true"
-)  # Apply smart formatting (phone numbers, dates, currency)
-DEEPGRAM_PUNCTUATE = (
-    os.environ.get("DEEPGRAM_PUNCTUATE", "true").lower() == "true"
-)  # Add punctuation to transcription for readability
-DEEPGRAM_NUMERALS = (
-    os.environ.get("DEEPGRAM_NUMERALS", "true").lower() == "true"
-)  # Convert spoken numbers to numerals (critical for Indian lakhs/crores)
-DEEPGRAM_PROFANITY_FILTER = (
-    os.environ.get("DEEPGRAM_PROFANITY_FILTER", "false").lower() == "true"
-)  # Filter profanity (disabled for business context)
-DEEPGRAM_DIARIZE = (
-    os.environ.get("DEEPGRAM_DIARIZE", "false").lower() == "true"
-)  # Enable speaker diarization (disabled for single-speaker voice agent)
-# Language detection options (streaming API only supports 'multi' for auto-detection or single language)
-DEEPGRAM_AUTO_DETECT_LANGUAGE = (
-    os.environ.get("DEEPGRAM_AUTO_DETECT_LANGUAGE", "false").lower() == "true"
-)  # Enable automatic language detection (uses 'multi' parameter)
+# --- Deepgram STT ---
+# Only API key lives here. All tuning params are in DeepgramSTTConfig (template)
+# with sensible defaults — no env vars needed.
+DEEPGRAM_API_KEY = os.getenv("DEEPGRAM_API_KEY")
 
 # --- Sarvam STT & TTS Configuration ---
 SARVAM_API_KEY = os.getenv("SARVAM_API_KEY")
@@ -356,7 +319,7 @@ BREEZE_BUDDY_VAD_MIN_VOLUME = float(
 )  # More tolerant for soft voice
 BREEZE_BUDDY_STT_SERVICE = os.getenv(
     "BREEZE_BUDDY_STT_SERVICE", "soniox"
-).lower()  # "google" or "openai"
+).lower()  # "soniox", "sarvam", "openai", "deepgram", or "google"
 
 # Session inactivity timeout
 AUTOMATIC_SESSION_INACTIVITY_TIMEOUT = float(

--- a/app/core/deprecation.py
+++ b/app/core/deprecation.py
@@ -1,0 +1,147 @@
+"""Deprecation utilities with structured logging.
+
+Provides a function decorator and a Pydantic model helper that log
+deprecation warnings with full log context (lead_id, call_sid, etc.)
+automatically via the loguru patcher.
+
+Usage — function/method::
+
+    from app.core.deprecation import deprecated
+
+    @deprecated("Use create_stt_from_config() instead")
+    async def old_function():
+        ...
+
+Usage — Pydantic model fields::
+
+    from app.core.deprecation import log_deprecated_fields
+
+    class MyModel(BaseModel):
+        old_field: Optional[str] = None  # deprecated
+
+        @model_validator(mode="after")
+        def _warn_deprecated(self):
+            log_deprecated_fields(self, {
+                "old_field": "new_config.field",
+            })
+            return self
+"""
+
+from __future__ import annotations
+
+import functools
+import inspect
+from typing import Any, Callable, Dict
+
+from pydantic import BaseModel
+
+from app.core.logger import logger
+
+# Track which deprecations have been logged per-process to avoid log spam
+# for module-level singletons. Per-call deprecations (Pydantic models) are
+# intentionally NOT deduped — each occurrence is useful for tracking migration.
+_warned_functions: set[str] = set()
+
+
+def deprecated(
+    reason: str,
+    *,
+    replacement: str | None = None,
+) -> Callable:
+    """Decorator that logs a deprecation warning on first use per process.
+
+    Works with both sync and async functions/methods. The warning includes
+    full log context (lead_id, call_sid, etc.) automatically.
+
+    Args:
+        reason: Why this is deprecated and what happened.
+        replacement: What to use instead (shown in log message).
+
+    Example::
+
+        @deprecated("Legacy env-var routing", replacement="create_stt_from_config()")
+        async def get_stt_service(language_hints=None):
+            ...
+    """
+
+    def decorator(func: Callable) -> Callable:
+        qualname = func.__qualname__
+        module = func.__module__
+
+        def _log_once():
+            key = f"{module}.{qualname}"
+            if key in _warned_functions:
+                return
+            _warned_functions.add(key)
+
+            parts = [f"DEPRECATED: {qualname}() — {reason}"]
+            if replacement:
+                parts.append(f"Use {replacement} instead.")
+            logger.warning(" ".join(parts))
+
+        if inspect.iscoroutinefunction(func):
+
+            @functools.wraps(func)
+            async def async_wrapper(*args: Any, **kwargs: Any) -> Any:
+                _log_once()
+                return await func(*args, **kwargs)
+
+            return async_wrapper
+
+        @functools.wraps(func)
+        def sync_wrapper(*args: Any, **kwargs: Any) -> Any:
+            _log_once()
+            return func(*args, **kwargs)
+
+        return sync_wrapper
+
+    return decorator
+
+
+def log_deprecated_fields(
+    instance: BaseModel,
+    field_map: Dict[str, str],
+) -> None:
+    """Log warnings for deprecated Pydantic fields that were explicitly set.
+
+    Only fires when a field was present in the input data (not for default
+    values). Each occurrence is logged — useful in production to track which
+    templates still use legacy fields.
+
+    The log automatically includes full context (lead_id, call_sid, etc.)
+    via the loguru patcher.
+
+    Args:
+        instance: The Pydantic model instance to check.
+        field_map: Mapping of ``{deprecated_field: replacement_path}``.
+
+    Example::
+
+        class ConfigurationModel(BaseModel):
+            stt_language: Optional[str] = None
+
+            @model_validator(mode="after")
+            def _warn_deprecated(self):
+                log_deprecated_fields(self, {
+                    "stt_language": "stt_configuration.language",
+                    "soniox_context": "stt_configuration.soniox.context",
+                })
+                return self
+    """
+    for old_field, new_path in field_map.items():
+        if old_field in instance.model_fields_set:
+            value = getattr(instance, old_field, None)
+            # Log metadata only — raw values may contain sensitive data
+            # (IDs, context JSON, etc.)
+            type_name = type(value).__name__ if value is not None else "NoneType"
+            try:
+                length = len(str(value)) if value is not None else 0
+            except Exception:
+                length = -1
+            logger.warning(
+                "Deprecated field '{}' is set (type: {}, length: {}). Use '{}' instead.",
+                old_field,
+                type_name,
+                length,
+                new_path,
+            )


### PR DESCRIPTION
## Summary
- **Normalized STT configuration**: New `stt_configuration` field in template `ConfigurationModel` — single source of truth for provider, language, turn detection, and provider-specific tuning (replaces scattered `stt_language`, `soniox_context`, `payload_based_language_selection`)
- **Deepgram Nova-3 support**: Full `DeepgramSTTConfig` with all tuning params (endpointing, utterance_end, smart_format, numerals, etc.) with sensible defaults baked in — no env/dynamic vars needed
- **SmartTurn ML turn detection**: `TurnDetectionMode.SMART_TURN` uses pipecat's `LocalSmartTurnAnalyzerV3` (8MB ONNX, Whisper-based) for prosody/intonation-based turn detection; auto-creates lightweight Silero VAD as trigger
- **Deprecation utilities**: New `app/core/deprecation.py` with `@deprecated` decorator and `log_deprecated_fields()` Pydantic helper with structured logging
- **Deepgram deprecation fixes**: Removed deprecated `vad_events` (pipecat v0.0.99+), fixed `endpointing` type to support int|bool
- **Gemini graceful skip**: `GoogleLLMService` no longer crashes on missing `GEMINI_API_KEY` — logs warning and keeps server running
- **Config cleanup**: Removed all Deepgram tuning vars from static/dynamic config — centralized in `DeepgramSTTConfig` template model

### Template JSON examples

**Deepgram Nova-3 with SmartTurn:**
```json
{
  "stt_configuration": {
    "provider": "deepgram",
    "language": "en",
    "turn_detection": "smart_turn",
    "deepgram": {"model": "nova-3-general"}
  }
}
```

**Soniox (current default — no change needed):**
```json
{
  "stt_configuration": {
    "provider": "soniox",
    "language": ["en", "hi"],
    "soniox": {"context": "{...}"}
  }
}
```

**No `stt_configuration` at all → 100% backward compatible** (falls back to `BREEZE_BUDDY_STT_SERVICE` env var)

## Test plan
- [ ] Verify existing Soniox templates work unchanged (no `stt_configuration` set)
- [ ] Verify legacy `stt_language` / `soniox_context` fields still work with deprecation warnings
- [ ] Test Deepgram Nova-3 with `BREEZE_BUDDY_STT_SERVICE=deepgram` (legacy path)
- [ ] Test Deepgram via template `stt_configuration` with `turn_detection: smart_turn`
- [ ] Test Deepgram via template `stt_configuration` with `turn_detection: timeout`
- [ ] Verify SmartTurn auto-creates Silero VAD when no VAD is provided
- [ ] Verify server starts without `GEMINI_API_KEY` set (graceful skip)
- [ ] Verify deprecation warnings appear in logs for legacy fields
- [ ] Confirm CI passes (black, isort, autoflake, pyrefly, single commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable turn detection modes (Smart Turn, Timeout-based) for improved voice interaction control
  * Introduced unified STT configuration system supporting Deepgram, Soniox, Sarvam, OpenAI, and Google providers

* **Bug Fixes**
  * Fixed Gemini web-search tool graceful degradation when API key is unavailable

* **Chores**
  * Consolidated Deepgram configuration with sensible defaults
  * Deprecated legacy STT configuration fields in favor of provider-specific templates

<!-- end of auto-generated comment: release notes by coderabbit.ai -->