### PR TITLE
fix(chat): keep [ui rendered: …] summary off the widget bubble

### DIFF
--- a/app/ai/voice/agents/breeze_buddy/chat/agent.py
+++ b/app/ai/voice/agents/breeze_buddy/chat/agent.py
@@ -18,6 +18,7 @@ from pipecat_flows import FlowsFunctionSchema
 from app.ai.voice.agents.breeze_buddy.chat import llm_driver
 from app.ai.voice.agents.breeze_buddy.chat.block_codec import (
     assistant_turn_to_blocks,
+    internal_text_block,
     plain_text_blocks,
     tool_results_to_user_blocks,
 )
@@ -327,26 +328,38 @@ class ChatAgent:
                 break
 
             # Strip <ui_stream> markers before persistence so the LLM
-            # doesn't see its own prior JSONL ops on replay. Append a
-            # compact summary of what tiles/handoffs the user actually
-            # saw — without it the LLM has no memory of its own UI and
-            # must reason from prose alone (which can drift from reality).
-            assistant_text = strip_ui_stream_markers("".join(turn_text))
+            # doesn't see its own prior JSONL ops on replay. The compact
+            # UI summary rides on a separate visibility=internal text
+            # block — the LLM keeps the referential memory ("the green
+            # one") on its next turn, but every widget-facing read path
+            # filters it out so it never shows up in the chat bubble.
+            visible_text = strip_ui_stream_markers("".join(turn_text))
             ui_summary = summarize_ui_ops(turn_ui_ops)
+
+            # In-memory LLM context still gets the augmented text — this
+            # branch loops back into another LLM call within the same
+            # /message, so the model needs the rendered-UI memory now.
+            llm_context_text = visible_text
             if ui_summary:
-                assistant_text = (assistant_text.rstrip() + "\n\n" + ui_summary).strip()
+                llm_context_text = (visible_text.rstrip() + "\n\n" + ui_summary).strip()
 
             # Persist the assistant turn-step with full Anthropic-shape
             # blocks [text? + tool_use*]. This is the load-bearing fix
             # for cross-turn identifier loss — on the next /message the
             # history loader replays tool_use.input verbatim, so the
             # LLM sees its own prior cart_id / checkout_id / etc.
-            assistant_blocks = assistant_turn_to_blocks(assistant_text, tool_calls)
+            assistant_blocks = assistant_turn_to_blocks(visible_text, tool_calls)
+            if ui_summary and assistant_blocks:
+                # Insert the internal summary block right after the
+                # visible text block so concatenation order on read
+                # matches what the LLM previously saw in-context.
+                insert_at = 1 if assistant_blocks[0].get("type") == "text" else 0
+                assistant_blocks.insert(insert_at, internal_text_block(ui_summary))
             if assistant_blocks:
                 await insert_chat_message(
                     session_id=self.session_id,
                     role=ChatMessageRole.ASSISTANT,
-                    content=assistant_text or None,
+                    content=visible_text or None,
                     content_blocks=assistant_blocks,
                     ui_blocks=turn_ui_ops or None,
                 )
