### PR TITLE
fix: Expected response schema

### DIFF
--- a/app/ai/voice/agents/breeze_buddy/agent/__init__.py
+++ b/app/ai/voice/agents/breeze_buddy/agent/__init__.py
@@ -800,12 +800,14 @@ class Agent:
             self.lead.metaData = {}
         self.lead.metaData["node_traversal"] = []
 
-        await self.flow_manager.initialize(initial_node_config)
-
-        # Record initial node entry after FlowManager is initialized
+        # Record initial node entry BEFORE flow_manager.initialize so that any
+        # global function called during the first LLM turn (e.g. get_driver_info
+        # on the initial node) finds an active node entry to record against.
         initial_node_name = self.flow_config["initial_node"]
         context = TemplateContext(self)
         context.record_node_entry(initial_node_name)
+
+        await self.flow_manager.initialize(initial_node_config)
         logger.info(
             f"FlowManager initialized with initial node: {self.flow_config['initial_node']}"
         )

--- a/app/ai/voice/agents/breeze_buddy/handlers/internal/hold_and_consult.py
+++ b/app/ai/voice/agents/breeze_buddy/handlers/internal/hold_and_consult.py
@@ -35,48 +35,12 @@ from app.database.accessor.breeze_buddy.hold_transfer import (
 from app.database.accessor.breeze_buddy.lead_call_tracker import (
     create_lead_call_tracker,
     update_lead_call_id_by_id,
+    update_lead_request_id,
 )
 from app.schemas import CallDirection, ExecutionMode, LeadCallStatus
 
 # Channel name pattern for Redis pub/sub
 _CHANNEL_PREFIX = "hold_transfer:result"
-
-
-def _resolve_payload_from_schema(
-    schema: Dict[str, str],
-    inbound_payload: Dict[str, Any],
-    call_sid: str,
-) -> Dict[str, Any]:
-    """Resolve outbound payload fields from payload_schema config.
-
-    For each key in schema:
-      - If value starts with "lead." → read from inbound_payload using the
-        remainder as the key. Logs a warning if the key is absent.
-      - Otherwise → treat the value as a literal string.
-
-    Args:
-        schema: Mapping of outbound variable name → "lead.<field>" or literal.
-        inbound_payload: The inbound lead's payload dict.
-        call_sid: Used in log messages.
-
-    Returns:
-        Resolved dict to merge into the outbound payload.
-    """
-    resolved: Dict[str, Any] = {}
-    for outbound_key, spec in schema.items():
-        if spec.startswith("lead."):
-            inbound_key = spec[len("lead.") :]
-            value = inbound_payload.get(inbound_key)
-            if value is None:
-                logger.warning(
-                    f"[hold_and_consult] payload_schema: inbound payload missing "
-                    f"'{inbound_key}' for outbound field '{outbound_key}' "
-                    f"(call {call_sid}). Proceeding with None."
-                )
-            resolved[outbound_key] = value
-        else:
-            resolved[outbound_key] = spec
-    return resolved
 
 
 async def hold_and_consult(
@@ -190,23 +154,12 @@ async def hold_and_consult(
     logger.info(f"[hold_and_consult] Subscribed to '{pub_channel}' for call {call_sid}")
 
     # ── 8. Create outbound lead with hold-transfer metadata ────────────
-    inbound_payload: Dict[str, Any] = {}
-    if context.lead and context.lead.payload:
-        inbound_payload = context.lead.payload
-
     outbound_payload: Dict[str, Any] = {}
 
-    # 1. Config-level payload_schema fields (lowest priority)
-    if hold_config.payload_schema:
-        schema_fields = _resolve_payload_from_schema(
-            hold_config.payload_schema, inbound_payload, call_sid
-        )
-        outbound_payload.update(schema_fields)
-
-    # 2. LLM-provided outbound_payload fields (overrides schema)
+    # LLM-provided outbound_payload fields
     outbound_payload.update(args_payload)
 
-    # 3. Internal keys always win — injected by system, not LLM
+    # Internal keys always win — injected by system, not LLM
     outbound_payload["_hold_transfer_pub_channel"] = pub_channel
     if hold_config.summarize:
         outbound_payload["_hold_transfer_summarize"] = True
@@ -255,6 +208,12 @@ async def hold_and_consult(
                 "status": "error",
                 "message": "Failed to create outbound lead.",
             }
+
+        # Link inbound lead → outbound lead by storing the outbound lead UUID
+        # in the inbound lead's request_id. The reverse link (outbound → inbound)
+        # is already set via request_id=inbound_lead_id above.
+        if inbound_lead_id:
+            await update_lead_request_id(str(inbound_lead_id), outbound_lead_id)
     except Exception as e:
         subscribe_task.cancel()
         logger.error(

--- a/app/ai/voice/agents/breeze_buddy/handlers/transport/http_handler.py
+++ b/app/ai/voice/agents/breeze_buddy/handlers/transport/http_handler.py
@@ -205,6 +205,7 @@ async def http_function_handler(
         if (
             is_success
             and config.expected_response_schema
+            and config.expected_response_schema != "full"
             and isinstance(data, (dict, list))
         ):
             data = apply_response_schema(
@@ -218,15 +219,27 @@ async def http_function_handler(
         logger.debug(f"[{function_name}] data going to LLM: {data}")
 
         # Record global function call in node traversal path.
-        # Store the filtered response only when expected_response_schema is
-        # defined — that's the curated subset we want to persist. For plain
-        # HTTP calls without a schema the raw response may be large / noisy,
-        # so we store None in that case.
-        response_to_store = (
-            data
-            if is_success and config.expected_response_schema and isinstance(data, dict)
-            else None
-        )
+        # Storage rules (controlled by expected_response_schema on the function):
+        #
+        #   Dict of JMESPath expressions  → store the already-filtered dict on 2xx;
+        #                                   store raw error body on 4xx/5xx
+        #   "full"                         → store the full raw response on 2xx;
+        #                                   store raw error body on 4xx/5xx
+        #   Empty {} (default / not set)   → store nothing
+        #
+        # For non-JSON error responses (e.g. plain "Not found" text on 404),
+        # wrap in a dict so they are always storable.
+        if config.expected_response_schema:
+            if isinstance(data, dict):
+                response_to_store: Optional[Dict[str, Any]] = data
+            elif is_success:
+                # 2xx non-dict (e.g. plain string or list) — wrap so it can be persisted
+                response_to_store = {"response": data, "status_code": status_code}
+            else:
+                # Non-JSON error body — wrap so it can be persisted
+                response_to_store = {"error": data, "status_code": status_code}
+        else:
+            response_to_store = None  # no schema — never store
         context.record_global_function_call(
             function_name=function_name,
             function_args=args,

--- a/app/ai/voice/agents/breeze_buddy/handlers/transport/utils/response_filter.py
+++ b/app/ai/voice/agents/breeze_buddy/handlers/transport/utils/response_filter.py
@@ -10,9 +10,15 @@ Common patterns
 - Array index:          ``"results[0].name"``
 - Array wildcard:       ``"items[*].name"``
 - Multi-field project:  ``"rides[*].{rideId: rideId, area: pickup.area}"``
-- Filter (with args):   ``"coinEarnHistory[?rideId=='{ride_id}']"``
-  The ``{ride_id}`` placeholder is resolved from the ``args`` dict via
-  ``str.format(**args)`` before the JMESPath expression is evaluated.
+- Filter (with args):   ``"coinEarnHistory[?rideId==`{ride_id}`]"``
+  The `` `{ride_id}` `` placeholder is replaced with a single-quoted
+  JMESPath string literal (``'value'``).  Any single-quotes in the value
+  are escaped as ``\'`` so they cannot break out of the string boundary —
+  injection-safe while remaining compatible with the Python jmespath library.
+
+  The old single-quoted form ``"coinEarnHistory[?rideId=='{ride_id}']"`` is
+  **not supported** and raises ``ValueError`` at call time.  Migrate all
+  placeholders to the backtick form.
 
 When ``expected_response_schema`` is empty the full response is returned
 unchanged (backward-compatible passthrough).
@@ -35,13 +41,24 @@ def apply_response_schema(
         schema: Mapping of ``{llm_field_name: jmespath_expression}``.
                 If empty, *data* is returned unchanged (passthrough).
         args:   The LLM-provided function call arguments. Used to resolve
-                ``{placeholder}`` tokens in expressions before evaluation
-                (e.g. ``"coinEarnHistory[?rideId=='{ride_id}']"``).
+                `` `{placeholder}` `` tokens in expressions before evaluation.
+                Placeholders **must** be wrapped in backticks so they are
+                substituted as JMESPath JSON literals via ``json.dumps``,
+                preventing injection via LLM-controlled argument values.
+
+                Example: ``"coinEarnHistory[?rideId==`{ride_id}`]"``
+
+                Using the old single-quoted form (``'{ride_id}'``) raises a
+                ``ValueError`` — migrate to the backtick form.
 
     Returns:
         A dict containing only the extracted fields, keyed by their
         LLM-facing names. Fields whose expression resolves to ``None`` are
         omitted from the result.
+
+    Raises:
+        ValueError: If a placeholder is found in the unsupported single-quoted
+            form ``'{key}'`` instead of the required backtick form `` `{key}` ``.
 
     Examples::
 
@@ -59,7 +76,7 @@ def apply_response_schema(
 
         apply_response_schema(
             {"coinEarnHistory": [{"rideId": "abc", "coins": 20}, {"rideId": "xyz", "coins": 30}]},
-            {"coinEarnHistory": "coinEarnHistory[?rideId=='{ride_id}']"},
+            {"coinEarnHistory": "coinEarnHistory[?rideId==`{ride_id}`]"},
             args={"ride_id": "abc"},
         )
         # → {"coinEarnHistory": [{"rideId": "abc", "coins": 20}]}
@@ -71,7 +88,27 @@ def apply_response_schema(
     result: Dict[str, Any] = {}
     for field_name, expression in schema.items():
         for key, val in resolved_args.items():
-            expression = expression.replace(f"{{{key}}}", str(val))
+            backtick_placeholder = f"`{{{key}}}`"
+            legacy_placeholder = f"{{{key}}}"
+
+            if backtick_placeholder in expression:
+                # Substitute as a single-quoted JMESPath string literal.
+                # Single-quotes in the value are escaped as \' so they cannot
+                # break out of the string boundary — injection-safe.
+                # We intentionally avoid json.dumps here because wrapping the
+                # value in backtick JSON literals (e.g. `"abc"`) causes the
+                # Python jmespath library to fail string equality comparisons
+                # in filter expressions (returns [] instead of matching rows).
+                safe_val = str(val).replace("'", "\\'")
+                expression = expression.replace(backtick_placeholder, f"'{safe_val}'")
+            elif legacy_placeholder in expression:
+                # Old single-quoted form is no longer supported.
+                raise ValueError(
+                    f"[response_filter] Unsupported placeholder syntax "
+                    f"'{legacy_placeholder}' in expression {expression!r}. "
+                    f"Migrate to backtick form: '`{legacy_placeholder}`'."
+                )
+
         value = jmespath.search(expression, data)
         if value is not None:
             result[field_name] = value

--- a/app/ai/voice/agents/breeze_buddy/template/types.py
+++ b/app/ai/voice/agents/breeze_buddy/template/types.py
@@ -3,7 +3,7 @@ Pydantic models for the dynamic workflow engine.
 """
 
 from enum import Enum
-from typing import Any, Dict, List, Literal, Optional
+from typing import Any, Dict, List, Literal, Optional, Union
 
 from pydantic import (
     BaseModel,
@@ -619,13 +619,7 @@ class HoldTransferConfig(BaseModel):
             "outbound_number_id": "uuid-of-outbound-number",
             "hold_music": "typing",
             "hold_timeout_seconds": 180,
-            "summarize": true,
-            "payload_schema": {
-                "customer_name": "lead.customer_name",
-                "customer_language": "lead.customer_language",
-                "trip_id": "lead.trip_id",
-                "agent_name": "Rhea"
-            }
+            "summarize": true
         }
     """
 
@@ -661,14 +655,6 @@ class HoldTransferConfig(BaseModel):
         ge=0.0,
         le=1.0,
         description="Volume for hold music playback (0.0–1.0). Default 0.4.",
-    )
-    payload_schema: Optional[Dict[str, str]] = Field(
-        None,
-        description="Mapping of outbound template variable names to values. "
-        "Use 'lead.<field>' to reference the inbound lead's payload field "
-        "(e.g. 'lead.customer_name'), or a plain string for a literal value "
-        "(e.g. 'Rhea'). Missing 'lead.<field>' references are logged as "
-        "warnings and resolved to None — the outbound call still proceeds.",
     )
 
 
@@ -1212,8 +1198,9 @@ class GlobalHttpFunction(BaseGlobalFunction):
     # talking while the request runs and the result is injected as a developer
     # message that re-triggers inference. Templates can override per-function.
     cancel_on_interruption: Optional[bool] = False
-    expected_response_schema: Dict[str, str] = {}
-    """Whitelist of fields to extract from the HTTP response before feeding to the LLM.
+    expected_response_schema: Union[Dict[str, str], Literal["full"]] = {}
+    """Whitelist of fields to extract from the HTTP response before feeding to the LLM,
+    or ``"full"`` to pass the entire response to the LLM and store it in node traversal.
 
     Key   = name as it will appear in the LLM payload.
     Value = JMESPath expression (https://jmespath.org) evaluated against the
@@ -1227,7 +1214,18 @@ class GlobalHttpFunction(BaseGlobalFunction):
         - Multi-field project: ``"rides[*].{rideId: rideId, area: pickup.area}"``
         - Filter with arg:     ``"coinEarnHistory[?rideId=='{ride_id}']"``
 
-    When empty (default), the full response data is passed to the LLM unchanged.
+    Behaviour by value:
+
+    - **Dict of JMESPath expressions** (e.g. ``{"driverId": "driverId"}``):
+      Response is filtered to only those fields before being sent to the LLM.
+      The filtered dict is also stored in node traversal. On 4xx/5xx the raw
+      error body is stored instead (filtering is skipped for error responses).
+
+    - **``"full"``**: The entire response is passed to the LLM unchanged and
+      stored in node traversal. On 4xx/5xx the raw error body is stored.
+
+    - **Empty dict ``{}`` (default)**: The full response is passed to the LLM
+      unchanged, but **nothing is stored** in node traversal.
     """
 
 

--- a/app/api/routers/breeze_buddy/analytics/handlers.py
+++ b/app/api/routers/breeze_buddy/analytics/handlers.py
@@ -217,6 +217,7 @@ async def get_call_details_analytics(
                 or datetime.now(),
                 updated_at=tracker.get("updated_at"),
                 execution_mode=tracker.get("execution_mode"),
+                call_direction=tracker.get("call_direction"),
             )
         )
 

--- a/app/database/accessor/breeze_buddy/lead_call_tracker.py
+++ b/app/database/accessor/breeze_buddy/lead_call_tracker.py
@@ -32,6 +32,7 @@ from app.database.queries.breeze_buddy.lead_call_tracker import (
     update_lead_call_initiated_time_query,
     update_lead_call_recording_url_query,
     update_lead_payload_query,
+    update_lead_request_id_query,
 )
 from app.schemas import (
     CallDirection,
@@ -681,3 +682,23 @@ async def append_metadata_field(
     except Exception as e:
         logger.error(f"Error updating lead metadata for ID {lead_id}: {e}")
         return None
+
+
+async def update_lead_request_id(lead_id: str, request_id: str) -> None:
+    """
+    Update the request_id column for a lead.
+
+    Used to link an inbound lead to its associated outbound (hold-transfer)
+    lead after the outbound leg is created.
+
+    Args:
+        lead_id: UUID of the lead to update (inbound lead)
+        request_id: Value to set as request_id (outbound lead UUID)
+    """
+    logger.info(f"Updating request_id for lead ID: {lead_id} → {request_id}")
+    try:
+        query_text, values = update_lead_request_id_query(lead_id, request_id)
+        await run_parameterized_query(query_text, values)
+        logger.info(f"request_id updated successfully for lead ID: {lead_id}")
+    except Exception as e:
+        logger.error(f"Error updating request_id for lead ID {lead_id}: {e}")

--- a/app/database/queries/breeze_buddy/lead_call_tracker.py
+++ b/app/database/queries/breeze_buddy/lead_call_tracker.py
@@ -610,6 +610,30 @@ def update_lead_payload_query(
     return text, values
 
 
+def update_lead_request_id_query(
+    lead_id: str, request_id: str
+) -> Tuple[str, List[Any]]:
+    """
+    Update the request_id column for a specific lead.
+
+    Args:
+        lead_id: Lead UUID
+        request_id: The value to set as request_id (e.g. linked outbound lead UUID)
+
+    Returns:
+        Tuple of (query_text, values)
+    """
+    text = f"""
+        UPDATE "{LEAD_CALL_TRACKER_TABLE}"
+        SET
+            "request_id" = $1,
+            "updated_at" = NOW()
+        WHERE "id" = $2;
+    """
+    values = [request_id, lead_id]
+    return text, values
+
+
 def append_metadata_field_query(
     lead_id: str, field_updates: Dict[str, Any]
 ) -> Tuple[str, List[Any]]:

--- a/app/schemas/breeze_buddy/analytics.py
+++ b/app/schemas/breeze_buddy/analytics.py
@@ -160,6 +160,7 @@ class CallDetailResult(BaseModel):
     created_at: datetime
     updated_at: Optional[datetime] = None
     execution_mode: Optional[str] = None
+    call_direction: Optional[str] = None
 
 
 class TrendDataPoint(BaseModel):


### PR DESCRIPTION
  - added support to store whole response in node traversal using "full" in expected response schema
  - fixed jmes path injection
  - removed unused payload scheam from hold and consult configurations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed flow initialization tracking to record entry at the correct stage.

* **New Features**
  * Added `"full"` response schema option to preserve unfiltered HTTP responses.
  * Enhanced HTTP error response handling with raw error body storage.

* **Breaking Changes**
  * Updated JMESPath filter placeholder syntax; legacy syntax now requires migration or raises errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->