### PR TITLE
feat: fix Call Time calculation

### DIFF
--- a/app/api/routers/breeze_buddy/analytics/handlers.py
+++ b/app/api/routers/breeze_buddy/analytics/handlers.py
@@ -211,6 +211,7 @@ async def get_call_details_analytics(
                 attempt_count=tracker.get("attempt_count"),
                 cost=tracker.get("cost"),
                 payload=payload,
+                call_initiated_time=tracker.get("call_initiated_time"),
                 created_at=tracker.get("call_initiated_time")
                 or tracker.get("created_at")
                 or datetime.now(),

--- a/app/schemas/breeze_buddy/analytics.py
+++ b/app/schemas/breeze_buddy/analytics.py
@@ -156,6 +156,7 @@ class CallDetailResult(BaseModel):
     attempt_count: Optional[int] = None
     cost: Optional[float] = None
     payload: Optional[Dict[str, Any]] = None
+    call_initiated_time: Optional[datetime] = None
     created_at: datetime
     updated_at: Optional[datetime] = None
 


### PR DESCRIPTION
 "Call Time" column displayed relative time based on updated_at (last record modification), showing misleading timestamps.
Solution: Added **call_initiated_time** field in the API response to use actual call start timestamp instead of record modification time.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced call analytics now include call initiation time tracking, providing precise timestamps for when calls begin. This improvement enables more detailed reporting, better call timing analysis, and improved visibility into call sequences for more informed business decisions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->