### PR TITLE
feat: daily warm transfer bridge — PSTN agent leg bridged into Daily …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,5 @@ logs
 .claude/memory/
 CLAUDE.local.md
 .claude/settings.json
+
+temp/

--- a/app/ai/voice/agents/breeze_buddy/agent/__init__.py
+++ b/app/ai/voice/agents/breeze_buddy/agent/__init__.py
@@ -136,6 +136,7 @@ class Agent:
         self.stream_sid: Optional[str] = None
         self.vad_analyzer: Optional[SileroVADAnalyzer] = None
         self.transport: Any = None
+        self.room_url: Optional[str] = None  # Daily room URL (Daily mode only)
         self.lead: Optional[LeadCallTracker] = None
         self.root_span: Any = None
         self.flow_manager: Optional[FlowManager] = None
@@ -383,6 +384,7 @@ class Agent:
 
         transport_params = get_transport_params(self.template, self.configurations)
         self.transport = await create_transport(runner_args, transport_params)
+        self.room_url = getattr(runner_args, "room_url", None)
 
     async def _setup_telephony_transport(self) -> bool:
         """Initialize transport for telephony mode. Returns False if setup fails."""

--- a/app/ai/voice/agents/breeze_buddy/handlers/internal/warm_transfer.py
+++ b/app/ai/voice/agents/breeze_buddy/handlers/internal/warm_transfer.py
@@ -1,27 +1,664 @@
 """
 Transfer Handler
 
-Handles transfer to human agent by creating a conference call.
-On success, terminates the AI conversation. On failure, continues gracefully.
+Handles transfer to a human agent.
+
+- **Telephony mode**: creates a conference call via the provider's conference
+  service, then ends the AI conversation.
+- **Daily mode**: dials the agent on PSTN via the lead's telephony provider,
+  waits for the bridge handler to confirm it has joined the Daily room, then
+  mutes STT, mutes the bot's Daily microphone, and unsubscribes the bot from
+  room audio. The bot stays in the room idle — customer and bridge bot remain
+  connected.
+
+The audio bridging for Daily mode runs in
+``app/api/routers/breeze_buddy/telephony/bridge.py`` — when the dialed agent
+answers, the provider's answer webhook is intercepted (see
+``answer/handlers.py``) and the WebSocket is routed to the bridge handler.
+
+Outbound number selection (Daily mode)
+---------------------------------------
+If ``lead.outbound_number_id`` is set (telephony leads, or Daily leads with an
+explicit pin), that number is used directly.
+
+For Daily leads with no outbound_number_id, the template must declare
+``configurations.transfer_provider`` (e.g. "PLIVO"). The handler then picks the
+least-loaded available number for that provider scoped to the lead's reseller,
+atomically claims it (channel increment), and releases it when the bridge ends.
 """
 
+import asyncio
+import uuid
 from typing import Any, Dict, Optional
+
+from pipecat.transports.daily.utils import (
+    DailyMeetingTokenParams,
+    DailyMeetingTokenProperties,
+    DailyRESTHelper,
+)
 
 from app.ai.voice.agents.breeze_buddy.handlers.internal.end_conversation import (
     end_conversation,
 )
+from app.ai.voice.agents.breeze_buddy.handlers.internal.stt import mute_stt
 from app.ai.voice.agents.breeze_buddy.template.context import TemplateContext
+from app.ai.voice.agents.breeze_buddy.utils.bridge_flag import (
+    STATUS_DISCONNECTED,
+    STATUS_FAILED,
+    STATUS_JOINED,
+    clear_bridge_flag,
+    get_bridge_flag,
+    set_bridge_flag,
+    update_bridge_status,
+)
 from app.ai.voice.agents.breeze_buddy.utils.transport.websockets import (
     close_websocket_safely,
 )
 from app.ai.voice.agents.breeze_buddy.utils.warm_transfer import set_transfer_flag
-from app.core.config.static import APP_BASE_URL
+from app.core.config.static import (
+    APP_BASE_URL,
+    BREEZE_BUDDY_DAILY_API_KEY,
+    BREEZE_BUDDY_DAILY_API_URL,
+)
 from app.core.logger import logger
+from app.core.transport.http_client import create_aiohttp_session
 from app.database.accessor import get_outbound_number_by_id
