### PR TITLE
feat(chat): UI metrics + compact wire form + repeat (fast/reliable/generic groundwork)

### DIFF
--- a/app/ai/voice/agents/breeze_buddy/chat/metrics.py
+++ b/app/ai/voice/agents/breeze_buddy/chat/metrics.py
@@ -1,0 +1,140 @@
+"""Per-turn UI-generation metrics for chat mode.
+
+Phase 0 of ``docs/widget/UI_FAST_RELIABLE_GENERIC_PLAN.md`` — the measurement
+foundation. A :class:`TurnMetrics` *observes* the SSE event stream a chat turn
+already emits (it never changes it) and logs one structured ``[CHAT_METRICS]``
+line at turn end. Everything it records is structural — timings, counts,
+op/drop classifications, byte sizes — and never user or tool payload content,
+so it respects the privacy-by-design logging contract.
+
+The two signals that drive the reliability + speed work:
+
+  * ``ui_dropped`` / ``drop_reasons`` — how often the healer/validator
+    discards an LLM-emitted op (the "missing Handoff" class of failure).
+  * ``ttfui_ms`` / ``ttlui_ms`` — time to first / last rendered op
+    (perceived + total UI latency).
+
+Query in OpenObserve with ``match_all_raw('[CHAT_METRICS]')`` and parse the
+``key=value`` tokens; tag before/after comparisons by the ``phase=`` field as
+each optimisation lands.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from typing import List, Optional
+
+from app.ai.voice.agents.breeze_buddy.chat.sse import SSEEvent
+from app.core.logger import logger
+
+# Cap distinct drop reasons so a pathological turn can't grow the log line
+# unbounded.
+_MAX_DROP_REASONS = 20
+
+
+class TurnMetrics:
+    """Accumulates structural metrics for one chat turn.
+
+    Construct with a monotonic ``t0`` (the caller picks the start point —
+    today: the moment ``agent.run_turn`` begins, i.e. UI-generation latency).
+    Feed every SSE event through :meth:`observe`, then call :meth:`emit` once
+    (idempotent) in the request's ``finally`` so it fires on the normal,
+    cancelled, and crashed paths alike.
+    """
+
+    def __init__(
+        self,
+        *,
+        session_id: str,
+        template_id: Optional[str],
+        t0: float,
+        phase: str = "baseline",
+    ) -> None:
+        self.session_id = session_id
+        self.template_id = template_id
+        self.t0 = t0
+        self.phase = phase
+        self.ttft_ms: Optional[float] = None  # first assistant_token (prose)
+        self.ttfui_ms: Optional[float] = None  # first ui_op (rendered UI)
+        self.ttlui_ms: Optional[float] = None  # last ui_op
+        self.ui_ops = 0
+        self.ui_dropped = 0
+        self.healer_applied = 0
+        self.tool_calls = 0
+        self.prose_chars = 0
+        self.ui_chars = 0
+        self.drop_reasons: List[str] = []
+        self.status: Optional[str] = None
+        self._emitted = False
+
+    def _ms(self) -> float:
+        return round((time.monotonic() - self.t0) * 1000, 1)
+
+    def observe(self, event: SSEEvent) -> None:
+        """Record one SSE event. Never raises — telemetry must not break a turn."""
+        try:
+            name = event.event
+            data = event.data if isinstance(event.data, dict) else {}
+            if name == "assistant_token":
+                if self.ttft_ms is None:
+                    self.ttft_ms = self._ms()
+                delta = data.get("delta")
+                if isinstance(delta, str):
+                    self.prose_chars += len(delta)
+            elif name == "ui_op":
+                now = self._ms()
+                if self.ttfui_ms is None:
+                    self.ttfui_ms = now
+                self.ttlui_ms = now
+                self.ui_ops += 1
+                op = data.get("op")
+                if op is not None:
+                    self.ui_chars += len(json.dumps(op, default=str))
+            elif name == "ui_op_dropped":
+                self.ui_dropped += 1
+                reason = data.get("reason")
+                if (
+                    isinstance(reason, str)
+                    and len(self.drop_reasons) < _MAX_DROP_REASONS
+                ):
+                    # First line only + hard truncate: validation errors lead
+                    # with a structural "N validation errors for <Model>" line;
+                    # any echoed input_value lives on later lines we drop, so
+                    # no payload content reaches the log. Whitespace is
+                    # collapsed to "_" so the value stays a single space-free
+                    # token in the key=value [CHAT_METRICS] line (parseable).
+                    first_line = reason.split("\n", 1)[0]
+                    self.drop_reasons.append("_".join(first_line.split())[:80])
+            elif name == "healer_applied":
+                self.healer_applied += 1
+            elif name == "function_call_started":
+                self.tool_calls += 1
+            elif name == "turn_end":
+                self.status = data.get("session_status")
+        except Exception:  # noqa: BLE001 - telemetry must never break a turn
+            pass
+
+    def emit(self) -> None:
+        """Log the structured metrics line once. Idempotent + non-raising."""
+        if self._emitted:
+            return
+        self._emitted = True
+        try:
+            reasons = ";".join(self.drop_reasons) if self.drop_reasons else "-"
+            logger.info(
+                "[CHAT_METRICS] "
+                f"session={self.session_id} template={self.template_id} "
+                f"phase={self.phase} status={self.status} "
+                f"ttft_ms={self.ttft_ms} ttfui_ms={self.ttfui_ms} "
+                f"ttlui_ms={self.ttlui_ms} total_ms={self._ms()} "
+                f"ui_ops={self.ui_ops} ui_dropped={self.ui_dropped} "
+                f"healer_applied={self.healer_applied} tool_calls={self.tool_calls} "
+                f"prose_chars={self.prose_chars} ui_chars={self.ui_chars} "
+                f"drop_reasons={reasons}"
+            )
+        except Exception:  # noqa: BLE001
+            pass
+
+
+__all__ = ["TurnMetrics"]

--- a/app/ai/voice/agents/breeze_buddy/chat/ui_stream.py
+++ b/app/ai/voice/agents/breeze_buddy/chat/ui_stream.py
@@ -22,6 +22,7 @@ one char at a time) — we keep a bounded carry buffer.
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 import re
@@ -208,6 +209,209 @@ class OpResult:
     healed_notes: List[str] = field(default_factory=list)
 
 
+# ---------------------------------------------------------------------------
+# Compact wire form (A3) — a terse shorthand the LLM emits, expanded
+# server-side to the canonical op shape *before* healing/validation. See
+# docs/widget/UI_FAST_RELIABLE_GENERIC_PLAN.md. Pure encoding change: the
+# canonical ops downstream — and the persisted ui_blocks the widget reads —
+# are unchanged. Both forms are accepted, so partial LLM adoption is always
+# safe; a malformed compact op falls through to the normal dropped path.
+#
+#   add:     {"+":"<id>:<Type>@<parent>", <prop>:<val>, ...}   (root drops "@<parent>")
+#   replace: {"~":"<id>", <prop>:<val>, ...}
+#   remove:  {"-":"<id>"}
+#   body row shorthand: {"kv":["Price","₹699"]} -> {"kind":"key_value","key":"Price","value":"₹699"}
+# ---------------------------------------------------------------------------
+
+_COMPACT_ADD_RE = re.compile(r"^\s*([^:@\s]+)\s*:\s*([^:@\s]+)\s*(?:@\s*(.+?))?\s*$")
+
+
+def _expand_body_shorthand(props: Dict[str, Any]) -> Dict[str, Any]:
+    """Expand ``{"kv":[k, v]}`` body items into canonical ``key_value`` items.
+
+    Only touches a list-valued ``body``; any item already in canonical
+    ``{"kind": ...}`` form (or any other shape) is left untouched.
+    """
+    body = props.get("body")
+    if not isinstance(body, list):
+        return props
+    new_body: List[Any] = []
+    changed = False
+    for item in body:
+        kv = item.get("kv") if isinstance(item, dict) else None
+        if isinstance(kv, list) and len(kv) == 2:
+            new_body.append({"kind": "key_value", "key": kv[0], "value": kv[1]})
+            changed = True
+        else:
+            new_body.append(item)
+    if not changed:
+        return props
+    return {**props, "body": new_body}
+
+
+def expand_compact_op(op: Dict[str, Any]) -> Dict[str, Any]:
+    """Expand one compact-form op dict to canonical shape.
+
+    Returns the input unchanged when it already carries an ``op`` key
+    (canonical) or is not a recognised compact form — so the two forms
+    coexist and a malformed compact op flows on to the normal parser, which
+    drops it with telemetry.
+    """
+    if not isinstance(op, dict) or "op" in op:
+        return op
+
+    spec = op.get("+")
+    if isinstance(spec, str):
+        m = _COMPACT_ADD_RE.match(spec)
+        if not m:
+            return op
+        out: Dict[str, Any] = {"op": "add", "id": m.group(1), "type": m.group(2)}
+        if m.group(3):
+            out["parent"] = m.group(3)
+        props = {k: v for k, v in op.items() if k != "+"}
+        # `repeat` is a structural directive (A1), not a visual prop — hoist it
+        # to the op level so the repeat expander sees it.
+        if "repeat" in props:
+            out["repeat"] = props.pop("repeat")
+        out["props"] = _expand_body_shorthand(props)
+        return out
+
+    rid = op.get("~")
+    if isinstance(rid, str):
+        return {
+            "op": "replace",
+            "id": rid,
+            "props": _expand_body_shorthand({k: v for k, v in op.items() if k != "~"}),
+        }
+
+    did = op.get("-")
+    if isinstance(did, str):
+        return {"op": "remove", "id": did}
+
+    return op
+
+
+def expand_compact_line(raw_line: str) -> str:
+    """Expand a compact-form JSONL line to canonical JSONL.
+
+    Pass-through (returns ``raw_line`` verbatim) for canonical lines and for
+    anything that doesn't parse as a JSON object — the downstream healer /
+    parser handle those exactly as before.
+    """
+    try:
+        op = json.loads(raw_line)
+    except (json.JSONDecodeError, ValueError):
+        return raw_line
+    if not isinstance(op, dict):
+        return raw_line
+    expanded = expand_compact_op(op)
+    if expanded is op:
+        return raw_line
+    return json.dumps(expanded, ensure_ascii=False)
+
+
+# ---------------------------------------------------------------------------
+# A1 — data/structure split (repeat + $item). The LLM emits ONE element with a
+# ``repeat`` directive carrying an inline data array; the server instantiates
+# the element once per row, binding ``{"$item":"<path>"}`` placeholders to that
+# row's value, and emits N canonical flat ops. The widget is unchanged (it gets
+# the same flat ops). Domain-blind: the engine only does "template x array -> N
+# ops"; what to show and which data live in the LLM-authored element + array, so
+# emergent per-item choices (e.g. binding the red variant's image) survive.
+# See docs/widget/UI_FAST_RELIABLE_GENERIC_PLAN.md.
+#
+#   {"op":"add","id":"tile","type":"Tile","parent":"root",
+#    "repeat":{"items":[{...},{...}],"key":"id"},
+#    "props":{"title":{"$item":"title"}, "media":{"src":{"$item":"image"}}}}
+# ---------------------------------------------------------------------------
+
+
+def _lookup_item_path(item: Any, path: str) -> Any:
+    """Resolve a dotted path (``a.b.c``) against one repeat row. A missing key
+    or a non-dict mid-path yields ``None`` (the prop is then dropped by
+    ``exclude_none`` at validation)."""
+    cur = item
+    for part in path.split("."):
+        if isinstance(cur, dict) and part in cur:
+            cur = cur[part]
+        else:
+            return None
+    return cur
+
+
+def _resolve_item_refs(value: Any, item: Any) -> Any:
+    """Recursively replace ``{"$item":"<path>"}`` placeholders with the value
+    at that path in ``item``. Everything else passes through unchanged, so a
+    template can freely mix bound and literal props."""
+    if isinstance(value, dict):
+        ref = value.get("$item")
+        if len(value) == 1 and isinstance(ref, str):
+            return _lookup_item_path(item, ref)
+        return {k: _resolve_item_refs(v, item) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_resolve_item_refs(v, item) for v in value]
+    return value
+
+
+def expand_repeat_line(line: str) -> List[str]:
+    """Expand a ``repeat`` template line into N canonical instance lines.
+
+    A line without ``repeat`` returns ``[line]`` unchanged (the common case).
+    A well-formed ``repeat`` returns one canonical op line per data row, with a
+    unique id derived from ``key`` (or the row index) and every ``{"$item":...}``
+    placeholder resolved. A ``repeat`` whose ``items`` isn't a list returns
+    ``[]`` — the bare template is never emitted, so it can't leak to the widget.
+    """
+    try:
+        op = json.loads(line)
+    except (json.JSONDecodeError, ValueError):
+        return [line]
+    if not isinstance(op, dict) or "repeat" not in op:
+        return [line]
+
+    rep = op.get("repeat")
+    items = rep.get("items") if isinstance(rep, dict) else None
+    if not isinstance(items, list):
+        return []
+    key = rep.get("key") if isinstance(rep, dict) else None
+    base = {k: v for k, v in op.items() if k != "repeat"}
+    tpl_id = base.get("id") or "item"
+    tpl_props = base.get("props")
+
+    out: List[str] = []
+    for idx, item in enumerate(items):
+        inst = dict(base)
+        suffix: Optional[str] = None
+        if isinstance(key, str) and isinstance(item, dict):
+            kv = item.get(key)
+            if kv is not None:
+                suffix = str(kv)
+        inst["id"] = f"{tpl_id}-{suffix if suffix is not None else idx}"
+        if isinstance(tpl_props, (dict, list)):
+            inst["props"] = _resolve_item_refs(tpl_props, item)
+        out.append(json.dumps(inst, ensure_ascii=False))
+    return out
+
+
+def _repeat_with_nonlist_items(line: str) -> bool:
+    """True when ``line`` is a ``repeat`` op whose ``items`` isn't a list.
+
+    Distinguishes a *malformed* repeat (which ``expand_repeat_line`` drops to
+    ``[]``) from a legitimately *empty* ``items: []`` (also ``[]`` but valid,
+    nothing to render). Lets ``process_op_line`` surface the malformed case as
+    an observable ``ui_op_dropped`` instead of a silent no-op.
+    """
+    try:
+        op = json.loads(line)
+    except (json.JSONDecodeError, ValueError):
+        return False
+    if not isinstance(op, dict) or "repeat" not in op:
+        return False
+    rep = op.get("repeat")
+    items = rep.get("items") if isinstance(rep, dict) else None
+    return not isinstance(items, list)
+
+
 def parse_op_line(line: str, *, allowlist: Optional[Set[str]] = None) -> OpResult:
     """Parse one JSONL line into a structured op dict; validate shape.
 
