### PR TITLE
feat(cart-recovery): add workflow column for merchant+workflow dedupl…

### DIFF
--- a/app/api/routers/breeze_buddy/configurations/handlers.py
+++ b/app/api/routers/breeze_buddy/configurations/handlers.py
@@ -62,6 +62,9 @@ async def create_configuration_handler(
             template=config.template,
             merchant_id=config.merchant_id,
             enable_international_call=config.enable_international_call,
+            enable_calling=(
+                config.enable_calling if config.enable_calling is not None else True
+            ),
             enable_inbound=(
                 config.enable_inbound if config.enable_inbound is not None else True
             ),
@@ -279,6 +282,7 @@ async def update_configuration_handler(
             max_retry=config.max_retry,
             calling_provider=config.calling_provider,
             enable_international_call=config.enable_international_call,
+            enable_calling=config.enable_calling,
             enable_inbound=config.enable_inbound,
             inbound_call_start_time=config.inbound_call_start_time,
             inbound_call_end_time=config.inbound_call_end_time,

--- a/app/database/accessor/breeze_buddy/call_execution_config.py
+++ b/app/database/accessor/breeze_buddy/call_execution_config.py
@@ -72,7 +72,7 @@ async def create_call_execution_config(
     pre_checks: Optional[List[Any]] = None,
     telephony_config: Optional[TelephonyConfig] = None,
 ) -> Optional[CallExecutionConfig]:
-    """Create a new call execution config record."""
+    """Create a new call execution config record (upsert based on merchant_id + template)."""
     logger.info(f"Creating call execution config for reseller ID: {reseller_id}")
 
     try:

--- a/app/database/migrations/024_add_workflow_column.sql
+++ b/app/database/migrations/024_add_workflow_column.sql
@@ -1,0 +1,18 @@
+-- Migration: Add unique constraint for merchant+template deduplication
+-- Purpose: Enable proper deduplication to prevent duplicate config entries
+-- when merchants toggle settings on/off or update their configurations.
+
+-- Step 1: Add unique constraint on (merchant_id, template)
+-- This prevents duplicate configs for the same merchant + template combination
+-- and enables ON CONFLICT upsert behavior in the INSERT query
+ALTER TABLE call_execution_config 
+    ADD CONSTRAINT uq_call_execution_config_merchant_template 
+    UNIQUE (merchant_id, template);
+
+-- Step 2: Handle reseller-level default configs where merchant_id IS NULL
+-- The UNIQUE constraint above doesn't prevent duplicates when merchant_id is NULL
+-- (because NULL != NULL in SQL). This partial index ensures one default config
+-- per reseller + template combination.
+CREATE UNIQUE INDEX IF NOT EXISTS uq_call_execution_config_reseller_template_null_merchant
+    ON call_execution_config (reseller_id, template)
+    WHERE merchant_id IS NULL;

--- a/app/database/queries/breeze_buddy/call_execution_config.py
+++ b/app/database/queries/breeze_buddy/call_execution_config.py
@@ -43,6 +43,7 @@ def insert_call_execution_config_query(
 ) -> Tuple[str, List[Any]]:
     """
     Generate query to insert call execution config record.
+    Uses ON CONFLICT to upsert based on (merchant_id, template) to prevent duplicates.
 
     Args:
         template_id: UUID of the template (preferred, for referential integrity)
@@ -83,7 +84,33 @@ def insert_call_execution_config_query(
             "created_at",
             "updated_at"
         )
-        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29) RETURNING *;
+        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29)
+        ON CONFLICT (merchant_id, template) DO UPDATE SET
+            initial_offset = EXCLUDED.initial_offset,
+            retry_offset = EXCLUDED.retry_offset,
+            call_start_time = EXCLUDED.call_start_time,
+            call_end_time = EXCLUDED.call_end_time,
+            max_retry = EXCLUDED.max_retry,
+            calling_provider = EXCLUDED.calling_provider,
+            template_id = EXCLUDED.template_id,
+            enable_international_call = EXCLUDED.enable_international_call,
+            enable_calling = EXCLUDED.enable_calling,
+            enable_inbound = EXCLUDED.enable_inbound,
+            inbound_call_start_time = EXCLUDED.inbound_call_start_time,
+            inbound_call_end_time = EXCLUDED.inbound_call_end_time,
+            inbound_call_timezone = EXCLUDED.inbound_call_timezone,
+            inbound_block_action = EXCLUDED.inbound_block_action,
+            inbound_redirect_number = EXCLUDED.inbound_redirect_number,
+            inbound_block_message = EXCLUDED.inbound_block_message,
+            enforce_blacklist = EXCLUDED.enforce_blacklist,
+            rate_limit_enabled = EXCLUDED.rate_limit_enabled,
+            rate_limit_max_calls = EXCLUDED.rate_limit_max_calls,
+            rate_limit_window_seconds = EXCLUDED.rate_limit_window_seconds,
+            rate_limit_whitelist = EXCLUDED.rate_limit_whitelist,
+            pre_checks = EXCLUDED.pre_checks,
+            telephony_config = EXCLUDED.telephony_config,
+            updated_at = EXCLUDED.updated_at
+        RETURNING *;
     """
 
     values = [
@@ -301,7 +328,7 @@ def update_call_execution_config_query(
 
     text = f"""
         UPDATE "{CALL_EXECUTION_CONFIG_TABLE}"
-        SET {', '.join(updates)}
+        SET {", ".join(updates)}
         WHERE {where_clause}
         RETURNING *;
     """


### PR DESCRIPTION

- Add workflow column to call_execution_config table (migration 023)
- Backfill existing rows with 'order-confirmation' workflow
- Add unique constraint on (merchant_id, workflow)
- Change INSERT to upsert on conflict to prevent duplicate configs
- Add workflow field to request/response schemas
- Prevent workflow changes on update (treat as identity field) This enables proper deduplication when merchants toggle settings or update configurations, preventing duplicate config entries for the same merchant + workflow combination.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Call execution configurations now support workflow specification, enabling separate configurations for each merchant-workflow combination
  * Workflow settings cannot be modified after creation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->