### PR TITLE
feat: add Meta Whatsapp onboarding support for Breeze Buddy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -107,6 +107,17 @@ JWT_SECRET_KEY="your_jwt_secret_key_here"
 JWT_ALGORITHM="HS256"
 JWT_ACCESS_TOKEN_EXPIRE_MINUTES=60
 
+# Meta WhatsApp Embedded Signup
+META_APP_ID=""
+META_APP_SECRET=""
+META_WHATSAPP_EMBEDDED_SIGNUP_CONFIG_ID=""
+META_GRAPH_API_VERSION="v25.0"
+META_GRAPH_BASE_URL="https://graph.facebook.com"
+META_REQUEST_TIMEOUT_SECONDS=10
+WHATSAPP_PAYMENT_LINK_TEMPLATE_NAME="buddy_payment_link_requested_v1"
+WHATSAPP_PAYMENT_LINK_TEMPLATE_LANGUAGE="en_US"
+WHATSAPP_PAYMENT_LINK_TEMPLATE_CATEGORY="UTILITY"
+
 # Google OAuth — for SSO login and self-service merchant signup
 # Create an OAuth 2.0 Client ID at: https://console.cloud.google.com/apis/credentials
 # Authorised JavaScript origins: https://your-dashboard-domain.com

--- a/app/api/routers/breeze_buddy/__init__.py
+++ b/app/api/routers/breeze_buddy/__init__.py
@@ -30,6 +30,7 @@ from app.api.routers.breeze_buddy.template_generator import (
 from app.api.routers.breeze_buddy.templates import router as templates_router
 from app.api.routers.breeze_buddy.users import router as users_router
 from app.api.routers.breeze_buddy.websocket import router as websocket_router
+from app.api.routers.breeze_buddy.whatsapp import router as whatsapp_router
 
 # Widget public mode (CHAT_MODE.md §14): per-merchant widget_config
 # CRUD (RBAC) + the unified /widget/session conversation router
@@ -104,3 +105,6 @@ router.include_router(chat_router, prefix="", tags=["chat"])
 # - widget: unified /widget/session/* conversation router (chat ↔ voice)
 router.include_router(widget_config_router, prefix="", tags=["widget-config"])
 router.include_router(widget_router, prefix="", tags=["widget-session"])
+
+# WhatsApp Embedded Signup (merchant onboarding for abandoned-recovery messaging)
+router.include_router(whatsapp_router, prefix="", tags=["whatsapp"])

--- a/app/api/routers/breeze_buddy/whatsapp/__init__.py
+++ b/app/api/routers/breeze_buddy/whatsapp/__init__.py
@@ -1,0 +1,112 @@
+"""WhatsApp Embedded Signup endpoints."""
+
+from fastapi import APIRouter, Depends, Query
+
+from app.api.security.breeze_buddy.rbac_token import get_current_user_with_rbac
+from app.schemas import UserInfo
+from app.schemas.breeze_buddy.whatsapp import (
+    MetaEmbeddedSignupCompleteRequest,
+    WhatsAppConnectionResponse,
+    WhatsAppEmbeddedSignupConfigResponse,
+    WhatsAppRegisterPhoneRequest,
+    WhatsAppSendPaymentLinkRequest,
+    WhatsAppSendPaymentLinkResponse,
+)
+
+from .handlers import (
+    complete_whatsapp_embedded_signup_handler,
+    disconnect_whatsapp_connection_handler,
+    get_whatsapp_connection_handler,
+    get_whatsapp_embedded_signup_config_handler,
+    register_whatsapp_phone_handler,
+    send_whatsapp_payment_link_handler,
+)
+
+router = APIRouter()
+
+
+@router.get(
+    "/whatsapp/embedded-signup/config",
+    response_model=WhatsAppEmbeddedSignupConfigResponse,
+)
+async def get_whatsapp_embedded_signup_config(
+    merchant_id: str = Query(..., description="Merchant ID to connect to WhatsApp"),
+    current_user: UserInfo = Depends(get_current_user_with_rbac),
+):
+    """
+    Return Meta app/config IDs for Loom to launch WhatsApp Embedded Signup.
+    """
+
+    return await get_whatsapp_embedded_signup_config_handler(
+        merchant_id=merchant_id,
+        current_user=current_user,
+    )
+
+
+@router.post(
+    "/whatsapp/embedded-signup/complete",
+    response_model=WhatsAppConnectionResponse,
+)
+async def complete_whatsapp_embedded_signup(
+    req: MetaEmbeddedSignupCompleteRequest,
+    current_user: UserInfo = Depends(get_current_user_with_rbac),
+):
+    """
+    Exchange Meta's short-lived code and store the merchant WhatsApp credentials.
+    """
+
+    return await complete_whatsapp_embedded_signup_handler(req, current_user)
+
+
+@router.get(
+    "/whatsapp/connection/{merchant_id}",
+    response_model=WhatsAppConnectionResponse,
+)
+async def get_whatsapp_connection(
+    merchant_id: str,
+    current_user: UserInfo = Depends(get_current_user_with_rbac),
+):
+    """Return merchant WhatsApp connection status."""
+
+    return await get_whatsapp_connection_handler(merchant_id, current_user)
+
+
+@router.post(
+    "/whatsapp/connection/{merchant_id}/register-phone",
+    response_model=WhatsAppConnectionResponse,
+)
+async def register_whatsapp_phone(
+    merchant_id: str,
+    req: WhatsAppRegisterPhoneRequest,
+    current_user: UserInfo = Depends(get_current_user_with_rbac),
+):
+    """Register a connected WhatsApp phone number for Cloud API messaging."""
+
+    return await register_whatsapp_phone_handler(merchant_id, req, current_user)
+
+
+@router.post(
+    "/whatsapp/connection/{merchant_id}/send-payment-link",
+    response_model=WhatsAppSendPaymentLinkResponse,
+)
+async def send_whatsapp_payment_link(
+    merchant_id: str,
+    req: WhatsAppSendPaymentLinkRequest,
+    current_user: UserInfo = Depends(get_current_user_with_rbac),
+):
+    """Send the approved payment-link WhatsApp template to a customer."""
+
+    return await send_whatsapp_payment_link_handler(merchant_id, req, current_user)
+
+
+@router.delete(
+    "/whatsapp/connection/{merchant_id}",
+    response_model=WhatsAppConnectionResponse,
+)
+async def disconnect_whatsapp_connection_endpoint(
+    merchant_id: str,
+    current_user: UserInfo = Depends(get_current_user_with_rbac),
+):
+    """Mark a merchant WhatsApp connection disconnected locally."""
+
+    return await disconnect_whatsapp_connection_handler(merchant_id, current_user)

--- a/app/api/routers/breeze_buddy/whatsapp/handlers.py
+++ b/app/api/routers/breeze_buddy/whatsapp/handlers.py
@@ -1,0 +1,439 @@
+"""Handlers for WhatsApp Embedded Signup endpoints."""
+
+from typing import Optional
+
+from fastapi import HTTPException, status
+
+from app.core.config.static import (
+    WHATSAPP_PAYMENT_LINK_TEMPLATE_CATEGORY,
+    WHATSAPP_PAYMENT_LINK_TEMPLATE_LANGUAGE,
+    WHATSAPP_PAYMENT_LINK_TEMPLATE_NAME,
+)
+from app.core.logger import logger
+from app.core.security.scope import resolve_merchant_ids
+from app.database.accessor.breeze_buddy import merchants as merchant_accessors
+from app.database.accessor.breeze_buddy.whatsapp import (
+    disconnect_whatsapp_connection,
+    get_whatsapp_business_token_by_merchant_id,
+    get_whatsapp_connection_by_merchant_id,
+    increment_whatsapp_message_counter,
+    update_whatsapp_connection_setup_status,
+    upsert_whatsapp_connection,
+)
+from app.schemas import UserInfo
+from app.schemas.breeze_buddy.whatsapp import (
+    MetaEmbeddedSignupCompleteRequest,
+    WhatsAppConnectionResponse,
+    WhatsAppConnectionStatus,
+    WhatsAppEmbeddedSignupConfigResponse,
+    WhatsAppRegisterPhoneRequest,
+    WhatsAppSendPaymentLinkRequest,
+    WhatsAppSendPaymentLinkResponse,
+)
+from app.services.meta.whatsapp import (
+    MetaWhatsAppAPIError,
+    MetaWhatsAppClient,
+    MetaWhatsAppConfigurationError,
+)
+
+
+async def _get_merchant_for_access(merchant_id: str):
+    merchant = await merchant_accessors.get_merchant_by_merchant_identifier(merchant_id)
+    if not merchant:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Merchant entity not found",
+        )
+    return merchant
+
+
+async def _validate_merchant_access(
+    current_user: UserInfo,
+    merchant_id: str,
+    operation: str,
+) -> None:
+    allowed = await resolve_merchant_ids(current_user)
+    if allowed is None:
+        return
+    if merchant_id not in allowed:
+        logger.warning(
+            f"User {current_user.username} attempted to {operation} WhatsApp "
+            f"connection for unauthorized merchant: {merchant_id}"
+        )
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=f"Access denied to merchant {merchant_id}",
+        )
+
+
+def _not_connected_response(merchant_id: str) -> WhatsAppConnectionResponse:
+    return WhatsAppConnectionResponse(
+        merchant_id=merchant_id,
+        status=WhatsAppConnectionStatus.NOT_CONNECTED,
+        connected=False,
+    )
+
+
+def _configuration_http_error(exc: MetaWhatsAppConfigurationError) -> HTTPException:
+    return HTTPException(
+        status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+        detail=str(exc),
+    )
+
+
+def _meta_http_error(
+    exc: MetaWhatsAppAPIError,
+    fallback: str,
+    status_code: int = status.HTTP_502_BAD_GATEWAY,
+) -> HTTPException:
+    detail = {"message": fallback}
+    if exc.error_code:
+        detail["meta_error_code"] = exc.error_code
+    if exc.error_subcode:
+        detail["meta_error_subcode"] = exc.error_subcode
+    if str(exc):
+        detail["meta_message"] = str(exc)
+    return HTTPException(status_code=status_code, detail=detail)
+
+
+async def get_whatsapp_embedded_signup_config_handler(
+    merchant_id: str,
+    current_user: UserInfo,
+    meta_client: Optional[MetaWhatsAppClient] = None,
+) -> WhatsAppEmbeddedSignupConfigResponse:
+    """Return the frontend config needed to launch Meta Embedded Signup."""
+
+    await _get_merchant_for_access(merchant_id)
+    await _validate_merchant_access(current_user, merchant_id, "view")
+
+    client = meta_client or MetaWhatsAppClient()
+    try:
+        client.ensure_configured()
+    except MetaWhatsAppConfigurationError as e:
+        raise _configuration_http_error(e)
+
+    connection = await get_whatsapp_connection_by_merchant_id(merchant_id)
+    response_connection = connection or None
+    response_status = (
+        connection.status if connection else WhatsAppConnectionStatus.NOT_CONNECTED
+    )
+
+    return WhatsAppEmbeddedSignupConfigResponse(
+        merchant_id=merchant_id,
+        app_id=client.app_id,
+        config_id=client.embedded_signup_config_id,
+        graph_api_version=client.graph_api_version,
+        status=response_status,
+        connected=response_status == WhatsAppConnectionStatus.CONNECTED,
+        connection=response_connection,
+    )
+
+
+async def get_whatsapp_connection_handler(
+    merchant_id: str,
+    current_user: UserInfo,
+) -> WhatsAppConnectionResponse:
+    """Return merchant WhatsApp connection status."""
+
+    await _get_merchant_for_access(merchant_id)
+    await _validate_merchant_access(current_user, merchant_id, "view")
+
+    connection = await get_whatsapp_connection_by_merchant_id(merchant_id)
+    return connection or _not_connected_response(merchant_id)
+
+
+async def complete_whatsapp_embedded_signup_handler(
+    req: MetaEmbeddedSignupCompleteRequest,
+    current_user: UserInfo,
+    meta_client: Optional[MetaWhatsAppClient] = None,
+) -> WhatsAppConnectionResponse:
+    """Exchange Meta's code and store merchant WhatsApp credentials."""
+
+    merchant = await _get_merchant_for_access(req.merchant_id)
+    await _validate_merchant_access(current_user, req.merchant_id, "complete")
+
+    if req.signup_event.type and req.signup_event.type != "WA_EMBEDDED_SIGNUP":
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="signup_event.type must be WA_EMBEDDED_SIGNUP",
+        )
+
+    session_info = req.signup_event.data
+    if not session_info.phone_number_id:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="signup_event.data.phone_number_id is required",
+        )
+    if not session_info.waba_id and not session_info.waba_ids:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="signup_event.data.waba_id is required",
+        )
+    if not session_info.waba_id and session_info.waba_ids:
+        session_info.waba_id = session_info.waba_ids[0]
+
+    if req.register_phone_number and not req.phone_number_pin:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="phone_number_pin is required when register_phone_number=true",
+        )
+
+    client = meta_client or MetaWhatsAppClient()
+    try:
+        token_result = await client.exchange_code_for_business_token(req.code)
+    except MetaWhatsAppConfigurationError as e:
+        raise _configuration_http_error(e)
+    except MetaWhatsAppAPIError as e:
+        raise _meta_http_error(e, "Meta token exchange failed")
+
+    status_value = WhatsAppConnectionStatus.CONNECTED
+    webhook_subscribed = False
+    phone_registered = False
+    last_error_code = None
+    last_error_message = None
+    template_result = None
+    last_template_error = None
+
+    if req.subscribe_webhooks:
+        try:
+            webhook_subscribed = await client.subscribe_app_to_waba(
+                session_info.waba_id or "",
+                token_result.access_token,
+            )
+            if not webhook_subscribed:
+                status_value = WhatsAppConnectionStatus.ERROR
+                last_error_message = "Meta webhook subscription returned success=false"
+        except MetaWhatsAppAPIError as e:
+            status_value = WhatsAppConnectionStatus.ERROR
+            last_error_code = e.error_code
+            last_error_message = f"Meta webhook subscription failed: {e}"
+
+    if req.register_phone_number and req.phone_number_pin:
+        try:
+            phone_registered = await client.register_phone_number(
+                session_info.phone_number_id,
+                token_result.access_token,
+                req.phone_number_pin,
+            )
+            if not phone_registered:
+                status_value = WhatsAppConnectionStatus.ERROR
+                last_error_message = "Meta phone registration returned success=false"
+        except MetaWhatsAppAPIError as e:
+            status_value = WhatsAppConnectionStatus.ERROR
+            last_error_code = e.error_code
+            last_error_message = f"Meta phone registration failed: {e}"
+
+    try:
+        template_result = await client.create_payment_link_utility_template(
+            session_info.waba_id or "",
+            token_result.access_token,
+        )
+    except MetaWhatsAppAPIError as e:
+        status_value = WhatsAppConnectionStatus.ERROR
+        last_error_code = e.error_code
+        last_template_error = f"Meta template creation failed: {e}"
+        if not last_error_message:
+            last_error_message = last_template_error
+
+    connection = await upsert_whatsapp_connection(
+        reseller_id=merchant.reseller_id,
+        merchant_id=req.merchant_id,
+        session_info=session_info,
+        token_result=token_result,
+        app_id=client.app_id,
+        config_id=client.embedded_signup_config_id,
+        graph_api_version=client.graph_api_version,
+        status=status_value,
+        webhook_subscribed=webhook_subscribed,
+        phone_registered=phone_registered,
+        last_error_code=last_error_code,
+        last_error_message=last_error_message,
+        last_onboarding_event=req.signup_event.event,
+        raw_signup_payload=req.signup_event.model_dump(mode="json"),
+        template_result=template_result,
+        template_name=WHATSAPP_PAYMENT_LINK_TEMPLATE_NAME,
+        template_language=WHATSAPP_PAYMENT_LINK_TEMPLATE_LANGUAGE,
+        template_category=WHATSAPP_PAYMENT_LINK_TEMPLATE_CATEGORY,
+        last_template_error=last_template_error,
+    )
+    if not connection:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to store WhatsApp connection",
+        )
+    return connection
+
+
+async def register_whatsapp_phone_handler(
+    merchant_id: str,
+    req: WhatsAppRegisterPhoneRequest,
+    current_user: UserInfo,
+    meta_client: Optional[MetaWhatsAppClient] = None,
+) -> WhatsAppConnectionResponse:
+    """Register an existing merchant WhatsApp phone number with Cloud API."""
+
+    await _get_merchant_for_access(merchant_id)
+    await _validate_merchant_access(current_user, merchant_id, "register")
+
+    connection = await get_whatsapp_connection_by_merchant_id(merchant_id)
+    if not connection or not connection.phone_number_id:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="WhatsApp connection not found",
+        )
+
+    business_token = await get_whatsapp_business_token_by_merchant_id(merchant_id)
+    if not business_token:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="WhatsApp business token is unavailable",
+        )
+
+    client = meta_client or MetaWhatsAppClient()
+    try:
+        phone_registered = await client.register_phone_number(
+            connection.phone_number_id,
+            business_token,
+            req.pin,
+        )
+    except MetaWhatsAppConfigurationError as e:
+        raise _configuration_http_error(e)
+    except MetaWhatsAppAPIError as e:
+        updated = await update_whatsapp_connection_setup_status(
+            merchant_id=merchant_id,
+            status=WhatsAppConnectionStatus.ERROR,
+            last_error_code=e.error_code,
+            last_error_message=f"Meta phone registration failed: {e}",
+        )
+        if updated:
+            return updated
+        raise _meta_http_error(e, "Meta phone registration failed")
+
+    status_value = (
+        WhatsAppConnectionStatus.CONNECTED
+        if phone_registered
+        else WhatsAppConnectionStatus.ERROR
+    )
+    updated = await update_whatsapp_connection_setup_status(
+        merchant_id=merchant_id,
+        status=status_value,
+        phone_registered=phone_registered,
+        last_error_code=None if phone_registered else "registration_failed",
+        last_error_message=(
+            None
+            if phone_registered
+            else "Meta phone registration returned success=false"
+        ),
+    )
+    if not updated:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="WhatsApp connection not found",
+        )
+    return updated
+
+
+async def send_whatsapp_payment_link_handler(
+    merchant_id: str,
+    req: WhatsAppSendPaymentLinkRequest,
+    current_user: UserInfo,
+    meta_client: Optional[MetaWhatsAppClient] = None,
+) -> WhatsAppSendPaymentLinkResponse:
+    """Send the merchant payment-link Utility template through WhatsApp."""
+
+    await _get_merchant_for_access(merchant_id)
+    await _validate_merchant_access(current_user, merchant_id, "send")
+
+    connection = await get_whatsapp_connection_by_merchant_id(merchant_id)
+    if not connection or not connection.phone_number_id:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="WhatsApp connection not found",
+        )
+    if connection.status != WhatsAppConnectionStatus.CONNECTED:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="WhatsApp connection is not connected",
+        )
+
+    template_status = (connection.payment_link_template_status or "").upper()
+    if template_status != "APPROVED":
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="WhatsApp payment link template is not approved",
+        )
+
+    business_token = await get_whatsapp_business_token_by_merchant_id(merchant_id)
+    if not business_token:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="WhatsApp business token is unavailable",
+        )
+
+    attempted = await increment_whatsapp_message_counter(
+        merchant_id=merchant_id,
+        counter="attempted",
+    )
+    if not attempted:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="WhatsApp connection not found",
+        )
+
+    client = meta_client or MetaWhatsAppClient()
+    try:
+        result = await client.send_payment_link_template_message(
+            phone_number_id=connection.phone_number_id,
+            business_token=business_token,
+            recipient_phone=req.recipient_phone,
+            customer_name=req.customer_name,
+            order_reference=req.order_reference,
+            payment_link=req.payment_link,
+            template_name=(
+                connection.payment_link_template_name
+                or WHATSAPP_PAYMENT_LINK_TEMPLATE_NAME
+            ),
+            language=(
+                connection.payment_link_template_language
+                or WHATSAPP_PAYMENT_LINK_TEMPLATE_LANGUAGE
+            ),
+        )
+    except MetaWhatsAppConfigurationError as e:
+        raise _configuration_http_error(e)
+    except MetaWhatsAppAPIError as e:
+        updated = await increment_whatsapp_message_counter(
+            merchant_id=merchant_id,
+            counter="failed",
+            last_error_code=e.error_code,
+            last_error_message=f"Meta WhatsApp payment link send failed: {e}",
+        )
+        if updated:
+            attempted = updated
+        raise _meta_http_error(e, "Meta WhatsApp payment link send failed")
+
+    success = await increment_whatsapp_message_counter(
+        merchant_id=merchant_id,
+        counter="success",
+    )
+    return WhatsAppSendPaymentLinkResponse(
+        message_id=result.message_id,
+        connection=success or attempted,
+    )
+
+
+async def disconnect_whatsapp_connection_handler(
+    merchant_id: str,
+    current_user: UserInfo,
+) -> WhatsAppConnectionResponse:
+    """Mark the merchant WhatsApp connection disconnected locally."""
+
+    await _get_merchant_for_access(merchant_id)
+    await _validate_merchant_access(current_user, merchant_id, "disconnect")
+
+    connection = await disconnect_whatsapp_connection(merchant_id)
+    if not connection:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="WhatsApp connection not found",
+        )
+    return connection

