### PR TITLE
BZ-4362: feat: Woocomerce webhook integration

### DIFF
--- a/app/api/routers/breeze_buddy/__init__.py
+++ b/app/api/routers/breeze_buddy/__init__.py
@@ -16,6 +16,9 @@ from app.api.routers.breeze_buddy.credentials import router as credentials_route
 # Daily transport (web/mobile clients via Daily.co)
 from app.api.routers.breeze_buddy.daily import router as daily_router
 from app.api.routers.breeze_buddy.demo import router as demo_router
+
+# Generic e-commerce integration ingress (WooCommerce/Magento/custom -> lead)
+from app.api.routers.breeze_buddy.integrations import router as integrations_router
 from app.api.routers.breeze_buddy.leads import router as leads_router
 from app.api.routers.breeze_buddy.merchants import router as merchants_router
 from app.api.routers.breeze_buddy.numbers import router as numbers_router
@@ -84,6 +87,9 @@ router.include_router(users_router, prefix="", tags=["users"])
 
 # Leads (call requests/trackers)
 router.include_router(leads_router, prefix="", tags=["leads"])
+
+# Generic e-commerce integration ingress (per-store signature auth; URL-param driven)
+router.include_router(integrations_router, prefix="", tags=["integrations"])
 
 # Telephony (webhook handlers for call providers)
 router.include_router(telephony_router, prefix="", tags=["telephony"])

--- a/app/api/routers/breeze_buddy/integrations/__init__.py
+++ b/app/api/routers/breeze_buddy/integrations/__init__.py
@@ -1,0 +1,40 @@
+"""
+Generic e-commerce integration ingress.
+
+A single platform-neutral endpoint that turns an external cart's order webhook
+into a Breeze Buddy lead:
+
+- POST /integrations/{platform}   e.g. /integrations/woocommerce
+
+Builds the same request nautilus sends to push_lead: reseller_id = the platform
+constant, merchant_id = the `merchant_id` query param (a clean store identifier,
+like nautilus's shopDomain), template = the `order-confirmation` default.
+Optional ingress check via `?filterCOD=true`.
+
+    /integrations/woocommerce?merchant_id=<store>   (+ optional &filterCOD=true)
+
+Authenticated by the webhook signature (not JWT), so the endpoint is
+intentionally excluded from the RBAC dependency. Reuses the existing template
+schema -- no new tenancy tables. Only WooCommerce is supported today; adding a
+platform = a new <platform>.py + a branch in handlers.py.
+"""
+
+from fastapi import APIRouter, Request
+
+from app.api.routers.breeze_buddy.integrations.handlers import (
+    ingest_integration_webhook,
+)
+
+router = APIRouter()
+
+
+@router.post("/integrations/{platform}")
+async def ingest_integration(platform: str, request: Request):
+    """
+    Receive an order webhook for `platform`. Authenticated by the webhook
+    signature. Query params: `merchant_id` (required store identifier) and
+    optional `filterCOD=true` / `template=`.
+    """
+    return await ingest_integration_webhook(
+        platform, request, dict(request.query_params)
+    )

