### PR TITLE
feat(voice): ApprovalManager + RTVI approval wiring for Daily calls

### DIFF
--- a/app/ai/voice/agents/breeze_buddy/agent/__init__.py
+++ b/app/ai/voice/agents/breeze_buddy/agent/__init__.py
@@ -22,6 +22,11 @@ from pipecat.runner.utils import (
 )
 from pipecat_flows import FlowManager
 
+from app.ai.voice.agents.breeze_buddy.agent.approval import (
+    RTVI_APPROVAL_DECISION,
+    RTVI_APPROVAL_REQUEST,
+    ApprovalManager,
+)
 from app.ai.voice.agents.breeze_buddy.agent.flow import (
     build_flow_config,
     load_template_config,
@@ -183,6 +188,12 @@ class Agent:
         # the agent skips greeting playback and starts the FlowManager
         # at start_node with prior_history pre-loaded into LLM context.
         self._widget_resume_seed: Optional[Dict[str, Any]] = None
+
+        # HITL approval channel — daily mode only, set alongside
+        # _rtvi_processor. None on telephony bots (no approval surface) and
+        # when RTVI is unavailable; the gate in template/approval.py treats
+        # those cases differently (telephony on_no_channel vs daily deny).
+        self.approval_manager: Optional[ApprovalManager] = None
 
     @property
     def is_daily_mode(self) -> bool:
@@ -737,6 +748,8 @@ class Agent:
         @self.transport.event_handler("on_client_disconnected")
         async def on_client_disconnected(transport, client):
             logger.info(f"Client disconnected: {client}")
+            if self.approval_manager:
+                self.approval_manager.deny_all("client_disconnected")
             if self._rtvi_processor:
                 await self._emit_rtvi_event(
                     "conversation-end", {"reason": "client_disconnected"}
@@ -753,13 +766,18 @@ class Agent:
         @self.task.event_handler("on_idle_timeout")
         async def on_idle_timeout(task):
             logger.info("Idle timeout detected.")
+            if self.approval_manager:
+                self.approval_manager.deny_all("idle_timeout")
             if self._rtvi_processor:
                 await self._emit_rtvi_event(
                     "conversation-end", {"reason": "idle_timeout"}
                 )
             await self._handle_unexpected_disconnect("idle_timeout")
 
-        # Register RTVI-specific event handlers for daily mode
+        # Register RTVI-specific event handlers for daily mode. Client
+        # messages are accepted whenever RTVI exists — widget voice runs as
+        # daily AGENT mode (is_stream_mode=False), so registering only in
+        # stream mode would make approval decisions undeliverable there.
         if self._rtvi_processor:
 
             @self._rtvi_processor.event_handler("on_client_ready")
@@ -767,13 +785,17 @@ class Agent:
                 await rtvi.push_frame(
                     RTVIServerMessageFrame(data={"type": "bot-ready"})
                 )
-
-        # Stream mode: accept tts-speak via RTVI client-message (PipecatClient SDK)
-        if self.is_stream_mode and self._rtvi_processor:
+                # Re-emit pending approval requests so a reconnecting client
+                # (page refresh within the Daily token TTL) repaints cards
+                # instead of losing them until timeout.
+                if self.approval_manager:
+                    for payload in self.approval_manager.pending_requests():
+                        await self._emit_rtvi_event(RTVI_APPROVAL_REQUEST, payload)
 
             @self._rtvi_processor.event_handler("on_client_message")
             async def on_client_message(rtvi, message):
-                if message.type == "tts-speak":
+                # tts-speak remains stream-mode-only (PipecatClient SDK).
+                if message.type == "tts-speak" and self.is_stream_mode:
                     data = message.data or {}
                     text = data.get("text", "")
                     if not isinstance(text, str) or not text:
@@ -787,6 +809,29 @@ class Agent:
                     if self.task:
                         logger.debug(f"[STREAM] TTS speak: {text[:80]}")
                         await self.task.queue_frame(TTSSpeakFrame(text=text))
+                elif message.type == RTVI_APPROVAL_DECISION:
+                    if not self.approval_manager:
+                        logger.warning(
+                            "[approval] Decision received but no approval "
+                            "manager on this bot"
+                        )
+                        return
+                    data = message.data or {}
+                    approval_id = data.get("approval_id")
+                    approved = data.get("approved")
+                    reason = data.get("reason")
+                    if not isinstance(approval_id, str) or not isinstance(
+                        approved, bool
+                    ):
+                        logger.warning(
+                            f"[approval] Malformed decision message: {data!r}"
+                        )
+                        return
+                    self.approval_manager.resolve(
+                        approval_id,
+                        approved,
+                        reason if isinstance(reason, str) else None,
+                    )
 
         # Register user turn started event to reset idle retry counter
         if self._context_aggregator and self._user_idle_callback_handler:
@@ -1064,6 +1109,19 @@ class Agent:
 
             if self.is_daily_mode and hasattr(self.task, "rtvi") and self.task.rtvi:
                 self._rtvi_processor = self.task.rtvi
+                # HITL approval channel rides the RTVI processor. Note: widget
+                # voice attachments run as daily AGENT mode (not stream), and
+                # RTVI requires ENABLE_BREEZE_BUDDY_DAILY_EVENTS=true — without
+                # it approval_manager stays None and gated calls are denied.
+                self.approval_manager = ApprovalManager(emit=self._emit_rtvi_event)
+                if self._user_idle_callback_handler:
+                    # While an approval card is showing, the user is silently
+                    # reading — idle prompts/end-call must not fire (idle
+                    # re-inference can also spawn duplicate gated calls).
+                    approval_manager = self.approval_manager
+                    self._user_idle_callback_handler.suppress_when = (
+                        approval_manager.has_pending
+                    )
 
             # Flow manager is agent-mode only (stream mode has no LLM to drive
             # node transitions or function calls).

--- a/app/ai/voice/agents/breeze_buddy/agent/approval.py
+++ b/app/ai/voice/agents/breeze_buddy/agent/approval.py
@@ -1,0 +1,205 @@
+"""In-process approval manager for Daily voice mode (HITL Pattern C).
+
+The gate (template/approval.py) calls ``request()`` from inside a function
+handler task; the end user's decision arrives via an RTVI
+``function-approval-decision`` client message routed to ``resolve()``.
+
+Lifecycle invariants (these are load-bearing — see plan review):
+- ``asyncio.wait_for`` CANCELS the inner future on timeout, so a late
+  ``resolve()`` must done-guard (no InvalidStateError) and report stale.
+- Every exit path (approve / deny / timeout / CancelledError / deny_all /
+  supersede) pops the map entry exactly once and emits exactly one
+  ``function-approval-resolved`` event, both owned by ``request()``'s
+  try/finally so there is a single emission point.
+- On CancelledError (user barge-in cancels sync gated handlers with ~1s
+  grace; pipeline teardown) the map pop is synchronous and the emit is a
+  cheap frame-queue put, so cleanup fits the grace window; the error is
+  re-raised so pipecat records the call as CANCELLED.
+- Duplicate request for the same function name (async re-call, parallel
+  batch) supersedes the older pending request.
+"""
+
+import asyncio
+import uuid
+from typing import Any, Awaitable, Callable, Dict, List, Optional, Tuple
+
+from app.ai.voice.agents.breeze_buddy.template.approval import (
+    WIRE_STATUS_APPROVED,
+    WIRE_STATUS_CANCELLED,
+    WIRE_STATUS_DENIED,
+    WIRE_STATUS_SUPERSEDED,
+    WIRE_STATUS_TIMEOUT,
+    ApprovalOutcome,
+)
+from app.ai.voice.agents.breeze_buddy.template.types import ApprovalConfig
+from app.core.logger import logger
+
+# RTVI message types (kebab-case, matching the existing server-message
+# convention — see handlers/transport/rtvi.py and docs/DAILY_RTVI_EVENTS.md).
+RTVI_APPROVAL_REQUEST = "function-approval-request"
+RTVI_APPROVAL_RESOLVED = "function-approval-resolved"
+RTVI_APPROVAL_DECISION = "function-approval-decision"
+
+EmitFn = Callable[..., Awaitable[None]]
+
+# Future resolves to (approved, wire_status, reason).
+_Resolution = Tuple[bool, str, Optional[str]]
+
+# Hard ceiling on the in-process wait. The pipeline's idle watchdog fires at
+# 300s of speech inactivity and tears the WHOLE call down (deny_all + BUSY);
+# a wait clamped below it resolves as a timeout the LLM can talk about
+# instead. ApprovalConfig only validates gt=0 (a tighter bound would make
+# old templates fail validation and silently UN-gate the function), so the
+# clamp lives here.
+_MAX_WAIT_SECS = 270.0
+
+
+class ApprovalManager:
+    """Tracks pending approval requests for one in-process voice bot."""
+
+    def __init__(self, emit: EmitFn):
+        self._emit = emit
+        self._pending: Dict[
+            str, Tuple["asyncio.Future[_Resolution]", Dict[str, Any]]
+        ] = {}
+        # function_name -> approval_id, for supersede-on-duplicate.
+        self._by_function: Dict[str, str] = {}
+
+    def has_pending(self) -> bool:
+        return bool(self._pending)
+
+    def pending_requests(self) -> List[Dict[str, Any]]:
+        """Request payloads for re-emit on client reconnect."""
+        return [payload for (_fut, payload) in self._pending.values()]
+
+    async def request(
+        self,
+        function_name: str,
+        arguments: Dict[str, Any],
+        config: ApprovalConfig,
+    ) -> ApprovalOutcome:
+        """Emit an approval request and wait for the decision."""
+        # Supersede an older pending request for the same function — its
+        # awaiting request() coroutine wakes up and handles its own
+        # cleanup + resolved emit.
+        prior_id = self._by_function.get(function_name)
+        if prior_id is not None:
+            prior = self._pending.get(prior_id)
+            if prior is not None and not prior[0].done():
+                logger.info(
+                    f"[approval] Superseding pending approval {prior_id} "
+                    f"for '{function_name}' with a newer request"
+                )
+                prior[0].set_result(
+                    (
+                        False,
+                        WIRE_STATUS_SUPERSEDED,
+                        "superseded by a newer request for the same function",
+                    )
+                )
+
+        wait_secs = config.timeout_secs
+        if wait_secs > _MAX_WAIT_SECS:
+            logger.warning(
+                f"[approval] timeout_secs={wait_secs} exceeds the pipeline "
+                f"idle budget; clamping to {_MAX_WAIT_SECS}s for "
+                f"'{function_name}'"
+            )
+            wait_secs = _MAX_WAIT_SECS
+
+        approval_id = str(uuid.uuid4())
+        payload: Dict[str, Any] = {
+            "approval_id": approval_id,
+            "function_name": function_name,
+            "arguments": arguments or {},
+            "prompt": config.prompt,
+            "timeout_secs": wait_secs,
+        }
+        fut: "asyncio.Future[_Resolution]" = asyncio.get_running_loop().create_future()
+        self._pending[approval_id] = (fut, payload)
+        self._by_function[function_name] = approval_id
+
+        outcome: Optional[ApprovalOutcome] = None
+        try:
+            logger.info(
+                f"[approval] Requesting approval for '{function_name}' "
+                f"(approval_id={approval_id}, timeout={wait_secs}s)"
+            )
+            await self._emit(RTVI_APPROVAL_REQUEST, payload)
+            try:
+                approved, status, reason = await asyncio.wait_for(
+                    fut, timeout=wait_secs
+                )
+                outcome = ApprovalOutcome(
+                    approved=approved, status=status, reason=reason
+                )
+            except asyncio.TimeoutError:
+                outcome = ApprovalOutcome(
+                    approved=False,
+                    status=WIRE_STATUS_TIMEOUT,
+                    reason="approval request timed out",
+                )
+            return outcome
+        except asyncio.CancelledError:
+            # Barge-in on a sync gated function or pipeline teardown.
+            outcome = ApprovalOutcome(
+                approved=False,
+                status=WIRE_STATUS_CANCELLED,
+                reason="cancelled by user interruption or call teardown",
+            )
+            raise
+        finally:
+            # Single cleanup + emission point for every exit path.
+            self._pending.pop(approval_id, None)
+            if self._by_function.get(function_name) == approval_id:
+                self._by_function.pop(function_name, None)
+            if outcome is not None:
+                logger.info(
+                    f"[approval] Resolved '{function_name}' "
+                    f"(approval_id={approval_id}) -> {outcome.status}"
+                    + (f" ({outcome.reason})" if outcome.reason else "")
+                )
+                try:
+                    await self._emit(
+                        RTVI_APPROVAL_RESOLVED,
+                        {"approval_id": approval_id, "status": outcome.status},
+                    )
+                except Exception as e:
+                    logger.warning(
+                        f"[approval] Failed to emit resolution for "
+                        f"{approval_id}: {e}"
+                    )
+
+    def resolve(
+        self, approval_id: str, approved: bool, reason: Optional[str] = None
+    ) -> bool:
+        """Apply a client decision. Returns False for stale/unknown ids.
+
+        Idempotent: duplicate decisions and decisions arriving after a
+        timeout (the future is already done/cancelled) are no-ops.
+        """
+        entry = self._pending.get(approval_id)
+        if entry is None or entry[0].done():
+            logger.warning(
+                f"[approval] Ignoring decision for stale/unknown "
+                f"approval_id={approval_id} (approved={approved})"
+            )
+            return False
+        status = WIRE_STATUS_APPROVED if approved else WIRE_STATUS_DENIED
+        entry[0].set_result((approved, status, reason))
+        return True
+
+    def deny_all(self, reason: str) -> None:
+        """Deny every pending request (disconnect / idle / conversation end).
+
+        Tolerates already-done futures; each awaiting ``request()`` performs
+        its own cleanup and resolved-event emission.
+        """
+        if not self._pending:
+            return
+        logger.info(
+            f"[approval] Denying {len(self._pending)} pending approval(s): " f"{reason}"
+        )
+        for _approval_id, (fut, _payload) in list(self._pending.items()):
+            if not fut.done():
+                fut.set_result((False, WIRE_STATUS_DENIED, reason))

--- a/app/ai/voice/agents/breeze_buddy/handlers/internal/end_conversation.py
+++ b/app/ai/voice/agents/breeze_buddy/handlers/internal/end_conversation.py
@@ -295,6 +295,13 @@ async def end_conversation(context: TemplateContext, args, transition_to=None):
             exc_info=True,
         )
     finally:
+        # Deny any pending HITL approvals before tearing down — pipecat does
+        # NOT cancel parallel function-call tasks on EndFrame, so a blocked
+        # gated handler would otherwise outlive the pipeline until timeout.
+        approval_manager = getattr(context.bot, "approval_manager", None)
+        if approval_manager:
+            approval_manager.deny_all("conversation_ended")
+
         # Send EndFrame to gracefully terminate the pipeline
         logger.info(
             f"Sending EndFrame to terminate pipeline for call {context.call_sid}"

--- a/app/ai/voice/agents/breeze_buddy/processors/user_idle.py
+++ b/app/ai/voice/agents/breeze_buddy/processors/user_idle.py
@@ -45,6 +45,10 @@ class UserIdleCallbackHandler:
         # Set when end_conversation is in flight, cleared if it fails so
         # subsequent idle events can retry.
         self._call_ended = False
+        # Optional predicate that pauses idle handling entirely while True
+        # (e.g. an approval card is pending and the user is silently
+        # reading it). Assigned post-construction by the agent.
+        self.suppress_when: Optional[Callable[[], bool]] = None
         logger.info(f"User idle detection enabled with max_retries: {max_retries}")
 
     def reset_retry_count(self) -> None:
@@ -56,6 +60,10 @@ class UserIdleCallbackHandler:
     async def handle_user_idle(self, aggregator: Any) -> None:
         """Prompt the user; end the call after ``max_retries`` prompts."""
         if self._call_ended:
+            return
+
+        if self.suppress_when is not None and self.suppress_when():
+            logger.debug("User idle event suppressed (pending approval or similar)")
             return
 
         self.retry_count += 1

--- a/docs/DAILY_RTVI_EVENTS.md
+++ b/docs/DAILY_RTVI_EVENTS.md
@@ -63,7 +63,7 @@ Real-time events emitted by the Breeze Buddy backend to Daily-connected clients 
 | `onCamUpdated` | Active camera changes | After `client.updateCam()` | Confirm camera switch |
 | `onDeviceError` | Device access fails | Permission denied, device in use, hardware error | Show "mic access denied" or "device unavailable" message |
 | **Server Messages** | | | |
-| `onServerMessage` | Backend sends custom RTVI event via `_emit_rtvi_event()` | On conversation-start, conversation-end, pipeline-error, bot-ready | Handle Breeze Buddy-specific lifecycle events |
+| `onServerMessage` | Backend sends custom RTVI event via `_emit_rtvi_event()` | On conversation-start, conversation-end, pipeline-error, bot-ready, function-approval-request, function-approval-resolved | Handle Breeze Buddy-specific lifecycle events + HITL approval cards |
 
 ## Event Timeline
 
@@ -568,9 +568,51 @@ onServerMessage: (message: { type: string; timestamp?: number; payload?: any }) 
     case 'pipeline-error':
       console.error('Pipeline error:', message.payload?.processor, message.payload?.error);
       break;
+    case 'function-approval-request':
+      // HITL: the LLM called an approval-gated function (template
+      // `approval` config). Show an approve/deny card; answer with the
+      // `function-approval-decision` client message below. Re-emitted
+      // for still-pending requests when a client (re)connects.
+      // payload: { approval_id, function_name, arguments, prompt, timeout_secs }
+      break;
+    case 'function-approval-resolved':
+      // HITL: a pending approval resolved — dismiss its card.
+      // payload: { approval_id, status }
+      // status: "approved" | "denied" | "timeout" | "cancelled" | "superseded"
+      break;
   }
 }
 ```
+
+### HITL function approvals (client → server)
+
+Answer a `function-approval-request` with:
+
+```typescript
+client.sendClientMessage('function-approval-decision', {
+  approval_id: '...',   // from the request payload
+  approved: true,       // or false
+  reason: 'optional',   // shown to the LLM on denial
+});
+```
+
+Semantics:
+- Decisions are idempotent per `approval_id` — duplicates and decisions
+  arriving after the wait timed out are ignored (the bot logs a stale-id
+  warning).
+- Whether the bot keeps talking while waiting is the function's existing
+  `cancel_on_interruption`: `true` = the bot blocks silently (and ANY user
+  utterance cancels the request → `status: "cancelled"`); `false` = async
+  call, the bot keeps conversing and the decision may arrive minutes later.
+- On timeout/deny the LLM receives `{"status": "denied"|"timeout", reason}`
+  as the tool result. Pending requests are denied automatically on client
+  disconnect, idle timeout, and conversation end.
+- A duplicate request for the same function supersedes the older pending
+  one (`status: "superseded"`).
+- Voice HITL requires RTVI (`ENABLE_BREEZE_BUDDY_DAILY_EVENTS=true`);
+  without it, gated calls on Daily are denied
+  (`approval_channel_unavailable`). Telephony has no approval surface —
+  the template's `approval.on_no_channel` decides.
 
 ---
 

--- a/tests/test_approval_manager.py
+++ b/tests/test_approval_manager.py
@@ -1,0 +1,139 @@
+"""Voice ApprovalManager lifecycle — exactly-once resolution emission,
+idempotent resolve, timeout/cancel/supersede/deny_all paths.
+
+Companion: [[agent/approval.py]]. The gate/_make_global_wrapper/
+_flows_async_kwargs tests live in tests/test_approval_gate.py.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import List
+
+import pytest
+
+from app.ai.voice.agents.breeze_buddy.agent.approval import (
+    RTVI_APPROVAL_REQUEST,
+    RTVI_APPROVAL_RESOLVED,
+    ApprovalManager,
+)
+from app.ai.voice.agents.breeze_buddy.template.types import ApprovalConfig
+
+
+class _EmitRecorder:
+    def __init__(self):
+        self.events: List[tuple] = []
+
+    async def __call__(self, event_type, payload=None):
+        self.events.append((event_type, payload))
+
+
+async def test_manager_approve_resolves_and_emits_once():
+    emit = _EmitRecorder()
+    manager = ApprovalManager(emit=emit)
+    cfg = ApprovalConfig(timeout_secs=5)
+
+    task = asyncio.create_task(manager.request("fn", {"a": 1}, cfg))
+    await asyncio.sleep(0.01)
+    request_events = [e for e in emit.events if e[0] == RTVI_APPROVAL_REQUEST]
+    assert len(request_events) == 1
+    approval_id = request_events[0][1]["approval_id"]
+
+    assert manager.resolve(approval_id, True) is True
+    outcome = await task
+    assert outcome.approved is True and outcome.status == "approved"
+    resolved = [e for e in emit.events if e[0] == RTVI_APPROVAL_RESOLVED]
+    assert len(resolved) == 1
+    assert resolved[0][1] == {"approval_id": approval_id, "status": "approved"}
+    assert not manager.has_pending()
+
+
+async def test_manager_duplicate_resolve_is_stale():
+    emit = _EmitRecorder()
+    manager = ApprovalManager(emit=emit)
+    task = asyncio.create_task(
+        manager.request("fn", {}, ApprovalConfig(timeout_secs=5))
+    )
+    await asyncio.sleep(0.01)
+    approval_id = emit.events[0][1]["approval_id"]
+    assert manager.resolve(approval_id, False, "no") is True
+    assert manager.resolve(approval_id, True) is False  # idempotent
+    outcome = await task
+    assert outcome.status == "denied" and outcome.reason == "no"
+
+
+async def test_manager_timeout_then_late_resolve_is_stale():
+    emit = _EmitRecorder()
+    manager = ApprovalManager(emit=emit)
+    outcome = await manager.request("fn", {}, ApprovalConfig(timeout_secs=0.01))
+    assert outcome.status == "timeout" and outcome.approved is False
+    approval_id = emit.events[0][1]["approval_id"]
+    # wait_for cancelled the future; a late decision must be a clean no-op.
+    assert manager.resolve(approval_id, True) is False
+    assert not manager.has_pending()
+
+
+async def test_manager_supersede_on_duplicate_function():
+    emit = _EmitRecorder()
+    manager = ApprovalManager(emit=emit)
+    cfg = ApprovalConfig(timeout_secs=5)
+    first = asyncio.create_task(manager.request("fn", {"v": 1}, cfg))
+    await asyncio.sleep(0.01)
+    second = asyncio.create_task(manager.request("fn", {"v": 2}, cfg))
+    await asyncio.sleep(0.01)
+
+    first_outcome = await first
+    assert first_outcome.status == "superseded" and first_outcome.approved is False
+
+    second_id = [e for e in emit.events if e[0] == RTVI_APPROVAL_REQUEST][1][1][
+        "approval_id"
+    ]
+    manager.resolve(second_id, True)
+    second_outcome = await second
+    assert second_outcome.approved is True
+    assert not manager.has_pending()
+
+
+async def test_manager_deny_all():
+    emit = _EmitRecorder()
+    manager = ApprovalManager(emit=emit)
+    cfg = ApprovalConfig(timeout_secs=5)
+    t1 = asyncio.create_task(manager.request("fn_a", {}, cfg))
+    t2 = asyncio.create_task(manager.request("fn_b", {}, cfg))
+    await asyncio.sleep(0.01)
+    assert manager.has_pending()
+    manager.deny_all("client_disconnected")
+    o1, o2 = await t1, await t2
+    assert o1.status == "denied" and o2.status == "denied"
+    assert o1.reason == "client_disconnected"
+    assert not manager.has_pending()
+
+
+async def test_manager_cancelled_emits_cancelled_and_reraises():
+    emit = _EmitRecorder()
+    manager = ApprovalManager(emit=emit)
+    task = asyncio.create_task(
+        manager.request("fn", {}, ApprovalConfig(timeout_secs=5))
+    )
+    await asyncio.sleep(0.01)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    resolved = [e for e in emit.events if e[0] == RTVI_APPROVAL_RESOLVED]
+    assert len(resolved) == 1
+    assert resolved[0][1]["status"] == "cancelled"
+    assert not manager.has_pending()
+
+
+async def test_manager_pending_requests_for_reemit():
+    emit = _EmitRecorder()
+    manager = ApprovalManager(emit=emit)
+    task = asyncio.create_task(
+        manager.request("fn", {"a": 1}, ApprovalConfig(timeout_secs=5))
+    )
+    await asyncio.sleep(0.01)
+    payloads = manager.pending_requests()
+    assert len(payloads) == 1
+    assert payloads[0]["function_name"] == "fn"
+    manager.resolve(payloads[0]["approval_id"], False)
+    await task


### PR DESCRIPTION
**HITL approval stack 5/7** — based on #823.

In-process approval gate for Daily voice calls: when a gated global function fires, the handler awaits an asyncio.Future while the client shows approval UI.

- \`agent/approval.py\`: \`ApprovalManager\` emits RTVI \`function-approval-request\`, resolves on the client's \`function-approval-decision\`. Exactly-once \`function-approval-resolved\` emission via a single try/finally; pop-claim makes duplicate/late decisions clean no-ops; same-function re-requests supersede the prior pending future; CancelledError (barge-in with \`cancel_on_interruption=true\`, or teardown) pops the map synchronously and re-raises within pipecat's 1s cancel grace. Waits clamp to 270s (pipeline idle is 300s).
- \`agent/__init__.py\`: manager exists whenever the RTVI processor does (requires \`ENABLE_BREEZE_BUDDY_DAILY_EVENTS=true\`). \`on_client_message\` registration moves **out** of the \`is_stream_mode\` guard — widget voice attachments run as Daily AGENT mode and must receive decisions; \`tts-speak\` stays stream-mode-only. \`deny_all()\` on every terminal path (disconnect, idle timeout, \`end_conversation\` before EndFrame — pipecat does NOT cancel parallel function-call tasks on EndFrame). \`on_client_ready\` re-emits pending requests for page-refresh repaint.
- \`user_idle.py\`: \`suppress_when\` — idle prompts suppressed while an approval pends (an idle nudge mid-wait could end the call BUSY under a visible card).
- Telephony bots get no manager: the gate's \`on_no_channel\` fallback governs.

Docs: \`DAILY_RTVI_EVENTS.md\` gains the three message types.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced Human-In-The-Loop (HITL) approval system for voice mode—clients can now approve or deny pending function calls with built-in timeout and cancellation handling.
  * Added idle timeout suppression while approval requests are active.

* **Documentation**
  * Added comprehensive HITL function approval documentation with event handling examples and client-side integration requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->