### PR TITLE
refactor: template resolution is id-only — remove name lookup + shared-template fallback

### DIFF
--- a/app/ai/voice/agents/breeze_buddy/agent/flow.py
+++ b/app/ai/voice/agents/breeze_buddy/agent/flow.py
@@ -41,10 +41,8 @@ async def load_template_config(
 
     template, template_vars = await flow_loader.load_template(
         reseller_id=lead.reseller_id,
-        template=lead.template,
-        merchant_id=lead.merchant_id if lead else None,
-        call_payload=lead.payload,
         template_id=lead.template_id,
+        call_payload=lead.payload,
     )
 
     # Apply overrides and re-render if playground mode

--- a/app/ai/voice/agents/breeze_buddy/dispatch/worker.py
+++ b/app/ai/voice/agents/breeze_buddy/dispatch/worker.py
@@ -77,7 +77,7 @@ from app.database.accessor import (
     acquire_lock_on_lead_by_id,
     defer_lead_next_attempt_and_release_lock,
     get_lead_by_id,
-    get_template_by_id_with_fallback,
+    get_template_by_id,
     is_number_blacklisted,
     release_lock_on_lead_by_id,
     update_lead_call_completion_details,
@@ -324,11 +324,12 @@ class Worker:
                 lock_released = await self._defer_and_release(locked.id, 300)
                 return
 
-            template = await get_template_by_id_with_fallback(
-                template_id=locked.template_id,
-                reseller_id=config.reseller_id,
-                merchant_id=config.merchant_id,
-                name=config.template,
+            # id-only resolution: leads always carry the template_id they
+            # resolved to at push time; name fallback was removed.
+            template = (
+                await get_template_by_id(locked.template_id)
+                if locked.template_id
+                else None
             )
 
             if not await _run_pre_checks_for_lead(config, locked, template, session):

--- a/app/ai/voice/agents/breeze_buddy/handlers/internal/agent_transfer.py
+++ b/app/ai/voice/agents/breeze_buddy/handlers/internal/agent_transfer.py
@@ -74,10 +74,8 @@ async def connect_to_agent(
         loader = FlowConfigLoader()
         template, template_vars = await loader.load_template(
             reseller_id=bot.lead.reseller_id,
-            template=bot.lead.template,
-            merchant_id=bot.lead.merchant_id,
-            call_payload=bot.lead.payload,
             template_id=target_template_id,
+            call_payload=bot.lead.payload,
         )
         validate_template_compat(template)
         if template.flow.get("mode") == FlowMode.IVR.value:

--- a/app/ai/voice/agents/breeze_buddy/template/loader.py
+++ b/app/ai/voice/agents/breeze_buddy/template/loader.py
@@ -19,7 +19,7 @@ from app.database.accessor.breeze_buddy.credentials import (
     get_credentials_as_template_vars,
 )
 from app.database.accessor.breeze_buddy.template import (
-    get_template_by_id_with_fallback,
+    get_template_by_id,
 )
 
 
@@ -28,29 +28,20 @@ class FlowConfigLoader:
 
     async def _load_template_from_db(
         self,
-        reseller_id: str,
-        name: str = "order-confirmation",
-        merchant_id: Optional[str] = None,
-        template_id: Optional[str] = None,
+        template_id: Optional[str],
     ) -> Optional[TemplateModel]:
         """
-        Load complete template from database.
-
-        Args:
-            reseller_id: Reseller identifier
-            name: Template name (defaults to "order-confirmation")
-            merchant_id: Optional merchant-specific identifier
-            template_id: Optional template UUID (preferred over name-based lookup)
+        Load complete template from database by id (id-only — name-based
+        resolution was removed).
 
         Returns:
             TemplateModel if found, None otherwise
         """
-        template = await get_template_by_id_with_fallback(
-            template_id=template_id,
-            reseller_id=reseller_id,
-            merchant_id=merchant_id,
-            name=name,
-        )
+        if not template_id:
+            logger.error("No template_id provided — cannot load template")
+            return None
+
+        template = await get_template_by_id(template_id)
 
         if template:
             nodes_count = len(template.flow.get("nodes", []))
@@ -60,12 +51,7 @@ class FlowConfigLoader:
                 nodes_count,
             )
         else:
-            logger.warning(
-                "No template found for reseller=%s, name=%s (template_id=%s)",
-                reseller_id,
-                name,
-                template_id,
-            )
+            logger.error("No template found for template_id=%s", template_id)
 
         return template
 
@@ -118,20 +104,17 @@ class FlowConfigLoader:
     async def load_template(
         self,
         reseller_id: str,
-        template: str,
-        merchant_id: Optional[str] = None,
+        template_id: Optional[str],
         call_payload: Optional[Dict[str, str]] = None,
-        template_id: Optional[str] = None,
     ) -> Tuple[TemplateModel, Dict[str, str]]:
         """
-        Load template and render task messages with variables.
+        Load template by id and render task messages with variables.
 
         Args:
-            reseller_id: Reseller identifier
-            template: Template name (used as fallback if template_id not provided)
-            merchant_id: Optional merchant-specific identifier
+            reseller_id: Reseller identifier (used for credential loading)
+            template_id: Template UUID (the ONLY resolution key — name-based
+                lookup was removed)
             call_payload: Optional payload variables
-            template_id: Optional template UUID (preferred over name-based lookup)
 
         Returns:
             TemplateModel with rendered task messages, and dictionary of template variables
@@ -141,13 +124,11 @@ class FlowConfigLoader:
         """
 
         # Load template from database
-        template_obj = await self._load_template_from_db(
-            reseller_id, template, merchant_id, template_id=template_id
-        )
+        template_obj = await self._load_template_from_db(template_id)
 
         if not template_obj:
             raise ValueError(
-                f"No template found for reseller={reseller_id}, template={template}"
+                f"No template found for reseller={reseller_id}, template_id={template_id}"
             )
 
         template_vars = {}

--- a/app/ai/voice/agents/breeze_buddy/types/models.py
+++ b/app/ai/voice/agents/breeze_buddy/types/models.py
@@ -2,7 +2,7 @@ from io import BytesIO
 from typing import Any, Dict, List, NamedTuple, Optional
 from uuid import UUID
 
-from pydantic import BaseModel, field_validator, model_validator
+from pydantic import BaseModel, field_validator
 
 from app.schemas.breeze_buddy.core import ExecutionMode
 
@@ -13,19 +13,21 @@ class CallRecordingResult(NamedTuple):
 
 
 class PushLeadRequest(BaseModel):
+    """Lead push request. Templates are identified by id ONLY — name-based
+    resolution was removed; a legacy ``template`` field in the body is
+    ignored (pydantic drops unknown fields)."""
+
     request_id: str
     payload: Dict[str, Any]
-    template: Optional[str] = None
-    template_id: Optional[str] = None
+    template_id: str
 
     @field_validator("template_id")
     @classmethod
-    def validate_template_id_format(cls, v: Optional[str]) -> Optional[str]:
-        if v is not None:
-            try:
-                UUID(v)
-            except ValueError as e:
-                raise ValueError("template_id must be a valid UUID") from e
+    def validate_template_id_format(cls, v: str) -> str:
+        try:
+            UUID(v)
+        except ValueError as e:
+            raise ValueError("template_id must be a valid UUID") from e
         return v
 
     reseller_id: str
@@ -42,12 +44,6 @@ class PushLeadRequest(BaseModel):
     flow_override: Optional[Dict[str, Any]] = (
         None  # Override template flow JSON (playground only)
     )
-
-    @model_validator(mode="after")
-    def check_template_identifier(self) -> "PushLeadRequest":
-        if not self.template and not self.template_id:
-            raise ValueError("Either 'template' or 'template_id' must be provided")
-        return self
 
 
 class LoginRequest(BaseModel):

--- a/app/api/routers/breeze_buddy/demo/handlers.py
+++ b/app/api/routers/breeze_buddy/demo/handlers.py
@@ -17,7 +17,7 @@ from app.database.accessor import create_lead_call_tracker, handle_lead_abort
 from app.database.accessor.breeze_buddy.lead_call_tracker import (
     update_lead_call_completion_details,
 )
-from app.database.accessor.breeze_buddy.template import get_template_by_merchant
+from app.database.accessor.breeze_buddy.template import get_template_in_scope
 from app.schemas import ExecutionMode, LeadCallStatus
 from app.services.redis import is_redis_configured
 from app.services.redis.client import get_redis_service
@@ -198,7 +198,9 @@ async def breeze_buddy_demo_connect_handler(
     await _rate_limit(client_ip)
 
     # Ensure template exists for this merchant/shop before proceeding
-    template = await get_template_by_merchant(
+    # Fixed internal demo templates: exact-scope lookup (no fallback);
+    # runtime template resolution elsewhere is id-only.
+    template = await get_template_in_scope(
         reseller_id=DEMO_RESELLER_ID,
         merchant_id=DEMO_MERCHANT_ID,
         name=body.agent,

--- a/app/api/routers/breeze_buddy/leads/handlers.py
+++ b/app/api/routers/breeze_buddy/leads/handlers.py
@@ -57,7 +57,6 @@ from app.database.accessor import (
     get_leads_by_request_id,
     get_outbound_number_by_id,
     get_template_by_id,
-    get_template_by_merchant,
     handle_lead_abort,
     is_number_blacklisted,
 )
@@ -195,66 +194,61 @@ async def push_lead_handler(req: PushLeadRequest, current_user: UserInfo) -> Dic
 
     logger.info(
         f"User {current_user.username} (role: {current_user.role}) pushing lead "
-        f"for reseller: {req.reseller_id}, template: {req.template}, template_id: {req.template_id}"
+        f"for reseller: {req.reseller_id}, template_id: {req.template_id}"
     )
 
     try:
-        # Fetch template: prefer template_id (direct UUID lookup), fall back to name-based
-        template = None
-        if req.template_id:
-            template = await get_template_by_id(req.template_id)
-            if template:
-                # Enforce that the template belongs to the requested reseller/merchant
-                if template.reseller_id != req.reseller_id:
-                    logger.warning(
-                        "Template ID %s does not belong to reseller %s (found reseller_id=%s)",
-                        req.template_id,
-                        req.reseller_id,
-                        template.reseller_id,
-                    )
-                    raise HTTPException(
-                        status_code=status.HTTP_404_NOT_FOUND,
-                        detail=f"Template not found for reseller: {req.reseller_id} "
-                        f"(template_id={req.template_id}, template={req.template})",
-                    )
-                if (
-                    req.merchant_id is not None
-                    and template.merchant_id is not None
-                    and template.merchant_id != req.merchant_id
-                ):
-                    logger.warning(
-                        "Template ID %s does not belong to merchant %s "
-                        "(found merchant_id=%s, reseller_id=%s)",
-                        req.template_id,
-                        req.merchant_id,
-                        template.merchant_id,
-                        template.reseller_id,
-                    )
-                    raise HTTPException(
-                        status_code=status.HTTP_404_NOT_FOUND,
-                        detail=f"Template not found for reseller: {req.reseller_id} "
-                        f"(template_id={req.template_id}, template={req.template})",
-                    )
-                # If the template is merchant-specific but request omits merchant_id,
-                # inherit the template's merchant_id so downstream config lookup and
-                # lead creation are consistent with the resolved template's scope.
-                if template.merchant_id is not None and req.merchant_id is None:
-                    logger.info(
-                        "Inheriting merchant_id=%s from template %s (not provided in request)",
-                        template.merchant_id,
-                        req.template_id,
-                    )
-                    req = req.model_copy(update={"merchant_id": template.merchant_id})
-        if not template and req.template:
-            template = await get_template_by_merchant(
-                req.reseller_id, req.merchant_id, req.template
-            )
+        # Templates resolve by id ONLY — name-based resolution (and the
+        # merchant→reseller shared-template fallback) has been removed.
+        template = await get_template_by_id(req.template_id)
+        if template:
+            # Enforce that the template belongs to the requested reseller/merchant
+            if template.reseller_id != req.reseller_id:
+                logger.warning(
+                    "Template ID %s does not belong to reseller %s (found reseller_id=%s)",
+                    req.template_id,
+                    req.reseller_id,
+                    template.reseller_id,
+                )
+                raise HTTPException(
+                    status_code=status.HTTP_404_NOT_FOUND,
+                    detail=f"Template not found for reseller: {req.reseller_id} "
+                    f"(template_id={req.template_id})",
+                )
+            if (
+                req.merchant_id is not None
+                and template.merchant_id is not None
+                and template.merchant_id != req.merchant_id
+            ):
+                logger.warning(
+                    "Template ID %s does not belong to merchant %s "
+                    "(found merchant_id=%s, reseller_id=%s)",
+                    req.template_id,
+                    req.merchant_id,
+                    template.merchant_id,
+                    template.reseller_id,
+                )
+                raise HTTPException(
+                    status_code=status.HTTP_404_NOT_FOUND,
+                    detail=f"Template not found for reseller: {req.reseller_id} "
+                    f"(template_id={req.template_id})",
+                )
+            # If the template is merchant-specific but request omits merchant_id,
+            # inherit the template's merchant_id so downstream config lookup and
+            # lead creation are consistent with the resolved template's scope.
+            if template.merchant_id is not None and req.merchant_id is None:
+                logger.info(
+                    "Inheriting merchant_id=%s from template %s (not provided in request)",
+                    template.merchant_id,
+                    req.template_id,
+                )
+                req = req.model_copy(update={"merchant_id": template.merchant_id})
 
         if not template:
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,
                 detail=f"Template not found for reseller: {req.reseller_id} "
-                f"(template_id={req.template_id}, template={req.template})",
+                f"(template_id={req.template_id})",
             )
 
         # Check if customer phone number is blacklisted

--- a/app/api/routers/breeze_buddy/telephony/answer/handlers.py
+++ b/app/api/routers/breeze_buddy/telephony/answer/handlers.py
@@ -73,7 +73,7 @@ from app.database.accessor.breeze_buddy.outbound_number import (
 )
 from app.database.accessor.breeze_buddy.template import (
     get_all_templates_by_outbound_number_id,
-    get_template_by_id_with_fallback,
+    get_template_by_id,
 )
 from app.schemas import CallDirection, InboundBlockAction, LeadCallStatus
 from app.services.redis.client import get_redis_service
@@ -125,11 +125,10 @@ async def resolve_call_templates(
         # Outbound call - look up template using template_id from lead (preferred) or fall back to name
         logger.info(f"[Answer] Outbound call detected, lead: {lead.id}")
 
-        template = await get_template_by_id_with_fallback(
-            template_id=lead.template_id,
-            reseller_id=lead.reseller_id,
-            merchant_id=lead.merchant_id,
-            name=lead.template,
+        # id-only resolution: the lead stores the template_id it resolved
+        # to at push time; name fallback was removed.
+        template = (
+            await get_template_by_id(lead.template_id) if lead.template_id else None
         )
         if not template:
             logger.error(f"[Answer] Template not found for lead: {lead.id}")

--- a/app/api/routers/breeze_buddy/templates/handlers.py
+++ b/app/api/routers/breeze_buddy/templates/handlers.py
@@ -21,7 +21,7 @@ from app.ai.voice.agents.breeze_buddy.utils.secrets import (
     merge_secrets,
 )
 from app.core.logger import logger
-from app.database.accessor import get_outbound_number_by_id, get_template_by_merchant
+from app.database.accessor import get_outbound_number_by_id, get_template_in_scope
 from app.database.accessor.breeze_buddy.template import (
     check_template_usage,
     create_template,
@@ -83,11 +83,10 @@ async def create_template_handler(
                 raise ValueError("nodes must be specified in flow structure")
 
         # Check if template already exists
-        existing = await get_template_by_merchant(
+        existing = await get_template_in_scope(
             template_data.reseller_id,
             template_data.merchant_id,
             template_data.name,
-            should_prioritize_merchant_specific=False,
         )
 
         if existing:
@@ -171,57 +170,6 @@ async def create_template_handler(
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=f"Error creating template: {str(e)}",
-        )
-
-
-async def get_template_handler(
-    reseller_id: str,
-    merchant_id: Optional[str],
-    name: Optional[str],
-    current_user: UserInfo,
-):
-    """
-    Get template(s) by reseller, shop, and name.
-
-    Args:
-        reseller_id: Reseller ID
-        merchant_id: Optional Merchant ID
-        name: Optional template name
-        current_user: Current authenticated user
-
-    Returns:
-        Template object or list of templates
-    """
-    logger.info(
-        f"User {current_user.username} (role: {current_user.role}) requesting template "
-        f"for reseller: {reseller_id}, shop: {merchant_id}, name: {name}"
-    )
-
-    try:
-        template = await get_template_by_merchant(
-            reseller_id=reseller_id,
-            merchant_id=merchant_id,
-            name=name,
-        )
-
-        if template:
-            logger.info(f"Template found: {template.id}")
-            return mask_template_secrets(template)
-        else:
-            logger.info(
-                f"No template found for reseller: {reseller_id}, "
-                f"merchant_id: {merchant_id}, name: {name}"
-            )
-            raise HTTPException(
-                status_code=status.HTTP_404_NOT_FOUND,
-                detail=f"Template '{name}' not found for reseller: {reseller_id}",
-            )
-
-    except Exception as e:
-        logger.error(f"Error getting template: {e}", exc_info=True)
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Error getting template: {str(e)}",
         )
 
 
@@ -424,11 +372,10 @@ async def replace_template_handler(
             or template_data.name != existing_template.name
         )
         if identity_changed:
-            conflicting = await get_template_by_merchant(
+            conflicting = await get_template_in_scope(
                 reseller_id,
                 template_data.merchant_id,
                 template_data.name,
-                should_prioritize_merchant_specific=False,
             )
             if conflicting and str(conflicting.id) != str(template_id):
                 raise HTTPException(

--- a/app/api/routers/breeze_buddy/webhooks/woocommerce/cart.py
+++ b/app/api/routers/breeze_buddy/webhooks/woocommerce/cart.py
@@ -8,7 +8,7 @@ aliases are checked — adjust the lookups here if your plugin nests data
 differently.
 """
 
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Dict, Tuple
 
 from app.core.logger import logger
 
@@ -113,8 +113,7 @@ async def process_abandoned_checkout(
     merchant_id: str,
     reseller_id: str,
     shop_name: str,
-    template: Optional[str],
-    template_id: Optional[str],
+    template_id: str,
 ) -> Dict[str, Any]:
     """Handle an abandoned-checkout webhook: always call (no payment yet)."""
     checkout_id = order.get("id") or first(
@@ -131,7 +130,6 @@ async def process_abandoned_checkout(
         payload,
         merchant_id,
         reseller_id,
-        template,
         template_id,
         "abandoned checkout",
     )

--- a/app/api/routers/breeze_buddy/webhooks/woocommerce/order.py
+++ b/app/api/routers/breeze_buddy/webhooks/woocommerce/order.py
@@ -5,7 +5,7 @@ Decides which placed orders push a call lead (per the ?all_orders= preference)
 and maps the WooCommerce order into the lead payload.
 """
 
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Dict, Tuple
 
 from app.core.logger import logger
 
@@ -105,8 +105,7 @@ async def process_order_confirmation(
     merchant_id: str,
     reseller_id: str,
     shop_name: str,
-    template: Optional[str],
-    template_id: Optional[str],
+    template_id: str,
     all_orders: bool,
 ) -> Dict[str, Any]:
     """Handle a placed-order webhook: push a lead per the ?all_orders= preference."""
@@ -146,7 +145,6 @@ async def process_order_confirmation(
         payload,
         merchant_id,
         reseller_id,
-        template,
         template_id,
         reason,
     )

--- a/app/api/routers/breeze_buddy/webhooks/woocommerce/services.py
+++ b/app/api/routers/breeze_buddy/webhooks/woocommerce/services.py
@@ -41,13 +41,12 @@ async def handle_woocommerce(
 ) -> Dict[str, Any]:
     """Verify + process a WooCommerce webhook, dispatching on topic.
 
-    Reads the ``template`` / ``template_id`` / ``all_orders`` query params off
+    Reads the ``template_id`` / ``all_orders`` query params off
     the request. Authenticated by the X-WC-Webhook-Signature HMAC (secret = the
     stored token). Returns 200 for every authenticated non-push outcome so
     WooCommerce doesn't retry-storm.
     """
     query = request.query_params
-    template = query.get("template")
     template_id = query.get("template_id")
     all_orders = query.get("all_orders", "").lower() == "true"
 
@@ -97,10 +96,12 @@ async def handle_woocommerce(
     except json.JSONDecodeError:
         order = {}
 
-    if not template and not template_id:
+    if not template_id:
+        # Templates resolve by id only — name support was removed; webhook
+        # URLs must carry ?template_id=<uuid>.
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Missing template (pass ?template= or ?template_id= in the URL)",
+            detail="Missing template_id (pass ?template_id= in the URL)",
         )
 
     merchant = await get_merchant_by_merchant_identifier(merchant_id)
@@ -120,13 +121,12 @@ async def handle_woocommerce(
             merchant_id,
             reseller_id,
             shop_name,
-            template,
             template_id,
             all_orders,
         )
     if topic == TOPIC_ABANDONED_CHECKOUT:
         return await process_abandoned_checkout(
-            order, merchant_id, reseller_id, shop_name, template, template_id
+            order, merchant_id, reseller_id, shop_name, template_id
         )
 
     raise HTTPException(

--- a/app/api/routers/breeze_buddy/webhooks/woocommerce/utils.py
+++ b/app/api/routers/breeze_buddy/webhooks/woocommerce/utils.py
@@ -79,8 +79,7 @@ async def push_lead(
     payload: Dict[str, Any],
     merchant_id: str,
     reseller_id: str,
-    template: Optional[str],
-    template_id: Optional[str],
+    template_id: str,
     trigger_reason: str,
 ) -> Dict[str, Any]:
     """Idempotently push a lead through the existing lead pipeline."""
@@ -104,7 +103,6 @@ async def push_lead(
     lead_req = PushLeadRequest(
         request_id=request_id,
         payload=payload,
-        template=template,
         template_id=template_id,
         reseller_id=reseller_id,
         merchant_id=merchant_id,

--- a/app/core/security/jwt.py
+++ b/app/core/security/jwt.py
@@ -245,4 +245,3 @@ async def get_current_user(
         )
 
     return jwt_manager.verify_token(credentials.credentials)
-

--- a/app/database/accessor/__init__.py
+++ b/app/database/accessor/__init__.py
@@ -64,8 +64,7 @@ from .breeze_buddy.outbound_number import (
 from .breeze_buddy.template import (
     create_template,
     get_template_by_id,
-    get_template_by_id_with_fallback,
-    get_template_by_merchant,
+    get_template_in_scope,
 )
 
 __all__ = [
@@ -77,8 +76,7 @@ __all__ = [
     "mask_phone",
     "create_template",
     "get_template_by_id",
-    "get_template_by_merchant",
-    "get_template_by_id_with_fallback",
+    "get_template_in_scope",
     "create_outbound_number",
     "get_outbound_number_by_id",
     "update_outbound_number_status",

--- a/app/database/accessor/breeze_buddy/template.py
+++ b/app/database/accessor/breeze_buddy/template.py
@@ -10,7 +10,6 @@ import asyncpg
 from app.ai.voice.agents.breeze_buddy.template.types import (
     TemplateModel,
 )
-from app.core.deprecation import deprecated
 from app.core.logger import logger
 from app.database.decoder.breeze_buddy.template import decode_template
 from app.database.queries import run_parameterized_query
@@ -23,8 +22,8 @@ from app.database.queries.breeze_buddy.template import (
     delete_template_if_not_referenced_query,
     get_all_templates_by_outbound_number_id_query,
     get_template_by_id_query,
-    get_template_by_merchant_query,
     get_template_by_outbound_number_id_query,
+    get_template_in_scope_query,
     get_templates_count_query,
     get_templates_list_query,
     replace_template_query,
@@ -39,54 +38,28 @@ def get_row_count(result: Optional[list[asyncpg.Record]]) -> int:
     return len(result) if result else 0
 
 
-@deprecated(
-    "Name-based template lookup. Pass template_id and use get_template_by_id_with_fallback() instead.",
-    replacement="get_template_by_id_with_fallback()",
-)
-async def get_template_by_merchant(
+async def get_template_in_scope(
     reseller_id: str,
-    merchant_id: Optional[str] = None,
-    name: Optional[str] = None,
-    should_prioritize_merchant_specific: bool = True,
+    merchant_id: Optional[str],
+    name: str,
 ) -> Optional[TemplateModel]:
-    """Get a template by reseller ID and optional filters."""
-    logger.info(f"Getting template by reseller: {reseller_id}")
+    """Get a template by its exact (reseller, merchant, name) scope.
 
+    merchant_id=None matches only reseller-level rows (merchant_id IS NULL).
+    There is deliberately NO merchant→reseller fallback: runtime resolution
+    is id-only (get_template_by_id); this exists for uniqueness checks and
+    fixed internal lookups.
+    """
     try:
-        query, values = get_template_by_merchant_query(reseller_id, merchant_id, name)
+        query, values = get_template_in_scope_query(reseller_id, merchant_id, name)
         result = await run_parameterized_query(query, values)
 
         if result and get_row_count(result) > 0:
-            decoded_result = decode_template(result[0])
-            if decoded_result:
-                logger.info(f"Template found: {decoded_result.id} with flow structure")
-            else:
-                logger.info(f"Template decoding failed for reseller: {reseller_id}")
-            return decoded_result
-
-        # If no template found with merchant_id, retry with merchant_id=None
-        if merchant_id is not None and should_prioritize_merchant_specific:
-            logger.info(
-                f"No template found with merchant_id: {merchant_id}, retrying with merchant_id=None"
-            )
-            query, values = get_template_by_merchant_query(reseller_id, None, name)
-            result = await run_parameterized_query(query, values)
-
-            if result and get_row_count(result) > 0:
-                decoded_result = decode_template(result[0])
-                if decoded_result:
-                    logger.info(
-                        f"Template found: {decoded_result.id} with flow structure (merchant_id=None)"
-                    )
-                else:
-                    logger.info(f"Template decoding failed for reseller: {reseller_id}")
-                return decoded_result
-
-        logger.info(f"No template found for reseller: {reseller_id}")
+            return decode_template(result[0])
         return None
 
     except Exception as e:
-        logger.error(f"Error getting template by reseller: {e}")
+        logger.error(f"Error getting template in scope for {reseller_id}: {e}")
         return None
 
 
@@ -284,48 +257,6 @@ async def get_templates_list(
     except Exception as e:
         logger.error(f"Error getting templates list: {e}", exc_info=True)
         return [], 0
-
-
-async def get_template_by_id_with_fallback(
-    template_id: Optional[str],
-    reseller_id: str,
-    merchant_id: Optional[str],
-    name: Optional[str] = None,
-) -> Optional[TemplateModel]:
-    """
-    Resolve a template by ID or fall back to name-based lookup.
-
-    Ownership is already validated at lead push time, so no re-validation is
-    performed here. The name-based fallback is inherently scoped to
-    reseller_id/merchant_id at the SQL level.
-
-    Resolution order:
-      1. If template_id is provided: fetch by ID directly.
-      2. If name is provided (and no ID result): fetch by reseller/merchant/name.
-
-    Args:
-        template_id: Optional template UUID (preferred)
-        reseller_id: Reseller identifier — used for name-based fallback only
-        merchant_id: Optional merchant identifier — used for name-based fallback only
-        name: Optional template name used as fallback
-
-    Returns:
-        TemplateModel if found, None otherwise
-    """
-    if template_id:
-        template = await get_template_by_id(template_id)
-        if template is not None:
-            logger.info("Resolved template by ID: %s", template.id)
-            return template
-        logger.warning(
-            "Template not found by ID=%s, falling back to name-based lookup",
-            template_id,
-        )
-
-    if name:
-        return await get_template_by_merchant(reseller_id, merchant_id, name)
-
-    return None
 
 
 async def get_template_by_id(template_id: str) -> Optional[TemplateModel]:

--- a/app/database/queries/breeze_buddy/template.py
+++ b/app/database/queries/breeze_buddy/template.py
@@ -8,12 +8,17 @@ from typing import Any, Dict, List, Optional, Tuple
 TEMPLATE_TABLE = "template"
 
 
-def get_template_by_merchant_query(
+def get_template_in_scope_query(
     reseller_id: str,
     merchant_id: Optional[str] = None,
     name: Optional[str] = None,
 ) -> Tuple[str, List[Any]]:
-    """Generate query to get a template by reseller ID and optional filters."""
+    """Query a template by its exact (reseller, merchant, name) scope.
+
+    merchant_id=None matches reseller-level rows only (merchant_id IS NULL);
+    no fallback. Runtime resolution is id-only — this serves uniqueness
+    checks and fixed internal lookups.
+    """
     conditions = ["reseller_id = $1"]
     values = [reseller_id]
 

--- a/tests/breeze_buddy/dispatch/conftest.py
+++ b/tests/breeze_buddy/dispatch/conftest.py
@@ -521,9 +521,7 @@ class DispatchHarness:
             lead.outcome = outcome
         return lead
 
-    async def get_template_by_id_with_fallback(
-        self, template_id: str, reseller_id: str, merchant_id: Optional[str], name: str
-    ) -> Optional[Any]:
+    async def get_template_by_id(self, template_id: str) -> Optional[Any]:
         # Returning None is fine — the worker skips greeting prep gracefully.
         return None
 
@@ -625,8 +623,8 @@ def harness(monkeypatch, fake_redis) -> DispatchHarness:
     )
     monkeypatch.setattr(
         worker_mod,
-        "get_template_by_id_with_fallback",
-        h.get_template_by_id_with_fallback,
+        "get_template_by_id",
+        h.get_template_by_id,
     )
     monkeypatch.setattr(worker_mod, "is_number_blacklisted", h.is_number_blacklisted)
 


### PR DESCRIPTION
## What

Templates now resolve strictly by `template_id` everywhere. Name-based lookup and the merchant→reseller shared-template fallback are removed from every path.

- **Lead push**: `PushLeadRequest.template_id` required (UUID-validated); the legacy `template` body field is dropped from the schema (ignored if a client still sends it). The lead's stored template name is derived from the resolved row — display metadata only.
- **Runtime**: dispatch worker, telephony answer, flow loader, and agent transfer load by the lead's stored `template_id` only. Stale ids now fail loudly instead of silently re-resolving by name.
- **Kept deliberately**: exact-scope `get_template_in_scope` (no reseller fallback) solely for create/replace uniqueness checks and the fixed demo lookup.
- **WooCommerce webhook**: requires `?template_id=` — the `?template=` name param is removed. Merchants must update their webhook URLs before this deploys.
- Removed a dead, never-routed get-template-by-name handler.

## ⚠️ Deploy gate

**Do not deploy until Nautilus (and any other name-pushing client) sends `template_id`.** Verify by grepping prod push-lead logs for `template_id: None` — must be zero. WooCommerce webhook URLs must be migrated to `?template_id=` first as well.

## Context

The per-merchant backfill this enables has already been executed against prod: `order-confirmation` + `abandoned-checkout` copies for all 539 active BB_SHOPIFY merchants (canary → waves, every copy verified byte-identical to its base, zero failures, journaled rollback lists; merchant→template_id mapping CSVs handed to the Nautilus team). Name-pushing merchants are already served by their copies via the (still-live) merchant-first resolution; id-pinned clients flip when Nautilus applies the mapping. Once shared-row traffic drains to zero, the shared rows get archived.

## Testing

- `uv run pyrefly check` — 0 errors
- `pytest` — **574 passed**, 1 xfailed (needs `JWT_SECRET_KEY` + `JWT_ALGORITHM` env)
- black / isort / autoflake clean (pre-commit hooks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F51zhmjVXXKYhM1RHf2huz