### PR TITLE
BZ-2517: feat(breeze-buddy): emit voice-to-chat-redirect RTVI event for restricted tools

### DIFF
--- a/app/ai/voice/agents/breeze_buddy/agent/__init__.py
+++ b/app/ai/voice/agents/breeze_buddy/agent/__init__.py
@@ -81,6 +81,10 @@ from app.ai.voice.agents.breeze_buddy.utils.common import (
     create_background_sound_mixer,
     track_error,
 )
+from app.ai.voice.agents.breeze_buddy.utils.voice_restrictions import (
+    VOICE_REDIRECT_TTS_MESSAGE,
+    VOICE_RESTRICTED_TOOLS,
+)
 from app.ai.voice.agents.breeze_buddy.utils.transport.websockets import (
     close_websocket_safely,
 )
@@ -163,6 +167,9 @@ class Agent:
 
         # RTVI processor for daily mode real-time events
         self._rtvi_processor: Any = None
+
+        # LLM service (set after create_services; None in stream mode)
+        self._llm: Any = None
 
         # Stream mode transcript collector (replaces LLMContext for transcription)
         self._transcript_collector: Optional[TranscriptCollectorProcessor] = None
@@ -644,6 +651,44 @@ class Agent:
                     RTVIServerMessageFrame(data={"type": "bot-ready"})
                 )
 
+        # Voice-to-chat redirect: intercept restricted tool calls in daily mode
+        if self.is_daily_mode and self._rtvi_processor and not self.is_stream_mode and self._llm:
+
+            @self._llm.event_handler("on_function_calls_started")
+            async def on_function_calls_started(service, function_calls):
+                """Intercept voice-restricted tool calls and redirect to chat."""
+                for fc in function_calls:
+                    if fc.function_name not in VOICE_RESTRICTED_TOOLS:
+                        continue
+
+                    logger.info(
+                        f"[VOICE_REDIRECT] Intercepted restricted tool '{fc.function_name}' "
+                        f"in voice mode, emitting redirect event. "
+                        f"conversation_id={self.conversation_id}"
+                    )
+
+                    # Speak the redirect message via TTS
+                    if self.task:
+                        try:
+                            await self.task.queue_frame(
+                                TTSSpeakFrame(text=VOICE_REDIRECT_TTS_MESSAGE)
+                            )
+                        except Exception as e:
+                            logger.warning(
+                                f"[VOICE_REDIRECT] Failed to queue TTS redirect message: {e}"
+                            )
+
+                    # Emit the RTVI event to Lighthouse frontend
+                    await self._emit_rtvi_event(
+                        "voice-to-chat-redirect",
+                        {
+                            "tool": fc.function_name,
+                            "reason": "voice_restricted",
+                            "conversation_id": self.conversation_id or "",
+                        },
+                    )
+                    break  # Handle only the first restricted tool per batch
+
         # Stream mode: accept tts-speak via RTVI client-message (PipecatClient SDK)
         if self.is_stream_mode and self._rtvi_processor:
 
@@ -808,6 +853,7 @@ class Agent:
             stt, llm, tts = await create_services(
                 self.configurations, include_llm=not is_stream
             )
+            self._llm = llm  # May be None in stream mode
             if not is_stream:
                 assert llm is not None, "LLM is required in agent mode"
 

--- a/app/ai/voice/agents/breeze_buddy/utils/voice_restrictions.py
+++ b/app/ai/voice/agents/breeze_buddy/utils/voice_restrictions.py
@@ -1,0 +1,27 @@
+"""Voice-restricted tool definitions for Breeze Buddy.
+
+Tools listed here are available in chat mode but not in voice mode
+because they are long-running agentic loops that would exhaust the
+LLM context window during a real-time voice conversation.
+"""
+
+from typing import FrozenSet
+
+# Tools that are only available in chat mode.
+# When the LLM invokes one of these during a voice session, the agent
+# should speak a redirect message and emit a 'voice-to-chat-redirect'
+# RTVI event to the Lighthouse frontend.
+VOICE_RESTRICTED_TOOLS: FrozenSet[str] = frozenset(
+    [
+        "initiateAgenticLoop",
+        "generateAdsPerformanceReport",
+        "generateShopifyBreezeGoLiveReport",
+        "runSRAnalysis",
+        "generateReport",
+    ]
+)
+
+VOICE_REDIRECT_TTS_MESSAGE = (
+    "This feature is only available in chat mode. "
+    "I'll take you there now so you can get the full analysis."
+)


### PR DESCRIPTION
## Summary

- Adds a `VOICE_RESTRICTED_TOOLS` frozenset and `VOICE_REDIRECT_TTS_MESSAGE` constant in a new `utils/voice_restrictions.py` module
- Registers an `on_function_calls_started` handler on the LLM service in daily (non-stream) mode: when the LLM invokes any voice-restricted tool, the agent speaks a short TTS redirect message and emits a `voice-to-chat-redirect` RTVI server event to the Lighthouse frontend
- Restricted tools: `initiateAgenticLoop`, `generateAdsPerformanceReport`, `generateShopifyBreezeGoLiveReport`, `runSRAnalysis`, `generateReport`

## Files Changed

- `app/ai/voice/agents/breeze_buddy/utils/voice_restrictions.py` *(created)* — defines `VOICE_RESTRICTED_TOOLS` and `VOICE_REDIRECT_TTS_MESSAGE`
- `app/ai/voice/agents/breeze_buddy/agent/__init__.py` *(modified)* — imports voice restriction constants, adds `self._llm` attribute, stores LLM reference after `create_services()`, registers `on_function_calls_started` handler in `_register_event_handlers()`

## Notes

- Uses `on_function_calls_started` on the LLM service (same pattern as the Automatic agent) rather than an RTVI processor event, because RTVIProcessor does not expose a function-call intercept event
- Handler is guarded by `is_daily_mode and not is_stream_mode` — telephony and stream-mode sessions are unaffected
- Logs with `[VOICE_REDIRECT]` prefix for easy filtering

## Discussion Thread

https://slack.com/archives/C08P35EAER0/p1776697311985229

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added voice mode restrictions that prevent certain long-running tools from being invoked during voice sessions.
  * Implemented automatic user guidance that provides a redirect message when restricted tools are attempted in voice mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->