### PR TITLE
add country code in mobile number

### DIFF
--- a/app/api/routers/breeze_buddy/webhooks/woocommerce/cart.py
+++ b/app/api/routers/breeze_buddy/webhooks/woocommerce/cart.py
@@ -12,7 +12,12 @@ from typing import Any, Dict, Optional, Tuple
 
 from app.core.logger import logger
 
-from .utils import TOPIC_ABANDONED_CHECKOUT, first, push_lead
+from .utils import (
+    TOPIC_ABANDONED_CHECKOUT,
+    first,
+    normalize_indian_phone,
+    push_lead,
+)
 
 
 def summarize_cart_items(data: Dict[str, Any]) -> str:
@@ -51,11 +56,11 @@ def build_abandoned_checkout_payload(
     """
     billing = data.get("billing") or {}
 
-    phone = (
+    phone = normalize_indian_phone(
         billing.get("phone")
         or first(data, "phone", "wcf_phone_number", "customer_mobile_number")
         or ""
-    ).strip()
+    )
 
     first_name = billing.get("first_name") or first(
         data, "first_name", "wcf_first_name"

--- a/app/api/routers/breeze_buddy/webhooks/woocommerce/order.py
+++ b/app/api/routers/breeze_buddy/webhooks/woocommerce/order.py
@@ -9,7 +9,7 @@ from typing import Any, Dict, Optional, Tuple
 
 from app.core.logger import logger
 
-from .utils import TOPIC_ORDER_CONFIRMATION, push_lead
+from .utils import TOPIC_ORDER_CONFIRMATION, normalize_indian_phone, push_lead
 
 
 def evaluate_trigger(order: Dict[str, Any], all_orders: bool) -> Tuple[bool, str]:
@@ -34,7 +34,7 @@ def build_order_payload(
     ``phone`` is returned separately so the caller can skip when empty.
     """
     billing = order.get("billing") or {}
-    phone = (billing.get("phone") or order.get("phone") or "").strip()
+    phone = normalize_indian_phone(billing.get("phone") or order.get("phone") or "")
 
     customer_name = " ".join(
         part

--- a/app/api/routers/breeze_buddy/webhooks/woocommerce/utils.py
+++ b/app/api/routers/breeze_buddy/webhooks/woocommerce/utils.py
@@ -22,6 +22,32 @@ TOPIC_ORDER_CONFIRMATION = "order-confirmation"
 TOPIC_ABANDONED_CHECKOUT = "abandoned-checkout"
 
 
+def normalize_indian_phone(raw: Optional[str]) -> str:
+    """Normalize a phone number to E.164 for dialing (defaults to India / +91).
+
+    Telephony providers require E.164 (e.g. +919876543210). WooCommerce / cart
+    checkouts often store a bare 10-digit number, or with spaces, a leading 0,
+    or a ``91`` prefix without ``+``. Numbers already in ``+<country>...`` form
+    are kept (only stripped of separators).
+    """
+    if not raw:
+        return ""
+    s = str(raw).strip()
+    if s.startswith("+"):
+        return "+" + "".join(ch for ch in s[1:] if ch.isdigit())
+    digits = "".join(ch for ch in s if ch.isdigit())
+    if not digits:
+        return ""
+    if len(digits) == 11 and digits.startswith("0"):
+        digits = digits[1:]  # drop trunk 0
+    if len(digits) == 12 and digits.startswith("91"):
+        return "+" + digits
+    if len(digits) == 10:
+        return "+91" + digits
+    # Unknown shape — assume it already carries a country code.
+    return "+" + digits
+
+
 def first(data: Dict[str, Any], *keys: str) -> Optional[Any]:
     """Return the first non-empty value among the given keys (nested-aware).
 


### PR DESCRIPTION
 - added support to add country code infront of mobile number and parse it correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved phone number handling for WooCommerce order and abandoned-checkout flows.
  * Customer phone numbers are now normalized more consistently, helping reduce issues caused by formatting differences, extra spaces, or missing country codes.
  * This should make captured contact details more reliable when orders or checkout events are processed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->