### PR TITLE
feat: Google Sheets data sources for Breeze Buddy templates

### DIFF
--- a/app/ai/voice/agents/automatic/services/mcp/utils.py
+++ b/app/ai/voice/agents/automatic/services/mcp/utils.py
@@ -11,8 +11,8 @@ from app.ai.voice.agents.automatic.features.charts.chart_tools import (
 )
 from app.ai.voice.agents.automatic.tools.internet import (
     tool_functions as internet_tool_functions,
-    tools as internet_tools,
 )
+from app.ai.voice.agents.automatic.tools.internet import tools as internet_tools
 from app.ai.voice.agents.automatic.utils.session_context import get_current_session_id
 from app.core.config.static import ENABLE_SEARCH_GROUNDING
 from app.core.logger import logger

--- a/app/ai/voice/agents/automatic/tools/__init__.py
+++ b/app/ai/voice/agents/automatic/tools/__init__.py
@@ -10,9 +10,11 @@ from app.core.config.static import (
 from app.core.logger import logger
 
 from . import breeze, charts, internet, juspay
-from .dummy import tool_functions as dummy_tool_functions, tools as dummy_tools
+from .dummy import tool_functions as dummy_tool_functions
+from .dummy import tools as dummy_tools
 from .dummy.acme_analytics import acme_tool_functions, acme_tools
-from .system import tool_functions as system_tool_functions, tools as system_tools
+from .system import tool_functions as system_tool_functions
+from .system import tools as system_tools
 
 
 def initialize_tools(

--- a/app/ai/voice/agents/automatic/tools/breeze/__init__.py
+++ b/app/ai/voice/agents/automatic/tools/breeze/__init__.py
@@ -1,8 +1,6 @@
 from .analytics import breeze_token, shop_id, shop_type, shop_url, tool_functions, tools
-from .configuration import (
-    tool_functions as configuration_tool_functions,
-    tools as configuration_tools,
-)
+from .configuration import tool_functions as configuration_tool_functions
+from .configuration import tools as configuration_tools
 
 __all__ = [
     "tools",

--- a/app/ai/voice/agents/breeze_buddy/agent/flow.py
+++ b/app/ai/voice/agents/breeze_buddy/agent/flow.py
@@ -44,6 +44,7 @@ async def load_template_config(
         merchant_id=lead.merchant_id if lead else None,
         call_payload=lead.payload,
         template_id=lead.template_id,
+        lead_id=lead.id if lead else None,
     )
 
     # Apply overrides and re-render if playground mode
@@ -143,6 +144,12 @@ def build_flow_config(
         "expected_callback_response_schema", None
     )
 
+    # Propagate data-source system messages set by the loader so that
+    # prepare_initial_node can prepend them to the initial node's context.
+    ds_messages = template.flow.get("_data_source_messages")
+    if ds_messages:
+        flow_config["_data_source_messages"] = ds_messages
+
     logger.info(
         f"Built flow config with {len(flow_config['nodes'])} nodes, "
         f"initial: {flow_config['initial_node']}, "
@@ -191,6 +198,17 @@ def prepare_initial_node(
         # Prepend the greeting message to task messages
         task_messages = [greeting_context_message] + task_messages
         logger.info(f"Injected greeting into LLM context: {greeting_text[:50]}...")
+
+    # Prepend data-source "message" injections (inject_as="message")
+    # These are system messages containing fetched sheet content that the
+    # LLM needs as read-only context before starting the conversation.
+    ds_messages = flow_config.get("_data_source_messages")
+    if ds_messages:
+        task_messages = ds_messages + task_messages
+        logger.info(
+            "Prepended %d data-source system message(s) to initial node",
+            len(ds_messages),
+        )
 
     return NodeConfig(
         name=node_config["name"],

--- a/app/ai/voice/agents/breeze_buddy/dispatch/reconcilers.py
+++ b/app/ai/voice/agents/breeze_buddy/dispatch/reconcilers.py
@@ -44,6 +44,8 @@ from app.database.accessor import (
 )
 from app.database.accessor.breeze_buddy.dispatch import (
     clean_stale_bb_locks as accessor_clean_stale_bb_locks,
+)
+from app.database.accessor.breeze_buddy.dispatch import (
     count_processing_by_outbound_number,
     get_unscheduled_backlog_leads,
 )

--- a/app/ai/voice/agents/breeze_buddy/dispatch/worker.py
+++ b/app/ai/voice/agents/breeze_buddy/dispatch/worker.py
@@ -52,6 +52,9 @@ from app.ai.voice.agents.breeze_buddy.managers.calls import (
     _release_number,
     _run_pre_checks_for_lead,
 )
+from app.ai.voice.agents.breeze_buddy.managers.data_source_prefetch import (
+    prefetch_data_sources,
+)
 from app.ai.voice.agents.breeze_buddy.managers.utils import (
     prepare_and_store_initial_greeting,
 )
@@ -339,10 +342,17 @@ class Worker:
 
             if template:
                 template = apply_playground_overrides(locked, template)
-                await prepare_and_store_initial_greeting(
-                    lead_id=locked.id,
-                    payload=locked.payload or {},
-                    template=template,
+                await asyncio.gather(
+                    prepare_and_store_initial_greeting(
+                        lead_id=locked.id,
+                        payload=locked.payload or {},
+                        template=template,
+                    ),
+                    prefetch_data_sources(
+                        lead_id=locked.id,
+                        template=template,
+                    ),
+                    return_exceptions=True,
                 )
 
             # Rate-limit PEEK before channel token. Read-only — we don't

--- a/app/ai/voice/agents/breeze_buddy/managers/data_source_prefetch.py
+++ b/app/ai/voice/agents/breeze_buddy/managers/data_source_prefetch.py
@@ -1,0 +1,87 @@
+"""
+Data Source Prefetch Manager
+
+Pre-warms Redis with Google Sheets content for all DataSourceRefs attached to a
+template at dispatch time.  This runs concurrently with greeting TTS synthesis so
+that sheet content is already cached before the call connects.
+
+Cache key : ``datasource:{lead_id}:{ref.name}``
+TTL        : 300 s  (covers typical call duration + re-try window)
+"""
+
+import asyncio
+from typing import Optional
+
+from app.ai.voice.agents.breeze_buddy.template.types import DataSourceRef, TemplateModel
+from app.core.logger import logger
+from app.database.accessor.breeze_buddy.data_source import get_data_source_by_id
+from app.services.google.sheets import fetch_formatted
+from app.services.redis import get_redis_service
+
+_CACHE_TTL = 300  # seconds
+_FETCH_TIMEOUT = 5.0  # generous timeout for background prefetch
+
+
+async def _prefetch_one(lead_id: str, ref: DataSourceRef) -> None:
+    """Fetch and cache content for a single DataSourceRef."""
+    cache_key = f"datasource:{lead_id}:{ref.name}"
+    try:
+        ds = await get_data_source_by_id(ref.data_source_id)
+        if not ds:
+            logger.warning(
+                "Prefetch: data source %s not found in DB (ref name=%s)",
+                ref.data_source_id,
+                ref.name,
+            )
+            return
+
+        content = await asyncio.wait_for(
+            fetch_formatted(
+                spreadsheet_id=ds.spreadsheet_id,
+                sheet_name=ds.sheet_name,
+                columns=ds.columns,
+                format=ds.format,
+            ),
+            timeout=_FETCH_TIMEOUT,
+        )
+
+        redis = await get_redis_service()
+        await redis.setex(cache_key, content, ttl_seconds=_CACHE_TTL)
+        logger.info(
+            "Prefetched data source '%s' for lead=%s (%d chars, TTL=%ds)",
+            ref.name,
+            lead_id,
+            len(content),
+            _CACHE_TTL,
+        )
+    except asyncio.TimeoutError:
+        logger.warning(
+            "Prefetch timeout for data source '%s', lead=%s", ref.name, lead_id
+        )
+    except Exception as exc:
+        logger.error(
+            "Prefetch error for data source '%s', lead=%s: %s",
+            ref.name,
+            lead_id,
+            exc,
+            exc_info=True,
+        )
+
+
+async def prefetch_data_sources(
+    lead_id: str,
+    template: Optional[TemplateModel],
+) -> None:
+    """
+    Pre-warm Redis with sheet content for every DataSourceRef on *template*.
+
+    Safe to call even when template is None or has no data_sources — it
+    silently returns without doing any work.
+    """
+    if not template or not template.data_sources:
+        return
+
+    await asyncio.gather(
+        *[_prefetch_one(lead_id, ref) for ref in template.data_sources],
+        return_exceptions=True,
+    )

--- a/app/ai/voice/agents/breeze_buddy/template/loader.py
+++ b/app/ai/voice/agents/breeze_buddy/template/loader.py
@@ -4,12 +4,14 @@ Flow Configuration Loader
 This module provides functionality to load templates from the database.
 """
 
-from typing import Dict, Optional, Tuple
+import asyncio
+from typing import Dict, List, Optional, Tuple
 
 from app.ai.voice.agents.breeze_buddy.template.transformation_function import (
     TEMPLATE_FUNCTION_REGISTRY,
 )
 from app.ai.voice.agents.breeze_buddy.template.types import (
+    DataSourceRef,
     FlowMode,
     TemplateModel,
 )
@@ -18,9 +20,12 @@ from app.core.logger import logger
 from app.database.accessor.breeze_buddy.credentials import (
     get_credentials_as_template_vars,
 )
+from app.database.accessor.breeze_buddy.data_source import get_data_source_by_id
 from app.database.accessor.breeze_buddy.template import (
     get_template_by_id_with_fallback,
 )
+from app.services.google.sheets import fetch_formatted
+from app.services.redis import get_redis_service
 
 
 class FlowConfigLoader:
@@ -87,6 +92,70 @@ class FlowConfigLoader:
         """Method-style alias preserved for the voice loader call sites."""
         return render_messages_with_vars(task_messages, variables)
 
+    async def _fetch_data_source_content(
+        self,
+        lead_id: Optional[str],
+        ref: DataSourceRef,
+    ) -> str:
+        """
+        Fetch formatted sheet content for a DataSourceRef.
+
+        Priority:
+        1. Redis cache (key ``datasource:{lead_id}:{ref.name}``, pre-warmed by prefetch manager)
+        2. Live Google Sheets fetch with 800 ms timeout
+        3. Fallback: "[Data unavailable]"
+        """
+        # 1. Redis cache check (requires lead_id)
+        if lead_id:
+            cache_key = f"datasource:{lead_id}:{ref.name}"
+            try:
+                redis = await get_redis_service()
+                cached = await redis.get(cache_key)
+                if cached:
+                    logger.info(
+                        "Data source cache hit: lead=%s name=%s", lead_id, ref.name
+                    )
+                    return cached
+            except Exception as exc:
+                logger.warning(
+                    "Redis cache check failed for datasource '%s': %s", ref.name, exc
+                )
+
+        # 2. Live fetch
+        try:
+            ds = await get_data_source_by_id(ref.data_source_id)
+            if not ds:
+                logger.warning(
+                    "Data source %s not found in DB (ref name=%s)",
+                    ref.data_source_id,
+                    ref.name,
+                )
+                return "[Data unavailable]"
+
+            content = await asyncio.wait_for(
+                fetch_formatted(
+                    spreadsheet_id=ds.spreadsheet_id,
+                    sheet_name=ds.sheet_name,
+                    columns=ds.columns,
+                    format=ds.format,
+                ),
+                timeout=0.8,
+            )
+            logger.info(
+                "Fetched data source '%s' live (%d chars)", ref.name, len(content)
+            )
+            return content
+        except asyncio.TimeoutError:
+            logger.warning(
+                "Timeout fetching data source '%s' (>800 ms); using fallback", ref.name
+            )
+            return "[Data unavailable]"
+        except Exception as exc:
+            logger.error(
+                "Error fetching data source '%s': %s", ref.name, exc, exc_info=True
+            )
+            return "[Data unavailable]"
+
     async def load_template(
         self,
         reseller_id: str,
@@ -94,6 +163,7 @@ class FlowConfigLoader:
         merchant_id: Optional[str] = None,
         call_payload: Optional[Dict[str, str]] = None,
         template_id: Optional[str] = None,
+        lead_id: Optional[str] = None,
     ) -> Tuple[TemplateModel, Dict[str, str]]:
         """
         Load template and render task messages with variables.
@@ -104,6 +174,7 @@ class FlowConfigLoader:
             merchant_id: Optional merchant-specific identifier
             call_payload: Optional payload variables
             template_id: Optional template UUID (preferred over name-based lookup)
+            lead_id: Optional lead UUID; used for Redis-cached data source content
 
         Returns:
             TemplateModel with rendered task messages, and dictionary of template variables
@@ -198,6 +269,25 @@ class FlowConfigLoader:
                     logger.info(
                         f"Injected extra payload field '{field_name}' into template_vars"
                     )
+
+        # 5. Inject data_source content.
+        # "var" sources → template_vars[ref.name] = content (rendered as {name} placeholder)
+        # "message" sources → appended to template_obj.flow["_data_source_messages"]
+        #   (consumed later in prepare_initial_node / build_flow_config)
+        if template_obj.data_sources:
+            _ds_messages: List[Dict] = []
+            for ref in template_obj.data_sources:
+                content = await self._fetch_data_source_content(lead_id, ref)
+                if ref.inject_as == "message":
+                    _ds_messages.append({"role": "system", "content": content})
+                    logger.info("Data source '%s' queued as system message", ref.name)
+                else:
+                    template_vars[ref.name] = content
+                    logger.info(
+                        "Data source '%s' injected into template_vars", ref.name
+                    )
+            if _ds_messages:
+                template_obj.flow["_data_source_messages"] = _ds_messages
 
         # Direct mode has a flat structure (system_prompt + flat function list)
         # rather than a nodes array, so render the top-level message fields and

--- a/app/ai/voice/agents/breeze_buddy/template/types.py
+++ b/app/ai/voice/agents/breeze_buddy/template/types.py
@@ -1991,6 +1991,31 @@ def _default_supported_channels() -> List[Literal["voice", "chat"]]:
     return ["voice"]
 
 
+# ─── Data Source Reference (stored inside template.data_sources) ────────────
+
+
+class DataSourceRef(BaseModel):
+    """
+    Reference to a data_source entity attached to a template.
+
+    data_source_id: FK to the data_source table
+    name: the {variable_name} placeholder (must be unique per template)
+    inject_as: how to land in LLM context
+    """
+
+    data_source_id: str = Field(description="UUID of the data_source entity")
+    name: str = Field(
+        description="Variable name used as {name} placeholder in template prompts"
+    )
+    inject_as: str = Field(
+        default="var",
+        description=(
+            '"var" — sheet content injected into template_vars as {name}. '
+            '"message" — prepended as a system message to the initial node.'
+        ),
+    )
+
+
 class TemplateModel(BaseModel):
     # Read-only fields (set by server, not editable via API).
     # These are intentionally excluded from ReplaceTemplateRequest so that
@@ -2008,6 +2033,10 @@ class TemplateModel(BaseModel):
     expected_callback_response_schema: Optional[Dict[str, Any]] = None
     configurations: Optional[ConfigurationModel] = None
     secrets: Optional[Dict[str, Any]] = None
+    data_sources: Optional[List["DataSourceRef"]] = Field(
+        None,
+        description="List of data source references attached to this template",
+    )
     outbound_number_id: Optional[str] = None
     is_active: bool = True
     # Channels this template is allowed to be served on. Defaults to
@@ -2052,6 +2081,7 @@ class CreateTemplateRequest(BaseModel):
     expected_callback_response_schema: Optional[Dict[str, Any]] = None
     configurations: Optional[ConfigurationModel] = None
     secrets: Optional[Dict[str, Any]] = None
+    data_sources: Optional[List["DataSourceRef"]] = None
     supported_channels: List[Literal["voice", "chat"]] = Field(
         default_factory=_default_supported_channels,
         min_length=1,
@@ -2093,6 +2123,7 @@ class ReplaceTemplateRequest(BaseModel):
     expected_callback_response_schema: Optional[Dict[str, Any]] = None
     configurations: Optional[ConfigurationModel] = None
     secrets: Optional[Dict[str, Any]] = None
+    data_sources: Optional[List["DataSourceRef"]] = None
     supported_channels: Optional[List[Literal["voice", "chat"]]] = Field(
         default=None,
         min_length=1,

--- a/app/api/routers/breeze_buddy/__init__.py
+++ b/app/api/routers/breeze_buddy/__init__.py
@@ -15,6 +15,7 @@ from app.api.routers.breeze_buddy.credentials import router as credentials_route
 
 # Daily transport (web/mobile clients via Daily.co)
 from app.api.routers.breeze_buddy.daily import router as daily_router
+from app.api.routers.breeze_buddy.data_sources import router as data_sources_router
 from app.api.routers.breeze_buddy.demo import router as demo_router
 from app.api.routers.breeze_buddy.leads import router as leads_router
 from app.api.routers.breeze_buddy.merchants import router as merchants_router
@@ -63,6 +64,9 @@ router.include_router(numbers_router, prefix="", tags=["numbers"])
 
 # Templates (conversational flow definitions)
 router.include_router(templates_router, prefix="", tags=["templates"])
+
+# Data Sources (Google Sheets attached to templates)
+router.include_router(data_sources_router, prefix="", tags=["data-sources"])
 
 # Playground (configuration exploration)
 router.include_router(playground_router, prefix="", tags=["playground"])

--- a/app/api/routers/breeze_buddy/data_sources/__init__.py
+++ b/app/api/routers/breeze_buddy/data_sources/__init__.py
@@ -1,0 +1,146 @@
+"""
+REST endpoints for data source management.
+
+Endpoints:
+- POST   /data-sources                       - Create data source
+- GET    /data-sources                       - List data sources (paginated)
+- GET    /data-sources/sheets/tabs           - List tabs in a Google Sheet (discovery)
+- GET    /data-sources/sheets/columns        - List column headers (discovery)
+- GET    /data-sources/sheets/preview        - Preview sheet data (discovery)
+- GET    /data-sources/{id}                  - Get single data source
+- PUT    /data-sources/{id}                  - Update data source
+- DELETE /data-sources/{id}                  - Delete data source
+
+IMPORTANT: discovery routes declared BEFORE /{id} to avoid FastAPI path conflict.
+"""
+
+from typing import List, Optional
+
+from fastapi import APIRouter, Depends, Query, status
+
+from app.api.security.breeze_buddy.rbac_token import get_current_user_with_rbac
+from app.schemas import UserInfo
+from app.schemas.breeze_buddy.data_source import (
+    ColumnsResponse,
+    DataSourceCreate,
+    DataSourceListResponse,
+    DataSourceResponse,
+    DataSourceUpdate,
+    PreviewResponse,
+    TabsResponse,
+)
+
+from .handlers import (
+    create_data_source_handler,
+    delete_data_source_handler,
+    get_data_source_handler,
+    list_columns_handler,
+    list_data_sources_handler,
+    list_tabs_handler,
+    preview_handler,
+    update_data_source_handler,
+)
+
+router = APIRouter()
+
+
+# ─── Discovery routes (must come before /{id}) ────────────────────────────────
+
+
+@router.get("/data-sources/sheets/tabs", response_model=TabsResponse)
+async def get_sheet_tabs(
+    spreadsheet_url: str = Query(..., description="Full Google Sheets URL"),
+    current_user: UserInfo = Depends(get_current_user_with_rbac),
+):
+    """List all tab names in a Google Spreadsheet."""
+    return await list_tabs_handler(spreadsheet_url)
+
+
+@router.get("/data-sources/sheets/columns", response_model=ColumnsResponse)
+async def get_sheet_columns(
+    spreadsheet_url: str = Query(..., description="Full Google Sheets URL"),
+    sheet_name: Optional[str] = Query(
+        None, description="Tab name (default: first tab)"
+    ),
+    current_user: UserInfo = Depends(get_current_user_with_rbac),
+):
+    """List column headers for a sheet tab."""
+    return await list_columns_handler(spreadsheet_url, sheet_name)
+
+
+@router.get("/data-sources/sheets/preview", response_model=PreviewResponse)
+async def preview_sheet(
+    spreadsheet_url: str = Query(..., description="Full Google Sheets URL"),
+    sheet_name: Optional[str] = Query(
+        None, description="Tab name (default: first tab)"
+    ),
+    columns: Optional[List[str]] = Query(None, description="Columns to include"),
+    max_rows: int = Query(10, ge=1, le=100, description="Max rows to return"),
+    current_user: UserInfo = Depends(get_current_user_with_rbac),
+):
+    """Preview up to N rows from a sheet."""
+    return await preview_handler(spreadsheet_url, sheet_name, columns, max_rows)
+
+
+# ─── CRUD routes ──────────────────────────────────────────────────────────────
+
+
+@router.post(
+    "/data-sources",
+    response_model=DataSourceResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def create_data_source(
+    req: DataSourceCreate,
+    current_user: UserInfo = Depends(get_current_user_with_rbac),
+):
+    """Create a new data source."""
+    return await create_data_source_handler(req, current_user)
+
+
+@router.get("/data-sources", response_model=DataSourceListResponse)
+async def list_data_sources(
+    reseller_id: Optional[str] = Query(None),
+    merchant_id: Optional[str] = Query(None),
+    is_active: Optional[bool] = Query(None),
+    page: int = Query(1, ge=1),
+    limit: int = Query(50, ge=1, le=200),
+    current_user: UserInfo = Depends(get_current_user_with_rbac),
+):
+    """List data sources with optional filters."""
+    return await list_data_sources_handler(
+        current_user=current_user,
+        reseller_id=reseller_id,
+        merchant_id=merchant_id,
+        is_active=is_active,
+        page=page,
+        limit=limit,
+    )
+
+
+@router.get("/data-sources/{data_source_id}", response_model=DataSourceResponse)
+async def get_data_source(
+    data_source_id: str,
+    current_user: UserInfo = Depends(get_current_user_with_rbac),
+):
+    """Get a single data source by ID."""
+    return await get_data_source_handler(data_source_id, current_user)
+
+
+@router.put("/data-sources/{data_source_id}", response_model=DataSourceResponse)
+async def update_data_source(
+    data_source_id: str,
+    req: DataSourceUpdate,
+    current_user: UserInfo = Depends(get_current_user_with_rbac),
+):
+    """Update a data source."""
+    return await update_data_source_handler(data_source_id, req, current_user)
+
+
+@router.delete("/data-sources/{data_source_id}", status_code=status.HTTP_200_OK)
+async def delete_data_source(
+    data_source_id: str,
+    current_user: UserInfo = Depends(get_current_user_with_rbac),
+):
+    """Delete a data source."""
+    return await delete_data_source_handler(data_source_id, current_user)

--- a/app/api/routers/breeze_buddy/data_sources/handlers.py
+++ b/app/api/routers/breeze_buddy/data_sources/handlers.py
@@ -1,0 +1,283 @@
+"""
+Business logic handlers for data source operations.
+"""
+
+from typing import List, Optional
+
+from fastapi import HTTPException, status
+
+from app.core.logger import logger
+from app.database.accessor.breeze_buddy.data_source import (
+    create_data_source,
+    delete_data_source,
+    get_data_source_by_id,
+    list_data_sources,
+    update_data_source,
+)
+from app.schemas import UserInfo
+from app.schemas.breeze_buddy.data_source import (
+    ColumnsResponse,
+    DataSourceCreate,
+    DataSourceListResponse,
+    DataSourceResponse,
+    DataSourceUpdate,
+    PreviewResponse,
+    TabsResponse,
+)
+from app.services.google.sheets import (
+    extract_spreadsheet_id,
+    fetch_sheet_data,
+    get_column_headers,
+    list_tabs,
+)
+
+
+def _resolve_reseller_ids(current_user: UserInfo) -> List[str]:
+    """Return the reseller IDs the caller is allowed to access."""
+    from app.schemas.breeze_buddy.auth import UserRole
+
+    if current_user.role == UserRole.ADMIN:
+        return []  # admin can see all — no filter applied in list_data_sources
+    return current_user.reseller_ids
+
+
+async def create_data_source_handler(
+    req: DataSourceCreate, current_user: UserInfo
+) -> DataSourceResponse:
+    """Create a new data source."""
+    from app.schemas.breeze_buddy.auth import UserRole
+
+    # Non-admin users can only create under their own reseller IDs
+    if current_user.role != UserRole.ADMIN:
+        if req.reseller_id not in current_user.reseller_ids:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Not allowed to create data source for this reseller",
+            )
+
+    logger.info(
+        f"User {current_user.username} creating data source '{req.name}' "
+        f"for reseller={req.reseller_id}"
+    )
+
+    ds = await create_data_source(
+        reseller_id=req.reseller_id,
+        merchant_id=req.merchant_id,
+        name=req.name,
+        source_type=req.source_type,
+        spreadsheet_url=req.spreadsheet_url,
+        sheet_name=req.sheet_name,
+        columns=req.columns,
+        format=req.format,
+        is_active=req.is_active,
+    )
+
+    if not ds:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Failed to create data source. URL may be invalid.",
+        )
+
+    return ds
+
+
+async def list_data_sources_handler(
+    current_user: UserInfo,
+    reseller_id: Optional[str] = None,
+    merchant_id: Optional[str] = None,
+    is_active: Optional[bool] = None,
+    page: int = 1,
+    limit: int = 50,
+) -> DataSourceListResponse:
+    """List data sources with RBAC filtering."""
+    from app.schemas.breeze_buddy.auth import UserRole
+
+    if current_user.role == UserRole.ADMIN:
+        effective_reseller_ids = [reseller_id] if reseller_id else None
+        effective_reseller_id = reseller_id
+    else:
+        allowed = current_user.reseller_ids
+        if reseller_id:
+            if reseller_id not in allowed:
+                raise HTTPException(
+                    status_code=status.HTTP_403_FORBIDDEN,
+                    detail="Not allowed to list data sources for this reseller",
+                )
+            effective_reseller_ids = [reseller_id]
+            effective_reseller_id = reseller_id
+        else:
+            effective_reseller_ids = allowed
+            effective_reseller_id = None
+
+    rows, total = await list_data_sources(
+        page=page,
+        limit=limit,
+        reseller_id=effective_reseller_id,
+        reseller_ids=effective_reseller_ids if not effective_reseller_id else None,
+        merchant_id=merchant_id,
+        is_active=is_active,
+    )
+
+    import math
+
+    total_pages = max(1, math.ceil(total / limit)) if total else 1
+
+    return DataSourceListResponse(
+        data_sources=rows,
+        total=total,
+        page=page,
+        limit=limit,
+        total_pages=total_pages,
+    )
+
+
+async def get_data_source_handler(
+    data_source_id: str, current_user: UserInfo
+) -> DataSourceResponse:
+    """Get a single data source by ID."""
+    from app.schemas.breeze_buddy.auth import UserRole
+
+    ds = await get_data_source_by_id(data_source_id)
+    if not ds:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Data source {data_source_id} not found",
+        )
+
+    if current_user.role != UserRole.ADMIN:
+        if ds.reseller_id not in current_user.reseller_ids:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Not allowed to access this data source",
+            )
+
+    return ds
+
+
+async def update_data_source_handler(
+    data_source_id: str, req: DataSourceUpdate, current_user: UserInfo
+) -> DataSourceResponse:
+    """Update a data source."""
+    from app.schemas.breeze_buddy.auth import UserRole
+
+    existing = await get_data_source_by_id(data_source_id)
+    if not existing:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Data source {data_source_id} not found",
+        )
+
+    if current_user.role != UserRole.ADMIN:
+        if existing.reseller_id not in current_user.reseller_ids:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Not allowed to update this data source",
+            )
+
+    updated = await update_data_source(
+        data_source_id=data_source_id,
+        name=req.name,
+        spreadsheet_url=req.spreadsheet_url,
+        sheet_name=req.sheet_name,
+        columns=req.columns,
+        format=req.format,
+        is_active=req.is_active,
+    )
+
+    if not updated:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Failed to update data source",
+        )
+
+    return updated
+
+
+async def delete_data_source_handler(
+    data_source_id: str, current_user: UserInfo
+) -> dict:
+    """Delete a data source."""
+    from app.schemas.breeze_buddy.auth import UserRole
+
+    existing = await get_data_source_by_id(data_source_id)
+    if not existing:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Data source {data_source_id} not found",
+        )
+
+    if current_user.role != UserRole.ADMIN:
+        if existing.reseller_id not in current_user.reseller_ids:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Not allowed to delete this data source",
+            )
+
+    deleted = await delete_data_source(data_source_id)
+    if not deleted:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to delete data source",
+        )
+
+    return {"status": "success", "id": data_source_id}
+
+
+async def list_tabs_handler(spreadsheet_url: str) -> TabsResponse:
+    """List tabs in a Google Sheet."""
+    spreadsheet_id = extract_spreadsheet_id(spreadsheet_url)
+    if not spreadsheet_id:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Invalid Google Sheets URL",
+        )
+
+    tabs = await list_tabs(spreadsheet_id)
+    return TabsResponse(spreadsheet_id=spreadsheet_id, tabs=tabs)
+
+
+async def list_columns_handler(
+    spreadsheet_url: str, sheet_name: Optional[str] = None
+) -> ColumnsResponse:
+    """List column headers for a sheet tab."""
+    spreadsheet_id = extract_spreadsheet_id(spreadsheet_url)
+    if not spreadsheet_id:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Invalid Google Sheets URL",
+        )
+
+    columns = await get_column_headers(spreadsheet_id, sheet_name)
+    return ColumnsResponse(
+        spreadsheet_id=spreadsheet_id,
+        sheet_name=sheet_name or "",
+        columns=columns,
+    )
+
+
+async def preview_handler(
+    spreadsheet_url: str,
+    sheet_name: Optional[str] = None,
+    columns: Optional[List[str]] = None,
+    max_rows: int = 10,
+) -> PreviewResponse:
+    """Preview sheet data (first N rows)."""
+    spreadsheet_id = extract_spreadsheet_id(spreadsheet_url)
+    if not spreadsheet_id:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Invalid Google Sheets URL",
+        )
+
+    rows = await fetch_sheet_data(
+        spreadsheet_id, sheet_name, columns, max_rows=max_rows
+    )
+    col_names = list(rows[0].keys()) if rows else []
+
+    return PreviewResponse(
+        spreadsheet_id=spreadsheet_id,
+        sheet_name=sheet_name,
+        columns=col_names,
+        rows=rows,
+        total_rows=len(rows),
+    )

