### PR TITLE
feat: add default call execution config fallback support

### DIFF
--- a/app/ai/voice/agents/breeze_buddy/managers/calls.py
+++ b/app/ai/voice/agents/breeze_buddy/managers/calls.py
@@ -106,6 +106,23 @@ async def _get_lead_config(lead: LeadCallTracker) -> Optional[CallExecutionConfi
             None,
         )
     if not config:
+        # Step 3: fall back to the default config (template IS NULL)
+        # Prefer merchant-specific default, then reseller-wide default
+        if lead.merchant_id:
+            config = next(
+                (
+                    c
+                    for c in configs
+                    if c.template is None and c.merchant_id == lead.merchant_id
+                ),
+                None,
+            )
+        if not config:
+            config = next(
+                (c for c in configs if c.template is None and c.merchant_id is None),
+                None,
+            )
+    if not config:
         logger.warning(
             f"No call execution config found for template: {lead.template} (template_id={lead.template_id})"
         )

--- a/app/api/routers/breeze_buddy/leads/handlers.py
+++ b/app/api/routers/breeze_buddy/leads/handlers.py
@@ -252,6 +252,27 @@ async def push_lead_handler(req: PushLeadRequest, current_user: UserInfo) -> Dic
             )
 
         if not config:
+            # Step 3: fall back to the default config (template IS NULL)
+            # Prefer merchant-specific default, then reseller-wide default
+            if req.merchant_id:
+                config = next(
+                    (
+                        c
+                        for c in call_execution_configs
+                        if c.template is None and c.merchant_id == req.merchant_id
+                    ),
+                    None,
+                )
+            if not config:
+                config = next(
+                    (
+                        c
+                        for c in call_execution_configs
+                        if c.template is None and c.merchant_id is None
+                    ),
+                    None,
+                )
+        if not config:
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,
                 detail=f"Call execution config not found for template: {template.name}",

