### PR TITLE
BZ-4269 : Batch config update support for agents

### DIFF
--- a/app/ai/voice/agents/breeze_buddy/template/field_reference.json
+++ b/app/ai/voice/agents/breeze_buddy/template/field_reference.json
@@ -17,7 +17,8 @@
     "secrets":                           { "description": "Flat dict of credential key-value pairs injected as template vars, overriding reseller-level credentials for the same keys. Values substitute into {secret_key} placeholders in HTTP URLs, headers, and bodies.", "example": { "api_token": "Bearer sk-prod-abc123", "webhook_secret": "wh_live_xyz789" } },
     "outbound_number_id":                { "description": "UUID of the outbound phone number record to use for calls from this template. Must belong to the reseller. Null to use the reseller-default number.", "example": "eb0df4e9-a438-4ce4-a828-addf9db5ce3a" },
     "is_active":                         { "description": "When false, the template is soft-disabled: dispatch will not enqueue new leads for it. Set to false (not delete) when retiring a template.", "example": true },
-    "supported_channels":                { "description": "Channels this template may be served on. Default ['voice']. Add 'chat' to enable the Buddy Assist web-chat mode. Must have at least one entry.", "example": ["voice"] }
+    "supported_channels":                { "description": "Channels this template may be served on. Default ['voice']. Add 'chat' to enable the Buddy Assist web-chat mode. Must have at least one entry.", "example": ["voice"] },
+    "workflow":                          { "description": "Use-case workflow this template belongs to, used to batch-scope config updates by workflow. Set explicitly at creation (defaults to 'non-shopify' when omitted); pre-existing rows were classified once by name via the migration backfill. One of: order-confirmation, abandonment-recovery, assist, test, non-shopify.", "example": "order-confirmation" }
   },
 
   "ConfigurationModel": {

--- a/app/ai/voice/agents/breeze_buddy/template/types.py
+++ b/app/ai/voice/agents/breeze_buddy/template/types.py
@@ -22,6 +22,21 @@ from app.core.deprecation import log_deprecated_fields
 from app.core.logger import logger
 
 
+class WorkflowType(str, Enum):
+    """Use-case workflow a template belongs to.
+
+    Values mirror Nautilus's WorkflowType so Shopify-provisioned templates can
+    be classified directly. ``non-shopify`` is the catch-all for every
+    non-Shopify reseller.
+    """
+
+    ORDER_CONFIRMATION = "order-confirmation"
+    ABANDONMENT_RECOVERY = "abandonment-recovery"
+    ASSIST = "assist"
+    TEST = "test"
+    NON_SHOPIFY = "non-shopify"
+
+
 class ActionType(str, Enum):
     TTS_SAY = "tts_say"
     END_CONVERSATION = "end_conversation"
@@ -2390,6 +2405,7 @@ class TemplateModel(BaseModel):
     merchant_id: Optional[str] = None
     created_at: Optional[Any] = None
     updated_at: Optional[Any] = None
+    workflow: WorkflowType = WorkflowType.NON_SHOPIFY
 
     # Editable fields (these match ReplaceTemplateRequest field names 1:1).
     name: str
@@ -2451,6 +2467,13 @@ class CreateTemplateRequest(BaseModel):
     supported_channels: List[Literal["voice", "chat"]] = Field(
         default_factory=_default_supported_channels,
         min_length=1,
+    )
+    workflow: Optional[WorkflowType] = Field(
+        default=None,
+        description=(
+            "Use-case workflow this template belongs to. Trusted as-is when "
+            "provided; defaults to non-shopify when omitted."
+        ),
     )
 
 

--- a/app/api/routers/breeze_buddy/templates/__init__.py
+++ b/app/api/routers/breeze_buddy/templates/__init__.py
@@ -13,9 +13,9 @@ Endpoints:
 For backward compatibility, old endpoints are available in deprecated/template.py
 """
 
-from typing import Optional
+from typing import Any, Dict, Optional
 
-from fastapi import APIRouter, Depends, Query, status
+from fastapi import APIRouter, Body, Depends, Header, Query, status
 
 from app.ai.voice.agents.breeze_buddy.template.types import (
     CreateTemplateRequest,
@@ -26,11 +26,13 @@ from app.api.security.breeze_buddy.rbac_token import get_current_user_with_rbac
 from app.core.security.authorization import require_admin
 from app.schemas import UserInfo
 from app.schemas.breeze_buddy.template import (
+    BatchConfigResponse,
     DeleteTemplateResponse,
     TemplateListResponse,
 )
 
 from .handlers import (
+    batch_patch_configurations_handler,
     create_template_handler,
     delete_template_handler,
     get_template_by_id_handler,
@@ -152,6 +154,70 @@ async def list_templates(
         page=page,
         limit=limit,
         search=search,
+    )
+
+
+@router.patch(
+    "/templates/batch-configurations",
+    response_model=BatchConfigResponse,
+    include_in_schema=False,
+)
+async def batch_patch_configurations(
+    patches: Dict[str, Any] = Body(
+        ...,
+        description=(
+            "Flat map of dotted configuration path -> new value, e.g. "
+            '{"tts_configuration.provider": "cartesia"}'
+        ),
+    ),
+    dry_run: bool = Query(True, description="Preview only; write nothing (default)"),
+    create: bool = Query(
+        False,
+        description="Create keys that don't exist (default: update existing only)",
+    ),
+    all_templates: bool = Query(
+        False,
+        alias="all",
+        description="Target every accessible template when no scope is provided",
+    ),
+    x_reseller_id: Optional[str] = Header(
+        None,
+        alias="X-Reseller-Id",
+        description="Reseller id(s); comma-separated for multiple",
+    ),
+    x_merchant_id: Optional[str] = Header(
+        None,
+        alias="X-Merchant-Id",
+        description="Merchant id(s); comma-separated for multiple",
+    ),
+    x_template_name: Optional[str] = Header(None, alias="X-Template-Name"),
+    x_workflow: Optional[str] = Header(
+        None,
+        alias="X-Workflow",
+        description="Workflow(s); comma-separated for multiple (e.g. order-confirmation,abandonment-recovery)",
+    ),
+    current_user: UserInfo = Depends(get_current_user_with_rbac),
+):
+    """
+    Batch-update template ``configurations`` across a scope (admin only).
+
+    Surgically patches only the dotted paths provided in the body; ``flow`` and
+    ``secrets`` are never touched. Scope is the AND of the X-* headers; at least
+    one is required unless ``?all=true``. RBAC always constrains the scope to the
+    caller's accessible resellers/merchants. Defaults to a dry run.
+    """
+    require_admin(current_user)
+
+    return await batch_patch_configurations_handler(
+        patches=patches,
+        dry_run=dry_run,
+        create=create,
+        all_templates=all_templates,
+        x_reseller_id=x_reseller_id,
+        x_merchant_id=x_merchant_id,
+        x_template_name=x_template_name,
+        x_workflow=x_workflow,
+        current_user=current_user,
     )
 
 

--- a/app/api/routers/breeze_buddy/templates/handlers.py
+++ b/app/api/routers/breeze_buddy/templates/handlers.py
@@ -14,6 +14,7 @@ from app.ai.voice.agents.breeze_buddy.template.types import (
     CreateTemplateRequest,
     FlowMode,
     ReplaceTemplateRequest,
+    WorkflowType,
 )
 from app.ai.voice.agents.breeze_buddy.utils.secrets import (
     mask_template_secrets,
@@ -23,6 +24,7 @@ from app.ai.voice.agents.breeze_buddy.utils.secrets import (
 from app.core.logger import logger
 from app.database.accessor import get_outbound_number_by_id, get_template_by_merchant
 from app.database.accessor.breeze_buddy.template import (
+    batch_update_template_configurations,
     check_template_usage,
     create_template,
     delete_template_if_not_referenced,
@@ -32,6 +34,7 @@ from app.database.accessor.breeze_buddy.template import (
 )
 from app.schemas import UserInfo
 from app.schemas.breeze_buddy.template import (
+    BatchConfigResponse,
     DeleteTemplateResponse,
     TemplateListResponse,
 )
@@ -140,6 +143,7 @@ async def create_template_handler(
             outbound_number_id=template_data.outbound_number_id,
             is_active=template_data.is_active,
             supported_channels=list(template_data.supported_channels),
+            workflow=template_data.workflow,
             now=now,
         )
 
@@ -665,3 +669,141 @@ async def delete_template_handler(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=f"Error deleting template: {str(e)}",
         )
+
+
+def _split_csv(value: Optional[str]) -> List[str]:
+    """Split a comma-separated header value into a clean list.
+
+    Trims each item and drops empties, so "a, b," -> ["a", "b"].
+    """
+    if not value:
+        return []
+    return [item.strip() for item in value.split(",") if item.strip()]
+
+
+def _resolve_workflow_scope(x_workflow: Optional[str]) -> Optional[List[str]]:
+    """Translate the X-Workflow header into concrete workflow values.
+
+    Accepts a single value or a comma-separated list; each must be a valid
+    WorkflowType. Any invalid value raises 422.
+    """
+    workflows = _split_csv(x_workflow)
+    if not workflows:
+        return None
+    resolved: List[str] = []
+    for workflow in workflows:
+        try:
+            resolved.append(WorkflowType(workflow).value)
+        except ValueError:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail=f"Invalid workflow: {workflow}",
+            )
+    return resolved
+
+
+async def batch_patch_configurations_handler(
+    patches: Dict[str, Any],
+    dry_run: bool,
+    create: bool,
+    all_templates: bool,
+    x_reseller_id: Optional[str],
+    x_merchant_id: Optional[str],
+    x_template_name: Optional[str],
+    x_workflow: Optional[str],
+    current_user: UserInfo,
+) -> BatchConfigResponse:
+    """Batch-update template configurations across a scope.
+
+    Scope is the AND of the provided X-* headers (reseller, merchant, template
+    name, workflow). At least one scope header is required unless ``all=true``
+    is passed. RBAC always constrains the scope to the caller's accessible
+    resellers/merchants. Defaults to a dry run.
+    """
+    logger.info(
+        f"User {current_user.username} (role: {current_user.role}) batch-patching "
+        f"configurations (dry_run={dry_run}, create={create}, all={all_templates}): "
+        f"reseller={x_reseller_id}, merchant={x_merchant_id}, "
+        f"template={x_template_name}, workflow={x_workflow}"
+    )
+
+    if not patches:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="A non-empty patches body is required",
+        )
+
+    patch_keys = list(patches.keys())
+    for i, key_a in enumerate(patch_keys):
+        for key_b in patch_keys[i + 1 :]:
+            if (
+                key_a == key_b
+                or key_b.startswith(f"{key_a}.")
+                or key_a.startswith(f"{key_b}.")
+            ):
+                raise HTTPException(
+                    status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                    detail=(
+                        f"Conflicting patch keys '{key_a}' and '{key_b}': one path "
+                        "nests inside the other. Send only the most specific path."
+                    ),
+                )
+
+    workflows = _resolve_workflow_scope(x_workflow)
+
+    scope_provided = any([x_reseller_id, x_merchant_id, x_template_name, workflows])
+    if not scope_provided and not all_templates:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=(
+                "Specify at least one scope (X-Reseller-Id, X-Merchant-Id, "
+                "X-Template-Name, X-Workflow) or pass ?all=true"
+            ),
+        )
+
+    filters: Dict[str, Any] = {}
+    reseller_ids = _split_csv(x_reseller_id)
+    if len(reseller_ids) > 1:
+        filters["reseller_ids"] = reseller_ids
+    elif reseller_ids:
+        filters["reseller_id"] = reseller_ids[0]
+    merchant_ids = _split_csv(x_merchant_id)
+    if len(merchant_ids) > 1:
+        filters["merchant_ids"] = merchant_ids
+    elif merchant_ids:
+        filters["merchant_id"] = merchant_ids[0]
+
+    filters = apply_hierarchical_template_filters(filters, current_user)
+
+    if x_template_name:
+        filters["template_name"] = x_template_name
+    if workflows:
+        filters["workflows"] = workflows
+
+    try:
+        response = await batch_update_template_configurations(
+            filters=filters,
+            patches=patches,
+            create=create,
+            dry_run=dry_run,
+        )
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error batch-patching configurations: {e}", exc_info=True)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Error batch-patching configurations: {str(e)}",
+        )
+
+    if not dry_run:
+        for item in response.results:
+            if any(stat in ("patched", "created") for stat in item.keys.values()):
+                try:
+                    await invalidate_template(item.id)
+                except Exception as cache_exc:
+                    logger.warning(
+                        f"Template cache invalidation failed for {item.id}: {cache_exc}"
+                    )
+
+    return response

--- a/app/database/accessor/breeze_buddy/template.py
+++ b/app/database/accessor/breeze_buddy/template.py
@@ -9,9 +9,11 @@ import asyncpg
 
 from app.ai.voice.agents.breeze_buddy.template.types import (
     TemplateModel,
+    WorkflowType,
 )
 from app.core.deprecation import deprecated
 from app.core.logger import logger
+from app.database import get_db_connection
 from app.database.decoder.breeze_buddy.template import decode_template
 from app.database.queries import run_parameterized_query
 from app.database.queries.breeze_buddy.call_execution_config import (
@@ -28,8 +30,14 @@ from app.database.queries.breeze_buddy.template import (
     get_templates_count_query,
     get_templates_list_query,
     replace_template_query,
+    select_templates_by_scope_query,
+    update_template_configurations_query,
 )
-from app.schemas.breeze_buddy.template import TemplateMetadata
+from app.schemas.breeze_buddy.template import (
+    BatchConfigResponse,
+    BatchConfigResultItem,
+    TemplateMetadata,
+)
 
 
 def get_row_count(result: Optional[list[asyncpg.Record]]) -> int:
@@ -104,6 +112,7 @@ async def create_template(
     outbound_number_id: Optional[str] = None,
     is_active: bool = True,
     supported_channels: Optional[List[str]] = None,
+    workflow: Optional[WorkflowType] = None,
 ) -> Optional[TemplateModel]:
     """Create a new template with flow stored as JSON."""
     logger.info(f"Creating template with ID: {template_id}")
@@ -130,6 +139,10 @@ async def create_template(
         # Convert secrets to JSON string
         secrets_json = json.dumps(secrets) if secrets is not None else None
 
+        workflow_value = (
+            workflow.value if workflow is not None else WorkflowType.NON_SHOPIFY.value
+        )
+
         query, values = create_template_query(
             template_id,
             reseller_id,
@@ -145,6 +158,7 @@ async def create_template(
             supported_channels or ["voice"],
             now,
             now,
+            workflow=workflow_value,
         )
 
         result = await run_parameterized_query(query, values)
@@ -262,6 +276,7 @@ async def get_templates_list(
                     reseller_id=row["reseller_id"],
                     merchant_id=row.get("merchant_id"),
                     name=row["name"],
+                    workflow=row.get("workflow") or "non-shopify",
                     is_active=row["is_active"],
                     supported_channels=list(row["supported_channels"]),
                     created_at=row["created_at"],
@@ -549,6 +564,7 @@ async def delete_template_if_not_referenced(
                 reseller_id=row["reseller_id"],
                 merchant_id=row.get("merchant_id"),
                 name=row["name"],
+                workflow=row.get("workflow") or "non-shopify",
                 is_active=row["is_active"],
                 created_at=row["created_at"],
                 updated_at=row["updated_at"],
@@ -602,3 +618,118 @@ async def get_all_templates_by_outbound_number_id(
             f"Error getting all templates by outbound_number_id: {e}", exc_info=True
         )
         return []
+
+
+_MISSING = object()
+
+
+def _resolve_config_path(config: Dict[str, Any], path_parts: List[str]) -> Any:
+    """Return the value at a dotted path inside a configurations dict, or
+    ``_MISSING`` if any segment is absent."""
+    current: Any = config
+    for part in path_parts:
+        if isinstance(current, dict) and part in current:
+            current = current[part]
+        else:
+            return _MISSING
+    return current
+
+
+async def batch_update_template_configurations(
+    filters: Dict[str, Any],
+    patches: Dict[str, Any],
+    create: bool,
+    dry_run: bool,
+) -> BatchConfigResponse:
+    """Apply a flat map of dotted configuration paths to every template
+    matching the given scope.
+
+    Only the ``configurations`` JSONB is touched (never flow/secrets). When
+    ``dry_run`` is True nothing is written; the returned per-template ``keys``
+    map previews the classification of each requested path.
+
+    Args:
+        filters: Scope filters consumed by select_templates_by_scope_query
+            (reseller/merchant scope, optional template_name, optional workflows).
+        patches: ``{"dotted.path": value}`` to apply.
+        create: Create keys that do not already exist (otherwise skip them).
+        dry_run: Preview only; perform no writes.
+    """
+    logger.info(
+        f"Batch config update (dry_run={dry_run}, create={create}) "
+        f"filters={filters} keys={list(patches.keys())}"
+    )
+
+    query, values = select_templates_by_scope_query(filters)
+    rows = await run_parameterized_query(query, values)
+
+    results: List[BatchConfigResultItem] = []
+    total_patched = 0
+    pending_updates: List[Tuple[str, List[Any]]] = []
+
+    for row in rows or []:
+        configurations = row.get("configurations")
+        if isinstance(configurations, str):
+            configurations = json.loads(configurations)
+        if not isinstance(configurations, dict):
+            configurations = {}
+
+        keys_status: Dict[str, str] = {}
+        set_operations: List[Any] = []
+
+        for dotted_path, new_value in patches.items():
+            path_parts = dotted_path.split(".")
+            current = _resolve_config_path(configurations, path_parts)
+
+            if current is _MISSING:
+                if create:
+                    keys_status[dotted_path] = "created"
+                    set_operations.append((path_parts, json.dumps(new_value)))
+                else:
+                    keys_status[dotted_path] = "skipped_not_present"
+            elif current == new_value:
+                keys_status[dotted_path] = "unchanged_same_value"
+            else:
+                keys_status[dotted_path] = "patched"
+                set_operations.append((path_parts, json.dumps(new_value)))
+
+        if set_operations:
+            total_patched += 1
+            if not dry_run:
+                pending_updates.append(
+                    update_template_configurations_query(
+                        str(row["id"]), set_operations, create
+                    )
+                )
+
+        results.append(
+            BatchConfigResultItem(
+                id=str(row["id"]),
+                reseller_id=row["reseller_id"],
+                merchant_id=row.get("merchant_id"),
+                name=row["name"],
+                workflow=row.get("workflow") or "non-shopify",
+                keys=keys_status,
+            )
+        )
+
+    # Apply every matched template's update inside one transaction so the batch
+    # is all-or-nothing -- a failure midway rolls back earlier writes.
+    if pending_updates:
+        async for conn in get_db_connection():
+            async with conn.transaction():
+                for update_query, update_values in pending_updates:
+                    await conn.execute(update_query, *update_values)
+            break
+
+    logger.info(
+        f"Batch config update matched {len(results)} templates, "
+        f"{total_patched} with changes (dry_run={dry_run})"
+    )
+
+    return BatchConfigResponse(
+        dry_run=dry_run,
+        total_templates=len(results),
+        total_patched=total_patched,
+        results=results,
+    )

--- a/app/database/decoder/breeze_buddy/template.py
+++ b/app/database/decoder/breeze_buddy/template.py
@@ -11,6 +11,7 @@ from app.ai.voice.agents.breeze_buddy.template.types import (
     LEGACY_VOICE_TO_PROVIDER,
     ConfigurationModel,
     TemplateModel,
+    WorkflowType,
 )
 from app.core.logger import logger
 
@@ -185,6 +186,13 @@ def decode_template(result: asyncpg.Record) -> Optional[TemplateModel]:
             secrets_data = json.loads(secrets_data)
         # If it's already a dict (from JSONB), use it directly
 
+    try:
+        workflow_value = WorkflowType(
+            result.get("workflow") or WorkflowType.NON_SHOPIFY
+        )
+    except ValueError:
+        workflow_value = WorkflowType.NON_SHOPIFY
+
     # supported_channels is a Postgres text[] (NOT NULL DEFAULT {'voice'}).
     # Some legacy SELECTs may not include the column — fall back to ['voice']
     # so the model always has at least one channel.
@@ -205,6 +213,7 @@ def decode_template(result: asyncpg.Record) -> Optional[TemplateModel]:
             if result.get("outbound_number_id")
             else None
         ),
+        workflow=workflow_value,
         is_active=result["is_active"],
         supported_channels=list(supported_channels),
         created_at=result["created_at"],

--- a/app/database/migrations/034_add_workflow_to_template.sql
+++ b/app/database/migrations/034_add_workflow_to_template.sql
@@ -1,0 +1,23 @@
+-- Migration 034: Add workflow classifier to template (+ backfill, indexes)
+
+BEGIN;
+
+ALTER TABLE template
+    ADD COLUMN IF NOT EXISTS workflow VARCHAR(50) NOT NULL DEFAULT 'non-shopify';
+
+UPDATE template
+SET workflow = CASE
+    WHEN name ILIKE '%assist%' THEN 'assist'
+    WHEN name ILIKE '%abandon%' OR name ILIKE '%recovery%' THEN 'abandonment-recovery'
+    WHEN name ILIKE '%confirmation%' THEN 'order-confirmation'
+    ELSE 'test'
+END
+WHERE reseller_id = 'BB_SHOPIFY';
+
+CREATE INDEX IF NOT EXISTS idx_template_workflow
+    ON template(workflow);
+
+CREATE INDEX IF NOT EXISTS idx_template_workflow_reseller
+    ON template(workflow, reseller_id);
+
+COMMIT;

--- a/app/database/queries/breeze_buddy/template.py
+++ b/app/database/queries/breeze_buddy/template.py
@@ -31,7 +31,7 @@ def get_template_by_merchant_query(
         SELECT id,
                reseller_id,
                merchant_id,
-               name, flow, expected_payload_schema, expected_callback_response_schema, configurations, secrets, outbound_number_id, is_active, supported_channels, created_at, updated_at
+               name, flow, expected_payload_schema, expected_callback_response_schema, configurations, secrets, outbound_number_id, workflow, is_active, supported_channels, created_at, updated_at
         FROM {TEMPLATE_TABLE}
         WHERE {" AND ".join(conditions)}
     """
@@ -64,12 +64,13 @@ def create_template_query(
     supported_channels: List[str],
     created_at,
     updated_at,
+    workflow: str = "non-shopify",
 ) -> Tuple[str, List[Any]]:
     """Generate query to create a new template."""
     query = f"""
-        INSERT INTO {TEMPLATE_TABLE} (id, reseller_id, merchant_id, name, flow, expected_payload_schema, expected_callback_response_schema, configurations, secrets, outbound_number_id, is_active, supported_channels, created_at, updated_at)
-        VALUES ($1, $2, $3, $4, $5::jsonb, $6::jsonb, $7::jsonb, $8::jsonb, $9::jsonb, $10, $11, $12, $13, $14)
-        RETURNING id, reseller_id, merchant_id, name, flow, expected_payload_schema, expected_callback_response_schema, configurations, secrets, outbound_number_id, is_active, supported_channels, created_at, updated_at
+        INSERT INTO {TEMPLATE_TABLE} (id, reseller_id, merchant_id, name, flow, expected_payload_schema, expected_callback_response_schema, configurations, secrets, outbound_number_id, is_active, supported_channels, created_at, updated_at, workflow)
+        VALUES ($1, $2, $3, $4, $5::jsonb, $6::jsonb, $7::jsonb, $8::jsonb, $9::jsonb, $10, $11, $12, $13, $14, $15)
+        RETURNING id, reseller_id, merchant_id, name, flow, expected_payload_schema, expected_callback_response_schema, configurations, secrets, outbound_number_id, workflow, is_active, supported_channels, created_at, updated_at
     """
 
     return query, [
@@ -87,6 +88,7 @@ def create_template_query(
         supported_channels,
         created_at,
         updated_at,
+        workflow,
     ]
 
 
@@ -108,7 +110,7 @@ def delete_template_if_not_referenced_query(template_id: str) -> tuple[str, list
         )
         DELETE FROM {TEMPLATE_TABLE}
         WHERE id IN (SELECT id FROM can_delete)
-        RETURNING id, reseller_id, merchant_id, name, is_active, created_at, updated_at
+        RETURNING id, reseller_id, merchant_id, name, workflow, is_active, created_at, updated_at
     """
     return query, [template_id]
 
@@ -181,7 +183,7 @@ def get_templates_list_query(filters: Dict[str, Any]) -> Tuple[str, List[Any]]:
         SELECT id,
                reseller_id,
                merchant_id,
-               name, is_active, supported_channels, created_at, updated_at
+               name, workflow, is_active, supported_channels, created_at, updated_at
         FROM {TEMPLATE_TABLE}
         {where_clause}
         ORDER BY {order_by}
@@ -220,7 +222,7 @@ def get_template_by_id_query(template_id: str) -> Tuple[str, List[Any]]:
         SELECT id,
                reseller_id,
                merchant_id,
-               name, flow, expected_payload_schema, expected_callback_response_schema, configurations, secrets, outbound_number_id, is_active, supported_channels, created_at, updated_at
+               name, flow, expected_payload_schema, expected_callback_response_schema, configurations, secrets, outbound_number_id, workflow, is_active, supported_channels, created_at, updated_at
         FROM {TEMPLATE_TABLE}
         WHERE id = $1
         LIMIT 1
@@ -254,7 +256,7 @@ def get_template_by_outbound_number_id_query(
         SELECT id,
                reseller_id,
                merchant_id,
-               name, flow, expected_payload_schema, expected_callback_response_schema, configurations, secrets, outbound_number_id, is_active, supported_channels, created_at, updated_at
+               name, flow, expected_payload_schema, expected_callback_response_schema, configurations, secrets, outbound_number_id, workflow, is_active, supported_channels, created_at, updated_at
         FROM {TEMPLATE_TABLE}
         WHERE {' AND '.join(conditions)}
         LIMIT 1
@@ -283,7 +285,7 @@ def get_all_templates_by_outbound_number_id_query(
         SELECT id,
                reseller_id,
                merchant_id,
-               name, flow, expected_payload_schema, expected_callback_response_schema, configurations, outbound_number_id, is_active, supported_channels, created_at, updated_at
+               name, flow, expected_payload_schema, expected_callback_response_schema, configurations, outbound_number_id, workflow, is_active, supported_channels, created_at, updated_at
         FROM {TEMPLATE_TABLE}
         WHERE outbound_number_id = $1
         AND is_active = TRUE
@@ -380,7 +382,7 @@ def replace_template_query(
         RETURNING id,
                   reseller_id,
                   merchant_id,
-                  name, flow, expected_payload_schema, expected_callback_response_schema, configurations, secrets, outbound_number_id, is_active, supported_channels, created_at, updated_at
+                  name, flow, expected_payload_schema, expected_callback_response_schema, configurations, secrets, outbound_number_id, workflow, is_active, supported_channels, created_at, updated_at
     """
 
     return query, [
@@ -398,3 +400,117 @@ def replace_template_query(
         updated_at,
         template_id,
     ]
+
+
+def select_templates_by_scope_query(filters: Dict[str, Any]) -> Tuple[str, List[Any]]:
+    """Select templates matching a batch-update scope.
+
+    Returns only the columns needed to classify and patch configurations
+    (never flow/secrets). Supported filter keys:
+        - reseller_id (single) / reseller_ids (list)
+        - merchant_id (single) / merchant_ids (list)
+        - template_name (single)
+        - workflows (list) -- one or more workflow values
+    """
+    conditions: List[str] = []
+    values: List[Any] = []
+
+    if filters.get("reseller_ids"):
+        values.append(filters["reseller_ids"])
+        conditions.append(f"reseller_id = ANY(${len(values)})")
+    elif filters.get("reseller_id"):
+        values.append(filters["reseller_id"])
+        conditions.append(f"reseller_id = ${len(values)}")
+
+    if filters.get("merchant_ids"):
+        values.append(filters["merchant_ids"])
+        conditions.append(f"merchant_id = ANY(${len(values)})")
+    elif filters.get("merchant_id"):
+        values.append(filters["merchant_id"])
+        conditions.append(f"merchant_id = ${len(values)}")
+
+    if filters.get("template_name"):
+        values.append(filters["template_name"])
+        conditions.append(f"name = ${len(values)}")
+
+    if filters.get("workflows"):
+        values.append(filters["workflows"])
+        conditions.append(f"workflow = ANY(${len(values)})")
+
+    where_clause = " WHERE " + " AND ".join(conditions) if conditions else ""
+
+    query = f"""
+        SELECT id, reseller_id, merchant_id, name, workflow, configurations
+        FROM {TEMPLATE_TABLE}
+        {where_clause}
+        ORDER BY created_at DESC
+    """
+
+    return query, values
+
+
+def update_template_configurations_query(
+    template_id: str,
+    set_operations: List[Tuple[List[str], str]],
+    create_missing: bool,
+) -> Tuple[str, List[Any]]:
+    """Build a surgical configurations update using nested jsonb_set.
+
+    Args:
+        template_id: Template UUID to update.
+        set_operations: List of (path_parts, json_value) tuples, where
+            path_parts is the JSONB path (e.g. ["tts_configuration", "provider"])
+            and json_value is the already JSON-encoded new value.
+        create_missing: Whether jsonb_set should create a missing leaf key.
+
+    Only the ``configurations`` column is touched; ``flow`` and ``secrets`` are
+    never modified.
+    """
+    base = "COALESCE(configurations, '{}'::jsonb)"
+    expr = base
+    values: List[Any] = []
+    create_flag = "true" if create_missing else "false"
+
+    # jsonb_set is a no-op when an intermediate parent is absent, so seed every
+    # missing parent object (shallowest first) before writing the leaves.
+    seen_parents: set = set()
+    parent_paths: List[List[str]] = []
+    for path_parts, _ in set_operations:
+        for depth in range(1, len(path_parts)):
+            prefix = path_parts[:depth]
+            key = tuple(prefix)
+            if key not in seen_parents:
+                seen_parents.add(key)
+                parent_paths.append(prefix)
+    parent_paths.sort(key=len)
+
+    for prefix in parent_paths:
+        values.append(prefix)
+        prefix_idx = len(values)
+        expr = (
+            f"jsonb_set({expr}, ${prefix_idx}::text[], "
+            f"COALESCE({base} #> ${prefix_idx}::text[], '{{}}'::jsonb), true)"
+        )
+
+    for path_parts, json_value in set_operations:
+        values.append(path_parts)
+        path_idx = len(values)
+        values.append(json_value)
+        value_idx = len(values)
+        expr = (
+            f"jsonb_set({expr}, ${path_idx}::text[], "
+            f"${value_idx}::jsonb, {create_flag})"
+        )
+
+    values.append(template_id)
+    id_idx = len(values)
+
+    query = f"""
+        UPDATE {TEMPLATE_TABLE}
+        SET configurations = {expr},
+            updated_at = NOW()
+        WHERE id = ${id_idx}
+        RETURNING id
+    """
+
+    return query, values

--- a/app/schemas/breeze_buddy/template.py
+++ b/app/schemas/breeze_buddy/template.py
@@ -1,7 +1,7 @@
 """Response schemas for template endpoints."""
 
 from datetime import datetime
-from typing import List, Optional
+from typing import Dict, List, Optional
 
 from pydantic import BaseModel
 
@@ -17,6 +17,7 @@ class TemplateMetadata(BaseModel):
     reseller_id: str
     merchant_id: Optional[str] = None
     name: str
+    workflow: str = "non-shopify"
     is_active: bool
     supported_channels: List[str] = ["voice"]
     created_at: datetime
@@ -45,3 +46,31 @@ class DeleteTemplateResponse(BaseModel):
     status: str
     message: str
     deleted_template: TemplateMetadata
+
+
+class BatchConfigResultItem(BaseModel):
+    """Per-template outcome of a batch configurations update.
+
+    ``keys`` maps each requested dotted configuration path to its status:
+    ``patched``, ``created``, ``skipped_not_present``, or ``unchanged_same_value``.
+    """
+
+    id: str
+    reseller_id: str
+    merchant_id: Optional[str] = None
+    name: str
+    workflow: str
+    keys: Dict[str, str]
+
+
+class BatchConfigResponse(BaseModel):
+    """Response for a batch configurations update.
+
+    With ``dry_run=True`` nothing is written; the per-template ``keys`` map is a
+    preview of what would change.
+    """
+
+    dry_run: bool
+    total_templates: int
+    total_patched: int
+    results: List[BatchConfigResultItem]


### PR DESCRIPTION
## What

Adds a `workflow` classifier to templates and an admin-only batch endpoint to update template `configurations` across a scope in one call.

## Changes

- **Migration 033** - adds `workflow` column (`VARCHAR(50) NOT NULL DEFAULT 'non-shopify'`), backfills existing `BB_SHOPIFY` templates by name (contains `assist` -> assist, `recovery` -> abandonment-recovery, `confirmation` -> order-confirmation, else `test`), and adds two indexes for workflow scoping.
- **WorkflowType enum** - `order-confirmation`, `abandonment-recovery`, `assist`, `test`, `non-shopify`; plus a `workflow` field on `TemplateModel`.
- **Data layer** - persist/read `workflow` across queries, decoder, and accessor; derive the label on create for Shopify templates using the same name rules as the backfill.
- **Endpoint** - `PATCH /templates/batch-configurations` (admin-only, hidden from OpenAPI). Scope is the AND of `X-Workflow` / `X-Reseller-Id` / `X-Merchant-Id` / `X-Template-Name`, or `?all=true`. RBAC always constrains scope to the caller's accessible resellers/merchants. Dry-run by default. Patches only the dotted paths inside `configurations` via `jsonb_set`; never touches `flow` or `secrets`.

## Deploy

Run `python scripts/migrate.py up` to apply migration 033.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added workflow support for templates, including automatic workflow classification and default handling for new records.
  * Introduced batch configuration updates for templates, with scoped changes, dry-run support, and a detailed per-template results summary.
  * Added support for filtering template operations by workflow and other scope fields.

* **Bug Fixes**
  * Improved template data handling so workflow values are consistently read, stored, and returned across template operations.
  * Added safer updates for template configurations to avoid unnecessary changes and handle invalid inputs more gracefully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->