### PR TITLE
feat: Google Sheets knowledge base connector — share-to-service-account, manual sync + scheduled poller

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -270,3 +270,13 @@ BB_DISPATCH_QPS_JITTER_MS=200               # ±ms applied to every ZADD score
 #   halt all workers during an incident. Fails open (treated as true) if
 #   DevCycle/Redis is unreachable, so a sick infra layer can't silently halt
 #   dispatch. Leads stay queued until the flag flips back.
+
+# Knowledge Base (RAG)
+# KB embeddings default to azure_openai/text-embedding-3-large via the
+# KB_AZURE_OPENAI_ENDPOINT/KB_AZURE_OPENAI_API_KEY dynamic-config keys —
+# separate from the LLM's AZURE_OPENAI_* on purpose. OPENAI_API_KEY is only
+# needed for KBs explicitly on provider=openai
+OPENAI_API_KEY=
+# Google Sheets KB connector: service-account JSON; merchants share their sheet
+# with this SA's client_email (Viewer). Falls back to GCS_CREDENTIALS_JSON.
+GOOGLE_SHEETS_SA_CREDENTIALS_JSON=

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,6 +146,15 @@ Breeze Buddy is the template-driven telephony agent. These patterns MUST be foll
 - Idle session cleanup is one task on the global `BackgroundTaskScheduler` (`chat/cleanup.py`); the scheduler's distributed lock keeps it single-pod-per-tick.
 - Open follow-ups: LLM-generated greeting (today only `static_greeting` works), outcome webhook on `end()`
 
+### Knowledge Base (RAG)
+- Merchant-scoped KBs (documents/sheets → chunks → pgvector) that templates attach via `configurations.knowledge_base` (`KnowledgeBaseConfig` in `template/types.py`) — no join table; KB delete does an in-use scan over template configs
+- Storage: `knowledge_base` / `kb_document` / `kb_chunk` tables (migration 034; pgvector `halfvec(768)` HNSW + `simple`-config tsvector + trigram). All embedding providers normalize to 768 dims (`app/services/embeddings/`, registry keyed by per-KB `embedding_config`; default = `azure_openai`/text-embedding-3-large in-region, `openai` is explicit opt-in)
+- Ingestion: `app/services/knowledge_base/` — connector registry (`file`, `google_sheet`; Onyx-style `load`/`detect_change` contract), source-aware chunking (heading-aware prose ~450 tokens; sheet/CSV rows = one chunk each with headers prepended), scheduler task claims PENDING docs via `FOR UPDATE SKIP LOCKED`, chunk-hash diff re-embeds only changed chunks
+- Retrieval: `retrieval.py::retrieve()` — one SQL, three legs (HNSW KNN + FTS + trigram) fused with RRF; callers own timeouts and ALWAYS fail open (voice ~0.4s, chat 1s, tool 5s)
+- Runtime modes (per template): `auto` (size-tiered) | `full_injection` (whole KB into initial node role_messages, fetched concurrently at boot) | `auto_retrieve` (`KnowledgeRetrievalProcessor` between user aggregator and LLM injects a transient system message, replaced-by-identity each turn) | `tool` (`query_knowledge_base` builtin, synthesized by `FlowConfigBuilder` from config). Realtime LLMs reject `auto`/`auto_retrieve` (`validate_template_compat`)
+- Sheets sync: share-to-service-account; `kb_sheets_poll` scheduler task probes Drive `modifiedTime` (15min default, 5min debounce) and requeues changed sheets; manual re-sync via `POST .../documents/{id}/sync`
+- KB context blocks are ephemeral everywhere: never persisted to `chat_message`, stripped from voice transcripts by `injection_header` prefix in `end_conversation`
+
 ## Important
 
 - IMPORTANT: Never modify migration SQL files directly. Create new sequential migrations (e.g., `026_your_change.sql`)

--- a/app/api/routers/breeze_buddy/knowledge_base/__init__.py
+++ b/app/api/routers/breeze_buddy/knowledge_base/__init__.py
@@ -12,6 +12,8 @@ Endpoints:
 - PUT    /knowledge-bases/{id}                         - Update metadata
 - DELETE /knowledge-bases/{id}                         - Delete (in-use check)
 - POST   /knowledge-bases/{id}/documents               - Upload file (multipart)
+- POST   /knowledge-bases/{id}/documents/sheet         - Connect a Google Sheet
+- GET    /knowledge-bases/sheets/service-account       - SA email to share with
 - GET    /knowledge-bases/{id}/documents               - List documents + status
 - DELETE /knowledge-bases/{id}/documents/{doc_id}      - Delete document
 - POST   /knowledge-bases/{id}/documents/{doc_id}/sync - Manual re-sync
