### PR TITLE
feat(widget): add redirect support to quick-reply pills

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,6 @@ logs
 .claude/memory/
 CLAUDE.local.md
 .claude/settings.json
+
+# Local scratch / test fixtures
+temp/

--- a/app/ai/voice/agents/breeze_buddy/template/types.py
+++ b/app/ai/voice/agents/breeze_buddy/template/types.py
@@ -16,6 +16,7 @@ from pydantic import (
     model_validator,
 )
 
+from app.ai.voice.agents.breeze_buddy.template.ui_catalog import ActionUnion, Icon
 from app.ai.voice.llm.types import LLMConfiguration
 from app.core.deprecation import log_deprecated_fields
 from app.core.logger import logger
@@ -658,6 +659,11 @@ class QuickReplyOption(BaseModel):
     omitted it falls back to ``label``, which lets the display text differ
     from the agent instruction (e.g. label="Track my order" while the
     backend receives a more explicit instruction).
+
+    Set ``action`` to override the click behavior. With an ``open_url``
+    action the chicklet **redirects** (opens the URL, honoring ``target``)
+    instead of messaging the agent; ``value`` is then optional and the
+    label fallback is not applied.
     """
 
     label: str = Field(..., min_length=1, description="Button text shown to the user.")
@@ -665,7 +671,24 @@ class QuickReplyOption(BaseModel):
         None,
         description=(
             "Payload sent to the backend. Defaults to label when absent "
-            "the fallback is applied server-side before the value reaches the client."
+            "the fallback is applied server-side before the value reaches the client. "
+            "Ignored when ``action`` is an ``open_url`` redirect."
+        ),
+    )
+    action: Optional[ActionUnion] = Field(
+        None,
+        description=(
+            "Optional click action. When omitted the chicklet sends ``value`` "
+            "to the agent (default). An ``open_url`` action makes it redirect "
+            "instead of messaging the agent."
+        ),
+    )
+    icon: Optional[Icon] = Field(
+        None,
+        description=(
+            "Optional icon shown alongside the label. Independent of "
+            "``value``/``action`` — applies to both message and redirect "
+            "chicklets."
         ),
     )
 

--- a/app/ai/voice/agents/breeze_buddy/template/ui_catalog.py
+++ b/app/ai/voice/agents/breeze_buddy/template/ui_catalog.py
@@ -86,15 +86,38 @@ class ToAssistantAction(BaseModel):
 
 
 class OpenUrlAction(BaseModel):
-    """Open ``url`` in a new tab. Server-provided URLs only."""
+    """Open ``url``. Server-provided URLs only.
+
+    ``target`` controls where it opens: ``new_tab`` (default — preserves the
+    historical behavior) or ``same_tab`` to navigate the current page (e.g.
+    a checkout redirect)."""
 
     model_config = ConfigDict(extra="forbid")
 
     type: Literal["open_url"] = "open_url"
     url: HttpUrl
+    target: Literal["new_tab", "same_tab"] = Field(
+        "new_tab",
+        description=(
+            "Where to open the URL. ``new_tab`` (default) opens a new tab; "
+            "``same_tab`` navigates the current page."
+        ),
+    )
 
 
 ActionUnion = Union[ToAssistantAction, OpenUrlAction]
+
+
+class Icon(BaseModel):
+    """A small icon shown alongside a quick-reply chicklet. Server-provided
+    URLs only (http/https), same posture as ``Image.src``."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    url: HttpUrl
+    alt: Optional[str] = Field(
+        None, description="Accessible label for the icon. Optional."
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -208,8 +231,13 @@ class Buttons(_CatalogBase):
 class QuickReplyItem(BaseModel):
     """One pill in a ``QuickReplies`` row.
 
-    ``value`` is what gets sent to the agent; ``label`` is what the user
-    sees. When ``value`` is absent the widget echoes ``label`` verbatim.
+    Default behavior (no ``action``): clicking sends ``value`` back to the
+    agent (``label`` when ``value`` is absent) — a ``to_assistant`` round-trip.
+
+    Set ``action`` to override the click behavior. With an ``open_url``
+    action the pill **redirects** (opens the URL, honoring ``target``)
+    instead of messaging the agent — useful for "View your order",
+    "Checkout", help links, etc. ``value`` is then optional.
     """
 
     model_config = ConfigDict(extra="forbid")
@@ -219,7 +247,16 @@ class QuickReplyItem(BaseModel):
         None,
         description=(
             "Payload sent to the agent. Falls back to ``label`` when absent — "
-            "lets the display text differ from the agent instruction."
+            "lets the display text differ from the agent instruction. Ignored "
+            "when ``action`` is an ``open_url`` redirect."
+        ),
+    )
+    action: Optional[ActionUnion] = Field(
+        None,
+        description=(
+            "Optional click action. When omitted the pill sends ``value`` to "
+            "the agent (default). An ``open_url`` action makes the pill "
+            "redirect instead of messaging the agent."
         ),
     )
 

