### PR TITLE
fix(widget+voice): carry, run & persist chat session-state across CHAT↔VOICE

### DIFF
--- a/app/ai/voice/agents/breeze_buddy/agent/__init__.py
+++ b/app/ai/voice/agents/breeze_buddy/agent/__init__.py
@@ -189,6 +189,13 @@ class Agent:
         # at start_node with prior_history pre-loaded into LLM context.
         self._widget_resume_seed: Optional[Dict[str, Any]] = None
 
+        # Reducer-built session state (cart_id/checkout_id/client facts),
+        # the voice counterpart of ChatAgent.agent_state. Seeded from a
+        # widget-resume (below), accumulated via state_reducers during the
+        # call by the global-function wrapper, and drained back to the
+        # chat_session on end_conversation. Empty {} for fresh/telephony calls.
+        self.agent_state: Dict[str, Any] = {}
+
         # HITL approval channel — daily mode only, set alongside
         # _rtvi_processor. None on telephony bots (no approval surface) and
         # when RTVI is unavailable; the gate in template/approval.py treats
@@ -332,11 +339,20 @@ class Agent:
                 "start_node": meta.get("start_node"),
                 "prior_history": list(meta.get("prior_history") or []),
                 "seed_message_count": int(meta.get("seed_message_count", 0) or 0),
+                # Reducer-built chat state (cart_id/checkout_id/...) carried
+                # across the CHAT->VOICE flip; merged into template_vars below.
+                "agent_state": dict(meta.get("agent_state") or {}),
             }
