### PR TITLE
(feat): add kill switch for dragon tts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -52,6 +52,22 @@ ELEVENLABS_VOICE_SPEED=1.15
 ELEVENLABS_TTS_SPEED=1.10
 ELEVENLABS_BB_VOICE_ID="bQQWtYx9EodAqMdkrNAc"
 
+# DragonTTS caching proxy + health gate. These are DYNAMIC config (resolved
+# Redis -> env -> default in app/core/config/dynamic.py) so they're tunable at
+# runtime without a redeploy; the values here are the env-fallback defaults.
+# DRAGONTTS_URL is the proxy base. Templates opt into caching via
+# tts_configuration.enable_tts_caching=true (provider = the upstream, e.g.
+# cartesia); at call time they route through DragonTTS as model
+# "<provider>:<model>" UNLESS the health flag dragontts:health is "0".
+# A scheduler task probes {DRAGONTTS_URL}/health once per
+# BACKGROUND_TASKS_LOOP_INTERVAL_SECONDS (default 60s) and, on failure, sets the
+# flag to "0" (one-way) so calls fall back to the upstream provider directly
+# until an admin restores it via POST /admin/dragontts/manage. Set
+# ENABLE_DRAGONTTS_KILL_SWITCH=false to disable the monitor.
+DRAGONTTS_URL="http://dragontts.beta.svc.cluster.local"
+DRAGONTTS_HEALTH_TIMEOUT_S=3.0
+ENABLE_DRAGONTTS_KILL_SWITCH=true
+
 # VAD settings
 VAD_CONFIDENCE=0.85
 VAD_MIN_VOLUME=0.75
@@ -198,7 +214,7 @@ SLACK_TAG_USERS="@john.doe,@jane.smith,@dev.team" # comma-separated list of user
 
 # Background Tasks Configuration
 ENABLE_BACKGROUND_TASKS=true  # Enable/disable the entire background task scheduler (default: true)
-BACKGROUND_TASKS_LOOP_INTERVAL_SECONDS=60  # How often the scheduler checks for tasks to run (in seconds, default: 60)
+BACKGROUND_TASKS_LOOP_INTERVAL_SECONDS=15  # How often the scheduler checks for tasks to run (in seconds, default: 15) (DragonTTS kill switch probes once per tick)
 
 # Langfuse Score Monitoring Configuration
 ENABLE_BB_LANGFUSE_MONITORING_LOOP=false  # Enable/disable Langfuse score monitoring task only (default: false)

--- a/app/ai/voice/agents/breeze_buddy/dispatch/alerts.py
+++ b/app/ai/voice/agents/breeze_buddy/dispatch/alerts.py
@@ -255,6 +255,39 @@ async def raise_orphan_webhook(call_id: str, source: str) -> None:
     )
 
 
+async def raise_dragontts_degraded() -> None:
+    """P1 — DragonTTS is unhealthy; the monitor marked the health flag ``"0"``.
+
+    Calls on templates with ``enable_tts_caching=true`` are now bypassing the
+    cache and routing to their upstream TTS provider directly until an operator
+    restores the flag. Throttled so a sustained outage pages once per 30 min,
+    not once per scheduler tick.
+    """
+    await _send(
+        alert_name="dragontts_degraded",
+        throttle_seconds=_THROTTLE_P1,
+        title="[P1] DragonTTS down — calls bypassing TTS caching",
+        fields=[
+            {
+                "name": "Effect",
+                "value": (
+                    "Templates with enable_tts_caching=true are routing to their "
+                    "upstream TTS provider directly (no caching) until the flag "
+                    "is restored."
+                ),
+            },
+            {
+                "name": "Recovery",
+                "value": (
+                    "Once DragonTTS /health is green, restore with "
+                    "POST /agent/voice/breeze-buddy/admin/dragontts/manage "
+                    '{"action":"restore"}.'
+                ),
+            },
+        ],
+    )
+
+
 # ---------------------------------------------------------------------------
 # Helper used by the health monitor to mark a condition as "cleared". Lets us
 # fire a fresh alert immediately when the same condition returns rather than

