### PR TITLE
fix: resolve pyrefly type errors in builder and audio utils

### DIFF
--- a/app/ai/voice/agents/breeze_buddy/template/builder.py
+++ b/app/ai/voice/agents/breeze_buddy/template/builder.py
@@ -6,7 +6,12 @@ This module builds Pipecat flow configurations from database models.
 
 from typing import Any, Callable, Dict, List, cast
 
-from pipecat_flows import FlowManager, FlowsFunctionSchema, NodeConfig
+from pipecat_flows import (
+    FlowManager,
+    FlowsDirectFunction,
+    FlowsFunctionSchema,
+    NodeConfig,
+)
 from pipecat_flows.types import ActionConfig, FlowResult
 
 from app.ai.voice.agents.breeze_buddy.handlers.internal import (
@@ -232,7 +237,7 @@ class FlowConfigBuilder:
             name=node.node_name,
             task_messages=task_messages,
             role_messages=role_messages,
-            functions=cast(List[FlowsFunctionSchema], functions),
+            functions=cast(List[FlowsDirectFunction | FlowsFunctionSchema], functions),
             pre_actions=cast(List[ActionConfig], pre_actions),
             post_actions=cast(List[ActionConfig], post_actions),
         )

--- a/app/ai/voice/agents/breeze_buddy/utils/common.py
+++ b/app/ai/voice/agents/breeze_buddy/utils/common.py
@@ -97,7 +97,9 @@ def convert_to_mulaw(audio_data: bytes, input_format: str = "raw") -> bytes:
             return mulaw_data
 
         # For MP3 format from ElevenLabs
-        audio_segment = AudioSegment.from_file(BytesIO(audio_data), format="mp3")
+        audio_segment: AudioSegment = AudioSegment.from_file(
+            BytesIO(audio_data), format="mp3"
+        )
         audio_segment = (
             audio_segment.set_frame_rate(8000).set_channels(1).set_sample_width(2)
         )
@@ -166,7 +168,7 @@ def load_audio(audio_path) -> OutputAudioRawFrame | None:
     if os.path.exists(audio_path):
         try:
             # Load audio file using pydub and convert to transport format
-            audio_segment = AudioSegment.from_wav(audio_path)
+            audio_segment: AudioSegment = AudioSegment.from_wav(audio_path)
 
             # Convert to 8000 Hz sample rate, mono channel, 16-bit PCM to match transport config
             audio_segment = (
@@ -486,7 +488,7 @@ async def prepare_initial_greeting_payload(
             )
 
             # Load and convert audio
-            audio = AudioSegment.from_wav(wav_file_path)
+            audio: AudioSegment = AudioSegment.from_wav(wav_file_path)
             audio = audio.set_frame_rate(8000).set_channels(1).set_sample_width(2)
             pcm_data: bytes = audio.raw_data  # type: ignore[assignment]
             mulaw_data = audioop.lin2ulaw(pcm_data, 2)


### PR DESCRIPTION
## Summary
- Cast `NodeConfig.functions` to the correct union type (`FlowsDirectFunction | FlowsFunctionSchema`) so it matches the pipecat-flows API after the 1.0 bump.
- Annotate `AudioSegment.from_file` / `from_wav` results so pyrefly resolves the `AudioSegment` overload instead of the `Generator` one, fixing three `set_frame_rate` missing-attribute errors.

## Test plan
- [x] `uv run pyrefly check` — `0 errors (6 suppressed)` (was 4 errors)
- [ ] CI: black, isort, autoflake, pyrefly, single-commit checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved internal code maintainability through type configuration and audio processing updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->