### PR TITLE
fix: skip outbound rate limit for non-TELEPHONY execution modes

### DIFF
--- a/app/ai/voice/agents/breeze_buddy/managers/calls.py
+++ b/app/ai/voice/agents/breeze_buddy/managers/calls.py
@@ -575,18 +575,19 @@ async def process_backlog_leads():
                     await _release_number(number_to_use.id, number_to_use.provider)
                     await release_lock_on_lead_by_id(locked_lead.id)
                     continue
-                rate_limit_allowed = await check_outbound_rate_limit_and_alert(
-                    customer_phone=customer_mobile,
-                    lead_id=str(locked_lead.id),
-                    reseller_id=locked_lead.reseller_id,
-                )
-                if not rate_limit_allowed:
-                    # TODO: advance next_attempt_at by the rate-limit window so
-                    # the scheduler does not immediately re-pick this lead and
-                    # re-trigger the alert on the next cycle.
-                    await _release_number(number_to_use.id, number_to_use.provider)
-                    await release_lock_on_lead_by_id(locked_lead.id)
-                    continue
+                if locked_lead.execution_mode == ExecutionMode.TELEPHONY:
+                    rate_limit_allowed = await check_outbound_rate_limit_and_alert(
+                        customer_phone=customer_mobile,
+                        lead_id=str(locked_lead.id),
+                        reseller_id=locked_lead.reseller_id,
+                    )
+                    if not rate_limit_allowed:
+                        # TODO: advance next_attempt_at by the rate-limit window so
+                        # the scheduler does not immediately re-pick this lead and
+                        # re-trigger the alert on the next cycle.
+                        await _release_number(number_to_use.id, number_to_use.provider)
+                        await release_lock_on_lead_by_id(locked_lead.id)
+                        continue
                 call = call_provider.make_call(
                     customer_mobile,
                     number_to_use.number,


### PR DESCRIPTION
## Summary

- Outbound rate limiting was being applied to all execution modes (`TELEPHONY`, `TELEPHONY_TEST`, `DAILY`, `DAILY_TEST`)
- Rate limit check should only apply to production telephony calls (`TELEPHONY`) — test and web modes should be unaffected
- Wraps the `check_outbound_rate_limit_and_alert` call with an `execution_mode == ExecutionMode.TELEPHONY` guard, consistent with the same pattern already used for retry logic at line 406

## Changes

`app/ai/voice/agents/breeze_buddy/managers/calls.py` — guard the outbound rate limit block so it only executes for `ExecutionMode.TELEPHONY`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Performance Improvements**
  * Optimized execution mode handling to improve processing efficiency for non-telephony modes while maintaining rate-limiting protections for telephony operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->