### PR TITLE
feat: add voice alert notification endpoint and DB layer

### DIFF
--- a/app/ai/voice/agents/breeze_buddy/dispatch/queue.py
+++ b/app/ai/voice/agents/breeze_buddy/dispatch/queue.py
@@ -22,12 +22,18 @@ from app.services.redis import get_redis_service
 # Execution modes the event-driven dispatcher places outbound calls for.
 # Mirrors the WHERE clause in ``get_unscheduled_backlog_leads_query`` so the
 # ingest path, retry path, and dispatch-now path all match the reconciler.
-# DAILY/DAILY_TEST/DAILY_STREAM are web-only — they're either customer-
-# initiated (inbound) or handled by a separate room-creation + notification
-# flow, NOT by the worker's ``provider.make_call`` PSTN dial. HOLD_TRANSFER
-# is a transient mid-call leg, not a standalone outbound to schedule.
+# TELEPHONY_ALERT is an outbound PSTN notification and uses the same worker
+# path as regular telephony. DAILY/DAILY_TEST/DAILY_STREAM are web-only —
+# they're either customer-initiated (inbound) or handled by a separate
+# room-creation + notification flow, NOT by the worker's ``provider.make_call``
+# PSTN dial. HOLD_TRANSFER is a transient mid-call leg, not a standalone
+# outbound to schedule.
 DISPATCHABLE_EXECUTION_MODES = frozenset(
-    {ExecutionMode.TELEPHONY, ExecutionMode.TELEPHONY_TEST}
+    {
+        ExecutionMode.TELEPHONY,
+        ExecutionMode.TELEPHONY_TEST,
+        ExecutionMode.TELEPHONY_ALERT,
+    }
 )
 
 

--- a/app/ai/voice/agents/breeze_buddy/managers/calls.py
+++ b/app/ai/voice/agents/breeze_buddy/managers/calls.py
@@ -428,6 +428,7 @@ async def _retry_call(
             request_id=lead.request_id,
             meta_data={},
             call_direction=lead.call_direction,  # Inherit call direction from parent lead
+            execution_mode=lead.execution_mode,
         )
 
         # Only ZADD onto the schedule if the DB insert actually landed. If
@@ -520,7 +521,8 @@ async def reconcile_stuck_processing_leads():
             if (
                 config
                 and locked_lead.call_direction == CallDirection.OUTBOUND
-                and locked_lead.execution_mode == ExecutionMode.TELEPHONY
+                and locked_lead.execution_mode
+                in (ExecutionMode.TELEPHONY, ExecutionMode.TELEPHONY_ALERT)
             ):
                 await _retry_call(locked_lead, config)
 
@@ -619,7 +621,8 @@ async def handle_call_completion(
         config
         and outcome in ["BUSY", "NO_ANSWER"]
         and lead.call_direction == CallDirection.OUTBOUND
-        and lead.execution_mode == ExecutionMode.TELEPHONY
+        and lead.execution_mode
+        in (ExecutionMode.TELEPHONY, ExecutionMode.TELEPHONY_ALERT)
     ):
         await _retry_call(lead, config, outcome)
 
@@ -708,7 +711,8 @@ async def handle_unanswered_calls(call_id: str):
     if (
         config
         and lead.call_direction == CallDirection.OUTBOUND
-        and lead.execution_mode == ExecutionMode.TELEPHONY
+        and lead.execution_mode
+        in (ExecutionMode.TELEPHONY, ExecutionMode.TELEPHONY_ALERT)
     ):
         await _retry_call(lead, config, "NO_ANSWER")
 

--- a/app/api/routers/breeze_buddy/__init__.py
+++ b/app/api/routers/breeze_buddy/__init__.py
@@ -2,6 +2,7 @@ from fastapi import APIRouter
 
 # Pod health probes (1-pod-1-call isolation architecture)
 from app.api.routers.breeze_buddy.agent_router.health import router as pod_router
+from app.api.routers.breeze_buddy.alerts import router as alerts_router
 
 # Modern RESTful routers
 from app.api.routers.breeze_buddy.analytics import router as analytics_router
@@ -118,6 +119,9 @@ router.include_router(leads_router, prefix="", tags=["leads"])
 
 # Campaigns (named bulk lead pushes)
 router.include_router(campaigns_router, prefix="", tags=["campaigns"])
+
+# Alerts (voice alert firing for on-call notifications)
+router.include_router(alerts_router, prefix="", tags=["alerts"])
 
 # Telephony (webhook handlers for call providers)
 router.include_router(telephony_router, prefix="", tags=["telephony"])

--- a/app/api/routers/breeze_buddy/alerts/__init__.py
+++ b/app/api/routers/breeze_buddy/alerts/__init__.py
@@ -1,0 +1,88 @@
+"""
+Alert fire endpoint.
+
+POST /alerts/fire -- receives an alert event, deduplicates via Redis,
+looks up alert group phone numbers, and pushes one BB lead per phone number.
+
+This is the single interface for all alert sources:
+- OpenObserve webhook destinations
+- Internal HealthMonitor background task
+- Future polling-based checks (e.g. balance pollers)
+
+Security:
+- reseller_id comes from the JWT token (not request body) to prevent impersonation.
+- Token must be scoped to exactly one reseller (reseller_ids must have a single entry).
+- merchant_id (optional) comes from the body, validated against token scope.
+"""
+
+from fastapi import APIRouter, Depends, HTTPException, status
+
+from app.api.routers.breeze_buddy.leads.rbac import validate_lead_access
+from app.api.security.breeze_buddy.rbac_token import get_current_user_with_rbac
+from app.schemas import AlertFireRequest, UserInfo, UserRole
+
+from .handlers import fire_alert_handler
+
+router = APIRouter()
+
+
+def _resolve_reseller_id(current_user: UserInfo) -> str:
+    """Extract the single reseller_id from the token.
+
+    ALERT_SYSTEM tokens must be scoped to exactly one reseller.
+    ADMIN tokens must also be scoped (admins should create a dedicated
+    alert_system user per reseller rather than using their own token).
+
+    Raises:
+        HTTPException 403 if token has no reseller_ids, multiple, or wildcard.
+    """
+    ids = current_user.reseller_ids
+    if not ids or len(ids) != 1 or ids[0] == "*":
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=(
+                "Alert token must be scoped to exactly one reseller. "
+                f"Got reseller_ids={ids}. "
+                "Create a dedicated alert_system user with a single reseller_id."
+            ),
+        )
+    return ids[0]
+
+
+@router.post("/alerts/fire", status_code=status.HTTP_202_ACCEPTED)
+async def fire_alert(
+    req: AlertFireRequest,
+    current_user: UserInfo = Depends(get_current_user_with_rbac),
+):
+    """
+    Fire a voice alert.
+
+    Flow:
+    1. Validate role (ADMIN or ALERT_SYSTEM only)
+    2. Extract reseller_id from JWT token (must be single-scoped)
+    3. Validate merchant_id (if provided) against token scope
+    4. Deduplicate on alert_id via Redis SETNX with dedup_ttl_seconds TTL
+    5. Look up alert_group_name in alert_groups table for this reseller
+    6. Validate template + call execution config exist (fail fast)
+    7. Push one BB lead per group member via create_lead_call_tracker()
+    8. Existing process_backlog_leads() cron picks up leads and fires calls
+
+    Auth: ADMIN or ALERT_SYSTEM JWT role required. Token must be scoped
+    to exactly one reseller_id.
+    """
+    # Step 1: Role gate
+    if current_user.role not in (UserRole.ADMIN, UserRole.ALERT_SYSTEM):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Only ADMIN or ALERT_SYSTEM roles can fire alerts",
+        )
+
+    # Step 2: Extract reseller_id from token
+    reseller_id = _resolve_reseller_id(current_user)
+
+    # Step 3: Validate merchant_id scope (reuses existing leads RBAC)
+    validate_lead_access(
+        current_user, reseller_id, req.merchant_id, operation="fire alert"
+    )
+
+    return await fire_alert_handler(req, current_user, reseller_id)

