### PR TITLE
(feat): add template based evaluator support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,4 @@ logs
 .claude/settings.local.json
 .claude/memory/
 CLAUDE.local.md
+.claude/settings.json

--- a/app/ai/voice/agents/breeze_buddy/agent/__init__.py
+++ b/app/ai/voice/agents/breeze_buddy/agent/__init__.py
@@ -737,6 +737,9 @@ class Agent:
             order_id=self.lead.request_id or "unknown",
             provider=self.provider or "",
             template_type=self.lead.template,
+            evaluator_config=(
+                self.configurations.evaluator_config if self.configurations else None
+            ),
         )
         try:
             with trace.use_span(self.root_span, end_on_exit=True):

--- a/app/ai/voice/agents/breeze_buddy/observability/tracing_setup.py
+++ b/app/ai/voice/agents/breeze_buddy/observability/tracing_setup.py
@@ -1,6 +1,7 @@
 import json
 from datetime import datetime, timezone
 from functools import wraps
+from typing import List, Optional
 
 from opentelemetry import trace
 from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
@@ -78,6 +79,7 @@ def create_root_span(
     order_id: str,
     provider: str,
     template_type: str,
+    evaluator_config: Optional[List[str]] = None,
 ) -> trace.Span:
     """
     Create and configure the root tracing span with all conversation attributes.
@@ -91,6 +93,8 @@ def create_root_span(
         order_id: Order/request ID
         provider: Provider name (daily or telephony provider)
         template_type: Template type being used
+        evaluator_config: List of evaluator names to add as Langfuse trace tags.
+            If None/empty, "ALL_EVALS" tag is added so all evaluators run.
 
     Returns:
         A span object that can be used with trace.use_span() context manager
@@ -123,6 +127,12 @@ def create_root_span(
         "daily" if transport_type == "daily" else provider,
     )
     span.set_attribute("template.type", template_type)
+
+    # Set evaluator tags for Langfuse trace filtering
+    # Langfuse maps `langfuse.trace.tags` span attribute to trace-level tags
+    tags = evaluator_config if evaluator_config is not None else ["ALL_EVALS"]
+    span.set_attribute("langfuse.trace.tags", tags)
+    logger.info(f"Langfuse trace tags set: {tags}")
 
     return span
 

--- a/app/ai/voice/agents/breeze_buddy/template/types.py
+++ b/app/ai/voice/agents/breeze_buddy/template/types.py
@@ -749,6 +749,12 @@ class ConfigurationModel(BaseModel):
         None,
         description="LLM provider and model configuration",
     )
+    evaluator_config: Optional[List[str]] = Field(
+        None,
+        description="List of LLM-as-judge evaluator names to run for this template. "
+        "Each name is added as a tag on the Langfuse trace. "
+        "If empty/None, 'ALL_EVALS' tag is added instead.",
+    )
 
     @model_validator(mode="after")
     def _backfill_legacy_from_stt_config(self):


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added template-level evaluator configuration, enabling users to specify which LLM-as-judge evaluators execute. Configured evaluator names are now tagged in observability traces for better visibility. When not configured, all evaluators run by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->