### PR TITLE
refactor(chat): extract _prepare_tools/_cycle_loop and _turn_sse_stream

### DIFF
--- a/app/ai/voice/agents/breeze_buddy/chat/agent.py
+++ b/app/ai/voice/agents/breeze_buddy/chat/agent.py
@@ -8,6 +8,7 @@ full architecture.
 
 import json
 import uuid
+from dataclasses import dataclass
 from typing import Any, AsyncIterator, Dict, List, Optional, Set, Tuple, cast
 
 from pipecat.adapters.schemas.tools_schema import ToolsSchema
@@ -73,6 +74,16 @@ from app.schemas.breeze_buddy.chat import ChatMessageRole
 # stops re-searching what it already found, which keeps real turns well under
 # this ceiling; 20 is headroom, not a target.
 _MAX_TOOL_CYCLES = 20
+
+
+@dataclass
+class _PreparedTools:
+    """Per-turn tool surface built once by ``_prepare_tools``."""
+
+    flow_config: Dict[str, Any]
+    global_funcs: List[FlowsFunctionSchema]
+    tool_retention: Optional[Dict[str, str]]
+    tool_projection: Optional[Dict[str, List[str]]]
 
 
 class ChatAgent:
@@ -197,6 +208,32 @@ class ChatAgent:
         history: List[Dict[str, Any]],
         current_node: Optional[str],
     ) -> AsyncIterator[SSEEvent]:
+        prep = await self._prepare_tools()
+        node = self._resolve_node(prep.flow_config, current_node)
+
+        # Persist user message before the LLM call so a crash mid-stream
+        # still leaves the user's input in history. We also write the
+        # canonical Anthropic-shape [text] block so the loader has a
+        # single source of truth on the next turn.
+        user_msg = await insert_chat_message(
+            session_id=self.session_id,
+            role=ChatMessageRole.USER,
+            content=user_content,
+            content_blocks=plain_text_blocks(user_content),
+        )
+        yield SSEEvent(
+            event="user_committed",
+            data={"idx": user_msg.idx if user_msg else None, "content": user_content},
+        )
+
+        context = self._seed_context(node, history, user_content, prep.global_funcs)
+        async for event in self._cycle_loop(context, node, prep):
+            yield event
+
+    async def _prepare_tools(self) -> _PreparedTools:
+        """Build the per-turn tool surface (flow config, wrapped handlers,
+        global + MCP functions, retention policy). Extracted from
+        ``_run_turn_inner`` so the seeding and the cycle loop stay readable."""
         flow_builder = FlowConfigBuilder(disabled_names=CHAT_DISABLED_NAMES, quiet=True)
         # Wrap before build_flow_config: _build_function_schema captures the
         # handler reference into a closure, so post-build wrapping is a no-op.
@@ -264,25 +301,25 @@ class ChatAgent:
                 if server.tool_context_projection:
                     tool_projection.update(server.tool_context_projection)
 
-        node = self._resolve_node(flow_config, current_node)
+        return _PreparedTools(
+            flow_config=flow_config,
+            global_funcs=global_funcs,
+            tool_retention=tool_retention or None,
+            tool_projection=tool_projection or None,
+        )
+
+    async def _cycle_loop(
+        self,
+        context: LLMContext,
+        node: Dict[str, Any],
+        prep: _PreparedTools,
+    ) -> AsyncIterator[SSEEvent]:
+        """The LLM ↔ tool loop for one turn, extracted from
+        ``_run_turn_inner``. ``context`` must already be seeded; this loop
+        drives LLM cycles and dispatches tool calls until the model
+        produces a user-facing reply (or the cycle cap trips)."""
+        global_funcs = prep.global_funcs
         node_name = cast(str, node["name"])
