### PR TITLE
feat(db): tool_approvals table + query/accessor/decoder layers

### DIFF
--- a/app/database/accessor/breeze_buddy/tool_approvals.py
+++ b/app/database/accessor/breeze_buddy/tool_approvals.py
@@ -1,0 +1,167 @@
+"""Async accessors for tool_approvals (HITL approval gate).
+
+Calls into queries/breeze_buddy/tool_approvals.py for SQL and
+decoder/breeze_buddy/tool_approvals.py for row → Pydantic.
+JSON serialization for JSONB columns happens here.
+"""
+
+import json
+from typing import Any, Dict, List, Optional
+
+from app.core.logger import logger
+from app.database.decoder.breeze_buddy.tool_approvals import decode_tool_approval
+from app.database.queries import run_parameterized_query
+from app.database.queries.breeze_buddy.tool_approvals import (
+    claim_pending_tool_approvals_query,
+    decide_tool_approval_query,
+    get_tool_approval_query,
+    insert_tool_approval_query,
+    list_pending_tool_approvals_query,
+)
+from app.schemas.breeze_buddy.chat import ToolApproval, ToolApprovalStatus
+
+
+async def insert_tool_approval(
+    session_id: str,
+    tool_call_id: str,
+    function_name: str,
+    arguments: Optional[Dict[str, Any]],
+    prompt: Optional[str],
+    expiry_secs: float,
+) -> Optional[ToolApproval]:
+    """Insert a PENDING approval row. Returns None on a duplicate
+    (session_id, tool_call_id) — ON CONFLICT DO NOTHING."""
+    query, values = insert_tool_approval_query(
+        session_id=session_id,
+        tool_call_id=tool_call_id,
+        function_name=function_name,
+        arguments_json=json.dumps(arguments or {}),
+        prompt=prompt,
+        expiry_secs=expiry_secs,
+    )
+    try:
+        result = await run_parameterized_query(query, values)
+        row = result[0] if result else None
+        if row is None:
+            logger.warning(
+                f"Duplicate tool approval ignored for session {session_id} "
+                f"tool_call_id={tool_call_id}"
+            )
+            return None
+        approval = decode_tool_approval(row)
+        if approval:
+            logger.info(
+                f"Tool approval requested: session={session_id} "
+                f"tool_call_id={tool_call_id} function={function_name} "
+                f"expires_at={approval.expires_at.isoformat()}"
+            )
+        return approval
+    except Exception as e:
+        logger.error(
+            f"Error inserting tool approval for session {session_id} "
+            f"({function_name}): {e}"
+        )
+        raise
+
+
+async def get_tool_approval(
+    session_id: str, tool_call_id: str
+) -> Optional[ToolApproval]:
+    query, values = get_tool_approval_query(session_id, tool_call_id)
+    try:
+        result = await run_parameterized_query(query, values)
+        row = result[0] if result else None
+        return decode_tool_approval(row) if row else None
+    except Exception as e:
+        logger.error(
+            f"Error fetching tool approval {tool_call_id} for session "
+            f"{session_id}: {e}"
+        )
+        raise
+
+
+async def list_pending_tool_approvals(
+    session_id: str,
+    include_expired: bool = False,
+) -> List[ToolApproval]:
+    """PENDING rows oldest-first; excludes lazily-expired rows by default."""
+    query, values = list_pending_tool_approvals_query(
+        session_id, include_expired=include_expired
+    )
+    try:
+        result = await run_parameterized_query(query, values)
+        approvals = [decode_tool_approval(row) for row in result or []]
+        return [a for a in approvals if a is not None]
+    except Exception as e:
+        logger.error(
+            f"Error listing pending tool approvals for session {session_id}: {e}"
+        )
+        raise
+
+
+async def decide_tool_approval(
+    session_id: str,
+    tool_call_id: str,
+    new_status: ToolApprovalStatus,
+    reason: Optional[str] = None,
+) -> Optional[ToolApproval]:
+    """Atomically claim a PENDING row with a decision.
+
+    Returns the updated row, or None if the claim lost the race (the row
+    was no longer PENDING) — callers map that to a 409.
+    """
+    query, values = decide_tool_approval_query(
+        session_id=session_id,
+        tool_call_id=tool_call_id,
+        new_status=new_status.value,
+        reason=reason,
+    )
+    try:
+        result = await run_parameterized_query(query, values)
+        row = result[0] if result else None
+        approval = decode_tool_approval(row) if row else None
+        if approval:
+            logger.info(
+                f"Tool approval decided: session={session_id} "
+                f"tool_call_id={tool_call_id} "
+                f"function={approval.function_name} -> {new_status.value}"
+                + (f" ({reason})" if reason else "")
+            )
+        return approval
+    except Exception as e:
+        logger.error(
+            f"Error deciding tool approval {tool_call_id} for session "
+            f"{session_id}: {e}"
+        )
+        raise
+
+
+async def claim_pending_tool_approvals(
+    session_id: str,
+    new_status: ToolApprovalStatus,
+    reason: Optional[str] = None,
+    only_expired: bool = False,
+) -> List[ToolApproval]:
+    """Bulk-claim PENDING rows (dangling resolution), returning them."""
+    query, values = claim_pending_tool_approvals_query(
+        session_id=session_id,
+        new_status=new_status.value,
+        reason=reason,
+        only_expired=only_expired,
+    )
+    try:
+        result = await run_parameterized_query(query, values)
+        approvals = [decode_tool_approval(row) for row in result or []]
+        claimed = [a for a in approvals if a is not None]
+        if claimed:
+            logger.info(
+                f"Claimed {len(claimed)} pending tool approval(s) as "
+                f"{new_status.value} for session {session_id}"
+                + (" (expired only)" if only_expired else "")
+            )
+        return claimed
+    except Exception as e:
+        logger.error(
+            f"Error claiming pending tool approvals for session " f"{session_id}: {e}"
+        )
+        raise