--- a/app/ai/voice/agents/breeze_buddy/template/ui_prompt.py
+++ b/app/ai/voice/agents/breeze_buddy/template/ui_prompt.py
@@ -89,7 +89,14 @@ _EXAMPLES: Dict[str, Dict[str, Any]] = {
         "items": [
             {"label": "Yes, confirm"},
             {"label": "No, cancel", "value": "cancel_order_intent"},
-            {"label": "Show more options"},
+            {
+                "label": "View your order",
+                "action": {
+                    "type": "open_url",
+                    "url": "https://shop.example/orders/123",
+                    "target": "new_tab",
+                },
+            },
         ],
     },
     "Handoff": {

--- a/app/api/routers/breeze_buddy/widget/handlers.py
+++ b/app/api/routers/breeze_buddy/widget/handlers.py
@@ -141,6 +141,12 @@ def _synthetic_widget_user(widget_config_id: str) -> UserInfo:
 # ---------------------------------------------------------------------------
 
 
+def _is_redirect_action(action: object) -> bool:
+    """True when a quick-reply action is an ``open_url`` redirect (vs. the
+    default send-to-agent behavior). Such pills carry no ``value``."""
+    return getattr(action, "type", None) == "open_url"
+
+
 def _extract_widget_config(
     template: object,
 ) -> tuple[List[QuickReplyWire], bool]:
@@ -155,7 +161,19 @@ def _extract_widget_config(
         return [], True
     quick_replies: List[QuickReplyWire] = [
         QuickReplyWire(
-            label=qr.label, value=qr.value if qr.value is not None else qr.label
+            label=qr.label,
+            # Redirect pills (open_url action) never message the agent, so they
+            # always emit value=None — even if the config set one. The
+            # label->value fallback applies only to plain message pills.
+            value=(
+                None
+                if _is_redirect_action(qr.action)
+                else (qr.value if qr.value is not None else qr.label)
+            ),
+            action=qr.action,
+            # Icon is purely presentational — pass it through verbatim for
+            # every pill (no value/action coupling).
+            icon=qr.icon,
         )
         for qr in (getattr(configurations, "quick_replies", None) or [])
     ]

--- a/app/schemas/breeze_buddy/chat.py
+++ b/app/schemas/breeze_buddy/chat.py
@@ -11,6 +11,8 @@ from typing import Any, Dict, List, Optional
 
 from pydantic import BaseModel, Field
 
+from app.ai.voice.agents.breeze_buddy.template.ui_catalog import ActionUnion, Icon
+
 
 class ChatSessionStatus(str, Enum):
     """Lifecycle status of a chat session."""
@@ -447,8 +449,25 @@ class QuickReplyWire(BaseModel):
     value: Optional[str] = Field(
         None,
         description=(
-            "Payload sent to the backend. Always populated — falls back to "
-            "label server-side when not explicitly set in the template."
+            "Payload sent to the backend. Populated for message pills — falls "
+            "back to label server-side when not explicitly set in the template. "
+            "May be null when ``action`` is an ``open_url`` redirect."
+        ),
+    )
+    action: Optional[ActionUnion] = Field(
+        None,
+        description=(
+            "Optional click action. When null the pill sends ``value`` to the "
+            "agent (default). An ``open_url`` action makes the pill redirect "
+            "(opening the URL, honoring its ``target``) instead of messaging."
+        ),
+    )
+    icon: Optional[Icon] = Field(
+        None,
+        description=(
+            "Optional icon (``url`` + ``alt``) shown alongside the label. "
+            "Passed through verbatim from the template config — present on "
+            "both message and redirect pills."
         ),
     )
 

--- a/tests/test_quick_reply_redirect.py
+++ b/tests/test_quick_reply_redirect.py
@@ -1,0 +1,242 @@
+"""Tests for redirect (``open_url``) support on quick-reply pills.
+
+Quick replies historically only sent ``value`` back to the agent. A pill
+can now optionally carry an ``action`` — an ``open_url`` action makes it
+redirect instead of messaging. These tests pin both the new behavior and
+backward compatibility (no ``action`` => unchanged send-to-agent path).
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from pydantic import ValidationError
+
+from app.ai.voice.agents.breeze_buddy.template.types import QuickReplyOption
+
+# Load the template package (ui_catalog) before any chat/* module — same
+# circular-import precaution as the sibling ui_prompt / ui_stream tests.
+from app.ai.voice.agents.breeze_buddy.template.ui_catalog import (
+    Icon,
+    OpenUrlAction,
+    QuickReplies,
+    QuickReplyItem,
+    ToAssistantAction,
+    validate_props,
+)
+from app.api.routers.breeze_buddy.widget.handlers import _extract_widget_config
+from app.schemas.breeze_buddy.chat import QuickReplyWire
+
+# ---------------------------------------------------------------------------
+# OpenUrlAction.target
+# ---------------------------------------------------------------------------
+
+
+def test_open_url_defaults_to_new_tab():
+    """Existing open_url actions (no target) keep opening in a new tab."""
+    action = OpenUrlAction(url="https://shop.example/orders/1")
+    assert action.target == "new_tab"
+
+
+def test_open_url_accepts_same_tab():
+    action = OpenUrlAction(url="https://shop.example/checkout", target="same_tab")
+    assert action.target == "same_tab"
+
+
+def test_open_url_rejects_unknown_target():
+    with pytest.raises(ValidationError):
+        # model_validate (vs the constructor) so the intentionally-bad literal
+        # is rejected at runtime without a static argument-type error.
+        OpenUrlAction.model_validate(
+            {"url": "https://shop.example/x", "target": "popup"}
+        )
+
+
+# ---------------------------------------------------------------------------
+# Dynamic QuickReplies primitive
+# ---------------------------------------------------------------------------
+
+
+def test_quick_replies_with_redirect_action_validates():
+    qr = validate_props(
+        "QuickReplies",
+        {
+            "items": [
+                {"label": "Yes"},
+                {
+                    "label": "View order",
+                    "action": {
+                        "type": "open_url",
+                        "url": "https://shop.example/orders/1",
+                        "target": "same_tab",
+                    },
+                },
+            ]
+        },
+    )
+    assert isinstance(qr, QuickReplies)
+    assert qr.items[0].action is None  # backward-compat: message pill
+    redirect = qr.items[1].action
+    assert isinstance(redirect, OpenUrlAction)
+    assert redirect.type == "open_url"
+    assert redirect.target == "same_tab"
+
+
+def test_quick_reply_item_without_action_is_backward_compatible():
+    item = QuickReplyItem(label="Track", value="Track my order")
+    assert item.action is None
+    assert item.value == "Track my order"
+
+
+def test_quick_reply_item_accepts_to_assistant_action():
+    item = QuickReplyItem(label="x", action={"type": "to_assistant", "msg": "hi"})
+    assert isinstance(item.action, ToAssistantAction)
+    assert item.action.type == "to_assistant"
+
+
+# ---------------------------------------------------------------------------
+# Static config model (QuickReplyOption) + wire (QuickReplyWire)
+# ---------------------------------------------------------------------------
+
+
+def test_static_option_redirect_needs_no_value():
+    opt = QuickReplyOption(
+        label="Checkout",
+        action={"type": "open_url", "url": "https://shop.example/checkout"},
+    )
+    assert opt.value is None
+    assert isinstance(opt.action, OpenUrlAction)
+    assert opt.action.type == "open_url"
+
+
+def test_static_option_without_action_is_backward_compatible():
+    opt = QuickReplyOption(label="Track", value="Track my order")
+    assert opt.action is None
+
+
+def test_wire_carries_action_with_null_value():
+    wire = QuickReplyWire(
+        label="Checkout",
+        value=None,
+        action={"type": "open_url", "url": "https://shop.example/checkout"},
+    )
+    assert wire.value is None
+    assert isinstance(wire.action, OpenUrlAction)
+    assert wire.action.target == "new_tab"
+
+
+# ---------------------------------------------------------------------------
+# Widget handler — value fallback only for message pills
+# ---------------------------------------------------------------------------
+
+
+def _template_with_quick_replies(options):
+    configurations = SimpleNamespace(quick_replies=options, enable_text_input=True)
+    return SimpleNamespace(configurations=configurations)
+
+
+def test_handler_message_pill_falls_back_to_label():
+    template = _template_with_quick_replies([QuickReplyOption(label="Track my order")])
+    replies, enable_text_input = _extract_widget_config(template)
+    assert enable_text_input is True
+    assert replies[0].value == "Track my order"  # label fallback
+    assert replies[0].action is None
+
+
+def test_handler_redirect_pill_has_null_value_and_passes_action():
+    template = _template_with_quick_replies(
+        [
+            QuickReplyOption(
+                label="View your order",
+                # Even with a value set, a redirect pill must drop it: it
+                # navigates, it never messages the agent.
+                value="should be dropped",
+                action={"type": "open_url", "url": "https://shop.example/orders/1"},
+            )
+        ]
+    )
+    replies, _ = _extract_widget_config(template)
+    # Redirect pills don't message the agent — value is always None.
+    assert replies[0].value is None
+    assert isinstance(replies[0].action, OpenUrlAction)
+    assert replies[0].action.type == "open_url"
+
+
+def test_handler_no_configurations_returns_defaults():
+    assert _extract_widget_config(SimpleNamespace(configurations=None)) == ([], True)
+
+
+# ---------------------------------------------------------------------------
+# Icon — backend-driven chicklet icon (static chicklets only)
+# ---------------------------------------------------------------------------
+
+
+def test_icon_validates_with_url_and_alt():
+    icon = Icon(url="https://cdn.example/user.svg", alt="My account")
+    assert str(icon.url) == "https://cdn.example/user.svg"
+    assert icon.alt == "My account"
+
+
+def test_icon_alt_is_optional():
+    icon = Icon(url="https://cdn.example/cart.svg")
+    assert icon.alt is None
+
+
+def test_icon_rejects_unknown_key():
+    with pytest.raises(ValidationError):
+        Icon.model_validate({"url": "https://cdn.example/x.svg", "size": "lg"})
+
+
+def test_static_option_carries_icon():
+    opt = QuickReplyOption(
+        label="My account",
+        action={"type": "open_url", "url": "https://shop.example/account"},
+        icon={"url": "https://cdn.example/user.svg", "alt": "My account"},
+    )
+    assert isinstance(opt.icon, Icon)
+    assert opt.icon.alt == "My account"
+
+
+def test_static_option_without_icon_is_backward_compatible():
+    opt = QuickReplyOption(label="Track", value="Track my order")
+    assert opt.icon is None
+
+
+def test_handler_passes_icon_through_for_message_pill():
+    template = _template_with_quick_replies(
+        [
+            QuickReplyOption(
+                label="What's on sale?",
+                value="Show me what's on sale",
+                icon={"url": "https://cdn.example/sale.svg", "alt": "Sale"},
+            )
+        ]
+    )
+    replies, _ = _extract_widget_config(template)
+    # Icon is presentational — it survives regardless of value/action.
+    assert replies[0].value == "Show me what's on sale"
+    assert isinstance(replies[0].icon, Icon)
+    assert str(replies[0].icon.url) == "https://cdn.example/sale.svg"
+
+
+def test_handler_passes_icon_through_for_redirect_pill():
+    template = _template_with_quick_replies(
+        [
+            QuickReplyOption(
+                label="My account",
+                action={"type": "open_url", "url": "https://shop.example/account"},
+                icon={"url": "https://cdn.example/user.svg", "alt": "My account"},
+            )
+        ]
+    )
+    replies, _ = _extract_widget_config(template)
+    assert replies[0].value is None  # redirect pill
+    assert isinstance(replies[0].icon, Icon)
+    assert replies[0].icon.alt == "My account"
+
+
+def test_handler_pill_without_icon_emits_none():
+    template = _template_with_quick_replies([QuickReplyOption(label="Track my order")])
+    replies, _ = _extract_widget_config(template)
+    assert replies[0].icon is None


### PR DESCRIPTION
Quick-reply chicklets could only send their value back to the agent. A pill can now optionally carry an action, reusing the catalog's existing ActionUnion: an open_url action makes the pill redirect (honoring a new target: new_tab|same_tab) instead of messaging the agent.

- ui_catalog: OpenUrlAction gains target; QuickReplyItem gains action
- ui_prompt: add a redirect example so the LLM can emit redirect pills
- types: QuickReplyOption (static config chicklets) gains action
- chat schema: QuickReplyWire carries action to the frontend
- widget handler: pass action through; only apply the value=label fallback for message pills (redirect pills have null value)

Backward compatible: action defaults to None (existing send-to-agent behavior), target defaults to new_tab. JSONB column, no migration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Quick-reply buttons can now perform URL redirects with configurable target behavior (open in new tab or same tab).
  * Maintains backward compatibility with existing message-based quick replies.

* **Tests**
  * Added comprehensive test coverage for quick-reply redirect functionality, including validation and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->