### PR TITLE
feat(meta-onboarding): add WhatsApp credentials storage and DB access layer with Connector Architecture base

### DIFF
--- a/app/database/accessor/__init__.py
+++ b/app/database/accessor/__init__.py
@@ -67,6 +67,24 @@ from .breeze_buddy.template import (
     get_template_by_id,
     get_template_in_scope,
 )
+from .breeze_buddy.connectors import (
+    disconnect_connector,
+    get_active_connector,
+    get_active_connector_credential,
+    get_connector,
+    get_connector_metrics,
+    increment_connector_metric,
+    mark_connector_error,
+    sync_connector_connection,
+)
+from .breeze_buddy.whatsapp import (
+    disconnect_merchant_whatsapp_connector,
+    get_active_merchant_whatsapp_connector,
+    get_merchant_whatsapp_connector,
+    get_whatsapp_credential_secret,
+    increment_merchant_whatsapp_message_counts,
+    sync_merchant_whatsapp_connection,
+)
 
 __all__ = [
     "is_number_blacklisted",
@@ -121,4 +139,18 @@ __all__ = [
     "get_credentials_as_template_vars",
     "update_credential",
     "delete_credential",
+    "get_connector",
+    "get_active_connector",
+    "get_active_connector_credential",
+    "sync_connector_connection",
+    "disconnect_connector",
+    "mark_connector_error",
+    "increment_connector_metric",
+    "get_connector_metrics",
+    "get_merchant_whatsapp_connector",
+    "get_active_merchant_whatsapp_connector",
+    "disconnect_merchant_whatsapp_connector",
+    "sync_merchant_whatsapp_connection",
+    "get_whatsapp_credential_secret",
+    "increment_merchant_whatsapp_message_counts",
 ]

--- a/app/database/accessor/breeze_buddy/connectors.py
+++ b/app/database/accessor/breeze_buddy/connectors.py
@@ -1,0 +1,204 @@
+"""Async accessors for generic merchant connectors and daily metrics."""
+
+from datetime import date, datetime, timezone
+from typing import List, Optional
+from uuid import uuid4
+
+from app.core.logger import logger
+from app.database import get_db_connection
+from app.database.decoder.breeze_buddy.connectors import (
+    decode_connector,
+    decode_connector_metric,
+)
+from app.database.decoder.breeze_buddy.credentials import decode_credential
+from app.database.queries import run_parameterized_query
+from app.database.queries.breeze_buddy.connectors import (
+    disconnect_connector_query,
+    get_active_connector_credential_query,
+    get_connector_metrics_query,
+    get_connector_query,
+    increment_connector_metric_query,
+    mark_connector_error_query,
+    upsert_connector_credential_query,
+    upsert_connector_query,
+)
+from app.schemas import Credential
+from app.schemas.breeze_buddy.connectors import (
+    Connector,
+    ConnectorMetric,
+    ConnectorMetricIncrement,
+    UpsertConnectorConnection,
+)
+
+
+async def get_connector(
+    reseller_id: str, merchant_id: str, connector: str
+) -> Optional[Connector]:
+    try:
+        query, values = get_connector_query(reseller_id, merchant_id, connector)
+        result = await run_parameterized_query(query, values)
+        return decode_connector(result[0]) if result else None
+    except Exception as e:
+        logger.error(
+            f"Error fetching connector {connector} for reseller={reseller_id} "
+            f"merchant={merchant_id}: {e}"
+        )
+        return None
+
+
+async def get_active_connector(
+    reseller_id: str, merchant_id: str, connector: str
+) -> Optional[Connector]:
+    try:
+        query, values = get_connector_query(
+            reseller_id, merchant_id, connector, active_only=True
+        )
+        result = await run_parameterized_query(query, values)
+        return decode_connector(result[0]) if result else None
+    except Exception as e:
+        logger.error(
+            f"Error fetching active connector {connector} for reseller={reseller_id} "
+            f"merchant={merchant_id}: {e}"
+        )
+        return None
+
+
+async def sync_connector_connection(
+    connection: UpsertConnectorConnection,
+) -> Optional[Connector]:
+    """Atomically create/update a connector credential and connector state."""
+    try:
+        credential_query, credential_values = upsert_connector_credential_query(
+            credential_id=str(uuid4()),
+            reseller_id=connection.reseller_id,
+            merchant_id=connection.merchant_id,
+            connector=connection.connector,
+            value=connection.credential_value,
+            is_encrypted=connection.credential_is_encrypted,
+            description=connection.credential_description,
+        )
+
+        async for conn in get_db_connection():
+            async with conn.transaction():
+                credential_rows = await conn.fetch(credential_query, *credential_values)
+                if not credential_rows:
+                    raise RuntimeError("Connector credential upsert returned no row")
+
+                connector_query, connector_values = upsert_connector_query(
+                    reseller_id=connection.reseller_id,
+                    merchant_id=connection.merchant_id,
+                    connector=connection.connector,
+                    credential_id=str(credential_rows[0]["id"]),
+                    metadata=connection.metadata,
+                )
+                connector_rows = await conn.fetch(connector_query, *connector_values)
+
+            if connector_rows:
+                return decode_connector(connector_rows[0])
+            return None
+    except Exception as e:
+        logger.error(
+            f"Error syncing connector {connection.connector} for "
+            f"reseller={connection.reseller_id} merchant={connection.merchant_id}: {e}",
+            exc_info=True,
+        )
+        return None
+
+
+async def disconnect_connector(
+    reseller_id: str, merchant_id: str, connector: str
+) -> bool:
+    try:
+        query, values = disconnect_connector_query(reseller_id, merchant_id, connector)
+        return bool(await run_parameterized_query(query, values))
+    except Exception as e:
+        logger.error(
+            f"Error disconnecting connector {connector} for reseller={reseller_id} "
+            f"merchant={merchant_id}: {e}"
+        )
+        return False
+
+
+async def mark_connector_error(
+    reseller_id: str, merchant_id: str, connector: str
+) -> Optional[Connector]:
+    try:
+        query, values = mark_connector_error_query(reseller_id, merchant_id, connector)
+        result = await run_parameterized_query(query, values)
+        return decode_connector(result[0]) if result else None
+    except Exception as e:
+        logger.error(
+            f"Error marking connector {connector} as error for "
+            f"reseller={reseller_id} merchant={merchant_id}: {e}"
+        )
+        return None
+
+
+async def get_active_connector_credential(
+    *, reseller_id: str, merchant_id: str, connector: str, credential_id: str
+) -> Optional[Credential]:
+    """Fetch one scoped, non-template-exposable connector credential."""
+    try:
+        query, values = get_active_connector_credential_query(
+            reseller_id=reseller_id,
+            merchant_id=merchant_id,
+            connector=connector,
+            credential_id=credential_id,
+        )
+        result = await run_parameterized_query(query, values)
+        return decode_credential(result[0], mask=False) if result else None
+    except Exception as e:
+        logger.error(
+            f"Error fetching connector credential for {connector}, "
+            f"reseller={reseller_id} merchant={merchant_id}: {e}"
+        )
+        return None
+
+
+async def increment_connector_metric(
+    metric: ConnectorMetricIncrement,
+) -> Optional[ConnectorMetric]:
+    if metric.increment == 0:
+        return None
+    try:
+        query, values = increment_connector_metric_query(
+            connector_id=metric.connector_id,
+            reseller_id=metric.reseller_id,
+            merchant_id=metric.merchant_id,
+            metric_name=metric.metric_name,
+            increment=metric.increment,
+            metric_date=metric.metric_date or datetime.now(timezone.utc).date(),
+        )
+        result = await run_parameterized_query(query, values)
+        return decode_connector_metric(result[0]) if result else None
+    except Exception as e:
+        logger.error(
+            f"Error incrementing connector metric {metric.metric_name} for "
+            f"connector={metric.connector_id}: {e}"
+        )
+        return None
+
+
+async def get_connector_metrics(
+    *,
+    connector_id: str,
+    reseller_id: str,
+    merchant_id: str,
+    start_date: date,
+    end_date: date,
+    metric_name: Optional[str] = None,
+) -> List[ConnectorMetric]:
+    try:
+        query, values = get_connector_metrics_query(
+            connector_id=connector_id,
+            reseller_id=reseller_id,
+            merchant_id=merchant_id,
+            start_date=start_date,
+            end_date=end_date,
+            metric_name=metric_name,
+        )
+        result = await run_parameterized_query(query, values)
+        return [decode_connector_metric(row) for row in result]
+    except Exception as e:
+        logger.error(f"Error fetching connector metrics for {connector_id}: {e}")
+        return []

--- a/app/database/accessor/breeze_buddy/credentials.py
+++ b/app/database/accessor/breeze_buddy/credentials.py
@@ -24,6 +24,8 @@ from app.database.queries.breeze_buddy.credentials import (
 from app.schemas import Credential, CredentialType
 from app.services.encryption import encrypt_credential
 
+_CONNECTOR_CREDENTIAL_PREFIX = "connector:"
+
 
 def _merge_credential_value(
     incoming: Dict[str, Any],
@@ -95,11 +97,16 @@ async def create_credential(
     credential_type: CredentialType,
     value: Dict[str, Any],
     description: Optional[str] = None,
+    merchant_id: Optional[str] = None,
 ) -> Optional[Credential]:
     """Create a new credential with optional KMS encryption."""
-    logger.info(f"Creating credential '{name}' for merchant: {reseller_id or 'GLOBAL'}")
+    logger.info(f"Creating credential '{name}' for reseller: {reseller_id or 'GLOBAL'}")
 
     try:
+        if name.startswith(_CONNECTOR_CREDENTIAL_PREFIX):
+            logger.error("Connector credential names are reserved for connector sync")
+            return None
+
         # Validate value structure matches credential_type
         _validate_credential_value(credential_type, value)
 
@@ -113,6 +120,8 @@ async def create_credential(
             value=stored_value,
             is_encrypted=is_encrypted,
             description=description,
+            merchant_id=merchant_id,
+            template_exposable=True,
         )
 
         result = await run_parameterized_query(query_text, values)
@@ -205,6 +214,10 @@ async def update_credential(
     logger.info(f"Updating credential {credential_id}")
 
     try:
+        if name and name.startswith(_CONNECTOR_CREDENTIAL_PREFIX):
+            logger.error("Connector credential names are reserved for connector sync")
+            return None
+
         stored_value = None
         is_encrypted = None
 

--- a/app/database/accessor/breeze_buddy/whatsapp.py
+++ b/app/database/accessor/breeze_buddy/whatsapp.py
@@ -1,0 +1,142 @@
+"""WhatsApp helpers backed by the generic connector database layer."""
+
+import json
+from datetime import datetime, timezone
+from typing import Optional
+
+from app.database.accessor.breeze_buddy.connectors import (
+    disconnect_connector,
+    get_active_connector,
+    get_active_connector_credential,
+    get_connector,
+    increment_connector_metric,
+    sync_connector_connection,
+)
+from app.schemas.breeze_buddy.connectors import (
+    Connector,
+    ConnectorMetricIncrement,
+    UpsertConnectorConnection,
+)
+from app.schemas.breeze_buddy.whatsapp import (
+    SyncMerchantWhatsAppConnection,
+    WhatsAppCredentialSecret,
+)
+
+_WHATSAPP_CONNECTOR = "whatsapp"
+
+
+def _whatsapp_metadata(connection: SyncMerchantWhatsAppConnection) -> dict:
+    metadata = dict(connection.metadata)
+    metadata.update(
+        {
+            "waba_id": connection.waba_id,
+            "phone_number_id": connection.phone_number_id,
+        }
+    )
+    if connection.template_name is not None:
+        metadata["template_name"] = connection.template_name
+    if connection.template_status is not None:
+        metadata["template_status"] = connection.template_status
+    return metadata
+
+
+async def sync_merchant_whatsapp_connection(
+    connection: SyncMerchantWhatsAppConnection,
+) -> Optional[Connector]:
+    """Persist a Nautilus WhatsApp connection through the generic connector path."""
+    secret = WhatsAppCredentialSecret(
+        encrypted_access_token=connection.encrypted_access_token,
+        token_encryption_scheme=connection.token_encryption_scheme,
+    )
+    return await sync_connector_connection(
+        UpsertConnectorConnection(
+            reseller_id=connection.reseller_id,
+            merchant_id=connection.merchant_id,
+            connector=_WHATSAPP_CONNECTOR,
+            credential_value=json.dumps(secret.model_dump()),
+            credential_is_encrypted=False,
+            credential_description="Nautilus-encrypted Meta WhatsApp access token",
+            metadata=_whatsapp_metadata(connection),
+        )
+    )
+
+
+async def get_merchant_whatsapp_connector(
+    reseller_id: str, merchant_id: str
+) -> Optional[Connector]:
+    return await get_connector(reseller_id, merchant_id, _WHATSAPP_CONNECTOR)
+
+
+async def get_active_merchant_whatsapp_connector(
+    reseller_id: str, merchant_id: str
+) -> Optional[Connector]:
+    return await get_active_connector(reseller_id, merchant_id, _WHATSAPP_CONNECTOR)
+
+
+async def disconnect_merchant_whatsapp_connector(
+    reseller_id: str, merchant_id: str
+) -> bool:
+    return await disconnect_connector(reseller_id, merchant_id, _WHATSAPP_CONNECTOR)
+
+
+async def get_whatsapp_credential_secret(
+    *, reseller_id: str, merchant_id: str, credential_id: str
+) -> Optional[WhatsAppCredentialSecret]:
+    credential = await get_active_connector_credential(
+        reseller_id=reseller_id,
+        merchant_id=merchant_id,
+        connector=_WHATSAPP_CONNECTOR,
+        credential_id=credential_id,
+    )
+    if not credential or not credential.value:
+        return None
+    try:
+        return WhatsAppCredentialSecret(**credential.value)
+    except Exception:
+        return None
+
+
+async def increment_merchant_whatsapp_message_counts(
+    reseller_id: str,
+    merchant_id: str,
+    *,
+    sent_increment: int = 0,
+    failed_increment: int = 0,
+) -> bool:
+    """Record WhatsApp message outcomes as generic daily connector metrics."""
+    if sent_increment < 0 or failed_increment < 0:
+        return False
+    if sent_increment == 0 and failed_increment == 0:
+        return True
+
+    connector = await get_active_merchant_whatsapp_connector(reseller_id, merchant_id)
+    if not connector:
+        return False
+
+    metric_date = datetime.now(timezone.utc).date()
+    succeeded = True
+    if sent_increment:
+        sent_metric = await increment_connector_metric(
+            ConnectorMetricIncrement(
+                connector_id=connector.id,
+                reseller_id=reseller_id,
+                merchant_id=merchant_id,
+                metric_name="messages_sent",
+                increment=sent_increment,
+                metric_date=metric_date,
+            )
+        )
+        succeeded = sent_metric is not None
+    if failed_increment:
+        failed_metric = await increment_connector_metric(
+            ConnectorMetricIncrement(
+                connector_id=connector.id,
+                reseller_id=reseller_id,
+                merchant_id=merchant_id,
+                metric_name="messages_failed",
+                increment=failed_increment,
+                metric_date=metric_date,
+            )
+        )
+        succeeded = succeeded and failed_metric is not None
+    return succeeded

--- a/app/database/decoder/breeze_buddy/connectors.py
+++ b/app/database/decoder/breeze_buddy/connectors.py
@@ -1,0 +1,54 @@
+"""Row decoders for connector records."""
+
+import json
+from typing import Any, Dict
+
+from app.core.logger import logger
+from app.schemas.breeze_buddy.connectors import (
+    Connector,
+    ConnectorMetric,
+    ConnectorStatus,
+)
+
+
+def _decode_metadata(value: Any) -> Dict[str, Any]:
+    if not value:
+        return {}
+    if isinstance(value, str):
+        try:
+            value = json.loads(value)
+        except json.JSONDecodeError:
+            logger.error("Failed to decode connector metadata JSON")
+            return {}
+    return dict(value) if isinstance(value, dict) else {}
+
+
+def decode_connector(row) -> Connector:
+    return Connector(
+        id=str(row["id"]),
+        reseller_id=row["reseller_id"],
+        merchant_id=row["merchant_id"],
+        connector=row["connector"],
+        credential_id=str(row["credential_id"]) if row.get("credential_id") else None,
+        status=ConnectorStatus(row["status"]),
+        connected_at=row.get("connected_at"),
+        disconnected_at=row.get("disconnected_at"),
+        last_sync_at=row.get("last_sync_at"),
+        metadata=_decode_metadata(row.get("metadata")),
+        created_at=row.get("created_at"),
+        updated_at=row.get("updated_at"),
+    )
+
+
+def decode_connector_metric(row) -> ConnectorMetric:
+    return ConnectorMetric(
+        id=str(row["id"]),
+        connector_id=str(row["connector_id"]),
+        merchant_id=row["merchant_id"],
+        reseller_id=row["reseller_id"],
+        metric_date=row["metric_date"],
+        metric_name=row["metric_name"],
+        value=row["value"],
+        created_at=row.get("created_at"),
+        updated_at=row.get("updated_at"),
+    )

--- a/app/database/decoder/breeze_buddy/credentials.py
+++ b/app/database/decoder/breeze_buddy/credentials.py
@@ -48,10 +48,12 @@ def decode_credential(
     return Credential(
         id=str(row["id"]),
         reseller_id=row["reseller_id"],
+        merchant_id=row.get("merchant_id"),
         name=row["name"],
         credential_type=CredentialType(row["credential_type"]),
         value=_mask_credential_value(real_value) if mask else real_value,
         is_encrypted=row["is_encrypted"],
+        template_exposable=row.get("template_exposable", True),
         description=row["description"],
         is_active=row["is_active"],
         created_at=row["created_at"],

--- a/app/database/migrations/034_whatsapp_credentials_foundation.sql
+++ b/app/database/migrations/034_whatsapp_credentials_foundation.sql
@@ -1,0 +1,67 @@
+-- Migration 034: Merchant connector foundation
+--
+-- Adds merchant-scoped connector credentials, generic connector state, and
+-- daily connector metrics. This migration is unapplied with this foundation
+-- branch, so it intentionally defines the final generic schema directly.
+
+BEGIN;
+
+ALTER TABLE credentials
+    ADD COLUMN IF NOT EXISTS merchant_id VARCHAR(255);
+
+ALTER TABLE credentials
+    ADD COLUMN IF NOT EXISTS template_exposable BOOLEAN NOT NULL DEFAULT TRUE;
+
+CREATE INDEX IF NOT EXISTS idx_credentials_reseller_merchant
+    ON credentials(reseller_id, merchant_id);
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_credentials_active_connector_secret
+    ON credentials(reseller_id, merchant_id, name)
+    WHERE is_active = TRUE
+      AND template_exposable = FALSE
+      AND reseller_id IS NOT NULL
+      AND merchant_id IS NOT NULL;
+
+CREATE TABLE IF NOT EXISTS connectors (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    reseller_id VARCHAR(255) NOT NULL,
+    merchant_id VARCHAR(255) NOT NULL,
+    connector VARCHAR(255) NOT NULL,
+    credential_id UUID REFERENCES credentials(id) ON DELETE SET NULL,
+    status VARCHAR(32) NOT NULL DEFAULT 'connected'
+        CHECK (status IN ('connected', 'disconnected', 'error')),
+    connected_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    disconnected_at TIMESTAMP WITH TIME ZONE,
+    last_sync_at TIMESTAMP WITH TIME ZONE,
+    -- Static provider configuration only; counters belong in connector_metrics.
+    metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    CONSTRAINT uq_connectors_reseller_merchant_connector
+        UNIQUE (reseller_id, merchant_id, connector)
+);
+
+CREATE INDEX IF NOT EXISTS idx_connectors_merchant_connector
+    ON connectors (merchant_id, connector);
+
+CREATE INDEX IF NOT EXISTS idx_connectors_credential_id
+    ON connectors (credential_id);
+
+CREATE TABLE IF NOT EXISTS connector_metrics (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    connector_id UUID NOT NULL REFERENCES connectors(id) ON DELETE CASCADE,
+    merchant_id VARCHAR(255) NOT NULL,
+    reseller_id VARCHAR(255) NOT NULL,
+    metric_date DATE NOT NULL,
+    metric_name VARCHAR(255) NOT NULL,
+    value BIGINT NOT NULL DEFAULT 0 CHECK (value >= 0),
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    CONSTRAINT unique_daily_connector_metric
+        UNIQUE (connector_id, metric_date, metric_name)
+);
+
+CREATE INDEX IF NOT EXISTS idx_connector_metrics_query
+    ON connector_metrics (merchant_id, connector_id, metric_date);
+
+COMMIT;

--- a/app/database/queries/breeze_buddy/connectors.py
+++ b/app/database/queries/breeze_buddy/connectors.py
@@ -1,0 +1,232 @@
+"""SQL builders for generic merchant connectors and their metrics."""
+
+import json
+from datetime import date, datetime, timezone
+from typing import Any, Dict, List, Optional, Tuple
+
+CONNECTORS_TABLE = "connectors"
+CONNECTOR_METRICS_TABLE = "connector_metrics"
+CONNECTOR_CREDENTIAL_PREFIX = "connector:"
+
+_CONNECTOR_COLUMNS = (
+    "id, reseller_id, merchant_id, connector, credential_id, status, connected_at, "
+    "disconnected_at, last_sync_at, metadata, created_at, updated_at"
+)
+_METRIC_COLUMNS = (
+    "id, connector_id, merchant_id, reseller_id, metric_date, metric_name, value, "
+    "created_at, updated_at"
+)
+
+
+def connector_credential_name(connector: str) -> str:
+    return f"{CONNECTOR_CREDENTIAL_PREFIX}{connector}"
+
+
+def upsert_connector_credential_query(
+    *,
+    credential_id: str,
+    reseller_id: str,
+    merchant_id: str,
+    connector: str,
+    value: str,
+    is_encrypted: bool,
+    description: Optional[str],
+) -> Tuple[str, List[Any]]:
+    now = datetime.now(timezone.utc)
+    query = """
+        INSERT INTO credentials
+            (id, reseller_id, merchant_id, name, credential_type, value,
+             is_encrypted, description, is_active, template_exposable,
+             created_at, updated_at)
+        VALUES ($1::uuid, $2, $3, $4, 'custom', $5, $6, $7, TRUE, FALSE, $8, $8)
+        ON CONFLICT (reseller_id, merchant_id, name)
+        WHERE is_active = TRUE
+          AND template_exposable = FALSE
+          AND reseller_id IS NOT NULL
+          AND merchant_id IS NOT NULL
+        DO UPDATE SET
+            value = EXCLUDED.value,
+            is_encrypted = EXCLUDED.is_encrypted,
+            description = EXCLUDED.description,
+            updated_at = EXCLUDED.updated_at
+        RETURNING *;
+    """
+    return (
+        query,
+        [
+            credential_id,
+            reseller_id,
+            merchant_id,
+            connector_credential_name(connector),
+            value,
+            is_encrypted,
+            description,
+            now,
+        ],
+    )
+
+
+def get_active_connector_credential_query(
+    *, reseller_id: str, merchant_id: str, connector: str, credential_id: str
+) -> Tuple[str, List[Any]]:
+    query = """
+        SELECT * FROM credentials
+        WHERE id = $1::uuid
+          AND reseller_id = $2
+          AND merchant_id = $3
+          AND name = $4
+          AND is_active = TRUE
+          AND template_exposable = FALSE;
+    """
+    return query, [
+        credential_id,
+        reseller_id,
+        merchant_id,
+        connector_credential_name(connector),
+    ]
+
+
+def upsert_connector_query(
+    *,
+    reseller_id: str,
+    merchant_id: str,
+    connector: str,
+    credential_id: str,
+    metadata: Dict[str, Any],
+) -> Tuple[str, List[Any]]:
+    now = datetime.now(timezone.utc)
+    query = f"""
+        INSERT INTO {CONNECTORS_TABLE}
+            (reseller_id, merchant_id, connector, credential_id, status,
+             connected_at, disconnected_at, last_sync_at, metadata, created_at,
+             updated_at)
+        VALUES ($1, $2, $3, $4::uuid, 'connected', $5, NULL, $5, $6::jsonb, $5, $5)
+        ON CONFLICT (reseller_id, merchant_id, connector)
+        DO UPDATE SET
+            credential_id = EXCLUDED.credential_id,
+            status = 'connected',
+            connected_at = CASE
+                WHEN {CONNECTORS_TABLE}.status IN ('disconnected', 'error')
+                THEN EXCLUDED.connected_at
+                ELSE {CONNECTORS_TABLE}.connected_at
+            END,
+            disconnected_at = NULL,
+            last_sync_at = EXCLUDED.last_sync_at,
+            metadata = EXCLUDED.metadata,
+            updated_at = EXCLUDED.updated_at
+        RETURNING {_CONNECTOR_COLUMNS};
+    """
+    return query, [
+        reseller_id,
+        merchant_id,
+        connector,
+        credential_id,
+        now,
+        json.dumps(metadata or {}),
+    ]
+
+
+def get_connector_query(
+    reseller_id: str, merchant_id: str, connector: str, *, active_only: bool = False
+) -> Tuple[str, List[Any]]:
+    status_filter = "AND status = 'connected'" if active_only else ""
+    query = f"""
+        SELECT {_CONNECTOR_COLUMNS}
+        FROM {CONNECTORS_TABLE}
+        WHERE reseller_id = $1 AND merchant_id = $2 AND connector = $3
+        {status_filter};
+    """
+    return query, [reseller_id, merchant_id, connector]
+
+
+def disconnect_connector_query(
+    reseller_id: str, merchant_id: str, connector: str
+) -> Tuple[str, List[Any]]:
+    now = datetime.now(timezone.utc)
+    query = f"""
+        WITH disconnected_connector AS (
+            UPDATE {CONNECTORS_TABLE}
+            SET status = 'disconnected', disconnected_at = $4, updated_at = $4
+            WHERE reseller_id = $1 AND merchant_id = $2 AND connector = $3
+            RETURNING credential_id
+        ), deactivated_credential AS (
+            UPDATE credentials c
+            SET is_active = FALSE, updated_at = $4
+            FROM disconnected_connector dc
+            WHERE c.id = dc.credential_id
+            RETURNING c.id
+        )
+        SELECT credential_id FROM disconnected_connector;
+    """
+    return query, [reseller_id, merchant_id, connector, now]
+
+
+def mark_connector_error_query(
+    reseller_id: str, merchant_id: str, connector: str
+) -> Tuple[str, List[Any]]:
+    now = datetime.now(timezone.utc)
+    query = f"""
+        UPDATE {CONNECTORS_TABLE}
+        SET status = 'error', updated_at = $4
+        WHERE reseller_id = $1 AND merchant_id = $2 AND connector = $3
+        RETURNING {_CONNECTOR_COLUMNS};
+    """
+    return query, [reseller_id, merchant_id, connector, now]
+
+
+def increment_connector_metric_query(
+    *,
+    connector_id: str,
+    reseller_id: str,
+    merchant_id: str,
+    metric_name: str,
+    increment: int,
+    metric_date: date,
+) -> Tuple[str, List[Any]]:
+    now = datetime.now(timezone.utc)
+    query = f"""
+        INSERT INTO {CONNECTOR_METRICS_TABLE}
+            (connector_id, reseller_id, merchant_id, metric_date, metric_name,
+             value, created_at, updated_at)
+        VALUES ($1::uuid, $2, $3, $4, $5, $6, $7, $7)
+        ON CONFLICT (connector_id, metric_date, metric_name)
+        DO UPDATE SET value = {CONNECTOR_METRICS_TABLE}.value + EXCLUDED.value,
+                      updated_at = EXCLUDED.updated_at
+        RETURNING {_METRIC_COLUMNS};
+    """
+    return query, [
+        connector_id,
+        reseller_id,
+        merchant_id,
+        metric_date,
+        metric_name,
+        increment,
+        now,
+    ]
+
+
+def get_connector_metrics_query(
+    *,
+    connector_id: str,
+    reseller_id: str,
+    merchant_id: str,
+    start_date: date,
+    end_date: date,
+    metric_name: Optional[str] = None,
+) -> Tuple[str, List[Any]]:
+    values: List[Any] = [connector_id, reseller_id, merchant_id, start_date, end_date]
+    metric_filter = ""
+    if metric_name:
+        metric_filter = "AND metric_name = $6"
+        values.append(metric_name)
+    query = f"""
+        SELECT {_METRIC_COLUMNS}
+        FROM {CONNECTOR_METRICS_TABLE}
+        WHERE connector_id = $1::uuid
+          AND reseller_id = $2
+          AND merchant_id = $3
+          AND metric_date BETWEEN $4 AND $5
+          {metric_filter}
+        ORDER BY metric_date ASC, metric_name ASC;
+    """
+    return query, values

--- a/app/database/queries/breeze_buddy/credentials.py
+++ b/app/database/queries/breeze_buddy/credentials.py
@@ -16,23 +16,28 @@ def insert_credential_query(
     value: str,
     is_encrypted: bool,
     description: Optional[str],
+    merchant_id: Optional[str] = None,
+    template_exposable: bool = True,
 ) -> Tuple[str, List[Any]]:
     """Generate query to insert a credential record."""
     text = f"""
         INSERT INTO "{CREDENTIALS_TABLE}"
-        ("id", "reseller_id", "name", "credential_type", "value",
-         "is_encrypted", "description", "is_active", "created_at", "updated_at")
-        VALUES ($1, $2, $3, $4, $5, $6, $7, TRUE, $8, $9)
+        ("id", "reseller_id", "merchant_id", "name", "credential_type", "value",
+         "is_encrypted", "description", "is_active", "template_exposable",
+         "created_at", "updated_at")
+        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, TRUE, $9, $10, $11)
         RETURNING *;
     """
     values = [
         id,
         reseller_id,
+        merchant_id,
         name,
         credential_type,
         value,
         is_encrypted,
         description,
+        template_exposable,
         datetime.now(),
         datetime.now(),
     ]
@@ -41,7 +46,11 @@ def insert_credential_query(
 
 def get_credential_by_id_query(credential_id: str) -> Tuple[str, List[Any]]:
     """Generate query to get a credential by ID."""
-    text = f'SELECT * FROM "{CREDENTIALS_TABLE}" WHERE "id" = $1;'
+    text = f"""
+        SELECT * FROM "{CREDENTIALS_TABLE}"
+        WHERE "id" = $1
+          AND "template_exposable" = TRUE;
+    """
     return text, [credential_id]
 
 
@@ -58,13 +67,16 @@ def get_credentials_by_merchant_query(
             SELECT * FROM "{CREDENTIALS_TABLE}"
             WHERE ("reseller_id" = $1 OR "reseller_id" IS NULL)
             AND "is_active" = TRUE
+            AND "template_exposable" = TRUE
             ORDER BY "reseller_id" NULLS FIRST, "name" ASC;
         """
         return text, [reseller_id]
     else:
         text = f"""
             SELECT * FROM "{CREDENTIALS_TABLE}"
-            WHERE "reseller_id" IS NULL AND "is_active" = TRUE
+            WHERE "reseller_id" IS NULL
+            AND "is_active" = TRUE
+            AND "template_exposable" = TRUE
             ORDER BY "name" ASC;
         """
         return text, []
@@ -72,8 +84,25 @@ def get_credentials_by_merchant_query(
 
 def get_all_credentials_query() -> Tuple[str, List[Any]]:
     """Generate query to get all credentials."""
-    text = f'SELECT * FROM "{CREDENTIALS_TABLE}" where "is_active" = TRUE ORDER BY "reseller_id" NULLS FIRST, "name" ASC;'
+    text = f"""
+        SELECT * FROM "{CREDENTIALS_TABLE}"
+        WHERE "is_active" = TRUE
+          AND "template_exposable" = TRUE
+        ORDER BY "reseller_id" NULLS FIRST, "name" ASC;
+    """
     return text, []
+
+
+def deactivate_credential_query(credential_id: str) -> Tuple[str, List[Any]]:
+    """Generate query to deactivate a credential by ID."""
+    text = f"""
+        UPDATE "{CREDENTIALS_TABLE}"
+        SET "is_active" = FALSE,
+            "updated_at" = $2
+        WHERE "id" = $1
+        RETURNING *;
+    """
+    return text, [credential_id, datetime.now()]
 
 
 def update_credential_query(
@@ -139,5 +168,10 @@ def update_credential_query(
 
 def delete_credential_query(credential_id: str) -> Tuple[str, List[Any]]:
     """Generate query to delete a credential by ID."""
-    text = f'DELETE FROM "{CREDENTIALS_TABLE}" WHERE "id" = $1 RETURNING *;'
+    text = f"""
+        DELETE FROM "{CREDENTIALS_TABLE}"
+        WHERE "id" = $1
+          AND "template_exposable" = TRUE
+        RETURNING *;
+    """
     return text, [credential_id]

--- a/app/schemas/__init__.py
+++ b/app/schemas/__init__.py
@@ -80,6 +80,18 @@ from app.schemas.breeze_buddy.users import (
     UserCreate,
     UserUpdate,
 )
+from app.schemas.breeze_buddy.whatsapp import (
+    WHATSAPP_SYNC_TOKEN_ENCRYPTION_SCHEME,
+    SyncMerchantWhatsAppConnection,
+    WhatsAppCredentialSecret,
+)
+from app.schemas.breeze_buddy.connectors import (
+    Connector,
+    ConnectorMetric,
+    ConnectorMetricIncrement,
+    ConnectorStatus,
+    UpsertConnectorConnection,
+)
 from app.schemas.feature_flags import (
     FeatureFlagDeleteResponse,
     FeatureFlagResponse,
@@ -146,6 +158,16 @@ __all__ = [
     "Credential",
     "CredentialType",
     "UpdateCredentialRequest",
+    # Connectors
+    "Connector",
+    "ConnectorMetric",
+    "ConnectorMetricIncrement",
+    "ConnectorStatus",
+    "UpsertConnectorConnection",
+    # WhatsApp
+    "SyncMerchantWhatsAppConnection",
+    "WhatsAppCredentialSecret",
+    "WHATSAPP_SYNC_TOKEN_ENCRYPTION_SCHEME",
     # Connection
     "BreezeBuddyDailyConnectRequest",
     # User Management

--- a/app/schemas/breeze_buddy/__init__.py
+++ b/app/schemas/breeze_buddy/__init__.py
@@ -58,6 +58,18 @@ from app.schemas.breeze_buddy.users import (
     UserResponse,
     UserUpdate as UserAccountUpdate,
 )
+from app.schemas.breeze_buddy.whatsapp import (
+    WHATSAPP_SYNC_TOKEN_ENCRYPTION_SCHEME,
+    SyncMerchantWhatsAppConnection,
+    WhatsAppCredentialSecret,
+)
+from app.schemas.breeze_buddy.connectors import (
+    Connector,
+    ConnectorMetric,
+    ConnectorMetricIncrement,
+    ConnectorStatus,
+    UpsertConnectorConnection,
+)
 
 __all__ = [
     # Auth
@@ -112,4 +124,14 @@ __all__ = [
     "UserListResponse",
     "UserResponse",
     "DeleteUserResponse",
+    # Connectors
+    "Connector",
+    "ConnectorMetric",
+    "ConnectorMetricIncrement",
+    "ConnectorStatus",
+    "UpsertConnectorConnection",
+    # WhatsApp
+    "SyncMerchantWhatsAppConnection",
+    "WhatsAppCredentialSecret",
+    "WHATSAPP_SYNC_TOKEN_ENCRYPTION_SCHEME",
 ]

--- a/app/schemas/breeze_buddy/connectors.py
+++ b/app/schemas/breeze_buddy/connectors.py
@@ -1,0 +1,85 @@
+"""Pydantic schemas for merchant connector state and metrics."""
+
+from datetime import date, datetime
+from enum import Enum
+import re
+from typing import Any, Dict, Optional
+
+from pydantic import BaseModel, Field, field_validator
+
+
+class ConnectorStatus(str, Enum):
+    CONNECTED = "connected"
+    DISCONNECTED = "disconnected"
+    ERROR = "error"
+
+
+def _validate_connector_name(value: str) -> str:
+    normalized = value.strip().lower()
+    if not re.fullmatch(r"[a-z0-9_]+", normalized):
+        raise ValueError(
+            "connector must contain only lowercase letters, numbers, and underscores"
+        )
+    return normalized
+
+
+class Connector(BaseModel):
+    id: str
+    reseller_id: str
+    merchant_id: str
+    connector: str
+    credential_id: Optional[str] = None
+    status: ConnectorStatus
+    connected_at: Optional[datetime] = None
+    disconnected_at: Optional[datetime] = None
+    last_sync_at: Optional[datetime] = None
+    metadata: Dict[str, Any] = Field(default_factory=dict)
+    created_at: Optional[datetime] = None
+    updated_at: Optional[datetime] = None
+
+
+class UpsertConnectorConnection(BaseModel):
+    """Internal input for an atomic connector credential and state sync."""
+
+    reseller_id: str = Field(..., min_length=1, max_length=255)
+    merchant_id: str = Field(..., min_length=1, max_length=255)
+    connector: str = Field(..., min_length=1, max_length=255)
+    credential_value: str = Field(..., min_length=1)
+    credential_is_encrypted: bool = False
+    credential_description: Optional[str] = Field(None, max_length=500)
+    metadata: Dict[str, Any] = Field(default_factory=dict)
+
+    @field_validator("connector")
+    @classmethod
+    def validate_connector(cls, value: str) -> str:
+        return _validate_connector_name(value)
+
+
+class ConnectorMetric(BaseModel):
+    id: str
+    connector_id: str
+    merchant_id: str
+    reseller_id: str
+    metric_date: date
+    metric_name: str
+    value: int = Field(ge=0)
+    created_at: Optional[datetime] = None
+    updated_at: Optional[datetime] = None
+
+
+class ConnectorMetricIncrement(BaseModel):
+    connector_id: str
+    reseller_id: str = Field(..., min_length=1, max_length=255)
+    merchant_id: str = Field(..., min_length=1, max_length=255)
+    metric_name: str = Field(..., min_length=1, max_length=255)
+    increment: int = Field(..., ge=0)
+    metric_date: Optional[date] = None
+
+
+__all__ = [
+    "Connector",
+    "ConnectorMetric",
+    "ConnectorMetricIncrement",
+    "ConnectorStatus",
+    "UpsertConnectorConnection",
+]

--- a/app/schemas/breeze_buddy/credentials.py
+++ b/app/schemas/breeze_buddy/credentials.py
@@ -51,12 +51,14 @@ class Credential(BaseModel):
 
     id: str
     reseller_id: Optional[str] = None
+    merchant_id: Optional[str] = None
     name: str
     credential_type: CredentialType
     value: Optional[Dict[str, Any]] = Field(
         default=None, description="Masked credential value in API responses"
     )
     is_encrypted: bool = False
+    template_exposable: bool = True
     description: Optional[str] = None
     is_active: bool = True
     created_at: Optional[datetime] = None

--- a/app/schemas/breeze_buddy/whatsapp.py
+++ b/app/schemas/breeze_buddy/whatsapp.py
@@ -1,0 +1,60 @@
+"""WhatsApp-specific request and secret schemas.
+
+Connection state is represented by the generic connector schemas.
+"""
+
+from typing import Any, Dict, Optional
+
+from pydantic import BaseModel, Field, field_validator
+
+WHATSAPP_SYNC_TOKEN_ENCRYPTION_SCHEME = "rsa-oaep-sha256"
+
+
+class WhatsAppCredentialSecret(BaseModel):
+    """Opaque Nautilus-encrypted WhatsApp token payload."""
+
+    encrypted_access_token: str = Field(..., min_length=1)
+    token_encryption_scheme: str = Field(WHATSAPP_SYNC_TOKEN_ENCRYPTION_SCHEME)
+
+    @field_validator("token_encryption_scheme")
+    @classmethod
+    def validate_token_encryption_scheme(cls, value: str) -> str:
+        """Only accept the Nautilus-to-Clairvoyance token encryption scheme."""
+        if value != WHATSAPP_SYNC_TOKEN_ENCRYPTION_SCHEME:
+            raise ValueError(
+                "token_encryption_scheme must be "
+                f"{WHATSAPP_SYNC_TOKEN_ENCRYPTION_SCHEME}"
+            )
+        return value
+
+
+class SyncMerchantWhatsAppConnection(BaseModel):
+    """Input required to sync a Nautilus WhatsApp connection into Clairvoyance."""
+
+    reseller_id: str = Field(..., min_length=1, max_length=255)
+    merchant_id: str = Field(..., min_length=1, max_length=255)
+    waba_id: str = Field(..., min_length=1, max_length=255)
+    phone_number_id: str = Field(..., min_length=1, max_length=255)
+    encrypted_access_token: str = Field(..., min_length=1)
+    token_encryption_scheme: str = Field(WHATSAPP_SYNC_TOKEN_ENCRYPTION_SCHEME)
+    template_name: Optional[str] = Field(None, max_length=255)
+    template_status: Optional[str] = Field(None, max_length=64)
+    metadata: Dict[str, Any] = Field(default_factory=dict)
+
+    @field_validator("token_encryption_scheme")
+    @classmethod
+    def validate_token_encryption_scheme(cls, value: str) -> str:
+        """Only accept the Nautilus-to-Clairvoyance token encryption scheme."""
+        if value != WHATSAPP_SYNC_TOKEN_ENCRYPTION_SCHEME:
+            raise ValueError(
+                "token_encryption_scheme must be "
+                f"{WHATSAPP_SYNC_TOKEN_ENCRYPTION_SCHEME}"
+            )
+        return value
+
+
+__all__ = [
+    "SyncMerchantWhatsAppConnection",
+    "WhatsAppCredentialSecret",
+    "WHATSAPP_SYNC_TOKEN_ENCRYPTION_SCHEME",
+]


### PR DESCRIPTION
  - add merchant-scoped WhatsApp credential foundation migration
  - create merchant_whatsapp_setting for WABA state and message counters
  - add WhatsApp schemas, queries, decoders, and accessors
  - sync WhatsApp credential and setting atomically for Nautilus onboarding
  - hide WhatsApp token credentials from generic credential APIs
  - reserve whatsapp_meta_access_token for the WhatsApp sync path

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added merchant-scoped WhatsApp connection support, including saving, syncing, disconnecting, and viewing settings.
  * Added support for storing and retrieving WhatsApp credential secrets and message counters.
  * Introduced new WhatsApp-related data models and status values for consistent handling.

* **Bug Fixes**
  * Improved credential handling so WhatsApp token credentials are kept separate from general credentials.
  * Added safeguards for invalid WhatsApp message counter updates and unsupported token encryption formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


<img width="1017" height="1060" alt="image" src="https://github.com/user-attachments/assets/17dc639b-1e11-4d3d-b04e-3c1184a4192f" />
<img width="1722" height="168" alt="image" src="https://github.com/user-attachments/assets/6144090f-5a3a-406c-b1b8-09f3a82f5ece" />



Video Proof:

https://drive.google.com/file/d/1JcrVpwkPyw8KZak3HjJNT3xt7Ct2lbnA/view?usp=sharing