--- a/app/database/decoder/breeze_buddy/tool_approvals.py
+++ b/app/database/decoder/breeze_buddy/tool_approvals.py
@@ -1,0 +1,29 @@
+"""Decoders for tool_approvals rows (HITL approval gate, migration 033)."""
+
+from typing import Optional
+
+import asyncpg
+
+from app.schemas.breeze_buddy.chat import ToolApproval, ToolApprovalStatus
+from app.utils.common import parse_json
+
+
+def decode_tool_approval(row: asyncpg.Record) -> Optional[ToolApproval]:
+    """Build a ToolApproval from a DB row, or None if row is empty."""
+    if not row:
+        return None
+    arguments = parse_json(row, "arguments") or {}
+    return ToolApproval(
+        id=str(row["id"]),
+        session_id=str(row["session_id"]),
+        channel=row.get("channel") or "CHAT",
+        tool_call_id=row["tool_call_id"],
+        function_name=row["function_name"],
+        arguments=arguments,
+        prompt=row.get("prompt"),
+        status=ToolApprovalStatus(row["status"]),
+        reason=row.get("reason"),
+        requested_at=row["requested_at"],
+        decided_at=row.get("decided_at"),
+        expires_at=row["expires_at"],
+    )

--- a/app/database/migrations/033_create_tool_approvals.sql
+++ b/app/database/migrations/033_create_tool_approvals.sql
@@ -1,0 +1,52 @@
+-- Migration 033: HITL tool-approval state for approval-gated global functions.
+--
+-- A template author can mark a global function (HTTP/builtin/custom) with an
+-- ``approval`` config; when the LLM calls it in CHAT mode the turn ends at the
+-- gate and a PENDING row is written here. The decision arrives later on the
+-- dedicated ``POST .../session/{id}/approval`` endpoint, which atomically
+-- claims the row (UPDATE ... WHERE status='PENDING') and resumes the turn.
+--
+-- Why a table (not Redis/memory): the paired tool_use block is already
+-- durably persisted in chat_message at gate time — until a tool_result row
+-- answers it, that history is invalid to replay. This row is the durable
+-- record that lets the dangling history be repaired (it holds tool_call_id /
+-- function_name / arguments), keeps expiry as a READABLE STATE (a late
+-- click gets "already timed out", not a 404), and is the audit trail for
+-- functions the author explicitly marked dangerous. Claim and tool_result
+-- insert are two statements under the per-session Redis lock; the
+-- claim-FIRST ordering keeps retries safe (a crash between them is healed
+-- in-memory by block_codec.repair_dangling_tool_uses on the next replay).
+--
+-- The table is channel-generic (``channel`` column) so a future voice audit
+-- trail can reuse it; in v1 only the chat path writes rows (voice approvals
+-- are in-process futures with no DB state). ``session_id`` therefore stays a
+-- NOT NULL FK to chat_session for now.
+--
+-- Expiry is lazy — no sweeper. Nothing is blocked server-side while a row is
+-- PENDING; stale rows are claimed (EXPIRED/SUPERSEDED) the next time the
+-- session is touched, and die with the session via CASCADE.
+
+CREATE TABLE IF NOT EXISTS tool_approvals (
+    id              uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    session_id      uuid NOT NULL REFERENCES chat_session(id) ON DELETE CASCADE,
+    channel         varchar(10) NOT NULL DEFAULT 'CHAT'
+        CHECK (channel IN ('CHAT', 'VOICE')),
+    tool_call_id    varchar(128) NOT NULL,
+    function_name   varchar(255) NOT NULL,
+    arguments       jsonb NOT NULL DEFAULT '{}'::jsonb,
+    prompt          text,
+    status          varchar(20) NOT NULL DEFAULT 'PENDING'
+        CHECK (status IN ('PENDING', 'APPROVED', 'DENIED', 'EXPIRED', 'SUPERSEDED')),
+    reason          text,
+    requested_at    timestamptz NOT NULL DEFAULT now(),
+    decided_at      timestamptz,
+    expires_at      timestamptz NOT NULL,
+
+    UNIQUE (session_id, tool_call_id)
+);
+
+-- Pending lookups are the hot path (per-turn dangling resolution + widget
+-- resume state); the partial index keeps them O(pending), not O(history).
+CREATE INDEX IF NOT EXISTS idx_tool_approvals_session_pending
+    ON tool_approvals (session_id)
+    WHERE status = 'PENDING';