--- a/app/api/routers/breeze_buddy/integrations/handlers.py
+++ b/app/api/routers/breeze_buddy/integrations/handlers.py
@@ -1,0 +1,127 @@
+"""
+Handler for the e-commerce integration webhook ingress.
+
+POST /integrations/{platform} turns an external cart's order webhook into a
+Breeze Buddy lead -- building the same request nautilus sends to `push_lead` for
+Shopify:
+
+  * reseller_id  = a constant (woocommerce.RESELLER_ID) -- nautilus uses 'BB_SHOPIFY'
+  * merchant_id  = the `merchant_id` query param (a clean store identifier, like
+                   nautilus's shopDomain)
+  * template     = the `order-confirmation` name (nautilus passes the same const),
+                   resolved via get_template_by_merchant inside push_lead
+
+Only WooCommerce is supported today; adding a platform means a new
+<platform>.py + a branch here. Reuses the existing template + lead machinery;
+nothing here touches nautilus or `shops`.
+"""
+
+import json
+from typing import Dict
+
+from fastapi import HTTPException, Request, status
+
+from app.ai.voice.agents.breeze_buddy.types.models import PushLeadRequest
+from app.api.routers.breeze_buddy.integrations import woocommerce as woo
+from app.api.routers.breeze_buddy.leads.handlers import push_lead_handler
+from app.core.logger import logger
+from app.schemas import UserInfo
+from app.schemas.breeze_buddy.auth import UserRole
+from app.schemas.breeze_buddy.core import ExecutionMode
+
+# 200 ack body: the platform should treat the webhook as delivered (no retry).
+_ACK = {"status": "ok"}
+
+# Default conversation, matching nautilus (which passes template='order-confirmation').
+_DEFAULT_TEMPLATE = "order-confirmation"
+
+
+async def ingest_integration_webhook(
+    platform: str, request: Request, query_params: Dict[str, str]
+) -> Dict[str, str]:
+    """
+    Verify + ingest one order webhook for `platform`.
+
+    Query params: `merchant_id` (required store identifier), optional
+    `filterCOD=true` and `template=`.
+
+    Raises HTTPException (4xx) for auth/validation failures so the platform
+    surfaces the misconfiguration; otherwise returns a 200 ack -- including for
+    skips and processing errors -- so the platform does not retry indefinitely.
+    """
+    if platform.strip().lower() != "woocommerce":
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Unsupported platform: {platform}",
+        )
+
+    merchant_id = query_params.get("merchant_id")
+    if not merchant_id:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="merchant_id query param is required",
+        )
+
+    template_name = query_params.get("template") or _DEFAULT_TEMPLATE
+
+    # Auth: same verification we use today -- HMAC-SHA256 of the raw body against
+    # ORDER_CONFIRMATION_WEBHOOK_SECRET_KEY (merchant sets it as the webhook Secret).
+    headers = {k.lower(): v for k, v in request.headers.items()}
+    signature = headers.get(woo.SIGNATURE_HEADER, "")
+    body = await request.body()
+    if not woo.verify_woocommerce(body, signature):
+        logger.warning(f"woocommerce: invalid signature for merchant {merchant_id}")
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid signature"
+        )
+
+    # From here everything is a soft failure -> 200 ack so the platform stops retrying.
+    try:
+        payload = json.loads(body)
+    except json.JSONDecodeError:
+        logger.warning(f"woocommerce: non-JSON body for merchant {merchant_id}")
+        return _ACK
+
+    if not isinstance(payload, dict) or not woo.is_woocommerce_order(payload):
+        logger.info("woocommerce: ping/non-order payload acknowledged")
+        return _ACK
+
+    # Same eligibility gate as the Shopify flow: has phone, not cancelled, COD filter.
+    rejection = woo.woocommerce_eligible(payload, query_params)
+    if rejection:
+        logger.info(f"woocommerce: order skipped: {rejection}")
+        return _ACK
+
+    lead_payload = woo.woocommerce_to_lead_payload(payload, merchant_id)
+    order_id = str(lead_payload.get("shopify_order_id") or "")
+
+    lead_req = PushLeadRequest(
+        request_id=order_id,
+        payload=lead_payload,
+        template=template_name,
+        reseller_id=woo.RESELLER_ID,
+        merchant_id=merchant_id,
+        execution_mode=ExecutionMode.TELEPHONY,  # match nautilus's push
+    )
+
+    # System identity: the webhook signature already authenticated this request
+    # and the tenant is fixed (constant reseller + merchant_id param), so use an admin user.
+    system_user = UserInfo(
+        id="integration-webhook",
+        username="integration-webhook",
+        role=UserRole.ADMIN,
+        reseller_ids=["*"],
+        merchant_ids=["*"],
+    )
+
+    try:
+        result = await push_lead_handler(lead_req, system_user)
+        logger.info(
+            f"woocommerce: order {order_id} queued as lead "
+            f"({result.get('lead_call_tracker_id')})"
+        )
+    except Exception as e:
+        # Do not 500 back to the platform; log for investigation and ack.
+        logger.error(f"woocommerce: failed to queue order {order_id}: {e}")
+
+    return _ACK

