### PR TITLE
fix(templates): reveal SecretStr values on JSON persistence (regression from #744)

### DIFF
--- a/app/ai/voice/agents/breeze_buddy/template/cache.py
+++ b/app/ai/voice/agents/breeze_buddy/template/cache.py
@@ -63,9 +63,18 @@ async def get_template_by_id_cached(template_id: str) -> Optional[TemplateModel]
         return None
 
     try:
+        # ``reveal_secrets`` lets HttpAuthConfig's field_serializer (see
+        # template/types.py) emit the underlying string for
+        # ``token``/``password``/``api_key_value`` rather than the masked
+        # ``"**********"`` form. Without it, cache writes would store a
+        # masked auth value, and the next cache HIT would reconstruct
+        # ``SecretStr("**********")`` — runtime would then send
+        # ``Authorization: Bearer **********`` to the upstream server.
+        # The Redis cache is internal/private; the masking only belongs
+        # in API responses, where the lack of context preserves it.
         await redis.setex(
             cache_key,
-            template.model_dump_json(),
+            template.model_dump_json(context={"reveal_secrets": True}),
             ttl_seconds=CACHE_TTL_SECONDS,
         )
         logger.debug(f"template cache populated: {template_id}")

--- a/app/ai/voice/agents/breeze_buddy/template/types.py
+++ b/app/ai/voice/agents/breeze_buddy/template/types.py
@@ -10,6 +10,8 @@ from pydantic import (
     ConfigDict,
     Field,
     SecretStr,
+    SerializationInfo,
+    field_serializer,
     model_validator,
 )
 
@@ -1049,6 +1051,28 @@ class HttpAuthConfig(BaseModel):
     password: Optional[SecretStr] = None  # For basic auth
     api_key_name: Optional[str] = None  # Header name for API key
     api_key_value: Optional[SecretStr] = None  # API key value
+
+    # Templates are persisted to Postgres as JSON. Pydantic's default
+    # JSON serialization for SecretStr produces the masked form
+    # ("**********"), which silently corrupts the stored value — the
+    # template would then send `Authorization: Bearer **********` at
+    # call time. We unmask **only** when an explicit
+    # ``context={"reveal_secrets": True}`` flag is passed to model_dump
+    # (the create/replace handlers do this on the persistence path).
+    # All other JSON serialization paths — notably FastAPI response
+    # encoding for GET / PUT — see no context, fall through to the
+    # masked form, and so do not leak literal tokens that an operator
+    # may have embedded directly (vs. the intended
+    # ``{credential_name}`` placeholder pattern).
+    @field_serializer("token", "password", "api_key_value", when_used="json")
+    def _reveal_secret(
+        self, value: Optional[SecretStr], info: SerializationInfo
+    ) -> Optional[str]:
+        if value is None:
+            return None
+        if info.context and info.context.get("reveal_secrets"):
+            return value.get_secret_value()
+        return "**********"
 
 
 class HttpRequestConfig(BaseModel):

--- a/app/ai/voice/agents/breeze_buddy/utils/secrets.py
+++ b/app/ai/voice/agents/breeze_buddy/utils/secrets.py
@@ -8,9 +8,21 @@ exposed in API responses while allowing updates to preserve existing values.
 from typing import Any, Dict, Optional
 
 from app.ai.voice.agents.breeze_buddy.template.types import TemplateModel
+from app.core.logger import logger
 
-# Mask value for secrets in API responses
+# Mask value for top-level template.secrets in API responses (legacy: 6 asterisks).
 SECRETS_MASK = "******"
+
+# Mask values that ``configurations.mcp.servers[*].auth.{token,password,
+# api_key_value}`` may arrive with on a PUT body. ``HttpAuthConfig``'s
+# field_serializer in ``template/types.py`` emits 10 asterisks; accept the
+# 6-asterisk top-level form too in case a UI client normalises everything to
+# one shape. Either form means "value unchanged — keep what's in DB".
+_AUTH_MASK_VALUES = frozenset({SECRETS_MASK, "**********"})
+
+# The three SecretStr fields on ``HttpAuthConfig``. If the schema gains
+# another secret-typed auth field, add it here.
+_AUTH_SECRET_FIELDS: tuple[str, ...] = ("token", "password", "api_key_value")
 
 
 def mask_secrets(secrets: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
@@ -65,6 +77,103 @@ def merge_secrets(
             merged[key] = value
 
     return merged if merged else None
+
+
+def merge_masked_mcp_auth(
+    new_configurations: Optional[Dict[str, Any]],
+    existing_configurations: Optional[Dict[str, Any]],
+) -> Optional[Dict[str, Any]]:
+    """In-place merge: replace masked auth secrets in ``new_configurations``
+    with the existing persisted values. Mirrors ``merge_secrets`` for
+    top-level template.secrets, but for the SecretStr fields under
+    ``configurations.mcp.servers[*].auth``.
+
+    Why this is needed: ``HttpAuthConfig.token``/``password``/``api_key_value``
+    are SecretStr fields. ``GET /templates/{id}`` masks them in the response
+    (Pydantic field_serializer, no reveal_secrets context). A client that does
+    GET → edit one unrelated field → PUT will send the masked literal back; if
+    we persist that literal, runtime sends ``Authorization: Bearer **********``
+    and auth silently breaks. Treat masked values as "unchanged" and substitute
+    the existing persisted value.
+
+    Pairing strategy: prefer ``server.name`` (the natural identity), fall back
+    to position. If neither matches, the masked value is left as-is and a
+    warning is logged — caller is responsible for either supplying a real
+    value or matching an existing server.
+
+    Currently only walks ``configurations.mcp.servers[*].auth`` because that's
+    the only HttpAuthConfig location reachable through ``ConfigurationModel``.
+    If the schema gains another auth-bearing path under configurations, extend
+    this walker.
+    """
+    if not new_configurations or not existing_configurations:
+        return new_configurations
+
+    new_servers = ((new_configurations.get("mcp") or {}).get("servers")) or []
+    existing_servers = ((existing_configurations.get("mcp") or {}).get("servers")) or []
+    if not new_servers:
+        return new_configurations
+
+    # Index existing servers by name (skip duplicates and unnamed entries —
+    # those fall through to position-based pairing).
+    seen_names: set = set()
+    by_name: Dict[str, Dict[str, Any]] = {}
+    for s in existing_servers:
+        if not isinstance(s, dict):
+            continue
+        name = s.get("name")
+        if not isinstance(name, str):
+            continue
+        if name in seen_names:
+            by_name.pop(name, None)  # ambiguous — disqualify
+            continue
+        seen_names.add(name)
+        by_name[name] = s
+
+    for i, new_server in enumerate(new_servers):
+        if not isinstance(new_server, dict):
+            continue
+        new_auth = new_server.get("auth")
+        if not isinstance(new_auth, dict):
+            continue
+
+        # Find the existing pair: by name first, then by position.
+        existing_server: Optional[Dict[str, Any]] = None
+        name = new_server.get("name")
+        if isinstance(name, str) and name in by_name:
+            existing_server = by_name[name]
+        elif i < len(existing_servers) and isinstance(existing_servers[i], dict):
+            existing_server = existing_servers[i]
+
+        existing_auth = (
+            existing_server.get("auth") if existing_server is not None else None
+        )
+
+        for field in _AUTH_SECRET_FIELDS:
+            v = new_auth.get(field)
+            if not (isinstance(v, str) and v in _AUTH_MASK_VALUES):
+                continue
+            existing_v = (
+                existing_auth.get(field) if isinstance(existing_auth, dict) else None
+            )
+            if isinstance(existing_v, str):
+                new_auth[field] = existing_v
+            else:
+                # Masked value with no real counterpart — most likely a
+                # newly-added MCP server with a placeholder the caller forgot
+                # to fill, or a renamed server that broke the pairing. Don't
+                # silently persist the literal mask: clear the field so the
+                # template fails loudly at MCP setup rather than appearing
+                # configured but sending ``Bearer **********``.
+                logger.warning(
+                    "merge_masked_mcp_auth: masked %r on mcp server %r has no "
+                    "existing value to substitute; clearing the field",
+                    field,
+                    name or f"<index={i}>",
+                )
+                new_auth[field] = None
+
+    return new_configurations
 
 
 def mask_template_secrets(template: TemplateModel) -> TemplateModel:

--- a/app/api/routers/breeze_buddy/templates/handlers.py
+++ b/app/api/routers/breeze_buddy/templates/handlers.py
@@ -17,6 +17,7 @@ from app.ai.voice.agents.breeze_buddy.template.types import (
 )
 from app.ai.voice.agents.breeze_buddy.utils.secrets import (
     mask_template_secrets,
+    merge_masked_mcp_auth,
     merge_secrets,
 )
 from app.core.logger import logger
@@ -111,13 +112,19 @@ async def create_template_handler(
         now = datetime.now(timezone.utc)
 
         # Build configurations dict from the ConfigurationModel.
-        # mode="json" unwraps SecretStr fields (e.g. mcp.servers[*].auth.token)
-        # to their string value so the downstream json.dumps in
-        # ``create_template`` doesn't choke on a SecretStr instance.
+        # mode="json" + reveal_secrets context unwraps SecretStr fields
+        # (e.g. mcp.servers[*].auth.token) to their underlying string so
+        # the downstream json.dumps in ``create_template`` writes the
+        # real value (typically a ``{credential_name}`` placeholder).
+        # Without the context flag, HttpAuthConfig's serializer falls
+        # back to the masked "**********" form, which is what we want
+        # everywhere except this persistence path.
         configurations = None
         if template_data.configurations:
             configurations = template_data.configurations.model_dump(
-                exclude_none=True, mode="json"
+                exclude_none=True,
+                mode="json",
+                context={"reveal_secrets": True},
             )
 
         template = await create_template(
@@ -404,13 +411,39 @@ async def replace_template_handler(
         now = datetime.now(timezone.utc)
 
         # Build configurations dict from the ConfigurationModel.
-        # mode="json" unwraps SecretStr fields (e.g. mcp.servers[*].auth.token)
-        # to their string value so the downstream json.dumps in
-        # ``replace_template`` doesn't choke on a SecretStr instance.
+        # mode="json" + reveal_secrets context unwraps SecretStr fields
+        # (e.g. mcp.servers[*].auth.token) to their underlying string so
+        # the downstream json.dumps in ``replace_template`` writes the
+        # real value (typically a ``{credential_name}`` placeholder).
+        # Without the context flag, HttpAuthConfig's serializer falls
+        # back to the masked "**********" form, which is what we want
+        # everywhere except this persistence path.
         configurations = None
         if template_data.configurations:
             configurations = template_data.configurations.model_dump(
-                exclude_none=True, mode="json"
+                exclude_none=True,
+                mode="json",
+                context={"reveal_secrets": True},
+            )
+            # GET /templates returns auth secrets as "**********" (the
+            # field_serializer masks when no reveal_secrets context).
+            # A typical UI does GET → edit-one-unrelated-field → PUT,
+            # which sends the masked literal back. Without this merge
+            # the masked literal would land in DB and silently break
+            # auth (runtime would emit ``Bearer **********``). Treat
+            # masked auth values as "unchanged" — same shape as the
+            # ``merge_secrets`` call below for top-level secrets.
+            existing_configurations = (
+                existing_template.configurations.model_dump(
+                    exclude_none=True,
+                    mode="json",
+                    context={"reveal_secrets": True},
+                )
+                if existing_template.configurations
+                else None
+            )
+            configurations = merge_masked_mcp_auth(
+                configurations, existing_configurations
             )
 
         # Merge secrets: preserve **** values from existing, update real values


### PR DESCRIPTION
## Summary

PR #744 stopped the `SecretStr is not JSON serializable` crash on `POST/PUT /templates` by switching the configurations dump to `mode="json"`. That stops the crash, but Pydantic's default JSON serialization for `SecretStr` is the masked form (`"**********"`) — silently corrupting the persisted token. At call time the loaded template then sends `Authorization: Bearer **********` to the upstream MCP / HTTP endpoint, which fails auth. Reproduced on prod with `template_id 12d3bed6-fa45-45c6-b1ed-a285f57ad289` (Exa MCP, bearer token `"{exa_api_key}"` placeholder, persisted as `"**********"`). That row has been deleted.

## Fix

`HttpAuthConfig` now has a `field_serializer(when_used="json")` that reveals the underlying string for the three `SecretStr` fields (`token`, `password`, `api_key_value`) **only when** `model_dump` is invoked with `context={"reveal_secrets": True}`. Without the context flag the serializer falls back to the masked `"**********"` form, so:

- The two persistence paths (`create_template_handler`, `replace_template_handler`) pass the context and write the real value (typically a `{credential_name}` placeholder resolved per call from the credentials table).
- All other JSON serialization paths — notably FastAPI response encoding for `GET /templates/{id}` and the PUT response — see no context, fall through to the masked form, and so do not leak literal tokens that an operator may have embedded directly.

This addresses the AI review note on this PR: an unconditional `when_used="json"` unmask would cause `GET`/`PUT` response handlers (both have `response_model=TemplateModel`) to start returning raw auth material that previously stayed masked by `SecretStr`'s default JSON behavior. `mask_template_secrets()` only masks `template.secrets`, not `template.configurations`, so the Pydantic-level mask was the only guard for `configurations.mcp.servers[*].auth.token` in API responses. The context flag preserves that guard.

`mode="python"` (the default) keeps the `SecretStr` instance, so in-memory access via `.get_secret_value()` on the runtime path is unaffected.

## Verification (against the running local server)

Four cases, all green:

1. **Placeholder template** — `POST` -> DB has `"{exa_api_key}"` literal, `GET` API response `auth.token == "**********"`.
2. **Literal-token template** — `POST` with `token="sk-LITERAL-LEAK-CANARY-12345"` -> DB has the literal canary, `GET` API response `auth.token == "**********"`, **canary string occurs zero times in the response body** (full-body grep).
3. **PUT replace path** — `PUT` with `token="sk-PUT-CANARY-67890"` -> DB has the new literal canary, PUT response masked, canary occurs zero times in response body.
4. Both test rows cleaned up locally after verification.

`pyrefly check` 0 errors, black + isort clean.

## Test plan

- [x] Repro on prod confirmed (`12d3bed6-…` had `"**********"` token)
- [x] Local POST -> GET roundtrip: persists real value, response masked
- [x] Local POST with literal token -> response body grep: zero leak
- [x] Local PUT roundtrip: persists real value, response masked
- [x] Linters + type check pass
- [ ] Once merged + deployed: re-POST `prod/02_template_create.json` and verify the persisted token is the literal placeholder while `GET` responds masked

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved serialization handling of sensitive authentication data (tokens, passwords, and API keys) within template configurations, providing enhanced control over when sensitive values are revealed or properly masked in system output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->