### PR TITLE
BZ-4346: feat: Add metrics primitives to the ui catalog

### DIFF
--- a/app/ai/voice/agents/breeze_buddy/template/ui_catalog.py
+++ b/app/ai/voice/agents/breeze_buddy/template/ui_catalog.py
@@ -654,6 +654,79 @@ class SideEffect(_CatalogBase):
 
 
 # ---------------------------------------------------------------------------
+# Metric primitives (group: metrics)
+#
+# Single-number / stat widgets for analytics dashboards — the "big number"
+# tiles, not full charts. Rendered by the widget like every other primitive.
+# Numeric display strings are passed pre-formatted (e.g. "2,999", "₹1,299")
+# so locale formatting stays the upstream tool's job.
+# ---------------------------------------------------------------------------
+
+
+class KPI(_CatalogBase):
+    """A headline metric: a big value with a label and optional change.
+    Use for the key number in an analytics answer (e.g. total calls, success
+    rate). ``value`` is a pre-formatted display string."""
+
+    label: str = Field(
+        ..., min_length=1, description="What the number measures (e.g. 'Total calls')."
+    )
+    value: str = Field(
+        ...,
+        min_length=1,
+        description="The metric, pre-formatted (e.g. '2,999', '87%').",
+    )
+    delta: Optional[str] = Field(
+        None, description="Optional change vs a baseline, pre-formatted (e.g. '+12%')."
+    )
+    trend: Optional[Literal["up", "down", "flat"]] = Field(
+        None, description="Direction of the change; colours the delta + arrow."
+    )
+
+
+class MetricCard(_CatalogBase):
+    """A metric inside a bordered card: title + big value + optional caption.
+    Use for a labelled stat tile in a grid of metrics."""
+
+    title: str = Field(
+        ..., min_length=1, description="Card title (e.g. 'No-answer rate')."
+    )
+    value: str = Field(..., min_length=1, description="The metric, pre-formatted.")
+    caption: Optional[str] = Field(
+        None, description="Optional supporting text under the value."
+    )
+    tone: Optional[Literal["neutral", "positive", "warning", "info"]] = Field(
+        "neutral", description="Accent colour for the card."
+    )
+
+
+class Sparkline(_CatalogBase):
+    """A tiny inline trend line (no axes/labels) for a sequence of numbers.
+    Use beside a KPI to show its recent movement compactly."""
+
+    values: List[float] = Field(
+        ..., min_length=2, description="Ordered numeric points to plot."
+    )
+    color: Optional[str] = Field(None, description="Optional stroke colour (CSS).")
+
+
+class ProgressBar(_CatalogBase):
+    """A horizontal bar showing progress toward a goal (value out of max).
+    Use for rates / completion (e.g. '87% confirmed')."""
+
+    value: float = Field(
+        ..., ge=0, description="Current value (clamped to [0, max] at render)."
+    )
+    max: float = Field(100, gt=0, description="Maximum value (default 100).")
+    label: Optional[str] = Field(
+        None, description="Optional label shown above the bar."
+    )
+    tone: Optional[Literal["neutral", "positive", "warning", "info"]] = Field(
+        "neutral", description="Accent colour for the filled portion."
+    )
+
+
+# ---------------------------------------------------------------------------
 # Chart primitives (group: graphs)
 #
 # Rendered by local Svelte chart primitives (BarChart.svelte, LineChart.svelte,
