### PR TITLE
feat(api): POST /approval on chat/demo/widget + supersede pre-step

### DIFF
--- a/app/ai/voice/agents/breeze_buddy/handlers/transport/utils/response_transform.py
+++ b/app/ai/voice/agents/breeze_buddy/handlers/transport/utils/response_transform.py
@@ -290,6 +290,9 @@ def omit_fields(value: Any, args: Dict[str, Any]) -> Any:
 
 _HTML_TAG_RE = re.compile(r"<[^>]+>")
 _WHITESPACE_RE = re.compile(r"\s+")
+# A stripped tag becomes a space, so ``word</b>.`` collapses to ``word .`` —
+# drop the space a removed tag leaves immediately before closing punctuation.
+_SPACE_BEFORE_PUNCT_RE = re.compile(r"\s+([.,;:!?)\]])")
 
 
 @register_transform("strip_html")
@@ -315,6 +318,7 @@ def strip_html(value: Any, args: Dict[str, Any]) -> Any:
         return value
     plain = _HTML_TAG_RE.sub(" ", value)
     plain = _WHITESPACE_RE.sub(" ", plain).strip()
+    plain = _SPACE_BEFORE_PUNCT_RE.sub(r"\1", plain)
     max_chars = args.get("max_chars")
     if isinstance(max_chars, int) and max_chars > 0 and len(plain) > max_chars:
         clipped = plain[:max_chars]

