### PR TITLE
fix(chat-ui): render category chiclets and rescue silently-dropped UI ops

### DIFF
--- a/app/ai/voice/agents/breeze_buddy/chat/ui_healer.py
+++ b/app/ai/voice/agents/breeze_buddy/chat/ui_healer.py
@@ -19,10 +19,12 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 from typing import Any, Callable, Dict, List, Optional, Set, Tuple
 
 from app.ai.voice.agents.breeze_buddy.chat.ui_stream import HealerResult
 from app.ai.voice.agents.breeze_buddy.template.ui_catalog import (
+    QUICK_REPLIES_MAX_ITEMS,
     UI_CATALOG,
     is_known_type,
 )
@@ -179,6 +181,99 @@ def _rule_tag_flatten_array_text(
     return op, "tag_flattened_array_text"
 
 
+def _rule_clamp_quickreplies_items(
+    op: Dict[str, Any], ctx: HealerContext
+) -> Tuple[Dict[str, Any], Optional[str]]:
+    """``QuickReplies`` over the item cap → truncate to the cap instead of
+    letting the whole row drop on ``max_length``. The LLM occasionally emits
+    more pills than allowed (e.g. every category in a storefront with more
+    categories than the cap); showing the first N beats showing nothing.
+    ``min_length`` underflow is left for the validator — the healer can't
+    invent options."""
+    if op.get("op") != "add" or op.get("type") != "QuickReplies":
+        return op, None
+    props = op.get("props")
+    if not isinstance(props, dict):
+        return op, None
+    items = props.get("items")
+    if not isinstance(items, list) or len(items) <= QUICK_REPLIES_MAX_ITEMS:
+        return op, None
+    dropped = len(items) - QUICK_REPLIES_MAX_ITEMS
+    props["items"] = items[:QUICK_REPLIES_MAX_ITEMS]
+    op["props"] = props
+    return op, f"clamped_quickreplies_items:-{dropped}"
+
+
+# Every ``url``/``src`` prop reachable here is a pydantic ``HttpUrl`` field —
+# Handoff.url, Image.src, Icon.url, OpenUrlAction.url (nested in *.action),
+# TileMedia.src (nested in *.media). The lone str-typed exception, ``SideEffect.url``
+# (deliberately same-origin-relative), is excluded by the type guard in the rule
+# below so its relative paths (e.g. ``cart.js``) survive untouched. Anything
+# already carrying a scheme (http:, https:, mailto:, tel:) is left alone; a bare
+# host like ``shop.com/cart`` — which ``HttpUrl`` rejects as "relative URL without
+# a base" and drops the op — gets an ``https://`` prefix. Host-less relatives
+# (leading ``/`` ``#`` ``?``) have no host to attach a scheme to → left for the
+# validator.
+_URL_PROP_KEYS = frozenset({"url", "src"})
+_HAS_SCHEME_RE = re.compile(r"^[a-zA-Z][a-zA-Z0-9+.\-]*:")
+
+
+def _coerce_url_string(value: Any) -> Tuple[Any, bool]:
+    if not isinstance(value, str):
+        return value, False
+    s = value.strip()
+    if not s or _HAS_SCHEME_RE.match(s):
+        return value, False
+    if s.startswith("//"):  # protocol-relative → pin to https
+        return "https:" + s, True
+    if s[0] in "/#?":  # host-less relative path / anchor / query — can't fix
+        return value, False
+    head = s.split("/", 1)[0].split("?", 1)[0]
+    if "." in head and " " not in head:  # looks like a domain
+        return "https://" + s, True
+    return value, False
+
+
+def _walk_coerce_urls(node: Any) -> int:
+    coerced = 0
+    if isinstance(node, dict):
+        for k, v in list(node.items()):
+            if k in _URL_PROP_KEYS:
+                new_v, changed = _coerce_url_string(v)
+                if changed:
+                    node[k] = new_v
+                    coerced += 1
+            else:
+                coerced += _walk_coerce_urls(v)
+    elif isinstance(node, list):
+        for item in node:
+            coerced += _walk_coerce_urls(item)
+    return coerced
+
+
+def _rule_coerce_scheme_less_urls(
+    op: Dict[str, Any], ctx: HealerContext
+) -> Tuple[Dict[str, Any], Optional[str]]:
+    """Prepend ``https://`` to scheme-less host URLs in ``url`` / ``src`` props
+    (including nested action / media). Rescues the checkout ``Handoff`` and any
+    bare-domain link the LLM emits without a scheme — pydantic ``HttpUrl`` would
+    otherwise reject it and the op would drop.
+
+    Scoped to ``add`` ops (whose ``type`` we can trust) and skips ``SideEffect``,
+    whose ``url`` is a deliberately same-origin-relative ``str`` (not ``HttpUrl``)
+    — coercing it would corrupt a valid relative path like ``cart.js``."""
+    if op.get("op") != "add" or op.get("type") == "SideEffect":
+        return op, None
+    props = op.get("props")
+    if not isinstance(props, dict):
+        return op, None
+    coerced = _walk_coerce_urls(props)
+    if not coerced:
+        return op, None
+    op["props"] = props
+    return op, f"coerced_scheme_less_url:{coerced}"
+
+
 def _rule_dedupe_id(
     op: Dict[str, Any], ctx: HealerContext
 ) -> Tuple[Dict[str, Any], Optional[str]]:
@@ -233,8 +328,9 @@ def _rule_drop_orphan_add(
 
 # Order matters: rename aliases first (so Tag.label → Tag.text doesn't
 # get stripped); then strip remaining unknowns; then per-primitive
-# coercions; then dedupe last (the rename can mutate id-bearing props
-# in theory). Drops run after, gating on the cleaned-up shape.
+# coercions (incl. QuickReplies item-clamp and scheme-less URL repair, which
+# run on the cleaned props); then dedupe last (the rename can mutate
+# id-bearing props in theory). Drops run after, gating on the cleaned-up shape.
 _TRANSFORM_RULES: List[
     Callable[[Dict[str, Any], HealerContext], Tuple[Dict[str, Any], Optional[str]]]
 ] = [
@@ -242,6 +338,8 @@ _TRANSFORM_RULES: List[
     _rule_strip_unknown_props,
     _rule_button_default_label,
     _rule_tag_flatten_array_text,
+    _rule_clamp_quickreplies_items,
+    _rule_coerce_scheme_less_urls,
     _rule_dedupe_id,
 ]
 

--- a/app/ai/voice/agents/breeze_buddy/template/ui_catalog.py
+++ b/app/ai/voice/agents/breeze_buddy/template/ui_catalog.py
@@ -261,19 +261,29 @@ class QuickReplyItem(BaseModel):
     )
 
 
+# Max pills in a ``QuickReplies`` row. Raised 8 → 12 so option/category
+# menus (e.g. a storefront with 9 categories) render as chiclets instead
+# of the whole row failing ``max_length`` validation and being dropped.
+# The healer clamps any over-emission down to this same cap (see
+# ``chat/ui_healer._rule_clamp_quickreplies_items``) so >cap degrades to
+# the first N pills rather than dropping the row whole.
+QUICK_REPLIES_MAX_ITEMS = 12
+
+
 class QuickReplies(_CatalogBase):
     """Turn-scoped quick-reply row — the LLM-driven equivalent of startup
     chicklets.
 
-    Emit at the end of any assistant turn where you want to suggest 2–5
-    follow-up options. The widget renders them as pill buttons right below
-    the message; clicking one fires a ``to_assistant`` action and disables
-    the whole row (one-shot).
+    Emit at the end of an assistant turn to offer tappable follow-ups or a
+    short option/category menu (2–12 pills). The widget renders them as pill
+    buttons right below the message; clicking one fires a ``to_assistant``
+    action and disables the whole row (one-shot).
 
     Use ``QuickReplies`` instead of ``Buttons`` when the options are
-    *transient turn suggestions* (e.g. "Do you want to confirm?", "See
-    more options", "Back to menu"). Use ``Buttons``/``Button`` when the
-    action is a persistent CTA (checkout, product link, handoff).
+    *transient turn suggestions* or a category/option menu (e.g. "Do you
+    want to confirm?", "See more options", "Back to menu", a category
+    list). Use ``Buttons``/``Button`` when the action is a persistent CTA
+    (checkout, product link, handoff).
 
     Example::
 
@@ -287,8 +297,8 @@ class QuickReplies(_CatalogBase):
     items: List[QuickReplyItem] = Field(
         ...,
         min_length=2,
-        max_length=8,
-        description="2–8 reply options. Shown as pill buttons.",
+        max_length=QUICK_REPLIES_MAX_ITEMS,
+        description="2–12 reply options. Shown as pill buttons.",
     )
 
 

--- a/tests/test_ui_healer.py
+++ b/tests/test_ui_healer.py
@@ -9,7 +9,9 @@ from app.ai.voice.agents.breeze_buddy.chat.ui_healer import (
 
 # Load template package before chat/* modules — same circular-import trap.
 from app.ai.voice.agents.breeze_buddy.template.ui_catalog import (  # noqa: F401
+    QUICK_REPLIES_MAX_ITEMS,
     UI_CATALOG,
+    validate_props,
 )
 
 
@@ -186,3 +188,229 @@ def test_healer_alias_does_not_override_canonical_when_both_present():
     assert out["props"]["text"] == "explicit"
     # `label` was stripped (unknown prop), not renamed.
     assert "label" not in out["props"]
+
+
+# ---------------------------------------------------------------------------
+# QuickReplies item-cap clamp (chiclets resilience)
+# ---------------------------------------------------------------------------
+
+
+def _qr_items(n: int):
+    return [{"label": f"Category {i}"} for i in range(n)]
+
+
+def test_quickreplies_cap_is_twelve():
+    """Lock the chiclet cap: 12 items validate, 13 do not."""
+    assert QUICK_REPLIES_MAX_ITEMS == 12
+    validate_props("QuickReplies", {"items": _qr_items(12)})  # no raise
+    raised = False
+    try:
+        validate_props("QuickReplies", {"items": _qr_items(13)})
+    except Exception:
+        raised = True
+    assert raised, "13 items should exceed the QuickReplies cap"
+
+
+def test_healer_clamps_quickreplies_over_cap():
+    """>cap QuickReplies → truncate to the cap (and the clamped op then passes
+    catalog validation) instead of dropping the whole row."""
+    import json
+
+    line = json.dumps(
+        {
+            "op": "add",
+            "id": "qr",
+            "type": "QuickReplies",
+            "parent": "root",
+            "props": {"items": _qr_items(14)},
+        }
+    )
+    r = heal_op_line(line, _ctx(known_ids={"root"}))
+    assert r.drop is False
+    assert any(n == "clamped_quickreplies_items:-2" for n in r.notes)
+    out = json.loads(r.line)  # type: ignore[arg-type]
+    assert len(out["props"]["items"]) == QUICK_REPLIES_MAX_ITEMS
+    # the healed op now survives catalog validation
+    validate_props("QuickReplies", out["props"])
+
+
+def test_healer_leaves_quickreplies_at_cap():
+    import json
+
+    line = json.dumps(
+        {
+            "op": "add",
+            "id": "qr",
+            "type": "QuickReplies",
+            "parent": "root",
+            "props": {"items": _qr_items(QUICK_REPLIES_MAX_ITEMS)},
+        }
+    )
+    r = heal_op_line(line, _ctx(known_ids={"root"}))
+    assert r.drop is False
+    assert not any(n.startswith("clamped_quickreplies_items") for n in r.notes)
+
+
+# ---------------------------------------------------------------------------
+# Scheme-less URL coercion (checkout Handoff resilience)
+# ---------------------------------------------------------------------------
+
+
+def test_healer_coerces_scheme_less_handoff_url():
+    """Bare-domain checkout Handoff url → https:// (and then validates)."""
+    import json
+
+    line = json.dumps(
+        {
+            "op": "add",
+            "id": "root",
+            "type": "Handoff",
+            "props": {
+                "reason": "checkout",
+                "label": "Review and checkout",
+                "url": "shop.myshopify.com/cart",
+                "lifecycle": "popup",
+            },
+        }
+    )
+    r = heal_op_line(line, _ctx(known_ids=set()))
+    assert r.drop is False
+    assert any(n == "coerced_scheme_less_url:1" for n in r.notes)
+    out = json.loads(r.line)  # type: ignore[arg-type]
+    assert out["props"]["url"] == "https://shop.myshopify.com/cart"
+    validate_props("Handoff", out["props"])
+
+
+def test_healer_leaves_absolute_url_untouched():
+    import json
+
+    line = json.dumps(
+        {
+            "op": "add",
+            "id": "root",
+            "type": "Handoff",
+            "props": {
+                "reason": "checkout",
+                "label": "Go",
+                "url": "https://shop.com/cart",
+                "lifecycle": "popup",
+            },
+        }
+    )
+    r = heal_op_line(line, _ctx(known_ids=set()))
+    assert not any(n.startswith("coerced_scheme_less_url") for n in r.notes)
+    out = json.loads(r.line)  # type: ignore[arg-type]
+    assert out["props"]["url"] == "https://shop.com/cart"
+
+
+def test_healer_leaves_hostless_relative_url():
+    """A leading-slash path has no host to attach a scheme to — leave it for
+    the validator (the healer must not invent a host)."""
+    import json
+
+    line = json.dumps(
+        {
+            "op": "add",
+            "id": "root",
+            "type": "Handoff",
+            "props": {
+                "reason": "checkout",
+                "label": "Go",
+                "url": "/cart",
+                "lifecycle": "popup",
+            },
+        }
+    )
+    r = heal_op_line(line, _ctx(known_ids=set()))
+    assert not any(n.startswith("coerced_scheme_less_url") for n in r.notes)
+    out = json.loads(r.line)  # type: ignore[arg-type]
+    assert out["props"]["url"] == "/cart"
+
+
+def test_healer_leaves_mailto_untouched():
+    import json
+
+    line = json.dumps(
+        {
+            "op": "add",
+            "id": "root",
+            "type": "Handoff",
+            "props": {
+                "reason": "support",
+                "label": "Email",
+                "url": "mailto:a@b.com",
+                "lifecycle": "popup",
+            },
+        }
+    )
+    r = heal_op_line(line, _ctx(known_ids=set()))
+    assert not any(n.startswith("coerced_scheme_less_url") for n in r.notes)
+    out = json.loads(r.line)  # type: ignore[arg-type]
+    assert out["props"]["url"] == "mailto:a@b.com"
+
+
+def test_healer_coerces_protocol_relative_image_src():
+    import json
+
+    line = json.dumps(
+        {
+            "op": "add",
+            "id": "img",
+            "type": "Image",
+            "parent": "root",
+            "props": {"src": "//cdn.shop.com/a.jpg", "alt": "a"},
+        }
+    )
+    r = heal_op_line(line, _ctx(known_ids={"root"}))
+    assert any(n == "coerced_scheme_less_url:1" for n in r.notes)
+    out = json.loads(r.line)  # type: ignore[arg-type]
+    assert out["props"]["src"] == "https://cdn.shop.com/a.jpg"
+
+
+def test_healer_coerces_nested_quickreply_action_url():
+    """Scheme-less url nested inside a QuickReplies item's open_url action."""
+    import json
+
+    line = json.dumps(
+        {
+            "op": "add",
+            "id": "qr",
+            "type": "QuickReplies",
+            "parent": "root",
+            "props": {
+                "items": [
+                    {
+                        "label": "Track order",
+                        "action": {"type": "open_url", "url": "shop.com/orders"},
+                    },
+                    {"label": "Home"},
+                ]
+            },
+        }
+    )
+    r = heal_op_line(line, _ctx(known_ids={"root"}))
+    assert any(n == "coerced_scheme_less_url:1" for n in r.notes)
+    out = json.loads(r.line)  # type: ignore[arg-type]
+    assert out["props"]["items"][0]["action"]["url"] == "https://shop.com/orders"
+    validate_props("QuickReplies", out["props"])
+
+
+def test_healer_leaves_sideeffect_relative_url_untouched():
+    """``SideEffect.url`` is a same-origin-relative str (not HttpUrl) — a
+    root-level dotted path like ``cart.js`` must NOT be rewritten into a host."""
+    import json
+
+    line = json.dumps(
+        {
+            "op": "add",
+            "id": "se",
+            "type": "SideEffect",
+            "parent": "root",
+            "props": {"kind": "fetch", "url": "cart.js", "method": "GET"},
+        }
+    )
+    r = heal_op_line(line, _ctx(known_ids={"root"}))
+    assert r.drop is False
+    assert not any(n.startswith("coerced_scheme_less_url") for n in r.notes)
+    out = json.loads(r.line)  # type: ignore[arg-type]
+    assert out["props"]["url"] == "cart.js"


### PR DESCRIPTION
## Problem

On the Buddy-Assist widget (d2cstore / `breeze-it-store.myshopify.com`), the assistant rendered prose promising a tappable UI — "tap one to explore", "Ready to checkout?" — but the UI never appeared. The debug overlay showed `N ops · 1 dropped`.

Root-caused to the strict catalog validator silently dropping two ops:

1. **Category picker** — the model emits a `QuickReplies` (chiclets) row with all **9** store categories, but `QuickReplies.items` was hard-capped at `max_length=8` → `too_long` ValidationError → the whole pill row dropped (only an empty `Stack` container rendered).
2. **Cart checkout button** — the mandated checkout `Handoff` uses `url:'{shop_url}/cart'`, and `shop_url` is a bare domain, so the URL is scheme-less (`shop.com/cart`). `Handoff.url` is a strict pydantic `HttpUrl` → rejected as "relative URL without a base" → the **only** path to checkout dropped on every cart render.

Both confirmed by reproducing the turns live (Vertex → `UiStreamExtractor` → `process_op_line`).

## Changes

- **Chiclets cap** — `QuickReplies.items` `max_length` `8 → 12` via a new `QUICK_REPLIES_MAX_ITEMS` constant, so a 9-category storefront renders all categories as chiclets. `render_primitives_section` regenerates the prompt's primitive docs from the schema, so the model is informed automatically.
- **Healer resilience** (so the strict validator degrades gracefully instead of silently dropping):
  - `_rule_clamp_quickreplies_items` — `QuickReplies` over the cap is truncated to the first N pills (show N, not nothing) instead of dropping the row.
  - `_rule_coerce_scheme_less_urls` — scheme-less host URLs in `url`/`src` props (incl. nested `action`/`media`) get an `https://` prefix, rescuing the checkout `Handoff` and any bare-domain link. Scoped to `add` ops and **skips `SideEffect.url`** (the one intentionally same-origin-relative `str` field — e.g. `cart.js`), leaves `mailto:`/`tel:`/absolute/host-less-relative URLs untouched.

## Tests

`tests/test_ui_healer.py` — cap lock (12 valid / 13 invalid), clamp 14→12 (+ re-validates), and URL coercion incl. bare-domain Handoff, absolute, host-less relative, `mailto:`, protocol-relative `//host`, nested action url, and the `SideEffect.url` relative-path guard.

All green: 572 passed / 1 xfailed, pyrefly 0 errors, black/isort/autoflake clean. Went through an adversarial review pass that caught the `SideEffect.url` over-coercion (now fixed + tested).

## Notes / follow-ups

- The d2cstore template was already hotfixed in config (checkout URL → `https://`, prompt nudge to a Carousel). Once this deploys, that template can flip its category guidance back to chiclets, and the bare-domain checkout URL is auto-healed regardless.
- The same bare-`{shop_url}/cart` checkout pattern likely exists in other Buddy-Assist templates (firstbud / thebeyondbound / thedripcorugs / indigo) — this healer rule covers them all without per-template edits.
- Frontend (loom widget) should be sanity-checked that it doesn't itself cap the number of rendered pills below 12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Quick replies now support up to 12 items instead of 8
  * URLs without explicit schemes are automatically normalized to include HTTPS
  * Over-limit quick reply items are automatically trimmed with diagnostic logging

<!-- end of auto-generated comment: release notes by coderabbit.ai -->