--- a/app/api/routers/breeze_buddy/signup/handlers.py
+++ b/app/api/routers/breeze_buddy/signup/handlers.py
@@ -46,10 +46,8 @@ from app.core.config.static import GOOGLE_CLIENT_ID, JWT_ACCESS_TOKEN_EXPIRE_MIN
 from app.core.logger import logger
 from app.core.security.password import verify_password
 from app.core.security.scope import resolve_merchant_ids, resolve_reseller_ids
-from app.database.accessor.breeze_buddy import (
-    merchants as merchant_accessors,
-    users as user_accessors,
-)
+from app.database.accessor.breeze_buddy import merchants as merchant_accessors
+from app.database.accessor.breeze_buddy import users as user_accessors
 from app.schemas import TokenResponse, UserInfo, UserRole
 from app.schemas.breeze_buddy.signup import (
     AccountSummary,

--- a/app/api/routers/breeze_buddy/templates/handlers.py
+++ b/app/api/routers/breeze_buddy/templates/handlers.py
@@ -137,6 +137,11 @@ async def create_template_handler(
             expected_callback_response_schema=template_data.expected_callback_response_schema,
             configurations=configurations,
             secrets=template_data.secrets,
+            data_sources=(
+                [ds.model_dump() for ds in template_data.data_sources]
+                if template_data.data_sources
+                else None
+            ),
             outbound_number_id=template_data.outbound_number_id,
             is_active=template_data.is_active,
             supported_channels=list(template_data.supported_channels),
@@ -472,6 +477,11 @@ async def replace_template_handler(
             expected_callback_response_schema=template_data.expected_callback_response_schema,
             configurations=configurations,
             secrets=merged_secrets,
+            data_sources=(
+                [ds.model_dump() for ds in template_data.data_sources]
+                if template_data.data_sources
+                else None
+            ),
             outbound_number_id=template_data.outbound_number_id,
             is_active=template_data.is_active,
             merchant_id=template_data.merchant_id,

--- a/app/database/accessor/breeze_buddy/data_source.py
+++ b/app/database/accessor/breeze_buddy/data_source.py
@@ -1,0 +1,160 @@
+"""
+Accessor functions for the data_source table.
+Layer 2 of the three-layer DB pattern: business logic + DB execution.
+"""
+
+import json
+from datetime import datetime, timezone
+from typing import List, Optional, Tuple
+from uuid import uuid4
+
+from app.core.logger import logger
+from app.database.decoder.breeze_buddy.data_source import (
+    decode_data_source,
+    decode_data_sources,
+)
+from app.database.queries import run_parameterized_query
+from app.database.queries.breeze_buddy.data_source import (
+    delete_data_source_query,
+    get_data_source_by_id_query,
+    insert_data_source_query,
+    list_data_sources_query,
+    update_data_source_query,
+)
+from app.schemas.breeze_buddy.data_source import DataSourceResponse
+from app.services.google.sheets import extract_spreadsheet_id
+
+
+async def create_data_source(
+    reseller_id: str,
+    merchant_id: Optional[str],
+    name: str,
+    source_type: str,
+    spreadsheet_url: str,
+    sheet_name: Optional[str],
+    columns: Optional[List[str]],
+    format: str,
+    is_active: bool = True,
+) -> Optional[DataSourceResponse]:
+    """Create a new data source record."""
+    try:
+        spreadsheet_id = extract_spreadsheet_id(spreadsheet_url)
+        if not spreadsheet_id:
+            logger.error(f"Cannot extract spreadsheet_id from URL: {spreadsheet_url}")
+            return None
+
+        now = datetime.now(timezone.utc)
+        columns_json = json.dumps(columns) if columns else None
+
+        query, values = insert_data_source_query(
+            id=str(uuid4()),
+            reseller_id=reseller_id,
+            merchant_id=merchant_id,
+            name=name,
+            source_type=source_type,
+            spreadsheet_url=spreadsheet_url,
+            spreadsheet_id=spreadsheet_id,
+            sheet_name=sheet_name,
+            columns_json=columns_json,
+            format=format,
+            is_active=is_active,
+            now=now,
+        )
+        result = await run_parameterized_query(query, values)
+        return decode_data_source(result[0]) if result else None
+    except Exception as e:
+        logger.error(f"Error creating data_source: {e}", exc_info=True)
+        return None
+
+
+async def get_data_source_by_id(
+    data_source_id: str,
+) -> Optional[DataSourceResponse]:
+    """Fetch a single data source by ID."""
+    try:
+        query, values = get_data_source_by_id_query(data_source_id)
+        result = await run_parameterized_query(query, values)
+        return decode_data_source(result[0]) if result else None
+    except Exception as e:
+        logger.error(f"Error fetching data_source {data_source_id}: {e}", exc_info=True)
+        return None
+
+
+async def list_data_sources(
+    page: int = 1,
+    limit: int = 50,
+    reseller_id: Optional[str] = None,
+    reseller_ids: Optional[List[str]] = None,
+    merchant_id: Optional[str] = None,
+    is_active: Optional[bool] = None,
+) -> Tuple[List[DataSourceResponse], int]:
+    """List data sources with pagination and optional filters."""
+    try:
+        data_q, count_q, values = list_data_sources_query(
+            page=page,
+            limit=limit,
+            reseller_id=reseller_id,
+            reseller_ids=reseller_ids,
+            merchant_id=merchant_id,
+            is_active=is_active,
+        )
+        rows = await run_parameterized_query(data_q, values)
+        # count_query uses same WHERE — strip LIMIT/OFFSET values (last 2)
+        count_result = await run_parameterized_query(count_q, values[:-2])
+        total = count_result[0]["total"] if count_result else 0
+        return decode_data_sources(rows or []), total
+    except Exception as e:
+        logger.error(f"Error listing data_sources: {e}", exc_info=True)
+        return [], 0
+
+
+async def update_data_source(
+    data_source_id: str,
+    name: Optional[str] = None,
+    spreadsheet_url: Optional[str] = None,
+    sheet_name: Optional[str] = None,
+    columns: Optional[List[str]] = None,
+    format: Optional[str] = None,
+    is_active: Optional[bool] = None,
+) -> Optional[DataSourceResponse]:
+    """Update an existing data source. Only provided fields are updated."""
+    try:
+        new_spreadsheet_id = None
+        if spreadsheet_url:
+            new_spreadsheet_id = extract_spreadsheet_id(spreadsheet_url)
+            if not new_spreadsheet_id:
+                logger.error(
+                    f"Cannot extract spreadsheet_id from URL: {spreadsheet_url}"
+                )
+                return None
+
+        now = datetime.now(timezone.utc)
+        columns_json = json.dumps(columns) if columns is not None else None
+
+        query, values = update_data_source_query(
+            data_source_id=data_source_id,
+            name=name,
+            spreadsheet_url=spreadsheet_url,
+            spreadsheet_id=new_spreadsheet_id,
+            sheet_name=sheet_name,
+            columns_json=columns_json,
+            format=format,
+            is_active=is_active,
+            now=now,
+        )
+        result = await run_parameterized_query(query, values)
+        return decode_data_source(result[0]) if result else None
+    except Exception as e:
+        logger.error(f"Error updating data_source {data_source_id}: {e}", exc_info=True)
+        return None
+
+
+async def delete_data_source(data_source_id: str) -> bool:
+    """Hard delete a data source. Returns True if deleted."""
+    try:
+        query, values = delete_data_source_query(data_source_id)
+        result = await run_parameterized_query(query, values)
+        return bool(result)
+    except Exception as e:
+        logger.error(f"Error deleting data_source {data_source_id}: {e}", exc_info=True)
+        return False

--- a/app/database/accessor/breeze_buddy/template.py
+++ b/app/database/accessor/breeze_buddy/template.py
@@ -100,6 +100,7 @@ async def create_template(
     now,
     configurations: Optional[dict] = None,
     secrets: Optional[dict] = None,
+    data_sources: Optional[List[dict]] = None,
     outbound_number_id: Optional[str] = None,
     is_active: bool = True,
     supported_channels: Optional[List[str]] = None,
@@ -129,6 +130,11 @@ async def create_template(
         # Convert secrets to JSON string
         secrets_json = json.dumps(secrets) if secrets is not None else None
 
+        # Convert data_sources to JSON string
+        data_sources_json = (
+            json.dumps(data_sources) if data_sources is not None else None
+        )
+
         query, values = create_template_query(
             template_id,
             reseller_id,
@@ -139,6 +145,7 @@ async def create_template(
             expected_callback_response_schema_json,
             configurations_json,
             secrets_json,
+            data_sources_json,
             outbound_number_id,  # Moved: now matches SQL column order
             is_active,
             supported_channels or ["voice"],
@@ -353,6 +360,7 @@ async def replace_template(
     expected_callback_response_schema: Optional[dict],
     configurations: Optional[dict],
     secrets: Optional[dict],
+    data_sources: Optional[List[dict]],
     outbound_number_id: Optional[str],
     is_active: bool,
     merchant_id: Optional[str],
@@ -402,6 +410,11 @@ async def replace_template(
         # Convert secrets to JSON string
         secrets_json = json.dumps(secrets) if secrets is not None else None
 
+        # Convert data_sources to JSON string
+        data_sources_json = (
+            json.dumps(data_sources) if data_sources is not None else None
+        )
+
         query, values = replace_template_query(
             template_id,
             name,
@@ -410,6 +423,7 @@ async def replace_template(
             expected_callback_response_schema_json,
             configurations_json,
             secrets_json,
+            data_sources_json,
             outbound_number_id,
             is_active,
             merchant_id,

--- a/app/database/decoder/breeze_buddy/data_source.py
+++ b/app/database/decoder/breeze_buddy/data_source.py
@@ -1,0 +1,46 @@
+"""
+Decoder for the data_source table.
+Converts raw asyncpg Records into DataSourceResponse Pydantic models.
+Layer 3 of the three-layer DB pattern.
+"""
+
+import json
+from typing import List, Optional
+
+import asyncpg
+
+from app.schemas.breeze_buddy.data_source import DataSourceResponse
+
+
+def decode_data_source(result: asyncpg.Record) -> Optional[DataSourceResponse]:
+    """Decode a single data_source row."""
+    if not result:
+        return None
+
+    columns = result.get("columns")
+    if columns and isinstance(columns, str):
+        columns = json.loads(columns)
+
+    return DataSourceResponse(
+        id=str(result["id"]),
+        reseller_id=result["reseller_id"],
+        merchant_id=result.get("merchant_id"),
+        name=result["name"],
+        source_type=result["source_type"],
+        spreadsheet_url=result["spreadsheet_url"],
+        spreadsheet_id=result["spreadsheet_id"],
+        sheet_name=result.get("sheet_name"),
+        columns=columns,
+        format=result["format"],
+        is_active=result["is_active"],
+        created_at=result["created_at"],
+        updated_at=result["updated_at"],
+    )
+
+
+def decode_data_sources(results: List[asyncpg.Record]) -> List[DataSourceResponse]:
+    """Decode a list of data_source rows."""
+    if not results:
+        return []
+    decoded = [decode_data_source(r) for r in results]
+    return [d for d in decoded if d is not None]

--- a/app/database/decoder/breeze_buddy/template.py
+++ b/app/database/decoder/breeze_buddy/template.py
@@ -185,6 +185,13 @@ def decode_template(result: asyncpg.Record) -> Optional[TemplateModel]:
             secrets_data = json.loads(secrets_data)
         # If it's already a dict (from JSONB), use it directly
 
+    # Parse data_sources from JSONB (can be str, list, or None)
+    data_sources_data = result.get("data_sources")
+    if data_sources_data:
+        if isinstance(data_sources_data, str):
+            data_sources_data = json.loads(data_sources_data)
+        # If it's already a list (from JSONB), use it directly
+
     # supported_channels is a Postgres text[] (NOT NULL DEFAULT {'voice'}).
     # Some legacy SELECTs may not include the column — fall back to ['voice']
     # so the model always has at least one channel.
@@ -200,6 +207,7 @@ def decode_template(result: asyncpg.Record) -> Optional[TemplateModel]:
         expected_callback_response_schema=expected_callback_response_schema_data,
         configurations=configurations,
         secrets=secrets_data,
+        data_sources=data_sources_data,
         outbound_number_id=(
             str(result["outbound_number_id"])
             if result.get("outbound_number_id")

--- a/app/database/migrations/026_create_data_source_table.sql
+++ b/app/database/migrations/026_create_data_source_table.sql
@@ -1,0 +1,36 @@
+-- Migration 026: Create data_source table for external data source definitions
+-- A data source defines how to fetch external data (e.g., a Google Sheet tab)
+-- that can be injected into template variables or LLM context at call time.
+
+CREATE TABLE IF NOT EXISTS data_source (
+    id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    reseller_id     VARCHAR(255) NOT NULL,
+    merchant_id     VARCHAR(255),                   -- NULL = reseller-level (shared across merchants)
+    name            VARCHAR(255) NOT NULL,           -- user-given name; becomes {name} placeholder
+    source_type     VARCHAR(50)  NOT NULL DEFAULT 'google_sheet'
+                        CHECK (source_type IN ('google_sheet')),
+    spreadsheet_url TEXT         NOT NULL,           -- full URL pasted by user
+    spreadsheet_id  VARCHAR(255) NOT NULL,           -- extracted from URL
+    sheet_name      VARCHAR(255),                   -- tab name; NULL = first tab
+    columns         JSONB,                          -- ["Col1","Col2"]; NULL = all columns
+    format          VARCHAR(50)  NOT NULL DEFAULT 'markdown_table'
+                        CHECK (format IN ('markdown_table', 'csv', 'json')),
+    is_active       BOOLEAN      NOT NULL DEFAULT true,
+    created_at      TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    updated_at      TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+);
+
+-- Scoped lookup indexes
+CREATE INDEX IF NOT EXISTS idx_data_source_reseller_id ON data_source(reseller_id);
+CREATE INDEX IF NOT EXISTS idx_data_source_merchant_id ON data_source(merchant_id);
+CREATE INDEX IF NOT EXISTS idx_data_source_is_active   ON data_source(is_active);
+
+-- Unique name within reseller+merchant scope
+CREATE UNIQUE INDEX IF NOT EXISTS uq_data_source_reseller_merchant_name
+    ON data_source(reseller_id, merchant_id, name)
+    WHERE merchant_id IS NOT NULL;
+
+-- Unique name at reseller level (no merchant)
+CREATE UNIQUE INDEX IF NOT EXISTS uq_data_source_reseller_name_null_merchant
+    ON data_source(reseller_id, name)
+    WHERE merchant_id IS NULL;

--- a/app/database/migrations/027_add_data_sources_column_to_template.sql
+++ b/app/database/migrations/027_add_data_sources_column_to_template.sql
@@ -1,0 +1,11 @@
+-- Migration 027: Add data_sources column to template table
+-- Stores an array of data source references attached to this template.
+-- Each element: {"data_source_id": "uuid", "name": "var_name", "inject_as": "var"|"message"}
+
+ALTER TABLE template
+    ADD COLUMN IF NOT EXISTS data_sources JSONB;
+
+COMMENT ON COLUMN template.data_sources IS
+    'Array of data source refs: [{data_source_id, name, inject_as}]. '
+    'name becomes the {placeholder} in template vars. '
+    'inject_as: "var" = render into prompts, "message" = prepend system message.';

--- a/app/database/queries/breeze_buddy/data_source.py
+++ b/app/database/queries/breeze_buddy/data_source.py
@@ -1,0 +1,145 @@
+"""
+SQL query builders for the data_source table.
+Layer 1 of the three-layer DB pattern: pure SQL, no DB calls.
+Returns (sql_string, values_list) tuples consumed by run_parameterized_query().
+"""
+
+from datetime import datetime
+from typing import Any, List, Optional, Tuple
+
+DATA_SOURCE_TABLE = "data_source"
+
+
+def insert_data_source_query(
+    id: str,
+    reseller_id: str,
+    merchant_id: Optional[str],
+    name: str,
+    source_type: str,
+    spreadsheet_url: str,
+    spreadsheet_id: str,
+    sheet_name: Optional[str],
+    columns_json: Optional[str],
+    format: str,
+    is_active: bool,
+    now: datetime,
+) -> Tuple[str, List[Any]]:
+    query = f"""
+        INSERT INTO {DATA_SOURCE_TABLE}
+            (id, reseller_id, merchant_id, name, source_type,
+             spreadsheet_url, spreadsheet_id, sheet_name,
+             columns, format, is_active, created_at, updated_at)
+        VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9::jsonb,$10,$11,$12,$13)
+        RETURNING *
+    """
+    return query, [
+        id,
+        reseller_id,
+        merchant_id,
+        name,
+        source_type,
+        spreadsheet_url,
+        spreadsheet_id,
+        sheet_name,
+        columns_json,
+        format,
+        is_active,
+        now,
+        now,
+    ]
+
+
+def get_data_source_by_id_query(data_source_id: str) -> Tuple[str, List[Any]]:
+    query = f"SELECT * FROM {DATA_SOURCE_TABLE} WHERE id = $1 LIMIT 1"
+    return query, [data_source_id]
+
+
+def list_data_sources_query(
+    page: int,
+    limit: int,
+    reseller_id: Optional[str] = None,
+    reseller_ids: Optional[List[str]] = None,
+    merchant_id: Optional[str] = None,
+    is_active: Optional[bool] = None,
+) -> Tuple[str, str, List[Any]]:
+    """Returns (data_query, count_query, values). count_query has same WHERE, no LIMIT/OFFSET."""
+    conditions: List[str] = []
+    values: List[Any] = []
+
+    if reseller_ids:
+        values.append(reseller_ids)
+        conditions.append(f"reseller_id = ANY(${len(values)})")
+    elif reseller_id:
+        values.append(reseller_id)
+        conditions.append(f"reseller_id = ${len(values)}")
+
+    if merchant_id:
+        values.append(merchant_id)
+        conditions.append(f"merchant_id = ${len(values)}")
+
+    if is_active is not None:
+        values.append(is_active)
+        conditions.append(f"is_active = ${len(values)}")
+
+    where = ("WHERE " + " AND ".join(conditions)) if conditions else ""
+    offset = (page - 1) * limit
+
+    data_query = f"""
+        SELECT * FROM {DATA_SOURCE_TABLE}
+        {where}
+        ORDER BY created_at DESC
+        LIMIT ${len(values) + 1} OFFSET ${len(values) + 2}
+    """
+    count_query = f"SELECT COUNT(*) AS total FROM {DATA_SOURCE_TABLE} {where}"
+
+    return data_query, count_query, values + [limit, offset]
+
+
+def update_data_source_query(
+    data_source_id: str,
+    name: Optional[str],
+    spreadsheet_url: Optional[str],
+    spreadsheet_id: Optional[str],
+    sheet_name: Optional[str],
+    columns_json: Optional[str],
+    format: Optional[str],
+    is_active: Optional[bool],
+    now: datetime,
+) -> Tuple[str, List[Any]]:
+    sets: List[str] = []
+    values: List[Any] = []
+
+    def _add(col: str, val: Any, cast: str = "") -> None:
+        sets.append(f"{col} = ${len(values) + 1}{cast}")
+        values.append(val)
+
+    if name is not None:
+        _add("name", name)
+    if spreadsheet_url is not None:
+        _add("spreadsheet_url", spreadsheet_url)
+    if spreadsheet_id is not None:
+        _add("spreadsheet_id", spreadsheet_id)
+    if sheet_name is not None:
+        _add("sheet_name", sheet_name)
+    if columns_json is not None:
+        _add("columns", columns_json, "::jsonb")
+    if format is not None:
+        _add("format", format)
+    if is_active is not None:
+        _add("is_active", is_active)
+
+    _add("updated_at", now)
+    values.append(data_source_id)
+
+    query = f"""
+        UPDATE {DATA_SOURCE_TABLE}
+        SET {", ".join(sets)}
+        WHERE id = ${len(values)}
+        RETURNING *
+    """
+    return query, values
+
+
+def delete_data_source_query(data_source_id: str) -> Tuple[str, List[Any]]:
+    query = f"DELETE FROM {DATA_SOURCE_TABLE} WHERE id = $1 RETURNING id"
+    return query, [data_source_id]

--- a/app/database/queries/breeze_buddy/template.py
+++ b/app/database/queries/breeze_buddy/template.py
@@ -31,7 +31,7 @@ def get_template_by_merchant_query(
         SELECT id,
                reseller_id,
                merchant_id,
-               name, flow, expected_payload_schema, expected_callback_response_schema, configurations, secrets, outbound_number_id, is_active, supported_channels, created_at, updated_at
+               name, flow, expected_payload_schema, expected_callback_response_schema, configurations, secrets, data_sources, outbound_number_id, is_active, supported_channels, created_at, updated_at
         FROM {TEMPLATE_TABLE}
         WHERE {" AND ".join(conditions)}
     """
@@ -57,6 +57,7 @@ def create_template_query(
     secrets: Optional[
         str
     ],  # JSON string containing secrets and variables for HTTP functions
+    data_sources: Optional[str],  # JSON string containing data source refs
     outbound_number_id: Optional[
         str
     ],  # Changed: moved before is_active to match SQL column order
@@ -67,9 +68,9 @@ def create_template_query(
 ) -> Tuple[str, List[Any]]:
     """Generate query to create a new template."""
     query = f"""
-        INSERT INTO {TEMPLATE_TABLE} (id, reseller_id, merchant_id, name, flow, expected_payload_schema, expected_callback_response_schema, configurations, secrets, outbound_number_id, is_active, supported_channels, created_at, updated_at)
-        VALUES ($1, $2, $3, $4, $5::jsonb, $6::jsonb, $7::jsonb, $8::jsonb, $9::jsonb, $10, $11, $12, $13, $14)
-        RETURNING id, reseller_id, merchant_id, name, flow, expected_payload_schema, expected_callback_response_schema, configurations, secrets, outbound_number_id, is_active, supported_channels, created_at, updated_at
+        INSERT INTO {TEMPLATE_TABLE} (id, reseller_id, merchant_id, name, flow, expected_payload_schema, expected_callback_response_schema, configurations, secrets, data_sources, outbound_number_id, is_active, supported_channels, created_at, updated_at)
+        VALUES ($1, $2, $3, $4, $5::jsonb, $6::jsonb, $7::jsonb, $8::jsonb, $9::jsonb, $10::jsonb, $11, $12, $13, $14, $15)
+        RETURNING id, reseller_id, merchant_id, name, flow, expected_payload_schema, expected_callback_response_schema, configurations, secrets, data_sources, outbound_number_id, is_active, supported_channels, created_at, updated_at
     """
 
     return query, [
@@ -82,6 +83,7 @@ def create_template_query(
         expected_callback_response_schema,
         configurations,
         secrets,
+        data_sources,
         outbound_number_id,
         is_active,
         supported_channels,
@@ -184,7 +186,7 @@ def get_template_by_id_query(template_id: str) -> Tuple[str, List[Any]]:
         SELECT id,
                reseller_id,
                merchant_id,
-               name, flow, expected_payload_schema, expected_callback_response_schema, configurations, secrets, outbound_number_id, is_active, supported_channels, created_at, updated_at
+               name, flow, expected_payload_schema, expected_callback_response_schema, configurations, secrets, data_sources, outbound_number_id, is_active, supported_channels, created_at, updated_at
         FROM {TEMPLATE_TABLE}
         WHERE id = $1
         LIMIT 1
@@ -218,7 +220,7 @@ def get_template_by_outbound_number_id_query(
         SELECT id,
                reseller_id,
                merchant_id,
-               name, flow, expected_payload_schema, expected_callback_response_schema, configurations, secrets, outbound_number_id, is_active, supported_channels, created_at, updated_at
+               name, flow, expected_payload_schema, expected_callback_response_schema, configurations, secrets, data_sources, outbound_number_id, is_active, supported_channels, created_at, updated_at
         FROM {TEMPLATE_TABLE}
         WHERE {' AND '.join(conditions)}
         LIMIT 1
@@ -298,6 +300,7 @@ def replace_template_query(
     expected_callback_response_schema: Optional[str],
     configurations: Optional[str],
     secrets: Optional[str],
+    data_sources: Optional[str],
     outbound_number_id: Optional[str],
     is_active: bool,
     merchant_id: Optional[str],
@@ -315,6 +318,7 @@ def replace_template_query(
         expected_callback_response_schema: Expected callback response schema JSON string or None
         configurations: Configurations JSON string or None
         secrets: Secrets and variables JSON string or None
+        data_sources: Data source refs JSON string or None
         outbound_number_id: Outbound number ID or None
         is_active: Whether template is active
         merchant_id: Merchant identifier or None
@@ -332,16 +336,17 @@ def replace_template_query(
             expected_callback_response_schema = $4::jsonb,
             configurations = $5::jsonb,
             secrets = $6::jsonb,
-            outbound_number_id = $7,
-            is_active = $8,
-            merchant_id = $9,
-            supported_channels = $10,
-            updated_at = $11
-        WHERE id = $12
+            data_sources = $7::jsonb,
+            outbound_number_id = $8,
+            is_active = $9,
+            merchant_id = $10,
+            supported_channels = $11,
+            updated_at = $12
+        WHERE id = $13
         RETURNING id,
                   reseller_id,
                   merchant_id,
-                  name, flow, expected_payload_schema, expected_callback_response_schema, configurations, secrets, outbound_number_id, is_active, supported_channels, created_at, updated_at
+                  name, flow, expected_payload_schema, expected_callback_response_schema, configurations, secrets, data_sources, outbound_number_id, is_active, supported_channels, created_at, updated_at
     """
 
     return query, [
@@ -351,6 +356,7 @@ def replace_template_query(
         expected_callback_response_schema,
         configurations,
         secrets,
+        data_sources,
         outbound_number_id,
         is_active,
         merchant_id,

--- a/app/schemas/breeze_buddy/__init__.py
+++ b/app/schemas/breeze_buddy/__init__.py
@@ -41,6 +41,15 @@ from app.schemas.breeze_buddy.core import (
     TelephonyConfig,
     UpdateCallExecutionConfigRequest,
 )
+from app.schemas.breeze_buddy.data_source import (
+    ColumnsResponse,
+    DataSourceCreate,
+    DataSourceListResponse,
+    DataSourceResponse,
+    DataSourceUpdate,
+    PreviewResponse,
+    TabsResponse,
+)
 from app.schemas.breeze_buddy.merchants import (
     MerchantCreate,
     MerchantListResponse,
@@ -53,11 +62,13 @@ from app.schemas.breeze_buddy.template import (
 )
 from app.schemas.breeze_buddy.users import (
     DeleteUserResponse,
-    UserCreate as UserAccountCreate,
+)
+from app.schemas.breeze_buddy.users import UserCreate as UserAccountCreate
+from app.schemas.breeze_buddy.users import (
     UserListResponse,
     UserResponse,
-    UserUpdate as UserAccountUpdate,
 )
+from app.schemas.breeze_buddy.users import UserUpdate as UserAccountUpdate
 
 __all__ = [
     # Auth
@@ -98,6 +109,14 @@ __all__ = [
     "OutboundNumberStatus",
     "TelephonyConfig",
     "UpdateCallExecutionConfigRequest",
+    # Data Sources
+    "DataSourceCreate",
+    "DataSourceListResponse",
+    "DataSourceResponse",
+    "DataSourceUpdate",
+    "TabsResponse",
+    "ColumnsResponse",
+    "PreviewResponse",
     # Template
     "TemplateListResponse",
     "TemplateMetadata",

--- a/app/schemas/breeze_buddy/data_source.py
+++ b/app/schemas/breeze_buddy/data_source.py
@@ -1,0 +1,100 @@
+"""
+Pydantic schemas for the data_source REST API.
+"""
+
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, Field
+
+
+class DataSourceCreate(BaseModel):
+    """Request body for POST /data-sources"""
+
+    reseller_id: str = Field(description="Reseller that owns this data source")
+    merchant_id: Optional[str] = Field(
+        None,
+        description="Scope to a specific merchant. NULL = all merchants of reseller",
+    )
+    name: str = Field(
+        description="Human-readable name; also becomes the {variable_name} placeholder"
+    )
+    source_type: str = Field(
+        default="google_sheet", description="Currently: 'google_sheet'"
+    )
+    spreadsheet_url: str = Field(description="Full Google Sheets URL")
+    sheet_name: Optional[str] = Field(
+        None, description="Tab name. NULL = first tab in spreadsheet"
+    )
+    columns: Optional[List[str]] = Field(
+        None, description="Columns to include. NULL = all columns"
+    )
+    format: str = Field(
+        default="markdown_table",
+        description="Output format: 'markdown_table' | 'csv' | 'json'",
+    )
+    is_active: bool = Field(default=True)
+
+
+class DataSourceUpdate(BaseModel):
+    """Request body for PUT /data-sources/{id}"""
+
+    name: Optional[str] = None
+    spreadsheet_url: Optional[str] = None
+    sheet_name: Optional[str] = None
+    columns: Optional[List[str]] = None
+    format: Optional[str] = None
+    is_active: Optional[bool] = None
+
+
+class DataSourceResponse(BaseModel):
+    """Response shape for a single data source"""
+
+    id: str
+    reseller_id: str
+    merchant_id: Optional[str] = None
+    name: str
+    source_type: str
+    spreadsheet_url: str
+    spreadsheet_id: str
+    sheet_name: Optional[str] = None
+    columns: Optional[List[str]] = None
+    format: str
+    is_active: bool
+    created_at: datetime
+    updated_at: datetime
+
+
+class DataSourceListResponse(BaseModel):
+    """Response shape for GET /data-sources (paginated)"""
+
+    data_sources: List[DataSourceResponse]
+    total: int
+    page: int = 1
+    limit: int = 50
+    total_pages: int = 1
+
+
+class TabsResponse(BaseModel):
+    """Response for GET /data-sources/sheets/tabs"""
+
+    spreadsheet_id: str
+    tabs: List[str]
+
+
+class ColumnsResponse(BaseModel):
+    """Response for GET /data-sources/sheets/columns"""
+
+    spreadsheet_id: str
+    sheet_name: str
+    columns: List[str]
+
+
+class PreviewResponse(BaseModel):
+    """Response for GET /data-sources/sheets/preview"""
+
+    spreadsheet_id: str
+    sheet_name: Optional[str] = None
+    columns: List[str]
+    rows: List[Dict[str, Any]]
+    total_rows: int

--- a/app/services/google/sheets.py
+++ b/app/services/google/sheets.py
@@ -1,0 +1,267 @@
+"""
+Google Sheets Service
+
+Fetches data from Google Sheets using the platform's shared GCP service account.
+Merchants share their sheet with the platform SA email (Viewer access).
+The SA credentials come from GOOGLE_CREDENTIALS_JSON env var.
+
+Supported output formats:
+  - markdown_table : LLM-readable, token-efficient
+  - csv            : compact, parseable
+  - json           : structured, for programmatic use
+"""
+
+import asyncio
+import json
+import re
+from typing import List, Optional
+
+from google.oauth2 import service_account
+from googleapiclient.discovery import build
+from googleapiclient.errors import HttpError
+
+from app.core.config.static import GOOGLE_CREDENTIALS_JSON
+from app.core.logger import logger
+
+# Read-only scope — we never write to sheets
+_SCOPES = ["https://www.googleapis.com/auth/spreadsheets.readonly"]
+
+# Regex to extract spreadsheet ID from any Google Sheets URL format
+_SPREADSHEET_ID_RE = re.compile(r"/spreadsheets/d/([a-zA-Z0-9\-_]+)")
+
+
+def extract_spreadsheet_id(url: str) -> Optional[str]:
+    """Extract spreadsheet ID from a Google Sheets URL."""
+    match = _SPREADSHEET_ID_RE.search(url)
+    return match.group(1) if match else None
+
+
+def _get_sheets_service():
+    """Build authenticated Google Sheets API service using the platform SA."""
+    if not GOOGLE_CREDENTIALS_JSON:
+        logger.error(
+            "GOOGLE_CREDENTIALS_JSON env var is not set — cannot access Google Sheets"
+        )
+        return None
+
+    try:
+        credentials_dict = json.loads(GOOGLE_CREDENTIALS_JSON)
+    except json.JSONDecodeError as e:
+        logger.error(f"Failed to parse GOOGLE_CREDENTIALS_JSON: {e}")
+        return None
+
+    try:
+        credentials = service_account.Credentials.from_service_account_info(
+            credentials_dict, scopes=_SCOPES
+        )
+        service = build("sheets", "v4", credentials=credentials, cache_discovery=False)
+        return service
+    except Exception as e:
+        logger.error(f"Failed to build Google Sheets service: {e}")
+        return None
+
+
+async def list_tabs(spreadsheet_id: str) -> List[str]:
+    """List all tab (sheet) names in a spreadsheet."""
+
+    def _fetch():
+        service = _get_sheets_service()
+        if not service:
+            return []
+        try:
+            result = (
+                service.spreadsheets()
+                .get(spreadsheetId=spreadsheet_id, fields="sheets.properties.title")
+                .execute()
+            )
+            return [sheet["properties"]["title"] for sheet in result.get("sheets", [])]
+        except HttpError as e:
+            logger.error(
+                f"Google Sheets API error listing tabs for {spreadsheet_id}: {e}"
+            )
+            return []
+        except Exception as e:
+            logger.error(f"Unexpected error listing tabs for {spreadsheet_id}: {e}")
+            return []
+
+    return await asyncio.get_event_loop().run_in_executor(None, _fetch)
+
+
+async def get_column_headers(
+    spreadsheet_id: str,
+    sheet_name: Optional[str] = None,
+) -> List[str]:
+    """Get column headers (first row) of a sheet tab."""
+
+    def _fetch():
+        service = _get_sheets_service()
+        if not service:
+            return []
+        try:
+            tab = sheet_name
+            if not tab:
+                meta = (
+                    service.spreadsheets()
+                    .get(
+                        spreadsheetId=spreadsheet_id,
+                        fields="sheets.properties.title",
+                    )
+                    .execute()
+                )
+                sheets = meta.get("sheets", [])
+                if not sheets:
+                    return []
+                tab = sheets[0]["properties"]["title"]
+
+            range_str = f"'{tab}'!1:1"
+            result = (
+                service.spreadsheets()
+                .values()
+                .get(spreadsheetId=spreadsheet_id, range=range_str)
+                .execute()
+            )
+            rows = result.get("values", [])
+            return rows[0] if rows else []
+        except HttpError as e:
+            logger.error(
+                f"Google Sheets API error fetching headers "
+                f"for {spreadsheet_id}/{sheet_name}: {e}"
+            )
+            return []
+        except Exception as e:
+            logger.error(
+                f"Unexpected error fetching headers "
+                f"for {spreadsheet_id}/{sheet_name}: {e}"
+            )
+            return []
+
+    return await asyncio.get_event_loop().run_in_executor(None, _fetch)
+
+
+async def fetch_sheet_data(
+    spreadsheet_id: str,
+    sheet_name: Optional[str] = None,
+    columns: Optional[List[str]] = None,
+    max_rows: int = 500,
+) -> List[dict]:
+    """Fetch sheet data as a list of row dicts {column_name: value}."""
+
+    def _fetch():
+        service = _get_sheets_service()
+        if not service:
+            return []
+        try:
+            tab = sheet_name
+            if not tab:
+                meta = (
+                    service.spreadsheets()
+                    .get(
+                        spreadsheetId=spreadsheet_id,
+                        fields="sheets.properties.title",
+                    )
+                    .execute()
+                )
+                sheets = meta.get("sheets", [])
+                if not sheets:
+                    return []
+                tab = sheets[0]["properties"]["title"]
+
+            range_str = f"'{tab}'!A1:ZZ{max_rows + 1}"
+            result = (
+                service.spreadsheets()
+                .values()
+                .get(spreadsheetId=spreadsheet_id, range=range_str)
+                .execute()
+            )
+            rows = result.get("values", [])
+            if not rows:
+                return []
+
+            headers = rows[0]
+            data_rows = rows[1:]
+
+            records = []
+            for row in data_rows:
+                padded = row + [""] * (len(headers) - len(row))
+                record = {headers[i]: padded[i] for i in range(len(headers))}
+                records.append(record)
+
+            if columns:
+                col_set = set(columns)
+                records = [
+                    {col: r.get(col, "") for col in columns if col in col_set}
+                    for r in records
+                ]
+
+            return records
+        except HttpError as e:
+            logger.error(
+                f"Google Sheets API error fetching data "
+                f"for {spreadsheet_id}/{sheet_name}: {e}"
+            )
+            return []
+        except Exception as e:
+            logger.error(
+                f"Unexpected error fetching data "
+                f"for {spreadsheet_id}/{sheet_name}: {e}"
+            )
+            return []
+
+    return await asyncio.get_event_loop().run_in_executor(None, _fetch)
+
+
+def _rows_to_markdown_table(headers: List[str], rows: List[dict]) -> str:
+    if not headers or not rows:
+        return "(no data)"
+    header_line = "| " + " | ".join(headers) + " |"
+    separator = "| " + " | ".join(["---"] * len(headers)) + " |"
+    data_lines = []
+    for row in rows:
+        cells = [str(row.get(h, "")) for h in headers]
+        data_lines.append("| " + " | ".join(cells) + " |")
+    return "\n".join([header_line, separator] + data_lines)
+
+
+def _rows_to_csv(headers: List[str], rows: List[dict]) -> str:
+    if not headers or not rows:
+        return "(no data)"
+    lines = [",".join(headers)]
+    for row in rows:
+        cells = [str(row.get(h, "")).replace(",", ";") for h in headers]
+        lines.append(",".join(cells))
+    return "\n".join(lines)
+
+
+def _rows_to_json(rows: List[dict]) -> str:
+    if not rows:
+        return "[]"
+    return json.dumps(rows, ensure_ascii=False)
+
+
+async def fetch_formatted(
+    spreadsheet_id: str,
+    sheet_name: Optional[str] = None,
+    columns: Optional[List[str]] = None,
+    format: str = "markdown_table",
+    max_rows: int = 500,
+) -> str:
+    """
+    Fetch sheet data and return as a formatted string for LLM injection.
+
+    Returns "[No data available]" on any error or empty sheet.
+    """
+    rows = await fetch_sheet_data(spreadsheet_id, sheet_name, columns, max_rows)
+    if not rows:
+        logger.warning(
+            f"No data fetched from spreadsheet={spreadsheet_id}, sheet={sheet_name}"
+        )
+        return "[No data available]"
+
+    headers = list(rows[0].keys()) if rows else []
+
+    if format == "csv":
+        return _rows_to_csv(headers, rows)
+    elif format == "json":
+        return _rows_to_json(rows)
+    else:
+        return _rows_to_markdown_table(headers, rows)

--- a/app/services/redis/client.py
+++ b/app/services/redis/client.py
@@ -8,7 +8,8 @@ from typing import Any, Awaitable, Dict, List, Optional, Union, cast
 
 from redis.asyncio import Redis
 from redis.asyncio.cluster import ClusterNode, RedisCluster
-from redis.exceptions import ConnectionError as RedisConnectionError, RedisError
+from redis.exceptions import ConnectionError as RedisConnectionError
+from redis.exceptions import RedisError
 
 from app.core.config.static import (
     REDIS_CLUSTER_NODES,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,8 +12,8 @@ dependencies = [
     "websockets>=11.0.3",
     "starlette>=0.27.0",
     "python-dotenv>=1.0.0",
-    "pipecat-ai[daily,google,assemblyai,silero,openai,azure,elevenlabs,aic,anthropic,deepgram,soniox,mcp,sarvam,cartesia]==1.1.0",
-    "pipecat-ai-flows==1.0.0",
+    "pipecat-ai[daily,google,assemblyai,silero,openai,azure,elevenlabs,aic,anthropic,deepgram,soniox,mcp,sarvam,cartesia]",
+    "pipecat-ai-flows",
     "loguru",
     "opentelemetry-api",
     "opentelemetry-sdk",
@@ -33,7 +33,7 @@ dependencies = [
     "redis[hiredis]>=5.0.0",
     "nltk",
     "jmespath>=1.1.0",
-    "h2>=4.3.0",
+    "google-api-python-client>=2.197.0",
 ]
 
 [project.optional-dependencies]
@@ -41,14 +41,8 @@ dev = [
     "black",
     "isort",
     "autoflake",
-    "pyrefly",
-    "pytest>=9.0.3",
-    "pytest-asyncio>=1.3.0",
+    "pyrefly"
 ]
-
-[tool.pytest.ini_options]
-asyncio_mode = "auto"
-testpaths = ["tests"]
 
 [build-system]
 requires = ["hatchling"]
@@ -64,12 +58,6 @@ target-version = ['py311']
 [tool.isort]
 profile = "black"
 line_length = 88
-combine_as_imports = true
 
 [tool.pyrefly]
 project-excludes = ["**/automatic/**"]
-
-[dependency-groups]
-dev = [
-    "pytest>=9.0.3",
-]

--- a/tests/breeze_buddy/dispatch/conftest.py
+++ b/tests/breeze_buddy/dispatch/conftest.py
@@ -13,21 +13,21 @@ that monkeypatches the worker's DB/provider collaborators so a full
 from __future__ import annotations
 
 import fnmatch
-from datetime import datetime, time as dtime, timedelta, timezone
+from datetime import datetime
+from datetime import time as dtime
+from datetime import timedelta, timezone
 from typing import Any, Dict, List, Optional, Tuple
 
 import pytest
 
 import app.services.redis as redis_pkg
-from app.ai.voice.agents.breeze_buddy.dispatch import (
-    alerts as alerts_mod,
-    channel_semaphore as ch_mod,
-    leader as leader_mod,
-    promoter as prom_mod,
-    queue as queue_mod,
-    reconcilers as recon_mod,
-    worker as worker_mod,
-)
+from app.ai.voice.agents.breeze_buddy.dispatch import alerts as alerts_mod
+from app.ai.voice.agents.breeze_buddy.dispatch import channel_semaphore as ch_mod
+from app.ai.voice.agents.breeze_buddy.dispatch import leader as leader_mod
+from app.ai.voice.agents.breeze_buddy.dispatch import promoter as prom_mod
+from app.ai.voice.agents.breeze_buddy.dispatch import queue as queue_mod
+from app.ai.voice.agents.breeze_buddy.dispatch import reconcilers as recon_mod
+from app.ai.voice.agents.breeze_buddy.dispatch import worker as worker_mod
 from app.schemas import CallProvider, ExecutionMode, LeadCallStatus
 from app.schemas.breeze_buddy.core import (
     CallExecutionConfig,

--- a/tests/breeze_buddy/dispatch/test_chaos_and_edges.py
+++ b/tests/breeze_buddy/dispatch/test_chaos_and_edges.py
@@ -48,11 +48,9 @@ from typing import cast
 
 import pytest
 
-from app.ai.voice.agents.breeze_buddy.dispatch import (
-    promoter as prom_mod,
-    reconcilers as recon_mod,
-    worker as w,
-)
+from app.ai.voice.agents.breeze_buddy.dispatch import promoter as prom_mod
+from app.ai.voice.agents.breeze_buddy.dispatch import reconcilers as recon_mod
+from app.ai.voice.agents.breeze_buddy.dispatch import worker as w
 from app.ai.voice.agents.breeze_buddy.dispatch.channel_semaphore import (
     channel_tokens_available,
     init_channel_semaphore,

--- a/tests/breeze_buddy/dispatch/test_end_to_end.py
+++ b/tests/breeze_buddy/dispatch/test_end_to_end.py
@@ -22,11 +22,9 @@ from __future__ import annotations
 from datetime import datetime, timedelta, timezone
 from typing import cast
 
-from app.ai.voice.agents.breeze_buddy.dispatch import (
-    promoter as prom_mod,
-    reconcilers as recon_mod,
-    worker as w,
-)
+from app.ai.voice.agents.breeze_buddy.dispatch import promoter as prom_mod
+from app.ai.voice.agents.breeze_buddy.dispatch import reconcilers as recon_mod
+from app.ai.voice.agents.breeze_buddy.dispatch import worker as w
 from app.ai.voice.agents.breeze_buddy.dispatch.channel_semaphore import (
     channel_tokens_available,
     init_channel_semaphore,

--- a/uv.lock
+++ b/uv.lock
@@ -9,38 +9,47 @@ resolution-markers = [
 ]
 
 [[package]]
+name = "aenum"
+version = "3.1.16"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/09/7a/61ed58e8be9e30c3fe518899cc78c284896d246d51381bab59b5db11e1f3/aenum-3.1.16.tar.gz", hash = "sha256:bfaf9589bdb418ee3a986d85750c7318d9d2839c1b1a1d6fe8fc53ec201cf140", size = 137693, upload-time = "2026-01-12T22:34:38.819Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e3/52/6ad8f63ec8da1bf40f96996d25d5b650fdd38f5975f8c813732c47388f18/aenum-3.1.16-py3-none-any.whl", hash = "sha256:9035092855a98e41b66e3d0998bd7b96280e85ceb3a04cc035636138a1943eaf", size = 165627, upload-time = "2025-04-25T03:17:58.89Z" },
+]
+
+[[package]]
 name = "aic-sdk"
-version = "2.2.0"
+version = "2.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2a/d6/bcb93b6a67b4dd88582ac244e92c057ccd0c356ebcdfb22cb8d01c097297/aic_sdk-2.2.0.tar.gz", hash = "sha256:1e459031e9a545956730443765dbe8d480f3f858abc940230c7b2e37126eaf61", size = 3345678, upload-time = "2026-04-23T14:02:17.92Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/68/c6/1f0b3d3d226c6d19ec654fdaea7859ee9931e0286735385b1f9ea4bcfba1/aic_sdk-2.0.1.tar.gz", hash = "sha256:2480d8398a26639ed7fb5175c37da82cf5e6b1138a1a301938cd8491fe461c20", size = 73091, upload-time = "2026-01-23T23:38:15.77Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/78/6d/c3179c3f21f1bf78c4db445776719de522c7927daf386c1d3fc3d8a4c54e/aic_sdk-2.2.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:95a69557c1331b7c72ca8fe624254a4ab3651062dee09097372c508fe13574b8", size = 4066328, upload-time = "2026-04-23T14:01:40.372Z" },
-    { url = "https://files.pythonhosted.org/packages/51/dc/137d3608634529adb2b66e78322b304e7a5f28839b6a130574efba9a1310/aic_sdk-2.2.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:d2a56d36e9135165a4ecb65ee4712ac1b943593d95708b04854b10ed6c7ef518", size = 3655869, upload-time = "2026-04-23T14:01:41.589Z" },
-    { url = "https://files.pythonhosted.org/packages/46/b2/58d5937c1ab6f2c0561d52bf6fe36fa84ef5a42950f378b118ef41514860/aic_sdk-2.2.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1a7ced8d9955087505a959b8193b6623a9844ef4ed65bea956857f957530d6f4", size = 3565036, upload-time = "2026-04-23T14:01:43.338Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/61/7ac4b02acfa04fbfe478fd69a2b3d25ae442534879866ff99bb00a2f23b0/aic_sdk-2.2.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:75a4f89d8e859d74b25a20803db27e5b796661c2e4c479314d0ec5a5a845633e", size = 3932959, upload-time = "2026-04-23T14:01:44.763Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/2a/6239e4717738b703078d5b88629bd6980c8776c9011e9350a3ef46cd0993/aic_sdk-2.2.0-cp311-cp311-win_amd64.whl", hash = "sha256:e5ebf942eb32dcca28ce6369d89d4687c088f5645cbc39704e409f930ad99c78", size = 3384308, upload-time = "2026-04-23T14:01:46.793Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/41/a9f79589b302e0a7888905a9072c98fcc020a85acd1cd8ee416db251c74f/aic_sdk-2.2.0-cp311-cp311-win_arm64.whl", hash = "sha256:91fdc07b357cbdfaf8b9c33bd65a54aa9577a2c0166be391b782b44676ed1c62", size = 3064103, upload-time = "2026-04-23T14:01:48.132Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/0c/5ba002a33e737406b47fca0bc44cd5d3eefef35ddc2f545b89dae2c6806a/aic_sdk-2.2.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:088a0c2ce0f577c20f5c40d3ae3a09508cd8a905b564cf3764adc1259742f81d", size = 4067060, upload-time = "2026-04-23T14:01:49.454Z" },
-    { url = "https://files.pythonhosted.org/packages/35/3d/c9ee338a1203a2a44ebad190cb75fd1f92d250dce7edfca657c4cdd2a0bc/aic_sdk-2.2.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ba08d6ae21c50d93966ab75a89769776070b268c8732836faaedfbded0414afe", size = 3655275, upload-time = "2026-04-23T14:01:51.057Z" },
-    { url = "https://files.pythonhosted.org/packages/84/2a/645845f903c86d34852ae0f27ce98944fe0b2ddc5d81a137faba058a3c6d/aic_sdk-2.2.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6aae0a1d36b26eecb2ade05fc1adad2e82e0c9b38e65ce215dc8c9b239f7fe4b", size = 3562283, upload-time = "2026-04-23T14:01:52.367Z" },
-    { url = "https://files.pythonhosted.org/packages/de/a6/6f5a5d5727257c7d7d8c4ee31f18edb4428a1986feedeca85986a9edba61/aic_sdk-2.2.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dbc3b3d398b35894ccefd3891cd779f325d87587a2d5b0445cc4662fd95a7751", size = 3932655, upload-time = "2026-04-23T14:01:53.891Z" },
-    { url = "https://files.pythonhosted.org/packages/51/40/fb36fb2700f1ca5797a9293a4c573acf32bc177bdf0919880775e4f57429/aic_sdk-2.2.0-cp312-cp312-win_amd64.whl", hash = "sha256:d08d5286f24a7d6a4f236feedb1dcdf3de6032d490c652d870f56b80711487c6", size = 3382782, upload-time = "2026-04-23T14:01:55.256Z" },
-    { url = "https://files.pythonhosted.org/packages/23/71/ba0296d148ef284a6316c5699f0cf3cb5bb3d116c67ee8ed8fef4862401d/aic_sdk-2.2.0-cp312-cp312-win_arm64.whl", hash = "sha256:6169a9c073f47d6e6ae661ce78b829c5446f9a9c0e6e04e764f83bb4362ad165", size = 3061053, upload-time = "2026-04-23T14:01:56.755Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/1c/313b7c6d8959e97096f3466cde73d6db9ef94e9b8a2cfa54fa2378fb81a8/aic_sdk-2.2.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:55197e48b970ba8a158ca250f75e30d4ac1df666291f2c7f508ff3c7222f7e38", size = 4066265, upload-time = "2026-04-23T14:01:58.514Z" },
-    { url = "https://files.pythonhosted.org/packages/1d/63/963e47170897ae4bd6b02611b2472b3276a61a2e2906be299ceaedd3e2d4/aic_sdk-2.2.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:099114a5b3a541d0f520dfcd87b195594fcdb6321fe6e62c5d4610d15a03d498", size = 3654664, upload-time = "2026-04-23T14:02:00.246Z" },
-    { url = "https://files.pythonhosted.org/packages/36/05/4e760cfdbd78e5be74c60ec9efc3ef846c56f69fad05698242d3e933b3ff/aic_sdk-2.2.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3532d58306f1d25d1108d58b25d4d8dceb37febc85497d0c23e4579811533e4f", size = 3561807, upload-time = "2026-04-23T14:02:01.489Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/99/6e67dac214f1993395ed8cb7e9cb51b66b48829e62ddfc67dde08211b183/aic_sdk-2.2.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c71f7b3964efe4bc8fb5fd2ad3091f08f3c119f811f30c30ce488540387e9d34", size = 3931923, upload-time = "2026-04-23T14:02:03.064Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/49/435e1b240611fbabe73c0fc528aa162ab64afcb4022033e6e0ba14585f1b/aic_sdk-2.2.0-cp313-cp313-win_amd64.whl", hash = "sha256:9d43afdae40ce615bdaecd77768dfe0ef28bad67982e8142994171aab00aa6c1", size = 3382400, upload-time = "2026-04-23T14:02:04.592Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/74/de149fbc0e9f7b30dadc9e105fce67dde27b8a7c566901901470d0b516cf/aic_sdk-2.2.0-cp313-cp313-win_arm64.whl", hash = "sha256:2795535f065c4e4d178e70887ce7cdba8df012d4d682d1485fb0f9f0ef3e2d89", size = 3060500, upload-time = "2026-04-23T14:02:06.119Z" },
-    { url = "https://files.pythonhosted.org/packages/7e/1a/f44c9088fa03dbf4b9d9fefe5f0367d0fed5a22999bc0a1e03394637b520/aic_sdk-2.2.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:0310151c7cf46fcd998ff41c7db515661f669ff4a0f592286aad4a35b4a08116", size = 4067817, upload-time = "2026-04-23T14:02:07.956Z" },
-    { url = "https://files.pythonhosted.org/packages/26/5e/8b7fc359db566dbb427d87340692281f467fa806d9cb8becbd13fa82dce6/aic_sdk-2.2.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:314eb4354bb3e4952e05720c5c76df0bb1a746c958e93706f8e950f890f46dfa", size = 3655548, upload-time = "2026-04-23T14:02:09.815Z" },
-    { url = "https://files.pythonhosted.org/packages/61/a8/8d079c7f488e71b181771343be7694060466c7adb75d907c96933d4ff7d5/aic_sdk-2.2.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c75c0b5b4c57d55910672a948d7502b96efc8101969463d01d5f13f1a2ff6a4c", size = 3563212, upload-time = "2026-04-23T14:02:11.17Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/86/fa9b3407128949fa19f84f43fc8b577e517172aa536ef1c1b495d8730c40/aic_sdk-2.2.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d12b998904b08a5ff5e97b8e0e878149b8e853cf32dacf72ba03dd42c890684e", size = 3933253, upload-time = "2026-04-23T14:02:13.336Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/64/eb913bf179c75007bf4bdff688aa3c91b88bc2e6b4a8f920881ac26b9511/aic_sdk-2.2.0-cp314-cp314-win_amd64.whl", hash = "sha256:b93c9a47ac81cdc94ec4d74f7fcba4380bedce4431373eb4ddd20861bb4aa65e", size = 3384593, upload-time = "2026-04-23T14:02:14.718Z" },
-    { url = "https://files.pythonhosted.org/packages/02/a2/237bfab9c23e97c583552846671743fd7451c94eecad2e96dfe756e1dbab/aic_sdk-2.2.0-cp314-cp314-win_arm64.whl", hash = "sha256:62d8165322d4c5d824e5cbd675e0bd0650bfdc1df3aa58edc320d5716b376b9a", size = 3062145, upload-time = "2026-04-23T14:02:16.517Z" },
+    { url = "https://files.pythonhosted.org/packages/57/6f/2a065d61ed333e46a704f6592b33a88ffd0848b2efa99b039c8e427b21a3/aic_sdk-2.0.1-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:06aa50a7f014c8b06387cdea6fb37c53c9697490eab98959039aeccc8d51e360", size = 4892089, upload-time = "2026-01-23T23:36:41.249Z" },
+    { url = "https://files.pythonhosted.org/packages/de/f7/cd0c82cec01a94d7e121d411780f43cb8e6611bd797a10c02fd02c858f49/aic_sdk-2.0.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:1f1ade29783354f09f270ce38649dd6aed57c237c1b090b2ddc0fb61bc651d47", size = 4449813, upload-time = "2026-01-23T23:36:43.845Z" },
+    { url = "https://files.pythonhosted.org/packages/44/16/d90d39716cf487f0a41fd5bd01670884f9d0901902d6616595ad3ea17464/aic_sdk-2.0.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:17040ea4d6a686429a214a5673c362890ad10cefb265b6f878a240763e6f39ef", size = 3594996, upload-time = "2026-01-23T23:36:46.334Z" },
+    { url = "https://files.pythonhosted.org/packages/21/5d/8852484f85fa60a8ec2e696f6de8363301cd6100b2e5a68289ccc36d02ca/aic_sdk-2.0.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f13f9b2211136dd6f46fa2f148a55aabf5b9c3cb40fc0beed9e435b0df60d34c", size = 4111589, upload-time = "2026-01-23T23:36:50.448Z" },
+    { url = "https://files.pythonhosted.org/packages/71/ca/22c99be2aca92f77d4f0fe742827cd2db5f0c761797ebe0e5bd43872259a/aic_sdk-2.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:f4c3556bad0b74f2c0a5c2a253f14ca58b7129ce5b17848b8b0948f68286639d", size = 3663706, upload-time = "2026-01-23T23:36:54.581Z" },
+    { url = "https://files.pythonhosted.org/packages/19/fc/fbd7ee793cf15ef3319d12399ee9300c21c09acf654e1d8d1f64f682d750/aic_sdk-2.0.1-cp311-cp311-win_arm64.whl", hash = "sha256:11de01064d028adeb2d2edda4546e86002d5b43710fcdc00a33ee2403a1676d4", size = 3274994, upload-time = "2026-01-23T23:36:58.177Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/04/07ed2ae4b4dc9f31522fa971791fd7d7e38feac8ce2b9d3316394b2e5fe5/aic_sdk-2.0.1-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:f48dde209a704a51e65a44c7846c033dc860003467cef0fc2d15d7f8aa137dbc", size = 4893276, upload-time = "2026-01-23T23:37:03.097Z" },
+    { url = "https://files.pythonhosted.org/packages/58/87/6328bcf58e633acdf65fd72c4dee61f468fef399c0868e5c446b99166bf5/aic_sdk-2.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:2017ea843fc9e38612a13f1b0a668428a3f6862792baf230ac79a65d9c0633d9", size = 4450341, upload-time = "2026-01-23T23:37:08.648Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/59/da5138346944ac7dc61ed70e66c1fb2fddef815dc2bab561316db5aef252/aic_sdk-2.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:065954c17116b96408ebfbff29152ca458bb083a9e56178c70adbafdda08218a", size = 3594974, upload-time = "2026-01-23T23:37:13.83Z" },
+    { url = "https://files.pythonhosted.org/packages/06/d8/17e1a77820a6848efb7c97751bc6022f65c5ca6436dc3caf3a9da356def1/aic_sdk-2.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fa7a196160d6eaf2b856c542bc967c2e08e11a5d93ac4e632f843a01b2872274", size = 4113591, upload-time = "2026-01-23T23:37:19.067Z" },
+    { url = "https://files.pythonhosted.org/packages/38/3b/04b70a75364c2ef1717018a81963a8e16bffc3f9f064f125cb111870b6a4/aic_sdk-2.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:dbd007a683ebff4def95fa5a7ace1602aa2d150fa80761231b044edd57e98bbb", size = 3661883, upload-time = "2026-01-23T23:37:25.242Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/bd/64bc3ce090cc110f3721c5e54f97f9fcb67dc50bd8dc6408896650d1d68e/aic_sdk-2.0.1-cp312-cp312-win_arm64.whl", hash = "sha256:f776c5f0425b39073d4caca2f0bdea036647c4162d4673ef498e1306d41bb39e", size = 3271232, upload-time = "2026-01-23T23:37:30.005Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/72/8445a7201aa5969216b5d4ab60bb2ebefa2ac07f557e9ebca27172be2f00/aic_sdk-2.0.1-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:a7ff35422ffb813e8a5b4afed6eb56d4e8abc1ecabf464084d4c7b5b8aff0e43", size = 4892624, upload-time = "2026-01-23T23:37:33.229Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/9c/5b060cbd9e9bcea5e62df13cf3e722f4355286e2174c298ffcfe337c680d/aic_sdk-2.0.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:6cda0b6db664712099da483f803128e4e5256625aed2d85e65e5cc823a0e873b", size = 4449490, upload-time = "2026-01-23T23:37:35.938Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/f8/ac61d007dc8d158a8f516327db74b6f3b1cf78b16be43acd29775197533d/aic_sdk-2.0.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7ade8754bd878da0509e70636a9b4eaba0280741db5afabf752102ef605ffaac", size = 3594360, upload-time = "2026-01-23T23:37:38.943Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/c4/af0c00055450b060b23e8dd5f3c1a208ea1444c6b497eaf29d3de6e215fa/aic_sdk-2.0.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9b2f44c660aa29613be05c576da25092b3570c8fb3dddc09b70625789d066202", size = 4112325, upload-time = "2026-01-23T23:37:41.613Z" },
+    { url = "https://files.pythonhosted.org/packages/86/8e/62a7c53cc1bf2345ea20b554d1d8a61058301cd8088ff94ba95809b04a02/aic_sdk-2.0.1-cp313-cp313-win_amd64.whl", hash = "sha256:ce1656991fc4dbbb40257c72a4b8fc4d4839363ca4b7b25a84ae5a83914ae90c", size = 3661441, upload-time = "2026-01-23T23:37:45.025Z" },
+    { url = "https://files.pythonhosted.org/packages/39/98/aa9d6ccba0a1902f8480544fcf468dd3696ecb5392f02c2770f9020e6f9a/aic_sdk-2.0.1-cp313-cp313-win_arm64.whl", hash = "sha256:0138e964feb15d9fb5d2c9c64a8d45a807171900f53351e5525c26869237bd1c", size = 3270753, upload-time = "2026-01-23T23:37:47.882Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/3e/6a693ba223e2e55e142983c6243968222070405c6a90ec4c5a61b46652c1/aic_sdk-2.0.1-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:11eb0c3686ff83f340c875b864840fad19e3a98cd6e59815f83e9248a3ffb397", size = 4893527, upload-time = "2026-01-23T23:37:52.021Z" },
+    { url = "https://files.pythonhosted.org/packages/35/9c/f149870d75f28c851de439d4039f85aa590f47499272f932841e4dc0a9a5/aic_sdk-2.0.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:27844521dc1ae3e1226e7371ec3e68fc4726515f14c5e82a6030f276b612c1a8", size = 4450169, upload-time = "2026-01-23T23:37:55.964Z" },
+    { url = "https://files.pythonhosted.org/packages/92/87/8ee4e1763b603ad3d6d535d7ecfa7a2943145bcc18f2db4600279aa37af3/aic_sdk-2.0.1-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:adf617d4e4e8910764118d1baf1521c752218fd304c75d7e22352d4755cabd50", size = 3595300, upload-time = "2026-01-23T23:37:59.494Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/b4/06d6f5c1b45d839d4d8ad4fbcb45dc224e980c69976c48e39d5e32850c51/aic_sdk-2.0.1-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0e2bc9071599b9703783b6b100758cd7621b30a64abddc8072f6872932b74c21", size = 4113837, upload-time = "2026-01-23T23:38:03.565Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/35/d7a2f7b37183b08b2e8969c3d6c6d1824253cd32894d72f250075edee654/aic_sdk-2.0.1-cp314-cp314-win_amd64.whl", hash = "sha256:9db2bfb4f1ab40a4b130d8d0e158277461b25c7b78bffffba90f816766cb28e9", size = 3663055, upload-time = "2026-01-23T23:38:07.741Z" },
+    { url = "https://files.pythonhosted.org/packages/90/97/9ed859e70b1d0c68edc9748c4e69d251e89a3faa462f36ce26c1f8aa7844/aic_sdk-2.0.1-cp314-cp314-win_arm64.whl", hash = "sha256:3c6ed1bfda589970e6c6b96ae29f112baa430ad91e149e76004825870198a5c7", size = 3272737, upload-time = "2026-01-23T23:38:13.966Z" },
 ]
 
 [[package]]
@@ -529,6 +538,27 @@ wheels = [
 ]
 
 [[package]]
+name = "cartesia"
+version = "2.0.17"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "audioop-lts", marker = "python_full_version >= '3.13' and python_full_version < '4'" },
+    { name = "httpx" },
+    { name = "httpx-sse" },
+    { name = "iterators" },
+    { name = "pydantic" },
+    { name = "pydantic-core" },
+    { name = "pydub" },
+    { name = "typing-extensions" },
+    { name = "websockets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fa/ff/bfd3191a7fdbbb5c4dfe4d34461c6aa0d158a6eea599cb9a5df2c91109fa/cartesia-2.0.17.tar.gz", hash = "sha256:fd7fcdcbb5aac47ff6b35cd48420b4993ef1742aaa71bb7d52b335314045d584", size = 79227, upload-time = "2025-11-13T21:06:45.332Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/52/9c/f7b83329e0567d0ab165abd81405108d146abc9728732c1af3858ee38bfd/cartesia-2.0.17-py3-none-any.whl", hash = "sha256:de8975ced1c5c09f1b51bb87ceea6c1641ba817901cfc73c47fc4e37c6ca351a", size = 153376, upload-time = "2025-11-13T21:06:42.872Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.1.4"
 source = { registry = "https://pypi.org/simple" }
@@ -691,10 +721,10 @@ dependencies = [
     { name = "boto3" },
     { name = "cryptography" },
     { name = "fastapi" },
+    { name = "google-api-python-client" },
     { name = "google-auth" },
     { name = "google-cloud-storage", version = "3.4.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
     { name = "google-cloud-storage", version = "3.9.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "h2" },
     { name = "jmespath" },
     { name = "langfuse" },
     { name = "loguru" },
@@ -702,7 +732,7 @@ dependencies = [
     { name = "opentelemetry-api" },
     { name = "opentelemetry-exporter-otlp-proto-http" },
     { name = "opentelemetry-sdk" },
-    { name = "pipecat-ai", extra = ["aic", "anthropic", "assemblyai", "azure", "cartesia", "daily", "deepgram", "elevenlabs", "google", "mcp", "openai", "sarvam", "soniox"] },
+    { name = "pipecat-ai", extra = ["aic", "anthropic", "assemblyai", "azure", "cartesia", "daily", "deepgram", "elevenlabs", "google", "mcp", "openai", "sarvam", "silero", "soniox"] },
     { name = "pipecat-ai-flows" },
     { name = "plivo" },
     { name = "pydub" },
@@ -724,13 +754,6 @@ dev = [
     { name = "black" },
     { name = "isort" },
     { name = "pyrefly" },
-    { name = "pytest" },
-    { name = "pytest-asyncio" },
-]
-
-[package.dev-dependencies]
-dev = [
-    { name = "pytest" },
 ]
 
 [package.metadata]
@@ -743,9 +766,9 @@ requires-dist = [
     { name = "boto3" },
     { name = "cryptography", specifier = ">=44.0.1" },
     { name = "fastapi", specifier = "==0.115.12" },
+    { name = "google-api-python-client", specifier = ">=2.197.0" },
     { name = "google-auth", specifier = ">=2.17.0" },
     { name = "google-cloud-storage", specifier = ">=2.10.0" },
-    { name = "h2", specifier = ">=4.3.0" },
     { name = "isort", marker = "extra == 'dev'" },
     { name = "jmespath", specifier = ">=1.1.0" },
     { name = "langfuse" },
@@ -754,14 +777,12 @@ requires-dist = [
     { name = "opentelemetry-api" },
     { name = "opentelemetry-exporter-otlp-proto-http" },
     { name = "opentelemetry-sdk" },
-    { name = "pipecat-ai", extras = ["daily", "google", "assemblyai", "silero", "openai", "azure", "elevenlabs", "aic", "anthropic", "deepgram", "soniox", "mcp", "sarvam", "cartesia"], specifier = "==1.1.0" },
-    { name = "pipecat-ai-flows", specifier = "==1.0.0" },
+    { name = "pipecat-ai", extras = ["daily", "google", "assemblyai", "silero", "openai", "azure", "elevenlabs", "aic", "anthropic", "deepgram", "soniox", "mcp", "sarvam", "cartesia"] },
+    { name = "pipecat-ai-flows" },
     { name = "plivo" },
     { name = "pydub" },
     { name = "pyjwt" },
     { name = "pyrefly", marker = "extra == 'dev'" },
-    { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
-    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=1.3.0" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
     { name = "python-multipart", specifier = ">=0.0.6" },
     { name = "pytz", specifier = "==2025.2" },
@@ -773,9 +794,6 @@ requires-dist = [
     { name = "websockets", specifier = ">=11.0.3" },
 ]
 provides-extras = ["dev"]
-
-[package.metadata.requires-dev]
-dev = [{ name = "pytest", specifier = ">=9.0.3" }]
 
 [[package]]
 name = "click"
@@ -796,6 +814,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "coloredlogs"
+version = "15.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "humanfriendly" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cc/c7/eed8f27100517e8c0e6b923d5f0845d0cb99763da6fdee00478f91db7325/coloredlogs-15.0.1.tar.gz", hash = "sha256:7c991aa71a4577af2f82600d8f8f3a89f936baeaf9b50a9c197da014e5bf16b0", size = 278520, upload-time = "2021-06-11T10:22:45.202Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/06/3d6badcf13db419e25b07041d9c7b4a2c331d3f4e7134445ec5df57714cd/coloredlogs-15.0.1-py2.py3-none-any.whl", hash = "sha256:612ee75c546f53e92e70049c9dbfcc18c935a2b9a53b66085ce9ef6a6e5c0934", size = 46018, upload-time = "2021-06-11T10:22:42.561Z" },
 ]
 
 [[package]]
@@ -859,13 +889,26 @@ wheels = [
 
 [[package]]
 name = "daily-python"
-version = "0.28.0"
+version = "0.23.0"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7c/4b/6420ec1f4626e3366c110d6d718ad25f6cc10faa9b0406e7799fd6176449/daily_python-0.28.0-cp37-abi3-macosx_10_15_x86_64.whl", hash = "sha256:0d10e03b8b5182da7c44c9f2873f264c6714322f7bd85dacb74f07bdfb4a047e", size = 13355739, upload-time = "2026-04-27T19:07:29.379Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/1a/9b4f9806af2ce2ac336af3df776aa49646027083b874bee1cc912343b7db/daily_python-0.28.0-cp37-abi3-macosx_11_0_arm64.whl", hash = "sha256:37f65c5e7fcafaae2f74f71a92167567c3cc1026ad773465d771d72699a535d5", size = 11886919, upload-time = "2026-04-27T19:07:31.845Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/61/fb60c5fefc72cad76c4afa7364eb05cfc2685a5c87b55ced9f48a935eb3d/daily_python-0.28.0-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:a0752e149bd8ec06bcb572b2324473eb45391be380a393d88ac649c133cc6de8", size = 13953001, upload-time = "2026-04-27T19:07:34.122Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/ef/56a6b1bfd2c489fc0f69b5e4c25e7bb0a88e9c3d42dfb1a9f5d3977924b3/daily_python-0.28.0-cp37-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:37886713f8d5fc05f0c542f4a38db84e0957e6bdc8f08d77de067b128b1b71c0", size = 14477317, upload-time = "2026-04-27T19:07:35.929Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/3b/0f1465833787db21933caf9db0c4e45d10a31f477c2ae08ebe3edf31764d/daily_python-0.23.0-cp37-abi3-macosx_10_15_x86_64.whl", hash = "sha256:74998c9aabeccf8306def27219eb943df5a268f26ba7e25e0a105ced9425591a", size = 13450473, upload-time = "2025-12-18T03:21:50.488Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/ca/7a9b581d411101454855c21559b1c9d9d58b6c527480548bba03e00a5641/daily_python-0.23.0-cp37-abi3-macosx_11_0_arm64.whl", hash = "sha256:ce80746f5cba434371a9cb9995d8c4ec19d1490bd993b7dfd35356d81bd68425", size = 11988100, upload-time = "2025-12-18T03:21:53.265Z" },
+    { url = "https://files.pythonhosted.org/packages/40/eb/15303b6ae2cdc5c591d6629d162085037697ca519d57751408c66f775991/daily_python-0.23.0-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:21a59b1730ae047f2335b9fdcf8ebb9fe05c3768dc4239ec955461f3f78476b0", size = 14094021, upload-time = "2025-12-18T03:21:55.606Z" },
+    { url = "https://files.pythonhosted.org/packages/65/b9/f063e4854ba6e4edeea46e082720b7af82fb3cbf27e60efce63dbe34fe6d/daily_python-0.23.0-cp37-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:00b22041ef85556cc06262f9b8e39b686bdf37d50219d07542d7a2f9c3d413d4", size = 14616886, upload-time = "2025-12-18T03:21:58.084Z" },
+]
+
+[[package]]
+name = "dataclasses-json"
+version = "0.6.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "marshmallow" },
+    { name = "typing-inspect" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/64/a4/f71d9cf3a5ac257c993b5ca3f93df5f7fb395c725e7f1e6479d2514173c3/dataclasses_json-0.6.7.tar.gz", hash = "sha256:b6b3e528266ea45b9535223bc53ca645f5208833c29229e847b3f26a1cc55fc0", size = 32227, upload-time = "2024-06-09T16:20:19.103Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c3/be/d0d44e092656fe7a06b55e6103cbce807cdbdee17884a5367c68c9860853/dataclasses_json-0.6.7-py3-none-any.whl", hash = "sha256:0dbf33f26c8d5305befd61b39d2b3414e8a407bedc2834dea9b8d642666fb40a", size = 28686, upload-time = "2024-06-09T16:20:16.715Z" },
 ]
 
 [[package]]
@@ -879,18 +922,33 @@ wheels = [
 
 [[package]]
 name = "deepgram-sdk"
-version = "6.1.1"
+version = "4.7.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "aenum" },
+    { name = "aiofiles" },
+    { name = "aiohttp" },
+    { name = "dataclasses-json" },
+    { name = "deprecation" },
     { name = "httpx" },
-    { name = "pydantic" },
-    { name = "pydantic-core" },
     { name = "typing-extensions" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/29/91/85360d998685fee6b570e12250e5ac74ca43420d5d22b44a865b6c3f2469/deepgram_sdk-6.1.1.tar.gz", hash = "sha256:78726f42b2386f80d9fdd92a22ac59ad5558b6c0475b29bb57273ddaaa344794", size = 202224, upload-time = "2026-03-27T19:59:57.202Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/17/c7/3c5918c2c74e3d56cf3d738aa174bc688c73069dc9682fc1bfaeb2058cc6/deepgram_sdk-4.7.0.tar.gz", hash = "sha256:e371396d8835d449782df472c3bd501f6cad41b3c925f66771933ff3fc4b1a13", size = 100128, upload-time = "2025-07-21T15:43:56.705Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6f/7f/818ac35b40e38f225858cea38808c7fdd57292553479cabf0bebf7fcdc91/deepgram_sdk-6.1.1-py3-none-any.whl", hash = "sha256:329f45f2a084e8786d3e90d4a4aee630b85cf8770a3b2ee6323bedb176c47113", size = 576299, upload-time = "2026-03-27T19:59:55.949Z" },
+    { url = "https://files.pythonhosted.org/packages/33/63/43a6e46b35eae9739e22b5cace4a22ece76d4aff74b563563b9507411484/deepgram_sdk-4.7.0-py3-none-any.whl", hash = "sha256:1a2a0890aa43cbc510e07b0f911f6841770ca0222e6fcc069bd3e2afcde1c061", size = 157911, upload-time = "2025-07-21T15:43:55.695Z" },
+]
+
+[[package]]
+name = "deprecation"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5a/d3/8ae2869247df154b64c1884d7346d412fed0c49df84db635aab2d1c40e62/deprecation-2.1.0.tar.gz", hash = "sha256:72b3bde64e5d778694b0cf68178aed03d15e15477116add3fb773e581f9518ff", size = 173788, upload-time = "2020-04-20T14:23:38.738Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/c3/253a89ee03fc9b9682f1541728eb66db7db22148cd94f89ab22528cd1e1b/deprecation-2.1.0-py2.py3-none-any.whl", hash = "sha256:a10811591210e1fb0e768a8c25517cabeabcba6f0bf96564f8ff45189f90b14a", size = 11178, upload-time = "2020-04-20T14:23:36.581Z" },
 ]
 
 [[package]]
@@ -1057,6 +1115,15 @@ wheels = [
 ]
 
 [[package]]
+name = "future"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a7/b2/4140c69c6a66432916b26158687e821ba631a4c9273c474343badf84d3ba/future-1.0.0.tar.gz", hash = "sha256:bd2968309307861edae1458a4f8a4f3598c03be43b97521076aebf5d94c07b05", size = 1228490, upload-time = "2024-02-21T11:52:38.461Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/71/ae30dadffc90b9006d77af76b393cb9dfbfc9629f339fc1574a1c52e6806/future-1.0.0-py3-none-any.whl", hash = "sha256:929292d34f5872e70396626ef385ec22355a1fae8ad29e1a734c3e43f9fbc216", size = 491326, upload-time = "2024-02-21T11:52:35.956Z" },
+]
+
+[[package]]
 name = "google-api-core"
 version = "2.25.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1109,21 +1176,52 @@ grpc = [
 ]
 
 [[package]]
+name = "google-api-python-client"
+version = "2.197.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-api-core", version = "2.25.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "google-api-core", version = "2.29.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
+    { name = "google-auth" },
+    { name = "google-auth-httplib2" },
+    { name = "httplib2" },
+    { name = "uritemplate" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/22/09/081d66357118bd260f8f182cb1b2dd5bd32ca88e3714d7c93896cab946fc/google_api_python_client-2.197.0.tar.gz", hash = "sha256:32e03977eda4a66eafc6ae58dc9ec46426b6025636d5ef019c5703013eddd4e5", size = 14707398, upload-time = "2026-05-28T20:23:12.498Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/e5/e9cc221fd75230974d4ef45eb72d2261feca3c110d5554215d516bfe6534/google_api_python_client-2.197.0-py3-none-any.whl", hash = "sha256:0f8b89aa75768161dd4f5092d6bcb386c13236b32e0d9a938c02f71342094d14", size = 15287302, upload-time = "2026-05-28T20:23:09.683Z" },
+]
+
+[[package]]
 name = "google-auth"
-version = "2.49.2"
+version = "2.48.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
     { name = "pyasn1-modules" },
+    { name = "rsa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c6/fc/e925290a1ad95c975c459e2df070fac2b90954e13a0370ac505dff78cb99/google_auth-2.49.2.tar.gz", hash = "sha256:c1ae38500e73065dcae57355adb6278cf8b5c8e391994ae9cbadbcb9631ab409", size = 333958, upload-time = "2026-04-10T00:41:21.888Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0c/41/242044323fbd746615884b1c16639749e73665b718209946ebad7ba8a813/google_auth-2.48.0.tar.gz", hash = "sha256:4f7e706b0cd3208a3d940a19a822c37a476ddba5450156c3e6624a71f7c841ce", size = 326522, upload-time = "2026-01-26T19:22:47.157Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/73/76/d241a5c927433420507215df6cac1b1fa4ac0ba7a794df42a84326c68da8/google_auth-2.49.2-py3-none-any.whl", hash = "sha256:c2720924dfc82dedb962c9f52cabb2ab16714fd0a6a707e40561d217574ed6d5", size = 240638, upload-time = "2026-04-10T00:41:14.501Z" },
+    { url = "https://files.pythonhosted.org/packages/83/1d/d6466de3a5249d35e832a52834115ca9d1d0de6abc22065f049707516d47/google_auth-2.48.0-py3-none-any.whl", hash = "sha256:2e2a537873d449434252a9632c28bfc268b0adb1e53f9fb62afc5333a975903f", size = 236499, upload-time = "2026-01-26T19:22:45.099Z" },
 ]
 
 [package.optional-dependencies]
 requests = [
     { name = "requests" },
+]
+
+[[package]]
+name = "google-auth-httplib2"
+version = "0.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-auth" },
+    { name = "httplib2" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1c/b3/f192c8bc7e41e0ebdbd95afcae4783417a34b6a6af62d22daf22c3fd38fc/google_auth_httplib2-0.4.0.tar.gz", hash = "sha256:d5b030a204b7a4b4d553ba9ca701b62481ee2b74419325580be70f7d85ffed35", size = 11161, upload-time = "2026-05-07T08:03:46.878Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/97/be/954c35a62b9e31de66b0a43c225c9b6bb9e0f98d6b1dc110a2308e3644f5/google_auth_httplib2-0.4.0-py3-none-any.whl", hash = "sha256:8e55cfafa3358cba85f6cad4a886138e88e158d71e7e5c9ee5936a5c1507fb91", size = 9529, upload-time = "2026-05-07T08:02:12.375Z" },
 ]
 
 [[package]]
@@ -1248,7 +1346,7 @@ wheels = [
 
 [[package]]
 name = "google-genai"
-version = "1.73.1"
+version = "1.63.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -1262,9 +1360,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3d/d8/40f5f107e5a2976bbac52d421f04d14fc221b55a8f05e66be44b2f739fe6/google_genai-1.73.1.tar.gz", hash = "sha256:b637e3a3b9e2eccc46f27136d470165803de84eca52abfed2e7352081a4d5a15", size = 530998, upload-time = "2026-04-14T21:06:19.153Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/46/d7/07ec5dadd0741f09e89f3ff5f0ce051ce2aa3a76797699d661dc88def077/google_genai-1.63.0.tar.gz", hash = "sha256:dc76cab810932df33cbec6c7ef3ce1538db5bef27aaf78df62ac38666c476294", size = 491970, upload-time = "2026-02-11T23:46:28.472Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/65/af/508e0528015240d710c6763f7c89ff44fab9a94a80b4377e265d692cbfd6/google_genai-1.73.1-py3-none-any.whl", hash = "sha256:af2d2287d25e42a187de19811ef33beb2e347c7e2bdb4dc8c467d78254e43a2c", size = 783595, upload-time = "2026-04-14T21:06:17.464Z" },
+    { url = "https://files.pythonhosted.org/packages/82/c8/ba32159e553fab787708c612cf0c3a899dafe7aca81115d841766e3bfe69/google_genai-1.63.0-py3-none-any.whl", hash = "sha256:6206c13fc20f332703ca7375bea7c191c82f95d6781c29936c6982d86599b359", size = 724747, upload-time = "2026-02-11T23:46:26.697Z" },
 ]
 
 [[package]]
@@ -1363,19 +1461,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
-]
-
-[[package]]
-name = "h2"
-version = "4.3.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "hpack" },
-    { name = "hyperframe" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/1d/17/afa56379f94ad0fe8defd37d6eb3f89a25404ffc71d4d848893d270325fc/h2-4.3.0.tar.gz", hash = "sha256:6c59efe4323fa18b47a632221a1888bd7fde6249819beda254aeca909f221bf1", size = 2152026, upload-time = "2025-08-23T18:12:19.778Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/69/b2/119f6e6dcbd96f9069ce9a2665e0146588dc9f88f29549711853645e736a/h2-4.3.0-py3-none-any.whl", hash = "sha256:c438f029a25f7945c69e0ccf0fb951dc3f73a5f6412981daee861431b70e2bdd", size = 61779, upload-time = "2025-08-23T18:12:17.779Z" },
 ]
 
 [[package]]
@@ -1481,15 +1566,6 @@ wheels = [
 ]
 
 [[package]]
-name = "hpack"
-version = "4.1.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/2c/48/71de9ed269fdae9c8057e5a4c0aa7402e8bb16f2c6e90b3aa53327b113f8/hpack-4.1.0.tar.gz", hash = "sha256:ec5eca154f7056aa06f196a557655c5b009b382873ac8d1e66e79e87535f1dca", size = 51276, upload-time = "2025-01-22T21:44:58.347Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/07/c6/80c95b1b2b94682a72cbdbfb85b81ae2daffa4291fbfa1b1464502ede10d/hpack-4.1.0-py3-none-any.whl", hash = "sha256:157ac792668d995c657d93111f46b4535ed114f0c9c8d672271bbec7eae1b496", size = 34357, upload-time = "2025-01-22T21:44:56.92Z" },
-]
-
-[[package]]
 name = "httpcore"
 version = "1.0.9"
 source = { registry = "https://pypi.org/simple" }
@@ -1500,6 +1576,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httplib2"
+version = "0.31.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyparsing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c1/1f/e86365613582c027dda5ddb64e1010e57a3d53e99ab8a72093fa13d565ec/httplib2-0.31.2.tar.gz", hash = "sha256:385e0869d7397484f4eab426197a4c020b606edd43372492337c0b4010ae5d24", size = 250800, upload-time = "2026-01-23T11:04:44.165Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2f/90/fd509079dfcab01102c0fdd87f3a9506894bc70afcf9e9785ef6b2b3aff6/httplib2-0.31.2-py3-none-any.whl", hash = "sha256:dbf0c2fa3862acf3c55c078ea9c0bc4481d7dc5117cae71be9514912cf9f8349", size = 91099, upload-time = "2026-01-23T11:04:42.78Z" },
 ]
 
 [[package]]
@@ -1548,12 +1636,15 @@ wheels = [
 ]
 
 [[package]]
-name = "hyperframe"
-version = "6.1.0"
+name = "humanfriendly"
+version = "10.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/02/e7/94f8232d4a74cc99514c13a9f995811485a6903d48e5d952771ef6322e30/hyperframe-6.1.0.tar.gz", hash = "sha256:f630908a00854a7adeabd6382b43923a4c4cd4b821fcb527e6ab9e15382a3b08", size = 26566, upload-time = "2025-01-22T21:41:49.302Z" }
+dependencies = [
+    { name = "pyreadline3", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cc/3f/2c29224acb2e2df4d2046e4c73ee2662023c58ff5b113c4c1adac0886c43/humanfriendly-10.0.tar.gz", hash = "sha256:6b0b831ce8f15f7300721aa49829fc4e83921a9a301cc7f606be6686a2288ddc", size = 360702, upload-time = "2021-09-17T21:40:43.31Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/48/30/47d0bf6072f7252e6521f3447ccfa40b421b6824517f82854703d0f5a98b/hyperframe-6.1.0-py3-none-any.whl", hash = "sha256:b03380493a519fce58ea5af42e4a42317bf9bd425596f7a0835ffce80f1a42e5", size = 13007, upload-time = "2025-01-22T21:41:47.295Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/0f/310fb31e39e2d734ccaa2c0fb981ee41f7bd5056ce9bc29b2248bd569169/humanfriendly-10.0-py2.py3-none-any.whl", hash = "sha256:1697e1a8a8f550fd43c2865cd84542fc175a61dcb779b6fee18cf6b6ccba1477", size = 86794, upload-time = "2021-09-17T21:40:39.897Z" },
 ]
 
 [[package]]
@@ -1578,21 +1669,21 @@ wheels = [
 ]
 
 [[package]]
-name = "iniconfig"
-version = "2.3.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
-]
-
-[[package]]
 name = "isort"
 version = "7.0.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/63/53/4f3c058e3bace40282876f9b553343376ee687f3c35a525dc79dbd450f88/isort-7.0.0.tar.gz", hash = "sha256:5513527951aadb3ac4292a41a16cbc50dd1642432f5e8c20057d414bdafb4187", size = 805049, upload-time = "2025-10-11T13:30:59.107Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7f/ed/e3705d6d02b4f7aea715a353c8ce193efd0b5db13e204df895d38734c244/isort-7.0.0-py3-none-any.whl", hash = "sha256:1bcabac8bc3c36c7fb7b98a76c8abb18e0f841a3ba81decac7691008592499c1", size = 94672, upload-time = "2025-10-11T13:30:57.665Z" },
+]
+
+[[package]]
+name = "iterators"
+version = "0.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/02/c4/135b5bdb9f14f728fe1274361b336f77c5f1606af9a5622a765fe75f5fa0/iterators-0.2.0.tar.gz", hash = "sha256:e9927a1ea1ef081830fd1512f3916857c36bd4b37272819a6cd29d0f44431b97", size = 4284, upload-time = "2023-01-23T16:07:02.46Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bd/a1/9c29772ac9f3bdf9837c92ba5c1fc93f75da14c2e0c3fc41e10485f68feb/iterators-0.2.0-py3-none-any.whl", hash = "sha256:1d7ff03f576c9de0e01bac66209556c066d6b1fc45583a99cfc9f4645be7900e", size = 5022, upload-time = "2023-01-23T16:07:00.352Z" },
 ]
 
 [[package]]
@@ -1906,6 +1997,18 @@ wheels = [
 ]
 
 [[package]]
+name = "marshmallow"
+version = "3.26.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/79/de6c16cc902f4fc372236926b0ce2ab7845268dcc30fb2fbb7f71b418631/marshmallow-3.26.2.tar.gz", hash = "sha256:bbe2adb5a03e6e3571b573f42527c6fe926e17467833660bebd11593ab8dfd57", size = 222095, upload-time = "2025-12-22T06:53:53.309Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/be/2f/5108cb3ee4ba6501748c4908b908e55f42a5b66245b4cfe0c99326e1ef6e/marshmallow-3.26.2-py3-none-any.whl", hash = "sha256:013fa8a3c4c276c24d26d84ce934dc964e2aa794345a0f8c7e5a7191482c8a73", size = 50964, upload-time = "2025-12-22T06:53:51.801Z" },
+]
+
+[[package]]
 name = "mcp"
 version = "1.26.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2082,7 +2185,7 @@ wheels = [
 
 [[package]]
 name = "nltk"
-version = "3.9.4"
+version = "3.9.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
@@ -2090,9 +2193,9 @@ dependencies = [
     { name = "regex" },
     { name = "tqdm" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/74/a1/b3b4adf15585a5bc4c357adde150c01ebeeb642173ded4d871e89468767c/nltk-3.9.4.tar.gz", hash = "sha256:ed03bc098a40481310320808b2db712d95d13ca65b27372f8a403949c8b523d0", size = 2946864, upload-time = "2026-03-24T06:13:40.641Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/76/3a5e4312c19a028770f86fd7c058cf9f4ec4321c6cf7526bab998a5b683c/nltk-3.9.2.tar.gz", hash = "sha256:0f409e9b069ca4177c1903c3e843eef90c7e92992fa4931ae607da6de49e1419", size = 2887629, upload-time = "2025-10-01T07:19:23.764Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9d/91/04e965f8e717ba0ab4bdca5c112deeab11c9e750d94c4d4602f050295d39/nltk-3.9.4-py3-none-any.whl", hash = "sha256:f2fa301c3a12718ce4a0e9305c5675299da5ad9e26068218b69d692fda84828f", size = 1552087, upload-time = "2026-03-24T06:13:38.47Z" },
+    { url = "https://files.pythonhosted.org/packages/60/90/81ac364ef94209c100e12579629dc92bf7a709a84af32f8c551b02c07e94/nltk-3.9.2-py3-none-any.whl", hash = "sha256:1e209d2b3009110635ed9709a67a1a3e33a10f799490fa71cf4bec218c11c88a", size = 1513404, upload-time = "2025-10-01T07:19:21.648Z" },
 ]
 
 [[package]]
@@ -2172,9 +2275,10 @@ wheels = [
 
 [[package]]
 name = "onnxruntime"
-version = "1.24.4"
+version = "1.23.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "coloredlogs" },
     { name = "flatbuffers" },
     { name = "numpy" },
     { name = "packaging" },
@@ -2182,30 +2286,23 @@ dependencies = [
     { name = "sympy" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/60/69/6c40720201012c6af9aa7d4ecdd620e521bd806dc6269d636fdd5c5aeebe/onnxruntime-1.24.4-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:0bdfce8e9a6497cec584aab407b71bf697dac5e1b7b7974adc50bf7533bdb3a2", size = 17332131, upload-time = "2026-03-17T22:05:49.005Z" },
-    { url = "https://files.pythonhosted.org/packages/38/e9/8c901c150ce0c368da38638f44152fb411059c0c7364b497c9e5c957321a/onnxruntime-1.24.4-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:046ff290045a387676941a02a8ae5c3ebec6b4f551ae228711968c4a69d8f6b7", size = 15152472, upload-time = "2026-03-17T22:03:26.176Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/b6/7a4df417cdd01e8f067a509e123ac8b31af450a719fa7ed81787dd6057ec/onnxruntime-1.24.4-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e54ad52e61d2d4618dcff8fa1480ac66b24ee2eab73331322db1049f11ccf330", size = 17222993, upload-time = "2026-03-17T22:04:34.485Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/59/8febe015f391aa1757fa5ba82c759ea4b6c14ef970132efb5e316665ba61/onnxruntime-1.24.4-cp311-cp311-win_amd64.whl", hash = "sha256:b43b63eb24a2bc8fc77a09be67587a570967a412cccb837b6245ccb546691153", size = 12594863, upload-time = "2026-03-17T22:05:38.749Z" },
-    { url = "https://files.pythonhosted.org/packages/32/84/4155fcd362e8873eb6ce305acfeeadacd9e0e59415adac474bea3d9281bb/onnxruntime-1.24.4-cp311-cp311-win_arm64.whl", hash = "sha256:e26478356dba25631fb3f20112e345f8e8bf62c499bb497e8a559f7d69cf7e7b", size = 12259895, upload-time = "2026-03-17T22:05:28.812Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/38/31db1b232b4ba960065a90c1506ad7a56995cd8482033184e97fadca17cc/onnxruntime-1.24.4-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:cad1c2b3f455c55678ab2a8caa51fb420c25e6e3cf10f4c23653cdabedc8de78", size = 17341875, upload-time = "2026-03-17T22:05:51.669Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/60/c4d1c8043eb42f8a9aa9e931c8c293d289c48ff463267130eca97d13357f/onnxruntime-1.24.4-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1a5c5a544b22f90859c88617ecb30e161ee3349fcc73878854f43d77f00558b5", size = 15172485, upload-time = "2026-03-17T22:03:32.182Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/ab/5b68110e0460d73fad814d5bd11c7b1ddcce5c37b10177eb264d6a36e331/onnxruntime-1.24.4-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0d640eb9f3782689b55cfa715094474cd5662f2f137be6a6f847a594b6e9705c", size = 17244912, upload-time = "2026-03-17T22:04:37.251Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/f4/6b89e297b93704345f0f3f8c62229bee323ef25682a3f9b4f89a39324950/onnxruntime-1.24.4-cp312-cp312-win_amd64.whl", hash = "sha256:535b29475ca42b593c45fbb2152fbf1cdf3f287315bf650e6a724a0a1d065cdb", size = 12596856, upload-time = "2026-03-17T22:05:41.224Z" },
-    { url = "https://files.pythonhosted.org/packages/43/06/8b8ec6e9e6a474fcd5d772453f627ad4549dfe3ab8c0bf70af5afcde551b/onnxruntime-1.24.4-cp312-cp312-win_arm64.whl", hash = "sha256:e6214096e14b7b52e3bee1903dc12dc7ca09cb65e26664668a4620cc5e6f9a90", size = 12270275, upload-time = "2026-03-17T22:05:31.132Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/f0/8a21ec0a97e40abb7d8da1e8b20fb9e1af509cc6d191f6faa75f73622fb2/onnxruntime-1.24.4-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:e99a48078baaefa2b50fe5836c319499f71f13f76ed32d0211f39109147a49e0", size = 17341922, upload-time = "2026-03-17T22:03:56.364Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/25/d7908de8e08cee9abfa15b8aa82349b79733ae5865162a3609c11598805d/onnxruntime-1.24.4-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dc4aaed1e5e1aaacf2343c838a30a7c3ade78f13eeb16817411f929d04040a13", size = 15172290, upload-time = "2026-03-17T22:03:37.124Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/72/105ec27a78c5aa0154a7c0cd8c41c19a97799c3b12fc30392928997e3be3/onnxruntime-1.24.4-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e30c972bc02e072911aabb6891453ec73795386c0af2b761b65444b8a4c4745f", size = 17244738, upload-time = "2026-03-17T22:04:40.625Z" },
-    { url = "https://files.pythonhosted.org/packages/05/fb/a592736d968c2f58e12de4d52088dda8e0e724b26ad5c0487263adb45875/onnxruntime-1.24.4-cp313-cp313-win_amd64.whl", hash = "sha256:3b6ba8b0181a3aa88edab00eb01424ffc06f42e71095a91186c2249415fcff93", size = 12597435, upload-time = "2026-03-17T22:05:43.826Z" },
-    { url = "https://files.pythonhosted.org/packages/ad/04/ae2479e9841b64bd2eb44f8a64756c62593f896514369a11243b1b86ca5c/onnxruntime-1.24.4-cp313-cp313-win_arm64.whl", hash = "sha256:71d6a5c1821d6e8586a024000ece458db8f2fc0ecd050435d45794827ce81e19", size = 12269852, upload-time = "2026-03-17T22:05:33.353Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/af/a479a536c4398ffaf49fbbe755f45d5b8726bdb4335ab31b537f3d7149b8/onnxruntime-1.24.4-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1700f559c8086d06b2a4d5de51e62cb4ff5e2631822f71a36db8c72383db71ee", size = 15176861, upload-time = "2026-03-17T22:03:40.143Z" },
-    { url = "https://files.pythonhosted.org/packages/be/13/19f5da70c346a76037da2c2851ecbf1266e61d7f0dcdb887c667210d4608/onnxruntime-1.24.4-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4c74e268dc808e61e63784d43f9ddcdaf50a776c2819e8bd1d1b11ef64bf7e36", size = 17247454, upload-time = "2026-03-17T22:04:46.643Z" },
-    { url = "https://files.pythonhosted.org/packages/89/db/b30dbbd6037847b205ab75d962bc349bf1e46d02a65b30d7047a6893ffd6/onnxruntime-1.24.4-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:fbff2a248940e3398ae78374c5a839e49a2f39079b488bc64439fa0ec327a3e4", size = 17343300, upload-time = "2026-03-17T22:03:59.223Z" },
-    { url = "https://files.pythonhosted.org/packages/61/88/1746c0e7959961475b84c776d35601a21d445f463c93b1433a409ec3e188/onnxruntime-1.24.4-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e2b7969e72d8cb53ffc88ab6d49dd5e75c1c663bda7be7eb0ece192f127343d1", size = 15175936, upload-time = "2026-03-17T22:03:43.671Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/ba/4699cde04a52cece66cbebc85bd8335a0d3b9ad485abc9a2e15946a1349d/onnxruntime-1.24.4-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:14ed1f197fab812b695a5eaddb536c635e58a2fbbe50a517c78f082cc6ce9177", size = 17246432, upload-time = "2026-03-17T22:04:49.58Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/60/4590910841bb28bd3b4b388a9efbedf4e2d2cca99ddf0c863642b4e87814/onnxruntime-1.24.4-cp314-cp314-win_amd64.whl", hash = "sha256:311e309f573bf3c12aa5723e23823077f83d5e412a18499d4485c7eb41040858", size = 12903276, upload-time = "2026-03-17T22:05:46.349Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/6f/60e2c0acea1e1ac09b3e794b5a19c166eebf91c0b860b3e6db8e74983fda/onnxruntime-1.24.4-cp314-cp314-win_arm64.whl", hash = "sha256:3f0b910e86b759a4732663ec61fd57ac42ee1b0066f68299de164220b660546d", size = 12594365, upload-time = "2026-03-17T22:05:35.795Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/68/0c05d10f8f6c40fe0912ebec0d5a33884aaa2af2053507e864dab0883208/onnxruntime-1.24.4-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:aa12ddc54c9c4594073abcaa265cd9681e95fb89dae982a6f508a794ca42e661", size = 15176889, upload-time = "2026-03-17T22:03:48.021Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/1d/1666dc64e78d8587d168fec4e3b7922b92eb286a2ddeebcf6acb55c7dc82/onnxruntime-1.24.4-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e1cc6a518255f012134bc791975a6294806be9a3b20c4a54cca25194c90cf731", size = 17247021, upload-time = "2026-03-17T22:04:52.377Z" },
+    { url = "https://files.pythonhosted.org/packages/44/be/467b00f09061572f022ffd17e49e49e5a7a789056bad95b54dfd3bee73ff/onnxruntime-1.23.2-cp311-cp311-macosx_13_0_arm64.whl", hash = "sha256:6f91d2c9b0965e86827a5ba01531d5b669770b01775b23199565d6c1f136616c", size = 17196113, upload-time = "2025-10-22T03:47:33.526Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/a8/3c23a8f75f93122d2b3410bfb74d06d0f8da4ac663185f91866b03f7da1b/onnxruntime-1.23.2-cp311-cp311-macosx_13_0_x86_64.whl", hash = "sha256:87d8b6eaf0fbeb6835a60a4265fde7a3b60157cf1b2764773ac47237b4d48612", size = 19153857, upload-time = "2025-10-22T03:46:37.578Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/d8/506eed9af03d86f8db4880a4c47cd0dffee973ef7e4f4cff9f1d4bcf7d22/onnxruntime-1.23.2-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bbfd2fca76c855317568c1b36a885ddea2272c13cb0e395002c402f2360429a6", size = 15220095, upload-time = "2025-10-22T03:46:24.769Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/80/113381ba832d5e777accedc6cb41d10f9eca82321ae31ebb6bcede530cea/onnxruntime-1.23.2-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:da44b99206e77734c5819aa2142c69e64f3b46edc3bd314f6a45a932defc0b3e", size = 17372080, upload-time = "2025-10-22T03:47:00.265Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/db/1b4a62e23183a0c3fe441782462c0ede9a2a65c6bbffb9582fab7c7a0d38/onnxruntime-1.23.2-cp311-cp311-win_amd64.whl", hash = "sha256:902c756d8b633ce0dedd889b7c08459433fbcf35e9c38d1c03ddc020f0648c6e", size = 13468349, upload-time = "2025-10-22T03:47:25.783Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/9e/f748cd64161213adeef83d0cb16cb8ace1e62fa501033acdd9f9341fff57/onnxruntime-1.23.2-cp312-cp312-macosx_13_0_arm64.whl", hash = "sha256:b8f029a6b98d3cf5be564d52802bb50a8489ab73409fa9db0bf583eabb7c2321", size = 17195929, upload-time = "2025-10-22T03:47:36.24Z" },
+    { url = "https://files.pythonhosted.org/packages/91/9d/a81aafd899b900101988ead7fb14974c8a58695338ab6a0f3d6b0100f30b/onnxruntime-1.23.2-cp312-cp312-macosx_13_0_x86_64.whl", hash = "sha256:218295a8acae83905f6f1aed8cacb8e3eb3bd7513a13fe4ba3b2664a19fc4a6b", size = 19157705, upload-time = "2025-10-22T03:46:40.415Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/35/4e40f2fba272a6698d62be2cd21ddc3675edfc1a4b9ddefcc4648f115315/onnxruntime-1.23.2-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:76ff670550dc23e58ea9bc53b5149b99a44e63b34b524f7b8547469aaa0dcb8c", size = 15226915, upload-time = "2025-10-22T03:46:27.773Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/88/9cc25d2bafe6bc0d4d3c1db3ade98196d5b355c0b273e6a5dc09c5d5d0d5/onnxruntime-1.23.2-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f9b4ae77f8e3c9bee50c27bc1beede83f786fe1d52e99ac85aa8d65a01e9b77", size = 17382649, upload-time = "2025-10-22T03:47:02.782Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/b4/569d298f9fc4d286c11c45e85d9ffa9e877af12ace98af8cab52396e8f46/onnxruntime-1.23.2-cp312-cp312-win_amd64.whl", hash = "sha256:25de5214923ce941a3523739d34a520aac30f21e631de53bba9174dc9c004435", size = 13470528, upload-time = "2025-10-22T03:47:28.106Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/41/fba0cabccecefe4a1b5fc8020c44febb334637f133acefc7ec492029dd2c/onnxruntime-1.23.2-cp313-cp313-macosx_13_0_arm64.whl", hash = "sha256:2ff531ad8496281b4297f32b83b01cdd719617e2351ffe0dba5684fb283afa1f", size = 17196337, upload-time = "2025-10-22T03:46:35.168Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/f9/2d49ca491c6a986acce9f1d1d5fc2099108958cc1710c28e89a032c9cfe9/onnxruntime-1.23.2-cp313-cp313-macosx_13_0_x86_64.whl", hash = "sha256:162f4ca894ec3de1a6fd53589e511e06ecdc3ff646849b62a9da7489dee9ce95", size = 19157691, upload-time = "2025-10-22T03:46:43.518Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/a1/428ee29c6eaf09a6f6be56f836213f104618fb35ac6cc586ff0f477263eb/onnxruntime-1.23.2-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:45d127d6e1e9b99d1ebeae9bcd8f98617a812f53f46699eafeb976275744826b", size = 15226898, upload-time = "2025-10-22T03:46:30.039Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/2b/b57c8a2466a3126dbe0a792f56ad7290949b02f47b86216cd47d857e4b77/onnxruntime-1.23.2-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8bace4e0d46480fbeeb7bbe1ffe1f080e6663a42d1086ff95c1551f2d39e7872", size = 17382518, upload-time = "2025-10-22T03:47:05.407Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/93/aba75358133b3a941d736816dd392f687e7eab77215a6e429879080b76b6/onnxruntime-1.23.2-cp313-cp313-win_amd64.whl", hash = "sha256:1f9cc0a55349c584f083c1c076e611a7c35d5b867d5d6e6d6c823bf821978088", size = 13470276, upload-time = "2025-10-22T03:47:31.193Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/3d/6830fa61c69ca8e905f237001dbfc01689a4e4ab06147020a4518318881f/onnxruntime-1.23.2-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9d2385e774f46ac38f02b3a91a91e30263d41b2f1f4f26ae34805b2a9ddef466", size = 15229610, upload-time = "2025-10-22T03:46:32.239Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/ca/862b1e7a639460f0ca25fd5b6135fb42cf9deea86d398a92e44dfda2279d/onnxruntime-1.23.2-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e2b9233c4947907fd1818d0e581c049c41ccc39b2856cc942ff6d26317cee145", size = 17394184, upload-time = "2025-10-22T03:47:08.127Z" },
 ]
 
 [[package]]
@@ -2413,7 +2510,7 @@ wheels = [
 
 [[package]]
 name = "pipecat-ai"
-version = "1.1.0"
+version = "0.0.102"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiofiles" },
@@ -2436,9 +2533,9 @@ dependencies = [
     { name = "transformers" },
     { name = "wait-for2", marker = "python_full_version < '3.12'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/37/01/e83db0b7e51b13c76579f04ad16167231db1dea9726e43b182ca7324c8c4/pipecat_ai-1.1.0.tar.gz", hash = "sha256:abcb1eda51aac81ed0f236c49581e3ff6afa3d7e1fbce9022645d45b905446a1", size = 11049587, upload-time = "2026-04-27T21:03:48.777Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b1/61/60a6f7ff2424f9ea6e70c127ece28da241baf3e40b0b5bd6f196bd63a623/pipecat_ai-0.0.102.tar.gz", hash = "sha256:c999d2f0668ab11520396c445605d4eefa1e9bb1965362a52d3dcf3635890519", size = 10957064, upload-time = "2026-02-11T02:33:07.303Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/88/cf/3fa12ae09e891f5485a0f3cf15aa307049a358d9d4d06e1378c04340fc1f/pipecat_ai-1.1.0-py3-none-any.whl", hash = "sha256:74e576a9434477c11f352ca22ad804c5fd52b49b5c3ff6e7f06615f1f8f24573", size = 10711531, upload-time = "2026-04-27T21:03:45.931Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/72/2222f4208dc7eca15cdb174c9fe6303c795d60938f3122b15cfb25397d69/pipecat_ai-0.0.102-py3-none-any.whl", hash = "sha256:b533854d8b720860f8ddeb8a6557a1846a46d4226c0d2f42cb631f7dcf457a8b", size = 10611114, upload-time = "2026-02-11T02:33:04.652Z" },
 ]
 
 [package.optional-dependencies]
@@ -2455,6 +2552,7 @@ azure = [
     { name = "azure-cognitiveservices-speech" },
 ]
 cartesia = [
+    { name = "cartesia" },
     { name = "websockets" },
 ]
 daily = [
@@ -2483,22 +2581,25 @@ sarvam = [
     { name = "sarvamai" },
     { name = "websockets" },
 ]
+silero = [
+    { name = "onnxruntime" },
+]
 soniox = [
     { name = "websockets" },
 ]
 
 [[package]]
 name = "pipecat-ai-flows"
-version = "1.0.0"
+version = "0.0.22"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "docstring-parser" },
     { name = "loguru" },
     { name = "pipecat-ai" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/31/de/a9bbd7306039b9b46cd4cabf4ab4a5312b8434b4ef6141bda31129c1412d/pipecat_ai_flows-1.0.0.tar.gz", hash = "sha256:16f70c749fdb68258c68631819fc5b73fe025f511acc0e4328a5c5b5f1674efa", size = 4935777, upload-time = "2026-04-15T22:30:11.762Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ea/df/cc5258bd04c9347436673839ec3d9b858d95b0bb74ede23c97a6608f750d/pipecat_ai_flows-0.0.22.tar.gz", hash = "sha256:5cb3e6972760eb9d2068ff29eda9813b4d406fcf6c34bdc1ebf87e93e954ce30", size = 5510244, upload-time = "2025-11-18T15:12:00.841Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/87/bf/2b6e9a0d6b6fcda5900a14a92b08d2f1c631b0f815613df8d95d01bc5e01/pipecat_ai_flows-1.0.0-py3-none-any.whl", hash = "sha256:2b7202c23db45af48f35e7073ac5e6d508b823bf76f52061f39da47d88291879", size = 24477, upload-time = "2026-04-15T22:30:10.307Z" },
+    { url = "https://files.pythonhosted.org/packages/25/6d/b49bec4e304534cb61a9a563d82dfda9aebb49f45dd972f6f6a0bb1213f7/pipecat_ai_flows-0.0.22-py3-none-any.whl", hash = "sha256:68e0e239b29978bdeacf4af2259e8c4b8f7687045ce228450dd8945dac6c5c70", size = 30975, upload-time = "2025-11-18T15:11:59.068Z" },
 ]
 
 [[package]]
@@ -2524,15 +2625,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/fc/be/987fd3dddbf228fa62d2ad210d4575e4eda7d7e4ed889d6b104ee9db86c3/plivo-4.59.5.tar.gz", hash = "sha256:001db2880885a0dc33389af895425973a8c61fd5faf6d1b05335e48ce633c124", size = 57168, upload-time = "2026-01-22T03:28:39.49Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/93/b9/02da421677d82410b7fc99ec957046549f4d47b3ccacab7b4972bca88163/plivo-4.59.5-py2.py3-none-any.whl", hash = "sha256:6a22bedf32d40d32b0e43862ab4c9e2f9fa207f717448ce9117bc4aa7592de12", size = 89263, upload-time = "2026-01-22T03:28:37.828Z" },
-]
-
-[[package]]
-name = "pluggy"
-version = "1.6.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
 ]
 
 [[package]]
@@ -2859,15 +2951,34 @@ crypto = [
 
 [[package]]
 name = "pyloudnorm"
-version = "0.2.0"
+version = "0.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "future" },
     { name = "numpy" },
     { name = "scipy" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/23/00/f915eaa75326f4209941179c2b93ac477f2040e4aeff5bb21d16eb8058f9/pyloudnorm-0.2.0.tar.gz", hash = "sha256:8bf597658ea4e1975c275adf490f6deb5369ea409f2901f939915efa4b681b16", size = 14037, upload-time = "2026-01-04T11:43:35.265Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/75/b5/39d59c44ecd828fabfdbd796b50a561e6543ca90ef440ab307374f107856/pyloudnorm-0.1.1.tar.gz", hash = "sha256:63cd4e197dea4e7795160ea08ed02d318091bce883e436a6dbc5963326b71e1e", size = 8588, upload-time = "2023-01-05T16:11:28.601Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/aa/b6/65a49a05614b2548edbba3aab118f2ebe7441dfd778accdcdce9f6567f20/pyloudnorm-0.2.0-py3-none-any.whl", hash = "sha256:9bb69afb904f59d007a7f9ba3d75d16fb8aeef35c44d6df822a9f192d69cf13f", size = 10879, upload-time = "2026-01-04T11:43:34.534Z" },
+    { url = "https://files.pythonhosted.org/packages/58/f5/6724805521ab4e723a12182f92374031032aff28a8a89dc8505c52b79032/pyloudnorm-0.1.1-py3-none-any.whl", hash = "sha256:d7f12ebdd097a464d87ce2878fc4d942f15f8233e26cc03f33fefa226f869a14", size = 9636, upload-time = "2023-01-05T16:11:27.331Z" },
+]
+
+[[package]]
+name = "pyparsing"
+version = "3.3.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/91/9c6ee907786a473bf81c5f53cf703ba0957b23ab84c264080fb5a450416f/pyparsing-3.3.2.tar.gz", hash = "sha256:c777f4d763f140633dcb6d8a3eda953bf7a214dc4eff598413c070bcdc117cbc", size = 6851574, upload-time = "2026-01-21T03:57:59.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl", hash = "sha256:850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d", size = 122781, upload-time = "2026-01-21T03:57:55.912Z" },
+]
+
+[[package]]
+name = "pyreadline3"
+version = "3.5.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/49/4cea918a08f02817aabae639e3d0ac046fef9f9180518a3ad394e22da148/pyreadline3-3.5.4.tar.gz", hash = "sha256:8d57d53039a1c75adba8e50dd3d992b28143480816187ea5efbd5c78e6c885b7", size = 99839, upload-time = "2024-09-19T02:40:10.062Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/dc/491b7661614ab97483abf2056be1deee4dc2490ecbf7bff9ab5cdbac86e1/pyreadline3-3.5.4-py3-none-any.whl", hash = "sha256:eaf8e6cc3c49bcccf145fc6067ba8643d1df34d604a1ec0eccbf7a18e6d3fae6", size = 83178, upload-time = "2024-09-19T02:40:08.598Z" },
 ]
 
 [[package]]
@@ -2884,35 +2995,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/67/91/963f6afb1cc0fd020f925137d64f437b777fd31907ac34589e9a9f949069/pyrefly-0.52.0-py3-none-win32.whl", hash = "sha256:d24ed11ef5eab93625df0bb4e67f7f946208b2b0ed4359b78f69cabbc6f78e3d", size = 10836046, upload-time = "2026-02-09T15:29:57.661Z" },
     { url = "https://files.pythonhosted.org/packages/be/e7/d2699327bef724d79b0afb11723497369a2876ec5715a78878abf49253dd/pyrefly-0.52.0-py3-none-win_amd64.whl", hash = "sha256:0e5bee368fbdce6430b7672304bc4e36f11bc3b72ad067cbfde934d380701a3b", size = 11622998, upload-time = "2026-02-09T15:29:59.595Z" },
     { url = "https://files.pythonhosted.org/packages/ff/57/491936d2293fee8ef91c2d16a841022decfd0824d1eda37ea87e667c41b9/pyrefly-0.52.0-py3-none-win_arm64.whl", hash = "sha256:8cabc07740e90c0baea12a1e7c48d6422130a19331033e8d9a16dd63e7e90db0", size = 11131664, upload-time = "2026-02-09T15:30:01.957Z" },
-]
-
-[[package]]
-name = "pytest"
-version = "9.0.3"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "iniconfig" },
-    { name = "packaging" },
-    { name = "pluggy" },
-    { name = "pygments" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
-]
-
-[[package]]
-name = "pytest-asyncio"
-version = "1.3.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pytest" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
 ]
 
 [[package]]
@@ -3347,6 +3429,18 @@ wheels = [
 ]
 
 [[package]]
+name = "rsa"
+version = "4.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyasn1" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/da/8a/22b7beea3ee0d44b1916c0c1cb0ee3af23b700b6da9f04991899d0c555d4/rsa-4.9.1.tar.gz", hash = "sha256:e7bdbfdb5497da4c07dfd35530e1a902659db6ff241e39d9953cad06ebd0ae75", size = 29034, upload-time = "2025-04-16T09:51:18.218Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/8d/0133e4eb4beed9e425d9a98ed6e081a55d195481b7632472be1af08d2f6b/rsa-4.9.1-py3-none-any.whl", hash = "sha256:68635866661c6836b8d39430f97a996acbd61bfa49406748ea243539fe239762", size = 34696, upload-time = "2025-04-16T09:51:17.142Z" },
+]
+
+[[package]]
 name = "s3transfer"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3382,7 +3476,7 @@ wheels = [
 
 [[package]]
 name = "sarvamai"
-version = "0.1.28"
+version = "0.1.21"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
@@ -3391,9 +3485,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/23/44/57a7a37be64953bb0bec9f674e92a9f8fb7070ce6aeb44c6f22720458b40/sarvamai-0.1.28.tar.gz", hash = "sha256:bc52f0c849e429d1a4493e49b1b4b65bf06965f3936d4eb6ee3da3130452e7ea", size = 139022, upload-time = "2026-04-20T08:05:12.185Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e9/08/e5efcb30818ed220b818319255c22fd91e379489ebaa93efd6f444fb4987/sarvamai-0.1.21.tar.gz", hash = "sha256:865065635b2b99d40f5519308832954015627938e06a6333b5f62ae9c36278bb", size = 87386, upload-time = "2025-10-07T07:37:47.085Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/84/90/95cd195a3a2ae9a9973c6a05705207e8dd97b5aea90339bc24343cb54850/sarvamai-0.1.28-py3-none-any.whl", hash = "sha256:52e71c0a0f521552d4d948ec452699b44554a56e64ee354b14da2efc9d9046b3", size = 269335, upload-time = "2026-04-20T08:05:10.712Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/4e/b9933f72681b7aed91b86913337dd3981fad97027881fbc66c3c5eb03568/sarvamai-0.1.21-py3-none-any.whl", hash = "sha256:daa4e5d16635fe434f5f270cee416849249285369141d77132a17f0bf670f120", size = 175204, upload-time = "2025-10-07T07:37:46.024Z" },
 ]
 
 [[package]]
@@ -3515,28 +3609,23 @@ wheels = [
 
 [[package]]
 name = "soxr"
-version = "1.0.0"
+version = "0.5.0.post1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/42/7e/f4b461944662ad75036df65277d6130f9411002bfb79e9df7dff40a31db9/soxr-1.0.0.tar.gz", hash = "sha256:e07ee6c1d659bc6957034f4800c60cb8b98de798823e34d2a2bba1caa85a4509", size = 171415, upload-time = "2025-09-07T13:22:21.317Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/02/c0/4429bf9b3be10e749149e286aa5c53775399ec62891c6b970456c6dca325/soxr-0.5.0.post1.tar.gz", hash = "sha256:7092b9f3e8a416044e1fa138c8172520757179763b85dc53aa9504f4813cff73", size = 170853, upload-time = "2024-08-31T03:43:33.058Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/65/ce/a3262bc8733d3a4ce5f660ed88c3d97f4b12658b0909e71334cba1721dcb/soxr-1.0.0-cp311-cp311-macosx_10_14_x86_64.whl", hash = "sha256:28e19d74a5ef45c0d7000f3c70ec1719e89077379df2a1215058914d9603d2d8", size = 206739, upload-time = "2025-09-07T13:21:54.572Z" },
-    { url = "https://files.pythonhosted.org/packages/64/dc/e8cbd100b652697cc9865dbed08832e7e135ff533f453eb6db9e6168d153/soxr-1.0.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:f8dc69fc18884e53b72f6141fdf9d80997edbb4fec9dc2942edcb63abbe0d023", size = 165233, upload-time = "2025-09-07T13:21:55.887Z" },
-    { url = "https://files.pythonhosted.org/packages/75/12/4b49611c9ba5e9fe6f807d0a83352516808e8e573f8b4e712fc0c17f3363/soxr-1.0.0-cp311-cp311-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3f15450e6f65f22f02fcd4c5a9219c873b1e583a73e232805ff160c759a6b586", size = 208867, upload-time = "2025-09-07T13:21:57.076Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/70/92146ab970a3ef8c43ac160035b1e52fde5417f89adb10572f7e788d9596/soxr-1.0.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1f73f57452f9df37b4de7a4052789fcbd474a5b28f38bba43278ae4b489d4384", size = 242633, upload-time = "2025-09-07T13:21:58.621Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/a7/628479336206959463d08260bffed87905e7ba9e3bd83ca6b405a0736e94/soxr-1.0.0-cp311-cp311-win_amd64.whl", hash = "sha256:9f417c3d69236051cf5a1a7bad7c4bff04eb3d8fcaa24ac1cb06e26c8d48d8dc", size = 173814, upload-time = "2025-09-07T13:21:59.798Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/c7/f92b81f1a151c13afb114f57799b86da9330bec844ea5a0d3fe6a8732678/soxr-1.0.0-cp312-abi3-macosx_10_14_x86_64.whl", hash = "sha256:abecf4e39017f3fadb5e051637c272ae5778d838e5c3926a35db36a53e3a607f", size = 205508, upload-time = "2025-09-07T13:22:01.252Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/1d/c945fea9d83ea1f2be9d116b3674dbaef26ed090374a77c394b31e3b083b/soxr-1.0.0-cp312-abi3-macosx_11_0_arm64.whl", hash = "sha256:e973d487ee46aa8023ca00a139db6e09af053a37a032fe22f9ff0cc2e19c94b4", size = 163568, upload-time = "2025-09-07T13:22:03.558Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/80/10640970998a1d2199bef6c4d92205f36968cddaf3e4d0e9fe35ddd405bd/soxr-1.0.0-cp312-abi3-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e8ce273cca101aff3d8c387db5a5a41001ba76ef1837883438d3c652507a9ccc", size = 204707, upload-time = "2025-09-07T13:22:05.125Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/87/2726603c13c2126cb8ded9e57381b7377f4f0df6ba4408e1af5ddbfdc3dd/soxr-1.0.0-cp312-abi3-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e8f2a69686f2856d37823bbb7b78c3d44904f311fe70ba49b893af11d6b6047b", size = 238032, upload-time = "2025-09-07T13:22:06.428Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/04/530252227f4d0721a5524a936336485dfb429bb206a66baf8e470384f4a2/soxr-1.0.0-cp312-abi3-win_amd64.whl", hash = "sha256:2a3b77b115ae7c478eecdbd060ed4f61beda542dfb70639177ac263aceda42a2", size = 172070, upload-time = "2025-09-07T13:22:07.62Z" },
-    { url = "https://files.pythonhosted.org/packages/99/77/d3b3c25b4f1b1aa4a73f669355edcaee7a52179d0c50407697200a0e55b9/soxr-1.0.0-cp314-cp314t-macosx_10_14_x86_64.whl", hash = "sha256:392a5c70c04eb939c9c176bd6f654dec9a0eaa9ba33d8f1024ed63cf68cdba0a", size = 209509, upload-time = "2025-09-07T13:22:08.773Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/ee/3ca73e18781bb2aff92b809f1c17c356dfb9a1870652004bd432e79afbfa/soxr-1.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:fdc41a1027ba46777186f26a8fba7893be913383414135577522da2fcc684490", size = 167690, upload-time = "2025-09-07T13:22:10.259Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/f0/eea8b5f587a2531657dc5081d2543a5a845f271a3bea1c0fdee5cebde021/soxr-1.0.0-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:449acd1dfaf10f0ce6dfd75c7e2ef984890df94008765a6742dafb42061c1a24", size = 209541, upload-time = "2025-09-07T13:22:11.739Z" },
-    { url = "https://files.pythonhosted.org/packages/64/59/2430a48c705565eb09e78346950b586f253a11bd5313426ced3ecd9b0feb/soxr-1.0.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:38b35c99e408b8f440c9376a5e1dd48014857cd977c117bdaa4304865ae0edd0", size = 243025, upload-time = "2025-09-07T13:22:12.877Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/1b/f84a2570a74094e921bbad5450b2a22a85d58585916e131d9b98029c3e69/soxr-1.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:a39b519acca2364aa726b24a6fd55acf29e4c8909102e0b858c23013c38328e5", size = 184850, upload-time = "2025-09-07T13:22:14.068Z" },
+    { url = "https://files.pythonhosted.org/packages/29/28/dc62dae260a77603e8257e9b79078baa2ca4c0b4edc6f9f82c9113d6ef18/soxr-0.5.0.post1-cp311-cp311-macosx_10_14_x86_64.whl", hash = "sha256:6fb77b626773a966e3d8f6cb24f6f74b5327fa5dc90f1ff492450e9cdc03a378", size = 203648, upload-time = "2024-08-31T03:43:08.339Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/48/3e88329a695f6e0e38a3b171fff819d75d7cc055dae1ec5d5074f34d61e3/soxr-0.5.0.post1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:39e0f791ba178d69cd676485dbee37e75a34f20daa478d90341ecb7f6d9d690f", size = 159933, upload-time = "2024-08-31T03:43:10.053Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/a5/6b439164be6871520f3d199554568a7656e96a867adbbe5bac179caf5776/soxr-0.5.0.post1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4f0b558f445ba4b64dbcb37b5f803052eee7d93b1dbbbb97b3ec1787cb5a28eb", size = 221010, upload-time = "2024-08-31T03:43:11.839Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/e5/400e3bf7f29971abad85cb877e290060e5ec61fccd2fa319e3d85709c1be/soxr-0.5.0.post1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ca6903671808e0a6078b0d146bb7a2952b118dfba44008b2aa60f221938ba829", size = 252471, upload-time = "2024-08-31T03:43:13.347Z" },
+    { url = "https://files.pythonhosted.org/packages/86/94/6a7e91bea7e6ca193ee429869b8f18548cd79759e064021ecb5756024c7c/soxr-0.5.0.post1-cp311-cp311-win_amd64.whl", hash = "sha256:c4d8d5283ed6f5efead0df2c05ae82c169cfdfcf5a82999c2d629c78b33775e8", size = 166723, upload-time = "2024-08-31T03:43:15.212Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/e3/d422d279e51e6932e7b64f1170a4f61a7ee768e0f84c9233a5b62cd2c832/soxr-0.5.0.post1-cp312-abi3-macosx_10_14_x86_64.whl", hash = "sha256:fef509466c9c25f65eae0ce1e4b9ac9705d22c6038c914160ddaf459589c6e31", size = 199993, upload-time = "2024-08-31T03:43:17.24Z" },
+    { url = "https://files.pythonhosted.org/packages/20/f1/88adaca3c52e03bcb66b63d295df2e2d35bf355d19598c6ce84b20be7fca/soxr-0.5.0.post1-cp312-abi3-macosx_11_0_arm64.whl", hash = "sha256:4704ba6b13a3f1e41d12acf192878384c1c31f71ce606829c64abdf64a8d7d32", size = 156373, upload-time = "2024-08-31T03:43:18.633Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/38/bad15a9e615215c8219652ca554b601663ac3b7ac82a284aca53ec2ff48c/soxr-0.5.0.post1-cp312-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bd052a66471a7335b22a6208601a9d0df7b46b8d087dce4ff6e13eed6a33a2a1", size = 216564, upload-time = "2024-08-31T03:43:20.789Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/1a/569ea0420a0c4801c2c8dd40d8d544989522f6014d51def689125f3f2935/soxr-0.5.0.post1-cp312-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a3f16810dd649ab1f433991d2a9661e9e6a116c2b4101039b53b3c3e90a094fc", size = 248455, upload-time = "2024-08-31T03:43:22.165Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/10/440f1ba3d4955e0dc740bbe4ce8968c254a3d644d013eb75eea729becdb8/soxr-0.5.0.post1-cp312-abi3-win_amd64.whl", hash = "sha256:b1be9fee90afb38546bdbd7bde714d1d9a8c5a45137f97478a83b65e7f3146f6", size = 164937, upload-time = "2024-08-31T03:43:23.671Z" },
 ]
 
 [[package]]
@@ -3694,6 +3783,19 @@ wheels = [
 ]
 
 [[package]]
+name = "typing-inspect"
+version = "0.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mypy-extensions" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/dc/74/1789779d91f1961fa9438e9a8710cdae6bd138c80d7303996933d117264a/typing_inspect-0.9.0.tar.gz", hash = "sha256:b23fc42ff6f6ef6954e4852c1fb512cdd18dbea03134f91f856a95ccc9461f78", size = 13825, upload-time = "2023-05-24T20:25:47.612Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/65/f3/107a22063bf27bdccf2024833d3445f4eea42b2e598abfbd46f6a63b6cb0/typing_inspect-0.9.0-py3-none-any.whl", hash = "sha256:9ee6fc59062311ef8547596ab6b955e1b8aa46242d854bfc78f4f6b0eff35f9f", size = 8827, upload-time = "2023-05-24T20:25:45.287Z" },
+]
+
+[[package]]
 name = "typing-inspection"
 version = "0.4.2"
 source = { registry = "https://pypi.org/simple" }
@@ -3703,6 +3805,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "uritemplate"
+version = "4.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/98/60/f174043244c5306c9988380d2cb10009f91563fc4b31293d27e17201af56/uritemplate-4.2.0.tar.gz", hash = "sha256:480c2ed180878955863323eea31b0ede668795de182617fef9c6ca09e6ec9d0e", size = 33267, upload-time = "2025-06-02T15:12:06.318Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a9/99/3ae339466c9183ea5b8ae87b34c0b897eda475d2aec2307cae60e5cd4f29/uritemplate-4.2.0-py3-none-any.whl", hash = "sha256:962201ba1c4edcab02e60f9a0d3821e82dfc5d2d6662a21abd533879bdb8a686", size = 11488, upload-time = "2025-06-02T15:12:03.405Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adds a Google Sheets data source feature to Breeze Buddy. Merchants attach a Google Sheet to a template; sheet content is fetched pre-call and injected into LLM context either as a `{variable}` placeholder or as a prepended system message.

## What Changed

### Database
- `026_create_data_source_table.sql` — new standalone `data_source` entity (reseller-scoped, reusable across templates)
- `027_add_data_sources_column_to_template.sql` — `template.data_sources JSONB` stores `[{data_source_id, name, inject_as}]` refs

### Service Layer
- `app/services/google/sheets.py` — Google Sheets API v4 wrapper; `fetch_formatted` (markdown_table/csv/json), `list_tabs`, `get_column_headers`, `fetch_sheet_data`; sync SDK wrapped in `run_in_executor`; uses existing `GOOGLE_CREDENTIALS_JSON` SA

### DB Layer (three-layer pattern)
- `queries/breeze_buddy/data_source.py` — SQL builders for CRUD + paginated list
- `decoder/breeze_buddy/data_source.py` — asyncpg Record → `DataSourceResponse`
- `accessor/breeze_buddy/data_source.py` — business logic; extracts `spreadsheet_id` from URL at write time
- `queries/breeze_buddy/template.py` — `data_sources` added to all SELECT/INSERT/UPDATE queries
- `decoder/breeze_buddy/template.py` — parses `data_sources` JSONB → `List[DataSourceRef]`
- `accessor/breeze_buddy/template.py` — threads `data_sources_json` through create/replace

### Schemas
- `schemas/breeze_buddy/data_source.py` — `DataSourceCreate`, `DataSourceUpdate`, `DataSourceResponse`, `DataSourceListResponse`, `TabsResponse`, `ColumnsResponse`, `PreviewResponse`
- `template/types.py` — `DataSourceRef` model; `data_sources` field on `TemplateModel`, `CreateTemplateRequest`, `ReplaceTemplateRequest`

### API
- `routers/breeze_buddy/data_sources/` — 8 endpoints:
  - `GET /data-sources/sheets/tabs|columns|preview` — discovery (declared before `/{id}` to avoid FastAPI path conflict)
  - `POST/GET /data-sources` — CRUD
  - `GET/PUT/DELETE /data-sources/{id}` — single resource
- RBAC: non-admin scoped to their `reseller_ids`

### Runtime — Pre-warm
- `managers/data_source_prefetch.py` — fetches all `DataSourceRef`s concurrently, writes to Redis (`datasource:{lead_id}:{name}`, TTL=300s)
- `dispatch/worker.py` — wired into `asyncio.gather` alongside greeting TTS; both complete before dial

### Runtime — Call Time
- `template/loader.py` — Layer 5 in `load_template()`:
  - `_fetch_data_source_content`: Redis hit → live fetch (800ms timeout) → `"[Data unavailable]"` fallback
  - `inject_as="var"` → `template_vars[name]` (rendered as `{name}` in prompts)
  - `inject_as="message"` → `template.flow["_data_source_messages"]`
- `agent/flow.py` — `build_flow_config` propagates `_data_source_messages`; `prepare_initial_node` prepends to `task_messages`

## Injection Modes

| `inject_as` | Mechanism | Best for |
|---|---|---|
| `"var"` (default) | `{name}` substituted inline in prompts | Specific positional references |
| `"message"` | System message prepended to initial node | Large reference datasets as ambient context |

## Extensibility

`source_type` CHECK constraint designed for future sources (`file`, `url`, `text`). Adding a new type touches only: new migration + new service + dispatch switch in `_fetch_data_source_content`. All inject/cache/API layers reused unchanged.

## Not in Scope (Phase 2)
- File/document upload source type
- URL scrape source type  
- RAG / vector search (per-turn retrieval)
- Per-node KB scoping
- Per-merchant OAuth (currently shared platform SA via `GOOGLE_CREDENTIALS_JSON`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added ability to attach Google Sheets data sources to conversation templates with automatic prefetching for improved performance.
  * Introduced REST API endpoints for data source management (create, read, update, delete operations).
  * Added Google Sheets discovery tools to browse tabs, columns, and preview sheet data.

* **Chores**
  * Updated dependencies and refactored internal code organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->