### PR TITLE
feat(voice): widget voice-as-chat — stream mode through the chat brain

### DIFF
--- a/app/ai/voice/agents/breeze_buddy/agent/__init__.py
+++ b/app/ai/voice/agents/breeze_buddy/agent/__init__.py
@@ -31,7 +31,6 @@ from app.ai.voice.agents.breeze_buddy.agent.flow import (
     build_flow_config,
     load_template_config,
     prepare_initial_node,
-    prepare_resume_node,
     setup_flow_manager,
 )
 from app.ai.voice.agents.breeze_buddy.agent.inbound import (
@@ -59,6 +58,7 @@ from app.ai.voice.agents.breeze_buddy.agent.utils import (
     send_initial_greeting,
     send_initial_greeting_daily,
 )
+from app.ai.voice.agents.breeze_buddy.chat.voice_bridge import WidgetVoiceBridge
 from app.ai.voice.agents.breeze_buddy.handlers.internal.end_conversation import (
     end_conversation,
 )
@@ -70,6 +70,9 @@ from app.ai.voice.agents.breeze_buddy.observability.tracing_setup import (
     create_root_span,
 )
 from app.ai.voice.agents.breeze_buddy.processors import TranscriptCollectorProcessor
+from app.ai.voice.agents.breeze_buddy.processors.voice_ui_stream import (
+    coerce_ui_action_text,
+)
 from app.ai.voice.agents.breeze_buddy.services.inbound_policy import (
     get_block_redirect,
 )
@@ -113,6 +116,9 @@ from app.schemas.breeze_buddy.core import ExecutionMode, LeadCallTracker
 
 DEFAULT_OUTCOME = "BUSY"
 TTS_SPEAK_MAX_CHARS = 2000
+# Cap on a carousel/product-click `ui-action` message injected as a user turn
+# (mirrors TTS_SPEAK_MAX_CHARS). See docs/widget/VOICE_AS_CHAT.md (A2).
+UI_ACTION_MAX_CHARS = 2000
 
 
 class Agent:
@@ -182,18 +188,19 @@ class Agent:
         # Error tracking
         self.errors: List[Dict[str, Any]] = []
 
-        # Widget-mode resume seed (CHAT_MODE.md §14). Populated from
-        # lead.metaData in _setup_*_transport when this voice call is a
-        # transient attachment to an in-progress chat_session. When set,
-        # the agent skips greeting playback and starts the FlowManager
-        # at start_node with prior_history pre-loaded into LLM context.
-        self._widget_resume_seed: Optional[Dict[str, Any]] = None
+        # Widget voice-as-chat bridge (stream mode + a bound chat_session).
+        # Constructed in _register_event_handlers once self.task exists; drives
+        # every finished user turn through the chat brain (run_chat_turn) and
+        # speaks the assistant prose via TTS. None for telephony / non-widget
+        # stream / agent-mode calls. See chat/voice_bridge.py + the
+        # widget-voice-as-chat re-architecture plan.
+        self._voice_bridge: Optional[WidgetVoiceBridge] = None
 
         # Reducer-built session state (cart_id/checkout_id/client facts),
-        # the voice counterpart of ChatAgent.agent_state. Seeded from a
-        # widget-resume (below), accumulated via state_reducers during the
-        # call by the global-function wrapper, and drained back to the
-        # chat_session on end_conversation. Empty {} for fresh/telephony calls.
+        # the voice counterpart of ChatAgent.agent_state. Accumulated via
+        # state_reducers during an AGENT-mode call by the global-function
+        # wrapper. Empty {} for stream-mode widget voice (the chat brain owns
+        # state there) and for telephony calls with no reducers.
         self.agent_state: Dict[str, Any] = {}
 
         # HITL approval channel — daily mode only, set alongside
@@ -326,35 +333,6 @@ class Agent:
         )
         update_log_context(call_sid=self.call_sid)
 
-        # Widget-mode resume seed: see CHAT_MODE.md §14. When this voice
-        # call is a transient attachment to an in-progress chat_session,
-        # the unified widget router stuffs the seed into lead.metaData.
-        # We capture it here so the greeting / initial-node code paths
-        # below can branch on it cleanly.
-        meta = self.lead.metaData or {}
-        widget_session_id = meta.get("widget_session_id")
-        if widget_session_id:
-            self._widget_resume_seed = {
-                "widget_session_id": str(widget_session_id),
-                "start_node": meta.get("start_node"),
-                "prior_history": list(meta.get("prior_history") or []),
-                "seed_message_count": int(meta.get("seed_message_count", 0) or 0),
-                # Reducer-built chat state (cart_id/checkout_id/...) carried
-                # across the CHAT->VOICE flip; merged into template_vars below.
-                "agent_state": dict(meta.get("agent_state") or {}),
-            }
-            # Seed the live agent_state from the chat session so voice tool
-            # calls inject/update it (tool_arg_injection + state_reducers via
-            # the global-function wrapper) and the final state drains back on
-            # end_conversation.
-            self.agent_state = dict(self._widget_resume_seed["agent_state"])
-            logger.info(
-                f"Widget voice resume: chat_session={widget_session_id} "
-                f"start_node={self._widget_resume_seed['start_node']!r} "
-                f"prior_msgs={len(self._widget_resume_seed['prior_history'])} "
-                f"agent_state_keys={sorted(self.agent_state)}"
-            )
-
         logger.info(
             f"Starting Daily bot for lead_id: {lead_id}, call_sid: {self.call_sid}"
         )
@@ -376,22 +354,6 @@ class Agent:
         except ValueError as e:
             logger.error(f"Failed to load template config for Daily mode: {e}")
             raise
-
-        # Widget resume: thread the chat session's accumulated agent_state
-        # (cart_id/checkout_id/client-pushed facts) into template_vars so
-        # {placeholder} resolution in the resumed voice flow uses the
-        # chat-built identifiers instead of losing them on the flip.
-        # only_if_missing — never clobber an explicitly-rendered call var.
-        if self._widget_resume_seed:
-            resumed_state = self._widget_resume_seed.get("agent_state") or {}
-            merged_keys = [k for k in resumed_state if k not in self.template_vars]
-            for k in merged_keys:
-                self.template_vars[k] = resumed_state[k]
-            if merged_keys:
-                logger.info(
-                    f"Widget voice resume: merged {len(merged_keys)} agent_state "
-                    f"var(s) into template_vars: {sorted(merged_keys)}"
-                )
 
         # Synthesize and cache the initial greeting in Redis so it can be
         # played out on client-connect. Idempotent: if the dispatch worker
@@ -842,12 +804,6 @@ class Agent:
                         logger.debug(f"[STREAM] TTS speak: {text[:80]}")
                         await self.task.queue_frame(TTSSpeakFrame(text=text))
                 elif message.type == RTVI_APPROVAL_DECISION:
-                    if not self.approval_manager:
-                        logger.warning(
-                            "[approval] Decision received but no approval "
-                            "manager on this bot"
-                        )
-                        return
                     data = message.data or {}
                     approval_id = data.get("approval_id")
                     approved = data.get("approved")
@@ -859,11 +815,45 @@ class Agent:
                             f"[approval] Malformed decision message: {data!r}"
                         )
                         return
-                    self.approval_manager.resolve(
-                        approval_id,
-                        approved,
-                        reason if isinstance(reason, str) else None,
-                    )
+                    reason_str = reason if isinstance(reason, str) else None
+                    if self._voice_bridge is not None:
+                        # Stream-mode widget voice: the chat brain gated the call
+                        # (Pattern B). Drive the resume turn through the bridge.
+                        await self._voice_bridge.handle_approval_decision(
+                            approval_id, approved, reason_str
+                        )
+                    elif self.approval_manager:
+                        # Agent-mode voice (Pattern C): resolve the in-handler gate.
+                        self.approval_manager.resolve(approval_id, approved, reason_str)
+                    else:
+                        logger.warning(
+                            "[approval] Decision received but no approval "
+                            "channel on this bot"
+                        )
+                elif message.type == "ui-action":
+                    # Widget voice-as-chat: a carousel/product click arrives as
+                    # a user turn. The backend emits no transcript echo (the
+                    # widget renders the bubble optimistically). See
+                    # docs/widget/VOICE_AS_CHAT.md (A2).
+                    text = coerce_ui_action_text(message.data, UI_ACTION_MAX_CHARS)
+                    if text is None:
+                        logger.warning(f"[ui-action] empty/malformed: {message.data!r}")
+                        return
+                    if self._voice_bridge is not None:
+                        # Stream mode: drive the click through the chat brain,
+                        # exactly like a spoken turn.
+                        logger.debug(f"[ui-action] bridge user turn: {text[:80]}")
+                        await self._voice_bridge.handle_user_turn(text)
+                    elif self.task:
+                        # Agent mode: inject into the live LLM context
+                        # (run_llm=True) — the same mid-call user-turn injection
+                        # user_idle.py uses; pipecat handles barge-in natively.
+                        logger.debug(f"[ui-action] inject user turn: {text[:80]}")
+                        await self.task.queue_frame(
+                            LLMMessagesAppendFrame(
+                                [{"role": "user", "content": text}], run_llm=True
+                            )
+                        )
 
         # Register user turn started event to reset idle retry counter
         if self._context_aggregator and self._user_idle_callback_handler:
@@ -881,12 +871,51 @@ class Agent:
                         logger.debug("Post-greeting timer cancelled - user spoke")
                 self._user_idle_callback_handler.reset_retry_count()
 
+        # Widget voice-as-chat bridge: stream mode + a bound chat_session.
+        # Drive every finished user turn through the chat brain (run_chat_turn)
+        # — the bridge speaks the assistant prose via TTS and emits RTVI
+        # transcript / ui-op / turn-end events. on_user_turn_started cancels an
+        # in-flight turn on barge-in (pipecat's broadcast_interruption already
+        # flushed queued TTS natively). No idle handler is wired in stream mode,
+        # so these registrations don't collide with the block above.
+        widget_session_id = (
+            (self.lead.metaData or {}).get("widget_session_id") if self.lead else None
+        )
+        if self.is_stream_mode and widget_session_id and self._context_aggregator:
+            self._voice_bridge = WidgetVoiceBridge(
+                session_id=str(widget_session_id),
+                task=self.task,
+                emit_rtvi=self._emit_rtvi_event,
+            )
+            bridge = self._voice_bridge
+            bridge_user_aggregator = self._context_aggregator.user()
+
+            @bridge_user_aggregator.event_handler("on_user_turn_stopped")
+            async def _bridge_user_turn_stopped(aggregator, strategy, message):
+                await bridge.handle_user_turn(getattr(message, "content", None))
+
+            @bridge_user_aggregator.event_handler("on_user_turn_started")
+            async def _bridge_user_turn_started(aggregator, strategy):
+                await bridge.cancel_inflight()
+
+            logger.info(
+                "[STREAM] Widget voice-as-chat bridge wired for chat_session "
+                f"{widget_session_id}"
+            )
+
     async def _handle_client_connected(self) -> None:
         """Handle client connection and initialize flow."""
         if self.is_stream_mode:
             if self.lead and self.lead.metaData is None:
                 self.lead.metaData = {}
             logger.info("[STREAM] Client connected — ready for STT/TTS")
