### PR TITLE
fix: reconciler now finds stuck PROCESSING leads and cleans up

### DIFF
--- a/app/ai/voice/agents/breeze_buddy/managers/calls.py
+++ b/app/ai/voice/agents/breeze_buddy/managers/calls.py
@@ -433,7 +433,7 @@ async def reconcile_stuck_processing_leads():
     logger.info("Cleaning up stuck leads...")
     stale_time = datetime.now(timezone.utc) - timedelta(minutes=10)
     stale_leads = await get_leads_by_status_and_time_before(
-        LeadCallStatus.PROCESSING, stale_time
+        LeadCallStatus.PROCESSING, stale_time, include_locked=True
     )
 
     logger.info(f"Found {len(stale_leads)} stuck leads to clean up.")
@@ -441,9 +441,13 @@ async def reconcile_stuck_processing_leads():
     for lead in stale_leads:
         locked_lead = None
         try:
-            # Atomically acquire lock AND verify still in PROCESSING (single DB trip)
+            # Forcefully acquire the lock — the lead may still be marked
+            # is_locked=TRUE from a crashed pod. Safe here because the
+            # BackgroundTaskScheduler distributed lock ensures only one
+            # reconciler runs at a time, and we only reach this path after
+            # a 10-minute staleness timeout.
             locked_lead = await acquire_lock_on_lead_by_id(
-                lead.id, expected_status=LeadCallStatus.PROCESSING
+                lead.id, expected_status=LeadCallStatus.PROCESSING, force=True
             )
             if not locked_lead:
                 logger.info(

--- a/app/database/accessor/breeze_buddy/lead_call_tracker.py
+++ b/app/database/accessor/breeze_buddy/lead_call_tracker.py
@@ -124,21 +124,29 @@ async def create_lead_call_tracker(
 
 
 async def acquire_lock_on_lead_by_id(
-    lead_id: str, expected_status: Optional[LeadCallStatus] = None
+    lead_id: str,
+    expected_status: Optional[LeadCallStatus] = None,
+    force: bool = False,
 ) -> Optional[LeadCallTracker]:
     """
     Atomically acquire lock on a lead by ID.
     If expected_status is provided, only acquires when the lead's status matches —
     combining lock + status check in one DB round-trip instead of three (lock, check, release).
     Returns the locked lead if successful, None if already locked or status mismatched.
+
+    ``force=True`` bypasses the ``is_locked = FALSE`` guard for the reconciler
+    to reclaim dangling locks left by crashed pods.
     """
     logger.info(
         f"Attempting to acquire lock on lead with ID: {lead_id}"
         + (f" (expected_status={expected_status.value})" if expected_status else "")
+        + (" [force]" if force else "")
     )
 
     try:
-        query_text, values = acquire_lock_on_lead_by_id_query(lead_id, expected_status)
+        query_text, values = acquire_lock_on_lead_by_id_query(
+            lead_id, expected_status, force=force
+        )
         result = await run_parameterized_query(query_text, values)
         if result and get_row_count(result) > 0:
             decoded_result = decode_lead_call_tracker(result[0])
@@ -481,15 +489,18 @@ async def get_all_lead_call_trackers(
 
 
 async def get_leads_by_status_and_time_before(
-    status: LeadCallStatus, time: datetime
+    status: LeadCallStatus, time: datetime, include_locked: bool = False
 ) -> List[LeadCallTracker]:
     """
     Get leads based on their status and a time before which they were initiated.
+    Pass include_locked=True to include locked rows (used by the PROCESSING reconciler).
     """
     logger.info(f"Getting leads with status {status} initiated before {time}")
 
     try:
-        query_text, values = get_leads_by_status_and_time_before_query(status, time)
+        query_text, values = get_leads_by_status_and_time_before_query(
+            status, time, include_locked=include_locked
+        )
         result = await run_parameterized_query(query_text, values)
         if result:
             decoded = [decode_lead_call_tracker(row) for row in result]

--- a/app/database/queries/breeze_buddy/lead_call_tracker.py
+++ b/app/database/queries/breeze_buddy/lead_call_tracker.py
@@ -106,7 +106,9 @@ def insert_lead_call_tracker_query(
 
 
 def acquire_lock_on_lead_by_id_query(
-    lead_id: str, expected_status: Optional[LeadCallStatus] = None
+    lead_id: str,
+    expected_status: Optional[LeadCallStatus] = None,
+    force: bool = False,
 ) -> Tuple[str, List[Any]]:
     """
     Generate query to atomically acquire lock on a lead by ID.
@@ -121,6 +123,11 @@ def acquire_lock_on_lead_by_id_query(
     lock wins; subsequent locks (e.g. by ``reconcile_stuck_processing_leads``
     on a PROCESSING row) preserve the original timestamp. See
     docs/BACKLOG_DISPATCHER_REDESIGN.md.
+
+    ``force=True`` skips the ``is_locked = FALSE`` guard, allowing the
+    reconciler to reclaim a lock left dangling by a crashed pod. Only safe
+    because the BackgroundTaskScheduler's distributed lock ensures a single
+    reconciler runs at a time and only calls this after a 10-minute timeout.
     """
     set_clause = '"is_locked" = TRUE, "updated_at" = NOW()'
     if expected_status == LeadCallStatus.BACKLOG:
@@ -130,8 +137,9 @@ def acquire_lock_on_lead_by_id_query(
         UPDATE "{LEAD_CALL_TRACKER_TABLE}"
         SET {set_clause}
         WHERE "id" = $1
-        AND "is_locked" = FALSE
     """
+    if not force:
+        text += '        AND "is_locked" = FALSE\n'
     values: List[Any] = [lead_id]
     if expected_status is not None:
         text += f'        AND "status" = ${len(values) + 1}\n'
@@ -415,18 +423,22 @@ def get_all_lead_call_trackers_query(
 
 
 def get_leads_by_status_and_time_before_query(
-    status: LeadCallStatus, time: datetime
+    status: LeadCallStatus, time: datetime, include_locked: bool = False
 ) -> Tuple[str, List[Any]]:
     """
-    Generate query to select leads based on their status and a time before which they were initiated.
-    Only returns unlocked leads to prevent race conditions.
+    Generate query to select leads based on their status and a time before which
+    they were initiated. By default excludes locked rows (safe for BACKLOG/RETRY).
+    Pass include_locked=True for the PROCESSING reconciler path where leads are
+    always locked by design.
     """
     text = f"""
         SELECT * FROM "{LEAD_CALL_TRACKER_TABLE}"
         WHERE "status" = $1
         AND "call_initiated_time" < $2
-        AND "is_locked" = FALSE;
     """
+    if not include_locked:
+        text += '        AND "is_locked" = FALSE\n'
+    text += ";"
     values = [status.value, time]
     return text, values
 


### PR DESCRIPTION
- PROCESSING leads are always locked (worker holds lock until call-end webhook)
- the is_locked=FALSE filter was silently excluding all of them every reconciler run
- reconciler logged "Found 0 stuck leads" indefinitely, leaving leads permanently stuck
- the CAS inside acquire_lock_on_lead_by_id already handles concurrency safely
<img width="1562" height="1718" alt="image" src="https://github.com/user-attachments/assets/6af7b0ae-ce98-48de-9a2c-453ec3351ab9" />
<img width="1728" height="691" alt="image" src="https://github.com/user-attachments/assets/80c29278-c250-4ff0-be05-47e98a6c585a" />
<img width="1726" height="415" alt="image" src="https://github.com/user-attachments/assets/a1bc430c-81ac-4b9d-a276-0199355b0070" />
<img width="1720" height="556" alt="image" src="https://github.com/user-attachments/assets/4e4542d4-fb15-4d9d-9f72-c47bc0c12b93" />
<img width="1728" height="1063" alt="image" src="https://github.com/user-attachments/assets/a67b0d68-1568-4968-b5e2-ef3950c587e7" />
<img width="1726" height="736" alt="image" src="https://github.com/user-attachments/assets/ba80c77b-5f9d-4742-b788-f2dd8761173b" />
<img width="1089" height="279" alt="image" src="https://github.com/user-attachments/assets/51773150-64b4-4fa5-8a9b-63387f3ac84a" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where certain leads were being incorrectly excluded from retrieval queries.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/juspay/clairvoyance/pull/787?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
