### PR TITLE
feat(chat): add stateless text-channel chat mode for breeze buddy templates

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,6 +141,15 @@ Breeze Buddy is the template-driven telephony agent. These patterns MUST be foll
 - **Log context** via `set_log_context()` / `update_log_context()` using contextvars (call_sid, lead_id, reseller_id, merchant_id)
 - **Transcriptions**: Collected from LLM message history in `end_conversation`, stored as `{role, content}` array in `lead.metaData`
 
+### Chat (text) mode
+- Same template + FlowManager + LLM as voice; swaps audio I/O for text frames. Spec lives in `docs/CHAT_MODE.md`
+- Code under `app/ai/voice/agents/breeze_buddy/chat/` (agent, transport, sse, cleanup) + router at `app/api/routers/breeze_buddy/chat.py`
+- Templates opt in via `supported_channels: ["voice", "chat"]`; chat agents construct the builder with `disabled_names=CHAT_DISABLED_NAMES` (defined in `chat/disabled.py`) to strip voice-only functions/actions (mute_stt, play_audio_sound, warm_transfer, end_conversation, ...)
+- **Stateless per turn**: `POST /message` builds a fresh `ChatAgent`, replays history from DB into `LLMContext`, drives one turn via `run_turn`, tears down. No in-memory registry, no sticky LB.
+- Per-session `RedisLock` (180s TTL, no auto-extend) wraps the entire turn — single mutual-exclusion primitive across pods.
+- Idle session cleanup is one task on the global `BackgroundTaskScheduler` (`chat/cleanup.py`); the scheduler's distributed lock keeps it single-pod-per-tick.
+- Open follow-ups: LLM-generated greeting (today only `static_greeting` works), outcome webhook on `end()`
+
 ## Important
 
 - IMPORTANT: Never modify migration SQL files directly. Create new sequential migrations (e.g., `026_your_change.sql`)

--- a/app/ai/voice/agents/breeze_buddy/chat/__init__.py
+++ b/app/ai/voice/agents/breeze_buddy/chat/__init__.py
@@ -1,0 +1,6 @@
+"""Chat (text-mode) extensions for Breeze Buddy.
+
+This subpackage hosts everything specific to running a Breeze Buddy
+template as a text/chat agent (REST + SSE, no STT/TTS/VAD). Voice
+agents do not import from here. See docs/CHAT_MODE.md for the design.
+"""

--- a/app/ai/voice/agents/breeze_buddy/chat/agent.py
+++ b/app/ai/voice/agents/breeze_buddy/chat/agent.py
@@ -1,0 +1,427 @@
+"""ChatAgent — direct LLM driver for one chat turn.
+
+Stateless per turn: a fresh ``ChatAgent`` is constructed per ``POST /message``,
+drives one user → assistant turn, then is discarded. The agent is a thin loop
+around :func:`llm_driver.stream` — see ``docs/CHAT_MODE.md`` §4 + §9 for the
+full architecture.
+"""
+
+import json
+from typing import Any, AsyncIterator, Dict, List, Optional, cast
+
+from pipecat.adapters.schemas.tools_schema import ToolsSchema
+from pipecat.frames.frames import FunctionCallFromLLM
+from pipecat.processors.aggregators.llm_context import LLMContext, LLMContextMessage
+from pipecat_flows import FlowsFunctionSchema
+
+from app.ai.voice.agents.breeze_buddy.chat import llm_driver
+from app.ai.voice.agents.breeze_buddy.chat.disabled import CHAT_DISABLED_NAMES
+from app.ai.voice.agents.breeze_buddy.chat.sse import SSEEvent
+from app.ai.voice.agents.breeze_buddy.template.builder import FlowConfigBuilder
+from app.ai.voice.agents.breeze_buddy.template.context import with_context
+from app.ai.voice.agents.breeze_buddy.template.types import TemplateModel
+from app.ai.voice.agents.breeze_buddy.template.utils import render_messages_with_vars
+from app.ai.voice.agents.breeze_buddy.utils.language_utils.prompt_injections import (
+    inject_language_rules,
+)
+from app.core.logger import logger
+from app.core.transport.http_client import create_aiohttp_session
+from app.database.accessor.breeze_buddy.chat_session import (
+    insert_chat_message,
+    update_chat_session_after_turn,
+)
+from app.schemas.breeze_buddy.chat import ChatMessageRole
+
+# Each tool-call → handler → re-invoke counts as one cycle. Real flows rarely
+# cross 3; this guard stops a pathological template (handler always returns
+# a transition that loops back) from burning unbounded LLM calls.
+_MAX_TOOL_CYCLES = 8
+
+
+class ChatAgent:
+    """Single-turn driver. Construct, ``run_turn``, discard."""
+
+    def __init__(
+        self,
+        *,
+        session_id: str,
+        template: TemplateModel,
+        llm: Any,
+        template_vars: Optional[dict] = None,
+    ) -> None:
+        self.session_id = session_id
+        self.template = template
+        self.template_vars = template_vars or {}
+        self._llm = llm
+        # TemplateContext reads these off the bot. flow_config is set in
+        # run_turn; vad_analyzer=None lets template/{vad,interruption}.py
+        # bare-attribute checks short-circuit; lead/call_sid stay None
+        # because chat has no call lifecycle. aiohttp_session is required
+        # by http_function_handler — held per-turn and closed in run_turn's
+        # finally so the transient ClientSession's connector doesn't leak.
+        self.flow_config: Optional[Dict[str, Any]] = None
+        self.vad_analyzer = None
+        self.lead = None
+        self.call_sid: Optional[str] = None
+        self.aiohttp_session: Optional[Any] = None
+
+    async def run_turn(
+        self,
+        *,
+        user_content: str,
+        history: List[Dict[str, Any]],
+        current_node: Optional[str],
+    ) -> AsyncIterator[SSEEvent]:
+        # Per-turn aiohttp session for global HTTP function calls. Created
+        # lazily, closed in finally below so the ClientSession's TCP
+        # connector is always released — even if the generator is closed
+        # mid-stream by the SSE client disconnecting.
+        self.aiohttp_session = create_aiohttp_session()
+        try:
+            async for event in self._run_turn_inner(
+                user_content=user_content,
+                history=history,
+                current_node=current_node,
+            ):
+                yield event
+        finally:
+            if self.aiohttp_session is not None:
+                await self.aiohttp_session.close()
+                self.aiohttp_session = None
+
+    async def _run_turn_inner(
+        self,
+        *,
+        user_content: str,
+        history: List[Dict[str, Any]],
+        current_node: Optional[str],
+    ) -> AsyncIterator[SSEEvent]:
+        flow_builder = FlowConfigBuilder(disabled_names=CHAT_DISABLED_NAMES, quiet=True)
+        # Wrap before build_flow_config: _build_function_schema captures the
+        # handler reference into a closure, so post-build wrapping is a no-op.
+        for handler_name, handler_func in flow_builder.handler_map.items():
+            flow_builder.handler_map[handler_name] = with_context(self)(handler_func)
+        flow_config = flow_builder.build_flow_config(self.template)
+        self.flow_config = flow_config
+
+        # Global functions live alongside per-node ones for the LLM. In direct
+        # mode this is the channel for *any* tools (the synthesized node has
+        # no per-node functions); in flow mode it's the always-available
+        # cross-node tool set. ``build_global_functions`` already runs
+        # ``filter_disabled_identifiers`` against CHAT_DISABLED_NAMES, so
+        # voice-only entries (warm_transfer, end_conversation, etc.) never
+        # reach the LLM in chat. ``bot_instance=self`` mirrors voice so global
+        # function adapters that need the bot for post-action context resolve
+        # against the ChatAgent (which carries the same flow_config / lead /
+        # call_sid / vad_analyzer attribute surface those adapters read).
+        global_funcs: List[FlowsFunctionSchema] = flow_builder.build_global_functions(
+            self.template.flow, bot_instance=self
+        )
+
+        node = self._resolve_node(flow_config, current_node)
+        node_name = cast(str, node["name"])
+
+        # Persist user message before the LLM call so a crash mid-stream
+        # still leaves the user's input in history.
+        user_msg = await insert_chat_message(
+            session_id=self.session_id,
+            role=ChatMessageRole.USER,
+            content=user_content,
+        )
+        yield SSEEvent(
+            event="user_committed",
+            data={"idx": user_msg.idx if user_msg else None, "content": user_content},
+        )
+
+        context = self._seed_context(node, history, user_content, global_funcs)
+
+        assistant_text_chunks: List[str] = []
+        for cycle in range(1, _MAX_TOOL_CYCLES + 1):
+            tool_calls: List[FunctionCallFromLLM] = []
+            turn_text: List[str] = []
+
+            async for kind, payload in llm_driver.stream(
+                self._llm, context, log_label=f"chat#{self.session_id[:8]}"
+            ):
+                if kind == "text":
+                    text = cast(str, payload)
+                    turn_text.append(text)
+                    yield SSEEvent(event="assistant_token", data={"delta": text})
+                elif kind == "tool_call":
+                    call = cast(FunctionCallFromLLM, payload)
+                    tool_calls.append(call)
+                    yield SSEEvent(
+                        event="function_call_started",
+                        data={
+                            "name": call.function_name,
+                            "args": dict(call.arguments),
+                            "tool_call_id": call.tool_call_id,
+                        },
+                    )
+
+            assistant_text_chunks.extend(turn_text)
+            if not tool_calls:
+                break
+
+            # Mirror LLMAssistantContextAggregator: append assistant message
+            # carrying tool_calls, then a tool-result per call. Universal
+            # OpenAI shape; per-provider adapter converts on next request.
+            context.add_message(
+                cast(
+                    LLMContextMessage,
+                    {
+                        "role": "assistant",
+                        "content": "".join(turn_text) or None,
+                        "tool_calls": [
+                            {
+                                "id": call.tool_call_id,
+                                "type": "function",
+                                "function": {
+                                    "name": call.function_name,
+                                    "arguments": json.dumps(call.arguments),
+                                },
+                            }
+                            for call in tool_calls
+                        ],
+                    },
+                )
+            )
+
+            next_node: Optional[Dict[str, Any]] = None
+            for call in tool_calls:
+                result_payload, transition_node = await self._dispatch_tool_call(
+                    call, node, global_funcs
+                )
+                context.add_message(
+                    cast(
+                        LLMContextMessage,
+                        {
+                            "role": "tool",
+                            "tool_call_id": call.tool_call_id,
+                            "content": json.dumps(result_payload, default=str),
+                        },
+                    )
+                )
+                yield SSEEvent(
+                    event="function_call_completed",
+                    data={
+                        "name": call.function_name,
+                        "tool_call_id": call.tool_call_id,
+                        "result_summary": _summarize_result(result_payload),
+                    },
+                )
+                if transition_node is not None and next_node is None:
+                    next_node = transition_node
+
+            if next_node is not None:
+                node = next_node
+                node_name = cast(str, node.get("name") or node_name)
+                self._apply_node_transition(context, node, global_funcs)
+                yield SSEEvent(event="node_transition", data={"to": node_name})
+        else:
+            # Loop ran to completion without ``break`` — every cycle produced
+            # a tool call. Bail out rather than burning more LLM calls.
+            # Persist whatever node we last transitioned into so the next
+            # ``/message`` resumes from there instead of replaying tool
+            # calls from a stale node.
+            await update_chat_session_after_turn(
+                session_id=self.session_id, current_node=node_name or None
+            )
+            logger.error(
+                f"ChatAgent {self.session_id}: exceeded {_MAX_TOOL_CYCLES} "
+                "tool-call cycles without a user-facing reply"
+            )
+            yield SSEEvent(
+                event="error",
+                data={
+                    "code": "tool_cycle_limit",
+                    "message": (
+                        f"Exceeded {_MAX_TOOL_CYCLES} tool-call cycles "
+                        "without a user-facing reply"
+                    ),
+                },
+            )
+            yield SSEEvent(event="turn_end", data={"session_status": "FAILED"})
+            return
+
+        assistant_text = "".join(assistant_text_chunks).strip()
+        if assistant_text:
+            stored = await insert_chat_message(
+                session_id=self.session_id,
+                role=ChatMessageRole.ASSISTANT,
+                content=assistant_text,
+            )
+            yield SSEEvent(
+                event="assistant_message",
+                data={
+                    "idx": stored.idx if stored else None,
+                    "content": assistant_text,
+                },
+            )
+
+        await update_chat_session_after_turn(
+            session_id=self.session_id, current_node=node_name or None
+        )
+        yield SSEEvent(event="turn_end", data={"session_status": "ACTIVE"})
+
+    def _resolve_node(
+        self, flow_config: Dict[str, Any], current_node: Optional[str]
+    ) -> Dict[str, Any]:
+        target = current_node or flow_config["initial_node"]
+        if target not in flow_config["nodes"]:
+            logger.warning(
+                f"ChatAgent {self.session_id}: current_node '{target}' missing "
+                f"from template; falling back to '{flow_config['initial_node']}'"
+            )
+            target = flow_config["initial_node"]
+        return cast(Dict[str, Any], flow_config["nodes"][target])
+
+    def _render_node_messages(
+        self, node: Dict[str, Any]
+    ) -> tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
+        """Render role + task messages with template_vars and inject language
+        rules — chat parity with FlowConfigLoader.load_template."""
+        role_messages = render_messages_with_vars(
+            list(node.get("role_messages", [])), self.template_vars
+        )
+        role_messages = inject_language_rules(
+            role_messages,
+            self.template_vars.get("language_name", "English"),
+            getattr(
+                getattr(self.template, "configurations", None),
+                "payload_based_language_selection",
+                False,
+            ),
+        )
+        task_messages = render_messages_with_vars(
+            list(node.get("task_messages", [])), self.template_vars
+        )
+        return role_messages, task_messages
+
+    def _seed_context(
+        self,
+        node: Dict[str, Any],
+        history: List[Dict[str, Any]],
+        user_content: str,
+        global_funcs: List[FlowsFunctionSchema],
+    ) -> LLMContext:
+        """Build initial LLMContext: [role, task, …history…, new user]."""
+        role_messages, task_messages = self._render_node_messages(node)
+        messages: List[Dict[str, Any]] = [
+            *role_messages,
+            *task_messages,
+            *history,
+            {"role": "user", "content": user_content},
+        ]
+        return LLMContext(
+            messages=cast(List[LLMContextMessage], messages),
+            tools=_tools_schema(node, global_funcs),
+        )
+
+    def _apply_node_transition(
+        self,
+        context: LLMContext,
+        next_node: Dict[str, Any],
+        global_funcs: List[FlowsFunctionSchema],
+    ) -> None:
+        """Mid-turn transition — append new task_messages + swap tools.
+
+        Mirrors FlowManager._set_node: role_messages stay from the original
+        node (only sent on the very first node); task_messages append so the
+        previous node's instructions remain in scope for the model.
+        """
+        _, task_messages = self._render_node_messages(next_node)
+        for msg in task_messages:
+            context.add_message(cast(LLMContextMessage, msg))
+        context.set_tools(_tools_schema(next_node, global_funcs))
+
+    async def _dispatch_tool_call(
+        self,
+        call: FunctionCallFromLLM,
+        node: Dict[str, Any],
+        global_funcs: List[FlowsFunctionSchema],
+    ) -> tuple[Any, Optional[Dict[str, Any]]]:
+        """Find the wrapper handler for ``call`` and invoke it.
+
+        FlowConfigBuilder built each handler as ``(llm_args, flow_manager)``.
+        Chat has no FlowManager — pass None; the wrappers in our codebase
+        capture transition_to/hooks/function_config in closures and never
+        read the second arg.
+
+        Lookup falls through per-node functions first, then globals — same
+        precedence as voice's FlowManager (per-node shadow globals when
+        names collide).
+        """
+        candidates: List[FlowsFunctionSchema] = [
+            *(
+                fn
+                for fn in node.get("functions") or []
+                if isinstance(fn, FlowsFunctionSchema)
+            ),
+            *global_funcs,
+        ]
+        handler_fn: Any = next(
+            (fn.handler for fn in candidates if fn.name == call.function_name),
+            None,
+        )
+        if handler_fn is None:
+            logger.error(
+                f"ChatAgent {self.session_id}: no handler for '{call.function_name}'"
+            )
+            return (
+                {"status": "error", "error": f"No handler for {call.function_name!r}"},
+                None,
+            )
+
+        try:
+            raw = await handler_fn(dict(call.arguments), None)
+        except Exception as exc:
+            logger.error(
+                f"ChatAgent {self.session_id}: handler {call.function_name!r} "
+                f"raised: {exc}",
+                exc_info=True,
+            )
+            return ({"status": "error", "error": f"{type(exc).__name__}: {exc}"}, None)
+
+        # transition_handler returns (result, next_node). Global / HTTP
+        # functions return the response payload directly.
+        if (
+            isinstance(raw, tuple)
+            and len(raw) == 2
+            and (raw[1] is None or isinstance(raw[1], dict))
+        ):
+            return raw[0], raw[1]
+        return raw, None
+
+
+def _tools_schema(
+    node: Dict[str, Any], global_funcs: List[FlowsFunctionSchema]
+) -> ToolsSchema:
+    """ToolsSchema concatenating per-node ``functions`` with globals.
+
+    ``FlowsFunctionSchema.to_function_schema()`` strips flow-only fields
+    (handler, cancel_on_interruption, timeout_secs); ToolsSchema accepts
+    plain FunctionSchema and FlowsDirectFunction interchangeably.
+
+    Direct mode synthesizes a node with empty ``functions`` and lets every
+    tool flow through ``global_funcs`` (which the builder populates from
+    ``flow.functions``). Flow mode keeps both lists — per-node first so a
+    naming collision shadows the global, matching ``_dispatch_tool_call``.
+    """
+    standard: List[Any] = [
+        fn.to_function_schema() if isinstance(fn, FlowsFunctionSchema) else fn
+        for fn in (node.get("functions") or [])
+    ]
+    standard.extend(fn.to_function_schema() for fn in global_funcs)
+    return ToolsSchema(standard_tools=standard)
+
+
+def _summarize_result(value: Any) -> Any:
+    """Coerce a tool result to JSON-clean for the SSE payload. Full payload
+    still lands in DB / logs."""
+    if isinstance(value, (str, int, float, bool, type(None))):
+        return value
+    return str(value)
+
+
+__all__ = ["ChatAgent"]

--- a/app/ai/voice/agents/breeze_buddy/chat/cleanup.py
+++ b/app/ai/voice/agents/breeze_buddy/chat/cleanup.py
@@ -1,0 +1,100 @@
+"""Idle chat-session cleanup task.
+
+Marks ACTIVE/IDLE rows whose ``last_activity_at`` is past
+``CHAT_SESSION_END_TIMEOUT_SECONDS`` as ENDED. Registered with the global
+``BackgroundTaskScheduler`` whose distributed Redis lock keeps the sweep
+single-pod-per-tick. UPDATE is idempotent (``WHERE status <> 'ENDED'``), so
+duplicate runs from a botched lock acquire are safe.
+"""
+
+from datetime import timedelta
+
+from app.core.config.dynamic import CHAT_SESSION_END_TIMEOUT_SECONDS
+from app.core.logger import logger
+from app.database.accessor.breeze_buddy.chat_session import (
+    end_chat_session,
+    list_idle_chat_sessions,
+)
+from app.schemas.breeze_buddy.chat import ChatEndedReason, ChatSessionStatus
+from app.services.redis.locks import LockAcquireError, RedisLock
+from app.utils.common import utcnow
+
+# Same lock key + TTL as the per-turn lock in
+# ``app/api/routers/breeze_buddy/chat/handlers.py`` — must stay in sync.
+# Inlined (rather than imported) to keep the chat agent tree free of a
+# routers/ dependency. Cleanup work itself is sub-second; the TTL exists
+# only as a safety net so a crashed pod can't pin an in-flight session
+# forever.
+_SESSION_LOCK_TTL_SECONDS = 180
+
+# Per-tick processing cap. Higher than the accessor default (100) so that
+# a transient backlog from one stalled tick is drained on the next one.
+# We deliberately don't loop within a single tick: stale rows we skipped
+# (because a turn was mid-flight) would re-appear in the next query and
+# spin until a per-tick cap. One batch per tick keeps the math simple
+# and the scheduler unblocked.
+_SWEEP_BATCH_SIZE = 1_000
+
+
+def _lock_key(session_id: str) -> str:
+    return f"chat:session:{session_id}:lock"
+
+
+async def end_idle_chat_sessions() -> None:
+    """Sweep ACTIVE/IDLE rows past the inactivity threshold; mark ENDED.
+
+    Each session is closed under the same per-session ``RedisLock`` that
+    ``POST /message`` and ``POST /end`` take. Without it, this sweeper
+    could mark a session ENDED while another pod is mid-turn — that pod
+    would happily insert the assistant reply and bump ``last_activity_at``
+    against a row this task has already terminated, breaking the chat
+    mode "single mutual-exclusion primitive across pods" guarantee.
+    A ``LockAcquireError`` here means a turn is in flight, so the session
+    isn't actually idle and we skip it; the next tick will catch it.
+    """
+    idle_after = await CHAT_SESSION_END_TIMEOUT_SECONDS()
+    cutoff = utcnow() - timedelta(seconds=idle_after)
+
+    try:
+        stale = await list_idle_chat_sessions(
+            cutoff=cutoff,
+            statuses=[ChatSessionStatus.ACTIVE, ChatSessionStatus.IDLE],
+            limit=_SWEEP_BATCH_SIZE,
+        )
+    except Exception as exc:
+        logger.error(f"chat cleanup: list_idle_chat_sessions failed: {exc}")
+        return
+
+    if not stale:
+        return
+
+    ended = 0
+    skipped = 0
+    for row in stale:
+        session_id = str(row.id)
+        lock = RedisLock(_lock_key(session_id), ttl_seconds=_SESSION_LOCK_TTL_SECONDS)
+        try:
+            await lock.acquire()
+        except LockAcquireError:
+            skipped += 1
+            continue
+        try:
+            await end_chat_session(
+                session_id=session_id,
+                ended_reason=ChatEndedReason.IDLE_TIMEOUT,
+            )
+            ended += 1
+        except Exception as exc:
+            logger.warning(f"chat cleanup: end_chat_session failed for {row.id}: {exc}")
+        finally:
+            await lock.release()
+
+    saturated = len(stale) >= _SWEEP_BATCH_SIZE
+    logger.info(
+        f"chat cleanup: marked {ended}/{len(stale)} idle session(s) ENDED "
+        f"({skipped} skipped, threshold={idle_after}s"
+        f"{', batch saturated — more will be processed next tick' if saturated else ''})"
+    )
+
+
+__all__ = ["end_idle_chat_sessions"]

--- a/app/ai/voice/agents/breeze_buddy/chat/disabled.py
+++ b/app/ai/voice/agents/breeze_buddy/chat/disabled.py
@@ -1,0 +1,41 @@
+"""Chat-mode handler/function filter list.
+
+Names listed here are voice-only (or not yet implemented for chat) and are
+stripped from per-node functions, global functions, and per-node pre/post
+actions before pydantic validation. Stripping (rather than noop-swapping)
+keeps a single ``handler_map`` for both channels and prevents the LLM from
+ever seeing these functions as callable.
+
+Passed into ``FlowConfigBuilder`` from ``ChatAgent.run_turn`` — the builder
+itself is channel-agnostic and just consumes the set.
+
+Why each entry is disabled:
+
+- ``mute_stt`` / ``unmute_stt`` / ``play_audio_sound``: voice-only side
+  effects (no STT or audio output exists in the chat pipeline).
+- ``warm_transfer`` / ``connect_to_live_agent``: chat-to-human handoff is
+  not implemented in v1; see ``docs/CHAT_MODE.md §15`` for the Phase 2
+  plan.
+- ``end_conversation``: voice templates wire this as a post-action on the
+  closing node to push ``EndFrame()`` and tear down the long-lived call
+  pipeline. Chat agents are constructed-and-discarded per turn — the
+  pipeline tears down via ``run_turn``'s ``finally`` already, and queueing
+  an ``EndFrame`` mid-turn races the just-queued ``LLMRunFrame`` for the
+  closing node and cancels the user-facing reply in flight.
+"""
+
+from __future__ import annotations
+
+CHAT_DISABLED_NAMES: frozenset[str] = frozenset(
+    {
+        "mute_stt",
+        "unmute_stt",
+        "play_audio_sound",
+        "warm_transfer",
+        "connect_to_live_agent",
+        "end_conversation",
+    }
+)
+
+
+__all__ = ["CHAT_DISABLED_NAMES"]

