### PR TITLE
feat: azure_openai embedding provider — platform default, in-region query embeddings

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,6 +30,12 @@ BREEZE_BUDDY_DAILY_API_URL=  # Optional: Falls back to DAILY_API_URL
 AZURE_OPENAI_API_KEY=
 AZURE_OPENAI_ENDPOINT=
 AZURE_OPENAI_MODEL="gpt-4o-automatic"
+# KB embeddings (azure_openai is the default provider for new knowledge bases).
+# Separate keys from the LLM's AZURE_OPENAI_* above ON PURPOSE — rotating or
+# repointing one must never silently move the other. Both are dynamic config:
+# Redis override first, then these env values.
+KB_AZURE_OPENAI_ENDPOINT=
+KB_AZURE_OPENAI_API_KEY=
 GOOGLE_CREDENTIALS_JSON=
 # AIC (AI Coustics) Audio Filter Configuration
 ENABLE_AIC_FILTER=true

--- a/app/core/config/dynamic.py
+++ b/app/core/config/dynamic.py
@@ -603,6 +603,22 @@ async def AZURE_OPENAI_REALTIME_ENDPOINT() -> str:
 
 
 # --- Knowledge Base (RAG) ---
+async def KB_AZURE_OPENAI_ENDPOINT() -> str:
+    """Azure endpoint for the ``azure_openai`` EMBEDDING provider (the
+    default for new KBs). Deliberately separate from the LLM's static
+    AZURE_OPENAI_ENDPOINT so repointing or rotating one never silently
+    moves the other; Redis-settable at runtime, so the embed endpoint can
+    be changed without a deploy."""
+    return await get_config("KB_AZURE_OPENAI_ENDPOINT", "", str)
+
+
+async def KB_AZURE_OPENAI_API_KEY() -> str:
+    """API key for the ``azure_openai`` embedding provider — kept separate
+    from the LLM's AZURE_OPENAI_API_KEY on purpose (see
+    KB_AZURE_OPENAI_ENDPOINT); Redis-settable for no-deploy rotation."""
+    return await get_config("KB_AZURE_OPENAI_API_KEY", "", str)
+
+
 async def KB_INGEST_BATCH_SIZE() -> int:
     """Max documents the ingestion worker claims per tick/kick."""
     return await get_config("KB_INGEST_BATCH_SIZE", 5, int)

--- a/app/schemas/breeze_buddy/knowledge_base.py
+++ b/app/schemas/breeze_buddy/knowledge_base.py
@@ -32,11 +32,17 @@ class EmbeddingConfig(BaseModel):
 
     All providers are normalized to 768 dimensions (Matryoshka truncation +
     L2 renorm) so a single ``halfvec(768)`` column/index serves every KB.
