### PR TITLE
feat: knowledge base core — pgvector schema, ingestion pipeline, hybrid retrieval, CRUD API

### DIFF
--- a/app/api/routers/breeze_buddy/__init__.py
+++ b/app/api/routers/breeze_buddy/__init__.py
@@ -16,6 +16,9 @@ from app.api.routers.breeze_buddy.credentials import router as credentials_route
 # Daily transport (web/mobile clients via Daily.co)
 from app.api.routers.breeze_buddy.daily import router as daily_router
 from app.api.routers.breeze_buddy.demo import router as demo_router
+
+# Knowledge base (RAG) management: KBs, documents, retrieval testing
+from app.api.routers.breeze_buddy.knowledge_base import router as knowledge_base_router
 from app.api.routers.breeze_buddy.leads import router as leads_router
 from app.api.routers.breeze_buddy.merchants import router as merchants_router
 from app.api.routers.breeze_buddy.numbers import router as numbers_router
@@ -66,6 +69,9 @@ router.include_router(numbers_router, prefix="", tags=["numbers"])
 
 # Templates (conversational flow definitions)
 router.include_router(templates_router, prefix="", tags=["templates"])
+
+# Knowledge bases (merchant documents/sheets for agent RAG)
+router.include_router(knowledge_base_router, prefix="", tags=["knowledge-base"])
 
 # AI-assisted template generation / refinement (streaming SSE)
 router.include_router(template_generator_router, prefix="", tags=["template-generator"])

--- a/app/api/routers/breeze_buddy/knowledge_base/__init__.py
+++ b/app/api/routers/breeze_buddy/knowledge_base/__init__.py
@@ -1,0 +1,177 @@
+"""
+Knowledge base management endpoints with RBAC.
+
+Merchants upload documents (and later link Google Sheets) into
+merchant-scoped knowledge bases; agents retrieve from them at runtime via
+the template's ``configurations.knowledge_base`` attachment.
+
+Endpoints:
+- POST   /knowledge-bases                              - Create knowledge base
+- GET    /knowledge-bases/list                         - List (RBAC-filtered)
+- GET    /knowledge-bases/{id}                         - Get by ID
+- PUT    /knowledge-bases/{id}                         - Update metadata
+- DELETE /knowledge-bases/{id}                         - Delete (in-use check)
+- POST   /knowledge-bases/{id}/documents               - Upload file (multipart)
+- GET    /knowledge-bases/{id}/documents               - List documents + status
+- DELETE /knowledge-bases/{id}/documents/{doc_id}      - Delete document
+- POST   /knowledge-bases/{id}/documents/{doc_id}/sync - Manual re-sync
+- POST   /knowledge-bases/{id}/query                   - Retrieval testing
+"""
+
+from typing import Optional
+
+from fastapi import APIRouter, Depends, File, Query, UploadFile, status
+
+from app.api.security.breeze_buddy.rbac_token import get_current_user_with_rbac
+from app.schemas import UserInfo
+from app.schemas.breeze_buddy.knowledge_base import (
+    CreateKnowledgeBaseRequest,
+    DeleteKnowledgeBaseResponse,
+    KbDocument,
+    KbDocumentListResponse,
+    KnowledgeBase,
+    KnowledgeBaseListResponse,
+    QueryKnowledgeBaseRequest,
+    QueryKnowledgeBaseResponse,
+    UpdateKnowledgeBaseRequest,
+)
+
+from .handlers import (
+    create_kb_handler,
+    delete_document_handler,
+    delete_kb_handler,
+    get_kb_handler,
+    list_documents_handler,
+    list_kbs_handler,
+    query_kb_handler,
+    resync_document_handler,
+    update_kb_handler,
+    upload_document_handler,
+)
+from .rbac import require_admin_or_reseller_owner
+
+router = APIRouter()
+
+
+@router.post(
+    "/knowledge-bases",
+    response_model=KnowledgeBase,
+    status_code=status.HTTP_201_CREATED,
+)
+async def create_knowledge_base(
+    request: CreateKnowledgeBaseRequest,
+    current_user: UserInfo = Depends(get_current_user_with_rbac),
+):
+    """Create a knowledge base scoped to a reseller (optionally a merchant)."""
+    require_admin_or_reseller_owner(
+        current_user, request.reseller_id, "create knowledge bases"
+    )
+    return await create_kb_handler(request, current_user)
+
+
+@router.get("/knowledge-bases/list", response_model=KnowledgeBaseListResponse)
+async def list_knowledge_bases(
+    reseller_id: Optional[str] = Query(None, description="Filter by reseller ID"),
+    merchant_id: Optional[str] = Query(None, description="Filter by merchant ID"),
+    include_archived: bool = Query(False, description="Include archived KBs"),
+    search: Optional[str] = Query(None, description="Case-insensitive name search"),
+    page: Optional[int] = Query(None, ge=1, description="Page number (1-based)"),
+    limit: Optional[int] = Query(None, ge=1, le=100, description="Page size"),
+    current_user: UserInfo = Depends(get_current_user_with_rbac),
+):
+    """List knowledge bases accessible to the caller (JWT-scoped)."""
+    return await list_kbs_handler(
+        current_user, reseller_id, merchant_id, include_archived, search, page, limit
+    )
+
+
+@router.get("/knowledge-bases/{kb_id}", response_model=KnowledgeBase)
+async def get_knowledge_base(
+    kb_id: str,
+    current_user: UserInfo = Depends(get_current_user_with_rbac),
+):
+    """Get a knowledge base by ID (includes document/chunk counts)."""
+    return await get_kb_handler(kb_id, current_user)
+
+
+@router.put("/knowledge-bases/{kb_id}", response_model=KnowledgeBase)
+async def update_knowledge_base(
+    kb_id: str,
+    request: UpdateKnowledgeBaseRequest,
+    current_user: UserInfo = Depends(get_current_user_with_rbac),
+):
+    """Update knowledge base metadata/settings (embedding config is
+    immutable -- stored vectors depend on it)."""
+    return await update_kb_handler(kb_id, request, current_user)
+
+
+@router.delete("/knowledge-bases/{kb_id}", response_model=DeleteKnowledgeBaseResponse)
+async def delete_knowledge_base(
+    kb_id: str,
+    current_user: UserInfo = Depends(get_current_user_with_rbac),
+):
+    """Delete a knowledge base. 409 if any template still references it."""
+    return await delete_kb_handler(kb_id, current_user)
+
+
+@router.post(
+    "/knowledge-bases/{kb_id}/documents",
+    response_model=KbDocument,
+    status_code=status.HTTP_201_CREATED,
+)
+async def upload_document(
+    kb_id: str,
+    file: UploadFile = File(...),
+    current_user: UserInfo = Depends(get_current_user_with_rbac),
+):
+    """Upload a document (pdf/docx/xlsx/csv/txt/md). Stored in GCS, then
+    parsed/chunked/embedded by the background ingestion worker; poll the
+    documents list for READY/ERROR status."""
+    return await upload_document_handler(kb_id, file, current_user)
+
+
+@router.get("/knowledge-bases/{kb_id}/documents", response_model=KbDocumentListResponse)
+async def list_documents(
+    kb_id: str,
+    current_user: UserInfo = Depends(get_current_user_with_rbac),
+):
+    """List a knowledge base's documents with ingestion status."""
+    return await list_documents_handler(kb_id, current_user)
+
+
+@router.delete("/knowledge-bases/{kb_id}/documents/{document_id}")
+async def delete_document(
+    kb_id: str,
+    document_id: str,
+    current_user: UserInfo = Depends(get_current_user_with_rbac),
+):
+    """Delete a document and its chunks; the stored file is removed and
+    runtime knowledge caches refresh on the next turn."""
+    return await delete_document_handler(kb_id, document_id, current_user)
+
+
+@router.post(
+    "/knowledge-bases/{kb_id}/documents/{document_id}/sync",
+    response_model=KbDocument,
+)
+async def sync_document(
+    kb_id: str,
+    document_id: str,
+    current_user: UserInfo = Depends(get_current_user_with_rbac),
+):
+    """Manually re-sync a document (re-parse file / re-fetch sheet)."""
+    return await resync_document_handler(kb_id, document_id, current_user)
+
+
+@router.post(
+    "/knowledge-bases/{kb_id}/query", response_model=QueryKnowledgeBaseResponse
+)
+async def query_knowledge_base(
+    kb_id: str,
+    request: QueryKnowledgeBaseRequest,
+    current_user: UserInfo = Depends(get_current_user_with_rbac),
+):
+    """Retrieval testing ("hit testing"): run a query against this KB and
+    inspect the scored chunks. Powers the management UI test panel and
+    pre-launch accuracy evals."""
+    return await query_kb_handler(kb_id, request, current_user)

--- a/app/api/routers/breeze_buddy/knowledge_base/handlers.py
+++ b/app/api/routers/breeze_buddy/knowledge_base/handlers.py
@@ -1,0 +1,433 @@
+"""
+Business logic handlers for knowledge base operations.
+"""
+
+import asyncio
+import time
+from typing import Optional
+from uuid import UUID, uuid4
+
+import asyncpg
+from fastapi import HTTPException, UploadFile, status
+
+from app.core.config.dynamic import KB_MAX_DOCUMENTS_PER_KB, KB_MAX_FILE_MB
+from app.core.logger import logger
+from app.database.accessor.breeze_buddy.knowledge_base import (
+    create_kb_document,
+    create_knowledge_base,
+    delete_kb_document,
+    delete_knowledge_base,
+    find_templates_using_kb,
+    get_kb_document_by_id,
+    get_knowledge_base_by_id,
+    list_kb_documents,
+    list_knowledge_bases,
+    mark_kb_document_for_resync,
+    update_knowledge_base,
+)
+from app.schemas import UserInfo
+from app.schemas.breeze_buddy.knowledge_base import (
+    CreateKnowledgeBaseRequest,
+    DeleteKnowledgeBaseResponse,
+    EmbeddingConfig,
+    KbDocument,
+    KbDocumentListResponse,
+    KbDocumentSourceType,
+    KnowledgeBase,
+    KnowledgeBaseListResponse,
+    QueryKnowledgeBaseRequest,
+    QueryKnowledgeBaseResponse,
+    UpdateKnowledgeBaseRequest,
+)
+from app.services.gcp.storage.storage import GCSStorage
+from app.services.knowledge_base import kick_ingestion, retrieve
+from app.services.knowledge_base.ingestion import bump_kb_version
+
+from .rbac import (
+    accessible_scope_filters,
+    require_admin_or_reseller_owner,
+    validate_kb_access,
+)
+
+ALLOWED_UPLOAD_EXTENSIONS = {"pdf", "docx", "xlsx", "csv", "txt", "md"}
+
+
+def _require_uuid(value: str, label: str) -> None:
+    """Non-UUID path params 404 cleanly instead of surfacing an asyncpg
+    DataError as a 500 (uuid columns reject non-UUID parameter text)."""
+    try:
+        UUID(value)
+    except (ValueError, AttributeError, TypeError):
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"{label} {value} not found",
+        )
+
+
+async def _get_kb_or_404(kb_id: str) -> KnowledgeBase:
+    """Shared entry check for every KB-scoped endpoint: validate the path
+    param is a UUID, load the KB, 404 if absent. Callers follow with the
+    RBAC check appropriate to their operation (read vs write gate)."""
+    _require_uuid(kb_id, "Knowledge base")
+    kb = await get_knowledge_base_by_id(kb_id)
+    if kb is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Knowledge base {kb_id} not found",
+        )
+    return kb
+
+
+async def create_kb_handler(
+    request: CreateKnowledgeBaseRequest, current_user: UserInfo
+) -> KnowledgeBase:
+    """Create a knowledge base (POST /knowledge-bases).
+
+    Write-gated by ``require_admin_or_reseller_owner`` at the route.
+    Duplicate (reseller, merchant, name) maps to 409 via the typed
+    unique-violation catch; embedding config defaults to OpenAI 768-dim
+    and is frozen after creation.
+    """
+    logger.info(
+        f"User {current_user.username} creating knowledge base '{request.name}' "
+        f"for reseller {request.reseller_id}"
+    )
+    try:
+        kb = await create_knowledge_base(
+            reseller_id=request.reseller_id,
+            merchant_id=request.merchant_id,
+            name=request.name,
+            description=request.description,
+            embedding_config=(
+                request.embedding_config or EmbeddingConfig()
+            ).model_dump(),
+            settings=request.settings or {},
+        )
+    except asyncpg.UniqueViolationError as e:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=(
+                f"A knowledge base named '{request.name}' already exists "
+                f"for this reseller/merchant"
+            ),
+        ) from e
+    except Exception as e:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to create knowledge base",
+        ) from e
+    if kb is None:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to create knowledge base",
+        )
+    return kb
+
+
+async def list_kbs_handler(
+    current_user: UserInfo,
+    reseller_id: Optional[str],
+    merchant_id: Optional[str],
+    include_archived: bool,
+    search: Optional[str],
+    page: Optional[int],
+    limit: Optional[int],
+) -> KnowledgeBaseListResponse:
+    """List knowledge bases visible to the caller (GET /knowledge-bases/list).
+
+    Visibility comes from the JWT via ``accessible_scope_filters`` — request
+    params can only narrow it, never widen it. Backs the loom KB list page
+    and its template-attachment KB picker.
+    """
+    reseller_ids, merchant_ids = accessible_scope_filters(
+        current_user, reseller_id, merchant_id
+    )
+    knowledge_bases, total = await list_knowledge_bases(
+        reseller_ids=reseller_ids,
+        merchant_ids=merchant_ids,
+        include_archived=include_archived,
+        search=search,
+        page=page,
+        limit=limit,
+    )
+    return KnowledgeBaseListResponse(knowledge_bases=knowledge_bases, total=total)
+
+
+async def get_kb_handler(kb_id: str, current_user: UserInfo) -> KnowledgeBase:
+    """Get one knowledge base with live counts (GET /knowledge-bases/{id}).
+
+    Read-gated: any user whose JWT covers the KB's reseller/merchant may
+    view. Backs the loom KB detail page header.
+    """
+    kb = await _get_kb_or_404(kb_id)
+    validate_kb_access(current_user, kb.reseller_id, kb.merchant_id, "read")
+    return kb
+
+
+async def update_kb_handler(
+    kb_id: str, request: UpdateKnowledgeBaseRequest, current_user: UserInfo
+) -> KnowledgeBase:
+    """Update KB name/description/settings/status (PUT /knowledge-bases/{id}).
+
+    Write-gated. Only provided fields change; embedding config is
+    intentionally not editable here (stored vectors depend on it).
+    """
+    kb = await _get_kb_or_404(kb_id)
+    require_admin_or_reseller_owner(
+        current_user, kb.reseller_id, "update knowledge bases"
+    )
+    updated = await update_knowledge_base(
+        kb_id,
+        name=request.name,
+        description=request.description,
+        settings=request.settings,
+        status=request.status.value if request.status else None,
+    )
+    if updated is None:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to update knowledge base",
+        )
+    return updated
+
+
+async def delete_kb_handler(
+    kb_id: str, current_user: UserInfo
+) -> DeleteKnowledgeBaseResponse:
+    """Delete a knowledge base after the template in-use safety check."""
+    kb = await _get_kb_or_404(kb_id)
+    require_admin_or_reseller_owner(
+        current_user, kb.reseller_id, "delete knowledge bases"
+    )
+
+    templates_using = await find_templates_using_kb(kb_id)
+    if templates_using:
+        names = ", ".join(t["name"] for t in templates_using[:5])
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=(
+                f"Knowledge base is attached to {len(templates_using)} "
+                f"template(s) ({names}). Detach it before deleting."
+            ),
+        )
+
+    # Best-effort GCS cleanup before the CASCADE wipes the rows.
+    documents = await list_kb_documents(kb_id)
+    gcs_paths = [
+        d.source_ref.get("gcs_path")
+        for d in documents
+        if d.source_type == KbDocumentSourceType.FILE and d.source_ref.get("gcs_path")
+    ]
+    if gcs_paths:
+
+        def _cleanup():
+            # Best-effort sweep of the KB's stored files (sync client, run
+            # in a thread). Failures here don't block the DB delete.
+            storage = GCSStorage()
+            for path in gcs_paths:
+                storage.delete_file(path)
+
+        await asyncio.to_thread(_cleanup)
+
+    deleted = await delete_knowledge_base(kb_id)
+    if not deleted:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Knowledge base {kb_id} not found",
+        )
+    await bump_kb_version(kb_id)
+    return DeleteKnowledgeBaseResponse(
+        status="success",
+        kb_id=kb_id,
+        message=f"Knowledge base '{kb.name}' deleted with {len(documents)} document(s)",
+    )
+
+
+async def upload_document_handler(
+    kb_id: str, file: UploadFile, current_user: UserInfo
+) -> KbDocument:
+    """Upload a file into a knowledge base: validate -> GCS -> PENDING doc
+    -> immediate ingestion kick."""
+    kb = await _get_kb_or_404(kb_id)
+    require_admin_or_reseller_owner(current_user, kb.reseller_id, "upload documents")
+
+    filename = file.filename or "upload"
+    extension = filename.rsplit(".", 1)[-1].lower() if "." in filename else ""
+    if extension not in ALLOWED_UPLOAD_EXTENSIONS:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=(
+                f"Unsupported file type '.{extension}'. Supported: "
+                f"{', '.join(sorted(ALLOWED_UPLOAD_EXTENSIONS))}"
+            ),
+        )
+
+    max_docs = await KB_MAX_DOCUMENTS_PER_KB()
+    documents = await list_kb_documents(kb_id)
+    if len(documents) >= max_docs:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Knowledge base already has {len(documents)} documents "
+            f"(cap: {max_docs})",
+        )
+
+    max_mb = await KB_MAX_FILE_MB()
+    max_bytes = max_mb * 1024 * 1024
+    # Reject before buffering: file.size covers well-formed multipart bodies,
+    # and the capped read bounds memory even when size is absent or wrong.
+    if file.size is not None and file.size > max_bytes:
+        raise HTTPException(
+            status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            detail=f"File is {file.size // (1024 * 1024)}MB; the cap is {max_mb}MB",
+        )
+    data = await file.read(max_bytes + 1)
+    if len(data) > max_bytes:
+        raise HTTPException(
+            status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            detail=f"File exceeds the {max_mb}MB cap",
+        )
+    if not data:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail="Uploaded file is empty"
+        )
+
+    gcs_path = f"kb/{kb_id}/{uuid4()}/{filename}"
+
+    def _upload() -> bool:
+        # Sync GCS client — runs via asyncio.to_thread so the upload doesn't
+        # block the event loop shared with live calls.
+        import io
+
+        return GCSStorage().upload_file_object(
+            io.BytesIO(data), gcs_path, content_type=file.content_type
+        )
+
+    uploaded = await asyncio.to_thread(_upload)
+    if not uploaded:
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="Failed to store the file; try again",
+        )
+
+    document = await create_kb_document(
+        kb_id=kb_id,
+        source_type=KbDocumentSourceType.FILE.value,
+        name=filename,
+        source_ref={"gcs_path": gcs_path},
+        mime_type=file.content_type,
+        size_bytes=len(data),
+    )
+    if document is None:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to register the document",
+        )
+
+    kick_ingestion()
+    return document
+
+
+async def list_documents_handler(
+    kb_id: str, current_user: UserInfo
+) -> KbDocumentListResponse:
+    """List a KB's documents with ingestion status (GET .../documents).
+
+    Backs the loom documents table — status badges (PENDING/PROCESSING/
+    READY/ERROR), chunk counts and last-synced timestamps come from here.
+    """
+    kb = await _get_kb_or_404(kb_id)
+    validate_kb_access(current_user, kb.reseller_id, kb.merchant_id, "read")
+    documents = await list_kb_documents(kb_id)
+    return KbDocumentListResponse(documents=documents, total=len(documents))
+
+
+async def delete_document_handler(
+    kb_id: str, document_id: str, current_user: UserInfo
+) -> dict:
+    """Delete one document (DELETE .../documents/{id}).
+
+    Chunks go with it via CASCADE; the GCS object is removed best-effort in
+    a thread; the KB cache version is bumped so full-injection/token caches
+    refresh. The document must belong to the KB in the path (guards against
+    cross-KB ID probing).
+    """
+    kb = await _get_kb_or_404(kb_id)
+    require_admin_or_reseller_owner(current_user, kb.reseller_id, "delete documents")
+
+    _require_uuid(document_id, "Document")
+    document = await get_kb_document_by_id(document_id)
+    if document is None or document.kb_id != kb_id:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Document {document_id} not found in knowledge base {kb_id}",
+        )
+
+    gcs_path = document.source_ref.get("gcs_path")
+    if document.source_type == KbDocumentSourceType.FILE and gcs_path:
+        await asyncio.to_thread(lambda: GCSStorage().delete_file(gcs_path))
+
+    await delete_kb_document(document_id)
+    await bump_kb_version(kb_id)
+    return {
+        "status": "success",
+        "document_id": document_id,
+        "message": f"Document '{document.name}' deleted",
+    }
+
+
+async def resync_document_handler(
+    kb_id: str, document_id: str, current_user: UserInfo
+) -> KbDocument:
+    """Manual re-sync: send READY/ERROR back to PENDING and kick ingestion.
+
+    For files this re-parses the stored object; for google_sheet documents
+    (follow-up PR) it re-fetches the sheet.
+    """
+    kb = await _get_kb_or_404(kb_id)
+    require_admin_or_reseller_owner(current_user, kb.reseller_id, "sync documents")
+
+    _require_uuid(document_id, "Document")
+    document = await get_kb_document_by_id(document_id)
+    if document is None or document.kb_id != kb_id:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Document {document_id} not found in knowledge base {kb_id}",
+        )
+
+    requeued = await mark_kb_document_for_resync(document_id)
+    if requeued is None:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=f"Document is currently {document.status.value}; "
+            "wait for it to finish before re-syncing",
+        )
+
+    kick_ingestion()
+    return requeued
+
+
+async def query_kb_handler(
+    kb_id: str, request: QueryKnowledgeBaseRequest, current_user: UserInfo
+) -> QueryKnowledgeBaseResponse:
+    """Retrieval testing ("hit testing"): query -> scored chunks."""
+    kb = await _get_kb_or_404(kb_id)
+    validate_kb_access(current_user, kb.reseller_id, kb.merchant_id, "query")
+
+    started = time.perf_counter()
+    try:
+        chunks = await retrieve(
+            kb_ids=[kb_id],
+            query=request.query,
+            top_k=request.top_k,
+            score_threshold=request.score_threshold,
+        )
+    except Exception as e:
+        logger.error(f"Retrieval test failed for KB {kb_id}: {e}", exc_info=True)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Retrieval failed",
+        )
+    latency_ms = (time.perf_counter() - started) * 1000
+    return QueryKnowledgeBaseResponse(
+        query=request.query, chunks=chunks, latency_ms=round(latency_ms, 1)
+    )

