### PR TITLE
fix(hitl): bundle four minor HITL approval follow-ups

### DIFF
--- a/app/ai/voice/agents/breeze_buddy/agent/approval.py
+++ b/app/ai/voice/agents/breeze_buddy/agent/approval.py
@@ -8,9 +8,18 @@ Lifecycle invariants (these are load-bearing — see plan review):
 - ``asyncio.wait_for`` CANCELS the inner future on timeout, so a late
   ``resolve()`` must done-guard (no InvalidStateError) and report stale.
 - Every exit path (approve / deny / timeout / CancelledError / deny_all /
-  supersede) pops the map entry exactly once and emits exactly one
-  ``function-approval-resolved`` event, both owned by ``request()``'s
-  try/finally so there is a single emission point.
+  supersede) pops the map entry exactly once and emits AT MOST ONE
+  ``function-approval-resolved`` event — never two. (At-most-one, not
+  exactly-one: RTVI emits are best-effort everywhere in this manager, so a
+  failed emit is logged and swallowed, leaving zero events for that id; the
+  client also learns of resolution from the next request / a deny_all.) The
+  pop and (for all paths except supersede) the emit are owned by
+  ``request()``'s try/finally. The one exception: a superseded request's
+  resolved event is emitted eagerly by the *superseding* ``request()`` —
+  before its own ``function-approval-request``, so the client sees
+  resolved-then-request — and the superseded coroutine's finally skips its
+  emit (so the two never both emit; if the eager emit fails it is swallowed
+  like any other).
 - On CancelledError (user barge-in cancels sync gated handlers with ~1s
   grace; pipeline teardown) the map pop is synchronous and the emit is a
   cheap frame-queue put, so cleanup fits the grace window; the error is
@@ -125,6 +134,22 @@ class ApprovalManager:
                         "superseded by an identical newer request",
                     )
                 )
+                # Emit the superseded resolution NOW, before this newer
+                # request's function-approval-request below, so the client
+                # sees resolved-then-request order (the old card is dismissed
+                # before its replacement appears). The superseded coroutine's
+                # finally detects its SUPERSEDED status and skips its own emit,
+                # so the resolved event still fires exactly once per id.
+                try:
+                    await self._emit(
+                        RTVI_APPROVAL_RESOLVED,
+                        {"approval_id": prior_id, "status": WIRE_STATUS_SUPERSEDED},
+                    )
+                except Exception as e:
+                    logger.warning(
+                        f"[approval] Failed to emit supersede resolution for "
+                        f"{prior_id}: {e}"
+                    )
 
         wait_secs = config.timeout_secs
         if wait_secs > _MAX_WAIT_SECS:
@@ -187,16 +212,22 @@ class ApprovalManager:
                     f"(approval_id={approval_id}) -> {outcome.status}"
                     + (f" ({outcome.reason})" if outcome.reason else "")
                 )