--- a/app/ai/voice/agents/breeze_buddy/template/types.py
+++ b/app/ai/voice/agents/breeze_buddy/template/types.py
@@ -380,6 +380,18 @@ class TTSConfig(BaseModel):
             "aloud. Leave unset/false for plain text. Ignored by other providers."
         ),
     )
+    enable_tts_caching: Optional[bool] = Field(
+        None,
+        description=(
+            "When true AND provider is not 'dragontts', route TTS through the "
+            "DragonTTS caching proxy at call time using model "
+            "'<provider>:<model>' (e.g. provider=cartesia + model=sonic-3.5 -> "
+            "dragontts:cartesia:sonic-3.5). Default None (off) — opt in per "
+            "template. The DragonTTS kill switch flips this to false on DragonTTS "
+            "failure; it never rewrites provider/model. Ignored when provider is "
+            "already 'dragontts' (those always route through DragonTTS)."
+        ),
+    )
 
 
 class TTSSelectionConfig(BaseModel):

--- a/app/ai/voice/agents/breeze_buddy/tts/__init__.py
+++ b/app/ai/voice/agents/breeze_buddy/tts/__init__.py
@@ -8,6 +8,9 @@ from app.ai.voice.agents.breeze_buddy.template.types import (
     TTSConfig,
     TTSProvider,
 )
