### PR TITLE
fix(transport): bound aiohttp pools and right-size Postgres pool

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -92,10 +92,19 @@ POSTGRES_HOST=""
 POSTGRES_PORT="5432"
 POSTGRES_DB="clairvoyance"
 
-# Connection pool settings
-POSTGRES_POOL_SIZE=5
-POSTGRES_MAX_OVERFLOW=10
+# Connection pool settings. Per pod — multiply by replica count when
+# sizing the managed Postgres max_connections.
+POSTGRES_POOL_SIZE=10
+POSTGRES_MAX_OVERFLOW=30
 POSTGRES_POOL_RECYCLE=3600
+
+# aiohttp pool settings. Per pod. The factory default applies to per-
+# request sessions; the shared pool is the lifespan-owned session
+# consumed by dispatch workers and the Daily REST helper.
+AIOHTTP_DEFAULT_POOL_LIMIT=50
+AIOHTTP_DEFAULT_POOL_LIMIT_PER_HOST=10
+AIOHTTP_SHARED_POOL_LIMIT=200
+AIOHTTP_SHARED_POOL_LIMIT_PER_HOST=32
 
 # AWS Configuration
 SKIP_KMS_DECRYPT=false

--- a/app/ai/voice/agents/breeze_buddy/dispatch/worker.py
+++ b/app/ai/voice/agents/breeze_buddy/dispatch/worker.py
@@ -68,7 +68,7 @@ from app.core.config.static import (
     BB_WORKER_HEARTBEAT_TTL_S,
 )
 from app.core.logger import logger