@@ -25,22 +27,28 @@ from fastapi import APIRouter, Depends, File, Query, UploadFile, status
 from app.api.security.breeze_buddy.rbac_token import get_current_user_with_rbac
 from app.schemas import UserInfo
 from app.schemas.breeze_buddy.knowledge_base import (
+    AddSheetDocumentRequest,
     CreateKnowledgeBaseRequest,
     DeleteKnowledgeBaseResponse,
     KbDocument,
+    KbDocumentDownloadResponse,
     KbDocumentListResponse,
     KnowledgeBase,
     KnowledgeBaseListResponse,
     QueryKnowledgeBaseRequest,
     QueryKnowledgeBaseResponse,
+    SheetsServiceAccountResponse,
     UpdateKnowledgeBaseRequest,
 )
 
 from .handlers import (
+    add_sheet_document_handler,
     create_kb_handler,
     delete_document_handler,
     delete_kb_handler,
+    download_document_handler,
     get_kb_handler,
+    get_sheets_service_account_handler,
     list_documents_handler,
     list_kbs_handler,
     query_kb_handler,
@@ -83,6 +91,20 @@ async def list_knowledge_bases(
     return await list_kbs_handler(
         current_user, reseller_id, merchant_id, include_archived, search, page, limit
     )
+
+
+# NOTE: declared before /knowledge-bases/{kb_id} so "sheets" never matches
+# as a kb_id path parameter.
+@router.get(
+    "/knowledge-bases/sheets/service-account",
+    response_model=SheetsServiceAccountResponse,
+)
+async def get_sheets_service_account(
+    current_user: UserInfo = Depends(get_current_user_with_rbac),
+):
+    """The service-account email a merchant must share their sheet with
+    (Viewer) before connecting it."""
+    return get_sheets_service_account_handler()
 
 
 @router.get("/knowledge-bases/{kb_id}", response_model=KnowledgeBase)
@@ -130,6 +152,22 @@ async def upload_document(
     return await upload_document_handler(kb_id, file, current_user)
 
 
+@router.post(
+    "/knowledge-bases/{kb_id}/documents/sheet",
+    response_model=KbDocument,
+    status_code=status.HTTP_201_CREATED,
+)
+async def add_sheet_document(
+    kb_id: str,
+    request: AddSheetDocumentRequest,
+    current_user: UserInfo = Depends(get_current_user_with_rbac),
+):
+    """Connect a Google Sheet (shared with our service account) as a live
+    document. Initial sync runs immediately; afterwards the scheduled poller
+    re-syncs on change (or use the manual sync endpoint)."""
+    return await add_sheet_document_handler(kb_id, request, current_user)
+
+
 @router.get("/knowledge-bases/{kb_id}/documents", response_model=KbDocumentListResponse)
 async def list_documents(
     kb_id: str,
@@ -148,6 +186,20 @@ async def delete_document(
     """Delete a document and its chunks; the stored file is removed and
     runtime knowledge caches refresh on the next turn."""
     return await delete_document_handler(kb_id, document_id, current_user)
+
+
+@router.get(
+    "/knowledge-bases/{kb_id}/documents/{document_id}/download",
+    response_model=KbDocumentDownloadResponse,
+)
+async def download_document(
+    kb_id: str,
+    document_id: str,
+    current_user: UserInfo = Depends(get_current_user_with_rbac),
+):
+    """Get a download link for a document's original source: a short-lived
+    signed GCS URL for uploaded files, or the Google Sheet URL for sheets."""
+    return await download_document_handler(kb_id, document_id, current_user)
 
 
 @router.post(

--- a/app/api/routers/breeze_buddy/knowledge_base/handlers.py
+++ b/app/api/routers/breeze_buddy/knowledge_base/handlers.py
@@ -27,16 +27,19 @@ from app.database.accessor.breeze_buddy.knowledge_base import (
 )
 from app.schemas import UserInfo
 from app.schemas.breeze_buddy.knowledge_base import (
+    AddSheetDocumentRequest,
     CreateKnowledgeBaseRequest,
     DeleteKnowledgeBaseResponse,
     EmbeddingConfig,
     KbDocument,
+    KbDocumentDownloadResponse,
     KbDocumentListResponse,
     KbDocumentSourceType,
     KnowledgeBase,
     KnowledgeBaseListResponse,
     QueryKnowledgeBaseRequest,
     QueryKnowledgeBaseResponse,
+    SheetsServiceAccountResponse,
     UpdateKnowledgeBaseRequest,
 )
 from app.services.gcp.storage.storage import GCSStorage
@@ -327,6 +330,104 @@ async def upload_document_handler(
     return document
 
 
+async def add_sheet_document_handler(
+    kb_id: str, request: "AddSheetDocumentRequest", current_user: UserInfo
+) -> KbDocument:
+    """Connect a Google Sheet: validate SA access -> PENDING doc -> kick."""
+    from app.services.knowledge_base.connectors.google_sheets import (
+        fetch_spreadsheet_meta,
+        parse_spreadsheet_id,
+    )
+
+    kb = await _get_kb_or_404(kb_id)
+    require_admin_or_reseller_owner(current_user, kb.reseller_id, "connect sheets")
+
+    max_docs = await KB_MAX_DOCUMENTS_PER_KB()
+    documents = await list_kb_documents(kb_id)
+    if len(documents) >= max_docs:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Knowledge base already has {len(documents)} documents "
+            f"(cap: {max_docs})",
+        )
+
+    try:
+        spreadsheet_id = parse_spreadsheet_id(request.sheet_url)
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+
+    duplicate = next(
+        (
+            d
+            for d in documents
+            if d.source_type == KbDocumentSourceType.GOOGLE_SHEET
+            and d.source_ref.get("spreadsheet_id") == spreadsheet_id
+        ),
+        None,
+    )
+    if duplicate is not None:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=f"This spreadsheet is already connected as '{duplicate.name}'",
+        )
+
+    try:
+        meta = await fetch_spreadsheet_meta(spreadsheet_id)
+    except ValueError as e:
+        # Access/parse errors carry the share-with-SA guidance.
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+    except Exception as e:
+        logger.error(f"Sheet validation failed for {spreadsheet_id}: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="Could not reach Google Sheets; try again",
+        )
+
+    document = await create_kb_document(
+        kb_id=kb_id,
+        source_type=KbDocumentSourceType.GOOGLE_SHEET.value,
+        name=request.name or meta["title"],
+        source_ref={
+            "spreadsheet_id": spreadsheet_id,
+            "ranges": request.ranges or [],
+        },
+        mime_type="application/vnd.google-apps.spreadsheet",
+    )
+    if document is None:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to register the sheet",
+        )
+
+    kick_ingestion()
+    return document
+
+
+def get_sheets_service_account_handler() -> "SheetsServiceAccountResponse":
+    """The SA email to share sheets with (shown in the connect-sheet UI)."""
+    from app.services.knowledge_base.connectors.google_sheets import (
+        get_service_account_email,
+    )
+
+    try:
+        email = get_service_account_email()
+    except Exception as e:
+        logger.error(f"Sheets service-account lookup failed: {e}", exc_info=True)
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=(
+                "Google Sheets sync is not configured: set "
+                "GOOGLE_SHEETS_SA_CREDENTIALS_JSON (or GCS_CREDENTIALS_JSON)"
+            ),
+        ) from e
+    if not email:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Google Sheets service account has no client_email",
+        )
+    return SheetsServiceAccountResponse(email=email)
+
+
 async def list_documents_handler(
     kb_id: str, current_user: UserInfo
 ) -> KbDocumentListResponse:
@@ -404,6 +505,73 @@ async def resync_document_handler(
 
     kick_ingestion()
     return requeued
+
+
+_DOWNLOAD_URL_TTL_MINUTES = 10
+
+
+async def download_document_handler(
+    kb_id: str, document_id: str, current_user: UserInfo
+) -> KbDocumentDownloadResponse:
+    """Hand back the original source of a document.
+
+    Files: short-lived signed GCS URL (Content-Disposition forces the
+    original filename), so users can always retrieve exactly what they
+    uploaded. Sheets: the document IS the Google Sheet, so return its
+    canonical URL. Read-level access — same as list/query, not admin-gated.
+    Called from the loom docs-table download action (GET .../download).
+    """
+    kb = await _get_kb_or_404(kb_id)
+    validate_kb_access(
+        current_user, kb.reseller_id, kb.merchant_id, "download documents"
+    )
+
+    _require_uuid(document_id, "Document")
+    document = await get_kb_document_by_id(document_id)
+    if document is None or document.kb_id != kb_id:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Document {document_id} not found in knowledge base {kb_id}",
+        )
+
+    source_ref = document.source_ref or {}
+
+    if document.source_type == KbDocumentSourceType.GOOGLE_SHEET:
+        spreadsheet_id = source_ref.get("spreadsheet_id")
+        if not spreadsheet_id:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="This document has no downloadable source",
+            )
+        return KbDocumentDownloadResponse(
+            url=f"https://docs.google.com/spreadsheets/d/{spreadsheet_id}/edit",
+            filename=document.name,
+            expires_in_seconds=None,
+        )
+
+    gcs_path = source_ref.get("gcs_path")
+    if not gcs_path:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="This document has no stored file to download",
+        )
+
+    url = GCSStorage().generate_signed_url(
+        gcs_path,
+        expires_minutes=_DOWNLOAD_URL_TTL_MINUTES,
+        download_filename=document.name,
+    )
+    if url is None:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="File storage is unavailable; try again shortly",
+        )
+
+    return KbDocumentDownloadResponse(
+        url=url,
+        filename=document.name,
+        expires_in_seconds=_DOWNLOAD_URL_TTL_MINUTES * 60,
+    )
 
 
 async def query_kb_handler(

--- a/app/core/config/dynamic.py
+++ b/app/core/config/dynamic.py
@@ -654,3 +654,30 @@ async def KB_MERCHANT_MAX_CHUNKS() -> int:
     per reseller on a 15GB instance); the per-KB cap above only binds once
     this one has been raised for a reseller."""
     return await get_config("KB_MERCHANT_MAX_CHUNKS", 20000, int)
+
+
+async def KB_SHEETS_POLL_ENABLED() -> bool:
+    """Master switch for the scheduled Google Sheets freshness poller."""
+    return await get_config("KB_SHEETS_POLL_ENABLED", "true", bool)
+
+
+async def KB_SHEETS_POLL_INTERVAL_SECONDS() -> int:
+    """Scheduler interval for the sheets poller (read at startup).
+
+    Hardened against malformed env overrides like KB_INGESTION_INTERVAL_SECONDS
+    (a bad value would disable ALL background tasks at startup).
+    """
+    value = await get_config("KB_SHEETS_POLL_INTERVAL_SECONDS", 900, int)
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        logger.warning(
+            f"Invalid KB_SHEETS_POLL_INTERVAL_SECONDS value {value!r}; using 900"
+        )
+        return 900
+
+
+async def KB_SHEETS_MIN_SYNC_INTERVAL_SECONDS() -> int:
+    """Debounce floor: a sheet is never re-synced more often than this,
+    even if Drive reports changes (Sheets bumps modifiedTime aggressively)."""
+    return await get_config("KB_SHEETS_MIN_SYNC_INTERVAL_SECONDS", 300, int)

--- a/app/core/config/static.py
+++ b/app/core/config/static.py
@@ -43,6 +43,13 @@ GOOGLE_CREDENTIALS_JSON = os.environ.get("GOOGLE_CREDENTIALS_JSON", "")
 GCS_CREDENTIALS_JSON = os.environ.get("GCS_CREDENTIALS_JSON", "")
 GCS_BUCKET = os.environ.get("GCS_BUCKET", "atoms-sdk")
 
+# Google Sheets sync (knowledge base connector). Service-account JSON; the
+# merchant shares their sheet with this SA's email (Viewer). Falls back to
+# GCS_CREDENTIALS_JSON when unset (same SA reused with Sheets/Drive scopes).
+GOOGLE_SHEETS_SA_CREDENTIALS_JSON = os.environ.get(
+    "GOOGLE_SHEETS_SA_CREDENTIALS_JSON", ""
+)
+
 ENABLE_AIC_FILTER = os.environ.get("ENABLE_AIC_FILTER", "false").lower() == "true"
 AIC_LICENSE_KEY = os.environ.get("AIC_LICENSE_KEY", "")
 # Breeze Buddy AIC License Key

--- a/app/database/accessor/breeze_buddy/knowledge_base.py
+++ b/app/database/accessor/breeze_buddy/knowledge_base.py
@@ -30,6 +30,7 @@ from app.database.queries.breeze_buddy.knowledge_base import (
     get_kb_token_total_query,
     get_knowledge_base_by_id_query,
     get_merchant_chunk_total_query,
+    get_sheet_documents_due_for_poll_query,
     hybrid_search_chunks_query,
     insert_kb_document_query,
     insert_knowledge_base_query,
@@ -500,4 +501,19 @@ async def hybrid_search_chunks(
         return []
     except Exception as e:
         logger.error(f"Error in hybrid search over KBs {kb_ids}: {e}")
+        raise
+
+
+async def get_sheet_documents_due_for_poll(
+    min_sync_age_seconds: int,
+) -> List[KbDocument]:
+    """READY google_sheet documents older than the debounce floor."""
+    try:
+        query_text, values = get_sheet_documents_due_for_poll_query(
+            min_sync_age_seconds
+        )
+        result = await run_parameterized_query(query_text, values)
+        return decode_kb_document_list(result)
+    except Exception as e:
+        logger.error(f"Error listing sheet documents due for poll: {e}")
         raise

--- a/app/database/queries/breeze_buddy/knowledge_base.py
+++ b/app/database/queries/breeze_buddy/knowledge_base.py
@@ -551,3 +551,22 @@ def hybrid_search_chunks_query(
         top_k,
     ]
     return text, values
+
+
+def get_sheet_documents_due_for_poll_query(
+    min_sync_age_seconds: int,
+) -> Tuple[str, List[Any]]:
+    """Generate query for READY google_sheet documents due a freshness probe.
+
+    The age floor debounces the poller (Sheets bumps modifiedTime on every
+    keystroke-ish save; we never re-sync a sheet more often than this).
+    """
+    text = f"""
+        SELECT * FROM "{KB_DOCUMENT_TABLE}"
+        WHERE "source_type" = 'google_sheet'
+          AND "status" = 'READY'
+          AND ("synced_at" IS NULL
+               OR "synced_at" < now() - make_interval(secs => $1))
+        ORDER BY "synced_at" NULLS FIRST;
+    """
+    return text, [min_sync_age_seconds]

--- a/app/main.py
+++ b/app/main.py
@@ -36,6 +36,7 @@ from app.core.background_tasks import BackgroundTaskScheduler
 from app.core.config.dynamic import (
     ENABLE_BACKGROUND_TASKS,
     KB_INGESTION_INTERVAL_SECONDS,
+    KB_SHEETS_POLL_INTERVAL_SECONDS,
 )
 from app.core.config.static import (
     BACKGROUND_TASKS_LOOP_INTERVAL_SECONDS,
@@ -61,6 +62,9 @@ from app.core.middleware.widget_cors_bypass import CustomWidgetCorsBypassMiddlew
 from app.database import close_db_pool, init_db_pool
 from app.services.knowledge_base import (
     process_pending_documents as process_pending_kb_documents,
+)
+from app.services.knowledge_base.sheets_poll import (
+    poll_sheet_documents as poll_kb_sheet_documents,
 )
 from app.services.langfuse.tasks.task import initialize_langfuse_tasks
 from app.services.redis import (
@@ -148,6 +152,15 @@ async def lifespan(_app: FastAPI):
                 name="kb_ingestion",
                 func=process_pending_kb_documents,
                 interval_seconds=await KB_INGESTION_INTERVAL_SECONDS(),
+            )
+
+            # Google Sheets freshness poller: one cheap Drive modifiedTime
+            # probe per connected sheet per tick; changed sheets requeue for
+            # ingestion (KB_SHEETS_POLL_ENABLED gates each tick at runtime).
+            _background_scheduler.register_task(
+                name="kb_sheets_poll",
+                func=poll_kb_sheet_documents,
+                interval_seconds=await KB_SHEETS_POLL_INTERVAL_SECONDS(),
             )
 
             # Event-driven dispatch reconcilers (Plane 5). Only registered on

--- a/app/schemas/breeze_buddy/knowledge_base.py
+++ b/app/schemas/breeze_buddy/knowledge_base.py
@@ -105,6 +105,20 @@ class CreateKnowledgeBaseRequest(BaseModel):
     settings: Optional[Dict[str, Any]] = None
 
 
+class KbDocumentDownloadResponse(BaseModel):
+    """Response of GET /knowledge-bases/{kb_id}/documents/{id}/download.
+
+    For uploaded files ``url`` is a short-lived signed GCS link (the browser
+    downloads the original bytes directly, nothing streams through the app);
+    for google_sheet documents it is the sheet's normal Google URL and
+    ``expires_in_seconds`` is null.
+    """
+
+    url: str
+    filename: str
+    expires_in_seconds: Optional[int] = None
+
+
 class UpdateKnowledgeBaseRequest(BaseModel):
     name: Optional[str] = Field(None, min_length=1, max_length=255)
     description: Optional[str] = None
@@ -126,6 +140,27 @@ class DeleteKnowledgeBaseResponse(BaseModel):
     status: str
     kb_id: str
     message: str
+
+
+class AddSheetDocumentRequest(BaseModel):
+    """Connect a Google Sheet as a knowledge base document."""
+
+    sheet_url: str = Field(
+        ..., min_length=10, description="Full Google Sheets URL (or bare ID)."
+    )
+    ranges: Optional[List[str]] = Field(
+        None,
+        description="Sheet tabs / A1 ranges to sync. Omit to sync all tabs.",
+    )
+    name: Optional[str] = Field(
+        None, description="Display name; defaults to the spreadsheet title."
+    )
+
+
+class SheetsServiceAccountResponse(BaseModel):
+    """The service-account email merchants share their sheet with."""
+
+    email: str
 
 
 class QueryKnowledgeBaseRequest(BaseModel):

--- a/app/services/gcp/storage/storage.py
+++ b/app/services/gcp/storage/storage.py
@@ -3,6 +3,7 @@ GCS Storage - Google Cloud Storage operations
 Simplified module for uploading audio files to GCS
 """
 