--- a/app/core/config/static.py
+++ b/app/core/config/static.py
@@ -285,6 +285,25 @@ ENABLE_LIGHTHOUSE_AUTH = os.getenv("ENABLE_LIGHTHOUSE_AUTH", "false").lower() ==
 # Obtain from: https://console.cloud.google.com/apis/credentials
 GOOGLE_CLIENT_ID = os.getenv("GOOGLE_CLIENT_ID", "")
 
+# Meta WhatsApp Embedded Signup
+META_APP_ID = os.getenv("META_APP_ID", "")
+META_APP_SECRET = os.getenv("META_APP_SECRET", "")
+META_WHATSAPP_EMBEDDED_SIGNUP_CONFIG_ID = os.getenv(
+    "META_WHATSAPP_EMBEDDED_SIGNUP_CONFIG_ID", ""
+)
+META_GRAPH_API_VERSION = os.getenv("META_GRAPH_API_VERSION", "v25.0")
+META_GRAPH_BASE_URL = os.getenv("META_GRAPH_BASE_URL", "https://graph.facebook.com")
+META_REQUEST_TIMEOUT_SECONDS = int(os.getenv("META_REQUEST_TIMEOUT_SECONDS", "10"))
+WHATSAPP_PAYMENT_LINK_TEMPLATE_NAME = os.getenv(
+    "WHATSAPP_PAYMENT_LINK_TEMPLATE_NAME", "buddy_payment_link_requested_v1"
+)
+WHATSAPP_PAYMENT_LINK_TEMPLATE_LANGUAGE = os.getenv(
+    "WHATSAPP_PAYMENT_LINK_TEMPLATE_LANGUAGE", "en_US"
+)
+WHATSAPP_PAYMENT_LINK_TEMPLATE_CATEGORY = os.getenv(
+    "WHATSAPP_PAYMENT_LINK_TEMPLATE_CATEGORY", "UTILITY"
+)
+
 BREEZE_BUDDY_STT_SERVICE = os.getenv(
     "BREEZE_BUDDY_STT_SERVICE", "soniox"
 ).lower()  # "soniox", "sarvam", "openai", "deepgram", or "google"

