### PR TITLE
fix: allow reseller_id change via template PUT + reject empty reseller_id on create

### DIFF
--- a/app/ai/voice/agents/breeze_buddy/template/types.py
+++ b/app/ai/voice/agents/breeze_buddy/template/types.py
@@ -3,7 +3,7 @@ Pydantic models for the dynamic workflow engine.
 """
 
 from enum import Enum
-from typing import Any, Dict, List, Literal, Optional, Union
+from typing import Annotated, Any, Dict, List, Literal, Optional, Union
 
 from pydantic import (
     BaseModel,
@@ -11,6 +11,7 @@ from pydantic import (
     Field,
     SecretStr,
     SerializationInfo,
+    StringConstraints,
     field_serializer,
     model_validator,
 )
@@ -2040,9 +2041,15 @@ class RequestFlowNode(BaseModel):
     functions: List[RequestFlowFunction] = []
 
 
+# A template with reseller_id "" is unreachable by every reseller-scoped
+# lookup (RBAC filters, get-by-name resolution, config fallback), so reject
+# empty / whitespace-only values at the schema boundary.
+ResellerId = Annotated[str, StringConstraints(strip_whitespace=True, min_length=1)]
+
+
 class CreateTemplateRequest(BaseModel):
     # New field names
-    reseller_id: str
+    reseller_id: ResellerId
     name: str
     merchant_id: Optional[str] = None
     outbound_number_id: Optional[str] = None
@@ -2064,7 +2071,7 @@ class ReplaceTemplateRequest(BaseModel):
     IMPORTANT — GET-to-PUT contract:
     This model uses extra="ignore" so that a GET /templates/{id} response can be
     sent directly to PUT /templates/{id} after editing. Read-only fields returned
-    by GET (id, merchant_id, created_at, updated_at) are automatically stripped.
+    by GET (id, created_at, updated_at) are automatically stripped.
     When adding new read-only fields to TemplateModel, do NOT add them here —
     they will be safely ignored. When adding new editable fields, add them to
     BOTH TemplateModel and this model with the SAME field name.
@@ -2072,6 +2079,12 @@ class ReplaceTemplateRequest(BaseModel):
     Non-nullable fields (name, flow, is_active) must be provided - throws 400 if not.
     Nullable fields (merchant_id, outbound_number_id, expected_payload_schema,
     expected_callback_response_schema, configurations) - if not provided, set to NULL.
+
+    ``reseller_id`` is optional (``None`` default) for backward compatibility:
+    pre-existing PUT clients never sent it (it used to be silently ignored), so
+    omitting it preserves the persisted value. When provided it must be
+    non-empty and the template is moved to that reseller — handler re-validates
+    RBAC against the destination and checks for name collisions there.
 
     ``supported_channels`` is intentionally optional (``None`` default) rather
     than defaulting to ``['voice']``: pre-chat-feature PUT clients have no
@@ -2081,9 +2094,10 @@ class ReplaceTemplateRequest(BaseModel):
     """
 
     # extra="ignore" allows clients to pass the full GET response body to PUT;
-    # read-only fields (id, merchant_id, created_at, updated_at) are auto-stripped.
+    # read-only fields (id, created_at, updated_at) are auto-stripped.
     model_config = ConfigDict(extra="ignore")
 
+    reseller_id: Optional[ResellerId] = None
     name: str
     merchant_id: Optional[str] = None
     outbound_number_id: Optional[str] = None

--- a/app/api/routers/breeze_buddy/templates/__init__.py
+++ b/app/api/routers/breeze_buddy/templates/__init__.py
@@ -196,11 +196,16 @@ async def replace_template(
     expected_payload_schema, expected_callback_response_schema, configurations)
     - if not provided, they will be set to NULL.
 