-from app.schemas import CallProvider
+from app.database.accessor.breeze_buddy.outbound_number import (
+    claim_outbound_number_if_available,
+    decrement_outbound_number_channels,
+    get_available_outbound_numbers_by_provider_and_reseller,
+    increment_outbound_number_channels,
+    update_outbound_number_status,
+)
+from app.schemas import (
+    CallProvider,
+    ExecutionMode,
+    OutboundNumber,
+    OutboundNumberStatus,
+)
+
+DAILY_EXECUTION_MODES = {
+    ExecutionMode.DAILY,
+    ExecutionMode.DAILY_TEST,
+    ExecutionMode.DAILY_STREAM,
+}
+
+# Providers whose bridge serializer is implemented (V1: Plivo only).
+# Transfers on other providers are rejected early to avoid a misleading
+# outbound-call that times out at the bridge join stage.
+BRIDGE_SUPPORTED_PROVIDERS = {"plivo"}
+
+# How long to wait for the bridge handler to mark itself "joined" after the
+# outbound agent call is initiated. Dial + ring + answer + Daily-join can
+# realistically take ~10-25s; 45s gives headroom without leaving the customer
+# hanging too long.
+BRIDGE_JOIN_TIMEOUT_SECONDS = 45.0
+BRIDGE_POLL_INTERVAL_SECONDS = 0.25
+
+
+# ---------------------------------------------------------------------------
+# Daily warm-transfer helpers
+# ---------------------------------------------------------------------------
+
+
+async def _mint_bridge_daily_token(room_url: str, aiohttp_session) -> Optional[str]:
+    """Mint a fresh owner token for the bridge handler to join the Daily room."""
+    daily_rest = DailyRESTHelper(
+        daily_api_key=BREEZE_BUDDY_DAILY_API_KEY,
+        daily_api_url=BREEZE_BUDDY_DAILY_API_URL,
+        aiohttp_session=aiohttp_session,
+    )
+    try:
+        return await daily_rest.get_token(
+            room_url,
+            expiry_time=3600,
+            params=DailyMeetingTokenParams(properties=DailyMeetingTokenProperties()),
+        )
+    except Exception as e:
+        logger.error(f"Failed to mint bridge Daily token for {room_url}: {e}")
+        return None
+
+
+async def _wait_for_bridge_status(
+    call_sid: str,
+    timeout_seconds: float = BRIDGE_JOIN_TIMEOUT_SECONDS,
+) -> Optional[str]:
+    """Poll the bridge flag until status leaves ``dialing`` or timeout.
+
+    Returns the terminal status (``joined`` / ``failed`` / ``disconnected``)
+    or None on timeout. A pre-join ``disconnected`` (clean WS close before the
+    bridge joined the room) is terminal — without this the poller would burn
+    the full timeout on a bridge that already ended.
+    """
+    deadline = asyncio.get_event_loop().time() + timeout_seconds
+    while asyncio.get_event_loop().time() < deadline:
+        flag = await get_bridge_flag(call_sid)
+        if flag is None:
+            # Flag was cleared by an error path — treat as failure.
+            return STATUS_FAILED
+        status = flag.get("status")
+        if status in (STATUS_JOINED, STATUS_FAILED, STATUS_DISCONNECTED):
+            return status
+        await asyncio.sleep(BRIDGE_POLL_INTERVAL_SECONDS)
+    return None
+
+
+async def _pick_and_claim_outbound_number(
+    provider: CallProvider, reseller_id: str
+) -> Optional[OutboundNumber]:
+    """Pick and atomically claim the first available outbound number from the pool.
+
+    For Plivo/Exotel: atomically increments channels; skips numbers at capacity.
+    For Twilio: marks first available number IN_USE (Twilio is one-call-per-number).
+    Returns the claimed record, or None if no number is available.
+    """
+    candidates = await get_available_outbound_numbers_by_provider_and_reseller(
+        provider, reseller_id
+    )
+    if not candidates:
+        return None
+
+    provider_name = provider.value.lower()
+
+    for num in candidates:
+        if provider_name in ("plivo", "exotel"):
+            claimed = await increment_outbound_number_channels(num.id)
+            if claimed:
+                logger.info(
+                    f"[DailyTransfer] Claimed outbound number {num.id} "
+                    f"({num.number}) via channel increment"
+                )
+                return num
+        else:
+            # Twilio: atomic conditional update — only succeeds when the row
+            # still has status=AVAILABLE, preventing double-allocation under
+            # concurrent transfer requests.
+            updated = await claim_outbound_number_if_available(num.id)
+            if updated:
+                logger.info(
+                    f"[DailyTransfer] Claimed outbound number {num.id} "
+                    f"({num.number}) via atomic status lock"
+                )
+                return num
+
+    return None
+
+
+async def _release_outbound_number(record: OutboundNumber, claimed: bool) -> None:
+    """Release a previously claimed outbound number back to the pool."""
+    if not claimed:
+        return
+    provider_name = record.provider.value.lower()
+    try:
+        if provider_name in ("plivo", "exotel"):
+            await decrement_outbound_number_channels(record.id)
+        else:
+            await update_outbound_number_status(
+                record.id, OutboundNumberStatus.AVAILABLE
+            )
+        logger.info(
+            f"[DailyTransfer] Released outbound number {record.id} ({record.number})"
+        )
+    except Exception as e:
+        logger.error(
+            f"[DailyTransfer] Failed to release outbound number {record.id}: {e}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Daily warm-transfer entry point
+# ---------------------------------------------------------------------------
+
+
+async def _connect_to_live_agent_daily(
+    context: TemplateContext,
+    args: Dict[str, Any],
+    transition_to: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Daily-mode warm transfer to a human agent on PSTN.
+
+    Mirrors the failure-mode shape of ``connect_to_live_agent`` so the LLM
+    sees consistent error contracts across telephony and Daily modes.
+    """
+    customer_call_sid = context.call_sid
+    logger.info(f"[DailyTransfer] Initiated for customer call {customer_call_sid}")
+
+    if not context.room_url:
+        logger.error(f"[DailyTransfer] No room_url on bot for {customer_call_sid}")
+        return {
+            "status": "failed",
+            "reason": "missing_room_url",
+            "message": "Daily room URL unavailable",
+        }
+
+    configurations = getattr(context.bot, "configurations", None)
+    transfer_number = getattr(configurations, "transfer_number", None)
+    if not transfer_number:
+        logger.warning(
+            f"[DailyTransfer] No transfer_number configured for {customer_call_sid}"
+        )
+        return {
+            "status": "failed",
+            "reason": "transfer_number_not_configured",
+            "message": (
+                "Transfer number is not configured for this assistant. "
+                "Continuing with AI."
+            ),
+        }
+
+    # --- Resolve outbound number ---
+    # Path A: lead already has an assigned number (telephony leads, or Daily leads
+    #         with an explicit template pin).
+    # Path B: Daily lead with no number → pick from pool using transfer_provider.
+    claimed = False
+    outbound_number_record: Optional[OutboundNumber] = None
+
+    if context.lead and context.lead.outbound_number_id:
+        outbound_number_record = await get_outbound_number_by_id(
+            context.lead.outbound_number_id
+        )
+        if not outbound_number_record:
+            logger.error(
+                f"[DailyTransfer] outbound number not found "
+                f"({context.lead.outbound_number_id})"
+            )
+            return {
+                "status": "failed",
+                "reason": "outbound_number_not_found",
+                "message": "Outbound number configuration not found",
+            }
+    else:
+        # Pool selection path.
+        transfer_provider_str = getattr(configurations, "transfer_provider", None)
+        if not transfer_provider_str:
+            logger.error(
+                f"[DailyTransfer] No outbound_number_id on lead and no "
+                f"transfer_provider in template config for {customer_call_sid}"
+            )
+            return {
+                "status": "failed",
+                "reason": "transfer_provider_not_configured",
+                "message": (
+                    "No outbound number or transfer provider configured. "
+                    "Continuing with AI."
+                ),
+            }
+
+        try:
+            provider_enum = CallProvider(transfer_provider_str.upper())
+        except ValueError:
+            logger.error(
+                f"[DailyTransfer] Invalid transfer_provider '{transfer_provider_str}' "
+                f"for {customer_call_sid}"
+            )
+            return {
+                "status": "failed",
+                "reason": "invalid_transfer_provider",
+                "message": "Transfer provider is not recognised. Continuing with AI.",
+            }
+
+        reseller_id = context.lead.reseller_id if context.lead else ""
+        outbound_number_record = await _pick_and_claim_outbound_number(
+            provider_enum, reseller_id
+        )
+        if not outbound_number_record:
+            logger.warning(
+                f"[DailyTransfer] No available outbound number for "
+                f"provider={transfer_provider_str} reseller={reseller_id}"
+            )
+            return {
+                "status": "failed",
+                "reason": "no_available_outbound_number",
+                "message": (
+                    "No outbound numbers are currently available. "
+                    "Continuing with AI."
+                ),
+            }
+        claimed = True
+
+    provider_enum = outbound_number_record.provider
+    provider_name = provider_enum.value.lower()
+
+    # Only providers whose bridge serializer is implemented are supported.
+    # Reject early so the LLM gets a deterministic failure rather than a
+    # 45-second timeout waiting for a bridge that can never join.
+    if provider_name not in BRIDGE_SUPPORTED_PROVIDERS:
+        logger.error(
+            f"[DailyTransfer] Provider '{provider_name}' is not supported by the "
+            f"bridge (supported: {BRIDGE_SUPPORTED_PROVIDERS}). "
+            f"Call {customer_call_sid}"
+        )
+        await _release_outbound_number(outbound_number_record, claimed)
+        return {
+            "status": "failed",
+            "reason": "unsupported_bridge_provider",
+            "message": (
+                f"Bridge is not yet available for provider '{provider_name}'. "
+                "Continuing with AI."
+            ),
+        }
+
+    # Lazy import to avoid circulars (telephony/utils imports the agent module).
+    from app.ai.voice.agents.breeze_buddy.services.telephony.utils import (
+        get_voice_provider,
+    )
+
+    _session_owned = context.aiohttp_session is None
+    aiohttp_session = context.aiohttp_session or create_aiohttp_session()
+    try:
+        return await _run_daily_transfer(
+            context=context,
+            customer_call_sid=customer_call_sid,
+            transfer_number=transfer_number,
+            outbound_number_record=outbound_number_record,
+            claimed=claimed,
+            provider_enum=provider_enum,
+            provider_name=provider_name,
+            get_voice_provider=get_voice_provider,
+            aiohttp_session=aiohttp_session,
+        )
+    finally:
+        if _session_owned:
+            try:
+                await aiohttp_session.close()
+            except Exception as close_err:
+                logger.warning(
+                    f"[DailyTransfer] Failed to close aiohttp session for "
+                    f"{customer_call_sid}: {close_err}"
+                )
+
+
+async def _run_daily_transfer(
+    context: TemplateContext,
+    customer_call_sid: str,
+    transfer_number: str,
+    outbound_number_record: OutboundNumber,
+    claimed: bool,
+    provider_enum,
+    provider_name: str,
+    get_voice_provider,
+    aiohttp_session,
+) -> Dict[str, Any]:
+    """Inner implementation of Daily warm-transfer, separated so the caller
+    can own the aiohttp session lifecycle."""
+
+    if not context.room_url:
+        await _release_outbound_number(outbound_number_record, claimed)
+        return {
+            "status": "failed",
+            "reason": "no_room_url",
+            "message": "Daily room URL is not set on context",
+        }
+
+    room_url: str = context.room_url
+
+    # Mint a Daily owner token for the bridge to use when joining the room.
+    daily_token = await _mint_bridge_daily_token(room_url, aiohttp_session)
+    if not daily_token:
+        await _release_outbound_number(outbound_number_record, claimed)
+        return {
+            "status": "failed",
+            "reason": "daily_token_mint_failed",
+            "message": "Could not mint Daily token for bridge",
+        }
+
+    # Derive room_name from the URL (Daily URL = https://{team}.daily.co/{room})
+    room_name = room_url.rstrip("/").rsplit("/", 1)[-1]
+
+    try:
+        voice_provider = get_voice_provider(provider_enum, aiohttp_session)
+    except Exception as e:
+        logger.error(
+            f"[DailyTransfer] get_voice_provider failed for {customer_call_sid}: {e}",
+            exc_info=True,
+        )
+        await _release_outbound_number(outbound_number_record, claimed)
+        return {
+            "status": "failed",
+            "reason": "provider_init_failed",
+            "message": "Failed to initialize telephony provider",
+        }
+
+    # Pre-create the bridge flag with a generated id and pass it through the
+    # provider answer/status URLs. For Plivo, the create-call response id is
+    # not guaranteed to be the same value later sent as CallUUID, so the bridge
+    # must not depend on matching those ids at answer time.
+    bridge_id = f"daily-bridge-{uuid.uuid4().hex}"
+    try:
+        ok = await set_bridge_flag(
+            call_sid=bridge_id,
+            room_url=room_url,
+            room_name=room_name,
+            lead_id=str(context.lead.id) if context.lead else "",
+            provider=provider_name,
+            outbound_number=outbound_number_record.number,
+            agent_phone=transfer_number,
+            daily_token=daily_token,
+            outbound_number_id=outbound_number_record.id if claimed else None,
+            claimed=claimed,
+        )
+        if not ok:
+            logger.error(
+                f"[DailyTransfer] set_bridge_flag returned False for {bridge_id}"
+            )
+            await _release_outbound_number(outbound_number_record, claimed)
+            return {
+                "status": "failed",
+                "reason": "bridge_flag_set_failed",
+                "message": "Failed to set bridge routing flag",
+            }
+    except Exception as e:
+        logger.error(
+            f"[DailyTransfer] set_bridge_flag raised for {bridge_id}: {e}",
+            exc_info=True,
+        )
+        await _release_outbound_number(outbound_number_record, claimed)
+        return {
+            "status": "failed",
+            "reason": "bridge_flag_set_failed",
+            "message": "Failed to set bridge routing flag",
+        }
+
+    # Initiate outbound call to the agent. The provider's answer webhook
+    # (e.g. /plivo/answer?bridge_id=...) will detect the bridge flag and route
+    # the WS to the bridge handler instead of the AI bot.
+    # make_call uses a blocking SDK / requests call; offload to a thread so
+    # the event loop is not stalled during network I/O.
+    try:
+        call_result = await asyncio.to_thread(
+            voice_provider.make_call,
+            customer_mobile_number=transfer_number,
+            outbound_number=outbound_number_record.number,
+            reseller_id=context.lead.reseller_id if context.lead else None,
+            template_name=None,
+            extra_params={"bridge_id": bridge_id},
+        )
+    except Exception as e:
+        logger.error(
+            f"[DailyTransfer] make_call exception for {customer_call_sid}: {e}",
+            exc_info=True,
+        )
+        await clear_bridge_flag(bridge_id)
+        await _release_outbound_number(outbound_number_record, claimed)
+        return {
+            "status": "failed",
+            "reason": "make_call_exception",
+            "message": "Failed to initiate agent call",
+            "error": str(e),
+        }
+
+    if not call_result or call_result.get("status") != "call_initiated":
+        logger.error(
+            f"[DailyTransfer] make_call did not initiate for {customer_call_sid}: "
+            f"{call_result}"
+        )
+        await clear_bridge_flag(bridge_id)
+        await _release_outbound_number(outbound_number_record, claimed)
+        return {
+            "status": "failed",
+            "reason": "make_call_failed",
+            "message": "Provider did not accept the agent call request",
+        }
+
+    agent_call_sid = call_result.get("sid")
+    if not agent_call_sid:
+        await clear_bridge_flag(bridge_id)
+        await _release_outbound_number(outbound_number_record, claimed)
+        return {
+            "status": "failed",
+            "reason": "missing_agent_call_sid",
+            "message": "Provider returned no call sid",
+        }
+
+    logger.info(
+        f"[DailyTransfer] Dialing agent {transfer_number} via {provider_name}, "
+        f"bridge_id={bridge_id}, agent_call_sid={agent_call_sid}, claimed={claimed}, "
+        f"waiting for bridge join…"
+    )
+
+    # Wait for the bridge to join the Daily room (or fail).
+    terminal_status = await _wait_for_bridge_status(bridge_id)
+
+    if terminal_status != STATUS_JOINED:
+        # Failure or timeout — the bridge's finally block will release the number
+        # if it got that far; if not (flag still exists), release here.
+        if terminal_status is None:
+            reason = "join_timeout"
+        else:
+            flag_at_failure = await get_bridge_flag(bridge_id) or {}
+            reason = flag_at_failure.get("failure_reason") or (
+                "bridge_disconnected_before_join"
+                if terminal_status == STATUS_DISCONNECTED
+                else "bridge_failed"
+            )
+        await update_bridge_status(bridge_id, STATUS_FAILED, failure_reason=reason)
+        # Release number only if the bridge never started (flag still holds claimed=True).
+        flag_now = await get_bridge_flag(bridge_id)
+        if flag_now and flag_now.get("claimed"):
+            await _release_outbound_number(outbound_number_record, claimed)
+        logger.warning(
+            f"[DailyTransfer] Bridge did not join for {agent_call_sid}: {reason}"
+        )
+        return {
+            "status": "failed",
+            "reason": reason,
+            "message": (
+                "Could not connect the human agent. Continuing with AI assistant."
+            ),
+        }
+
+    # Bridge is live in the Daily room — record transfer metadata.
+    transfer_meta = {
+        "status": "success",
+        "conference_id": agent_call_sid,  # No conference; reuse field for parity
+        "agent_phone_number": transfer_number,
+        "agent_call_id": agent_call_sid,
+        "bridge_id": bridge_id,
+        "via": "daily_bridge",
+    }
+    if context.lead and hasattr(context.lead, "metaData"):
+        if context.lead.metaData is None:
+            context.lead.metaData = {}
+        context.lead.metaData["transfer"] = transfer_meta
+
+    logger.info(
+        f"[DailyTransfer] Bridge joined for {agent_call_sid}; "
+        "muting AI STT and microphone"
+    )
+
+    # Mute STT so no new LLM turns fire while the bridge is live.
+    try:
+        await mute_stt(context, None)
+    except Exception as e:
+        logger.warning(
+            f"[DailyTransfer] mute_stt failed (continuing): {e}",
+            exc_info=True,
+        )
+
+    # Mute the bot's Daily microphone so it stops sending audio to the room.
+    try:
+        await context.bot.transport.update_publishing(
+            {"microphone": {"isPublishing": False}}
+        )
+        logger.info(f"[DailyTransfer] AI mic muted in Daily room for {agent_call_sid}")
+    except Exception as e:
+        logger.warning(
+            f"[DailyTransfer] update_publishing mute failed (continuing): {e}",
+            exc_info=True,
+        )
+
+    # Unsubscribe the bot from room audio. Daily's virtual speaker selection
+    # is process-global: when the bridge runs in this same process, its
+    # speaker device also receives THIS client's room mix, which contains the
+    # bridge bot's published track — the human agent's own voice — so the
+    # agent hears themselves on the phone. Unsubscribed, this client renders
+    # nothing into the shared speaker.
+    try:
+        await context.bot.transport.update_subscriptions(
+            profile_settings={"base": {"microphone": "unsubscribed"}}
+        )
+        logger.info(
+            f"[DailyTransfer] AI bot unsubscribed from room audio for "
+            f"{agent_call_sid}"
+        )
+    except Exception as e:
+        logger.warning(
+            f"[DailyTransfer] update_subscriptions unsubscribe failed "
+            f"(continuing): {e}",
+            exc_info=True,
+        )
+
+    return {
+        "status": "success",
+        "conference_id": agent_call_sid,
+        "agent_call_id": agent_call_sid,
+        "bridge_id": bridge_id,
+        "message": "Successfully transferred to human agent",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Main entry point (telephony + Daily)
+# ---------------------------------------------------------------------------
 
 
 async def connect_to_live_agent(
+    context: TemplateContext,
+    args: Dict[str, Any],
+    transition_to: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Guarded entry point for warm transfer (telephony + Daily).
+
+    Templates can wire this handler as both a node function and a node action,
+    firing it twice for one transfer intent (observed in prod logs as two
+    concurrent executions — which would dial the agent twice and run two
+    bridges). The bot instance lives for exactly one call, so an attribute
+    works as the in-flight latch; the single event loop makes check-then-set
+    atomic. The latch stays set after a successful transfer and is released
+    after a failure so the LLM can legitimately retry later.
+    """
+    if getattr(context.bot, "_transfer_in_flight", False):
+        logger.warning(
+            f"Duplicate connect_to_live_agent invocation suppressed for "
+            f"{context.call_sid}"
+        )
+        return {
+            "status": "in_progress",
+            "reason": "transfer_already_in_progress",
+            "message": "A transfer is already in progress.",
+        }
+    context.bot._transfer_in_flight = True
+    try:
+        result = await _connect_to_live_agent_impl(context, args, transition_to)
+    except Exception:
+        context.bot._transfer_in_flight = False
+        raise
+    if not isinstance(result, dict) or result.get("status") != "success":
+        context.bot._transfer_in_flight = False
+    return result
+
+
+async def _connect_to_live_agent_impl(
     context: TemplateContext,
     args: Dict[str, Any],
     transition_to: Optional[str] = None,
@@ -41,6 +678,13 @@ async def connect_to_live_agent(
         Dict with status, reason, message, conference_id, agent_call_id
     """
     logger.info(f"Transfer called for {context.call_sid}")
+
+    # Daily-mode calls have no telephony leg to bridge into — delegate to the
+    # Daily-specific handler which dials the agent on PSTN and bridges audio
+    # into the Daily room via an in-process WebSocket forwarder.
+    lead = context.lead
+    if lead is not None and lead.execution_mode in DAILY_EXECUTION_MODES:
+        return await _connect_to_live_agent_daily(context, args, transition_to)
 
     # Fetch outbound number from database
     if not context.lead or not context.lead.outbound_number_id:
@@ -158,7 +802,6 @@ async def connect_to_live_agent(
             )
 
             agent_call_id = conference_result.get("agent_call_id")
-            conference_result.get("conference_id")
 
             transfer_meta = {
                 "status": "success",
@@ -200,11 +843,9 @@ async def connect_to_live_agent(
                     and hasattr(context.bot, "ws")
                     and context.bot.ws
                 ):
-
                     logger.info(
                         f"Explicitly closing websocket for Plivo transfer on call {context.call_sid}"
                     )
-
                     await close_websocket_safely(
                         context.bot.ws, 1000, "Transfer complete"
                     )

--- a/app/ai/voice/agents/breeze_buddy/services/daily/transfer_bridge.py
+++ b/app/ai/voice/agents/breeze_buddy/services/daily/transfer_bridge.py
@@ -1,0 +1,421 @@
+"""
+In-process audio bridge between a telephony WebSocket leg and a Daily room.
+
+Used by the Daily warm-transfer flow: when the dialed agent picks up, the
+telephony provider opens a WebSocket to the bridge endpoint. This module
+builds a Pipecat dual-transport pipeline that forwards audio in both
+directions with no STT/LLM/TTS in the path. Sample-rate conversion is
+delegated to Pipecat's transport layer (input transport emits frames at its
+native rate; output transport resamples to its own configured rate). The
+telephony sender is unpaced (see _UnpacedFastAPIWebsocketOutputTransport) and
+the daily→tel stream is primed with silence so event-loop jitter doesn't
+become audible gaps on the phone leg.
+
+V1 supports Plivo only. Exotel works through the same dispatcher path and
+can be added by wiring its serializer + provider hangup; Twilio requires a
+separate dial path (its `make_call` does not route through `/answer`).
+"""
+
+import asyncio
+import os
+from typing import Optional
+
+import plivo
+from fastapi import WebSocket
+from pipecat.frames.frames import (
+    Frame,
+    InputAudioRawFrame,
+    OutputAudioRawFrame,
+)
+from pipecat.pipeline.parallel_pipeline import ParallelPipeline
+from pipecat.pipeline.pipeline import Pipeline
+from pipecat.pipeline.runner import PipelineRunner
+from pipecat.pipeline.task import PipelineTask
+from pipecat.processors.frame_processor import FrameDirection, FrameProcessor
+from pipecat.serializers.plivo import PlivoFrameSerializer
+from pipecat.transports.daily.transport import DailyParams, DailyTransport
+from pipecat.transports.websocket.fastapi import (
+    FastAPIWebsocketOutputTransport,
+    FastAPIWebsocketParams,
+    FastAPIWebsocketTransport,
+)
+
+from app.ai.voice.agents.breeze_buddy.template.vad import TELEPHONY_SAMPLE_RATE
+from app.ai.voice.agents.breeze_buddy.utils.bridge_flag import (
+    STATUS_DISCONNECTED,
+    STATUS_FAILED,
+    STATUS_JOINED,
+    clear_bridge_flag,
+    get_bridge_flag,
+    update_bridge_status,
+)
+from app.core.config.static import PLIVO_AUTH_ID, PLIVO_AUTH_TOKEN
+from app.core.logger import logger
+from app.database.accessor.breeze_buddy.outbound_number import (
+    decrement_outbound_number_channels,
+    update_outbound_number_status,
+)
+from app.schemas import OutboundNumberStatus
+
+# Daily bridge audio stays at 16 kHz on the WebRTC side. The Plivo side remains
+# 8 kHz mu-law; Pipecat's output transport performs the 16k -> 8k conversion.
+DAILY_BRIDGE_AUDIO_IN_SAMPLE_RATE = 16000
+DAILY_BRIDGE_AUDIO_OUT_SAMPLE_RATE = 16000
+
+# Plivo media frames are 20 ms at 8 kHz. Keep our outgoing playAudio cadence
+# aligned with that instead of Pipecat's default 40 ms chunks.
+TELEPHONY_BRIDGE_AUDIO_OUT_10MS_CHUNKS = 2
+
+# Silence sent ahead of the first Daily audio frame so Plivo holds a standing
+# playout buffer. The bridge shares the FastAPI event loop; combined with the
+# unpaced sender below, this cushion keeps loop stalls up to this size from
+# becoming audible gaps on the phone leg.
+TELEPHONY_PRIME_MS = 160
+BRIDGE_BOT_NAME = "transfer-bridge"
+
+# ---------------------------------------------------------------------------
+# In-process bridge task registry
+# Maps bridge flag id → PipelineTask for active bridge pipelines.
+# Used by the telephony status callback to terminate a bridge when the
+# agent's call ends (rather than waiting for the WebSocket to close).
+# ---------------------------------------------------------------------------
+_bridge_tasks: dict[str, PipelineTask] = {}
+
+
+async def terminate_bridge(bridge_id: str) -> bool:
+    """Queue an EndFrame on the named bridge pipeline.
+
+    Returns True if a running bridge was found and signalled, False otherwise.
+    Safe to call from any async context in the same process.
+    """
+    task = _bridge_tasks.get(bridge_id)
+    if not task:
+        return False
+    from pipecat.frames.frames import EndFrame
+
+    await task.queue_frame(EndFrame())
+    logger.info(f"[BridgeRun] Termination signalled for bridge {bridge_id}")
+    return True
+
+
+async def _hangup_agent_leg(call_id: str) -> None:
+    """Best-effort hangup of the agent's PSTN leg via Plivo REST.
+
+    Failure paths close the WebSocket, but with keepCallAlive=true Plivo keeps
+    the call up — the agent would sit on a dead line until hanging up manually.
+    Idempotent: Plivo returns 404 when the call already ended.
+    """
+    try:
+        client = plivo.RestClient(PLIVO_AUTH_ID, PLIVO_AUTH_TOKEN)
+        await asyncio.to_thread(client.calls.delete, call_id)
+        logger.info(f"[BridgeRun] Hung up agent leg {call_id} after bridge failure")
+    except Exception as e:
+        logger.warning(
+            f"[BridgeRun] Agent-leg hangup for {call_id} skipped/failed: {e}"
+        )
+
+
+class _AudioForwarder(FrameProcessor):
+    """Converts incoming InputAudioRawFrame to OutputAudioRawFrame so it can
+    be sent out on a different transport's output side. All other frames
+    (StartFrame, EndFrame, SystemFrame, etc.) are passed through unchanged so
+    downstream output transports receive the lifecycle frames they need to
+    initialise their MediaSender.
+
+    When ``prime_ms`` is set, one silence frame of that duration is pushed
+    ahead of the first audio frame. Downstream this becomes a standing playout
+    buffer on the far end (Plivo queues playAudio and plays sequentially), so
+    send-side jitter shorter than the prime is inaudible. The silence uses the
+    incoming frame's sample rate so the output transport's stream resampler
+    only ever sees one input rate.
+
+    The optional label is used in periodic debug logs so audio flow can be
+    confirmed from the logs without attaching a debugger.
+    """
+
+    def __init__(self, label: str = "", prime_ms: int = 0, tap: bool = False):
+        super().__init__()
+        self._label = label
+        self._prime_ms = prime_ms
+        self._primed = prime_ms <= 0
+        self._count = 0
+        # Debug tap: accumulate forwarded PCM in memory (~32 KB/s at 16 kHz)
+        # so run_bridge can dump it to disk when the bridge ends.
+        self._tap_buffer: Optional[bytearray] = bytearray() if tap else None
+        self._tap_rate = 0
+
+    async def process_frame(self, frame: Frame, direction: FrameDirection):
+        await super().process_frame(frame, direction)
+        if isinstance(frame, InputAudioRawFrame):
+            if not self._primed:
+                self._primed = True
+                silence = b"\x00" * (
+                    frame.sample_rate * 2 * frame.num_channels * self._prime_ms // 1000
+                )
+                await self.push_frame(
+                    OutputAudioRawFrame(
+                        audio=silence,
+                        sample_rate=frame.sample_rate,
+                        num_channels=frame.num_channels,
+                    ),
+                    direction,
+                )
+                logger.debug(
+                    f"[BridgeRun] {self._label} primed {self._prime_ms}ms of silence"
+                )
+            if self._tap_buffer is not None:
+                self._tap_buffer += frame.audio
+                self._tap_rate = frame.sample_rate
+            self._count += 1
+            if self._count % 100 == 0:
+                logger.debug(
+                    f"[BridgeRun] {self._label} forwarded {self._count} frames"
+                )
+            await self.push_frame(
+                OutputAudioRawFrame(
+                    audio=frame.audio,
+                    sample_rate=frame.sample_rate,
+                    num_channels=frame.num_channels,
+                ),
+                direction,
+            )
+        else:
+            await self.push_frame(frame, direction)
+
+
+class _UnpacedFastAPIWebsocketOutputTransport(FastAPIWebsocketOutputTransport):
+    """Output transport without the per-chunk send throttle.
+
+    Pipecat's ``_write_audio_sleep`` paces sends to real time and re-anchors
+    its schedule whenever a chunk is late, so time lost to an event-loop stall
+    is never recovered — each stall becomes a permanent gap in the playAudio
+    stream (heard as crackling on the phone). The bridge's source is already
+    real-time (the Daily room), so arrival order paces sends naturally; with
+    the sleep removed, any backlog after a stall flushes immediately into
+    Plivo's server-side buffer instead of gapping.
+    """
+
+    async def _write_audio_sleep(self):
+        pass
+
+
+class _UnpacedFastAPIWebsocketTransport(FastAPIWebsocketTransport):
+    """FastAPIWebsocketTransport whose output side skips the send throttle."""
+
+    def __init__(
+        self,
+        websocket: WebSocket,
+        params: FastAPIWebsocketParams,
+        input_name: Optional[str] = None,
+        output_name: Optional[str] = None,
+    ):
+        super().__init__(websocket, params, input_name, output_name)
+        self._output = _UnpacedFastAPIWebsocketOutputTransport(
+            self, self._client, params, name=self._output_name
+        )
+
+
+def _build_telephony_serializer(provider: str, stream_id: str, call_id: str):
+    """Pipecat serializer for the dialed agent leg."""
+    if provider == "plivo":
+        return PlivoFrameSerializer(
+            stream_id=stream_id,
+            call_id=call_id,
+            auth_id=PLIVO_AUTH_ID,
+            auth_token=PLIVO_AUTH_TOKEN,
+            params=PlivoFrameSerializer.InputParams(sample_rate=TELEPHONY_SAMPLE_RATE),
+        )
+    raise NotImplementedError(
+        f"Bridge serializer not implemented for provider '{provider}'. "
+        "V1 supports Plivo only."
+    )
+
+
+async def run_bridge(
+    websocket: WebSocket,
+    provider: str,
+    stream_id: str,
+    call_id: str,
+    flag_id: str,
+    room_url: str,
+    daily_token: str,
+) -> None:
+    """Build and run the bridge pipeline until either leg disconnects.
+
+    Updates the Redis bridge flag as the bridge transitions through joined →
+    disconnected (or failed) so the AI bot's wait loop can react.
+
+    Args:
+        websocket: the accepted FastAPI WebSocket from the telephony provider.
+        provider: lowercase provider name ("plivo").
+        stream_id: provider stream id parsed from the WS handshake.
+        call_id: provider call sid.
+        flag_id: Redis bridge flag key — the generated pre-dial bridge id,
+            carried on the answer/status/WS URLs as ``bridge_id``. Also the
+            in-process task-registry key.
+        room_url: Daily room URL the AI bot is in.
+        daily_token: fresh owner token minted by the Daily handler.
+    """
+    _failed = False  # tracks whether an exception path already set STATUS_FAILED
+
+    # Debug tap: set BRIDGE_AUDIO_TAP_DIR to capture both directions as raw
+    # PCM (s16le mono) for offline echo/quality analysis. Deliberately a plain
+    # env read, not part of the static config surface — diagnostic only.
+    tap_dir = os.getenv("BRIDGE_AUDIO_TAP_DIR", "")
+    forward_tel_to_daily = _AudioForwarder("tel→daily", tap=bool(tap_dir))
+    forward_daily_to_tel = _AudioForwarder(
+        "daily→tel", prime_ms=TELEPHONY_PRIME_MS, tap=bool(tap_dir)
+    )
+
+    try:
+        # Build transports and pipeline inside the try block so that errors
+        # here (e.g. NotImplementedError for unsupported providers) are caught,
+        # published as STATUS_FAILED, and re-raised rather than leaving the
+        # warm-transfer poller spinning until its timeout fires.
+        serializer = _build_telephony_serializer(provider, stream_id, call_id)
+
+        telephony_transport = _UnpacedFastAPIWebsocketTransport(
+            websocket=websocket,
+            params=FastAPIWebsocketParams(
+                audio_in_enabled=True,
+                audio_out_enabled=True,
+                audio_in_sample_rate=TELEPHONY_SAMPLE_RATE,
+                audio_out_sample_rate=TELEPHONY_SAMPLE_RATE,
+                audio_out_10ms_chunks=TELEPHONY_BRIDGE_AUDIO_OUT_10MS_CHUNKS,
+                add_wav_header=False,
+                serializer=serializer,
+            ),
+        )
+
+        daily_transport = DailyTransport(
+            room_url=room_url,
+            token=daily_token,
+            bot_name=BRIDGE_BOT_NAME,
+            params=DailyParams(
+                audio_in_enabled=True,
+                audio_out_enabled=True,
+                # Read Daily as the mixed room speaker stream. Capturing each
+                # participant track separately and appending frames into one
+                # PSTN output stream can sound like jitter/stutter.
+                audio_in_user_tracks=False,
+                audio_in_sample_rate=DAILY_BRIDGE_AUDIO_IN_SAMPLE_RATE,
+                audio_out_sample_rate=DAILY_BRIDGE_AUDIO_OUT_SAMPLE_RATE,
+            ),
+        )
+
+        @daily_transport.event_handler("on_joined")
+        async def on_joined(transport, data):
+            await update_bridge_status(flag_id, STATUS_JOINED)
+            logger.info(f"[BridgeRun] Bridge joined Daily room for call {call_id}")
+
+        # Single pipeline with a ParallelPipeline so both directions share one
+        # PipelineTask and one StartFrame sequence. The previous dual-Pipeline /
+        # asyncio.gather approach caused both tasks to race over the shared
+        # transport instances during startup (DailyTransport.start() is not
+        # re-entrant), leaving both StartFrames permanently unacknowledged and
+        # the bridge frozen with no audio forwarded.
+        pipeline = Pipeline(
+            [
+                ParallelPipeline(
+                    [
+                        telephony_transport.input(),
+                        forward_tel_to_daily,
+                        daily_transport.output(),
+                    ],
+                    [
+                        daily_transport.input(),
+                        forward_daily_to_tel,
+                        telephony_transport.output(),
+                    ],
+                )
+            ]
+        )
+
+        # cancel_on_idle_timeout must be off: idle detection resets only on
+        # BotSpeakingFrame/UserSpeakingFrame, and this pipeline (no TTS, no
+        # VAD) emits neither — the default would kill every bridge at 300s.
+        task = PipelineTask(pipeline, enable_rtvi=False, cancel_on_idle_timeout=False)
+        runner = PipelineRunner(handle_sigint=False)
+
+        # Daily's virtual speaker selection (used for the mixed room stream) is
+        # process-global: a second concurrent bridge in this pod steals the
+        # room mix from the first, cross-feeding audio between the calls —
+        # each agent hears the other bridge's track (echo loops, and a privacy
+        # leak across unrelated calls). Refuse instead of corrupting both;
+        # this transfer fails cleanly and the AI conversation continues.
+        if _bridge_tasks:
+            raise RuntimeError("concurrent_bridge_unsupported_in_this_process")
+
+        # Register in the in-process registry so the status callback can reach us.
+        _bridge_tasks[flag_id] = task
+        logger.info(f"[BridgeRun] Starting bridge for call {call_id}, room {room_url}")
+
+        await runner.run(task)
+
+    except Exception as e:
+        _failed = True
+        logger.error(
+            f"[BridgeRun] Bridge exception for call {call_id}: {e}",
+            exc_info=True,
+        )
+        await update_bridge_status(flag_id, STATUS_FAILED, failure_reason=str(e))
+        await _hangup_agent_leg(call_id)
+        raise
+    finally:
+        if tap_dir:
+            for fwd, tag in (
+                (forward_tel_to_daily, "tel_to_daily"),
+                (forward_daily_to_tel, "daily_to_tel"),
+            ):
+                if not fwd._tap_buffer:
+                    continue
+                path = os.path.join(
+                    tap_dir, f"bridge-{call_id}-{tag}-{fwd._tap_rate}hz.raw"
+                )
+                try:
+                    with open(path, "wb") as f:
+                        f.write(fwd._tap_buffer)
+                    logger.info(
+                        f"[BridgeRun] Audio tap written: {path} (play with: "
+                        f"ffplay -f s16le -ar {fwd._tap_rate} -ch_layout mono "
+                        f"'{path}')"
+                    )
+                except Exception as tap_err:
+                    logger.warning(
+                        f"[BridgeRun] Audio tap write failed for {path}: {tap_err}"
+                    )
+
+        _bridge_tasks.pop(flag_id, None)
+
+        # On a clean exit, mark the bridge disconnected so waiters know it's
+        # over.  On a failure path the flag is already STATUS_FAILED (and the
+        # monotonic guard in update_bridge_status will reject any overwrite), so
+        # skip the STATUS_DISCONNECTED write to keep the failure signal intact.
+        if not _failed:
+            await update_bridge_status(flag_id, STATUS_DISCONNECTED)
+
+        # Release pool number if one was claimed by the warm-transfer handler.
+        flag = await get_bridge_flag(flag_id)
+        if flag and flag.get("claimed") and flag.get("outbound_number_id"):
+            oid = flag["outbound_number_id"]
+            prov = (flag.get("provider") or "").lower()
+            try:
+                if prov in ("plivo", "exotel"):
+                    await decrement_outbound_number_channels(oid)
+                elif prov == "twilio":
+                    await update_outbound_number_status(
+                        oid, OutboundNumberStatus.AVAILABLE
+                    )
+                logger.info(
+                    f"[BridgeRun] Released outbound number {oid} for call {call_id}"
+                )
+            except Exception as rel_err:
+                logger.error(
+                    f"[BridgeRun] Failed to release outbound number {oid}: {rel_err}"
+                )
+
+        await clear_bridge_flag(flag_id)
+        logger.info(f"[BridgeRun] Bridge ended for call {call_id}")
+
+
+__all__ = ["run_bridge", "terminate_bridge"]

--- a/app/ai/voice/agents/breeze_buddy/services/telephony/base_provider.py
+++ b/app/ai/voice/agents/breeze_buddy/services/telephony/base_provider.py
@@ -36,6 +36,7 @@ class VoiceCallProvider(ABC):
         outbound_number: str,
         reseller_id: Optional[str] = None,
         template_name: Optional[str] = None,
+        extra_params: Optional[Dict[str, str]] = None,
     ) -> Optional[Dict[str, Any]]:
         """
         Initiate a call.
@@ -49,6 +50,7 @@ class VoiceCallProvider(ABC):
             outbound_number: Caller ID / outbound number
             reseller_id: Optional merchant ID for tiered pod allocation
             template_name: Optional template name for WebSocket path routing
+            extra_params: Optional provider webhook query params
         """
 
     def set_completion_callback(self, callback):

--- a/app/ai/voice/agents/breeze_buddy/services/telephony/exotel/exotel.py
+++ b/app/ai/voice/agents/breeze_buddy/services/telephony/exotel/exotel.py
@@ -63,14 +63,16 @@ class ExotelProvider(VoiceCallProvider):
         outbound_number: str,
         reseller_id: Optional[str] = None,
         template_name: Optional[str] = None,
+        extra_params: Optional[Dict[str, str]] = None,
     ) -> Optional[Dict[str, Any]]:
         """
         Initiate an outbound call via Exotel.
 
         Note: Exotel uses applet-based routing configured in their dashboard,
         so reseller_id and template_name are not used here directly (included
-        for interface consistency). The template is resolved at answer-time
-        via the voicebot-url webhook handler.
+        for interface consistency). extra_params is also accepted for interface
+        consistency. The template is resolved at answer-time via the voicebot-url
+        webhook handler.
         """
         # Resolve applet app ID: telephony_config override > env default
         if self.telephony_config and self.telephony_config.applet_app_id:

--- a/app/ai/voice/agents/breeze_buddy/services/telephony/plivo/plivo.py
+++ b/app/ai/voice/agents/breeze_buddy/services/telephony/plivo/plivo.py
@@ -54,6 +54,7 @@ class PlivoProvider(VoiceCallProvider):
         outbound_number: str,
         reseller_id: Optional[str] = None,
         template_name: Optional[str] = None,
+        extra_params: Optional[dict[str, str]] = None,
     ):
         """
         Initiate an outbound call via Plivo.
@@ -69,6 +70,7 @@ class PlivoProvider(VoiceCallProvider):
             outbound_number: Caller ID / outbound number
             reseller_id: Optional merchant ID for tiered pod allocation
             template_name: Optional template name for WebSocket path routing
+            extra_params: Optional query params for answer/status callbacks
         """
         answer_url = f"{self.APP_BASE_URL}/agent/voice/breeze-buddy/plivo/answer"
         params = {}
@@ -76,15 +78,23 @@ class PlivoProvider(VoiceCallProvider):
             params["reseller_id"] = reseller_id
         if template_name:
             params["template"] = template_name
+        if extra_params:
+            params.update(extra_params)
         if params:
             answer_url += "?" + urlencode(params)
+
+        hangup_url = (
+            f"{self.APP_BASE_URL}/agent/voice/breeze-buddy/plivo/callback/status"
+        )
+        if extra_params:
+            hangup_url += "?" + urlencode(extra_params)
 
         try:
             response = self.client.calls.create(
                 from_=outbound_number,
                 to_=customer_mobile_number,
                 answer_url=answer_url,
-                hangup_url=f"{self.APP_BASE_URL}/agent/voice/breeze-buddy/plivo/callback/status",
+                hangup_url=hangup_url,
             )
 
             logger.info(f"Plivo call initiated with answer_url: {answer_url}")

--- a/app/ai/voice/agents/breeze_buddy/services/telephony/twilio/twilio.py
+++ b/app/ai/voice/agents/breeze_buddy/services/telephony/twilio/twilio.py
@@ -80,6 +80,7 @@ class TwilioProvider(VoiceCallProvider):
         outbound_number: str,
         reseller_id: Optional[str] = None,
         template_name: Optional[str] = None,
+        extra_params: Optional[Dict[str, str]] = None,
     ) -> Optional[Dict[str, Any]]:
         """
         Initiate an outbound call via Twilio.
@@ -99,6 +100,7 @@ class TwilioProvider(VoiceCallProvider):
             outbound_number: Caller ID / outbound number
             reseller_id: Optional merchant ID for tiered pod allocation
             template_name: Optional template name for WebSocket path routing
+            extra_params: Optional webhook query params
         """
         try:
             if ENABLE_VOICE_AGENT_POD_ISOLATION:
@@ -111,6 +113,8 @@ class TwilioProvider(VoiceCallProvider):
                     query_params["reseller_id"] = reseller_id
                 if template_name:
                     query_params["template"] = template_name
+                if extra_params:
+                    query_params.update(extra_params)
                 webhook_url = (
                     f"{self.APP_BASE_URL}/api/v1/twilio/allocate?"
                     + urlencode(query_params)

--- a/app/ai/voice/agents/breeze_buddy/template/context.py
+++ b/app/ai/voice/agents/breeze_buddy/template/context.py
@@ -139,6 +139,11 @@ class TemplateContext:
         return getattr(self.bot, "telephony_service", None)
 
     @property
+    def room_url(self):
+        """Daily room URL (only set in Daily mode)."""
+        return getattr(self.bot, "room_url", None)
+
+    @property
     def end_conversation_callbacks(self):
         """Get end conversation callbacks"""
         return self.bot.end_conversation_callbacks

--- a/app/ai/voice/agents/breeze_buddy/template/types.py
+++ b/app/ai/voice/agents/breeze_buddy/template/types.py
@@ -1241,6 +1241,13 @@ class ConfigurationModel(BaseModel):
     transfer_number: Optional[str] = Field(
         None, description="Phone number to transfer the call to"
     )
+    transfer_provider: Optional[str] = Field(
+        None,
+        description=(
+            "Telephony provider pool to use for Daily warm-transfer PSTN dial "
+            "(PLIVO / EXOTEL / TWILIO). Required when the lead has no outbound_number_id."
+        ),
+    )
     vad_config: Optional[VadConfig] = Field(
         None, description="Default VAD configuration for the template"
     )

--- a/app/ai/voice/agents/breeze_buddy/utils/bridge_flag.py
+++ b/app/ai/voice/agents/breeze_buddy/utils/bridge_flag.py
@@ -1,0 +1,137 @@
+"""
+Redis state for the Daily warm-transfer telephony bridge.
+
+The AI bot (running in a Daily room) writes a bridge flag keyed by the dialed
+agent leg's call_sid. When the provider's answer webhook fires for that leg,
+the dispatcher looks up the flag and routes the WebSocket to the bridge
+handler instead of the standard AI bot path. The handler updates the flag
+status as it joins / fails so the AI bot can decide whether to hand off or
+inform the LLM that the transfer failed.
+"""
+
+import json
+import time
+from typing import Any, Dict, Optional
+
+from app.core.logger import logger
+from app.services.redis.client import get_redis_service
+
+BRIDGE_FLAG_PREFIX = "bridge:"
+BRIDGE_FLAG_TTL_SECONDS = 7200  # 2h, matches transfer flag
+
+STATUS_DIALING = "dialing"
+STATUS_JOINED = "joined"
+STATUS_FAILED = "failed"
+STATUS_DISCONNECTED = "disconnected"
+
+# Once a flag reaches one of these states it must not be overwritten.
+# The warm-transfer poller and the bridge handler can both write status
+# concurrently (timeout-failure vs joined/disconnected); monotonic
+# enforcement ensures the first terminal write wins.
+_TERMINAL_STATUSES = {STATUS_JOINED, STATUS_FAILED}
+
+
+def _key(call_sid: str) -> str:
+    return f"{BRIDGE_FLAG_PREFIX}{call_sid}"
+
+
+async def set_bridge_flag(
+    call_sid: str,
+    room_url: str,
+    room_name: str,
+    lead_id: str,
+    provider: str,
+    outbound_number: str,
+    agent_phone: str,
+    daily_token: str,
+    outbound_number_id: Optional[str] = None,
+    claimed: bool = False,
+    ttl_seconds: int = BRIDGE_FLAG_TTL_SECONDS,
+) -> bool:
+    """Write the initial bridge flag in `dialing` status.
+
+    ``outbound_number_id`` and ``claimed`` are set when the Daily warm-transfer
+    handler picked a number from the pool. The bridge's finally block reads
+    these to release the number when the call ends.
+    """
+    payload = {
+        "room_url": room_url,
+        "room_name": room_name,
+        "lead_id": lead_id,
+        "provider": provider,
+        "outbound_number": outbound_number,
+        "outbound_number_id": outbound_number_id,
+        "claimed": claimed,
+        "agent_phone": agent_phone,
+        "daily_token": daily_token,
+        "status": STATUS_DIALING,
+        "failure_reason": None,
+        "created_at": time.time(),
+    }
+    redis = await get_redis_service()
+    ok = await redis.setex(_key(call_sid), json.dumps(payload), ttl_seconds)
+    if ok:
+        logger.info(f"[BRIDGE REDIS] Set flag for call {call_sid} (room={room_name})")
+    else:
+        logger.error(f"[BRIDGE REDIS] Failed to set flag for call {call_sid}")
+    return ok
+
+
+async def get_bridge_flag(call_sid: str) -> Optional[Dict[str, Any]]:
+    """Return bridge flag payload or None."""
+    redis = await get_redis_service()
+    raw = await redis.get(_key(call_sid))
+    if not raw:
+        return None
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError as e:
+        logger.error(f"[BRIDGE REDIS] Invalid JSON for call {call_sid}: {e}")
+        return None
+
+
+async def update_bridge_status(
+    call_sid: str,
+    status: str,
+    failure_reason: Optional[str] = None,
+) -> bool:
+    """Update status (and optional failure_reason) on an existing flag.
+
+    Monotonic: once the flag is in a terminal state (joined / failed) no
+    further status writes are accepted.  This prevents the warm-transfer
+    timeout path from overwriting a ``joined`` written by the bridge handler
+    (or vice-versa) when both race to write after a near-simultaneous event.
+    """
+    flag = await get_bridge_flag(call_sid)
+    if not flag:
+        logger.warning(
+            f"[BRIDGE REDIS] update_bridge_status: no flag for call {call_sid}"
+        )
+        return False
+
+    current = flag.get("status")
+    if current in _TERMINAL_STATUSES:
+        logger.debug(
+            f"[BRIDGE REDIS] Ignoring status={status} for call {call_sid}: "
+            f"already terminal ({current})"
+        )
+        return False
+
+    flag["status"] = status
+    if failure_reason is not None:
+        flag["failure_reason"] = failure_reason
+
+    redis = await get_redis_service()
+    ok = await redis.setex(_key(call_sid), json.dumps(flag), BRIDGE_FLAG_TTL_SECONDS)
+    if ok:
+        logger.info(
+            f"[BRIDGE REDIS] Updated call {call_sid} status={status} "
+            f"reason={failure_reason}"
+        )
+    return ok
+
+
+async def clear_bridge_flag(call_sid: str) -> bool:
+    """Delete the bridge flag."""
+    redis = await get_redis_service()
+    return await redis.delete(_key(call_sid))

--- a/app/api/routers/breeze_buddy/telephony/__init__.py
+++ b/app/api/routers/breeze_buddy/telephony/__init__.py
@@ -11,6 +11,7 @@ Sub-modules:
 from fastapi import APIRouter
 
 from .answer import router as answer_router
+from .bridge import router as bridge_router
 from .callbacks import router as callbacks_router
 
 router = APIRouter()
@@ -20,3 +21,6 @@ router.include_router(callbacks_router, prefix="", tags=["telephony-callbacks"])
 
 # Include answer router (unified call answering endpoint)
 router.include_router(answer_router, prefix="", tags=["telephony-answer"])
+
+# Include bridge router (Daily warm-transfer agent leg WebSocket)
+router.include_router(bridge_router, prefix="", tags=["telephony-bridge"])

--- a/app/api/routers/breeze_buddy/telephony/answer/handlers.py
+++ b/app/api/routers/breeze_buddy/telephony/answer/handlers.py
@@ -53,6 +53,7 @@ from app.ai.voice.agents.breeze_buddy.services.telephony.plivo.recording import 
     start_call_recording,
 )
 from app.ai.voice.agents.breeze_buddy.template.types import TTSConfig
+from app.ai.voice.agents.breeze_buddy.utils.bridge_flag import get_bridge_flag
 from app.core.config.dynamic import (
     BB_NOISE_CANCELLATION_ENABLED,
     BB_NOISE_CANCELLATION_LEVEL,
@@ -271,8 +272,15 @@ def _build_websocket_url(
 # ---------------------------------------------------------------------------
 
 
-async def _build_plivo_stream_xml(ws_url: str) -> str:
-    """Build Plivo XML response with Stream element for WebSocket connection."""
+async def _build_plivo_stream_xml(ws_url: str, audio_track: str = "") -> str:
+    """Build Plivo XML response with Stream element for WebSocket connection.
+
+    ``audio_track`` (e.g. "inbound") pins the Stream's audioTrack attribute.
+    The warm-transfer bridge sets it explicitly so the WS media can never
+    contain audio we injected via playAudio (which would loop the customer's
+    voice back into the Daily room). Empty string omits the attribute,
+    preserving the existing AI-bot behavior.
+    """
     noise_cancellation_enabled = await BB_NOISE_CANCELLATION_ENABLED()
     noise_cancellation_level = await BB_NOISE_CANCELLATION_LEVEL()
     noise_cancellation_attr = (
@@ -289,13 +297,15 @@ async def _build_plivo_stream_xml(ws_url: str) -> str:
             f'noiseCancellationLevel="{noise_cancellation_level}"'
         )
 
+    audio_track_attr = f'audioTrack="{audio_track}" ' if audio_track else ""
+
     # Escape special XML characters in URL (primarily & -> &amp;)
     # Using html_escape with quote=False to avoid escaping quotes in the URL
     ws_url_escaped = html_escape(ws_url, quote=False)
 
     return f"""<?xml version="1.0" encoding="UTF-8"?>
 <Response>
-    <Stream {noise_cancellation_attr} bidirectional="true" keepCallAlive="true" contentType="audio/x-mulaw;rate=8000">
+    <Stream {noise_cancellation_attr} {audio_track_attr}bidirectional="true" keepCallAlive="true" contentType="audio/x-mulaw;rate=8000">
         {ws_url_escaped}
     </Stream>
 </Response>"""
@@ -348,9 +358,9 @@ def _build_json_response(ws_url: str) -> Response:
     )
 
 
-async def _build_xml_response(ws_url: str) -> HTMLResponse:
+async def _build_xml_response(ws_url: str, audio_track: str = "") -> HTMLResponse:
     """Build Plivo XML response."""
-    xml = await _build_plivo_stream_xml(ws_url)
+    xml = await _build_plivo_stream_xml(ws_url, audio_track=audio_track)
     return HTMLResponse(content=xml, media_type="application/xml")
 
 
@@ -519,11 +529,11 @@ async def handle_provider_answer(request: Request, provider: str) -> Response:
     """
     tag = f"Answer:{provider}"
 
-    # Extract call params
-    if request.method == "GET":
-        params = dict(request.query_params)
-    else:
-        params = dict(await request.form())
+    # Extract call params. Keep query params even for POST callbacks because
+    # provider answer URLs can include our routing metadata (e.g. bridge_id).
+    params = dict(request.query_params)
+    if request.method != "GET":
+        params.update(dict(await request.form()))
 
     call_id, from_number, to_number = _extract_call_params(params, provider)
     logger.info(f"[{tag}] call_id={call_id}, from={from_number}, to={to_number}")
@@ -531,6 +541,32 @@ async def handle_provider_answer(request: Request, provider: str) -> Response:
     if not call_id:
         logger.error(f"[{tag}] Missing call ID")
         return _error_response(provider, "Missing call identifier", 400)
+
+    # Daily warm-transfer bridge: when the AI bot dials a human agent, it
+    # writes a bridge flag keyed by a generated bridge_id and passes that id
+    # through the provider answer URL. Detect that here and route the WS to
+    # the bridge endpoint instead of the AI bot.
+    # Skips pod allocation, IVR, inbound policy — none apply to the bridge.
+    # Only route to the bridge endpoint for providers whose serializer is
+    # implemented (V1: Plivo only). Other providers fall through to the
+    # normal AI-bot path and the bridge will have already failed at the
+    # outbound-number selection stage in the warm-transfer handler.
+    _BRIDGE_SUPPORTED_PROVIDERS = {"plivo"}
+    bridge_id = str(params.get("bridge_id") or "")
+    bridge_flag = await get_bridge_flag(bridge_id) if bridge_id else None
+    if bridge_flag and provider in _BRIDGE_SUPPORTED_PROVIDERS:
+        ws_base = APP_BASE_URL.replace("https://", "wss://").replace("http://", "ws://")
+        bridge_ws_url = (
+            f"{ws_base}/agent/voice/breeze-buddy/{provider}/bridge/v2"
+            f"?bridge_id={quote(bridge_id, safe='')}"
+        )
+        logger.info(
+            f"[{tag}] Bridge flag found for {call_id} "
+            f"(bridge_id={bridge_id}); routing WS to {bridge_ws_url}"
+        )
+        # audioTrack pinned to inbound: the bridge republishes this WS media
+        # into the Daily room, so it must only ever contain the agent's mic.
+        return await _build_xml_response(bridge_ws_url, audio_track="inbound")
 
     # Plivo-specific: start recording
     if provider == "plivo":

--- a/app/api/routers/breeze_buddy/telephony/bridge.py
+++ b/app/api/routers/breeze_buddy/telephony/bridge.py
@@ -1,0 +1,123 @@
+"""
+WebSocket endpoint for the Daily warm-transfer bridge.
+
+When a Daily-mode lead transfers to a human agent, the AI bot dials the
+agent through the lead's telephony provider and writes a Redis bridge flag
+keyed by the agent leg's call_sid. The provider's answer webhook (see
+``answer/handlers.py``) detects that flag and points the provider's
+``<Connect><Stream>`` here instead of the standard AI bot WebSocket.
+
+This endpoint accepts the WebSocket, identifies the call, looks up the
+flag, and runs an in-process audio bridge between the telephony WS and the
+Daily room. No AI bot is started for this leg.
+"""
+
+from fastapi import APIRouter, WebSocket
+from pipecat.runner.utils import parse_telephony_websocket
+from starlette.websockets import WebSocketDisconnect
+
+from app.ai.voice.agents.breeze_buddy.services.daily.transfer_bridge import (
+    run_bridge,
+)
+from app.ai.voice.agents.breeze_buddy.utils.bridge_flag import (
+    STATUS_FAILED,
+    get_bridge_flag,
+    update_bridge_status,
+)
+from app.core.logger import logger
+
+router = APIRouter()
+
+
+@router.websocket("/{service_provider}/bridge/v2")
+async def telephony_bridge_handler(service_provider: str, websocket: WebSocket):
+    """Run the Daily warm-transfer audio bridge for the dialed agent leg."""
+    provider_name = service_provider.lower()
+    logger.info(f"[Bridge WS] Connection received for provider {provider_name}")
+
+    await websocket.accept()
+
+    try:
+        transport_type, call_data = await parse_telephony_websocket(websocket)
+    except Exception as e:
+        logger.error(f"[Bridge WS] parse_telephony_websocket failed: {e}")
+        await websocket.close(code=4000, reason="Bridge: cannot parse stream")
+        return
+
+    call_id = call_data.get("call_id")
+    stream_id = call_data.get("stream_id")
+    if not call_id or not stream_id:
+        logger.error(f"[Bridge WS] Missing call_id/stream_id in handshake: {call_data}")
+        await websocket.close(code=4000, reason="Bridge: missing call identifiers")
+        return
+
+    flag_id = str(websocket.query_params.get("bridge_id") or "")
+
+    flag = await get_bridge_flag(flag_id) if flag_id else None
+    if not flag:
+        logger.error(
+            f"[Bridge WS] No bridge flag for call {call_id} "
+            f"(flag_id={flag_id}); rejecting"
+        )
+        await websocket.close(code=4004, reason="Bridge: no flag for call")
+        return
+
+    expected_provider = flag.get("provider")
+    if expected_provider and expected_provider != provider_name:
+        logger.error(
+            f"[Bridge WS] Provider mismatch for call {call_id}: "
+            f"flag={expected_provider} ws={provider_name}"
+        )
+        await update_bridge_status(
+            flag_id, STATUS_FAILED, failure_reason="provider_mismatch"
+        )
+        await websocket.close(code=4003, reason="Bridge: provider mismatch")
+        return
+
+    room_url = flag.get("room_url")
+    daily_token = flag.get("daily_token")
+    if not room_url or not daily_token:
+        logger.error(f"[Bridge WS] Flag for {call_id} missing room_url/daily_token")
+        await update_bridge_status(
+            flag_id, STATUS_FAILED, failure_reason="missing_daily_credentials"
+        )
+        await websocket.close(code=4000, reason="Bridge: missing Daily credentials")
+        return
+
+    logger.info(
+        f"[Bridge WS] Starting bridge for call {call_id} "
+        f"(stream={stream_id}, flag_id={flag_id}, room={room_url})"
+    )
+
+    try:
+        await run_bridge(
+            websocket=websocket,
+            provider=provider_name,
+            stream_id=stream_id,
+            call_id=call_id,
+            flag_id=flag_id,
+            room_url=room_url,
+            daily_token=daily_token,
+        )
+    except WebSocketDisconnect:
+        logger.info(f"[Bridge WS] Client disconnected for call {call_id}")
+    except Exception as e:
+        logger.error(
+            f"[Bridge WS] Bridge run failed for call {call_id}: {e}",
+            exc_info=True,
+        )
+        try:
+            await update_bridge_status(flag_id, STATUS_FAILED, failure_reason=str(e))
+        except Exception as flag_err:
+            logger.warning(
+                f"[Bridge WS] Could not update bridge flag for {call_id}: {flag_err}"
+            )
+        try:
+            if websocket.client_state.name != "DISCONNECTED":
+                await websocket.close(code=1011, reason="Bridge: internal error")
+        except Exception as close_err:
+            logger.warning(
+                f"[Bridge WS] Could not close socket for {call_id}: {close_err}"
+            )
+    finally:
+        logger.info(f"[Bridge WS] Connection closed for call {call_id}")

--- a/app/api/routers/breeze_buddy/telephony/callbacks/handlers.py
+++ b/app/api/routers/breeze_buddy/telephony/callbacks/handlers.py
@@ -22,11 +22,21 @@ from app.ai.voice.agents.breeze_buddy.managers.calls import (
 from app.ai.voice.agents.breeze_buddy.services.agent_router.client import (
     safe_release_pod,
 )
+from app.ai.voice.agents.breeze_buddy.services.daily.transfer_bridge import (
+    terminate_bridge,
+)
 from app.ai.voice.agents.breeze_buddy.services.telephony.exotel.exotel import (
     exotel_dial_text,
 )
 from app.ai.voice.agents.breeze_buddy.services.telephony.plivo.plivo import (
     plivo_dial_xml,
+)
+from app.ai.voice.agents.breeze_buddy.utils.bridge_flag import (
+    STATUS_DISCONNECTED,
+    STATUS_FAILED,
+    STATUS_JOINED,
+    get_bridge_flag,
+    update_bridge_status,
 )
 from app.ai.voice.agents.breeze_buddy.utils.hold_transfer import (
     publish_hold_transfer_result,
@@ -240,18 +250,20 @@ async def handle_callback_status(request: Request, provider: str) -> Response:
         200 OK response
     """
     form = await request.form()
+    params = dict(request.query_params)
+    params.update(dict(form))
     logger.info(f"Received callback from {provider} with form data: {form}")
 
-    call_sid = form.get("CallSid")
+    call_sid = params.get("CallSid")
     call_status = None
 
     if provider.lower() == "twilio":
-        call_status = form.get("CallStatus")
+        call_status = params.get("CallStatus")
     elif provider.lower() == "exotel":
-        call_status = form.get("Status")
+        call_status = params.get("Status")
     elif provider.lower() == "plivo":
-        call_sid = form.get("CallUUID")
-        call_status = form.get("CallStatus")
+        call_sid = params.get("CallUUID")
+        call_status = params.get("CallStatus")
 
     # Terminal call statuses across all providers:
     # - completed, busy, failed, no-answer: universal (Twilio, Plivo, Exotel)
@@ -271,6 +283,7 @@ async def handle_callback_status(request: Request, provider: str) -> Response:
 
     if call_sid and call_status:
         call_status = str(call_status)
+        call_status_lower = call_status.lower()
         logger.info(
             f"Status callback: {call_status} for call {call_sid} from {provider}",
             extra={"call_sid": call_sid, "status": call_status, "provider": provider},
@@ -278,13 +291,58 @@ async def handle_callback_status(request: Request, provider: str) -> Response:
 
         # Backup release: notify Smart Router when call ends.
         # Idempotent — safe even if WebSocket already released the pod.
-        if call_status.lower() in ended_statuses:
+        if call_status_lower in ended_statuses:
             await safe_release_pod(
                 call_sid=str(call_sid), reason=f"status_{call_status}"
             )
 
+            # Bridge call (agent leg of a Daily warm transfer): the dial puts
+            # bridge_id in the callback URL's query params, so normal calls
+            # never enter this branch (and skip the Redis lookup entirely).
+            # Update the flag if it still exists, terminate the in-process
+            # pipeline, and skip retry logic — the agent leg has no lead.
+            bridge_id = params.get("bridge_id")
+            if bridge_id:
+                bridge_flag = await get_bridge_flag(bridge_id)
+                if bridge_flag:
+                    bridge_already_joined = (
+                        bridge_flag.get("status") == STATUS_JOINED
+                    )
+                    terminal_status = (
+                        STATUS_FAILED
+                        if call_status_lower
+                        in (
+                            "no-answer",
+                            "failed",
+                            "busy",
+                            "timeout",
+                            "cancel",
+                            "canceled",
+                            "cancelled",
+                        )
+                        or not bridge_already_joined
+                        else STATUS_DISCONNECTED
+                    )
+                    await update_bridge_status(
+                        bridge_id,
+                        terminal_status,
+                        failure_reason=(
+                            f"status_{call_status_lower}"
+                            if terminal_status == STATUS_FAILED
+                            else None
+                        ),
+                    )
+
+                terminated = await terminate_bridge(bridge_id)
+                logger.info(
+                    f"[BridgeRun] Status callback ({call_status}) for bridge "
+                    f"{bridge_id}, call {call_sid}: "
+                    f"{'pipeline terminated' if terminated else 'no local pipeline'}"
+                )
+                return Response(status_code=200)
+
         # Handle failed calls for retry logic
-        if call_status.lower() in (
+        if call_status_lower in (
             "no-answer",
             "failed",
             "busy",
@@ -315,9 +373,9 @@ async def handle_callback_status(request: Request, provider: str) -> Response:
                                 pub_channel,
                                 {
                                     "status": status_map.get(
-                                        call_status.lower(), call_status.lower()
+                                        call_status_lower, call_status_lower
                                     ),
-                                    "summary": f"Outbound call {call_status.lower()}",
+                                    "summary": f"Outbound call {call_status_lower}",
                                 },
                             )
                             logger.info(

--- a/app/database/accessor/breeze_buddy/outbound_number.py
+++ b/app/database/accessor/breeze_buddy/outbound_number.py
@@ -14,10 +14,12 @@ from app.database.decoder.breeze_buddy.outbound_number import (
 )
 from app.database.queries import run_parameterized_query
 from app.database.queries.breeze_buddy.outbound_number import (
+    claim_outbound_number_if_available_query,
     decrement_outbound_number_channels_query,
     disable_outbound_number_query,
     get_all_outbound_numbers_query,
     get_all_outbound_numbers_with_call_count_query,
+    get_available_outbound_numbers_by_provider_and_reseller_query,
     get_outbound_number_based_on_status_and_provider_query,
     get_outbound_number_by_id_query,
     get_outbound_number_by_number_query,
@@ -98,6 +100,36 @@ async def get_outbound_number_by_id(
 
     except Exception as e:
         logger.error(f"Error getting outbound number by ID: {e}")
+        return None
+
+
+async def claim_outbound_number_if_available(
+    outbound_number_id: str,
+) -> Optional[OutboundNumber]:
+    """
+    Atomically claim an outbound number (Twilio) by setting status to IN_USE
+    only when the current status is AVAILABLE.
+
+    Returns the updated record on success, or None if the number was already
+    claimed by a concurrent worker (or doesn't exist).
+    """
+    logger.info(f"Claiming outbound number (if available) for ID: {outbound_number_id}")
+    try:
+        query_text, values = claim_outbound_number_if_available_query(
+            outbound_number_id
+        )
+        result = await run_parameterized_query(query_text, values)
+        if result and get_row_count(result) > 0:
+            decoded_result = decode_outbound_number(result)
+            logger.info(f"Outbound number claimed atomically: {decoded_result}")
+            return decoded_result
+        logger.warning(
+            f"Could not claim outbound number {outbound_number_id} — "
+            "already in use or does not exist"
+        )
+        return None
+    except Exception as e:
+        logger.error(f"Error claiming outbound number {outbound_number_id}: {e}")
         return None
 
 
@@ -318,3 +350,32 @@ async def get_outbound_number_by_number(number: str) -> Optional[OutboundNumber]
     except Exception as e:
         logger.error(f"Error getting outbound number by number: {e}")
         return None
+
+
+async def get_available_outbound_numbers_by_provider_and_reseller(
+    provider: CallProvider, reseller_id: str
+) -> List[OutboundNumber]:
+    """
+    Return AVAILABLE outbound numbers for a provider scoped to a reseller.
+
+    Reseller-specific numbers are returned before generic ones (reseller_id IS NULL),
+    with least-loaded numbers first within each tier. Used by the Daily warm-transfer
+    handler to pick and claim a number from the pool when the lead has no
+    outbound_number_id.
+    """
+    try:
+        query_text, values = (
+            get_available_outbound_numbers_by_provider_and_reseller_query(
+                provider, reseller_id
+            )
+        )
+        result = await run_parameterized_query(query_text, values)
+        if result and get_row_count(result) > 0:
+            return decode_outbound_number_list(result)
+        return []
+    except Exception as e:
+        logger.error(
+            f"Error fetching available outbound numbers for provider={provider} "
+            f"reseller={reseller_id}: {e}"
+        )
+        return []

--- a/app/database/queries/breeze_buddy/outbound_number.py
+++ b/app/database/queries/breeze_buddy/outbound_number.py
@@ -204,6 +204,54 @@ def get_outbound_number_based_on_status_and_provider_query(
     return text, values
 
 
+def get_available_outbound_numbers_by_provider_and_reseller_query(
+    provider: CallProvider, reseller_id: str
+) -> Tuple[str, List[Any]]:
+    """
+    Return AVAILABLE numbers for a provider scoped to a reseller.
+
+    Ordering: reseller-specific numbers before generic (reseller_id IS NULL),
+    then least-loaded (lowest channels), then oldest first for stability.
+    """
+    text = f"""
+        SELECT *
+        FROM "{OUTBOUND_NUMBER_TABLE}"
+        WHERE "status" = 'AVAILABLE'
+          AND "provider" = $1
+          AND ("reseller_id" = $2 OR "reseller_id" IS NULL)
+        ORDER BY
+          CASE WHEN "reseller_id" = $2 THEN 0 ELSE 1 END,
+          "channels" ASC NULLS FIRST,
+          "created_at" DESC;
+    """
+    values = [provider.value, reseller_id]
+    return text, values
+
+
+def claim_outbound_number_if_available_query(
+    outbound_number_id: str,
+) -> Tuple[str, List[Any]]:
+    """
+    Atomically claim an outbound number by setting status to IN_USE only when
+    the current status is AVAILABLE.
+
+    The ``WHERE status = 'AVAILABLE'`` guard makes the claim atomic: if two
+    concurrent workers both fetch the same candidate and race here, only one
+    UPDATE will match (the other sees status = 'IN_USE' and returns no rows).
+    Used for Twilio numbers where capacity is modelled as a binary AVAILABLE /
+    IN_USE status rather than a channels counter.
+    """
+    text = f"""
+        UPDATE "{OUTBOUND_NUMBER_TABLE}"
+        SET "status" = 'IN_USE', "updated_at" = NOW()
+        WHERE "id" = $1
+          AND "status" = 'AVAILABLE'
+        RETURNING *;
+    """
+    values = [outbound_number_id]
+    return text, values
+
+
 def get_outbound_number_by_number_query(number: str) -> Tuple[str, List[Any]]:
     """
     Generate query to get outbound number by phone number.

--- a/docs/breeze_buddy/daily_warm_transfer.md
+++ b/docs/breeze_buddy/daily_warm_transfer.md
@@ -1,0 +1,144 @@
+# Daily Warm Transfer (Telephony Bridge)
+
+Design doc for warm-transferring a Daily (web/mobile) call to a human agent reachable only by phone (PSTN).
+
+## Status
+
+Implemented — V1 (Plivo only). Exotel can be added by wiring its serializer in
+`transfer_bridge._build_telephony_serializer`; Twilio requires a separate dial
+path (its `make_call` does not route through `/answer`).
+
+## Problem
+
+Today, `connect_to_live_agent` ([handlers/internal/warm_transfer.py](../../app/ai/voice/agents/breeze_buddy/handlers/internal/warm_transfer.py)) only works when the original customer call is itself a telephony call (Twilio / Plivo / Exotel). It uses each provider's conference / native-transfer API to bridge the customer's existing phone leg with a freshly-dialed agent leg.
+
+For Daily-mode leads (`ExecutionMode.DAILY*`), the customer is in a WebRTC room — there is no phone leg to bridge into. The function silently has no path for them.
+
+## Goal
+
+When the LLM in a Daily call invokes `connect_to_live_agent`:
+
+1. Dial the configured human agent on PSTN via the lead's existing telephony provider.
+2. Bridge that phone leg into the Daily room so customer (in Daily) and agent (on phone) talk live.
+3. AI bot leaves the room as soon as the bridge is live. No whisper / coaching.
+
+## Why a bridge bot, not Daily PSTN dial-out
+
+Daily.co supports native PSTN dial-out (`dialOut` API), which would add the agent's phone as a Daily participant directly with no bridge. We are **not** taking that path because:
+
+- Reuses existing Twilio / Plivo / Exotel outbound infrastructure, billing, outbound-number selection per reseller.
+- Keeps `lead.metaData.transfer` payload shape identical to the telephony warm-transfer flow → analytics queries don't fork.
+- No dependency on Daily PSTN credits / SIP trunk provisioning.
+
+The trade-off: we own the audio resampling and one extra Pipecat task per transfer.
+
+## Why in-process, not subprocess
+
+Originally planned as a subprocess (mirroring the AI bot's process model). Pivoted to **in-process**: the provider's WebSocket lands in the FastAPI server, so handling it in a new WS endpoint is direct. A subprocess would require shuttling audio frames over IPC (Redis pub-sub or unix socket) — adds latency, complexity, and a new failure surface for marginal isolation benefit. Crash isolation is per-handler: an exception in one bridge only kills that one transfer.
+
+## Architecture
+
+The bridge runs inside the FastAPI server as a WebSocket handler. When the dialed agent picks up, the telephony provider opens a WS to `/{provider}/bridge/v2` (e.g. `/agent/voice/breeze-buddy/plivo/bridge/v2`). That handler reads the Redis bridge flag, joins the existing Daily room as a Pipecat client, and runs a forwarding pipeline: telephony WS frames → resample/encode → Daily; Daily frames → resample/encode → telephony WS. The call identity (`call_id` / `stream_id`) is parsed from the provider's WebSocket handshake frames (via `parse_telephony_websocket`), not query parameters.
+
+## Sequence
+
+| Step | Actor              | Action                                                                                                         |
+| ---- | ------------------ | -------------------------------------------------------------------------------------------------------------- |
+| 1    | LLM (in AI Bot)    | Calls `connect_to_live_agent` function                                                                         |
+| 2    | AI Bot             | Resolves `outbound_number` from lead, picks provider                                                           |
+| 3    | AI Bot             | Generates `bridge_id` (`daily-bridge-{uuid}`), `set_bridge_flag(bridge_id, room_url, room_name, lead_id, …)`   |
+| 4    | AI Bot             | `provider.make_call(agent_phone, outbound_number, extra_params={"bridge_id": …})`                              |
+| 5    | AI Bot             | `bridge_id` rides the answer/hangup URLs as a query param (Plivo's create-call id ≠ webhook CallUUID)          |
+| 6    | AI Bot             | Waits (with 45s timeout) for `bridge:{bridge_id}.status == "joined"`                                           |
+| 7    | Provider           | Phone rings; agent picks up; provider POSTs answer webhook                                                     |
+| 8    | Webhook dispatcher | Reads `bridge:{bridge_id}` flag → returns `<Stream>` pointing at `…/plivo/bridge/v2?bridge_id=…`               |
+| 9    | Bridge WS handler  | Provider opens WS; handler joins Daily room R with bot token, builds forwarding pipeline                       |
+| 10   | Bridge WS handler  | Sets `bridge:{bridge_id}.status = "joined"`                                                                    |
+| 11   | AI Bot             | Sees joined status → mutes STT and its Daily mic; stays in the room                                                     |
+| 12   | Bridge WS handler  | Pumps audio in both directions until either leg ends                                                           |
+| 13   | Bridge WS handler  | On either leg ending: hangup the other; `update_lead_call_completion_details` + write `lead.metaData.transfer` |
+
+## Audio Bridging
+
+All conversion is delegated to Pipecat's transport layer — no custom resampling code.
+
+| Direction        | Source                                                              | Conversion                                                                     | Sink                                     |
+| ---------------- | ------------------------------------------------------------------- | ------------------------------------------------------------------------------ | ---------------------------------------- |
+| Customer → Agent | Daily mixed room speaker, 16 kHz mono (`audio_in_user_tracks=False`) | Output transport's SOXR stream resampler 16k → 8k, then `pcm_to_ulaw` (no-op resample + `lin2ulaw`) | Plivo `playAudio`, `audio/x-mulaw;8000`, 20 ms chunks |
+| Agent → Customer | Plivo WS μ-law 8 kHz                                                 | `ulaw_to_pcm` at 8 kHz (serializer `sample_rate=8000` pin), Daily output resamples 8k → 16k | Daily virtual mic, 16 kHz                 |
+
+Details that matter (each fixed a real audio bug):
+
+- **Mixed speaker, not per-participant tracks.** With `audio_in_user_tracks=True` (Pipecat default) each room participant arrives as a separate 16 kHz stream; naively forwarding interleaves them into one PSTN stream → garbled "shattering" audio on the phone.
+- **Serializer input rate pinned to 8000.** Without `InputParams(sample_rate=8000)` the Plivo serializer falls back to `StartFrame.audio_in_sample_rate` (16000), upsampling inbound μ-law to a rate the transport doesn't expect.
+- **Unpaced telephony sender + 160 ms silence prime.** The bridge runs on the shared FastAPI event loop and its source is exactly real-time, so Pipecat's per-chunk send throttle (which re-anchors after every late frame) turns loop stalls into permanent playout gaps on the Plivo side. The bridge overrides `_write_audio_sleep` to a no-op and primes the daily→tel stream with 160 ms of silence, giving Plivo a standing buffer that absorbs jitter.
+- **Idle timeout disabled.** The pipeline emits no `BotSpeakingFrame`/`UserSpeakingFrame`, so `PipelineTask`'s default idle timeout would cancel every bridge at 300 s. Built with `cancel_on_idle_timeout=False`.
+
+## Known limitations
+
+- **One bridge per pod at a time.** The mixed room stream uses Daily's virtual speaker device, and `Daily.select_speaker_device` is process-global — a second concurrent bridge in the same process steals the room mix from the first. `run_bridge` logs a warning when this happens. Fine at V1 transfer volume; revisit (subprocess isolation) if concurrent Daily transfers become common.
+
+## Redis Bridge Flag
+
+Key: `bridge:{bridge_id}` — a pre-dial generated `daily-bridge-{uuid}`. The agent leg's call sid cannot key the flag: Plivo's create-call response returns a `request_uuid` that differs from the `CallUUID` sent in webhooks, so `bridge_id` travels as a query param on the answer/hangup URLs instead.
+
+```json
+{
+  "room_url": "https://breezebuddy.daily.co/abc123",
+  "room_name": "abc123",
+  "lead_id": "lead_xyz",
+  "provider": "twilio",
+  "outbound_number": "+1...",
+  "agent_phone": "+91...",
+  "status": "dialing | joined | failed",
+  "failure_reason": "no_answer | busy | timeout | crash | null",
+  "created_at": 1736300000.0
+}
+```
+
+TTL: 2h (matches existing `transfer:{call_sid}` flag).
+
+## Provider differences
+
+The dispatcher-detect approach (preferred — see plan) means **no provider API changes**: each provider's existing inbound webhook entrypoint already handles `<Connect><Stream>` for AI calls; we add a flag check at the top to switch to the bridge stream URL when present.
+
+| Provider | Webhook entry                         | Notes                                   |
+| -------- | ------------------------------------- | --------------------------------------- |
+| Twilio   | `POST /v2/twilio/callback/{template}` | Returns TwiML `<Connect><Stream>`       |
+| Plivo    | `POST /v2/plivo/answer/{template}`    | Returns Plivo XML `<Stream>`            |
+| Exotel   | Applet-driven webhook                 | Stream URL returned via applet response |
+
+The bridge WebSocket endpoint must speak each provider's wire format (Twilio binary frame format vs Plivo vs Exotel) — Pipecat's telephony transports already abstract this. The bridge handler picks the transport based on the `{provider}` path parameter.
+
+## Failure Modes
+
+| Scenario                                         | Detection                                                      | Recovery                                                                                                                       |
+| ------------------------------------------------ | -------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| Agent doesn't answer (no_answer / busy / failed) | Provider status callback fires before `bridge.status = joined` | Set `bridge.status = failed`, `failure_reason`. AI bot poll/sub sees this → tells LLM transfer failed → conversation continues |
+| Answer timeout (30s)                             | AI bot wait expires                                            | Provider hangup API on `agent_call_sid`; flag → failed; LLM informed                                                           |
+| Customer leaves Daily mid-dial                   | Daily participant-left event in bridge handler                 | AI bot cancels outbound via provider hangup; bridge exits cleanly                                                              |
+| Bridge handler exception pre-join                | `bridge.status` never flips to joined; AI bot timeout          | Same as answer timeout                                                                                                         |
+| Telephony WS drops mid-call                      | WS disconnect event in handler                                 | Tear down Daily side; do **not** reconnect (PSTN won't reconnect cleanly); write transfer status `disconnected`                |
+| Agent hangs up normally                          | Telephony provider status callback `completed`                 | Bridge handler leaves Daily; lead marked complete                                                                              |
+
+## What gets shipped
+
+New code:
+
+- `app/ai/voice/agents/breeze_buddy/utils/bridge_flag.py` — Redis helpers for `bridge:{call_sid}`.
+- `app/ai/voice/agents/breeze_buddy/handlers/internal/daily_warm_transfer.py` — handler invoked by `connect_to_live_agent` for Daily mode.
+- `app/ai/voice/agents/breeze_buddy/services/daily/transfer_bridge.py` — async pipeline builder + run loop. Pure function called from the WS handler.
+- `app/api/routers/breeze_buddy/telephony/bridge.py` — new WebSocket endpoint `/{provider}/bridge/ws` that the dialed agent leg connects to.
+
+Modified:
+
+- [app/ai/voice/agents/breeze_buddy/handlers/internal/warm_transfer.py](../../app/ai/voice/agents/breeze_buddy/handlers/internal/warm_transfer.py) — branch on `execution_mode` at the top of `connect_to_live_agent`.
+- [app/api/routers/breeze_buddy/telephony/answer/handlers.py](../../app/api/routers/breeze_buddy/telephony/answer/handlers.py) — bridge-flag check at the top of `handle_provider_answer`; if set, return WS URL pointing at the bridge endpoint.
+- [app/api/routers/breeze_buddy/telephony/**init**.py](../../app/api/routers/breeze_buddy/telephony/__init__.py) — register bridge router.
+
+## Out of Scope
+
+- Whisper / coaching audio to agent before bridging in customer.
+- AI bot staying in room as silent transcription observer.
+- Per-leg recordings (Daily room cloud recording captures the full bridged audio).
+- Native Daily PSTN dial-out — alternative architecture, deferred.


### PR DESCRIPTION
…room

Adds in-process WebSocket audio bridge so that when an LLM in a Daily call invokes connect_to_live_agent, the human agent is dialled on PSTN and their voice is forwarded bidirectionally into the Daily room via a Pipecat dual-transport pipeline (no subprocess). The AI bot then leaves.

Changes:
- utils/bridge_flag.py: Redis state machine for the bridge leg (dialing → joined → disconnected/failed), keyed by agent call_sid
- handlers/internal/daily_warm_transfer.py: new handler; validates config, mints a fresh Daily owner token, dials agent via the lead's telephony provider, polls bridge flag, ends AI conversation on success
- handlers/internal/warm_transfer.py: branch on DAILY execution modes and delegate to daily_warm_transfer handler
- services/daily/transfer_bridge.py: run_bridge() builds FastAPIWebsocketTransport + DailyTransport pipelines with _AudioForwarder; marks flag joined before runner starts
- api/routers/breeze_buddy/telephony/bridge.py: /{provider}/bridge/v2 WebSocket endpoint; validates bridge flag, calls run_bridge()
- api/routers/breeze_buddy/telephony/__init__.py: mounts bridge router
- api/routers/breeze_buddy/telephony/answer/handlers.py: checks bridge flag at answer time and returns bridge WS URL instead of AI bot path
- agent/__init__.py + template/context.py: expose room_url on bot and TemplateContext so the handler can mint a token for the right room
- .githooks/pre-commit: make uv sync non-fatal + set UV_NO_SYNC=1 so subsequent uv run calls skip re-sync on incompatible platforms
- pyproject.toml: add pre-existing pipecat-stub-noise paths to pyrefly project-excludes (llm/stt/tts wrappers, mcp, language/tts utils)
- docs/breeze_buddy/daily_warm_transfer.md: design doc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added the ability to warm-transfer Daily video customers to human agents via PSTN using multiple telephony providers (Plivo, Exotel, Twilio) with provider-specific outbound number management.

* **Documentation**
  * Added comprehensive design documentation for Daily warm-transfer architecture, including bridge state management and provider-specific implementation details.

* **Chores**
  * Updated `.gitignore` to include additional configuration and temporary directory entries.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/juspay/clairvoyance/pull/751?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->