--- a/app/api/routers/breeze_buddy/knowledge_base/rbac.py
+++ b/app/api/routers/breeze_buddy/knowledge_base/rbac.py
@@ -1,0 +1,133 @@
+"""
+RBAC utilities for knowledge base endpoints.
+Mirrors the templates router: reseller + merchant scoping from the JWT,
+never from request parameters alone.
+"""
+
+from typing import List, Optional, Tuple
+
+from fastapi import HTTPException, status
+
+from app.core.logger import logger
+from app.schemas import UserInfo
+
+
+def validate_kb_access(
+    current_user: UserInfo,
+    reseller_id: str,
+    merchant_id: Optional[str],
+    operation: str = "access",
+) -> None:
+    """Validate the user can touch a KB belonging to reseller/merchant.
+
+    Raises:
+        HTTPException: 403 if the user lacks permission
+    """
+    if current_user.role == "admin":
+        return
+
+    if (
+        reseller_id not in current_user.reseller_ids
+        and "*" not in current_user.reseller_ids
+    ):
+        logger.warning(
+            f"User {current_user.username} attempted to {operation} knowledge "
+            f"base for unauthorized reseller: {reseller_id}"
+        )
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=f"Access denied to reseller {reseller_id}",
+        )
+
+    if merchant_id:
+        if (
+            merchant_id not in current_user.merchant_ids
+            and "*" not in current_user.merchant_ids
+        ):
+            logger.warning(
+                f"User {current_user.username} attempted to {operation} knowledge "
+                f"base for unauthorized merchant: {merchant_id}"
+            )
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail=f"Access denied to merchant {merchant_id}",
+            )
+
+
+def require_admin_or_reseller_owner(
+    current_user: UserInfo, reseller_id: str, operation: str = "perform this operation"
+) -> None:
+    """Write-gate: admin, or a user owning the target reseller.
+
+    Raises:
+        HTTPException: 403 if the user lacks permission
+    """
+    if current_user.role == "admin":
+        return
+
+    if reseller_id in current_user.reseller_ids or "*" in current_user.reseller_ids:
+        return
+
+    logger.warning(
+        f"User {current_user.username} (role: {current_user.role}) attempted "
+        f"to {operation} for unauthorized reseller: {reseller_id}"
+    )
+    raise HTTPException(
+        status_code=status.HTTP_403_FORBIDDEN,
+        detail=f"Access denied to {operation} for reseller {reseller_id}",
+    )
+
+
+def accessible_scope_filters(
+    current_user: UserInfo,
+    reseller_id: Optional[str],
+    merchant_id: Optional[str],
+) -> Tuple[Optional[List[str]], Optional[List[str]]]:
+    """Resolve list filters from the JWT (+ optional narrowing params).
+
+    Returns (reseller_ids, merchant_ids) where None means unrestricted
+    (admin/wildcard). Requested narrowing filters are validated against the
+    JWT scope.
+
+    Raises:
+        HTTPException: 403 on out-of-scope filter requests
+    """
+    if current_user.role == "admin" or "*" in current_user.reseller_ids:
+        reseller_ids = [reseller_id] if reseller_id else None
+    else:
+        if reseller_id:
+            if reseller_id not in current_user.reseller_ids:
+                raise HTTPException(
+                    status_code=status.HTTP_403_FORBIDDEN,
+                    detail=f"Access denied to reseller {reseller_id}",
+                )
+            reseller_ids = [reseller_id]
+        else:
+            if not current_user.reseller_ids:
+                raise HTTPException(
+                    status_code=status.HTTP_403_FORBIDDEN,
+                    detail="Access denied: user has no reseller assignments",
+                )
+            reseller_ids = current_user.reseller_ids
+
+    if current_user.role == "admin" or "*" in current_user.merchant_ids:
+        merchant_ids = [merchant_id] if merchant_id else None
+    else:
+        if merchant_id:
+            if merchant_id not in current_user.merchant_ids:
+                raise HTTPException(
+                    status_code=status.HTTP_403_FORBIDDEN,
+                    detail=f"Access denied to merchant {merchant_id}",
+                )
+            merchant_ids = [merchant_id]
+        else:
+            # Empty list means NO assignments — mirror templates RBAC and
+            # deny, never widen to unrestricted (None) visibility.
+            if not current_user.merchant_ids:
+                raise HTTPException(
+                    status_code=status.HTTP_403_FORBIDDEN,
+                    detail="Access denied: user has no merchant assignments",
+                )
+            merchant_ids = current_user.merchant_ids
+
+    return reseller_ids, merchant_ids

--- a/app/core/config/dynamic.py
+++ b/app/core/config/dynamic.py
@@ -600,3 +600,62 @@ async def AZURE_OPENAI_REALTIME_ENDPOINT() -> str:
     ``llm_configurations.realtime.endpoint``.
     """
     return await get_config("AZURE_OPENAI_REALTIME_ENDPOINT", "", str)
+
+
+# --- Knowledge Base (RAG) ---
+async def KB_INGEST_BATCH_SIZE() -> int:
+    """Max documents the ingestion worker claims per tick/kick."""
+    return await get_config("KB_INGEST_BATCH_SIZE", 5, int)
+
+
+async def KB_INGESTION_INTERVAL_SECONDS() -> int:
+    """Scheduler sweep interval for the KB ingestion task (read at startup).
+
+    Hardened against malformed env overrides (get_env_value returns the RAW
+    string when int() conversion fails): a bad value here would raise inside
+    the startup try-block and silently disable ALL background tasks.
+    """
+    value = await get_config("KB_INGESTION_INTERVAL_SECONDS", 60, int)
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        logger.warning(
+            f"Invalid KB_INGESTION_INTERVAL_SECONDS value {value!r}; using 60"
+        )
+        return 60
+
+
+async def KB_STALE_PROCESSING_MINUTES() -> int:
+    """Documents stuck in PROCESSING longer than this are requeued
+    (crashed/redeployed worker pod)."""
+    return await get_config("KB_STALE_PROCESSING_MINUTES", 15, int)
+
+
+async def KB_MAX_FILE_MB() -> int:
+    """Per-file upload size cap (also bounds parser memory/time)."""
+    return await get_config("KB_MAX_FILE_MB", 20, int)
+
+
+async def KB_MAX_DOCUMENTS_PER_KB() -> int:
+    """Per-knowledge-base document count cap."""
+    return await get_config("KB_MAX_DOCUMENTS_PER_KB", 100, int)
+
+
+async def KB_MAX_CHUNKS_PER_KB() -> int:
+    """Per-knowledge-base chunk cap (~40MB of text at 450-token chunks)."""
+    return await get_config("KB_MAX_CHUNKS_PER_KB", 25000, int)
+
+
+async def KB_MERCHANT_MAX_CHUNKS() -> int:
+    """Per-reseller total chunk cap across all knowledge bases
+    (noisy-neighbor protection for ingestion; raise per merchant on request).
+
+    Default is sized to launch infra (~30MB of text / ~140MB of DB footprint
+    per reseller on a 15GB instance); the per-KB cap above only binds once
+    this one has been raised for a reseller."""
+    return await get_config("KB_MERCHANT_MAX_CHUNKS", 20000, int)
+
+
+async def KB_EMBED_CACHE_TTL_SECONDS() -> int:
+    """TTL for the Redis query-embedding cache on the retrieval hot path."""
+    return await get_config("KB_EMBED_CACHE_TTL_SECONDS", 3600, int)

--- a/app/database/accessor/breeze_buddy/knowledge_base.py
+++ b/app/database/accessor/breeze_buddy/knowledge_base.py
@@ -1,0 +1,503 @@
+"""
+Database accessor functions for knowledge base entities.
+"""
+
+from typing import Any, Dict, List, Optional, Tuple
+from uuid import uuid4
+
+import asyncpg
+
+from app.core.logger import logger
+from app.database import get_db_connection
+from app.database.decoder.breeze_buddy.knowledge_base import (
+    decode_kb_document_list,
+    decode_knowledge_base_list,
+    decode_retrieved_chunk_list,
+    decode_single_kb_document,
+    decode_single_knowledge_base,
+)
+from app.database.queries import run_parameterized_query
+from app.database.queries.breeze_buddy.knowledge_base import (
+    claim_pending_kb_documents_query,
+    delete_kb_chunks_beyond_index_query,
+    delete_kb_document_query,
+    delete_knowledge_base_query,
+    find_templates_using_kb_query,
+    finish_kb_document_query,
+    get_chunk_hashes_for_document_query,
+    get_kb_document_by_id_query,
+    get_kb_full_text_query,
+    get_kb_token_total_query,
+    get_knowledge_base_by_id_query,
+    get_merchant_chunk_total_query,
+    hybrid_search_chunks_query,
+    insert_kb_document_query,
+    insert_knowledge_base_query,
+    list_kb_documents_query,
+    list_knowledge_bases_query,
+    mark_kb_document_for_resync_query,
+    requeue_stale_processing_documents_query,
+    update_knowledge_base_query,
+    upsert_kb_chunk_query,
+)
+from app.schemas.breeze_buddy.knowledge_base import (
+    KbDocument,
+    KnowledgeBase,
+    RetrievedChunk,
+)
+
+# pgvector >= 0.8 supports iterative index scans, which fix HNSW returning
+# fewer than k rows when the KB filter discards most candidates. Older
+# pgvector rejects the GUC; probe once and remember.
+_iterative_scan_supported: Optional[bool] = None
+
+
+async def create_knowledge_base(
+    reseller_id: str,
+    merchant_id: Optional[str],
+    name: str,
+    description: Optional[str],
+    embedding_config: Dict[str, Any],
+    settings: Dict[str, Any],
+) -> Optional[KnowledgeBase]:
+    """Create a new knowledge base row and return it decoded.
+
+    Called from ``create_kb_handler`` (POST /knowledge-bases). Re-raises
+    ``asyncpg.UniqueViolationError`` untouched so the handler can map
+    duplicate names to a 409.
+    """
+    logger.info(f"Creating knowledge base '{name}' for reseller {reseller_id}")
+    try:
+        query_text, values = insert_knowledge_base_query(
+            id=str(uuid4()),
+            reseller_id=reseller_id,
+            merchant_identifier=merchant_id,
+            name=name,
+            description=description,
+            embedding_config=embedding_config,
+            settings=settings,
+        )
+        result = await run_parameterized_query(query_text, values)
+        return decode_single_knowledge_base(result)
+    except Exception as e:
+        logger.error(f"Error creating knowledge base '{name}': {e}", exc_info=True)
+        raise
+
+
+async def get_knowledge_base_by_id(kb_id: str) -> Optional[KnowledgeBase]:
+    """Get a knowledge base by ID (with live document/chunk counts).
+
+    The most-shared read in the feature: API handlers (via ``_get_kb_or_404``),
+    the ingestion worker (quota checks + embedding config) and retrieval
+    (``_resolve_embedding_config`` on the query path) all come through here.
+    """
+    try:
+        query_text, values = get_knowledge_base_by_id_query(kb_id)
+        result = await run_parameterized_query(query_text, values)
+        return decode_single_knowledge_base(result)
+    except Exception as e:
+        logger.error(f"Error getting knowledge base {kb_id}: {e}")
+        raise
+
+
+async def list_knowledge_bases(
+    reseller_ids: Optional[List[str]] = None,
+    merchant_ids: Optional[List[str]] = None,
+    include_archived: bool = False,
+    search: Optional[str] = None,
+    page: Optional[int] = None,
+    limit: Optional[int] = None,
+) -> Tuple[List[KnowledgeBase], int]:
+    """List knowledge bases with RBAC filters. Returns (items, total).
+
+    ``total`` is the unpaginated match count (window function) so the loom
+    list page can paginate. Filters arrive pre-validated from
+    ``accessible_scope_filters``; None means unrestricted (admin/wildcard).
+    Called from ``list_kbs_handler`` (GET /knowledge-bases/list).
+    """
+    try:
+        query_text, values = list_knowledge_bases_query(
+            reseller_ids=reseller_ids,
+            merchant_ids=merchant_ids,
+            include_archived=include_archived,
+            search=search,
+            page=page,
+            limit=limit,
+        )
+        result = await run_parameterized_query(query_text, values)
+        total = result[0]["total_count"] if result else 0
+        return decode_knowledge_base_list(result), total
+    except Exception as e:
+        logger.error(f"Error listing knowledge bases: {e}")
+        raise
+
+
+async def update_knowledge_base(
+    kb_id: str,
+    name: Optional[str] = None,
+    description: Optional[str] = None,
+    settings: Optional[Dict[str, Any]] = None,
+    status: Optional[str] = None,
+) -> Optional[KnowledgeBase]:
+    """Update a knowledge base's metadata. Only provided fields change.
+
+    Called from ``update_kb_handler`` (PUT /knowledge-bases/{id}) — name,
+    description, settings and ACTIVE/ARCHIVED status. ``embedding_config``
+    is deliberately not updatable: stored vectors were produced with it.
+    """
+    try:
+        query_text, values = update_knowledge_base_query(
+            kb_id, name=name, description=description, settings=settings, status=status
+        )
+        result = await run_parameterized_query(query_text, values)
+        return decode_single_knowledge_base(result)
+    except Exception as e:
+        logger.error(f"Error updating knowledge base {kb_id}: {e}", exc_info=True)
+        raise
+
+
+async def delete_knowledge_base(kb_id: str) -> bool:
+    """Delete a knowledge base (documents and chunks CASCADE).
+
+    Called from ``delete_kb_handler`` only after the template in-use check
+    and GCS cleanup have run; returns False when the row was already gone.
+    """
+    logger.info(f"Deleting knowledge base {kb_id}")
+    try:
+        query_text, values = delete_knowledge_base_query(kb_id)
+        result = await run_parameterized_query(query_text, values)
+        return bool(result)
+    except Exception as e:
+        logger.error(f"Error deleting knowledge base {kb_id}: {e}")
+        raise
+
+
+async def find_templates_using_kb(kb_id: str) -> List[Dict[str, Any]]:
+    """Find templates whose configurations reference this KB (delete safety)."""
+    try:
+        query_text, values = find_templates_using_kb_query(kb_id)
+        result = await run_parameterized_query(query_text, values)
+        return [
+            {
+                "id": str(row["id"]),
+                "name": row["name"],
+                "reseller_id": row["reseller_id"],
+                "merchant_id": row["merchant_identifier"],
+            }
+            for row in result
+        ]
+    except Exception as e:
+        logger.error(f"Error finding templates using KB {kb_id}: {e}")
+        raise
+
+
+# ---------------------------------------------------------------------------
+# Documents
+# ---------------------------------------------------------------------------
+
+
+async def create_kb_document(
+    kb_id: str,
+    source_type: str,
+    name: str,
+    source_ref: Dict[str, Any],
+    mime_type: Optional[str] = None,
+    size_bytes: Optional[int] = None,
+    content_hash: Optional[str] = None,
+) -> Optional[KbDocument]:
+    """Create a document in PENDING state (picked up by ingestion)."""
+    try:
+        query_text, values = insert_kb_document_query(
+            id=str(uuid4()),
+            kb_id=kb_id,
+            source_type=source_type,
+            name=name,
+            source_ref=source_ref,
+            mime_type=mime_type,
+            size_bytes=size_bytes,
+            content_hash=content_hash,
+        )
+        result = await run_parameterized_query(query_text, values)
+        return decode_single_kb_document(result)
+    except Exception as e:
+        logger.error(f"Error creating document '{name}' in KB {kb_id}: {e}")
+        raise
+
+
+async def get_kb_document_by_id(document_id: str) -> Optional[KbDocument]:
+    """Get a document by ID.
+
+    Used by the document delete / manual re-sync handlers (existence +
+    ownership checks before acting).
+    """
+    try:
+        query_text, values = get_kb_document_by_id_query(document_id)
+        result = await run_parameterized_query(query_text, values)
+        return decode_single_kb_document(result)
+    except Exception as e:
+        logger.error(f"Error getting document {document_id}: {e}")
+        raise
+
+
+async def list_kb_documents(kb_id: str) -> List[KbDocument]:
+    """List all documents of a knowledge base, newest first.
+
+    Serves the loom documents table (GET .../documents), the upload
+    handler's per-KB document cap, and KB delete's GCS cleanup sweep.
+    """
+    try:
+        query_text, values = list_kb_documents_query(kb_id)
+        result = await run_parameterized_query(query_text, values)
+        return decode_kb_document_list(result)
+    except Exception as e:
+        logger.error(f"Error listing documents for KB {kb_id}: {e}")
+        raise
+
+
+async def claim_pending_kb_documents(batch_size: int) -> List[KbDocument]:
+    """Atomically claim PENDING documents for processing (race-safe)."""
+    try:
+        query_text, values = claim_pending_kb_documents_query(batch_size)
+        result = await run_parameterized_query(query_text, values)
+        return decode_kb_document_list(result)
+    except Exception as e:
+        logger.error(f"Error claiming pending documents: {e}")
+        raise
+
+
+async def requeue_stale_processing_documents(stale_minutes: int) -> int:
+    """Requeue documents stuck in PROCESSING (crashed worker) back to PENDING.
+
+    Self-healing sweep run at the start of every ingestion tick
+    (``process_pending_documents``): if a pod died mid-ingest, its claimed
+    documents become claimable again after ``stale_minutes``.
+    """
+    try:
+        query_text, values = requeue_stale_processing_documents_query(stale_minutes)
+        result = await run_parameterized_query(query_text, values)
+        if result:
+            logger.warning(f"Requeued {len(result)} stale PROCESSING documents")
+        return len(result)
+    except Exception as e:
+        logger.error(f"Error requeuing stale documents: {e}")
+        raise
+
+
+async def mark_kb_document_for_resync(document_id: str) -> Optional[KbDocument]:
+    """Send a READY/ERROR document back to PENDING for re-ingestion."""
+    try:
+        query_text, values = mark_kb_document_for_resync_query(document_id)
+        result = await run_parameterized_query(query_text, values)
+        return decode_single_kb_document(result)
+    except Exception as e:
+        logger.error(f"Error marking document {document_id} for resync: {e}")
+        raise
+
+
+async def finish_kb_document(
+    document_id: str,
+    status: str,
+    error_message: Optional[str] = None,
+    content_hash: Optional[str] = None,
+    chunk_count: int = 0,
+    token_count: int = 0,
+) -> Optional[KbDocument]:
+    """Finalize a document after an ingestion run (READY or ERROR).
+
+    Called only from the ingestion worker's ``_process_document`` — both the
+    success path (fresh counts, content hash) and the failure path (error
+    message shown in the loom UI).
+    """
+    try:
+        query_text, values = finish_kb_document_query(
+            document_id, status, error_message, content_hash, chunk_count, token_count
+        )
+        result = await run_parameterized_query(query_text, values)
+        return decode_single_kb_document(result)
+    except Exception as e:
+        logger.error(f"Error finalizing document {document_id}: {e}")
+        raise
+
+
+async def delete_kb_document(document_id: str) -> bool:
+    """Delete a document (chunks CASCADE); False if it didn't exist.
+
+    Called from ``delete_document_handler`` after RBAC; the handler also
+    removes the GCS object and bumps the KB cache version.
+    """
+    try:
+        query_text, values = delete_kb_document_query(document_id)
+        result = await run_parameterized_query(query_text, values)
+        return bool(result)
+    except Exception as e:
+        logger.error(f"Error deleting document {document_id}: {e}")
+        raise
+
+
+async def get_merchant_chunk_total(reseller_id: str) -> int:
+    """Total chunks across a reseller's KBs.
+
+    Feeds the per-reseller quota check in ingestion
+    (``_enforce_chunk_quotas`` vs ``KB_MERCHANT_MAX_CHUNKS``) — the
+    noisy-neighbor guard for shared-instance capacity.
+    """
+    try:
+        query_text, values = get_merchant_chunk_total_query(reseller_id)
+        result = await run_parameterized_query(query_text, values)
+        return int(result[0]["total"]) if result else 0
+    except Exception as e:
+        logger.error(f"Error getting chunk total for reseller {reseller_id}: {e}")
+        raise
+
+
+# ---------------------------------------------------------------------------
+# Chunks
+# ---------------------------------------------------------------------------
+
+
+async def get_chunk_hashes_for_document(document_id: str) -> Dict[int, str]:
+    """Existing chunk_index -> content_hash map (incremental re-embedding)."""
+    try:
+        query_text, values = get_chunk_hashes_for_document_query(document_id)
+        result = await run_parameterized_query(query_text, values)
+        return {row["chunk_index"]: row["content_hash"] for row in result}
+    except Exception as e:
+        logger.error(f"Error getting chunk hashes for document {document_id}: {e}")
+        raise
+
+
+async def upsert_kb_chunk(
+    document_id: str,
+    kb_id: str,
+    chunk_index: int,
+    text: str,
+    content_hash: str,
+    embedding: List[float],
+    metadata: Dict[str, Any],
+    token_count: int,
+) -> None:
+    """Insert or replace one chunk at (document_id, chunk_index).
+
+    Called from the ingestion embed loop for chunks whose content hash
+    changed. Together with ``delete_kb_chunks_beyond_index`` this is the
+    WRITE seam of the vector store (see ingestion.py module docstring).
+    """
+    try:
+        query_text, values = upsert_kb_chunk_query(
+            id=str(uuid4()),
+            document_id=document_id,
+            kb_id=kb_id,
+            chunk_index=chunk_index,
+            text_content=text,
+            content_hash=content_hash,
+            embedding=embedding,
+            metadata=metadata,
+            token_count=token_count,
+        )
+        await run_parameterized_query(query_text, values)
+    except Exception as e:
+        logger.error(
+            f"Error upserting chunk {chunk_index} of document {document_id}: {e}"
+        )
+        raise
+
+
+async def delete_kb_chunks_beyond_index(
+    document_id: str, max_index_exclusive: int
+) -> None:
+    """Delete chunks past the new chunk list's end (document shrank)."""
+    try:
+        query_text, values = delete_kb_chunks_beyond_index_query(
+            document_id, max_index_exclusive
+        )
+        await run_parameterized_query(query_text, values)
+    except Exception as e:
+        logger.error(f"Error trimming chunks for document {document_id}: {e}")
+        raise
+
+
+async def get_kb_full_text_rows(kb_ids: List[str]) -> List[Tuple[str, str]]:
+    """All READY chunk texts (with document names) for full-injection mode."""
+    try:
+        query_text, values = get_kb_full_text_query(kb_ids)
+        result = await run_parameterized_query(query_text, values)
+        return [(row["document_name"], row["text"]) for row in result]
+    except Exception as e:
+        logger.error(f"Error getting full KB text for {kb_ids}: {e}")
+        raise
+
+
+async def get_kb_token_total(kb_ids: List[str]) -> int:
+    """Total READY token count across KBs (AUTO mode size tiering)."""
+    try:
+        query_text, values = get_kb_token_total_query(kb_ids)
+        result = await run_parameterized_query(query_text, values)
+        return int(result[0]["total"]) if result else 0
+    except Exception as e:
+        logger.error(f"Error getting token total for KBs {kb_ids}: {e}")
+        raise
+
+
+async def hybrid_search_chunks(
+    kb_ids: List[str],
+    query_embedding: List[float],
+    query_text: str,
+    top_k: int,
+    candidate_k: int = 50,
+) -> List[RetrievedChunk]:
+    """Run the single hybrid retrieval query (vector + FTS + trigram, RRF).
+
+    Uses a dedicated connection so pgvector's iterative scan mode can be set
+    with transaction scope (``SET LOCAL``) when available.
+    """
+    global _iterative_scan_supported
+    sql, values = hybrid_search_chunks_query(
+        kb_ids=kb_ids,
+        query_embedding=query_embedding,
+        query_text=query_text,
+        top_k=top_k,
+        candidate_k=candidate_k,
+    )
+    try:
+        async for conn in get_db_connection():
+            # Probe the pgvector >= 0.8 GUC once, in its OWN transaction so a
+            # failed probe can't poison the query transaction. Only a missing
+            # GUC pins the flag False; transient errors leave it None so the
+            # next call re-probes instead of permanently degrading.
+            if _iterative_scan_supported is None:
+                try:
+                    async with conn.transaction():
+                        await conn.execute(
+                            "SET LOCAL hnsw.iterative_scan = 'relaxed_order'"
+                        )
+                    _iterative_scan_supported = True
+                except asyncpg.UndefinedObjectError:
+                    # SQLSTATE 42704 — the GUC doesn't exist. Typed catch is
+                    # locale-independent (message-matching breaks under a
+                    # non-English lc_messages and would re-probe every call).
+                    _iterative_scan_supported = False
+                    logger.info(
+                        "pgvector iterative scan unavailable (pgvector < 0.8); "
+                        "proceeding without"
+                    )
+                except Exception as probe_error:
+                    logger.warning(
+                        f"pgvector iterative-scan probe failed transiently, "
+                        f"will re-probe: {probe_error}"
+                    )
+
+            # Single execution path: session GUCs are always applied together
+            # regardless of the probe outcome.
+            async with conn.transaction():
+                if _iterative_scan_supported:
+                    await conn.execute(
+                        "SET LOCAL hnsw.iterative_scan = 'relaxed_order'"
+                    )
+                # Loosen the trigram leg (default 0.6 misses moderate typos).
+                await conn.execute("SET LOCAL pg_trgm.word_similarity_threshold = 0.3")
+                rows = await conn.fetch(sql, *values)
+                return decode_retrieved_chunk_list(rows)
+        return []
+    except Exception as e:
+        logger.error(f"Error in hybrid search over KBs {kb_ids}: {e}")
+        raise