-
-        # Persist user message before the LLM call so a crash mid-stream
-        # still leaves the user's input in history. We also write the
-        # canonical Anthropic-shape [text] block so the loader has a
-        # single source of truth on the next turn.
-        user_msg = await insert_chat_message(
-            session_id=self.session_id,
-            role=ChatMessageRole.USER,
-            content=user_content,
-            content_blocks=plain_text_blocks(user_content),
-        )
-        yield SSEEvent(
-            event="user_committed",
-            data={"idx": user_msg.idx if user_msg else None, "content": user_content},
-        )
-
-        context = self._seed_context(node, history, user_content, global_funcs)
 
         assistant_text_chunks: List[str] = []
         # ui_ops accumulator (Sprint 1.7) — captures each SpecStream op the
@@ -300,8 +337,8 @@ class ChatAgent:
                 self._llm,
                 context,
                 log_label=f"chat#{self.session_id[:8]}",
-                tool_context_retention=tool_retention or None,
-                tool_context_projection=tool_projection or None,
+                tool_context_retention=prep.tool_retention,
+                tool_context_projection=prep.tool_projection,
             ):
                 if kind == "text":
                     text = cast(str, payload)

--- a/app/api/routers/breeze_buddy/chat/handlers.py
+++ b/app/api/routers/breeze_buddy/chat/handlers.py
@@ -574,113 +574,17 @@ async def send_chat_message_handler(
             t0=time.monotonic(),
         )
 
