### PR TITLE
feat: Add support for dial first appraoch

### DIFF
--- a/app/ai/voice/agents/breeze_buddy/handlers/internal/builtin_dispatcher.py
+++ b/app/ai/voice/agents/breeze_buddy/handlers/internal/builtin_dispatcher.py
@@ -166,12 +166,14 @@ async def builtin_function_dispatcher(
         else:
             result_dict, next_node = result, None
 
-        # Record in node traversal path. Builtins have no expected_response_schema
-        # so function_response is always None.
+        # Record in node traversal path with the actual function response.
+        # This allows downstream logic (including the LLM via conversation
+        # context) to inspect the result of built-in calls such as
+        # transfer_to_agent for auditing and decision-making.
         context.record_global_function_call(
             function_name=function_config.name,
             function_args=args,
-            function_response=None,
+            function_response=result_dict,
         )
 
         return result_dict, next_node

--- a/app/ai/voice/agents/breeze_buddy/handlers/internal/warm_transfer.py
+++ b/app/ai/voice/agents/breeze_buddy/handlers/internal/warm_transfer.py
@@ -1,21 +1,35 @@
 """
 Transfer Handler
 
-Handles transfer to human agent by creating a conference call.
-On success, terminates the AI conversation. On failure, continues gracefully.
+Handles transfer to human agent using Plivo's MultiPartyCall (MPC).
+
+Flow (dial-first MPC):
+  1. Agent is dialled into a new MPC via add_participant(role='agent').
+     The customer's <Stream> is untouched and Buddy stays connected.
+  2. We subscribe to a Redis pub/sub channel and wait for the MPC
+     participant-state-changes webhook.
+  3. Agent answers → webhook moves customer into MPC, publishes "answered".
+     We end the AI conversation and close the WebSocket.
+  4. Agent no-answer → webhook publishes "unavailable".
+     Buddy continues the conversation seamlessly.
 """
 
+import asyncio
 from typing import Any, Dict, Optional
 
 from app.ai.voice.agents.breeze_buddy.handlers.internal.end_conversation import (
     end_conversation,
 )
+from app.ai.voice.agents.breeze_buddy.handlers.internal.stt import mute_stt, unmute_stt
 from app.ai.voice.agents.breeze_buddy.template.context import TemplateContext
+from app.ai.voice.agents.breeze_buddy.utils.hold_transfer import (
+    publish_hold_transfer_result,
+    subscribe_and_wait,
+)
 from app.ai.voice.agents.breeze_buddy.utils.transport.websockets import (
     close_websocket_safely,
 )
 from app.ai.voice.agents.breeze_buddy.utils.warm_transfer import set_transfer_flag
-from app.core.config.static import APP_BASE_URL
 from app.core.logger import logger
 from app.database.accessor import get_outbound_number_by_id
 from app.schemas import CallProvider
@@ -27,10 +41,10 @@ async def connect_to_live_agent(
     transition_to: Optional[str] = None,
 ) -> Dict[str, Any]:
     """
-    Initiate transfer to human agent via conference call.
+    Initiate warm transfer to human agent via Plivo MPC.
 
-    On success: Terminates AI conversation by calling end_conversation
-    On failure: Returns gracefully, allowing AI conversation to continue
+    On success (agent answers): terminates AI conversation.
+    On failure (agent no-answer): returns gracefully, allowing AI to continue.
 
     Args:
         context: Handler context with bot state access
@@ -123,7 +137,12 @@ async def connect_to_live_agent(
                     f"Customer phone number not found in payload for call {context.call_sid}"
                 )
 
-        # Set transfer flag in Redis (includes customer phone for Plivo dial-back)
+        # Mute STT before initiating transfer to prevent audio capture
+        # during the ringing period (up to 35 seconds).
+        await mute_stt(context, None)
+        logger.info(f"STT muted for call {context.call_sid} before transfer")
+
+        # Set transfer flag in Redis
         await set_transfer_flag(
             call_sid=context.call_sid,
             reseller_id=context.lead.reseller_id,
@@ -133,40 +152,111 @@ async def connect_to_live_agent(
         )
         logger.info(f"Transfer flag set in Redis for call {context.call_sid}")
 
-        # Build status callback URL for conference events
-        provider_name = context.provider.lower() if context.provider else None
-        status_callback_url = f"{APP_BASE_URL}/agent/voice/breeze-buddy/{provider_name}/callback/transfer/conference-end"
+        # Background subscriber — listens for webhook outcome.
+        # Uses a generous timeout ceiling; the real deadline is enforced
+        # by _timeout_publish below so both success and timeout paths
+        # deliver a message to the same Redis channel.
+        outcome_channel = f"transfer_outcome:{context.call_sid}"
+        logger.info(f"[Transfer] Subscribing to outcome channel: {outcome_channel}")
+        outcome_task = asyncio.create_task(
+            subscribe_and_wait(outcome_channel, timeout_seconds=40)
+        )
 
-        logger.info(f"Using conference status callback URL: {status_callback_url}")
+        # Background timer — publishes "unavailable" after 35s if no
+        # webhook has fired yet.  This guarantees the subscriber always
+        # receives a message (either "answered" from Plivo or
+        # "unavailable" from us), eliminating a separate timeout branch.
+        async def _timeout_publish():
+            await asyncio.sleep(35)
+            await publish_hold_transfer_result(
+                outcome_channel, {"status": "unavailable"}
+            )
+            logger.info(
+                f"[Transfer] Published 'unavailable' for call {context.call_sid} "
+                f"after 35s timeout"
+            )
 
+        timeout_task = asyncio.create_task(_timeout_publish())
+
+        # Trigger MPC transfer (agent is dialled into MPC, customer stays on Stream)
         conference_result = (
             await context.telephony_service.conference_service.handle_transfer(
                 conference_name=conference_name,
                 agent_phone_number=agent_phone_number,
                 customer_call_sid=context.call_sid,
                 outbound_number=outbound_number,
-                callback=None,
-                status_callback_url=status_callback_url,
-                customer_phone_number=customer_phone_number,
             )
         )
 
-        if conference_result.get("success"):
+        if not conference_result.get("success"):
+            outcome_task.cancel()
+            timeout_task.cancel()
+            for task in (outcome_task, timeout_task):
+                try:
+                    await task
+                except asyncio.CancelledError:
+                    pass
+            failure_reason = conference_result.get("reason", "unknown_error")
+            logger.warning(
+                f"[Transfer] MPC setup failed: {failure_reason}. AI continues."
+            )
+            # Unmute STT so the conversation can continue normally
+            await unmute_stt(context, None)
             logger.info(
-                f"Transfer successful: conference={conference_result.get('conference_id')}, "
-                f"agent_call={conference_result.get('agent_call_id')}"
+                f"STT unmuted for call {context.call_sid} after MPC setup failure"
+            )
+            return {
+                "status": "failed",
+                "reason": failure_reason,
+                "message": f"Transfer failed: {failure_reason}. Continuing with AI assistant.",
+            }
+
+        logger.info(
+            f"[Transfer] MPC transfer initiated: conference={conference_result.get('conference_id')}"
+        )
+
+        # Wait for MPC outcome — subscriber consumes whichever fires first
+        # (webhook "answered" or our own "unavailable" from _timeout_publish).
+        try:
+            outcome = await outcome_task
+        except asyncio.CancelledError:
+            timeout_task.cancel()
+            try:
+                await timeout_task
+            except asyncio.CancelledError:
+                pass
+            # Unmute STT so the conversation can continue normally
+            await unmute_stt(context, None)
+            logger.info(
+                f"STT unmuted for call {context.call_sid} after subscriber cancellation"
+            )
+            return {
+                "status": "failed",
+                "reason": "cancelled",
+                "message": "Transfer was cancelled. Continuing with AI assistant.",
+            }
+
+        # Cancel the timeout task if the webhook arrived first
+        timeout_task.cancel()
+        try:
+            await timeout_task
+        except asyncio.CancelledError:
+            pass
+
+        status = outcome.get("status") if outcome else "unavailable"
+
+        if status == "answered":
+            logger.info(
+                f"[Transfer] Agent answered for call {context.call_sid}. "
+                f"Ending AI conversation."
             )
 
-            agent_call_id = conference_result.get("agent_call_id")
-            conference_result.get("conference_id")
-
+            # Update lead metadata
             transfer_meta = {
                 "status": "success",
                 "conference_id": conference_result.get("conference_id"),
                 "agent_phone_number": agent_phone_number,
-                "agent_call_id": agent_call_id,
             }
-
             if context.lead and hasattr(context.lead, "metaData"):
                 if context.lead.metaData is None:
                     context.lead.metaData = {}
@@ -175,9 +265,8 @@ async def connect_to_live_agent(
             # For Plivo: suppress the serializer's auto hang-up before ending
             # the conversation. When end_conversation pushes EndFrame through
             # the pipeline the Plivo serializer would normally call _hang_up_call(),
-            # which drops the caller from the conference. Setting _hangup_attempted=True
-            # tells the serializer that a hang-up has already been handled so it
-            # skips the API call.
+            # which drops the caller. Setting _hangup_attempted=True tells the
+            # serializer that a hang-up has already been handled so it skips.
             if context.provider == CallProvider.PLIVO:
                 try:
                     plivo_serializer = context.bot.transport.output()._params.serializer
@@ -200,11 +289,9 @@ async def connect_to_live_agent(
                     and hasattr(context.bot, "ws")
                     and context.bot.ws
                 ):
-
                     logger.info(
                         f"Explicitly closing websocket for Plivo transfer on call {context.call_sid}"
                     )
-
                     await close_websocket_safely(
                         context.bot.ws, 1000, "Transfer complete"
                     )
@@ -212,22 +299,32 @@ async def connect_to_live_agent(
             return {
                 "status": "success",
                 "conference_id": conference_result.get("conference_id"),
-                "agent_call_id": agent_call_id,
                 "message": "Successfully transferred to human agent",
             }
-        else:
-            failure_reason = conference_result.get("reason", "unknown_error")
-            logger.warning(f"Transfer failed: {failure_reason}. AI continues.")
 
-            return {
-                "status": "failed",
-                "reason": failure_reason,
-                "message": f"Transfer failed: {failure_reason}. Continuing with AI assistant.",
-            }
+        # "unavailable" — agent didn't answer or hung up immediately
+        logger.warning(
+            f"[Transfer] Agent unavailable for call {context.call_sid}. AI continues."
+        )
+        # Unmute STT so the conversation can continue normally
+        await unmute_stt(context, None)
+        logger.info(f"STT unmuted for call {context.call_sid} after agent unavailable")
+        return {
+            "status": "failed",
+            "reason": "unavailable",
+            "message": "Transfer failed: agent did not answer. Continuing with AI assistant.",
+        }
 
     except Exception as e:
         logger.error(f"Transfer exception: {str(e)}", exc_info=True)
-
+        # Unmute STT so the conversation can continue normally
+        try:
+            await unmute_stt(context, None)
+            logger.info(
+                f"STT unmuted for call {context.call_sid} after transfer exception"
+            )
+        except Exception as unmute_err:
+            logger.warning(f"Failed to unmute STT after exception: {unmute_err}")
         return {
             "status": "failed",
             "reason": "exception",

--- a/app/ai/voice/agents/breeze_buddy/services/call_redirect.py
+++ b/app/ai/voice/agents/breeze_buddy/services/call_redirect.py
@@ -42,16 +42,13 @@ async def redirect_call(
             return False
 
         provider_name = provider.lower()
-        status_callback_url = f"{APP_BASE_URL}/agent/voice/breeze-buddy/{provider_name}/callback/transfer/conference-end"
+        f"{APP_BASE_URL}/agent/voice/breeze-buddy/{provider_name}/callback/transfer/conference-end"
 
         result = await telephony_service.conference_service.handle_transfer(
             conference_name=f"redirect-{call_sid}",
             agent_phone_number=redirect_number,
             customer_call_sid=call_sid,
             outbound_number=outbound_record.number,
-            callback=None,
-            status_callback_url=status_callback_url,
-            customer_phone_number=customer_phone_number,
         )
 
         if result.get("success"):

--- a/app/ai/voice/agents/breeze_buddy/services/telephony/plivo/conference.py
+++ b/app/ai/voice/agents/breeze_buddy/services/telephony/plivo/conference.py
@@ -1,135 +1,151 @@
 """
 Plivo Transfer Service
 
-Implements transfers by using Plivo's native Call Transfer API.
-When a transfer is requested, the customer's live call leg is transferred
-to a dial-up XML endpoint. This endpoint returns `<Dial><Number>` XML
-which connects the customer directly to the agent.
+Implements warm transfers using Plivo's MultiPartyCall (MPC) API.
 
-Flow:
-  1. ``calls.transfer(call_uuid=customer_call_sid, legs='aleg', aleg_url=<dial-up>)``
-     → Plivo fetches the answer_url which returns ``<Dial><Number>{agent}</Number></Dial>``
-       XML, making Plivo call the agent from the customer's leg.
-  2. The agent phone number is resolved in the webhook callback.
+Flow (dial-first MPC):
+  1. Agent is dialled into a new MPC via ``add_participant(role='agent')``.
+     The customer's live ``<Stream>`` is untouched and Buddy stays connected.
+  2. If the agent answers, a participant-state-changes webhook fires.
+     The customer's existing call is then moved into the MPC via
+     ``add_participant(call_uuid=...)``.  The ``<Stream>`` WebSocket dies
+     at this point — expected, as Buddy is done.
+  3. If the agent doesn't answer, the outbound leg simply times out.
+     The customer's ``<Stream>`` was never modified, so Buddy continues
+     the conversation seamlessly.
 
 Reference:
-  - Dial XML:  https://www.plivo.com/docs/voice/xml/dial
-  - Calls API: https://www.plivo.com/docs/voice/api/call#transfer-a-call
+  - Add Participant API: https://www.plivo.com/docs/voice/api/multiparty-calls#add-a-participant
 """
 
-from typing import Callable, Dict, Optional
-from urllib.parse import urlencode
+import asyncio
+from functools import partial
+from typing import Dict
 
 import plivo
 
 from app.core.config.static import APP_BASE_URL
 from app.core.logger import logger
 
-# Callback path that returns <Dial><Number> XML to connect customer → agent
-_DIAL_UP_PATH = "/agent/voice/breeze-buddy/plivo/callback/transfer/dial-up"
-
-
-def _dial_up_url(
-    customer_call_sid: str,
-    outbound_number: str,
-    status_callback_url: Optional[str] = None,
-) -> str:
-    """Build the URL for the dial-up callback during a call transfer."""
-    params: Dict[str, str] = {
-        "customer_call_sid": customer_call_sid,
-        "outbound_number": outbound_number,
-    }
-    if status_callback_url:
-        params["status_callback_url"] = status_callback_url
-    return f"{APP_BASE_URL}{_DIAL_UP_PATH}?{urlencode(params)}"
-
 
 class PlivoConferenceService:
     """
-    Service for managing Plivo transfers.
+    Service for managing Plivo transfers using MultiPartyCall (MPC).
 
-    Despite the class name (kept for backward-compatibility with
-    ``PlivoProvider`` which references ``self.conference_service``),
-    this implementation does **not** use Plivo Conferences.
-
-    Instead it transfers the live customer call using the native
-    Plivo API to an endpoint that returns ``<Dial><Number>`` XML
-    to bridge the agent to the customer's ongoing call.
+    The class name is retained for backward compatibility with
+    ``PlivoProvider`` which references ``self.conference_service``.
     """
 
     def __init__(self, plivo_client: plivo.RestClient):
         self.client = plivo_client
 
     # ------------------------------------------------------------------
-    # Transfer customer call to `<Dial><Number>` endpoint
+    # Add agent as outbound participant to an MPC
     # ------------------------------------------------------------------
 
-    def _transfer_call(
+    async def _add_agent_to_mpc(
         self,
-        customer_call_sid: str,
+        mpc_name: str,
+        agent_phone_number: str,
         outbound_number: str,
-        status_callback_url: Optional[str] = None,
+        customer_call_sid: str,
     ) -> Dict:
         """
-        Transfer the customer's live call via the Plivo native Transfer API.
+        Create a new MPC and add the agent as an outbound participant.
 
-        The ``aleg_url`` points to a callback that returns ``<Dial><Number>``
-        XML to dial the agent.
+        The customer's call is **not** modified — it stays on ``<Stream>``.
         """
-        answer_url = _dial_up_url(
-            customer_call_sid=customer_call_sid,
-            outbound_number=outbound_number,
-            status_callback_url=status_callback_url,
-        )
-
-        logger.info(
-            f"[Transfer] Transferring customer call {customer_call_sid} — "
-            f"bleg_url={answer_url}"
+        status_callback_url = (
+            f"{APP_BASE_URL}/agent/voice/breeze-buddy"
+            f"/plivo/callback/transfer/mpc-transfer"
+            f"?call_sid={customer_call_sid}"
         )
 
         try:
-            transfer_kwargs: Dict = dict(
-                call_uuid=customer_call_sid,
-                legs="aleg",
-                aleg_url=answer_url,
-                aleg_method="GET",
+            loop = asyncio.get_event_loop()
+            response = await loop.run_in_executor(
+                None,
+                partial(
+                    self.client.multi_party_calls.add_participant,
+                    friendly_name=mpc_name,
+                    role="agent",
+                    from_=outbound_number,
+                    to_=agent_phone_number,
+                    ring_timeout=30,
+                    end_mpc_on_exit=True,
+                    start_mpc_on_enter=True,
+                    stay_alone=True,
+                    status_callback_url=status_callback_url,
+                    status_callback_events="participant-state-changes",
+                ),
             )
 
-            response = self.client.calls.transfer(**transfer_kwargs)
-
-            logger.info(
-                f"[Transfer] calls.transfer response: {response}, "
-                f"type={type(response)}"
-            )
-            if hasattr(response, "__dict__"):
-                logger.info(f"[Transfer] response.__dict__: {response.__dict__}")
+            logger.info(f"[MPC] Agent added to MPC '{mpc_name}': response={response}")
 
             return {
                 "success": True,
-                "agent_call_uuid": customer_call_sid,
+                "reason": "success",
+                "agent_added": True,
+            }
+
+        except Exception as e:
+            error_message = str(e)
+            logger.error(
+                f"[MPC] Failed to add agent to MPC '{mpc_name}': {error_message}"
+            )
+            return {
+                "success": False,
+                "reason": "mpc_add_participant_error",
+                "error": error_message,
+            }
+
+    # ------------------------------------------------------------------
+    # Move existing call into MPC
+    # ------------------------------------------------------------------
+
+    async def move_customer_to_mpc(
+        self,
+        call_sid: str,
+        mpc_name: str,
+    ) -> Dict:
+        """
+        Move the customer's existing call leg into the MPC.
+
+        This terminates the ``<Stream>`` WebSocket — expected after the
+        agent has answered and Buddy should disconnect.
+        """
+        try:
+            loop = asyncio.get_event_loop()
+            response = await loop.run_in_executor(
+                None,
+                partial(
+                    self.client.multi_party_calls.add_participant,
+                    friendly_name=mpc_name,
+                    call_uuid=call_sid,
+                    role="customer",
+                    end_mpc_on_exit=True,
+                ),
+            )
+
+            logger.info(
+                f"[MPC] Customer {call_sid} moved to MPC '{mpc_name}': "
+                f"response={response}"
+            )
+
+            return {
+                "success": True,
                 "reason": "success",
             }
 
         except Exception as e:
             error_message = str(e)
             logger.error(
-                f"[Transfer] Failed to transfer call "
-                f"{customer_call_sid}: {error_message}"
+                f"[MPC] Failed to move customer {call_sid} to MPC "
+                f"'{mpc_name}': {error_message}"
             )
-
-            if (
-                "invalid" in error_message.lower()
-                or "not a valid" in error_message.lower()
-            ):
-                reason = "invalid_call_uuid"
-            elif "not found" in error_message.lower():
-                reason = "call_not_found"
-            else:
-                reason = "transfer_api_error"
-
             return {
                 "success": False,
-                "reason": reason,
+                "reason": "mpc_move_customer_error",
                 "error": error_message,
             }
 
@@ -143,96 +159,64 @@ class PlivoConferenceService:
         agent_phone_number: str,
         customer_call_sid: str,
         outbound_number: str,
-        callback: Optional[Callable] = None,
-        status_callback_url: Optional[str] = None,
-        customer_phone_number: Optional[str] = None,
     ) -> Dict:
         """
-        Execute transfer by using the Plivo native Transfer API.
+        Execute a warm transfer by dialling the agent into an MPC.
 
-        This delegates to `client.calls.transfer()`, transferring the
-        customer's live leg to the callback endpoint which will return XML
-        to connect the agent to the call.
+        The customer's ``<Stream>`` leg is left untouched.  The outcome
+        (answered / unavailable) is delivered asynchronously via the MPC
+        participant-state-changes webhook which publishes to a Redis
+        pub/sub channel.
 
         Returns dict matching the base-provider contract::
 
             {
                 "success": bool,
-                "conference_id": str,   # conference name (for compat)
-                "agent_call_id": str,   # agent leg call UUID
+                "conference_id": str,
+                "agent_call_id": str,
                 "reason": str,
             }
         """
+        mpc_name = f"transfer-{customer_call_sid}"
+
         logger.info(
-            f"[Transfer] Initiating transfer "
-            f"'{conference_name}' — agent={agent_phone_number}, "
-            f"customer_call_sid={customer_call_sid}"
+            f"[Transfer] Initiating MPC transfer '{mpc_name}' — "
+            f"agent={agent_phone_number}, customer={customer_call_sid}"
         )
 
         try:
-            # Transfer customer leg
-            transfer_result = self._transfer_call(
-                customer_call_sid=customer_call_sid,
+            result = await self._add_agent_to_mpc(
+                mpc_name=mpc_name,
+                agent_phone_number=agent_phone_number,
                 outbound_number=outbound_number,
-                status_callback_url=status_callback_url,
+                customer_call_sid=customer_call_sid,
             )
 
-            if not transfer_result["success"]:
-                logger.error(
-                    f"[Transfer] Failed to transfer customer call: "
-                    f"{transfer_result['reason']}"
-                )
+            if not result["success"]:
                 return {
-                    **transfer_result,
-                    "conference_id": conference_name,
+                    **result,
+                    "conference_id": mpc_name,
                     "agent_call_id": None,
                 }
 
-            agent_call_uuid = transfer_result["agent_call_uuid"]
-            logger.info(
-                f"[Transfer] Customer call {customer_call_sid} successfully transferred. "
-                f"Agent will be dialled."
-            )
-
-            if callback:
-                try:
-                    callback(
-                        conference_name,
-                        agent_call_uuid,
-                        customer_call_sid,
-                    )
-                except Exception as cb_err:
-                    logger.warning(f"Callback execution failed: {cb_err}")
-
             return {
                 "success": True,
-                "conference_id": conference_name,
-                "agent_call_id": agent_call_uuid,
+                "conference_id": mpc_name,
+                "agent_call_id": None,
                 "reason": "success",
             }
 
         except Exception as e:
             error_message = str(e)
             logger.error(
-                f"[Transfer] Unexpected error during transfer "
-                f"for '{conference_name}': {error_message}",
+                f"[Transfer] Unexpected error during MPC transfer "
+                f"'{mpc_name}': {error_message}",
                 exc_info=True,
             )
-
-            if "timeout" in error_message.lower():
-                reason = "timeout"
-            elif (
-                "authentication" in error_message.lower()
-                or "credentials" in error_message.lower()
-            ):
-                reason = "authentication_error"
-            else:
-                reason = "transfer_api_error"
-
             return {
                 "success": False,
-                "conference_id": conference_name,
+                "conference_id": mpc_name,
                 "agent_call_id": None,
-                "reason": reason,
+                "reason": "mpc_transfer_api_error",
                 "error": error_message,
             }

--- a/app/ai/voice/agents/breeze_buddy/services/telephony/plivo/plivo.py
+++ b/app/ai/voice/agents/breeze_buddy/services/telephony/plivo/plivo.py
@@ -3,7 +3,6 @@ from urllib.parse import urlencode
 
 import plivo
 from fastapi import WebSocket
-from starlette.responses import HTMLResponse
 
 from app.ai.voice.agents.breeze_buddy.agent import telephony_bot
 from app.ai.voice.agents.breeze_buddy.services.telephony.base_provider import (
@@ -11,6 +10,9 @@ from app.ai.voice.agents.breeze_buddy.services.telephony.base_provider import (
 )
 from app.ai.voice.agents.breeze_buddy.services.telephony.plivo.conference import (
     PlivoConferenceService,
+)
+from app.ai.voice.agents.breeze_buddy.utils.hold_transfer import (
+    publish_hold_transfer_result,
 )
 from app.core.config.static import (
     APP_BASE_URL,
@@ -107,36 +109,87 @@ class PlivoProvider(VoiceCallProvider):
             return None
 
 
-async def plivo_dial_xml(
-    transfer_data: dict, call_sid: str, params: dict
-) -> HTMLResponse:
-    """Build <Dial><Number> XML that bridges customer → agent."""
-    transfer_number = transfer_data.get("transfer_number")
-    if not transfer_number:
-        logger.error(f"[TRANSFER DIAL-UP] No transfer_number for call {call_sid}")
-        return HTMLResponse(
-            content='<?xml version="1.0" encoding="UTF-8"?>'
-            "<Response><Speak>Sorry, the transfer could not be completed.</Speak>"
-            "<Hangup/></Response>",
-            media_type="application/xml",
+async def handle_mpc_transfer_webhook(params: dict) -> None:
+    """Handle Plivo MPC participant-state-changes webhook.
+
+    Fires when an MPC participant's state changes (joins / exits).
+    Used to detect whether the agent answered the transfer call.
+
+    Flow:
+      - Agent answers → ParticipantJoin (role=agent)
+          → move customer into MPC, publish "answered" to Redis
+      - Agent no-answer → ParticipantExit (role=agent)
+          → publish "unavailable" to Redis
+    """
+    call_sid = str(params.get("call_sid") or "")
+    event = str(params.get("EventName", ""))
+    mpc_name = str(params.get("MPCName", ""))
+    participant_role = str(params.get("ParticipantRole", "")).lower()
+
+    logger.info(
+        f"[MPC-TRANSFER] event={event} role={participant_role} "
+        f"mpc={mpc_name} call_sid={call_sid}"
+    )
+
+    if not call_sid:
+        logger.error("[MPC-TRANSFER] Missing call_sid in callback")
+        return
+
+    outcome_channel = f"transfer_outcome:{call_sid}"
+
+    if participant_role == "agent" and event == "ParticipantJoin":
+        logger.info(
+            f"[MPC-TRANSFER] Agent answered for call {call_sid}. "
+            f"Moving customer into MPC '{mpc_name}'."
         )
 
-    agent_phone = transfer_number
-    if not agent_phone.startswith("+"):
-        agent_phone = f"+{agent_phone}"
+        client = plivo.RestClient(PLIVO_AUTH_ID, PLIVO_AUTH_TOKEN)
+        conference_service = PlivoConferenceService(client)
+        result = await conference_service.move_customer_to_mpc(
+            call_sid=call_sid,
+            mpc_name=mpc_name,
+        )
 
-    outbound_number = params.get("outbound_number", "")
-    action_url = (
-        f"{APP_BASE_URL}/agent/voice/breeze-buddy"
-        f"/plivo/callback/transfer/conclude"
-        f"?customer_call_sid={call_sid}"
-    )
-    xml = (
-        f'<?xml version="1.0" encoding="UTF-8"?>'
-        f"<Response>"
-        f'<Dial action="{action_url}" method="POST"'
-        f' callerId="{outbound_number}" timeout="30">'
-        f"<Number>{agent_phone}</Number>"
-        f"</Dial></Response>"
-    )
-    return HTMLResponse(content=xml, media_type="application/xml")
+        if result["success"]:
+            await publish_hold_transfer_result(
+                outcome_channel,
+                {"status": "answered"},
+            )
+            logger.info(
+                f"[MPC-TRANSFER] Customer moved to MPC, "
+                f"published 'answered' for {call_sid}"
+            )
+        else:
+            logger.error(
+                f"[MPC-TRANSFER] Failed to move customer to MPC: "
+                f"{result.get('error')}"
+            )
+            await publish_hold_transfer_result(
+                outcome_channel,
+                {
+                    "status": "unavailable",
+                    "reason": "mpc_move_failed",
+                    "error": result.get("error"),
+                },
+            )
+
+    elif participant_role == "agent" and event == "ParticipantExit":
+        # Agent never joined → timed out / busy → publish "unavailable".
+        # If ParticipantJoinTime is present, the agent had already joined
+        # and the transfer succeeded — this exit is a normal hang-up after
+        # a completed transfer and must not publish "unavailable".
+        join_time = str(params.get("ParticipantJoinTime", ""))
+        if join_time:
+            logger.info(
+                f"[MPC-TRANSFER] Agent exited after joining for call {call_sid}. "
+                f"Transfer was successful — not publishing 'unavailable'."
+            )
+        else:
+            logger.info(
+                f"[MPC-TRANSFER] Agent exited without joining for call {call_sid}. "
+                f"Publishing 'unavailable'."
+            )
+            await publish_hold_transfer_result(
+                outcome_channel,
+                {"status": "unavailable"},
+            )

--- a/app/ai/voice/agents/breeze_buddy/utils/hold_transfer.py
+++ b/app/ai/voice/agents/breeze_buddy/utils/hold_transfer.py
@@ -26,7 +26,7 @@ async def publish_hold_transfer_result(channel: str, result: Dict[str, Any]) -> 
     redis_service = await get_redis_service()
     redis_client = await redis_service.get_client()
     await redis_client.publish(channel, json.dumps(result))  # type: ignore[union-attr]
-    logger.info(f"[hold_transfer] Published result to channel '{channel}'")
+    logger.info(f"[pubsub] Published result to channel '{channel}'")
 
 
 async def subscribe_and_wait(
@@ -41,8 +41,7 @@ async def subscribe_and_wait(
     pubsub = redis_client.pubsub()  # type: ignore[union-attr]
     await pubsub.subscribe(channel)
     logger.info(
-        f"[hold_transfer] Subscribed to '{channel}', "
-        f"waiting up to {timeout_seconds}s"
+        f"[pubsub] Subscribed to '{channel}', " f"waiting up to {timeout_seconds}s"
     )
 
     try:
@@ -52,17 +51,15 @@ async def subscribe_and_wait(
         )
         if result:
             logger.info(
-                f"[hold_transfer] Received result on '{channel}': "
+                f"[pubsub] Received result on '{channel}': "
                 f"status={result.get('status')}"
             )
         return result
     except asyncio.TimeoutError:
-        logger.warning(
-            f"[hold_transfer] Timed out after {timeout_seconds}s on '{channel}'"
-        )
+        logger.warning(f"[pubsub] Timed out after {timeout_seconds}s on '{channel}'")
         return None
     except Exception as e:
-        logger.error(f"[hold_transfer] Error waiting on '{channel}': {e}")
+        logger.error(f"[pubsub] Error waiting on '{channel}': {e}")
         return None
     finally:
         await pubsub.unsubscribe(channel)

--- a/app/api/routers/breeze_buddy/telephony/callbacks/__init__.py
+++ b/app/api/routers/breeze_buddy/telephony/callbacks/__init__.py
@@ -10,7 +10,8 @@ Endpoints:
 - POST   /{provider}/callback/status                         - Receive call status updates
 - POST   /twilio/callback/twiml-fallback - Fallback TwiML when Smart Router is down
 - *      /{provider}/callback/transfer/{action}              - Transfer callbacks (GET/POST)
-    - dial-up           : Fetch dial-target info (Exotel GET, Plivo POST)
+    - dial-up           : Fetch dial-target info (Exotel GET, Plivo POST — legacy)
+    - mpc-transfer      : MPC participant state changes (Plivo POST)
     - conference-end    : Conference ended — resource cleanup (Twilio/Plivo POST)
 """
 

--- a/app/api/routers/breeze_buddy/telephony/callbacks/handlers.py
+++ b/app/api/routers/breeze_buddy/telephony/callbacks/handlers.py
@@ -26,7 +26,7 @@ from app.ai.voice.agents.breeze_buddy.services.telephony.exotel.exotel import (
     exotel_dial_text,
 )
 from app.ai.voice.agents.breeze_buddy.services.telephony.plivo.plivo import (
-    plivo_dial_xml,
+    handle_mpc_transfer_webhook,
 )
 from app.ai.voice.agents.breeze_buddy.utils.hold_transfer import (
     publish_hold_transfer_result,
@@ -89,6 +89,8 @@ async def handle_call_transfer(
 
     if action == "dial-up":
         return await _handle_transfer_dial_up(request, provider_lower)
+    elif action == "mpc-transfer":
+        return await _handle_mpc_transfer_status(request)
     elif action in ("conclude", "conference-end"):
         return HTMLResponse(
             content='<?xml version="1.0" encoding="UTF-8"?><Response><Hangup/></Response>',
@@ -100,6 +102,16 @@ async def handle_call_transfer(
             status_code=404,
             content=f"Unknown transfer action: {provider}/{action}",
         )
+
+
+async def _handle_mpc_transfer_status(request: Request) -> Response:
+    """Handle Plivo MPC participant-state-changes webhook.
+
+    Delegates to the Plivo service layer for all business logic.
+    """
+    params = {**dict(request.query_params), **dict(await request.form())}
+    await handle_mpc_transfer_webhook(params)
+    return Response(status_code=200)
 
 
 async def _handle_transfer_dial_up(request: Request, provider: str) -> Response:
@@ -133,7 +145,15 @@ async def _handle_transfer_dial_up(request: Request, provider: str) -> Response:
         return Response(status_code=404, content="Transfer not requested")
 
     if provider == "plivo":
-        return await plivo_dial_xml(transfer_data, call_sid, params)
+        # Legacy Plivo transfer — no longer used with MPC dial-first flow
+        logger.warning(
+            f"[TRANSFER DIAL-UP] Legacy dial-up called for {call_sid} — "
+            "MPC transfer should use mpc-transfer callback instead"
+        )
+        return HTMLResponse(
+            content='<?xml version="1.0" encoding="UTF-8"?><Response><Hangup/></Response>',
+            media_type="application/xml",
+        )
 
     # Exotel — return agent phone number as plain text
     return await exotel_dial_text(transfer_data)


### PR DESCRIPTION
  - Replace calls.transfer() + <Dial> XML with MultiPartyCall add_participant()
  - Agent dialed into MPC first, customer stays on Stream until agent answers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved warm transfer reliability by coordinating human transfers with an MPC-based flow, including automatic unavailability handling with a timed fallback.
  * Updated transfer outcome handling and callback routing to properly support new MPC transfer events (while safely hanging up for legacy dial-up behavior).
  * Enhanced auditability by recording the actual function handler results and improved transfer-related pub/sub logging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->