### PR TITLE
docs(voice): TODO for stream-mode ui_op aggregator flush (colon-tail leak)

### DIFF
--- a/app/ai/voice/agents/breeze_buddy/chat/voice_bridge.py
+++ b/app/ai/voice/agents/breeze_buddy/chat/voice_bridge.py
@@ -344,6 +344,20 @@ class WidgetVoiceBridge:
                 for chunk in agg.push(delta):
                     await self._speak(chunk, gen)
             elif ev.event == "ui_op":
+                # TODO(voice-as-chat): flush the sentence aggregator before
+                # emitting the ui-op, mirroring function_call_started /
+                # function_approval_requested / turn_end below. A <ui_stream>
+                # block is a hard turn boundary (the widget finalizes the open
+                # transcript bubble on ui-op), but unlike those branches this one
+                # does NOT agg.flush() first. If the prose before the marker ends
+                # mid-sentence — no terminal punctuation/newline, e.g. a trailing
+                # colon ("...best options:") — that tail stays buffered and gets
+                # prepended to the post-carousel prose, leaking into the next
+                # bubble. Low severity (the <ui_stream> marker is usually
+                # newline-led, so the buffer is empty at the boundary), deferred.
+                # Fix: `for chunk in agg.flush(): await self._speak(chunk, gen)`
+                # immediately before the emit below. See docs/widget/
+                # VOICE_GENERATIVE_UI_TODO.md.
                 op = ev.data.get("op") if isinstance(ev.data, dict) else None
                 if op is not None:
                     await self._emit_rtvi(_RTVI_UI_OP, {"op": op})

--- a/docs/widget/VOICE_GENERATIVE_UI_TODO.md
+++ b/docs/widget/VOICE_GENERATIVE_UI_TODO.md
@@ -72,3 +72,21 @@ carousels/cards. Opt-in per template via `configurations.ui_catalog` + the
 
 Reference for the original design: the generative-UI-over-RTVI work (commit `344863e`) and
 `docs/widget/VOICE_AS_CHAT.md` (§A1).
+
+---
+
+## Related deferred fix — stream-mode `ui_op` aggregator flush (low severity)
+
+In the **widget stream-mode** bridge (`chat/voice_bridge.py` `_consume_events`), the `ui_op`
+branch emits the `ui-op` RTVI event **without** first flushing the `_SentenceAggregator` — unlike
+`function_call_started` / `function_approval_requested` / `turn_end`, which all `agg.flush()` before
+their boundary event. A `<ui_stream>` block is a hard turn boundary (the widget finalizes the open
+transcript bubble on `ui-op`), so if the prose immediately before the marker ends mid-sentence (no
+terminal punctuation/newline — e.g. a trailing colon, `"...best options:"`), that buffered tail gets
+prepended to the post-carousel prose and **leaks into the next bubble**.
+
+- **Severity:** low. The `<ui_stream>` marker is normally newline-led, so the aggregator is usually
+  empty at the boundary; the leak only shows on a mid-sentence cutover.
+- **Fix:** add `for chunk in agg.flush(): await self._speak(chunk, gen)` immediately before the
+  `_emit_rtvi(_RTVI_UI_OP, ...)` call, mirroring the other boundary branches. See the `TODO(voice-as-chat)`
+  comment at that site.


### PR DESCRIPTION
## What

Documents a known, low-severity issue in the widget **stream-mode** voice bridge as a deferred TODO (no behavior change).

In `chat/voice_bridge.py` `_consume_events`, the `ui_op` branch emits the `ui-op` RTVI event **without** flushing the `_SentenceAggregator` first — unlike `function_call_started` / `function_approval_requested` / `turn_end`, which all `agg.flush()` before their boundary event. A `<ui_stream>` block is a hard turn boundary (the widget finalizes the open transcript bubble on `ui-op`), so if the prose before the marker ends mid-sentence (e.g. a trailing colon, `"...best options:"`), that buffered tail leaks into the post-carousel bubble.

## Why deferred

Low severity — the `<ui_stream>` marker is normally newline-led, so the aggregator is usually empty at the boundary; the leak only surfaces on a mid-sentence cutover. Captured now (right after the voice-as-chat release) so it isn't lost.

## Changes

- Inline `TODO(voice-as-chat)` at the `ui_op` branch with the exact one-line fix.
- Matching note in `docs/widget/VOICE_GENERATIVE_UI_TODO.md`.

**Fix (for the follow-up):** `for chunk in agg.flush(): await self._speak(chunk, gen)` immediately before the `_emit_rtvi(_RTVI_UI_OP, ...)` call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added notes documenting a known issue in voice-generative UI where buffered text can be incorrectly carried into subsequent content during certain operations.

* **Chores**
  * Added tracking comment for the deferred fix with detailed description of the intended resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->