### PR TITLE
BZ-4342: feat: Add graph primitives to ui catalog

### DIFF
--- a/app/ai/voice/agents/breeze_buddy/template/ui_catalog.py
+++ b/app/ai/voice/agents/breeze_buddy/template/ui_catalog.py
@@ -654,6 +654,76 @@ class SideEffect(_CatalogBase):
 
 
 # ---------------------------------------------------------------------------
+# Chart primitives (group: graphs)
+#
+# Rendered by local Svelte chart primitives (BarChart.svelte, LineChart.svelte,
+# …) in the Buddy Assist widget — the widget-side render support for these
+# schemas, same pattern as the core primitives. All charts share the same tiny
+# {label, value} data shape so the LLM can swap chart types freely.
+# ---------------------------------------------------------------------------
+
+
+class ChartDatum(BaseModel):
+    """One point in a chart: a category label and its numeric value."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    label: str = Field(
+        ..., min_length=1, description="Category label shown on the axis or legend."
+    )
+    value: float = Field(..., description="Numeric value for this point.")
+    color: Optional[str] = Field(
+        None, description="Optional CSS colour; falls back to the palette by order."
+    )
+
+
+class BarChart(_CatalogBase):
+    """Vertical bar chart for comparing discrete categories (e.g. calls per
+    hour, outcomes by type, top merchants). Use when comparing counts across
+    a small set of labelled categories."""
+
+    data: List[ChartDatum] = Field(
+        ..., min_length=1, description="Bars to plot, one per category."
+    )
+    title: Optional[str] = Field(None, description="Heading shown above the chart.")
+
+
+class LineChart(_CatalogBase):
+    """Line chart for a trend across an ordered sequence (e.g. attempts per day,
+    connect rate over a week). Use to show change over an ordered axis."""
+
+    data: List[ChartDatum] = Field(
+        ..., min_length=1, description="Points in order, plotted left to right."
+    )
+    title: Optional[str] = Field(None, description="Heading shown above the chart.")
+
+
+class AreaChart(_CatalogBase):
+    """Filled area chart for volume over time (e.g. daily call or chat volume).
+    Like a line chart but emphasises magnitude with a filled region."""
+
+    data: List[ChartDatum] = Field(
+        ..., min_length=1, description="Points in order, plotted left to right."
+    )
+    title: Optional[str] = Field(None, description="Heading shown above the chart.")
+
+
+class PieChart(_CatalogBase):
+    """Pie or donut chart for share-of-total (e.g. outcome breakdown, channel
+    split). Use when parts sum to a meaningful whole. Set ``donut`` for a ring
+    with a centre total."""
+
+    data: List[ChartDatum] = Field(
+        ..., min_length=1, description="Slices; each value is a share of the total."
+    )
+    title: Optional[str] = Field(None, description="Heading shown above the chart.")
+    donut: Optional[bool] = Field(
+        None,
+        description="Render as a donut ring with a centre total instead of a full pie.",
+    )
+
+
+# ---------------------------------------------------------------------------
 # Catalog manifest + group registry
 # ---------------------------------------------------------------------------
 
@@ -680,6 +750,11 @@ UI_CATALOG: Dict[str, Type[_CatalogBase]] = {
     "Handoff": Handoff,
     # Composite
     "Tile": Tile,
+    # Charts (graphs)
+    "BarChart": BarChart,
+    "LineChart": LineChart,
+    "AreaChart": AreaChart,
+    "PieChart": PieChart,
     # Effects (invisible)
     "SideEffect": SideEffect,
 }
@@ -720,13 +795,16 @@ PRIMITIVE_GROUPS: Dict[str, List[str]] = {
     "effects": [
         "SideEffect",
     ],
+    "graphs": [
+        "BarChart",
+        "LineChart",
+        "AreaChart",
+        "PieChart",
+    ],
     # Reserved for future expansion — schemas + widget components land
     # behind these group flags so existing templates aren't affected.
-    "graphs": [
-        # "LineChart", "BarChart", "PieChart", "AreaChart"
-    ],
     "metrics": [
-        # "KPI", "Sparkline", "MetricCard", "ProgressBar"
+        # KPI, MetricCard, Sparkline, ProgressBar — shipping in a follow-up PR
     ],
     "forms": [
         # "TextInput", "Select", "Checkbox", "RadioGroup"
@@ -764,6 +842,11 @@ PRIMITIVE_RENDER_ORDER: List[str] = [
     "Handoff",
     # Data
     "Table",
+    # Charts
+    "BarChart",
+    "LineChart",
+    "AreaChart",
+    "PieChart",
     # Notifications
     "Message",
     # Effects (invisible — last so it doesn't crowd the visual catalog)

--- a/app/ai/voice/agents/breeze_buddy/template/ui_prompt.py
+++ b/app/ai/voice/agents/breeze_buddy/template/ui_prompt.py
@@ -117,6 +117,43 @@ _EXAMPLES: Dict[str, Dict[str, Any]] = {
         "columns": ["Item", "Qty", "Total"],
         "rows": [["Item A", "1", "100"]],
     },
+    "BarChart": {
+        "+": "bar1:BarChart@root",
+        "title": "Orders by status",
+        "data": [
+            {"label": "Confirmed", "value": 42},
+            {"label": "Cancelled", "value": 8},
+            {"label": "No answer", "value": 15},
+        ],
+    },
+    "LineChart": {
+        "+": "line1:LineChart@root",
+        "title": "Calls per day",
+        "data": [
+            {"label": "Mon", "value": 120},
+            {"label": "Tue", "value": 98},
+            {"label": "Wed", "value": 141},
+        ],
+    },
+    "AreaChart": {
+        "+": "area1:AreaChart@root",
+        "title": "Chat volume",
+        "data": [
+            {"label": "Wk1", "value": 300},
+            {"label": "Wk2", "value": 420},
+            {"label": "Wk3", "value": 380},
+        ],
+    },
+    "PieChart": {
+        "+": "pie1:PieChart@root",
+        "title": "Outcome split",
+        "donut": True,
+        "data": [
+            {"label": "Confirmed", "value": 42},
+            {"label": "Cancelled", "value": 8},
+            {"label": "Address updated", "value": 12},
+        ],
+    },
 }
 
 

--- a/tests/test_ui_catalog_groups.py
+++ b/tests/test_ui_catalog_groups.py
@@ -4,6 +4,7 @@ Covers:
   * ``resolve_allowlist`` — default ("core" only), groups + primitives mix,
     disabled overrides, unknown group/primitive tolerance.
   * ``group_for`` — primitive → group reverse lookup.
+  * ``graphs`` group enablement + chart primitive ``validate_props`` shape.
 """
 
 from __future__ import annotations