+from datetime import timedelta
 from typing import BinaryIO, Optional
 
 from app.core.config.static import GCS_BUCKET
@@ -92,6 +93,55 @@ class GCSStorage:
         except Exception as e:
             logger.error(
                 f"Failed to download gs://{GCS_BUCKET}/{source_path}: {e}",
+                exc_info=True,
+            )
+            return None
+
+    def generate_signed_url(
+        self,
+        source_path: str,
+        expires_minutes: int = 10,
+        download_filename: Optional[str] = None,
+    ) -> Optional[str]:
+        """
+        Generate a short-lived V4 signed download URL for an object.
+
+        Signing happens locally with the service-account private key (no
+        API call), so this is cheap and synchronous. Used by the knowledge
+        base document-download endpoint to hand the browser a direct GCS
+        link without proxying file bytes through the app.
+
+        Args:
+            source_path (str): The object path in the GCS bucket
+            expires_minutes (int): URL validity window
+            download_filename (Optional[str]): When set, forces
+                Content-Disposition attachment with this filename so the
+                browser saves the file under its original name rather than
+                the storage path's UUID segment
+
+        Returns:
+            Optional[str]: The signed URL, or None on failure
+        """
+        try:
+            if not self.bucket:
+                logger.error("GCS bucket not initialized")
+                return None
+
+            blob = self.bucket.blob(source_path)
+            disposition = (
+                f'attachment; filename="{download_filename}"'
+                if download_filename
+                else None
+            )
+            return blob.generate_signed_url(
+                version="v4",
+                expiration=timedelta(minutes=expires_minutes),
+                response_disposition=disposition,
+            )
+
+        except Exception as e:
+            logger.error(
+                f"Failed to sign URL for gs://{GCS_BUCKET}/{source_path}: {e}",
                 exc_info=True,
             )
             return None

