### PR TITLE
feat(daily): run each Daily voice bot in its own OS subprocess

### DIFF
--- a/app/ai/voice/agents/breeze_buddy/services/daily/__init__.py
+++ b/app/ai/voice/agents/breeze_buddy/services/daily/__init__.py
@@ -1,5 +1,8 @@
-"""Daily transport service for Breeze Buddy."""
+"""Daily transport service for Breeze Buddy.
 
-from app.ai.voice.agents.breeze_buddy.services.daily.daily import start_daily_session
-
-__all__ = ["start_daily_session"]
+Intentionally side-effect free: ``bot_runner`` runs via ``python -m``, which
+imports this package BEFORE the module body executes — any import here would
+pull ``daily.py`` (and with it static config, freezing values from the
+pre-dotenv environment) before ``bot_runner``'s ``load_dotenv()`` line runs.
+Import ``start_daily_session`` from ``.daily`` directly.
+"""

--- a/app/ai/voice/agents/breeze_buddy/services/daily/bot_runner.py
+++ b/app/ai/voice/agents/breeze_buddy/services/daily/bot_runner.py
@@ -1,0 +1,111 @@
+"""Standalone entrypoint: run ONE Daily bot in its own OS process.
+
+Spawned per call by ``services/daily/daily.py::_launch_daily_bot``:
+
+    python -m app.ai.voice.agents.breeze_buddy.services.daily.bot_runner
+
+The launch payload arrives as one ``BotLaunchPayload`` JSON object on
+**stdin** (never argv — the Daily bot token must not be visible in ``ps``
+output). The child runs the exact same ``daily_bot`` code path as the
+in-process launch; all coordination with the API process (``/voice/end``,
+channel flips, approvals, the per-session lock) goes through Postgres /
+Redis / the Daily room, so nothing changes functionally by crossing the
+process boundary. See ``_launch_daily_bot`` for the full rationale.
+"""
+
+# Load .env before the app imports below so a manually launched child
+# (``python -m ... < payload.json``) resolves static config from the on-disk
+# .env exactly like ``run.py`` does. This works because the package chain
+# ``-m`` imports first is side-effect free (``services/daily/__init__.py`` is
+# intentionally empty) — nothing reads the environment before this line. In
+# deployments the parent passes its full environment and this is a no-op.
+from dotenv import load_dotenv
+
+load_dotenv()
+
+import asyncio  # noqa: E402
+import sys  # noqa: E402
+
+from pipecat.runner.types import DailyRunnerArguments  # noqa: E402
+from pydantic import ValidationError  # noqa: E402
+
+from app.ai.voice.agents.breeze_buddy.agent import daily_bot  # noqa: E402
+from app.ai.voice.agents.breeze_buddy.services.daily.daily import (  # noqa: E402
+    daily_completion_function,
+)
+from app.ai.voice.agents.breeze_buddy.services.daily.launch_payload import (  # noqa: E402
+    BotLaunchPayload,
+)
+from app.core.config.static import (  # noqa: E402
+    BB_VOICE_BOT_DB_MAX_OVERFLOW,
+    BB_VOICE_BOT_DB_POOL_SIZE,
+)
+from app.core.logger import logger  # noqa: E402
+from app.core.transport.http_client import create_aiohttp_session  # noqa: E402
+from app.database import close_db_pool, init_db_pool  # noqa: E402
+from app.services.redis import close_redis_connections  # noqa: E402
+
+# A stuck teardown must not keep the child process (and its Postgres/Redis
+# connections) alive after the call ended — the process exits either way and
+# the OS reclaims the sockets.
+_TEARDOWN_TIMEOUT_SECS = 10.0
+
+
+def _parse_payload(raw: str) -> DailyRunnerArguments:
+    """Parse the stdin JSON payload into DailyRunnerArguments.
+
+    Raises:
+        ValueError: If the payload is not valid JSON or misses required fields.
+    """
+    try:
+        payload = BotLaunchPayload.model_validate_json(raw)
+    except ValidationError as exc:
+        raise ValueError(f"bot_runner payload invalid: {exc}") from exc
+    return DailyRunnerArguments(
+        room_url=payload.room_url, token=payload.token, body=payload.body
+    )
+
+
+async def _amain(runner_args: DailyRunnerArguments) -> None:
+    """Run one bot to completion, then release the child's pools."""
+    # `or {}` narrows pipecat's `body: Any | None` — _parse_payload already
+    # guarantees a dict with a truthy lead_id.
+    lead_id = (runner_args.body or {})["lead_id"]
+    logger.info(f"[bot_runner] starting Daily bot subprocess for lead {lead_id}")
+    # Size the per-call pool explicitly BEFORE anything touches the DB —
+    # lazy first-use init would open the API pod's full default pool
+    # (min_size=POSTGRES_POOL_SIZE) in every child.
+    await init_db_pool(
+        min_size=BB_VOICE_BOT_DB_POOL_SIZE,
+        max_size=BB_VOICE_BOT_DB_POOL_SIZE + BB_VOICE_BOT_DB_MAX_OVERFLOW,
+    )
+    try:
+        # daily_bot's own finally closes the aiohttp session.
+        await daily_bot(
+            runner_args, daily_completion_function, create_aiohttp_session()
+        )
+    finally:
+        # Best-effort, time-bounded: pool.close() waits indefinitely for
+        # acquired connections, and a straggler must not pin a finished
+        # child process alive.
+        for closer in (close_db_pool, close_redis_connections):
+            try:
+                await asyncio.wait_for(closer(), timeout=_TEARDOWN_TIMEOUT_SECS)
+            except Exception as exc:  # noqa: BLE001 - teardown must never raise
+                logger.warning(f"[bot_runner] {closer.__name__} failed: {exc!r}")
+        logger.info(f"[bot_runner] Daily bot subprocess done for lead {lead_id}")
+
+
+def main() -> None:
+    """Read the launch payload from stdin and run the bot."""
+    raw = sys.stdin.read()
+    try:
+        runner_args = _parse_payload(raw)
+    except ValueError as exc:
+        logger.error(f"[bot_runner] invalid launch payload: {exc}")
+        sys.exit(2)
+    asyncio.run(_amain(runner_args))
+
+
+if __name__ == "__main__":
+    main()

