### PR TITLE
Add Kaleyra WhatsApp support for messaging

### DIFF
--- a/app/ai/voice/agents/breeze_buddy/handlers/internal/builtin_dispatcher.py
+++ b/app/ai/voice/agents/breeze_buddy/handlers/internal/builtin_dispatcher.py
@@ -25,6 +25,9 @@ from app.ai.voice.agents.breeze_buddy.handlers.internal.end_conversation_global 
 from app.ai.voice.agents.breeze_buddy.handlers.internal.get_current_time import (
     get_current_time,
 )
+from app.ai.voice.agents.breeze_buddy.handlers.internal.send_whatsapp import (
+    send_whatsapp_cart_link,
+)
 from app.ai.voice.agents.breeze_buddy.handlers.internal.stt import (
     mute_stt,
     unmute_stt,
@@ -46,6 +49,7 @@ BUILTIN_HANDLERS: Dict[str, Callable] = {
     "connect_to_live_agent": connect_to_live_agent,
     "end_conversation": end_conversation_global,
     "get_current_time": get_current_time,
+    "send_whatsapp_cart_link": send_whatsapp_cart_link,
     "update_outcome": update_outcome,
 }
 

--- a/app/ai/voice/agents/breeze_buddy/handlers/internal/send_whatsapp.py
+++ b/app/ai/voice/agents/breeze_buddy/handlers/internal/send_whatsapp.py
@@ -1,0 +1,121 @@
+"""
+Send WhatsApp Cart Link Handler
+
+Sends a WhatsApp message with the cart recovery link to the customer.
+Uses Kaleyra WhatsApp service with credentials from environment variables.
+"""
+
+from typing import Any, Dict
+
+from app.ai.voice.agents.breeze_buddy.template.context import TemplateContext
+from app.core.config.static import KALEYRA_WHATSAPP_TEMPLATE
+from app.core.logger import logger
+from app.services.whatsapp import kaleyra_whatsapp
+
+
+async def send_whatsapp_cart_link(
+    context: TemplateContext,
+    args: Dict[str, Any],
+) -> Dict[str, Any]:
+    """
+    Send cart recovery link via WhatsApp to the customer.
+
+    Extracts customer details from lead payload and sends a WhatsApp
+    template message using Kaleyra. Template parameters are extracted
+    from the lead payload.
+
+    Expected fields in lead.payload:
+        - customer_mobile_number: Phone number to send WhatsApp to
+        - customer_name: Customer's name (optional, defaults to "Customer")
+        - cart_link: Cart recovery link (for cart recovery template)
+        - shop_name: Store/shop name (optional)
+
+    Args:
+        context: TemplateContext with access to bot state and lead info
+        args: LLM function arguments (not used for this handler)
+
+    Returns:
+        Dict with:
+            - status: "success" or "failed"
+            - message: Description for LLM to convey to customer
+            - whatsapp_sent: Boolean indicating if message was sent
+
+    On failure, returns a message suggesting network issues and asking
+    the customer to open the checkout link directly.
+    """
+    # Extract lead payload
+    payload = context.lead.payload if context.lead else {}
+
+    # Get required fields
+    customer_phone = payload.get("customer_mobile_number", "")
+    customer_name = payload.get("customer_name", "Customer")
+    cart_link = payload.get("cart_link", "")
+    shop_name = payload.get("shop_name", "Store")
+
+    # Log the attempt
+    logger.info(
+        f"[send_whatsapp_cart_link] Sending WhatsApp to {customer_phone} "
+        f"for call {context.call_sid}"
+    )
+
+    # Validate required fields
+    if not customer_phone:
+        logger.error(
+            f"[send_whatsapp_cart_link] Missing customer_mobile_number in payload "
+            f"for call {context.call_sid}"
+        )
+        return {
+            "status": "failed",
+            "message": (
+                "Sorry, I couldn't send the cart link to your WhatsApp. "
+                "There seems to be a network issue. Meanwhile, you can open "
+                "the checkout link directly in your browser and proceed with "
+                "the payment. Thank you!"
+            ),
+            "whatsapp_sent": False,
+            "error": "Missing customer phone number",
+        }
+
+    # Build template parameters
+    # For test template (breeze_order_confirmation_v1): [name, order_id, store_name]
+    # For future cart recovery template: adjust parameters accordingly
+    template_params = [
+        customer_name,
+        cart_link or "N/A",  # Placeholder for order_id in test template
+        shop_name,
+    ]
+
+    # Send WhatsApp message via Kaleyra
+    result = await kaleyra_whatsapp.send_template_message(
+        to=customer_phone,
+        template_name=KALEYRA_WHATSAPP_TEMPLATE,
+        template_params=template_params,
+    )
+
+    if result.get("success"):
+        logger.info(
+            f"[send_whatsapp_cart_link] WhatsApp sent successfully to {customer_phone} "
+            f"for call {context.call_sid}, message_id={result.get('message_id')}"
+        )
+        return {
+            "status": "success",
+            "message": "WhatsApp message sent successfully",
+            "whatsapp_sent": True,
+            "message_id": result.get("message_id"),
+        }
+    else:
+        logger.error(
+            f"[send_whatsapp_cart_link] Failed to send WhatsApp to {customer_phone} "
+            f"for call {context.call_sid}: {result.get('error')}"
+        )
+        return {
+            "status": "success",  # Mark as success so call flow continues
+            "message": (
+                "Sorry, I couldn't send the cart link to your WhatsApp. "
+                "There seems to be a network issue. Meanwhile, you can open "
+                "the checkout link directly in your browser and proceed with "
+                "the payment. Thank you!"
+            ),
+            "whatsapp_sent": False,
+            "error": result.get("error"),
+        }

--- a/app/ai/voice/agents/breeze_buddy/template/transformation_function/utils.py
+++ b/app/ai/voice/agents/breeze_buddy/template/transformation_function/utils.py
@@ -1,7 +1,9 @@
 import re
 
 
-def indian_number_to_speech(number: int) -> str:
+def indian_number_to_speech(number: float | int) -> str:
+    # Round to nearest integer to handle float inputs like 2609.9
+    number = round(number)
     if number <= 0:
         return "0 rupees"
     parts = []

--- a/app/core/config/static.py
+++ b/app/core/config/static.py
@@ -572,3 +572,14 @@ HTTP_REQUEST_BLOCKED_CONTENT_TYPES = [
 
 # Maximum number of redirects to follow (0 to disable redirects)
 HTTP_REQUEST_MAX_REDIRECTS = int(os.environ.get("HTTP_REQUEST_MAX_REDIRECTS", "3"))
+
+# Kaleyra WhatsApp Configuration
+KALEYRA_API_BASE_URL = os.environ.get(
+    "KALEYRA_API_BASE_URL", "https://api.in.kaleyra.io/v2"
+)  # India region by default
+KALEYRA_SID = os.getenv("KALEYRA_SID", "")
+KALEYRA_API_KEY = os.getenv("KALEYRA_API_KEY", "")
+KALEYRA_WHATSAPP_FROM = os.getenv("KALEYRA_WHATSAPP_FROM", "")  # Sender phone number
+KALEYRA_WHATSAPP_TEMPLATE = os.getenv(
+    "KALEYRA_WHATSAPP_TEMPLATE", ""
+)  # Pre-approved WhatsApp template name

--- a/app/services/whatsapp/__init__.py
+++ b/app/services/whatsapp/__init__.py
@@ -1,0 +1,9 @@
+"""
+WhatsApp messaging services.
+
+Provides integrations with WhatsApp Business API providers.
+"""
+
+from app.services.whatsapp.kaleyra import KaleyraWhatsAppService, kaleyra_whatsapp
+
+__all__ = ["KaleyraWhatsAppService", "kaleyra_whatsapp"]

--- a/app/services/whatsapp/kaleyra.py
+++ b/app/services/whatsapp/kaleyra.py
@@ -1,0 +1,197 @@
+"""
+Kaleyra WhatsApp Service
+
+Provides functionality to send WhatsApp messages via Kaleyra V2 API.
+Based on Vayu's implementation pattern.
+
+API Reference: https://docs.kaleyra.com/
+Endpoint: POST https://api.in.kaleyra.io/v2/{SID}/whatsapp/{sender_phone}/messages
+"""
+
+from typing import Any, Optional
+
+import aiohttp
+
+from app.core.config.static import (
+    KALEYRA_API_BASE_URL,
+    KALEYRA_API_KEY,
+    KALEYRA_SID,
+    KALEYRA_WHATSAPP_FROM,
+    KALEYRA_WHATSAPP_TEMPLATE,
+)
+from app.core.logger import logger
+
+
+class KaleyraWhatsAppService:
+    """
+    Kaleyra V2 WhatsApp API client.
+
+    Sends WhatsApp template messages using Kaleyra's V2 API.
+    Credentials are loaded from environment variables.
+    """
+
+    def __init__(self) -> None:
+        """Initialize the Kaleyra WhatsApp service with env-based config."""
+        self.base_url = KALEYRA_API_BASE_URL.rstrip("/")
+        self.sid = KALEYRA_SID
+        self.api_key = KALEYRA_API_KEY
+        self.from_number = KALEYRA_WHATSAPP_FROM
+        self.default_template = KALEYRA_WHATSAPP_TEMPLATE
+
+    def _is_configured(self) -> bool:
+        """Check if all required Kaleyra credentials are configured."""
+        return bool(self.sid and self.api_key and self.from_number)
+
+    def _ensure_country_code(self, phone: str) -> str:
+        """
+        Ensure phone number has country code prefix.
+
+        Args:
+            phone: Phone number (may or may not have + prefix)
+
+        Returns:
+            Phone number with + prefix
+        """
+        phone = phone.strip()
+        if not phone.startswith("+"):
+            # Assume Indian number if no country code
+            if phone.startswith("91"):
+                return f"+{phone}"
+            return f"+91{phone}"
+        return phone
+
+    async def send_template_message(
+        self,
+        to: str,
+        template_name: Optional[str] = None,
+        template_params: Optional[list[str]] = None,
+        language_code: str = "en",
+    ) -> dict[str, Any]:
+        """
+        Send a WhatsApp template message via Kaleyra V2 API.
+
+        Args:
+            to: Recipient phone number (with or without country code)
+            template_name: Pre-approved WhatsApp template name.
+                          Falls back to KALEYRA_WHATSAPP_TEMPLATE env var.
+            template_params: List of text values for template body parameters.
+                            Order must match template placeholders ({{1}}, {{2}}, etc.)
+            language_code: Template language code (default: "en")
+
+        Returns:
+            Dict with keys:
+                - success: bool indicating if message was sent
+                - data: API response data (on success)
+                - error: Error message (on failure)
+                - message_id: Kaleyra message ID (on success, if available)
+        """
+        if not self._is_configured():
+            logger.warning(
+                "[KaleyraWhatsApp] Service not configured - missing credentials"
+            )
+            return {
+                "success": False,
+                "error": "Kaleyra WhatsApp service not configured",
+            }
+
+        # Use default template if not specified
+        template = template_name or self.default_template
+        if not template:
+            logger.error("[KaleyraWhatsApp] No template name provided or configured")
+            return {
+                "success": False,
+                "error": "No WhatsApp template name configured",
+            }
+
+        # Ensure phone has country code
+        recipient = self._ensure_country_code(to)
+        sender = self._ensure_country_code(self.from_number)
+
+        # Build Kaleyra V2 API URL
+        # Format: POST /{SID}/whatsapp/{sender_phone}/messages
+        url = f"{self.base_url}/{self.sid}/whatsapp/{sender}/messages"
+
+        # Build request headers
+        headers = {
+            "Content-Type": "application/json",
+            "api-key": self.api_key,
+            "cache-control": "no-cache",
+        }
+
+        # Build template components
+        components: list[dict[str, Any]] = []
+        if template_params:
+            components.append(
+                {
+                    "type": "body",
+                    "parameters": [
+                        {"type": "text", "text": param} for param in template_params
+                    ],
+                }
+            )
+
+        # Build Kaleyra V2 payload
+        payload = {
+            "messaging_object": {
+                "messaging_product": "whatsapp",
+                "recipient_type": "individual",
+                "to": recipient,
+                "type": "template",
+                "template": {
+                    "name": template,
+                    "language": {"code": language_code},
+                    "components": components,
+                },
+            }
+        }
+
+        logger.info(
+            f"[KaleyraWhatsApp] Sending template '{template}' to {recipient} "
+            f"with {len(template_params or [])} params"
+        )
+
+        try:
+            timeout = aiohttp.ClientTimeout(total=30)
+            async with aiohttp.ClientSession(timeout=timeout) as session:
+                async with session.post(url, json=payload, headers=headers) as response:
+                    response_data = await response.json()
+
+                    if 200 <= response.status < 300:
+                        logger.info(
+                            f"[KaleyraWhatsApp] Message sent successfully to {recipient}"
+                        )
+                        return {
+                            "success": True,
+                            "data": response_data,
+                            "message_id": response_data.get("id"),
+                        }
+                    else:
+                        error_msg = response_data.get(
+                            "error", response_data.get("message", "Unknown error")
+                        )
+                        logger.error(
+                            f"[KaleyraWhatsApp] API error: {response.status} - {error_msg}"
+                        )
+                        return {
+                            "success": False,
+                            "error": error_msg,
+                            "status_code": response.status,
+                            "data": response_data,
+                        }
+
+        except aiohttp.ClientError as e:
+            logger.error(f"[KaleyraWhatsApp] Network error: {e}")
+            return {
+                "success": False,
+                "error": f"Network error: {str(e)}",
+            }
+        except Exception as e:
+            logger.error(f"[KaleyraWhatsApp] Unexpected error: {e}", exc_info=True)
+            return {
+                "success": False,
+                "error": f"Unexpected error: {str(e)}",
+            }
+
+
+# Global singleton instance
+kaleyra_whatsapp = KaleyraWhatsAppService()


### PR DESCRIPTION
Add functionality to send WhatsApp template messages with cart recovery 
links to customers during voice calls. This enables agents to send 
checkout links directly to customers who prefer WhatsApp over verbal 
instructions.
- Add KaleyraWhatsAppService client for Kaleyra V2 WhatsApp API
- Add send_whatsapp_cart_link handler for Breeze Buddy function calls
- Register send_whatsapp function in builtin_dispatcher
- Add Kaleyra environment variables (SID, API_KEY, WHATSAPP_FROM, etc.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added WhatsApp cart link sending functionality to share cart information with customers directly via WhatsApp messaging.
  * Integrated Kaleyra WhatsApp Business API for reliable message delivery.

* **Chores**
  * Added configuration settings for WhatsApp integration.
  * Updated database schema to improve call execution configuration management with deduplication constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->