--- a/app/services/knowledge_base/connectors/__init__.py
+++ b/app/services/knowledge_base/connectors/__init__.py
@@ -9,9 +9,11 @@ from typing import Dict
 
 from app.services.knowledge_base.connectors.base import KBConnector
 from app.services.knowledge_base.connectors.file_upload import FileUploadConnector
+from app.services.knowledge_base.connectors.google_sheets import GoogleSheetsConnector
 
 SOURCE_CONNECTORS: Dict[str, KBConnector] = {
     FileUploadConnector.source_type: FileUploadConnector(),
+    GoogleSheetsConnector.source_type: GoogleSheetsConnector(),
 }
 
 

--- a/app/services/knowledge_base/connectors/google_sheets.py
+++ b/app/services/knowledge_base/connectors/google_sheets.py
@@ -1,0 +1,278 @@
+"""
+Google Sheets connector: merchant-shared spreadsheet -> NormalizedContent.
+
+Auth model: the platform's service account; the merchant shares their sheet
+with the SA email as Viewer (lowest-friction B2B pattern — no OAuth flow).
+Data access is REST via the shared aiohttp factory; only token minting uses
+the google-auth library (sync, run in a thread, cached until near expiry).
+
+Sync model (see also sheets_poll.py): Sheets has no row-level diff API, so
+change detection is a cheap Drive ``files.get(modifiedTime)`` probe and a
+"changed" verdict triggers a full ``values.batchGet`` re-read; the ingestion
+worker's chunk-hash diff then re-embeds only rows that actually changed.
+"""
+
+import asyncio
+import datetime
+import hashlib
+import json
+import re
+from typing import Any, Dict, List, Optional, Tuple
+
+import aiohttp
+
+from app.core.config.static import (
+    GCS_CREDENTIALS_JSON,
+    GOOGLE_SHEETS_SA_CREDENTIALS_JSON,
+)
+from app.core.logger import logger
+from app.core.transport.http_client import create_aiohttp_session
+from app.schemas.breeze_buddy.knowledge_base import KbDocument
+from app.services.knowledge_base.connectors.base import KBConnector
+from app.services.knowledge_base.types import NormalizedContent, TableData
+
+_SCOPES = [
+    "https://www.googleapis.com/auth/spreadsheets.readonly",
+    "https://www.googleapis.com/auth/drive.metadata.readonly",
+]
+_SHEETS_API = "https://sheets.googleapis.com/v4/spreadsheets"
+_DRIVE_API = "https://www.googleapis.com/drive/v3/files"
+
+_SPREADSHEET_URL_RE = re.compile(r"/spreadsheets/d/([a-zA-Z0-9_-]+)")
+
+MAX_SHEET_ROWS = 10_000
+MAX_SHEET_COLUMNS = 50
+
+# Token cache: (access_token, expiry_epoch). Minting is sync google-auth
+# work run in a thread; cached until 5 minutes before expiry.
+_token_cache: Optional[Tuple[str, float]] = None
+_token_lock = asyncio.Lock()
+
+_session: Optional[aiohttp.ClientSession] = None
+
+
+def _get_session() -> aiohttp.ClientSession:
+    """Lazily create/reuse the module's shared aiohttp session for all
+    Google API calls (connection reuse across poller probes and loads)."""
+    global _session
+    if _session is None or _session.closed:
+        _session = create_aiohttp_session(
+            timeout=aiohttp.ClientTimeout(total=60, connect=10)
+        )
+    return _session
+
+
+def _credentials_info() -> Dict[str, Any]:
+    """Parsed service-account JSON from env.
+
+    Dedicated ``GOOGLE_SHEETS_SA_CREDENTIALS_JSON`` wins; falls back to the
+    GCS service account (same project) — that SA then also needs the
+    Sheets/Drive readonly scopes granted. Raises a curated ValueError when
+    neither is set (surfaced as the 503 on the connect-sheet endpoint).
+    """
+    raw = GOOGLE_SHEETS_SA_CREDENTIALS_JSON or GCS_CREDENTIALS_JSON
+    if not raw:
+        raise ValueError(
+            "Google Sheets sync is not configured: set "
+            "GOOGLE_SHEETS_SA_CREDENTIALS_JSON (or GCS_CREDENTIALS_JSON)"
+        )
+    return json.loads(raw)
+
+
+def get_service_account_email() -> str:
+    """The SA email merchants must share their sheet with (Viewer)."""
+    return str(_credentials_info().get("client_email", ""))
+
+
+def parse_spreadsheet_id(url_or_id: str) -> str:
+    """Extract the spreadsheet ID from a full Sheets URL or bare ID.
+
+    Called by the add-sheet handler on whatever the merchant pasted into
+    the loom connect dialog; raises a user-facing ValueError (400) when
+    neither shape matches.
+    """
+    value = url_or_id.strip()
+    match = _SPREADSHEET_URL_RE.search(value)
+    if match:
+        return match.group(1)
+    if re.fullmatch(r"[a-zA-Z0-9_-]{20,}", value):
+        return value
+    raise ValueError(
+        "Could not parse a spreadsheet ID from the provided value; paste the "
+        "full Google Sheets URL"
+    )
+
+
+def _mint_token_sync() -> Tuple[str, float]:
+    """Mint a fresh OAuth access token from the SA credentials (sync).
+
+    google-auth is a sync library, so this runs via ``asyncio.to_thread``
+    from ``_get_access_token``. Returns (token, expiry_epoch); a missing
+    expiry assumes the standard ~1h lifetime minus safety margin.
+    """
+    from google.auth.transport.requests import Request
+    from google.oauth2 import service_account
+
+    credentials = service_account.Credentials.from_service_account_info(
+        _credentials_info(), scopes=_SCOPES
+    )
+    credentials.refresh(Request())
+    expiry = credentials.expiry
+    expiry_epoch = (
+        expiry.replace(tzinfo=datetime.timezone.utc).timestamp()
+        if expiry
+        else datetime.datetime.now(datetime.timezone.utc).timestamp() + 3000
+    )
+    return str(credentials.token), expiry_epoch
+
+
+async def _get_access_token() -> str:
+    """Cached SA access token, re-minted when <5 minutes from expiry.
+
+    Double-checked locking: the cheap check outside the lock serves the
+    common case without contention; the re-check inside prevents a
+    thundering herd of token mints when many probes race at expiry.
+    """
+    global _token_cache
+    now = datetime.datetime.now(datetime.timezone.utc).timestamp()
+    if _token_cache and _token_cache[1] - now > 300:
+        return _token_cache[0]
+    async with _token_lock:
+        now = datetime.datetime.now(datetime.timezone.utc).timestamp()
+        if _token_cache and _token_cache[1] - now > 300:
+            return _token_cache[0]
+        _token_cache = await asyncio.to_thread(_mint_token_sync)
+        return _token_cache[0]
+
+
+async def _api_get(url: str, params: Any = None) -> Dict[str, Any]:
+    """Authenticated GET against the Sheets/Drive APIs with error mapping.
+
+    Translates the statuses users actually hit into actionable messages:
+    403 -> "share with <SA email>" (the #1 onboarding mistake), 404 -> bad
+    URL, 429 -> rate limit (poller backs off by just failing the tick).
+    ValueError = user-fixable, RuntimeError = transient/ops.
+    """
+    token = await _get_access_token()
+    async with _get_session().get(
+        url, params=params, headers={"Authorization": f"Bearer {token}"}
+    ) as response:
+        if response.status == 403:
+            raise ValueError(
+                "Access denied. Share the sheet with "
+                f"{get_service_account_email()} (Viewer) and try again."
+            )
+        if response.status == 404:
+            raise ValueError("Spreadsheet not found — check the URL.")
+        if response.status == 429:
+            raise RuntimeError("Google Sheets API rate limit hit (429); retry later")
+        if response.status != 200:
+            body = await response.text()
+            raise RuntimeError(
+                f"Google API request failed ({response.status}): {body[:300]}"
+            )
+        return await response.json()
+
+
+async def fetch_spreadsheet_meta(spreadsheet_id: str) -> Dict[str, Any]:
+    """Validate access and return {title, sheet_titles} for the add-sheet flow."""
+    data = await _api_get(
+        f"{_SHEETS_API}/{spreadsheet_id}",
+        params={"fields": "properties.title,sheets.properties.title"},
+    )
+    return {
+        "title": data.get("properties", {}).get("title", "Untitled spreadsheet"),
+        "sheet_titles": [
+            s.get("properties", {}).get("title", "")
+            for s in data.get("sheets", [])
+            if s.get("properties", {}).get("title")
+        ],
+    }
+
+
+class GoogleSheetsConnector(KBConnector):
+    source_type = "google_sheet"
+
+    async def load(self, document: KbDocument) -> NormalizedContent:
+        """Fetch the sheet's current rows as TableData (one per tab).
+
+        The connector half of ingestion for google_sheet documents: one
+        ``values:batchGet`` for all configured ranges (or every tab when
+        none were pinned at connect time). The content hash over the
+        fetched values lets ingestion's row-level hash-diff re-embed only
+        edited rows.
+        """
+        spreadsheet_id = str(document.source_ref.get("spreadsheet_id") or "")
+        if not spreadsheet_id:
+            raise ValueError(
+                f"Document {document.id} has no spreadsheet_id in source_ref"
+            )
+
+        ranges: List[str] = list(document.source_ref.get("ranges") or [])
+        if not ranges:
+            meta = await fetch_spreadsheet_meta(spreadsheet_id)
+            ranges = meta["sheet_titles"]
+        if not ranges:
+            raise ValueError("Spreadsheet has no sheets to read")
+
+        data = await _api_get(
+            f"{_SHEETS_API}/{spreadsheet_id}/values:batchGet",
+            params=[("ranges", r) for r in ranges]
+            + [("majorDimension", "ROWS"), ("valueRenderOption", "FORMATTED_VALUE")],
+        )
+
+        tables: List[TableData] = []
+        for value_range in data.get("valueRanges", []):
+            rows: List[List[str]] = [
+                [str(cell) for cell in row[:MAX_SHEET_COLUMNS]]
+                for row in value_range.get("values", [])
+            ][: MAX_SHEET_ROWS + 1]
+            if len(rows) < 2:
+                continue  # header-only or empty tab
+            # "'Sheet1'!A1:Z100" -> "Sheet1"
+            range_name = value_range.get("range", "")
+            sheet_name = range_name.split("!")[0].strip("'") or "sheet"
+            tables.append(TableData(name=sheet_name, headers=rows[0], rows=rows[1:]))
+
+        if not tables:
+            raise ValueError(
+                "No data rows found — the sheet needs a header row plus at "
+                "least one data row"
+            )
+
+        content_hash = hashlib.sha256(
+            json.dumps(
+                [[t.name, t.headers, t.rows] for t in tables], ensure_ascii=False
+            ).encode("utf-8")
+        ).hexdigest()
+        return NormalizedContent(tables=tables, content_hash=content_hash)
+
+    async def detect_change(self, document: KbDocument) -> bool:
+        """Cheap freshness probe: Drive modifiedTime vs the last sync time.
+
+        Errors report "changed" so the poller falls through to a full
+        re-read (which surfaces real errors on the document row).
+        """
+        spreadsheet_id = str(document.source_ref.get("spreadsheet_id") or "")
+        if not spreadsheet_id or document.synced_at is None:
+            return True
+        try:
+            data = await _api_get(
+                f"{_DRIVE_API}/{spreadsheet_id}", params={"fields": "modifiedTime"}
+            )
+            modified_raw = data.get("modifiedTime")
+            if not modified_raw:
+                return True
+            modified_at = datetime.datetime.fromisoformat(
+                modified_raw.replace("Z", "+00:00")
+            )
+            synced_at = document.synced_at
+            if synced_at.tzinfo is None:
+                synced_at = synced_at.replace(tzinfo=datetime.timezone.utc)
+            return modified_at > synced_at
+        except Exception as e:
+            logger.warning(
+                f"Sheets change probe failed for document {document.id} "
+                f"(assuming changed): {e}"
+            )
+            return True