+            # Widget voice-as-chat: on the FIRST attachment (no prior user
+            # turns) speak the persisted chat greeting via TTS. A reconnect
+            # mid-conversation does not re-greet. The bridge gates on the chat
+            # history and pushes audio only (no transcript echo — the widget
+            # already shows the greeting bubble from its session load).
+            if self._voice_bridge is not None:
+                await self._voice_bridge.maybe_speak_greeting()
             return
 
         if (
@@ -904,18 +933,9 @@ class Agent:
         # greeting_source/text here makes prepare_initial_node inject the
         # greeting into the LLM context as an assistant message and switch
         # respond_immediately=False — same downstream behavior as telephony.
-        # DAILY_STREAM also uses a Daily transport but is client-driven STT/
-        # TTS-only (no LLM, no template playback) — explicitly skip greeting
-        # injection there so we don't push audio into a passthrough pipeline.
-        # Widget-mode resume: skip the greeting too. Prior chat history is
-        # already in the seed; re-greeting would repeat what the user
-        # already saw and feels broken (CHAT_MODE.md §14).
-        if (
-            self.is_daily_mode
-            and not self.is_stream_mode
-            and not self._widget_resume_seed
-            and self.task
-        ):
+        # (Stream mode returned above — its greeting is spoken by the voice
+        # bridge, not injected into an LLM context.)
+        if self.is_daily_mode and not self.is_stream_mode and self.task:
             greeting_result = await send_initial_greeting_daily(
                 task=self.task,
                 lead=self.lead,
@@ -944,27 +964,13 @@ class Agent:
 
         lead_payload = self.lead.payload or {}
 
-        # Widget-mode resume: start at the chat's current_node with the
-        # chat's history pre-seeded. See prepare_resume_node for why
-        # the history goes inside task_messages (FlowManager always
-        # RESETs context on first node init — we have to put the seed
-        # inside the same frame to survive).
-        if self._widget_resume_seed:
-            initial_node_config = prepare_resume_node(
-                flow_config=self.flow_config,
-                lead_payload=lead_payload,
-                configurations=self.configurations,
-                start_node_name=self._widget_resume_seed.get("start_node"),
-                prior_history=self._widget_resume_seed.get("prior_history") or [],
-            )
-        else:
-            initial_node_config = prepare_initial_node(
-                flow_config=self.flow_config,
-                lead_payload=lead_payload,
-                configurations=self.configurations,
-                has_greeting_source=bool(self.greeting_source),
-                greeting_text=self.greeting_text,
-            )
+        initial_node_config = prepare_initial_node(
+            flow_config=self.flow_config,
+            lead_payload=lead_payload,
+            configurations=self.configurations,
+            has_greeting_source=bool(self.greeting_source),
+            greeting_text=self.greeting_text,
+        )
 
         # Initialize node traversal tracking
         if self.lead.metaData is None:
@@ -974,30 +980,12 @@ class Agent:
         # Record initial-node entry BEFORE flow_manager.initialize so that any
         # global function called during the first LLM turn (e.g. get_driver_info
         # on the initial node) finds an active node entry to record against.
-        # For widget resume we use the resume node name (which falls back to
-        # initial_node if start_node is missing — see prepare_resume_node).
-        if self._widget_resume_seed:
-            initial_node_name = (
-                self._widget_resume_seed.get("start_node")
-                or self.flow_config["initial_node"]
-            )
-            if initial_node_name not in self.flow_config["nodes"]:
-                initial_node_name = self.flow_config["initial_node"]
-        else:
-            initial_node_name = self.flow_config["initial_node"]
+        initial_node_name = self.flow_config["initial_node"]
         context = TemplateContext(self)
         context.record_node_entry(initial_node_name)
 
         await self.flow_manager.initialize(initial_node_config)
-        logger.info(
-            f"FlowManager initialized at node: {initial_node_name}"
-            + (
-                f" (widget resume from chat_session "
-                f"{self._widget_resume_seed['widget_session_id']})"
-                if self._widget_resume_seed
-                else ""
-            )
-        )
+        logger.info(f"FlowManager initialized at node: {initial_node_name}")
 
     async def _run_with_tracing(self, runner: PipelineRunner) -> None:
         """Run the pipeline with OpenTelemetry tracing."""
@@ -1136,24 +1124,31 @@ class Agent:
             update_log_context(conversation_id=self.conversation_id)
 
             self.task = await create_pipeline_task(
-                pipeline, self.conversation_id, is_daily_mode=self.is_daily_mode
+                pipeline,
+                self.conversation_id,
+                is_daily_mode=self.is_daily_mode,
             )
 
             if self.is_daily_mode and hasattr(self.task, "rtvi") and self.task.rtvi:
                 self._rtvi_processor = self.task.rtvi
-                # HITL approval channel rides the RTVI processor. Note: widget
-                # voice attachments run as daily AGENT mode (not stream), and
-                # RTVI requires ENABLE_BREEZE_BUDDY_DAILY_EVENTS=true — without
-                # it approval_manager stays None and gated calls are denied.
-                self.approval_manager = ApprovalManager(emit=self._emit_rtvi_event)
-                if self._user_idle_callback_handler:
-                    # While an approval card is showing, the user is silently
-                    # reading — idle prompts/end-call must not fire (idle
-                    # re-inference can also spawn duplicate gated calls).
-                    approval_manager = self.approval_manager
-                    self._user_idle_callback_handler.suppress_when = (
-                        approval_manager.has_pending
-                    )
+                # HITL approval channel (Pattern C — the in-handler gate that
+                # blocks a voice global-function on a live RTVI card). This is
+                # AGENT-mode only: stream-mode widget voice has no FlowManager /
+                # global-function wrapper to ever reach the gate, and it gates
+                # approvals through the chat brain instead (Pattern B). So only
+                # non-widget daily agent-mode calls get an ApprovalManager.
+                # RTVI requires ENABLE_BREEZE_BUDDY_DAILY_EVENTS=true; without it
+                # approval_manager stays None and gated calls are denied.
+                if not is_stream:
+                    self.approval_manager = ApprovalManager(emit=self._emit_rtvi_event)
+                    if self._user_idle_callback_handler:
+                        # While an approval card is showing, the user is silently
+                        # reading — idle prompts/end-call must not fire (idle
+                        # re-inference can also spawn duplicate gated calls).
+                        approval_manager = self.approval_manager
+                        self._user_idle_callback_handler.suppress_when = (
+                            approval_manager.has_pending
+                        )
 
             # Flow manager is agent-mode only (stream mode has no LLM to drive
             # node transitions or function calls).

--- a/app/ai/voice/agents/breeze_buddy/agent/flow.py
+++ b/app/ai/voice/agents/breeze_buddy/agent/flow.py
@@ -137,6 +137,9 @@ def build_flow_config(
     Returns:
         Tuple of (flow_config, end_conversation_callbacks, expected_callback_response_schema)
     """
+    # NOTE: generative voice UI (the ``{{ui_primitives_section}}`` prompt
+    # splice) is deferred — see docs/widget/VOICE_GENERATIVE_UI_TODO.md. The
+    # builder leaves the placeholder inert when no ui_allowlist is passed.
     flow_config = flow_builder.build_flow_config(template)
     end_conversation_callbacks = flow_config.get("end_conversation_callbacks", [])
     expected_callback_response_schema = flow_config.get(
@@ -200,96 +203,4 @@ def prepare_initial_node(
         pre_actions=node_config.get("pre_actions", []),
         post_actions=node_config.get("post_actions", []),
         respond_immediately=not has_greeting_source,
-    )
-
-
-def prepare_resume_node(
-    flow_config: Dict[str, Any],
-    lead_payload: dict,
-    configurations: Optional[ConfigurationModel],
-    *,
-    start_node_name: Optional[str],
-    prior_history: List[Dict[str, Any]],
-) -> NodeConfig:
-    """Prepare a NodeConfig that resumes an existing conversation.
-
-    Used by the unified widget mode (CHAT_MODE.md §14) when voice is
-    attached to an in-progress chat session: we want the bot to start
-    at ``start_node_name`` with the chat's full message history
-    already in the LLM context.
-
-    Why this works (verified against pipecat-flows source at
-    .venv/lib/.../pipecat_flows/manager.py:712-825):
-
-      FlowManager always queues an ``LLMMessagesUpdateFrame`` (RESET)
-      on the FIRST ``_set_node`` call, regardless of context_strategy
-      — the condition is ``self._current_node is None``. A naive
-      "pre-seed LLMContext, then call initialize(node)" would have
-      the aggregator REPLACE the seed with [role + task] of the node,
-      wiping our history.
-
-      The clean workaround stays inside the official API: we put
-      ``prior_history`` at the tail of ``task_messages``. The RESET
-      frame then sets context to
-      [role_messages, task_messages, ...prior_history] in one shot —
-      the order we want. Each prior_history entry already has its own
-      ``{role: "user"|"assistant", content: str}``; the LLM doesn't
-      require role-homogeneous task_messages.
-
-    ``start_node_name`` defaults to ``flow_config["initial_node"]``
-    when None — covers the case where chat hadn't transitioned past
-    the initial node yet.
-
-    No greeting injection: when resuming we never want the bot to
-    re-greet (the greeting is already in prior_history if the chat
-    had one). ``respond_immediately=True`` so the bot responds to
-    whatever the user says first instead of speaking an empty turn.
-    """
-    node_name = start_node_name or flow_config["initial_node"]
-    if node_name not in flow_config["nodes"]:
-        # Defensive fallback — chat may have persisted a current_node
-        # that doesn't exist in this template version. Falling back to
-        # initial keeps the bot functional; we log loudly so operators
-        # notice template drift.
-        logger.warning(
-            f"prepare_resume_node: start_node {node_name!r} not in flow; "
-            f"falling back to initial_node {flow_config['initial_node']!r}"
-        )
-        node_name = flow_config["initial_node"]
-
-    node_config = flow_config["nodes"][node_name]
-
-    role_messages = inject_language_rules(
-        node_config.get("role_messages", []),
-        lead_payload.get("language_name", "English"),
-        getattr(configurations, "payload_based_language_selection", False),
-    )
-
-    task_messages: List[Dict[str, Any]] = list(node_config["task_messages"])
-    # Tail-append prior history so the RESET frame's payload becomes
-    # [role + task + history] in a single context replacement. Filter
-    # out any malformed entries defensively.
-    for entry in prior_history or []:
-        if not isinstance(entry, dict):
-            continue
-        role = entry.get("role")
-        content = entry.get("content")
-        if role not in ("user", "assistant") or not content:
-            continue
-        task_messages.append({"role": role, "content": content})
-
-    logger.info(
-        f"prepare_resume_node: resuming at {node_name!r} with "
-        f"{len(prior_history or [])} prior messages"
-    )
-
-    return NodeConfig(
-        name=node_config["name"],
-        task_messages=task_messages,
-        role_messages=role_messages,
-        functions=node_config.get("functions", []),
-        pre_actions=node_config.get("pre_actions", []),
-        post_actions=node_config.get("post_actions", []),
-        # No greeting on resume — let the user speak first.
-        respond_immediately=True,
     )

--- a/app/ai/voice/agents/breeze_buddy/agent/pipeline.py
+++ b/app/ai/voice/agents/breeze_buddy/agent/pipeline.py
@@ -37,6 +37,7 @@ from pipecat.turns.user_start import (
 )
 from pipecat.turns.user_stop import (
     BaseUserTurnStopStrategy,
+    SpeechTimeoutUserTurnStopStrategy,
     TurnAnalyzerUserTurnStopStrategy,
 )
 from pipecat.turns.user_turn_strategies import UserTurnStrategies
@@ -49,9 +50,6 @@ from app.ai.voice.agents.breeze_buddy.processors import (
     UserIdleCallbackHandler,
 )
 from app.ai.voice.agents.breeze_buddy.stt import get_stt_service
-from app.ai.voice.agents.breeze_buddy.template.interruption import (
-    AccumulatingSpeechTimeoutStrategy,
-)
 from app.ai.voice.agents.breeze_buddy.template.types import (
     ConfigurationModel,
     InterruptionConfig,
@@ -213,9 +211,11 @@ async def build_pipeline(
     Uses the universal LLMContextAggregatorPair with UserTurnStrategies:
     - Start: VADUserTurnStartStrategy (primary, ~100ms) + TranscriptionUserTurnStartStrategy
       (fallback for soft speech VAD misses, uses interim transcriptions)
-    - Stop: AccumulatingSpeechTimeoutStrategy (user_speech_timeout=0.0) — triggers
+    - Stop: SpeechTimeoutUserTurnStopStrategy (user_speech_timeout=0.0) — triggers
       immediately when Soniox sends a finalized transcript (after its own
-      max_endpoint_delay_ms semantic endpoint detection).
+      max_endpoint_delay_ms semantic endpoint detection). TIMEOUT mode passes a
+      non-zero user_speech_timeout so the turn ends only after that much silence
+      following the last transcript (the timer rearms on each new transcript).
     - VAD runs inside the aggregator (not the transport)
 
     Stream mode (mode="stream") reuses the same aggregator + turn strategies
@@ -425,8 +425,11 @@ async def build_pipeline(
         # TIMEOUT and STT_NATIVE are the same strategy — only the timeout differs.
         # STT_NATIVE uses 0.0 (fires immediately on finalized transcript, e.g. Soniox <end> token).
         # TIMEOUT uses user_speech_timeout (waits after last transcript, resets on each new one).
+        # pipecat 1.1.0's SpeechTimeoutUserTurnStopStrategy handles the no-VAD
+        # multi-turn case natively (per-turn reset + independent wait flags), so
+        # no subclass/sentinel is needed.
         stop_strategies = [
-            AccumulatingSpeechTimeoutStrategy(user_speech_timeout=user_speech_timeout)
+            SpeechTimeoutUserTurnStopStrategy(user_speech_timeout=user_speech_timeout)
         ]
         logger.info(
             f"Turn detection: {turn_detection_mode.value} (user_speech_timeout={user_speech_timeout}s)"
@@ -505,6 +508,10 @@ async def build_pipeline(
     if is_stream:
         pipeline_parts.extend([tts, transport.output()])
     else:
+        # Generative voice UI (a VoiceUiStreamProcessor tapping LLM text between
+        # the LLM and TTS to emit `ui-op` RTVI events) is DEFERRED — the
+        # processor module is kept but not plugged in. See
+        # docs/widget/VOICE_GENERATIVE_UI_TODO.md for the re-wiring steps.
         pipeline_parts.extend(
             [llm, tts, transport.output(), context_aggregator.assistant()]
         )
@@ -552,6 +559,7 @@ async def create_pipeline_task(
             function_call_report_level={
                 "*": RTVIFunctionCallReportLevel.FULL,
             },
+            ignored_sources=[],
         )
         if emit_daily_events
         else None

--- a/app/ai/voice/agents/breeze_buddy/chat/approvals.py
+++ b/app/ai/voice/agents/breeze_buddy/chat/approvals.py
@@ -13,12 +13,15 @@ in the same step, UNDER the session Redis lock and BEFORE the history is
 loaded — so every history load sees a fully-answered batch.
 """
 
-from typing import Any, Dict, List
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
 
 from app.ai.voice.agents.breeze_buddy.chat.block_codec import (
     tool_results_to_user_blocks,
 )
 from app.ai.voice.agents.breeze_buddy.template.approval import (
+    LLM_STATUS_DENIED,
     LLM_STATUS_NOT_DECIDED,
     LLM_STATUS_TIMEOUT,
     WIRE_STATUS_APPROVED,
@@ -30,6 +33,9 @@ from app.core.logger import logger
 from app.database.accessor.breeze_buddy.chat_session import insert_chat_message
 from app.database.accessor.breeze_buddy.tool_approvals import (
     claim_pending_tool_approvals,
+    decide_tool_approval,
+    get_tool_approval,
+    list_pending_tool_approvals,
 )
 from app.schemas.breeze_buddy.chat import (
     ChatMessageRole,
@@ -61,6 +67,130 @@ WIRE_STATUS_BY_DB_STATUS: Dict[ToolApprovalStatus, str] = {
     ToolApprovalStatus.EXPIRED: WIRE_STATUS_TIMEOUT,
     ToolApprovalStatus.SUPERSEDED: WIRE_STATUS_SUPERSEDED,
 }
+
+
+@dataclass
+class ApprovalClaim:
+    """Outcome of atomically claiming a HITL decision for one tool call.
+
+    Shared by the HTTP ``/approval`` route (maps terminal outcomes to 404/409)
+    and the voice bridge (maps them to RTVI events). ``outcome``:
+    - ``proceed`` — the row was PENDING and is now claimed; the caller drives
+      the resume turn (see ``run_chat_approval_continuation``).
+    - ``not_found`` — no approval with that id for the session.
+    - ``already_decided`` — the row was already resolved (``winning_status`` is
+      its wire status so the client can settle the card).
+    """
+
+    outcome: str
+    claimed: Optional[ToolApproval] = None
+    effective_approved: bool = False
+    wire_status: Optional[str] = None
+    decision_reason: Optional[str] = None
+    synthetic_result: Optional[Dict[str, Any]] = None
+    pending_sibling_ids: List[str] = field(default_factory=list)
+    expired_siblings: List[ToolApproval] = field(default_factory=list)
+    winning_status: Optional[str] = None
+
+
+async def claim_tool_approval(
+    session_id: str,
+    tool_call_id: str,
+    approved: bool,
+    reason: Optional[str],
+) -> ApprovalClaim:
+    """Atomically claim a pending HITL decision (the load-bearing DB step).
+
+    MUST run under the session Redis lock. Mirrors the order the approval
+    handler documents: claim the target row (a decision after ``expires_at``
+    claims it EXPIRED → wire ``timeout``); for deny/expired persist the
+    synthetic tool_result NOW so the history load sees a fully-answered batch;
+    lazily expire other pending rows past their TTL; collect the still-pending
+    sibling ids the resume turn must keep unanswered.
+
+    Returns an :class:`ApprovalClaim`; the caller maps a non-``proceed``
+    outcome to its transport (HTTP status vs RTVI event) and, on ``proceed``,
+    drives :func:`run_chat_approval_continuation`.
+    """
+    row = await get_tool_approval(session_id, tool_call_id)
+    if row is None:
+        return ApprovalClaim(outcome="not_found")
+    if row.status != ToolApprovalStatus.PENDING:
+        return ApprovalClaim(
+            outcome="already_decided",
+            winning_status=WIRE_STATUS_BY_DB_STATUS.get(row.status),
+        )
+
+    is_expired = row.expires_at <= datetime.now(timezone.utc)
+    if is_expired:
+        new_status = ToolApprovalStatus.EXPIRED
+        decision_reason: Optional[str] = "decision arrived after expiry"
+    elif approved:
+        new_status = ToolApprovalStatus.APPROVED
+        decision_reason = reason
+    else:
+        new_status = ToolApprovalStatus.DENIED
+        decision_reason = reason
+
+    claimed = await decide_tool_approval(
+        session_id, tool_call_id, new_status, decision_reason
+    )
+    if claimed is None:
+        # Lost the claim race to a concurrent decision.
+        relook = await get_tool_approval(session_id, tool_call_id)
+        return ApprovalClaim(
+            outcome="already_decided",
+            winning_status=(
+                WIRE_STATUS_BY_DB_STATUS.get(relook.status) if relook else None
+            ),
+        )
+
+    effective_approved = approved and not is_expired
+    wire_status = WIRE_STATUS_BY_DB_STATUS[new_status]
+    logger.info(
+        f"[approval] session={session_id} tool_call_id={tool_call_id} "
+        f"function={claimed.function_name} decision={new_status.value}"
+        + (f" reason={decision_reason!r}" if decision_reason else "")
+    )
+
+    synthetic_result: Optional[Dict[str, Any]] = None
+    if not effective_approved:
+        synthetic_result = (
+            dict(EXPIRED_RESULT)
+            if is_expired
+            else {
+                "status": LLM_STATUS_DENIED,
+                "reason": reason or "the user did not approve this action",
+            }
+        )
+        await insert_chat_message(
+            session_id=session_id,
+            role=ChatMessageRole.USER,
+            content=None,
+            content_blocks=tool_results_to_user_blocks(
+                [(tool_call_id, synthetic_result)]
+            ),
+        )
+
+    # Lazily expire the OTHER pending rows past their TTL (persists their
+    # synthetic timeout results); the caller surfaces them at stream start.
+    expired_siblings = await resolve_dangling_approvals(session_id, only_expired=True)
+    # include_expired: a sibling whose expires_at falls between the sweep and
+    # this read is still PENDING + decidable — keep it in the exclude set.
+    pending_siblings = await list_pending_tool_approvals(
+        session_id, include_expired=True
+    )
+
+    return ApprovalClaim(
+        outcome="proceed",
+        claimed=claimed,
+        effective_approved=effective_approved,
+        wire_status=wire_status,
+        decision_reason=decision_reason,
+        synthetic_result=synthetic_result,
+        pending_sibling_ids=[sib.tool_call_id for sib in pending_siblings],
+        expired_siblings=expired_siblings,
+    )
 
 
 async def resolve_dangling_approvals(

--- a/app/ai/voice/agents/breeze_buddy/chat/turn_core.py
+++ b/app/ai/voice/agents/breeze_buddy/chat/turn_core.py
@@ -1,0 +1,372 @@
+"""run_chat_turn — the channel-agnostic chat brain for one user turn.
+
+Factored out of ``send_chat_message_handler`` (chat router) so that BOTH the
+HTTP ``POST /message`` route and the widget **voice** bridge drive the SAME
+``ChatAgent`` turn against the same ``chat_session``. One brain, two transports:
+chat sends text over SSE; voice (stream mode) speaks the assistant prose via
+TTS. Neither path re-implements history replay, agent_state, approval
+supersede, or template-var rendering — they all live here.
+
+Lives in the agent/chat layer (next to ``ChatAgent``) rather than the router
+so the voice agent imports it *downward* — importing the router's
+``handlers.py`` from the voice subprocess would be a layering cycle.
+
+The HTTP shell (RedisLock, ``StreamingResponse``, cancel-bus, ``TurnMetrics``,
+``access_check``, the piggyback ``req.context`` 413 pre-validation) stays in
+``handlers.py``; the voice bridge (``chat/voice_bridge.py``) wraps the same
+``run_chat_turn`` generator with TTS + RTVI emission.
+"""
+
+from __future__ import annotations
+
+from typing import Any, AsyncIterator, Dict, List, Optional, cast
+
+from app.ai.voice.agents.breeze_buddy.chat.agent import ChatAgent
+from app.ai.voice.agents.breeze_buddy.chat.approvals import (
+    WIRE_STATUS_BY_DB_STATUS,
+    WIRE_STATUS_SUPERSEDED,
+    ApprovalClaim,
+    claim_tool_approval,
+    resolve_dangling_approvals,
+)
+from app.ai.voice.agents.breeze_buddy.chat.block_codec import (
+    blocks_to_llm_context_messages,
+    repair_dangling_tool_uses,
+)
+from app.ai.voice.agents.breeze_buddy.chat.sse import SSEEvent
+from app.ai.voice.agents.breeze_buddy.llm import get_llm_service
+from app.ai.voice.agents.breeze_buddy.template.cache import get_template_by_id_cached
+from app.ai.voice.agents.breeze_buddy.template.types import TemplateModel
+from app.core.config.dynamic import CHAT_HISTORY_REPLAY_LIMIT
+from app.core.logger import logger
+from app.database.accessor.breeze_buddy.chat_session import (
+    get_agent_session_state,
+    get_chat_session_by_id,
+    list_chat_messages_for_session,
+)
+from app.database.accessor.breeze_buddy.credentials import (
+    get_credentials_as_template_vars,
+)
+from app.schemas.breeze_buddy.chat import (
+    ChatMessageRole,
+    ChatSessionStatus,
+    ToolApprovalStatus,
+)
+
+
+def resolve_llm_configuration(template: TemplateModel) -> Any:
+    """Pick out ``configurations.llm_configurations`` (the canonical path)
+    safely. Mirrors voice's access pattern (see ``agent/pipeline.py``)."""
+    configurations = getattr(template, "configurations", None)
+    if configurations is None:
+        return None
+    return getattr(configurations, "llm_configurations", None)
+
+
+async def build_render_template_vars(
+    template: TemplateModel, persisted: Optional[Dict[str, Any]]
+) -> Dict[str, Any]:
+    """Build the per-turn render context. Same precedence as voice:
+    credentials < template.secrets < persisted payload values.
+
+    Moved here from the chat router so both the HTTP turn and the voice
+    bridge resolve ``{placeholder}`` values identically.
+    """
+    merged: Dict[str, Any] = {}
+    try:
+        creds = await get_credentials_as_template_vars(template.reseller_id)
+        if creds:
+            merged.update(creds)
+    except Exception as exc:
+        logger.warning(
+            f"chat: failed to load credentials for reseller "
+            f"{template.reseller_id}: {exc}"
+        )
+    if template.secrets:
+        merged.update(template.secrets)
+    if persisted:
+        merged.update(persisted)
+    return merged
+
+
+async def run_chat_turn(
+    *,
+    session_id: str,
+    user_content: str,
+    llm: Optional[Any] = None,
+    context_placement: Optional[str] = None,
+) -> AsyncIterator[SSEEvent]:
+    """Drive one chat-brain turn for ``session_id`` and yield its SSE events.
+
+    Loads the session + template + capped history + agent_state itself, runs
+    the same approval-supersede + history-repair the HTTP path does, then
+    drives ``ChatAgent.run_turn``. The agent self-persists every chat_message
+    (content_blocks / ui_blocks) and agent_state, so a voice turn writes the
+    session exactly as ``POST /message`` does.
+
+    ``llm`` — optional pre-built (pooled) LLM service; when ``None`` one is
+    resolved from the template. ``context_placement`` — optional per-turn
+    client-context render override (the HTTP piggyback carries it; voice
+    passes ``None``).
+
+    On a missing / ended session or a missing template, yields a terminal
+    ``error`` + ``turn_end`` instead of raising — the HTTP shell already
+    pre-validates those, and the voice bridge has no HTTP status to map.
+    """
+    session = await get_chat_session_by_id(session_id)
+    if session is None:
+        yield SSEEvent(
+            event="error",
+            data={"code": "session_not_found", "message": "Session not found"},
+        )
+        yield SSEEvent(event="turn_end", data={"session_status": "FAILED"})
+        return
+    if session.status == ChatSessionStatus.ENDED:
+        yield SSEEvent(
+            event="error",
+            data={"code": "session_ended", "message": "Session has ended"},
+        )
+        yield SSEEvent(event="turn_end", data={"session_status": "FAILED"})
+        return
+
+    template = await get_template_by_id_cached(session.template_id)
+    if template is None:
+        logger.error(
+            f"run_chat_turn: template {session.template_id!r} for session "
+            f"{session_id} no longer exists"
+        )
+        yield SSEEvent(
+            event="error",
+            data={"code": "template_missing", "message": "Template missing"},
+        )
+        yield SSEEvent(event="turn_end", data={"session_status": "FAILED"})
+        return
+
+    # HITL: a new user message supersedes every pending approval (the user
+    # moved on without deciding). Persists the synthetic tool_result rows
+    # that keep replayed history fully answered; the resolved events ride at
+    # the start of this turn's stream so live cards flip without client
+    # inference. (HTTP path used to do this inline; now it lives here so the
+    # voice bridge inherits it for free.)
+    superseded = await resolve_dangling_approvals(session_id, only_expired=False)
+    for row in superseded:
+        yield SSEEvent(
+            event="function_approval_resolved",
+            data={
+                "tool_call_id": row.tool_call_id,
+                "status": WIRE_STATUS_SUPERSEDED,
+                "reason": row.reason,
+            },
+        )
+
+    history_limit = await CHAT_HISTORY_REPLAY_LIMIT()
+    history_rows = await list_chat_messages_for_session(session_id, limit=history_limit)
+    # Replay the canonical Anthropic-shape blocks (post-migration 030),
+    # falling back to denormalised prose for legacy rows. tool_use /
+    # tool_result blocks survive so the LLM sees its own prior identifiers
+    # (cart_id, etc.) verbatim — this is what makes voice resume "just work".
+    history: list = blocks_to_llm_context_messages(
+        [
+            {
+                "role": row.role.value,
+                "content": row.content,
+                "content_blocks": row.content_blocks,
+            }
+            for row in history_rows
+            if row.role in (ChatMessageRole.USER, ChatMessageRole.ASSISTANT)
+        ]
+    )
+    # Heal any unmatched tool_use (decided-but-lost rows) → synthetic error
+    # result; drop orphan tool_results from window truncation.
+    history = cast(list, repair_dangling_tool_uses(history))
+
+    state_row = await get_agent_session_state(session_id)
+    agent_state: Dict[str, Any] = state_row.data if state_row else {}
+
+    persisted_template_vars = (
+        session.metadata.get("template_vars", {})
+        if isinstance(session.metadata, dict)
+        else {}
+    )
+    template_vars = await build_render_template_vars(template, persisted_template_vars)
+
+    if llm is None:
+        llm = await get_llm_service(resolve_llm_configuration(template), pooled=True)
+
+    agent = ChatAgent(
+        session_id=session_id,
+        template=template,
+        llm=llm,
+        template_vars=template_vars,
+        agent_state=agent_state,
+        context_placement=context_placement,
+    )
+    async for event in agent.run_turn(
+        user_content=user_content,
+        history=history,
+        current_node=session.current_node,
+    ):
+        yield event
+
+
+async def run_chat_approval_continuation(
+    *,
+    session_id: str,
+    claimed: Any,
+    effective_approved: bool,
+    wire_status: Optional[str],
+    decision_reason: Optional[str],
+    synthetic_result: Optional[Dict[str, Any]],
+    pending_sibling_ids: List[str],
+    llm: Optional[Any] = None,
+) -> AsyncIterator[SSEEvent]:
+    """Drive the resume turn AFTER a HITL decision has been claimed.
+
+    The shared continuation behind both the HTTP ``/approval`` route and the
+    voice bridge: load + repair history (keeping the claimed call and the
+    still-pending siblings unanswered), load agent_state + template_vars, then
+    drive ``ChatAgent.run_approval_turn`` — which executes the approved call (or
+    acknowledges the denial) and continues the LLM loop. The atomic claim +
+    sibling sweep already happened in :func:`claim_tool_approval`.
+    """
+    session = await get_chat_session_by_id(session_id)
+    if session is None or session.status == ChatSessionStatus.ENDED:
+        yield SSEEvent(
+            event="error",
+            data={"code": "session_gone", "message": "Session no longer active"},
+        )
+        yield SSEEvent(event="turn_end", data={"session_status": "FAILED"})
+        return
+    template = await get_template_by_id_cached(session.template_id)
+    if template is None:
+        yield SSEEvent(
+            event="error",
+            data={"code": "template_missing", "message": "Template missing"},
+        )
+        yield SSEEvent(event="turn_end", data={"session_status": "FAILED"})
+        return
+
+    history_limit = await CHAT_HISTORY_REPLAY_LIMIT()
+    history_rows = await list_chat_messages_for_session(session_id, limit=history_limit)
+    history: list = blocks_to_llm_context_messages(
+        [
+            {
+                "role": row.role.value,
+                "content": row.content,
+                "content_blocks": row.content_blocks,
+            }
+            for row in history_rows
+            if row.role in (ChatMessageRole.USER, ChatMessageRole.ASSISTANT)
+        ]
+    )
+    # The claimed call (answered in-turn by run_approval_turn) and the
+    # still-pending siblings must STAY unanswered; everything else unmatched is
+    # decided-but-lost and gets a synthetic error result.
+    exclude: set[str] = set(pending_sibling_ids)
+    claimed_id = getattr(claimed, "tool_call_id", None)
+    if claimed_id:
+        exclude.add(claimed_id)
+    history = cast(list, repair_dangling_tool_uses(history, exclude_ids=exclude))
+
+    state_row = await get_agent_session_state(session_id)
+    agent_state: Dict[str, Any] = state_row.data if state_row else {}
+    persisted_template_vars = (
+        session.metadata.get("template_vars", {})
+        if isinstance(session.metadata, dict)
+        else {}
+    )
+    template_vars = await build_render_template_vars(template, persisted_template_vars)
+    if llm is None:
+        llm = await get_llm_service(resolve_llm_configuration(template), pooled=True)
+
+    agent = ChatAgent(
+        session_id=session_id,
+        template=template,
+        llm=llm,
+        template_vars=template_vars,
+        agent_state=agent_state,
+    )
+    async for event in agent.run_approval_turn(
+        approval=claimed,
+        approved=effective_approved,
+        wire_status=wire_status or "",
+        decision_reason=decision_reason,
+        synthetic_result=synthetic_result,
+        history=history,
+        current_node=session.current_node,
+        pending_sibling_ids=pending_sibling_ids,
+    ):
+        yield event
+
+
+async def run_chat_approval_turn(
+    *,
+    session_id: str,
+    tool_call_id: str,
+    approved: bool,
+    reason: Optional[str] = None,
+    llm: Optional[Any] = None,
+) -> AsyncIterator[SSEEvent]:
+    """Self-contained HITL decision turn for the voice bridge.
+
+    Claims the decision (:func:`claim_tool_approval`) then drives the resume
+    turn (:func:`run_chat_approval_continuation`), mapping every outcome to SSE
+    events (no HTTP status — the HTTP ``/approval`` route does its own claim +
+    409/404 mapping but reuses the SAME claim + continuation underneath).
+    """
+    claim: ApprovalClaim = await claim_tool_approval(
+        session_id, tool_call_id, approved, reason
+    )
+    if claim.outcome == "not_found":
+        yield SSEEvent(
+            event="function_approval_resolved",
+            data={
+                "tool_call_id": tool_call_id,
+                "status": "cancelled",
+                "reason": "no longer pending",
+            },
+        )
+        yield SSEEvent(event="turn_end", data={"session_status": "ACTIVE"})
+        return
+    if claim.outcome == "already_decided":
+        yield SSEEvent(
+            event="function_approval_resolved",
+            data={
+                "tool_call_id": tool_call_id,
+                "status": claim.winning_status or "denied",
+                "reason": None,
+            },
+        )
+        yield SSEEvent(event="turn_end", data={"session_status": "ACTIVE"})
+        return
+
+    # proceed — surface any siblings expired during the claim, then continue.
+    for sib in claim.expired_siblings:
+        yield SSEEvent(
+            event="function_approval_resolved",
+            data={
+                "tool_call_id": sib.tool_call_id,
+                "status": WIRE_STATUS_BY_DB_STATUS[ToolApprovalStatus.EXPIRED],
+                "reason": sib.reason,
+            },
+        )
+    async for event in run_chat_approval_continuation(
+        session_id=session_id,
+        claimed=claim.claimed,
+        effective_approved=claim.effective_approved,
+        wire_status=claim.wire_status,
+        decision_reason=claim.decision_reason,
+        synthetic_result=claim.synthetic_result,
+        pending_sibling_ids=claim.pending_sibling_ids,
+        llm=llm,
+    ):
+        yield event
+
+
+__all__ = [
+    "run_chat_turn",
+    "run_chat_approval_turn",
+    "run_chat_approval_continuation",
+    "build_render_template_vars",
+    "resolve_llm_configuration",
+]

--- a/app/ai/voice/agents/breeze_buddy/chat/voice_bridge.py
+++ b/app/ai/voice/agents/breeze_buddy/chat/voice_bridge.py
@@ -1,0 +1,501 @@
+"""WidgetVoiceBridge — drives widget voice turns through the chat brain.
+
+Stream-mode widget voice runs **no LLM in the pipeline** (see
+``agent/pipeline.py`` ``mode="stream"``). Each finished user turn
+(``on_user_turn_stopped``) is handed to this bridge, which runs the SAME
+``ChatAgent`` turn as ``POST /message`` (via :func:`run_chat_turn`) and:
+
+- streams assistant prose back as ``TTSSpeakFrame``s (sentence-chunked) +
+  ``assistant-transcript`` RTVI events so the widget renders the bubble,
+- forwards ``ui_op`` events as ``ui-op`` RTVI events (carousels/Tiles),
+- plays a short filler before a slow tool call (so the user isn't left in
+  silence), and
+- ends the turn with a ``turn-end`` RTVI event.
+
+One brain, voice = pure audio I/O. cart_id, content_blocks history,
+agent_state / client-context, carousels — all inherited from chat because it
+*is* chat. See ``docs/widget/VOICE_AS_CHAT.md`` + the re-architecture plan.
+
+Concurrency: the bridge holds exactly one in-flight turn task. A barge-in
+(``on_user_turn_started`` → :meth:`cancel_inflight`) cancels it — pipecat's
+native ``broadcast_interruption`` has already flushed TTS — and bumps a
+generation counter so any tail frames from the cancelled turn are dropped.
+The cancelled ``run_chat_turn`` generator's ``finally`` closes its aiohttp /
+MCP pool, and the next turn's ``repair_dangling_tool_uses`` heals any tool_use
+left dangling by the interrupt (exactly like chat's ``/cancel``).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Awaitable, Callable, List, Optional
+
+from pipecat.frames.frames import TTSSpeakFrame
+
+from app.ai.voice.agents.breeze_buddy.chat.turn_core import (
+    run_chat_approval_turn,
+    run_chat_turn,
+)
+from app.ai.voice.agents.breeze_buddy.chat.ui_stream import strip_ui_stream_markers
+from app.core.logger import logger
+from app.database.accessor.breeze_buddy.chat_session import (
+    list_chat_messages_for_session,
+)
+from app.schemas.breeze_buddy.chat import ChatMessageRole
+from app.services.redis.locks import LockAcquireError, RedisLock
+
+# Cap on a single TTSSpeakFrame (mirrors agent/__init__.py TTS_SPEAK_MAX_CHARS).
+# Defined locally so this module doesn't import the Agent (which imports it).
+_TTS_SPEAK_MAX_CHARS = 2000
+
+# Per-session Redis lock — the SAME key + TTL the chat /message + /approval +
+# /voice routes use (chat/handlers.py ``_lock_key``, widget/handlers.py
+# ``_session_lock``). A voice turn writes chat_message rows whose idx is the
+# non-atomic ``MAX(idx)+1`` — only race-free WHILE this lock serialises every
+# writer of the session. While current_channel=VOICE the chat HTTP paths are
+# already 409-gated, so this is rarely contended; it closes the post-flip window
+# where a flip to CHAT races a still-writing bridge turn against a new /message.
+# Key kept inline (not imported from the FastAPI router) so this stays importable
+# in the voice subprocess.
+_SESSION_LOCK_TTL_SECONDS = 180
+
+
+def _lock_key(session_id: str) -> str:
+    return f"chat:session:{session_id}:lock"
+
+
+# Optional chunk-length floor for the sentence aggregator. 0 flushes every
+# complete sentence the moment it lands (lowest time-to-first-audio); raise it
+# to batch very short adjacent sentences into one TTS request.
+_SENTENCE_MIN_CHARS = 0
+
+# Spoken before the first tool call of a turn when the model hasn't said
+# anything yet, so a slow tool (cart fetch, search) isn't dead air.
+_DEFAULT_FILLER_PHRASE = "Just a second."
+
+# RTVI server-message types the widget consumes. ``ui-op`` +
+# ``function-approval-*`` match the agent-mode HITL / VoiceUiStreamProcessor
+# wire contract, so the widget's existing handlers work unchanged.
+_RTVI_ASSISTANT_TRANSCRIPT = "assistant-transcript"
+_RTVI_UI_OP = "ui-op"
+_RTVI_TURN_END = "turn-end"
+_RTVI_ERROR = "error"
+_RTVI_APPROVAL_REQUEST = "function-approval-request"
+_RTVI_APPROVAL_RESOLVED = "function-approval-resolved"
+# Tool-activity signals so the widget can show a "thinking / executing <tool>"
+# state on the voice orb (names match the chat SDK's events for 1:1 reuse).
+_RTVI_FUNCTION_CALL_STARTED = "function-call-started"
+_RTVI_FUNCTION_CALL_COMPLETED = "function-call-completed"
+
+# Agent._emit_rtvi_event(event_type, payload) — swallows its own exceptions.
+EmitRtvi = Callable[[str, Optional[dict]], Awaitable[None]]
+
+
+class _SentenceAggregator:
+    """Buffer assistant tokens and flush complete sentences for TTS.
+
+    Flushes the buffer up to and including a sentence-terminal punctuation
+    (``. ! ? … \\n``) that is followed by whitespace / end-of-buffer / another
+    terminal — so TTS speaks natural sentence units instead of word-by-word
+    fragments, while ``3.5`` (terminal followed by a digit) is never split.
+    With ``min_chars=0`` every complete sentence flushes the moment it lands;
+    a positive ``min_chars`` batches shorter sentences. ``flush()`` drains
+    whatever remains (called at turn end / before a tool call so held prose is
+    spoken).
+    """
+
+    _TERMINALS = ".!?…\n"
+
+    def __init__(self, min_chars: int = _SENTENCE_MIN_CHARS) -> None:
+        self._buf = ""
+        self._min = min_chars
+        self.has_emitted = False
+
+    @property
+    def is_empty(self) -> bool:
+        return not self._buf.strip()
+
+    def push(self, text: str) -> List[str]:
+        self._buf += text
+        out: List[str] = []
+        while True:
+            cut = self._next_cut()
+            if cut is None:
+                break
+            chunk = self._buf[:cut].strip()
+            self._buf = self._buf[cut:]
+            if chunk:
+                self.has_emitted = True
+                out.append(chunk)
+        return out
+
+    def _next_cut(self) -> Optional[int]:
+        # Return the index AFTER the first sentence-terminal whose chunk is at
+        # least ``min_chars`` long and is followed by whitespace / end-of-buffer
+        # / another terminal. Scanning from 0 means a short complete sentence
+        # flushes promptly (low latency) rather than merging with the next.
+        n = len(self._buf)
+        for i in range(n):
+            if self._buf[i] in self._TERMINALS:
+                j = i + 1
+                if j < self._min:
+                    continue
+                if j >= n or self._buf[j].isspace() or self._buf[j] in self._TERMINALS:
+                    return j
+        return None
+
+    def flush(self) -> List[str]:
+        chunk = self._buf.strip()
+        self._buf = ""
+        if chunk:
+            self.has_emitted = True
+            return [chunk]
+        return []
+
+
+class WidgetVoiceBridge:
+    """Drive one widget voice session's turns through the chat brain."""
+
+    def __init__(
+        self,
+        *,
+        session_id: str,
+        task: Any,
+        emit_rtvi: EmitRtvi,
+        filler_phrase: str = _DEFAULT_FILLER_PHRASE,
+    ) -> None:
+        self.session_id = session_id
+        self._task = task
+        self._emit_rtvi = emit_rtvi
+        self._filler_phrase = filler_phrase
+        self._inflight: Optional["asyncio.Task[None]"] = None
+        # Monotonic per-turn id. Bumped on every cancel / new turn so frames
+        # from a superseded turn (cancelled mid-stream by a barge-in) are
+        # dropped instead of leaking into the next turn's audio.
+        self._generation = 0
+
+    # -- turn lifecycle -----------------------------------------------------
+
+    async def handle_user_turn(self, user_content: Optional[str]) -> None:
+        """Entry point for ``on_user_turn_stopped`` — run one chat turn.
+
+        Fire-and-forget: spawns a tracked task so the pipecat event handler
+        returns immediately (the turn streams TTS frames in the background).
+        Blank utterances (the aggregator emits an empty turn on some VAD
+        edges) are ignored.
+        """
+        text = (user_content or "").strip()
+        if not text:
+            return
+        # Fully drain (cancel + await) any prior turn so its Redis lock is
+        # released before the new turn tries to acquire — otherwise a barge-in
+        # quickly followed by a new utterance would self-contend and drop the
+        # new turn.
+        await self._drain()
+        self._generation += 1
+        gen = self._generation
+        self._inflight = asyncio.create_task(self._run_turn(text, gen))
+
+    async def cancel_inflight(self) -> None:
+        """Barge-in (``on_user_turn_started``): stop the in-flight turn.
+
+        pipecat's ``broadcast_interruption`` already flushed queued TTS before
+        this fires; we just cancel the chat-turn task and bump the generation so
+        any frame it tries to queue before unwinding is dropped. We do NOT await
+        the task here (keep barge-in snappy) — the next ``handle_user_turn``'s
+        ``_drain`` awaits its teardown (incl. the lock release) before starting
+        the next turn. ``_inflight`` is left set so that drain can find it.
+        """
+        self._generation += 1
+        task = self._inflight
+        if task is not None and not task.done():
+            task.cancel()
+
+    async def aclose(self) -> None:
+        """Teardown (end_conversation): cancel + await the in-flight turn so its
+        Redis lock is released before the channel flips back to CHAT. Without
+        this drain a flip-to-CHAT could let a new /message turn race the bridge's
+        still-writing turn on the non-atomic chat_message idx allocation."""
+        await self._drain()
+
+    async def _drain(self) -> None:
+        """Cancel the in-flight turn and AWAIT its full teardown (run_chat_turn's
+        finally + the Redis lock release)."""
+        task = self._inflight
+        self._inflight = None
+        if task is None or task.done():
+            return
+        task.cancel()
+        try:
+            await task
+        except BaseException:  # noqa: BLE001 - drain must never propagate
+            pass
+
+    async def handle_approval_decision(
+        self, tool_call_id: Optional[str], approved: bool, reason: Optional[str] = None
+    ) -> None:
+        """A HITL decision arrived over RTVI during a voice turn.
+
+        Drives the resume turn through the chat brain (execute or deny the gated
+        call, then continue speaking the reply) — the voice counterpart of
+        ``POST /approval``. Same fire-and-forget + drain-prior shape as
+        ``handle_user_turn``.
+        """
+        if not tool_call_id:
+            return
+        await self._drain()
+        self._generation += 1
+        gen = self._generation
+        self._inflight = asyncio.create_task(
+            self._run_approval(tool_call_id, approved, reason, gen)
+        )
+
+    async def _run_turn(self, user_content: str, gen: int) -> None:
+        await self._drive(
+            lambda: run_chat_turn(
+                session_id=self.session_id, user_content=user_content
+            ),
+            gen,
+        )
+
+    async def _run_approval(
+        self, tool_call_id: str, approved: bool, reason: Optional[str], gen: int
+    ) -> None:
+        await self._drive(
+            lambda: run_chat_approval_turn(
+                session_id=self.session_id,
+                tool_call_id=tool_call_id,
+                approved=approved,
+                reason=reason,
+            ),
+            gen,
+        )
+
+    async def _drive(self, make_events: Callable[[], Any], gen: int) -> None:
+        """Acquire the session lock, consume one chat-brain event stream into
+        TTS + RTVI, and release the lock (cancel-safe). Shared by the spoken-turn
+        and approval-decision paths."""
+        lock = RedisLock(
+            _lock_key(self.session_id), ttl_seconds=_SESSION_LOCK_TTL_SECONDS
+        )
+        try:
+            await lock.acquire()
+        except LockAcquireError:
+            # Another writer holds the session lock — almost always a /message
+            # racing this turn through the post-flip window. Skip rather than
+            # risk a PK collision on the chat_message idx; the user can repeat.
+            logger.warning(
+                f"[voice-bridge] session {self.session_id} lock busy; skipping turn"
+            )
+            await self._emit_rtvi(
+                _RTVI_ERROR, {"code": "busy", "message": "One moment, please."}
+            )
+            if self._inflight is asyncio.current_task():
+                self._inflight = None
+            return
+
+        events = make_events()
+        try:
+            await self._consume_events(events, gen)
+        except asyncio.CancelledError:
+            # Barge-in / teardown. The CancelledError thrown into the async
+            # generator already ran its finally (aiohttp + MCP close) as it
+            # propagated; the next turn's repair heals any dangling tool_use.
+            # Uncancel so the shielded lock release below isn't re-cancelled
+            # (Python 3.11 cancel-counter gotcha — same fix the chat SSE stream
+            # uses); we don't re-raise, the turn is done.
+            cur = asyncio.current_task()
+            if cur is not None:
+                try:
+                    cur.uncancel()
+                except AttributeError:
+                    pass
+        except Exception as exc:  # noqa: BLE001
+            logger.error(
+                f"[voice-bridge] turn failed for session {self.session_id}: {exc}",
+                exc_info=True,
+            )
+            await self._emit_rtvi(
+                _RTVI_ERROR, {"code": "internal", "message": "voice turn failed"}
+            )
+        finally:
+            # Shield the release so a cancellation that lands here still issues
+            # the Redis DEL (else the lock lingers until its 180s TTL and the
+            # next turn / message 409s).
+            try:
+                await asyncio.shield(lock.release())
+            except Exception:  # noqa: BLE001
+                pass
+            if self._inflight is asyncio.current_task():
+                self._inflight = None
+
+    async def _consume_events(self, events: Any, gen: int) -> None:
+        """Adapt one chat-brain SSE stream into TTS frames + RTVI events."""
+        agg = _SentenceAggregator()
+        filler_fired = False
+        async for ev in events:
+            if gen != self._generation:
+                # Superseded by a newer turn without a task cancel (rare).
+                # Close the generator so its aiohttp/MCP pool is released.
+                await events.aclose()
+                return
+            if ev.event == "assistant_token":
+                delta = ev.data.get("delta", "") if isinstance(ev.data, dict) else ""
+                for chunk in agg.push(delta):
+                    await self._speak(chunk, gen)
+            elif ev.event == "ui_op":
+                op = ev.data.get("op") if isinstance(ev.data, dict) else None
+                if op is not None:
+                    await self._emit_rtvi(_RTVI_UI_OP, {"op": op})
+            elif ev.event == "function_call_started":
+                # Speak any prose held before this tool call, then play a filler
+                # only if the turn has been silent so far.
+                for chunk in agg.flush():
+                    await self._speak(chunk, gen)
+                # Tell the widget a tool is running so the orb can show
+                # "executing <tool>" (carries the name → TOOL_LABELS on the client).
+                data = ev.data if isinstance(ev.data, dict) else {}
+                await self._emit_rtvi(
+                    _RTVI_FUNCTION_CALL_STARTED,
+                    {
+                        "name": data.get("name"),
+                        "args": data.get("args") or {},
+                        "tool_call_id": data.get("tool_call_id"),
+                    },
+                )
+                if not filler_fired and not agg.has_emitted:
+                    filler_fired = True
+                    await self._speak_filler(gen)
+            elif ev.event == "function_call_completed":
+                # Tool finished — let the widget clear the "executing" state.
+                data = ev.data if isinstance(ev.data, dict) else {}
+                await self._emit_rtvi(
+                    _RTVI_FUNCTION_CALL_COMPLETED,
+                    {
+                        "name": data.get("name"),
+                        "tool_call_id": data.get("tool_call_id"),
+                    },
+                )
+            elif ev.event == "function_approval_requested":
+                # HITL gate hit mid-turn — speak any held prose, then surface the
+                # approval card live over RTVI (same wire contract the agent-mode
+                # HITL used, so the widget renders it unchanged). The decision
+                # comes back via on_client_message → handle_approval_decision.
+                for chunk in agg.flush():
+                    await self._speak(chunk, gen)
+                data = ev.data if isinstance(ev.data, dict) else {}
+                # Speak the approval prompt so the voice user HEARS the question
+                # (the card shows the same text plus the actual args). Without
+                # this the card would appear silently mid-call. Audio only
+                # (echo=False) — the inline card already renders this text, so
+                # echoing a transcript bubble too would duplicate the line.
+                prompt = data.get("prompt")
+                if isinstance(prompt, str) and prompt.strip():
+                    await self._speak(prompt, gen, echo=False)
+                await self._emit_rtvi(
+                    _RTVI_APPROVAL_REQUEST,
+                    {
+                        "approval_id": data.get("tool_call_id"),
+                        "function_name": data.get("name"),
+                        "arguments": data.get("args") or {},
+                        "prompt": prompt,
+                    },
+                )
+            elif ev.event == "function_approval_resolved":
+                data = ev.data if isinstance(ev.data, dict) else {}
+                await self._emit_rtvi(
+                    _RTVI_APPROVAL_RESOLVED,
+                    {
+                        "approval_id": data.get("tool_call_id"),
+                        "status": data.get("status"),
+                        "reason": data.get("reason"),
+                    },
+                )
+            elif ev.event == "turn_end":
+                for chunk in agg.flush():
+                    await self._speak(chunk, gen)
+                status = (
+                    ev.data.get("session_status") if isinstance(ev.data, dict) else None
+                )
+                await self._emit_rtvi(_RTVI_TURN_END, {"status": status})
+            elif ev.event == "error":
+                data = ev.data if isinstance(ev.data, dict) else {}
+                await self._emit_rtvi(
+                    _RTVI_ERROR,
+                    {
+                        "code": data.get("code"),
+                        "message": data.get("message", "voice turn error"),
+                    },
+                )
+            # user_committed / node_transition are intentionally not echoed: the
+            # user transcript already reaches the widget from STT via pipecat RTVI.
+
+    # -- emission helpers ---------------------------------------------------
+
+    async def _speak(self, text: str, gen: int, *, echo: bool = True) -> None:
+        if gen != self._generation:
+            return
+        # Defense-in-depth: assistant_token deltas are already <ui_stream>-
+        # stripped by ChatAgent, but strip again so a stray marker never
+        # reaches TTS.
+        clean = strip_ui_stream_markers(text).strip()
+        if not clean:
+            return
+        clean = clean[:_TTS_SPEAK_MAX_CHARS]
+        if self._task is not None:
+            await self._task.queue_frame(TTSSpeakFrame(text=clean))
+        # `echo=False` speaks audio only (no transcript bubble). Used for the
+        # HITL approval prompt: its text already renders on the inline approval
+        # card, so echoing it as a transcript would show the same line twice.
+        if echo:
+            await self._emit_rtvi(
+                _RTVI_ASSISTANT_TRANSCRIPT, {"content": clean, "final": False}
+            )
+
+    async def _speak_filler(self, gen: int) -> None:
+        if gen != self._generation or self._task is None:
+            return
+        # No transcript echo — the filler is audio comfort, not assistant
+        # content the widget should render or persist.
+        await self._task.queue_frame(TTSSpeakFrame(text=self._filler_phrase))
+
+    # -- greeting -----------------------------------------------------------
+
+    async def maybe_speak_greeting(self) -> None:
+        """Speak the persisted chat greeting on the FIRST voice attachment.
+
+        Only when the session has no user turns yet — a brand-new conversation
+        that went straight to voice. A reconnect mid-conversation does NOT
+        re-greet (the widget already shows the history). No transcript echo:
+        the greeting bubble is already rendered from the session's loaded
+        messages, so we only push it to TTS.
+        """
+        if self._task is None:
+            return
+        try:
+            messages = await list_chat_messages_for_session(self.session_id)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                f"[voice-bridge] greeting load failed for {self.session_id}: {exc}"
+            )
+            return
+        # Only REAL user speech/text suppresses the greeting. Tool-result rows
+        # are persisted as role=USER with content=None (chat/agent.py); they
+        # must not count as "the user already spoke".
+        if any(m.role == ChatMessageRole.USER and m.content for m in messages):
+            return  # mid-conversation reconnect — don't re-greet
+        greeting = next(
+            (
+                m.content
+                for m in messages
+                if m.role == ChatMessageRole.ASSISTANT and m.content
+            ),
+            None,
+        )
+        if greeting:
+            await self._task.queue_frame(
+                TTSSpeakFrame(text=greeting[:_TTS_SPEAK_MAX_CHARS])
+            )
+
+
+__all__ = ["WidgetVoiceBridge"]

--- a/app/ai/voice/agents/breeze_buddy/handlers/internal/end_conversation.py
+++ b/app/ai/voice/agents/breeze_buddy/handlers/internal/end_conversation.py
@@ -18,16 +18,8 @@ from app.ai.voice.agents.breeze_buddy.utils.hold_transfer import (
 from app.core.logger import logger
 from app.core.logger.context import clear_log_context
 from app.database.accessor.breeze_buddy.chat_session import (
-    drain_voice_into_chat_session,
-    upsert_agent_session_state_merge,
+    flip_chat_session_to_chat,
 )
-
-# Client-context-owned keys to exclude from the drain's merge so it never
-# clobbers a /context push (source of truth: chat/client_context.py). Inlined
-# rather than imported — end_conversation sits inside client_context's
-# transitive import chain (template.types -> builder -> handlers.internal), so
-# importing it back here would be a circular import.
-_CLIENT_CONTEXT_KEYS = ("_client_context", "_client_context_rev")
 
 callback_map = {
     "service_callback": service_callback,
@@ -125,67 +117,44 @@ async def end_conversation(context: TemplateContext, args, transition_to=None):
                 f"No context found for transcription collection in call {context.call_sid}"
             )
 
-        # ── Widget-mode drain ─────────────────────────────────────────────
-        # If this voice call was a transient attachment to a widget chat
-        # session (CHAT_MODE.md §14), drain the new turns back into the
-        # canonical chat_session so chat resumes with full conversation
-        # history. The drain is idempotent and best-effort — a failure
-        # here must NOT block the rest of end_conversation (DB lead
-        # update, callbacks, EndFrame), so it's wrapped in its own try.
+        # ── Widget voice attachment: flip channel back to CHAT ─────────────
+        # In the voice-as-chat architecture the chat brain (run_chat_turn)
+        # wrote every turn to the chat_session LIVE — there is no transcript to
+        # drain and no agent_state to merge back. All that remains is to flip
+        # current_channel VOICE → CHAT so /message and /voice/connect unblock.
+        # This is the authoritative flip (the pipeline has fully torn down, so
+        # no bridge turn is still writing); the /voice/end route's flip is the
+        # crash safety net. Both go through the conditional UPDATE, so whichever
+        # runs second is a no-op. Best-effort — a failure here must NOT block
+        # the rest of end_conversation (DB lead update, callbacks, EndFrame).
         widget_session_id = context.lead.metaData.get("widget_session_id")
         if widget_session_id:
             try:
-                seed_count = int(
-                    context.lead.metaData.get("seed_message_count", 0) or 0
-                )
-                # New voice turns = everything past the seed boundary in
-                # filtered_transcript (user/assistant only — the same
-                # shape chat_message stores).
-                new_messages = filtered_transcript[seed_count:]
-                final_node = None
-                if context.bot and getattr(context.bot, "flow_manager", None):
-                    final_node = context.bot.flow_manager.current_node
-                if not final_node:
-                    final_node = context.lead.metaData.get("start_node")
-                logger.info(
-                    f"widget drain: chat_session={widget_session_id} "
-                    f"new_turns={len(new_messages)} final_node={final_node!r}"
-                )
-                await drain_voice_into_chat_session(
-                    chat_session_id=str(widget_session_id),
-                    lead_id=str(context.lead.id),
-                    new_messages=new_messages,
-                    final_node=final_node,
-                )
-                # Persist voice-accumulated agent_state back to the chat
-                # session so a later chat turn sees cart_id/etc. that voice
-                # updated (mirror of the seed carried in on /voice/connect).
-                voice_state = getattr(context.bot, "agent_state", None)
-                if voice_state:
-                    # Merge back ONLY the keys voice actually CHANGED vs the
-                    # seed copied in at /voice/connect — never the whole seeded
-                    # state, never the client-context keys. A blanket merge of
-                    # the seed would re-assert a stale allowlisted key (e.g.
-                    # cart_id) and clobber a /context push made against the chat
-                    # session while voice was live (the /context endpoint has no
-                    # channel guard, so it runs concurrently with the call).
-                    seed_state = context.lead.metaData.get("agent_state")
-                    if not isinstance(seed_state, dict):
-                        seed_state = {}
-                    changed = {
-                        k: v
-                        for k, v in voice_state.items()
-                        if k not in _CLIENT_CONTEXT_KEYS and seed_state.get(k) != v
-                    }
-                    if changed:
-                        await upsert_agent_session_state_merge(
-                            chat_session_id=str(widget_session_id),
-                            patch=changed,
+                # Drain the voice bridge FIRST so its in-flight turn (and the
+                # per-session Redis lock it holds) is fully released before the
+                # flip — otherwise a flip to CHAT could let a new /message turn
+                # race the bridge's still-writing turn on the chat_message idx.
+                bridge = getattr(context.bot, "_voice_bridge", None)
+                if bridge is not None:
+                    try:
+                        await bridge.aclose()
+                    except Exception as drain_err:  # noqa: BLE001
+                        logger.warning(
+                            f"widget voice: bridge drain failed for "
+                            f"{widget_session_id}: {drain_err} (continuing)"
                         )
-            except Exception as drain_err:
+                await flip_chat_session_to_chat(
+                    session_id=str(widget_session_id),
+                    voice_lead_id=str(context.lead.id),
+                )
+                logger.info(
+                    f"widget voice: flipped chat_session {widget_session_id} "
+                    "back to CHAT on call end"
+                )
+            except Exception as flip_err:
                 logger.error(
-                    f"widget drain: failed for chat_session "
-                    f"{widget_session_id} / lead {context.lead.id}: {drain_err}",
+                    f"widget voice: flip-to-chat failed for chat_session "
+                    f"{widget_session_id} / lead {context.lead.id}: {flip_err}",
                     exc_info=True,
                 )
 

--- a/app/ai/voice/agents/breeze_buddy/processors/__init__.py
+++ b/app/ai/voice/agents/breeze_buddy/processors/__init__.py
@@ -9,9 +9,13 @@ from app.ai.voice.agents.breeze_buddy.processors.transcription_gate import (
 from app.ai.voice.agents.breeze_buddy.processors.user_idle import (
     UserIdleCallbackHandler,
 )
+from app.ai.voice.agents.breeze_buddy.processors.voice_ui_stream import (
+    VoiceUiStreamProcessor,
+)
 
 __all__ = [
     "TranscriptCollectorProcessor",
     "TranscriptionGateProcessor",
     "UserIdleCallbackHandler",
+    "VoiceUiStreamProcessor",
 ]

--- a/app/ai/voice/agents/breeze_buddy/processors/voice_ui_stream.py
+++ b/app/ai/voice/agents/breeze_buddy/processors/voice_ui_stream.py
@@ -1,0 +1,141 @@
+"""VoiceUiStreamProcessor — generative UI over the voice RTVI channel.
+
+Mirrors chat's ``<ui_stream>`` pipeline (``chat/ui_stream.py``) but emits
+validated UI ops over RTVI instead of SSE, and strips the markers from the
+assistant text *before* it reaches TTS (so the bot never speaks the JSON) and
+before the downstream assistant context aggregator (so the LLM context and the
+``end_conversation`` transcript carry clean prose — exactly mirroring chat's
+``strip_ui_stream_markers``).
+
+Placed between the LLM service and TTS in :func:`build_pipeline`, gated on a
+per-template ``ui_catalog`` opt-in (see ``docs/widget/VOICE_AS_CHAT.md`` A1).
+The op heal/parse/validate/repeat/root-anchor/allowlist logic is reused verbatim
+from ``chat/ui_stream.py`` (``process_op_line``) — this processor only adapts
+its ``SSEEvent`` output into ``_emit_rtvi_event("ui-op", {"op": ...})``.
+
+Daily (standard agent-mode STT/TTS) only. Widget voice now runs **stream**
+mode through the chat brain (``chat/voice_bridge.py``), where the chat
+``ChatAgent`` already emits + persists ``ui_op`` events — so this processor is
+NOT wired for widget voice; it remains for any non-widget daily agent-mode
+template that opts into ``ui_catalog``. Telephony has no RTVI processor and
+realtime speech-to-speech has no separate TTS stage to intercept (both out of
+scope).
+"""
+
+from __future__ import annotations
+
+from typing import Any, Awaitable, Callable, Dict, Optional, Set
+
+from pipecat.frames.frames import (
+    Frame,
+    LLMFullResponseEndFrame,
+    LLMFullResponseStartFrame,
+    LLMTextFrame,
+)
+from pipecat.processors.frame_processor import FrameDirection, FrameProcessor
+
+from app.ai.voice.agents.breeze_buddy.chat.ui_healer import (
+    HealerContext,
+    make_healer_fn,
+)
+from app.ai.voice.agents.breeze_buddy.chat.ui_stream import (
+    TextOut,
+    UiStreamExtractor,
+    process_op_line,
+)
+from app.core.logger import logger
+
+# Emit signature matches Agent._emit_rtvi_event(event_type, payload).
+RtviEmit = Callable[[str, Optional[Dict[str, Any]]], Awaitable[None]]
+
+
+def coerce_ui_action_text(
+    data: Optional[Dict[str, Any]], max_chars: int
+) -> Optional[str]:
+    """Validate + normalize a client ``ui-action`` message into the user-turn
+    text to inject. Returns ``None`` when the ``msg`` field is missing, not a
+    string, or blank. Trims whitespace and caps length (mirrors the tts-speak
+    truncation contract). See docs/widget/VOICE_AS_CHAT.md (A2)."""
+    text = (data or {}).get("msg", "")
+    if not isinstance(text, str) or not text.strip():
+        return None
+    return text.strip()[:max_chars]
+
+
+class VoiceUiStreamProcessor(FrameProcessor):
+    """Tap streamed LLM text, route ``<ui_stream>`` ops to RTVI, and forward
+    only marker-stripped prose downstream to TTS + the assistant aggregator."""
+
+    def __init__(
+        self,
+        *,
+        emit: RtviEmit,
+        allowlist: Set[str],
+        name: str = "VoiceUiStreamProcessor",
+    ) -> None:
+        super().__init__(name=name)
+        self._emit = emit
+        self._allowlist = allowlist
+        # Per-assistant-response state, reset on LLMFullResponseStartFrame. A
+        # voice call is one long session (chat gets a fresh ChatAgent per
+        # turn), so resetting per response keeps the id registry from growing
+        # unbounded over a long call (VOICE_AS_CHAT.md A1.3).
+        self._extractor = UiStreamExtractor()
+        self._known_ids: Set[str] = set()
+
+    async def process_frame(self, frame: Frame, direction: FrameDirection) -> None:
+        await super().process_frame(frame, direction)
+
+        if isinstance(frame, LLMFullResponseStartFrame):
+            self._extractor = UiStreamExtractor()
+            self._known_ids = set()
+            await self.push_frame(frame, direction)
+            return
+
+        if isinstance(frame, LLMTextFrame):
+            await self._handle_text(frame.text, direction)
+            return
+
+        if isinstance(frame, LLMFullResponseEndFrame):
+            # Drain residual prose held in the extractor's carry buffer before
+            # forwarding the end-of-response boundary, so trailing prose reaches
+            # TTS ahead of the boundary frame.
+            for item in self._extractor.flush():
+                if isinstance(item, TextOut) and item.value:
+                    await self.push_frame(LLMTextFrame(text=item.value), direction)
+            await self.push_frame(frame, direction)
+            return
+
+        await self.push_frame(frame, direction)
+
+    async def _handle_text(self, text: str, direction: FrameDirection) -> None:
+        if not text:
+            return
+        # Healer mutates ctx.known_ids (dedupe); process_op_line mutates the
+        # same set (root-anchor + add/remove tracking) — they MUST share one
+        # set, exactly as chat wires it (chat/agent.py _cycle_loop).
+        healer = make_healer_fn(
+            HealerContext(session_data={}, known_ids=self._known_ids)
+        )
+        for item in self._extractor.feed(text):
+            if isinstance(item, TextOut):
+                # Prose (markers stripped) → forward as an LLMTextFrame so TTS
+                # speaks it AND the downstream assistant aggregator records it
+                # (it keys on LLMTextFrame, not plain TextFrame).
+                if item.value:
+                    await self.push_frame(LLMTextFrame(text=item.value), direction)
+                continue
+            # JsonlOpLine → chat-identical heal/parse/validate → RTVI ui-op.
+            for ev in process_op_line(
+                item.raw,
+                session_state={},
+                healer=healer,
+                known_ids=self._known_ids,
+                allowlist=self._allowlist,
+            ):
+                if ev.event == "ui_op":
+                    op = ev.data.get("op") if isinstance(ev.data, dict) else None
+                    if isinstance(op, dict):
+                        await self._emit("ui-op", {"op": op})
+                elif ev.event == "ui_op_dropped":
+                    logger.debug(f"[voice-ui] op dropped: {ev.data}")

--- a/app/ai/voice/agents/breeze_buddy/template/interruption.py
+++ b/app/ai/voice/agents/breeze_buddy/template/interruption.py
@@ -26,7 +26,6 @@ from pipecat.turns.user_start import (
 )
 from pipecat.turns.user_stop import SpeechTimeoutUserTurnStopStrategy
 from pipecat.turns.user_turn_strategies import UserTurnStrategies
-from pipecat.utils.asyncio.task_manager import BaseTaskManager
 
 from app.ai.voice.agents.breeze_buddy.template.context import TemplateContext
 from app.ai.voice.agents.breeze_buddy.template.types import (
@@ -34,56 +33,6 @@ from app.ai.voice.agents.breeze_buddy.template.types import (
     InterruptionMode,
 )
 from app.core.logger import logger
-
-# Duration for the sentinel timer (24 hours). This timer exists solely to keep
-# _timeout_task non-None so Pipecat's fallback check (line 201 in
-# speech_timeout_user_turn_stop_strategy.py) doesn't fire immediately.
-_SENTINEL_DURATION_SECS = 86400
-
-
-class AccumulatingSpeechTimeoutStrategy(SpeechTimeoutUserTurnStopStrategy):
-    """Stop strategy that reliably supports multi-turn input collection.
-
-    Pipecat's SpeechTimeoutUserTurnStopStrategy has a bug in the no-VAD
-    fallback path: after a turn completes (timer fires → finally block sets
-    _timeout_task = None), the NEXT turn's first finalized transcript hits:
-
-        if self._timeout_task is None:
-            await self.trigger_user_turn_stopped()      # line 201
-
-    This triggers immediately, ignoring user_speech_timeout. The Phase 1
-    sentinel hack only protected the first turn after update_strategies().
-
-    Fix: override setup() and reset() to always re-seed a long-duration
-    sentinel timer when user_speech_timeout > 0, guaranteeing _timeout_task
-    is never None at the start of any turn. The sentinel is harmlessly
-    cancelled and replaced by the real timer on the first transcript.
-
-    When user_speech_timeout == 0, behaves identically to the base class
-    (immediate trigger on finalized transcript is the desired behavior).
-    """
-
-    async def setup(self, task_manager: BaseTaskManager):
-        await super().setup(task_manager)
-        self._seed_sentinel()
-
-    async def reset(self):
-        await super().reset()
-        self._seed_sentinel()
-
-    def _seed_sentinel(self):
-        """Seed a long-duration sentinel timer to keep _timeout_task non-None.
-
-        Only seeds when user_speech_timeout > 0 (collection mode) and no
-        timer is already running. The sentinel sleeps for 24 hours and is
-        cancelled by the fallback code in _handle_transcription() on the
-        first real transcript, which replaces it with the actual timer.
-        """
-        if self._user_speech_timeout > 0 and self._timeout_task is None:
-            self._timeout_task = self.task_manager.create_task(
-                self._timeout_handler(_SENTINEL_DURATION_SECS),
-                f"{self}::sentinel_timeout",
-            )
 
 
 async def reset_interruption_to_default(
@@ -273,13 +222,14 @@ async def _apply_interruption_config(
     else:
         start_strategies.append(TranscriptionUserTurnStartStrategy(use_interim=True))
 
-    # Use AccumulatingSpeechTimeoutStrategy which re-seeds the sentinel
-    # timer after every reset(), fixing the multi-turn _timeout_task=None bug.
-    # For user_speech_timeout=0, it behaves identically to the base class.
+    # pipecat 1.1.0's SpeechTimeoutUserTurnStopStrategy handles the no-VAD
+    # multi-turn case natively (per-turn reset + independent wait flags), so the
+    # turn ends after user_speech_timeout seconds of silence following the last
+    # transcript. user_speech_timeout=0 fires immediately on a finalized transcript.
     new_strategies = UserTurnStrategies(
         start=start_strategies,
         stop=[
-            AccumulatingSpeechTimeoutStrategy(user_speech_timeout=user_speech_timeout)
+            SpeechTimeoutUserTurnStopStrategy(user_speech_timeout=user_speech_timeout)
         ],
     )
 

--- a/app/ai/voice/agents/breeze_buddy/template/session_state.py
+++ b/app/ai/voice/agents/breeze_buddy/template/session_state.py
@@ -343,13 +343,12 @@ def _is_tool_success(tool_result: Any) -> bool:
 def _voice_state_session_id(bot_instance: Any) -> str:
     """Best-effort session id for inject_tool_args' eval context (voice path).
 
-    Prefers the widget chat_session id (widget-resume), falls back to the
-    lead id / call_sid. Used only for the ``{session_id}`` eval var + the
-    idempotency-hash discriminator — never a correctness key on voice.
+    Used by the AGENT-mode global-function / MCP tool wrappers (telephony +
+    non-widget daily) for the ``{session_id}`` eval var + the idempotency-hash
+    discriminator — never a correctness key on voice. Falls back lead id →
+    call_sid. (Widget voice now runs stream mode through the chat brain, which
+    owns its own session id, so there's no widget-resume seed to prefer here.)
     """
-    seed = getattr(bot_instance, "_widget_resume_seed", None)
-    if isinstance(seed, dict) and seed.get("widget_session_id"):
-        return str(seed["widget_session_id"])
     lead = getattr(bot_instance, "lead", None)
     if lead is not None and getattr(lead, "id", None):
         return str(lead.id)

--- a/app/ai/voice/agents/breeze_buddy/template/types.py
+++ b/app/ai/voice/agents/breeze_buddy/template/types.py
@@ -278,6 +278,7 @@ class TTSProvider(str, Enum):
     CARTESIA = "cartesia"
     SARVAM = "sarvam"
     GEMINI = "gemini"
+    GOOGLE = "google"
     SONIOX = "soniox"
 
 
@@ -333,11 +334,18 @@ class TTSConfig(BaseModel):
             "model": "tts-rt-v1",
             "language": "en"
         }
+
+    Example (Google Cloud TTS — Chirp 3 HD):
+        {
+            "provider": "google",
+            "voice_id": "en-IN-Chirp3-HD-Despina",
+            "language": "en-IN"
+        }
     """
 
     provider: TTSProvider = Field(
         ...,
-        description="TTS provider (elevenlabs, cartesia, sarvam, gemini, soniox)",
+        description="TTS provider (elevenlabs, cartesia, sarvam, gemini, google, soniox)",
     )
     voice_id: Optional[str] = Field(None, description="Provider-specific voice ID")
     model: Optional[str] = Field(

--- a/app/ai/voice/agents/breeze_buddy/tts/__init__.py
+++ b/app/ai/voice/agents/breeze_buddy/tts/__init__.py
@@ -8,28 +8,36 @@ from app.ai.voice.agents.breeze_buddy.template.types import (
     TTSConfig,
     TTSProvider,
 )
+from app.ai.voice.agents.breeze_buddy.tts.emoji_filter import (
+    EmojiTextFilter,
+    strip_emojis,
+)
 from app.ai.voice.agents.breeze_buddy.utils.common import convert_to_mulaw
 from app.ai.voice.tts import (
     CartesiaConfig,
     ElevenLabsConfig,
     GeminiConfig,
+    GoogleConfig,
     SarvamTTSConfig,
     SonioxTTSConfig,
     build_cartesia_tts,
     build_elevenlabs_tts,
     build_gemini_tts,
+    build_google_tts,
     build_sarvam_tts,
     build_soniox_tts,
 )
 from app.ai.voice.tts.cartesia import _generate_cartesia_audio
 from app.ai.voice.tts.elevenlabs import _generate_elevenlabs_audio
 from app.ai.voice.tts.gemini import _generate_gemini_audio
+from app.ai.voice.tts.google import _generate_google_audio
 from app.ai.voice.tts.sarvam import _generate_sarvam_audio
 from app.ai.voice.tts.soniox import _generate_soniox_audio
 from app.core.config.dynamic import (
     BB_AGGREGATE_SENTENCES,
     BB_ENABLE_ELEVENLABS_INDIAN_RESIDENCY,
     BB_SARVAM_TTS_ENABLE_PREPROCESSING,
+    BB_STRIP_EMOJIS_FROM_TTS,
     BB_TTS_SERVICE,
     BB_VOICE_PROVIDER_DEFAULTS,
 )
@@ -123,6 +131,13 @@ async def get_tts_service(voice_config: TTSConfig):
         f"model={voice_config.model}, speed={voice_config.speed}, language={voice_config.language}"
     )
 
+    # Emoji stripping applies to EVERY provider/flow. pipecat runs these filters
+    # only on the string sent to the TTS provider (incl. TTSSpeakFrame used by
+    # the widget stream mode + fillers); the transcript frame keeps its emoji.
+    text_filters: list = []
+    if await BB_STRIP_EMOJIS_FROM_TTS():
+        text_filters.append(EmojiTextFilter())
+
     if provider == "elevenlabs":
         use_indian_residency = await BB_ENABLE_ELEVENLABS_INDIAN_RESIDENCY()
         if use_indian_residency and not ELEVENLABS_INDIAN_RESIDENCY_API_KEY:
@@ -152,6 +167,7 @@ async def get_tts_service(voice_config: TTSConfig):
                 speed=voice_config.speed or 1.0,
                 language=_parse_language(voice_config.language, Language.EN_IN),
                 aggregate_sentences=aggregate,
+                text_filters=text_filters,
             )
         )
 
@@ -175,6 +191,7 @@ async def get_tts_service(voice_config: TTSConfig):
                 language=_parse_language(voice_config.language),
                 generation_config=generation_config,
                 aggregate_sentences=aggregate,
+                text_filters=text_filters,
             )
         )
 
@@ -193,6 +210,7 @@ async def get_tts_service(voice_config: TTSConfig):
                 pitch=voice_config.pitch or 0.0,
                 pace=voice_config.speed or 0.9,
                 enable_preprocessing=enable_preprocessing,
+                text_filters=text_filters,
             )
         )
 
@@ -207,6 +225,23 @@ async def get_tts_service(voice_config: TTSConfig):
                 language=_parse_language(voice_config.language, Language.EN_IN),
                 style_prompt=getattr(voice_config, "style_prompt", None),
                 credentials=GOOGLE_CREDENTIALS_JSON,
+                text_filters=text_filters,
+            )
+        )
+
+    elif provider == "google":
+        if not GOOGLE_CREDENTIALS_JSON:
+            raise ValueError("GOOGLE_CREDENTIALS_JSON is required for Google TTS")
+
+        # Chirp 3 HD: the voice name (e.g. en-IN-Chirp3-HD-Despina) encodes both
+        # the model and locale, so there is no model field. Language should match
+        # the voice's locale prefix; default to EN_IN.
+        return build_google_tts(
+            GoogleConfig(
+                voice_id=voice_config.voice_id or "en-IN-Chirp3-HD-Despina",
+                language=_parse_language(voice_config.language, Language.EN_IN),
+                credentials=GOOGLE_CREDENTIALS_JSON,
+                text_filters=text_filters,
             )
         )
 
@@ -223,6 +258,7 @@ async def get_tts_service(voice_config: TTSConfig):
                 model=voice_config.model or "tts-rt-v1",
                 language=_parse_language(voice_config.language, Language.EN),
                 aggregate_sentences=aggregate,
+                text_filters=text_filters,
             )
         )
 
@@ -251,6 +287,12 @@ async def generate_audio(
     overrides = configurations.tts_configuration_overrides if configurations else None
     resolved = await resolve_voice_config(voice_config, overrides)
     provider = resolved.provider.value
+
+    # Batch synth calls the provider API directly, bypassing the pipecat TTS
+    # service (and its EmojiTextFilter), so strip emoji here too. The caller
+    # stores the display text separately — the greeting bubble keeps its emoji.
+    if await BB_STRIP_EMOJIS_FROM_TTS():
+        text = strip_emojis(text)
 
     if provider == "sarvam":
         audio_data = await _generate_sarvam_audio(
@@ -287,6 +329,14 @@ async def generate_audio(
             style_prompt=getattr(resolved, "style_prompt", None),
         )
         # _generate_gemini_audio already downsamples to 16 kHz PCM
+        input_format = "raw"
+    elif provider == "google":
+        audio_data = await _generate_google_audio(
+            text=text,
+            voice_id=resolved.voice_id,
+            language=resolved.language,
+        )
+        # _generate_google_audio already downsamples to 16 kHz PCM
         input_format = "raw"
     elif provider == "soniox":
         audio_data = await _generate_soniox_audio(

--- a/app/ai/voice/agents/breeze_buddy/tts/emoji_filter.py
+++ b/app/ai/voice/agents/breeze_buddy/tts/emoji_filter.py
@@ -1,0 +1,113 @@
+"""Emoji stripping for Breeze Buddy TTS.
+
+Emojis read aloud by a TTS provider come out as noise ("grinning face with
+smiling eyes") or an awkward pause — never what we want spoken. This module
+removes them from the text handed to the synthesizer WITHOUT touching the text
+shown in the UI/transcript: it is wired in two places, both downstream of where
+the displayed copy is produced —
+
+  * as a pipecat ``BaseTextFilter`` on every TTS service (``get_tts_service``),
+    which the framework applies only to the string sent to the provider — the
+    ``AggregatedTextFrame`` pushed downstream for the transcript keeps the
+    original text (see pipecat ``TTSService._push_tts_frames``); and
+  * directly in the batch greeting synth (``generate_audio``), which calls the
+    provider HTTP/WS API and so bypasses the pipecat service.
+
+Covers every voice flow — telephony, Daily, and the widget stream mode
+(``TTSSpeakFrame`` goes through the same filter path).
+
+Transcript note: in the widget stream mode the displayed/persisted transcript
+is produced independently of TTS (the bridge's RTVI ``transcript`` event and the
+chat brain's ``chat_message`` rows), so it keeps its emoji. In the telephony /
+Daily full-agent pipeline the assistant context aggregator sits AFTER the TTS
+service, so the transcript stored in ``lead.metaData`` reflects the spoken
+(emoji-free) text — i.e. it matches the audio. Either way no emoji is voiced.
+"""
+
+import re
+from typing import Any, Mapping
+
+from pipecat.utils.text.base_text_filter import BaseTextFilter
+
+__all__ = ["strip_emojis", "EmojiTextFilter"]
+
+# Unicode blocks that are entirely emoji / pictographic symbols, plus the
+# invisible joiners and modifiers that glue emoji sequences together. None of
+# these ranges contain letters, digits, or ordinary punctuation, so removing
+# them is safe for ordinary prose.
+_EMOJI_PATTERN = re.compile(
+    "["
+    "\U0001f000-\U0001faff"  # mahjong/dominoes/cards, enclosed alnum/ideographic,
+    #                          emoticons, transport, alchemical, geometric-ext,
+    #                          arrows-C, supplemental & extended-A pictographs
+    "\U00002600-\U000026ff"  # miscellaneous symbols (☀ ☁ ⚡ ♻ …)
+    "\U00002700-\U000027bf"  # dingbats (✂ ✅ ✈ ✨ …)
+    "\U00002300-\U000023ff"  # misc technical (⌚ ⌛ ⏰ ⏳ ⏪ ⏩ …)
+    "\U00002b00-\U00002bff"  # misc symbols & arrows (⭐ ⬆ ⬇ ⬛ …)
+    "\U0000fe00-\U0000fe0f"  # variation selectors (emoji vs text presentation)
+    "\U0000200d"  # zero-width joiner (emoji sequences)
+    "\U000020e3"  # combining enclosing keycap (1️⃣ → 1)
+    "]+",
+    flags=re.UNICODE,
+)
+
+# A handful of emoji are encoded as <base char> + U+FE0F (variation selector-16)
+# where the BASE scalar lives outside the blocks above (legacy symbols promoted
+# to emoji). Removing FE0F alone would leave the bare glyph to reach TTS, so we
+# drop the whole pair — but ONLY when FE0F is present, so legitimate prose like
+# "Breeze™" or a literal arrow/square keeps its bare base character.
+_VS16_EMOJI_PATTERN = re.compile(
+    "["
+    "‼⁉™ℹ"  # ‼ ⁉ ™ ℹ
+    "↔-↙"  # ↔ ↕ ↖ ↗ ↘ ↙
+    "↩↪"  # ↩ ↪
+    "Ⓜ"  # Ⓜ
+    "▪▫◻-◾"  # ▪ ▫ ◻ ◼ ◽ ◾
+    "⤴⤵"  # ⤴ ⤵
+    "〰〽"  # 〰 〽
+    "]️"  # only when emoji-qualified by VS16 (U+FE0F)
+)
+
+# Runs of spaces/tabs left where an emoji sat between words (e.g. "hi 😀 there").
+# Newlines are preserved so multi-line prosody is untouched.
+_INLINE_WS_RUN = re.compile(r"[ \t]{2,}")
+
+
+def strip_emojis(text: str) -> str:
+    """Remove emoji (and their joiners/modifiers) from ``text`` for TTS.
+
+    Collapses the double space an inter-word emoji leaves behind, but does NOT
+    trim leading/trailing whitespace: when streaming tokens the TTS pipeline may
+    hand us a single token whose surrounding space separates it from adjacent
+    tokens. An all-emoji chunk collapses to empty, which the pipeline's
+    post-filter whitespace gate drops without emitting audio.
+    """
+    if not text:
+        return text
+    # FE0F-qualified pairs first (atomic), then the dedicated emoji blocks +
+    # standalone joiners/modifiers/variation-selectors.
+    cleaned = _VS16_EMOJI_PATTERN.sub("", text)
+    cleaned = _EMOJI_PATTERN.sub("", cleaned)
+    if cleaned == text:
+        return text  # fast path — nothing removed, leave the string identical
+    return _INLINE_WS_RUN.sub(" ", cleaned)
+
+
+class EmojiTextFilter(BaseTextFilter):
+    """pipecat TTS text filter that drops emoji before synthesis.
+
+    Affects only the text sent to the TTS provider; the transcript/UI copy is
+    pushed downstream separately and keeps its emoji.
+    """
+
+    async def filter(self, text: str) -> str:
+        return strip_emojis(text)
+
+    async def update_settings(self, settings: Mapping[str, Any]) -> None:
+        """No configurable settings."""
+
+    async def handle_interruption(self) -> None:
+        """Stateless — nothing to reset on interruption."""
+
+    async def reset_interruption(self) -> None:
+        """Stateless — nothing to reset after interruption."""

--- a/app/ai/voice/tts/cartesia.py
+++ b/app/ai/voice/tts/cartesia.py
@@ -1,7 +1,7 @@
 """Cartesia TTS helpers and builder."""
 
-from dataclasses import dataclass
-from typing import Optional
+from dataclasses import dataclass, field
+from typing import Optional, Sequence
 
 import httpx
 from pipecat.services.cartesia.tts import CartesiaTTSService, GenerationConfig
@@ -37,6 +37,7 @@ class CartesiaConfig:
     language: Language = Language.EN
     generation_config: Optional[GenerationConfig] = None
     aggregate_sentences: bool = True
+    text_filters: Sequence = field(default_factory=list)
 
 
 def build_cartesia_tts(config: CartesiaConfig) -> CartesiaTTSService:
@@ -62,6 +63,7 @@ def build_cartesia_tts(config: CartesiaConfig) -> CartesiaTTSService:
             if config.aggregate_sentences
             else TextAggregationMode.TOKEN
         ),
+        text_filters=list(config.text_filters) if config.text_filters else None,
     )
 
 

--- a/app/ai/voice/tts/google.py
+++ b/app/ai/voice/tts/google.py
@@ -1,14 +1,33 @@
-"""Google TTS helpers and builder."""
+"""Google TTS helpers and builder.
+
+Uses GoogleTTSService from pipecat for real-time pipeline synthesis (Chirp 3
+HD voices) and Google Cloud's streaming TTS API directly for pre-call greeting
+synthesis.
+
+Google Chirp 3 HD outputs 24 kHz PCM.  The `_generate_google_audio` helper
+downsamples to 16 kHz before returning so it is compatible with the shared
+`convert_to_mulaw` path (which assumes 16 kHz raw PCM input).
+"""
 
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass
 from typing import Any, Optional, Sequence
 
+import numpy as np
+from google.cloud import texttospeech_v1
+from google.oauth2 import service_account
 from pipecat.services.google.tts import GoogleTTSService
 from pipecat.transcriptions.language import Language
 
-__all__ = ["GoogleConfig", "build_google_tts"]
+from app.core.config.static import GOOGLE_CREDENTIALS_JSON
+from app.core.logger import logger
+
+__all__ = ["GoogleConfig", "build_google_tts", "_generate_google_audio"]
+
+# Google Chirp 3 HD native streaming sample rate
+_GOOGLE_SAMPLE_RATE = 24_000
 
 
 @dataclass
@@ -32,3 +51,100 @@ def build_google_tts(config: GoogleConfig):
         credentials=config.credentials,
         text_filters=text_filters,
     )
+
+
+async def _generate_google_audio(
+    text: str,
+    voice_id: str | None = None,
+    language: str | None = None,
+) -> bytes:
+    """Synthesize audio via the Google Cloud streaming TTS API (Chirp 3 HD).
+
+    Uses the same streaming_synthesize RPC that GoogleTTSService uses inside the
+    pipeline, so the output is identical. Unlike Gemini, the Chirp voice name
+    (e.g. "en-IN-Chirp3-HD-Despina") encodes the model, so no model_name is set.
+
+    Args:
+        text: Text to synthesize.
+        voice_id: Chirp voice name. Defaults to "en-IN-Chirp3-HD-Despina".
+        language: BCP-47 language code (e.g. "en-IN"). Defaults to "en-IN" and
+            should match the voice's locale prefix.
+
+    Returns:
+        Raw PCM bytes (16-bit, mono, **16 kHz**) after downsampling from
+        Chirp's native 24 kHz output. Compatible with `convert_to_mulaw`
+        when called with `input_format="raw"`.
+
+    Raises:
+        ValueError: If GOOGLE_CREDENTIALS_JSON is not set.
+    """
+    credentials_json = GOOGLE_CREDENTIALS_JSON
+    if not credentials_json:
+        raise ValueError(
+            "GOOGLE_CREDENTIALS_JSON is required for Google TTS pre-synthesis"
+        )
+
+    final_voice = voice_id or "en-IN-Chirp3-HD-Despina"
+    final_language = language or "en-IN"
+
+    logger.info(
+        f"Pre-synthesizing Google audio: {text[:50]}... "
+        f"[voice={final_voice}, lang={final_language}]"
+    )
+
+    json_account_info = json.loads(credentials_json)
+    creds = service_account.Credentials.from_service_account_info(json_account_info)
+    client = texttospeech_v1.TextToSpeechAsyncClient(credentials=creds)
+
+    try:
+        # Chirp voice name selects the model — no model_name needed.
+        voice_params = texttospeech_v1.VoiceSelectionParams(
+            language_code=final_language,
+            name=final_voice,
+        )
+
+        streaming_config = texttospeech_v1.StreamingSynthesizeConfig(
+            voice=voice_params,
+            streaming_audio_config=texttospeech_v1.StreamingAudioConfig(
+                audio_encoding=texttospeech_v1.AudioEncoding.PCM,
+                sample_rate_hertz=_GOOGLE_SAMPLE_RATE,
+            ),
+        )
+
+        async def _request_generator():
+            yield texttospeech_v1.StreamingSynthesizeRequest(
+                streaming_config=streaming_config
+            )
+            yield texttospeech_v1.StreamingSynthesizeRequest(
+                input=texttospeech_v1.StreamingSynthesisInput(text=text)
+            )
+
+        chunks: list[bytes] = []
+        streaming_responses = await client.streaming_synthesize(_request_generator())
+        async for response in streaming_responses:
+            if response.audio_content:
+                chunks.append(response.audio_content)
+
+        pcm_24k = b"".join(chunks)
+
+        if not pcm_24k:
+            raise RuntimeError(
+                "Google TTS returned empty audio — check credentials and voice settings"
+            )
+
+        # Ensure whole-frame alignment before resampling (16-bit = 2 bytes/frame)
+        if len(pcm_24k) % 2 != 0:
+            pcm_24k += b"\x00"
+
+        # Downsample 24 kHz → 16 kHz via linear interpolation (no scipy needed).
+        samples = np.frombuffer(pcm_24k, dtype=np.int16).astype(np.float32)
+        out_len = len(samples) * 16_000 // _GOOGLE_SAMPLE_RATE
+        indices = np.linspace(0, len(samples) - 1, out_len)
+        lo = np.floor(indices).astype(np.int32)
+        hi = np.minimum(lo + 1, len(samples) - 1)
+        frac = (indices - lo).astype(np.float32)
+        resampled = samples[lo] + frac * (samples[hi] - samples[lo])
+        pcm_16k = np.clip(resampled, -32768, 32767).astype(np.int16).tobytes()
+        return pcm_16k
+    finally:
+        await client.transport.grpc_channel.close()  # type: ignore[union-attr]

--- a/app/ai/voice/tts/sarvam.py
+++ b/app/ai/voice/tts/sarvam.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 import base64
-from dataclasses import dataclass
-from typing import Optional
+from dataclasses import dataclass, field
+from typing import Optional, Sequence
 
 import httpx
 from pipecat.services.sarvam.tts import SarvamTTSService
@@ -36,6 +36,7 @@ class SarvamTTSConfig:
     pace: float
     language_code: Optional[str] = None
     enable_preprocessing: bool = True
+    text_filters: Sequence = field(default_factory=list)
 
 
 def get_sarvam_language(language_code: Optional[str]) -> Language:
@@ -76,6 +77,7 @@ def build_sarvam_tts(config: SarvamTTSConfig):
             pace=config.pace,
             enable_preprocessing=config.enable_preprocessing,
         ),
+        text_filters=list(config.text_filters) if config.text_filters else None,
     )
 
 

--- a/app/ai/voice/tts/soniox.py
+++ b/app/ai/voice/tts/soniox.py
@@ -12,8 +12,8 @@ from __future__ import annotations
 import asyncio
 import base64
 import json
-from dataclasses import dataclass
-from typing import Optional
+from dataclasses import dataclass, field
+from typing import Optional, Sequence
 
 from pipecat.services.soniox.tts import (
     SonioxTTSService,
@@ -53,6 +53,7 @@ class SonioxTTSConfig:
     sample_rate: int = 16000
     audio_format: str = "pcm_s16le"
     aggregate_sentences: bool = True
+    text_filters: Sequence = field(default_factory=list)
 
 
 def build_soniox_tts(config: SonioxTTSConfig) -> SonioxTTSService:
@@ -83,6 +84,7 @@ def build_soniox_tts(config: SonioxTTSConfig) -> SonioxTTSService:
             if config.aggregate_sentences
             else TextAggregationMode.TOKEN
         ),
+        text_filters=list(config.text_filters) if config.text_filters else None,
     )
 
 

--- a/app/api/routers/breeze_buddy/chat/handlers.py
+++ b/app/api/routers/breeze_buddy/chat/handlers.py
@@ -8,35 +8,30 @@ stay thin: validate auth, then delegate.
 
 import asyncio
 import time
-from datetime import datetime, timezone
-from typing import Any, AsyncIterator, Callable, Dict, List, Optional, cast
+from datetime import datetime
+from typing import Any, AsyncIterator, Callable, Dict, List, Optional
 
 from fastapi import HTTPException, status
 from fastapi.responses import StreamingResponse
 
-from app.ai.voice.agents.breeze_buddy.chat.agent import ChatAgent
 from app.ai.voice.agents.breeze_buddy.chat.approvals import (
-    EXPIRED_RESULT,
     WIRE_STATUS_BY_DB_STATUS,
-    resolve_dangling_approvals,
+    claim_tool_approval,
 )
 from app.ai.voice.agents.breeze_buddy.chat.block_codec import (
-    blocks_to_llm_context_messages,
     filter_visible_blocks,
-    repair_dangling_tool_uses,
-    tool_results_to_user_blocks,
 )
 from app.ai.voice.agents.breeze_buddy.chat.client_context import (
     ClientContextTooLarge,
     compute_context_patch,
-    merge_context_into,
 )
 from app.ai.voice.agents.breeze_buddy.chat.metrics import TurnMetrics
 from app.ai.voice.agents.breeze_buddy.chat.sse import SSEEvent, format_sse
-from app.ai.voice.agents.breeze_buddy.llm import get_llm_service
-from app.ai.voice.agents.breeze_buddy.template.approval import (
-    LLM_STATUS_DENIED,
-    WIRE_STATUS_SUPERSEDED,
+from app.ai.voice.agents.breeze_buddy.chat.turn_core import (
+    build_render_template_vars,
+    resolve_llm_configuration,
+    run_chat_approval_continuation,
+    run_chat_turn,
 )
 from app.ai.voice.agents.breeze_buddy.template.cache import get_template_by_id_cached
 from app.ai.voice.agents.breeze_buddy.template.transformation_function import (
@@ -44,7 +39,6 @@ from app.ai.voice.agents.breeze_buddy.template.transformation_function import (
 )
 from app.ai.voice.agents.breeze_buddy.template.types import TemplateModel
 from app.api.routers.breeze_buddy.analytics.rbac import apply_hierarchical_filters
-from app.core.config.dynamic import CHAT_HISTORY_REPLAY_LIMIT
 from app.core.logger import logger
 from app.database.accessor.breeze_buddy.chat_session import (
     count_chat_sessions,
@@ -58,14 +52,6 @@ from app.database.accessor.breeze_buddy.chat_session import (
     list_chat_turn_metrics_for_session,
     merge_client_context,
     record_chat_turn_metrics,
-)
-from app.database.accessor.breeze_buddy.credentials import (
-    get_credentials_as_template_vars,
-)
-from app.database.accessor.breeze_buddy.tool_approvals import (
-    decide_tool_approval,
-    get_tool_approval,
-    list_pending_tool_approvals,
 )
 from app.schemas import UserInfo
 from app.schemas.breeze_buddy.chat import (
@@ -237,29 +223,6 @@ def _apply_payload_transformations(
     return out
 
 
-async def _build_render_template_vars(
-    template: TemplateModel, persisted: Optional[Dict[str, Any]]
-) -> Dict[str, Any]:
-    """Build the per-turn render context. Same precedence as voice:
-    credentials < template.secrets < persisted payload values.
-    """
-    merged: Dict[str, Any] = {}
-    try:
-        creds = await get_credentials_as_template_vars(template.reseller_id)
-        if creds:
-            merged.update(creds)
-    except Exception as exc:
-        logger.warning(
-            f"chat: failed to load credentials for reseller "
-            f"{template.reseller_id}: {exc}"
-        )
-    if template.secrets:
-        merged.update(template.secrets)
-    if persisted:
-        merged.update(persisted)
-    return merged
-
-
 # ---------------------------------------------------------------------------
 # Shared validators
 # ---------------------------------------------------------------------------
@@ -282,21 +245,12 @@ def validate_template_for_chat(template: TemplateModel) -> None:
             ),
         )
 
-    llm_cfg = _resolve_llm_configuration(template)
+    llm_cfg = resolve_llm_configuration(template)
     if llm_cfg is not None and getattr(llm_cfg, "realtime", False):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Realtime / speech-to-speech LLMs are not supported in chat mode.",
         )
-
-
-def _resolve_llm_configuration(template: TemplateModel):
-    """Pick out ``configurations.llm_configurations`` (the canonical path)
-    safely. Mirrors voice's access pattern (see ``agent/pipeline.py``)."""
-    configurations = getattr(template, "configurations", None)
-    if configurations is None:
-        return None
-    return getattr(configurations, "llm_configurations", None)
 
 
 def _render_initial_greeting(
@@ -386,7 +340,7 @@ async def create_chat_session_handler(
     # replay on the very first /message call. Render against the same
     # merged context turns will see, so a greeting that references a
     # credential / secret placeholder doesn't render with raw braces.
-    greeting_render_vars = await _build_render_template_vars(
+    greeting_render_vars = await build_render_template_vars(
         template, transformed_template_vars
     )
     greeting_text = _render_initial_greeting(template, greeting_render_vars)
@@ -492,65 +446,14 @@ async def send_chat_message_handler(
                 ),
             )
 
-        # HITL: a new user message supersedes every pending approval (the
-        # user moved on without deciding). MUST run under the lock and
-        # BEFORE the history load — it persists the synthetic tool_result
-        # rows that keep the replayed history fully answered. The resolved
-        # events ride at the start of this turn's stream so live cards
-        # flip to superseded without client-side inference.
-        # NOTE: requires migration 033 (tool_approvals) — run
-        # `python scripts/migrate.py up` before deploying this version.
-        superseded = await resolve_dangling_approvals(session_id, only_expired=False)
-        pre_events: List[SSEEvent] = [
-            SSEEvent(
-                event="function_approval_resolved",
-                data={
-                    "tool_call_id": row.tool_call_id,
-                    "status": WIRE_STATUS_SUPERSEDED,
-                    "reason": row.reason,
-                },
-            )
-            for row in superseded
-        ]
-
-        history_limit = await CHAT_HISTORY_REPLAY_LIMIT()
-        history_rows = await list_chat_messages_for_session(
-            session_id, limit=history_limit
-        )
-        # Replay the canonical Anthropic-shape blocks if present (post-
-        # migration 030), falling back to the denormalised prose for
-        # any legacy rows. Tool_use / tool_result blocks survive so the
-        # LLM sees its own prior identifiers (cart_id, etc.) verbatim.
-        history: list = blocks_to_llm_context_messages(
-            [
-                {
-                    "role": row.role.value,
-                    "content": row.content,
-                    "content_blocks": row.content_blocks,
-                }
-                for row in history_rows
-                if row.role in (ChatMessageRole.USER, ChatMessageRole.ASSISTANT)
-            ]
-        )
-        # Defensive both-direction repair: every pending approval was just
-        # resolved + persisted above, so nothing is legitimately dangling —
-        # any unmatched tool_use here is a decided-but-lost row (crash or
-        # cancel between claim and persist) and gets a synthetic error
-        # result; orphan tool_results from window truncation are dropped.
-        history = cast(list, repair_dangling_tool_uses(history))
-
-        # Load per-session agent state (cart_id, customer_id, etc. for
-        # commerce templates). Generic — the runtime doesn't read the
-        # keys; the template's tool_arg_injection rules do.
-        state_row = await get_agent_session_state(session_id)
-        agent_state: Dict[str, Any] = state_row.data if state_row else {}
-
         # Piggyback context patch (CLIENT_CONTEXT_UPDATES.md §5.2): an
-        # optional state/facts update riding with this message. Applied +
-        # persisted under the same lock BEFORE the turn builds, so it's
-        # effective on THIS turn (vs. the standalone /context endpoint, which
-        # lands on the next turn). Allowlist-gated by the template policy; an
-        # unconfigured template silently no-ops.
+        # optional state/facts update riding with this message. Persisted
+        # under the lock BEFORE the turn builds, so ``run_chat_turn`` re-reads
+        # it on THIS turn (vs. the standalone /context endpoint, which lands
+        # next turn). Allowlist-gated by the template policy; an unconfigured
+        # template silently no-ops. The 413 must surface here, before the SSE
+        # stream opens, so this validation stays in the HTTP shell (voice
+        # never sends a piggyback context, so run_chat_turn omits it).
         context_placement: Optional[str] = None
         if req.context is not None:
             cc_config = (
@@ -558,6 +461,8 @@ async def send_chat_message_handler(
                 if template.configurations
                 else None
             )
+            state_row = await get_agent_session_state(session_id)
+            agent_state: Dict[str, Any] = state_row.data if state_row else {}
             try:
                 state_patch, facts_patch, replace_facts, _, _ = compute_context_patch(
                     agent_state,
@@ -571,16 +476,13 @@ async def send_chat_message_handler(
                     status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
                     detail=str(exc),
                 ) from exc
-            # Update the in-memory state so THIS turn sees the context...
-            agent_state = merge_context_into(
-                agent_state, state_patch, facts_patch, replace_facts
-            )
-            # ...and persist via the atomic merge (message-bound, no revision)
-            # so a concurrent standalone /context push isn't clobbered. The
-            # turn's own write (agent.py) excludes the client-context keys.
-            # ``facts_patch`` is None only when the push carried no facts; an
-            # empty {} (a merge='replace' facts clear) IS a real write, so gate
-            # on ``is not None`` — truthiness would silently drop the clear.
+            # Persist via the atomic merge (message-bound, no revision) so a
+            # concurrent standalone /context push isn't clobbered; the turn's
+            # own write (agent.py) excludes the client-context keys.
+            # ``run_chat_turn`` re-loads agent_state below, so it sees this
+            # patch on THIS turn. ``facts_patch`` is None only when the push
+            # carried no facts; an empty {} (a merge='replace' facts clear) IS
+            # a real write, so gate on ``is not None``.
             if state_patch or facts_patch is not None:
                 await merge_client_context(
                     session_id,
@@ -591,38 +493,6 @@ async def send_chat_message_handler(
                 )
             context_placement = req.context.placement
 
-        persisted_template_vars = (
-            fresh.metadata.get("template_vars", {})
-            if isinstance(fresh.metadata, dict)
-            else {}
-        )
-        # Voice's loader merges credentials + template.secrets + payload
-        # values on every call (template/loader.py:125-183). Chat now does
-        # the same per-turn so HTTP/global function ``{placeholder}``
-        # resolution and prompt rendering see credentials/secrets the
-        # same way they would on voice. Doing it per-turn (not at session-
-        # create) keeps rotated credentials and updated secrets effective
-        # without resuming the session.
-        template_vars = await _build_render_template_vars(
-            template, persisted_template_vars
-        )
-
-        # Chat-only opt-in to the shared LLM client (Azure HTTP/2 pool,
-        # Claude-on-Vertex client + token cache). Voice uses fresh per-call
-        # services — subprocess-per-call gets nothing from sharing.
-        llm = await get_llm_service(_resolve_llm_configuration(template), pooled=True)
-        agent = ChatAgent(
-            session_id=session_id,
-            template=template,
-            llm=llm,
-            template_vars=template_vars,
-            agent_state=agent_state,
-            context_placement=context_placement,
-        )
-        # Snapshot into a local so the closure below doesn't have to rely
-        # on Optional narrowing surviving the boundary.
-        resume_node = fresh.current_node
-
         # Phase-0 measurement (docs/widget/UI_FAST_RELIABLE_GENERIC_PLAN.md):
         # observe the turn's SSE stream and log one [CHAT_METRICS] line at the
         # end. Passive — never mutates the events the widget receives.
@@ -632,17 +502,21 @@ async def send_chat_message_handler(
             t0=time.monotonic(),
         )
 
+        # The brain — approval supersede, history replay + repair, agent_state
+        # load, template-var render, ChatAgent drive — lives in
+        # ``run_chat_turn``, the SAME generator the widget voice bridge drives.
+        # This handler is just the HTTP shell: lock + access-check + 410/413
+        # gating + SSE wrapping.
         response = StreamingResponse(
             _turn_sse_stream(
                 session_id=session_id,
                 lock=lock,
                 turn_metrics=turn_metrics,
-                events=agent.run_turn(
+                events=run_chat_turn(
+                    session_id=session_id,
                     user_content=req.content,
-                    history=history,
-                    current_node=resume_node,
+                    context_placement=context_placement,
                 ),
-                pre_events=pre_events,
             ),
             media_type="text/event-stream",
             headers={
@@ -850,8 +724,13 @@ async def approve_chat_tool_handler(
                 ),
             )
 
-        row = await get_tool_approval(session_id, req.tool_call_id)
-        if row is None:
+        # Atomically claim the decision (PENDING-only; expiry → timeout;
+        # synthetic deny/timeout result + sibling sweep persisted under the
+        # lock). The SAME claim the voice bridge uses — see claim_tool_approval.
+        claim = await claim_tool_approval(
+            session_id, req.tool_call_id, req.approved, req.reason
+        )
+        if claim.outcome == "not_found":
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,
                 detail=(
@@ -859,71 +738,15 @@ async def approve_chat_tool_handler(
                     f"'{req.tool_call_id}' for this session"
                 ),
             )
-        if row.status != ToolApprovalStatus.PENDING:
+        if claim.outcome == "already_decided":
             raise _approval_conflict(
                 "already_decided",
-                f"This approval was already resolved ({row.status.value}).",
-                WIRE_STATUS_BY_DB_STATUS.get(row.status),
+                "This approval was already resolved.",
+                claim.winning_status,
             )
 
-        is_expired = row.expires_at <= datetime.now(timezone.utc)
-        if is_expired:
-            new_status = ToolApprovalStatus.EXPIRED
-            decision_reason: Optional[str] = "decision arrived after expiry"
-        elif req.approved:
-            new_status = ToolApprovalStatus.APPROVED
-            decision_reason = req.reason
-        else:
-            new_status = ToolApprovalStatus.DENIED
-            decision_reason = req.reason
-
-        claimed = await decide_tool_approval(
-            session_id, req.tool_call_id, new_status, decision_reason
-        )
-        if claimed is None:
-            # Lost the claim race to a concurrent decision.
-            relook = await get_tool_approval(session_id, req.tool_call_id)
-            raise _approval_conflict(
-                "already_decided",
-                "This approval was already resolved by a concurrent request.",
-                WIRE_STATUS_BY_DB_STATUS.get(relook.status) if relook else None,
-            )
-
-        effective_approved = req.approved and not is_expired
-        wire_status = WIRE_STATUS_BY_DB_STATUS[new_status]
-
-        logger.info(
-            f"[approval] session={session_id} tool_call_id={req.tool_call_id} "
-            f"function={claimed.function_name} decision={new_status.value}"
-            + (f" reason={decision_reason!r}" if decision_reason else "")
-        )
-
-        synthetic_result: Optional[Dict[str, Any]] = None
-        if not effective_approved:
-            synthetic_result = (
-                dict(EXPIRED_RESULT)
-                if is_expired
-                else {
-                    "status": LLM_STATUS_DENIED,
-                    "reason": req.reason or "the user did not approve this action",
-                }
-            )
-            # Persist under the lock, before streaming — the history load
-            # below already sees a fully-answered batch for this call.
-            await insert_chat_message(
-                session_id=session_id,
-                role=ChatMessageRole.USER,
-                content=None,
-                content_blocks=tool_results_to_user_blocks(
-                    [(req.tool_call_id, synthetic_result)]
-                ),
-            )
-
-        # Lazily expire the OTHER pending rows past their TTL (persists
-        # their synthetic timeout results) and surface them at stream start.
-        expired_siblings = await resolve_dangling_approvals(
-            session_id, only_expired=True
-        )
+        # Expired siblings (swept during the claim) ride at stream start so the
+        # widget flips their cards to timeout without client-side inference.
         pre_events: List[SSEEvent] = [
             SSEEvent(
                 event="function_approval_resolved",
@@ -933,65 +756,8 @@ async def approve_chat_tool_handler(
                     "reason": sib.reason,
                 },
             )
-            for sib in expired_siblings
+            for sib in claim.expired_siblings
         ]
-
-        # include_expired: a sibling whose expires_at falls between the
-        # sweep above and this statement is still PENDING and decidable —
-        # it must stay in the exclude set (and keep the turn awaiting)
-        # rather than getting a fabricated "lost" answer; the next touch
-        # lazily expires it.
-        pending_siblings = await list_pending_tool_approvals(
-            session_id, include_expired=True
-        )
-        pending_sibling_ids = [sib.tool_call_id for sib in pending_siblings]
-
-        history_limit = await CHAT_HISTORY_REPLAY_LIMIT()
-        history_rows = await list_chat_messages_for_session(
-            session_id, limit=history_limit
-        )
-        history: list = blocks_to_llm_context_messages(
-            [
-                {
-                    "role": hist_row.role.value,
-                    "content": hist_row.content,
-                    "content_blocks": hist_row.content_blocks,
-                }
-                for hist_row in history_rows
-                if hist_row.role in (ChatMessageRole.USER, ChatMessageRole.ASSISTANT)
-            ]
-        )
-        # The claimed call (approve path answers it in-turn) and the
-        # still-pending siblings must STAY unanswered; anything else
-        # unmatched is decided-but-lost and gets a synthetic error.
-        history = cast(
-            list,
-            repair_dangling_tool_uses(
-                history, exclude_ids={req.tool_call_id, *pending_sibling_ids}
-            ),
-        )
-
-        state_row = await get_agent_session_state(session_id)
-        agent_state: Dict[str, Any] = state_row.data if state_row else {}
-
-        persisted_template_vars = (
-            fresh.metadata.get("template_vars", {})
-            if isinstance(fresh.metadata, dict)
-            else {}
-        )
-        template_vars = await _build_render_template_vars(
-            template, persisted_template_vars
-        )
-
-        llm = await get_llm_service(_resolve_llm_configuration(template), pooled=True)
-        agent = ChatAgent(
-            session_id=session_id,
-            template=template,
-            llm=llm,
-            template_vars=template_vars,
-            agent_state=agent_state,
-        )
-        resume_node = fresh.current_node
 
         turn_metrics = TurnMetrics(
             session_id=session_id,
@@ -1004,15 +770,14 @@ async def approve_chat_tool_handler(
                 session_id=session_id,
                 lock=lock,
                 turn_metrics=turn_metrics,
-                events=agent.run_approval_turn(
-                    approval=claimed,
-                    approved=effective_approved,
-                    wire_status=wire_status,
-                    decision_reason=decision_reason,
-                    synthetic_result=synthetic_result,
-                    history=history,
-                    current_node=resume_node,
-                    pending_sibling_ids=pending_sibling_ids,
+                events=run_chat_approval_continuation(
+                    session_id=session_id,
+                    claimed=claim.claimed,
+                    effective_approved=claim.effective_approved,
+                    wire_status=claim.wire_status,
+                    decision_reason=claim.decision_reason,
+                    synthetic_result=claim.synthetic_result,
+                    pending_sibling_ids=claim.pending_sibling_ids,
                 ),
                 pre_events=pre_events,
             ),

--- a/app/api/routers/breeze_buddy/widget/handlers.py
+++ b/app/api/routers/breeze_buddy/widget/handlers.py
@@ -180,6 +180,19 @@ def _extract_widget_config(
     return quick_replies, enable_text_input
 
 
+def _template_voice_enabled(template: object) -> bool:
+    """Whether the widget should offer a voice mode for this template.
+
+    True ⇔ ``'voice'`` is in ``template.supported_channels``. Mirrors the
+    /voice/connect gate exactly — including its default-to-voice-enabled
+    behavior when the list is unset/empty (legacy templates predate the
+    field) — so the button the embed shows and the connect the server accepts
+    never disagree. The server stays the enforcement point; this flag is UX.
+    """
+    supported = list(getattr(template, "supported_channels", []) or []) or ["voice"]
+    return "voice" in supported
+
+
 # ---------------------------------------------------------------------------
 # POST /widget/session
 # ---------------------------------------------------------------------------
@@ -250,6 +263,7 @@ async def create_widget_session_handler(
         ttl_seconds=DEFAULT_WIDGET_TOKEN_TTL_MINUTES * 60,
         quick_replies=quick_replies,
         enable_text_input=enable_text_input,
+        voice_enabled=_template_voice_enabled(template),
     )
 
 
@@ -557,10 +571,7 @@ async def voice_connect_handler(
             detail="Widget template misconfigured",
         )
 
-    supported: List[str] = list(getattr(template, "supported_channels", []) or []) or [
-        "voice"
-    ]
-    if "voice" not in supported:
+    if not _template_voice_enabled(template):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Template does not include 'voice' in supported_channels.",
@@ -597,48 +608,29 @@ async def voice_connect_handler(
                 ),
             )
 
-        # ── Build seed -----------------------------------------------------
-        history = await list_chat_messages_for_session(session_id)
-        prior_history: List[Dict[str, Any]] = [
-            {"role": m.role.value, "content": m.content} for m in history if m.content
-        ]
-        seed_message_count = len(prior_history)
+        # ── Build lead payload + widget back-link --------------------------
+        # The chat brain (run_chat_turn) owns history, agent_state, and the
+        # current node — the stream-mode bot resumes them straight from the
+        # chat_session at turn time (no seed to carry, no end-of-call drain).
+        # The voice lead carries only what the voice runtime itself needs: the
+        # rendered template_vars (for {placeholder} resolution in
+        # load_template_config) and the widget_session_id back-link the bridge
+        # drives turns against (and end_conversation flips the channel on).
         template_vars: Dict[str, Any] = (
             session.metadata.get("template_vars", {})
             if isinstance(session.metadata, dict)
             else {}
         )
-
-        # ``payload`` flows into voice's load_template_config — so the
-        # template_vars from chat must be here for the renderer.
         payload: Dict[str, Any] = {
             **template_vars,
             "is_widget": True,
             "widget_config_id": cfg.id,
             "source": "widget",
         }
-        # Carry the chat session's accumulated agent_state (reducer-built
-        # identifiers like cart_id / checkout_id, plus client-pushed facts)
-        # into the voice seed so they survive the CHAT->VOICE flip. Without
-        # this, a voice continuation of a chat that already built a cart
-        # loses the cart_id and would silently act on a fresh cart.
-        agent_state_row = await get_agent_session_state(session_id)
-        agent_state_data: Dict[str, Any] = (
-            dict(agent_state_row.data) if agent_state_row else {}
-        )
-
-        # ``meta_data`` carries the voice-runtime seed (read by the
-        # agent's _setup_*_transport). The widget_session_id back-link
-        # is what the end_conversation drain uses to find the
-        # chat_session to drain into.
         meta_data_seed: Dict[str, Any] = {
             "is_widget": True,
             "widget_config_id": cfg.id,
             "widget_session_id": session_id,
-            "start_node": session.current_node,
-            "prior_history": prior_history,
-            "seed_message_count": seed_message_count,
-            "agent_state": agent_state_data,
         }
         template_name = getattr(template, "name", None) or "widget"
 
@@ -647,10 +639,16 @@ async def voice_connect_handler(
         lead_id: Optional[str] = session.voice_lead_id
         if lead_id:
             # 2nd+ attachment: reuse the bound lead. The reset bumps
-            # attempt_count, refreshes the seed, and clears per-call
-            # fields (call_id, outcome, recording_url, etc.) so they
-            # don't leak from the previous attempt.
-            reset_lead = await reset_widget_voice_lead(lead_id, payload, meta_data_seed)
+            # attempt_count, refreshes the seed, re-asserts DAILY_STREAM
+            # (so a lead created before the stream pivot is upgraded), and
+            # clears per-call fields (call_id, outcome, recording_url, etc.)
+            # so they don't leak from the previous attempt.
+            reset_lead = await reset_widget_voice_lead(
+                lead_id,
+                payload,
+                meta_data_seed,
+                execution_mode=ExecutionMode.DAILY_STREAM,
+            )
             if reset_lead is None:
                 # Lead was archived / hard-deleted. Fall through to
                 # create a fresh one and rebind. Shouldn't normally
@@ -674,7 +672,10 @@ async def voice_connect_handler(
                 attempt_count=0,
                 meta_data=meta_data_seed,
                 request_id=f"widget-{new_lead_id}",
-                execution_mode=ExecutionMode.DAILY,
+                # Widget voice runs STREAM mode: STT/TTS-only pipeline with no
+                # LLM/FlowManager — every turn is driven through the chat brain
+                # by the WidgetVoiceBridge. See the voice-as-chat re-architecture.
+                execution_mode=ExecutionMode.DAILY_STREAM,
                 status=LeadCallStatus.BACKLOG,
                 call_direction=CallDirection.INBOUND,
             )
@@ -774,18 +775,22 @@ async def voice_end_handler(
 ) -> WidgetVoiceEndResponse:
     """Best-effort end of the voice attachment.
 
-    Two paths run the actual drain (transcripts back into chat_message,
-    flip channel back to CHAT):
-      1. The bot's ``end_conversation`` handler, when Daily disconnects.
-      2. This route, as a fallback (e.g., user closed tab; bot is
-         still up but the user is gone) — we signal the bot via the
-         existing daily_completion_function and return immediately.
-    Both paths are guarded by the same per-session Redis lock and the
-    conditional UPDATE in ``drain_voice_into_chat_session_query``.
+    The chat brain wrote every turn live (no end-of-call drain), so ending
+    voice is just: signal the bot to tear down, then flip the channel back to
+    CHAT. Two paths flip:
+      1. The bot's ``end_conversation`` handler, when Daily disconnects — the
+         authoritative flip, after the pipeline (and any in-flight bridge
+         turn) has fully torn down.
+      2. This route — signals the bot via ``daily_completion_function`` and
+         then flips explicitly as the crash safety net: a bot that dies
+         before ``end_conversation`` would otherwise leave the session stuck
+         on VOICE and 409 ``/message`` + ``/voice/connect`` forever.
+    Both flips go through the conditional UPDATE in ``flip_chat_session_to_chat``
+    (current_channel=VOICE AND voice_lead_id matches), so whichever runs
+    second is a harmless no-op.
 
-    Idempotent: if channel is already CHAT (drain already ran) we
-    return success without doing anything. ``voice_lead_id`` stays
-    bound on the chat_session so the next /voice/connect reuses
+    Idempotent: if channel is already CHAT we return success without doing
+    anything. ``voice_lead_id`` stays bound so the next /voice/connect reuses
     the same lead.
     """
     lock = _session_lock(session_id)
@@ -827,12 +832,8 @@ async def voice_end_handler(
             )
             return WidgetVoiceEndResponse(status="cleared_orphan_state", lead_id=None)
 
-        # Signal the bot to wind down. The bot's end_conversation
-        # handler will run the drain when its pipeline tears down.
-        # We don't block on it — return optimistically. If the bot
-        # crashed and never drains, the conditional UPDATE in
-        # ``flip_chat_session_to_chat`` (or a janitor sweep) is the
-        # safety net.
+        # Signal the bot to wind down (best-effort, non-blocking). Its
+        # end_conversation flips the channel when the pipeline tears down.
         lead = await get_lead_by_id(lead_id)
         call_id = lead.call_id if lead and lead.call_id else lead_id
         try:
@@ -844,6 +845,19 @@ async def voice_end_handler(
             logger.warning(
                 f"widget voice: daily_completion_function failed for "
                 f"call_id={call_id}: {exc} (continuing)"
+            )
+
+        # Flip the channel back to CHAT now as the crash safety net. The chat
+        # brain wrote every turn live, so there's nothing to wait for; the
+        # conditional UPDATE makes the bot's own end_conversation flip a no-op
+        # if it runs after. Without this, a bot that dies before
+        # end_conversation leaves the session stuck on VOICE forever.
+        try:
+            await flip_chat_session_to_chat(session_id, voice_lead_id=lead_id)
+        except Exception as flip_err:
+            logger.warning(
+                f"widget voice: flip-to-chat failed for {session_id} / "
+                f"{lead_id}: {flip_err} (bot end_conversation will retry)"
             )
 
         return WidgetVoiceEndResponse(status="end_requested", lead_id=lead_id)
@@ -927,6 +941,7 @@ async def get_widget_session_state_handler(
         messages=messages,
         quick_replies=quick_replies,
         enable_text_input=enable_text_input,
+        voice_enabled=_template_voice_enabled(template),
         template_vars=template_vars,
         metadata=session.metadata or {},
         client_context=client_context,

--- a/app/core/config/dynamic.py
+++ b/app/core/config/dynamic.py
@@ -38,6 +38,13 @@ BB_SPEECH_PROVIDER_DEFAULTS: dict[str, dict] = {
         "model": "tts-rt-v1",
         "language": "en",
     },
+    # Google Cloud TTS — Chirp 3 HD voices. The voice name encodes the model
+    # and locale (e.g. en-IN-Chirp3-HD-Despina), so there is no separate model
+    # field; language should match the voice's locale prefix.
+    "google": {
+        "voice_id": "en-IN-Chirp3-HD-Despina",
+        "language": "en-IN",
+    },
 }
 
 
@@ -339,6 +346,17 @@ async def BB_AGGREGATE_SENTENCES(provider: str) -> bool:
     """Returns aggregate_sentences setting for a provider from Redis."""
     key = f"BB_{provider.upper()}_AGGREGATE_SENTENCES"
     return await get_config(key, True, bool)
+
+
+async def BB_STRIP_EMOJIS_FROM_TTS() -> bool:
+    """Whether to strip emoji from text sent to the TTS provider (default True).
+
+    Applies to every voice flow (telephony, Daily, widget stream); no emoji is
+    ever voiced. The widget stream-mode transcript is produced independently of
+    TTS (bridge RTVI event + chat_message) and keeps its emoji; the telephony /
+    Daily stored transcript reflects the spoken (emoji-free) text. Kill-switch.
+    """
+    return await get_config("BB_STRIP_EMOJIS_FROM_TTS", True, bool)
 
 
 async def SHOPS_FOR_TEMPLATE_FLOW() -> list[str]:

--- a/app/database/accessor/breeze_buddy/chat_session.py
+++ b/app/database/accessor/breeze_buddy/chat_session.py
@@ -21,7 +21,6 @@ from app.database.queries import run_parameterized_query
 from app.database.queries.breeze_buddy.chat_session import (
     count_chat_sessions_query,
     create_chat_session_query,
-    drain_voice_into_chat_session_query,
     end_chat_session_query,
     flip_chat_session_channel_query,
     get_agent_session_state_query,
@@ -342,76 +341,6 @@ async def flip_chat_session_to_chat(
         return decode_chat_session(row) if row else None
     except Exception as e:
         logger.error(f"Error flipping chat_session {session_id} to CHAT: {e}")
-        raise
-
-
-async def drain_voice_into_chat_session(
-    *,
-    chat_session_id: str,
-    lead_id: str,
-    new_messages: List[Dict[str, Any]],
-    final_node: Optional[str],
-) -> bool:
-    """End-of-voice drain: append new turns, advance current_node,
-    flip channel back to CHAT.
-
-    voice_lead_id is intentionally PRESERVED — the lead is bound to
-    the conversation for its full lifetime; the next /voice/connect
-    reuses it via attempt_count.
-
-    Idempotent against duplicate fires (e.g., end_conversation invoked
-    twice). The (session_id, idx) PK + atomic idx subquery in
-    insert_chat_message_query make duplicate INSERTs impossible at
-    the DB level; we wrap each insert just in case so a single
-    duplicate doesn't stop the rest.
-
-    Returns True when the channel flip succeeded (this drain owned
-    the close-out). False when the row had already moved on
-    (another caller ended the voice first).
-    """
-    # 1. Append any new turns.
-    for msg in new_messages:
-        role = msg.get("role")
-        content = msg.get("content")
-        if role not in ("user", "assistant") or not content:
-            continue
-        try:
-            await insert_chat_message(
-                session_id=chat_session_id,
-                role=ChatMessageRole(role),
-                content=content,
-            )
-        except Exception as e:
-            logger.warning(
-                f"drain: skip insert (session={chat_session_id}, role={role!r}): {e}"
-            )
-
-    # 2. Flip channel + advance current_node atomically. voice_lead_id
-    # stays bound for reuse on the next /voice/connect.
-    query, values = drain_voice_into_chat_session_query(
-        chat_session_id,
-        final_node=final_node,
-        expected_voice_lead_id=lead_id,
-    )
-    try:
-        result = await run_parameterized_query(query, values)
-        if result:
-            logger.info(
-                f"drain: voice lead {lead_id} drained into chat_session "
-                f"{chat_session_id}, final_node={final_node!r} "
-                "(voice_lead_id preserved for reuse)"
-            )
-            return True
-        logger.info(
-            f"drain: chat_session {chat_session_id} no longer matches "
-            f"lead {lead_id}; flip skipped"
-        )
-        return False
-    except Exception as e:
-        logger.error(
-            f"drain: failed to flip chat_session {chat_session_id} after "
-            f"lead {lead_id}: {e}"
-        )
         raise
 
 

--- a/app/database/accessor/breeze_buddy/lead_call_tracker.py
+++ b/app/database/accessor/breeze_buddy/lead_call_tracker.py
@@ -756,6 +756,7 @@ async def reset_widget_voice_lead(
     lead_id: str,
     payload: Dict[str, Any],
     meta_data_seed: Dict[str, Any],
+    execution_mode: ExecutionMode = ExecutionMode.DAILY_STREAM,
 ) -> Optional[LeadCallTracker]:
     """Reset a widget voice lead so the next /voice/connect can reuse it.
 
@@ -763,15 +764,17 @@ async def reset_widget_voice_lead(
     chat_session has ONE voice lead (set in chat_session.voice_lead_id)
     that persists for the conversation's lifetime. Each /voice/connect
     after the first reuses this lead — bumps attempt_count, refreshes
-    the seed (start_node, prior_history), clears per-call fields
-    (call_id, outcome, etc.) so they don't leak from the previous
-    attempt.
+    the widget seed, re-asserts ``execution_mode`` (so a pre-stream-pivot
+    lead is upgraded to DAILY_STREAM), clears per-call fields (call_id,
+    outcome, etc.) so they don't leak from the previous attempt.
     """
     logger.info(
         f"Resetting widget voice lead {lead_id} for next attempt "
-        f"(seed: {sorted(meta_data_seed.keys())})"
+        f"(seed: {sorted(meta_data_seed.keys())}, mode: {execution_mode.value})"
     )
-    query_text, values = reset_widget_voice_lead_query(lead_id, payload, meta_data_seed)
+    query_text, values = reset_widget_voice_lead_query(
+        lead_id, payload, meta_data_seed, execution_mode.value
+    )
     try:
         result = await run_parameterized_query(query_text, values)
         if result and get_row_count(result) > 0:

--- a/app/database/queries/breeze_buddy/chat_session.py
+++ b/app/database/queries/breeze_buddy/chat_session.py
@@ -306,36 +306,6 @@ def flip_chat_session_channel_query(
     return query, params
 
 
-def drain_voice_into_chat_session_query(
-    session_id: str,
-    *,
-    final_node: Optional[str],
-    expected_voice_lead_id: str,
-) -> Tuple[str, List[Any]]:
-    """Final UPDATE at the end of a voice attachment.
-
-    Flips channel back to CHAT, optionally advances current_node to
-    whatever node the voice flow ended on. Does NOT clear
-    voice_lead_id — the lead stays bound so the next
-    /voice/connect on this session can reuse it.
-
-    Conditioned on (current_channel='VOICE' AND voice_lead_id matches)
-    so a stale callback for an old lead can't flip a freshly-reused
-    session back to CHAT.
-    """
-    query = f"""
-        UPDATE {CHAT_SESSION_TABLE}
-        SET current_channel = 'CHAT',
-            current_node    = COALESCE($1, current_node),
-            last_activity_at = now()
-        WHERE id = $2
-          AND current_channel = 'VOICE'
-          AND voice_lead_id = $3::uuid
-        RETURNING {_SESSION_COLUMNS}
-    """
-    return query, [final_node, session_id, expected_voice_lead_id]
-
-
 # -- chat_message -------------------------------------------------------------
 
 

--- a/app/database/queries/breeze_buddy/lead_call_tracker.py
+++ b/app/database/queries/breeze_buddy/lead_call_tracker.py
@@ -717,6 +717,7 @@ def reset_widget_voice_lead_query(
     lead_id: str,
     payload: Dict[str, Any],
     meta_data_seed: Dict[str, Any],
+    execution_mode: str,
 ) -> Tuple[str, List[Any]]:
     """Reset a widget voice lead so the next /voice/connect can reuse it.
 
@@ -732,10 +733,12 @@ def reset_widget_voice_lead_query(
       - payload REPLACED with the latest template_vars (chat may have
         accumulated new state since the prior voice attachment)
       - meta_data is *merged* with the new seed so widget-mode markers
-        (is_widget, widget_config_id, widget_session_id) and the new
-        seed (start_node, prior_history, seed_message_count) overwrite
-        their prior values, but unrelated fields the bot wrote during
-        the prior attempt (e.g., evaluator scores) are preserved
+        (is_widget, widget_config_id, widget_session_id) overwrite their
+        prior values, but unrelated fields the bot wrote during the prior
+        attempt (e.g., evaluator scores) are preserved
+      - execution_mode RE-ASSERTED (e.g. DAILY_STREAM) so a lead created
+        before the stream pivot is upgraded on reuse instead of silently
+        running the old agent-mode pipeline
       - call_id, call_initiated_time, call_end_time, outcome, cost,
         recording_url are CLEARED so they don't leak from the prior
         attempt's call into this one
@@ -747,6 +750,7 @@ def reset_widget_voice_lead_query(
             "attempt_count"        = COALESCE("attempt_count", 0) + 1,
             "payload"              = $3::jsonb,
             "meta_data"            = COALESCE("meta_data", '{{}}')::jsonb || $4::jsonb,
+            "execution_mode"       = $5,
             "call_id"              = NULL,
             "call_initiated_time"  = NULL,
             "call_end_time"        = NULL,
@@ -762,5 +766,6 @@ def reset_widget_voice_lead_query(
         LeadCallStatus.BACKLOG.value,
         json.dumps(payload),
         json.dumps(meta_data_seed),
+        execution_mode,
     ]
     return text, values

--- a/app/schemas/breeze_buddy/chat.py
+++ b/app/schemas/breeze_buddy/chat.py
@@ -506,6 +506,15 @@ class CreateWidgetSessionResponse(BaseModel):
             "Ignored by the client when quick_replies is empty."
         ),
     )
+    voice_enabled: bool = Field(
+        False,
+        description=(
+            "Whether this merchant's template offers a voice mode — i.e. "
+            "'voice' is in the template's supported_channels (the same gate "
+            "/voice/connect enforces). The embed shows the voice-mode button "
+            "only when True; the server stays the enforcement point."
+        ),
+    )
 
 
 class UpdateWidgetContextRequest(ClientContextPatch):
@@ -593,6 +602,14 @@ class WidgetSessionStateResponse(BaseModel):
             "False = composer hidden for all turns; only quick replies or "
             "agent-driven input is possible. "
             "Ignored by the client when quick_replies is empty."
+        ),
+    )
+    voice_enabled: bool = Field(
+        False,
+        description=(
+            "Whether this merchant's template offers a voice mode — i.e. "
+            "'voice' is in the template's supported_channels. Lets the embed "
+            "restore the voice-mode button after a reload without re-deriving."
         ),
     )
     template_vars: Dict[str, Any] = Field(default_factory=dict)

--- a/docs/DAILY_RTVI_EVENTS.md
+++ b/docs/DAILY_RTVI_EVENTS.md
@@ -63,7 +63,8 @@ Real-time events emitted by the Breeze Buddy backend to Daily-connected clients 
 | `onCamUpdated` | Active camera changes | After `client.updateCam()` | Confirm camera switch |
 | `onDeviceError` | Device access fails | Permission denied, device in use, hardware error | Show "mic access denied" or "device unavailable" message |
 | **Server Messages** | | | |
-| `onServerMessage` | Backend sends custom RTVI event via `_emit_rtvi_event()` | On conversation-start, conversation-end, pipeline-error, bot-ready, function-approval-request, function-approval-resolved | Handle Breeze Buddy-specific lifecycle events + HITL approval cards |
+| `onServerMessage` | Backend sends custom RTVI event via `_emit_rtvi_event()` | On conversation-start, conversation-end, pipeline-error, bot-ready, function-approval-request, function-approval-resolved, ui-op | Handle Breeze Buddy-specific lifecycle events + HITL approval cards + generative voice UI |
+| `ui-action` *(client → server)* | Carousel/product click injected as a live user turn | `client.sendClientMessage('ui-action', { msg, display? })` | Drive the voice LLM from a UI click (widget voice-as-chat) |
 
 ## Event Timeline
 
@@ -580,6 +581,13 @@ onServerMessage: (message: { type: string; timestamp?: number; payload?: any }) 
       // payload: { approval_id, status }
       // status: "approved" | "denied" | "timeout" | "cancelled" | "superseded"
       break;
+    case 'ui-op':
+      // Generative voice UI: the LLM emitted a <ui_stream> op (carousel,
+      // tile, card, …). Apply it to the session UI tree and render with the
+      // SAME primitives chat uses. payload: { op } — chat-identical UiOp:
+      // { op: "add"|"replace"|"remove", id, type? (add), parent? (add
+      // non-root), props? }. Opt-in per template via `configurations.ui_catalog`.
+      break;
   }
 }
 ```
@@ -613,6 +621,47 @@ Semantics:
   without it, gated calls on Daily are denied
   (`approval_channel_unavailable`). Telephony has no approval surface —
   the template's `approval.on_no_channel` decides.
+
+### Generative voice UI (widget voice-as-chat)
+
+Lets a Daily voice agent render the same generative UI as chat (carousels,
+tiles, cards) and accept clicks as live user turns. See
+`docs/widget/VOICE_AS_CHAT.md`.
+
+**`ui-op` (server → client).** The LLM emits `<ui_stream>` JSONL blocks in its
+text; the `VoiceUiStreamProcessor` (between LLM and TTS) heals/validates each op
+exactly as chat does, forwards only the marker-stripped prose to TTS (so the bot
+never speaks the JSON), and emits one `onServerMessage` `ui-op` per validated op:
+
+```typescript
+// payload: { op: { op: "add"|"replace"|"remove", id, type?, parent?, props? } }
+// Identical UiOp wire shape to chat's `ui_op` SSE event — reuse the same
+// renderer (BbUiPane / UiRenderer). Disabled/unknown primitives are dropped
+// server-side (never emitted), per the template's resolved ui_catalog allowlist.
+```
+
+**`ui-action` (client → server).** A carousel/product click is injected as a
+live user turn (the same mid-call injection user-idle uses):
+
+```typescript
+client.sendClientMessage('ui-action', {
+  msg: 'Tell me about Dawn',   // injected into the LLM context (run_llm=true)
+  display: 'Dawn',             // optional; the widget renders this bubble
+});
+```
+
+Semantics:
+- The backend injects `msg` into context only and emits **no** transcript echo —
+  the widget renders the `display` bubble optimistically (matches chat's
+  carousel-click). `msg` is trimmed and capped at `UI_ACTION_MAX_CHARS` (2000);
+  blank/non-string messages are ignored.
+- Barge-in is native: a click while the bot is speaking interrupts it (works
+  only with interruption enabled — the default; `disabled_discard` drops it).
+- Daily-only and opt-in: `ui-op`/`ui-action` require RTVI
+  (`ENABLE_BREEZE_BUDDY_DAILY_EVENTS=true`) **and** a template that sets
+  `configurations.ui_catalog` and includes `{{ui_primitives_section}}` in its
+  voice prompt. Telephony (no RTVI) and realtime speech-to-speech (no separate
+  TTS stage) never emit `ui-op`.
 
 ---
 

--- a/docs/widget/VOICE_AS_CHAT.md
+++ b/docs/widget/VOICE_AS_CHAT.md
@@ -1,0 +1,352 @@
+# Widget Voice-as-Chat
+
+> **Architecture v2 — stream mode + one brain (current, 2026-06-18).**
+> Everything from "## 1. Goal" down is the **superseded v1 plan** (dual-brain:
+> a voice FlowManager+LLM agent in `ExecutionMode.DAILY` synced to the chat
+> `ChatAgent` via a resume seed + an end-of-call drain + `prepare_resume_node` +
+> a `ui_turn_sink`). That design caused every voice/chat sync bug (cart_id lost
+> on reconnect, carousels lost, "no cart in this session"). It has been
+> **removed**. Read this v2 section as the source of truth; the rest is kept for
+> historical context only.
+
+## Architecture v2 — widget voice = stream mode through the chat brain
+
+Widget voice now runs **`ExecutionMode.DAILY_STREAM`**: a Daily pipeline of
+`transport.input → STT → TranscriptionGate → TranscriptCollector →
+user_aggregator → TTS → transport.output` with **no LLM and no FlowManager**.
+Every finished user turn is driven through the **existing chat `ChatAgent`** — the
+same brain `POST /message` uses — so voice is pure audio I/O around one brain.
+cart_id, `content_blocks` history, `agent_state` / client-context, carousels,
+policy links are all inherited from chat because it *is* chat. No resume seed, no
+drain, no block re-encoding, no sync layer.
+
+**Backend (clairvoyance):**
+- `chat/turn_core.py` — `run_chat_turn(session_id, user_content, …)`: the chat
+  brain factored out of `send_chat_message_handler` (loads session/template/
+  history+repair/agent_state/template_vars, supersedes pending approvals, drives
+  `ChatAgent.run_turn`). Both `POST /message` and the voice bridge call it. The
+  HTTP shell (RedisLock, SSE, cancel-bus, TurnMetrics, the 413 piggyback
+  pre-validation) stays in `chat/handlers.py`.
+- `chat/voice_bridge.py` — `WidgetVoiceBridge`: tapped from the pipeline's
+  `on_user_turn_stopped` (full concatenated utterance) in stream mode for a
+  widget session. Runs `run_chat_turn` in a tracked task and adapts the SSE
+  events: `assistant_token` → sentence-aggregate → `TTSSpeakFrame` (speak) +
+  `assistant-transcript` RTVI (render); `ui_op` → `ui-op` RTVI; the first tool
+  call before any prose → a TTS filler; `turn_end` → `turn-end` RTVI.
+  `on_user_turn_started` → `cancel_inflight()` (pipecat already flushed TTS
+  natively); a generation counter drops a cancelled turn's tail frames; the next
+  turn's `repair_dangling_tool_uses` heals any tool_use the barge-in left
+  dangling — exactly like chat's `/cancel`.
+- `agent/__init__.py` — wires the bridge when `is_stream_mode AND
+  lead.metaData.widget_session_id`; speaks the persisted chat greeting once on
+  the first attachment (no user turns yet); routes `ui-action` clicks through the
+  bridge in stream mode.
+- `widget/handlers.py` — `voice_connect` creates/reuses the lead with
+  `DAILY_STREAM` and carries only `{is_widget, widget_config_id,
+  widget_session_id}` + the rendered `payload` (the brain owns history/state/
+  node). `voice_end` flips `current_channel` back to CHAT (crash safety net);
+  `end_conversation` flips it authoritatively on pipeline teardown — both via the
+  conditional `flip_chat_session_to_chat` UPDATE, so the second is a no-op.
+
+**Frontend (loom `client-sdk`):** `session.ts routeServerMessage` maps the
+bridge's `assistant-transcript` (build/extend the assistant bubble), `turn-end`
+(finalize it), and `error` server messages — reusing the same `currentAssistantEntry`
+→ `transcript` → store pipeline the old `onBotLlm*` callbacks fed in agent mode.
+The user transcript still comes from STT via pipecat's `onUserTranscript`; `ui-op`
+is unchanged.
+
+**Removed by v2:** `prepare_resume_node` + `_render_resume_state_note` (flow.py),
+the `_widget_resume_seed` plumbing (agent), `drain_voice_into_chat_session` +
+query, `attach_voice_ui_blocks` + the `ui_turn_sink`/`_voice_ui_turns`
+persistence (the chat brain now persists voice carousels as
+`chat_message.ui_blocks` itself). The live `VoiceUiStreamProcessor` ui-op emit is
+kept for any **non-widget** daily agent-mode template with `ui_catalog`.
+
+**Deferred:** warm per-session `ChatAgent` (latency); re-adding specific
+voice-only functions stripped by `CHAT_DISABLED_NAMES` if web voice needs them.
+
+---
+
+# Widget Voice-as-Chat — Implementation Plan (v1, SUPERSEDED)
+
+> **Status:** Superseded by Architecture v2 above. Kept for historical context.
+> Spans **clairvoyance** (backend), **loom `client-sdk`**, and
+> **loom `breeze-buddy-assist-widget`**.
+
+## 1. Goal (locked with the user)
+
+When voice is toggled in the widget, **keep the chat UI** instead of swapping to a
+full-screen voice pane:
+
+- User speech and assistant speech render as **message bubbles** in the same transcript.
+- **Carousels / product UI render with the SAME chat SpecStream primitives**
+  (`BbUiPane → UiRenderer → Carousel/Tile/Button`) — no new UI components — delivered
+  over the voice channel and able to be **generated mid-call**.
+- The transcript (incl. carousels) stays **fully visible and scrollable**.
+- **No text input box** during voice. The footer becomes a voice-control bar:
+  **Mic mute/unmute · Speaker off (mute bot audio) · End**, plus a Listening/Speaking status.
+- Clicking a product **feeds in as input to the LIVE voice agent** and shows as a user bubble.
+
+Decisions: **Full scope** (loom + clairvoyance). Reuse chat UI primitives. Defer nothing
+that the requirement needs.
+
+## 2. Why this needs backend work (the architecture)
+
+During a live Daily voice call the session is `current_channel=VOICE`, so the chat
+`/message` HTTP path 409s — the click/input path **cannot** reuse it. The widget voice
+attachment runs **`ExecutionMode.DAILY`** (agent mode, in-process Daily bot), RTVI enabled
+when `ENABLE_BREEZE_BUDDY_DAILY_EVENTS=true` (default true). Three flows over the RTVI channel:
+
+| Flow | Direction | Status today | Work |
+|---|---|---|---|
+| **Transcripts** (user speech + bot text) | server→client | ✅ already emitted (`RTVIObserverParams(user_transcription_enabled=True, bot_tts_enabled=True)`, pipeline.py:541-555); SDK already emits `'transcript'` | Frontend ingest only |
+| **Generative UI** (carousels/cards) | server→client | ❌ ui-ops only stream over chat SSE; nothing over voice RTVI | **Backend A1** + SDK `ui-op` event + widget render |
+| **Click → input** (carousel/product selection) | client→server | ❌ `on_client_message` handles only `tts-speak` + approval decisions | **Backend A2** + SDK `sendUserAction` + widget wiring |
+
+Backend transport already exists: `Agent._emit_rtvi_event(event_type, payload)`
+(agent/__init__.py:216-231, pushes `RTVIServerMessageFrame(data={type,timestamp,payload})`)
+and the `on_client_message` handler (agent/__init__.py:827-866). The automatic agent's
+charts-over-RTVI (`features/charts/rtvi/rtvi.py`) and `LLMSpyProcessor`
+(`automatic/processors/llm_spy.py:321-325`) are the **transport pattern** to mirror
+(NOT its HITL — out of scope per standing mandate).
+
+---
+
+## Part A — clairvoyance backend
+
+### A1. Generative UI over the voice RTVI channel
+
+The LLM produces UI exactly as in chat: it emits `<ui_stream>…</ui_stream>` JSONL blocks in
+its text output. We reuse chat's entire extraction/heal/validate stack and only swap the
+**SSE sink for an RTVI sink**.
+
+**A1.1 — Prompt: make the voice LLM emit `<ui_stream>`.** Voice templates don't include the
+generative-UI instructions today. Inject the SAME instructions chat uses so the voice LLM
+emits ui_stream blocks (and a short *speakable* prose line alongside, since the prose becomes
+TTS). Reuse chat's prompt-injection hook + `resolve_allowlist(...)` per-template gating
+(chat does this at `chat/agent.py:200-209`). *Confirm the exact injection point during impl —
+chat adds it in the flow/builder path.*
+
+**A1.2 — `VoiceUiStreamProcessor` (new `FrameProcessor`).** Insert between the LLM service and
+TTS in `build_pipeline()` (pipeline.py:~194-519), gated on `is_daily_mode AND ui_enabled`.
+For each LLM text frame:
+- Feed text to a session-scoped `UiStreamExtractor` (ui_stream.py:78 — handles markers split
+  across frames via its carry buffer).
+- `TextOut` (prose, markers stripped) → forward downstream to TTS **so the bot never speaks the
+  JSON** (this is the load-bearing reason the processor sits *before* TTS).
+- `JsonlOpLine` → run through `heal_op_line` + `parse_op_line` + catalog `validate_props`
+  (reuse `process_op_line`, ui_stream.py:584-677, swapping the SSE factory for the RTVI emit)
+  → `await bot._emit_rtvi_event('ui-op', {'op': <validated_op_dict>})`.
+- Model it on `LLMSpyProcessor` (automatic/processors/llm_spy.py) — same "tap frames, emit RTVI"
+  shape, but tapping LLM **text** (not function-result) frames.
+
+**A1.3 — known-ids scope.** Chat resets `_known_ui_ids` per turn; a voice call is one long
+session. Scope known-ids **per assistant response** (reset on each bot-turn start) to avoid an
+unbounded id registry over a long call (recon risk).
+
+**A1.4 — UiOp wire shape (unchanged from chat):**
+`{op:'add'|'replace'|'remove', id, type (add only), parent (add non-root), props}`.
+Emit envelope: `_emit_rtvi_event('ui-op', {op})` → client sees `{type:'ui-op', timestamp, payload:{op}}`.
+
+### A2. Client input injection (carousel/product click → user turn)
+
+Extend `on_client_message` (agent/__init__.py:827-866) with a `ui-action` branch (mirrors the
+existing `tts-speak` / approval-decision branches):
+
+```python
+elif message.type == "ui-action":          # client→server, from SDK sendUserAction
+    data = message.data or {}
+    text = (data.get("msg") or "").strip()
+    if not isinstance(text, str) or not text:
+        logger.warning("[ui-action] empty/malformed"); return
+    text = text[:UI_ACTION_MAX_CHARS]       # new static.py cap, mirror TTS_SPEAK_MAX_CHARS
+    if self.task:
+        await self.task.queue_frame(
+            LLMMessagesAppendFrame([{"role": "user", "content": text}], run_llm=True)
+        )
+```
+
+- `LLMMessagesAppendFrame(..., run_llm=True)` is the exact mid-call user-turn injection pattern
+  already used by `user_idle.py:85-91` and (PTT) the automatic agent. Frame enters pipeline top;
+  Pipecat's interruption strategy handles barge-in natively — **no custom barge-in logic**.
+- The backend injects `msg` into context only; it emits **no** transcript echo. The widget
+  renders the `display` bubble optimistically (see C3) — matches how chat's carousel click
+  optimistically appends the user bubble.
+- **No DB audit / no persistence change** — voice turns already drain to `chat_message` on
+  `end_conversation`; the injected user turn rides the LLM context like any spoken turn.
+
+### A3. Transcripts — confirm only
+
+Already flow over RTVI (A2 table). No backend change. Confirm `ENABLE_BREEZE_BUDDY_DAILY_EVENTS=true`
+in the target env (without it `_rtvi_processor` is None → ui-ops + approvals silently no-op).
+
+### A4. Wire-contract additions (single source of truth)
+
+- **server→client** RTVI `ui-op` — payload `{op: <UiOp>}` (chat-identical UiOp).
+- **client→server** RTVI `ui-action` — data `{msg, display?}`.
+- Transcripts: existing RTVI transcription events (unchanged).
+
+### A5. Backend verification
+
+`uv run pyrefly check`; new tests: `VoiceUiStreamProcessor` (prose passthrough + marker strip +
+op emit, reusing chat's ui_stream test fixtures), `on_client_message` ui-action injection
+(queues `LLMMessagesAppendFrame`), telephony/no-RTVI no-op. Docs: `docs/DAILY_RTVI_EVENTS.md`
+(+`ui-op`, +`ui-action`).
+
+---
+
+## Part B — client-sdk (`loom/packages/client-sdk`)
+
+### B1. Voice `ui-op` event (mirror chat)
+- `session/types.ts`: add `'ui-op': (e: {op: UiOp}) => void` to `VoiceSessionEventMap`
+  (~L127-168); import `UiOp` from `../ui/types.js`. Optional `onUiOp` sugar.
+- `session/session.ts` `routeServerMessage` (~L124-186): add `case 'ui-op'` reading
+  `obj.payload.op`, validate `{op,id}` (mirror `_turn-engine.ts:222-227`), `emitter.emit('ui-op',{op})`.
+
+### B2. `sendUserAction` (carousel click → live voice)
+- New `VoiceSession.sendUserAction(action: UiAction & {type:'to_assistant'})` → fire-and-forget
+  `sendMessage('ui-action', {msg: action.msg, display: action.display})` (mirror `respondToApproval`,
+  session.ts:375-393; try/catch — `sendMessage` throws when disconnected).
+
+### B3. Speaker mute (bot audio)
+- `session.ts`: `isAudioMuted` state; `setAudioMuted(muted)` sets `audioElement.muted` AND
+  `assistantAudioTrack.enabled = !muted` (defensive). **Re-apply on `onTrackStarted`** (track can
+  be replaced mid-call — recon risk). Expose `muteAudio()/unmuteAudio()/setAudioMuted`; emit
+  `'audio-mute-change'`; include `isAudioMuted` in `getState()`.
+
+### B4. Store ingestion (the unified-history core) — `store/_buddy-chat-store.ts`
+The widget consumes the SDK **only** through `BuddyChatStore`, so the merge lives here:
+- **Transcripts → bubbles:** subscribe (via the store's voice wiring) to `'transcript'`. Map
+  `UserTranscript`→ a `ChatTextMessage{role:'user'}`; `AssistantTranscript` (streaming, accumulates,
+  `isComplete`) → an assistant `ChatTextMessage` that updates then finalizes. New action
+  `ingestVoiceTranscript(entry)`.
+- **Voice ui-ops → cards:** subscribe to `'ui-op'`; buffer into a `ChatUiMessage` attached to the
+  current assistant turn — reuse the existing `appendUiOp`/`activeUiMessage` machinery
+  (_buddy-chat-store.ts:472-496), keyed off the voice turn instead of an SSE turn.
+- **Voice delegates** for the widget surface: add `sendUserAction`, `setAudioMuted` (+ getState
+  audio flag) to the `StoreSession` Pick and the store's public API (the widget can't reach the raw
+  session). `transferToVoice`/`endVoice` already exist.
+
+### B5. SDK tests
+`approval.test.ts`-style harness: `ui-op` server-message → `'ui-op'` event + store `ChatUiMessage`;
+`sendUserAction` → POST/RTVI body+type; transcript→bubble mapping (partial→final); `setAudioMuted`
+toggles element+track and survives a track-restart. Bump **0.4.0 → 0.5.0** + CHANGELOG (additive).
+
+---
+
+## Part C — widget (`loom/packages/breeze-buddy-assist-widget`)
+
+### C1. Layout: chat stays visible; footer becomes voice controls
+- `BbWindow.svelte`: stop rendering the voice pane as a full-cover `overlay` (`position:absolute;
+  inset:0`). Keep `BbTextPane` in `body` (flex:1, already reflows). The voice controls live in the
+  **footer** (replacing the composer), so the transcript simply shrinks by the footer height —
+  pure flex, no CSS hiding. Approval cards move inline into the transcript (BbTurn already renders
+  `kind:'approval'`) — drop the BbVoicePane bottom-sheet.
+- `BuddyAssist.svelte` footer (~L973-983): `{#if voiceLive}` render **`BbVoiceControls`** (new) else
+  `BbComposer` as today. **No text input during voice.**
+- `approvalsDisabled` should NO LONGER include `voiceLive` (cards are now interactive during voice).
+
+### C2. `BbVoiceControls.svelte` (new, presentational)
+Footer bar mirroring the composer pill chrome: **Mic mute/unmute** (`voiceSession.setMicEnabled`,
+reflect `mic-change`) · **Speaker off** (`store.setAudioMuted`, reflect `audio-mute-change`) ·
+**End** (red, `stopVoice()`) · a **Listening/Speaking/Connecting** status badge (driven by
+`assistant-speech-*` + `voiceStatus`). Reuse `BbVoicePane`'s existing button SVGs/styles; styles in
+`internal.ts` under one hoisted `.bb-voice-controls` class (check:styles). Then **delete/retire
+`BbVoicePane.svelte`** (its mascot can become a small inline status glyph if wanted).
+
+### C3. Carousel click during voice → inject + optimistic bubble
+`handleAction` (BuddyAssist.svelte:510-546): branch on `voiceLive`:
+```
+if (voiceLive && voiceSession) {
+  store.appendUserBubble(action.display ?? action.msg);   // optimistic (no server echo)
+  store.sendUserAction({type:'to_assistant', msg: action.msg, display: action.display});
+} else { send(cleaned, bubble); }                           // chat path unchanged
+```
+`open_url` actions behave as today. (Optimistic bubble because the backend injects `msg` into
+context but emits no transcript echo — confirmed in A2.)
+
+### C4. Transcript + ui-op rendering — reuse, don't rebuild
+Because B4 feeds voice transcripts + ui-ops into the **same store message list**, `BbTextPane →
+BbTurn → BbUiPane` render them with zero new rendering code. Only wiring: in `startVoice`
+(~L603-661) the store's voice subscriptions (B4) are what populate the list; verify auto-scroll
+(BbTextPane.svelte:138-164) follows new voice bubbles.
+
+### C5. Build & deploy
+Voice deps (`@pipecat-ai/*`, `@daily-co/daily-js`) already in the widget (lazy chunks). `pnpm
+--filter client-sdk check|test|build` then widget `check|check:styles|build`; assert the dist file
+list; exercise from the BUILT bundle in the harness (`modes="text,voice"`, port 5180,
+`api-base`→local clairvoyance branch). Docs: SDK README/CHANGELOG, widget README (voice mode UX).
+
+---
+
+## 3. Rollout (deploy order is load-bearing)
+
+1. **Backend deploy** (clairvoyance) — wire-safe against old SDK: new RTVI `ui-op` events are
+   ignored by an old `routeServerMessage` (switch has no default); `ui-action` is never sent by an
+   old SDK. Degradation = no carousels/clicks in voice, transcripts still flow.
+2. **loom deploy** (SDK 0.5.0 + widget, one release) — new SDK on old backend is dormant (no
+   `ui-op` frames arrive; `sendUserAction` injects nothing). Publish ALL `dist/assist*.js`.
+3. **Template opt-in LAST** — only a template that includes the generative-UI prompt instructions
+   (A1.1) will render UI in voice; roll out per-template after both deploys are live.
+4. `ENABLE_BREEZE_BUDDY_DAILY_EVENTS=true` required (already default).
+
+## 4. Risks / decisions to confirm during implementation
+
+- **A1.1 prompt injection point** — exact chat hook that adds the `<ui_stream>` instructions +
+  allowlist; reuse it for voice. (Only real unknown; everything else has a verified pattern.)
+- **TTS must never speak the JSON** — guaranteed by placing `VoiceUiStreamProcessor` *before* TTS
+  and forwarding only marker-stripped prose. Prompt should keep the prose short + speakable.
+- **Barge-in semantics** — a click while the bot is speaking injects a user turn; works only with
+  interruption ENABLED (default). With `disabled_discard` the click would be dropped — document /
+  ensure widget voice uses interruption-enabled.
+- **Telephony** — Daily-only (no `_rtvi_processor` on Twilio/Plivo/Exotel); out of scope.
+- **known-ids growth** over a long call — reset per assistant response (A1.3).
+
+## 4. Resume parity — voice UI ops persist as `ui_blocks` (added 2026-06-18)
+
+Found in live testing: after ending a voice call and reopening the widget, the
+**carousels were gone** while text remained — the conversation looked half-
+forgotten. Root cause: chat persists each assistant turn's UI ops in the
+`chat_message.ui_blocks` column (the widget's `resumed` handler repaints them),
+but the voice `end_conversation` drain only wrote `content` (text), never
+`ui_blocks`. So a widget reload (`GET /widget/session/{id}/state`) returned voice
+turns with empty `uiBlocks` → no carousels.
+
+Fix is **backend-only** (the loom `resumed` handler already repaints `uiBlocks`
+channel-agnostically — once persisted, voice carousels restore exactly like chat):
+
+- **`VoiceUiStreamProcessor`** accumulates the UI ops of each assistant turn into
+  an ordered `ui_turn_sink` (one bucket per *spoken* response — empty when a turn
+  drew no UI; a prose-less all-UI turn is dropped, the §4a gap). Interruption-safe:
+  a barge-in commits the pending bucket on the next response's start frame — or on
+  the call-ending frame if no further turn follows — so the sink stays 1:1 with the
+  assistant messages the context aggregator commits.
+- **`build_pipeline` / `Agent`** thread the bot's `self._voice_ui_turns` list in as
+  the sink.
+- **`end_conversation`** calls `attach_voice_ui_blocks(new_messages, ui_turns)` to
+  zip the buckets onto the assistant entries it drains; **`drain_voice_into_chat_session`**
+  passes `ui_blocks` to `insert_chat_message` (same column + shape chat uses).
+
+Text + LLM memory already worked (the drain persisted text and `/voice/connect`
+re-seeds `prior_history` into the next call's LLM context — verified in logs). The
+only missing piece was the UI, now at parity with chat.
+
+## 4a. Known limitation / deferred follow-up
+
+- **No `summarize_ui_ops` referential memory for voice (deferred — not small).** Chat appends a
+  compact `[ui rendered: …]` summary as a `visibility=internal` block so the LLM remembers what it
+  showed ("the green one") without the widget ever displaying it. Voice's context is built by the
+  frame aggregator and `end_conversation` reads the LLM message history verbatim — there is **no
+  internal-visibility filter**, so injecting the summary would pollute the persisted transcript with
+  synthetic `[ui rendered: …]` lines. Doing it right needs a transcript-side filter, not just an
+  injection. Low impact for voice: the bot's *spoken* prose (which is in context) already names the
+  items, so only pure-UI-no-speech turns lose referents — rare in voice. Implement alongside a
+  transcript-filtering hook if/when referential misses are observed.
+
+## 5. Suggested sequencing (stackable PRs)
+
+1. **clairvoyance PR** — A1 (`VoiceUiStreamProcessor` + prompt) + A2 (`ui-action` inject) + tests + docs.
+2. **loom SDK PR** — B1–B5 (ui-op event, sendUserAction, speaker mute, store ingestion) + 0.5.0.
+3. **loom widget PR** — C1–C5 (layout, `BbVoiceControls`, click routing, retire `BbVoicePane`).
+
+Backend and SDK are independently dormant, so order is flexible; widget depends on the SDK PR.

--- a/docs/widget/VOICE_GENERATIVE_UI_TODO.md
+++ b/docs/widget/VOICE_GENERATIVE_UI_TODO.md
@@ -1,0 +1,74 @@
+# TODO — Re-enable generative voice UI (agent-mode Daily) — DEFERRED
+
+**Status:** deferred out of the widget voice-as-chat PR (`feat/widget-voice-as-chat-backend`).
+The `VoiceUiStreamProcessor` module is **kept** but **not plugged into the pipeline**.
+
+## What this feature is
+
+Generative UI over the **voice** RTVI channel for **non-widget, Daily *agent-mode*** calls
+(`ExecutionMode.DAILY` / `DAILY_TEST`, i.e. a full FlowManager + LLM pipeline). The LLM emits
+`<ui_stream>` ops inline; a `VoiceUiStreamProcessor` placed between the LLM and TTS strips the
+markers from the spoken prose and re-emits each op as an RTVI `ui-op` event so the client renders
+carousels/cards. Opt-in per template via `configurations.ui_catalog` + the
+`{{ui_primitives_section}}` prompt placeholder.
+
+## Why it was deferred
+
+- **Widget voice no longer uses it.** Widget voice is now stream mode (`DAILY_STREAM`) driven by
+  the chat `ChatAgent`, which emits and persists `ui_op` itself via the `WidgetVoiceBridge`
+  (`chat/voice_bridge.py`). The processor was gated off for stream mode anyway
+  (`_resolve_voice_ui_allowlist` returned `None` when `is_stream`).
+- The only remaining consumer would be a **non-widget** Daily agent-mode call with a `ui_catalog`
+  template — a path not currently exercised. Keeping the half-wired feature in this PR added
+  surface area (an extra processor in the agent pipeline, RTVI observer `ignored_sources`
+  juggling) for no active caller. Deferring keeps the voice-as-chat PR focused.
+
+## What was REMOVED (the wiring) — and where
+
+- `agent/flow.py` — `build_flow_config` lost its `ui_allowlist` param; it now calls
+  `flow_builder.build_flow_config(template)` (the `{{ui_primitives_section}}` placeholder stays
+  inert).
+- `agent/pipeline.py` — `build_pipeline` lost `ui_emit` / `ui_allowlist` params and the
+  `VoiceUiStreamProcessor` splice (the agent tail is now plain `[llm, tts, output, assistant]`);
+  `create_pipeline_task` lost `ignored_rtvi_sources`; the `VoiceUiStreamProcessor` / `RtviEmit`
+  imports are gone.
+- `agent/__init__.py` — removed `self._voice_ui_allowlist`, the `_resolve_voice_ui_allowlist`
+  method, the `resolve_allowlist` import, and the `ui_emit` / `ui_allowlist` /
+  `ignored_rtvi_sources` arguments at the `build_flow_config` + `build_pipeline` +
+  `create_pipeline_task` call sites.
+
+## What was KEPT (do NOT delete — still used or intentionally dormant)
+
+- `processors/voice_ui_stream.py` — the `VoiceUiStreamProcessor` class (+ `RtviEmit`) and the
+  `coerce_ui_action_text` helper. The module is exported from `processors/__init__.py`.
+- `coerce_ui_action_text` is **still in use** for **click-to-talk** (the `ui-action` inbound
+  injection), which the widget voice-as-chat bridge relies on — unrelated to the deferred
+  generative-UI *output*.
+- `FlowConfigBuilder.build_flow_config(..., ui_allowlist=...)` (in `template/builder.py`) keeps its
+  keyword-only `ui_allowlist` param — **chat** still uses it; only the voice caller stopped passing
+  it.
+- The `configurations.ui_catalog` template field and `template/ui_catalog.resolve_allowlist`.
+
+## How to RE-ENABLE later (re-wiring checklist)
+
+1. `agent/__init__.py`: restore `self._voice_ui_allowlist: Optional[Set[str]] = None`, the
+   `_resolve_voice_ui_allowlist(is_stream, is_realtime)` method (gates on
+   `not is_stream and not is_realtime and is_daily_mode and configurations.ui_catalog`), and
+   re-import `resolve_allowlist`. Recompute `is_realtime = stt is None and tts is None and llm is not None`
+   and set `self._voice_ui_allowlist` before building the pipeline.
+2. Pass `ui_allowlist=self._voice_ui_allowlist` to `build_flow_config(...)`.
+3. Pass `ui_emit=self._emit_rtvi_event, ui_allowlist=self._voice_ui_allowlist` to `build_pipeline(...)`,
+   and `ignored_rtvi_sources=[llm] if (self._voice_ui_allowlist is not None and llm) else None` to
+   `create_pipeline_task(...)`.
+4. `agent/pipeline.py`: re-add the `ui_emit` / `ui_allowlist` params + the
+   `VoiceUiStreamProcessor` splice in the agent (`else`) branch, the `ignored_rtvi_sources` param on
+   `create_pipeline_task`, and the two imports (`VoiceUiStreamProcessor`, `RtviEmit`). Restore `Set`
+   to the typing import.
+5. `agent/flow.py`: re-add the `ui_allowlist` param and pass it to
+   `flow_builder.build_flow_config(template, ui_allowlist=ui_allowlist)`. Restore `Set` to the
+   typing import.
+6. Tests: `tests/test_voice_ui_stream.py` covers the processor in isolation and stays green; add a
+   wiring/integration test for the agent-mode splice.
+
+Reference for the original design: the generative-UI-over-RTVI work (commit `344863e`) and
+`docs/widget/VOICE_AS_CHAT.md` (§A1).

--- a/tests/test_emoji_filter.py
+++ b/tests/test_emoji_filter.py
@@ -1,0 +1,68 @@
+"""Tests for the TTS emoji filter (strip_emojis + EmojiTextFilter)."""
+
+import asyncio
+
+from app.ai.voice.agents.breeze_buddy.tts.emoji_filter import (
+    EmojiTextFilter,
+    strip_emojis,
+)
+
+
+def test_removes_common_emoji():
+    assert strip_emojis("Hello 😀") == "Hello "
+    assert strip_emojis("Great job 👍🎉") == "Great job "
+    assert strip_emojis("Order shipped 🚚 today") == "Order shipped today"
+
+
+def test_removes_across_unicode_blocks():
+    # emoticons, misc symbols, dingbats, transport, supplemental, technical,
+    # misc-symbols-and-arrows, extended-A
+    samples = "😀 ☀ ✅ 🚀 🤖 ⌚ ⭐ 🩷"
+    assert strip_emojis(samples).strip() == ""
+
+
+def test_removes_zwj_sequences_and_skin_tones_and_keycaps():
+    # ZWJ family, skin-tone modifier, variation selector, keycap
+    assert strip_emojis("family 👨‍👩‍👧 here").replace(" ", "") == "familyhere"
+    assert strip_emojis("wave 👋🏽").strip() == "wave"
+    assert strip_emojis("heart ❤️").strip() == "heart"
+    assert strip_emojis("press 1️⃣").strip() == "press 1"  # keycap leaves the digit
+    assert strip_emojis("flag 🇮🇳").strip() == "flag"  # regional indicators
+
+
+def test_collapses_inter_word_double_space_but_keeps_edges():
+    # an emoji between words leaves a double space → collapse to one
+    assert strip_emojis("hi 😀 there") == "hi there"
+    # leading/trailing whitespace is preserved (streaming tokens rely on it)
+    assert strip_emojis(" word ") == " word "
+    assert strip_emojis("lead 😀") == "lead "
+
+
+def test_preserves_plain_text_and_non_emoji_symbols():
+    # No emoji → identity (fast path), and legit symbols/punctuation untouched
+    plain = "Your total is $19.99 (incl. tax) — see Brand™ for details. 100% sure!"
+    assert strip_emojis(plain) == plain
+    assert strip_emojis("a + b = c, 3 < 4") == "a + b = c, 3 < 4"
+
+
+def test_removes_vs16_qualified_legacy_symbol_emoji():
+    # base char outside the main blocks + U+FE0F → fully removed (not just FE0F)
+    assert strip_emojis("note ℹ️ here").replace(" ", "") == "notehere"  # ℹ️
+    assert strip_emojis("warning ‼️").strip() == "warning"  # ‼️
+    assert strip_emojis("metro Ⓜ️").strip() == "metro"  # Ⓜ️
+    assert strip_emojis("see ↔️").strip() == "see"  # ↔️
+    # bare base chars (no VS16) are PRESERVED — legit prose / punctuation
+    assert strip_emojis("Breeze™ brand") == "Breeze™ brand"  # ™ kept
+    assert strip_emojis("range a ↔ b") == "range a ↔ b"  # bare ↔ kept
+
+
+def test_empty_and_emoji_only():
+    assert strip_emojis("") == ""
+    assert strip_emojis("😀😀😀") == ""  # all-emoji collapses to empty
+
+
+def test_filter_is_async_and_strips():
+    f = EmojiTextFilter()
+    assert asyncio.run(f.filter("Hi 😀 there")) == "Hi there"
+    # unchanged text round-trips identically
+    assert asyncio.run(f.filter("plain text")) == "plain text"

--- a/tests/test_turn_core.py
+++ b/tests/test_turn_core.py
@@ -1,0 +1,224 @@
+"""Tests for run_chat_turn — the channel-agnostic chat brain.
+
+run_chat_turn is the generator both POST /message and the widget voice bridge
+drive. These tests mock its DB/LLM boundary and assert: terminal error events
+on a missing/ended session, the approval-supersede events riding at the start
+of the stream, and clean delegation to ChatAgent.run_turn for the happy path.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any, List, cast
+
+import pytest
+
+from app.ai.voice.agents.breeze_buddy.chat import turn_core as tc
+from app.ai.voice.agents.breeze_buddy.chat.approvals import (
+    WIRE_STATUS_SUPERSEDED,
+    ApprovalClaim,
+)
+from app.ai.voice.agents.breeze_buddy.chat.sse import SSEEvent
+from app.schemas.breeze_buddy.chat import ChatSessionStatus
+
+
+async def _collect(agen) -> List[SSEEvent]:
+    return [ev async for ev in agen]
+
+
+def _patch_common(monkeypatch, *, superseded=None, agent_events=None):
+    """Patch the run_chat_turn boundary for the happy path."""
+
+    async def _limit():
+        return 50
+
+    async def _messages(session_id, limit=None):
+        return []
+
+    async def _state(session_id):
+        return None
+
+    async def _vars(template, persisted):
+        return {}
+
+    async def _llm(cfg, pooled=False):
+        return object()
+
+    async def _resolve(session_id, only_expired=False):
+        return superseded or []
+
+    class _FakeChatAgent:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+        async def run_turn(self, *, user_content, history, current_node):
+            for ev in agent_events or []:
+                yield ev
+
+    monkeypatch.setattr(tc, "CHAT_HISTORY_REPLAY_LIMIT", _limit)
+    monkeypatch.setattr(tc, "list_chat_messages_for_session", _messages)
+    monkeypatch.setattr(tc, "get_agent_session_state", _state)
+    monkeypatch.setattr(tc, "build_render_template_vars", _vars)
+    monkeypatch.setattr(tc, "get_llm_service", _llm)
+    monkeypatch.setattr(tc, "resolve_dangling_approvals", _resolve)
+    monkeypatch.setattr(tc, "blocks_to_llm_context_messages", lambda rows: [])
+    monkeypatch.setattr(tc, "repair_dangling_tool_uses", lambda h: h)
+    monkeypatch.setattr(tc, "ChatAgent", _FakeChatAgent)
+
+
+def _active_session():
+    return SimpleNamespace(
+        status=ChatSessionStatus.ACTIVE,
+        current_node="start",
+        template_id="t1",
+        metadata={"template_vars": {}},
+    )
+
+
+async def test_missing_session_yields_error_and_turn_end(monkeypatch):
+    async def _none(session_id):
+        return None
+
+    monkeypatch.setattr(tc, "get_chat_session_by_id", _none)
+    events = await _collect(run_then(tc, session_id="missing"))
+    assert [e.event for e in events] == ["error", "turn_end"]
+    assert events[0].data["code"] == "session_not_found"
+    assert events[1].data["session_status"] == "FAILED"
+
+
+async def test_ended_session_yields_error_and_turn_end(monkeypatch):
+    async def _ended(session_id):
+        return SimpleNamespace(
+            status=ChatSessionStatus.ENDED,
+            current_node="start",
+            template_id="t1",
+            metadata={},
+        )
+
+    monkeypatch.setattr(tc, "get_chat_session_by_id", _ended)
+    events = await _collect(run_then(tc, session_id="s"))
+    assert [e.event for e in events] == ["error", "turn_end"]
+    assert events[0].data["code"] == "session_ended"
+
+
+async def test_missing_template_yields_error(monkeypatch):
+    async def _session(session_id):
+        return _active_session()
+
+    async def _no_template(template_id):
+        return None
+
+    monkeypatch.setattr(tc, "get_chat_session_by_id", _session)
+    monkeypatch.setattr(tc, "get_template_by_id_cached", _no_template)
+    events = await _collect(run_then(tc, session_id="s"))
+    assert [e.event for e in events] == ["error", "turn_end"]
+    assert events[0].data["code"] == "template_missing"
+
+
+async def test_supersede_events_ride_first(monkeypatch):
+    async def _session(session_id):
+        return _active_session()
+
+    async def _template(template_id):
+        return SimpleNamespace(id="t1")
+
+    monkeypatch.setattr(tc, "get_chat_session_by_id", _session)
+    monkeypatch.setattr(tc, "get_template_by_id_cached", _template)
+    _patch_common(
+        monkeypatch,
+        superseded=[SimpleNamespace(tool_call_id="tc1", reason="moved on")],
+        agent_events=[
+            SSEEvent("assistant_token", {"delta": "hi"}),
+            SSEEvent("turn_end", {"session_status": "ACTIVE"}),
+        ],
+    )
+    events = await _collect(run_then(tc, session_id="s"))
+    # The superseded approval is resolved first, then the agent's turn.
+    assert events[0].event == "function_approval_resolved"
+    assert events[0].data["status"] == WIRE_STATUS_SUPERSEDED
+    assert events[0].data["tool_call_id"] == "tc1"
+    assert [e.event for e in events[1:]] == ["assistant_token", "turn_end"]
+
+
+async def test_delegates_to_chat_agent_when_no_pending(monkeypatch):
+    async def _session(session_id):
+        return _active_session()
+
+    async def _template(template_id):
+        return SimpleNamespace(id="t1")
+
+    monkeypatch.setattr(tc, "get_chat_session_by_id", _session)
+    monkeypatch.setattr(tc, "get_template_by_id_cached", _template)
+    _patch_common(
+        monkeypatch,
+        superseded=[],
+        agent_events=[
+            SSEEvent("assistant_message", {"idx": 1, "content": "done"}),
+            SSEEvent("turn_end", {"session_status": "ACTIVE"}),
+        ],
+    )
+    events = await _collect(run_then(tc, session_id="s"))
+    assert [e.event for e in events] == ["assistant_message", "turn_end"]
+
+
+def run_then(module, *, session_id):
+    """run_chat_turn invocation helper (keeps the await off the call site)."""
+    return module.run_chat_turn(session_id=session_id, user_content="hi")
+
+
+# ---------------------------------------------------------------------------
+# run_chat_approval_turn (the voice bridge's HITL entry point)
+# ---------------------------------------------------------------------------
+
+
+async def test_approval_turn_not_found(monkeypatch):
+    async def _claim(session_id, tool_call_id, approved, reason):
+        return ApprovalClaim(outcome="not_found")
+
+    monkeypatch.setattr(tc, "claim_tool_approval", _claim)
+    events = await _collect(
+        tc.run_chat_approval_turn(session_id="s", tool_call_id="tc1", approved=True)
+    )
+    assert [e.event for e in events] == ["function_approval_resolved", "turn_end"]
+    assert events[0].data["status"] == "cancelled"
+
+
+async def test_approval_turn_already_decided(monkeypatch):
+    async def _claim(session_id, tool_call_id, approved, reason):
+        return ApprovalClaim(outcome="already_decided", winning_status="denied")
+
+    monkeypatch.setattr(tc, "claim_tool_approval", _claim)
+    events = await _collect(
+        tc.run_chat_approval_turn(session_id="s", tool_call_id="tc1", approved=False)
+    )
+    assert events[0].event == "function_approval_resolved"
+    assert events[0].data["status"] == "denied"
+
+
+async def test_approval_turn_proceed_delegates(monkeypatch):
+    claimed = SimpleNamespace(tool_call_id="tc1", function_name="f")
+
+    async def _claim(session_id, tool_call_id, approved, reason):
+        return ApprovalClaim(
+            outcome="proceed",
+            claimed=cast(Any, claimed),
+            effective_approved=True,
+            wire_status="approved",
+            expired_siblings=cast(
+                Any, [SimpleNamespace(tool_call_id="sib1", reason="expired")]
+            ),
+        )
+
+    async def _continuation(**kwargs):
+        yield SSEEvent("assistant_message", {"idx": 1, "content": "ok"})
+        yield SSEEvent("turn_end", {"session_status": "ACTIVE"})
+
+    monkeypatch.setattr(tc, "claim_tool_approval", _claim)
+    monkeypatch.setattr(tc, "run_chat_approval_continuation", _continuation)
+    events = await _collect(
+        tc.run_chat_approval_turn(session_id="s", tool_call_id="tc1", approved=True)
+    )
+    # The expired sibling is resolved first, then the continuation streams.
+    assert events[0].event == "function_approval_resolved"
+    assert events[0].data["tool_call_id"] == "sib1"
+    assert [e.event for e in events[1:]] == ["assistant_message", "turn_end"]

--- a/tests/test_turn_stop_strategy.py
+++ b/tests/test_turn_stop_strategy.py
@@ -1,0 +1,118 @@
+"""Regression tests for the user-turn-stop strategy used in timeout/stt_native
+turn detection.
+
+History: a local ``AccumulatingSpeechTimeoutStrategy`` subclass patched a bug in
+pipecat's old single-timer ``SpeechTimeoutUserTurnStopStrategy`` by re-seeding a
+sentinel timer in ``setup()``/``reset()`` (it poked ``self._timeout_task``).
+
+pipecat 1.1.0 rewrote that base class into a two-timer design with no
+``_timeout_task``/``_timeout_handler``. The subclass's ``_seed_sentinel`` only
+ran when ``user_speech_timeout > 0`` (it short-circuited at 0.0), so every
+``stt_native`` template (timeout 0.0) was unaffected — but the moment a template
+switched to ``turn_detection: timeout`` with a non-zero ``user_speech_timeout``,
+``setup()``/``reset()`` raised ``AttributeError`` on the missing
+``_timeout_task`` and broke the turn lifecycle: the user turn never stopped, so
+the LLM was never invoked and the bot listened forever.
+
+Fix: drop the subclass and use the base ``SpeechTimeoutUserTurnStopStrategy``
+directly (it now handles the no-VAD multi-turn case natively). These tests lock
+that in.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from pipecat.frames.frames import TranscriptionFrame
+from pipecat.turns.user_stop import SpeechTimeoutUserTurnStopStrategy
+from pipecat.utils.asyncio.task_manager import TaskManager, TaskManagerParams
+
+from app.ai.voice.agents.breeze_buddy.template import interruption
+
+
+def _make_task_manager() -> TaskManager:
+    tm = TaskManager()
+    tm.setup(TaskManagerParams(loop=asyncio.get_running_loop()))
+    return tm
+
+
+def _transcription(text: str = "hello", finalized: bool = True) -> TranscriptionFrame:
+    return TranscriptionFrame(
+        user_id="user",
+        text=text,
+        timestamp="2026-06-18T00:00:00Z",
+        finalized=finalized,
+    )
+
+
+def test_accumulating_subclass_is_removed():
+    """The obsolete subclass must not come back — it crashes on pipecat 1.1.0."""
+    assert not hasattr(interruption, "AccumulatingSpeechTimeoutStrategy")
+
+
+def test_base_strategy_lacks_old_single_timer_api():
+    """Guards the root cause: the old `_timeout_task` attribute is gone, so any
+    code re-seeding it (the deleted `_seed_sentinel`) would AttributeError."""
+    strat = SpeechTimeoutUserTurnStopStrategy(user_speech_timeout=1.0)
+    assert not hasattr(strat, "_timeout_task")
+    assert hasattr(strat, "_user_speech_timeout_task")
+
+
+async def test_setup_and_reset_do_not_raise_with_positive_timeout():
+    """The exact crash we fixed: setup()+reset() with user_speech_timeout > 0.
+
+    The deleted subclass raised AttributeError here; the base class must not.
+    """
+    strat = SpeechTimeoutUserTurnStopStrategy(user_speech_timeout=1.0)
+    await strat.setup(_make_task_manager())
+    await strat.reset()  # called by the turn controller on every turn start/stop
+    await strat.cleanup()
+
+
+async def test_fires_after_timeout_in_no_vad_fallback():
+    """A finalized transcript with no VAD stop must end the turn after
+    user_speech_timeout seconds of silence (the timeout-mode behavior the
+    template change wanted)."""
+    fired = asyncio.Event()
+    strat = SpeechTimeoutUserTurnStopStrategy(user_speech_timeout=0.05)
+    strat.add_event_handler("on_user_turn_stopped", lambda *_a, **_k: fired.set())
+    await strat.setup(_make_task_manager())
+
+    await strat.process_frame(_transcription(finalized=True))
+    # Not fired immediately — the policy floor must elapse first.
+    assert not fired.is_set()
+
+    await asyncio.wait_for(fired.wait(), timeout=1.0)
+    await strat.cleanup()
+
+
+async def test_timer_rearms_on_each_transcript():
+    """While the user keeps producing transcripts inside the window, the turn
+    must NOT end — the timer rearms on every new transcript."""
+    fired = asyncio.Event()
+    strat = SpeechTimeoutUserTurnStopStrategy(user_speech_timeout=0.15)
+    strat.add_event_handler("on_user_turn_stopped", lambda *_a, **_k: fired.set())
+    await strat.setup(_make_task_manager())
+
+    # Three transcripts spaced under the timeout — each rearms the timer.
+    for _ in range(3):
+        await strat.process_frame(_transcription(finalized=True))
+        await asyncio.sleep(0.05)
+        assert not fired.is_set()
+
+    # Now go quiet — the turn ends.
+    await asyncio.wait_for(fired.wait(), timeout=1.0)
+    await strat.cleanup()
+
+
+async def test_fires_quickly_with_zero_timeout_stt_native():
+    """stt_native uses user_speech_timeout=0.0 and must still end the turn
+    right after a finalized transcript (behavior-preserving vs the old code)."""
+    fired = asyncio.Event()
+    strat = SpeechTimeoutUserTurnStopStrategy(user_speech_timeout=0.0)
+    strat.add_event_handler("on_user_turn_stopped", lambda *_a, **_k: fired.set())
+    await strat.setup(_make_task_manager())
+
+    await strat.process_frame(_transcription(finalized=True))
+    await asyncio.wait_for(fired.wait(), timeout=1.0)
+    await strat.cleanup()

--- a/tests/test_voice_bridge.py
+++ b/tests/test_voice_bridge.py
@@ -1,0 +1,488 @@
+"""Tests for WidgetVoiceBridge — widget voice driven through the chat brain.
+
+The bridge runs the SAME ChatAgent turn as POST /message (via run_chat_turn)
+and adapts the SSE event stream into TTSSpeakFrames + RTVI events. These tests
+stub ``run_chat_turn`` with a controllable async generator and drive a fake
+pipeline task + RTVI emit, so they exercise the bridge's adaptation logic
+(sentence aggregation, marker stripping, filler-once, barge-in cancel, greeting
+gating) without a live LLM or DB.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+from pipecat.frames.frames import TTSSpeakFrame
+
+from app.ai.voice.agents.breeze_buddy.chat import voice_bridge as vb
+from app.ai.voice.agents.breeze_buddy.chat.sse import SSEEvent
+from app.ai.voice.agents.breeze_buddy.chat.voice_bridge import (
+    _DEFAULT_FILLER_PHRASE,
+    WidgetVoiceBridge,
+    _SentenceAggregator,
+)
+from app.schemas.breeze_buddy.chat import ChatMessageRole
+
+
+class _FakeTask:
+    def __init__(self) -> None:
+        self.frames: list = []
+
+    async def queue_frame(self, frame) -> None:
+        self.frames.append(frame)
+
+
+class _FakeEmit:
+    def __init__(self) -> None:
+        self.calls: list = []
+
+    async def __call__(self, event_type, payload=None) -> None:
+        self.calls.append((event_type, payload))
+
+
+class _FakeLock:
+    """No-op RedisLock stand-in for unit tests (no Redis). Tracks balance so a
+    test can assert the lock is released even when a turn is cancelled."""
+
+    acquired = 0
+    released = 0
+    raise_on_acquire = False
+
+    def __init__(self, *args, **kwargs) -> None:
+        pass
+
+    async def acquire(self) -> None:
+        if _FakeLock.raise_on_acquire:
+            raise vb.LockAcquireError("busy")
+        _FakeLock.acquired += 1
+
+    async def release(self) -> None:
+        _FakeLock.released += 1
+
+
+@pytest.fixture(autouse=True)
+def _patch_redis_lock(monkeypatch):
+    _FakeLock.acquired = 0
+    _FakeLock.released = 0
+    _FakeLock.raise_on_acquire = False
+    monkeypatch.setattr(vb, "RedisLock", _FakeLock)
+    yield
+
+
+def _spoken(task: _FakeTask) -> list:
+    return [f.text for f in task.frames if isinstance(f, TTSSpeakFrame)]
+
+
+def _emitted(emit: _FakeEmit, event_type: str) -> list:
+    return [payload for (et, payload) in emit.calls if et == event_type]
+
+
+def _stub_run_chat_turn(*events: SSEEvent):
+    """Build a run_chat_turn replacement that yields ``events`` in order."""
+
+    async def _gen(*, session_id, user_content, llm=None, context_placement=None):
+        for ev in events:
+            yield ev
+
+    return _gen
+
+
+def _make_bridge() -> tuple[WidgetVoiceBridge, _FakeTask, _FakeEmit]:
+    task = _FakeTask()
+    emit = _FakeEmit()
+    bridge = WidgetVoiceBridge(session_id="sess-1", task=task, emit_rtvi=emit)
+    return bridge, task, emit
+
+
+async def _run_one_turn(bridge: WidgetVoiceBridge, text: str = "hi") -> None:
+    await bridge.handle_user_turn(text)
+    inflight = bridge._inflight
+    assert inflight is not None
+    await inflight
+
+
+# ---------------------------------------------------------------------------
+# _SentenceAggregator
+# ---------------------------------------------------------------------------
+
+
+def test_aggregator_flushes_complete_sentences_past_min():
+    agg = _SentenceAggregator(min_chars=10)
+    # Below min — held.
+    assert agg.push("Hi") == []
+    # Crosses min and hits a terminal followed by a space → flush.
+    out = agg.push(" there, friend. And more")
+    assert out == ["Hi there, friend."]
+    assert not agg.is_empty  # "And more" still buffered
+    assert agg.flush() == ["And more"]
+    assert agg.is_empty
+
+
+def test_aggregator_does_not_split_decimal_midnumber():
+    agg = _SentenceAggregator(min_chars=4)
+    # The "." in 3.5 is followed by a digit, not whitespace → not a cut point.
+    out = agg.push("It costs 3.5 dollars total. Next")
+    assert out == ["It costs 3.5 dollars total."]
+
+
+def test_aggregator_flush_empty_is_noop():
+    agg = _SentenceAggregator()
+    assert agg.flush() == []
+    assert agg.has_emitted is False
+
+
+# ---------------------------------------------------------------------------
+# WidgetVoiceBridge — turn streaming
+# ---------------------------------------------------------------------------
+
+
+async def test_blank_user_turn_is_ignored(monkeypatch):
+    monkeypatch.setattr(vb, "run_chat_turn", _stub_run_chat_turn())
+    bridge, task, _ = _make_bridge()
+    await bridge.handle_user_turn("   ")
+    assert bridge._inflight is None
+    assert _spoken(task) == []
+
+
+async def test_speaks_sentences_and_emits_transcript(monkeypatch):
+    monkeypatch.setattr(
+        vb,
+        "run_chat_turn",
+        _stub_run_chat_turn(
+            SSEEvent("assistant_token", {"delta": "Hello there, friend. "}),
+            SSEEvent("assistant_token", {"delta": "How are you today?"}),
+            SSEEvent("turn_end", {"session_status": "ACTIVE"}),
+        ),
+    )
+    bridge, task, emit = _make_bridge()
+    await _run_one_turn(bridge)
+
+    spoken = _spoken(task)
+    assert spoken == ["Hello there, friend.", "How are you today?"]
+    # Each spoken chunk also rides an assistant-transcript RTVI event.
+    transcripts = [p["content"] for p in _emitted(emit, "assistant-transcript")]
+    assert transcripts == ["Hello there, friend.", "How are you today?"]
+    # turn-end is emitted once.
+    assert len(_emitted(emit, "turn-end")) == 1
+
+
+async def test_strips_ui_stream_markers_from_tts(monkeypatch):
+    monkeypatch.setattr(
+        vb,
+        "run_chat_turn",
+        _stub_run_chat_turn(
+            SSEEvent(
+                "assistant_token",
+                {"delta": 'Here you go. <ui_stream>{"op":"add"}</ui_stream> Done now.'},
+            ),
+            SSEEvent("turn_end", {"session_status": "ACTIVE"}),
+        ),
+    )
+    bridge, task, _ = _make_bridge()
+    await _run_one_turn(bridge)
+    joined = " ".join(_spoken(task))
+    assert "<ui_stream>" not in joined
+    assert '"op"' not in joined
+    assert "Here you go." in joined
+    assert "Done now." in joined
+
+
+async def test_ui_op_forwarded_as_rtvi(monkeypatch):
+    op = {"op": "add", "id": "root", "type": "Carousel"}
+    monkeypatch.setattr(
+        vb,
+        "run_chat_turn",
+        _stub_run_chat_turn(
+            SSEEvent("ui_op", {"op": op}),
+            SSEEvent("turn_end", {"session_status": "ACTIVE"}),
+        ),
+    )
+    bridge, _, emit = _make_bridge()
+    await _run_one_turn(bridge)
+    assert _emitted(emit, "ui-op") == [{"op": op}]
+
+
+async def test_filler_fires_once_before_prose(monkeypatch):
+    monkeypatch.setattr(
+        vb,
+        "run_chat_turn",
+        _stub_run_chat_turn(
+            SSEEvent("function_call_started", {"name": "get_cart"}),
+            SSEEvent("function_call_started", {"name": "search"}),
+            SSEEvent("assistant_token", {"delta": "Your cart has two items total."}),
+            SSEEvent("turn_end", {"session_status": "ACTIVE"}),
+        ),
+    )
+    bridge, task, _ = _make_bridge()
+    await _run_one_turn(bridge)
+    spoken = _spoken(task)
+    # Exactly one filler (default phrase), before the prose, despite two tool
+    # calls.
+    assert spoken[0] == _DEFAULT_FILLER_PHRASE
+    assert spoken.count(_DEFAULT_FILLER_PHRASE) == 1
+    assert "Your cart has two items total." in spoken
+
+
+async def test_no_filler_when_prose_came_first(monkeypatch):
+    monkeypatch.setattr(
+        vb,
+        "run_chat_turn",
+        _stub_run_chat_turn(
+            SSEEvent("assistant_token", {"delta": "Let me look that up for you. "}),
+            SSEEvent("function_call_started", {"name": "get_cart"}),
+            SSEEvent("assistant_token", {"delta": "You have two items."}),
+            SSEEvent("turn_end", {"session_status": "ACTIVE"}),
+        ),
+    )
+    bridge, task, _ = _make_bridge()
+    await _run_one_turn(bridge)
+    assert _DEFAULT_FILLER_PHRASE not in _spoken(task)
+
+
+async def test_barge_in_cancel_drops_tail(monkeypatch):
+    gate = asyncio.Event()
+
+    async def _gen(*, session_id, user_content, llm=None, context_placement=None):
+        yield SSEEvent(
+            "assistant_token", {"delta": "This is the first sentence here. "}
+        )
+        await gate.wait()  # block until the test releases (it won't — cancelled)
+        yield SSEEvent("assistant_token", {"delta": "Tail that must be dropped."})
+        yield SSEEvent("turn_end", {"session_status": "ACTIVE"})
+
+    monkeypatch.setattr(vb, "run_chat_turn", _gen)
+    bridge, task, _ = _make_bridge()
+    await bridge.handle_user_turn("hi")
+    inflight = bridge._inflight
+    assert inflight is not None
+    # Let the first sentence flush, then barge in.
+    await asyncio.sleep(0.02)
+    assert _spoken(task) == ["This is the first sentence here."]
+    await bridge.cancel_inflight()
+    # _run_turn swallows the CancelledError (uncancel pattern) so the task
+    # completes cleanly — the next handle_user_turn drains it.
+    await bridge._drain()
+    # The tail never spoke — cancel stopped the generator and bumped the
+    # generation so any late frame is dropped.
+    assert _spoken(task) == ["This is the first sentence here."]
+    # The Redis lock acquired for the turn was released despite the cancel.
+    assert _FakeLock.acquired == 1 and _FakeLock.released == 1
+
+
+async def test_lock_busy_skips_turn(monkeypatch):
+    _FakeLock.raise_on_acquire = True
+    monkeypatch.setattr(
+        vb,
+        "run_chat_turn",
+        _stub_run_chat_turn(
+            SSEEvent("assistant_token", {"delta": "This should never be spoken."}),
+            SSEEvent("turn_end", {"session_status": "ACTIVE"}),
+        ),
+    )
+    bridge, task, emit = _make_bridge()
+    await _run_one_turn(bridge)
+    # Lock contended → the turn is skipped (no TTS) and a busy error is emitted.
+    assert _spoken(task) == []
+    busy = [p for p in _emitted(emit, "error") if p.get("code") == "busy"]
+    assert busy
+
+
+async def test_lock_released_after_normal_turn(monkeypatch):
+    monkeypatch.setattr(
+        vb,
+        "run_chat_turn",
+        _stub_run_chat_turn(
+            SSEEvent("assistant_token", {"delta": "All done here."}),
+            SSEEvent("turn_end", {"session_status": "ACTIVE"}),
+        ),
+    )
+    bridge, _, _ = _make_bridge()
+    await _run_one_turn(bridge)
+    assert _FakeLock.acquired == 1 and _FakeLock.released == 1
+
+
+async def test_error_event_emits_rtvi_error(monkeypatch):
+    monkeypatch.setattr(
+        vb,
+        "run_chat_turn",
+        _stub_run_chat_turn(
+            SSEEvent("error", {"code": "boom", "message": "kaboom"}),
+            SSEEvent("turn_end", {"session_status": "FAILED"}),
+        ),
+    )
+    bridge, _, emit = _make_bridge()
+    await _run_one_turn(bridge)
+    errors = _emitted(emit, "error")
+    assert errors and errors[0]["message"] == "kaboom"
+
+
+# ---------------------------------------------------------------------------
+# WidgetVoiceBridge — greeting gating
+# ---------------------------------------------------------------------------
+
+
+def _msg(role: ChatMessageRole, content):
+    return SimpleNamespace(role=role, content=content)
+
+
+async def test_greeting_spoken_on_first_attach(monkeypatch):
+    async def _fake_messages(session_id):
+        return [_msg(ChatMessageRole.ASSISTANT, "Hi! How can I help?")]
+
+    monkeypatch.setattr(vb, "list_chat_messages_for_session", _fake_messages)
+    bridge, task, _ = _make_bridge()
+    await bridge.maybe_speak_greeting()
+    assert _spoken(task) == ["Hi! How can I help?"]
+
+
+async def test_greeting_skipped_when_user_already_spoke(monkeypatch):
+    async def _fake_messages(session_id):
+        return [
+            _msg(ChatMessageRole.ASSISTANT, "Hi! How can I help?"),
+            _msg(ChatMessageRole.USER, "show me shoes"),
+            _msg(ChatMessageRole.ASSISTANT, "Here are some shoes."),
+        ]
+
+    monkeypatch.setattr(vb, "list_chat_messages_for_session", _fake_messages)
+    bridge, task, _ = _make_bridge()
+    await bridge.maybe_speak_greeting()
+    assert _spoken(task) == []  # mid-conversation reconnect — no re-greet
+
+
+async def test_greeting_fires_despite_tool_result_user_rows(monkeypatch):
+    # Tool-result rows are role=USER, content=None — they must NOT count as the
+    # user having spoken (the greeting off-by-one guard).
+    async def _fake_messages(session_id):
+        return [
+            _msg(ChatMessageRole.ASSISTANT, "Hi! How can I help?"),
+            _msg(ChatMessageRole.USER, None),  # synthetic tool_result row
+        ]
+
+    monkeypatch.setattr(vb, "list_chat_messages_for_session", _fake_messages)
+    bridge, task, _ = _make_bridge()
+    await bridge.maybe_speak_greeting()
+    assert _spoken(task) == ["Hi! How can I help?"]
+
+
+# ---------------------------------------------------------------------------
+# WidgetVoiceBridge — HITL (voice approval cards)
+# ---------------------------------------------------------------------------
+
+
+async def test_forwards_approval_request_to_rtvi(monkeypatch):
+    monkeypatch.setattr(
+        vb,
+        "run_chat_turn",
+        _stub_run_chat_turn(
+            SSEEvent("assistant_token", {"delta": "Let me get that approved. "}),
+            SSEEvent(
+                "function_approval_requested",
+                {
+                    "tool_call_id": "tc1",
+                    "name": "request_human_callback",
+                    "args": {"phone": "x"},
+                    "prompt": "Connect you to a human?",
+                },
+            ),
+            SSEEvent(
+                "turn_end", {"session_status": "ACTIVE", "awaiting_approval": True}
+            ),
+        ),
+    )
+    bridge, task, emit = _make_bridge()
+    await _run_one_turn(bridge)
+    spoken = _spoken(task)
+    # Prose before the gate is still spoken...
+    assert "Let me get that approved." in spoken
+    # ...the approval prompt is spoken aloud so voice users hear the question...
+    assert "Connect you to a human?" in spoken
+    # ...and the approval card is surfaced live with widget-shaped fields.
+    reqs = _emitted(emit, "function-approval-request")
+    assert reqs and reqs[0] == {
+        "approval_id": "tc1",
+        "function_name": "request_human_callback",
+        "arguments": {"phone": "x"},
+        "prompt": "Connect you to a human?",
+    }
+
+
+async def test_forwards_function_call_lifecycle_to_rtvi(monkeypatch):
+    monkeypatch.setattr(
+        vb,
+        "run_chat_turn",
+        _stub_run_chat_turn(
+            SSEEvent(
+                "function_call_started",
+                {
+                    "name": "search_products",
+                    "args": {"q": "bottle"},
+                    "tool_call_id": "tc1",
+                },
+            ),
+            SSEEvent(
+                "function_call_completed",
+                {
+                    "name": "search_products",
+                    "tool_call_id": "tc1",
+                    "result_summary": "ok",
+                },
+            ),
+            SSEEvent("turn_end", {"session_status": "ACTIVE"}),
+        ),
+    )
+    bridge, task, emit = _make_bridge()
+    await _run_one_turn(bridge)
+    # The tool's start/finish are surfaced to the widget so the orb can show a
+    # "executing <tool>" state (start carries name + args; completion clears it).
+    started = _emitted(emit, "function-call-started")
+    completed = _emitted(emit, "function-call-completed")
+    assert started and started[0] == {
+        "name": "search_products",
+        "args": {"q": "bottle"},
+        "tool_call_id": "tc1",
+    }
+    assert completed and completed[0] == {
+        "name": "search_products",
+        "tool_call_id": "tc1",
+    }
+
+
+async def test_handle_approval_decision_drives_resume(monkeypatch):
+    captured: dict = {}
+
+    async def _stub_approval(
+        *, session_id, tool_call_id, approved, reason=None, llm=None
+    ):
+        captured.update(
+            session_id=session_id, tool_call_id=tool_call_id, approved=approved
+        )
+        yield SSEEvent(
+            "function_approval_resolved",
+            {"tool_call_id": tool_call_id, "status": "approved", "reason": None},
+        )
+        yield SSEEvent("assistant_token", {"delta": "Done — connecting you now."})
+        yield SSEEvent("turn_end", {"session_status": "ACTIVE"})
+
+    monkeypatch.setattr(vb, "run_chat_approval_turn", _stub_approval)
+    bridge, task, emit = _make_bridge()
+    await bridge.handle_approval_decision("tc1", True, None)
+    inflight = bridge._inflight
+    assert inflight is not None
+    await inflight
+
+    assert captured == {"session_id": "sess-1", "tool_call_id": "tc1", "approved": True}
+    resolved = _emitted(emit, "function-approval-resolved")
+    assert resolved and resolved[0]["approval_id"] == "tc1"
+    assert resolved[0]["status"] == "approved"
+    assert "Done — connecting you now." in _spoken(task)
+    # Lock acquired + released for the approval turn too.
+    assert _FakeLock.acquired == 1 and _FakeLock.released == 1
+
+
+async def test_handle_approval_decision_ignores_blank_id(monkeypatch):
+    monkeypatch.setattr(vb, "run_chat_approval_turn", _stub_run_chat_turn())
+    bridge, _, _ = _make_bridge()
+    await bridge.handle_approval_decision(None, True, None)
+    assert bridge._inflight is None

--- a/tests/test_voice_ui_stream.py
+++ b/tests/test_voice_ui_stream.py
@@ -1,0 +1,207 @@
+"""Tests for VoiceUiStreamProcessor + the ui-action text coercion.
+
+Covers the clairvoyance backend of widget voice-as-chat (VOICE_AS_CHAT.md):
+  * A1 — generative UI over RTVI: prose passthrough (markers stripped so TTS
+    never speaks JSON), ui-op emission reusing chat's heal/parse/validate,
+    markers split across frames, per-template allowlist gating, and the
+    per-assistant-response known-ids reset.
+  * A2 — ui-action coercion: validation + whitespace trim + length cap.
+
+The processor is exercised end-to-end through pipecat's run_test harness so
+super().process_frame() + push_frame() behave exactly as in a live pipeline.
+"""
+
+from __future__ import annotations
+
+from typing import List
+from unittest.mock import AsyncMock
+
+from pipecat.frames.frames import (
+    Frame,
+    LLMFullResponseEndFrame,
+    LLMFullResponseStartFrame,
+    LLMTextFrame,
+)
+from pipecat.tests.utils import run_test
+
+from app.ai.voice.agents.breeze_buddy.processors.voice_ui_stream import (
+    VoiceUiStreamProcessor,
+    coerce_ui_action_text,
+)
+from app.ai.voice.agents.breeze_buddy.template.ui_catalog import resolve_allowlist
+
+
+def _make(emit: AsyncMock, allowlist=None) -> VoiceUiStreamProcessor:
+    return VoiceUiStreamProcessor(
+        emit=emit,
+        allowlist=allowlist if allowlist is not None else resolve_allowlist(),
+    )
+
+
+def _response(*text_frames: str) -> List[Frame]:
+    """Wrap text deltas in a single bot response (start … deltas … end)."""
+    frames: List[Frame] = [LLMFullResponseStartFrame()]
+    frames.extend(LLMTextFrame(text=t) for t in text_frames)
+    frames.append(LLMFullResponseEndFrame())
+    return frames
+
+
+def _spoken(down_frames) -> str:
+    return "".join(f.text for f in down_frames if isinstance(f, LLMTextFrame))
+
+
+def _emitted_ops(emit: AsyncMock):
+    return [
+        c.args[1]["op"] for c in emit.await_args_list if c.args and c.args[0] == "ui-op"
+    ]
+
+
+# ---------------------------------------------------------------------------
+# A1 — generative UI over RTVI
+# ---------------------------------------------------------------------------
+
+
+async def test_prose_only_passes_through_no_ui_op():
+    emit = AsyncMock()
+    proc = _make(emit)
+    down, _ = await run_test(proc, frames_to_send=_response("Hello there!"))
+    assert _spoken(down) == "Hello there!"
+    assert _emitted_ops(emit) == []
+
+
+async def test_ui_stream_block_strips_markers_and_emits_ops():
+    emit = AsyncMock()
+    proc = _make(emit)
+    block = (
+        "Here are some options. "
+        "<ui_stream>\n"
+        '{"op":"add","id":"root","type":"Stack"}\n'
+        '{"op":"add","id":"t1","type":"Text","parent":"root","props":{"text":"Hi"}}\n'
+        "</ui_stream>"
+        " Anything else?"
+    )
+    down, _ = await run_test(proc, frames_to_send=_response(block))
+
+    spoken = _spoken(down)
+    # The bot must never speak the JSON or the markers.
+    assert "<ui_stream>" not in spoken
+    assert "</ui_stream>" not in spoken
+    assert '"op"' not in spoken
+    assert "Here are some options." in spoken
+    assert "Anything else?" in spoken
+
+    ops = _emitted_ops(emit)
+    assert len(ops) == 2
+    assert ops[0]["id"] == "root" and ops[0]["type"] == "Stack"
+    assert ops[1]["id"] == "t1" and ops[1]["type"] == "Text"
+
+
+async def test_markers_split_across_frames():
+    emit = AsyncMock()
+    proc = _make(emit)
+    parts = [
+        "Look ",
+        "<ui_st",
+        "ream>\n",
+        '{"op":"add","id":"roo',
+        't","type":"Stack"}\n',
+        "</ui_str",
+        "eam> done",
+    ]
+    down, _ = await run_test(proc, frames_to_send=_response(*parts))
+
+    spoken = _spoken(down)
+    assert "ui_stream" not in spoken
+    assert "Look" in spoken
+    assert "done" in spoken
+
+    ops = _emitted_ops(emit)
+    assert len(ops) == 1
+    assert ops[0]["id"] == "root" and ops[0]["type"] == "Stack"
+
+
+async def test_disabled_primitive_is_not_emitted():
+    emit = AsyncMock()
+    allow = resolve_allowlist(enabled_groups=["core"], disabled_primitives=["Carousel"])
+    proc = _make(emit, allow)
+    block = '<ui_stream>\n{"op":"add","id":"root","type":"Carousel"}\n</ui_stream>'
+    down, _ = await run_test(proc, frames_to_send=_response(block))
+
+    # Carousel disabled for this template → dropped server-side, never emitted.
+    assert _emitted_ops(emit) == []
+    assert "Carousel" not in _spoken(down)
+
+
+async def test_allowed_primitive_still_emits_with_restricted_allowlist():
+    emit = AsyncMock()
+    allow = resolve_allowlist(enabled_groups=["core"], disabled_primitives=["Carousel"])
+    proc = _make(emit, allow)
+    block = '<ui_stream>\n{"op":"add","id":"root","type":"Stack"}\n</ui_stream>'
+    await run_test(proc, frames_to_send=_response(block))
+
+    ops = _emitted_ops(emit)
+    assert len(ops) == 1 and ops[0]["type"] == "Stack"
+
+
+async def test_known_ids_reset_per_assistant_response():
+    """A voice call is one long session; each bot response must start with a
+    fresh id registry. Without the reset the healer would rename the second
+    response's duplicate ``root`` to ``root__2`` (A1.3)."""
+    emit = AsyncMock()
+    proc = _make(emit)
+    block = '<ui_stream>\n{"op":"add","id":"root","type":"Stack"}\n</ui_stream>'
+    frames = _response(block) + _response(block)
+    await run_test(proc, frames_to_send=frames)
+
+    ops = _emitted_ops(emit)
+    assert len(ops) == 2
+    # Reset ⇒ both responses emit a clean ``root`` (no dedupe rename).
+    assert all(op["id"] == "root" for op in ops)
+
+
+async def test_unclosed_block_drops_partial_and_keeps_prose():
+    emit = AsyncMock()
+    proc = _make(emit)
+    # Opens a block but never closes it before the response ends.
+    block = 'before <ui_stream>\n{"op":"add","id":"root","ty'
+    down, _ = await run_test(proc, frames_to_send=_response(block))
+
+    spoken = _spoken(down)
+    assert "before" in spoken
+    assert "ui_stream" not in spoken
+    # Partial JSONL inside the unclosed block is dropped, not emitted/spoken.
+    assert _emitted_ops(emit) == []
+    assert '"op"' not in spoken
+
+
+# ---------------------------------------------------------------------------
+# A2 — ui-action text coercion
+# ---------------------------------------------------------------------------
+
+
+def test_coerce_ui_action_valid():
+    assert coerce_ui_action_text({"msg": "Tell me about Dawn"}, 2000) == (
+        "Tell me about Dawn"
+    )
+
+
+def test_coerce_ui_action_trims_whitespace():
+    assert coerce_ui_action_text({"msg": "  hi  "}, 2000) == "hi"
+
+
+def test_coerce_ui_action_truncates_to_cap():
+    assert coerce_ui_action_text({"msg": "x" * 50}, 10) == "x" * 10
+
+
+def test_coerce_ui_action_rejects_blank():
+    assert coerce_ui_action_text({"msg": "   "}, 2000) is None
+
+
+def test_coerce_ui_action_rejects_missing():
+    assert coerce_ui_action_text({}, 2000) is None
+    assert coerce_ui_action_text(None, 2000) is None
+
+
+def test_coerce_ui_action_rejects_non_string():
+    assert coerce_ui_action_text({"msg": 123}, 2000) is None
+    assert coerce_ui_action_text({"msg": {"x": 1}}, 2000) is None


### PR DESCRIPTION
## What

Re-architects Buddy Assist **widget voice** from a dual-brain design (a separate voice FlowManager+LLM kept in sync with the chat `ChatAgent`) to **stream mode** (`ExecutionMode.DAILY_STREAM` — STT in / TTS out, no LLM in the pipeline) driven by the existing chat `ChatAgent`. Voice becomes pure audio I/O around one brain, so `cart_id`, content-block history, `agent_state`, carousels, and HITL are all inherited from chat for free.

**Telephony (Twilio/Plivo/Exotel) is untouched** — it never uses `DAILY_STREAM` and runs no chat session.

## Key changes

- **`chat/turn_core.py`** (new) — channel-agnostic `run_chat_turn` (+ approval continuation) factored out of the chat HTTP handler so the voice subprocess drives the same brain.
- **`chat/voice_bridge.py`** (new) — `WidgetVoiceBridge` taps `on_user_turn_stopped` → `run_chat_turn` → adapts the SSE stream into `TTSSpeakFrame` + RTVI events; holds the per-session Redis lock per turn; barge-in cancels the in-flight turn.
- **HITL over voice** rides the chat approval path: the gated call surfaces an inline, persistent approval card (same `kind:'approval'` message as chat); the prompt is spoken **audio-only** so the card text isn't duplicated.
- Forward `function-call-started`/`function-call-completed` RTVI events so the widget can show a "thinking / executing <tool>" state on the voice orb.
- **Carousel-click injection** (`ui-action`) during voice.
- **Deletes the dual-brain sync layer** (`prepare_resume_node`, voice drain, ui-blocks-for-voice, `agent_state` seeding).

### Deferred (out of this PR)

- **Generative UI _output_ over RTVI** for non-widget Daily *agent-mode* voice (`VoiceUiStreamProcessor`) is **deferred**. The processor module is **kept but not plugged into the pipeline**; the wiring was removed from `agent/__init__.py`, `agent/pipeline.py`, `agent/flow.py`. Widget voice (stream mode) doesn't use it — the chat `ChatAgent` emits/persists `ui_op` itself. See **`docs/widget/VOICE_GENERATIVE_UI_TODO.md`** for the re-wiring checklist. (`coerce_ui_action_text` / click-to-talk is unrelated and stays.)

## Testing

- `uv run pyrefly check` — 0 errors
- `uv run black --check` / isort / autoflake — clean
- `JWT_SECRET_KEY=test JWT_ALGORITHM=HS256 uv run pytest tests/ -q` — **553 passed, 1 xfailed**
- Manual E2E on the local harness: voice↔chat parity (cart inheritance, carousels), inline HITL approval (appears mid-call, persists with resolved badge), barge-in stops TTS mid-sentence.

Pairs with the loom frontend PR (SDK + widget).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