--- a/app/api/routers/breeze_buddy/alerts/handlers.py
+++ b/app/api/routers/breeze_buddy/alerts/handlers.py
@@ -1,0 +1,248 @@
+"""
+Business logic for alert firing.
+
+Responsibilities:
+1. Redis SETNX dedup on alert_id (fail-open: skip dedup on Redis error)
+2. Resolve alert_group_name -> phone numbers from DB (scoped by reseller_id)
+3. Validate template + call_execution_config exist
+4. Push one lead per phone number via create_lead_call_tracker()
+5. Schedule each lead on the event-driven dispatch queue
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, Any, Dict, List
+
+from fastapi import HTTPException, status
+
+from app.ai.voice.agents.breeze_buddy.dispatch.queue import schedule_lead
+from app.core.logger import logger
+from app.database.accessor import (
+    create_lead_call_tracker,
+    get_alert_group_by_name,
+    get_call_execution_config_by_merchant_id,
+    get_template_in_scope,
+)
+from app.schemas import ExecutionMode, LeadCallStatus, UserInfo
+from app.services.redis.client import get_redis_service
+
+if TYPE_CHECKING:
+    from app.schemas.breeze_buddy.alerts import AlertFireRequest
+
+
+def _mask_phone(phone: str) -> str:
+    """Mask phone number for logging and API responses."""
+    return "****"
+
+
+async def _try_dedup_acquire(dedup_key: str, ttl: int) -> bool | None:
+    """
+    Attempt Redis SETNX for dedup.
+
+    Uses the raw Redis client directly to avoid the service layer's
+    internal exception catching (which silently converts errors to False
+    and would cause fail-closed dedup suppression).
+
+    Returns:
+        True  -- key acquired (first fire in window)
+        False -- key exists (duplicate, suppress)
+        None  -- Redis error (fail-open: skip dedup, proceed with alert)
+    """
+    try:
+        redis = await get_redis_service()
+        client = await redis.get_client()
+        acquired = await client.set(dedup_key, "1", nx=True, ex=ttl)
+        return bool(acquired)
+    except Exception as e:
+        logger.error(f"Redis error during dedup acquire for '{dedup_key}': {e}")
+        return None
+
+
+async def _try_dedup_release(dedup_key: str) -> None:
+    """Best-effort release of dedup key. Failures are logged, not raised."""
+    try:
+        redis = await get_redis_service()
+        client = await redis.get_client()
+        await client.delete(dedup_key)
+    except Exception as e:
+        logger.error(f"Redis error during dedup release for '{dedup_key}': {e}")
+
+
+async def fire_alert_handler(
+    req: AlertFireRequest, current_user: UserInfo, reseller_id: str
+) -> Dict[str, Any]:
+    """
+    Core alert firing logic.
+
+    Args:
+        req: AlertFireRequest with alert parameters (no reseller_id)
+        current_user: Authenticated user info (used for audit logging)
+        reseller_id: Resolved from the JWT token by the router
+
+    Returns:
+        Dict with status, alert_id, leads_queued, and per-member results
+    """
+    dedup_key = f"bb:alert:dedup:{reseller_id}:{req.alert_id}"
+    dedup_acquired = False
+
+    logger.info(
+        f"Alert fire request from user={current_user.username} "
+        f"role={current_user.role.value} reseller={reseller_id} "
+        f"alert_id={req.alert_id}"
+    )
+
+    # -- Step 1: Dedup (fail-open on Redis error) --------------------
+    if req.dedup_ttl_seconds > 0:
+        result = await _try_dedup_acquire(dedup_key, req.dedup_ttl_seconds)
+        if result is False:
+            logger.info(
+                f"Alert '{req.alert_id}' deduplicated (TTL key exists in Redis)"
+            )
+            return {
+                "status": "deduplicated",
+                "alert_id": req.alert_id,
+                "message": (
+                    f"Alert suppressed — already fired within "
+                    f"{req.dedup_ttl_seconds}s window"
+                ),
+            }
+        if result is True:
+            dedup_acquired = True
+        # result is None => Redis error, proceed without dedup
+
+    # -- Step 2: Resolve alert group (scoped by reseller) -------------
+    group = await get_alert_group_by_name(req.alert_group_name, reseller_id)
+    if not group:
+        if dedup_acquired:
+            await _try_dedup_release(dedup_key)
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=(
+                f"Alert group '{req.alert_group_name}' not found "
+                f"for reseller '{reseller_id}'"
+            ),
+        )
+    members: List[Dict[str, str]] = group.members
+    if not members:
+        if dedup_acquired:
+            await _try_dedup_release(dedup_key)
+        logger.warning(
+            f"Alert group '{req.alert_group_name}' has no members — no calls fired"
+        )
+        return {
+            "status": "no_members",
+            "alert_id": req.alert_id,
+            "alert_group_name": req.alert_group_name,
+            "leads_queued": 0,
+        }
+
+    # -- Step 3: Validate template + config (fail fast) ---------------
+    template = await get_template_in_scope(reseller_id, req.merchant_id, req.template)
+    if not template:
+        if dedup_acquired:
+            await _try_dedup_release(dedup_key)
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=(
+                f"Template '{req.template}' not found for reseller '{reseller_id}'"
+            ),
+        )
+
+    configs = await get_call_execution_config_by_merchant_id(
+        reseller_id, req.merchant_id
+    )
+    config = next((c for c in (configs or []) if c.template == req.template), None)
+    if not config:
+        if dedup_acquired:
+            await _try_dedup_release(dedup_key)
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=(f"Call execution config not found for template '{req.template}'"),
+        )
+
+    # -- Step 4: Push one lead per member -----------------------------
+    queued_leads: List[Dict[str, str]] = []
+    failed: List[Dict[str, str]] = []
+
+    for member in members:
+        phone = member.get("phone")
+        name = member.get("name", "")
+        masked = _mask_phone(phone) if phone else "none"
+
+        if not phone:
+            logger.warning(f"Skipping alert group member {name!r} — no phone number")
+            continue
+
+        lead_id = str(uuid.uuid4())
+        request_id = f"alert-{req.alert_id}-{lead_id[:8]}"
+
+        # extra_payload merged first so reserved keys always win
+        payload: Dict[str, Any] = {
+            **(req.extra_payload or {}),
+            "customer_mobile_number": phone,
+            "customer_name": name,
+            "alert_message": req.alert_message,
+            "alert_id": req.alert_id,
+        }
+
+        try:
+            next_attempt_at = datetime.now(timezone.utc)
+            lead = await create_lead_call_tracker(
+                id=lead_id,
+                reseller_id=reseller_id,
+                template=req.template,
+                template_id=str(template.id),
+                merchant_id=req.merchant_id,
+                next_attempt_at=next_attempt_at,
+                payload=payload,
+                attempt_count=0,
+                meta_data={
+                    "alert_id": req.alert_id,
+                    "alert_group": req.alert_group_name,
+                },
+                request_id=request_id,
+                execution_mode=ExecutionMode.TELEPHONY_ALERT,
+                status=LeadCallStatus.BACKLOG,
+            )
+
+            if lead:
+                await schedule_lead(lead_id=lead_id, next_attempt_at=next_attempt_at)
+                queued_leads.append(
+                    {
+                        "lead_id": lead_id,
+                        "phone": masked,
+                        "name": name,
+                    }
+                )
+                logger.info(
+                    f"Alert lead queued: {lead_id} -> {masked} (alert={req.alert_id})"
+                )
+            else:
+                failed.append(
+                    {
+                        "phone": masked,
+                        "reason": "create_lead_call_tracker returned None",
+                    }
+                )
+        except Exception as e:
+            logger.error(
+                f"Failed to queue alert lead for {masked}: {e}",
+                exc_info=True,
+            )
+            failed.append({"phone": masked, "reason": str(e)})
+
+    # Release dedup key if any leads failed so retries are not suppressed
+    if failed and dedup_acquired:
+        await _try_dedup_release(dedup_key)
+
+    return {
+        "status": "queued" if queued_leads else "all_failed",
+        "alert_id": req.alert_id,
+        "alert_group_name": req.alert_group_name,
+        "reseller_id": reseller_id,
+        "leads_queued": len(queued_leads),
+        "leads": queued_leads,
+        "failed": failed,
+    }

--- a/app/api/routers/breeze_buddy/auth/__init__.py
+++ b/app/api/routers/breeze_buddy/auth/__init__.py
@@ -5,7 +5,7 @@ This module provides JWT token-based authentication endpoints for breeze buddy.
 
 Endpoints:
 - POST   /login              - Authenticate user and get JWT token
-- POST   /auth/s2s/token     - Generate long-lived S2S token (admin only)
+- POST   /auth/s2s/token     - Generate long-lived S2S token (admin / alert_system)
 - GET    /auth/me            - Get current user info from token
 - POST   /auth/logout        - Logout (client-side token removal)
 - GET    /logout             - Legacy logout endpoint (deprecated)
@@ -72,11 +72,11 @@ async def generate_s2s_token(request: S2STokenRequest):
     """
     Generate long-lived token for Server-to-Server (S2S) authentication.
 
