### PR TITLE
Add DragonTTS voice service integration

### DIFF
--- a/app/ai/voice/agents/breeze_buddy/template/types.py
+++ b/app/ai/voice/agents/breeze_buddy/template/types.py
@@ -280,6 +280,7 @@ class TTSProvider(str, Enum):
     GEMINI = "gemini"
     GOOGLE = "google"
     SONIOX = "soniox"
+    DRAGONTTS = "dragontts"
 
 
 # Maps legacy tts_voice_name values to current provider strings for backward compat.

--- a/app/ai/voice/agents/breeze_buddy/tts/__init__.py
+++ b/app/ai/voice/agents/breeze_buddy/tts/__init__.py
@@ -15,12 +15,14 @@ from app.ai.voice.agents.breeze_buddy.tts.emoji_filter import (
 from app.ai.voice.agents.breeze_buddy.utils.common import convert_to_mulaw
 from app.ai.voice.tts import (
     CartesiaConfig,
+    DragonTTSConfig,
     ElevenLabsConfig,
     GeminiConfig,
     GoogleConfig,
     SarvamTTSConfig,
     SonioxTTSConfig,
     build_cartesia_tts,
+    build_dragontts_tts,
     build_elevenlabs_tts,
     build_gemini_tts,
     build_google_tts,
@@ -28,6 +30,7 @@ from app.ai.voice.tts import (
     build_soniox_tts,
 )
 from app.ai.voice.tts.cartesia import _generate_cartesia_audio
+from app.ai.voice.tts.dragontts import _collect_params, _generate_dragontts_audio
 from app.ai.voice.tts.elevenlabs import _generate_elevenlabs_audio
 from app.ai.voice.tts.gemini import _generate_gemini_audio
 from app.ai.voice.tts.google import _generate_google_audio
@@ -43,6 +46,7 @@ from app.core.config.dynamic import (
 )
 from app.core.config.static import (
     CARTESIA_API_KEY,
+    DRAGONTTS_URL,
     ELEVENLABS_API_KEY,
     ELEVENLABS_INDIAN_RESIDENCY_API_KEY,
     ELEVENLABS_INDIAN_RESIDENCY_WEBSOCKET_URL,
@@ -125,6 +129,36 @@ def _parse_language(code: str | None, fallback: Language = Language.EN) -> Langu
 async def get_tts_service(voice_config: TTSConfig):
     """Build a TTS service from a resolved TTSConfig."""
     provider = voice_config.provider.value
+
+    if provider == "dragontts":
+        # Route the live stream through DragonTTS so every aggregated sentence
+        # is served from its cache (scripted phrases become permanent hits) and
+        # synthesized+stored on miss. ``model`` carries the nested provider as
+        # "<provider>:<model>"; DragonTTS applies the params relevant to it.
+        nested = (voice_config.model or "").split(":", 1)
+        if len(nested) != 2:
+            raise ValueError(
+                f"dragontts model must be '<provider>:<model>', got {voice_config.model!r}"
+            )
+        nested_provider, nested_model = nested
+        aggregate = await BB_AGGREGATE_SENTENCES(nested_provider)
+
+        logger.info(
+            f"Building DragonTTS streaming service: nested_provider={nested_provider}, "
+            f"model={nested_model}, voice_id={voice_config.voice_id}, "
+            f"language={voice_config.language}"
+        )
+
+        return build_dragontts_tts(
+            DragonTTSConfig(
+                url=DRAGONTTS_URL,
+                model_id=voice_config.model,  # full "<provider>:<model>"
+                voice_id=voice_config.voice_id or "",
+                language=voice_config.language or "",
+                params=_collect_params(voice_config),
+                aggregate_sentences=aggregate,
+            )
+        )
 
     logger.info(
         f"Building TTS service: provider={provider}, voice_id={voice_config.voice_id}, "
@@ -346,6 +380,9 @@ async def generate_audio(
             language=resolved.language,
         )
         input_format = "raw"
+    elif provider == "dragontts":
+        # DragonTTS caching proxy — returns μ-law directly (no local conversion).
+        return await _generate_dragontts_audio(text=text, resolved=resolved)
     else:
         raise ValueError(f"Unsupported TTS provider: {provider}")
 

--- a/app/ai/voice/tts/__init__.py
+++ b/app/ai/voice/tts/__init__.py
@@ -7,6 +7,7 @@ reuse the same provider-specific setup logic.
 from __future__ import annotations
 
 from .cartesia import CartesiaConfig, build_cartesia_tts
+from .dragontts import DragonTTSConfig, build_dragontts_tts
 from .elevenlabs import ElevenLabsConfig, build_elevenlabs_tts
 from .gemini import GeminiConfig, build_gemini_tts
 from .google import GoogleConfig, build_google_tts
@@ -17,6 +18,9 @@ __all__ = [
     # Cartesia
     "CartesiaConfig",
     "build_cartesia_tts",
+    # DragonTTS (caching proxy)
+    "DragonTTSConfig",
+    "build_dragontts_tts",
     # ElevenLabs
     "ElevenLabsConfig",
     "build_elevenlabs_tts",

--- a/app/ai/voice/tts/dragontts.py
+++ b/app/ai/voice/tts/dragontts.py
@@ -1,0 +1,269 @@
+"""DragonTTS caching-proxy TTS helpers and builder.
+
+DragonTTS is treated as a first-class TTS provider. The template selects
+``provider: "dragontts"`` and sets ``model`` to ``"<provider>:<model>"`` (e.g.
+``"cartesia:sonic-3.5"``), ``voice_id``, and the tuning params. DragonTTS
+applies the relevant params per nested provider and caches the result.
+
+Two entry points share the same DragonTTS cache (keyed by output_format, so
+each path caches in its own format):
+
+- :func:`_generate_dragontts_audio` — one-shot synthesis (returns μ-law 8 kHz
+  mono for Twilio). POSTs to DragonTTS ``/tts/bytes``. Used by the
+  non-streaming ``generate_audio`` path.
+- :class:`DragonTTSService` — a pipecat ``TTSService`` for the **live streaming
+  conversation**. Per aggregated sentence it POSTs to DragonTTS ``/tts/stream``
+  (raw ``pcm_s16le`` @ 16 kHz) and streams the chunked response, yielding one
+  ``TTSAudioRawFrame`` per chunk. DragonTTS serves cached phrases instantly and,
+  on a miss, streams from the nested provider over a warm socket pool while
+  teeing the clip to the cache — so scripted phrases become permanent hits and
+  misses still reach the caller with low TTFB. The base class emits the
+  start/stop frames; pipecat streams the audio downstream.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Optional
+
+import httpx
+from pipecat.frames.frames import (
+    CancelFrame,
+    EndFrame,
+    ErrorFrame,
+    Frame,
+    StartFrame,
+    TTSAudioRawFrame,
+)
+from pipecat.services.settings import TTSSettings
+from pipecat.services.tts_service import TTSService, TextAggregationMode
+from pipecat.transcriptions.language import Language
+
+from app.core.config.static import DRAGONTTS_URL
+from app.core.logger import logger
+
+if TYPE_CHECKING:
+    from app.ai.voice.agents.breeze_buddy.template.types import TTSConfig
+
+__all__ = [
+    "DragonTTSConfig",
+    "DragonTTSService",
+    "build_dragontts_tts",
+    "_generate_dragontts_audio",
+]
+
+
+# Params DragonTTS folds into the cache key and applies per nested provider.
+_PARAM_FIELDS = ("speed", "volume", "emotion", "pitch", "style_prompt")
+
+
+def _collect_params(resolved: "TTSConfig") -> dict:
+    """Pull the non-None tuning params off a resolved TTSConfig."""
+    return {
+        key: getattr(resolved, key)
+        for key in _PARAM_FIELDS
+        if getattr(resolved, key, None) is not None
+    }
+
+
+async def _generate_dragontts_audio(*, text: str, resolved: "TTSConfig") -> bytes:
+    """Synthesize via DragonTTS. Returns μ-law (8 kHz mono) bytes.
+
+    ``resolved.model`` carries the nested provider as ``"<provider>:<model>"``.
+    All tuning params are forwarded; DragonTTS applies the ones relevant to the
+    nested provider and folds them into the cache key.
+    """
+    body = {
+        "model_id": resolved.model,
+        "transcript": text,
+        "voice": {"id": resolved.voice_id},
+        "language": resolved.language or "",
+        "output_format": {"container": "raw", "encoding": "mulaw", "sample_rate": 8000},
+        "params": _collect_params(resolved),
+    }
+
+    logger.info(
+        f"Routing TTS via DragonTTS: model_id={resolved.model}, voice_id={resolved.voice_id}"
+    )
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        response = await client.post(f"{DRAGONTTS_URL}/tts/bytes", json=body)
+        response.raise_for_status()
+        return response.content
+
+
+@dataclass
+class DragonTTSConfig:
+    """Configuration for the DragonTTS streaming service.
+
+    Attributes:
+        url: DragonTTS base URL (env-derived default).
+        model_id: Nested provider as ``"<provider>:<model>"`` (e.g.
+            ``"cartesia:sonic-3.5"``).
+        voice_id: Voice ID to synthesize with.
+        language: Language code forwarded to DragonTTS (empty to use the
+            nested provider default).
+        params: Tuning params (speed/volume/emotion/pitch/style_prompt) folded
+            into the cache key and applied per nested provider.
+        aggregate_sentences: Whether to buffer LLM output to sentence
+            boundaries before synthesizing (lower provider call count).
+    """
+
+    url: str
+    model_id: str
+    voice_id: str
+    language: str = ""
+    params: dict = field(default_factory=dict)
+    aggregate_sentences: bool = True
+
+
+class DragonTTSService(TTSService):
+    """Pipecat TTS service that routes the live stream through DragonTTS.
+
+    Each aggregated sentence is POSTed to DragonTTS ``/tts/stream``, which
+    streams audio chunks back — a cache HIT streams the cached blob, a MISS
+    streams from the nested provider as it synthesizes (low TTFB) while teeing
+    the full clip to the cache. Each chunk is yielded as its own audio frame so
+    pipecat can play it incrementally. Output is raw ``pcm_s16le`` @ 16 kHz
+    mono, matching the other providers' streaming output so the downstream
+    transport resamples to μ-law for telephony.
+    """
+
+    # DragonTTS returns raw pcm_s16le at 16 kHz for this service — fixed.
+    OUTPUT_SAMPLE_RATE = 16000
+    # No read timeout: streaming responses may pause between chunks (provider is
+    # still synthesizing). Connect/pool/write stay bounded.
+    _TIMEOUT = httpx.Timeout(connect=10.0, read=None, write=30.0, pool=10.0)
+
+    def __init__(
+        self,
+        *,
+        url: str,
+        model_id: str,
+        voice_id: str,
+        language: str = "",
+        params: Optional[dict] = None,
+        aggregate_sentences: bool = True,
+        **kwargs,
+    ) -> None:
+        super().__init__(
+            sample_rate=self.OUTPUT_SAMPLE_RATE,
+            push_start_frame=True,
+            push_stop_frames=True,
+            text_aggregation_mode=(
+                TextAggregationMode.SENTENCE
+                if aggregate_sentences
+                else TextAggregationMode.TOKEN
+            ),
+            # The base class requires a settings store; language is handled
+            # directly (DragonTTS takes a plain code), so leave it unset here.
+            settings=TTSSettings(model=model_id, voice=voice_id, language=None),
+            **kwargs,
+        )
+        self._url = url.rstrip("/")
+        self._model_id = model_id
+        self._voice_id = voice_id
+        self._language = language or ""
+        self._params = dict(params or {})
+        self._client: httpx.AsyncClient | None = None
+
+    def language_to_service_language(self, language: Language) -> str | None:
+        """DragonTTS accepts a plain language code — no provider mapping needed."""
+        return None
+
+    async def start(self, frame: StartFrame) -> None:
+        await super().start(frame)
+        self._client = httpx.AsyncClient(timeout=self._TIMEOUT)
+
+    async def _close_client(self) -> None:
+        if self._client is not None:
+            await self._client.aclose()
+            self._client = None
+
+    async def stop(self, frame: EndFrame) -> None:
+        await super().stop(frame)
+        await self._close_client()
+
+    async def cancel(self, frame: CancelFrame) -> None:
+        await super().cancel(frame)
+        await self._close_client()
+
+    async def run_tts(self, text: str, context_id: str) -> AsyncGenerator[Frame, None]:
+        """Stream one aggregated sentence via DragonTTS, yielding a frame per chunk."""
+        logger.debug(f"{self}: Generating TTS via DragonTTS [{text}]")
+
+        # Defensive: build a client if start() wasn't invoked by the pipeline.
+        if self._client is None:
+            self._client = httpx.AsyncClient(timeout=self._TIMEOUT)
+
+        body = {
+            "model_id": self._model_id,
+            "transcript": text,
+            "voice": {"id": self._voice_id},
+            "language": self._language,
+            "output_format": {
+                "container": "raw",
+                "encoding": "pcm_s16le",
+                "sample_rate": self.OUTPUT_SAMPLE_RATE,
+            },
+            "params": self._params,
+        }
+
+        try:
+            # Stream the response so audio frames flow as chunks arrive
+            # (HIT: cached blob; MISS: provider-synthesized chunks). Align
+            # chunks to 2-byte (16-bit sample) boundaries so every frame is a
+            # whole number of samples; carry any trailing odd byte to the next.
+            carry = b""
+            async with self._client.stream("POST", f"{self._url}/tts/stream", json=body) as response:
+                response.raise_for_status()
+                async for chunk in response.aiter_bytes():
+                    if not chunk:
+                        continue
+                    data = carry + chunk
+                    usable = len(data) - (len(data) % 2)
+                    if usable <= 0:
+                        carry = data
+                        continue
+                    carry = data[usable:]
+                    yield TTSAudioRawFrame(
+                        audio=data[:usable],
+                        sample_rate=self.OUTPUT_SAMPLE_RATE,
+                        num_channels=1,
+                        context_id=context_id,
+                    )
+            if carry:  # flush the final (possibly odd) tail
+                yield TTSAudioRawFrame(
+                    audio=carry,
+                    sample_rate=self.OUTPUT_SAMPLE_RATE,
+                    num_channels=1,
+                    context_id=context_id,
+                )
+        except httpx.HTTPStatusError as e:
+            detail = e.response.text[:200]
+            logger.error(f"DragonTTS returned HTTP {e.response.status_code}: {detail}")
+            yield ErrorFrame(
+                error=f"DragonTTS returned HTTP {e.response.status_code}: {detail}"
+            )
+        except Exception as e:
+            logger.error(f"DragonTTS synthesis failed: {e}")
+            yield ErrorFrame(error=f"DragonTTS synthesis failed: {e}")
+
+
+def build_dragontts_tts(config: DragonTTSConfig) -> DragonTTSService:
+    """Create a DragonTTS streaming service.
+
+    Args:
+        config: DragonTTSConfig instance with TTS parameters.
+
+    Returns:
+        Configured DragonTTSService instance.
+    """
+    return DragonTTSService(
+        url=config.url,
+        model_id=config.model_id,
+        voice_id=config.voice_id,
+        language=config.language,
+        params=config.params,
+        aggregate_sentences=config.aggregate_sentences,
+    )

--- a/app/core/config/dynamic.py
+++ b/app/core/config/dynamic.py
@@ -45,6 +45,13 @@ BB_SPEECH_PROVIDER_DEFAULTS: dict[str, dict] = {
         "voice_id": "en-IN-Chirp3-HD-Despina",
         "language": "en-IN",
     },
+    # DragonTTS caching proxy — model carries the nested provider as
+    # "<provider>:<model>" (e.g. "cartesia:sonic-3.5").
+    "dragontts": {
+        "voice_id": "bec003e2-3cb3-429c-8468-206a393c67ad",
+        "model": "cartesia:sonic-3.5",
+        "language": "en",
+    },
 }
 
 

--- a/app/core/config/static.py
+++ b/app/core/config/static.py
@@ -8,6 +8,10 @@ ENVIRONMENT = os.environ.get("ENVIRONMENT", "production")
 PROD_LOG_LEVEL = os.environ.get("PROD_LOG_LEVEL", "INFO")
 APP_BASE_URL = os.environ.get("APP_BASE_URL", "")
 
+# DragonTTS caching proxy. Breeze Buddy one-shot TTS (provider="dragontts") is
+# routed here. Override via env for non-local deployments.
+DRAGONTTS_URL = os.environ.get("DRAGONTTS_URL", "http://localhost:8000")
+
 # Uvicorn
 PORT = int(os.environ.get("PORT", 8000))
 HOST = os.environ.get("HOST", "0.0.0.0")


### PR DESCRIPTION
Wire DragonTTSService (streaming run_tts + one-shot generate_audio) into breeze_buddy's TTS provider selection and the voice TTS registry, plus the config fields for the dragonTTS base URL. dragonTTS is an internal ClusterIP caching proxy in front of Cartesia/Sarvam/ElevenLabs/Gemini.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added DragonTTS as a new supported TTS provider.
  * Configured default settings for DragonTTS provider integration, including voice, model, and language configuration options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->