### PR TITLE
feat(tts): add Soniox TTS provider end-to-end

### DIFF
--- a/app/ai/voice/agents/breeze_buddy/template/types.py
+++ b/app/ai/voice/agents/breeze_buddy/template/types.py
@@ -278,6 +278,7 @@ class TTSProvider(str, Enum):
     CARTESIA = "cartesia"
     SARVAM = "sarvam"
     GEMINI = "gemini"
+    SONIOX = "soniox"
 
 
 # Maps legacy tts_voice_name values to current provider strings for backward compat.
@@ -324,10 +325,19 @@ class TTSConfig(BaseModel):
             "speed": 0.9,
             "pitch": 0.0
         }
+
+    Example (Soniox):
+        {
+            "provider": "soniox",
+            "voice_id": "Priya",
+            "model": "tts-rt-v1",
+            "language": "en"
+        }
     """
 
     provider: TTSProvider = Field(
-        ..., description="TTS provider (elevenlabs, cartesia, sarvam, gemini)"
+        ...,
+        description="TTS provider (elevenlabs, cartesia, sarvam, gemini, soniox)",
     )
     voice_id: Optional[str] = Field(None, description="Provider-specific voice ID")
     model: Optional[str] = Field(

--- a/app/ai/voice/agents/breeze_buddy/tts/__init__.py
+++ b/app/ai/voice/agents/breeze_buddy/tts/__init__.py
@@ -14,15 +14,18 @@ from app.ai.voice.tts import (
     ElevenLabsConfig,
     GeminiConfig,
     SarvamTTSConfig,
+    SonioxTTSConfig,
     build_cartesia_tts,
     build_elevenlabs_tts,
     build_gemini_tts,
     build_sarvam_tts,
+    build_soniox_tts,
 )
 from app.ai.voice.tts.cartesia import _generate_cartesia_audio
 from app.ai.voice.tts.elevenlabs import _generate_elevenlabs_audio
 from app.ai.voice.tts.gemini import _generate_gemini_audio
 from app.ai.voice.tts.sarvam import _generate_sarvam_audio
+from app.ai.voice.tts.soniox import _generate_soniox_audio
 from app.core.config.dynamic import (
     BB_AGGREGATE_SENTENCES,
     BB_ENABLE_ELEVENLABS_INDIAN_RESIDENCY,
@@ -37,6 +40,7 @@ from app.core.config.static import (
     ELEVENLABS_INDIAN_RESIDENCY_WEBSOCKET_URL,
     GOOGLE_CREDENTIALS_JSON,
     SARVAM_API_KEY,
+    SONIOX_API_KEY,
 )
 from app.core.logger import logger
 
@@ -206,6 +210,22 @@ async def get_tts_service(voice_config: TTSConfig):
             )
         )
 
+    elif provider == "soniox":
+        if not SONIOX_API_KEY:
+            raise ValueError("SONIOX_API_KEY is required for Soniox TTS")
+
+        aggregate = await BB_AGGREGATE_SENTENCES("soniox")
+
+        return build_soniox_tts(
+            SonioxTTSConfig(
+                api_key=SONIOX_API_KEY,
+                voice=voice_config.voice_id or "Priya",
+                model=voice_config.model or "tts-rt-v1",
+                language=_parse_language(voice_config.language, Language.EN),
+                aggregate_sentences=aggregate,
+            )
+        )
+
     else:
         raise ValueError(f"Unsupported TTS provider: {provider}")
 
@@ -267,6 +287,14 @@ async def generate_audio(
             style_prompt=getattr(resolved, "style_prompt", None),
         )
         # _generate_gemini_audio already downsamples to 16 kHz PCM
+        input_format = "raw"
+    elif provider == "soniox":
+        audio_data = await _generate_soniox_audio(
+            text=text,
+            voice=resolved.voice_id,
+            model=resolved.model,
+            language=resolved.language,
+        )
         input_format = "raw"
     else:
         raise ValueError(f"Unsupported TTS provider: {provider}")

--- a/app/ai/voice/tts/__init__.py
+++ b/app/ai/voice/tts/__init__.py
@@ -11,6 +11,7 @@ from .elevenlabs import ElevenLabsConfig, build_elevenlabs_tts
 from .gemini import GeminiConfig, build_gemini_tts
 from .google import GoogleConfig, build_google_tts
 from .sarvam import SarvamTTSConfig, build_sarvam_tts, get_sarvam_language
+from .soniox import SonioxTTSConfig, build_soniox_tts
 
 __all__ = [
     # Cartesia
@@ -29,4 +30,7 @@ __all__ = [
     "SarvamTTSConfig",
     "build_sarvam_tts",
     "get_sarvam_language",
+    # Soniox
+    "SonioxTTSConfig",
+    "build_soniox_tts",
 ]

--- a/app/ai/voice/tts/soniox.py
+++ b/app/ai/voice/tts/soniox.py
@@ -1,0 +1,173 @@
+"""Soniox TTS helpers and builder.
+
+Wraps pipecat's :class:`SonioxTTSService` (WebSocket streaming TTS) to fit the
+shared builder pattern used by other providers in this package, and provides a
+one-shot WebSocket synth helper for greeting prep — pipecat's Soniox client
+is streaming-only, so the one-shot path is implemented directly against the
+same WebSocket protocol.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+from dataclasses import dataclass
+from typing import Optional
+
+from pipecat.services.soniox.tts import (
+    SonioxTTSService,
+    language_to_soniox_tts_language,
+)
+from pipecat.services.tts_service import TextAggregationMode
+from pipecat.transcriptions.language import Language
+from websockets.asyncio.client import connect as websocket_connect
+
+from app.core.config.static import SONIOX_API_KEY
+from app.core.logger import logger
+
+__all__ = [
+    "SonioxTTSConfig",
+    "build_soniox_tts",
+    "_generate_soniox_audio",
+]
+
+
+SONIOX_TTS_WS_URL = "wss://tts-rt.soniox.com/tts-websocket"
+
+# Outer bound for the one-shot greeting synth, matching the 30s timeout the
+# HTTP one-shot helpers (sarvam, elevenlabs) use. websockets' own
+# open_timeout/ping defaults cover the handshake and dead peers; this guards
+# the case of a connected server that never sends `terminated`.
+SONIOX_TTS_SYNTH_TIMEOUT_SECS = 30.0
+
+
+@dataclass
+class SonioxTTSConfig:
+    """Configuration for Soniox TTS."""
+
+    api_key: str
+    voice: str
+    model: str
+    language: Language = Language.EN
+    sample_rate: int = 16000
+    audio_format: str = "pcm_s16le"
+    aggregate_sentences: bool = True
+
+
+def build_soniox_tts(config: SonioxTTSConfig) -> SonioxTTSService:
+    """Create a Soniox TTS service.
+
+    Pipecat handles Language enum -> Soniox language code conversion at
+    init time via ``language_to_service_language``, so the enum is forwarded
+    untouched.
+    """
+
+    logger.info(
+        f"Using SonioxTTSService with model={config.model}, voice={config.voice}, "
+        f"language={config.language}, sample_rate={config.sample_rate}, "
+        f"audio_format={config.audio_format}"
+    )
+
+    return SonioxTTSService(
+        api_key=config.api_key,
+        sample_rate=config.sample_rate,
+        audio_format=config.audio_format,
+        settings=SonioxTTSService.Settings(
+            voice=config.voice,
+            model=config.model,
+            language=config.language,
+        ),
+        text_aggregation_mode=(
+            TextAggregationMode.SENTENCE
+            if config.aggregate_sentences
+            else TextAggregationMode.TOKEN
+        ),
+    )
+
+
+async def _generate_soniox_audio(
+    text: str,
+    voice: Optional[str] = None,
+    model: Optional[str] = None,
+    language: Optional[str] = None,
+    sample_rate: int = 16000,
+) -> bytes:
+    """One-shot synth via Soniox WebSocket for greeting prep.
+
+    Opens a single WebSocket, sends config + text + ``text_end:true``, collects
+    base64-encoded audio chunks until ``terminated``, and returns the
+    concatenated PCM bytes.
+
+    Returns 16-bit little-endian PCM mono at the requested ``sample_rate``,
+    matching ``convert_to_mulaw`` expectations for downstream telephony use.
+    """
+    if not SONIOX_API_KEY:
+        raise ValueError("SONIOX_API_KEY is required for Soniox TTS")
+
+    voice = voice or "Priya"
+    model = model or "tts-rt-v1"
+
+    if language:
+        try:
+            lang_enum = Language(language)
+        except ValueError:
+            logger.warning(
+                f"Invalid Soniox language code '{language}', falling back to EN"
+            )
+            lang_enum = Language.EN
+    else:
+        lang_enum = Language.EN
+
+    soniox_lang = language_to_soniox_tts_language(lang_enum) or "en"
+
+    config_msg = {
+        "api_key": SONIOX_API_KEY,
+        "stream_id": "greeting",
+        "model": model,
+        "voice": voice,
+        "language": soniox_lang,
+        "audio_format": "pcm_s16le",
+        "sample_rate": sample_rate,
+    }
+    text_msg = {"text": text, "text_end": True, "stream_id": "greeting"}
+
+    logger.info(
+        f"Synthesizing greeting with Soniox (pcm_s16le {sample_rate}): {text[:50]}..."
+    )
+
+    audio_chunks: list[bytes] = []
+    try:
+        async with asyncio.timeout(SONIOX_TTS_SYNTH_TIMEOUT_SECS):
+            async with websocket_connect(SONIOX_TTS_WS_URL) as ws:
+                await ws.send(json.dumps(config_msg))
+                await ws.send(json.dumps(text_msg))
+
+                async for raw in ws:
+                    try:
+                        msg = json.loads(raw)
+                    except json.JSONDecodeError:
+                        continue
+
+                    error_code = msg.get("error_code")
+                    if error_code is not None:
+                        error_message = msg.get("error_message", "")
+                        raise Exception(
+                            f"Soniox TTS error {error_code}: {error_message}"
+                        )
+
+                    audio_b64 = msg.get("audio")
+                    if audio_b64:
+                        audio_chunks.append(base64.b64decode(audio_b64))
+
+                    if msg.get("terminated"):
+                        break
+    except asyncio.TimeoutError:
+        raise Exception(
+            f"Soniox TTS synth timed out after {SONIOX_TTS_SYNTH_TIMEOUT_SECS}s"
+        )
+
+    if not audio_chunks:
+        raise Exception("No audio returned from Soniox TTS")
+
+    return b"".join(audio_chunks)

