### PR TITLE
woocommerce <> buddy

### DIFF
--- a/app/api/routers/breeze_buddy/__init__.py
+++ b/app/api/routers/breeze_buddy/__init__.py
@@ -29,6 +29,7 @@ from app.api.routers.breeze_buddy.template_generator import (
 )
 from app.api.routers.breeze_buddy.templates import router as templates_router
 from app.api.routers.breeze_buddy.users import router as users_router
+from app.api.routers.breeze_buddy.webhooks import router as webhooks_router
 from app.api.routers.breeze_buddy.websocket import router as websocket_router
 
 # Widget public mode (CHAT_MODE.md §14): per-merchant widget_config
@@ -78,6 +79,9 @@ router.include_router(blacklist_router, prefix="", tags=["blacklist"])
 
 # Merchants (merchant identifiers - admin only)
 router.include_router(merchants_router, prefix="", tags=["merchants"])
+
+# E-commerce order webhooks (generic /webhook/{platform}/{merchant_id})
+router.include_router(webhooks_router, prefix="", tags=["webhooks"])
 
 # User Accounts (login accounts with RBAC)
 router.include_router(users_router, prefix="", tags=["users"])

--- a/app/api/routers/breeze_buddy/merchants/handlers.py
+++ b/app/api/routers/breeze_buddy/merchants/handlers.py
@@ -2,11 +2,13 @@
 Handlers for merchant endpoints.
 """
 
+from datetime import datetime, timedelta, timezone
 from typing import Optional
 
 import asyncpg
 from fastapi import HTTPException
 
+from app.api.security.breeze_buddy.rbac_token import rbac_token_manager
 from app.core.logger import logger
 from app.core.security.scope import resolve_merchant_ids
 from app.database.accessor.breeze_buddy import merchants as merchant_accessors
@@ -113,6 +115,32 @@ async def create_merchant_handler(
             raise HTTPException(
                 status_code=500, detail="Failed to create merchant entity"
             )
+
+        # Optionally mint a per-merchant S2S token, store it on the merchant row,
+        # and return it once (e.g. to use as a webhook HMAC secret).
+        if merchant_data.issue_token:
+            if not reseller_id:
+                raise HTTPException(
+                    status_code=400,
+                    detail="reseller_id is required to issue a token",
+                )
+            expires_delta = timedelta(days=merchant_data.token_lifetime_days)
+            token = rbac_token_manager.create_access_token_with_rbac(
+                user_id=f"merchant:{merchant_data.merchant_id}",
+                username=f"merchant-{merchant_data.merchant_id}",
+                role=UserRole.MERCHANT,
+                reseller_ids=[reseller_id],
+                merchant_ids=[merchant_data.merchant_id],
+                owner_id=current_user.id,
+                expires_delta=expires_delta,
+            )
+            await merchant_accessors.set_merchant_s2s_token(
+                merchant_data.merchant_id, token
+            )
+            merchant.token = token
+            merchant.token_expires_at = (
+                datetime.now(timezone.utc) + expires_delta
+            ).isoformat()
 
         return merchant
 

--- a/app/api/routers/breeze_buddy/webhooks/__init__.py
+++ b/app/api/routers/breeze_buddy/webhooks/__init__.py
@@ -1,0 +1,37 @@
+"""
+E-commerce order webhooks.
+
+Setup is done via POST /merchant with issue_token=true (merchants router), which
+mints and stores the per-merchant token. That token is pasted into the platform's
+webhook "Secret" field; deliveries are authenticated by the platform's HMAC
+signature, and qualifying orders push a call lead.
+
+    POST /webhook/{platform}/{topic}/{merchant_id}?template=<name>&all_orders=<bool>
+    e.g. POST /webhook/woocommerce/order-confirmation/my-store?template=order-confirmation
+         POST /webhook/woocommerce/order-confirmation/my-store?template=order-confirmation&all_orders=true
+         POST /webhook/woocommerce/abandoned-checkout/my-store?template=abandoned-checkout
+
+- topic:      order-confirmation | abandoned-checkout
+- all_orders: false (default) -> only COD orders push a lead
+              true            -> every order pushes a lead  (order-confirmation only)
+"""
+
+from fastapi import APIRouter, Request, status
+
+from .handlers import handle_webhook
+
+router = APIRouter()
+
+
+@router.post(
+    "/webhook/{platform}/{topic}/{merchant_id}", status_code=status.HTTP_200_OK
+)
+async def webhook(platform: str, topic: str, merchant_id: str, request: Request):
+    """Ingest an e-commerce webhook and dispatch by platform + topic.
+
+    Query params (read from the request in the platform handler):
+      ``template`` / ``template_id`` — the call template for pushed leads.
+      ``all_orders`` — order-confirmation only: ``true`` pushes every order,
+      absent/``false`` pushes only COD orders.
+    """
+    return await handle_webhook(platform, topic, merchant_id, request)

--- a/app/api/routers/breeze_buddy/webhooks/handlers.py
+++ b/app/api/routers/breeze_buddy/webhooks/handlers.py
@@ -1,0 +1,41 @@
+"""
+E-commerce order webhooks — generic dispatcher.
+
+POST /webhook/{platform}/{topic}/{merchant_id} dispatches on the platform name.
+Each platform's processing lives in its own module (e.g. woocommerce/services.py);
+to add a platform, add one branch here and a matching module.
+
+- ``platform`` — e.g. ``woocommerce``.
+- ``topic``    — the kind of event (``order-confirmation``, ``abandoned-checkout``),
+  handled per-platform.
+- ``all_orders`` — query param controlling which orders push a call lead
+  (``false`` = COD only, ``true`` = every order); interpreted per-platform.
+"""
+
+from typing import Any, Dict
+
+from fastapi import HTTPException, Request, status
+
+from app.api.routers.breeze_buddy.webhooks.woocommerce.services import (
+    handle_woocommerce,
+)
+
+
+async def handle_webhook(
+    platform: str,
+    topic: str,
+    merchant_id: str,
+    request: Request,
+) -> Dict[str, Any]:
+    """Dispatch an incoming webhook to the right platform handler.
+
+    Query params (``template`` / ``template_id`` / ``all_orders``) are read from
+    ``request`` inside the platform handler.
+    """
+    if platform == "woocommerce":
+        return await handle_woocommerce(topic, merchant_id, request)
+
+    raise HTTPException(
+        status_code=status.HTTP_404_NOT_FOUND,
+        detail=f"Unsupported platform: {platform}",
+    )

--- a/app/api/routers/breeze_buddy/webhooks/woocommerce/__init__.py
+++ b/app/api/routers/breeze_buddy/webhooks/woocommerce/__init__.py
@@ -1,0 +1,1 @@
+"""WooCommerce webhook handling (order-confirmation, abandoned-checkout)."""

--- a/app/api/routers/breeze_buddy/webhooks/woocommerce/cart.py
+++ b/app/api/routers/breeze_buddy/webhooks/woocommerce/cart.py
@@ -1,0 +1,132 @@
+"""
+WooCommerce abandoned-checkout flow.
+
+Every abandoned checkout calls (no payment yet). Maps the checkout payload into
+exactly the fields the abandoned-checkout template's expected_payload_schema
+requires. Input field names vary by abandoned-cart plugin, so several common
+aliases are checked — adjust the lookups here if your plugin nests data
+differently.
+"""
+
+from typing import Any, Dict, Optional, Tuple
+
+from app.core.logger import logger
+
+from .utils import TOPIC_ABANDONED_CHECKOUT, first, push_lead
+
+
+def summarize_cart_items(data: Dict[str, Any]) -> str:
+    """Build the ``cart_items_summary`` string: "Name (x2), Other (x1)".
+
+    Reads ``line_items`` / ``cart_contents`` (a list of item dicts). If the
+    payload already carries a summary string, that is used as-is.
+    """
+    existing = data.get("cart_items_summary")
+    if isinstance(existing, str) and existing.strip():
+        return existing.strip()
+
+    items = data.get("line_items") or data.get("cart_contents") or []
+    if isinstance(items, str):
+        return items.strip()
+
+    parts = []
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        name = item.get("name") or item.get("product_name")
+        qty = item.get("quantity") or item.get("qty") or 1
+        if name:
+            parts.append(f"{name} (x{qty})")
+    return ", ".join(parts)
+
+
+def build_abandoned_checkout_payload(
+    data: Dict[str, Any], shop_name: str
+) -> Tuple[str, Dict[str, Any]]:
+    """Map an abandoned-checkout webhook into (phone, lead_payload).
+
+    Produces exactly the fields the abandoned-checkout template's
+    expected_payload_schema requires: shop_name, cart_total (number),
+    recovery_url, customer_name, cart_items_summary, customer_mobile_number.
+    """
+    billing = data.get("billing") or {}
+
+    phone = (
+        billing.get("phone")
+        or first(data, "phone", "wcf_phone_number", "customer_mobile_number")
+        or ""
+    ).strip()
+
+    first_name = billing.get("first_name") or first(
+        data, "first_name", "wcf_first_name"
+    )
+    last_name = billing.get("last_name") or first(data, "last_name", "wcf_last_name")
+    customer_name = " ".join(
+        part for part in [first_name, last_name] if part
+    ).strip() or (first_name or "Customer")
+
+    # cart_total must be numeric (template runs indian_number_to_speech on it).
+    raw_total = first(data, "cart_total", "total", "order_total")
+    cart_total: Any = 0.0
+    if isinstance(raw_total, (str, int, float)):
+        try:
+            cart_total = float(raw_total)
+        except (TypeError, ValueError):
+            logger.warning(
+                f"abandoned-checkout: could not parse cart_total from {raw_total!r}"
+            )
+    else:
+        logger.warning(
+            f"abandoned-checkout: missing/invalid cart_total ({raw_total!r})"
+        )
+
+    recovery_url = (
+        first(
+            data,
+            "recovery_url",
+            "checkout_url",
+            "abandoned_checkout_url",
+            "abandoned_cart_link",
+            "url",
+        )
+        or ""
+    )
+
+    payload = {
+        "shop_name": shop_name,
+        "cart_total": cart_total,
+        "recovery_url": recovery_url,
+        "customer_name": customer_name,
+        "cart_items_summary": summarize_cart_items(data),
+        "customer_mobile_number": phone,
+    }
+    return phone, payload
+
+
+async def process_abandoned_checkout(
+    order: Dict[str, Any],
+    merchant_id: str,
+    reseller_id: str,
+    shop_name: str,
+    template: Optional[str],
+    template_id: Optional[str],
+) -> Dict[str, Any]:
+    """Handle an abandoned-checkout webhook: always call (no payment yet)."""
+    checkout_id = order.get("id") or first(
+        order, "session_id", "checkout_id", "email", "phone"
+    )
+    if not checkout_id:
+        return {"status": "ignored", "reason": "no checkout id in payload"}
+
+    phone, payload = build_abandoned_checkout_payload(order, shop_name)
+    return await push_lead(
+        TOPIC_ABANDONED_CHECKOUT,
+        checkout_id,
+        phone,
+        payload,
+        merchant_id,
+        reseller_id,
+        template,
+        template_id,
+        "abandoned checkout",
+    )

--- a/app/api/routers/breeze_buddy/webhooks/woocommerce/order.py
+++ b/app/api/routers/breeze_buddy/webhooks/woocommerce/order.py
@@ -1,0 +1,124 @@
+"""
+WooCommerce order-confirmation flow.
+
+Decides which placed orders push a call lead (per the ?all_orders= preference)
+and maps the WooCommerce order into the lead payload.
+"""
+
+from typing import Any, Dict, Optional, Tuple
+
+from app.core.logger import logger
+
+from .utils import TOPIC_ORDER_CONFIRMATION, push_lead
+
+
+def evaluate_trigger(order: Dict[str, Any], all_orders: bool) -> Tuple[bool, str]:
+    """Decide whether an order should push a lead, per the ?all_orders= preference.
+
+    Returns (should_push, reason).
+      all_orders=False — only Cash-on-Delivery orders push a lead (default).
+      all_orders=True  — every order pushes a lead.
+    """
+    is_cod = (order.get("payment_method") or "").lower() == "cod"
+
+    if all_orders:
+        return True, "cod" if is_cod else "all"
+    return (True, "cod") if is_cod else (False, "not a cod order")
+
+
+def build_order_payload(
+    order: Dict[str, Any], shop_name: str
+) -> Tuple[str, Dict[str, Any]]:
+    """Map a WooCommerce order into (phone, lead_payload).
+
+    ``phone`` is returned separately so the caller can skip when empty.
+    """
+    billing = order.get("billing") or {}
+    phone = (billing.get("phone") or order.get("phone") or "").strip()
+
+    customer_name = " ".join(
+        part
+        for part in [
+            billing.get("first_name") or order.get("first_name"),
+            billing.get("last_name") or order.get("last_name"),
+        ]
+        if part
+    ).strip()
+
+    customer_address = ", ".join(
+        part
+        for part in [
+            billing.get("address_1"),
+            billing.get("address_2"),
+            billing.get("city"),
+            billing.get("state"),
+            billing.get("postcode"),
+        ]
+        if part
+    ).strip()
+
+    # WooCommerce sends monetary amounts as strings ("199.00"); coerce to a
+    # number for templates whose schema expects a numeric total_price.
+    raw_total = order.get("total") or order.get("cart_total")
+    total_price: Any = raw_total
+    if isinstance(raw_total, (str, int, float)):
+        try:
+            total_price = float(raw_total)
+        except (TypeError, ValueError):
+            total_price = raw_total
+
+    payload = {
+        "customer_name": customer_name or (billing.get("first_name") or "Customer"),
+        "customer_mobile_number": phone,
+        "customer_address": customer_address,
+        "shop_name": shop_name,
+        "order_id": order.get("id"),
+        "order_number": order.get("number"),
+        "total_price": total_price,
+        "currency": order.get("currency"),
+        "payment_method": (order.get("payment_method") or "").lower(),
+        "payment_method_title": order.get("payment_method_title"),
+        "order_status": (order.get("status") or "").lower(),
+        "items": [
+            {
+                "name": item.get("name"),
+                "quantity": item.get("quantity"),
+                "total": item.get("total"),
+            }
+            for item in (order.get("line_items") or [])
+        ],
+    }
+    return phone, payload
+
+
+async def process_order_confirmation(
+    order: Dict[str, Any],
+    merchant_id: str,
+    reseller_id: str,
+    shop_name: str,
+    template: Optional[str],
+    template_id: Optional[str],
+    all_orders: bool,
+) -> Dict[str, Any]:
+    """Handle a placed-order webhook: push a lead per the ?all_orders= preference."""
+    order_id = order.get("id")
+    if not order_id:
+        return {"status": "ignored", "reason": "no order id in payload"}
+
+    should_push, reason = evaluate_trigger(order, all_orders)
+    if not should_push:
+        logger.info(f"woocommerce order {order_id} skipped: {reason}")
+        return {"status": "skipped", "reason": reason}
+
+    phone, payload = build_order_payload(order, shop_name)
+    return await push_lead(
+        TOPIC_ORDER_CONFIRMATION,
+        order_id,
+        phone,
+        payload,
+        merchant_id,
+        reseller_id,
+        template,
+        template_id,
+        reason,
+    )

--- a/app/api/routers/breeze_buddy/webhooks/woocommerce/services.py
+++ b/app/api/routers/breeze_buddy/webhooks/woocommerce/services.py
@@ -1,0 +1,135 @@
+"""
+WooCommerce webhook processing — entry point + auth.
+
+``handle_woocommerce`` verifies the delivery (HMAC signature + the stored JWT),
+resolves the merchant/reseller, then dispatches on the topic to the per-flow
+handlers:
+
+- ``order-confirmation`` -> order.process_order_confirmation
+- ``abandoned-checkout`` -> cart.process_abandoned_checkout
+
+Shared helpers (``push_lead``, ``first``, topic constants) live in utils.py.
+
+Auth: the per-merchant token stored on the merchant row (merchants.s2s_token,
+written by POST /merchant with issue_token=true) is the HMAC secret WooCommerce
+signs each delivery with (X-WC-Webhook-Signature).
+"""
+
+import hmac
+import json
+from typing import Any, Dict
+
+from fastapi import HTTPException, Request, status
+
+from app.api.security.breeze_buddy.rbac_token import rbac_token_manager
+from app.core.logger import logger
+from app.core.security.sha import calculate_hmac_sha256
+from app.database.accessor.breeze_buddy.merchants import (
+    get_merchant_by_merchant_identifier,
+    get_merchant_s2s_token,
+)
+
+from .cart import process_abandoned_checkout
+from .order import process_order_confirmation
+from .utils import TOPIC_ABANDONED_CHECKOUT, TOPIC_ORDER_CONFIRMATION
+
+
+async def handle_woocommerce(
+    topic: str,
+    merchant_id: str,
+    request: Request,
+) -> Dict[str, Any]:
+    """Verify + process a WooCommerce webhook, dispatching on topic.
+
+    Reads the ``template`` / ``template_id`` / ``all_orders`` query params off
+    the request. Authenticated by the X-WC-Webhook-Signature HMAC (secret = the
+    stored token). Returns 200 for every authenticated non-push outcome so
+    WooCommerce doesn't retry-storm.
+    """
+    query = request.query_params
+    template = query.get("template")
+    template_id = query.get("template_id")
+    all_orders = query.get("all_orders", "").lower() == "true"
+
+    raw_body = await request.body()
+
+    token = await get_merchant_s2s_token(merchant_id)
+    if not token:
+        # 404 (not 403) to avoid confirming which merchant_ids are set up.
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Integration not found",
+        )
+
+    signature = request.headers.get("x-wc-webhook-signature")
+
+    # WooCommerce sends an unsigned ping when the webhook is saved/activated:
+    # body `webhook_id=N` as application/x-www-form-urlencoded (not JSON), no
+    # signature header. It carries no order data — ack it 200 so WooCommerce
+    # activates the endpoint. (A failing ping gets the webhook auto-disabled
+    # after a few retries.) Real deliveries are JSON and carry a signature.
+    if not signature:
+        if b"webhook_id" in raw_body:
+            logger.info(f"woocommerce ping for merchant {merchant_id}")
+            return {"status": "ok", "ping": True}
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid webhook signature",
+        )
+
+    expected = calculate_hmac_sha256(raw_body.decode("utf-8"), token)
+    if not hmac.compare_digest(expected, signature):
+        logger.warning(
+            f"woocommerce webhook signature mismatch for merchant {merchant_id}"
+        )
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid webhook signature",
+        )
+
+    # The stored token is a JWT — verify it so an expired/rotated token is
+    # rejected even though its HMAC still matches (this is how it is "revoked":
+    # let it expire or re-register the merchant to mint a fresh one).
+    rbac_token_manager.verify_rbac_token(token)
+
+    try:
+        order = json.loads(raw_body) if raw_body else {}
+    except json.JSONDecodeError:
+        order = {}
+
+    if not template and not template_id:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Missing template (pass ?template= or ?template_id= in the URL)",
+        )
+
+    merchant = await get_merchant_by_merchant_identifier(merchant_id)
+    reseller_id = merchant.reseller_id if merchant else None
+    if not reseller_id:
+        logger.error(f"woocommerce merchant {merchant_id} has no reseller_id")
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Merchant has no associated reseller",
+        )
+    shop_name = merchant.name if merchant and merchant.name else merchant_id
+
+    # Dispatch on the topic (URL path segment).
+    if topic == TOPIC_ORDER_CONFIRMATION:
+        return await process_order_confirmation(
+            order,
+            merchant_id,
+            reseller_id,
+            shop_name,
+            template,
+            template_id,
+            all_orders,
+        )
+    if topic == TOPIC_ABANDONED_CHECKOUT:
+        return await process_abandoned_checkout(
+            order, merchant_id, reseller_id, shop_name, template, template_id
+        )
+
+    raise HTTPException(
+        status_code=status.HTTP_404_NOT_FOUND,
+        detail=f"Unsupported topic: {topic}",
+    )

--- a/app/api/routers/breeze_buddy/webhooks/woocommerce/utils.py
+++ b/app/api/routers/breeze_buddy/webhooks/woocommerce/utils.py
@@ -1,0 +1,106 @@
+"""
+Shared helpers for WooCommerce webhook processing.
+
+- topic constants (URL path segment)
+- ``first``: generic nested-aware field lookup
+- ``push_lead``: idempotent lead push used by both the order-confirmation and
+  abandoned-checkout flows.
+"""
+
+from typing import Any, Dict, Optional
+
+from fastapi import HTTPException, status
+
+from app.ai.voice.agents.breeze_buddy.types.models import PushLeadRequest
+from app.api.routers.breeze_buddy.leads.handlers import push_lead_handler
+from app.core.logger import logger
+from app.database.accessor import get_leads_by_request_id
+from app.schemas import UserInfo, UserRole
+
+# Supported topics (URL path segment).
+TOPIC_ORDER_CONFIRMATION = "order-confirmation"
+TOPIC_ABANDONED_CHECKOUT = "abandoned-checkout"
+
+
+def first(data: Dict[str, Any], *keys: str) -> Optional[Any]:
+    """Return the first non-empty value among the given keys (nested-aware).
+
+    Looks at the top level and inside a nested ``other_fields`` block (used by
+    some abandoned-cart plugins, e.g. WooCommerce Cart Abandonment Recovery).
+    """
+    other = data.get("other_fields") or {}
+    for key in keys:
+        val = data.get(key)
+        if val:
+            return val
+        val = other.get(key)
+        if val:
+            return val
+    return None
+
+
+async def push_lead(
+    topic: str,
+    order_id: Any,
+    phone: str,
+    payload: Dict[str, Any],
+    merchant_id: str,
+    reseller_id: str,
+    template: Optional[str],
+    template_id: Optional[str],
+    trigger_reason: str,
+) -> Dict[str, Any]:
+    """Idempotently push a lead through the existing lead pipeline."""
+    if not phone:
+        return {"status": "skipped", "reason": "no customer phone number"}
+
+    request_id = f"woocommerce-{merchant_id}-{topic}-{order_id}"
+
+    # Idempotency: WooCommerce re-delivers on non-2xx.
+    if await get_leads_by_request_id(request_id):
+        logger.info(f"woocommerce {topic} {order_id} already queued ({request_id})")
+        return {"status": "duplicate", "request_id": request_id}
+
+    service_user = UserInfo(
+        id=f"woocommerce:{merchant_id}",
+        username=f"woocommerce-{merchant_id}",
+        role=UserRole.MERCHANT,
+        reseller_ids=[reseller_id],
+        merchant_ids=[merchant_id],
+    )
+    lead_req = PushLeadRequest(
+        request_id=request_id,
+        payload=payload,
+        template=template,
+        template_id=template_id,
+        reseller_id=reseller_id,
+        merchant_id=merchant_id,
+    )
+
+    # TEMP DEBUG (local testing) — remove later. Logs the exact lead about to be
+    # pushed for both flows (order-confirmation + abandoned-checkout).
+    logger.info(
+        f"[woo-push] {topic} pushing lead: request_id={request_id} "
+        f"template={template} template_id={template_id} "
+        f"reseller_id={reseller_id} merchant_id={merchant_id} payload={payload}"
+    )
+
+    try:
+        result = await push_lead_handler(lead_req, service_user)
+    except HTTPException as e:
+        # Blacklisted number is an expected, non-retryable skip.
+        if e.status_code == status.HTTP_403_FORBIDDEN:
+            logger.info(f"woocommerce {topic} {order_id} skipped: {e.detail}")
+            return {"status": "skipped", "reason": str(e.detail)}
+        # Config errors: log and 200 so WooCommerce doesn't retry forever.
+        logger.error(
+            f"woocommerce {topic} {order_id} push failed ({e.status_code}): {e.detail}"
+        )
+        return {"status": "error", "reason": str(e.detail)}
+
+    return {
+        "status": "queued",
+        "request_id": request_id,
+        "lead_call_tracker_id": result.get("lead_call_tracker_id"),
+        "trigger": trigger_reason,
+    }

--- a/app/database/accessor/breeze_buddy/merchants.py
+++ b/app/database/accessor/breeze_buddy/merchants.py
@@ -17,8 +17,10 @@ from app.database.queries.breeze_buddy.merchants import (
     delete_merchant_query,
     get_all_merchants_query,
     get_merchant_by_merchant_identifier_query,
+    get_merchant_s2s_token_query,
     get_merchants_by_ids_query,
     get_merchants_by_reseller_query,
+    set_merchant_s2s_token_query,
     update_merchant_query,
 )
 from app.schemas.breeze_buddy.merchants import MerchantResponse
@@ -337,4 +339,42 @@ async def delete_merchant(merchant_id: str) -> bool:
         return False
     except Exception as e:
         logger.error(f"Error deleting merchant entity {merchant_id}: {e}")
+        raise
+
+
+async def set_merchant_s2s_token(merchant_id: str, token: str) -> bool:
+    """Store an S2S token (webhook HMAC secret) on a merchant row.
+
+    Stored as-is in the nullable ``s2s_token`` column. Returns True if the
+    merchant existed and was updated, False otherwise.
+    """
+    query, values = set_merchant_s2s_token_query(merchant_id, token)
+
+    try:
+        result = await run_parameterized_query(query, values)
+        updated = bool(result)
+        if updated:
+            logger.info(f"Stored S2S token on merchant: {merchant_id}")
+        else:
+            logger.warning(
+                f"Cannot store S2S token: merchant '{merchant_id}' not found"
+            )
+        return updated
+    except Exception as e:
+        logger.error(f"Error storing S2S token on merchant {merchant_id}: {e}")
+        raise
+
+
+async def get_merchant_s2s_token(merchant_id: str) -> Optional[str]:
+    """Read a merchant's stored S2S token, or None if unset."""
+    query, values = get_merchant_s2s_token_query(merchant_id)
+
+    try:
+        result = await run_parameterized_query(query, values)
+        row = result[0] if result else None
+        if not row or not row["s2s_token"]:
+            return None
+        return row["s2s_token"]
+    except Exception as e:
+        logger.error(f"Error reading S2S token for merchant {merchant_id}: {e}")
         raise

