### PR TITLE
feat: add alert action for LLM observers

### DIFF
--- a/app/ai/voice/agents/breeze_buddy/observers/manager.py
+++ b/app/ai/voice/agents/breeze_buddy/observers/manager.py
@@ -12,6 +12,7 @@ from typing import Any, List
 
 from pipecat.processors.aggregators.llm_context import LLMContext
 
+from app.ai.voice.agents.breeze_buddy.template.types import ActionType
 from app.core.logger import logger
 
 from .observer import RealtimeObserver
@@ -34,7 +35,9 @@ class ObserverManager:
         self._observers = observers
         self._llm_context = llm_context
         self._turn_count: int = 0
-        self._acted: set[str] = set()  # observer names that already acted
+        self._acted: set[str] = set()  # non-ALERT observers that already fired
+        self._fired_alerts: set[str] = set()  # ALERT observers that already fired
+        self._action_taken: bool = False  # True once any non-ALERT action executes
         self._check_lock = asyncio.Lock()
         # Strong references to in-flight tasks — prevents GC from collecting
         # them mid-flight when PipelineRunner runs with force_gc=True.
@@ -83,14 +86,22 @@ class ObserverManager:
             if self._stopped:
                 return
 
+            def _is_alert(obs: RealtimeObserver) -> bool:
+                return (
+                    obs.config.action is not None
+                    and obs.config.action.type == ActionType.ALERT
+                )
+
             eligible = [
                 obs
                 for obs in self._observers
                 if event_name in obs.config.trigger_on
-                and obs.name not in self._acted
+                and self._turn_count >= obs.config.start_after_turn
                 and (
-                    event_name != "on_user_turn_message_added"
-                    or self._turn_count > obs.config.start_after_turn
+                    _is_alert(obs)
+                    and obs.name not in self._fired_alerts
+                    or not _is_alert(obs)
+                    and obs.name not in self._acted
                 )
             ]
             if not eligible:
@@ -104,28 +115,34 @@ class ObserverManager:
                 f"{[obs.name for obs in eligible]}"
             )
 