--- a/app/ai/voice/agents/breeze_buddy/chat/llm_driver.py
+++ b/app/ai/voice/agents/breeze_buddy/chat/llm_driver.py
@@ -1,0 +1,390 @@
+"""Direct LLM streaming + tool-call accumulator for chat mode.
+
+One streaming SDK call per invocation; yields ``("text", str)`` for content
+deltas and ``("tool_call", FunctionCallFromLLM)`` after the stream closes for
+each materialized tool call. Provider dispatch is by ``isinstance`` against
+pipecat's three base classes — covers every provider in pipecat 1.1's
+``services/`` tree (current Buddy usage: Azure, Vertex Gemini, Vertex Claude).
+
+We read ``service._client`` and ``service._settings`` directly: pipecat 1.1
+exposes no public streaming-with-tools entry point. Tested with pipecat 1.1.0
++ pipecat-ai-flows 1.1.0; revisit on upgrade.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, AsyncIterator, Literal, Tuple, Union
+
+from pipecat.frames.frames import FunctionCallFromLLM
+from pipecat.processors.aggregators.llm_context import LLMContext
+from pipecat.services.anthropic.llm import AnthropicLLMService
+from pipecat.services.google.llm import GoogleLLMService
+from pipecat.services.openai.base_llm import BaseOpenAILLMService
+
+from app.core.logger import logger
+
+DriverEvent = Tuple[Literal["text", "tool_call"], Union[str, FunctionCallFromLLM]]
+
+
+__all__ = ["DriverEvent", "stream"]
+
+
+async def stream(
+    llm_service: Any,
+    context: LLMContext,
+    *,
+    log_label: str = "chat",
+) -> AsyncIterator[DriverEvent]:
+    """Issue one streaming LLM call; yield text deltas + tool calls.
+
+    The caller owns ``context`` mutation between turns of the tool-call loop.
+    This function only reads it.
+    """
+    if isinstance(llm_service, BaseOpenAILLMService):
+        async for event in _stream_openai(llm_service, context, log_label):
+            yield event
+        return
+    if isinstance(llm_service, AnthropicLLMService):
+        async for event in _stream_anthropic(llm_service, context, log_label):
+            yield event
+        return
+    if isinstance(llm_service, GoogleLLMService):
+        async for event in _stream_gemini(llm_service, context, log_label):
+            yield event
+        return
+
+    raise TypeError(
+        f"chat llm_driver: unsupported LLM service type {type(llm_service).__name__}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# OpenAI-compatible (Azure, OpenAI direct, DeepSeek, Groq, Cerebras, …)
+# ---------------------------------------------------------------------------
+
+
+async def _stream_openai(
+    service: BaseOpenAILLMService,
+    context: LLMContext,
+    log_label: str,
+) -> AsyncIterator[DriverEvent]:
+    """Mirror BaseOpenAILLMService._process_context minus the frame layer.
+
+    Tool-call deltas arrive interleaved with text deltas, indexed by
+    ``tool_calls[*].index``. Per-index we accumulate name + args fragments
+    and flush on index advance / stream close.
+    """
+    adapter = service.get_llm_adapter()
+    invocation_params = adapter.get_llm_invocation_params(
+        context,
+        system_instruction=service._settings.system_instruction,
+        convert_developer_to_user=not service.supports_developer_role,
+    )
+
+    settings = service._settings
+    params: dict[str, Any] = {
+        "model": settings.model,
+        "stream": True,
+        "messages": invocation_params["messages"],
+        "tools": invocation_params["tools"],
+        "tool_choice": invocation_params["tool_choice"],
+    }
+    # Forward only explicitly-set settings so we don't paint over provider
+    # defaults with NOT_GIVEN sentinels.
+    for attr in (
+        "temperature",
+        "top_p",
+        "frequency_penalty",
+        "presence_penalty",
+        "seed",
+        "max_tokens",
+        "max_completion_tokens",
+    ):
+        value = getattr(settings, attr, None)
+        if value is not None:
+            params[attr] = value
+    params.update(getattr(settings, "extra", None) or {})
+
+    logger.debug(f"[{log_label}] llm_driver: openai stream model={settings.model}")
+
+    # Per-index aggregation: OpenAI's streaming spec emits ``delta.tool_calls``
+    # as an *array* of fragments, each tagged with a sparse ``index``. Multiple
+    # fragments — sometimes for *different* indices — can ride the same chunk
+    # when the model invokes parallel tool calls. Reading only ``[0]`` and
+    # advancing a sequential counter drops any second-or-later entry in the
+    # chunk and breaks the moment indices arrive non-monotonically.
+    tool_acc: dict[int, dict[str, str]] = {}
+
+    stream_obj = await service._client.chat.completions.create(**params)
+    try:
+        async for chunk in stream_obj:
+            if not chunk.choices:
+                continue
+            delta = chunk.choices[0].delta
+            if delta is None:
+                continue
+            if delta.tool_calls:
+                for tc in delta.tool_calls:
+                    slot = tool_acc.setdefault(
+                        tc.index, {"name": "", "args": "", "id": ""}
+                    )
+                    if tc.id:
+                        slot["id"] = tc.id
+                    if tc.function and tc.function.name:
+                        slot["name"] += tc.function.name
+                    if tc.function and tc.function.arguments:
+                        slot["args"] += tc.function.arguments
+            elif delta.content:
+                yield ("text", delta.content)
+    finally:
+        if hasattr(stream_obj, "close"):
+            try:
+                await stream_obj.close()
+            except Exception:
+                pass
+
+    for idx in sorted(tool_acc.keys()):
+        slot = tool_acc[idx]
+        name = slot["name"]
+        raw_args = slot["args"]
+        tid = slot["id"]
+        if not name:
+            continue
+        try:
+            parsed_args = json.loads(raw_args) if raw_args else {}
+        except json.JSONDecodeError:
+            # Don't dump raw_args — tool payloads can carry merchant/user data.
+            logger.warning(
+                f"[{log_label}] llm_driver: bad tool args for {name!r} "
+                f"(payload_length={len(raw_args)})"
+            )
+            parsed_args = {}
+        yield (
+            "tool_call",
+            FunctionCallFromLLM(
+                function_name=name,
+                tool_call_id=tid,
+                arguments=parsed_args,
+                context=context,
+            ),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Anthropic (Claude on Vertex, Anthropic direct)
+# ---------------------------------------------------------------------------
+
+
+async def _stream_anthropic(
+    service: AnthropicLLMService,
+    context: LLMContext,
+    log_label: str,
+) -> AsyncIterator[DriverEvent]:
+    """Mirror AnthropicLLMService._process_context minus frame pushes.
+
+    Anthropic streams discrete events: ``content_block_start(tool_use)`` opens
+    a tool call, ``content_block_delta(partial_json=...)`` accumulates args,
+    ``message_delta(stop_reason="tool_use")`` finalises it.
+    """
+    # VertexAnthropicLLMService overrides this hook to append a dummy user
+    # turn when context ends on assistant — go through the service so the
+    # override kicks in.
+    invocation_params = service._get_llm_invocation_params(context)
+
+    settings = service._settings
+    params: dict[str, Any] = {
+        "model": settings.model,
+        "stream": True,
+        "max_tokens": settings.max_tokens,
+        # Pipecat sends this beta unconditionally; preserve voice parity.
+        "betas": ["interleaved-thinking-2025-05-14"],
+    }
+    for attr in ("temperature", "top_k", "top_p"):
+        value = getattr(settings, attr, None)
+        if value is not None:
+            params[attr] = value
+    thinking = getattr(settings, "thinking", None)
+    # ``thinking`` is typed as ``ThinkingConfig | NotGiven``; guard the
+    # NOT_GIVEN sentinel which has no ``model_dump``.
+    if thinking and hasattr(thinking, "model_dump"):
+        params["thinking"] = thinking.model_dump(exclude_unset=True)
+    params.update(invocation_params)
+    params.update(getattr(settings, "extra", None) or {})
+
+    logger.debug(f"[{log_label}] llm_driver: anthropic stream model={settings.model}")
+
+    cur_tool_block: Any = None
+    cur_args = ""
+    pending_calls: list[FunctionCallFromLLM] = []
+
+    # The Anthropic SDK returns ``AsyncStream`` here
+    # (anthropic/_streaming.py: AsyncStream), which exposes ``close()``.
+    # Wrap iteration so an outer cancellation (SSE client disconnect)
+    # closes the underlying httpx response instead of waiting for GC.
+    response = await service._client.beta.messages.create(**params)
+    try:
+        async for event in response:
+            et = getattr(event, "type", None)
+            if et == "content_block_start":
+                block = event.content_block
+                if block.type == "tool_use":
+                    if cur_tool_block is not None:
+                        pending_calls.append(
+                            _finalize_anthropic_call(
+                                cur_tool_block, cur_args, context, log_label
+                            )
+                        )
+                    cur_tool_block = block
+                    cur_args = ""
+            elif et == "content_block_delta":
+                d = event.delta
+                if hasattr(d, "text") and d.text:
+                    yield ("text", d.text)
+                elif hasattr(d, "partial_json") and cur_tool_block is not None:
+                    cur_args += d.partial_json or ""
+            elif et == "message_delta":
+                stop = getattr(getattr(event, "delta", None), "stop_reason", None)
+                if stop == "tool_use" and cur_tool_block is not None:
+                    pending_calls.append(
+                        _finalize_anthropic_call(
+                            cur_tool_block, cur_args, context, log_label
+                        )
+                    )
+                    cur_tool_block = None
+                    cur_args = ""
+    finally:
+        await _close_stream(response)
+
+    # Flush any block dangling at stream end.
+    if cur_tool_block is not None:
+        pending_calls.append(
+            _finalize_anthropic_call(cur_tool_block, cur_args, context, log_label)
+        )
+
+    for call in pending_calls:
+        yield ("tool_call", call)
+
+
+def _finalize_anthropic_call(
+    block: Any, raw_args: str, context: LLMContext, log_label: str
+) -> FunctionCallFromLLM:
+    try:
+        parsed_args = json.loads(raw_args) if raw_args else {}
+    except json.JSONDecodeError:
+        # Don't dump raw_args — tool payloads can carry merchant/user data.
+        logger.warning(
+            f"[{log_label}] llm_driver: bad Anthropic tool args for "
+            f"{block.name!r} (payload_length={len(raw_args)})"
+        )
+        parsed_args = {}
+    return FunctionCallFromLLM(
+        function_name=block.name,
+        tool_call_id=block.id,
+        arguments=parsed_args,
+        context=context,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Gemini (Vertex Gemini, Gemini direct)
+# ---------------------------------------------------------------------------
+
+
+async def _stream_gemini(
+    service: GoogleLLMService,
+    context: LLMContext,
+    log_label: str,
+) -> AsyncIterator[DriverEvent]:
+    """Mirror GoogleLLMService._process_context minus frame pushes.
+
+    Gemini chunks are part-shaped, not delta-shaped: each ``part`` is either
+    fully-formed text or a fully-materialized ``function_call`` (no
+    accumulation needed).
+    """
+    import uuid as _uuid
+
+    from google.genai.types import GenerateContentConfig
+
+    adapter = service.get_llm_adapter()
+    invocation_params = adapter.get_llm_invocation_params(
+        context, system_instruction=service._settings.system_instruction
+    )
+
+    # Go through the service builder so model-aware thinking defaults apply
+    # (e.g. Gemini 2.5 Flash thinking_budget=0).
+    generation_params = service._build_generation_params(
+        system_instruction=invocation_params["system_instruction"],
+        tools=invocation_params["tools"] or [],
+        tool_config=service._tool_config,
+    )
+    service._maybe_unset_thinking_budget(generation_params)
+
+    model_name = service._settings.model
+    if not isinstance(model_name, str):
+        raise RuntimeError(
+            f"chat llm_driver: gemini service has no concrete model name (got {model_name!r})"
+        )
+
+    logger.debug(f"[{log_label}] llm_driver: gemini stream model={model_name}")
+
+    # ``generate_content_stream`` returns a plain async generator
+    # (google/genai/models.py: ``base_async_generator``) that wraps the
+    # underlying ``AsyncStream``. Closing it via Python's native
+    # ``aclose()`` cancels the inner ``async for`` and cascades to the
+    # SDK's stream cleanup.
+    response = await service._client.aio.models.generate_content_stream(
+        model=model_name,
+        contents=invocation_params["messages"],
+        config=GenerateContentConfig(**generation_params),
+    )
+    try:
+        async for chunk in response:
+            if not chunk.candidates:
+                continue
+            for candidate in chunk.candidates:
+                if not (candidate.content and candidate.content.parts):
+                    continue
+                for part in candidate.content.parts:
+                    if part.text and not part.thought:
+                        yield ("text", part.text)
+                    elif part.function_call:
+                        fc = part.function_call
+                        if not fc.name:
+                            logger.warning(
+                                f"[{log_label}] llm_driver: gemini function_call "
+                                "with no name; skipping"
+                            )
+                            continue
+                        yield (
+                            "tool_call",
+                            FunctionCallFromLLM(
+                                function_name=fc.name,
+                                tool_call_id=fc.id or str(_uuid.uuid4()),
+                                arguments=fc.args or {},
+                                context=context,
+                            ),
+                        )
+    finally:
+        await _close_stream(response)
+
+
+async def _close_stream(response: Any) -> None:
+    """Best-effort close for SDK stream / async-generator return values.
+
+    - Python async generators (Gemini's ``base_async_generator``) expose
+      ``aclose``; calling it raises ``GeneratorExit`` into the body and
+      cascades to the wrapped SDK stream.
+    - SDK ``AsyncStream`` classes (Anthropic, OpenAI) expose ``close``.
+    - Swallow exceptions: cleanup runs in a ``finally`` and we'd rather
+      lose the close error than mask the real one being unwound.
+    """
+    closer = getattr(response, "aclose", None) or getattr(response, "close", None)
+    if closer is None:
+        return
+    try:
+        result = closer()
+        if hasattr(result, "__await__"):
+            await result
+    except Exception as exc:  # noqa: BLE001
+        logger.debug(f"llm_driver: stream close raised (ignored): {exc}")

--- a/app/ai/voice/agents/breeze_buddy/chat/sse.py
+++ b/app/ai/voice/agents/breeze_buddy/chat/sse.py
@@ -1,0 +1,29 @@
+"""SSE wire helpers for the chat router.
+
+Just the event dataclass and the wire formatter — the agent yields
+``SSEEvent`` directly, no Frame classifier. Event taxonomy lives in
+``docs/CHAT_MODE.md`` §6.4.
+"""
+
+import json
+from dataclasses import dataclass, field
+from typing import Any, Dict, Optional
+
+
+@dataclass
+class SSEEvent:
+    event: str
+    data: Dict[str, Any] = field(default_factory=dict)
+    id: Optional[str] = None
+
+
+def format_sse(event: SSEEvent) -> str:
+    """Render an SSE event in wire format. Caller flushes the stream."""
+    lines = [f"event: {event.event}"]
+    if event.id is not None:
+        lines.append(f"id: {event.id}")
+    lines.append("data: " + json.dumps(event.data, ensure_ascii=False))
+    return "\n".join(lines) + "\n\n"
+
+
+__all__ = ["SSEEvent", "format_sse"]

--- a/app/ai/voice/agents/breeze_buddy/llm/__init__.py
+++ b/app/ai/voice/agents/breeze_buddy/llm/__init__.py
@@ -43,8 +43,15 @@ from app.core.logger import logger
 from app.services.live_config.store import get_config
 
 
-async def _resolve_azure(llm_config: LLMConfiguration | None) -> AzureLLMService:
-    """Build Azure LLM, using dynamic config as fallback for template overrides."""
+async def _resolve_azure(
+    llm_config: LLMConfiguration | None, *, pooled: bool = False
+) -> AzureLLMService:
+    """Build Azure LLM, using dynamic config as fallback for template overrides.
+
+    ``pooled=True`` is reserved for chat mode (long-lived process, multiple
+    turns). Voice runs each call in its own subprocess and gets nothing
+    from connection sharing — keep voice on the stock pipecat service.
+    """
     # Endpoint: template override or env default
     endpoint = (
         llm_config.endpoint
@@ -101,7 +108,8 @@ async def _resolve_azure(llm_config: LLMConfiguration | None) -> AzureLLMService
                 if llm_config and llm_config.function_call_timeout_secs
                 else 10.0
             ),
-        )
+        ),
+        pooled=pooled,
     )
 
 
@@ -170,7 +178,7 @@ async def _resolve_vertex(llm_config: LLMConfiguration) -> GoogleVertexLLMServic
 
 
 async def _resolve_claude_vertex(
-    llm_config: LLMConfiguration,
+    llm_config: LLMConfiguration, *, pooled: bool = False
 ) -> VertexAnthropicLLMService:
     """Build Claude on Vertex AI — all params required from template config."""
     credentials_json = await GOOGLE_VERTEX_CREDENTIALS_JSON()
@@ -228,12 +236,15 @@ async def _resolve_claude_vertex(
                 if llm_config.function_call_timeout_secs
                 else 10.0
             ),
-        )
+        ),
+        pooled=pooled,
     )
 
 
 async def get_llm_service(
     llm_config: LLMConfiguration | None = None,
+    *,
+    pooled: bool = False,
 ) -> Union[AzureLLMService, GoogleVertexLLMService, VertexAnthropicLLMService]:
     """Get LLM service instance based on configuration.
 
@@ -244,6 +255,10 @@ async def get_llm_service(
 
     Args:
         llm_config: Optional template-level LLM configuration.
+        pooled: chat-mode opt-in for sharing the underlying client across
+            calls. Today Azure (HTTP/2 httpx pool) and Claude on Vertex
+            (AsyncAnthropicVertex client + OAuth token cache) honour it;
+            Gemini Vertex ignores it (still per-call).
 
     Returns:
         Configured LLM service instance.
@@ -251,24 +266,29 @@ async def get_llm_service(
     Raises:
         ValueError: If required provider configuration is missing.
     """
+    # Pooled callers (chat) re-resolve every turn — demote the
+    # provider-selection trace so follow-up turns don't spam INFO.
+    # Voice (pooled=False) keeps INFO for once-per-call setup.
+    _dispatch_log = logger.debug if pooled else logger.info
+
     if (
         not llm_config
         or not llm_config.provider
         or llm_config.provider == LLMProvider.AZURE
     ):
-        logger.info("Using Azure LLM provider")
-        return await _resolve_azure(llm_config)
+        _dispatch_log("Using Azure LLM provider")
+        return await _resolve_azure(llm_config, pooled=pooled)
 
     if llm_config.provider == LLMProvider.GOOGLE_VERTEX:
         if llm_config.sdk == LLMSdk.ANTHROPIC:
-            logger.info("Using Claude on Vertex AI (Anthropic SDK)")
-            return await _resolve_claude_vertex(llm_config)
+            _dispatch_log("Using Claude on Vertex AI (Anthropic SDK)")
+            return await _resolve_claude_vertex(llm_config, pooled=pooled)
 
-        logger.info("Using Gemini on Vertex AI (Google SDK)")
+        _dispatch_log("Using Gemini on Vertex AI (Google SDK)")
         return await _resolve_vertex(llm_config)
 
     # Fallback — shouldn't happen with the enum, but be safe
     logger.warning(
         f"Unknown LLM provider '{llm_config.provider}', falling back to Azure"
     )
-    return await _resolve_azure(llm_config)
+    return await _resolve_azure(llm_config, pooled=pooled)

--- a/app/ai/voice/agents/breeze_buddy/template/builder.py
+++ b/app/ai/voice/agents/breeze_buddy/template/builder.py
@@ -4,7 +4,7 @@ Flow Configuration Builder
 This module builds Pipecat flow configurations from database models.
 """
 
-from typing import Any, Callable, Dict, List, cast
+from typing import AbstractSet, Any, Callable, Dict, List, cast
 
 from pipecat_flows import (
     FlowManager,
@@ -53,19 +53,90 @@ DIRECT_MODE_NODE_NAME = "__direct__"
 _GLOBAL_FUNCTION_TYPES = {t.value for t in GlobalFunctionType}
 
 
+def filter_disabled_identifiers(
+    items: List[Dict[str, Any]],
+    disabled: AbstractSet[str],
+    log_label: str = "item",
+) -> List[Dict[str, Any]]:
+    """Drop dicts whose ``name``, ``function_name`` *or* ``handler`` is disabled.
+
+    All three identifier keys are checked: a single ``or`` chain would let
+    an authored entry like ``{"name": "transfer_to_finance", "handler":
+    "connect_to_live_agent"}`` slip past, because ``name`` resolves first
+    and isn't in the disabled set even though the handler binding is.
+    Action entries (which carry only ``handler``) and function entries
+    (``name`` / ``function_name``) are both covered by the union check.
+
+    Returns the input list as-is when ``disabled`` is empty (no copy
+    made), so call sites can route through this helper unconditionally
+    without paying for an allocation in the common case.
+
+    A ``WARNING`` is logged for each stripped item, suffixed with
+    ``log_label`` so authors can locate the affected JSON array.
+    """
+    if not disabled:
+        return items
+
+    out: List[Dict[str, Any]] = []
+    for item in items:
+        if isinstance(item, dict):
+            present: set[str] = {
+                str(item[k])
+                for k in ("name", "function_name", "handler")
+                if isinstance(item.get(k), str)
+            }
+            blocked = present & disabled
+            if blocked:
+                logger.warning(
+                    f"Stripping disabled {log_label} (matched {sorted(blocked)})"
+                )
+                continue
+        out.append(item)
+    return out
+
+
 class FlowConfigBuilder:
     """Builds Pipecat flow configurations from database models"""
 
-    def __init__(self):
+    def __init__(
+        self,
+        disabled_names: AbstractSet[str] = frozenset(),
+        *,
+        quiet: bool = False,
+    ):
         """
         Initialize builder with a static handler map.
 
         The handler_map contains raw handlers that will be wrapped with
-        with_context(bot_instance) in agent.py before use.
+        with_context(bot_instance) in agent.py before use. The map is
+        the same regardless of caller — channel-specific behaviour is
+        realised by filtering template-level references via
+        ``filter_disabled_identifiers`` rather than swapping handler
+        bodies.
 
         Note: Global function adapters are registered at module level in
         global_function_handler.py (same pattern as HookRegistry).
+
+        Args:
+            disabled_names: Identifiers to drop from per-node functions,
+                global functions, and per-node pre/post actions before
+                pydantic validation. Voice agents pass nothing (default
+                empty set, no-op fast-path inside the filter); chat
+                agents pass ``CHAT_DISABLED_NAMES`` (see
+                ``app.ai.voice.agents.breeze_buddy.chat.disabled``).
+            quiet: When True, demote the per-build INFO log lines
+                (``Building flow config``, ``Built direct-mode flow
+                config``, ``Direct mode: built N function(s)``,
+                ``Built flow config with N nodes``) to DEBUG. Chat
+                rebuilds the flow per turn — keep INFO for voice's
+                once-per-call setup but skip the noise on follow-up
+                chat turns.
         """
+        self._disabled_names = disabled_names
+        # Pre-bind so call sites stay terse: ``self._log(...)`` instead
+        # of ``(logger.debug if quiet else logger.info)(...)`` per call.
+        self._log = logger.debug if quiet else logger.info
+
         self.handler_map = {
             "mute_stt": mute_stt,
             "unmute_stt": unmute_stt,
@@ -91,7 +162,7 @@ class FlowConfigBuilder:
         Raises:
             ValueError: If initial node is not found or flow structure is invalid
         """
-        logger.info(
+        self._log(
             f"Building flow config from template: {template.name if hasattr(template, 'name') else 'unknown'}"
         )
 
@@ -127,9 +198,36 @@ class FlowConfigBuilder:
             # Transform function_name to name for compatibility
             transformed_node_data = node_data.copy()
             if "functions" in transformed_node_data:
+                # Templates are now L2-cached (``template/cache.py``) and
+                # ``node_data.copy()`` is shallow — the inner ``functions``
+                # list and its dicts are still cache-owned. Materialise a
+                # fresh list of shallow-copied dicts so the rename below
+                # (``pop("function_name")``) doesn't rewrite the cached
+                # template in place and corrupt subsequent turns.
+                transformed_node_data["functions"] = [
+                    dict(func) if isinstance(func, dict) else func
+                    for func in filter_disabled_identifiers(
+                        transformed_node_data["functions"],
+                        self._disabled_names,
+                        "function",
+                    )
+                ]
                 for func in transformed_node_data["functions"]:
-                    if "function_name" in func and "name" not in func:
+                    if isinstance(func, dict) and (
+                        "function_name" in func and "name" not in func
+                    ):
                         func["name"] = func.pop("function_name")
+
+            # In chat mode, also strip FUNCTION-type pre/post actions whose
+            # handler is voice-only — otherwise they'd attempt to invoke STT
+            # mute / audio playback against a transport that has neither.
+            for action_field in ("pre_actions", "post_actions"):
+                if action_field in transformed_node_data:
+                    transformed_node_data[action_field] = filter_disabled_identifiers(
+                        transformed_node_data[action_field],
+                        self._disabled_names,
+                        "action",
+                    )
 
             flow_nodes.append(FlowNodeModel.model_validate(transformed_node_data))
             logger.debug(
@@ -157,7 +255,7 @@ class FlowConfigBuilder:
         end_conversation_callbacks = flow.get("end_conversation_callbacks", [])
         logger.debug(f"End conversation callbacks: {end_conversation_callbacks}")
 
-        logger.info(
+        self._log(
             f"Built flow config with {len(nodes)} nodes, initial: {initial_node_name}, "
             f"callbacks: {end_conversation_callbacks}"
         )
@@ -222,7 +320,7 @@ class FlowConfigBuilder:
 
         end_conversation_callbacks = flow.get("end_conversation_callbacks", [])
 
-        logger.info(
+        self._log(
             f"Built direct-mode flow config: 1 synthesized node "
             f"({DIRECT_MODE_NODE_NAME}), system_prompt={len(system_prompt)} chars, "
             f"end_conversation_callbacks={end_conversation_callbacks}"
@@ -262,15 +360,29 @@ class FlowConfigBuilder:
         # adapter registry; everything else is a FlowFunction (hooks-only).
         if flow.get("mode") == FlowMode.DIRECT.value:
             return self._build_direct_mode_functions(
-                flow.get("functions") or [],
+                filter_disabled_identifiers(
+                    flow.get("functions") or [], self._disabled_names, "function"
+                ),
                 bot_instance=bot_instance,
             )
 
         # Flow mode: keep the legacy split between per-node `functions` (built
         # by `_build_function_schema` during node construction) and top-level
-        # `global_functions` (built here via the adapter registry).
+        # `global_functions` (built here via the adapter registry). The
+        # filter is a no-op in voice mode (returns the same list), so we can
+        # always run it; we shallow-copy the flow dict to avoid mutating the
+        # caller's structure when assigning the filtered list back.
+        flow_for_globals = {
+            **flow,
+            "global_functions": filter_disabled_identifiers(
+                flow.get("global_functions") or [], self._disabled_names, "function"
+            ),
+        }
+
         return GlobalFunctionRegistry.build(
-            flow, handler_map=self.handler_map, bot_instance=bot_instance
+            flow_for_globals,
+            handler_map=self.handler_map,
+            bot_instance=bot_instance,
         )
 
     def _build_direct_mode_functions(
@@ -319,7 +431,7 @@ class FlowConfigBuilder:
         for func_model in flow_function_models:
             result.append(self._build_function_schema(func_model))
 
-        logger.info(
+        self._log(
             f"Direct mode: built {len(result)} function(s) "
             f"({len(global_entries)} adapter-routed, {len(flow_function_models)} hook-only)"
         )

--- a/app/ai/voice/agents/breeze_buddy/template/cache.py
+++ b/app/ai/voice/agents/breeze_buddy/template/cache.py
@@ -1,0 +1,90 @@
+"""Redis-backed template cache (L2 only).
+
+Templates are read-hot, write-rare. Without caching every chat ``/message``
+turn pays a Postgres roundtrip + Pydantic decode + a fistful of
+``[Deprecated]`` warnings (legacy voice config migration). With L2 the
+entire fleet shares one decode every TTL window.
+
+Bust strategy: explicit ``invalidate_template()`` from the template
+PUT/DELETE handlers makes propagation eager. ``CACHE_TTL_SECONDS`` is just
+a safety net for the case where bust fails (transient Redis error) or for
+out-of-band writes (direct SQL, replication lag).
+
+Cache hits also avoid the legacy-config migration path because we
+serialize the post-migration ``TemplateModel`` — old deprecation warnings
+fire only on the first decode of each template.
+"""
+
+from typing import Optional
+
+from app.ai.voice.agents.breeze_buddy.template.types import TemplateModel
+from app.core.logger import logger
+from app.database.accessor.breeze_buddy.template import (
+    get_template_by_id as _db_get_template_by_id,
+)
+from app.services.redis.client import get_redis_service, is_redis_configured
+
+CACHE_TTL_SECONDS = 60
+_KEY_PREFIX = "bb:template:"
+
+
+def _key(template_id: str) -> str:
+    return f"{_KEY_PREFIX}{template_id}"
+
+
+async def get_template_by_id_cached(template_id: str) -> Optional[TemplateModel]:
+    """Return the cached template or fetch + cache on miss.
+
+    Falls through to the DB unconditionally if Redis is unconfigured or
+    misbehaving — the cache is best-effort, never load-bearing.
+    """
+    if not is_redis_configured():
+        return await _db_get_template_by_id(template_id)
+
+    cache_key = _key(template_id)
+    redis = await get_redis_service()
+
+    try:
+        cached = await redis.get(cache_key)
+    except Exception as exc:
+        logger.warning(f"template cache GET failed for {template_id}: {exc}")
+        cached = None
+
+    if cached is not None:
+        try:
+            return TemplateModel.model_validate_json(cached)
+        except Exception as exc:
+            logger.warning(
+                f"template cache decode failed for {template_id}, refetching: {exc}"
+            )
+
+    template = await _db_get_template_by_id(template_id)
+    if template is None:
+        return None
+
+    try:
+        await redis.setex(
+            cache_key,
+            template.model_dump_json(),
+            ttl_seconds=CACHE_TTL_SECONDS,
+        )
+        logger.debug(f"template cache populated: {template_id}")
+    except Exception as exc:
+        logger.warning(f"template cache SET failed for {template_id}: {exc}")
+
+    return template
+
+
+async def invalidate_template(template_id: str) -> None:
+    """Drop the Redis entry. Idempotent; safe to call when key is absent."""
+    if not is_redis_configured():
+        return
+    try:
+        redis = await get_redis_service()
+        await redis.delete(_key(template_id))
+        logger.info(f"template cache invalidated: {template_id}")
+    except Exception as exc:
+        logger.warning(f"template cache invalidate failed for {template_id}: {exc}")
+
+
+__all__ = ["CACHE_TTL_SECONDS", "get_template_by_id_cached", "invalidate_template"]

--- a/app/ai/voice/agents/breeze_buddy/template/context.py
+++ b/app/ai/voice/agents/breeze_buddy/template/context.py
@@ -208,7 +208,8 @@ class TemplateContext:
             function_args: Arguments passed to the function that brought us here
         """
         if not self.lead:
-            logger.warning("Cannot record node entry: lead is None")
+            # Expected in chat mode (no lead by design); voice always sets one.
+            logger.info("Skipping node entry record: lead is None")
             return
 
         if self.lead.metaData is None:
@@ -238,7 +239,8 @@ class TemplateContext:
         The via_function and function_args are set during node entry, not exit.
         """
         if not self.lead or not self.lead.metaData:
-            logger.warning("Cannot record node exit: lead or metaData is None")
+            # Expected in chat mode (no lead by design); voice always sets one.
+            logger.info("Skipping node exit record: lead or metaData is None")
             return
 
         if "node_traversal" not in self.lead.metaData:

--- a/app/ai/voice/agents/breeze_buddy/template/hooks.py
+++ b/app/ai/voice/agents/breeze_buddy/template/hooks.py
@@ -197,9 +197,10 @@ class UpdateOutcomeInDatabaseHook(Hook):
 
         # Get lead from context
         if not context.lead or not context.lead.id:
-            logger.warning(
-                f"No lead found in context for function '{function_name}'. "
-                f"Cannot update outcome in database."
+            # Expected in chat mode (no lead by design). Outcome persistence
+            # to chat_session is a separate concern; see docs/CHAT_MODE.md §15.
+            logger.info(
+                f"Skipping outcome DB update for '{function_name}': no lead in context."
             )
             return
 

--- a/app/ai/voice/agents/breeze_buddy/template/loader.py
+++ b/app/ai/voice/agents/breeze_buddy/template/loader.py
@@ -13,6 +13,7 @@ from app.ai.voice.agents.breeze_buddy.template.types import (
     FlowMode,
     TemplateModel,
 )
+from app.ai.voice.agents.breeze_buddy.template.utils import render_messages_with_vars
 from app.core.logger import logger
 from app.database.accessor.breeze_buddy.credentials import (
     get_credentials_as_template_vars,
@@ -83,32 +84,8 @@ class FlowConfigLoader:
     def render_task_messages(
         self, task_messages: list, variables: Dict[str, str]
     ) -> list:
-        """
-        Render task messages with runtime variables.
-
-        Args:
-            task_messages: List of task message objects
-            variables: Dictionary of variable values
-
-        Returns:
-            List of rendered task messages
-        """
-        rendered_messages = []
-        for message in task_messages:
-            if isinstance(message, dict) and "content" in message:
-                content = message["content"]
-                # Replace variables in content
-                for key, value in variables.items():
-                    placeholder = f"{{{key}}}"
-                    content = content.replace(placeholder, str(value))
-
-                rendered_message = message.copy()
-                rendered_message["content"] = content
-                rendered_messages.append(rendered_message)
-            else:
-                rendered_messages.append(message)
-
-        return rendered_messages
+        """Method-style alias preserved for the voice loader call sites."""
+        return render_messages_with_vars(task_messages, variables)
 
     async def load_template(
         self,

--- a/app/ai/voice/agents/breeze_buddy/template/types.py
+++ b/app/ai/voice/agents/breeze_buddy/template/types.py
@@ -3,7 +3,7 @@ Pydantic models for the dynamic workflow engine.
 """
 
 from enum import Enum
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Literal, Optional
 
 from pydantic import (
     BaseModel,
@@ -1226,6 +1226,11 @@ class DirectModeFlow(BaseModel):
     )
 
 
+def _default_supported_channels() -> List[Literal["voice", "chat"]]:
+    """Default `TemplateModel.supported_channels` factory — voice-only."""
+    return ["voice"]
+
+
 class TemplateModel(BaseModel):
     # Read-only fields (set by server, not editable via API).
     # These are intentionally excluded from ReplaceTemplateRequest so that
@@ -1245,6 +1250,15 @@ class TemplateModel(BaseModel):
     secrets: Optional[Dict[str, Any]] = None
     outbound_number_id: Optional[str] = None
     is_active: bool = True
+    # Channels this template is allowed to be served on. Defaults to
+    # voice-only so existing templates are unaffected. Add "chat" to
+    # opt the template into the chat (text) mode flow build path
+    # (see docs/CHAT_MODE.md §8). Persistence column lands with the
+    # chat router task; until then the field uses the default.
+    supported_channels: List[Literal["voice", "chat"]] = Field(
+        default_factory=_default_supported_channels,
+        min_length=1,
+    )
 
 
 # Request models for API
@@ -1278,6 +1292,10 @@ class CreateTemplateRequest(BaseModel):
     expected_callback_response_schema: Optional[Dict[str, Any]] = None
     configurations: Optional[ConfigurationModel] = None
     secrets: Optional[Dict[str, Any]] = None
+    supported_channels: List[Literal["voice", "chat"]] = Field(
+        default_factory=_default_supported_channels,
+        min_length=1,
+    )
 
 
 class ReplaceTemplateRequest(BaseModel):
@@ -1294,6 +1312,12 @@ class ReplaceTemplateRequest(BaseModel):
     Non-nullable fields (name, flow, is_active) must be provided - throws 400 if not.
     Nullable fields (merchant_id, outbound_number_id, expected_payload_schema,
     expected_callback_response_schema, configurations) - if not provided, set to NULL.
+
+    ``supported_channels`` is intentionally optional (``None`` default) rather
+    than defaulting to ``['voice']``: pre-chat-feature PUT clients have no
+    knowledge of this field, and silently overwriting a chat-enabled template
+    back to voice-only on every unrelated edit would be a behaviour change.
+    Handler keeps the persisted value when this field is omitted.
     """
 
     # extra="ignore" allows clients to pass the full GET response body to PUT;
@@ -1309,3 +1333,7 @@ class ReplaceTemplateRequest(BaseModel):
     expected_callback_response_schema: Optional[Dict[str, Any]] = None
     configurations: Optional[ConfigurationModel] = None
     secrets: Optional[Dict[str, Any]] = None
+    supported_channels: Optional[List[Literal["voice", "chat"]]] = Field(
+        default=None,
+        min_length=1,
+    )

--- a/app/ai/voice/agents/breeze_buddy/template/utils.py
+++ b/app/ai/voice/agents/breeze_buddy/template/utils.py
@@ -1,0 +1,23 @@
+"""Pure helpers shared between the voice template loader and the chat agent."""
+
+from typing import Dict
+
+
+def render_messages_with_vars(messages: list, variables: Dict[str, str]) -> list:
+    """Replace ``{key}`` placeholders in each message's ``content`` from
+    ``variables``. Pure function — used by both the voice loader and the
+    chat agent so the substitution logic stays in one place.
+    """
+    rendered_messages = []
+    for message in messages:
+        if isinstance(message, dict) and "content" in message:
+            content = message["content"]
+            for key, value in variables.items():
+                placeholder = f"{{{key}}}"
+                content = content.replace(placeholder, str(value))
+            rendered_message = message.copy()
+            rendered_message["content"] = content
+            rendered_messages.append(rendered_message)
+        else:
+            rendered_messages.append(message)
+    return rendered_messages

--- a/app/ai/voice/agents/breeze_buddy/utils/secrets.py
+++ b/app/ai/voice/agents/breeze_buddy/utils/secrets.py
@@ -90,6 +90,12 @@ def mask_template_secrets(template: TemplateModel) -> TemplateModel:
         secrets=mask_secrets(template.secrets),
         outbound_number_id=template.outbound_number_id,
         is_active=template.is_active,
+        # ``supported_channels`` must be carried through the masked copy.
+        # If not preserved, GET / PUT response paths fall back to the
+        # ``TemplateModel`` default (``['voice']``) and chat-enabled
+        # templates appear voice-only to API clients — which then PUT the
+        # default back, silently disabling chat on round-trip edits.
+        supported_channels=list(template.supported_channels),
         created_at=template.created_at,
         updated_at=template.updated_at,
     )

--- a/app/ai/voice/llm/_pools.py
+++ b/app/ai/voice/llm/_pools.py
@@ -1,0 +1,143 @@
+"""Process-wide HTTP / API client pools for the chat LLM path.
+
+Why this exists, in two beats:
+
+1. **HTTP/2 is load-bearing for streaming.** The OpenAI SDK's SSE iterator
+   (``openai/_streaming.py:__stream__``) breaks out on ``[DONE]`` and calls
+   ``response.aclose()`` mid-body. With HTTP/1.1 httpx refuses to re-pool a
+   response with unread bytes — every chat turn paid a fresh handshake. With
+   HTTP/2 the SDK's per-stream close terminates only that stream; the
+   underlying TCP+TLS connection multiplexes the next request on top. Azure
+   OpenAI endpoints negotiate h2 via ALPN (``curl -sI --http2`` confirms
+   ``HTTP/2 200``); falls back to HTTP/1.1 for endpoints that don't.
+
+2. **Pool can't live in Redis.** httpx pools own live TCP sockets and TLS
+   sessions — process-local file descriptors that no protocol can transfer
+   across pods. Each pod warms its own pool on first use. Pod count is
+   bounded; session count isn't, so this scales fine.
+
+Voice is unaffected: each voice call runs in its own subprocess (one client,
+lives for the call), so the per-call pool is single-entry-and-die regardless.
+
+The Anthropic Vertex pool follows the same logic: ``AsyncAnthropicVertex``
+owns its own httpx client *and* an OAuth token cache, so reusing one client
+across chat turns avoids both repeated TLS handshakes and re-minting the
+Vertex access token on every turn.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Optional
+
+import httpx
+from anthropic import AsyncAnthropicVertex
+from google.oauth2 import service_account
+
+from app.core.logger import logger
+
+__all__ = [
+    "close_all_pools",
+    "get_anthropic_vertex_client",
+    "get_azure_httpx_client",
+]
+
+# ``keepalive_expiry=120s`` stays comfortably under Azure's idle timeout
+# (~4 min) so we close from our side first and avoid "connection reset by
+# peer" surprises. Limits match pipecat's generic OpenAI service
+# (``pipecat/services/openai/base_llm.py:255``).
+_AZURE_HTTPX_POOLS: dict[tuple[str, str], httpx.AsyncClient] = {}
+
+
+def get_azure_httpx_client(endpoint: str, api_version: str) -> httpx.AsyncClient:
+    """Return the shared httpx client for ``(endpoint, api_version)``."""
+    key = (endpoint, api_version)
+    client = _AZURE_HTTPX_POOLS.get(key)
+    if client is None:
+        client = httpx.AsyncClient(
+            http2=True,
+            limits=httpx.Limits(
+                max_keepalive_connections=100,
+                max_connections=1000,
+                keepalive_expiry=120.0,
+            ),
+            timeout=httpx.Timeout(connect=5.0, read=60.0, write=10.0, pool=5.0),
+        )
+        _AZURE_HTTPX_POOLS[key] = client
+        logger.info(
+            f"Azure httpx pool created for endpoint={endpoint} api_version={api_version}"
+        )
+    return client
+
+
+_ANTHROPIC_VERTEX_POOLS: dict[tuple[str, str, str], AsyncAnthropicVertex] = {}
+
+
+def _credentials_fingerprint(credentials_json: str) -> str:
+    """Stable short hash so two distinct SAs for the same project/region get
+    distinct cache entries. Hash, not the raw JSON, so the cache key never
+    holds private-key material."""
+    return hashlib.sha256(credentials_json.encode("utf-8")).hexdigest()[:16]
+
+
+def get_anthropic_vertex_client(
+    *,
+    credentials_json: str,
+    project_id: str,
+    region: str,
+) -> AsyncAnthropicVertex:
+    """Return a shared ``AsyncAnthropicVertex`` for ``(project, region, creds)``.
+
+    Sharing this client across chat turns reuses both the underlying httpx
+    connection pool and the Vertex OAuth token cache that the Anthropic SDK
+    maintains on each ``AsyncAnthropicVertex`` instance.
+    """
+    key = (project_id, region, _credentials_fingerprint(credentials_json))
+    client = _ANTHROPIC_VERTEX_POOLS.get(key)
+    if client is None:
+        creds = service_account.Credentials.from_service_account_info(
+            json.loads(credentials_json),
+            scopes=["https://www.googleapis.com/auth/cloud-platform"],
+        )
+        client = AsyncAnthropicVertex(
+            region=region,
+            project_id=project_id,
+            credentials=creds,
+        )
+        _ANTHROPIC_VERTEX_POOLS[key] = client
+        logger.info(
+            f"AsyncAnthropicVertex pool created for project={project_id} "
+            f"region={region} creds_fp={key[2]}"
+        )
+    return client
+
+
+async def _close_anthropic_vertex_clients() -> None:
+    for key, client in list(_ANTHROPIC_VERTEX_POOLS.items()):
+        close: Optional[object] = getattr(client, "aclose", None) or getattr(
+            client, "close", None
+        )
+        if close is None:
+            continue
+        try:
+            result = close()  # type: ignore[operator]
+            if hasattr(result, "__await__"):
+                await result
+        except Exception as exc:
+            logger.warning(f"AsyncAnthropicVertex pool close failed for {key}: {exc}")
+    _ANTHROPIC_VERTEX_POOLS.clear()
+
+
+async def close_all_pools() -> None:
+    """Close every shared client. Wired into FastAPI lifespan shutdown."""
+    for key, client in list(_AZURE_HTTPX_POOLS.items()):
+        try:
+            await client.aclose()
+        except Exception as exc:
+            logger.warning(f"Azure httpx pool close failed for {key}: {exc}")
+    _AZURE_HTTPX_POOLS.clear()
+    logger.info("All Azure httpx pools closed")
+
+    await _close_anthropic_vertex_clients()
+    logger.info("All AsyncAnthropicVertex pools closed")

--- a/app/ai/voice/llm/azure.py
+++ b/app/ai/voice/llm/azure.py
@@ -1,15 +1,48 @@
-"""Azure OpenAI LLM config and builder."""
+"""Azure OpenAI LLM config and builder.
+
+Two construction modes:
+
+- **Stock** (``pooled=False``, default): plain :class:`AzureLLMService` with
+  the SDK's per-instance httpx client. This is what voice mode uses, where
+  each call runs in its own subprocess and tears down — there's nothing
+  to share, and we want zero divergence from upstream pipecat behavior.
+
+- **Pooled** (``pooled=True``): :class:`_PooledAzureLLMService` injects a
+  process-wide HTTP/2 httpx client (see ``_pools.py``) so multiple chat
+  turns within the same process reuse one TCP+TLS handshake. Only chat
+  mode opts in.
+"""
 
 from __future__ import annotations
 
 from dataclasses import dataclass
 from typing import Any, Optional
 
+from openai import AsyncAzureOpenAI
 from pipecat.services.azure.llm import AzureLLMService, AzureLLMSettings
 
+from app.ai.voice.llm._pools import get_azure_httpx_client
 from app.core.logger import logger
 
 __all__ = ["AzureConfig", "build_azure_llm"]
+
+
+class _PooledAzureLLMService(AzureLLMService):
+    """AzureLLMService that injects a process-wide httpx client.
+
+    Pipecat's stock ``create_client`` (``pipecat/services/azure/llm.py:79``)
+    drops ``**kwargs``, so the only way to share a connection pool is to
+    override here. See ``_pools.py`` for the why (HTTP/2 + SSE pooling).
+    Used only by chat mode — voice subprocesses get the stock service.
+    """
+
+    def create_client(self, api_key=None, base_url=None, **kwargs):
+        return AsyncAzureOpenAI(
+            api_key=api_key,
+            azure_endpoint=self._endpoint,
+            api_version=self._api_version,
+            http_client=get_azure_httpx_client(self._endpoint, self._api_version),
+        )
 
 
 @dataclass
@@ -25,18 +58,19 @@ class AzureConfig:
     function_call_timeout_secs: float = 10.0
 
 
-def build_azure_llm(config: AzureConfig) -> AzureLLMService:
-    """Create an Azure OpenAI LLM service instance.
+def build_azure_llm(config: AzureConfig, *, pooled: bool = False) -> AzureLLMService:
+    """Create an Azure OpenAI LLM service.
 
     Args:
-        config: Azure-specific configuration.
-
-    Returns:
-        Configured AzureLLMService instance.
+        config: model + auth + sampling parameters.
+        pooled: when ``True``, return a service that shares the process
+            HTTP/2 httpx pool (chat mode). When ``False`` (default,
+            voice mode), return the stock pipecat service so per-call
+            subprocesses keep upstream behavior unchanged.
     """
     logger.info(
         f"Building Azure LLM service with model={config.model}, "
-        f"reasoning_effort={config.reasoning_effort}"
+        f"reasoning_effort={config.reasoning_effort}, pooled={pooled}"
     )
 
     extra: dict = {}
@@ -50,7 +84,8 @@ def build_azure_llm(config: AzureConfig) -> AzureLLMService:
     if config.max_tokens is not None:
         settings_kwargs["max_completion_tokens"] = config.max_tokens
 
-    return AzureLLMService(
+    cls = _PooledAzureLLMService if pooled else AzureLLMService
+    return cls(
         api_key=config.api_key,
         endpoint=config.endpoint,
         model=config.model,

--- a/app/ai/voice/llm/claude_vertex.py
+++ b/app/ai/voice/llm/claude_vertex.py
@@ -27,6 +27,7 @@ from pipecat.services.anthropic.llm import (
     AnthropicLLMSettings,
 )
 
+from app.ai.voice.llm._pools import get_anthropic_vertex_client
 from app.core.logger import logger
 
 __all__ = ["ClaudeVertexConfig", "build_claude_vertex_llm"]
@@ -90,31 +91,49 @@ class ClaudeVertexConfig:
     function_call_timeout_secs: float = 10.0
 
 
-def build_claude_vertex_llm(config: ClaudeVertexConfig) -> VertexAnthropicLLMService:
+def build_claude_vertex_llm(
+    config: ClaudeVertexConfig, *, pooled: bool = False
+) -> VertexAnthropicLLMService:
     """Create a Claude on Vertex AI LLM service instance.
 
     Args:
         config: Claude Vertex-specific configuration.
+        pooled: When True, share the underlying ``AsyncAnthropicVertex``
+            client (httpx pool + Vertex OAuth token cache) across calls.
+            Reserved for chat mode (long-lived process). Voice runs each
+            call in its own subprocess and gets nothing from sharing —
+            keep voice on a fresh per-call client.
 
     Returns:
         Configured VertexAnthropicLLMService instance with Vertex AI client.
     """
-    logger.info(
+    # Pooled callers (chat) build this every turn but only the first
+    # produces a new pooled client — keep the per-call log at DEBUG so
+    # follow-up turns stay quiet. Voice (pooled=False) builds once per
+    # call and keeps INFO for setup observability.
+    _build_log = logger.debug if pooled else logger.info
+    _build_log(
         f"Building Claude Vertex LLM service with model={config.model}, "
         f"project_id={config.project_id}, region={config.region}, "
-        f"thinking_enabled={config.thinking_enabled}"
+        f"thinking_enabled={config.thinking_enabled}, pooled={pooled}"
     )
 
-    creds = service_account.Credentials.from_service_account_info(
-        json.loads(config.credentials_json),
-        scopes=["https://www.googleapis.com/auth/cloud-platform"],
-    )
-
-    vertex_client = AsyncAnthropicVertex(
-        region=config.region,
-        project_id=config.project_id,
-        credentials=creds,
-    )
+    if pooled:
+        vertex_client = get_anthropic_vertex_client(
+            credentials_json=config.credentials_json,
+            project_id=config.project_id,
+            region=config.region,
+        )
+    else:
+        creds = service_account.Credentials.from_service_account_info(
+            json.loads(config.credentials_json),
+            scopes=["https://www.googleapis.com/auth/cloud-platform"],
+        )
+        vertex_client = AsyncAnthropicVertex(
+            region=config.region,
+            project_id=config.project_id,
+            credentials=creds,
+        )
 
     # Build thinking config if enabled
     thinking = None

--- a/app/api/routers/breeze_buddy/__init__.py
+++ b/app/api/routers/breeze_buddy/__init__.py
@@ -9,6 +9,7 @@ from app.api.routers.breeze_buddy.analytics import router as analytics_router
 # Auth, telephony, cron, websocket
 from app.api.routers.breeze_buddy.auth import router as auth_router
 from app.api.routers.breeze_buddy.blacklist import router as blacklist_router
+from app.api.routers.breeze_buddy.chat import router as chat_router
 from app.api.routers.breeze_buddy.configurations import router as configurations_router
 from app.api.routers.breeze_buddy.credentials import router as credentials_router
 from app.api.routers.breeze_buddy.cron import router as cron_router
@@ -80,3 +81,6 @@ router.include_router(websocket_router, prefix="", tags=["websocket"])
 router.include_router(pod_router, prefix="/pod", tags=["pod"])
 
 router.include_router(daily_router, prefix="", tags=["daily"])
+
+# Chat (text-mode sessions: REST + SSE, no STT/TTS/VAD)
+router.include_router(chat_router, prefix="", tags=["chat"])

--- a/app/api/routers/breeze_buddy/chat/__init__.py
+++ b/app/api/routers/breeze_buddy/chat/__init__.py
@@ -1,0 +1,205 @@
+"""
+Chat (text-mode) endpoints for Breeze Buddy.
+
+Five endpoints under ``/agent/voice/breeze-buddy/chat`` (the actual
+breeze_buddy mount per ``app/main.py``; ``CHAT_MODE.md §6`` shows the
+logical ``/api/breeze_buddy/chat`` namespace):
+
+- ``POST /chat/session`` — create a new chat session row, persist
+  the rendered ``initial_greeting`` (if the template has one), return it.
+- ``GET  /chat/session/{id}`` — full session state for resume.
+- ``POST /chat/session/{id}/message`` — drive one user→assistant
+  turn, stream events back as Server-Sent Events.
+- ``POST /chat/session/{id}/end`` — mark the session ENDED.
+- ``GET  /chat/session/{id}/transcript`` — read-only transcript
+  export.
+
+Architecture: stateless per turn. Each ``POST /message`` constructs a
+fresh ``ChatAgent``, replays history from the DB, drives one turn,
+and tears down. No in-memory registry, no sticky LB, no lock
+auto-extension — a single turn fits comfortably inside the 180s lock
+TTL. Idle session cleanup is owned by the global
+``BackgroundTaskScheduler``. See ``CHAT_MODE.md §11`` for the
+multi-pod model.
+
+For module layout this mirrors the leads router:
+- ``__init__.py`` — thin route declarations: auth + RBAC + delegation.
+- ``handlers.py`` — DB / lock / agent business logic.
+- ``rbac.py`` — reseller / merchant access validators.
+"""
+
+from fastapi import APIRouter, Depends, HTTPException, status
+
+from app.ai.voice.agents.breeze_buddy.template.cache import get_template_by_id_cached
+from app.api.security.breeze_buddy.rbac_token import get_current_user_with_rbac
+from app.schemas import UserInfo
+from app.schemas.breeze_buddy.chat import (
+    ChatTranscriptResponse,
+    CreateChatSessionRequest,
+    CreateChatSessionResponse,
+    EndChatSessionResponse,
+    GetChatSessionResponse,
+    SendChatMessageRequest,
+)
+
+from .demo import router as demo_router
+from .handlers import (
+    create_chat_session_handler,
+    end_chat_session_handler,
+    get_chat_session_handler,
+    get_chat_transcript_handler,
+    load_chat_session_or_404,
+    send_chat_message_handler,
+    validate_template_for_chat,
+)
+from .rbac import validate_chat_create_access, validate_chat_session_access
+
+router = APIRouter(prefix="/chat", tags=["chat"])
+
+
+@router.post(
+    "/session",
+    status_code=status.HTTP_201_CREATED,
+    response_model=CreateChatSessionResponse,
+)
+async def create_session(
+    req: CreateChatSessionRequest,
+    current_user: UserInfo = Depends(get_current_user_with_rbac),
+) -> CreateChatSessionResponse:
+    """
+    Create a new chat session for a chat-enabled template.
+
+    The session is pure DB state at this point — no agent, no
+    pipeline. The first ``POST /message`` builds the agent on demand.
+    If the template defines ``configurations.initial_greeting``, it is
+    rendered with ``req.template_vars``, persisted as the first
+    assistant message, and returned in the response.
+
+    RBAC:
+    - Admin: Can create a session for any reseller/merchant
+    - Reseller / Merchant: Must have access to the template's
+      reseller (and merchant if scoped)
+
+    Returns 400 if the template doesn't list ``"chat"`` in
+    ``supported_channels`` or uses a realtime/S2S LLM (voice-only).
+    """
+    template = await get_template_by_id_cached(req.template_id)
+    if template is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Template '{req.template_id}' not found",
+        )
+
+    validate_chat_create_access(
+        current_user,
+        reseller_id=template.reseller_id,
+        merchant_id=getattr(template, "merchant_id", None),
+        operation="create chat session",
+    )
+    validate_template_for_chat(template)
+
+    return await create_chat_session_handler(req, template, current_user)
+
+
+@router.get("/session/{session_id}", response_model=GetChatSessionResponse)
+async def get_session(
+    session_id: str,
+    current_user: UserInfo = Depends(get_current_user_with_rbac),
+) -> GetChatSessionResponse:
+    """
+    Get a chat session's current state + full message history.
+
+    Used by clients on resume (e.g., page reload) to rebuild the UI.
+
+    RBAC:
+    - Admin: Can read any session
+    - Reseller / Merchant: Must own the session's reseller / merchant
+      (returns 404 to avoid leaking existence)
+    """
+    session = await load_chat_session_or_404(session_id)
+    validate_chat_session_access(current_user, session, operation="get_session")
+    return await get_chat_session_handler(session)
+
+
+@router.post("/session/{session_id}/message")
+async def send_message(
+    session_id: str,
+    req: SendChatMessageRequest,
+    current_user: UserInfo = Depends(get_current_user_with_rbac),
+):
+    """
+    Drive one user→assistant turn; stream Server-Sent Events back to
+    the client until ``turn_end``.
+
+    Multi-pod safe: a per-session Redis lock guarantees one driver at
+    a time. Lock contention surfaces as ``409 Conflict`` before any
+    SSE bytes are written.
+
+    RBAC is enforced inside the handler under the lock to keep the
+    happy path to a single session read. See
+    ``send_chat_message_handler`` for the rationale.
+
+    Returns:
+        ``StreamingResponse`` (``text/event-stream``) of SSE events.
+        404 if session id is unknown, 410 if already ENDED, 409 if
+        contended.
+    """
+
+    # Closure-build the access check so the handler stays auth-agnostic
+    # (the demo router passes ``access_check=None`` — the demo token is
+    # already bound to a specific session_id and there's nothing further
+    # to authorise).
+    def _check(session) -> None:
+        validate_chat_session_access(current_user, session, operation="send_message")
+
+    return await send_chat_message_handler(session_id, req, access_check=_check)
+
+
+@router.post("/session/{session_id}/end", response_model=EndChatSessionResponse)
+async def end_session(
+    session_id: str,
+    current_user: UserInfo = Depends(get_current_user_with_rbac),
+) -> EndChatSessionResponse:
+    """
+    Mark the chat session ENDED. Idempotent.
+
+    Acquires the per-session Redis lock so a concurrent
+    ``send_message`` doesn't race with the end mutation.
+
+    RBAC:
+    - Admin: Can end any session
+    - Reseller / Merchant: Must own the session (404 otherwise)
+    """
+    session = await load_chat_session_or_404(session_id)
+    validate_chat_session_access(current_user, session, operation="end_session")
+    return await end_chat_session_handler(session_id, session)
+
+
+@router.get(
+    "/session/{session_id}/transcript",
+    response_model=ChatTranscriptResponse,
+)
+async def get_transcript(
+    session_id: str,
+    current_user: UserInfo = Depends(get_current_user_with_rbac),
+) -> ChatTranscriptResponse:
+    """
+    Read-only transcript export for audit / handoff.
+
+    RBAC:
+    - Admin: Can export any transcript
+    - Reseller / Merchant: Must own the session (404 otherwise)
+    """
+    session = await load_chat_session_or_404(session_id)
+    validate_chat_session_access(current_user, session, operation="get_transcript")
+    return await get_chat_transcript_handler(session)
+
+
+# Public demo subrouter (CHAT_MODE.md §13). Mounted under ``/chat/demo``;
+# none of these routes use ``get_current_user_with_rbac`` — the demo
+# token + IP rate-limit live inside ``demo.py``. Kept on a sub-prefix so
+# anything not explicitly opted-in via ``DEMO_TEMPLATES`` stays gated by
+# the standard RBAC routes above.
+router.include_router(demo_router, prefix="/demo", tags=["chat-demo"])
+
+__all__ = ["router"]

--- a/app/api/routers/breeze_buddy/chat/demo.py
+++ b/app/api/routers/breeze_buddy/chat/demo.py
@@ -1,0 +1,317 @@
+"""Public chat-demo endpoints (CHAT_MODE.md §13).
+
+Mounted under ``/chat/demo`` by the chat router. Three goals shape every
+decision in this file:
+
+1. **No standing credential required.** A visitor can land on a static
+   demo page and get a working chat without signing in. We mint a
+   short-lived bearer token (``demo_token.py``) at session-create time;
+   subsequent ``/message`` and ``/end`` calls present that token.
+
+2. **Bounded blast radius.** The token is *only* valid for the session
+   id it was minted for and only for the demo paths in this file. It
+   carries no reseller / merchant scopes, so it can't be misused on any
+   non-demo endpoint. A per-IP rate limit caps how many sessions a
+   single client can spin up; a per-session message cap caps the LLM
+   spend any single conversation can incur.
+
+3. **Reuse the chat path.** The actual turn-driving logic lives in
+   ``handlers.send_chat_message_handler`` — we don't want a parallel
+   stack with subtly different lock / SSE / cleanup behaviour. The
+   handler now accepts an ``access_check`` closure; we pass ``None``
+   (the demo token is already session-bound) and add a cap pre-check
+   on top.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+
+from app.ai.voice.agents.breeze_buddy.template.cache import get_template_by_id_cached
+from app.api.routers.breeze_buddy.chat.handlers import (
+    create_chat_session_handler,
+    end_chat_session_handler,
+    load_chat_session_or_404,
+    send_chat_message_handler,
+    validate_template_for_chat,
+)
+from app.api.security.breeze_buddy.demo_token import (
+    DemoSessionContext,
+    mint_demo_token,
+    require_demo_session,
+)
+from app.core.config.dynamic import (
+    DEMO_MESSAGE_CAP_PER_SESSION,
+    DEMO_MESSAGES_PER_IP_HOUR,
+    DEMO_SESSIONS_PER_IP_HOUR,
+)
+from app.core.config.static import DEMO_TEMPLATES
+from app.core.logger import logger
+from app.database.accessor.breeze_buddy.chat_session import (
+    list_chat_messages_for_session,
+)
+from app.schemas import UserInfo, UserRole
+from app.schemas.breeze_buddy.chat import (
+    ChatEndedReason,
+    ChatMessageRole,
+    ChatSessionStatus,
+    CreateChatSessionRequest,
+    CreateDemoSessionRequest,
+    CreateDemoSessionResponse,
+    DemoTemplateInfo,
+    EndChatSessionResponse,
+    ListDemoTemplatesResponse,
+    SendChatMessageRequest,
+)
+from app.services.redis.rate_limit import check_rate_limit
+
+router = APIRouter()
+
+# One-hour fixed window for both buckets — the cap (per session-creates,
+# per messages) is what shapes abuse resistance, not the granularity.
+_RATE_WINDOW_SECONDS = 3600
+
+
+def _client_ip(request: Request) -> str:
+    """Best-effort caller IP for rate-limit keying.
+
+    Honours ``X-Forwarded-For`` (first hop) when present so a load
+    balancer / reverse proxy doesn't make every visitor share one
+    bucket. Falls back to ``request.client.host``. Returns ``unknown``
+    if both are missing — treated as one shared bucket, which is the
+    safest default.
+    """
+    forwarded = request.headers.get("x-forwarded-for")
+    if forwarded:
+        return forwarded.split(",")[0].strip() or "unknown"
+    if request.client and request.client.host:
+        return request.client.host
+    return "unknown"
+
+
+async def _enforce_ip_limit(*, request: Request, bucket: str, limit: int) -> None:
+    """Raise 429 with ``Retry-After`` if ``request``'s IP is over ``limit``."""
+    decision = await check_rate_limit(
+        bucket=bucket,
+        identifier=_client_ip(request),
+        limit=limit,
+        window_seconds=_RATE_WINDOW_SECONDS,
+        prefix="demo",
+    )
+    if decision.allowed:
+        return
+    raise HTTPException(
+        status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+        detail=(
+            f"Demo rate limit hit ({decision.count}/{decision.limit} per hour). "
+            "Try again later."
+        ),
+        headers={"Retry-After": str(decision.retry_after_seconds)},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Routes
+# ---------------------------------------------------------------------------
+
+
+@router.get(
+    "/templates",
+    response_model=ListDemoTemplatesResponse,
+    summary="List publicly-available demo templates",
+)
+async def list_demo_templates() -> ListDemoTemplatesResponse:
+    """Static page hits this to populate its template picker.
+
+    Reads ``DEMO_TEMPLATES`` from static config — adding a new demo is
+    an env-var change. Returns an empty list when nothing is configured
+    so a freshly-deployed env doesn't 500 the demo page.
+    """
+    return ListDemoTemplatesResponse(
+        templates=[
+            DemoTemplateInfo(slug=slug, template_id=template_id)
+            for slug, template_id in DEMO_TEMPLATES.items()
+        ]
+    )
+
+
+@router.post(
+    "/session",
+    response_model=CreateDemoSessionResponse,
+    status_code=status.HTTP_201_CREATED,
+    summary="Mint a demo session + bearer token",
+)
+async def create_demo_session(
+    req: CreateDemoSessionRequest, request: Request
+) -> CreateDemoSessionResponse:
+    """Create a chat session for a registered demo slug + return a token.
+
+    Flow:
+      1. Per-IP rate limit on session creates.
+      2. Resolve slug → template_id; refuse unknown slugs (don't leak
+         which template ids exist).
+      3. Reuse ``create_chat_session_handler`` so the demo session is a
+         normal ``chat_session`` row (greeting render, secrets/credentials
+         merge, expected_payload_schema transforms — all consistent with
+         the authenticated path).
+      4. Stash the message cap on ``metadata.demo`` for read-back by
+         status / debug endpoints. The token also carries it (the
+         message handler trusts the token; metadata is informational).
+      5. Mint a JWT bound to ``demo_session_id`` and return it.
+    """
+    await _enforce_ip_limit(
+        request=request,
+        bucket="session_create",
+        limit=await DEMO_SESSIONS_PER_IP_HOUR(),
+    )
+
+    template_id = DEMO_TEMPLATES.get(req.slug)
+    if template_id is None:
+        # Don't 404 with the slug echoed back unchanged — small
+        # reconnaissance hardening; the static page already knows the
+        # valid slugs from /templates.
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Unknown demo template slug",
+        )
+
+    template = await get_template_by_id_cached(template_id)
+    if template is None:
+        # Misconfigured DEMO_TEMPLATES env var — log loudly so we
+        # notice in deploys, but don't leak the template_id to the
+        # caller.
+        logger.error(
+            f"demo: template {template_id!r} from DEMO_TEMPLATES is missing in DB "
+            f"(slug={req.slug!r})"
+        )
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Demo template misconfigured",
+        )
+    validate_template_for_chat(template)
+
+    # ``create_chat_session_handler`` expects the same shape the admin
+    # path uses; we synthesize a minimal ``UserInfo`` here only for the
+    # log line inside the handler. It carries no scopes / permissions —
+    # the demo token (separate concept) is what authenticates follow-up
+    # calls.
+    synthetic_user = UserInfo(
+        id="demo",
+        username="demo",
+        role=UserRole.USER,
+        reseller_ids=[],
+        merchant_ids=[],
+        permissions=[],
+    )
+    # Resolve the cap once and reuse it — minting after the handler so a
+    # mid-create flag flip can't disagree with what's persisted in
+    # metadata vs. the JWT.
+    cap = await DEMO_MESSAGE_CAP_PER_SESSION()
+    create_req = CreateChatSessionRequest(
+        template_id=template_id,
+        template_vars=req.template_vars,
+        metadata={"demo": {"slug": req.slug, "cap": cap}},
+    )
+    create_resp = await create_chat_session_handler(
+        create_req, template, synthetic_user
+    )
+
+    token = await mint_demo_token(
+        session_id=create_resp.session_id,
+        message_cap=cap,
+    )
+    return CreateDemoSessionResponse(
+        session_id=create_resp.session_id,
+        status=create_resp.status,
+        current_node=create_resp.current_node,
+        greeting=create_resp.greeting,
+        demo_token=token,
+        message_cap=cap,
+    )
+
+
+async def _assistant_turn_count(session_id: str) -> int:
+    """How many assistant messages already exist on this session.
+
+    Includes the static greeting (which is persisted as an assistant
+    row at session-create time) — that's intentional: a 20-cap session
+    where the greeting takes one means the user gets 19 exchanges. The
+    static page can show ``cap - 1`` to set expectations.
+    """
+    rows = await list_chat_messages_for_session(session_id)
+    return sum(1 for r in rows if r.role == ChatMessageRole.ASSISTANT)
+
+
+@router.post(
+    "/session/{session_id}/message",
+    summary="Stream one demo turn (SSE) — capped per session",
+)
+async def demo_send_message(
+    session_id: str,
+    req: SendChatMessageRequest,
+    request: Request,
+    ctx: DemoSessionContext = Depends(require_demo_session),
+):
+    """Drive one user→assistant turn for a demo session.
+
+    Two gates *before* the chat handler runs:
+      - per-IP message rate limit (high-frequency abuse signal);
+      - per-session assistant-turn cap from the demo token.
+
+    Both raise 429 (with ``Retry-After`` for the IP one) — the static
+    page can swap into a "demo finished, refresh to start a new one"
+    state when it sees the cap response.
+
+    No ``access_check`` is passed to ``send_chat_message_handler``: the
+    demo token already binds ``session_id``, so additional auth would
+    be redundant.
+    """
+    await _enforce_ip_limit(
+        request=request,
+        bucket="message",
+        limit=await DEMO_MESSAGES_PER_IP_HOUR(),
+    )
+
+    # Prefer the cap baked into the token (frozen at session-create); fall
+    # back to the live dynamic value only if the token has none, so an old
+    # token + new flag still gets a sensible cap.
+    cap = ctx.message_cap or await DEMO_MESSAGE_CAP_PER_SESSION()
+    used = await _assistant_turn_count(session_id)
+    if used >= cap:
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail=(
+                f"Demo session reached its {cap}-turn limit. "
+                "Start a new demo session to continue exploring."
+            ),
+        )
+
+    return await send_chat_message_handler(session_id, req, access_check=None)
+
+
+@router.post(
+    "/session/{session_id}/end",
+    response_model=EndChatSessionResponse,
+    summary="End a demo session (idempotent)",
+)
+async def demo_end_session(
+    session_id: str,
+    ctx: DemoSessionContext = Depends(require_demo_session),
+) -> EndChatSessionResponse:
+    """Mirror the authenticated end_session route, demo-token gated.
+
+    Reuses ``end_chat_session_handler`` so idempotency / lock semantics
+    / read-back of the actual ``ended_reason`` (in case the idle sweeper
+    raced) all behave identically.
+    """
+    session = await load_chat_session_or_404(session_id)
+    if session.status == ChatSessionStatus.ENDED:
+        return EndChatSessionResponse(
+            session_id=session_id,
+            status=ChatSessionStatus.ENDED,
+            ended_reason=session.ended_reason or ChatEndedReason.USER_ENDED,
+        )
+    return await end_chat_session_handler(session_id, session)
+
+
+__all__ = ["router"]

--- a/app/api/routers/breeze_buddy/chat/handlers.py
+++ b/app/api/routers/breeze_buddy/chat/handlers.py
@@ -1,0 +1,528 @@
+"""
+Business logic handlers for chat (text-mode) operations.
+
+All handlers perform DB operations and (for ``send_message``) own the
+per-session Redis lock + agent lifecycle. Routes in ``__init__.py``
+stay thin: validate auth, then delegate.
+"""
+
+from typing import Any, AsyncIterator, Callable, Dict, Optional
+
+from fastapi import HTTPException, status
+from fastapi.responses import StreamingResponse
+
+from app.ai.voice.agents.breeze_buddy.chat.agent import ChatAgent
+from app.ai.voice.agents.breeze_buddy.chat.sse import SSEEvent, format_sse
+from app.ai.voice.agents.breeze_buddy.llm import get_llm_service
+from app.ai.voice.agents.breeze_buddy.template.cache import get_template_by_id_cached
+from app.ai.voice.agents.breeze_buddy.template.transformation_function import (
+    TEMPLATE_FUNCTION_REGISTRY,
+)
+from app.ai.voice.agents.breeze_buddy.template.types import TemplateModel
+from app.core.config.dynamic import CHAT_HISTORY_REPLAY_LIMIT
+from app.core.logger import logger
+from app.database.accessor.breeze_buddy.chat_session import (
+    create_chat_session,
+    end_chat_session,
+    get_chat_session_by_id,
+    insert_chat_message,
+    list_chat_messages_for_session,
+)
+from app.database.accessor.breeze_buddy.credentials import (
+    get_credentials_as_template_vars,
+)
+from app.schemas import UserInfo
+from app.schemas.breeze_buddy.chat import (
+    ChatEndedReason,
+    ChatMessageRole,
+    ChatSession,
+    ChatSessionStatus,
+    ChatTranscriptResponse,
+    CreateChatSessionRequest,
+    CreateChatSessionResponse,
+    EndChatSessionResponse,
+    GetChatSessionResponse,
+    GreetingMessage,
+    SendChatMessageRequest,
+)
+from app.services.redis.locks import LockAcquireError, RedisLock
+
+# Per-session lock TTL. A single chat turn (LLM call + tool round-trips)
+# is well under this — if it isn't, the upstream LLM is hung and we
+# want the lock to expire so retries can recover. No mid-turn renewal.
+_SESSION_LOCK_TTL_SECONDS = 180
+
+
+def _lock_key(session_id: str) -> str:
+    """Redis key for the per-session distributed lock."""
+    return f"chat:session:{session_id}:lock"
+
+
+# ---------------------------------------------------------------------------
+# template_vars merging — chat parity with voice's loader.py
+# ---------------------------------------------------------------------------
+#
+# Voice's ``FlowConfigLoader.load_template`` (template/loader.py) merges
+# three sources into ``template_vars`` before rendering: reseller
+# credentials, ``template.secrets``, and payload values run through any
+# ``expected_payload_schema`` transformation functions. Chat used to
+# rehydrate only the persisted payload, which silently broke
+# ``{api_key}``-style placeholders in HTTP global functions. The two
+# helpers below restore parity:
+#
+# - ``_apply_payload_transformations`` runs once at session-create time:
+#   chat has a single fixed payload per session, so the transformations
+#   (e.g., timestamp formatters) are computed once and the transformed
+#   dict is the thing we persist into ``chat_session.metadata``.
+# - ``_build_render_template_vars`` runs per-turn: it overlays credentials
+#   (which can rotate) and template secrets (which may have changed since
+#   session-create) on top of the persisted payload values, so each turn
+#   sees the freshest values without re-doing the transformation work.
+
+
+def _apply_payload_transformations(
+    payload: Optional[Dict[str, Any]],
+    expected_schema: Optional[Dict[str, Any]],
+) -> Dict[str, Any]:
+    """Mirror voice's payload-vs-schema reconciliation, minus rendering."""
+    if not expected_schema:
+        return dict(payload or {})
+
+    out: Dict[str, Any] = {}
+    payload = payload or {}
+    for field_name, field_schema in expected_schema.items():
+        value: Any = payload.get(field_name, "")
+        if field_name not in payload:
+            logger.warning(
+                f"chat session create: schema field {field_name!r} missing from "
+                "template_vars; defaulting to empty string"
+            )
+        function_names: list[str] = []
+        if isinstance(field_schema, dict):
+            raw = field_schema.get("function")
+            if isinstance(raw, list):
+                function_names = [n for n in raw if isinstance(n, str)]
+            elif isinstance(raw, str):
+                function_names = [raw]
+        for fn_name in function_names:
+            fn = TEMPLATE_FUNCTION_REGISTRY.get(fn_name)
+            if fn is None:
+                logger.warning(
+                    f"chat session create: unknown transformation function "
+                    f"{fn_name!r} for field {field_name!r}; skipping"
+                )
+                continue
+            try:
+                value = fn() if value in (None, "") else fn(value)
+            except Exception as exc:
+                logger.warning(
+                    f"chat session create: transformation {fn_name!r} for "
+                    f"{field_name!r} raised: {exc}"
+                )
+        out[field_name] = value
+    return out
+
+
+async def _build_render_template_vars(
+    template: TemplateModel, persisted: Optional[Dict[str, Any]]
+) -> Dict[str, Any]:
+    """Build the per-turn render context. Same precedence as voice:
+    credentials < template.secrets < persisted payload values.
+    """
+    merged: Dict[str, Any] = {}
+    try:
+        creds = await get_credentials_as_template_vars(template.reseller_id)
+        if creds:
+            merged.update(creds)
+    except Exception as exc:
+        logger.warning(
+            f"chat: failed to load credentials for reseller "
+            f"{template.reseller_id}: {exc}"
+        )
+    if template.secrets:
+        merged.update(template.secrets)
+    if persisted:
+        merged.update(persisted)
+    return merged
+
+
+# ---------------------------------------------------------------------------
+# Shared validators
+# ---------------------------------------------------------------------------
+
+
+def validate_template_for_chat(template: TemplateModel) -> None:
+    """Reject templates that aren't opted in to chat (CHAT_MODE.md §8.5).
+
+    Used by the route layer before delegating to ``create_session_handler``
+    so a 400 doesn't reach DB.
+    """
+    supported = getattr(template, "supported_channels", None) or []
+    if "chat" not in supported:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=(
+                "Template does not include 'chat' in supported_channels. "
+                "Add 'chat' to the template's supported_channels to enable "
+                "chat sessions."
+            ),
+        )
+
+    llm_cfg = _resolve_llm_configuration(template)
+    if llm_cfg is not None and getattr(llm_cfg, "realtime", False):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Realtime / speech-to-speech LLMs are not supported in chat mode.",
+        )
+
+
+def _resolve_llm_configuration(template: TemplateModel):
+    """Pick out ``configurations.llm_configurations`` (the canonical path)
+    safely. Mirrors voice's access pattern (see ``agent/pipeline.py``)."""
+    configurations = getattr(template, "configurations", None)
+    if configurations is None:
+        return None
+    return getattr(configurations, "llm_configurations", None)
+
+
+def _render_initial_greeting(
+    template: TemplateModel, template_vars: dict
+) -> Optional[str]:
+    """Resolve ``template.configurations.initial_greeting`` with template_vars.
+
+    Returns the rendered string, or None if the template has no greeting
+    configured / the rendered text is blank. Substitution mirrors voice
+    (``managers/utils.py``): naive ``"{key}".replace`` per pair, so a
+    missing var leaves its placeholder in place rather than raising.
+    """
+    configurations = getattr(template, "configurations", None)
+    raw = getattr(configurations, "initial_greeting", None) if configurations else None
+    if not raw:
+        return None
+    rendered = raw
+    for key, value in (template_vars or {}).items():
+        if isinstance(value, (str, int, float, bool)):
+            rendered = rendered.replace(f"{{{key}}}", str(value))
+    rendered = rendered.strip()
+    return rendered or None
+
+
+async def load_chat_session_or_404(session_id: str) -> ChatSession:
+    """Load a session row or raise 404. Used by route-layer pre-checks."""
+    session = await get_chat_session_by_id(session_id)
+    if session is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Chat session '{session_id}' not found",
+        )
+    return session
+
+
+# ---------------------------------------------------------------------------
+# Handlers
+# ---------------------------------------------------------------------------
+
+
+async def create_chat_session_handler(
+    req: CreateChatSessionRequest,
+    template: TemplateModel,
+    current_user: UserInfo,
+) -> CreateChatSessionResponse:
+    """Insert chat session row; persist the rendered initial greeting if any.
+
+    The session is pure DB state at this point — no agent, no
+    pipeline. The first ``POST /message`` builds the agent on demand.
+    """
+    logger.info(
+        f"User {current_user.username} (role: {current_user.role}) creating chat "
+        f"session for template={req.template_id}"
+    )
+
+    # Run any ``expected_payload_schema`` transformations on the user's
+    # payload up front (voice does the equivalent on every call; chat has
+    # one payload per session so once is enough) — that way the persisted
+    # template_vars already match what voice would have produced.
+    transformed_template_vars = _apply_payload_transformations(
+        req.template_vars, template.expected_payload_schema
+    )
+    # Server-owned `template_vars` must win over any client-supplied
+    # metadata: a crafted `metadata={"template_vars": ...}` would otherwise
+    # corrupt prompt rendering for every subsequent turn on this session.
+    persisted_metadata = {
+        **(req.metadata or {}),
+        "template_vars": transformed_template_vars,
+    }
+    db_session = await create_chat_session(
+        template_id=req.template_id,
+        reseller_id=template.reseller_id,
+        merchant_id=getattr(template, "merchant_id", None),
+        metadata=persisted_metadata,
+    )
+    if db_session is None:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to create chat_session row",
+        )
+
+    # Reuse the voice template's initial_greeting field as the chat
+    # greeting (CHAT_MODE.md §8.4): one place to author "first thing the
+    # bot says", whether the template ships on voice, chat, or both.
+    # Skip the LLM round-trip on session create by persisting it as the
+    # first assistant message so it appears in the agent's history
+    # replay on the very first /message call. Render against the same
+    # merged context turns will see, so a greeting that references a
+    # credential / secret placeholder doesn't render with raw braces.
+    greeting_render_vars = await _build_render_template_vars(
+        template, transformed_template_vars
+    )
+    greeting_text = _render_initial_greeting(template, greeting_render_vars)
+    if greeting_text:
+        await insert_chat_message(
+            session_id=db_session.id,
+            role=ChatMessageRole.ASSISTANT,
+            content=greeting_text,
+        )
+
+    return CreateChatSessionResponse(
+        session_id=db_session.id,
+        status=db_session.status,
+        current_node=db_session.current_node,
+        greeting=GreetingMessage(content=greeting_text) if greeting_text else None,
+    )
+
+
+async def get_chat_session_handler(session: ChatSession) -> GetChatSessionResponse:
+    """Return the session row + full message history for resume."""
+    messages = await list_chat_messages_for_session(session.id)
+    return GetChatSessionResponse(
+        session_id=session.id,
+        status=session.status,
+        current_node=session.current_node,
+        messages=messages,
+        metadata=session.metadata,
+    )
+
+
+async def send_chat_message_handler(
+    session_id: str,
+    req: SendChatMessageRequest,
+    *,
+    access_check: Optional[Callable[[ChatSession], None]] = None,
+) -> StreamingResponse:
+    """Drive one turn; stream SSE events until ``turn_end``.
+
+    Multi-pod safe: the per-session Redis lock guarantees one driver
+    at a time. The lock is acquired before the SSE response opens so
+    contention surfaces as a clean ``409 Conflict``.
+
+    The agent is constructed fresh per call from DB state (session
+    row, template, capped message history). No sticky LB or in-memory
+    cache is involved.
+
+    Per-turn DB shape: 1 session read + 1 template read + 1 history
+    read (capped) + 2 message INSERTs + 1 combined session UPDATE.
+    All round-trips constant per turn — none scale with conversation
+    length.
+
+    Auth shape: the route layer is the only thing that knows what kind
+    of credential authenticated this call (admin RBAC token vs. demo
+    token, see ``demo.py``). It builds an ``access_check`` closure that
+    runs *under the lock* against the freshly-read session row. Pass
+    ``None`` to skip — useful for demo paths where the bearer token is
+    already bound to a specific ``session_id`` and there's nothing
+    further to authorise.
+    """
+    lock = RedisLock(_lock_key(session_id), ttl_seconds=_SESSION_LOCK_TTL_SECONDS)
+    try:
+        await lock.acquire()
+    except LockAcquireError:
+        # Fail-fast (CHAT_MODE.md D12): no server-side blocking acquire.
+        # Clients that want serial turns chain on the previous response.
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=(
+                "Another turn is already in flight for this session. "
+                "Wait for the previous /message stream to complete and retry."
+            ),
+        )
+
+    # Lock is held from here. The SSE generator's own ``finally`` releases
+    # it once streaming starts; until ``StreamingResponse`` is constructed
+    # successfully, this outer ``finally`` is the safety net so any
+    # exception during prep — HTTPException, DB blip, anything — releases
+    # rather than leaking the lock until the 180s TTL.
+    lock_handed_off = False
+    try:
+        fresh = await get_chat_session_by_id(session_id)
+        if fresh is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Chat session '{session_id}' not found",
+            )
+        if access_check is not None:
+            access_check(fresh)
+        if fresh.status == ChatSessionStatus.ENDED:
+            raise HTTPException(
+                status_code=status.HTTP_410_GONE,
+                detail=f"Chat session '{session_id}' has ended",
+            )
+
+        template = await get_template_by_id_cached(fresh.template_id)
+        if template is None:
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail=(
+                    f"Template '{fresh.template_id}' for chat session "
+                    f"'{session_id}' no longer exists"
+                ),
+            )
+
+        history_limit = await CHAT_HISTORY_REPLAY_LIMIT()
+        history_rows = await list_chat_messages_for_session(
+            session_id, limit=history_limit
+        )
+        history: list = [
+            {"role": row.role.value, "content": row.content}
+            for row in history_rows
+            if row.role in (ChatMessageRole.USER, ChatMessageRole.ASSISTANT)
+            and row.content
+        ]
+
+        persisted_template_vars = (
+            fresh.metadata.get("template_vars", {})
+            if isinstance(fresh.metadata, dict)
+            else {}
+        )
+        # Voice's loader merges credentials + template.secrets + payload
+        # values on every call (template/loader.py:125-183). Chat now does
+        # the same per-turn so HTTP/global function ``{placeholder}``
+        # resolution and prompt rendering see credentials/secrets the
+        # same way they would on voice. Doing it per-turn (not at session-
+        # create) keeps rotated credentials and updated secrets effective
+        # without resuming the session.
+        template_vars = await _build_render_template_vars(
+            template, persisted_template_vars
+        )
+
+        # Chat-only opt-in to the shared LLM client (Azure HTTP/2 pool,
+        # Claude-on-Vertex client + token cache). Voice uses fresh per-call
+        # services — subprocess-per-call gets nothing from sharing.
+        llm = await get_llm_service(_resolve_llm_configuration(template), pooled=True)
+        agent = ChatAgent(
+            session_id=session_id,
+            template=template,
+            llm=llm,
+            template_vars=template_vars,
+        )
+        # Snapshot into a local so the closure below doesn't have to rely
+        # on Optional narrowing surviving the boundary.
+        resume_node = fresh.current_node
+
+        async def stream() -> AsyncIterator[str]:
+            try:
+                async for event in agent.run_turn(
+                    user_content=req.content,
+                    history=history,
+                    current_node=resume_node,
+                ):
+                    yield format_sse(event)
+            except Exception as exc:
+                # Full exception (incl. SDK / DB internals) goes to logs; the
+                # SSE payload is intentionally generic — provider stack traces,
+                # internal URLs, and SQL strings should not reach the client.
+                logger.error(
+                    f"send_message stream for session {session_id} crashed: {exc}",
+                    exc_info=True,
+                )
+                yield format_sse(
+                    SSEEvent(
+                        event="error",
+                        data={
+                            "code": "internal",
+                            "message": "Internal server error",
+                        },
+                    )
+                )
+                yield format_sse(
+                    SSEEvent(event="turn_end", data={"session_status": "FAILED"})
+                )
+            finally:
+                await lock.release()
+
+        response = StreamingResponse(
+            stream(),
+            media_type="text/event-stream",
+            headers={
+                "Cache-Control": "no-cache, no-transform",
+                "X-Accel-Buffering": "no",
+                "Connection": "keep-alive",
+            },
+        )
+        lock_handed_off = True
+        return response
+    finally:
+        if not lock_handed_off:
+            await lock.release()
+
+
+async def end_chat_session_handler(
+    session_id: str, session: ChatSession
+) -> EndChatSessionResponse:
+    """Mark the session ENDED. Idempotent under concurrent calls.
+
+    The pre-loaded ``session`` was fetched (and access-checked) by the
+    route. We re-acquire the lock here only to serialise against an
+    in-flight ``send_message`` on the same session.
+    """
+    if session.status == ChatSessionStatus.ENDED:
+        return EndChatSessionResponse(
+            session_id=session_id,
+            status=ChatSessionStatus.ENDED,
+            ended_reason=session.ended_reason or ChatEndedReason.USER_ENDED,
+        )
+
+    lock = RedisLock(_lock_key(session_id), ttl_seconds=_SESSION_LOCK_TTL_SECONDS)
+    try:
+        await lock.acquire()
+    except LockAcquireError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=str(exc),
+        ) from exc
+
+    try:
+        ended_row = await end_chat_session(
+            session_id=session_id, ended_reason=ChatEndedReason.USER_ENDED
+        )
+    finally:
+        await lock.release()
+
+    # ``end_chat_session`` returns ``None`` when the row was already ENDED
+    # by some other actor (e.g., the idle sweeper raced this call between
+    # the route's pre-load and our lock acquisition). Read back the row so
+    # the response reports the *actual* ended_reason instead of pretending
+    # the user ended a session that was, in fact, idle-timed-out.
+    if ended_row is None:
+        ended_row = await get_chat_session_by_id(session_id)
+
+    return EndChatSessionResponse(
+        session_id=session_id,
+        status=ChatSessionStatus.ENDED,
+        ended_reason=(
+            (ended_row.ended_reason if ended_row else None)
+            or ChatEndedReason.USER_ENDED
+        ),
+    )
+
+
+async def get_chat_transcript_handler(
+    session: ChatSession,
+) -> ChatTranscriptResponse:
+    """Plain JSON transcript export. Useful for audit / handoff."""
+    messages = await list_chat_messages_for_session(session.id)
+    return ChatTranscriptResponse(
+        session_id=session.id,
+        template_id=session.template_id,
+        status=session.status,
+        messages=messages,
+    )