--- a/app/api/routers/breeze_buddy/chat/__init__.py
+++ b/app/api/routers/breeze_buddy/chat/__init__.py
@@ -37,6 +37,7 @@ from app.ai.voice.agents.breeze_buddy.template.cache import get_template_by_id_c
 from app.api.security.breeze_buddy.rbac_token import get_current_user_with_rbac
 from app.schemas import UserInfo
 from app.schemas.breeze_buddy.chat import (
+    ApproveToolRequest,
     ChatSessionStatus,
     ChatTranscriptResponse,
     CreateChatSessionRequest,
@@ -49,6 +50,7 @@ from app.schemas.breeze_buddy.chat import (
 
 from .demo import router as demo_router
 from .handlers import (
+    approve_chat_tool_handler,
     cancel_chat_turn_handler,
     create_chat_session_handler,
     end_chat_session_handler,
@@ -202,6 +204,37 @@ async def send_message(
         validate_chat_session_access(current_user, session, operation="send_message")
 
     return await send_chat_message_handler(session_id, req, access_check=_check)
+
+
+@router.post("/session/{session_id}/approval")
+async def approve_tool(
+    session_id: str,
+    req: ApproveToolRequest,
+    current_user: UserInfo = Depends(get_current_user_with_rbac),
+):
+    """
+    Apply a human decision to a pending HITL tool approval and stream
+    the resumed turn (same SSE shape as ``/message``).
+
+    The turn that requested approval ended with ``turn_end
+    {awaiting_approval: true}``; this endpoint atomically claims the
+    pending row, executes (approve) or records a denial (deny / late
+    decision past expiry → timeout), and continues the LLM loop.
+
+    Note: like ``/message`` on this RBAC surface, there is no
+    current_channel gate — accepted asymmetry with the widget surface.
+
+    Returns:
+        ``StreamingResponse`` (``text/event-stream``). 404 if the session
+        or tool_call_id is unknown, 410 if the session ENDED, 409 with a
+        machine-readable ``detail.code`` (``already_decided`` |
+        ``lock_contended``) on conflicts.
+    """
+
+    def _check(session) -> None:
+        validate_chat_session_access(current_user, session, operation="approve_tool")
+
+    return await approve_chat_tool_handler(session_id, req, access_check=_check)
 
 
 @router.post(

--- a/app/api/routers/breeze_buddy/chat/demo.py
+++ b/app/api/routers/breeze_buddy/chat/demo.py
@@ -29,6 +29,7 @@ from fastapi import APIRouter, Depends, HTTPException, Request, status
 
 from app.ai.voice.agents.breeze_buddy.template.cache import get_template_by_id_cached
 from app.api.routers.breeze_buddy.chat.handlers import (
+    approve_chat_tool_handler,
     create_chat_session_handler,
     end_chat_session_handler,
     load_chat_session_or_404,
@@ -52,6 +53,7 @@ from app.database.accessor.breeze_buddy.chat_session import (
 )
 from app.schemas import UserInfo, UserRole
 from app.schemas.breeze_buddy.chat import (
+    ApproveToolRequest,
     ChatEndedReason,
     ChatMessageRole,
     ChatSessionStatus,
@@ -242,6 +244,35 @@ async def _assistant_turn_count(session_id: str) -> int:
     return sum(1 for r in rows if r.role == ChatMessageRole.ASSISTANT)
 
 
+async def _enforce_demo_turn_budget(
+    request: Request, ctx: DemoSessionContext, session_id: str
+) -> None:
+    """Shared pre-gates for every demo turn-driving route (/message and
+    /approval): per-IP message rate limit, then the per-session
+    assistant-turn cap. Both raise 429.
+
+    Prefer the cap baked into the token (frozen at session-create); fall
+    back to the live dynamic value only if the token has none, so an old
+    token + new flag still gets a sensible cap.
+    """
+    await _enforce_ip_limit(
+        request=request,
+        bucket="message",
+        limit=await DEMO_MESSAGES_PER_IP_HOUR(),
+    )
+
+    cap = ctx.message_cap or await DEMO_MESSAGE_CAP_PER_SESSION()
+    used = await _assistant_turn_count(session_id)
+    if used >= cap:
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail=(
+                f"Demo session reached its {cap}-turn limit. "
+                "Start a new demo session to continue exploring."
+            ),
+        )
+
+
 @router.post(
     "/session/{session_id}/message",
     summary="Stream one demo turn (SSE) — capped per session",
@@ -266,27 +297,32 @@ async def demo_send_message(
     demo token already binds ``session_id``, so additional auth would
     be redundant.
     """
-    await _enforce_ip_limit(
-        request=request,
-        bucket="message",
-        limit=await DEMO_MESSAGES_PER_IP_HOUR(),
-    )
-
-    # Prefer the cap baked into the token (frozen at session-create); fall
-    # back to the live dynamic value only if the token has none, so an old
-    # token + new flag still gets a sensible cap.
-    cap = ctx.message_cap or await DEMO_MESSAGE_CAP_PER_SESSION()
-    used = await _assistant_turn_count(session_id)
-    if used >= cap:
-        raise HTTPException(
-            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
-            detail=(
-                f"Demo session reached its {cap}-turn limit. "
-                "Start a new demo session to continue exploring."
-            ),
-        )
+    await _enforce_demo_turn_budget(request, ctx, session_id)
 
     return await send_chat_message_handler(session_id, req, access_check=None)
+
+
+@router.post(
+    "/session/{session_id}/approval",
+    summary="Decide a pending HITL tool approval (SSE resume) — demo surface",
+)
+async def demo_approve_tool(
+    session_id: str,
+    req: ApproveToolRequest,
+    request: Request,
+    ctx: DemoSessionContext = Depends(require_demo_session),
+):
+    """Demo-token variant of the approval route.
+
+    Same pre-gates as ``demo_send_message``: per-IP limit on the shared
+    "message" bucket AND the per-session assistant-turn cap — an approval
+    resume is a full LLM turn with a fresh tool-cycle budget, so skipping
+    the cap would let a looping template convert one capped session into
+    an hour-rate-limited stream of free turns.
+    """
+    await _enforce_demo_turn_budget(request, ctx, session_id)
+
+    return await approve_chat_tool_handler(session_id, req, access_check=None)
 
 
 @router.post(

--- a/app/api/routers/breeze_buddy/chat/handlers.py
+++ b/app/api/routers/breeze_buddy/chat/handlers.py
@@ -8,17 +8,23 @@ stay thin: validate auth, then delegate.
 
 import asyncio
 import time
-from datetime import datetime
-from typing import Any, AsyncIterator, Callable, Dict, Optional, cast
+from datetime import datetime, timezone
+from typing import Any, AsyncIterator, Callable, Dict, List, Optional, cast
 
 from fastapi import HTTPException, status
 from fastapi.responses import StreamingResponse
 
 from app.ai.voice.agents.breeze_buddy.chat.agent import ChatAgent
+from app.ai.voice.agents.breeze_buddy.chat.approvals import (
+    EXPIRED_RESULT,
+    WIRE_STATUS_BY_DB_STATUS,
+    resolve_dangling_approvals,
+)
 from app.ai.voice.agents.breeze_buddy.chat.block_codec import (
     blocks_to_llm_context_messages,
     filter_visible_blocks,
     repair_dangling_tool_uses,
+    tool_results_to_user_blocks,
 )
 from app.ai.voice.agents.breeze_buddy.chat.client_context import (
     ClientContextTooLarge,
@@ -27,6 +33,10 @@ from app.ai.voice.agents.breeze_buddy.chat.client_context import (
 from app.ai.voice.agents.breeze_buddy.chat.metrics import TurnMetrics
 from app.ai.voice.agents.breeze_buddy.chat.sse import SSEEvent, format_sse
 from app.ai.voice.agents.breeze_buddy.llm import get_llm_service
+from app.ai.voice.agents.breeze_buddy.template.approval import (
+    LLM_STATUS_DENIED,
+    WIRE_STATUS_SUPERSEDED,
+)
 from app.ai.voice.agents.breeze_buddy.template.cache import get_template_by_id_cached
 from app.ai.voice.agents.breeze_buddy.template.transformation_function import (
     TEMPLATE_FUNCTION_REGISTRY,
@@ -51,8 +61,14 @@ from app.database.accessor.breeze_buddy.chat_session import (
 from app.database.accessor.breeze_buddy.credentials import (
     get_credentials_as_template_vars,
 )
+from app.database.accessor.breeze_buddy.tool_approvals import (
+    decide_tool_approval,
+    get_tool_approval,
+    list_pending_tool_approvals,
+)
 from app.schemas import UserInfo
 from app.schemas.breeze_buddy.chat import (
+    ApproveToolRequest,
     ChatEndedReason,
     ChatMessageRole,
     ChatSession,
@@ -65,6 +81,7 @@ from app.schemas.breeze_buddy.chat import (
     GreetingMessage,
     ListChatSessionsResponse,
     SendChatMessageRequest,
+    ToolApprovalStatus,
 )
 from app.services.redis.locks import LockAcquireError, RedisLock
 
@@ -415,7 +432,8 @@ async def send_chat_message_handler(
     row, template, capped message history). No sticky LB or in-memory
     cache is involved.
 
-    Per-turn DB shape: 1 session read + 1 template read + 1 history
+    Per-turn DB shape: 1 session read + 1 template read + 1 approval-
+    supersede UPDATE (claims nothing when no approvals pend) + 1 history
     read (capped) + 2 message INSERTs + 1 combined session UPDATE.
     All round-trips constant per turn — none scale with conversation
     length.
@@ -473,6 +491,27 @@ async def send_chat_message_handler(
                 ),
             )
 
+        # HITL: a new user message supersedes every pending approval (the
+        # user moved on without deciding). MUST run under the lock and
+        # BEFORE the history load — it persists the synthetic tool_result
+        # rows that keep the replayed history fully answered. The resolved
+        # events ride at the start of this turn's stream so live cards
+        # flip to superseded without client-side inference.
+        # NOTE: requires migration 033 (tool_approvals) — run
+        # `python scripts/migrate.py up` before deploying this version.
+        superseded = await resolve_dangling_approvals(session_id, only_expired=False)
+        pre_events: List[SSEEvent] = [
+            SSEEvent(
+                event="function_approval_resolved",
+                data={
+                    "tool_call_id": row.tool_call_id,
+                    "status": WIRE_STATUS_SUPERSEDED,
+                    "reason": row.reason,
+                },
+            )
+            for row in superseded
+        ]
+
         history_limit = await CHAT_HISTORY_REPLAY_LIMIT()
         history_rows = await list_chat_messages_for_session(
             session_id, limit=history_limit
@@ -492,10 +531,11 @@ async def send_chat_message_handler(
                 if row.role in (ChatMessageRole.USER, ChatMessageRole.ASSISTANT)
             ]
         )
-        # Defensive both-direction repair: an unmatched tool_use (crash or
-        # cancel between the assistant-row persist and the tool-result
-        # persist) gets a synthetic error result; orphan tool_results from
-        # window truncation are dropped. No-op on well-formed history.
+        # Defensive both-direction repair: every pending approval was just
+        # resolved + persisted above, so nothing is legitimately dangling —
+        # any unmatched tool_use here is a decided-but-lost row (crash or
+        # cancel between claim and persist) and gets a synthetic error
+        # result; orphan tool_results from window truncation are dropped.
         history = cast(list, repair_dangling_tool_uses(history))
 
         # Load per-session agent state (cart_id, customer_id, etc. for
@@ -584,6 +624,7 @@ async def send_chat_message_handler(
                     history=history,
                     current_node=resume_node,
                 ),
+                pre_events=pre_events,
             ),
             media_type="text/event-stream",
             headers={
@@ -605,12 +646,15 @@ async def _turn_sse_stream(
     lock: RedisLock,
     turn_metrics: TurnMetrics,
     events: AsyncIterator[SSEEvent],
+    pre_events: Optional[List[SSEEvent]] = None,
 ) -> AsyncIterator[str]:
-    """SSE generator scaffolding for a chat turn stream.
+    """SSE generator scaffolding shared by ``/message`` and ``/approval``.
 
     Owns the cancel-bus registration, CancelledError → ``turn_end
     {CANCELED}`` mapping, generic error masking, the shielded lock
-    release, and the best-effort turn-metrics write.
+    release, and the best-effort turn-metrics write. ``pre_events`` are
+    emitted before the agent's stream (e.g. ``function_approval_resolved``
+    for rows the handler lazily expired/superseded under the lock).
     """
     # Register ourselves so /cancel can find and cancel this task
     # cross-pod. The registration MUST happen inside the generator
@@ -625,6 +669,9 @@ async def _turn_sse_stream(
         registered = True
     try:
         try:
+            for pre in pre_events or []:
+                turn_metrics.observe(pre)
+                yield format_sse(pre)
             async for event in events:
                 turn_metrics.observe(event)
                 yield format_sse(event)
@@ -709,6 +756,260 @@ async def _turn_sse_stream(
         # row (assistant_idx None); the [CHAT_METRICS] log already
         # captured it either way.
         await _persist_turn_metrics(turn_metrics)
+
+
+def _approval_conflict(code: str, message: str, wire_status: Optional[str] = None):
+    """409 with a machine-readable body for the approval route.
+
+    The SDK branches on ``detail.code`` (already_decided | lock_contended |
+    voice_live) — do NOT collapse these into the factories' blanket
+    409→voice-live-conflict mapping. ``status`` carries the winning wire
+    status for already_decided so the client can settle the card.
+    """
+    detail: Dict[str, Any] = {"code": code, "message": message}
+    if wire_status is not None:
+        detail["status"] = wire_status
+    return HTTPException(status_code=status.HTTP_409_CONFLICT, detail=detail)
+
+
+async def approve_chat_tool_handler(
+    session_id: str,
+    req: ApproveToolRequest,
+    *,
+    access_check: Optional[Callable[[ChatSession], None]] = None,
+) -> StreamingResponse:
+    """Apply a HITL decision to a pending tool approval and stream the
+    resumed turn (same SSE shape as ``/message``).
+
+    Order is load-bearing (see plan review):
+    1. Atomically claim the target row (only a PENDING row can be decided;
+       a lost race 409s with ``already_decided`` + the winning status).
+    2. A decision arriving after ``expires_at`` claims the row as EXPIRED
+       (wire status ``timeout``) — the resume turn still runs so the LLM
+       can acknowledge the timeout.
+    3. Deny/expired: persist the synthetic tool_result row NOW, under the
+       lock, before the stream is constructed — no execution is needed, so
+       the decided-but-unpersisted crash window doesn't exist for them.
+    4. Lazily expire any OTHER pending rows past their TTL and emit their
+       ``function_approval_resolved {timeout}`` at stream start (this is
+       the one stream the widget is actively listening to).
+    5. Load history AFTER all the above so replay is fully answered, then
+       repair with the claimed id + still-pending siblings excluded.
+    """
+    lock = RedisLock(_lock_key(session_id), ttl_seconds=_SESSION_LOCK_TTL_SECONDS)
+    try:
+        await lock.acquire()
+    except LockAcquireError:
+        raise _approval_conflict(
+            "lock_contended",
+            "Another turn is already in flight for this session. "
+            "Wait for the in-flight stream to complete and retry.",
+        )
+
+    lock_handed_off = False
+    try:
+        fresh = await get_chat_session_by_id(session_id)
+        if fresh is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Chat session '{session_id}' not found",
+            )
+        if access_check is not None:
+            access_check(fresh)
+        if fresh.status == ChatSessionStatus.ENDED:
+            raise HTTPException(
+                status_code=status.HTTP_410_GONE,
+                detail=f"Chat session '{session_id}' has ended",
+            )
+
+        template = await get_template_by_id_cached(fresh.template_id)
+        if template is None:
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail=(
+                    f"Template '{fresh.template_id}' for chat session "
+                    f"'{session_id}' no longer exists"
+                ),
+            )
+
+        row = await get_tool_approval(session_id, req.tool_call_id)
+        if row is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=(
+                    f"No approval request with tool_call_id "
+                    f"'{req.tool_call_id}' for this session"
+                ),
+            )
+        if row.status != ToolApprovalStatus.PENDING:
+            raise _approval_conflict(
+                "already_decided",
+                f"This approval was already resolved ({row.status.value}).",
+                WIRE_STATUS_BY_DB_STATUS.get(row.status),
+            )
+
+        is_expired = row.expires_at <= datetime.now(timezone.utc)
+        if is_expired:
+            new_status = ToolApprovalStatus.EXPIRED
+            decision_reason: Optional[str] = "decision arrived after expiry"
+        elif req.approved:
+            new_status = ToolApprovalStatus.APPROVED
+            decision_reason = req.reason
+        else:
+            new_status = ToolApprovalStatus.DENIED
+            decision_reason = req.reason
+
+        claimed = await decide_tool_approval(
+            session_id, req.tool_call_id, new_status, decision_reason
+        )
+        if claimed is None:
+            # Lost the claim race to a concurrent decision.
+            relook = await get_tool_approval(session_id, req.tool_call_id)
+            raise _approval_conflict(
+                "already_decided",
+                "This approval was already resolved by a concurrent request.",
+                WIRE_STATUS_BY_DB_STATUS.get(relook.status) if relook else None,
+            )
+
+        effective_approved = req.approved and not is_expired
+        wire_status = WIRE_STATUS_BY_DB_STATUS[new_status]
+
+        logger.info(
+            f"[approval] session={session_id} tool_call_id={req.tool_call_id} "
+            f"function={claimed.function_name} decision={new_status.value}"
+            + (f" reason={decision_reason!r}" if decision_reason else "")
+        )
+
+        synthetic_result: Optional[Dict[str, Any]] = None
+        if not effective_approved:
+            synthetic_result = (
+                dict(EXPIRED_RESULT)
+                if is_expired
+                else {
+                    "status": LLM_STATUS_DENIED,
+                    "reason": req.reason or "the user did not approve this action",
+                }
+            )
+            # Persist under the lock, before streaming — the history load
+            # below already sees a fully-answered batch for this call.
+            await insert_chat_message(
+                session_id=session_id,
+                role=ChatMessageRole.USER,
+                content=None,
+                content_blocks=tool_results_to_user_blocks(
+                    [(req.tool_call_id, synthetic_result)]
+                ),
+            )
+
+        # Lazily expire the OTHER pending rows past their TTL (persists
+        # their synthetic timeout results) and surface them at stream start.
+        expired_siblings = await resolve_dangling_approvals(
+            session_id, only_expired=True
+        )
+        pre_events: List[SSEEvent] = [
+            SSEEvent(
+                event="function_approval_resolved",
+                data={
+                    "tool_call_id": sib.tool_call_id,
+                    "status": WIRE_STATUS_BY_DB_STATUS[ToolApprovalStatus.EXPIRED],
+                    "reason": sib.reason,
+                },
+            )
+            for sib in expired_siblings
+        ]
+
+        # include_expired: a sibling whose expires_at falls between the
+        # sweep above and this statement is still PENDING and decidable —
+        # it must stay in the exclude set (and keep the turn awaiting)
+        # rather than getting a fabricated "lost" answer; the next touch
+        # lazily expires it.
+        pending_siblings = await list_pending_tool_approvals(
+            session_id, include_expired=True
+        )
+        pending_sibling_ids = [sib.tool_call_id for sib in pending_siblings]
+
+        history_limit = await CHAT_HISTORY_REPLAY_LIMIT()
+        history_rows = await list_chat_messages_for_session(
+            session_id, limit=history_limit
+        )
+        history: list = blocks_to_llm_context_messages(
+            [
+                {
+                    "role": hist_row.role.value,
+                    "content": hist_row.content,
+                    "content_blocks": hist_row.content_blocks,
+                }
+                for hist_row in history_rows
+                if hist_row.role in (ChatMessageRole.USER, ChatMessageRole.ASSISTANT)
+            ]
+        )
+        # The claimed call (approve path answers it in-turn) and the
+        # still-pending siblings must STAY unanswered; anything else
+        # unmatched is decided-but-lost and gets a synthetic error.
+        history = cast(
+            list,
+            repair_dangling_tool_uses(
+                history, exclude_ids={req.tool_call_id, *pending_sibling_ids}
+            ),
+        )
+
+        state_row = await get_agent_session_state(session_id)
+        agent_state: Dict[str, Any] = state_row.data if state_row else {}
+
+        persisted_template_vars = (
+            fresh.metadata.get("template_vars", {})
+            if isinstance(fresh.metadata, dict)
+            else {}
+        )
+        template_vars = await _build_render_template_vars(
+            template, persisted_template_vars
+        )
+
+        llm = await get_llm_service(_resolve_llm_configuration(template), pooled=True)
+        agent = ChatAgent(
+            session_id=session_id,
+            template=template,
+            llm=llm,
+            template_vars=template_vars,
+            agent_state=agent_state,
+        )
+        resume_node = fresh.current_node
+
+        turn_metrics = TurnMetrics(
+            session_id=session_id,
+            template_id=template.id,
+            t0=time.monotonic(),
+        )
+
+        response = StreamingResponse(
+            _turn_sse_stream(
+                session_id=session_id,
+                lock=lock,
+                turn_metrics=turn_metrics,
+                events=agent.run_approval_turn(
+                    approval=claimed,
+                    approved=effective_approved,
+                    wire_status=wire_status,
+                    decision_reason=decision_reason,
+                    synthetic_result=synthetic_result,
+                    history=history,
+                    current_node=resume_node,
+                    pending_sibling_ids=pending_sibling_ids,
+                ),
+                pre_events=pre_events,
+            ),
+            media_type="text/event-stream",
+            headers={
+                "Cache-Control": "no-cache, no-transform",
+                "X-Accel-Buffering": "no",
+                "Connection": "keep-alive",
+            },
+        )
+        lock_handed_off = True
+        return response
+    finally:
+        if not lock_handed_off:
+            await lock.release()
 
 
 async def cancel_chat_turn_handler(session_id: str) -> None:

--- a/app/api/routers/breeze_buddy/widget/__init__.py
+++ b/app/api/routers/breeze_buddy/widget/__init__.py
@@ -29,6 +29,7 @@ from app.api.security.breeze_buddy.widget_token import (
     require_widget_session,
 )
 from app.schemas.breeze_buddy.chat import (
+    ApproveToolRequest,
     CreateWidgetSessionRequest,
     CreateWidgetSessionResponse,
     EndChatSessionResponse,
@@ -41,6 +42,7 @@ from app.schemas.breeze_buddy.chat import (
 )
 
 from .handlers import (
+    approve_widget_tool_handler,
     cancel_widget_message_handler,
     create_widget_session_handler,
     end_widget_session_handler,
@@ -76,6 +78,11 @@ async def widget_message_preflight(session_id: str) -> Response:
 
 @router.options("/session/{session_id}/cancel")
 async def widget_cancel_preflight(session_id: str) -> Response:
+    return options_cors_response()
+
+
+@router.options("/session/{session_id}/approval")
+async def widget_approval_preflight(session_id: str) -> Response:
     return options_cors_response()
 
 
@@ -152,6 +159,25 @@ async def cancel_widget_message(
     """
     await cancel_widget_message_handler(session_id, ctx)
     return Response(status_code=status.HTTP_202_ACCEPTED)
+
+
+@router.post(
+    "/session/{session_id}/approval",
+    summary="Decide a pending HITL tool approval (streams the resumed turn)",
+)
+async def approve_widget_tool(
+    session_id: str,
+    req: ApproveToolRequest,
+    request: Request,
+    ctx: WidgetSessionContext = Depends(require_widget_session),
+):
+    """Apply the end user's approve/deny to a pending gated function call.
+
+    Streams the resumed turn as SSE (same shape as ``/message``). 409s
+    carry a machine-readable ``detail.code``: ``already_decided`` |
+    ``lock_contended`` | ``voice_live``.
+    """
+    return await approve_widget_tool_handler(session_id, req, request, ctx)
 
 
 @router.post(

--- a/app/api/routers/breeze_buddy/widget/handlers.py
+++ b/app/api/routers/breeze_buddy/widget/handlers.py
@@ -36,6 +36,7 @@ from app.ai.voice.agents.breeze_buddy.services.daily.daily import (
 )
 from app.ai.voice.agents.breeze_buddy.template.cache import get_template_by_id_cached
 from app.api.routers.breeze_buddy.chat.handlers import (
+    approve_chat_tool_handler,
     cancel_chat_turn_handler,
     create_chat_session_handler,
     end_chat_session_handler,
@@ -68,6 +69,9 @@ from app.database.accessor.breeze_buddy.lead_call_tracker import (
     handle_lead_abort,
     reset_widget_voice_lead,
 )
+from app.database.accessor.breeze_buddy.tool_approvals import (
+    list_pending_tool_approvals,
+)
 from app.database.accessor.breeze_buddy.widget_config import (
     get_widget_config_by_id,
 )
@@ -79,6 +83,7 @@ from app.schemas import (
     UserRole,
 )
 from app.schemas.breeze_buddy.chat import (
+    ApproveToolRequest,
     ChatMessage,
     ChatSessionStatus,
     CreateChatSessionRequest,
@@ -285,6 +290,68 @@ async def send_widget_message_handler(
         )
 
     return await send_chat_message_handler(session_id, req, access_check=None)
+
+
+# ---------------------------------------------------------------------------
+# POST /widget/session/{id}/approval
+# ---------------------------------------------------------------------------
+
+
+async def approve_widget_tool_handler(
+    session_id: str,
+    req: ApproveToolRequest,
+    request: Request,
+    ctx: WidgetSessionContext,
+):
+    """Decide a pending HITL tool approval on the widget surface.
+
+    Same gate order as ``send_widget_message_handler`` (config-active 401
+    → IP limit → ownership → 410 ENDED → 409 channel!=CHAT), then
+    delegates to the shared chat approval handler. The channel 409
+    carries ``detail.code="voice_live"`` so the SDK can distinguish it
+    from ``already_decided`` / ``lock_contended``.
+    """
+    cfg = await get_widget_config_by_id(ctx.widget_config_id)
+    if cfg is None or not cfg.active:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Widget configuration not found or inactive",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    await enforce_widget_ip_limit(
+        request=request,
+        bucket="message",
+        limit=cfg.max_messages_per_ip_hour,
+        widget_config_id=cfg.id,
+    )
+
+    session = await get_chat_session_by_id(session_id)
+    if session is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Widget session '{session_id}' not found",
+        )
+    assert_widget_session_ownership(session, ctx)
+    if session.status == ChatSessionStatus.ENDED:
+        raise HTTPException(
+            status_code=status.HTTP_410_GONE,
+            detail=f"Widget session '{session_id}' has ended",
+        )
+    if session.current_channel != WidgetChannel.CHAT:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={
+                "code": "voice_live",
+                "message": (
+                    f"Widget session is on channel "
+                    f"{session.current_channel.value}; end the voice "
+                    "attachment before deciding chat approvals."
+                ),
+            },
+        )
+
+    return await approve_chat_tool_handler(session_id, req, access_check=None)
 
 
 # ---------------------------------------------------------------------------
@@ -820,6 +887,10 @@ async def get_widget_session_state_handler(
         if isinstance(facts, dict):
             client_context = facts
 
+    # Unexpired pending HITL approvals so the embed can repaint approval
+    # cards after a reload (lazy expiry — the accessor filters expires_at).
+    pending_approvals = await list_pending_tool_approvals(session_id)
+
     return WidgetSessionStateResponse(
         session_id=session_id,
         status=session.status,
@@ -831,4 +902,5 @@ async def get_widget_session_state_handler(
         template_vars=template_vars,
         metadata=session.metadata or {},
         client_context=client_context,
+        pending_approvals=pending_approvals,
     )

--- a/docs/CHAT_MODE.md
+++ b/docs/CHAT_MODE.md
@@ -201,6 +201,7 @@ All endpoints under `/api/breeze_buddy/chat/`. JWT required; same RBAC middlewar
 | `POST` | `/session` | Create new chat session for a template. Returns session ID + initial assistant greeting. |
 | `GET` | `/session/{id}` | Resume — returns full message history and current status. |
 | `POST` | `/session/{id}/message` | Send user message. Returns **SSE stream** for the assistant's turn. |
+| `POST` | `/session/{id}/approval` | Decide a pending HITL tool approval (§6.7). Returns **SSE stream** for the resumed turn. |
 | `POST` | `/session/{id}/end` | Explicit end (user closes the chat). Fires outcome webhook. |
 | `GET` | `/session/{id}/transcript` | Plain JSON transcript export (read-only). |
 
@@ -275,8 +276,10 @@ Acquires per-session lock (Redis). Returns **SSE stream** with these event types
 | `assistant_message` | `{ idx, content }` | Full assistant turn (always emitted at end of turn, after streaming). |
 | `function_call_started` | `{ name, args, tool_call_id }` | "Thinking…" indicator equivalent. |
 | `function_call_completed` | `{ name, tool_call_id, result_summary }` | |
+| `function_approval_requested` | `{ tool_call_id, name, args, prompt, expires_at }` | HITL (§6.7): the LLM called an approval-gated function. `args` are the post-injection arguments that will actually run. The turn ends right after (see `turn_end`). |
+| `function_approval_resolved` | `{ tool_call_id, status, reason }` | HITL (§6.7): a pending approval resolved. `status` ∈ `approved \| denied \| timeout \| superseded`. Emitted on the `/approval` resume stream, and at stream start for lazily expired/superseded rows. |
 | `node_transition` | `{ to }` | Synthesized node moved (flow mode only). The `from` field from D8's draft was dropped — clients should track `current_node` themselves between turns. |
-| `turn_end` | `{ session_status }` | Closes the SSE stream. Always last. |
+| `turn_end` | `{ session_status, assistant_idx, awaiting_approval?, pending_tool_call_ids? }` | Closes the SSE stream. Always last. `awaiting_approval: true` (additive, HITL §6.7) means the turn paused at one or more gated calls — `session_status` stays `ACTIVE` and the decision arrives via `/approval`. |
 | `error` | `{ code, message }` | Stream closes after. |
 
 If lock contended → HTTP 409 (don't open SSE).
@@ -291,6 +294,59 @@ isn't fired by v1. There is no in-memory registry to evict from (§4).
 ### 6.6 `GET /session/{id}/transcript`
 
 Plain JSON. Useful for export/audit. Same payload as `GET /session/{id}` minus runtime status.
+
+### 6.7 HITL tool approvals — `POST /session/{id}/approval` → SSE
+
+A template author marks a global function (HTTP/builtin/custom) with an
+`approval` config (`template/types.py:ApprovalConfig`). When the LLM calls
+it in chat, the gated call does **not** execute: the turn persists a
+PENDING row in `tool_approvals` (migration 033), emits
+`function_approval_requested`, and ends with `turn_end
+{awaiting_approval: true}` (Pattern B — approval-as-data, no in-memory
+wait). The decision arrives here:
+
+Request: `{ "tool_call_id": "...", "approved": true|false, "reason"?: "..." }`
+
+The handler atomically claims the row (`UPDATE … WHERE status='PENDING'`),
+then streams the resumed turn — identical event shapes to `/message`, but
+with **no** `user_committed` (there is no new user message):
+`function_approval_resolved` → `function_call_completed` →
+`assistant_token`* → `turn_end`.
+
+Semantics worth knowing:
+
+- **Approve** executes the stored post-injection arguments verbatim (the
+  idempotency hash baked at gate time replays — it IS that operation),
+  persists the result, then continues the LLM loop.
+- **Deny** persists a synthetic `{"status":"denied"}` tool result under the
+  lock *before* streaming; the LLM acknowledges in the resumed turn.
+- **Expiry is lazy** (`expires_at` = `chat_expiry_secs`, default 1h). A
+  late decision claims the row as `EXPIRED` (wire status `timeout`) and
+  the resume still runs so the LLM can say it timed out. No sweeper.
+- **Supersede**: any new `/message` claims every pending row as
+  `SUPERSEDED` with an LLM-visible `not_decided` result (deliberately not
+  "denied" — the user moved on, they didn't refuse).
+- **Sibling batches**: with several gated calls in one batch, each decision
+  is its own `/approval` POST; only the last one (no pending siblings left)
+  re-invokes the LLM. Replay stays provider-valid throughout — every
+  persisted `tool_use` is answered before any LLM call
+  (`block_codec.repair_dangling_tool_uses` is the defensive backstop).
+- **409s carry a machine-readable body**: `detail.code` ∈
+  `already_decided` (with the winning `status`) | `lock_contended` |
+  `voice_live` (widget surface only). Clients must branch on the code —
+  not all 409s mean "voice is live".
+
+All three auth surfaces expose the route: `/chat/session/{id}/approval`
+(RBAC), `/chat/demo/session/{id}/approval` (demo bearer + the same
+per-session turn cap as `/message`), `/widget/session/{id}/approval`
+(widget bearer + CORS preflight). `GET /widget/session/{id}` additionally
+returns `pending_approvals` (unexpired) so a reloaded embed can repaint
+cards.
+
+Voice (Daily) uses a different pattern for the same template config —
+in-process gating via RTVI messages; see `docs/DAILY_RTVI_EVENTS.md`.
+Telephony has no approval surface: `approval.on_no_channel` decides
+(`execute` default with a loud warning, or `deny`).
 
 ## 7. Agent Runtime
 

--- a/tests/test_response_transform.py
+++ b/tests/test_response_transform.py
@@ -341,7 +341,7 @@ def test_omit_fields_via_walker_at_root_strips_envelope():
 
 
 def test_strip_html_removes_tags_and_normalises_whitespace():
-    assert strip_html("<p>Hello   <b>world</b>!</p>", {}) == "Hello world !"
+    assert strip_html("<p>Hello   <b>world</b>!</p>", {}) == "Hello world!"
 
 
 def test_strip_html_truncates_at_word_boundary():


### PR DESCRIPTION
**HITL approval stack 7/7** — based on #825.

⚠️ **Deploy requirement: migration 033 (\`tool_approvals\`, PR #823) MUST be applied to the target DB before this deploys.** The supersede pre-step runs on **every** \`/message\` (all three surfaces) and the widget state GET reads pending approvals — with no table, all chat traffic 500s. (Deliberate decision: no graceful degradation; migrations always run with deploy.)

Resume endpoint: \`POST /session/{id}/approval {tool_call_id, approved, reason?}\` on RBAC, demo (same turn-budget pre-check as \`/message\`, via the extracted \`_enforce_demo_turn_budget\`), and widget (OPTIONS preflight + full gate order ending in 409 \`code=voice_live\` while a voice attachment is live). Response streams the resumed turn as SSE, same shape as \`/message\`.

Handler order: load (404) → not-PENDING 409 \`code=already_decided\` + winning status → expired claims as EXPIRED / wire \`timeout\` (resume still runs so the model can say so) → atomic claim (lost race → already_decided) → deny/expired persists the synthetic tool_result row under the lock BEFORE the stream constructs → expired-siblings sweep (resolved events ride at stream start) → history + dangling repair excluding {claimed id} ∪ still-pending siblings → \`run_approval_turn\`.

409 bodies are machine-readable: \`{detail:{code: already_decided|lock_contended|voice_live, status?}}\` — the SDK branches on \`code\`; do not collapse into a blanket conflict mapping.

\`send_chat_message_handler\` gains the supersede pre-step: a new user message resolves every pending approval as SUPERSEDED under the lock BEFORE history load. Widget session state returns \`pending_approvals\` for reload repaint. Docs: \`CHAT_MODE.md\` route + SSE table + approvals subsection.

**After merge**: backend deploy → loom SDK 0.4.0 publish + widget upload → only then template opt-in (the \`approval\` field is the real feature flag).

🤖 Generated with [Claude Code](https://claude.com/claude-code)