--- a/app/database/migrations/034_add_s2s_token_to_merchants.sql
+++ b/app/database/migrations/034_add_s2s_token_to_merchants.sql
@@ -1,0 +1,10 @@
+-- Migration 034: Store per-merchant S2S token on the merchants table
+-- The token minted by POST /merchant (issue_token=true) is stored here (nullable)
+-- and used as the platform webhook's HMAC secret (e.g. WooCommerce's
+-- X-WC-Webhook-Signature). NULL until a token is issued for the merchant.
+
+BEGIN;
+
+ALTER TABLE merchants ADD COLUMN IF NOT EXISTS s2s_token TEXT;
+
+COMMIT;

--- a/app/database/queries/breeze_buddy/merchants.py
+++ b/app/database/queries/breeze_buddy/merchants.py
@@ -298,3 +298,24 @@ def delete_merchant_query(merchant_id: str) -> Tuple[str, List[Any]]:
             (SELECT COUNT(*) FROM delete_operation) as deleted_count
     """
     return query, [merchant_id]
+
+
+def set_merchant_s2s_token_query(merchant_id: str, token: str) -> Tuple[str, List[Any]]:
+    """Generate query to store an S2S token (webhook HMAC secret) on a merchant."""
+    query = f"""
+        UPDATE {MERCHANTS_TABLE}
+        SET s2s_token = $1, updated_at = $2
+        WHERE merchant_id = $3
+        RETURNING merchant_id
+    """
+    return query, [token, datetime.now(timezone.utc), merchant_id]
+
+
+def get_merchant_s2s_token_query(merchant_id: str) -> Tuple[str, List[Any]]:
+    """Generate query to read a merchant's stored S2S token."""
+    query = f"""
+        SELECT s2s_token
+        FROM {MERCHANTS_TABLE}
+        WHERE merchant_id = $1
+    """
+    return query, [merchant_id]