-        async def stream() -> AsyncIterator[str]:
-            # Register ourselves so /cancel can find and cancel this task
-            # cross-pod. The registration MUST happen inside the generator
-            # body (not in the outer handler) — the task that actually
-            # drives ``yield`` is the StreamingResponse iterator task, and
-            # that's the only one whose cancel() reliably propagates into
-            # ``agent.run_turn()``.
-            current_task = asyncio.current_task()
-            registered = False
-            if current_task is not None:
-                cancel_bus.register(session_id, current_task)
-                registered = True
-            try:
-                try:
-                    async for event in agent.run_turn(
-                        user_content=req.content,
-                        history=history,
-                        current_node=resume_node,
-                    ):
-                        turn_metrics.observe(event)
-                        yield format_sse(event)
-                except asyncio.CancelledError:
-                    # User clicked Stop. Emit a clean turn_end so the client
-                    # sees a structured end (the SDK's turn engine maps this
-                    # to ``turn-end: CANCELED`` and flips status back to
-                    # ready). Don't re-raise — letting CancelledError
-                    # propagate would tear down the StreamingResponse mid-
-                    # write, which Starlette logs as an error.
-                    #
-                    # Python 3.11+ asyncio gotcha: simply catching
-                    # CancelledError leaves the task's cancel-counter > 0,
-                    # so the NEXT await in this generator (the finally's
-                    # ``lock.release()``) is re-raised as CancelledError
-                    # before the Redis DEL goes out. Result: the lock stays
-                    # held until its 180s TTL and the next /message gets
-                    # 409. Calling ``uncancel()`` decrements the counter
-                    # so cleanup can complete. Symptom this fixes:
-                    # "cancelled by user" log fires, but follow-up sends
-                    # still see HTTP 409.
-                    if current_task is not None:
-                        try:
-                            current_task.uncancel()
-                        except AttributeError:
-                            # Python <3.11 — no uncancel; rely on the
-                            # ``shield`` in the finally below.
-                            pass
-                    logger.info(
-                        f"send_message stream for session {session_id} cancelled by user"
-                    )
-                    turn_metrics.status = "CANCELED"
-                    yield format_sse(
-                        SSEEvent(event="turn_end", data={"session_status": "CANCELED"})
-                    )
-                except Exception as exc:
-                    # Full exception (incl. SDK / DB internals) goes to logs; the
-                    # SSE payload is intentionally generic — provider stack traces,
-                    # internal URLs, and SQL strings should not reach the client.
-                    logger.error(
-                        f"send_message stream for session {session_id} crashed: {exc}",
-                        exc_info=True,
-                    )
-                    yield format_sse(
-                        SSEEvent(
-                            event="error",
-                            data={
-                                "code": "internal",
-                                "message": "Internal server error",
-                            },
-                        )
-                    )
-                    turn_metrics.status = "FAILED"
-                    yield format_sse(
-                        SSEEvent(event="turn_end", data={"session_status": "FAILED"})
-                    )
-            finally:
-                turn_metrics.emit()
-                if registered and current_task is not None:
-                    cancel_bus.unregister(session_id, current_task)
-                # Shield the release: on a natural client disconnect path
-                # (Starlette cancels the generator without our explicit
-                # except-CancelledError running), the bare ``await
-                # lock.release()`` would be re-cancelled before the Redis
-                # DEL goes out. ``shield`` lets the DEL complete; the
-                # surrounding cancellation still propagates afterwards.
-                try:
-                    await asyncio.shield(lock.release())
-                except asyncio.CancelledError:
-                    # Cancellation arrived after the shielded release
-                    # already kicked off. Don't swallow it — re-raise so
-                    # the generator exits cleanly.
-                    raise
-                except Exception as release_exc:
-                    logger.warning(
-                        f"send_message stream for session {session_id}: "
-                        f"lock release failed in finally: {release_exc}"
-                    )
-                # Best-effort: mirror this turn's metrics into
-                # chat_turn_metrics (migration 032) so the conversational-log
-                # UI can show latency per turn without querying logs. Last in
-                # the finally — after lock release — so a DB blip never delays
-                # releasing the lock. No-op when the turn produced no assistant
-                # row (assistant_idx None); the [CHAT_METRICS] log already
-                # captured it either way.
-                await _persist_turn_metrics(turn_metrics)
-
         response = StreamingResponse(
-            stream(),
+            _turn_sse_stream(
+                session_id=session_id,
+                lock=lock,
+                turn_metrics=turn_metrics,
+                events=agent.run_turn(
+                    user_content=req.content,
+                    history=history,
+                    current_node=resume_node,
+                ),
+            ),
             media_type="text/event-stream",
             headers={
                 "Cache-Control": "no-cache, no-transform",
@@ -693,6 +597,118 @@ async def send_chat_message_handler(
     finally:
         if not lock_handed_off:
             await lock.release()
+
+
+async def _turn_sse_stream(
+    *,
+    session_id: str,
+    lock: RedisLock,
+    turn_metrics: TurnMetrics,
+    events: AsyncIterator[SSEEvent],
+) -> AsyncIterator[str]:
+    """SSE generator scaffolding for a chat turn stream.
+
+    Owns the cancel-bus registration, CancelledError → ``turn_end
+    {CANCELED}`` mapping, generic error masking, the shielded lock
+    release, and the best-effort turn-metrics write.
+    """
+    # Register ourselves so /cancel can find and cancel this task
+    # cross-pod. The registration MUST happen inside the generator
+    # body (not in the outer handler) — the task that actually
+    # drives ``yield`` is the StreamingResponse iterator task, and
+    # that's the only one whose cancel() reliably propagates into
+    # the agent's turn generator.
+    current_task = asyncio.current_task()
+    registered = False
+    if current_task is not None:
+        cancel_bus.register(session_id, current_task)
+        registered = True
+    try:
+        try:
+            async for event in events:
+                turn_metrics.observe(event)
+                yield format_sse(event)
+        except asyncio.CancelledError:
+            # User clicked Stop. Emit a clean turn_end so the client
+            # sees a structured end (the SDK's turn engine maps this
+            # to ``turn-end: CANCELED`` and flips status back to
+            # ready). Don't re-raise — letting CancelledError
+            # propagate would tear down the StreamingResponse mid-
+            # write, which Starlette logs as an error.
+            #
+            # Python 3.11+ asyncio gotcha: simply catching
+            # CancelledError leaves the task's cancel-counter > 0,
+            # so the NEXT await in this generator (the finally's
+            # ``lock.release()``) is re-raised as CancelledError
+            # before the Redis DEL goes out. Result: the lock stays
+            # held until its 180s TTL and the next /message gets
+            # 409. Calling ``uncancel()`` decrements the counter
+            # so cleanup can complete. Symptom this fixes:
+            # "cancelled by user" log fires, but follow-up sends
+            # still see HTTP 409.
+            if current_task is not None:
+                try:
+                    current_task.uncancel()
+                except AttributeError:
+                    # Python <3.11 — no uncancel; rely on the
+                    # ``shield`` in the finally below.
+                    pass
+            logger.info(f"chat turn stream for session {session_id} cancelled by user")
+            turn_metrics.status = "CANCELED"
+            yield format_sse(
+                SSEEvent(event="turn_end", data={"session_status": "CANCELED"})
+            )
+        except Exception as exc:
+            # Full exception (incl. SDK / DB internals) goes to logs; the
+            # SSE payload is intentionally generic — provider stack traces,
+            # internal URLs, and SQL strings should not reach the client.
+            logger.error(
+                f"chat turn stream for session {session_id} crashed: {exc}",
+                exc_info=True,
+            )
+            yield format_sse(
+                SSEEvent(
+                    event="error",
+                    data={
+                        "code": "internal",
+                        "message": "Internal server error",
+                    },
+                )
+            )
+            turn_metrics.status = "FAILED"
+            yield format_sse(
+                SSEEvent(event="turn_end", data={"session_status": "FAILED"})
+            )
+    finally:
+        turn_metrics.emit()
+        if registered and current_task is not None:
+            cancel_bus.unregister(session_id, current_task)
+        # Shield the release: on a natural client disconnect path
+        # (Starlette cancels the generator without our explicit
+        # except-CancelledError running), the bare ``await
+        # lock.release()`` would be re-cancelled before the Redis
+        # DEL goes out. ``shield`` lets the DEL complete; the
+        # surrounding cancellation still propagates afterwards.
+        try:
+            await asyncio.shield(lock.release())
+        except asyncio.CancelledError:
+            # Cancellation arrived after the shielded release
+            # already kicked off. Don't swallow it — re-raise so
+            # the generator exits cleanly.
+            raise
+        except Exception as release_exc:
+            logger.warning(
+                f"chat turn stream for session {session_id}: "
+                f"lock release failed in finally: {release_exc}"
+            )
+        # Best-effort: mirror this turn's metrics into
+        # chat_turn_metrics (migration 032) so the conversational-log
+        # UI can show latency per turn without querying logs. Last in
+        # the finally — after lock release — so a DB blip never delays
+        # releasing the lock. No-op when the turn produced no assistant
+        # row (assistant_idx None); the [CHAT_METRICS] log already
+        # captured it either way.
+        await _persist_turn_metrics(turn_metrics)
 
 
 async def cancel_chat_turn_handler(session_id: str) -> None:


### PR DESCRIPTION
**HITL approval stack 2/7** — based on #820.

No behavior change. \`ChatAgent._run_turn_inner\` was one ~300-line method mixing per-turn tool-surface construction, context seeding, and the LLM↔tool cycle loop; the handler inlined the SSE generator scaffolding inside \`send_chat_message_handler\`.

- \`_prepare_tools()\` builds the per-turn tool surface (\`_PreparedTools\`)
- \`_cycle_loop()\` drives the LLM↔tool loop over a seeded context
- \`_turn_sse_stream()\` owns the SSE stream scaffolding (cancel-bus registration, CancelledError→\`turn_end {CANCELED}\` mapping incl. the \`uncancel()\` lock fix, shielded lock release, metrics write — ordering preserved exactly)

Groundwork for reusing the loop and stream scaffolding from additional turn entry points (the approval resume turn, PR 6–7 of this stack).

**Reviewer note**: three operator-visible log strings are renamed \`send_message stream …\` → \`chat turn stream …\` (the helper becomes shared by \`/message\` and \`/approval\` later in the stack). If any alert/grep keys on the old strings, update it. SSE wire bytes, DB writes, and lock lifecycle are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)