### PR TITLE
feat(template): ApprovalConfig + generic approval gate for global functions

### DIFF
--- a/app/ai/voice/agents/breeze_buddy/template/approval.py
+++ b/app/ai/voice/agents/breeze_buddy/template/approval.py
@@ -1,0 +1,215 @@
+"""
+Human-in-the-loop approval gate for global functions.
+
+A template author marks a global function (HTTP / builtin / custom) as gated
+by adding an ``approval`` config to it (see ApprovalConfig in types.py). When
+the LLM calls a gated function, execution is held until an explicit end-user
+decision:
+
+- Chat: ChatAgent gates pre-dispatch (Pattern B — the turn ends at the gate
+  and the decision arrives on a dedicated endpoint), so the in-handler gate
+  below is bypassed via the ``handles_approval_externally`` flag.
+- Voice (Daily): the gate blocks in-process on the bot's ApprovalManager
+  (Pattern C); the decision arrives as an RTVI client message.
+- Telephony: no approval surface exists — ``approval.on_no_channel`` applies.
+- Daily WITHOUT a working approval channel (e.g. RTVI disabled via
+  ENABLE_BREEZE_BUDDY_DAILY_EVENTS=false): always DENY. The surface that is
+  supposed to show an approval UI must never silently auto-execute.
+
+Denials materialize as an LLM-visible tool result so the model can react.
+"""
+
+from dataclasses import dataclass
+from typing import Any, Awaitable, Callable, Dict, Optional
+
+from app.ai.voice.agents.breeze_buddy.template.context import TemplateContext
+from app.ai.voice.agents.breeze_buddy.template.types import (
+    ApprovalConfig,
+    ApprovalOnNoChannel,
+    BaseGlobalFunction,
+)
+from app.core.logger import logger
+
+# LLM-visible statuses for gated calls that did not execute. These are what
+# the model reads in the tool result; the SSE/RTVI wire layer has its own
+# enum (approved|denied|timeout|cancelled|superseded).
+LLM_STATUS_DENIED = "denied"
+LLM_STATUS_TIMEOUT = "timeout"
+LLM_STATUS_NOT_DECIDED = "not_decided"
+
+# Wire statuses (shared vocabulary with the SDK — see plan wire contract).
+WIRE_STATUS_APPROVED = "approved"
+WIRE_STATUS_DENIED = "denied"
+WIRE_STATUS_TIMEOUT = "timeout"
+WIRE_STATUS_CANCELLED = "cancelled"
+WIRE_STATUS_SUPERSEDED = "superseded"
+
+_GLOBAL_FUNCTION_TYPES = {"http", "builtin", "custom"}
+
+
+@dataclass
+class ApprovalOutcome:
+    """Result of a voice approval wait (see agent/approval.py)."""
+
+    approved: bool
+    status: str  # wire status: approved | denied | timeout | superseded
+    reason: Optional[str] = None
+
+
+def denial_result(status: str, reason: str) -> Dict[str, str]:
+    """LLM-visible tool result for a gated call that did not execute."""
+    return {"status": status, "reason": reason}
+
+
+async def gate_global_function(
+    bot_instance: Any,
+    func: BaseGlobalFunction,
+    llm_args: Dict[str, Any],
+    execute: Callable[[], Awaitable[Any]],
+) -> Any:
+    """Run ``execute()`` only after the function's approval gate clears.
+
+    ``execute`` carries the full call side effects (filler audio, handler,
+    post-actions) — a denied call therefore plays no filler and fires no
+    side effects.
+
+    CancelledError from the approval wait (user barge-in on a sync gated
+    function, or pipeline teardown) propagates — pipecat's aggregator
+    records the call as CANCELLED and never re-invokes the handler.
+    """
+    approval = getattr(func, "approval", None)
+    if approval is None:
+        return await execute()
+
+    # Chat gates pre-dispatch in ChatAgent._cycle_loop; checking this flag
+    # FIRST prevents double-gating (ChatAgent never has an approval_manager,
+    # but the explicit flag keeps the contract obvious).
+    if getattr(bot_instance, "handles_approval_externally", False):
+        return await execute()
+
+    manager = getattr(bot_instance, "approval_manager", None)
+    if manager is None:
+        if getattr(bot_instance, "is_daily_mode", False):
+            # Channel expected but unavailable (e.g. RTVI disabled by env
+            # flag). Never auto-execute a gated function here.
+            logger.error(
+                f"[approval] '{func.name}' is approval-gated but this daily "
+                "bot has no approval channel (RTVI unavailable — check "
+                "ENABLE_BREEZE_BUDDY_DAILY_EVENTS). Denying."
+            )
+            return denial_result(LLM_STATUS_DENIED, "approval_channel_unavailable")
+
+        # Telephony: no approval surface can exist.
+        if approval.on_no_channel == ApprovalOnNoChannel.DENY:
+            logger.warning(
+                f"[approval] '{func.name}' denied on a channel with no "
+                "approval surface (on_no_channel=deny)."
+            )
+            return denial_result(LLM_STATUS_DENIED, "no_approval_channel")
+
+        logger.warning(
+            f"[approval] EXECUTING approval-gated function '{func.name}' "
+            "WITHOUT human approval — no approval surface on this channel "
+            "(telephony) and on_no_channel=execute. "
+            f"args_keys={sorted(llm_args.keys()) if llm_args else []}"
+        )
+        return await execute()
+
+    # Voice gate: optional spoken announcement, then block on the decision.
+    if approval.voice_announce:
+        try:
+            await TemplateContext(bot_instance).queue_tts_filler(
+                approval.voice_announce
+            )
+        except Exception as e:
+            logger.warning(f"[approval] Failed to queue voice_announce: {e}")
+
+    outcome: ApprovalOutcome = await manager.request(func.name, llm_args, approval)
+    if outcome.approved:
+        return await execute()
+
+    # Channel-consistent LLM statuses: superseded is NOT a refusal (a newer
+    # request replaced this one — chat's supersede uses the same status so
+    # the model never verbalizes "okay, I won't do X" for a moved-on call).
+    if outcome.status == WIRE_STATUS_TIMEOUT:
+        llm_status = LLM_STATUS_TIMEOUT
+    elif outcome.status == WIRE_STATUS_SUPERSEDED:
+        llm_status = LLM_STATUS_NOT_DECIDED
+    else:
+        llm_status = LLM_STATUS_DENIED
+    return denial_result(
+        llm_status,
+        outcome.reason or "the user did not approve this action",
+    )
+
+
+def build_approval_map(flow: Any) -> Dict[str, ApprovalConfig]:
+    """Map function name -> ApprovalConfig for every gated global function.
+
+    Mirrors how GlobalFunctionRegistry discovers functions:
+    - flow mode: top-level ``global_functions``
+    - direct mode: flat ``functions`` entries with type http/builtin/custom,
+      honoring the ``function_name`` -> ``name`` alias (builder.py routing)
+
+    Also warns on unsupported placements so template authors are not
+    silently surprised:
+    - ``approval`` on a per-node function (not supported in v1, ignored)
+    - a gated global whose name is shadowed by a per-node function (chat
+      gates the call by name pre-dispatch, voice's wrapper gate only wraps
+      globals — silent channel divergence)
+    """
+    approval_map: Dict[str, ApprovalConfig] = {}
+    if not isinstance(flow, dict):
+        return approval_map
+
+    def _scan_entry(entry: Any, source: str) -> None:
+        if not isinstance(entry, dict) or entry.get("approval") is None:
+            return
+        name = entry.get("name") or entry.get("function_name")
+        if not name:
+            logger.warning(
+                f"[approval] Ignoring approval config on a nameless " f"{source} entry"
+            )
+            return
+        try:
+            approval_map[name] = ApprovalConfig.model_validate(entry["approval"])
+        except Exception as e:
+            logger.warning(
+                f"[approval] Ignoring malformed approval config on "
+                f"'{name}' ({source}): {e}"
+            )
+
+    for entry in flow.get("global_functions") or []:
+        _scan_entry(entry, "global_functions")
+
+    for entry in flow.get("functions") or []:
+        if isinstance(entry, dict) and entry.get("type") in _GLOBAL_FUNCTION_TYPES:
+            _scan_entry(entry, "functions (direct mode)")
+
+    node_function_names = set()
+    for node in flow.get("nodes") or []:
+        if not isinstance(node, dict):
+            continue
+        for fn in node.get("functions") or []:
+            if not isinstance(fn, dict):
+                continue
+            fn_name = fn.get("name") or fn.get("function_name")
+            if fn_name:
+                node_function_names.add(fn_name)
+            if fn.get("approval") is not None:
+                logger.warning(
+                    f"[approval] 'approval' on per-node function "
+                    f"'{fn_name}' is not supported in v1; ignored. Move the "
+                    "function to global_functions to gate it."
+                )
+
+    for gated_name in approval_map:
+        if gated_name in node_function_names:
+            logger.warning(
+                f"[approval] Gated global '{gated_name}' is shadowed by a "
+                "per-node function of the same name: chat will gate the "
+                "shadowing per-node function (name-keyed), voice will not "
+                "(wrapper gate only wraps globals)."
+            )
+
+    return approval_map