--- a/app/ai/voice/agents/breeze_buddy/services/daily/daily.py
+++ b/app/ai/voice/agents/breeze_buddy/services/daily/daily.py
@@ -8,6 +8,7 @@ This module handles Daily (web-based) voice session infrastructure:
 """
 
 import asyncio
+import sys
 import time
 import uuid
 from datetime import datetime
@@ -23,7 +24,13 @@ from pipecat.transports.daily.utils import (
 )
 
 from app.ai.voice.agents.breeze_buddy.agent import daily_bot
+from app.ai.voice.agents.breeze_buddy.services.daily.launch_payload import (
+    BotLaunchPayload,
+)
+from app.core.config.dynamic import BB_DAILY_BOT_SUBPROCESS
 from app.core.config.static import (
+    BB_DAILY_BOT_MAX_LIFETIME_SECS,
+    BB_MAX_CONCURRENT_DAILY_BOTS,
     BREEZE_BUDDY_DAILY_API_KEY,
     BREEZE_BUDDY_DAILY_API_URL,
 )
@@ -58,6 +65,117 @@ async def daily_completion_function(
     )
 
 
+# Strong references to live bot work: reaper tasks for subprocess bots and
+# the bot task itself for the legacy in-process launch. asyncio only keeps
+# weak references to tasks, so a bare create_task could be garbage-collected
+# mid-flight (Ruff RUF006). Doubles as the live-bot counter behind
+# BB_MAX_CONCURRENT_DAILY_BOTS — each entry is exactly one live call.
+_live_bot_tasks: set = set()
+
+
+def _track_live_bot(task: "asyncio.Task") -> None:
+    _live_bot_tasks.add(task)
+    task.add_done_callback(_live_bot_tasks.discard)
+
+
+async def _reap_bot_process(proc: asyncio.subprocess.Process, lead_id: str) -> None:
+    """Await a bot subprocess and log its exit — no state changes.
+
+    Log-only on normal exits: a dead bot is covered by the same safety nets
+    that covered a dead in-process bot task before process isolation (the
+    /voice/end crash-net channel flip and the 1h Daily room expiry).
+
+    The lifetime kill is a last-resort watchdog: a healthy call can never
+    outlive the 1h Daily room expiry, so a child alive past
+    BB_DAILY_BOT_MAX_LIFETIME_SECS is wedged (e.g. a stuck daily-python
+    native thread that also hangs pipecat's idle-timeout teardown) and would
+    otherwise leak the process and its Postgres/Redis connections forever.
+    """
+    try:
+        returncode = await asyncio.wait_for(
+            proc.wait(), timeout=BB_DAILY_BOT_MAX_LIFETIME_SECS
+        )
+    except asyncio.TimeoutError:
+        logger.warning(
+            f"Daily bot subprocess for lead {lead_id} (pid={proc.pid}) exceeded "
+            f"BB_DAILY_BOT_MAX_LIFETIME_SECS={BB_DAILY_BOT_MAX_LIFETIME_SECS}s — "
+            "killing wedged child"
+        )
+        try:
+            proc.kill()
+        except ProcessLookupError:
+            pass  # exited between the timeout and the kill
+        returncode = await proc.wait()
+    if returncode == 0:
+        logger.info(f"Daily bot subprocess for lead {lead_id} exited cleanly")
+    else:
+        logger.warning(
+            f"Daily bot subprocess for lead {lead_id} exited with code {returncode}"
+        )
+
+
+async def _launch_daily_bot(runner_args: DailyRunnerArguments) -> None:
+    """Spawn ``bot_runner`` as the call's own OS process.
+
+    Per-call process isolation keeps the audio pipeline (and the chat brain
+    it drives in stream mode) away from API-traffic event-loop stalls — the
+    widget voice crackle root cause — and contains daily-python native
+    crashes to one call. The child runs the exact same ``daily_bot`` code;
+    all bot↔API coordination is via Postgres/Redis/the Daily room, so
+    behavior is identical to the historical in-process launch.
+
+    ``BB_DAILY_BOT_SUBPROCESS=false`` (dynamic config: DevCycle/Redis or env,
+    escape hatch) falls back to the legacy in-process asyncio-task launch.
+    """
+    # `or {}` / `or ""` narrow pipecat's Optional field types;
+    # start_daily_session always sets token and builds body around lead_id.
+    body = runner_args.body or {}
+    lead_id = body["lead_id"]
+    if not await BB_DAILY_BOT_SUBPROCESS():
+        # Legacy in-process launch. The aiohttp session lives for the bot's
+        # lifetime (global HTTP functions); daily_bot's finally closes it.
+        bot_aiohttp_session = create_aiohttp_session()
+        bot_task = asyncio.create_task(
+            daily_bot(runner_args, daily_completion_function, bot_aiohttp_session)
+        )
+        _track_live_bot(bot_task)
+        logger.info(
+            f"Started in-process Daily bot for lead_id: {lead_id} "
+            "(BB_DAILY_BOT_SUBPROCESS=false)"
+        )
+        return
+
+    payload = BotLaunchPayload(
+        room_url=runner_args.room_url,
+        token=runner_args.token or "",
+        body=body,
+    ).model_dump_json()
+    # Payload goes over stdin, never argv: the Daily bot token must not be
+    # visible in `ps` output. stdout/stderr are inherited so the child's
+    # loguru output lands in the same container log stream; the environment
+    # is inherited too — the child sizes its own small DB pool explicitly in
+    # bot_runner via init_db_pool(min_size=BB_VOICE_BOT_DB_POOL_SIZE, ...).
+    proc = await asyncio.create_subprocess_exec(
+        sys.executable,
+        "-m",
+        "app.ai.voice.agents.breeze_buddy.services.daily.bot_runner",
+        stdin=asyncio.subprocess.PIPE,
+    )
+    # Reap unconditionally from here on: even if the stdin handoff below
+    # fails (e.g. the child died on startup), the process must still be
+    # awaited so it never lingers as a zombie.
+    _track_live_bot(asyncio.create_task(_reap_bot_process(proc, lead_id)))
+    assert proc.stdin is not None  # PIPE above guarantees it
+    try:
+        proc.stdin.write(payload.encode())
+        await proc.stdin.drain()
+    finally:
+        # Always signal EOF — bot_runner blocks on stdin.read() and a
+        # half-written payload must fail its parse instead of hanging it.
+        proc.stdin.close()
+    logger.info(f"Spawned Daily bot subprocess (pid={proc.pid}) for lead_id: {lead_id}")
+
+
 async def start_daily_session(
     lead_id: str, *, enable_recording: bool = True
 ) -> Dict[str, Any]:
@@ -67,7 +185,8 @@ async def start_daily_session(
     1. Generates a unique session ID
     2. Creates a Daily room with appropriate settings
     3. Generates tokens for both user and bot
-    4. Starts the bot in background
+    4. Starts the bot in its own OS process (legacy in-process launch via
+       BB_DAILY_BOT_SUBPROCESS=false)
 
     Args:
         lead_id: The ID of the lead to start the session for
@@ -83,6 +202,20 @@ async def start_daily_session(
     Returns:
         Dict containing room_url, token (for user), session_id, and lead_id
     """
+    # Reject BEFORE creating any room/DB state: each live bot is its own OS
+    # process holding dedicated Postgres/Redis connections and ~300MB RSS, so
+    # an unbounded spike would exhaust shared infrastructure (Postgres
+    # max_connections) that the old shared-pool in-process launch never
+    # touched. The count is approximate (no lock) — the cap is a safety rail,
+    # not an exact scheduler.
+    live_bots = len(_live_bot_tasks)
+    if live_bots >= BB_MAX_CONCURRENT_DAILY_BOTS:
+        raise RuntimeError(
+            f"Daily bot capacity reached ({live_bots} live bots >= "
+            f"BB_MAX_CONCURRENT_DAILY_BOTS={BB_MAX_CONCURRENT_DAILY_BOTS}); "
+            "rejecting new voice session"
+        )
+
     # Generate session ID
     session_id = str(uuid.uuid4())
 
@@ -169,14 +302,25 @@ async def start_daily_session(
         },
     )
 