--- a/app/core/config/dynamic.py
+++ b/app/core/config/dynamic.py
@@ -33,6 +33,11 @@ BB_SPEECH_PROVIDER_DEFAULTS: dict[str, dict] = {
         "speed": 0.9,
         "pitch": 0.0,
     },
+    "soniox": {
+        "voice_id": "Priya",
+        "model": "tts-rt-v1",
+        "language": "en",
+    },
 }
 
 


### PR DESCRIPTION
## Summary

- Wires Soniox WebSocket TTS into the shared builder/factory pattern alongside ElevenLabs, Cartesia, and Sarvam. Templates can now select Soniox via `tts_configuration.provider = "soniox"`.
- New `app/ai/voice/tts/soniox.py`: thin `SonioxTTSConfig` + `build_soniox_tts` wrapping pipecat's `SonioxTTSService` (no subclassing — pipecat handles the WS protocol, multiplexing, keepalives), plus a small `_generate_soniox_audio` one-shot WS synth for greeting prep (pipecat's Soniox client is streaming-only, so the one-shot is implemented directly against the same documented WS protocol).
- Adds `SONIOX` to `TTSProvider` enum and a Soniox example to the `TTSConfig` docstring; wires the `soniox` branch into `get_tts_service` and `generate_audio`; adds hardcoded soniox defaults (`Priya` / `tts-rt-v1` / `en`) to `BB_SPEECH_PROVIDER_DEFAULTS`. Reuses the existing `SONIOX_API_KEY` from the STT integration.

