### PR TITLE
feat(breeze_buddy): normalize lead_call_tracker outcomes to UPPERCASE

### DIFF
--- a/app/database/migrations/026_normalize_outcomes_to_uppercase.sql
+++ b/app/database/migrations/026_normalize_outcomes_to_uppercase.sql
@@ -1,0 +1,13 @@
+-- Migration 026: Normalize lead_call_tracker.outcome values to UPPERCASE.
+-- All Clairvoyance code uses UPPERCASE outcome literals; this backfills any
+-- historical rows where a bypass path may have written lowercase.
+-- Going forward, the DB query layer enforces UPPER() at INSERT/UPDATE time.
+
+BEGIN;
+
+UPDATE lead_call_tracker
+SET outcome = UPPER(outcome)
+WHERE outcome IS NOT NULL
+  AND outcome <> UPPER(outcome);
+
+COMMIT;

--- a/app/database/queries/breeze_buddy/lead_call_tracker.py
+++ b/app/database/queries/breeze_buddy/lead_call_tracker.py
@@ -97,7 +97,7 @@ def insert_lead_call_tracker_query(
         call_id,
         outbound_number_id,
         call_direction.value,
-        outcome,
+        outcome.upper() if outcome else None,
         datetime.now(),
         datetime.now(),
     ]
@@ -330,7 +330,7 @@ def update_lead_call_completion_details_query(
         set_clauses.append(f'"status" = ${len(values)}')
 
     if outcome is not None:
-        values.append(outcome)
+        values.append(outcome.upper())
         set_clauses.append(f'"outcome" = ${len(values)}')
 
     if meta_data is not None:


### PR DESCRIPTION
  - Apply .upper() on outcome at insert/update in lead_call_tracker.py
  - Add migration 026 to backfill any existing lowercase rows

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Lead call tracker outcome values are now consistently normalized to uppercase across new entries and existing data for uniform formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->