### PR TITLE
fix(hitl): unify when-to-gate (shadow) + supersede keying across chat/voice

### DIFF
--- a/app/ai/voice/agents/breeze_buddy/agent/approval.py
+++ b/app/ai/voice/agents/breeze_buddy/agent/approval.py
@@ -15,11 +15,13 @@ Lifecycle invariants (these are load-bearing — see plan review):
   grace; pipeline teardown) the map pop is synchronous and the emit is a
   cheap frame-queue put, so cleanup fits the grace window; the error is
   re-raised so pipecat records the call as CANCELLED.
-- Duplicate request for the same function name (async re-call, parallel
-  batch) supersedes the older pending request.
+- An IDENTICAL re-call (same function name AND same arguments) supersedes
+  the older pending request. Distinct parallel calls to the same function
+  (different arguments) each keep their own pending card.
 """
 
 import asyncio
+import json
 import uuid
 from typing import Any, Awaitable, Callable, Dict, List, Optional, Tuple
 
@@ -54,6 +56,26 @@ _Resolution = Tuple[bool, str, Optional[str]]
 _MAX_WAIT_SECS = 270.0
 
 
+def _dedupe_key(function_name: str, arguments: Optional[Dict[str, Any]]) -> str:
+    """Supersede key = function name + a stable fingerprint of the arguments.
+
+    A true re-call (same function, same args) collides and supersedes the
+    stale pending request; two DISTINCT parallel calls to the same function
+    (different args — e.g. two ``add_to_cart``) get different keys and each
+    keep their own pending card instead of one clobbering the other.
+    """
+    try:
+        return (
+            f"{function_name}\x00"
+            f"{json.dumps(arguments or {}, sort_keys=True, default=str)}"
+        )
+    except Exception:
+        # LLM tool args are JSON-serializable in practice; if some exotic
+        # value isn't, fall back to function-name-only keying (the older,
+        # coarser supersede behavior) rather than crash the gate.
+        return function_name
+
+
 class ApprovalManager:
     """Tracks pending approval requests for one in-process voice bot."""
 
@@ -62,8 +84,11 @@ class ApprovalManager:
         self._pending: Dict[
             str, Tuple["asyncio.Future[_Resolution]", Dict[str, Any]]
         ] = {}
-        # function_name -> approval_id, for supersede-on-duplicate.
-        self._by_function: Dict[str, str] = {}
+        # dedupe-key -> approval_id, for supersede-on-duplicate. Key is
+        # function_name + args fingerprint (see _dedupe_key): a true re-call
+        # supersedes; distinct parallel calls to the same function each keep
+        # their own card.
+        self._by_request: Dict[str, str] = {}
 
     def has_pending(self) -> bool:
         return bool(self._pending)
@@ -79,22 +104,25 @@ class ApprovalManager:
         config: ApprovalConfig,
     ) -> ApprovalOutcome:
         """Emit an approval request and wait for the decision."""
-        # Supersede an older pending request for the same function — its
-        # awaiting request() coroutine wakes up and handles its own
-        # cleanup + resolved emit.
-        prior_id = self._by_function.get(function_name)
+        # Supersede an older pending request that is an IDENTICAL re-call
+        # (same function, same args) — its awaiting request() coroutine wakes
+        # up and handles its own cleanup + resolved emit. Distinct parallel
+        # calls to the same function (different args) get different dedupe
+        # keys, so neither supersedes the other.
+        dedupe_key = _dedupe_key(function_name, arguments)
+        prior_id = self._by_request.get(dedupe_key)
         if prior_id is not None:
             prior = self._pending.get(prior_id)
             if prior is not None and not prior[0].done():
                 logger.info(
                     f"[approval] Superseding pending approval {prior_id} "
-                    f"for '{function_name}' with a newer request"
+                    f"for '{function_name}' with an identical newer request"
                 )
                 prior[0].set_result(
                     (
                         False,
                         WIRE_STATUS_SUPERSEDED,
-                        "superseded by a newer request for the same function",
+                        "superseded by an identical newer request",
                     )
                 )
 
@@ -117,7 +145,7 @@ class ApprovalManager:
         }
         fut: "asyncio.Future[_Resolution]" = asyncio.get_running_loop().create_future()
         self._pending[approval_id] = (fut, payload)
-        self._by_function[function_name] = approval_id
+        self._by_request[dedupe_key] = approval_id
 
         outcome: Optional[ApprovalOutcome] = None
         try:
@@ -151,8 +179,8 @@ class ApprovalManager:
         finally:
             # Single cleanup + emission point for every exit path.
             self._pending.pop(approval_id, None)
-            if self._by_function.get(function_name) == approval_id:
-                self._by_function.pop(function_name, None)
+            if self._by_request.get(dedupe_key) == approval_id:
+                self._by_request.pop(dedupe_key, None)
             if outcome is not None:
                 logger.info(
                     f"[approval] Resolved '{function_name}' "

--- a/app/ai/voice/agents/breeze_buddy/chat/agent.py
+++ b/app/ai/voice/agents/breeze_buddy/chat/agent.py
@@ -79,6 +79,43 @@ from app.schemas.breeze_buddy.chat import ChatMessageRole, ToolApproval
 _MAX_TOOL_CYCLES = 20
 
 
+def _partition_gated_calls(
+    tool_calls: List[Any],
+    approval_map: Dict[str, Any],
+    node: Dict[str, Any],
+) -> Tuple[List[Any], List[Any]]:
+    """Split a tool-call batch into (gated, ungated) for HITL.
+
+    A gated name shadowed by a per-node function in the CURRENT node is
+    treated as UNGATED: in that node the LLM calls the per-node function
+    (which the author did not gate), not the gated global of the same name.
+    Non-shadow nodes are unaffected — a gated global is still gated. This
+    keeps chat consistent with voice, whose wrapper gates only globals.
+    """
+    # ``node["functions"]`` holds FlowsFunctionSchema objects in flow mode
+    # (FlowConfigBuilder._build_node runs every per-node function through
+    # _build_function_schema) — NOT plain dicts. Match the idiom used by
+    # _dispatch_tool_call / _tools_schema below: filter on FlowsFunctionSchema
+    # and read ``.name``. The builder renames function_name→name before the
+    # schema exists, so there is no alias to fall back to here.
+    node_fn_names = {
+        fn.name
+        for fn in (node.get("functions") or [])
+        if isinstance(fn, FlowsFunctionSchema)
+    }
+    gated = [
+        c
+        for c in tool_calls
+        if c.function_name in approval_map and c.function_name not in node_fn_names
+    ]
+    ungated = [
+        c
+        for c in tool_calls
+        if c.function_name not in approval_map or c.function_name in node_fn_names
+    ]
+    return gated, ungated
+
+
 @dataclass
 class _PreparedTools:
     """Per-turn tool surface shared by ``run_turn`` and ``run_approval_turn``."""
@@ -508,13 +545,12 @@ class ChatAgent:
 
             # HITL partition: approval-gated calls do NOT execute now — the
             # turn ends after the ungated siblings finish, and each gated
-            # call waits for its decision on the approval endpoint.
-            gated_calls = [
-                c for c in tool_calls if c.function_name in self._approval_map
-            ]
-            ungated_calls = [
-                c for c in tool_calls if c.function_name not in self._approval_map
-            ]
+            # call waits for its decision on the approval endpoint. Node-aware
+            # (see _partition_gated_calls): a per-node function shadows a
+            # same-named gated global, so it stays UNGATED — matching voice.
+            gated_calls, ungated_calls = _partition_gated_calls(
+                tool_calls, self._approval_map, node
+            )
 
             next_node: Optional[Dict[str, Any]] = None
             tool_result_pairs: List[Tuple[str, Any]] = []

--- a/app/ai/voice/agents/breeze_buddy/template/approval.py
+++ b/app/ai/voice/agents/breeze_buddy/template/approval.py
@@ -228,9 +228,11 @@ def build_approval_map(flow: Any) -> Dict[str, ApprovalConfig]:
         if gated_name in node_function_names:
             logger.warning(
                 f"[approval] Gated global '{gated_name}' is shadowed by a "
-                "per-node function of the same name: chat will gate the "
-                "shadowing per-node function (name-keyed), voice will not "
-                "(wrapper gate only wraps globals)."
+                "per-node function of the same name. In nodes that define it, "
+                "the per-node function runs UNGATED on BOTH chat and voice "
+                "(per-node functions are not gateable in v1); the gate applies "
+                "only in nodes where the global is reachable. Rename one to "
+                "remove the ambiguity."
             )
 
     return approval_map

--- a/tests/test_approval_manager.py
+++ b/tests/test_approval_manager.py
@@ -73,13 +73,15 @@ async def test_manager_timeout_then_late_resolve_is_stale():
     assert not manager.has_pending()
 
 
-async def test_manager_supersede_on_duplicate_function():
+async def test_manager_supersede_on_identical_recall():
+    """An identical re-call (same function AND same args) supersedes the
+    stale pending request."""
     emit = _EmitRecorder()
     manager = ApprovalManager(emit=emit)
     cfg = ApprovalConfig(timeout_secs=5)
     first = asyncio.create_task(manager.request("fn", {"v": 1}, cfg))
     await asyncio.sleep(0.01)
-    second = asyncio.create_task(manager.request("fn", {"v": 2}, cfg))
+    second = asyncio.create_task(manager.request("fn", {"v": 1}, cfg))
     await asyncio.sleep(0.01)
 
     first_outcome = await first
@@ -91,6 +93,35 @@ async def test_manager_supersede_on_duplicate_function():
     manager.resolve(second_id, True)
     second_outcome = await second
     assert second_outcome.approved is True
+    assert not manager.has_pending()
+
+
+async def test_manager_no_supersede_on_distinct_parallel_args():
+    """Two distinct parallel calls to the same function (DIFFERENT args, e.g.
+    two add_to_cart) each keep their own pending card — neither supersedes the
+    other (the parallel-drop bug fix)."""
+    emit = _EmitRecorder()
+    manager = ApprovalManager(emit=emit)
+    cfg = ApprovalConfig(timeout_secs=5)
+    first = asyncio.create_task(manager.request("add_to_cart", {"item": "A"}, cfg))
+    await asyncio.sleep(0.01)
+    second = asyncio.create_task(manager.request("add_to_cart", {"item": "B"}, cfg))
+    await asyncio.sleep(0.01)
+
+    # Both pending — no supersede, and nothing resolved yet.
+    assert manager.has_pending()
+    req_events = [e for e in emit.events if e[0] == RTVI_APPROVAL_REQUEST]
+    assert len(req_events) == 2
+    assert [e for e in emit.events if e[0] == RTVI_APPROVAL_RESOLVED] == []
+
+    # Each resolves independently to its own decision.
+    ids = [e[1]["approval_id"] for e in req_events]
+    manager.resolve(ids[0], True)
+    manager.resolve(ids[1], False)
+    o1 = await first
+    o2 = await second
+    assert o1.approved is True
+    assert o2.approved is False
     assert not manager.has_pending()
 
 

--- a/tests/test_chat_gate_partition.py
+++ b/tests/test_chat_gate_partition.py
@@ -1,0 +1,77 @@
+"""Chat HITL partition — node-aware gating (_partition_gated_calls).
+
+A gated *global* function shadowed by a same-named *per-node* function must
+NOT be gated in the node that defines the per-node one (the LLM calls the
+per-node function there, which the author did not gate) — matching voice,
+whose wrapper gates only globals. In nodes that don't shadow it, the gated
+global is still gated.
+
+The node's ``functions`` at runtime are ``FlowsFunctionSchema`` objects (the
+builder runs every per-node function through ``_build_function_schema``), NOT
+plain dicts — so these fixtures construct real schemas. Feeding plain dicts
+here would exercise a shape that never reaches the partition in production.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from pipecat_flows import FlowsFunctionSchema
+
+from app.ai.voice.agents.breeze_buddy.chat.agent import _partition_gated_calls
+
+
+def _call(name: str) -> SimpleNamespace:
+    return SimpleNamespace(function_name=name)
+
+
+def _schema(name: str) -> FlowsFunctionSchema:
+    """A per-node function as it actually appears in a built node."""
+    return FlowsFunctionSchema(name=name, description="", properties={}, required=[])
+
+
+def test_partition_gates_global_in_non_shadow_node():
+    calls = [_call("issue_refund"), _call("search")]
+    approval_map = {"issue_refund": object()}
+    node = {"functions": [_schema("search")]}  # no per-node issue_refund
+    gated, ungated = _partition_gated_calls(calls, approval_map, node)
+    assert [c.function_name for c in gated] == ["issue_refund"]
+    assert [c.function_name for c in ungated] == ["search"]
+
+
+def test_partition_skips_gated_name_shadowed_by_per_node_function():
+    calls = [_call("issue_refund")]
+    approval_map = {"issue_refund": object()}
+    node = {"functions": [_schema("issue_refund")]}  # per-node shadows it
+    gated, ungated = _partition_gated_calls(calls, approval_map, node)
+    assert gated == []  # not gated — the per-node fn runs (matches voice)
+    assert [c.function_name for c in ungated] == ["issue_refund"]
+
+
+def test_partition_ignores_non_schema_node_entries():
+    # Only FlowsFunctionSchema entries can shadow (that is all
+    # _dispatch_tool_call dispatches per-node). A stray non-schema entry —
+    # e.g. a raw dict that slipped through — must NOT register as a per-node
+    # function, so a gated global of that name is still gated.
+    calls = [_call("issue_refund")]
+    approval_map = {"issue_refund": object()}
+    node = {"functions": [{"name": "issue_refund"}]}  # plain dict, not a schema
+    gated, ungated = _partition_gated_calls(calls, approval_map, node)
+    assert [c.function_name for c in gated] == ["issue_refund"]
+    assert ungated == []
+
+
+def test_partition_empty_or_missing_node_functions_gates_normally():
+    calls = [_call("X")]
+    approval_map = {"X": object()}
+    for node in ({}, {"functions": []}, {"functions": None}):
+        gated, ungated = _partition_gated_calls(calls, approval_map, node)
+        assert [c.function_name for c in gated] == ["X"]
+        assert ungated == []
+
+
+def test_partition_ungated_call_unaffected():
+    calls = [_call("search")]
+    gated, ungated = _partition_gated_calls(calls, {"issue_refund": object()}, {})
+    assert gated == []
+    assert [c.function_name for c in ungated] == ["search"]


