### PR TITLE
fix: bust greeting audio cache on template PUT and DELETE

### DIFF
--- a/app/ai/voice/agents/breeze_buddy/template/cache.py
+++ b/app/ai/voice/agents/breeze_buddy/template/cache.py
@@ -91,6 +91,7 @@ async def invalidate_template(template_id: str) -> None:
     try:
         redis = await get_redis_service()
         await redis.delete(_key(template_id))
+        await redis.delete(f"greeting:template:{template_id}")
         logger.info(f"template cache invalidated: {template_id}")
     except Exception as exc:
         logger.warning(f"template cache invalidate failed for {template_id}: {exc}")


### PR DESCRIPTION
invalidate_template() only deletes the template model cache key (bb:template:{id}) but the pre-synthesized greeting audio is stored under a separate key (greeting:template:{id}). After a PUT, the old audio was still being served from Redis causing initial_greeting changes to have no effect until TTL expiry.

- Delete greeting:template:{id} in both PUT and DELETE handlers
- Add get_redis_service import to handlers.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cache handling for greeting templates to ensure updates and deletions are reflected promptly in the application.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/juspay/clairvoyance/pull/757)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->