## What's exposed

| `TTSConfig` field | Soniox use |
|---|---|
| `voice_id` | maps to Soniox `voice` (e.g. `Priya`, `Adrian`, plus the v3 voices listed in `SonioxTTSSpeakerV3`) |
| `model` | maps to Soniox `model` (default `tts-rt-v1`) |
| `language` | parsed via `_parse_language` to a `Language` enum, then converted by pipecat to a Soniox 2-letter code (`en`, `ml`, `hi`, ...) |
| `speed` / `volume` / `emotion` / `pitch` | silently ignored — Soniox doesn't accept them |

Other Soniox-specific knobs (`sample_rate` 16000, `audio_format` `pcm_s16le`) are set to telephony-friendly defaults inside the builder; pipecat resamples downstream and `convert_to_mulaw` produces 8 kHz mu-law for Twilio/Plivo/Exotel.

## Dynamic config

Picked up automatically by existing helpers:
- `BB_VOICE_DEFAULTS_SONIOX` (Redis JSON, optional override of hardcoded defaults via `BB_VOICE_PROVIDER_DEFAULTS`)
- `BB_SONIOX_AGGREGATE_SENTENCES` (Redis bool, via `BB_AGGREGATE_SENTENCES("soniox")`)

## Test plan

- [ ] `uv run pyrefly check` passes (verified locally — 0 errors)
- [ ] `uv run black --check . && uv run isort --check . --profile black` pass
- [ ] Construct a TTS service via the factory with `provider=soniox` and verify the resulting service is `SonioxTTSService` with expected `voice` / `model` / `language` / `audio_format` (verified locally)
- [ ] Make an outbound call with a template that has `"tts_configuration": {"provider": "soniox", "voice_id": "Priya", "model": "tts-rt-v1", "language": "en"}` and confirm audio plays correctly
- [ ] Test a template with a dynamic greeting (variables in `static_greeting` text) and verify `_generate_soniox_audio` returns playable audio that converts cleanly to mu-law
- [ ] Try a non-English language (e.g. `"language": "ml"`) and confirm Soniox accepts it and produces audio

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Soniox as a supported text-to-speech provider. Users can now configure voice synthesis with customizable models, languages, and audio formats for audio generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