--- a/app/schemas/breeze_buddy/merchants.py
+++ b/app/schemas/breeze_buddy/merchants.py
@@ -29,6 +29,18 @@ class MerchantCreate(BaseModel):
         description="Reseller user ID who owns this merchant. "
         "Admin-only field; auto-set for resellers.",
     )
+    issue_token: bool = Field(
+        False,
+        description="If true, mint a per-merchant S2S token, store it on the "
+        "merchant row, and return it (once) in the response. Used e.g. as the "
+        "webhook HMAC secret. Requires a reseller_id.",
+    )
+    token_lifetime_days: int = Field(
+        default=3650,
+        ge=1,
+        le=365000,
+        description="Lifetime of the issued token in days (only when issue_token).",
+    )
 
 
 class MerchantUpdate(BaseModel):
@@ -43,7 +55,11 @@ class MerchantUpdate(BaseModel):
 
 
 class MerchantResponse(BaseModel):
-    """Merchant entity response."""
+    """Merchant entity response.
+
+    ``token`` / ``token_expires_at`` are populated only on create when
+    ``issue_token`` was requested; they are null on list/get/update.
+    """
 
     merchant_id: str
     name: Optional[str] = None
@@ -52,6 +68,14 @@ class MerchantResponse(BaseModel):
     reseller_id: Optional[str] = None
     created_at: Optional[datetime] = None
     updated_at: Optional[datetime] = None
+    token: Optional[str] = Field(
+        None,
+        description="Per-merchant S2S token, returned once when issue_token=true. "
+        "Store it now — it is not retrievable later.",
+    )
+    token_expires_at: Optional[str] = Field(
+        None, description="ISO timestamp when the issued token expires"
+    )
 
 
 class MerchantListResponse(BaseModel):


### PR DESCRIPTION
 - one admin endpoint to register merchant and generate token per merchant
 - we can use this token in webhook secret and then we get webhook when order created\
 - then we process the webhook by checking few checks and push leads

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an admin-only merchant registration flow that creates or updates merchant access and returns a new secure token.
  * Added support for incoming e-commerce order webhooks, including WooCommerce order events.

* **Bug Fixes**
  * Improved webhook handling for unpaid/COD orders, duplicate deliveries, and unsupported or invalid requests.
  * Added safer token storage and rotation for merchant integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->