### PR TITLE
feat(widget): add push-to-talk STT transcription endpoint

### DIFF
--- a/app/ai/voice/stt/__init__.py
+++ b/app/ai/voice/stt/__init__.py
@@ -13,8 +13,13 @@ from .google import build_google_stt
 from .openai import build_openai_stt
 from .sarvam import SarvamConfig, build_sarvam_stt, get_sarvam_language
 from .soniox import SonioxConfig, build_soniox_stt
+from .transcribe import Transcription, TranscriptionError, transcribe_audio
 
 __all__ = [
+    # One-shot (push-to-talk) transcription
+    "Transcription",
+    "TranscriptionError",
+    "transcribe_audio",
     # AssemblyAI
     "build_assemblyai_stt",
     # Deepgram

--- a/app/ai/voice/stt/transcribe.py
+++ b/app/ai/voice/stt/transcribe.py
@@ -1,0 +1,291 @@
+"""One-shot (push-to-talk) speech-to-text.
+
+The builders elsewhere in this package create *streaming* Pipecat STT
+services (websocket / pipeline bound). This module is the opposite: a
+single, direct "audio bytes -> text" call for short clips — e.g. the
+chat widget's push-to-talk button. No pipeline, no batching/polling.
+
+Provider is chosen by the caller from the template's
+``stt_configuration.provider``. OpenAI, Deepgram, and Sarvam each expose
+a simple token-auth REST endpoint that returns the transcript in one
+response, so we hit those directly with ``httpx``. Soniox — the platform's
+primary provider — has no synchronous endpoint, so its one-shot path uses
+the async file API (upload → create job → poll → fetch transcript → cleanup).
+Google (OAuth-only) still has no direct one-shot path, so a template
+configured for it transcribes the clip with OpenAI Whisper instead. Any
+provider's transient/format failure also falls back to Whisper so
+push-to-talk "just works".
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional, Union
+
+from app.core.config.dynamic import SONIOX_ASYNC_MODEL
+from app.core.config.static import (
+    DEEPGRAM_API_KEY,
+    OPENAI_STT_API_KEY,
+    OPENAI_STT_MODEL,
+    SARVAM_API_KEY,
+    SONIOX_API_KEY,
+)
+from app.core.logger import logger
+from app.core.transport.http_client import create_http_client
+
+__all__ = ["Transcription", "TranscriptionError", "transcribe_audio"]
+
+_HTTP_TIMEOUT_SECONDS = 30.0
+
+_OPENAI_URL = "https://api.openai.com/v1/audio/transcriptions"
+_DEEPGRAM_URL = "https://api.deepgram.com/v1/listen"
+_SARVAM_URL = "https://api.sarvam.ai/speech-to-text"
+
+# Soniox has no synchronous endpoint; one-shot transcription goes through its
+# async file API. Short push-to-talk clips finish in 1-3s, so a brief poll loop
+# (capped at ~28s) is enough before falling back to Whisper.
+_SONIOX_BASE_URL = "https://api.soniox.com"
+_SONIOX_POLL_INTERVAL_SECONDS = 0.7
+_SONIOX_MAX_POLLS = 40
+
+LanguageHint = Optional[Union[str, List[str]]]
+
+
+@dataclass
+class Transcription:
+    """Result of a one-shot transcription."""
+
+    text: str
+    provider: str
+
+
+class TranscriptionError(Exception):
+    """Raised when transcription fails and no fallback could recover it."""
+
+
+def _short_lang(language: LanguageHint) -> Optional[str]:
+    """ISO-639-1 hint for OpenAI / Deepgram (``"en-IN"`` -> ``"en"``)."""
+    if isinstance(language, list):
+        language = language[0] if language else None
+    if not language:
+        return None
+    return str(language).split("-")[0].lower() or None
+
+
+def _sarvam_lang(language: LanguageHint) -> str:
+    """Sarvam wants a BCP-47 region code (``"hi-IN"``) or ``"unknown"`` to
+    auto-detect — a bare ``"hi"`` is not accepted, so fall back to auto."""
+    if isinstance(language, list):
+        language = language[0] if language else None
+    if not language:
+        return "unknown"
+    s = str(language)
+    return s if "-" in s else "unknown"
+
+
+async def _openai(
+    audio: bytes, content_type: Optional[str], filename: str, lang: Optional[str]
+) -> Transcription:
+    headers = {"Authorization": f"Bearer {OPENAI_STT_API_KEY}"}
+    files = {"file": (filename, audio, content_type or "audio/webm")}
+    data = {"model": OPENAI_STT_MODEL or "whisper-1"}
+    if lang:
+        data["language"] = lang
+    async with create_http_client(timeout=_HTTP_TIMEOUT_SECONDS) as client:
+        resp = await client.post(_OPENAI_URL, headers=headers, files=files, data=data)
+    resp.raise_for_status()
+    text = (resp.json().get("text") or "").strip()
+    return Transcription(text=text, provider="openai")
+
+
+async def _deepgram(
+    audio: bytes, content_type: Optional[str], lang: Optional[str]
+) -> Transcription:
+    params = {"model": "nova-3", "smart_format": "true", "language": lang or "multi"}
+    headers = {
+        "Authorization": f"Token {DEEPGRAM_API_KEY}",
+        "Content-Type": content_type or "audio/webm",
+    }
+    async with create_http_client(timeout=_HTTP_TIMEOUT_SECONDS) as client:
+        resp = await client.post(
+            _DEEPGRAM_URL, params=params, headers=headers, content=audio
+        )
+    resp.raise_for_status()
+    alts = resp.json()["results"]["channels"][0]["alternatives"]
+    text = (alts[0]["transcript"] if alts else "").strip()
+    return Transcription(text=text, provider="deepgram")
+
+
+async def _sarvam(
+    audio: bytes, content_type: Optional[str], filename: str, lang_code: str
+) -> Transcription:
+    headers = {"api-subscription-key": SARVAM_API_KEY or ""}
+    files = {"file": (filename, audio, content_type or "audio/wav")}
+    data = {"model": "saarika:v2", "language_code": lang_code}
+    async with create_http_client(timeout=_HTTP_TIMEOUT_SECONDS) as client:
+        resp = await client.post(_SARVAM_URL, headers=headers, files=files, data=data)
+    resp.raise_for_status()
+    return Transcription(
+        text=(resp.json().get("transcript") or "").strip(), provider="sarvam"
+    )
+
+
+def _soniox_lang_hints(language: LanguageHint) -> Optional[List[str]]:
+    """Soniox wants an array of short language codes (``["en", "hi"]``); omit
+    entirely to auto-detect. ``"en-IN"`` -> ``"en"``."""
+    if isinstance(language, list):
+        langs: List[str] = [str(item) for item in language]
+    elif language:
+        langs = [str(language)]
+    else:
+        return None
+    hints = [item.split("-")[0].lower() for item in langs if item]
+    return hints or None
+
+
+async def _soniox(
+    audio: bytes,
+    content_type: Optional[str],
+    filename: str,
+    language: LanguageHint,
+) -> Transcription:
+    """One-shot transcription via Soniox's async file API.
+
+    Soniox has no synchronous endpoint, so this uploads the clip, creates an
+    async job, polls until it completes, fetches the transcript, then best-effort
+    deletes both server-side records. Raises a plain ``Exception`` (never
+    :class:`TranscriptionError`) on any failure so ``transcribe_audio`` recovers
+    via Whisper.
+    """
+    file_id: Optional[str] = None
+    transcription_id: Optional[str] = None
+    async with create_http_client(
+        timeout=_HTTP_TIMEOUT_SECONDS,
+        base_url=_SONIOX_BASE_URL,
+        headers={"Authorization": f"Bearer {SONIOX_API_KEY}"},
+    ) as client:
+        try:
+            # 1. Upload bytes — httpx sets the multipart boundary; never hand-set
+            #    Content-Type (the container/codec is auto-detected anyway).
+            up = await client.post(
+                "/v1/files",
+                files={"file": (filename, audio, content_type or "audio/webm")},
+            )
+            up.raise_for_status()
+            file_id = up.json()["id"]
+
+            # 2. Create the async transcription job. The model resolves
+            #    Redis → env → default, so it can be bumped without a deploy.
+            body: Dict[str, Any] = {
+                "model": await SONIOX_ASYNC_MODEL(),
+                "file_id": file_id,
+            }
+            hints = _soniox_lang_hints(language)
+            if hints:
+                body["language_hints"] = hints
+            cr = await client.post("/v1/transcriptions", json=body)
+            cr.raise_for_status()
+            transcription_id = cr.json()["id"]
+
+            # 3. Poll until terminal (short clips finish in a few seconds).
+            status = ""
+            for _ in range(_SONIOX_MAX_POLLS):
+                st = await client.get(f"/v1/transcriptions/{transcription_id}")
+                st.raise_for_status()
+                doc = st.json()
+                status = doc.get("status", "")
+                if status == "error":
+                    raise RuntimeError(
+                        doc.get("error_message") or "soniox transcription error"
+                    )
+                if status == "completed":
+                    break
+                await asyncio.sleep(_SONIOX_POLL_INTERVAL_SECONDS)
+            if status != "completed":
+                raise RuntimeError("soniox transcription timed out")
+
+            # 4. Fetch transcript — prefer the top-level text, else join tokens
+            #    (token.text already carries leading spaces, so empty-string join).
+            tr = await client.get(f"/v1/transcriptions/{transcription_id}/transcript")
+            tr.raise_for_status()
+            data = tr.json()
+            text = (data.get("text") or "").strip()
+            if not text:
+                text = "".join(
+                    t.get("text", "") for t in (data.get("tokens") or [])
+                ).strip()
+            if not text:
+                raise RuntimeError("soniox returned empty transcript")
+            return Transcription(text=text, provider="soniox")
+        finally:
+            # 5. Best-effort cleanup — never break the request path.
+            cleanup_paths: List[str] = []
+            if transcription_id:
+                cleanup_paths.append(f"/v1/transcriptions/{transcription_id}")
+            if file_id:
+                cleanup_paths.append(f"/v1/files/{file_id}")
+            for path in cleanup_paths:
+                try:
+                    await client.delete(path)
+                except Exception:
+                    pass
+
+
+async def transcribe_audio(
+    audio: bytes,
+    content_type: Optional[str],
+    *,
+    provider: Optional[str],
+    language: LanguageHint = None,
+    filename: str = "audio.webm",
+) -> Transcription:
+    """Transcribe ``audio`` to text using the template-selected ``provider``.
+
+    ``provider`` is an ``STTProvider`` value (``"soniox"`` | ``"deepgram"`` |
+    ``"sarvam"`` | ``"openai"`` | ``"google"``). Soniox uses its async file API;
+    Google (no direct one-shot path) and any provider whose key is unset
+    transcribe via OpenAI Whisper. Raises :class:`TranscriptionError` only when
+    no provider can run.
+    """
+    if not audio:
+        raise TranscriptionError("empty audio")
+
+    p = (provider or "").lower()
+    lang = _short_lang(language)
+
+    try:
+        if p == "soniox" and SONIOX_API_KEY:
+            # Pass the raw language (str | list) — Soniox takes a hints array.
+            return await _soniox(audio, content_type, filename, language)
+        if p == "deepgram" and DEEPGRAM_API_KEY:
+            return await _deepgram(audio, content_type, lang)
+        if p == "sarvam" and SARVAM_API_KEY:
+            return await _sarvam(audio, content_type, filename, _sarvam_lang(language))
+        if not OPENAI_STT_API_KEY:
+            raise TranscriptionError(
+                f"no usable STT provider for '{provider}' (OPENAI_STT_API_KEY unset)"
+            )
+        if p not in ("openai", "deepgram", "sarvam", "soniox"):
+            logger.info(
+                "transcribe: provider '{}' has no direct one-shot path; "
+                "using OpenAI Whisper",
+                provider,
+            )
+        return await _openai(audio, content_type, filename, lang)
+    except TranscriptionError:
+        raise
+    except Exception as e:
+        # Recover with Whisper so the user still gets text (e.g. Sarvam rejecting
+        # webm, or a Soniox job error/timeout).
+        if p in ("soniox", "deepgram", "sarvam") and OPENAI_STT_API_KEY:
+            logger.warning(
+                "transcribe: provider '{}' failed ({}); falling back to OpenAI Whisper",
+                provider,
+                e,
+            )
+            try:
+                return await _openai(audio, content_type, filename, lang)
+            except Exception as e2:
+                raise TranscriptionError(f"transcription failed: {e2}") from e2
+        raise TranscriptionError(f"transcription failed: {e}") from e

--- a/app/api/routers/breeze_buddy/widget/__init__.py
+++ b/app/api/routers/breeze_buddy/widget/__init__.py
@@ -21,7 +21,7 @@ Origin + per-IP rate limit. All other routes use the session-bound
 ``widget_token`` minted at create-time.
 """
 
-from fastapi import APIRouter, Depends, Request, Response, status
+from fastapi import APIRouter, Depends, File, Request, Response, UploadFile, status
 
 from app.api.routers.breeze_buddy.widget_common import options_cors_response
 from app.api.security.breeze_buddy.widget_token import (
@@ -37,6 +37,7 @@ from app.schemas.breeze_buddy.chat import (
     UpdateWidgetContextRequest,
     UpdateWidgetContextResponse,
     WidgetSessionStateResponse,
+    WidgetTranscribeResponse,
     WidgetVoiceConnectResponse,
     WidgetVoiceEndResponse,
 )
@@ -48,6 +49,7 @@ from .handlers import (
     end_widget_session_handler,
     get_widget_session_state_handler,
     send_widget_message_handler,
+    transcribe_widget_audio_handler,
     update_widget_context_handler,
     voice_connect_handler,
     voice_end_handler,
@@ -73,6 +75,11 @@ async def widget_get_preflight(session_id: str) -> Response:
 
 @router.options("/session/{session_id}/message")
 async def widget_message_preflight(session_id: str) -> Response:
+    return options_cors_response()
+
+
+@router.options("/session/{session_id}/transcribe")
+async def widget_transcribe_preflight(session_id: str) -> Response:
     return options_cors_response()
 
 
@@ -139,6 +146,27 @@ async def send_widget_message(
     ctx: WidgetSessionContext = Depends(require_widget_session),
 ):
     return await send_widget_message_handler(session_id, req, request, ctx)
+
+
+@router.post(
+    "/session/{session_id}/transcribe",
+    response_model=WidgetTranscribeResponse,
+    summary="Transcribe a push-to-talk audio clip to text (no turn)",
+)
+async def transcribe_widget_audio(
+    session_id: str,
+    request: Request,
+    audio: UploadFile = File(...),
+    ctx: WidgetSessionContext = Depends(require_widget_session),
+) -> WidgetTranscribeResponse:
+    """Push-to-talk: upload a short audio clip, get the transcript back.
+
+    Returns the text (it is NOT sent as a turn) so the embed can drop it
+    into the composer for the user to review/edit, then send via
+    ``/message``. The STT provider follows the template's
+    ``stt_configuration``; streaming-only providers fall back to Whisper.
+    """
+    return await transcribe_widget_audio_handler(session_id, audio, request, ctx)
 
 
 @router.post(

--- a/app/api/routers/breeze_buddy/widget/handlers.py
+++ b/app/api/routers/breeze_buddy/widget/handlers.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 import uuid
 from typing import Any, Dict, List, Optional
 
-from fastapi import HTTPException, Request, status
+from fastapi import HTTPException, Request, UploadFile, status
 
 from app.ai.voice.agents.breeze_buddy.chat.client_context import (
     CLIENT_CONTEXT_KEY,
@@ -34,6 +34,7 @@ from app.ai.voice.agents.breeze_buddy.services.daily.daily import (
     start_daily_session,
 )
 from app.ai.voice.agents.breeze_buddy.template.cache import get_template_by_id_cached
+from app.ai.voice.stt import TranscriptionError, transcribe_audio
 from app.api.routers.breeze_buddy.chat.handlers import (
     approve_chat_tool_handler,
     cancel_chat_turn_handler,
@@ -53,6 +54,8 @@ from app.api.security.breeze_buddy.widget_token import (
     assert_widget_session_ownership,
     mint_widget_token,
 )
+from app.core.config.dynamic import WIDGET_STT_MAX_AUDIO_BYTES
+from app.core.config.static import BREEZE_BUDDY_STT_SERVICE
 from app.core.logger import logger
 from app.database.accessor import create_lead_call_tracker, get_lead_by_id
 from app.database.accessor.breeze_buddy.chat_session import (
@@ -94,6 +97,7 @@ from app.schemas.breeze_buddy.chat import (
     UpdateWidgetContextResponse,
     WidgetChannel,
     WidgetSessionStateResponse,
+    WidgetTranscribeResponse,
     WidgetVoiceConnectResponse,
     WidgetVoiceEndResponse,
 )
@@ -321,6 +325,108 @@ async def send_widget_message_handler(
         )
 
     return await send_chat_message_handler(session_id, req, access_check=None)
+
+
+# ---------------------------------------------------------------------------
+# POST /widget/session/{id}/transcribe  (push-to-talk STT)
+# ---------------------------------------------------------------------------
+
+
+async def transcribe_widget_audio_handler(
+    session_id: str,
+    audio: UploadFile,
+    request: Request,
+    ctx: WidgetSessionContext,
+) -> WidgetTranscribeResponse:
+    """Transcribe a push-to-talk clip and return the text for review.
+
+    Stateless: no Redis lock, no DB writes — transcription touches no
+    session state, so it can run alongside an in-flight turn. Same gate
+    order as ``send_widget_message_handler`` (config-active 401 → IP limit
+    → ownership → 410 ENDED), then one direct STT call.
+
+    Provider follows the template's ``stt_configuration.provider`` (default
+    ``BREEZE_BUDDY_STT_SERVICE``); Soniox transcribes via its async file API,
+    while Google (no one-shot path) falls back to Whisper inside
+    ``transcribe_audio``. The returned text is NOT sent as a turn — the embed
+    drops it into the composer for the user to edit and send via ``/message``.
+    """
+    cfg = await get_widget_config_by_id(ctx.widget_config_id)
+    if cfg is None or not cfg.active:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Widget configuration not found or inactive",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    # Separate "transcribe" bucket (same per-merchant hourly cap as messages)
+    # so STT spend is counted independently of chat turns.
+    await enforce_widget_ip_limit(
+        request=request,
+        bucket="transcribe",
+        limit=cfg.max_messages_per_ip_hour,
+        widget_config_id=cfg.id,
+    )
+
+    session = await get_chat_session_by_id(session_id)
+    if session is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Widget session '{session_id}' not found",
+        )
+    assert_widget_session_ownership(session, ctx)
+    if session.status == ChatSessionStatus.ENDED:
+        raise HTTPException(
+            status_code=status.HTTP_410_GONE,
+            detail=f"Widget session '{session_id}' has ended",
+        )
+
+    max_bytes = await WIDGET_STT_MAX_AUDIO_BYTES()
+    chunks: list[bytes] = []
+    total = 0
+    while True:
+        chunk = await audio.read(64 * 1024)
+        if not chunk:
+            break
+        total += len(chunk)
+        if total > max_bytes:
+            raise HTTPException(
+                status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+                detail=f"Audio exceeds the {max_bytes}-byte limit",
+            )
+        chunks.append(chunk)
+    data = b"".join(chunks)
+    if not data:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Empty audio upload",
+        )
+
+    template = await get_template_by_id_cached(session.template_id)
+    configurations = getattr(template, "configurations", None)
+    stt = getattr(configurations, "stt_configuration", None)
+    if stt is not None and stt.provider is not None:
+        provider = stt.provider.value
+    else:
+        provider = BREEZE_BUDDY_STT_SERVICE
+    language = stt.language if stt is not None else None
+
+    try:
+        result = await transcribe_audio(
+            data,
+            audio.content_type,
+            provider=provider,
+            language=language,
+            filename=audio.filename or "audio.webm",
+        )
+    except TranscriptionError as e:
+        logger.warning("widget transcribe failed (session={}): {}", session_id, e)
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="Transcription failed",
+        ) from e
+
+    return WidgetTranscribeResponse(text=result.text, provider=result.provider)
 
 
 # ---------------------------------------------------------------------------

--- a/app/core/config/dynamic.py
+++ b/app/core/config/dynamic.py
@@ -177,6 +177,23 @@ async def CHAT_HISTORY_REPLAY_LIMIT() -> int:
     return await get_config("CHAT_HISTORY_REPLAY_LIMIT", 100, int)
 
 
+async def WIDGET_STT_MAX_AUDIO_BYTES() -> int:
+    """Max audio upload accepted by ``POST /widget/session/{id}/transcribe``
+    (push-to-talk). Clips are short; the default 10 MB sits well under
+    provider limits (OpenAI Whisper is 25 MB). Read per request so it can
+    be tightened during abuse without a deploy."""
+    return await get_config("WIDGET_STT_MAX_AUDIO_BYTES", 10 * 1024 * 1024, int)
+
+
+async def SONIOX_ASYNC_MODEL() -> str:
+    """Soniox async/file model for one-shot (push-to-talk) transcription.
+
+    Used by ``transcribe_audio`` when a template's STT provider is Soniox.
+    Resolves Redis → env → default, so the model can be bumped (e.g.
+    ``stt-async-v5`` → ``v6``) without a deploy."""
+    return await get_config("SONIOX_ASYNC_MODEL", "stt-async-v5", str)
+
+
 # ============================================================================
 # Public chat-demo tuning knobs (CHAT_MODE.md §13).
 #

--- a/app/schemas/breeze_buddy/chat.py
+++ b/app/schemas/breeze_buddy/chat.py
@@ -632,6 +632,20 @@ class WidgetSessionStateResponse(BaseModel):
     )
 
 
+class WidgetTranscribeResponse(BaseModel):
+    """Body of ``POST /widget/session/{id}/transcribe``.
+
+    Push-to-talk: the clip is transcribed and the text is returned for the
+    embed to drop into the composer (the user reviews/edits, then sends via
+    ``POST /widget/session/{id}/message``). ``provider`` is the STT provider
+    that actually produced the text (may differ from the template's when a
+    streaming-only provider falls back to Whisper).
+    """
+
+    text: str
+    provider: str
+
+
 __all__ = [
     "ChatSessionStatus",
     "ChatMessageRole",
@@ -666,4 +680,5 @@ __all__ = [
     "WidgetVoiceConnectResponse",
     "WidgetVoiceEndResponse",
     "WidgetSessionStateResponse",
+    "WidgetTranscribeResponse",
 ]

--- a/docs/CHAT_MODE.md
+++ b/docs/CHAT_MODE.md
@@ -1013,6 +1013,7 @@ URL prefix `/agent/voice/breeze-buddy/widget`:
 |---|---|---|---|
 | `/session` | POST | `public_widget_key` + Origin + per-IP RL | mints widget_token, returns greeting |
 | `/session/{id}/message` | POST | widget_token | SSE stream; 409 if channel ≠ CHAT |
+| `/session/{id}/transcribe` | POST | widget_token | push-to-talk: multipart `audio` → `{text, provider}`; stateless, no turn. Provider from template `stt_configuration` (Soniox/Google fall back to Whisper) |
 | `/session/{id}/voice/connect` | POST | widget_token | spins up Daily room + bot, seeds from chat history |
 | `/session/{id}/voice/end` | POST | widget_token | best-effort signal; drain runs in `end_conversation` |
 | `/session/{id}/end` | POST | widget_token | ends whole conversation; signals voice if live |


### PR DESCRIPTION
Add a one-shot speech-to-text path for the chat widget's push-to-talk button: POST /widget/session/{id}/transcribe accepts a short audio clip and returns the transcript for the user to review before sending.

- New app/ai/voice/stt/transcribe.py: direct provider-routed REST transcription (OpenAI Whisper / Deepgram / Sarvam), with Whisper fallback for streaming-only providers (Soniox/Google) and transient failures. Provider is chosen from the template's stt_configuration.
- Widget route + handler with ownership, per-merchant IP rate limiting (transcribe bucket), empty/oversize guards, and CORS preflight.
- WidgetTranscribeResponse schema; WIDGET_STT_MAX_AUDIO_BYTES as a Redis-backed dynamic config dial.
- Docs: CHAT_MODE.md endpoint entry.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added push-to-talk audio transcription capability to widgets with multi-provider support and intelligent fallback handling.
  * Introduced configurable audio upload size limits for transcription requests.

* **Documentation**
  * Updated documentation with new transcription endpoint details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->