+
+    Defaults to the in-region Azure deployment — everything goes through
+    Azure unless a KB explicitly opts into another provider. The config is
+    persisted on the row at creation, so changing these defaults never
+    retroactively reinterprets existing KBs.
     """
 
-    provider: str = Field("openai", description="Embedding provider key.")
+    provider: str = Field("azure_openai", description="Embedding provider key.")
     model: str = Field(
-        "text-embedding-3-small", description="Provider model identifier."
+        "text-embedding-3-large",
+        description="Provider model identifier (Azure: the deployment name).",
     )
     dimensions: int = Field(768, description="Stored vector dimensions (fixed).")
 

--- a/app/services/embeddings/__init__.py
+++ b/app/services/embeddings/__init__.py
@@ -9,6 +9,9 @@ entry -- retrieval and ingestion are provider-agnostic.
 from typing import Callable, Dict
 
 from app.schemas.breeze_buddy.knowledge_base import EmbeddingConfig
+from app.services.embeddings.azure_openai_provider import (
+    AzureOpenAIEmbeddingProvider,
+)
 from app.services.embeddings.base import (
     TARGET_DIMENSIONS,
     EmbeddingProvider,
@@ -18,6 +21,10 @@ from app.services.embeddings.openai_provider import OpenAIEmbeddingProvider
 
 _PROVIDER_REGISTRY: Dict[str, Callable[[str], EmbeddingProvider]] = {
     "openai": lambda model: OpenAIEmbeddingProvider(model=model),
+    # DEFAULT (EmbeddingConfig defaults here): in-region Azure deployment of
+    # the same models; ``model`` is the Azure deployment name. See the
+    # provider module for the latency rationale.
+    "azure_openai": lambda model: AzureOpenAIEmbeddingProvider(model=model),
 }
 
 # Instances are stateless besides the shared HTTP session; cache per

--- a/app/services/embeddings/azure_openai_provider.py
+++ b/app/services/embeddings/azure_openai_provider.py
@@ -1,0 +1,120 @@
+"""
+Azure OpenAI embeddings provider — the platform default (EmbeddingConfig
+defaults here; other providers are explicit opt-in per KB).
+
+Same wire format as the OpenAI provider but served from an in-region Azure
+deployment, which is what keeps query-embedding traffic inside the voice
+budget: retrieval must finish within ``retrieval_timeout_secs`` (0.4s
+default), and a Standard deployment in Azure South India answers in
+~70-90ms warm vs 400ms+ cross-region.
+
+Credentials come from the ``KB_AZURE_OPENAI_ENDPOINT`` /
+``KB_AZURE_OPENAI_API_KEY`` dynamic-config keys (Redis override → env),
+resolved on every call so the key can be rotated at runtime without a
+deploy. They are deliberately NOT the LLM's static ``AZURE_OPENAI_*``
+vars — embeddings and LLM must be repointable/rotatable independently.
+
+``model`` on the KB's ``embedding_config`` is the Azure DEPLOYMENT name,
+not an OpenAI model id (they coincide when the deployment is named after
+its model, e.g. ``text-embedding-3-large``). Third-generation embedding
+deployments support the ``dimensions`` parameter, so truncation to 768
+happens server-side like the OpenAI provider.
+"""
+
+from typing import List, Optional
+
+import aiohttp
+
+from app.core.config.dynamic import (
+    KB_AZURE_OPENAI_API_KEY,
+    KB_AZURE_OPENAI_ENDPOINT,
+)
+from app.core.logger import logger
+from app.core.transport.http_client import create_aiohttp_session
+from app.services.embeddings.base import (
+    TARGET_DIMENSIONS,
+    EmbeddingProvider,
+    InputType,
+    truncate_and_normalize,
+)
+
+_API_VERSION = "2024-10-21"
+
+# One lazily-created session shared across calls (connection reuse matters on
+# the query hot path). aiohttp sessions are cheap to hold and die with the
+# process.
+_session: Optional[aiohttp.ClientSession] = None
+
+
+def _get_session() -> aiohttp.ClientSession:
+    """Lazily create/reuse the module's shared aiohttp session.
+
+    Re-created if closed. Keeping one session gives TLS/connection reuse,
+    which matters for the per-turn query embedding on the voice hot path.
+    """
+    global _session
+    if _session is None or _session.closed:
+        _session = create_aiohttp_session(
+            timeout=aiohttp.ClientTimeout(total=30, connect=5)
+        )
+    return _session
+
+
+class AzureOpenAIEmbeddingProvider(EmbeddingProvider):
+    provider_key = "azure_openai"
+
+    def __init__(self, model: str = "text-embedding-3-large"):
+        """``model`` is the Azure deployment name. Endpoint/key are dynamic
+        config, so (unlike the OpenAI provider) missing credentials surface
+        on the first ``embed`` call, not at construction.
+
+        Constructed only via the registry factory in
+        ``app/services/embeddings/__init__.py`` (one instance per model).
+        """
+        self.model = model
+
+    async def embed(
+        self, texts: List[str], input_type: InputType = "document"
+    ) -> List[List[float]]:
+        """Embed a batch of texts into 768-dim unit vectors.
+
+        Called from ingestion (document chunks, batched) and retrieval
+        (single query string). ``input_type`` is ignored — OpenAI models
+        don't distinguish query vs document embeddings. Raises ValueError
+        when the KB_AZURE_OPENAI_* config is missing and RuntimeError on
+        non-200; callers own retry/fail-open policy.
+        """
+        if not texts:
+            return []
+
+        endpoint = await KB_AZURE_OPENAI_ENDPOINT()
+        api_key = await KB_AZURE_OPENAI_API_KEY()
+        if not endpoint or not api_key:
+            raise ValueError(
+                "KB_AZURE_OPENAI_ENDPOINT / KB_AZURE_OPENAI_API_KEY are not "
+                "configured; cannot use the azure_openai embedding provider"
+            )
+
+        url = (
+            f"{endpoint.rstrip('/')}/openai/deployments/"
+            f"{self.model}/embeddings?api-version={_API_VERSION}"
+        )
+        payload = {"input": texts, "dimensions": TARGET_DIMENSIONS}
+        headers = {"api-key": api_key}
+
+        async with _get_session().post(url, json=payload, headers=headers) as response:
+            if response.status != 200:
+                body = await response.text()
+                logger.error(
+                    f"Azure OpenAI embeddings request failed "
+                    f"({response.status}): {body[:500]}"
+                )
+                raise RuntimeError(
+                    f"Azure OpenAI embeddings request failed with status "
+                    f"{response.status}"
+                )
+            data = await response.json()
+
+        # The API returns items with an ``index`` field; order defensively.
+        items = sorted(data["data"], key=lambda item: item["index"])
+        return [truncate_and_normalize(item["embedding"]) for item in items]

--- a/app/services/embeddings/openai_provider.py
+++ b/app/services/embeddings/openai_provider.py
@@ -1,5 +1,6 @@
 """