--- a/app/database/accessor/breeze_buddy/call_execution_config.py
+++ b/app/database/accessor/breeze_buddy/call_execution_config.py
@@ -52,7 +52,7 @@ async def create_call_execution_config(
     max_retry: int,
     calling_provider: CallProvider,
     reseller_id: str,
-    template: str,
+    template: Optional[str],
     merchant_id: Optional[str],
     enable_international_call: bool,
     enable_calling: bool = True,
@@ -72,7 +72,9 @@ async def create_call_execution_config(
     pre_checks: Optional[List[Any]] = None,
     telephony_config: Optional[TelephonyConfig] = None,
 ) -> Optional[CallExecutionConfig]:
-    """Create a new call execution config record (upsert based on merchant_id + template)."""
+    """Create a new call execution config record (upsert based on partial unique indexes).
+    When template is None the row acts as the DEFAULT config for the merchant/reseller.
+    """
     logger.info(f"Creating call execution config for reseller ID: {reseller_id}")
 
     try:
@@ -144,7 +146,7 @@ async def get_call_execution_config_by_merchant_id(
             )
             return decoded_result
 
-        if merchant_id:
+        if merchant_id is not None:
             # If no config is found for the specific merchant_id, try with NULL
             logger.info(
                 f"No config found for merchant_id {merchant_id}, trying generic config."
@@ -193,7 +195,7 @@ async def get_all_call_execution_configs() -> List[CallExecutionConfig]:
 
 async def update_call_execution_config(
     reseller_id: str,
-    template: str,
+    template: Optional[str] = None,
     merchant_id: Optional[str] = None,
     initial_offset: Optional[int] = None,
     retry_offset: Optional[int] = None,

--- a/app/database/migrations/029_nullable_template_in_call_execution_config.sql
+++ b/app/database/migrations/029_nullable_template_in_call_execution_config.sql
@@ -1,0 +1,49 @@
+-- Migration 029: Allow NULL template in call_execution_config for default configs
+--
+-- Problem: Every template required its own call_execution_config row, even when
+-- all timing/settings were identical.
+--
+-- Solution: A row with template IS NULL acts as the DEFAULT config for a
+-- reseller/merchant. The resolution chain is:
+--   1. Exact template_id match
+--   2. Exact template name match
+--   3. Default config (template IS NULL)  <-- NEW
+--
+-- Changes:
+--   1. Make the `template` column nullable
+--   2. Drop the old non-partial unique constraint (doesn't handle NULLs correctly)
+--   3. Replace with partial unique indexes that cover all four cases:
+--        a) template IS NOT NULL, merchant IS NOT NULL  → unique on (merchant_id, template)
+--        b) template IS NOT NULL, merchant IS NULL      → unique on (reseller_id, template)
+--        c) template IS NULL,     merchant IS NOT NULL  → unique on (reseller_id, merchant_id)  [DEFAULT per merchant]
+--        d) template IS NULL,     merchant IS NULL      → unique on (reseller_id)               [DEFAULT for reseller]
+
+-- Step 1: Make template nullable
+ALTER TABLE call_execution_config
+    ALTER COLUMN "template" DROP NOT NULL;
+
+-- Step 2: Drop the old non-null-aware unique constraint
+ALTER TABLE call_execution_config
+    DROP CONSTRAINT IF EXISTS uq_call_execution_config_merchant_template;
+
+-- Step 3a: Per-template, per-merchant uniqueness (matches old behaviour)
+CREATE UNIQUE INDEX IF NOT EXISTS uq_call_execution_config_template_merchant
+    ON call_execution_config (merchant_id, template)
+    WHERE template IS NOT NULL AND merchant_id IS NOT NULL;
+
+-- Step 3b: Per-template, no merchant (reseller-level) uniqueness
+-- (replaces the old uq_call_execution_config_reseller_template_null_merchant)
+DROP INDEX IF EXISTS uq_call_execution_config_reseller_template_null_merchant;
+CREATE UNIQUE INDEX IF NOT EXISTS uq_call_execution_config_template_null_merchant
+    ON call_execution_config (reseller_id, template)
+    WHERE template IS NOT NULL AND merchant_id IS NULL;
+
+-- Step 3c: Default config per merchant (template IS NULL, merchant IS NOT NULL)
+CREATE UNIQUE INDEX IF NOT EXISTS uq_call_execution_config_default_with_merchant
+    ON call_execution_config (reseller_id, merchant_id)
+    WHERE template IS NULL AND merchant_id IS NOT NULL;
+
+-- Step 3d: Default config for reseller (template IS NULL, merchant IS NULL)
+CREATE UNIQUE INDEX IF NOT EXISTS uq_call_execution_config_default_no_merchant
+    ON call_execution_config (reseller_id)
+    WHERE template IS NULL AND merchant_id IS NULL;

--- a/app/database/queries/breeze_buddy/call_execution_config.py
+++ b/app/database/queries/breeze_buddy/call_execution_config.py
@@ -11,6 +11,26 @@ from app.schemas import CallProvider
 CALL_EXECUTION_CONFIG_TABLE = "call_execution_config"
 
 