--- a/app/api/routers/breeze_buddy/chat/rbac.py
+++ b/app/api/routers/breeze_buddy/chat/rbac.py
@@ -1,0 +1,118 @@
+"""
+RBAC (Role-Based Access Control) utilities for chat sessions.
+Handles reseller + merchant access control based on JWT token.
+
+Mirrors the leads RBAC split: ``validate_chat_create_access`` returns
+403 for the create path (caller already knows the reseller/template
+scope), while ``validate_chat_session_access`` returns 404 for
+operations on an existing session id (don't leak existence).
+"""
+
+from typing import Optional
+
+from fastapi import HTTPException, status
+
+from app.core.logger import logger
+from app.schemas import UserInfo
+from app.schemas.breeze_buddy.chat import ChatSession
+
+
+def validate_chat_create_access(
+    current_user: UserInfo,
+    reseller_id: str,
+    merchant_id: Optional[str],
+    operation: str = "create chat session",
+) -> None:
+    """
+    Validate user has access to create a chat session for the given
+    reseller and merchant. Used by ``POST /chat/session`` where the
+    caller has explicitly named the template (and therefore the
+    reseller/merchant scope), so leaking the scope is fine.
+
+    Args:
+        current_user: Current authenticated user with RBAC info
+        reseller_id: Reseller ID to validate access for
+        merchant_id: Merchant identifier to validate access for (optional)
+        operation: Operation being performed (for logging)
+
+    Raises:
+        HTTPException: 403 if user lacks permission
+    """
+    if current_user.role == "admin":
+        return
+
+    if (
+        reseller_id not in current_user.reseller_ids
+        and "*" not in current_user.reseller_ids
+    ):
+        logger.warning(
+            f"User {current_user.username} attempted to {operation} "
+            f"for unauthorized reseller: {reseller_id}"
+        )
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=f"Access denied to reseller {reseller_id}",
+        )
+
+    if merchant_id:
+        if (
+            merchant_id not in current_user.merchant_ids
+            and "*" not in current_user.merchant_ids
+        ):
+            logger.warning(
+                f"User {current_user.username} attempted to {operation} "
+                f"for unauthorized merchant: {merchant_id}"
+            )
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail=f"Access denied to merchant {merchant_id}",
+            )
+
+
+def validate_chat_session_access(
+    current_user: UserInfo,
+    session: ChatSession,
+    operation: str = "access",
+) -> None:
+    """
+    Validate user has access to read or operate on a specific chat
+    session. Returns 404 (not 403) so unauthorized callers cannot
+    discover whether a session exists by probing.
+
+    Args:
+        current_user: Current authenticated user
+        session: ChatSession row to validate access against
+        operation: Operation being performed (for logging)
+
+    Raises:
+        HTTPException: 404 if user lacks permission
+    """
+    if current_user.role == "admin":
+        return
+
+    if (
+        session.reseller_id not in current_user.reseller_ids
+        and "*" not in current_user.reseller_ids
+    ):
+        logger.warning(
+            f"User {current_user.username} attempted to {operation} "
+            f"chat session {session.id} for unauthorized reseller: "
+            f"{session.reseller_id}"
+        )
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Chat session not found"
+        )
+
+    if session.merchant_id:
+        if (
+            session.merchant_id not in current_user.merchant_ids
+            and "*" not in current_user.merchant_ids
+        ):
+            logger.warning(
+                f"User {current_user.username} attempted to {operation} "
+                f"chat session {session.id} for unauthorized merchant: "
+                f"{session.merchant_id}"
+            )
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND, detail="Chat session not found"
+            )