--- a/app/database/queries/breeze_buddy/tool_approvals.py
+++ b/app/database/queries/breeze_buddy/tool_approvals.py
@@ -1,0 +1,124 @@
+"""SQL builders for the tool_approvals table (HITL approval gate).
+
+This module contains ONLY query generation functions. Business logic lives
+in accessor/breeze_buddy/tool_approvals.py. JSON serialization is the
+caller's responsibility — query builders treat JSONB values as opaque
+strings (matches the chat_session pattern).
+"""
+
+from typing import Any, List, Optional, Tuple
+
+TOOL_APPROVALS_TABLE = "tool_approvals"
+
+_APPROVAL_COLUMNS = """
+    id, session_id, channel, tool_call_id, function_name,
+    arguments, prompt, status, reason,
+    requested_at, decided_at, expires_at
+"""
+
+
+def insert_tool_approval_query(
+    session_id: str,
+    tool_call_id: str,
+    function_name: str,
+    arguments_json: str,
+    prompt: Optional[str],
+    expiry_secs: float,
+) -> Tuple[str, List[Any]]:
+    """Insert a PENDING approval row, returning it.
+
+    ``ON CONFLICT DO NOTHING`` so a duplicate provider tool_call_id can
+    never crash the gate turn mid-stream (returns no row on conflict).
+    """
+    query = f"""
+        INSERT INTO {TOOL_APPROVALS_TABLE} (
+            session_id, channel, tool_call_id, function_name,
+            arguments, prompt, expires_at
+        )
+        VALUES ($1, 'CHAT', $2, $3, $4::jsonb, $5,
+                now() + make_interval(secs => $6))
+        ON CONFLICT (session_id, tool_call_id) DO NOTHING
+        RETURNING {_APPROVAL_COLUMNS}
+    """
+    return query, [
+        session_id,
+        tool_call_id,
+        function_name,
+        arguments_json,
+        prompt,
+        expiry_secs,
+    ]
+
+
+def get_tool_approval_query(
+    session_id: str, tool_call_id: str
+) -> Tuple[str, List[Any]]:
+    query = f"""
+        SELECT {_APPROVAL_COLUMNS}
+        FROM {TOOL_APPROVALS_TABLE}
+        WHERE session_id = $1 AND tool_call_id = $2
+    """
+    return query, [session_id, tool_call_id]
+
+
+def list_pending_tool_approvals_query(
+    session_id: str,
+    include_expired: bool = False,
+) -> Tuple[str, List[Any]]:
+    """PENDING rows for a session, oldest first.
+
+    ``include_expired=True`` is for the dangling-resolution sweep (which
+    must see every PENDING row); the default filters lazily-expired rows
+    out for user-facing surfaces (siblings check, widget resume state).
+    """
+    expiry_clause = "" if include_expired else "AND expires_at > now()"
+    query = f"""
+        SELECT {_APPROVAL_COLUMNS}
+        FROM {TOOL_APPROVALS_TABLE}
+        WHERE session_id = $1 AND status = 'PENDING' {expiry_clause}
+        ORDER BY requested_at ASC
+    """
+    return query, [session_id]
+
+
+def decide_tool_approval_query(
+    session_id: str,
+    tool_call_id: str,
+    new_status: str,
+    reason: Optional[str],
+) -> Tuple[str, List[Any]]:
+    """Atomic decision claim: only a PENDING row can be decided.
+
+    Returns the updated row, or no row if the claim lost a race (the row
+    was already decided/superseded/expired by another request).
+    """
+    query = f"""
+        UPDATE {TOOL_APPROVALS_TABLE}
+        SET status = $1, reason = $2, decided_at = now()
+        WHERE session_id = $3 AND tool_call_id = $4 AND status = 'PENDING'
+        RETURNING {_APPROVAL_COLUMNS}
+    """
+    return query, [new_status, reason, session_id, tool_call_id]
+
+
+def claim_pending_tool_approvals_query(
+    session_id: str,
+    new_status: str,
+    reason: Optional[str],
+    only_expired: bool = False,
+) -> Tuple[str, List[Any]]:
+    """Bulk-claim PENDING rows (dangling resolution), returning them.
+
+    - ``only_expired=False``: claims ALL pending rows (supersede on a new
+      user message).
+    - ``only_expired=True``: claims only rows past expires_at (lazy expiry
+      inside the approval handler).
+    """
+    expiry_clause = "AND expires_at <= now()" if only_expired else ""
+    query = f"""
+        UPDATE {TOOL_APPROVALS_TABLE}
+        SET status = $1, reason = $2, decided_at = now()
+        WHERE session_id = $3 AND status = 'PENDING' {expiry_clause}
+        RETURNING {_APPROVAL_COLUMNS}
+    """
+    return query, [new_status, reason, session_id]

