### PR TITLE
fix: filter call_execution_config by template name to unblock reseller-level fallback

### DIFF
--- a/app/ai/voice/agents/breeze_buddy/managers/calls.py
+++ b/app/ai/voice/agents/breeze_buddy/managers/calls.py
@@ -83,7 +83,7 @@ async def _get_lead_config(lead: LeadCallTracker) -> Optional[CallExecutionConfi
     """
 
     configs = await get_call_execution_config_by_merchant_id(
-        lead.reseller_id, lead.merchant_id
+        lead.reseller_id, lead.merchant_id, template_name=lead.template
     )
     if not configs:
         logger.warning(

--- a/app/api/routers/breeze_buddy/leads/handlers.py
+++ b/app/api/routers/breeze_buddy/leads/handlers.py
@@ -290,7 +290,7 @@ async def push_lead_handler(req: PushLeadRequest, current_user: UserInfo) -> Dic
 
         # Get call execution config
         call_execution_configs = await get_call_execution_config_by_merchant_id(
-            req.reseller_id, req.merchant_id
+            req.reseller_id, req.merchant_id, template_name=template.name
         )
 
         if not call_execution_configs:

--- a/app/database/accessor/breeze_buddy/call_execution_config.py
+++ b/app/database/accessor/breeze_buddy/call_execution_config.py
@@ -125,15 +125,27 @@ async def create_call_execution_config(
 async def get_call_execution_config_by_merchant_id(
     reseller_id: str,
     merchant_id: Optional[str] = None,
+    template_name: Optional[str] = None,
 ) -> List[CallExecutionConfig]:
     """
     Get call execution config by reseller ID.
+
+    When template_name is provided the lookup is template-aware:
+      1. Query with reseller_id + merchant_id + template_name
+      2. If not found, retry with merchant_id=NULL (reseller-level fallback)
+
+    This mirrors the template accessor fallback so a merchant that shares a
+    reseller-level config for a given template is resolved correctly even
+    when the merchant has other merchant-specific configs for different templates.
+
+    When template_name is omitted the existing behaviour is preserved (returns
+    all configs for the merchant/reseller scope).
     """
     logger.info(f"Getting call execution config by reseller ID: {reseller_id}")
 
     try:
         query_text, values = get_call_execution_config_by_merchant_id_query(
-            reseller_id, merchant_id
+            reseller_id, merchant_id, template_name
         )
         result = await run_parameterized_query(query_text, values)
 
@@ -150,7 +162,7 @@ async def get_call_execution_config_by_merchant_id(
                 f"No config found for merchant_id {merchant_id}, trying generic config."
             )
             query_text, values = get_call_execution_config_by_merchant_id_query(
-                reseller_id, None
+                reseller_id, None, template_name
             )
             result = await run_parameterized_query(query_text, values)
             if result:

--- a/app/database/queries/breeze_buddy/call_execution_config.py
+++ b/app/database/queries/breeze_buddy/call_execution_config.py
@@ -151,25 +151,52 @@ def insert_call_execution_config_query(
 def get_call_execution_config_by_merchant_id_query(
     reseller_id: str,
     merchant_id: Optional[str],
+    template_name: Optional[str] = None,
 ) -> Tuple[str, List[Any]]:
     """
     Generate query to get call execution config by reseller ID and merchant identifier.
+
+    When template_name is provided the query filters by template name, enabling
+    the accessor to apply a merchant→reseller fallback that is template-aware.
+    When template_name is omitted the query returns all configs for the given
+    scope (existing behaviour, used by admin listing and inbound handlers).
     """
     if merchant_id:
-        text = f"""
-            SELECT *
-            FROM "{CALL_EXECUTION_CONFIG_TABLE}" 
-            WHERE reseller_id = $1 
-            AND merchant_id = $2;
-        """
-        values: List[Any] = [reseller_id, merchant_id]
+        if template_name:
+            text = f"""
+                SELECT *
+                FROM "{CALL_EXECUTION_CONFIG_TABLE}"
+                WHERE reseller_id = $1
+                AND merchant_id = $2
+                AND template = $3;
+            """
+            values: List[Any] = [reseller_id, merchant_id, template_name]
+        else:
+            text = f"""
+                SELECT *
+                FROM "{CALL_EXECUTION_CONFIG_TABLE}" 
+                WHERE reseller_id = $1 
+                AND merchant_id = $2;
+            """
+            values = [reseller_id, merchant_id]
     else:
-        text = f"""
-            SELECT *
-            FROM "{CALL_EXECUTION_CONFIG_TABLE}" 
-            WHERE reseller_id = $1;
-        """
-        values = [reseller_id]
+        if template_name:
+            # Reseller-level fallback: only rows where merchant_id IS NULL
+            text = f"""
+                SELECT *
+                FROM "{CALL_EXECUTION_CONFIG_TABLE}"
+                WHERE reseller_id = $1
+                AND merchant_id IS NULL
+                AND template = $2;
+            """
+            values = [reseller_id, template_name]
+        else:
+            text = f"""
+                SELECT *
+                FROM "{CALL_EXECUTION_CONFIG_TABLE}" 
+                WHERE reseller_id = $1;
+            """
+            values = [reseller_id]
     return text, values
 
 


### PR DESCRIPTION

- merchant with configs for other templates blocked the merchant→reseller fallback
- handler failed to match mismatched config against resolved template, returning 404
- add optional `template_name` param to query and accessor; filters by template when provided
- update leads/handlers.py, managers/calls.py, ivr.py to pass template name on fetch
- leave telephony/answer/handlers.py and configurations/handlers.py unchanged (need all configs)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved call execution configuration lookup to properly consider the selected IVR template during policy checks and lead processing, ensuring template-specific settings are correctly applied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->