-OpenAI embeddings provider (default).
+OpenAI (direct) embeddings provider — explicit opt-in; the platform default
+is the in-region ``azure_openai`` provider.
 
 Calls the REST endpoint directly through the shared aiohttp factory (proxy
 aware) -- no SDK dependency. ``text-embedding-3-small`` supports the


### PR DESCRIPTION
## What

1. Adds an **`azure_openai`** provider to the KB embeddings registry (`app/services/embeddings/`) — one new module + one registry entry.
2. **Makes it the default**: `EmbeddingConfig` now defaults to `azure_openai` / `text-embedding-3-large`. Everything goes through Azure unless a KB explicitly opts into another provider (`provider: "openai"` still works, unchanged).
3. Credentials are **new dynamic-config keys, separate from the LLM's** `AZURE_OPENAI_*`: `KB_AZURE_OPENAI_ENDPOINT` + `KB_AZURE_OPENAI_API_KEY` in `core/config/dynamic.py` (Redis override → env → default), resolved per call — the embed key **rotates at runtime without a deploy**, and repointing embeddings never silently moves the LLM (or vice versa).

- `embedding_config.model` for Azure = the **deployment name** (currently `text-embedding-3-large`, Standard/South India).
- Third-gen deployments accept `dimensions: 768` server-side → same `halfvec(768)` column/index as every provider.
- Shared aiohttp session for hot-path connection reuse; missing config fails fast with a clear error on first `embed` call.

## Why default = Azure

Measured from India, per-turn query embedding via OpenAI US takes **428–1403ms (median ~550ms)** — every `auto_retrieve` voice turn blows the 0.4s retrieval budget and fails open ungrounded. Azure has **no `text-embedding-3-small` Standard (regional) deployment in any India region**; **`text-embedding-3-large` is Standard in South India** ([region matrix](https://learn.microsoft.com/en-us/azure/foundry/foundry-models/concepts/models-sold-directly-by-azure-region-availability)).

Live measurements (`x-ms-region: South India` verified per response):

| Path | Latency |
|---|---|
| Query embed, warm — **including the 2 dynamic-config lookups** | **~70–91ms** |
| Query embed, cold (incl. TLS) | ~135ms |
| Ingestion batch of 20 chunks | ~320ms |
| Previous: OpenAI US from India | 428–1403ms, median ~550ms |

Full hybrid retrieval (embed + 4–8ms SQL) lands at **~80–100ms/turn**, comfortably inside the voice budget. 3-large is also a quality upgrade over 3-small (MTEB 64.6 vs 62.3, MIRACL 54.9 vs 44.0 — big multilingual win).

## Safety of the default flip

- `embedding_config` is **persisted on the KB row at creation** → existing KBs keep `openai`/3-small and are untouched.
- Loom does not send `embedding_config` on create → new KBs pick up the Azure default from the backend.
- Environments without `KB_AZURE_OPENAI_*` set: deploys dark; a defaulted KB's first embed fails fast with "KB_AZURE_OPENAI_ENDPOINT / KB_AZURE_OPENAI_API_KEY are not configured". **Set both (env or Redis) before first KB use in prod.**

## Migration note

Vectors from different models are not comparable: flipping an existing KB `openai/3-small` → `azure_openai/3-large` requires re-ingesting its documents first. `embedding_config` is per-KB and query embedding follows the KB's own config, so migration is per-KB atomic; KBs attached to the same template flip together.

## Testing

- Live through the real registry path: bare `EmbeddingConfig()` → `AzureOpenAIEmbeddingProvider` → 768-dim unit vectors (query + batch); dynamic-config resolution verified via env fallback (Redis absent) and blank-config fail-fast; explicit `openai` config still resolves independently of the Azure keys.
- `black` / `isort` / `autoflake` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)