@@ -359,7 +372,7 @@ class ChatAgent:
                     LLMContextMessage,
                     {
                         "role": "assistant",
-                        "content": assistant_text or None,
+                        "content": llm_context_text or None,
                         "tool_calls": [
                             {
                                 "id": call.tool_call_id,
@@ -496,29 +509,38 @@ class ChatAgent:
 
         # Reconstruct prose-only history (strips every
         # <ui_stream>…</ui_stream>) so saved messages never carry SpecStream
-        # ops forward into future turns. The canonical [text] block keeps
-        # history replay uniform on subsequent loads. A compact UI summary
-        # is appended so the LLM still has referential memory of what the
-        # shopper actually saw (titles, handoffs) on the next turn.
-        assistant_text = strip_ui_stream_markers("".join(assistant_text_chunks)).strip()
+        # ops forward into future turns. A compact UI summary rides on a
+        # separate visibility=internal block so the LLM keeps referential
+        # memory of what the shopper saw ("the green one"), while every
+        # widget-facing read path filters it out. The SSE wire and the
+        # denormalised `content` column both carry visible prose only.
+        visible_text = strip_ui_stream_markers("".join(assistant_text_chunks)).strip()
         ui_summary = summarize_ui_ops(turn_ui_ops)
+        persisted_blocks: List[Dict[str, Any]] = []
+        if visible_text:
+            persisted_blocks.extend(plain_text_blocks(visible_text))
         if ui_summary:
-            assistant_text = (assistant_text + "\n\n" + ui_summary).strip()
-        if assistant_text:
+            persisted_blocks.append(internal_text_block(ui_summary))
+        if persisted_blocks:
             stored = await insert_chat_message(
                 session_id=self.session_id,
                 role=ChatMessageRole.ASSISTANT,
-                content=assistant_text,
-                content_blocks=plain_text_blocks(assistant_text),
+                content=visible_text or None,
+                content_blocks=persisted_blocks,
                 ui_blocks=turn_ui_ops or None,
             )
-            yield SSEEvent(
-                event="assistant_message",
-                data={
-                    "idx": stored.idx if stored else None,
-                    "content": assistant_text,
-                },
-            )
+            # Only emit a bubble when there's actual visible prose. A
+            # summary-only row (the LLM rendered UI without narrating)
+            # still gets persisted for next-turn LLM memory but doesn't
+            # create an empty chat bubble on the wire.
+            if visible_text:
+                yield SSEEvent(
+                    event="assistant_message",
+                    data={
+                        "idx": stored.idx if stored else None,
+                        "content": visible_text,
+                    },
+                )
 
         await update_chat_session_after_turn(
             session_id=self.session_id, current_node=node_name or None

--- a/app/ai/voice/agents/breeze_buddy/chat/block_codec.py
+++ b/app/ai/voice/agents/breeze_buddy/chat/block_codec.py
@@ -46,6 +46,14 @@ from pipecat.processors.aggregators.llm_context import LLMContextMessage
 
 from app.core.logger import logger
 
+# A content_block carrying this visibility marker is LLM-context only:
+# the history loader concatenates it into the LLM's prior-turn memory,
+# but every widget-facing read path strips it before responding. This
+# is how internal-only memory (rendered-UI summaries today; tool-intent
+# traces, refine_ui hints, eval breadcrumbs tomorrow) rides on the
+# canonical content_blocks pipe without leaking onto the user's screen.
+VISIBILITY_INTERNAL = "internal"
+
 # ---------------------------------------------------------------------------
 # Encoding: write side (turn-loop → DB)
 # ---------------------------------------------------------------------------
@@ -109,6 +117,33 @@ def plain_text_blocks(text: str) -> List[Dict[str, Any]]:
     """Single-element [text] block. Used for the user's prose question
     and for the final assistant prose reply."""
     return [{"type": "text", "text": text}]
+
+
+def internal_text_block(text: str) -> Dict[str, Any]:
+    """A text block flagged visibility=internal — LLM-context only.
+
+    The history loader concatenates this into the LLM's prior-turn
+    memory; widget-facing read paths strip it via [[filter_visible_blocks]].
+    """
+    return {"type": "text", "text": text, "visibility": VISIBILITY_INTERNAL}
+
+
+# ---------------------------------------------------------------------------
+# Visibility filtering: widget-facing read side
+# ---------------------------------------------------------------------------
+
+
+def filter_visible_blocks(blocks: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Drop any block tagged ``visibility=internal``.
+
+    Pre-fix rows that carried the summary inline in a normal text block
+    are left untouched — minimal-blast-radius fix that only governs new
+    writes. Existing transcripts continue to display the legacy
+    ``[ui rendered: …]`` tail until they age out.
+    """
+    if not blocks:
+        return blocks
+    return [b for b in blocks if b.get("visibility") != VISIBILITY_INTERNAL]
 
 
 # ---------------------------------------------------------------------------
@@ -238,8 +273,11 @@ def _user_row_to_openai(
 
 
 __all__ = [
+    "VISIBILITY_INTERNAL",
     "assistant_turn_to_blocks",
     "tool_results_to_user_blocks",
     "plain_text_blocks",
+    "internal_text_block",
+    "filter_visible_blocks",
     "blocks_to_llm_context_messages",
 ]

--- a/app/api/routers/breeze_buddy/chat/handlers.py
+++ b/app/api/routers/breeze_buddy/chat/handlers.py
@@ -15,6 +15,7 @@ from fastapi.responses import StreamingResponse
 from app.ai.voice.agents.breeze_buddy.chat.agent import ChatAgent
 from app.ai.voice.agents.breeze_buddy.chat.block_codec import (
     blocks_to_llm_context_messages,
+    filter_visible_blocks,
 )
 from app.ai.voice.agents.breeze_buddy.chat.sse import SSEEvent, format_sse
 from app.ai.voice.agents.breeze_buddy.llm import get_llm_service
@@ -63,6 +64,43 @@ _SESSION_LOCK_TTL_SECONDS = 180
 def _lock_key(session_id: str) -> str:
     """Redis key for the per-session distributed lock."""
     return f"chat:session:{session_id}:lock"
+
+
+def _sanitize_messages_for_widget(messages: list) -> list:
+    """Strip LLM-context-only blocks before responding to widget callers.
+
+    The chat agent persists certain blocks tagged ``visibility=internal``
+    (rendered-UI summaries today; tool-intent and refine_ui breadcrumbs
+    tomorrow) so the LLM keeps referential memory across turns. Widget
+    transcripts must never see those.
+
+    Scope is intentionally forward-only: rows written before the
+    visibility split still carry the summary inline and pass through
+    unchanged. They'll age out of view as conversations turn over.
+    """
+    cleaned = []
+    for msg in messages:
+        blocks = msg.content_blocks
+        if not blocks:
+            cleaned.append(msg)
+            continue
+        visible_blocks = filter_visible_blocks(blocks)
+        if not visible_blocks:
+            # No visible text blocks left after filtering. Keep the row
+            # iff it carries ui_blocks the widget needs for tile/carousel
+            # repaint on resume (UI-only turns: the LLM rendered a
+            # Carousel with no narration; only the internal summary +
+            # ui_blocks are stored). Clear content_blocks to None so the
+            # widget doesn't render an empty chat bubble — it'll see the
+            # row, replay ui_blocks into ui_state, and skip the bubble.
+            # When ui_blocks is also empty, drop the row entirely.
+            if msg.ui_blocks:
+                cleaned.append(
+                    msg.model_copy(update={"content": None, "content_blocks": None})
+                )
+            continue
+        cleaned.append(msg.model_copy(update={"content_blocks": visible_blocks}))
+    return cleaned
 
 
 # ---------------------------------------------------------------------------
@@ -305,7 +343,7 @@ async def get_chat_session_handler(session: ChatSession) -> GetChatSessionRespon
         session_id=session.id,
         status=session.status,
         current_node=session.current_node,
-        messages=messages,
+        messages=_sanitize_messages_for_widget(messages),
         metadata=session.metadata,
     )
 
@@ -631,5 +669,5 @@ async def get_chat_transcript_handler(
         session_id=session.id,
         template_id=session.template_id,
         status=session.status,
-        messages=messages,
+        messages=_sanitize_messages_for_widget(messages),
     )

--- a/tests/test_block_codec_visibility.py
+++ b/tests/test_block_codec_visibility.py
@@ -1,0 +1,187 @@
+# pyrefly: ignore-errors
+# Same TypedDict-union narrowing limitation as test_ui_stream.py —
+# blocks_to_llm_context_messages returns LLMContextMessage (a Union of
+# LLMSpecificMessage variants); pyrefly can't narrow the indexable
+# variant from a runtime ``role`` check.
+"""Tests for the visibility-flag split that keeps LLM-only blocks
+(rendered-UI summaries today; agent-memory breadcrumbs tomorrow) off
+the widget's wire while preserving them for the LLM's next-turn replay.
+
+Companion: [[block_codec.py:filter_visible_blocks]] and the agent.py
+persistence path that emits ``visibility=internal`` text blocks.
+"""
+
+from __future__ import annotations
+
+import os
+
+from app.ai.voice.agents.breeze_buddy.chat.block_codec import (
+    VISIBILITY_INTERNAL,
+    blocks_to_llm_context_messages,
+    filter_visible_blocks,
+    internal_text_block,
+)
+
+# Handler import needs JWT_SECRET_KEY at module load time. Tests don't
+# verify tokens, so a dummy value is fine.
+os.environ.setdefault("JWT_SECRET_KEY", "test-secret-not-used-by-these-tests")
+os.environ.setdefault("JWT_ALGORITHM", "HS256")
+
+from app.api.routers.breeze_buddy.chat.handlers import (  # noqa: E402
+    _sanitize_messages_for_widget,
+)
+from app.schemas.breeze_buddy.chat import ChatMessage, ChatMessageRole  # noqa: E402
+
+
+def _mk(idx, **kwargs):
+    return ChatMessage(
+        session_id="s1", idx=idx, role=ChatMessageRole.ASSISTANT, **kwargs
+    )
+
+
+# ---------------------------------------------------------------------------
+# filter_visible_blocks — widget-facing read side
+# ---------------------------------------------------------------------------
+
+
+def test_filter_drops_internal_text_blocks():
+    blocks = [
+        {"type": "text", "text": "Hi there!"},
+        internal_text_block("[ui rendered: 1 Tile(s): 'Mug']"),
+        {"type": "tool_use", "id": "t1", "name": "search", "input": {}},
+    ]
+    out = filter_visible_blocks(blocks)
+    assert len(out) == 2
+    assert out[0] == {"type": "text", "text": "Hi there!"}
+    assert out[1]["type"] == "tool_use"
+
+
+def test_filter_passes_text_blocks_through_unchanged_when_clean():
+    blocks = [{"type": "text", "text": "Clean prose."}]
+    assert filter_visible_blocks(blocks) == blocks
+
+
+def test_filter_leaves_pre_fix_rows_alone():
+    # Existing rows persisted before the visibility split carry the
+    # summary inline. The fix is forward-only; legacy rows pass through
+    # unchanged so we don't need a backfill.
+    legacy = [
+        {
+            "type": "text",
+            "text": (
+                "Here are a few options.\n\n"
+                "[ui rendered: 2 Tile(s): 'Mug', 'Bottle']"
+            ),
+        }
+    ]
+    assert filter_visible_blocks(legacy) == legacy
+
+
+def test_filter_handles_empty_input():
+    assert filter_visible_blocks([]) == []
+    assert filter_visible_blocks(None) is None  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# LLM-side replay — visibility flag must NOT filter on this path
+# ---------------------------------------------------------------------------
+
+
+def test_llm_replay_keeps_internal_text_in_context():
+    rows = [
+        {
+            "role": "assistant",
+            "content": "Here is a Mug.",
+            "content_blocks": [
+                {"type": "text", "text": "Here is a Mug."},
+                internal_text_block("[ui rendered: 1 Tile(s): 'Mug']"),
+            ],
+        }
+    ]
+    messages = blocks_to_llm_context_messages(rows)
+    assert len(messages) == 1
+    # Both blocks flow into the LLM's prior-turn memory: visible prose
+    # plus the internal summary, concatenated in storage order.
+    assert messages[0]["content"] == "Here is a Mug.[ui rendered: 1 Tile(s): 'Mug']"
+
+
+def test_internal_text_block_carries_visibility_marker():
+    block = internal_text_block("noted")
+    assert block["type"] == "text"
+    assert block["text"] == "noted"
+    assert block["visibility"] == VISIBILITY_INTERNAL
+
+
+# ---------------------------------------------------------------------------
+# _sanitize_messages_for_widget — handler-level row pruning
+# ---------------------------------------------------------------------------
+
+
+def test_ui_only_row_preserved_with_content_cleared():
+    """UI-only assistant turns (LLM rendered a Carousel with no prose)
+    persist as ``content_blocks=[internal_summary]`` plus ``ui_blocks``.
+    The widget needs ui_blocks delivered so it can repaint tiles on
+    resume — without this case the entire row would be dropped and the
+    UI state would vanish on refresh."""
+    row = _mk(
+        1,
+        content=None,
+        content_blocks=[internal_text_block("[ui rendered: 1 Tile(s)]")],
+        ui_blocks=[
+            {"op": "add", "id": "root", "type": "Carousel", "props": {}},
+            {
+                "op": "add",
+                "id": "t-1",
+                "type": "Tile",
+                "parent": "root",
+                "props": {"title": "X"},
+            },
+        ],
+    )
+    out = _sanitize_messages_for_widget([row])
+    assert (
+        len(out) == 1
+    ), "UI-only row was dropped — widget would lose tile state on resume"
+    assert out[0].content is None
+    assert (
+        out[0].content_blocks is None
+    ), "content_blocks must be cleared so no empty bubble renders"
+    assert (
+        out[0].ui_blocks == row.ui_blocks
+    ), "ui_blocks must survive for widget tile replay"
+
+
+def test_summary_only_row_dropped_when_no_ui_blocks():
+    row = _mk(
+        2,
+        content=None,
+        content_blocks=[internal_text_block("[ui rendered: …]")],
+        ui_blocks=None,
+    )
+    assert _sanitize_messages_for_widget([row]) == []
+
+
+def test_mixed_row_keeps_visible_and_ui_blocks():
+    row = _mk(
+        3,
+        content="Here are some bottles.",
+        content_blocks=[
+            {"type": "text", "text": "Here are some bottles."},
+            internal_text_block("[ui rendered: 2 Tile(s)]"),
+        ],
+        ui_blocks=[{"op": "add", "id": "root", "type": "Carousel"}],
+    )
+    out = _sanitize_messages_for_widget([row])
+    assert len(out) == 1
+    assert len(out[0].content_blocks) == 1
+    assert out[0].content_blocks[0]["text"] == "Here are some bottles."
+    assert out[0].ui_blocks == row.ui_blocks
+
+
+def test_row_without_content_blocks_untouched():
+    """Greeting-style rows (legacy or pre-blocks) pass through verbatim."""
+    row = _mk(4, content="Hi!", content_blocks=None)
+    out = _sanitize_messages_for_widget([row])
+    assert len(out) == 1
+    assert out[0].content == "Hi!"
+    assert out[0].content_blocks is None


### PR DESCRIPTION
## The bug
The compact \`[ui rendered: …]\` line that the chat agent appends to assistant turns is meant as **LLM-only memory** — so the model can resolve referents like "the green one" on the next turn without re-emitting the full op stream. It was being appended to a single \`assistant_text\` variable that's then used for three things at once:
1. In-memory LLM context (correct consumer)
2. DB persistence — \`content\` and \`content_blocks[0].text\` (correct, needed for next-turn replay)
3. SSE \`assistant_message.content\` field (**leak #1** — shows in the live bubble)

Plus the GET /chat/session/{id}/messages endpoint returned the persisted (augmented) text verbatim, so on resume the widget re-rendered the summary in the bubble (**leak #2**).

## The fix
Introduce a \`visibility=internal\` flag on content_blocks. The agent persists **two** blocks per turn: a visible text block + an internal text block carrying the summary. Read paths split cleanly:

| Read path                                | Behaviour                                         |
| ---------------------------------------- | ------------------------------------------------- |
| \`blocks_to_llm_context_messages\` (LLM)   | concatenates **all** text blocks (unchanged)      |
| \`assistant_message\` SSE event (wire)     | emits visible prose only                          |
| \`GET /chat/session/{id}/messages\` (wire) | strips visibility=internal blocks before returning |
| \`GET /chat/transcript\` (audit export)    | same                                              |

Designed to generalise — future LLM-only crumbs (refine_ui hints, tool-intent traces, eval breadcrumbs) ride the same channel without another regex or sentinel.

## Scope is forward-only
Rows persisted **before** this fix still carry the summary inline and pass through unchanged. They'll age out as conversations turn over. No backfill, no schema migration.

## Files
- \`block_codec.py\` — \`VISIBILITY_INTERNAL\`, \`internal_text_block()\`, \`filter_visible_blocks()\`
- \`agent.py\` — split \`assistant_text\` into \`visible_text\` + \`ui_summary\`; persist as two blocks; SSE emits visible_text only; suppress empty-bubble emit when the turn was UI-only
- \`handlers.py\` — \`_sanitize_messages_for_widget()\` filters internal blocks from GET session/transcript responses; drops rows that become empty after filtering
- \`tests/test_block_codec_visibility.py\` — filter, LLM-replay, and legacy-row-passthrough coverage

## Test plan
- [ ] Send a turn that emits a Tile + Handoff; observe live bubble has no \`[ui rendered: …]\` tail
- [ ] Reload the chat; resume history; observe no leak on the historical bubble for new turns
- [ ] Send a follow-up referent ("show me the green one") and confirm the model still resolves it — the summary is still reaching the LLM
- [ ] Old assistant rows in the session continue to display their legacy inline summary (expected; forward-only scope)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed chat message display to properly separate internal AI processing summaries from user-visible assistant responses, ensuring widgets and transcripts show only relevant information.

* **Refactor**
  * Reorganized message persistence to isolate internal context-only blocks from visible content, improving message clarity in user-facing interfaces.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/juspay/clairvoyance/pull/781?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->