### PR TITLE
feat(buddy-assist): cart-sync derive_field transform + SideEffect primitive

### DIFF
--- a/app/ai/voice/agents/breeze_buddy/handlers/transport/utils/response_transform.py
+++ b/app/ai/voice/agents/breeze_buddy/handlers/transport/utils/response_transform.py
@@ -327,10 +327,86 @@ def strip_html(value: Any, args: Dict[str, Any]) -> Any:
     return plain
 
 
+@register_transform("derive_field")
+def derive_field(value: Any, args: Dict[str, Any]) -> Any:
+    """Derive a new field on a dict via regex-capture + format-template.
+
+    Reads a string field, runs a regex (positional or named groups), and
+    writes the formatted result to a destination field on the same dict.
+    Purely a shape op — no domain knowledge — so templates can use it to
+    build any derived string (URLs, IDs, display labels) from any existing
+    string field on a response object.
+
+    Args:
+        from     — source field name (default: ``"id"``)
+        pattern  — regex with capture groups. Named groups (``(?P<name>…)``)
+                   substitute by ``{name}`` in ``template``; positional
+                   groups substitute by ``{0}``, ``{1}``, …
+        template — format string applied to the captured groups.
+        to       — destination field name (required). Existing values at
+                   ``to`` are overwritten.
+        overwrite — bool, default ``True``. When ``False``, only write if
+                    the destination is missing/None.
+
+    Behavior:
+        - Non-dict ``value``: pass-through.
+        - Source missing / not a string / regex doesn't match: no-op.
+        - Bad regex or template placeholder mismatch: logged warning, no-op.
+    """
+    if not isinstance(value, dict):
+        return value
+
+    src_field = args.get("from", "id")
+    pattern = args.get("pattern")
+    template = args.get("template")
+    dst_field = args.get("to")
+    overwrite = args.get("overwrite", True)
+
+    if not pattern or not template or not dst_field:
+        return value
+
+    if not overwrite and value.get(dst_field) is not None:
+        return value
+
+    src = value.get(src_field)
+    if not isinstance(src, str):
+        return value
+
+    try:
+        match = re.search(pattern, src)
+    except re.error as e:
+        logger.warning(
+            f"[derive_field] bad regex {pattern!r} for field {src_field!r}: {e}"
+        )
+        return value
+    if not match:
+        return value
+
+    try:
+        named = match.groupdict()
+        if named and all(v is not None for v in named.values()):
+            value[dst_field] = template.format(**named)
+        else:
+            value[dst_field] = template.format(*match.groups())
+    except (IndexError, KeyError, ValueError) as e:
+        # IndexError/KeyError: template references a capture group that
+        # doesn't exist. ValueError: malformed format string (e.g. a bare
+        # "{" or unbalanced braces). All are template-author bugs that
+        # should no-op per this fn's documented contract, not abort the
+        # whole transform pass for the response.
+        logger.warning(
+            f"[derive_field] template {template!r} does not fit captures of "
+            f"{pattern!r}: {e}"
+        )
+
+    return value
+
+
 __all__ = [
     "TRANSFORM_REGISTRY",
     "TransformFn",
     "apply_response_transforms",
+    "derive_field",
     "omit_fields",
     "pick_fields",
     "register_transform",

--- a/app/ai/voice/agents/breeze_buddy/template/ui_catalog.py
+++ b/app/ai/voice/agents/breeze_buddy/template/ui_catalog.py
@@ -41,7 +41,14 @@ from __future__ import annotations
 from enum import Enum
 from typing import Any, Dict, List, Literal, Optional, Set, Type, Union
 
-from pydantic import BaseModel, ConfigDict, Field, HttpUrl, field_validator
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    HttpUrl,
+    field_validator,
+    model_validator,
+)
 
 CATALOG_VERSION: str = "v1"
 
@@ -442,6 +449,124 @@ class Tile(_CatalogBase):
 
 
 # ---------------------------------------------------------------------------
