### PR TITLE
(feat): add outcome support for chat sessions

### DIFF
--- a/app/ai/voice/agents/breeze_buddy/template/hooks.py
+++ b/app/ai/voice/agents/breeze_buddy/template/hooks.py
@@ -28,6 +28,9 @@ from app.ai.voice.agents.breeze_buddy.template.types import (
     HookConfig,
 )
 from app.core.logger import logger
+from app.database.accessor.breeze_buddy.chat_session import (
+    update_chat_session_outcome,
+)
 from app.database.accessor.breeze_buddy.lead_call_tracker import (
     update_lead_call_completion_details,
 )
@@ -198,11 +201,29 @@ class UpdateOutcomeInDatabaseHook(Hook):
 
         # Get lead from context
         if not context.lead or not context.lead.id:
-            # Expected in chat mode (no lead by design). Outcome persistence
-            # to chat_session is a separate concern; see docs/CHAT_MODE.md §15.
-            logger.info(
-                f"Skipping outcome DB update for '{function_name}': no lead in context."
-            )
+            # Chat / assist mode (no lead by design): persist the singular
+            # outcome to chat_session.outcome instead of dropping it. The
+            # session id rides on the bot (ChatAgent.session_id); when even
+            # that is absent (e.g. a bare test harness) there is nothing to
+            # write to. Mirroring to a bound voice lead is a follow-up.
+            session_id = getattr(context.bot, "session_id", None)
+            if not session_id:
+                logger.info(
+                    f"No lead and no chat session for '{function_name}': "
+                    f"skipping outcome persistence."
+                )
+                return
+            try:
+                await update_chat_session_outcome(str(session_id), str(outcome))
+                logger.info(
+                    f"Persisted chat outcome '{outcome}' to session {session_id} "
+                    f"(function: '{function_name}')"
+                )
+            except Exception as e:
+                logger.opt(exception=True).error(
+                    f"Failed to persist chat outcome '{outcome}' to session "
+                    f"{session_id} (function: '{function_name}'): {e}"
+                )
             return
 
         try:

--- a/app/database/accessor/breeze_buddy/chat_session.py
+++ b/app/database/accessor/breeze_buddy/chat_session.py
@@ -34,6 +34,7 @@ from app.database.queries.breeze_buddy.chat_session import (
     record_chat_turn_metrics_query,
     set_chat_session_voice_lead_query,
     update_chat_session_after_turn_query,
+    update_chat_session_outcome_query,
     upsert_agent_session_state_merge_query,
     upsert_agent_session_state_query,
 )
@@ -131,6 +132,29 @@ async def end_chat_session(
         return None
     except Exception as e:
         logger.error(f"Error ending chat session {session_id}: {e}")
+        raise
+
+
+async def update_chat_session_outcome(
+    session_id: str,
+    outcome: str,
+) -> Optional[str]:
+    """Set the singular outcome on a chat_session WITHOUT ending it.
+
+    Used by the chat-aware ``update_outcome_in_database`` hook so an assist /
+    chat session records an outcome as soon as the LLM sets one. Returns the
+    written outcome, or None if no row matched. Raises on DB error.
+    """
+    query, values = update_chat_session_outcome_query(session_id, outcome)
+    try:
+        result = await run_parameterized_query(query, values)
+        if not result:
+            return None
+        return result[0]["outcome"]
+    except Exception as e:
+        logger.error(
+            f"Error setting outcome '{outcome}' on chat session {session_id}: {e}"
+        )
         raise
 
 

--- a/app/database/queries/breeze_buddy/chat_session.py
+++ b/app/database/queries/breeze_buddy/chat_session.py
@@ -107,6 +107,33 @@ def end_chat_session_query(
     return query, [outcome, ended_reason, session_id]
 
 
+def update_chat_session_outcome_query(
+    session_id: str,
+    outcome: str,
+) -> Tuple[str, List[Any]]:
+    """Set the singular ``outcome`` on a chat_session WITHOUT ending it.
+
+    Used by the chat-aware ``update_outcome_in_database`` hook (and the
+    ``update_outcome`` builtin that fires it) so a chat / assist session
+    records an outcome as soon as the LLM sets one — instead of dropping
+    it, which is what happened before when the hook bailed on
+    ``context.lead`` being None. Returns the written outcome.
+
+    No-op (returns no row) if the session is already ``ENDED`` — mirrors the
+    ``end_chat_session_query`` guard so a late fire-and-forget write (the hook
+    is scheduled via ``asyncio.create_task``) can't overwrite a terminal
+    session's state.
+    """
+    query = f"""
+        UPDATE {CHAT_SESSION_TABLE}
+        SET outcome = $2,
+            last_activity_at = now()
+        WHERE id = $1 AND status <> 'ENDED'
+        RETURNING outcome
+    """
+    return query, [session_id, outcome]
+
+
 def list_idle_chat_sessions_query(
     cutoff: datetime,
     statuses: List[str],


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Chat and assist sessions now retain their outcome even when no lead is available.
* **Bug Fixes**
  * Improved outcome saving for sessions, reducing cases where the final result was not stored.
  * Added better error handling when session data is missing or saving the outcome fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->