--- a/app/api/routers/breeze_buddy/templates/handlers.py
+++ b/app/api/routers/breeze_buddy/templates/handlers.py
@@ -4,11 +4,12 @@ All handlers perform database operations and enforce business rules.
 """
 
 from datetime import datetime, timezone
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 from uuid import uuid4
 
 from fastapi import HTTPException, status
 
+from app.ai.voice.agents.breeze_buddy.template.cache import invalidate_template
 from app.ai.voice.agents.breeze_buddy.template.types import (
     CreateTemplateRequest,
     ReplaceTemplateRequest,
@@ -116,6 +117,7 @@ async def create_template_handler(
             secrets=template_data.secrets,
             outbound_number_id=template_data.outbound_number_id,
             is_active=template_data.is_active,
+            supported_channels=list(template_data.supported_channels),
             now=now,
         )
 
@@ -391,6 +393,19 @@ async def replace_template_handler(
             incoming_secrets=template_data.secrets,
             existing_secrets=existing_template.secrets,
         )
+        # Preserve persisted ``supported_channels`` when the client doesn't
+        # explicitly send the field — older PUT clients don't know about it,
+        # and a default-driven overwrite would silently revert chat-enabled
+        # templates to voice-only on unrelated edits.
+        supported_channels: List[str] = [
+            str(ch)
+            for ch in (
+                template_data.supported_channels
+                if template_data.supported_channels is not None
+                else existing_template.supported_channels
+            )
+        ]
+
         updated_template = await replace_template(
             template_id=template_id,
             name=template_data.name,
@@ -402,6 +417,7 @@ async def replace_template_handler(
             outbound_number_id=template_data.outbound_number_id,
             is_active=template_data.is_active,
             merchant_id=template_data.merchant_id,
+            supported_channels=supported_channels,
             now=now,
         )
 
@@ -409,6 +425,17 @@ async def replace_template_handler(
             raise HTTPException(
                 status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
                 detail="Failed to update template",
+            )
+
+        # Cache invalidation is best-effort: the DB write has already
+        # committed, so a Redis blip here must not surface as a 500 to a
+        # client whose mutation actually succeeded. Stale cache entries
+        # self-correct on TTL expiry.
+        try:
+            await invalidate_template(template_id)
+        except Exception as cache_exc:
+            logger.warning(
+                f"Template cache invalidation failed for {template_id}: {cache_exc}"
             )
 
         logger.info(
@@ -493,6 +520,13 @@ async def delete_template_handler(
             raise HTTPException(
                 status_code=status.HTTP_409_CONFLICT,
                 detail=detail,
+            )
+
+        try:
+            await invalidate_template(template_id)
+        except Exception as cache_exc:
+            logger.warning(
+                f"Template cache invalidation failed for {template_id}: {cache_exc}"
             )
 
         logger.info(

--- a/app/api/security/breeze_buddy/demo_token.py
+++ b/app/api/security/breeze_buddy/demo_token.py
@@ -1,0 +1,148 @@
+"""Demo-session JWT — mint + verify for the public chat demo.
+
+Why a separate token type instead of reusing the standard RBAC JWT:
+
+- The public demo endpoints have **no upstream user**. Visitors hit
+  ``POST /chat/demo/session`` (slug in the JSON body) anonymously and
+  need a credential for the subsequent ``/message`` SSE call.
+- Reusing the RBAC JWT would mean handing out a token with non-empty
+  ``reseller_ids`` / ``merchant_ids`` to anonymous visitors, which would
+  authenticate them on *every* breeze_buddy endpoint that accepts those
+  scopes. That's a wide blast radius for a token we mint freely.
+
+The demo token therefore:
+
+1. Carries a ``demo: true`` claim — the standard RBAC verifier
+   (``rbac_token.py``) doesn't read this, so a demo token will never
+   pass standard auth. The demo dependency below is the only verifier
+   that will accept it.
+2. Pins ``demo_session_id`` to the chat session created at mint time.
+   The dependency rejects any path-param ``session_id`` that doesn't
+   match — so a leaked token can't be steered to other sessions.
+3. Carries the per-session ``demo_message_cap`` so the message handler
+   enforces it without an extra DB read.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import timedelta
+from typing import Annotated, Any, Dict
+
+import jwt as pyjwt
+from fastapi import Depends, HTTPException, Path, status
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+
+from app.core.config.dynamic import DEMO_TOKEN_TTL_MINUTES
+from app.core.logger import logger
+from app.core.security.jwt import jwt_manager
+
+# Reuse the existing HTTPBearer scheme so OpenAPI sees one consistent
+# auth header across the API. ``auto_error=True`` returns 403 when the
+# header is missing — same behaviour as the RBAC dependency.
+_demo_bearer = HTTPBearer(auto_error=True, scheme_name="DemoBearer")
+
+
+class DemoSessionContext:
+    """Resolved demo-token claims, returned by :func:`require_demo_session`.
+
+    Mirrors the read-only shape of ``UserInfo`` callers expect from the
+    standard RBAC dep — but the demo handler treats it specifically, so
+    no abstract base is needed.
+    """
+
+    __slots__ = ("session_id", "message_cap", "subject")
+
+    def __init__(self, *, session_id: str, message_cap: int, subject: str) -> None:
+        self.session_id = session_id
+        self.message_cap = message_cap
+        self.subject = subject
+
+
+async def mint_demo_token(*, session_id: str, message_cap: int) -> str:
+    """Issue a demo JWT bound to ``session_id`` for ``DEMO_TOKEN_TTL_MINUTES``.
+
+    ``sub`` is a fresh anonymous identifier (``demo-<short-uuid>``) — useful
+    in logs but never used for authorization. The actual gate is the
+    ``demo_session_id`` claim verified below. Async because the TTL is a
+    Redis/DevCycle-backed dynamic knob.
+    """
+    ttl_minutes = await DEMO_TOKEN_TTL_MINUTES()
+    subject = f"demo-{uuid.uuid4().hex[:12]}"
+    payload: Dict[str, Any] = {
+        "sub": subject,
+        "demo": True,
+        "demo_session_id": session_id,
+        "demo_message_cap": int(message_cap),
+    }
+    return jwt_manager.create_access_token(
+        payload, expires_delta=timedelta(minutes=ttl_minutes)
+    )
+
+
+def _decode_or_401(token: str) -> Dict[str, Any]:
+    """Verify the JWT signature + standard claims, or raise 401."""
+    try:
+        return pyjwt.decode(
+            token,
+            jwt_manager.secret_key,
+            algorithms=[jwt_manager.algorithm],
+        )
+    except pyjwt.ExpiredSignatureError:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Demo session token expired",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+    except pyjwt.InvalidTokenError as exc:
+        logger.warning(f"demo_token: invalid token: {exc}")
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid demo session token",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+
+def require_demo_session(
+    session_id: Annotated[str, Path(...)],
+    creds: Annotated[HTTPAuthorizationCredentials, Depends(_demo_bearer)],
+) -> DemoSessionContext:
+    """FastAPI dependency for ``/chat/demo/session/{session_id}/...`` routes.
+
+    Verifies the bearer token is a *demo* token (``demo: true``) and that
+    its bound ``demo_session_id`` matches the URL path. Either check
+    failing yields 401 — same status as the standard RBAC dep so clients
+    don't have to special-case demo-vs-real failures.
+    """
+    payload = _decode_or_401(creds.credentials)
+    if not payload.get("demo"):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Token is not a demo token",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    claim_session = payload.get("demo_session_id")
+    if not isinstance(claim_session, str) or claim_session != session_id:
+        # Don't reveal which session the token *was* for — that's a
+        # potential reconnaissance signal in a public endpoint.
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Demo token does not match this session",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    raw_cap = payload.get("demo_message_cap")
+    try:
+        message_cap = int(raw_cap) if raw_cap is not None else 0
+    except (TypeError, ValueError):
+        message_cap = 0
+
+    return DemoSessionContext(
+        session_id=session_id,
+        message_cap=message_cap,
+        subject=str(payload.get("sub", "")),
+    )
+
+
+__all__ = ["DemoSessionContext", "mint_demo_token", "require_demo_session"]

