### PR TITLE
fix(cors): bypass static allowlist for widget public paths

### DIFF
--- a/app/core/middleware/widget_cors_bypass.py
+++ b/app/core/middleware/widget_cors_bypass.py
@@ -1,0 +1,134 @@
+"""Path-aware CORS dispatcher for the widget public surface.
+
+Background — two CORS layers exist on this service:
+
+1. **App-level FastAPI ``CORSMiddleware``** (``app/main.py``) — enforces
+   the static ``CORS_ALLOWED_ORIGINS`` list. Right gate for admin /
+   RBAC routes (portal-only surfaces) where the origin set is small
+   and stable.
+
+2. **Per-widget ``allowed_origins``** (``widget_common.py``
+   :func:`resolve_widget_config_for_request`) — enforces the
+   merchant-configured origin allowlist stored on the ``widget_config``
+   row. The real production gate for the public widget surface;
+   onboarding a new merchant means updating one DB row, not a redeploy.
+
+The widget routes already mount their own ``@router.options(...)``
+handlers that emit permissive preflight headers via
+:func:`options_cors_response` so the merchant-side preflight always
+succeeds and reaches our application logic. But the global
+``CORSMiddleware`` runs first and 400s any preflight whose ``Origin``
+isn't in the static list — so the route-level OPTIONS handler is
+never reached, and adding a new merchant to production currently
+requires editing the ``CORS_ALLOWED_ORIGINS`` env var + a rolling
+restart.
+
+This middleware fixes that asymmetry: requests against the public
+widget path prefix bypass the static-list middleware entirely (and
+hit the route-level OPTIONS / per-widget allowlist instead), while
+every other path stays behind the strict static list.
+"""
+
+from __future__ import annotations
+
+from typing import Iterable, Sequence
+
+from starlette.middleware.cors import CORSMiddleware
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
+
+# Headers we inject on bypassed non-preflight responses when the handler
+# hasn't already set them. ACAO=* is required for the browser to expose
+# the response body to JS; without it, the request reaches our handler
+# but the browser refuses to surface the result. Credentials stay off
+# because ``Allow-Credentials: true`` + ``Origin: *`` is invalid per
+# spec — widget tokens travel in ``Authorization``, so cookies aren't
+# needed anyway. ``Vary: Origin`` keeps caches honest.
+_BYPASS_RESPONSE_ACAO: tuple[bytes, bytes] = (
+    b"access-control-allow-origin",
+    b"*",
+)
+_BYPASS_RESPONSE_VARY: tuple[bytes, bytes] = (b"vary", b"Origin")
+
+# Paths that bypass the global allowlist. Trailing slash is meaningful:
+# ``/widget/`` matches the public session/message routes but not the
+# admin-only ``/widget-config`` CRUD which must stay locked to portal
+# origins.
+_DEFAULT_BYPASS_PREFIXES: tuple[str, ...] = ("/agent/voice/breeze-buddy/widget/",)
+
+
+class CustomWidgetCorsBypassMiddleware:
+    """ASGI dispatcher: send widget paths straight through, everything
+    else through ``CORSMiddleware``.
+
+    The widget surface enforces origin allowlist per-merchant inside
+    the route handlers (see ``widget_common.resolve_widget_config_for_request``)
+    and emits its own preflight via ``@router.options(...)``. The
+    static allowlist would only get in the way and force a redeploy
+    for every new merchant onboarding, so widget paths bypass it.
+    """
+
+    def __init__(
+        self,
+        app: ASGIApp,
+        *,
+        allow_origins: Sequence[str],
+        allow_credentials: bool = True,
+        allow_methods: Iterable[str] = ("*",),
+        allow_headers: Iterable[str] = ("*",),
+        bypass_path_prefixes: Sequence[str] = _DEFAULT_BYPASS_PREFIXES,
+    ) -> None:
+        self._inner_app = app
+        # Wrap the inner app in the strict CORS middleware. Non-bypass
+        # paths get the same behaviour as before this middleware was
+        # introduced — drop-in compatible.
+        self._cors_app = CORSMiddleware(
+            app,
+            allow_origins=list(allow_origins),
+            allow_credentials=allow_credentials,
+            allow_methods=list(allow_methods),
+            allow_headers=list(allow_headers),
+        )
+        self._bypass_prefixes = tuple(bypass_path_prefixes)
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        # Non-HTTP traffic (websockets, lifespan) doesn't touch CORS;
+        # pass it through the same wrapped chain the strict middleware
+        # uses so we don't accidentally drop lifespan events.
+        if scope.get("type") != "http":
+            await self._cors_app(scope, receive, send)
+            return
+
+        path = scope.get("path", "")
+        if any(path.startswith(p) for p in self._bypass_prefixes):
+            # Skip the static allowlist entirely. The widget routes
+            # carry their own permissive OPTIONS handlers AND validate
+            # the caller's origin against widget_config.allowed_origins
+            # inside the POST handler — that's the auth gate.
+            #
+            # Inject ACAO on the way out so the browser exposes the
+            # response body to JS. The OPTIONS handlers already set
+            # their own ACAO via options_cors_response(); we only fill
+            # it in when missing, so preflight responses pass through
+            # untouched.
+            await self._inner_app(scope, receive, self._wrap_send(send))
+            return
+
+        await self._cors_app(scope, receive, send)
+
+    @staticmethod
+    def _wrap_send(send: Send) -> Send:
+        async def send_with_cors(message: Message) -> None:
+            if message["type"] == "http.response.start":
+                headers = list(message.get("headers") or [])
+                lower_keys = {k.lower() for k, _ in headers}
+                if b"access-control-allow-origin" not in lower_keys:
+                    headers.append(_BYPASS_RESPONSE_ACAO)
+                    if b"vary" not in lower_keys:
+                        headers.append(_BYPASS_RESPONSE_VARY)
+                message["headers"] = headers
+            await send(message)
+
+        return send_with_cors
+
+
+__all__ = ["CustomWidgetCorsBypassMiddleware"]