+            # Seed the live agent_state from the chat session so voice tool
+            # calls inject/update it (tool_arg_injection + state_reducers via
+            # the global-function wrapper) and the final state drains back on
+            # end_conversation.
+            self.agent_state = dict(self._widget_resume_seed["agent_state"])
             logger.info(
                 f"Widget voice resume: chat_session={widget_session_id} "
                 f"start_node={self._widget_resume_seed['start_node']!r} "
-                f"prior_msgs={len(self._widget_resume_seed['prior_history'])}"
+                f"prior_msgs={len(self._widget_resume_seed['prior_history'])} "
+                f"agent_state_keys={sorted(self.agent_state)}"
             )
 
         logger.info(
@@ -360,6 +376,22 @@ class Agent:
         except ValueError as e:
             logger.error(f"Failed to load template config for Daily mode: {e}")
             raise
+
+        # Widget resume: thread the chat session's accumulated agent_state
+        # (cart_id/checkout_id/client-pushed facts) into template_vars so
+        # {placeholder} resolution in the resumed voice flow uses the
+        # chat-built identifiers instead of losing them on the flip.
+        # only_if_missing — never clobber an explicitly-rendered call var.
+        if self._widget_resume_seed:
+            resumed_state = self._widget_resume_seed.get("agent_state") or {}
+            merged_keys = [k for k in resumed_state if k not in self.template_vars]
+            for k in merged_keys:
+                self.template_vars[k] = resumed_state[k]
+            if merged_keys:
+                logger.info(
+                    f"Widget voice resume: merged {len(merged_keys)} agent_state "
+                    f"var(s) into template_vars: {sorted(merged_keys)}"
+                )
 
         # Synthesize and cache the initial greeting in Redis so it can be
         # played out on client-connect. Idempotent: if the dispatch worker

--- a/app/ai/voice/agents/breeze_buddy/chat/agent.py
+++ b/app/ai/voice/agents/breeze_buddy/chat/agent.py
@@ -174,6 +174,11 @@ class ChatAgent:
         # global-function adapters receive bot_instance=self and would
         # otherwise double-gate.
         self.handles_approval_externally = True
+        # Chat runs inject_tool_args / apply_state_reducers itself inside
+        # _cycle_loop; this flag tells the shared global-function wrapper NOT
+        # to re-apply them (voice has no such loop, so it lets the wrapper do
+        # it). Prevents double-application of the SessionStatePolicy.
+        self.handles_state_externally = True
         # function name -> ApprovalConfig for every gated global function.
         self._approval_map = build_approval_map(self.template.flow or {})
 

--- a/app/ai/voice/agents/breeze_buddy/handlers/internal/end_conversation.py
+++ b/app/ai/voice/agents/breeze_buddy/handlers/internal/end_conversation.py
@@ -19,6 +19,7 @@ from app.core.logger import logger
 from app.core.logger.context import clear_log_context
 from app.database.accessor.breeze_buddy.chat_session import (
     drain_voice_into_chat_session,
+    upsert_agent_session_state,
 )
 
 callback_map = {
@@ -149,6 +150,15 @@ async def end_conversation(context: TemplateContext, args, transition_to=None):
                     new_messages=new_messages,
                     final_node=final_node,
                 )
+                # Persist voice-accumulated agent_state back to the chat
+                # session so a later chat turn sees cart_id/etc. that voice
+                # updated (mirror of the seed carried in on /voice/connect).
+                voice_state = getattr(context.bot, "agent_state", None)
+                if voice_state:
+                    await upsert_agent_session_state(
+                        chat_session_id=str(widget_session_id),
+                        data=voice_state,
+                    )
             except Exception as drain_err:
                 logger.error(
                     f"widget drain: failed for chat_session "

--- a/app/ai/voice/agents/breeze_buddy/mcp/__init__.py
+++ b/app/ai/voice/agents/breeze_buddy/mcp/__init__.py
@@ -28,6 +28,10 @@ from app.ai.voice.agents.breeze_buddy.mcp.cache import get_or_discover_server_to
 # others; the latent handlers<->template cycle the note below describes is
 # pre-existing and unchanged by this import.)
 from app.ai.voice.agents.breeze_buddy.template.approval import gate_call
+from app.ai.voice.agents.breeze_buddy.template.session_state import (
+    _inject_voice_state,
+    _reduce_voice_state,
+)
 
 # Template types FIRST — fully loads the `template` package (whose
 # __init__ eagerly pulls in http_handler / http_requester / hooks /
@@ -96,6 +100,33 @@ def _gate_mcp_handler(
         return await gate_call(bot_instance, registered_name, approval, args, execute)
 
     return gated_handler
+
+
+def _state_wrap_mcp_handler(handler: Any, bot_instance: Any, tool_name: str) -> Any:
+    """Apply the voice SessionStatePolicy to an MCP tool handler.
+
+    The MCP counterpart of ``_make_global_wrapper``'s state hook: inject
+    state-driven args before the call and lift identifiers off the result
+    after it, so a template's ``tool_arg_injection`` / ``state_reducers`` reach
+    MCP tools on voice (chat already runs them in its ``_cycle_loop``). No-op
+    without a bot, and skipped when the bot sets ``handles_state_externally``
+    (chat). ``tool_name`` is the REGISTERED name the LLM calls — the name that
+    injection/reducer rules target. Applied OUTSIDE the approval gate, so a
+    denied call's bare ``{status, reason}`` simply finds no matching reducer
+    paths (no-op), while an approved call reduces its real result.
+    """
+    if bot_instance is None:
+        return handler
+
+    async def state_handler(args: Dict[str, Any], flow_manager: Any) -> Any:
+        if getattr(bot_instance, "handles_state_externally", False):
+            return await handler(args, flow_manager)
+        injected = _inject_voice_state(bot_instance, tool_name, args)
+        result = await handler(injected, flow_manager)
+        _reduce_voice_state(bot_instance, tool_name, result)
+        return result
+
+    return state_handler
 
 
 def _deep_merge_defaults(
@@ -641,6 +672,7 @@ async def _load_server_tools(
                 tool_name,
                 tool_approval,
             )
+            handler = _state_wrap_mcp_handler(handler, bot_instance, tool_name)
             schema_kwargs: Dict[str, Any] = {}
             if tool_approval is not None:
                 schema_kwargs["timeout_secs"] = _mcp_approval_timeout_secs(
@@ -698,6 +730,7 @@ async def _load_server_tools(
             tool_name,
             tool_approval,
         )
+        handler = _state_wrap_mcp_handler(handler, bot_instance, tool_name)
         schema_kwargs: Dict[str, Any] = {}
         if tool_approval is not None:
             schema_kwargs["timeout_secs"] = _mcp_approval_timeout_secs(tool_approval)

--- a/app/ai/voice/agents/breeze_buddy/template/global_function.py
+++ b/app/ai/voice/agents/breeze_buddy/template/global_function.py
@@ -22,6 +22,10 @@ from app.ai.voice.agents.breeze_buddy.template.context import TemplateContext
 from app.ai.voice.agents.breeze_buddy.template.func_action_handlers import (
     execute_func_post_actions,
 )
+from app.ai.voice.agents.breeze_buddy.template.session_state import (
+    _inject_voice_state,
+    _reduce_voice_state,
+)
 from app.ai.voice.agents.breeze_buddy.template.types import (
     BaseGlobalFunction,
     GlobalBuiltinFunction,
@@ -94,16 +98,31 @@ def _make_global_wrapper(
     """
 
     async def wrapper_handler(llm_args, flow_manager):
+        # SessionStatePolicy (voice): inject state-driven args before the
+        # handler runs and lift identifiers off the result after it — the
+        # same reducers / tool_arg_injection chat applies. Chat sets
+        # handles_state_externally and does this in its own _cycle_loop, so
+        # skip here to avoid double-application.
+        manages_state = not getattr(bot_instance, "handles_state_externally", False)
+        effective_args = (
+            _inject_voice_state(bot_instance, func.name, llm_args)
+            if manages_state
+            else llm_args
+        )
+
         async def execute() -> Any:
             await _run_filler_and_music(bot_instance, func)
             try:
                 result = await wrapped_handler(
-                    llm_args,
+                    effective_args,
                     function_config=func,
                 )
             finally:
                 # Always stop music even if handler errors
                 await _stop_music(bot_instance, func)
+
+            if manages_state:
+                _reduce_voice_state(bot_instance, func.name, result)
 
             if func.func_post_actions and bot_instance:
                 asyncio.create_task(
@@ -116,7 +135,7 @@ def _make_global_wrapper(
                 )
             return result
 
-        return await gate_global_function(bot_instance, func, llm_args, execute)
+        return await gate_global_function(bot_instance, func, effective_args, execute)
 
     return wrapper_handler
 

--- a/app/ai/voice/agents/breeze_buddy/template/session_state.py
+++ b/app/ai/voice/agents/breeze_buddy/template/session_state.py
@@ -329,6 +329,74 @@ def _is_tool_success(tool_result: Any) -> bool:
     return True
 
 
+# ---------------------------------------------------------------------------
+# Voice SessionStatePolicy — bot-aware application of the engines above.
+#
+# Chat runs inject_tool_args / apply_state_reducers itself inside
+# ChatAgent._cycle_loop. Voice has no such loop, so these helpers are applied
+# at the voice tool seams — global functions (template/global_function.py's
+# _make_global_wrapper) and MCP tools (mcp/__init__.py's loader). bot_instance
+# is duck-typed via getattr so this stays import-light (no agent import).
+# ---------------------------------------------------------------------------
+
+
+def _voice_state_session_id(bot_instance: Any) -> str:
+    """Best-effort session id for inject_tool_args' eval context (voice path).
+
+    Prefers the widget chat_session id (widget-resume), falls back to the
+    lead id / call_sid. Used only for the ``{session_id}`` eval var + the
+    idempotency-hash discriminator — never a correctness key on voice.
+    """
+    seed = getattr(bot_instance, "_widget_resume_seed", None)
+    if isinstance(seed, dict) and seed.get("widget_session_id"):
+        return str(seed["widget_session_id"])
+    lead = getattr(bot_instance, "lead", None)
+    if lead is not None and getattr(lead, "id", None):
+        return str(lead.id)
+    return str(getattr(bot_instance, "call_sid", "") or "")
+
+
+def _inject_voice_state(
+    bot_instance: Any, tool_name: str, llm_args: Dict[str, Any]
+) -> Dict[str, Any]:
+    """Voice SessionStatePolicy (read): fill state-driven tool args.
+
+    Mirrors what ``ChatAgent._cycle_loop`` does for chat — so a template's
+    ``tool_arg_injection`` rules (e.g. thread ``cart_id`` from session state
+    into ``update_cart``) work on voice too. Applied to both voice global
+    functions and voice MCP tools. No-op when no injection rules are declared.
+    """
+    configs = getattr(bot_instance, "configurations", None)
+    injections = getattr(configs, "tool_arg_injection", None) if configs else None
+    if not injections:
+        return llm_args
+    state = getattr(bot_instance, "agent_state", None) or {}
+    return inject_tool_args(
+        tool_name=tool_name,
+        args=llm_args,
+        state_data=state,
+        chat_session_id=_voice_state_session_id(bot_instance),
+        injections=injections,
+    )
+
+
+def _reduce_voice_state(bot_instance: Any, tool_name: str, result: Any) -> None:
+    """Voice SessionStatePolicy (write): lift identifiers off a tool result
+    into ``bot_instance.agent_state`` via the template's ``state_reducers``.
+    No-op when no reducers are declared or the bot carries no agent_state.
+    """
+    configs = getattr(bot_instance, "configurations", None)
+    reducers = getattr(configs, "state_reducers", None) if configs else None
+    if not reducers:
+        return
+    state = getattr(bot_instance, "agent_state", None)
+    if state is None:
+        return
+    bot_instance.agent_state = apply_state_reducers(
+        state_data=state, tool_name=tool_name, tool_result=result, reducers=reducers
+    )
+
+
 __all__ = [
     "apply_state_reducers",
     "inject_tool_args",

--- a/app/api/routers/breeze_buddy/widget/handlers.py
+++ b/app/api/routers/breeze_buddy/widget/handlers.py
@@ -600,6 +600,16 @@ async def voice_connect_handler(
             "widget_config_id": cfg.id,
             "source": "widget",
         }
+        # Carry the chat session's accumulated agent_state (reducer-built
+        # identifiers like cart_id / checkout_id, plus client-pushed facts)
+        # into the voice seed so they survive the CHAT->VOICE flip. Without
+        # this, a voice continuation of a chat that already built a cart
+        # loses the cart_id and would silently act on a fresh cart.
+        agent_state_row = await get_agent_session_state(session_id)
+        agent_state_data: Dict[str, Any] = (
+            dict(agent_state_row.data) if agent_state_row else {}
+        )
+
         # ``meta_data`` carries the voice-runtime seed (read by the
         # agent's _setup_*_transport). The widget_session_id back-link
         # is what the end_conversation drain uses to find the
@@ -611,6 +621,7 @@ async def voice_connect_handler(
             "start_node": session.current_node,
             "prior_history": prior_history,
             "seed_message_count": seed_message_count,
+            "agent_state": agent_state_data,
         }
         template_name = getattr(template, "name", None) or "widget"
 

--- a/tests/test_mcp_approval.py
+++ b/tests/test_mcp_approval.py
@@ -17,6 +17,7 @@ from typing import Any, Dict, List, Optional
 from app.ai.voice.agents.breeze_buddy.mcp import (
     _gate_mcp_handler,
     _mcp_approval_timeout_secs,
+    _state_wrap_mcp_handler,
     get_mcp_global_functions,
     get_mcp_global_functions_cached,
 )
@@ -25,6 +26,8 @@ from app.ai.voice.agents.breeze_buddy.template.types import (
     ApprovalConfig,
     McpConfig,
     McpServerConfig,
+    StateReducer,
+    ToolArgInjection,
 )
 
 
@@ -292,3 +295,82 @@ async def test_voice_loader_gated_handler_denies_without_network():
     result = await handler({"line_items": [1]}, None)
     assert result == {"status": "denied", "reason": "nope"}
     assert bot.approval_manager.requests[0]["function_name"] == "create_checkout"
+
+
+# ---------------------------------------------------------------------------
+# voice SessionStatePolicy for MCP tools — _state_wrap_mcp_handler
+# (inject_tool_args / apply_state_reducers, the MCP counterpart of
+# _make_global_wrapper's state hook; the pure engines are covered in
+# tests/test_session_state.py)
+# ---------------------------------------------------------------------------
+
+import json as _json  # noqa: E402
+
+
+def _state_bot(
+    agent_state: Dict[str, Any], *, external: bool = False
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        handles_state_externally=external,
+        configurations=SimpleNamespace(
+            tool_arg_injection=[
+                ToolArgInjection(
+                    tool_name="create_checkout",
+                    set_paths={"cart_id": "state.data.cart_id"},
+                )
+            ],
+            state_reducers=[
+                StateReducer(
+                    tool_name="create_checkout", set_paths={"cart_id": "cart.id"}
+                )
+            ],
+        ),
+        agent_state=dict(agent_state),
+        _widget_resume_seed=None,
+        lead=None,
+        call_sid="cs1",
+    )
+
+
+def _mcp_envelope(payload: dict) -> dict:
+    return {"status": "success", "data": _json.dumps(payload)}
+
+
+def _recording_mcp_handler(record: Dict[str, Any], result: Any):
+    async def handler(args, flow_manager):
+        record["args"] = args
+        return result
+
+    return handler
+
+
+async def test_state_wrap_injects_and_reduces_on_voice():
+    record: Dict[str, Any] = {}
+    bot = _state_bot({"cart_id": "C1"})
+    wrapped = _state_wrap_mcp_handler(
+        _recording_mcp_handler(record, _mcp_envelope({"cart": {"id": "C2"}})),
+        bot,
+        "create_checkout",
+    )
+    result = await wrapped({}, None)
+    assert record["args"].get("cart_id") == "C1"  # injected from state
+    assert bot.agent_state["cart_id"] == "C2"  # reduced from the result
+    assert result == _mcp_envelope({"cart": {"id": "C2"}})
+
+
+async def test_state_wrap_skips_when_handled_externally():
+    record: Dict[str, Any] = {}
+    bot = _state_bot({"cart_id": "C1"}, external=True)
+    wrapped = _state_wrap_mcp_handler(
+        _recording_mcp_handler(record, _mcp_envelope({"cart": {"id": "C2"}})),
+        bot,
+        "create_checkout",
+    )
+    await wrapped({}, None)
+    assert "cart_id" not in record["args"]  # not injected by the wrapper
+    assert bot.agent_state == {"cart_id": "C1"}  # not reduced by the wrapper
+
+
+async def test_state_wrap_noop_without_bot():
+    handler = _recording_mcp_handler({}, _mcp_envelope({}))
+    assert _state_wrap_mcp_handler(handler, None, "create_checkout") is handler

--- a/tests/test_voice_session_state.py
+++ b/tests/test_voice_session_state.py
@@ -1,0 +1,154 @@
+"""Voice SessionStatePolicy — back-port of inject_tool_args / apply_state_reducers
+to the voice global-function wrapper.
+
+Chat runs these in ChatAgent._cycle_loop; voice has no such loop, so the shared
+``_make_global_wrapper`` applies them — gated by ``handles_state_externally`` so
+chat (which sets the flag) is NOT double-applied. The pure inject/reduce engines
+themselves are covered in tests/test_session_state.py; here we test the voice
+wiring + the gating.
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from typing import Any, Dict
+
+from app.ai.voice.agents.breeze_buddy.template.global_function import (
+    _make_global_wrapper,
+)
+from app.ai.voice.agents.breeze_buddy.template.session_state import (
+    _inject_voice_state,
+    _reduce_voice_state,
+)
+
+# template.types FIRST — warm up the template package before importing
+# global_function (same import-order constraint as tests/test_session_state.py).
+from app.ai.voice.agents.breeze_buddy.template.types import (  # isort: skip
+    GlobalBuiltinFunction,
+    StateReducer,
+    ToolArgInjection,
+)
+
+
+def _flow_result(payload: dict, status: str = "success") -> dict:
+    return {"status": status, "data": json.dumps(payload)}
+
+
+def _func(name: str = "update_cart") -> GlobalBuiltinFunction:
+    return GlobalBuiltinFunction.model_validate(
+        {
+            "type": "builtin",
+            "name": name,
+            "description": "Update the cart",
+            "handler": "noop_handler",
+        }
+    )
+
+
+def _configs() -> SimpleNamespace:
+    return SimpleNamespace(
+        tool_arg_injection=[
+            ToolArgInjection(
+                tool_name="update_cart", set_paths={"cart_id": "state.data.cart_id"}
+            )
+        ],
+        state_reducers=[
+            StateReducer(tool_name="update_cart", set_paths={"cart_id": "cart.id"})
+        ],
+    )
+
+
+def _voice_bot(agent_state: Dict[str, Any]) -> SimpleNamespace:
+    """Voice bot: NO handles_state_externally -> wrapper manages state."""
+    return SimpleNamespace(
+        configurations=_configs(),
+        agent_state=dict(agent_state),
+        _widget_resume_seed=None,
+        lead=None,
+        call_sid="cs1",
+    )
+
+
+def _recording_handler(record: Dict[str, Any], result: Any):
+    async def handler(args, function_config=None):
+        record["args"] = args
+        return result
+
+    return handler
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+
+def test_inject_voice_state_fills_missing_from_state():
+    out = _inject_voice_state(_voice_bot({"cart_id": "C1"}), "update_cart", {})
+    assert out["cart_id"] == "C1"
+
+
+def test_inject_voice_state_llm_value_wins_only_if_missing():
+    out = _inject_voice_state(
+        _voice_bot({"cart_id": "C1"}), "update_cart", {"cart_id": "FROM_LLM"}
+    )
+    assert out["cart_id"] == "FROM_LLM"
+
+
+def test_inject_voice_state_noop_without_rules():
+    bot = SimpleNamespace(
+        configurations=SimpleNamespace(tool_arg_injection=[]),
+        agent_state={"cart_id": "C1"},
+    )
+    assert _inject_voice_state(bot, "update_cart", {"x": 1}) == {"x": 1}
+
+
+def test_inject_voice_state_noop_without_configurations():
+    bot = SimpleNamespace(configurations=None, agent_state={"cart_id": "C1"})
+    assert _inject_voice_state(bot, "update_cart", {"x": 1}) == {"x": 1}
+
+
+def test_reduce_voice_state_lifts_identifier_into_agent_state():
+    bot = _voice_bot({})
+    _reduce_voice_state(bot, "update_cart", _flow_result({"cart": {"id": "C2"}}))
+    assert bot.agent_state["cart_id"] == "C2"
+
+
+def test_reduce_voice_state_noop_without_reducers():
+    bot = SimpleNamespace(
+        configurations=SimpleNamespace(state_reducers=[]), agent_state={"a": 1}
+    )
+    _reduce_voice_state(bot, "update_cart", _flow_result({"cart": {"id": "C2"}}))
+    assert bot.agent_state == {"a": 1}
+
+
+# ---------------------------------------------------------------------------
+# wrapper gating (voice applies, chat skips)
+# ---------------------------------------------------------------------------
+
+
+async def test_wrapper_injects_and_reduces_on_voice():
+    record: Dict[str, Any] = {}
+    bot = _voice_bot({"cart_id": "C1"})
+    wrapper = _make_global_wrapper(
+        _func(), _recording_handler(record, _flow_result({"cart": {"id": "C2"}})), bot
+    )
+    # LLM provided no cart_id; the wrapper injects it from agent_state...
+    result = await wrapper({}, None)
+    assert record["args"].get("cart_id") == "C1"
+    # ...and reduces the result back into agent_state.
+    assert bot.agent_state["cart_id"] == "C2"
+    assert result == _flow_result({"cart": {"id": "C2"}})
+
+
+async def test_wrapper_skips_state_when_handled_externally():
+    """Chat sets handles_state_externally -> wrapper neither injects nor reduces."""
+    record: Dict[str, Any] = {}
+    bot = _voice_bot({"cart_id": "C1"})
+    bot.handles_state_externally = True
+    wrapper = _make_global_wrapper(
+        _func(), _recording_handler(record, _flow_result({"cart": {"id": "C2"}})), bot
+    )
+    await wrapper({}, None)
+    assert "cart_id" not in record["args"]  # not injected by the wrapper
+    assert bot.agent_state == {"cart_id": "C1"}  # not reduced by the wrapper


### PR DESCRIPTION
## What

So a widget **CHAT↔VOICE** flip keeps the session's reducer-built state (`cart_id`, `checkout_id`, client facts) instead of silently dropping it. **Root cause:** the voice runtime had *zero* state-reducer / `tool_arg_injection` code — a template's state config worked in chat and silently no-op'd on the real voice call.

### 1. Carry (CHAT→VOICE seed)
Seed `agent_session_state` (`widget/handlers.py`) → merge into `template_vars` (`only_if_missing`) so chat-built IDs thread through voice's existing `{placeholder}` resolution. Voice agent holds `self.agent_state`.

### 2. Run (SessionStatePolicy on voice)
`inject_tool_args` before each voice tool, `apply_state_reducers` after — the *same* pure engines chat runs in `_cycle_loop` — at **both** voice tool seams: **global functions** (`_make_global_wrapper`) **and MCP tools** (the mcp loader's `_state_wrap_mcp_handler`, applied outside the approval gate). Gated by a new `handles_state_externally` flag (chat sets it → wrapper skips; voice applies). The two helpers live in `session_state.py` next to the pure engines so both seams share them. No-op without state config.

### 3. Persist (VOICE→CHAT drain)
`end_conversation` writes voice's accumulated `agent_state` back to the chat session — completes the round-trip.

## Re: the AI review comment (merge timing)
**Validated — not applicable, so not changed.** `_render_direct_mode_flow` (loader.py:72-82) renders only the `system_prompt` at load; *"Function descriptions are not rendered."* So function `{placeholder}`s (where these IDs live) resolve at **call** time from the already-merged `template_vars`. And part #2 adds `inject_tool_args` as the robust call-time path anyway.

## Verification
- `tests/test_voice_session_state.py` (8) — global-function inject/reduce + gating; `tests/test_mcp_approval.py` (+3) — MCP state wrap.
- pyrefly 0 errors; full suite **452 passed**; field_reference coverage green.

## Manual repro
Chat adds an item (builds `cart_id`) → tap mic → voice acts on the **same** cart → back in chat, cart persists.