+def _conflict_target(template: Optional[str], merchant_id: Optional[str]) -> str:
+    """
+    Return the ON CONFLICT partial-index target for an upsert into call_execution_config.
+
+    The migration created four partial unique indexes that cover all combinations of
+    nullable template and nullable merchant_id — this helper picks the right one.
+    """
+    if template is None:
+        return (
+            "(reseller_id, merchant_id) WHERE template IS NULL AND merchant_id IS NOT NULL"
+            if merchant_id is not None
+            else "(reseller_id) WHERE template IS NULL AND merchant_id IS NULL"
+        )
+    return (
+        "(merchant_id, template) WHERE template IS NOT NULL AND merchant_id IS NOT NULL"
+        if merchant_id is not None
+        else "(reseller_id, template) WHERE template IS NOT NULL AND merchant_id IS NULL"
+    )
+
+
 # Call execution config queries
 def insert_call_execution_config_query(
     id: str,
@@ -21,7 +41,7 @@ def insert_call_execution_config_query(
     max_retry: int,
     calling_provider: CallProvider,
     reseller_id: str,
-    template: str,
+    template: Optional[str],
     merchant_id: Optional[str],
     enable_international_call: bool,
     enable_calling: bool = True,
@@ -43,11 +63,11 @@ def insert_call_execution_config_query(
 ) -> Tuple[str, List[Any]]:
     """
     Generate query to insert call execution config record.
-    Uses ON CONFLICT to upsert based on (merchant_id, template) to prevent duplicates.
+    Uses ON CONFLICT to upsert based on unique constraints to prevent duplicates.
 
     Args:
         template_id: UUID of the template (preferred, for referential integrity)
-        template: Name of the template (kept for backward compatibility)
+        template: Name of the template (kept for backwards compatibility)
         pre_checks: JSON string of pre-check configurations
         telephony_config: JSON string of telephony provider overrides
     """
@@ -85,7 +105,7 @@ def insert_call_execution_config_query(
             "updated_at"
         )
         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29)
-        ON CONFLICT (merchant_id, template) DO UPDATE SET
+        ON CONFLICT {_conflict_target(template, merchant_id)} DO UPDATE SET
             initial_offset = EXCLUDED.initial_offset,
             retry_offset = EXCLUDED.retry_offset,
             call_start_time = EXCLUDED.call_start_time,
@@ -155,7 +175,7 @@ def get_call_execution_config_by_merchant_id_query(
     """
     Generate query to get call execution config by reseller ID and merchant identifier.
     """
-    if merchant_id:
+    if merchant_id is not None:
         text = f"""
             SELECT *
             FROM "{CALL_EXECUTION_CONFIG_TABLE}" 
@@ -208,7 +228,7 @@ def delete_call_execution_config_query(config_id: str) -> Tuple[str, List[Any]]:
 
 def update_call_execution_config_query(
     reseller_id: str,
-    template: str,
+    template: Optional[str] = None,
     merchant_id: Optional[str] = None,
     initial_offset: Optional[int] = None,
     retry_offset: Optional[int] = None,
@@ -315,16 +335,20 @@ def update_call_execution_config_query(
     reseller_id_param = param_count
     param_count += 1
 
-    values.append(template)
-    template_param = param_count
-    param_count += 1
+    if template is not None:
+        values.append(template)
+        template_param = param_count
+        param_count += 1
+        template_clause = f'"template" = ${template_param}'
+    else:
+        template_clause = '"template" IS NULL'
 
-    if merchant_id:
+    if merchant_id is not None:
         values.append(merchant_id)
         merchant_identifier_param = param_count
-        where_clause = f'reseller_id = ${reseller_id_param} AND "template" = ${template_param} AND merchant_id = ${merchant_identifier_param}'
+        where_clause = f"reseller_id = ${reseller_id_param} AND {template_clause} AND merchant_id = ${merchant_identifier_param}"
     else:
-        where_clause = f'reseller_id = ${reseller_id_param} AND "template" = ${template_param} AND merchant_id IS NULL'
+        where_clause = f"reseller_id = ${reseller_id_param} AND {template_clause} AND merchant_id IS NULL"
 
     text = f"""
         UPDATE "{CALL_EXECUTION_CONFIG_TABLE}"
@@ -356,7 +380,7 @@ def calling_activation_for_merchant_query(
             SET "enable_calling" = $1, "updated_at" = $2
             RETURNING *;
         """
-    elif merchant_id:
+    elif merchant_id is not None:
         # Update specific merchant (we always have reseller_id for the merchant)
         text = f"""
             UPDATE "{CALL_EXECUTION_CONFIG_TABLE}"

--- a/app/database/queries/breeze_buddy/template.py
+++ b/app/database/queries/breeze_buddy/template.py
@@ -17,7 +17,7 @@ def get_template_by_merchant_query(
     conditions = ["reseller_id = $1"]
     values = [reseller_id]
 
-    if merchant_id:
+    if merchant_id is not None:
         conditions.append(f"merchant_id = ${len(values) + 1}")
         values.append(merchant_id)
     else:

--- a/app/schemas/breeze_buddy/core.py
+++ b/app/schemas/breeze_buddy/core.py
@@ -216,7 +216,7 @@ class CreateCallExecutionConfigRequest(BaseModel):
     max_retry: int
     calling_provider: CallProvider
     reseller_id: str
-    template: str
+    template: Optional[str] = None
     merchant_id: Optional[str] = None
     enable_international_call: bool = True
     enable_calling: Optional[bool] = True
@@ -262,7 +262,7 @@ class UpdateCallExecutionConfigRequest(BaseModel):
     """Request to update call execution configuration"""
 
     reseller_id: str
-    template: str
+    template: Optional[str] = None
     merchant_id: Optional[str] = None
     initial_offset: Optional[int] = None
     retry_offset: Optional[int] = None
@@ -323,7 +323,7 @@ class CallExecutionConfig(BaseModel):
     max_retry: int
     calling_provider: CallProvider
     reseller_id: str
-    template: str
+    template: Optional[str] = None
     template_id: Optional[str] = None
     merchant_id: Optional[str] = None
     enable_international_call: bool = True


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for default call execution configurations that automatically serve as fallbacks when template-specific settings are unavailable.

* **Improvements**
  * Enhanced call execution configuration resolution with more flexible matching logic and robust default configuration handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<html><head></head><body><h2>Dev Proof: Default Call Execution Config Fallback</h2><h3>Before:
<img width="3456" height="2234" alt="image" src="https://github.com/user-attachments/assets/07a96e14-e82a-429d-8645-592a9efc9a5e" />
</h3><h3>After:</h3><h3>Setup</h3><ul><li><p>App running locally on port 8000</p></li>
<img width="3210" height="522" alt="image" src="https://github.com/user-attachments/assets/990392b6-f630-41f8-87a7-68df10039e0b" />


1. Push lead with all configs present | initial_offset=60 ✅
Proof:
<img width="2970" height="740" alt="image" src="https://github.com/user-attachments/assets/eb233ef9-8adc-40d8-bb39-c2981f99ab92" />
<img width="3456" height="2234" alt="image" src="https://github.com/user-attachments/assets/96769316-b93d-4aa2-941c-3befd10ceaf2" />

2. Delete template-specific config | initial_offset=120 ✅
Proof:
<img width="1728" height="1117" alt="Screenshot 2026-05-19 at 5 30 06 PM" src="https://github.com/user-attachments/assets/51cdc977-4fa7-417a-bc3c-27b7642ab003" />
<img width="692" height="233" alt="Screenshot 2026-05-19 at 5 30 32 PM" src="https://github.com/user-attachments/assets/f77a457b-b3d6-4036-b897-10432ed6d042" />

3. Delete merchant default config | initial_offset=180 ✅
Proof:
<img width="1728" height="1117" alt="Screenshot 2026-05-19 at 5 31 38 PM" src="https://github.com/user-attachments/assets/10b1751a-a07c-41bd-aa56-f6706fda67bb" />
<img width="906" height="270" alt="Screenshot 2026-05-19 at 5 31 55 PM" src="https://github.com/user-attachments/assets/cdc008d9-9c6e-4c64-90a0-d3ccd1350319" />

4.  Delete reseller default config | HTTP 404 ✅
Proof:
<img width="1728" height="1117" alt="Screenshot 2026-05-19 at 5 33 02 PM" src="https://github.com/user-attachments/assets/6b1e19b8-e221-4276-9408-b08f10a02a89" />

<p>Verified <code inline="">_get_lead_config()</code> fallback chain using a <code inline="">LeadCallTracker</code> with the same reseller/merchant/template.</p><p>Observed fallback order:</p><ol><li><p>Template-specific config</p></li><li><p>Merchant default config (<code inline="">template IS NULL</code>)</p></li><li><p>Reseller default config (<code inline="">template IS NULL AND merchant_id IS NULL</code>)</p></li><li><p>No config → <code inline="">None</code></p></li></ol><h3>Screenshots</h3><p>Attached:</p><ul><li><p>Curl responses</p></li><li><p>DB verification queries</p></li></ul></body></html>