@@ -20,6 +21,7 @@ from app.ai.voice.agents.breeze_buddy.template.ui_catalog import (
     SideEffectKind,
     group_for,
     resolve_allowlist,
+    validate_props,
 )
 
 # ---------------------------------------------------------------------------
@@ -178,3 +180,37 @@ def test_sideeffect_default_kind_is_fetch_so_url_required():
     for the same reason ``SideEffect(kind=fetch)`` does."""
     with pytest.raises(ValidationError, match="kind='fetch' requires"):
         SideEffect()
+
+
+# ---------------------------------------------------------------------------
+# graphs group
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_graphs_group_includes_all_chart_types():
+    """Enabling the ``graphs`` group surfaces exactly the four chart types."""
+    result = resolve_allowlist(enabled_groups=["graphs"])
+    assert result == {"BarChart", "LineChart", "AreaChart", "PieChart"}
+
+
+def test_chart_primitives_map_back_to_graphs_group():
+    """Each chart primitive reverse-maps to the ``graphs`` group."""
+    for chart in ("BarChart", "LineChart", "AreaChart", "PieChart"):
+        assert group_for(chart) == "graphs"
+
+
+def test_validate_props_accepts_minimal_bar_chart():
+    """A minimal single-datum BarChart payload passes validation."""
+    chart = validate_props("BarChart", {"data": [{"label": "Mon", "value": 5}]})
+    # validate_props is typed to return the _CatalogBase base, so read the
+    # concrete fields via model_dump() rather than dynamic attribute access.
+    datum = chart.model_dump()["data"][0]
+    assert datum["label"] == "Mon"
+    assert datum["value"] == 5
+
+
+def test_validate_props_rejects_empty_chart_datum_label():
+    """``ChartDatum.label`` enforces ``min_length=1`` — empty labels are rejected
+    (parity with Button/Tag/Table labels)."""
+    with pytest.raises(ValidationError):
+        validate_props("BarChart", {"data": [{"label": "", "value": 5}]})


### PR DESCRIPTION
- Add a `graphs` primitive group to the generative-UI catalog so the LLM can render charts in the Assist widget.
- 
<img width="870" height="1312" alt="Screenshot 2026-07-02 at 1 42 36 PM" src="https://github.com/user-attachments/assets/5d3022e3-5f90-4c19-bd6b-a9282b9a3e84" />
<img width="818" height="1200" alt="Screenshot 2026-07-02 at 1 43 25 PM" src="https://github.com/user-attachments/assets/38b553dc-d557-4799-9a58-b30cffc86358" />
<img width="932" height="1360" alt="Screenshot 2026-07-02 at 1 46 16 PM" src="https://github.com/user-attachments/assets/eec31e19-99ae-4736-815b-d85093f11989" />
<img width="856" height="1284" alt="Screenshot 2026-07-02 at 1 46 48 PM" src="https://github.com/user-attachments/assets/d25e8468-28bc-46f3-8533-14caaeec25f0" />
<img width="890" height="1180" alt="Screenshot 2026-07-02 at 1 48 14 PM" src="https://github.com/user-attachments/assets/299b2000-d8a8-44bd-b9dd-2a29081f2c0f" />
<img width="886" height="1222" alt="Screenshot 2026-07-02 at 1 48 34 PM" src="https://github.com/user-attachments/assets/67362208-cf90-4ede-89aa-f5b2207b39d5" />