-from app.core.transport.http_client import create_aiohttp_session
+from app.core.transport.http_client import get_shared_aiohttp_session
 from app.database.accessor import (
     acquire_lock_on_lead_by_id,
     defer_lead_next_attempt_and_release_lock,
@@ -170,18 +170,20 @@ class Worker:
     # -- main loop ----------------------------------------------------------
 
     async def _loop(self) -> None:
-        async with create_aiohttp_session() as session:
-            while not self._stopping.is_set():
-                try:
-                    await self._iteration(session)
-                except Exception as e:  # noqa: BLE001
-                    logger.error(
-                        f"Worker {self._uuid}: unexpected error in loop: {e}",
-                        exc_info=True,
-                    )
-                    # Yield briefly so we don't hot-spin if something is
-                    # systemically broken.
-                    await asyncio.sleep(1.0)
+        while not self._stopping.is_set():
+            try:
+                # Re-fetch each iteration so a lifespan that swaps the
+                # shared session out (today: only on shutdown) can't
+                # leave us pinned to a closed reference.
+                await self._iteration(get_shared_aiohttp_session())
+            except Exception as e:  # noqa: BLE001
+                logger.error(
+                    f"Worker {self._uuid}: unexpected error in loop: {e}",
+                    exc_info=True,
+                )
+                # Yield briefly so we don't hot-spin if something is
+                # systemically broken.
+                await asyncio.sleep(1.0)
 
     async def _iteration(self, session: Optional[aiohttp.ClientSession]) -> None:
         """One pop-and-dispatch cycle. Errors are logged and contained."""

--- a/app/core/config/static.py
+++ b/app/core/config/static.py
@@ -325,10 +325,25 @@ POSTGRES_HOST = os.getenv("POSTGRES_HOST", "")
 POSTGRES_PORT = os.getenv("POSTGRES_PORT", "")
 POSTGRES_DB = os.getenv("POSTGRES_DB", "")
 
-# Connection pool settings
-POSTGRES_POOL_SIZE = int(os.getenv("POSTGRES_POOL_SIZE", "5"))
-POSTGRES_MAX_OVERFLOW = int(os.getenv("POSTGRES_MAX_OVERFLOW", "10"))
+# Connection pool settings. Sizes are **per pod** — multiply by replica
+# count when sizing the managed Postgres ``max_connections``. Defaults
+# absorb a BB_WORKER_COUNT=20 burst (multiple short acquires per
+# dispatch cycle) plus the FastAPI request path and reconcilers.
+POSTGRES_POOL_SIZE = int(os.getenv("POSTGRES_POOL_SIZE", "10"))
+POSTGRES_MAX_OVERFLOW = int(os.getenv("POSTGRES_MAX_OVERFLOW", "30"))
 POSTGRES_POOL_RECYCLE = int(os.getenv("POSTGRES_POOL_RECYCLE", "3600"))  # 1 hour
+
+# aiohttp connection-pool sizing. Bound the TCPConnector limits so per-
+# request sessions (factory default) and the long-lived shared session
+# don't each get aiohttp's unbounded default. Per pod.
+AIOHTTP_DEFAULT_POOL_LIMIT = int(os.getenv("AIOHTTP_DEFAULT_POOL_LIMIT", "50"))
+AIOHTTP_DEFAULT_POOL_LIMIT_PER_HOST = int(
+    os.getenv("AIOHTTP_DEFAULT_POOL_LIMIT_PER_HOST", "10")
+)
+AIOHTTP_SHARED_POOL_LIMIT = int(os.getenv("AIOHTTP_SHARED_POOL_LIMIT", "200"))
+AIOHTTP_SHARED_POOL_LIMIT_PER_HOST = int(
+    os.getenv("AIOHTTP_SHARED_POOL_LIMIT_PER_HOST", "32")
+)
 
 # KMS Configuration
 SKIP_KMS_DECRYPT = os.getenv("SKIP_KMS_DECRYPT", "false").lower() == "true"

--- a/app/core/transport/http_client.py
+++ b/app/core/transport/http_client.py
@@ -1,5 +1,28 @@
 """
-Centralized HTTP client factory with proxy support for both httpx and aiohttp
+Centralized HTTP client factory with proxy support for both httpx and aiohttp.
+
+Pool sizing
+-----------
+``aiohttp.ClientSession``'s default ``TCPConnector`` is unbounded per
+host. Two pieces of machinery here keep that under control:
+
+1. ``create_aiohttp_session()`` installs a bounded ``TCPConnector`` by
+   default (sized via ``AIOHTTP_DEFAULT_POOL_LIMIT`` /
+   ``AIOHTTP_DEFAULT_POOL_LIMIT_PER_HOST``) so per-request callers stop
+   consuming the unbounded default. Callers can override by passing
+   their own ``connector=`` kwarg.
+
+2. ``init_shared_aiohttp_session()`` exposes a single process-wide
+   session sized via ``AIOHTTP_SHARED_POOL_LIMIT`` /
+   ``AIOHTTP_SHARED_POOL_LIMIT_PER_HOST``. The lifespan handler in
+   ``app/main.py`` initialises it on startup and closes it on
+   shutdown. Long-lived consumers (dispatch workers, Daily REST
+   helper) pull this via ``get_shared_aiohttp_session()`` instead of
+   each opening their own.
+
+The shared session is created inside the lifespan's async context —
+never at import time — so aiohttp's running-loop requirement is
+respected on every supported Python version.
 """
 
 from typing import Optional
@@ -8,11 +31,20 @@ import aiohttp
 import httpx
 
 from app.core.config.static import (
+    AIOHTTP_DEFAULT_POOL_LIMIT,
+    AIOHTTP_DEFAULT_POOL_LIMIT_PER_HOST,
+    AIOHTTP_SHARED_POOL_LIMIT,
+    AIOHTTP_SHARED_POOL_LIMIT_PER_HOST,
     AWS_PROXY_HOST,
     AWS_PROXY_PORT,
     CLOUD_ENVIRONMENT,
 )
 from app.core.logger import logger
+
+# Module-level singleton. Owned by the FastAPI lifespan handler: init on
+# startup, close on shutdown. Never created at import time — aiohttp's
+# TCPConnector requires a running event loop.
+_shared_session: Optional[aiohttp.ClientSession] = None
 
 
 def get_proxy_config() -> Optional[str]:
@@ -57,21 +89,86 @@ def create_http_client(**kwargs) -> httpx.AsyncClient:
 
 def create_aiohttp_session(**session_kwargs) -> aiohttp.ClientSession:
     """
-    Create an aiohttp.ClientSession with proxy support
+    Create an aiohttp.ClientSession with proxy support and a bounded pool.
 
-    Args:
-        **session_kwargs: Additional arguments to pass to aiohttp.ClientSession
+    When no explicit ``connector=`` is supplied we substitute a bounded
+    ``TCPConnector`` sized via the ``AIOHTTP_DEFAULT_POOL_LIMIT*``
+    settings, so per-request callers don't each inherit aiohttp's
+    unbounded default. Callers that need different sizing (e.g. the
+    shared session) can still pass their own ``connector=`` and we'll
+    respect it.
 
-    Returns:
-        aiohttp.ClientSession: Configured aiohttp session
+    For the long-lived dispatch-worker / Daily REST case, prefer
+    ``get_shared_aiohttp_session()`` — that avoids creating N independent
+    connection pools, one per worker.
     """
     proxy_url = get_proxy_config()
 
-    # Use aiohttp's built-in proxy parameter in the constructor
     if proxy_url:
         session_kwargs["proxy"] = proxy_url
         logger.debug(f"Created aiohttp session with proxy: {proxy_url}")
     else:
         logger.debug("Created aiohttp session without proxy")
 
+    if "connector" not in session_kwargs:
+        session_kwargs["connector"] = aiohttp.TCPConnector(
+            limit=AIOHTTP_DEFAULT_POOL_LIMIT,
+            limit_per_host=AIOHTTP_DEFAULT_POOL_LIMIT_PER_HOST,
+        )
+
     return aiohttp.ClientSession(**session_kwargs)
+
+
+async def init_shared_aiohttp_session() -> aiohttp.ClientSession:
+    """
+    Initialise the process-wide shared aiohttp session. Idempotent.
+
+    The session uses a ``TCPConnector`` sized via the
+    ``AIOHTTP_SHARED_POOL_LIMIT*`` settings — enough headroom for
+    ``BB_WORKER_COUNT`` dispatch workers plus the FastAPI request path
+    to share one pool without contending under burst load.
+
+    Must be called from inside a running event loop (the FastAPI
+    lifespan handler is the intended caller). The matching
+    ``close_shared_aiohttp_session()`` must be called from lifespan
+    shutdown to drain the connector cleanly.
+    """
+    global _shared_session
+    if _shared_session is not None and not _shared_session.closed:
+        return _shared_session
+    connector = aiohttp.TCPConnector(
+        limit=AIOHTTP_SHARED_POOL_LIMIT,
+        limit_per_host=AIOHTTP_SHARED_POOL_LIMIT_PER_HOST,
+    )
+    _shared_session = create_aiohttp_session(connector=connector)
+    logger.info(
+        "Initialised shared aiohttp session "
+        f"(limit={AIOHTTP_SHARED_POOL_LIMIT}, "
+        f"limit_per_host={AIOHTTP_SHARED_POOL_LIMIT_PER_HOST})"
+    )
+    return _shared_session
+
+
+def get_shared_aiohttp_session() -> aiohttp.ClientSession:
+    """
+    Return the process-wide shared aiohttp session.
+
+    Raises ``RuntimeError`` if ``init_shared_aiohttp_session()`` has not
+    been called yet — that's a programming error: the lifespan handler
+    must initialise the session before workers or handlers consume it.
+    """
+    if _shared_session is None or _shared_session.closed:
+        raise RuntimeError(
+            "Shared aiohttp session is not initialised. "
+            "Call init_shared_aiohttp_session() during application startup."
+        )
+    return _shared_session
+
+
+async def close_shared_aiohttp_session() -> None:
+    """Close the process-wide shared aiohttp session, if any."""
+    global _shared_session
+    if _shared_session is not None and not _shared_session.closed:
+        await _shared_session.close()
+        logger.info("Closed shared aiohttp session")
+    _shared_session = None

--- a/app/main.py
+++ b/app/main.py
@@ -73,7 +73,10 @@ from app.core.config.static import (
 # Import necessary components from the new structure
 from app.core.logger import logger
 from app.core.security.jwt import validate_automatic_request
-from app.core.transport.http_client import create_aiohttp_session
+from app.core.transport.http_client import (
+    close_shared_aiohttp_session,
+    init_shared_aiohttp_session,
+)
 from app.database import close_db_pool, init_db_pool
 from app.helpers.automatic.daily_room_pool import (
     cleanup_room_pool,
@@ -144,8 +147,9 @@ async def lifespan(_app: FastAPI):
         "Worker process: DevCycle flags pre-loaded by parent process, reading from Redis"
     )
 
-    # Initialize aiohttp session with proxy support for Daily API
-    aiohttp_session = create_aiohttp_session()
+    # Process-wide shared aiohttp session; consumed by dispatch workers
+    # via get_shared_aiohttp_session() and the Daily REST helper below.
+    aiohttp_session = await init_shared_aiohttp_session()
     daily_helpers["rest"] = DailyRESTHelper(
         daily_api_key=DAILY_API_KEY,
         daily_api_url=DAILY_API_URL,
@@ -352,9 +356,8 @@ async def lifespan(_app: FastAPI):
     await close_db_pool()
     # Close Redis connections
     await close_redis_connections()
-    # Close aiohttp session
-    await aiohttp_session.close()
-    logger.info("Aiohttp session closed.")
+    # Close the shared aiohttp session (drains the TCP connector)
+    await close_shared_aiohttp_session()
 
 
 app = FastAPI(title="Breeze Automatic Server", version=__version__, lifespan=lifespan)

--- a/tests/breeze_buddy/dispatch/test_chaos_and_edges.py
+++ b/tests/breeze_buddy/dispatch/test_chaos_and_edges.py
@@ -457,10 +457,16 @@ async def test_worker_main_loop_stops_on_event(fake_redis, monkeypatch):
         iteration_count += 1
         await asyncio.sleep(0.01)
 
+    # _loop() now pulls the process-wide shared aiohttp session via
+    # get_shared_aiohttp_session(); in tests no lifespan has initialised
+    # it, so stub the getter to return None — the fake_iteration above
+    # never actually uses the session value.
+    monkeypatch.setattr(w, "get_shared_aiohttp_session", lambda: None)
+
     worker = w.Worker(worker_uuid="w-exit")
     monkeypatch.setattr(worker, "_iteration", fake_iteration)
     worker._stopping.clear()
-    # Drive the loop body inline; skip create_aiohttp_session.
+    # Drive the loop body inline; skip the real shared-session lookup.
     task = asyncio.create_task(worker._loop())
 
     await asyncio.sleep(0.05)


### PR DESCRIPTION
## Summary

- **aiohttp**: bound the default `TCPConnector` (was `limit=100, limit_per_host=0` unbounded). With 20 long-lived dispatch workers per pod each owning a session, the per-pod TCP-connection ceiling was ~2,000. Introduces a process-wide shared session (`init/get/close_shared_aiohttp_session()`) owned by the FastAPI lifespan; dispatch workers and the Daily REST helper consume it. Per-pod ceiling: ~2,100 → ~200.
- **Postgres**: pool was `min=5, max=15` — undersized for `BB_WORKER_COUNT=20`; 5+ workers would queue on `pool.acquire()` during a burst. Raised to `min=10, max=40`. Per-pod ceiling: 15 → 40.
- All four aiohttp limits and the Postgres pool sizes are env-driven via `app/core/config/static.py` (`AIOHTTP_DEFAULT_POOL_LIMIT[_PER_HOST]`, `AIOHTTP_SHARED_POOL_LIMIT[_PER_HOST]`, `POSTGRES_POOL_SIZE`, `POSTGRES_MAX_OVERFLOW`).

This is **defense-in-depth hardening**, not a fire-fight — the 2,000 figure is a ceiling, not observed usage. Postgres pool queuing was math-likely under burst but not yet alarmed in metrics. Worth shipping before the next scale-up of `BB_WORKER_COUNT`.

**Sizes are per pod** — managed Postgres `max_connections` should be sized as `pod_count × 40` plus headroom.

## Files changed

- `app/core/transport/http_client.py` — bound factory default; add shared-session triad (lifespan-owned).
- `app/main.py` — lifespan startup awaits `init_shared_aiohttp_session()`, shutdown awaits `close_shared_aiohttp_session()`.
- `app/ai/voice/agents/breeze_buddy/dispatch/worker.py` — `_loop` consumes the shared session per iteration (defends against future session-swap pinning workers to a closed reference).
- `app/core/config/static.py` — new `AIOHTTP_*` env vars; Postgres defaults raised.
- `.env.example` — matching defaults + per-pod note.
- `tests/breeze_buddy/dispatch/test_chaos_and_edges.py` — `test_worker_main_loop_stops_on_event` monkeypatches the new getter (no lifespan in tests; the fake `_iteration` never reads the session).

## Test plan

- [x] `uv run pytest tests/breeze_buddy/dispatch/ -x` → 96 passed, 1 xfailed
- [x] `uv run pyrefly check` → 0 errors
- [x] `python -m py_compile` on every touched file
- [ ] Smoke test in dev: start the server, confirm `"Initialised shared aiohttp session (limit=200, limit_per_host=32)"` appears in startup logs and `"Closed shared aiohttp session"` appears on SIGTERM
- [ ] Verify FastAPI lifespan ordering on shutdown: workers drain before shared session closes (already verified by code review; this is operational confirmation)
- [ ] Confirm managed Postgres `max_connections` headroom for `pod_count × 40` before deploying

## Follow-ups (out of scope, noted for tracking)

- Migrate direct `aiohttp.ClientSession(...)` callsites that still bypass `create_aiohttp_session()` and its bounded default + proxy support: `app/services/slack/alert.py`, `app/services/live_config/store.py`, `app/services/langfuse/client.py`, and `app/ai/voice/agents/breeze_buddy/services/telephony/{exotel,plivo,twilio}/recording.py`.
- `Worker.stop()` cancels the task but doesn't await the cancelled coroutine — parity with the prior per-worker-session code, same shutdown blast radius. Worth tightening eventually.
- `asyncpg.create_pool()` has no `command_timeout=` — with `max_size=40` a stuck PG could leave up to 40 acquires waiting forever before workers fall over.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased database connection pool limits to support higher concurrency.
  * Added configurable HTTP connection pool settings with per-host and shared limits.
  * Refactored HTTP session management to use a shared instance across the application, improving resource efficiency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/juspay/clairvoyance/pull/775?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->