### PR TITLE
feat: inline Google Sheets data source integration

### DIFF
--- a/app/ai/voice/agents/breeze_buddy/dispatch/worker.py
+++ b/app/ai/voice/agents/breeze_buddy/dispatch/worker.py
@@ -52,6 +52,9 @@ from app.ai.voice.agents.breeze_buddy.managers.calls import (
     _release_number,
     _run_pre_checks_for_lead,
 )
+from app.ai.voice.agents.breeze_buddy.managers.data_source_prefetch import (
+    prefetch_data_sources,
+)
 from app.ai.voice.agents.breeze_buddy.managers.utils import (
     prepare_and_store_initial_greeting,
 )
@@ -339,6 +342,8 @@ class Worker:
 
             if template:
                 template = apply_playground_overrides(locked, template)
+                if template.data_sources:
+                    asyncio.create_task(prefetch_data_sources(template=template))
                 await prepare_and_store_initial_greeting(
                     lead_id=locked.id,
                     payload=locked.payload or {},

--- a/app/ai/voice/agents/breeze_buddy/managers/data_source_prefetch.py
+++ b/app/ai/voice/agents/breeze_buddy/managers/data_source_prefetch.py
@@ -1,0 +1,93 @@
+"""
+Data Source Prefetch Manager
+
+Pre-warms Redis with Google Sheets content for all DataSourceRefs attached to a
+template at dispatch time. Runs concurrently with greeting TTS synthesis.
+
+Cache key is scoped to a content hash so concurrent calls sharing the same sheet
+use a single cached copy.
+
+Cache key : ``datasource:{sheet_id}:{sheet_name}:{cols_hash}``
+TTL        : 60 s
+"""
+
+import asyncio
+import hashlib
+import json
+from typing import Optional
+
+from app.ai.voice.agents.breeze_buddy.template.types import DataSourceRef, TemplateModel
+from app.core.logger import logger
+from app.services.data_sources import DATA_SOURCE_UNAVAILABLE
+from app.services.google.sheets import extract_spreadsheet_id, fetch_formatted
+from app.services.redis import get_redis_service
+
+_CACHE_TTL = 60  # seconds — shared across leads; short to keep data fresh
+_FETCH_TIMEOUT = 5.0
+
+
+def _cache_key(ref: DataSourceRef) -> str:
+    """Derive a stable cache key from the sheet config."""
+    spreadsheet_id = extract_spreadsheet_id(ref.spreadsheet_url)
+    if not spreadsheet_id:
+        spreadsheet_id = "invalid_url"
+    sheet = ref.sheet_name or "_first_"
+    cols = json.dumps(sorted(ref.columns or []))
+    cols_digest = hashlib.md5(cols.encode()).hexdigest()[:8]
+    return f"datasource:{spreadsheet_id}:{sheet}:{cols_digest}:{ref.format.value}"
+
+
+async def _prefetch_one(ref: DataSourceRef) -> None:
+    if not ref.is_active:
+        return
+
+    spreadsheet_id = extract_spreadsheet_id(ref.spreadsheet_url)
+    if not spreadsheet_id:
+        logger.warning("Prefetch: invalid spreadsheet_url for '%s'", ref.name)
+        return
+
+    try:
+        content = await asyncio.wait_for(
+            fetch_formatted(
+                spreadsheet_id=spreadsheet_id,
+                sheet_name=ref.sheet_name,
+                columns=ref.columns,
+                format=ref.format.value,
+            ),
+            timeout=_FETCH_TIMEOUT,
+        )
+    except asyncio.TimeoutError:
+        logger.warning("Prefetch timeout for data source '%s'", ref.name)
+        return
+    except Exception as exc:
+        logger.error(
+            "Prefetch error for data source '%s': %s", ref.name, exc, exc_info=True
+        )
+        return
+
+    if not content or content == DATA_SOURCE_UNAVAILABLE:
+        return
+
+    cache_key = _cache_key(ref)
+    try:
+        redis = await get_redis_service()
+        await redis.setex(cache_key, content, ttl_seconds=_CACHE_TTL)
+        logger.info(
+            "Prefetched data source '%s' (%d chars, TTL=%ds)",
+            ref.name,
+            len(content),
+            _CACHE_TTL,
+        )
+    except Exception as exc:
+        logger.error("Failed to cache data source '%s': %s", ref.name, exc)
+
+
+async def prefetch_data_sources(
+    template: Optional[TemplateModel],
+) -> None:
+    if not template or not template.data_sources:
+        return
+    await asyncio.gather(
+        *[_prefetch_one(ref) for ref in template.data_sources],
+        return_exceptions=True,
+    )

--- a/app/ai/voice/agents/breeze_buddy/template/field_reference.json
+++ b/app/ai/voice/agents/breeze_buddy/template/field_reference.json
@@ -17,7 +17,8 @@
     "secrets":                           { "description": "Flat dict of credential key-value pairs injected as template vars, overriding reseller-level credentials for the same keys. Values substitute into {secret_key} placeholders in HTTP URLs, headers, and bodies.", "example": { "api_token": "Bearer sk-prod-abc123", "webhook_secret": "wh_live_xyz789" } },
     "outbound_number_id":                { "description": "UUID of the outbound phone number record to use for calls from this template. Must belong to the reseller. Null to use the reseller-default number.", "example": "eb0df4e9-a438-4ce4-a828-addf9db5ce3a" },
     "is_active":                         { "description": "When false, the template is soft-disabled: dispatch will not enqueue new leads for it. Set to false (not delete) when retiring a template.", "example": true },
-    "supported_channels":                { "description": "Channels this template may be served on. Default ['voice']. Add 'chat' to enable the Buddy Assist web-chat mode. Must have at least one entry.", "example": ["voice"] }
+    "supported_channels":                { "description": "Channels this template may be served on. Default ['voice']. Add 'chat' to enable the Buddy Assist web-chat mode. Must have at least one entry.", "example": ["voice"] },
+    "data_sources":                      { "description": "Google Sheets data sources attached to this template. Each ref has name, spreadsheet_url, sheet_name, columns filter, output format (markdown_table/csv/json), and is_active flag. Fetched at call dispatch and injected as {datasource_<name>} template vars into LLM context. For example, a ref named 'customer_list' is referenced as {datasource_customer_list} in prompts.", "example": [{ "name": "customer_list", "spreadsheet_url": "https://docs.google.com/spreadsheets/d/abc123", "sheet_name": "Sheet1", "columns": ["Name", "Status"], "format": "markdown_table", "is_active": true }] }
   },
 
   "ConfigurationModel": {

--- a/app/ai/voice/agents/breeze_buddy/template/loader.py
+++ b/app/ai/voice/agents/breeze_buddy/template/loader.py
@@ -4,12 +4,16 @@ Flow Configuration Loader
 This module provides functionality to load templates from the database.
 """
 
+import asyncio
+import hashlib
+import json
 from typing import Dict, Optional, Tuple
 
 from app.ai.voice.agents.breeze_buddy.template.transformation_function import (
     TEMPLATE_FUNCTION_REGISTRY,
 )
 from app.ai.voice.agents.breeze_buddy.template.types import (
+    DataSourceRef,
     FlowMode,
     TemplateModel,
 )
@@ -21,6 +25,9 @@ from app.database.accessor.breeze_buddy.credentials import (
 from app.database.accessor.breeze_buddy.template import (
     get_template_by_id_with_fallback,
 )
+from app.services.data_sources import DATA_SOURCE_UNAVAILABLE
+from app.services.google.sheets import extract_spreadsheet_id, fetch_formatted
+from app.services.redis import get_redis_service
 
 
 class FlowConfigLoader:
@@ -205,6 +212,23 @@ class FlowConfigLoader:
                         f"Injected extra payload field '{field_name}' into template_vars"
                     )
 
+        # 5. data sources — inject as {datasource_<name>} variables
+        if template_obj.data_sources:
+            contents = await asyncio.gather(
+                *[
+                    self._fetch_one_data_source(ref)
+                    for ref in template_obj.data_sources
+                ],
+                return_exceptions=True,
+            )
+            for ref, result in zip(template_obj.data_sources, contents):
+                if not isinstance(result, Exception) and result is not None:
+                    var_key = f"datasource_{ref.name}"
+                    if var_key not in template_vars:
+                        template_vars[var_key] = result
+                        logger.info(
+                            f"Injected data source '{ref.name}' as variable '{var_key}'"
+                        )
         # Direct mode has a flat structure (system_prompt + flat function list)
         # rather than a nodes array, so render the top-level message fields and
         # skip the per-node loop entirely.
@@ -275,3 +299,59 @@ class FlowConfigLoader:
 
         logger.info(f"Rendered task messages for template {template_obj.name}")
         return template_obj, template_vars
+
+    async def _fetch_one_data_source(self, ref: "DataSourceRef") -> str:
+        if not ref.is_active:
+            return DATA_SOURCE_UNAVAILABLE
+
+        spreadsheet_id = extract_spreadsheet_id(ref.spreadsheet_url)
+        if not spreadsheet_id:
+            logger.warning(
+                "Data source '%s' has malformed spreadsheet_url: %s",
+                ref.name,
+                ref.spreadsheet_url,
+            )
+            return DATA_SOURCE_UNAVAILABLE
+
+        sheet = ref.sheet_name or "_first_"
+        cols = json.dumps(sorted(ref.columns or []))
+        cols_digest = hashlib.md5(cols.encode()).hexdigest()[:8]
+        cache_key = (
+            f"datasource:{spreadsheet_id}:{sheet}:{cols_digest}:{ref.format.value}"
+        )
+
+        try:
+            redis = await get_redis_service()
+            cached = await redis.get(cache_key)
+            if cached:
+                return cached
+        except Exception:
+            pass
+
+        try:
+            content = await asyncio.wait_for(
+                fetch_formatted(
+                    spreadsheet_id=spreadsheet_id,
+                    sheet_name=ref.sheet_name,
+                    columns=ref.columns,
+                    format=ref.format.value,
+                ),
+                timeout=5.0,
+            )
+        except asyncio.TimeoutError:
+            logger.warning("Data source '%s' fetch timed out", ref.name)
+            return DATA_SOURCE_UNAVAILABLE
+        except Exception as exc:
+            logger.error(
+                "Data source '%s' fetch failed: %s", ref.name, exc, exc_info=True
+            )
+            return DATA_SOURCE_UNAVAILABLE
+
+        if content != DATA_SOURCE_UNAVAILABLE:
+            try:
+                redis = await get_redis_service()
+                await redis.setex(cache_key, content, ttl_seconds=60)
+            except Exception:
+                pass
+
+        return content

--- a/app/ai/voice/agents/breeze_buddy/template/types.py
+++ b/app/ai/voice/agents/breeze_buddy/template/types.py
@@ -2062,6 +2062,40 @@ def _default_supported_channels() -> List[Literal["voice", "chat"]]:
     return ["voice"]
 
 
+class DataSourceFormat(str, Enum):
+    MARKDOWN_TABLE = "markdown_table"
+    CSV = "csv"
+    JSON = "json"
+
+
+class DataSourceRef(BaseModel):
+    """Inline config for a data source attached to a template.
+
+    Content is fetched at call time and injected as ``template_vars[datasource_<name>]``.
+    The merchant references it in prompts with ``{datasource_<name>}`` placeholder syntax
+    (e.g. name='products' → use ``{datasource_products}`` in prompts).
+    The ``datasource_`` prefix prevents collision with payload credentials.
+    """
+
+    name: str = Field(
+        description="Variable name. Referenced in prompts as {datasource_<name>} (e.g. name='products' → {datasource_products})"
+    )
+    spreadsheet_url: str = Field(
+        description="Full Google Sheets URL (shared with platform SA)"
+    )
+    sheet_name: Optional[str] = Field(
+        default=None, description="Tab name. NULL = first tab"
+    )
+    columns: Optional[List[str]] = Field(
+        default=None, description="Columns to include. NULL = all columns"
+    )
+    format: DataSourceFormat = Field(
+        default=DataSourceFormat.MARKDOWN_TABLE,
+        description="Output format: 'markdown_table' | 'csv' | 'json'",
+    )
+    is_active: bool = Field(default=True, description="Skip if false at call time")
+
+
 class TemplateModel(BaseModel):
     # Read-only fields (set by server, not editable via API).
     # These are intentionally excluded from ReplaceTemplateRequest so that
@@ -2081,6 +2115,10 @@ class TemplateModel(BaseModel):
     secrets: Optional[Dict[str, Any]] = None
     outbound_number_id: Optional[str] = None
     is_active: bool = True
+    data_sources: Optional[List[DataSourceRef]] = Field(
+        default=None,
+        description="Inline data source configs attached to this template",
+    )
     # Channels this template is allowed to be served on. Defaults to
     # voice-only so existing templates are unaffected. Add "chat" to
     # opt the template into the chat (text) mode flow build path
@@ -2129,6 +2167,7 @@ class CreateTemplateRequest(BaseModel):
     expected_callback_response_schema: Optional[Dict[str, Any]] = None
     configurations: Optional[ConfigurationModel] = None
     secrets: Optional[Dict[str, Any]] = None
+    data_sources: Optional[List[DataSourceRef]] = None
     supported_channels: List[Literal["voice", "chat"]] = Field(
         default_factory=_default_supported_channels,
         min_length=1,
@@ -2177,6 +2216,7 @@ class ReplaceTemplateRequest(BaseModel):
     expected_callback_response_schema: Optional[Dict[str, Any]] = None
     configurations: Optional[ConfigurationModel] = None
     secrets: Optional[Dict[str, Any]] = None
+    data_sources: Optional[List[DataSourceRef]] = None
     supported_channels: Optional[List[Literal["voice", "chat"]]] = Field(
         default=None,
         min_length=1,

--- a/app/api/routers/breeze_buddy/__init__.py
+++ b/app/api/routers/breeze_buddy/__init__.py
@@ -15,6 +15,7 @@ from app.api.routers.breeze_buddy.credentials import router as credentials_route
 
 # Daily transport (web/mobile clients via Daily.co)
 from app.api.routers.breeze_buddy.daily import router as daily_router
+from app.api.routers.breeze_buddy.data_sources import router as data_sources_router
 from app.api.routers.breeze_buddy.demo import router as demo_router
 from app.api.routers.breeze_buddy.leads import router as leads_router
 from app.api.routers.breeze_buddy.merchants import router as merchants_router
@@ -44,6 +45,7 @@ router = APIRouter()
 # ============================================================================
 
 # Public demo (unauthenticated)
+router.include_router(data_sources_router, prefix="", tags=["data-sources"])
 router.include_router(demo_router, prefix="", tags=["demo"])
 
 # Authentication (JWT & S2S tokens)

--- a/app/api/routers/breeze_buddy/data_sources/__init__.py
+++ b/app/api/routers/breeze_buddy/data_sources/__init__.py
@@ -1,0 +1,65 @@
+"""
+Sheet discovery endpoints (admin-only utility).
+
+Discovery routes declared BEFORE /{id} to avoid path conflict if CRUD endpoints
+are added later.
+"""
+
+from typing import List, Optional
+
+from fastapi import APIRouter, Depends, Query
+
+from app.api.security.breeze_buddy.rbac_token import get_current_user_with_rbac
+from app.core.security.authorization import require_admin
+from app.schemas import UserInfo
+from app.schemas.breeze_buddy.data_source import (
+    ColumnsResponse,
+    PreviewResponse,
+    TabsResponse,
+)
+
+from .handlers import (
+    list_columns_handler,
+    list_tabs_handler,
+    preview_handler,
+)
+
+router = APIRouter()
+
+
+@router.get("/data-sources/sheets/tabs", response_model=TabsResponse)
+async def get_sheet_tabs(
+    spreadsheet_url: str = Query(..., description="Full Google Sheets URL"),
+    current_user: UserInfo = Depends(get_current_user_with_rbac),
+):
+    """List all tab names in a Google Spreadsheet (admin-only)."""
+    require_admin(current_user)
+    return await list_tabs_handler(spreadsheet_url, current_user)
+
+
+@router.get("/data-sources/sheets/columns", response_model=ColumnsResponse)
+async def get_sheet_columns(
+    spreadsheet_url: str = Query(..., description="Full Google Sheets URL"),
+    sheet_name: Optional[str] = Query(
+        None, description="Tab name (default: first tab)"
+    ),
+    current_user: UserInfo = Depends(get_current_user_with_rbac),
+):
+    """List column headers for a sheet tab (admin-only)."""
+    require_admin(current_user)
+    return await list_columns_handler(spreadsheet_url, sheet_name)
+
+
+@router.get("/data-sources/sheets/preview", response_model=PreviewResponse)
+async def preview_sheet(
+    spreadsheet_url: str = Query(..., description="Full Google Sheets URL"),
+    sheet_name: Optional[str] = Query(
+        None, description="Tab name (default: first tab)"
+    ),
+    columns: Optional[List[str]] = Query(None, description="Columns to include"),
+    max_rows: int = Query(10, ge=1, le=100, description="Max rows to return"),
+    current_user: UserInfo = Depends(get_current_user_with_rbac),
+):
+    """Preview up to N rows from a sheet (admin-only)."""
+    require_admin(current_user)
+    return await preview_handler(spreadsheet_url, sheet_name, columns, max_rows)

--- a/app/api/routers/breeze_buddy/data_sources/handlers.py
+++ b/app/api/routers/breeze_buddy/data_sources/handlers.py
@@ -1,0 +1,97 @@
+"""Discovery handlers for sheet exploration (admin-only)."""
+
+from typing import List, Optional
+
+from fastapi import HTTPException, status
+
+from app.core.logger import logger
+from app.schemas.breeze_buddy.auth import UserInfo
+from app.schemas.breeze_buddy.data_source import (
+    ColumnsResponse,
+    PreviewResponse,
+    TabsResponse,
+)
+from app.services.google.sheets import (
+    extract_spreadsheet_id,
+    fetch_sheet_data,
+    get_column_headers,
+    list_tabs,
+)
+
+
+def _log_caller(spreadsheet_id: str, current_user: UserInfo) -> None:
+    logger.info(
+        "Sheet discovery: spreadsheet_id=%s user=%s resellers=%s",
+        spreadsheet_id,
+        current_user.id,
+        current_user.reseller_ids,
+    )
+
+
+async def list_tabs_handler(
+    spreadsheet_url: str, current_user: UserInfo
+) -> TabsResponse:
+    spreadsheet_id = extract_spreadsheet_id(spreadsheet_url)
+    if not spreadsheet_id:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Invalid Google Sheets URL",
+        )
+    _log_caller(spreadsheet_id, current_user)
+    tabs = await list_tabs(spreadsheet_id)
+    return TabsResponse(spreadsheet_id=spreadsheet_id, tabs=tabs)
+
+
+async def list_columns_handler(
+    spreadsheet_url: str,
+    sheet_name: Optional[str] = None,
+) -> ColumnsResponse:
+    spreadsheet_id = extract_spreadsheet_id(spreadsheet_url)
+    if not spreadsheet_id:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Invalid Google Sheets URL",
+        )
+    logger.info(
+        "Listing columns for spreadsheet_id=%s tab=%s",
+        spreadsheet_id,
+        sheet_name or "(default)",
+    )
+    columns = await get_column_headers(spreadsheet_id, sheet_name)
+    return ColumnsResponse(
+        spreadsheet_id=spreadsheet_id,
+        sheet_name=sheet_name or "",
+        columns=columns,
+    )
+
+
+async def preview_handler(
+    spreadsheet_url: str,
+    sheet_name: Optional[str] = None,
+    columns: Optional[List[str]] = None,
+    max_rows: int = 10,
+) -> PreviewResponse:
+    spreadsheet_id = extract_spreadsheet_id(spreadsheet_url)
+    if not spreadsheet_id:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Invalid Google Sheets URL",
+        )
+    logger.info(
+        "Previewing spreadsheet_id=%s tab=%s cols=%s rows=%d",
+        spreadsheet_id,
+        sheet_name or "(default)",
+        len(columns) if columns else "all",
+        max_rows,
+    )
+    rows = await fetch_sheet_data(
+        spreadsheet_id, sheet_name, columns, max_rows=max_rows
+    )
+    col_names = list(rows[0].keys()) if rows else []
+    return PreviewResponse(
+        spreadsheet_id=spreadsheet_id,
+        sheet_name=sheet_name,
+        columns=col_names,
+        rows=rows,
+        total_rows=len(rows),
+    )

--- a/app/api/routers/breeze_buddy/templates/handlers.py
+++ b/app/api/routers/breeze_buddy/templates/handlers.py
@@ -140,6 +140,11 @@ async def create_template_handler(
             outbound_number_id=template_data.outbound_number_id,
             is_active=template_data.is_active,
             supported_channels=list(template_data.supported_channels),
+            data_sources=(
+                [ds.model_dump() for ds in template_data.data_sources]
+                if template_data.data_sources
+                else None
+            ),
             now=now,
         )
 
@@ -535,6 +540,15 @@ async def replace_template_handler(
             is_active=template_data.is_active,
             merchant_id=template_data.merchant_id,
             supported_channels=supported_channels,
+            data_sources=(
+                ([ds.model_dump() for ds in template_data.data_sources] or None)
+                if template_data.data_sources is not None
+                else (
+                    [ds.model_dump() for ds in existing_template.data_sources]
+                    if existing_template.data_sources
+                    else None
+                )
+            ),
             now=now,
         )
 

--- a/app/database/accessor/breeze_buddy/template.py
+++ b/app/database/accessor/breeze_buddy/template.py
@@ -104,6 +104,7 @@ async def create_template(
     outbound_number_id: Optional[str] = None,
     is_active: bool = True,
     supported_channels: Optional[List[str]] = None,
+    data_sources: Optional[list] = None,
 ) -> Optional[TemplateModel]:
     """Create a new template with flow stored as JSON."""
     logger.info(f"Creating template with ID: {template_id}")
@@ -130,6 +131,8 @@ async def create_template(
         # Convert secrets to JSON string
         secrets_json = json.dumps(secrets) if secrets is not None else None
 
+        data_sources_json = json.dumps(data_sources) if data_sources else None
+
         query, values = create_template_query(
             template_id,
             reseller_id,
@@ -143,6 +146,7 @@ async def create_template(
             outbound_number_id,  # Moved: now matches SQL column order
             is_active,
             supported_channels or ["voice"],
+            data_sources_json,
             now,
             now,
         )
@@ -374,6 +378,7 @@ async def replace_template(
     merchant_id: Optional[str],
     now,
     supported_channels: Optional[List[str]] = None,
+    data_sources: Optional[list] = None,
 ) -> Optional[TemplateModel]:
     """
     Update an existing template.
@@ -420,6 +425,8 @@ async def replace_template(
         # Convert secrets to JSON string
         secrets_json = json.dumps(secrets) if secrets is not None else None
 
+        data_sources_json = json.dumps(data_sources) if data_sources else None
+
         query, values = replace_template_query(
             template_id,
             reseller_id,
@@ -433,6 +440,7 @@ async def replace_template(
             is_active,
             merchant_id,
             supported_channels or ["voice"],
+            data_sources_json,
             now,
         )
 

--- a/app/database/decoder/breeze_buddy/template.py
+++ b/app/database/decoder/breeze_buddy/template.py
@@ -190,6 +190,10 @@ def decode_template(result: asyncpg.Record) -> Optional[TemplateModel]:
     # so the model always has at least one channel.
     supported_channels = result.get("supported_channels") or ["voice"]
 
+    data_sources_data = result.get("data_sources")
+    if data_sources_data and isinstance(data_sources_data, str):
+        data_sources_data = json.loads(data_sources_data)
+
     return TemplateModel(
         id=str(result["id"]),
         reseller_id=result["reseller_id"],
@@ -207,6 +211,7 @@ def decode_template(result: asyncpg.Record) -> Optional[TemplateModel]:
         ),
         is_active=result["is_active"],
         supported_channels=list(supported_channels),
+        data_sources=data_sources_data,
         created_at=result["created_at"],
         updated_at=result["updated_at"],
     )

--- a/app/database/migrations/034_add_data_sources_to_template.sql
+++ b/app/database/migrations/034_add_data_sources_to_template.sql
@@ -1,0 +1,4 @@
+ALTER TABLE template ADD COLUMN data_sources JSONB DEFAULT NULL;
+
+COMMENT ON COLUMN template.data_sources IS
+    'Array of inline DataSourceRef: [{name, spreadsheet_url, sheet_name?, columns?, format?, is_active}]';

--- a/app/database/queries/breeze_buddy/template.py
+++ b/app/database/queries/breeze_buddy/template.py
@@ -31,7 +31,7 @@ def get_template_by_merchant_query(
         SELECT id,
                reseller_id,
                merchant_id,
-               name, flow, expected_payload_schema, expected_callback_response_schema, configurations, secrets, outbound_number_id, is_active, supported_channels, created_at, updated_at
+               name, flow, expected_payload_schema, expected_callback_response_schema, configurations, secrets, outbound_number_id, is_active, supported_channels, data_sources, created_at, updated_at
         FROM {TEMPLATE_TABLE}
         WHERE {" AND ".join(conditions)}
     """
@@ -62,14 +62,15 @@ def create_template_query(
     ],  # Changed: moved before is_active to match SQL column order
     is_active: bool,
     supported_channels: List[str],
-    created_at,
-    updated_at,
+    data_sources: Optional[str] = None,
+    created_at=None,
+    updated_at=None,
 ) -> Tuple[str, List[Any]]:
     """Generate query to create a new template."""
     query = f"""
-        INSERT INTO {TEMPLATE_TABLE} (id, reseller_id, merchant_id, name, flow, expected_payload_schema, expected_callback_response_schema, configurations, secrets, outbound_number_id, is_active, supported_channels, created_at, updated_at)
-        VALUES ($1, $2, $3, $4, $5::jsonb, $6::jsonb, $7::jsonb, $8::jsonb, $9::jsonb, $10, $11, $12, $13, $14)
-        RETURNING id, reseller_id, merchant_id, name, flow, expected_payload_schema, expected_callback_response_schema, configurations, secrets, outbound_number_id, is_active, supported_channels, created_at, updated_at
+        INSERT INTO {TEMPLATE_TABLE} (id, reseller_id, merchant_id, name, flow, expected_payload_schema, expected_callback_response_schema, configurations, secrets, outbound_number_id, is_active, supported_channels, data_sources, created_at, updated_at)
+        VALUES ($1, $2, $3, $4, $5::jsonb, $6::jsonb, $7::jsonb, $8::jsonb, $9::jsonb, $10, $11, $12, $13::jsonb, $14, $15)
+        RETURNING id, reseller_id, merchant_id, name, flow, expected_payload_schema, expected_callback_response_schema, configurations, secrets, outbound_number_id, is_active, supported_channels, data_sources, created_at, updated_at
     """
 
     return query, [
@@ -85,6 +86,7 @@ def create_template_query(
         outbound_number_id,
         is_active,
         supported_channels,
+        data_sources,
         created_at,
         updated_at,
     ]
@@ -181,7 +183,7 @@ def get_templates_list_query(filters: Dict[str, Any]) -> Tuple[str, List[Any]]:
         SELECT id,
                reseller_id,
                merchant_id,
-               name, is_active, supported_channels, created_at, updated_at
+               name, is_active, supported_channels, data_sources, created_at, updated_at
         FROM {TEMPLATE_TABLE}
         {where_clause}
         ORDER BY {order_by}
@@ -220,7 +222,7 @@ def get_template_by_id_query(template_id: str) -> Tuple[str, List[Any]]:
         SELECT id,
                reseller_id,
                merchant_id,
-               name, flow, expected_payload_schema, expected_callback_response_schema, configurations, secrets, outbound_number_id, is_active, supported_channels, created_at, updated_at
+               name, flow, expected_payload_schema, expected_callback_response_schema, configurations, secrets, outbound_number_id, is_active, supported_channels, data_sources, created_at, updated_at
         FROM {TEMPLATE_TABLE}
         WHERE id = $1
         LIMIT 1
@@ -254,9 +256,9 @@ def get_template_by_outbound_number_id_query(
         SELECT id,
                reseller_id,
                merchant_id,
-               name, flow, expected_payload_schema, expected_callback_response_schema, configurations, secrets, outbound_number_id, is_active, supported_channels, created_at, updated_at
+               name, flow, expected_payload_schema, expected_callback_response_schema, configurations, secrets, outbound_number_id, is_active, supported_channels, data_sources, created_at, updated_at
         FROM {TEMPLATE_TABLE}
-        WHERE {' AND '.join(conditions)}
+        WHERE {" AND ".join(conditions)}
         LIMIT 1
     """
     return query, [outbound_number_id]
@@ -283,7 +285,7 @@ def get_all_templates_by_outbound_number_id_query(
         SELECT id,
                reseller_id,
                merchant_id,
-               name, flow, expected_payload_schema, expected_callback_response_schema, configurations, outbound_number_id, is_active, supported_channels, created_at, updated_at
+               name, flow, expected_payload_schema, expected_callback_response_schema, configurations, outbound_number_id, is_active, supported_channels, data_sources, created_at, updated_at
         FROM {TEMPLATE_TABLE}
         WHERE outbound_number_id = $1
         AND is_active = TRUE
@@ -339,7 +341,8 @@ def replace_template_query(
     is_active: bool,
     merchant_id: Optional[str],
     supported_channels: List[str],
-    updated_at,
+    data_sources: Optional[str] = None,
+    updated_at=None,
 ) -> Tuple[str, List[Any]]:
     """
     Generate query to replace a template.
@@ -357,6 +360,7 @@ def replace_template_query(
         is_active: Whether template is active
         merchant_id: Merchant identifier or None
         supported_channels: Channels (voice/chat) the template is allowed on
+        data_sources: Data sources JSON string or None
         updated_at: Updated timestamp
 
     Returns:
@@ -375,12 +379,13 @@ def replace_template_query(
             reseller_id = $9,
             merchant_id = $10,
             supported_channels = $11,
-            updated_at = $12
-        WHERE id = $13
+            data_sources = $12::jsonb,
+            updated_at = $13
+        WHERE id = $14
         RETURNING id,
                   reseller_id,
                   merchant_id,
-                  name, flow, expected_payload_schema, expected_callback_response_schema, configurations, secrets, outbound_number_id, is_active, supported_channels, created_at, updated_at
+                  name, flow, expected_payload_schema, expected_callback_response_schema, configurations, secrets, outbound_number_id, is_active, supported_channels, data_sources, created_at, updated_at
     """
 
     return query, [
@@ -395,6 +400,7 @@ def replace_template_query(
         reseller_id,
         merchant_id,
         supported_channels,
+        data_sources,
         updated_at,
         template_id,
     ]

--- a/app/schemas/breeze_buddy/data_source.py
+++ b/app/schemas/breeze_buddy/data_source.py
@@ -1,0 +1,26 @@
+"""
+Pydantic schemas for sheet discovery endpoints (admin-only utility).
+"""
+
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel
+
+
+class TabsResponse(BaseModel):
+    spreadsheet_id: str
+    tabs: List[str]
+
+
+class ColumnsResponse(BaseModel):
+    spreadsheet_id: str
+    sheet_name: str
+    columns: List[str]
+
+
+class PreviewResponse(BaseModel):
+    spreadsheet_id: str
+    sheet_name: Optional[str] = None
+    columns: List[str]
+    rows: List[Dict[str, Any]]
+    total_rows: int

--- a/app/services/data_sources.py
+++ b/app/services/data_sources.py
@@ -1,0 +1,1 @@
+DATA_SOURCE_UNAVAILABLE = "[Data unavailable]"

--- a/app/services/google/sheets.py
+++ b/app/services/google/sheets.py
@@ -1,0 +1,269 @@
+"""
+Google Sheets Service
+
+Fetches data from Google Sheets using the platform's shared GCP service account.
+Merchants share their sheet with the platform SA email (Viewer access).
+The SA credentials come from GOOGLE_CREDENTIALS_JSON env var.
+
+Supported output formats:
+  - markdown_table : LLM-readable, token-efficient
+  - csv            : compact, parseable
+  - json           : structured, for programmatic use
+"""
+
+import asyncio
+import csv
+import io
+import json
+import re
+from typing import List, Optional
+from urllib.parse import quote
+
+from google.auth.transport.requests import AuthorizedSession
+from google.oauth2 import service_account
+
+from app.core.config.static import GOOGLE_CREDENTIALS_JSON
+from app.core.logger import logger
+from app.services.data_sources import DATA_SOURCE_UNAVAILABLE
+
+# Read-only scope — we never write to sheets
+_SCOPES = ["https://www.googleapis.com/auth/spreadsheets.readonly"]
+
+# Regex to extract spreadsheet ID from any Google Sheets URL format
+_SPREADSHEET_ID_RE = re.compile(r"/spreadsheets/d/([a-zA-Z0-9\-_]+)")
+
+
+def extract_spreadsheet_id(url: str) -> Optional[str]:
+    """Extract spreadsheet ID from a Google Sheets URL."""
+    match = _SPREADSHEET_ID_RE.search(url)
+    return match.group(1) if match else None
+
+
+_session: Optional[AuthorizedSession] = None
+_session_ok: Optional[bool] = None
+
+
+def _get_sheets_session() -> Optional[AuthorizedSession]:
+    """Build and cache an authenticated HTTP session for the Google Sheets API.
+
+    Token refresh is handled transparently by google-auth. The session is reused
+    across requests to avoid repeated credential parsing and token exchange.
+    """
+    global _session, _session_ok
+
+    if _session is not None:
+        return _session
+    if _session_ok is False:
+        return None
+
+    if not GOOGLE_CREDENTIALS_JSON:
+        logger.error(
+            "GOOGLE_CREDENTIALS_JSON env var is not set — cannot access Google Sheets"
+        )
+        _session_ok = False
+        return None
+
+    try:
+        credentials_dict = json.loads(GOOGLE_CREDENTIALS_JSON)
+    except json.JSONDecodeError as e:
+        logger.error(f"Failed to parse GOOGLE_CREDENTIALS_JSON: {e}")
+        _session_ok = False
+        return None
+
+    try:
+        credentials = service_account.Credentials.from_service_account_info(
+            credentials_dict, scopes=_SCOPES
+        )
+        _session = AuthorizedSession(credentials)
+        _session_ok = True
+        return _session
+    except Exception as e:
+        logger.error(f"Failed to build Google Sheets session: {e}")
+        _session_ok = False
+        return None
+
+
+def _get_json(session: AuthorizedSession, url: str, params: Optional[dict] = None):
+    response = session.get(url, params=params, timeout=10)
+    response.raise_for_status()
+    return response.json()
+
+
+async def list_tabs(spreadsheet_id: str) -> List[str]:
+    """List all tab (sheet) names in a spreadsheet."""
+
+    def _fetch():
+        session = _get_sheets_session()
+        if not session:
+            return []
+        try:
+            result = _get_json(
+                session,
+                f"https://sheets.googleapis.com/v4/spreadsheets/{spreadsheet_id}",
+                params={"fields": "sheets.properties.title"},
+            )
+            return [sheet["properties"]["title"] for sheet in result.get("sheets", [])]
+        except Exception as e:
+            logger.error(f"Error listing tabs for {spreadsheet_id}: {e}")
+            return []
+
+    return await asyncio.get_running_loop().run_in_executor(None, _fetch)
+
+
+async def get_column_headers(
+    spreadsheet_id: str,
+    sheet_name: Optional[str] = None,
+) -> List[str]:
+    """Get column headers (first row) of a sheet tab."""
+
+    def _fetch():
+        session = _get_sheets_session()
+        if not session:
+            return []
+        try:
+            tab = sheet_name
+            if not tab:
+                meta = _get_json(
+                    session,
+                    f"https://sheets.googleapis.com/v4/spreadsheets/{spreadsheet_id}",
+                    params={"fields": "sheets.properties.title"},
+                )
+                sheets = meta.get("sheets", [])
+                if not sheets:
+                    return []
+                tab = sheets[0]["properties"]["title"]
+
+            range_str = f"'{tab}'!1:1"
+            result = _get_json(
+                session,
+                "https://sheets.googleapis.com/v4/spreadsheets/"
+                f"{spreadsheet_id}/values/{quote(range_str, safe='')}",
+            )
+            rows = result.get("values", [])
+            return rows[0] if rows else []
+        except Exception as e:
+            logger.error(
+                f"Error fetching headers for {spreadsheet_id}/{sheet_name}: {e}"
+            )
+            return []
+
+    return await asyncio.get_running_loop().run_in_executor(None, _fetch)
+
+
+async def fetch_sheet_data(
+    spreadsheet_id: str,
+    sheet_name: Optional[str] = None,
+    columns: Optional[List[str]] = None,
+    max_rows: int = 500,
+) -> List[dict]:
+    """Fetch sheet data as a list of row dicts {column_name: value}."""
+
+    def _fetch():
+        session = _get_sheets_session()
+        if not session:
+            return []
+        try:
+            tab = sheet_name
+            if not tab:
+                meta = _get_json(
+                    session,
+                    f"https://sheets.googleapis.com/v4/spreadsheets/{spreadsheet_id}",
+                    params={"fields": "sheets.properties.title"},
+                )
+                sheets = meta.get("sheets", [])
+                if not sheets:
+                    return []
+                tab = sheets[0]["properties"]["title"]
+
+            range_str = f"'{tab}'!A1:ZZ{max_rows + 1}"
+            result = _get_json(
+                session,
+                "https://sheets.googleapis.com/v4/spreadsheets/"
+                f"{spreadsheet_id}/values/{quote(range_str, safe='')}",
+            )
+            rows = result.get("values", [])
+            if not rows:
+                return []
+
+            headers = rows[0]
+            data_rows = rows[1:]
+
+            records = []
+            for row in data_rows:
+                padded = row + [""] * (len(headers) - len(row))
+                record = {headers[i]: padded[i] for i in range(len(headers))}
+                records.append(record)
+
+            if columns:
+                records = [{col: r.get(col, "") for col in columns} for r in records]
+
+            return records
+        except Exception as e:
+            logger.error(f"Error fetching data for {spreadsheet_id}/{sheet_name}: {e}")
+            return []
+
+    return await asyncio.get_running_loop().run_in_executor(None, _fetch)
+
+
+def _escape_md_cell(value: str) -> str:
+    """Escape pipe and newline characters so they don't break the table layout."""
+    return value.replace("\\", "\\\\").replace("|", "\\|").replace("\n", " ")
+
+
+def _rows_to_markdown_table(headers: List[str], rows: List[dict]) -> str:
+    if not headers or not rows:
+        return "(no data)"
+    escaped_headers = [_escape_md_cell(h) for h in headers]
+    header_line = "| " + " | ".join(escaped_headers) + " |"
+    separator = "| " + " | ".join(["---"] * len(headers)) + " |"
+    data_lines = []
+    for row in rows:
+        cells = [_escape_md_cell(str(row.get(h, ""))) for h in headers]
+        data_lines.append("| " + " | ".join(cells) + " |")
+    return "\n".join([header_line, separator] + data_lines)
+
+
+def _rows_to_csv(headers: List[str], rows: List[dict]) -> str:
+    if not headers or not rows:
+        return "(no data)"
+    output = io.StringIO()
+    writer = csv.writer(output, lineterminator="\n")
+    writer.writerow(headers)
+    for row in rows:
+        writer.writerow([str(row.get(h, "")) for h in headers])
+    return output.getvalue()
+
+
+def _rows_to_json(rows: List[dict]) -> str:
+    if not rows:
+        return "[]"
+    return json.dumps(rows, ensure_ascii=False)
+
+
+async def fetch_formatted(
+    spreadsheet_id: str,
+    sheet_name: Optional[str] = None,
+    columns: Optional[List[str]] = None,
+    format: str = "markdown_table",
+    max_rows: int = 500,
+) -> str:
+    """
+    Fetch sheet data and return as a formatted string for LLM injection.
+
+    Returns DATA_SOURCE_UNAVAILABLE on any error or empty sheet.
+    """
+    rows = await fetch_sheet_data(spreadsheet_id, sheet_name, columns, max_rows)
+    if not rows:
+        logger.warning(
+            f"No data fetched from spreadsheet={spreadsheet_id}, sheet={sheet_name}"
+        )
+        return DATA_SOURCE_UNAVAILABLE
+
+    headers = list(rows[0].keys()) if rows else []
+
+    if format == "csv":
+        return _rows_to_csv(headers, rows)
+    elif format == "json":
+        return _rows_to_json(rows)
+    else:
+        return _rows_to_markdown_table(headers, rows)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "boto3",
     "google-cloud-storage>=2.10.0",
     "google-auth>=2.17.0",
+    "google-api-python-client>=2.86.0",
     "cryptography>=44.0.1",
     "twilio",
     "plivo",

--- a/tests/test_google_sheets.py
+++ b/tests/test_google_sheets.py
@@ -1,0 +1,501 @@
+"""Tests for app.services.google.sheets — URL extraction, formatting, and
+fetch error paths (without real network calls).
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Optional
+
+import pytest
+
+from app.ai.voice.agents.breeze_buddy.template.types import DataSourceRef
+from app.services.data_sources import DATA_SOURCE_UNAVAILABLE
+from app.services.google.sheets import (
+    _rows_to_csv,
+    _rows_to_json,
+    _rows_to_markdown_table,
+    extract_spreadsheet_id,
+    fetch_formatted,
+    fetch_sheet_data,
+    get_column_headers,
+    list_tabs,
+)
+
+# ---------------------------------------------------------------------------
+# extract_spreadsheet_id
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "url,expected",
+    [
+        (
+            "https://docs.google.com/spreadsheets/d/abc123/edit#gid=0",
+            "abc123",
+        ),
+        (
+            "https://docs.google.com/spreadsheets/d/ABC-123_xyz/edit",
+            "ABC-123_xyz",
+        ),
+        (
+            "https://docs.google.com/spreadsheets/d/abc123",
+            "abc123",
+        ),
+        ("https://example.com", None),
+        ("", None),
+        ("not-a-url", None),
+    ],
+)
+def test_extract_spreadsheet_id(url: str, expected: Optional[str]):
+    assert extract_spreadsheet_id(url) == expected
+
+
+# ---------------------------------------------------------------------------
+# _rows_to_markdown_table
+# ---------------------------------------------------------------------------
+
+
+def test_markdown_empty():
+    assert _rows_to_markdown_table([], []) == "(no data)"
+
+
+def test_markdown_no_rows():
+    assert _rows_to_markdown_table(["a", "b"], []) == "(no data)"
+
+
+def test_markdown_basic():
+    result = _rows_to_markdown_table(
+        ["Name", "Age"],
+        [{"Name": "Alice", "Age": "30"}, {"Name": "Bob", "Age": "25"}],
+    )
+    lines = result.split("\n")
+    assert lines[0] == "| Name | Age |"
+    assert lines[1] == "| --- | --- |"
+    assert lines[2] == "| Alice | 30 |"
+    assert lines[3] == "| Bob | 25 |"
+
+
+def test_markdown_missing_cell():
+    result = _rows_to_markdown_table(
+        ["A", "B", "C"],
+        [{"A": "1", "B": "2"}],
+    )
+    assert "| 1 | 2 |  |" in result
+
+
+def test_markdown_escapes_pipe_in_cell():
+    result = _rows_to_markdown_table(
+        ["Options"],
+        [{"Options": "pick A | B"}],
+    )
+    assert "pick A \\| B" in result
+
+
+def test_markdown_escapes_newline_in_cell():
+    result = _rows_to_markdown_table(
+        ["Desc"],
+        [{"Desc": "line1\nline2"}],
+    )
+    assert "line1 line2" in result
+    assert "\n" not in next(line for line in result.split("\n") if "line1" in line)
+
+
+def test_markdown_escapes_backslash_in_cell():
+    result = _rows_to_markdown_table(
+        ["Path"],
+        [{"Path": "a\\b"}],
+    )
+    assert "a\\\\b" in result
+
+
+def test_markdown_escapes_pipe_in_header():
+    result = _rows_to_markdown_table(
+        ["A | B"],
+        [{"A | B": "1"}],
+    )
+    assert "| A \\| B |" in result
+
+
+def test_markdown_escapes_combined_special_chars():
+    result = _rows_to_markdown_table(
+        ["Cell"],
+        [{"Cell": "a|b\nc\\d"}],
+    )
+    assert "a\\|b c\\\\d" in result
+
+
+# ---------------------------------------------------------------------------
+# _rows_to_csv
+# ---------------------------------------------------------------------------
+
+
+def test_csv_empty():
+    assert _rows_to_csv([], []) == "(no data)"
+
+
+def test_csv_basic():
+    result = _rows_to_csv(
+        ["Name", "Age"],
+        [{"Name": "Alice", "Age": "30"}, {"Name": "Bob", "Age": "25"}],
+    )
+    assert result == "Name,Age\nAlice,30\nBob,25\n"
+
+
+def test_csv_with_comma():
+    result = _rows_to_csv(
+        ["Desc"],
+        [{"Desc": "hello, world"}],
+    )
+    assert result == 'Desc\n"hello, world"\n'
+
+
+# ---------------------------------------------------------------------------
+# _rows_to_json
+# ---------------------------------------------------------------------------
+
+
+def test_json_empty():
+    assert _rows_to_json([]) == "[]"
+
+
+def test_json_basic():
+    rows = [{"a": "1"}, {"a": "2"}]
+    result = _rows_to_json(rows)
+    assert json.loads(result) == rows
+
+
+# ---------------------------------------------------------------------------
+# datasource_ namespace convention
+# ---------------------------------------------------------------------------
+
+
+def test_datasource_var_is_namespaced():
+    ref = DataSourceRef.model_validate(
+        {
+            "name": "products",
+            "spreadsheet_url": "https://docs.google.com/spreadsheets/d/abc123/edit",
+            "format": "markdown_table",
+        }
+    )
+    var_key = f"datasource_{ref.name}"
+    assert var_key == "datasource_products"
+    assert var_key.startswith("datasource_")
+
+
+def test_datasource_var_does_not_clash_with_bare_name():
+    ref = DataSourceRef.model_validate(
+        {
+            "name": "api_token",
+            "spreadsheet_url": "https://docs.google.com/spreadsheets/d/abc123/edit",
+            "format": "csv",
+        }
+    )
+    var_key = f"datasource_{ref.name}"
+    assert var_key == "datasource_api_token"
+    assert var_key != ref.name
+
+
+# ---------------------------------------------------------------------------
+# Async helpers: faking the Google API session
+# ---------------------------------------------------------------------------
+
+
+def _fake_session(json_responses: list):
+    """Fake AuthorizedSession that returns canned JSON responses.
+
+    Each call to session.get consumes the next response in *json_responses*.
+    Responses match real Sheets API shape — ``{"values": [[...], ...]}`` or
+    ``{"sheets": [...]}``.
+    """
+
+    class _FakeResponse:
+        def __init__(self, data):
+            self._data = data
+
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return self._data
+
+    class _FakeSession:
+        def __init__(self):
+            self._idx = 0
+            self.closed = False
+
+        def get(self, url: str, *, params: Optional[dict] = None, timeout: int = 10):
+            resp = _FakeResponse(json_responses[self._idx])
+            self._idx += 1
+            return resp
+
+        def close(self):
+            self.closed = True
+
+    return _FakeSession()
+
+
+def _values_response(rows: list[list]) -> dict:
+    """Wrap values list in the shape returned by the Sheets API."""
+    return {"values": rows}
+
+
+@pytest.fixture(autouse=True)
+def patch_session(monkeypatch):
+    monkeypatch.setattr(
+        "app.services.google.sheets._get_sheets_session",
+        lambda: None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# list_tabs
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_tabs_success(monkeypatch):
+    fake = _fake_session(
+        [
+            {
+                "sheets": [
+                    {"properties": {"title": "Sheet1"}},
+                    {"properties": {"title": "Tab Two"}},
+                ]
+            }
+        ]
+    )
+    monkeypatch.setattr(
+        "app.services.google.sheets._get_sheets_session",
+        lambda: fake,
+    )
+    result = await list_tabs("abc123")
+    assert result == ["Sheet1", "Tab Two"]
+
+
+@pytest.mark.asyncio
+async def test_list_tabs_no_session(monkeypatch):
+    monkeypatch.setattr(
+        "app.services.google.sheets._get_sheets_session",
+        lambda: None,
+    )
+    result = await list_tabs("abc123")
+    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_list_tabs_api_error(monkeypatch):
+    def _boom(*a, **k):
+        raise RuntimeError("network down")
+
+    fake = _fake_session([])
+    fake.get = _boom  # type: ignore[method-assign]
+    monkeypatch.setattr(
+        "app.services.google.sheets._get_sheets_session",
+        lambda: fake,
+    )
+    result = await list_tabs("abc123")
+    assert result == []
+
+
+# ---------------------------------------------------------------------------
+# get_column_headers
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_headers_explicit_tab(monkeypatch):
+    fake = _fake_session([_values_response([["Name", "Age", "City"]])])
+    monkeypatch.setattr(
+        "app.services.google.sheets._get_sheets_session",
+        lambda: fake,
+    )
+    result = await get_column_headers("abc123", sheet_name="MyTab")
+    assert result == ["Name", "Age", "City"]
+
+
+@pytest.mark.asyncio
+async def test_get_headers_auto_first_tab(monkeypatch):
+    fake = _fake_session(
+        [
+            {"sheets": [{"properties": {"title": "FirstTab"}}]},
+            _values_response([["Col1", "Col2"]]),
+        ]
+    )
+    monkeypatch.setattr(
+        "app.services.google.sheets._get_sheets_session",
+        lambda: fake,
+    )
+    result = await get_column_headers("abc123", sheet_name=None)
+    assert result == ["Col1", "Col2"]
+
+
+@pytest.mark.asyncio
+async def test_get_headers_no_session(monkeypatch):
+    monkeypatch.setattr(
+        "app.services.google.sheets._get_sheets_session",
+        lambda: None,
+    )
+    result = await get_column_headers("abc123")
+    assert result == []
+
+
+# ---------------------------------------------------------------------------
+# fetch_sheet_data
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_fetch_data_basic(monkeypatch):
+    fake = _fake_session(
+        [
+            _values_response([["Name", "Age"], ["Alice", "30"], ["Bob", "25"]]),
+        ]
+    )
+    monkeypatch.setattr(
+        "app.services.google.sheets._get_sheets_session",
+        lambda: fake,
+    )
+    result = await fetch_sheet_data("abc123", sheet_name="Sheet1")
+    assert result == [
+        {"Name": "Alice", "Age": "30"},
+        {"Name": "Bob", "Age": "25"},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_fetch_data_column_filter(monkeypatch):
+    fake = _fake_session(
+        [
+            _values_response(
+                [["A", "B", "C"], ["1", "2", "3"], ["4", "5", "6"]],
+            ),
+        ]
+    )
+    monkeypatch.setattr(
+        "app.services.google.sheets._get_sheets_session",
+        lambda: fake,
+    )
+    result = await fetch_sheet_data("abc123", sheet_name="Sheet1", columns=["A", "C"])
+    assert result == [
+        {"A": "1", "C": "3"},
+        {"A": "4", "C": "6"},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_fetch_data_short_rows_padded(monkeypatch):
+    fake = _fake_session(
+        [
+            _values_response(
+                [["A", "B", "C"], ["1", "2"]],
+            ),
+        ]
+    )
+    monkeypatch.setattr(
+        "app.services.google.sheets._get_sheets_session",
+        lambda: fake,
+    )
+    result = await fetch_sheet_data("abc123", sheet_name="Sheet1")
+    assert result == [{"A": "1", "B": "2", "C": ""}]
+
+
+@pytest.mark.asyncio
+async def test_fetch_data_no_session(monkeypatch):
+    monkeypatch.setattr(
+        "app.services.google.sheets._get_sheets_session",
+        lambda: None,
+    )
+    result = await fetch_sheet_data("abc123")
+    assert result == []
+
+
+# ---------------------------------------------------------------------------
+# fetch_formatted
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_fetch_formatted_markdown(monkeypatch):
+    fake = _fake_session(
+        [
+            _values_response(
+                [["Product", "Price"], ["Widget", "10"]],
+            ),
+        ]
+    )
+    monkeypatch.setattr(
+        "app.services.google.sheets._get_sheets_session",
+        lambda: fake,
+    )
+    result = await fetch_formatted(
+        "abc123", sheet_name="Sheet1", format="markdown_table"
+    )
+    assert "| Product | Price |" in result
+    assert "| Widget | 10 |" in result
+
+
+@pytest.mark.asyncio
+async def test_fetch_formatted_csv(monkeypatch):
+    fake = _fake_session(
+        [
+            _values_response([["A", "B"], ["1", "2"]]),
+        ]
+    )
+    monkeypatch.setattr(
+        "app.services.google.sheets._get_sheets_session",
+        lambda: fake,
+    )
+    result = await fetch_formatted("abc123", sheet_name="Sheet1", format="csv")
+    assert result == "A,B\n1,2\n"
+
+
+@pytest.mark.asyncio
+async def test_fetch_formatted_json(monkeypatch):
+    fake = _fake_session(
+        [
+            _values_response([["A"], ["1"]]),
+        ]
+    )
+    monkeypatch.setattr(
+        "app.services.google.sheets._get_sheets_session",
+        lambda: fake,
+    )
+    result = await fetch_formatted("abc123", sheet_name="Sheet1", format="json")
+    assert json.loads(result) == [{"A": "1"}]
+
+
+@pytest.mark.asyncio
+async def test_fetch_formatted_default_is_markdown(monkeypatch):
+    fake = _fake_session(
+        [
+            _values_response([["X"], ["Y"]]),
+        ]
+    )
+    monkeypatch.setattr(
+        "app.services.google.sheets._get_sheets_session",
+        lambda: fake,
+    )
+    result = await fetch_formatted("abc123", sheet_name="Sheet1")
+    assert "| X |" in result
+
+
+@pytest.mark.asyncio
+async def test_fetch_formatted_no_data_returns_placeholder(monkeypatch):
+    monkeypatch.setattr(
+        "app.services.google.sheets._get_sheets_session",
+        lambda: None,
+    )
+    result = await fetch_formatted("abc123", sheet_name="Empty")
+    assert result == DATA_SOURCE_UNAVAILABLE
+
+
+@pytest.mark.asyncio
+async def test_fetch_formatted_empty_rows_returns_placeholder(monkeypatch):
+    fake = _fake_session([_values_response([])])
+    monkeypatch.setattr(
+        "app.services.google.sheets._get_sheets_session",
+        lambda: fake,
+    )
+    result = await fetch_formatted("abc123", sheet_name="Empty")
+    assert result == DATA_SOURCE_UNAVAILABLE

--- a/uv.lock
+++ b/uv.lock
@@ -691,6 +691,7 @@ dependencies = [
     { name = "boto3" },
     { name = "cryptography" },
     { name = "fastapi" },
+    { name = "google-api-python-client" },
     { name = "google-auth" },
     { name = "google-cloud-storage", version = "3.4.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
     { name = "google-cloud-storage", version = "3.9.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
@@ -743,6 +744,7 @@ requires-dist = [
     { name = "boto3" },
     { name = "cryptography", specifier = ">=44.0.1" },
     { name = "fastapi", specifier = "==0.115.12" },
+    { name = "google-api-python-client", specifier = ">=2.86.0" },
     { name = "google-auth", specifier = ">=2.17.0" },
     { name = "google-cloud-storage", specifier = ">=2.10.0" },
     { name = "h2", specifier = ">=4.3.0" },
@@ -1109,6 +1111,23 @@ grpc = [
 ]
 
 [[package]]
+name = "google-api-python-client"
+version = "2.197.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-api-core", version = "2.25.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "google-api-core", version = "2.29.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
+    { name = "google-auth" },
+    { name = "google-auth-httplib2" },
+    { name = "httplib2" },
+    { name = "uritemplate" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/22/09/081d66357118bd260f8f182cb1b2dd5bd32ca88e3714d7c93896cab946fc/google_api_python_client-2.197.0.tar.gz", hash = "sha256:32e03977eda4a66eafc6ae58dc9ec46426b6025636d5ef019c5703013eddd4e5", size = 14707398, upload-time = "2026-05-28T20:23:12.498Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/e5/e9cc221fd75230974d4ef45eb72d2261feca3c110d5554215d516bfe6534/google_api_python_client-2.197.0-py3-none-any.whl", hash = "sha256:0f8b89aa75768161dd4f5092d6bcb386c13236b32e0d9a938c02f71342094d14", size = 15287302, upload-time = "2026-05-28T20:23:09.683Z" },
+]
+
+[[package]]
 name = "google-auth"
 version = "2.49.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1124,6 +1143,19 @@ wheels = [
 [package.optional-dependencies]
 requests = [
     { name = "requests" },
+]
+
+[[package]]
+name = "google-auth-httplib2"
+version = "0.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-auth" },
+    { name = "httplib2" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1c/b3/f192c8bc7e41e0ebdbd95afcae4783417a34b6a6af62d22daf22c3fd38fc/google_auth_httplib2-0.4.0.tar.gz", hash = "sha256:d5b030a204b7a4b4d553ba9ca701b62481ee2b74419325580be70f7d85ffed35", size = 11161, upload-time = "2026-05-07T08:03:46.878Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/97/be/954c35a62b9e31de66b0a43c225c9b6bb9e0f98d6b1dc110a2308e3644f5/google_auth_httplib2-0.4.0-py3-none-any.whl", hash = "sha256:8e55cfafa3358cba85f6cad4a886138e88e158d71e7e5c9ee5936a5c1507fb91", size = 9529, upload-time = "2026-05-07T08:02:12.375Z" },
 ]
 
 [[package]]
@@ -1500,6 +1532,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httplib2"
+version = "0.31.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyparsing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c1/1f/e86365613582c027dda5ddb64e1010e57a3d53e99ab8a72093fa13d565ec/httplib2-0.31.2.tar.gz", hash = "sha256:385e0869d7397484f4eab426197a4c020b606edd43372492337c0b4010ae5d24", size = 250800, upload-time = "2026-01-23T11:04:44.165Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2f/90/fd509079dfcab01102c0fdd87f3a9506894bc70afcf9e9785ef6b2b3aff6/httplib2-0.31.2-py3-none-any.whl", hash = "sha256:dbf0c2fa3862acf3c55c078ea9c0bc4481d7dc5117cae71be9514912cf9f8349", size = 91099, upload-time = "2026-01-23T11:04:42.78Z" },
 ]
 
 [[package]]
@@ -2871,6 +2915,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pyparsing"
+version = "3.3.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/91/9c6ee907786a473bf81c5f53cf703ba0957b23ab84c264080fb5a450416f/pyparsing-3.3.2.tar.gz", hash = "sha256:c777f4d763f140633dcb6d8a3eda953bf7a214dc4eff598413c070bcdc117cbc", size = 6851574, upload-time = "2026-01-21T03:57:59.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl", hash = "sha256:850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d", size = 122781, upload-time = "2026-01-21T03:57:55.912Z" },
+]
+
+[[package]]
 name = "pyrefly"
 version = "0.52.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3703,6 +3756,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "uritemplate"
+version = "4.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/98/60/f174043244c5306c9988380d2cb10009f91563fc4b31293d27e17201af56/uritemplate-4.2.0.tar.gz", hash = "sha256:480c2ed180878955863323eea31b0ede668795de182617fef9c6ca09e6ec9d0e", size = 33267, upload-time = "2025-06-02T15:12:06.318Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a9/99/3ae339466c9183ea5b8ae87b34c0b897eda475d2aec2307cae60e5cd4f29/uritemplate-4.2.0-py3-none-any.whl", hash = "sha256:962201ba1c4edcab02e60f9a0d3821e82dfc5d2d6662a21abd533879bdb8a686", size = 11488, upload-time = "2025-06-02T15:12:03.405Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Inline `DataSourceRef` config stored in `template.data_sources` JSONB
- No separate `data_source` table, CRUD endpoints, or accessor layers
- Content fetched at call time with Redis cache (60s TTL, shared by content hash)
- Prefetch at dispatch for cache warming (fire-and-forget)
- `inject_as="var"` → `template_vars[{name}]` variable substitution
- `inject_as="message"` → prepended system message
- Discovery routes (`/data-sources/sheets/*`) for sheet exploration (admin-only)
- `_ds_messages` returned separately from `load_template()` — survives playground overrides

## Changed Files (20 files, +723/-25)
- **New**: `services/google/sheets.py` — Google Sheets API service (markdown/csv/json)
- **New**: `managers/data_source_prefetch.py` — background cache warming
- **New**: `api/routers/data_sources/` — discovery routes (admin-only)
- **New**: `migrations/034` — `ALTER TABLE template ADD data_sources JSONB`
- **Modified**: `types.py` — `DataSourceRef` with inline config + `data_sources` on `TemplateModel`
- **Modified**: `loader.py` — Layer 5 content injection
- **Modified**: `flow.py` — `_ds_messages` propagation
- **Modified**: `worker.py` — prefetch at dispatch
- **Modified**: `pyproject.toml` — add `google-api-python-client`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
* Added Google Sheets data source integration—templates can now reference Google Sheets to populate conversation data dynamically
* New admin APIs for discovering sheets, listing columns, and previewing data from spreadsheets
* Automatic data caching to optimize performance when using sheet data sources
* Support for multiple output formats (markdown, CSV, JSON) when injecting sheet data into conversations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->