### PR TITLE
fix: set in-memory outcome to prevent BUSY default in direct mode

### DIFF
--- a/app/ai/voice/agents/breeze_buddy/template/hooks.py
+++ b/app/ai/voice/agents/breeze_buddy/template/hooks.py
@@ -244,6 +244,12 @@ class UpdateOutcomeInDatabaseHook(Hook):
                 )
                 outcome = "TRANSFERRED"
 
+            # Set in-memory outcome AFTER transfer override but BEFORE the
+            # async DB write.  This prevents a race condition in Direct Mode
+            # where end_conversation_global checks context.lead.outcome and
+            # defaults to BUSY because the async DB write hasn't completed yet.
+            context.lead.outcome = outcome
+
             # Update lead in database with outcome
             logger.info(
                 f"Updating lead {context.lead.id} in database with outcome: {outcome}, "


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a timing issue where outcome data could briefly display as stale in certain scenarios, ensuring more consistent and reliable outcome updates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/juspay/clairvoyance/pull/765?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->