+    reseller_id is optional: if omitted, the persisted value is kept; if
+    provided (non-empty), the template is moved to that reseller (requires
+    access to the destination reseller, 409 on name collision there).
+
     Path Parameters:
     - template_id: Template UUID
 
     Request Body:
         {
+            "reseller_id": "reseller_id",
             "name": "updated-template-name",
             "merchant_id": "merchant_id",
             "outbound_number_id": "uuid",
@@ -217,6 +222,8 @@ async def replace_template(
     Raises:
         - 404: Template not found
         - 400: Validation error (missing required fields)
+        - 403: No access to the current or destination reseller
+        - 409: Another template with the same reseller/merchant/name exists
     """
     return await replace_template_handler(template_id, template_data, current_user)
 

--- a/app/api/routers/breeze_buddy/templates/handlers.py
+++ b/app/api/routers/breeze_buddy/templates/handlers.py
@@ -398,6 +398,45 @@ async def replace_template_handler(
             operation="access template",
         )
 
+        # Resolve the target reseller. ``None`` (field omitted) preserves the
+        # persisted value — older PUT clients never sent reseller_id. When the
+        # template moves to a different reseller, the user must also have
+        # rights on the destination.
+        reseller_id = (
+            template_data.reseller_id
+            if template_data.reseller_id is not None
+            else existing_template.reseller_id
+        )
+        if reseller_id != existing_template.reseller_id:
+            validate_template_access(
+                current_user,
+                reseller_id,
+                template_data.merchant_id,
+                operation="move template to reseller",
+            )
+
+        # If the (reseller, merchant, name) identity changes, it must not
+        # collide with another template — the DB unique indexes would
+        # otherwise reject the UPDATE and surface as an opaque 500.
+        identity_changed = (
+            reseller_id != existing_template.reseller_id
+            or template_data.merchant_id != existing_template.merchant_id
+            or template_data.name != existing_template.name
+        )
+        if identity_changed:
+            conflicting = await get_template_by_merchant(
+                reseller_id,
+                template_data.merchant_id,
+                template_data.name,
+                should_prioritize_merchant_specific=False,
+            )
+            if conflicting and str(conflicting.id) != str(template_id):
+                raise HTTPException(
+                    status_code=status.HTTP_409_CONFLICT,
+                    detail=f"Template already exists for reseller {reseller_id} "
+                    f"and template name: {template_data.name}",
+                )
+
         # Validate flow structure (direct mode has a different shape — see
         # the create handler for the matching branch).
         flow = template_data.flow
@@ -485,6 +524,7 @@ async def replace_template_handler(
 
         updated_template = await replace_template(
             template_id=template_id,
+            reseller_id=reseller_id,
             name=template_data.name,
             flow=flow,
             expected_payload_schema=template_data.expected_payload_schema,

--- a/app/database/accessor/breeze_buddy/template.py
+++ b/app/database/accessor/breeze_buddy/template.py
@@ -362,6 +362,7 @@ async def get_template_by_id(template_id: str) -> Optional[TemplateModel]:
 
 async def replace_template(
     template_id: str,
+    reseller_id: str,
     name: str,
     flow: dict,
     expected_payload_schema: Optional[dict],
@@ -379,6 +380,8 @@ async def replace_template(
 
     Args:
         template_id: Template UUID
+        reseller_id: Reseller identifier (required, caller resolves omitted values
+            to the persisted one)
         name: Template name (required)
         flow: Flow structure (required)
         expected_payload_schema: Expected payload schema (optional, set to NULL if not provided)
@@ -419,6 +422,7 @@ async def replace_template(
 
         query, values = replace_template_query(
             template_id,
+            reseller_id,
             name,
             flow_json,
             expected_payload_schema_json,

--- a/app/database/queries/breeze_buddy/template.py
+++ b/app/database/queries/breeze_buddy/template.py
@@ -328,6 +328,7 @@ def check_template_usage_query(template_id: str) -> Tuple[str, List[Any]]:
 
 def replace_template_query(
     template_id: str,
+    reseller_id: str,
     name: str,
     flow: str,
     expected_payload_schema: Optional[str],
@@ -345,6 +346,7 @@ def replace_template_query(
 
     Args:
         template_id: Template UUID
+        reseller_id: Reseller identifier (required)
         name: Template name (required)
         flow: Flow JSON string (required)
         expected_payload_schema: Expected payload schema JSON string or None
@@ -370,10 +372,11 @@ def replace_template_query(
             secrets = $6::jsonb,
             outbound_number_id = $7,
             is_active = $8,
-            merchant_id = $9,
-            supported_channels = $10,
-            updated_at = $11
-        WHERE id = $12
+            reseller_id = $9,
+            merchant_id = $10,
+            supported_channels = $11,
+            updated_at = $12
+        WHERE id = $13
         RETURNING id,
                   reseller_id,
                   merchant_id,
@@ -389,6 +392,7 @@ def replace_template_query(
         secrets,
         outbound_number_id,
         is_active,
+        reseller_id,
         merchant_id,
         supported_channels,
         updated_at,


### PR DESCRIPTION
## Problem

`PUT /templates/{id}` silently drops `reseller_id` from the request body, and `POST /templates` accepts `reseller_id: ""`. In prod this produced template `1706c221-…` (`airline-payment-failure-recovery`) with an empty `reseller_id` — unreachable by every reseller-scoped lookup (RBAC filters, get-by-name resolution, merchant→reseller config fallback) — with **no API path to repair it**, since the PUT returned 200 while ignoring the field.

Three stacked causes:
1. `ReplaceTemplateRequest` never declared `reseller_id`; `extra="ignore"` swallowed it without error
2. `replace_template_handler` never forwarded it to the accessor
3. `replace_template_query` never set the column (it only appeared in `RETURNING`)

## Fix

**PUT supports reseller_id (backward-compatible):**
- `ReplaceTemplateRequest.reseller_id: Optional[ResellerId] = None` — omitted ⇒ persisted value kept, so older PUT clients see zero behavior change
- On reseller change the handler re-validates RBAC against the **destination** reseller (`403` if no access)
- When the `(reseller, merchant, name)` identity changes, an explicit conflict check returns `409` instead of the opaque `500` the DB unique indexes (`uq_template_reseller_*`, migration 018) used to cause
- `reseller_id` wired through accessor `replace_template` → `replace_template_query` `UPDATE ... SET`

**Create guardrail:**
- Shared `ResellerId = Annotated[str, StringConstraints(strip_whitespace=True, min_length=1)]` type used by both `CreateTemplateRequest` (now required non-empty) and `ReplaceTemplateRequest` — empty/whitespace-only reseller ids are rejected with a 422 at the schema boundary

## Validation

- `uv run pyrefly check` — 0 errors
- black / isort / autoflake clean (pre-commit hook)
- Smoke-tested the models: PUT omitting the field preserves (`None`), `"breeze"` accepted, `""`/`"   "` rejected on both POST and PUT; GET→PUT roundtrip with read-only fields (`id`, `created_at`, `updated_at`) still ignored

## Notes

- A GET→PUT roundtrip of an *already-broken* row (`reseller_id: ""`) now fails validation instead of silently keeping the empty value — intentional: it forces assigning a real reseller, which is exactly the repair path this PR unlocks
- After deploy, the stuck prod template can be fixed with a plain PUT carrying `"reseller_id": "breeze"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional `reseller_id` support in template updates for backward compatibility; when omitted, the existing reseller assignment is preserved.

* **Bug Fixes**
  * Improved error handling with clear conflict detection (409 status) when template names collide, replacing generic database errors.
  * Enhanced access control validation when moving templates between resellers.

* **Documentation**
  * Clarified API documentation for `reseller_id` semantics and access requirements during template updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->