+# Effects primitives (group: effects)
+#
+# Invisible primitives that run a browser-side side-effect when mounted.
+# Distinct from UI primitives — they render no DOM. Used for things the
+# server can describe but cannot do itself (set a host-page cookie, ping
+# a host-only endpoint, etc.) and are auditable as ops in the SpecStream.
+# ---------------------------------------------------------------------------
+
+
+class SideEffectKind(str, Enum):
+    """What a SideEffect op does on mount. Closed set keeps the surface
+    small and the side-effects auditable.
+
+    * ``fetch`` — fire-and-forget ``fetch(url, …)``. Same-origin or
+      CORS-enabled URLs only. Used to ping host-only endpoints, trigger
+      session-bound mutations, or kick off prefetches. Requires ``url``.
+    * ``set_cookie`` — write a cookie on the host page via
+      ``document.cookie`` (same-origin only — the browser enforces this).
+      Used to pin host-page state to server-built identifiers (e.g.
+      pointing a storefront's cookie cart at a server-created cart).
+      Requires ``name`` and ``value``.
+    """
+
+    fetch = "fetch"
+    set_cookie = "set_cookie"
+
+
+class SideEffect(_CatalogBase):
+    """Invisible primitive that runs a browser-side side-effect on mount.
+
+    Renders nothing. Used for things the server can describe but cannot do
+    itself — e.g. pinning a host-page cookie to a server-built identifier,
+    pinging a host-only endpoint, prefetching.
+
+    Field requirements vary by ``kind`` — ``fetch`` uses ``url`` (+ method
+    / credentials), ``set_cookie`` uses ``name`` / ``value`` (+ path /
+    samesite / secure). Other fields are ignored.
+
+    Idempotency: the widget dedupes by ``(kind, …action-fingerprint…)``
+    per page session so re-renders of the same op — or the same value
+    emitted across multiple turns / multiple widget instances — fire the
+    side-effect at most once. Set ``once=False`` to opt out (e.g. for
+    periodic pings).
+
+    Errors are swallowed and logged by the widget so a failed side-effect
+    never breaks the conversation flow.
+    """
+
+    kind: SideEffectKind = SideEffectKind.fetch
+    # --- kind=fetch fields ---
+    url: Optional[str] = Field(
+        None,
+        description=(
+            "Target URL (required when ``kind='fetch'``). Same-origin paths"
+            " or absolute URLs. Cross-origin requires server CORS."
+        ),
+    )
+    method: Optional[Literal["GET", "POST"]] = "GET"
+    credentials: Optional[Literal["omit", "same-origin", "include"]] = "include"
+    # --- kind=set_cookie fields ---
+    name: Optional[str] = Field(
+        None,
+        description="Cookie name (required when ``kind='set_cookie'``).",
+    )
+    value: Optional[str] = Field(
+        None,
+        description="Cookie value (required when ``kind='set_cookie'``).",
+    )
+    path: Optional[str] = Field(
+        "/",
+        description="Cookie path (``kind='set_cookie'``). Default '/'.",
+    )
+    samesite: Optional[Literal["Strict", "Lax", "None"]] = Field(
+        "Lax",
+        description="Cookie SameSite (``kind='set_cookie'``).",
+    )
+    secure: bool = Field(
+        True,
+        description="Cookie Secure flag (``kind='set_cookie'``). Default True.",
+    )
+    # --- common ---
+    once: bool = Field(
+        default=True,
+        description=("Dedupe by (kind, fingerprint) per page session. Default true."),
+    )
+
+    @model_validator(mode="after")
+    def _require_kind_specific_fields(self) -> "SideEffect":
+        """Enforce kind-specific required fields.
+
+        The fields are declared ``Optional[...]`` on the model so that one
+        Pydantic class can carry both ``fetch`` and ``set_cookie`` shapes,
+        but the contract is that ``url`` is required for ``fetch`` and
+        ``name`` + ``value`` are required for ``set_cookie``. Without this
+        validator, ``validate_props`` would silently accept malformed
+        ops (e.g. a ``fetch`` op with no url, or a ``set_cookie`` op with
+        no name) and the widget would no-op them — which is graceful at
+        runtime but masks template-author bugs. Validate them at parse
+        time so the healer rejects them before they reach the widget.
+        """
+        if self.kind == SideEffectKind.fetch:
+            if not self.url:
+                raise ValueError(
+                    "SideEffect kind='fetch' requires a non-empty 'url' prop"
+                )
+        elif self.kind == SideEffectKind.set_cookie:
+            if not self.name:
+                raise ValueError(
+                    "SideEffect kind='set_cookie' requires a non-empty 'name' prop"
+                )
+            if not self.value:
+                raise ValueError(
+                    "SideEffect kind='set_cookie' requires a non-empty 'value' prop"
+                )
+        return self
+
+
+# ---------------------------------------------------------------------------
 # Catalog manifest + group registry
 # ---------------------------------------------------------------------------
 
