### PR TITLE
BZ-4431: fix(leads): handle list-valued stt_language in playground lead push

### DIFF
--- a/app/api/routers/breeze_buddy/leads/handlers.py
+++ b/app/api/routers/breeze_buddy/leads/handlers.py
@@ -346,6 +346,8 @@ async def push_lead_handler(req: PushLeadRequest, current_user: UserInfo) -> Dic
             # skip LLM-based detection entirely.
             overrides = req.configurations_override or {}
             stt_language = overrides.get("stt_language", "")
+            if isinstance(stt_language, list):
+                stt_language = stt_language[0] if stt_language else ""
             normalized_language = SHORT_TO_FULL_LANGUAGE_CODE.get(
                 stt_language, stt_language
             )


### PR DESCRIPTION
### Problem
Playground test calls fail with `500 – unhashable type: 'list'` when the template supports multiple STT languages.

Multi-language templates store `stt_language` as a list (e.g. `["en", "hi", "ta", "te", "pa"]`). In the `is_playground` branch of `push_lead_handler`, that value is used directly as a dict key:

```python
normalized_language = SHORT_TO_FULL_LANGUAGE_CODE.get(stt_language, stt_language)
```

A list is unhashable, so the lookup raises `unhashable type: 'list'` and the lead push 500s. Only the playground path is affected — the normal path goes through `determine_language_for_call`, which already coerces a list to its first entry.

### Fix
Coerce a list `stt_language` to its first entry (the primary language) before the lookup, mirroring `determine_language_for_call` (`language_detector.py`):

```python
stt_language = overrides.get("stt_language", "")
if isinstance(stt_language, list):
    stt_language = stt_language[0] if stt_language else ""
```

Scope is limited to computing `language_name`. The full multi-language list is still passed to STT downstream (`pipeline.py`), so multilingual understanding is unchanged.

### Testing
- Playground test call on a template with a list-valued `stt_language` now succeeds (previously 500).
- Scalar `stt_language` is unchanged (the guard is a no-op).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of speech-to-text language overrides so list-based values are safely normalized before lookup.
  * Prevented issues where language settings could be processed as multiple values instead of a single selected option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->