### PR TITLE
fix: synthesize initial greeting for inbound calls

### DIFF
--- a/app/ai/voice/agents/breeze_buddy/agent/__init__.py
+++ b/app/ai/voice/agents/breeze_buddy/agent/__init__.py
@@ -55,6 +55,9 @@ from app.ai.voice.agents.breeze_buddy.agent.utils import (
 from app.ai.voice.agents.breeze_buddy.handlers.internal.end_conversation import (
     end_conversation,
 )
+from app.ai.voice.agents.breeze_buddy.managers.utils import (
+    prepare_and_store_initial_greeting,
+)
 from app.ai.voice.agents.breeze_buddy.observability.tracing_setup import (
     create_root_span,
 )
@@ -485,6 +488,33 @@ class Agent:
             logger.error("Missing required attributes after setup")
             clear_log_context()
             return False
+
+        # Inbound calls have no pre-call window to synthesize the greeting
+        # (lead is created on-the-fly here), so do it before send_initial_greeting
+        # to avoid the dial-tone fallback. Idempotent for outbound — cron has
+        # already populated the cache, so this is a Redis hit and no-op.
+        # Bounded by a short timeout: if TTS hangs, the WS is already accepted
+        # and the customer would hear dead air. On timeout/error, fall through
+        # to send_initial_greeting which plays the dial-tone fallback.
+        try:
+            await asyncio.wait_for(
+                prepare_and_store_initial_greeting(
+                    lead_id=self.lead.id,
+                    payload=self.lead.payload or {},
+                    template=self.template,
+                ),
+                timeout=5.0,
+            )
+        except asyncio.TimeoutError:
+            logger.warning(
+                f"Greeting synthesis timed out for lead {self.lead.id}; "
+                "falling back to dial tone"
+            )
+        except Exception as e:
+            logger.warning(
+                f"Greeting synthesis failed for lead {self.lead.id}: {e}; "
+                "falling back to dial tone"
+            )
 
         greeting_result = await send_initial_greeting(
             ws=self.ws,


### PR DESCRIPTION
## Summary
- Inbound calls always fell through to the dial-tone fallback because the greeting Redis cache was never populated for them — leads are created on-the-fly when the WS connects, so there's no pre-call window like outbound's cron path has.
- Call `prepare_and_store_initial_greeting()` right before `send_initial_greeting()` in the WS startup path. Idempotent for outbound (Redis hit, no-op since cron already cached it); synthesizes on the spot for inbound.

## Behavior
| Path | Before | After |
|---|---|---|
| Outbound, any greeting | Cached in cron, played | Same — Redis hit, no-op |
| Inbound, static greeting (no prior cache) | Dial tone | Synthesized + cached |
| Inbound, dynamic `{customer_mobile_number}` greeting | Dial tone | Resolved + synthesized per-lead |

Inbound WS startup gains ~300-800ms TTS synthesis on cache miss; static greetings amortize across calls.

## Test plan
- [ ] Inbound call to a template with a static `initial_greeting` plays the configured greeting on first call (cache miss) and on subsequent calls (cache hit)
- [ ] Inbound call to a template with `{customer_mobile_number}` placeholder plays the resolved greeting
- [ ] Outbound calls still play their pre-synthesized greeting with no regression (verify via logs: should see "Using existing static greeting audio")
- [ ] If TTS synthesis fails, falls back to dial tone (existing behavior preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced telephony transport initialization to pre-populate and synchronize the initial greeting cache before delivery. For inbound calls, greetings are now prepared ahead of time to ensure reliable delivery. Outbound calls continue to use existing idempotency mechanisms to maintain consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->