-        # Launch checks outside the lock — each completes independently.
-        for obs in eligible:
-            task = asyncio.create_task(
-                self._check_and_act(obs, transcript),
-                name=f"obs-check:{obs.name}",
+            # gather() over as_completed(): as_completed wraps futures in
+            # new coroutines so the original future→observer mapping breaks.
+            # gather() returns results in input order which is deterministic
+            # and keeps the observer→result pairing trivial via zip().
+            results = await asyncio.gather(
+                *[obs.check(transcript) for obs in eligible],
+                return_exceptions=True,
             )
-            self._track_task(task)
 
-    async def _check_and_act(self, obs: RealtimeObserver, transcript: str) -> None:
-        """Run a single observer check and fire its action on detection."""
-        try:
-            detected = await obs.check(transcript)
-        except Exception:
-            logger.exception(f"Observer {obs.name} check failed")
-            return
-
-        if detected and obs.name not in self._acted:
-            self._acted.add(obs.name)
-            try:
-                await obs.execute_action()
-            except Exception:
-                logger.exception(f"Observer {obs.name} execute_action failed")
+            for obs, result in zip(eligible, results):
+                if self._action_taken:
+                    return
+                if isinstance(result, Exception):
+                    logger.error(f"Observer {obs.name} check failed: {result}")
+                    continue
+                if result is True:
+                    is_alert = _is_alert(obs)
+                    if is_alert:
+                        self._fired_alerts.add(obs.name)
+                    else:
+                        self._acted.add(obs.name)
+                        self._action_taken = True
+                    try:
+                        await obs.execute_action()
+                    except Exception as e:
+                        logger.error(f"Observer {obs.name} execute_action failed: {e}")
+                    if self._action_taken:
+                        return
 
     # ------------------------------------------------------------------
     # Transcript building

--- a/app/ai/voice/agents/breeze_buddy/observers/observer.py
+++ b/app/ai/voice/agents/breeze_buddy/observers/observer.py
@@ -21,11 +21,12 @@ from typing import Any, Dict
 from pipecat.adapters.schemas.function_schema import FunctionSchema
 
 from app.ai.voice.agents.breeze_buddy.template.context import TemplateContext
-from app.ai.voice.agents.breeze_buddy.template.hooks import set_outcome
-from app.ai.voice.agents.breeze_buddy.template.types import ObserverConfig
+from app.ai.voice.agents.breeze_buddy.template.types import ActionType, ObserverConfig
 from app.core.logger import logger
+from app.services.slack.alert import slack_alert
 
 from .llm import call_llm
+from .utils import set_outcome
 
 
 def _build_tools(tool_defs: list[dict]) -> list[FunctionSchema]:
@@ -64,6 +65,7 @@ class RealtimeObserver:
         self._agent_context = agent_context
         self._handler_map = handler_map
         self._tools = _build_tools(config.tools)
+        self._last_detection: Dict[str, Any] = {}
 
     # ------------------------------------------------------------------
     # Detection
@@ -97,9 +99,13 @@ class RealtimeObserver:
                 return False
 
             self._last_detection = tool_args or {}
+            # Capture the active node now — by the time execute_action
+            # runs, the main LLM may have already transitioned.
+            flow_mgr = getattr(self._agent_context, "flow_manager", None)
+            self._detected_at_node = flow_mgr.current_node if flow_mgr else None
             logger.info(
                 f"Observer {self.name} detected: "
-                f"{tool_name}, latency={latency_ms:.0f}ms"
+                f"{tool_name}({tool_args}), latency={latency_ms:.0f}ms"
             )
             return True
 
@@ -119,34 +125,70 @@ class RealtimeObserver:
         functions), then calls the configured action handler.
         """
         lead = self._agent_context.lead
+        action = self.config.action
+        handler_name = action.handler or action.type
 
-        outcome = (self.config.action.args or {}).get("outcome")
         if lead:
             if lead.metaData is None:
                 lead.metaData = {}
             lead.metaData["observer_triggered"] = self.name
 
-        action = self.config.action
-
-        # Record observer action in node traversal before set_outcome,
-        # so it's included when metaData is written to DB.
+        # Record observer action — only the winning observer reaches
+        # execute_action (manager sets _action_taken after first detect).
+        # Use the node captured at detection time (check()) since the
+        # active node may have changed due to race with main LLM.
         ctx = TemplateContext(self._agent_context)
-        ctx.record_observer_action(self.name, action.type, action.args)
+        ctx.record_observer_action(
+            self.name,
+            handler_name,
+            action.args,
+            node_name=getattr(self, "_detected_at_node", None),
+        )
 
+        outcome = (action.args or {}).get("outcome")
         if lead and outcome:
             lead.outcome = outcome
+            ctx = TemplateContext(self._agent_context)
             await set_outcome(ctx, outcome, triggered_by=self.name)
-        handler_name = action.handler or action.type
-        handler = self._handler_map.get(handler_name)
 
-        if handler:
-            logger.info(
-                f"Observer {self.name} executing action: "
-                f"{handler_name}, outcome={outcome}"
+        if action.type == ActionType.ALERT:
+            logger.info(f"Observer {self.name} executing action: alert")
+            call_sid = ctx.call_sid
+            safe_detection = (
+                list(self._last_detection.keys())
+                if isinstance(self._last_detection, dict)
+                else []
             )
-            await handler(action.args or {})
+            try:
+                await slack_alert.send(
+                    title=f"🟠 Breeze Buddy - Observer: {self.name}",
+                    fields=[
+                        {"name": "Observer", "value": self.name},
+                        {"name": "Call SID", "value": f"`{call_sid or 'N/A'}`"},
+                        {"name": "Detection fields", "value": f"`{safe_detection}`"},
+                    ],
+                    fallback_text=f"Observer '{self.name}' flagged call {call_sid}",
+                )
+                logger.info(
+                    f"Observer '{self.name}' sent Slack alert "
+                    f"(call={call_sid}, fields={safe_detection})"
+                )
+            except Exception:
+                logger.exception(f"Observer '{self.name}' failed to send Slack alert")
         else:
-            logger.error(
-                f"Observer {self.name}: handler {handler_name} "
-                f"not found in handler_map"
-            )
+            handler = self._handler_map.get(handler_name)
+            if handler:
+                logger.info(
+                    f"Observer {self.name} executing action: "
+                    f"{handler_name}, outcome={outcome}"
+                )
+                handler_args = {
+                    **(action.args or {}),
+                    "detection": self._last_detection,
+                }
+                await handler(handler_args)
+            else:
+                logger.error(
+                    f"Observer {self.name}: handler {handler_name} "
+                    f"not found in handler_map"
+                )

--- a/app/ai/voice/agents/breeze_buddy/observers/utils.py
+++ b/app/ai/voice/agents/breeze_buddy/observers/utils.py
@@ -1,0 +1,39 @@
+"""Utility functions for observers."""
+
+from app.ai.voice.agents.breeze_buddy.template.context import TemplateContext
+from app.ai.voice.agents.breeze_buddy.template.hooks import HookConfig, HookRegistry
+from app.ai.voice.agents.breeze_buddy.template.types import FieldConfig, FieldSource
+from app.core.logger import logger
+
+
+async def set_outcome(
+    context: TemplateContext, outcome: str, triggered_by: str = ""
+) -> None:
+    """Set call outcome via update_outcome_in_database hook.
+
+    Same path template function hooks use (confirm_order → CONFIRM, etc.).
+
+    Args:
+        context: TemplateContext for the current call
+        outcome: Outcome value (e.g., "VOICEMAIL", "HALLUCINATION")
+        triggered_by: Who triggered this (e.g., "voicemail_detector")
+    """
+    hook = HookRegistry.get("update_outcome_in_database")
+    if not hook:
+        logger.warning(
+            f"set_outcome: 'update_outcome_in_database' hook not found, "
+            f"outcome '{outcome}' not persisted"
+        )
+        return
+    hook_config = HookConfig(
+        name="update_outcome_in_database",
+        expected_fields={
+            "outcome": FieldConfig(source=FieldSource.STATIC, value=outcome)
+        },
+    )
+    await hook.safe_execute(
+        context,
+        {"outcome": outcome},
+        triggered_by or "set_outcome",
+        hook_config,
+    )

--- a/app/ai/voice/agents/breeze_buddy/template/context.py
+++ b/app/ai/voice/agents/breeze_buddy/template/context.py
@@ -358,16 +358,18 @@ class TemplateContext:
         observer_name: str,
         action_type: str,
         action_args: Optional[Dict[str, Any]] = None,
+        node_name: Optional[str] = None,
     ) -> None:
-        """Record an observer-triggered action under the currently active node.
+        """Record an observer-triggered action under a specific node.
 
-        Appends an entry to the ``observer_actions`` list of the most recent
-        node traversal entry (the one with ``exited_at`` still None).
+        If ``node_name`` is given, finds that node in traversal history.
+        Otherwise falls back to the currently active (last open) node.
 
         Args:
             observer_name: Name of the observer that triggered (from config).
             action_type: The action the observer executed (e.g. end_conversation).
             action_args: Arguments from the observer's configured action.
+            node_name: Node where the observer detected (captured at check time).
         """
         if not self.lead or not self.lead.metaData:
             return
