### PR TITLE
(feat): add startup chicklets support in template

### DIFF
--- a/app/ai/voice/agents/breeze_buddy/template/types.py
+++ b/app/ai/voice/agents/breeze_buddy/template/types.py
@@ -619,6 +619,26 @@ class FillerAudioConfig(BaseModel):
         return self
 
 
+class QuickReplyOption(BaseModel):
+    """One quick-reply chicklet shown to the user on widget open.
+
+    ``label`` is the button text displayed in the UI and echoed as the
+    user's chat bubble. ``value`` is the text sent to the backend; when
+    omitted it falls back to ``label``, which lets the display text differ
+    from the agent instruction (e.g. label="Track my order" while the
+    backend receives a more explicit instruction).
+    """
+
+    label: str = Field(..., min_length=1, description="Button text shown to the user.")
+    value: Optional[str] = Field(
+        None,
+        description=(
+            "Payload sent to the backend. Defaults to label when absent "
+            "the fallback is applied server-side before the value reaches the client."
+        ),
+    )
+
+
 class HoldTransferConfig(BaseModel):
     """Configuration for hold & consultative transfer.
 
@@ -1256,6 +1276,22 @@ class ConfigurationModel(BaseModel):
 
     initial_greeting: Optional[str] = (
         None  # Initial greeting text template with variables (e.g., "Hi {customer_name}")
+    )
+    quick_replies: List[QuickReplyOption] = Field(
+        default_factory=list,
+        description=(
+            "Quick-reply chicklet buttons shown to the user on widget open. "
+            "Empty list = no chicklets, normal composer shown."
+        ),
+    )
+    enable_text_input: bool = Field(
+        True,
+        description=(
+            "Whether the free-text composer is shown. "
+            "True (default) = composer visible; user can type freely. "
+            "False = composer hidden for all turns; only quick replies or "
+            "agent-driven input is possible."
+        ),
     )
     ivr_configuration: Optional[IvrConfig] = None  # IVR-specific configuration
     # DEPRECATED: Use ivr_configuration.greeting / ivr_configuration.goodbye / ivr_configuration.priority

--- a/app/api/routers/breeze_buddy/widget/handlers.py
+++ b/app/api/routers/breeze_buddy/widget/handlers.py
@@ -76,6 +76,7 @@ from app.schemas.breeze_buddy.chat import (
     CreateChatSessionRequest,
     CreateWidgetSessionRequest,
     CreateWidgetSessionResponse,
+    QuickReplyWire,
     SendChatMessageRequest,
     WidgetChannel,
     WidgetSessionStateResponse,
@@ -118,6 +119,33 @@ def _synthetic_widget_user(widget_config_id: str) -> UserInfo:
         merchant_ids=[],
         permissions=[],
     )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _extract_widget_config(
+    template: object,
+) -> tuple[List[QuickReplyWire], bool]:
+    """Extract quick-reply options and enable_text_input flag from a template.
+
+    Returns a ``(quick_replies, enable_text_input)`` tuple. Reads directly
+    from ``configurations.quick_replies`` and ``configurations.enable_text_input``;
+    both default to ``([], True)`` when the template defines neither.
+    """
+    configurations = getattr(template, "configurations", None)
+    if configurations is None:
+        return [], True
+    quick_replies: List[QuickReplyWire] = [
+        QuickReplyWire(
+            label=qr.label, value=qr.value if qr.value is not None else qr.label
+        )
+        for qr in (getattr(configurations, "quick_replies", None) or [])
+    ]
+    enable_text_input: bool = getattr(configurations, "enable_text_input", True)
+    return quick_replies, enable_text_input
 
 
 # ---------------------------------------------------------------------------
@@ -177,6 +205,8 @@ async def create_widget_session_handler(
         ttl_minutes=DEFAULT_WIDGET_TOKEN_TTL_MINUTES,
     )
 
+    quick_replies, enable_text_input = _extract_widget_config(template)
+
     return CreateWidgetSessionResponse(
         session_id=create_resp.session_id,
         status=create_resp.status,
@@ -186,6 +216,8 @@ async def create_widget_session_handler(
         greeting=create_resp.greeting,
         widget_token=widget_token,
         ttl_seconds=DEFAULT_WIDGET_TOKEN_TTL_MINUTES * 60,
+        quick_replies=quick_replies,
+        enable_text_input=enable_text_input,
     )
 
 
@@ -647,6 +679,10 @@ async def get_widget_session_state_handler(
     session = await load_chat_session_or_404(session_id)
     assert_widget_session_ownership(session, ctx)
     messages: List[ChatMessage] = await list_chat_messages_for_session(session_id)
+
+    template = await get_template_by_id_cached(session.template_id)
+    quick_replies, enable_text_input = _extract_widget_config(template)
+
     template_vars: Dict[str, Any] = (
         session.metadata.get("template_vars", {})
         if isinstance(session.metadata, dict)
@@ -658,6 +694,8 @@ async def get_widget_session_state_handler(
         current_channel=session.current_channel,
         current_node=session.current_node,
         messages=messages,
+        quick_replies=quick_replies,
+        enable_text_input=enable_text_input,
         template_vars=template_vars,
         metadata=session.metadata or {},
     )

--- a/app/schemas/breeze_buddy/chat.py
+++ b/app/schemas/breeze_buddy/chat.py
@@ -267,6 +267,24 @@ class CreateWidgetSessionRequest(BaseModel):
     )
 
 
+class QuickReplyWire(BaseModel):
+    """One quick-reply option returned in the widget session-create response.
+
+    Mirrors ``QuickReplyOption`` from the template ``ConfigurationModel``
+    but lives in the public API schema layer so the wire shape stays
+    stable independent of any internal model refactors.
+    """
+
+    label: str = Field(..., description="Button text displayed to the user.")
+    value: Optional[str] = Field(
+        None,
+        description=(
+            "Payload sent to the backend. Always populated — falls back to "
+            "label server-side when not explicitly set in the template."
+        ),
+    )
+
+
 class CreateWidgetSessionResponse(BaseModel):
     """Body of ``POST /widget/session``.
 