@@ -305,21 +509,56 @@ def ui_op_event(op: Dict[str, Any]) -> SSEEvent:
     return SSEEvent(event="ui_op", data={"op": op})
 
 
+def _op_signature(line: str) -> Dict[str, Any]:
+    """Structural-only descriptor of an op line for telemetry.
+
+    After ``repeat`` expansion a line carries resolved per-row props (titles,
+    prices, image URLs, …). Telemetry events must never forward that content,
+    so we surface only the structural keys (``op``/``id``/``type`` — ids and
+    type names, never payload), falling back to a short content hash so a
+    malformed/unparseable line is still correlatable without exposing data.
+    """
+    try:
+        obj = json.loads(line)
+    except (json.JSONDecodeError, ValueError):
+        obj = None
+    if isinstance(obj, dict):
+        sig = {
+            k: obj[k]
+            for k in ("op", "id", "type")
+            if isinstance(obj.get(k), (str, int))
+        }
+        if sig:
+            return sig
+    digest = hashlib.sha1(line.encode("utf-8", "replace")).hexdigest()[:12]
+    return {"hash": digest}
+
+
 def healer_applied_event(line: str, note: str) -> SSEEvent:
     """Observability event — fired when the healer fixed an incoming line.
 
-    Carries the original ``line`` (truncated) and a short ``note`` describing
-    the rule that fired. Widget ignores; server-side telemetry consumes.
+    Carries a structural-only op signature (never the resolved payload) and a
+    short ``note`` describing the rule that fired. Widget ignores; server-side
+    telemetry consumes.
     """