--- a/app/core/config/dynamic.py
+++ b/app/core/config/dynamic.py
@@ -61,6 +61,104 @@ async def ENABLE_CHAT_MODE_PROMPT() -> bool:
     return await get_config("ENABLE_CHAT_MODE_PROMPT", True, bool)
 
 
+# ============================================================================
+# Chat (text-mode) idle session timeout. Read by the cleanup task in
+# app/ai/voice/agents/breeze_buddy/chat/cleanup.py on every sweep so a
+# DevCycle change propagates without a pod restart. The sweep cadence
+# itself lives in static config (CHAT_SESSION_END_TIMEOUT_LOOP_INTERVAL_SECONDS
+# in app/core/config/static.py) because the BackgroundTaskScheduler binds it
+# once at startup.
+# See docs/CHAT_MODE.md §7.3.
+# ============================================================================
+async def CHAT_SESSION_END_TIMEOUT_SECONDS() -> int:
+    """Mark an ACTIVE/IDLE chat session ENDED once it has been inactive
+    for this many seconds. The safety net that prevents zombie sessions
+    from accumulating forever. Default 60 minutes."""
+    return await get_config("CHAT_SESSION_END_TIMEOUT_SECONDS", 3600, int)
+
+
+async def CHAT_HISTORY_REPLAY_LIMIT() -> int:
+    """Cap on prior chat_message rows replayed into LLMContext per turn.
+
+    The only per-turn read whose cost grows with conversation length;
+    capping keeps DB read + LLM input-token cost flat for long
+    sessions (and the LLM context window is bounded anyway). Default
+    100 (≈50 user/assistant exchanges) — well above typical chat
+    session length, so in practice the cap only kicks in for
+    pathologically long sessions.
+
+    Tuning trade-offs:
+    - **Too low** (≤ ~10): the LLM "forgets" earlier context within
+      a single session. Concrete failures — user states their name /
+      account / preference early, asks about it 12 turns later, bot
+      can't recall it; bot re-asks a question already answered;
+      multi-step intents ("do X, then Y, then Z") lose the original
+      intent once truncated; FlowManager node assumes context the
+      LLM no longer sees, producing contradictions; previously-
+      called function results drop out of context, so the LLM
+      either re-calls (cost) or hallucinates.
+    - **Too high** (≥ ~500): DB read returns a large rowset every
+      turn; LLM input-token cost rises proportionally; TTFT latency
+      grows with prompt length; risk of bumping the model's context
+      window for very long sessions."""
+    return await get_config("CHAT_HISTORY_REPLAY_LIMIT", 100, int)
+
+
+# ============================================================================
+# Public chat-demo tuning knobs (CHAT_MODE.md §13).
+#
+# All four are operational dials we may want to turn during incident
+# response or after observing real demo traffic, *without* a deploy.
+# Reads are async because they hit Redis/DevCycle — cheap, but call
+# sites must ``await``. Each value is captured at the moment it's needed:
+#
+# - ``DEMO_MESSAGE_CAP_PER_SESSION`` is read at session-create and
+#   baked into the demo JWT, so changes apply to *future* sessions only.
+# - ``DEMO_TOKEN_TTL_MINUTES`` is read at mint time, same forward-only
+#   semantics.
+# - The two rate limits are read on every request, so they take effect
+#   immediately on the next request.
+# ============================================================================
+
+
+async def DEMO_MESSAGE_CAP_PER_SESSION() -> int:
+    """Hard ceiling on assistant turns per public demo session.
+
+    Persisted into the demo JWT on session-create — the per-turn handler
+    reads it from the token, not from Redis again, so changing this only
+    affects sessions created *after* the tweak. Default 20.
+    """
+    return await get_config("DEMO_MESSAGE_CAP_PER_SESSION", 20, int)
+
+
+async def DEMO_SESSIONS_PER_IP_HOUR() -> int:
+    """Per-IP cap on demo session creates inside a 1-hour fixed window.
+    Read on every ``POST /chat/demo/session`` so a tweak takes effect on
+    the next request.
+
+    Default 100 (intentionally loose). Real LLM spend is bounded by the
+    *per-session* turn cap and the per-IP message rate — session creates
+    are cheap (one DB insert + one greeting LLM call at most). Keeping
+    this number in three digits avoids false positives when several
+    visitors share a NAT'd IP (corporate networks, mobile carriers,
+    classrooms doing a live demo)."""
+    return await get_config("DEMO_SESSIONS_PER_IP_HOUR", 100, int)
+
+
+async def DEMO_MESSAGES_PER_IP_HOUR() -> int:
+    """Per-IP cap on demo messages inside a 1-hour fixed window. Same
+    semantics as ``DEMO_SESSIONS_PER_IP_HOUR``. Default 600."""
+    return await get_config("DEMO_MESSAGES_PER_IP_HOUR", 600, int)
+
+
+async def DEMO_TOKEN_TTL_MINUTES() -> int:
+    """Demo bearer-token lifetime, in minutes. Long enough for a typical
+    demo conversation (cap + a few minutes of think time per turn) and
+    short enough that a leaked token isn't a long-running attack vector.
+    Read at mint time only. Default 30."""
+    return await get_config("DEMO_TOKEN_TTL_MINUTES", 30, int)
+
+
 # --- Sarvam Configuration ---
 async def SARVAM_STT_MODEL() -> str:
     """Returns SARVAM_STT_MODEL from Redis"""

--- a/app/core/config/static.py
+++ b/app/core/config/static.py
@@ -258,6 +258,52 @@ AZURE_BREEZE_BUDDY_OPENAI_MODEL = os.environ.get(
     "AZURE_BREEZE_BUDDY_OPENAI_MODEL", "gpt-4o-automatic"
 )
 
+# Chat (text-mode) idle-cleanup sweep cadence. Bound once at startup by
+# BackgroundTaskScheduler.register_task — a change requires a pod restart.
+# The threshold itself (CHAT_SESSION_END_TIMEOUT_SECONDS, in dynamic.py)
+# stays live-tunable. Default 5 minutes.
+CHAT_SESSION_END_TIMEOUT_LOOP_INTERVAL_SECONDS = int(
+    os.environ.get("CHAT_SESSION_END_TIMEOUT_LOOP_INTERVAL_SECONDS", 300)
+)
+
+
+# ---------------------------------------------------------------------------
+# Public chat demo (CHAT_MODE.md §13) — structural config
+# ---------------------------------------------------------------------------
+#
+# DEMO_TEMPLATES is a comma-separated ``slug:template_id`` list, parsed
+# once at import. Visitors pass the slug in the JSON body of
+# ``POST /chat/demo/session``; the demo router resolves it to the
+# template_id below. Adding a new demo = env var change + pod restart;
+# no DB migration. Anything not listed here is invisible to the demo
+# router, so an accidentally chat-enabled production template can't
+# leak through.
+#
+# This stays static (rather than living in dynamic.py) because the value
+# is structured (parsed dict) and adding/removing demos is operationally
+# infrequent. The *tuning* knobs (caps, rate limits, token TTL) live in
+# dynamic.py and can be dialed without a restart.
+def _parse_demo_templates(raw: str) -> dict[str, str]:
+    out: dict[str, str] = {}
+    for entry in (raw or "").split(","):
+        entry = entry.strip()
+        if not entry:
+            continue
+        if ":" not in entry:
+            continue
+        slug, template_id = entry.split(":", 1)
+        slug = slug.strip()
+        template_id = template_id.strip()
+        if slug and template_id:
+            out[slug] = template_id
+    return out
+
+
+DEMO_TEMPLATES: dict[str, str] = _parse_demo_templates(
+    os.environ.get("DEMO_TEMPLATES", "")
+)
+
+
 # Twilio settings
 TWILIO_ACCOUNT_SID = os.getenv("TWILIO_ACCOUNT_SID", "")
 TWILIO_AUTH_TOKEN = os.getenv("TWILIO_AUTH_TOKEN", "")

--- a/app/core/logger/__init__.py
+++ b/app/core/logger/__init__.py
@@ -242,6 +242,12 @@ def setup_logging_interception():
     logging.getLogger("websockets").disabled = True
     logging.getLogger("daily_core").disabled = True
 
+    # HTTP transport / SDK chatter — at DEBUG these dump every HPACK header
+    # table entry, every chunk, the full LLM request body, etc. Useful when
+    # debugging the connection layer; pure noise in normal operation.
+    for noisy in ("h2", "hpack", "hyperframe", "httpcore", "httpx", "openai"):
+        logging.getLogger(noisy).setLevel(logging.WARNING)
+
 
 # Initial logger configuration
 _setup_logger_sinks(include_session_id=False)

--- a/app/database/accessor/breeze_buddy/chat_session.py
+++ b/app/database/accessor/breeze_buddy/chat_session.py
@@ -1,0 +1,191 @@
+"""Async accessors for chat_session and chat_message.
+
+Calls into queries/breeze_buddy/chat_session.py for SQL and
+decoder/breeze_buddy/chat_session.py for row → Pydantic.
+JSON serialization for JSONB columns happens here.
+"""
+
+import json
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+
+from app.core.logger import logger
+from app.database.decoder.breeze_buddy.chat_session import (
+    decode_chat_message,
+    decode_chat_session,
+)
+from app.database.queries import run_parameterized_query
+from app.database.queries.breeze_buddy.chat_session import (
+    create_chat_session_query,
+    end_chat_session_query,
+    get_chat_session_by_id_query,
+    insert_chat_message_query,
+    list_chat_messages_for_session_query,
+    list_idle_chat_sessions_query,
+    update_chat_session_after_turn_query,
+)
+from app.schemas.breeze_buddy.chat import (
+    ChatMessage,
+    ChatMessageRole,
+    ChatSession,
+    ChatSessionStatus,
+)
+
+# -- chat_session -------------------------------------------------------------
+
+
+async def create_chat_session(
+    template_id: str,
+    reseller_id: str,
+    merchant_id: Optional[str] = None,
+    metadata: Optional[Dict[str, Any]] = None,
+) -> Optional[ChatSession]:
+    """Insert a new ACTIVE chat session and return the full row."""
+    query, values = create_chat_session_query(
+        template_id=template_id,
+        reseller_id=reseller_id,
+        merchant_id=merchant_id,
+        metadata_json=json.dumps(metadata or {}),
+    )
+    try:
+        result = await run_parameterized_query(query, values)
+        row = result[0] if result else None
+        if row:
+            session = decode_chat_session(row)
+            if session:
+                logger.info(
+                    f"Created chat session {session.id} "
+                    f"(template={template_id}, reseller={reseller_id})"
+                )
+            return session
+        return None
+    except Exception as e:
+        logger.error(f"Error creating chat session for template {template_id}: {e}")
+        raise
+
+
+async def get_chat_session_by_id(session_id: str) -> Optional[ChatSession]:
+    query, values = get_chat_session_by_id_query(session_id)
+    try:
+        result = await run_parameterized_query(query, values)
+        row = result[0] if result else None
+        return decode_chat_session(row) if row else None
+    except Exception as e:
+        logger.error(f"Error fetching chat session {session_id}: {e}")
+        raise
+
+
+async def update_chat_session_after_turn(
+    session_id: str,
+    current_node: Optional[str] = None,
+) -> None:
+    """Single post-turn UPDATE: bump activity + (optionally) set current_node.
+
+    Pass ``current_node=None`` for turns that didn't transition or for
+    direct-mode templates — the column is preserved via COALESCE.
+    """
+    query, values = update_chat_session_after_turn_query(session_id, current_node)
+    try:
+        await run_parameterized_query(query, values)
+    except Exception as e:
+        logger.error(f"Error updating chat session {session_id} after turn: {e}")
+        raise
+
+
+async def end_chat_session(
+    session_id: str,
+    ended_reason: str,
+    outcome: Optional[str] = None,
+) -> Optional[ChatSession]:
+    """Idempotent end. Returns the updated row, or None if already ENDED."""
+    query, values = end_chat_session_query(
+        session_id=session_id,
+        outcome=outcome,
+        ended_reason=ended_reason,
+    )
+    try:
+        result = await run_parameterized_query(query, values)
+        row = result[0] if result else None
+        if row:
+            session = decode_chat_session(row)
+            if session:
+                logger.info(f"Ended chat session {session_id} (reason={ended_reason})")
+            return session
+        return None
+    except Exception as e:
+        logger.error(f"Error ending chat session {session_id}: {e}")
+        raise
+
+
+async def list_idle_chat_sessions(
+    cutoff: datetime,
+    statuses: List[ChatSessionStatus],
+    limit: int = 100,
+) -> List[ChatSession]:
+    """Find sessions whose last_activity_at < cutoff and status ∈ statuses."""
+    query, values = list_idle_chat_sessions_query(
+        cutoff=cutoff,
+        statuses=[s.value for s in statuses],
+        limit=limit,
+    )
+    try:
+        rows = await run_parameterized_query(query, values)
+        sessions: List[ChatSession] = []
+        for row in rows or []:
+            decoded = decode_chat_session(row)
+            if decoded:
+                sessions.append(decoded)
+        return sessions
+    except Exception as e:
+        logger.error(f"Error listing idle chat sessions: {e}")
+        raise
+
+
+# -- chat_message -------------------------------------------------------------
+
+
+async def insert_chat_message(
+    session_id: str,
+    role: ChatMessageRole,
+    content: Optional[str] = None,
+) -> Optional[ChatMessage]:
+    """Append one message; idx is auto-allocated atomically by the query."""
+    query, values = insert_chat_message_query(
+        session_id=session_id,
+        role=role.value,
+        content=content,
+    )
+    try:
+        result = await run_parameterized_query(query, values)
+        row = result[0] if result else None
+        return decode_chat_message(row) if row else None
+    except Exception as e:
+        logger.error(
+            f"Error inserting chat message into session {session_id} "
+            f"(role={role.value}): {e}"
+        )
+        raise
+
+
+async def list_chat_messages_for_session(
+    session_id: str, limit: Optional[int] = None
+) -> List[ChatMessage]:
+    """Return chat messages for a session, oldest-first.
+
+    ``limit=None`` returns the full log (transcript / resume use). Pass
+    a positive int to cap to the N most recent messages — used by the
+    per-turn LLM-context replay so reads don't grow with conversation
+    length.
+    """
+    query, values = list_chat_messages_for_session_query(session_id, limit=limit)
+    try:
+        rows = await run_parameterized_query(query, values)
+        messages: List[ChatMessage] = []
+        for row in rows or []:
+            decoded = decode_chat_message(row)
+            if decoded:
+                messages.append(decoded)
+        return messages
+    except Exception as e:
+        logger.error(f"Error listing chat messages for session {session_id}: {e}")
+        raise

--- a/app/database/accessor/breeze_buddy/template.py
+++ b/app/database/accessor/breeze_buddy/template.py
@@ -102,6 +102,7 @@ async def create_template(
     secrets: Optional[dict] = None,
     outbound_number_id: Optional[str] = None,
     is_active: bool = True,
+    supported_channels: Optional[List[str]] = None,
 ) -> Optional[TemplateModel]:
     """Create a new template with flow stored as JSON."""
     logger.info(f"Creating template with ID: {template_id}")
@@ -140,6 +141,7 @@ async def create_template(
             secrets_json,
             outbound_number_id,  # Moved: now matches SQL column order
             is_active,
+            supported_channels or ["voice"],
             now,
             now,
         )
@@ -355,6 +357,7 @@ async def replace_template(
     is_active: bool,
     merchant_id: Optional[str],
     now,
+    supported_channels: Optional[List[str]] = None,
 ) -> Optional[TemplateModel]:
     """
     Update an existing template.
@@ -410,6 +413,7 @@ async def replace_template(
             outbound_number_id,
             is_active,
             merchant_id,
+            supported_channels or ["voice"],
             now,
         )
 

--- a/app/database/decoder/breeze_buddy/chat_session.py
+++ b/app/database/decoder/breeze_buddy/chat_session.py
@@ -1,0 +1,49 @@
+"""Decoders for chat_session and chat_message rows."""
+
+from typing import Optional
+
+import asyncpg
+
+from app.schemas.breeze_buddy.chat import (
+    ChatEndedReason,
+    ChatMessage,
+    ChatMessageRole,
+    ChatSession,
+    ChatSessionStatus,
+)
+from app.utils.common import parse_json
+
+
+def decode_chat_session(row: asyncpg.Record) -> Optional[ChatSession]:
+    """Build a ChatSession from a DB row, or None if row is empty."""
+    if not row:
+        return None
+    metadata = parse_json(row, "metadata") or {}
+    ended_reason_raw = row.get("ended_reason")
+    return ChatSession(
+        id=str(row["id"]),
+        template_id=str(row["template_id"]),
+        reseller_id=row["reseller_id"],
+        merchant_id=row.get("merchant_id"),
+        status=ChatSessionStatus(row["status"]),
+        outcome=row.get("outcome"),
+        current_node=row.get("current_node"),
+        metadata=metadata,
+        created_at=row["created_at"],
+        last_activity_at=row["last_activity_at"],
+        ended_at=row.get("ended_at"),
+        ended_reason=(ChatEndedReason(ended_reason_raw) if ended_reason_raw else None),
+    )
+
+
+def decode_chat_message(row: asyncpg.Record) -> Optional[ChatMessage]:
+    """Build a ChatMessage from a DB row, or None if row is empty."""
+    if not row:
+        return None
+    return ChatMessage(
+        session_id=str(row["session_id"]),
+        idx=row["idx"],
+        role=ChatMessageRole(row["role"]),
+        content=row.get("content"),
+        created_at=row["created_at"],
+    )

--- a/app/database/decoder/breeze_buddy/template.py
+++ b/app/database/decoder/breeze_buddy/template.py
@@ -185,6 +185,11 @@ def decode_template(result: asyncpg.Record) -> Optional[TemplateModel]:
             secrets_data = json.loads(secrets_data)
         # If it's already a dict (from JSONB), use it directly
 
+    # supported_channels is a Postgres text[] (NOT NULL DEFAULT {'voice'}).
+    # Some legacy SELECTs may not include the column — fall back to ['voice']
+    # so the model always has at least one channel.
+    supported_channels = result.get("supported_channels") or ["voice"]
+
     return TemplateModel(
         id=str(result["id"]),
         reseller_id=result["reseller_id"],
@@ -201,6 +206,7 @@ def decode_template(result: asyncpg.Record) -> Optional[TemplateModel]:
             else None
         ),
         is_active=result["is_active"],
+        supported_channels=list(supported_channels),
         created_at=result["created_at"],
         updated_at=result["updated_at"],
     )

--- a/app/database/migrations/026_create_chat_session_tables.sql
+++ b/app/database/migrations/026_create_chat_session_tables.sql
@@ -1,0 +1,76 @@
+-- Migration 026: Chat session and message tables for Breeze Buddy chat (text) mode.
+--
+-- Two tables:
+--   chat_session  — one row per chat session (lifecycle, current flow node, snapshot
+--                   of accumulated flow state). Keyed by UUID exposed to clients.
+--   chat_message  — append-only message log. Insert-only per turn (no rewrites)
+--                   so write cost is O(1) regardless of conversation length.
+--
+-- Plus an ALTER on `template` to add `supported_channels`, the per-template
+-- opt-in that gates which channels (voice, chat) the template can be served on.
+-- Defaults to {'voice'} so existing rows keep their current behaviour.
+--
+-- Design reference: docs/CHAT_MODE.md §5 / §8.
+-- Lifecycle is fundamentally different from voice (inbound, on-demand, resumable,
+-- no cron, no dial retry), so this is a separate entity from lead_call_tracker.
+-- Outcome/transcript shape mirrors voice so webhooks and analytics see uniform
+-- "interaction" records across channels.
+
+ALTER TABLE template
+    ADD COLUMN supported_channels text[] NOT NULL DEFAULT ARRAY['voice']::text[];
+
+-- ``cardinality()`` returns 0 for empty arrays; ``array_length`` returns
+-- NULL, and a NULL CHECK predicate passes — which would silently let an
+-- empty ``supported_channels`` slip in. Use ``cardinality`` so the
+-- constraint actually rejects ``'{}'``.
+ALTER TABLE template
+    ADD CONSTRAINT template_supported_channels_check CHECK (
+        cardinality(supported_channels) >= 1
+        AND supported_channels <@ ARRAY['voice', 'chat']::text[]
+    );
+
+CREATE TABLE chat_session (
+    id                uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    template_id       uuid NOT NULL REFERENCES template(id) ON DELETE RESTRICT,
+    reseller_id       varchar(255) NOT NULL,
+    merchant_id       varchar(255),
+    status            varchar(20) NOT NULL DEFAULT 'ACTIVE',
+    outcome           varchar(50),
+    current_node      varchar(255),
+    metadata          jsonb NOT NULL DEFAULT '{}'::jsonb,
+    created_at        timestamptz NOT NULL DEFAULT now(),
+    last_activity_at  timestamptz NOT NULL DEFAULT now(),
+    ended_at          timestamptz,
+    ended_reason      varchar(50),
+    CONSTRAINT chat_session_status_check
+        CHECK (status IN ('ACTIVE', 'IDLE', 'ENDED')),
+    CONSTRAINT chat_session_ended_reason_check
+        CHECK (
+            ended_reason IS NULL
+            OR ended_reason IN ('user_ended', 'idle_timeout')
+        )
+);
+
+-- Dashboard listing: most recent active sessions by tenant.
+CREATE INDEX idx_chat_session_dashboard
+    ON chat_session (reseller_id, merchant_id, status, last_activity_at DESC);
+
+-- Idle sweeper: find active/idle sessions whose last_activity_at exceeded TTL.
+CREATE INDEX idx_chat_session_idle_sweep
+    ON chat_session (status, last_activity_at);
+
+-- Analytics by template.
+CREATE INDEX idx_chat_session_template_id
+    ON chat_session (template_id);
+
+
+CREATE TABLE chat_message (
+    session_id   uuid NOT NULL REFERENCES chat_session(id) ON DELETE CASCADE,
+    idx          integer NOT NULL,
+    role         varchar(20) NOT NULL,
+    content      text,
+    created_at   timestamptz NOT NULL DEFAULT now(),
+    PRIMARY KEY (session_id, idx),
+    CONSTRAINT chat_message_role_check
+        CHECK (role IN ('user', 'assistant'))
+);

--- a/app/database/queries/breeze_buddy/chat_session.py
+++ b/app/database/queries/breeze_buddy/chat_session.py
@@ -1,0 +1,182 @@
+"""SQL builders for chat_session and chat_message tables.
+
+This module contains ONLY query generation functions. Business logic
+lives in accessor/breeze_buddy/chat_session.py. JSON serialization is
+the caller's responsibility — query builders treat JSONB values as
+opaque strings (matches the existing call_execution_config pattern).
+"""
+
+from datetime import datetime
+from typing import Any, List, Optional, Tuple
+
+CHAT_SESSION_TABLE = "chat_session"
+CHAT_MESSAGE_TABLE = "chat_message"
+
+_SESSION_COLUMNS = """
+    id, template_id, reseller_id, merchant_id,
+    status, outcome, current_node, metadata,
+    created_at, last_activity_at, ended_at, ended_reason
+"""
+
+_MESSAGE_COLUMNS = """
+    session_id, idx, role, content, created_at
+"""
+
+
+# -- chat_session -------------------------------------------------------------
+
+
+def create_chat_session_query(
+    template_id: str,
+    reseller_id: str,
+    merchant_id: Optional[str],
+    metadata_json: str,
+) -> Tuple[str, List[Any]]:
+    """Insert a new ACTIVE session, returning the full row."""
+    query = f"""
+        INSERT INTO {CHAT_SESSION_TABLE} (
+            template_id, reseller_id, merchant_id, metadata
+        )
+        VALUES ($1, $2, $3, $4::jsonb)
+        RETURNING {_SESSION_COLUMNS}
+    """
+    return query, [template_id, reseller_id, merchant_id, metadata_json]
+
+
+def get_chat_session_by_id_query(session_id: str) -> Tuple[str, List[Any]]:
+    query = f"""
+        SELECT {_SESSION_COLUMNS}
+        FROM {CHAT_SESSION_TABLE}
+        WHERE id = $1
+    """
+    return query, [session_id]
+
+
+def update_chat_session_after_turn_query(
+    session_id: str,
+    current_node: Optional[str],
+) -> Tuple[str, List[Any]]:
+    """Single post-turn UPDATE: bump activity + (optionally) set current_node.
+
+    Used at the tail of every successful chat turn. ``current_node``
+    may be ``None`` for turns that didn't transition (or for direct-mode
+    templates) — in that case the column is left as-is via COALESCE.
+    """
+    query = f"""
+        UPDATE {CHAT_SESSION_TABLE}
+        SET current_node = COALESCE($1, current_node),
+            last_activity_at = now()
+        WHERE id = $2
+    """
+    return query, [current_node, session_id]
+
+
+def end_chat_session_query(
+    session_id: str,
+    outcome: Optional[str],
+    ended_reason: str,
+) -> Tuple[str, List[Any]]:
+    """Idempotent end: only flips status if not already ENDED.
+
+    `ended_at` and `ended_reason` are preserved if already set, so a
+    retry doesn't overwrite the original ending event.
+    """
+    query = f"""
+        UPDATE {CHAT_SESSION_TABLE}
+        SET status = 'ENDED',
+            outcome = COALESCE($1, outcome),
+            ended_at = COALESCE(ended_at, now()),
+            ended_reason = COALESCE(ended_reason, $2),
+            last_activity_at = now()
+        WHERE id = $3 AND status <> 'ENDED'
+        RETURNING {_SESSION_COLUMNS}
+    """
+    return query, [outcome, ended_reason, session_id]
+
+
+def list_idle_chat_sessions_query(
+    cutoff: datetime,
+    statuses: List[str],
+    limit: int = 100,
+) -> Tuple[str, List[Any]]:
+    """Sessions whose last_activity_at < cutoff and status ∈ statuses.
+
+    Ordered ascending so the oldest are processed first by the sweeper.
+    """
+    query = f"""
+        SELECT {_SESSION_COLUMNS}
+        FROM {CHAT_SESSION_TABLE}
+        WHERE status = ANY($1)
+          AND last_activity_at < $2
+        ORDER BY last_activity_at ASC
+        LIMIT $3
+    """
+    return query, [statuses, cutoff, limit]
+
+
+# -- chat_message -------------------------------------------------------------
+
+
+def insert_chat_message_query(
+    session_id: str,
+    role: str,
+    content: Optional[str],
+) -> Tuple[str, List[Any]]:
+    """Insert one message with auto-allocated idx (per-session monotonic).
+
+    Idx allocation is a subquery on chat_message itself, so the INSERT
+    is atomic. Combined with the per-session Redis lock and the
+    (session_id, idx) PK, duplicates are impossible.
+    """
+    query = f"""
+        INSERT INTO {CHAT_MESSAGE_TABLE} (
+            session_id, idx, role, content
+        )
+        VALUES (
+            $1,
+            COALESCE(
+                (SELECT MAX(idx) + 1
+                 FROM {CHAT_MESSAGE_TABLE}
+                 WHERE session_id = $1),
+                0
+            ),
+            $2, $3
+        )
+        RETURNING {_MESSAGE_COLUMNS}
+    """
+    return query, [session_id, role, content]
+
+
+def list_chat_messages_for_session_query(
+    session_id: str,
+    limit: Optional[int] = None,
+) -> Tuple[str, List[Any]]:
+    """Message log for a session, ordered by idx ASC.
+
+    When ``limit`` is set, returns only the most recent ``limit`` rows
+    (still ordered ascending) — used by the per-turn LLM-context replay
+    where unbounded reads would scale with conversation length. ``None``
+    returns the full log (used by transcript export and resume API).
+    """
+    if limit is None:
+        query = f"""
+            SELECT {_MESSAGE_COLUMNS}
+            FROM {CHAT_MESSAGE_TABLE}
+            WHERE session_id = $1
+            ORDER BY idx ASC
+        """
+        return query, [session_id]
+
+    # Take the last ``limit`` rows (DESC + LIMIT) then re-sort ASC so
+    # the caller gets chronological order.
+    query = f"""
+        SELECT {_MESSAGE_COLUMNS} FROM (
+            SELECT {_MESSAGE_COLUMNS}
+            FROM {CHAT_MESSAGE_TABLE}
+            WHERE session_id = $1
+            ORDER BY idx DESC
+            LIMIT $2
+        ) recent
+        ORDER BY idx ASC
+    """
+    return query, [session_id, limit]

--- a/app/database/queries/breeze_buddy/template.py
+++ b/app/database/queries/breeze_buddy/template.py
@@ -28,10 +28,10 @@ def get_template_by_merchant_query(
         values.append(name)
 
     query = f"""
-        SELECT id, 
-               reseller_id, 
-               merchant_id, 
-               name, flow, expected_payload_schema, expected_callback_response_schema, configurations, secrets, outbound_number_id, is_active, created_at, updated_at
+        SELECT id,
+               reseller_id,
+               merchant_id,
+               name, flow, expected_payload_schema, expected_callback_response_schema, configurations, secrets, outbound_number_id, is_active, supported_channels, created_at, updated_at
         FROM {TEMPLATE_TABLE}
         WHERE {" AND ".join(conditions)}
     """
@@ -61,14 +61,15 @@ def create_template_query(
         str
     ],  # Changed: moved before is_active to match SQL column order
     is_active: bool,
+    supported_channels: List[str],
     created_at,
     updated_at,
 ) -> Tuple[str, List[Any]]:
     """Generate query to create a new template."""
     query = f"""