@@ -283,6 +301,23 @@ class CreateWidgetSessionResponse(BaseModel):
     widget_token: str = Field(..., description="Bearer token for follow-up calls.")
     ttl_seconds: int = Field(
         ..., description="Lifetime of widget_token in seconds (24h)."
+    )
+    quick_replies: List[QuickReplyWire] = Field(
+        default_factory=list,
+        description=(
+            "Quick-reply chicklet options defined in the template's "
+            "configurations.quick_replies section. "
+            "Empty list when the template defines no quick replies."
+        ),
+    )
+    enable_text_input: bool = Field(
+        True,
+        description=(
+            "Whether the free-text composer is shown. "
+            "False = composer hidden for all turns; only quick replies or "
+            "agent-driven input is possible. "
+            "Ignored by the client when quick_replies is empty."
+        ),
     )
 
 
@@ -319,6 +354,23 @@ class WidgetSessionStateResponse(BaseModel):
     current_channel: WidgetChannel
     current_node: Optional[str] = None
     messages: List[ChatMessage]
+    quick_replies: List[QuickReplyWire] = Field(
+        default_factory=list,
+        description=(
+            "Quick-reply chicklet options defined in the template's "
+            "configurations.quick_replies section. "
+            "Empty list when the template defines no quick replies."
+        ),
+    )
+    enable_text_input: bool = Field(
+        True,
+        description=(
+            "Whether the free-text composer is shown. "
+            "False = composer hidden for all turns; only quick replies or "
+            "agent-driven input is possible. "
+            "Ignored by the client when quick_replies is empty."
+        ),
+    )
     template_vars: Dict[str, Any] = Field(default_factory=dict)
     metadata: Dict[str, Any] = Field(default_factory=dict)
 
@@ -343,6 +395,7 @@ __all__ = [
     "CreateDemoSessionRequest",
     "CreateDemoSessionResponse",
     "CreateWidgetSessionRequest",
+    "QuickReplyWire",
     "CreateWidgetSessionResponse",
     "WidgetVoiceConnectResponse",
     "WidgetVoiceEndResponse",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added quick-reply buttons that appear when the widget first loads, enabling users to select from predefined response options without typing.
  * Added configuration control to show or hide the free-text input composer on the widget's initial load.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->