-    # Create aiohttp session for the bot's lifecycle (for global HTTP functions)
-    # Not using async with here because bot runs in background task
-    bot_aiohttp_session = create_aiohttp_session()
-
-    # Start the bot in background with the completion function and aiohttp session
-    asyncio.create_task(
-        daily_bot(runner_args, daily_completion_function, bot_aiohttp_session)
-    )
+    # Start the bot in its own OS process (see _launch_daily_bot). Unlike the
+    # old create_task launch this CAN fail (fork error, child dying before
+    # reading stdin) — and the room/call_id/recording-sentinel writes above
+    # are already committed, so roll the sentinel back: neither the dashboard
+    # handler nor the demo abort path clears it, and a lead whose bot never
+    # spawned must not render a recording player for a recording that can
+    # never exist. call_id is left in place — a retry overwrites it.
+    try:
+        await _launch_daily_bot(runner_args)
+    except Exception:
+        if enable_recording:
+            try:
+                await update_lead_call_recording_url(room.name, "")
+            except Exception as cleanup_exc:
+                logger.warning(
+                    f"Failed to clear recording_url after failed bot launch "
+                    f"for lead {lead_id}: {cleanup_exc}"
+                )
+        raise
 
     logger.info(
         f"Successfully started Breeze Buddy Daily bot for lead_id: {lead_id}, session: {session_id}"

--- a/app/ai/voice/agents/breeze_buddy/services/daily/launch_payload.py
+++ b/app/ai/voice/agents/breeze_buddy/services/daily/launch_payload.py
@@ -1,0 +1,36 @@
+"""Wire contract for the parent -> child Daily bot launch payload.
+
+Single source of truth for the JSON handed to ``bot_runner`` over stdin:
+``daily.py`` serializes it, ``bot_runner`` parses it, so the two halves of
+the process boundary cannot drift (and a field added on one side without the
+other fails loudly instead of being silently dropped).
+
+Deliberately imports nothing from the app: it must stay importable before
+``bot_runner``'s ``load_dotenv()`` has run.
+"""
+
+from typing import Any, Dict
+
+from pydantic import BaseModel, field_validator
+
+
+class BotLaunchPayload(BaseModel):
+    """The one JSON object written to the bot child's stdin."""
+
+    room_url: str
+    token: str
+    body: Dict[str, Any]
+
+    @field_validator("room_url", "token")
+    @classmethod
+    def _non_empty(cls, value: str) -> str:
+        if not value:
+            raise ValueError("must be non-empty")
+        return value
+
+    @field_validator("body")
+    @classmethod
+    def _has_lead_id(cls, value: Dict[str, Any]) -> Dict[str, Any]:
+        if not value.get("lead_id"):
+            raise ValueError("must contain a truthy 'lead_id'")
+        return value

--- a/app/api/routers/breeze_buddy/daily/handlers.py
+++ b/app/api/routers/breeze_buddy/daily/handlers.py
@@ -6,7 +6,7 @@ from typing import Any, Dict
 
 from fastapi import HTTPException
 
-from app.ai.voice.agents.breeze_buddy.services.daily import start_daily_session
+from app.ai.voice.agents.breeze_buddy.services.daily.daily import start_daily_session
 from app.core.logger import logger
 from app.database.accessor import get_lead_by_id
 from app.schemas import (

--- a/app/core/config/dynamic.py
+++ b/app/core/config/dynamic.py
@@ -119,6 +119,20 @@ async def BB_RECONCILE_BACKLOG_LIMIT() -> int:
     return await get_config("BB_RECONCILE_BACKLOG_LIMIT", 1000, int)
 
 
+async def BB_DAILY_BOT_SUBPROCESS() -> bool:
+    """Run each Daily voice bot in its own OS subprocess (default: True).
+
+    When True, ``start_daily_session`` spawns ``services/daily/bot_runner.py``
+    per call, isolating the audio pipeline from API-traffic event-loop stalls
+    (the widget voice crackle root cause) and containing daily-python native
+    crashes to one call. Flip to False (DevCycle/Redis, or the
+    ``BB_DAILY_BOT_SUBPROCESS`` env var) as the escape hatch back to the
+    legacy in-process asyncio-task launch. Read at launch time only —
+    flipping affects new calls, never live ones.
+    """
+    return await get_config("BB_DAILY_BOT_SUBPROCESS", True, bool)
+
+
 async def DAILY_SUMMARY_HOUR() -> int:
     """Returns DAILY_SUMMARY_HOUR from Redis (24-hour format: 0-23)"""
     return await get_config("DAILY_SUMMARY_HOUR", 21, int)

--- a/app/core/config/static.py
+++ b/app/core/config/static.py
@@ -260,6 +260,26 @@ POSTGRES_POOL_SIZE = int(os.getenv("POSTGRES_POOL_SIZE", "5"))
 POSTGRES_MAX_OVERFLOW = int(os.getenv("POSTGRES_MAX_OVERFLOW", "10"))
 POSTGRES_POOL_RECYCLE = int(os.getenv("POSTGRES_POOL_RECYCLE", "3600"))  # 1 hour
 
+# Daily voice bot subprocess (per-call child processes; see
+# breeze_buddy/services/daily). Kept next to the API pool settings above so
+# the two are tuned together.
+# Per-child asyncpg pool: bot_runner calls
+# init_db_pool(min_size=BB_VOICE_BOT_DB_POOL_SIZE, max_size=POOL+OVERFLOW)
+# explicitly — a per-call child must stay far below the API pod's defaults.
+BB_VOICE_BOT_DB_POOL_SIZE = int(os.environ.get("BB_VOICE_BOT_DB_POOL_SIZE", "1"))
+BB_VOICE_BOT_DB_MAX_OVERFLOW = int(os.environ.get("BB_VOICE_BOT_DB_MAX_OVERFLOW", "2"))
+# Per-pod cap on live Daily bots (each is one OS process + 1-3 Postgres
+# connections + a Redis connection + ~300MB RSS). start_daily_session rejects
+# new sessions above this instead of letting a spike exhaust Postgres
+# max_connections.
+BB_MAX_CONCURRENT_DAILY_BOTS = int(os.environ.get("BB_MAX_CONCURRENT_DAILY_BOTS", "20"))
+# Watchdog: kill a bot child still alive past this. Healthy calls end at the
+# 1h Daily room expiry, so anything older is wedged (e.g. a stuck
+# daily-python native thread) and would leak its process/connections forever.
+BB_DAILY_BOT_MAX_LIFETIME_SECS = int(
+    os.environ.get("BB_DAILY_BOT_MAX_LIFETIME_SECS", "4500")
+)
+
 # KMS Configuration
 SKIP_KMS_DECRYPT = os.getenv("SKIP_KMS_DECRYPT", "false").lower() == "true"
 AWS_REGION = os.getenv("AWS_REGION", "us-east-1")

--- a/app/database/__init__.py
+++ b/app/database/__init__.py
@@ -3,6 +3,8 @@ Database module for the application.
 This module contains database connection and models.
 """
 
+from typing import Optional
+
 import asyncpg
 
 from app.core.config.static import (
@@ -20,12 +22,23 @@ from app.services.aws.kms import decrypt_kms
 pool = None
 
 
-async def init_db_pool():
+async def init_db_pool(min_size: Optional[int] = None, max_size: Optional[int] = None):
     """
     Initialize the database connection pool.
+
+    Args:
+        min_size: Connections opened eagerly. Defaults to POSTGRES_POOL_SIZE.
+            Per-call bot subprocesses pass an explicit small size so each
+            child doesn't open the API pod's full pool.
+        max_size: Pool ceiling. Defaults to POSTGRES_POOL_SIZE +
+            POSTGRES_MAX_OVERFLOW.
     """
     global pool
     if pool is None:
+        if min_size is None:
+            min_size = POSTGRES_POOL_SIZE
+        if max_size is None:
+            max_size = POSTGRES_POOL_SIZE + POSTGRES_MAX_OVERFLOW
         db_env_vars = [
             POSTGRES_USER,
             POSTGRES_PASSWORD,
@@ -54,8 +67,8 @@ async def init_db_pool():
                 database=POSTGRES_DB,
                 host=POSTGRES_HOST,
                 port=POSTGRES_PORT,
-                min_size=POSTGRES_POOL_SIZE,
-                max_size=POSTGRES_POOL_SIZE + POSTGRES_MAX_OVERFLOW,
+                min_size=min_size,
+                max_size=max_size,
             )
             logger.info("Database pool initialized successfully.")
         except Exception as e:

--- a/tests/test_daily_bot_subprocess.py
+++ b/tests/test_daily_bot_subprocess.py
@@ -1,0 +1,322 @@
+"""Tests for the per-call Daily bot subprocess launch.
+
+``_launch_daily_bot`` spawns ``bot_runner`` with a ``BotLaunchPayload`` on
+stdin (never argv — the Daily token must not show in ``ps``);
+``BB_DAILY_BOT_SUBPROCESS=false`` falls back to the legacy in-process task.
+``bot_runner`` sizes its own small DB pool explicitly, the reaper kills a
+child that outlives ``BB_DAILY_BOT_MAX_LIFETIME_SECS``, and
+``start_daily_session`` rejects above ``BB_MAX_CONCURRENT_DAILY_BOTS`` and
+rolls back the recording sentinel when the launch fails.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, List, Tuple
+
+import pytest
+from pipecat.runner.types import DailyRunnerArguments
+
+from app.ai.voice.agents.breeze_buddy.services.daily import (
+    bot_runner,
+    daily as daily_mod,
+)
+from app.ai.voice.agents.breeze_buddy.services.daily.launch_payload import (
+    BotLaunchPayload,
+)
+
+
+async def _flag_on() -> bool:
+    return True
+
+
+async def _flag_off() -> bool:
+    return False
+
+
+_ROOM_URL = "https://example.daily.co/room-x"
+_TOKEN = "tok-secret"
+_BODY = {"lead_id": "lead-1", "session_id": "sess-1"}
+_RUNNER_ARGS = DailyRunnerArguments(room_url=_ROOM_URL, token=_TOKEN, body=_BODY)
+
+
+# ---------------------------------------------------------------------------
+# bot_runner._parse_payload / BotLaunchPayload
+# ---------------------------------------------------------------------------
+
+
+def test_parse_payload_round_trip() -> None:
+    raw = BotLaunchPayload(
+        room_url=_ROOM_URL, token=_TOKEN, body=_BODY
+    ).model_dump_json()
+    parsed = bot_runner._parse_payload(raw)
+    assert parsed.room_url == _RUNNER_ARGS.room_url
+    assert parsed.token == _RUNNER_ARGS.token
+    assert parsed.body == _RUNNER_ARGS.body
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "not json",
+        '["not", "an", "object"]',
+        '{"token": "t", "body": {"lead_id": "l"}}',  # no room_url
+        '{"room_url": "r", "body": {"lead_id": "l"}}',  # no token
+        '{"room_url": "r", "token": "t", "body": {}}',  # no lead_id
+        '{"room_url": "", "token": "t", "body": {"lead_id": "l"}}',  # empty url
+    ],
+)
+def test_parse_payload_rejects_bad_input(raw: str) -> None:
+    with pytest.raises(ValueError):
+        bot_runner._parse_payload(raw)
+
+
+# ---------------------------------------------------------------------------
+# _launch_daily_bot — subprocess spawn contract
+# ---------------------------------------------------------------------------
+
+
+class _FakeStdin:
+    def __init__(self) -> None:
+        self.data = b""
+        self.closed = False
+
+    def write(self, data: bytes) -> None:
+        self.data += data
+
+    async def drain(self) -> None:
+        pass
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class _FakeProcess:
+    pid = 4242
+
+    def __init__(self) -> None:
+        self.stdin = _FakeStdin()
+
+    async def wait(self) -> int:
+        return 0
+
+
+class _WedgedProcess:
+    """A child whose wait() only returns after kill()."""
+
+    pid = 4243
+
+    def __init__(self) -> None:
+        self.stdin = _FakeStdin()
+        self.killed = False
+        self._dead = asyncio.Event()
+
+    def kill(self) -> None:
+        self.killed = True
+        self._dead.set()
+
+    async def wait(self) -> int:
+        await self._dead.wait()
+        return -9
+
+
+async def test_launch_in_process_when_env_escape_hatch_set(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: List[Tuple[Any, Any, Any]] = []
+
+    async def fake_daily_bot(
+        runner_args: Any, completion_function: Any, session: Any
+    ) -> None:
+        calls.append((runner_args, completion_function, session))
+
+    async def fail_exec(*args: Any, **kwargs: Any) -> None:
+        raise AssertionError("no subprocess must spawn when escape hatch is set")
+
+    monkeypatch.setattr(daily_mod, "BB_DAILY_BOT_SUBPROCESS", _flag_off)
+    monkeypatch.setattr(daily_mod, "daily_bot", fake_daily_bot)
+    monkeypatch.setattr(daily_mod, "create_aiohttp_session", lambda: "fake-session")
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fail_exec)
+
+    await daily_mod._launch_daily_bot(_RUNNER_ARGS)
+    await asyncio.sleep(0)  # let the tracked bot task run
+
+    assert len(calls) == 1
+    runner_args, completion_function, session = calls[0]
+    assert runner_args is _RUNNER_ARGS
+    assert completion_function is daily_mod.daily_completion_function
+    assert session == "fake-session"
+
+
+async def test_launch_spawns_bot_runner_subprocess(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    spawned: List[Tuple[Any, Any]] = []
+    procs: List[_FakeProcess] = []
+
+    async def fake_exec(*args: Any, **kwargs: Any) -> _FakeProcess:
+        spawned.append((args, kwargs))
+        proc = _FakeProcess()
+        procs.append(proc)
+        return proc
+
+    monkeypatch.setattr(daily_mod, "BB_DAILY_BOT_SUBPROCESS", _flag_on)
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+
+    await daily_mod._launch_daily_bot(_RUNNER_ARGS)
+    await asyncio.sleep(0)  # let the reaper task run the fake wait()
+
+    assert len(spawned) == 1
+    args, kwargs = spawned[0]
+
+    # Spawns `<python> -m app...services.daily.bot_runner`
+    assert args[1:] == (
+        "-m",
+        "app.ai.voice.agents.breeze_buddy.services.daily.bot_runner",
+    )
+
+    # The token travels over stdin, never argv (must not show in `ps`).
+    assert not any("tok-secret" in str(a) for a in args)
+
+    # The environment is inherited untouched — the child sizes its own DB
+    # pool explicitly in bot_runner, not via env overrides.
+    assert "env" not in kwargs
+
+    # EOF signalled so the child's stdin.read() returns, and the payload the
+    # parent actually wrote parses in the child's own parser.
+    (proc,) = procs
+    assert proc.stdin.closed
+    parsed = bot_runner._parse_payload(proc.stdin.data.decode())
+    assert parsed.room_url == _RUNNER_ARGS.room_url
+    assert parsed.token == _RUNNER_ARGS.token
+    assert parsed.body == _RUNNER_ARGS.body
+
+
+async def test_reaper_kills_child_past_max_lifetime(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(daily_mod, "BB_DAILY_BOT_MAX_LIFETIME_SECS", 0.01)
+    proc = _WedgedProcess()
+
+    await daily_mod._reap_bot_process(proc, "lead-1")  # type: ignore[arg-type]
+
+    assert proc.killed
+
+
+# ---------------------------------------------------------------------------
+# bot_runner._amain — explicit per-child pool sizing + bounded teardown
+# ---------------------------------------------------------------------------
+
+
+async def test_amain_sizes_child_pool_and_closes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pool_inits: List[dict] = []
+    closed: List[str] = []
+
+    async def fake_init_db_pool(**kwargs: Any) -> None:
+        pool_inits.append(kwargs)
+
+    async def fake_daily_bot(*args: Any) -> None:
+        pass
+
+    async def fake_close_db_pool() -> None:
+        closed.append("db")
+
+    async def fake_close_redis_connections() -> None:
+        closed.append("redis")
+
+    monkeypatch.setattr(bot_runner, "init_db_pool", fake_init_db_pool)
+    monkeypatch.setattr(bot_runner, "daily_bot", fake_daily_bot)
+    monkeypatch.setattr(bot_runner, "close_db_pool", fake_close_db_pool)
+    monkeypatch.setattr(
+        bot_runner, "close_redis_connections", fake_close_redis_connections
+    )
+    monkeypatch.setattr(bot_runner, "create_aiohttp_session", lambda: "fake-session")
+
+    await bot_runner._amain(_RUNNER_ARGS)
+
+    assert pool_inits == [
+        {
+            "min_size": bot_runner.BB_VOICE_BOT_DB_POOL_SIZE,
+            "max_size": bot_runner.BB_VOICE_BOT_DB_POOL_SIZE
+            + bot_runner.BB_VOICE_BOT_DB_MAX_OVERFLOW,
+        }
+    ]
+    assert closed == ["db", "redis"]
+
+
+# ---------------------------------------------------------------------------
+# start_daily_session — capacity cap + launch-failure rollback
+# ---------------------------------------------------------------------------
+
+
+async def test_capacity_cap_rejects_before_any_state_is_created(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _NoRoom:
+        def __init__(self, **kwargs: Any) -> None:
+            raise AssertionError("no Daily room must be created above the cap")
+
+    monkeypatch.setattr(daily_mod, "BB_MAX_CONCURRENT_DAILY_BOTS", 0)
+    monkeypatch.setattr(daily_mod, "DailyRESTHelper", _NoRoom)
+
+    with pytest.raises(RuntimeError, match="capacity"):
+        await daily_mod.start_daily_session("lead-1")
+
+
+class _FakeAiohttpSession:
+    async def __aenter__(self) -> "_FakeAiohttpSession":
+        return self
+
+    async def __aexit__(self, *args: Any) -> bool:
+        return False
+
+
+class _FakeRoom:
+    url = "https://example.daily.co/room-y"
+    name = "room-y"
+
+
+class _FakeRESTHelper:
+    def __init__(self, **kwargs: Any) -> None:
+        pass
+
+    async def create_room(self, params: Any) -> _FakeRoom:
+        return _FakeRoom()
+
+    async def get_token(self, room_url: str, **kwargs: Any) -> str:
+        return "tok"
+
+
+async def test_launch_failure_clears_recording_sentinel(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    recording_updates: List[Tuple[str, str]] = []
+
+    async def fake_update_call_id(lead_id: str, call_id: str) -> object:
+        return object()
+
+    async def fake_update_recording_url(call_id: str, url: str) -> object:
+        recording_updates.append((call_id, url))
+        return object()
+
+    async def failing_launch(runner_args: Any) -> None:
+        raise RuntimeError("fork failed")
+
+    monkeypatch.setattr(
+        daily_mod, "create_aiohttp_session", lambda: _FakeAiohttpSession()
+    )
+    monkeypatch.setattr(daily_mod, "DailyRESTHelper", _FakeRESTHelper)
+    monkeypatch.setattr(daily_mod, "update_lead_call_id_by_id", fake_update_call_id)
+    monkeypatch.setattr(
+        daily_mod, "update_lead_call_recording_url", fake_update_recording_url
+    )
+    monkeypatch.setattr(daily_mod, "_launch_daily_bot", failing_launch)
+
+    with pytest.raises(RuntimeError, match="fork failed"):
+        await daily_mod.start_daily_session("lead-1")
+
+    # Sentinel set on the happy path, then cleared by the rollback — a lead
+    # whose bot never spawned must not render a recording player.
+    assert recording_updates == [("room-y", "daily"), ("room-y", "")]


### PR DESCRIPTION
## Why

Part 3 of the widget voice **crackle fix** (#891 = larger output chunks, #892 = pipecat 1.5.0). Daily bots ran via `asyncio.create_task` **inside the single-worker FastAPI process**, so the 10 ms-paced audio writer competed with every HTTP request, chat-brain turn, and other live call on one event loop. Any stall beyond the ~40–100 ms of pacing slack underruns Daily's virtual mic; the browser conceals the gap and the agent's voice crackles. Process isolation removes the cause instead of just widening the tolerance — and contains daily-python native crashes (e.g. the 0.28.0 playout-thread UAF) to a single call instead of the whole API pod.

## What

`start_daily_session` now spawns `services/daily/bot_runner.py` as a **per-call OS process** running the exact same `daily_bot` code path.

Gated by **`BB_DAILY_BOT_SUBPROCESS` dynamic config (DevCycle/Redis → env → default), default ON** — flipping to `false` is the no-restart escape hatch back to the legacy in-process launch (read at launch time; affects new calls only, never live ones). The escape-hatch task is now held via a strong reference (same RUF006 treatment as the reapers).

- **Launch payload over stdin, never argv** — the Daily bot token must not appear in `ps` output. The contract is a single shared Pydantic model, `BotLaunchPayload` (`services/daily/launch_payload.py`): the parent serializes it, the child validates it (invalid payload → exit 2), so the two halves cannot drift.
- **Small per-child DB pool, explicit**: `bot_runner` calls `init_db_pool(min_size=BB_VOICE_BOT_DB_POOL_SIZE, max_size=+BB_VOICE_BOT_DB_MAX_OVERFLOW)` (defaults 1/+2) before anything touches the DB — no env-var smuggling across the process boundary. Constants live next to the `POSTGRES_*` pool settings in static.py.
- **Per-pod capacity cap**: each live bot is one OS process + 1–3 Postgres conns + a Redis conn + ~300 MB RSS, so `start_daily_session` rejects new sessions once `BB_MAX_CONCURRENT_DAILY_BOTS` (default 20) bots are live — **before** creating any room/DB state. A spike can no longer exhaust Postgres `max_connections`.
- **Reaper + watchdog**: every child is awaited (no zombies) and its exit code logged; a child still alive past `BB_DAILY_BOT_MAX_LIFETIME_SECS` (default 4500 s — healthy calls end at the 1 h room expiry) is killed. This covers the wedge pipecat's 300 s idle-timeout cannot: its teardown awaits a native daily-python `_leave()` that a stuck native thread hangs forever. Child-side teardown (`close_db_pool`/`close_redis_connections`) is also time-bounded (10 s each) so a straggler can't pin a finished child alive.
- **Launch-failure rollback**: the subprocess launch *can* fail after the room/`call_id`/recording-sentinel DB writes (fork error, child dying before reading stdin) — `start_daily_session` now clears the `recording_url` sentinel on failure so dashboard/demo leads don't render a player for a recording that never existed.
- **Logging is unchanged**: the child inherits stdout/stderr, and `app.core.logger` initializes identically from the inherited `ENVIRONMENT` (colored dev / JSON prod). Log context (`lead_id`, `call_sid`, `conversation_id`) is set inside the bot exactly as before; the JSON `process` field now carries the per-call PID (a filtering improvement).
- **`services/daily/__init__.py` is intentionally empty**: `python -m` imports the package chain before `bot_runner`'s body runs, so any import there would freeze static config from the pre-dotenv environment. With the chain side-effect free, `bot_runner`'s `load_dotenv()` genuinely runs before any config read — a manually launched child (`python -m … < payload.json`) resolves the on-disk `.env` exactly like `run.py`.

## Why this changes no functionality (deep-dig findings)

- Every bot↔API coordination path is already process-agnostic: `/voice/end` signals via DB write + the widget leaving the Daily room; the bot's `end_conversation` flips the channel via DB; chat approvals are DB-backed; the per-session lock is a **Redis** lock (cross-process by design). No in-process registry exists.
- Every resource the bot needs is a lazy singleton (asyncpg pool, Redis client) or env-driven (static config, dynamic config via Redis with env fallback). Nothing depends on FastAPI's lifespan.
- The seam was pre-built: `chat/turn_core.py` / `chat/voice_bridge.py` are explicitly layered to stay importable "from the voice subprocess".
- Applies uniformly to widget `DAILY_STREAM`, demo, and dashboard Daily bots (all three callers share `start_daily_session`).

## Known deltas (documented, accepted)

- **Bot join gains ~4.6–6.3 s measured on dev hardware** (child interpreter + full agent-stack import; CPU-limited pods may be slower). Between the widget's CHAT→VOICE flip and the bot joining, the user hears silence and `/message` is 409-guarded — the pre-warmed child pool follow-up is the fix if this hurts in practice.
- Per call: one extra process (own ONNX model copies, budget ~200–400 MB) and 1–3 Postgres connections — bounded by `BB_MAX_CONCURRENT_DAILY_BOTS`, but **pod memory/PG headroom should still be checked before prod rollout** (or flip the flag off until sized).
- On pod SIGTERM, children are killed when PID 1 exits rather than dying with uvicorn's task cancellation. Base behavior also lost in-flight call state on deploys (`_run_generation` swallows the cancellation), so this is parity; a child-side SIGTERM handler that runs full teardown is a possible follow-up the subprocess architecture newly enables.

## Verification

- `uv run pyrefly check` — 0 errors
- `uv run pytest` — **587 passed, 1 xfailed** (13 new tests: payload round-trip incl. child-side parse of the parent's actual bytes; spawn args/inherited-env/stdin contract; token-not-in-argv; escape-hatch fallback; watchdog kill; explicit child pool sizing + bounded teardown; capacity-cap rejection before room creation; recording-sentinel rollback)
- `bot_runner` smoke-tested via `python -m` — invalid payload exits 2 with a clean error log; importing the `services.daily` package pulls zero app modules (verified)
- Manual E2E on beta: widget voice attach → child appears in `ps`, greeting/turns/carousels/barge-in work, `/voice/end` tears down and child exits 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JMS9AtnyXQXHADd1ca1TwK