-                try:
-                    await self._emit(
-                        RTVI_APPROVAL_RESOLVED,
-                        {"approval_id": approval_id, "status": outcome.status},
-                    )
-                except Exception as e:
-                    logger.warning(
-                        f"[approval] Failed to emit resolution for "
-                        f"{approval_id}: {e}"
-                    )
+                # A superseded request's resolved event was already emitted
+                # eagerly by the superseding request() (resolved-before-request
+                # ordering); skip it here to preserve exactly-one emission per
+                # approval_id. Supersede is the only path that yields this
+                # status, so the guard never suppresses a real resolution.
+                if outcome.status != WIRE_STATUS_SUPERSEDED:
+                    try:
+                        await self._emit(
+                            RTVI_APPROVAL_RESOLVED,
+                            {"approval_id": approval_id, "status": outcome.status},
+                        )
+                    except Exception as e:
+                        logger.warning(
+                            f"[approval] Failed to emit resolution for "
+                            f"{approval_id}: {e}"
+                        )
 
     def resolve(
         self, approval_id: str, approved: bool, reason: Optional[str] = None

--- a/app/ai/voice/agents/breeze_buddy/chat/agent.py
+++ b/app/ai/voice/agents/breeze_buddy/chat/agent.py
@@ -972,6 +972,13 @@ class ChatAgent:
         if pending_sibling_ids:
             # Other gated calls from the same batch still await decisions;
             # invoking the LLM now would replay dangling tool_use blocks.
+            # ``assistant_idx`` is intentionally None: this branch returns
+            # BEFORE _cycle_loop, so no LLM inference ran this turn and there
+            # is no metrics row to key (_persist_turn_metrics early-returns on
+            # None). The SDK settles each card off function_approval_resolved /
+            # function_call_completed (both carry tool_call_id), so it needs no
+            # assistant anchor here; emitting a prior turn's gate-row idx would
+            # mis-attribute metrics to a row this turn never wrote.
             yield SSEEvent(
                 event="turn_end",
                 data={

--- a/app/ai/voice/agents/breeze_buddy/handlers/transport/utils/response_transform.py
+++ b/app/ai/voice/agents/breeze_buddy/handlers/transport/utils/response_transform.py
@@ -290,9 +290,14 @@ def omit_fields(value: Any, args: Dict[str, Any]) -> Any:
 
 _HTML_TAG_RE = re.compile(r"<[^>]+>")
 _WHITESPACE_RE = re.compile(r"\s+")
-# A stripped tag becomes a space, so ``word</b>.`` collapses to ``word .`` —
-# drop the space a removed tag leaves immediately before closing punctuation.
-_SPACE_BEFORE_PUNCT_RE = re.compile(r"\s+([.,;:!?)\]])")
+# A stripped tag becomes a space, so ``word</b>.`` would collapse to ``word .``.
+# Drop the run of tags (and the whitespace between/after them) that sits
+# immediately before closing punctuation, keeping only the punctuation — this
+# also handles nested closes like ``<em>x</em></strong>.`` -> ``x.``. Anchored
+# to the tag site on purpose: a global "space before punctuation" pass also
+# corrupts tag-free text — decimals ("3 . 14" -> "3. 14"), spaced parens
+# ("( a )" -> "( a)"), initials ("Mr . Smith").
+_TAG_BEFORE_PUNCT_RE = re.compile(r"(?:<[^>]+>\s*)+([.,;:!?)\]])")
 
 
 @register_transform("strip_html")
@@ -316,9 +321,11 @@ def strip_html(value: Any, args: Dict[str, Any]) -> Any:
     """
     if not isinstance(value, str):
         return value
-    plain = _HTML_TAG_RE.sub(" ", value)
+    # Drop tags sitting directly before closing punctuation first (no injected
+    # space), then turn the remaining tags into spaces and collapse runs.
+    plain = _TAG_BEFORE_PUNCT_RE.sub(r"\1", value)
+    plain = _HTML_TAG_RE.sub(" ", plain)
     plain = _WHITESPACE_RE.sub(" ", plain).strip()
-    plain = _SPACE_BEFORE_PUNCT_RE.sub(r"\1", plain)
     max_chars = args.get("max_chars")
     if isinstance(max_chars, int) and max_chars > 0 and len(plain) > max_chars:
         clipped = plain[:max_chars]

--- a/app/ai/voice/agents/breeze_buddy/template/approval.py
+++ b/app/ai/voice/agents/breeze_buddy/template/approval.py
@@ -27,6 +27,7 @@ from app.ai.voice.agents.breeze_buddy.template.types import (
     ApprovalConfig,
     ApprovalOnNoChannel,
     BaseGlobalFunction,
+    GlobalFunctionType,
 )
 from app.core.logger import logger
 
@@ -44,7 +45,10 @@ WIRE_STATUS_TIMEOUT = "timeout"
 WIRE_STATUS_CANCELLED = "cancelled"
 WIRE_STATUS_SUPERSEDED = "superseded"
 
-_GLOBAL_FUNCTION_TYPES = {"http", "builtin", "custom"}
+# Derived from the enum (mirrors builder.py:_GLOBAL_FUNCTION_TYPES) so a new
+# GlobalFunctionType is gated by chat and voice in lockstep — a hardcoded set
+# here would silently skip a 4th type that the builder/voice path still gates.
+_GLOBAL_FUNCTION_TYPES = {t.value for t in GlobalFunctionType}
 
 
 @dataclass

--- a/tests/test_approval_manager.py
+++ b/tests/test_approval_manager.py
@@ -96,6 +96,45 @@ async def test_manager_supersede_on_identical_recall():
     assert not manager.has_pending()
 
 
+async def test_manager_supersede_emits_resolved_before_new_request():
+    """On supersede the wire order is request(old) -> resolved(old) ->
+    request(new): the old card is dismissed before its replacement appears,
+    and the superseded id resolves exactly once."""
+    emit = _EmitRecorder()
+    manager = ApprovalManager(emit=emit)
+    cfg = ApprovalConfig(timeout_secs=5)
+    first = asyncio.create_task(manager.request("fn", {"v": 1}, cfg))
+    await asyncio.sleep(0.01)
+    second = asyncio.create_task(manager.request("fn", {"v": 1}, cfg))
+    await asyncio.sleep(0.01)
+
+    first_outcome = await first
+    assert first_outcome.status == "superseded"
+
+    # request(old), resolved(old, superseded), request(new) — in that order.
+    assert [e[0] for e in emit.events] == [
+        RTVI_APPROVAL_REQUEST,
+        RTVI_APPROVAL_RESOLVED,
+        RTVI_APPROVAL_REQUEST,
+    ]
+    first_id = emit.events[0][1]["approval_id"]
+    assert emit.events[1][1] == {"approval_id": first_id, "status": "superseded"}
+
+    second_id = emit.events[2][1]["approval_id"]
+    assert second_id != first_id
+    manager.resolve(second_id, True)
+    assert (await second).approved is True
+
+    # The superseded id never resolves twice (eager emit + finally-skip).
+    resolved_first = [
+        e
+        for e in emit.events
+        if e[0] == RTVI_APPROVAL_RESOLVED and e[1]["approval_id"] == first_id
+    ]
+    assert len(resolved_first) == 1
+    assert not manager.has_pending()
+
+
 async def test_manager_no_supersede_on_distinct_parallel_args():
     """Two distinct parallel calls to the same function (DIFFERENT args, e.g.
     two add_to_cart) each keep their own pending card — neither supersedes the

--- a/tests/test_approval_map.py
+++ b/tests/test_approval_map.py
@@ -113,3 +113,36 @@ def test_non_dict_flow_is_safe():
     assert build_approval_map(None) == {}
     assert build_approval_map([]) == {}
     assert build_approval_map({}) == {}
+
+
+def test_global_function_types_match_enum():
+    # The gated-type set must stay derived from GlobalFunctionType so chat
+    # (build_approval_map) and voice/builder gate the same set. A hardcoded
+    # literal would silently skip any newly added type on the chat side.
+    from app.ai.voice.agents.breeze_buddy.template.approval import (
+        _GLOBAL_FUNCTION_TYPES,
+    )
+    from app.ai.voice.agents.breeze_buddy.template.types import GlobalFunctionType
+
+    assert _GLOBAL_FUNCTION_TYPES == {t.value for t in GlobalFunctionType}
+
+
+def test_every_global_function_type_is_gateable():
+    # Every enum-listed type, when carrying an approval config in flow mode,
+    # is mapped — guards against a future type being added to the enum but not
+    # gated by chat.
+    from app.ai.voice.agents.breeze_buddy.template.types import GlobalFunctionType
+
+    flow = {
+        "global_functions": [
+            {
+                "type": t.value,
+                "name": f"fn_{t.value}",
+                "description": "d",
+                "approval": {},
+            }
+            for t in GlobalFunctionType
+        ]
+    }
+    amap = build_approval_map(flow)
+    assert set(amap) == {f"fn_{t.value}" for t in GlobalFunctionType}

--- a/tests/test_response_transform.py
+++ b/tests/test_response_transform.py
@@ -373,6 +373,30 @@ def test_strip_html_non_string_passes_through():
     assert strip_html(42, {}) == 42
 
 
+def test_strip_html_drops_tag_directly_before_punctuation():
+    # A tag sitting immediately before closing punctuation must NOT leave a
+    # space where it was (this is what the tag-site anchoring buys us).
+    assert strip_html("<p>The bottle is <b>insulated</b>.</p>", {}) == (
+        "The bottle is insulated."
+    )
+    assert strip_html("<p>done</p>.", {}) == "done."
+    assert strip_html("Buy now<b>!</b>", {}) == "Buy now!"
+    # Nested closes immediately before punctuation collapse cleanly too.
+    assert strip_html("<p>It is <strong><em>great</em></strong>.</p>", {}) == (
+        "It is great."
+    )
+
+
+def test_strip_html_preserves_spaces_around_punctuation_in_tag_free_text():
+    # The old global "space before punctuation" pass corrupted tag-free text;
+    # anchoring to tag sites leaves these untouched.
+    assert strip_html("3 . 14", {}) == "3 . 14"
+    assert strip_html("( a )", {}) == "( a )"
+    assert strip_html("Mr . Smith", {}) == "Mr . Smith"
+    assert strip_html("Wait ! Really ?", {}) == "Wait ! Really ?"
+    assert strip_html("emoticon :) test", {}) == "emoticon :) test"
+
+
 def test_strip_html_via_walker_on_nested_path():
     data = {
         "products": [


### PR DESCRIPTION
Bundles the four actionable minor findings from `docs/HITL_REVIEW_FINDINGS.md` into one PR. All are on already-merged `release` code; **none block rollout**. Full suite **465 passed**, pyrefly **0 errors**.

### 1. `strip_html` over-broad space-before-punctuation pass → tag-site anchored
The post-merge wiring review (and #826's bundled fix) introduced `_SPACE_BEFORE_PUNCT_RE` applied globally, which corrupted **tag-free** text:
- `"3 . 14"` → `"3. 14"` (decimal)
- `"( a )"` → `"( a)"` (asymmetric)
- `"Mr . Smith"` → `"Mr. Smith"`

Replaced with `_TAG_BEFORE_PUNCT_RE = (?:<[^>]+>\s*)+([.,;:!?)\]])` — drops only a *run of tags* (plus inter-tag whitespace) sitting immediately before closing punctuation, so `<em>x</em></strong>.` → `x.` while tag-free text is left alone. (Findings item 1.)

### 2. Voice supersede emits resolved **before** the new request
`ApprovalManager` superseded a pending approval but emitted the new `function-approval-request` *before* the old `function-approval-resolved`. Now the superseded resolution is emitted eagerly (before the new request), and the superseded coroutine's `finally` skips its own emit so the two never both fire. Docstring invariant corrected to **at-most-one** (RTVI emits are best-effort manager-wide). (Findings item 2.)

### 3. `_GLOBAL_FUNCTION_TYPES` derived from the enum
`template/approval.py` hardcoded `{"http","builtin","custom"}`; now `{t.value for t in GlobalFunctionType}`, mirroring `builder.py`. A future 4th type is then gated by chat and voice in lockstep instead of silently skipped on the chat side. (Findings item 3.)

### 4. Document the intentional `assistant_idx=None`
On the sibling-pending approval-resume branch, `turn_end` carries `assistant_idx=None`. Added a comment: that branch returns **before** `_cycle_loop`, so no LLM inference ran and there is no metrics row to key (`_persist_turn_metrics` early-returns on `None`); the SDK settles cards off `function_approval_resolved`/`function_call_completed` (both carry `tool_call_id`). Emitting a prior turn's gate-row idx would mis-attribute metrics. Comment-only. (Findings item 4.)

### Tests
- `test_response_transform.py`: tag-free preservation, tag-before-punct (incl. nested closes).
- `test_approval_manager.py`: supersede emit-order + exactly-once.
- `test_approval_map.py`: enum drift-guard + per-type gating.

### Verification
Implemented fixes were adversarially reviewed by a 3-agent workflow (regex corruption/ReDoS, async emit-ordering interleavings, enum/idx claims): items 1/3/4 clean; item 2's only finding was the best-effort emit-failure window (pre-existing for all paths), addressed by the docstring correction above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)