### PR TITLE
fix(chat): terminal sweep — resolve pending approvals on session end

### DIFF
--- a/app/ai/voice/agents/breeze_buddy/chat/approvals.py
+++ b/app/ai/voice/agents/breeze_buddy/chat/approvals.py
@@ -114,3 +114,44 @@ async def resolve_dangling_approvals(
         f"{new_status.value} for session {session_id}"
     )
     return claimed
+
+
+async def terminate_pending_approvals(session_id: str) -> List[ToolApproval]:
+    """Resolve ALL still-pending approvals when a session terminates.
+
+    The chat counterpart of voice's ``ApprovalManager.deny_all`` on a terminal
+    event (disconnect / idle / conversation-end). The idle-cleanup task ends a
+    session, but without this its gated ``tool_approval`` rows are left PENDING
+    until lazy expiry — a dangling ``tool_use`` a late reload or audit would
+    see unanswered, and a ``pending_approvals`` query would report as still
+    live on an ended session. Claims every pending row as EXPIRED (timeout
+    result) and writes the coalesced synthetic ``tool_result`` so the
+    dangling-tool_use invariant holds even on an ended session.
+
+    Differs from ``resolve_dangling_approvals(only_expired=False)`` only in the
+    terminal STATUS: that path SUPERSEDES (the user moved on, mid-session);
+    this one EXPIRES (the session itself ended — closer to voice's terminal
+    deny). The caller runs under the session Redis lock (see chat/cleanup.py),
+    and the claim is an atomic CAS, so a racing ``/approval`` simply loses.
+    """
+    claimed = await claim_pending_tool_approvals(
+        session_id=session_id,
+        new_status=ToolApprovalStatus.EXPIRED,
+        reason="the chat session ended before a decision arrived",
+        only_expired=False,  # claim ALL pending, not just rows past expires_at
+    )
+    if not claimed:
+        return []
+
+    pairs = [(row.tool_call_id, EXPIRED_RESULT) for row in claimed]
+    await insert_chat_message(
+        session_id=session_id,
+        role=ChatMessageRole.USER,
+        content=None,
+        content_blocks=tool_results_to_user_blocks(pairs),
+    )
+    logger.info(
+        f"[approval] Terminated {len(claimed)} pending approval(s) on session "
+        f"end for {session_id}"
+    )
+    return claimed

--- a/app/ai/voice/agents/breeze_buddy/chat/cleanup.py
+++ b/app/ai/voice/agents/breeze_buddy/chat/cleanup.py
@@ -9,6 +9,9 @@ duplicate runs from a botched lock acquire are safe.
 
 from datetime import timedelta
 
+from app.ai.voice.agents.breeze_buddy.chat.approvals import (
+    terminate_pending_approvals,
+)
 from app.core.config.dynamic import CHAT_SESSION_END_TIMEOUT_SECONDS
 from app.core.logger import logger
 from app.database.accessor.breeze_buddy.chat_session import (
@@ -84,6 +87,15 @@ async def end_idle_chat_sessions() -> None:
                 ended_reason=ChatEndedReason.IDLE_TIMEOUT,
             )
             ended += 1
+            # Terminal sweep: resolve any approvals left PENDING on the now-
+            # ENDED session (chat's analog of voice deny_all). Best-effort —
+            # a failure here must not undo the end. Runs under the same lock.
+            try:
+                await terminate_pending_approvals(session_id)
+            except Exception as exc:
+                logger.warning(
+                    f"chat cleanup: terminate approvals failed for {session_id}: {exc}"
+                )
         except Exception as exc:
             logger.warning(f"chat cleanup: end_chat_session failed for {row.id}: {exc}")
         finally:

--- a/tests/test_chat_approval_terminal_sweep.py
+++ b/tests/test_chat_approval_terminal_sweep.py
@@ -1,0 +1,63 @@
+"""Chat terminal approval sweep — terminate_pending_approvals.
+
+The chat counterpart of voice's ApprovalManager.deny_all on a terminal event:
+when the idle-cleanup task ends a session, any still-PENDING approvals must be
+resolved (EXPIRED) instead of left dangling. The two DB calls
+(claim_pending_tool_approvals + insert_chat_message) are monkeypatched so this
+is a pure logic test.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from app.ai.voice.agents.breeze_buddy.chat import approvals as approvals_mod
+from app.ai.voice.agents.breeze_buddy.chat.approvals import terminate_pending_approvals
+from app.schemas.breeze_buddy.chat import ToolApprovalStatus
+
+
+async def test_terminate_claims_all_pending_as_expired(monkeypatch):
+    claim: dict = {}
+    inserted: dict = {}
+
+    async def fake_claim(*, session_id, new_status, reason, only_expired):
+        claim.update(
+            session_id=session_id, new_status=new_status, only_expired=only_expired
+        )
+        return [SimpleNamespace(tool_call_id="t1"), SimpleNamespace(tool_call_id="t2")]
+
+    async def fake_insert(*, session_id, role, content, content_blocks):
+        inserted.update(session_id=session_id, content_blocks=content_blocks)
+
+    monkeypatch.setattr(approvals_mod, "claim_pending_tool_approvals", fake_claim)
+    monkeypatch.setattr(approvals_mod, "insert_chat_message", fake_insert)
+
+    claimed = await terminate_pending_approvals("sess-1")
+
+    # Claims ALL pending (not only_expired) and marks them EXPIRED — the
+    # terminal status (vs SUPERSEDED for a mid-session new message).
+    assert claim["new_status"] == ToolApprovalStatus.EXPIRED
+    assert claim["only_expired"] is False
+    assert claim["session_id"] == "sess-1"
+    assert [r.tool_call_id for r in claimed] == ["t1", "t2"]
+    # One coalesced synthetic tool_result row answers both claimed approvals,
+    # keeping the dangling-tool_use invariant intact on the ended session.
+    assert inserted["session_id"] == "sess-1"
+    assert inserted["content_blocks"]
+
+
+async def test_terminate_noop_when_nothing_pending(monkeypatch):
+    insert_calls = {"n": 0}
+
+    async def fake_claim(**_kwargs):
+        return []
+
+    async def fake_insert(**_kwargs):
+        insert_calls["n"] += 1
+
+    monkeypatch.setattr(approvals_mod, "claim_pending_tool_approvals", fake_claim)
+    monkeypatch.setattr(approvals_mod, "insert_chat_message", fake_insert)
+
+    claimed = await terminate_pending_approvals("sess-2")
+    assert claimed == []
+    assert insert_calls["n"] == 0  # no synthetic row written when nothing pending


### PR DESCRIPTION
## What

The HITL **deny-on-terminal** policy slice of the "one approval policy, two transports" unification.

Chat's idle-cleanup task (`end_idle_chat_sessions`) marks a session **ENDED** but never resolved its still-**PENDING** `tool_approval` rows — they were left dangling until lazy expiry. **Voice** already does the equivalent eagerly (`ApprovalManager.deny_all` on disconnect / idle / conversation-end); chat had **no terminal sweep**. That's a documented chat↔voice divergence (the deny-on-terminal decision differs between the two transports).

## How

- **`chat/approvals.py`** — `terminate_pending_approvals(session_id)`: atomically claims every pending row as **EXPIRED** (timeout result) and writes the coalesced synthetic `tool_result`, so the dangling-`tool_use` invariant holds even on an ended session. It differs from `resolve_dangling_approvals(only_expired=False)` only in the terminal *status*: **EXPIRED** (the session itself ended) vs **SUPERSEDED** (a mid-session new message).
- **`chat/cleanup.py`** — calls it right after `end_chat_session`, **under the same per-session Redis lock**, best-effort (a failure never undoes the end; the atomic claim makes a racing `/approval` simply lose the CAS and 409).

## Why this slice (and not the rest of the coordinator)

The HITL policy is already half-unified — `gate_call` and the status vocabulary (`approval.py:36-45`) are shared. Of the three forked decisions, this PR fixes the cleanest one. The other two **change working behavior and need a product call**, so they're deliberately out of scope:
- **when-to-gate / shadow-gating** — a gated global shadowed by a same-named per-node function is gated by chat (name-keyed) but not voice; picking one rule is a behavior change with an ambiguous "intended" answer.
- **supersede trigger** — voice keys on duplicate-same-function, chat on new-user-message; unifying needs the `tool_call_id` threading (findings doc #5).

## Verification
- `tests/test_chat_approval_terminal_sweep.py` (2) — claims-all-as-EXPIRED + writes the synthetic result; no-op when nothing pending.
- pyrefly 0 errors; full suite **443 passed**; field_reference coverage green.