@@ -467,6 +592,8 @@ UI_CATALOG: Dict[str, Type[_CatalogBase]] = {
     "Handoff": Handoff,
     # Composite
     "Tile": Tile,
+    # Effects (invisible)
+    "SideEffect": SideEffect,
 }
 
 
@@ -500,6 +627,9 @@ PRIMITIVE_GROUPS: Dict[str, List[str]] = {
     ],
     "composite": [
         "Tile",
+    ],
+    "effects": [
+        "SideEffect",
     ],
     # Reserved for future expansion — schemas + widget components land
     # behind these group flags so existing templates aren't affected.
@@ -546,6 +676,8 @@ PRIMITIVE_RENDER_ORDER: List[str] = [
     "Table",
     # Notifications
     "Message",
+    # Effects (invisible — last so it doesn't crowd the visual catalog)
+    "SideEffect",
 ]
 
 

--- a/tests/test_response_transform.py
+++ b/tests/test_response_transform.py
@@ -12,19 +12,23 @@ arithmetic rules for the first built-in op.
 
 from __future__ import annotations
 
+# isort: off
+# Order matters: template.types fully loads the `template` package (whose
+# __init__ pulls in hooks/http_requester) BEFORE the utility import
+# triggers handlers.transport.utils.__init__ → field_resolver →
+# template.types again. Reversing these triggers a circular-import error.
+from app.ai.voice.agents.breeze_buddy.template.types import ResponseTransform
+
 from app.ai.voice.agents.breeze_buddy.handlers.transport.utils.response_transform import (
     apply_response_transforms,
+    derive_field,
     omit_fields,
     pick_fields,
     scale_by_exponent,
     strip_html,
 )
 
-# Order matters: template.types fully loads the `template` package (whose
-# __init__ pulls in hooks/http_requester) BEFORE the utility import
-# triggers handlers.transport.utils.__init__ → field_resolver →
-# template.types again. Reversing these triggers a circular-import error.
-from app.ai.voice.agents.breeze_buddy.template.types import ResponseTransform
+# isort: on
 
 # ---------------------------------------------------------------------------
 # scale_by_exponent — pure arithmetic, no domain knowledge
@@ -515,3 +519,237 @@ def test_walker_mutates_caller_payload_in_place():
     # i.e. the http_handler's `transformed = copy.deepcopy(data)` pattern
     # produces a value the original input is decoupled from.
     assert snapshot["order"]["total"]["amount"] == 5000