--- a/app/services/knowledge_base/sheets_poll.py
+++ b/app/services/knowledge_base/sheets_poll.py
@@ -1,0 +1,57 @@
+"""
+Scheduled Google Sheets freshness poller.
+
+Runs on the BackgroundTaskScheduler (distributed lock -> one pod per tick).
+For every READY google_sheet document past the debounce floor it does ONE
+cheap Drive ``files.get(modifiedTime)`` call; changed sheets are flipped back
+to PENDING and the ingestion worker re-reads them (chunk-hash diff re-embeds
+only edited rows). Merchants can always force it sooner with "Sync now".
+"""
+
+import asyncio
+
+from app.core.config.dynamic import (
+    KB_SHEETS_MIN_SYNC_INTERVAL_SECONDS,
+    KB_SHEETS_POLL_ENABLED,
+)
+from app.core.logger import logger
+from app.database.accessor.breeze_buddy.knowledge_base import (
+    get_sheet_documents_due_for_poll,
+    mark_kb_document_for_resync,
+)
+from app.services.knowledge_base.connectors import get_connector
+from app.services.knowledge_base.ingestion import kick_ingestion
+
+# Gentle pacing between Drive probes (quota: 60 read req/min/user).
+_PROBE_SPACING_SECONDS = 0.25
+
+
+async def poll_sheet_documents() -> int:
+    """Probe connected sheets for changes; returns the number requeued."""
+    if not await KB_SHEETS_POLL_ENABLED():
+        return 0
+
+    min_age = await KB_SHEETS_MIN_SYNC_INTERVAL_SECONDS()
+    documents = await get_sheet_documents_due_for_poll(min_age)
+    if not documents:
+        return 0
+
+    connector = get_connector("google_sheet")
+    changed = 0
+    for document in documents:
+        try:
+            if await connector.detect_change(document):
+                requeued = await mark_kb_document_for_resync(document.id)
+                if requeued is not None:
+                    changed += 1
+                    logger.info(
+                        f"Sheet document {document.id} ('{document.name}') "
+                        "changed at source; queued for re-sync"
+                    )
+        except Exception as e:
+            logger.warning(f"Sheets poll probe failed for document {document.id}: {e}")
+        await asyncio.sleep(_PROBE_SPACING_SECONDS)
+
+    if changed:
+        kick_ingestion()
+    return changed


