### PR TITLE
refactor: drop the KB query-embedding Redis cache

### DIFF
--- a/app/core/config/dynamic.py
+++ b/app/core/config/dynamic.py
@@ -654,8 +654,3 @@ async def KB_MERCHANT_MAX_CHUNKS() -> int:
     per reseller on a 15GB instance); the per-KB cap above only binds once
     this one has been raised for a reseller."""
     return await get_config("KB_MERCHANT_MAX_CHUNKS", 20000, int)
-
-
-async def KB_EMBED_CACHE_TTL_SECONDS() -> int:
-    """TTL for the Redis query-embedding cache on the retrieval hot path."""
-    return await get_config("KB_EMBED_CACHE_TTL_SECONDS", 3600, int)

--- a/app/services/embeddings/__init__.py
+++ b/app/services/embeddings/__init__.py
@@ -29,7 +29,7 @@ def get_embedding_provider(config: EmbeddingConfig) -> EmbeddingProvider:
     """Resolve (and cache) an EmbeddingProvider from a KB's embedding_config.
 
     The two call sites are the seams where providers plug in: ingestion's
-    embed loop and retrieval's ``_embed_query_cached``. Instances are cached
+    embed loop and retrieval's ``_embed_query``. Instances are cached
     per ``provider:model`` — they're stateless besides the shared HTTP
     session, so one per process is enough. Unknown providers raise
     immediately with the list of valid keys.

--- a/app/services/knowledge_base/retrieval.py
+++ b/app/services/knowledge_base/retrieval.py
@@ -1,7 +1,7 @@
 """
 Knowledge base retrieval service -- the latency-critical path.
 
-``retrieve()`` = query embedding (Redis-cached) + one hybrid SQL round trip
+``retrieve()`` = query embedding (one provider API call) + one hybrid SQL round trip
 (vector KNN + full-text + trigram, RRF-fused). Callers on the voice hot path
 wrap it in ``asyncio.wait_for`` and fail open. Full-KB text / token totals
 (for full-injection mode) are cached in Redis under version-stamped keys;
@@ -26,7 +26,6 @@ import json
 import time
 from typing import List, Optional, Tuple
 
-from app.core.config.dynamic import KB_EMBED_CACHE_TTL_SECONDS
 from app.core.logger import logger
 from app.database.accessor.breeze_buddy.knowledge_base import (
     get_kb_full_text_rows,
@@ -43,8 +42,7 @@ _TOKEN_TOTAL_CACHE_TTL_SECONDS = 3600
 
 
 def _normalize_query(query: str) -> str:
-    """Collapse whitespace so trivially-different phrasings share one
-    embedding cache entry (and one consistent FTS/trigram input)."""
+    """Collapse whitespace for a consistent FTS/trigram input."""
     return " ".join(query.split()).strip()
 
 
@@ -84,35 +82,18 @@ async def _resolve_embedding_config(kb_ids: List[str]) -> EmbeddingConfig:
     return kb.embedding_config
 
 
-async def _embed_query_cached(query: str, config: EmbeddingConfig) -> List[float]:
-    """Embed the query with a Redis cache in front (dodges the fat p95 tail
-    of embedding APIs for repeated phrasings)."""
-    normalized = _normalize_query(query)
-    cache_key = (
-        f"kb:emb:{config.provider}:{config.model}:"
-        f"{hashlib.sha1(normalized.lower().encode()).hexdigest()}"
+async def _embed_query(query: str, config: EmbeddingConfig) -> List[float]:
+    """Embed the retrieval query via the provider — one API call per
+    retrieval, no caching. A query-embedding Redis cache existed here and
+    was removed on purpose: real conversation queries are near-unique
+    (multi-turn joins), so the hit rate never justified the memory and
+    complexity. If repeat-heavy traffic ever shows up in logs, prefer a
+    semantic result cache over resurrecting exact-text caching.
+    """
+    vectors = await get_embedding_provider(config).embed(
+        [_normalize_query(query)], input_type="query"
     )
-
-    redis = None
-    try:
-        redis = await get_redis_service()
-        cached = await redis.get(cache_key)
-        if cached:
-            return json.loads(cached)
-    except Exception:
-        pass  # cache is best-effort
-
-    provider = get_embedding_provider(config)
-    vectors = await provider.embed([normalized], input_type="query")
-    vector = vectors[0]
-
-    if redis is not None:
-        try:
-            ttl = await KB_EMBED_CACHE_TTL_SECONDS()
-            await redis.setex(cache_key, json.dumps(vector), ttl)
-        except Exception:
-            pass
-    return vector
+    return vectors[0]
 
 
 async def retrieve(
@@ -134,7 +115,7 @@ async def retrieve(
 
     started = time.perf_counter()
     config = await _resolve_embedding_config(kb_ids)
-    query_embedding = await _embed_query_cached(normalized, config)
+    query_embedding = await _embed_query(normalized, config)
     embed_ms = (time.perf_counter() - started) * 1000
 
     chunks = await hybrid_search_chunks(


### PR DESCRIPTION
## What

Removes the Redis query-embedding cache from `retrieve()`. Hit-rate analysis: auto_retrieve builds its retrieval query as `previous user turn + "\n" + current utterance` from turn 2 onward, so production queries are near-unique per conversation — the exact-text cache almost never hit while costing ~16KB Redis per entry (768 floats as JSON) for an hour each, on the same Redis that carries locks and sessions.

- `retrieve()` now embeds directly via the provider (one API call per retrieval — which is what effectively happened anyway)
- `KB_EMBED_CACHE_TTL_SECONDS` dynamic-config knob deleted; no `kb:emb*` keys are ever written
- **Unchanged**: the version-keyed full-KB-text and token-total caches (one entry per KB, not per query — load-bearing for full_injection call-boot latency)
- A comment in `_embed_query` records the removal rationale; if repeat-heavy traffic ever appears in logs, the right reintroduction is a semantic result cache, not exact-text matching

## Verification

Live on a local stack (PG16 + pgvector 0.8.4, real OpenAI embeddings): repeated identical `/query` calls both hit the embed API (no fast path), zero `kb:emb*` keys in Redis after the calls, chunk IDs + RRF scores identical run-to-run. `pyrefly check` 0 errors; module imports clean.

Raised standalone off `release` so it can merge ahead of the Google Sheets PR (#876); rebasing #876 afterwards collapses its copy of these changes to an empty diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Retrieval now uses a direct embedding lookup during search, which simplifies the query path and removes a previous cached step.
  * The embedding cache TTL is no longer configurable through dynamic settings; caching behavior now follows the built-in default handling.
  * Updated search-related documentation to reflect the current retrieval flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->