-    truncated = line if len(line) <= 200 else line[:200] + "…"
-    return SSEEvent(event="healer_applied", data={"raw": truncated, "note": note})
+    return SSEEvent(
+        event="healer_applied", data={"op": _op_signature(line), "note": note}
+    )
 
 
 def ui_op_dropped_event(line: str, reason: str) -> SSEEvent:
     """Observability event — fired when a line failed validation and was
-    dropped. Widget ignores."""
-    truncated = line if len(line) <= 200 else line[:200] + "…"
-    return SSEEvent(event="ui_op_dropped", data={"raw": truncated, "reason": reason})
+    dropped. Widget ignores.
+
+    Emits a structural-only op signature (never the resolved payload) and the
+    first line of ``reason`` — Pydantic errors echo ``input_value`` on later
+    lines, so we drop those here too (defense-in-depth alongside the metrics
+    layer's own truncation).
+    """
+    first_reason = reason.split("\n", 1)[0][:200]
+    return SSEEvent(
+        event="ui_op_dropped", data={"op": _op_signature(line), "reason": first_reason}
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -352,7 +591,8 @@ def process_op_line(
 ) -> List[SSEEvent]:
     """Run one raw JSONL line through (healer →) parse → validate → SSE.
 
-    Returns a list of SSE events (0 to ~3) to forward to the client:
+    Returns a list of SSE events to forward to the client (0 to many — a
+    ``repeat`` template fans out to one ``ui_op`` per data row):
       * ``healer_applied`` — one per applied healer note (telemetry)
       * ``ui_op_dropped`` — when validation fails (telemetry)
       * ``ui_op`` — the validated op, ready for the widget
@@ -367,30 +607,40 @@ def process_op_line(
     no template-level filtering applies.
     """
     events: List[SSEEvent] = []
-    line = raw_line
-
-    if healer is not None:
-        result = healer(line, session_state or {})
-        for note in result.notes:
-            events.append(healer_applied_event(line, note))
-        if result.drop:
-            return events
-        if result.line is not None:
-            line = result.line
-
-    parsed = parse_op_line(line, allowlist=allowlist)
-    if parsed.error:
-        events.append(ui_op_dropped_event(line, parsed.error))
+    # A3 — expand the compact wire form to canonical; then A1 — fan a `repeat`
+    # template out into one canonical line per data row. A plain op is a single
+    # line; canonical/unparseable lines pass through untouched.
+    compact_line = expand_compact_line(raw_line)
+    expanded = expand_repeat_line(compact_line)
+    # A malformed `repeat` (items not a list) expands to nothing. Surface it as
+    # an observable drop rather than rendering silently — keeps the reliability
+    # metrics honest. A legitimately empty `items: []` is not flagged.
+    if not expanded and _repeat_with_nonlist_items(compact_line):
+        events.append(ui_op_dropped_event(compact_line, "repeat_items_not_list"))
         return events
+    for line in expanded:
+        if healer is not None:
+            result = healer(line, session_state or {})
+            for note in result.notes:
+                events.append(healer_applied_event(line, note))
+            if result.drop:
+                continue
+            if result.line is not None:
+                line = result.line
 
-    op = parsed.op  # type: ignore[assignment]
-    if known_ids is not None and op is not None:
-        if op["op"] == "add":
-            known_ids.add(op["id"])
-        elif op["op"] == "remove":
-            known_ids.discard(op["id"])
+        parsed = parse_op_line(line, allowlist=allowlist)
+        if parsed.error:
+            events.append(ui_op_dropped_event(line, parsed.error))
+            continue
 
-    events.append(ui_op_event(op))  # type: ignore[arg-type]
+        op = parsed.op  # type: ignore[assignment]
+        if known_ids is not None and op is not None:
+            if op["op"] == "add":
+                known_ids.add(op["id"])
+            elif op["op"] == "remove":
+                known_ids.discard(op["id"])
+
+        events.append(ui_op_event(op))  # type: ignore[arg-type]
     return events
 
 
@@ -480,6 +730,9 @@ __all__ = [
     "OpResult",
     "HealerResult",
     "HealerFn",
+    "expand_compact_op",
+    "expand_compact_line",
+    "expand_repeat_line",
     "parse_op_line",
     "process_op_line",
     "ui_op_event",

--- a/app/ai/voice/agents/breeze_buddy/template/ui_prompt.py
+++ b/app/ai/voice/agents/breeze_buddy/template/ui_prompt.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 import enum
 import json
 import typing
+from functools import lru_cache
 from typing import Any, Dict, List, Set, Type, TypeGuard, Union, get_args, get_origin
 
 from pydantic import BaseModel
@@ -41,126 +42,65 @@ from app.ai.voice.agents.breeze_buddy.template.ui_catalog import (
 )
 
 # ---------------------------------------------------------------------------
-# Hard-coded minimal-but-realistic examples per primitive. The LLM cribs from
-# these for the JIT few-shot pattern, so they must round-trip through
+# Hard-coded minimal-but-realistic examples per primitive, shown in the
+# compact wire form (A3). The LLM cribs from these for the JIT few-shot
+# pattern, so each must round-trip through ``expand_compact_op`` ->
 # ``validate_props`` cleanly. Keep them small — one op per primitive.
 # ---------------------------------------------------------------------------
 
 
 _EXAMPLES: Dict[str, Dict[str, Any]] = {
     "Tile": {
-        "op": "add",
-        "id": "p1",
-        "type": "Tile",
-        "parent": "root",
-        "props": {
-            "media": {"src": "https://x/y.jpg", "alt": "snowboard"},
-            "title": "The Complete Snowboard",
-            "body": [{"kind": "key_value", "key": "Price", "value": "₹699.95"}],
-            "attributes": [{"label": "Premium", "tone": "info"}],
-            "actions": [
-                {
-                    "label": "View",
-                    "action": {
-                        "type": "to_assistant",
-                        "msg": "Tell me about <id>",
-                    },
-                }
-            ],
-        },
+        "+": "p1:Tile@root",
+        "media": {"src": "https://x/y.jpg", "alt": "snowboard"},
+        "title": "The Complete Snowboard",
+        "body": [{"kv": ["Price", "₹699.95"]}],
+        "attributes": [{"label": "Premium", "tone": "info"}],
+        "actions": [
+            {
+                "label": "View",
+                "action": {"type": "to_assistant", "msg": "Tell me about <id>"},
+            }
+        ],
     },
-    "Carousel": {
-        "op": "add",
-        "id": "c1",
-        "type": "Carousel",
-        "parent": "root",
-        "props": {"snap": True},
-    },
-    "Stack": {
-        "op": "add",
-        "id": "s1",
-        "type": "Stack",
-        "parent": "root",
-        "props": {"gap": "md"},
-    },
-    "Card": {
-        "op": "add",
-        "id": "card1",
-        "type": "Card",
-        "parent": "root",
-        "props": {"variant": "default"},
-    },
+    "Carousel": {"+": "c1:Carousel@root", "snap": True},
+    "Stack": {"+": "s1:Stack@root", "gap": "md"},
+    "Card": {"+": "card1:Card@root", "variant": "default"},
     "Image": {
-        "op": "add",
-        "id": "img1",
-        "type": "Image",
-        "parent": "card1",
-        "props": {
-            "src": "https://x/y.jpg",
-            "alt": "snowboard",
-            "aspect": "4:3",
-        },
+        "+": "img1:Image@card1",
+        "src": "https://x/y.jpg",
+        "alt": "snowboard",
+        "aspect": "4:3",
     },
     "Text": {
-        "op": "add",
-        "id": "t1",
-        "type": "Text",
-        "parent": "card1",
-        "props": {"text": "Limited edition release", "variant": "body"},
+        "+": "t1:Text@card1",
+        "text": "Limited edition release",
+        "variant": "body",
     },
-    "Tag": {
-        "op": "add",
-        "id": "tag1",
-        "type": "Tag",
-        "parent": "card1",
-        "props": {"text": "New", "tone": "info"},
-    },
+    "Tag": {"+": "tag1:Tag@card1", "text": "New", "tone": "info"},
     "Button": {
-        "op": "add",
-        "id": "btn1",
-        "type": "Button",
-        "parent": "card1",
-        "props": {
-            "label": "View",
-            "action": {
-                "type": "to_assistant",
-                "msg": "Tell me more about <id>",
-            },
-            "variant": "primary",
-        },
+        "+": "btn1:Button@card1",
+        "label": "View",
+        "action": {"type": "to_assistant", "msg": "Tell me more about <id>"},
+        "variant": "primary",
     },
     "Handoff": {
-        "op": "add",
-        "id": "h1",
-        "type": "Handoff",
-        "parent": "root",
-        "props": {
-            "reason": "<intent>",
-            "label": "Continue",
-            "url": "https://example/handoff/abc",
-            "lifecycle": "popup",
-        },
+        "+": "h1:Handoff@root",
+        "reason": "<intent>",
+        "label": "Continue",
+        "url": "https://example/handoff/abc",
+        "lifecycle": "popup",
     },
     "Message": {
-        "op": "add",
-        "id": "msg1",
-        "type": "Message",
-        "parent": "root",
-        "props": {
-            "severity": "warning",
-            "resolution": "recoverable",
-            "content": "Temporary issue retrieving data.",
-        },
+        "+": "msg1:Message@root",
+        "severity": "warning",
+        "resolution": "recoverable",
+        "content": "Temporary issue retrieving data.",
     },
     "Table": {
-        "op": "add",
-        "id": "tbl1",
-        "type": "Table",
-        "parent": "root",
-        "props": {
-            "columns": ["Item", "Qty", "Total"],
-            "rows": [["Item A", "1", "100"]],
-        },
+        "+": "tbl1:Table@root",
+        "columns": ["Item", "Qty", "Total"],
+        "rows": [["Item A", "1", "100"]],
     },
 }
 
@@ -383,7 +323,24 @@ _HEADER = (
     "## Available primitives\n"
     "\n"
     "Use ONLY these primitive types in <ui_stream> ops. The server drops "
-    "unknown or disabled types silently. Asterisk (*) marks required props."
+    "unknown or disabled types silently. Asterisk (*) marks required props.\n"
+    "\n"
+    "Emit each op in COMPACT wire form (fewer tokens):\n"
+    '  add:     {"+":"<id>:<Type>@<parent>", <prop>:<val>, ...}   '
+    '(props are top-level keys; a root op drops "@<parent>")\n'
+    '  replace: {"~":"<id>", <prop>:<val>, ...}\n'
+    '  remove:  {"-":"<id>"}\n'
+    '  body key/value row: {"kv":["Label","Value"]}\n'
+    "Each Example below uses this form. The canonical "
+    '{"op":"add","id":...,"type":...,"props":{...}} shape is also accepted.\n'
+    "\n"
+    "Lists — render N similar items with ONE element, not N (far fewer tokens):\n"
+    '  {"+":"tile:Tile@root", "repeat":{"items":[<rows>],"key":"id"}, '
+    '"title":{"$item":"title"}, "media":{"src":{"$item":"image"}}}\n'
+    "  `repeat.items` is your data array — YOU pick the rows and which fields "
+    "to surface (so per-item choices like the matching variant's image/price "
+    'still apply); `{"$item":"<field>"}` binds that row\'s value (dotted '
+    "paths ok). The server expands it to one op per row, so all rows render."
 )
 
 _FOOTER = (
@@ -396,14 +353,41 @@ _FOOTER = (
     '  - Root id is always "root"; root op omits `parent`.\n'
     "  - All non-root `add` ops MUST have `parent`.\n"
     "  - `replace` swaps props on an existing id; `remove` deletes a node.\n"
-    '  - For "items in a list", emit ONE Tile per item — never compose '
-    "Card+Image+Text manually."
+    '  - For "items in a list", emit ONE Tile per item via a `repeat` '
+    "template (see Lists above) — never compose Card+Image+Text manually."
 )
 
 _EMPTY_BODY = (
     "(No primitives are enabled for this template. The widget will render "
     "nothing — keep responses prose-only.)"
 )
+
+
+@lru_cache(maxsize=64)
+def _render_primitives_section_cached(allowlist_key: frozenset) -> str:
+    """Pure render keyed by a hashable allowlist (D1, see
+    ``docs/widget/UI_FAST_RELIABLE_GENERIC_PLAN.md``).
+
+    The catalog (``UI_CATALOG`` / ``PRIMITIVE_RENDER_ORDER`` / ``_EXAMPLES``)
+    is static at module load, so the rendered section is a deterministic
+    function of the allowlist — safe to memoise for the process lifetime.
+    Keyed by ``frozenset`` so templates sharing a UI allowlist share one
+    rendered section (and one Pydantic-introspection pass), instead of
+    re-walking the catalog on every ``_splice_ui_primitives`` call (up to
+    several per turn).
+    """
+    allowlist = set(allowlist_key)
+    entries: List[str] = []
+    for name in PRIMITIVE_RENDER_ORDER:
+        if name not in allowlist:
+            continue
+        model = UI_CATALOG.get(name)
+        if model is None:
+            continue
+        entries.append(_render_entry(name, model))
+
+    body = "\n\n".join(entries) if entries else _EMPTY_BODY
+    return f"{_HEADER}\n\n{body}\n\n{_FOOTER}"
 
 
 def render_primitives_section(allowlist: Set[str]) -> str:
@@ -419,18 +403,12 @@ def render_primitives_section(allowlist: Set[str]) -> str:
     "nothing enabled" note + the footer, so the prompt still parses and
     the LLM understands the situation rather than crashing on missing
     text.
-    """
-    entries: List[str] = []
-    for name in PRIMITIVE_RENDER_ORDER:
-        if name not in allowlist:
-            continue
-        model = UI_CATALOG.get(name)
-        if model is None:
-            continue
-        entries.append(_render_entry(name, model))
 
-    body = "\n\n".join(entries) if entries else _EMPTY_BODY
-    return f"{_HEADER}\n\n{body}\n\n{_FOOTER}"
+    Memoised by allowlist (see :func:`_render_primitives_section_cached`):
+    the section is rebuilt from the static catalog once per distinct
+    allowlist, not per turn.
+    """
+    return _render_primitives_section_cached(frozenset(allowlist))
 
 
 __all__ = ["render_primitives_section"]

--- a/app/api/routers/breeze_buddy/chat/handlers.py
+++ b/app/api/routers/breeze_buddy/chat/handlers.py
@@ -7,6 +7,7 @@ stay thin: validate auth, then delegate.
 """
 
 import asyncio
+import time
 from typing import Any, AsyncIterator, Callable, Dict, Optional
 
 from fastapi import HTTPException, status
@@ -17,6 +18,7 @@ from app.ai.voice.agents.breeze_buddy.chat.block_codec import (
     blocks_to_llm_context_messages,
     filter_visible_blocks,
 )
+from app.ai.voice.agents.breeze_buddy.chat.metrics import TurnMetrics
 from app.ai.voice.agents.breeze_buddy.chat.sse import SSEEvent, format_sse
 from app.ai.voice.agents.breeze_buddy.llm import get_llm_service
 from app.ai.voice.agents.breeze_buddy.template.cache import get_template_by_id_cached
@@ -479,6 +481,15 @@ async def send_chat_message_handler(
         # on Optional narrowing surviving the boundary.
         resume_node = fresh.current_node
 
+        # Phase-0 measurement (docs/widget/UI_FAST_RELIABLE_GENERIC_PLAN.md):
+        # observe the turn's SSE stream and log one [CHAT_METRICS] line at the
+        # end. Passive — never mutates the events the widget receives.
+        turn_metrics = TurnMetrics(
+            session_id=session_id,
+            template_id=template.id,
+            t0=time.monotonic(),
+        )
+
         async def stream() -> AsyncIterator[str]:
             # Register ourselves so /cancel can find and cancel this task
             # cross-pod. The registration MUST happen inside the generator
@@ -498,6 +509,7 @@ async def send_chat_message_handler(
                         history=history,
                         current_node=resume_node,
                     ):
+                        turn_metrics.observe(event)
                         yield format_sse(event)
                 except asyncio.CancelledError:
                     # User clicked Stop. Emit a clean turn_end so the client
@@ -527,6 +539,7 @@ async def send_chat_message_handler(
                     logger.info(
                         f"send_message stream for session {session_id} cancelled by user"
                     )
+                    turn_metrics.status = "CANCELED"
                     yield format_sse(
                         SSEEvent(event="turn_end", data={"session_status": "CANCELED"})
                     )
@@ -547,10 +560,12 @@ async def send_chat_message_handler(
                             },
                         )
                     )
+                    turn_metrics.status = "FAILED"
                     yield format_sse(
                         SSEEvent(event="turn_end", data={"session_status": "FAILED"})
                     )
             finally:
+                turn_metrics.emit()
                 if registered and current_task is not None:
                     cancel_bus.unregister(session_id, current_task)
                 # Shield the release: on a natural client disconnect path

--- a/docs/widget/UI_FAST_RELIABLE_GENERIC_PLAN.md
+++ b/docs/widget/UI_FAST_RELIABLE_GENERIC_PLAN.md
@@ -1,0 +1,181 @@
+# Buddy Widget — Fast, Reliable, Generic UI (execution plan)
+
+**Status:** In progress — Phase 0 landing in this branch
+**Companion:** `docs/widget/UI_PERF_OPTIMIZATIONS.md` (PR #801) — the perf survey this plan executes against.
+**Scope:** `chat/{agent,ui_stream,ui_healer,metrics}.py`, `api/routers/breeze_buddy/chat/handlers.py`, `template/*`, the 4 Shopify-assist templates.
+
+## Goal & non-negotiables
+
+Make the widget's generative UI **fast**, **reliable**, and **generic** — without
+giving up the thing that makes it generative.
+
+- **The LLM stays the author of the UI.** We do *not* move card rendering
+  server-side. Emergent UI (e.g. an ad-hoc "WhatsApp support" redirect button the
+  model decides to show) must keep working.
+- **Engine stays domain-blind.** Every domain specific (Handoff label/url,
+  required-op declarations, render hints) lives in the **template**. Widget
+  primitives stay vertical-agnostic.
+- **Catalog is the single source of truth.** Every change is additive / opt-in,
+  with the flat-op form preserved as fallback (per `UI_PERF_OPTIMIZATIONS.md` §6).
+- **Don't over-engineer.** Measure first; add machinery only where the numbers
+  demand it.
+
+## The incident this addresses
+
+Production (The Drip Co., 2026-05-29, session `f659423e`): a cart rendered the
+tiles + total but the **"Review and checkout" Handoff was missing** — the LLM
+emitted `… → CardHeader(total) → SideEffect`, silently skipping the Handoff op
+(present in 3 of 4 carts that day, ~25% drop). Not truncation (the op *after* it
+was emitted), not a render bug — **the LLM intermittently drops a structural op.**
+The cart-cookie `SideEffect` is LLM-emitted too, so it carries the same risk.
+
+The fix for the dropped button and the fix for slow rendering turn out to be the
+**same lever** — shorter, more structured, cached emission renders faster *and*
+drops fewer ops. Speed and reliability are not traded against each other here.
+
+## How we get reliability (LLM keeps authoring)
+
+Three generic levers, cheapest first:
+
+1. **Make it hard to drop** — restructure the cart `tool_ui_instructions` into a
+   tight ordered checklist with a hard invariant ("the Review-and-checkout
+   Handoff is MANDATORY; a cart without it is invalid"). Plus shorter emission
+   (lever A1 below) drifts less. Cuts the rate; not a guarantee.
+2. **Self-heal the gap** — template declares per-render *required ops* (by id); at
+   turn finalization the healer **injects any the LLM dropped**, from the declared
+   snippet. The LLM still authors the card; the net is invisible unless it fails.
+   This is the *guarantee*, and it's the "self-healing when needed" goal. A
+   guardrail, **not** a server render.
+3. **Constrain at generation time** (`UI_PERF_OPTIMIZATIONS.md` Tier C) — emit ops
+   through a JSON-Schema-constrained channel so invalid/incomplete renders can't
+   be generated. Durable end-state; heavier.
+
+## How we get speed (none of it touches authorship)
+
+Time-to-UI is gated by tokens emitted + when generation starts. Three sub-levers:
+
+- **Emit fewer tokens** — **A3** compact wire form (~30-40%/op), **A1**
+  data/structure split (`repeat`/`$item`, 5-10× on lists; the model authors the
+  template, the server binds the already-present tool-result data).
+- **Start sooner** — Tier **D** free wins (prompt-cache the catalog, move
+  `_ui_examples` to the cached prefix, `emits_ui` skip, short-circuit validation).
+- **Paint progressively** — Tier **B** per-prop streaming (skeletons; perceived
+  first-paint ~200-400ms).
+
+> Trade-off we accepted by keeping the LLM as author: no ~100ms server-paint (that
+> needed server-side emission). Floor is TTFT + first tokens → realistically
+> ~200-400ms perceived + a much faster total. That's the price of generative UI.
+
+## Phases
+
+### Phase 0 — Foundation (this branch)
+- [x] **Turn metrics** (`chat/metrics.py` + router observation): `ttft_ms`,
+      `ttfui_ms`, `ttlui_ms`, `total_ms`, `ui_ops`, **`ui_dropped` + reasons**,
+      `healer_applied`, `tool_calls`, `prose_chars`, `ui_chars`, `status` — one
+      structured `[CHAT_METRICS]` log per turn, tagged by `phase=`. Passive; never
+      mutates the wire. Structural only (no payload content).
+- [ ] Dashboards / queries: drop-rate and TTFR p50/p95/p99 by template.
+
+### Phase 1 — Now (cheap, template-only)
+- [ ] **Cart instruction hardening** on the 4 templates — ordered checklist +
+      mandatory-Handoff invariant; make the cart-cookie `SideEffect` equally
+      non-skippable. *(Production PUT — reviewed before deploy.)*
+- **Tier D free wins** — [x] D1 LRU primitives cache · [ ] D2 Anthropic
+      `cache_control` markers · [ ] D3 `_ui_examples` → cached system prompt ·
+      [ ] D4 short-circuit `validate_props` · [ ] D5 `emits_ui` skip. *(D2/D4/D3
+      touch the live LLM-call or validation hot path — each is its own change,
+      not batched.)*
+
+### Phase 2 — Next (bigger speed, no authorship change)
+- [x] **A3** compact wire form — LLM emits `{"+":"<id>:<Type>@<parent>", ...props}`
+      / `{"~":"id",...}` / `{"-":"id"}` + `{"kv":[k,v]}` body rows; expanded
+      server-side in `ui_stream.expand_compact_op` *before* the healer, so the
+      canonical ops + persisted `ui_blocks` are unchanged and both forms are
+      accepted. **Measured: ~15% smaller on a content-heavy carousel, up to ~46%
+      on small structural ops** (lower than #801's 30-40% because real tiles are
+      content-dominated — that's A1's territory).
+- **A1** data/structure split (`repeat`/`$item`):
+  - [x] **v1 — inline data.** LLM emits ONE element with `repeat:{items:[...],key}`
+        + `{"$item":"<path>"}` bindings; the server fans it out to N canonical flat
+        ops in `ui_stream.expand_repeat_line` (no widget change; all rows always
+        render — they can't be individually dropped). The LLM still shapes the data
+        array, so per-item emergent choices (e.g. binding the red variant's image)
+        survive. **Measured ~33% smaller / 1.5x on an 8-tile carousel** (structural
+        repetition removed; data is typed once).
+  - [ ] **v2 — tool-result binding (deferred).** Bind the array from the turn's
+        tool result so the LLM types *no* data → the ~5–10x cut on large
+        "show-all" lists. Agent-level (the expander must read the turn's tool
+        results). **Build bind-all only — NOT selector paths or id-select-lists.**
+        Gated on metrics. See the full breakdown in "A1 v2 — the breakdown" below.
+
+### Phase 3 — Only if metrics still show gaps
+- [ ] **Self-heal completion net** — declared required-ops, inject-on-miss in the
+      healer. The reliability *guarantee*; build only if Phase 1 doesn't drive
+      drops to ~0.
+- [ ] **B** per-prop streaming (perceived first-paint).
+- [ ] **Tier C** constrained decoding (durable reliability end-state).
+
+## Sequencing
+
+`Phase 0 → Phase 1 → measure → Phase 2 (A1 for the carousel win) → reach into
+Phase 3 only where the numbers say so.` Ship and measure before each escalation.
+
+## A1 v2 — tool-result binding: the breakdown (deferred)
+
+**What it is.** In v1 the LLM types the data array (`repeat:{items:[...]}`); the
+server only dedups the *structure* (~33%). In v2 the LLM types **no data** — it
+references the tool result, and the server binds the array from the tool output
+that's already in context: `repeat:{from:"<tool>.<path>"}`. LLM output collapses
+to the template + a reference → the ~5–10x cut, and the data is the *literal
+tool result* so prices/URLs/images can't be mistyped.
+
+**The catch.** Binding the raw array shows *all* of it. The moment the model
+wants anything other than "all rows, default fields," the selection has to be
+expressed *somehow* — and where that selection lives decides reliability.
+
+**Three list shapes → three mechanisms.** They are not the same problem:
+
+| Shape | Reliable mechanism | Why |
+|---|---|---|
+| **Show ALL of a result** (20 of 20, default fields) | **v2 bind-all** `repeat:{from:"<tool>.<path>"}` | one tool reference; data from source; the big win |
+| **Show a chosen SUBSET** (5 of 20) | **v1 inline** — LLM emits the 5 rows it picked | selection is the LLM's strength; bind-all would show 20; an id-select-list would add a reference surface for a modest win |
+| **Per-item value selection** (red variant's image, not default) | **v1 inline / flat** — LLM picks each value | the LLM reasons over the data; a predicate can't ("crimson" ≠ "Red", out-of-stock fallbacks, …) |
+
+**Build vs don't build.**
+- **Build (if justified): bind-all only.** `from` is a dotted path into the
+  latest tool result; no `items`, no `select`, no predicates. Covers the dominant
+  "show me the products" case.
+- **Don't build: selector paths** (`variants[options.color='Red'].image`). They
+  move the LLM's reliable *semantic* selection into an abstract *declarative
+  query* the engine executes — schema-coupled, silent `None` failures, can't
+  handle the messy real cases. The LLM is better at selection than at writing
+  correct predicates.
+- **Probably don't build: id-select-lists.** For subsets, v1 (emit the chosen
+  rows) avoids the reference surface entirely; the id-list saving is modest.
+  Revisit only if large subset-renders prove common.
+
+**The principle.** *Engine for mechanical binding, LLM for semantic selection.*
+v2's win is moving **data** to the engine (reliable: no typos, from source). Its
+one new failure surface is the **reference** — the LLM must name the right tool
+result + path; a wrong reference fails silently (empty list). Never push the
+*which/what* (selection) into a binding the engine resolves — that's where
+reliability drops.
+
+**Implementation notes.** Agent-level: `expand_repeat_line` is stateless today
+(per line). v2 needs a `tool_data` dict (`tool_name → latest result`) threaded
+from the agent's `_run_turn_inner` (which already accumulates `tool_result_pairs`)
+into `process_op_line`. Timing: a `from`-binding can only reference a tool result
+from a **completed prior cycle** (results land after each cycle's stream) — the
+normal "search in cycle N, render in cycle N+1" flow satisfies this; a reference
+to a not-yet-returned tool resolves to empty. Stays domain-blind: `from` is just a
+path; the engine never learns "products."
+
+**Decision gate.** Build *nothing* here until `[CHAT_METRICS]` shows large
+"show-all" carousels (high `ui_chars` from many rows on uniform lists) are common
+*and* their token cost is a real latency/cost driver. If subset / per-item lists
+dominate instead, v1 already covers them reliably — do nothing.
+
+## Done already (context)
+- **Cart-cookie key fix** — the `cart` cookie now carries `<token>%3Fkey%3D<key>`
+  (was keyless, which made `/checkout` mint a new empty cart). Deployed + verified
+  on all 4 Shopify-assist templates.

--- a/tests/test_compact_wire_form.py
+++ b/tests/test_compact_wire_form.py
@@ -1,0 +1,265 @@
+"""Tests for the A3 compact wire form expander (``chat/ui_stream.py``).
+
+Covers ``expand_compact_op`` / ``expand_compact_line``: add/replace/remove
+shorthand, the ``{"kv":[k,v]}`` body shorthand, canonical + malformed
+pass-through, and an end-to-end check that a compact line through
+``process_op_line`` yields the same canonical ``ui_op`` as its canonical
+equivalent.
+"""
+
+from __future__ import annotations
+
+import json
+
+from app.ai.voice.agents.breeze_buddy.chat.ui_stream import (
+    expand_compact_line,
+    expand_compact_op,
+    expand_repeat_line,
+    process_op_line,
+)
+
+
+def test_compact_add_with_parent() -> None:
+    out = expand_compact_op({"+": "p1:Tile@root", "title": "Dawn"})
+    assert out == {
+        "op": "add",
+        "id": "p1",
+        "type": "Tile",
+        "parent": "root",
+        "props": {"title": "Dawn"},
+    }
+
+
+def test_compact_add_root_omits_parent() -> None:
+    out = expand_compact_op({"+": "root:Stack", "gap": "md"})
+    assert out == {"op": "add", "id": "root", "type": "Stack", "props": {"gap": "md"}}
+    assert "parent" not in out
+
+
+def test_compact_replace() -> None:
+    out = expand_compact_op({"~": "p1", "title": "New"})
+    assert out == {"op": "replace", "id": "p1", "props": {"title": "New"}}
+
+
+def test_compact_remove() -> None:
+    out = expand_compact_op({"-": "p1"})
+    assert out == {"op": "remove", "id": "p1"}
+
+
+def test_kv_body_shorthand_expands() -> None:
+    out = expand_compact_op({"+": "p1:Tile@root", "body": [{"kv": ["Price", "₹699"]}]})
+    assert out["props"]["body"] == [
+        {"kind": "key_value", "key": "Price", "value": "₹699"}
+    ]
+
+
+def test_canonical_body_item_left_untouched() -> None:
+    item = {"kind": "key_value", "key": "Price", "value": "₹1"}
+    out = expand_compact_op({"+": "p1:Tile@root", "body": [item]})
+    assert out["props"]["body"] == [item]
+
+
+def test_canonical_op_passes_through_identically() -> None:
+    canonical = {"op": "add", "id": "p1", "type": "Tile", "parent": "root", "props": {}}
+    assert expand_compact_op(canonical) is canonical
+
+
+def test_malformed_compact_spec_passes_through() -> None:
+    # No "id:Type" colon — can't expand; return unchanged so the parser drops it.
+    bad = {"+": "justanid", "title": "x"}
+    assert expand_compact_op(bad) is bad
+
+
+def test_expand_line_canonical_passthrough_is_verbatim() -> None:
+    line = '{"op":"add","id":"root","type":"Stack"}'
+    assert expand_compact_line(line) == line
+
+
+def test_expand_line_non_json_and_non_dict_passthrough() -> None:
+    assert expand_compact_line("not json") == "not json"
+    assert expand_compact_line("[1,2,3]") == "[1,2,3]"  # valid JSON, but not a dict
+
+
+def test_expand_line_produces_canonical_json() -> None:
+    out = expand_compact_line('{"+":"p1:Tile@root","title":"Dawn"}')
+    assert json.loads(out) == {
+        "op": "add",
+        "id": "p1",
+        "type": "Tile",
+        "parent": "root",
+        "props": {"title": "Dawn"},
+    }
+
+
+def test_compact_and_canonical_yield_same_ui_op_end_to_end() -> None:
+    """A compact line and its canonical equivalent must produce identical
+    ui_op events through the full process_op_line pipeline (no healer)."""
+    compact = '{"+":"t1:Tile@root","title":"Dawn","body":[{"kv":["Price","₹699"]}]}'
+    canonical = (
+        '{"op":"add","id":"t1","type":"Tile","parent":"root","props":'
+        '{"title":"Dawn","body":[{"kind":"key_value","key":"Price","value":"₹699"}]}}'
+    )
+    ev_c = [e for e in process_op_line(compact) if e.event == "ui_op"]
+    ev_k = [e for e in process_op_line(canonical) if e.event == "ui_op"]
+    assert len(ev_c) == 1 and len(ev_k) == 1
+    assert ev_c[0].data["op"] == ev_k[0].data["op"]
+
+
+# ---------------------------------------------------------------------------
+# A1 — repeat / $item expansion
+# ---------------------------------------------------------------------------
+
+
+def _parse_lines(lines: list[str]) -> list[dict]:
+    return [json.loads(line) for line in lines]
+
+
+def test_repeat_fans_out_one_op_per_row_with_keyed_ids() -> None:
+    line = json.dumps(
+        {
+            "op": "add",
+            "id": "tile",
+            "type": "Tile",
+            "parent": "root",
+            "repeat": {
+                "items": [{"id": "a", "title": "Alpha"}, {"id": "b", "title": "Beta"}],
+                "key": "id",
+            },
+            "props": {"title": {"$item": "title"}},
+        }
+    )
+    out = _parse_lines(expand_repeat_line(line))
+    assert [o["id"] for o in out] == ["tile-a", "tile-b"]
+    assert [o["props"]["title"] for o in out] == ["Alpha", "Beta"]
+    # repeat is stripped from the instances; structure carries through
+    assert all("repeat" not in o for o in out)
+    assert all(o["type"] == "Tile" and o["parent"] == "root" for o in out)
+
+
+def test_repeat_without_key_uses_index() -> None:
+    line = json.dumps(
+        {
+            "op": "add",
+            "id": "t",
+            "type": "Tile",
+            "parent": "root",
+            "repeat": {"items": [{"title": "X"}, {"title": "Y"}]},
+            "props": {"title": {"$item": "title"}},
+        }
+    )
+    out = _parse_lines(expand_repeat_line(line))
+    assert [o["id"] for o in out] == ["t-0", "t-1"]
+
+
+def test_item_dotted_path_and_nested_binding() -> None:
+    line = json.dumps(
+        {
+            "op": "add",
+            "id": "t",
+            "type": "Tile",
+            "parent": "root",
+            "repeat": {"items": [{"id": "1", "v": {"img": "u1.jpg"}}], "key": "id"},
+            "props": {"media": {"src": {"$item": "v.img"}, "alt": "x"}},
+        }
+    )
+    out = _parse_lines(expand_repeat_line(line))
+    assert out[0]["props"]["media"] == {"src": "u1.jpg", "alt": "x"}
+
+
+def test_item_missing_field_resolves_to_none() -> None:
+    line = json.dumps(
+        {
+            "op": "add",
+            "id": "t",
+            "type": "Tile",
+            "parent": "root",
+            "repeat": {"items": [{"id": "1"}], "key": "id"},
+            "props": {"title": {"$item": "title"}},
+        }
+    )
+    out = _parse_lines(expand_repeat_line(line))
+    assert out[0]["props"]["title"] is None
+
+
+def test_repeat_empty_or_invalid_items_emits_nothing() -> None:
+    base = {"op": "add", "id": "t", "type": "Tile", "parent": "root", "props": {}}
+    assert expand_repeat_line(json.dumps({**base, "repeat": {"items": []}})) == []
+    assert expand_repeat_line(json.dumps({**base, "repeat": {"items": "nope"}})) == []
+
+
+def test_no_repeat_passes_line_through_verbatim() -> None:
+    line = '{"op":"add","id":"root","type":"Stack"}'
+    assert expand_repeat_line(line) == [line]
+
+
+def test_compact_repeat_hoists_and_expands_end_to_end() -> None:
+    """A compact repeat template emits one validated ui_op per row through the
+    full pipeline, binding each row's data — including a per-item 'red variant'
+    image the LLM placed in the data array (emergent choice preserved)."""
+    compact = json.dumps(
+        {
+            "+": "tile:Tile@root",
+            "repeat": {
+                "items": [
+                    {
+                        "id": "9",
+                        "title": "Red Bottle A",
+                        "img": "https://cdn/red-a.jpg",
+                    },
+                    {
+                        "id": "8",
+                        "title": "Red Bottle B",
+                        "img": "https://cdn/red-b.jpg",
+                    },
+                ],
+                "key": "id",
+            },
+            "title": {"$item": "title"},
+            "media": {"src": {"$item": "img"}, "alt": {"$item": "title"}},
+        }
+    )
+    ui_ops = [e.data["op"] for e in process_op_line(compact) if e.event == "ui_op"]
+    assert len(ui_ops) == 2
+    assert [o["id"] for o in ui_ops] == ["tile-9", "tile-8"]
+    assert ui_ops[0]["type"] == "Tile" and ui_ops[0]["parent"] == "root"
+    assert ui_ops[0]["props"]["title"] == "Red Bottle A"
+    assert ui_ops[0]["props"]["media"]["src"] == "https://cdn/red-a.jpg"
+    assert ui_ops[1]["props"]["media"]["src"] == "https://cdn/red-b.jpg"
+
+
+def test_malformed_repeat_emits_observable_drop() -> None:
+    """A repeat whose items isn't a list is surfaced as ui_op_dropped
+    (reason=repeat_items_not_list) instead of silently rendering nothing."""
+    line = json.dumps(
+        {
+            "op": "add",
+            "id": "t",
+            "type": "Tile",
+            "parent": "root",
+            "repeat": {"items": "nope"},
+            "props": {},
+        }
+    )
+    events = process_op_line(line)
+    dropped = [e for e in events if e.event == "ui_op_dropped"]
+    assert len(dropped) == 1
+    assert dropped[0].data["reason"] == "repeat_items_not_list"
+    # Structural-only op signature — no resolved payload (props/repeat) leaks.
+    assert dropped[0].data["op"].get("type") == "Tile"
+    assert "props" not in dropped[0].data["op"]
+    assert "repeat" not in dropped[0].data["op"]
+
+
+def test_empty_repeat_items_is_not_flagged() -> None:
+    """An empty ``items: []`` is a valid no-op — no rows and no drop event."""
+    line = json.dumps(
+        {
+            "op": "add",
+            "id": "t",
+            "type": "Tile",
+            "parent": "root",
+            "repeat": {"items": []},
+            "props": {},
+        }
+    )
+    assert process_op_line(line) == []

--- a/tests/test_ui_prompt.py
+++ b/tests/test_ui_prompt.py
@@ -89,17 +89,25 @@ def test_tile_entry_marks_media_optional():
 
 
 def test_tile_example_validates_against_catalog():
-    """The hard-coded example must round-trip through validate_props
-    cleanly, otherwise we'd be teaching the LLM an invalid shape."""
+    """The hard-coded compact example must round-trip through
+    expand_compact_op -> validate_props cleanly, otherwise we'd be teaching
+    the LLM an invalid shape."""
+    # Local import: the chat package must load after the template package
+    # (circular-import precaution above), so don't hoist this to module top.
+    from app.ai.voice.agents.breeze_buddy.chat.ui_stream import expand_compact_op
+
     section = render_primitives_section({"Tile"})
     # Pull the JSON after the "Example: " marker for the Tile entry.
     tile_block = section.split("**Tile**", 1)[1]
     example_line = next(
         line for line in tile_block.splitlines() if line.strip().startswith("Example:")
     )
-    payload = json.loads(example_line.split("Example:", 1)[1].strip())
+    # Example is in compact wire form — expand to canonical before validating.
+    payload = expand_compact_op(
+        json.loads(example_line.split("Example:", 1)[1].strip())
+    )
     assert payload["type"] == "Tile"
-    # Server-side validator must accept the example props.
+    # Server-side validator must accept the expanded example props.
     validate_props("Tile", payload["props"])
 
 


### PR DESCRIPTION
## Summary

Engine/code groundwork for making the Buddy-Assist widget's generative UI **fast, reliable, and generic** — while keeping the **LLM as the UI author** and the engine domain-blind. Every change is additive: the canonical op form remains a first-class fallback, so this is safe to ship before the LLM adopts the new wire forms.

Full plan + rationale: `docs/widget/UI_FAST_RELIABLE_GENERIC_PLAN.md` (companion to the perf survey in #801).

## What's in this PR

- **P0 — measurement** (`chat/metrics.py`, `chat/handlers.py`): `TurnMetrics` passively observes the SSE stream and logs one structured `[CHAT_METRICS]` line per turn — `ttft/ttfui/ttlui/total_ms`, `ui_ops`, **`ui_dropped` + reasons**, `healer_applied`, `tool_calls`, `prose/ui` char sizes, `status`; tagged by `phase=`. Structural only (no payload content; drop reasons keep just the first validation line). Idempotent, non-raising, no agent change.
- **D1 — primitives cache** (`template/ui_prompt.py`): memoise `render_primitives_section` by frozenset allowlist. Output byte-identical; rebuilds once per distinct allowlist instead of per turn.
- **A3 — compact wire form** (`chat/ui_stream.py`, `template/ui_prompt.py`): the LLM may emit `{"+":"id:Type@parent",...props}` / `{"~":"id",...}` / `{"-":"id"}` + `{"kv":[k,v]}` body rows; `expand_compact_op/_line` restore canonical shape **before the healer**, so the parser/validator/persisted `ui_blocks`/widget are unchanged. Both forms accepted.
- **A1 v1 — data/structure split, inline data** (`chat/ui_stream.py`, `template/ui_prompt.py`): the LLM emits ONE element with `repeat:{items:[...],key}` + `{"$item":"<path>"}` bindings; `expand_repeat_line` fans it out to one canonical flat op per row (unique id from key/index, dotted-path `$item` resolution) **before the healer** — no widget change, all rows always render. The LLM still shapes the data array, so per-item emergent choices (e.g. binding the red variant's image) survive. `process_op_line` now loops `expand_repeat_line(expand_compact_line(raw))`.

## Measured (output-token reduction → ~proportional UI-generation speedup)

| Turn | vs live today |
|---|---|
| 8-tile carousel (A3 + A1) | **~51% fewer** (≈2× faster UI gen) |
| Single product detail Stack (A3) | **~35% fewer** |
| Cart / non-list UI (A3) | **~15–21% fewer** |
| Prose-only | ~unchanged |

Estimates from op-size counts; the realised numbers come from the `[CHAT_METRICS]` deltas once this deploys (that's the point of P0).

## Not in this PR

- **Cart-instruction hardening** (the Handoff/SideEffect reliability fix) — already deployed separately as a **template** change to the 4 Shopify-assist merchants; it's data, not code.
- **Deferred** (gated on the metrics): Tier D D2–D5 (TTFT), A1 v2 (tool-result binding), the P3 self-heal net, Tier C constrained decoding — see the plan doc.

## Tests

`tests/test_compact_wire_form.py` (compact + repeat unit, compact==canonical and compact-repeat end-to-end incl. the red-variant binding) and `tests/test_ui_prompt.py` (expands the example before validating). **63 passing** across the touched suites; black/isort/autoflake/pyrefly clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Added compact UI wire format for faster, more efficient UI generation with reduced token usage
  * Implemented per-turn chat metrics collection for improved system observability and debugging

* **Documentation**
  * Added execution plan documenting UI performance, reliability, and generic behavior improvements

* **Tests**
  * Added comprehensive test coverage for compact UI format expansion and validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->