+
+
+# ---------------------------------------------------------------------------
+# derive_field — regex-capture + format-template, no domain knowledge
+# ---------------------------------------------------------------------------
+
+
+def test_derive_field_positional_captures_format_into_template():
+    value = {"id": "gid://shopify/Cart/AbCdEf?key=XyZ789"}
+    derive_field(
+        value,
+        {
+            "from": "id",
+            "pattern": r"Cart/([^?]+)\?key=(.+)$",
+            "template": "/cart/c/{0}?key={1}",
+            "to": "claim_url",
+        },
+    )
+    assert value["claim_url"] == "/cart/c/AbCdEf?key=XyZ789"
+    # Source untouched.
+    assert value["id"] == "gid://shopify/Cart/AbCdEf?key=XyZ789"
+
+
+def test_derive_field_named_captures_format_into_template():
+    value = {"id": "gid://shopify/Cart/AbCdEf?key=XyZ789"}
+    derive_field(
+        value,
+        {
+            "from": "id",
+            "pattern": r"Cart/(?P<token>[^?]+)\?key=(?P<key>.+)$",
+            "template": "/cart/c/{token}?key={key}",
+            "to": "claim_url",
+        },
+    )
+    assert value["claim_url"] == "/cart/c/AbCdEf?key=XyZ789"
+
+
+def test_derive_field_via_walker_writes_sibling_field():
+    data = {"cart": {"id": "gid://shopify/Cart/T?key=K", "checkout_url": "https://x"}}
+    apply_response_transforms(
+        data,
+        [
+            ResponseTransform(
+                path="cart",
+                fn="derive_field",
+                args={
+                    "from": "id",
+                    "pattern": r"Cart/([^?]+)\?key=(.+)$",
+                    "template": "/cart/c/{0}?key={1}",
+                    "to": "claim_url",
+                },
+            )
+        ],
+    )
+    assert data["cart"]["claim_url"] == "/cart/c/T?key=K"
+    # Adjacent fields preserved.
+    assert data["cart"]["checkout_url"] == "https://x"
+
+
+def test_derive_field_at_root_path_writes_root_field():
+    # UCP cart shape: id lives at root, not under a `cart` wrapper.
+    data = {"id": "gid://shopify/Cart/Tok123?key=abc", "line_items": []}
+    apply_response_transforms(
+        data,
+        [
+            ResponseTransform(
+                path="",
+                fn="derive_field",
+                args={
+                    "from": "id",
+                    "pattern": r"Cart/([^?]+)\?key=",
+                    "template": "{0}",
+                    "to": "cart_token",
+                },
+            )
+        ],
+    )
+    assert data["cart_token"] == "Tok123"
+
+
+def test_derive_field_no_match_is_noop():
+    value = {"id": "not-a-shopify-cart"}
+    derive_field(
+        value,
+        {
+            "from": "id",
+            "pattern": r"Cart/([^?]+)\?key=(.+)$",
+            "template": "/cart/c/{0}?key={1}",
+            "to": "claim_url",
+        },
+    )
+    assert "claim_url" not in value
+
+
+def test_derive_field_missing_source_is_noop():
+    value = {"unrelated": "x"}
+    derive_field(
+        value,
+        {
+            "from": "id",
+            "pattern": r".*",
+            "template": "{0}",
+            "to": "claim_url",
+        },
+    )
+    assert value == {"unrelated": "x"}
+
+
+def test_derive_field_non_string_source_is_noop():
+    value = {"id": 123}
+    derive_field(
+        value,
+        {
+            "from": "id",
+            "pattern": r".*",
+            "template": "{0}",
+            "to": "claim_url",
+        },
+    )
+    assert "claim_url" not in value
+
+
+def test_derive_field_missing_required_args_is_noop():
+    value = {"id": "anything"}
+    # No template
+    derive_field(value, {"from": "id", "pattern": r".*", "to": "out"})
+    assert "out" not in value
+    # No pattern
+    derive_field(value, {"from": "id", "template": "{0}", "to": "out"})
+    assert "out" not in value
+    # No `to`
+    derive_field(value, {"from": "id", "pattern": r".*", "template": "{0}"})
+    assert value == {"id": "anything"}
+
+
+def test_derive_field_overwrite_false_skips_existing_destination():
+    value = {"id": "abc-123", "out": "preexisting"}
+    derive_field(
+        value,
+        {
+            "from": "id",
+            "pattern": r"(\w+)-(\d+)",
+            "template": "{0}_{1}",
+            "to": "out",
+            "overwrite": False,
+        },
+    )
+    assert value["out"] == "preexisting"
+
+
+def test_derive_field_overwrite_true_replaces_existing():
+    value = {"id": "abc-123", "out": "preexisting"}
+    derive_field(
+        value,
+        {
+            "from": "id",
+            "pattern": r"(\w+)-(\d+)",
+            "template": "{0}_{1}",
+            "to": "out",
+        },
+    )
+    assert value["out"] == "abc_123"
+
+
+def test_derive_field_non_dict_returns_unchanged():
+    assert derive_field("hello", {}) == "hello"
+    assert derive_field(None, {}) is None
+    assert derive_field([1, 2], {}) == [1, 2]
+
+
+def test_derive_field_bad_regex_logs_and_is_noop():
+    value = {"id": "x"}
+    derive_field(
+        value,
+        {
+            "from": "id",
+            "pattern": r"(unclosed",
+            "template": "{0}",
+            "to": "out",
+        },
+    )
+    assert "out" not in value
+
+
+def test_derive_field_template_placeholder_mismatch_is_noop():
+    value = {"id": "abc-123"}
+    # Template references {5} but only 2 groups captured.
+    derive_field(
+        value,
+        {
+            "from": "id",
+            "pattern": r"(\w+)-(\d+)",
+            "template": "{5}",
+            "to": "out",
+        },
+    )
+    assert "out" not in value
+
+
+def test_derive_field_malformed_template_is_noop():
+    """Malformed format strings (bare ``{``, unbalanced braces, …) raise
+    ValueError from ``str.format`` — must be caught and no-op'd per the
+    documented contract, not propagate and abort the whole pass.
+    """
+    value = {"id": "abc-123"}
+    derive_field(
+        value,
+        {
+            "from": "id",
+            "pattern": r"(\w+)-(\d+)",
+            "template": "{",
+            "to": "out",
+        },
+    )
+    assert "out" not in value
+    # And as part of a larger transform pass — must not raise upstream.
+    data = {"products": [{"id": "ok-1"}, {"id": "ok-2"}]}
+    apply_response_transforms(
+        data,
+        [
+            ResponseTransform(
+                path="products[*]",
+                fn="derive_field",
+                args={
+                    "from": "id",
+                    "pattern": r"(\w+)-(\d+)",
+                    "template": "{",
+                    "to": "out",
+                },
+            )
+        ],
+    )
+    # Original values preserved, no "out" field added.
+    assert data["products"] == [{"id": "ok-1"}, {"id": "ok-2"}]

