### PR TITLE
feat(chat): MCP support with per-template Redis-cached tool discovery

### DIFF
--- a/app/ai/voice/agents/breeze_buddy/chat/agent.py
+++ b/app/ai/voice/agents/breeze_buddy/chat/agent.py
@@ -17,6 +17,7 @@ from pipecat_flows import FlowsFunctionSchema
 from app.ai.voice.agents.breeze_buddy.chat import llm_driver
 from app.ai.voice.agents.breeze_buddy.chat.disabled import CHAT_DISABLED_NAMES
 from app.ai.voice.agents.breeze_buddy.chat.sse import SSEEvent
+from app.ai.voice.agents.breeze_buddy.mcp import get_mcp_global_functions_cached
 from app.ai.voice.agents.breeze_buddy.template.builder import FlowConfigBuilder
 from app.ai.voice.agents.breeze_buddy.template.context import with_context
 from app.ai.voice.agents.breeze_buddy.template.types import TemplateModel
@@ -117,6 +118,25 @@ class ChatAgent:
         global_funcs: List[FlowsFunctionSchema] = flow_builder.build_global_functions(
             self.template.flow, bot_instance=self
         )
+
+        # Append MCP tools (no CHAT_DISABLED_NAMES filtering — MCP names are
+        # external/dynamic and never overlap the voice-only set). Discovery
+        # is cached per (template_id, URL hash) in Redis with a 300s TTL,
+        # so the list_tools round-trip happens at most once per template
+        # per TTL window across the whole pod fleet — not per turn.
+        mcp_config = (
+            self.template.configurations.mcp if self.template.configurations else None
+        )
+        if mcp_config and mcp_config.servers:
+            mcp_funcs = await get_mcp_global_functions_cached(
+                mcp_config, self.template_vars, self.template.id
+            )
+            existing_names = {fn.name for fn in global_funcs}
+            unique = [fn for fn in mcp_funcs if fn.name not in existing_names]
+            global_funcs.extend(unique)
+            logger.info(
+                f"[BUDDY_MCP] chat: added {len(unique)} MCP tools as global functions"
+            )
 
         node = self._resolve_node(flow_config, current_node)
         node_name = cast(str, node["name"])