--- a/app/database/decoder/breeze_buddy/knowledge_base.py
+++ b/app/database/decoder/breeze_buddy/knowledge_base.py
@@ -1,0 +1,169 @@
+"""
+Decoder functions for knowledge_base, kb_document and kb_chunk rows.
+"""
+
+import json
+from typing import Any, Dict, List, Optional
+
+import asyncpg
+
+from app.schemas.breeze_buddy.knowledge_base import (
+    EmbeddingConfig,
+    KbDocument,
+    KnowledgeBase,
+    RetrievedChunk,
+)
+
+
+def _jsonb(value: Any) -> Dict[str, Any]:
+    """Coerce a JSONB column to a dict.
+
+    asyncpg returns JSONB as ``str`` unless a codec is registered on the
+    pool (we don't register one), so every JSONB field in this module goes
+    through here; also normalizes NULL to ``{}``.
+    """
+    if value is None:
+        return {}
+    if isinstance(value, dict):
+        return value
+    return json.loads(value)
+
+
+def decode_knowledge_base(row: asyncpg.Record) -> KnowledgeBase:
+    """Decode a single knowledge_base row (optionally with count columns)."""
+    embedding_config = _jsonb(row["embedding_config"])
+    keys = row.keys()
+    return KnowledgeBase(
+        id=str(row["id"]),
+        reseller_id=row["reseller_id"],
+        merchant_id=row["merchant_identifier"],
+        name=row["name"],
+        description=row["description"],
+        embedding_config=(
+            EmbeddingConfig(**embedding_config)
+            if embedding_config
+            else EmbeddingConfig()
+        ),
+        settings=_jsonb(row["settings"]),
+        status=row["status"],
+        document_count=row["document_count"] if "document_count" in keys else None,
+        chunk_count=row["chunk_count"] if "chunk_count" in keys else None,
+        created_at=row["created_at"],
+        updated_at=row["updated_at"],
+    )
+
+
+def decode_knowledge_base_list(
+    result: Optional[List[asyncpg.Record]],
+) -> List[KnowledgeBase]:
+    """Decode a list result into KnowledgeBase models ([] for empty/None).
+
+    Standard list-shape wrapper used by accessor ``list_knowledge_bases``.
+    """
+    if not result:
+        return []
+    return [decode_knowledge_base(row) for row in result]
+
+
+def decode_single_knowledge_base(
+    result: Optional[List[asyncpg.Record]],
+) -> Optional[KnowledgeBase]:
+    """Decode the first row of a result, or None when nothing matched.
+
+    Used by accessors whose query returns at most one row (get by id,
+    create/update RETURNING).
+    """
+    if not result or len(result) == 0:
+        return None
+    return decode_knowledge_base(result[0])
+
+
+def decode_kb_document(row: asyncpg.Record) -> KbDocument:
+    """Decode one kb_document row into the KbDocument model.
+
+    ``source_ref`` (GCS path / spreadsheet id) comes through the JSONB
+    helper; status stays the raw enum string and is validated by Pydantic.
+    """
+    return KbDocument(
+        id=str(row["id"]),
+        kb_id=str(row["kb_id"]),
+        source_type=row["source_type"],
+        name=row["name"],
+        source_ref=_jsonb(row["source_ref"]),
+        mime_type=row["mime_type"],
+        size_bytes=row["size_bytes"],
+        status=row["status"],
+        error_message=row["error_message"],
+        content_hash=row["content_hash"],
+        chunk_count=row["chunk_count"],
+        token_count=row["token_count"],
+        synced_at=row["synced_at"],
+        created_at=row["created_at"],
+        updated_at=row["updated_at"],
+    )
+
+
+def decode_kb_document_list(
+    result: Optional[List[asyncpg.Record]],
+) -> List[KbDocument]:
+    """Decode a list result into KbDocument models ([] for empty/None).
+
+    Used by document listing, the ingestion claim query and the sheets
+    poller's due-documents query.
+    """
+    if not result:
+        return []
+    return [decode_kb_document(row) for row in result]
+
+
+def decode_single_kb_document(
+    result: Optional[List[asyncpg.Record]],
+) -> Optional[KbDocument]:
+    """Decode the first document row of a result, or None when absent.
+
+    Used by get-by-id, resync and finish accessors (single-row queries).
+    """
+    if not result or len(result) == 0:
+        return None
+    return decode_kb_document(result[0])
+
+
+def decode_retrieved_chunk(row: asyncpg.Record) -> RetrievedChunk:
+    """Decode one hybrid-search hit into a RetrievedChunk.
+
+    ``score`` is the RRF fusion score (only meaningful for ordering);
+    ``vector_similarity`` is the cosine similarity of the vector leg and is
+    None for keyword-only hits — retrieval's score_threshold deliberately
+    skips those (exact SKU matches shouldn't be dropped for lacking a
+    cosine score).
+    """
+    return RetrievedChunk(
+        id=str(row["id"]),
+        document_id=str(row["document_id"]),
+        kb_id=str(row["kb_id"]),
+        chunk_index=row["chunk_index"],
+        text=row["text"],
+        metadata=_jsonb(row["metadata"]),
+        token_count=row["token_count"],
+        score=float(row["score"]) if row["score"] is not None else 0.0,
+        vector_similarity=(
+            float(row["vector_similarity"])
+            if row["vector_similarity"] is not None
+            else None
+        ),
+        document_name=row["document_name"],
+    )
+
+
+def decode_retrieved_chunk_list(
+    result: Optional[List[asyncpg.Record]],
+) -> List[RetrievedChunk]:
+    """Decode hybrid-search rows into RetrievedChunk list ([] for none).
+
+    Terminal step of ``hybrid_search_chunks`` — everything the runtime
+    (voice/chat/tool) and the /query hit-testing endpoint see comes
+    through here.
+    """
+    if not result:
+        return []
+    return [decode_retrieved_chunk(row) for row in result]

