### PR TITLE
feat(buddy-assist): widget public mode + SpecStream UI + UCP cutover

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,6 +1,6 @@
 # TODO
 
-Living index of follow-ups for this repo. Append new items at the bottom of the relevant section. Remove rows when the underlying work lands. Last updated: 2026-05-21 (post PR #779 event-driven-dispatcher rate-limit and number-unavailable fix).
+Living index of follow-ups for this repo. Append new items at the bottom of the relevant section. Remove rows when the underlying work lands. Last updated: 2026-05-21 (PR #778 buddy-assist widget rollout, rebased on PR #779 dispatcher rate-limit / number-unavailable fix).
 
 ---
 
@@ -112,3 +112,120 @@ Tests pass (they assert call counts, not order). Pure documentation drift. Trivi
 Our subclass at `app/ai/voice/stt/soniox/service.py` exists solely to inject `max_endpoint_delay_ms` into the WebSocket connection config. Pipecat 1.1.0 does not expose this field on `SonioxSTTSettings` and `_connect_websocket` does not forward `s.extra` either, so a subclass override is currently the only option. The override copies the entire body of pipecat's private `_connect_websocket` — any restructure upstream silently drops our injection.
 
 **Action**: file an upstream PR adding `if isinstance(s.extra, dict): config.update(s.extra)` to `pipecat/services/soniox/stt.py:_connect_websocket` (mirrors what `DeepgramSTTSettings` already does via `_sync_extra_to_fields`). Once merged, our subclass goes away — we just pass `extra={"max_endpoint_delay_ms": ...}` to `SonioxSTTService.Settings`. Tiny PR, generally useful, lets us delete `app/ai/voice/stt/soniox/service.py` entirely.
+
+---
+
+## 6. Buddy-Assist widget rollout — PR #778 follow-ups (2026-05-21)
+
+PR #778 (`feat(buddy-assist): widget public mode + SpecStream UI + UCP cutover`) shipped Phases 0–2 of the review fixes inline. Everything below was reviewed in `/tmp/pr-778-review-tracker.md`, triaged as "not a dealbreaker", and deferred here. Reference the tracker for original line numbers + agent rationale.
+
+### 6.A Cross-repo coordination (do these immediately after #778 merges)
+
+| # | What | Where | Why it can't ship in this PR |
+|---|---|---|---|
+| 1 | **Commit + push `static/buddy-assist-agent/canonical.template.json`** — flip from `"idempotency_key": "uuid_v4"` to `"idempotency_key": "idempotency_hash"` (already modified in working tree, file is still untracked in nautilus). | `nautilus/static/buddy-assist-agent/canonical.template.json` lines 51 + 60 | Nautilus repo, separate PR. The clairvoyance generator is in place (back-compat — still honors `uuid_v4`); B11 is **plumbed but inert** until the template flips. |
+| 2 | **Re-provision Milton merchant** so the updated template lands in the DB. | `nautilus/scripts/provision-buddy-assist-merchant.sh` (also currently untracked) | Operational, post-template-merge. |
+| 3 | **Smoke-test idempotency on Milton** (task #104, RR-1) — verify a retry of `create_cart`/`update_cart` with identical args produces an identical key and Shopify returns the cached result. | Manual / e2e harness | Depends on #1 + #2 above. |
+| 4 | **Move UCP signing keys out of `/tmp/ucp-keys/`** (task #105, RR-2) into a stable production secret store (Cloud SQL Secret Manager, K8s secret, etc.). | Infrastructure / deploy config | Required before RFC 9421 signing lands (see 6.B/B10). Pre-existing concern, not introduced by #778. |
+| 5 | **Consolidated e2e validation pass** on Milton after the rollout (task #106, RR-3): chat → voice → end → resume, cart flow end-to-end, cancel mid-stream, content_blocks/ui_blocks persisted + replayed. | Manual / Showcase harness | Post-deploy gate before declaring the rollout complete. |
+
+### 6.B P0 — RFC 9421 HTTP signing (do this BEFORE Shopify flips enforcement on)
+
+Currently UCP requests go out **unsigned**. Curl-probed Milton on 2026-05-21: `tools/call search_catalog` returns HTTP 200 with the catalog body, no `Signature-Input` required. The agent profile at `https://breezebuddy.ai/.well-known/ucp/agent.json` already advertises the public key (kid `hQuP1Q-e_SCrtOo4df-PoQBVy2Tm8Zi-8fZcLzT8bZg`) so the infrastructure side is ready — only the request-signing code never landed.
+
+**What to ship**:
+1. Add `httpsig` (or RFC-9421-compliant equivalent) to the direct-HTTP poster in `app/ai/voice/agents/breeze_buddy/mcp/__init__.py:_create_direct_http_tool_handler`. Sign `@method`, `@target-uri`, `content-digest`, `content-type`, plus a fresh `created` timestamp; ed25519 / ES256 to match the kid in the profile.
+2. Load the private key from a stable location (see 6.A item #4). Cache the parsed key at process start; refuse to start if missing.
+3. Bench: TLS-per-call + signing-per-call together — pair with B7 (connection pooling) so the perf hit doesn't compound.
+4. Unit test against a `httpx.MockTransport` that verifies the signature parses.
+
+**Trip-wire**: add a daily synthetic that POSTs unsigned and EXPECTS success. The day Shopify flips enforcement on, that synthetic starts failing and gives us a heads-up before real merchants see 401s.
+
+### 6.C Connection-layer hardening (compounds with 6.B; ship together)
+
+| # | What | Where |
+|---|---|---|
+| B7 | **Pool the `httpx.AsyncClient`.** Currently `async with httpx.AsyncClient(...)` per tool call → fresh TLS handshake every dispatch. Mirror the `MCPPool` pattern: one client per turn, closed in `close_mcp_pool` alongside the legacy MCP clients. | `mcp/__init__.py:_create_direct_http_tool_handler` |
+| B9 | **One retry with backoff on 5xx + `httpx.TransportError`.** Shopify deploys cause expected 502 bursts. **Only safe to enable after B11/idempotency-hash is live in production** — without stable keys, retries create duplicates. | `mcp/__init__.py:_create_direct_http_tool_handler` |
+| M21 | **Lift `inject_tool_args` into the channel-agnostic handler.** Voice mode UCP tool calls currently bypass `inject_tool_args` entirely — they get `_deep_merge_defaults` (static profile) but NO idempotency hash, NO state-driven cart_id injection. Architectural lift: handlers don't have per-call session context today; either thread `flow_manager.session_id` through, or move the injection invocation into the call site that has both. | `mcp/__init__.py:_create_direct_http_tool_handler` + `agent/__init__.py:1028` |
+
+### 6.D UCP observability + tests
+
+| # | What | Where |
+|---|---|---|
+| M22 | **Schema drift counter.** Emit a metric (`tool_call_status` keyed by `tool_name`) on every non-2xx UCP response so a Shopify-side schema change is visible before it pages. | `mcp/__init__.py` |
+| M23 | **UCP response-transform error-path tests.** Current `tests/test_response_transform.py` covers happy paths only. Add `httpx.MockTransport` cases: 4xx body, 5xx body, empty body, non-JSON, missing `result.content`, malformed JSON inside `text` block. | `tests/test_response_transform.py` |
+| M24 | **Same-key-across-retries idempotency test.** Existing `test_session_state.py:362` asserts a fresh value per call — flip the assertion to verify two identical inputs produce the SAME hash (the broken behaviour was enshrined by the test). Add a second test for "same args, different turn_id → different hash". | `tests/test_session_state.py` |
+| M25 | **Surface JSON-RPC error fields.** Today an upstream JSON-RPC error returns `{"status":"error","data": json.dumps(err)}` — the LLM has to string-parse to find the code. Promote to discrete fields: `error_code`, `error_message`. | `mcp/__init__.py:262-267` |
+
+### 6.E Chat-agent / cancel-bus robustness
+
+| # | What | Where |
+|---|---|---|
+| M31 | **`_MAX_TOOL_CYCLES` bail path persists half-state.** If a turn hits the 8-cycle ceiling with `tool_calls` still pending, the loop bails and persists `tool_use` blocks WITHOUT matching `tool_result` rows → next turn's history replay is malformed and most LLM providers reject the conversation. Either skip the persist on the bail OR write synthetic `tool_result` error envelopes for the unmatched calls. | `chat/agent.py:444-457` |
+| H2 | **TOCTOU on channel gating.** The widget `/message` route checks `current_channel == CHAT` BEFORE acquiring the per-session Redis lock; session can flip to VOICE between check and lock → chat turn lands mid-voice. Pass an `access_check` closure into `send_chat_message_handler` that re-checks under the lock. | `widget/handlers.py:241-243` |
+| M30 | **Multi-cancel `uncancel()` loop.** CPython 3.11's `Task.cancel()` is counted — cross-pod cancel + client disconnect produces count >1 and a single `uncancel()` leaves the task still cancelling. Loop: `while current_task.cancelling(): current_task.uncancel()`. | `chat/handlers.py:482-488` |
+| M33 | **Cleanup chaining can leak the MCP pool.** `run_turn` finally block: if `aiohttp_session.close()` raises, `close_mcp_pool()` is skipped → StreamableHTTP connection leak. Use `contextlib.AsyncExitStack` so each cleanup runs independently. | `chat/agent.py:157-162` |
+| M27 | **`agent_session_state` race under slow LLM calls.** The per-session Redis lock has a 180s TTL; an LLM call that overruns the TTL allows the next turn to start, then both write `data_json` last-write-wins on the older turn. Add row-level `version` + CAS, OR document the TTL as load-bearing. | `template/session_state.py:160-205` |
+
+### 6.F Anonymous-endpoint hardening
+
+| # | What | Where |
+|---|---|---|
+| M5 | **Normalize `allowed_origins` matching.** Currently exact-string; `https://example.com` ≠ `https://example.com:443` ≠ `https://EXAMPLE.com`. Normalize on ingress + storage (lowercase host, strip default port); validate entries against a strict URL regex on admin write. | `widget_common.py:_caller_origin` + `widget_config/handlers.py` |
+| M8 | **Validate client-supplied `template_vars` + `metadata` on `POST /widget/session`.** Currently passed through unchecked → prompt-injection vector if any template_var lands in a system-prompt slot, plus storage pollution (no size cap). Schema validation against the per-template `template_vars` declaration; cap `metadata` size (~4KB); disallow client-supplied `widget` key. | `widget/handlers.py:create_widget_session_handler` |
+| M37 | **Prompt-injection via interpolation ordering.** `{{ui_primitives_section}}` is spliced AFTER template_vars are rendered → a malicious template_var value of `"{{ui_primitives_section}}"` can inject the catalog block in arbitrary positions. Render the primitives section FIRST, then template_vars with a strict key allowlist. Pair with M8. | `template/ui_prompt.py` + `template/builder.py:60-75` |
+| M1 | **Widget JWT claims: add `aud`/`iss`/`jti`.** 24h TTL with no revocation means a compromised token is usable for a day. Add `aud="breeze-buddy/widget"` + `iss`, enforce on verify; add `jti` and a revoke-by-jti Redis set so ops can kill specific tokens. Consider shortening TTL with refresh. | `api/security/breeze_buddy/widget_token.py:80-88` |
+| M2 | **RBAC `typ` allowlist (not denylist).** Today's verifier rejects `typ=widget` and `demo=true` — brittle because any new token type accidentally inherits RBAC. Mint RBAC tokens with `typ="rbac"`/`"s2s"`; verifier rejects anything else. Stage with a feature flag during back-fill. | `api/security/breeze_buddy/rbac_token.py:98-111` |
+| M7 | **CORS preflight unit test.** Assert `Access-Control-Allow-Credentials: true` is NEVER paired with `Access-Control-Allow-Origin: *`. Current code is safe; the test is a guardrail against future drift. | `widget_common.py` + new test file |
+
+### 6.G Database polish
+
+| # | What | Where |
+|---|---|---|
+| M10 | **`CREATE INDEX CONCURRENTLY` for chat_message indexes.** Migration 030 creates indexes without `CONCURRENTLY` → write lock for build duration. Today the table is small (<100k rows) so the lock is sub-second; this becomes mandatory before the table grows past ~1M rows. | `database/migrations/030_widget_public_mode_and_session_persistence.sql:142-144, 188-189` (large-table indexes) |
+| M11 | **Document down-migration policy.** No reversal path for migration 030. Confirm with infra whether "deploy-forward only" is the team rule; if rollback is supported, write the reverse. | `database/migrations/030_*` + new `docs/MIGRATIONS.md` |
+| M13 | **`list_widget_configs_query` empty list semantics.** Empty `reseller_ids: List` produces `= ANY('{}')` → matches zero rows (silent "deny all"). Either treat empty as "no filter" or as "deny all" with an explicit comment + caller guarantee. | `database/queries/breeze_buddy/widget_config.py:115,119` |
+| M14 | **`reset_widget_voice_lead_query` clobbers analytics fields.** Verify analytics pipeline reads `call_id`/`outcome`/`cost` from a snapshot table (not directly from `lead_call_tracker`); if the latter, this query loses per-attempt history on re-attach. | `database/queries/breeze_buddy/lead_call_tracker.py:687-703` |
+| M16 | **`accessor/widget_config.py:list count_query values[:-2]`** assumes last 2 binds are LIMIT/OFFSET via implicit coupling. Match the defensive guard in `merchants.py:152`: `values[:-2] if len(values) > 2 else []`. | `database/accessor/breeze_buddy/widget_config.py:144` |
+
+### 6.H SpecStream polish
+
+| # | What | Where |
+|---|---|---|
+| M34 | **`replace` ops bypass catalog validation.** Healer rules + `primitive_disabled` only fire on `add`. Track `id → type` in extractor state; run the full validation pipeline (healer + props + allowlist) on `replace` too. Otherwise LLM can land arbitrary props on existing tree nodes. | `chat/ui_stream.py:255-275` + `chat/ui_healer.py:_rule_*` |
+| M26 | **`apply_state_reducers` key allowlist.** Reducers write raw JMESPath results into `next_state` with no key filter — a malicious or buggy template reducer could overwrite security-relevant state keys other code trusts. Either declare reducer-allowed key shape or document that all state keys are LLM-influenced. Templates are internally authored so this is defense-in-depth. | `template/session_state.py:120-131` |
+| M35 | `_CARRY_MAX` couples to the literal marker length — if `<ui_stream>` ever lengthens (e.g. v2 marker), partial markers across small chunks silently miss. Drop the `_CARRY_MAX` subtractor. | `chat/ui_stream.py:181-187` |
+| M36 | `remove` op with unknown id passes through silently. Add a drop rule + `ui_op_dropped: reason=remove_unknown_id` telemetry so LLM hallucination is distinguishable from legitimate cross-turn remove. | `chat/ui_healer.py:182-198` + `chat/ui_stream.py:387-391` |
+| M38 | **`ToAssistantAction.display` server-side XSS sanitization.** The widget is the sole defense today. Add a Pydantic field validator that strips `<script>` etc. so a buggy LLM payload doesn't depend on widget hygiene. | `template/ui_catalog.py:71-78` |
+| M39 | **Cap `Message.msg` field length.** `min_length=1` but no max → 10MB LLM-emitted strings can round-trip through the API. Add `max_length=8192`. | `template/ui_catalog.py:68-78` |
+
+### 6.I Cancel-bus polish
+
+| # | What | Where |
+|---|---|---|
+| M28 | `cancel_bus.cancel()` returns 202 on Redis publish failure → 3-min wedge with no client telemetry. Add a counter on publish-failure. | `chat/cancel_bus.py:107-130` |
+| M29 | Subscriber reconnect loop has no circuit-break → sustained Redis outage = `error` log spam at 2/min/pod forever. Downgrade to `warning` after first ~5 consecutive failures; drop `exc_info=True`. | `chat/cancel_bus.py:188-198` |
+| M32 | Instance-level `_ui_extractor` + `_known_ui_ids` on `ChatAgent` are correct today (fresh agent per `/message`), but the implicit guarantee isn't enforced. Move into a `run_turn`-local so a future refactor to long-lived agent can't silently regress. | `chat/agent.py:108-116` |
+
+### 6.J Minors / log hygiene / type tightening (do alongside whatever you're already touching)
+
+- `widget_token.py:106` — log JWT exception **type only**, not message (PyJWT messages can include token fragments).
+- `rbac_token.py:151-154` — drop `reseller_ids`/`merchant_ids` logging to `debug` (hot-path noise + scope leak surface).
+- `agent/__init__.py:313-324` — tighten widget seed gate with an explicit `is_widget` check (today: any truthy `widget_session_id` triggers; copy-paste during debugging on a telephony lead would silently kill its greeting).
+- `flow.py:268-279` — cap `prior_history` by token count before assembling resume seed (avoid 64k context blow-up on long widget sessions).
+- `queries/widget_config.py:34-44` — `created_at`/`updated_at` are passed as bind values AND have DB `DEFAULT now()`. Pick one source (app clock drifts on skewed hosts).
+- `decoder/widget_config.py:14` — `row.get("allowed_origins") or []` swallows falsy non-empty values. Use `if row.get(...) is not None else []`.
+- `chat/agent.py:139` — `history: List[Dict[str, Any]]` is loosely typed (violates CLAUDE.md "no any types"). Re-export `LLMContextMessage` and use it.
+- `chat/agent.py:618` — exception envelopes can leak SQL strings / internal paths. Sanitize before returning to the LLM context.
+- `tool_result_normalizer.py` — file is a 63-LOC MCP envelope unwrapper, not "JIT UI instructions" as the brief suggested. Rename or update docstring + SCALE_ROADMAP.
+- `WidgetVoiceEndResponse.status` (`schemas/breeze_buddy/chat.py:259-263`) — free `str`. Promote to `Enum` so clients can switch without string-matching.
+- `decoder/widget_config.py:6` — untyped `row` param. Add `asyncpg.Record` annotation.
+- Drop the duplicate "Money is absent" regression assertion (currently in BOTH `tests/test_ui_stream.py:202-211` and `tests/test_ui_catalog_groups.py:101-104`).
+- `schemas/breeze_buddy/widget_config.py:5` — module docstring references "migration 029" but the table actually lands in migration 030. Trivial doc fix.
+- `api/routers/breeze_buddy/widget/__init__.py:12` — docstring says "Six routes" but the router now also exposes `POST /widget/session/{id}/cancel`. Bump count or list explicitly.
+- `tests/test_jit_instructions.py`, `tests/test_primitive_disabled.py`, `tests/test_response_transform.py` — test funcs missing `-> None`. Apply once across all three (and `test_ui_stream.py` summary tests landed without it too — pick all up in one sweep).
+- `chat/agent.py:252` — loop counter `cycle` is unused inside the body. Rename to `_cycle` to silence the linter without behavior change.
+- `chat/ui_stream.py:412-426` — `__all__` is in declaration order, not alphabetical. Sort once when something else touches the file.
+- `template/types.py:935` — `tool_schemas: Optional[List[Dict[str, Any]]]` accepts any dict shape. Promote to a `ToolSchema(BaseModel)` with explicit `name: str`, `description: Optional[str]`, `properties: Dict[str, Any]`, `required: Optional[List[str]]`. A malformed template currently passes Pydantic validation and only blows up later with `KeyError` during tool-load. Defense-in-depth, not a present bug.
+- `mcp/__init__.py:_maybe_inject_ui_instructions` (line ~190) — collapses `ToolUiTrigger.ON_SUCCESS` and `ON_ANY` into the same branch. The helper only runs on success paths, so `on_any` never fires on direct-HTTP error responses. Plumb an `is_success: bool` arg through the three call sites (lines ~317, ~390, ~410) plus the early-return error branch in `_create_direct_http_tool_handler` so `on_any` fires correctly. Latent — currently no template uses `on_any`, but it's a footgun for the next one.

--- a/app/ai/voice/agents/breeze_buddy/agent/__init__.py
+++ b/app/ai/voice/agents/breeze_buddy/agent/__init__.py
@@ -26,6 +26,7 @@ from app.ai.voice.agents.breeze_buddy.agent.flow import (
     build_flow_config,
     load_template_config,
     prepare_initial_node,
+    prepare_resume_node,
     setup_flow_manager,
 )
 from app.ai.voice.agents.breeze_buddy.agent.inbound import (
@@ -174,6 +175,13 @@ class Agent:
         # Error tracking
         self.errors: List[Dict[str, Any]] = []
 
+        # Widget-mode resume seed (CHAT_MODE.md §14). Populated from
+        # lead.metaData in _setup_*_transport when this voice call is a
+        # transient attachment to an in-progress chat_session. When set,
+        # the agent skips greeting playback and starts the FlowManager
+        # at start_node with prior_history pre-loaded into LLM context.
+        self._widget_resume_seed: Optional[Dict[str, Any]] = None
+
     @property
     def is_daily_mode(self) -> bool:
         return self.transport_type == TRANSPORT_TYPE_DAILY
@@ -297,6 +305,26 @@ class Agent:
             self.lead.call_id or f"daily-{datetime.now().strftime('%Y%m%d%H%M%S')}"
         )
         update_log_context(call_sid=self.call_sid)
+
+        # Widget-mode resume seed: see CHAT_MODE.md §14. When this voice
+        # call is a transient attachment to an in-progress chat_session,
+        # the unified widget router stuffs the seed into lead.metaData.
+        # We capture it here so the greeting / initial-node code paths
+        # below can branch on it cleanly.
+        meta = self.lead.metaData or {}
+        widget_session_id = meta.get("widget_session_id")
+        if widget_session_id:
+            self._widget_resume_seed = {
+                "widget_session_id": str(widget_session_id),
+                "start_node": meta.get("start_node"),
+                "prior_history": list(meta.get("prior_history") or []),
+                "seed_message_count": int(meta.get("seed_message_count", 0) or 0),
+            }
+            logger.info(
+                f"Widget voice resume: chat_session={widget_session_id} "
+                f"start_node={self._widget_resume_seed['start_node']!r} "
+                f"prior_msgs={len(self._widget_resume_seed['prior_history'])}"
+            )
 
         logger.info(
             f"Starting Daily bot for lead_id: {lead_id}, call_sid: {self.call_sid}"
@@ -761,7 +789,15 @@ class Agent:
         # DAILY_STREAM also uses a Daily transport but is client-driven STT/
         # TTS-only (no LLM, no template playback) — explicitly skip greeting
         # injection there so we don't push audio into a passthrough pipeline.
-        if self.is_daily_mode and not self.is_stream_mode and self.task:
+        # Widget-mode resume: skip the greeting too. Prior chat history is
+        # already in the seed; re-greeting would repeat what the user
+        # already saw and feels broken (CHAT_MODE.md §14).
+        if (
+            self.is_daily_mode
+            and not self.is_stream_mode
+            and not self._widget_resume_seed
+            and self.task
+        ):
             greeting_result = await send_initial_greeting_daily(
                 task=self.task,
                 lead=self.lead,
@@ -789,29 +825,60 @@ class Agent:
         ) = build_flow_config(self.flow_builder, self.template)
 
         lead_payload = self.lead.payload or {}
-        initial_node_config = prepare_initial_node(
-            flow_config=self.flow_config,
-            lead_payload=lead_payload,
-            configurations=self.configurations,
-            has_greeting_source=bool(self.greeting_source),
-            greeting_text=self.greeting_text,
-        )
+
+        # Widget-mode resume: start at the chat's current_node with the
+        # chat's history pre-seeded. See prepare_resume_node for why
+        # the history goes inside task_messages (FlowManager always
+        # RESETs context on first node init — we have to put the seed
+        # inside the same frame to survive).
+        if self._widget_resume_seed:
+            initial_node_config = prepare_resume_node(
+                flow_config=self.flow_config,
+                lead_payload=lead_payload,
+                configurations=self.configurations,
+                start_node_name=self._widget_resume_seed.get("start_node"),
+                prior_history=self._widget_resume_seed.get("prior_history") or [],
+            )
+        else:
+            initial_node_config = prepare_initial_node(
+                flow_config=self.flow_config,
+                lead_payload=lead_payload,
+                configurations=self.configurations,
+                has_greeting_source=bool(self.greeting_source),
+                greeting_text=self.greeting_text,
+            )
 
         # Initialize node traversal tracking
         if self.lead.metaData is None:
             self.lead.metaData = {}
         self.lead.metaData["node_traversal"] = []
 
-        # Record initial node entry BEFORE flow_manager.initialize so that any
+        # Record initial-node entry BEFORE flow_manager.initialize so that any
         # global function called during the first LLM turn (e.g. get_driver_info
         # on the initial node) finds an active node entry to record against.
-        initial_node_name = self.flow_config["initial_node"]
+        # For widget resume we use the resume node name (which falls back to
+        # initial_node if start_node is missing — see prepare_resume_node).
+        if self._widget_resume_seed:
+            initial_node_name = (
+                self._widget_resume_seed.get("start_node")
+                or self.flow_config["initial_node"]
+            )
+            if initial_node_name not in self.flow_config["nodes"]:
+                initial_node_name = self.flow_config["initial_node"]
+        else:
+            initial_node_name = self.flow_config["initial_node"]
         context = TemplateContext(self)
         context.record_node_entry(initial_node_name)
 
         await self.flow_manager.initialize(initial_node_config)
         logger.info(
-            f"FlowManager initialized with initial node: {self.flow_config['initial_node']}"
+            f"FlowManager initialized at node: {initial_node_name}"
+            + (
+                f" (widget resume from chat_session "
+                f"{self._widget_resume_seed['widget_session_id']})"
+                if self._widget_resume_seed
+                else ""
+            )
         )
 
     async def _run_with_tracing(self, runner: PipelineRunner) -> None:

--- a/app/ai/voice/agents/breeze_buddy/agent/flow.py
+++ b/app/ai/voice/agents/breeze_buddy/agent/flow.py
@@ -201,3 +201,95 @@ def prepare_initial_node(
         post_actions=node_config.get("post_actions", []),
         respond_immediately=not has_greeting_source,
     )
+
+
+def prepare_resume_node(
+    flow_config: Dict[str, Any],
+    lead_payload: dict,
+    configurations: Optional[ConfigurationModel],
+    *,
+    start_node_name: Optional[str],
+    prior_history: List[Dict[str, Any]],
+) -> NodeConfig:
+    """Prepare a NodeConfig that resumes an existing conversation.
+
+    Used by the unified widget mode (CHAT_MODE.md §14) when voice is
+    attached to an in-progress chat session: we want the bot to start
+    at ``start_node_name`` with the chat's full message history
+    already in the LLM context.
+
+    Why this works (verified against pipecat-flows source at
+    .venv/lib/.../pipecat_flows/manager.py:712-825):
+
+      FlowManager always queues an ``LLMMessagesUpdateFrame`` (RESET)
+      on the FIRST ``_set_node`` call, regardless of context_strategy
+      — the condition is ``self._current_node is None``. A naive
+      "pre-seed LLMContext, then call initialize(node)" would have
+      the aggregator REPLACE the seed with [role + task] of the node,
+      wiping our history.
+
+      The clean workaround stays inside the official API: we put
+      ``prior_history`` at the tail of ``task_messages``. The RESET
+      frame then sets context to
+      [role_messages, task_messages, ...prior_history] in one shot —
+      the order we want. Each prior_history entry already has its own
+      ``{role: "user"|"assistant", content: str}``; the LLM doesn't
+      require role-homogeneous task_messages.
+
+    ``start_node_name`` defaults to ``flow_config["initial_node"]``
+    when None — covers the case where chat hadn't transitioned past
+    the initial node yet.
+
+    No greeting injection: when resuming we never want the bot to
+    re-greet (the greeting is already in prior_history if the chat
+    had one). ``respond_immediately=True`` so the bot responds to
+    whatever the user says first instead of speaking an empty turn.
+    """
+    node_name = start_node_name or flow_config["initial_node"]
+    if node_name not in flow_config["nodes"]:
+        # Defensive fallback — chat may have persisted a current_node
+        # that doesn't exist in this template version. Falling back to
+        # initial keeps the bot functional; we log loudly so operators
+        # notice template drift.
+        logger.warning(
+            f"prepare_resume_node: start_node {node_name!r} not in flow; "
+            f"falling back to initial_node {flow_config['initial_node']!r}"
+        )
+        node_name = flow_config["initial_node"]
+
+    node_config = flow_config["nodes"][node_name]
+
+    role_messages = inject_language_rules(
+        node_config.get("role_messages", []),
+        lead_payload.get("language_name", "English"),
+        getattr(configurations, "payload_based_language_selection", False),
+    )
+
+    task_messages: List[Dict[str, Any]] = list(node_config["task_messages"])
+    # Tail-append prior history so the RESET frame's payload becomes
+    # [role + task + history] in a single context replacement. Filter
+    # out any malformed entries defensively.
+    for entry in prior_history or []:
+        if not isinstance(entry, dict):
+            continue
+        role = entry.get("role")
+        content = entry.get("content")
+        if role not in ("user", "assistant") or not content:
+            continue
+        task_messages.append({"role": role, "content": content})
+
+    logger.info(
+        f"prepare_resume_node: resuming at {node_name!r} with "
+        f"{len(prior_history or [])} prior messages"
+    )
+
+    return NodeConfig(
+        name=node_config["name"],
+        task_messages=task_messages,
+        role_messages=role_messages,
+        functions=node_config.get("functions", []),
+        pre_actions=node_config.get("pre_actions", []),
+        post_actions=node_config.get("post_actions", []),
+        # No greeting on resume — let the user speak first.
+        respond_immediately=True,
+    )

--- a/app/ai/voice/agents/breeze_buddy/chat/agent.py
+++ b/app/ai/voice/agents/breeze_buddy/chat/agent.py
@@ -7,7 +7,8 @@ full architecture.
 """
 
 import json
-from typing import Any, AsyncIterator, Dict, List, Optional, cast
+import uuid
+from typing import Any, AsyncIterator, Dict, List, Optional, Set, Tuple, cast
 
 from pipecat.adapters.schemas.tools_schema import ToolsSchema
 from pipecat.frames.frames import FunctionCallFromLLM
@@ -15,12 +16,38 @@ from pipecat.processors.aggregators.llm_context import LLMContext, LLMContextMes
 from pipecat_flows import FlowsFunctionSchema
 
 from app.ai.voice.agents.breeze_buddy.chat import llm_driver
+from app.ai.voice.agents.breeze_buddy.chat.block_codec import (
+    assistant_turn_to_blocks,
+    plain_text_blocks,
+    tool_results_to_user_blocks,
+)
 from app.ai.voice.agents.breeze_buddy.chat.disabled import CHAT_DISABLED_NAMES
 from app.ai.voice.agents.breeze_buddy.chat.sse import SSEEvent
-from app.ai.voice.agents.breeze_buddy.mcp import get_mcp_global_functions_cached
+from app.ai.voice.agents.breeze_buddy.chat.tool_result_normalizer import normalize
+from app.ai.voice.agents.breeze_buddy.chat.ui_healer import (
+    HealerContext,
+    make_healer_fn,
+)
+from app.ai.voice.agents.breeze_buddy.chat.ui_stream import (
+    TextOut,
+    UiStreamExtractor,
+    process_op_line,
+    strip_ui_stream_markers,
+    summarize_ui_ops,
+)
+from app.ai.voice.agents.breeze_buddy.mcp import (
+    MCPPool,
+    close_mcp_pool,
+    get_mcp_global_functions_cached,
+)
 from app.ai.voice.agents.breeze_buddy.template.builder import FlowConfigBuilder
 from app.ai.voice.agents.breeze_buddy.template.context import with_context
+from app.ai.voice.agents.breeze_buddy.template.session_state import (
+    apply_state_reducers,
+    inject_tool_args,
+)
 from app.ai.voice.agents.breeze_buddy.template.types import TemplateModel
+from app.ai.voice.agents.breeze_buddy.template.ui_catalog import resolve_allowlist
 from app.ai.voice.agents.breeze_buddy.template.utils import render_messages_with_vars
 from app.ai.voice.agents.breeze_buddy.utils.language_utils.prompt_injections import (
     inject_language_rules,
@@ -30,6 +57,7 @@ from app.core.transport.http_client import create_aiohttp_session
 from app.database.accessor.breeze_buddy.chat_session import (
     insert_chat_message,
     update_chat_session_after_turn,
+    upsert_agent_session_state,
 )
 from app.schemas.breeze_buddy.chat import ChatMessageRole
 
@@ -49,11 +77,19 @@ class ChatAgent:
         template: TemplateModel,
         llm: Any,
         template_vars: Optional[dict] = None,
+        agent_state: Optional[Dict[str, Any]] = None,
     ) -> None:
         self.session_id = session_id
         self.template = template
         self.template_vars = template_vars or {}
         self._llm = llm
+        # Generic per-session state dict — the canonical store for any
+        # identifiers the template's reducers care about (cart_id,
+        # checkout_id, etc.). Loaded from agent_session_state on turn
+        # start; mutated by apply_state_reducers after each tool result;
+        # upserted to Postgres before the next turn. Empty dict on first
+        # turn or when the row doesn't exist yet.
+        self.agent_state: Dict[str, Any] = dict(agent_state or {})
         # TemplateContext reads these off the bot. flow_config is set in
         # run_turn; vad_analyzer=None lets template/{vad,interruption}.py
         # bare-attribute checks short-circuit; lead/call_sid stay None
@@ -65,6 +101,38 @@ class ChatAgent:
         self.lead = None
         self.call_sid: Optional[str] = None
         self.aiohttp_session: Optional[Any] = None
+        # Per-turn MCP client pool — one MCPClient per server, opened on
+        # the first tool call and reused for every subsequent call within
+        # the same turn. Closed in run_turn's finally so the StreamableHTTP
+        # connection is released even if the SSE consumer disconnects
+        # mid-stream. ``None`` between turns; ``{}`` while a turn is live.
+        self.mcp_pool: Optional[MCPPool] = None
+        # Streaming extractor for <ui_stream>…</ui_stream> blocks in
+        # assistant text. Each complete JSONL line inside the marker is
+        # healed (S1.2) → catalog-validated → emitted as a `ui_op` SSE event.
+        self._ui_extractor = UiStreamExtractor()
+        # Session-wide UI tree id registry. The healer uses this to detect
+        # duplicate ids (and rename to ``id__2`` / ``id__3``). Across-turn
+        # persistence is deferred until session UI state hydration ships
+        # — for now ids only collide within a single turn.
+        self._known_ui_ids: Set[str] = set()
+        # Per-template primitive allowlist resolved from
+        # ``configurations.ui_catalog``. Drives server-side primitive_disabled
+        # validation drops. Templates without ui_catalog config default to
+        # the 'core' group via ``resolve_allowlist``.
+        ui_cat = (
+            self.template.configurations.ui_catalog
+            if self.template.configurations
+            else None
+        )
+        if ui_cat is not None:
+            self._ui_allowlist: Set[str] = resolve_allowlist(
+                enabled_groups=ui_cat.enabled_groups,
+                enabled_primitives=ui_cat.enabled_primitives,
+                disabled_primitives=ui_cat.disabled_primitives,
+            )
+        else:
+            self._ui_allowlist = resolve_allowlist()
 
     async def run_turn(
         self,
@@ -78,6 +146,16 @@ class ChatAgent:
         # connector is always released — even if the generator is closed
         # mid-stream by the SSE client disconnecting.
         self.aiohttp_session = create_aiohttp_session()
+        # Per-turn MCP client pool — same lifecycle pattern. Empty dict
+        # so handlers can stash clients on first acquire; closed below.
+        self.mcp_pool = {}
+        # Per-turn identifier for the idempotency-hash injection generator
+        # (see template/session_state.py:_gen_idempotency_hash). Every
+        # tool dispatch within this turn shares this id, so a retry of
+        # the same intent produces the same idempotency key. The next
+        # turn gets a fresh uuid → different key → upstream treats it
+        # as a new operation even with identical args.
+        self._turn_id = uuid.uuid4().hex
         try:
             async for event in self._run_turn_inner(
                 user_content=user_content,
@@ -89,6 +167,8 @@ class ChatAgent:
             if self.aiohttp_session is not None:
                 await self.aiohttp_session.close()
                 self.aiohttp_session = None
+            await close_mcp_pool(self.mcp_pool)
+            self.mcp_pool = None
 
     async def _run_turn_inner(
         self,
@@ -102,7 +182,9 @@ class ChatAgent:
         # handler reference into a closure, so post-build wrapping is a no-op.
         for handler_name, handler_func in flow_builder.handler_map.items():
             flow_builder.handler_map[handler_name] = with_context(self)(handler_func)
-        flow_config = flow_builder.build_flow_config(self.template)
+        flow_config = flow_builder.build_flow_config(
+            self.template, ui_allowlist=self._ui_allowlist
+        )
         self.flow_config = flow_config
 
         # Global functions live alongside per-node ones for the LLM. In direct
@@ -129,7 +211,10 @@ class ChatAgent:
         )
         if mcp_config and mcp_config.servers:
             mcp_funcs = await get_mcp_global_functions_cached(
-                mcp_config, self.template_vars, self.template.id
+                mcp_config,
+                self.template_vars,
+                self.template.id,
+                mcp_pool=self.mcp_pool,
             )
             existing_names = {fn.name for fn in global_funcs}
             unique = [fn for fn in mcp_funcs if fn.name not in existing_names]
@@ -138,15 +223,29 @@ class ChatAgent:
                 f"[BUDDY_MCP] chat: added {len(unique)} MCP tools as global functions"
             )
 
+        # Aggregate per-tool context-retention policy across every MCP server
+        # the template declares. Used by llm_driver to compact stale
+        # tool_result blocks in the messages array before each LLM call —
+        # bounds input-token cost as a session accumulates tool calls.
+        # Tools not in the map default to ``session`` (no compaction).
+        tool_retention: Dict[str, str] = {}
+        if mcp_config and mcp_config.servers:
+            for server in mcp_config.servers:
+                if server.tool_context_retention:
+                    tool_retention.update(server.tool_context_retention)
+
         node = self._resolve_node(flow_config, current_node)
         node_name = cast(str, node["name"])
 
         # Persist user message before the LLM call so a crash mid-stream
-        # still leaves the user's input in history.
+        # still leaves the user's input in history. We also write the
+        # canonical Anthropic-shape [text] block so the loader has a
+        # single source of truth on the next turn.
         user_msg = await insert_chat_message(
             session_id=self.session_id,
             role=ChatMessageRole.USER,
             content=user_content,
+            content_blocks=plain_text_blocks(user_content),
         )
         yield SSEEvent(
             event="user_committed",
@@ -156,17 +255,61 @@ class ChatAgent:
         context = self._seed_context(node, history, user_content, global_funcs)
 
         assistant_text_chunks: List[str] = []
+        # ui_ops accumulator (Sprint 1.7) — captures each SpecStream op the
+        # LLM emits during this user turn. Persisted alongside the assistant
+        # message so the widget resume path can repaint Tiles/Carousels
+        # after a page refresh. Reset per cycle so each persisted row
+        # carries only the ops produced by THAT cycle.
+        turn_ui_ops: List[Dict[str, Any]] = []
         for cycle in range(1, _MAX_TOOL_CYCLES + 1):
             tool_calls: List[FunctionCallFromLLM] = []
             turn_text: List[str] = []
+            turn_ui_ops = []
 
             async for kind, payload in llm_driver.stream(
-                self._llm, context, log_label=f"chat#{self.session_id[:8]}"
+                self._llm,
+                context,
+                log_label=f"chat#{self.session_id[:8]}",
+                tool_context_retention=tool_retention or None,
             ):
                 if kind == "text":
                     text = cast(str, payload)
                     turn_text.append(text)
-                    yield SSEEvent(event="assistant_token", data={"delta": text})
+                    # Strip <ui_stream>…</ui_stream> from the user-facing
+                    # prose stream. Each TextOut becomes an
+                    # assistant_token; each JsonlOpLine is healed →
+                    # catalog-validated → emitted as one or more SSE
+                    # events (ui_op + optional healer_applied/ui_op_dropped).
+                    healer_ctx = HealerContext(
+                        session_data=self.agent_state,
+                        known_ids=self._known_ui_ids,
+                    )
+                    healer = make_healer_fn(healer_ctx)
+                    for out in self._ui_extractor.feed(text):
+                        if isinstance(out, TextOut):
+                            yield SSEEvent(
+                                event="assistant_token", data={"delta": out.value}
+                            )
+                        else:
+                            for ev in process_op_line(
+                                out.raw,
+                                session_state=self.agent_state,
+                                healer=healer,
+                                known_ids=self._known_ui_ids,
+                                allowlist=self._ui_allowlist,
+                            ):
+                                # Capture successful ui_op emissions for the
+                                # widget resume path (persisted on the
+                                # assistant row via ui_blocks).
+                                if ev.event == "ui_op":
+                                    op_payload = (
+                                        ev.data.get("op")
+                                        if isinstance(ev.data, dict)
+                                        else None
+                                    )
+                                    if isinstance(op_payload, dict):
+                                        turn_ui_ops.append(op_payload)
+                                yield ev
                 elif kind == "tool_call":
                     call = cast(FunctionCallFromLLM, payload)
                     tool_calls.append(call)
@@ -183,6 +326,31 @@ class ChatAgent:
             if not tool_calls:
                 break
 
+            # Strip <ui_stream> markers before persistence so the LLM
+            # doesn't see its own prior JSONL ops on replay. Append a
+            # compact summary of what tiles/handoffs the user actually
+            # saw — without it the LLM has no memory of its own UI and
+            # must reason from prose alone (which can drift from reality).
+            assistant_text = strip_ui_stream_markers("".join(turn_text))
+            ui_summary = summarize_ui_ops(turn_ui_ops)
+            if ui_summary:
+                assistant_text = (assistant_text.rstrip() + "\n\n" + ui_summary).strip()
+
+            # Persist the assistant turn-step with full Anthropic-shape
+            # blocks [text? + tool_use*]. This is the load-bearing fix
+            # for cross-turn identifier loss — on the next /message the
+            # history loader replays tool_use.input verbatim, so the
+            # LLM sees its own prior cart_id / checkout_id / etc.
+            assistant_blocks = assistant_turn_to_blocks(assistant_text, tool_calls)
+            if assistant_blocks:
+                await insert_chat_message(
+                    session_id=self.session_id,
+                    role=ChatMessageRole.ASSISTANT,
+                    content=assistant_text or None,
+                    content_blocks=assistant_blocks,
+                    ui_blocks=turn_ui_ops or None,
+                )
+
             # Mirror LLMAssistantContextAggregator: append assistant message
             # carrying tool_calls, then a tool-result per call. Universal
             # OpenAI shape; per-provider adapter converts on next request.
@@ -191,7 +359,7 @@ class ChatAgent:
                     LLMContextMessage,
                     {
                         "role": "assistant",
-                        "content": "".join(turn_text) or None,
+                        "content": assistant_text or None,
                         "tool_calls": [
                             {
                                 "id": call.tool_call_id,
@@ -207,10 +375,29 @@ class ChatAgent:
                 )
             )
 
+            # Generic argument-injection — read template-declared rules
+            # and merge session state into outgoing tool args (e.g. a
+            # missing cart_id is filled from agent_state.data.cart_id).
+            # only_if_missing semantics: the LLM's explicit value wins.
+            arg_injection_rules = (
+                self.template.configurations.tool_arg_injection
+                if self.template.configurations
+                else []
+            )
+
             next_node: Optional[Dict[str, Any]] = None
+            tool_result_pairs: List[Tuple[str, Any]] = []
             for call in tool_calls:
+                injected_args = inject_tool_args(
+                    tool_name=call.function_name,
+                    args=dict(call.arguments),
+                    state_data=self.agent_state,
+                    chat_session_id=self.session_id,
+                    injections=arg_injection_rules,
+                    turn_id=self._turn_id,
+                )
                 result_payload, transition_node = await self._dispatch_tool_call(
-                    call, node, global_funcs
+                    call, node, global_funcs, injected_args=injected_args
                 )
                 context.add_message(
                     cast(
@@ -222,6 +409,22 @@ class ChatAgent:
                         },
                     )
                 )
+                # Apply template-declared reducers to lift identifiers
+                # off the tool result into session state (e.g.
+                # update_cart's cart.id → state.data.cart_id). Engine
+                # is commerce-blind; rules live in template JSON.
+                reducer_rules = (
+                    self.template.configurations.state_reducers
+                    if self.template.configurations
+                    else []
+                )
+                self.agent_state = apply_state_reducers(
+                    state_data=self.agent_state,
+                    tool_name=call.function_name,
+                    tool_result=result_payload,
+                    reducers=reducer_rules,
+                )
+                tool_result_pairs.append((call.tool_call_id, result_payload))
                 yield SSEEvent(
                     event="function_call_completed",
                     data={
@@ -232,6 +435,21 @@ class ChatAgent:
                 )
                 if transition_node is not None and next_node is None:
                     next_node = transition_node
+
+            # Persist the coalesced tool_result user-row + the updated
+            # session state. Both go to Postgres so a crash before the
+            # next LLM call doesn't lose either.
+            if tool_result_pairs:
+                await insert_chat_message(
+                    session_id=self.session_id,
+                    role=ChatMessageRole.USER,
+                    content=None,
+                    content_blocks=tool_results_to_user_blocks(tool_result_pairs),
+                )
+            await upsert_agent_session_state(
+                chat_session_id=self.session_id,
+                data=self.agent_state,
+            )
 
             if next_node is not None:
                 node = next_node
@@ -261,15 +479,38 @@ class ChatAgent:
                     ),
                 },
             )
+            # Flush extractor state — any unclosed <ui_stream> block is
+            # dropped with a log warning by the extractor itself.
+            for _ in self._ui_extractor.flush():
+                pass
             yield SSEEvent(event="turn_end", data={"session_status": "FAILED"})
             return
 
-        assistant_text = "".join(assistant_text_chunks).strip()
+        # Drain any held marker carry. Trailing prose held mid-marker is
+        # forwarded; an unmatched <ui_stream> open is dropped (with warning).
+        for out in self._ui_extractor.flush():
+            if isinstance(out, TextOut):
+                yield SSEEvent(event="assistant_token", data={"delta": out.value})
+            # JsonlOpLine items from flush() shouldn't happen — defensive
+            # path drops them (flush only ever yields TextOut today).
+
+        # Reconstruct prose-only history (strips every
+        # <ui_stream>…</ui_stream>) so saved messages never carry SpecStream
+        # ops forward into future turns. The canonical [text] block keeps
+        # history replay uniform on subsequent loads. A compact UI summary
+        # is appended so the LLM still has referential memory of what the
+        # shopper actually saw (titles, handoffs) on the next turn.
+        assistant_text = strip_ui_stream_markers("".join(assistant_text_chunks)).strip()
+        ui_summary = summarize_ui_ops(turn_ui_ops)
+        if ui_summary:
+            assistant_text = (assistant_text + "\n\n" + ui_summary).strip()
         if assistant_text:
             stored = await insert_chat_message(
                 session_id=self.session_id,
                 role=ChatMessageRole.ASSISTANT,
                 content=assistant_text,
+                content_blocks=plain_text_blocks(assistant_text),
+                ui_blocks=turn_ui_ops or None,
             )
             yield SSEEvent(
                 event="assistant_message",
@@ -360,6 +601,7 @@ class ChatAgent:
         call: FunctionCallFromLLM,
         node: Dict[str, Any],
         global_funcs: List[FlowsFunctionSchema],
+        injected_args: Optional[Dict[str, Any]] = None,
     ) -> tuple[Any, Optional[Dict[str, Any]]]:
         """Find the wrapper handler for ``call`` and invoke it.
 
@@ -371,6 +613,10 @@ class ChatAgent:
         Lookup falls through per-node functions first, then globals — same
         precedence as voice's FlowManager (per-node shadow globals when
         names collide).
+
+        ``injected_args`` is the post-injection argument dict from
+        :func:`inject_tool_args` (template-declared session-state fills).
+        When omitted, the LLM-provided ``call.arguments`` are used as-is.
         """
         candidates: List[FlowsFunctionSchema] = [
             *(
@@ -393,8 +639,11 @@ class ChatAgent:
                 None,
             )
 
+        args_for_handler = (
+            injected_args if injected_args is not None else dict(call.arguments)
+        )
         try:
-            raw = await handler_fn(dict(call.arguments), None)
+            raw = await handler_fn(args_for_handler, None)
         except Exception as exc:
             logger.error(
                 f"ChatAgent {self.session_id}: handler {call.function_name!r} "
@@ -410,8 +659,8 @@ class ChatAgent:
             and len(raw) == 2
             and (raw[1] is None or isinstance(raw[1], dict))
         ):
-            return raw[0], raw[1]
-        return raw, None
+            return normalize(call.function_name, raw[0]), raw[1]
+        return normalize(call.function_name, raw), None
 
 
 def _tools_schema(

--- a/app/ai/voice/agents/breeze_buddy/chat/block_codec.py
+++ b/app/ai/voice/agents/breeze_buddy/chat/block_codec.py
@@ -1,0 +1,245 @@
+"""Anthropic-shape ↔ OpenAI/LLMContext-shape conversion for chat history.
+
+Persistence format (``chat_message.content_blocks`` JSONB) is canonical
+Anthropic content blocks. Pipecat's ``LLMContext`` speaks OpenAI shape
+internally and converts on the wire to whichever provider is in use.
+This module is the seam between those two shapes.
+
+Why Anthropic-shape on disk:
+- Pairs cleanly with the existing ``chat_message`` ``role`` CHECK
+  constraint (``user``/``assistant`` only — tool_result blocks live
+  inside a user row).
+- Matches every reference implementation in the research set
+  (`shop-chat-agent`, `claude-cookbooks`, `mcp-python-sdk`).
+- Provider-stable: when we eventually swap Claude for a non-Anthropic
+  model, the on-disk shape is still the standard.
+
+Block shapes
+------------
+Assistant row blocks::
+
+    [
+        {"type": "text", "text": "..."},                         # optional
+        {"type": "tool_use", "id": "...", "name": "...",
+         "input": {...}},                                        # 0..N
+    ]
+
+User row blocks (text turn)::
+
+    [{"type": "text", "text": "..."}]
+
+User row blocks (tool-result turn — emitted between tool cycles)::
+
+    [
+        {"type": "tool_result", "tool_use_id": "...", "content": "..."},
+        ...
+    ]
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Dict, List, cast
+
+from pipecat.frames.frames import FunctionCallFromLLM
+from pipecat.processors.aggregators.llm_context import LLMContextMessage
+
+from app.core.logger import logger
+
+# ---------------------------------------------------------------------------
+# Encoding: write side (turn-loop → DB)
+# ---------------------------------------------------------------------------
+
+
+def assistant_turn_to_blocks(
+    text: str,
+    tool_calls: List[FunctionCallFromLLM],
+) -> List[Dict[str, Any]]:
+    """Build an Anthropic-shape block list for one assistant turn-step.
+
+    ``text`` may be empty (the LLM emitted only a tool_use); ``tool_calls``
+    may be empty (the LLM emitted only prose). At least one of the two
+    is always present when the caller invokes this — otherwise the turn
+    step is a no-op and should not be persisted.
+    """
+    blocks: List[Dict[str, Any]] = []
+    if text:
+        blocks.append({"type": "text", "text": text})
+    for call in tool_calls:
+        blocks.append(
+            {
+                "type": "tool_use",
+                "id": call.tool_call_id,
+                "name": call.function_name,
+                "input": dict(call.arguments),
+            }
+        )
+    return blocks
+
+
+def tool_results_to_user_blocks(
+    pairs: List[tuple],
+) -> List[Dict[str, Any]]:
+    """Coalesce N tool results into one Anthropic-shape user turn.
+
+    ``pairs`` is a list of ``(tool_call_id, result_payload)``. The
+    result_payload is whatever our dispatcher returned (FlowResult-ish
+    dict or string) — we JSON-encode for the on-disk content.
+    """
+    blocks: List[Dict[str, Any]] = []
+    for tool_call_id, result_payload in pairs:
+        if isinstance(result_payload, str):
+            encoded = result_payload
+        else:
+            try:
+                encoded = json.dumps(result_payload, default=str)
+            except (TypeError, ValueError):
+                encoded = str(result_payload)
+        blocks.append(
+            {
+                "type": "tool_result",
+                "tool_use_id": tool_call_id,
+                "content": encoded,
+            }
+        )
+    return blocks
+
+
+def plain_text_blocks(text: str) -> List[Dict[str, Any]]:
+    """Single-element [text] block. Used for the user's prose question
+    and for the final assistant prose reply."""
+    return [{"type": "text", "text": text}]
+
+
+# ---------------------------------------------------------------------------
+# Decoding: read side (DB → LLMContext seed)
+# ---------------------------------------------------------------------------
+
+
+def blocks_to_llm_context_messages(
+    rows: List[Dict[str, Any]],
+) -> List[LLMContextMessage]:
+    """Convert a chronological list of chat_message rows into the
+    OpenAI-shape LLMContextMessage list that ``LLMContext`` consumes.
+
+    Each row is a dict with at least ``role`` and ``content_blocks``
+    (or legacy ``content``). Tool_result blocks expand into multiple
+    ``{role:"tool"}`` messages. Unknown block types are dropped with a
+    warning so a forward-incompatible block never breaks replay.
+    """
+    out: List[LLMContextMessage] = []
+
+    for row in rows:
+        role = row.get("role")
+        blocks = row.get("content_blocks")
+        fallback_text = row.get("content")
+
+        # Pre-migration rows or rows somehow missing content_blocks:
+        # synthesise a text block from the denormalised content column.
+        if not blocks and fallback_text:
+            blocks = [{"type": "text", "text": fallback_text}]
+        if not blocks:
+            continue
+
+        if role == "assistant":
+            out.append(_assistant_row_to_openai(blocks))
+        elif role == "user":
+            out.extend(_user_row_to_openai(blocks))
+        else:
+            logger.warning(f"[block_codec] skipping unknown role {role!r}")
+
+    return out
+
+
+def _assistant_row_to_openai(blocks: List[Dict[str, Any]]) -> LLMContextMessage:
+    """Anthropic assistant blocks → one OpenAI-shape assistant message.
+
+    Concatenates text blocks; collects tool_use blocks into the
+    OpenAI ``tool_calls`` array.
+    """
+    text_parts: List[str] = []
+    tool_calls: List[Dict[str, Any]] = []
+
+    for block in blocks:
+        btype = block.get("type")
+        if btype == "text":
+            t = block.get("text")
+            if t:
+                text_parts.append(t)
+        elif btype == "tool_use":
+            tool_calls.append(
+                {
+                    "id": block.get("id"),
+                    "type": "function",
+                    "function": {
+                        "name": block.get("name"),
+                        "arguments": json.dumps(block.get("input") or {}),
+                    },
+                }
+            )
+        else:
+            logger.warning(
+                f"[block_codec] skipping unknown assistant block type {btype!r}"
+            )
+
+    msg: Dict[str, Any] = {"role": "assistant"}
+    if text_parts:
+        msg["content"] = "".join(text_parts)
+    else:
+        msg["content"] = None
+    if tool_calls:
+        msg["tool_calls"] = tool_calls
+    return cast(LLMContextMessage, msg)
+
+
+def _user_row_to_openai(
+    blocks: List[Dict[str, Any]],
+) -> List[LLMContextMessage]:
+    """Anthropic user blocks → 1+ OpenAI messages.
+
+    Text-only blocks → one ``{role:"user"}`` message. Tool_result
+    blocks → one ``{role:"tool"}`` message per result. A row can in
+    theory mix both (Anthropic allows it); we emit the tool_result
+    messages first (closer to the originating tool_use), then a
+    user-text message if any.
+    """
+    text_parts: List[str] = []
+    tool_msgs: List[LLMContextMessage] = []
+
+    for block in blocks:
+        btype = block.get("type")
+        if btype == "text":
+            t = block.get("text")
+            if t:
+                text_parts.append(t)
+        elif btype == "tool_result":
+            tool_msgs.append(
+                cast(
+                    LLMContextMessage,
+                    {
+                        "role": "tool",
+                        "tool_call_id": block.get("tool_use_id"),
+                        "content": block.get("content") or "",
+                    },
+                )
+            )
+        else:
+            logger.warning(f"[block_codec] skipping unknown user block type {btype!r}")
+
+    msgs: List[LLMContextMessage] = list(tool_msgs)
+    if text_parts:
+        msgs.append(
+            cast(
+                LLMContextMessage,
+                {"role": "user", "content": "".join(text_parts)},
+            )
+        )
+    return msgs
+
+
+__all__ = [
+    "assistant_turn_to_blocks",
+    "tool_results_to_user_blocks",
+    "plain_text_blocks",
+    "blocks_to_llm_context_messages",
+]

--- a/app/ai/voice/agents/breeze_buddy/chat/context_compactor.py
+++ b/app/ai/voice/agents/breeze_buddy/chat/context_compactor.py
@@ -1,0 +1,206 @@
+"""Conversation-context compactor for chat turns.
+
+Walks the Anthropic ``messages`` array right before it's sent to the LLM and
+rewrites stale ``tool_result`` payloads down to a 1-line stub. Goal: keep
+input-token cost bounded as a session accumulates tool calls.
+
+Behavioral contract
+-------------------
+* The ``tool_use`` block (a small assistant-side dict carrying the tool name
+  and args) is **always preserved** — that gives the LLM proof the tool ran
+  and lets it spot when it should re-call.
+* Only the matching ``tool_result.content`` is rewritten — to a deterministic
+  stub like ``[pruned: search_catalog({"query":"red"}) ran earlier; re-call
+  to refresh]``.
+* Rewriting only happens for tool names whose ``tool_context_retention``
+  policy is ``last_turn_only`` AND only for tool_result blocks older than
+  the most recent ``recent_keep`` tool_result(s). The newest one (or two)
+  always pass through untouched so the agent can reason about what the
+  current turn just fetched.
+* Tools not listed in the retention map are treated as ``session`` —
+  preserved as-is (current behavior, no surprise drift).
+
+Cache implications
+------------------
+Compaction mutates earlier messages, which **breaks Anthropic prompt-cache
+hits** on the prefix that includes those messages. The caller (chat agent)
+has made a deliberate trade: bounded context > marginal cache savings.
+Don't add cache_control markers around compacted blocks; let the adapter
+re-cache from the next stable boundary.
+
+Why per-tool, not per-result-size
+----------------------------------
+A size-based heuristic ("compact any tool_result over 5K chars") would be
+simpler but rigid. Per-tool policy lets the template author keep state-
+bearing tools (cart) fully readable while pruning the heavy, easy-to-re-
+derive ones (catalog search). The trade-off is one extra field on the
+``McpServerConfig`` — small price for clean semantics.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Dict, List, Optional
+
+from app.core.logger import logger
+
+__all__ = ["compact_tool_results"]
+
+# Tools whose retention is not explicitly set default to this. ``session``
+# means "keep tool_result content as-is" — preserves backward compatibility
+# for any merchant template that doesn't opt in.
+_DEFAULT_RETENTION = "session"
+
+
+def _stub_for(tool_name: str, tool_args: Any) -> str:
+    """Format the replacement content for a compacted tool_result.
+
+    Includes the tool name and a compact JSON form of the args so the LLM
+    can see *what was previously asked* — enough to decide whether to
+    re-call. Capped because tool args can themselves be large.
+    """
+    try:
+        args_repr = json.dumps(tool_args, separators=(",", ":"), ensure_ascii=False)
+    except (TypeError, ValueError):
+        args_repr = str(tool_args)
+    # Bound the args repr so a single bloated arg can't reinflate context.
+    if len(args_repr) > 200:
+        args_repr = args_repr[:197] + "..."
+    return (
+        f"[pruned: {tool_name}({args_repr}) ran earlier — "
+        "re-call this tool if you need fresh data]"
+    )
+
+
+def _is_tool_result_block(block: Any) -> bool:
+    return isinstance(block, dict) and block.get("type") == "tool_result"
+
+
+def _is_tool_use_block(block: Any) -> bool:
+    return isinstance(block, dict) and block.get("type") == "tool_use"
+
+
+def compact_tool_results(
+    messages: List[Dict[str, Any]],
+    retention: Optional[Dict[str, str]] = None,
+    recent_keep: int = 1,
+) -> List[Dict[str, Any]]:
+    """Return a copy of ``messages`` with stale tool_results rewritten to stubs.
+
+    Args:
+        messages: Anthropic-format conversation list. Each message has a
+            ``role`` and ``content`` (which may be a string or a list of
+            content blocks).
+        retention: Map of tool name → ``"last_turn_only"`` | ``"session"``.
+            Tools not in the map default to ``"session"`` (preserved).
+            ``None`` or empty map → returns messages essentially unchanged
+            (only does a shallow copy).
+        recent_keep: How many most-recent tool_result blocks to leave
+            untouched. Default 1: the assistant always sees the very last
+            tool result intact (the one its current turn is reasoning
+            about). Increase to 2 for "I might re-reference the last two
+            calls" workflows.
+
+    Returns:
+        A new list of messages (input is not mutated). Tool_use blocks are
+        always preserved; only stale tool_result content is rewritten.
+    """
+    if not messages:
+        return list(messages)
+
+    retention = retention or {}
+
+    # Build a tool_use_id → (tool_name, tool_args) index by scanning assistant
+    # messages. The pairing is by ``tool_use_id`` (Anthropic's contract) — the
+    # tool_result block carries ``tool_use_id`` referring back to the
+    # tool_use it answers.
+    tool_use_index: Dict[str, Dict[str, Any]] = {}
+    for msg in messages:
+        if msg.get("role") != "assistant":
+            continue
+        content = msg.get("content")
+        if not isinstance(content, list):
+            continue
+        for block in content:
+            if _is_tool_use_block(block):
+                tu_id = block.get("id")
+                if tu_id:
+                    tool_use_index[tu_id] = {
+                        "name": block.get("name", "?"),
+                        "input": block.get("input"),
+                    }
+
+    # First pass: locate every tool_result block, in order, and decide which
+    # ones to compact. We compact a tool_result iff:
+    #   - the tool it answers has retention == "last_turn_only", AND
+    #   - it is NOT in the last ``recent_keep`` tool_results.
+    tool_result_positions: List[tuple] = []  # (msg_index, block_index, tool_name)
+    for i, msg in enumerate(messages):
+        if msg.get("role") != "user":
+            continue
+        content = msg.get("content")
+        if not isinstance(content, list):
+            continue
+        for j, block in enumerate(content):
+            if not _is_tool_result_block(block):
+                continue
+            tu_id = block.get("tool_use_id")
+            tool_meta = tool_use_index.get(tu_id) if tu_id else None
+            tool_name = tool_meta["name"] if tool_meta else "?"
+            tool_result_positions.append((i, j, tool_name, tool_meta))
+
+    # Decide which positions get compacted. The last ``recent_keep`` are
+    # always preserved. Everything earlier with policy == last_turn_only
+    # gets compacted.
+    keep_set = (
+        set((i, j) for i, j, _, _ in tool_result_positions[-recent_keep:])
+        if recent_keep > 0
+        else set()
+    )
+
+    # Second pass: build the output. Shallow-copy each message; deep-copy
+    # only when we actually rewrite content (avoids unnecessary work).
+    n_compacted = 0
+    out: List[Dict[str, Any]] = []
+    for i, msg in enumerate(messages):
+        if msg.get("role") != "user" or not isinstance(msg.get("content"), list):
+            out.append(msg)
+            continue
+
+        new_content = list(msg["content"])  # shallow copy of the content list
+        rewrote = False
+        for j, block in enumerate(new_content):
+            if not _is_tool_result_block(block):
+                continue
+            if (i, j) in keep_set:
+                continue
+            # Find the tool name; default to session if unknown.
+            tu_id = block.get("tool_use_id")
+            tool_meta = tool_use_index.get(tu_id) if tu_id else None
+            tool_name = tool_meta["name"] if tool_meta else None
+            if not tool_name:
+                continue
+            policy = retention.get(tool_name, _DEFAULT_RETENTION)
+            if policy != "last_turn_only":
+                continue
+            # Compact this one.
+            tool_args = tool_meta.get("input") if tool_meta else None
+            new_content[j] = {
+                **block,
+                "content": _stub_for(tool_name, tool_args),
+            }
+            rewrote = True
+            n_compacted += 1
+
+        if rewrote:
+            out.append({**msg, "content": new_content})
+        else:
+            out.append(msg)
+
+    if n_compacted:
+        logger.debug(
+            f"[context_compactor] rewrote {n_compacted} stale tool_result "
+            f"block(s) to stubs (retention map: "
+            f"{ {k: v for k, v in retention.items() if v != _DEFAULT_RETENTION} })"
+        )
+    return out

--- a/app/ai/voice/agents/breeze_buddy/chat/llm_driver.py
+++ b/app/ai/voice/agents/breeze_buddy/chat/llm_driver.py
@@ -14,7 +14,7 @@ exposes no public streaming-with-tools entry point. Tested with pipecat 1.1.0
 from __future__ import annotations
 
 import json
-from typing import Any, AsyncIterator, Literal, Tuple, Union
+from typing import Any, AsyncIterator, Dict, Literal, Optional, Tuple, Union
 
 from pipecat.frames.frames import FunctionCallFromLLM
 from pipecat.processors.aggregators.llm_context import LLMContext
@@ -22,6 +22,9 @@ from pipecat.services.anthropic.llm import AnthropicLLMService
 from pipecat.services.google.llm import GoogleLLMService
 from pipecat.services.openai.base_llm import BaseOpenAILLMService
 
+from app.ai.voice.agents.breeze_buddy.chat.context_compactor import (
+    compact_tool_results,
+)
 from app.core.logger import logger
 
 DriverEvent = Tuple[Literal["text", "tool_call"], Union[str, FunctionCallFromLLM]]
@@ -35,18 +38,26 @@ async def stream(
     context: LLMContext,
     *,
     log_label: str = "chat",
+    tool_context_retention: Optional[Dict[str, str]] = None,
 ) -> AsyncIterator[DriverEvent]:
     """Issue one streaming LLM call; yield text deltas + tool calls.
 
     The caller owns ``context`` mutation between turns of the tool-call loop.
     This function only reads it.
+
+    ``tool_context_retention`` is an optional per-tool policy map (currently
+    honoured only by the Anthropic path) that lets the compactor rewrite
+    stale ``tool_result`` blocks into 1-line stubs — bounding input-token
+    cost across long sessions. ``None`` or an empty map is a no-op.
     """
     if isinstance(llm_service, BaseOpenAILLMService):
         async for event in _stream_openai(llm_service, context, log_label):
             yield event
         return
     if isinstance(llm_service, AnthropicLLMService):
-        async for event in _stream_anthropic(llm_service, context, log_label):
+        async for event in _stream_anthropic(
+            llm_service, context, log_label, tool_context_retention
+        ):
             yield event
         return
     if isinstance(llm_service, GoogleLLMService):
@@ -180,6 +191,7 @@ async def _stream_anthropic(
     service: AnthropicLLMService,
     context: LLMContext,
     log_label: str,
+    tool_context_retention: Optional[Dict[str, str]] = None,
 ) -> AsyncIterator[DriverEvent]:
     """Mirror AnthropicLLMService._process_context minus frame pushes.
 
@@ -211,6 +223,18 @@ async def _stream_anthropic(
         params["thinking"] = thinking.model_dump(exclude_unset=True)
     params.update(invocation_params)
     params.update(getattr(settings, "extra", None) or {})
+
+    # Compact stale tool_result blocks per the template's retention policy.
+    # Applied AFTER invocation_params/settings.extra are merged in, so the
+    # compaction reflects exactly what's about to go on the wire. The most
+    # recent tool_result stays intact (``recent_keep=1``) so the LLM can
+    # reason about the call its current turn just made.
+    if tool_context_retention and isinstance(params.get("messages"), list):
+        params["messages"] = compact_tool_results(
+            params["messages"],
+            retention=tool_context_retention,
+            recent_keep=1,
+        )
 
     logger.debug(f"[{log_label}] llm_driver: anthropic stream model={settings.model}")
 

--- a/app/ai/voice/agents/breeze_buddy/chat/tool_result_normalizer.py
+++ b/app/ai/voice/agents/breeze_buddy/chat/tool_result_normalizer.py
@@ -1,0 +1,63 @@
+"""Unwrap the Clairvoyance + pipecat MCP envelope around tool results.
+
+All vertical-specific shaping (numeric scaling, field flattening, image
+precedence) used to live here. That logic now belongs in the template's
+``tool_response_transforms`` (declarative) so this engine stays vertical-
+agnostic. This module's only remaining job is to peel the two-layer
+transport envelope so downstream callers see a plain dict (or whatever
+the raw value was) instead of ``{"status": "...", "data": "<json>"}``.
+
+The public ``normalize(tool_name, raw)`` signature is preserved for forward
+compatibility — callers don't need to change, and a future per-tool hook can
+slot in here without another agent-side refactor.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, Optional
+
+_log = logging.getLogger(__name__)
+
+
+def _unwrap_mcp_envelope(raw: Any) -> Optional[Any]:
+    """Peel the Clairvoyance + pipecat MCP layering and return the inner value.
+
+    Clairvoyance wraps MCP results as ``{"status": "success", "data": <value>}``;
+    pipecat's ``MCPClient._call_tool`` concatenates ``text`` content chunks into
+    a JSON-encoded string.  This helper unwraps both layers and returns the
+    innermost value, or ``None`` if any layer is missing/unparseable.
+    """
+    if not isinstance(raw, dict):
+        return None
+
+    # 1. Clairvoyance envelope: {"status": "success"/"error", "data": ...}
+    if "status" in raw and "data" in raw:
+        if raw.get("status") != "success":
+            return None
+        raw = raw["data"]
+
+    # 2. pipecat passes the MCP text-content as a raw JSON string — parse it.
+    if isinstance(raw, str):
+        try:
+            raw = json.loads(raw)
+        except (json.JSONDecodeError, ValueError):
+            return None
+
+    return raw
+
+
+def normalize(tool_name: str, raw: Any) -> Any:
+    """Unwrap the Clairvoyance/pipecat MCP envelope around ``raw``.
+
+    ``tool_name`` is kept for forward compatibility with potential per-tool
+    hooks; the current body has no per-tool branching.  When the envelope is
+    missing or unparseable, ``raw`` is returned unchanged so a malformed
+    response never breaks a turn.
+    """
+    inner = _unwrap_mcp_envelope(raw)
+    return inner if inner is not None else raw
+
+
+__all__ = ["normalize"]

--- a/app/ai/voice/agents/breeze_buddy/chat/ui_healer.py
+++ b/app/ai/voice/agents/breeze_buddy/chat/ui_healer.py
@@ -1,0 +1,315 @@
+"""In-stream healer — deterministic rule layer over raw JSONL ops.
+
+Sits between the LLM's emission and the parser/validator. Fixes the few
+mechanical mistakes the LLM repeatedly makes (duplicate ids, unknown
+prop keys, near-miss prop names) without burning a second LLM call.
+<250ms latency per Vercel v0's "LLM Suspense" pattern.
+
+Each rule is a pure function ``(op_dict, ctx) → Optional[op_dict]`` plus
+a tag string for telemetry. The dispatcher applies rules in order; the
+first rule to mutate the op annotates the ``notes`` list, then the next
+rule sees the mutated op. ``drop=True`` short-circuits the pipeline.
+
+The healer is intentionally code-defined (not template-configurable) —
+mechanical fixes don't vary by merchant. See SCALE_ROADMAP.md §"Open
+questions / Healer rule-set governance".
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, Callable, Dict, List, Optional, Set, Tuple
+
+from app.ai.voice.agents.breeze_buddy.chat.ui_stream import HealerResult
+from app.ai.voice.agents.breeze_buddy.template.ui_catalog import (
+    UI_CATALOG,
+    is_known_type,
+)
+
+_log = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Healer context — what each rule may inspect/mutate beyond the op
+# ---------------------------------------------------------------------------
+
+
+class HealerContext:
+    """Per-line healer ctx. Carries session state (read-only for rules) and
+    the running ``known_ids`` set (mutated by rules). Constructed by the
+    chat agent at the start of each turn and passed to ``heal_op``."""
+
+    def __init__(
+        self,
+        *,
+        session_data: Dict[str, Any],
+        known_ids: Set[str],
+    ) -> None:
+        self.session_data = session_data
+        self.known_ids = known_ids
+
+
+# ---------------------------------------------------------------------------
+# Individual rules — each returns (mutated_op, note_or_None)
+# ---------------------------------------------------------------------------
+
+
+# Per-primitive prop-name aliases the LLM frequently confuses. Applied
+# BEFORE the unknown-props strip so a Tag.label → Tag.text rename rescues
+# an op that would otherwise drop. Keys are (type, alias) → canonical name.
+# Empirically derived from real-traffic emissions — extend as new misses
+# appear in `ui_op_dropped` telemetry.
+_PROP_ALIASES: Dict[Tuple[str, str], str] = {
+    ("Tag", "label"): "text",
+    ("Tag", "name"): "text",
+    ("Tag", "value"): "text",
+    ("Text", "content"): "text",  # legacy DSL prop name
+    ("Text", "value"): "text",
+    ("Button", "title"): "label",
+    ("Button", "text"): "label",
+    ("Image", "url"): "src",
+    ("Image", "image"): "src",
+    ("Image", "title"): "alt",
+    ("CardHeader", "heading"): "title",
+    ("CardHeader", "header"): "title",
+}
+
+
+def _rule_rename_prop_aliases(
+    op: Dict[str, Any], ctx: HealerContext
+) -> Tuple[Dict[str, Any], Optional[str]]:
+    """Rename common alias props onto their catalog-canonical names BEFORE
+    the unknown-props strip. Saves Tag.label → Tag.text etc. — the LLM
+    consistently reaches for these synonyms across runs, and the
+    strip-then-validate path would otherwise drop the whole op."""
+    if op.get("op") != "add":
+        return op, None
+    type_name = op.get("type")
+    if not isinstance(type_name, str) or not is_known_type(type_name):
+        return op, None
+    props = op.get("props")
+    if not isinstance(props, dict):
+        return op, None
+    schema = UI_CATALOG[type_name]
+    allowed = set(schema.model_fields.keys())
+    renames: List[str] = []
+    for alias_name in list(props.keys()):
+        canonical = _PROP_ALIASES.get((type_name, alias_name))
+        if not canonical or canonical not in allowed or alias_name in allowed:
+            continue
+        # Skip rename if the canonical key is already set — LLM intent wins.
+        if canonical in props and props[canonical] is not None:
+            continue
+        props[canonical] = props.pop(alias_name)
+        renames.append(f"{alias_name}->{canonical}")
+    if not renames:
+        return op, None
+    op["props"] = props
+    return op, f"renamed_alias_props:{type_name}:{','.join(renames)}"
+
+
+def _rule_strip_unknown_props(
+    op: Dict[str, Any], ctx: HealerContext
+) -> Tuple[Dict[str, Any], Optional[str]]:
+    """For ``add`` ops: drop props that aren't in the catalog schema."""
+    if op.get("op") != "add":
+        return op, None
+    type_name = op.get("type")
+    if not isinstance(type_name, str) or not is_known_type(type_name):
+        return op, None
+    schema = UI_CATALOG[type_name]
+    allowed = set(schema.model_fields.keys())
+    props = op.get("props") or {}
+    if not isinstance(props, dict):
+        return op, None
+    extras = [k for k in props if k not in allowed]
+    if not extras:
+        return op, None
+    for k in extras:
+        props.pop(k, None)
+    op["props"] = props
+    return op, f"stripped_unknown_props:{','.join(extras)}"
+
+
+def _rule_button_default_label(
+    op: Dict[str, Any], ctx: HealerContext
+) -> Tuple[Dict[str, Any], Optional[str]]:
+    """Button with an action but no label → default ``"Continue"``."""
+    if op.get("op") != "add" or op.get("type") != "Button":
+        return op, None
+    props = op.get("props")
+    if not isinstance(props, dict):
+        return op, None
+    if props.get("label"):
+        return op, None
+    if "action" not in props:
+        return op, None
+    props["label"] = "Continue"
+    op["props"] = props
+    return op, "button_default_label"
+
+
+def _rule_tag_flatten_array_text(
+    op: Dict[str, Any], ctx: HealerContext
+) -> Tuple[Dict[str, Any], Optional[str]]:
+    """Tag.text emitted as a JSON-array string → flatten to ``"a, b, c"``."""
+    if op.get("op") != "add" or op.get("type") != "Tag":
+        return op, None
+    props = op.get("props")
+    if not isinstance(props, dict):
+        return op, None
+    text = props.get("text")
+    if not isinstance(text, str):
+        return op, None
+    stripped = text.strip()
+    if not (stripped.startswith("[") and stripped.endswith("]")):
+        return op, None
+    try:
+        parsed = json.loads(stripped)
+    except json.JSONDecodeError:
+        return op, None
+    if not isinstance(parsed, list):
+        return op, None
+    flat = ", ".join(str(x) for x in parsed if x is not None)
+    if not flat:
+        return op, None
+    props["text"] = flat
+    op["props"] = props
+    return op, "tag_flattened_array_text"
+
+
+def _rule_dedupe_id(
+    op: Dict[str, Any], ctx: HealerContext
+) -> Tuple[Dict[str, Any], Optional[str]]:
+    """Duplicate ``id`` in the same session → rename to ``id__2`` / ``id__3``."""
+    if op.get("op") != "add":
+        return op, None
+    op_id = op.get("id")
+    if not isinstance(op_id, str) or not op_id:
+        return op, None
+    if op_id not in ctx.known_ids:
+        return op, None
+    n = 2
+    while f"{op_id}__{n}" in ctx.known_ids:
+        n += 1
+    new_id = f"{op_id}__{n}"
+    op["id"] = new_id
+    return op, f"renamed_duplicate_id:{op_id}->{new_id}"
+
+
+def _rule_drop_unknown_type(
+    op: Dict[str, Any], ctx: HealerContext
+) -> Tuple[Optional[Dict[str, Any]], Optional[str]]:
+    """``add`` op with an unknown ``type`` → drop (healer can't invent one)."""
+    if op.get("op") != "add":
+        return op, None
+    type_name = op.get("type")
+    if isinstance(type_name, str) and not is_known_type(type_name):
+        return None, f"dropped_unknown_type:{type_name!r}"
+    return op, None
+
+
+def _rule_drop_orphan_add(
+    op: Dict[str, Any], ctx: HealerContext
+) -> Tuple[Optional[Dict[str, Any]], Optional[str]]:
+    """Non-root ``add`` op missing ``parent`` → drop. Refuse to guess the
+    intended parent — that's a worse failure mode than a missing card."""
+    if op.get("op") != "add":
+        return op, None
+    op_id = op.get("id")
+    if op_id == "root":
+        return op, None
+    parent = op.get("parent")
+    if not isinstance(parent, str) or not parent:
+        return None, "dropped_orphan_add"
+    return op, None
+
+
+# ---------------------------------------------------------------------------
+# Pipeline
+# ---------------------------------------------------------------------------
+
+
+# Order matters: rename aliases first (so Tag.label → Tag.text doesn't
+# get stripped); then strip remaining unknowns; then per-primitive
+# coercions; then dedupe last (the rename can mutate id-bearing props
+# in theory). Drops run after, gating on the cleaned-up shape.
+_TRANSFORM_RULES: List[
+    Callable[[Dict[str, Any], HealerContext], Tuple[Dict[str, Any], Optional[str]]]
+] = [
+    _rule_rename_prop_aliases,
+    _rule_strip_unknown_props,
+    _rule_button_default_label,
+    _rule_tag_flatten_array_text,
+    _rule_dedupe_id,
+]
+
+
+_DROP_RULES: List[
+    Callable[
+        [Dict[str, Any], HealerContext], Tuple[Optional[Dict[str, Any]], Optional[str]]
+    ]
+] = [
+    _rule_drop_unknown_type,
+    _rule_drop_orphan_add,
+]
+
+
+def heal_op_line(raw_line: str, ctx: HealerContext) -> HealerResult:
+    """Apply healer rules to one JSONL line.
+
+    1. Parse the raw line as JSON (skip → drop on malformed).
+    2. Apply transform rules in order; collect notes per applied rule.
+    3. Apply drop rules; if any fires, return ``drop=True``.
+    4. Serialize back to JSONL and return.
+
+    The returned line is *guaranteed* to be valid JSON (because we just
+    serialized it), but is NOT guaranteed to pass catalog validation —
+    that's the parser/validator's job downstream.
+    """
+    notes: List[str] = []
+
+    try:
+        op = json.loads(raw_line)
+    except json.JSONDecodeError as exc:
+        return HealerResult(
+            line=None,
+            notes=[f"dropped_malformed_json:{exc.msg}"],
+            drop=True,
+        )
+
+    if not isinstance(op, dict):
+        return HealerResult(line=None, notes=["dropped_op_not_object"], drop=True)
+
+    for rule in _TRANSFORM_RULES:
+        op, note = rule(op, ctx)
+        if note:
+            notes.append(note)
+
+    for drop_rule in _DROP_RULES:
+        op_or_none, note = drop_rule(op, ctx)
+        if op_or_none is None:
+            if note:
+                notes.append(note)
+            return HealerResult(line=None, notes=notes, drop=True)
+        op = op_or_none
+
+    return HealerResult(line=json.dumps(op), notes=notes, drop=False)
+
+
+def make_healer_fn(ctx: HealerContext):
+    """Closure adaptor — returns a ``HealerFn`` (the shape expected by
+    :func:`process_op_line`)."""
+
+    def _healer(raw: str, _session_state: Dict[str, Any]) -> HealerResult:
+        return heal_op_line(raw, ctx)
+
+    return _healer
+
+
+__all__ = [
+    "HealerContext",
+    "heal_op_line",
+    "make_healer_fn",
+]

--- a/app/ai/voice/agents/breeze_buddy/chat/ui_stream.py
+++ b/app/ai/voice/agents/breeze_buddy/chat/ui_stream.py
@@ -1,0 +1,490 @@
+"""SpecStream / A2UI wire format — JSONL emission pipeline.
+
+Replaces the OpenUI Lang DSL (``<ui>…</ui>`` + ``@Each`` / ``Card([…])``
+grammar) with a flat JSON-patch stream.
+
+The LLM emits operations one-per-line, wrapped in a literal
+``<ui_stream>…</ui_stream>`` sentinel::
+
+    <ui_stream>
+    {"op":"add","id":"root","type":"Carousel"}
+    {"op":"add","id":"t1","type":"Tile","parent":"root","props":{"title":"Dawn","body":[{"kind":"key_value","key":"Price","value":"₹699.95"}],"actions":[{"label":"View","action":{"type":"to_assistant","msg":"Tell me about Dawn"}}]}}
+    {"op":"remove","id":"c2"}
+    </ui_stream>
+
+Each complete line is parsed → optionally healed (S1.2) → catalog-validated
+→ surfaced as an ``ui_op`` SSE event. The widget applies the op to a
+session-stateful ``ui_state`` store; the renderer walks the tree.
+
+The marker may straddle token boundaries (Anthropic in particular tokenises
+one char at a time) — we keep a bounded carry buffer.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, Iterator, List, Literal, Optional, Set, Union
+
+from app.ai.voice.agents.breeze_buddy.chat.sse import SSEEvent
+from app.ai.voice.agents.breeze_buddy.template.ui_catalog import (
+    is_known_type,
+    validate_props,
+)
+
+_log = logging.getLogger(__name__)
+
+_OPEN = "<ui_stream>"
+_CLOSE = "</ui_stream>"
+_CARRY_MAX = max(len(_OPEN), len(_CLOSE)) - 1
+
+
+# ---------------------------------------------------------------------------
+# Streaming items
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class TextOut:
+    """Prose chunk to forward as an ``assistant_token`` SSE event."""
+
+    value: str
+    kind: Literal["text"] = "text"
+
+
+@dataclass(frozen=True)
+class JsonlOpLine:
+    """One JSONL line extracted from inside a ``<ui_stream>`` block.
+
+    The raw string is preserved verbatim so the healer (S1.2) can fix
+    malformed JSON before the parser/validator runs.
+    """
+
+    raw: str
+    kind: Literal["op_line"] = "op_line"
+
+
+YieldItem = Union[TextOut, JsonlOpLine]
+
+
+# ---------------------------------------------------------------------------
+# Streaming extractor
+# ---------------------------------------------------------------------------
+
+
+class UiStreamExtractor:
+    """Stateful FSM that pulls ``<ui_stream>…</ui_stream>`` blocks out of an
+    assistant text stream, yielding TextOut for prose and JsonlOpLine for
+    each complete line of JSONL seen inside a block.
+
+    Public API: ``feed(delta)`` per text delta, ``flush()`` at stream end.
+    """
+
+    def __init__(self) -> None:
+        # OUTSIDE — collecting prose, looking for "<ui_stream>".
+        # INSIDE — collecting JSONL, splitting on newlines, looking for "</ui_stream>".
+        self._state: Literal["OUTSIDE", "INSIDE"] = "OUTSIDE"
+        # Bytes held back because they might be the start of a marker.
+        self._carry: str = ""
+        # Partial JSONL line accumulator (active while INSIDE).
+        self._line_buf: str = ""
+
+    def feed(self, delta: str) -> Iterator[YieldItem]:
+        """Process one text delta. Yields zero or more text/op_line items."""
+        if not delta:
+            return
+        buffer = self._carry + delta
+        self._carry = ""
+        yield from self._process(buffer)
+
+    def flush(self) -> Iterator[YieldItem]:
+        """Drain held state at stream end.
+
+        Outside a block: forward residual carry as prose.
+        Inside a block: drop partial JSONL with a warning — the LLM opened
+        ``<ui_stream>`` but never closed it.
+        """
+        if self._state == "OUTSIDE":
+            if self._carry:
+                yield TextOut(value=self._carry)
+            self._carry = ""
+            return
+        partial = self._line_buf + self._carry
+        _log.warning(
+            "ui_stream: stream ended inside <ui_stream> block (dropping %d chars)",
+            len(partial),
+        )
+        self._line_buf = ""
+        self._carry = ""
+        self._state = "OUTSIDE"
+
+    # ---- Internal FSM ----------------------------------------------------
+
+    def _process(self, buffer: str) -> Iterator[YieldItem]:
+        while buffer:
+            if self._state == "OUTSIDE":
+                idx = buffer.find(_OPEN)
+                if idx != -1:
+                    if idx > 0:
+                        yield TextOut(value=buffer[:idx])
+                    buffer = buffer[idx + len(_OPEN) :]
+                    self._state = "INSIDE"
+                    continue
+                hold = _tail_marker_prefix(buffer, _OPEN)
+                if hold:
+                    if len(buffer) > hold:
+                        yield TextOut(value=buffer[:-hold])
+                    self._carry = buffer[-hold:]
+                else:
+                    yield TextOut(value=buffer)
+                    self._carry = ""
+                return
+
+            # INSIDE — first check if the close marker is anywhere ahead.
+            close_idx = buffer.find(_CLOSE)
+            newline_idx = buffer.find("\n")
+
+            # No close, no newline — accumulate partial line (carrying any
+            # trailing chars that could start the close marker).
+            if close_idx == -1 and newline_idx == -1:
+                hold = _tail_marker_prefix(buffer, _CLOSE)
+                if hold:
+                    self._line_buf += buffer[:-hold]
+                    self._carry = buffer[-hold:]
+                else:
+                    self._line_buf += buffer
+                    self._carry = ""
+                return
+
+            # Close before newline? Flush remaining line then exit block.
+            if close_idx != -1 and (newline_idx == -1 or close_idx < newline_idx):
+                self._line_buf += buffer[:close_idx]
+                line = self._line_buf.strip()
+                self._line_buf = ""
+                if line:
+                    yield JsonlOpLine(raw=line)
+                buffer = buffer[close_idx + len(_CLOSE) :]
+                self._state = "OUTSIDE"
+                continue
+
+            # Newline first — yield the complete line, continue inside.
+            self._line_buf += buffer[:newline_idx]
+            line = self._line_buf.strip()
+            self._line_buf = ""
+            if line:
+                yield JsonlOpLine(raw=line)
+            buffer = buffer[newline_idx + 1 :]
+
+
+def _tail_marker_prefix(buffer: str, marker: str) -> int:
+    """Length of the longest suffix of ``buffer`` that is a prefix of ``marker``."""
+    max_check = min(len(buffer), len(marker) - 1, _CARRY_MAX)
+    for n in range(max_check, 0, -1):
+        if marker.startswith(buffer[-n:]):
+            return n
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# Op parsing + validation
+# ---------------------------------------------------------------------------
+
+
+_ALLOWED_OPS: Set[str] = {"add", "replace", "remove"}
+
+
+@dataclass
+class OpResult:
+    """Outcome of parsing + validating one JSONL line.
+
+    Exactly one of ``op`` / ``error`` is set.
+    """
+
+    op: Optional[Dict[str, Any]] = None
+    error: Optional[str] = None
+    # Set when the line was healed — describes what changed (for telemetry).
+    healed_notes: List[str] = field(default_factory=list)
+
+
+def parse_op_line(line: str, *, allowlist: Optional[Set[str]] = None) -> OpResult:
+    """Parse one JSONL line into a structured op dict; validate shape.
+
+    Returns ``OpResult.op`` populated when the line is a well-formed op
+    addressing a known catalog type, with props that pass the type's
+    Pydantic schema. Otherwise ``OpResult.error`` carries a short reason
+    for telemetry.
+
+    This is the deterministic gate — the healer (S1.2) runs *before* this
+    on raw lines to repair common mistakes (missing currency, stringly
+    money, etc.). Anything still broken at this layer is logged and dropped.
+
+    ``allowlist`` is the per-template resolved primitive allowlist (see
+    ``ui_catalog.resolve_allowlist`` + ``UiCatalogConfig``). When set, an
+    ``add`` op whose type is known to the catalog but NOT in this allowlist
+    drops with reason ``primitive_disabled:<type>`` — distinct from
+    ``unknown_type``, so telemetry separates "LLM hallucinated" from
+    "merchant turned off". When ``None``, no template-level filtering
+    applies (all known catalog types accepted).
+    """
+    try:
+        op = json.loads(line)
+    except json.JSONDecodeError as exc:
+        return OpResult(error=f"malformed_json: {exc.msg}")
+
+    if not isinstance(op, dict):
+        return OpResult(error="op_not_object")
+
+    op_kind = op.get("op")
+    if op_kind not in _ALLOWED_OPS:
+        return OpResult(error=f"unknown_op:{op_kind!r}")
+
+    op_id = op.get("id")
+    if not isinstance(op_id, str) or not op_id:
+        return OpResult(error="missing_or_empty_id")
+
+    if op_kind == "remove":
+        # Remove is just (op, id) — no type/props/parent required.
+        extra = set(op.keys()) - {"op", "id"}
+        if extra:
+            for k in extra:
+                op.pop(k, None)
+        return OpResult(op=op)
+
+    # add / replace require either a type (add) or props (replace).
+    if op_kind == "add":
+        type_name = op.get("type")
+        if not isinstance(type_name, str) or not type_name:
+            return OpResult(error="add_missing_type")
+        if not is_known_type(type_name):
+            return OpResult(error=f"unknown_type:{type_name!r}")
+        # Template-level enable check — distinct telemetry from unknown_type.
+        if allowlist is not None and type_name not in allowlist:
+            return OpResult(error=f"primitive_disabled:{type_name}")
+        parent = op.get("parent")
+        # Root op has id == "root" by convention; everyone else needs parent.
+        if op_id != "root" and (not isinstance(parent, str) or not parent):
+            return OpResult(error="missing_parent")
+
+    elif op_kind == "replace":
+        # Type may be present (info only) but we don't require it; replace
+        # carries new props only. Look up existing node's type from session
+        # state at apply-time on the widget side.
+        if "props" not in op:
+            return OpResult(error="replace_missing_props")
+
+    # Validate props (if any) against catalog.
+    props = op.get("props") or {}
+    if not isinstance(props, dict):
+        return OpResult(error="props_not_object")
+
+    # On `add`, we know the type. On `replace` without type, props are
+    # weakly validated (must be an object); strong validation against the
+    # existing node's type happens on the widget side, where the tree
+    # state is authoritative.
+    if op_kind == "add":
+        try:
+            validated = validate_props(op["type"], props)
+        except Exception as exc:  # ValidationError + defensive
+            return OpResult(error=f"props_validation_failed: {type(exc).__name__}")
+        # Replace props with the model_dump so downstream callers see
+        # normalized values (enum → string, HttpUrl → str, defaults filled).
+        op["props"] = validated.model_dump(exclude_none=True, mode="json")
+
+    return OpResult(op=op)
+
+
+# ---------------------------------------------------------------------------
+# SSE event factories
+# ---------------------------------------------------------------------------
+
+
+def ui_op_event(op: Dict[str, Any]) -> SSEEvent:
+    """SSE event carrying a single applied op."""
+    return SSEEvent(event="ui_op", data={"op": op})
+
+
+def healer_applied_event(line: str, note: str) -> SSEEvent:
+    """Observability event — fired when the healer fixed an incoming line.
+
+    Carries the original ``line`` (truncated) and a short ``note`` describing
+    the rule that fired. Widget ignores; server-side telemetry consumes.
+    """
+    truncated = line if len(line) <= 200 else line[:200] + "…"
+    return SSEEvent(event="healer_applied", data={"raw": truncated, "note": note})
+
+
+def ui_op_dropped_event(line: str, reason: str) -> SSEEvent:
+    """Observability event — fired when a line failed validation and was
+    dropped. Widget ignores."""
+    truncated = line if len(line) <= 200 else line[:200] + "…"
+    return SSEEvent(event="ui_op_dropped", data={"raw": truncated, "reason": reason})
+
+
+# ---------------------------------------------------------------------------
+# Process one JSONL line → SSEEvent(s)
+# ---------------------------------------------------------------------------
+
+
+HealerFn = Callable[[str, Dict[str, Any]], "HealerResult"]
+
+
+@dataclass
+class HealerResult:
+    """Output of a healer rule pass. ``line`` is the (possibly rewritten)
+    JSONL line; ``notes`` is the list of rule names that fired (for
+    telemetry); ``drop`` is True when the line should be silently dropped
+    (e.g. unknown type that the healer cannot rescue)."""
+
+    line: Optional[str]
+    notes: List[str] = field(default_factory=list)
+    drop: bool = False
+
+
+def process_op_line(
+    raw_line: str,
+    *,
+    session_state: Optional[Dict[str, Any]] = None,
+    healer: Optional[HealerFn] = None,
+    known_ids: Optional[Set[str]] = None,
+    allowlist: Optional[Set[str]] = None,
+) -> List[SSEEvent]:
+    """Run one raw JSONL line through (healer →) parse → validate → SSE.
+
+    Returns a list of SSE events (0 to ~3) to forward to the client:
+      * ``healer_applied`` — one per applied healer note (telemetry)
+      * ``ui_op_dropped`` — when validation fails (telemetry)
+      * ``ui_op`` — the validated op, ready for the widget
+
+    ``known_ids`` lets the caller scope duplicate-id detection across the
+    full session UI tree. The healer mutates it (adding/removing ids) so
+    the caller should keep a single set across all lines in a turn.
+
+    ``allowlist`` is the resolved-per-template primitive allowlist. Ops
+    targeting types not in the allowlist drop with reason
+    ``primitive_disabled:<type>`` — see ``parse_op_line``. When ``None``,
+    no template-level filtering applies.
+    """
+    events: List[SSEEvent] = []
+    line = raw_line
+
+    if healer is not None:
+        result = healer(line, session_state or {})
+        for note in result.notes:
+            events.append(healer_applied_event(line, note))
+        if result.drop:
+            return events
+        if result.line is not None:
+            line = result.line
+
+    parsed = parse_op_line(line, allowlist=allowlist)
+    if parsed.error:
+        events.append(ui_op_dropped_event(line, parsed.error))
+        return events
+
+    op = parsed.op  # type: ignore[assignment]
+    if known_ids is not None and op is not None:
+        if op["op"] == "add":
+            known_ids.add(op["id"])
+        elif op["op"] == "remove":
+            known_ids.discard(op["id"])
+
+    events.append(ui_op_event(op))  # type: ignore[arg-type]
+    return events
+
+
+_UI_STREAM_MARKER_RE = re.compile(r"<ui_stream>.*?</ui_stream>", re.DOTALL)
+
+
+def strip_ui_stream_markers(text: str) -> str:
+    """Remove every ``<ui_stream>…</ui_stream>`` block from ``text``.
+
+    Used at persistence time so saved assistant prose never carries SpecStream
+    JSONL forward into future turns — the LLM would otherwise read its own
+    prior op stream as if it were chat prose.
+    """
+    if not text:
+        return text
+    return _UI_STREAM_MARKER_RE.sub("", text)
+
+
+_SUMMARY_TITLE_CAP = 80
+_SUMMARY_TILE_CAP = 8
+_SUMMARY_URL_CAP = 60
+
+
+def summarize_ui_ops(ops: List[Dict[str, Any]]) -> str:
+    """Produce a compact 1-line summary of UI ops emitted in a turn.
+
+    The chat history strips ``<ui_stream>`` blocks before replay (so the LLM
+    doesn't re-read raw JSONL), which leaves it blind to what tiles, prices,
+    and actions the shopper actually saw. This summary restores a thin
+    memory — enough for the LLM to disambiguate referents like "the green
+    one" or "the bigger size" on follow-up turns, without paying the full
+    op-stream token cost.
+
+    Format: ``[ui rendered: 4 Tile(s): 'Title A', 'Title B'; 1 Handoff(s) → https://...]``
+    Returns ``""`` if nothing user-facing was added.
+    """
+    if not ops:
+        return ""
+
+    by_type: Dict[str, List[Dict[str, Any]]] = {}
+    for op in ops:
+        if op.get("op") != "add":
+            continue
+        type_name = op.get("type") or "?"
+        by_type.setdefault(type_name, []).append(op.get("props") or {})
+
+    parts: List[str] = []
+
+    tiles = by_type.pop("Tile", None)
+    if tiles:
+        titles = [
+            repr(str(p.get("title") or "?")[:_SUMMARY_TITLE_CAP])
+            for p in tiles[:_SUMMARY_TILE_CAP]
+        ]
+        tail = (
+            f" (+{len(tiles) - _SUMMARY_TILE_CAP} more)"
+            if len(tiles) > _SUMMARY_TILE_CAP
+            else ""
+        )
+        parts.append(f"{len(tiles)} Tile(s): {', '.join(titles)}{tail}")
+
+    handoffs = by_type.pop("Handoff", None)
+    if handoffs:
+        urls = sorted({str(p.get("url") or "?")[:_SUMMARY_URL_CAP] for p in handoffs})
+        parts.append(f"{len(handoffs)} Handoff(s) → {', '.join(urls)}")
+
+    # Remaining primitives (Card, Carousel, Table, Message, etc.) — count only.
+    # Layout containers like Stack/Row are skipped from the summary; they
+    # describe arrangement, not content the shopper meaningfully sees.
+    _LAYOUT_ONLY = {"Stack", "Row"}
+    for type_name in sorted(by_type):
+        if type_name in _LAYOUT_ONLY:
+            continue
+        items = by_type[type_name]
+        parts.append(f"{len(items)} {type_name}")
+
+    if not parts:
+        return ""
+    return "[ui rendered: " + "; ".join(parts) + "]"
+
+
+__all__ = [
+    "UiStreamExtractor",
+    "TextOut",
+    "JsonlOpLine",
+    "YieldItem",
+    "OpResult",
+    "HealerResult",
+    "HealerFn",
+    "parse_op_line",
+    "process_op_line",
+    "ui_op_event",
+    "healer_applied_event",
+    "ui_op_dropped_event",
+    "strip_ui_stream_markers",
+    "summarize_ui_ops",
+]

--- a/app/ai/voice/agents/breeze_buddy/handlers/internal/end_conversation.py
+++ b/app/ai/voice/agents/breeze_buddy/handlers/internal/end_conversation.py
@@ -17,6 +17,9 @@ from app.ai.voice.agents.breeze_buddy.utils.hold_transfer import (
 )
 from app.core.logger import logger
 from app.core.logger.context import clear_log_context
+from app.database.accessor.breeze_buddy.chat_session import (
+    drain_voice_into_chat_session,
+)
 
 callback_map = {
     "service_callback": service_callback,
@@ -113,6 +116,45 @@ async def end_conversation(context: TemplateContext, args, transition_to=None):
             logger.warning(
                 f"No context found for transcription collection in call {context.call_sid}"
             )
+
+        # ── Widget-mode drain ─────────────────────────────────────────────
+        # If this voice call was a transient attachment to a widget chat
+        # session (CHAT_MODE.md §14), drain the new turns back into the
+        # canonical chat_session so chat resumes with full conversation
+        # history. The drain is idempotent and best-effort — a failure
+        # here must NOT block the rest of end_conversation (DB lead
+        # update, callbacks, EndFrame), so it's wrapped in its own try.
+        widget_session_id = context.lead.metaData.get("widget_session_id")
+        if widget_session_id:
+            try:
+                seed_count = int(
+                    context.lead.metaData.get("seed_message_count", 0) or 0
+                )
+                # New voice turns = everything past the seed boundary in
+                # filtered_transcript (user/assistant only — the same
+                # shape chat_message stores).
+                new_messages = filtered_transcript[seed_count:]
+                final_node = None
+                if context.bot and getattr(context.bot, "flow_manager", None):
+                    final_node = context.bot.flow_manager.current_node
+                if not final_node:
+                    final_node = context.lead.metaData.get("start_node")
+                logger.info(
+                    f"widget drain: chat_session={widget_session_id} "
+                    f"new_turns={len(new_messages)} final_node={final_node!r}"
+                )
+                await drain_voice_into_chat_session(
+                    chat_session_id=str(widget_session_id),
+                    lead_id=str(context.lead.id),
+                    new_messages=new_messages,
+                    final_node=final_node,
+                )
+            except Exception as drain_err:
+                logger.error(
+                    f"widget drain: failed for chat_session "
+                    f"{widget_session_id} / lead {context.lead.id}: {drain_err}",
+                    exc_info=True,
+                )
 
         # ── Hold-transfer: publish outbound result to inbound pod ──────────
         # Runs regardless of whether context.context exists so that outbound

--- a/app/ai/voice/agents/breeze_buddy/handlers/transport/http_handler.py
+++ b/app/ai/voice/agents/breeze_buddy/handlers/transport/http_handler.py
@@ -19,6 +19,7 @@ Uses the same resolution pattern as hooks:
 - {placeholder} resolution in http_request config
 """
 
+import copy
 import json
 from typing import Any, Dict, Optional, Tuple
 
@@ -31,6 +32,9 @@ from app.ai.voice.agents.breeze_buddy.handlers.transport.utils.field_resolver im
 )
 from app.ai.voice.agents.breeze_buddy.handlers.transport.utils.response_filter import (
     apply_response_schema,
+)
+from app.ai.voice.agents.breeze_buddy.handlers.transport.utils.response_transform import (
+    apply_response_transforms,
 )
 from app.ai.voice.agents.breeze_buddy.template.context import TemplateContext
 from app.ai.voice.agents.breeze_buddy.template.types import (
@@ -215,6 +219,22 @@ async def http_function_handler(
                 f"[{function_name}] response filtered via expected_response_schema: "
                 f"{list(config.expected_response_schema.keys())}"
             )
+
+        # Response transforms — applied after projection so templates can
+        # both narrow AND mutate. Channel-agnostic: voice + chat both
+        # dispatch through this handler. Only 2xx — error bodies stay raw
+        # so the LLM can read them verbatim.
+        #
+        # ``apply_response_transforms`` mutates in place; deep-copy first
+        # so a mid-loop exception leaves the original ``data`` intact
+        # rather than handing the LLM a partially-transformed payload.
+        if is_success and config.response_transforms and isinstance(data, (dict, list)):
+            try:
+                transformed = copy.deepcopy(data)
+                apply_response_transforms(transformed, config.response_transforms)
+                data = transformed
+            except Exception as e:
+                logger.warning(f"[{function_name}] response_transforms failed: {e}")
 
         logger.debug(f"[{function_name}] data going to LLM: {data}")
 

--- a/app/ai/voice/agents/breeze_buddy/handlers/transport/utils/response_transform.py
+++ b/app/ai/voice/agents/breeze_buddy/handlers/transport/utils/response_transform.py
@@ -1,0 +1,339 @@
+"""In-place response transforms.
+
+Companion to ``response_filter.apply_response_schema`` — but where that one
+*projects* (reshapes the response into a new dict via JMESPath), this one
+*mutates* specific paths in-place while everything else passes through
+untouched. The two are complementary, both declared in the template, both
+applied at the tool handler before the result reaches the LLM.
+
+Why we need it
+--------------
+Some upstream tools return slightly-wrong-shape data the LLM can't fix
+cheaply — e.g. an integer needs unscaling by a power of ten, a nested
+field needs flattening. We want the LLM to see one consistent shape.
+Projecting the entire response just to scale two fields forces the
+template author to enumerate every preserved key — fragile and verbose.
+An in-place transform is the natural fit.
+
+Channel-agnostic
+----------------
+Transforms are applied inside the tool handler closure (HTTP adapter +
+MCP handler), which is the chokepoint both voice and chat dispatch
+through. Nothing channel-specific to wire up.
+
+Vertical-agnostic
+-----------------
+The registry ships only generic arithmetic / shape ops. Any vertical
+(commerce, scheduling, finance, …) declares which transforms to apply
+in its template — the engine itself knows nothing about money, carts,
+appointments, or invoices.
+
+Authoring shape
+---------------
+Each transform is ``{path, fn, args?}``:
+
+    {
+        "path": "products[*].price_range.min",
+        "fn": "scale_by_exponent",
+        "args": {"exponent": 2}
+    }
+
+Path syntax is the subset of JSON pointer-ish dotted notation we need:
+
+    - ``a.b.c``       — descend dict keys
+    - ``a[*].b``      — iterate every element of array ``a`` and descend ``b`` on each
+    - ``a[*]``        — apply the transform to every element of ``a`` directly
+
+JMESPath was considered for the path field but it's read-only (returns
+copies, not references), so we'd have to walk the data Python-side anyway
+to mutate. A small purpose-built walker is simpler and keeps the path
+spec narrowly scoped to the in-place-mutation idiom.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple
+
+from app.core.logger import logger
+
+if TYPE_CHECKING:
+    from app.ai.voice.agents.breeze_buddy.template.types import ResponseTransform
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+TransformFn = Callable[[Any, Dict[str, Any]], Any]
+"""A transform takes the value at the matched path and an args dict (from the
+template) and returns the new value to install at the same path."""
+
+TRANSFORM_REGISTRY: Dict[str, TransformFn] = {}
+
+
+def register_transform(name: str) -> Callable[[TransformFn], TransformFn]:
+    """Register a transform fn under ``name``. Decorator form."""
+
+    def _decorator(fn: TransformFn) -> TransformFn:
+        if name in TRANSFORM_REGISTRY:
+            logger.warning(
+                f"[response_transform] re-registering '{name}' "
+                f"(was: {TRANSFORM_REGISTRY[name].__name__})"
+            )
+        TRANSFORM_REGISTRY[name] = fn
+        return fn
+
+    return _decorator
+
+
+# ---------------------------------------------------------------------------
+# Path parsing + walker
+# ---------------------------------------------------------------------------
+
+# One path segment: a key name optionally followed by [*] (array iteration).
+_SEGMENT_RE = re.compile(r"^([^.\[\]]+)(\[\*\])?$")
+
+
+def _parse_path(path: str) -> List[Tuple[str, bool]]:
+    """Parse a dotted path into (key, is_array) segments. Empty path → []."""
+    if not path:
+        return []
+    segments: List[Tuple[str, bool]] = []
+    for part in path.split("."):
+        match = _SEGMENT_RE.match(part)
+        if not match:
+            raise ValueError(f"unsupported path segment {part!r} in {path!r}")
+        segments.append((match.group(1), bool(match.group(2))))
+    return segments
+
+
+def _walk(
+    data: Any,
+    segments: List[Tuple[str, bool]],
+    fn: TransformFn,
+    args: Dict[str, Any],
+) -> None:
+    """Walk ``segments`` into ``data`` and apply ``fn`` at every leaf, mutating
+    in place. Silently no-ops on shape mismatch (missing keys, non-list under
+    [*], non-dict mid-path) so a partial response never blows up a turn.
+    """
+    if not segments or not isinstance(data, dict):
+        return
+
+    key, is_array = segments[0]
+    rest = segments[1:]
+    if key not in data:
+        return
+    target = data[key]
+
+    if is_array:
+        if not isinstance(target, list):
+            return
+        if rest:
+            for item in target:
+                _walk(item, rest, fn, args)
+        else:
+            data[key] = [fn(item, args) for item in target]
+        return
+
+    if rest:
+        _walk(target, rest, fn, args)
+    else:
+        data[key] = fn(target, args)
+
+
+def apply_response_transforms(
+    data: Any,
+    transforms: Optional[List["ResponseTransform"]],
+) -> Any:
+    """Run every transform in order against ``data``, mutating in place.
+
+    Returns the (now-mutated) ``data`` for caller convenience. Unknown
+    transform names are logged and skipped — a stale template never breaks
+    a live turn.
+    """
+    if not transforms or not isinstance(data, (dict, list)):
+        return data
+
+    for rule in transforms:
+        fn = TRANSFORM_REGISTRY.get(rule.fn)
+        if fn is None:
+            logger.warning(
+                f"[response_transform] unknown fn {rule.fn!r} for path "
+                f"{rule.path!r} — skipping"
+            )
+            continue
+
+        try:
+            segments = _parse_path(rule.path)
+        except ValueError as e:
+            logger.warning(f"[response_transform] {e} — skipping")
+            continue
+
+        # Allow the root-level case (empty path) — apply fn to the response root.
+        if not segments:
+            data = fn(data, rule.args)
+            continue
+
+        if isinstance(data, dict):
+            _walk(data, segments, fn, rule.args)
+        # Lists at the root with a path like "[*].…" aren't a use case yet —
+        # MCP/HTTP responses we transform are dict-rooted. Skip silently if so.
+
+    return data
+
+
+# ---------------------------------------------------------------------------
+# Built-in transforms — purely arithmetic / shape-level, no domain knowledge
+# ---------------------------------------------------------------------------
+
+
+@register_transform("scale_by_exponent")
+def scale_by_exponent(value: Any, args: Dict[str, Any]) -> Any:
+    """Normalise a numeric subfield to a display-formatted decimal string.
+
+    Operates on a dict; reads the number at ``amount_field`` and writes a
+    formatted display string back at the same key. Two input modes:
+
+      * **Minor-unit input** (``int``, ``float``, or string with no ``.``/``,``):
+        divides by ``10 ** exponent`` to convert to major units, then formats.
+      * **Already-decimal input** (string containing ``.``): re-formats for
+        display consistency (e.g. ``"1585.9"`` → ``"1,585.90"``) without
+        re-scaling — the value is taken as-is in major units.
+
+    Output is always a thousand-separated string with ``exponent`` decimal
+    places, so all downstream display strings have consistent shape regardless
+    of whether the upstream tool returned minor units or pre-formatted decimals.
+
+    Args:
+        amount_field — key holding the number (default: ``"amount"``)
+        exponent     — non-negative integer exponent of 10 (default: ``2``).
+                       For ISO 4217 currencies that's 2 for INR/USD/EUR, 0 for
+                       JPY/KRW, 3 for KWD/OMR — the template picks the value
+                       for its data source.
+    """
+    if not isinstance(value, dict):
+        return value
+
+    amount_field = args.get("amount_field", "amount")
+    try:
+        exponent = int(args.get("exponent", 2))
+    except (TypeError, ValueError):
+        return value
+    if exponent < 0:
+        return value
+
+    amount = value.get(amount_field)
+    if amount is None:
+        return value
+
+    try:
+        amount_num = float(amount)
+    except (TypeError, ValueError):
+        return value
+
+    # Detect already-decimal input vs minor-unit input. A string carrying a
+    # decimal separator is taken at face value (no re-scaling); ints, floats,
+    # and integer-shaped strings are treated as minor units to be divided.
+    is_decimal_already = isinstance(amount, str) and ("." in amount or "," in amount)
+    scaled = amount_num if is_decimal_already else amount_num / (10**exponent)
+
+    if exponent == 0:
+        value[amount_field] = f"{int(round(scaled)):,}"
+    else:
+        value[amount_field] = f"{scaled:,.{exponent}f}"
+    return value
+
+
+@register_transform("pick_fields")
+def pick_fields(value: Any, args: Dict[str, Any]) -> Any:
+    """Keep only the listed top-level keys in a dict; drop everything else.
+
+    The first line of defence against tool-result bloat — most upstream MCP
+    catalogue/lookup responses ship dozens of fields the agent never reads
+    (full variant matrices, collection metadata, sku/barcode/weight, etc.).
+    Path the rule at ``products[*]`` (or any single-item path) so the walker
+    invokes this fn once per dict and we slim each one to its essentials.
+
+    Args:
+        keep — list of top-level keys to retain. Missing keys are silently
+               omitted (a partial upstream payload never blows up a turn).
+               Empty / missing keep list returns an empty dict.
+
+    Non-dict inputs pass through unchanged so chaining stays safe.
+    """
+    if not isinstance(value, dict):
+        return value
+    keep = args.get("keep") or []
+    return {k: value[k] for k in keep if k in value}
+
+
+@register_transform("omit_fields")
+def omit_fields(value: Any, args: Dict[str, Any]) -> Any:
+    """Drop the listed top-level keys; keep everything else.
+
+    Useful when most fields are wanted and only a few obvious offenders
+    (protocol envelopes, debug metadata) need removing — saves enumerating
+    every preserved key like ``pick_fields`` would. Use ``path: ""`` to
+    drop top-level keys on the response root.
+
+    Args:
+        drop — list of top-level keys to remove. Missing keys are a no-op.
+
+    Non-dict inputs pass through unchanged.
+    """
+    if not isinstance(value, dict):
+        return value
+    drop = set(args.get("drop") or ())
+    return {k: v for k, v in value.items() if k not in drop}
+
+
+_HTML_TAG_RE = re.compile(r"<[^>]+>")
+_WHITESPACE_RE = re.compile(r"\s+")
+
+
+@register_transform("strip_html")
+def strip_html(value: Any, args: Dict[str, Any]) -> Any:
+    """Strip HTML tags, collapse whitespace, optionally truncate at a word
+    boundary.
+
+    Upstream catalogue responses commonly include rich-text descriptions as
+    HTML strings — the agent's prompt rules instruct it to render plain text
+    anyway, so shipping the markup is pure waste. This op pulls the plain
+    text out and (when ``max_chars`` is set) clips it at the nearest word
+    boundary with an ellipsis so the LLM still sees a sentence-shaped
+    excerpt rather than a jagged cut.
+
+    Args:
+        max_chars — optional positive int; when set, clip the result.
+                    Word-boundary truncation; trailing ``…`` appended.
+
+    Operates on string values. Non-string inputs pass through unchanged so
+    upstream shape drift never crashes a turn.
+    """
+    if not isinstance(value, str):
+        return value
+    plain = _HTML_TAG_RE.sub(" ", value)
+    plain = _WHITESPACE_RE.sub(" ", plain).strip()
+    max_chars = args.get("max_chars")
+    if isinstance(max_chars, int) and max_chars > 0 and len(plain) > max_chars:
+        clipped = plain[:max_chars]
+        # Cut at the last space so we don't end mid-word; fall back to a hard
+        # cut if there's no space in the window (e.g. one giant token).
+        space = clipped.rfind(" ")
+        if space > 0:
+            clipped = clipped[:space]
+        plain = clipped + "…"
+    return plain
+
+
+__all__ = [
+    "TRANSFORM_REGISTRY",
+    "TransformFn",
+    "apply_response_transforms",
+    "omit_fields",
+    "pick_fields",
+    "register_transform",
+    "scale_by_exponent",
+    "strip_html",
+]

--- a/app/ai/voice/agents/breeze_buddy/mcp/__init__.py
+++ b/app/ai/voice/agents/breeze_buddy/mcp/__init__.py
@@ -2,10 +2,13 @@
 
 import asyncio
 import base64
+import json
 import re
+import uuid
 from datetime import timedelta
-from typing import Any, Dict, List, cast
+from typing import Any, Dict, List, Optional, cast
 
+import httpx
 from mcp.client.session_group import StreamableHttpParameters
 from pipecat.services.llm_service import (
     FunctionCallParams,
@@ -14,26 +17,341 @@ from pipecat.services.llm_service import (
 from pipecat.services.mcp_service import MCPClient
 from pipecat_flows.types import FlowResult, FlowsFunctionSchema
 
+from app.ai.voice.agents.breeze_buddy.handlers.transport.utils.response_transform import (
+    apply_response_transforms,
+)
 from app.ai.voice.agents.breeze_buddy.mcp.cache import get_or_discover_server_tools
+
+# Template types FIRST — fully loads the `template` package (whose
+# __init__ eagerly pulls in http_handler / http_requester / hooks /
+# field_resolver) before we touch handlers/transport/utils/. Importing
+# the transform helper before this would trigger
+# handlers.transport.utils.__init__ → field_resolver → template.types
+# while template/__init__.py is mid-load, causing a cycle.
 from app.ai.voice.agents.breeze_buddy.template.types import (
     HttpAuthType,
     McpConfig,
     McpServerConfig,
+    ResponseTransform,
+    ToolUiHint,
+    ToolUiTrigger,
 )
 from app.core.logger import logger
+
+
+def _deep_merge_defaults(
+    args: Dict[str, Any], defaults: Dict[str, Any]
+) -> Dict[str, Any]:
+    """Deep-merge ``defaults`` into ``args``; caller-provided values win.
+
+    Mirrors ``only_if_missing`` semantics in :func:`inject_tool_args`. New dict
+    is returned (no mutation). Used to inject protocol-level metadata that
+    every tool call on a server needs (e.g. Shopify UCP's
+    ``arguments.meta.ucp-agent.profile``) without touching session-state-driven
+    injection logic in the chat agent.
+    """
+    if not defaults:
+        return dict(args)
+
+    def merge(into: Dict[str, Any], src: Dict[str, Any]) -> Dict[str, Any]:
+        for k, v in src.items():
+            existing = into.get(k)
+            if isinstance(v, dict) and isinstance(existing, dict):
+                into[k] = merge(dict(existing), v)
+            elif k not in into or into[k] is None:
+                into[k] = v
+        return into
+
+    return merge(dict(args), defaults)
+
+
+# Turn-scoped MCP client pool. Keys are stable server labels (server.name
+# or template URL form) and values are live MCPClient instances whose
+# StreamableHTTP connection + ClientSession + initialize handshake have
+# already happened. The owning component (e.g. ChatAgent.run_turn) creates
+# an empty dict at turn start and calls ``close_mcp_pool`` in its finally
+# block. Handlers lazily acquire from the pool on first call and reuse on
+# every subsequent call within the same turn, eliminating the per-call
+# connect/initialize/notifications round-trip (~150–300 ms).
+MCPPool = Dict[str, MCPClient]
+
+
+async def _acquire_pooled_client(
+    pool: MCPPool,
+    key: str,
+    server_params: StreamableHttpParameters,
+) -> MCPClient:
+    """Return a live MCPClient from the pool, opening + stashing on first miss.
+
+    Tool calls within one chat turn execute sequentially (see
+    ``ChatAgent._run_turn_inner``'s ``for call in tool_calls`` loop), so no
+    lock is needed — at most one acquire is in flight per server at a time.
+    """
+    existing = pool.get(key)
+    if existing is not None:
+        return existing
+    client = MCPClient(server_params=server_params)
+    await client.start()
+    pool[key] = client
+    return client
+
+
+async def close_mcp_pool(pool: Optional[MCPPool]) -> None:
+    """Close every MCPClient in the pool. Safe to call with None / empty.
+
+    Errors during close are swallowed (logged at WARNING) so one bad
+    connection doesn't prevent the rest from being released — matches the
+    behaviour of an ``async with`` cleanup when the body raises.
+    """
+    if not pool:
+        return
+    for key, client in list(pool.items()):
+        try:
+            await client.close()
+        except Exception as e:
+            logger.warning(f"[BUDDY_MCP] error closing pooled client {key!r}: {e}")
+    pool.clear()
 
 
 # NOTE: Uses private _tool_wrapper to integrate with FlowManager's global
 # functions. Public register_tools(llm) bypasses FlowManager orchestration.
 # Pin pipecat-ai version to guard against API changes.
+def _maybe_apply_transforms(
+    result: Any,
+    response_transforms: Optional[List[ResponseTransform]],
+    tool_name: str,
+) -> Any:
+    """Parse → mutate → re-encode if the tool result is a JSON string and the
+    template declared any transforms for this tool. No-op otherwise so plain
+    text responses and missing-transform tools pass through unchanged.
+
+    Re-encoding preserves the return-shape contract pipecat / FlowManager /
+    chat-normalizer expect (a JSON-encoded string sitting under ``data``),
+    so this works identically for voice + chat + any future channel.
+    """
+    if not response_transforms or not isinstance(result, str):
+        return result
+    try:
+        parsed = json.loads(result)
+    except (json.JSONDecodeError, ValueError):
+        return result
+    if not isinstance(parsed, (dict, list)):
+        return result
+    try:
+        # Capture the return value: root-level transforms (path="") rebind
+        # ``parsed`` to a new dict (e.g. ``omit_fields`` dropping the protocol
+        # envelope), and that rebinding only propagates if we pick it up here.
+        # Nested-path transforms still mutate in place, so this is safe either
+        # way.
+        parsed = apply_response_transforms(parsed, response_transforms)
+    except Exception as e:
+        logger.warning(
+            f"[BUDDY_MCP] tool {tool_name!r} response_transforms failed: {e}"
+        )
+        return result
+    try:
+        return json.dumps(parsed)
+    except (TypeError, ValueError):
+        return result
+
+
+def _maybe_inject_ui_instructions(
+    result: Any,
+    ui_hint: Optional[ToolUiHint],
+    tool_name: str,
+) -> Any:
+    """JIT UI instruction injection (Sidekick pattern).
+
+    When the template declares a ``ToolUiHint`` for this tool, splice the
+    hint payload into the tool's response object so the LLM sees it as
+    part of the tool result. Keys used:
+
+      * ``_ui_instructions`` — the free-text guidance string
+      * ``_ui_examples`` — optional list of worked examples (each a dict)
+      * ``_ui_skip`` — boolean True when ``trigger == skip_ui``
+
+    Same return-shape contract as :func:`_maybe_apply_transforms` — parse
+    → mutate → re-encode. No-op for non-JSON string payloads or non-object
+    JSON (lists pass through; only dicts gain extra keys).
+    """
+    if ui_hint is None:
+        return result
+    if not isinstance(result, str):
+        return result
+
+    try:
+        parsed = json.loads(result)
+    except (json.JSONDecodeError, ValueError):
+        return result
+    if not isinstance(parsed, dict):
+        return result
+
+    try:
+        if ui_hint.trigger == ToolUiTrigger.SKIP_UI:
+            parsed["_ui_skip"] = True
+        else:
+            if ui_hint.instructions:
+                parsed["_ui_instructions"] = ui_hint.instructions
+            if ui_hint.examples:
+                parsed["_ui_examples"] = [
+                    ex.model_dump(exclude_none=True) for ex in ui_hint.examples
+                ]
+    except Exception as e:
+        logger.warning(
+            f"[BUDDY_MCP] tool {tool_name!r} ui_instructions inject failed: {e}"
+        )
+        return result
+
+    try:
+        return json.dumps(parsed)
+    except (TypeError, ValueError):
+        return result
+
+
+def _create_direct_http_tool_handler(
+    server_params: StreamableHttpParameters,
+    tool_name: str,
+    response_transforms: Optional[List[ResponseTransform]] = None,
+    ui_hint: Optional[ToolUiHint] = None,
+    default_args: Optional[Dict[str, Any]] = None,
+) -> Any:
+    """Direct JSON-RPC HTTP poster — bypasses pipecat MCPClient entirely.
+
+    Used when the upstream rejects the standard MCP handshake (initialize +
+    tools/list) but accepts standalone `tools/call` POSTs. Shopify UCP is
+    the motivating case: it gates discovery on the per-call agent profile,
+    so we declare tool schemas in the template (`server.tool_schemas`) and
+    skip discovery entirely; each call is a stateless JSON-RPC POST with
+    the profile attached at `arguments.meta.ucp-agent.profile` via
+    `default_args`.
+
+    Same return-shape contract as the pipecat-backed handler — `default_args`
+    deep-merge, response_transforms, ui_hint injection all apply.
+    """
+
+    async def handler(args: Dict[str, Any], flow_manager: Any) -> FlowResult:
+        merged_args = _deep_merge_defaults(args, default_args or {})
+        body = {
+            "jsonrpc": "2.0",
+            "id": uuid.uuid4().hex,
+            "method": "tools/call",
+            "params": {"name": tool_name, "arguments": merged_args},
+        }
+        # server_params.headers can be None in some MCP wirings; coalesce
+        # to an empty dict so the subsequent setdefault calls always have
+        # a target. Filter out any None values that may have been declared
+        # — httpx's headers param expects str-str pairs.
+        raw_headers = server_params.headers or {}
+        headers: Dict[str, str] = {
+            k: v for k, v in raw_headers.items() if v is not None
+        }
+        headers.setdefault("Content-Type", "application/json")
+        headers.setdefault("Accept", "application/json")
+
+        timeout_s = (
+            server_params.timeout.total_seconds() if server_params.timeout else 30.0
+        )
+        try:
+            async with httpx.AsyncClient(timeout=timeout_s) as client:
+                resp = await client.post(server_params.url, json=body, headers=headers)
+        except Exception as e:
+            logger.warning(f"[BUDDY_MCP] direct {tool_name!r} transport failed: {e}")
+            return cast(
+                FlowResult,
+                {"status": "error", "data": f"MCP transport error: {e}"},
+            )
+
+        # Surface HTTP-level failures as structured envelopes before
+        # attempting to parse JSON. Without this branch, a 502 with an
+        # HTML body would raise ValueError on resp.json() and the LLM
+        # would see a generic "MCP tool error: <ValueError>" instead of
+        # "upstream returned 502" — making prod incidents harder to
+        # debug AND blocking the LLM from any chance of recovery.
+        if resp.status_code >= 400:
+            body_preview = resp.text[:500]
+            logger.warning(
+                f"[BUDDY_MCP] direct {tool_name!r} HTTP {resp.status_code}: "
+                f"{body_preview!r}"
+            )
+            return cast(
+                FlowResult,
+                {
+                    "status": "error",
+                    "status_code": resp.status_code,
+                    "data": f"Upstream HTTP {resp.status_code}: {body_preview}",
+                },
+            )
+
+        try:
+            payload = resp.json()
+        except Exception as e:
+            logger.warning(
+                f"[BUDDY_MCP] direct {tool_name!r} non-JSON 2xx response: {e}"
+            )
+            return cast(
+                FlowResult,
+                {"status": "error", "data": f"MCP response not JSON: {e}"},
+            )
+
+        if "error" in payload:
+            err = payload["error"]
+            return cast(
+                FlowResult,
+                {"status": "error", "data": json.dumps(err)},
+            )
+
+        # JSON-RPC tools/call result is `{content: [{type:'text', text:'<json>'}], ...}`.
+        # Extract the text payload — that's what pipecat's wrapper hands the LLM.
+        result_obj = payload.get("result", {})
+        content = result_obj.get("content") or []
+        text_block = next(
+            (
+                c.get("text")
+                for c in content
+                if isinstance(c, dict) and c.get("type") == "text"
+            ),
+            None,
+        )
+        result: Any = text_block if text_block is not None else json.dumps(result_obj)
+        result = _maybe_apply_transforms(result, response_transforms, tool_name)
+        result = _maybe_inject_ui_instructions(result, ui_hint, tool_name)
+        return cast(FlowResult, {"status": "success", "data": result})
+
+    return handler
+
+
 def _create_mcp_tool_handler(
     server_params: StreamableHttpParameters,
     tool_name: str,
+    pool: Optional[MCPPool] = None,
+    server_key: Optional[str] = None,
+    response_transforms: Optional[List[ResponseTransform]] = None,
+    ui_hint: Optional[ToolUiHint] = None,
+    default_args: Optional[Dict[str, Any]] = None,
 ) -> Any:
-    """Create a FlowManager-compatible handler that creates a fresh MCPClient per call.
+    """Create a FlowManager-compatible handler for one MCP tool.
 
-    A new MCPClient is created for each invocation to avoid race conditions when
-    the LLM makes parallel tool calls. The client is cleaned up after each call.
+    When ``pool`` is provided (chat mode), the handler shares a single
+    MCPClient with every other tool on the same server for the lifetime
+    of the turn — the caller owns pool teardown via ``close_mcp_pool``.
+
+    When ``pool`` is ``None`` (voice mode / call sites that haven't been
+    plumbed through), the handler falls back to opening + closing a fresh
+    MCPClient on every invocation — the pre-pool behaviour.
+
+    When ``response_transforms`` is non-empty, the parsed tool result is
+    walked + mutated in place per the rules before being handed to the
+    LLM. The transform step is channel-agnostic — same code runs whether
+    the caller is voice (pipecat FlowManager) or chat (ChatAgent).
+
+    When ``ui_hint`` is set, the parsed tool result is post-processed via
+    :func:`_maybe_inject_ui_instructions` so the LLM sees per-tool JIT
+    UI authoring guidance alongside the data (Sidekick pattern).
+
+    When ``default_args`` is non-empty, those values are deep-merged into
+    the caller's ``args`` (caller wins on conflicts) before dispatch. This
+    is how UCP protocol metadata like ``meta.ucp-agent.profile`` lands on
+    every tool call without polluting per-tool injection rules.
     """
 
     async def handler(args: Dict[str, Any], flow_manager: Any) -> FlowResult:
@@ -48,19 +366,48 @@ def _create_mcp_tool_handler(
             if not future.done():
                 future.set_result(result)
 
+        # Apply server-level default_args (protocol-level metadata like
+        # UCP's meta.ucp-agent.profile). Channel-agnostic; runs before
+        # dispatch in BOTH voice and chat paths.
+        merged_args = _deep_merge_defaults(args, default_args or {})
+
         params = FunctionCallParams(
             function_name=tool_name,
             tool_call_id="",
-            arguments=args,
+            arguments=merged_args,
             llm=None,  # type: ignore[arg-type]
             context=None,  # type: ignore[arg-type]
             result_callback=result_callback,
         )
 
+        # Pooled path — chat mode.
+        if pool is not None and server_key is not None:
+            try:
+                client = await _acquire_pooled_client(pool, server_key, server_params)
+                await asyncio.wait_for(client._tool_wrapper(params), timeout=30)
+                result = await asyncio.wait_for(future, timeout=30)
+                result = _maybe_apply_transforms(result, response_transforms, tool_name)
+                result = _maybe_inject_ui_instructions(result, ui_hint, tool_name)
+                return cast(FlowResult, {"status": "success", "data": result})
+            except asyncio.TimeoutError:
+                # Evict so the next call in this turn opens a fresh client.
+                await _evict_pooled_client(pool, server_key)
+                return cast(FlowResult, {"status": "error", "data": "MCP tool timeout"})
+            except Exception as e:
+                await _evict_pooled_client(pool, server_key)
+                logger.warning(f"[BUDDY_MCP] Tool '{tool_name}' failed: {e}")
+                return cast(
+                    FlowResult, {"status": "error", "data": f"MCP tool error: {e}"}
+                )
+
+        # Unpooled path — voice mode (and any caller that hasn't migrated).
+        # Fresh MCPClient per call; matches the pre-0.7 behaviour exactly.
         try:
             async with MCPClient(server_params=server_params) as mcp_client:
                 await asyncio.wait_for(mcp_client._tool_wrapper(params), timeout=30)
             result = await asyncio.wait_for(future, timeout=30)
+            result = _maybe_apply_transforms(result, response_transforms, tool_name)
+            result = _maybe_inject_ui_instructions(result, ui_hint, tool_name)
             return cast(FlowResult, {"status": "success", "data": result})
         except asyncio.TimeoutError:
             return cast(FlowResult, {"status": "error", "data": "MCP tool timeout"})
@@ -69,6 +416,23 @@ def _create_mcp_tool_handler(
             return cast(FlowResult, {"status": "error", "data": f"MCP tool error: {e}"})
 
     return handler
+
+
+async def _evict_pooled_client(pool: MCPPool, key: str) -> None:
+    """Drop a pooled client after a failed call so the next acquire reopens.
+
+    A streaming-HTTP MCP connection can be half-broken (server closed the
+    stream, network blip mid-response) where the client object survives
+    but subsequent ``call_tool`` requests time out. Evicting on any failure
+    keeps the rest of the turn usable at the cost of one fresh connect.
+    """
+    bad = pool.pop(key, None)
+    if bad is None:
+        return
+    try:
+        await bad.close()
+    except Exception as e:
+        logger.warning(f"[BUDDY_MCP] error closing evicted client {key!r}: {e}")
 
 
 def _resolve_placeholders(value: str, template_vars: Dict[str, Any]) -> str:
@@ -176,27 +540,89 @@ async def _load_server_tools(
     label = server.name or server.url
     logger.info(f"[BUDDY_MCP] Connecting to {label}")
 
-    # Use a temporary client just to fetch the tools schema
+    # Declared-schemas path (UCP): skip the pipecat MCPClient handshake
+    # entirely. Each tool registers a direct-HTTP poster bound to server.url.
+    #
+    # Truthiness pitfall guard: `if server.tool_schemas:` would treat an
+    # empty list `[]` as "no schemas declared" and silently misroute to
+    # the discovery branch — which against a UCP endpoint fails on
+    # `initialize`. We branch on `is not None` so a deliberately-empty
+    # declaration is honored (and warned about) instead.
+    if server.tool_schemas is not None:
+        if not server.tool_schemas:
+            logger.warning(
+                f"[BUDDY_MCP] {label}: tool_schemas is declared but empty — "
+                "skipping discovery (no tools will be registered for this server). "
+                "Either populate tool_schemas or remove the field entirely to "
+                "fall back to MCPClient discovery."
+            )
+            return []
+        functions: List[FlowsFunctionSchema] = []
+        for schema in server.tool_schemas:
+            tool_name = schema["name"]
+            if tool_name in existing_names and server.name:
+                tool_name = f"{server.name}_{tool_name}"
+            tool_transforms = (
+                server.tool_response_transforms.get(schema["name"]) or None
+            )
+            tool_ui_hint = server.tool_ui_instructions.get(schema["name"])
+            functions.append(
+                FlowsFunctionSchema(
+                    name=tool_name,
+                    description=schema.get("description", ""),
+                    properties=schema.get("properties", {}),
+                    required=schema.get("required", []),
+                    handler=_create_direct_http_tool_handler(
+                        server_params,
+                        schema["name"],
+                        response_transforms=tool_transforms,
+                        ui_hint=tool_ui_hint,
+                        default_args=server.default_args,
+                    ),
+                )
+            )
+            existing_names.add(tool_name)
+            logger.info(
+                f"[BUDDY_MCP] Registered (declared) tool: {tool_name} (from {label})"
+            )
+        logger.info(f"[BUDDY_MCP] Loaded {len(functions)} declared tools from {label}")
+        return functions
+
+    # Discovery path (legacy MCP): handshake with the server and fetch the
+    # tool schema dynamically. Used when ``server.tool_schemas`` isn't set
+    # — UCP servers go through the declared-schemas branch above and never
+    # reach this code.
     async with MCPClient(server_params=server_params) as temp_client:
         tools_schema = await asyncio.wait_for(
             temp_client.get_tools_schema(),
             timeout=server.timeout,
         )
 
-    functions: List[FlowsFunctionSchema] = []
+    discovered_functions: List[FlowsFunctionSchema] = []
     for func_schema in tools_schema.standard_tools:
         # Prefix tool name with server name only on collision
         tool_name = func_schema.name
         if tool_name in existing_names and server.name:
             tool_name = f"{server.name}_{tool_name}"
 
-        functions.append(
+        # Look up per-tool transforms by the RAW MCP tool name (templates
+        # author against the upstream name; the local prefix is internal).
+        tool_transforms = server.tool_response_transforms.get(func_schema.name) or None
+        tool_ui_hint = server.tool_ui_instructions.get(func_schema.name)
+
+        discovered_functions.append(
             FlowsFunctionSchema(
                 name=tool_name,
                 description=func_schema.description,
                 properties=func_schema.properties,
                 required=func_schema.required,
-                handler=_create_mcp_tool_handler(server_params, func_schema.name),
+                handler=_create_mcp_tool_handler(
+                    server_params,
+                    func_schema.name,
+                    response_transforms=tool_transforms,
+                    ui_hint=tool_ui_hint,
+                    default_args=server.default_args,
+                ),
             )
         )
         # Track the chosen name so a subsequent tool from the same server
@@ -204,8 +630,8 @@ async def _load_server_tools(
         existing_names.add(tool_name)
         logger.info(f"[BUDDY_MCP] Registered tool: {tool_name} (from {label})")
 
-    logger.info(f"[BUDDY_MCP] Loaded {len(functions)} tools from {label}")
-    return functions
+    logger.info(f"[BUDDY_MCP] Loaded {len(discovered_functions)} tools from {label}")
+    return discovered_functions
 
 
 async def get_mcp_global_functions(
@@ -244,15 +670,19 @@ async def get_mcp_global_functions_cached(
     mcp_config: McpConfig,
     template_vars: Dict[str, Any],
     template_id: str,
+    mcp_pool: Optional[MCPPool] = None,
 ) -> List[FlowsFunctionSchema]:
     """Cache-aware variant for chat mode.
 
     Reads tool metadata from Redis (per-template + URL hash, see
-    ``mcp/cache.py``) and rebuilds ``FlowsFunctionSchema`` using the same
-    ``_create_mcp_tool_handler`` voice uses (per-invocation MCPClient — no
-    private API, no shared session). Auth headers are rebuilt from
+    ``mcp/cache.py``) and rebuilds ``FlowsFunctionSchema`` using
+    ``_create_mcp_tool_handler``. Auth headers are rebuilt from
     ``template_vars`` on every call so credential rotation takes effect on
     the next turn without cache invalidation.
+
+    When ``mcp_pool`` is provided the resulting handlers share one
+    MCPClient per server for the lifetime of the turn. The caller owns
+    pool teardown via ``close_mcp_pool``.
     """
     all_functions: List[FlowsFunctionSchema] = []
 
@@ -272,6 +702,52 @@ async def get_mcp_global_functions_cached(
         # Stable label: prefer server.name; fall back to the raw template
         # URL (placeholder form) rather than the resolved URL.
         label = server.name or server.url
+
+        # Declared-schemas path (UCP): skip discovery entirely. Match the
+        # `is not None` semantics in `_load_server_tools` (line 551) — an
+        # empty list MUST short-circuit, not fall through to discovery,
+        # which would handshake against a UCP endpoint that has no MCP
+        # initialize support and fail.
+        if server.tool_schemas is not None:
+            if not server.tool_schemas:
+                logger.warning(
+                    f"[BUDDY_MCP] chat: {label}: tool_schemas declared but empty — "
+                    "no tools registered for this server (skipping discovery)."
+                )
+                continue
+            existing_names = {f.name for f in all_functions}
+            for schema in server.tool_schemas:
+                tool_name = schema["name"]
+                if tool_name in existing_names and server.name:
+                    tool_name = f"{server.name}_{tool_name}"
+                tool_transforms = (
+                    server.tool_response_transforms.get(schema["name"]) or None
+                )
+                tool_ui_hint = server.tool_ui_instructions.get(schema["name"])
+                all_functions.append(
+                    FlowsFunctionSchema(
+                        name=tool_name,
+                        description=schema.get("description", ""),
+                        properties=schema.get("properties", {}),
+                        required=schema.get("required", []),
+                        handler=_create_direct_http_tool_handler(
+                            server_params,
+                            schema["name"],
+                            response_transforms=tool_transforms,
+                            ui_hint=tool_ui_hint,
+                            default_args=server.default_args,
+                        ),
+                    )
+                )
+                existing_names.add(tool_name)
+                logger.debug(
+                    f"[BUDDY_MCP] chat: registered (declared) tool: {tool_name} (from {label})"
+                )
+            logger.info(
+                f"[BUDDY_MCP] chat: loaded {len(server.tool_schemas)} declared tools from {label}"
+            )
+            continue
+
         try:
             tools_meta = await get_or_discover_server_tools(
                 template_id=template_id,
@@ -290,13 +766,23 @@ async def get_mcp_global_functions_cached(
             tool_name = meta["name"]
             if tool_name in existing_names and server.name:
                 tool_name = f"{server.name}_{tool_name}"
+            tool_transforms = server.tool_response_transforms.get(meta["name"]) or None
+            tool_ui_hint = server.tool_ui_instructions.get(meta["name"])
             all_functions.append(
                 FlowsFunctionSchema(
                     name=tool_name,
                     description=meta["description"],
                     properties=meta["properties"],
                     required=meta["required"],
-                    handler=_create_mcp_tool_handler(server_params, meta["name"]),
+                    handler=_create_mcp_tool_handler(
+                        server_params,
+                        meta["name"],
+                        pool=mcp_pool,
+                        server_key=label,
+                        response_transforms=tool_transforms,
+                        ui_hint=tool_ui_hint,
+                        default_args=server.default_args,
+                    ),
                 )
             )
             existing_names.add(tool_name)

--- a/app/ai/voice/agents/breeze_buddy/services/daily/daily.py
+++ b/app/ai/voice/agents/breeze_buddy/services/daily/daily.py
@@ -58,7 +58,9 @@ async def daily_completion_function(
     )
 
 
-async def start_daily_session(lead_id: str) -> Dict[str, Any]:
+async def start_daily_session(
+    lead_id: str, *, enable_recording: bool = True
+) -> Dict[str, Any]:
     """Create a Daily room and start the bot for a lead.
 
     This function handles the infrastructure setup for Daily sessions:
@@ -69,6 +71,14 @@ async def start_daily_session(lead_id: str) -> Dict[str, Any]:
 
     Args:
         lead_id: The ID of the lead to start the session for
+        enable_recording: When True (default — preserves existing
+            telephony / demo behaviour), enable Daily cloud recording
+            and set the recording_url sentinel so the dashboard player
+            renders. The unified widget router (CHAT_MODE.md §14)
+            passes False to skip recording entirely for widget voice
+            attachments — the lead is reused across attachments and a
+            single recording_url field cannot represent N
+            recordings, so we drop the feature for widget v1.
 
     Returns:
         Dict containing room_url, token (for user), session_id, and lead_id
@@ -84,45 +94,70 @@ async def start_daily_session(lead_id: str) -> Dict[str, Any]:
             aiohttp_session=aiohttp_session,
         )
 
-        # Create room with params (recording enabled for cloud recording)
+        # Create room with params. Cloud recording is opt-in per call so
+        # widget voice attachments can skip it (no per-call recording
+        # surface — the lead is reused across attachments).
+        room_properties_kwargs: Dict[str, Any] = {
+            "exp": time.time() + 3600,  # 1 hour expiry
+            "eject_at_room_exp": True,
+        }
+        if enable_recording:
+            room_properties_kwargs["enable_recording"] = "cloud"
         room_params = DailyRoomParams(
-            properties=DailyRoomProperties(
-                exp=time.time() + 3600,  # 1 hour expiry
-                eject_at_room_exp=True,
-                enable_recording="cloud",
-            )
+            properties=DailyRoomProperties(**room_properties_kwargs)
         )
         room = await daily_rest.create_room(room_params)
         room_url = room.url
 
         # Create tokens
         user_token = await daily_rest.get_token(room_url)
-        bot_token = await daily_rest.get_token(
-            room_url,
-            expiry_time=3600,
-            params=DailyMeetingTokenParams(
-                properties=DailyMeetingTokenProperties(
-                    start_cloud_recording=True,
-                )
-            ),
-        )
+        if enable_recording:
+            bot_token = await daily_rest.get_token(
+                room_url,
+                expiry_time=3600,
+                params=DailyMeetingTokenParams(
+                    properties=DailyMeetingTokenProperties(
+                        start_cloud_recording=True,
+                    )
+                ),
+            )
+        else:
+            bot_token = await daily_rest.get_token(room_url, expiry_time=3600)
 
-    # Store room name as call_id for on-demand recording retrieval
+    # Store room name as call_id for on-demand recording retrieval.
+    # Always set call_id (it's the call SID equivalent for Daily mode
+    # and feeds end_conversation lookups), but only set the
+    # recording_url sentinel when recording is actually enabled — a
+    # widget call with no recording shouldn't show a player.
     updated_lead = await update_lead_call_id_by_id(lead_id, room.name)
     if not updated_lead:
         logger.warning(
-            f"Failed to set call_id for lead {lead_id} — recording retrieval may not work"
+            f"Failed to set call_id for lead {lead_id} — completion lookup may not work"
         )
-    else:
-        # Set sentinel recording_url so frontend shows the recording player
-        # (depends on call_id being set above)
+    elif enable_recording:
+        # Sentinel recording_url so frontend shows the recording player
+        # (depends on call_id being set above).
         recording_lead = await update_lead_call_recording_url(room.name, "daily")
         if not recording_lead:
             logger.warning(
                 f"Failed to set recording_url for lead {lead_id} — frontend may not show recording player"
             )
+    else:
+        # Clear any stale sentinel from a prior recorded attachment on this
+        # same lead. Widget voice reuses leads across attachments, so a
+        # previous run that set ``recording_url="daily"`` would otherwise
+        # leave a player visible on this non-recorded session.
+        cleared_lead = await update_lead_call_recording_url(room.name, "")
+        if not cleared_lead:
+            logger.warning(
+                f"Failed to clear stale recording_url for lead {lead_id} — "
+                "frontend may still show a stale recording player"
+            )
 
-    logger.info(f"Created Daily room for Breeze Buddy session {session_id}: {room_url}")
+    logger.info(
+        f"Created Daily room for Breeze Buddy session {session_id}: {room_url} "
+        f"(recording={'on' if enable_recording else 'off'})"
+    )
 
     # Prepare runner arguments for Daily transport
     runner_args = DailyRunnerArguments(

--- a/app/ai/voice/agents/breeze_buddy/template/builder.py
+++ b/app/ai/voice/agents/breeze_buddy/template/builder.py
@@ -4,7 +4,7 @@ Flow Configuration Builder
 This module builds Pipecat flow configurations from database models.
 """
 
-from typing import AbstractSet, Any, Callable, Dict, List, cast
+from typing import AbstractSet, Any, Callable, Dict, List, Optional, Set, cast
 
 from pipecat_flows import (
     FlowManager,
@@ -41,12 +41,39 @@ from app.ai.voice.agents.breeze_buddy.template.types import (
     GlobalFunctionType,
     TemplateModel,
 )
+from app.ai.voice.agents.breeze_buddy.template.ui_prompt import (
+    render_primitives_section,
+)
 from app.core.logger import logger
 
 # Synthetic node name used in direct mode. There is only ever one node so the
 # concrete name does not matter, but it must be stable across the build/init
 # code paths and unlikely to collide with a user-defined node.
 DIRECT_MODE_NODE_NAME = "__direct__"
+
+# Literal placeholder in template prompts (system_prompt for direct mode,
+# task_messages / role_messages for flow mode) that the builder replaces
+# with the rendered "## Available primitives" section at build time.
+UI_PRIMITIVES_PLACEHOLDER = "{{ui_primitives_section}}"
+
+
+def _splice_ui_primitives(text: str, ui_allowlist: Optional[Set[str]]) -> str:
+    """Substitute ``{{ui_primitives_section}}`` with the rendered section.
+
+    When ``ui_allowlist`` is ``None`` the placeholder is replaced with an
+    empty string — keeps templates that haven't opted into the catalog
+    flow path working unchanged, and lets test fixtures opt out without
+    importing the catalog. When the placeholder isn't present the input
+    is returned untouched (fast path; most non-chat templates).
+    """
+    if UI_PRIMITIVES_PLACEHOLDER not in text:
+        return text
+    if ui_allowlist is None:
+        return text.replace(UI_PRIMITIVES_PLACEHOLDER, "")
+    return text.replace(
+        UI_PRIMITIVES_PLACEHOLDER, render_primitives_section(ui_allowlist)
+    )
+
 
 # Function dicts whose ``type`` is one of these are routed through the global
 # function adapter registry; everything else is treated as a FlowFunction.
@@ -149,12 +176,25 @@ class FlowConfigBuilder:
             "custom_python_code_handler": custom_python_code_handler,
         }
 
-    def build_flow_config(self, template: TemplateModel) -> Dict[str, Any]:
+    def build_flow_config(
+        self,
+        template: TemplateModel,
+        *,
+        ui_allowlist: Optional[Set[str]] = None,
+    ) -> Dict[str, Any]:
         """
         Convert database template to Pipecat flow format.
 
         Args:
             template: Template configuration from database
+            ui_allowlist: Optional set of UI-catalog primitive names the
+                LLM may emit on this session. When set, the builder
+                splices the rendered ``## Available primitives`` section
+                into every ``{{ui_primitives_section}}`` placeholder it
+                finds in the template's system_prompt / task_messages /
+                role_messages. When ``None`` (the voice / no-chat default),
+                the placeholder is replaced with an empty string so
+                templates remain channel-agnostic.
 
         Returns:
             Dictionary in Pipecat flow format with transitions
@@ -176,7 +216,7 @@ class FlowConfigBuilder:
         # prompt. Reuses the rest of the flow path unchanged so all features
         # (filler audio, hooks, evaluators, OTEL, greeting injection) work.
         if flow.get("mode") == FlowMode.DIRECT.value:
-            return self._build_direct_flow_config(template)
+            return self._build_direct_flow_config(template, ui_allowlist=ui_allowlist)
 
         initial_node_name = flow.get("initial_node")
         if not initial_node_name:
@@ -249,7 +289,7 @@ class FlowConfigBuilder:
         nodes = {}
         for node in flow_nodes:
             logger.debug(f"Building node: {node.node_name}")
-            nodes[node.node_name] = self._build_node(node)
+            nodes[node.node_name] = self._build_node(node, ui_allowlist=ui_allowlist)
 
         # Extract end_conversation_callbacks if present
         end_conversation_callbacks = flow.get("end_conversation_callbacks", [])
@@ -267,7 +307,12 @@ class FlowConfigBuilder:
             "expected_callback_response_schema": template.expected_callback_response_schema,
         }
 
-    def _build_direct_flow_config(self, template: TemplateModel) -> Dict[str, Any]:
+    def _build_direct_flow_config(
+        self,
+        template: TemplateModel,
+        *,
+        ui_allowlist: Optional[Set[str]] = None,
+    ) -> Dict[str, Any]:
         """
         Build a flow config for direct mode (one global system prompt, no nodes).
 
@@ -297,6 +342,13 @@ class FlowConfigBuilder:
             raise ValueError(
                 "Direct mode requires a non-empty 'system_prompt' string in flow"
             )
+
+        # Splice the rendered "## Available primitives" section into the
+        # template prompt before it reaches the LLM. Templates without the
+        # placeholder are untouched; templates with a placeholder but no
+        # allowlist (voice / pre-chat) get an empty-string replacement so
+        # the same template can serve both channels.
+        system_prompt = _splice_ui_primitives(system_prompt, ui_allowlist)
 
         # system_prompt goes into role_messages so pipecat-flows prepends it
         # ahead of task_messages. When a greeting is played, prepare_initial_node
@@ -450,12 +502,20 @@ class FlowConfigBuilder:
         )
         return result
 
-    def _build_node(self, node: FlowNodeModel) -> NodeConfig:
+    def _build_node(
+        self,
+        node: FlowNodeModel,
+        *,
+        ui_allowlist: Optional[Set[str]] = None,
+    ) -> NodeConfig:
         """
         Build NodeConfig from FlowNodeModel.
 
         Args:
             node: Flow node model from database
+            ui_allowlist: Optional UI primitive allowlist used to splice
+                ``{{ui_primitives_section}}`` placeholders in task /
+                role messages.
 
         Returns:
             NodeConfig object
@@ -463,12 +523,20 @@ class FlowConfigBuilder:
         logger.debug(f"Building NodeConfig for node: {node.node_name}")
 
         task_messages = [
-            {"role": msg.role, "content": msg.content} for msg in node.task_messages
+            {
+                "role": msg.role,
+                "content": _splice_ui_primitives(msg.content, ui_allowlist),
+            }
+            for msg in node.task_messages
         ]
         logger.debug(f"Node {node.node_name} has {len(task_messages)} task messages")
 
         role_messages = [
-            {"role": msg.role, "content": msg.content} for msg in node.role_messages
+            {
+                "role": msg.role,
+                "content": _splice_ui_primitives(msg.content, ui_allowlist),
+            }
+            for msg in node.role_messages
         ]
         logger.debug(f"Node {node.node_name} has {len(role_messages)} role messages")
 

--- a/app/ai/voice/agents/breeze_buddy/template/session_state.py
+++ b/app/ai/voice/agents/breeze_buddy/template/session_state.py
@@ -1,0 +1,335 @@
+"""Declarative session-state reducer + tool-arg injection engines.
+
+Both engines are **commerce-agnostic**. They evaluate JMESPath
+expressions declared in the template config against a context (tool
+result for the reducer; ``{session_id, state.data, args}`` for the
+injection engine) and either:
+
+- merge values into a session-scoped ``data: dict`` (reducer), or
+- merge values into outgoing MCP tool arguments (injection).
+
+Commerce flavour — knowing that ``cart.id`` from ``update_cart`` should
+land at the ``cart_id`` state key, and that the ``update_cart`` tool's
+``cart_id`` argument should be filled from that state — lives entirely
+in template JSON. The Python here doesn't know what a cart is.
+
+Sibling to :mod:`response_transform` (which mutates tool responses
+declaratively) and :mod:`response_filter` (which projects them
+declaratively).
+
+Why we need this
+----------------
+Anthropic's tool loop discipline (see ``poc/claude-cookbooks/INSIGHTS.md``)
+plus the canonical Shopify reference (``poc/shop-chat-agent``) plus the
+A2A / AP2 / UCP specs all converge on the same rule: identifiers live
+out-of-band, not in the LLM transcript. We preserve tool_use/tool_result
+blocks so the LLM can self-recover; we also persist a canonical state
+row so compaction and voice/chat parity have a single source of truth;
+and we inject server-side identifiers into outgoing tool calls so the
+LLM never has to guess.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import time
+import uuid
+from datetime import datetime, timezone
+from typing import Any, Callable, Dict, List, Optional
+
+import jmespath
+
+from app.ai.voice.agents.breeze_buddy.template.types import (
+    StateReducer,
+    ToolArgInjection,
+)
+from app.core.logger import logger
+
+# ---------------------------------------------------------------------------
+# Value generators — commerce-agnostic
+# ---------------------------------------------------------------------------
+#
+# Each generator is a zero-arg callable that returns the value to stamp
+# onto an outgoing tool arg. Used for things the LLM shouldn't be asked
+# to invent: idempotency keys, request ids, client-side timestamps.
+#
+# Wire-format note: values are serialised by the MCP layer downstream;
+# strings here are intentional so they round-trip JSON cleanly.
+
+
+def _gen_uuid_v4() -> str:
+    return str(uuid.uuid4())
+
+
+def _gen_uuid_v7() -> str:
+    # Python's stdlib only ships v1/v3/v4/v5. uuid_v7 is monotonic +
+    # time-ordered which is friendlier to log search; we fall back to
+    # v4 if the runtime doesn't have the helper (older Python).
+    fn = getattr(uuid, "uuid7", None)
+    return str(fn() if fn else uuid.uuid4())
+
+
+def _gen_timestamp_iso8601() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _gen_timestamp_unix_ms() -> int:
+    return int(time.time() * 1000)
+
+
+_GENERATORS: Dict[str, Callable[[], Any]] = {
+    "uuid_v4": _gen_uuid_v4,
+    "uuid_v7": _gen_uuid_v7,
+    "timestamp_iso8601": _gen_timestamp_iso8601,
+    "timestamp_unix_ms": _gen_timestamp_unix_ms,
+}
+
+
+# Sentinel name for the context-aware idempotency-hash generator. Special-cased
+# inside ``inject_tool_args`` because it depends on per-call context
+# (args, tool_name, session_id, turn_id) — the zero-arg ``_GENERATORS``
+# table can't carry that. Templates use:
+#     "generators": {"idempotency_key": "idempotency_hash"}
+# to opt in. The legacy "uuid_v4" choice still works but is NOT retry-safe
+# (each dispatch produces a fresh value, defeating idempotency on retry).
+_IDEMPOTENCY_HASH_GENERATOR = "idempotency_hash"
+
+
+def _gen_idempotency_hash(
+    *,
+    tool_name: str,
+    args: Dict[str, Any],
+    session_id: str,
+    turn_id: str,
+) -> str:
+    """Deterministic idempotency key for retry-safe UCP mutations.
+
+    Hash inputs:
+      - tool_name     — distinguishes ``create_cart`` from ``update_cart``
+      - canonical args— sorted JSON so key ordering doesn't shift the hash
+      - session_id    — scopes the key to one widget conversation
+      - turn_id       — distinguishes "retry within the same turn"
+                        (same intent, same key, idempotent) from "user
+                        re-issues the same action in a later turn"
+                        (legitimately a new operation, different key)
+
+    Output is the first 128 bits of SHA-256 in hex (32 chars), matching
+    UUID-string width and easy to grep for. SHA-256 prefix is collision-
+    resistant well past the lifetime of any reasonable widget session.
+
+    Same intent → same key → upstream returns the prior result on retry.
+    Different intent (or different turn) → different key → fresh op.
+    """
+    canonical = json.dumps(args, sort_keys=True, separators=(",", ":"))
+    h = hashlib.sha256()
+    # Version prefix so a future scheme change can be detected and
+    # transitioned without ambiguity.
+    h.update(b"breeze-buddy.idempotency.v1\0")
+    h.update(tool_name.encode("utf-8"))
+    h.update(b"\0")
+    h.update(session_id.encode("utf-8"))
+    h.update(b"\0")
+    h.update(turn_id.encode("utf-8"))
+    h.update(b"\0")
+    h.update(canonical.encode("utf-8"))
+    return h.hexdigest()[:32]
+
+
+# ---------------------------------------------------------------------------
+# Reducer engine — tool result → state delta
+# ---------------------------------------------------------------------------
+
+
+def apply_state_reducers(
+    state_data: Dict[str, Any],
+    tool_name: str,
+    tool_result: Any,
+    reducers: Optional[List[StateReducer]],
+) -> Dict[str, Any]:
+    """Compute the next state from the current state + a tool result.
+
+    Returns a new dict (does not mutate the input). Reducers with a
+    non-matching ``tool_name`` are skipped. ``only_on_success`` rules
+    skip on tool error envelopes. Missing JMESPath matches and lookup
+    failures are silently skipped (a stale rule never crashes a turn).
+    """
+    if not reducers:
+        return dict(state_data)
+
+    next_state = dict(state_data)
+    payload = _unwrap_tool_payload(tool_result)
+
+    for rule in reducers:
+        if rule.tool_name != tool_name:
+            continue
+        if rule.only_on_success and not _is_tool_success(tool_result):
+            continue
+        if payload is None:
+            continue
+
+        for state_key, expr in rule.set_paths.items():
+            try:
+                value = jmespath.search(expr, payload)
+            except Exception as e:
+                logger.warning(
+                    f"[session_state] reducer {tool_name!r} key {state_key!r} "
+                    f"JMESPath failed: {e}"
+                )
+                continue
+            if value is None:
+                continue
+            next_state[state_key] = value
+
+    return next_state
+
+
+# ---------------------------------------------------------------------------
+# Tool-arg injection engine — state → outgoing tool arguments
+# ---------------------------------------------------------------------------
+
+
+def inject_tool_args(
+    tool_name: str,
+    args: Dict[str, Any],
+    state_data: Dict[str, Any],
+    chat_session_id: str,
+    injections: Optional[List[ToolArgInjection]],
+    turn_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Apply matching injection rules to a tool's argument dict.
+
+    Returns a new dict (does not mutate ``args``). ``only_if_missing``
+    rules (default) skip arg keys the LLM already provided — the LLM's
+    intent wins when it explicitly passes a value, the state-driven
+    default fills in when it doesn't. This is the discipline every
+    reference implementation in our research adopted (see e.g. Stripe's
+    ``StripeMcpClient.callTool`` priority: per-call override > session
+    context > none).
+
+    ``turn_id`` is required for the ``idempotency_hash`` generator (the
+    hash includes turn_id so that the same intent across distinct turns
+    gets distinct keys). Passing None falls back to ``chat_session_id``
+    as the turn discriminator — degrades the hash to "session-scoped"
+    semantics, which is OK for inert callers but breaks retry safety for
+    repeat-the-same-action flows. Chat agent always passes a fresh turn
+    uuid from ``ChatAgent.run_turn``.
+    """
+    if not injections:
+        return dict(args)
+
+    next_args = dict(args)
+    eval_context = {
+        "session_id": chat_session_id,
+        "state": {"data": state_data},
+        "args": dict(args),
+    }
+
+    for rule in injections:
+        if rule.tool_name != tool_name:
+            continue
+        for arg_key, expr in rule.set_paths.items():
+            if rule.only_if_missing and next_args.get(arg_key) is not None:
+                continue
+            try:
+                value = jmespath.search(expr, eval_context)
+            except Exception as e:
+                logger.warning(
+                    f"[session_state] injection {tool_name!r} arg {arg_key!r} "
+                    f"JMESPath failed: {e}"
+                )
+                continue
+            if value is None:
+                continue
+            next_args[arg_key] = value
+
+        for arg_key, generator_name in rule.generators.items():
+            if rule.only_if_missing and next_args.get(arg_key) is not None:
+                continue
+            # Context-aware idempotency hash. Special-cased because the
+            # zero-arg _GENERATORS table can't carry per-call context.
+            # Hash uses ``next_args`` (post-injection) rather than the
+            # original LLM ``args`` so server-injected paths like
+            # ``cart_id`` are part of the digest — without this, two
+            # materially different dispatched requests in the same turn
+            # would collide on the same idempotency key.
+            if generator_name == _IDEMPOTENCY_HASH_GENERATOR:
+                try:
+                    next_args[arg_key] = _gen_idempotency_hash(
+                        tool_name=tool_name,
+                        args=next_args,
+                        session_id=chat_session_id,
+                        turn_id=turn_id or chat_session_id,
+                    )
+                except Exception as e:
+                    logger.warning(
+                        f"[session_state] injection {tool_name!r} arg {arg_key!r} "
+                        f"idempotency_hash failed: {e}"
+                    )
+                continue
+            fn = _GENERATORS.get(generator_name)
+            if fn is None:
+                logger.warning(
+                    f"[session_state] injection {tool_name!r} arg {arg_key!r} "
+                    f"unknown generator {generator_name!r}; supported: "
+                    f"{sorted(_GENERATORS) + [_IDEMPOTENCY_HASH_GENERATOR]}"
+                )
+                continue
+            try:
+                next_args[arg_key] = fn()
+            except Exception as e:
+                logger.warning(
+                    f"[session_state] injection {tool_name!r} arg {arg_key!r} "
+                    f"generator {generator_name!r} failed: {e}"
+                )
+
+    return next_args
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _unwrap_tool_payload(tool_result: Any) -> Optional[Any]:
+    """Pull the structured payload out of our standard ``FlowResult`` envelope.
+
+    MCP tool handlers (see :mod:`mcp`) wrap the upstream response as
+    ``{"status": "success"|"error", "data": "<json-string-or-text>"}``.
+    Reducers operate on the *parsed* upstream payload, not the envelope.
+
+    Returns the parsed payload, or ``None`` if the envelope is missing
+    or malformed (in which case all reducers silently no-op).
+    """
+    if not isinstance(tool_result, dict):
+        return tool_result
+    if "data" not in tool_result:
+        return tool_result
+    data = tool_result["data"]
+    if isinstance(data, str):
+        try:
+            return json.loads(data)
+        except (ValueError, json.JSONDecodeError):
+            return data
+    return data
+
+
+def _is_tool_success(tool_result: Any) -> bool:
+    """Treat an explicit ``status="error"`` as a failure; anything else
+    (including missing-status / non-dict results) as success.
+
+    Conservative on purpose — we don't want to skip a reducer that would
+    have set state just because the envelope is a plain string.
+    """
+    if isinstance(tool_result, dict):
+        status = tool_result.get("status")
+        if status is None:
+            return True
+        return status not in ("error", "failed")
+    return True
+
+
+__all__ = [
+    "apply_state_reducers",
+    "inject_tool_args",
+]

--- a/app/ai/voice/agents/breeze_buddy/template/types.py
+++ b/app/ai/voice/agents/breeze_buddy/template/types.py
@@ -701,6 +701,110 @@ class IvrConfig(BaseModel):
     )
 
 
+class ResponseTransform(BaseModel):
+    """One in-place response-transform rule declared in a template.
+
+    Sibling to ``expected_response_schema`` (projection): where projection
+    reshapes the response into a new dict, transforms mutate specific paths
+    and pass the rest through. Both are applied inside the tool handler
+    closure, so voice + chat + any future channel benefit uniformly.
+
+    Runtime registry + walker + the first built-in (``scale_by_exponent``)
+    live in ``handlers/transport/utils/response_transform.py``.
+    """
+
+    path: str = Field(
+        ...,
+        description=(
+            "Dotted path to the field(s) to transform. "
+            "Use [*] to iterate array elements. "
+            "Examples: 'order.total', 'products[*].price_range.min', 'items[*]'."
+        ),
+    )
+    fn: str = Field(
+        ...,
+        description=(
+            "Registered transform name "
+            "(see handlers/transport/utils/response_transform.py)."
+        ),
+    )
+    args: Dict[str, Any] = Field(
+        default_factory=dict,
+        description="Optional arguments forwarded to the transform fn.",
+    )
+
+
+class ToolUiTrigger(str, Enum):
+    """When the JIT UI hint should ship with this tool's response.
+
+    * ``on_success`` — append only when the tool returns success.
+    * ``on_any`` — append regardless of status (errors too).
+    * ``skip_ui`` — never emit UI for this tool's result. Hint payload is
+      ignored; only the ``_ui_skip`` flag is appended so the LLM knows.
+    """
+
+    ON_SUCCESS = "on_success"
+    ON_ANY = "on_any"
+    SKIP_UI = "skip_ui"
+
+
+class ToolUiExample(BaseModel):
+    """A short worked example the LLM can crib from when authoring a
+    ``<ui_stream>`` block for this tool's result. Optional but recommended
+    — Sidekick-style few-shot in the tool response itself."""
+
+    scenario: str = Field(
+        ..., description="Short label for the example (e.g. '3 products, INR')."
+    )
+    input_sketch: Optional[str] = Field(
+        None,
+        description=(
+            "Pseudocode for the shape of the tool result this example "
+            "applies to (e.g. '{products: [{id, title, price_range}…]}')."
+        ),
+    )
+    expected_jsonl: List[Dict[str, Any]] = Field(
+        default_factory=list,
+        description=(
+            "List of expected SpecStream ops the LLM should emit. Each "
+            "entry is a JSON dict with op/id/type/parent/props."
+        ),
+    )
+
+
+class ToolUiHint(BaseModel):
+    """Per-tool UI authoring guidance — Sidekick-pattern JIT instructions
+    that ride along with the tool result instead of bloating the system
+    prompt.
+
+    At dispatch time, the matching hint's ``instructions`` (and optional
+    ``examples``) are spliced into the tool result envelope under
+    ``_ui_instructions`` / ``_ui_examples`` so the LLM sees them as part
+    of the tool's payload. The LLM then emits a ``<ui_stream>`` block
+    using SpecStream JSONL ops grounded in the data it just received.
+
+    Commerce flavour lives in template JSON; engine + injection point are
+    commerce-agnostic.
+    """
+
+    trigger: ToolUiTrigger = Field(
+        ToolUiTrigger.ON_SUCCESS,
+        description="When the hint fires (see ToolUiTrigger).",
+    )
+    instructions: str = Field(
+        "",
+        description=(
+            "Free-text guidance shown to the LLM with the tool result. "
+            "Tell it which primitives to use, what to skip, what tone to "
+            "strike. Keep under ~2KB per tool."
+        ),
+    )
+    examples: List[ToolUiExample] = Field(
+        default_factory=list,
+        description="Optional few-shot examples appended to the hint.",
+    )
+
+
 class McpServerConfig(BaseModel):
     """Configuration for a single MCP tool server.
 
@@ -775,6 +879,71 @@ class McpServerConfig(BaseModel):
     headers: Dict[str, str] = Field(
         default_factory=dict, description="Additional static headers to send"
     )
+    tool_response_transforms: Dict[str, List["ResponseTransform"]] = Field(
+        default_factory=dict,
+        description=(
+            "Per-tool in-place response transforms applied after the MCP tool "
+            "call returns, before the result is fed to the LLM. Keys are the "
+            "raw MCP tool names (e.g. 'search_catalog'); values are lists of "
+            "ResponseTransform rules. Channel-agnostic — applied inside the "
+            "tool handler closure, so voice + chat + any future channel "
+            "benefit uniformly. Use the registered transform names from "
+            "handlers/transport/utils/response_transform.py."
+        ),
+    )
+    tool_ui_instructions: Dict[str, "ToolUiHint"] = Field(
+        default_factory=dict,
+        description=(
+            "Per-tool JIT UI authoring guidance (Sidekick pattern). Keys "
+            "are raw MCP tool names; values declare what UI the LLM "
+            "should emit for that tool's result. Injected into the tool "
+            "response envelope under '_ui_instructions' / '_ui_examples' "
+            "/ '_ui_skip' before the LLM sees it, so per-tool guidance "
+            "doesn't bloat the system prompt."
+        ),
+    )
+    tool_context_retention: Dict[str, Literal["last_turn_only", "session"]] = Field(
+        default_factory=dict,
+        description=(
+            "Per-tool conversation-context retention policy, applied at "
+            "message-prep time before the LLM call. Keys are raw MCP tool "
+            "names; values are:\n"
+            "  - ``last_turn_only``: the tool_result content is replaced "
+            "    with a 1-line stub once it's no longer the most-recent "
+            "    tool_result in history. Forces the agent to re-call the "
+            "    tool for grounding rather than relying on stale memory. "
+            "    Best for high-token / fast-changing data (catalog "
+            "    searches, lookups).\n"
+            "  - ``session``: tool_result is kept full for the whole "
+            "    session. Best for state-bearing tools (cart calls — "
+            "    line_items + totals shape later turns).\n"
+            "Tools not listed default to ``session`` (current behavior)."
+        ),
+    )
+    default_args: Dict[str, Any] = Field(
+        default_factory=dict,
+        description=(
+            "Static arguments deep-merged into every tool call's `arguments` "
+            "object before the call is dispatched. Caller-provided values win "
+            "(only_if_missing semantics). Used for protocol-level metadata "
+            "that every tool on this server needs — e.g. Shopify UCP requires "
+            "`meta.ucp-agent.profile` to be present on every tools/call. "
+            "Channel-agnostic; applied inside the handler closure for both "
+            "voice and chat."
+        ),
+    )
+    tool_schemas: Optional[List[Dict[str, Any]]] = Field(
+        default=None,
+        description=(
+            "When set, skip MCP discovery (initialize + tools/list) entirely "
+            "and register the declared schemas instead. Tool calls go via a "
+            "direct JSON-RPC HTTP POST to `url`, bypassing pipecat's MCPClient "
+            "session. Required for Shopify UCP, which rejects `initialize` "
+            "and `tools/list` without an agent profile we can only attach to "
+            "individual `tools/call` requests. Each entry: "
+            "`{name, description, properties, required}`."
+        ),
+    )
 
 
 class McpConfig(BaseModel):
@@ -785,7 +954,203 @@ class McpConfig(BaseModel):
     )
 
 
+class UiCatalogConfig(BaseModel):
+    """Per-template selection of which generative-UI primitives the LLM
+    may emit and the widget will render.
+
+    Resolution at session start (see ``ui_catalog.resolve_allowlist``):
+      1. Start with every primitive in ``enabled_groups``.
+      2. Union in any ``enabled_primitives`` one-offs.
+      3. Subtract ``disabled_primitives``.
+
+    The resolved allowlist drives three things:
+      * Server-side ``ui_op`` validation — disabled types drop with
+        reason ``primitive_disabled:<type>`` (distinct from
+        ``unknown_type`` so telemetry tells the difference).
+      * The auto-rendered "## Available primitives" section spliced
+        into the system prompt — the LLM never even sees disabled
+        primitives, so it can't accidentally emit them.
+      * The widget's render path (no change — widget compiles in all
+        primitives; server filtering is the gate).
+
+    Example::
+
+        "configurations": {
+            "ui_catalog": {
+                "enabled_groups": ["core", "composite"],
+                "enabled_primitives": [],
+                "disabled_primitives": []
+            }
+        }
+
+    Default behaviour (config absent): ``enabled_groups = ["core"]`` so
+    pre-Tile templates keep working unchanged.
+    """
+
+    enabled_groups: List[str] = Field(
+        default_factory=lambda: ["core"],
+        description=(
+            "Primitive groups the LLM may emit. Known groups: 'core', "
+            "'composite', 'graphs', 'metrics', 'forms', 'media', 'data'. "
+            "Unknown groups are silently ignored."
+        ),
+    )
+    enabled_primitives: List[str] = Field(
+        default_factory=list,
+        description=(
+            "Explicit one-off primitives to enable beyond what the groups "
+            "provide. Useful for trying a single new primitive without "
+            "enabling its whole group."
+        ),
+    )
+    disabled_primitives: List[str] = Field(
+        default_factory=list,
+        description=(
+            "Explicit overrides to remove from the resolved set, e.g. "
+            "disable 'Table' on a voice-first template even though it's "
+            "in the 'core' group."
+        ),
+    )
+
+
+class StateReducer(BaseModel):
+    """One per-tool rule that maps a tool result onto session state.
+
+    Generic — Python runtime knows nothing about which keys mean what.
+    Each rule names one tool and a set of (state_key → JMESPath) pairs;
+    when that tool returns, every matching JMESPath is evaluated against
+    the parsed tool payload and the result is merged into the session's
+    ``data`` dict (see migration 030 / agent_session_state).
+
+    Commerce flavour lives in the template JSON, e.g.::
+
+        "state_reducers": [
+            {"tool_name": "update_cart",
+             "set_paths": {"cart_id": "cart.id",
+                           "checkout_url": "cart.checkout_url"}}
+        ]
+
+    A future flavour (travel, tickets) ships different reducers — same
+    engine, same schema.
+    """
+
+    tool_name: str = Field(
+        ...,
+        description="Raw MCP tool name (or HTTP function name) the reducer fires on.",
+    )
+    set_paths: Dict[str, str] = Field(
+        default_factory=dict,
+        description=(
+            "Map of state_key → JMESPath expression evaluated against the "
+            "parsed tool payload. Missing matches / lookup failures are "
+            "silently skipped so a stale rule never crashes a turn."
+        ),
+    )
+    only_on_success: bool = Field(
+        True,
+        description=(
+            "When true (default), skip the rule if the tool envelope's "
+            "status indicates an error — keeps state out of the way of "
+            "obviously-failed calls."
+        ),
+    )
+
+
+class ToolArgInjection(BaseModel):
+    """One per-tool rule that injects session state into outgoing tool args.
+
+    The companion to :class:`StateReducer` — where the reducer captures
+    server-side identifiers off tool results, this rule reads them back
+    out of session state and stamps them onto the next tool's arguments.
+    The LLM never has to thread the identifier through prose.
+
+    Two sources are supported, both commerce-agnostic:
+
+    - ``set_paths`` — read from context (state / args / session_id) via
+      JMESPath. Used for things the runtime already knows (e.g. a cart
+      id captured by a reducer on the previous turn).
+    - ``generators`` — produce a value at call time (uuid_v4, uuid_v7,
+      timestamp_iso8601, timestamp_unix_ms). Used for idempotency keys,
+      request ids, client-side timestamps — values the LLM shouldn't be
+      asked to invent. Any MCP server that follows the Stripe-style
+      Idempotency-Key convention can re-use this without code changes.
+
+    Default behaviour (``only_if_missing=True``) is to fill ONLY when the
+    LLM didn't pass the field — explicit LLM intent always wins.
+
+    Commerce flavour in template JSON::
+
+        "tool_arg_injection": [
+            {"tool_name": "update_cart",
+             "set_paths": {"cart_id": "state.data.cart_id"},
+             "generators": {"idempotency_key": "uuid_v4"}}
+        ]
+    """
+
+    tool_name: str = Field(
+        ...,
+        description="Raw MCP tool name (or HTTP function name) the rule fires on.",
+    )
+    set_paths: Dict[str, str] = Field(
+        default_factory=dict,
+        description=(
+            "Map of arg_key → JMESPath expression evaluated against the "
+            "context ``{session_id, state.data, args}``. Use "
+            "`state.data.cart_id` for state lookups, `args.foo` to "
+            "post-process an LLM-provided arg, or `session_id` for the "
+            "raw chat session id."
+        ),
+    )
+    generators: Dict[str, str] = Field(
+        default_factory=dict,
+        description=(
+            "Map of arg_key → generator name. Generator produces a value "
+            "at call time. Supported: 'uuid_v4', 'uuid_v7', "
+            "'timestamp_iso8601', 'timestamp_unix_ms'. Honours "
+            "``only_if_missing`` like ``set_paths``."
+        ),
+    )
+    only_if_missing: bool = Field(
+        True,
+        description=(
+            "When true (default), skip the rule if the LLM already "
+            "passed a non-null value for the arg key — the LLM's "
+            "explicit intent wins. Set to false to force-override."
+        ),
+    )
+
+
 class ConfigurationModel(BaseModel):
+    # --- Agent session state (generic) ---
+    state_reducers: List[StateReducer] = Field(
+        default_factory=list,
+        description=(
+            "Declarative rules that lift identifiers from tool results "
+            "into a per-session `agent_session_state.data` JSONB. "
+            "Generic engine — the template decides which keys matter."
+        ),
+    )
+    tool_arg_injection: List[ToolArgInjection] = Field(
+        default_factory=list,
+        description=(
+            "Declarative rules that stamp session-state values onto "
+            "outgoing MCP tool arguments (e.g. cart_id from prior turn). "
+            "Generic engine — the template decides which args matter."
+        ),
+    )
+
+    # --- Generative-UI primitive selection (per-template, per-merchant) ---
+    ui_catalog: Optional["UiCatalogConfig"] = Field(
+        None,
+        description=(
+            "Optional. Selects which UI primitives the LLM may emit and "
+            "the widget will render. Resolution + rendering happens at "
+            "session start; the resolved allowlist drives both server "
+            "validation and the system-prompt 'Available primitives' "
+            "section. When absent, defaults to enabling the 'core' group."
+        ),
+    )
+
     # --- STT (provider + turn detection) ---
     stt_configuration: Optional[STTConfiguration] = Field(
         None,
@@ -1169,6 +1534,17 @@ class BaseGlobalFunction(BaseModel):
         default=None,
         description="Per-function timeout override in seconds. Falls back to "
         "the LLM service's function_call_timeout_secs when unset.",
+    )
+    response_transforms: List["ResponseTransform"] = Field(
+        default_factory=list,
+        description=(
+            "Optional in-place transforms applied to the tool result before "
+            "the LLM sees it. Complements expected_response_schema (projection): "
+            "transforms mutate specific paths and pass everything else through. "
+            "Channel-agnostic — applied inside the handler, so voice + chat + "
+            "any future channel benefit uniformly. Use the registered transform "
+            "names from handlers/transport/utils/response_transform.py."
+        ),
     )
 
 

--- a/app/ai/voice/agents/breeze_buddy/template/ui_catalog.py
+++ b/app/ai/voice/agents/breeze_buddy/template/ui_catalog.py
@@ -1,0 +1,660 @@
+"""Typed SpecStream / A2UI component catalog + group registry.
+
+Each primitive is a Pydantic ``BaseModel`` describing the ``props`` allowed
+on an ``add`` / ``replace`` op for that ``type``. Catalog is the runtime
+source of truth — validation, healing, JIT instruction targets, renderer
+contracts, and system-prompt rendering all consult it.
+
+The catalog is partitioned into **groups** (``core`` / ``composite`` /
+``graphs`` / ``metrics`` / ``forms`` / ``media`` / ``data``). Templates
+declare which groups + optional one-offs are enabled per merchant via
+``configurations.ui_catalog`` — the LLM never sees primitives that
+aren't enabled for its template. Server validation drops disabled ops
+with a distinct reason (``primitive_disabled:<type>``) so telemetry can
+separate "LLM hallucinated" from "merchant turned off".
+
+Catalog versions: a single ``v1`` URI ships the whole set. Primitives bump
+together (see SCALE_ROADMAP.md §"Open questions").
+
+Wire format (mirrors A2UI v0.9 / Vercel json-render SpecStream)::
+
+    {"op":"add","id":"root","type":"Carousel"}
+    {"op":"add","id":"p1","type":"Tile","parent":"root","props":{
+        "media":{"src":"https://...","alt":"snowboard"},
+        "title":"The Complete Snowboard",
+        "body":[{"kind":"key_value","key":"Price","value":"₹699.95"}],
+        "attributes":[{"label":"Premium","tone":"info"}],
+        "actions":[{"label":"View","action":{"type":"to_assistant","msg":"..."}}]
+    }}
+    {"op":"remove","id":"c2"}
+
+The catalog is fully commerce-agnostic — no Money, no checkout, no
+cart shape. Vertical flavor (product cards, cart lines, FAQ answers,
+appointment slots, …) lives entirely in the template's
+``tool_ui_instructions`` (JIT pattern). Upstream-provided display
+strings (e.g. ``"₹699.95"``) flow through ``Text`` / ``key_value``
+body rows; locale-aware reformatting is the upstream tool's job.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import Any, Dict, List, Literal, Optional, Set, Type, Union
+
+from pydantic import BaseModel, ConfigDict, Field, HttpUrl, field_validator
+
+CATALOG_VERSION: str = "v1"
+
+
+# ---------------------------------------------------------------------------
+# Actions — embedded inside Button.props.action and Tile actions
+# ---------------------------------------------------------------------------
+
+
+class ToAssistantAction(BaseModel):
+    """Re-enter the chat as if the shopper typed ``msg``. Identifier-carrying
+    messages are how row-scoped buttons round-trip context (e.g. include the
+    product id in the message).
+
+    ``display`` lets the shopper see a clean label while ``msg`` keeps the
+    identifier (e.g. ``msg='Add gid://shopify/.../12345 to cart'``,
+    ``display='Add this product to my cart'``). When absent the widget
+    falls back to a heuristic GID-stripper for the user bubble; backend
+    always receives the full ``msg``."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    type: Literal["to_assistant"] = "to_assistant"
+    msg: str = Field(
+        ..., min_length=1, description="Message to deliver back to the agent."
+    )
+    display: Optional[str] = Field(
+        None,
+        description=(
+            "Optional user-facing label shown in the chat bubble instead of "
+            "``msg``. Use whenever ``msg`` contains technical context (GIDs, "
+            "UUIDs, raw payloads) that the shopper shouldn't see."
+        ),
+    )
+
+
+class OpenUrlAction(BaseModel):
+    """Open ``url`` in a new tab. Server-provided URLs only."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    type: Literal["open_url"] = "open_url"
+    url: HttpUrl
+
+
+ActionUnion = Union[ToAssistantAction, OpenUrlAction]
+
+
+# ---------------------------------------------------------------------------
+# Base — forbid unknown props so the healer can deterministically strip them
+# ---------------------------------------------------------------------------
+
+
+class _CatalogBase(BaseModel):
+    """All primitive schemas inherit this. ``extra='forbid'`` makes Pydantic
+    raise on unknown keys; the healer's ``_rule_strip_unknown_props`` rule
+    catches and removes them before validation runs."""
+
+    model_config = ConfigDict(extra="forbid")
+
+
+# ---------------------------------------------------------------------------
+# Layout primitives (group: core)
+# ---------------------------------------------------------------------------
+
+
+class Stack(_CatalogBase):
+    """Vertical stack container. Children added via subsequent ``add`` ops
+    with this op's id as ``parent``."""
+
+    gap: Optional[Literal["sm", "md", "lg"]] = Field(
+        None, description="Spacing between children. Defaults to md."
+    )
+
+
+class Row(_CatalogBase):
+    """Horizontal row container."""
+
+    gap: Optional[Literal["sm", "md", "lg"]] = None
+    align: Optional[Literal["start", "center", "end", "between"]] = None
+
+
+class Card(_CatalogBase):
+    """Bordered card surface. Use for freeform composition. PREFER ``Tile``
+    when rendering "items in a list" — Tile is uniform by construction."""
+
+    variant: Optional[Literal["default", "muted", "highlighted"]] = None
+
+
+class CardHeader(_CatalogBase):
+    """Heading row inside a Card. Usually contains a Text and optional Tag."""
+
+    title: str = Field(..., description="Heading text.")
+    subtitle: Optional[str] = None
+
+
+# ---------------------------------------------------------------------------
+# Content primitives (group: core)
+# ---------------------------------------------------------------------------
+
+
+class Image(_CatalogBase):
+    """Product image / illustration. Renderer applies object-fit cover."""
+
+    src: HttpUrl
+    alt: str = Field(..., description="Alt text — never empty.")
+    aspect: Optional[Literal["1:1", "4:3", "16:9"]] = "1:1"
+
+
+class Text(_CatalogBase):
+    """Prose, captions, body copy. Use the tool response's pre-formatted
+    display string verbatim for things like prices — never invent or
+    reformat locale-specific values."""
+
+    text: str = Field(..., min_length=1)
+    variant: Optional[Literal["body", "caption", "heading", "muted"]] = "body"
+
+
+class Carousel(_CatalogBase):
+    """Horizontal-scrolling list. Children typically Tiles (preferred) or Cards."""
+
+    snap: Optional[bool] = True
+
+
+class Tag(_CatalogBase):
+    """Chip-shaped attribute. Use for categorical attributes, not for
+    descriptive prose (that's Text)."""
+
+    text: str = Field(..., min_length=1)
+    tone: Optional[Literal["neutral", "positive", "warning", "info"]] = "neutral"
+
+
+# ---------------------------------------------------------------------------
+# Action primitives (group: core)
+# ---------------------------------------------------------------------------
+
+
+class Button(_CatalogBase):
+    """Single button. ``action`` MUST validate as ``ActionUnion``."""
+
+    label: str = Field(..., min_length=1)
+    action: ActionUnion
+    variant: Optional[Literal["primary", "secondary", "ghost"]] = "primary"
+
+    @field_validator("action", mode="before")
+    @classmethod
+    def _normalize_action(cls, v: Any) -> Any:
+        return v
+
+
+class Buttons(_CatalogBase):
+    """Inline row of buttons."""
+
+    align: Optional[Literal["start", "center", "end"]] = "start"
+
+
+# ---------------------------------------------------------------------------
+# Data primitives (group: core)
+# ---------------------------------------------------------------------------
+
+
+class Table(_CatalogBase):
+    """Tabular data. ``columns`` is a list of header labels; ``rows`` is a
+    list of equal-length string lists. NEVER render arrays inside Text."""
+
+    columns: List[str] = Field(..., min_length=1)
+    rows: List[List[str]] = Field(default_factory=list)
+
+    @field_validator("rows")
+    @classmethod
+    def _rows_match_columns(cls, v: List[List[str]], info: Any) -> List[List[str]]:
+        cols = info.data.get("columns") or []
+        for i, row in enumerate(v):
+            if len(row) != len(cols):
+                raise ValueError(f"row {i} has {len(row)} cells; expected {len(cols)}")
+        return v
+
+
+# ---------------------------------------------------------------------------
+# Typed primitives — the "new 3" that motivated the SpecStream migration
+# (group: core)
+# ---------------------------------------------------------------------------
+
+
+class MessageSeverity(str, Enum):
+    info = "info"
+    warning = "warning"
+    error = "error"
+    success = "success"
+
+
+class MessageResolution(str, Enum):
+    """Drives a fixed UI affordance — closed enum, no surprises.
+
+    * ``recoverable`` — silent retry; renderer shows nothing.
+    * ``requires_user_input`` — render an inline form bound to ``param``.
+    * ``requires_user_confirmation`` — render a confirm CTA.
+    * ``unrecoverable`` — render a Handoff with a continue_url.
+    """
+
+    recoverable = "recoverable"
+    requires_user_input = "requires_user_input"
+    requires_user_confirmation = "requires_user_confirmation"
+    unrecoverable = "unrecoverable"
+
+
+class Message(_CatalogBase):
+    """Spec-driven user notification. Severity + resolution mechanically
+    drive UI — the LLM never picks visual treatment."""
+
+    severity: MessageSeverity
+    resolution: MessageResolution
+    content: str = Field(..., min_length=1)
+    param: Optional[str] = Field(
+        None,
+        description=(
+            "JSONPath into the underlying tool payload — used when "
+            "``resolution == requires_user_input`` to bind the inline form."
+        ),
+    )
+
+
+class HandoffLifecycle(str, Enum):
+    """How the widget transitions when the user takes the handoff.
+
+    * ``popup`` — ``window.open`` and poll a completion token (10s default).
+    * ``same_tab`` — set ``location.href`` directly.
+    * ``polling`` — widget shows a shimmer and polls a completion endpoint
+      without leaving the chat.
+    """
+
+    popup = "popup"
+    same_tab = "same_tab"
+    polling = "polling"
+
+
+class Handoff(_CatalogBase):
+    """Typed handoff URL. Replaces ad-hoc ``OpenUrl`` button actions where
+    the URL has lifecycle semantics (checkout, auth, 3DS, escalation, …)."""
+
+    reason: str = Field(
+        ...,
+        description=(
+            "Stable string identifying the handoff intent — e.g. "
+            "'checkout', 'auth', '3ds', 'compliance_review', 'escalation'."
+        ),
+    )
+    label: str = Field(..., min_length=1, description="Human-visible CTA text.")
+    url: HttpUrl
+    lifecycle: HandoffLifecycle
+
+
+# ---------------------------------------------------------------------------
+# Composite primitives (group: composite)
+#
+# Tile is the generic uniform "item in a list" primitive. The renderer
+# owns the layout (media → eyebrow → title → subtitle → body → attributes →
+# actions); the LLM fills slots. Use Tile for product cards, cart lines,
+# order summaries, FAQ answers, appointments — anywhere a uniform shape
+# matters more than per-item composition flexibility.
+# ---------------------------------------------------------------------------
+
+
+class TileMedia(BaseModel):
+    """Image-ish thing at the top of a Tile. Same fields as the Image
+    primitive but nested as a structured slot instead of a child op."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    src: HttpUrl
+    alt: str = Field(..., min_length=1, description="Alt text — never empty.")
+    aspect: Optional[Literal["1:1", "4:3", "16:9"]] = "1:1"
+
+
+class TileBodyKind(str, Enum):
+    """Polymorphic body item discriminator. Adding a new kind is a deliberate
+    catalog bump — closed set keeps render deterministic."""
+
+    text = "text"
+    key_value = "key_value"
+    message = "message"
+
+
+class TileBodyItem(BaseModel):
+    """One polymorphic row in a Tile's body.
+
+    Set ``kind`` plus the matching field for that kind; other fields are
+    ignored. Pydantic's ``extra='forbid'`` rejects mistakes.
+
+    Examples::
+
+        {"kind": "text", "text": "Limited edition release"}
+        {"kind": "key_value", "key": "Price", "value": "₹699.95"}
+        {"kind": "key_value", "key": "Material", "value": "Wood + epoxy"}
+        {"kind": "message", "message": {"severity":"warning", "resolution":"recoverable", "content":"Low stock"}}
+
+    Numeric-money values flow through ``key_value`` (or ``text``) using the
+    upstream tool's pre-formatted display string — the catalog stays
+    commerce-agnostic.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    kind: TileBodyKind
+    text: Optional[str] = Field(None, description="Set when kind == text.")
+    key: Optional[str] = Field(None, description="Set when kind == key_value.")
+    value: Optional[str] = Field(None, description="Set when kind == key_value.")
+    message: Optional[Message] = Field(None, description="Set when kind == message.")
+
+
+class TileAttribute(BaseModel):
+    """One chip in the attribute row. Maps to a Tag at render time."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    label: str = Field(..., min_length=1)
+    tone: Optional[Literal["neutral", "positive", "warning", "info"]] = "neutral"
+
+
+class TileAction(BaseModel):
+    """One button in the action row at the bottom of a Tile."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    label: str = Field(..., min_length=1)
+    action: ActionUnion
+    variant: Optional[Literal["primary", "secondary", "ghost"]] = "primary"
+
+
+class Tile(_CatalogBase):
+    """Generic uniform composite — slot-filled card.
+
+    Renderer owns the layout (top → bottom):
+
+      ┌─────────────────────┐
+      │       media         │   optional, fixed-aspect at top
+      ├─────────────────────┤
+      │ EYEBROW             │   optional, small label
+      │ Title               │   required, prominent
+      │ subtitle            │   optional, secondary
+      │ body rows…          │   polymorphic content
+      │ [attr1] [attr2] …   │   optional chip row
+      │ [Action]  [Action]  │   button row at bottom
+      └─────────────────────┘
+
+    Every Tile in the same parent (typically a Carousel or Stack) renders
+    the SAME shape — picking Tile over hand-composed Card+Image+Text+Tag
+    children guarantees visual uniformity even if the LLM forgets a slot
+    on some items. Missing slots simply don't render — the layout stays
+    intact.
+
+    Density tunes padding + gap tokens:
+      * ``compact``  — tight rows, list-line use case
+      * ``default``  — standard product-card use case
+      * ``spacious`` — order summary / confirm card use case
+
+    Layout chooses media placement:
+      * ``card``  — media on TOP (default); use for carousel/grid items
+        and detail views.
+      * ``row``   — media on LEFT as a small thumbnail; use for line items
+        in a vertical list (cart, transactions, inbox, history). In a
+        Stack of row-layout Tiles, per-tile card chrome is suppressed in
+        favour of hairline separators between siblings — the list reads
+        as a single coherent block, not a column of cards.
+    """
+
+    media: Optional[TileMedia] = None
+    eyebrow: Optional[str] = Field(
+        None, description="Small uppercase label above title (e.g. 'NEW', 'SALE')."
+    )
+    title: str = Field(..., min_length=1, description="The Tile's primary heading.")
+    subtitle: Optional[str] = Field(
+        None, description="Optional secondary line under title."
+    )
+    trailing: Optional[str] = Field(
+        None,
+        description=(
+            "Prominent right-aligned value at the title row. Used most often "
+            "in ``layout='row'`` to surface a price, total, count, or status "
+            "without needing a labeled key_value body row. Typically a short "
+            "display string (currency, count, percentage)."
+        ),
+    )
+    body: List[TileBodyItem] = Field(
+        default_factory=list,
+        description="Polymorphic content rows (text / money / key_value / message).",
+    )
+    attributes: List[TileAttribute] = Field(
+        default_factory=list,
+        description="Optional chip row above the actions row.",
+    )
+    actions: List[TileAction] = Field(
+        default_factory=list,
+        description="Optional button row at the bottom of the Tile.",
+    )
+    density: Optional[Literal["compact", "default", "spacious"]] = "default"
+    layout: Optional[Literal["card", "row"]] = "card"
+
+
+# ---------------------------------------------------------------------------
+# Catalog manifest + group registry
+# ---------------------------------------------------------------------------
+
+
+UI_CATALOG: Dict[str, Type[_CatalogBase]] = {
+    # Layout (core)
+    "Stack": Stack,
+    "Row": Row,
+    "Card": Card,
+    "CardHeader": CardHeader,
+    # Content (core)
+    "Image": Image,
+    "Text": Text,
+    "Carousel": Carousel,
+    "Tag": Tag,
+    # Actions (core)
+    "Button": Button,
+    "Buttons": Buttons,
+    # Data (core)
+    "Table": Table,
+    # Typed (core)
+    "Message": Message,
+    "Handoff": Handoff,
+    # Composite
+    "Tile": Tile,
+}
+
+
+# Group registry — each primitive belongs to exactly one group. Adding a
+# new group means adding a key here AND, for system-prompt rendering, an
+# entry in ``PRIMITIVE_RENDER_ORDER`` so the LLM sees a sensible order.
+#
+# Future groups have empty member lists today; populating them is the
+# extension path:
+#   1. Add the new primitive's Pydantic schema above
+#   2. Register it in UI_CATALOG
+#   3. Append it to the matching group's list
+#   4. Add render-order entry
+#   5. Add a Svelte component + UiNode dispatch on the widget side
+#   6. Templates opt in via ``ui_catalog.enabled_groups``
+PRIMITIVE_GROUPS: Dict[str, List[str]] = {
+    "core": [
+        "Stack",
+        "Row",
+        "Card",
+        "CardHeader",
+        "Image",
+        "Text",
+        "Carousel",
+        "Tag",
+        "Button",
+        "Buttons",
+        "Table",
+        "Message",
+        "Handoff",
+    ],
+    "composite": [
+        "Tile",
+    ],
+    # Reserved for future expansion — schemas + widget components land
+    # behind these group flags so existing templates aren't affected.
+    "graphs": [
+        # "LineChart", "BarChart", "PieChart", "AreaChart"
+    ],
+    "metrics": [
+        # "KPI", "Sparkline", "MetricCard", "ProgressBar"
+    ],
+    "forms": [
+        # "TextInput", "Select", "Checkbox", "RadioGroup"
+        # — required for `requires_user_input` Messages in S3.3
+    ],
+    "media": [
+        # "Video", "Audio", "Embed"
+    ],
+    "data": [
+        # "DataGrid", "Pivot", "TreeView"
+    ],
+}
+
+
+# Order in which primitives appear in the system-prompt rendering. Listed
+# composite-first so the LLM defaults to Tile for list items, then core
+# building blocks for freeform composition.
+PRIMITIVE_RENDER_ORDER: List[str] = [
+    # Composite first — preferred for list items
+    "Tile",
+    # Layout containers
+    "Carousel",
+    "Stack",
+    "Row",
+    "Card",
+    "CardHeader",
+    # Content
+    "Image",
+    "Text",
+    "Tag",
+    # Actions
+    "Button",
+    "Buttons",
+    "Handoff",
+    # Data
+    "Table",
+    # Notifications
+    "Message",
+]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def group_for(type_name: str) -> Optional[str]:
+    """Return the group name a primitive belongs to, or None if unknown."""
+    for group_name, members in PRIMITIVE_GROUPS.items():
+        if type_name in members:
+            return group_name
+    return None
+
+
+def is_known_type(type_name: str) -> bool:
+    """True when ``type_name`` is a registered primitive (regardless of
+    whether any template has it enabled)."""
+    return type_name in UI_CATALOG
+
+
+def resolve_allowlist(
+    *,
+    enabled_groups: Optional[List[str]] = None,
+    enabled_primitives: Optional[List[str]] = None,
+    disabled_primitives: Optional[List[str]] = None,
+) -> Set[str]:
+    """Resolve a template's UI-catalog config into a concrete allowlist set.
+
+    Precedence (highest → lowest):
+      1. ``disabled_primitives`` always wins (remove from the result).
+      2. ``enabled_primitives`` adds one-offs even if their group isn't
+         in ``enabled_groups``.
+      3. ``enabled_groups`` expands to all primitives in those groups.
+
+    Unknown group names and primitive names are silently ignored so a
+    stale template doesn't crash a session.
+
+    When ``enabled_groups`` is None (the absent-config case), the default
+    is ``{"core"}`` — keeps backward compatibility with templates that
+    pre-date ``configurations.ui_catalog``.
+    """
+    if enabled_groups is None and not enabled_primitives:
+        enabled_groups = ["core"]
+    enabled_groups = enabled_groups or []
+    enabled_primitives = enabled_primitives or []
+    # Use a distinct variable name for the set form so pyrefly can keep the
+    # parameter's `Optional[List[str]]` type intact (reassigning would shift
+    # the binding to `set[str]` and trip downstream type checks).
+    disabled_set: Set[str] = set(disabled_primitives or [])
+
+    result: Set[str] = set()
+    for group in enabled_groups:
+        for prim in PRIMITIVE_GROUPS.get(group, []):
+            result.add(prim)
+    for prim in enabled_primitives:
+        if prim in UI_CATALOG:
+            result.add(prim)
+    result -= disabled_set
+    # Drop anything that's no longer a registered primitive (defensive
+    # against templates referencing names that the catalog removed in a
+    # later bump).
+    result &= set(UI_CATALOG.keys())
+    return result
+
+
+def validate_props(type_name: str, props: Dict[str, Any]) -> _CatalogBase:
+    """Validate ``props`` against the primitive's Pydantic schema.
+
+    Raises ``pydantic.ValidationError`` on mismatch — caller decides whether
+    to drop the op, heal it, or surface to the LLM.
+    """
+    schema = UI_CATALOG[type_name]
+    return schema.model_validate(props or {})
+
+
+__all__ = [
+    "CATALOG_VERSION",
+    "UI_CATALOG",
+    "PRIMITIVE_GROUPS",
+    "PRIMITIVE_RENDER_ORDER",
+    "group_for",
+    "is_known_type",
+    "resolve_allowlist",
+    "validate_props",
+    "ToAssistantAction",
+    "OpenUrlAction",
+    "ActionUnion",
+    "Stack",
+    "Row",
+    "Card",
+    "CardHeader",
+    "Image",
+    "Text",
+    "Carousel",
+    "Tag",
+    "Button",
+    "Buttons",
+    "Table",
+    "Message",
+    "MessageSeverity",
+    "MessageResolution",
+    "Handoff",
+    "HandoffLifecycle",
+    "Tile",
+    "TileMedia",
+    "TileBodyKind",
+    "TileBodyItem",
+    "TileAttribute",
+    "TileAction",
+]

--- a/app/ai/voice/agents/breeze_buddy/template/ui_prompt.py
+++ b/app/ai/voice/agents/breeze_buddy/template/ui_prompt.py
@@ -1,0 +1,436 @@
+"""Render the ``## Available primitives`` section of the system prompt.
+
+The LLM sees a per-template, per-merchant slice of the primitive catalog.
+At session start the chat agent resolves the allowlist (see
+``UiCatalogConfig`` + ``resolve_allowlist``) and the builder splices the
+output of :func:`render_primitives_section` into the template's
+``system_prompt`` wherever the literal placeholder
+``{{ui_primitives_section}}`` appears.
+
+The rendering is deliberately introspection-driven so the prompt always
+matches the runtime schema — adding a new primitive (or a new field on
+an existing one) updates the prompt automatically; the catalog stays
+the single source of truth.
+
+Format is terse — the LLM reads this every turn:
+
+    **Tile** — Generic uniform composite — slot-filled card.
+      Props:
+        media?: {src*: HttpUrl, alt*: str, ...}
+        title*: str
+        ...
+      Example: {"op":"add",...}
+
+Asterisks mark required fields; question marks mark optional fields.
+``Literal[...]`` enums render as ``"a"|"b"``; nested Pydantic submodels
+render with their own brace-shape; ``List[T]`` renders as ``[T-shape]``.
+"""
+
+from __future__ import annotations
+
+import enum
+import json
+import typing
+from typing import Any, Dict, List, Set, Type, TypeGuard, Union, get_args, get_origin
+
+from pydantic import BaseModel
+
+from app.ai.voice.agents.breeze_buddy.template.ui_catalog import (
+    PRIMITIVE_RENDER_ORDER,
+    UI_CATALOG,
+)
+
+# ---------------------------------------------------------------------------
+# Hard-coded minimal-but-realistic examples per primitive. The LLM cribs from
+# these for the JIT few-shot pattern, so they must round-trip through
+# ``validate_props`` cleanly. Keep them small — one op per primitive.
+# ---------------------------------------------------------------------------
+
+
+_EXAMPLES: Dict[str, Dict[str, Any]] = {
+    "Tile": {
+        "op": "add",
+        "id": "p1",
+        "type": "Tile",
+        "parent": "root",
+        "props": {
+            "media": {"src": "https://x/y.jpg", "alt": "snowboard"},
+            "title": "The Complete Snowboard",
+            "body": [{"kind": "key_value", "key": "Price", "value": "₹699.95"}],
+            "attributes": [{"label": "Premium", "tone": "info"}],
+            "actions": [
+                {
+                    "label": "View",
+                    "action": {
+                        "type": "to_assistant",
+                        "msg": "Tell me about <id>",
+                    },
+                }
+            ],
+        },
+    },
+    "Carousel": {
+        "op": "add",
+        "id": "c1",
+        "type": "Carousel",
+        "parent": "root",
+        "props": {"snap": True},
+    },
+    "Stack": {
+        "op": "add",
+        "id": "s1",
+        "type": "Stack",
+        "parent": "root",
+        "props": {"gap": "md"},
+    },
+    "Card": {
+        "op": "add",
+        "id": "card1",
+        "type": "Card",
+        "parent": "root",
+        "props": {"variant": "default"},
+    },
+    "Image": {
+        "op": "add",
+        "id": "img1",
+        "type": "Image",
+        "parent": "card1",
+        "props": {
+            "src": "https://x/y.jpg",
+            "alt": "snowboard",
+            "aspect": "4:3",
+        },
+    },
+    "Text": {
+        "op": "add",
+        "id": "t1",
+        "type": "Text",
+        "parent": "card1",
+        "props": {"text": "Limited edition release", "variant": "body"},
+    },
+    "Tag": {
+        "op": "add",
+        "id": "tag1",
+        "type": "Tag",
+        "parent": "card1",
+        "props": {"text": "New", "tone": "info"},
+    },
+    "Button": {
+        "op": "add",
+        "id": "btn1",
+        "type": "Button",
+        "parent": "card1",
+        "props": {
+            "label": "View",
+            "action": {
+                "type": "to_assistant",
+                "msg": "Tell me more about <id>",
+            },
+            "variant": "primary",
+        },
+    },
+    "Handoff": {
+        "op": "add",
+        "id": "h1",
+        "type": "Handoff",
+        "parent": "root",
+        "props": {
+            "reason": "<intent>",
+            "label": "Continue",
+            "url": "https://example/handoff/abc",
+            "lifecycle": "popup",
+        },
+    },
+    "Message": {
+        "op": "add",
+        "id": "msg1",
+        "type": "Message",
+        "parent": "root",
+        "props": {
+            "severity": "warning",
+            "resolution": "recoverable",
+            "content": "Temporary issue retrieving data.",
+        },
+    },
+    "Table": {
+        "op": "add",
+        "id": "tbl1",
+        "type": "Table",
+        "parent": "root",
+        "props": {
+            "columns": ["Item", "Qty", "Total"],
+            "rows": [["Item A", "1", "100"]],
+        },
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# Type rendering — extract a terse signature from a Pydantic field annotation
+# ---------------------------------------------------------------------------
+
+
+# Pydantic adds a metadata layer around HttpUrl that's awkward to walk.
+# We special-case it (and other common types) for cleaner output.
+_TYPE_NAME_MAP: Dict[Any, str] = {
+    str: "str",
+    int: "int",
+    float: "float",
+    bool: "bool",
+}
+
+
+def _is_pydantic_model(t: Any) -> TypeGuard[Type[BaseModel]]:
+    """TypeGuard so callers' subsequent uses of ``t`` narrow to
+    ``Type[BaseModel]`` for static analysers without needing a cast."""
+    return isinstance(t, type) and issubclass(t, BaseModel)
+
+
+def _render_literal(args: tuple) -> str:
+    """Render Literal["a","b"] as ``"a"|"b"``."""
+    return "|".join(f'"{a}"' if isinstance(a, str) else str(a) for a in args)
+
+
+def _render_type(t: Any, *, recurse_models: bool = True) -> str:
+    """Best-effort terse rendering of a Pydantic field annotation.
+
+    The renderer doesn't aim to be a full type printer — it produces
+    something terse enough for the system prompt while still hinting at
+    nested shape. ``recurse_models=False`` short-circuits nested model
+    expansion (used to render ``List[Model]`` as ``[Model-shape]``
+    without recursing twice).
+    """
+    if t is type(None):
+        return "null"
+    if t in _TYPE_NAME_MAP:
+        return _TYPE_NAME_MAP[t]
+
+    origin = get_origin(t)
+    args = get_args(t)
+
+    # Optional[T] / Union[T, None] — unwrap and render inner.
+    if origin is Union:
+        non_none = [a for a in args if a is not type(None)]
+        if len(non_none) == 1:
+            return _render_type(non_none[0], recurse_models=recurse_models)
+        return "|".join(
+            _render_type(a, recurse_models=recurse_models) for a in non_none
+        )
+
+    # Literal["a", "b"]
+    if origin is typing.Literal:
+        return _render_literal(args)
+
+    # List[T] → [T-shape]
+    if origin in (list, List):
+        if not args:
+            return "[]"
+        inner = args[0]
+        if _is_pydantic_model(inner):
+            return f"[{_render_model_inline(inner)}]"
+        return f"[{_render_type(inner, recurse_models=recurse_models)}]"
+
+    # Dict[K, V]
+    if origin in (dict, Dict):
+        if len(args) == 2:
+            return f"{{{_render_type(args[0])}: {_render_type(args[1])}}}"
+        return "dict"
+
+    # Pydantic model — render inline shape.
+    if _is_pydantic_model(t):
+        if recurse_models:
+            return _render_model_inline(t)
+        return t.__name__
+
+    # Enum subclass — render its values as a Literal-style union so the LLM
+    # sees the actual allowed strings rather than the opaque class name.
+    if isinstance(t, type) and issubclass(t, enum.Enum):
+        return "|".join(
+            f'"{m.value}"' if isinstance(m.value, str) else str(m.value) for m in t
+        )
+
+    # HttpUrl, custom types — fall back to class name.
+    if isinstance(t, type):
+        return t.__name__
+
+    # Anything else — string-cast and trim ``typing.`` prefix.
+    s = str(t)
+    if s.startswith("typing."):
+        s = s[len("typing.") :]
+    return s
+
+
+def _render_model_inline(model: Type[BaseModel]) -> str:
+    """Render a nested model as ``{field*: type, optional?: type}``.
+
+    Stops recursing into further nested models — second-level nesting
+    just shows the field names without their full sub-shape, to keep
+    the prompt readable. ``Message``-inside-``TileBodyItem`` shows as
+    ``message?: {severity*, resolution*, content*, param?}`` which is
+    what the spec calls for.
+    """
+    parts: List[str] = []
+    for fname, field in model.model_fields.items():
+        required = field.is_required()
+        suffix = "*" if required else "?"
+        ann = field.annotation
+        # For doubly-nested models, just show the field-name shape (one
+        # level of detail) — no annotation. ``{amount*, currency*}``.
+        inner_origin = get_origin(ann)
+        inner_args = get_args(ann)
+        non_none = (
+            [a for a in inner_args if a is not type(None)]
+            if inner_origin is Union
+            else []
+        )
+        target = non_none[0] if len(non_none) == 1 else ann
+        if _is_pydantic_model(target):
+            parts.append(f"{fname}{suffix}: {_render_nested_shape(target)}")
+        else:
+            parts.append(f"{fname}{suffix}: {_render_type(ann, recurse_models=False)}")
+    return "{" + ", ".join(parts) + "}"
+
+
+def _render_nested_shape(model: Type[BaseModel]) -> str:
+    """One-level-deep summary: ``{field*, other?}`` — just names + req markers.
+
+    Used for second-level nesting so the prompt doesn't explode. Caller
+    has already rendered the outer model's field name; this fills the
+    type column.
+    """
+    parts: List[str] = []
+    for fname, field in model.model_fields.items():
+        parts.append(f"{fname}{'*' if field.is_required() else '?'}")
+    return "{" + ", ".join(parts) + "}"
+
+
+def _render_top_level_field(fname: str, field: Any) -> str:
+    """Render one ``Name: type`` line for a top-level primitive field."""
+    required = field.is_required()
+    suffix = "*" if required else "?"
+    ann = field.annotation
+
+    # Unwrap Optional[T] for clearer top-level output.
+    origin = get_origin(ann)
+    args = get_args(ann)
+    if origin is Union:
+        non_none = [a for a in args if a is not type(None)]
+        if len(non_none) == 1:
+            ann = non_none[0]
+            origin = get_origin(ann)
+            args = get_args(ann)
+
+    # List[T] → ``[shape]``
+    if origin in (list, List) and args:
+        inner = args[0]
+        if _is_pydantic_model(inner):
+            return f"{fname}{suffix}: [{_render_model_inline(inner)}]"
+        return f"{fname}{suffix}: [{_render_type(inner)}]"
+
+    # Top-level nested model — render inline shape.
+    if _is_pydantic_model(ann):
+        return f"{fname}{suffix}: {_render_model_inline(ann)}"
+
+    # Literal at top level (e.g. density).
+    if origin is typing.Literal:
+        return f"{fname}{suffix}: {_render_literal(args)}"
+
+    # Plain scalar / HttpUrl / Enum.
+    return f"{fname}{suffix}: {_render_type(ann)}"
+
+
+# ---------------------------------------------------------------------------
+# Per-primitive entry
+# ---------------------------------------------------------------------------
+
+
+def _purpose_line(model: Type[BaseModel]) -> str:
+    """Extract the first non-empty line of the model's docstring."""
+    doc = model.__doc__ or ""
+    for line in doc.split("\n"):
+        line = line.strip()
+        if line:
+            return line
+    return ""
+
+
+def _render_entry(name: str, model: Type[BaseModel]) -> str:
+    """Render one primitive's entry: name, purpose, props, example."""
+    lines: List[str] = []
+    lines.append(f"**{name}** — {_purpose_line(model)}")
+
+    fields = model.model_fields
+    if fields:
+        lines.append("  Props:")
+        for fname, field in fields.items():
+            lines.append(f"    {_render_top_level_field(fname, field)}")
+    else:
+        lines.append("  Props: (none)")
+
+    example = _EXAMPLES.get(name)
+    if example is not None:
+        lines.append(f"  Example: {json.dumps(example, separators=(',', ':'))}")
+
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Top-level section
+# ---------------------------------------------------------------------------
+
+
+_HEADER = (
+    "## Available primitives\n"
+    "\n"
+    "Use ONLY these primitive types in <ui_stream> ops. The server drops "
+    "unknown or disabled types silently. Asterisk (*) marks required props."
+)
+
+_FOOTER = (
+    "Action shape (embedded inside Button/Tile/Handoff):\n"
+    '  {type:"to_assistant", msg*: string}  — re-enter the chat as if '
+    "the user typed `msg`\n"
+    '  {type:"open_url", url*: HttpUrl}     — open a URL in a new tab\n'
+    "\n"
+    "Composition rules:\n"
+    '  - Root id is always "root"; root op omits `parent`.\n'
+    "  - All non-root `add` ops MUST have `parent`.\n"
+    "  - `replace` swaps props on an existing id; `remove` deletes a node.\n"
+    '  - For "items in a list", emit ONE Tile per item — never compose '
+    "Card+Image+Text manually."
+)
+
+_EMPTY_BODY = (
+    "(No primitives are enabled for this template. The widget will render "
+    "nothing — keep responses prose-only.)"
+)
+
+
+def render_primitives_section(allowlist: Set[str]) -> str:
+    """Render the ``## Available primitives`` section for an allowlist.
+
+    Walks ``PRIMITIVE_RENDER_ORDER`` and emits one entry per primitive
+    that is both in the catalog and in ``allowlist``. Names appearing in
+    the allowlist but not in the render order are silently skipped — the
+    render order is the curated, human-tuned sequence the LLM should
+    read.
+
+    An empty allowlist returns a section with the header + a short
+    "nothing enabled" note + the footer, so the prompt still parses and
+    the LLM understands the situation rather than crashing on missing
+    text.
+    """
+    entries: List[str] = []
+    for name in PRIMITIVE_RENDER_ORDER:
+        if name not in allowlist:
+            continue
+        model = UI_CATALOG.get(name)
+        if model is None:
+            continue
+        entries.append(_render_entry(name, model))
+
+    body = "\n\n".join(entries) if entries else _EMPTY_BODY
+    return f"{_HEADER}\n\n{body}\n\n{_FOOTER}"
+
+
+__all__ = ["render_primitives_section"]

--- a/app/api/routers/breeze_buddy/__init__.py
+++ b/app/api/routers/breeze_buddy/__init__.py
@@ -28,6 +28,12 @@ from app.api.routers.breeze_buddy.templates import router as templates_router
 from app.api.routers.breeze_buddy.users import router as users_router
 from app.api.routers.breeze_buddy.websocket import router as websocket_router
 
+# Widget public mode (CHAT_MODE.md §14): per-merchant widget_config
+# CRUD (RBAC) + the unified /widget/session conversation router
+# (anonymous, public_widget_key + Origin gated).
+from app.api.routers.breeze_buddy.widget import router as widget_router
+from app.api.routers.breeze_buddy.widget_config import router as widget_config_router
+
 router = APIRouter()
 
 # ============================================================================
@@ -86,3 +92,9 @@ router.include_router(daily_router, prefix="", tags=["daily"])
 
 # Chat (text-mode sessions: REST + SSE, no STT/TTS/VAD)
 router.include_router(chat_router, prefix="", tags=["chat"])
+
+# Widget public mode (CHAT_MODE.md §14)
+# - widget_config: per-merchant config (admin/reseller-scoped CRUD)
+# - widget: unified /widget/session/* conversation router (chat ↔ voice)
+router.include_router(widget_config_router, prefix="", tags=["widget-config"])
+router.include_router(widget_router, prefix="", tags=["widget-session"])

--- a/app/api/routers/breeze_buddy/chat/__init__.py
+++ b/app/api/routers/breeze_buddy/chat/__init__.py
@@ -28,7 +28,7 @@ For module layout this mirrors the leads router:
 - ``rbac.py`` — reseller / merchant access validators.
 """
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Response, status
 
 from app.ai.voice.agents.breeze_buddy.template.cache import get_template_by_id_cached
 from app.api.security.breeze_buddy.rbac_token import get_current_user_with_rbac
@@ -44,6 +44,7 @@ from app.schemas.breeze_buddy.chat import (
 
 from .demo import router as demo_router
 from .handlers import (
+    cancel_chat_turn_handler,
     create_chat_session_handler,
     end_chat_session_handler,
     get_chat_session_handler,
@@ -153,6 +154,39 @@ async def send_message(
         validate_chat_session_access(current_user, session, operation="send_message")
 
     return await send_chat_message_handler(session_id, req, access_check=_check)
+
+
+@router.post(
+    "/session/{session_id}/cancel",
+    status_code=status.HTTP_202_ACCEPTED,
+    summary="Cancel an in-flight chat turn (Stop button)",
+)
+async def cancel_turn(
+    session_id: str,
+    current_user: UserInfo = Depends(get_current_user_with_rbac),
+) -> Response:
+    """Cancel the in-flight ``/message`` SSE stream for ``session_id``.
+
+    Best-effort and idempotent — returns 202 regardless of whether a
+    turn was actually running. The owning pod cancels its asyncio task;
+    the stream's ``finally`` releases the per-session Redis lock so the
+    next ``/message`` can proceed immediately instead of waiting on
+    the lock TTL.
+
+    RBAC:
+    - Admin: Can cancel any session
+    - Reseller / Merchant: Must own the session (404 otherwise)
+
+    The earlier "auth-only" model (skip the session lookup, treat cancel
+    as harmless) was a DoS / griefing vector — any authenticated user
+    could cancel any tenant's in-flight turn by guessing/leaking session
+    UUIDs. The cost of one indexed SELECT is well under the LLM round-trip
+    we're cancelling.
+    """
+    session = await load_chat_session_or_404(session_id)
+    validate_chat_session_access(current_user, session, operation="cancel_turn")
+    await cancel_chat_turn_handler(session_id)
+    return Response(status_code=status.HTTP_202_ACCEPTED)
 
 
 @router.post("/session/{session_id}/end", response_model=EndChatSessionResponse)

--- a/app/api/routers/breeze_buddy/chat/cancel_bus.py
+++ b/app/api/routers/breeze_buddy/chat/cancel_bus.py
@@ -1,0 +1,249 @@
+"""
+Cross-pod cancel signalling for in-flight chat turns.
+
+Problem this solves
+-------------------
+``send_chat_message_handler`` opens an SSE stream and holds the
+per-session Redis lock until ``turn_end``. If the client aborts the
+fetch (the widget Stop button), TCP close is only surfaced when the
+server tries to write to the socket — and the agent is usually deep in
+an LLM call or MCP tool call, not yielding. So the lock stays held
+until its 180s TTL elapses, blocking any follow-up ``/message`` POST
+on the same session with a 409 ("Another turn is already in flight").
+
+How this works
+--------------
+Two cooperating pieces:
+
+1. **Per-pod task registry** (``_active_tasks``): a process-local
+   ``Dict[session_id, asyncio.Task]`` populated by ``register()`` /
+   cleared by ``unregister()`` inside the stream generator. Only the
+   pod that owns the running task can cancel it from inside its own
+   event loop — that's the whole point of the local registry.
+
+2. **Cross-pod fanout** via Redis pubsub on channel ``_CANCEL_CHANNEL``.
+   ``cancel(session_id)`` publishes the session id. Every pod runs one
+   long-lived subscriber (started in app lifespan) that looks up the
+   session in its local registry and calls ``task.cancel()`` if found.
+   Pods that don't own the task ignore the message.
+
+Cost model
+----------
+- One persistent Redis subscriber connection per pod (idle blocking on
+  ``get_message``; ~0 CPU when no cancels are firing).
+- ``_active_tasks`` adds ~200 bytes per concurrent in-flight stream.
+- Zero overhead on the hot path: the stream generator does NOT poll
+  Redis between yields. The hot path runs unchanged.
+
+Single-pod (local dev) works because pod A == pod B — the publish
+fanout still reaches the local subscriber.
+
+Failure modes
+-------------
+- Redis down at app start: subscriber start fails; cancel becomes a
+  no-op (falls back to TTL). Logged; not raised — the app shouldn't
+  fail to start because cancel is degraded.
+- ``task.cancel()`` racing with natural turn-end: harmless — the task
+  is already done, ``cancel()`` returns ``False``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Dict, Optional
+
+from redis.exceptions import RedisError
+
+from app.core.logger import logger
+from app.services.redis.client import RedisService, get_redis_service
+
+# Redis pubsub channel name. Single channel for all sessions — message
+# payload is the session_id. One channel keeps the subscriber simple
+# (no per-session subscribe/unsubscribe churn).
+_CANCEL_CHANNEL = "breeze-buddy:chat:cancel"
+
+# Process-local registry: session_id → the asyncio Task running the
+# SSE stream for that session on THIS pod. Populated by
+# ``register()`` inside the stream generator; cleared by
+# ``unregister()`` in its finally block.
+_active_tasks: Dict[str, asyncio.Task] = {}
+
+# Handle to the subscriber task started by ``start_subscriber()`` so
+# ``stop_subscriber()`` can cancel it on shutdown. ``None`` when the
+# subscriber isn't running (Redis unconfigured or start failed).
+_subscriber_task: Optional[asyncio.Task] = None
+
+
+def register(session_id: str, task: asyncio.Task) -> None:
+    """Mark ``task`` as the in-flight stream for ``session_id`` on this pod.
+
+    Overwrites any prior registration for the same session — the Redis
+    lock already enforces single-driver semantics, so a duplicate
+    registration would indicate a programming error (lock check
+    bypassed) rather than legitimate concurrent streams. We log and
+    overwrite rather than raise so the request still gets served.
+    """
+    prior = _active_tasks.get(session_id)
+    if prior is not None and not prior.done():
+        logger.warning(
+            f"cancel_bus: overwriting active task for session={session_id} "
+            "— prior task wasn't unregistered (Redis lock invariant broken?)"
+        )
+    _active_tasks[session_id] = task
+
+
+def unregister(session_id: str, task: asyncio.Task) -> None:
+    """Remove ``task`` from the registry IFF it's still the registered one.
+
+    Guarded by identity comparison so a stale ``finally`` from an older
+    cancelled task doesn't evict the registration for a newer turn that
+    raced past it.
+    """
+    current = _active_tasks.get(session_id)
+    if current is task:
+        _active_tasks.pop(session_id, None)
+
+
+async def cancel(session_id: str) -> None:
+    """Publish a cancel for ``session_id`` to every pod.
+
+    Best-effort. Returns immediately after publish; the actual
+    ``task.cancel()`` happens asynchronously on whichever pod owns the
+    task. If Redis is down, this no-ops with a warning — the caller
+    (HTTP handler) will still return 202; the lock will release on
+    TTL.
+    """
+    try:
+        redis: RedisService = await get_redis_service()
+        client = await redis.get_client()
+        # `client` is typed `Union[Redis, RedisCluster]`. Single-node Redis
+        # exposes publish/pubsub directly; RedisCluster's pubsub semantics
+        # differ (shard-scoped) and would need a separate code path. We run
+        # single-node in dev + prod today; if we ever move to Cluster, this
+        # whole module needs a cluster-aware pubsub rewrite anyway.
+        await client.publish(_CANCEL_CHANNEL, session_id)  # type: ignore[union-attr]
+        logger.debug(f"cancel_bus: published cancel for session={session_id}")
+    except (RedisError, Exception) as exc:
+        logger.warning(
+            f"cancel_bus: publish failed for session={session_id}: {exc} "
+            "— stream will only release on lock TTL"
+        )
+
+
+def _cancel_local(session_id: str) -> bool:
+    """Cancel the locally-registered task for ``session_id`` if any.
+
+    Returns ``True`` if a task was cancelled, ``False`` if the session
+    isn't running on this pod (which is the common case for multi-pod
+    deployments — only one pod ever owns a given session at a time).
+    """
+    task = _active_tasks.get(session_id)
+    if task is None:
+        return False
+    if task.done():
+        return False
+    task.cancel()
+    logger.info(f"cancel_bus: cancelled local task for session={session_id}")
+    return True
+
+
+async def _subscriber_loop() -> None:
+    """Long-lived loop: subscribe to ``_CANCEL_CHANNEL`` and fan messages
+    out to the local registry.
+
+    Reconnects with exponential backoff on Redis errors — the
+    subscriber must outlive transient network blips so cancel keeps
+    working after a Redis restart. Backoff caps at 30s.
+    """
+    backoff = 1.0
+    while True:
+        try:
+            redis: RedisService = await get_redis_service()
+            client = await redis.get_client()
+            # See `cancel()` above — single-node only path; Cluster's pubsub
+            # is shard-scoped and would need a separate connection model.
+            pubsub = client.pubsub()  # type: ignore[union-attr]
+            try:
+                await pubsub.subscribe(_CANCEL_CHANNEL)
+                logger.info(f"cancel_bus: subscribed to '{_CANCEL_CHANNEL}'")
+                backoff = 1.0
+                # ``listen()`` yields messages forever; the only normal
+                # exit is task cancellation on app shutdown.
+                async for message in pubsub.listen():
+                    if message.get("type") != "message":
+                        # Skip 'subscribe' confirmation + heartbeats.
+                        continue
+                    data = message.get("data")
+                    if isinstance(data, bytes):
+                        session_id = data.decode("utf-8", errors="replace")
+                    else:
+                        session_id = str(data)
+                    _cancel_local(session_id)
+            finally:
+                try:
+                    await pubsub.unsubscribe(_CANCEL_CHANNEL)
+                    await pubsub.aclose()
+                except Exception:
+                    pass
+        except asyncio.CancelledError:
+            logger.info("cancel_bus: subscriber cancelled (app shutdown)")
+            raise
+        except Exception as exc:
+            logger.error(
+                f"cancel_bus: subscriber error ({exc!r}); "
+                f"reconnecting in {backoff:.1f}s",
+                exc_info=True,
+            )
+            await asyncio.sleep(backoff)
+            backoff = min(backoff * 2, 30.0)
+
+
+async def start_subscriber() -> None:
+    """Start the pubsub subscriber as a background asyncio task.
+
+    Idempotent — calling twice is a no-op. Safe to call from the app
+    lifespan startup. If Redis isn't configured, this logs and returns
+    without starting the loop (cancel falls back to TTL).
+    """
+    global _subscriber_task
+    if _subscriber_task is not None and not _subscriber_task.done():
+        return
+    try:
+        # Probe Redis once before spawning the loop — gives a clean
+        # log line on misconfiguration instead of a tight reconnect
+        # spin on first message.
+        redis = await get_redis_service()
+        await redis.ping()
+    except Exception as exc:
+        logger.warning(
+            f"cancel_bus: Redis unreachable at startup ({exc!r}); "
+            "subscriber not started — cancel will fall back to lock TTL"
+        )
+        return
+    _subscriber_task = asyncio.create_task(
+        _subscriber_loop(), name="breeze-buddy-cancel-bus-subscriber"
+    )
+    logger.info("cancel_bus: subscriber task started")
+
+
+async def stop_subscriber() -> None:
+    """Cancel the pubsub subscriber. Idempotent."""
+    global _subscriber_task
+    task = _subscriber_task
+    _subscriber_task = None
+    if task is None or task.done():
+        return
+    task.cancel()
+    try:
+        await task
+    except (asyncio.CancelledError, Exception):
+        pass
+
+
+__all__ = [
+    "cancel",
+    "register",
+    "start_subscriber",
+    "stop_subscriber",
+    "unregister",
+]

--- a/app/api/routers/breeze_buddy/chat/handlers.py
+++ b/app/api/routers/breeze_buddy/chat/handlers.py
@@ -6,12 +6,16 @@ per-session Redis lock + agent lifecycle. Routes in ``__init__.py``
 stay thin: validate auth, then delegate.
 """
 
+import asyncio
 from typing import Any, AsyncIterator, Callable, Dict, Optional
 
 from fastapi import HTTPException, status
 from fastapi.responses import StreamingResponse
 
 from app.ai.voice.agents.breeze_buddy.chat.agent import ChatAgent
+from app.ai.voice.agents.breeze_buddy.chat.block_codec import (
+    blocks_to_llm_context_messages,
+)
 from app.ai.voice.agents.breeze_buddy.chat.sse import SSEEvent, format_sse
 from app.ai.voice.agents.breeze_buddy.llm import get_llm_service
 from app.ai.voice.agents.breeze_buddy.template.cache import get_template_by_id_cached
@@ -24,6 +28,7 @@ from app.core.logger import logger
 from app.database.accessor.breeze_buddy.chat_session import (
     create_chat_session,
     end_chat_session,
+    get_agent_session_state,
     get_chat_session_by_id,
     insert_chat_message,
     list_chat_messages_for_session,
@@ -46,6 +51,8 @@ from app.schemas.breeze_buddy.chat import (
     SendChatMessageRequest,
 )
 from app.services.redis.locks import LockAcquireError, RedisLock
+
+from . import cancel_bus
 
 # Per-session lock TTL. A single chat turn (LLM call + tool round-trips)
 # is well under this — if it isn't, the upstream LLM is hung and we
@@ -381,12 +388,27 @@ async def send_chat_message_handler(
         history_rows = await list_chat_messages_for_session(
             session_id, limit=history_limit
         )
-        history: list = [
-            {"role": row.role.value, "content": row.content}
-            for row in history_rows
-            if row.role in (ChatMessageRole.USER, ChatMessageRole.ASSISTANT)
-            and row.content
-        ]
+        # Replay the canonical Anthropic-shape blocks if present (post-
+        # migration 030), falling back to the denormalised prose for
+        # any legacy rows. Tool_use / tool_result blocks survive so the
+        # LLM sees its own prior identifiers (cart_id, etc.) verbatim.
+        history: list = blocks_to_llm_context_messages(
+            [
+                {
+                    "role": row.role.value,
+                    "content": row.content,
+                    "content_blocks": row.content_blocks,
+                }
+                for row in history_rows
+                if row.role in (ChatMessageRole.USER, ChatMessageRole.ASSISTANT)
+            ]
+        )
+
+        # Load per-session agent state (cart_id, customer_id, etc. for
+        # commerce templates). Generic — the runtime doesn't read the
+        # keys; the template's tool_arg_injection rules do.
+        state_row = await get_agent_session_state(session_id)
+        agent_state: Dict[str, Any] = state_row.data if state_row else {}
 
         persisted_template_vars = (
             fresh.metadata.get("template_vars", {})
@@ -413,41 +435,104 @@ async def send_chat_message_handler(
             template=template,
             llm=llm,
             template_vars=template_vars,
+            agent_state=agent_state,
         )
         # Snapshot into a local so the closure below doesn't have to rely
         # on Optional narrowing surviving the boundary.
         resume_node = fresh.current_node
 
         async def stream() -> AsyncIterator[str]:
+            # Register ourselves so /cancel can find and cancel this task
+            # cross-pod. The registration MUST happen inside the generator
+            # body (not in the outer handler) — the task that actually
+            # drives ``yield`` is the StreamingResponse iterator task, and
+            # that's the only one whose cancel() reliably propagates into
+            # ``agent.run_turn()``.
+            current_task = asyncio.current_task()
+            registered = False
+            if current_task is not None:
+                cancel_bus.register(session_id, current_task)
+                registered = True
             try:
-                async for event in agent.run_turn(
-                    user_content=req.content,
-                    history=history,
-                    current_node=resume_node,
-                ):
-                    yield format_sse(event)
-            except Exception as exc:
-                # Full exception (incl. SDK / DB internals) goes to logs; the
-                # SSE payload is intentionally generic — provider stack traces,
-                # internal URLs, and SQL strings should not reach the client.
-                logger.error(
-                    f"send_message stream for session {session_id} crashed: {exc}",
-                    exc_info=True,
-                )
-                yield format_sse(
-                    SSEEvent(
-                        event="error",
-                        data={
-                            "code": "internal",
-                            "message": "Internal server error",
-                        },
+                try:
+                    async for event in agent.run_turn(
+                        user_content=req.content,
+                        history=history,
+                        current_node=resume_node,
+                    ):
+                        yield format_sse(event)
+                except asyncio.CancelledError:
+                    # User clicked Stop. Emit a clean turn_end so the client
+                    # sees a structured end (the SDK's turn engine maps this
+                    # to ``turn-end: CANCELED`` and flips status back to
+                    # ready). Don't re-raise — letting CancelledError
+                    # propagate would tear down the StreamingResponse mid-
+                    # write, which Starlette logs as an error.
+                    #
+                    # Python 3.11+ asyncio gotcha: simply catching
+                    # CancelledError leaves the task's cancel-counter > 0,
+                    # so the NEXT await in this generator (the finally's
+                    # ``lock.release()``) is re-raised as CancelledError
+                    # before the Redis DEL goes out. Result: the lock stays
+                    # held until its 180s TTL and the next /message gets
+                    # 409. Calling ``uncancel()`` decrements the counter
+                    # so cleanup can complete. Symptom this fixes:
+                    # "cancelled by user" log fires, but follow-up sends
+                    # still see HTTP 409.
+                    if current_task is not None:
+                        try:
+                            current_task.uncancel()
+                        except AttributeError:
+                            # Python <3.11 — no uncancel; rely on the
+                            # ``shield`` in the finally below.
+                            pass
+                    logger.info(
+                        f"send_message stream for session {session_id} cancelled by user"
                     )
-                )
-                yield format_sse(
-                    SSEEvent(event="turn_end", data={"session_status": "FAILED"})
-                )
+                    yield format_sse(
+                        SSEEvent(event="turn_end", data={"session_status": "CANCELED"})
+                    )
+                except Exception as exc:
+                    # Full exception (incl. SDK / DB internals) goes to logs; the
+                    # SSE payload is intentionally generic — provider stack traces,
+                    # internal URLs, and SQL strings should not reach the client.
+                    logger.error(
+                        f"send_message stream for session {session_id} crashed: {exc}",
+                        exc_info=True,
+                    )
+                    yield format_sse(
+                        SSEEvent(
+                            event="error",
+                            data={
+                                "code": "internal",
+                                "message": "Internal server error",
+                            },
+                        )
+                    )
+                    yield format_sse(
+                        SSEEvent(event="turn_end", data={"session_status": "FAILED"})
+                    )
             finally:
-                await lock.release()
+                if registered and current_task is not None:
+                    cancel_bus.unregister(session_id, current_task)
+                # Shield the release: on a natural client disconnect path
+                # (Starlette cancels the generator without our explicit
+                # except-CancelledError running), the bare ``await
+                # lock.release()`` would be re-cancelled before the Redis
+                # DEL goes out. ``shield`` lets the DEL complete; the
+                # surrounding cancellation still propagates afterwards.
+                try:
+                    await asyncio.shield(lock.release())
+                except asyncio.CancelledError:
+                    # Cancellation arrived after the shielded release
+                    # already kicked off. Don't swallow it — re-raise so
+                    # the generator exits cleanly.
+                    raise
+                except Exception as release_exc:
+                    logger.warning(
+                        f"send_message stream for session {session_id}: "
+                        f"lock release failed in finally: {release_exc}"
+                    )
 
         response = StreamingResponse(
             stream(),
@@ -463,6 +548,28 @@ async def send_chat_message_handler(
     finally:
         if not lock_handed_off:
             await lock.release()
+
+
+async def cancel_chat_turn_handler(session_id: str) -> None:
+    """Best-effort cancel of an in-flight ``send_message`` turn.
+
+    Publishes the session id on the cancel pubsub channel; whichever
+    pod owns the running stream task receives it, calls
+    ``task.cancel()``, and the stream's ``finally`` releases the lock.
+
+    Returns nothing (route returns 202). The cancel is best-effort:
+    - If the session isn't running anywhere, this is a no-op (the
+      lock isn't held, the next /message proceeds normally).
+    - If Redis is down, this is a no-op + warning log — the lock
+      will still release on TTL (180s).
+
+    We do NOT touch the lock here: the running task's ``finally``
+    block holds the unique token and is the only safe releaser.
+    Force-deleting the key from here would let the next /message
+    start while the old agent is still mid-LLM-call, racing on DB
+    writes for the same session.
+    """
+    await cancel_bus.cancel(session_id)
 
 
 async def end_chat_session_handler(

--- a/app/api/routers/breeze_buddy/widget/__init__.py
+++ b/app/api/routers/breeze_buddy/widget/__init__.py
@@ -1,0 +1,196 @@
+"""Unified widget endpoints (CHAT_MODE.md §14).
+
+Six routes under ``/agent/voice/breeze-buddy/widget``:
+
+- ``POST /widget/session``                              create
+- ``POST /widget/session/{id}/message``                 chat turn (SSE)
+- ``POST /widget/session/{id}/voice/connect``           open voice attachment
+- ``POST /widget/session/{id}/voice/end``               close voice attachment
+- ``POST /widget/session/{id}/end``                     end whole conversation
+- ``GET  /widget/session/{id}``                         resume state
+
+Plus an OPTIONS handler per route returning permissive CORS so the
+browser preflight from any merchant origin can reach our handlers —
+the per-merchant origin allowlist is enforced inside the POST handlers
+(application layer), not via global CORSMiddleware (transport layer).
+
+The first route uses the ``public_widget_key`` (from the embed) +
+Origin + per-IP rate limit. All other routes use the session-bound
+``widget_token`` minted at create-time.
+"""
+
+from fastapi import APIRouter, Depends, Request, Response, status
+
+from app.api.routers.breeze_buddy.widget_common import options_cors_response
+from app.api.security.breeze_buddy.widget_token import (
+    WidgetSessionContext,
+    require_widget_session,
+)
+from app.schemas.breeze_buddy.chat import (
+    CreateWidgetSessionRequest,
+    CreateWidgetSessionResponse,
+    EndChatSessionResponse,
+    SendChatMessageRequest,
+    WidgetSessionStateResponse,
+    WidgetVoiceConnectResponse,
+    WidgetVoiceEndResponse,
+)
+
+from .handlers import (
+    cancel_widget_message_handler,
+    create_widget_session_handler,
+    end_widget_session_handler,
+    get_widget_session_state_handler,
+    send_widget_message_handler,
+    voice_connect_handler,
+    voice_end_handler,
+)
+
+router = APIRouter(prefix="/widget", tags=["widget-session"])
+
+
+# ---------------------------------------------------------------------------
+# CORS preflight (transport layer — application allowlist runs in handlers)
+# ---------------------------------------------------------------------------
+
+
+@router.options("/session")
+async def widget_create_preflight() -> Response:
+    return options_cors_response()
+
+
+@router.options("/session/{session_id}")
+async def widget_get_preflight(session_id: str) -> Response:
+    return options_cors_response()
+
+
+@router.options("/session/{session_id}/message")
+async def widget_message_preflight(session_id: str) -> Response:
+    return options_cors_response()
+
+
+@router.options("/session/{session_id}/cancel")
+async def widget_cancel_preflight(session_id: str) -> Response:
+    return options_cors_response()
+
+
+@router.options("/session/{session_id}/voice/connect")
+async def widget_voice_connect_preflight(session_id: str) -> Response:
+    return options_cors_response()
+
+
+@router.options("/session/{session_id}/voice/end")
+async def widget_voice_end_preflight(session_id: str) -> Response:
+    return options_cors_response()
+
+
+@router.options("/session/{session_id}/end")
+async def widget_end_preflight(session_id: str) -> Response:
+    return options_cors_response()
+
+
+# ---------------------------------------------------------------------------
+# Public — auth via public_widget_key + Origin + per-IP rate limit
+# ---------------------------------------------------------------------------
+
+
+@router.post(
+    "/session",
+    response_model=CreateWidgetSessionResponse,
+    status_code=status.HTTP_201_CREATED,
+    summary="Create a widget session + mint widget_token",
+)
+async def create_widget_session(
+    body: CreateWidgetSessionRequest, request: Request
+) -> CreateWidgetSessionResponse:
+    return await create_widget_session_handler(body, request)
+
+
+# ---------------------------------------------------------------------------
+# Authenticated by widget_token (session-bound)
+# ---------------------------------------------------------------------------
+
+
+@router.post(
+    "/session/{session_id}/message",
+    summary="Stream one widget chat turn (SSE)",
+)
+async def send_widget_message(
+    session_id: str,
+    req: SendChatMessageRequest,
+    request: Request,
+    ctx: WidgetSessionContext = Depends(require_widget_session),
+):
+    return await send_widget_message_handler(session_id, req, request, ctx)
+
+
+@router.post(
+    "/session/{session_id}/cancel",
+    status_code=status.HTTP_202_ACCEPTED,
+    summary="Cancel an in-flight widget chat turn (Stop button)",
+)
+async def cancel_widget_message(
+    session_id: str,
+    ctx: WidgetSessionContext = Depends(require_widget_session),
+) -> Response:
+    """Cancel the in-flight ``/message`` stream for ``session_id``.
+
+    Best-effort + idempotent — always returns 202. The owning pod
+    cancels its asyncio task; the stream's ``finally`` releases the
+    per-session Redis lock so the next ``/message`` can proceed
+    immediately. If no turn is in flight, this is a harmless no-op.
+    """
+    await cancel_widget_message_handler(session_id, ctx)
+    return Response(status_code=status.HTTP_202_ACCEPTED)
+
+
+@router.post(
+    "/session/{session_id}/voice/connect",
+    response_model=WidgetVoiceConnectResponse,
+    summary="Open a voice attachment on this widget session",
+)
+async def voice_connect(
+    session_id: str,
+    request: Request,
+    ctx: WidgetSessionContext = Depends(require_widget_session),
+) -> WidgetVoiceConnectResponse:
+    return await voice_connect_handler(session_id, request, ctx)
+
+
+@router.post(
+    "/session/{session_id}/voice/end",
+    response_model=WidgetVoiceEndResponse,
+    summary="Close the voice attachment (best-effort, idempotent)",
+)
+async def voice_end(
+    session_id: str,
+    ctx: WidgetSessionContext = Depends(require_widget_session),
+) -> WidgetVoiceEndResponse:
+    return await voice_end_handler(session_id, ctx)
+
+
+@router.post(
+    "/session/{session_id}/end",
+    response_model=EndChatSessionResponse,
+    summary="End the whole widget conversation",
+)
+async def end_widget_session(
+    session_id: str,
+    ctx: WidgetSessionContext = Depends(require_widget_session),
+) -> EndChatSessionResponse:
+    return await end_widget_session_handler(session_id, ctx)
+
+
+@router.get(
+    "/session/{session_id}",
+    response_model=WidgetSessionStateResponse,
+    summary="Resume payload for the widget after a page reload",
+)
+async def get_widget_session_state(
+    session_id: str,
+    ctx: WidgetSessionContext = Depends(require_widget_session),
+) -> WidgetSessionStateResponse:
+    return await get_widget_session_state_handler(session_id, ctx)
+
+
+__all__ = ["router"]

--- a/app/api/routers/breeze_buddy/widget/handlers.py
+++ b/app/api/routers/breeze_buddy/widget/handlers.py
@@ -1,0 +1,663 @@
+"""Business logic for the unified widget endpoints (CHAT_MODE.md §14).
+
+The chat_session row is the canonical conversation backbone. Voice is
+a transient attachment: ONE lead_call_tracker row per conversation,
+set in chat_session.voice_lead_id on the first /voice/connect and
+REUSED for every subsequent attachment via attempt_count. Recordings
+are intentionally disabled for widget voice — the lead has only one
+recording_url field, and reusing the lead across N attempts means we
+can't represent N recordings without a schema change. Product can
+add per-attempt recording later (e.g., metaData.attempts list) if
+needed.
+
+``current_channel`` is the state-machine field that gates valid
+transitions. Per-session Redis lock (``chat:session:{id}:lock``)
+coordinates ``/message``, ``/voice/connect``, ``/voice/end``,
+``/end``, and the end_conversation drain so they can't race on the
+same session.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any, Dict, List, Optional
+
+from fastapi import HTTPException, Request, status
+
+from app.ai.voice.agents.breeze_buddy.services.daily.daily import (
+    daily_completion_function,
+    start_daily_session,
+)
+from app.ai.voice.agents.breeze_buddy.template.cache import get_template_by_id_cached
+from app.api.routers.breeze_buddy.chat.handlers import (
+    cancel_chat_turn_handler,
+    create_chat_session_handler,
+    end_chat_session_handler,
+    load_chat_session_or_404,
+    send_chat_message_handler,
+    validate_template_for_chat,
+)
+from app.api.routers.breeze_buddy.widget_common import (
+    enforce_widget_ip_limit,
+    resolve_widget_config_for_request,
+)
+from app.api.security.breeze_buddy.widget_token import (
+    DEFAULT_WIDGET_TOKEN_TTL_MINUTES,
+    WidgetSessionContext,
+    assert_widget_session_ownership,
+    mint_widget_token,
+)
+from app.core.logger import logger
+from app.database.accessor import create_lead_call_tracker, get_lead_by_id
+from app.database.accessor.breeze_buddy.chat_session import (
+    bind_voice_lead_to_chat_session,
+    flip_chat_session_to_chat,
+    flip_chat_session_to_voice,
+    get_chat_session_by_id,
+    list_chat_messages_for_session,
+)
+from app.database.accessor.breeze_buddy.lead_call_tracker import (
+    handle_lead_abort,
+    reset_widget_voice_lead,
+)
+from app.database.accessor.breeze_buddy.widget_config import (
+    get_widget_config_by_id,
+)
+from app.schemas import (
+    CallDirection,
+    ExecutionMode,
+    LeadCallStatus,
+    UserInfo,
+    UserRole,
+)
+from app.schemas.breeze_buddy.chat import (
+    ChatMessage,
+    ChatSessionStatus,
+    CreateChatSessionRequest,
+    CreateWidgetSessionRequest,
+    CreateWidgetSessionResponse,
+    SendChatMessageRequest,
+    WidgetChannel,
+    WidgetSessionStateResponse,
+    WidgetVoiceConnectResponse,
+    WidgetVoiceEndResponse,
+)
+from app.services.redis.locks import LockAcquireError, RedisLock
+
+# Per-session Redis lock TTL — same as the chat sender's lock so the
+# two paths can serialise on the same key. Voice connect / end is fast
+# (DB writes + a Daily REST call), well under this.
+_SESSION_LOCK_TTL_SECONDS = 180
+
+# The Daily room itself expires after 1h (set in start_daily_session).
+# Surface that to the client so the embed knows when to reconnect.
+_DAILY_ROOM_TTL_SECONDS = 3600
+
+
+def _session_lock(session_id: str) -> RedisLock:
+    """Same key shape as chat handlers' ``_lock_key`` so all five
+    widget operations + the existing chat handlers serialise."""
+    return RedisLock(
+        f"chat:session:{session_id}:lock",
+        ttl_seconds=_SESSION_LOCK_TTL_SECONDS,
+    )
+
+
+def _synthetic_widget_user(widget_config_id: str) -> UserInfo:
+    """Minimal UserInfo for the chat handlers' log line.
+
+    Carries no scopes — the widget_token (separate concept) is what
+    authenticates follow-up calls. Mirrors ``chat/demo.py``'s
+    ``synthetic_user`` pattern.
+    """
+    return UserInfo(
+        id="widget",
+        username=f"widget:{widget_config_id}",
+        role=UserRole.USER,
+        reseller_ids=[],
+        merchant_ids=[],
+        permissions=[],
+    )
+
+
+# ---------------------------------------------------------------------------
+# POST /widget/session
+# ---------------------------------------------------------------------------
+
+
+async def create_widget_session_handler(
+    body: CreateWidgetSessionRequest, request: Request
+) -> CreateWidgetSessionResponse:
+    """Create a widget session backed by a chat_session row."""
+    cfg = await resolve_widget_config_for_request(
+        request=request,
+        public_widget_key=body.public_widget_key,
+        rate_bucket="session_create",
+        rate_limit=None,  # use cfg.max_sessions_per_ip_hour default
+    )
+
+    template = await get_template_by_id_cached(cfg.template_id)
+    if template is None:
+        # Template was deleted out from under the widget_config. The
+        # FK on widget_config(template_id) is RESTRICT but a misconfig
+        # is still possible during teardown — log + 500.
+        logger.error(
+            f"widget: template {cfg.template_id!r} from widget_config "
+            f"{cfg.id} is missing in DB"
+        )
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Widget template misconfigured",
+        )
+    # Chat is the entry channel; voice opt-in is checked at /voice/connect.
+    validate_template_for_chat(template)
+
+    synthetic_user = _synthetic_widget_user(cfg.id)
+    create_req = CreateChatSessionRequest(
+        template_id=cfg.template_id,
+        template_vars=body.template_vars,
+        # Server-owned widget marker beats anything the client supplies
+        # via metadata — same precedence rule as ``template_vars`` in
+        # ``create_chat_session_handler``.
+        metadata={
+            **(body.metadata or {}),
+            "widget": {
+                "widget_config_id": cfg.id,
+                "public_widget_key_prefix": cfg.public_widget_key[:6],
+            },
+        },
+    )
+    create_resp = await create_chat_session_handler(
+        create_req, template, synthetic_user
+    )
+
+    widget_token = mint_widget_token(
+        widget_session_id=create_resp.session_id,
+        widget_config_id=cfg.id,
+        ttl_minutes=DEFAULT_WIDGET_TOKEN_TTL_MINUTES,
+    )
+
+    return CreateWidgetSessionResponse(
+        session_id=create_resp.session_id,
+        status=create_resp.status,
+        # Migration 029 default; the row was just created so it's CHAT.
+        current_channel=WidgetChannel.CHAT,
+        current_node=create_resp.current_node,
+        greeting=create_resp.greeting,
+        widget_token=widget_token,
+        ttl_seconds=DEFAULT_WIDGET_TOKEN_TTL_MINUTES * 60,
+    )
+
+
+# ---------------------------------------------------------------------------
+# POST /widget/session/{id}/message
+# ---------------------------------------------------------------------------
+
+
+async def send_widget_message_handler(
+    session_id: str,
+    req: SendChatMessageRequest,
+    request: Request,
+    ctx: WidgetSessionContext,
+):
+    """Drive one chat turn. 409 if voice is currently active."""
+    cfg = await get_widget_config_by_id(ctx.widget_config_id)
+    if cfg is None or not cfg.active:
+        # Token's widget_config_id is stale — probably deleted via the
+        # admin CRUD. 401 so the client knows to abandon the token.
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Widget configuration not found or inactive",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    await enforce_widget_ip_limit(
+        request=request,
+        bucket="message",
+        limit=cfg.max_messages_per_ip_hour,
+        widget_config_id=cfg.id,
+    )
+
+    # Cheap pre-check before delegating — the chat handler will reload
+    # the session under its own lock, but we want a clean 409 for
+    # "voice is live" before the SSE stream opens.
+    session = await get_chat_session_by_id(session_id)
+    if session is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Widget session '{session_id}' not found",
+        )
+    assert_widget_session_ownership(session, ctx)
+    if session.status == ChatSessionStatus.ENDED:
+        raise HTTPException(
+            status_code=status.HTTP_410_GONE,
+            detail=f"Widget session '{session_id}' has ended",
+        )
+    if session.current_channel != WidgetChannel.CHAT:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=(
+                f"Widget session is on channel {session.current_channel.value}; "
+                "end the voice attachment first."
+            ),
+        )
+
+    return await send_chat_message_handler(session_id, req, access_check=None)
+
+
+# ---------------------------------------------------------------------------
+# POST /widget/session/{id}/cancel
+# ---------------------------------------------------------------------------
+
+
+async def cancel_widget_message_handler(
+    session_id: str, ctx: WidgetSessionContext
+) -> None:
+    """Cancel the in-flight chat turn for a widget session (Stop button).
+
+    Widget auth is provided by the session-scoped widget_token via the
+    route's ``Depends(require_widget_session)``. We DO pre-load the
+    session row — the token claim binds to ``widget_session_id`` but a
+    leaked token + a discovered session UUID could still drive a
+    cross-tenant cancel if we don't verify ``widget_config_id`` ownership
+    here. One indexed SELECT << the LLM round-trip we're cancelling.
+    """
+    session = await get_chat_session_by_id(session_id)
+    if session is None:
+        # Session vanished — nothing to cancel; treat as success.
+        return
+    assert_widget_session_ownership(session, ctx)
+    await cancel_chat_turn_handler(session_id)
+
+
+# ---------------------------------------------------------------------------
+# POST /widget/session/{id}/voice/connect
+# ---------------------------------------------------------------------------
+
+
+async def voice_connect_handler(
+    session_id: str,
+    request: Request,
+    ctx: WidgetSessionContext,
+) -> WidgetVoiceConnectResponse:
+    """Open a voice attachment on the chat_session.
+
+    A widget conversation gets exactly ONE voice lead (set in
+    ``chat_session.voice_lead_id`` on the first /voice/connect) and
+    REUSED for every subsequent attachment. ``attempt_count`` on the
+    lead row records how many times the user switched to voice within
+    the conversation. See CHAT_MODE.md §14 for why we reuse instead
+    of creating a new lead per attachment.
+
+    The lead carries seed metadata so the voice runtime resumes at
+    the chat's ``current_node`` with the chat's full message history
+    pre-loaded into the LLM context. See agent/__init__.py + flow.py
+    + end_conversation.py for the resume + drain mechanics.
+    """
+    cfg = await get_widget_config_by_id(ctx.widget_config_id)
+    if cfg is None or not cfg.active:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Widget configuration not found or inactive",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    await enforce_widget_ip_limit(
+        request=request,
+        bucket="voice_connect",
+        limit=cfg.max_voice_sessions_per_ip_hour,
+        widget_config_id=cfg.id,
+    )
+
+    template = await get_template_by_id_cached(cfg.template_id)
+    if template is None:
+        logger.error(
+            f"widget voice: template {cfg.template_id!r} from widget_config "
+            f"{cfg.id} is missing in DB"
+        )
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Widget template misconfigured",
+        )
+
+    supported: List[str] = list(getattr(template, "supported_channels", []) or []) or [
+        "voice"
+    ]
+    if "voice" not in supported:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Template does not include 'voice' in supported_channels.",
+        )
+
+    lock = _session_lock(session_id)
+    try:
+        await lock.acquire()
+    except LockAcquireError:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Another operation is in flight for this session. Wait and retry.",
+        )
+
+    try:
+        session = await get_chat_session_by_id(session_id)
+        if session is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Widget session '{session_id}' not found",
+            )
+        assert_widget_session_ownership(session, ctx)
+        if session.status == ChatSessionStatus.ENDED:
+            raise HTTPException(
+                status_code=status.HTTP_410_GONE,
+                detail=f"Widget session '{session_id}' has ended",
+            )
+        if session.current_channel != WidgetChannel.CHAT:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail=(
+                    "A voice attachment is already active for this session; "
+                    "end it first."
+                ),
+            )
+
+        # ── Build seed -----------------------------------------------------
+        history = await list_chat_messages_for_session(session_id)
+        prior_history: List[Dict[str, Any]] = [
+            {"role": m.role.value, "content": m.content} for m in history if m.content
+        ]
+        seed_message_count = len(prior_history)
+        template_vars: Dict[str, Any] = (
+            session.metadata.get("template_vars", {})
+            if isinstance(session.metadata, dict)
+            else {}
+        )
+
+        # ``payload`` flows into voice's load_template_config — so the
+        # template_vars from chat must be here for the renderer.
+        payload: Dict[str, Any] = {
+            **template_vars,
+            "is_widget": True,
+            "widget_config_id": cfg.id,
+            "source": "widget",
+        }
+        # ``meta_data`` carries the voice-runtime seed (read by the
+        # agent's _setup_*_transport). The widget_session_id back-link
+        # is what the end_conversation drain uses to find the
+        # chat_session to drain into.
+        meta_data_seed: Dict[str, Any] = {
+            "is_widget": True,
+            "widget_config_id": cfg.id,
+            "widget_session_id": session_id,
+            "start_node": session.current_node,
+            "prior_history": prior_history,
+            "seed_message_count": seed_message_count,
+        }
+        template_name = getattr(template, "name", None) or "widget"
+
+        # ── Branch: reuse existing voice lead vs create a new one ----------
+        is_new_lead = False
+        lead_id: Optional[str] = session.voice_lead_id
+        if lead_id:
+            # 2nd+ attachment: reuse the bound lead. The reset bumps
+            # attempt_count, refreshes the seed, and clears per-call
+            # fields (call_id, outcome, recording_url, etc.) so they
+            # don't leak from the previous attempt.
+            reset_lead = await reset_widget_voice_lead(lead_id, payload, meta_data_seed)
+            if reset_lead is None:
+                # Lead was archived / hard-deleted. Fall through to
+                # create a fresh one and rebind. Shouldn't normally
+                # happen but recovering keeps the widget functional.
+                logger.warning(
+                    f"widget voice: bound lead {lead_id} missing; recreating"
+                )
+                lead_id = None
+
+        if lead_id is None:
+            # First attachment (or recovery from a missing lead).
+            new_lead_id = str(uuid.uuid4())
+            new_lead = await create_lead_call_tracker(
+                id=new_lead_id,
+                reseller_id=cfg.reseller_id,
+                template=template_name,
+                template_id=str(template.id),
+                merchant_id=cfg.merchant_id,
+                next_attempt_at=None,
+                payload=payload,
+                attempt_count=0,
+                meta_data=meta_data_seed,
+                request_id=f"widget-{new_lead_id}",
+                execution_mode=ExecutionMode.DAILY,
+                status=LeadCallStatus.BACKLOG,
+                call_direction=CallDirection.INBOUND,
+            )
+            if new_lead is None:
+                raise HTTPException(
+                    status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                    detail="Failed to create voice attachment lead",
+                )
+            lead_id = new_lead_id
+            is_new_lead = True
+
+            # Bind voice_lead_id to the chat_session — only succeeds
+            # when voice_lead_id IS NULL (no concurrent /voice/connect
+            # already bound a lead). Returns None on conflict.
+            bound = await bind_voice_lead_to_chat_session(session_id, lead_id)
+            if bound is None:
+                try:
+                    await handle_lead_abort(lead_id, "widget_bind_race")
+                except Exception as abort_err:
+                    logger.error(
+                        f"widget voice: failed to abort lead {lead_id} after "
+                        f"bind race: {abort_err}"
+                    )
+                raise HTTPException(
+                    status_code=status.HTTP_409_CONFLICT,
+                    detail="Voice attachment lost a race; retry.",
+                )
+
+        # ── Flip CHAT → VOICE ----------------------------------------------
+        flipped = await flip_chat_session_to_voice(session_id)
+        if flipped is None:
+            # Channel changed under us. If we just created a fresh
+            # lead, abort it; for a reused lead, leave it BACKLOG —
+            # the next /voice/connect will reset it again.
+            if is_new_lead:
+                try:
+                    await handle_lead_abort(lead_id, "widget_attach_conflict")
+                except Exception as abort_err:
+                    logger.error(
+                        f"widget voice: failed to abort lead {lead_id} after "
+                        f"flip conflict: {abort_err}"
+                    )
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="Voice attachment lost a race; retry.",
+            )
+
+        # ── Start Daily room (no recording for widget mode; see §14) -------
+        try:
+            session_info = await start_daily_session(lead_id, enable_recording=False)
+        except Exception as exc:
+            logger.error(
+                f"widget voice: start_daily_session failed for lead {lead_id}: "
+                f"{exc}",
+                exc_info=True,
+            )
+            # Rollback channel back to CHAT so the user can retry.
+            try:
+                await flip_chat_session_to_chat(session_id, lead_id)
+            except Exception as flip_err:
+                logger.error(
+                    f"widget voice: rollback flip failed for {session_id} / "
+                    f"{lead_id}: {flip_err}"
+                )
+            # Only abort if we just created the lead — for reuse, keep
+            # voice_lead_id bound so the next attempt can reset.
+            if is_new_lead:
+                try:
+                    await handle_lead_abort(lead_id, "widget_voice_start_failed")
+                except Exception as abort_err:
+                    logger.error(
+                        f"widget voice: rollback abort failed for {lead_id}: "
+                        f"{abort_err}"
+                    )
+            raise HTTPException(
+                status_code=status.HTTP_502_BAD_GATEWAY,
+                detail="Failed to start widget voice session. Try again shortly.",
+            )
+
+        return WidgetVoiceConnectResponse(
+            room_url=session_info["room_url"],
+            daily_token=session_info["token"],
+            lead_id=lead_id,
+            ttl_seconds=_DAILY_ROOM_TTL_SECONDS,
+        )
+    finally:
+        await lock.release()
+
+
+# ---------------------------------------------------------------------------
+# POST /widget/session/{id}/voice/end
+# ---------------------------------------------------------------------------
+
+
+async def voice_end_handler(
+    session_id: str, ctx: WidgetSessionContext
+) -> WidgetVoiceEndResponse:
+    """Best-effort end of the voice attachment.
+
+    Two paths run the actual drain (transcripts back into chat_message,
+    flip channel back to CHAT):
+      1. The bot's ``end_conversation`` handler, when Daily disconnects.
+      2. This route, as a fallback (e.g., user closed tab; bot is
+         still up but the user is gone) — we signal the bot via the
+         existing daily_completion_function and return immediately.
+    Both paths are guarded by the same per-session Redis lock and the
+    conditional UPDATE in ``drain_voice_into_chat_session_query``.
+
+    Idempotent: if channel is already CHAT (drain already ran) we
+    return success without doing anything. ``voice_lead_id`` stays
+    bound on the chat_session so the next /voice/connect reuses
+    the same lead.
+    """
+    lock = _session_lock(session_id)
+    try:
+        await lock.acquire()
+    except LockAcquireError:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Another operation is in flight for this session.",
+        )
+
+    try:
+        session = await get_chat_session_by_id(session_id)
+        if session is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Widget session '{session_id}' not found",
+            )
+        assert_widget_session_ownership(session, ctx)
+        if session.current_channel != WidgetChannel.VOICE:
+            # Already drained or never voice — no-op.
+            return WidgetVoiceEndResponse(
+                status="not_active", lead_id=session.voice_lead_id
+            )
+
+        lead_id = session.voice_lead_id
+        if not lead_id:
+            # Inconsistent state — channel says VOICE but no bound
+            # lead. Force-flip back so the session isn't stuck; without
+            # this call /message and /voice/connect would 409 forever
+            # because the channel guard sees VOICE indefinitely.
+            logger.warning(
+                f"widget voice: chat_session {session_id} on VOICE with no "
+                "voice_lead_id; clearing"
+            )
+            await flip_chat_session_to_chat(
+                session_id=session_id,
+                voice_lead_id=None,
+            )
+            return WidgetVoiceEndResponse(status="cleared_orphan_state", lead_id=None)
+
+        # Signal the bot to wind down. The bot's end_conversation
+        # handler will run the drain when its pipeline tears down.
+        # We don't block on it — return optimistically. If the bot
+        # crashed and never drains, the conditional UPDATE in
+        # ``flip_chat_session_to_chat`` (or a janitor sweep) is the
+        # safety net.
+        lead = await get_lead_by_id(lead_id)
+        call_id = lead.call_id if lead and lead.call_id else lead_id
+        try:
+            await daily_completion_function(
+                call_id=call_id,
+                outcome="ended_by_widget",
+            )
+        except Exception as exc:
+            logger.warning(
+                f"widget voice: daily_completion_function failed for "
+                f"call_id={call_id}: {exc} (continuing)"
+            )
+
+        return WidgetVoiceEndResponse(status="end_requested", lead_id=lead_id)
+    finally:
+        await lock.release()
+
+
+# ---------------------------------------------------------------------------
+# POST /widget/session/{id}/end
+# ---------------------------------------------------------------------------
+
+
+async def end_widget_session_handler(session_id: str, ctx: WidgetSessionContext):
+    """End the whole conversation.
+
+    If voice is live, signal it to wind down first (best-effort, same
+    as /voice/end); then mark the chat_session ENDED via the existing
+    end_chat_session_handler. The voice_lead_id stays on the
+    chat_session for audit / analytics.
+    """
+    # Pre-check before locking — if voice is live, signal the bot first
+    # so we don't deadlock with the bot's drain holding the lock.
+    session_pre = await get_chat_session_by_id(session_id)
+    if session_pre is not None:
+        assert_widget_session_ownership(session_pre, ctx)
+    if session_pre and session_pre.current_channel == WidgetChannel.VOICE:
+        try:
+            await voice_end_handler(session_id, ctx)
+        except HTTPException as exc:
+            if exc.status_code != status.HTTP_409_CONFLICT:
+                raise
+            # Lock was contended — proceed; end_chat_session_handler
+            # will acquire its own lock and serialise after.
+
+    session = await load_chat_session_or_404(session_id)
+    assert_widget_session_ownership(session, ctx)
+    return await end_chat_session_handler(session_id, session)
+
+
+# ---------------------------------------------------------------------------
+# GET /widget/session/{id}
+# ---------------------------------------------------------------------------
+
+
+async def get_widget_session_state_handler(
+    session_id: str, ctx: WidgetSessionContext
+) -> WidgetSessionStateResponse:
+    """Resume payload for the embed after a page reload."""
+    session = await load_chat_session_or_404(session_id)
+    assert_widget_session_ownership(session, ctx)
+    messages: List[ChatMessage] = await list_chat_messages_for_session(session_id)
+    template_vars: Dict[str, Any] = (
+        session.metadata.get("template_vars", {})
+        if isinstance(session.metadata, dict)
+        else {}
+    )
+    return WidgetSessionStateResponse(
+        session_id=session_id,
+        status=session.status,
+        current_channel=session.current_channel,
+        current_node=session.current_node,
+        messages=messages,
+        template_vars=template_vars,
+        metadata=session.metadata or {},
+    )

--- a/app/api/routers/breeze_buddy/widget_common.py
+++ b/app/api/routers/breeze_buddy/widget_common.py
@@ -1,0 +1,268 @@
+"""Shared widget-public utilities used by both the chat and voice widget
+routers (CHAT_MODE.md §14).
+
+Three concerns live here so the chat (``chat/widget.py``) and voice
+(``daily_widget/handlers.py``) sub-routers stay focused on their own
+flow:
+
+1. **Best-effort caller IP** for rate-limit keying. Honours
+   ``X-Forwarded-For`` (first hop) when present so a load balancer
+   doesn't make every visitor share one bucket.
+2. **Origin / Referer extraction + per-merchant allowlist check**.
+   Empty ``allowed_origins`` is deny-all (safer default than allow-all).
+3. **One-call ``resolve_widget_config_for_request``** that loads the
+   row, enforces active + origin, and applies the per-IP rate limit
+   before returning the config to the handler.
+
+CORS preflight is a separate concern — see ``options_cors_response``
+below. The browser's preflight must succeed for *any* origin so the
+request can reach our handler; only then can the per-merchant origin
+allowlist run. The two layers (CORS = transport, allowlist =
+application) are intentionally split.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+from urllib.parse import urlparse
+
+from fastapi import HTTPException, Request, Response, status
+
+from app.core.logger import logger
+from app.database.accessor.breeze_buddy.widget_config import (
+    get_widget_config_by_public_key,
+)
+from app.schemas.breeze_buddy.widget_config import WidgetConfigResponse
+from app.services.redis.rate_limit import check_rate_limit
+
+# One-hour fixed window for all widget IP buckets — the cap (per
+# session-creates, per messages, per voice-connects) is what shapes
+# abuse resistance, not the granularity. Matches demo (``chat/demo.py``).
+_RATE_WINDOW_SECONDS = 3600
+_RATE_LIMIT_PREFIX = "widget"
+
+
+def client_ip(request: Request) -> str:
+    """Best-effort caller IP for rate-limit keying.
+
+    Honours ``X-Forwarded-For`` *last* hop when present — the last entry
+    is the one our trusted proxy / load balancer wrote, every earlier hop
+    is attacker-controllable. Falls back to ``request.client.host`` (the
+    direct peer). Returns ``unknown`` when both are missing — that's one
+    shared bucket, which is the safest default.
+
+    Earlier implementations took the first XFF hop, which let any client
+    iterate the header on each request and get unbounded rate-limit
+    buckets — defeating the cap. Last-hop assumes the deployment is
+    behind a known proxy that strips client-supplied XFF. If you ever
+    deploy widget endpoints WITHOUT a trusted proxy in front, set the
+    proxy header explicitly (``X-Real-IP``) and switch to read that.
+    """
+    forwarded = request.headers.get("x-forwarded-for")
+    if forwarded:
+        # rsplit picks the *last* IP — the one written by our trusted
+        # last-hop. ``unknown`` if the header is malformed / empty.
+        last = forwarded.rsplit(",", 1)[-1].strip()
+        if last:
+            return last
+    if request.client and request.client.host:
+        return request.client.host
+    return "unknown"
+
+
+def _origin_from_referer(referer: Optional[str]) -> Optional[str]:
+    """Strip a Referer URL down to ``scheme://host[:port]`` for allowlist
+    comparison. Returns None when the header is missing or unparseable.
+    """
+    if not referer:
+        return None
+    try:
+        parsed = urlparse(referer)
+    except Exception:
+        return None
+    if not parsed.scheme or not parsed.netloc:
+        return None
+    return f"{parsed.scheme}://{parsed.netloc}"
+
+
+def _caller_origin(request: Request) -> Optional[str]:
+    """Pick the caller's origin: ``Origin`` header wins; ``Referer`` is a
+    fallback for the rare cases where a browser strips Origin (legacy
+    cross-origin GETs, some privacy proxies).
+    """
+    origin = request.headers.get("origin")
+    if origin:
+        return origin.strip() or None
+    return _origin_from_referer(request.headers.get("referer"))
+
+
+async def _enforce_widget_ip_limit(
+    *, request: Request, bucket: str, limit: int, widget_config_id: str
+) -> None:
+    """Raise 429 with ``Retry-After`` when ``request``'s IP is over ``limit``.
+
+    Mirrors the demo helper in ``chat/demo.py`` but namespaces the Redis
+    keys under ``"widget"`` so demo and widget counters don't share
+    buckets.
+
+    The Redis identifier is ``"{widget_config_id}:{client_ip}"`` so each
+    merchant has its OWN per-IP bucket — without this prefix, traffic to
+    one merchant's widget would burn another merchant's quota.
+    Combined with the last-hop XFF parsing in ``client_ip``, an attacker
+    rotating XFF values can no longer escape the cap (last hop is
+    proxy-written, not client-controllable).
+
+    ``fail_closed=True`` is passed through to the rate limiter so a
+    Redis outage denies new widget traffic instead of opening the
+    floodgates — widget endpoints are anonymous + LLM-cost-amplifying;
+    fail-open here is genuinely worse than a brief 503.
+    """
+    decision = await check_rate_limit(
+        bucket=bucket,
+        identifier=f"{widget_config_id}:{client_ip(request)}",
+        limit=limit,
+        window_seconds=_RATE_WINDOW_SECONDS,
+        prefix=_RATE_LIMIT_PREFIX,
+        fail_closed=True,
+    )
+    if decision.allowed:
+        return
+    raise HTTPException(
+        status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+        detail=(
+            f"Widget rate limit hit ({decision.count}/{decision.limit} per hour). "
+            "Try again later."
+        ),
+        headers={"Retry-After": str(decision.retry_after_seconds)},
+    )
+
+
+async def resolve_widget_config_for_request(
+    *,
+    request: Request,
+    public_widget_key: str,
+    rate_bucket: str,
+    rate_limit: Optional[int] = None,
+) -> WidgetConfigResponse:
+    """Load the widget_config + enforce origin + per-IP rate limit.
+
+    Args:
+        request: The FastAPI request (used for headers + client IP).
+        public_widget_key: Opaque key the embed sent in its JSON body.
+        rate_bucket: Logical bucket name (e.g. ``"chat_session"``,
+            ``"chat_message"``, ``"voice_connect"``). Lets multiple
+            widget routes share Redis storage without colliding.
+        rate_limit: Override the default cap pulled from the row. If
+            ``None``, the route is expected to pick a value off the
+            loaded ``WidgetConfigResponse`` itself — used when the row
+            hadn't been loaded yet.
+
+    Behaviour:
+        - Returns 404 (no echo) when the key is unknown or the row is
+          inactive — same reconnaissance-hardening as the demo router.
+        - Returns 403 when the caller's origin (or Referer-derived
+          origin) isn't in ``allowed_origins`` — same status when
+          ``allowed_origins`` is empty (deny-all by default).
+        - Returns 429 with ``Retry-After`` when the per-IP bucket for
+          ``rate_bucket`` is over ``rate_limit``.
+    """
+    cfg = await get_widget_config_by_public_key(public_widget_key)
+    if cfg is None or not cfg.active:
+        # Don't differentiate "unknown" from "inactive" to the caller —
+        # both are 404 with no detail. The log carries the prefix for
+        # operators debugging a misconfigured embed.
+        logger.warning(
+            "widget: unknown or inactive public_widget_key "
+            f"(prefix={public_widget_key[:6]!r})"
+        )
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Widget configuration not found",
+        )
+
+    origin = _caller_origin(request)
+    if origin is None:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Origin required for widget routes",
+        )
+    if not cfg.allowed_origins or origin not in cfg.allowed_origins:
+        logger.warning(
+            f"widget: origin {origin!r} not in allowed_origins for "
+            f"widget_config={cfg.id}"
+        )
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Origin not permitted for this widget",
+        )
+
+    effective_limit = (
+        rate_limit if rate_limit is not None else cfg.max_sessions_per_ip_hour
+    )
+    await _enforce_widget_ip_limit(
+        request=request,
+        bucket=rate_bucket,
+        limit=effective_limit,
+        widget_config_id=cfg.id,
+    )
+    return cfg
+
+
+async def enforce_widget_ip_limit(
+    *, request: Request, bucket: str, limit: int, widget_config_id: str
+) -> None:
+    """Public alias for the IP rate-limit helper.
+
+    Used by routes that already resolved a ``widget_config`` from a
+    session-bound JWT (no key lookup needed) but still want to bound
+    follow-up calls — e.g., ``POST /chat/widget/session/{id}/message``
+    enforcing ``max_messages_per_ip_hour``. ``widget_config_id`` is
+    required so the per-IP bucket is also scoped per-merchant (one
+    merchant's traffic can't exhaust another's quota).
+    """
+    await _enforce_widget_ip_limit(
+        request=request,
+        bucket=bucket,
+        limit=limit,
+        widget_config_id=widget_config_id,
+    )
+
+
+# ---------------------------------------------------------------------------
+# CORS preflight
+# ---------------------------------------------------------------------------
+
+# Permissive CORS headers for widget routes. The browser must be able to
+# issue the preflight from any merchant origin so the request reaches our
+# handler — the *application-layer* allowlist (``allowed_origins`` above)
+# is what gates production traffic. Credentials are intentionally not
+# enabled: widget tokens travel in ``Authorization``, and
+# ``Access-Control-Allow-Credentials: true`` combined with ``Origin: *``
+# is invalid per spec.
+_CORS_HEADERS = {
+    "Access-Control-Allow-Origin": "*",
+    # GET is needed for the session-resume endpoint
+    # (`GET /widget/session/{id}`). Browser-side preflight blocks any
+    # method not listed here when the request carries Authorization.
+    "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
+    "Access-Control-Allow-Headers": "authorization, content-type",
+    "Access-Control-Max-Age": "600",
+}
+
+
+def options_cors_response() -> Response:
+    """204 response with permissive CORS headers for OPTIONS preflight.
+
+    Mount an OPTIONS handler on each widget router that returns this so
+    the browser preflight succeeds for any origin. The actual per-
+    merchant allowlist runs inside the corresponding POST handler.
+    """
+    return Response(status_code=status.HTTP_204_NO_CONTENT, headers=_CORS_HEADERS)
+
+
+__all__ = [
+    "client_ip",
+    "enforce_widget_ip_limit",
+    "options_cors_response",
+    "resolve_widget_config_for_request",
+]

--- a/app/api/routers/breeze_buddy/widget_config/__init__.py
+++ b/app/api/routers/breeze_buddy/widget_config/__init__.py
@@ -1,0 +1,121 @@
+"""RBAC-gated CRUD for widget_config rows (CHAT_MODE.md §14).
+
+Five endpoints under ``/agent/voice/breeze-buddy/widget-config``:
+
+- ``POST   /widget-config``            — create (admin / scoped reseller)
+- ``GET    /widget-config/list``       — list (RBAC-filtered)
+- ``GET    /widget-config/{id}``       — get by id
+- ``PUT    /widget-config/{id}``       — partial update
+- ``DELETE /widget-config/{id}``       — delete (admin only)
+
+Mirrors the templates router (see ``templates/__init__.py``) — thin
+routes that validate auth + RBAC, then delegate to handlers.
+``public_widget_key`` is generated server-side at create-time and never
+accepted from the client.
+"""
+
+from typing import Optional
+
+from fastapi import APIRouter, Depends, Query, status
+
+from app.api.security.breeze_buddy.rbac_token import get_current_user_with_rbac
+from app.core.security.authorization import require_admin
+from app.schemas import UserInfo
+from app.schemas.breeze_buddy.widget_config import (
+    DeleteWidgetConfigResponse,
+    WidgetConfigCreate,
+    WidgetConfigListResponse,
+    WidgetConfigResponse,
+    WidgetConfigUpdate,
+)
+
+from .handlers import (
+    create_widget_config_handler,
+    delete_widget_config_handler,
+    get_widget_config_by_id_handler,
+    list_widget_configs_handler,
+    update_widget_config_handler,
+)
+
+router = APIRouter()
+
+
+@router.post(
+    "/widget-config",
+    status_code=status.HTTP_201_CREATED,
+    response_model=WidgetConfigResponse,
+)
+async def create_widget_config(
+    body: WidgetConfigCreate,
+    current_user: UserInfo = Depends(get_current_user_with_rbac),
+) -> WidgetConfigResponse:
+    """Create a widget_config row. ``public_widget_key`` is generated
+    server-side; the request body cannot supply it.
+
+    RBAC:
+    - Admin: can create for any reseller/merchant.
+    - Reseller / Merchant: must have access to the reseller_id and
+      merchant_id in the body (403 otherwise).
+    """
+    return await create_widget_config_handler(body, current_user)
+
+
+@router.get("/widget-config/list", response_model=WidgetConfigListResponse)
+async def list_widget_configs(
+    reseller_id: Optional[str] = Query(None),
+    merchant_id: Optional[str] = Query(None),
+    include_inactive: bool = Query(False),
+    page: int = Query(1, ge=1),
+    limit: int = Query(50, ge=1, le=200),
+    current_user: UserInfo = Depends(get_current_user_with_rbac),
+) -> WidgetConfigListResponse:
+    """List widget_configs visible to the caller.
+
+    Filter by reseller_id / merchant_id (subject to RBAC) or pass
+    nothing to get everything the caller can see. ``include_inactive``
+    defaults to ``False``.
+    """
+    return await list_widget_configs_handler(
+        reseller_id=reseller_id,
+        merchant_id=merchant_id,
+        include_inactive=include_inactive,
+        page=page,
+        limit=limit,
+        current_user=current_user,
+    )
+
+
+@router.get("/widget-config/{widget_config_id}", response_model=WidgetConfigResponse)
+async def get_widget_config(
+    widget_config_id: str,
+    current_user: UserInfo = Depends(get_current_user_with_rbac),
+) -> WidgetConfigResponse:
+    """Get a widget_config by id. RBAC: must have access to its
+    reseller / merchant (403 otherwise)."""
+    return await get_widget_config_by_id_handler(widget_config_id, current_user)
+
+
+@router.put("/widget-config/{widget_config_id}", response_model=WidgetConfigResponse)
+async def update_widget_config(
+    widget_config_id: str,
+    body: WidgetConfigUpdate,
+    current_user: UserInfo = Depends(get_current_user_with_rbac),
+) -> WidgetConfigResponse:
+    """Partial update. Fields omitted from the body remain unchanged.
+    ``public_widget_key`` cannot be set or rotated through this route."""
+    return await update_widget_config_handler(widget_config_id, body, current_user)
+
+
+@router.delete(
+    "/widget-config/{widget_config_id}", response_model=DeleteWidgetConfigResponse
+)
+async def delete_widget_config(
+    widget_config_id: str,
+    current_user: UserInfo = Depends(get_current_user_with_rbac),
+) -> DeleteWidgetConfigResponse:
+    """Delete a widget_config row. Admin only (matches templates DELETE)."""
+    require_admin(current_user)
+    return await delete_widget_config_handler(widget_config_id, current_user)
+
+
+__all__ = ["router"]

--- a/app/api/routers/breeze_buddy/widget_config/handlers.py
+++ b/app/api/routers/breeze_buddy/widget_config/handlers.py
@@ -1,0 +1,283 @@
+"""Business logic for widget_config CRUD (CHAT_MODE.md §14).
+
+All handlers run after the route layer has validated the user's RBAC
+token. Reseller/merchant scoping is enforced here via
+``validate_template_access`` from the templates RBAC module — same
+predicate semantics (admin → all; reseller owns reseller_id; merchant
+owns merchant_id), so the two surfaces stay consistent.
+
+``public_widget_key`` is generated server-side here and never read
+from the request body, so a client cannot pre-commit a key it knows.
+"""
+
+import secrets
+from math import ceil
+from typing import Optional
+
+from fastapi import HTTPException, status
+
+from app.api.routers.breeze_buddy.templates.rbac import validate_template_access
+from app.core.logger import logger
+from app.database.accessor import get_template_by_id
+from app.database.accessor.breeze_buddy.widget_config import (
+    create_widget_config,
+    delete_widget_config,
+    get_widget_config_by_id,
+    get_widget_config_by_reseller_merchant,
+    list_widget_configs,
+    update_widget_config,
+)
+from app.schemas import UserInfo
+from app.schemas.breeze_buddy.widget_config import (
+    DeleteWidgetConfigResponse,
+    WidgetConfigCreate,
+    WidgetConfigListResponse,
+    WidgetConfigResponse,
+    WidgetConfigUpdate,
+)
+
+# 32 url-safe bytes → ~43 chars; well inside the column's varchar(128)
+# and gives ~256 bits of entropy. Matches what major SaaS vendors hand
+# out for embed keys.
+_PUBLIC_KEY_NBYTES = 32
+
+
+def _generate_public_widget_key() -> str:
+    """Opaque, URL-safe, hard to guess. Never echo the prefix in 404s."""
+    return secrets.token_urlsafe(_PUBLIC_KEY_NBYTES)
+
+
+async def create_widget_config_handler(
+    body: WidgetConfigCreate, current_user: UserInfo
+) -> WidgetConfigResponse:
+    logger.info(
+        f"User {current_user.username} (role: {current_user.role}) creating "
+        f"widget_config for reseller={body.reseller_id} merchant={body.merchant_id}"
+    )
+
+    # RBAC: caller must own the reseller_id + merchant_id they're
+    # configuring. Admin is allowed everywhere.
+    validate_template_access(
+        current_user,
+        body.reseller_id,
+        body.merchant_id,
+        operation="create widget_config",
+    )
+
+    # Confirm the template exists and is in the same reseller/merchant
+    # scope. The FK would catch a missing template_id at insert time, but
+    # we want a clear 400 (not 500) for invalid input.
+    template = await get_template_by_id(body.template_id)
+    if not template:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Template '{body.template_id}' not found",
+        )
+    if template.reseller_id != body.reseller_id:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Template does not belong to the specified reseller",
+        )
+    # ``template.merchant_id is None`` means the template applies to all
+    # merchants under that reseller — allowed for any merchant_id here.
+    # Otherwise both must match.
+    template_merchant = getattr(template, "merchant_id", None)
+    if template_merchant and template_merchant != body.merchant_id:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Template does not belong to the specified merchant",
+        )
+
+    existing = await get_widget_config_by_reseller_merchant(
+        body.reseller_id, body.merchant_id
+    )
+    if existing:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=(
+                "widget_config already exists for this reseller/merchant. "
+                "Update or delete the existing row instead."
+            ),
+        )
+
+    public_widget_key = _generate_public_widget_key()
+    created = await create_widget_config(
+        reseller_id=body.reseller_id,
+        merchant_id=body.merchant_id,
+        public_widget_key=public_widget_key,
+        template_id=body.template_id,
+        allowed_origins=body.allowed_origins,
+        max_sessions_per_ip_hour=body.max_sessions_per_ip_hour,
+        max_messages_per_ip_hour=body.max_messages_per_ip_hour,
+        max_concurrent_per_ip=body.max_concurrent_per_ip,
+        max_voice_sessions_per_ip_hour=body.max_voice_sessions_per_ip_hour,
+        active=body.active,
+    )
+    if not created:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to create widget_config",
+        )
+    return created
+
+
+async def list_widget_configs_handler(
+    *,
+    reseller_id: Optional[str],
+    merchant_id: Optional[str],
+    include_inactive: bool,
+    page: int,
+    limit: int,
+    current_user: UserInfo,
+) -> WidgetConfigListResponse:
+    """RBAC-aware listing.
+
+    Admins see all rows in scope. Non-admins are scoped to their
+    accessible resellers / merchants; the query receives those arrays
+    as ``reseller_ids`` / ``merchant_ids`` filters. A non-admin
+    requesting a specific reseller_id / merchant_id they don't own
+    gets 403.
+    """
+    accessible_reseller_ids: Optional[list] = None
+    accessible_merchant_ids: Optional[list] = None
+
+    if current_user.role != "admin":
+        if "*" not in current_user.reseller_ids:
+            accessible_reseller_ids = current_user.reseller_ids
+            if reseller_id and reseller_id not in current_user.reseller_ids:
+                raise HTTPException(
+                    status_code=status.HTTP_403_FORBIDDEN,
+                    detail=f"Access denied to reseller {reseller_id}",
+                )
+        if "*" not in current_user.merchant_ids:
+            accessible_merchant_ids = current_user.merchant_ids
+            if merchant_id and merchant_id not in current_user.merchant_ids:
+                raise HTTPException(
+                    status_code=status.HTTP_403_FORBIDDEN,
+                    detail=f"Access denied to merchant {merchant_id}",
+                )
+
+    items, total = await list_widget_configs(
+        page=page,
+        limit=limit,
+        reseller_id=reseller_id,
+        merchant_id=merchant_id,
+        reseller_ids=accessible_reseller_ids,
+        merchant_ids=accessible_merchant_ids,
+        include_inactive=include_inactive,
+    )
+    return WidgetConfigListResponse(
+        widget_configs=items,
+        total=total,
+        page=page,
+        limit=limit,
+    )
+
+
+async def get_widget_config_by_id_handler(
+    widget_config_id: str, current_user: UserInfo
+) -> WidgetConfigResponse:
+    cfg = await get_widget_config_by_id(widget_config_id)
+    if cfg is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"widget_config {widget_config_id} not found",
+        )
+    validate_template_access(
+        current_user,
+        cfg.reseller_id,
+        cfg.merchant_id,
+        operation="read widget_config",
+    )
+    return cfg
+
+
+async def update_widget_config_handler(
+    widget_config_id: str,
+    body: WidgetConfigUpdate,
+    current_user: UserInfo,
+) -> WidgetConfigResponse:
+    cfg = await get_widget_config_by_id(widget_config_id)
+    if cfg is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"widget_config {widget_config_id} not found",
+        )
+    validate_template_access(
+        current_user,
+        cfg.reseller_id,
+        cfg.merchant_id,
+        operation="update widget_config",
+    )
+
+    # If template_id is being changed, validate it exists and stays in
+    # the same reseller/merchant scope as the widget_config.
+    if body.template_id is not None and body.template_id != cfg.template_id:
+        template = await get_template_by_id(body.template_id)
+        if not template:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"Template '{body.template_id}' not found",
+            )
+        if template.reseller_id != cfg.reseller_id:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Template does not belong to this widget's reseller",
+            )
+        template_merchant = getattr(template, "merchant_id", None)
+        if template_merchant and template_merchant != cfg.merchant_id:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Template does not belong to this widget's merchant",
+            )
+
+    updated = await update_widget_config(
+        widget_config_id,
+        template_id=body.template_id,
+        allowed_origins=body.allowed_origins,
+        max_sessions_per_ip_hour=body.max_sessions_per_ip_hour,
+        max_messages_per_ip_hour=body.max_messages_per_ip_hour,
+        max_concurrent_per_ip=body.max_concurrent_per_ip,
+        max_voice_sessions_per_ip_hour=body.max_voice_sessions_per_ip_hour,
+        active=body.active,
+    )
+    if updated is None:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to update widget_config",
+        )
+    return updated
+
+
+async def delete_widget_config_handler(
+    widget_config_id: str, current_user: UserInfo
+) -> DeleteWidgetConfigResponse:
+    cfg = await get_widget_config_by_id(widget_config_id)
+    if cfg is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"widget_config {widget_config_id} not found",
+        )
+    # Admin gate already happened at the route layer; we don't double-
+    # check via validate_template_access because admin matches everything.
+    deleted = await delete_widget_config(widget_config_id)
+    if not deleted:
+        # Race with a concurrent delete — treat as 404 for the caller.
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"widget_config {widget_config_id} not found",
+        )
+    return DeleteWidgetConfigResponse(
+        status="success",
+        message=(
+            f"widget_config {widget_config_id} (reseller={cfg.reseller_id}, "
+            f"merchant={cfg.merchant_id}) deleted"
+        ),
+        deleted_id=widget_config_id,
+    )
+
+
+# Re-exported for callers that want to compute total_pages from a list
+# response without importing math themselves.
+def total_pages(total: int, limit: int) -> int:
+    return max(ceil(total / limit), 1) if limit else 1

--- a/app/api/security/breeze_buddy/rbac_token.py
+++ b/app/api/security/breeze_buddy/rbac_token.py
@@ -88,6 +88,28 @@ class BreezeBuddyRBACTokenManager:
                 algorithms=[self.jwt_manager.algorithm],
             )
 
+            # Reject non-RBAC token types up front. Widget tokens (typ="widget",
+            # see ``widget_token.py``) and demo tokens (``demo: true``, see
+            # ``demo_token.py``) are signed by the same key but must never be
+            # accepted on RBAC routes — they carry no reseller/merchant scopes
+            # and would otherwise authenticate as a UserInfo with empty
+            # arrays. All existing RBAC/s2s tokens are minted without these
+            # claims, so the check is backward-compatible.
+            if payload.get("typ") == "widget":
+                logger.warning("RBAC verifier: rejected widget token")
+                raise HTTPException(
+                    status_code=status.HTTP_401_UNAUTHORIZED,
+                    detail="Could not validate credentials",
+                    headers={"WWW-Authenticate": "Bearer"},
+                )
+            if payload.get("demo") is True:
+                logger.warning("RBAC verifier: rejected demo token")
+                raise HTTPException(
+                    status_code=status.HTTP_401_UNAUTHORIZED,
+                    detail="Could not validate credentials",
+                    headers={"WWW-Authenticate": "Bearer"},
+                )
+
             # Check if token has expired (redundant with jwt.decode but explicit)
             exp = payload.get("exp")
             if exp is None:

--- a/app/api/security/breeze_buddy/widget_token.py
+++ b/app/api/security/breeze_buddy/widget_token.py
@@ -1,0 +1,204 @@
+"""Widget-session JWT — mint + verify for the unified widget endpoints.
+
+Why a separate token type instead of reusing the standard RBAC JWT or
+the demo token (see ``demo_token.py``):
+
+- Widget endpoints (``/widget/session/*``) are reached anonymously
+  from a merchant's browser embed. Like the demo, they have no
+  upstream user; unlike the demo, they are production traffic gated
+  by a per-merchant ``widget_config`` row instead of a hardcoded slug
+  allowlist.
+- A widget JWT carries ``typ: "widget"``. The standard RBAC verifier
+  (``rbac_token.py``) is hardened to reject ``typ == "widget"`` so a
+  leaked widget token cannot drive any RBAC endpoint. The demo
+  verifier (``demo_token.py``) already rejects non-demo tokens by
+  checking ``demo: true``.
+- One token, one session, both channels. The conversation backbone is
+  a single ``chat_session`` row that voice can attach to as a
+  transient. The token binds to ``widget_session_id`` and stays valid
+  across chat → voice → chat handoffs — no re-mint needed (see
+  ``docs/CHAT_MODE.md`` §14 for the unified-session model).
+- Pinned to ``widget_session_id``: the dependency rejects any
+  path-param ``session_id`` that doesn't match — so a leaked token
+  can't be steered to other sessions.
+
+TTL default is 24 h. Voice attachments inside that 24 h are bounded
+separately by Daily room expiry (1 h).
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import timedelta
+from typing import Annotated, Any, Dict
+
+import jwt as pyjwt
+from fastapi import Depends, HTTPException, Path, status
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+
+from app.core.logger import logger
+from app.core.security.jwt import jwt_manager
+
+# Shared HTTPBearer scheme so the OpenAPI doc shows one consistent
+# Authorization header across widget routes. ``auto_error=True`` gives
+# us 403 when the header is missing — matches RBAC/demo behaviour.
+_widget_bearer = HTTPBearer(auto_error=True, scheme_name="WidgetBearer")
+
+TYP_WIDGET = "widget"
+
+# Default lifetime — see module docstring.
+DEFAULT_WIDGET_TOKEN_TTL_MINUTES = 24 * 60
+
+
+class WidgetSessionContext:
+    """Resolved widget-token claims, returned by ``require_widget_session``."""
+
+    __slots__ = ("session_id", "widget_config_id", "subject")
+
+    def __init__(self, *, session_id: str, widget_config_id: str, subject: str) -> None:
+        self.session_id = session_id
+        self.widget_config_id = widget_config_id
+        self.subject = subject
+
+
+def mint_widget_token(
+    *,
+    widget_session_id: str,
+    widget_config_id: str,
+    ttl_minutes: int = DEFAULT_WIDGET_TOKEN_TTL_MINUTES,
+) -> str:
+    """Issue a widget JWT bound to ``widget_session_id``.
+
+    ``sub`` is a fresh anonymous identifier (``widget-<short-uuid>``) —
+    useful in logs but never used for authorization. The real gates are
+    the ``typ`` and ``widget_session_id`` claims verified by
+    ``require_widget_session``.
+
+    Synchronous: callers know the TTL they want (24h for widget mode).
+    """
+    subject = f"widget-{uuid.uuid4().hex[:12]}"
+    payload: Dict[str, Any] = {
+        "sub": subject,
+        "typ": TYP_WIDGET,
+        "widget_session_id": widget_session_id,
+        "widget_config_id": widget_config_id,
+    }
+    return jwt_manager.create_access_token(
+        payload, expires_delta=timedelta(minutes=ttl_minutes)
+    )
+
+
+def _decode_or_401(token: str) -> Dict[str, Any]:
+    """Verify the JWT signature + standard claims, or raise 401."""
+    try:
+        return pyjwt.decode(
+            token,
+            jwt_manager.secret_key,
+            algorithms=[jwt_manager.algorithm],
+        )
+    except pyjwt.ExpiredSignatureError:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Widget session token expired",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+    except pyjwt.InvalidTokenError as exc:
+        logger.warning(f"widget_token: invalid token: {exc}")
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid widget session token",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+
+def require_widget_session(
+    session_id: Annotated[str, Path(...)],
+    creds: Annotated[HTTPAuthorizationCredentials, Depends(_widget_bearer)],
+) -> WidgetSessionContext:
+    """FastAPI dependency for ``/widget/session/{session_id}/...`` routes.
+
+    Verifies the bearer token is a *widget* token (``typ=widget``) and
+    that its bound ``widget_session_id`` matches the URL path. Either
+    check failing yields 401 — same status as the standard RBAC /
+    demo deps so clients don't have to special-case widget failures.
+    """
+    payload = _decode_or_401(creds.credentials)
+
+    if payload.get("typ") != TYP_WIDGET:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Token is not a widget token",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    claim_session = payload.get("widget_session_id")
+    if not isinstance(claim_session, str) or claim_session != session_id:
+        # Don't echo back which session the token *was* for — small
+        # reconnaissance hardening on a public endpoint.
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Widget token does not match this session",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    widget_config_id = payload.get("widget_config_id")
+    if not isinstance(widget_config_id, str) or not widget_config_id:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Widget token missing widget_config_id",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    return WidgetSessionContext(
+        session_id=session_id,
+        widget_config_id=widget_config_id,
+        subject=str(payload.get("sub", "")),
+    )
+
+
+def assert_widget_session_ownership(session: Any, ctx: WidgetSessionContext) -> None:
+    """Verify the chat_session was created by the same widget_config the
+    bearer token claims. Returns silently on match; raises 404 on
+    mismatch (or on a malformed metadata payload).
+
+    Why a separate assert instead of folding into ``require_widget_session``:
+    the dep runs before the session is loaded — it only sees the path
+    param + the token claims. The DB-side proof "this session row belongs
+    to widget_config X" can only be checked after a SELECT, so each
+    handler runs it explicitly right after ``get_chat_session_by_id``.
+
+    Why 404 (not 403): leaking "this session exists but isn't yours"
+    gives an attacker who's already harvested session UUIDs a probe
+    oracle. We treat ownership mismatch and not-found identically.
+
+    The check defends against a leaked widget token being steered at
+    any session UUID the attacker has discovered (logs, error pages,
+    metrics) — without this assert, `widget_session_id`-claim binding
+    alone is insufficient.
+    """
+    try:
+        widget_meta = (
+            session.metadata.get("widget") if session and session.metadata else None
+        )
+        owning_config_id = widget_meta.get("widget_config_id") if widget_meta else None
+    except AttributeError:
+        owning_config_id = None
+    if owning_config_id != ctx.widget_config_id:
+        logger.warning(
+            f"widget ownership mismatch: token widget_config_id={ctx.widget_config_id} "
+            f"vs session metadata={owning_config_id!r} (session_id={ctx.session_id})"
+        )
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Widget session '{ctx.session_id}' not found",
+        )
+
+
+__all__ = [
+    "DEFAULT_WIDGET_TOKEN_TTL_MINUTES",
+    "TYP_WIDGET",
+    "WidgetSessionContext",
+    "assert_widget_session_ownership",
+    "mint_widget_token",
+    "require_widget_session",
+]

--- a/app/core/config/static.py
+++ b/app/core/config/static.py
@@ -435,7 +435,11 @@ BB_PROMOTER_LEADER_TTL_S = int(os.environ.get("BB_PROMOTER_LEADER_TTL_S", 5))
 BB_PROMOTER_LEADER_RENEW_S = int(os.environ.get("BB_PROMOTER_LEADER_RENEW_S", 2))
 
 # Workers
-BB_WORKER_COUNT = int(os.environ.get("BB_WORKER_COUNT", 20))
+# Default count is environment-aware: dev pods only need a couple of BLPOP
+# loops for smoke-testing the dispatcher path; production sizes for real
+# outbound load. Explicit BB_WORKER_COUNT in the env wins over the default.
+_BB_WORKER_COUNT_DEFAULT = 2 if ENVIRONMENT == "dev" else 20
+BB_WORKER_COUNT = int(os.environ.get("BB_WORKER_COUNT", _BB_WORKER_COUNT_DEFAULT))
 BB_WORKER_BLPOP_TIMEOUT_S = int(os.environ.get("BB_WORKER_BLPOP_TIMEOUT_S", 30))
 BB_WORKER_HEARTBEAT_TTL_S = int(os.environ.get("BB_WORKER_HEARTBEAT_TTL_S", 60))
 BB_WORKER_HEARTBEAT_REFRESH_S = int(os.environ.get("BB_WORKER_HEARTBEAT_REFRESH_S", 10))

--- a/app/core/security/jwt.py
+++ b/app/core/security/jwt.py
@@ -26,10 +26,41 @@ CREDENTIALS_EXCEPTION = HTTPException(
 )
 
 
+# Algorithms PyJWT is allowed to honor. Explicit allowlist — never
+# include "none" (would accept unsigned tokens), and never trust the
+# `alg` claim in the token header itself. If the env var ``JWT_ALGORITHM``
+# is set to anything outside this set, the process refuses to start.
+_ALLOWED_JWT_ALGORITHMS = {
+    "HS256",
+    "HS384",
+    "HS512",
+    "RS256",
+    "RS384",
+    "RS512",
+    "ES256",
+}
+
+
 class JWTManager:
     """JWT token management class"""
 
     def __init__(self):
+        # Fail-fast on misconfiguration. Empty secret → PyJWT would
+        # validate against an empty key (catastrophic). Empty / "none"
+        # algorithm → PyJWT could accept unsigned tokens. Either is a
+        # production-critical foot-gun; we refuse to start instead of
+        # discovering it on the first auth request.
+        if not JWT_SECRET_KEY:
+            raise RuntimeError(
+                "JWT_SECRET_KEY env var is empty. Set it to a strong random "
+                "secret before starting the service."
+            )
+        if JWT_ALGORITHM not in _ALLOWED_JWT_ALGORITHMS:
+            raise RuntimeError(
+                f"JWT_ALGORITHM env var is {JWT_ALGORITHM!r}; must be one of "
+                f"{sorted(_ALLOWED_JWT_ALGORITHMS)}. The value 'none' is "
+                "explicitly forbidden — it would accept unsigned tokens."
+            )
         self.secret_key = JWT_SECRET_KEY
         self.algorithm = JWT_ALGORITHM
         self.access_token_expire_minutes = JWT_ACCESS_TOKEN_EXPIRE_MINUTES
@@ -297,6 +328,15 @@ async def get_breeze_buddy_session(request: Request):
     if not session_cookie:
         return None
     try:
+        # Algorithm goes through the same allowlist as JWTManager —
+        # JWT_ALGORITHM is validated at JWTManager construction, but
+        # this decode bypasses the manager, so we re-assert here.
+        if JWT_ALGORITHM not in _ALLOWED_JWT_ALGORITHMS:
+            logger.error(
+                f"get_breeze_buddy_session: JWT_ALGORITHM={JWT_ALGORITHM!r} "
+                "not in allowlist — refusing to decode."
+            )
+            return None
         payload = jwt.decode(
             session_cookie, BREEZE_BUDDY_SESSION_SECRET_KEY, algorithms=[JWT_ALGORITHM]
         )

--- a/app/database/accessor/breeze_buddy/chat_session.py
+++ b/app/database/accessor/breeze_buddy/chat_session.py
@@ -1,4 +1,4 @@
-"""Async accessors for chat_session and chat_message.
+"""Async accessors for chat_session, chat_message, and agent_session_state.
 
 Calls into queries/breeze_buddy/chat_session.py for SQL and
 decoder/breeze_buddy/chat_session.py for row → Pydantic.
@@ -11,24 +11,32 @@ from typing import Any, Dict, List, Optional
 
 from app.core.logger import logger
 from app.database.decoder.breeze_buddy.chat_session import (
+    decode_agent_session_state,
     decode_chat_message,
     decode_chat_session,
 )
 from app.database.queries import run_parameterized_query
 from app.database.queries.breeze_buddy.chat_session import (
     create_chat_session_query,
+    drain_voice_into_chat_session_query,
     end_chat_session_query,
+    flip_chat_session_channel_query,
+    get_agent_session_state_query,
     get_chat_session_by_id_query,
     insert_chat_message_query,
     list_chat_messages_for_session_query,
     list_idle_chat_sessions_query,
+    set_chat_session_voice_lead_query,
     update_chat_session_after_turn_query,
+    upsert_agent_session_state_query,
 )
 from app.schemas.breeze_buddy.chat import (
+    AgentSessionState,
     ChatMessage,
     ChatMessageRole,
     ChatSession,
     ChatSessionStatus,
+    WidgetChannel,
 )
 
 # -- chat_session -------------------------------------------------------------
@@ -148,12 +156,31 @@ async def insert_chat_message(
     session_id: str,
     role: ChatMessageRole,
     content: Optional[str] = None,
+    content_blocks: Optional[List[Dict[str, Any]]] = None,
+    ui_blocks: Optional[List[Dict[str, Any]]] = None,
 ) -> Optional[ChatMessage]:
-    """Append one message; idx is auto-allocated atomically by the query."""
+    """Append one message; idx is auto-allocated atomically by the query.
+
+    ``content_blocks`` is the canonical Anthropic content array (text +
+    tool_use on assistant rows, text + tool_result on user rows). When
+    supplied it's the source of truth for history replay; ``content``
+    remains as a denormalised prose view. Pre-migration callers that
+    pass only ``content`` still work — the column defaults to NULL and
+    the loader synthesises a [text] block.
+
+    ``ui_blocks`` (migration 030) is the SpecStream ui_op list emitted
+    during an assistant turn. Consumed only by the widget resume path
+    to repaint Tiles/Carousels — the LLM never sees this column. Pass
+    ``None`` (default) on user turns and on assistant turns without UI.
+    """
     query, values = insert_chat_message_query(
         session_id=session_id,
         role=role.value,
         content=content,
+        content_blocks_json=(
+            json.dumps(content_blocks) if content_blocks is not None else None
+        ),
+        ui_blocks_json=(json.dumps(ui_blocks) if ui_blocks else None),
     )
     try:
         result = await run_parameterized_query(query, values)
@@ -188,4 +215,197 @@ async def list_chat_messages_for_session(
         return messages
     except Exception as e:
         logger.error(f"Error listing chat messages for session {session_id}: {e}")
+        raise
+
+
+# -- widget-mode channel state mutations (migration 030) --------------------
+
+
+async def bind_voice_lead_to_chat_session(
+    session_id: str, voice_lead_id: str
+) -> Optional[ChatSession]:
+    """First-time bind of a voice lead to a chat_session.
+
+    Conditioned on ``voice_lead_id IS NULL`` so a concurrent
+    /voice/connect can't overwrite an already-bound lead. Returns
+    the updated row, or None when the row already had a
+    voice_lead_id (caller should reuse the existing lead).
+    """
+    query, values = set_chat_session_voice_lead_query(session_id, voice_lead_id)
+    try:
+        result = await run_parameterized_query(query, values)
+        row = result[0] if result else None
+        return decode_chat_session(row) if row else None
+    except Exception as e:
+        logger.error(
+            f"Error binding voice lead {voice_lead_id} to chat_session "
+            f"{session_id}: {e}"
+        )
+        raise
+
+
+async def flip_chat_session_to_voice(session_id: str) -> Optional[ChatSession]:
+    """Flip current_channel CHAT → VOICE.
+
+    Conditioned on the row currently being CHAT. Returns the updated
+    row, or None when the precondition failed (409 from caller).
+    Used by POST /widget/session/{id}/voice/connect.
+    """
+    query, values = flip_chat_session_channel_query(
+        session_id,
+        new_channel=WidgetChannel.VOICE.value,
+        expected_channel=WidgetChannel.CHAT.value,
+    )
+    try:
+        result = await run_parameterized_query(query, values)
+        row = result[0] if result else None
+        return decode_chat_session(row) if row else None
+    except Exception as e:
+        logger.error(f"Error flipping chat_session {session_id} to VOICE: {e}")
+        raise
+
+
+async def flip_chat_session_to_chat(
+    session_id: str, voice_lead_id: Optional[str]
+) -> Optional[ChatSession]:
+    """Flip current_channel VOICE → CHAT. Used as the /voice/end
+    rollback path (when end_conversation drain isn't going to happen).
+
+    Conditioned on (current_channel=VOICE AND voice_lead_id matches)
+    so a stale callback for an old lead can't clobber a re-attached
+    session. voice_lead_id is preserved (the lead is still bound to
+    this conversation).
+
+    Pass ``voice_lead_id=None`` for the orphan-state path
+    (`current_channel=VOICE` but `voice_lead_id` is NULL) — the query
+    builder omits the voice_lead_id predicate when None, so the
+    conditional UPDATE still matches the inconsistent row by id +
+    current_channel alone.
+    """
+    query, values = flip_chat_session_channel_query(
+        session_id,
+        new_channel=WidgetChannel.CHAT.value,
+        expected_channel=WidgetChannel.VOICE.value,
+        expected_voice_lead_id=voice_lead_id,
+    )
+    try:
+        result = await run_parameterized_query(query, values)
+        row = result[0] if result else None
+        return decode_chat_session(row) if row else None
+    except Exception as e:
+        logger.error(f"Error flipping chat_session {session_id} to CHAT: {e}")
+        raise
+
+
+async def drain_voice_into_chat_session(
+    *,
+    chat_session_id: str,
+    lead_id: str,
+    new_messages: List[Dict[str, Any]],
+    final_node: Optional[str],
+) -> bool:
+    """End-of-voice drain: append new turns, advance current_node,
+    flip channel back to CHAT.
+
+    voice_lead_id is intentionally PRESERVED — the lead is bound to
+    the conversation for its full lifetime; the next /voice/connect
+    reuses it via attempt_count.
+
+    Idempotent against duplicate fires (e.g., end_conversation invoked
+    twice). The (session_id, idx) PK + atomic idx subquery in
+    insert_chat_message_query make duplicate INSERTs impossible at
+    the DB level; we wrap each insert just in case so a single
+    duplicate doesn't stop the rest.
+
+    Returns True when the channel flip succeeded (this drain owned
+    the close-out). False when the row had already moved on
+    (another caller ended the voice first).
+    """
+    # 1. Append any new turns.
+    for msg in new_messages:
+        role = msg.get("role")
+        content = msg.get("content")
+        if role not in ("user", "assistant") or not content:
+            continue
+        try:
+            await insert_chat_message(
+                session_id=chat_session_id,
+                role=ChatMessageRole(role),
+                content=content,
+            )
+        except Exception as e:
+            logger.warning(
+                f"drain: skip insert (session={chat_session_id}, role={role!r}): {e}"
+            )
+
+    # 2. Flip channel + advance current_node atomically. voice_lead_id
+    # stays bound for reuse on the next /voice/connect.
+    query, values = drain_voice_into_chat_session_query(
+        chat_session_id,
+        final_node=final_node,
+        expected_voice_lead_id=lead_id,
+    )
+    try:
+        result = await run_parameterized_query(query, values)
+        if result:
+            logger.info(
+                f"drain: voice lead {lead_id} drained into chat_session "
+                f"{chat_session_id}, final_node={final_node!r} "
+                "(voice_lead_id preserved for reuse)"
+            )
+            return True
+        logger.info(
+            f"drain: chat_session {chat_session_id} no longer matches "
+            f"lead {lead_id}; flip skipped"
+        )
+        return False
+    except Exception as e:
+        logger.error(
+            f"drain: failed to flip chat_session {chat_session_id} after "
+            f"lead {lead_id}: {e}"
+        )
+        raise
+
+
+# -- agent_session_state ------------------------------------------------------
+
+
+async def get_agent_session_state(
+    chat_session_id: str,
+) -> Optional[AgentSessionState]:
+    """Read the agent state row for a session. Returns None if absent.
+
+    The runtime treats `data` as opaque — what's inside is determined
+    by template-declared reducers.
+    """
+    query, values = get_agent_session_state_query(chat_session_id)
+    try:
+        result = await run_parameterized_query(query, values)
+        row = result[0] if result else None
+        return decode_agent_session_state(row) if row else None
+    except Exception as e:
+        logger.error(f"Error reading agent_session_state for {chat_session_id}: {e}")
+        raise
+
+
+async def upsert_agent_session_state(
+    chat_session_id: str,
+    data: Dict[str, Any],
+) -> Optional[AgentSessionState]:
+    """INSERT-or-REPLACE the full data dict for a session.
+
+    Caller is responsible for computing the merged next state via the
+    reducer engine. This accessor is a dumb store — keeps merging logic
+    pure-Python and easy to test.
+    """
+    query, values = upsert_agent_session_state_query(
+        chat_session_id=chat_session_id,
+        data_json=json.dumps(data),
+    )
+    try:
+        result = await run_parameterized_query(query, values)
+        row = result[0] if result else None
+        return decode_agent_session_state(row) if row else None
+    except Exception as e:
+        logger.error(f"Error upserting agent_session_state for {chat_session_id}: {e}")
         raise

--- a/app/database/accessor/breeze_buddy/lead_call_tracker.py
+++ b/app/database/accessor/breeze_buddy/lead_call_tracker.py
@@ -23,6 +23,7 @@ from app.database.queries.breeze_buddy.lead_call_tracker import (
     get_leads_by_status_and_time_before_query,
     insert_lead_call_tracker_query,
     release_lock_on_lead_by_id_query,
+    reset_widget_voice_lead_query,
     update_langfuse_scores_query,
     update_lead_call_completion_details_query,
     update_lead_call_details_query,
@@ -678,3 +679,34 @@ async def update_lead_request_id(lead_id: str, request_id: str) -> None:
         logger.info(f"request_id updated successfully for lead ID: {lead_id}")
     except Exception as e:
         logger.error(f"Error updating request_id for lead ID {lead_id}: {e}")
+
+
+async def reset_widget_voice_lead(
+    lead_id: str,
+    payload: Dict[str, Any],
+    meta_data_seed: Dict[str, Any],
+) -> Optional[LeadCallTracker]:
+    """Reset a widget voice lead so the next /voice/connect can reuse it.
+
+    Used only by the unified widget router (CHAT_MODE.md §14): one
+    chat_session has ONE voice lead (set in chat_session.voice_lead_id)
+    that persists for the conversation's lifetime. Each /voice/connect
+    after the first reuses this lead — bumps attempt_count, refreshes
+    the seed (start_node, prior_history), clears per-call fields
+    (call_id, outcome, etc.) so they don't leak from the previous
+    attempt.
+    """
+    logger.info(
+        f"Resetting widget voice lead {lead_id} for next attempt "
+        f"(seed: {sorted(meta_data_seed.keys())})"
+    )
+    query_text, values = reset_widget_voice_lead_query(lead_id, payload, meta_data_seed)
+    try:
+        result = await run_parameterized_query(query_text, values)
+        if result and get_row_count(result) > 0:
+            return decode_lead_call_tracker(result[0])
+        logger.error(f"Failed to reset widget voice lead {lead_id} (no row updated)")
+        return None
+    except Exception as e:
+        logger.error(f"Error resetting widget voice lead {lead_id}: {e}")
+        raise

--- a/app/database/accessor/breeze_buddy/widget_config.py
+++ b/app/database/accessor/breeze_buddy/widget_config.py
@@ -1,0 +1,201 @@
+"""Async accessor functions for widget_config (migration 030).
+
+Thin wrappers around ``run_parameterized_query`` + ``decode_widget_config``.
+Returns Pydantic models, never raw rows. Errors are logged + re-raised
+so route handlers can convert them into the appropriate HTTP status.
+"""
+
+from typing import List, Optional, Tuple
+
+from app.core.logger import logger
+from app.database.decoder.breeze_buddy.widget_config import decode_widget_config
+from app.database.queries import run_parameterized_query
+from app.database.queries.breeze_buddy.widget_config import (
+    create_widget_config_query,
+    delete_widget_config_query,
+    get_widget_config_by_id_query,
+    get_widget_config_by_public_key_query,
+    get_widget_config_by_reseller_merchant_query,
+    list_widget_configs_query,
+    update_widget_config_query,
+)
+from app.schemas.breeze_buddy.widget_config import WidgetConfigResponse
+
+
+async def create_widget_config(
+    *,
+    reseller_id: str,
+    merchant_id: str,
+    public_widget_key: str,
+    template_id: str,
+    allowed_origins: List[str],
+    max_sessions_per_ip_hour: int,
+    max_messages_per_ip_hour: int,
+    max_concurrent_per_ip: int,
+    max_voice_sessions_per_ip_hour: int,
+    active: bool,
+) -> Optional[WidgetConfigResponse]:
+    query, values = create_widget_config_query(
+        reseller_id=reseller_id,
+        merchant_id=merchant_id,
+        public_widget_key=public_widget_key,
+        template_id=template_id,
+        allowed_origins=allowed_origins,
+        max_sessions_per_ip_hour=max_sessions_per_ip_hour,
+        max_messages_per_ip_hour=max_messages_per_ip_hour,
+        max_concurrent_per_ip=max_concurrent_per_ip,
+        max_voice_sessions_per_ip_hour=max_voice_sessions_per_ip_hour,
+        active=active,
+    )
+    try:
+        result = await run_parameterized_query(query, values)
+        row = result[0] if result else None
+        if row:
+            logger.info(
+                f"Created widget_config: reseller={reseller_id} merchant={merchant_id} "
+                f"id={row['id']}"
+            )
+            return decode_widget_config(row)
+        return None
+    except Exception as e:
+        logger.error(
+            f"Error creating widget_config for reseller={reseller_id} "
+            f"merchant={merchant_id}: {e}"
+        )
+        raise
+
+
+async def get_widget_config_by_id(
+    widget_config_id: str,
+) -> Optional[WidgetConfigResponse]:
+    query, values = get_widget_config_by_id_query(widget_config_id)
+    try:
+        result = await run_parameterized_query(query, values)
+        row = result[0] if result else None
+        return decode_widget_config(row) if row else None
+    except Exception as e:
+        logger.error(f"Error fetching widget_config {widget_config_id}: {e}")
+        raise
+
+
+async def get_widget_config_by_public_key(
+    public_widget_key: str,
+) -> Optional[WidgetConfigResponse]:
+    """Hot path: resolve a widget_config from the public key the embed sent.
+
+    Returns ``None`` on miss so the handler can decide between 404 (key
+    unknown / inactive) and an audit log.
+    """
+    query, values = get_widget_config_by_public_key_query(public_widget_key)
+    try:
+        result = await run_parameterized_query(query, values)
+        row = result[0] if result else None
+        return decode_widget_config(row) if row else None
+    except Exception as e:
+        # Log without the actual key — it's a credential.
+        logger.error(
+            f"Error fetching widget_config by public_widget_key "
+            f"(key_prefix={public_widget_key[:6]!r}): {e}"
+        )
+        raise
+
+
+async def get_widget_config_by_reseller_merchant(
+    reseller_id: str, merchant_id: str
+) -> Optional[WidgetConfigResponse]:
+    query, values = get_widget_config_by_reseller_merchant_query(
+        reseller_id, merchant_id
+    )
+    try:
+        result = await run_parameterized_query(query, values)
+        row = result[0] if result else None
+        return decode_widget_config(row) if row else None
+    except Exception as e:
+        logger.error(
+            f"Error fetching widget_config for reseller={reseller_id} "
+            f"merchant={merchant_id}: {e}"
+        )
+        raise
+
+
+async def list_widget_configs(
+    *,
+    page: int = 1,
+    limit: int = 50,
+    reseller_id: Optional[str] = None,
+    merchant_id: Optional[str] = None,
+    reseller_ids: Optional[List[str]] = None,
+    merchant_ids: Optional[List[str]] = None,
+    include_inactive: bool = False,
+) -> Tuple[List[WidgetConfigResponse], int]:
+    query, count_query, values = list_widget_configs_query(
+        page=page,
+        limit=limit,
+        reseller_id=reseller_id,
+        merchant_id=merchant_id,
+        reseller_ids=reseller_ids,
+        merchant_ids=merchant_ids,
+        include_inactive=include_inactive,
+    )
+    try:
+        rows = await run_parameterized_query(query, values)
+        # values[:-2] strips the LIMIT/OFFSET so the count query sees the
+        # same WHERE-bound parameters.
+        count_result = await run_parameterized_query(count_query, values[:-2])
+        count_row = count_result[0] if count_result else None
+        items = [decode_widget_config(r) for r in rows] if rows else []
+        total = count_row["total"] if count_row else 0
+        return items, total
+    except Exception as e:
+        logger.error(f"Error listing widget_configs: {e}")
+        raise
+
+
+async def update_widget_config(
+    widget_config_id: str,
+    *,
+    template_id: Optional[str] = None,
+    allowed_origins: Optional[List[str]] = None,
+    max_sessions_per_ip_hour: Optional[int] = None,
+    max_messages_per_ip_hour: Optional[int] = None,
+    max_concurrent_per_ip: Optional[int] = None,
+    max_voice_sessions_per_ip_hour: Optional[int] = None,
+    active: Optional[bool] = None,
+) -> Optional[WidgetConfigResponse]:
+    query, values = update_widget_config_query(
+        widget_config_id=widget_config_id,
+        template_id=template_id,
+        allowed_origins=allowed_origins,
+        max_sessions_per_ip_hour=max_sessions_per_ip_hour,
+        max_messages_per_ip_hour=max_messages_per_ip_hour,
+        max_concurrent_per_ip=max_concurrent_per_ip,
+        max_voice_sessions_per_ip_hour=max_voice_sessions_per_ip_hour,
+        active=active,
+    )
+    if not values:
+        # Caller passed no fields — return current row so PUT semantics
+        # stay consistent across "no-op" and "real change".
+        return await get_widget_config_by_id(widget_config_id)
+    try:
+        result = await run_parameterized_query(query, values)
+        row = result[0] if result else None
+        if row:
+            logger.info(f"Updated widget_config: {widget_config_id}")
+            return decode_widget_config(row)
+        return None
+    except Exception as e:
+        logger.error(f"Error updating widget_config {widget_config_id}: {e}")
+        raise
+
+
+async def delete_widget_config(widget_config_id: str) -> bool:
+    query, values = delete_widget_config_query(widget_config_id)
+    try:
+        result = await run_parameterized_query(query, values)
+        deleted = bool(result)
+        if deleted:
+            logger.info(f"Deleted widget_config: {widget_config_id}")
+        return deleted
+    except Exception as e:
+        logger.error(f"Error deleting widget_config {widget_config_id}: {e}")
+        raise

--- a/app/database/decoder/breeze_buddy/chat_session.py
+++ b/app/database/decoder/breeze_buddy/chat_session.py
@@ -1,15 +1,17 @@
-"""Decoders for chat_session and chat_message rows."""
+"""Decoders for chat_session, chat_message, and agent_session_state rows."""
 
-from typing import Optional
+from typing import Any, Dict, List, Optional, cast
 
 import asyncpg
 
 from app.schemas.breeze_buddy.chat import (
+    AgentSessionState,
     ChatEndedReason,
     ChatMessage,
     ChatMessageRole,
     ChatSession,
     ChatSessionStatus,
+    WidgetChannel,
 )
 from app.utils.common import parse_json
 
@@ -20,6 +22,11 @@ def decode_chat_session(row: asyncpg.Record) -> Optional[ChatSession]:
         return None
     metadata = parse_json(row, "metadata") or {}
     ended_reason_raw = row.get("ended_reason")
+    # current_channel + voice_lead_id arrived in migration 030. Older
+    # SELECTs that don't list them would return None — default to CHAT
+    # so the field stays valid for legacy callers.
+    channel_raw = row.get("current_channel") or WidgetChannel.CHAT.value
+    voice_lead_id_raw = row.get("voice_lead_id")
     return ChatSession(
         id=str(row["id"]),
         template_id=str(row["template_id"]),
@@ -29,6 +36,8 @@ def decode_chat_session(row: asyncpg.Record) -> Optional[ChatSession]:
         outcome=row.get("outcome"),
         current_node=row.get("current_node"),
         metadata=metadata,
+        current_channel=WidgetChannel(channel_raw),
+        voice_lead_id=str(voice_lead_id_raw) if voice_lead_id_raw else None,
         created_at=row["created_at"],
         last_activity_at=row["last_activity_at"],
         ended_at=row.get("ended_at"),
@@ -40,10 +49,30 @@ def decode_chat_message(row: asyncpg.Record) -> Optional[ChatMessage]:
     """Build a ChatMessage from a DB row, or None if row is empty."""
     if not row:
         return None
+    # parse_json is annotated `Optional[Dict[str, Any]]` for legacy callers
+    # but the JSON columns we read here are stored as arrays (lists of block
+    # dicts). The runtime accepts whatever shape the column held; the cast
+    # silences pyrefly's narrow return-type inference without changing the
+    # shared helper's signature (which would ripple through many callers).
+    blocks_raw = cast(Optional[List[Dict[str, Any]]], parse_json(row, "content_blocks"))
+    ui_raw = cast(Optional[List[Dict[str, Any]]], parse_json(row, "ui_blocks"))
     return ChatMessage(
         session_id=str(row["session_id"]),
         idx=row["idx"],
         role=ChatMessageRole(row["role"]),
         content=row.get("content"),
+        content_blocks=blocks_raw,
+        ui_blocks=ui_raw,
         created_at=row["created_at"],
+    )
+
+
+def decode_agent_session_state(row: asyncpg.Record) -> Optional[AgentSessionState]:
+    """Build an AgentSessionState from a DB row, or None if row is empty."""
+    if not row:
+        return None
+    return AgentSessionState(
+        chat_session_id=str(row["chat_session_id"]),
+        data=parse_json(row, "data") or {},
+        updated_at=row["updated_at"],
     )

--- a/app/database/decoder/breeze_buddy/widget_config.py
+++ b/app/database/decoder/breeze_buddy/widget_config.py
@@ -1,0 +1,22 @@
+"""Row → Pydantic decoder for widget_config (migration 030)."""
+
+from app.schemas.breeze_buddy.widget_config import WidgetConfigResponse
+
+
+def decode_widget_config(row) -> WidgetConfigResponse:
+    """Build WidgetConfigResponse from a widget_config asyncpg Record."""
+    return WidgetConfigResponse(
+        id=str(row["id"]),
+        reseller_id=row["reseller_id"],
+        merchant_id=row["merchant_id"],
+        public_widget_key=row["public_widget_key"],
+        template_id=str(row["template_id"]),
+        allowed_origins=list(row.get("allowed_origins") or []),
+        max_sessions_per_ip_hour=row["max_sessions_per_ip_hour"],
+        max_messages_per_ip_hour=row["max_messages_per_ip_hour"],
+        max_concurrent_per_ip=row["max_concurrent_per_ip"],
+        max_voice_sessions_per_ip_hour=row["max_voice_sessions_per_ip_hour"],
+        active=row.get("active", True),
+        created_at=row.get("created_at"),
+        updated_at=row.get("updated_at"),
+    )

--- a/app/database/migrations/030_widget_public_mode_and_session_persistence.sql
+++ b/app/database/migrations/030_widget_public_mode_and_session_persistence.sql
@@ -1,0 +1,208 @@
+-- Migration 030: widget public mode + chat-session persistence (consolidated).
+--
+-- Two feature areas that ship together — splitting them was an accident of
+-- branch ordering, not a logical division. Both depend only on tables that
+-- existed in 027 (chat_session, chat_message) and add net-new
+-- tables/columns; they don't touch each other's surfaces.
+--
+-- A. Widget public mode (CHAT_MODE.md §14)
+-- ----------------------------------------
+--   A1. widget_config — per-merchant config used by embedded browser
+--       widgets to drive Breeze Buddy chat + voice without an RBAC s2s
+--       JWT. The widget snippet carries an opaque public_widget_key
+--       (generated via secrets.token_urlsafe(32)); the widget routes
+--       resolve it together with the Origin header. Empty allowed_origins
+--       means "deny all" so a freshly created row is unusable until an
+--       admin populates it.
+--   A2. chat_session.current_channel + voice_lead_id — promotes
+--       chat_session from "chat-only" to the canonical widget conversation
+--       backbone. The conversation reuses ONE lead_call_tracker row
+--       across every voice attachment (bumped attempt_count) instead of
+--       creating + tearing down a lead per handoff.
+--       State machine on current_channel:
+--         CHAT  → VOICE  (POST /widget/session/{id}/voice/connect)
+--         VOICE → CHAT   (POST /widget/session/{id}/voice/end | end_conversation drain)
+--         CHAT  → ENDED  (POST /widget/session/{id}/end)
+--         VOICE → ENDED  (POST /widget/session/{id}/end — also forces drain)
+--       Backwards compatible: existing rows default to CHAT; legacy chat
+--       routes never read current_channel; only the new /widget/session
+--       router mutates it.
+--
+-- B. Chat-session persistence (history + state + UI replay)
+-- ---------------------------------------------------------
+--   B1. chat_message.content_blocks (JSONB) — canonical Anthropic content
+--       array for both roles. Replaces prior prose-only persistence which
+--       dropped tool_use / tool_result blocks and caused the LLM to
+--       hallucinate identifiers (cart_id, checkout_id) on subsequent
+--       turns. The existing `content TEXT` column is retained for
+--       transcript export / analytics / non-JSONB callers.
+--   B2. agent_session_state — generic per-session state row. Deliberately
+--       domain-blind: no cart_id / checkout_id columns. Identifiers live
+--       inside the `data` JSONB, populated by template-declared reducers
+--       (template/session_state.py). A future vertical (travel, ticketing,
+--       …) ships different reducers with zero migration cost. Outgoing
+--       MCP tool calls read the same JSONB to inject identifiers.
+--   B3. chat_message.ui_blocks (JSONB) — SpecStream `ui_op` events emitted
+--       during an assistant turn. Consumed only by the widget resume path
+--       (GET /widget/session/{id}): on refresh the widget replays each
+--       turn's ui_blocks through the same applyOp pipeline the live SSE
+--       stream uses, repainting Tiles / Carousels / cart views without
+--       rerunning the LLM. Kept separate from content_blocks so the LLM
+--       never sees prior ui_ops on replay (by design).
+--
+-- All statements use IF NOT EXISTS / catalog-existence guards so the
+-- migration is safe to re-run on a partially-applied environment.
+
+BEGIN;
+
+-- ===========================================================================
+-- A. Widget public mode
+-- ===========================================================================
+
+-- ---------------------------------------------------------------------------
+-- A1. widget_config
+-- ---------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS widget_config (
+    id                              uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    reseller_id                     varchar(255) NOT NULL,
+    merchant_id                     varchar(255) NOT NULL,
+    public_widget_key               varchar(128) NOT NULL UNIQUE,
+    template_id                     uuid NOT NULL REFERENCES template(id)
+                                        ON DELETE RESTRICT,
+    -- Empty array means "deny all" — explicit by default so a freshly
+    -- created widget_config can't be used until the admin adds origins.
+    allowed_origins                 text[] NOT NULL DEFAULT ARRAY[]::text[],
+    -- Chat caps (per-IP, hourly window for sessions/messages; concurrency
+    -- is enforced separately at request time).
+    max_sessions_per_ip_hour        integer NOT NULL DEFAULT 60,
+    max_messages_per_ip_hour        integer NOT NULL DEFAULT 600,
+    max_concurrent_per_ip           integer NOT NULL DEFAULT 4,
+    -- Voice caps (per-IP, hourly window for connect attempts).
+    max_voice_sessions_per_ip_hour  integer NOT NULL DEFAULT 10,
+    active                          boolean NOT NULL DEFAULT TRUE,
+    created_at                      timestamptz NOT NULL DEFAULT now(),
+    updated_at                      timestamptz NOT NULL DEFAULT now(),
+    CONSTRAINT widget_config_reseller_merchant_unique
+        UNIQUE (reseller_id, merchant_id),
+    -- Caps must be non-negative; 0 is interpreted as "disabled" by the
+    -- rate limiter (matches services/redis/rate_limit.py:81-86).
+    CONSTRAINT widget_config_caps_nonneg CHECK (
+        max_sessions_per_ip_hour       >= 0
+        AND max_messages_per_ip_hour       >= 0
+        AND max_concurrent_per_ip          >= 0
+        AND max_voice_sessions_per_ip_hour >= 0
+    )
+);
+
+-- NOTE: explicit indexes on (public_widget_key) and (reseller_id, merchant_id)
+-- removed — the UNIQUE / CONSTRAINT clauses above already produce btree
+-- indexes on those exact columns. Adding named indexes would duplicate
+-- the storage + write cost with no read benefit. If you need a named
+-- handle for ops queries, query pg_index by the constraint-backed
+-- index name (e.g. widget_config_public_widget_key_key).
+
+
+-- ---------------------------------------------------------------------------
+-- A2. chat_session.current_channel + voice_lead_id
+-- ---------------------------------------------------------------------------
+
+ALTER TABLE chat_session
+    ADD COLUMN IF NOT EXISTS current_channel varchar(20) NOT NULL DEFAULT 'CHAT';
+
+-- The constraint name uses CHECK; Postgres has no IF NOT EXISTS for
+-- ADD CONSTRAINT, so guard with a catalog lookup.
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conname = 'chat_session_current_channel_check'
+    ) THEN
+        ALTER TABLE chat_session
+            ADD CONSTRAINT chat_session_current_channel_check
+            CHECK (current_channel IN ('CHAT', 'VOICE', 'ENDED'));
+    END IF;
+END$$;
+
+-- The widget conversation's voice lead. Set once on the first
+-- /voice/connect, reused for every subsequent voice attachment via
+-- attempt_count on the lead row. Stays non-NULL after the first
+-- attachment so we don't have to recreate the lead on each handoff
+-- — keeps the conversation to ONE row in lead_call_tracker.
+-- Not a FK to lead_call_tracker(id) because lead rows can be
+-- archived/cleaned independently of the chat_session lifetime.
+ALTER TABLE chat_session
+    ADD COLUMN IF NOT EXISTS voice_lead_id uuid;
+
+-- Operationally useful: find sessions stuck in VOICE for longer than
+-- expected (orphan detection / janitor sweep).
+CREATE INDEX IF NOT EXISTS idx_chat_session_voice_lead
+    ON chat_session (voice_lead_id)
+    WHERE voice_lead_id IS NOT NULL;
+
+
+-- ===========================================================================
+-- B. Chat-session persistence
+-- ===========================================================================
+
+-- ---------------------------------------------------------------------------
+-- B1. chat_message.content_blocks — canonical Anthropic content array
+-- ---------------------------------------------------------------------------
+
+ALTER TABLE chat_message
+    ADD COLUMN IF NOT EXISTS content_blocks jsonb;
+
+-- GIN index on the content_blocks JSONB array supports recovery +
+-- audit queries that look up a turn by Anthropic tool_use_id
+-- (e.g. "find the call that minted cart X"). Earlier draft used
+-- `(content_blocks->>'tool_use_id')`, which always returns NULL on
+-- a JSONB *array* — `->>` only extracts from objects. GIN on the
+-- whole column with the default jsonb_ops handles `@> '[{"tool_use_id":"..."}]'`
+-- containment queries that audit code actually issues. Predicate
+-- keeps the index narrow — rows without blocks are skipped.
+CREATE INDEX IF NOT EXISTS idx_chat_message_content_blocks_gin
+    ON chat_message USING gin (content_blocks)
+    WHERE content_blocks IS NOT NULL;
+
+-- Backfill: synthesise a single-element [text] block array for every
+-- pre-migration row that has prose. After this, history replay can use
+-- content_blocks unconditionally without a NULL-safety fork.
+-- WHERE-clause idempotent on re-run (skips rows already backfilled).
+UPDATE chat_message
+    SET content_blocks = jsonb_build_array(
+        jsonb_build_object('type', 'text', 'text', content)
+    )
+    WHERE content_blocks IS NULL
+      AND content IS NOT NULL;
+
+
+-- ---------------------------------------------------------------------------
+-- B2. agent_session_state — generic per-session domain-blind state
+-- ---------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS agent_session_state (
+    chat_session_id  uuid PRIMARY KEY REFERENCES chat_session(id) ON DELETE CASCADE,
+    data             jsonb NOT NULL DEFAULT '{}'::jsonb,
+    updated_at       timestamptz NOT NULL DEFAULT now()
+);
+
+-- updated_at index for any future TTL / staleness sweepers.
+CREATE INDEX IF NOT EXISTS idx_agent_session_state_updated_at
+    ON agent_session_state (updated_at);
+
+
+-- ---------------------------------------------------------------------------
+-- B3. chat_message.ui_blocks — SpecStream ui_op replay
+-- ---------------------------------------------------------------------------
+
+ALTER TABLE chat_message
+    ADD COLUMN IF NOT EXISTS ui_blocks JSONB DEFAULT NULL;
+
+COMMENT ON COLUMN chat_message.ui_blocks IS
+    'SpecStream ui_op list emitted during this assistant turn. NULL on user '
+    'turns and on assistant turns that emitted no UI. Used by the widget '
+    'resume path to repaint Tiles/Carousels after a page reload without '
+    'rerunning the LLM. Independent of content_blocks (which is the canonical '
+    'Anthropic-shape history the LLM sees on subsequent turns).';
+
+COMMIT;

--- a/app/database/queries/breeze_buddy/chat_session.py
+++ b/app/database/queries/breeze_buddy/chat_session.py
@@ -11,15 +11,21 @@ from typing import Any, List, Optional, Tuple
 
 CHAT_SESSION_TABLE = "chat_session"
 CHAT_MESSAGE_TABLE = "chat_message"
+AGENT_SESSION_STATE_TABLE = "agent_session_state"
 
 _SESSION_COLUMNS = """
     id, template_id, reseller_id, merchant_id,
     status, outcome, current_node, metadata,
+    current_channel, voice_lead_id,
     created_at, last_activity_at, ended_at, ended_reason
 """
 
 _MESSAGE_COLUMNS = """
-    session_id, idx, role, content, created_at
+    session_id, idx, role, content, content_blocks, ui_blocks, created_at
+"""
+
+_AGENT_STATE_COLUMNS = """
+    chat_session_id, data, updated_at
 """
 
 
@@ -114,6 +120,108 @@ def list_idle_chat_sessions_query(
     return query, [statuses, cutoff, limit]
 
 
+# -- widget-mode channel state mutations (migration 030) --------------------
+
+
+def set_chat_session_voice_lead_query(
+    session_id: str, voice_lead_id: str
+) -> Tuple[str, List[Any]]:
+    """First-time bind of a voice lead to a chat_session.
+
+    Conditioned on ``voice_lead_id IS NULL`` so a concurrent
+    /voice/connect can't overwrite an already-bound lead. Returns the
+    row when the bind succeeded, empty if the row already had a
+    voice_lead_id (caller should reuse the existing one).
+    """
+    query = f"""
+        UPDATE {CHAT_SESSION_TABLE}
+        SET voice_lead_id = $2::uuid,
+            last_activity_at = now()
+        WHERE id = $1 AND voice_lead_id IS NULL
+        RETURNING {_SESSION_COLUMNS}
+    """
+    return query, [session_id, voice_lead_id]
+
+
+def flip_chat_session_channel_query(
+    session_id: str,
+    *,
+    new_channel: str,
+    expected_channel: str,
+    expected_voice_lead_id: Optional[str] = None,
+) -> Tuple[str, List[Any]]:
+    """Conditionally flip current_channel.
+
+    The conditional WHERE gives the unified widget router a
+    single-statement state machine — the row only updates when its
+    current state matches the caller's expectation. This makes
+    /voice/connect, /voice/end, and the drain race-free even if
+    multiple workers attempt the same transition concurrently.
+
+    ``expected_channel`` MUST match. Pass the channel the caller
+    believes it's leaving ('CHAT' for /voice/connect; 'VOICE' for
+    /voice/end and drain).
+
+    ``expected_voice_lead_id`` (optional) — when set, also requires
+    the row's voice_lead_id to match. Used by drain so a stale
+    end_conversation callback for an old lead can't flip a
+    freshly-reused session back to CHAT.
+
+    Returns the row when the UPDATE succeeded, empty when no row
+    matched (callers should treat empty as a 409 conflict).
+    """
+    where_clauses: List[str] = [
+        "id = $1",
+        "current_channel = $3",
+    ]
+    params: List[Any] = [session_id, new_channel, expected_channel]
+    next_idx = 4
+
+    if expected_voice_lead_id is not None:
+        where_clauses.append(f"voice_lead_id = ${next_idx}::uuid")
+        params.append(expected_voice_lead_id)
+        next_idx += 1
+
+    query = f"""
+        UPDATE {CHAT_SESSION_TABLE}
+        SET current_channel = $2,
+            last_activity_at = now()
+        WHERE {' AND '.join(where_clauses)}
+        RETURNING {_SESSION_COLUMNS}
+    """
+    return query, params
+
+
+def drain_voice_into_chat_session_query(
+    session_id: str,
+    *,
+    final_node: Optional[str],
+    expected_voice_lead_id: str,
+) -> Tuple[str, List[Any]]:
+    """Final UPDATE at the end of a voice attachment.
+
+    Flips channel back to CHAT, optionally advances current_node to
+    whatever node the voice flow ended on. Does NOT clear
+    voice_lead_id — the lead stays bound so the next
+    /voice/connect on this session can reuse it.
+
+    Conditioned on (current_channel='VOICE' AND voice_lead_id matches)
+    so a stale callback for an old lead can't flip a freshly-reused
+    session back to CHAT.
+    """
+    query = f"""
+        UPDATE {CHAT_SESSION_TABLE}
+        SET current_channel = 'CHAT',
+            current_node    = COALESCE($1, current_node),
+            last_activity_at = now()
+        WHERE id = $2
+          AND current_channel = 'VOICE'
+          AND voice_lead_id = $3::uuid
+        RETURNING {_SESSION_COLUMNS}
+    """
+    return query, [final_node, session_id, expected_voice_lead_id]
+
+
 # -- chat_message -------------------------------------------------------------
 
 
@@ -121,16 +229,27 @@ def insert_chat_message_query(
     session_id: str,
     role: str,
     content: Optional[str],
+    content_blocks_json: Optional[str] = None,
+    ui_blocks_json: Optional[str] = None,
 ) -> Tuple[str, List[Any]]:
     """Insert one message with auto-allocated idx (per-session monotonic).
 
     Idx allocation is a subquery on chat_message itself, so the INSERT
     is atomic. Combined with the per-session Redis lock and the
     (session_id, idx) PK, duplicates are impossible.
+
+    ``content_blocks_json`` is the canonical Anthropic content array
+    serialised to a JSON string. When supplied, the loader's history
+    replay path uses it verbatim; ``content`` is kept as a denormalised
+    prose-only view for transcripts/analytics.
+
+    ``ui_blocks_json`` (migration 030) is the SpecStream ui_op list
+    serialised to a JSON string. Consumed only by the widget resume
+    path to repaint Tiles/Carousels; the LLM never sees this column.
     """
     query = f"""
         INSERT INTO {CHAT_MESSAGE_TABLE} (
-            session_id, idx, role, content
+            session_id, idx, role, content, content_blocks, ui_blocks
         )
         VALUES (
             $1,
@@ -140,11 +259,11 @@ def insert_chat_message_query(
                  WHERE session_id = $1),
                 0
             ),
-            $2, $3
+            $2, $3, $4::jsonb, $5::jsonb
         )
         RETURNING {_MESSAGE_COLUMNS}
     """
-    return query, [session_id, role, content]
+    return query, [session_id, role, content, content_blocks_json, ui_blocks_json]
 
 
 def list_chat_messages_for_session_query(
@@ -180,3 +299,41 @@ def list_chat_messages_for_session_query(
         ORDER BY idx ASC
     """
     return query, [session_id, limit]
+
+
+# -- agent_session_state ------------------------------------------------------
+
+
+def get_agent_session_state_query(chat_session_id: str) -> Tuple[str, List[Any]]:
+    """Read the agent state row for a session. Returns no rows if absent.
+
+    Generic table — `data` JSONB holds whatever keys the template's
+    reducers set. Runtime knows nothing about the keys.
+    """
+    query = f"""
+        SELECT {_AGENT_STATE_COLUMNS}
+        FROM {AGENT_SESSION_STATE_TABLE}
+        WHERE chat_session_id = $1
+    """
+    return query, [chat_session_id]
+
+
+def upsert_agent_session_state_query(
+    chat_session_id: str,
+    data_json: str,
+) -> Tuple[str, List[Any]]:
+    """INSERT-or-REPLACE the entire `data` JSONB for a session.
+
+    The reducer engine merges + computes the next state from the prior
+    state + tool result in Python, then this query persists the result
+    atomically. No SQL-level merge — keeps the engine pure.
+    """
+    query = f"""
+        INSERT INTO {AGENT_SESSION_STATE_TABLE} (chat_session_id, data, updated_at)
+        VALUES ($1, $2::jsonb, now())
+        ON CONFLICT (chat_session_id) DO UPDATE
+            SET data = EXCLUDED.data,
+                updated_at = EXCLUDED.updated_at
+        RETURNING {_AGENT_STATE_COLUMNS}
+    """
+    return query, [chat_session_id, data_json]

--- a/app/database/queries/breeze_buddy/lead_call_tracker.py
+++ b/app/database/queries/breeze_buddy/lead_call_tracker.py
@@ -655,3 +655,56 @@ def append_metadata_field_query(
     """
     values = [json.dumps(field_updates), lead_id]
     return text, values
+
+
+def reset_widget_voice_lead_query(
+    lead_id: str,
+    payload: Dict[str, Any],
+    meta_data_seed: Dict[str, Any],
+) -> Tuple[str, List[Any]]:
+    """Reset a widget voice lead so the next /voice/connect can reuse it.
+
+    Used only by the unified widget router (CHAT_MODE.md §14): one
+    chat_session has ONE voice lead (set in chat_session.voice_lead_id)
+    that persists for the conversation's lifetime; each /voice/connect
+    after the first reuses this lead instead of creating a new row.
+
+    Behaviour:
+      - status flipped back to BACKLOG so the bot can run again
+      - attempt_count incremented (analytics treats this attempt as
+        the Nth voice attachment in the conversation)
+      - payload REPLACED with the latest template_vars (chat may have
+        accumulated new state since the prior voice attachment)
+      - meta_data is *merged* with the new seed so widget-mode markers
+        (is_widget, widget_config_id, widget_session_id) and the new
+        seed (start_node, prior_history, seed_message_count) overwrite
+        their prior values, but unrelated fields the bot wrote during
+        the prior attempt (e.g., evaluator scores) are preserved
+      - call_id, call_initiated_time, call_end_time, outcome, cost,
+        recording_url are CLEARED so they don't leak from the prior
+        attempt's call into this one
+    """
+    text = f"""
+        UPDATE "{LEAD_CALL_TRACKER_TABLE}"
+        SET
+            "status"               = $2,
+            "attempt_count"        = COALESCE("attempt_count", 0) + 1,
+            "payload"              = $3::jsonb,
+            "meta_data"            = COALESCE("meta_data", '{{}}')::jsonb || $4::jsonb,
+            "call_id"              = NULL,
+            "call_initiated_time"  = NULL,
+            "call_end_time"        = NULL,
+            "outcome"              = NULL,
+            "cost"                 = NULL,
+            "recording_url"        = NULL,
+            "updated_at"           = NOW()
+        WHERE "id" = $1
+        RETURNING *;
+    """
+    values: List[Any] = [
+        lead_id,
+        LeadCallStatus.BACKLOG.value,
+        json.dumps(payload),
+        json.dumps(meta_data_seed),
+    ]
+    return text, values

--- a/app/database/queries/breeze_buddy/widget_config.py
+++ b/app/database/queries/breeze_buddy/widget_config.py
@@ -1,0 +1,225 @@
+"""SQL builders for widget_config (migration 030).
+
+Pure functions; no DB I/O. Returns ``Tuple[str, List[Any]]`` for
+``run_parameterized_query``. All placeholders are PostgreSQL-style
+``$N`` — never use string formatting for user input.
+"""
+
+from datetime import datetime, timezone
+from typing import Any, List, Optional, Tuple
+
+WIDGET_CONFIG_TABLE = "widget_config"
+
+_COLUMNS = (
+    "id, reseller_id, merchant_id, public_widget_key, template_id, "
+    "allowed_origins, max_sessions_per_ip_hour, max_messages_per_ip_hour, "
+    "max_concurrent_per_ip, max_voice_sessions_per_ip_hour, active, "
+    "created_at, updated_at"
+)
+
+
+def create_widget_config_query(
+    *,
+    reseller_id: str,
+    merchant_id: str,
+    public_widget_key: str,
+    template_id: str,
+    allowed_origins: List[str],
+    max_sessions_per_ip_hour: int,
+    max_messages_per_ip_hour: int,
+    max_concurrent_per_ip: int,
+    max_voice_sessions_per_ip_hour: int,
+    active: bool,
+) -> Tuple[str, List[Any]]:
+    query = f"""
+        INSERT INTO {WIDGET_CONFIG_TABLE} (
+            reseller_id, merchant_id, public_widget_key, template_id,
+            allowed_origins, max_sessions_per_ip_hour, max_messages_per_ip_hour,
+            max_concurrent_per_ip, max_voice_sessions_per_ip_hour,
+            active, created_at, updated_at
+        ) VALUES (
+            $1, $2, $3, $4::uuid, $5, $6, $7, $8, $9, $10, $11, $12
+        )
+        RETURNING {_COLUMNS}
+    """
+    now = datetime.now(timezone.utc)
+    values: List[Any] = [
+        reseller_id,
+        merchant_id,
+        public_widget_key,
+        template_id,
+        list(allowed_origins),
+        int(max_sessions_per_ip_hour),
+        int(max_messages_per_ip_hour),
+        int(max_concurrent_per_ip),
+        int(max_voice_sessions_per_ip_hour),
+        bool(active),
+        now,
+        now,
+    ]
+    return query, values
+
+
+def get_widget_config_by_id_query(widget_config_id: str) -> Tuple[str, List[Any]]:
+    query = f"""
+        SELECT {_COLUMNS}
+        FROM {WIDGET_CONFIG_TABLE}
+        WHERE id = $1::uuid
+    """
+    return query, [widget_config_id]
+
+
+def get_widget_config_by_public_key_query(
+    public_widget_key: str,
+) -> Tuple[str, List[Any]]:
+    query = f"""
+        SELECT {_COLUMNS}
+        FROM {WIDGET_CONFIG_TABLE}
+        WHERE public_widget_key = $1
+    """
+    return query, [public_widget_key]
+
+
+def get_widget_config_by_reseller_merchant_query(
+    reseller_id: str, merchant_id: str
+) -> Tuple[str, List[Any]]:
+    query = f"""
+        SELECT {_COLUMNS}
+        FROM {WIDGET_CONFIG_TABLE}
+        WHERE reseller_id = $1 AND merchant_id = $2
+    """
+    return query, [reseller_id, merchant_id]
+
+
+def list_widget_configs_query(
+    *,
+    page: int = 1,
+    limit: int = 50,
+    reseller_id: Optional[str] = None,
+    merchant_id: Optional[str] = None,
+    reseller_ids: Optional[List[str]] = None,
+    merchant_ids: Optional[List[str]] = None,
+    include_inactive: bool = False,
+) -> Tuple[str, str, List[Any]]:
+    """Returns (query, count_query, values).
+
+    Filters compose like templates: exact reseller_id / merchant_id when
+    supplied, otherwise the optional ``reseller_ids`` / ``merchant_ids``
+    arrays scope the result to the caller's RBAC reach.
+    """
+    where: List[str] = []
+    params: List[Any] = []
+    idx = 1
+
+    if reseller_id:
+        where.append(f"reseller_id = ${idx}")
+        params.append(reseller_id)
+        idx += 1
+    elif reseller_ids is not None:
+        where.append(f"reseller_id = ANY(${idx})")
+        params.append(reseller_ids)
+        idx += 1
+
+    if merchant_id:
+        where.append(f"merchant_id = ${idx}")
+        params.append(merchant_id)
+        idx += 1
+    elif merchant_ids is not None:
+        where.append(f"merchant_id = ANY(${idx})")
+        params.append(merchant_ids)
+        idx += 1
+
+    if not include_inactive:
+        where.append("active = TRUE")
+
+    where_clause = f"WHERE {' AND '.join(where)}" if where else ""
+    offset = max(page - 1, 0) * limit
+
+    query = f"""
+        SELECT {_COLUMNS}
+        FROM {WIDGET_CONFIG_TABLE}
+        {where_clause}
+        ORDER BY created_at DESC
+        LIMIT ${idx} OFFSET ${idx + 1}
+    """
+    count_query = f"SELECT COUNT(*) AS total FROM {WIDGET_CONFIG_TABLE} {where_clause}"
+    params.extend([limit, offset])
+    return query, count_query, params
+
+
+def update_widget_config_query(
+    *,
+    widget_config_id: str,
+    template_id: Optional[str] = None,
+    allowed_origins: Optional[List[str]] = None,
+    max_sessions_per_ip_hour: Optional[int] = None,
+    max_messages_per_ip_hour: Optional[int] = None,
+    max_concurrent_per_ip: Optional[int] = None,
+    max_voice_sessions_per_ip_hour: Optional[int] = None,
+    active: Optional[bool] = None,
+) -> Tuple[str, List[Any]]:
+    """Returns ("", []) if no fields were provided — callers should treat
+    that as a no-op and return the current row."""
+    set_clauses: List[str] = []
+    params: List[Any] = []
+    idx = 1
+
+    if template_id is not None:
+        set_clauses.append(f"template_id = ${idx}::uuid")
+        params.append(template_id)
+        idx += 1
+
+    if allowed_origins is not None:
+        set_clauses.append(f"allowed_origins = ${idx}")
+        params.append(list(allowed_origins))
+        idx += 1
+
+    if max_sessions_per_ip_hour is not None:
+        set_clauses.append(f"max_sessions_per_ip_hour = ${idx}")
+        params.append(int(max_sessions_per_ip_hour))
+        idx += 1
+
+    if max_messages_per_ip_hour is not None:
+        set_clauses.append(f"max_messages_per_ip_hour = ${idx}")
+        params.append(int(max_messages_per_ip_hour))
+        idx += 1
+
+    if max_concurrent_per_ip is not None:
+        set_clauses.append(f"max_concurrent_per_ip = ${idx}")
+        params.append(int(max_concurrent_per_ip))
+        idx += 1
+
+    if max_voice_sessions_per_ip_hour is not None:
+        set_clauses.append(f"max_voice_sessions_per_ip_hour = ${idx}")
+        params.append(int(max_voice_sessions_per_ip_hour))
+        idx += 1
+
+    if active is not None:
+        set_clauses.append(f"active = ${idx}")
+        params.append(bool(active))
+        idx += 1
+
+    if not set_clauses:
+        return "", []
+
+    set_clauses.append(f"updated_at = ${idx}")
+    params.append(datetime.now(timezone.utc))
+    idx += 1
+
+    params.append(widget_config_id)
+    query = f"""
+        UPDATE {WIDGET_CONFIG_TABLE}
+        SET {', '.join(set_clauses)}
+        WHERE id = ${idx}::uuid
+        RETURNING {_COLUMNS}
+    """
+    return query, params
+
+
+def delete_widget_config_query(widget_config_id: str) -> Tuple[str, List[Any]]:
+    query = f"""
+        DELETE FROM {WIDGET_CONFIG_TABLE}
+        WHERE id = $1::uuid
+        RETURNING id
+    """
+    return query, [widget_config_id]

--- a/app/main.py
+++ b/app/main.py
@@ -36,6 +36,7 @@ from app.ai.voice.agents.breeze_buddy.services.agent_router.client import (
 # Database imports
 from app.ai.voice.llm._pools import close_all_pools as close_llm_http_pools
 from app.api.routers import automatic, breeze_buddy, devcycle, feature_flags, systems
+from app.api.routers.breeze_buddy.chat import cancel_bus as chat_cancel_bus
 
 # Import background task scheduler
 from app.core.background_tasks import BackgroundTaskScheduler
@@ -137,6 +138,15 @@ async def lifespan(_app: FastAPI):
             logger.info("Redis not configured - skipping Redis initialization")
     except Exception as e:
         logger.error(f"Failed to initialize Redis client: {e}")
+
+    # Start the chat cancel-bus pubsub subscriber. Fans cross-pod cancel
+    # publishes out to the local in-flight task registry so the widget
+    # Stop button releases the per-session Redis lock immediately instead
+    # of waiting on TTL. No-op + warning log if Redis isn't reachable.
+    try:
+        await chat_cancel_bus.start_subscriber()
+    except Exception as e:
+        logger.error(f"Failed to start chat cancel-bus subscriber: {e}")
 
     # DevCycle feature flags are initialized by parent process (run.py) before uvicorn starts
     # Worker processes only need to read from Redis using get_config()
@@ -325,6 +335,12 @@ async def lifespan(_app: FastAPI):
     if _background_scheduler:
         logger.info("Stopping background task scheduler...")
         await _background_scheduler.stop()
+
+    # Stop chat cancel-bus subscriber
+    try:
+        await chat_cancel_bus.stop_subscriber()
+    except Exception as e:
+        logger.error(f"Error stopping chat cancel-bus subscriber: {e}")
 
     # Graceful drain period - wait for active sessions to complete if enabled
     if ENABLE_SIGTERM_HANDLER and _is_draining:

--- a/app/schemas/breeze_buddy/chat.py
+++ b/app/schemas/breeze_buddy/chat.py
@@ -34,8 +34,31 @@ class ChatEndedReason(str, Enum):
     IDLE_TIMEOUT = "idle_timeout"
 
 
+class WidgetChannel(str, Enum):
+    """Active channel on a chat_session row (migration 030).
+
+    Defaults to CHAT for legacy chat_session rows; only the unified
+    widget router (CHAT_MODE.md §14) ever flips this to VOICE / ENDED.
+    """
+
+    CHAT = "CHAT"
+    VOICE = "VOICE"
+    ENDED = "ENDED"
+
+
 class ChatSession(BaseModel):
-    """One row of `chat_session`."""
+    """One row of `chat_session`.
+
+    With migration 030 this row doubles as the "widget session" — the
+    canonical conversation backbone for the unified widget mode.
+    ``current_channel`` and ``voice_lead_id`` are widget-mode fields;
+    legacy chat callers can ignore them (default CHAT, NULL).
+
+    ``voice_lead_id`` is set once on the first ``/voice/connect`` and
+    stays set for the lifetime of the chat_session — every subsequent
+    voice attachment reuses the same lead via ``attempt_count``,
+    instead of creating + tearing down a lead per handoff.
+    """
 
     id: str
     template_id: str
@@ -45,6 +68,8 @@ class ChatSession(BaseModel):
     outcome: Optional[str] = None
     current_node: Optional[str] = None
     metadata: Dict[str, Any] = Field(default_factory=dict)
+    current_channel: WidgetChannel = WidgetChannel.CHAT
+    voice_lead_id: Optional[str] = None
     created_at: Optional[datetime] = None
     last_activity_at: Optional[datetime] = None
     ended_at: Optional[datetime] = None
@@ -52,13 +77,45 @@ class ChatSession(BaseModel):
 
 
 class ChatMessage(BaseModel):
-    """One row of `chat_message` (append-only log)."""
+    """One row of `chat_message` (append-only log).
+
+    ``content`` is the prose-only denormalised view (kept for
+    transcripts and analytics). ``content_blocks`` is the canonical
+    Anthropic content array — text + tool_use on assistant rows,
+    text + tool_result on user rows — and is the source of truth for
+    history replay. Rows written before migration 030 have
+    ``content_blocks`` backfilled to a single-element [text] array.
+
+    ``ui_blocks`` is the SpecStream ``ui_op`` list emitted during an
+    assistant turn (also added in migration 030). Consumed only by the
+    widget resume path to repaint Tiles/Carousels after a page reload
+    — the LLM never sees prior ui_ops, by design. ``None`` on user
+    turns, on assistant turns that emitted no UI, and on rows written
+    before migration 030.
+    """
 
     session_id: str
     idx: int
     role: ChatMessageRole
     content: Optional[str] = None
+    content_blocks: Optional[List[Dict[str, Any]]] = None
+    ui_blocks: Optional[List[Dict[str, Any]]] = None
     created_at: Optional[datetime] = None
+
+
+class AgentSessionState(BaseModel):
+    """One row of `agent_session_state` (per-session typed state).
+
+    ``data`` is a generic JSON dict — the runtime treats it as opaque.
+    Keys are populated by template-declared reducers (e.g. a commerce
+    template sets ``cart_id``, ``checkout_id``, ``customer_id`` from
+    Shopify MCP tool results). A future flavour (travel, appointments)
+    ships different reducers; the row schema is unchanged.
+    """
+
+    chat_session_id: str
+    data: Dict[str, Any] = Field(default_factory=dict)
+    updated_at: Optional[datetime] = None
 
 
 # ---------------------------------------------------------------------------
@@ -181,12 +238,99 @@ class CreateDemoSessionResponse(BaseModel):
     message_cap: int = Field(..., description="Max assistant turns before 429.")
 
 
+# ---------------------------------------------------------------------------
+# Unified widget-mode schemas (CHAT_MODE.md §14)
+#
+# One conversation, one widget_token, two channels (CHAT ↔ VOICE). The
+# session_id always refers to the canonical chat_session row that owns
+# the conversation; voice is a transient attachment that drains back
+# into the same row at end_conversation.
+# ---------------------------------------------------------------------------
+
+
+class CreateWidgetSessionRequest(BaseModel):
+    """Body of ``POST /widget/session``."""
+
+    public_widget_key: str = Field(
+        ...,
+        min_length=10,
+        description="Opaque per-merchant widget key (server-generated, see widget_config).",
+    )
+    template_vars: Dict[str, Any] = Field(
+        default_factory=dict,
+        description="Render-time variables (customer_name, etc.). "
+        "Same shape as the RBAC chat path's template_vars.",
+    )
+    metadata: Dict[str, Any] = Field(
+        default_factory=dict,
+        description="Opaque caller context, persisted on chat_session.metadata.",
+    )
+
+
+class CreateWidgetSessionResponse(BaseModel):
+    """Body of ``POST /widget/session``.
+
+    Mirrors ``CreateChatSessionResponse`` + the session-bound widget
+    token + the active channel. The same widget_token works for chat
+    AND voice attachment routes — no re-mint at handoff.
+    """
+
+    session_id: str
+    status: ChatSessionStatus
+    current_channel: WidgetChannel = WidgetChannel.CHAT
+    current_node: Optional[str] = None
+    greeting: Optional[GreetingMessage] = None
+    widget_token: str = Field(..., description="Bearer token for follow-up calls.")
+    ttl_seconds: int = Field(
+        ..., description="Lifetime of widget_token in seconds (24h)."
+    )
+
+
+class WidgetVoiceConnectResponse(BaseModel):
+    """Body of ``POST /widget/session/{id}/voice/connect``."""
+
+    room_url: str
+    daily_token: str
+    lead_id: str
+    ttl_seconds: int = Field(
+        ...,
+        description="Daily room expiry (typ. 3600s). The widget_token "
+        "outlives this; you can reconnect voice within the widget_token TTL.",
+    )
+
+
+class WidgetVoiceEndResponse(BaseModel):
+    """Body of ``POST /widget/session/{id}/voice/end``."""
+
+    status: str
+    lead_id: Optional[str] = None
+
+
+class WidgetSessionStateResponse(BaseModel):
+    """Body of ``GET /widget/session/{id}``.
+
+    Full state for the embed to rehydrate the UI after a page reload
+    without re-greeting. Includes message history (canonical, post-drain
+    if voice ended) and template_vars (from chat_session.metadata).
+    """
+
+    session_id: str
+    status: ChatSessionStatus
+    current_channel: WidgetChannel
+    current_node: Optional[str] = None
+    messages: List[ChatMessage]
+    template_vars: Dict[str, Any] = Field(default_factory=dict)
+    metadata: Dict[str, Any] = Field(default_factory=dict)
+
+
 __all__ = [
     "ChatSessionStatus",
     "ChatMessageRole",
     "ChatEndedReason",
+    "WidgetChannel",
     "ChatSession",
     "ChatMessage",
+    "AgentSessionState",
     "CreateChatSessionRequest",
     "CreateChatSessionResponse",
     "GreetingMessage",
@@ -198,4 +342,9 @@ __all__ = [
     "ListDemoTemplatesResponse",
     "CreateDemoSessionRequest",
     "CreateDemoSessionResponse",
+    "CreateWidgetSessionRequest",
+    "CreateWidgetSessionResponse",
+    "WidgetVoiceConnectResponse",
+    "WidgetVoiceEndResponse",
+    "WidgetSessionStateResponse",
 ]

--- a/app/schemas/breeze_buddy/widget_config.py
+++ b/app/schemas/breeze_buddy/widget_config.py
@@ -1,0 +1,98 @@
+"""Pydantic models for widget_config rows (migration 030).
+
+widget_config is the per-merchant configuration that powers the
+widget-public auth mode (CHAT_MODE.md §14). One row per merchant; an
+opaque ``public_widget_key`` is generated server-side and embedded in
+the merchant's widget snippet.
+
+public_widget_key is **never** accepted on Create/Update — it's
+read-only on the response. Callers that want to rotate it should add
+a dedicated rotate endpoint later; this PR keeps the surface minimal.
+"""
+
+from datetime import datetime
+from typing import List, Optional
+
+from pydantic import BaseModel, Field
+
+
+class WidgetConfigCreate(BaseModel):
+    """Body of ``POST /widget-config``."""
+
+    reseller_id: str = Field(..., min_length=1, max_length=255)
+    merchant_id: str = Field(..., min_length=1, max_length=255)
+    template_id: str = Field(
+        ...,
+        description="UUID of the template the widget will run. Must exist; "
+        "FK constraint enforces this.",
+    )
+    allowed_origins: List[str] = Field(
+        default_factory=list,
+        description="Exact-match list of allowed Origin / Referer values. "
+        "Empty list means deny all (widget cannot be used until populated).",
+    )
+    max_sessions_per_ip_hour: int = Field(60, ge=0)
+    max_messages_per_ip_hour: int = Field(600, ge=0)
+    max_concurrent_per_ip: int = Field(4, ge=0)
+    max_voice_sessions_per_ip_hour: int = Field(10, ge=0)
+    active: bool = Field(True, description="Inactive rows behave like 404.")
+
+
+class WidgetConfigUpdate(BaseModel):
+    """Body of ``PUT /widget-config/{id}``.
+
+    All fields optional — only the fields supplied are updated.
+    ``public_widget_key`` deliberately not present.
+    """
+
+    template_id: Optional[str] = None
+    allowed_origins: Optional[List[str]] = None
+    max_sessions_per_ip_hour: Optional[int] = Field(None, ge=0)
+    max_messages_per_ip_hour: Optional[int] = Field(None, ge=0)
+    max_concurrent_per_ip: Optional[int] = Field(None, ge=0)
+    max_voice_sessions_per_ip_hour: Optional[int] = Field(None, ge=0)
+    active: Optional[bool] = None
+
+
+class WidgetConfigResponse(BaseModel):
+    """One widget_config row as returned by GET/list/create."""
+
+    id: str
+    reseller_id: str
+    merchant_id: str
+    public_widget_key: str
+    template_id: str
+    allowed_origins: List[str] = Field(default_factory=list)
+    max_sessions_per_ip_hour: int = 60
+    max_messages_per_ip_hour: int = 600
+    max_concurrent_per_ip: int = 4
+    max_voice_sessions_per_ip_hour: int = 10
+    active: bool = True
+    created_at: Optional[datetime] = None
+    updated_at: Optional[datetime] = None
+
+
+class WidgetConfigListResponse(BaseModel):
+    """Body of ``GET /widget-config/list``."""
+
+    widget_configs: List[WidgetConfigResponse]
+    total: int
+    page: int = 1
+    limit: int = 50
+
+
+class DeleteWidgetConfigResponse(BaseModel):
+    """Body of ``DELETE /widget-config/{id}``."""
+
+    status: str = "success"
+    message: str
+    deleted_id: str
+
+
+__all__ = [
+    "WidgetConfigCreate",
+    "WidgetConfigUpdate",
+    "WidgetConfigResponse",
+    "WidgetConfigListResponse",
+    "DeleteWidgetConfigResponse",
+]

--- a/app/services/redis/rate_limit.py
+++ b/app/services/redis/rate_limit.py
@@ -50,6 +50,7 @@ async def check_rate_limit(
     limit: int,
     window_seconds: int,
     prefix: str = "ratelimit",
+    fail_closed: bool = False,
 ) -> RateLimitDecision:
     """Increment the counter for ``(bucket, identifier)``; deny when over.
 
@@ -63,13 +64,30 @@ async def check_rate_limit(
             ``floor(now / window_seconds)``.
         prefix: Redis key prefix. Override only if you need to isolate
             tests from prod (the default is fine for everything else).
+        fail_closed: When True, Redis unavailability / errors block the
+            request (returns ``allowed=False`` with a short retry-after).
+            Use this for production traffic where unbounded fallthrough
+            would be costly — widget endpoints in particular accept
+            anonymous traffic and back LLM-cost-amplification risk on a
+            Redis blip. Default ``False`` preserves the legacy fail-open
+            posture for demo endpoints where availability beats abuse
+            protection.
 
     Returns ``allowed=True`` (and increments) when count <= limit, else
-    ``allowed=False``. Fails *open* — if Redis is unconfigured or errors,
-    we let the request through and log a warning. Demo abuse is preferable
-    to a Redis hiccup taking down the demo entirely.
+    ``allowed=False``.
     """
     if not is_redis_configured():
+        if fail_closed:
+            logger.warning(
+                f"rate_limit: Redis not configured; bucket={bucket!r} "
+                f"id={identifier!r} fail-closed (denying)"
+            )
+            return RateLimitDecision(
+                allowed=False,
+                count=0,
+                limit=limit,
+                retry_after_seconds=30,
+            )
         logger.warning(
             f"rate_limit: Redis not configured; bucket={bucket!r} "
             f"id={identifier!r} fail-open"
@@ -99,6 +117,17 @@ async def check_rate_limit(
             # is readable for the full window before Redis evicts it.
             await redis.expire(key, window_seconds + 5)
     except Exception as exc:
+        if fail_closed:
+            logger.warning(
+                f"rate_limit: Redis error for bucket={bucket!r} id={identifier!r}: "
+                f"{exc} (fail-closed, denying)"
+            )
+            return RateLimitDecision(
+                allowed=False,
+                count=0,
+                limit=limit,
+                retry_after_seconds=30,
+            )
         logger.warning(
             f"rate_limit: Redis error for bucket={bucket!r} id={identifier!r}: "
             f"{exc} (fail-open)"

--- a/docs/CHAT_MODE.md
+++ b/docs/CHAT_MODE.md
@@ -845,3 +845,346 @@ loom/packages/client-sdk/src/chat/types.ts
 **Sign-off:** doc approved 2026-05-04. Implementation proceeds in the order listed in §16; Phase 1 ends at the §15 exit criteria.
 
 **2026-05-04 rewrite:** chat mode migrated from Pipecat-pipeline-based execution to a direct LLM driver. Voice path untouched. See §4, §7, §9, and §16 for the post-rewrite shape; §3 D3 retains the original decision row marked superseded for historical context.
+
+---
+
+## 18. Widget Public Mode (Unified Chat ↔ Voice)
+
+> **Prereq:** PostgreSQL ≥ 11. Migration 030 uses `ADD COLUMN NOT NULL
+> DEFAULT 'CHAT'` on `chat_session`, which is a metadata-only operation
+> from pg 11 onward (no table rewrite). Older PG versions would rewrite
+> the entire table under `ACCESS EXCLUSIVE`; deploy targets must pin
+> pg ≥ 11 before applying this migration.
+
+Production browser embeds drive a single conversation that can move
+between text and voice without losing context. **Not** a demo: there
+are no env-allowlisted slugs, no demo TTL, no per-session message
+caps. Per-merchant configuration (a `widget_config` row) gates which
+template runs, which origins may embed, and the per-IP rate limits.
+
+### 18.1 What it solves vs `/chat/demo` and `/demo/connect`
+
+| concern | `/chat/demo` | `/demo/connect` | `/widget/session/*` |
+|---|---|---|---|
+| audience | demo page visitors | demo page visitors | shoppers on merchant sites |
+| template selection | env-allowlisted slug | hardcoded `DEMO_TEMPLATE` | per-merchant `widget_config.template_id` |
+| reseller / merchant | none | hardcoded `website-demo` | per-merchant row |
+| origin allowlist | global CORS | global CORS | per-merchant `allowed_origins` |
+| per-IP caps | env defaults | hardcoded 10/h, 50/d | per-merchant `widget_config` columns |
+| session lifetime | demo TTL + msg cap | 7-day demo TTL on lead | until explicit `/end` (token TTL: 24h) |
+| chat ↔ voice | n/a | n/a | unified single session |
+
+A widget JWT carries `typ: "widget"` and is rejected by the RBAC
+verifier (`app/api/security/breeze_buddy/rbac_token.py`) and the demo
+verifier (`app/api/security/breeze_buddy/demo_token.py`). Widget
+tokens cannot drive any non-widget endpoint, and RBAC / demo tokens
+cannot drive any widget endpoint.
+
+### 18.2 Single-session model
+
+The conversation is one logical entity that the embed tracks via one
+`session_id`. Internally:
+
+```
+chat_session  (= widget conversation; promoted by migration 030)
+   id, template_id, current_node, current_channel, voice_lead_id,
+   metadata.template_vars, status
+   ├── chat_message rows ............ canonical message log
+   └── lead_call_tracker (ONE per     created lazily on the first
+        conversation, REUSED)         /voice/connect; reused for every
+                                      subsequent attachment via
+                                      attempt_count. voice_lead_id is
+                                      set on chat_session and stays
+                                      bound for the conversation's
+                                      lifetime.
+                                      lead.metaData.widget_session_id  ← back-link
+                                      lead.metaData.start_node          ← seed
+                                      lead.metaData.prior_history       ← seed
+                                      lead.metaData.seed_message_count  ← seed
+                                      at end_conversation: drain into
+                                      chat_message + flip channel back to CHAT
+                                      (voice_lead_id PRESERVED so the
+                                      next attachment reuses this lead)
+```
+
+**One lead per conversation, not per attachment.** A single widget
+conversation that toggles chat ↔ voice multiple times produces
+exactly ONE row in `lead_call_tracker`. Each `/voice/connect` after
+the first calls `reset_widget_voice_lead` which:
+
+- bumps `attempt_count` (this is the Nth voice attachment)
+- resets `status` to BACKLOG so the bot can run again
+- replaces `payload` with the latest template_vars
+- merges in a fresh `meta_data` seed (start_node, prior_history,
+  seed_message_count) — the chat_session may have advanced since the
+  prior voice attempt
+- clears per-call fields (call_id, outcome, recording_url,
+  call_initiated_time, call_end_time, cost) so they don't leak from
+  the prior attempt
+
+`chat_session` is the source of truth for conversation state. Voice
+"borrows" it for the duration of each Daily.co call; the bot's
+`end_conversation` handler drains the new turns back into
+`chat_message` and advances `current_node` to whatever node the
+voice flow ended on.
+
+### 18.3 State machine on `current_channel`
+
+| from | to | trigger |
+|---|---|---|
+| CHAT  | VOICE | `POST /widget/session/{id}/voice/connect` |
+| VOICE | CHAT  | `POST /widget/session/{id}/voice/end` *or* end_conversation drain |
+| CHAT  | ENDED | `POST /widget/session/{id}/end` |
+| VOICE | ENDED | `POST /widget/session/{id}/end` (also signals the voice bot) |
+
+Disallowed transitions return 409:
+- `POST /message` while channel ≠ CHAT
+- `POST /voice/connect` while channel ≠ CHAT (voice already live)
+
+The state machine is enforced by conditional `UPDATE … WHERE
+current_channel = …` queries in
+`app/database/queries/breeze_buddy/chat_session.py` so concurrent
+workers cannot push the row into an inconsistent state.
+`voice_lead_id` is set ONCE (via `bind_voice_lead_to_chat_session`,
+conditioned on `voice_lead_id IS NULL`) and stays set for the
+conversation's lifetime; the drain preserves it.
+
+### 18.4 Routes
+
+URL prefix `/agent/voice/breeze-buddy/widget`:
+
+| route | method | auth | notes |
+|---|---|---|---|
+| `/session` | POST | `public_widget_key` + Origin + per-IP RL | mints widget_token, returns greeting |
+| `/session/{id}/message` | POST | widget_token | SSE stream; 409 if channel ≠ CHAT |
+| `/session/{id}/voice/connect` | POST | widget_token | spins up Daily room + bot, seeds from chat history |
+| `/session/{id}/voice/end` | POST | widget_token | best-effort signal; drain runs in `end_conversation` |
+| `/session/{id}/end` | POST | widget_token | ends whole conversation; signals voice if live |
+| `/session/{id}` | GET | widget_token | resume payload for embed rehydrate |
+| OPTIONS on each | OPTIONS | none | permissive CORS preflight |
+
+CORS preflight returns permissive headers (`Origin: *`, methods/
+headers/max-age) so the browser preflight succeeds for any merchant
+site. The per-merchant `allowed_origins` check runs **inside** the
+POST handler — application-layer enforcement, not transport-layer.
+
+### 18.5 Tokens
+
+One widget JWT covers the whole conversation, both channels, the
+full 24-hour TTL. No re-mint at handoff. Claims:
+
+```json
+{
+  "sub": "widget-<12-hex>",
+  "typ": "widget",
+  "widget_session_id": "<chat_session.id>",
+  "widget_config_id": "<widget_config.id>",
+  "iat": ..., "exp": ...
+}
+```
+
+Voice attachments inside that 24h are bounded separately by Daily
+room expiry (1h, set in `start_daily_session`). The widget can
+reconnect voice (a new `/voice/connect` → new lead) up to the widget
+token's expiry.
+
+### 18.6 widget_config (per-merchant)
+
+Created by migration 030 (along with the chat_session columns).
+CRUD under `/agent/voice/breeze-buddy/widget-config`
+(admin / reseller-scoped). The `public_widget_key` is generated
+server-side by `secrets.token_urlsafe(32)` at create time and is
+never accepted from the client — the response is the only place a
+caller sees the key.
+
+```
+id                              uuid
+reseller_id                     varchar
+merchant_id                     varchar
+public_widget_key               varchar (server-generated, embedded in widget HTML)
+template_id                     uuid → template(id) ON DELETE RESTRICT
+allowed_origins                 text[]   (empty = deny all)
+max_sessions_per_ip_hour        int (default 60)
+max_messages_per_ip_hour        int (default 600)
+max_concurrent_per_ip           int (default 4, reserved for future use)
+max_voice_sessions_per_ip_hour  int (default 10)
+active                          bool
+```
+
+`UNIQUE (reseller_id, merchant_id)` — one widget per merchant.
+
+### 18.7 Voice runtime — resume + drain
+
+`/voice/connect` writes the resume seed into `lead.metaData` (fresh
+on first attachment via `create_lead_call_tracker`; refreshed on
+subsequent attachments via `reset_widget_voice_lead`):
+
+```
+{
+  is_widget: true,
+  widget_config_id: <uuid>,
+  widget_session_id: <chat_session.id>,
+  start_node:        <chat_session.current_node>,
+  prior_history:     [{role, content}, ...],   // full chat_message log
+  seed_message_count: <len(prior_history)>
+}
+```
+
+The seed advances on each /voice/connect: `prior_history` grows by
+whatever was added since the last attachment (chat turns + drained
+voice turns from prior attempts), and `start_node` reflects wherever
+the conversation last advanced to.
+
+The voice agent (`app/ai/voice/agents/breeze_buddy/agent/__init__.py`)
+reads the seed in `_setup_daily_transport` and:
+
+1. **Skips the greeting playback** — the prior turns already occupy
+   the user's screen; re-greeting feels broken.
+2. **Calls `prepare_resume_node` instead of `prepare_initial_node`**
+   to build the FlowManager's first NodeConfig.
+
+#### 14.7.0 Recordings disabled for widget voice
+
+`start_daily_session` accepts `enable_recording: bool = True`. The
+unified widget router passes `False` so widget voice sessions don't
+trigger Daily cloud recording and don't set the `recording_url`
+sentinel on the lead. Reason: with one lead reused across N voice
+attachments, the lead's single `recording_url` field cannot
+represent N recordings without a schema change. Telephony and demo
+paths default to `enable_recording=True` and behave exactly as
+before.
+
+#### 14.7.1 Sharp edge: pipecat resets context on first node
+
+`pipecat-flows`' `FlowManager._update_llm_context`
+(`.venv/lib/.../pipecat_flows/manager.py:712-825`) ALWAYS queues an
+`LLMMessagesUpdateFrame` (RESET) on the first `_set_node` call,
+regardless of `context_strategy` — the condition is
+`self._current_node is None`. A naive "pre-seed `LLMContext`, then
+call `initialize(node)`" would have the aggregator REPLACE the seed
+with `[role + task]` of the resume node, wiping our history.
+
+`prepare_resume_node` works around this inside the official API:
+**prior history is appended to the resume node's `task_messages`**.
+The RESET frame then sets context to
+`[role_messages, task_messages, ...prior_history]` in one shot — the
+order we want. Each prior history entry carries its own
+`{role: "user"|"assistant", content: str}` shape; the LLM doesn't
+require role-homogeneous task_messages.
+
+Implementation must run a real Daily-room round-trip to verify this
+holds — pipecat's downstream LLM service code may have hidden
+assumptions about task_messages roles.
+
+#### 14.7.2 Drain at end_conversation
+
+`handlers/internal/end_conversation.py` runs after Daily disconnects.
+After it collects `transcription` from `LLMContext.messages`, it
+checks for `lead.metaData.widget_session_id`. When present:
+
+1. Compute `new_messages = filtered_transcript[seed_message_count:]`
+   — only the turns past the seed boundary.
+2. Read `final_node = bot.flow_manager.current_node` (public property
+   on FlowManager — see `manager.py:189-219`).
+3. Call `drain_voice_into_chat_session(...)` which:
+   - INSERTs each new turn as a `chat_message` row (idempotent on
+     the `(session_id, idx)` PK).
+   - `UPDATE chat_session SET current_channel='CHAT',
+     current_node=$final_node WHERE id=$id AND current_channel='VOICE'
+     AND voice_lead_id=$lead_id` — conditioned on the lead we own so
+     a concurrent re-attach can't be clobbered. **`voice_lead_id` is
+     deliberately PRESERVED** so the next /voice/connect reuses this
+     same lead.
+
+The drain is wrapped in its own try/except so a failure cannot block
+the rest of `end_conversation` (lead UPDATE, callbacks, EndFrame).
+
+#### 14.7.3 Edge cases
+
+- **Bot crashes before drain.** Channel stays VOICE; `voice_lead_id`
+  points at a lead that's still in PROCESSING/BACKLOG. The next
+  `/voice/end` calls `flip_chat_session_to_chat` to roll back state.
+  A janitor sweep on `voice_lead_id IS NOT NULL AND
+  current_channel='VOICE' AND last_activity_at < now() - threshold`
+  (out of scope for this PR) is the long-term safety net.
+- **Daily room expires (1h)**. Pipecat's normal end-of-call flow
+  fires `end_conversation`, which executes the drain. No special
+  handling needed.
+- **Race between `/voice/end` and end_conversation drain**. Both
+  acquire the same per-session Redis lock (`chat:session:{id}:lock`),
+  so they serialize. The conditional UPDATE in the drain query
+  ensures only one writer can flip the channel.
+
+### 18.8 Manual verification checklist (no automated tests in this PR)
+
+1. `python scripts/migrate.py up` — 030 applies cleanly (creates
+   `widget_config` table + adds `chat_session.current_channel` and
+   `chat_session.voice_lead_id`).
+2. RBAC unaffected: log in via existing
+   `POST /agent/voice/breeze-buddy/login`, hit
+   `GET /agent/voice/breeze-buddy/templates/list`, expect 200. The
+   token has no `typ` claim, so the new check is a no-op for it.
+3. Admin `POST /agent/voice/breeze-buddy/widget-config` returns a
+   row with a generated `public_widget_key`. Confirm: the request
+   body cannot supply or override the key.
+4. `POST /agent/voice/breeze-buddy/widget/session` with valid key +
+   matching `Origin` returns `widget_token`,
+   `current_channel='CHAT'`, optional greeting. With wrong `Origin`
+   returns 403; with missing/inactive key returns 404.
+5. `POST /agent/voice/breeze-buddy/widget/session/{id}/message` with
+   widget_token streams SSE. With a stale RBAC token returns 401.
+6. `POST /agent/voice/breeze-buddy/widget/session/{id}/voice/connect`
+   with a chat-only template returns 400; with a voice-enabled
+   template returns Daily creds and flips channel to VOICE.
+7. While channel=VOICE, `POST .../message` returns 409.
+8. Talk in the Daily room for 2-3 turns, then close the room. Within
+   a few seconds, `GET /widget/session/{id}` shows
+   `current_channel='CHAT'`, the new turns appear in `messages`,
+   `current_node` reflects wherever the voice flow ended.
+9. Reconnect voice via another `/voice/connect`. Confirm:
+   (a) the new Daily room is seeded with the FULL history (chat
+   turns + drained voice turns from the prior attempt);
+   (b) the **same lead row** is reused — query
+   `lead_call_tracker WHERE id = chat_session.voice_lead_id`,
+   `attempt_count` should be ≥ 2, `call_id` reflects the new room.
+   No new lead row should appear from this conversation.
+10. `POST /widget/session/{id}/end` ends the whole conversation;
+    channel goes to ENDED. Subsequent ops 410.
+11. RBAC tokens and demo tokens both 401 against
+    `/widget/session/*`. Widget tokens 401 against
+    `/chat/session/*` (RBAC routes).
+12. 61st `/widget/session` create from one IP within an hour
+    returns 429 with `Retry-After`.
+
+### 18.9 Files
+
+**New:**
+- `app/database/migrations/029_widget_public_mode.sql` (creates
+  `widget_config` table + adds `chat_session.current_channel` and
+  `chat_session.voice_lead_id` — both ship together because each is
+  dead weight without the other)
+- `app/api/routers/breeze_buddy/widget/{__init__,handlers}.py`
+- `app/api/routers/breeze_buddy/widget_config/{__init__,handlers}.py`
+- `app/api/routers/breeze_buddy/widget_common.py`
+- `app/api/security/breeze_buddy/widget_token.py`
+- `app/database/{queries,accessor,decoder}/breeze_buddy/widget_config.py`
+- `app/schemas/breeze_buddy/widget_config.py`
+
+**Edited (additive):**
+- `app/api/routers/breeze_buddy/__init__.py` — include both widget routers.
+- `app/api/security/breeze_buddy/rbac_token.py` — reject `typ=widget`
+  and `demo=true` tokens.
+- `app/database/queries/breeze_buddy/chat_session.py` — `_SESSION_COLUMNS`
+  + state-mutation + drain query builders.
+- `app/database/accessor/breeze_buddy/chat_session.py` — attach /
+  detach / drain accessors.
+- `app/database/decoder/breeze_buddy/chat_session.py` — populate
+  `current_channel` + `voice_lead_id`.
+- `app/schemas/breeze_buddy/chat.py` — `WidgetChannel` enum, widget
+  request/response shapes, `ChatSession` extra fields.
+- `app/ai/voice/agents/breeze_buddy/agent/flow.py` — `prepare_resume_node`.
+- `app/ai/voice/agents/breeze_buddy/agent/__init__.py` — read
+  `lead.metaData` widget seed; branch greeting + node prep.
+- `app/ai/voice/agents/breeze_buddy/handlers/internal/end_conversation.py`
+  — drain back to chat_session when widget_session_id present.
+

--- a/docs/widget/SCALE_ROADMAP.md
+++ b/docs/widget/SCALE_ROADMAP.md
@@ -1,0 +1,1262 @@
+# Breeze Buddy Assist — Scale Roadmap
+
+Single source of truth for planned work. Update as scope changes. No implementation has started for any item below the "Already shipped" section unless explicitly noted.
+
+**Last updated**: 2026-05-21 (rev 9 — widget polish wave: cancel/stop, thinking indicator, dual-channel display, new-chat sheet, showcase landing, BbTurn segment-id fix, composer redesign; voice readiness audit recorded for next sprint)
+**Validation policy**: end-to-end testing happens **once**, after all planned sprint work has landed. No piecemeal browser tests in between — except for smoke checks immediately after each sprint to catch obvious wire-format regressions. Sprint 1 surfaced two tweaks (max_tokens, alias rename); Sprint 1.5 added Tile + groups; Sprint 1.6 (commerce-scrub) + 1.7 (session resume) + Sprint 3 (UCP cutover, S3.1+S3.2) all shipped and live-validated. See §"Real-traffic learnings".
+
+---
+
+## 🧭 Quickstart for resuming (read first after context compaction)
+
+If you're picking this up after compaction, here's the orientation:
+
+1. **The big picture in one paragraph**: cart-id fix + Sprint 1/1.5/1.6/1.7 + **Sprint 3 (UCP cutover, S3.1 + S3.2 idempotency)** are all shipped AND live-validated. UCP migration is 26 days ahead of Shopify's 2026-06-15 deadline. Catalog + cart traffic runs on `/api/ucp/mcp` via a direct-HTTP poster that bypasses Pipecat MCPClient (UCP rejects `initialize`); profile hosted at `https://breezebuddy.ai/.well-known/ucp/agent.json`. The runtime carries **seven** load-bearing pivots: (a) no UI subagent — single-agent + in-stream healer; (b) pure SpecStream JSONL — no hybrid DSL; (c) composite slot-filled `Tile` primitive; (d) per-template primitive-group selection; (e) zero commerce primitives in runtime; (f) session-resume via localStorage + persisted ui_blocks; (g) **declared `tool_schemas` + `default_args` + direct-HTTP poster as the UCP integration path; `state_reducers` + `tool_arg_injection` (now with generic generators: uuid_v4/uuid_v7/timestamp_*) are the commerce-agnostic engines on top.** Payment works today via `continue_url` Handoff → Shopify hosted checkout. On top of the seven pivots, the **widget panel is now polished for release** (Sprint 1.8): stop-button + server-side cancel via Redis pubsub fan-out, TTFB-only thinking indicator with random Claude-Code-style verbs, dual-channel `display?: string` on `to_assistant` actions (LLM payload keeps GIDs, user bubble gets human label), new-chat confirmation bottom-sheet, and a 20-vertical use-case showcase at `/showcase.html` (Sprint 1.9). **We are in release-readiness mode** — refine, smoke, ship; next phase is queued below.
+
+2. **Where the deep context lives** (cited liberally below):
+   - `poc/GOLDEN_INSIGHTS.md` — cart-id loss + generic-vs-flavoured verdict
+   - `poc/GOLDEN_UI_INSIGHTS.md` — open-source UI patterns (15-repo synthesis)
+   - `poc/WEB_RESEARCH_UI_GEN.md` — production-system research, source of the three pivots
+   - `poc/REPOS.md` — index of 15 cloned repos under `poc/`
+   - `docs/features/BREEZE_BUDDY_ASSIST.md` — primary design doc
+
+3. **How to act on it**: pick a sprint item (S1.1, S1.2, etc.) below, read its "Files to touch" + "Acceptance criteria", read the relevant `poc/*.md` referenced in §Architectural decisions, and start. No e2e tests between items — they accumulate for the final pass.
+
+4. **What NOT to revisit**: see §"Considered and rejected" — items already weighed and explicitly dropped (UI subagent, hybrid DSL/JSONL, RSC-streamed UI, etc.). Don't re-litigate without new evidence.
+
+5. **Release readiness — what's required to refine + ship the current set** (2026-05-20):
+
+   **Required before release** (small, mechanical, all ≤30 min each):
+   1. **Smoke-test S3.2 idempotency_key on Milton** — confirm UCP accepts top-level `idempotency_key`; if not, nest under `meta.idempotency_key` (1-line template change). Look at request body in clairvoyance logs after one `create_cart` + one `update_cart`.
+   2. **Move private signing keys** from `/tmp/ucp-keys/private_jwk.json` → `~/.config/breeze-buddy/private_jwk.json`. `/tmp` evaporates on reboot. Update any clairvoyance env / scripts that reference the old path.
+   3. **Consolidated e2e validation pass** (§"Validation strategy" — 13-point checklist). One pass across both merchants; no piecemeal repeats.
+
+   **Optional / deferred** (not blocking; can revisit anytime):
+   - **A7 — `primitive_disabled` telemetry deliberate test** — requires temporary template tweak (`disabled_primitives: ["Table"]`), re-provision, deliberate Table emission, then revert. Proves the group-allowlist gate end-to-end. ~3 min when needed.
+   - **Cross-provider swap (Anthropic → OpenAI)** — flip `llm_configurations.sdk` in the template, re-provision, repeat A1. Validates block-codec neutrality. Low priority.
+   - **Voice mode is NOT in this release.** Backend `/voice/connect` + `/voice/end` are live and `VoiceSession` types are exported from the SDK, but SDK `transferTo('voice')` is a stub and the widget has no in-call UI. Full breakdown + effort estimate recorded in §"Voice readiness audit (2026-05-21)" below. Plan is to ship voice as a clean next-sprint item once one open product question (call-screen UX) is decided.
+
+   **Anticipated quirks that did NOT surface** (recorded so we don't re-fear them):
+   - **Numeric-tag noise**: Milton products carry tag codes like `1008`/`5019`/`6010`. The LLM correctly ignored them and synthesized semantic chips (`Stainless Steel`, `Vacuum Insulated`, `BPA-Free Plastic`) from descriptions. **No healer rule needed.**
+   - **Empty `alt_text`**: many Milton products have no `media[0].alt_text`. The LLM correctly used `product.title` as the alt per JIT. **No `props_validation_failed` observed.**
+
+   **Process notes**:
+   - The user owns the Clairvoyance process directly (runs it in their own terminal, never spawn in background). Same for any long-running session-owned process.
+   - The widget Vite dev server is spawned by the assistant on this machine (port 5180); needs a restart whenever the SDK dist changes because Vite caches resolved imports. `pnpm install` from the nautilus root refreshes the pnpm cached symlink to the SDK after a build.
+
+---
+
+## 📦 This release vs next phase
+
+### In this release (refine + ship)
+
+All of these are shipped + live-validated; this is what we are smoke-testing once more and releasing:
+
+| Sprint | What | Status |
+|---|---|---|
+| Cart-id fix | block persistence + session state + arg-injection | ✅ shipped + live-validated |
+| Sprint 1 | SpecStream JSONL wire + in-stream healer + JIT UI instructions | ✅ shipped + live-validated |
+| Sprint 1.5 | Composite `Tile` primitive + per-template primitive groups | ✅ shipped + live-validated |
+| Sprint 1.6 | Commerce-scrub (runtime now 100% commerce-agnostic; Money primitive deleted; `scale_by_exponent` replaces `scale_money_amount`; `requires_buyer_*` → `requires_user_*`) | ✅ shipped + live-validated |
+| Sprint 1.7 | Session resume on refresh (localStorage + `GET /widget/session/{id}` + persisted `ui_blocks` column) | ✅ shipped + live-validated |
+| Sprint 3 (S3.1) | Full UCP cutover — direct-HTTP poster, declared `tool_schemas`, `default_args` profile injection, FLAT cart shape, `links[]` policy fallback | ✅ shipped 2026-05-20 + live-validated on Milton |
+| Sprint 3 (S3.2) | Idempotency-Key — generic `generators:` source on `tool_arg_injection` (uuid_v4/uuid_v7/timestamp_iso8601/timestamp_unix_ms); template wires `idempotency_key` on `create_cart` + `update_cart` | ✅ shipped 2026-05-20 (151/151 tests; +8 generator tests) |
+| Sprint 1.8 | Widget polish wave — cancel/stop button with multi-pod-safe server cancel (Redis pubsub `breeze-buddy:chat:cancel` + per-pod task registry in `cancel_bus.py`), TTFB-only thinking indicator (mascot + shimmer + sequential dots, 12 random verbs), dual-channel `display?` on `UiAction.to_assistant` (catalog + SDK + widget + canonical-template prompt), new-chat confirmation bottom-sheet, BbTurn segment-id stability fix (typewriter no longer re-types on tool-without-UI), composer redesign (send button inside input pill, "buddy by Breeze" watermark above), mascot launcher iterations (BbBuddy pearly orb + BbSolidOrb oil-slick swirl variant) | ✅ shipped 2026-05-21 |
+| Sprint 1.9 | Use-case showcase — `showcase.html` + `Showcase.svelte` rendering 20 diverse vertical demos using REAL widget chrome (BbHeader + BbWatermark + BbComposer) and the actual `UiRenderer`, demonstrating cross-industry reusability with 9+ distinct visual archetypes | ✅ shipped 2026-05-21 |
+
+**Refinement gates before release** (see §"Release readiness" in Quickstart): smoke-test idempotency_key wiring on Milton; move signing keys out of `/tmp`; consolidated e2e pass.
+
+### Next phase (after this release)
+
+Concrete, in priority order. Pick from this list when refinement + release lands:
+
+| Phase | Sprint | What | Why now | Effort |
+|---|---|---|---|---|
+| **NP-1** | S4.1 | **Eval harness** — frozen prompts + golden screenshots + LLM-as-judge in CI | Reliability foundation. Every template tweak today is rolling the dice. **Recommend starting here.** | ~1 week |
+| **NP-2** | S2.1 | Voice/chat UI parity — same SpecStream over RTVI + SSE | **Architecture is 70% in place** — backend `/voice/connect` + `/voice/end` live, `VoiceSession` types exported, Daily.co + Pipecat plumbing reused from the standalone voice product. Gap is ~7–8 dev-days of SDK + widget UI wiring. See §"Voice readiness audit (2026-05-21)" for the full breakdown. | ~7–8 dev-days |
+| **NP-3** | S2.2 | MCP Apps emission wrapper | Free distribution to Claude / ChatGPT / Goose / VS Code | ~3 days |
+| **NP-4** | S2.3 | `refine_ui(card_id, intent)` tool | "Make this card smaller" → targeted patch, not full re-render | ~3 days |
+| **NP-5** | S2.4 | **A2A AgentCard** at `/.well-known/agent-card.json` ← **distinct from the UCP profile at `/.well-known/ucp/agent.json` (already shipped)**. A2A AgentCard is Google's agent-to-agent federation spec; the UCP profile is Shopify's commerce protocol identity. Two specs, two endpoints. | A2A federation forward-compat. Future-proofing only. | ~2 days |
+
+### 📦 Repo layout — widget moved to loom (2026-05-20)
+
+The Breeze Buddy Assist widget package previously lived at `nautilus/packages/breeze-buddy-assist-widget/`. It now lives at `loom/packages/breeze-buddy-assist-widget/`, colocated with the `@juspay/breeze-buddy-client-sdk` it depends on (was an absolute `file:` link, now `workspace:*`).
+
+Production serve path: `https://breezebuddy.ai/widget/assist.js` (loom nginx + Cloud Run). Storefronts load it via a `<script>` tag — no nautilus build artifact required. Shopify-app integration shrinks to:
+
+```html
+<script src="https://breezebuddy.ai/widget/assist.js" async></script>
+<breeze-buddy-assist tenant="…" shop="…"></breeze-buddy-assist>
+```
+
+What stays in nautilus: the Shopify app (`shopify-apps/breeze-buddy/`), OAuth/webhooks, the canonical template JSON (`static/buddy-assist-agent/`), provisioning scripts, DB migrations — i.e. everything the Shopify-app installation flow touches. What stays in clairvoyance: unchanged (the Python agent backend).
+
+Historical references in this doc that mention `nautilus/packages/breeze-buddy-assist-widget/...` describe past state and are accurate for the period they refer to. For *today's* layout, see §"File map".
+
+### Demoted to deferred-on-demand (no longer in next phase)
+
+- **S3.3 Dual-tier error envelope** — today's catch-all "technical hiccup" message is acceptable. Revisit only after eval data (NP-1) shows which error scenarios actually hurt UX. Trigger: ≥3 distinct error categories surface in production telemetry with bad UX impact.
+- **S3.4 ConfirmCard Trusted Surface** — current `continue_url` Handoff gets shoppers to Shopify hosted checkout, where Apple Pay / Google Pay / cards / Shop Pay all work. ConfirmCard is the "agentic-pay-in-chat" upgrade — strategic bet, not a deadline item. Trigger: positioning commits to in-chat purchase completion as a differentiator.
+
+Both items remain documented under §"Sprint 3" below for posterity, with their original effort + mechanism notes. The "Deferred — on-demand" table is the load-bearing one.
+
+---
+
+## Architectural decisions (record of pivots — don't re-litigate)
+
+Three architectural pivots happened this week. They supersede the original "build a UI subagent" direction. Recording them here so future-us doesn't re-discover them.
+
+| Decision | Rationale | Source |
+|---|---|---|
+| **No UI subagent.** Stay single-agent for UI generation. | Vercel v0 (most capable UI generator in production), Shopify Sidekick, Claude Artifacts, ChatGPT Canvas, Tldraw Make Real — every leading production system does this without a UI subagent. Cognition's "subagents fragment context, UI needs coherent context" argument applies. | `poc/WEB_RESEARCH_UI_GEN.md` §"Counter-evidence" |
+| **In-stream healer instead of subagent.** A deterministic + (later) tiny-model layer fixes mechanical errors mid-stream in <250ms. Solves correctness without the cost/latency/complexity of a second LLM call. | Vercel v0 publicly documented this as "LLM Suspense" + AutoFix. Difference between ~90% and ~99% generation success. | `poc/WEB_RESEARCH_UI_GEN.md` §"Vercel v0" |
+| **Pure SpecStream / A2UI wire format.** Drop our OpenUI Lang DSL. LLM emits JSON-patch operations over JSONL, renderer applies patches incrementally against a session-stateful component tree. | Industry consolidating on this format (A2UI, json-render, MCP Apps). Bulletproof JSONL parsing. Multi-framework renderers available. Stateful UI for free. Standards-aligned for cross-host distribution. Reliability + scalability win — token cost is the only tradeoff and not a constraint. | `poc/WEB_RESEARCH_UI_GEN.md` §"NEW patterns A/B" |
+| **JIT UI instructions (Sidekick pattern).** Per-tool UI guidance ships in tool *responses*, not the system prompt. | Shopify Sidekick proved this scales to many tools without prompt bloat. Extends our existing `response_transforms` infra naturally. | `poc/WEB_RESEARCH_UI_GEN.md` §"Pattern 7" |
+| **Trusted Surface bypasses LLM entirely.** High-stakes UI (T&C, confirm, future payment) is server-rendered directly from a typed payload — no LLM in the path. | AP2 spec mandates the trusted surface be non-agentic. Architectural seam we already have in the T&C modal. | `poc/AP2/UI_INSIGHTS.md` |
+| **Composite `Tile` primitive for list items.** Renderer owns the layout; LLM fills typed slots (media/eyebrow/title/subtitle/body/attributes/actions/density). One `ui_op` per item replaces a hand-composed Card+Image+Text+Tag+Button subtree. Slot-filled UI is uniform by construction; the LLM can't half-emit a card. | Real-traffic smoke showed LLM-composed cards drift in completeness/order across items in the same Carousel. Industry consolidates on this pattern (A2UI templates, MCP Apps widgets, Slack Block Kit, OpenAI Apps SDK). ~80% fewer ops per card; bulletproof uniformity. | First live smoke 2026-05-19 (screenshots showed half-cards); see §"Real-traffic learnings" and §"Already shipped → Sprint 1.5". |
+| **Per-template primitive-group registry.** Catalog partitions into named groups (`core`/`composite`/`graphs`/`metrics`/`forms`/`media`/`data`). Template's `configurations.ui_catalog.enabled_groups` declares which groups the merchant gets. Server validates ops against the resolved allowlist (drops disabled types with `primitive_disabled:<type>`, distinct telemetry from `unknown_type`). System prompt auto-renders only the enabled primitives' schemas — LLM never even sees disabled types. | Generalizes the "what UI does this merchant get" question without proliferating use-case-specific primitives. New primitive families (graphs, forms) ship behind a group flag — existing templates unaffected. The LLM-only-sees-enabled principle prevents accidental emission and shrinks per-merchant prompt size. | Designed during Sprint 1.5 polish loop; replaces the deleted `gen_ui` allowlist at the right abstraction layer. |
+| **Zero commerce primitives in runtime — vertical flavor lives entirely in template + MCP.** Deleted the `Money` primitive (the only commerce-coded type in the catalog). Replaced its usage with `key_value` body rows carrying upstream display strings (e.g. `{key:"Price", value:"₹699.95"}`). Renamed `MessageResolution.requires_buyer_*` → `requires_user_*` (commerce-vocabulary leak). Replaced `scale_money_amount` (currency-aware) with `scale_by_exponent` (pure arithmetic, exponent from template args). | The runtime is now domain-neutral: a fitness, scheduling, finance, or real-estate template can adopt the same catalog + healer + builder without any commerce baggage. Price formatting is the upstream tool's responsibility (Shopify already returns formatted amounts); the LLM passes display strings through verbatim. Removes the entire `_PROP_ALIASES` Money entries + 2 Money-only healer rules + ISO 4217 currency tables. ~250 LoC net deletion. | Triggered by user audit 2026-05-19 questioning "why is Money a primitive at all?" + "scale_money_amount is hard commerce." Both calls were correct. |
+
+What's subsumed by these decisions (items that were separate, now collapse into the above):
+
+- ~~Three-channel result envelope~~ → natural in SpecStream (`content` is prose, JSONL stream is `structuredContent`, `_meta` for host directives)
+- ~~Typed `<Money>` `<Message>` `<Handoff>` primitives~~ → become schema entries in the SpecStream component catalog
+- ~~A2A DataPart promotion~~ → SpecStream IS the DataPart format; just publish the AgentCard
+- ~~English `description` on every primitive~~ → schema descriptions are first-class in component catalog
+- ~~Hybrid DSL/JSONL with compile step~~ → pure JSONL, no compile step
+- ~~Split `StatusUpdate` vs `ArtifactUpdate`~~ → SpecStream's stateful patches subsume this
+- ~~UI subagent (4-week build)~~ → deleted; healer replaces it
+
+### Considered and rejected (don't re-bring these up without new evidence)
+
+| Idea | Why rejected | Could revisit if |
+|---|---|---|
+| **UI subagent invoked as tool call** | v0/Sidekick/Artifacts all produce best-in-class UI without one. Cognition's "subagents fragment context, UI needs coherent context" applies. JIT instructions + healer + constrained catalog hit the same quality ceiling without the cost/complexity. | Single-agent quality plateaus measurably below target after S1.1+S1.3+S1.2 land. Have data, not vibes. |
+| **Hybrid DSL/JSONL (DSL author surface, JSONL wire)** | Compile step is an extra failure mode at the seam. Two formats to maintain. Reliability + scalability lose to pure SpecStream. LLM ergonomics solved by JIT instructions anyway. | Never — pure SpecStream is strictly simpler. |
+| **Keep current OpenUI Lang DSL end-to-end** | Bespoke parser/grammar maintenance forever. No industry tooling. Token-efficient but token cost isn't a constraint. Misses progressive render, stateful patches, multi-framework renderers, MCP Apps compat. | Never. The DSL was the right call 6 months ago when no standards existed; not now. |
+| **Pre-built widget bundles (OpenAI Apps SDK pattern)** | One-tool ↔ one-widget rigidity caps creativity. Wrong for open-ended commerce composition. | Only as the deferred `@Widget(...)` escape valve, IF SpecStream composition genuinely can't express a canonical UI elegantly. High bar. |
+| **Vercel AI SDK RSC (React Server Components from LLM)** | Vercel themselves paused it Q1 2026 — flickering on `.done()`, suspense crashes, quadratic data transfer. We dodged a bullet. | Never — Vercel walked away. |
+| **MCP `_meta` injection for cart_id (golden insight recommendation)** | Pipecat MCP client doesn't expose `_meta` on the wire. We did argument injection instead — same semantic, different target. Forward-compatible: when proxy/UCP cutover lands, retarget rules from arg-keys to meta-keys with no template authoring change. | If a future proxy gives us `_meta` plumbing AND there's evidence it's better than arg injection. |
+| **Three-channel envelope as a separate sprint item** | Subsumed by SpecStream — the JSONL stream IS the structuredContent channel. Building it separately would be duplicate work. | Never. |
+| **Fine-tuned tiny healer model (v1)** | Deterministic rules cover the common cases; let's measure catch rate before investing in a model. | Deterministic catch rate < ~85% after Sprint 1 ships. |
+
+---
+
+## `agent_session_state` — substrate + leverage map
+
+The per-session JSONB store added in migration 030 carries three keys today (`cart_id`, `checkout_url`, `policy_links`). Architecturally it's a substrate, not a feature: a server-side memory layer driven entirely by template `state_reducers` + `tool_arg_injection` rules (with `generators:` for synthesised values), with **zero vertical coupling in the Python runtime**.
+
+Recording the leverage so future-us doesn't reinvent it. Every entry below is "1–3 reducer rules + maybe an injector + a system-prompt branch" — no Python.
+
+### Engine properties that make this cheap
+
+1. **JSONB is shapeless.** Adding `state.return_flow.step` or `state.preferences.size` needs no migration.
+2. **Template-only wiring.** Each use is a few lines in `state_reducers` + `tool_arg_injection`; the engines (`apply_state_reducers`, `inject_tool_args`) stay vertical-blind.
+3. **Composable with `generators:`.** `uuid_v4`, `uuid_v7`, `timestamp_iso8601`, `timestamp_unix_ms` work for any synthesised value (request ids, mandate ids, trace ids, idempotency keys — already used).
+4. **Survives refresh, compaction, and provider swap.** Reliability properties accumulate per session without any per-vertical persistence work.
+
+### Near-term — already implied by the UCP roadmap
+
+| Future use | What gets captured | Trigger |
+|---|---|---|
+| **`customer_id`** | Identity-link tool response → `state.customer_id`; injected into every subsequent cart / order call | UCP `identity_linking` extension lands; or post-auth flow ships |
+| **`order_id`** | Checkout-complete event → `state.order_id`; injected into WISMO / receipt / status follow-up tools | UCP `order` extension stable (replaces Nautilus WISMO) |
+| **`discount_code` / `applied_discounts`** | Reducer captures applied codes from cart response; injector keeps them sticky on every `update_cart` | UCP `discount` extension lands |
+| **`shipping_address_id`** | Captured at address-selection step; injected into subsequent checkout-step tools so the user doesn't reselect | Multi-step checkout flow gets built |
+| **AP2 mandate ids** (`cart_mandate_id`, `payment_mandate_id`) | Generated client-side or returned from mandate creation; ride out-of-band, never in LLM prose | AP2 payment scope unlocks |
+
+### Session preferences (sticky across turns + refresh)
+
+| Future use | Why this table |
+|---|---|
+| **`locale` / `currency`** | Captured from first cart/product response or geolocation tool; injected into every subsequent catalog call so a USD user doesn't see INR mid-session |
+| **`size_preference` / `color_preference` / `negative_constraints`** | LLM extracts "I'm a US 10, never leather" early via a synthetic `set_user_preferences` tool; injected as filters into every future `search_catalog`. Cures the "you forgot what I said two turns ago" complaint with no model changes. |
+| **`a_b_variant_id`** | Session-sticky experiment bucket; consistent treatment across refresh |
+| **`accepted_terms` / `marketing_opt_in`** | One T&C accept survives refresh; user not re-prompted |
+
+### Workflow state machines (the underrated use)
+
+For multi-step flows where the current step matters, the **template + reducer IS the FSM** — no Python state machine needed.
+
+- **Returns / refunds**: `state.return_flow.step = "awaiting_reason"` → `"awaiting_photos"` → `"submitted"`. System prompt branches on the key.
+- **Address verification**: `pending` → `verified` → `corrections_needed`.
+- **Future verticals** (appointment booking, travel itinerary, etc.): `step = service → time → confirm → paid`. Each tool advances the state.
+
+Pattern is identical to `cart_id` — runtime engine doesn't know what `return_flow.step` *means*; the template's reducers + injectors + prompt branching wire it up.
+
+### Telemetry hooks (naturally feed Sprint 4 eval harness)
+
+Once the eval harness lands (NP-1), these are the per-session signals worth scoring on:
+
+- `tool_call_counts: {search_catalog: 4, get_product: 7, …}` — flag sessions that grind on browse without converting
+- `last_intent: "browsing" | "comparing" | "checkout" | "support"` — slice quality by intent bucket
+- `refusal_count` — bumped on every "I can't help with that"; high count → escalate
+- `detected_pii: bool` — set on first credit-card / email mention; drives retention policy
+
+### Safety + guardrails
+
+- **Loop detection**: `state.loop_count` bumped when the same intent repeats; past a threshold, prompt branches to offer-help-different-way.
+- **Refusal escalation**: 3rd refusal in a session → auto-emit a Handoff to human support.
+- **Per-session friendly throttle**: not infra-level rate-limiting; the "you've asked me a lot, want a summary?" UX.
+
+### Multi-surface continuity (voice ↔ chat)
+
+`chat_session.voice_lead_id` already exists; `agent_session_state` is where cross-surface scratch lives:
+
+- `voice_started_at`, `last_interrupt_at` — voice-specific telemetry
+- `cards_shown: [tile_id, …]` — so the user voice-saying "the second one" disambiguates
+- `pending_voice_confirm: {action, payload}` — captured before a voice-initiated action; consumed by the next yes/no turn
+
+### A2A / cross-agent handoffs (deferred bucket — see NP-5)
+
+When A2A federation becomes real:
+
+- `state.a2a_session_id` — correlation id for handoff
+- `state.handoff_context: {tool_history, identifiers, summary}` — the bundle to forward
+- `state.federation_trace_id` — tracing across hops
+
+### What this table is NOT for (worth saying)
+
+- **Cross-session data** (user profile, purchase history) — belongs in customer-level tables. This row dies with the session.
+- **High-write hot state** (every keystroke / token) — it's upsert-per-turn, not append-log. Use a separate audit table for that.
+- **Facts the LLM needs to reason over** — those go in `content_blocks`. `agent_session_state` holds identifiers + flags the **runtime** threads on the LLM's behalf, not facts the LLM needs to weigh.
+
+### Most valuable next single use
+
+After the eval harness lands (NP-1), session-level **preference capture** (size / colour / negative constraints) is the highest-leverage 1-day addition. Two reducer rules + one prompt branch; visibly improves multi-turn shopping without any model change.
+
+---
+
+## Already shipped
+
+### Sprint 1.8 — Widget polish wave (shipped 2026-05-21)
+
+A multi-session pass to ready the panel for production. All of these landed in `loom/packages/breeze-buddy-assist-widget/` and `loom/packages/client-sdk/`; one cross-cutting Clairvoyance change (cancel-bus + UiAction.display in catalog) landed in `clairvoyance/app/api/routers/breeze_buddy/chat/` and `clairvoyance/app/ai/voice/agents/breeze_buddy/template/`.
+
+**Server-side cancel for in-flight chat turns** — the widget Stop button now actually releases the per-session Redis lock instead of waiting on the 180s TTL. Multi-pod safe via Redis pubsub channel `breeze-buddy:chat:cancel`:
+- `clairvoyance/app/api/routers/breeze_buddy/chat/cancel_bus.py` — NEW. Per-pod `Dict[session_id, asyncio.Task]` + Redis subscriber loop with exponential backoff. `register()` / `unregister()` / `cancel()` / `start_subscriber()` / `stop_subscriber()`.
+- `chat/handlers.py` — `stream()` registers `asyncio.current_task()` on entry, unregisters in finally. Catches `CancelledError` → yields clean `turn_end: CANCELED`. Critical Python-3.11 detail: explicit `current_task.uncancel()` after the catch + `asyncio.shield(lock.release())` in finally to prevent re-cancellation losing the Redis `DEL`.
+- New routes: `POST /chat/session/{id}/cancel` (admin auth) + `POST /widget/session/{id}/cancel` (widget-token auth). Both fire-and-forget 202.
+- App lifespan in `main.py` starts + stops the subscriber.
+- SDK `widget.ts:cancel()` fires `POST /cancel` alongside the local AbortController abort.
+
+**TTFB-only thinking indicator** — `BbThinkingRow.svelte` (NEW) renders the buddy orb + a shimmering verb (one of 12 random: Thinking / Pondering / Cooking / Brewing / Mulling / ...) + sequential dots that build up (`.` → `..` → `...`) and reset. Tool-name override map for known tools (`search_products` → "Searching products"). Shown ONLY between user-send and first assistant token/UI op (predicate: `sending=true && last message is user`). No bubble chrome — chrome-less status row makes it visually distinguishable from messages.
+
+**Dual-channel display for actions** — `UiAction.to_assistant` now accepts optional `display?: string`. LLM payload (`msg`) always reaches the backend with full GIDs/identifiers; user bubble shows `display` when present, or falls back to a client-side heuristic that maps `gid://shopify/<Type>/<id>` → "this <type>". Touched: `client-sdk/.../ui/types.ts`, `client-sdk/.../store/_buddy-chat-store.ts` (`send` accepts `displayText`), `widget/.../ui/UiNode.svelte`, `widget/.../ui/UiRenderer.svelte`, `widget/.../ui/primitives/Tile.svelte`, `widget/.../BuddyAssist.svelte` (new `humanizeForBubble()`). Backend: `clairvoyance/.../template/ui_catalog.py` `ToAssistantAction.display: Optional[str]` (extra="forbid" was rejecting). Template: `canonical.template.json` instructions for `search_catalog` / `get_product` / `create_cart` now include `display:` constructed from `product.title` / `line.item.title`.
+
+**New-chat confirmation flow** — header `+` icon button to the left of close; click opens `BbConfirmSheet.svelte` (NEW — bottom-sheet, chosen over modal for narrow-panel readability), confirm calls `resetSession()` + `ensureSession()` for a fresh thread. `BbWindow.svelte` gained an optional `overlay` snippet so the sheet stays scoped to the panel.
+
+**BbTurn segment-id stability fix** — the typewriter was re-typing previously-revealed text whenever the model called a tool that emits NO UI op (text → tool → text adjacent in blocks). Root cause: `buf.ids.join('+')` flipped segment key from `'asst_1'` to `'asst_1+asst_2'`, triggering keyed `{#each}` remount and `revealedLen` re-init. Fix: use `buf.ids[0]!` so the segment key is invariant across joins.
+
+**Composer redesign** — send button moved INSIDE the input pill (single rounded shape), placeholder changed to "Message…", "buddy by Breeze" watermark above composer (subtle font + 0.28 opacity), panel background unified to `--panel-bg-2` (cream) end-to-end so no seam between chat body and footer, send icon flips to a stop square while `status==='sending'` (wired to the cancel flow above).
+
+**Mascot launcher** — `BbBuddy.svelte` (pearly orb with pill eyes + lavender stroke border) and `BbSolidOrb.svelte` (oil-slick swirl variant, three lavender/magenta/coral blobs at reduced chroma + bright central wisp + heavy SVG film grain) — both consumed by `BbLauncher.svelte` which renders a configurable pill ("Talk to an Agent" or empty for bare orb) with a phone-mode size reduction at `<=480px`.
+
+**Dev harness uplift** — `index.html` (dev harness) gained: scenario testing chips (TTFB / long-stream / heavy-carousel / text-only / tool-with-side-effects / 300+ char user-bubble), Launcher variants toggle (mascot↔solid, label on/off), "Open Use-Case Showcase →" link. `index-shopify.html` repointed from swaroop-juspay to Milton (same key as dev harness).
+
+### Sprint 1.9 — Use-case showcase (shipped 2026-05-21)
+
+`showcase.html` + `Showcase.svelte` (NEW, ~1200 lines) demonstrate the widget repurposed across 20 diverse verticals: Restaurant ordering · Healthcare booking · Insurance quote · EdTech tutor · Legal triage · Real estate · Travel itinerary · HR onboarding · Bank account opening · Telecom plan finder · Fitness coach · Recipe assistant · Event ticketing (StagePass) · SaaS onboarding · Government services · Mental health check-in · Pet adoption · Job application · Auto repair (Cascade Auto) · Hotel concierge.
+
+Each preview renders the REAL widget chrome (imports `BbHeader`, `BbBuddy`, `BbAssistantTextBubble`, `UiRenderer`, `BbWatermark`, `BbComposer`) so demos look exactly like the production widget — not generic cards. Mock transport was retired (`createMockWidgetChatSession` throws), so previews use hand-authored `UiOp[]` arrays fed through the real renderer (Strategy B from the rebuild brief). Token scope: `.panel-scope` re-declares `--*` and `--openui-*` tokens that `tokens.css` normally scopes to `:host` since we render outside the Shadow DOM.
+
+9+ distinct visual archetypes: text-only markdown (EdTech, Recipe) · image-dominant carousel (Restaurant, Real Estate, Pet Adoption) · table/comparison (Insurance, Telecom) · slot/picker grid in a Carousel (Healthcare, Event Ticketing seat tiers, Auto Repair bays) · checklist (HR) · form-flow step card (Bank, Government) · mood/chip selection (Mental Health, Fitness) · handoff-driven (Legal) · tile stack + handoff (Jobs) · narrative multi-section (Travel) · SaaS feature tour (SaaS onboarding).
+
+Three slot-grid scenarios were initially rendered as `Row` and overflowed; switched to `Carousel` after first review for proper horizontal snap-scroll.
+
+Image sources: `picsum.photos/seed/{seed}/{w}/{h}` for realistic photos; inline SVG data: URLs for decorative bits (SaaS feature screenshot). Replaced every dead `source.unsplash.com` URL.
+
+Footer disclaimer notes previews are static; button actions fire into a no-op handler that flashes a hint pill ("Preview only — '…' would dispatch in a real session.").
+
+Link from the dev harness landing: "Open Use-Case Showcase →" pill, top of `index.html`.
+
+### Sprint 1.7 — Session resume on refresh (shipped + live-validated 2026-05-20)
+
+Cross-cutting fix for the cart-orphaning bug discovered during the A6 refresh smoke. Before this sprint, a Cmd+R reload created a brand-new chat session, breaking the `agent_session_state` row's link to the Shopify cart_id — every refresh effectively dropped the cart on the floor (and visually wiped all prior Tiles). The widget now persists the session id + widget_token in `localStorage` (keyed by tenant + shop) and resumes the prior session via `GET /widget/session/{id}`, replaying both chat bubbles AND persisted UI ops.
+
+| Surface | Change |
+|---|---|
+| `database/migrations/030_chat_session_persistence.sql` | Adds `ui_blocks JSONB` column on `chat_message` (alongside the `content_blocks` + `agent_session_state` additions consolidated into this single migration). Independent of `content_blocks` — the LLM never sees prior ui_ops on replay (by design). |
+| `schemas/breeze_buddy/chat.py` | `ChatMessage.ui_blocks: Optional[List[Dict]]` added. |
+| `database/{queries,decoder,accessor}/breeze_buddy/chat_session.py` | `_MESSAGE_COLUMNS` adds `ui_blocks`; `insert_chat_message_query` accepts `ui_blocks_json`; `decode_chat_message` parses it; `insert_chat_message` plumbs `ui_blocks` through. |
+| `ai/voice/agents/breeze_buddy/chat/agent.py` | Per-cycle `turn_ui_ops: List[Dict]` accumulator. The stream loop captures each successful `ui_op` SSE event (post-healer, post-allowlist) into the list and passes it as `ui_blocks=turn_ui_ops or None` to both in-loop and final `insert_chat_message` calls. |
+| Server resume endpoint | `GET /agent/voice/breeze-buddy/widget/session/{id}` already existed (returns `WidgetSessionStateResponse`) — now serves `ui_blocks` for free via the schema/decoder changes. **No new endpoint needed.** |
+| `loom/.../client-sdk/src/lib/chat/widget.ts` | localStorage helpers (`resumeStorageKey`, `readStoredSession`, `writeStoredSession`, `clearStoredSession`). Resume probe runs BEFORE the create flow: if a non-expired stored entry exists, do `GET /widget/session/{id}` with the stored bearer; on 200 adopt the sessionId+widgetToken, backfill SDK `transcripts`, and **schedule a `setTimeout(0)` emit of the `resumed` event** so consumers attaching via `session.on('resumed', …)` after the factory promise resolves still receive it (queueMicrotask would have fired before the consumer's `.then()` ran — load-bearing distinction discovered during A6 smoke). On any failure (404/401/network/JSON parse) the storage entry is dropped and we fall through to a normal `POST /widget/session`. After a successful create, the new session is written to storage with `expiresAt = Date.now() + ttl_seconds*1000`. Storage is cleared on `end()`, on `410` idle-timeout, and on `410` already-ended. |
+| `loom/.../client-sdk/src/lib/chat/types.ts` | New `resumed` event added to `WidgetChatSessionEventMap`; new `ResumedSessionDetails` + `ResumedMessage` types. |
+| `loom/.../client-sdk/src/lib/store/_buddy-chat-store.ts` | `attach()` registers `session.on('resumed', …)` that REPLACES `state.messages` with a fresh array built from the resume payload — one `ChatTextMessage` per user content, one per assistant content, plus one `ChatUiMessage` for any assistant turn with persisted `ui_blocks`. The existing snapshot-transcript hydration (assistant-only) is harmless because the replay-replace runs after it. |
+| Widget package | **No code changes.** The widget's `BbUiPane` already consumes `ChatUiMessage.ops` via the same `applyOp` pipeline the live SSE stream uses, so replayed ops repaint Tiles/Carousels/cart views identically to live. |
+
+**Architectural property gained**: refresh becomes lossless. Cart-id continuity, chat history, and rendered UI all survive a page reload — and a tomorrow-morning reload (24h widget_token TTL). No `agent_session_state` rows get orphaned; one user = one shopify cart per session lifetime.
+
+**Verification**: A6 smoke passes — fresh session → 2 user prompts → refresh → GET 200 hits `/widget/session/<id>`, both user + assistant bubbles repaint, localStorage carries `{sessionId, widgetToken, expiresAt}` keyed `bb:chat:session:v1:<baseUrl>|<widgetKey>|<shopUrl>`. Network tab confirms POST /session NOT called on the refreshed mount.
+
+**Notable trap recorded for future-us**: `queueMicrotask` is NOT sufficient when the factory is itself an async function — its returned promise's `.then` is ALSO a microtask, scheduled AFTER the body's `queueMicrotask`. The emit fires before the consumer's `.then` runs and the event is silently lost. `setTimeout(handler, 0)` (a macrotask) is the right defer primitive here. See widget.ts comments around line 595 for the full rationale.
+
+### Sprint 1.6 — Commerce-scrub (shipped 2026-05-19, live-validated 2026-05-20)
+
+**Smoke results (rev 7)**: A1 (snowboard carousel), A2 (no drops/heals), A3 (product detail Tile after JIT root-id fix), A4 (cart-id reuse + row layout + thumbnails + trailing slot), A5 (skip_ui FAQ), A6 (refresh persistence — covered by Sprint 1.7 below), B1 (Milton catalog — numeric tag filter + empty alt handled by LLM/JIT, no healer needed), B2 (Milton cart flow — cart-amount transforms added during B2 to fix `₹316.0` → `₹316.00` formatting) all green. Two carts in DB confirm session-scoped cart-id reuse across `update_cart` + `get_cart`.
+
+**Post-smoke template patch**: added 8 `tool_response_transforms` entries (4 each for `update_cart` + `get_cart`) covering `cart.cost.total_amount`, `cart.cost.subtotal_amount`, `cart.lines[*].cost.total_amount`, `cart.lines[*].cost.subtotal_amount`. UCP returns cart amounts as decimal-already strings (e.g. `"316.0"`); the transform's "decimal-string reformatting" path normalises them to `"316.00"` with thousands separators (`"1,029.00"` for the DUO DLX 1000 ml). Originally the template only scaled `search_catalog` / `get_product_details` paths.
+
+
+
+User-audit-driven cleanup: the runtime carried more commerce vocabulary than the agreed principle "runtime commerce-agnostic; commerce in template JSON only" allows. This sprint scrubbed the runtime to genuine zero-commerce. No new features; pure architectural cleanup.
+
+| Surface | Change |
+|---|---|
+| `template/ui_catalog.py` | **Money primitive deleted.** Class removed; dropped from `UI_CATALOG`, `PRIMITIVE_GROUPS["core"]`, `PRIMITIVE_RENDER_ORDER`, `__all__`. `TileBodyKind.money` enum value + `TileBodyItem.money` field also removed (Tile body is now `text`/`key_value`/`message`). |
+| `template/ui_catalog.py` | **`MessageResolution` enum renamed**: `requires_buyer_input` → `requires_user_input`; `requires_buyer_review` → `requires_user_confirmation` (also drops "review" in favour of the more accurate "confirmation" since the rendered affordance is a confirm CTA). |
+| `chat/ui_healer.py` | **Two Money-specific rules deleted** (`_rule_money_infer_currency`, `_rule_money_coerce_string_amount`). ISO 4217 `_CURRENCY_EXPONENT` table + `_exponent_for` helper removed. `_PROP_ALIASES` entries for Money (`value→amount`, `price→amount`) gone. `HealerContext.default_currency` kwarg removed. |
+| `handlers/transport/utils/response_transform.py` | **`scale_money_amount` → `scale_by_exponent`**. Pure arithmetic now: takes an explicit `{exponent: int}` arg, no ISO 4217 lookup, no currency knowledge. Templates declare the exponent for their data source. `_ZERO_DECIMAL_CURRENCIES` / `_THREE_DECIMAL_CURRENCIES` / `_minor_unit_scale` all deleted. |
+| `template/ui_prompt.py` | Dropped Money from `_EXAMPLES`. Genericised remaining example messages (`"Tell me more about <id>"` etc.). Updated docstring refs from Money → Message in nested-render examples. Footer composition rules drop the "never compose Card+Image+Text+Money" advice (no Money to compose). |
+| `chat/ui_stream.py`, `chat/tool_result_normalizer.py` | Docstring sweep — removed Money examples; updated "vertical-agnostic" framing for normalizer. |
+| `template/types.py` | Updated `ResponseTransform` docstring to reference `scale_by_exponent`. |
+| `static/buddy-assist-agent/canonical.template.json` | `tool_response_transforms` now use `scale_by_exponent` + `{exponent: 2}` args. All 4 `tool_ui_instructions` (search_catalog, get_product_details, update_cart, get_cart) rewritten — no Money emission. Price/total rendered as `key_value` body rows with `"₹" + amount` from the upstream-scaled value. Cart total moved into `CardHeader.subtitle` (was a standalone Money op). |
+| `packages/breeze-buddy-assist-widget/src/lib/ui/primitives/Money.svelte` | **Deleted.** |
+| `packages/breeze-buddy-assist-widget/src/lib/ui/UiNode.svelte` | Money import + Money dispatch branch removed. `TileNarrowedBodyItem` union narrowed to drop `money` variant. `TileMessageResolution` renamed buyer→user. `narrowBody` simplified (one fewer kind). |
+| `packages/breeze-buddy-assist-widget/src/lib/ui/primitives/Tile.svelte` | `TileMoneyPayload` interface removed. `TileBodyKind` narrowed to `text`/`key_value`/`message`. Money import + body switch case dropped. `TileMessageResolution` renamed. |
+| `packages/breeze-buddy-assist-widget/src/lib/ui/primitives/Message.svelte` | `Resolution` type renamed; docstring updated. |
+| Tests | `tests/test_response_transform.py` rewritten for `scale_by_exponent` API (currency-aware tests replaced with exponent-aware). Money-specific tests removed from `test_ui_stream.py` / `test_ui_healer.py` / `test_tile_validation.py`. `test_ui_prompt.py` swapped Money→Tag in allowlist tests. `test_ui_catalog_groups.py` added explicit assertion that Money is no longer registered. **All 133 tests pass.** |
+
+**Verification done**: 133/133 pytest pass, widget `pnpm build` succeeds (175.45 kB / 57.03 kB gzip, +0 errors), `svelte-check` reports 0 errors / 0 warnings.
+
+**Verification pending** (needs user-owned clairvoyance + re-provision):
+- Live smoke on both merchants — confirm `key_value` price rendering looks visually equivalent to the old Money chip.
+- Confirm no `props_validation_failed` events for stale `kind:"money"` body rows from cached prompts.
+- Confirm `requires_user_input` / `requires_user_confirmation` flow once a Message-with-resolution arrives (Sprint 3 form work depends on this).
+
+**Net delta**: ~250 LoC removed, 0 LoC added on architectural surface (catalog/healer/builder/transform); template + widget refactored for the simpler primitive set. Architectural property gained: **runtime is now formally vertical-agnostic** — same code can power non-commerce verticals without any catalog edit.
+
+### Sprint 1 — SpecStream + healer + JIT instructions (live-validated 2026-05-19)
+
+The OpenUI Lang DSL is deleted across all 3 repos. Replaced with SpecStream/A2UI JSONL ops + in-stream healer + Sidekick-pattern JIT UI instructions in tool response envelopes.
+
+| Layer | Files | What ships |
+|---|---|---|
+| **Server: catalog** | `clones/clairvoyance/app/ai/voice/agents/breeze_buddy/template/ui_catalog.py` | 14 Pydantic primitives (Stack, Row, Card, CardHeader, Image, Text, Carousel, Tag, Button, Buttons, Table + new typed Money, Message, Handoff). `UI_CATALOG: Dict[str, Type[BaseModel]]`. |
+| **Server: wire format** | `clones/clairvoyance/app/ai/voice/agents/breeze_buddy/chat/ui_stream.py` | `UiStreamExtractor` (replaces UiMarkerExtractor) — `<ui_stream>` marker FSM yielding per-line JSONL ops. `parse_op_line` validates against catalog. `process_op_line` runs (healer → parse → SSE-emit) per line. `strip_ui_stream_markers` for persistence. |
+| **Server: healer** | `clones/clairvoyance/app/ai/voice/agents/breeze_buddy/chat/ui_healer.py` | Deterministic rule layer; runs before validation. 7 transform rules (incl. `_PROP_ALIASES` rename, unknown-props strip, Money currency inference, Money amount coercion, Button default label, Tag array-flatten, id dedupe) + 2 drop rules (unknown type, orphan add). Emits `healer_applied` SSE events. |
+| **Server: JIT instructions** | `clones/clairvoyance/app/ai/voice/agents/breeze_buddy/template/types.py` + `mcp/__init__.py` | `ToolUiHint` Pydantic model on `McpServerConfig.tool_ui_instructions`. `_maybe_inject_ui_instructions` splices `_ui_instructions` / `_ui_examples` / `_ui_skip` into tool result envelopes (Sidekick pattern). |
+| **Server: chat agent** | `clones/clairvoyance/app/ai/voice/agents/breeze_buddy/chat/agent.py` | `UiStreamExtractor` replaces `UiMarkerExtractor`; per-line ops fan out to SSE; session-wide `_known_ui_ids` set for dedupe. Markers stripped before persistence so replay history is prose-only. |
+| **Server: deletions** | `chat/ui_emit.py`, `ui_marker.py`, `ui_parser.py`, `ui_resolver.py`, `ui_prompt.py` (all gone); 5 corresponding test files deleted. | OpenUI Lang DSL fully retired server-side. |
+| **Widget: store** | `nautilus/packages/breeze-buddy-assist-widget/src/lib/ui/ui_state.svelte.ts` | Svelte 5 `$state` tree store. `applyOp` (add/replace/remove), `getNode`, `reset`. Recursive subtree removal. One store per UI block, mounted per assistant turn by `BbUiPane`. |
+| **Widget: renderer** | `src/lib/ui/UiRenderer.svelte`, `UiNode.svelte` | Stateful patch-applier. Walks tree from `rootId`; dispatches by `type` to primitive component; maps catalog props → existing primitive props (gap tokens, variant names, etc). |
+| **Widget: new primitives** | `src/lib/ui/primitives/Money.svelte`, `Message.svelte`, `Handoff.svelte` | Money uses `Intl.NumberFormat` with ISO 4217 exponent table (handles JPY zero-decimal, KWD three-decimal). Message has severity + resolution → fixed affordance. Handoff is typed CTA with lifecycle (popup/same_tab/polling). |
+| **Widget: turn integration** | `src/lib/components/BbUiPane.svelte`, `BbTurn.svelte`, `BbTextPane.svelte`, `BuddyAssist.svelte` | BbUiPane owns a per-block UiStore + an `appliedCount` watermark — applies only new ops as they stream in, never re-applies. Plumbs `UiAction` (not `ParsedAction`). |
+| **Widget: deletions** | `src/lib/ui/_evaluator.ts`, all 3 stale smoke tests | DSL evaluator gone. |
+| **SDK** | `~/Repos/loom/packages/client-sdk/` v0.7.0 | `_lang-core/` directory deleted (~3kLOC vendored parser). `_parse.ts`, `_action-bus.ts`, `_evaluator.ts`, `primitives/`, `UiRenderer.svelte`, `UiNode.svelte` all gone. `ui/types.ts` shrunk to 3 exports: `UiOp`, `UiAction`, `UI_CATALOG_VERSION`. `_turn-engine.ts` handles `ui_op` / `healer_applied` / `ui_op_dropped` SSE events. `chat/types.ts` `ChatUiMessage` shape: `{id, kind:'ui', role, ops: UiOp[], createdAt}`. `store/_buddy-chat-store.ts` accumulates ops per-turn into an active live array. `mock/index.ts` stubbed (throws `NotImplementedError`; SpecStream mock returns in Sprint 4). |
+| **Template** | `nautilus/static/buddy-assist-agent/canonical.template.json` | System prompt's UI section <300 chars; declares SpecStream op shapes; no DSL grammar. `tool_ui_instructions` map for `search_catalog` / `get_product_details` / `update_cart` / `get_cart` / `search_shop_policies_and_faqs` (last one `trigger: skip_ui`). `gen_ui` block removed. `max_tokens: 16384` (was 1024 — bumped after first live run showed JSONL truncation). |
+| **Tests** | `clones/clairvoyance/tests/{test_ui_stream,test_ui_healer,test_jit_instructions}.py` | 67 tests pass (23 ui_stream + 19 healer + 6 JIT + 19 session_state). SDK: 50 tests pass after `tsc --noEmit` clean. Widget: svelte-check 0 errors / 0 warnings. |
+
+### Sprint 1 live-validation status
+
+First real-traffic smoke ran 2026-05-19 against `swaroop-juspay.myshopify.com` with Claude Sonnet 4.6 via Vertex.
+
+| Scenario | Status | Evidence |
+|---|---|---|
+| Product search → carousel of cards | ✅ validated (pre-Tile) | Real SSE stream emitted `ui_op` events with stable ids (`c-<product.id>`, `c-<product.id>-img|title|price|btn`), Money with minor-unit int + INR currency, Button action `{type:"to_assistant",msg:"Tell me about gid://shopify/Product/..."}`. Surfaced card-uniformity issue → fixed in Sprint 1.5 via Tile composite. |
+| JIT instructions in tool response | ✅ validated | `function_call_completed.result_summary` carries `_ui_instructions` verbatim — LLM grounded card layout on it. |
+| In-stream healer | ✅ validated | `healer_applied: renamed_alias_props:Tag:label->text` fires per Tag op in real traffic. |
+| Block persistence + replay | ✅ validated (indirect) | Next-turn LLM context shows prior `tool_use` + `tool_result` blocks in canonical Anthropic shape — meaning the codec round-trips correctly. |
+| **Tile renders uniformly (Sprint 1.5)** | ⬜ pending Milton/swaroop restart smoke | Expected: ONE `ui_op` with `type:"Tile"` per product (vs prior 5-6 child ops), every Tile pixel-uniform by construction. |
+| **System prompt has rendered primitives section (Sprint 1.5)** | ⬜ pending restart | `template/ui_prompt.py::render_primitives_section` should produce a section with Tile + Carousel + core primitives; LLM gets it via builder splice. |
+| **`primitive_disabled:<type>` telemetry (Sprint 1.5)** | ⬜ pending — needs a deliberate-failure test | Disable e.g. `Table` via `disabled_primitives`; emit a Table op; confirm `ui_op_dropped` with reason `primitive_disabled:Table` (not `unknown_type`). |
+| Cart-id reuse (the OG fix) | ⬜ not yet exercised | Needs "add to cart" + "add another" flow. ~2 min to test. |
+| `skip_ui` trigger (FAQ prompt) | ⬜ not yet exercised | "what's your return policy?" should yield zero `ui_op` events. ~1 min. |
+| Refresh-page persistence | ⬜ not yet exercised | Refresh mid-conversation; prior turns' cards repaint from history. ~1 min. |
+| Cross-provider (Anthropic → OpenAI) | ⬜ not yet exercised | Template swap `llm_configurations.sdk:"anthropic"` → `"openai"`, re-provision, retry. Proves block-codec neutrality. ~5 min. |
+| **Second-merchant smoke (Milton)** | ⬜ in progress | milton-india-store provisioned; widget dev harness pointed at it. Anticipated quirks documented in §"Real-traffic learnings" #4 (numeric tags, empty alt_text). |
+
+### Real-traffic learnings (post-ship telemetry-driven tweaks)
+
+The first live smoke surfaced two issues that needed an immediate fix rather than waiting for the consolidated e2e pass. Recording the pattern so future post-ship checks know what to look for:
+
+1. **LLM emits Tag with `label` instead of `text`.** The catalog's Tag schema requires `text`; LLM consistently reaches for `label` (the prop name on Button). Healer's "strip unknowns" rule stripped `label`, leaving Tag with no `text`, which then failed Pydantic validation → op dropped → no chip rendered. Fix: added `_rule_rename_prop_aliases` BEFORE the strip step, with a `_PROP_ALIASES: Dict[(type, alias), canonical]` table. Currently covers:
+   - `Tag`: `label`/`name`/`value` → `text`
+   - `Text`: `content`/`value` → `text` (legacy DSL prop name)
+   - `Button`: `title`/`text` → `label`
+   - `Image`: `url`/`image` → `src`; `title` → `alt`
+   - `Money`: `value`/`price` → `amount`
+   - `CardHeader`: `heading`/`header` → `title`
+
+   Semantics: rename only when the canonical key is empty (LLM intent wins). Extend the table as new `ui_op_dropped` events surface different near-misses.
+
+2. **`max_tokens` undersized for JSONL.** Template default was `1024`, which truncated a 10-product carousel mid-emission (`stream ended inside <ui_stream> block (dropping 136 chars)`). JSONL is ~3× more tokens than the prior DSL would have been. Bumped to `16384` (~50 cards' worth of ops + prose headroom). Claude Sonnet 4.6 supports up to 64k output tokens; `32768` or `65536` are the natural next breakpoints if a single reply ever needs to express more than ~50 cards. Token cost is not a constraint per user direction.
+
+3. **LLM-composed cards drift in completeness.** Screenshots from the swaroop-juspay smoke showed Card subtrees with inconsistent children — some cards rendered Image+Title+Price+Button, some only Image, some only Text. The Card primitive's flex layout was sound; the failure was upstream — the LLM emitted partial card subtrees in the same Carousel. Fix shipped in Sprint 1.5: the **composite `Tile` primitive replaces hand-composed Card+children for list items**. Renderer owns the layout; LLM fills typed slots; missing slots simply don't render (no awkward empty space). One `ui_op` per Tile vs the prior 6-7 per card. See §"Sprint 1.5" ship report.
+
+4. **Milton-specific data quirks (anticipated, to confirm in live smoke).** Second-merchant provisioning surfaced two product-data shapes that may need healer extensions:
+   - **Numeric tags**: Milton products have `tags: ["1008", "5019", "6010"]` instead of human-readable labels. JIT instruction tells the LLM to "skip internal tags (BLOCK_COD, SKU patterns, vendor handles)" but pure-numeric strings aren't in that list. If the LLM emits numeric chips, extend the JIT filter or add a healer rule: `Tile.attributes` items whose `label` matches `^\d+$` get dropped.
+   - **Empty `alt_text`**: Milton's `media[0].alt_text` is `""`. The Tile schema requires `media.alt` non-empty (Pydantic `min_length=1`). The JIT explicitly maps `alt: product.title` so the LLM should fall back to title; if it instead pulls the empty `alt_text` directly, the Tile drops with `props_validation_failed`. Watch `ui_op_dropped` events on the first Milton smoke; if hit, add a healer rule that defaults `Tile.media.alt` to the Tile's `title` when empty.
+
+### Sprint 1.5 — Composite `Tile` + template-driven primitive groups (shipped 2026-05-19)
+
+Polish layer over Sprint 1. Triggered by first-live-smoke observation: LLM-composed Card+children subtrees produced visually inconsistent cards (some half-emitted, some missing slots). The fix: replace hand-composed list items with a single composite primitive (`Tile`) whose layout the renderer owns. To keep the catalog extensible (graphs/metrics/forms in future), partitioned all primitives into named groups with per-template enable/disable.
+
+| Layer | Files | What ships |
+|---|---|---|
+| **Catalog restructure** | `clones/clairvoyance/app/ai/voice/agents/breeze_buddy/template/ui_catalog.py` | `PRIMITIVE_GROUPS: Dict[str, List[str]]` — 7 groups (`core`/`composite`/`graphs`/`metrics`/`forms`/`media`/`data`). `core` has the 14 Sprint-1 primitives; `composite` has `Tile`; future groups are empty placeholders for the extension pattern. `PRIMITIVE_RENDER_ORDER` controls the system-prompt rendering order (composite-first so LLM defaults to Tile for list items). Helpers: `group_for(name)`, `is_known_type(name)`, `resolve_allowlist(enabled_groups, enabled_primitives, disabled_primitives) → Set[str]`. |
+| **Tile schema** | same file | `Tile` Pydantic model with slots: `media?: TileMedia`, `eyebrow?`, `title*`, `subtitle?`, `body: List[TileBodyItem] = []` (polymorphic `kind: text\|money\|key_value\|message`), `attributes: List[TileAttribute] = []`, `actions: List[TileAction] = []`, `density: "compact"\|"default"\|"spacious" = "default"`. Reuses existing `Money`, `Message`, `ActionUnion` for nested validation. |
+| **Template config** | `clones/clairvoyance/app/ai/voice/agents/breeze_buddy/template/types.py` | New `UiCatalogConfig` Pydantic model wired onto `ConfigurationModel.ui_catalog: Optional[UiCatalogConfig]`. Fields: `enabled_groups: List[str] = ["core"]`, `enabled_primitives: List[str] = []`, `disabled_primitives: List[str] = []`. Absent config defaults to enabling just `core` — backward compatible with pre-Tile templates. |
+| **Stream allowlist gate** | `clones/clairvoyance/app/ai/voice/agents/breeze_buddy/chat/ui_stream.py` | `parse_op_line(line, *, allowlist=None)` and `process_op_line(..., allowlist=None)` accept the resolved allowlist set. Ops whose type is in catalog but not in allowlist drop with `error == "primitive_disabled:<Type>"` — distinct from `unknown_type` so telemetry separates "merchant turned off" from "LLM hallucinated". `allowlist=None` means no template-level filtering (all known catalog types pass). |
+| **Agent allowlist resolution** | `clones/clairvoyance/app/ai/voice/agents/breeze_buddy/chat/agent.py` | `ChatAgent.__init__` reads `template.configurations.ui_catalog` and calls `resolve_allowlist(...)` once per turn, stashing the result on `self._ui_allowlist`. Pipes it into `process_op_line` (validation) AND into `flow_builder.build_flow_config(..., ui_allowlist=...)` (system prompt rendering). |
+| **System-prompt primitives section** | `clones/clairvoyance/app/ai/voice/agents/breeze_buddy/template/ui_prompt.py` (NEW) | `render_primitives_section(allowlist: Set[str]) -> str`. Introspects each enabled primitive's Pydantic `model_fields` to produce a Markdown section: name + 1-line purpose (from docstring) + prop schema with `*`/`?` required markers (handles `Literal[...]`, nested Pydantic models, `List[T]`, `Optional[T]`) + a hardcoded round-trip-validated example op. Walks `PRIMITIVE_RENDER_ORDER` so Tile appears first. Header + composition rules + action-shape reference appended. |
+| **Builder splice** | `clones/clairvoyance/app/ai/voice/agents/breeze_buddy/template/builder.py` | `FlowConfigBuilder.build_flow_config(template, *, ui_allowlist=None)` — added keyword arg without changing constructor signature. If the template's `system_prompt` (direct mode) or `task_messages`/`role_messages` (flow mode) contains the literal placeholder `{{ui_primitives_section}}`, it's replaced with the rendered section. `ui_allowlist=None` substitutes empty string (voice templates without the placeholder are unaffected). |
+| **Widget Tile renderer** | `nautilus/packages/breeze-buddy-assist-widget/src/lib/ui/primitives/Tile.svelte` (NEW, 398 LOC) | Owns the entire layout: media (cover-fit, edge-bleed to card corners) → eyebrow (small-caps) → title (2-line clamped) → subtitle → polymorphic body rows (dispatched by kind: text→Text, money→Money, message→Message, key_value→key/value span pair) → attribute chips (mapped to Tag tone tokens) → action row (single Button stretched, multiple wrapped in Buttons group). Density tokens map to `--openui-gap-{s,m,l}` and tune padding. `min-height: 320px`, `min-width: 240px`, `max-width: 280px` for Carousel-context uniformity. |
+| **Widget dispatch** | `nautilus/packages/breeze-buddy-assist-widget/src/lib/ui/UiNode.svelte` | Added Tile import + `{:else if node.type === 'Tile'}` branch. Full TS narrowing via `narrowMedia`/`narrowBody`/`narrowAttributes`/`narrowActions`/`narrowAction`/`narrowDensity` helpers — coerces `Record<string, unknown>` props into the Tile schema with proper discriminated unions. **No `any` types** per project rule. |
+| **Template config** | `nautilus/static/buddy-assist-agent/canonical.template.json` | New `"ui_catalog": {"enabled_groups": ["core", "composite"]}` under `configurations`. `flow.system_prompt` gets the literal `{{ui_primitives_section}}` placeholder line. All 4 product-touching tool_ui_instructions (`search_catalog`/`get_product_details`/`update_cart`/`get_cart`) rewritten to emit Tiles: one Tile per product/line, slot mapping from MCP response to Tile slots, stable ids (`t-<product.id>`, `t-l-<line.id>`). FAQ stays `skip_ui`. |
+| **Tests** | `clones/clairvoyance/tests/{test_ui_catalog_groups,test_tile_validation,test_primitive_disabled,test_ui_prompt}.py` | **139 tests pass total** (was 67 before Sprint 1.5). New: 11 ui_catalog_groups (resolve_allowlist precedence/edge cases, group_for) + 14 tile_validation (full happy path, polymorphic body kinds, required-title, extra-prop rejection) + 7 primitive_disabled (`primitive_disabled:<type>` reason distinct from `unknown_type`, allowlist=None passthrough, allowlist=set() disables all, remove/replace ops bypass gate) + 11 ui_prompt (filtering, render-order, slot-name presence, validated examples, header/footer composition rules). |
+| **Widget build** | — | `pnpm check`: 0 errors / 0 warnings. `pnpm build`: 189 modules, `dist/assist.js` 177 kB / gzip 57.6 kB. |
+
+**Live state (post-Sprint-1.5)**:
+- swaroop-juspay merchant: template `595650c5-b3c1-4b68-a3e9-5f22630283e0`, public_widget_key `DKt-j-YE-qCZeNcUt_Fh2v4OQ9LjqbyreDjBi7Poe5s`
+- **milton-india-store merchant**: template `760a45f5-68c3-4941-8a73-558758f366d0`, public_widget_key `LT_uwSgXxRBDfPxf529QaX9MfP1PRgkUKtkjr0mhp7o` (newly provisioned 2026-05-19 to test against a second real Shopify storefront)
+- Both templates declare `ui_catalog: {enabled_groups: ["core", "composite"]}`, `max_tokens: 16384`, Tile-based `tool_ui_instructions`, `{{ui_primitives_section}}` placeholder in system_prompt
+- Dev harness `nautilus/packages/breeze-buddy-assist-widget/index.html` currently points at milton (`tenant="LT_uwSg..."`, `shop="milton-india-store.myshopify.com"`). Swap back to swaroop by changing those two attributes.
+- Redis caches (`bb:tpl:*`, `bb:mcp:tools:*`) invalidated after each re-provision
+
+### Cart-id loss fix (hybrid: block persistence + session state + arg-injection)
+
+Implements the cart-id loss fix from `poc/GOLDEN_INSIGHTS.md`. Three layers, all generic (commerce flavour lives in template JSON):
+
+| Layer | Files | What it does |
+|---|---|---|
+| **Block persistence** | `clones/clairvoyance/app/database/migrations/030_chat_session_persistence.sql` (consolidated migration covering all three additions below), `app/database/queries/breeze_buddy/chat_session.py`, `app/database/accessor/breeze_buddy/chat_session.py`, `app/database/decoder/breeze_buddy/chat_session.py`, `app/schemas/breeze_buddy/chat.py`, `app/ai/voice/agents/breeze_buddy/chat/block_codec.py`, `app/ai/voice/agents/breeze_buddy/chat/agent.py`, `app/api/routers/breeze_buddy/chat/handlers.py` | Stop stripping `tool_use`/`tool_result` blocks; persist Anthropic-shape content arrays; reconstruct OpenAI-shape `LLMContextMessage` on replay. |
+| **Generic session state** | `030_chat_session_persistence.sql` (same consolidated migration), plus the accessor/decoder/schema files above | `agent_session_state(chat_session_id PK, data JSONB, updated_at)`. Generic — no commerce columns. |
+| **Reducer + arg-injection engines** | `clones/clairvoyance/app/ai/voice/agents/breeze_buddy/template/session_state.py`, `app/ai/voice/agents/breeze_buddy/template/types.py` (new `StateReducer`, `ToolArgInjection`) | Declarative JMESPath rules in template config lift identifiers from tool results into state and inject them into subsequent tool args. |
+| **Commerce config** | `nautilus/static/buddy-assist-agent/canonical.template.json` | The only commerce-aware code in the change. Declares: `update_cart`/`get_cart` → lift `cart.id` to `state.data.cart_id`; inject `state.data.cart_id` into `update_cart`/`get_cart` args if missing. |
+| **Tests** | `clones/clairvoyance/tests/test_session_state.py` | 19 tests; end-to-end reproduces the original logs.txt failure. All pass. |
+
+Consolidated migration `030_chat_session_persistence.sql` applied to dev DB (previously shipped as three separate files 030/031/032; squashed pre-release since the PR hadn't gone out). Template re-provisioned. Server restart was needed at the time.
+
+Provider neutrality: confirmed — the on-disk Anthropic-shape blocks round-trip through our codec to OpenAI-shape `LLMContextMessage`, and Pipecat's per-provider adapters convert on the wire. Verified by reading `pipecat/adapters/services/anthropic_adapter.py:261-307` (converts OpenAI-shape tool_calls → Anthropic tool_use blocks; role:tool → tool_result inside user message) and `open_ai_adapter.py:162` (passes OpenAI shape through). Swapping Claude → GPT/Gemini is a template config edit (`llm_configurations.sdk: "anthropic"` → `"openai"`), no code change.
+
+**Canonical template excerpt** (in `nautilus/static/buddy-assist-agent/canonical.template.json`) — the commerce-specific config that the runtime is otherwise agnostic to. Reference shape:
+
+```jsonc
+"configurations": {
+  "state_reducers": [
+    {
+      "tool_name": "update_cart",
+      "set_paths": {
+        "cart_id": "cart.id",
+        "checkout_url": "cart.checkout_url",
+        "currency": "cart.cost.total_amount.currency"
+      }
+    },
+    {
+      "tool_name": "get_cart",
+      "set_paths": {
+        "cart_id": "cart.id",
+        "checkout_url": "cart.checkout_url",
+        "currency": "cart.cost.total_amount.currency"
+      }
+    }
+  ],
+  "tool_arg_injection": [
+    {
+      "tool_name": "update_cart",
+      "set_paths": { "cart_id": "state.data.cart_id" }
+    },
+    {
+      "tool_name": "get_cart",
+      "set_paths": { "cart_id": "state.data.cart_id" }
+    }
+  ],
+  "mcp": {
+    "servers": [
+      {
+        "name": "shopify-storefront",
+        "url": "https://{shop_url}/api/mcp",
+        "auth": { "type": "none" },
+        "tool_response_transforms": { /* scale_money_amount rules */ }
+      }
+    ]
+  }
+}
+```
+
+Sprint 1 (S1.3) extends this section with a top-level `tool_ui_instructions` map; Sprint 3 (S3.1) adds a second MCP server entry for `/api/ucp/mcp` with `included_tools` scoping.
+
+### Architectural rationale for the cart-id fix (preserved for future-us)
+
+The fix is hybrid because no single layer is sufficient. (a) Block persistence alone leaves compaction broken — when sessions outgrow context, summarization strips ids unless we explicitly preserve them. (b) Session state alone doesn't fix same-turn hallucination — the LLM still hallucinates if its own prior `tool_use.input` isn't in history. (c) Arg injection alone is the cleanest end state but needs upstream cooperation (a proxy or UCP cutover) we don't fully have. Together they form the architecture all major refs (`shop-chat-agent`, `claude-cookbooks`, `openai-apps-sdk`, `AP2`, `LangGraph`, `stripe-ai`, `ACP`) converged on.
+
+We chose **argument injection** over MCP `_meta` injection because pipecat's MCPClient doesn't expose `_meta` on the wire today. Same semantic, different target. The engine is forward-compatible: when a proxy or UCP cutover lets us write `_meta`, retarget rules from arg-keys to meta-keys with no template-authoring change.
+
+---
+
+## Voice readiness audit (2026-05-21)
+
+Recorded so we can pick voice up next sprint without re-discovering what's already wired vs what's missing. Net: text widget ships now; voice is one bounded sprint away.
+
+### What's already in place (~70%)
+
+**Backend** — `/widget/session/{id}/voice/connect` + `/widget/session/{id}/voice/end` routes are live; the chat ↔ voice handoff state machine flips `current_channel` on connect/end; Daily.co rooms are provisioned per session; the `lead_call_tracker` row carries chat history + `cart_id` + `agent_session_state` seed across the handoff so the voice agent inherits the chat's context. The Milton template declares `supported_channels: ["chat", "voice"]`. The voice runtime itself is the standalone Breeze Buddy voice product — Pipecat + Daily.co + the existing TTS/STT plumbing — reused, not rebuilt.
+
+**SDK** — full `VoiceSession` type surface already exported: VAD events (`speech_started` / `speech_stopped`), TTS events (`tts_started` / `tts_stopped`), transcript events (`transcript_partial` / `transcript_final`), control (`mute` / `unmute` / `end`). No new types needed.
+
+**Widget** — `modes` + `defaultMode` custom-element props already declared on `<breeze-buddy-assist>`. `BbComposer.voiceEnabled` prop exists and the voice-toggle button is rendered (currently hardcoded `false`). Mascot has `speaking` / `thinking` / `idle` animation states defined. The container is voice-aware in shape; just not wired.
+
+### What's missing (~30%)
+
+- **SDK**: `ChatSession.transferTo('voice')` is a `NotImplementedError` stub. ~120 LOC to wire — call `POST /voice/connect`, return a `VoiceSession` proxy that joins the Daily room.
+- **SDK**: no `createWidgetVoiceSession()` factory for starting in voice mode directly. ~150 LOC.
+- **Widget**: no `mode: 'text' | 'voice'` state on the panel. ~25 LOC.
+- **Widget**: no `BbVoicePane.svelte` for the in-call UI (mute / end-call / waveform / transcript). ~250 LOC.
+- **Widget**: pane swap + voice-live-conflict banner in `BuddyAssist.svelte` (one mode active at a time). ~70 LOC.
+
+### Architectural drift
+
+Very low. No new DB schema; no new transport (Daily + Pipecat as-is); no SDK refactor (the chat store stays unchanged and the voice session is a sibling, not a parent). One small product decision — **transcript-during-call vs minimal call-screen** — affects ~80 LOC of pane UI but not the architecture.
+
+### Effort estimate
+
+7–8 dev-days end-to-end:
+- SDK wiring: 1.5–2 days
+- Widget UI (pane + banner + transitions): 3–4 days
+- Backend: ~0 days for happy path (routes already exist)
+- Testing across happy path + drop + reconnect: 1.5 days
+- Polish (animations, voice-toggle affordance, accessibility): 1.5 days
+
+### Recommendation
+
+Don't release voice in this cut. Ship the text widget; voice is a clean next-sprint item once the open product question (call-screen UX) is decided. The longer we sit on the half-wired surface without shipping, the more the chat-only widget's release timeline slips for an item that, by the spec audit, isn't holding any of the rest back.
+
+---
+
+## Sprint 1 — SpecStream migration + healer + JIT instructions (✅ SHIPPED 2026-05-19)
+
+> **Status: shipped + live-validated.** Detailed delta lives under §"Already shipped → Sprint 1". The original plan below stays for posterity so future readers can see the design intent. Reference for what was actually built: §"Already shipped → Sprint 1" table. Reference for what was learned during the first live smoke: §"Real-traffic learnings".
+
+The foundational sprint. Everything downstream depends on this landing cleanly.
+
+### S1.1 — Replace OpenUI Lang DSL with SpecStream JSONL wire format
+
+**Goal**: LLM emits a flat JSONL stream of JSON-patch operations against a typed component catalog. Widget applies patches incrementally to a stateful session-wide UI tree.
+
+**Wire format** (mirrors A2UI v0.9 / Vercel json-render SpecStream):
+
+```jsonl
+{"op":"add","id":"root","type":"Stack"}
+{"op":"add","id":"c1","type":"Card","parent":"root"}
+{"op":"add","id":"c1-img","type":"Image","parent":"c1","props":{"src":"...","alt":"..."}}
+{"op":"add","id":"c1-price","type":"Money","parent":"c1","props":{"amount":69995,"currency":"INR"}}
+{"op":"replace","id":"c1-price","props":{"amount":59995,"currency":"INR"}}
+{"op":"remove","id":"c2"}
+```
+
+**Files to delete** (clean cut, no living legacy):
+- `clones/clairvoyance/app/ai/voice/agents/breeze_buddy/chat/ui_parser.py`
+- `clones/clairvoyance/app/ai/voice/agents/breeze_buddy/chat/ui_resolver.py`
+- `clones/clairvoyance/app/ai/voice/agents/breeze_buddy/chat/ui_marker.py`
+- `clones/clairvoyance/app/ai/voice/agents/breeze_buddy/chat/ui_emit.py` (rewritten, not deleted)
+- `clones/loom/packages/client-sdk/src/lib/ui/_lang-core/` (entire directory)
+- `nautilus/packages/breeze-buddy-assist-widget/src/lib/ui/_evaluator.ts`
+
+**Files to create / rewrite**:
+- `clones/clairvoyance/app/ai/voice/agents/breeze_buddy/chat/ui_stream.py` (NEW) — JSONL stream parser + emitter; validates each op against component catalog
+- `clones/clairvoyance/app/ai/voice/agents/breeze_buddy/template/ui_catalog.py` (NEW) — typed Pydantic schemas for each primitive
+- `clones/clairvoyance/app/ai/voice/agents/breeze_buddy/template/types.py` — extend with `UiCatalog`, `PrimitiveSpec` types
+- `nautilus/packages/breeze-buddy-assist-widget/src/lib/ui/UiRenderer.svelte` — rewrite as stateful patch-applier (currently a stateless re-renderer)
+- `nautilus/packages/breeze-buddy-assist-widget/src/lib/ui/ui_state.ts` (NEW) — Svelte 5 `$state` store for the session UI tree
+
+**Primitives in v1 catalog** (port from current 11, plus 3 new typed):
+
+| Primitive | Source | Notes |
+|---|---|---|
+| Stack, Row, Card, CardHeader | Existing | Layout |
+| Image, Text, Carousel | Existing | Content |
+| Button, Buttons | Existing | Actions |
+| Table, Tag | Existing | Data display |
+| Money | NEW | `{amount: int (minor units), currency: ISO 4217}` — never string-concat money again |
+| Message | NEW | `{severity, resolution, content, param?}` — closed enum drives fixed UI affordance |
+| Handoff | NEW | `{reason, label, url, lifecycle: popup\|same_tab\|polling}` — widening `@OpenUrl` |
+
+**Catalog schema shape** — full Pydantic for each primitive, lives in `template/ui_catalog.py`. Sketch (target shapes for the 3 new typed primitives):
+
+```python
+class Money(BaseModel):
+    """Render an amount with currency-aware formatting. The LLM emits minor-unit
+    integers (paisa for INR, cents for USD); the widget formats using ISO 4217
+    exponents. Three-decimal (KWD/OMR/BHD) and zero-decimal (JPY/KRW/VND) handled
+    natively. NEVER use Text for money — the schema requires Money for amounts."""
+    amount: int = Field(..., description="Amount in ISO 4217 minor units")
+    currency: str = Field(..., description="ISO 4217 code (INR, USD, JPY, KWD…)")
+    display_text: Optional[str] = Field(None, description="Seller-authored override (UCP/ACP pattern)")
+
+class MessageSeverity(str, Enum):
+    info = "info"
+    warning = "warning"
+    error = "error"
+    success = "success"
+
+class MessageResolution(str, Enum):
+    recoverable = "recoverable"                  # silent retry; no UI
+    requires_buyer_input = "requires_buyer_input"  # render inline form bound to `param`
+    requires_buyer_review = "requires_buyer_review"  # render confirm CTA
+    unrecoverable = "unrecoverable"              # render Handoff with continue_url
+
+class Message(BaseModel):
+    """Spec-driven notification. Severity + resolution mechanically drive UI."""
+    severity: MessageSeverity
+    resolution: MessageResolution
+    content: str
+    param: Optional[str] = Field(None, description="JSONPath into cart/checkout for input binding")
+
+class HandoffLifecycle(str, Enum):
+    popup = "popup"        # window.open + 10s token poll
+    same_tab = "same_tab"  # location.href
+    polling = "polling"    # widget shows shimmer + polls completion endpoint
+
+class Handoff(BaseModel):
+    """Typed handoff URL — replaces ad-hoc @OpenUrl. Carries reason + lifecycle."""
+    reason: str   # "checkout" | "auth" | "3ds" | "compliance_review" | "escalation" | …
+    label: str    # human-visible button text
+    url: HttpUrl
+    lifecycle: HandoffLifecycle
+```
+
+**Wire format comparison** (DSL → SpecStream, for posterity — so future-us understands why):
+
+```
+OpenUI Lang (deleted):                       SpecStream JSONL (new):
+─────────────────────                        ────────────────────
+products = search_catalog.products           {"op":"add","id":"root","type":"Carousel"}
+root = Carousel(@Each(products, "p",         {"op":"add","id":"c1","type":"Card","parent":"root"}
+  Card([                                     {"op":"add","id":"c1-img","type":"Image",
+    Image(p.image, p.title),                  "parent":"c1","props":{"src":"...","alt":"..."}}
+    Text(p.title),                           {"op":"add","id":"c1-title","type":"Text",
+    Text("₹" + p.price),                      "parent":"c1","props":{"text":"Dawn snowboard"}}
+    Button("Add to cart",                    {"op":"add","id":"c1-price","type":"Money",
+      Action([@ToAssistant(...)]))            "parent":"c1","props":{"amount":69995,"currency":"INR"}}
+  ])))                                       {"op":"add","id":"c1-btn","type":"Button",
+                                              "parent":"c1","props":{"label":"Add to cart",
+                                              "action":{"type":"to_assistant","msg":"add gid://...Dawn"}}}
+                                             ... (one block per product)
+```
+
+Tradeoffs (as evaluated, for the record):
+- SpecStream is ~30% more tokens (not a constraint per user)
+- SpecStream wins on reliability (JSONL parsing bulletproof, schema-validates per-op), scalability (industry standard, multi-framework, MCP Apps compat), and **stateful** UI (patches against persistent tree → progressive render, edits, removals).
+- DSL author surface elegance was the only DSL win; solved by JIT instructions giving the LLM rich per-tool examples without prompt bloat.
+
+**Effort**: M+ (~2 weeks). ~600 server LOC + ~400 widget LOC + tests + prompt migration.
+
+**Acceptance criteria**:
+- LLM emits JSONL successfully against canonical product / cart / FAQ prompts
+- Widget renders Money/Message/Handoff correctly across INR, JPY (zero-decimal), KWD (three-decimal)
+- Old DSL files deleted; no references remain in any `import`/`require`
+- 19 existing session_state tests still pass (cart-id fix unaffected)
+
+### S1.2 — In-stream healer (deterministic v1)
+
+**Goal**: Catch the 5-10 most common LLM emission mistakes mid-stream before they reach the renderer. <250ms latency, no extra LLM call.
+
+**Scope (v1 — deterministic only, per user direction)**:
+
+| Rule | Input (broken) | Output (healed) |
+|---|---|---|
+| Unknown `type` | `{"op":"add","id":"x","type":"ProductCarousel","parent":"root"}` | Reject op, log warning. (Type wasn't in catalog → likely LLM hallucination.) |
+| Missing `parent` on non-root op | `{"op":"add","id":"x","type":"Card"}` | Drop op, log. Root ops are exempt (no `parent` required). |
+| Unknown primitive props | `{"op":"add","id":"m1","type":"Money","props":{"amount":99,"currency":"INR","tone":"red"}}` | Strip `tone`, keep `amount`+`currency`. Log stripped key. |
+| Money missing `currency` | `{"op":"add","id":"m1","type":"Money","props":{"amount":69995}}` | Infer from `agent_session_state.data.currency` (set by reducer). Fallback to merchant default. |
+| Action missing `label` | `{"op":"add","id":"b1","type":"Button","props":{"action":{...}}}` | Default to "Continue" or intent-derived label. |
+| Duplicate `id` in same session | `{"op":"add","id":"c1",...}` after `c1` already exists | Rename to `c1__2`, log. (Or `replace` if same parent+type — heuristic.) |
+| Malformed JSONL line | `{"op":"add","id":"x"` (truncated) | Skip line, continue stream. |
+| Money string instead of int | `{"props":{"amount":"₹699.95"}}` | Parse → 69995 (using INR exponent). Log. |
+| Tag with raw JSON array | `{"type":"Tag","props":{"text":"[\"a\",\"b\"]"}}` | Emit one Tag op per array element. |
+
+Each rule = a single function in `ui_healer.py` with one unit test. Healer is a synchronous pure function: `(jsonl_line, session_state) → Optional[jsonl_line]`. Emits `healer_applied` SSE event per fix for observability.
+
+**Files to create**:
+- `clones/clairvoyance/app/ai/voice/agents/breeze_buddy/chat/ui_healer.py` (NEW) — deterministic rule engine, ~200-300 LOC
+- `clones/clairvoyance/tests/test_ui_healer.py` (NEW) — one test per rule
+
+**Out of scope for v1**:
+- Tiny fine-tuned model (vercel-autofixer-01 style) — deferred until we measure deterministic catch rate
+- Semantic fixes ("this card looks bad") — not addressable by healer; that's a prompt-quality concern
+
+**Effort**: S (~3 days).
+
+**Acceptance criteria**:
+- Each rule has a unit test that demonstrates the broken input → healed output
+- Healer integrated into ui_stream pipeline; emits a `healer_applied` SSE event per fix (for observability)
+
+### S1.3 — JIT (Just-in-Time) UI instructions in tool responses
+
+**Goal**: Per-tool UI guidance ships in the tool's response, not the system prompt. Solves prompt bloat without a subagent.
+
+**Mechanism**: extend the existing `response_transforms` engine on `McpServerConfig` with a sibling `tool_ui_instructions` map. Engine appends the matching tool's instructions to the tool's result envelope before the LLM sees it. Per-merchant overrides via template config.
+
+Full shape (as it would land in `canonical.template.json`):
+
+```jsonc
+"tool_ui_instructions": {
+  "search_catalog": {
+    "trigger": "on_success",
+    "instructions": "Render results as a Carousel of Cards. Skip if products is empty (let prose handle no-results message). Each card must include: Image (src + alt from product.image), Text (title), Money (amount + currency from price_range.min), 1-2 Tag chips from top differentiating attributes (skip internal tags like BLOCK_COD, SKU patterns, vendor handles). Button 'View' with @ToAssistant('tell me about ' + p.id). Aim for visual polish — multiple Tags, clear hierarchy, image-leading. NEVER inline product data as string literals.",
+    "examples": [
+      {
+        "scenario": "3 products, INR",
+        "input_sketch": "{products: [{id, title, price_range, image, tags}, …]}",
+        "expected_jsonl": [
+          {"op":"add","id":"root","type":"Carousel"},
+          {"op":"add","id":"c1","type":"Card","parent":"root"},
+          "..."
+        ]
+      }
+    ]
+  },
+  "update_cart": {
+    "trigger": "on_success",
+    "instructions": "Replace the cart card with the updated state. Show line items (Image, Text title, Tag for variant, Money for line subtotal), then a CardHeader 'Total' with Money for cart.cost.total_amount, then a Button 'Checkout' as Handoff{lifecycle:popup, url:cart.checkout_url}.",
+    "examples": []
+  },
+  "search_shop_policies_and_faqs": {
+    "trigger": "skip_ui",
+    "instructions": "No UI for FAQ answers — let prose handle. Don't emit a ui_stream tool call."
+  }
+}
+```
+
+`trigger` values: `on_success` (only on 2xx tool results), `on_any` (success or error), `skip_ui` (suppress UI emission for this tool's results entirely).
+
+**Files to touch**:
+- `clones/clairvoyance/app/ai/voice/agents/breeze_buddy/template/types.py` — add `tool_ui_instructions: Dict[str, ToolUiHint]` on `McpServerConfig`
+- `clones/clairvoyance/app/ai/voice/agents/breeze_buddy/mcp/__init__.py` — when a tool result returns, append JIT UI instructions to the result envelope BEFORE handing to LLM
+- `nautilus/static/buddy-assist-agent/canonical.template.json` — declare per-tool UI hints
+- System prompt: shrink the "## Generative UI" section dramatically; just declare "Use ui_stream tool to emit UI; tool responses will carry per-result guidance."
+
+**Effort**: S (~3 days). ~100 server LOC + template JSON.
+
+**Acceptance criteria**:
+- System prompt's UI section reduced from ~1200 chars to <300 chars
+- Tool result for `search_catalog` carries the rendering hint
+- LLM emits richer product cards than today (verified manually + via golden screenshots in Sprint 4)
+
+### S1.4 — Update system prompt for SpecStream emission
+
+**Goal**: Teach the LLM the new emission protocol with examples per scenario.
+
+**Files to touch**:
+- `nautilus/static/buddy-assist-agent/canonical.template.json` — system_prompt + new "## UI emission" section with 5-10 worked examples
+- Per-merchant template overrides ship their own `tool_ui_instructions` via the JIT mechanism
+
+**Effort**: S (~2 days, mostly prompt iteration).
+
+**Acceptance criteria**:
+- 90%+ success rate on a 20-prompt golden set (manual eval; CI eval comes in Sprint 4)
+
+### Sprint 1 sequencing
+
+```
+Week 1:  S1.1 wire format design + Pydantic catalog + Svelte renderer skeleton
+Week 2:  S1.1 finish (12 primitives end-to-end), S1.2 healer in parallel
+Week 3:  S1.3 JIT, S1.4 prompt migration, integration smoke
+```
+
+**Total**: 4 deliverables, ~3 weeks. S1.1 is the load-bearing one; others stack on top.
+
+---
+
+## Sprint 2 — Voice parity + cross-host + iteration tool (~2 weeks)
+
+Lower-risk follow-on. Each item is independent.
+
+### S2.1 — Voice/chat UI parity (same SpecStream over RTVI + SSE)
+
+**Goal**: Cards visible during voice calls. Same patch-applier widget mounts on both surfaces.
+
+**Files to touch**:
+- `clones/clairvoyance/app/ai/voice/agents/breeze_buddy/chat/ui_stream.py` — fan out SpecStream JSONL to BOTH SSE (chat) and RTVI server-message (voice)
+- `clones/clairvoyance/app/ai/voice/agents/breeze_buddy/handlers/transport/rtvi.py` — extend `SseRtviForwarder` to carry JSONL ops
+- `loom/packages/breeze-buddy-assist-widget/src/lib/BuddyAssist.svelte` — subscribe to RTVI server messages, route to the same `ui_state` store as SSE
+
+**Effort**: S (~1 week). ~150 LOC.
+
+**Acceptance criteria**: voice-initiate, ask for snowboards, cards stream into widget during the call. Voice-end, return to chat, cards persist.
+
+### S2.2 — MCP Apps emission wrapper (cross-host distribution)
+
+**Goal**: Free distribution to Claude/ChatGPT/Goose/VS Code by emitting MCP Apps format alongside our native SpecStream.
+
+**Mechanism**: a tool response can include an additional `text/html;profile=mcp-app` resource that wraps the SpecStream output in a sandboxed iframe stub. Hosts that speak MCP Apps render the iframe; our native widget ignores it.
+
+**Files to touch**:
+- `clones/clairvoyance/app/ai/voice/agents/breeze_buddy/chat/mcp_apps_wrapper.py` (NEW) — wrap SpecStream JSONL → HTML iframe stub per MCP Apps spec
+- Tool dispatcher — opt-in flag per merchant template
+
+**Effort**: S (~3 days). ~150 LOC.
+
+**Acceptance criteria**: emit a sample tool response with both native + MCP Apps resources; validate against MCP Apps spec.
+
+### S2.3 — `refine_ui(card_id, intent)` tool
+
+**Goal**: Iteration flows — "make this card more compact", "show me a comparison view of these two" — produce targeted JSON-patch diffs, not whole-tree re-renders.
+
+**Mechanism**: a new tool `refine_ui` that the LLM calls when the user requests an edit to existing UI. Takes the stable `card_id` (assigned by SpecStream) + the user's intent. LLM emits a small set of `replace`/`add`/`remove` ops scoped to the target.
+
+**Files to touch**:
+- `nautilus/static/buddy-assist-agent/canonical.template.json` — register `refine_ui` tool; teach via system prompt
+- The healer applies (same rules)
+
+**Effort**: S (~3 days).
+
+**Acceptance criteria**: "make this card smaller" produces a single `replace` op on the card's content, not a full re-render.
+
+### S2.4 — Publish AgentCard at `.well-known/`
+
+**Goal**: A2A federation forward-compat. Declare our component catalog as a versioned extension URI.
+
+**Files to touch**:
+- `nautilus/static/buddy-assist-agent/.well-known/agent-card.json` (NEW)
+- `nautilus/static/buddy-assist-agent/spec/openui-lang/v1.json` (NEW — the catalog schema)
+
+**Effort**: S (~2 days).
+
+**Acceptance criteria**: AgentCard validates against A2A spec; extension URI is fetchable and serves the catalog schema.
+
+---
+
+## Sprint 3 — Full UCP cutover (✅ SHIPPED + live-validated 2026-05-20, deadline 2026-06-15)
+
+**Sprint scope was rebuilt three times during execution as live probing exposed Shopify's incomplete UCP rollout. Final shape — single endpoint, declared schemas, no legacy.**
+
+### Reality-check timeline (compressed)
+
+1. Initial assumption: legacy + UCP share tools; just URL-swap. **Wrong** — UCP renames tools (`get_product_details` → `get_product`), renames args (`cart_id` → `id`), uses a different cart schema (`cart.line_items[{item:{id}, quantity}]` not `cart.add_items[{product_variant_id}]`), and introduces a separate `create_cart` tool.
+2. Plan A: hybrid via `discovery_url` (Pipecat MCPClient against legacy for schemas; route calls to UCP). **Abandoned** — legacy tool names + arg shapes don't match UCP, so the abstraction leaks.
+3. Plan B: OAuth client_credentials + per-tool `tool_auth` for the policies tool. **Removed** — even with a valid bearer + the (undocumented) `Shopify-Buyer-IP` header, `search_shop_policies_and_faqs` returns "Tool not found" on UCP. Shopify hasn't migrated it yet.
+4. Plan C (final): **UCP-only, declared tool schemas, direct HTTP poster**. Pipecat MCPClient is bypassed entirely for this server because UCP rejects `initialize` (no profile placement Shopify accepts on the handshake).
+
+### Final architecture (S3.1)
+
+**Profile hosting** — [PR juspay/loom#129 merged](https://github.com/juspay/loom/pull/129). Live at `https://breezebuddy.ai/.well-known/ucp/agent.json` with `Cache-Control: public, max-age=300`. Declares 5 capabilities: catalog.search, catalog.lookup, cart, checkout, dev.shopify.catalog. ES256 P-256 public JWK in `signing_keys[]` (private key at `/tmp/ucp-keys/`; move to stable location before prod).
+
+**Template (`canonical.template.json`)** — single MCP server, no legacy.
+- 5 `tool_schemas` declared inline: `search_catalog`, `lookup_catalog`, `get_product`, `get_cart`, `create_cart`, `update_cart` (6 entries — `create_cart` is separate from `update_cart` on UCP).
+- `default_args.meta.ucp-agent.profile` injected on every call by the handler's `_deep_merge_defaults` helper.
+- `state_reducers` capture `id → cart_id`, `continue_url → checkout_url`, `links → policy_links` on all three cart tools (response shape is FLAT, no `cart.` wrapper).
+- `tool_arg_injection` fills `id` from `state.data.cart_id` for update/get_cart.
+- `tool_response_transforms` scale UCP minor-units → decimals at `totals[*]`, `line_items[*].item` (with `amount_field: price`), `line_items[*].totals[*]`, `products[*].price_range.min/max`, `product.list_price_range.*`, `product.variants[*].price/list_price`.
+- JIT instructions rewritten for UCP shape: `line_items[*].item.image_url` (image baked in — no reuse heuristic), `line_items[*].item.title`, `totals` per-line and per-cart, `continue_url` for checkout Handoff.
+
+**Code (`clones/clairvoyance/app/ai/voice/agents/breeze_buddy/`)**:
+- `mcp/__init__.py` — new `_create_direct_http_tool_handler` (UCP path: stateless JSON-RPC POST per call, no Pipecat session). `_create_mcp_tool_handler` keeps the Pipecat path for any non-UCP server. Branch on `server.tool_schemas` to choose path. `_deep_merge_defaults` merges `default_args` into args (caller wins).
+- `template/types.py` — `McpServerConfig` gains `default_args` and `tool_schemas`. (`tool_auth` + `Oauth2ClientCredentialsConfig` + `HttpAuthType.OAUTH2_CLIENT_CREDENTIALS` + `mcp/oauth.py` + `discovery_url` + `included_tools` were all built and then removed as the plan compressed.)
+- `tests/test_mcp_default_args.py` — 8 new tests. 143/143 total pass.
+
+**Live-validated 2026-05-20 against Milton**:
+- A1–A4 catalog search → product detail → create_cart → cart view all run cleanly via direct HTTP poster.
+- Scaling fires correctly: `61300` (minor units) → `"613.00"` (decimal string) on `price` and `totals[*].amount` and `line_items[*].totals[*].amount`.
+- JIT improvements landed: MRP moved to `subtitle` slot (muted, above body) on get_product detail card; carousel gets a description-snippet subtitle + "Save X%" / sizes / colours attribute chips with strict filter for noise tags (`gst_update_mrp`, ALL_CAPS_SNAKE, digit codes, vendor handles).
+
+### Policies-tool — deferred until Shopify migrates
+
+`search_shop_policies_and_faqs` is NOT on UCP for our credential set. Two-step fallback:
+1. **Cart links workaround (active)** — cart responses include a `links[]` array with `{refund_policy, privacy_policy, terms_of_service, shipping_policy}` URLs. Captured via `state_reducer` into `state.data.policy_links`. System prompt instructs the agent to emit a Handoff to the matching URL when a cart exists. No tool call needed.
+2. **Real UCP migration** — when Shopify exposes the tool, add a fresh `tool_schemas` entry. OAuth scaffolding can be re-added in ~30 LOC at that point (it was removed cleanly).
+
+### Sprint 3 follow-ups — status as of 2026-05-20
+
+- **S3.2 Idempotency-Key** ✅ **SHIPPED 2026-05-20.** See block below.
+- **S3.3 Dual-tier error envelope** ⏬ **demoted to deferred-on-demand.** Trigger: ≥3 distinct error categories with bad UX show up in production telemetry. Current behaviour (catch-all "technical hiccup") is acceptable until eval data says otherwise. Mechanism notes preserved below for the day it gets picked up.
+- **S3.4 ConfirmCard Trusted Surface** ⏬ **demoted to deferred-on-demand.** Trigger: positioning commits to "agentic pay-in-chat" as a differentiator. Current `continue_url` Handoff already gets shoppers to Shopify hosted checkout with Apple Pay / GPay / cards / Shop Pay all working. Mechanism notes preserved below.
+
+### What ships next (release-readiness mode)
+
+This release: refine + smoke + ship the work above. **Next phase** queue (priority order):
+
+1. **NP-1 — S4.1 Eval harness** (~1 week) — reliability foundation. Recommended start.
+2. **NP-2 — S2.1 Voice parity** (~1 week) — only if voice is in scope.
+3. **NP-3 — S2.2 MCP Apps emission** (~3 days) — cross-host distribution.
+4. **NP-4 — S2.3 `refine_ui`** (~3 days) — targeted UI edits.
+5. **NP-5 — S2.4 A2A AgentCard** (~2 days) — federation forward-compat. **Distinct from the UCP profile we shipped** (different spec, different endpoint).
+
+### S3.2 — Idempotency-Key on every mutating MCP call (✅ SHIPPED 2026-05-20)
+
+**Goal achieved**: every `create_cart` and `update_cart` carries a fresh UUID v4 `idempotency_key`, generated by the engine before dispatch. Same UUID round-trips on retry (driven by intent, not turn) once the chat agent layers retry on top.
+
+**Generic engine change** (commerce-agnostic; benefits any MCP server with mutating tools):
+
+- `clones/clairvoyance/app/ai/voice/agents/breeze_buddy/template/types.py` — `ToolArgInjection` gains a `generators: Dict[arg_key, generator_name]` field, sibling to `set_paths`. Honours `only_if_missing` (caller value wins).
+- `clones/clairvoyance/app/ai/voice/agents/breeze_buddy/template/session_state.py` — adds `_GENERATORS` registry with four built-ins: `uuid_v4`, `uuid_v7` (falls back to v4 if stdlib lacks it), `timestamp_iso8601`, `timestamp_unix_ms`. Unknown generator name logs a warning and skips — defensive stance matches the existing JMESPath path.
+
+**Template wiring** (vertical-specific; lives in `canonical.template.json`):
+
+```jsonc
+"tool_arg_injection": [
+  {"tool_name": "create_cart", "generators": {"idempotency_key": "uuid_v4"}},
+  {"tool_name": "update_cart", "set_paths": {"id": "state.data.cart_id"},
+                                 "generators": {"idempotency_key": "uuid_v4"}},
+  {"tool_name": "get_cart",    "set_paths": {"id": "state.data.cart_id"}}
+]
+```
+
+**Tests**: 151/151 pass (was 143/143; +8 generator tests). Covers: uuid_v4 fills missing arg + parses as v4, `only_if_missing` honoured, force-override works, unknown generator silently skipped, each call produces fresh value, iso8601 + unix_ms shapes, generators + set_paths coexist on one rule.
+
+**Known open question (for the smoke pass)**: UCP's exact accepted placement for `idempotency_key` isn't documented. We know `meta.ucp-agent.profile` works via `default_args` deep-merge; whether `idempotency_key` belongs at the top level or under `meta.idempotency_key` is TBD. Top-level is the conservative default — UCP typically passes unknown args through silently. If Milton smoke shows UCP rejects, the fix is either (a) move under `meta.` (requires nested-key support in the generators engine — ~5 LOC), or (b) emit as an HTTP header in the direct-HTTP poster. Both are 1-evening tasks.
+
+**What this engine unlocks beyond UCP**:
+- Stripe-style `Idempotency-Key` for any future MCP integration with mutating endpoints
+- Client-side `request_id` for distributed tracing across tool calls
+- `timestamp_unix_ms` for any tool that wants client-clock signals (avoids ML model fabricating timestamps)
+- Future: easy to add `nanoid` / `ulid` / monotonic-counter generators (all ~3 LOC each)
+
+### S3.3 — Dual-tier error envelope (resolution-driven retry) — ⏬ DEFERRED-ON-DEMAND (2026-05-20)
+
+> **Demoted on 2026-05-20.** Trigger to re-prioritize: ≥3 distinct error categories with bad UX surface in production telemetry from the eval harness (NP-1). Current "technical hiccup" catch-all is acceptable until then. Notes below preserved for the day this gets picked up.
+
+**Goal**: LLM stops guessing whether to retry vs ask user. Resolution enum drives a fixed state machine.
+
+**Mechanism**: 
+- Main agent handles protocol-level vs business-level errors distinctly
+- Business errors with `resolution: recoverable` → silent retry (no LLM round-trip)
+- `requires_buyer_input` → emit a `Message` primitive with the inline param
+- `requires_buyer_review` → emit a `Message` with a confirm CTA
+- `unrecoverable` → emit a `Handoff` with `continue_url`
+
+**Files to touch**:
+- `clones/clairvoyance/app/ai/voice/agents/breeze_buddy/mcp/__init__.py` — parse UCP/ACP response envelope, surface error envelope distinctly
+- `clones/clairvoyance/app/ai/voice/agents/breeze_buddy/template/session_state.py` — extend reducer to lift `escalation_reasons`
+- System prompt — explicit retry/ask/escalate rules
+
+**Effort**: M (~1 week).
+
+### S3.4 — `ConfirmCard` primitive (Trusted Surface foundation) — ⏬ DEFERRED-ON-DEMAND (2026-05-20)
+
+> **Demoted on 2026-05-20.** Trigger to re-prioritize: positioning commits to "agentic pay-in-chat" as a differentiator. Current `continue_url` Handoff already gets shoppers to Shopify hosted checkout where Apple Pay / GPay / cards / Shop Pay all work; UX is fine, conversion is fine. ConfirmCard is the upgrade that lets the shopper never leave chat. Strategic bet, not a deadline item. Notes below preserved.
+
+**Goal**: T&C / future-payment confirm UI is server-rendered directly from a typed payload — no LLM in the path. AP2-conformant by construction.
+
+**Mechanism**:
+- New primitive `ConfirmCard` in the SpecStream catalog
+- BUT — when the LLM tries to emit it, the server intercepts: the primitive's `props` come ONLY from a typed `confirm_request` payload that came from a tool, never from LLM-emitted strings
+- Widget renders from the typed payload directly
+- "Show your work" expandable panel (AP2 pattern) shows the underlying confirm_request structure to the user
+
+**Files to touch**:
+- `clones/clairvoyance/app/ai/voice/agents/breeze_buddy/chat/ui_stream.py` — special handling for ConfirmCard ops (server replaces LLM-emitted props with typed payload)
+- `loom/packages/breeze-buddy-assist-widget/src/lib/ui/primitives/ConfirmCard.svelte` (NEW)
+- Replace today's T&C modal as the first ConfirmCard consumer
+
+**Effort**: M (~1 week).
+
+### Sprint 3 sequencing — final outcome
+
+```
+S3.1 + S3.2 — shipped + live-validated 2026-05-20 (well ahead of the 2026-06-15 Shopify UCP deadline)
+S3.3 + S3.4 — demoted to deferred-on-demand; see triggers above
+```
+
+---
+
+## Sprint 4 — Golden-screenshot eval pipeline (parallelizable with Sprint 2 or 3)
+
+### S4.1 — Eval harness
+
+**Goal**: Regression testing for generative UI. Catch quality drops before they ship.
+
+**Pattern** (ArtifactsBench-style):
+1. Frozen prompt list (~30 canonical prompts: product search, cart view, FAQ, comparison, etc.)
+2. CI runs the agent against each prompt
+3. Capture 3 temporal screenshots of the rendered widget output
+4. Multimodal LLM-as-judge scores each against a per-prompt checklist + golden screenshot
+5. Fail the CI if any prompt drops below threshold
+
+**Files to create**:
+- `nautilus/eval/golden-prompts.json` — the frozen prompt list with checklists
+- `nautilus/eval/golden-screenshots/` — reference renders
+- `nautilus/eval/run_eval.ts` — Playwright + agent invocation + judge call
+- `.github/workflows/ui-eval.yml` — CI job
+
+**Effort**: M (~1 week).
+
+**Acceptance criteria**: CI passes on a known-good baseline; deliberately broken prompt fails the gate.
+
+---
+
+## Deferred — on-demand, not in next 8 weeks
+
+| Item | Trigger to start | Source |
+|---|---|---|
+| **Fine-tuned tiny healer model** (vercel-autofixer-01 style) | If deterministic healer catch rate is insufficient after measurement | `poc/WEB_RESEARCH_UI_GEN.md` §"Vercel v0" |
+| **`@Widget(...)` escape valve for registered widgets** | Only if we have a canonical UI that SpecStream composition can't express elegantly | `poc/GOLDEN_UI_INSIGHTS.md` §8 |
+| **AP2 mandate signing infrastructure** | Payment scope unlocked | `poc/AP2/INSIGHTS.md` |
+| **Identity linking (dev.ucp.common.identity_linking)** | Customer-account flows become required | UCP spec |
+| **Discount extension (dev.ucp.shopping.discount)** | Discount UI requested by merchants | UCP spec |
+| **Order MCP (dev.ucp.shopping.order)** | Replaces Nautilus WISMO when UCP order spec stable | UCP spec |
+| **Programmatic Tool Calling / `batch_tool`** | Voice latency becomes measurable regression | `poc/claude-cookbooks/INSIGHTS.md` |
+| **AgentCard JWS signing** | Third-party clients call us as A2A peer | `poc/A2A/INSIGHTS.md` |
+| **Session compaction with ID-preserving summary** | Session length hits context limits | `poc/claude-cookbooks/INSIGHTS.md` |
+| **Vision-LLM-as-judge in render loop** | "Design-conscious merchants" tier; per-render visual correctness checks | `poc/WEB_RESEARCH_UI_GEN.md` §"Pattern G" |
+
+---
+
+## Validation strategy
+
+**One consolidated e2e pass at the end of all planned sprints, not piecemeal.**
+
+*Update (2026-05-19): the post-Sprint-1 smoke test surfaced two fixes (max_tokens, alias rename) that needed to ship before the consolidated pass. Smoke checks immediately after each sprint are explicitly carved out — see §"Real-traffic learnings". Validation status table is in §"Already shipped → Sprint 1 live-validation status".*
+
+### What to cover
+
+1. **Cart-id reuse** (already-shipped fix):
+   - New session → "Add Dawn to cart" → "Add Ski Wax to cart" → confirm single cart_id reused, no orphan, no "cart does not exist" error
+   - `agent_session_state.data.cart_id` populated; `chat_message.content_blocks` contains tool_use/tool_result pairs
+
+2. **SpecStream wire format** (S1.1):
+   - LLM successfully emits JSONL on canonical prompts (product search, cart view, FAQ, comparison)
+   - Widget renders progressively (Card frame → image → text → button)
+   - Stable IDs persist across turns
+   - Old DSL imports return ImportError if anyone references them
+
+3. **In-stream healer** (S1.2):
+   - 7 deliberately-broken inputs heal correctly via deterministic rules
+   - `healer_applied` SSE events observable
+
+4. **JIT UI instructions** (S1.3):
+   - Tool response for `search_catalog` carries UI instructions
+   - System prompt UI section measurably shorter
+   - Product cards visibly richer than today's baseline
+
+5. **Voice/chat parity** (S2.1):
+   - Chat: open, see cart card. Voice-connect mid-session, ask for another product, card streams into voice surface. Voice-end, card history intact in chat.
+
+6. **MCP Apps emission** (S2.2):
+   - Tool response carries both native SpecStream + `text/html;profile=mcp-app` resource
+   - Both validate
+
+7. **`refine_ui`** (S2.3):
+   - "Make the third card smaller" produces ≤3 patch ops, not full re-render
+
+8. **UCP cutover** (S3.1):
+   - Catalog calls hit `/api/ucp/mcp`; cart calls still on `/api/mcp`
+   - Capability negotiation field present on responses
+
+9. **Resolution-driven retry** (S3.3):
+   - Force `recoverable` error → silent retry, no LLM round-trip
+   - Force `requires_buyer_input` → inline `Message` primitive with form
+
+10. **Trusted Surface** (S3.4):
+    - T&C modal replaced with ConfirmCard; LLM-emitted prose for `props` is ignored
+
+11. **Idempotency** (S3.2):
+    - Network-disconnect an `update_cart`; reconnect; same key used; no double-add
+
+12. **Golden screenshots** (S4.1):
+    - CI passes on baseline; deliberately broken prompt fails
+
+13. **Cross-provider** (validates provider-neutrality claim from cart-id fix):
+    - Swap template `llm_configurations.sdk: "anthropic"` → `"openai"`; same flows work
+
+### What NOT to do
+
+- No piecemeal browser tests between sprint items
+- No promoting individual items to "done" before this e2e pass
+
+---
+
+## Failure UX policy
+
+Explicit policy for what the user sees when generation fails. Avoid silent-failure-on-the-long-tail; it's the killer of trust.
+
+| Failure mode | Detection | User-visible behavior |
+|---|---|---|
+| Healer rule fires (mechanical fix applied) | `healer_applied` SSE event | None — silent fix. Telemetry only. |
+| Healer can't fix (op dropped) | Catalog/schema reject | UI continues rendering remaining ops. Missing card is just absent. No banner. |
+| Whole `ui_stream` tool call fails (LLM emits nothing valid) | No ops received before tool result | Prose-only response (degraded). No skeleton/error widget. Main agent's prose carries the answer. |
+| Tool result with `trigger: skip_ui` | Config | No UI, prose handles. Working as intended. |
+| MCP tool failure (cart create returns 4xx) | Resolution-driven retry envelope (S3.3) | `recoverable` → silent retry. `requires_buyer_input` → Message primitive inline. `requires_buyer_review` → confirm CTA. `unrecoverable` → Handoff. |
+| `refine_ui` targets nonexistent `card_id` | Server validation | Server returns error to LLM (`{ok: false, reason: "card_id not found"}`); main agent handles in prose. |
+| ConfirmCard with malformed typed payload | Server-side validation before render | Server logs error, returns `{ok: false}` to LLM. Main agent falls back to plain-prose summary + Handoff to web checkout. |
+| SSE/RTVI stream disconnect mid-render | Client detects | Widget keeps already-applied ops; resumes from session UI state on reconnect. Partial cards stay partial; user can ask "show me again." |
+| Healer catch rate < 85% in production telemetry | Sprint 4 eval pipeline | Trigger: invest in fine-tuned tiny healer model (deferred item). |
+
+Principle: **degraded but coherent > broken-looking**. If we can't render perfectly, the conversation continues in prose and the user can re-ask.
+
+---
+
+## Open questions / deferred decisions
+
+Things we explicitly chose NOT to decide yet. Each entry has a "decide when" trigger so we don't paralyze on them.
+
+| Question | Current default | Decide when |
+|---|---|---|
+| **Voice barge-in policy** — does user interrupt clear in-flight UI cards? | Cards persist; user can ask to clear. | Sprint 2 (S2.1), once voice parity demos surface the UX feel. |
+| **Session UI state persistence** — do we save the SpecStream tree to DB for resume across reloads? | Rehydrate on reconnect from session state + last tool results (no separate UI persistence). | If reload-loses-cards bugs appear in beta. |
+| **Per-merchant UI prompt themes** — common base prompt vs per-merchant fork? | Per-merchant via `tool_ui_instructions` in template config. Common base might emerge as a default block merchants override. | Once we have ≥3 merchants and observe drift. |
+| **`@Widget(...)` registered-widget escape valve** | Don't ship. SpecStream composition is expressive enough. | Concrete case where SpecStream can't elegantly express a canonical UI. High bar. |
+| **JIT instruction token cost ceiling** | Unbounded for now (cost not a constraint). | If a single tool's instructions exceed ~2KB or merchants ship hundreds. |
+| **Healer rule-set governance** — code-defined vs template-configurable? | Code-defined in `ui_healer.py`. Merchants don't extend. | If merchants need merchant-specific heal rules (likely never). |
+| **MCP Apps host targeting** — emit by default for all merchants, or opt-in flag? | Opt-in via template flag `emit_mcp_apps: true`. Default off. | When a merchant asks for cross-host distribution. |
+| **Eval pipeline judge model** — Sonnet, Opus, or external? | Sonnet for cost; revisit if scores drift from human review. | After 4 weeks of CI eval data. |
+| **Refine-ui scope** — only adjacent card edits, or arbitrary tree mutations? | Adjacent edits (replace one card's content; add/remove cards from same root). | When users start asking for cross-card refinements. |
+| **Component catalog versioning** — single `v1` URI, or per-primitive? | Single `v1` URI for the catalog; primitives bump together. | When a merchant pins to a stale version. |
+
+---
+
+## Operational notes
+
+### Server restart required after each Clairvoyance code change
+
+The running `python run.py` process holds Python modules in memory. Schema changes to `template/types.py`, new modules, or any updated handler code require a restart to take effect. Migrations apply live (DB-level); template JSON re-provision is live; code changes are not.
+
+### Template cache invalidation
+
+Templates are cached in Redis with TTL. After a template re-provision, either wait for TTL expiry or invalidate keys matching `bb:tpl:*` and `bb:mcp:tools:*`.
+
+### Local dev token mint (RBAC admin)
+
+```bash
+cd clones/clairvoyance && set -a && source .env && set +a && .venv/bin/python <<'PY'
+from datetime import timedelta
+from app.api.security.breeze_buddy.rbac_token import rbac_token_manager
+from app.schemas.breeze_buddy.auth import UserRole
+token = rbac_token_manager.create_access_token_with_rbac(
+    user_id='local-admin', username='local-admin', role=UserRole.ADMIN,
+    reseller_ids=['*'], merchant_ids=['*'], email='admin@local',
+    expires_delta=timedelta(hours=6),
+)
+open('/tmp/clairvoyance_admin_token.txt', 'w').write(token)
+PY
+```
+
+Trap I hit (record so you don't): use `BreezeBuddyRBACTokenManager.create_access_token_with_rbac`, NOT `JWTManager.create_access_token`. The RBAC verifier reads `sub` (not `id`) — the generic JWTManager mints `id`, gets rejected by the RBAC route with `"Could not validate credentials"`.
+
+Second trap: **don't `stdout` the token in Python**. Pipecat's `import` writes its `ᓚᘏᗢ Pipecat 1.1.0 …` logger banner to stdout at module-load time. The token gets concatenated with log noise. Always write via `open(path, 'w').write(token)` from inside the Python heredoc.
+
+### Re-provision command
+
+Run from `nautilus/` cwd:
+
+```bash
+cd ~/Repos/BreezeBuddy/nautilus && \
+CLAIRVOYANCE_ADMIN_TOKEN="$(cat /tmp/clairvoyance_admin_token.txt)" \
+  CLAIRVOYANCE_BASE_URL="http://localhost:8000" \
+  MERCHANT_DOMAIN=swaroop-juspay.myshopify.com \
+  bash scripts/provision-buddy-assist-merchant.sh
+```
+
+The script is idempotent: first run creates template + widget_config; subsequent runs PUT updates. Swap `MERCHANT_DOMAIN` to provision a second merchant (each gets its own `template_id` + `widget_config_id` + `public_widget_key`).
+
+`STOREFRONT_TOKEN` is optional but warns if absent; for both `swaroop-juspay` and `milton-india-store` dev stores, MCP is open (no auth header required).
+
+### Live merchants (post-Sprint-1.5)
+
+| Merchant | Template ID | Widget Key | MCP base | Notes |
+|---|---|---|---|---|
+| `swaroop-juspay.myshopify.com` | `595650c5-b3c1-4b68-a3e9-5f22630283e0` | `DKt-j-YE-qCZeNcUt_Fh2v4OQ9LjqbyreDjBi7Poe5s` | `https://swaroop-juspay.myshopify.com/api/mcp` | Original smoke target. Shopify demo inventory (snowboards, shoes). |
+| `milton-india-store.myshopify.com` | `760a45f5-68c3-4941-8a73-558758f366d0` | `LT_uwSgXxRBDfPxf529QaX9MfP1PRgkUKtkjr0mhp7o` | `https://milton-india-store.myshopify.com/api/mcp` | Real-storefront smoke. Water bottles, kitchenware. Tags are numeric codes; `alt_text` empty — anticipated healer/JIT tweaks in §"Real-traffic learnings" #4. |
+
+Both share the same `canonical.template.json` source; each provisioning produces an independent merchant-scoped template row. To switch the dev harness between merchants, edit `loom/packages/breeze-buddy-assist-widget/index.html` — change the `tenant=` (widget-key) + `shop=` attributes on the `<breeze-buddy-assist>` element.
+
+### Testing SpecStream emission locally (Sprint 1+)
+
+To be defined as part of S1.1 implementation. Likely: a `--dry-run` mode in the chat agent that emits JSONL to stdout for inspection without hitting the widget.
+
+### Validating the AgentCard (Sprint 2+)
+
+```bash
+# After S2.4 publishes the AgentCard
+curl http://localhost:5180/.well-known/agent-card.json | jq .
+# Validate against A2A spec
+```
+
+---
+
+## File map (where to find things across the monorepo)
+
+Three repos involved. Routinely mixed up. Map for clarity:
+
+| Path root | Repo | Purpose |
+|---|---|---|
+| `~/Repos/BreezeBuddy/nautilus/` | nautilus (Shopify-side) | Shopify app, widget, storefront extensions, canonical template JSON, docs, migrations for Shopify-side tables |
+| `~/Repos/BreezeBuddy/clones/clairvoyance/` | clairvoyance (agent backend) | Python backend: chat agent, voice agent, MCP client, template engine, DB accessors, FastAPI routes, migrations for chat_session/agent_session_state/etc. |
+| `~/Repos/loom/packages/client-sdk/` | client-sdk | Framework-agnostic JS SDK published as `@juspay/breeze-buddy-client-sdk`. Used to host the OpenUI Lang parser; will be slimmed when DSL is deleted in S1.1. |
+| `~/Repos/BreezeBuddy/poc/` | research scratch (not deployed) | 15 cloned reference repos + 3 synthesis docs (GOLDEN_INSIGHTS, GOLDEN_UI_INSIGHTS, WEB_RESEARCH_UI_GEN) + 15 per-repo INSIGHTS.md + 9 UI_INSIGHTS.md. Source for every architectural decision. |
+
+Quick lookup (Sprint 1 + 1.5 — current state):
+
+- Chat agent turn loop: `clones/clairvoyance/app/ai/voice/agents/breeze_buddy/chat/agent.py` (resolves `_ui_allowlist` per turn from `template.configurations.ui_catalog`)
+- Chat history persistence: `clones/clairvoyance/app/database/{queries,accessor,decoder}/breeze_buddy/chat_session.py`
+- Anthropic block ↔ OpenAI LLMContextMessage codec: `clones/clairvoyance/app/ai/voice/agents/breeze_buddy/chat/block_codec.py`
+- Reducer + arg-injection engines: `clones/clairvoyance/app/ai/voice/agents/breeze_buddy/template/session_state.py`
+- MCP client wrapper + JIT-instruction injection: `clones/clairvoyance/app/ai/voice/agents/breeze_buddy/mcp/__init__.py`
+- Template types (Pydantic): `clones/clairvoyance/app/ai/voice/agents/breeze_buddy/template/types.py` (`ToolUiHint`, `ToolUiTrigger`, `ToolUiExample`, **`UiCatalogConfig`**)
+- **SpecStream UI catalog** (15 primitives + group registry): `clones/clairvoyance/app/ai/voice/agents/breeze_buddy/template/ui_catalog.py` — `PRIMITIVE_GROUPS`, `PRIMITIVE_RENDER_ORDER`, `resolve_allowlist`, `group_for`, **`Tile` + `TileMedia`/`TileBodyItem`/`TileAttribute`/`TileAction`**
+- **System-prompt primitives section renderer**: `clones/clairvoyance/app/ai/voice/agents/breeze_buddy/template/ui_prompt.py` — `render_primitives_section(allowlist)` introspects Pydantic schemas
+- Builder + system-prompt splice: `clones/clairvoyance/app/ai/voice/agents/breeze_buddy/template/builder.py` (`build_flow_config(..., ui_allowlist=...)`, replaces `{{ui_primitives_section}}` placeholder)
+- **UI wire format / extractor / parser / allowlist gate**: `clones/clairvoyance/app/ai/voice/agents/breeze_buddy/chat/ui_stream.py` (`parse_op_line(..., allowlist=)`, `process_op_line(..., allowlist=)`)
+- **In-stream healer + alias table**: `clones/clairvoyance/app/ai/voice/agents/breeze_buddy/chat/ui_healer.py` (`_PROP_ALIASES`)
+- Response-transform engine: `clones/clairvoyance/app/ai/voice/agents/breeze_buddy/handlers/transport/utils/response_transform.py`
+- Chat API router: `clones/clairvoyance/app/api/routers/breeze_buddy/chat/handlers.py`
+- Migration runner: `clones/clairvoyance/scripts/migrate.py`
+- Migrations (chat-side): `clones/clairvoyance/app/database/migrations/`
+- Migrations (Shopify-side): `nautilus/database/migrations/`
+- Canonical template (commerce config + JIT instructions + system prompt + ui_catalog config): `nautilus/static/buddy-assist-agent/canonical.template.json`
+- Provisioning script: `nautilus/scripts/provision-buddy-assist-merchant.sh`
+- **Widget package (lives in loom)**: `loom/packages/breeze-buddy-assist-widget/`. Built via `pnpm run build` at loom root (root build calls `build:widget` which copies output to `loom/build/widget/`). Served at `https://breezebuddy.ai/widget/assist.js`.
+- **Widget UI state store** (Svelte 5 $state tree): `loom/packages/breeze-buddy-assist-widget/src/lib/ui/ui_state.svelte.ts`
+- Widget renderer (stateful patch applier): `loom/packages/breeze-buddy-assist-widget/src/lib/ui/UiRenderer.svelte` + `UiNode.svelte` (Tile dispatch with TS narrowing)
+- Widget primitives: `src/lib/ui/primitives/` (Stack/Row/Card/CardHeader/Image/Text/Carousel/Button/Buttons/Table/Tag + typed Message/Handoff + composite `Tile.svelte`)
+- Widget UI pane (per-block ops application): `src/lib/components/BbUiPane.svelte`
+- Widget shell: `src/BuddyAssist.svelte` (registers the `<breeze-buddy-assist>` custom element)
+- Widget dev harness: `loom/packages/breeze-buddy-assist-widget/index.html` — edit `tenant=` and `shop=` to switch between merchants.
+- **Use-case showcase landing (Sprint 1.9)**: `loom/packages/breeze-buddy-assist-widget/showcase.html` + `Showcase.svelte` — 20 vertical demos using real widget chrome + `UiRenderer`.
+- **TTFB thinking indicator (Sprint 1.8)**: `loom/packages/breeze-buddy-assist-widget/src/lib/components/BbThinkingRow.svelte`
+- **New-chat bottom-sheet (Sprint 1.8)**: `loom/packages/breeze-buddy-assist-widget/src/lib/components/BbConfirmSheet.svelte`
+- **Mascot + launcher + footer wordmark (Sprint 1.8)**: `loom/packages/breeze-buddy-assist-widget/src/lib/components/BbBuddy.svelte` + `BbSolidOrb.svelte` + `BbLauncher.svelte` + `BbWatermark.svelte`
+- **Cross-pod cancel pubsub + per-pod task registry (Sprint 1.8)**: `clairvoyance/app/api/routers/breeze_buddy/chat/cancel_bus.py`
+- SDK UI types (now data-only): `~/Repos/loom/packages/client-sdk/src/lib/ui/types.ts` (`UiOp`, `UiAction`, `UI_CATALOG_VERSION`)
+- SDK chat store (per-turn ops accumulator): `~/Repos/loom/packages/client-sdk/src/lib/store/_buddy-chat-store.ts`
+- SDK turn engine (SSE → events): `~/Repos/loom/packages/client-sdk/src/lib/chat/_turn-engine.ts`
+- Tests (cart-id fix): `clones/clairvoyance/tests/test_session_state.py` (19 tests)
+- Tests (response transforms): `clones/clairvoyance/tests/test_response_transform.py`
+- Tests (UI wire format): `clones/clairvoyance/tests/test_ui_stream.py` (23 tests)
+- Tests (healer): `clones/clairvoyance/tests/test_ui_healer.py` (19 tests — incl. alias-rename cases)
+- Tests (JIT instructions): `clones/clairvoyance/tests/test_jit_instructions.py` (6 tests)
+- **Tests (catalog groups)**: `clones/clairvoyance/tests/test_ui_catalog_groups.py` (11 tests — resolve_allowlist precedence, group_for, edge cases)
+- **Tests (Tile validation)**: `clones/clairvoyance/tests/test_tile_validation.py` (14 tests — slot coverage, polymorphic body kinds, required-title rejection)
+- **Tests (primitive_disabled)**: `clones/clairvoyance/tests/test_primitive_disabled.py` (7 tests — `primitive_disabled:<type>` distinct from `unknown_type`)
+- **Tests (ui_prompt render)**: `clones/clairvoyance/tests/test_ui_prompt.py` (11 tests — allowlist filtering, render order, slot-name presence, validated examples)
+
+**Deleted in Sprint 1** (don't try to import these — they're gone):
+- `clones/clairvoyance/app/ai/voice/agents/breeze_buddy/chat/{ui_parser,ui_resolver,ui_marker,ui_emit,ui_prompt}.py`
+- `~/Repos/loom/packages/client-sdk/src/lib/ui/_lang-core/` (entire directory ~3kLOC vendored parser)
+- `~/Repos/loom/packages/client-sdk/src/lib/ui/{_parse,_action-bus,_evaluator}.ts`
+- `~/Repos/loom/packages/client-sdk/src/lib/ui/{UiRenderer,UiNode}.svelte` (SDK-side; widget owns the renderer now)
+- `~/Repos/loom/packages/client-sdk/src/lib/ui/primitives/` (entire directory)
+- `nautilus/packages/breeze-buddy-assist-widget/src/lib/ui/_evaluator.ts`
+
+## References
+
+### Internal docs (read in this order if catching up)
+
+1. **`poc/WEB_RESEARCH_UI_GEN.md`** — production-system research; source of the three pivots that shape this roadmap
+2. **`poc/GOLDEN_UI_INSIGHTS.md`** — open-source UI synthesis (15 repos)
+3. **`poc/GOLDEN_INSIGHTS.md`** — cart-id loss + generic-vs-flavoured verdict (informs already-shipped sprint)
+4. **`poc/REPOS.md`** — index of the 15 cloned open-source repos
+5. **`docs/features/BREEZE_BUDDY_ASSIST.md`** — primary design doc (older — predates this roadmap)
+6. Individual `poc/<repo>/INSIGHTS.md` and `poc/<repo>/UI_INSIGHTS.md` — per-repo deep reads
+
+### External references for the new direction
+
+- [Vercel json-render](https://github.com/vercel-labs/json-render) — SpecStream wire format reference impl (Apache 2.0)
+- [A2UI v0.9](https://developers.googleblog.com/a2ui-v0-9-generative-ui/) — Google's open generative-UI spec
+- [MCP Apps spec](https://blog.modelcontextprotocol.io/posts/2026-01-26-mcp-apps/) — cross-host UI standard (Jan 2026)
+- [Vercel v0 composite model](https://vercel.com/blog/v0-composite-model-family) — healer architecture
+- [Shopify Sidekick engineering](https://shopify.engineering/building-production-ready-agentic-systems) — JIT instructions pattern
+- [Cognition: Don't Build Multi-Agents](https://cognition.ai/blog/dont-build-multi-agents) — context-coherence argument against UI subagent
+- [Anthropic multi-agent research system](https://www.anthropic.com/engineering/multi-agent-research-system) — the counter-position; where multi-agent wins (research, not UI)
+- [AG-UI protocol](https://docs.ag-ui.com/) — stateful-agent UI assumption; informs our patch-based renderer
+- [ArtifactsBench paper](https://arxiv.org/pdf/2507.04952) — multimodal eval pipeline pattern for S4.1
+
+External references for the new direction:
+- [Vercel json-render](https://github.com/vercel-labs/json-render) — SpecStream wire format reference impl
+- [A2UI v0.9](https://developers.googleblog.com/a2ui-v0-9-generative-ui/) — Google's open generative-UI spec
+- [MCP Apps](https://blog.modelcontextprotocol.io/posts/2026-01-26-mcp-apps/) — cross-host UI standard
+- [Vercel v0 composite model](https://vercel.com/blog/v0-composite-model-family) — healer architecture
+- [Shopify Sidekick](https://shopify.engineering/building-production-ready-agentic-systems) — JIT instructions pattern
+- [Cognition: Don't Build Multi-Agents](https://cognition.ai/blog/dont-build-multi-agents) — why no UI subagent

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,3 +68,8 @@ combine_as_imports = true
 
 [tool.pyrefly]
 project-excludes = ["**/automatic/**"]
+
+[dependency-groups]
+dev = [
+    "pytest>=9.0.3",
+]

--- a/tests/test_context_compactor.py
+++ b/tests/test_context_compactor.py
@@ -1,0 +1,218 @@
+# pyrefly: ignore-errors
+# Test indexes into result dicts whose return type pyrefly can't infer tightly.
+"""Tests for the conversation-context compactor.
+
+The compactor rewrites stale ``tool_result`` blocks in an Anthropic ``messages``
+array to 1-line stubs. The contract is narrow but easy to get wrong on
+edge cases (mixed roles, multi-block messages, missing tool_use linkage),
+so the cases here cover both the happy paths and the don't-blow-up paths.
+"""
+
+from __future__ import annotations
+
+from app.ai.voice.agents.breeze_buddy.chat.context_compactor import (
+    compact_tool_results,
+)
+
+
+def _tool_use(tu_id: str, name: str, args: dict) -> dict:
+    return {"type": "tool_use", "id": tu_id, "name": name, "input": args}
+
+
+def _tool_result(tu_id: str, content: str) -> dict:
+    return {"type": "tool_result", "tool_use_id": tu_id, "content": content}
+
+
+def _assistant_with_tool_use(tu_id: str, name: str, args: dict) -> dict:
+    return {"role": "assistant", "content": [_tool_use(tu_id, name, args)]}
+
+
+def _user_with_tool_result(tu_id: str, content: str) -> dict:
+    return {"role": "user", "content": [_tool_result(tu_id, content)]}
+
+
+# ---------------------------------------------------------------------------
+# Happy path — old catalog calls compact, latest stays intact
+# ---------------------------------------------------------------------------
+
+
+def test_compacts_older_last_turn_only_results_keeping_most_recent():
+    messages = [
+        {"role": "user", "content": "find me bottles"},
+        _assistant_with_tool_use("u1", "search_catalog", {"query": "bottle"}),
+        _user_with_tool_result("u1", '{"products": ["A","B","C"]}' * 200),  # bulky
+        {"role": "assistant", "content": "Here are some bottles."},
+        {"role": "user", "content": "red ones?"},
+        _assistant_with_tool_use("u2", "search_catalog", {"query": "red bottle"}),
+        _user_with_tool_result("u2", '{"products": ["red1"]}' * 200),  # bulky, NEWEST
+    ]
+    out = compact_tool_results(
+        messages, retention={"search_catalog": "last_turn_only"}, recent_keep=1
+    )
+    # Older tool_result (u1) gets stubbed
+    assert "[pruned: search_catalog" in out[2]["content"][0]["content"]
+    assert "u1" == out[2]["content"][0]["tool_use_id"]
+    # Newest tool_result (u2) untouched
+    assert out[6]["content"][0]["content"].startswith('{"products"')
+    # tool_use blocks are PRESERVED (LLM still sees what was called)
+    assert out[1]["content"][0]["type"] == "tool_use"
+    assert out[1]["content"][0]["name"] == "search_catalog"
+
+
+def test_recent_keep_two_preserves_last_two_results():
+    messages = [
+        _assistant_with_tool_use("u1", "search_catalog", {"q": "1"}),
+        _user_with_tool_result("u1", "first" * 200),
+        _assistant_with_tool_use("u2", "search_catalog", {"q": "2"}),
+        _user_with_tool_result("u2", "second" * 200),
+        _assistant_with_tool_use("u3", "search_catalog", {"q": "3"}),
+        _user_with_tool_result("u3", "third" * 200),
+    ]
+    out = compact_tool_results(
+        messages, retention={"search_catalog": "last_turn_only"}, recent_keep=2
+    )
+    # First call compacted, last two preserved
+    assert "[pruned" in out[1]["content"][0]["content"]
+    assert out[3]["content"][0]["content"] == "second" * 200
+    assert out[5]["content"][0]["content"] == "third" * 200
+
+
+# ---------------------------------------------------------------------------
+# Session-mode preservation — cart calls stay intact
+# ---------------------------------------------------------------------------
+
+
+def test_session_retention_preserves_old_tool_results():
+    messages = [
+        _assistant_with_tool_use("c1", "create_cart", {"items": ["x"]}),
+        _user_with_tool_result("c1", "cart-state-blob" * 200),
+        _assistant_with_tool_use("u1", "search_catalog", {"q": "y"}),
+        _user_with_tool_result("u1", "search-blob" * 200),
+    ]
+    out = compact_tool_results(
+        messages,
+        retention={
+            "create_cart": "session",
+            "search_catalog": "last_turn_only",
+        },
+        recent_keep=1,
+    )
+    # Cart result preserved despite being older
+    assert out[1]["content"][0]["content"] == "cart-state-blob" * 200
+    # Search result is the most recent, so also preserved by recent_keep
+    assert out[3]["content"][0]["content"] == "search-blob" * 200
+
+
+def test_unknown_tool_defaults_to_session_no_compaction():
+    """A tool not in the retention map is treated as 'session' (kept)."""
+    messages = [
+        _assistant_with_tool_use("x1", "mystery_tool", {}),
+        _user_with_tool_result("x1", "mystery-blob" * 200),
+        _assistant_with_tool_use("x2", "mystery_tool", {}),
+        _user_with_tool_result("x2", "mystery2" * 200),
+    ]
+    out = compact_tool_results(
+        messages, retention={"search_catalog": "last_turn_only"}, recent_keep=1
+    )
+    assert out[1]["content"][0]["content"] == "mystery-blob" * 200
+
+
+# ---------------------------------------------------------------------------
+# Stub formatting
+# ---------------------------------------------------------------------------
+
+
+def test_stub_includes_tool_name_and_args():
+    messages = [
+        _assistant_with_tool_use("u1", "search_catalog", {"query": "red bottle"}),
+        _user_with_tool_result("u1", "big"),
+        _assistant_with_tool_use("u2", "search_catalog", {"query": "blue"}),
+        _user_with_tool_result("u2", "big"),
+    ]
+    out = compact_tool_results(
+        messages, retention={"search_catalog": "last_turn_only"}, recent_keep=1
+    )
+    stub = out[1]["content"][0]["content"]
+    assert "search_catalog" in stub
+    assert "red bottle" in stub  # args echo back
+    assert "re-call" in stub.lower()
+
+
+def test_stub_truncates_huge_args():
+    big_query = "x" * 5000
+    messages = [
+        _assistant_with_tool_use("u1", "search_catalog", {"query": big_query}),
+        _user_with_tool_result("u1", "result"),
+        _assistant_with_tool_use("u2", "search_catalog", {"query": "small"}),
+        _user_with_tool_result("u2", "result"),
+    ]
+    out = compact_tool_results(
+        messages, retention={"search_catalog": "last_turn_only"}, recent_keep=1
+    )
+    stub = out[1]["content"][0]["content"]
+    # The stub is bounded — should be well under the original args size.
+    assert len(stub) < 500
+
+
+# ---------------------------------------------------------------------------
+# No-op cases — these are the "don't blow up" guarantees
+# ---------------------------------------------------------------------------
+
+
+def test_empty_messages_returns_empty():
+    assert compact_tool_results([], retention={"x": "last_turn_only"}) == []
+
+
+def test_no_retention_map_returns_messages_unchanged():
+    messages = [
+        _assistant_with_tool_use("u1", "search_catalog", {}),
+        _user_with_tool_result("u1", "blob"),
+    ]
+    out = compact_tool_results(messages, retention=None)
+    assert out[1]["content"][0]["content"] == "blob"
+
+
+def test_string_content_messages_pass_through():
+    """User messages with plain-string content (no tool blocks) shouldn't crash."""
+    messages = [
+        {"role": "user", "content": "hello"},
+        {"role": "assistant", "content": "hi there!"},
+    ]
+    out = compact_tool_results(messages, retention={"search_catalog": "last_turn_only"})
+    assert out == messages
+
+
+def test_tool_result_without_matching_tool_use_is_left_alone():
+    """If a tool_result has no preceding tool_use block we can resolve, skip it.
+
+    Real Anthropic conversations always pair these; but a corrupted/replayed
+    history shouldn't crash the compactor.
+    """
+    messages = [
+        # tool_result whose tool_use_id never appeared as a tool_use
+        _user_with_tool_result("orphan", "lonely-blob" * 200),
+        _assistant_with_tool_use("u1", "search_catalog", {}),
+        _user_with_tool_result("u1", "newest"),
+    ]
+    out = compact_tool_results(
+        messages, retention={"search_catalog": "last_turn_only"}, recent_keep=1
+    )
+    # The orphan is untouched (no tool name → no policy → preserved).
+    assert out[0]["content"][0]["content"] == "lonely-blob" * 200
+    # The newest result is also untouched (recent_keep=1).
+    assert out[2]["content"][0]["content"] == "newest"
+
+
+def test_does_not_mutate_input_messages():
+    messages = [
+        _assistant_with_tool_use("u1", "search_catalog", {}),
+        _user_with_tool_result("u1", "blob" * 200),
+        _assistant_with_tool_use("u2", "search_catalog", {}),
+        _user_with_tool_result("u2", "newest"),
+    ]
+    original_blob = messages[1]["content"][0]["content"]
+    compact_tool_results(
+        messages, retention={"search_catalog": "last_turn_only"}, recent_keep=1
+    )
+    # Input list untouched (compactor returns a new list, copy-on-write).
+    assert messages[1]["content"][0]["content"] == original_blob

--- a/tests/test_jit_instructions.py
+++ b/tests/test_jit_instructions.py
@@ -1,0 +1,83 @@
+"""Tests for JIT (Just-in-Time) UI instruction injection into MCP tool
+responses. Covers each ``ToolUiTrigger`` value end-to-end."""
+
+from __future__ import annotations
+
+import json
+
+from app.ai.voice.agents.breeze_buddy.mcp import _maybe_inject_ui_instructions
+from app.ai.voice.agents.breeze_buddy.template.types import (
+    ToolUiExample,
+    ToolUiHint,
+    ToolUiTrigger,
+)
+
+
+def _wrap(payload: dict) -> str:
+    return json.dumps(payload)
+
+
+def test_jit_inject_on_success_appends_instructions():
+    hint = ToolUiHint(
+        trigger=ToolUiTrigger.ON_SUCCESS,
+        instructions="Render as a Carousel of Cards.",
+    )
+    result = _wrap({"products": [{"id": "p1", "title": "Snowboard"}]})
+    out = _maybe_inject_ui_instructions(result, hint, "search_catalog")
+    parsed = json.loads(out)
+    assert parsed["_ui_instructions"] == "Render as a Carousel of Cards."
+    assert parsed["products"][0]["id"] == "p1"
+
+
+def test_jit_inject_appends_examples_when_present():
+    hint = ToolUiHint(
+        trigger=ToolUiTrigger.ON_SUCCESS,
+        instructions="Render a Card.",
+        examples=[
+            ToolUiExample(
+                scenario="single product",
+                input_sketch="{product: {id, title}}",
+                expected_jsonl=[
+                    {"op": "add", "id": "root", "type": "Card"},
+                ],
+            )
+        ],
+    )
+    result = _wrap({"product": {"id": "p1"}})
+    out = _maybe_inject_ui_instructions(result, hint, "get_product_details")
+    parsed = json.loads(out)
+    assert isinstance(parsed["_ui_examples"], list)
+    assert parsed["_ui_examples"][0]["scenario"] == "single product"
+    assert parsed["_ui_examples"][0]["expected_jsonl"][0]["type"] == "Card"
+
+
+def test_jit_skip_ui_sets_flag_and_omits_instructions():
+    hint = ToolUiHint(
+        trigger=ToolUiTrigger.SKIP_UI,
+        instructions="(unused)",
+    )
+    result = _wrap({"answer": "Our return policy is 30 days."})
+    out = _maybe_inject_ui_instructions(result, hint, "search_shop_policies_and_faqs")
+    parsed = json.loads(out)
+    assert parsed["_ui_skip"] is True
+    assert "_ui_instructions" not in parsed
+
+
+def test_jit_no_hint_passes_through_unchanged():
+    result = _wrap({"products": []})
+    out = _maybe_inject_ui_instructions(result, None, "search_catalog")
+    assert out == result
+
+
+def test_jit_inject_no_op_on_non_object_payload():
+    # Lists and primitives pass through; the LLM gets the raw structure.
+    list_payload = json.dumps([{"id": 1}, {"id": 2}])
+    hint = ToolUiHint(trigger=ToolUiTrigger.ON_SUCCESS, instructions="x")
+    assert _maybe_inject_ui_instructions(list_payload, hint, "tool") == list_payload
+
+
+def test_jit_inject_handles_non_json_string_passthrough():
+    # Plain text tool results pass through (no _ui_instructions appended).
+    plain = "Sorry, no results."
+    hint = ToolUiHint(trigger=ToolUiTrigger.ON_SUCCESS, instructions="x")
+    assert _maybe_inject_ui_instructions(plain, hint, "tool") == plain

--- a/tests/test_mcp_default_args.py
+++ b/tests/test_mcp_default_args.py
@@ -1,0 +1,84 @@
+"""Unit tests for the MCP handler's _deep_merge_defaults helper.
+
+The helper is used to merge protocol-level static arguments (e.g. Shopify
+UCP's `meta.ucp-agent.profile`) into every tool call's `arguments` object
+without touching session-state-driven injection rules.
+"""
+
+from app.ai.voice.agents.breeze_buddy.mcp import _deep_merge_defaults
+
+
+def test_empty_defaults_returns_copy_of_args() -> None:
+    args = {"a": 1, "b": 2}
+    out = _deep_merge_defaults(args, {})
+    assert out == args
+    assert out is not args  # new dict
+
+
+def test_defaults_fill_missing_keys() -> None:
+    out = _deep_merge_defaults({"a": 1}, {"b": 2})
+    assert out == {"a": 1, "b": 2}
+
+
+def test_caller_wins_on_top_level_collision() -> None:
+    out = _deep_merge_defaults({"a": 1}, {"a": 99})
+    assert out == {"a": 1}
+
+
+def test_deep_merge_of_nested_dicts() -> None:
+    out = _deep_merge_defaults(
+        {"catalog": {"query": "water"}},
+        {
+            "meta": {"ucp-agent": {"profile": "https://x/agent.json"}},
+            "catalog": {"limit": 10},
+        },
+    )
+    assert out == {
+        "catalog": {"query": "water", "limit": 10},
+        "meta": {"ucp-agent": {"profile": "https://x/agent.json"}},
+    }
+
+
+def test_caller_wins_on_nested_collision() -> None:
+    out = _deep_merge_defaults(
+        {"meta": {"ucp-agent": {"profile": "OVERRIDE"}}},
+        {"meta": {"ucp-agent": {"profile": "https://default/agent.json"}}},
+    )
+    assert out == {"meta": {"ucp-agent": {"profile": "OVERRIDE"}}}
+
+
+def test_ucp_profile_injection_idiomatic_shape() -> None:
+    """The exact wire shape we send to Shopify UCP."""
+    args_from_llm = {"catalog": {"query": "blue water bottle"}}
+    server_defaults = {
+        "meta": {
+            "ucp-agent": {
+                "profile": "https://breezebuddy.ai/.well-known/ucp/agent.json"
+            }
+        }
+    }
+    out = _deep_merge_defaults(args_from_llm, server_defaults)
+    assert out["catalog"] == {"query": "blue water bottle"}
+    assert (
+        out["meta"]["ucp-agent"]["profile"]
+        == "https://breezebuddy.ai/.well-known/ucp/agent.json"
+    )
+
+
+def test_args_with_partial_meta_still_get_profile() -> None:
+    """If the LLM happens to pass its own `meta` for some reason, our profile
+    should still land (defaults fill the missing ucp-agent subtree)."""
+    out = _deep_merge_defaults(
+        {"meta": {"other_namespace": {"x": 1}}},
+        {"meta": {"ucp-agent": {"profile": "https://x/agent.json"}}},
+    )
+    assert out["meta"]["other_namespace"] == {"x": 1}
+    assert out["meta"]["ucp-agent"]["profile"] == "https://x/agent.json"
+
+
+def test_does_not_mutate_inputs() -> None:
+    args = {"a": 1}
+    defaults = {"b": 2}
+    _ = _deep_merge_defaults(args, defaults)
+    assert args == {"a": 1}
+    assert defaults == {"b": 2}

--- a/tests/test_primitive_disabled.py
+++ b/tests/test_primitive_disabled.py
@@ -1,0 +1,98 @@
+"""Tests for template-level primitive allowlist filtering in ``parse_op_line``.
+
+The resolved per-template allowlist (see ``ui_catalog.resolve_allowlist`` +
+``UiCatalogConfig``) drops ``add`` ops whose type is known to the catalog
+but NOT enabled for the template. The error reason must be distinct from
+``unknown_type`` so telemetry separates "LLM hallucinated" from
+"merchant turned off".
+"""
+
+from __future__ import annotations
+
+from app.ai.voice.agents.breeze_buddy.chat.ui_stream import parse_op_line
+
+# Load template package first to avoid circular-import trap on first import
+# of chat/* (mirrors test_ui_stream + test_session_state).
+from app.ai.voice.agents.breeze_buddy.template.ui_catalog import (  # noqa: F401
+    UI_CATALOG,
+)
+
+# ---------------------------------------------------------------------------
+# Disabled primitives drop with the distinct reason
+# ---------------------------------------------------------------------------
+
+
+def test_disabled_known_primitive_yields_primitive_disabled_error():
+    """Carousel is in the catalog, but allowlist only contains Tile —
+    so the op must drop with ``primitive_disabled:Carousel``."""
+    line = '{"op":"add","id":"root","type":"Carousel"}'
+    r = parse_op_line(line, allowlist={"Tile"})
+    assert r.op is None
+    assert r.error == "primitive_disabled:Carousel"
+
+
+def test_primitive_disabled_is_distinct_from_unknown_type():
+    """An unknown type with allowlist still set must surface unknown_type,
+    NOT primitive_disabled — so telemetry can tell the two cases apart."""
+    line = '{"op":"add","id":"x","type":"NotAPrimitive","parent":"root"}'
+    r = parse_op_line(line, allowlist={"Tile"})
+    assert r.op is None
+    assert r.error and r.error.startswith("unknown_type")
+    assert "primitive_disabled" not in r.error
+
+
+def test_allowlist_none_means_no_template_level_filtering():
+    """When ``allowlist=None``, every catalog-registered type passes
+    (back-compat for pre-ui_catalog templates)."""
+    line = '{"op":"add","id":"root","type":"Carousel"}'
+    r = parse_op_line(line, allowlist=None)
+    assert r.error is None
+    assert r.op is not None
+    assert r.op["type"] == "Carousel"
+
+
+def test_empty_allowlist_disables_everything():
+    """``allowlist=set()`` (vs ``None``) explicitly disables every primitive —
+    every add op drops with ``primitive_disabled:<type>``."""
+    line = '{"op":"add","id":"root","type":"Carousel"}'
+    r = parse_op_line(line, allowlist=set())
+    assert r.op is None
+    assert r.error == "primitive_disabled:Carousel"
+
+    line2 = '{"op":"add","id":"root","type":"Tile","props":{"title":"x"}}'
+    r2 = parse_op_line(line2, allowlist=set())
+    assert r2.op is None
+    assert r2.error == "primitive_disabled:Tile"
+
+
+def test_allowlist_pass_when_type_enabled():
+    """When the type IS in the allowlist, normal validation continues."""
+    line = '{"op":"add","id":"root","type":"Tile","props":{"title":"hello"}}'
+    r = parse_op_line(line, allowlist={"Tile"})
+    assert r.error is None
+    assert r.op is not None
+    assert r.op["type"] == "Tile"
+    assert r.op["props"]["title"] == "hello"
+
+
+# ---------------------------------------------------------------------------
+# Allowlist applies to add only — remove/replace pass through
+# ---------------------------------------------------------------------------
+
+
+def test_remove_op_ignores_allowlist():
+    """``remove`` carries only id — there is no type to gate."""
+    line = '{"op":"remove","id":"c1"}'
+    r = parse_op_line(line, allowlist=set())
+    assert r.error is None
+    assert r.op == {"op": "remove", "id": "c1"}
+
+
+def test_replace_op_ignores_allowlist_when_no_type_specified():
+    """``replace`` carries new props only; type comes from existing tree state
+    at apply time on the widget. Allowlist only gates ``add``."""
+    line = '{"op":"replace","id":"c1","props":{"text":"hi"}}'
+    r = parse_op_line(line, allowlist=set())
+    assert r.error is None
+    assert r.op is not None
+    assert r.op["op"] == "replace"

--- a/tests/test_response_transform.py
+++ b/tests/test_response_transform.py
@@ -1,0 +1,517 @@
+# pyrefly: ignore-errors
+# Test indexes into result dicts whose return type pyrefly can't infer
+# tightly (`Cannot index into str/object`). Runtime correctness is covered.
+"""Tests for in-place response transforms and the built-in scale_by_exponent.
+
+Both pieces are channel-agnostic and vertical-agnostic: the walker doesn't
+care who calls it, and the registered transform fn doesn't know about
+voice vs chat — or about commerce, scheduling, or any other domain. These
+tests exercise the walker shape-matching, the registry behaviour, and the
+arithmetic rules for the first built-in op.
+"""
+
+from __future__ import annotations
+
+from app.ai.voice.agents.breeze_buddy.handlers.transport.utils.response_transform import (
+    apply_response_transforms,
+    omit_fields,
+    pick_fields,
+    scale_by_exponent,
+    strip_html,
+)
+
+# Order matters: template.types fully loads the `template` package (whose
+# __init__ pulls in hooks/http_requester) BEFORE the utility import
+# triggers handlers.transport.utils.__init__ → field_resolver →
+# template.types again. Reversing these triggers a circular-import error.
+from app.ai.voice.agents.breeze_buddy.template.types import ResponseTransform
+
+# ---------------------------------------------------------------------------
+# scale_by_exponent — pure arithmetic, no domain knowledge
+# ---------------------------------------------------------------------------
+
+
+def test_scale_by_exponent_default_two_integer_to_decimal_string():
+    value = {"amount": 69995}
+    scale_by_exponent(value, {})
+    assert value["amount"] == "699.95"
+
+
+def test_scale_by_exponent_default_two_digit_string():
+    value = {"amount": "69995"}
+    scale_by_exponent(value, {})
+    assert value["amount"] == "699.95"
+
+
+def test_scale_by_exponent_decimal_string_is_reformatted_consistently():
+    # Already-decimal input is taken at face value (no re-scaling), but still
+    # passes through the display formatter so output shape is consistent.
+    value = {"amount": "885.95"}
+    scale_by_exponent(value, {})
+    assert value["amount"] == "885.95"
+
+
+def test_scale_by_exponent_decimal_string_normalises_short_decimal():
+    # "1585.9" comes back from upstream UCP — we want "1,585.90" for display
+    # (thousands separator + exponent-aligned decimals).
+    value = {"amount": "1585.9"}
+    scale_by_exponent(value, {})
+    assert value["amount"] == "1,585.90"
+
+
+def test_scale_by_exponent_zero_keeps_integer_shape_with_separator():
+    value = {"amount": 1000}
+    scale_by_exponent(value, {"exponent": 0})
+    assert value["amount"] == "1,000"
+
+
+def test_scale_by_exponent_adds_thousands_separator_after_scaling():
+    # Minor-unit input crossing the thousands boundary gets the separator.
+    value = {"amount": 158590}
+    scale_by_exponent(value, {})
+    assert value["amount"] == "1,585.90"
+
+
+def test_scale_by_exponent_three_emits_three_decimal_places():
+    value = {"amount": 1234}
+    scale_by_exponent(value, {"exponent": 3})
+    assert value["amount"] == "1.234"
+
+
+def test_scale_by_exponent_custom_amount_field():
+    value = {"price": 1599}
+    scale_by_exponent(value, {"amount_field": "price"})
+    assert value["price"] == "15.99"
+
+
+def test_scale_by_exponent_unknown_amount_field_is_noop():
+    value = {"unrelated": "x"}
+    scale_by_exponent(value, {"amount_field": "amount"})
+    assert value == {"unrelated": "x"}
+
+
+def test_scale_by_exponent_negative_exponent_is_noop():
+    value = {"amount": 100}
+    scale_by_exponent(value, {"exponent": -1})
+    assert value == {"amount": 100}
+
+
+def test_scale_by_exponent_non_numeric_amount_is_noop():
+    value = {"amount": "not-a-number"}
+    scale_by_exponent(value, {})
+    assert value == {"amount": "not-a-number"}
+
+
+def test_scale_by_exponent_non_dict_returns_unchanged():
+    assert scale_by_exponent(42, {}) == 42
+    assert scale_by_exponent("not a dict", {}) == "not a dict"
+    assert scale_by_exponent(None, {}) is None
+
+
+# ---------------------------------------------------------------------------
+# apply_response_transforms — walker
+# ---------------------------------------------------------------------------
+
+
+def test_walker_mutates_nested_path():
+    data = {"order": {"total": {"amount": 5000}}}
+    apply_response_transforms(
+        data,
+        [
+            ResponseTransform(
+                path="order.total", fn="scale_by_exponent", args={"exponent": 2}
+            )
+        ],
+    )
+    assert data["order"]["total"]["amount"] == "50.00"
+
+
+def test_walker_iterates_arrays_with_wildcard():
+    data = {
+        "products": [
+            {"id": "a", "price": {"amount": 69995}},
+            {"id": "b", "price": {"amount": 12345}},
+        ]
+    }
+    apply_response_transforms(
+        data,
+        [
+            ResponseTransform(
+                path="products[*].price", fn="scale_by_exponent", args={"exponent": 2}
+            )
+        ],
+    )
+    assert data["products"][0]["price"]["amount"] == "699.95"
+    assert data["products"][1]["price"]["amount"] == "123.45"
+    # Other fields untouched.
+    assert data["products"][0]["id"] == "a"
+
+
+def test_walker_handles_deeply_nested_array_path():
+    data = {
+        "products": [
+            {
+                "price_range": {
+                    "min": {"amount": 69995},
+                    "max": {"amount": 99995},
+                }
+            }
+        ]
+    }
+    apply_response_transforms(
+        data,
+        [
+            ResponseTransform(
+                path="products[*].price_range.min",
+                fn="scale_by_exponent",
+                args={"exponent": 2},
+            ),
+            ResponseTransform(
+                path="products[*].price_range.max",
+                fn="scale_by_exponent",
+                args={"exponent": 2},
+            ),
+        ],
+    )
+    assert data["products"][0]["price_range"]["min"]["amount"] == "699.95"
+    assert data["products"][0]["price_range"]["max"]["amount"] == "999.95"
+
+
+def test_walker_missing_key_is_silent_noop():
+    data = {"order": {"id": "abc"}}
+    apply_response_transforms(
+        data,
+        [ResponseTransform(path="order.total", fn="scale_by_exponent")],
+    )
+    assert data == {"order": {"id": "abc"}}
+
+
+def test_walker_non_list_under_wildcard_is_silent_noop():
+    data = {"products": {"not": "a list"}}
+    apply_response_transforms(
+        data,
+        [ResponseTransform(path="products[*].price", fn="scale_by_exponent")],
+    )
+    assert data == {"products": {"not": "a list"}}
+
+
+def test_walker_unknown_fn_is_logged_and_skipped():
+    data = {"order": {"total": {"amount": 100}}}
+    apply_response_transforms(
+        data,
+        [ResponseTransform(path="order.total", fn="nonexistent_fn")],
+    )
+    assert data["order"]["total"]["amount"] == 100
+
+
+def test_walker_empty_transforms_returns_input_unchanged():
+    data = {"a": 1}
+    result = apply_response_transforms(data, [])
+    assert result is data
+    assert data == {"a": 1}
+
+
+def test_walker_non_dict_root_returns_unchanged():
+    result = apply_response_transforms(
+        "just a string",
+        [ResponseTransform(path="x", fn="scale_by_exponent")],
+    )
+    assert result == "just a string"
+
+
+def test_walker_array_leaf_applies_fn_to_each_element():
+    data = {
+        "items": [
+            {"amount": 100},
+            {"amount": 250},
+        ]
+    }
+    apply_response_transforms(
+        data,
+        [
+            ResponseTransform(
+                path="items[*]", fn="scale_by_exponent", args={"exponent": 2}
+            )
+        ],
+    )
+    assert data["items"][0]["amount"] == "1.00"
+    assert data["items"][1]["amount"] == "2.50"
+
+
+def test_walker_multiple_transforms_applied_in_order():
+    data = {"a": {"amount": 100}}
+    apply_response_transforms(
+        data,
+        [
+            ResponseTransform(path="a", fn="scale_by_exponent", args={"exponent": 2}),
+            ResponseTransform(path="a", fn="scale_by_exponent", args={"exponent": 2}),
+        ],
+    )
+    # Second pass is a no-op because amount is now a decimal string.
+    assert data["a"]["amount"] == "1.00"
+
+
+# ---------------------------------------------------------------------------
+# pick_fields — projection, drops everything not in keep list
+# ---------------------------------------------------------------------------
+
+
+def test_pick_fields_keeps_only_listed_keys():
+    value = {"id": "x", "title": "T", "variants": [1, 2], "collections": [3]}
+    out = pick_fields(value, {"keep": ["id", "title"]})
+    assert out == {"id": "x", "title": "T"}
+
+
+def test_pick_fields_missing_keys_silently_dropped():
+    out = pick_fields({"id": "x"}, {"keep": ["id", "title", "missing"]})
+    assert out == {"id": "x"}
+
+
+def test_pick_fields_empty_keep_returns_empty_dict():
+    assert pick_fields({"a": 1, "b": 2}, {}) == {}
+    assert pick_fields({"a": 1, "b": 2}, {"keep": []}) == {}
+
+
+def test_pick_fields_non_dict_passes_through():
+    assert pick_fields("nope", {"keep": ["x"]}) == "nope"
+    assert pick_fields([1, 2], {"keep": ["x"]}) == [1, 2]
+
+
+def test_pick_fields_via_walker_slims_each_array_element():
+    data = {
+        "products": [
+            {"id": "a", "title": "A", "junk": "drop me", "variants": [1, 2]},
+            {"id": "b", "title": "B", "junk": "drop me too", "variants": [3]},
+        ]
+    }
+    apply_response_transforms(
+        data,
+        [
+            ResponseTransform(
+                path="products[*]", fn="pick_fields", args={"keep": ["id", "title"]}
+            )
+        ],
+    )
+    assert data["products"] == [{"id": "a", "title": "A"}, {"id": "b", "title": "B"}]
+
+
+# ---------------------------------------------------------------------------
+# omit_fields — selective deletion, keeps everything not in drop list
+# ---------------------------------------------------------------------------
+
+
+def test_omit_fields_drops_listed_keys():
+    out = omit_fields({"a": 1, "b": 2, "c": 3}, {"drop": ["a", "c"]})
+    assert out == {"b": 2}
+
+
+def test_omit_fields_missing_keys_silently_skipped():
+    out = omit_fields({"a": 1}, {"drop": ["x", "y"]})
+    assert out == {"a": 1}
+
+
+def test_omit_fields_empty_drop_returns_input_unchanged():
+    assert omit_fields({"a": 1}, {}) == {"a": 1}
+    assert omit_fields({"a": 1}, {"drop": []}) == {"a": 1}
+
+
+def test_omit_fields_via_walker_at_root_strips_envelope():
+    # Most important real-world case: drop protocol metadata at the response
+    # root so the LLM never sees the UCP envelope etc. Requires the caller
+    # site to capture the return value (mcp/__init__.py does).
+    data = {"ucp": {"v": 1}, "products": [{"id": "a"}], "messages": []}
+    result = apply_response_transforms(
+        data,
+        [
+            ResponseTransform(
+                path="", fn="omit_fields", args={"drop": ["ucp", "messages"]}
+            )
+        ],
+    )
+    assert result == {"products": [{"id": "a"}]}
+
+
+# ---------------------------------------------------------------------------
+# strip_html — strip tags, collapse whitespace, optional word-boundary clip
+# ---------------------------------------------------------------------------
+
+
+def test_strip_html_removes_tags_and_normalises_whitespace():
+    assert strip_html("<p>Hello   <b>world</b>!</p>", {}) == "Hello world !"
+
+
+def test_strip_html_truncates_at_word_boundary():
+    s = "Vacuum-insulated bottle keeps drinks hot and cold for hours."
+    out = strip_html(s, {"max_chars": 30})
+    # 30-char window lands mid-word, so we clip at the prior space.
+    assert out.endswith("…")
+    assert len(out) <= 31  # 30 + ellipsis
+    # The char right before the ellipsis must NOT be a space — confirms we
+    # clipped at a word boundary (the space) rather than mid-word.
+    assert out[-2] != " ", out
+    # And the input MUST have been clipped (output is shorter than input).
+    assert len(out) < len(s)
+
+
+def test_strip_html_no_truncation_when_under_cap():
+    assert strip_html("Short text.", {"max_chars": 100}) == "Short text."
+
+
+def test_strip_html_zero_or_negative_max_chars_no_clip():
+    s = "<p>Hello world</p>"
+    assert strip_html(s, {"max_chars": 0}) == "Hello world"
+    assert strip_html(s, {"max_chars": -5}) == "Hello world"
+
+
+def test_strip_html_non_string_passes_through():
+    assert strip_html({"html": "<p>x</p>"}, {}) == {"html": "<p>x</p>"}
+    assert strip_html(None, {}) is None
+    assert strip_html(42, {}) == 42
+
+
+def test_strip_html_via_walker_on_nested_path():
+    data = {
+        "products": [
+            {"description": {"html": "<p>The bottle is <b>vacuum-insulated</b>.</p>"}}
+        ]
+    }
+    apply_response_transforms(
+        data,
+        [
+            ResponseTransform(
+                path="products[*].description.html",
+                fn="strip_html",
+                args={"max_chars": 100},
+            )
+        ],
+    )
+    assert (
+        data["products"][0]["description"]["html"] == "The bottle is vacuum-insulated."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Aggressive projection — the real-world search_catalog scenario
+# ---------------------------------------------------------------------------
+
+
+def test_combined_projection_strips_catalog_response_aggressively():
+    """End-to-end: simulate the catalog-bloat fix on a UCP-shaped response."""
+    data = {
+        "ucp": {"version": "2026-04-08", "capabilities": {"x": "huge"}},
+        "messages": [],
+        "products": [
+            {
+                "id": "gid://shopify/Product/1",
+                "title": "Test Bottle",
+                "description": {"html": "<p>Reusable & <i>insulated</i>.</p>"},
+                "price_range": {"min": {"amount": 51900, "currency": "INR"}},
+                "media": [{"type": "image", "url": "https://x/y.jpg"}],
+                "options": [{"name": "Color", "values": [{"label": "Red"}]}],
+                "tags": ["best-seller"],
+                # bloat we expect dropped:
+                "variants": [{"id": "v1", "sku": "SKU1"} for _ in range(15)],
+                "collections": [
+                    {"id": "c1", "title": "Summer", "description": "x" * 1000}
+                ],
+                "url": "https://shop/product/1",
+                "handle": "test-bottle",
+                "gift_card": False,
+            }
+        ],
+        "pagination": {"cursor": None, "has_more": False},
+    }
+    transforms = [
+        ResponseTransform(
+            path="", fn="omit_fields", args={"drop": ["ucp", "messages"]}
+        ),
+        ResponseTransform(
+            path="products[*]",
+            fn="pick_fields",
+            args={
+                "keep": [
+                    "id",
+                    "title",
+                    "description",
+                    "price_range",
+                    "list_price_range",
+                    "media",
+                    "options",
+                    "tags",
+                ]
+            },
+        ),
+        ResponseTransform(
+            path="products[*].description.html",
+            fn="strip_html",
+            args={"max_chars": 200},
+        ),
+        ResponseTransform(
+            path="products[*].price_range.min",
+            fn="scale_by_exponent",
+            args={"exponent": 2},
+        ),
+    ]
+    result = apply_response_transforms(data, transforms)
+    # Envelope gone.
+    assert "ucp" not in result
+    assert "messages" not in result
+    # Pagination kept (we never asked to drop it).
+    assert "pagination" in result
+    # Product slimmed.
+    p = result["products"][0]
+    assert set(p.keys()) == {
+        "id",
+        "title",
+        "description",
+        "price_range",
+        "media",
+        "options",
+        "tags",
+    }
+    # Variants & collections are the big spenders — confirm they're gone.
+    assert "variants" not in p
+    assert "collections" not in p
+    assert "url" not in p
+    # HTML stripped.
+    assert p["description"]["html"] == "Reusable & insulated."
+    # Scaling still works on the kept subtree.
+    assert p["price_range"]["min"]["amount"] == "519.00"
+
+
+# ---------------------------------------------------------------------------
+# Regression: in-place mutation contract — justifies the deep-copy guard
+# in http_handler.py around the apply_response_transforms call. If a
+# transform raises mid-walk, the caller's payload would otherwise be
+# left in a half-transformed state.
+# ---------------------------------------------------------------------------
+
+
+def test_walker_mutates_caller_payload_in_place():
+    """apply_response_transforms MUTATES the input dict in place.
+
+    This is the contract the http_handler deep-copy guard depends on:
+    because mutation is in place, a mid-walk exception would otherwise
+    surface a partially-transformed payload to the LLM. The handler
+    therefore copies before calling and only swaps on success.
+    """
+    import copy as _copy
+
+    data = {"order": {"total": {"amount": 5000}}}
+    snapshot = _copy.deepcopy(data)
+
+    apply_response_transforms(
+        data,
+        [
+            ResponseTransform(
+                path="order.total", fn="scale_by_exponent", args={"exponent": 2}
+            )
+        ],
+    )
+
+    # Same dict identity — mutation was in place
+    assert data["order"]["total"]["amount"] == "50.00"
+    # The snapshot, taken from a deep-copy of the original, was untouched —
+    # i.e. the http_handler's `transformed = copy.deepcopy(data)` pattern
+    # produces a value the original input is decoupled from.
+    assert snapshot["order"]["total"]["amount"] == 5000

--- a/tests/test_session_state.py
+++ b/tests/test_session_state.py
@@ -1,0 +1,510 @@
+"""Tests for the generic session-state engine (reducer + arg injection).
+
+Both engines are commerce-agnostic — the tests assert that an arbitrary
+key shape (cart_id today, foo_handle in a hypothetical other template)
+flows correctly. No commerce logic is hardcoded in the engine.
+"""
+
+from __future__ import annotations
+
+from app.ai.voice.agents.breeze_buddy.template.session_state import (
+    apply_state_reducers,
+    inject_tool_args,
+)
+
+# Order matters: template.types fully loads the template package (whose
+# __init__ pulls in field_resolver / http_requester / hooks) BEFORE we
+# touch the session_state module, otherwise the StateReducer/
+# ToolArgInjection imports trigger handlers.transport.utils.__init__ →
+# field_resolver → template.types again (mid-load) and the import fails.
+from app.ai.voice.agents.breeze_buddy.template.types import (
+    StateReducer,
+    ToolArgInjection,
+)
+
+# ---------------------------------------------------------------------------
+# apply_state_reducers
+# ---------------------------------------------------------------------------
+
+
+def _flow_result(payload: dict, status: str = "success") -> dict:
+    """Wrap a parsed payload in the dispatcher's FlowResult envelope."""
+    import json as _json
+
+    return {"status": status, "data": _json.dumps(payload)}
+
+
+def test_reducer_lifts_single_field_from_payload():
+    state: dict = {}
+    rule = StateReducer(
+        tool_name="update_cart",
+        set_paths={"cart_id": "cart.id"},
+    )
+    result = _flow_result({"cart": {"id": "gid://shopify/Cart/abc"}})
+    out = apply_state_reducers(state, "update_cart", result, [rule])
+    assert out == {"cart_id": "gid://shopify/Cart/abc"}
+
+
+def test_reducer_lifts_multiple_fields_in_one_rule():
+    rule = StateReducer(
+        tool_name="update_cart",
+        set_paths={
+            "cart_id": "cart.id",
+            "checkout_url": "cart.checkout_url",
+            "currency": "cart.cost.total_amount.currency",
+        },
+    )
+    result = _flow_result(
+        {
+            "cart": {
+                "id": "c1",
+                "checkout_url": "https://shop/c/c1",
+                "cost": {"total_amount": {"amount": "49.95", "currency": "INR"}},
+            }
+        }
+    )
+    out = apply_state_reducers({}, "update_cart", result, [rule])
+    assert out["cart_id"] == "c1"
+    assert out["checkout_url"] == "https://shop/c/c1"
+    assert out["currency"] == "INR"
+
+
+def test_reducer_does_not_match_other_tools():
+    rule = StateReducer(tool_name="update_cart", set_paths={"cart_id": "cart.id"})
+    result = _flow_result({"cart": {"id": "x"}})
+    out = apply_state_reducers({}, "search_catalog", result, [rule])
+    assert out == {}
+
+
+def test_reducer_preserves_prior_state_for_unset_paths():
+    rule = StateReducer(tool_name="update_cart", set_paths={"cart_id": "cart.id"})
+    result = _flow_result({"cart": {"id": "new"}})
+    out = apply_state_reducers(
+        {"cart_id": "old", "customer_id": "cust1"},
+        "update_cart",
+        result,
+        [rule],
+    )
+    # cart_id replaced from new payload; customer_id untouched.
+    assert out == {"cart_id": "new", "customer_id": "cust1"}
+
+
+def test_reducer_skips_on_jmespath_no_match():
+    rule = StateReducer(tool_name="update_cart", set_paths={"cart_id": "cart.id"})
+    result = _flow_result({"errors": [{"message": "cart does not exist"}]})
+    out = apply_state_reducers({"cart_id": "kept"}, "update_cart", result, [rule])
+    # cart.id is None — rule skipped; prior state preserved.
+    assert out == {"cart_id": "kept"}
+
+
+def test_reducer_skips_on_error_envelope_when_only_on_success():
+    rule = StateReducer(
+        tool_name="update_cart",
+        set_paths={"cart_id": "cart.id"},
+        only_on_success=True,
+    )
+    result = _flow_result({"cart": {"id": "x"}}, status="error")
+    out = apply_state_reducers({"cart_id": "kept"}, "update_cart", result, [rule])
+    assert out == {"cart_id": "kept"}
+
+
+def test_reducer_applies_on_error_when_only_on_success_false():
+    rule = StateReducer(
+        tool_name="update_cart",
+        set_paths={"cart_id": "cart.id"},
+        only_on_success=False,
+    )
+    result = _flow_result({"cart": {"id": "x"}}, status="error")
+    out = apply_state_reducers({}, "update_cart", result, [rule])
+    assert out == {"cart_id": "x"}
+
+
+def test_reducer_input_state_is_not_mutated():
+    """Engine returns a new dict — callers can safely pass in a live state."""
+    rule = StateReducer(tool_name="update_cart", set_paths={"cart_id": "cart.id"})
+    initial = {"cart_id": "old"}
+    result = _flow_result({"cart": {"id": "new"}})
+    out = apply_state_reducers(initial, "update_cart", result, [rule])
+    assert initial == {"cart_id": "old"}  # untouched
+    assert out == {"cart_id": "new"}
+
+
+def test_reducer_with_empty_rules_returns_copy_of_state():
+    initial = {"cart_id": "x"}
+    out = apply_state_reducers(initial, "any_tool", _flow_result({}), [])
+    assert out == initial
+    assert out is not initial  # still a defensive copy
+
+
+def test_reducer_works_for_arbitrary_non_commerce_key():
+    """The engine is commerce-agnostic — a hypothetical travel template
+    using `booking_handle` works the same."""
+    rule = StateReducer(
+        tool_name="book_flight",
+        set_paths={"booking_handle": "reservation.handle"},
+    )
+    result = _flow_result({"reservation": {"handle": "PNR-XYZ123"}})
+    out = apply_state_reducers({}, "book_flight", result, [rule])
+    assert out == {"booking_handle": "PNR-XYZ123"}
+
+
+# ---------------------------------------------------------------------------
+# inject_tool_args
+# ---------------------------------------------------------------------------
+
+
+def test_injection_fills_missing_arg_from_state():
+    rule = ToolArgInjection(
+        tool_name="update_cart",
+        set_paths={"cart_id": "state.data.cart_id"},
+    )
+    out = inject_tool_args(
+        tool_name="update_cart",
+        args={"add_items": [{"product_variant_id": "v1", "quantity": 1}]},
+        state_data={"cart_id": "c1"},
+        chat_session_id="sess-uuid",
+        injections=[rule],
+    )
+    assert out["cart_id"] == "c1"
+    assert out["add_items"] == [{"product_variant_id": "v1", "quantity": 1}]
+
+
+def test_injection_preserves_explicit_llm_value_by_default():
+    """only_if_missing=True (default) — LLM's value wins."""
+    rule = ToolArgInjection(
+        tool_name="update_cart",
+        set_paths={"cart_id": "state.data.cart_id"},
+    )
+    out = inject_tool_args(
+        tool_name="update_cart",
+        args={"cart_id": "llm-provided"},
+        state_data={"cart_id": "from-state"},
+        chat_session_id="sess",
+        injections=[rule],
+    )
+    assert out["cart_id"] == "llm-provided"
+
+
+def test_injection_force_override_when_only_if_missing_false():
+    rule = ToolArgInjection(
+        tool_name="update_cart",
+        set_paths={"cart_id": "state.data.cart_id"},
+        only_if_missing=False,
+    )
+    out = inject_tool_args(
+        tool_name="update_cart",
+        args={"cart_id": "llm-hallucinated"},
+        state_data={"cart_id": "canonical"},
+        chat_session_id="sess",
+        injections=[rule],
+    )
+    assert out["cart_id"] == "canonical"
+
+
+def test_injection_no_state_value_leaves_args_alone():
+    """No source value → rule no-ops; the dispatcher hits the upstream
+    without cart_id, which lets the MCP server mint a new one
+    (the existing fallback path)."""
+    rule = ToolArgInjection(
+        tool_name="update_cart",
+        set_paths={"cart_id": "state.data.cart_id"},
+    )
+    out = inject_tool_args(
+        tool_name="update_cart",
+        args={"add_items": []},
+        state_data={},  # no cart_id yet
+        chat_session_id="sess",
+        injections=[rule],
+    )
+    assert "cart_id" not in out
+    assert out == {"add_items": []}
+
+
+def test_injection_only_matches_named_tool():
+    rule = ToolArgInjection(
+        tool_name="update_cart",
+        set_paths={"cart_id": "state.data.cart_id"},
+    )
+    out = inject_tool_args(
+        tool_name="search_catalog",
+        args={"query": "snowboard"},
+        state_data={"cart_id": "c1"},
+        chat_session_id="sess",
+        injections=[rule],
+    )
+    assert "cart_id" not in out
+
+
+def test_injection_can_read_session_id():
+    """A future _meta-injection target can pull the session id directly."""
+    rule = ToolArgInjection(
+        tool_name="any_tool",
+        set_paths={"buddy_session_id": "session_id"},
+    )
+    out = inject_tool_args(
+        tool_name="any_tool",
+        args={},
+        state_data={},
+        chat_session_id="abc-123",
+        injections=[rule],
+    )
+    assert out["buddy_session_id"] == "abc-123"
+
+
+def test_injection_args_not_mutated():
+    """inject_tool_args returns a copy — caller's args dict is safe."""
+    rule = ToolArgInjection(
+        tool_name="update_cart",
+        set_paths={"cart_id": "state.data.cart_id"},
+    )
+    original = {"add_items": [{"qty": 1}]}
+    out = inject_tool_args(
+        tool_name="update_cart",
+        args=original,
+        state_data={"cart_id": "c1"},
+        chat_session_id="sess",
+        injections=[rule],
+    )
+    assert "cart_id" not in original
+    assert out["cart_id"] == "c1"
+
+
+def test_injection_with_empty_rules_returns_copy_of_args():
+    original = {"a": 1}
+    out = inject_tool_args(
+        tool_name="x",
+        args=original,
+        state_data={},
+        chat_session_id="s",
+        injections=[],
+    )
+    assert out == original
+    assert out is not original
+
+
+# ---------------------------------------------------------------------------
+# Generators (uuid_v4, timestamps, …) — commerce-agnostic
+# ---------------------------------------------------------------------------
+
+
+def test_injection_generator_uuid_v4_fills_missing_arg():
+    """S3.2: idempotency-key style — engine stamps a fresh UUID when
+    the LLM didn't provide one."""
+    import uuid as _uuid
+
+    rule = ToolArgInjection(
+        tool_name="create_cart",
+        generators={"idempotency_key": "uuid_v4"},
+    )
+    out = inject_tool_args(
+        tool_name="create_cart",
+        args={"cart": {"line_items": []}},
+        state_data={},
+        chat_session_id="sess",
+        injections=[rule],
+    )
+    assert "idempotency_key" in out
+    # Round-trips as a UUID and is a v4
+    parsed = _uuid.UUID(out["idempotency_key"])
+    assert parsed.version == 4
+
+
+def test_injection_generator_respects_only_if_missing():
+    rule = ToolArgInjection(
+        tool_name="create_cart",
+        generators={"idempotency_key": "uuid_v4"},
+    )
+    out = inject_tool_args(
+        tool_name="create_cart",
+        args={"idempotency_key": "caller-supplied"},
+        state_data={},
+        chat_session_id="sess",
+        injections=[rule],
+    )
+    # Caller value wins — same discipline as set_paths
+    assert out["idempotency_key"] == "caller-supplied"
+
+
+def test_injection_generator_force_override():
+    rule = ToolArgInjection(
+        tool_name="create_cart",
+        generators={"idempotency_key": "uuid_v4"},
+        only_if_missing=False,
+    )
+    out = inject_tool_args(
+        tool_name="create_cart",
+        args={"idempotency_key": "stale-value"},
+        state_data={},
+        chat_session_id="sess",
+        injections=[rule],
+    )
+    assert out["idempotency_key"] != "stale-value"
+
+
+def test_injection_generator_unknown_name_is_silently_skipped():
+    """An unknown generator name should not crash the turn — it logs
+    a warning and leaves the arg dict alone (same defensive stance as
+    set_paths)."""
+    rule = ToolArgInjection(
+        tool_name="x",
+        generators={"foo": "not_a_real_generator"},
+    )
+    out = inject_tool_args(
+        tool_name="x",
+        args={},
+        state_data={},
+        chat_session_id="sess",
+        injections=[rule],
+    )
+    assert "foo" not in out
+
+
+def test_injection_generator_each_call_produces_fresh_value():
+    rule = ToolArgInjection(
+        tool_name="x",
+        generators={"req_id": "uuid_v4"},
+    )
+    a = inject_tool_args(
+        tool_name="x", args={}, state_data={}, chat_session_id="s", injections=[rule]
+    )
+    b = inject_tool_args(
+        tool_name="x", args={}, state_data={}, chat_session_id="s", injections=[rule]
+    )
+    assert a["req_id"] != b["req_id"]
+
+
+def test_injection_generator_timestamp_iso8601():
+    rule = ToolArgInjection(
+        tool_name="x",
+        generators={"ts": "timestamp_iso8601"},
+    )
+    out = inject_tool_args(
+        tool_name="x", args={}, state_data={}, chat_session_id="s", injections=[rule]
+    )
+    # ISO-8601 UTC like 2026-05-20T12:34:56.789012+00:00
+    assert "T" in out["ts"]
+    assert out["ts"].endswith("+00:00")
+
+
+def test_injection_generator_timestamp_unix_ms():
+    rule = ToolArgInjection(
+        tool_name="x",
+        generators={"ts": "timestamp_unix_ms"},
+    )
+    out = inject_tool_args(
+        tool_name="x", args={}, state_data={}, chat_session_id="s", injections=[rule]
+    )
+    assert isinstance(out["ts"], int)
+    # Sanity: ~13 digits for ms since epoch in this era
+    assert 1_700_000_000_000 < out["ts"] < 4_000_000_000_000
+
+
+def test_injection_set_paths_and_generators_coexist_on_one_rule():
+    """update_cart needs cart_id from state AND a fresh idempotency_key —
+    both in one rule."""
+    rule = ToolArgInjection(
+        tool_name="update_cart",
+        set_paths={"id": "state.data.cart_id"},
+        generators={"idempotency_key": "uuid_v4"},
+    )
+    out = inject_tool_args(
+        tool_name="update_cart",
+        args={"cart": {"line_items": [{"item": {"id": "gid://Shopify/v1"}}]}},
+        state_data={"cart_id": "c-123"},
+        chat_session_id="sess",
+        injections=[rule],
+    )
+    assert out["id"] == "c-123"
+    assert "idempotency_key" in out
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: simulate the reported failure scenario
+# ---------------------------------------------------------------------------
+
+
+def test_full_lifecycle_reproduces_the_fix():
+    """The exact failure mode from logs.txt:
+    1) update_cart creates a cart, returns cart.id = c1
+    2) next turn, LLM omits cart_id (or hallucinates one)
+    3) without the engine: server returns "cart does not exist"
+    4) with the engine: state.data.cart_id is c1; injection fills it
+    """
+    reducer = StateReducer(
+        tool_name="update_cart",
+        set_paths={"cart_id": "cart.id"},
+    )
+    injection = ToolArgInjection(
+        tool_name="update_cart",
+        set_paths={"cart_id": "state.data.cart_id"},
+    )
+
+    # Turn 1: LLM calls update_cart(add_items=[snowboard]); MCP creates a cart.
+    state: dict = {}
+    turn1_args = {"add_items": [{"product_variant_id": "snowboard_v", "quantity": 1}]}
+    # No cart_id in args yet, no cart_id in state — injection is no-op.
+    injected = inject_tool_args("update_cart", turn1_args, state, "sess", [injection])
+    assert "cart_id" not in injected
+
+    # Server returns a fresh cart.
+    result = _flow_result(
+        {
+            "cart": {
+                "id": "gid://shopify/Cart/hWNCJg...",
+                "checkout_url": "https://shop/c/hWNCJg",
+            }
+        }
+    )
+    state = apply_state_reducers(state, "update_cart", result, [reducer])
+    assert state["cart_id"] == "gid://shopify/Cart/hWNCJg..."
+
+    # Turn 2: LLM calls update_cart(add_items=[wax]) — forgets cart_id.
+    turn2_args = {"add_items": [{"product_variant_id": "wax_v", "quantity": 1}]}
+    injected = inject_tool_args("update_cart", turn2_args, state, "sess", [injection])
+    # Engine fills it from session state — no more hallucination / orphan carts.
+    assert injected["cart_id"] == "gid://shopify/Cart/hWNCJg..."
+    assert injected["add_items"] == [{"product_variant_id": "wax_v", "quantity": 1}]
+
+
+# ---------------------------------------------------------------------------
+# Regression: idempotency_hash must hash post-injection args
+# ---------------------------------------------------------------------------
+
+
+def test_idempotency_hash_includes_injected_set_paths():
+    """Regression: hash was previously computed from the original LLM args,
+    missing any cart_id (or other id) injected by ``set_paths`` in the same
+    rule. Two materially different dispatched requests would then collide
+    on the same idempotency key and the second would be no-op'd by the
+    upstream server.
+    """
+    rule = ToolArgInjection(
+        tool_name="update_cart",
+        set_paths={"cart_id": "state.data.cart_id"},
+        generators={"idempotency_key": "idempotency_hash"},
+    )
+    base_args = {"add_items": [{"product_variant_id": "v1", "quantity": 1}]}
+
+    # Same LLM args, different state cart_ids — must produce different hashes.
+    out_a = inject_tool_args(
+        tool_name="update_cart",
+        args=dict(base_args),
+        state_data={"cart_id": "cart-A"},
+        chat_session_id="sess",
+        turn_id="turn-1",
+        injections=[rule],
+    )
+    out_b = inject_tool_args(
+        tool_name="update_cart",
+        args=dict(base_args),
+        state_data={"cart_id": "cart-B"},
+        chat_session_id="sess",
+        turn_id="turn-1",
+        injections=[rule],
+    )
+    assert out_a["cart_id"] == "cart-A"
+    assert out_b["cart_id"] == "cart-B"
+    assert out_a["idempotency_key"] != out_b["idempotency_key"], (
+        "hash must include the injected cart_id; two distinct carts "
+        "produced the same idempotency key"
+    )

--- a/tests/test_tile_validation.py
+++ b/tests/test_tile_validation.py
@@ -1,0 +1,254 @@
+# pyrefly: ignore-errors
+# Pydantic dynamic-attribute noise: validate_props("Tile", ...) returns
+# _CatalogBase per its signature; pyrefly can't narrow on string dispatch,
+# so concrete subclass attrs (.title, .body, .actions, etc.) read as
+# missing-attribute even though runtime resolves them fine.
+"""Tests for the Tile composite primitive's Pydantic schema.
+
+Covers:
+  * Full-fixture happy path covering every slot.
+  * Required ``title`` enforcement.
+  * Polymorphic ``body`` items — each ``kind`` validates the matching field.
+  * Minimal happy case (title + one money body row).
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from app.ai.voice.agents.breeze_buddy.template.ui_catalog import validate_props
+
+# ---------------------------------------------------------------------------
+# Happy path: full Tile shape
+# ---------------------------------------------------------------------------
+
+
+def test_validate_full_tile_with_all_slots():
+    props = {
+        "media": {
+            "src": "https://cdn.example.com/snowboard.jpg",
+            "alt": "snowboard",
+            "aspect": "1:1",
+        },
+        "eyebrow": "NEW",
+        "title": "The Complete Snowboard",
+        "subtitle": "Limited edition release",
+        "body": [
+            {"kind": "text", "text": "Hand-built with sustainable materials."},
+            {"kind": "key_value", "key": "Price", "value": "₹699.95"},
+            {"kind": "key_value", "key": "Material", "value": "Wood + epoxy"},
+            {
+                "kind": "message",
+                "message": {
+                    "severity": "warning",
+                    "resolution": "recoverable",
+                    "content": "Low stock",
+                },
+            },
+        ],
+        "attributes": [
+            {"label": "Premium", "tone": "info"},
+            {"label": "Eco", "tone": "positive"},
+        ],
+        "actions": [
+            {
+                "label": "Add to cart",
+                "action": {"type": "to_assistant", "msg": "Add board to cart"},
+                "variant": "primary",
+            }
+        ],
+        "density": "spacious",
+    }
+    tile = validate_props("Tile", props)
+    assert tile.title == "The Complete Snowboard"
+    assert tile.density == "spacious"
+    assert len(tile.body) == 4
+    assert tile.body[1].value == "₹699.95"
+    assert tile.body[2].key == "Material"
+    assert len(tile.attributes) == 2
+    assert tile.actions[0].label == "Add to cart"
+
+
+# ---------------------------------------------------------------------------
+# Required-field enforcement
+# ---------------------------------------------------------------------------
+
+
+def test_validate_tile_rejects_missing_title():
+    """``title`` is the only required slot on a Tile."""
+    props = {
+        "body": [{"kind": "text", "text": "no title here"}],
+    }
+    with pytest.raises(ValidationError) as exc_info:
+        validate_props("Tile", props)
+    # The error must reference the missing title field.
+    assert "title" in str(exc_info.value).lower()
+
+
+def test_validate_tile_rejects_empty_title():
+    """``min_length=1`` rejects an empty string just like missing."""
+    with pytest.raises(ValidationError):
+        validate_props("Tile", {"title": ""})
+
+
+# ---------------------------------------------------------------------------
+# Minimal happy case
+# ---------------------------------------------------------------------------
+
+
+def test_validate_minimal_tile_title_plus_key_value_body():
+    """The shape canonical.template.json's search_catalog instruction tells
+    the LLM to emit — title + one key_value body row, nothing else."""
+    tile = validate_props(
+        "Tile",
+        {
+            "title": "Foo",
+            "body": [{"kind": "key_value", "key": "Price", "value": "₹699.95"}],
+        },
+    )
+    assert tile.title == "Foo"
+    assert tile.body[0].kind.value == "key_value"
+    assert tile.body[0].key == "Price"
+    assert tile.body[0].value == "₹699.95"
+    # Density defaults to "default" — not required at the wire layer.
+    assert tile.density == "default"
+
+
+def test_validate_minimal_tile_just_title():
+    """Title alone is enough — every other slot is optional."""
+    tile = validate_props("Tile", {"title": "Bare"})
+    assert tile.title == "Bare"
+    assert tile.body == []
+    assert tile.attributes == []
+    assert tile.actions == []
+    assert tile.media is None
+
+
+# ---------------------------------------------------------------------------
+# Polymorphic body items — each kind validates correctly
+# ---------------------------------------------------------------------------
+
+
+def test_body_kind_text():
+    tile = validate_props(
+        "Tile",
+        {
+            "title": "T",
+            "body": [{"kind": "text", "text": "A paragraph of body copy."}],
+        },
+    )
+    assert tile.body[0].text == "A paragraph of body copy."
+
+
+def test_body_kind_key_value():
+    tile = validate_props(
+        "Tile",
+        {
+            "title": "T",
+            "body": [{"kind": "key_value", "key": "Color", "value": "Cobalt blue"}],
+        },
+    )
+    assert tile.body[0].key == "Color"
+    assert tile.body[0].value == "Cobalt blue"
+
+
+def test_body_kind_message():
+    tile = validate_props(
+        "Tile",
+        {
+            "title": "T",
+            "body": [
+                {
+                    "kind": "message",
+                    "message": {
+                        "severity": "info",
+                        "resolution": "recoverable",
+                        "content": "Heads up: low stock.",
+                    },
+                }
+            ],
+        },
+    )
+    assert tile.body[0].message.content == "Heads up: low stock."
+
+
+def test_body_rejects_unknown_kind():
+    with pytest.raises(ValidationError):
+        validate_props(
+            "Tile",
+            {
+                "title": "T",
+                "body": [{"kind": "bogus", "text": "x"}],
+            },
+        )
+
+
+def test_body_rejects_extra_props_inside_item():
+    """``extra='forbid'`` on TileBodyItem catches typos / hallucinated fields."""
+    with pytest.raises(ValidationError):
+        validate_props(
+            "Tile",
+            {
+                "title": "T",
+                "body": [
+                    {
+                        "kind": "text",
+                        "text": "hi",
+                        "weight": "bold",  # not a valid TileBodyItem field
+                    }
+                ],
+            },
+        )
+
+
+def test_tile_rejects_unknown_top_level_prop():
+    """The renderer healer relies on ``extra='forbid'`` to strip noise."""
+    with pytest.raises(ValidationError):
+        validate_props(
+            "Tile",
+            {
+                "title": "T",
+                "footnote": "unsupported slot",
+            },
+        )
+
+
+# ---------------------------------------------------------------------------
+# Action variant validation
+# ---------------------------------------------------------------------------
+
+
+def test_tile_action_to_assistant():
+    tile = validate_props(
+        "Tile",
+        {
+            "title": "T",
+            "actions": [
+                {
+                    "label": "View",
+                    "action": {"type": "to_assistant", "msg": "Tell me about T"},
+                }
+            ],
+        },
+    )
+    assert tile.actions[0].action.msg == "Tell me about T"
+    # variant defaults to "primary"
+    assert tile.actions[0].variant == "primary"
+
+
+def test_tile_action_open_url():
+    tile = validate_props(
+        "Tile",
+        {
+            "title": "T",
+            "actions": [
+                {
+                    "label": "Docs",
+                    "action": {"type": "open_url", "url": "https://example.com/"},
+                    "variant": "ghost",
+                }
+            ],
+        },
+    )
+    assert tile.actions[0].variant == "ghost"

--- a/tests/test_tool_result_normalizer.py
+++ b/tests/test_tool_result_normalizer.py
@@ -1,0 +1,77 @@
+"""Tests for app.ai.voice.agents.breeze_buddy.chat.tool_result_normalizer.
+
+Self-contained: stdlib + the normalizer module only.  Run with::
+
+    uv run pytest tests/test_tool_result_normalizer.py -v
+
+The module's job is now solely to peel the Clairvoyance + pipecat MCP
+envelope; per-tool shaping (numeric scaling, field flattening, image
+precedence) lives in the template's ``tool_response_transforms``.
+"""
+
+import json
+
+from app.ai.voice.agents.breeze_buddy.chat.tool_result_normalizer import normalize
+
+
+def _wrap(inner) -> dict:
+    """Clairvoyance + pipecat MCP envelope."""
+    return {"status": "success", "data": json.dumps(inner)}
+
+
+class TestEnvelopeUnwrap:
+    def test_unwraps_success_envelope_to_inner_dict(self):
+        inner = {"products": [{"id": "gid://shopify/Product/1", "title": "Board"}]}
+        assert normalize("search_catalog", _wrap(inner)) == inner
+
+    def test_inner_payload_passes_through_untouched(self):
+        # No per-tool flattening — raw MCP shape is preserved verbatim so the
+        # LLM can reference fields like ``data.products[0].price_range.min.amount``.
+        inner = {
+            "products": [
+                {
+                    "id": "gid://shopify/Product/1",
+                    "title": "Snowboard",
+                    "price_range": {"min": {"amount": 69995, "currency": "INR"}},
+                    "media": [
+                        {"type": "image", "url": "https://cdn.example.com/x.jpg"}
+                    ],
+                }
+            ]
+        }
+        out = normalize("search_catalog", _wrap(inner))
+        assert out == inner
+        # Raw minor-unit price is preserved (no server-side scaling).
+        assert out["products"][0]["price_range"]["min"]["amount"] == 69995
+
+    def test_error_status_returns_raw_envelope(self):
+        payload = {"status": "error", "data": json.dumps({"products": []})}
+        # Cannot unwrap an error envelope → fall back to the raw payload so
+        # the LLM still sees *something* and the turn doesn't blow up.
+        assert normalize("search_catalog", payload) == payload
+
+    def test_malformed_json_in_data_returns_raw_envelope(self):
+        payload = {"status": "success", "data": "this is not json {"}
+        assert normalize("search_catalog", payload) == payload
+
+    def test_unenveloped_dict_passes_through(self):
+        raw = {"products": [{"id": "1", "title": "x"}]}
+        assert normalize("search_catalog", raw) == raw
+
+    def test_non_dict_input_returned_as_is(self):
+        assert normalize("search_catalog", "not a dict") == "not a dict"
+        assert normalize("search_catalog", None) is None
+        assert normalize("search_catalog", 42) == 42
+
+    def test_tool_name_is_ignored(self):
+        # The signature keeps ``tool_name`` for forward-compat with future
+        # per-tool hooks, but no current behaviour depends on it.
+        payload = _wrap({"cart": {"id": "gid://shopify/Cart/1"}})
+        assert normalize("get_cart", payload) == normalize("anything_else", payload)
+        assert normalize("", payload) == {"cart": {"id": "gid://shopify/Cart/1"}}
+
+    def test_nested_envelope_data_already_dict(self):
+        # Some callers may bypass the pipecat stringification layer.
+        inner = {"cart": {"id": "gid://shopify/Cart/9", "lines": []}}
+        payload = {"status": "success", "data": inner}
+        assert normalize("get_cart", payload) == inner

--- a/tests/test_ui_catalog_groups.py
+++ b/tests/test_ui_catalog_groups.py
@@ -1,0 +1,125 @@
+"""Tests for the UI-catalog group registry + allowlist resolver.
+
+Covers:
+  * ``resolve_allowlist`` — default ("core" only), groups + primitives mix,
+    disabled overrides, unknown group/primitive tolerance.
+  * ``group_for`` — primitive → group reverse lookup.
+"""
+
+from __future__ import annotations
+
+# Load template package first so its __init__ chain completes before any
+# `chat/*` module imports (mirrors test_ui_stream / test_session_state).
+from app.ai.voice.agents.breeze_buddy.template.ui_catalog import (
+    PRIMITIVE_GROUPS,
+    UI_CATALOG,
+    group_for,
+    resolve_allowlist,
+)
+
+# ---------------------------------------------------------------------------
+# resolve_allowlist
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_default_returns_core_group_only():
+    """When called with no args, defaults to just the 'core' group — the
+    backward-compat behaviour for templates predating ``ui_catalog``."""
+    result = resolve_allowlist()
+    expected = set(PRIMITIVE_GROUPS["core"])
+    assert result == expected
+    # Composite primitives (e.g. Tile) must NOT leak in.
+    assert "Tile" not in result
+
+
+def test_resolve_groups_core_plus_composite_includes_tile():
+    result = resolve_allowlist(enabled_groups=["core", "composite"])
+    assert "Tile" in result
+    # Sanity: still has all core primitives.
+    for prim in PRIMITIVE_GROUPS["core"]:
+        assert prim in result
+
+
+def test_resolve_disabled_primitive_subtracts_from_group():
+    """``disabled_primitives`` wins over ``enabled_groups``."""
+    result = resolve_allowlist(enabled_groups=["core"], disabled_primitives=["Table"])
+    assert "Table" not in result
+    # Everything else core remains.
+    for prim in PRIMITIVE_GROUPS["core"]:
+        if prim == "Table":
+            continue
+        assert prim in result
+
+
+def test_resolve_enabled_primitive_without_group():
+    """``enabled_primitives`` adds one-offs even when no group is enabled."""
+    result = resolve_allowlist(enabled_primitives=["Tile"])
+    assert result == {"Tile"}
+
+
+def test_resolve_unknown_group_is_silently_dropped():
+    """Stale templates referencing a removed group don't crash a session."""
+    result = resolve_allowlist(enabled_groups=["nonexistent"])
+    assert result == set()
+
+
+def test_resolve_unknown_primitive_in_enabled_is_dropped():
+    """Stale templates referencing a removed primitive don't crash either."""
+    result = resolve_allowlist(enabled_primitives=["NotAPrimitive", "Tile"])
+    assert result == {"Tile"}
+
+
+def test_resolve_combined_groups_and_primitives_with_disabled():
+    """Full precedence walk — groups expand, primitives union, disabled subtract."""
+    result = resolve_allowlist(
+        enabled_groups=["core"],
+        enabled_primitives=["Tile"],
+        disabled_primitives=["Table", "Message"],
+    )
+    assert "Tile" in result  # added by enabled_primitives
+    assert "Table" not in result  # subtracted
+    assert "Message" not in result  # subtracted
+    assert "Stack" in result  # core, not subtracted
+
+
+# ---------------------------------------------------------------------------
+# group_for
+# ---------------------------------------------------------------------------
+
+
+def test_group_for_composite_returns_composite():
+    assert group_for("Tile") == "composite"
+
+
+def test_group_for_core_primitives_returns_core():
+    assert group_for("Text") == "core"
+    assert group_for("Stack") == "core"
+    assert group_for("Carousel") == "core"
+
+
+def test_money_is_not_a_registered_primitive():
+    """Money was deleted as a commerce leak — the runtime ships zero
+    commerce-tinted primitives."""
+    assert "Money" not in UI_CATALOG
+    assert group_for("Money") is None
+
+
+def test_group_for_unknown_returns_none():
+    assert group_for("Foo") is None
+    assert group_for("ProductCarousel") is None
+
+
+# ---------------------------------------------------------------------------
+# Catalog x group registry consistency
+# ---------------------------------------------------------------------------
+
+
+def test_every_group_member_is_registered_in_catalog():
+    """No group should reference a primitive that isn't in UI_CATALOG."""
+    catalog_keys = set(UI_CATALOG.keys())
+    for group_name, members in PRIMITIVE_GROUPS.items():
+        for prim in members:
+            assert prim in catalog_keys, (
+                f"group {group_name!r} references {prim!r} "
+                f"which is not registered in UI_CATALOG"
+            )

--- a/tests/test_ui_healer.py
+++ b/tests/test_ui_healer.py
@@ -1,0 +1,188 @@
+"""Tests for the in-stream healer — one rule per test."""
+
+from __future__ import annotations
+
+from app.ai.voice.agents.breeze_buddy.chat.ui_healer import (
+    HealerContext,
+    heal_op_line,
+)
+
+# Load template package before chat/* modules — same circular-import trap.
+from app.ai.voice.agents.breeze_buddy.template.ui_catalog import (  # noqa: F401
+    UI_CATALOG,
+)
+
+
+def _ctx(**overrides) -> HealerContext:
+    return HealerContext(
+        session_data=overrides.get("session_data", {}),
+        known_ids=overrides.get("known_ids", set()),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Drop rules
+# ---------------------------------------------------------------------------
+
+
+def test_healer_drops_unknown_type():
+    r = heal_op_line(
+        '{"op":"add","id":"x","type":"NotARealPrimitive","parent":"root"}',
+        _ctx(known_ids={"root"}),
+    )
+    assert r.drop is True
+    assert any(n.startswith("dropped_unknown_type") for n in r.notes)
+
+
+def test_healer_drops_orphan_non_root_add():
+    r = heal_op_line(
+        '{"op":"add","id":"x","type":"Text","props":{"text":"hi"}}',
+        _ctx(known_ids=set()),
+    )
+    assert r.drop is True
+    assert "dropped_orphan_add" in r.notes
+
+
+def test_healer_keeps_root_op_without_parent():
+    r = heal_op_line(
+        '{"op":"add","id":"root","type":"Carousel"}',
+        _ctx(known_ids=set()),
+    )
+    assert r.drop is False
+    assert r.line is not None
+
+
+def test_healer_drops_malformed_json():
+    r = heal_op_line('{"op":"add"', _ctx())
+    assert r.drop is True
+    assert any(n.startswith("dropped_malformed_json") for n in r.notes)
+
+
+# ---------------------------------------------------------------------------
+# Transform rules
+# ---------------------------------------------------------------------------
+
+
+def test_healer_strips_unknown_props():
+    r = heal_op_line(
+        '{"op":"add","id":"t1","type":"Tag","parent":"root","props":{"text":"Premium","weight":"bold"}}',
+        _ctx(known_ids={"root"}),
+    )
+    assert r.drop is False
+    assert any(n.startswith("stripped_unknown_props:weight") for n in r.notes)
+    import json
+
+    out = json.loads(r.line)  # type: ignore[arg-type]
+    assert "weight" not in out["props"]
+    assert out["props"]["text"] == "Premium"
+
+
+def test_healer_button_default_label():
+    r = heal_op_line(
+        '{"op":"add","id":"b1","type":"Button","parent":"root","props":{"action":{"type":"to_assistant","msg":"hi"}}}',
+        _ctx(known_ids={"root"}),
+    )
+    assert r.drop is False
+    import json
+
+    out = json.loads(r.line)  # type: ignore[arg-type]
+    assert out["props"]["label"] == "Continue"
+    assert any(n == "button_default_label" for n in r.notes)
+
+
+def test_healer_tag_flattens_array_text():
+    r = heal_op_line(
+        '{"op":"add","id":"t1","type":"Tag","parent":"root","props":{"text":"[\\"new\\", \\"sale\\"]"}}',
+        _ctx(known_ids={"root"}),
+    )
+    assert r.drop is False
+    import json
+
+    out = json.loads(r.line)  # type: ignore[arg-type]
+    assert out["props"]["text"] == "new, sale"
+    assert any(n == "tag_flattened_array_text" for n in r.notes)
+
+
+def test_healer_dedupes_id():
+    known = {"c1"}
+    r = heal_op_line(
+        '{"op":"add","id":"c1","type":"Card","parent":"root"}',
+        _ctx(known_ids=known | {"root"}),
+    )
+    assert r.drop is False
+    import json
+
+    out = json.loads(r.line)  # type: ignore[arg-type]
+    assert out["id"] == "c1__2"
+    assert any(n.startswith("renamed_duplicate_id:c1->c1__2") for n in r.notes)
+
+
+def test_healer_passthrough_clean_line():
+    r = heal_op_line(
+        '{"op":"add","id":"root","type":"Stack","props":{"gap":"md"}}',
+        _ctx(),
+    )
+    assert r.drop is False
+    assert r.notes == []
+    assert r.line is not None
+
+
+# ---------------------------------------------------------------------------
+# Alias rename — derived from real-traffic ui_op_dropped telemetry
+# ---------------------------------------------------------------------------
+
+
+def test_healer_renames_tag_label_to_text():
+    """The single most common real-traffic miss: Tag.props.label → Tag.text."""
+    r = heal_op_line(
+        '{"op":"add","id":"t1","type":"Tag","parent":"root","props":{"label":"Premium"}}',
+        _ctx(known_ids={"root"}),
+    )
+    assert r.drop is False
+    import json
+
+    out = json.loads(r.line)  # type: ignore[arg-type]
+    assert out["props"]["text"] == "Premium"
+    assert "label" not in out["props"]
+    assert any("renamed_alias_props:Tag:label->text" in n for n in r.notes)
+
+
+def test_healer_renames_text_content_to_text():
+    """Legacy DSL-era prop: Text.props.content → Text.props.text."""
+    r = heal_op_line(
+        '{"op":"add","id":"x","type":"Text","parent":"root","props":{"content":"Hello","variant":"heading"}}',
+        _ctx(known_ids={"root"}),
+    )
+    assert r.drop is False
+    import json
+
+    out = json.loads(r.line)  # type: ignore[arg-type]
+    assert out["props"]["text"] == "Hello"
+
+
+def test_healer_renames_image_url_to_src_and_title_to_alt():
+    r = heal_op_line(
+        '{"op":"add","id":"i","type":"Image","parent":"root","props":{"url":"https://x/y.jpg","title":"a snowboard"}}',
+        _ctx(known_ids={"root"}),
+    )
+    assert r.drop is False
+    import json
+
+    out = json.loads(r.line)  # type: ignore[arg-type]
+    assert out["props"]["src"] == "https://x/y.jpg"
+    assert out["props"]["alt"] == "a snowboard"
+
+
+def test_healer_alias_does_not_override_canonical_when_both_present():
+    """LLM intent wins: if `text` is already set, don't overwrite from `label`."""
+    r = heal_op_line(
+        '{"op":"add","id":"t1","type":"Tag","parent":"root","props":{"text":"explicit","label":"fallback"}}',
+        _ctx(known_ids={"root"}),
+    )
+    assert r.drop is False
+    import json
+
+    out = json.loads(r.line)  # type: ignore[arg-type]
+    assert out["props"]["text"] == "explicit"
+    # `label` was stripped (unknown prop), not renamed.
+    assert "label" not in out["props"]

--- a/tests/test_ui_prompt.py
+++ b/tests/test_ui_prompt.py
@@ -1,0 +1,156 @@
+"""Tests for the per-template "## Available primitives" renderer.
+
+The renderer walks the catalog's curated render order, drops names not
+in the session's allowlist, and emits a Markdown section the chat agent
+splices into the system prompt. These tests pin the load-bearing
+behaviours: section header / footer presence, per-primitive entries,
+allowlist filtering, and the empty-state fallback.
+"""
+
+from __future__ import annotations
+
+import json
+
+# Load the template package before any chat/* module reaches it — same
+# circular-import precaution as the sibling ui_stream / ui_healer tests.
+from app.ai.voice.agents.breeze_buddy.template.ui_catalog import (  # noqa: F401
+    PRIMITIVE_RENDER_ORDER,
+    UI_CATALOG,
+    validate_props,
+)
+from app.ai.voice.agents.breeze_buddy.template.ui_prompt import (
+    render_primitives_section,
+)
+
+# ---------------------------------------------------------------------------
+# Allowlist filtering
+# ---------------------------------------------------------------------------
+
+
+def test_section_includes_only_allowlisted_primitives():
+    section = render_primitives_section({"Tile", "Carousel", "Tag"})
+    # Headings appear for each allowlisted primitive.
+    assert "**Tile**" in section
+    assert "**Carousel**" in section
+    assert "**Tag**" in section
+    # And do NOT appear for primitives outside the allowlist. We check
+    # the bold-marked header form to avoid false positives on prose
+    # mentions (the footer mentions Tile/Card/Image/Text by name).
+    assert "**Stack**" not in section
+    assert "**Card**" not in section
+    assert "**Image**" not in section
+    assert "**Text**" not in section
+    assert "**Table**" not in section
+    assert "**Message**" not in section
+    assert "**Handoff**" not in section
+    assert "**Button**" not in section
+
+
+def test_section_renders_in_curated_order():
+    # Tile is rendered before Carousel before Tag per PRIMITIVE_RENDER_ORDER.
+    section = render_primitives_section({"Tag", "Carousel", "Tile"})
+    tile_idx = section.index("**Tile**")
+    carousel_idx = section.index("**Carousel**")
+    tag_idx = section.index("**Tag**")
+    assert tile_idx < carousel_idx < tag_idx
+
+
+# ---------------------------------------------------------------------------
+# Tile entry — slot names matter for the JIT pattern
+# ---------------------------------------------------------------------------
+
+
+def test_tile_entry_mentions_all_slot_names():
+    section = render_primitives_section({"Tile"})
+    # The Tile renderer relies on these slot names being visible to the
+    # LLM. Pin them — if a future schema renames a slot, this test
+    # forces the prompt rendering to catch up.
+    for slot in (
+        "media",
+        "eyebrow",
+        "title",
+        "subtitle",
+        "body",
+        "attributes",
+        "actions",
+    ):
+        assert slot in section, f"missing Tile slot: {slot}"
+
+
+def test_tile_entry_marks_title_required():
+    section = render_primitives_section({"Tile"})
+    # ``title*`` with the asterisk marker.
+    assert "title*:" in section
+
+
+def test_tile_entry_marks_media_optional():
+    section = render_primitives_section({"Tile"})
+    assert "media?:" in section
+
+
+def test_tile_example_validates_against_catalog():
+    """The hard-coded example must round-trip through validate_props
+    cleanly, otherwise we'd be teaching the LLM an invalid shape."""
+    section = render_primitives_section({"Tile"})
+    # Pull the JSON after the "Example: " marker for the Tile entry.
+    tile_block = section.split("**Tile**", 1)[1]
+    example_line = next(
+        line for line in tile_block.splitlines() if line.strip().startswith("Example:")
+    )
+    payload = json.loads(example_line.split("Example:", 1)[1].strip())
+    assert payload["type"] == "Tile"
+    # Server-side validator must accept the example props.
+    validate_props("Tile", payload["props"])
+
+
+# ---------------------------------------------------------------------------
+# Section frame — header, footer, composition rules
+# ---------------------------------------------------------------------------
+
+
+def test_section_starts_with_canonical_header():
+    section = render_primitives_section({"Tile"})
+    assert section.startswith("## Available primitives")
+    # Header explains the asterisk convention so the LLM understands.
+    assert "Asterisk (*) marks required props" in section
+
+
+def test_section_has_action_shape_block():
+    section = render_primitives_section({"Tile"})
+    assert "Action shape" in section
+    assert "to_assistant" in section
+    assert "open_url" in section
+
+
+def test_section_has_composition_rules_at_bottom():
+    section = render_primitives_section({"Tile"})
+    rules_idx = section.find("Composition rules:")
+    assert rules_idx != -1
+    # The composition rules block is the last thing — nothing else
+    # follows it of any consequence.
+    tail = section[rules_idx:]
+    assert "Root id is always" in tail
+    assert "non-root `add` ops MUST have `parent`" in tail
+    assert "ONE Tile per item" in tail
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_empty_allowlist_does_not_crash():
+    section = render_primitives_section(set())
+    # Header + footer still rendered so the LLM gets a coherent message.
+    assert "## Available primitives" in section
+    assert "Composition rules:" in section
+    # And the empty-state body is present.
+    assert "No primitives are enabled" in section
+
+
+def test_unknown_primitive_in_allowlist_is_ignored():
+    # Mixing in a name that's not in PRIMITIVE_RENDER_ORDER / UI_CATALOG
+    # should be silently skipped (defence against stale templates).
+    section = render_primitives_section({"Tile", "NotARealPrimitive"})
+    assert "**Tile**" in section
+    assert "NotARealPrimitive" not in section

--- a/tests/test_ui_stream.py
+++ b/tests/test_ui_stream.py
@@ -1,0 +1,414 @@
+# pyrefly: ignore-errors
+# Same Pydantic dynamic-attr narrowing limitation as
+# test_tile_validation.py — validate_props returns _CatalogBase, concrete
+# subclass attrs read as missing to pyrefly.
+"""Tests for the SpecStream JSONL emission pipeline.
+
+Covers:
+  * UiStreamExtractor — token streaming around ``<ui_stream>`` markers
+  * parse_op_line — catalog validation, prop schema enforcement
+  * strip_ui_stream_markers — persistence-time prose extraction
+  * process_op_line — full healer + parse + validate flow
+"""
+
+from __future__ import annotations
+
+from app.ai.voice.agents.breeze_buddy.chat.ui_stream import (
+    JsonlOpLine,
+    TextOut,
+    UiStreamExtractor,
+    parse_op_line,
+    process_op_line,
+    strip_ui_stream_markers,
+    summarize_ui_ops,
+)
+
+# Load template package first so its __init__ chain completes before any
+# `chat/*` module imports drag in `handlers.transport.utils.field_resolver`
+# mid-load and trip the circular-import guard (same trap as test_session_state).
+from app.ai.voice.agents.breeze_buddy.template.ui_catalog import (
+    UI_CATALOG,
+    is_known_type,
+    validate_props,
+)
+
+# ---------------------------------------------------------------------------
+# UiStreamExtractor
+# ---------------------------------------------------------------------------
+
+
+def _drain(extractor: UiStreamExtractor):
+    """Collect everything the extractor yields after a feed + flush cycle."""
+    out = list(extractor.flush())
+    return out
+
+
+def test_extractor_yields_prose_outside_markers():
+    ex = UiStreamExtractor()
+    items = list(ex.feed("hello world"))
+    items.extend(_drain(ex))
+    assert items == [TextOut(value="hello world")]
+
+
+def test_extractor_isolates_jsonl_lines_inside_marker():
+    ex = UiStreamExtractor()
+    items: list = []
+    items.extend(ex.feed("here you go <ui_stream>\n"))
+    items.extend(ex.feed('{"op":"add","id":"root","type":"Stack"}\n'))
+    items.extend(
+        ex.feed(
+            '{"op":"add","id":"a","type":"Text","parent":"root","props":{"text":"hi"}}\n'
+        )
+    )
+    items.extend(ex.feed("</ui_stream> done"))
+    items.extend(_drain(ex))
+
+    types = [type(i).__name__ for i in items]
+    assert types == ["TextOut", "JsonlOpLine", "JsonlOpLine", "TextOut"]
+    prose = [i.value for i in items if isinstance(i, TextOut)]
+    assert prose == ["here you go ", " done"]
+    op_lines = [i.raw for i in items if isinstance(i, JsonlOpLine)]
+    assert op_lines[0] == '{"op":"add","id":"root","type":"Stack"}'
+    assert "Text" in op_lines[1]
+
+
+def test_extractor_handles_split_marker_across_deltas():
+    ex = UiStreamExtractor()
+    items: list = []
+    # Marker split mid-tag.
+    for chunk in [
+        "pre <",
+        "ui_s",
+        "tream>\n",
+        '{"op":"remove","id":"x"}',
+        "\n</ui_st",
+        "ream>",
+    ]:
+        items.extend(ex.feed(chunk))
+    items.extend(_drain(ex))
+
+    text = "".join(i.value for i in items if isinstance(i, TextOut))
+    assert text.startswith("pre ")
+    ops = [i.raw for i in items if isinstance(i, JsonlOpLine)]
+    assert ops == ['{"op":"remove","id":"x"}']
+
+
+def test_extractor_drops_unclosed_block():
+    ex = UiStreamExtractor()
+    list(ex.feed('hi <ui_stream>\n{"op":"add","id":"root","type":"Stack"}\n'))
+    # Stream ends before </ui_stream>; flush should drop the partial body.
+    flushed = list(ex.flush())
+    # No JSONL emission from flush; partial line silently dropped (warning logged).
+    assert all(not isinstance(i, JsonlOpLine) for i in flushed)
+
+
+# ---------------------------------------------------------------------------
+# parse_op_line
+# ---------------------------------------------------------------------------
+
+
+def test_parse_add_op_validates_against_catalog():
+    line = '{"op":"add","id":"root","type":"Stack","props":{"gap":"md"}}'
+    r = parse_op_line(line)
+    assert r.error is None
+    assert r.op == {"op": "add", "id": "root", "type": "Stack", "props": {"gap": "md"}}
+
+
+def test_parse_add_op_with_typed_primitive():
+    line = '{"op":"add","id":"h","type":"Handoff","parent":"root","props":{"reason":"checkout","label":"Pay","url":"https://example.com/c","lifecycle":"popup"}}'
+    r = parse_op_line(line)
+    assert r.error is None
+    assert r.op["props"]["reason"] == "checkout"
+    assert r.op["props"]["lifecycle"] == "popup"
+
+
+def test_parse_rejects_unknown_type():
+    line = '{"op":"add","id":"x","type":"NotAPrimitive","parent":"root"}'
+    r = parse_op_line(line)
+    assert r.op is None
+    assert r.error and r.error.startswith("unknown_type")
+
+
+def test_parse_rejects_unknown_props_on_known_type():
+    line = '{"op":"add","id":"x","type":"Tag","parent":"root","props":{"text":"new","weight":"bold"}}'
+    r = parse_op_line(line)
+    assert r.op is None
+    assert r.error and r.error.startswith("props_validation_failed")
+
+
+def test_parse_rejects_non_root_without_parent():
+    line = '{"op":"add","id":"x","type":"Text","props":{"text":"hi"}}'
+    r = parse_op_line(line)
+    assert r.op is None
+    assert r.error == "missing_parent"
+
+
+def test_parse_root_op_does_not_require_parent():
+    line = '{"op":"add","id":"root","type":"Carousel"}'
+    r = parse_op_line(line)
+    assert r.error is None
+
+
+def test_parse_remove_op_is_minimal():
+    line = '{"op":"remove","id":"c1"}'
+    r = parse_op_line(line)
+    assert r.error is None
+    assert r.op == {"op": "remove", "id": "c1"}
+
+
+def test_parse_replace_op_requires_props():
+    line = '{"op":"replace","id":"c1"}'
+    r = parse_op_line(line)
+    assert r.error == "replace_missing_props"
+
+
+def test_parse_rejects_unknown_op_kind():
+    line = '{"op":"weird","id":"c1"}'
+    r = parse_op_line(line)
+    assert r.error and r.error.startswith("unknown_op")
+
+
+def test_parse_rejects_malformed_json():
+    line = '{"op":"add"'
+    r = parse_op_line(line)
+    assert r.error and r.error.startswith("malformed_json")
+
+
+# ---------------------------------------------------------------------------
+# Catalog manifest
+# ---------------------------------------------------------------------------
+
+
+def test_catalog_contains_all_v1_primitives():
+    expected = {
+        "Stack",
+        "Row",
+        "Card",
+        "CardHeader",
+        "Image",
+        "Text",
+        "Carousel",
+        "Tag",
+        "Button",
+        "Buttons",
+        "Table",
+        "Message",
+        "Handoff",
+        "Tile",
+    }
+    assert expected.issubset(set(UI_CATALOG.keys()))
+
+
+def test_catalog_does_not_contain_money_primitive():
+    """Money was a commerce-tinted typed primitive — runtime is now
+    fully commerce-agnostic; price display lives in template-emitted
+    key_value / text body rows."""
+    assert "Money" not in UI_CATALOG
+
+
+def test_is_known_type_negative():
+    assert is_known_type("Stack")
+    assert not is_known_type("ProductCarousel")
+    assert not is_known_type("Money")
+
+
+def test_validate_props_handoff():
+    h = validate_props(
+        "Handoff",
+        {
+            "reason": "checkout",
+            "label": "Pay",
+            "url": "https://example.com/c",
+            "lifecycle": "popup",
+        },
+    )
+    assert h.reason == "checkout"
+    assert h.lifecycle.value == "popup"
+
+
+# ---------------------------------------------------------------------------
+# strip_ui_stream_markers
+# ---------------------------------------------------------------------------
+
+
+def test_strip_ui_stream_markers_removes_block_only():
+    text = (
+        "Here you go:\n"
+        '<ui_stream>\n{"op":"add","id":"root","type":"Stack"}\n</ui_stream>\n'
+        "let me know if you need more."
+    )
+    out = strip_ui_stream_markers(text)
+    assert "ui_stream" not in out
+    assert "Here you go:" in out
+    assert "let me know" in out
+
+
+def test_strip_ui_stream_markers_handles_multiple_blocks():
+    text = "a <ui_stream>{}</ui_stream> b <ui_stream>{}</ui_stream> c"
+    out = strip_ui_stream_markers(text)
+    assert out == "a  b  c"
+
+
+def test_strip_ui_stream_markers_passthrough_empty():
+    assert strip_ui_stream_markers("") == ""
+    assert strip_ui_stream_markers("no markers here") == "no markers here"
+
+
+# ---------------------------------------------------------------------------
+# process_op_line — full healer→parse→validate pipeline
+# ---------------------------------------------------------------------------
+
+
+def test_process_emits_ui_op_event_on_clean_line():
+    line = '{"op":"add","id":"root","type":"Carousel"}'
+    events = process_op_line(line, session_state={}, healer=None, known_ids=set())
+    assert len(events) == 1
+    assert events[0].event == "ui_op"
+    assert events[0].data["op"]["type"] == "Carousel"
+
+
+def test_process_emits_dropped_event_on_unknown_type():
+    line = '{"op":"add","id":"x","type":"WidgetThatDoesntExist","parent":"root"}'
+    events = process_op_line(line, session_state={}, healer=None, known_ids={"root"})
+    assert any(e.event == "ui_op_dropped" for e in events)
+
+
+def test_process_known_ids_tracks_add_remove():
+    known: set = set()
+    process_op_line('{"op":"add","id":"root","type":"Stack"}', known_ids=known)
+    assert "root" in known
+    process_op_line(
+        '{"op":"add","id":"c1","type":"Card","parent":"root"}', known_ids=known
+    )
+    assert "c1" in known
+    process_op_line('{"op":"remove","id":"c1"}', known_ids=known)
+    assert "c1" not in known
+
+
+# ---------------------------------------------------------------------------
+# summarize_ui_ops — compact memory of rendered UI for the LLM's next turn
+# ---------------------------------------------------------------------------
+
+
+def _tile(tid: str, title: str) -> dict:
+    return {
+        "op": "add",
+        "id": tid,
+        "type": "Tile",
+        "parent": "root",
+        "props": {"title": title},
+    }
+
+
+def _handoff(hid: str, url: str, reason: str = "checkout") -> dict:
+    return {
+        "op": "add",
+        "id": hid,
+        "type": "Handoff",
+        "parent": "root",
+        "props": {"reason": reason, "label": "Go", "url": url, "lifecycle": "popup"},
+    }
+
+
+def test_summarize_empty_returns_empty_string():
+    assert summarize_ui_ops([]) == ""
+
+
+def test_summarize_handles_only_layout_ops():
+    # Stack/Row by themselves carry no shopper-facing content — skip them
+    # so we don't pollute history with vacuous "[ui rendered: 1 Stack]" lines.
+    ops = [
+        {"op": "add", "id": "root", "type": "Stack", "props": {"gap": "md"}},
+        {"op": "add", "id": "r1", "type": "Row", "parent": "root", "props": {}},
+    ]
+    assert summarize_ui_ops(ops) == ""
+
+
+def test_summarize_tiles_include_titles():
+    ops = [
+        _tile("t1", "Red Bottle 390ml"),
+        _tile("t2", "Green Bottle 520ml"),
+    ]
+    out = summarize_ui_ops(ops)
+    assert out.startswith("[ui rendered: 2 Tile(s):")
+    assert "Red Bottle 390ml" in out
+    assert "Green Bottle 520ml" in out
+    assert out.endswith("]")
+
+
+def test_summarize_caps_tile_titles_at_eight():
+    ops = [_tile(f"t{i}", f"Bottle #{i}") for i in range(12)]
+    out = summarize_ui_ops(ops)
+    assert "12 Tile(s):" in out
+    # Only the first 8 titles appear verbatim
+    assert "Bottle #0" in out
+    assert "Bottle #7" in out
+    assert "Bottle #8" not in out
+    assert "(+4 more)" in out
+
+
+def test_summarize_truncates_long_titles():
+    long_title = "X" * 200
+    ops = [_tile("t1", long_title)]
+    out = summarize_ui_ops(ops)
+    # Title is bounded — full 200-char string should not appear verbatim
+    assert "X" * 200 not in out
+    assert "1 Tile(s):" in out
+
+
+def test_summarize_mixed_primitives_keeps_ordering():
+    ops = [
+        _tile("t1", "Red Bottle"),
+        _handoff("h1", "https://example.com/checkout/abc"),
+        {
+            "op": "add",
+            "id": "tbl1",
+            "type": "Table",
+            "parent": "root",
+            "props": {"columns": ["A"], "rows": [["1"]]},
+        },
+    ]
+    out = summarize_ui_ops(ops)
+    # Tiles first, then Handoffs, then other primitives alphabetically
+    assert out.index("Tile") < out.index("Handoff")
+    assert out.index("Handoff") < out.index("Table")
+    assert "1 Table" in out
+
+
+def test_summarize_handoff_dedupes_same_url():
+    ops = [
+        _handoff("h1", "https://example.com/cart/abc", "checkout"),
+        _handoff("h2", "https://example.com/cart/abc", "checkout"),
+    ]
+    out = summarize_ui_ops(ops)
+    # Two Handoff ops, one unique URL
+    assert "2 Handoff(s)" in out
+    assert out.count("https://example.com/cart/abc") == 1
+
+
+def test_summarize_ignores_replace_and_remove():
+    # Only ``add`` ops contribute to the rendered-content summary;
+    # replace/remove only update existing nodes.
+    ops = [
+        _tile("t1", "Red Bottle"),
+        {"op": "replace", "id": "t1", "props": {"title": "Updated"}},
+        {"op": "remove", "id": "t1"},
+    ]
+    out = summarize_ui_ops(ops)
+    # Only the original add counts
+    assert "1 Tile(s)" in out
+    assert "Red Bottle" in out
+
+
+def test_summarize_handles_unknown_type_gracefully():
+    ops = [
+        {
+            "op": "add",
+            "id": "x1",
+            "type": "FutureThingy",
+            "parent": "root",
+            "props": {},
+        }
+    ]
+    out = summarize_ui_ops(ops)
+    assert "1 FutureThingy" in out

--- a/uv.lock
+++ b/uv.lock
@@ -728,6 +728,11 @@ dev = [
     { name = "pytest-asyncio" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "aiohttp", specifier = ">=3.8.4" },
@@ -768,6 +773,9 @@ requires-dist = [
     { name = "websockets", specifier = ">=11.0.3" },
 ]
 provides-extras = ["dev"]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pytest", specifier = ">=9.0.3" }]
 
 [[package]]
 name = "click"


### PR DESCRIPTION
## Summary
End-to-end shipment of the buddy-assist widget. Combines all sprints into one PR; migration 030 ships all schema in one go.

- **Widget-public auth foundation** — `/widget/session/*` router, `widget_token` (typ=widget, 24h), per-merchant `widget_config` (CORS allowlist, IP rate limits, voice toggles), RBAC hardened (rejects `typ=widget` + `demo=true`)
- **Unified chat ↔ voice** — `chat_session.current_channel` + `voice_lead_id`; single reused lead, no row churn; voice resumes at prior `current_node` with full chat history; `end_conversation` drains voice turns back to chat
- **SpecStream UI wire format (Sprints 1 + 1.5 + 1.6)** — `ui_catalog` (typed primitives), `ui_stream` (JSONL ops), `ui_healer`, `ui_prompt`, `tool_result_normalizer`; Tile composite + template-driven primitive groups; commerce-scrub (Money deleted, requires_buyer_* → requires_user_*)
- **Session resume on refresh (Sprint 1.7)** — `chat_message.content_blocks` / `ui_blocks`, `agent_session_state`, `block_codec`, generic state-reducer engine
- **UCP cutover (Sprint 3)** — direct-HTTP poster bypassing Pipecat MCPClient (UCP rejects initialize); declared `tool_schemas` + `default_args` + arg-injection generators (uuid_v4/v7/timestamp); `response_transform.py`
- **Cancel-bus (Sprint 1.8)** — cross-pod Redis pubsub + per-pod asyncio task registry; `POST /chat/session/{id}/cancel` and matching widget endpoint; Py3.11 cancellation fix
- **Dual-channel display** — `ToAssistantAction.display` Optional[str]; LLM payload keeps raw GIDs, user bubble gets human label

## Migration 030
Consolidated, **idempotent** (IF NOT EXISTS / DO $ pg_constraint check $). Creates `widget_config` table, adds `chat_session.current_channel` + `voice_lead_id`, adds `chat_message.content_blocks` + `ui_blocks`, creates `agent_session_state` table. Backfill UPDATE is idempotent via WHERE-clause guard. Safe to re-apply.

## Tests
11 new test modules: `test_ui_stream`, `test_ui_healer`, `test_jit_instructions`, `test_session_state`, `test_tool_result_normalizer`, `test_response_transform`, `test_tile_validation`, `test_primitive_disabled`, `test_mcp_default_args`, `test_ui_catalog_groups`, `test_ui_prompt`.

## Blast radius — existing chat / voice / telephony
- **Existing `/chat/session/*`**: chat agent rewritten internally to use SpecStream / block_codec; external API contracts preserved. Backward-compatible session schema (new columns default sensibly).
- **Inbound PSTN / outbound dial-out**: zero behavioral change. Widget-only code paths gated on `lead.metaData.widget_session_id` which only the new widget router sets. `start_daily_session(enable_recording=...)` keeps `True` default so demo/daily callers unchanged.
- **MCP plumbing**: replaced with UCP direct-HTTP poster — internal change, tool surface preserved via declared `tool_schemas`.

## Test plan
- [ ] Migration 030 applies cleanly on a release-snapshot DB
- [ ] `/widget/session/*` accepts `widget_token`, rejects customer JWT
- [ ] RBAC verifier rejects `typ=widget` and `demo=true` tokens
- [ ] Voice resume e2e: chat → /voice/connect → end_conversation → chat-side sees voice turns drained
- [ ] Cart flow on Milton: search → add to cart → checkout (full UCP round-trip)
- [ ] Cancel mid-stream: POST /cancel aborts in-flight turn; SSE stream emits canceled event
- [ ] Existing inbound PSTN call: greeting still fires; no regression in `prepare_initial_node`
- [ ] Existing outbound dial-out: recording still enabled by default
- [ ] All 11 new test modules pass in CI

## Review guidance
- **Security**: review the new auth perimeter — `widget_token.py`, `rbac_token.py` hardening, `widget_common.py` rate limits + CORS
- **DB**: migration 030 + new query/accessor surface — verify idempotency + index strategy
- **Logic**: voice resume/drain mechanics in `agent/__init__.py`, `flow.py:prepare_resume_node`, `end_conversation.py`
- **UI wire format**: `ui_catalog.py` + `ui_stream.py` + `ui_healer.py` + `ui_prompt.py` form one logical unit (SpecStream)
- **UCP**: `mcp/__init__.py` rewrite + `response_transform.py` for the protocol cutover

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added embedded widget mode enabling seamless chat-to-voice switching with automatic message preservation
  * Added template-driven tool customization with response transformations and session state management
  * Added structured UI primitives system for rich component rendering in conversations
  * Added per-widget rate limiting and origin allowlisting controls

* **Improvements**
  * Enhanced tool result handling and normalization across MCP integrations
  * Added cross-pod turn cancellation support
  * Added configurable voice recording control

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/juspay/clairvoyance/pull/778?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->