--- a/app/ai/voice/agents/breeze_buddy/mcp/__init__.py
+++ b/app/ai/voice/agents/breeze_buddy/mcp/__init__.py
@@ -14,6 +14,7 @@ from pipecat.services.llm_service import (
 from pipecat.services.mcp_service import MCPClient
 from pipecat_flows.types import FlowResult, FlowsFunctionSchema
 
+from app.ai.voice.agents.breeze_buddy.mcp.cache import get_or_discover_server_tools
 from app.ai.voice.agents.breeze_buddy.template.types import (
     HttpAuthType,
     McpConfig,
@@ -70,7 +71,7 @@ def _create_mcp_tool_handler(
     return handler
 
 
-def _resolve_placeholders(value: str, template_vars: Dict[str, str]) -> str:
+def _resolve_placeholders(value: str, template_vars: Dict[str, Any]) -> str:
     """Substitute {variable} placeholders in a string using template_vars.
 
     Uses single-pass regex substitution to prevent cascading substitution
@@ -90,7 +91,7 @@ def _resolve_placeholders(value: str, template_vars: Dict[str, str]) -> str:
 
 def _build_auth_headers(
     server: McpServerConfig,
-    template_vars: Dict[str, str],
+    template_vars: Dict[str, Any],
 ) -> Dict[str, str]:
     """Resolve auth config into HTTP headers, substituting {variable} placeholders."""
     if not server.auth or server.auth.type == HttpAuthType.NONE:
@@ -117,6 +118,38 @@ def _build_auth_headers(
     return {}
 
 
+def _build_server_params(
+    server: McpServerConfig,
+    template_vars: Dict[str, Any],
+) -> StreamableHttpParameters:
+    """Resolve a server config + template_vars into StreamableHttpParameters.
+
+    Shared by the voice loader (per-call clients) and the chat session pool
+    (per-turn persistent clients). Substitutes ``{variable}`` placeholders in
+    the URL and auth fields from ``template_vars``.
+    """
+    resolved_url = _resolve_placeholders(server.url, template_vars)
+    if resolved_url != server.url:
+        # Don't log the resolved URL — it can contain customer-identifying
+        # values (e.g. shop subdomain). Operators can correlate via the
+        # stable label logged at the call site.
+        logger.debug(
+            f"[BUDDY_MCP] Resolved URL placeholder for server {server.name or '<unnamed>'!r}"
+        )
+
+    headers: Dict[str, str] = {"Content-Type": "application/json"}
+    headers.update(server.headers)  # static headers from config
+    headers.update(_build_auth_headers(server, template_vars))  # auth headers
+
+    return StreamableHttpParameters(
+        url=resolved_url,
+        headers=headers,
+        timeout=timedelta(seconds=server.timeout),
+        sse_read_timeout=timedelta(seconds=server.timeout),
+        terminate_on_close=True,
+    )
+
+
 async def _load_server_tools(
     server: McpServerConfig,
     template_vars: Dict[str, str],
@@ -136,28 +169,12 @@ async def _load_server_tools(
 
     Each tool handler creates a fresh MCPClient per invocation for thread safety.
     """
-    # Resolve {variable} placeholders in the URL from template_vars.
-    # This allows dynamic MCP URLs such as https://{shop_url}/ai/mcp.
-    resolved_url = _resolve_placeholders(server.url, template_vars)
-    if resolved_url != server.url:
-        logger.info(
-            f"[BUDDY_MCP] Resolved MCP URL placeholder: {server.url!r} -> {resolved_url!r}"
-        )
-
-    label = server.name or resolved_url
+    server_params = _build_server_params(server, template_vars)
+    # Prefer the stable name; fall back to the raw template URL (with
+    # placeholders) rather than the resolved URL to avoid logging
+    # customer-identifying substitutions.
+    label = server.name or server.url
     logger.info(f"[BUDDY_MCP] Connecting to {label}")
-
-    headers: Dict[str, str] = {"Content-Type": "application/json"}
-    headers.update(server.headers)  # static headers from config
-    headers.update(_build_auth_headers(server, template_vars))  # auth headers
-
-    server_params = StreamableHttpParameters(
-        url=resolved_url,
-        headers=headers,
-        timeout=timedelta(seconds=server.timeout),
-        sse_read_timeout=timedelta(seconds=server.timeout),
-        terminate_on_close=True,
-    )
 
     # Use a temporary client just to fetch the tools schema
     async with MCPClient(server_params=server_params) as temp_client:
@@ -182,6 +199,9 @@ async def _load_server_tools(
                 handler=_create_mcp_tool_handler(server_params, func_schema.name),
             )
         )
+        # Track the chosen name so a subsequent tool from the same server
+        # with a duplicate name also gets prefixed.
+        existing_names.add(tool_name)
         logger.info(f"[BUDDY_MCP] Registered tool: {tool_name} (from {label})")
 
     logger.info(f"[BUDDY_MCP] Loaded {len(functions)} tools from {label}")
@@ -211,10 +231,78 @@ async def get_mcp_global_functions(
             )
             tools = await asyncio.shield(task)
             all_functions.extend(tools)
-        except BaseException as e:
+        except Exception as e:
             logger.error(
                 f"[BUDDY_MCP] Failed to load tools from {label}, skipping: {type(e).__name__}: {e}"
             )
 
     logger.info(f"[BUDDY_MCP] Total tools loaded: {len(all_functions)}")
+    return all_functions
+
+
+async def get_mcp_global_functions_cached(
+    mcp_config: McpConfig,
+    template_vars: Dict[str, Any],
+    template_id: str,
+) -> List[FlowsFunctionSchema]:
+    """Cache-aware variant for chat mode.
+
+    Reads tool metadata from Redis (per-template + URL hash, see
+    ``mcp/cache.py``) and rebuilds ``FlowsFunctionSchema`` using the same
+    ``_create_mcp_tool_handler`` voice uses (per-invocation MCPClient — no
+    private API, no shared session). Auth headers are rebuilt from
+    ``template_vars`` on every call so credential rotation takes effect on
+    the next turn without cache invalidation.
+    """
+    all_functions: List[FlowsFunctionSchema] = []
+
+    for server in mcp_config.servers:
+        if not server.enabled:
+            continue
+
+        try:
+            server_params = _build_server_params(server, template_vars)
+        except Exception as e:
+            logger.error(
+                f"[BUDDY_MCP] chat: failed to build server params for "
+                f"{server.name or server.url}: {type(e).__name__}: {e}"
+            )
+            continue
+
+        # Stable label: prefer server.name; fall back to the raw template
+        # URL (placeholder form) rather than the resolved URL.
+        label = server.name or server.url
+        try:
+            tools_meta = await get_or_discover_server_tools(
+                template_id=template_id,
+                server=server,
+                server_params=server_params,
+            )
+        except Exception as e:
+            logger.error(
+                f"[BUDDY_MCP] chat: failed to load tools from {label}, "
+                f"skipping: {type(e).__name__}: {e}"
+            )
+            continue
+
+        existing_names = {f.name for f in all_functions}
+        for meta in tools_meta:
+            tool_name = meta["name"]
+            if tool_name in existing_names and server.name:
+                tool_name = f"{server.name}_{tool_name}"
+            all_functions.append(
+                FlowsFunctionSchema(
+                    name=tool_name,
+                    description=meta["description"],
+                    properties=meta["properties"],
+                    required=meta["required"],
+                    handler=_create_mcp_tool_handler(server_params, meta["name"]),
+                )
+            )
+            existing_names.add(tool_name)
+            logger.debug(
+                f"[BUDDY_MCP] chat: registered tool: {tool_name} (from {label})"
+            )
+
+    logger.info(f"[BUDDY_MCP] chat: total tools loaded: {len(all_functions)}")
     return all_functions

--- a/app/ai/voice/agents/breeze_buddy/mcp/cache.py
+++ b/app/ai/voice/agents/breeze_buddy/mcp/cache.py
@@ -1,0 +1,146 @@
+"""Redis cache for MCP tool discovery.
+
+MCP ``list_tools`` is an HTTP round-trip to the configured server. Without
+caching, every chat ``/message`` would pay this cost per server. The cache
+keys per ``(template_id, server-identity-hash)`` so all sessions of the
+same template + same resolved URL share one discovery for the TTL window.
+
+What's cached: only the public tool metadata (name, description, input
+schema). Auth credentials are NOT in the key or in the value — they're
+rebuilt per turn from ``template_vars`` (loaded fresh from the credentials
+table). Credential rotation therefore takes effect on the next turn with
+no cache invalidation.
+
+Best-effort: Redis errors fall through to live discovery so cache outages
+don't break MCP tool availability.
+"""
+
+import asyncio
+import hashlib
+import json
+from typing import Any, Dict, List, TypedDict
+
+from mcp.client.session_group import StreamableHttpParameters
+from pipecat.services.mcp_service import MCPClient
+
+from app.ai.voice.agents.breeze_buddy.template.types import McpServerConfig
+from app.core.logger import logger
+from app.services.redis.client import get_redis_service, is_redis_configured
+
+CACHE_TTL_SECONDS = 300
+_KEY_PREFIX = "bb:mcp:tools:"
+
+
+class ToolMeta(TypedDict):
+    """Cached tool metadata. Mirrors FunctionSchema's public fields."""
+
+    name: str
+    description: str
+    properties: Dict[str, Any]
+    required: List[str]
+
+
+def _cache_key(
+    template_id: str,
+    server: McpServerConfig,
+    server_params: StreamableHttpParameters,
+) -> str:
+    """Hash the inputs that determine *which tools the server returns*.
+
+    Auth is intentionally excluded — different credentials against the same
+    server return the same tools schema, so they should share a cache entry.
+    """
+    label = server.name or ""
+    headers_json = json.dumps(server.headers, sort_keys=True)
+    raw = f"{label}|{server_params.url}|{server.timeout}|{headers_json}"
+    digest = hashlib.sha256(raw.encode()).hexdigest()[:16]
+    return f"{_KEY_PREFIX}{template_id}:{digest}"
+
+
+_REQUIRED_TOOL_FIELDS = ("name", "description", "properties", "required")
+
+
+def _is_valid_tools_payload(decoded: Any) -> bool:
+    """Reject malformed cache entries before they reach the call site.
+
+    Downstream callers index ``meta["name"]`` etc. unconditionally, so a
+    half-formed entry would raise mid-iteration and skip the whole server.
+    Validate shape here and force a re-discover instead.
+    """
+    if not isinstance(decoded, list):
+        return False
+    return all(
+        isinstance(item, dict) and all(field in item for field in _REQUIRED_TOOL_FIELDS)
+        for item in decoded
+    )
+
+
+async def _live_discovery(
+    server_params: StreamableHttpParameters, timeout: int
+) -> List[ToolMeta]:
+    """Open a fresh MCPClient, fetch tools schema, return JSON-friendly metadata."""
+    async with MCPClient(server_params=server_params) as client:
+        tools_schema = await asyncio.wait_for(
+            client.get_tools_schema(),
+            timeout=timeout,
+        )
+    return [
+        ToolMeta(
+            name=fn.name,
+            description=fn.description,
+            properties=fn.properties,
+            required=list(fn.required),
+        )
+        for fn in tools_schema.standard_tools
+    ]
+
+
+async def get_or_discover_server_tools(
+    template_id: str,
+    server: McpServerConfig,
+    server_params: StreamableHttpParameters,
+) -> List[ToolMeta]:
+    """Return cached tools metadata, or discover via MCP and populate cache.
+
+    Falls through to live discovery if Redis is unconfigured or
+    misbehaving. Discovery failures propagate so the caller can decide
+    whether to skip the server.
+    """
+    if not is_redis_configured():
+        return await _live_discovery(server_params, server.timeout)
+
+    key = _cache_key(template_id, server, server_params)
+    redis = await get_redis_service()
+
+    try:
+        cached = await redis.get(key)
+    except Exception as exc:
+        logger.warning(f"[BUDDY_MCP] cache GET failed for {key}: {exc}")
+        cached = None
+
+    if cached is not None:
+        try:
+            decoded = json.loads(cached)
+            if _is_valid_tools_payload(decoded):
+                logger.debug(f"[BUDDY_MCP] cache hit: {key} ({len(decoded)} tool(s))")
+                return decoded
+            logger.warning(
+                f"[BUDDY_MCP] cache payload for {key} failed shape check, refetching"
+            )
+        except Exception as exc:
+            logger.warning(
+                f"[BUDDY_MCP] cache decode failed for {key}, refetching: {exc}"
+            )
+
+    tools = await _live_discovery(server_params, server.timeout)
+
+    try:
+        await redis.setex(key, json.dumps(tools), ttl_seconds=CACHE_TTL_SECONDS)
+        logger.info(f"[BUDDY_MCP] cache populated: {key} ({len(tools)} tool(s))")
+    except Exception as exc:
+        logger.warning(f"[BUDDY_MCP] cache SET failed for {key}: {exc}")
+
+    return tools
+
+
+__all__ = ["CACHE_TTL_SECONDS", "ToolMeta", "get_or_discover_server_tools"]


### PR DESCRIPTION
## Summary

Wires the voice MCP integration (#687) into chat/text mode. To avoid paying the \`list_tools\` round-trip on every \`/message\`, MCP tool discovery is cached in Redis per **(template_id, server-URL hash)** with a 300s TTL, shared across all sessions of the same template + URL across the whole pod fleet.

## Design

- **Cache key**: \`bb:mcp:tools:{template_id}:{sha256_short(server.name|resolved_url|timeout|static_headers)}\` — hashes only the inputs that determine *which* tools the server returns. Auth is intentionally excluded from the key.
- **Cache value**: list of public tool metadata only (name, description, properties, required). **No auth credentials in Redis.**
- **TTL**: 300s (module-level constant in \`cache.py\`; not currently env-configurable — bump to env var if it needs tuning per environment).
- **Auth flow**: rebuilt per-turn from \`template_vars\` (loaded fresh from credentials table on every turn). Credential rotation takes effect on the next turn — no cache invalidation needed.
- **Best-effort**: Redis errors fall through to live discovery so cache outages don't break MCP tool availability. Cache decode failures and shape-mismatch entries also re-fetch.

The first \`/message\` on a fresh template + URL pays the discovery round-trip; subsequent turns (and other sessions on the same template + URL) hit the cache for the rest of the TTL window.

## Changes

- **\`mcp/cache.py\`** (new): \`get_or_discover_server_tools()\` — Redis-backed; on miss opens \`MCPClient\`, calls \`list_tools\`, populates cache. Validates per-element shape on read.
- **\`mcp/__init__.py\`**:
  - Extract \`_build_server_params\` helper shared with voice's \`_load_server_tools\`.
  - Add \`get_mcp_global_functions_cached(mcp_config, template_vars, template_id)\` for chat — uses cache + reuses voice's \`_create_mcp_tool_handler\` (per-invocation \`MCPClient\`, no private API).
  - Widen \`_resolve_placeholders\` and \`_build_auth_headers\` types to \`Dict[str, Any]\` (matches reality — non-string values are skipped).
  - Don't log resolved URLs (customer-identifying); demote placeholder-resolution log to debug; fall back to raw template URL (placeholder form) for the connection log when \`server.name\` is missing.
  - Replace \`except BaseException\` with \`except Exception\` in both voice and chat paths so \`asyncio.CancelledError\` propagates correctly.
  - Update \`existing_names\` after each tool append to handle intra-server duplicate names (was only checked once before the loop).
- **\`chat/agent.py\`**: in \`_run_turn_inner\`, append cached MCP tools to \`global_funcs\` after \`build_global_functions\`. No \`CHAT_DISABLED_NAMES\` filtering for MCP names (external/dynamic, never overlap voice-only set).

## Voice path is touched but behavior-preserving

Voice's \`_load_server_tools\` was refactored to use the new shared \`_build_server_params\` helper. Two small bug fixes that also affect voice:
- \`except BaseException\` → \`except Exception\` (no longer swallows \`CancelledError\`).
- \`existing_names.add(tool_name)\` after append (handles intra-server duplicate tool names — previously, two tools with the same name from a single server would bypass the prefixing check).

## Modes

Works in **both direct mode and node mode** for chat. Integration point is \`build_global_functions\` (which already branches on \`flow.mode\` internally), so MCP tools land correctly:
- Direct mode: synthesized node has empty per-node \`functions\` → globals are the only path.
- Node mode: per-node \`functions\` ∪ globals; MCP available cross-node.

## Test plan

- [ ] Chat session against a Storefront MCP template with \`shop_url\` in payload — verify cache populates on first \`/message\`, subsequent turns hit cache (\`cache hit\` log line at debug level).
- [ ] Multi-tool turn — confirm only one cached schema lookup; tool invocations still open per-call \`MCPClient\`.
- [ ] Multiple sessions on the same template — second session's \`/message\` hits cache directly (no discovery).
- [ ] Credential rotation — update \`{shopify_storefront_token}\`, next turn uses new auth without cache invalidation.
- [ ] Redis down (\`is_redis_configured() = False\` or transient error) — falls through to live discovery, MCP still works.
- [ ] Misconfigured/unreachable MCP server — turn still completes, error logged, other tools remain available.
- [ ] Verify resolved URLs no longer appear in info-level logs (only at debug).
- [ ] Voice path regression — \`/push/lead/v2\` flow with MCP-configured template still works.
- [ ] Direct-mode template with MCP — tools reach the LLM via the synthesized-node path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)