+from app.ai.voice.agents.breeze_buddy.tts.dragontts.health import (
+    is_dragontts_healthy,
+)
 from app.ai.voice.agents.breeze_buddy.tts.emoji_filter import (
     EmojiTextFilter,
     strip_emojis,
@@ -43,10 +46,10 @@ from app.core.config.dynamic import (
     BB_STRIP_EMOJIS_FROM_TTS,
     BB_TTS_SERVICE,
     BB_VOICE_PROVIDER_DEFAULTS,
+    DRAGONTTS_URL,
 )
 from app.core.config.static import (
     CARTESIA_API_KEY,
-    DRAGONTTS_URL,
     ELEVENLABS_API_KEY,
     ELEVENLABS_INDIAN_RESIDENCY_API_KEY,
     ELEVENLABS_INDIAN_RESIDENCY_WEBSOCKET_URL,
@@ -66,6 +69,7 @@ _VOICE_CONFIG_FIELDS = (
     "pitch",
     "style_prompt",
     "enable_ssml_parsing",
+    "enable_tts_caching",
 )
 
 
@@ -131,21 +135,36 @@ async def get_tts_service(voice_config: TTSConfig):
     """Build a TTS service from a resolved TTSConfig."""
     provider = voice_config.provider.value
 
-    if provider == "dragontts":
-        # Route the live stream through DragonTTS so every aggregated sentence
-        # is served from its cache (scripted phrases become permanent hits) and
-        # synthesized+stored on miss. ``model`` carries the nested provider as
-        # "<provider>:<model>"; DragonTTS applies the params relevant to it.
-        model_id = voice_config.model
-        if not model_id:
-            raise ValueError("dragontts requires model '<provider>:<model>'")
-        nested = model_id.split(":", 1)
-        if len(nested) != 2 or not nested[0] or not nested[1]:
-            raise ValueError(
-                f"dragontts model must be '<provider>:<model>' with non-empty "
-                f"parts, got {model_id!r}"
-            )
-        nested_provider, nested_model = nested
+    # Route through the DragonTTS caching proxy when the template selects it
+    # directly (legacy provider="dragontts") OR opts in via enable_tts_caching
+    # AND DragonTTS is currently healthy. When DragonTTS is down the health flag
+    # is "0", so enable_tts_caching templates fall through to their upstream
+    # provider directly (graceful — calls work, just uncached). Legacy
+    # provider="dragontts" is intentionally not health-gated.
+    if provider == "dragontts" or (
+        voice_config.enable_tts_caching is True and await is_dragontts_healthy()
+    ):
+        if provider == "dragontts":
+            # Legacy: model already carries "<provider>:<model>".
+            model_id = voice_config.model
+            if not model_id:
+                raise ValueError("dragontts requires model '<provider>:<model>'")
+            nested = model_id.split(":", 1)
+            if len(nested) != 2 or not nested[0] or not nested[1]:
+                raise ValueError(
+                    f"dragontts model must be '<provider>:<model>' with non-empty "
+                    f"parts, got {model_id!r}"
+                )
+            nested_provider = nested[0]
+            nested_model = nested[1]
+        else:
+            # Auto-wrap: provider is the upstream; build the proxy model id.
+            if not voice_config.model:
+                raise ValueError("enable_tts_caching requires a model")
+            nested_provider = provider
+            nested_model = voice_config.model
+            model_id = f"{provider}:{voice_config.model}"
+
         aggregate = await BB_AGGREGATE_SENTENCES(nested_provider)
 
         logger.info(
@@ -156,8 +175,8 @@ async def get_tts_service(voice_config: TTSConfig):
 
         return build_dragontts_tts(
             DragonTTSConfig(
-                url=DRAGONTTS_URL,
-                model_id=model_id,  # full "<provider>:<model>", validated above
+                url=await DRAGONTTS_URL(),
+                model_id=model_id,  # full "<provider>:<model>"
                 voice_id=voice_config.voice_id or "",
                 language=voice_config.language or "",
                 params=_collect_params(voice_config),
@@ -335,6 +354,27 @@ async def generate_audio(
     if await BB_STRIP_EMOJIS_FROM_TTS():
         text = strip_emojis(text)
 
+    # Route greetings/IVR through the DragonTTS caching proxy (same rule as the
+    # live path in get_tts_service): legacy provider="dragontts" always, or an
+    # upstream with enable_tts_caching on AND DragonTTS healthy (synthesize
+    # model "<provider>:<model>"). When DragonTTS is down, enable_tts_caching
+    # greetings synthesize via the upstream directly.
+    if provider == "dragontts" or (
+        provider != "dragontts"
+        and resolved.enable_tts_caching is True
+        and await is_dragontts_healthy()
+    ):
+        if provider != "dragontts":
+            if not resolved.model:
+                raise ValueError("enable_tts_caching requires a model")
+            resolved = resolved.model_copy(
+                update={
+                    "provider": TTSProvider.DRAGONTTS,
+                    "model": f"{provider}:{resolved.model}",
+                }
+            )
+        return await _generate_dragontts_audio(text=text, resolved=resolved)
+
     if provider == "sarvam":
         audio_data = await _generate_sarvam_audio(
             text=text,
@@ -387,9 +427,6 @@ async def generate_audio(
             language=resolved.language,
         )
         input_format = "raw"
-    elif provider == "dragontts":
-        # DragonTTS caching proxy — returns μ-law directly (no local conversion).
-        return await _generate_dragontts_audio(text=text, resolved=resolved)
     else:
         raise ValueError(f"Unsupported TTS provider: {provider}")
 

--- a/app/ai/voice/agents/breeze_buddy/tts/dragontts/__init__.py
+++ b/app/ai/voice/agents/breeze_buddy/tts/dragontts/__init__.py
@@ -1,0 +1,12 @@
+"""DragonTTS health gate, kill switch, and scheduler monitor.
+
+Submodules:
+- :mod:`health` — the ``dragontts:health`` Redis flag state machine (one-shot
+  probe, call-time gate, internal writer). Imported by the call-time TTS path,
+  so it stays free of ``dispatch`` imports.
+- :mod:`kill_switch` — operator-facing kill/restore action + status read
+  (the ``/admin/dragontts/{manage,status}`` endpoints).
+- :mod:`monitor` — the scheduler task (probe + page). Imported ONLY by
+  ``app.main``; deliberately NOT imported here, so importing :mod:`health` from
+  the call path never pulls in ``dispatch`` (which would form a cycle).
+"""

--- a/app/ai/voice/agents/breeze_buddy/tts/dragontts/health.py
+++ b/app/ai/voice/agents/breeze_buddy/tts/dragontts/health.py
@@ -1,0 +1,87 @@
+"""DragonTTS health flag — the underlying state machine.
+
+Owns the ``dragontts:health`` Redis flag and its primitives: a one-shot probe
+(``check_dragontts_health``), the call-time gate (``is_dragontts_healthy``),
+and the internal flag writer (``_set_health``). It is imported by the call-time
+TTS path (``tts/__init__``), so it MUST NOT import the ``dispatch`` package —
+that would form a cycle (``dispatch`` -> ``worker`` -> ``managers.utils`` ->
+``tts/__init__``). The operator-facing kill/restore actions live in
+``kill_switch.py``; the scheduler task that drives the probe + pages on failure
+lives in ``monitor.py`` (imported only by ``app.main``).
+
+On a failed probe, ``check_dragontts_health`` marks DragonTTS unhealthy by
+setting ``dragontts:health = "0"`` — **one-way**: the gate only ever marks
+down (1->0), never up. At call time, templates with
+``tts_configuration.enable_tts_caching=true`` route through DragonTTS unless
+the flag is ``"0"``, in which case they use their upstream provider directly.
+
+Flag values: ``"0"`` = unhealthy (bypass caching); absent or ``"1"`` = healthy
+(use DragonTTS). A missing key defaults to healthy so a fresh deploy caches
+immediately, before the first probe.
+"""
+
+from __future__ import annotations
+
+import httpx
+
+from app.core.config.dynamic import DRAGONTTS_HEALTH_TIMEOUT_S, DRAGONTTS_URL
+from app.core.logger import logger
+from app.services.redis import get_redis_service
+
+__all__ = [
+    "check_dragontts_health",
+    "is_dragontts_healthy",
+]
+
+# "0" = unhealthy (bypass DragonTTS for enable_tts_caching templates);
+# absent / "1" = healthy (route through DragonTTS).
+_HEALTH_KEY = "dragontts:health"
+
+
+async def check_dragontts_health() -> bool:
+    """Probe DragonTTS ``/health``. On failure, mark it unhealthy (one-way
+    1->0). On success, do nothing — recovery is manual via the admin endpoint.
+
+    Returns the probe result. A 2xx response is healthy; anything else
+    (non-2xx, timeout, connection error) is unhealthy.
+    """
+    health_url = f"{await DRAGONTTS_URL()}/health"
+    timeout = await DRAGONTTS_HEALTH_TIMEOUT_S()
+    try:
+        async with httpx.AsyncClient(timeout=timeout) as client:
+            response = await client.get(health_url)
+            healthy = response.is_success
+            if not healthy:
+                logger.warning(
+                    f"DragonTTS health probe returned HTTP {response.status_code}"
+                )
+    except Exception as e:  # noqa: BLE001 — any probe failure = unhealthy
+        logger.warning(f"DragonTTS health probe failed: {e}")
+        healthy = False
+
+    if not healthy:
+        # One-way: only mark down. A subsequent admin restore flips it back up.
+        await _set_health(False)
+    return healthy
+
+
+async def _set_health(healthy: bool) -> None:
+    try:
+        redis = await get_redis_service()
+        await redis.set(_HEALTH_KEY, "1" if healthy else "0")
+    except Exception as e:  # noqa: BLE001 — flag write is best-effort
+        logger.warning(f"Failed to set DragonTTS health flag: {e}")
+
+
+async def is_dragontts_healthy() -> bool:
+    """``True`` unless the flag is explicitly ``"0"`` (absent/``"1"`` => healthy).
+
+    A Redis read error returns ``True`` (keep caching) — consistent with the
+    "missing = healthy" default; the only bypass signal is an explicit ``"0"``.
+    """
+    try:
+        redis = await get_redis_service()
+        return await redis.get(_HEALTH_KEY) != "0"
+    except Exception as e:  # noqa: BLE001
+        logger.warning(f"Failed to read DragonTTS health flag: {e}")
+        return True

--- a/app/ai/voice/agents/breeze_buddy/tts/dragontts/kill_switch.py
+++ b/app/ai/voice/agents/breeze_buddy/tts/dragontts/kill_switch.py
@@ -1,0 +1,36 @@
+"""DragonTTS kill switch — operator-facing control surface.
+
+Manual, two-way control of the one-way health flag from :mod:`health`:
+``set_dragontts_health`` (the admin kill/restore action exposed at
+``POST /admin/dragontts/manage``) and ``get_dragontts_status`` (the
+status read exposed at ``GET /admin/dragontts/status``). Both layer on top of
+the health primitives; this module adds no state of its own.
+
+The automatic monitor (:mod:`monitor`) only ever marks the flag unhealthy
+(1->0); ``set_dragontts_health`` is the only way to restore it. Note: if
+DragonTTS is still actually down, the monitor's next failed probe re-marks it
+``"0"``, so a restore only sticks once DragonTTS has recovered.
+"""
+
+from __future__ import annotations
+
+from app.ai.voice.agents.breeze_buddy.tts.dragontts.health import (
+    _set_health,
+    is_dragontts_healthy,
+)
+
+__all__ = ["set_dragontts_health", "get_dragontts_status"]
+
+
+async def set_dragontts_health(healthy: bool) -> None:
+    """Manually flip the DragonTTS health flag (admin endpoint, both ways).
+
+    A single Redis SET via ``_set_health``, so it's atomic — no lock needed.
+    """
+    await _set_health(healthy)
+
+
+async def get_dragontts_status() -> dict:
+    """Return the DragonTTS health state for the status endpoint."""
+    healthy = await is_dragontts_healthy()
+    return {"health": "healthy" if healthy else "unhealthy"}

--- a/app/ai/voice/agents/breeze_buddy/tts/dragontts/monitor.py
+++ b/app/ai/voice/agents/breeze_buddy/tts/dragontts/monitor.py
@@ -1,0 +1,39 @@
+"""Scheduler-facing DragonTTS health monitor — probe + alert.
+
+This module is the composition point that wires the low-level health gate
+(:mod:`health`) to the dispatch alerting layer. It is imported only by the app
+lifespan (``app.main``) to register the scheduler task, never by the call-time
+TTS path (``tts/__init__``).
+
+Keeping the monitor out of :mod:`health` is what breaks the import cycle:
+``tts/__init__`` imports ``health``, and ``health`` must not reach up into
+``dispatch`` (which pulls in ``worker`` -> ``managers.utils`` -> back to
+``tts/__init__``). Because only this module — not ``health`` — imports
+``dispatch.alerts``, and nothing on the call path imports this module, all
+imports can live at module top with no lazy import.
+
+It cannot live inside ``dispatch/`` (e.g. next to the analogous
+``monitor_dispatch_health`` in ``reconcilers.py``): that is precisely the tree
+``health`` must not import, so co-locating it there would re-introduce the cycle.
+"""
+
+from __future__ import annotations
+
+from app.ai.voice.agents.breeze_buddy.dispatch.alerts import raise_dragontts_degraded
+from app.ai.voice.agents.breeze_buddy.tts.dragontts.health import (
+    check_dragontts_health,
+)
+
+__all__ = ["monitor_dragontts_health"]
+
+
+async def monitor_dragontts_health() -> None:
+    """One scheduler tick: probe DragonTTS (marks the flag down on failure);
+    page on-call if unhealthy.
+
+    The one-way mark-down lives in ``check_dragontts_health``; this function
+    only layers the alert on top.
+    """
+    healthy = await check_dragontts_health()
+    if not healthy:
+        await raise_dragontts_degraded()

--- a/app/ai/voice/tts/dragontts.py
+++ b/app/ai/voice/tts/dragontts.py
@@ -40,7 +40,7 @@ from pipecat.services.settings import TTSSettings
 from pipecat.services.tts_service import TextAggregationMode, TTSService
 from pipecat.transcriptions.language import Language
 
-from app.core.config.static import DRAGONTTS_URL
+from app.core.config.dynamic import DRAGONTTS_URL
 from app.core.logger import logger
 
 if TYPE_CHECKING:
@@ -88,7 +88,9 @@ async def _generate_dragontts_audio(*, text: str, resolved: "TTSConfig") -> byte
     )
     async with httpx.AsyncClient(timeout=30.0) as client:
         try:
-            response = await client.post(f"{DRAGONTTS_URL}/tts/bytes", json=body)
+            response = await client.post(
+                f"{await DRAGONTTS_URL()}/tts/bytes", json=body
+            )
             response.raise_for_status()
         except httpx.HTTPStatusError as e:
             logger.error(

--- a/app/api/routers/breeze_buddy/__init__.py
+++ b/app/api/routers/breeze_buddy/__init__.py
@@ -20,6 +20,9 @@ from app.api.routers.breeze_buddy.credentials import router as credentials_route
 from app.api.routers.breeze_buddy.daily import router as daily_router
 from app.api.routers.breeze_buddy.demo import router as demo_router
 
+# DragonTTS kill switch (admin-only one-directional TTS failover)
+from app.api.routers.breeze_buddy.dragontts import router as dragontts_router
+
 # Knowledge base (RAG) management: KBs, documents, retrieval testing
 from app.api.routers.breeze_buddy.knowledge_base import router as knowledge_base_router
 from app.api.routers.breeze_buddy.leads import router as leads_router
@@ -76,6 +79,9 @@ router.include_router(numbers_router, prefix="", tags=["numbers"])
 
 # Templates (conversational flow definitions)
 router.include_router(templates_router, prefix="", tags=["templates"])
+
+# DragonTTS kill switch (admin-only: force kill / restore + status)
+router.include_router(dragontts_router, prefix="", tags=["dragontts"])
 
 # Knowledge bases (merchant documents/sheets for agent RAG)
 router.include_router(knowledge_base_router, prefix="", tags=["knowledge-base"])

--- a/app/api/routers/breeze_buddy/dragontts.py
+++ b/app/api/routers/breeze_buddy/dragontts.py
@@ -1,0 +1,55 @@
+"""DragonTTS management endpoints (admin-only).
+
+Manual control of the one-way DragonTTS health flag:
+
+- ``POST /admin/dragontts/manage`` — ``kill_switch`` marks DragonTTS unhealthy
+  (calls bypass caching) or ``restore`` marks it healthy (calls resume
+  caching). A single atomic Redis SET.
+- ``GET  /admin/dragontts/status`` — current health state.
+
+The automatic monitor runs independently and only ever marks the flag
+unhealthy (1->0); the manage endpoint is the only way to restore it.
+"""
+
+from fastapi import APIRouter, Depends
+
+from app.ai.voice.agents.breeze_buddy.tts.dragontts.kill_switch import (
+    get_dragontts_status,
+    set_dragontts_health,
+)
+from app.api.security.breeze_buddy.rbac_token import get_current_user_with_rbac
+from app.core.security.authorization import require_admin
+from app.schemas import UserInfo
+from app.schemas.breeze_buddy.dragontts import (
+    DragonTTSStatus,
+    ManageDragonTTSResponse,
+    ManageDragonTTSAction,
+    ManageDragonTTSRequest,
+)
+
+router = APIRouter()
+
+
+@router.post("/admin/dragontts/manage", response_model=ManageDragonTTSResponse)
+async def manage_dragon_tts(
+    body: ManageDragonTTSRequest,
+    current_user: UserInfo = Depends(get_current_user_with_rbac),
+    ) -> ManageDragonTTSResponse:
+    """Manage the DragonTTS health flag: ``kill_switch`` -> bypass caching,
+    ``restore`` -> resume caching."""
+    require_admin(current_user)
+    await set_dragontts_health(body.action == ManageDragonTTSAction.RESTORE)
+    status = await get_dragontts_status()
+    return ManageDragonTTSResponse(action=body.action, **status)
+
+
+@router.get(
+    "/admin/dragontts/status",
+    response_model=DragonTTSStatus,
+)
+async def get_dragon_tts_status(
+    current_user: UserInfo = Depends(get_current_user_with_rbac),
+) -> DragonTTSStatus:
+    """Return the current DragonTTS health-gate state (health + caching)."""
+    require_admin(current_user)
+    return DragonTTSStatus(**await get_dragontts_status())

--- a/app/core/config/dynamic.py
+++ b/app/core/config/dynamic.py
@@ -700,3 +700,39 @@ async def KB_MERCHANT_MAX_CHUNKS() -> int:
     per reseller on a 15GB instance); the per-KB cap above only binds once
     this one has been raised for a reseller."""
     return await get_config("KB_MERCHANT_MAX_CHUNKS", 20000, int)
+
+
+# ----------------------------------------------------------------------------
+# DragonTTS caching proxy + kill switch. Migrated from static env vars so the
+# proxy URL / health-probe timeout / enable flag can be tuned live via Redis
+# (devcycle:flags blob) without a redeploy. Resolution chain is the standard
+# get_config one: Redis -> env -> the literal default below.
+#
+# (BACKGROUND_TASKS_LOOP_INTERVAL_SECONDS — the shared scheduler loop cadence —
+# stays in static.py: it's a pre-existing knob for ALL background tasks and the
+# scheduler binds it once at startup, so a Redis change would only take effect
+# on the next pod restart anyway. DRAGONTTS_URL below is awaited on every call
+# and every health probe.)
+# ----------------------------------------------------------------------------
+
+
+async def DRAGONTTS_URL() -> str:
+    """Base URL of the DragonTTS caching proxy."""
+    return await get_config(
+        "DRAGONTTS_URL", "http://dragontts.beta.svc.cluster.local", str
+    )
+
+
+async def DRAGONTTS_HEALTH_TIMEOUT_S() -> float:
+    """Health probe timeout in seconds (default 3.0). Defensive parse."""
+    value = await get_config("DRAGONTTS_HEALTH_TIMEOUT_S", 3.0, float)
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        logger.warning(f"Invalid DRAGONTTS_HEALTH_TIMEOUT_S value {value!r}; using 3.0")
+        return 3.0
+
+
+async def ENABLE_DRAGONTTS_KILL_SWITCH() -> bool:
+    """Enable the DragonTTS health-monitor kill switch (default True)."""
+    return await get_config("ENABLE_DRAGONTTS_KILL_SWITCH", True, bool)

--- a/app/core/config/static.py
+++ b/app/core/config/static.py
@@ -8,11 +8,12 @@ ENVIRONMENT = os.environ.get("ENVIRONMENT", "production")
 PROD_LOG_LEVEL = os.environ.get("PROD_LOG_LEVEL", "INFO")
 APP_BASE_URL = os.environ.get("APP_BASE_URL", "")
 
-# DragonTTS caching proxy. Breeze Buddy one-shot TTS (provider="dragontts") is
-# routed here. Override via env for non-local deployments.
-DRAGONTTS_URL = os.environ.get(
-    "DRAGONTTS_URL", "http://dragontts.beta.svc.cluster.local"
-)
+# NOTE: DragonTTS config (DRAGONTTS_URL, DRAGONTTS_HEALTH_TIMEOUT_S,
+# ENABLE_DRAGONTTS_KILL_SWITCH) lives in
+# app/core/config/dynamic.py as async functions (Redis -> env -> default
+# resolution) so it's tunable at runtime. The matching env vars still work as
+# the env-fallback layer. BACKGROUND_TASKS_LOOP_INTERVAL_SECONDS (below) stays
+# static — it's the pre-existing shared scheduler cadence for all tasks.
 
 # Uvicorn
 PORT = int(os.environ.get("PORT", 8000))
@@ -565,7 +566,9 @@ SLACK_TAG_USERS = os.environ.get("SLACK_TAG_USERS", "narsimha.reddy")
 
 BACKGROUND_TASKS_LOOP_INTERVAL_SECONDS = int(
     os.environ.get("BACKGROUND_TASKS_LOOP_INTERVAL_SECONDS", "60")
-)  # How often the scheduler checks tasks (in seconds)
+)  # How often the scheduler checks tasks (in seconds). Pre-existing shared
+# cadence for ALL background tasks (chat cleanup, kb ingestion, reconcilers,
+# the DragonTTS kill-switch probe, ...).
 
 # Langfuse Score Monitoring Configuration
 ENABLE_BB_LANGFUSE_MONITORING_LOOP = (

--- a/app/main.py
+++ b/app/main.py
@@ -25,6 +25,9 @@ from app.ai.voice.agents.breeze_buddy.managers.calls import (
 from app.ai.voice.agents.breeze_buddy.services.agent_router.client import (
     close_smart_router_client,
 )
+from app.ai.voice.agents.breeze_buddy.tts.dragontts.monitor import (
+    monitor_dragontts_health,
+)
 
 # Database imports
 from app.ai.voice.llm._pools import close_all_pools as close_llm_http_pools
@@ -35,6 +38,7 @@ from app.api.routers.breeze_buddy.chat import cancel_bus as chat_cancel_bus
 from app.core.background_tasks import BackgroundTaskScheduler
 from app.core.config.dynamic import (
     ENABLE_BACKGROUND_TASKS,
+    ENABLE_DRAGONTTS_KILL_SWITCH,
     KB_INGESTION_INTERVAL_SECONDS,
 )
 from app.core.config.static import (
@@ -149,6 +153,21 @@ async def lifespan(_app: FastAPI):
                 func=process_pending_kb_documents,
                 interval_seconds=await KB_INGESTION_INTERVAL_SECONDS(),
             )
+
+            # DragonTTS health monitor — a scheduler task probes DragonTTS
+            # /health each tick and, on failure, one-way marks the health flag
+            # "0" so enable_tts_caching templates bypass the cache and use their
+            # upstream provider directly. Recovery is manual via the admin
+            # endpoint. Rides the scheduler like the reconcilers below; probe
+            # cadence is BACKGROUND_TASKS_LOOP_INTERVAL_SECONDS (default 60s).
+            # Entry point: tts/dragontts/monitor.py
+            # (health gate: tts/dragontts/health.py; kill switch: kill_switch.py).
+            if await ENABLE_DRAGONTTS_KILL_SWITCH():
+                _background_scheduler.register_task(
+                    name="dragon_tts_health_check",
+                    func=monitor_dragontts_health,
+                    interval_seconds=BACKGROUND_TASKS_LOOP_INTERVAL_SECONDS,
+                )
 
             # Event-driven dispatch reconcilers (Plane 5). Only registered on
             # main-server pods; the scheduler's SET NX EX lock further

--- a/app/schemas/breeze_buddy/dragontts.py
+++ b/app/schemas/breeze_buddy/dragontts.py
@@ -1,0 +1,38 @@
+"""Schemas for the DragonTTS management endpoints."""
+
+from enum import Enum
+
+from pydantic import BaseModel
+
+
+class ManageDragonTTSAction(str, Enum):
+    """Operator action for ``POST /admin/dragontts/manage``.
+
+    The kill-switch (bypass caching) is one action; more may be added as the
+    manage endpoint gains operations.
+    """
+
+    KILL_SWITCH = "kill_switch"  # engage kill switch -> bypass caching (flag "0")
+    RESTORE = "restore"  # restore from kill switch -> resume caching (flag "1")
+
+
+class ManageDragonTTSRequest(BaseModel):
+    """Request body for ``POST /admin/dragontts/manage``."""
+
+    action: ManageDragonTTSAction
+
+
+class DragonTTSStatus(BaseModel):
+    """Current DragonTTS health-gate state (``GET /admin/dragontts/status``)."""
+
+    health: str  # "healthy" | "unhealthy"
+
+
+class ManageDragonTTSResponse(BaseModel):
+    """Response for ``POST /admin/dragontts/manage``: the action performed and
+    the resulting DragonTTS state. Intended to grow as the manage endpoint gains
+    operations beyond kill/restore.
+    """
+
+    action: ManageDragonTTSAction
+    health: str  # "healthy" | "unhealthy"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional DragonTTS caching for supported voice templates.
  * Added automatic DragonTTS health monitoring to disable caching when the service is unavailable.
  * Added admin controls to view, disable, or restore DragonTTS caching.
  * Added runtime configuration for the DragonTTS proxy URL and health-check settings.

* **Bug Fixes**
  * TTS caching now bypasses the proxy when DragonTTS is unhealthy, allowing audio generation to continue through the configured provider.
  * Added operational alerts when DragonTTS becomes degraded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->