--- a/app/database/accessor/breeze_buddy/credentials.py
+++ b/app/database/accessor/breeze_buddy/credentials.py
@@ -18,8 +18,10 @@ from app.database.queries.breeze_buddy.credentials import (
     get_all_credentials_query,
     get_credential_by_id_query,
     get_credentials_by_merchant_query,
+    get_merchant_credential_by_name_query,
     insert_credential_query,
     update_credential_query,
+    upsert_merchant_credential_by_name_query,
 )
 from app.schemas import Credential, CredentialType
 from app.services.encryption import encrypt_credential
@@ -95,9 +97,13 @@ async def create_credential(
     credential_type: CredentialType,
     value: Dict[str, Any],
     description: Optional[str] = None,
+    merchant_id: Optional[str] = None,
 ) -> Optional[Credential]:
     """Create a new credential with optional KMS encryption."""
-    logger.info(f"Creating credential '{name}' for merchant: {reseller_id or 'GLOBAL'}")
+    logger.info(
+        f"Creating credential '{name}' for reseller: {reseller_id or 'GLOBAL'}, "
+        f"merchant: {merchant_id or 'NONE'}"
+    )
 
     try:
         # Validate value structure matches credential_type
@@ -108,6 +114,7 @@ async def create_credential(
         query_text, values = insert_credential_query(
             id=str(uuid4()),
             reseller_id=reseller_id,
+            merchant_id=merchant_id,
             name=name,
             credential_type=credential_type.value,
             value=stored_value,
@@ -145,13 +152,70 @@ async def get_credential_by_id(
         return None
 
 
+async def get_merchant_credential_by_name(
+    reseller_id: Optional[str],
+    merchant_id: str,
+    name: str,
+    mask: bool = True,
+) -> Optional[Credential]:
+    """Get an active named credential scoped to one merchant."""
+
+    try:
+        query_text, values = get_merchant_credential_by_name_query(
+            reseller_id=reseller_id,
+            merchant_id=merchant_id,
+            name=name,
+        )
+        result = await run_parameterized_query(query_text, values)
+        return decode_single_credential(result, mask=mask)
+    except Exception as e:
+        logger.error(
+            f"Error getting credential '{name}' for merchant {merchant_id}: {e}"
+        )
+        return None
+
+
+async def upsert_merchant_credential_by_name(
+    reseller_id: Optional[str],
+    merchant_id: str,
+    name: str,
+    credential_type: CredentialType,
+    value: Dict[str, Any],
+    description: Optional[str] = None,
+    mask: bool = True,
+) -> Optional[Credential]:
+    """Create or update a named merchant-scoped credential."""
+
+    try:
+        _validate_credential_value(credential_type, value)
+        stored_value, is_encrypted = encrypt_credential(value)
+        query_text, values = upsert_merchant_credential_by_name_query(
+            id=str(uuid4()),
+            reseller_id=reseller_id,
+            merchant_id=merchant_id,
+            name=name,
+            credential_type=credential_type.value,
+            value=stored_value,
+            is_encrypted=is_encrypted,
+            description=description,
+        )
+        result = await run_parameterized_query(query_text, values)
+        return decode_single_credential(result, mask=mask)
+    except Exception as e:
+        logger.error(
+            f"Error upserting credential '{name}' for merchant {merchant_id}: {e}",
+            exc_info=True,
+        )
+        return None
+
+
 async def get_credentials_by_merchant(
     reseller_id: Optional[str],
     mask: bool = True,
 ) -> List[Credential]:
     """
-    Get credentials for a merchant (includes global credentials).
-    Results ordered: global first, then merchant-specific.
+    Get global and reseller-scoped credentials for template/API configuration.
+    Merchant-scoped system credentials are fetched through explicit helpers.
     """
     try:
         query_text, values = get_credentials_by_merchant_query(reseller_id)
@@ -178,7 +242,7 @@ async def get_credentials_as_template_vars(
 ) -> Dict[str, Any]:
     """
     Get credentials as a flat dict for template_vars resolution.
-    Merges global + merchant-specific credentials (merchant overrides global).
+    Merges global + reseller-specific credentials.
     """
     try:
         query_text, values = get_credentials_by_merchant_query(reseller_id)

--- a/app/database/accessor/breeze_buddy/whatsapp.py
+++ b/app/database/accessor/breeze_buddy/whatsapp.py
@@ -1,0 +1,242 @@
+"""Database accessor functions for merchant WhatsApp credentials."""
+
+import json
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, List, Optional
+from uuid import uuid4
+
+from app.core.logger import logger
+from app.database.accessor.breeze_buddy.credentials import (
+    get_credential_by_id,
+    upsert_merchant_credential_by_name,
+)
+from app.database.decoder.breeze_buddy.whatsapp import (
+    decode_single_whatsapp_connection,
+    decode_whatsapp_connection_list,
+)
+from app.database.queries import run_parameterized_query
+from app.database.queries.breeze_buddy.whatsapp import (
+    disconnect_whatsapp_connection_query,
+    get_whatsapp_connection_by_merchant_id_query,
+    increment_whatsapp_message_counter_query,
+    list_whatsapp_connections_by_reseller_id_query,
+    update_whatsapp_connection_setup_status_query,
+    upsert_whatsapp_connection_query,
+)
+from app.schemas import CredentialType
+from app.schemas.breeze_buddy.whatsapp import (
+    MetaEmbeddedSignupSessionInfo,
+    MetaTemplateCreateResult,
+    MetaTokenExchangeResult,
+    WhatsAppConnectionResponse,
+    WhatsAppConnectionStatus,
+)
+
+WHATSAPP_BUSINESS_TOKEN_CREDENTIAL_NAME = "whatsapp_business_token"
+
+
+def _token_expires_at(expires_in: Optional[int]) -> Optional[datetime]:
+    """Convert a Meta expires_in value to an absolute UTC timestamp."""
+
+    if not expires_in:
+        return None
+    return datetime.now(timezone.utc) + timedelta(seconds=expires_in)
+
+
+async def upsert_whatsapp_connection(
+    reseller_id: Optional[str],
+    merchant_id: str,
+    session_info: MetaEmbeddedSignupSessionInfo,
+    token_result: MetaTokenExchangeResult,
+    app_id: Optional[str],
+    config_id: Optional[str],
+    graph_api_version: str,
+    status: WhatsAppConnectionStatus,
+    webhook_subscribed: bool,
+    phone_registered: bool,
+    last_error_code: Optional[str],
+    last_error_message: Optional[str],
+    last_onboarding_event: Optional[str],
+    raw_signup_payload: Dict[str, Any],
+    template_result: Optional[MetaTemplateCreateResult] = None,
+    template_name: Optional[str] = None,
+    template_language: Optional[str] = None,
+    template_category: Optional[str] = None,
+    last_template_error: Optional[str] = None,
+) -> Optional[WhatsAppConnectionResponse]:
+    """Create or update a merchant WhatsApp connection."""
+
+    token_credential = await upsert_merchant_credential_by_name(
+        reseller_id=reseller_id,
+        merchant_id=merchant_id,
+        name=WHATSAPP_BUSINESS_TOKEN_CREDENTIAL_NAME,
+        credential_type=CredentialType.BEARER_TOKEN,
+        value={"token": token_result.access_token},
+        description="Meta WhatsApp business token from Embedded Signup",
+        mask=False,
+    )
+    if not token_credential:
+        raise RuntimeError("Failed to store WhatsApp business token credential")
+
+    template_created_at = (
+        datetime.now(timezone.utc)
+        if template_result and (template_result.id or template_result.status)
+        else None
+    )
+    query, values = upsert_whatsapp_connection_query(
+        id=str(uuid4()),
+        reseller_id=reseller_id,
+        merchant_id=merchant_id,
+        business_token_credential_id=token_credential.id,
+        meta_business_id=session_info.business_id,
+        waba_id=session_info.waba_id or (session_info.waba_ids or [""])[0],
+        phone_number_id=session_info.phone_number_id or "",
+        display_phone_number=None,
+        verified_name=None,
+        token_type=token_result.token_type,
+        token_expires_at=_token_expires_at(token_result.expires_in),
+        scope=token_result.scope,
+        app_id=app_id,
+        config_id=config_id,
+        graph_api_version=graph_api_version,
+        status=status.value,
+        webhook_subscribed=webhook_subscribed,
+        phone_registered=phone_registered,
+        last_error_code=last_error_code,
+        last_error_message=last_error_message,
+        last_onboarding_event=last_onboarding_event,
+        raw_signup_payload_json=json.dumps(raw_signup_payload or {}),
+        payment_link_template_id=template_result.id if template_result else None,
+        payment_link_template_name=template_name,
+        payment_link_template_language=template_language,
+        payment_link_template_category=(
+            template_result.category if template_result else template_category
+        ),
+        payment_link_template_status=(
+            template_result.status if template_result else None
+        ),
+        payment_link_template_created_at=template_created_at,
+        last_template_error=last_template_error,
+    )
+
+    try:
+        result = await run_parameterized_query(query, values)
+        return decode_single_whatsapp_connection(result)
+    except Exception as e:
+        logger.error(
+            f"Error upserting WhatsApp connection for merchant {merchant_id}: {e}",
+            exc_info=True,
+        )
+        raise
+
+
+async def get_whatsapp_connection_by_merchant_id(
+    merchant_id: str,
+) -> Optional[WhatsAppConnectionResponse]:
+    """Get a merchant WhatsApp connection by merchant ID."""
+
+    query, values = get_whatsapp_connection_by_merchant_id_query(merchant_id)
+    try:
+        result = await run_parameterized_query(query, values)
+        return decode_single_whatsapp_connection(result)
+    except Exception as e:
+        logger.error(
+            f"Error fetching WhatsApp connection for merchant {merchant_id}: {e}"
+        )
+        raise
+
+
+async def get_whatsapp_business_token_by_merchant_id(
+    merchant_id: str,
+) -> Optional[str]:
+    """Get a decrypted WhatsApp business token for internal sending APIs."""
+
+    query, values = get_whatsapp_connection_by_merchant_id_query(merchant_id)
+    try:
+        result = await run_parameterized_query(query, values)
+        if not result:
+            return None
+        connection = decode_single_whatsapp_connection(result)
+        if not connection or not connection.business_token_credential_id:
+            return None
+
+        credential = await get_credential_by_id(
+            connection.business_token_credential_id,
+            mask=False,
+        )
+        if not credential or not credential.value:
+            return None
+
+        token = credential.value.get("token")
+        return token if isinstance(token, str) else None
+    except Exception as e:
+        logger.error(
+            f"Error fetching WhatsApp business token for merchant {merchant_id}: {e}"
+        )
+        raise
+
+
+async def list_whatsapp_connections_by_reseller_id(
+    reseller_id: str,
+) -> List[WhatsAppConnectionResponse]:
+    """List merchant WhatsApp connections for a reseller."""
+
+    query, values = list_whatsapp_connections_by_reseller_id_query(reseller_id)
+    try:
+        result = await run_parameterized_query(query, values)
+        return decode_whatsapp_connection_list(result)
+    except Exception as e:
+        logger.error(
+            f"Error listing WhatsApp connections for reseller {reseller_id}: {e}"
+        )
+        raise
+
+
+async def update_whatsapp_connection_setup_status(
+    merchant_id: str,
+    status: WhatsAppConnectionStatus,
+    webhook_subscribed: Optional[bool] = None,
+    phone_registered: Optional[bool] = None,
+    last_error_code: Optional[str] = None,
+    last_error_message: Optional[str] = None,
+) -> Optional[WhatsAppConnectionResponse]:
+    """Update setup flags after webhook subscription or phone registration."""
+
+    query, values = update_whatsapp_connection_setup_status_query(
+        merchant_id=merchant_id,
+        status=status.value,
+        webhook_subscribed=webhook_subscribed,
+        phone_registered=phone_registered,
+        last_error_code=last_error_code,
+        last_error_message=last_error_message,
+    )
+    result = await run_parameterized_query(query, values)
+    return decode_single_whatsapp_connection(result)
+
+
+async def increment_whatsapp_message_counter(
+    merchant_id: str,
+    counter: str,
+    last_error_code: Optional[str] = None,
+    last_error_message: Optional[str] = None,
+) -> Optional[WhatsAppConnectionResponse]:
+    """Increment a merchant-level WhatsApp message counter."""
+
+    query, values = increment_whatsapp_message_counter_query(
+        merchant_id=merchant_id,
+        counter=counter,
+        last_error_code=last_error_code,
+        last_error_message=last_error_message,
+    )
+    result = await run_parameterized_query(query, values)
+    return decode_single_whatsapp_connection(result)
+
+
+async def disconnect_whatsapp_connection(
+    merchant_id: str,
+) -> Optional[WhatsAppConnectionResponse]:
+    """Mark a merchant WhatsApp connection disconnected locally."""
+
+    query, values = disconnect_whatsapp_connection_query(merchant_id)
+    result = await run_parameterized_query(query, values)
+    return decode_single_whatsapp_connection(result)

--- a/app/database/decoder/breeze_buddy/credentials.py
+++ b/app/database/decoder/breeze_buddy/credentials.py
@@ -48,6 +48,7 @@ def decode_credential(
     return Credential(
         id=str(row["id"]),
         reseller_id=row["reseller_id"],
+        merchant_id=row["merchant_id"],
         name=row["name"],
         credential_type=CredentialType(row["credential_type"]),
         value=_mask_credential_value(real_value) if mask else real_value,

--- a/app/database/decoder/breeze_buddy/whatsapp.py
+++ b/app/database/decoder/breeze_buddy/whatsapp.py
@@ -1,0 +1,80 @@
+"""Decoder functions for merchant WhatsApp credential rows."""
+
+from typing import List, Optional
+
+import asyncpg
+
+from app.schemas.breeze_buddy.whatsapp import (
+    WhatsAppConnectionResponse,
+    WhatsAppConnectionStatus,
+)
+
+
+def decode_whatsapp_connection(row: asyncpg.Record) -> WhatsAppConnectionResponse:
+    """Decode a merchant WhatsApp credential row for API responses."""
+
+    status = WhatsAppConnectionStatus(row["status"])
+    return WhatsAppConnectionResponse(
+        merchant_id=row["merchant_id"],
+        reseller_id=row["reseller_id"],
+        business_token_credential_id=(
+            str(row["business_token_credential_id"])
+            if row["business_token_credential_id"]
+            else None
+        ),
+        status=status,
+        connected=status == WhatsAppConnectionStatus.CONNECTED,
+        waba_id=row["waba_id"],
+        phone_number_id=row["phone_number_id"],
+        meta_business_id=row["meta_business_id"],
+        display_phone_number=row["display_phone_number"],
+        verified_name=row["verified_name"],
+        app_id=row["app_id"],
+        config_id=row["config_id"],
+        graph_api_version=row["graph_api_version"],
+        webhook_subscribed=row["webhook_subscribed"],
+        phone_registered=row["phone_registered"],
+        token_type=row["token_type"],
+        token_expires_at=row["token_expires_at"],
+        scope=row["scope"],
+        payment_link_template_id=row["payment_link_template_id"],
+        payment_link_template_name=row["payment_link_template_name"],
+        payment_link_template_language=row["payment_link_template_language"],
+        payment_link_template_category=row["payment_link_template_category"],
+        payment_link_template_status=row["payment_link_template_status"],
+        payment_link_template_created_at=row["payment_link_template_created_at"],
+        payment_link_template_approved_at=row["payment_link_template_approved_at"],
+        last_template_error=row["last_template_error"],
+        messages_attempted_count=row["messages_attempted_count"] or 0,
+        messages_success_count=row["messages_success_count"] or 0,
+        messages_failed_count=row["messages_failed_count"] or 0,
+        last_message_attempted_at=row["last_message_attempted_at"],
+        last_message_success_at=row["last_message_success_at"],
+        last_message_failed_at=row["last_message_failed_at"],
+        last_error_code=row["last_error_code"],
+        last_error_message=row["last_error_message"],
+        last_onboarding_event=row["last_onboarding_event"],
+        connected_at=row["connected_at"],
+        created_at=row["created_at"],
+        updated_at=row["updated_at"],
+    )
+
+
+def decode_whatsapp_connection_list(
+    rows: Optional[List[asyncpg.Record]],
+) -> List[WhatsAppConnectionResponse]:
+    """Decode multiple merchant WhatsApp credential rows."""
+
+    if not rows:
+        return []
+    return [decode_whatsapp_connection(row) for row in rows]
+
+
+def decode_single_whatsapp_connection(
+    rows: Optional[List[asyncpg.Record]],
+) -> Optional[WhatsAppConnectionResponse]:
+    """Decode a single merchant WhatsApp credential row."""
+
+    if not rows:
+        return None
+    return decode_whatsapp_connection(rows[0])

--- a/app/database/migrations/034_create_merchant_whatsapp_credentials.sql
+++ b/app/database/migrations/034_create_merchant_whatsapp_credentials.sql
@@ -1,0 +1,77 @@
+-- Migration 034: Create merchant WhatsApp onboarding storage
+-- Stores Meta Embedded Signup assets per merchant while keeping tokens in credentials.
+
+BEGIN;
+
+ALTER TABLE credentials
+ADD COLUMN IF NOT EXISTS merchant_id VARCHAR(255);
+
+CREATE INDEX IF NOT EXISTS idx_credentials_merchant_id
+    ON credentials(merchant_id);
+
+CREATE INDEX IF NOT EXISTS idx_credentials_reseller_merchant_name
+    ON credentials(reseller_id, merchant_id, name);
+
+CREATE TABLE IF NOT EXISTS merchant_whatsapp_credentials (
+    id VARCHAR(255) PRIMARY KEY,
+    reseller_id VARCHAR(255),
+    merchant_id VARCHAR(255) NOT NULL REFERENCES merchants(merchant_id) ON DELETE CASCADE,
+    business_token_credential_id UUID NOT NULL REFERENCES credentials(id),
+    meta_business_id VARCHAR(255),
+    waba_id VARCHAR(255) NOT NULL,
+    phone_number_id VARCHAR(255) NOT NULL,
+    display_phone_number VARCHAR(64),
+    verified_name VARCHAR(255),
+    token_type VARCHAR(64),
+    token_expires_at TIMESTAMP WITH TIME ZONE,
+    scope TEXT,
+    app_id VARCHAR(255),
+    config_id VARCHAR(255),
+    graph_api_version VARCHAR(32) NOT NULL,
+    status VARCHAR(50) CHECK (
+        status IN ('CONNECTED', 'ERROR', 'DISCONNECTED')
+    ) NOT NULL,
+    webhook_subscribed BOOLEAN DEFAULT false NOT NULL,
+    phone_registered BOOLEAN DEFAULT false NOT NULL,
+    last_error_code VARCHAR(255),
+    last_error_message TEXT,
+    last_onboarding_event VARCHAR(64),
+    raw_signup_payload JSONB DEFAULT '{}'::jsonb NOT NULL,
+    payment_link_template_id VARCHAR(255),
+    payment_link_template_name VARCHAR(255),
+    payment_link_template_language VARCHAR(32),
+    payment_link_template_category VARCHAR(64),
+    payment_link_template_status VARCHAR(64),
+    payment_link_template_created_at TIMESTAMP WITH TIME ZONE,
+    payment_link_template_approved_at TIMESTAMP WITH TIME ZONE,
+    last_template_error TEXT,
+    messages_attempted_count BIGINT DEFAULT 0 NOT NULL,
+    messages_success_count BIGINT DEFAULT 0 NOT NULL,
+    messages_failed_count BIGINT DEFAULT 0 NOT NULL,
+    last_message_attempted_at TIMESTAMP WITH TIME ZONE,
+    last_message_success_at TIMESTAMP WITH TIME ZONE,
+    last_message_failed_at TIMESTAMP WITH TIME ZONE,
+    connected_at TIMESTAMP WITH TIME ZONE,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW() NOT NULL,
+    updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW() NOT NULL
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_merchant_whatsapp_credentials_merchant_id
+    ON merchant_whatsapp_credentials(merchant_id);
+
+CREATE INDEX IF NOT EXISTS idx_merchant_whatsapp_credentials_reseller_id
+    ON merchant_whatsapp_credentials(reseller_id);
+
+CREATE INDEX IF NOT EXISTS idx_merchant_whatsapp_credentials_waba_id
+    ON merchant_whatsapp_credentials(waba_id);
+
+CREATE INDEX IF NOT EXISTS idx_merchant_whatsapp_credentials_phone_number_id
+    ON merchant_whatsapp_credentials(phone_number_id);
+
+CREATE INDEX IF NOT EXISTS idx_merchant_whatsapp_credentials_token_credential_id
+    ON merchant_whatsapp_credentials(business_token_credential_id);
+
+CREATE INDEX IF NOT EXISTS idx_merchant_whatsapp_credentials_template_status
+    ON merchant_whatsapp_credentials(payment_link_template_status);
+
+COMMIT;

--- a/app/database/queries/breeze_buddy/credentials.py
+++ b/app/database/queries/breeze_buddy/credentials.py
@@ -11,6 +11,7 @@ CREDENTIALS_TABLE = "credentials"
 def insert_credential_query(
     id: str,
     reseller_id: Optional[str],
+    merchant_id: Optional[str],
     name: str,
     credential_type: str,
     value: str,
@@ -20,14 +21,15 @@ def insert_credential_query(
     """Generate query to insert a credential record."""
     text = f"""
         INSERT INTO "{CREDENTIALS_TABLE}"
-        ("id", "reseller_id", "name", "credential_type", "value",
+        ("id", "reseller_id", "merchant_id", "name", "credential_type", "value",
          "is_encrypted", "description", "is_active", "created_at", "updated_at")
-        VALUES ($1, $2, $3, $4, $5, $6, $7, TRUE, $8, $9)
+        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, TRUE, $9, $10)
         RETURNING *;
     """
     values = [
         id,
         reseller_id,
+        merchant_id,
         name,
         credential_type,
         value,
@@ -45,18 +47,91 @@ def get_credential_by_id_query(credential_id: str) -> Tuple[str, List[Any]]:
     return text, [credential_id]
 
 
+def get_merchant_credential_by_name_query(
+    reseller_id: Optional[str],
+    merchant_id: str,
+    name: str,
+) -> Tuple[str, List[Any]]:
+    """Generate query to get a named merchant-scoped credential."""
+
+    text = f"""
+        SELECT * FROM "{CREDENTIALS_TABLE}"
+        WHERE "reseller_id" IS NOT DISTINCT FROM $1
+          AND "merchant_id" = $2
+          AND "name" = $3
+          AND "is_active" = TRUE
+        ORDER BY "updated_at" DESC
+        LIMIT 1;
+    """
+    return text, [reseller_id, merchant_id, name]
+
+
+def upsert_merchant_credential_by_name_query(
+    id: str,
+    reseller_id: Optional[str],
+    merchant_id: str,
+    name: str,
+    credential_type: str,
+    value: str,
+    is_encrypted: bool,
+    description: Optional[str],
+) -> Tuple[str, List[Any]]:
+    """Generate query to upsert a named merchant-scoped credential."""
+
+    now = datetime.now()
+    text = f"""
+        WITH updated AS (
+            UPDATE "{CREDENTIALS_TABLE}"
+            SET "credential_type" = $4,
+                "value" = $5,
+                "is_encrypted" = $6,
+                "description" = $7,
+                "is_active" = TRUE,
+                "updated_at" = $8
+            WHERE "reseller_id" IS NOT DISTINCT FROM $1
+              AND "merchant_id" = $2
+              AND "name" = $3
+            RETURNING *
+        ),
+        inserted AS (
+            INSERT INTO "{CREDENTIALS_TABLE}"
+            ("id", "reseller_id", "merchant_id", "name", "credential_type",
+             "value", "is_encrypted", "description", "is_active",
+             "created_at", "updated_at")
+            SELECT $9, $1, $2, $3, $4, $5, $6, $7, TRUE, $8, $8
+            WHERE NOT EXISTS (SELECT 1 FROM updated)
+            RETURNING *
+        )
+        SELECT * FROM updated
+        UNION ALL
+        SELECT * FROM inserted;
+    """
+    return text, [
+        reseller_id,
+        merchant_id,
+        name,
+        credential_type,
+        value,
+        is_encrypted,
+        description,
+        now,
+        id,
+    ]
+
+
 def get_credentials_by_merchant_query(
     reseller_id: Optional[str],
 ) -> Tuple[str, List[Any]]:
     """
     Generate query to get credentials for a merchant.
     If reseller is provided, returns reseller-specific + global credentials.
-    If reseller is None, returns only global credentials.
+    Merchant-scoped system credentials are intentionally excluded.
     """
     if reseller_id:
         text = f"""
             SELECT * FROM "{CREDENTIALS_TABLE}"
             WHERE ("reseller_id" = $1 OR "reseller_id" IS NULL)
+            AND "merchant_id" IS NULL
             AND "is_active" = TRUE
             ORDER BY "reseller_id" NULLS FIRST, "name" ASC;
         """
@@ -64,7 +139,9 @@ def get_credentials_by_merchant_query(
     else:
         text = f"""
             SELECT * FROM "{CREDENTIALS_TABLE}"
-            WHERE "reseller_id" IS NULL AND "is_active" = TRUE
+            WHERE "reseller_id" IS NULL
+            AND "merchant_id" IS NULL
+            AND "is_active" = TRUE
             ORDER BY "name" ASC;
         """
         return text, []
@@ -72,7 +149,12 @@ def get_credentials_by_merchant_query(
 
 def get_all_credentials_query() -> Tuple[str, List[Any]]:
     """Generate query to get all credentials."""
-    text = f'SELECT * FROM "{CREDENTIALS_TABLE}" where "is_active" = TRUE ORDER BY "reseller_id" NULLS FIRST, "name" ASC;'
+    text = f"""
+        SELECT * FROM "{CREDENTIALS_TABLE}"
+        WHERE "is_active" = TRUE
+        AND "merchant_id" IS NULL
+        ORDER BY "reseller_id" NULLS FIRST, "name" ASC;
+    """
     return text, []
 
 

--- a/app/database/queries/breeze_buddy/whatsapp.py
+++ b/app/database/queries/breeze_buddy/whatsapp.py
@@ -1,0 +1,249 @@
+"""Database query functions for merchant WhatsApp credentials."""
+
+from datetime import datetime, timezone
+from typing import Any, List, Optional, Tuple
+
+MERCHANT_WHATSAPP_CREDENTIALS_TABLE = "merchant_whatsapp_credentials"
+
+
+def upsert_whatsapp_connection_query(
+    id: str,
+    reseller_id: Optional[str],
+    merchant_id: str,
+    business_token_credential_id: str,
+    meta_business_id: Optional[str],
+    waba_id: str,
+    phone_number_id: str,
+    display_phone_number: Optional[str],
+    verified_name: Optional[str],
+    token_type: Optional[str],
+    token_expires_at: Optional[datetime],
+    scope: Optional[str],
+    app_id: Optional[str],
+    config_id: Optional[str],
+    graph_api_version: str,
+    status: str,
+    webhook_subscribed: bool,
+    phone_registered: bool,
+    last_error_code: Optional[str],
+    last_error_message: Optional[str],
+    last_onboarding_event: Optional[str],
+    raw_signup_payload_json: str,
+    payment_link_template_id: Optional[str],
+    payment_link_template_name: Optional[str],
+    payment_link_template_language: Optional[str],
+    payment_link_template_category: Optional[str],
+    payment_link_template_status: Optional[str],
+    payment_link_template_created_at: Optional[datetime],
+    last_template_error: Optional[str],
+) -> Tuple[str, List[Any]]:
+    """Generate upsert query for a merchant WhatsApp connection."""
+
+    now = datetime.now(timezone.utc)
+    text = f"""
+        INSERT INTO {MERCHANT_WHATSAPP_CREDENTIALS_TABLE} (
+            id, reseller_id, merchant_id, business_token_credential_id,
+            meta_business_id, waba_id, phone_number_id, display_phone_number,
+            verified_name, token_type, token_expires_at, scope, app_id,
+            config_id, graph_api_version, status, webhook_subscribed,
+            phone_registered, last_error_code, last_error_message,
+            last_onboarding_event, raw_signup_payload, payment_link_template_id,
+            payment_link_template_name, payment_link_template_language,
+            payment_link_template_category, payment_link_template_status,
+            payment_link_template_created_at, last_template_error,
+            connected_at, created_at, updated_at
+        ) VALUES (
+            $1, $2, $3, $4,
+            $5, $6, $7, $8,
+            $9, $10, $11, $12, $13,
+            $14, $15, $16, $17,
+            $18, $19, $20,
+            $21, $22::jsonb, $23,
+            $24, $25,
+            $26, $27,
+            $28, $29,
+            $30, $31, $32
+        )
+        ON CONFLICT (merchant_id) DO UPDATE SET
+            reseller_id = EXCLUDED.reseller_id,
+            business_token_credential_id = EXCLUDED.business_token_credential_id,
+            meta_business_id = EXCLUDED.meta_business_id,
+            waba_id = EXCLUDED.waba_id,
+            phone_number_id = EXCLUDED.phone_number_id,
+            display_phone_number = EXCLUDED.display_phone_number,
+            verified_name = EXCLUDED.verified_name,
+            token_type = EXCLUDED.token_type,
+            token_expires_at = EXCLUDED.token_expires_at,
+            scope = EXCLUDED.scope,
+            app_id = EXCLUDED.app_id,
+            config_id = EXCLUDED.config_id,
+            graph_api_version = EXCLUDED.graph_api_version,
+            status = EXCLUDED.status,
+            webhook_subscribed = EXCLUDED.webhook_subscribed,
+            phone_registered = EXCLUDED.phone_registered,
+            last_error_code = EXCLUDED.last_error_code,
+            last_error_message = EXCLUDED.last_error_message,
+            last_onboarding_event = EXCLUDED.last_onboarding_event,
+            raw_signup_payload = EXCLUDED.raw_signup_payload,
+            payment_link_template_id = EXCLUDED.payment_link_template_id,
+            payment_link_template_name = EXCLUDED.payment_link_template_name,
+            payment_link_template_language = EXCLUDED.payment_link_template_language,
+            payment_link_template_category = EXCLUDED.payment_link_template_category,
+            payment_link_template_status = EXCLUDED.payment_link_template_status,
+            payment_link_template_created_at = EXCLUDED.payment_link_template_created_at,
+            last_template_error = EXCLUDED.last_template_error,
+            connected_at = CASE
+                WHEN EXCLUDED.status = 'CONNECTED' THEN EXCLUDED.connected_at
+                ELSE {MERCHANT_WHATSAPP_CREDENTIALS_TABLE}.connected_at
+            END,
+            updated_at = EXCLUDED.updated_at
+        RETURNING *;
+    """
+    values = [
+        id,
+        reseller_id,
+        merchant_id,
+        business_token_credential_id,
+        meta_business_id,
+        waba_id,
+        phone_number_id,
+        display_phone_number,
+        verified_name,
+        token_type,
+        token_expires_at,
+        scope,
+        app_id,
+        config_id,
+        graph_api_version,
+        status,
+        webhook_subscribed,
+        phone_registered,
+        last_error_code,
+        last_error_message,
+        last_onboarding_event,
+        raw_signup_payload_json,
+        payment_link_template_id,
+        payment_link_template_name,
+        payment_link_template_language,
+        payment_link_template_category,
+        payment_link_template_status,
+        payment_link_template_created_at,
+        last_template_error,
+        now if status == "CONNECTED" else None,
+        now,
+        now,
+    ]
+    return text, values
+
+
+def get_whatsapp_connection_by_merchant_id_query(
+    merchant_id: str,
+) -> Tuple[str, List[Any]]:
+    """Generate query to fetch WhatsApp connection by merchant ID."""
+
+    text = f"""
+        SELECT *
+        FROM {MERCHANT_WHATSAPP_CREDENTIALS_TABLE}
+        WHERE merchant_id = $1;
+    """
+    return text, [merchant_id]
+
+
+def list_whatsapp_connections_by_reseller_id_query(
+    reseller_id: str,
+) -> Tuple[str, List[Any]]:
+    """Generate query to list WhatsApp connections by reseller ID."""
+
+    text = f"""
+        SELECT *
+        FROM {MERCHANT_WHATSAPP_CREDENTIALS_TABLE}
+        WHERE reseller_id = $1
+        ORDER BY updated_at DESC;
+    """
+    return text, [reseller_id]
+
+
+def update_whatsapp_connection_setup_status_query(
+    merchant_id: str,
+    status: str,
+    webhook_subscribed: Optional[bool] = None,
+    phone_registered: Optional[bool] = None,
+    last_error_code: Optional[str] = None,
+    last_error_message: Optional[str] = None,
+) -> Tuple[str, List[Any]]:
+    """Generate query to update setup flags after onboarding actions."""
+
+    updates = ["status = $2", "updated_at = $3"]
+    values: List[Any] = [merchant_id, status, datetime.now(timezone.utc)]
+    param_idx = 4
+
+    if webhook_subscribed is not None:
+        updates.append(f"webhook_subscribed = ${param_idx}")
+        values.append(webhook_subscribed)
+        param_idx += 1
+
+    if phone_registered is not None:
+        updates.append(f"phone_registered = ${param_idx}")
+        values.append(phone_registered)
+        param_idx += 1
+
+    updates.append(f"last_error_code = ${param_idx}")
+    values.append(last_error_code)
+    param_idx += 1
+
+    updates.append(f"last_error_message = ${param_idx}")
+    values.append(last_error_message)
+
+    text = f"""
+        UPDATE {MERCHANT_WHATSAPP_CREDENTIALS_TABLE}
+        SET {", ".join(updates)}
+        WHERE merchant_id = $1
+        RETURNING *;
+    """
+    return text, values
+
+
+def increment_whatsapp_message_counter_query(
+    merchant_id: str,
+    counter: str,
+    last_error_code: Optional[str] = None,
+    last_error_message: Optional[str] = None,
+) -> Tuple[str, List[Any]]:
+    """Generate query to increment a simple WhatsApp message counter."""
+
+    counter_columns = {
+        "attempted": ("messages_attempted_count", "last_message_attempted_at"),
+        "success": ("messages_success_count", "last_message_success_at"),
+        "failed": ("messages_failed_count", "last_message_failed_at"),
+    }
+    if counter not in counter_columns:
+        raise ValueError(f"Unsupported WhatsApp message counter: {counter}")
+
+    count_column, timestamp_column = counter_columns[counter]
+    now = datetime.now(timezone.utc)
+    text = f"""
+        UPDATE {MERCHANT_WHATSAPP_CREDENTIALS_TABLE}
+        SET {count_column} = {count_column} + 1,
+            {timestamp_column} = $2,
+            last_error_code = $3,
+            last_error_message = $4,
+            updated_at = $2
+        WHERE merchant_id = $1
+        RETURNING *;
+    """
+    return text, [merchant_id, now, last_error_code, last_error_message]
+
+
+def disconnect_whatsapp_connection_query(
+    merchant_id: str,
+) -> Tuple[str, List[Any]]:
+    """Generate query to mark a merchant WhatsApp connection disconnected."""
+
+    text = f"""
+        UPDATE {MERCHANT_WHATSAPP_CREDENTIALS_TABLE}
+        SET status = 'DISCONNECTED',
+            updated_at = $2
+        WHERE merchant_id = $1
+        RETURNING *;
+    """
+    return text, [merchant_id, datetime.now(timezone.utc)]

--- a/app/schemas/breeze_buddy/credentials.py
+++ b/app/schemas/breeze_buddy/credentials.py
@@ -51,6 +51,7 @@ class Credential(BaseModel):
 
     id: str
     reseller_id: Optional[str] = None
+    merchant_id: Optional[str] = None
     name: str
     credential_type: CredentialType
     value: Optional[Dict[str, Any]] = Field(

--- a/app/schemas/breeze_buddy/whatsapp.py
+++ b/app/schemas/breeze_buddy/whatsapp.py
@@ -1,0 +1,168 @@
+"""Schemas for WhatsApp Embedded Signup onboarding."""
+
+from datetime import datetime
+from enum import Enum
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class WhatsAppConnectionStatus(str, Enum):
+    """Merchant WhatsApp connection state."""
+
+    NOT_CONNECTED = "NOT_CONNECTED"
+    CONNECTED = "CONNECTED"
+    ERROR = "ERROR"
+    DISCONNECTED = "DISCONNECTED"
+
+
+class MetaEmbeddedSignupSessionInfo(BaseModel):
+    """Asset IDs returned by Meta's WA_EMBEDDED_SIGNUP message event."""
+
+    model_config = ConfigDict(extra="allow")
+
+    phone_number_id: Optional[str] = None
+    waba_id: Optional[str] = None
+    business_id: Optional[str] = None
+    waba_ids: Optional[List[str]] = None
+    ad_account_ids: Optional[List[str]] = None
+    page_ids: Optional[List[str]] = None
+    dataset_ids: Optional[List[str]] = None
+    catalog_ids: Optional[List[str]] = None
+    instagram_account_ids: Optional[List[str]] = None
+
+
+class MetaEmbeddedSignupEvent(BaseModel):
+    """Raw WA_EMBEDDED_SIGNUP event posted by Loom."""
+
+    model_config = ConfigDict(extra="allow")
+
+    data: MetaEmbeddedSignupSessionInfo = Field(
+        default_factory=MetaEmbeddedSignupSessionInfo
+    )
+    type: Optional[str] = None
+    event: Optional[str] = None
+
+
+class MetaEmbeddedSignupCompleteRequest(BaseModel):
+    """Complete merchant WhatsApp onboarding after Meta returns a code."""
+
+    merchant_id: str = Field(..., min_length=1)
+    code: str = Field(..., min_length=1)
+    signup_event: MetaEmbeddedSignupEvent
+    subscribe_webhooks: bool = True
+    register_phone_number: bool = False
+    phone_number_pin: Optional[str] = Field(
+        default=None,
+        pattern=r"^\d{6}$",
+        description="Required when register_phone_number=true.",
+    )
+
+
+class WhatsAppRegisterPhoneRequest(BaseModel):
+    """Register an already connected merchant phone number with Cloud API."""
+
+    pin: str = Field(..., pattern=r"^\d{6}$")
+
+
+class WhatsAppSendPaymentLinkRequest(BaseModel):
+    """Send the approved payment-link WhatsApp template to a customer."""
+
+    recipient_phone: str = Field(..., min_length=6, max_length=32)
+    customer_name: str = Field(..., min_length=1, max_length=128)
+    order_reference: str = Field(..., min_length=1, max_length=128)
+    payment_link: str = Field(..., min_length=1, max_length=2048)
+
+
+class WhatsAppConnectionResponse(BaseModel):
+    """Masked WhatsApp connection metadata returned to Loom."""
+
+    merchant_id: str
+    reseller_id: Optional[str] = None
+    business_token_credential_id: Optional[str] = None
+    status: WhatsAppConnectionStatus
+    connected: bool = False
+    waba_id: Optional[str] = None
+    phone_number_id: Optional[str] = None
+    meta_business_id: Optional[str] = None
+    display_phone_number: Optional[str] = None
+    verified_name: Optional[str] = None
+    app_id: Optional[str] = None
+    config_id: Optional[str] = None
+    graph_api_version: Optional[str] = None
+    webhook_subscribed: bool = False
+    phone_registered: bool = False
+    token_type: Optional[str] = None
+    token_expires_at: Optional[datetime] = None
+    scope: Optional[str] = None
+    payment_link_template_id: Optional[str] = None
+    payment_link_template_name: Optional[str] = None
+    payment_link_template_language: Optional[str] = None
+    payment_link_template_category: Optional[str] = None
+    payment_link_template_status: Optional[str] = None
+    payment_link_template_created_at: Optional[datetime] = None
+    payment_link_template_approved_at: Optional[datetime] = None
+    last_template_error: Optional[str] = None
+    messages_attempted_count: int = 0
+    messages_success_count: int = 0
+    messages_failed_count: int = 0
+    last_message_attempted_at: Optional[datetime] = None
+    last_message_success_at: Optional[datetime] = None
+    last_message_failed_at: Optional[datetime] = None
+    last_error_code: Optional[str] = None
+    last_error_message: Optional[str] = None
+    last_onboarding_event: Optional[str] = None
+    connected_at: Optional[datetime] = None
+    created_at: Optional[datetime] = None
+    updated_at: Optional[datetime] = None
+
+
+class WhatsAppEmbeddedSignupConfigResponse(BaseModel):
+    """Frontend configuration needed to launch Meta Embedded Signup."""
+
+    merchant_id: str
+    app_id: str
+    config_id: str
+    graph_api_version: str
+    status: WhatsAppConnectionStatus
+    connected: bool
+    connection: Optional[WhatsAppConnectionResponse] = None
+
+
+class WhatsAppTokenPayload(BaseModel):
+    """Internal decrypted WhatsApp token payload."""
+
+    access_token: str
+
+
+class MetaTokenExchangeResult(BaseModel):
+    """Meta OAuth token exchange response normalized for storage."""
+
+    access_token: str
+    token_type: Optional[str] = None
+    expires_in: Optional[int] = None
+    scope: Optional[str] = None
+    raw_metadata: Dict[str, Any] = Field(default_factory=dict)
+
+
+class MetaTemplateCreateResult(BaseModel):
+    """Meta message template creation response normalized for storage."""
+
+    id: Optional[str] = None
+    status: Optional[str] = None
+    category: Optional[str] = None
+    raw_metadata: Dict[str, Any] = Field(default_factory=dict)
+
+
+class MetaMessageSendResult(BaseModel):
+    """Meta WhatsApp message send response normalized for callers."""
+
+    message_id: Optional[str] = None
+    raw_metadata: Dict[str, Any] = Field(default_factory=dict)
+
+
+class WhatsAppSendPaymentLinkResponse(BaseModel):
+    """Response for a merchant WhatsApp payment-link send attempt."""
+
+    message_id: Optional[str] = None
+    connection: WhatsAppConnectionResponse

--- a/app/services/meta/__init__.py
+++ b/app/services/meta/__init__.py
@@ -1,0 +1,1 @@
+"""Meta service integrations."""

--- a/app/services/meta/whatsapp.py
+++ b/app/services/meta/whatsapp.py
@@ -1,0 +1,368 @@
+"""Meta Graph API client for WhatsApp Embedded Signup onboarding."""
+
+from typing import Any, Dict, Optional
+
+import httpx
+
+from app.core.config.static import (
+    META_APP_ID,
+    META_APP_SECRET,
+    META_GRAPH_API_VERSION,
+    META_GRAPH_BASE_URL,
+    META_REQUEST_TIMEOUT_SECONDS,
+    META_WHATSAPP_EMBEDDED_SIGNUP_CONFIG_ID,
+    WHATSAPP_PAYMENT_LINK_TEMPLATE_CATEGORY,
+    WHATSAPP_PAYMENT_LINK_TEMPLATE_LANGUAGE,
+    WHATSAPP_PAYMENT_LINK_TEMPLATE_NAME,
+)
+from app.core.transport.http_client import create_http_client
+from app.schemas.breeze_buddy.whatsapp import (
+    MetaMessageSendResult,
+    MetaTemplateCreateResult,
+    MetaTokenExchangeResult,
+)
+
+
+class MetaWhatsAppConfigurationError(RuntimeError):
+    """Raised when Meta WhatsApp env config is missing."""
+
+
+class MetaWhatsAppAPIError(RuntimeError):
+    """Raised when Meta Graph API returns an error."""
+
+    def __init__(
+        self,
+        message: str,
+        status_code: Optional[int] = None,
+        error_code: Optional[str] = None,
+        error_subcode: Optional[str] = None,
+    ) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+        self.error_code = error_code
+        self.error_subcode = error_subcode
+
+
+def normalize_graph_api_version(version: str) -> str:
+    """Return Graph API version with a leading 'v'."""
+
+    version = (version or "").strip()
+    if not version:
+        return "v25.0"
+    return version if version.startswith("v") else f"v{version}"
+
+
+class MetaWhatsAppClient:
+    """Small async Meta Graph client for onboarding calls."""
+
+    def __init__(
+        self,
+        app_id: str = META_APP_ID,
+        app_secret: str = META_APP_SECRET,
+        embedded_signup_config_id: str = META_WHATSAPP_EMBEDDED_SIGNUP_CONFIG_ID,
+        graph_api_version: str = META_GRAPH_API_VERSION,
+        graph_base_url: str = META_GRAPH_BASE_URL,
+        timeout_seconds: int = META_REQUEST_TIMEOUT_SECONDS,
+    ) -> None:
+        self.app_id = app_id
+        self.app_secret = app_secret
+        self._embedded_signup_config_id = embedded_signup_config_id
+        self.graph_api_version = normalize_graph_api_version(graph_api_version)
+        self.graph_base_url = graph_base_url.rstrip("/")
+        self.timeout_seconds = timeout_seconds
+
+    @property
+    def embedded_signup_config_id(self) -> str:
+        """Configured Facebook Login for Business configuration ID."""
+
+        return self._embedded_signup_config_id
+
+    def ensure_configured(self) -> None:
+        """Validate required env config before launching or completing signup."""
+
+        missing = []
+        if not self.app_id:
+            missing.append("META_APP_ID")
+        if not self.app_secret:
+            missing.append("META_APP_SECRET")
+        if not self.embedded_signup_config_id:
+            missing.append("META_WHATSAPP_EMBEDDED_SIGNUP_CONFIG_ID")
+        if missing:
+            raise MetaWhatsAppConfigurationError(
+                f"Missing Meta WhatsApp configuration: {', '.join(missing)}"
+            )
+
+    async def exchange_code_for_business_token(
+        self, code: str
+    ) -> MetaTokenExchangeResult:
+        """Exchange Meta's short-lived code for a business token."""
+
+        self.ensure_configured()
+        data = await self._request_json(
+            method="GET",
+            path="/oauth/access_token",
+            params={
+                "client_id": self.app_id,
+                "client_secret": self.app_secret,
+                "code": code,
+            },
+        )
+        access_token = data.get("access_token")
+        if not isinstance(access_token, str) or not access_token:
+            raise MetaWhatsAppAPIError("Meta token exchange did not return a token")
+
+        expires_in = data.get("expires_in")
+        return MetaTokenExchangeResult(
+            access_token=access_token,
+            token_type=data.get("token_type"),
+            expires_in=expires_in if isinstance(expires_in, int) else None,
+            scope=data.get("scope"),
+            raw_metadata={
+                key: value for key, value in data.items() if key != "access_token"
+            },
+        )
+
+    async def subscribe_app_to_waba(
+        self,
+        waba_id: str,
+        business_token: str,
+    ) -> bool:
+        """Subscribe this app to webhooks on the customer's WABA."""
+
+        self.ensure_configured()
+        data = await self._request_json(
+            method="POST",
+            path=f"/{waba_id}/subscribed_apps",
+            access_token=business_token,
+        )
+        return data.get("success") is True
+
+    async def register_phone_number(
+        self,
+        phone_number_id: str,
+        business_token: str,
+        pin: str,
+    ) -> bool:
+        """Register the customer's WhatsApp phone number for Cloud API."""
+
+        self.ensure_configured()
+        data = await self._request_json(
+            method="POST",
+            path=f"/{phone_number_id}/register",
+            access_token=business_token,
+            json_body={
+                "messaging_product": "whatsapp",
+                "pin": pin,
+            },
+        )
+        return data.get("success") is True
+
+    async def create_payment_link_utility_template(
+        self,
+        waba_id: str,
+        business_token: str,
+        template_name: str = WHATSAPP_PAYMENT_LINK_TEMPLATE_NAME,
+        language: str = WHATSAPP_PAYMENT_LINK_TEMPLATE_LANGUAGE,
+        category: str = WHATSAPP_PAYMENT_LINK_TEMPLATE_CATEGORY,
+    ) -> MetaTemplateCreateResult:
+        """Create the default customer-requested payment link Utility template."""
+
+        components = [
+            {
+                "type": "BODY",
+                "text": (
+                    "Hi {{1}}, as requested, here is the payment link for "
+                    "order {{2}}: {{3}}. This link is shared for the "
+                    "transaction you requested."
+                ),
+                "example": {
+                    "body_text": [
+                        [
+                            "Rahul",
+                            "ORD-12345",
+                            "https://example.com/pay/abc123",
+                        ]
+                    ]
+                },
+            }
+        ]
+        return await self.create_message_template(
+            waba_id=waba_id,
+            business_token=business_token,
+            name=template_name,
+            language=language,
+            category=category,
+            components=components,
+        )
+
+    async def create_message_template(
+        self,
+        waba_id: str,
+        business_token: str,
+        name: str,
+        language: str,
+        category: str,
+        components: list[dict[str, Any]],
+    ) -> MetaTemplateCreateResult:
+        """Create a message template in the customer's WABA."""
+
+        self.ensure_configured()
+        data = await self._request_json(
+            method="POST",
+            path=f"/{waba_id}/message_templates",
+            access_token=business_token,
+            json_body={
+                "name": name,
+                "language": language,
+                "category": category,
+                "components": components,
+            },
+        )
+        return MetaTemplateCreateResult(
+            id=str(data["id"]) if data.get("id") is not None else None,
+            status=str(data["status"]) if data.get("status") is not None else None,
+            category=(
+                str(data["category"]) if data.get("category") is not None else category
+            ),
+            raw_metadata=data,
+        )
+
+    async def send_payment_link_template_message(
+        self,
+        phone_number_id: str,
+        business_token: str,
+        recipient_phone: str,
+        customer_name: str,
+        order_reference: str,
+        payment_link: str,
+        template_name: str = WHATSAPP_PAYMENT_LINK_TEMPLATE_NAME,
+        language: str = WHATSAPP_PAYMENT_LINK_TEMPLATE_LANGUAGE,
+    ) -> MetaMessageSendResult:
+        """Send the approved payment-link template through Cloud API."""
+
+        data = await self.send_template_message(
+            phone_number_id=phone_number_id,
+            business_token=business_token,
+            recipient_phone=recipient_phone,
+            template_name=template_name,
+            language=language,
+            body_parameters=[
+                customer_name,
+                order_reference,
+                payment_link,
+            ],
+        )
+        return data
+
+    async def send_template_message(
+        self,
+        phone_number_id: str,
+        business_token: str,
+        recipient_phone: str,
+        template_name: str,
+        language: str,
+        body_parameters: list[str],
+    ) -> MetaMessageSendResult:
+        """Send a WhatsApp template message with text body parameters."""
+
+        self.ensure_configured()
+        data = await self._request_json(
+            method="POST",
+            path=f"/{phone_number_id}/messages",
+            access_token=business_token,
+            json_body={
+                "messaging_product": "whatsapp",
+                "recipient_type": "individual",
+                "to": recipient_phone,
+                "type": "template",
+                "template": {
+                    "name": template_name,
+                    "language": {"code": language},
+                    "components": [
+                        {
+                            "type": "body",
+                            "parameters": [
+                                {"type": "text", "text": parameter}
+                                for parameter in body_parameters
+                            ],
+                        }
+                    ],
+                },
+            },
+        )
+        message_id = None
+        messages = data.get("messages")
+        if isinstance(messages, list) and messages:
+            first_message = messages[0]
+            if isinstance(first_message, dict) and first_message.get("id") is not None:
+                message_id = str(first_message["id"])
+        return MetaMessageSendResult(message_id=message_id, raw_metadata=data)
+
+    async def _request_json(
+        self,
+        method: str,
+        path: str,
+        params: Optional[Dict[str, Any]] = None,
+        access_token: Optional[str] = None,
+        json_body: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        """Execute a Meta Graph request and normalize JSON errors."""
+
+        path = path if path.startswith("/") else f"/{path}"
+        if path == "/oauth/access_token":
+            url = f"{self.graph_base_url}/{self.graph_api_version}{path}"
+        else:
+            url = f"{self.graph_base_url}/{self.graph_api_version}{path}"
+
+        headers = {}
+        if access_token:
+            headers["Authorization"] = f"Bearer {access_token}"
+
+        async with create_http_client(timeout=self.timeout_seconds) as client:
+            try:
+                response = await client.request(
+                    method,
+                    url,
+                    params=params,
+                    headers=headers,
+                    json=json_body,
+                )
+            except httpx.HTTPError as e:
+                raise MetaWhatsAppAPIError(f"Meta Graph request failed: {e}") from e
+
+        try:
+            data = response.json()
+        except ValueError as e:
+            raise MetaWhatsAppAPIError(
+                "Meta Graph response was not valid JSON",
+                status_code=response.status_code,
+            ) from e
+
+        if response.status_code >= 400:
+            error = data.get("error") if isinstance(data, dict) else None
+            if isinstance(error, dict):
+                raise MetaWhatsAppAPIError(
+                    str(error.get("message") or "Meta Graph request failed"),
+                    status_code=response.status_code,
+                    error_code=(
+                        str(error.get("code"))
+                        if error.get("code") is not None
+                        else None
+                    ),
+                    error_subcode=(
+                        str(error.get("error_subcode"))
+                        if error.get("error_subcode") is not None
+                        else None
+                    ),
+                )
+            raise MetaWhatsAppAPIError(
+                "Meta Graph request failed",
+                status_code=response.status_code,
+            )
+
+        if not isinstance(data, dict):
+            raise MetaWhatsAppAPIError(
+                "Meta Graph response JSON was not an object",
+                status_code=response.status_code,
+            )
+        return data

--- a/tests/breeze_buddy/test_whatsapp_meta_client.py
+++ b/tests/breeze_buddy/test_whatsapp_meta_client.py
@@ -1,0 +1,223 @@
+from __future__ import annotations
+
+import asyncio
+
+import httpx
+import pytest
+
+from app.services.meta import whatsapp
+from app.services.meta.whatsapp import (
+    MetaWhatsAppAPIError,
+    MetaWhatsAppClient,
+    normalize_graph_api_version,
+)
+
+
+def _mocked_client(handler):
+    transport = httpx.MockTransport(handler)
+    return httpx.AsyncClient(transport=transport)
+
+
+def test_normalize_graph_api_version() -> None:
+    assert normalize_graph_api_version("25.0") == "v25.0"
+    assert normalize_graph_api_version("v21.0") == "v21.0"
+    assert normalize_graph_api_version("") == "v25.0"
+
+
+def test_exchange_code_for_business_token(monkeypatch) -> None:
+    seen = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["url"] = str(request.url)
+        return httpx.Response(
+            200,
+            json={
+                "access_token": "business-token",
+                "token_type": "bearer",
+                "expires_in": 3600,
+                "scope": "whatsapp_business_messaging",
+            },
+        )
+
+    monkeypatch.setattr(
+        whatsapp,
+        "create_http_client",
+        lambda **_: _mocked_client(handler),
+    )
+
+    client = MetaWhatsAppClient(
+        app_id="app-id",
+        app_secret="app-secret",
+        embedded_signup_config_id="config-id",
+        graph_api_version="v25.0",
+        graph_base_url="https://graph.facebook.com",
+    )
+
+    result = asyncio.run(client.exchange_code_for_business_token("code-123"))
+
+    assert result.access_token == "business-token"
+    assert result.token_type == "bearer"
+    assert result.expires_in == 3600
+    assert "client_id=app-id" in seen["url"]
+    assert "client_secret=app-secret" in seen["url"]
+    assert "code=code-123" in seen["url"]
+
+
+def test_subscribe_app_to_waba_uses_business_token(monkeypatch) -> None:
+    seen = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["url"] = str(request.url)
+        seen["authorization"] = request.headers.get("authorization")
+        return httpx.Response(200, json={"success": True})
+
+    monkeypatch.setattr(
+        whatsapp,
+        "create_http_client",
+        lambda **_: _mocked_client(handler),
+    )
+
+    client = MetaWhatsAppClient(
+        app_id="app-id",
+        app_secret="app-secret",
+        embedded_signup_config_id="config-id",
+        graph_api_version="v25.0",
+        graph_base_url="https://graph.facebook.com",
+    )
+
+    assert asyncio.run(client.subscribe_app_to_waba("waba-1", "business-token")) is True
+    assert seen["url"] == "https://graph.facebook.com/v25.0/waba-1/subscribed_apps"
+    assert seen["authorization"] == "Bearer business-token"
+
+
+def test_create_payment_link_utility_template(monkeypatch) -> None:
+    seen = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["url"] = str(request.url)
+        seen["authorization"] = request.headers.get("authorization")
+        seen["body"] = request.read().decode()
+        return httpx.Response(
+            200,
+            json={
+                "id": "template-1",
+                "status": "PENDING",
+                "category": "UTILITY",
+            },
+        )
+
+    monkeypatch.setattr(
+        whatsapp,
+        "create_http_client",
+        lambda **_: _mocked_client(handler),
+    )
+
+    client = MetaWhatsAppClient(
+        app_id="app-id",
+        app_secret="app-secret",
+        embedded_signup_config_id="config-id",
+        graph_api_version="v25.0",
+        graph_base_url="https://graph.facebook.com",
+    )
+
+    result = asyncio.run(
+        client.create_payment_link_utility_template("waba-1", "business-token")
+    )
+
+    assert result.id == "template-1"
+    assert result.status == "PENDING"
+    assert result.category == "UTILITY"
+    assert seen["url"] == "https://graph.facebook.com/v25.0/waba-1/message_templates"
+    assert seen["authorization"] == "Bearer business-token"
+    assert '"category":"UTILITY"' in seen["body"]
+    assert '"name":"buddy_payment_link_requested_v1"' in seen["body"]
+    assert "as requested" in seen["body"]
+    assert "transaction you requested" in seen["body"]
+
+
+def test_send_payment_link_template_message(monkeypatch) -> None:
+    seen = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["url"] = str(request.url)
+        seen["authorization"] = request.headers.get("authorization")
+        seen["body"] = request.read().decode()
+        return httpx.Response(
+            200,
+            json={
+                "messaging_product": "whatsapp",
+                "contacts": [{"input": "919876543210", "wa_id": "919876543210"}],
+                "messages": [{"id": "wamid.message-1"}],
+            },
+        )
+
+    monkeypatch.setattr(
+        whatsapp,
+        "create_http_client",
+        lambda **_: _mocked_client(handler),
+    )
+
+    client = MetaWhatsAppClient(
+        app_id="app-id",
+        app_secret="app-secret",
+        embedded_signup_config_id="config-id",
+        graph_api_version="v25.0",
+        graph_base_url="https://graph.facebook.com",
+    )
+
+    result = asyncio.run(
+        client.send_payment_link_template_message(
+            phone_number_id="phone-1",
+            business_token="business-token",
+            recipient_phone="919876543210",
+            customer_name="Rahul",
+            order_reference="ORD-12345",
+            payment_link="https://example.com/pay/abc123",
+        )
+    )
+
+    assert result.message_id == "wamid.message-1"
+    assert seen["url"] == "https://graph.facebook.com/v25.0/phone-1/messages"
+    assert seen["authorization"] == "Bearer business-token"
+    assert '"messaging_product":"whatsapp"' in seen["body"]
+    assert '"to":"919876543210"' in seen["body"]
+    assert '"name":"buddy_payment_link_requested_v1"' in seen["body"]
+    assert '"code":"en_US"' in seen["body"]
+    assert '"text":"Rahul"' in seen["body"]
+    assert '"text":"ORD-12345"' in seen["body"]
+    assert '"text":"https://example.com/pay/abc123"' in seen["body"]
+
+
+def test_graph_error_raises_normalized_error(monkeypatch) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            400,
+            json={
+                "error": {
+                    "message": "Invalid OAuth access token",
+                    "code": 190,
+                    "error_subcode": 460,
+                }
+            },
+        )
+
+    monkeypatch.setattr(
+        whatsapp,
+        "create_http_client",
+        lambda **_: _mocked_client(handler),
+    )
+
+    client = MetaWhatsAppClient(
+        app_id="app-id",
+        app_secret="app-secret",
+        embedded_signup_config_id="config-id",
+        graph_api_version="v25.0",
+        graph_base_url="https://graph.facebook.com",
+    )
+
+    with pytest.raises(MetaWhatsAppAPIError) as exc:
+        asyncio.run(client.exchange_code_for_business_token("expired-code"))
+
+    assert exc.value.status_code == 400
+    assert exc.value.error_code == "190"
+    assert exc.value.error_subcode == "460"

--- a/tests/breeze_buddy/test_whatsapp_schemas.py
+++ b/tests/breeze_buddy/test_whatsapp_schemas.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from app.schemas.breeze_buddy.whatsapp import (
+    MetaEmbeddedSignupCompleteRequest,
+    WhatsAppRegisterPhoneRequest,
+)
+
+
+def test_complete_request_accepts_signup_payload() -> None:
+    req = MetaEmbeddedSignupCompleteRequest(
+        merchant_id="shop.example",
+        code="exchange-code",
+        signup_event={
+            "type": "WA_EMBEDDED_SIGNUP",
+            "event": "FINISH",
+            "data": {
+                "phone_number_id": "106540352242922",
+                "waba_id": "524126980791429",
+                "business_id": "2729063490586005",
+            },
+        },
+    )
+
+    assert req.signup_event.data.phone_number_id == "106540352242922"
+    assert req.signup_event.data.waba_id == "524126980791429"
+
+
+def test_phone_registration_pin_must_be_six_digits() -> None:
+    WhatsAppRegisterPhoneRequest(pin="123456")
+
+    with pytest.raises(ValidationError):
+        WhatsAppRegisterPhoneRequest(pin="12345")
+
+    with pytest.raises(ValidationError):
+        WhatsAppRegisterPhoneRequest(pin="abcdef")


### PR DESCRIPTION
  - Add WhatsApp Embedded Signup config, status, and completion APIs
  - Store merchant WhatsApp credentials in the existing credentials flow
  - Add Meta WhatsApp client for token exchange, phone number lookup, and template creation
  - Create utility payment link template after merchant onboarding
  - Track merchant-level WhatsApp message send count
  - Add required Meta WhatsApp configuration envs
  - Exclude merchant-scoped WhatsApp credentials from generic credential listing