@@ -750,6 +823,11 @@ UI_CATALOG: Dict[str, Type[_CatalogBase]] = {
     "Handoff": Handoff,
     # Composite
     "Tile": Tile,
+    # Metrics (analytics stats)
+    "KPI": KPI,
+    "MetricCard": MetricCard,
+    "Sparkline": Sparkline,
+    "ProgressBar": ProgressBar,
     # Charts (graphs)
     "BarChart": BarChart,
     "LineChart": LineChart,
@@ -804,7 +882,10 @@ PRIMITIVE_GROUPS: Dict[str, List[str]] = {
     # Reserved for future expansion — schemas + widget components land
     # behind these group flags so existing templates aren't affected.
     "metrics": [
-        # KPI, MetricCard, Sparkline, ProgressBar — shipping in a follow-up PR
+        "KPI",
+        "MetricCard",
+        "Sparkline",
+        "ProgressBar",
     ],
     "forms": [
         # "TextInput", "Select", "Checkbox", "RadioGroup"
@@ -842,6 +923,11 @@ PRIMITIVE_RENDER_ORDER: List[str] = [
     "Handoff",
     # Data
     "Table",
+    # Metrics (analytics stats)
+    "KPI",
+    "MetricCard",
+    "Sparkline",
+    "ProgressBar",
     # Charts
     "BarChart",
     "LineChart",

--- a/app/ai/voice/agents/breeze_buddy/template/ui_prompt.py
+++ b/app/ai/voice/agents/breeze_buddy/template/ui_prompt.py
@@ -117,6 +117,28 @@ _EXAMPLES: Dict[str, Dict[str, Any]] = {
         "columns": ["Item", "Qty", "Total"],
         "rows": [["Item A", "1", "100"]],
     },
+    "KPI": {
+        "+": "kpi1:KPI@root",
+        "label": "Total calls",
+        "value": "2,999",
+        "delta": "+12%",
+        "trend": "up",
+    },
+    "MetricCard": {
+        "+": "mc1:MetricCard@root",
+        "title": "No-answer rate",
+        "value": "52%",
+        "caption": "1,551 of 2,999 this week",
+        "tone": "warning",
+    },
+    "Sparkline": {"+": "spark1:Sparkline@root", "values": [120, 98, 141, 110, 165]},
+    "ProgressBar": {
+        "+": "prog1:ProgressBar@root",
+        "label": "Confirmed",
+        "value": 87,
+        "max": 100,
+        "tone": "positive",
+    },
     "BarChart": {
         "+": "bar1:BarChart@root",
         "title": "Orders by status",

--- a/tests/test_ui_catalog_groups.py
+++ b/tests/test_ui_catalog_groups.py
@@ -5,6 +5,7 @@ Covers:
     disabled overrides, unknown group/primitive tolerance.
   * ``group_for`` — primitive → group reverse lookup.
   * ``graphs`` group enablement + chart primitive ``validate_props`` shape.
+  * ``metrics`` group enablement + metric primitive ``validate_props`` shape.
 """
 
 from __future__ import annotations
@@ -210,7 +211,39 @@ def test_validate_props_accepts_minimal_bar_chart():
 
 
 def test_validate_props_rejects_empty_chart_datum_label():
-    """``ChartDatum.label`` enforces ``min_length=1`` — empty labels are rejected
+    """``ChartPoint.label`` enforces ``min_length=1`` — empty labels are rejected
     (parity with Button/Tag/Table labels)."""
     with pytest.raises(ValidationError):
         validate_props("BarChart", {"data": [{"label": "", "value": 5}]})
+
+
+# ---------------------------------------------------------------------------
+# metrics group
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_metrics_group_includes_all_metric_types():
+    """Enabling the ``metrics`` group surfaces exactly the four metric types."""
+    result = resolve_allowlist(enabled_groups=["metrics"])
+    assert result == {"KPI", "MetricCard", "Sparkline", "ProgressBar"}
+
+
+def test_metric_primitives_map_back_to_metrics_group():
+    """Each metric primitive reverse-maps to the ``metrics`` group."""
+    for prim in ("KPI", "MetricCard", "Sparkline", "ProgressBar"):
+        assert group_for(prim) == "metrics"
+
+
+def test_validate_props_accepts_minimal_kpi():
+    """A KPI with just label + value validates and round-trips its fields."""
+    kpi = validate_props("KPI", {"label": "Total calls", "value": "2,999"})
+    dumped = kpi.model_dump()
+    assert dumped["label"] == "Total calls"
+    assert dumped["value"] == "2,999"
+
+
+def test_validate_props_rejects_empty_kpi_label():
+    """``KPI.label`` enforces ``min_length=1`` — empty labels are rejected
+    so the widget never renders a blank metric label."""
+    with pytest.raises(ValidationError):
+        validate_props("KPI", {"label": "", "value": "42"})

--- a/tests/test_ui_prompt.py
+++ b/tests/test_ui_prompt.py
@@ -11,6 +11,8 @@ from __future__ import annotations
 
 import json
 
+import pytest
+
 # Load the template package before any chat/* module reaches it — same
 # circular-import precaution as the sibling ui_stream / ui_healer tests.
 from app.ai.voice.agents.breeze_buddy.template.ui_catalog import (  # noqa: F401
@@ -109,6 +111,25 @@ def test_tile_example_validates_against_catalog():
     assert payload["type"] == "Tile"
     # Server-side validator must accept the expanded example props.
     validate_props("Tile", payload["props"])
+
+
+@pytest.mark.parametrize("name", ["KPI", "MetricCard", "Sparkline", "ProgressBar"])
+def test_metric_example_validates_against_catalog(name):
+    """Each metric primitive's hard-coded compact example must round-trip
+    through expand_compact_op -> validate_props, so a malformed example can't
+    ship and mis-train the LLM prompt (mirrors the Tile contract test)."""
+    from app.ai.voice.agents.breeze_buddy.chat.ui_stream import expand_compact_op
+
+    section = render_primitives_section({name})
+    block = section.split(f"**{name}**", 1)[1]
+    example_line = next(
+        line for line in block.splitlines() if line.strip().startswith("Example:")
+    )
+    payload = expand_compact_op(
+        json.loads(example_line.split("Example:", 1)[1].strip())
+    )
+    assert payload["type"] == name
+    validate_props(name, payload["props"])
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION

 - Add a `metrics` primitive group to the generative-UI catalog
 - Introduce KPI, MetricCard, Sparkline, and ProgressBar schemas
 - Register them in the catalog manifest + render order
 - Add few-shot prompt examples so the LLM emits them correctly
 - Templates opt in via ui_catalog.enabled_groups
 - 
<img width="800" height="1268" alt="Screenshot 2026-07-02 at 1 40 51 PM" src="https://github.com/user-attachments/assets/389308db-911d-45f8-a2c6-98a9fc26361d" />
<img width="818" height="1200" alt="Screenshot 2026-07-02 at 1 43 25 PM" src="https://github.com/user-attachments/assets/0d12fd62-95a0-492b-8291-434e74593e46" />
<img width="794" height="1256" alt="Screenshot 2026-07-01 at 10 41 32 PM" src="https://github.com/user-attachments/assets/2320b228-f37a-45cb-883f-ae9e86f91f56" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Metrics section to the UI catalog with support for KPI-style widgets.
  * Introduced four new metric display options: KPI, MetricCard, Sparkline, and ProgressBar.
  * Updated example content so these new widgets can be surfaced in generated UI prompts.

* **Bug Fixes**
  * Improved ordering and registration of UI primitives so metric components appear in the expected place in the catalog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->