### PR TITLE
Abort lead for cancelled orders

### DIFF
--- a/app/api/routers/breeze_buddy/webhooks/woocommerce/order.py
+++ b/app/api/routers/breeze_buddy/webhooks/woocommerce/order.py
@@ -9,9 +9,16 @@ from typing import Any, Dict, Optional, Tuple
 
 from app.core.logger import logger
 
-from .utils import TOPIC_ORDER_CONFIRMATION, normalize_indian_phone, push_lead
+from .utils import (
+    TOPIC_ORDER_CONFIRMATION,
+    abort_backlog_leads,
+    normalize_indian_phone,
+    push_lead,
+)
 
 CALLABLE_ORDER_STATUSES = {"processing", "on-hold"}
+# A placed order that got cancelled — abort any not-yet-dialed leads for it.
+CANCELLED_ORDER_STATUSES = {"cancelled"}
 
 
 def evaluate_trigger(order: Dict[str, Any], all_orders: bool) -> Tuple[bool, str]:
@@ -107,9 +114,18 @@ async def process_order_confirmation(
     if not order_id:
         return {"status": "ignored", "reason": "no order id in payload"}
 
+    order_status = (order.get("status") or "").lower()
+
+    # Merchant cancelled the order before we called: abort any not-yet-dialed
+    # (BACKLOG) leads for it so we don't ring to confirm a cancelled order. A
+    # call already in progress is left as-is.
+    if order_status in CANCELLED_ORDER_STATUSES:
+        return await abort_backlog_leads(
+            TOPIC_ORDER_CONFIRMATION, order_id, merchant_id, "merchant cancelled order"
+        )
+
     # Only call freshly placed orders — skip terminal/fulfilled statuses so
     # cancel / delivered / tracking updates on old orders don't trigger a call.
-    order_status = (order.get("status") or "").lower()
     if order_status not in CALLABLE_ORDER_STATUSES:
         logger.info(
             f"woocommerce order {order_id} skipped: status '{order_status}' "

--- a/app/api/routers/breeze_buddy/webhooks/woocommerce/utils.py
+++ b/app/api/routers/breeze_buddy/webhooks/woocommerce/utils.py
@@ -5,17 +5,24 @@ Shared helpers for WooCommerce webhook processing.
 - ``first``: generic nested-aware field lookup
 - ``push_lead``: idempotent lead push used by both the order-confirmation and
   abandoned-checkout flows.
+- ``abort_backlog_leads``: cancel not-yet-dialed leads for an order.
 """
 
-from typing import Any, Dict, Optional
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
 
 from fastapi import HTTPException, status
 
 from app.ai.voice.agents.breeze_buddy.types.models import PushLeadRequest
 from app.api.routers.breeze_buddy.leads.handlers import push_lead_handler
 from app.core.logger import logger
-from app.database.accessor import get_leads_by_request_id
-from app.schemas import UserInfo, UserRole
+from app.database.accessor import (
+    acquire_lock_on_lead_by_id,
+    get_leads_by_request_id,
+    release_lock_on_lead_by_id,
+    update_lead_call_completion_details,
+)
+from app.schemas import LeadCallStatus, UserInfo, UserRole
 
 # Supported topics (URL path segment).
 TOPIC_ORDER_CONFIRMATION = "order-confirmation"
@@ -103,14 +110,6 @@ async def push_lead(
         merchant_id=merchant_id,
     )
 
-    # TEMP DEBUG (local testing) — remove later. Logs the exact lead about to be
-    # pushed for both flows (order-confirmation + abandoned-checkout).
-    logger.info(
-        f"[woo-push] {topic} pushing lead: request_id={request_id} "
-        f"template={template} template_id={template_id} "
-        f"reseller_id={reseller_id} merchant_id={merchant_id} payload={payload}"
-    )
-
     try:
         result = await push_lead_handler(lead_req, service_user)
     except HTTPException as e:
@@ -129,4 +128,61 @@ async def push_lead(
         "request_id": request_id,
         "lead_call_tracker_id": result.get("lead_call_tracker_id"),
         "trigger": trigger_reason,
+    }
+
+
+async def abort_backlog_leads(
+    topic: str,
+    order_id: Any,
+    merchant_id: str,
+    reason: str,
+) -> Dict[str, Any]:
+    """Abort not-yet-dialed leads for an order (e.g. the merchant cancelled it).
+
+    Only leads still in BACKLOG *and* not yet claimed by a dispatch worker are
+    aborted — claimed via the same atomic status-guarded lock the worker uses
+    (``expected_status=BACKLOG``, which also requires ``is_locked=FALSE``), so a
+    call already being set up or in progress is left untouched. Aborted leads are
+    marked FINISHED with outcome ``ABORTED`` and the reason in ``metaData``.
+    """
+    request_id = f"woocommerce-{merchant_id}-{topic}-{order_id}"
+    leads = await get_leads_by_request_id(request_id)
+    if not leads:
+        return {
+            "status": "noop",
+            "reason": "no leads for order",
+            "request_id": request_id,
+        }
+
+    aborted: List[str] = []
+    skipped: List[str] = []
+    for lead in leads:
+        # Atomically claim only if still BACKLOG and unlocked. If a worker already
+        # owns it (call in progress) or it already finished, acquire returns None
+        # and we leave the lead as-is.
+        locked = await acquire_lock_on_lead_by_id(
+            lead.id, expected_status=LeadCallStatus.BACKLOG
+        )
+        if not locked:
+            skipped.append(lead.id)
+            continue
+        await update_lead_call_completion_details(
+            id=lead.id,
+            status=LeadCallStatus.FINISHED,
+            outcome="ABORTED",
+            meta_data={"reason": reason},
+            call_end_time=datetime.now(timezone.utc),
+        )
+        await release_lock_on_lead_by_id(lead.id)
+        aborted.append(lead.id)
+
+    logger.info(
+        f"woocommerce abort {request_id}: aborted={aborted} "
+        f"left_untouched={skipped}"
+    )
+    return {
+        "status": "aborted" if aborted else "noop",
+        "request_id": request_id,
+        "aborted_lead_ids": aborted,
+        "skipped_lead_ids": skipped,
     }


### PR DESCRIPTION
- while consuming order update webhook, we check the order status if it is cancelled, then we check for the leads against the orderId
 - we then abort all the leads of that particular orderId

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Cancelled WooCommerce orders now stop any pending follow-up leads from being processed.
  * Leads already queued for those orders are marked as aborted, helping prevent unwanted calls after cancellation.
  * The webhook flow now handles cancellation earlier, reducing the chance of cancelled orders continuing through normal processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->