### PR TITLE
feat(stt): add global RBAC-gated transcription endpoint

### DIFF
--- a/app/ai/voice/stt/transcribe.py
+++ b/app/ai/voice/stt/transcribe.py
@@ -85,11 +85,15 @@ def _sarvam_lang(language: LanguageHint) -> str:
 
 
 async def _openai(
-    audio: bytes, content_type: Optional[str], filename: str, lang: Optional[str]
+    audio: bytes,
+    content_type: Optional[str],
+    filename: str,
+    lang: Optional[str],
+    model: Optional[str] = None,
 ) -> Transcription:
     headers = {"Authorization": f"Bearer {OPENAI_STT_API_KEY}"}
     files = {"file": (filename, audio, content_type or "audio/webm")}
-    data = {"model": OPENAI_STT_MODEL or "whisper-1"}
+    data = {"model": model or OPENAI_STT_MODEL or "whisper-1"}
     if lang:
         data["language"] = lang
     async with create_http_client(timeout=_HTTP_TIMEOUT_SECONDS) as client:
@@ -100,9 +104,16 @@ async def _openai(
 
 
 async def _deepgram(
-    audio: bytes, content_type: Optional[str], lang: Optional[str]
+    audio: bytes,
+    content_type: Optional[str],
+    lang: Optional[str],
+    model: Optional[str] = None,
 ) -> Transcription:
-    params = {"model": "nova-3", "smart_format": "true", "language": lang or "multi"}
+    params = {
+        "model": model or "nova-3",
+        "smart_format": "true",
+        "language": lang or "multi",
+    }
     headers = {
         "Authorization": f"Token {DEEPGRAM_API_KEY}",
         "Content-Type": content_type or "audio/webm",
@@ -118,11 +129,15 @@ async def _deepgram(
 
 
 async def _sarvam(
-    audio: bytes, content_type: Optional[str], filename: str, lang_code: str
+    audio: bytes,
+    content_type: Optional[str],
+    filename: str,
+    lang_code: str,
+    model: Optional[str] = None,
 ) -> Transcription:
     headers = {"api-subscription-key": SARVAM_API_KEY or ""}
     files = {"file": (filename, audio, content_type or "audio/wav")}
-    data = {"model": "saarika:v2", "language_code": lang_code}
+    data = {"model": model or "saarika:v2", "language_code": lang_code}
     async with create_http_client(timeout=_HTTP_TIMEOUT_SECONDS) as client:
         resp = await client.post(_SARVAM_URL, headers=headers, files=files, data=data)
     resp.raise_for_status()
@@ -149,6 +164,7 @@ async def _soniox(
     content_type: Optional[str],
     filename: str,
     language: LanguageHint,
+    model: Optional[str] = None,
 ) -> Transcription:
     """One-shot transcription via Soniox's async file API.
 
@@ -175,10 +191,11 @@ async def _soniox(
             up.raise_for_status()
             file_id = up.json()["id"]
 
-            # 2. Create the async transcription job. The model resolves
-            #    Redis → env → default, so it can be bumped without a deploy.
+            # 2. Create the async transcription job. A caller-supplied model
+            #    overrides; otherwise it resolves Redis → env → default, so it
+            #    can be bumped without a deploy.
             body: Dict[str, Any] = {
-                "model": await SONIOX_ASYNC_MODEL(),
+                "model": model or await SONIOX_ASYNC_MODEL(),
                 "file_id": file_id,
             }
             hints = _soniox_lang_hints(language)
@@ -237,31 +254,42 @@ async def transcribe_audio(
     content_type: Optional[str],
     *,
     provider: Optional[str],
+    model: Optional[str] = None,
     language: LanguageHint = None,
     filename: str = "audio.webm",
 ) -> Transcription:
-    """Transcribe ``audio`` to text using the template-selected ``provider``.
+    """Transcribe ``audio`` to text using the selected ``provider``.
 
     ``provider`` is an ``STTProvider`` value (``"soniox"`` | ``"deepgram"`` |
     ``"sarvam"`` | ``"openai"`` | ``"google"``). Soniox uses its async file API;
     Google (no direct one-shot path) and any provider whose key is unset
     transcribe via OpenAI Whisper. Raises :class:`TranscriptionError` only when
     no provider can run.
+
+    ``model`` optionally overrides the provider's default model. It is provider-
+    specific, so it is only forwarded to the direct provider call — never to the
+    OpenAI Whisper fallback below, unless the selected provider was OpenAI itself
+    (a Deepgram/Sarvam/Soniox model name would be meaningless to Whisper).
     """
     if not audio:
         raise TranscriptionError("empty audio")
 
     p = (provider or "").lower()
     lang = _short_lang(language)
+    # Only pass ``model`` to the Whisper fallback when OpenAI was the intended
+    # provider; other providers' model names don't apply to Whisper.
+    fallback_model = model if p == "openai" else None
 
     try:
         if p == "soniox" and SONIOX_API_KEY:
             # Pass the raw language (str | list) — Soniox takes a hints array.
-            return await _soniox(audio, content_type, filename, language)
+            return await _soniox(audio, content_type, filename, language, model)
         if p == "deepgram" and DEEPGRAM_API_KEY:
-            return await _deepgram(audio, content_type, lang)
+            return await _deepgram(audio, content_type, lang, model)
         if p == "sarvam" and SARVAM_API_KEY:
-            return await _sarvam(audio, content_type, filename, _sarvam_lang(language))
+            return await _sarvam(
+                audio, content_type, filename, _sarvam_lang(language), model
+            )
         if not OPENAI_STT_API_KEY:
             raise TranscriptionError(
                 f"no usable STT provider for '{provider}' (OPENAI_STT_API_KEY unset)"
@@ -272,7 +300,7 @@ async def transcribe_audio(
                 "using OpenAI Whisper",
                 provider,
             )
-        return await _openai(audio, content_type, filename, lang)
+        return await _openai(audio, content_type, filename, lang, fallback_model)
     except TranscriptionError:
         raise
     except Exception as e:
@@ -285,7 +313,9 @@ async def transcribe_audio(
                 e,
             )
             try:
-                return await _openai(audio, content_type, filename, lang)
+                return await _openai(
+                    audio, content_type, filename, lang, fallback_model
+                )
             except Exception as e2:
                 raise TranscriptionError(f"transcription failed: {e2}") from e2
         raise TranscriptionError(f"transcription failed: {e}") from e

--- a/app/api/routers/breeze_buddy/__init__.py
+++ b/app/api/routers/breeze_buddy/__init__.py
@@ -35,6 +35,9 @@ from app.api.routers.breeze_buddy.resellers import router as resellers_router
 
 # Self-service signup and Google SSO (public, unauthenticated)
 from app.api.routers.breeze_buddy.signup import router as signup_router
+
+# Global (template-independent) STT: one-shot transcription behind RBAC auth
+from app.api.routers.breeze_buddy.stt import router as stt_router
 from app.api.routers.breeze_buddy.telephony import router as telephony_router
 from app.api.routers.breeze_buddy.template_generator import (
     router as template_generator_router,
@@ -106,6 +109,9 @@ router.include_router(webhooks_router, prefix="", tags=["webhooks"])
 
 # User Accounts (login accounts with RBAC)
 router.include_router(users_router, prefix="", tags=["users"])
+
+# Global STT (template-independent one-shot transcription, RBAC-gated)
+router.include_router(stt_router, prefix="", tags=["stt"])
 
 # Leads (call requests/trackers)
 router.include_router(leads_router, prefix="", tags=["leads"])

--- a/app/api/routers/breeze_buddy/stt/__init__.py
+++ b/app/api/routers/breeze_buddy/stt/__init__.py
@@ -1,0 +1,49 @@
+"""Global (template-independent) STT endpoints.
+
+Routes under ``/agent/voice/breeze-buddy/stt``:
+
+- ``POST /transcribe``   one-shot audio-clip -> transcript
+
+Unlike the widget push-to-talk route (``/widget/session/{id}/transcribe``),
+this endpoint is bound to no widget session and no template: the caller passes
+the STT ``provider`` and (optionally) ``model``/``language`` directly. It sits
+behind the standard RBAC bearer auth, so both interactive dashboard users and
+machine (S2S) callers can reach it.
+"""
+
+from typing import Optional
+
+from fastapi import APIRouter, Depends, File, Form, UploadFile
+
+from app.api.security.breeze_buddy.rbac_token import get_current_user_with_rbac
+from app.schemas import UserInfo
+from app.schemas.breeze_buddy.stt import GlobalTranscribeResponse
+
+from .handlers import transcribe_audio_handler
+
+router = APIRouter(prefix="/stt", tags=["stt"])
+
+
+@router.post(
+    "/transcribe",
+    response_model=GlobalTranscribeResponse,
+    summary="Transcribe an audio clip to text (provider/model chosen per-request)",
+)
+async def transcribe(
+    audio: UploadFile = File(...),
+    provider: str = Form(...),
+    model: Optional[str] = Form(None),
+    language: Optional[str] = Form(None),
+    current_user: UserInfo = Depends(get_current_user_with_rbac),
+) -> GlobalTranscribeResponse:
+    """One-shot speech-to-text, independent of any widget session or template.
+
+    Upload a short clip plus the ``provider`` (``soniox`` | ``deepgram`` |
+    ``sarvam`` | ``openai`` | ``google``) and optional ``model``/``language``;
+    get the transcript back. Streaming-only providers and transient failures
+    fall back to OpenAI Whisper inside the shared transcription core.
+    """
+    return await transcribe_audio_handler(audio, provider, model, language)
+
+
+__all__ = ["router"]

--- a/app/api/routers/breeze_buddy/stt/handlers.py
+++ b/app/api/routers/breeze_buddy/stt/handlers.py
@@ -1,0 +1,82 @@
+"""Handlers for the global (template-independent) STT endpoints."""
+
+from typing import Optional
+
+from fastapi import HTTPException, UploadFile, status
+
+from app.ai.voice.agents.breeze_buddy.template.types import STTProvider
+from app.ai.voice.stt import TranscriptionError, transcribe_audio
+from app.core.config.dynamic import WIDGET_STT_MAX_AUDIO_BYTES
+from app.core.logger import logger
+from app.schemas.breeze_buddy.stt import GlobalTranscribeResponse
+
+_VALID_PROVIDERS = {p.value for p in STTProvider}
+
+
+async def transcribe_audio_handler(
+    audio: UploadFile,
+    provider: str,
+    model: Optional[str],
+    language: Optional[str],
+) -> GlobalTranscribeResponse:
+    """Transcribe an uploaded clip with a caller-chosen provider/model.
+
+    Stateless and template-independent: no widget session, no template lookup.
+    The clip is read with the shared size guard, then handed to the shared
+    ``transcribe_audio`` core (Soniox uses its async file API; Google — and any
+    provider whose key is unset — falls back to Whisper inside that core).
+    """
+    prov = (provider or "").strip().lower()
+    if prov not in _VALID_PROVIDERS:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=(
+                f"Unknown STT provider '{provider}'. "
+                f"Valid providers: {sorted(_VALID_PROVIDERS)}"
+            ),
+        )
+
+    max_bytes = await WIDGET_STT_MAX_AUDIO_BYTES()
+    chunks: list[bytes] = []
+    total = 0
+    while True:
+        chunk = await audio.read(64 * 1024)
+        if not chunk:
+            break
+        total += len(chunk)
+        if total > max_bytes:
+            raise HTTPException(
+                status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+                detail=f"Audio exceeds the {max_bytes}-byte limit",
+            )
+        chunks.append(chunk)
+    data = b"".join(chunks)
+    if not data:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Empty audio upload",
+        )
+
+    model_override = model.strip() if model and model.strip() else None
+    lang = language.strip() if language and language.strip() else None
+
+    try:
+        result = await transcribe_audio(
+            data,
+            audio.content_type,
+            provider=prov,
+            model=model_override,
+            language=lang,
+            filename=audio.filename or "audio.webm",
+        )
+    except TranscriptionError as e:
+        logger.warning("global transcribe failed (provider={}): {}", prov, e)
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="Transcription failed",
+        ) from e
+
+    response_model = model_override if result.provider == prov else None
+    return GlobalTranscribeResponse(
+        text=result.text, provider=result.provider, model=response_model
+    )

--- a/app/schemas/breeze_buddy/stt.py
+++ b/app/schemas/breeze_buddy/stt.py
@@ -1,0 +1,22 @@
+"""Schemas for the global (template-independent) STT endpoints."""
+
+from typing import Optional
+
+from pydantic import BaseModel
+
+
+class GlobalTranscribeResponse(BaseModel):
+    """Body of ``POST /agent/voice/breeze-buddy/stt/transcribe``.
+
+    One-shot transcription decoupled from any widget session or template: the
+    caller supplies the audio clip plus the ``provider``/``model`` to use.
+    ``provider`` is the STT provider that actually produced the text (may differ
+    from the requested one when a streaming-only provider falls back to Whisper).
+    ``model`` echoes back the requested override only when that requested provider
+    produced the transcript (``None`` when the provider default was used, or when
+    the request fell back to a different provider).
+    """
+
+    text: str
+    provider: str
+    model: Optional[str] = None

--- a/tests/test_global_stt_handler.py
+++ b/tests/test_global_stt_handler.py
@@ -1,0 +1,39 @@
+"""Tests for the global, template-independent STT handler."""
+
+from io import BytesIO
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import UploadFile
+
+from app.api.routers.breeze_buddy.stt import handlers
+
+
+@pytest.mark.parametrize(
+    ("result_provider", "expected_model"),
+    [("deepgram", "nova-3"), ("openai", None)],
+)
+async def test_model_override_only_matches_requested_provider(
+    monkeypatch: pytest.MonkeyPatch,
+    result_provider: str,
+    expected_model: str | None,
+) -> None:
+    monkeypatch.setattr(
+        handlers, "WIDGET_STT_MAX_AUDIO_BYTES", AsyncMock(return_value=1024)
+    )
+    monkeypatch.setattr(
+        handlers,
+        "transcribe_audio",
+        AsyncMock(return_value=SimpleNamespace(text="hello", provider=result_provider)),
+    )
+
+    response = await handlers.transcribe_audio_handler(
+        UploadFile(BytesIO(b"audio"), filename="clip.webm"),
+        provider=" DEEPGRAM ",
+        model=" nova-3 ",
+        language=None,
+    )
+
+    assert response.provider == result_provider
+    assert response.model == expected_model


### PR DESCRIPTION
Add POST /agent/voice/breeze-buddy/stt/transcribe: a one-shot speech-to-text endpoint decoupled from any widget session or template. The caller passes the audio clip plus provider and (optional) model and language directly, and it sits behind the standard RBAC bearer auth so both interactive dashboard users and machine (S2S) callers can reach it.

- transcribe.py: thread an optional per-provider `model` override through transcribe_audio and each provider call (OpenAI/Deepgram/Sarvam/Soniox), falling back to today's default when unset. The override only reaches the Whisper fallback when the selected provider was OpenAI, so another provider's model name never leaks into Whisper.
- New app/api/routers/breeze_buddy/stt router + handler: validates provider against STTProvider (400), reuses the WIDGET_STT_MAX_AUDIO_BYTES size guard (413/400 on oversize/empty), maps TranscriptionError to 502. No widget session / template / ownership coupling.
- GlobalTranscribeResponse schema ({text, provider, model}).
- Registered the router in the breeze_buddy aggregator.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a global speech-to-text endpoint for authenticated audio transcription.
  * Added optional provider, model, and language controls for one-shot transcription.
  * Added provider-specific model selection with automatic default fallback.
  * Responses now include the transcribed text, provider, and selected model when applicable.

* **Bug Fixes**
  * Improved handling of unsupported providers, empty uploads, oversized audio files, and transcription failures.
  * Normalized provider and model inputs before processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->