### PR TITLE
feat: Add emoji filter before TTS

### DIFF
--- a/app/ai/voice/agents/breeze_buddy/processors/emoji_text_filter.py
+++ b/app/ai/voice/agents/breeze_buddy/processors/emoji_text_filter.py
@@ -1,0 +1,49 @@
+"""Emoji text filter for TTS services.
+
+Strips emoji and pictographic symbols from LLM-generated text before it is
+sent to any TTS provider.  Without this filter, emoji characters cause TTS
+services to either speak the codepoint name aloud (e.g. "grinning face") or
+produce garbled audio.
+"""
+
+import re
+
+from pipecat.utils.text.base_text_filter import BaseTextFilter
+
+__all__ = ["EmojiTextFilter", "strip_emoji"]
+
+# Unicode ranges that cover the standard emoji / pictographic blocks.
+# Using a single compiled pattern for performance.
+_EMOJI_PATTERN = re.compile(
+    "["
+    "\U0001f600-\U0001f64f"  # emoticons
+    "\U0001f300-\U0001f5ff"  # symbols & pictographs
+    "\U0001f680-\U0001f6ff"  # transport & map symbols
+    "\U0001f1e0-\U0001f1ff"  # regional indicator symbols (flags)
+    "\U00002700-\U000027bf"  # dingbats
+    "\U000024c2-\U0001f251"  # enclosed characters / misc symbols
+    "\U0001f900-\U0001f9ff"  # supplemental symbols & pictographs
+    "\U0001fa00-\U0001fa6f"  # chess symbols, medical symbols
+    "\U0001fa70-\U0001faff"  # food, drink, household symbols
+    "\U00002600-\U000026ff"  # miscellaneous symbols (☀ ☁ ☎ etc.)
+    "]+",
+    flags=re.UNICODE,
+)
+
+
+def strip_emoji(text: str) -> str:
+    """Remove all emoji characters from *text* and collapse extra whitespace."""
+    return _EMOJI_PATTERN.sub("", text).strip()
+
+
+class EmojiTextFilter(BaseTextFilter):
+    """Pipecat ``BaseTextFilter`` that removes emoji from TTS input text.
+
+    Pass an instance of this class via the ``text_filters`` parameter of any
+    pipecat TTS service to silently drop emoji before synthesis:
+
+        service = ElevenLabsTTSService(..., text_filters=[EmojiTextFilter()])
+    """
+
+    async def filter(self, text: str) -> str:
+        return strip_emoji(text)

--- a/app/ai/voice/agents/breeze_buddy/tts/__init__.py
+++ b/app/ai/voice/agents/breeze_buddy/tts/__init__.py
@@ -3,6 +3,10 @@
 from pipecat.services.cartesia.tts import GenerationConfig
 from pipecat.transcriptions.language import Language
 
+from app.ai.voice.agents.breeze_buddy.processors.emoji_text_filter import (
+    EmojiTextFilter,
+    strip_emoji,
+)
 from app.ai.voice.agents.breeze_buddy.template.types import (
     ConfigurationModel,
     TTSConfig,
@@ -148,6 +152,7 @@ async def get_tts_service(voice_config: TTSConfig):
                 speed=voice_config.speed or 1.0,
                 language=_parse_language(voice_config.language, Language.EN_IN),
                 aggregate_sentences=aggregate,
+                text_filters=[EmojiTextFilter()],
             )
         )
 
@@ -171,6 +176,7 @@ async def get_tts_service(voice_config: TTSConfig):
                 language=_parse_language(voice_config.language),
                 generation_config=generation_config,
                 aggregate_sentences=aggregate,
+                text_filters=[EmojiTextFilter()],
             )
         )
 
@@ -189,6 +195,7 @@ async def get_tts_service(voice_config: TTSConfig):
                 pitch=voice_config.pitch or 0.0,
                 pace=voice_config.speed or 0.9,
                 enable_preprocessing=enable_preprocessing,
+                text_filters=[EmojiTextFilter()],
             )
         )
 
@@ -203,6 +210,7 @@ async def get_tts_service(voice_config: TTSConfig):
                 language=_parse_language(voice_config.language, Language.EN_IN),
                 style_prompt=getattr(voice_config, "style_prompt", None),
                 credentials=GOOGLE_CREDENTIALS_JSON,
+                text_filters=[EmojiTextFilter()],
             )
         )
 
@@ -231,6 +239,10 @@ async def generate_audio(
     overrides = configurations.tts_configuration_overrides if configurations else None
     resolved = await resolve_voice_config(voice_config, overrides)
     provider = resolved.provider.value
+
+    # Strip emoji before sending to any provider — TTS APIs either speak the
+    # codepoint name aloud or produce garbled audio when emoji are present.
+    text = strip_emoji(text)
 
     if provider == "sarvam":
         audio_data = await _generate_sarvam_audio(

--- a/app/ai/voice/tts/cartesia.py
+++ b/app/ai/voice/tts/cartesia.py
@@ -1,7 +1,7 @@
 """Cartesia TTS helpers and builder."""
 
 from dataclasses import dataclass
-from typing import Optional
+from typing import Optional, Sequence
 
 import httpx
 from pipecat.services.cartesia.tts import CartesiaTTSService, GenerationConfig
@@ -37,6 +37,7 @@ class CartesiaConfig:
     language: Language = Language.EN
     generation_config: Optional[GenerationConfig] = None
     aggregate_sentences: bool = True
+    text_filters: Optional[Sequence] = None
 
 
 def build_cartesia_tts(config: CartesiaConfig) -> CartesiaTTSService:
@@ -57,6 +58,7 @@ def build_cartesia_tts(config: CartesiaConfig) -> CartesiaTTSService:
             language=config.language,
             generation_config=config.generation_config,
         ),
+        text_filters=list(config.text_filters) if config.text_filters else None,
         text_aggregation_mode=(
             TextAggregationMode.SENTENCE
             if config.aggregate_sentences

--- a/app/ai/voice/tts/sarvam.py
+++ b/app/ai/voice/tts/sarvam.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import base64
 from dataclasses import dataclass
-from typing import Optional
+from typing import Optional, Sequence
 
 import httpx
 from pipecat.services.sarvam.tts import SarvamTTSService
@@ -36,6 +36,7 @@ class SarvamTTSConfig:
     pace: float
     language_code: Optional[str] = None
     enable_preprocessing: bool = True
+    text_filters: Optional[Sequence] = None
 
 
 def get_sarvam_language(language_code: Optional[str]) -> Language:
@@ -76,6 +77,7 @@ def build_sarvam_tts(config: SarvamTTSConfig):
             pace=config.pace,
             enable_preprocessing=config.enable_preprocessing,
         ),
+        text_filters=list(config.text_filters) if config.text_filters else None,
     )
 
 


### PR DESCRIPTION
  - Added emoji filter betwen LLM and TTS to filter emojis being passed in the transcript to LLM.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic emoji filtering to text-to-speech services. Text input is now sanitized to remove emoji characters before audio synthesis, improving voice output quality across all supported voice providers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/juspay/clairvoyance/pull/788?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->