### PR TITLE
added field enable_language_detection for Soniox stt

### DIFF
--- a/app/ai/voice/agents/breeze_buddy/stt/__init__.py
+++ b/app/ai/voice/agents/breeze_buddy/stt/__init__.py
@@ -127,6 +127,7 @@ async def create_stt_from_config(config: STTConfiguration):
             logger.info("Using template-specific Soniox context")
 
         language = _normalize_language(config.language)
+        enable_lang_id = sx.enable_language_identification if sx else None
         return build_soniox_stt(
             SonioxConfig(
                 api_key=SONIOX_API_KEY,
@@ -137,6 +138,7 @@ async def create_stt_from_config(config: STTConfiguration):
                 max_endpoint_delay_ms=BREEZE_BUDDY_SONIOX_MAX_ENDPOINT_DELAY_MS,
                 log_context="Breeze Buddy",
                 language_hints_strict=bool(language),
+                enable_language_identification=enable_lang_id,
             )
         )
 

--- a/app/ai/voice/agents/breeze_buddy/template/types.py
+++ b/app/ai/voice/agents/breeze_buddy/template/types.py
@@ -69,6 +69,10 @@ class SonioxSTTConfig(BaseModel):
     model: Optional[str] = Field(
         None, description="Soniox model (e.g. 'stt-rt-v4'). Defaults from env."
     )
+    enable_language_identification: Optional[bool] = Field(
+        None,
+        description="Enable automatic language identification. Defaults to None.",
+    )
 
 
 class DeepgramSTTConfig(BaseModel):

--- a/app/ai/voice/stt/soniox/config.py
+++ b/app/ai/voice/stt/soniox/config.py
@@ -39,6 +39,7 @@ class SonioxConfig:
     client_reference_id: Optional[str] = None
     log_context: str = "Soniox"
     language_hints_strict: bool = False
+    enable_language_identification: Optional[bool] = None
 
 
 def _parse_soniox_context(
@@ -138,12 +139,15 @@ def build_soniox_stt(config: SonioxConfig):
 
     context = _parse_soniox_context(config.context_json, config.log_context)
 
+    enable_lang_id = config.enable_language_identification
+
     soniox_settings = SonioxSTTService.Settings(
         model=config.model,
         language_hints=language_hints,
         context=context,
         client_reference_id=config.client_reference_id,
         language_hints_strict=config.language_hints_strict,
+        enable_language_identification=enable_lang_id,
     )
 
     # Format language hints for logging


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional language identification capability to Soniox speech-to-text service. Users can now enable automatic language detection through configuration (defaults to disabled).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/juspay/clairvoyance/pull/785?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->