### PR TITLE
fix: orphan webhook alerts for inbound calls

### DIFF
--- a/app/ai/voice/agents/breeze_buddy/agent/__init__.py
+++ b/app/ai/voice/agents/breeze_buddy/agent/__init__.py
@@ -97,10 +97,12 @@ from app.core.logger.context import (
     set_log_context,
     update_log_context,
 )
-from app.database.accessor import update_lead_call_initiated_time
+from app.database.accessor import get_lead_by_call_id, update_lead_call_initiated_time
 from app.database.accessor.breeze_buddy.lead_call_tracker import (
     update_lead_call_initiated_time_by_id,
+    update_lead_template,
 )
+from app.database.accessor.breeze_buddy.template import get_template_by_id
 from app.schemas import CallProvider
 from app.schemas.breeze_buddy.core import ExecutionMode, LeadCallTracker
 
@@ -423,13 +425,12 @@ class Agent:
         self.lead = await update_lead_call_initiated_time(
             self.call_sid, call_initiated_time
         )
-        if not self.lead:
-            # Extract URL query params for Plivo inbound (contains from_number, to_number)
-            url_query_params = dict(self.ws.query_params) if self.ws else {}
-            from_number = call_data.get("from") or url_query_params.get(
-                "from_number", ""
-            )
 
+        # Extract URL query params for Plivo inbound (contains from_number, to_number)
+        url_query_params = dict(self.ws.query_params) if self.ws else {}
+        from_number = call_data.get("from") or url_query_params.get("from_number", "")
+
+        if not self.lead:
             # Inbound call - extract template_id (handles IVR mode if enabled)
             (
                 template_id_from_query,
@@ -492,6 +493,46 @@ class Agent:
                     )
                     clear_log_context()
                     return False
+        else:
+            # Lead was already created in the answer handler (e.g. for inbound calls).
+            # If this is IVR mode, we still need to run template selection and update
+            # the lead if a different template was chosen.
+            ivr_mode = url_query_params.get("ivr_mode") == "true"
+            if ivr_mode:
+                (
+                    template_id_from_query,
+                    error_reason,
+                    _was_ivr,
+                ) = await get_template_id_from_call(
+                    ws=self.ws,
+                    stream_sid=self.stream_sid,
+                    call_sid=self.call_sid,
+                    call_data=call_data,
+                    provider=self.provider or "",
+                    telephony_service=self.telephony_service,
+                    from_number=from_number,
+                )
+                if error_reason:
+                    clear_log_context()
+                    return False
+                if (
+                    template_id_from_query
+                    and self.lead.template_id != template_id_from_query
+                ):
+                    template = await get_template_by_id(template_id_from_query)
+                    if template:
+                        updated_lead = await update_lead_template(
+                            lead_id=self.lead.id,
+                            template=template.name,
+                            template_id=str(template.id),
+                        )
+                        if updated_lead:
+                            self.lead = updated_lead
+                        else:
+                            logger.warning(
+                                f"Failed to update lead template to "
+                                f"{template_id_from_query} for lead {self.lead.id}"
+                            )
 
         # Update context with lead_id (call_sid already set above)
         update_log_context(lead_id=str(self.lead.id))
@@ -925,6 +966,17 @@ class Agent:
                 await self._setup_daily_transport(runner_args)
             else:
                 if not await self._setup_telephony_transport():
+                    if self.completion_function and self.call_sid:
+
+                        lead = await get_lead_by_call_id(self.call_sid)
+                        # If lead is None (not found), or it doesn't have an outcome,
+                        # or the outcome is not a BLOCKED_ outcome, then it's an early hangup.
+                        if not lead or not lead.outcome:
+                            await self.completion_function(
+                                call_id=self.call_sid,
+                                outcome="EARLY_HANGUP",
+                                call_end_time=datetime.now(timezone.utc),
+                            )
                     return
 
             # Override TTS provider if LLM-based selection was done at lead push time.

