### PR TITLE
fix: cast pydub AudioSegment.from_* for pyrefly

### DIFF
--- a/app/ai/voice/agents/breeze_buddy/utils/common.py
+++ b/app/ai/voice/agents/breeze_buddy/utils/common.py
@@ -5,7 +5,7 @@ import os
 import re
 from datetime import datetime, timezone
 from io import BytesIO
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple, cast
 
 from pipecat.frames.frames import OutputAudioRawFrame
 from pydub import AudioSegment
@@ -97,8 +97,8 @@ def convert_to_mulaw(audio_data: bytes, input_format: str = "raw") -> bytes:
             return mulaw_data
 
         # For MP3 format from ElevenLabs
-        audio_segment: AudioSegment = AudioSegment.from_file(
-            BytesIO(audio_data), format="mp3"
+        audio_segment = cast(
+            AudioSegment, AudioSegment.from_file(BytesIO(audio_data), format="mp3")
         )
         audio_segment = (
             audio_segment.set_frame_rate(8000).set_channels(1).set_sample_width(2)
@@ -168,7 +168,7 @@ def load_audio(audio_path) -> OutputAudioRawFrame | None:
     if os.path.exists(audio_path):
         try:
             # Load audio file using pydub and convert to transport format
-            audio_segment: AudioSegment = AudioSegment.from_wav(audio_path)
+            audio_segment = cast(AudioSegment, AudioSegment.from_wav(audio_path))
 
             # Convert to 8000 Hz sample rate, mono channel, 16-bit PCM to match transport config
             audio_segment = (
@@ -488,7 +488,7 @@ async def prepare_initial_greeting_payload(
             )
 
             # Load and convert audio
-            audio: AudioSegment = AudioSegment.from_wav(wav_file_path)
+            audio = cast(AudioSegment, AudioSegment.from_wav(wav_file_path))
             audio = audio.set_frame_rate(8000).set_channels(1).set_sample_width(2)
             pcm_data: bytes = audio.raw_data  # type: ignore[assignment]
             mulaw_data = audioop.lin2ulaw(pcm_data, 2)


### PR DESCRIPTION
## Summary
Follow-up to #733. The annotation form merged in #733 (`audio_segment: AudioSegment = AudioSegment.from_file(...)`) still trips pyrefly with a `bad-assignment` error, because pydub's `from_file`/`from_wav` actually return `AudioSegment | Generator[...]`. The annotation rejects the `Generator` side at the call site.

This PR switches to `cast(AudioSegment, ...)` in the same three spots, which accepts the union at the call site and treats the variable as `AudioSegment` downstream. After this change `uv run pyrefly check` is clean again.

## Test plan
- [x] `uv run pyrefly check` → `0 errors (6 suppressed)`
- [ ] CI: black, isort, autoflake, pyrefly, single-commit checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)