### PR TITLE
feat: stream SSE global function responses over RTVI

### DIFF
--- a/app/ai/voice/agents/breeze_buddy/handlers/transport/http_handler.py
+++ b/app/ai/voice/agents/breeze_buddy/handlers/transport/http_handler.py
@@ -20,6 +20,9 @@ from typing import Any, Dict, Optional, Tuple
 from app.ai.voice.agents.breeze_buddy.handlers.transport.http_requester import (
     HttpRequestExecutor,
 )
+from app.ai.voice.agents.breeze_buddy.handlers.transport.rtvi import (
+    SseRtviForwarder,
+)
 from app.ai.voice.agents.breeze_buddy.handlers.transport.utils.field_resolver import (
     FieldResolver,
 )
@@ -27,6 +30,7 @@ from app.ai.voice.agents.breeze_buddy.template.context import TemplateContext
 from app.ai.voice.agents.breeze_buddy.template.types import (
     FieldSource,
     GlobalHttpFunction,
+    SseResponseMode,
 )
 from app.core.logger import logger
 
@@ -131,10 +135,15 @@ async def http_function_handler(
             f"request to {config.http_request.url}"
         )
 
+        # SSE events stream to the client automatically via the forwarder;
+        # sse_response_handler only shapes what the LLM sees on return.
+        sse_forwarder = SseRtviForwarder(context, function_name)
+
         result = await executor.execute(
             config=config.http_request,
             resolved_fields=resolved_fields,
             fire_and_forget=False,  # KEY: Wait for response
+            on_sse_event=sse_forwarder,
         )
 
         # Step 3: Handle response
@@ -152,18 +161,41 @@ async def http_function_handler(
             f"body_length={len(response_body)} bytes"
         )
 
-        # Step 4: Try to parse JSON, fallback to raw text
-        try:
-            data = json.loads(response_body)
-            logger.debug(
-                f"[{function_name}] Parsed JSON response with "
-                f"{len(data) if isinstance(data, dict) else 'non-dict'} keys"
-            )
-        except json.JSONDecodeError:
-            logger.debug(
-                f"[{function_name}] Response is not valid JSON, using raw text"
-            )
-            data = response_body
+        data: Any
+        chunks = sse_forwarder.chunks
+        if chunks:
+            logger.info(f"[{function_name}] SSE response: {len(chunks)} chunks")
+            sse_forwarder.emit_end()
+            handler_cfg = config.sse_response_handler
+            if handler_cfg and handler_cfg.mode == SseResponseMode.SELECT:
+                idx = handler_cfg.select_index
+                try:
+                    if idx is None:
+                        raise IndexError("select_index not set")
+                    data = chunks[idx].get("data", "")
+                    logger.info(f"[{function_name}] SSE select[{idx}] returned to LLM")
+                except IndexError as e:
+                    logger.warning(
+                        f"[{function_name}] invalid select_index={idx} "
+                        f"for {len(chunks)} chunks: {e}"
+                    )
+                    return {
+                        "status": "error",
+                        "error": "Something went wrong",
+                    }, None
+            else:
+                # None / FULL: concatenated data strings from the executor.
+                data = response_body
+                logger.debug(
+                    f"[{function_name}] SSE full mode: {len(response_body)} bytes to LLM"
+                )
+        else:
+            try:
+                data = json.loads(response_body)
+                logger.debug(f"[{function_name}] parsed JSON response")
+            except json.JSONDecodeError:
+                data = response_body
+                logger.debug(f"[{function_name}] non-JSON response, using raw text")
 
         # Step 5: Return formatted response to LLM
         is_success = 200 <= status_code < 300

--- a/app/ai/voice/agents/breeze_buddy/handlers/transport/http_requester.py
+++ b/app/ai/voice/agents/breeze_buddy/handlers/transport/http_requester.py
@@ -16,7 +16,7 @@ import asyncio
 import base64
 import ipaddress
 import json
-from typing import Any, Optional, Tuple
+from typing import Any, Awaitable, Callable, Dict, Optional, Tuple
 from urllib.parse import urlencode, urlparse
 
 import aiohttp
@@ -56,6 +56,7 @@ class HttpRequestExecutor:
         config: HttpRequestConfig,
         resolved_fields: Optional[dict] = None,
         fire_and_forget: bool = True,