-    This endpoint allows admin users to generate long-lived JWT tokens
-    (up to 365 days) for automated integrations and S2S communication.
+    This endpoint allows admin and alert_system users to generate long-lived JWT
+    tokens (up to 365 days) for automated integrations and S2S communication.
 
     Requirements:
-    - Only admin users can generate S2S tokens (security restriction)
+    - Only admin and alert_system users can generate S2S tokens
     - Maximum token lifetime: 365 days
     - Token should be stored securely by the caller
 
@@ -85,6 +85,7 @@ async def generate_s2s_token(request: S2STokenRequest):
     - Automated scripts and cron jobs
     - Third-party platform integrations
     - CI/CD pipelines
+    - Voice alert notification systems
 
     Request Body:
         {
@@ -112,7 +113,7 @@ async def generate_s2s_token(request: S2STokenRequest):
 
     Security:
         - Returns 401 if credentials are invalid or account is inactive
-        - Returns 403 if user is not an admin
+        - Returns 403 if user is not admin or alert_system
     """
     return await generate_s2s_token_handler(request)
 

--- a/app/api/routers/breeze_buddy/auth/handlers.py
+++ b/app/api/routers/breeze_buddy/auth/handlers.py
@@ -161,11 +161,11 @@ async def generate_s2s_token_handler(request: S2STokenRequest) -> S2STokenRespon
     """
     Generate long-lived token for Server-to-Server (S2S) authentication.
 
-    Allows admin users to generate long-lived JWT tokens (up to 365 days)
-    for automated integrations and S2S communication.
+    Allows admin and alert_system users to generate long-lived JWT tokens
+    (up to 365 days) for automated integrations and S2S communication.
 
     Security restrictions:
-    - Only admin users can generate S2S tokens
+    - Only admin and alert_system users can generate S2S tokens
     - Maximum token lifetime: 365 days
 
     Args:
@@ -176,7 +176,7 @@ async def generate_s2s_token_handler(request: S2STokenRequest) -> S2STokenRespon
 
     Raises:
         HTTPException: 401 if credentials are invalid or account is inactive
-        HTTPException: 403 if user is not an admin
+        HTTPException: 403 if user is not admin or alert_system
     """
     # Authenticate user
     user = await get_user_by_username(request.username)
@@ -203,14 +203,14 @@ async def generate_s2s_token_handler(request: S2STokenRequest) -> S2STokenRespon
             detail="Account is inactive. Please contact administrator.",
         )
 
-    # Security restriction: Only admins can generate S2S tokens
-    if user.role != UserRole.ADMIN:
+    # Security restriction: Only admins and alert_system users can generate S2S tokens
+    if user.role not in (UserRole.ADMIN, UserRole.ALERT_SYSTEM):
         logger.warning(
-            f"S2S token request denied: non-admin user - {request.username} (role: {user.role})"
+            f"S2S token request denied: unauthorized role - {request.username} (role: {user.role})"
         )
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
-            detail="Only admin users can generate S2S tokens. Please contact your administrator.",
+            detail="Only admin and alert_system users can generate S2S tokens. Please contact your administrator.",
         )
 
     # Generate long-lived token
@@ -242,14 +242,20 @@ async def generate_s2s_token_handler(request: S2STokenRequest) -> S2STokenRespon
                 )
         resolved_merchant_ids = request.merchant_ids
 
-    # If scopes are restricted (not wildcard), downgrade the token role
-    # from ADMIN to RESELLER. RBAC checks short-circuit on role == "admin"
-    # before inspecting reseller_ids/merchant_ids, so an ADMIN-role token
-    # would bypass those restrictions entirely.
+    # If scopes are restricted (not wildcard), downgrade ADMIN tokens to
+    # RESELLER. RBAC checks short-circuit on role == "admin" before inspecting
+    # reseller_ids/merchant_ids, so an ADMIN-role token would bypass those
+    # restrictions entirely. ALERT_SYSTEM is already a constrained integration
+    # role and must be preserved so its S2S token can call /alerts/fire.
     scopes_are_restricted = (
         "*" not in resolved_reseller_ids or "*" not in resolved_merchant_ids
     )
-    token_role = UserRole.RESELLER if scopes_are_restricted else user.role
+    if user.role == UserRole.ALERT_SYSTEM:
+        token_role = UserRole.ALERT_SYSTEM
+    elif scopes_are_restricted:
+        token_role = UserRole.RESELLER
+    else:
+        token_role = user.role
 
     access_token = rbac_token_manager.create_access_token_with_rbac(
         user_id=user.id,

--- a/app/api/security/breeze_buddy/rbac_token.py
+++ b/app/api/security/breeze_buddy/rbac_token.py
@@ -238,6 +238,10 @@ class BreezeBuddyRBACTokenManager:
                 "read:own_data",
                 "analytics:own",
             ]
+        elif role_str == "alert_system":
+            return [
+                "alerts:fire",
+            ]
         else:
             return []
 

--- a/app/database/accessor/__init__.py
+++ b/app/database/accessor/__init__.py
@@ -3,6 +3,10 @@ Main database accessor module.
 This module exports all database accessor functions.
 """
 
+from .breeze_buddy.alert_groups import (
+    get_alert_group_by_name,
+    upsert_alert_group,
+)
 from .breeze_buddy.blacklisted_numbers import (
     add_blacklisted_number,
     check_blacklisted_number,
@@ -73,6 +77,8 @@ from .breeze_buddy.template import (
 )
 
 __all__ = [
+    "get_alert_group_by_name",
+    "upsert_alert_group",
     "is_number_blacklisted",
     "add_blacklisted_number",
     "remove_blacklisted_number",

--- a/app/database/accessor/breeze_buddy/alert_groups.py
+++ b/app/database/accessor/breeze_buddy/alert_groups.py
@@ -1,0 +1,57 @@
+"""
+Database accessor functions for alert_groups table.
+"""
+
+from typing import Dict, List, Optional
+
+from app.core.logger import logger
+from app.database.decoder.breeze_buddy.alert_groups import decode_alert_group
+from app.database.queries import run_parameterized_query
+from app.database.queries.breeze_buddy.alert_groups import (
+    get_alert_group_by_name_query,
+    upsert_alert_group_query,
+)
+from app.schemas.breeze_buddy.alerts import AlertGroup
+
+
+async def get_alert_group_by_name(name: str, reseller_id: str) -> Optional[AlertGroup]:
+    """
+    Fetch alert group by name, scoped to a reseller.
+
+    Returns:
+        AlertGroup model, or None if not found.
+    """
+    try:
+        text, values = get_alert_group_by_name_query(name, reseller_id)
+        result = await run_parameterized_query(text, values)
+        return decode_alert_group(result[0] if result else None)
+    except Exception as e:
+        logger.error(
+            f"Error fetching alert group '{name}' for reseller '{reseller_id}': {e}"
+        )
+        raise
+
+
+async def upsert_alert_group(
+    name: str, reseller_id: str, members: List[Dict[str, str]]
+) -> Optional[AlertGroup]:
+    """
+    Create or update an alert group scoped to a reseller.
+
+    Args:
+        name: Group name (unique per reseller)
+        reseller_id: Owning reseller identifier
+        members: List of dicts with 'name' and 'phone' keys
+
+    Returns:
+        The created/updated AlertGroup model, or None on failure.
+    """
+    try:
+        text, values = upsert_alert_group_query(name, reseller_id, members)
+        result = await run_parameterized_query(text, values)
+        return decode_alert_group(result[0] if result else None)
+    except Exception as e:
+        logger.error(
+            f"Error upserting alert group '{name}' for reseller '{reseller_id}': {e}"
+        )
+        raise

--- a/app/database/decoder/breeze_buddy/alert_groups.py
+++ b/app/database/decoder/breeze_buddy/alert_groups.py
@@ -1,0 +1,23 @@
+"""Decoders for alert_groups rows."""
+
+import json
+from typing import Optional
+
+from app.schemas.breeze_buddy.alerts import AlertGroup
+
+
+def decode_alert_group(row) -> Optional[AlertGroup]:
+    """Build AlertGroup from database row, or None if row is empty."""
+    if not row:
+        return None
+    members = row["members"]
+    if isinstance(members, str):
+        members = json.loads(members)
+    return AlertGroup(
+        id=str(row["id"]),
+        name=row["name"],
+        reseller_id=row["reseller_id"],
+        members=members,
+        created_at=row["created_at"],
+        updated_at=row["updated_at"],
+    )

--- a/app/database/migrations/034_add_alert_system_role_and_telephony_alert_mode.sql
+++ b/app/database/migrations/034_add_alert_system_role_and_telephony_alert_mode.sql
@@ -1,0 +1,17 @@
+-- 034_add_alert_system_role_and_telephony_alert_mode.sql
+-- 1. Add 'alert_system' to the users role CHECK constraint.
+-- 2. Add 'TELEPHONY_ALERT' to the lead_call_tracker execution_mode CHECK constraint.
+
+BEGIN;
+
+-- Users role: add 'alert_system'
+ALTER TABLE users DROP CONSTRAINT IF EXISTS users_role_check;
+ALTER TABLE users ADD CONSTRAINT users_role_check
+    CHECK (role IN ('admin', 'reseller', 'merchant', 'user', 'alert_system'));
+
+-- Execution mode: add 'TELEPHONY_ALERT'
+ALTER TABLE lead_call_tracker DROP CONSTRAINT IF EXISTS lead_call_tracker_execution_mode_check;
+ALTER TABLE lead_call_tracker ADD CONSTRAINT lead_call_tracker_execution_mode_check
+    CHECK (execution_mode IN ('TELEPHONY', 'TELEPHONY_TEST', 'DAILY', 'DAILY_TEST', 'DAILY_STREAM', 'HOLD_TRANSFER', 'TELEPHONY_ALERT'));
+
+COMMIT;

--- a/app/database/migrations/035_create_alert_groups_table.sql
+++ b/app/database/migrations/035_create_alert_groups_table.sql
@@ -1,0 +1,16 @@
+-- 035_create_alert_groups_table.sql
+-- Alert groups: named sets of phone numbers to call when an alert fires.
+-- Scoped by reseller_id so each reseller manages its own groups.
+-- members is a JSONB array: [{"name": "Alice", "phone": "+919876543210"}, ...]
+
+CREATE TABLE IF NOT EXISTS alert_groups (
+    id           UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+    name         TEXT        NOT NULL,
+    reseller_id  TEXT        NOT NULL,
+    members      JSONB       NOT NULL DEFAULT '[]'::jsonb,
+    created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (name, reseller_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_alert_groups_reseller_id ON alert_groups (reseller_id);

--- a/app/database/queries/breeze_buddy/alert_groups.py
+++ b/app/database/queries/breeze_buddy/alert_groups.py
@@ -1,0 +1,35 @@
+"""
+Database query functions for alert_groups table.
+"""
+
+import json
+from typing import Any, Dict, List, Tuple
+
+ALERT_GROUPS_TABLE = "alert_groups"
+
+
+def get_alert_group_by_name_query(name: str, reseller_id: str) -> Tuple[str, List[Any]]:
+    """Get alert group by name scoped to a reseller."""
+    text = f"""
+        SELECT "id", "name", "reseller_id", "members", "created_at", "updated_at"
+        FROM "{ALERT_GROUPS_TABLE}"
+        WHERE "name" = $1 AND "reseller_id" = $2;
+    """
+    values: List[Any] = [name, reseller_id]
+    return text, values
+
+
+def upsert_alert_group_query(
+    name: str, reseller_id: str, members: List[Dict[str, str]]
+) -> Tuple[str, List[Any]]:
+    """Create or update an alert group scoped to a reseller."""
+    text = f"""
+        INSERT INTO "{ALERT_GROUPS_TABLE}" ("name", "reseller_id", "members", "updated_at")
+        VALUES ($1, $2, $3::jsonb, NOW())
+        ON CONFLICT ("name", "reseller_id") DO UPDATE
+            SET "members" = EXCLUDED."members",
+                "updated_at" = NOW()
+        RETURNING "id", "name", "reseller_id", "members", "created_at", "updated_at";
+    """
+    values: List[Any] = [name, reseller_id, json.dumps(members)]
+    return text, values

--- a/app/database/queries/breeze_buddy/analytics.py
+++ b/app/database/queries/breeze_buddy/analytics.py
@@ -113,7 +113,9 @@ def build_analytics_where_clause(
     # HOLD_TRANSFER is included so hold & consult outbound legs appear in
     # the dashboard alongside regular TELEPHONY calls.
     if filter_execution_mode:
-        conditions.append("lct.execution_mode IN ('TELEPHONY', 'HOLD_TRANSFER')")
+        conditions.append(
+            "lct.execution_mode IN ('TELEPHONY', 'TELEPHONY_ALERT', 'HOLD_TRANSFER')"
+        )
 
     # Date range filters - convert IST to UTC before passing to DB
     if "date_from" in filters and filters["date_from"]:

--- a/app/database/queries/breeze_buddy/dispatch.py
+++ b/app/database/queries/breeze_buddy/dispatch.py
@@ -28,7 +28,7 @@ def get_unscheduled_backlog_leads_query(
         FROM "{LEAD_CALL_TRACKER_TABLE}"
         WHERE "status" = 'BACKLOG'
           AND "is_locked" = FALSE
-          AND "execution_mode" IN ('TELEPHONY', 'TELEPHONY_TEST')
+          AND "execution_mode" IN ('TELEPHONY', 'TELEPHONY_TEST', 'TELEPHONY_ALERT')
           AND "next_attempt_at" <= NOW() + ($1 || ' seconds')::interval
         ORDER BY "next_attempt_at" ASC
         LIMIT $2;

--- a/app/schemas/__init__.py
+++ b/app/schemas/__init__.py
@@ -9,6 +9,7 @@ organized hierarchically:
   - core.py: Core domain models (leads, numbers, configs)
 """
 
+from app.schemas.breeze_buddy.alerts import AlertFireRequest, AlertGroup
 from app.schemas.breeze_buddy.analytics import (
     AnalyticsFilters,
     AnalyticsOptions,
@@ -91,6 +92,9 @@ from app.schemas.feature_flags import (
 )
 
 __all__ = [
+    # Alerts
+    "AlertFireRequest",
+    "AlertGroup",
     # Auth
     "AuthTokenData",
     "LaunchTokenRequest",

--- a/app/schemas/breeze_buddy/__init__.py
+++ b/app/schemas/breeze_buddy/__init__.py
@@ -1,5 +1,6 @@
 """Breeze Buddy agent schemas."""
 
+from app.schemas.breeze_buddy.alerts import AlertFireRequest, AlertGroup
 from app.schemas.breeze_buddy.analytics import (
     AnalyticsFilters,
     AnalyticsOptions,
@@ -63,6 +64,9 @@ from app.schemas.breeze_buddy.users import (
 )
 
 __all__ = [
+    # Alerts
+    "AlertFireRequest",
+    "AlertGroup",
     # Auth
     "AuthTokenData",
     "LaunchTokenRequest",

--- a/app/schemas/breeze_buddy/alerts.py
+++ b/app/schemas/breeze_buddy/alerts.py
@@ -1,0 +1,79 @@
+"""Alert-related request/response schemas."""
+
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, Field
+
+
+class AlertGroup(BaseModel):
+    """Alert group model matching the alert_groups DB table."""
+
+    id: str
+    name: str
+    reseller_id: str
+    members: List[Dict[str, str]]
+    created_at: Optional[datetime] = None
+    updated_at: Optional[datetime] = None
+
+
+class AlertFireRequest(BaseModel):
+    """Request body for POST /alerts/fire.
+
+    Note: reseller_id is NOT in the body — it comes from the JWT token claims.
+    This prevents reseller impersonation. The token must be scoped to exactly
+    one reseller (reseller_ids must have a single entry, not ["*"]).
+    """
+
+    # Dedup key — must be unique per alert scenario.
+    # OpenObserve: use {alert_name} template variable (e.g. "stt-degraded")
+    # Internal: use a descriptive ID (e.g. "stt-degraded-<epoch_bucket>")
+    alert_id: str = Field(
+        ...,
+        min_length=1,
+        description="Unique alert identifier for deduplication",
+        examples=["stt-degraded", "tts-elevenlabs-down"],
+    )
+
+    # Which group of people to call
+    alert_group_name: str = Field(
+        ...,
+        min_length=1,
+        description="Name of the alert group (must exist in alert_groups table for this reseller)",
+        examples=["platform-oncall"],
+    )
+
+    # Human-readable message spoken via TTS
+    # The caller builds this string — the endpoint just passes it through
+    alert_message: str = Field(
+        ...,
+        min_length=1,
+        description="Alert message spoken via TTS on the call",
+        examples=["STT degraded: 47 errors in 5 minutes"],
+    )
+
+    # BB template config — fully reuses existing template machinery
+    # merchant_id is optional and validated against the token's merchant_ids scope
+    merchant_id: Optional[str] = Field(
+        None,
+        description="Merchant ID (optional). Validated against JWT token scope.",
+    )
+    template: str = Field(
+        ...,
+        min_length=1,
+        description="BB template name (must exist in templates table)",
+        examples=["alert-voice-notification"],
+    )
+
+    # How long (seconds) to suppress duplicate alerts for this alert_id
+    dedup_ttl_seconds: int = Field(
+        default=300,
+        ge=0,
+        description="Dedup window in seconds. 0 = no dedup.",
+    )
+
+    # Extra payload fields merged into the lead payload
+    extra_payload: Optional[Dict[str, Any]] = Field(
+        default=None,
+        description="Additional fields to include in the lead payload",
+    )

--- a/app/schemas/breeze_buddy/auth.py
+++ b/app/schemas/breeze_buddy/auth.py
@@ -23,6 +23,7 @@ class UserRole(str, Enum):
     RESELLER = "reseller"
     MERCHANT = "merchant"
     USER = "user"  # Renamed from SHOP
+    ALERT_SYSTEM = "alert_system"
 
 
 class Permission(str, Enum):

--- a/app/schemas/breeze_buddy/core.py
+++ b/app/schemas/breeze_buddy/core.py
@@ -44,6 +44,7 @@ class ExecutionMode(str, Enum):
 
     TELEPHONY = "TELEPHONY"  # Production telephony calls
     TELEPHONY_TEST = "TELEPHONY_TEST"  # Test telephony calls
+    TELEPHONY_ALERT = "TELEPHONY_ALERT"  # Alert-triggered telephony calls
     DAILY = "DAILY"  # Production Daily (web) calls
     DAILY_TEST = "DAILY_TEST"  # Test Daily (web) calls
     DAILY_STREAM = "DAILY_STREAM"  # Daily STT/TTS-only (no LLM, client-driven)

--- a/tests/breeze_buddy/alerts/conftest.py
+++ b/tests/breeze_buddy/alerts/conftest.py
@@ -1,0 +1,12 @@
+"""Conftest for alerts tests -- sets required env vars for imports."""
+
+import os
+
+# Must be set before the app's module-level imports fire.
+os.environ.setdefault("JWT_SECRET_KEY", "test-secret-key-for-tests-only")
+os.environ.setdefault("JWT_ALGORITHM", "HS256")
+os.environ.setdefault("JWT_ACCESS_TOKEN_EXPIRE_MINUTES", "60")
+os.environ.setdefault("BREEZE_BUDDY_SESSION_SECRET_KEY", "test-session-secret")
+os.environ.setdefault("BREEZE_BUDDY_DASHBOARD_USERNAME", "test_admin")
+os.environ.setdefault("BREEZE_BUDDY_DASHBOARD_PASSWORD", "test_password")
+os.environ.setdefault("BB_DISPATCH_QPS_JITTER_MS", "100")

--- a/tests/breeze_buddy/alerts/test_handler.py
+++ b/tests/breeze_buddy/alerts/test_handler.py
@@ -1,0 +1,417 @@
+"""
+Unit tests for ``app.api.routers.breeze_buddy.alerts.handlers``.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Dict, Optional
+
+import pytest
+
+from app.api.routers.breeze_buddy.alerts import handlers as handlers_mod
+from app.schemas import (
+    ExecutionMode,
+    LeadCallStatus,
+    LeadCallTracker,
+    UserInfo,
+    UserRole,
+)
+from app.schemas.breeze_buddy.alerts import AlertGroup
+
+# ---------------------------------------------------------------------------
+# _mask_phone
+# ---------------------------------------------------------------------------
+
+
+def test_mask_phone_full_masking_short_number():
+    """Phones of 4 or fewer digits are fully masked."""
+    assert handlers_mod._mask_phone("1234") == "****"
+
+
+def test_mask_phone_full_masking_long_number():
+    """Phones longer than 4 digits return '****' with NO partial digits exposed."""
+    result = handlers_mod._mask_phone("+919876543210")
+    assert result == "****"
+
+
+def test_mask_phone_empty_returns_stars():
+    assert handlers_mod._mask_phone("") == "****"
+
+
+# ---------------------------------------------------------------------------
+# _try_dedup_acquire -- fail-open
+# ---------------------------------------------------------------------------
+
+
+async def test_dedup_acquire_returns_true_on_new_key(monkeypatch):
+    """First SET NX should acquire (return True)."""
+
+    class FakeRedisClient:
+        async def set(self, *args, **kwargs):
+            return True
+
+    class FakeRedisService:
+        async def get_client(self):
+            return FakeRedisClient()
+
+    async def _get():
+        return FakeRedisService()
+
+    monkeypatch.setattr(handlers_mod, "get_redis_service", _get)
+
+    result = await handlers_mod._try_dedup_acquire("key1", 300)
+    assert result is True
+
+
+async def test_dedup_acquire_returns_false_on_existing_key(monkeypatch):
+    """SET NX returns False when key already exists."""
+
+    class FakeRedisClient:
+        async def set(self, *args, **kwargs):
+            return False
+
+    class FakeRedisService:
+        async def get_client(self):
+            return FakeRedisClient()
+
+    async def _get():
+        return FakeRedisService()
+
+    monkeypatch.setattr(handlers_mod, "get_redis_service", _get)
+
+    result = await handlers_mod._try_dedup_acquire("key1", 300)
+    assert result is False
+
+
+async def test_dedup_acquire_fail_open_on_redis_error(monkeypatch):
+    """Redis connection error returns None (fail-open, proceed with alert)."""
+
+    async def _get():
+        raise RuntimeError("simulated Redis outage")
+
+    monkeypatch.setattr(handlers_mod, "get_redis_service", _get)
+
+    result = await handlers_mod._try_dedup_acquire("key1", 300)
+    assert result is None
+
+
+async def test_dedup_acquire_fail_open_on_set_error(monkeypatch):
+    """Redis.set raising an exception returns None (fail-open)."""
+
+    class BrokenRedisClient:
+        async def set(self, *args, **kwargs):
+            raise RuntimeError("simulated SET failure")
+
+    class FakeRedisService:
+        async def get_client(self):
+            return BrokenRedisClient()
+
+    async def _get():
+        return FakeRedisService()
+
+    monkeypatch.setattr(handlers_mod, "get_redis_service", _get)
+
+    result = await handlers_mod._try_dedup_acquire("key1", 300)
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# _try_dedup_release -- error suppression
+# ---------------------------------------------------------------------------
+
+
+async def test_dedup_release_does_not_raise_on_error(monkeypatch):
+    """Release failures are logged, never raised."""
+
+    async def _get():
+        raise RuntimeError("simulated Redis outage")
+
+    monkeypatch.setattr(handlers_mod, "get_redis_service", _get)
+
+    # Must not raise
+    await handlers_mod._try_dedup_release("key1")
+
+
+# ---------------------------------------------------------------------------
+# fire_alert_handler -- dedup_release on partial failure
+# ---------------------------------------------------------------------------
+
+
+def _make_user() -> UserInfo:
+    return UserInfo(
+        id="user-1",
+        username="alert_bot",
+        role=UserRole.ALERT_SYSTEM,
+        reseller_ids=["res-1"],
+    )
+
+
+def _make_req(**overrides: Any) -> Any:
+    """Build an AlertFireRequest-like object (not Pydantic, to avoid validation)."""
+    from app.schemas import AlertFireRequest
+
+    defaults: Dict[str, Any] = {
+        "alert_id": "test-alert",
+        "alert_group_name": "oncall",
+        "alert_message": "Test alert",
+        "merchant_id": "merchant-1",
+        "template": "alert-template",
+        "dedup_ttl_seconds": 300,
+        "extra_payload": None,
+    }
+    defaults.update(overrides)
+    return AlertFireRequest(**defaults)
+
+
+class FakeTemplate:
+    id = "tmpl-1"
+
+
+class FakeConfig:
+    template = "alert-template"
+
+
+class FakeLeadResponse:
+    id = "lead-1"
+    reseller_id = "res-1"
+    template = "alert-template"
+    template_id = "tmpl-1"
+    merchant_id = "merchant-1"
+    payload = {}
+    metaData = {}
+    status = LeadCallStatus.BACKLOG
+    execution_mode = ExecutionMode.TELEPHONY_ALERT
+    attempt_count = 0
+
+
+def _make_group(members: list) -> AlertGroup:
+    return AlertGroup(
+        id="grp-1",
+        name="oncall",
+        reseller_id="res-1",
+        members=members,
+        created_at=datetime.now(timezone.utc),
+        updated_at=datetime.now(timezone.utc),
+    )
+
+
+async def test_handler_dedup_released_on_partial_failure(monkeypatch):
+    """
+    5 members, 3 queue successfully, 2 fail.
+    Dedup key must be released so retries are not suppressed.
+    """
+    dedup_released: list[str] = []
+
+    # -- Mock Redis: acquire succeeds, capture release calls ----------
+    class FakeRedis:
+        async def get_client(self):
+            return self
+
+        async def set(self, *args, **kwargs):
+            return True  # acquire
+
+        async def delete(self, key: str):
+            dedup_released.append(key)
+
+    async def _redis_get():
+        return FakeRedis()
+
+    monkeypatch.setattr(handlers_mod, "get_redis_service", _redis_get)
+
+    # -- Mock DB: alert group with 5 members --------------------------
+    members = [{"name": f"user{i}", "phone": f"+91987654321{i}"} for i in range(5)]
+
+    async def _get_group(name: str, reseller_id: str):
+        return _make_group(members)
+
+    monkeypatch.setattr(handlers_mod, "get_alert_group_by_name", _get_group)
+
+    # -- Mock template lookup -----------------------------------------
+    async def _get_template(*args, **kwargs):
+        return FakeTemplate()
+
+    monkeypatch.setattr(handlers_mod, "get_template_in_scope", _get_template)
+
+    # -- Mock config lookup -------------------------------------------
+    async def _get_config(*args, **kwargs):
+        return [FakeConfig()]
+
+    monkeypatch.setattr(
+        handlers_mod, "get_call_execution_config_by_merchant_id", _get_config
+    )
+
+    # -- Mock lead creation: 3 succeed, 2 fail ------------------------
+    call_count = 0
+
+    async def _create_lead(**kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count <= 3:
+            return FakeLeadResponse()
+        return None
+
+    monkeypatch.setattr(handlers_mod, "create_lead_call_tracker", _create_lead)
+
+    # -- Mock schedule -------------------------------------------------
+    async def _schedule(lead_id: str, next_attempt_at: datetime):
+        return True
+
+    monkeypatch.setattr(handlers_mod, "schedule_lead", _schedule)
+
+    # -- Execute -------------------------------------------------------
+    req = _make_req()
+    user = _make_user()
+    result = await handlers_mod.fire_alert_handler(req, user, "res-1")
+
+    assert result["status"] == "queued"
+    assert len(result["leads"]) == 3
+    assert len(result["failed"]) == 2
+    # Dedup must be released since not ALL members queued
+    assert len(dedup_released) == 1
+
+
+async def test_handler_dedup_held_on_full_success(monkeypatch):
+    """All 3 members queue successfully -- dedup key must NOT be released."""
+    dedup_released: list[str] = []
+
+    class FakeRedis:
+        async def get_client(self):
+            return self
+
+        async def set(self, *args, **kwargs):
+            return True
+
+        async def delete(self, key: str):
+            dedup_released.append(key)
+
+    async def _redis_get():
+        return FakeRedis()
+
+    monkeypatch.setattr(handlers_mod, "get_redis_service", _redis_get)
+
+    members = [{"name": f"user{i}", "phone": f"+91987654321{i}"} for i in range(3)]
+
+    async def _get_group(name: str, reseller_id: str):
+        return _make_group(members)
+
+    monkeypatch.setattr(handlers_mod, "get_alert_group_by_name", _get_group)
+
+    async def _get_template(*args, **kwargs):
+        return FakeTemplate()
+
+    monkeypatch.setattr(handlers_mod, "get_template_in_scope", _get_template)
+
+    async def _get_config(*args, **kwargs):
+        return [FakeConfig()]
+
+    monkeypatch.setattr(
+        handlers_mod, "get_call_execution_config_by_merchant_id", _get_config
+    )
+
+    async def _create_lead(**kwargs):
+        return FakeLeadResponse()
+
+    monkeypatch.setattr(handlers_mod, "create_lead_call_tracker", _create_lead)
+
+    async def _schedule(lead_id: str, next_attempt_at: datetime):
+        return True
+
+    monkeypatch.setattr(handlers_mod, "schedule_lead", _schedule)
+
+    req = _make_req()
+    user = _make_user()
+    result = await handlers_mod.fire_alert_handler(req, user, "res-1")
+
+    assert result["status"] == "queued"
+    assert len(result["leads"]) == 3
+    assert len(result["failed"]) == 0
+    # Dedup must NOT be released -- all leads queued successfully
+    assert len(dedup_released) == 0
+
+
+async def test_handler_dedup_not_called_when_ttl_zero(monkeypatch):
+    """dedup_ttl_seconds=0 means skip dedup entirely."""
+    acquire_called = False
+
+    class FakeRedis:
+        async def get_client(self):
+            return self
+
+        async def set(self, *args, **kwargs):
+            nonlocal acquire_called
+            acquire_called = True
+            return True
+
+    async def _redis_get():
+        return FakeRedis()
+
+    monkeypatch.setattr(handlers_mod, "get_redis_service", _redis_get)
+
+    members = [{"name": "user1", "phone": "+919876543210"}]
+
+    async def _get_group(name: str, reseller_id: str):
+        return _make_group(members)
+
+    monkeypatch.setattr(handlers_mod, "get_alert_group_by_name", _get_group)
+
+    async def _get_template(*args, **kwargs):
+        return FakeTemplate()
+
+    monkeypatch.setattr(handlers_mod, "get_template_in_scope", _get_template)
+
+    async def _get_config(*args, **kwargs):
+        return [FakeConfig()]
+
+    monkeypatch.setattr(
+        handlers_mod, "get_call_execution_config_by_merchant_id", _get_config
+    )
+
+    async def _create_lead(**kwargs):
+        return FakeLeadResponse()
+
+    monkeypatch.setattr(handlers_mod, "create_lead_call_tracker", _create_lead)
+
+    async def _schedule(lead_id: str, next_attempt_at: datetime):
+        return True
+
+    monkeypatch.setattr(handlers_mod, "schedule_lead", _schedule)
+
+    req = _make_req(dedup_ttl_seconds=0)
+    user = _make_user()
+    result = await handlers_mod.fire_alert_handler(req, user, "res-1")
+
+    assert result["status"] == "queued"
+    assert not acquire_called
+
+
+async def test_handler_404_becomes_422_for_missing_group(monkeypatch):
+    """Missing alert group raises HTTP 422, not 404."""
+
+    class FakeRedis:
+        async def get_client(self):
+            return self
+
+        async def set(self, *args, **kwargs):
+            return True
+
+    async def _redis_get():
+        return FakeRedis()
+
+    monkeypatch.setattr(handlers_mod, "get_redis_service", _redis_get)
+
+    async def _get_group(name: str, reseller_id: str):
+        return None  # group not found
+
+    monkeypatch.setattr(handlers_mod, "get_alert_group_by_name", _get_group)
+
+    req = _make_req()
+    user = _make_user()
+
+    from fastapi import HTTPException
+
+    with pytest.raises(HTTPException) as exc_info:
+        await handlers_mod.fire_alert_handler(req, user, "res-1")
+
+    assert exc_info.value.status_code == 422
+    assert "not found" in str(exc_info.value.detail).lower()

--- a/tests/breeze_buddy/dispatch/test_queue.py
+++ b/tests/breeze_buddy/dispatch/test_queue.py
@@ -121,8 +121,8 @@ async def test_schedule_lead_does_not_raise_on_redis_error(monkeypatch):
 # ---------------------------------------------------------------------------
 
 
-def test_is_dispatchable_telephony_modes_only():
-    """Only TELEPHONY and TELEPHONY_TEST should pass the gate.
+def test_is_dispatchable_outbound_pstn_modes_only():
+    """Only standalone outbound PSTN modes should pass the gate.
 
     DAILY / DAILY_TEST / DAILY_STREAM are web-mode (customer joins a Daily
     room) — they must NOT enter the dispatcher's PSTN-dial path. HOLD_TRANSFER
@@ -133,6 +133,7 @@ def test_is_dispatchable_telephony_modes_only():
 
     assert queue.is_dispatchable(ExecutionMode.TELEPHONY) is True
     assert queue.is_dispatchable(ExecutionMode.TELEPHONY_TEST) is True
+    assert queue.is_dispatchable(ExecutionMode.TELEPHONY_ALERT) is True
     assert queue.is_dispatchable(ExecutionMode.DAILY) is False
     assert queue.is_dispatchable(ExecutionMode.DAILY_TEST) is False
     assert queue.is_dispatchable(ExecutionMode.DAILY_STREAM) is False


### PR DESCRIPTION
Standalone alerting service for firing voice calls to on-call groups.

- POST /alerts/fire endpoint with Redis SETNX deduplication
- alert_groups DB table (migration 023) + queries + accessors
- ALERT_SYSTEM role added to UserRole enum for JWT auth
- Fully parameterized via request body (no config dependencies)
- Reuses existing BB template/lead machinery end-to-end

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a voice alert notification system with a new endpoint to trigger alerts to designated recipient groups.
  * Implemented built-in deduplication to prevent duplicate alerts within configurable time windows.
  * Added alert group management for organizing alert recipients by name.

* **Documentation**
  * Added comprehensive design documentation for the voice alert notification system including architecture and usage guidelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->