### PR TITLE
bump: Bump the cartesia model version to sonic-3.5

### DIFF
--- a/app/ai/voice/agents/breeze_buddy/tts/__init__.py
+++ b/app/ai/voice/agents/breeze_buddy/tts/__init__.py
@@ -167,7 +167,7 @@ async def get_tts_service(voice_config: TTSConfig):
             CartesiaConfig(
                 api_key=CARTESIA_API_KEY,
                 voice_id=voice_config.voice_id or "",
-                model=voice_config.model or "sonic-3",
+                model=voice_config.model or "sonic-3.5",
                 language=_parse_language(voice_config.language),
                 generation_config=generation_config,
                 aggregate_sentences=aggregate,

--- a/app/ai/voice/tts/cartesia.py
+++ b/app/ai/voice/tts/cartesia.py
@@ -33,7 +33,7 @@ class CartesiaConfig:
 
     api_key: str
     voice_id: str
-    model: str = "sonic-3"
+    model: str = "sonic-3.5"
     language: Language = Language.EN
     generation_config: Optional[GenerationConfig] = None
     aggregate_sentences: bool = True
@@ -86,7 +86,7 @@ async def _generate_cartesia_audio(
     # Use provided values or fall back to Redis/hardcoded defaults
     defaults = await BB_VOICE_PROVIDER_DEFAULTS("cartesia")
     final_voice_id = voice_id or defaults.get("voice_id", "")
-    final_model = model or defaults.get("model", "sonic-3")
+    final_model = model or defaults.get("model", "sonic-3.5")
     language = defaults.get("language", "en")
 
     url = "https://api.cartesia.ai/tts/bytes"

--- a/app/core/config/dynamic.py
+++ b/app/core/config/dynamic.py
@@ -20,7 +20,7 @@ BB_SPEECH_PROVIDER_DEFAULTS: dict[str, dict] = {
     },
     "cartesia": {
         "voice_id": "bec003e2-3cb3-429c-8468-206a393c67ad",
-        "model": "sonic-3",
+        "model": "sonic-3.5",
         "speed": 1.0,
         "volume": 1.0,
         "emotion": "neutral",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the default text-to-speech model from sonic-3 to sonic-3.5. This affects voice output generation across the application when no specific model is configured.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/juspay/clairvoyance/pull/793?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->