--- a/app/ai/voice/agents/breeze_buddy/template/field_reference.json
+++ b/app/ai/voice/agents/breeze_buddy/template/field_reference.json
@@ -101,7 +101,8 @@
     "post_actions":          { "description": "Actions after the handler completes. JSON key 'post_actions' (Python alias for func_post_actions). See FlowAction.", "example": [] },
     "cancel_on_interruption": { "description": "false (http default): LLM keeps talking while the function runs. true (builtin default): LLM waits for the function. null = use type default. Override per-function only when the type default is wrong.", "example": null },
     "timeout_secs":          { "description": "Per-function timeout override in seconds. Null uses the LLM service's global default. Set for known-slow functions (e.g. SSE streaming).", "example": 30.0 },
-    "response_transforms":   { "description": "In-place transforms applied to the tool result before the LLM sees it. Each entry is a registered transform name. Applied after expected_response_schema projection.", "example": [] }
+    "response_transforms":   { "description": "In-place transforms applied to the tool result before the LLM sees it. Each entry is a registered transform name. Applied after expected_response_schema projection.", "example": [] },
+    "approval":              { "description": "Require human approval before this function executes (HITL). Presence gates the call: in chat the turn pauses at the gated call and resumes on the approval endpoint; in Daily voice the handler waits on an in-process approval; telephony falls back to on_no_channel. Omit to execute immediately.", "example": { "prompt": "Approve issuing a refund of {amount} to {customer}?", "voice_announce": "I need your approval to issue this refund.", "timeout_secs": 120, "chat_expiry_secs": 3600, "on_no_channel": "execute" } }
   },
 
   "GlobalHttpFunction": {

--- a/app/ai/voice/agents/breeze_buddy/template/global_function.py
+++ b/app/ai/voice/agents/breeze_buddy/template/global_function.py
@@ -17,6 +17,7 @@ from typing import Any, Callable, Dict, List, Optional, Protocol, runtime_checka
 
 from pipecat_flows import FlowsFunctionSchema
 
+from app.ai.voice.agents.breeze_buddy.template.approval import gate_global_function
 from app.ai.voice.agents.breeze_buddy.template.context import TemplateContext
 from app.ai.voice.agents.breeze_buddy.template.func_action_handlers import (
     execute_func_post_actions,
@@ -35,6 +36,12 @@ from app.ai.voice.agents.breeze_buddy.utils.parser import (
 from app.core.config.static import GLOBAL_FUNCTION_DESCRIPTION_SUFFIX
 from app.core.logger import logger
 
+# Execution budget assumed for a handler whose template sets no explicit
+# timeout_secs, used when sizing the watchdog for approval-gated functions.
+# Must be >= the LLM services' function_call_timeout_secs default (10s).
+_APPROVAL_EXEC_FALLBACK_SECS = 60.0
+_APPROVAL_BUDGET_MARGIN_SECS = 15.0
+
 
 def _flows_async_kwargs(func: BaseGlobalFunction) -> Dict[str, Any]:
     """Per-function pipecat-flows 1.0 kwargs, opt-in via template config.
@@ -46,13 +53,72 @@ def _flows_async_kwargs(func: BaseGlobalFunction) -> Dict[str, Any]:
     therefore controlled by the per-subclass model defaults — `GlobalHttp
     Function` defaults to async (False) for slow APIs and `GlobalBuiltin
     Function` defaults to sync (True) for control-flow critical handlers.
+
+    Approval-gated functions get an ADDITIVE watchdog budget (approval wait
+    + execution + margin), never max(): pipecat's watchdog does NOT cancel
+    the handler — it fires result_callback(None), the aggregator marks the
+    call COMPLETED, and any later real result is dropped while the side
+    effect still executes. An undersized budget therefore means a silent
+    bot, a dropped result, and a possible LLM retry / duplicate execution.
     """
     extra: Dict[str, Any] = {}
     if func.cancel_on_interruption is not None:
         extra["cancel_on_interruption"] = func.cancel_on_interruption
     if func.timeout_secs is not None:
         extra["timeout_secs"] = func.timeout_secs
+    if func.approval is not None:
+        exec_budget = (
+            func.timeout_secs
+            if func.timeout_secs is not None
+            else _APPROVAL_EXEC_FALLBACK_SECS
+        )
+        extra["timeout_secs"] = (
+            func.approval.timeout_secs + exec_budget + _APPROVAL_BUDGET_MARGIN_SECS
+        )
     return extra
+
+
+def _make_global_wrapper(
+    func: BaseGlobalFunction,
+    wrapped_handler: Callable,
+    bot_instance: Any,
+) -> Callable:
+    """Build the outer handler shared by all global function adapters.
+
+    Execution side effects (filler phrase, background music, fire-and-forget
+    func_post_actions) live INSIDE the ``execute`` closure handed to the
+    approval gate, so a denied/timed-out gated call plays no filler and
+    fires no post-actions. On the approve path the behavior is identical to
+    the pre-refactor wrappers: filler/music start, handler runs, music stops
+    (even on error), post-actions fire on the result.
+    """
+
+    async def wrapper_handler(llm_args, flow_manager):
+        async def execute() -> Any:
+            await _run_filler_and_music(bot_instance, func)
+            try:
+                result = await wrapped_handler(
+                    llm_args,
+                    function_config=func,
+                )
+            finally:
+                # Always stop music even if handler errors
+                await _stop_music(bot_instance, func)
+
+            if func.func_post_actions and bot_instance:
+                asyncio.create_task(
+                    execute_func_post_actions(
+                        bot_instance,
+                        result,
+                        func.func_post_actions,
+                        func.name,
+                    )
+                )
+            return result
+
+        return await gate_global_function(bot_instance, func, llm_args, execute)
+
+    return wrapper_handler
 
 
 async def _run_filler_and_music(
@@ -254,49 +320,10 @@ class HttpGlobalFunctionAdapter:
             f"http_request={func.http_request.method.value} {func.http_request.url}"
         )
 
-        # Create outer wrapper that passes function_config via kwargs
-        # This follows the same pattern as normal functions passing transition_to, hooks, etc.
-        def create_wrapper(
-            captured_func: GlobalHttpFunction, captured_bot_instance: Any
-        ):
-            async def wrapper_handler(llm_args, flow_manager):
-                """
-                Outer wrapper for global HTTP function.
-
-                1. Runs filler phrase TTS + enables background music (if configured)
-                2. Calls the wrapped handler (with_context wrapper) passing function_config
-                3. Disables background music after handler returns
-                4. Fires post-actions (fire-and-forget)
-                """
-                # Pre-call: filler phrase + background music
-                await _run_filler_and_music(captured_bot_instance, captured_func)
-
-                try:
-                    result = await wrapped_handler(
-                        llm_args,
-                        function_config=captured_func,
-                    )
-                finally:
-                    # Post-call: always stop music even if handler errors
-                    await _stop_music(captured_bot_instance, captured_func)
-
-                if captured_func.func_post_actions and captured_bot_instance:
-                    asyncio.create_task(
-                        execute_func_post_actions(
-                            captured_bot_instance,
-                            result,
-                            captured_func.func_post_actions,
-                            captured_func.name,
-                        )
-                    )
-                return result
-
-            return wrapper_handler
-
         return FlowsFunctionSchema(
             name=func.name,
             description=enhanced_description,
-            handler=create_wrapper(func, bot_instance),
+            handler=_make_global_wrapper(func, wrapped_handler, bot_instance),
             properties=func.properties,
             required=func.required,
             **_flows_async_kwargs(func),
@@ -367,47 +394,10 @@ class BuiltinGlobalFunctionAdapter:
             f"Building builtin global function: {func.name}, handler={func.handler}"
         )
 
-        def create_wrapper(
-            captured_func: GlobalBuiltinFunction, captured_bot_instance: Any
-        ):
-            async def wrapper_handler(llm_args, flow_manager):
-                """
-                Outer wrapper for built-in global function.
-
-                1. Runs filler phrase TTS + enables background music (if configured)
-                2. Passes function_config to the dispatcher via kwargs
-                3. Disables background music after handler returns
-                4. Fires post-actions (fire-and-forget)
-                """
-                # Pre-call: filler phrase + background music
-                await _run_filler_and_music(captured_bot_instance, captured_func)
-
-                try:
-                    result = await wrapped_handler(
-                        llm_args,
-                        function_config=captured_func,
-                    )
-                finally:
-                    # Post-call: always stop music even if handler errors
-                    await _stop_music(captured_bot_instance, captured_func)
-
-                if captured_func.func_post_actions and captured_bot_instance:
-                    asyncio.create_task(
-                        execute_func_post_actions(
-                            captured_bot_instance,
-                            result,
-                            captured_func.func_post_actions,
-                            captured_func.name,
-                        )
-                    )
-                return result
-
-            return wrapper_handler
-
         return FlowsFunctionSchema(
             name=func.name,
             description=enhanced_description,
-            handler=create_wrapper(func, bot_instance),
+            handler=_make_global_wrapper(func, wrapped_handler, bot_instance),
             properties=func.properties,
             required=func.required,
             **_flows_async_kwargs(func),
@@ -495,45 +485,10 @@ class CustomPythonGlobalFunctionAdapter:
             f"timeout={func.timeout_seconds}s"
         )
 
-        def create_wrapper(
-            captured_func: GlobalCustomFunction, captured_bot_instance: Any
-        ):
-            async def wrapper_handler(llm_args, flow_manager):
-                """
-                Outer wrapper for custom Python global function.
-
-                Passes function_config (with compiled_handler) to the handler.
-                The with_context wrapper extracts function_config and passes
-                it to custom_python_code_handler.
-                """
-                # Pre-call: filler phrase + background music
-                await _run_filler_and_music(captured_bot_instance, captured_func)
-
-                try:
-                    result = await wrapped_handler(
-                        llm_args,
-                        function_config=captured_func,
-                    )
-                finally:
-                    # Post-call: always stop music even if handler errors
-                    await _stop_music(captured_bot_instance, captured_func)
-                if captured_func.func_post_actions and captured_bot_instance:
-                    asyncio.create_task(
-                        execute_func_post_actions(
-                            captured_bot_instance,
-                            result,
-                            captured_func.func_post_actions,
-                            captured_func.name,
-                        )
-                    )
-                return result
-
-            return wrapper_handler
-
         return FlowsFunctionSchema(
             name=func.name,
             description=enhanced_description,
-            handler=create_wrapper(func, bot_instance),
+            handler=_make_global_wrapper(func, wrapped_handler, bot_instance),
             properties=func.properties,
             required=func.required,
             **_flows_async_kwargs(func),

--- a/app/ai/voice/agents/breeze_buddy/template/types.py
+++ b/app/ai/voice/agents/breeze_buddy/template/types.py
@@ -1693,6 +1693,67 @@ class GlobalFunctionType(str, Enum):
     CUSTOM = "custom"  # Future: custom Python function handlers
 
 
+class ApprovalOnNoChannel(str, Enum):
+    """Fallback behavior for approval-gated functions on channels with no
+    approval surface (telephony). Daily/web voice without a working approval
+    channel always denies and never consults this setting."""
+
+    EXECUTE = "execute"
+    DENY = "deny"
+
+
+class ApprovalConfig(BaseModel):
+    """Human-in-the-loop approval for a global function.
+
+    Presence of this config on a function marks it as gated: the LLM may call
+    the function, but execution waits for an explicit end-user decision.
+
+    Channel behavior:
+    - Chat: the turn ends at the gated call (`turn_end` carries
+      ``awaiting_approval``); the decision arrives on the dedicated
+      ``POST .../session/{id}/approval`` endpoint which resumes the turn.
+    - Voice (Daily): the in-process handler blocks on an RTVI
+      ``function-approval-decision`` client message. Whether the bot keeps
+      conversing while waiting is governed by the function's existing
+      ``cancel_on_interruption`` flag (True = bot waits silently and any user
+      utterance cancels the request; False = async call, the bot keeps
+      talking and the decision may arrive minutes later).
+    - Telephony: no approval surface exists; ``on_no_channel`` applies.
+    """
+
+    prompt: Optional[str] = Field(
+        None,
+        description="Human-facing text shown on the approval card. Note: the "
+        "post-injection arguments that will actually run are shown to the "
+        "end user alongside this prompt.",
+    )
+    voice_announce: Optional[str] = Field(
+        None,
+        description="Optional phrase spoken (queue_tts_filler) when the voice "
+        "gate starts waiting, e.g. 'I need your approval for this refund.' "
+        "None = no spoken announcement (the visual card is the only cue).",
+    )
+    timeout_secs: float = Field(
+        120,
+        gt=0,
+        description="VOICE-only: how long the in-process gate waits for a "
+        "decision before resolving as timeout. Must stay below the pipeline "
+        "idle timeout (300s) and the template's user-idle end-call budget.",
+    )
+    chat_expiry_secs: float = Field(
+        3600,
+        gt=0,
+        description="CHAT-only: TTL for the pending approval card "
+        "(expires_at). Decoupled from the voice wait — chat blocks nothing "
+        "server-side, so this can be generous.",
+    )
+    on_no_channel: ApprovalOnNoChannel = Field(
+        ApprovalOnNoChannel.EXECUTE,
+        description="TELEPHONY-only fallback when no approval surface exists: "
+        "'execute' (default; logs a loud warning) or 'deny'.",
+    )
+
+
 class BaseGlobalFunction(BaseModel):
     """Base model for all global function types.
 
@@ -1729,6 +1790,15 @@ class BaseGlobalFunction(BaseModel):
         default=None,
         description="Per-function timeout override in seconds. Falls back to "
         "the LLM service's function_call_timeout_secs when unset.",
+    )
+    approval: Optional[ApprovalConfig] = Field(
+        default=None,
+        description="Human-in-the-loop gate. When set, the function is "
+        "approval-gated: execution waits for an explicit end-user decision "
+        "(chat: dedicated approval endpoint resumes the turn; voice: RTVI "
+        "decision message). Interacts with cancel_on_interruption — True "
+        "means the bot blocks while waiting (and any user utterance cancels "
+        "the request), False means the bot keeps conversing (async call).",
     )
     response_transforms: List["ResponseTransform"] = Field(
         default_factory=list,

--- a/tests/test_approval_gate.py
+++ b/tests/test_approval_gate.py
@@ -1,0 +1,232 @@
+"""HITL approval gate — gate_global_function, _make_global_wrapper,
+and _flows_async_kwargs.
+
+Companion: [[template/approval.py]], [[template/global_function.py]] and
+the plan's review findings (additive watchdog budget; daily-without-channel
+must DENY; deny path must skip filler and post-actions). The voice
+ApprovalManager lifecycle is covered in tests/test_approval_manager.py.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any, Dict, List, Optional
+
+from app.ai.voice.agents.breeze_buddy.template.approval import (
+    ApprovalOutcome,
+    gate_global_function,
+)
+from app.ai.voice.agents.breeze_buddy.template.global_function import (
+    _flows_async_kwargs,
+    _make_global_wrapper,
+)
+from app.ai.voice.agents.breeze_buddy.template.types import GlobalBuiltinFunction
+
+
+def _builtin(approval: Optional[Dict[str, Any]] = None, **overrides):
+    cfg: Dict[str, Any] = {
+        "type": "builtin",
+        "name": "issue_refund",
+        "description": "Issue a refund",
+        "handler": "issue_refund_handler",
+    }
+    if approval is not None:
+        cfg["approval"] = approval
+    cfg.update(overrides)
+    return GlobalBuiltinFunction.model_validate(cfg)
+
+
+class _FakeManager:
+    """Scripted ApprovalManager stand-in for gate tests."""
+
+    def __init__(self, outcome: ApprovalOutcome):
+        self.outcome = outcome
+        self.requests: List[Dict[str, Any]] = []
+
+    async def request(self, function_name, arguments, config):
+        self.requests.append(
+            {"function_name": function_name, "arguments": arguments, "config": config}
+        )
+        return self.outcome
+
+
+class _FakeTask:
+    def __init__(self):
+        self.frames: List[Any] = []
+
+    async def queue_frame(self, frame):
+        self.frames.append(frame)
+
+
+async def _execute_recorder(record: List[str], result: Any = {"ok": True}):
+    async def execute():
+        record.append("executed")
+        return result
+
+    return execute
+
+
+# ---------------------------------------------------------------------------
+# gate_global_function
+# ---------------------------------------------------------------------------
+
+
+async def test_ungated_function_executes_directly():
+    record: List[str] = []
+    execute = await _execute_recorder(record)
+    result = await gate_global_function(SimpleNamespace(), _builtin(), {}, execute)
+    assert record == ["executed"]
+    assert result == {"ok": True}
+
+
+async def test_chat_agent_bypasses_in_handler_gate():
+    """ChatAgent gates pre-dispatch — the wrapper gate must pass through."""
+    record: List[str] = []
+    execute = await _execute_recorder(record)
+    bot = SimpleNamespace(handles_approval_externally=True, approval_manager=None)
+    func = _builtin(approval={"prompt": "ok?"})
+    result = await gate_global_function(bot, func, {}, execute)
+    assert record == ["executed"]
+    assert result == {"ok": True}
+
+
+async def test_daily_without_channel_denies():
+    """A daily bot with no approval manager (RTVI off) must DENY — the
+    surface that's supposed to show an approval UI never auto-executes."""
+    record: List[str] = []
+    execute = await _execute_recorder(record)
+    bot = SimpleNamespace(is_daily_mode=True)
+    func = _builtin(approval={"prompt": "ok?", "on_no_channel": "execute"})
+    result = await gate_global_function(bot, func, {}, execute)
+    assert record == []
+    assert result == {"status": "denied", "reason": "approval_channel_unavailable"}
+
+
+async def test_telephony_on_no_channel_execute():
+    record: List[str] = []
+    execute = await _execute_recorder(record)
+    bot = SimpleNamespace(is_daily_mode=False)
+    func = _builtin(approval={"prompt": "ok?"})  # default on_no_channel=execute
+    result = await gate_global_function(bot, func, {"a": 1}, execute)
+    assert record == ["executed"]
+    assert result == {"ok": True}
+
+
+async def test_telephony_on_no_channel_deny():
+    record: List[str] = []
+    execute = await _execute_recorder(record)
+    bot = SimpleNamespace(is_daily_mode=False)
+    func = _builtin(approval={"on_no_channel": "deny"})
+    result = await gate_global_function(bot, func, {}, execute)
+    assert record == []
+    assert result == {"status": "denied", "reason": "no_approval_channel"}
+
+
+async def test_voice_approve_executes():
+    record: List[str] = []
+    execute = await _execute_recorder(record)
+    manager = _FakeManager(ApprovalOutcome(approved=True, status="approved"))
+    bot = SimpleNamespace(is_daily_mode=True, approval_manager=manager, task=None)
+    func = _builtin(approval={"prompt": "refund ok?"})
+    result = await gate_global_function(bot, func, {"x": 1}, execute)
+    assert record == ["executed"]
+    assert result == {"ok": True}
+    assert manager.requests[0]["function_name"] == "issue_refund"
+    assert manager.requests[0]["arguments"] == {"x": 1}
+
+
+async def test_voice_deny_returns_llm_visible_denial():
+    record: List[str] = []
+    execute = await _execute_recorder(record)
+    manager = _FakeManager(
+        ApprovalOutcome(approved=False, status="denied", reason="user said no")
+    )
+    bot = SimpleNamespace(is_daily_mode=True, approval_manager=manager, task=None)
+    func = _builtin(approval={"prompt": "ok?"})
+    result = await gate_global_function(bot, func, {}, execute)
+    assert record == []
+    assert result == {"status": "denied", "reason": "user said no"}
+
+
+async def test_voice_timeout_maps_to_timeout_status():
+    execute = await _execute_recorder([])
+    manager = _FakeManager(
+        ApprovalOutcome(
+            approved=False, status="timeout", reason="approval request timed out"
+        )
+    )
+    bot = SimpleNamespace(is_daily_mode=True, approval_manager=manager, task=None)
+    func = _builtin(approval={})
+    result = await gate_global_function(bot, func, {}, execute)
+    assert result["status"] == "timeout"
+
+
+async def test_voice_announce_queued_before_wait():
+    manager = _FakeManager(ApprovalOutcome(approved=False, status="denied"))
+    task = _FakeTask()
+    bot = SimpleNamespace(is_daily_mode=True, approval_manager=manager, task=task)
+    func = _builtin(approval={"voice_announce": "I need your approval."})
+    await gate_global_function(bot, func, {}, await _execute_recorder([]))
+    assert len(task.frames) == 1
+    assert task.frames[0].text == "I need your approval."
+
+
+# ---------------------------------------------------------------------------
+# _make_global_wrapper — deny must skip filler + post-actions entirely
+# ---------------------------------------------------------------------------
+
+
+async def test_wrapper_denied_call_never_invokes_handler():
+    calls: List[Any] = []
+
+    async def wrapped_handler(llm_args, function_config=None):
+        calls.append(llm_args)
+        return {"ok": True}
+
+    manager = _FakeManager(ApprovalOutcome(approved=False, status="denied"))
+    bot = SimpleNamespace(is_daily_mode=True, approval_manager=manager, task=None)
+    func = _builtin(approval={"prompt": "ok?"})
+    wrapper = _make_global_wrapper(func, wrapped_handler, bot)
+    result = await wrapper({"q": 1}, None)
+    assert calls == []
+    assert result["status"] == "denied"
+
+
+async def test_wrapper_approved_call_invokes_handler_with_config():
+    seen: List[Any] = []
+
+    async def wrapped_handler(llm_args, function_config=None):
+        seen.append((llm_args, function_config))
+        return {"done": 1}
+
+    manager = _FakeManager(ApprovalOutcome(approved=True, status="approved"))
+    bot = SimpleNamespace(is_daily_mode=True, approval_manager=manager, task=None)
+    func = _builtin(approval={})
+    wrapper = _make_global_wrapper(func, wrapped_handler, bot)
+    result = await wrapper({"q": 1}, None)
+    assert result == {"done": 1}
+    assert seen[0][0] == {"q": 1}
+    assert seen[0][1] is func
+
+
+# ---------------------------------------------------------------------------
+# _flows_async_kwargs — ADDITIVE watchdog budget (never max())
+# ---------------------------------------------------------------------------
+
+
+def test_async_kwargs_passthrough_without_approval():
+    func = _builtin(timeout_secs=42.0)
+    assert _flows_async_kwargs(func)["timeout_secs"] == 42.0
+
+
+def test_async_kwargs_additive_budget_default_exec():
+    func = _builtin(approval={"timeout_secs": 120})
+    # 120 (wait) + 60 (exec fallback) + 15 (margin)
+    assert _flows_async_kwargs(func)["timeout_secs"] == 195.0
+
+
+def test_async_kwargs_additive_budget_with_func_timeout():
+    # A 119s approval wait must still leave the author's full 90s exec
+    # budget — max() would not (the review's watchdog finding).
+    func = _builtin(timeout_secs=90.0, approval={"timeout_secs": 120})
+    assert _flows_async_kwargs(func)["timeout_secs"] == 120 + 90 + 15

--- a/tests/test_approval_map.py
+++ b/tests/test_approval_map.py
@@ -1,0 +1,115 @@
+"""build_approval_map — discovery parity with GlobalFunctionRegistry.
+
+Covers: flow mode (global_functions), direct mode (flat functions with the
+function_name alias), malformed configs (skipped, never raise), unsupported
+per-node placement (ignored), and name shadowing (still mapped — chat gates
+by name; the builder logs the divergence warning).
+"""
+
+from __future__ import annotations
+
+from app.ai.voice.agents.breeze_buddy.template.approval import build_approval_map
+
+
+def test_flow_mode_global_functions():
+    flow = {
+        "global_functions": [
+            {
+                "type": "http",
+                "name": "issue_refund",
+                "description": "d",
+                "approval": {"prompt": "Refund OK?", "timeout_secs": 60},
+            },
+            {"type": "http", "name": "check_status", "description": "d"},
+        ]
+    }
+    amap = build_approval_map(flow)
+    assert set(amap) == {"issue_refund"}
+    assert amap["issue_refund"].prompt == "Refund OK?"
+    assert amap["issue_refund"].timeout_secs == 60
+
+
+def test_direct_mode_function_name_alias():
+    flow = {
+        "mode": "direct",
+        "functions": [
+            {
+                "type": "builtin",
+                "function_name": "transfer_money",
+                "description": "d",
+                "handler": "h",
+                "approval": {},
+            },
+            # Non-global types are FlowFunctions — never gated even if a
+            # stray approval key is present.
+            {
+                "function_name": "collect_feedback",
+                "description": "d",
+                "approval": {},
+            },
+        ],
+    }
+    amap = build_approval_map(flow)
+    assert set(amap) == {"transfer_money"}
+    assert amap["transfer_money"].timeout_secs == 120  # defaults
+
+
+def test_malformed_approval_config_is_skipped():
+    flow = {
+        "global_functions": [
+            {
+                "type": "http",
+                "name": "bad",
+                "description": "d",
+                "approval": {"timeout_secs": "not-a-number"},
+            },
+            {
+                "type": "http",
+                "name": "good",
+                "description": "d",
+                "approval": {},
+            },
+        ]
+    }
+    amap = build_approval_map(flow)
+    assert set(amap) == {"good"}
+
+
+def test_per_node_approval_is_ignored():
+    flow = {
+        "global_functions": [],
+        "nodes": [
+            {
+                "node_name": "start",
+                "functions": [{"name": "node_fn", "description": "d", "approval": {}}],
+            }
+        ],
+    }
+    assert build_approval_map(flow) == {}
+
+
+def test_shadowed_global_still_mapped():
+    flow = {
+        "global_functions": [
+            {
+                "type": "http",
+                "name": "shared_name",
+                "description": "d",
+                "approval": {},
+            }
+        ],
+        "nodes": [
+            {
+                "node_name": "start",
+                "functions": [{"name": "shared_name", "description": "d"}],
+            }
+        ],
+    }
+    amap = build_approval_map(flow)
+    assert "shared_name" in amap
+
+
+def test_non_dict_flow_is_safe():
+    assert build_approval_map(None) == {}
+    assert build_approval_map([]) == {}
+    assert build_approval_map({}) == {}


### PR DESCRIPTION
**HITL approval stack 3/7** — based on #821.

Template authors can mark any global function (HTTP / builtin / custom) as requiring human approval:

```json
{"approval": {"prompt": "…", "voice_announce": "…", "timeout_secs": 120,
              "chat_expiry_secs": 3600, "on_no_channel": "execute"}}
```

- \`template/approval.py\`: \`gate_global_function()\` wraps execution — bots exposing an approval channel wait for the decision; a Daily bot with **no** channel **denies** (the surface that should show approval UI never silently executes); telephony falls back to \`on_no_channel\` (execute logs a loud warning). \`build_approval_map()\` scans flow + direct-mode functions, warns on unsupported per-node placement and name shadowing.
- \`global_function.py\`: the three identical per-type wrapper closures unify into \`_make_global_wrapper()\`; filler audio + post-actions move inside the \`execute()\` closure so a **denied call has zero side effects**. \`_flows_async_kwargs\` grants an **additive** watchdog budget (approval wait + exec timeout + margin) — pipecat's function-call watchdog never cancels the handler, so a non-additive budget would drop the real result after a slow approval and invite duplicate execution.
- pydantic ignores unknown fields by default, so templates carrying \`approval\` stay parseable by older pods.

**Do not add \`approval\` to any production template until the full stack (PRs 4–7 + the loom SDK/widget release) is deployed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Global functions now support human-in-the-loop approval gating—execution can be configured to wait for end-user confirmation via voice announcement or chat interface before proceeding
  * Configurable approval timeouts, custom prompts, and channel-specific fallback behavior

* **Documentation**
  * Updated field reference documentation with approval configuration details for global functions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->