--- a/app/schemas/breeze_buddy/chat.py
+++ b/app/schemas/breeze_buddy/chat.py
@@ -46,6 +46,53 @@ class WidgetChannel(str, Enum):
     ENDED = "ENDED"
 
 
+class ToolApprovalStatus(str, Enum):
+    """Lifecycle of a HITL tool-approval row (migration 033).
+
+    PENDING rows are claimed atomically (UPDATE ... WHERE status='PENDING')
+    by exactly one of: an explicit decision (APPROVED/DENIED), lazy expiry
+    (EXPIRED — the user decided after expires_at, or the handler swept it),
+    or a new user message (SUPERSEDED — the user moved on without deciding).
+    """
+
+    PENDING = "PENDING"
+    APPROVED = "APPROVED"
+    DENIED = "DENIED"
+    EXPIRED = "EXPIRED"
+    SUPERSEDED = "SUPERSEDED"
+
+
+class ToolApproval(BaseModel):
+    """One row of `tool_approvals` — a gated function call awaiting (or past)
+    its human decision. ``arguments`` are the post-injection args that will
+    actually run on approval."""
+
+    id: str
+    session_id: str
+    channel: str = "CHAT"
+    tool_call_id: str
+    function_name: str
+    arguments: Dict[str, Any] = Field(default_factory=dict)
+    prompt: Optional[str] = None
+    status: ToolApprovalStatus
+    reason: Optional[str] = None
+    requested_at: datetime
+    decided_at: Optional[datetime] = None
+    expires_at: datetime
+
+
+class ApproveToolRequest(BaseModel):
+    """Body of ``POST .../session/{id}/approval`` (all three auth surfaces)."""
+
+    tool_call_id: str = Field(..., min_length=1, max_length=128)
+    approved: bool
+    reason: Optional[str] = Field(
+        None,
+        max_length=500,
+        description="Optional free-text reason shown to the LLM on denial.",
+    )
+
+
 class ChatSession(BaseModel):
     """One row of `chat_session`.
 
@@ -539,6 +586,14 @@ class WidgetSessionStateResponse(BaseModel):
             "Empty when none was pushed."
         ),
     )
+    pending_approvals: List[ToolApproval] = Field(
+        default_factory=list,
+        description=(
+            "Unexpired PENDING HITL tool approvals for this session, oldest "
+            "first, so the embed can repaint approval cards after a reload. "
+            "Empty when nothing is awaiting a decision."
+        ),
+    )
 
 
 __all__ = [
@@ -546,6 +601,9 @@ __all__ = [
     "ChatMessageRole",
     "ChatEndedReason",
     "WidgetChannel",
+    "ToolApprovalStatus",
+    "ToolApproval",
+    "ApproveToolRequest",
     "ChatSession",
     "ChatMessage",
     "AgentSessionState",


### PR DESCRIPTION
**HITL approval stack 4/7** — based on #822.

Migration 033 creates \`tool_approvals\`: one row per approval-gated tool call awaiting a human decision. Channel-generic by design (CHAT today; VOICE reserves the door for a future audit trail without a new table). \`UNIQUE(session_id, tool_call_id)\` + \`ON CONFLICT DO NOTHING\` make pending inserts idempotent; the partial PENDING index bounds per-session lookups; rows cascade with \`chat_session\`.

Three-layer pattern: queries → accessor (\`decide_tool_approval\` is an atomic claim \`UPDATE … WHERE status='PENDING' RETURNING\` — a lost race returns None; \`claim_pending_tool_approvals\` sweeps for supersede/expiry) → decoder.

Expiry is **lazy state**, not a sweeper: EXPIRED/SUPERSEDED stay readable so late clicks get a precise 409 and the LLM can acknowledge what happened.

Schemas: \`ToolApprovalStatus\`, \`ToolApproval\`, \`ApproveToolRequest\` + \`pending_approvals\` (default \`[]\`) on \`WidgetSessionStateResponse\`.

**Fully dormant** — nothing references these layers until PR 6–7. ⚠️ Run \`python scripts/migrate.py up\` with the deploy; **033 must be applied before PR 7 deploys** (its supersede pre-step runs on every \`/message\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)