--- a/tests/test_ui_catalog_groups.py
+++ b/tests/test_ui_catalog_groups.py
@@ -10,9 +10,14 @@ from __future__ import annotations
 
 # Load template package first so its __init__ chain completes before any
 # `chat/*` module imports (mirrors test_ui_stream / test_session_state).
+import pytest
+from pydantic import ValidationError
+
 from app.ai.voice.agents.breeze_buddy.template.ui_catalog import (
     PRIMITIVE_GROUPS,
     UI_CATALOG,
+    SideEffect,
+    SideEffectKind,
     group_for,
     resolve_allowlist,
 )
@@ -123,3 +128,53 @@ def test_every_group_member_is_registered_in_catalog():
                 f"group {group_name!r} references {prim!r} "
                 f"which is not registered in UI_CATALOG"
             )
+
+
+# ---------------------------------------------------------------------------
+# SideEffect — kind-specific required fields enforced at validation time
+# ---------------------------------------------------------------------------
+
+
+def test_sideeffect_fetch_requires_url():
+    """``kind='fetch'`` without a non-empty ``url`` is invalid — the widget
+    would silently no-op, but the contract should reject at parse time."""
+    with pytest.raises(ValidationError, match="kind='fetch' requires"):
+        SideEffect(kind=SideEffectKind.fetch)
+    with pytest.raises(ValidationError, match="kind='fetch' requires"):
+        SideEffect(kind=SideEffectKind.fetch, url="")
+
+
+def test_sideeffect_fetch_with_url_is_valid():
+    op = SideEffect(kind=SideEffectKind.fetch, url="/cart/sync")
+    assert op.url == "/cart/sync"
+    assert op.method == "GET"
+    assert op.credentials == "include"
+
+
+def test_sideeffect_set_cookie_requires_name_and_value():
+    with pytest.raises(ValidationError, match="kind='set_cookie' requires"):
+        SideEffect(kind=SideEffectKind.set_cookie)
+    with pytest.raises(ValidationError, match="kind='set_cookie' requires.*name"):
+        SideEffect(kind=SideEffectKind.set_cookie, value="abc")
+    with pytest.raises(ValidationError, match="kind='set_cookie' requires.*value"):
+        SideEffect(kind=SideEffectKind.set_cookie, name="cart")
+    with pytest.raises(ValidationError, match="kind='set_cookie' requires.*name"):
+        SideEffect(kind=SideEffectKind.set_cookie, name="", value="abc")
+    with pytest.raises(ValidationError, match="kind='set_cookie' requires.*value"):
+        SideEffect(kind=SideEffectKind.set_cookie, name="cart", value="")
+
+
+def test_sideeffect_set_cookie_with_name_and_value_is_valid():
+    op = SideEffect(kind=SideEffectKind.set_cookie, name="cart", value="abc123")
+    assert op.name == "cart"
+    assert op.value == "abc123"
+    assert op.path == "/"
+    assert op.samesite == "Lax"
+    assert op.secure is True
+
+
+def test_sideeffect_default_kind_is_fetch_so_url_required():
+    """``kind`` defaults to ``fetch`` — a bare ``SideEffect()`` must reject
+    for the same reason ``SideEffect(kind=fetch)`` does."""
+    with pytest.raises(ValidationError, match="kind='fetch' requires"):
+        SideEffect()


### PR DESCRIPTION
## Summary

Adds two generic, vertical-agnostic pieces that together let any template declaratively sync a server-built identifier into a host-page cookie or HTTP request — used in production to pin the storefront's `/cart.js` cart cookie to the same Storefront-API / UCP cart that Buddy Assist built, so the merchant's online-store cart page reflects what the agent added.

