### PR TITLE
feat(mcp): human-in-the-loop approval for MCP tools (chat + voice)

### DIFF
--- a/app/ai/voice/agents/breeze_buddy/agent/__init__.py
+++ b/app/ai/voice/agents/breeze_buddy/agent/__init__.py
@@ -1138,6 +1138,9 @@ class Agent:
                         mcp_global_functions = await get_mcp_global_functions(
                             mcp_config=mcp_config,
                             template_vars=self.template_vars,
+                            # Thread the bot so a gated MCP tool can reach the
+                            # ApprovalManager and block in-process (Pattern C).
+                            bot_instance=self,
                         )
                     except Exception as e:
                         logger.error(

--- a/app/ai/voice/agents/breeze_buddy/chat/agent.py
+++ b/app/ai/voice/agents/breeze_buddy/chat/agent.py
@@ -279,7 +279,7 @@ class ChatAgent:
             self.template.configurations.mcp if self.template.configurations else None
         )
         if mcp_config and mcp_config.servers:
-            mcp_funcs = await get_mcp_global_functions_cached(
+            mcp_funcs, mcp_approvals = await get_mcp_global_functions_cached(
                 mcp_config,
                 self.template_vars,
                 self.template.id,
@@ -291,6 +291,27 @@ class ChatAgent:
             logger.info(
                 f"[BUDDY_MCP] chat: added {len(unique)} MCP tools as global functions"
             )
+            # HITL: gate MCP tools by NAME, alongside flow global functions.
+            # This is the only place the final registered names exist (the
+            # __init__ build_approval_map runs before MCP load), so the merge
+            # lives here rather than in build_approval_map. Everything
+            # downstream (partition, pending-row persist, approval endpoint,
+            # resume re-dispatch) is name-keyed and type-agnostic — it gates
+            # MCP tools with no further change. Only tools that actually
+            # registered (survived the collision-dedup above) are gated; a
+            # gated tool dropped on a name clash is logged, never silently
+            # un-gated-by-surprise.
+            if mcp_approvals:
+                unique_names = {fn.name for fn in unique}
+                for name, cfg in mcp_approvals.items():
+                    if name in unique_names:
+                        self._approval_map[name] = cfg
+                    else:
+                        logger.warning(
+                            f"[BUDDY_MCP] chat: gated MCP tool '{name}' was "
+                            "dropped on a name collision with an existing "
+                            "function; it will NOT be approval-gated."
+                        )
 
         # Aggregate per-tool context-retention policy across every MCP server
         # the template declares. Used by llm_driver to compact stale

--- a/app/ai/voice/agents/breeze_buddy/mcp/__init__.py
+++ b/app/ai/voice/agents/breeze_buddy/mcp/__init__.py
@@ -6,7 +6,7 @@ import json
 import re
 import uuid
 from datetime import timedelta
-from typing import Any, Dict, List, Optional, cast
+from typing import Any, Dict, List, Optional, Tuple, cast
 
 import httpx
 from mcp.client.session_group import StreamableHttpParameters
@@ -22,6 +22,13 @@ from app.ai.voice.agents.breeze_buddy.handlers.transport.utils.response_transfor
 )
 from app.ai.voice.agents.breeze_buddy.mcp.cache import get_or_discover_server_tools
 
+# gate_call wraps gated MCP tool handlers with the HITL approval gate (voice).
+# Cycle-safe: template.approval only depends on template.context +
+# template.types, never on mcp. (isort orders this template import among the
+# others; the latent handlers<->template cycle the note below describes is
+# pre-existing and unchanged by this import.)
+from app.ai.voice.agents.breeze_buddy.template.approval import gate_call
+
 # Template types FIRST — fully loads the `template` package (whose
 # __init__ eagerly pulls in http_handler / http_requester / hooks /
 # field_resolver) before we touch handlers/transport/utils/. Importing
@@ -29,6 +36,7 @@ from app.ai.voice.agents.breeze_buddy.mcp.cache import get_or_discover_server_to
 # handlers.transport.utils.__init__ → field_resolver → template.types
 # while template/__init__.py is mid-load, causing a cycle.
 from app.ai.voice.agents.breeze_buddy.template.types import (
+    ApprovalConfig,
     HttpAuthType,
     McpConfig,
     McpServerConfig,
@@ -37,6 +45,57 @@ from app.ai.voice.agents.breeze_buddy.template.types import (
     ToolUiTrigger,
 )
 from app.core.logger import logger
+
+# --- HITL approval for MCP tools -------------------------------------------
+# Watchdog budget for a gated MCP tool: approval wait + the handler's dispatch
+# ceiling + margin. The MCP handler does up to two 30s waits (_tool_wrapper +
+# the result future), so the exec ceiling is ~60s. Mirrors the ADDITIVE budget
+# in template/global_function.py — pipecat's watchdog fires
+# result_callback(None) rather than cancelling the handler, so an undersized
+# timeout would silently drop the real result while the side effect still runs.
+_MCP_APPROVAL_EXEC_BUDGET_SECS = 60.0
+_MCP_APPROVAL_BUDGET_MARGIN_SECS = 15.0
+
+
+def _mcp_approval_timeout_secs(approval: ApprovalConfig) -> float:
+    """Additive pipecat watchdog budget for a gated MCP FlowsFunctionSchema."""
+    return (
+        approval.timeout_secs
+        + _MCP_APPROVAL_EXEC_BUDGET_SECS
+        + _MCP_APPROVAL_BUDGET_MARGIN_SECS
+    )
+
+
+def _gate_mcp_handler(
+    handler: Any,
+    bot_instance: Any,
+    registered_name: str,
+    approval: Optional[ApprovalConfig],
+) -> Any:
+    """Wrap an MCP tool handler with the HITL approval gate (voice path).
+
+    No-op when there is no approval config or no bot to reach the
+    ApprovalManager — returns the handler unchanged. On chat the bot sets
+    ``handles_approval_externally`` so ``gate_call`` short-circuits to execute
+    (chat gates pre-dispatch via its approval map); this wrap is therefore only
+    load-bearing on Daily voice.
+
+    A denied/timed-out call never runs the real MCP round-trip (no upstream
+    side effect): ``gate_call`` returns the bare ``{status, reason}`` denial —
+    the same shape a denied voice GLOBAL function returns, so the LLM reads it
+    uniformly. Only on approve does the real MCP ``{status, data}`` envelope
+    flow through.
+    """
+    if approval is None or bot_instance is None:
+        return handler
+
+    async def gated_handler(args: Dict[str, Any], flow_manager: Any) -> Any:
+        async def execute() -> Any:
+            return await handler(args, flow_manager)
+
+        return await gate_call(bot_instance, registered_name, approval, args, execute)
+
+    return gated_handler
 
 
 def _deep_merge_defaults(
@@ -518,6 +577,7 @@ async def _load_server_tools(
     server: McpServerConfig,
     template_vars: Dict[str, str],
     existing_names: set,
+    bot_instance: Any = None,
 ) -> List[FlowsFunctionSchema]:
     """Connect to a single MCP server and return its tools as FlowsFunctionSchema.
 
@@ -566,24 +626,40 @@ async def _load_server_tools(
                 server.tool_response_transforms.get(schema["name"]) or None
             )
             tool_ui_hint = server.tool_ui_instructions.get(schema["name"])
+            # HITL: per-tool approval is authored against the RAW upstream
+            # name (like transforms/ui), but gated under the REGISTERED name.
+            tool_approval = server.tool_approvals.get(schema["name"])
+            handler = _gate_mcp_handler(
+                _create_direct_http_tool_handler(
+                    server_params,
+                    schema["name"],
+                    response_transforms=tool_transforms,
+                    ui_hint=tool_ui_hint,
+                    default_args=server.default_args,
+                ),
+                bot_instance,
+                tool_name,
+                tool_approval,
+            )
+            schema_kwargs: Dict[str, Any] = {}
+            if tool_approval is not None:
+                schema_kwargs["timeout_secs"] = _mcp_approval_timeout_secs(
+                    tool_approval
+                )
             functions.append(
                 FlowsFunctionSchema(
                     name=tool_name,
                     description=schema.get("description", ""),
                     properties=schema.get("properties", {}),
                     required=schema.get("required", []),
-                    handler=_create_direct_http_tool_handler(
-                        server_params,
-                        schema["name"],
-                        response_transforms=tool_transforms,
-                        ui_hint=tool_ui_hint,
-                        default_args=server.default_args,
-                    ),
+                    handler=handler,
+                    **schema_kwargs,
                 )
             )
             existing_names.add(tool_name)
             logger.info(
                 f"[BUDDY_MCP] Registered (declared) tool: {tool_name} (from {label})"
+                + (" [approval-gated]" if tool_approval is not None else "")
             )
         logger.info(f"[BUDDY_MCP] Loaded {len(functions)} declared tools from {label}")
         return functions
@@ -609,6 +685,22 @@ async def _load_server_tools(
         # author against the upstream name; the local prefix is internal).
         tool_transforms = server.tool_response_transforms.get(func_schema.name) or None
         tool_ui_hint = server.tool_ui_instructions.get(func_schema.name)
+        tool_approval = server.tool_approvals.get(func_schema.name)
+        handler = _gate_mcp_handler(
+            _create_mcp_tool_handler(
+                server_params,
+                func_schema.name,
+                response_transforms=tool_transforms,
+                ui_hint=tool_ui_hint,
+                default_args=server.default_args,
+            ),
+            bot_instance,
+            tool_name,
+            tool_approval,
+        )
+        schema_kwargs: Dict[str, Any] = {}
+        if tool_approval is not None:
+            schema_kwargs["timeout_secs"] = _mcp_approval_timeout_secs(tool_approval)
 
         discovered_functions.append(
             FlowsFunctionSchema(
@@ -616,19 +708,17 @@ async def _load_server_tools(
                 description=func_schema.description,
                 properties=func_schema.properties,
                 required=func_schema.required,
-                handler=_create_mcp_tool_handler(
-                    server_params,
-                    func_schema.name,
-                    response_transforms=tool_transforms,
-                    ui_hint=tool_ui_hint,
-                    default_args=server.default_args,
-                ),
+                handler=handler,
+                **schema_kwargs,
             )
         )
         # Track the chosen name so a subsequent tool from the same server
         # with a duplicate name also gets prefixed.
         existing_names.add(tool_name)
-        logger.info(f"[BUDDY_MCP] Registered tool: {tool_name} (from {label})")
+        logger.info(
+            f"[BUDDY_MCP] Registered tool: {tool_name} (from {label})"
+            + (" [approval-gated]" if tool_approval is not None else "")
+        )
 
     logger.info(f"[BUDDY_MCP] Loaded {len(discovered_functions)} tools from {label}")
     return discovered_functions
@@ -637,11 +727,18 @@ async def _load_server_tools(
 async def get_mcp_global_functions(
     mcp_config: McpConfig,
     template_vars: Dict[str, str] | None = None,
+    bot_instance: Any = None,
 ) -> List[FlowsFunctionSchema]:
     """Fetch tools from all enabled MCP servers and return as FlowManager global functions.
 
     Each tool handler creates a fresh MCPClient per invocation, so no shared
     client cleanup is needed at the call level.
+
+    ``bot_instance`` (the voice agent) is threaded into the tool handlers so an
+    MCP tool with a ``tool_approvals`` entry can reach the bot's
+    ApprovalManager and gate in-process before its real round-trip (Pattern C).
+    Chat uses :func:`get_mcp_global_functions_cached`, which gates pre-dispatch
+    instead and needs no bot reference here.
     """
     template_vars = template_vars or {}
     all_functions: List[FlowsFunctionSchema] = []
@@ -653,7 +750,9 @@ async def get_mcp_global_functions(
         try:
             existing_names = {f.name for f in all_functions}
             task = asyncio.create_task(
-                _load_server_tools(server, template_vars, existing_names)
+                _load_server_tools(
+                    server, template_vars, existing_names, bot_instance=bot_instance
+                )
             )
             tools = await asyncio.shield(task)
             all_functions.extend(tools)
@@ -671,7 +770,7 @@ async def get_mcp_global_functions_cached(
     template_vars: Dict[str, Any],
     template_id: str,
     mcp_pool: Optional[MCPPool] = None,
-) -> List[FlowsFunctionSchema]:
+) -> Tuple[List[FlowsFunctionSchema], Dict[str, ApprovalConfig]]:
     """Cache-aware variant for chat mode.
 
     Reads tool metadata from Redis (per-template + URL hash, see
@@ -683,8 +782,16 @@ async def get_mcp_global_functions_cached(
     When ``mcp_pool`` is provided the resulting handlers share one
     MCPClient per server for the lifetime of the turn. The caller owns
     pool teardown via ``close_mcp_pool``.
+
+    Returns ``(functions, approval_map)`` where ``approval_map`` maps each
+    gated MCP tool's REGISTERED name (raw, or ``<server.name>_<name>`` on a
+    cross-server collision) to its ApprovalConfig. Chat does NOT wrap the
+    handlers (unlike voice): it gates pre-dispatch by merging this map into
+    ChatAgent._approval_map, so the existing name-keyed partition / pending
+    row / approval-endpoint / resume machinery gates MCP tools unchanged.
     """
     all_functions: List[FlowsFunctionSchema] = []
+    approval_map: Dict[str, ApprovalConfig] = {}
 
     for server in mcp_config.servers:
         if not server.enabled:
@@ -724,6 +831,9 @@ async def get_mcp_global_functions_cached(
                     server.tool_response_transforms.get(schema["name"]) or None
                 )
                 tool_ui_hint = server.tool_ui_instructions.get(schema["name"])
+                tool_approval = server.tool_approvals.get(schema["name"])
+                if tool_approval is not None:
+                    approval_map[tool_name] = tool_approval
                 all_functions.append(
                     FlowsFunctionSchema(
                         name=tool_name,
@@ -768,6 +878,9 @@ async def get_mcp_global_functions_cached(
                 tool_name = f"{server.name}_{tool_name}"
             tool_transforms = server.tool_response_transforms.get(meta["name"]) or None
             tool_ui_hint = server.tool_ui_instructions.get(meta["name"])
+            tool_approval = server.tool_approvals.get(meta["name"])
+            if tool_approval is not None:
+                approval_map[tool_name] = tool_approval
             all_functions.append(
                 FlowsFunctionSchema(
                     name=tool_name,
@@ -791,4 +904,4 @@ async def get_mcp_global_functions_cached(
             )
 
     logger.info(f"[BUDDY_MCP] chat: total tools loaded: {len(all_functions)}")
-    return all_functions
+    return all_functions, approval_map

--- a/app/ai/voice/agents/breeze_buddy/template/approval.py
+++ b/app/ai/voice/agents/breeze_buddy/template/approval.py
@@ -61,23 +61,28 @@ def denial_result(status: str, reason: str) -> Dict[str, str]:
     return {"status": status, "reason": reason}
 
 
-async def gate_global_function(
+async def gate_call(
     bot_instance: Any,
-    func: BaseGlobalFunction,
+    name: str,
+    approval: Optional[ApprovalConfig],
     llm_args: Dict[str, Any],
     execute: Callable[[], Awaitable[Any]],
 ) -> Any:
-    """Run ``execute()`` only after the function's approval gate clears.
+    """Run ``execute()`` only after the approval gate for ``name`` clears.
+
+    Channel-generic core shared by global functions (via
+    :func:`gate_global_function`) and MCP tools (via the wrapper in
+    ``mcp/__init__.py``). ``name`` is the LLM-visible call name; ``approval``
+    is its ApprovalConfig (None => ungated => execute immediately).
 
     ``execute`` carries the full call side effects (filler audio, handler,
-    post-actions) — a denied call therefore plays no filler and fires no
-    side effects.
+    post-actions / the real MCP round-trip) — a denied call therefore plays
+    no filler and fires no side effects.
 
     CancelledError from the approval wait (user barge-in on a sync gated
-    function, or pipeline teardown) propagates — pipecat's aggregator
-    records the call as CANCELLED and never re-invokes the handler.
+    call, or pipeline teardown) propagates — pipecat's aggregator records
+    the call as CANCELLED and never re-invokes the handler.
     """
-    approval = getattr(func, "approval", None)
     if approval is None:
         return await execute()
 
@@ -91,9 +96,9 @@ async def gate_global_function(
     if manager is None:
         if getattr(bot_instance, "is_daily_mode", False):
             # Channel expected but unavailable (e.g. RTVI disabled by env
-            # flag). Never auto-execute a gated function here.
+            # flag). Never auto-execute a gated call here.
             logger.error(
-                f"[approval] '{func.name}' is approval-gated but this daily "
+                f"[approval] '{name}' is approval-gated but this daily "
                 "bot has no approval channel (RTVI unavailable — check "
                 "ENABLE_BREEZE_BUDDY_DAILY_EVENTS). Denying."
             )
@@ -102,13 +107,13 @@ async def gate_global_function(
         # Telephony: no approval surface can exist.
         if approval.on_no_channel == ApprovalOnNoChannel.DENY:
             logger.warning(
-                f"[approval] '{func.name}' denied on a channel with no "
+                f"[approval] '{name}' denied on a channel with no "
                 "approval surface (on_no_channel=deny)."
             )
             return denial_result(LLM_STATUS_DENIED, "no_approval_channel")
 
         logger.warning(
-            f"[approval] EXECUTING approval-gated function '{func.name}' "
+            f"[approval] EXECUTING approval-gated call '{name}' "
             "WITHOUT human approval — no approval surface on this channel "
             "(telephony) and on_no_channel=execute. "
             f"args_keys={sorted(llm_args.keys()) if llm_args else []}"
@@ -124,7 +129,7 @@ async def gate_global_function(
         except Exception as e:
             logger.warning(f"[approval] Failed to queue voice_announce: {e}")
 
-    outcome: ApprovalOutcome = await manager.request(func.name, llm_args, approval)
+    outcome: ApprovalOutcome = await manager.request(name, llm_args, approval)
     if outcome.approved:
         return await execute()
 
@@ -140,6 +145,22 @@ async def gate_global_function(
     return denial_result(
         llm_status,
         outcome.reason or "the user did not approve this action",
+    )
+
+
+async def gate_global_function(
+    bot_instance: Any,
+    func: BaseGlobalFunction,
+    llm_args: Dict[str, Any],
+    execute: Callable[[], Awaitable[Any]],
+) -> Any:
+    """Approval gate for a global function — thin shim over :func:`gate_call`.
+
+    Reads the function's name + approval and delegates; keeps the existing
+    call sites (``_make_global_wrapper``) unchanged.
+    """
+    return await gate_call(
+        bot_instance, func.name, getattr(func, "approval", None), llm_args, execute
     )
 
 

--- a/app/ai/voice/agents/breeze_buddy/template/types.py
+++ b/app/ai/voice/agents/breeze_buddy/template/types.py
@@ -1011,6 +1011,23 @@ class McpServerConfig(BaseModel):
             "voice and chat."
         ),
     )
+    tool_approvals: Dict[str, "ApprovalConfig"] = Field(
+        default_factory=dict,
+        description=(
+            "Per-tool human-in-the-loop approval gates. Keys are the RAW "
+            "upstream MCP tool names (e.g. 'create_checkout'); values are "
+            "ApprovalConfig. When an entry exists, a call to that tool pauses "
+            "for an explicit end-user decision before it executes: chat ends "
+            "the turn with a function_approval_requested event and resumes on "
+            "the approval endpoint; Daily voice blocks in-process on the RTVI "
+            "approval channel (Pattern C). Same keying rule as the other "
+            "per-tool maps — author against the raw upstream name; a tool "
+            "whose name collides across servers is gated under its registered "
+            "``<server.name>_<name>`` form. Telephony has no approval surface "
+            "(see ApprovalConfig.on_no_channel, default 'execute'); set it to "
+            "'deny' for high-stakes write tools (refunds, checkout)."
+        ),
+    )
     tool_schemas: Optional[List[Dict[str, Any]]] = Field(
         default=None,
         description=(
@@ -1703,10 +1720,13 @@ class ApprovalOnNoChannel(str, Enum):
 
 
 class ApprovalConfig(BaseModel):
-    """Human-in-the-loop approval for a global function.
+    """Human-in-the-loop approval for a global function or an MCP tool.
 
-    Presence of this config on a function marks it as gated: the LLM may call
-    the function, but execution waits for an explicit end-user decision.
+    Presence of this config marks the call as gated: the LLM may call the
+    function/tool, but execution waits for an explicit end-user decision. On a
+    global function it is set inline via ``BaseGlobalFunction.approval``; on an
+    MCP tool it is set via ``McpServerConfig.tool_approvals[<raw tool name>]``.
+    The gate semantics below are identical for both.
 
     Channel behavior:
     - Chat: the turn ends at the gated call (`turn_end` carries

--- a/tests/test_mcp_approval.py
+++ b/tests/test_mcp_approval.py
@@ -1,0 +1,294 @@
+"""HITL approval for MCP tools.
+
+Companion: [[mcp/__init__.py]] (_gate_mcp_handler, _mcp_approval_timeout_secs,
+the loader approval-map wiring) and [[template/approval.py]] (gate_call).
+
+Covers the channel-generic pieces without network/Redis by using the
+declared-schemas (``tool_schemas``) loader path, which builds
+FlowsFunctionSchema objects with no MCP handshake, plus direct unit tests of
+the gate wrapper with a scripted ApprovalManager.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any, Dict, List, Optional
+
+from app.ai.voice.agents.breeze_buddy.mcp import (
+    _gate_mcp_handler,
+    _mcp_approval_timeout_secs,
+    get_mcp_global_functions,
+    get_mcp_global_functions_cached,
+)
+from app.ai.voice.agents.breeze_buddy.template.approval import ApprovalOutcome
+from app.ai.voice.agents.breeze_buddy.template.types import (
+    ApprovalConfig,
+    McpConfig,
+    McpServerConfig,
+)
+
+
+class _FakeManager:
+    """Scripted ApprovalManager stand-in (request() returns a fixed outcome)."""
+
+    def __init__(self, outcome: ApprovalOutcome):
+        self.outcome = outcome
+        self.requests: List[Dict[str, Any]] = []
+
+    async def request(self, function_name, arguments, config):
+        self.requests.append(
+            {"function_name": function_name, "arguments": arguments, "config": config}
+        )
+        return self.outcome
+
+
+def _voice_bot(outcome: ApprovalOutcome) -> SimpleNamespace:
+    """Daily voice bot: has an ApprovalManager, gates in-process."""
+    return SimpleNamespace(
+        handles_approval_externally=False,
+        is_daily_mode=True,
+        approval_manager=_FakeManager(outcome),
+    )
+
+
+def _approval(**overrides) -> ApprovalConfig:
+    cfg: Dict[str, Any] = {"prompt": "Approve checkout?", "timeout_secs": 90}
+    cfg.update(overrides)
+    return ApprovalConfig.model_validate(cfg)
+
+
+def _server(
+    tool_approvals: Optional[Dict[str, Any]] = None,
+    *,
+    name: str = "shopify",
+    tool_name: str = "create_checkout",
+    extra_tool: Optional[str] = None,
+) -> McpServerConfig:
+    schemas = [
+        {"name": tool_name, "description": "Create a checkout", "properties": {}}
+    ]
+    if extra_tool:
+        schemas.append(
+            {"name": extra_tool, "description": "Search the catalog", "properties": {}}
+        )
+    return McpServerConfig.model_validate(
+        {
+            "enabled": True,
+            "name": name,
+            "url": "https://shop.example/api/mcp",
+            "auth": {"type": "none"},
+            "tool_schemas": schemas,
+            "tool_approvals": tool_approvals or {},
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# model + helpers
+# ---------------------------------------------------------------------------
+
+
+def test_tool_approvals_parses_into_approval_config():
+    server = _server({"create_checkout": {"prompt": "ok?", "on_no_channel": "deny"}})
+    cfg = server.tool_approvals["create_checkout"]
+    assert isinstance(cfg, ApprovalConfig)
+    assert cfg.prompt == "ok?"
+    assert cfg.on_no_channel.value == "deny"
+    assert _server().tool_approvals == {}
+
+
+def test_watchdog_budget_is_additive():
+    # approval wait (90) + MCP exec ceiling (60) + margin (15)
+    assert _mcp_approval_timeout_secs(_approval(timeout_secs=90)) == 165.0
+    assert _mcp_approval_timeout_secs(_approval(timeout_secs=10)) == 85.0
+
+
+# ---------------------------------------------------------------------------
+# _gate_mcp_handler — voice in-closure gate
+# ---------------------------------------------------------------------------
+
+
+async def _recording_handler(record: List[str], result: Any):
+    async def handler(args: Dict[str, Any], flow_manager: Any) -> Any:
+        record.append("executed")
+        return result
+
+    return handler
+
+
+async def test_gate_passthrough_when_no_approval():
+    record: List[str] = []
+    inner = await _recording_handler(record, {"status": "success", "data": "x"})
+    wrapped = _gate_mcp_handler(
+        inner, _voice_bot(ApprovalOutcome(True, "approved")), "t", None
+    )
+    assert wrapped is inner  # identity — no wrap
+
+
+async def test_gate_passthrough_when_no_bot():
+    record: List[str] = []
+    inner = await _recording_handler(record, {"status": "success", "data": "x"})
+    wrapped = _gate_mcp_handler(inner, None, "t", _approval())
+    assert wrapped is inner
+
+
+async def test_gate_approve_runs_real_handler():
+    record: List[str] = []
+    inner = await _recording_handler(record, {"status": "success", "data": "done"})
+    bot = _voice_bot(ApprovalOutcome(True, "approved"))
+    wrapped = _gate_mcp_handler(inner, bot, "create_checkout", _approval())
+    result = await wrapped({"line_items": [1]}, None)
+    assert record == ["executed"]
+    assert result == {"status": "success", "data": "done"}
+    # the LLM-visible name + args reach the manager (the approval card)
+    assert bot.approval_manager.requests[0]["function_name"] == "create_checkout"
+    assert bot.approval_manager.requests[0]["arguments"] == {"line_items": [1]}
+
+
+async def test_gate_deny_skips_real_handler():
+    record: List[str] = []
+    inner = await _recording_handler(record, {"status": "success", "data": "done"})
+    bot = _voice_bot(ApprovalOutcome(False, "denied", reason="user said no"))
+    wrapped = _gate_mcp_handler(inner, bot, "create_checkout", _approval())
+    result = await wrapped({"x": 1}, None)
+    assert record == []  # real MCP round-trip never ran — no side effect
+    assert result == {"status": "denied", "reason": "user said no"}
+
+
+async def test_gate_timeout_maps_to_timeout_status():
+    record: List[str] = []
+    inner = await _recording_handler(record, {"status": "success", "data": "done"})
+    bot = _voice_bot(ApprovalOutcome(False, "timeout", reason="no decision in time"))
+    wrapped = _gate_mcp_handler(inner, bot, "t", _approval())
+    result = await wrapped({}, None)
+    assert record == []
+    assert result["status"] == "timeout"
+
+
+async def test_gate_superseded_maps_to_not_decided():
+    record: List[str] = []
+    inner = await _recording_handler(record, {"status": "success", "data": "done"})
+    bot = _voice_bot(ApprovalOutcome(False, "superseded"))
+    wrapped = _gate_mcp_handler(inner, bot, "t", _approval())
+    result = await wrapped({}, None)
+    assert result["status"] == "not_decided"  # not a refusal
+
+
+async def test_gate_chat_bot_executes_without_manager():
+    """Chat sets handles_approval_externally — the in-closure gate is a no-op."""
+    record: List[str] = []
+    inner = await _recording_handler(record, {"status": "success", "data": "done"})
+    bot = SimpleNamespace(handles_approval_externally=True, approval_manager=None)
+    wrapped = _gate_mcp_handler(inner, bot, "t", _approval())
+    result = await wrapped({}, None)
+    assert record == ["executed"]
+    assert result == {"status": "success", "data": "done"}
+
+
+async def test_gate_daily_without_manager_denies():
+    """Daily mode but no approval channel (RTVI off) must DENY, never execute."""
+    record: List[str] = []
+    inner = await _recording_handler(record, {"status": "success", "data": "done"})
+    bot = SimpleNamespace(
+        handles_approval_externally=False, is_daily_mode=True, approval_manager=None
+    )
+    wrapped = _gate_mcp_handler(inner, bot, "t", _approval())
+    result = await wrapped({}, None)
+    assert record == []
+    assert result == {"status": "denied", "reason": "approval_channel_unavailable"}
+
+
+async def test_gate_telephony_on_no_channel_deny():
+    record: List[str] = []
+    inner = await _recording_handler(record, {"status": "success", "data": "done"})
+    bot = SimpleNamespace(
+        handles_approval_externally=False, is_daily_mode=False, approval_manager=None
+    )
+    wrapped = _gate_mcp_handler(inner, bot, "t", _approval(on_no_channel="deny"))
+    result = await wrapped({}, None)
+    assert record == []
+    assert result["status"] == "denied"
+
+
+async def test_gate_telephony_on_no_channel_execute():
+    record: List[str] = []
+    inner = await _recording_handler(record, {"status": "success", "data": "done"})
+    bot = SimpleNamespace(
+        handles_approval_externally=False, is_daily_mode=False, approval_manager=None
+    )
+    wrapped = _gate_mcp_handler(inner, bot, "t", _approval(on_no_channel="execute"))
+    await wrapped({}, None)
+    assert record == ["executed"]  # telephony fallback executes (loud warning)
+
+
+# ---------------------------------------------------------------------------
+# chat loader — get_mcp_global_functions_cached returns (functions, map)
+# ---------------------------------------------------------------------------
+
+
+async def test_chat_loader_returns_approval_map_keyed_by_registered_name():
+    cfg = McpConfig(servers=[_server({"create_checkout": {"prompt": "ok?"}})])
+    funcs, approvals = await get_mcp_global_functions_cached(cfg, {}, "tmpl-1")
+    assert {f.name for f in funcs} == {"create_checkout"}
+    assert set(approvals) == {"create_checkout"}
+    assert isinstance(approvals["create_checkout"], ApprovalConfig)
+
+
+async def test_chat_loader_ungated_tool_absent_from_map():
+    cfg = McpConfig(servers=[_server(extra_tool="search_catalog")])  # no approvals
+    funcs, approvals = await get_mcp_global_functions_cached(cfg, {}, "tmpl-1")
+    assert {f.name for f in funcs} == {"create_checkout", "search_catalog"}
+    assert approvals == {}
+
+
+async def test_chat_loader_collision_keys_under_prefixed_name():
+    """A gated tool colliding across servers is keyed under <server>_<name>."""
+    cfg = McpConfig(
+        servers=[
+            _server({"create_checkout": {"prompt": "A"}}, name="main"),
+            _server({"create_checkout": {"prompt": "B"}}, name="alt"),
+        ]
+    )
+    funcs, approvals = await get_mcp_global_functions_cached(cfg, {}, "tmpl-1")
+    names = {f.name for f in funcs}
+    assert names == {"create_checkout", "alt_create_checkout"}
+    # both gated, each under its REGISTERED name (the name the LLM calls)
+    assert set(approvals) == {"create_checkout", "alt_create_checkout"}
+    assert approvals["create_checkout"].prompt == "A"
+    assert approvals["alt_create_checkout"].prompt == "B"
+
+
+# ---------------------------------------------------------------------------
+# voice loader — get_mcp_global_functions wraps + sizes the watchdog
+# ---------------------------------------------------------------------------
+
+
+async def test_voice_loader_sets_watchdog_budget_on_gated_tool_only():
+    cfg = McpConfig(
+        servers=[
+            _server(
+                {"create_checkout": {"timeout_secs": 90}}, extra_tool="search_catalog"
+            )
+        ]
+    )
+    funcs = await get_mcp_global_functions(
+        cfg, {}, bot_instance=_voice_bot(ApprovalOutcome(True, "approved"))
+    )
+    by_name = {f.name: f for f in funcs}
+    assert by_name["create_checkout"].timeout_secs == 165.0  # 90 + 60 + 15
+    # ungated tool keeps the FlowsFunctionSchema default (no additive budget)
+    assert by_name["search_catalog"].timeout_secs is None
+
+
+async def test_voice_loader_gated_handler_denies_without_network():
+    """A denied gated MCP tool returns a denial and never makes the HTTP call."""
+    cfg = McpConfig(servers=[_server({"create_checkout": {"prompt": "ok?"}})])
+    bot = _voice_bot(ApprovalOutcome(False, "denied", reason="nope"))
+    funcs = await get_mcp_global_functions(cfg, {}, bot_instance=bot)
+    # handler uses the legacy (args, flow_manager) MCP convention; type as Any
+    # so pyrefly doesn't apply FlowsFunctionSchema's single-arg handler type.
+    handler: Any = {f.name: f.handler for f in funcs}["create_checkout"]
+    # Deny path short-circuits before the real httpx POST — no network needed.
+    result = await handler({"line_items": [1]}, None)
+    assert result == {"status": "denied", "reason": "nope"}
+    assert bot.approval_manager.requests[0]["function_name"] == "create_checkout"


### PR DESCRIPTION
## What

Extends the generic HITL approval gate to **MCP tools**, on both chat and Daily voice. Follow-up to the original HITL feature (which only gated global functions). No DB migration — the `tool_approvals` table + approval endpoint ship already and are reused verbatim.

## Author-facing surface

Mark an MCP tool gated by adding its **raw upstream name** to a new per-server map, keyed exactly like `tool_response_transforms` / `tool_ui_instructions`:

```jsonc
"configurations": {
  "mcp": { "servers": [{
    "name": "shopify",
    "url": "https://{shop_url}/api/mcp",
    "tool_approvals": {
      "create_checkout": { "prompt": "Approve this checkout?", "timeout_secs": 90, "on_no_channel": "deny" }
    }
  }]}
}
```

The value is the existing `ApprovalConfig` (reused unchanged — `prompt`, `voice_announce`, `timeout_secs`, `chat_expiry_secs`, `on_no_channel`).

## How

- **Shared gate** (`template/approval.py`): extracted `gate_call(bot_instance, name, approval, llm_args, execute)` from `gate_global_function` — a pure, behavior-preserving refactor (it only ever read `func.name` + the approval value). `gate_global_function` is now a one-line shim. Global functions and MCP tools share one channel-branching path.
- **Chat** (name-keyed, pre-dispatch — "nearly free"): `get_mcp_global_functions_cached` now returns `(functions, {registered_name -> ApprovalConfig})`; `ChatAgent._prepare_tools` merges that map into `self._approval_map` after MCP load (the only point the final registered names exist). The existing partition / pending-row persist / `/approval` endpoint / resume re-dispatch are all name-keyed and gate MCP tools unchanged. A gated tool dropped on a name collision is logged, never silently un-gated.
- **Voice** (in-closure gate, Pattern C): `bot_instance` is threaded through `get_mcp_global_functions → _load_server_tools →` both handler factories; each gated MCP handler is wrapped with the approval gate at **both** the pipecat-MCPClient and the direct-HTTP/UCP build sites (UCP = the high-stakes cart/checkout path). Gated MCP `FlowsFunctionSchema`s get the **additive pipecat watchdog budget** (approval wait + ~60s MCP exec ceiling + 15s margin) so the watchdog can't fire mid-wait and drop the result. A denied call returns the bare `{status, reason}` denial (same shape a denied voice global function returns) and never runs the real round-trip.

## Correctness notes

- **Both dispatch paths gate** — MCPClient and direct-HTTP/UCP.
- **Name keying** — authored against the raw upstream name; gated under the registered name (`<server>_<name>` on cross-server collision), matching every other per-tool MCP map.
- **Telephony** has no approval surface → `ApprovalConfig.on_no_channel` applies (default `execute`; the field docs recommend `deny` for write tools). Daily without the RTVI channel **denies**.
- **Resume** re-runs `_prepare_tools` on a fresh `mcp_pool`, so an approved MCP tool genuinely re-executes.

## Tests / checks

- New `tests/test_mcp_approval.py` (17 tests): gate approve/deny/timeout/superseded, chat-bypass, daily-without-channel DENY, telephony `on_no_channel`, the registered-name approval map incl. cross-server collision keying, and the additive watchdog budget.
- Full suite **441 passed**, 1 xfailed; `pyrefly` 0 errors; `field_reference.json` coverage green; black/isort/autoflake clean.

## Out of scope / known limits

- Same-name gated MCP tool called twice in one parallel voice batch: the function-name-keyed `ApprovalManager` supersedes the first (matches existing global-function behavior). Chat is safe (rows keyed by `tool_call_id`).
- MCP voice approvals get no DB audit row in v1 (same as global-function voice approvals).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added human-in-the-loop approval workflows for MCP tools with per-tool approval configuration and channel-specific handling
  * Implemented approval timeout budgeting and state management across voice, chat, and telephony channels
  * Added fallback behavior for channels without approval surfaces

* **Refactor**
  * Centralized approval gating logic into a shared helper for consistent behavior across channels

* **Tests**
  * Added comprehensive test suite covering approval parsing, timeout calculation, handler gating, loader wiring, and approval outcomes across all channel types

<!-- end of auto-generated comment: release notes by coderabbit.ai -->