### PR DESCRIPTION
## What

The two behavior-changing slices of the HITL "one policy, two transports" unification — both chat↔voice divergences resolved for **correctness + consistency, with no new machinery**. (The additive deny-on-terminal slice ships separately as the chat terminal-sweep PR.)

### 1. When-to-gate — shadow-gating
The `approval` config lives on a **global** function. In a node that defines a same-named **per-node** function, the LLM calls the *per-node* one (it shadows the global) — which the author never gated. Chat gated it anyway by flat name; voice didn't (its wrapper gates only globals). **A documented divergence.**

Fix: chat's partition is now **node-aware** (`_partition_gated_calls`) — a name that resolves to a per-node function in the current node stays **ungated**, matching voice. The gated global is still gated in every node that *doesn't* shadow it, so **non-shadow nodes are byte-for-byte unchanged**. `build_approval_map`'s warning now describes the consistent behavior.

### 2. Supersede keying
Voice's `ApprovalManager` keyed supersede by `function_name`, so two **distinct** parallel calls to the same function (e.g. `add_to_cart(A)` + `add_to_cart(B)`) had the second **silently drop** the first.

Fix: key supersede by **`function_name` + an args fingerprint**. A true re-call (same fn, *same* args) still supersedes — so an async re-call can't double-execute a refund — but distinct parallel calls each keep their own card. (This is the safe middle between "keep function-name keying" = drops distinct calls, and "remove supersede" = allows double-execution.)

## Why these choices

The HITL policy is already half-unified (`gate_call` + the status vocabulary are shared). For each forked decision I picked the option that's **correct, fail-safe, and lowest-complexity**:
- Shadow: don't gate what the author didn't mark, and stay consistent across channels — *without* node-awareness in voice (out of scope) or un-gating a real global.
- Supersede: the args fingerprint distinguishes a re-call from distinct parallel calls — the only signal that actually separates them — so neither failure mode (drop vs double-execute) occurs.

## Verification
- `tests/test_chat_gate_partition.py` — shadow / non-shadow / `function_name` alias / empty node / ungated.
- `tests/test_approval_manager.py` — updated: identical re-call supersedes; **distinct parallel args do NOT** (the dropped-call fix).
- pyrefly 0 errors; full suite **447 passed**; field_reference coverage green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Approval manager now correctly identifies duplicate requests by matching both function name and arguments, ensuring only truly identical re-calls are superseded.
  * Fixed gating behavior when per-node functions shadow global functions with the same name.
  * Updated shadowing warnings to accurately reflect gating scope across chat and voice interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->