### PR DESCRIPTION
## What

PR 3 of 3 (stacked on #875). Merchants link a Google Sheet as a live KB document by sharing it (Viewer) with the platform service account and pasting the URL — no OAuth flow.

- **google_sheets connector**: token minting via google-auth (already a dep through google-cloud-storage; sync work in a thread, cached to expiry), data access over REST through the shared aiohttp factory. `load()` = `values.batchGet` across all tabs (or configured ranges) → one table per tab → the existing row-as-chunk pipeline; `detect_change()` = one Drive `files.get(modifiedTime)` probe vs `synced_at`. 403/404/429 map to actionable errors (403 tells the caller which SA email to share with).
- **API**: `POST /knowledge-bases/{id}/documents/sheet` (parse URL → validate access → PENDING doc → immediate ingest kick; 409 on duplicate spreadsheet) and `GET /knowledge-bases/sheets/service-account` for the connect-sheet UI. Manual "Sync now" reuses the existing document sync endpoint.
- **Scheduled poller** (`kb_sheets_poll`, default 15min, runtime-gated by `KB_SHEETS_POLL_ENABLED`): probes READY sheets past a 5-min debounce floor, requeues changed ones — ingestion's chunk-hash diff then re-embeds only edited rows. Probes paced 250ms apart against the 60 req/min/user Drive quota.
- **Config/docs**: `GOOGLE_SHEETS_SA_CREDENTIALS_JSON` (falls back to `GCS_CREDENTIALS_JSON`), dynamic poll knobs, `.env.example` and CLAUDE.md updates for the whole KB feature.

Deferred by design: Drive `files.watch` webhooks (7-day channel renewal churn) and per-merchant OAuth for Workspaces that block external sharing.

## Verification

Import smoke with connector + poller registered; spreadsheet URL/ID parsing round-trips; `pyrefly check`: 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VGDzk5UuP7SM3twwoV91uV

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Google Sheets as a supported knowledge base source, including sheet connection, document download, and service-account sharing details.
  * Introduced a scheduled freshness check to keep sheet-backed knowledge base content up to date.
  * Added signed download links for stored files and direct links for connected sheets.

* **Bug Fixes**
  * Improved freshness detection so changed sheets are re-queued for re-sync automatically.
  * Added safer handling for missing sources, access issues, and temporary sync failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Riders (2026-07-09)

- **Download original**: `GET /knowledge-bases/{kb}/documents/{id}/download` — 10-min V4 signed GCS URL for files (Content-Disposition keeps the uploaded filename; signing is local, no bytes proxied), canonical Sheet URL for sheet docs. Read-level RBAC. Pairs with the download icon shipped in loom#219.
- **Query-embedding cache REMOVED** (superseding an interim slimming pass): real conversation queries are near-unique (multi-turn joins of prev turn + current utterance), so the exact-text cache's hit rate never justified its Redis memory or complexity. `retrieve()` now embeds directly via the provider; `KB_EMBED_CACHE_TTL_SECONDS` knob deleted; no `kb:emb*` keys are written. The version-keyed full-text/token caches (per-KB, load-bearing for full_injection boot) are unchanged. If repeat-heavy traffic ever shows up, the right reintroduction is a semantic result cache, not exact-text matching. Verified live: repeated queries both hit the embed API, zero cache keys, identical results.