--- a/app/database/migrations/034_knowledge_base.sql
+++ b/app/database/migrations/034_knowledge_base.sql
@@ -1,0 +1,115 @@
+-- Migration 034: Knowledge Base (RAG) storage.
+--
+-- Merchants upload documents (files now; Google Sheets / text in follow-ups)
+-- into merchant-scoped knowledge bases. Documents are parsed, chunked and
+-- embedded by a background ingestion task; agents retrieve at runtime via
+-- hybrid search (pgvector HNSW + full-text + trigram, RRF-fused) with a
+-- strict latency budget on the voice path.
+--
+-- Design notes:
+-- * ``halfvec(768)``: all embedding providers are normalized to 768 dims via
+--   Matryoshka truncation + L2 renorm, so one column/index serves every
+--   provider and fp16 halves storage vs ``vector``.
+-- * ``tsv`` uses the 'simple' config (no stemming): merchant content mixes
+--   English/Hinglish/SKUs where stemming hurts exact matches; the trigram
+--   index adds typo tolerance for the keyword leg.
+-- * Template <-> KB attachment lives in template ``configurations`` JSONB
+--   (same precedent as MCP config) -- no join table. KB deletion does an
+--   in-use scan over template configurations at the API layer.
+-- * DEPLOYMENT PREREQUISITE: the Postgres instance must allow
+--   ``CREATE EXTENSION vector`` (pgvector) and ``pg_trgm`` (RDS/Cloud SQL do).
+
+CREATE EXTENSION IF NOT EXISTS vector;
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+
+CREATE TABLE IF NOT EXISTS knowledge_base (
+    id                  uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    reseller_id         varchar(255) NOT NULL,
+    merchant_identifier varchar(255),
+    name                varchar(255) NOT NULL,
+    description         text,
+    -- {"provider": "openai", "model": "text-embedding-3-small", "dimensions": 768}
+    embedding_config    jsonb NOT NULL DEFAULT '{}'::jsonb,
+    settings            jsonb NOT NULL DEFAULT '{}'::jsonb,
+    status              varchar(20) NOT NULL DEFAULT 'ACTIVE'
+        CHECK (status IN ('ACTIVE', 'ARCHIVED')),
+    created_at          timestamptz NOT NULL DEFAULT now(),
+    updated_at          timestamptz NOT NULL DEFAULT now()
+);
+
+-- Name uniqueness must also hold for reseller-level KBs (merchant NULL):
+-- a plain UNIQUE constraint treats NULLs as distinct, so mirror the
+-- template table's split partial-index pattern (migration 018).
+CREATE UNIQUE INDEX IF NOT EXISTS uq_knowledge_base_reseller_merchant_name
+    ON knowledge_base (reseller_id, merchant_identifier, name)
+    WHERE merchant_identifier IS NOT NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_knowledge_base_reseller_name_no_merchant
+    ON knowledge_base (reseller_id, name)
+    WHERE merchant_identifier IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_knowledge_base_reseller
+    ON knowledge_base (reseller_id);
+
+CREATE TABLE IF NOT EXISTS kb_document (
+    id            uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    kb_id         uuid NOT NULL REFERENCES knowledge_base(id) ON DELETE CASCADE,
+    -- 'text' is reserved for a future inline-snippet source; only 'file' and
+    -- 'google_sheet' get API surface in v1.
+    source_type   varchar(20) NOT NULL
+        CHECK (source_type IN ('file', 'google_sheet', 'text')),
+    name          varchar(512) NOT NULL,
+    -- file: {"gcs_path": "..."} | google_sheet: {"spreadsheet_id": "...", "ranges": [...]}
+    source_ref    jsonb NOT NULL DEFAULT '{}'::jsonb,
+    mime_type     varchar(255),
+    size_bytes    bigint,
+    status        varchar(20) NOT NULL DEFAULT 'PENDING'
+        CHECK (status IN ('PENDING', 'PROCESSING', 'READY', 'ERROR')),
+    error_message text,
+    content_hash  varchar(64),
+    chunk_count   integer NOT NULL DEFAULT 0,
+    token_count   integer NOT NULL DEFAULT 0,
+    synced_at     timestamptz,
+    created_at    timestamptz NOT NULL DEFAULT now(),
+    updated_at    timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_kb_document_kb
+    ON kb_document (kb_id);
+
+-- The ingestion sweeper polls for claimable work; keep that scan O(pending).
+CREATE INDEX IF NOT EXISTS idx_kb_document_pending
+    ON kb_document (created_at)
+    WHERE status IN ('PENDING', 'PROCESSING');
+
+CREATE TABLE IF NOT EXISTS kb_chunk (
+    id           uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    document_id  uuid NOT NULL REFERENCES kb_document(id) ON DELETE CASCADE,
+    kb_id        uuid NOT NULL REFERENCES knowledge_base(id) ON DELETE CASCADE,
+    chunk_index  integer NOT NULL,
+    text         text NOT NULL,
+    -- sha256 of the chunk text; ingestion re-embeds only chunks whose hash
+    -- changed (incremental sync: edited sheet rows, appended doc sections).
+    content_hash varchar(64) NOT NULL,
+    embedding    halfvec(768),
+    tsv          tsvector GENERATED ALWAYS AS
+        (to_tsvector('simple', left(text, 100000))) STORED,
+    -- headings breadcrumb, row_key/row_hash for tabular rows, lang, ...
+    metadata     jsonb NOT NULL DEFAULT '{}'::jsonb,
+    token_count  integer NOT NULL DEFAULT 0,
+    created_at   timestamptz NOT NULL DEFAULT now(),
+
+    UNIQUE (document_id, chunk_index)
+);
+
+CREATE INDEX IF NOT EXISTS idx_kb_chunk_kb
+    ON kb_chunk (kb_id);
+
+CREATE INDEX IF NOT EXISTS idx_kb_chunk_embedding_hnsw
+    ON kb_chunk USING hnsw (embedding halfvec_cosine_ops);
+
+CREATE INDEX IF NOT EXISTS idx_kb_chunk_tsv
+    ON kb_chunk USING gin (tsv);
+
+CREATE INDEX IF NOT EXISTS idx_kb_chunk_text_trgm
+    ON kb_chunk USING gin (text gin_trgm_ops);

--- a/app/database/queries/breeze_buddy/knowledge_base.py
+++ b/app/database/queries/breeze_buddy/knowledge_base.py
@@ -1,0 +1,542 @@
+"""
+Database query functions for knowledge_base, kb_document and kb_chunk tables.
+"""
+
+import json
+from datetime import datetime
+from typing import Any, Dict, List, Optional, Tuple
+
+KNOWLEDGE_BASE_TABLE = "knowledge_base"
+KB_DOCUMENT_TABLE = "kb_document"
+KB_CHUNK_TABLE = "kb_chunk"
+
+
+def _vector_literal(embedding: List[float]) -> str:
+    """Serialize an embedding for a ``$N::halfvec(768)`` cast parameter.
+
+    Embeddings are passed as pgvector text literals so no asyncpg type codec
+    registration is needed on the pool.
+    """
+    return "[" + ",".join(f"{v:.8f}" for v in embedding) + "]"
+
+
+# ---------------------------------------------------------------------------
+# knowledge_base
+# ---------------------------------------------------------------------------
+
+
+def insert_knowledge_base_query(
+    id: str,
+    reseller_id: str,
+    merchant_identifier: Optional[str],
+    name: str,
+    description: Optional[str],
+    embedding_config: Dict[str, Any],
+    settings: Dict[str, Any],
+) -> Tuple[str, List[Any]]:
+    """Generate query to insert a knowledge base.
+
+    ``RETURNING *`` lets the accessor decode the created row without a
+    second round trip. Called from accessor ``create_knowledge_base``
+    (POST /knowledge-bases). Duplicate names surface as a unique-violation
+    from the partial indexes in migration 034 (409 at the API layer).
+    """
+    text = f"""
+        INSERT INTO "{KNOWLEDGE_BASE_TABLE}"
+        ("id", "reseller_id", "merchant_identifier", "name", "description",
+         "embedding_config", "settings", "created_at", "updated_at")
+        VALUES ($1, $2, $3, $4, $5, $6::jsonb, $7::jsonb, $8, $9)
+        RETURNING *;
+    """
+    now = datetime.now()
+    values = [
+        id,
+        reseller_id,
+        merchant_identifier,
+        name,
+        description,
+        json.dumps(embedding_config),
+        json.dumps(settings),
+        now,
+        now,
+    ]
+    return text, values
+
+
+def get_knowledge_base_by_id_query(kb_id: str) -> Tuple[str, List[Any]]:
+    """Generate query to get a knowledge base by ID with live counts."""
+    text = f"""
+        SELECT kb.*,
+               (SELECT COUNT(*) FROM "{KB_DOCUMENT_TABLE}" d WHERE d."kb_id" = kb."id")
+                   AS document_count,
+               (SELECT COALESCE(SUM(d."chunk_count"), 0) FROM "{KB_DOCUMENT_TABLE}" d
+                 WHERE d."kb_id" = kb."id") AS chunk_count
+        FROM "{KNOWLEDGE_BASE_TABLE}" kb
+        WHERE kb."id" = $1;
+    """
+    return text, [kb_id]
+
+
+def list_knowledge_bases_query(
+    reseller_ids: Optional[List[str]] = None,
+    merchant_ids: Optional[List[str]] = None,
+    include_archived: bool = False,
+    search: Optional[str] = None,
+    page: Optional[int] = None,
+    limit: Optional[int] = None,
+) -> Tuple[str, List[Any]]:
+    """Generate query to list knowledge bases with RBAC filters + counts."""
+    conditions: List[str] = []
+    values: List[Any] = []
+    param = 1
+
+    if reseller_ids is not None:
+        conditions.append(f'kb."reseller_id" = ANY(${param})')
+        values.append(reseller_ids)
+        param += 1
+
+    if merchant_ids is not None:
+        conditions.append(
+            f'(kb."merchant_identifier" = ANY(${param}) OR kb."merchant_identifier" IS NULL)'
+        )
+        values.append(merchant_ids)
+        param += 1
+
+    if not include_archived:
+        conditions.append("kb.\"status\" = 'ACTIVE'")
+
+    if search:
+        conditions.append(f'kb."name" ILIKE ${param}')
+        values.append(f"%{search}%")
+        param += 1
+
+    where = f"WHERE {' AND '.join(conditions)}" if conditions else ""
+
+    pagination = ""
+    if page is not None and limit is not None:
+        pagination = f"LIMIT ${param} OFFSET ${param + 1}"
+        values.extend([limit, (page - 1) * limit])
+        param += 2
+
+    text = f"""
+        SELECT kb.*,
+               COUNT(*) OVER() AS total_count,
+               (SELECT COUNT(*) FROM "{KB_DOCUMENT_TABLE}" d WHERE d."kb_id" = kb."id")
+                   AS document_count,
+               (SELECT COALESCE(SUM(d."chunk_count"), 0) FROM "{KB_DOCUMENT_TABLE}" d
+                 WHERE d."kb_id" = kb."id") AS chunk_count
+        FROM "{KNOWLEDGE_BASE_TABLE}" kb
+        {where}
+        ORDER BY kb."updated_at" DESC
+        {pagination};
+    """
+    return text, values
+
+
+def update_knowledge_base_query(
+    kb_id: str,
+    name: Optional[str] = None,
+    description: Optional[str] = None,
+    settings: Optional[Dict[str, Any]] = None,
+    status: Optional[str] = None,
+) -> Tuple[str, List[Any]]:
+    """Generate query to update a knowledge base. Only updates provided fields."""
+    updates: List[str] = []
+    values: List[Any] = []
+    param = 1
+
+    if name is not None:
+        updates.append(f'"name" = ${param}')
+        values.append(name)
+        param += 1
+
+    if description is not None:
+        updates.append(f'"description" = ${param}')
+        values.append(description)
+        param += 1
+
+    if settings is not None:
+        updates.append(f'"settings" = ${param}::jsonb')
+        values.append(json.dumps(settings))
+        param += 1
+
+    if status is not None:
+        updates.append(f'"status" = ${param}')
+        values.append(status)
+        param += 1
+
+    updates.append(f'"updated_at" = ${param}')
+    values.append(datetime.now())
+    param += 1
+
+    values.append(kb_id)
+    text = f"""
+        UPDATE "{KNOWLEDGE_BASE_TABLE}"
+        SET {', '.join(updates)}
+        WHERE "id" = ${param}
+        RETURNING *;
+    """
+    return text, values
+
+
+def delete_knowledge_base_query(kb_id: str) -> Tuple[str, List[Any]]:
+    """Generate query to delete a knowledge base (chunks/documents CASCADE)."""
+    text = f'DELETE FROM "{KNOWLEDGE_BASE_TABLE}" WHERE "id" = $1 RETURNING *;'
+    return text, [kb_id]
+
+
+def find_templates_using_kb_query(kb_id: str) -> Tuple[str, List[Any]]:
+    """Generate query to find templates whose configurations reference a KB.
+
+    Attachment lives at ``configurations.knowledge_base.knowledge_base_ids``
+    (JSONB array of KB id strings) -- used for delete-safety checks.
+    """
+    text = """
+        SELECT "id", "name", "reseller_id", "merchant_identifier"
+        FROM "template"
+        WHERE "configurations" -> 'knowledge_base' -> 'knowledge_base_ids' ? $1;
+    """
+    return text, [kb_id]
+
+
+# ---------------------------------------------------------------------------
+# kb_document
+# ---------------------------------------------------------------------------
+
+
+def insert_kb_document_query(
+    id: str,
+    kb_id: str,
+    source_type: str,
+    name: str,
+    source_ref: Dict[str, Any],
+    mime_type: Optional[str],
+    size_bytes: Optional[int],
+    content_hash: Optional[str],
+) -> Tuple[str, List[Any]]:
+    """Generate query to insert a document in PENDING state.
+
+    PENDING is the hand-off contract with the ingestion worker: the row is
+    invisible to retrieval until the worker flips it to READY. Called from
+    accessor ``create_kb_document`` on file upload (and sheet connect in the
+    sheets PR); the handler kicks ingestion right after.
+    """
+    text = f"""
+        INSERT INTO "{KB_DOCUMENT_TABLE}"
+        ("id", "kb_id", "source_type", "name", "source_ref", "mime_type",
+         "size_bytes", "content_hash", "status", "created_at", "updated_at")
+        VALUES ($1, $2, $3, $4, $5::jsonb, $6, $7, $8, 'PENDING', $9, $10)
+        RETURNING *;
+    """
+    now = datetime.now()
+    values = [
+        id,
+        kb_id,
+        source_type,
+        name,
+        json.dumps(source_ref),
+        mime_type,
+        size_bytes,
+        content_hash,
+        now,
+        now,
+    ]
+    return text, values
+
+
+def get_kb_document_by_id_query(document_id: str) -> Tuple[str, List[Any]]:
+    """Generate query to get a document by ID.
+
+    Backs the document-scoped API operations (delete, manual re-sync) and
+    the ingestion worker's KB lookups; plain primary-key fetch.
+    """
+    text = f'SELECT * FROM "{KB_DOCUMENT_TABLE}" WHERE "id" = $1;'
+    return text, [document_id]
+
+
+def list_kb_documents_query(kb_id: str) -> Tuple[str, List[Any]]:
+    """Generate query to list all documents of a knowledge base.
+
+    Newest first for the loom documents table; also used by the upload
+    handler for the per-KB document-count cap and by KB delete for the
+    best-effort GCS cleanup sweep.
+    """
+    text = f"""
+        SELECT * FROM "{KB_DOCUMENT_TABLE}"
+        WHERE "kb_id" = $1
+        ORDER BY "created_at" DESC;
+    """
+    return text, [kb_id]
+
+
+def claim_pending_kb_documents_query(batch_size: int) -> Tuple[str, List[Any]]:
+    """Generate query to atomically claim PENDING documents for processing.
+
+    ``FOR UPDATE SKIP LOCKED`` makes the claim race-safe when the immediate
+    post-upload kick and the scheduler sweeper (possibly on another pod)
+    overlap.
+    """
+    text = f"""
+        UPDATE "{KB_DOCUMENT_TABLE}"
+        SET "status" = 'PROCESSING', "updated_at" = now()
+        WHERE "id" IN (
+            SELECT "id" FROM "{KB_DOCUMENT_TABLE}"
+            WHERE "status" = 'PENDING'
+            ORDER BY "created_at"
+            LIMIT $1
+            FOR UPDATE SKIP LOCKED
+        )
+        RETURNING *;
+    """
+    return text, [batch_size]
+
+
+def requeue_stale_processing_documents_query(
+    stale_minutes: int,
+) -> Tuple[str, List[Any]]:
+    """Generate query to requeue documents stuck in PROCESSING (pod died)."""
+    text = f"""
+        UPDATE "{KB_DOCUMENT_TABLE}"
+        SET "status" = 'PENDING', "updated_at" = now()
+        WHERE "status" = 'PROCESSING'
+          AND "updated_at" < now() - make_interval(mins => $1)
+        RETURNING "id";
+    """
+    return text, [stale_minutes]
+
+
+def mark_kb_document_for_resync_query(document_id: str) -> Tuple[str, List[Any]]:
+    """Generate query to send a READY/ERROR document back to PENDING."""
+    text = f"""
+        UPDATE "{KB_DOCUMENT_TABLE}"
+        SET "status" = 'PENDING', "error_message" = NULL, "updated_at" = now()
+        WHERE "id" = $1 AND "status" IN ('READY', 'ERROR')
+        RETURNING *;
+    """
+    return text, [document_id]
+
+
+def finish_kb_document_query(
+    document_id: str,
+    status: str,
+    error_message: Optional[str],
+    content_hash: Optional[str],
+    chunk_count: int,
+    token_count: int,
+) -> Tuple[str, List[Any]]:
+    """Generate query to finalize a document after ingestion.
+
+    Terminal state write of one ingestion run: READY with fresh counts, or
+    ERROR with a message the loom UI surfaces. ``COALESCE`` keeps the last
+    known content_hash when a failed run has none. Called only from the
+    ingestion worker (``_process_document``).
+    """
+    text = f"""
+        UPDATE "{KB_DOCUMENT_TABLE}"
+        SET "status" = $2,
+            "error_message" = $3,
+            "content_hash" = COALESCE($4, "content_hash"),
+            "chunk_count" = $5,
+            "token_count" = $6,
+            "synced_at" = now(),
+            "updated_at" = now()
+        WHERE "id" = $1
+        RETURNING *;
+    """
+    return text, [
+        document_id,
+        status,
+        error_message,
+        content_hash,
+        chunk_count,
+        token_count,
+    ]
+
+
+def delete_kb_document_query(document_id: str) -> Tuple[str, List[Any]]:
+    """Generate query to delete a document (chunks CASCADE).
+
+    Called from the DELETE document endpoint after RBAC; the handler also
+    removes the GCS object and bumps the KB cache version afterwards.
+    """
+    text = f'DELETE FROM "{KB_DOCUMENT_TABLE}" WHERE "id" = $1 RETURNING *;'
+    return text, [document_id]
+
+
+def get_merchant_chunk_total_query(reseller_id: str) -> Tuple[str, List[Any]]:
+    """Generate query for a reseller's total chunk count (quota enforcement)."""
+    text = f"""
+        SELECT COALESCE(SUM(d."chunk_count"), 0) AS total
+        FROM "{KB_DOCUMENT_TABLE}" d
+        JOIN "{KNOWLEDGE_BASE_TABLE}" kb ON kb."id" = d."kb_id"
+        WHERE kb."reseller_id" = $1;
+    """
+    return text, [reseller_id]
+
+
+# ---------------------------------------------------------------------------
+# kb_chunk
+# ---------------------------------------------------------------------------
+
+
+def get_chunk_hashes_for_document_query(document_id: str) -> Tuple[str, List[Any]]:
+    """Generate query for the (chunk_index, content_hash) map of a document."""
+    text = f"""
+        SELECT "chunk_index", "content_hash"
+        FROM "{KB_CHUNK_TABLE}"
+        WHERE "document_id" = $1;
+    """
+    return text, [document_id]
+
+
+def upsert_kb_chunk_query(
+    id: str,
+    document_id: str,
+    kb_id: str,
+    chunk_index: int,
+    text_content: str,
+    content_hash: str,
+    embedding: List[float],
+    metadata: Dict[str, Any],
+    token_count: int,
+) -> Tuple[str, List[Any]]:
+    """Generate query to insert or replace a chunk at (document_id, chunk_index)."""
+    text = f"""
+        INSERT INTO "{KB_CHUNK_TABLE}"
+        ("id", "document_id", "kb_id", "chunk_index", "text", "content_hash",
+         "embedding", "metadata", "token_count")
+        VALUES ($1, $2, $3, $4, $5, $6, $7::halfvec(768), $8::jsonb, $9)
+        ON CONFLICT ("document_id", "chunk_index") DO UPDATE SET
+            "text" = EXCLUDED."text",
+            "content_hash" = EXCLUDED."content_hash",
+            "embedding" = EXCLUDED."embedding",
+            "metadata" = EXCLUDED."metadata",
+            "token_count" = EXCLUDED."token_count";
+    """
+    values = [
+        id,
+        document_id,
+        kb_id,
+        chunk_index,
+        text_content,
+        content_hash,
+        _vector_literal(embedding),
+        json.dumps(metadata),
+        token_count,
+    ]
+    return text, values
+
+
+def delete_kb_chunks_beyond_index_query(
+    document_id: str, max_index_exclusive: int
+) -> Tuple[str, List[Any]]:
+    """Generate query to delete chunks past the new chunk list's end."""
+    text = f"""
+        DELETE FROM "{KB_CHUNK_TABLE}"
+        WHERE "document_id" = $1 AND "chunk_index" >= $2;
+    """
+    return text, [document_id, max_index_exclusive]
+
+
+def get_kb_full_text_query(kb_ids: List[str]) -> Tuple[str, List[Any]]:
+    """Generate query for full-injection mode: all READY chunks in order."""
+    text = f"""
+        SELECT c."text", d."name" AS document_name
+        FROM "{KB_CHUNK_TABLE}" c
+        JOIN "{KB_DOCUMENT_TABLE}" d ON d."id" = c."document_id"
+        WHERE c."kb_id" = ANY($1::uuid[]) AND d."status" = 'READY'
+        ORDER BY d."created_at", c."document_id", c."chunk_index";
+    """
+    return text, [kb_ids]
+
+
+def get_kb_token_total_query(kb_ids: List[str]) -> Tuple[str, List[Any]]:
+    """Generate query for the total READY token count across KBs.
+
+    Sums document-level counters (cheap) rather than scanning chunks.
+    Drives AUTO-mode size tiering (full-injection vs auto-retrieve) and the
+    full-injection token cap; called via retrieval ``get_kb_token_count``.
+    """
+    text = f"""
+        SELECT COALESCE(SUM("token_count"), 0) AS total
+        FROM "{KB_DOCUMENT_TABLE}"
+        WHERE "kb_id" = ANY($1::uuid[]) AND "status" = 'READY';
+    """
+    return text, [kb_ids]
+
+
+def hybrid_search_chunks_query(
+    kb_ids: List[str],
+    query_embedding: List[float],
+    query_text: str,
+    top_k: int,
+    candidate_k: int = 50,
+    rrf_k: int = 60,
+) -> Tuple[str, List[Any]]:
+    """Generate the single hybrid retrieval query.
+
+    Three legs over the KB-filtered chunk set -- vector KNN (HNSW), full-text
+    ('simple' config, websearch syntax) and trigram word-similarity (typo
+    tolerance for SKUs/product names) -- fused with Reciprocal Rank Fusion:
+    ``score = sum(1 / (rrf_k + rank_leg))``.
+    """
+    text = f"""
+        WITH vec AS (
+            SELECT "id",
+                   ROW_NUMBER() OVER (ORDER BY "embedding" <=> $2::halfvec(768)) AS rank,
+                   1 - ("embedding" <=> $2::halfvec(768)) AS similarity
+            FROM "{KB_CHUNK_TABLE}"
+            WHERE "kb_id" = ANY($1::uuid[]) AND "embedding" IS NOT NULL
+            ORDER BY "embedding" <=> $2::halfvec(768)
+            LIMIT $4
+        ),
+        fts AS (
+            SELECT "id",
+                   ROW_NUMBER() OVER (
+                       ORDER BY ts_rank_cd("tsv", websearch_to_tsquery('simple', $3)) DESC
+                   ) AS rank
+            FROM "{KB_CHUNK_TABLE}"
+            WHERE "kb_id" = ANY($1::uuid[])
+              AND "tsv" @@ websearch_to_tsquery('simple', $3)
+            ORDER BY rank
+            LIMIT $4
+        ),
+        trgm AS (
+            SELECT "id",
+                   ROW_NUMBER() OVER (
+                       ORDER BY word_similarity($3, "text") DESC
+                   ) AS rank
+            FROM "{KB_CHUNK_TABLE}"
+            WHERE "kb_id" = ANY($1::uuid[])
+              AND "text" %> $3
+            ORDER BY rank
+            LIMIT $4
+        )
+        SELECT c."id", c."document_id", c."kb_id", c."chunk_index", c."text",
+               c."metadata", c."token_count",
+               d."name" AS document_name,
+               v."similarity" AS vector_similarity,
+               COALESCE(1.0 / ($5 + v.rank), 0)
+                   + COALESCE(1.0 / ($5 + f.rank), 0)
+                   + COALESCE(1.0 / ($5 + t.rank), 0) AS score
+        FROM "{KB_CHUNK_TABLE}" c
+        -- READY-only: never serve chunks of documents that are mid-resync
+        -- (PROCESSING) or half-ingested (ERROR); mirrors get_kb_full_text_query.
+        JOIN "{KB_DOCUMENT_TABLE}" d
+            ON d."id" = c."document_id" AND d."status" = 'READY'
+        LEFT JOIN vec v ON v."id" = c."id"
+        LEFT JOIN fts f ON f."id" = c."id"
+        LEFT JOIN trgm t ON t."id" = c."id"
+        WHERE v."id" IS NOT NULL OR f."id" IS NOT NULL OR t."id" IS NOT NULL
+        ORDER BY score DESC
+        LIMIT $6;
+    """
+    values = [
+        kb_ids,
+        _vector_literal(query_embedding),
+        query_text,
+        candidate_k,
+        rrf_k,
+        top_k,
+    ]
+    return text, values

--- a/app/main.py
+++ b/app/main.py
@@ -35,6 +35,7 @@ from app.api.routers.breeze_buddy.chat import cancel_bus as chat_cancel_bus
 from app.core.background_tasks import BackgroundTaskScheduler
 from app.core.config.dynamic import (
     ENABLE_BACKGROUND_TASKS,
+    KB_INGESTION_INTERVAL_SECONDS,
 )
 from app.core.config.static import (
     BACKGROUND_TASKS_LOOP_INTERVAL_SECONDS,
@@ -58,6 +59,9 @@ from app.core.config.static import (
 from app.core.logger import logger
 from app.core.middleware.widget_cors_bypass import CustomWidgetCorsBypassMiddleware
 from app.database import close_db_pool, init_db_pool
+from app.services.knowledge_base import (
+    process_pending_documents as process_pending_kb_documents,
+)
 from app.services.langfuse.tasks.task import initialize_langfuse_tasks
 from app.services.redis import (
     close_redis_connections,
@@ -134,6 +138,16 @@ async def lifespan(_app: FastAPI):
                 name="chat_session_idle_cleanup",
                 func=end_idle_chat_sessions,
                 interval_seconds=CHAT_SESSION_END_TIMEOUT_LOOP_INTERVAL_SECONDS,
+            )
+
+            # Knowledge base ingestion sweeper. Uploads kick processing
+            # immediately in-process; this sweep catches kicks lost to pod
+            # restarts and requeues stale PROCESSING claims. The claim query
+            # uses FOR UPDATE SKIP LOCKED, so kick + sweep never double-work.
+            _background_scheduler.register_task(
+                name="kb_ingestion",
+                func=process_pending_kb_documents,
+                interval_seconds=await KB_INGESTION_INTERVAL_SECONDS(),
             )
 
             # Event-driven dispatch reconcilers (Plane 5). Only registered on

--- a/app/schemas/breeze_buddy/knowledge_base.py
+++ b/app/schemas/breeze_buddy/knowledge_base.py
@@ -1,0 +1,142 @@
+"""
+Pydantic schemas for Knowledge Base (RAG) entities and API contracts.
+"""
+
+from datetime import datetime
+from enum import Enum
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, Field
+
+
+class KnowledgeBaseStatus(str, Enum):
+    ACTIVE = "ACTIVE"
+    ARCHIVED = "ARCHIVED"
+
+
+class KbDocumentSourceType(str, Enum):
+    FILE = "file"
+    GOOGLE_SHEET = "google_sheet"
+    TEXT = "text"
+
+
+class KbDocumentStatus(str, Enum):
+    PENDING = "PENDING"
+    PROCESSING = "PROCESSING"
+    READY = "READY"
+    ERROR = "ERROR"
+
+
+class EmbeddingConfig(BaseModel):
+    """Per-KB embedding provider configuration.
+
+    All providers are normalized to 768 dimensions (Matryoshka truncation +
+    L2 renorm) so a single ``halfvec(768)`` column/index serves every KB.
+    """
+
+    provider: str = Field("openai", description="Embedding provider key.")
+    model: str = Field(
+        "text-embedding-3-small", description="Provider model identifier."
+    )
+    dimensions: int = Field(768, description="Stored vector dimensions (fixed).")
+
+
+class KnowledgeBase(BaseModel):
+    id: str
+    reseller_id: str
+    merchant_id: Optional[str] = None
+    name: str
+    description: Optional[str] = None
+    embedding_config: EmbeddingConfig = Field(default_factory=EmbeddingConfig)
+    settings: Dict[str, Any] = Field(default_factory=dict)
+    status: KnowledgeBaseStatus = KnowledgeBaseStatus.ACTIVE
+    document_count: Optional[int] = None
+    chunk_count: Optional[int] = None
+    created_at: Optional[datetime] = None
+    updated_at: Optional[datetime] = None
+
+
+class KbDocument(BaseModel):
+    id: str
+    kb_id: str
+    source_type: KbDocumentSourceType
+    name: str
+    source_ref: Dict[str, Any] = Field(default_factory=dict)
+    mime_type: Optional[str] = None
+    size_bytes: Optional[int] = None
+    status: KbDocumentStatus = KbDocumentStatus.PENDING
+    error_message: Optional[str] = None
+    content_hash: Optional[str] = None
+    chunk_count: int = 0
+    token_count: int = 0
+    synced_at: Optional[datetime] = None
+    created_at: Optional[datetime] = None
+    updated_at: Optional[datetime] = None
+
+
+class RetrievedChunk(BaseModel):
+    """A chunk returned by hybrid retrieval, with fused + per-leg scores."""
+
+    id: str
+    document_id: str
+    kb_id: str
+    chunk_index: int
+    text: str
+    metadata: Dict[str, Any] = Field(default_factory=dict)
+    token_count: int = 0
+    score: float = Field(0.0, description="RRF-fused relevance score.")
+    vector_similarity: Optional[float] = Field(
+        None, description="Cosine similarity from the vector leg (0-1)."
+    )
+    document_name: Optional[str] = None
+
+
+# ---------------------------------------------------------------------------
+# API request/response models
+# ---------------------------------------------------------------------------
+
+
+class CreateKnowledgeBaseRequest(BaseModel):
+    reseller_id: str
+    merchant_id: Optional[str] = None
+    name: str = Field(..., min_length=1, max_length=255)
+    description: Optional[str] = None
+    embedding_config: Optional[EmbeddingConfig] = None
+    settings: Optional[Dict[str, Any]] = None
+
+
+class UpdateKnowledgeBaseRequest(BaseModel):
+    name: Optional[str] = Field(None, min_length=1, max_length=255)
+    description: Optional[str] = None
+    settings: Optional[Dict[str, Any]] = None
+    status: Optional[KnowledgeBaseStatus] = None
+
+
+class KnowledgeBaseListResponse(BaseModel):
+    knowledge_bases: List[KnowledgeBase]
+    total: int
+
+
+class KbDocumentListResponse(BaseModel):
+    documents: List[KbDocument]
+    total: int
+
+
+class DeleteKnowledgeBaseResponse(BaseModel):
+    status: str
+    kb_id: str
+    message: str
+
+
+class QueryKnowledgeBaseRequest(BaseModel):
+    """Retrieval-testing request ("hit testing")."""
+
+    query: str = Field(..., min_length=1, max_length=2000)
+    top_k: int = Field(6, ge=1, le=20)
+    score_threshold: float = Field(0.0, ge=0.0, le=1.0)
+
+
+class QueryKnowledgeBaseResponse(BaseModel):
+    query: str
+    chunks: List[RetrievedChunk]
+    latency_ms: float

--- a/app/services/embeddings/__init__.py
+++ b/app/services/embeddings/__init__.py
@@ -1,0 +1,57 @@
+"""
+Embedding provider registry.
+
+Providers are keyed by ``EmbeddingConfig.provider`` (stored per knowledge
+base). Adding a provider (Gemini, Cohere, ...) is one module + one registry
+entry -- retrieval and ingestion are provider-agnostic.
+"""
+
+from typing import Callable, Dict
+
+from app.schemas.breeze_buddy.knowledge_base import EmbeddingConfig
+from app.services.embeddings.base import (
+    TARGET_DIMENSIONS,
+    EmbeddingProvider,
+    truncate_and_normalize,
+)
+from app.services.embeddings.openai_provider import OpenAIEmbeddingProvider
+
+_PROVIDER_REGISTRY: Dict[str, Callable[[str], EmbeddingProvider]] = {
+    "openai": lambda model: OpenAIEmbeddingProvider(model=model),
+}
+
+# Instances are stateless besides the shared HTTP session; cache per
+# (provider, model) so hot-path calls skip construction.
+_instances: Dict[str, EmbeddingProvider] = {}
+
+
+def get_embedding_provider(config: EmbeddingConfig) -> EmbeddingProvider:
+    """Resolve (and cache) an EmbeddingProvider from a KB's embedding_config.
+
+    The two call sites are the seams where providers plug in: ingestion's
+    embed loop and retrieval's ``_embed_query_cached``. Instances are cached
+    per ``provider:model`` — they're stateless besides the shared HTTP
+    session, so one per process is enough. Unknown providers raise
+    immediately with the list of valid keys.
+    """
+    key = f"{config.provider}:{config.model}"
+    if key in _instances:
+        return _instances[key]
+
+    factory = _PROVIDER_REGISTRY.get(config.provider)
+    if factory is None:
+        raise ValueError(
+            f"Unknown embedding provider '{config.provider}'. "
+            f"Available: {sorted(_PROVIDER_REGISTRY)}"
+        )
+    instance = factory(config.model)
+    _instances[key] = instance
+    return instance
+
+
+__all__ = [
+    "EmbeddingProvider",
+    "TARGET_DIMENSIONS",
+    "get_embedding_provider",
+    "truncate_and_normalize",
+]

--- a/app/services/embeddings/base.py
+++ b/app/services/embeddings/base.py
@@ -1,0 +1,58 @@
+"""
+Embedding provider abstraction.
+
+Every provider returns vectors normalized to a fixed dimension count
+(``TARGET_DIMENSIONS``) via Matryoshka truncation + L2 renormalization, so a
+single ``halfvec(768)`` column/index serves every knowledge base regardless
+of provider. Adding a provider = one module implementing ``EmbeddingProvider``
++ one registry entry in ``app/services/embeddings/__init__.py``.
+"""
+
+import math
+from abc import ABC, abstractmethod
+from typing import List, Literal
+
+TARGET_DIMENSIONS = 768
+
+InputType = Literal["query", "document"]
+
+
+class EmbeddingProvider(ABC):
+    """Async embedding provider interface."""
+
+    provider_key: str = ""
+
+    @abstractmethod
+    async def embed(
+        self, texts: List[str], input_type: InputType = "document"
+    ) -> List[List[float]]:
+        """Embed a batch of texts into TARGET_DIMENSIONS-dim unit vectors.
+
+        ``input_type`` lets providers that distinguish query vs document
+        embeddings (Cohere, Voyage) use the right mode; providers that don't
+        (OpenAI) ignore it.
+        """
+        raise NotImplementedError
+
+
+def truncate_and_normalize(
+    vector: List[float], dims: int = TARGET_DIMENSIONS
+) -> List[float]:
+    """Matryoshka truncation to ``dims`` + L2 renormalization.
+
+    The normalization step every provider funnels through so all stored
+    vectors are 768-dim unit vectors — one halfvec column/index serves
+    every provider, and cosine distance stays valid after truncation.
+    Called by each provider's ``embed`` on every vector it returns.
+    """
+    if len(vector) < dims:
+        # Fail here with a clear message instead of at the halfvec(768)
+        # insert boundary with an opaque dimension-mismatch error.
+        raise ValueError(
+            f"Embedding has {len(vector)} dimensions, expected at least {dims}"
+        )
+    truncated = vector[:dims]
+    norm = math.sqrt(sum(v * v for v in truncated))
+    if norm == 0:
+        return truncated
+    return [v / norm for v in truncated]

--- a/app/services/embeddings/openai_provider.py
+++ b/app/services/embeddings/openai_provider.py
@@ -1,0 +1,99 @@
+"""
+OpenAI embeddings provider (default).
+
+Calls the REST endpoint directly through the shared aiohttp factory (proxy
+aware) -- no SDK dependency. ``text-embedding-3-small`` supports the
+``dimensions`` parameter natively, so truncation happens server-side and the
+L2 renorm here is a cheap safety pass.
+"""
+
+from typing import List, Optional
+
+import aiohttp
+
+from app.core.config.static import OPENAI_API_KEY
+from app.core.logger import logger
+from app.core.transport.http_client import create_aiohttp_session
+from app.services.embeddings.base import (
+    TARGET_DIMENSIONS,
+    EmbeddingProvider,
+    InputType,
+    truncate_and_normalize,
+)
+
+_OPENAI_EMBEDDINGS_URL = "https://api.openai.com/v1/embeddings"
+
+# One lazily-created session shared across calls (connection reuse matters on
+# the query hot path). aiohttp sessions are cheap to hold and die with the
+# process.
+_session: Optional[aiohttp.ClientSession] = None
+
+
+def _get_session() -> aiohttp.ClientSession:
+    """Lazily create/reuse the module's shared aiohttp session.
+
+    Re-created if closed. Keeping one session gives TLS/connection reuse,
+    which matters for the per-turn query embedding on the voice hot path.
+    """
+    global _session
+    if _session is None or _session.closed:
+        _session = create_aiohttp_session(
+            timeout=aiohttp.ClientTimeout(total=30, connect=5)
+        )
+    return _session
+
+
+class OpenAIEmbeddingProvider(EmbeddingProvider):
+    provider_key = "openai"
+
+    def __init__(self, model: str = "text-embedding-3-small"):
+        """Fail fast at construction (not first call) when the API key is
+        missing — surfaces misconfiguration at ingestion kick / first
+        retrieval instead of as a confusing mid-call HTTP 401.
+
+        Constructed only via the registry factory in
+        ``app/services/embeddings/__init__.py`` (one instance per model).
+        """
+        if not OPENAI_API_KEY:
+            raise ValueError(
+                "OPENAI_API_KEY is not configured; cannot use the openai "
+                "embedding provider"
+            )
+        self.model = model
+
+    async def embed(
+        self, texts: List[str], input_type: InputType = "document"
+    ) -> List[List[float]]:
+        """Embed a batch of texts into 768-dim unit vectors.
+
+        Called from ingestion (document chunks, batched) and retrieval
+        (single query string, behind the Redis cache). ``input_type`` is
+        ignored — OpenAI doesn't distinguish query vs document embeddings.
+        Raises RuntimeError on non-200; callers own retry/fail-open policy.
+        """
+        if not texts:
+            return []
+
+        payload = {
+            "model": self.model,
+            "input": texts,
+            "dimensions": TARGET_DIMENSIONS,
+        }
+        headers = {"Authorization": f"Bearer {OPENAI_API_KEY}"}
+
+        async with _get_session().post(
+            _OPENAI_EMBEDDINGS_URL, json=payload, headers=headers
+        ) as response:
+            if response.status != 200:
+                body = await response.text()
+                logger.error(
+                    f"OpenAI embeddings request failed ({response.status}): {body[:500]}"
+                )
+                raise RuntimeError(
+                    f"OpenAI embeddings request failed with status {response.status}"
+                )
+            data = await response.json()
+
+        # The API returns items with an ``index`` field; order defensively.
+        items = sorted(data["data"], key=lambda item: item["index"])
+        return [truncate_and_normalize(item["embedding"]) for item in items]

--- a/app/services/gcp/storage/storage.py
+++ b/app/services/gcp/storage/storage.py
@@ -71,6 +71,58 @@ class GCSStorage:
             logger.error(f"Failed to upload file object to GCS: {e}", exc_info=True)
             return False
 
+    def download_as_bytes(self, source_path: str) -> Optional[bytes]:
+        """
+        Download an object from the GCS bucket as bytes.
+
+        Args:
+            source_path (str): The object path in the GCS bucket
+
+        Returns:
+            Optional[bytes]: File contents, or None on failure
+        """
+        try:
+            if not self.bucket:
+                logger.error("GCS bucket not initialized")
+                return None
+
+            blob = self.bucket.blob(source_path)
+            return blob.download_as_bytes()
+
+        except Exception as e:
+            logger.error(
+                f"Failed to download gs://{GCS_BUCKET}/{source_path}: {e}",
+                exc_info=True,
+            )
+            return None
+
+    def delete_file(self, source_path: str) -> bool:
+        """
+        Delete an object from the GCS bucket.
+
+        Args:
+            source_path (str): The object path in the GCS bucket
+
+        Returns:
+            bool: True if deleted (or already absent), False on failure
+        """
+        try:
+            if not self.bucket:
+                logger.error("GCS bucket not initialized")
+                return False
+
+            blob = self.bucket.blob(source_path)
+            if blob.exists():
+                blob.delete()
+            return True
+
+        except Exception as e:
+            logger.error(
+                f"Failed to delete gs://{GCS_BUCKET}/{source_path}: {e}",
+                exc_info=True,
+            )
+            return False
+
 
 def upload_file_to_gcs(
     file_obj: BinaryIO,

--- a/app/services/knowledge_base/__init__.py
+++ b/app/services/knowledge_base/__init__.py
@@ -1,0 +1,21 @@
+"""
+Knowledge base (RAG) services: connectors, chunking, ingestion, retrieval.
+"""
+
+from app.services.knowledge_base.ingestion import (
+    kick_ingestion,
+    process_pending_documents,
+)
+from app.services.knowledge_base.retrieval import (
+    get_full_kb_text,
+    get_kb_token_count,
+    retrieve,
+)
+
+__all__ = [
+    "get_full_kb_text",
+    "get_kb_token_count",
+    "kick_ingestion",
+    "process_pending_documents",
+    "retrieve",
+]

--- a/app/services/knowledge_base/chunking.py
+++ b/app/services/knowledge_base/chunking.py
@@ -1,0 +1,300 @@
+"""
+Source-type-aware chunking.
+
+Prose (pdf/docx/md/txt): heading-aware recursive splitting to ~450 tokens
+with sentence-level overlap; paragraphs are never split mid-way unless a
+single paragraph alone exceeds the hard cap, so Q&A pairs and numbered
+procedures stay intact (Retell guidance for voice KBs).
+
+Tabular (csv/xlsx/sheets): one row = one chunk with column headers prepended
+("Product: X | Price: 499") plus one sheet-summary chunk (Onyx pattern) --
+paired with the keyword leg of hybrid search this is what makes exact
+prices/SKUs retrievable.
+"""
+
+import hashlib
+import re
+from typing import Any, Dict, List, Optional, Tuple
+
+from app.core.logger import logger
+from app.services.knowledge_base.types import (
+    NormalizedContent,
+    PreparedChunk,
+    TableData,
+)
+
+TARGET_CHUNK_TOKENS = 450
+OVERLAP_TOKENS = 50
+MAX_CHUNK_TOKENS = 900
+
+_HEADING_RE = re.compile(r"^(#{1,6})\s+(.*)$")
+# Western/Devanagari enders need trailing whitespace; CJK/Arabic enders are
+# split points on their own (CJK prose has no space after 。！？).
+_SENTENCE_RE = re.compile(r"(?<=[.!?।])\s+|(?<=[。！？؟۔])")
+
+_encoder = None
+_encoder_failed = False
+
+
+def count_tokens(text: str) -> int:
+    """Token count via tiktoken (cl100k_base), heuristic fallback if the
+    encoding files can't be loaded (offline/restricted environments)."""
+    global _encoder, _encoder_failed
+    if not _encoder_failed and _encoder is None:
+        try:
+            import tiktoken
+
+            _encoder = tiktoken.get_encoding("cl100k_base")
+        except Exception as e:
+            _encoder_failed = True
+            logger.warning(f"tiktoken unavailable, using len/4 heuristic: {e}")
+    if _encoder is not None:
+        try:
+            return len(_encoder.encode(text, disallowed_special=()))
+        except Exception:
+            pass
+    return max(1, len(text) // 4)
+
+
+def _hash(text: str) -> str:
+    """Stable SHA-256 fingerprint of chunk text.
+
+    This is the identity used by ingestion's hash-diff: same text -> same
+    hash -> chunk is skipped instead of re-embedded on re-sync.
+    """
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _make_chunk(text: str, metadata: Dict[str, Any]) -> PreparedChunk:
+    """Wrap final chunk text into a PreparedChunk (token count + hash).
+
+    Single construction point so every chunk — prose, table row, summary —
+    gets its fingerprint and token count computed the same way.
+    """
+    return PreparedChunk(
+        text=text,
+        metadata=metadata,
+        token_count=count_tokens(text),
+        content_hash=_hash(text),
+    )
+
+
+def _split_sections(text: str) -> List[Tuple[str, str]]:
+    """Split prose on markdown headings into (breadcrumb, body) sections.
+
+    Text without headings becomes a single section with an empty breadcrumb.
+    """
+    lines = text.split("\n")
+    sections: List[Tuple[str, List[str]]] = []
+    breadcrumb: List[Tuple[int, str]] = []
+    current: List[str] = []
+
+    def flush():
+        # Close the section being accumulated: emit (breadcrumb, body) if it
+        # has any non-blank content, then reset the line buffer.
+        if current and any(line.strip() for line in current):
+            crumb = " > ".join(title for _, title in breadcrumb)
+            sections.append((crumb, current.copy()))
+        current.clear()
+
+    for line in lines:
+        match = _HEADING_RE.match(line)
+        if match:
+            flush()
+            level = len(match.group(1))
+            title = match.group(2).strip()
+            breadcrumb[:] = [(lv, t) for lv, t in breadcrumb if lv < level]
+            breadcrumb.append((level, title))
+        else:
+            current.append(line)
+    flush()
+
+    return [(crumb, "\n".join(body).strip()) for crumb, body in sections]
+
+
+def _split_paragraphs(body: str) -> List[str]:
+    """Split on blank lines, keeping numbered/bulleted list items glued to
+    their block so procedures never split across chunks."""
+    raw = [p.strip() for p in re.split(r"\n\s*\n", body) if p.strip()]
+    merged: List[str] = []
+    for para in raw:
+        starts_listish = bool(re.match(r"^(\d+[\.\)]|[-*•])\s", para))
+        if merged and starts_listish:
+            prev = merged[-1]
+            prev_listish = bool(
+                re.match(r"^(\d+[\.\)]|[-*•])\s", prev.split("\n")[-1].strip())
+            ) or prev.rstrip().endswith(":")
+            if prev_listish and count_tokens(prev) < MAX_CHUNK_TOKENS:
+                merged[-1] = prev + "\n" + para
+                continue
+        merged.append(para)
+    return merged
+
+
+def _hard_split(text: str) -> List[str]:
+    """Last-resort halving for text with no usable sentence boundaries
+    (minified blobs, giant spreadsheet cells, unpunctuated prose).
+
+    Guarantees every piece fits MAX_CHUNK_TOKENS regardless of language —
+    embedding APIs hard-reject single inputs past their token cap (8192 for
+    OpenAI), which would otherwise fail the whole document.
+    """
+    if count_tokens(text) <= MAX_CHUNK_TOKENS:
+        return [text]
+    mid = len(text) // 2
+    return _hard_split(text[:mid].strip()) + _hard_split(text[mid:].strip())
+
+
+def _split_oversized(paragraph: str) -> List[str]:
+    """Sentence-split a single paragraph that alone exceeds MAX_CHUNK_TOKENS.
+
+    Normal paragraphs are never cut (Q&A pairs / procedures stay intact);
+    this is the escape hatch for wall-of-text paragraphs. Pieces target
+    TARGET_CHUNK_TOKENS; anything still oversized (no sentence boundaries
+    at all) falls through to ``_hard_split``. Called from ``chunk_prose``.
+    """
+    sentences = [s for s in _SENTENCE_RE.split(paragraph) if s and s.strip()]
+    pieces: List[str] = []
+    buf: List[str] = []
+    buf_tokens = 0
+    for sentence in sentences:
+        tokens = count_tokens(sentence)
+        if buf and buf_tokens + tokens > TARGET_CHUNK_TOKENS:
+            pieces.append(" ".join(buf))
+            buf, buf_tokens = [], 0
+        buf.append(sentence)
+        buf_tokens += tokens
+    if buf:
+        pieces.append(" ".join(buf))
+    # A "sentence" with no boundaries at all can still exceed the hard cap.
+    capped: List[str] = []
+    for piece in pieces:
+        capped.extend(_hard_split(piece))
+    return capped
+
+
+def chunk_prose(
+    text: str, base_metadata: Optional[Dict[str, Any]] = None
+) -> List[PreparedChunk]:
+    """Heading-aware chunking of prose text (pdf/docx/md/txt content).
+
+    Pipeline per section: split on markdown headings (breadcrumb kept as a
+    ``Section:`` prefix + metadata), pack paragraphs to ~TARGET_CHUNK_TOKENS,
+    carry sentence-tail overlap between adjacent chunks of a section.
+    Called from ``build_chunks`` for a connector's ``NormalizedContent.text``.
+    """
+    base_metadata = base_metadata or {}
+    chunks: List[PreparedChunk] = []
+
+    for crumb, body in _split_sections(text):
+        paragraphs: List[str] = []
+        for para in _split_paragraphs(body):
+            if count_tokens(para) > MAX_CHUNK_TOKENS:
+                paragraphs.extend(_split_oversized(para))
+            else:
+                paragraphs.append(para)
+
+        buf: List[str] = []
+        buf_tokens = 0
+
+        def flush_buf():
+            # Emit the buffered paragraphs as one chunk, then seed the next
+            # buffer with a sentence-tail overlap (~OVERLAP_TOKENS) so a
+            # thought spanning the boundary is present in both chunks. The
+            # final flush below deliberately does NOT reuse this: it must
+            # not seed overlap after the last chunk of a section.
+            nonlocal buf, buf_tokens
+            if not buf:
+                return
+            body_text = "\n\n".join(buf)
+            prefix = f"Section: {crumb}\n\n" if crumb else ""
+            metadata = dict(base_metadata)
+            if crumb:
+                metadata["section"] = crumb
+            chunks.append(_make_chunk(prefix + body_text, metadata))
+            # Sentence-tail overlap into the next chunk of the same section.
+            tail = buf[-1]
+            tail_sentences = _SENTENCE_RE.split(tail)
+            overlap: List[str] = []
+            overlap_tokens = 0
+            for sentence in reversed(tail_sentences):
+                overlap_tokens += count_tokens(sentence)
+                if overlap_tokens > OVERLAP_TOKENS:
+                    break
+                overlap.insert(0, sentence)
+            buf = [" ".join(overlap)] if overlap else []
+            buf_tokens = count_tokens(buf[0]) if buf else 0
+
+        for para in paragraphs:
+            tokens = count_tokens(para)
+            if buf and buf_tokens + tokens > TARGET_CHUNK_TOKENS:
+                flush_buf()
+            buf.append(para)
+            buf_tokens += tokens
+        # Final flush without seeding overlap.
+        if buf:
+            body_text = "\n\n".join(buf)
+            prefix = f"Section: {crumb}\n\n" if crumb else ""
+            metadata = dict(base_metadata)
+            if crumb:
+                metadata["section"] = crumb
+            chunks.append(_make_chunk(prefix + body_text, metadata))
+
+    return chunks
+
+
+def chunk_table(table: TableData) -> List[PreparedChunk]:
+    """Row-as-chunk with headers prepended, plus one sheet-summary chunk."""
+    chunks: List[PreparedChunk] = []
+    headers = [h.strip() for h in table.headers]
+
+    non_empty_rows = 0
+    for row_index, row in enumerate(table.rows):
+        cells = [str(cell).strip() if cell is not None else "" for cell in row]
+        if not any(cells):
+            continue
+        non_empty_rows += 1
+        pairs = [
+            f"{header}: {cell}"
+            for header, cell in zip(headers, cells)
+            if header and cell
+        ]
+        if not pairs:
+            continue
+        text = (
+            f"{table.name} — " + " | ".join(pairs) if table.name else " | ".join(pairs)
+        )
+        row_key = f"{table.name}:{row_index}"
+        row_hash = _hash("|".join(cells))
+        # A pathological row (multi-MB cell) must not exceed the embedding
+        # API's per-input cap; split parts share row_key/row_hash so the
+        # incremental diff still treats the row as one unit.
+        for part_index, part in enumerate(_hard_split(text)):
+            metadata: Dict[str, Any] = {
+                "table": table.name,
+                "row_key": row_key,
+                "row_hash": row_hash,
+            }
+            if part_index:
+                metadata["row_part"] = part_index
+            chunks.append(_make_chunk(part, metadata))
+
+    if headers and non_empty_rows:
+        summary = (
+            f"Table '{table.name}' contains {non_empty_rows} rows with columns: "
+            + ", ".join(h for h in headers if h)
+            + "."
+        )
+        chunks.insert(0, _make_chunk(summary, {"table": table.name, "summary": True}))
+
+    return chunks
+
+
+def build_chunks(content: NormalizedContent) -> List[PreparedChunk]:
+    """Chunk a connector's normalized output (prose and/or tables)."""
+    chunks: List[PreparedChunk] = []
+    if content.text and content.text.strip():
+        chunks.extend(chunk_prose(content.text))
+    for table in content.tables:
+        chunks.extend(chunk_table(table))
+    return chunks

--- a/app/services/knowledge_base/connectors/__init__.py
+++ b/app/services/knowledge_base/connectors/__init__.py
@@ -1,0 +1,36 @@
+"""
+Source connector registry.
+
+Keyed by ``kb_document.source_type``. Adding a source (google_sheet, notion,
+website, ...) = one connector module + one entry here.
+"""
+
+from typing import Dict
+
+from app.services.knowledge_base.connectors.base import KBConnector
+from app.services.knowledge_base.connectors.file_upload import FileUploadConnector
+
+SOURCE_CONNECTORS: Dict[str, KBConnector] = {
+    FileUploadConnector.source_type: FileUploadConnector(),
+}
+
+
+def get_connector(source_type: str) -> KBConnector:
+    """Resolve the connector for a document's source_type.
+
+    Ingestion's single dispatch point (``_process_document``): the worker
+    never knows source specifics, it just calls ``connector.load``.
+    Raises ValueError (-> document ERROR with a clear message) for
+    unregistered types, e.g. rows written by a newer deploy during a
+    rolling update.
+    """
+    connector = SOURCE_CONNECTORS.get(source_type)
+    if connector is None:
+        raise ValueError(
+            f"No connector registered for source type '{source_type}'. "
+            f"Available: {sorted(SOURCE_CONNECTORS)}"
+        )
+    return connector
+
+
+__all__ = ["KBConnector", "SOURCE_CONNECTORS", "get_connector"]

--- a/app/services/knowledge_base/connectors/base.py
+++ b/app/services/knowledge_base/connectors/base.py
@@ -1,0 +1,36 @@
+"""
+Source connector contract for knowledge base ingestion.
+
+Onyx-inspired minimal interface: ``load`` does a full fetch + normalization;
+``detect_change`` is the cheap freshness probe used by scheduled sync (a
+Drive ``modifiedTime`` call for sheets, a content-hash comparison for files).
+New sources (notion, website, ...) plug in via ``SOURCE_CONNECTORS`` in
+``app/services/knowledge_base/connectors/__init__.py``.
+"""
+
+from abc import ABC, abstractmethod
+
+from app.schemas.breeze_buddy.knowledge_base import KbDocument
+from app.services.knowledge_base.types import NormalizedContent
+
+
+class KBConnector(ABC):
+    """Async connector for one document source type."""
+
+    source_type: str = ""
+
+    @abstractmethod
+    async def load(self, document: KbDocument) -> NormalizedContent:
+        """Fetch and normalize the document's full content.
+
+        Raises on unrecoverable errors; the ingestion worker converts those
+        into ERROR document status with the message surfaced to the UI.
+        """
+        raise NotImplementedError
+
+    async def detect_change(self, document: KbDocument) -> bool:
+        """Cheap probe: has the source changed since ``document.synced_at``?
+
+        Default: assume changed (manual re-sync always re-fetches).
+        """
+        return True

--- a/app/services/knowledge_base/connectors/file_upload.py
+++ b/app/services/knowledge_base/connectors/file_upload.py
@@ -1,0 +1,214 @@
+"""
+File-upload connector: GCS object -> NormalizedContent.
+
+Parsing is format-aware: PDF (pypdf), DOCX (python-docx, including embedded
+tables), Markdown/plain text (passthrough), CSV (stdlib) and XLSX (openpyxl)
+as tabular data. Parsers run in a thread (they're CPU-bound / the GCS client
+is sync) so the event loop stays free.
+"""
+
+import asyncio
+import csv
+import hashlib
+import io
+from typing import List, Tuple
+
+from app.core.logger import logger
+from app.schemas.breeze_buddy.knowledge_base import KbDocument
+from app.services.gcp.storage.storage import GCSStorage
+from app.services.knowledge_base.connectors.base import KBConnector
+from app.services.knowledge_base.types import NormalizedContent, TableData
+
+MAX_TABLE_COLUMNS = 50
+
+
+def _extension(name: str) -> str:
+    """Lowercased file extension ('' if none) — used by ``_parse`` as the
+    fallback when the mime type is missing or too generic to dispatch on."""
+    return name.rsplit(".", 1)[-1].lower() if "." in name else ""
+
+
+def _parse_pdf(data: bytes) -> NormalizedContent:
+    """PDF bytes -> plain text (page texts joined by blank lines).
+
+    A page that fails extraction is skipped with a warning rather than
+    failing the document — scanned/image pages yield empty strings, and
+    ``load`` rejects the document only if NOTHING was extractable. Import
+    is deferred so pypdf loads only when a PDF is actually ingested.
+    """
+    from pypdf import PdfReader
+
+    reader = PdfReader(io.BytesIO(data))
+    pages = []
+    for page in reader.pages:
+        try:
+            pages.append(page.extract_text() or "")
+        except Exception as e:
+            logger.warning(f"pypdf failed to extract a page: {e}")
+    return NormalizedContent(text="\n\n".join(pages))
+
+
+def _parse_docx(data: bytes) -> NormalizedContent:
+    """DOCX bytes -> markdown-ish text + embedded tables.
+
+    Word heading styles become ``#`` markdown headings so the prose chunker
+    can split on sections and build breadcrumbs; embedded tables (>= 2 rows)
+    are lifted out as TableData for row-as-chunk treatment.
+    """
+    import docx
+
+    document = docx.Document(io.BytesIO(data))
+    # Preserve heading structure as markdown so the prose chunker can split
+    # on sections.
+    lines: List[str] = []
+    for para in document.paragraphs:
+        text = para.text.strip()
+        if not text:
+            lines.append("")
+            continue
+        style = (para.style.name or "").lower() if para.style else ""
+        if style.startswith("heading"):
+            try:
+                level = int(style.replace("heading", "").strip() or "1")
+            except ValueError:
+                level = 1
+            lines.append("#" * min(level, 6) + " " + text)
+        else:
+            lines.append(text)
+
+    tables: List[TableData] = []
+    for table_index, table in enumerate(document.tables):
+        rows = [[cell.text.strip() for cell in row.cells] for row in table.rows]
+        if len(rows) >= 2:
+            tables.append(
+                TableData(
+                    name=f"table_{table_index + 1}",
+                    headers=rows[0][:MAX_TABLE_COLUMNS],
+                    rows=[r[:MAX_TABLE_COLUMNS] for r in rows[1:]],
+                )
+            )
+    return NormalizedContent(text="\n".join(lines), tables=tables)
+
+
+def _parse_csv(data: bytes, name: str) -> NormalizedContent:
+    """CSV bytes -> one TableData (first row = headers).
+
+    utf-8-sig handles Excel's BOM exports; blank rows are dropped; the
+    filename (sans extension) becomes the table name that row chunks are
+    prefixed with.
+    """
+    text = data.decode("utf-8-sig", errors="replace")
+    reader = csv.reader(io.StringIO(text))
+    rows = [row for row in reader if any(cell.strip() for cell in row)]
+    if not rows:
+        return NormalizedContent()
+    table_name = name.rsplit(".", 1)[0]
+    return NormalizedContent(
+        tables=[
+            TableData(
+                name=table_name,
+                headers=rows[0][:MAX_TABLE_COLUMNS],
+                rows=[r[:MAX_TABLE_COLUMNS] for r in rows[1:]],
+            )
+        ]
+    )
+
+
+def _parse_xlsx(data: bytes) -> NormalizedContent:
+    """XLSX bytes -> one TableData per worksheet (first row = headers).
+
+    ``read_only`` + ``data_only`` keeps memory flat on big workbooks and
+    reads computed values instead of formulas. Sheets with fewer than 2
+    rows (no data under the header) are skipped.
+    """
+    import openpyxl
+
+    workbook = openpyxl.load_workbook(io.BytesIO(data), read_only=True, data_only=True)
+    tables: List[TableData] = []
+    try:
+        for sheet in workbook.worksheets:
+            rows: List[List[str]] = []
+            for row in sheet.iter_rows(values_only=True):
+                cells = ["" if v is None else str(v) for v in row]
+                if any(cell.strip() for cell in cells):
+                    rows.append(cells[:MAX_TABLE_COLUMNS])
+            if len(rows) >= 2:
+                tables.append(
+                    TableData(name=sheet.title, headers=rows[0], rows=rows[1:])
+                )
+    finally:
+        workbook.close()
+    return NormalizedContent(tables=tables)
+
+
+def _parse_text(data: bytes) -> NormalizedContent:
+    """TXT/Markdown bytes -> text passthrough (markdown headings are
+    understood downstream by the prose chunker's section splitter)."""
+    return NormalizedContent(text=data.decode("utf-8", errors="replace"))
+
+
+def _parse(data: bytes, name: str, mime_type: str) -> NormalizedContent:
+    """Dispatch raw bytes to the right format parser.
+
+    Mime type wins when informative, extension is the fallback (browsers
+    send unreliable mime types for CSVs especially). Raises ValueError for
+    unsupported types — belt-and-braces behind the API's extension check.
+    """
+    ext = _extension(name)
+    mime = (mime_type or "").lower()
+
+    if "pdf" in mime or ext == "pdf":
+        return _parse_pdf(data)
+    if "wordprocessingml" in mime or ext == "docx":
+        return _parse_docx(data)
+    if "spreadsheetml" in mime or ext == "xlsx":
+        return _parse_xlsx(data)
+    if "csv" in mime or ext == "csv":
+        return _parse_csv(data, name)
+    if ext in ("txt", "md", "markdown") or mime.startswith("text/"):
+        return _parse_text(data)
+
+    raise ValueError(
+        f"Unsupported file type for '{name}' (mime: {mime_type or 'unknown'}). "
+        "Supported: pdf, docx, xlsx, csv, txt, md"
+    )
+
+
+class FileUploadConnector(KBConnector):
+    source_type = "file"
+
+    async def load(self, document: KbDocument) -> NormalizedContent:
+        """Download the uploaded file from GCS and parse it.
+
+        The connector half of ingestion's ``_process_document``. Download +
+        parse run in a worker thread (sync GCS client, CPU-bound parsers) so
+        the event loop — shared with live calls — stays free. Sets
+        ``content_hash`` from the raw bytes for whole-document change checks.
+        """
+        gcs_path = str(document.source_ref.get("gcs_path") or "")
+        if not gcs_path:
+            raise ValueError(f"Document {document.id} has no gcs_path in source_ref")
+
+        def _download_and_parse() -> Tuple[NormalizedContent, str]:
+            # Runs inside asyncio.to_thread: both the GCS download (sync
+            # client) and parsing (CPU-bound) happen off the event loop.
+            data = GCSStorage().download_as_bytes(gcs_path)
+            if data is None:
+                raise RuntimeError(f"Failed to download {gcs_path} from GCS")
+            parsed = _parse(data, document.name, document.mime_type or "")
+            return parsed, hashlib.sha256(data).hexdigest()
+
+        content, content_hash = await asyncio.to_thread(_download_and_parse)
+        content.content_hash = content_hash
+
+        if not content.text and not content.tables:
+            raise ValueError(
+                f"No extractable text found in '{document.name}' -- the file may "
+                "be scanned/image-only or empty"
+            )
+        return content
+
+    async def detect_change(self, document: KbDocument) -> bool:
+        """Uploaded files are immutable snapshots; a new upload creates a new
+        GCS object. Manual re-sync re-processes unconditionally."""
+        return True

--- a/app/services/knowledge_base/ingestion.py
+++ b/app/services/knowledge_base/ingestion.py
@@ -1,0 +1,266 @@
+"""
+Knowledge base ingestion worker.
+
+Documents are claimed from PENDING via ``FOR UPDATE SKIP LOCKED`` so the
+immediate post-upload kick and the scheduler sweeper (any pod) never process
+the same document twice. Per document: connector.load -> chunk -> hash-diff
+against existing chunks -> embed only changed chunks -> upsert/trim ->
+READY/ERROR. Hash-diffing keys off (chunk_index, content_hash), so a 1000-row
+sheet with 3 edited rows re-embeds 3 chunks.
+
+FUTURE STORE SWAP: the ``upsert_kb_chunk`` / ``delete_kb_chunks_beyond_index``
+pair below is the single WRITE seam for the vector store (READ seam:
+retrieval.py ``retrieve()`` -- see the fuller migration note there). A second
+backend (OpenSearch/Qdrant/...) plugs in by dual-writing here and backfilling
+from the embeddings already stored in Postgres.
+"""
+
+import asyncio
+import hashlib
+from typing import List
+
+from app.core.config.dynamic import (
+    KB_INGEST_BATCH_SIZE,
+    KB_MAX_CHUNKS_PER_KB,
+    KB_MERCHANT_MAX_CHUNKS,
+    KB_STALE_PROCESSING_MINUTES,
+)
+from app.core.logger import logger
+from app.database.accessor.breeze_buddy.knowledge_base import (
+    claim_pending_kb_documents,
+    delete_kb_chunks_beyond_index,
+    finish_kb_document,
+    get_chunk_hashes_for_document,
+    get_knowledge_base_by_id,
+    get_merchant_chunk_total,
+    requeue_stale_processing_documents,
+    upsert_kb_chunk,
+)
+from app.schemas.breeze_buddy.knowledge_base import (
+    KbDocument,
+    KbDocumentStatus,
+    KnowledgeBase,
+)
+from app.services.embeddings import get_embedding_provider
+from app.services.knowledge_base.chunking import build_chunks
+from app.services.knowledge_base.connectors import get_connector
+from app.services.knowledge_base.types import PreparedChunk
+from app.services.redis import get_redis_service
+
+# Conservative batching against embedding API limits (OpenAI: 2048 inputs,
+# ~300K tokens per request for 3-small).
+EMBED_BATCH_MAX_ITEMS = 128
+EMBED_BATCH_MAX_TOKENS = 100_000
+
+
+async def bump_kb_version(kb_id: str) -> None:
+    """Invalidate version-keyed KB caches (full text / token totals).
+
+    Cache keys embed a per-KB version counter, so INCR is the whole
+    invalidation story -- no SCAN/pattern deletes.
+    """
+    try:
+        redis = await get_redis_service()
+        await redis.incr(f"kb:ver:{kb_id}")
+    except Exception as e:
+        logger.warning(f"Failed to bump KB version for {kb_id}: {e}")
+
+
+# Strong refs to in-flight kicks: the event loop only holds weak references
+# to tasks, so an unreferenced fire-and-forget task may be GC'd mid-run.
+_kick_tasks: set = set()
+
+
+def kick_ingestion() -> None:
+    """Fire-and-forget processing kick after an upload/re-sync, so documents
+    don't wait for the next scheduler tick. Race-safe via the claim query."""
+
+    async def _run():
+        # Wrapper so an ingestion failure inside a fire-and-forget task is
+        # logged instead of becoming an unobserved task exception.
+        try:
+            await process_pending_documents()
+        except Exception as e:
+            logger.error(f"Ingestion kick failed: {e}", exc_info=True)
+
+    task = asyncio.create_task(_run())
+    _kick_tasks.add(task)
+    task.add_done_callback(_kick_tasks.discard)
+
+
+async def process_pending_documents() -> int:
+    """Scheduler task + kick entry point. Returns processed document count."""
+    stale_minutes = await KB_STALE_PROCESSING_MINUTES()
+    try:
+        await requeue_stale_processing_documents(stale_minutes)
+    except Exception:
+        pass  # already logged; claiming can proceed
+
+    batch_size = await KB_INGEST_BATCH_SIZE()
+    documents = await claim_pending_kb_documents(batch_size)
+    if not documents:
+        return 0
+
+    logger.info(f"KB ingestion claimed {len(documents)} document(s)")
+    for document in documents:
+        await _process_document(document)
+    return len(documents)
+
+
+async def _process_document(document: KbDocument) -> None:
+    """Run one claimed document through the full ingestion pipeline.
+
+    connector.load -> build_chunks -> quota check -> hash-diff -> embed
+    changed chunks (batched) -> upsert/trim -> READY + version bump.
+    Any failure marks the document ERROR with the message the loom UI
+    shows; errors never propagate to the scheduler loop, so one bad
+    document can't stall the batch. Called from
+    ``process_pending_documents`` for each claimed row.
+    """
+    logger.info(
+        f"Ingesting document {document.id} ('{document.name}', "
+        f"{document.source_type}) in KB {document.kb_id}"
+    )
+    try:
+        kb = await get_knowledge_base_by_id(document.kb_id)
+        if kb is None:
+            raise ValueError(f"Knowledge base {document.kb_id} not found")
+
+        connector = get_connector(document.source_type)
+        content = await connector.load(document)
+        chunks = build_chunks(content)
+
+        if not chunks:
+            raise ValueError("Document produced no chunks after parsing")
+
+        await _enforce_chunk_quotas(kb, document, len(chunks))
+
+        existing_hashes = await get_chunk_hashes_for_document(document.id)
+        changed: List[tuple[int, PreparedChunk]] = [
+            (index, chunk)
+            for index, chunk in enumerate(chunks)
+            if existing_hashes.get(index) != chunk.content_hash
+        ]
+
+        embedded = 0
+        for batch in _embedding_batches(changed):
+            texts = [chunk.text for _, chunk in batch]
+            provider = get_embedding_provider(kb.embedding_config)
+            vectors = await provider.embed(texts, input_type="document")
+            if len(vectors) != len(batch):
+                # zip() would silently drop chunks and still mark the
+                # document READY with missing embeddings.
+                raise RuntimeError(
+                    f"Embedding provider returned {len(vectors)} vectors "
+                    f"for {len(batch)} inputs"
+                )
+            for (index, chunk), vector in zip(batch, vectors):
+                await upsert_kb_chunk(
+                    document_id=document.id,
+                    kb_id=document.kb_id,
+                    chunk_index=index,
+                    text=chunk.text,
+                    content_hash=chunk.content_hash,
+                    embedding=vector,
+                    metadata=chunk.metadata,
+                    token_count=chunk.token_count,
+                )
+                embedded += 1
+
+        await delete_kb_chunks_beyond_index(document.id, len(chunks))
+
+        total_tokens = sum(chunk.token_count for chunk in chunks)
+        content_hash = content.content_hash or _hash_chunks(chunks)
+        await finish_kb_document(
+            document.id,
+            status=KbDocumentStatus.READY.value,
+            content_hash=content_hash,
+            chunk_count=len(chunks),
+            token_count=total_tokens,
+        )
+        await bump_kb_version(document.kb_id)
+        logger.info(
+            f"Document {document.id} READY: {len(chunks)} chunks "
+            f"({embedded} re-embedded, {len(chunks) - embedded} unchanged, "
+            f"{total_tokens} tokens)"
+        )
+
+    except Exception as e:
+        logger.error(f"Ingestion failed for document {document.id}: {e}", exc_info=True)
+        try:
+            await finish_kb_document(
+                document.id,
+                status=KbDocumentStatus.ERROR.value,
+                error_message=str(e)[:2000],
+                chunk_count=document.chunk_count,
+                token_count=document.token_count,
+            )
+        except Exception as finish_error:
+            logger.error(
+                f"Failed to mark document {document.id} as ERROR: {finish_error}"
+            )
+
+
+async def _enforce_chunk_quotas(
+    kb: KnowledgeBase, document: KbDocument, new_chunk_count: int
+) -> None:
+    """Noisy-neighbor protection: per-KB and per-reseller chunk caps.
+
+    Both caps compare the store's CURRENT totals plus this document's delta,
+    so they bound the knowledge base / reseller as a whole, not just the
+    single document being ingested.
+    """
+    delta = new_chunk_count - document.chunk_count
+
+    kb_cap = await KB_MAX_CHUNKS_PER_KB()
+    kb_total = kb.chunk_count or 0
+    if delta > 0 and kb_total + delta > kb_cap:
+        raise ValueError(
+            f"Knowledge base chunk cap exceeded ({kb_total} existing + {delta} "
+            f"new > {kb_cap}); split content across knowledge bases or contact "
+            "support to raise the limit"
+        )
+
+    merchant_cap = await KB_MERCHANT_MAX_CHUNKS()
+    current_total = await get_merchant_chunk_total(kb.reseller_id)
+    if delta > 0 and current_total + delta > merchant_cap:
+        raise ValueError(
+            f"Reseller chunk quota exceeded ({current_total} + {delta} > "
+            f"{merchant_cap}); contact support to raise the limit"
+        )
+
+
+def _embedding_batches(changed: List[tuple[int, PreparedChunk]]):
+    """Yield embed-API batches bounded by item count AND token budget.
+
+    Two limits because providers enforce both (OpenAI: 2048 inputs,
+    ~300K tokens per request); we stay well under with 128/100K. Used only
+    by ``_process_document``'s embed loop.
+    """
+    batch: List[tuple[int, PreparedChunk]] = []
+    batch_tokens = 0
+    for item in changed:
+        tokens = item[1].token_count
+        if batch and (
+            len(batch) >= EMBED_BATCH_MAX_ITEMS
+            or batch_tokens + tokens > EMBED_BATCH_MAX_TOKENS
+        ):
+            yield batch
+            batch, batch_tokens = [], 0
+        batch.append(item)
+        batch_tokens += tokens
+    if batch:
+        yield batch
+
+
+def _hash_chunks(chunks: List[PreparedChunk]) -> str:
+    """Whole-document fingerprint from the ordered chunk hashes.
+
+    Fallback for connectors that don't provide a content hash of their own
+    (files do via GCS bytes; this covers the rest). Stored on kb_document
+    so ``detect_change`` / re-sync can cheaply answer "did anything change?".
+    """
+    digest = hashlib.sha256()
+    for chunk in chunks:
+        digest.update(chunk.content_hash.encode("utf-8"))
+    return digest.hexdigest()

--- a/app/services/knowledge_base/retrieval.py
+++ b/app/services/knowledge_base/retrieval.py
@@ -1,0 +1,238 @@
+"""
+Knowledge base retrieval service -- the latency-critical path.
+
+``retrieve()`` = query embedding (Redis-cached) + one hybrid SQL round trip
+(vector KNN + full-text + trigram, RRF-fused). Callers on the voice hot path
+wrap it in ``asyncio.wait_for`` and fail open. Full-KB text / token totals
+(for full-injection mode) are cached in Redis under version-stamped keys;
+ingestion bumps the version on every publish, so no pattern invalidation is
+needed.
+
+FUTURE STORE SWAP (OpenSearch/Qdrant/Turbopuffer): ``retrieve()`` is the
+single READ seam -- swapping the vector store means reimplementing only the
+``hybrid_search_chunks`` call it delegates to (the WRITE seam is the chunk
+upsert/trim pair in ingestion.py). Deliberately NOT abstracted into a
+VectorStore interface while pgvector is the only backend; when a second
+backend lands, extract the interface then, dual-write, backfill by copying
+stored embeddings (no re-embed needed), and flip reads per-merchant via
+dynamic config. Postgres stays the system of record for KB/document
+metadata regardless of backend. Triggers to revisit: ~5M total chunks,
+p95 retrieval drift (HNSW outgrowing RAM), or vernacular keyword quality
+needing real language analyzers.
+"""
+
+import hashlib
+import json
+import time
+from typing import List, Optional, Tuple
+
+from app.core.config.dynamic import KB_EMBED_CACHE_TTL_SECONDS
+from app.core.logger import logger
+from app.database.accessor.breeze_buddy.knowledge_base import (
+    get_kb_full_text_rows,
+    get_kb_token_total,
+    get_knowledge_base_by_id,
+    hybrid_search_chunks,
+)
+from app.schemas.breeze_buddy.knowledge_base import EmbeddingConfig, RetrievedChunk
+from app.services.embeddings import get_embedding_provider
+from app.services.redis import get_redis_service
+
+_FULL_TEXT_CACHE_TTL_SECONDS = 3600
+_TOKEN_TOTAL_CACHE_TTL_SECONDS = 3600
+
+
+def _normalize_query(query: str) -> str:
+    """Collapse whitespace so trivially-different phrasings share one
+    embedding cache entry (and one consistent FTS/trigram input)."""
+    return " ".join(query.split()).strip()
+
+
+async def _get_kb_versions(kb_ids: List[str]) -> List[str]:
+    """Per-KB version counters (bumped by ingestion) for cache keys."""
+    versions = []
+    try:
+        redis = await get_redis_service()
+        for kb_id in sorted(kb_ids):
+            version = await redis.get(f"kb:ver:{kb_id}")
+            versions.append(version or "0")
+    except Exception:
+        # Redis down -> unique key per call (cache miss, correct results).
+        versions = [str(time.time())]
+    return versions
+
+
+def _versioned_key(prefix: str, kb_ids: List[str], versions: List[str]) -> str:
+    """Build a Redis cache key that embeds the KB version counters.
+
+    Because the version is part of the key, ingestion invalidates caches by
+    just INCR-ing the counter — old keys become unreachable and expire via
+    TTL; no SCAN/pattern deletes. Used by the full-text and token-total
+    caches below.
+    """
+    raw = "|".join(sorted(kb_ids)) + "@" + ".".join(versions)
+    return f"{prefix}:{hashlib.sha1(raw.encode()).hexdigest()}"
+
+
+async def _resolve_embedding_config(kb_ids: List[str]) -> EmbeddingConfig:
+    """Query embedding uses the first KB's provider. Cross-provider KB
+    attachment is unsupported (vectors aren't comparable across providers);
+    template validation enforces this at attach time."""
+    kb = await get_knowledge_base_by_id(kb_ids[0])
+    if kb is None:
+        raise ValueError(f"Knowledge base {kb_ids[0]} not found")
+    return kb.embedding_config
+
+
+async def _embed_query_cached(query: str, config: EmbeddingConfig) -> List[float]:
+    """Embed the query with a Redis cache in front (dodges the fat p95 tail
+    of embedding APIs for repeated phrasings)."""
+    normalized = _normalize_query(query)
+    cache_key = (
+        f"kb:emb:{config.provider}:{config.model}:"
+        f"{hashlib.sha1(normalized.lower().encode()).hexdigest()}"
+    )
+
+    redis = None
+    try:
+        redis = await get_redis_service()
+        cached = await redis.get(cache_key)
+        if cached:
+            return json.loads(cached)
+    except Exception:
+        pass  # cache is best-effort
+
+    provider = get_embedding_provider(config)
+    vectors = await provider.embed([normalized], input_type="query")
+    vector = vectors[0]
+
+    if redis is not None:
+        try:
+            ttl = await KB_EMBED_CACHE_TTL_SECONDS()
+            await redis.setex(cache_key, json.dumps(vector), ttl)
+        except Exception:
+            pass
+    return vector
+
+
+async def retrieve(
+    kb_ids: List[str],
+    query: str,
+    top_k: int = 6,
+    score_threshold: float = 0.0,
+) -> List[RetrievedChunk]:
+    """Hybrid retrieval over the given knowledge bases.
+
+    Raises on failure -- callers own the timeout/fail-open policy
+    (``asyncio.wait_for`` on the voice path, looser budgets in chat/tool).
+    """
+    if not kb_ids:
+        return []
+    normalized = _normalize_query(query)
+    if not normalized:
+        return []
+
+    started = time.perf_counter()
+    config = await _resolve_embedding_config(kb_ids)
+    query_embedding = await _embed_query_cached(normalized, config)
+    embed_ms = (time.perf_counter() - started) * 1000
+
+    chunks = await hybrid_search_chunks(
+        kb_ids=kb_ids,
+        query_embedding=query_embedding,
+        query_text=normalized,
+        top_k=top_k,
+    )
+
+    if score_threshold > 0:
+        # Threshold applies to the vector leg; keyword-only hits (exact
+        # SKU/price matches with no meaningful cosine score) are kept.
+        chunks = [
+            chunk
+            for chunk in chunks
+            if chunk.vector_similarity is None
+            or chunk.vector_similarity >= score_threshold
+        ]
+
+    total_ms = (time.perf_counter() - started) * 1000
+    logger.info(
+        f"KB retrieve: {len(chunks)} chunks from {len(kb_ids)} KB(s) in "
+        f"{total_ms:.0f}ms (embed {embed_ms:.0f}ms)"
+    )
+    return chunks
+
+
+async def get_kb_token_count(kb_ids: List[str]) -> int:
+    """Total READY tokens across KBs (AUTO mode size tiering), cached."""
+    if not kb_ids:
+        return 0
+    versions = await _get_kb_versions(kb_ids)
+    cache_key = _versioned_key("kb:tokens", kb_ids, versions)
+    try:
+        redis = await get_redis_service()
+        cached = await redis.get(cache_key)
+        if cached is not None:
+            return int(cached)
+    except Exception:
+        redis = None
+
+    total = await get_kb_token_total(kb_ids)
+    if redis is not None:
+        try:
+            await redis.setex(cache_key, str(total), _TOKEN_TOTAL_CACHE_TTL_SECONDS)
+        except Exception:
+            pass
+    return total
+
+
+async def get_full_kb_text(
+    kb_ids: List[str], max_tokens: Optional[int] = None
+) -> Tuple[str, int]:
+    """Concatenated READY chunk text for full-injection mode, cached.
+
+    Returns (text, token_count). ``max_tokens`` guards against a KB that
+    grew past the injection threshold between resolution and fetch.
+    """
+    if not kb_ids:
+        return "", 0
+    versions = await _get_kb_versions(kb_ids)
+    cache_key = _versioned_key("kb:text", kb_ids, versions)
+
+    redis = None
+    try:
+        redis = await get_redis_service()
+        cached = await redis.get(cache_key)
+        if cached is not None:
+            payload = json.loads(cached)
+            return payload["text"], payload["tokens"]
+    except Exception:
+        redis = None
+
+    rows = await get_kb_full_text_rows(kb_ids)
+    sections: List[str] = []
+    current_doc = None
+    for document_name, chunk_text in rows:
+        if document_name != current_doc:
+            sections.append(f"\n### {document_name}\n")
+            current_doc = document_name
+        sections.append(chunk_text)
+    text = "\n".join(sections).strip()
+    tokens = await get_kb_token_count(kb_ids)
+
+    if max_tokens is not None and tokens > max_tokens:
+        logger.warning(
+            f"Full KB text for {kb_ids} is {tokens} tokens, over the "
+            f"{max_tokens} cap -- refusing full injection"
+        )
+        return "", tokens
+
+    if redis is not None:
+        try:
+            await redis.setex(
+                cache_key,
+                json.dumps({"text": text, "tokens": tokens}),
+                _FULL_TEXT_CACHE_TTL_SECONDS,
+            )
+        except Exception:
+            pass
+    return text, tokens

--- a/app/services/knowledge_base/types.py
+++ b/app/services/knowledge_base/types.py
@@ -1,0 +1,34 @@
+"""
+Internal data types shared by the knowledge base ingestion pipeline.
+"""
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+
+@dataclass
+class TableData:
+    """One extracted table/sheet: header row + data rows."""
+
+    name: str
+    headers: List[str]
+    rows: List[List[str]]
+
+
+@dataclass
+class NormalizedContent:
+    """Connector output: prose text and/or tables, ready for chunking."""
+
+    text: Optional[str] = None
+    tables: List[TableData] = field(default_factory=list)
+    content_hash: Optional[str] = None
+
+
+@dataclass
+class PreparedChunk:
+    """A chunk ready for hash-diffing and embedding."""
+
+    text: str
+    metadata: Dict[str, Any]
+    token_count: int
+    content_hash: str

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,10 @@ dependencies = [
     "nltk",
     "jmespath>=1.1.0",
     "h2>=4.3.0",
+    "pypdf>=6.14.2",
+    "python-docx>=1.2.0",
+    "openpyxl>=3.1.5",
+    "tiktoken>=0.13.0",
 ]
 
 [project.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -699,6 +699,7 @@ dependencies = [
     { name = "langfuse" },
     { name = "loguru" },
     { name = "nltk" },
+    { name = "openpyxl" },
     { name = "opentelemetry-api" },
     { name = "opentelemetry-exporter-otlp-proto-http" },
     { name = "opentelemetry-sdk" },
@@ -707,12 +708,15 @@ dependencies = [
     { name = "plivo" },
     { name = "pydub" },
     { name = "pyjwt" },
+    { name = "pypdf" },
+    { name = "python-docx" },
     { name = "python-dotenv" },
     { name = "python-multipart" },
     { name = "pytz" },
     { name = "redis", extra = ["hiredis"] },
     { name = "soundfile" },
     { name = "starlette" },
+    { name = "tiktoken" },
     { name = "twilio" },
     { name = "uvicorn" },
     { name = "websockets" },
@@ -751,6 +755,7 @@ requires-dist = [
     { name = "langfuse" },
     { name = "loguru" },
     { name = "nltk" },
+    { name = "openpyxl", specifier = ">=3.1.5" },
     { name = "opentelemetry-api" },
     { name = "opentelemetry-exporter-otlp-proto-http" },
     { name = "opentelemetry-sdk" },
@@ -759,15 +764,18 @@ requires-dist = [
     { name = "plivo" },
     { name = "pydub" },
     { name = "pyjwt" },
+    { name = "pypdf", specifier = ">=6.14.2" },
     { name = "pyrefly", marker = "extra == 'dev'" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=1.3.0" },
+    { name = "python-docx", specifier = ">=1.2.0" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
     { name = "python-multipart", specifier = ">=0.0.6" },
     { name = "pytz", specifier = "==2025.2" },
     { name = "redis", extras = ["hiredis"], specifier = ">=5.0.0" },
     { name = "soundfile" },
     { name = "starlette", specifier = ">=0.27.0" },
+    { name = "tiktoken", specifier = ">=0.13.0" },
     { name = "twilio" },
     { name = "uvicorn", specifier = "==0.34.2" },
     { name = "websockets", specifier = ">=11.0.3" },
@@ -909,6 +917,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b2/9d/c3b43da9515bd270df0f80548d9944e389870713cc1fe2b8fb35fe2bcefd/docstring_parser-0.17.0.tar.gz", hash = "sha256:583de4a309722b3315439bb31d64ba3eebada841f2e2cee23b99df001434c912", size = 27442, upload-time = "2025-07-21T07:35:01.868Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/55/e2/2537ebcff11c1ee1ff17d8d0b6f4db75873e3b0fb32c2d4a2ee31ecb310a/docstring_parser-0.17.0-py3-none-any.whl", hash = "sha256:cf2569abd23dce8099b300f9b4fa8191e9582dda731fd533daf54c4551658708", size = 36896, upload-time = "2025-07-21T07:35:00.684Z" },
+]
+
+[[package]]
+name = "et-xmlfile"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/38/af70d7ab1ae9d4da450eeec1fa3918940a5fafb9055e934af8d6eb0c2313/et_xmlfile-2.0.0.tar.gz", hash = "sha256:dab3f4764309081ce75662649be815c4c9081e88f0837825f90fd28317d4da54", size = 17234, upload-time = "2024-10-25T17:25:40.039Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/8b/5fe2cc11fee489817272089c4203e679c63b570a5aaeb18d852ae3cbba6a/et_xmlfile-2.0.0-py3-none-any.whl", hash = "sha256:7a91720bc756843502c3b7504c77b8fe44217c85c537d85037f0f536151b2caa", size = 18059, upload-time = "2024-10-25T17:25:39.051Z" },
 ]
 
 [[package]]
@@ -2228,6 +2245,18 @@ wheels = [
 ]
 
 [[package]]
+name = "openpyxl"
+version = "3.1.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "et-xmlfile" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3d/f9/88d94a75de065ea32619465d2f77b29a0469500e99012523b91cc4141cd1/openpyxl-3.1.5.tar.gz", hash = "sha256:cf0e3cf56142039133628b5acffe8ef0c12bc902d2aadd3e0fe5878dc08d1050", size = 186464, upload-time = "2024-06-28T14:03:44.161Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c0/da/977ded879c29cbd04de313843e76868e6e13408a94ed6b987245dc7c8506/openpyxl-3.1.5-py2.py3-none-any.whl", hash = "sha256:5282c12b107bffeef825f4617dc029afaf41d0ea60823bbb665ef3079dc79de2", size = 250910, upload-time = "2024-06-28T14:03:41.161Z" },
+]
+
+[[package]]
 name = "opentelemetry-api"
 version = "1.39.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2871,6 +2900,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pypdf"
+version = "6.14.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/03/72/7dfd5ff1c9c37de97a731701f51af091325f123d9d4270361c9c69e4431f/pypdf-6.14.2.tar.gz", hash = "sha256:7873f502fe4385e79539b21d872392dc0c4e3714327c15881cbc7fbfd1f95b25", size = 6491182, upload-time = "2026-06-23T14:18:30.859Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/e6/136aa8993a2ae7214e0b0ef2edaa0d2e08d1d4e4982635b08a835ff31ec8/pypdf-6.14.2-py3-none-any.whl", hash = "sha256:3f07891af76dc002657e04993ab9b4de81de29f9013b9761d0b7968bff12e946", size = 349514, upload-time = "2026-06-23T14:18:28.867Z" },
+]
+
+[[package]]
 name = "pyrefly"
 version = "0.52.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2925,6 +2963,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
+name = "python-docx"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "lxml" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a9/f7/eddfe33871520adab45aaa1a71f0402a2252050c14c7e3009446c8f4701c/python_docx-1.2.0.tar.gz", hash = "sha256:7bc9d7b7d8a69c9c02ca09216118c86552704edc23bac179283f2e38f86220ce", size = 5723256, upload-time = "2025-06-16T20:46:27.921Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d0/00/1e03a4989fa5795da308cd774f05b704ace555a70f9bf9d3be057b680bcf/python_docx-1.2.0-py3-none-any.whl", hash = "sha256:3fd478f3250fbbbfd3b94fe1e985955737c145627498896a8a6bf81f4baf66c7", size = 252987, upload-time = "2025-06-16T20:46:22.506Z" },
 ]
 
 [[package]]
@@ -3582,6 +3633,60 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/47/c6/ee486fd809e357697ee8a44d3d69222b344920433d3b6666ccd9b374630c/tenacity-9.1.4.tar.gz", hash = "sha256:adb31d4c263f2bd041081ab33b498309a57c77f9acf2db65aadf0898179cf93a", size = 49413, upload-time = "2026-02-07T10:45:33.841Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d7/c1/eb8f9debc45d3b7918a32ab756658a0904732f75e555402972246b0b8e71/tenacity-9.1.4-py3-none-any.whl", hash = "sha256:6095a360c919085f28c6527de529e76a06ad89b23659fa881ae0649b867a9d55", size = 28926, upload-time = "2026-02-07T10:45:32.24Z" },
+]
+
+[[package]]
+name = "tiktoken"
+version = "0.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "regex" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/e5/5f3cb2159769d0f4324c0e9e87f9de3c4b1cd45848a96b2eb3566ad5ca77/tiktoken-0.13.0.tar.gz", hash = "sha256:c9435714c3a84c2319499de9a300c0e604449dd0799ff246458b3bb6a7f433c1", size = 38986, upload-time = "2026-05-15T04:51:27.153Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1a/4c/1bc81f4cd53e827c4ee67ca951b5935724716049452d8dfa09b8b82372bb/tiktoken-0.13.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:7bfe1849caa65d1e1d9871817170ec497bbb7984e182012e1bdce72f66608cdb", size = 1036353, upload-time = "2026-05-15T04:50:21.757Z" },
+    { url = "https://files.pythonhosted.org/packages/75/91/10b9c7076bc02c246c853201fdbbe300a4b8c5ed7b84c25f7403f4e32655/tiktoken-0.13.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:91c180fe255bd5a86d8316210d2833a1d4d33d026cd86a67812f4773743c8d26", size = 984644, upload-time = "2026-05-15T04:50:23.256Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/e4/fceae98015fab47fcd49b8bd7f46145bcd187a47e0add1e5378ed67ef980/tiktoken-0.13.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:059c8ecf554eb5b41e6e054ba467b871b03277d267dee7244380aca4359747d4", size = 1119261, upload-time = "2026-05-15T04:50:24.348Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/39/fe42ad00de01a8c4a49ad8649a2c8a316835a9cad5961b11d21eac0020a5/tiktoken-0.13.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:36217497eaffc158607a3b26f065300db2aefd43b115263f3b9688ce38146173", size = 1138253, upload-time = "2026-05-15T04:50:25.505Z" },
+    { url = "https://files.pythonhosted.org/packages/03/c4/ccee1ecccca107e9a16efcecdeeb964c325305038554d466ece65b42338f/tiktoken-0.13.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:303f7d91b4fce3baddbcde05c139091d4caa5026ac7214c1dc7ff7a71ee429ff", size = 1185747, upload-time = "2026-05-15T04:50:27.02Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/03/cd0cba295522b91eb55c6b2704f1df895f8226cfe60ab10d4d51d0cc9e69/tiktoken-0.13.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:5d48843bee149630eb735a99e1f4a85b47308d21868ea63163f6e87768d3cfed", size = 1241265, upload-time = "2026-05-15T04:50:28.815Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/25/a10efd564402d82c2ff50d12057353ace447aa8007deceaa48641f63d35c/tiktoken-0.13.0-cp311-cp311-win_amd64.whl", hash = "sha256:fc1c44cd37b43fc46bae593129164f4f281e82ea116b57a85aa81bda57eafc94", size = 876509, upload-time = "2026-05-15T04:50:30.026Z" },
+    { url = "https://files.pythonhosted.org/packages/85/8e/144bde4e01df66b34bb865557c7cd754ed08b036217ebd79c9db5e9048a9/tiktoken-0.13.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:32ac870a806cfb260a02d0cb70426aef02e038297f8ad50df5040bb5af360791", size = 1034888, upload-time = "2026-05-15T04:50:31.579Z" },
+    { url = "https://files.pythonhosted.org/packages/36/18/d4ac9d20956cdebca04841316660ed584c2fecdc2b81722a28bc7ad3b1e4/tiktoken-0.13.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:4d9980f11429ed2d737c463bb1fb78cf330caa026adf002f714aced7849a687b", size = 982970, upload-time = "2026-05-15T04:50:32.961Z" },
+    { url = "https://files.pythonhosted.org/packages/74/ed/6bb8d05b9f731f749fee5c6f5ca63e981143c826a5985877330507bd13b7/tiktoken-0.13.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:3f277ebea5edd7b8bf03c6f9431e1d67d517530115572b2dc1d465326e8f88c7", size = 1115741, upload-time = "2026-05-15T04:50:34.475Z" },
+    { url = "https://files.pythonhosted.org/packages/34/de/2ca96b07a82d972b74fe4b46de055b79c904e45c7eab699354a0bfa697dc/tiktoken-0.13.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:a116178fa7e1b4065bff05214360373a65cac22f965be7b3f73d00a0dbfe7649", size = 1136523, upload-time = "2026-05-15T04:50:35.782Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/dc/9dafec002c2d4424378563cf4cf5c7fb93631d2a55013c8b87554ee4012c/tiktoken-0.13.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2c397ddda233208345b01bd30f2fca79ff730e55731d0108a603f9bc57f6af3b", size = 1181954, upload-time = "2026-05-15T04:50:36.99Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/d0/1f8578c45b2f24759b46f0b50d31878c63c73e6bf0f2227e10ec5c5408dc/tiktoken-0.13.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:95097e4f89b06403976e498abf61a0ee73a7497e73fb599cb211d8197a054d91", size = 1240069, upload-time = "2026-05-15T04:50:38.221Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/90/28d7f154888610aa9237e541986beb62b479df29d193a5a0617dbb1514d0/tiktoken-0.13.0-cp312-cp312-win_amd64.whl", hash = "sha256:8f2d16e7a7c783ad81f36e457d046d1f1c8af70b22aec8a13238efe531977c41", size = 874748, upload-time = "2026-05-15T04:50:39.587Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/83/b096c859c2a47c11731bf2f5885f4028b809dfe2396582883eed9cae372f/tiktoken-0.13.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5df5d1507bd245f1ccad4a074698240021239e455eb0bb4ced4e3d7181872154", size = 1034228, upload-time = "2026-05-15T04:50:40.988Z" },
+    { url = "https://files.pythonhosted.org/packages/53/61/c68e123b6d753e3fc2751e9b18e732c9d8bf1e1926762e736eee935d931c/tiktoken-0.13.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:8fe806a50664e83a6ffd56cbd1e4f5dcc6cd32a3e7538f70dc38b1a271384545", size = 982978, upload-time = "2026-05-15T04:50:42.195Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/8b/96cc178cc584e65d363134500f297790b06cd48cdeb1e8fcf7bbe60f4715/tiktoken-0.13.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:125bc05005e747f993a83dc67934249932d6e4209854452cd4c0b1d53fba3ba2", size = 1116355, upload-time = "2026-05-15T04:50:43.564Z" },
+    { url = "https://files.pythonhosted.org/packages/86/f5/bab735d2c72ea55404b295d02d092644eb5f7cc6205e34d35eb9abfb9ab2/tiktoken-0.13.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:5e6358911cab4adee6712da27d65573496a4f68cf8a2b5fca6a4ad10fc5748cf", size = 1135772, upload-time = "2026-05-15T04:50:44.782Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/b9/6de04ebdf904edfaad87788011b3735087a0c9ea671b9027e1e4e965e8c8/tiktoken-0.13.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:975cbd78d085d75d26b59660e262736dcaed1e35f8f142cd6291025c01d25486", size = 1182415, upload-time = "2026-05-15T04:50:46.422Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/9c/470a05f3b1caf038f44880e334d47ab674e0c80d514c66b375d14d5afa10/tiktoken-0.13.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:75ab9bc99fa020a4c283424590ecd7f3afd70c1c281cb3fa3192a6c3af9f9615", size = 1239879, upload-time = "2026-05-15T04:50:48.052Z" },
+    { url = "https://files.pythonhosted.org/packages/42/a6/c1936d16055436cb32e6c6128d68629622e00f4768562f55653752d34768/tiktoken-0.13.0-cp313-cp313-win_amd64.whl", hash = "sha256:6b1615f0ff71953d19729ceb18865429c185b0a23c5353f1bbca34a394bf60f7", size = 874829, upload-time = "2026-05-15T04:50:49.202Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/07/acb5992c3772b5a36284f742cfb7a5895aa4471d1848ac31464ad50d7fdf/tiktoken-0.13.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:6eb4a5bfbc6426938026b1a334e898ac53541360d62d8c689870160cc80abd67", size = 1033600, upload-time = "2026-05-15T04:50:50.4Z" },
+    { url = "https://files.pythonhosted.org/packages/14/e9/742e9aec30f59b9f161f7ff7cd072e02ea836c9e1c0854a8076dfcd40d5c/tiktoken-0.13.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:43cee3e5400573b2046fbf092cc7a5bc30164f9e4c95ce20714da929df48737a", size = 982516, upload-time = "2026-05-15T04:50:52.03Z" },
+    { url = "https://files.pythonhosted.org/packages/72/74/ca1541b053e7648254d2e4b42a253e1bb4359f2c91a0a8d49228c794e1a0/tiktoken-0.13.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:7de52e3f566d19b3b11bd37eea552c6c305ad74081f736882bd44d148ed4c48d", size = 1115518, upload-time = "2026-05-15T04:50:53.543Z" },
+    { url = "https://files.pythonhosted.org/packages/46/e3/93825eaf5a4a504795b787e5d5dea07fbeb3dabf97aa7b450be8bde59c89/tiktoken-0.13.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:51384448aa508e4df84c0f7c1dc3211c7f7b8096325660ee5fc82f3e11b381ce", size = 1136867, upload-time = "2026-05-15T04:50:55.191Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/46/002b68de6827091d5ae90b048f326e8aad8d953520950e5ce1508879414f/tiktoken-0.13.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:e28157350f7ebf35008dd8e9e0fdb621f976e4230c881099c85e8cf07eaa50e2", size = 1181826, upload-time = "2026-05-15T04:50:56.296Z" },
+    { url = "https://files.pythonhosted.org/packages/db/c6/d393e3185a276505182f7abd93fe714f3c444a2be9180798fa052347504e/tiktoken-0.13.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:165cf1820ea4a354985c2490a5205d4cc74661c934aca79dd0368232fff94e0f", size = 1239489, upload-time = "2026-05-15T04:50:57.918Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/4d/bc07d1f1635d4897a202acc0ae11c2886eaa7325c359ba4741b47bf8e225/tiktoken-0.13.0-cp313-cp313t-win_amd64.whl", hash = "sha256:6c43a675ca14f6f2749ba7f12075d37456015a24b859f2517b9beb4ef30807ec", size = 873820, upload-time = "2026-05-15T04:50:59.528Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/93/0dd6adca026a616c3a92974566b43381eea4b475ce1f36c062b8271a9ac5/tiktoken-0.13.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:eaaaef47c2406277181d2086484c317bf7fc433e2d5d03ff94f56b0dcec87471", size = 1034977, upload-time = "2026-05-15T04:51:00.957Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/77/5ec6e6bc5b30bed6d93f7f2162d8f6b32437b3ba27cb527cfe004f6109c9/tiktoken-0.13.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:ca8b310bd93b3772cb1b7922d915446864860f562bdfe4825c63a0aed3fb28cd", size = 983635, upload-time = "2026-05-15T04:51:02.629Z" },
+    { url = "https://files.pythonhosted.org/packages/94/b0/c8ae9aff00d625c50659b4513e707a0462c4bf5d4d6cc1b802103225c02e/tiktoken-0.13.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:32e0c12305105002c047b3bb1070b0dd9a73b0cb3b2856a8972b810e7a4f5881", size = 1116036, upload-time = "2026-05-15T04:51:04.082Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/ac/6a5dddd1d0a6018ecb389bd0353e6b4a515eb4d2286611bd0ace1937b9e1/tiktoken-0.13.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:5ba5fd62507a932d1241346179e3b39bc7bf7408f03c272652d93b3bedf5db24", size = 1135544, upload-time = "2026-05-15T04:51:05.229Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/b8/585032b4384b2f7dcdaddcb52865c83a701a420d09e3c2b4a2be1c450c57/tiktoken-0.13.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:d108bc2d470fc53c8ecd24f2c0fd2b5f98c33e87cdb6aa2e9b8c5dced703d273", size = 1182217, upload-time = "2026-05-15T04:51:06.517Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/b6/993ff1ded3958215fd341a847b8e5ffeb5de473f435296870d314fc91ac4/tiktoken-0.13.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:cb99cb5127449f58d0a2d5f5ccfb390d8dbdfd919c221246caaee29d8725ed51", size = 1239404, upload-time = "2026-05-15T04:51:07.843Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/3d/fef7e06e3b33e7538db0ced734cf9fe23b6832d2ac4990c119c377aec55e/tiktoken-0.13.0-cp314-cp314-win_amd64.whl", hash = "sha256:115c4f26ffa11caac8b54eea35c2ad38c612c20a48d35dd15d70a02ac6f51f58", size = 918686, upload-time = "2026-05-15T04:51:08.925Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/82/a7fc44582bc32ab00de988a2299bf77c077f59068b233109e34b7d6ca7e6/tiktoken-0.13.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:472527e9132952f2fbf77cd290658bacf003d4d5a3fabc18e5fbd407cbae4d9b", size = 1034454, upload-time = "2026-05-15T04:51:10.035Z" },
+    { url = "https://files.pythonhosted.org/packages/37/d0/24d8a890c14f432a05cea669c17bebeaa99f96a7c79523b590f564246411/tiktoken-0.13.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:4e2f67d27c9626cdd25fe33d9313c5cdb3d8d82da646b68d6eb8e7e9c20e6448", size = 982976, upload-time = "2026-05-15T04:51:11.23Z" },
+    { url = "https://files.pythonhosted.org/packages/49/b7/2ab43f62788a9266187a9bfc1d3af99ad83e5eaa25fbef168a69cd5ad14f/tiktoken-0.13.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:2b920b35805cd64585a37c3dc7ce65fba4d2d36016be01e1d7942482ca29093a", size = 1115526, upload-time = "2026-05-15T04:51:12.608Z" },
+    { url = "https://files.pythonhosted.org/packages/64/39/1494321ed323ce7a14d88e3cd6cb9058625977df1c6961ddc492bd10a9f3/tiktoken-0.13.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:493af3aa28a4aaf2e3d2600a2ee717252c9bf5ab38fff94eb5a02db5ab77e5ad", size = 1136466, upload-time = "2026-05-15T04:51:13.926Z" },
+    { url = "https://files.pythonhosted.org/packages/96/d9/dfd086aa2d918c563a140720e0ce296cada1634efd2783d5cf51e05f984e/tiktoken-0.13.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:6644c9c2b5cf3916f5a3641d7d12fdb3f006a7b3d9ff6acdaec44e29ab1ff91e", size = 1181863, upload-time = "2026-05-15T04:51:15.025Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/68/a18b4f307086954fdae32714cb4f85562e34f9d34ab206e61f1816aa6018/tiktoken-0.13.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5cb65b60b9408563676d874a3a4ee573370066f0dc4e29d84e82e989c6517424", size = 1239218, upload-time = "2026-05-15T04:51:16.103Z" },
+    { url = "https://files.pythonhosted.org/packages/16/5b/f2aa703a4fc5d2dff73460a7d46cc2f3f44aa0f3dd8eeb20d2a0ecf68862/tiktoken-0.13.0-cp314-cp314t-win_amd64.whl", hash = "sha256:85b78cc3a2c3d48723ca751fa981f1fedccd54194ca0471b957364353a898b07", size = 918110, upload-time = "2026-05-15T04:51:17.237Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

Foundation for merchant-scoped Knowledge Bases (RAG) for Breeze Buddy agents (PR 1 of 3 — runtime integration and Google Sheets sync follow on top of this branch).

- **Migration 034**: `pgvector` + `pg_trgm` extensions; `knowledge_base` / `kb_document` / `kb_chunk` tables with `halfvec(768)` HNSW, `simple`-config tsvector and trigram indexes. All embedding providers are normalized to 768 dims (Matryoshka truncation + L2 renorm) so one column/index serves every provider.
- **DB trio** (queries/accessor/decoder) incl. race-safe PENDING claim (`FOR UPDATE SKIP LOCKED`), stale-PROCESSING requeue, chunk-hash maps, and a single hybrid retrieval query (vector KNN + websearch FTS + word-similarity trigram, RRF-fused) with pgvector 0.8 iterative scans when available.
- **Embedding provider abstraction** (`app/services/embeddings/`): registry keyed by per-KB `embedding_config`; OpenAI `text-embedding-3-small` default via the shared aiohttp factory (no new SDK); Redis query-embedding cache on the hot path.
- **Connector abstraction** (Onyx-style `load`/`detect_change`) with the file connector (GCS download; pdf/docx/xlsx/csv/txt/md parsers).
- **Source-aware chunking**: heading-aware ~450-token prose chunks that never split Q&A pairs/numbered procedures; tabular row-as-chunk with header context + sheet summary — paired with the keyword leg this is what makes exact prices/SKUs retrievable.
- **Ingestion worker** on `BackgroundTaskScheduler` + immediate post-upload kick; hash-diff upsert re-embeds only changed chunks; per-KB and per-reseller quotas (dynamic config); version-keyed Redis cache invalidation.
- **RBAC'd `/knowledge-bases` router**: CRUD (+ template in-use delete guard), multipart upload → GCS → PENDING doc, manual re-sync, and a `/query` retrieval-testing endpoint.

## Verification (local PG16 + pgvector 0.8.4)

- Migration applies cleanly; exact-vector match ranks first; exact SKU (`KX-9912`) wins via the keyword leg despite a random query vector; misspelled "shiping polcy" retrieves the shipping chunk via trigram; foreign-KB queries return 0 rows (tenant isolation); incremental upsert/trim and the template in-use JSONB scan behave as designed.
- `pyrefly check`: 0 errors; black/isort/autoflake clean.

## Deploy prerequisites

- Postgres must allow `CREATE EXTENSION vector` (RDS/Cloud SQL do).
- `OPENAI_API_KEY` set (embeddings); `ENABLE_BACKGROUND_TASKS` on for ingestion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VGDzk5UuP7SM3twwoV91uV

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added knowledge base management with create, view, update, delete, and search capabilities.
  * Added document upload, listing, deletion, and manual re-sync for knowledge bases.
  * Added retrieval testing so users can query a knowledge base and see matching results with response timing.
  * Added background ingestion to process uploaded documents automatically.
* **Bug Fixes**
  * Improved access control so knowledge base actions respect user scope and permissions.
  * Added better handling for upload limits, duplicate records, and processing errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->