-        INSERT INTO {TEMPLATE_TABLE} (id, reseller_id, merchant_id, name, flow, expected_payload_schema, expected_callback_response_schema, configurations, secrets, outbound_number_id, is_active, created_at, updated_at)
-        VALUES ($1, $2, $3, $4, $5::jsonb, $6::jsonb, $7::jsonb, $8::jsonb, $9::jsonb, $10, $11, $12, $13)
-        RETURNING id, reseller_id, merchant_id, name, flow, expected_payload_schema, expected_callback_response_schema, configurations, secrets, outbound_number_id, is_active, created_at, updated_at
+        INSERT INTO {TEMPLATE_TABLE} (id, reseller_id, merchant_id, name, flow, expected_payload_schema, expected_callback_response_schema, configurations, secrets, outbound_number_id, is_active, supported_channels, created_at, updated_at)
+        VALUES ($1, $2, $3, $4, $5::jsonb, $6::jsonb, $7::jsonb, $8::jsonb, $9::jsonb, $10, $11, $12, $13, $14)
+        RETURNING id, reseller_id, merchant_id, name, flow, expected_payload_schema, expected_callback_response_schema, configurations, secrets, outbound_number_id, is_active, supported_channels, created_at, updated_at
     """
 
     return query, [
@@ -83,6 +84,7 @@ def create_template_query(
         secrets,
         outbound_number_id,
         is_active,
+        supported_channels,
         created_at,
         updated_at,
     ]
@@ -179,10 +181,10 @@ def get_template_by_id_query(template_id: str) -> Tuple[str, List[Any]]:
         Tuple of (query string, values list)
     """
     query = f"""
-        SELECT id, 
-               reseller_id, 
-               merchant_id, 
-               name, flow, expected_payload_schema, expected_callback_response_schema, configurations, secrets, outbound_number_id, is_active, created_at, updated_at
+        SELECT id,
+               reseller_id,
+               merchant_id,
+               name, flow, expected_payload_schema, expected_callback_response_schema, configurations, secrets, outbound_number_id, is_active, supported_channels, created_at, updated_at
         FROM {TEMPLATE_TABLE}
         WHERE id = $1
         LIMIT 1
@@ -213,10 +215,10 @@ def get_template_by_outbound_number_id_query(
         )
 
     query = f"""
-        SELECT id, 
-               reseller_id, 
-               merchant_id, 
-               name, flow, expected_payload_schema, expected_callback_response_schema, configurations, secrets, outbound_number_id, is_active, created_at, updated_at
+        SELECT id,
+               reseller_id,
+               merchant_id,
+               name, flow, expected_payload_schema, expected_callback_response_schema, configurations, secrets, outbound_number_id, is_active, supported_channels, created_at, updated_at
         FROM {TEMPLATE_TABLE}
         WHERE {' AND '.join(conditions)}
         LIMIT 1