--- a/app/ai/voice/agents/breeze_buddy/agent/inbound.py
+++ b/app/ai/voice/agents/breeze_buddy/agent/inbound.py
@@ -5,6 +5,7 @@ from datetime import datetime
 from typing import Any, Dict, Optional, Tuple
 
 from app.core.logger import logger
+from app.database.accessor import get_lead_by_call_id
 from app.database.accessor.breeze_buddy.lead_call_tracker import (
     create_lead_call_tracker,
 )
@@ -45,6 +46,14 @@ async def handle_inbound_call(
             f"Inbound calls not supported for {provider}. call_sid: {call_sid}"
         )
         return None, "Inbound calls not supported"
+
+    # Defensive guard: lead may have been created in the answer handler
+    existing_lead = await get_lead_by_call_id(call_sid)
+    if existing_lead:
+        logger.info(
+            f"Lead already exists for call_sid: {call_sid}, lead_id: {existing_lead.id}"
+        )
+        return existing_lead, None
 
     logger.info(f"No lead found for call_sid: {call_sid} - treating as inbound call")
 
@@ -123,6 +132,14 @@ async def create_lead_from_template_id(
         If failed, lead is None and error_reason contains the failure reason.
     """
     logger.info(f"Creating lead from template_id: {template_id}")
+
+    # Defensive guard: lead may have been created in the answer handler
+    existing_lead = await get_lead_by_call_id(call_sid)
+    if existing_lead:
+        logger.info(
+            f"Lead already exists for call_sid: {call_sid}, lead_id: {existing_lead.id}"
+        )
+        return existing_lead, None
 
     # Load template by ID
     template = await get_template_by_id(template_id)

--- a/app/ai/voice/agents/breeze_buddy/agent/ivr.py
+++ b/app/ai/voice/agents/breeze_buddy/agent/ivr.py
@@ -17,6 +17,7 @@ import base64
 import hashlib
 import json
 import uuid
+from datetime import datetime, timezone
 from typing import Dict, List, Optional, Tuple
 
 from fastapi import WebSocket
@@ -36,9 +37,14 @@ from app.ai.voice.agents.breeze_buddy.utils.transport.websockets import (
     send_message,
 )
 from app.core.logger import logger
-from app.database.accessor import get_call_execution_config_by_merchant_id
+from app.database.accessor import (
+    get_call_execution_config_by_merchant_id,
+    get_lead_by_call_id,
+    update_lead_call_completion_details,
+    update_lead_template,
+)
 from app.database.accessor.breeze_buddy.template import get_template_by_id
-from app.schemas import InboundBlockAction
+from app.schemas import InboundBlockAction, LeadCallStatus
 from app.services.redis.client import get_redis_service
 
 # Constants
@@ -123,7 +129,7 @@ async def get_template_id_from_call(
         )
 
         if not selected_template_id:
-            logger.error("[IVR] No valid template selected, ending call")
+            logger.warning("[IVR] No valid template selected, ending call")
             # WebSocket already closed by IVR menu after goodbye audio
             return None, "IVR failed - no template selected", True
 
@@ -233,12 +239,44 @@ async def _check_deferred_inbound_policy(
                 customer_phone_number=from_number,
             )
 
-        # Fire-and-forget: log blocked call to lead_call_tracker
-        asyncio.create_task(
-            log_blocked_call(
+        # Update the existing IVR-OPTIONS lead with the real template and blocked outcome.
+        # Fall back to creating a new lead if no existing lead found (legacy safety).
+        outcome = (
+            "BLOCKED_REDIRECT"
+            if policy.action == InboundBlockAction.REDIRECT and redirect_number
+            else "BLOCKED_REJECT"
+        )
+        meta_data = {
+            "block_reason": policy.reason,
+            "block_action": policy.action.value if policy.action else None,
+            "block_message": policy.message,
+            "redirect_number": redirect_number,
+            "provider": provider,
+            "from_number": from_number,
+            "to_number": "",
+        }
+        existing = await get_lead_by_call_id(call_sid)
+        if existing:
+            await update_lead_call_completion_details(
+                id=existing.id,
+                status=LeadCallStatus.FINISHED,
+                outcome=outcome,
+                meta_data=meta_data,
+                call_end_time=datetime.now(timezone.utc),
+            )
+            await update_lead_template(
+                lead_id=existing.id,
+                template=template.name,
+                template_id=str(template.id),
+            )
+            logger.info(
+                f"[IVR] Updated existing lead {existing.id} with outcome={outcome}"
+            )
+        else:
+            await log_blocked_call(
                 call_id=call_sid,
                 from_number=from_number,
-                to_number="",  # Not available in IVR context
+                to_number="",
                 provider=provider,
                 reseller_id=reseller_id,
                 merchant_id=template.merchant_id,
@@ -254,7 +292,6 @@ async def _check_deferred_inbound_policy(
                 block_message=policy.message,
                 redirect_number=redirect_number,
             )
-        )
 
         # Close WebSocket
         await close_websocket_safely(ws, code=4003, reason=policy.reason or "blocked")
@@ -679,7 +716,7 @@ async def _send_audio(
     if success:
         logger.info(f"[IVR] Sent audio ({len(audio_bytes)} bytes) via {provider_str}")
     else:
-        logger.error("[IVR] Failed to send audio")
+        logger.warning("[IVR] Failed to send audio")
 
 
 async def _wait_for_valid_dtmf(

--- a/app/ai/voice/agents/breeze_buddy/managers/calls.py
+++ b/app/ai/voice/agents/breeze_buddy/managers/calls.py
@@ -545,9 +545,15 @@ async def handle_call_completion(
         lead.metaData and lead.metaData.get("transfer", {}).get("status") == "success"
     )
 
-    config = await _get_lead_config(lead)
-    if not config:
-        return
+    config = None
+    if lead.template == "IVR-OPTIONS":
+        logger.info(
+            f"Skipping config check for template IVR-OPTIONS for lead {lead.id}"
+        )
+    else:
+        config = await _get_lead_config(lead)
+        if not config:
+            return
 
     # Override outcome to "TRANSFERRED" for transfer calls
     if is_transfer:
@@ -563,7 +569,8 @@ async def handle_call_completion(
 
     # Only retry outbound telephony calls - inbound and test calls should not be retried
     if (
-        outcome in ["BUSY", "NO_ANSWER"]
+        config
+        and outcome in ["BUSY", "NO_ANSWER"]
         and lead.call_direction == CallDirection.OUTBOUND
         and lead.execution_mode == ExecutionMode.TELEPHONY
     ):
@@ -634,9 +641,15 @@ async def handle_unanswered_calls(call_id: str):
         )
         return
 
-    config = await _get_lead_config(lead)
-    if not config:
-        return
+    config = None
+    if lead.template == "IVR-OPTIONS":
+        logger.info(
+            f"Skipping config check for template IVR-OPTIONS for lead {lead.id}"
+        )
+    else:
+        config = await _get_lead_config(lead)
+        if not config:
+            return
 
     await update_lead_call_completion_details(
         id=lead.id,
@@ -648,7 +661,8 @@ async def handle_unanswered_calls(call_id: str):
 
     # Only retry outbound telephony calls - inbound and test calls should not be retried
     if (
-        lead.call_direction == CallDirection.OUTBOUND
+        config
+        and lead.call_direction == CallDirection.OUTBOUND
         and lead.execution_mode == ExecutionMode.TELEPHONY
     ):
         await _retry_call(lead, config, "NO_ANSWER")

--- a/app/api/routers/breeze_buddy/telephony/answer/handlers.py
+++ b/app/api/routers/breeze_buddy/telephony/answer/handlers.py
@@ -28,6 +28,8 @@ INBOUND (customer calls us):
 
 import asyncio
 import json
+import uuid
+from datetime import datetime, timezone
 from html import escape as html_escape
 from typing import Any, Dict, Optional
 from urllib.parse import quote
@@ -63,6 +65,9 @@ from app.database.accessor import (
     get_call_execution_config_by_merchant_id,
     get_lead_by_call_id,
 )
+from app.database.accessor.breeze_buddy.lead_call_tracker import (
+    create_lead_call_tracker,
+)
 from app.database.accessor.breeze_buddy.outbound_number import (
     get_outbound_number_by_number,
 )
@@ -70,7 +75,7 @@ from app.database.accessor.breeze_buddy.template import (
     get_all_templates_by_outbound_number_id,
     get_template_by_id_with_fallback,
 )
-from app.schemas import InboundBlockAction
+from app.schemas import CallDirection, InboundBlockAction, LeadCallStatus
 from app.services.redis.client import get_redis_service
 
 
@@ -397,6 +402,63 @@ def _build_block_response(
     )
 
 
+async def _create_inbound_lead_in_answer_handler(
+    call_id: str,
+    from_number: str,
+    templates: list,
+) -> None:
+    """Create an inbound lead in the answer handler before returning XML.
+
+    This ensures the lead exists in the database even if the caller hangs
+    up before the WebSocket connects, preventing orphan-call webhooks for
+    normal immediate-hangup behaviour.
+
+    Uses the first resolved template; IVR selection may update the template
+    later in the WebSocket handler if the user chooses a different one.
+
+    Errors are swallowed — the answer response must not be blocked by a
+    DB write failure.
+    """
+    if not templates:
+        return
+
+    first_template = templates[0]
+    is_ivr_mode = len(templates) > 1
+
+    if is_ivr_mode:
+        lead_template_name = "IVR-OPTIONS"
+        lead_template_id = None
+    else:
+        lead_template_name = first_template.name
+        lead_template_id = str(first_template.id)
+
+    lead_id = str(uuid.uuid4())
+    try:
+        await create_lead_call_tracker(
+            id=lead_id,
+            reseller_id=first_template.reseller_id,
+            template=lead_template_name,
+            template_id=lead_template_id,
+            merchant_id=first_template.merchant_id,
+            next_attempt_at=None,
+            payload={"customer_mobile_number": from_number},
+            call_initiated_time=datetime.now(timezone.utc),
+            status=LeadCallStatus.PROCESSING,
+            call_id=call_id,
+            outbound_number_id=(
+                str(first_template.outbound_number_id)
+                if first_template.outbound_number_id
+                else None
+            ),
+            call_direction=CallDirection.INBOUND,
+        )
+        logger.info(f"[Answer] Created inbound lead {lead_id} for call_id {call_id}")
+    except Exception as e:
+        logger.error(
+            f"[Answer] Failed to create inbound lead for call_id {call_id}: {e}"
+        )
+
+
 async def _build_provider_response(
     provider: str,
     result: dict,
@@ -689,6 +751,15 @@ async def handle_provider_answer(request: Request, provider: str) -> Response:
                 result["template_list"] = [
                     {"id": str(t.id), "name": t.name} for t in allowed_templates
                 ]
+
+        # Create inbound lead early so it exists even if caller hangs up before
+        # the WebSocket connects. This prevents orphan-call webhooks for normal
+        # immediate-hangup behaviour.
+        await _create_inbound_lead_in_answer_handler(
+            call_id=call_id,
+            from_number=from_number,
+            templates=result.get("templates", []),
+        )
 
     return await _build_provider_response(
         provider, result, call_id, from_number, to_number

--- a/app/database/accessor/__init__.py
+++ b/app/database/accessor/__init__.py
@@ -48,6 +48,7 @@ from .breeze_buddy.lead_call_tracker import (
     update_lead_call_id_by_id,
     update_lead_call_initiated_time,
     update_lead_call_recording_url,
+    update_lead_template,
 )
 from .breeze_buddy.outbound_number import (
     create_outbound_number,
@@ -105,6 +106,7 @@ __all__ = [
     "get_leads_by_request_id",
     "update_lead_call_completion_details",
     "update_lead_call_initiated_time",
+    "update_lead_template",
     "update_lead_call_id_by_id",
     "update_lead_call_recording_url",
     "get_all_lead_call_trackers",

--- a/app/database/accessor/breeze_buddy/lead_call_tracker.py
+++ b/app/database/accessor/breeze_buddy/lead_call_tracker.py
@@ -34,6 +34,7 @@ from app.database.queries.breeze_buddy.lead_call_tracker import (
     update_lead_call_recording_url_query,
     update_lead_payload_query,
     update_lead_request_id_query,
+    update_lead_template_query,
 )
 from app.schemas import (
     CallDirection,
@@ -275,7 +276,7 @@ async def get_lead_by_call_id(call_id: str) -> Optional[LeadCallTracker]:
             logger.info(f"Lead found: {decoded_result}")
             return decoded_result
 
-        logger.error("Lead not found")
+        logger.warning("Lead not found")
         return None
 
     except Exception as e:
@@ -462,6 +463,44 @@ async def update_lead_call_completion_details(
 
     except Exception as e:
         logger.error(f"Error updating lead call completion details: {e}")
+        return None
+
+
+async def update_lead_template(
+    lead_id: str, template: str, template_id: str
+) -> Optional[LeadCallTracker]:
+    """
+    Update the template name and template_id for a lead.
+
+    Used when an IVR selection results in a different template than the
+    one the lead was initially created with in the answer handler.
+
+    Args:
+        lead_id: Lead UUID
+        template: New template name
+        template_id: New template UUID
+
+    Returns:
+        Updated LeadCallTracker record if successful, None otherwise
+    """
+    logger.info(
+        f"Updating template for lead_id: {lead_id} to template: {template}, "
+        f"template_id: {template_id}"
+    )
+
+    try:
+        query_text, values = update_lead_template_query(lead_id, template, template_id)
+        result = await run_parameterized_query(query_text, values)
+        if result and get_row_count(result) > 0:
+            decoded_result = decode_lead_call_tracker(result[0])
+            logger.info(f"Lead template updated successfully: {decoded_result}")
+            return decoded_result
+
+        logger.error(f"Failed to update lead template for lead_id: {lead_id}")
+        return None
+
+    except Exception as e:
+        logger.error(f"Error updating lead template for lead_id {lead_id}: {e}")
         return None
 
 

--- a/app/database/queries/breeze_buddy/lead_call_tracker.py
+++ b/app/database/queries/breeze_buddy/lead_call_tracker.py
@@ -655,6 +655,36 @@ def update_lead_request_id_query(
     return text, values
 
 
+def update_lead_template_query(
+    lead_id: str, template: str, template_id: str
+) -> Tuple[str, List[Any]]:
+    """
+    Update the template name and template_id for a lead.
+
+    Used when an IVR selection results in a different template than the
+    one the lead was initially created with in the answer handler.
+
+    Args:
+        lead_id: Lead UUID
+        template: New template name
+        template_id: New template UUID
+
+    Returns:
+        Tuple of (query_text, values)
+    """
+    text = f"""
+        UPDATE "{LEAD_CALL_TRACKER_TABLE}"
+        SET
+            "template" = $1,
+            "template_id" = $2,
+            "updated_at" = NOW()
+        WHERE "id" = $3
+        RETURNING *;
+    """
+    values = [template, template_id, lead_id]
+    return text, values
+
+
 def append_metadata_field_query(
     lead_id: str, field_updates: Dict[str, Any]
 ) -> Tuple[str, List[Any]]:


### PR DESCRIPTION
…lling is false

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * IVR flows now support template re-selection for existing leads and update lead templates when changed.
  * Added idempotency guards to avoid duplicate lead creation for inbound calls.
  * Inbound leads are pre-created earlier to improve persistence when callers disconnect; early-hangup paths now mark incomplete calls appropriately.
  * Outbound retry behavior tightened to avoid unnecessary retries.

* **Chores**
  * Lowered log severity for several non-critical voice/transport errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->