--- a/app/main.py
+++ b/app/main.py
@@ -9,7 +9,6 @@ from typing import Any, Dict
 
 import uvicorn
 from fastapi import Depends, FastAPI
-from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from pipecat.transports.daily.utils import DailyRESTHelper
 
@@ -73,6 +72,7 @@ from app.core.config.static import (
 
 # Import necessary components from the new structure
 from app.core.logger import logger
+from app.core.middleware.widget_cors_bypass import CustomWidgetCorsBypassMiddleware
 from app.core.security.jwt import validate_automatic_request
 from app.core.transport.http_client import create_aiohttp_session
 from app.database import close_db_pool, init_db_pool
@@ -375,13 +375,20 @@ async def lifespan(_app: FastAPI):
 
 app = FastAPI(title="Breeze Automatic Server", version=__version__, lifespan=lifespan)
 
-# Add CORS middleware
+# CORS — path-aware. The strict static allowlist (CORS_ALLOWED_ORIGINS)
+# still gates admin/RBAC/portal traffic, but the public widget surface
+# (/agent/voice/breeze-buddy/widget/…) bypasses it: those routes carry
+# their own permissive @router.options handlers and enforce per-merchant
+# allowed_origins inside the POST handler via widget_config. Without
+# this bypass, onboarding each new merchant would require editing this
+# env var and a rolling restart — defeating the whole point of the
+# per-widget allowlist.
 app.add_middleware(
-    CORSMiddleware,
+    CustomWidgetCorsBypassMiddleware,
     allow_origins=CORS_ALLOWED_ORIGINS,
     allow_credentials=True,
-    allow_methods=["*"],  # Allows all methods
-    allow_headers=["*"],  # Allows all headers
+    allow_methods=["*"],
+    allow_headers=["*"],
 )
 
 app.include_router(

--- a/tests/test_widget_cors_bypass.py
+++ b/tests/test_widget_cors_bypass.py
@@ -1,0 +1,165 @@
+# pyrefly: ignore-errors
+"""Tests for [[widget_cors_bypass.CustomWidgetCorsBypassMiddleware]].
+
+Verifies the asymmetry the fix introduces:
+  * widget public paths (``/agent/voice/breeze-buddy/widget/…``) are
+    NOT subject to the static ``CORS_ALLOWED_ORIGINS`` list — any
+    origin can preflight; per-merchant ``widget_config.allowed_origins``
+    is the auth gate.
+  * admin / RBAC paths still go through ``CORSMiddleware`` with the
+    static list — unknown origins get rejected.
+"""
+
+from __future__ import annotations
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.core.middleware.widget_cors_bypass import CustomWidgetCorsBypassMiddleware
+
+
+def _build_app() -> FastAPI:
+    """Tiny FastAPI mirror with two routes — one widget-shaped, one
+    admin-shaped — to exercise both middleware branches without pulling
+    in the full breeze-buddy router stack."""
+    app = FastAPI()
+
+    @app.get("/agent/voice/breeze-buddy/widget/session")
+    def widget_get() -> dict:
+        return {"ok": True}
+
+    # Mount our own preflight on the widget path that mirrors what
+    # widget_common.options_cors_response() does in prod. Required
+    # because the middleware bypasses the strict CORSMiddleware here
+    # and lets the route handle preflight itself.
+    @app.options("/agent/voice/breeze-buddy/widget/session")
+    def widget_options() -> "Response":
+        from starlette.responses import Response
+
+        return Response(
+            status_code=204,
+            headers={
+                "Access-Control-Allow-Origin": "*",
+                "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
+                "Access-Control-Allow-Headers": "authorization, content-type",
+                "Access-Control-Max-Age": "600",
+            },
+        )
+
+    @app.get("/agent/voice/breeze-buddy/templates")
+    def admin_get() -> dict:
+        return {"ok": True}
+
+    app.add_middleware(
+        CustomWidgetCorsBypassMiddleware,
+        allow_origins=["https://portal.breeze.in"],
+        allow_credentials=True,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
+    return app
+
+
+def test_widget_preflight_allowed_from_arbitrary_origin() -> None:
+    """The whole point of the fix: a brand-new merchant origin must
+    reach our handler so per-widget allowlist can run. Without the
+    bypass the global allowlist would 400 here.
+
+    Also asserts ACAO is exactly ``*`` (not ``*, *``) — the bypass
+    injects ACAO when missing but must NOT duplicate the header the
+    route-level OPTIONS handler already set. httpx joins duplicates
+    with ``, ``, so an equality check on the single value catches it.
+    """
+    client = TestClient(_build_app())
+    resp = client.options(
+        "/agent/voice/breeze-buddy/widget/session",
+        headers={
+            "Origin": "https://firstbud.in",
+            "Access-Control-Request-Method": "GET",
+            "Access-Control-Request-Headers": "authorization,content-type",
+        },
+    )
+    assert resp.status_code == 204
+    assert resp.headers.get("access-control-allow-origin") == "*"
+
+
+def test_widget_get_allowed_from_arbitrary_origin() -> None:
+    """Confirms non-preflight requests on widget paths also bypass —
+    AND that the response carries ``Access-Control-Allow-Origin: *``.
+
+    Without ACAO on the response the browser would block JS from
+    reading the body even though the request reached our handler.
+    The bypass middleware has to inject it because we skip
+    ``CORSMiddleware`` and the widget POST/GET handlers don't set
+    CORS headers themselves (they return Pydantic models)."""
+    client = TestClient(_build_app())
+    resp = client.get(
+        "/agent/voice/breeze-buddy/widget/session",
+        headers={"Origin": "https://firstbud.in"},
+    )
+    assert resp.status_code == 200
+    assert resp.json() == {"ok": True}
+    assert resp.headers.get("access-control-allow-origin") == "*"
+    assert "Origin" in resp.headers.get("vary", "")
+
+
+def test_admin_preflight_rejected_from_unknown_origin() -> None:
+    """Admin / RBAC paths must STILL be gated by the static list — the
+    bypass is widget-only. portal.breeze.in is allowed; everything else
+    should 400 on preflight."""
+    client = TestClient(_build_app())
+    resp = client.options(
+        "/agent/voice/breeze-buddy/templates",
+        headers={
+            "Origin": "https://firstbud.in",
+            "Access-Control-Request-Method": "GET",
+        },
+    )
+    # Starlette's CORSMiddleware returns 400 for disallowed origins
+    # on preflight, no allow-origin header echoed.
+    assert resp.status_code == 400
+    assert "access-control-allow-origin" not in {k.lower() for k in resp.headers}
+
+
+def test_admin_preflight_allowed_from_listed_origin() -> None:
+    """The static list still works for the origins it's meant to
+    protect (portal/admin tools)."""
+    client = TestClient(_build_app())
+    resp = client.options(
+        "/agent/voice/breeze-buddy/templates",
+        headers={
+            "Origin": "https://portal.breeze.in",
+            "Access-Control-Request-Method": "GET",
+        },
+    )
+    assert resp.status_code == 200
+    assert resp.headers.get("access-control-allow-origin") == "https://portal.breeze.in"
+
+
+def test_widget_config_admin_path_stays_strict() -> None:
+    """Trailing-slash discipline: ``/widget-config`` (admin CRUD) must
+    NOT be bypassed — only ``/widget/`` (note the slash) is the public
+    surface. This guards against accidentally widening the bypass to
+    the admin widget-config endpoints if someone trims the prefix."""
+    app = FastAPI()
+
+    @app.get("/agent/voice/breeze-buddy/widget-config")
+    def widget_config() -> dict:
+        return {"ok": True}
+
+    app.add_middleware(
+        CustomWidgetCorsBypassMiddleware,
+        allow_origins=["https://portal.breeze.in"],
+        allow_credentials=True,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
+    client = TestClient(app)
+    resp = client.options(
+        "/agent/voice/breeze-buddy/widget-config",
+        headers={
+            "Origin": "https://firstbud.in",
+            "Access-Control-Request-Method": "GET",
+        },
+    )
+    assert resp.status_code == 400


### PR DESCRIPTION
## Problem
Onboarding a new merchant (e.g. \`firstbud.in\` just now) 400s the CORS preflight on \`POST /agent/voice/breeze-buddy/widget/session\` until we manually append the origin to the \`CORS_ALLOWED_ORIGINS\` env var and roll prod.

Live repro against current prod:
\`\`\`
$ curl -sI -X OPTIONS \\
    https://clairvoyance.breezelabs.app/agent/voice/breeze-buddy/widget/session \\
    -H 'Origin: https://firstbud.in' \\
    -H 'Access-Control-Request-Method: POST'

HTTP/2 400
vary: Origin
# (no access-control-allow-origin echoed → browser blocks)
\`\`\`

That defeats the design. The widget surface already enforces per-merchant Origin allowlist **inside** the handler via \`widget_config.allowed_origins\` (see \`widget_common.resolve_widget_config_for_request\`) — any new merchant should be one DB row away from working. Each widget route also mounts its own \`@router.options\` handler that emits permissive preflight headers via \`widget_common.options_cors_response()\`. But the global FastAPI \`CORSMiddleware\` intercepts the preflight first and never lets the request reach those handlers.

## Fix
\`WidgetCorsBypassMiddleware\` — a small ASGI dispatcher that wraps the strict \`CORSMiddleware\` and short-circuits it for one path prefix:

| Path prefix | CORS behaviour |
|---|---|
| \`/agent/voice/breeze-buddy/widget/\` (note trailing slash) | bypass static list; route-level OPTIONS + per-widget allowlist enforce |
| everything else (incl. \`/widget-config\` admin CRUD) | unchanged — strict \`CORS_ALLOWED_ORIGINS\` list |

Drop-in compatible: non-widget paths still use the same \`CORSMiddleware\` as before. \`CORS_ALLOWED_ORIGINS\` env var still controls the strict list for admin / portal / RBAC routes.

The trailing slash on \`/widget/\` is **load-bearing** — it excludes \`/widget-config\` (admin CRUD) from the bypass. Tested explicitly (\`test_widget_config_admin_path_stays_strict\`).

## Tests (all pass)
\`tests/test_widget_cors_bypass.py\` — FastAPI TestClient drives all 4 quadrants of the matrix:

1. ✅ \`test_widget_preflight_allowed_from_arbitrary_origin\` — \`firstbud.in\` preflight → 204 on widget path
2. ✅ \`test_widget_get_allowed_from_arbitrary_origin\` — non-preflight requests on widget paths bypass too
3. ✅ \`test_admin_preflight_rejected_from_unknown_origin\` — \`firstbud.in\` preflight → 400 on \`/templates\` (admin)
4. ✅ \`test_admin_preflight_allowed_from_listed_origin\` — \`portal.breeze.in\` preflight → 200 on \`/templates\`
5. ✅ \`test_widget_config_admin_path_stays_strict\` — \`/widget-config\` (no slash before \`-\`) stays gated

## What this means for future merchant onboarding
Before this PR: new merchant = env var edit + rolling restart.
After: new merchant = one \`widget-config\` POST that puts the origin into \`allowed_origins\`. Zero deploys.

## Out of scope
- Doesn't touch \`CORS_ALLOWED_ORIGINS\` env var. Existing admin-tool origins (\`buddy.breezelabs.app\`, \`portal.breeze.in\`, \`portal.breezesdk.store\`) still work identically.
- Doesn't change the per-widget \`allowed_origins\` enforcement logic in \`widget_common\` — that's the real auth gate and already correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implemented selective CORS policy enforcement: widget endpoints now permit cross-origin requests from any origin, while admin and configuration endpoints maintain strict origin validation for enhanced security.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/juspay/clairvoyance/pull/782?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->