@@ -242,10 +244,10 @@ def get_all_templates_by_outbound_number_id_query(
     expected and by design.
     """
     query = f"""
-        SELECT id, 
-               reseller_id, 
-               merchant_id, 
-               name, flow, expected_payload_schema, expected_callback_response_schema, configurations, outbound_number_id, is_active, created_at, updated_at
+        SELECT id,
+               reseller_id,
+               merchant_id,
+               name, flow, expected_payload_schema, expected_callback_response_schema, configurations, outbound_number_id, is_active, supported_channels, created_at, updated_at
         FROM {TEMPLATE_TABLE}
         WHERE outbound_number_id = $1
         AND is_active = TRUE
@@ -299,6 +301,7 @@ def replace_template_query(
     outbound_number_id: Optional[str],
     is_active: bool,
     merchant_id: Optional[str],
+    supported_channels: List[str],
     updated_at,
 ) -> Tuple[str, List[Any]]:
     """
@@ -315,6 +318,7 @@ def replace_template_query(
         outbound_number_id: Outbound number ID or None
         is_active: Whether template is active
         merchant_id: Merchant identifier or None
+        supported_channels: Channels (voice/chat) the template is allowed on
         updated_at: Updated timestamp
 
     Returns:
@@ -331,12 +335,13 @@ def replace_template_query(
             outbound_number_id = $7,
             is_active = $8,
             merchant_id = $9,
-            updated_at = $10
-        WHERE id = $11
-        RETURNING id, 
-                  reseller_id, 
-                  merchant_id, 
-                  name, flow, expected_payload_schema, expected_callback_response_schema, configurations, secrets, outbound_number_id, is_active, created_at, updated_at
+            supported_channels = $10,
+            updated_at = $11
+        WHERE id = $12
+        RETURNING id,
+                  reseller_id,
+                  merchant_id,
+                  name, flow, expected_payload_schema, expected_callback_response_schema, configurations, secrets, outbound_number_id, is_active, supported_channels, created_at, updated_at
     """
 
     return query, [
@@ -349,6 +354,7 @@ def replace_template_query(
         outbound_number_id,
         is_active,
         merchant_id,
+        supported_channels,
         updated_at,
         template_id,
     ]

--- a/app/main.py
+++ b/app/main.py
@@ -14,17 +14,24 @@ from fastapi.responses import JSONResponse
 from pipecat.transports.daily.utils import DailyRESTHelper
 
 from app import __version__
+from app.ai.voice.agents.breeze_buddy.chat.cleanup import end_idle_chat_sessions
 from app.ai.voice.agents.breeze_buddy.services.agent_router.client import (
     close_smart_router_client,
 )
+
+# Database imports
+from app.ai.voice.llm._pools import close_all_pools as close_llm_http_pools
 from app.api.routers import automatic, breeze_buddy, devcycle, feature_flags, systems
 
 # Import background task scheduler
 from app.core.background_tasks import BackgroundTaskScheduler
-from app.core.config.dynamic import ENABLE_BACKGROUND_TASKS
+from app.core.config.dynamic import (
+    ENABLE_BACKGROUND_TASKS,
+)
 from app.core.config.static import (
     BACKGROUND_TASKS_LOOP_INTERVAL_SECONDS,
     BOT_MAX_DRAIN_SECONDS,
+    CHAT_SESSION_END_TIMEOUT_LOOP_INTERVAL_SECONDS,
     CORS_ALLOWED_ORIGINS,
     DAILY_API_KEY,
     DAILY_API_URL,
@@ -43,8 +50,6 @@ from app.core.config.static import (
 from app.core.logger import logger
 from app.core.security.jwt import validate_automatic_request
 from app.core.transport.http_client import create_aiohttp_session
-
-# Database imports
 from app.database import close_db_pool, init_db_pool
 from app.helpers.automatic.daily_room_pool import (
     cleanup_room_pool,
@@ -167,7 +172,14 @@ async def lifespan(_app: FastAPI):
             # Initialize Langfuse tasks (if configured)
             await initialize_langfuse_tasks(_background_scheduler)
 
-            ### Register new tasks here
+            # Chat-mode idle session cleanup. Distributed lock comes
+            # free from the scheduler, so only one pod runs the sweep
+            # per interval. See docs/CHAT_MODE.md §7.3.
+            _background_scheduler.register_task(
+                name="chat_session_idle_cleanup",
+                func=end_idle_chat_sessions,
+                interval_seconds=CHAT_SESSION_END_TIMEOUT_LOOP_INTERVAL_SECONDS,
+            )
 
             # Start the scheduler only if tasks are registered
             if _background_scheduler.tasks:
@@ -210,6 +222,9 @@ async def lifespan(_app: FastAPI):
     await cleanup_voice_agent_pool()
     # Cleanup bot processes
     await cleanup_bot_processes()
+    # Close shared httpx pools used by chat LLM clients (Azure today).
+    # Drains keep-alive connections cleanly so we don't leak fds on SIGTERM.
+    await close_llm_http_pools()
     # Close database pool
     await close_db_pool()
     # Close Redis connections

--- a/app/schemas/breeze_buddy/chat.py
+++ b/app/schemas/breeze_buddy/chat.py
@@ -1,0 +1,201 @@
+"""Pydantic models for chat (text-mode) sessions and their messages.
+
+Mirror the chat_session and chat_message tables (migration 026).
+Outcome reuses the voice outcome convention (free-form string), so
+analytics over voice + chat use the same field semantics.
+"""
+
+from datetime import datetime
+from enum import Enum
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, Field
+
+
+class ChatSessionStatus(str, Enum):
+    """Lifecycle status of a chat session."""
+
+    ACTIVE = "ACTIVE"
+    IDLE = "IDLE"
+    ENDED = "ENDED"
+
+
+class ChatMessageRole(str, Enum):
+    """Role of a chat message within the conversation."""
+
+    USER = "user"
+    ASSISTANT = "assistant"
+
+
+class ChatEndedReason(str, Enum):
+    """Why a chat session was ended."""
+
+    USER_ENDED = "user_ended"
+    IDLE_TIMEOUT = "idle_timeout"
+
+
+class ChatSession(BaseModel):
+    """One row of `chat_session`."""
+
+    id: str
+    template_id: str
+    reseller_id: str
+    merchant_id: Optional[str] = None
+    status: ChatSessionStatus = ChatSessionStatus.ACTIVE
+    outcome: Optional[str] = None
+    current_node: Optional[str] = None
+    metadata: Dict[str, Any] = Field(default_factory=dict)
+    created_at: Optional[datetime] = None
+    last_activity_at: Optional[datetime] = None
+    ended_at: Optional[datetime] = None
+    ended_reason: Optional[ChatEndedReason] = None
+
+
+class ChatMessage(BaseModel):
+    """One row of `chat_message` (append-only log)."""
+
+    session_id: str
+    idx: int
+    role: ChatMessageRole
+    content: Optional[str] = None
+    created_at: Optional[datetime] = None
+
+
+# ---------------------------------------------------------------------------
+# API request / response models (chat router — task #9).
+#
+# Kept in this module rather than a separate ``chat_api.py`` because they
+# share enums and field semantics with the row models above and there
+# isn't enough surface area to justify the extra file.
+# ---------------------------------------------------------------------------
+
+
+class CreateChatSessionRequest(BaseModel):
+    """Body of ``POST /api/breeze_buddy/chat/session``."""
+
+    template_id: str = Field(..., description="UUID of the chat-enabled template")
+    template_vars: Dict[str, Any] = Field(
+        default_factory=dict,
+        description="Render-time variables (customer_name, etc.). Same shape as voice lead_payload but plain JSON.",
+    )
+    metadata: Dict[str, Any] = Field(
+        default_factory=dict,
+        description="Opaque caller-provided context, persisted on chat_session.metadata.",
+    )
+
+
+class GreetingMessage(BaseModel):
+    """Initial assistant greeting attached to the create-session response."""
+
+    role: ChatMessageRole = ChatMessageRole.ASSISTANT
+    content: str
+
+
+class CreateChatSessionResponse(BaseModel):
+    """Body of the 200 OK on ``POST /session``."""
+
+    session_id: str
+    status: ChatSessionStatus
+    current_node: Optional[str] = None
+    greeting: Optional[GreetingMessage] = Field(
+        default=None,
+        description="Static greeting if the template provided one; None otherwise (assistant stays silent until the user sends the first message).",
+    )
+
+
+class SendChatMessageRequest(BaseModel):
+    """Body of ``POST /session/{id}/message``."""
+
+    content: str = Field(..., min_length=1, description="The user's message text.")
+
+
+class GetChatSessionResponse(BaseModel):
+    """Body of ``GET /session/{id}`` — full session state for resume."""
+
+    session_id: str
+    status: ChatSessionStatus
+    current_node: Optional[str] = None
+    messages: List[ChatMessage]
+    metadata: Dict[str, Any] = Field(default_factory=dict)
+
+
+class EndChatSessionResponse(BaseModel):
+    """Body of ``POST /session/{id}/end``."""
+
+    session_id: str
+    status: ChatSessionStatus
+    ended_reason: ChatEndedReason
+
+
+class ChatTranscriptResponse(BaseModel):
+    """Body of ``GET /session/{id}/transcript`` — read-only transcript export."""
+
+    session_id: str
+    template_id: str
+    status: ChatSessionStatus
+    messages: List[ChatMessage]
+
+
+# ---------------------------------------------------------------------------
+# Public chat-demo schemas (CHAT_MODE.md §13)
+# ---------------------------------------------------------------------------
+
+
+class DemoTemplateInfo(BaseModel):
+    """One entry in ``GET /chat/demo/templates`` — what a static demo
+    page needs to render a picker. ``slug`` is the URL-safe handle the
+    create-session endpoint expects in the request body."""
+
+    slug: str
+    template_id: str
+
+
+class ListDemoTemplatesResponse(BaseModel):
+    templates: List[DemoTemplateInfo]
+
+
+class CreateDemoSessionRequest(BaseModel):
+    """Body of ``POST /chat/demo/session``.
+
+    ``slug`` is the registered demo identifier (see ``DEMO_TEMPLATES``);
+    ``template_vars`` is the same payload the authenticated chat path
+    accepts — used to render the greeting (e.g., ``{customer_name}``).
+    """
+
+    slug: str = Field(..., min_length=1)
+    template_vars: Dict[str, Any] = Field(default_factory=dict)
+
+
+class CreateDemoSessionResponse(BaseModel):
+    """Body of ``POST /chat/demo/session``.
+
+    Mirrors ``CreateChatSessionResponse`` plus the demo-only fields the
+    client needs to drive subsequent ``/message`` SSE calls.
+    """
+
+    session_id: str
+    status: ChatSessionStatus
+    current_node: Optional[str] = None
+    greeting: Optional[GreetingMessage] = None
+    demo_token: str = Field(..., description="Bearer token for follow-up calls.")
+    message_cap: int = Field(..., description="Max assistant turns before 429.")
+
+
+__all__ = [
+    "ChatSessionStatus",
+    "ChatMessageRole",
+    "ChatEndedReason",
+    "ChatSession",
+    "ChatMessage",
+    "CreateChatSessionRequest",
+    "CreateChatSessionResponse",
+    "GreetingMessage",
+    "SendChatMessageRequest",
+    "GetChatSessionResponse",
+    "EndChatSessionResponse",
+    "ChatTranscriptResponse",
+    "DemoTemplateInfo",
+    "ListDemoTemplatesResponse",
+    "CreateDemoSessionRequest",
+    "CreateDemoSessionResponse",
+]

--- a/app/services/redis/__init__.py
+++ b/app/services/redis/__init__.py
@@ -11,6 +11,7 @@ from .client import (
     get_redis_service,
     is_redis_configured,
 )
+from .locks import LockAcquireError, RedisLock
 
 __all__ = [
     "RedisFactory",
@@ -18,4 +19,6 @@ __all__ = [
     "get_redis_service",
     "close_redis_connections",
     "is_redis_configured",
+    "RedisLock",
+    "LockAcquireError",
 ]

--- a/app/services/redis/locks.py
+++ b/app/services/redis/locks.py
@@ -1,0 +1,160 @@
+"""Distributed RedisLock async context manager.
+
+Per-key Redis lock with unique-token release semantics so concurrent
+holders cannot release each other's locks. ``acquire`` uses ``SET NX
+EX``; ``release`` runs a Lua script that compares the caller's token
+before deleting the key.
+
+Use as::
+
+    async with RedisLock(key, ttl_seconds=60) as lock:
+        ...                       # protected work
+
+The context manager raises :class:`LockAcquireError` if the key is
+already held — callers should map that to whatever contention signal
+makes sense for their surface (HTTP 409, retry, abort, …). The lock
+has no mid-block renewal: pick a TTL that covers the worst-case
+work; if work runs longer the holder has lost the lock and should
+bail.
+
+Distinct from the set-and-forget pattern in
+``app/core/background_tasks/scheduler.py`` which uses ``SET NX EX``
+once and lets the TTL handle "release" implicitly. That pattern is
+fine for cron-style tasks where exactly-one-per-interval is the
+goal, but unsafe whenever holders need to coordinate explicit
+release or guard against another caller stealing a stale lock —
+which is what this module is for.
+"""
+
+import uuid
+from typing import Optional
+
+from app.core.logger import logger
+from app.services.redis.client import RedisService, get_redis_service
+
+
+class LockAcquireError(Exception):
+    """Raised when a :class:`RedisLock` cannot be acquired (already held)."""
+
+    def __init__(self, key: str):
+        super().__init__(f"Lock '{key}' is already held")
+        self.key = key
+
+
+# Compare-and-DEL: only release if our token still owns the key. Without
+# the token check, a holder whose TTL elapsed (and whose work was picked
+# up by another pod) would delete the *other pod's* fresh lock on
+# release — silently breaking the mutual exclusion guarantee.
+_RELEASE_LUA = (
+    "if redis.call('GET', KEYS[1]) == ARGV[1] then "
+    "  return redis.call('DEL', KEYS[1]) "
+    "else return 0 end"
+)
+
+
+class RedisLock:
+    """Per-key distributed lock with token-scoped release.
+
+    Not re-entrant: acquiring twice on the same instance without an
+    intervening release raises ``RuntimeError`` to surface the bug
+    rather than silently leaking the prior token.
+    """
+
+    def __init__(
+        self,
+        key: str,
+        ttl_seconds: int = 60,
+        *,
+        redis_service: Optional[RedisService] = None,
+    ):
+        """
+        Args:
+            key: Redis key. Should be namespaced per resource (e.g.
+                ``"<domain>:<resource_type>:<id>:lock"``) so unrelated
+                locks can't collide on the same key.
+            ttl_seconds: Auto-expiry. If the holder dies without
+                releasing, the lock is freed when the TTL elapses.
+                There is no mid-block renewal — pick a TTL that
+                covers the worst-case work.
+            redis_service: Optional explicit service — useful in tests.
+                When ``None``, fetched lazily on first use via
+                ``get_redis_service()``.
+        """
+        self.key = key
+        self.ttl_seconds = ttl_seconds
+        self._redis = redis_service
+        self._token: Optional[str] = None
+
+    @property
+    def token(self) -> Optional[str]:
+        """The unique token issued at acquire-time, or ``None`` if not held."""
+        return self._token
+
+    async def _get_redis(self) -> RedisService:
+        if self._redis is None:
+            self._redis = await get_redis_service()
+        return self._redis
+
+    async def acquire(self) -> str:
+        """Try to acquire the lock. Returns the token on success.
+
+        Raises:
+            LockAcquireError: Key is already held by another caller.
+            RuntimeError: This instance is already holding the lock —
+                indicates a programming error (double-acquire).
+        """
+        if self._token is not None:
+            raise RuntimeError(f"RedisLock for key '{self.key}' already acquired")
+
+        token = uuid.uuid4().hex
+        redis = await self._get_redis()
+        ok = await redis.set(self.key, token, nx=True, ex=self.ttl_seconds)
+        if not ok:
+            raise LockAcquireError(self.key)
+
+        self._token = token
+        logger.debug(
+            f"Acquired RedisLock key='{self.key}' ttl={self.ttl_seconds}s "
+            f"token={token[:8]}..."
+        )
+        return token
+
+    async def release(self) -> bool:
+        """Release the lock iff our token still owns it. Idempotent.
+
+        Returns:
+            ``True`` if our token was holder and we released it;
+            ``False`` if the lock had already been freed (TTL elapsed,
+            or another caller acquired after a stale TTL). Either way
+            the caller's handle is cleared.
+        """
+        if self._token is None:
+            return False
+
+        redis = await self._get_redis()
+        result = await redis.run_script(
+            _RELEASE_LUA, keys=[self.key], args=[self._token]
+        )
+        released = bool(result)
+        if not released:
+            logger.warning(
+                f"RedisLock key='{self.key}' token={self._token[:8]}... "
+                "was already lost before release (TTL elapsed or stolen)"
+            )
+        else:
+            logger.debug(
+                f"Released RedisLock key='{self.key}' token={self._token[:8]}..."
+            )
+
+        self._token = None
+        return released
+
+    async def __aenter__(self) -> "RedisLock":
+        await self.acquire()
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        await self.release()
+
+
+__all__ = ["RedisLock", "LockAcquireError"]

--- a/app/services/redis/rate_limit.py
+++ b/app/services/redis/rate_limit.py
@@ -1,0 +1,120 @@
+"""Tiny Redis fixed-window rate limiter.
+
+Used by the public chat-demo endpoints (CHAT_MODE.md §13) to bound per-IP
+abuse: anonymous visitors can mint a demo token and stream LLM responses,
+so we need a cheap way to cap session-creates and message volume.
+
+Why fixed-window (not sliding/token-bucket): we're not protecting an SLA,
+we're stopping bots. The boundary-burst behaviour is acceptable — a
+visitor that times their requests perfectly to straddle two windows can
+get 2x the limit, which is still bounded.
+
+Storage shape: ``<prefix>:<bucket>:<seconds_since_epoch_floored_to_window>``.
+Window is computed deterministically from ``time.time()`` so two pods
+share the same bucket without coordination. TTL is the window length plus
+a small grace period so a key created at second ``T`` lives long enough
+to be readable until ``T + window``.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from typing import Optional
+
+from app.core.logger import logger
+from app.services.redis import get_redis_service, is_redis_configured
+
+__all__ = ["RateLimitDecision", "check_rate_limit"]
+
+
+@dataclass(frozen=True)
+class RateLimitDecision:
+    """Outcome of a rate-limit check.
+
+    ``allowed`` is the only field most callers need; ``count`` and
+    ``retry_after_seconds`` are exposed for clients that want to surface
+    "you have N requests left" or a 429 ``Retry-After`` header.
+    """
+
+    allowed: bool
+    count: int
+    limit: int
+    retry_after_seconds: int
+
+
+async def check_rate_limit(
+    *,
+    bucket: str,
+    identifier: str,
+    limit: int,
+    window_seconds: int,
+    prefix: str = "ratelimit",
+) -> RateLimitDecision:
+    """Increment the counter for ``(bucket, identifier)``; deny when over.
+
+    Args:
+        bucket: Logical bucket name (e.g., ``demo_session_create``). Lets
+            multiple limits coexist in Redis without colliding.
+        identifier: The thing we're limiting against — typically client
+            IP, but works for user_id, hashed-fingerprint, anything.
+        limit: Max events allowed inside ``window_seconds``.
+        window_seconds: Window size; current bucket index is
+            ``floor(now / window_seconds)``.
+        prefix: Redis key prefix. Override only if you need to isolate
+            tests from prod (the default is fine for everything else).
+
+    Returns ``allowed=True`` (and increments) when count <= limit, else
+    ``allowed=False``. Fails *open* — if Redis is unconfigured or errors,
+    we let the request through and log a warning. Demo abuse is preferable
+    to a Redis hiccup taking down the demo entirely.
+    """
+    if not is_redis_configured():
+        logger.warning(
+            f"rate_limit: Redis not configured; bucket={bucket!r} "
+            f"id={identifier!r} fail-open"
+        )
+        return RateLimitDecision(
+            allowed=True, count=0, limit=limit, retry_after_seconds=0
+        )
+
+    if limit <= 0:
+        # A non-positive limit means "disabled" — pass through without
+        # touching Redis at all so callers can flip a feature off cheaply.
+        return RateLimitDecision(
+            allowed=True, count=0, limit=limit, retry_after_seconds=0
+        )
+
+    now = int(time.time())
+    window_index = now // window_seconds
+    key = f"{prefix}:{bucket}:{identifier}:{window_index}"
+    seconds_into_window = now - (window_index * window_seconds)
+    retry_after = max(window_seconds - seconds_into_window, 1)
+
+    try:
+        redis = await get_redis_service()
+        count: Optional[int] = await redis.incr(key)
+        if count == 1:
+            # New bucket — set TTL just past the window edge so the key
+            # is readable for the full window before Redis evicts it.
+            await redis.expire(key, window_seconds + 5)
+    except Exception as exc:
+        logger.warning(
+            f"rate_limit: Redis error for bucket={bucket!r} id={identifier!r}: "
+            f"{exc} (fail-open)"
+        )
+        return RateLimitDecision(
+            allowed=True, count=0, limit=limit, retry_after_seconds=0
+        )
+
+    if count is None:
+        return RateLimitDecision(
+            allowed=True, count=0, limit=limit, retry_after_seconds=0
+        )
+
+    return RateLimitDecision(
+        allowed=count <= limit,
+        count=count,
+        limit=limit,
+        retry_after_seconds=retry_after,
+    )

--- a/app/utils/common.py
+++ b/app/utils/common.py
@@ -3,11 +3,16 @@ Common utilities for validation, parsing, and helper functions.
 """
 
 import json
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 
 from app.core.config.static import AWS_BREEZE_PORTAL_URL, GCP_BREEZE_PORTAL_URL
 from app.core.logger import logger
+
+
+def utcnow() -> datetime:
+    """Tz-aware UTC now — use for any column declared ``timestamptz``."""
+    return datetime.now(timezone.utc)
 
 
 def parse_iso_datetime(iso_string: Optional[str]) -> Optional[datetime]:

--- a/docs/CHAT_MODE.md
+++ b/docs/CHAT_MODE.md
@@ -1,0 +1,847 @@
+# Breeze Buddy Chat Mode — Design & Implementation Plan
+
+Status: **Implemented (direct LLM driver, post-pipeline rewrite).**
+Owners: Breeze Buddy team.
+Related docs: [BREEZE_BUDDY_ARCHITECTURE.md](./BREEZE_BUDDY_ARCHITECTURE.md), [DAILY_RTVI_EVENTS.md](./DAILY_RTVI_EVENTS.md), [README_WARM_TRANSFER.md](./README_WARM_TRANSFER.md).
+
+> **2026-05-04 update — pipeline removed.** Chat mode no longer runs through a Pipecat
+> `Pipeline` / `PipelineRunner` / `FlowManager` / custom transport. The driver now calls
+> the provider SDK directly and reuses pipecat's `LLMAdapter` + `LLMContext` only as
+> stateless schema/format helpers. Sections §4, §7, §9 reflect the direct driver. D3 in
+> §3 is preserved as historical context — it is no longer the operative decision.
+
+---
+
+## 1. Problem Statement
+
+Today Breeze Buddy supports template-driven conversational AI agents only over **voice** channels (Twilio/Plivo/Exotel telephony, Daily web). The same template (nodes, functions, hooks, LLM prompts) cannot be exposed as a **text/chat** experience. We want to extend Breeze Buddy so that a single template can power both voice and text/chat agents, with text mode preserving the entire flow and LLM behavior while removing STT/TTS/VAD.
+
+## 2. Goals & Non-Goals
+
+### Goals (v1)
+- Expose a Breeze Buddy template as an inbound, web-only, text-based chat agent.
+- Reuse the existing template, FlowManager, LLM, global functions, and handlers without forking the execution path.
+- REST + SSE API surface, JWT/RBAC scoped by reseller/merchant (same model as voice).
+- Resumable sessions with full message history.
+- Auto-greeting, idle timeout, configurable token streaming (block or stream).
+- Surface RTVI-style events to the chat client (function-call "thinking…", flow transitions, end-of-turn).
+
+### Non-Goals (v1)
+- Async/messaging channels (WhatsApp, SMS, Slack) — architecture extendable, not implemented.
+- Outbound chat (proactive first-message) — architecture extendable, not implemented.
+- Warm transfer to a human chat agent — deferred to **Phase 2**. The `warm_transfer` global function will be **hidden from the LLM** in chat-mode templates for v1.
+- Frontend UI inside clairvoyance — we expose the backend; loom owns the UI.
+- Cross-channel transfer (chat ↔ voice).
+
+## 3. Decisions (Locked In)
+
+| # | Decision | Rationale |
+|---|---|---|
+| D1 | New `chat_session` + `chat_message` tables, **not** a reuse of `LeadCallTracker`. | Lifecycle is fundamentally different (inbound, on-demand, resumable; no cron, no dial retry). Voice-specific columns don't fit. Mirror the **outcome contract** so webhooks/analytics see uniform "interaction" records. |
+| D2 | **Append-only message log** + lightweight session snapshot. No "rewrite full state blob per turn." | O(1) write per turn vs O(N²) bytes over a session. Scales to 10K+ concurrent sessions on modest Postgres. Cheap rehydration via indexed range scan. |
+| D3 | ~~Keep using **Pipecat pipeline + FlowManager** even for text.~~ **Superseded 2026-05-04.** Chat now uses a **direct LLM driver** (provider SDK directly + pipecat adapters as stateless helpers). Voice still uses the full pipeline. | Pipeline/runner/transport/FlowManager were paying the voice-architecture tax — frame ordering races, drain-loop counters, `on_pipeline_started` handshakes, 60s frame-timeout guard — for a code path that just streams tokens and dispatches tool calls. Direct driver removed ~600 LOC of scaffolding while keeping templates, hooks, and node transitions intact. See §4 + §9. |
+| D4 | **Single-process, asyncio-task-per-session.** No subprocess pool. | Chat is pure async I/O. Voice's subprocess model is justified by audio CPU work (VAD/STT codec); text doesn't need it. One process can serve hundreds-thousands of concurrent chats. |
+| D5 | **Explicit opt-in** via `supported_channels` array on the template (default `["voice"]`). | Most existing voice templates have voice-coded phrasing ("press 1", "you can now speak"). Silent dual-mode would surprise authors and pollute analytics. |
+| D6 | Voice-only handlers (`play_audio_sound`, `mute_stt`, `unmute_stt`) are **filtered out of functions and pre/post actions** when the builder is constructed with `disabled_names=CHAT_DISABLED_NAMES`. | Single `handler_map` for both channels; LLM never sees voice-only functions; no risk of an action-handler running against a transport that has no STT or audio. |
+| D7 | `warm_transfer` is **hidden from the LLM** when running a chat session in v1. Implemented in Phase 2. | Real text-to-text human handoff needs a human-agent inbox UI + identity model + relay; meaningful sub-project. |
+| D8 | REST + SSE transport. **Pattern A**: one SSE stream per turn (POST returns SSE). | Simpler than long-lived SSE; matches REST semantics; resumable across reconnects. |
+| D9 | Token streaming is **always on** in v1 — every turn emits `assistant_token` deltas before the final `assistant_message`. The per-session `stream: true \| false` opt-out is deferred; clients that want block mode can ignore the deltas. | Cuts a request-shape decision out of the v1 surface; we can add the opt-out without a breaking change later. |
+| D10 | RBAC: same JWT model as `/api/breeze_buddy/*` routers, scoped by reseller_id/merchant_id. | No new auth model. |
+| D11 | In-flight turn commit: **commit-on-completion** (assistant turn persists only after fully generated). | Simpler than streaming-with-incremental-commit; users see clean history on resume. Streaming-with-commit can come in a later phase. |
+| D12 | Per-session **distributed lock** (Redis) on POST to prevent concurrent-turn races across pods. **Fail-fast: 409 Conflict if held** — no server-side queueing, no blocking acquire. | No sticky-session requirement; any pod can serve any session. Blocking acquire would tie up FastAPI workers and a TCP keep-alive slot per waiting client; clients that need serialized requests can chain on the previous response client-side. |
+
+## 4. High-Level Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│                         FastAPI Router                              │
+│  POST /chat/session                                                 │
+│  GET  /chat/session/{id}                                            │
+│  POST /chat/session/{id}/message  → SSE stream (one turn)           │
+│  POST /chat/session/{id}/end                                        │
+└─────────────────────────────────┬───────────────────────────────────┘
+                                  │ per-session Redis lock
+                                  ▼
+                ┌──────────────────────────────────────┐
+                │             ChatAgent                │
+                │   (constructed-and-discarded /turn)  │
+                │                                      │
+                │   ┌──────────────────────────────┐   │
+                │   │ build flow_config (template) │   │
+                │   │ wrap handlers w/ context     │   │
+                │   │ seed LLMContext from history │   │
+                │   └─────────────┬────────────────┘   │
+                │                 │                    │
+                │                 ▼                    │
+                │   ┌──────────────────────────────┐   │
+                │   │   chat/llm_driver.stream()   │   │
+                │   │                              │   │
+                │   │  dispatch by service type:   │   │
+                │   │    - AzureLLMService    →    │   │
+                │   │      OpenAI streaming        │   │
+                │   │    - VertexAnthropic    →    │   │
+                │   │      messages.create stream  │   │
+                │   │    - GoogleVertex (Gemini)→  │   │
+                │   │      generate_content_stream │   │
+                │   │                              │   │
+                │   │  yields: ("text", str)       │   │
+                │   │          ("tool_call", call) │   │
+                │   └─────────────┬────────────────┘   │
+                │                 │                    │
+                │                 ▼                    │
+                │   on tool calls: invoke handler      │
+                │     (transition_handler etc.)        │
+                │     → if returns next_node_config,   │
+                │       swap node task_messages,       │
+                │       loop back to driver            │
+                │   on no-tool turn: turn complete     │
+                └─────────────┬────────────────────────┘
+                              ▼
+                ┌──────────────────────────────┐
+                │   PostgreSQL                 │
+                │   chat_session  (state row)  │
+                │   chat_message  (append log) │
+                └──────────────────────────────┘
+```
+
+**Key idea:** chat is a thin loop around a streaming LLM call. Pipecat's adapters
+(`OpenAILLMAdapter` / `AnthropicLLMAdapter` / `GeminiLLMAdapter`) and `LLMContext` are
+imported as stateless helpers — schema conversion and message-format conversion only.
+There is no `Pipeline`, `PipelineRunner`, `FlowManager`, custom transport, or frame
+classifier in the chat code path.
+
+### What's reused vs new vs deleted (post-rewrite)
+
+| Component | Action |
+|---|---|
+| `agents/breeze_buddy/template/{types,builder,transition,hooks,loader,context}.py` | **Reused unchanged.** Template models, FlowConfigBuilder, transition_handler, HookRegistry, render_messages_with_vars, TemplateContext (+ `with_context`) all work outside the pipeline because they are pure async functions. |
+| `agents/breeze_buddy/handlers/**` | **Reused unchanged.** Every handler signature already takes `(context, args, ...)` — chat just invokes them directly instead of via a frame-driven function-call registry. |
+| Pipecat `LLMAdapter` (per provider) | **Reused as a stateless helper.** Driver calls `service.get_llm_adapter().get_llm_invocation_params(context, ...)` to convert universal-shaped messages + tools into the provider's wire format. |
+| Pipecat `LLMContext` | **Reused as a data container.** No aggregator, no observers — just a place to hold the running message list and tools. |
+| Pipecat provider service (`AzureLLMService`, `GoogleVertexLLMService`, `VertexAnthropicLLMService`) | **Reused for credentials + client construction only.** Driver reads `service._client` (the AsyncOpenAI / AsyncAnthropicVertex / genai client) and `service._settings` (model, max_tokens, temperature, thinking, …) and issues the streaming SDK call directly. |
+| `agents/breeze_buddy/agent/pipeline.py` `build_chat_pipeline()` | **Deleted.** Voice-only `build_pipeline()` stays. |
+| `agents/breeze_buddy/agent/flow.py` `setup_flow_manager()` | **Not called from chat.** Voice still uses it. |
+| `agents/breeze_buddy/chat/text_transport.py` | **Deleted.** No transport, no frame plumbing. |
+| `agents/breeze_buddy/chat/sse.py` `classify_frame` / `TURN_END` | **Deleted.** Driver yields SSE events directly; classifier indirection gone. `SSEEvent` + `format_sse` retained. |
+| `agents/breeze_buddy/chat/agent.py` | **Rewritten.** ~150 LOC: build flow_config → seed LLMContext → loop {stream LLM → dispatch tool calls → maybe transition → repeat}. |
+| New: `agents/breeze_buddy/chat/llm_driver.py` | Provider-agnostic streaming + tool-call accumulator. Three async generators, one per wire format (OpenAI-compatible / Anthropic / Gemini). |
+| `agents/breeze_buddy/chat/cleanup.py` | **Reused unchanged.** Idle-session sweeper (one-shot DB UPDATE; no pipeline involvement). |
+| `database/migrations/026_*.sql`, `database/{queries,accessor,decoder}/breeze_buddy/chat_session.py`, `schemas/breeze_buddy/chat.py`, `api/routers/breeze_buddy/chat/{handlers,rbac}.py` | **Reused unchanged.** None of these touch the pipeline or driver internals. |
+
+## 5. Data Model
+
+### 5.1 `chat_session`
+
+Session-level state. One row per chat session.
+
+| Column | Type | Notes |
+|---|---|---|
+| `id` | UUID PK | Session ID exposed to clients. |
+| `template_id` | UUID FK → `template.id` | Which template drives the conversation. |
+| `reseller_id` | varchar(255) | RBAC scoping. Matches existing voice-table type. |
+| `merchant_id` | varchar(255) NULL | RBAC scoping. |
+| `status` | varchar(20) | `ACTIVE` \| `IDLE` \| `ENDED`. (No `BACKLOG`/`PROCESSING` — that's voice-only semantics.) |
+| `outcome` | varchar(50) NULL | Reuses voice outcome enum for analytics uniformity. |
+| `current_node` | varchar(255) NULL | FlowManager's current node name. Indexed-by-name analytics + cheap O(1) restore on rehydration. |
+| `metadata` | JSONB | Session-creation payload (resolved `template_vars`, `request_id`, etc.) plus any sticky flags hooks set during the conversation (e.g., `transfer_initiated`). |
+| `created_at` | TIMESTAMPTZ | |
+| `last_activity_at` | TIMESTAMPTZ | Updated on every turn. Drives idle eviction + idle-timeout end. |
+| `ended_at` | TIMESTAMPTZ NULL | |
+| `ended_reason` | varchar(50) NULL | `user_ended` \| `idle_timeout`. |
+
+> No `channel` column or `FAILED` status: there's only one channel today (web), and failure paths emit an SSE `error` event without mutating the session row. Add real channel discrimination back when WhatsApp/SMS/Slack land.
+
+**Why no `template_version` column:** v1 doesn't pin templates per session — sessions read the latest template from DB on every rehydration (same as voice). Add real version-pinning when the `template` table itself gets versioning.
+
+**Why no `flow_state_json` column:** the per-session runtime state we'd put in it is already covered: `current_node` is its own indexed column; resolved `template_vars` live in `metadata`; tool-call replay across turns is owned by the in-process `LLMContext` (chat agents are constructed-and-discarded per turn but the context is rebuilt from message history); sticky hook flags live in `metadata`. Add it back only if FlowManager turns out to have non-recoverable internal state we need to round-trip.
+
+Indexes:
+- `(reseller_id, merchant_id, status, last_activity_at DESC)` for dashboard listing.
+- `(status, last_activity_at)` for the idle-timeout sweeper job.
+- `(template_id)` for analytics by template.
+
+### 5.2 `chat_message` (append-only)
+
+| Column | Type | Notes |
+|---|---|---|
+| `session_id` | UUID FK → `chat_session.id` | |
+| `idx` | INT | Monotonic per session. |
+| `role` | TEXT | `user` \| `assistant`. |
+| `content` | TEXT NULL | The message text. |
+| `created_at` | TIMESTAMPTZ | |
+
+Primary key: `(session_id, idx)`. Index: same. Insert-only — never updated.
+
+> No `function_call_json` / `function_response_json` / `tokens_in` / `tokens_out` / `latency_ms` columns and no `system` / `function` role values: tool calls collapse into the trailing assistant text and are replayed per turn from the rebuilt `LLMContext`, and there's no per-call instrumentation pass yet. Reintroduce in lockstep with the writers.
+
+**Rehydration query:**
+```sql
+SELECT role, content
+  FROM chat_message
+ WHERE session_id = $1
+ ORDER BY idx ASC;
+```
+
+### 5.3 Migration `026_create_chat_session_tables.sql`
+
+Single forward migration adding both tables + indexes. No backfill (chat is a new product). Follows the [migration policy](../CLAUDE.md): never edit existing migration files; create new sequential ones.
+
+### 5.4 Outcome contract uniformity
+
+`chat_session.outcome`, `chat_session.metadata`, and the end-of-session webhook payload mirror the voice equivalents on `LeadCallTracker`. A merchant integrating with both channels sees the same JSON shape with a `channel` discriminator.
+
+## 6. API Surface (REST + SSE)
+
+All endpoints under `/api/breeze_buddy/chat/`. JWT required; same RBAC middleware as existing breeze_buddy routers.
+
+### 6.1 Endpoint Inventory
+
+| Method | Path | Purpose |
+|---|---|---|
+| `POST` | `/session` | Create new chat session for a template. Returns session ID + initial assistant greeting. |
+| `GET` | `/session/{id}` | Resume — returns full message history and current status. |
+| `POST` | `/session/{id}/message` | Send user message. Returns **SSE stream** for the assistant's turn. |
+| `POST` | `/session/{id}/end` | Explicit end (user closes the chat). Fires outcome webhook. |
+| `GET` | `/session/{id}/transcript` | Plain JSON transcript export (read-only). |
+
+### 6.2 `POST /session`
+
+Request:
+```json
+{
+  "template_id": "uuid",
+  "channel": "web",
+  "template_vars": { "customer_name": "Asha", ... },
+  "metadata": { "anything": "useful" },
+  "stream": true
+}
+```
+
+Response (200):
+```json
+{
+  "session_id": "uuid",
+  "status": "ACTIVE",
+  "greeting": { "role": "assistant", "content": "Hi Asha, ..." },
+  "current_node": "intro"
+}
+```
+
+Validation:
+- Template must exist and have `"chat" in supported_channels`.
+- Reseller/merchant scope check.
+
+Side effects:
+- INSERT `chat_session`.
+- If the template has `configurations.initial_greeting`, render it with
+  `template_vars` and INSERT the first `chat_message` row (`role=assistant`).
+  No agent / pipeline is constructed at session-create time — chat is
+  stateless-per-turn (§4) and the first `POST /message` builds the
+  per-turn `ChatAgent` on demand.
+
+### 6.3 `GET /session/{id}`
+
+Response:
+```json
+{
+  "session_id": "uuid",
+  "status": "ACTIVE | IDLE | ENDED",
+  "current_node": "verify_identity",
+  "messages": [
+    { "idx": 0, "role": "assistant", "content": "Hi Asha…", "created_at": "..." },
+    { "idx": 1, "role": "user", "content": "Hello", "created_at": "..." },
+    ...
+  ],
+  "metadata": { ... }
+}
+```
+
+If `IDLE`: the session is rehydratable. Sending a `/message` will revive it.
+If `ENDED`: read-only.
+
+### 6.4 `POST /session/{id}/message`  → SSE
+
+Request:
+```json
+{ "content": "user typed text" }
+```
+
+Acquires per-session lock (Redis). Returns **SSE stream** with these event types:
+
+| Event | Payload | Notes |
+|---|---|---|
+| `user_committed` | `{ idx, content }` | The user message has been persisted. |
+| `assistant_token` | `{ delta }` | Token stream (v1 always streams; the per-session `stream` opt-out from D9 was deferred). |
+| `assistant_message` | `{ idx, content }` | Full assistant turn (always emitted at end of turn, after streaming). |
+| `function_call_started` | `{ name, args, tool_call_id }` | "Thinking…" indicator equivalent. |
+| `function_call_completed` | `{ name, tool_call_id, result_summary }` | |
+| `node_transition` | `{ to }` | Synthesized node moved (flow mode only). The `from` field from D8's draft was dropped — clients should track `current_node` themselves between turns. |
+| `turn_end` | `{ session_status }` | Closes the SSE stream. Always last. |
+| `error` | `{ code, message }` | Stream closes after. |
+
+If lock contended → HTTP 409 (don't open SSE).
+If session ENDED → HTTP 410 Gone.
+
+### 6.5 `POST /session/{id}/end`
+
+Marks `ENDED` under the per-session lock. The outcome webhook (same shape as
+voice end-of-call webhook with `channel: "web"`) is a phase-2 follow-up — it
+isn't fired by v1. There is no in-memory registry to evict from (§4).
+
+### 6.6 `GET /session/{id}/transcript`
+
+Plain JSON. Useful for export/audit. Same payload as `GET /session/{id}` minus runtime status.
+
+## 7. Agent Runtime
+
+### 7.1 `ChatAgent` (`app/ai/voice/agents/breeze_buddy/chat/agent.py`)
+
+**One-shot per-turn driver.** Fresh `ChatAgent` per `POST /message`; single user → assistant
+turn; discarded. No long-lived state, no pipeline, no runner.
+
+```
+class ChatAgent:
+    session_id, template, template_vars, llm_service
+
+    async def run_turn(
+        *, user_content: str,
+        history: list[dict],         # prior turns from DB
+        current_node: str | None,    # resume node from chat_session.current_node
+    ) -> AsyncIterator[SSEEvent]
+```
+
+`run_turn` is a single async loop:
+
+1. Build `flow_config` via `FlowConfigBuilder(disabled_names=CHAT_DISABLED_NAMES).build_flow_config(template)`.
+2. Wrap each entry in `flow_builder.handler_map` with `with_context(self)` so the
+   `transition_handler` and friends receive a `TemplateContext` first arg.
+3. Resolve the resume node: `current_node` or `initial_node`.
+4. Render `role_messages` + `task_messages` via `render_messages_with_vars` and
+   `inject_language_rules` (chat path mirrors voice's `FlowConfigLoader.load_template`).
+5. Persist the user message → yield `user_committed`.
+6. Build an `LLMContext`:
+   - `messages = [system role_messages] + task_messages + history + [user_content]`
+   - `tools = ToolsSchema(standard_tools=[fn.to_function_schema() for fn in node.functions])`
+7. **Tool-call loop:**
+
+   ```python
+   while True:
+       text_chunks: list[str] = []
+       tool_calls: list[FunctionCallFromLLM] = []
+       async for kind, payload in llm_driver.stream(self._llm, context, label):
+           if kind == "text":
+               text_chunks.append(payload)
+               yield SSEEvent("assistant_token", {"delta": payload})
+           elif kind == "tool_call":
+               tool_calls.append(payload)
+               yield SSEEvent("function_call_started", {...})
+
+       if not tool_calls:
+           break  # turn complete
+
+       # Mirror what an LLMAssistantContextAggregator would write back:
+       context.add_message({"role": "assistant", "tool_calls": [...]})
+       for call in tool_calls:
+           result, next_node_cfg = await invoke_handler(call, flow_config)
+           context.add_message({"role": "tool",
+                                "tool_call_id": call.tool_call_id,
+                                "content": json.dumps(result)})
+           yield SSEEvent("function_call_completed", {...})
+           if next_node_cfg is not None:
+               # FlowManager-style transition: swap task_messages + tools
+               apply_node_transition(context, next_node_cfg, template_vars)
+   ```
+
+8. Persist the assistant message → yield `assistant_message`.
+9. Single combined UPDATE on `chat_session` (last_activity_at + current_node).
+
+There is no `try / finally` around a pipeline runner anymore — there is nothing to
+cancel. The only cleanup is closing whatever the SDK opened, which the SDK handles on
+its own when the async generator returns.
+
+### 7.2 `chat/llm_driver.py` — provider-agnostic streaming
+
+Single module. Public surface:
+
+```python
+async def stream(
+    llm_service: AzureLLMService | GoogleVertexLLMService | VertexAnthropicLLMService,
+    context: LLMContext,
+    *,
+    log_label: str,
+) -> AsyncIterator[tuple[Literal["text", "tool_call"], str | FunctionCallFromLLM]]:
+    """Issue one streaming LLM call; yield text deltas and (after stream ends)
+    any tool calls. Provider dispatch happens inside on the service type."""
+```
+
+Internally three implementations, each ~50 LOC, port the streaming +
+tool-call accumulation from pipecat's per-provider `_process_context` minus the
+frame-pushing layer:
+
+| Service class | SDK call | Streaming pattern |
+|---|---|---|
+| `AzureLLMService` (any `BaseOpenAILLMService` subclass) | `service._client.chat.completions.create(stream=True, **params)` | OpenAI delta-stream: `tool_calls[idx].function.{name,arguments}` accumulate per index; flush on index change. (Mirrors `pipecat/services/openai/base_llm.py:404-540`.) |
+| `VertexAnthropicLLMService` (any `AnthropicLLMService` subclass) | `service._client.beta.messages.create(stream=True, **params)` | Anthropic event stream: `content_block_start (tool_use)` → `content_block_delta (partial_json)` accumulate; flush on `message_delta(stop_reason="tool_use")`. (Mirrors `pipecat/services/anthropic/llm.py:340-487`.) |
+| `GoogleVertexLLMService` (any `GoogleLLMService` subclass) | `service._client.aio.models.generate_content_stream(...)` | Gemini parts: `part.text` for content, `part.function_call` already-materialized for tool calls. (Mirrors `pipecat/services/google/llm.py:432-619`.) |
+
+**How the driver talks to the service:**
+- `adapter = service.get_llm_adapter()` (already attached by pipecat at construction).
+- `params_from_context = adapter.get_llm_invocation_params(context, ...)` returns
+  provider-shaped `messages`/`tools`/`system` dict.
+- `service._settings` provides model, max_tokens, temperature, top_p, thinking, etc.
+- `service._client` is the SDK client pipecat already constructed (with our
+  Azure/Vertex/AnthropicVertex credentials from `app/ai/voice/llm/*.py`).
+
+Reusing pipecat's adapter means OpenAI-compatible providers we don't currently use
+(DeepSeek, Groq, Cerebras, Mistral, Fireworks, Ollama, Nvidia, Nebius, Perplexity,
+Grok) automatically work behind the OpenAI branch as soon as someone wires them into
+`get_llm_service`. Anthropic-direct (non-Vertex) and Google Gemini API (non-Vertex)
+also work behind their respective branches with no driver change.
+
+### 7.3 Idle session cleanup (`app/ai/voice/agents/breeze_buddy/chat/cleanup.py`)
+
+Unchanged from the pipeline-era design. There is no in-memory registry; the only
+background task is `end_idle_chat_sessions()` registered with the global
+`BackgroundTaskScheduler`. The scheduler's distributed Redis lock keeps the sweep
+single-pod-per-tick.
+
+### 7.4 Per-turn lifecycle
+
+1. Acquire per-session Redis lock (TTL 180s).
+2. Re-read `chat_session` under the lock.
+3. Read capped message history.
+4. Read template.
+5. Build a fresh `ChatAgent` with the configured LLM service; `run_turn(...)`.
+6. Stream SSE events to the client until `turn_end` or `error`.
+7. Release the lock in `finally`.
+
+Per-turn cost (excluding LLM): ~3 indexed DB reads + 2 INSERTs + 1 UPDATE. **Pipeline
+construction cost is now zero** (no `PipelineTask`, no `PipelineRunner`, no transport).
+
+### 7.3 Idle session cleanup (`app/ai/voice/agents/breeze_buddy/chat/cleanup.py`)
+
+There is **no in-memory registry** in chat mode (decision recorded in §11). The only background concern is preventing zombie ACTIVE/IDLE rows from accumulating when users walk away.
+
+`end_idle_chat_sessions()` is a single async function registered against the global `BackgroundTaskScheduler` from `app/main.py` lifespan:
+
+```
+_background_scheduler.register_task(
+    name="chat_session_idle_cleanup",
+    func=end_idle_chat_sessions,
+    interval_seconds=CHAT_SESSION_END_TIMEOUT_LOOP_INTERVAL_SECONDS,  # static, default 300s
+)
+```
+
+The scheduler's distributed Redis lock guarantees only one pod runs the sweep per interval — at 100s of pods that's a single global cron, not N redundant sweeps.
+
+The function:
+1. Reads `CHAT_SESSION_END_TIMEOUT_SECONDS` from dynamic config (live-tunable via DevCycle).
+2. Queries `list_idle_chat_sessions(cutoff, [ACTIVE, IDLE])`.
+3. For each row, calls `end_chat_session(..., ended_reason=IDLE_TIMEOUT)`. The accessor's UPDATE is idempotent (`WHERE status <> 'ENDED'`), so duplicate sweeps from a botched lock acquire would still be safe.
+
+### 7.4 Per-turn lifecycle (no rehydration step)
+
+In the stateless model there is no separate "cache hit" vs "cache miss" path. Every `POST /message` runs the same sequence:
+
+1. Acquire per-session Redis lock (TTL 180s, no auto-extend).
+2. Re-read `chat_session` under the lock (covers the race where another pod ended it between request entry and lock acquisition).
+3. Read `chat_message` rows for the session — these become `prefill_messages` for `LLMContext`.
+4. Read the template (single indexed query).
+5. Build a fresh `ChatAgent`, call `run_turn(user_content, history, current_node)`.
+6. Stream SSE events to the client until `turn_end`.
+7. Release the lock in `finally`.
+
+Per-turn cost (excluding the LLM call itself): ~3 indexed DB reads + 2 INSERTs + pipeline construction. Pipeline construction in chat mode is light — no STT, TTS, VAD, smart-turn, or Daily-room provisioning. Single-digit ms for the build.
+
+## 8. Template Layer Changes
+
+### 8.1 `supported_channels` flag
+
+Add to `template/types.py`:
+
+```
+class TemplateModel(BaseModel):
+    ...
+    supported_channels: List[Literal["voice", "chat"]] = Field(
+        default_factory=lambda: ["voice"]
+    )
+```
+
+- Default `["voice"]` keeps every existing template safe (chat creation rejects them).
+- Authors opt in by adding `"chat"`.
+- Validation: at least one channel; values constrained to the literal set.
+- **Applies to both `flow` and `direct` template modes.** The field lives on `TemplateModel` (sibling to `flow`), so it is mode-agnostic. A direct-mode template with `supported_channels: ["voice", "chat"]` builds in chat just like a flow-mode one — the only difference is which build path inside `FlowConfigBuilder` is taken (flow vs direct), and the chat-mode function/action strip (see §8.2) applies uniformly to both paths.
+
+Builder/dashboard UX: a single channel-checkbox group in the template editor. Out of scope for this doc — backend provides the field; dashboard work is its own ticket.
+
+### 8.2 Voice-only feature handling in chat mode
+
+`FlowConfigBuilder` accepts a `disabled_names: AbstractSet[str] = frozenset()` kwarg — chat mode is realised by *filtering* template references to voice-only handlers, not by swapping the handlers for noops. The set itself lives in `app/ai/voice/agents/breeze_buddy/chat/disabled.py` (`CHAT_DISABLED_NAMES`); the builder is channel-agnostic and just consumes it. Voice callers pass nothing (default empty set, no-op fast-path); chat callers pass `CHAT_DISABLED_NAMES`:
+
+```
+mute_stt
+unmute_stt
+play_audio_sound
+warm_transfer
+connect_to_live_agent
+end_conversation
+```
+
+A single module-level helper `filter_disabled_identifiers(items, disabled, log_label)` does the actual filtering — it drops any dict whose identifier (resolved via `name > function_name > handler`) is in the disabled set. When `disabled` is empty (voice mode) it returns the input list unchanged with no copy, so the same call site is used regardless of caller.
+
+The filter is applied at four sites before Pydantic validation:
+
+1. **Per-node `functions`** (flow mode) — LLM never sees disabled functions as callable.
+2. **Per-node `pre_actions` / `post_actions`** (flow mode) — `type == "function"` actions whose `handler` is disabled are dropped; `tts_say` and other non-function actions pass through untouched, so the chat pipeline never tries to invoke STT-mute / audio-play against a transport that has neither.
+3. **Top-level `global_functions`** (flow mode).
+4. **Flat `functions` array** (direct mode).
+
+A `WARNING` log line is emitted for every stripped entry, suffixed with the call-site label (`function` or `action`) so authors can locate the affected JSON array.
+
+Non-voice handlers (`end_conversation`, `transition_handler`, `http_function_handler`, `builtin_function_dispatcher`, `custom_python_code_handler`) work unchanged across both channels.
+
+### 8.3 Identifier precedence
+
+The filter resolves a dict's identifier via `name > function_name > handler`. A template that explicitly renames a function (e.g., `name: "transfer_to_finance"` with `handler: "connect_to_live_agent"`) is treated as the renamed function and **passes through** — the filter only fires when the user-visible identifier itself is in `CHAT_DISABLED_NAMES`. This is intentional: a renamed function probably points to bespoke logic the template author wants to keep, and the precedence makes that opt-out free.
+
+Action dicts only carry a `handler` key, so the chain reduces to that key naturally — no separate code path is needed for actions.
+
+`warm_transfer` / `connect_to_live_agent` are v1 stopgap entries in `CHAT_DISABLED_NAMES` — Phase 2 replaces these with a real chat-to-human handoff (see §15).
+
+### 8.4 Initial greeting
+
+**Default: voice-equivalent (LLM-generated).** Reuse `prepare_initial_node` (`agent/flow.py:134-182`). After cold-start, run one synthetic LLM turn with **no user message** to elicit the greeting from the template's `task_messages` and template_vars. This matches voice behavior exactly.
+
+**Optional override: `static_greeting` field on the template.** If the template defines a non-empty `static_greeting` string (`{placeholder}` substitution applied from `template_vars`), skip the LLM call and use that string directly. Saves one LLM call per session start — meaningful at high-volume merchants where the greeting is the same every time anyway.
+
+In both paths:
+- Persist the greeting as the first `chat_message` (`role=assistant`, `idx=0`).
+- Return it in the `POST /session` response.
+
+### 8.5 Validation rules at session creation
+
+When `POST /session` is called:
+1. Template must include `"chat"` in `supported_channels`.
+2. Template's required `template_vars` must be satisfied by the request payload (same logic voice uses).
+3. Realtime LLM models (S2S) — disallow in v1; chat templates must use a text LLM. Return 400.
+
+## 9. Direct LLM Driver (replaces "Pipecat Pipeline in Text Mode")
+
+### 9.1 Why we dropped the pipeline
+
+The voice pipeline is justified by what it abstracts: VAD, STT, TTS, turn detection,
+interruption strategies, transcription gate, audio mixers, RTVI observer, OTEL tracing.
+For chat *none of those exist*; what survives is one LLM call + a tool-call dispatch.
+Running that through `Pipeline → PipelineRunner → BreezeBuddyTextTransport →
+LLMUserAggregator → LLMService(FlowManager-driven) → LLMAssistantAggregator →
+BreezeBuddyTextTransport.output → SSE classifier` paid the voice tax for no benefit
+and surfaced as several real bugs: frame-ordering races between SystemFrame fast-path
+and ControlFrame queueing, `on_pipeline_started` handshake required before pushing
+user text, drain-loop counters to detect "this LLM cycle vs the next", a 60s
+per-frame timeout that triggered when streaming was actually fine.
+
+### 9.2 What replaces it
+
+Three pieces:
+
+1. **`chat/llm_driver.py`** — three async generators (one per wire format) issuing the
+   provider-specific streaming SDK call directly. Each yields `("text", str)` for
+   content deltas and `("tool_call", FunctionCallFromLLM)` for materialized tool calls
+   after the stream closes. ~150 LOC total.
+
+2. **`chat/agent.py`** — one async loop:
+   build flow_config → seed `LLMContext` → repeat { stream LLM → if tool calls,
+   dispatch handlers + apply transitions → continue; else break }. ~150 LOC.
+
+3. **Pipecat `LLMAdapter` per provider** — pure schema/format converters. Driver calls
+   `adapter.get_llm_invocation_params(context, ...)` to get the provider-shaped
+   `messages`/`tools`/`system` dict, then merges with `service._settings` to build the
+   request params.
+
+### 9.3 Per-turn flow
+
+```
+POST /message
+  │
+  ▼
+agent.run_turn(user_content, history, current_node)
+  ├── build flow_config (FlowConfigBuilder, disabled_names=CHAT_DISABLED_NAMES)
+  ├── wrap handler_map with with_context(self)
+  ├── render role_messages + task_messages w/ template_vars
+  ├── seed LLMContext = role + task + history + user
+  └── loop:
+        │
+        ▼
+        llm_driver.stream(llm_service, context)
+          ├── get adapter via service.get_llm_adapter()
+          ├── adapter.get_llm_invocation_params(context) → provider-shaped params
+          ├── service._client.<provider-call>(stream=True, **params)
+          └── async for chunk:
+                ├── text delta  → yield ("text", "hello")
+                └── tool delta  → accumulate in indexed buffer
+              when stream ends:
+                └── yield ("tool_call", FunctionCallFromLLM(...))
+        │
+        ▼
+        agent collects:
+          ├── append text deltas → SSE assistant_token (streamed)
+          └── if tool_calls:
+                ├── add assistant message w/ tool_calls to LLMContext
+                ├── for each call: invoke handler (the wrapper from
+                │     FlowConfigBuilder._build_function_schema —
+                │     handler returns (FlowResult, NodeConfig | None))
+                ├── add tool result message(s) to LLMContext
+                ├── if NodeConfig returned: swap task_messages + tools
+                │     (apply_node_transition, mirroring FlowManager._set_node)
+                └── continue loop
+        │
+        ▼
+        else (no tool calls):
+          ├── persist assistant message → SSE assistant_message
+          ├── update chat_session.last_activity_at + current_node
+          └── SSE turn_end
+```
+
+### 9.4 Provider portability matrix
+
+| Provider | Used today by Buddy | Driver branch | LOC for new wire format |
+|---|---|---|---|
+| Azure OpenAI | ✅ default | OpenAI-compatible | 0 |
+| Google Vertex (Gemini) | ✅ template opt-in | Gemini | 0 |
+| Anthropic on Vertex (Claude) | ✅ template opt-in | Anthropic | 0 |
+| Anthropic direct (non-Vertex) | future | reuse Anthropic branch | 0 |
+| Google Gemini API (non-Vertex) | future | reuse Gemini branch | 0 |
+| OpenAI direct, DeepSeek, Groq, Cerebras, Mistral, Fireworks, Ollama, Nvidia, Nebius, Perplexity, Grok | future | reuse OpenAI branch | 0 |
+| New non-OpenAI-compatible provider | future | new branch | ~50 LOC |
+
+### 9.5 RTVI events for chat
+
+**Removed from chat in v1.** The RTVI observer was attached to the (now-deleted)
+pipeline. Function-call lifecycle events that loom cares about are still surfaced
+as first-class SSE events (`function_call_started`, `function_call_completed`,
+`assistant_token`). Re-introducing RTVI envelope semantics for chat is a future
+refinement; track in CHAT_MODE follow-ups if loom asks for it.
+
+## 10. Persistence & Rehydration
+
+### 10.1 Append-only message log
+
+Per turn:
+- 1 INSERT: user message → `chat_message` (`role=user`).
+- 1 INSERT: assistant message → `chat_message` (`role=assistant`).
+- 1 UPDATE on `chat_session.last_activity_at` (and `current_node` only when transition occurred).
+
+Tool-call rounds inside one turn don't write extra rows — tool calls fold into the trailing assistant text and are replayed each turn from the rebuilt `LLMContext`. If structured tool-call persistence becomes a requirement (audit, replay across processes), reintroduce `function_call_json` / `function_response_json` together with the writers.
+
+### 10.2 Snapshot triggers
+
+Two pieces of session state get updated outside the per-turn message inserts:
+
+- `current_node` (top-level column) — `UPDATE chat_session SET current_node = $1` whenever FlowManager transitions. Typically rare relative to message turns.
+- `metadata` (JSONB) — `UPDATE chat_session SET metadata = $1` only when a hook sets a sticky flag (e.g., `transfer_initiated`). Most turns leave `metadata` untouched.
+
+`last_activity_at` is updated on every turn in the same transaction as the `chat_message` inserts.
+
+### 10.3 In-flight turn handling
+
+- Assistant message persists **only after the full turn completes** (even when streaming tokens to client).
+- If client disconnects mid-stream:
+  - Pipeline continues to completion (don't abort the LLM call mid-stream — wasteful and risks half-applied function calls).
+  - Final assistant message + any function calls still persist.
+  - On reconnect, the user sees the complete assistant message in history.
+- If pod crashes mid-stream: the user's message has already been persisted (committed before LLM started). The assistant's response is lost. On reconnect, the user sees their message but no assistant reply. They can resend or rephrase. (Acceptable for v1; Phase 4 may add streaming-with-incremental-commit.)
+
+### 10.4 Crash recovery
+
+On pod startup:
+- No "drain" step required — sessions live in DB and there is no in-memory cache to warm.
+- The global `BackgroundTaskScheduler` runs `end_idle_chat_sessions` (§7.3) on its own cadence; any row left ACTIVE/IDLE past `CHAT_SESSION_END_TIMEOUT_SECONDS` is marked ENDED with `ended_reason=idle_timeout`.
+
+## 11. Concurrency & Multi-Pod Safety
+
+### 11.1 Per-session lock
+
+Redis lock keyed by `session_id`, acquired at the start of `POST /message` and `POST /end`, released on completion. TTL of 180s — comfortably longer than any reasonable single-turn LLM call (function-calling chain, tail latencies). **No auto-extend.** A turn that runs longer than the TTL means the upstream is hung; the lock should expire so retries can recover, not perpetually block all other pods.
+
+If lock contended → 409 Conflict. Client retries.
+
+**Implementation:** `RedisLock` async context manager in `app/services/redis/locks.py`:
+
+- `acquire(key, ttl)` — `SET NX EX`, returns a unique token (so concurrent holders can't release each other's locks).
+- `release(key, token)` — compare-and-del Lua script.
+
+The scheduler can adopt this helper later; no immediate change there.
+
+### 11.2 No sticky sessions, no in-memory cache
+
+Any pod can serve any session because all state lives in DB + the per-session Redis lock. There is no per-pod in-memory `ChatAgent` map — the agent is constructed fresh per turn. This trades a few ms of pipeline construction for:
+- linear horizontal scale (no cache-coherence cost across N pods),
+- no phantom warm agents on pods that previously served a session,
+- no background eviction loop running redundantly on every pod.
+
+The decision is recorded in §15 Phase 1 → see also CLAUDE.md "Chat (text) mode".
+
+### 11.3 No in-process lock
+
+Because the agent is one-shot per turn there is no shared in-pod state to guard. The Redis lock alone is the mutual-exclusion primitive.
+
+## 12. Observability
+
+- **OTEL spans:** root span per chat session, child span per turn (mirroring voice). Span attributes: `chat.session_id`, `chat.template_id`, `chat.merchant_id`, `chat.current_node`, `chat.turn_idx`.
+- **Logging:** extend existing `set_log_context` / `update_log_context` to include `chat_session_id`. All chat code paths participate in the same loguru context vars used by voice.
+- **Langfuse:** existing tracing pipeline captures LLM calls regardless of channel. Add `channel: "chat"` as a span attribute so traces are filterable.
+- **Metrics:** per-pod counters for active sessions, idle evictions, rehydrations, lock contentions, turn latency p50/p95.
+
+## 13. Loom client-sdk Wiring
+
+Backend exposes the API; loom owns the client. Out of scope for this repo but the contract is:
+
+- New `ChatClient` class in `loom/packages/client-sdk` analogous to the Daily voice client.
+- Methods: `createSession`, `sendMessage` (returns async iterator over SSE events), `resume`, `end`, `getTranscript`.
+- Reuses RTVI event types where applicable so app-level event handlers can be shared between voice and chat.
+- This work is tracked in a separate ticket against the `loom` repo.
+
+## 14. Testing Strategy
+
+### 14.1 Unit tests
+- `BreezeBuddyTextTransport` frame plumbing (push text → frame appears in queue, output frames fan out to subscribers).
+- `ChatSessionRegistry` idle eviction.
+- Chat-mode strip: `_strip_chat_disabled_functions` and `_strip_chat_disabled_actions` remove voice-only entries (per §8.2) for both flow and direct templates, while leaving voice-mode builds untouched.
+- Template `supported_channels` validation.
+- `flow_state_json` round-trip (snapshot + rehydrate yields equivalent FlowManager state).
+
+### 14.2 Integration tests
+- End-to-end: create session → greeting → 5 user messages crossing 2 node transitions → end → verify webhook fired with correct outcome and full transcript.
+- Resume: create session → 3 turns → simulate eviction → 2 more turns → verify history is correct and FlowManager continues from the right node.
+- Concurrency: parallel POSTs to same session → exactly one succeeds, others get 409.
+- Voice-only action in chat: template with `play_audio_sound` action runs without error, no audio side-effect.
+- Realtime LLM template rejected at chat session creation (400).
+
+### 14.3 Manual smoke
+- Run a real template end-to-end against a local dev server using `curl` for POSTs and `curl -N` for SSE.
+- Run the same template in voice mode (existing path) afterward to confirm no regression.
+
+## 15. Phased Delivery
+
+### Phase 1 (v1) — MVP
+**Scope:** everything in this doc except warm transfer.
+
+Deliverables:
+- Migration 026.
+- DB layer: queries/accessor/decoder for chat tables.
+- `app/ai/voice/agents/breeze_buddy/chat/` module: `agent.py`, `text_transport.py`, `registry.py`, `sse.py`.
+- Adapter in `agent/pipeline.py`: `build_chat_pipeline()`.
+- `template/types.py`: `supported_channels` field; `template/builder.py`: chat-mode handler override map; `warm_transfer` strip.
+- Router: `api/routers/breeze_buddy/chat.py` with the 5 endpoints.
+- Schemas: `schemas/breeze_buddy/chat.py`.
+- Outcome webhook reuse with `channel: "web"`.
+- Tests per §14.
+- Doc: this file kept current; update `BREEZE_BUDDY_ARCHITECTURE.md` with a chat-mode pointer.
+
+**Exit criteria:** A merchant can author a template with `supported_channels: ["voice", "chat"]`, create a chat session via API, hold a multi-turn conversation with token streaming and function calls, disconnect and resume, and receive an outcome webhook on session end.
+
+### Phase 2 — Warm Transfer to Human Chat Agent
+**Scope:** real text-to-text human handoff.
+
+Deliverables:
+- Human-agent identity model (which clairvoyance users are "chat agents," presence/availability).
+- Inbox API: list pending transfer requests, accept, decline.
+- Relay: post-handoff messages route between user and human; the LLM steps out (or stays as copilot — design decision in Phase 2 kickoff).
+- New session lifecycle states: `TRANSFER_PENDING`, `TRANSFERRED`.
+- `warm_transfer` handler implemented for chat (currently stripped).
+- Loom UI: agent inbox + chat handoff UX.
+
+**Open design questions for Phase 2:**
+- AI as silent observer post-handoff vs full disengagement?
+- Routing rules (round-robin, skill-based, last-touched-by)?
+- Concurrent agent capacity limits?
+
+### Phase 3 — Additional Channels
+**Scope:** WhatsApp first (most-requested), then SMS/Slack as needed.
+
+What changes:
+- Channel-specific webhook receivers (incoming message → push to existing chat infrastructure).
+- Channel-specific outbound senders (WhatsApp Business API / Twilio Messaging API / Slack API).
+- Outbound chat (proactive first-message) becomes a real requirement here.
+- Async semantics: a "session" may span days; idle timeout becomes much longer; in-memory registry becomes mostly cache, DB becomes canonical.
+- Per-channel formatting (markdown vs WhatsApp-flavored).
+
+### Phase 4 — Performance & Scale
+Triggers (any of these):
+- Sustained 5K+ concurrent active sessions per pod.
+- Postgres write IOPS becomes a bottleneck.
+- Azure connection-rate limits or ephemeral-port exhaustion appear in logs.
+- p99 turn latency creeps up and correlates with TLS handshake counts.
+- Users complain about LLM-stream interruption losing context.
+
+Options to deploy:
+- **Shared `httpx.AsyncClient` for the Azure LLM path.** Each chat turn currently constructs a fresh `AsyncAzureOpenAI` → fresh `httpx.AsyncClient` → fresh TCP+TLS on first request. Sharing a process-wide client across turns saves the 50–200ms handshake on subsequent turns when the pool stays warm (idle timeout ~60–120s upstream) and reduces ephemeral-port / connection churn against the Azure endpoint. Implementation: subclass `AzureLLMService`, override `create_client` to pass `http_client=` into `AsyncAzureOpenAI`, cache the httpx client by `(endpoint, api_version)` in a process-wide dict, close on lifespan shutdown. Roughly ~80 LOC for Azure-only; per-provider abstraction (Vertex / Claude) when those land in chat. Skipped in Phase 1 — measure before building. **Note**: pipecat's `AzureLLMService.create_client` ignores `**kwargs` so injection requires the subclass; out-of-the-box the kwarg won't reach `AsyncAzureOpenAI`.
+- **Redis hot cache** for `chat_message` (write-through). Reduces Postgres read load on rehydration.
+- **Streaming-with-incremental-commit:** persist assistant tokens as they stream so a mid-stream disconnect leaves a partial-but-recoverable transcript.
+- **Per-session sharding** of the registry across pods (consistent hashing) to reduce rehydration churn.
+- **Message-log windowing:** load only the last N messages + a running summary for long sessions. Trivial query change; no schema migration. *(Shipped in Phase 1 as a hard cap via `CHAT_HISTORY_REPLAY_LIMIT`; the "running summary" half remains future work.)*
+
+## 16. File Inventory (current state — post pipeline-removal rewrite)
+
+Chat-specific code (`app/ai/voice/agents/breeze_buddy/chat/`):
+```
+__init__.py        # package marker
+agent.py           # ChatAgent.run_turn — single async loop; ~150 LOC
+llm_driver.py      # provider-agnostic streaming + tool-call accumulator
+sse.py             # SSEEvent dataclass + format_sse wire helper (no frame classifier)
+cleanup.py         # idle session sweeper (registered with BackgroundTaskScheduler)
+```
+
+Deleted in the rewrite:
+```
+text_transport.py                            # BreezeBuddyTextTransport, _TextInputProcessor, _TextOutputProcessor
+agent/pipeline.py::build_chat_pipeline()     # text-only pipeline branch
+chat/sse.py::classify_frame, TURN_END        # frame → SSE classifier (driver yields events directly)
+```
+
+Shared template / handler code (unchanged — works in both voice and chat unmodified):
+```
+agents/breeze_buddy/template/{types,builder,transition,hooks,loader,context,vad,interruption,input_collection}.py
+agents/breeze_buddy/handlers/internal/*.py
+agents/breeze_buddy/handlers/transport/http_handler.py
+agents/breeze_buddy/template/global_function.py
+```
+
+Router / DB / schemas (unchanged):
+```
+api/routers/breeze_buddy/chat/{__init__,handlers,rbac}.py
+schemas/breeze_buddy/chat.py
+database/migrations/026_create_chat_session_tables.sql
+database/{queries,accessor,decoder}/breeze_buddy/chat_session.py
+services/redis/locks.py
+```
+
+Deferred (still tracked, unaffected by the rewrite):
+- LLM-generated greeting at cold-start (only `static_greeting` works today)
+- Outcome webhook on session end
+- RTVI envelope events for chat (if loom asks for them)
+- Per-turn LLM metrics (tokens, latency) and structured tool-call persistence — add columns + writers in lockstep when an instrumentation pass lands.
+
+Out-of-repo (loom):
+```
+loom/packages/client-sdk/src/chat/ChatClient.ts
+loom/packages/client-sdk/src/chat/types.ts
+```
+
+## 17. Resolutions to Pre-Coding Open Questions
+
+| # | Question | Resolution |
+|---|---|---|
+| Q1 | ~~Pipecat `BaseTransport` interface + cleanest input frame~~ | **Obsolete after 2026-05-04 rewrite.** Chat no longer uses a transport, an aggregator, or any frame plumbing. The driver pushes user text into an `LLMContext` directly and streams the response from the SDK. See §7.2 + §9. |
+| Q2 | Greeting cost | **Both, with voice-equivalent default.** LLM-generated greeting (current voice behavior) is the default. Optional `static_greeting` field on the template overrides when present, saving one LLM call per session start. See §8.4. |
+| Q3 | Idle TTLs | **Inactivity-based, configurable via dynamic config.** Both timers (in-memory eviction + session-end timeout) reset on every user activity. Stored in `app/core/config/dynamic.py` (Redis-backed runtime config) so product can tune without redeploys. Defaults: `CHAT_IDLE_EVICTION_SECONDS=600` (10 min), `CHAT_SESSION_END_TIMEOUT_SECONDS=3600` (60 min). |
+| Q4 | Outcome enum | **Reuse the voice outcome enum.** No chat-specific values for v1. Additive expansion later if product wants chat-only outcomes. |
+| Q5 | LLM streaming compatibility | **All currently-wired providers stream natively.** Verified in pipecat 1.1: `pipecat/services/{azure,anthropic,google}/llm.py` all extend `pipecat/services/llm_service.py` and yield `LLMTextFrame` chunks during the LLM response. Streaming is the default — no extra config. Block mode is a server-side aggregation (collect all chunks, emit one `assistant_message` SSE event). |
+| Q6 | Lock implementation | **Extract a small reusable helper.** Existing pattern is inlined in `app/core/background_tasks/scheduler.py:121-138` (Redis `SET NX EX`, set-and-forget). Chat needs real acquire/release/extend semantics, so extract `RedisLock` into `app/services/redis/locks.py`. Use compare-and-del Lua script for safe release. See §11.1. |
+| Q7 | Webhook payload shape | **Mirror voice payload, add `channel: "web"`.** Canonical end-of-call shape from `callbacks/service_callback.py`: `{callSid, outcome, attemptCount, transcription (json string), callDuration, orderId, ...extracted_fields}`. Chat uses identical field names with `callSid = chat_session.id`, `attemptCount = 1`, `callDuration = ended_at - created_at`. Adding `channel` is non-breaking for tolerant consumers. Strict-schema validators may reject; document in merchant integration guide that strict consumers should configure a separate webhook URL. |
+
+---
+
+**Sign-off:** doc approved 2026-05-04. Implementation proceeds in the order listed in §16; Phase 1 ends at the §15 exit criteria.
+
+**2026-05-04 rewrite:** chat mode migrated from Pipecat-pipeline-based execution to a direct LLM driver. Voice path untouched. See §4, §7, §9, and §16 for the post-rewrite shape; §3 D3 retains the original decision row marked superseded for historical context.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
     "redis[hiredis]>=5.0.0",
     "nltk",
     "jmespath>=1.1.0",
+    "h2>=4.3.0",
 ]
 
 [project.optional-dependencies]

--- a/scripts/migrate.py
+++ b/scripts/migrate.py
@@ -1,0 +1,249 @@
+#!/usr/bin/env python3
+"""Clairvoyance migration runner.
+
+Applies SQL files from app/database/migrations/ in lexicographic order, tracking
+applied migrations in the `_clairvoyance_migrations` table (separate from the
+nautilus `_migrations` table on the same database).
+
+Subcommands:
+    status              List applied vs pending migrations.
+    up                  Apply all pending migrations (each in its own transaction).
+    mark <files...>     Mark filenames as applied without running their SQL.
+                        Used to bootstrap when the schema already exists.
+    mark --up-to <f>    Mark every migration up to and including <f> as applied.
+
+Connection info comes from .env (POSTGRES_USER/PASSWORD/HOST/PORT/DB). In prod,
+POSTGRES_PASSWORD must already be decrypted before invoking this script.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import hashlib
+import os
+import sys
+from pathlib import Path
+
+import asyncpg
+from dotenv import load_dotenv
+
+load_dotenv()
+
+MIGRATIONS_DIR = (
+    Path(__file__).resolve().parent.parent / "app" / "database" / "migrations"
+)
+TRACKING_TABLE = "_clairvoyance_migrations"
+
+CREATE_TRACKING_TABLE = f"""
+CREATE TABLE IF NOT EXISTS {TRACKING_TABLE} (
+    id          SERIAL PRIMARY KEY,
+    filename    TEXT NOT NULL UNIQUE,
+    checksum    TEXT NOT NULL,
+    applied_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+"""
+
+
+def list_migration_files() -> list[Path]:
+    return sorted(MIGRATIONS_DIR.glob("*.sql"))
+
+
+def file_checksum(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+async def get_pool() -> asyncpg.Pool:
+    return await asyncpg.create_pool(
+        user=os.environ["POSTGRES_USER"],
+        password=os.environ["POSTGRES_PASSWORD"],
+        database=os.environ["POSTGRES_DB"],
+        host=os.environ["POSTGRES_HOST"],
+        port=int(os.environ.get("POSTGRES_PORT", "5432")),
+        min_size=1,
+        max_size=2,
+    )
+
+
+async def fetch_applied(conn: asyncpg.Connection) -> dict[str, str]:
+    rows = await conn.fetch(f"SELECT filename, checksum FROM {TRACKING_TABLE};")
+    return {r["filename"]: r["checksum"] for r in rows}
+
+
+def _checksum_drift(
+    files: list[Path], applied: dict[str, str]
+) -> list[tuple[str, str, str]]:
+    """Return ``[(filename, stored_checksum, current_checksum), ...]`` for any
+    already-applied migration whose on-disk file no longer matches the
+    checksum recorded at apply time."""
+    drift: list[tuple[str, str, str]] = []
+    for f in files:
+        stored = applied.get(f.name)
+        if stored is None:
+            continue
+        current = file_checksum(f)
+        if stored != current:
+            drift.append((f.name, stored, current))
+    return drift
+
+
+async def cmd_status() -> int:
+    pool = await get_pool()
+    try:
+        async with pool.acquire() as conn:
+            await conn.execute(CREATE_TRACKING_TABLE)
+            applied = await fetch_applied(conn)
+        files = list_migration_files()
+        pending = [f for f in files if f.name not in applied]
+        drift = _checksum_drift(files, applied)
+        print(f"Applied: {len(applied)}    Pending: {len(pending)}\n")
+        for f in files:
+            tag = "applied" if f.name in applied else "PENDING"
+            print(f"  {tag:8}  {f.name}")
+        if drift:
+            print(
+                "\nWARNING: checksum drift detected on already-applied migrations:",
+                file=sys.stderr,
+            )
+            for name, stored, current in drift:
+                print(
+                    f"  {name}: stored={stored[:12]}... disk={current[:12]}...",
+                    file=sys.stderr,
+                )
+            print(
+                "  Edit applied migration files only with extreme care; the "
+                "SQL was already executed.",
+                file=sys.stderr,
+            )
+        return 0
+    finally:
+        await pool.close()
+
+
+async def cmd_up() -> int:
+    pool = await get_pool()
+    try:
+        async with pool.acquire() as conn:
+            await conn.execute(CREATE_TRACKING_TABLE)
+            applied = await fetch_applied(conn)
+            files = list_migration_files()
+
+            # Refuse to proceed if a previously-applied SQL file has been
+            # edited since it was first run. The DB state is whatever the
+            # original SQL produced; reconciling that with the new file
+            # needs human attention, not a silent skip that lets envs drift.
+            drift = _checksum_drift(files, applied)
+            if drift:
+                print(
+                    "error: checksum drift on already-applied migrations:",
+                    file=sys.stderr,
+                )
+                for name, stored, current in drift:
+                    print(
+                        f"  {name}: stored={stored[:12]}... disk={current[:12]}...",
+                        file=sys.stderr,
+                    )
+                print(
+                    "Revert the file or write a new migration; do not edit "
+                    "applied SQL.",
+                    file=sys.stderr,
+                )
+                return 1
+
+            pending = [f for f in files if f.name not in applied]
+            if not pending:
+                print("Nothing to do.")
+                return 0
+            for f in pending:
+                print(f"Applying {f.name}...", end=" ", flush=True)
+                sql = f.read_text()
+                checksum = file_checksum(f)
+                async with conn.transaction():
+                    await conn.execute(sql)
+                    await conn.execute(
+                        f"INSERT INTO {TRACKING_TABLE} (filename, checksum) "
+                        "VALUES ($1, $2)",
+                        f.name,
+                        checksum,
+                    )
+                print("OK")
+            print(f"\nApplied {len(pending)} migration(s).")
+        return 0
+    finally:
+        await pool.close()
+
+
+async def cmd_mark(filenames: list[str]) -> int:
+    if not filenames:
+        print("error: provide filenames or --up-to", file=sys.stderr)
+        return 2
+    pool = await get_pool()
+    try:
+        async with pool.acquire() as conn:
+            await conn.execute(CREATE_TRACKING_TABLE)
+            for name in filenames:
+                path = MIGRATIONS_DIR / name
+                if not path.exists():
+                    print(
+                        f"  skip {name} (not found in {MIGRATIONS_DIR})",
+                        file=sys.stderr,
+                    )
+                    continue
+                await conn.execute(
+                    f"INSERT INTO {TRACKING_TABLE} (filename, checksum) "
+                    "VALUES ($1, $2) ON CONFLICT (filename) DO NOTHING",
+                    name,
+                    file_checksum(path),
+                )
+                print(f"  marked {name}")
+        return 0
+    finally:
+        await pool.close()
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    sub = p.add_subparsers(dest="cmd", required=True)
+    sub.add_parser("status", help="List applied vs pending migrations")
+    sub.add_parser("up", help="Apply all pending migrations")
+    m = sub.add_parser(
+        "mark",
+        help="Mark migrations as applied without running their SQL",
+    )
+    m.add_argument("filenames", nargs="*", help="Filenames to mark as applied")
+    m.add_argument(
+        "--up-to",
+        dest="up_to",
+        help="Mark every migration up to and including this filename",
+    )
+    return p.parse_args()
+
+
+async def main() -> int:
+    args = parse_args()
+    if args.cmd == "status":
+        return await cmd_status()
+    if args.cmd == "up":
+        return await cmd_up()
+    if args.cmd == "mark":
+        if args.up_to:
+            target = args.up_to
+            files = list_migration_files()
+            names: list[str] = []
+            for f in files:
+                names.append(f.name)
+                if f.name == target:
+                    return await cmd_mark(names)
+            print(
+                f"error: --up-to filename not found in migrations dir: {target}",
+                file=sys.stderr,
+            )
+            return 1
+        return await cmd_mark(args.filenames)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(main()))

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -35,4 +35,14 @@ uv sync --extra dev
 echo "Checking pipecat version..."
 uv run python -c "import pipecat; print(f'pipecat-ai version: {pipecat.__version__}')"
 
+# Run pending DB migrations if .env is present.
+# Safe to skip if the DB isn't reachable yet — the runner will surface a clear error
+# and the user can re-run `uv run python scripts/migrate.py up` after configuring it.
+if [ -f .env ]; then
+  echo "Running pending DB migrations..."
+  uv run python scripts/migrate.py up || echo "⚠️  Migrations did not complete. Check POSTGRES_* in .env and run 'uv run python scripts/migrate.py up' once your DB is reachable."
+else
+  echo "ℹ️  No .env found — skipping migrations. Copy .env.example to .env, fill POSTGRES_*, then run 'uv run python scripts/migrate.py up'."
+fi
+
 echo "✅ Setup complete!"

--- a/uv.lock
+++ b/uv.lock
@@ -694,6 +694,7 @@ dependencies = [
     { name = "google-auth" },
     { name = "google-cloud-storage", version = "3.4.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
     { name = "google-cloud-storage", version = "3.9.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
+    { name = "h2" },
     { name = "jmespath" },
     { name = "langfuse" },
     { name = "loguru" },
@@ -737,6 +738,7 @@ requires-dist = [
     { name = "fastapi", specifier = "==0.115.12" },
     { name = "google-auth", specifier = ">=2.17.0" },
     { name = "google-cloud-storage", specifier = ">=2.10.0" },
+    { name = "h2", specifier = ">=4.3.0" },
     { name = "isort", marker = "extra == 'dev'" },
     { name = "jmespath", specifier = ">=1.1.0" },
     { name = "langfuse" },
@@ -1352,6 +1354,19 @@ wheels = [
 ]
 
 [[package]]
+name = "h2"
+version = "4.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "hpack" },
+    { name = "hyperframe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1d/17/afa56379f94ad0fe8defd37d6eb3f89a25404ffc71d4d848893d270325fc/h2-4.3.0.tar.gz", hash = "sha256:6c59efe4323fa18b47a632221a1888bd7fde6249819beda254aeca909f221bf1", size = 2152026, upload-time = "2025-08-23T18:12:19.778Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/b2/119f6e6dcbd96f9069ce9a2665e0146588dc9f88f29549711853645e736a/h2-4.3.0-py3-none-any.whl", hash = "sha256:c438f029a25f7945c69e0ccf0fb951dc3f73a5f6412981daee861431b70e2bdd", size = 61779, upload-time = "2025-08-23T18:12:17.779Z" },
+]
+
+[[package]]
 name = "hf-xet"
 version = "1.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1454,6 +1469,15 @@ wheels = [
 ]
 
 [[package]]
+name = "hpack"
+version = "4.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/48/71de9ed269fdae9c8057e5a4c0aa7402e8bb16f2c6e90b3aa53327b113f8/hpack-4.1.0.tar.gz", hash = "sha256:ec5eca154f7056aa06f196a557655c5b009b382873ac8d1e66e79e87535f1dca", size = 51276, upload-time = "2025-01-22T21:44:58.347Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/c6/80c95b1b2b94682a72cbdbfb85b81ae2daffa4291fbfa1b1464502ede10d/hpack-4.1.0-py3-none-any.whl", hash = "sha256:157ac792668d995c657d93111f46b4535ed114f0c9c8d672271bbec7eae1b496", size = 34357, upload-time = "2025-01-22T21:44:56.92Z" },
+]
+
+[[package]]
 name = "httpcore"
 version = "1.0.9"
 source = { registry = "https://pypi.org/simple" }
@@ -1509,6 +1533,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c4/fc/eb9bc06130e8bbda6a616e1b80a7aa127681c448d6b49806f61db2670b61/huggingface_hub-1.4.1.tar.gz", hash = "sha256:b41131ec35e631e7383ab26d6146b8d8972abc8b6309b963b306fbcca87f5ed5", size = 642156, upload-time = "2026-02-06T09:20:03.013Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d5/ae/2f6d96b4e6c5478d87d606a1934b5d436c4a2bce6bb7c6fdece891c128e3/huggingface_hub-1.4.1-py3-none-any.whl", hash = "sha256:9931d075fb7a79af5abc487106414ec5fba2c0ae86104c0c62fd6cae38873d18", size = 553326, upload-time = "2026-02-06T09:20:00.728Z" },
+]
+
+[[package]]
+name = "hyperframe"
+version = "6.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/02/e7/94f8232d4a74cc99514c13a9f995811485a6903d48e5d952771ef6322e30/hyperframe-6.1.0.tar.gz", hash = "sha256:f630908a00854a7adeabd6382b43923a4c4cd4b821fcb527e6ab9e15382a3b08", size = 26566, upload-time = "2025-01-22T21:41:49.302Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/48/30/47d0bf6072f7252e6521f3447ccfa40b421b6824517f82854703d0f5a98b/hyperframe-6.1.0-py3-none-any.whl", hash = "sha256:b03380493a519fce58ea5af42e4a42317bf9bd425596f7a0835ffce80f1a42e5", size = 13007, upload-time = "2025-01-22T21:41:47.295Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adds a chat (text) channel that reuses the same template + FlowManager + LLM stack as voice, swapping audio I/O for text frames.

- **Stateless per turn**: each `POST /message` builds a fresh `ChatAgent`, replays history from DB into `LLMContext`, drives one turn via `run_turn`, tears down. No in-memory registry, no sticky LB.
- **Per-session `RedisLock`** (180s TTL, no auto-extend) wraps the entire turn — single mutual-exclusion primitive across pods.
- **Idle session cleanup** is one task on the global `BackgroundTaskScheduler` (`chat/cleanup.py`); the scheduler's distributed lock keeps it single-pod-per-tick.
- **Templates opt in** via `supported_channels: ["voice", "chat"]`; chat agents construct the builder with `disabled_names=CHAT_DISABLED_NAMES` to strip voice-only functions/actions (`mute_stt`, `play_audio_sound`, `warm_transfer`, `end_conversation`, ...).

## What's in this PR

- **Chat agent + transport** — `app/ai/voice/agents/breeze_buddy/chat/` (`agent.py`, `sse.py`, `llm_driver.py`, `cleanup.py`, `disabled.py`)
- **Chat router + RBAC** — `app/api/routers/breeze_buddy/chat/`
- **Schema** — migration `026_create_chat_session_tables.sql`, accessor/decoder/queries under `app/database/*/breeze_buddy/chat_session.py`, Pydantic models in `app/schemas/breeze_buddy/chat.py`
- **Per-session Redis lock primitive** — `app/services/redis/locks.py`
- **Template extras** — `template/cache.py` (cache layer), `template/utils.py` (extracted `render_messages_with_vars` for voice/chat reuse), `supported_channels` in `template/types.py`
- **LLM pools refactor** — `app/ai/voice/llm/_pools.py`, plus updates to `azure.py` and `claude_vertex.py`
- **Tooling/docs** — `scripts/migrate.py` migration runner, `docs/CHAT_MODE.md` architecture spec, `CLAUDE.md` chat-mode section

## Test plan

- [ ] Run migration `026` against a dev DB (`scripts/migrate.py`)
- [ ] Create a template with `supported_channels: ["voice", "chat"]`
- [ ] `POST /message` end-to-end smoke test — confirm SSE stream emits `user_committed`, `assistant_token`, `function_call_started/completed`, `node_transition`
- [ ] Concurrent requests against the same session_id are serialized by the per-session Redis lock (second request blocks until first releases)
- [ ] Voice-only functions (warm_transfer, end_conversation, mute_stt, play_audio_sound) absent from the LLM tool list in chat mode
- [ ] Idle cleanup task purges stale chat_session rows on a single pod per tick (no double-purge across pods)
- [ ] Voice flows still work — verify a voice template build/run is unaffected by the shared `template/utils.py` extraction and `_pools.py` refactor
- [ ] CI green: black, isort, autoflake, pyrefly, single-commit check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Breeze Buddy Chat mode: text-based conversations via REST/SSE API
  * Chat session management: create, send messages, end sessions, export transcripts
  * Automatic idle session cleanup with configurable timeout
  * Per-session distributed locking for safe concurrent access

* **Improvements**
  * Added LLM connection pooling for improved chat performance
  * Templates now support opt-in to chat mode via `supported_channels`

* **Documentation**
  * Added comprehensive Chat Mode architecture guide

<!-- end of auto-generated comment: release notes by coderabbit.ai -->