+        on_sse_event: Optional[Callable[[Dict[str, Any]], Awaitable[None]]] = None,
     ) -> Optional[Tuple[int, str]]:
         """
         Execute HTTP request with template resolution.
@@ -66,6 +67,12 @@ class HttpRequestExecutor:
                             Defaults to empty dict if None.
             fire_and_forget: If True (default), returns None (hook behavior).
                             If False, returns (status_code, response_body) tuple.
+            on_sse_event: Optional async callback invoked once per parsed SSE event
+                          when the server responds with Content-Type: text/event-stream
+                          and fire_and_forget is False. Each event is
+                          ``{"event": str|None, "id": str|None, "data": str}``.
+                          When SSE is consumed, ``response_body`` is the newline-joined
+                          concatenation of all event ``data`` fields.
 
         Returns:
             None if fire_and_forget=True
@@ -151,6 +158,27 @@ class HttpRequestExecutor:
                                     return (0, error_msg)
                             except ValueError:
                                 pass  # Invalid Content-Length, will check actual size below
+
+                        # SSE branch: stream events when the server opts in
+                        # with text/event-stream and the caller supplied a
+                        # per-event callback. Only on 2xx — error bodies fall
+                        # through to the bulk read path below.
+                        is_sse = "text/event-stream" in content_type
+                        if (
+                            is_sse
+                            and on_sse_event is not None
+                            and not fire_and_forget
+                            and 200 <= status < 300
+                        ):
+                            concatenated = await self._consume_sse_stream(
+                                response=response,
+                                on_sse_event=on_sse_event,
+                            )
+                            logger.info(
+                                f"HTTP {config.method.value} SSE stream complete: "
+                                f"total_data_bytes={len(concatenated)}"
+                            )
+                            return (status, concatenated)
 
                         # Read response with size limit
                         response_bytes = await response.content.read(
@@ -242,6 +270,68 @@ class HttpRequestExecutor:
             if fire_and_forget:
                 return None
             return (0, str(e))
+
+    @staticmethod
+    async def _consume_sse_stream(
+        response: aiohttp.ClientResponse,
+        on_sse_event: Callable[[Dict[str, Any]], Awaitable[None]],
+    ) -> str:
+        """Parse a text/event-stream response line by line.
+
+        SSE: blank line terminates an event; multiple ``data:`` lines join with
+        ``\\n``; lines starting with ``:`` are comments; fields have the form
+        ``field: value`` with an optional space after the colon. Stops once
+        emitted data exceeds ``HTTP_REQUEST_MAX_RESPONSE_BYTES``.
+        """
+        chunks: list[str] = []
+        total_bytes = 0
+        event_name: Optional[str] = None
+        event_id: Optional[str] = None
+        data_lines: list[str] = []
+
+        async def dispatch() -> None:
+            nonlocal event_name, event_id, data_lines, total_bytes
+            if not data_lines and event_name is None:
+                return
+            event_data = "\n".join(data_lines)
+            try:
+                await on_sse_event(
+                    {"event": event_name, "id": event_id, "data": event_data}
+                )
+            except Exception as cb_err:
+                logger.warning(f"on_sse_event callback raised: {cb_err}")
+            chunks.append(event_data)
+            total_bytes += len(event_data.encode("utf-8"))
+            event_name = None
+            event_id = None
+            data_lines = []
+
+        while True:
+            line_bytes = await response.content.readline()
+            if not line_bytes:
+                break
+            line = line_bytes.decode("utf-8", errors="replace").rstrip("\r\n")
+            if line == "":
+                await dispatch()
+                if total_bytes > HTTP_REQUEST_MAX_RESPONSE_BYTES:
+                    logger.warning(
+                        f"SSE stream exceeded {HTTP_REQUEST_MAX_RESPONSE_BYTES} bytes; closing"
+                    )
+                    break
+                continue
+            if line.startswith(":"):
+                continue
+            field, _, value = line.partition(":")
+            if value.startswith(" "):
+                value = value[1:]
+            if field == "data":
+                data_lines.append(value)
+            elif field == "event":
+                event_name = value
+            elif field == "id":
+                event_id = value
+        await dispatch()
+        return "\n".join(chunks)
 
     def _build_headers_with_auth(
         self, headers_dict: dict, auth_config, has_body: bool

--- a/app/ai/voice/agents/breeze_buddy/handlers/transport/rtvi.py
+++ b/app/ai/voice/agents/breeze_buddy/handlers/transport/rtvi.py
@@ -1,0 +1,57 @@
+"""RTVI event emission for global HTTP function SSE streams.
+
+Mirrors each parsed SSE event (and a terminal end marker) to connected Daily
+clients as RTVIServerMessages. Emissions are scheduled on the event loop and
+never awaited, so RTVI push latency can't block SSE consumption or the
+handler's return to the LLM.
+"""
+
+import asyncio
+from typing import Any, Dict, List
+
+from app.ai.voice.agents.breeze_buddy.template.context import TemplateContext
+
+SSE_EVENT_TYPE = "global-function-sse-event"
+SSE_END_TYPE = "global-function-sse-end"
+
+
+def _schedule_emit(
+    context: TemplateContext, event_type: str, payload: Dict[str, Any]
+) -> None:
+    """Fire-and-forget RTVI server message. No-op when off Daily."""
+    emit = getattr(context.bot, "_emit_rtvi_event", None)
+    if emit is None:
+        return
+    asyncio.create_task(emit(event_type, payload))
+
+
+class SseRtviForwarder:
+    """Callable that records SSE chunks and streams each to the client."""
+
+    def __init__(self, context: TemplateContext, function_name: str):
+        self._context = context
+        self._function_name = function_name
+        self.chunks: List[Dict[str, Any]] = []
+
+    async def __call__(self, event: Dict[str, Any]) -> None:
+        index = len(self.chunks)
+        self.chunks.append(event)
+        _schedule_emit(
+            self._context,
+            SSE_EVENT_TYPE,
+            {
+                "function_name": self._function_name,
+                "index": index,
+                "event": event,
+            },
+        )
+
+    def emit_end(self) -> None:
+        _schedule_emit(
+            self._context,
+            SSE_END_TYPE,
+            {
+                "function_name": self._function_name,
+                "total_events": len(self.chunks),
+            },
+        )

--- a/app/ai/voice/agents/breeze_buddy/template/types.py
+++ b/app/ai/voice/agents/breeze_buddy/template/types.py
@@ -819,6 +819,28 @@ class BaseGlobalFunction(BaseModel):
     func_post_actions: List[FlowAction] = Field(default=[], alias="post_actions")
 
 
+class SseResponseMode(str, Enum):
+    """How SSE response chunks are returned to the LLM."""
+
+    FULL = "full"
+    SELECT = "select"
+
+
+class SseResponseHandlerConfig(BaseModel):
+    """Controls how an SSE (text/event-stream) response is returned to the LLM.
+
+    RTVI streaming of each SSE event to the client happens automatically in
+    Daily mode regardless of this config. This only shapes the LLM-visible
+    payload.
+
+    - FULL: return concatenated data strings across all events to the LLM.
+    - SELECT: return only the chunk at `select_index` (supports negative indexing).
+    """
+
+    mode: SseResponseMode = SseResponseMode.FULL
+    select_index: Optional[int] = None
+
+
 class GlobalHttpFunction(BaseGlobalFunction):
     """
     Configuration for a global HTTP function available across all nodes.
