### PR TITLE
fix(chat): anchor a root container so compound multi-block replies render

### DIFF
--- a/app/ai/voice/agents/breeze_buddy/chat/ui_stream.py
+++ b/app/ai/voice/agents/breeze_buddy/chat/ui_stream.py
@@ -635,10 +635,42 @@ def process_op_line(
 
         op = parsed.op  # type: ignore[assignment]
         if known_ids is not None and op is not None:
+            # Guarantee the conventional `root` container is anchored before any
+            # block attaches to it. The widget anchors its per-message tree on
+            # the first `add id="root"` and DROPS any add whose parent doesn't
+            # exist. A turn that renders MULTIPLE top-level blocks (e.g. a cart
+            # card AND a product carousel) can't make them all BE root, so the
+            # model parents each to `root` with its own id — but may forget to
+            # `add` root, which orphans the whole tree into a blank reply. Inject
+            # a neutral Stack root so no block orphans; rescue a stray
+            # `replace root` (model assuming a prior turn's root) into that
+            # anchoring add. Domain-blind; a no-op once root exists, so normal
+            # single-block renders (the block IS root) are untouched.
+            if "root" not in known_ids:
+                if op["op"] == "replace" and op["id"] == "root":
+                    op = {
+                        "op": "add",
+                        "id": "root",
+                        "type": "Stack",
+                        "props": op.get("props") or {"gap": "md"},
+                    }
+                elif op["op"] == "add" and op.get("parent") == "root":
+                    known_ids.add("root")
+                    events.append(
+                        ui_op_event(
+                            {
+                                "op": "add",
+                                "id": "root",
+                                "type": "Stack",
+                                "props": {"gap": "md"},
+                            }
+                        )
+                    )
+
             if op["op"] == "add":
-                known_ids.add(op["id"])
+                known_ids.add(str(op["id"]))
             elif op["op"] == "remove":
-                known_ids.discard(op["id"])
+                known_ids.discard(str(op["id"]))
 
         events.append(ui_op_event(op))  # type: ignore[arg-type]
     return events

--- a/tests/test_compact_wire_form.py
+++ b/tests/test_compact_wire_form.py
@@ -263,3 +263,66 @@ def test_empty_repeat_items_is_not_flagged() -> None:
         }
     )
     assert process_op_line(line) == []
+
+
+# ---------------------------------------------------------------------------
+# Root anchoring — multiple top-level blocks in one turn (compound requests)
+# ---------------------------------------------------------------------------
+
+
+def test_root_anchor_injected_for_orphan_block() -> None:
+    # Block parents to `root` but the model never `add`ed root → inject a
+    # neutral Stack root first, so the block has an anchor (else it orphans
+    # and the widget renders nothing).
+    known: set = set()
+    line = (
+        '{"op":"add","id":"cart","type":"Stack","parent":"root","props":{"gap":"md"}}'
+    )
+    ops = [
+        e.data["op"]
+        for e in process_op_line(line, known_ids=known)
+        if e.event == "ui_op"
+    ]
+    assert [(o["op"], o["id"], o.get("type")) for o in ops] == [
+        ("add", "root", "Stack"),
+        ("add", "cart", "Stack"),
+    ]
+    assert "root" in known
+
+
+def test_replace_root_rescued_to_add_anchor() -> None:
+    # A `replace root` before root exists (model assumed a prior-turn root) is
+    # rescued into the anchoring add.
+    known: set = set()
+    line = '{"op":"replace","id":"root","props":{"gap":"md"}}'
+    ops = [
+        e.data["op"]
+        for e in process_op_line(line, known_ids=known)
+        if e.event == "ui_op"
+    ]
+    assert len(ops) == 1
+    assert (ops[0]["op"], ops[0]["id"], ops[0]["type"]) == ("add", "root", "Stack")
+
+
+def test_no_anchor_when_model_adds_root() -> None:
+    # Normal single-block render: the block IS root → no injection, untouched.
+    known: set = set()
+    line = '{"op":"add","id":"root","type":"Carousel","props":{"snap":true}}'
+    ops = [
+        e.data["op"]
+        for e in process_op_line(line, known_ids=known)
+        if e.event == "ui_op"
+    ]
+    assert len(ops) == 1 and ops[0]["id"] == "root" and ops[0]["type"] == "Carousel"
+
+
+def test_second_block_does_not_duplicate_root() -> None:
+    # Two top-level blocks → exactly one injected root; both attach as siblings.
+    known: set = set()
+    l1 = '{"op":"add","id":"cart","type":"Stack","parent":"root","props":{"gap":"md"}}'
+    l2 = '{"op":"add","id":"bottles","type":"Carousel","parent":"root","props":{"snap":true}}'
+    process_op_line(l1, known_ids=known)  # anchors root + adds cart
+    ops2 = [
+        e.data["op"] for e in process_op_line(l2, known_ids=known) if e.event == "ui_op"
+    ]
+    assert [(o["op"], o["id"]) for o in ops2] == [("add", "bottles")]  # no second root


### PR DESCRIPTION
## The bug

A chat reply that renders **multiple top-level blocks in one turn** — e.g. *"add this to my cart **and** show me a carousel"* (a cart card **and** a product carousel) — rendered as a **blank reply** in the widget.

**Why:** the widget anchors its per-message UI tree on the first `add id="root"` and **drops any `add` whose parent doesn't exist** (`loom ui_state.svelte.ts`). Two top-level blocks can't both be `id="root"`, so the model parents each to `root` with its own id — but often emits a `replace root` (or nothing) instead of an `add root`. With no root node, both subtrees orphan → the widget drops everything → blank screen. (Confirmed from a real session: 14 valid ops streamed, all orphaned.)

## The fix

`process_op_line` now **guarantees the `root` container exists**: when an `add` attaches to a `root` that was never added this turn, it injects a neutral `Stack` root first; a stray `replace root` (model assuming a prior turn's root) is rescued into that anchoring add.

- **Domain-blind** — pure structural guarantee, no knowledge of products/cart/etc.
- **Additive / zero-risk** — a no-op once `root` exists, so normal single-block renders (where the block *is* root) are completely untouched.
- **No template changes required** — works against the existing templates.

Both blocks then render as **siblings** under the injected root.

## Testing

- 4 unit tests in `tests/test_compact_wire_form.py` (orphan-block injection, `replace root` rescue, single-block untouched, no duplicate root on the 2nd block). `pyrefly` clean.
- **Verified live**: *"add the first to my cart and also show me thermosteel bottles"* → `add root(Stack)` + cart-card + carousel as siblings, **18 ops, 0 dropped** (was a blank reply before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved stability of UI rendering by ensuring proper initialization and handling of root container elements, preventing cases where root elements may be missing or duplicated in multi-block interactions.

* **Tests**
  * Added test coverage for root element initialization scenarios to enhance code reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->