@@ -375,23 +377,30 @@ class TemplateContext:
         if "node_traversal" not in self.lead.metaData:
             return
 
-        active_entry = None
-        for entry in reversed(self.lead.metaData["node_traversal"]):
-            if entry.get("exited_at") is None:
-                active_entry = entry
-                break
+        target_entry = None
+        if node_name:
+            for entry in reversed(self.lead.metaData["node_traversal"]):
+                if entry.get("node_name") == node_name:
+                    target_entry = entry
+                    break
 
-        if active_entry is None:
+        if target_entry is None:
+            for entry in reversed(self.lead.metaData["node_traversal"]):
+                if entry.get("exited_at") is None:
+                    target_entry = entry
+                    break
+
+        if target_entry is None:
             logger.warning(
                 f"Cannot record observer action '{observer_name}': "
-                "no active node entry found"
+                "no matching node entry found"
             )
             return
 
-        if "observer_actions" not in active_entry:
-            active_entry["observer_actions"] = []
+        if "observer_actions" not in target_entry:
+            target_entry["observer_actions"] = []
 
-        active_entry["observer_actions"].append(
+        target_entry["observer_actions"].append(
             {
                 "observer_name": observer_name,
                 "action": action_type,
@@ -401,7 +410,7 @@ class TemplateContext:
         )
         logger.info(
             f"Recorded observer action '{observer_name}' ({action_type}) "
-            f"under node '{active_entry.get('node_name')}'"
+            f"under node '{target_entry.get('node_name')}'"
         )
 
     def record_ivr_input(

--- a/app/ai/voice/agents/breeze_buddy/template/hooks.py
+++ b/app/ai/voice/agents/breeze_buddy/template/hooks.py
@@ -23,7 +23,6 @@ from app.ai.voice.agents.breeze_buddy.handlers.transport.utils.field_resolver im
 )
 from app.ai.voice.agents.breeze_buddy.template.context import TemplateContext
 from app.ai.voice.agents.breeze_buddy.template.types import (
-    FieldConfig,
     FieldSource,
     HookConfig,
 )
@@ -460,36 +459,3 @@ class HookRegistry:
 # Register hooks
 HookRegistry.register("update_outcome_in_database", UpdateOutcomeInDatabaseHook())
 HookRegistry.register("send_http_request", ExternalHTTPHook())
-
-
-async def set_outcome(
-    context: TemplateContext, outcome: str, triggered_by: str = ""
-) -> None:
-    """Set call outcome via update_outcome_in_database hook.
-
-    Same path template function hooks use (confirm_order → CONFIRM, etc.).
-
-    Args:
-        context: TemplateContext for the current call
-        outcome: Outcome value (e.g., "VOICEMAIL", "HALLUCINATION")
-        triggered_by: Who triggered this (e.g., "voicemail_detector")
-    """
-    hook = HookRegistry.get("update_outcome_in_database")
-    if not hook:
-        logger.warning(
-            f"set_outcome: 'update_outcome_in_database' hook not found, "
-            f"outcome '{outcome}' not persisted"
-        )
-        return
-    hook_config = HookConfig(
-        name="update_outcome_in_database",
-        expected_fields={
-            "outcome": FieldConfig(source=FieldSource.STATIC, value=outcome)
-        },
-    )
-    await hook.safe_execute(
-        context,
-        {"outcome": outcome},
-        triggered_by or "set_outcome",
-        hook_config,
-    )

--- a/app/ai/voice/agents/breeze_buddy/template/types.py
+++ b/app/ai/voice/agents/breeze_buddy/template/types.py
@@ -27,6 +27,7 @@ class ActionType(str, Enum):
     TTS_SAY = "tts_say"
     END_CONVERSATION = "end_conversation"
     FUNCTION = "function"
+    ALERT = "alert"
 
 
 class VadConfig(BaseModel):


### PR DESCRIPTION
Observers can now use action type 'alert' to send a Slack alert on detection (reusing the shared slack_alert.send) without changing the outcome or ending the call. Adds ActionType.ALERT, RealtimeObserver ._send_alert(), and stores the detection tool args for the alert reason.

Also moves set_outcome out of template/hooks.py (registration-only) into observers/observer.py, its sole caller (avoids a manager<->observer import cycle); removes the now-unused FieldConfig import from hooks.py.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an alert action for voice agent detections, sending a Slack notification with the observer name, call details, and detected reason.
  * Improved detection context by capturing and reusing the most recent detection details for alerting and outcome handling.
* **Bug Fixes**
  * Improved and streamlined outcome updates so they’re recorded immediately after a detection is captured, using the updated execution path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->