@@ -848,6 +870,7 @@ class GlobalHttpFunction(BaseGlobalFunction):
     type: GlobalFunctionType = GlobalFunctionType.HTTP
     expected_fields: Dict[str, FieldConfig] = {}
     http_request: HttpRequestConfig
+    sse_response_handler: Optional[SseResponseHandlerConfig] = None
 
 
 class GlobalBuiltinFunction(BaseGlobalFunction):


### PR DESCRIPTION
## Summary
- Global HTTP functions now detect `text/event-stream` responses and stream each parsed SSE event to Daily clients as `RTVIServerMessage`s (`global-function-sse-event` per chunk, terminal `global-function-sse-end`). Emissions are fire-and-forget so SSE consumption and the LLM return are never blocked on RTVI push latency.
- New optional `sse_response_handler: {mode: full | select, select_index: int}` on `GlobalHttpFunction` controls the LLM-visible payload. `full` (default) returns concatenated `data` strings; `select` returns a single chunk's `data` (supports negative indexing). Clients always get the whole stream via RTVI regardless of this config.
- Non-SSE responses retain current JSON/text behavior. Size cap (`HTTP_REQUEST_MAX_RESPONSE_BYTES`) is enforced on the aggregated SSE data.

## Files touched
- `app/ai/voice/agents/breeze_buddy/template/types.py` — `SseResponseMode`, `SseResponseHandlerConfig`, new field on `GlobalHttpFunction`.
- `app/ai/voice/agents/breeze_buddy/handlers/transport/http_requester.py` — `execute()` gains an `on_sse_event` callback; new `_consume_sse_stream()` parses the SSE wire format (blank-line event boundaries, multi-line `data`, `:` comments) and caps total data bytes.
- `app/ai/voice/agents/breeze_buddy/handlers/transport/rtvi.py` — new `SseRtviForwarder` that records chunks and schedules RTVI pushes via `asyncio.create_task`. No-op off Daily.
- `app/ai/voice/agents/breeze_buddy/handlers/transport/http_handler.py` — wires the forwarder, emits `sse-end`, applies `sse_response_handler` to shape the LLM payload; invalid `select_index` returns an error.

## Test plan
- [ ] Point a test template at an SSE endpoint (e.g. OpenAI-style chunked response); confirm `onServerMessage` fires `global-function-sse-event` per chunk and a terminal `global-function-sse-end` on a Daily client.
- [ ] With `sse_response_handler: null` and `mode: full` — verify the LLM receives concatenated `data` strings.
- [ ] With `mode: select, select_index: 0` / `-1` — verify only that chunk's `data` reaches the LLM, streaming still hits the client.
- [ ] With out-of-range `select_index` — LLM receives `{status: error, error: "Something went wrong"}`.
- [ ] Non-SSE global function still returns JSON / raw text as before (regression).
- [ ] Telephony (non-Daily) call with an SSE response — `_schedule_emit` no-ops, handler still returns shaped payload to the LLM.
- [ ] Oversized SSE stream closes cleanly at `HTTP_REQUEST_MAX_RESPONSE_BYTES`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* Added Server-Sent Events (SSE) support for HTTP functions to enable real-time streaming responses
* Implemented live event forwarding capabilities to connected clients for improved interactivity
* Added configurable SSE response handling modes to flexibly process streaming data (full stream or selective extraction)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->