### PR TITLE
fix(templates): unwrap SecretStr in configurations dump (create/replace handlers)

### DIFF
--- a/app/api/routers/breeze_buddy/templates/handlers.py
+++ b/app/api/routers/breeze_buddy/templates/handlers.py
@@ -110,10 +110,15 @@ async def create_template_handler(
         # Create the template
         now = datetime.now(timezone.utc)
 
-        # Build configurations dict from the ConfigurationModel
+        # Build configurations dict from the ConfigurationModel.
+        # mode="json" unwraps SecretStr fields (e.g. mcp.servers[*].auth.token)
+        # to their string value so the downstream json.dumps in
+        # ``create_template`` doesn't choke on a SecretStr instance.
         configurations = None
         if template_data.configurations:
-            configurations = template_data.configurations.model_dump(exclude_none=True)
+            configurations = template_data.configurations.model_dump(
+                exclude_none=True, mode="json"
+            )
 
         template = await create_template(
             template_id=str(uuid4()),
@@ -398,11 +403,15 @@ async def replace_template_handler(
         # Update the template
         now = datetime.now(timezone.utc)
 
-        # Build configurations dict from the ConfigurationModel
-        # If configurations is explicitly provided, use it; otherwise set to None (NULL)
+        # Build configurations dict from the ConfigurationModel.
+        # mode="json" unwraps SecretStr fields (e.g. mcp.servers[*].auth.token)
+        # to their string value so the downstream json.dumps in
+        # ``replace_template`` doesn't choke on a SecretStr instance.
         configurations = None
         if template_data.configurations:
-            configurations = template_data.configurations.model_dump(exclude_none=True)
+            configurations = template_data.configurations.model_dump(
+                exclude_none=True, mode="json"
+            )
 
         # Merge secrets: preserve **** values from existing, update real values
         merged_secrets = merge_secrets(


### PR DESCRIPTION
## Summary

Templates whose \`configurations\` contains any \`SecretStr\` field — most importantly \`configurations.mcp.servers[*].auth.token\` introduced in #687 / #742 — couldn't be created or updated via the API. The error surfaced as a generic \`500 Failed to create template\` because the accessor swallows the underlying \`TypeError\`.

The exception under the hood:

\`\`\`
Error creating template: Object of type SecretStr is not JSON serializable
\`\`\`

Root cause in \`templates/handlers.py:115-116\` and \`:407-409\`:

\`\`\`python
configurations = template_data.configurations.model_dump(exclude_none=True)
\`\`\`

Pydantic's default \`model_dump()\` keeps \`SecretStr\` fields as \`SecretStr\` *instances*, not plain strings. The downstream \`json.dumps\` in \`create_template\` / \`replace_template\` then raises.

## Fix

Add \`mode=\"json\"\` so Pydantic emits JSON-compatible types — \`SecretStr\` becomes its underlying string value (the literal placeholder like \`\"{exa_api_key}\"\`, not the real secret; the placeholder resolves at chat-turn time from the credentials table).

Same change applied to both \`create_template_handler\` and \`replace_template_handler\`. Round-trip is safe: when the stored config is later read and re-validated through \`ConfigurationModel\`, Pydantic re-wraps the string into \`SecretStr\` automatically.

## Why this hadn't been caught

Existing direct-mode + MCP templates (e.g. local \`chat-direct-claude\`) were inserted via raw SQL, bypassing this handler. The first attempt to create one through \`POST /templates\` is what surfaced both this and #743.

## Verification (real, end-to-end)

1. Reproduced the \`TypeError\` against \`release\` HEAD with the production payload (\`prod/02_template_create.json\`) — \`create_template\` returned \`None\` → handler returned \`500 Failed to create template\`.
2. Applied this fix; re-ran the same path:
   - **Direct handler call** (\`create_template_handler\`) → 201, template id returned, cleaned up.
   - **Real HTTP POST** through a uvicorn-\`--reload\`-loaded local server → 201, template created and verified to round-trip cleanly:
     \`\`\`
     {\"status\":\"success\",\"template_id\":\"a9baa747-...\",\"message\":\"Template 'http-test-942141' created successfully with 0 nodes\"}
     HTTP 201
     \`\`\`
3. Cleanup: test row deleted from local DB.
4. \`pyrefly check\` 0 errors; \`black\` / \`isort\` clean.

## Stacking with #743

This is a sibling fix to #743 (which let direct-mode payloads past the validator). Both are needed to create the Acme/Exa-MCP demo template via the API. With both merged, \`bash prod/RUNBOOK.sh\` completes through the template-create step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)