The runtime stays commerce-agnostic; all Shopify-specific knowledge lives in the per-merchant template config (transforms + UI instructions). The widget-side companion of this ships in [loom#144](https://github.com/juspay/loom/pull/144).

## What's in this PR

### `response_transform.py` — `derive_field` transform

Reads a string field, runs a regex (positional or named captures), formats a template, and writes the result to a destination field on the same dict. Registered alongside `scale_by_exponent` / `pick_fields` / `strip_html` / `omit_fields`.

```json
{
  \"path\": \"\",
  \"fn\": \"derive_field\",
  \"args\": {
    \"from\": \"id\",
    \"pattern\": \"Cart/([^?]+)\\\\?key=\",
    \"template\": \"{0}\",
    \"to\": \"cart_token\"
  }
}
```

That above is the real production config for the Shopify UCP cart-sync (extracts the cart token from `gid://shopify/Cart/<token>?key=<key>` so a template can emit `SideEffect kind='set_cookie' name='cart' value:cart_token`).

The engine has no domain knowledge of carts, IDs, or URLs — pure regex+template.

### `ui_catalog.py` — `SideEffect` primitive (new `effects` group)

Invisible primitive (renders nothing). The widget runs a one-shot browser-side action on mount:

- **`kind='fetch'`** — fire-and-forget `fetch(url, {method, credentials})` for host-only endpoints, prefetch, analytics.
- **`kind='set_cookie'`** — same-origin `document.cookie` write to pin host-page state (the storefront `cart` cookie) to a server-built identifier.

Closed enum keeps the surface auditable. Per-page-session dedupe by `(kind, fingerprint)` so re-renders, multiple widget instances, and chat+voice all fire at most once.

Registered in `UI_CATALOG` + new `PRIMITIVE_GROUPS[\"effects\"]` + appended to `PRIMITIVE_RENDER_ORDER` (last — invisible, doesn't crowd the visual catalog). Templates opt in via `configurations.ui_catalog.enabled_groups = [\"core\", \"composite\", \"effects\"]`.

### Tests — `tests/test_response_transform.py`

14 new tests for `derive_field` covering positional captures, named captures, root-path application, no-match, missing source, non-string source, missing required args, `overwrite=False`, non-dict input, bad regex, template/groups mismatch, and the via-walker case writing a sibling field.

Also reorders imports with `# isort: off` / `# isort: on` so `template.types` loads before the utility import — the existing comment above `ResponseTransform` already documented the requirement; this just enforces it. Without this reorder, the test file fails to collect locally with `ImportError: cannot import name 'HttpRequestExecutor' ... (most likely due to a circular import)`. (CI runs only formatters + type-check; pytest isn't wired into `pr-build-check.yml`, which is presumably why this latent issue wasn't caught.)

## Companion PR

The widget-side `SideEffect.svelte` component (the thing that actually runs the fetch / cookie write in the browser) and the `UiNode.svelte` dispatch entry are in **[juspay/loom#144](https://github.com/juspay/loom/pull/144)**. Land that one first or together — the backend catalog change here is harmless without the widget piece (templates that don't emit `SideEffect` are unaffected).

## Verification

End-to-end on `www.milton.in` and `breeze-it-store.myshopify.com` (both UCP):
- `update_cart` returns `gid://shopify/Cart/<token>?key=<key>` → `derive_field` extracts `cart_token` → widget writes `document.cookie = 'cart=<token>; ...'` → storefront `/cart.js` returns the same cart, sticky across multiple agent turns (add 1 → 4 → 1 verified).

## Pre-existing failures surfaced

Once the circular-import is fixed, 2 upstream `strip_html` tests fail (`test_strip_html_via_walker_on_nested_path` and `test_combined_projection_strips_catalog_response_aggressively`) — both because `strip_html` leaves a space before punctuation when stripping inline tags (`\"<i>insulated</i>.\"` → `\"insulated .\"`). Pre-existing bug, **not introduced by this PR**, just newly visible since the file can now be collected. Out of scope here — happy to file a follow-up.

## Test plan

- [x] `uv run pytest tests/test_response_transform.py -q --deselect <pre-existing-strip-html-failures>` → **50 passed** (including 14 new derive_field tests)
- [x] `uv run black --check` clean on all three files
- [x] `uv run isort --check` clean
- [x] `uv run autoflake --check` clean
- [x] `uv run pyrefly check` — 0 errors
- [x] End-to-end verified in production against UCP storefronts (milton, breeze-it-store)
- [ ] Reviewer: load milton/breeze-it-store widget on a test storefront and confirm cart-sync after `update_cart`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added field derivation capability for response transformation using regex patterns and templates.
  * Introduced side effects support in UI primitives for fetch operations and cookie handling.

* **Tests**
  * Added comprehensive test coverage for field derivation transform.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/juspay/clairvoyance/pull/792?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->