### PR TITLE
fix(chat): stream list items progressively instead of all-at-once

### DIFF
--- a/app/ai/voice/agents/breeze_buddy/template/ui_prompt.py
+++ b/app/ai/voice/agents/breeze_buddy/template/ui_prompt.py
@@ -334,13 +334,18 @@ _HEADER = (
     "Each Example below uses this form. The canonical "
     '{"op":"add","id":...,"type":...,"props":{...}} shape is also accepted.\n'
     "\n"
-    "Lists — render N similar items with ONE element, not N (far fewer tokens):\n"
-    '  {"+":"tile:Tile@root", "repeat":{"items":[<rows>],"key":"id"}, '
-    '"title":{"$item":"title"}, "media":{"src":{"$item":"image"}}}\n'
-    "  `repeat.items` is your data array — YOU pick the rows and which fields "
-    "to surface (so per-item choices like the matching variant's image/price "
-    'still apply); `{"$item":"<field>"}` binds that row\'s value (dotted '
-    "paths ok). The server expands it to one op per row, so all rows render."
+    "Lists/carousels — STREAM items progressively: emit the container op "
+    "FIRST, then ONE op per item, EACH ON ITS OWN LINE. The server forwards "
+    "each line the instant it completes, so items paint one-by-one as you "
+    "write them (fast first paint) instead of all landing at the end. You "
+    "still pick the items and each item's fields (e.g. the matching variant's "
+    "image/price). Example — container, then one compact op per item:\n"
+    '  {"+":"car:Carousel@root","snap":true}\n'
+    '  {"+":"p1:Tile@car","title":"Dawn","media":{"src":"https://x/1.jpg","alt":"Dawn"}}\n'
+    '  {"+":"p2:Tile@car","title":"Dusk","media":{"src":"https://x/2.jpg","alt":"Dusk"}}\n'
+    "Never pack a whole list into a single line (e.g. a `repeat` template with "
+    "an inline items array) — that holds the first item back until the entire "
+    "list is generated, defeating progressive rendering."
 )
 
 _FOOTER = (
@@ -353,8 +358,10 @@ _FOOTER = (
     '  - Root id is always "root"; root op omits `parent`.\n'
     "  - All non-root `add` ops MUST have `parent`.\n"
     "  - `replace` swaps props on an existing id; `remove` deletes a node.\n"
-    '  - For "items in a list", emit ONE Tile per item via a `repeat` '
-    "template (see Lists above) — never compose Card+Image+Text manually."
+    '  - For "items in a list", emit the container then ONE op per item, '
+    "each on its OWN line (see Lists above) so they stream in progressively "
+    "— never compose Card+Image+Text manually, and never pack the whole list "
+    "into one line."
 )
 
 _EMPTY_BODY = (

--- a/tests/test_ui_prompt.py
+++ b/tests/test_ui_prompt.py
@@ -139,7 +139,20 @@ def test_section_has_composition_rules_at_bottom():
     tail = section[rules_idx:]
     assert "Root id is always" in tail
     assert "non-root `add` ops MUST have `parent`" in tail
-    assert "ONE Tile per item" in tail
+    assert "ONE op per item" in tail
+
+
+def test_header_mandates_progressive_list_rendering():
+    # The shared prompt must steer the model toward streaming list items
+    # one-op-per-line (progressive paint), NOT packing them into a single
+    # `repeat` line (all-at-once). This is the load-bearing instruction for
+    # incremental rendering — pin it so a future prompt edit can't silently
+    # regress first-paint latency.
+    section = render_primitives_section({"Tile", "Carousel"})
+    assert "EACH ON ITS OWN LINE" in section
+    assert "progressive" in section.lower()
+    # And it must warn against the single-line / repeat batching form.
+    assert "Never pack a whole list into a single line" in section
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Make chat list/carousel rendering **progressive** (items paint one-by-one as the model writes them) instead of all-at-once.

## Why

The streaming pipeline is already incremental end-to-end — `UiStreamExtractor` yields each `<ui_stream>` op the instant its JSONL line completes, and `agent.py` forwards each `ui_op` SSE event immediately. But the **shared UI prompt** (`ui_prompt.py`, shipped in #802) steered the model toward the `repeat` form for lists, which packs every item into **one giant JSONL line**. The server gets no newline until that whole line finishes generating, so all items land at once at the end — defeating the incremental pipeline and hurting first-paint latency.

This was also *unreliable*: per-template instructions say "one Tile per product" (incremental) while the shared prompt said "use `repeat`" (all-at-once) — a direct conflict, so behaviour depended on which the model followed.

## Change (prompt-only, generic)

- `_HEADER`: replace the `repeat`-preferring "Lists" guidance with **progressive** guidance — emit the container op first, then **one compact op per item, each on its own line**, with a worked example.
- `_FOOTER` composition rule: same — container then one op per item per line; explicitly "never pack the whole list into one line."
- The engine still **accepts** `repeat` (`expand_repeat_line` unchanged, fully backward-compatible) — it's just no longer the prompted default.

Because this lives in the shared prompt, every chat template gets progressive rendering by default — it no longer depends on per-template wording.

## Behaviour

| | Before | After |
|---|---|---|
| First item visible | after the **whole** list is generated (~all-at-once) | as soon as the **first** item's line completes |
| Driven by | per-template wording (conflicting with shared prompt) | shared prompt — generic, every template |
| Wire form | `repeat` mega-line | container + one compact op per item per line |
| Per-op token savings (A3 compact form) | ✅ | ✅ (unchanged) |

## Tests

- `tests/test_ui_prompt.py`: updated the composition-rule assertion; added `test_header_mandates_progressive_list_rendering` pinning the progressive guidance + the anti-batching warning.
- `tests/test_compact_wire_form.py`: unchanged and green — `repeat` engine support is retained.
- `37 passed` (ui_prompt + compact_wire_form).

🤖 Generated with [Claude Code](https://claude.com/claude-code)