### PR TITLE
fix(dispatcher): gate scheduler by execution_mode (no PSTN dial for Daily leads)

### DIFF
--- a/app/ai/voice/agents/breeze_buddy/dispatch/__init__.py
+++ b/app/ai/voice/agents/breeze_buddy/dispatch/__init__.py
@@ -18,7 +18,9 @@ from app.ai.voice.agents.breeze_buddy.dispatch.promoter import (
     stop_promoter,
 )
 from app.ai.voice.agents.breeze_buddy.dispatch.queue import (
+    DISPATCHABLE_EXECUTION_MODES,
     cancel_scheduled_lead,
+    is_dispatchable,
     schedule_lead,
 )
 from app.ai.voice.agents.breeze_buddy.dispatch.reconcilers import (
@@ -34,11 +36,13 @@ from app.ai.voice.agents.breeze_buddy.dispatch.worker import (
 )
 
 __all__ = [
+    "DISPATCHABLE_EXECUTION_MODES",
     "LeaderElection",
     "acquire_channel_token",
     "cancel_scheduled_lead",
     "clean_stale_bb_locks",
     "init_channel_semaphore",
+    "is_dispatchable",
     "monitor_dispatch_health",
     "reap_stuck_processing_lists",
     "reconcile_backlog_to_zset",

--- a/app/ai/voice/agents/breeze_buddy/dispatch/queue.py
+++ b/app/ai/voice/agents/breeze_buddy/dispatch/queue.py
@@ -16,7 +16,25 @@ from typing import Any, Optional, cast
 from app.ai.voice.agents.breeze_buddy.dispatch.keys import SCHEDULE_ZSET
 from app.core.config.static import BB_DISPATCH_QPS_JITTER_MS
 from app.core.logger import logger
+from app.schemas import ExecutionMode
 from app.services.redis import get_redis_service
+
+# Execution modes the event-driven dispatcher places outbound calls for.
+# Mirrors the WHERE clause in ``get_unscheduled_backlog_leads_query`` so the
+# ingest path, retry path, and dispatch-now path all match the reconciler.
+# DAILY/DAILY_TEST/DAILY_STREAM are web-only — they're either customer-
+# initiated (inbound) or handled by a separate room-creation + notification
+# flow, NOT by the worker's ``provider.make_call`` PSTN dial. HOLD_TRANSFER
+# is a transient mid-call leg, not a standalone outbound to schedule.
+DISPATCHABLE_EXECUTION_MODES = frozenset(
+    {ExecutionMode.TELEPHONY, ExecutionMode.TELEPHONY_TEST}
+)
+
+
+def is_dispatchable(execution_mode: ExecutionMode) -> bool:
+    """Return True if a lead with this execution_mode should be put on the
+    dispatch schedule (and processed by a worker)."""
+    return execution_mode in DISPATCHABLE_EXECUTION_MODES
 
 
 def _to_unix_ms(when: datetime) -> int:

--- a/app/ai/voice/agents/breeze_buddy/dispatch/worker.py
+++ b/app/ai/voice/agents/breeze_buddy/dispatch/worker.py
@@ -37,7 +37,10 @@ from app.ai.voice.agents.breeze_buddy.dispatch.keys import (
     reseller_paused_key,
     worker_heartbeat_key,
 )
-from app.ai.voice.agents.breeze_buddy.dispatch.queue import schedule_lead
+from app.ai.voice.agents.breeze_buddy.dispatch.queue import (
+    is_dispatchable,
+    schedule_lead,
+)
 from app.ai.voice.agents.breeze_buddy.managers.calls import (
     _acquire_number,
     _get_available_number,
@@ -249,6 +252,18 @@ class Worker:
             logger.info(
                 f"Worker {self._uuid}: lead {lead_id} status is "
                 f"{lead.status.value}, skipping"
+            )
+            return
+        if not is_dispatchable(lead.execution_mode):
+            # Defensive backstop. The ingest paths (handler, retry,
+            # dispatch-now) and the reconciler query all filter non-
+            # dispatchable modes out, so this should never fire. If it
+            # does, drop the lead with a loud log rather than dialling
+            # a phantom PSTN call for a DAILY/web-mode lead.
+            logger.error(
+                f"Worker {self._uuid}: lead {lead_id} has non-dispatchable "
+                f"execution_mode={lead.execution_mode.value}; dropping without "
+                "dispatch (someone bypassed the schedule_lead gate)."
             )
             return
         if await self._reseller_paused(lead.reseller_id):

--- a/app/ai/voice/agents/breeze_buddy/managers/calls.py
+++ b/app/ai/voice/agents/breeze_buddy/managers/calls.py
@@ -22,7 +22,10 @@ from app.ai.voice.agents.breeze_buddy.dispatch.alerts import raise_orphan_webhoo
 from app.ai.voice.agents.breeze_buddy.dispatch.channel_semaphore import (
     release_channel_token,
 )
-from app.ai.voice.agents.breeze_buddy.dispatch.queue import schedule_lead
+from app.ai.voice.agents.breeze_buddy.dispatch.queue import (
+    is_dispatchable,
+    schedule_lead,
+)
 from app.ai.voice.agents.breeze_buddy.managers.pre_checks import run_pre_checks
 from app.ai.voice.agents.breeze_buddy.services.agent_router.client import (
     safe_release_pod,
@@ -394,8 +397,12 @@ async def _retry_call(
 
         # Event-driven dispatch: ZADD the retry onto the schedule. Best-effort
         # — DB is authoritative; reconciler heals dropped ZADDs.
+        # Gated on execution_mode — only telephony retries flow through the
+        # worker's make_call path. DAILY retries (if any) are handled by the
+        # web-mode flow, not by phantom-dialling via Plivo/Twilio.
         # See docs/BACKLOG_DISPATCHER_REDESIGN.md §4 (retry semantics).
-        await schedule_lead(lead_id=retry_id, next_attempt_at=next_attempt_at)
+        if is_dispatchable(lead.execution_mode):
+            await schedule_lead(lead_id=retry_id, next_attempt_at=next_attempt_at)
 
 
 async def reconcile_stuck_processing_leads():

--- a/app/api/routers/breeze_buddy/leads/handlers.py
+++ b/app/api/routers/breeze_buddy/leads/handlers.py
@@ -12,6 +12,7 @@ from fastapi import HTTPException, status
 
 from app.ai.voice.agents.breeze_buddy.dispatch import (
     cancel_scheduled_lead,
+    is_dispatchable,
     schedule_lead,
 )
 from app.ai.voice.agents.breeze_buddy.services.daily.recording import (
@@ -350,8 +351,13 @@ async def push_lead_handler(req: PushLeadRequest, current_user: UserInfo) -> Dic
         # Event-driven dispatch: drop a scheduling sticky note onto
         # bb:schedule:leads. Best-effort — DB is authoritative; the
         # reconciler heals any dropped ZADDs within 60s.
+        # Gated on execution_mode so we only dispatch TELEPHONY leads;
+        # DAILY / DAILY_STREAM are handled by separate web-mode flows
+        # (customer-initiated room join) and would otherwise cause a
+        # phantom Plivo/Twilio dial via the worker's make_call path.
         # See docs/BACKLOG_DISPATCHER_REDESIGN.md §2 Plane 1.
-        if next_attempt_at is not None:
+        lead_execution_mode = req.execution_mode or ExecutionMode.TELEPHONY
+        if next_attempt_at is not None and is_dispatchable(lead_execution_mode):
             await schedule_lead(lead_id=uuid, next_attempt_at=next_attempt_at)
 
         logger.info(f"Lead call tracker {req.request_id} added to queue with ID {uuid}")
@@ -771,6 +777,17 @@ async def dispatch_now_lead_handler(lead_id: str, current_user: UserInfo) -> Dic
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
             detail="Lead is locked by another dispatcher",
+        )
+    if not is_dispatchable(lead.execution_mode):
+        # /dispatch-now is a TELEPHONY-only endpoint. DAILY / DAILY_STREAM
+        # leads are handled by web-mode flows (customer-initiated room
+        # join) and would phantom-dial via the worker if scheduled here.
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=(
+                f"Lead execution_mode '{lead.execution_mode.value}' is not "
+                "dispatchable via /dispatch-now (telephony-only endpoint)"
+            ),
         )
 
     now = datetime.now(timezone.utc)

--- a/tests/breeze_buddy/dispatch/test_end_to_end.py
+++ b/tests/breeze_buddy/dispatch/test_end_to_end.py
@@ -381,3 +381,43 @@ async def test_reaper_drops_already_processing_lead(harness, fake_redis, monkeyp
         proc_key not in fake_redis.client.lists
         or fake_redis.client.lists[proc_key] == []
     )
+
+
+# ---------------------------------------------------------------------------
+# Execution-mode gate (Daily / web-mode leads must not dial PSTN)
+# ---------------------------------------------------------------------------
+
+
+async def test_daily_lead_reaching_worker_is_dropped(harness, fake_redis):
+    """
+    Defensive backstop: if a DAILY-mode lead somehow gets on the ready list
+    (e.g., a bypassed ingest path), the worker drops it BEFORE acquiring a
+    channel token and BEFORE calling make_call. No phantom Plivo/Twilio dial.
+
+    This is the test that pins the fix for the reported bug:
+        "When tested with daily, this lead is also getting scheduled and a
+         Plivo call is getting initiated."
+    """
+    from app.schemas import ExecutionMode
+
+    lead = make_lead("lead-daily")
+    lead.execution_mode = ExecutionMode.DAILY  # ← key difference
+    harness.add_lead(lead)
+
+    await init_channel_semaphore(harness.number.id, 1)
+    await fake_redis.client.rpush(READY_LIST, lead.id)
+
+    worker = w.Worker(worker_uuid="w-daily-drop")
+    await worker._iteration(session=None)
+
+    # Worker did NOT call make_call — no phantom telephony dial.
+    assert harness.call_recorder.calls == []
+    # Channel token NEVER consumed.
+    assert await channel_tokens_available(harness.number.id) == 1
+    # Lead was NOT locked, NOT deferred, NOT released — worker exited before
+    # acquire_lock_on_lead_by_id.
+    assert lead.id not in harness.locked_lead_ids
+    assert harness.deferred == []
+    assert lead.id not in harness.released_locks
+    # Status untouched.
+    assert lead.status == LeadCallStatus.BACKLOG

--- a/tests/breeze_buddy/dispatch/test_queue.py
+++ b/tests/breeze_buddy/dispatch/test_queue.py
@@ -114,3 +114,26 @@ async def test_schedule_lead_does_not_raise_on_redis_error(monkeypatch):
     ok = await queue.schedule_lead("lead-x", when)
 
     assert ok is False
+
+
+# ---------------------------------------------------------------------------
+# Execution-mode gating
+# ---------------------------------------------------------------------------
+
+
+def test_is_dispatchable_telephony_modes_only():
+    """Only TELEPHONY and TELEPHONY_TEST should pass the gate.
+
+    DAILY / DAILY_TEST / DAILY_STREAM are web-mode (customer joins a Daily
+    room) — they must NOT enter the dispatcher's PSTN-dial path. HOLD_TRANSFER
+    is a mid-call leg, not a standalone outbound to schedule. This filter
+    mirrors the SQL WHERE clause in get_unscheduled_backlog_leads_query.
+    """
+    from app.schemas import ExecutionMode
+
+    assert queue.is_dispatchable(ExecutionMode.TELEPHONY) is True
+    assert queue.is_dispatchable(ExecutionMode.TELEPHONY_TEST) is True
+    assert queue.is_dispatchable(ExecutionMode.DAILY) is False
+    assert queue.is_dispatchable(ExecutionMode.DAILY_TEST) is False
+    assert queue.is_dispatchable(ExecutionMode.DAILY_STREAM) is False
+    assert queue.is_dispatchable(ExecutionMode.HOLD_TRANSFER) is False


### PR DESCRIPTION
## Summary

Follow-up to PR #770. Fixes a real bug observed in testing: **Daily-mode leads were getting scheduled by the dispatcher and dialled out via the telephony provider (Plivo / Twilio)** — producing phantom PSTN calls for what should have been web-mode Daily room joins.

## Root cause

PR #770's reconciler SQL already filtered to TELEPHONY only:
\`\`\`sql
AND \"execution_mode\" IN ('TELEPHONY', 'TELEPHONY_TEST')
\`\`\`

But the three **ingest sites** that put leads onto the schedule didn't have the same filter — they only checked `next_attempt_at is not None`. So a Daily lead with `next_attempt_at` set entered the dispatch ZSET, got promoted by the promoter, picked up by a worker, and dialled via `make_call()` over PSTN.

## Fix — single source of truth

New helper in `dispatch/queue.py`:
\`\`\`python
DISPATCHABLE_EXECUTION_MODES = frozenset(
    {ExecutionMode.TELEPHONY, ExecutionMode.TELEPHONY_TEST}
)

def is_dispatchable(execution_mode: ExecutionMode) -> bool:
    return execution_mode in DISPATCHABLE_EXECUTION_MODES
\`\`\`

Now used by **all 5 layers**, matching the reconciler's filter exactly:

| Layer | Site |
|---|---|
| Lead-create handler | `handlers.py:354` — skip schedule if non-dispatchable |
| /dispatch-now endpoint | `handlers.py:780` — return 400 if non-dispatchable |
| Retry creation | `calls.py:398` — skip schedule if parent lead non-dispatchable |
| Worker defensive backstop | `worker.py:_dispatch` — drop with error log |
| Reconciler SQL | unchanged (already correct) |

## Why a follow-up PR

PR #770 had already been merged when this bug was reported. The Daily-mode fix went onto the now-stale branch via force-push, so it never reached `release`. This PR cherry-picks just the Daily-fix delta (7 files, +128/-4 lines) onto a fresh branch off `release`.

## Tests

| Test | Pins |
|---|---|
| `test_is_dispatchable_telephony_modes_only` | TELEPHONY / TELEPHONY_TEST pass; DAILY / DAILY_TEST / DAILY_STREAM / HOLD_TRANSFER fail |
| `test_daily_lead_reaching_worker_is_dropped` | Regression test — confirms a Daily lead placed directly on the ready list exits the worker before make_call / channel acquire / lock acquire |

## Test plan

- [ ] CI green: black --check, isort --check, autoflake --check, pyrefly check, 1-commit count
- [ ] Apply on staging
- [ ] Create a DAILY lead with `next_attempt_at` set; verify it does NOT appear in `bb:schedule:leads` (ZCARD doesn't increment)
- [ ] Verify no Plivo/Twilio dial happens for the Daily lead
- [ ] Verify the existing Daily-mode flow (room creation + customer notification) still works
- [ ] Create a TELEPHONY lead with `next_attempt_at` — verify it dispatches as before
- [ ] Hit `POST /leads/{daily_lead_id}/dispatch-now` — verify 400 response with clear error
- [ ] Hit `POST /leads/{telephony_lead_id}/dispatch-now` — verify 200 as before

## Quality gates

| Check | Result |
|---|---|
| pytest | **94 passed, 1 xfailed** |
| pyrefly | 0 errors |
| black / isort | clean |
| Commit count | 1 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to prevent non-telephony execution modes from being incorrectly routed through the dispatch system.
  * Improved error handling to drop ineligible leads before processing.

* **Tests**
  * Added test coverage for execution mode filtering and dispatch validation logic.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/juspay/clairvoyance/pull/773?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->