### PR TITLE
fix: skip rate limit evaluation for inactive templates

### DIFF
--- a/app/ai/voice/agents/breeze_buddy/managers/calls.py
+++ b/app/ai/voice/agents/breeze_buddy/managers/calls.py
@@ -576,7 +576,9 @@ async def process_backlog_leads():
                     await _release_number(number_to_use.id, number_to_use.provider)
                     await release_lock_on_lead_by_id(locked_lead.id)
                     continue
-                if locked_lead.execution_mode == ExecutionMode.TELEPHONY:
+                if locked_lead.execution_mode == ExecutionMode.TELEPHONY and (
+                    template is None or template.is_active
+                ):
                     rate_limit_allowed, defer_seconds = (
                         await check_outbound_rate_limit_and_alert(
                             customer_phone=customer_mobile,


### PR DESCRIPTION
Only run outbound rate limit check when the template is active. Inactive templates still proceed through the full call flow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved handling of inactive templates in telephony call processing. Rate-limiting logic now correctly skips when templates are inactive, ensuring more accurate call queue management.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/juspay/clairvoyance/pull/763)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->