### PR TITLE
fix(templates): allow direct-mode flows in create/replace API handlers

### DIFF
--- a/app/api/routers/breeze_buddy/templates/handlers.py
+++ b/app/api/routers/breeze_buddy/templates/handlers.py
@@ -12,6 +12,7 @@ from fastapi import HTTPException, status
 from app.ai.voice.agents.breeze_buddy.template.cache import invalidate_template
 from app.ai.voice.agents.breeze_buddy.template.types import (
     CreateTemplateRequest,
+    FlowMode,
     ReplaceTemplateRequest,
 )
 from app.ai.voice.agents.breeze_buddy.utils.secrets import (
@@ -65,11 +66,20 @@ async def create_template_handler(
         if not flow:
             raise ValueError("Flow structure is required")
 
-        if "initial_node" not in flow:
-            raise ValueError("initial_node must be specified in flow structure")
-
-        if "nodes" not in flow or not flow["nodes"]:
-            raise ValueError("nodes must be specified in flow structure")
+        # Direct-mode flows have a flat ``system_prompt`` + ``functions`` list
+        # and no ``initial_node`` / ``nodes``. The legacy node-based check
+        # below would reject them despite the runtime supporting them
+        # (``template/builder.py:_build_direct_flow_config``).
+        if flow.get("mode") == FlowMode.DIRECT.value:
+            if "system_prompt" not in flow:
+                raise ValueError(
+                    "system_prompt must be specified in direct-mode flow structure"
+                )
+        else:
+            if "initial_node" not in flow:
+                raise ValueError("initial_node must be specified in flow structure")
+            if "nodes" not in flow or not flow["nodes"]:
+                raise ValueError("nodes must be specified in flow structure")
 
         # Check if template already exists
         existing = await get_template_by_merchant(
@@ -357,16 +367,22 @@ async def replace_template_handler(
             operation="access template",
         )
 
-        # Validate flow structure
+        # Validate flow structure (direct mode has a different shape — see
+        # the create handler for the matching branch).
         flow = template_data.flow
         if not flow:
             raise ValueError("Flow structure is required")
 
-        if "initial_node" not in flow:
-            raise ValueError("initial_node must be specified in flow structure")
-
-        if "nodes" not in flow or not flow["nodes"]:
-            raise ValueError("nodes must be specified in flow structure")
+        if flow.get("mode") == FlowMode.DIRECT.value:
+            if "system_prompt" not in flow:
+                raise ValueError(
+                    "system_prompt must be specified in direct-mode flow structure"
+                )
+        else:
+            if "initial_node" not in flow:
+                raise ValueError("initial_node must be specified in flow structure")
+            if "nodes" not in flow or not flow["nodes"]:
+                raise ValueError("nodes must be specified in flow structure")
 
         # Validate outbound_number_id if provided
         if template_data.outbound_number_id:


### PR DESCRIPTION
## Summary

The \`POST /templates\` and \`PUT /templates/{id}\` handlers unconditionally required \`flow.initial_node\` and \`flow.nodes\` — but direct-mode flows (added in commit \`e225f50\`) use a flat \`system_prompt\` + \`functions\` structure with **neither field**. As a result, direct-mode templates couldn't be created or updated via the API; the only way to land them was a direct DB insert.

The runtime (\`template/builder.py:_build_direct_flow_config\`) supports direct mode end-to-end, so this is a bug in the API validators only.

## Fix

Branch on \`flow.mode\`:

- **Direct mode** (\`flow.mode == \"direct\"\`): require \`system_prompt\` (mirrors the runtime's check at \`builder.py:296\`).
- **Node mode** (default / \`\"flow\"\`): keep the existing \`initial_node\` + \`nodes\` requirement.

Same change applied to both \`create_template_handler\` and \`replace_template_handler\`.

## Discovery

Surfaced when trying to push a chat-mode demo template to prod via the API — got back \`{\"detail\":\"initial_node must be specified in flow structure\"}\` even though the same template ran fine locally (it had been inserted directly into the dev DB, not via the API).

## Test plan

- [ ] \`POST /templates\` with a direct-mode flow (\`{\"mode\":\"direct\",\"system_prompt\":\"...\",\"functions\":[...]}\`) — should now return 201 (was 400 before).
- [ ] \`POST /templates\` with direct mode but no \`system_prompt\` — should return 400 with \`system_prompt must be specified in direct-mode flow structure\`.
- [ ] \`POST /templates\` with a node-mode flow missing \`initial_node\` — still returns 400 with the existing message.
- [ ] \`POST /templates\` with a node-mode flow missing \`nodes\` — still returns 400.
- [ ] \`PUT /templates/{id}\` — same four cases.

## Verification

- \`pyrefly check\`: 0 errors
- \`black\` / \`isort\`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved template validation to ensure flow configurations include required fields based on their mode type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->