--- a/app/api/routers/breeze_buddy/integrations/woocommerce.py
+++ b/app/api/routers/breeze_buddy/integrations/woocommerce.py
@@ -1,0 +1,150 @@
+"""
+Everything WooCommerce-specific: signature verification, order-vs-ping
+detection, the eligibility gate, and translation into the lead payload.
+
+The lead payload is built to the SAME shape nautilus already sends to
+clairvoyance for Shopify (the `order-confirmation` template's expected keys):
+customer_mobile_number, customer_name, shop_name, customer_address, total_price,
+items[{product_name, quantity}], shopify_order_id, payment_status. So the same
+template works unchanged -- we do NOT invent a new payload shape.
+
+Verification reuses the SAME secret + helper the service uses for
+order-confirmation webhooks today (ORDER_CONFIRMATION_WEBHOOK_SECRET_KEY +
+calculate_hmac_sha256).
+
+WooCommerce REST order shape:
+https://woocommerce.github.io/woocommerce-rest-api-docs/#order-properties
+"""
+
+import hmac
+from typing import Any, Dict, List, Optional
+
+from app.core.config.static import ORDER_CONFIRMATION_WEBHOOK_SECRET_KEY
+from app.core.logger import logger
+from app.core.security.sha import calculate_hmac_sha256
+from app.database.queries.breeze_buddy.blacklisted_numbers import (
+    normalize_phone_number,
+)
+
+# Constant reseller for WooCommerce leads (mirrors nautilus's 'BB_SHOPIFY').
+RESELLER_ID = "woocommerce"
+# Header WooCommerce puts its base64 HMAC-SHA256 body signature in.
+SIGNATURE_HEADER = "x-wc-webhook-signature"
+
+_COD_METHOD_IDS = {"cod", "cash on delivery"}
+_TRUE = {"1", "true", "yes", "on"}
+
+
+def verify_woocommerce(body: bytes, signature: str) -> bool:
+    """
+    WooCommerce sends `X-WC-Webhook-Signature` = base64(HMAC_SHA256(raw_body,
+    secret)) -- the same scheme as our existing order-confirmation webhook.
+    Verify constant-time against ORDER_CONFIRMATION_WEBHOOK_SECRET_KEY.
+    """
+    if not signature or not ORDER_CONFIRMATION_WEBHOOK_SECRET_KEY:
+        return False
+    try:
+        expected = calculate_hmac_sha256(
+            body.decode("utf-8"), ORDER_CONFIRMATION_WEBHOOK_SECRET_KEY
+        )
+        return hmac.compare_digest(expected, signature)
+    except Exception as e:
+        logger.warning(f"WooCommerce signature verification error: {e}")
+        return False
+
+
+def is_woocommerce_order(payload: Dict[str, Any]) -> bool:
+    """Woo posts a {webhook_id} ping with no order when a webhook is saved."""
+    return bool(payload.get("id")) and isinstance(payload.get("line_items"), list)
+
+
+def _phone(order: Dict[str, Any]) -> str:
+    """E.164 phone, matching nautilus's formatCustomerPhone (+91). Reuses the
+    existing normalizer (strips to the last 10 digits) then adds the +91 prefix;
+    robust to leading zeros / already-prefixed numbers."""
+    billing = order.get("billing") or {}
+    shipping = order.get("shipping") or {}
+    raw = billing.get("phone") or shipping.get("phone") or ""
+    digits = normalize_phone_number(raw)
+    return f"+91{digits}" if digits else ""
+
+
+def _is_cod(order: Dict[str, Any]) -> bool:
+    method = (order.get("payment_method") or "").strip().lower()
+    title = (order.get("payment_method_title") or "").strip().lower()
+    return method in _COD_METHOD_IDS or title in _COD_METHOD_IDS
+
+
+def woocommerce_eligible(
+    order: Dict[str, Any], query_params: Dict[str, str]
+) -> Optional[str]:
+    """
+    Same per-order eligibility gate nautilus applies for Shopify
+    (pickNextEligibleOrderQuery): has phone, not cancelled, COD filter. Returns
+    a rejection reason, or None if the order should become a lead.
+    """
+    if not _phone(order):
+        return "no phone number"
+    if (order.get("status") or "").strip().lower() == "cancelled":
+        return "order cancelled"
+    filter_cod = str(query_params.get("filterCOD", "")).strip().lower() in _TRUE
+    if filter_cod and not _is_cod(order):
+        return "filterCOD: order is not COD"
+    return None
+
+
+def _name(billing: Dict[str, Any]) -> str:
+    first = (billing.get("first_name") or "").strip()
+    last = (billing.get("last_name") or "").strip()
+    return " ".join(part for part in (first, last) if part)
+
+
+def _address(order: Dict[str, Any]) -> str:
+    """Flatten the shipping (fallback billing) address into a single string,
+    matching nautilus's `customer_address` (one string, not a struct)."""
+    src = order.get("shipping") or {}
+    if not any(src.get(k) for k in ("address_1", "city", "postcode")):
+        src = order.get("billing") or {}
+    parts = [
+        src.get("address_1"),
+        src.get("address_2"),
+        src.get("city"),
+        src.get("state"),
+        src.get("postcode"),
+        src.get("country"),
+    ]
+    return ", ".join(str(p).strip() for p in parts if p and str(p).strip())
+
+
+def _total(order: Dict[str, Any]) -> float:
+    total = order.get("total")
+    if total is None:
+        return 0.0
+    try:
+        return float(total)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def woocommerce_to_lead_payload(
+    order: Dict[str, Any], shop_name: str
+) -> Dict[str, Any]:
+    """Translate a WooCommerce order into the nautilus order-confirmation payload."""
+    raw_items: List[Dict[str, Any]] = order.get("line_items") or []
+    items = [
+        {
+            "product_name": item.get("name") or "",
+            "quantity": int(item.get("quantity") or 1),
+        }
+        for item in raw_items
+    ]
+    return {
+        "customer_mobile_number": _phone(order),
+        "customer_name": _name(order.get("billing") or {}) or "Customer",
+        "shop_name": shop_name,
+        "customer_address": _address(order),
+        "total_price": _total(order),
+        "items": items,
+        "shopify_order_id": str(order.get("id") or order.get("number") or ""),
+        "payment_status": "COD" if _is_cod(order) else "PREPAID",
+    }


### PR DESCRIPTION
 - Add POST /agent/voice/breeze-buddy/integrations/{platform}: verify signature, translate the order, create a lead via existing push_lead.
 - Mirrors nautilus's Shopify push (reseller const, merchant_id param, order-confirmation, TELEPHONY, same payload keys); COD filter via ?filterCOD=true.
 - Reuses ORDER_CONFIRMATION_WEBHOOK_SECRET_KEY + calculate_hmac_sha256; no new secret, no new table, no migration, nautilus/shops untouched
 - 
<img width="1719" height="869" alt="Screenshot 2026-07-03 at 5 43 34 PM" src="https://github.com/user-attachments/assets/a813c184-aa30-41ad-ac06-b01b0bdd2b4d" />
<img width="1715" height="297" alt="Screenshot 2026-07-03 at 5 44 13 PM" src="https://github.com/user-attachments/assets/7648abf2-1f58-4889-a7ba-e7739e56eccc" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new integration endpoint for incoming webhook orders from an external commerce platform.
  * Enabled automatic processing of eligible order events into lead creation, with support for order confirmations and cart/order webhooks.
  * Added order filtering and validation so only complete, relevant orders are processed.

* **Bug Fixes**
  * Improved handling of invalid, incomplete, or non-order webhook payloads so they are acknowledged without retry loops.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->