### PR TITLE
feat(kb): Google Sheets connector + on-demand tab retrieval

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -300,3 +300,13 @@ BB_DISPATCH_QPS_JITTER_MS=200               # ±ms applied to every ZADD score
 #   halt all workers during an incident. Fails open (treated as true) if
 #   DevCycle/Redis is unreachable, so a sick infra layer can't silently halt
 #   dispatch. Leads stay queued until the flag flips back.
+
+# Knowledge Base (RAG)
+# KB embeddings default to azure_openai/text-embedding-3-large via the
+# KB_AZURE_OPENAI_ENDPOINT/KB_AZURE_OPENAI_API_KEY dynamic-config keys —
+# separate from the LLM's AZURE_OPENAI_* on purpose. OPENAI_API_KEY is only
+# needed for KBs explicitly on provider=openai
+OPENAI_API_KEY=
+# Google Sheets KB connector: uses GOOGLE_CREDENTIALS_JSON (above) as the
+# service-account; merchants share their sheet with that SA's client_email
+# (Viewer). That SA needs the Sheets/Drive readonly scopes granted.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,6 +146,15 @@ Breeze Buddy is the template-driven telephony agent. These patterns MUST be foll
 - Idle session cleanup is one task on the global `BackgroundTaskScheduler` (`chat/cleanup.py`); the scheduler's distributed lock keeps it single-pod-per-tick.
 - Open follow-ups: LLM-generated greeting (today only `static_greeting` works), outcome webhook on `end()`
 
+### Knowledge Base (RAG)
+- Merchant-scoped KBs (documents/sheets → chunks → pgvector) that templates attach via `configurations.knowledge_base` (`KnowledgeBaseConfig` in `template/types.py`) — no join table; KB delete does an in-use scan over template configs
+- Storage: `knowledge_base` / `kb_document` / `kb_chunk` tables (migration 034; pgvector `halfvec(768)` HNSW + `simple`-config tsvector + trigram). All embedding providers normalize to 768 dims (`app/services/embeddings/`, registry keyed by per-KB `embedding_config`; default = `azure_openai`/text-embedding-3-large in-region, `openai` is explicit opt-in)
+- Ingestion: `app/services/knowledge_base/` — connector registry (`file`, `google_sheet`; Onyx-style `load`/`detect_change` contract), source-aware chunking (heading-aware prose ~450 tokens; sheet/CSV rows = one chunk each with headers prepended), scheduler task claims PENDING docs via `FOR UPDATE SKIP LOCKED`, chunk-hash diff re-embeds only changed chunks
+- Retrieval: `retrieval.py::retrieve()` — one SQL, three legs (HNSW KNN + FTS + trigram) fused with RRF; callers own timeouts and ALWAYS fail open (voice ~0.4s, chat 1s, tool 5s)
+- Runtime modes (per template): `auto` (size-tiered) | `full_injection` (whole KB into initial node role_messages, fetched concurrently at boot) | `auto_retrieve` (`KnowledgeRetrievalProcessor` between user aggregator and LLM injects a transient system message, replaced-by-identity each turn) | `tool` (`query_knowledge_base` builtin, synthesized by `FlowConfigBuilder` from config). Realtime LLMs reject `auto`/`auto_retrieve` (`validate_template_compat`)
+- Sheets sync: share-to-service-account; `kb_sheets_poll` scheduler task probes Drive `modifiedTime` (15min default, 5min debounce) and requeues changed sheets; manual re-sync via `POST .../documents/{id}/sync`
+- KB context blocks are ephemeral everywhere: never persisted to `chat_message`, stripped from voice transcripts by `injection_header` prefix in `end_conversation`
+
 ## Important
 
 - IMPORTANT: Never modify migration SQL files directly. Create new sequential migrations (e.g., `026_your_change.sql`)

--- a/app/ai/voice/agents/breeze_buddy/handlers/internal/builtin_dispatcher.py
+++ b/app/ai/voice/agents/breeze_buddy/handlers/internal/builtin_dispatcher.py
@@ -31,6 +31,10 @@ from app.ai.voice.agents.breeze_buddy.handlers.internal.get_current_time import 
 from app.ai.voice.agents.breeze_buddy.handlers.internal.hold_and_consult import (
     hold_and_consult,
 )
+from app.ai.voice.agents.breeze_buddy.handlers.internal.kb_tab_data import (
+    get_tab_data,
+    list_tabs,
+)
 from app.ai.voice.agents.breeze_buddy.handlers.internal.query_knowledge_base import (
     query_knowledge_base,
 )
@@ -56,7 +60,9 @@ BUILTIN_HANDLERS: Dict[str, Callable] = {
     "connect_to_live_agent": connect_to_live_agent,
     "end_conversation": end_conversation_global,
     "get_current_time": get_current_time,
+    "get_tab_data": get_tab_data,
     "hold_and_consult": hold_and_consult,
+    "list_kb_tabs": list_tabs,
     "query_knowledge_base": query_knowledge_base,
     "update_outcome": update_outcome,
 }

--- a/app/ai/voice/agents/breeze_buddy/handlers/internal/kb_tab_data.py
+++ b/app/ai/voice/agents/breeze_buddy/handlers/internal/kb_tab_data.py
@@ -1,0 +1,126 @@
+"""
+Get Tab Data / List Tabs Handlers (KB tool mode, tab-scoped)
+
+Built-in global functions the LLM calls explicitly to pull the raw text of
+one ingested spreadsheet tab, or discover which tab names exist, from the
+template's attached knowledge base(s). Sibling to query_knowledge_base.py:
+same TemplateContext contract, same fail-open/timeout discipline, but reads
+a tab deterministically by name instead of running semantic search.
+
+Available in BOTH voice and chat (must never be added to CHAT_DISABLED_NAMES).
+"""
+
+import asyncio
+from typing import Any, Dict, Optional
+
+from app.ai.voice.agents.breeze_buddy.services.knowledge_base import (
+    DEFAULT_KB_INSTRUCTION,
+)
+from app.ai.voice.agents.breeze_buddy.template.context import TemplateContext
+from app.ai.voice.agents.breeze_buddy.template.types import KnowledgeBaseConfig
+from app.core.logger import logger
+from app.services.knowledge_base import get_kb_tab_text, list_kb_tabs
+
+_TAB_FETCH_TIMEOUT_SECS = 5.0
+
+
+def _attached_kb_config(context: TemplateContext) -> Optional[KnowledgeBaseConfig]:
+    """The template's KB config, or None when KB is absent/disabled."""
+    config = getattr(context.configurations, "knowledge_base", None)
+    if config is None or not config.enabled or not config.knowledge_base_ids:
+        return None
+    return config
+
+
+def _no_kb_error() -> Dict[str, Any]:
+    return {
+        "status": "error",
+        "message": "No knowledge base is attached to this template.",
+    }
+
+
+async def get_tab_data(
+    context: TemplateContext,
+    args: Dict[str, Any],
+) -> Dict[str, Any]:
+    """Fetch one tab's full text by name from the attached knowledge base(s)."""
+    config = _attached_kb_config(context)
+    if config is None:
+        return _no_kb_error()
+    kb_ids = config.knowledge_base_ids
+
+    tab_name = str(args.get("tab_name") or "").strip()
+    if not tab_name:
+        return {
+            "status": "error",
+            "message": "A non-empty 'tab_name' argument is required.",
+        }
+
+    try:
+        text, truncated = await asyncio.wait_for(
+            get_kb_tab_text(kb_ids, tab_name), timeout=_TAB_FETCH_TIMEOUT_SECS
+        )
+    except asyncio.TimeoutError:
+        logger.warning(f"[get_tab_data] timed out for call {context.call_sid}")
+        return {
+            "status": "error",
+            "message": "Tab lookup timed out; answer without it or tell the "
+            "user you could not check.",
+        }
+    except Exception as e:
+        logger.error(f"[get_tab_data] failed: {e}", exc_info=True)
+        return {
+            "status": "error",
+            "message": "Tab lookup failed; answer without it or tell the "
+            "user you could not check.",
+        }
+
+    if not text:
+        return {
+            "status": "not_found",
+            "message": f"No tab named '{tab_name}' was found. Call "
+            "list_kb_tabs to see available tab names.",
+        }
+
+    logger.info(
+        f"[get_tab_data] loaded tab '{tab_name}' for call {context.call_sid} "
+        f"({len(text)} chars, truncated={truncated})"
+    )
+    result: Dict[str, Any] = {
+        "status": "success",
+        "tab_name": tab_name,
+        "content": text,
+        "instruction": config.injection_instruction or DEFAULT_KB_INSTRUCTION,
+    }
+    if truncated:
+        result["truncated"] = True
+        result["message"] = (
+            "This tab is large and was truncated to its first portion. Answer "
+            "from what's shown, and if it may be incomplete, ask the user to "
+            "narrow the request (e.g. a specific item, row, or category)."
+        )
+    return result
+
+
+async def list_tabs(
+    context: TemplateContext,
+    args: Dict[str, Any],
+) -> Dict[str, Any]:
+    """List the tab names available across the attached knowledge base(s)."""
+    config = _attached_kb_config(context)
+    if config is None:
+        return _no_kb_error()
+    kb_ids = config.knowledge_base_ids
+
+    try:
+        names = await asyncio.wait_for(
+            list_kb_tabs(kb_ids), timeout=_TAB_FETCH_TIMEOUT_SECS
+        )
+    except asyncio.TimeoutError:
+        logger.warning(f"[list_tabs] timed out for call {context.call_sid}")
+        return {"status": "error", "message": "Tab lookup timed out."}
+    except Exception as e:
+        logger.error(f"[list_tabs] failed: {e}", exc_info=True)
+        return {"status": "error", "message": "Tab lookup failed."}
+
+    return {"status": "success", "tabs": names}

--- a/app/api/routers/breeze_buddy/knowledge_base/__init__.py
+++ b/app/api/routers/breeze_buddy/knowledge_base/__init__.py
@@ -12,6 +12,8 @@ Endpoints:
 - PUT    /knowledge-bases/{id}                         - Update metadata
 - DELETE /knowledge-bases/{id}                         - Delete (in-use check)
 - POST   /knowledge-bases/{id}/documents               - Upload file (multipart)
+- POST   /knowledge-bases/{id}/documents/sheet         - Connect a Google Sheet
+- GET    /knowledge-bases/sheets/service-account       - SA email to share with
 - GET    /knowledge-bases/{id}/documents               - List documents + status
 - DELETE /knowledge-bases/{id}/documents/{doc_id}      - Delete document
 - POST   /knowledge-bases/{id}/documents/{doc_id}/sync - Manual re-sync
@@ -27,6 +29,7 @@ from fastapi.responses import JSONResponse, StreamingResponse
 from app.api.security.breeze_buddy.rbac_token import get_current_user_with_rbac
 from app.schemas import UserInfo
 from app.schemas.breeze_buddy.knowledge_base import (
+    AddSheetDocumentRequest,
     CreateKnowledgeBaseRequest,
     DeleteKnowledgeBaseResponse,
     KbDocument,
@@ -36,16 +39,19 @@ from app.schemas.breeze_buddy.knowledge_base import (
     KnowledgeBaseListResponse,
     QueryKnowledgeBaseRequest,
     QueryKnowledgeBaseResponse,
+    SheetsServiceAccountResponse,
     UpdateKnowledgeBaseRequest,
 )
 
 from .handlers import (
+    add_sheet_document_handler,
     create_kb_handler,
     delete_document_handler,
     delete_kb_handler,
     download_document_handler,
     get_kb_handler,
     get_kb_usage_handler,
+    get_sheets_service_account_handler,
     list_documents_handler,
     list_kbs_handler,
     query_kb_handler,
@@ -93,6 +99,20 @@ async def list_knowledge_bases(
     )
 
 
+# NOTE: declared before /knowledge-bases/{kb_id} so "sheets" never matches
+# as a kb_id path parameter.
+@router.get(
+    "/knowledge-bases/sheets/service-account",
+    response_model=SheetsServiceAccountResponse,
+)
+async def get_sheets_service_account(
+    current_user: UserInfo = Depends(get_current_user_with_rbac),
+):
+    """The service-account email a merchant must share their sheet with
+    (Viewer) before connecting it."""
+    return get_sheets_service_account_handler()
+
+
 @router.get("/knowledge-bases/{kb_id}", response_model=KnowledgeBase)
 async def get_knowledge_base(
     kb_id: str,
@@ -136,6 +156,22 @@ async def upload_document(
     parsed/chunked/embedded by the background ingestion worker; poll the
     documents list for READY/ERROR status."""
     return await upload_document_handler(kb_id, file, current_user)
+
+
+@router.post(
+    "/knowledge-bases/{kb_id}/documents/sheet",
+    response_model=KbDocument,
+    status_code=status.HTTP_201_CREATED,
+)
+async def add_sheet_document(
+    kb_id: str,
+    request: AddSheetDocumentRequest,
+    current_user: UserInfo = Depends(get_current_user_with_rbac),
+):
+    """Connect a Google Sheet (shared with our service account) as a live
+    document. Initial sync runs immediately; afterwards the scheduled poller
+    re-syncs on change (or use the manual sync endpoint)."""
+    return await add_sheet_document_handler(kb_id, request, current_user)
 
 
 @router.get("/knowledge-bases/{kb_id}/documents", response_model=KbDocumentListResponse)

--- a/app/api/routers/breeze_buddy/knowledge_base/handlers.py
+++ b/app/api/routers/breeze_buddy/knowledge_base/handlers.py
@@ -30,6 +30,7 @@ from app.database.accessor.breeze_buddy.knowledge_base import (
 )
 from app.schemas import UserInfo
 from app.schemas.breeze_buddy.knowledge_base import (
+    AddSheetDocumentRequest,
     CreateKnowledgeBaseRequest,
     DeleteKnowledgeBaseResponse,
     EmbeddingConfig,
@@ -42,6 +43,7 @@ from app.schemas.breeze_buddy.knowledge_base import (
     KnowledgeBaseListResponse,
     QueryKnowledgeBaseRequest,
     QueryKnowledgeBaseResponse,
+    SheetsServiceAccountResponse,
     UpdateKnowledgeBaseRequest,
 )
 from app.services.gcp.storage.storage import GCSStorage
@@ -345,6 +347,106 @@ async def upload_document_handler(
 
     kick_ingestion()
     return document
+
+
+async def add_sheet_document_handler(
+    kb_id: str, request: "AddSheetDocumentRequest", current_user: UserInfo
+) -> KbDocument:
+    """Connect a Google Sheet: validate SA access -> PENDING doc -> kick."""
+    from app.services.knowledge_base.connectors.google_sheets import (
+        fetch_spreadsheet_meta,
+        parse_spreadsheet_id,
+    )
+
+    kb = await _get_kb_or_404(kb_id)
+    require_kb_write_access(
+        current_user, kb.reseller_id, kb.merchant_id, "connect sheets"
+    )
+
+    max_docs = await KB_MAX_DOCUMENTS_PER_KB()
+    documents = await list_kb_documents(kb_id)
+    if len(documents) >= max_docs:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Knowledge base already has {len(documents)} documents "
+            f"(cap: {max_docs})",
+        )
+
+    try:
+        spreadsheet_id = parse_spreadsheet_id(request.sheet_url)
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+
+    duplicate = next(
+        (
+            d
+            for d in documents
+            if d.source_type == KbDocumentSourceType.GOOGLE_SHEET
+            and d.source_ref.get("spreadsheet_id") == spreadsheet_id
+        ),
+        None,
+    )
+    if duplicate is not None:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=f"This spreadsheet is already connected as '{duplicate.name}'",
+        )
+
+    try:
+        meta = await fetch_spreadsheet_meta(spreadsheet_id)
+    except ValueError as e:
+        # Access/parse errors carry the share-with-SA guidance.
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+    except Exception as e:
+        logger.error(f"Sheet validation failed for {spreadsheet_id}: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="Could not reach Google Sheets; try again",
+        )
+
+    document = await create_kb_document(
+        kb_id=kb_id,
+        source_type=KbDocumentSourceType.GOOGLE_SHEET.value,
+        name=request.name or meta["title"],
+        source_ref={
+            "spreadsheet_id": spreadsheet_id,
+            "ranges": request.ranges or [],
+            # download_document_handler's GOOGLE_SHEET branch reads this —
+            # keep in sync with that lookup (sheet_url/spreadsheet_url/url).
+            "sheet_url": f"https://docs.google.com/spreadsheets/d/{spreadsheet_id}/edit",
+        },
+        mime_type="application/vnd.google-apps.spreadsheet",
+    )
+    if document is None:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to register the sheet",
+        )
+
+    kick_ingestion()
+    return document
+
+
+def get_sheets_service_account_handler() -> "SheetsServiceAccountResponse":
+    """The SA email to share sheets with (shown in the connect-sheet UI)."""
+    from app.services.knowledge_base.connectors.google_sheets import (
+        get_service_account_email,
+    )
+
+    try:
+        email = get_service_account_email()
+    except Exception as e:
+        logger.error(f"Sheets service-account lookup failed: {e}", exc_info=True)
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Google Sheets sync is not configured: set GOOGLE_CREDENTIALS_JSON",
+        ) from e
+    if not email:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Google Sheets service account has no client_email",
+        )
+    return SheetsServiceAccountResponse(email=email)
 
 
 async def list_documents_handler(

--- a/app/api/routers/breeze_buddy/knowledge_base/rbac.py
+++ b/app/api/routers/breeze_buddy/knowledge_base/rbac.py
@@ -20,6 +20,12 @@ def validate_kb_access(
 ) -> None:
     """Validate the user can touch a KB belonging to reseller/merchant.
 
+    Mirrors require_kb_write_access's ownership hierarchy (admin: everything;
+    reseller: any KB under their reseller, incl. all its merchants; merchant:
+    only KBs for a merchant they own) so read access is never stricter than
+    write access — a reseller-role user must be able to read a KB it's
+    already permitted to write to.
+
     Raises:
         HTTPException: 403 if the user lacks permission
     """
@@ -38,6 +44,11 @@ def validate_kb_access(
             status_code=status.HTTP_403_FORBIDDEN,
             detail=f"Access denied to reseller {reseller_id}",
         )
+
+    # A reseller-role user owning the reseller may read any of its KBs,
+    # including ones owned by a different merchant under that reseller.
+    if current_user.role == "reseller":
+        return
 
     if merchant_id:
         if (

--- a/app/core/config/dynamic.py
+++ b/app/core/config/dynamic.py
@@ -261,7 +261,7 @@ async def SONIOX_ASYNC_MODEL() -> str:
 #   semantics.
 # - The two rate limits are read on every request, so they take effect
 #   immediately on the next request.
-# ============================================================================
+# =====================================================================
 
 
 async def DEMO_MESSAGE_CAP_PER_SESSION() -> int:
@@ -764,3 +764,52 @@ async def DRAGONTTS_HEALTH_TIMEOUT_S() -> float:
 async def PLIVO_INR_CONVERSION_RATE() -> float:
     """Returns PLIVO_INR_CONVERSION_RATE from Redis"""
     return await get_config("PLIVO_INR_CONVERSION_RATE", 80.0, float)
+
+
+async def KB_SHEETS_POLL_ENABLED() -> bool:
+    """Master switch for the scheduled Google Sheets freshness poller."""
+    return await get_config("KB_SHEETS_POLL_ENABLED", "true", bool)
+
+
+async def KB_SHEETS_POLL_INTERVAL_SECONDS() -> int:
+    """Scheduler interval for the sheets poller (read at startup).
+
+    Hardened against malformed env overrides like KB_INGESTION_INTERVAL_SECONDS
+    (a bad value would disable ALL background tasks at startup).
+    """
+    value = await get_config("KB_SHEETS_POLL_INTERVAL_SECONDS", 900, int)
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        logger.warning(
+            f"Invalid KB_SHEETS_POLL_INTERVAL_SECONDS value {value!r}; using 900"
+        )
+        return 900
+
+
+async def KB_SHEETS_MIN_SYNC_INTERVAL_SECONDS() -> int:
+    """Debounce floor: a sheet is never re-synced more often than this,
+    even if Drive reports changes (Sheets bumps modifiedTime aggressively)."""
+    return await get_config("KB_SHEETS_MIN_SYNC_INTERVAL_SECONDS", 300, int)
+
+
+async def KB_SHEETS_POLL_BATCH_SIZE() -> int:
+    """Max sheet documents probed per poller tick.
+
+    Without a cap, a platform with many connected sheets due at once probes
+    all of them serially in one tick — unbounded tick wall-clock, and at
+    KB_SHEETS_PROBE_SPACING_SECONDS pacing (~1 req/s, under the 60 req/min/
+    user Drive quota) that's still one probe per second, so a large backlog
+    needs capping rather than raw throughput. Mirrors KB_INGEST_BATCH_SIZE.
+    """
+    return await get_config("KB_SHEETS_POLL_BATCH_SIZE", 50, int)
+
+
+async def KB_SHEETS_PROBE_SPACING_SECONDS() -> float:
+    """Delay between Drive modifiedTime probes within one poller tick.
+
+    Drive's read quota is 60 req/min/user; 1.0s spacing sits at that
+    ceiling. Redis-settable so ops can loosen/tighten it without a deploy if
+    the real quota ever changes or multiple pods share one service account.
+    """
+    return await get_config("KB_SHEETS_PROBE_SPACING_SECONDS", 1.0, float)

--- a/app/database/accessor/breeze_buddy/knowledge_base.py
+++ b/app/database/accessor/breeze_buddy/knowledge_base.py
@@ -27,13 +27,16 @@ from app.database.queries.breeze_buddy.knowledge_base import (
     get_chunk_hashes_for_document_query,
     get_kb_document_by_id_query,
     get_kb_full_text_query,
+    get_kb_tab_rows_query,
     get_kb_token_total_query,
     get_knowledge_base_by_id_query,
     get_merchant_chunk_total_query,
+    get_sheet_documents_due_for_poll_query,
     hybrid_search_chunks_query,
     insert_kb_document_query,
     insert_knowledge_base_query,
     list_kb_documents_query,
+    list_kb_tab_names_query,
     list_knowledge_bases_query,
     mark_kb_document_for_resync_query,
     requeue_stale_processing_documents_query,
@@ -427,6 +430,28 @@ async def get_kb_full_text_rows(kb_ids: List[str]) -> List[Tuple[str, str]]:
         raise
 
 
+async def get_kb_tab_rows(kb_ids: List[str], tab_name: str) -> List[Tuple[str, str]]:
+    """All READY chunk texts (with document names) tagged with this tab name."""
+    try:
+        query_text, values = get_kb_tab_rows_query(kb_ids, tab_name)
+        result = await run_parameterized_query(query_text, values)
+        return [(row["document_name"], row["text"]) for row in result]
+    except Exception as e:
+        logger.error(f"Error getting tab '{tab_name}' text for {kb_ids}: {e}")
+        raise
+
+
+async def list_kb_tab_names(kb_ids: List[str]) -> List[str]:
+    """Distinct tab/table names available across these KBs' READY chunks."""
+    try:
+        query_text, values = list_kb_tab_names_query(kb_ids)
+        result = await run_parameterized_query(query_text, values)
+        return [row["table_name"] for row in result]
+    except Exception as e:
+        logger.error(f"Error listing tab names for {kb_ids}: {e}")
+        raise
+
+
 async def get_kb_token_total(kb_ids: List[str]) -> int:
     """Total READY token count across KBs (AUTO mode size tiering)."""
     try:
@@ -500,4 +525,21 @@ async def hybrid_search_chunks(
         return []
     except Exception as e:
         logger.error(f"Error in hybrid search over KBs {kb_ids}: {e}")
+        raise
+
+
+async def get_sheet_documents_due_for_poll(
+    min_sync_age_seconds: int,
+    batch_size: int,
+) -> List[KbDocument]:
+    """READY google_sheet documents older than the debounce floor, capped at
+    batch_size (oldest-synced first)."""
+    try:
+        query_text, values = get_sheet_documents_due_for_poll_query(
+            min_sync_age_seconds, batch_size
+        )
+        result = await run_parameterized_query(query_text, values)
+        return decode_kb_document_list(result)
+    except Exception as e:
+        logger.error(f"Error listing sheet documents due for poll: {e}")
         raise

--- a/app/database/queries/breeze_buddy/knowledge_base.py
+++ b/app/database/queries/breeze_buddy/knowledge_base.py
@@ -461,6 +461,56 @@ def get_kb_full_text_query(kb_ids: List[str]) -> Tuple[str, List[Any]]:
     return text, [kb_ids]
 
 
+def get_kb_tab_rows_query(kb_ids: List[str], tab_name: str) -> Tuple[str, List[Any]]:
+    """Generate query for one tab's text: all READY chunks tagged with this
+    sheet/table name, in ingestion order.
+
+    Mirrors get_kb_full_text_query but filters chunk metadata by table name
+    instead of taking every chunk. Chunk metadata is populated by
+    chunking.py::chunk_table (metadata={"table": table.name, ...}) for every
+    row of an ingested spreadsheet tab.
+
+    Note: if a KB contains multiple documents that each have a tab with the
+    same name, rows from all of them are returned concatenated (scoping is
+    by kb_id, not document_id). Fine for the single-sheet-per-KB case this
+    is built for; revisit if that assumption breaks.
+
+    Match is case-insensitive: an LLM calling get_tab_data("pricing") should
+    still hit a tab actually named "Pricing" rather than round-tripping
+    through list_kb_tabs first — the whole point of this tool over semantic
+    search is a deterministic hit, and case is the one mismatch an LLM is
+    likely to make even when it got the name from list_kb_tabs.
+    """
+    text = f"""
+        SELECT c."text", d."name" AS document_name
+        FROM "{KB_CHUNK_TABLE}" c
+        JOIN "{KB_DOCUMENT_TABLE}" d ON d."id" = c."document_id"
+        WHERE c."kb_id" = ANY($1::uuid[])
+          AND d."status" = 'READY'
+          AND LOWER(c."metadata"->>'table') = LOWER($2)
+        ORDER BY d."created_at", c."document_id", c."chunk_index";
+    """
+    return text, [kb_ids, tab_name]
+
+
+def list_kb_tab_names_query(kb_ids: List[str]) -> Tuple[str, List[Any]]:
+    """Generate query for the distinct tab/table names available across
+    these KBs' READY chunks — lets callers discover valid get_tab_data
+    arguments instead of guessing.
+    """
+    text = f"""
+        SELECT DISTINCT c."metadata"->>'table' AS table_name
+        FROM "{KB_CHUNK_TABLE}" c
+        JOIN "{KB_DOCUMENT_TABLE}" d ON d."id" = c."document_id"
+        WHERE c."kb_id" = ANY($1::uuid[])
+          AND d."status" = 'READY'
+          AND c."metadata"->>'table' IS NOT NULL
+          AND c."metadata"->>'table' != ''
+        ORDER BY table_name;
+    """
+    return text, [kb_ids]
+
+
 def get_kb_token_total_query(kb_ids: List[str]) -> Tuple[str, List[Any]]:
     """Generate query for the total READY token count across KBs.
 
@@ -551,3 +601,30 @@ def hybrid_search_chunks_query(
         top_k,
     ]
     return text, values
+
+
+def get_sheet_documents_due_for_poll_query(
+    min_sync_age_seconds: int,
+    batch_size: int,
+) -> Tuple[str, List[Any]]:
+    """Generate query for READY google_sheet documents due a freshness probe.
+
+    The age floor debounces the poller (Sheets bumps modifiedTime on every
+    keystroke-ish save; we never re-sync a sheet more often than this).
+    Bounded by batch_size, unlike an unbounded pull -- a platform with many
+    connected sheets due at once would otherwise probe every one of them
+    serially in a single tick with no cap, mirroring KB_INGEST_BATCH_SIZE's
+    role in the ingestion pipeline. Oldest-synced sheets are probed first so
+    a large backlog drains fairly across ticks instead of starving the same
+    tail forever.
+    """
+    text = f"""
+        SELECT * FROM "{KB_DOCUMENT_TABLE}"
+        WHERE "source_type" = 'google_sheet'
+          AND "status" = 'READY'
+          AND ("synced_at" IS NULL
+               OR "synced_at" < now() - make_interval(secs => $1))
+        ORDER BY "synced_at" NULLS FIRST
+        LIMIT $2;
+    """
+    return text, [min_sync_age_seconds, batch_size]

--- a/app/main.py
+++ b/app/main.py
@@ -39,6 +39,7 @@ from app.core.background_tasks import BackgroundTaskScheduler
 from app.core.config.dynamic import (
     ENABLE_BACKGROUND_TASKS,
     KB_INGESTION_INTERVAL_SECONDS,
+    KB_SHEETS_POLL_INTERVAL_SECONDS,
 )
 from app.core.config.static import (
     BACKGROUND_TASKS_LOOP_INTERVAL_SECONDS,
@@ -65,6 +66,9 @@ from app.core.middleware.widget_cors_bypass import CustomWidgetCorsBypassMiddlew
 from app.database import close_db_pool, init_db_pool
 from app.services.knowledge_base import (
     process_pending_documents as process_pending_kb_documents,
+)
+from app.services.knowledge_base.sheets_poll import (
+    poll_sheet_documents as poll_kb_sheet_documents,
 )
 from app.services.langfuse.tasks.task import initialize_langfuse_tasks
 from app.services.redis import (
@@ -168,6 +172,14 @@ async def lifespan(_app: FastAPI):
                     func=monitor_dragontts_health,
                     interval_seconds=BACKGROUND_TASKS_LOOP_INTERVAL_SECONDS,
                 )
+            # Google Sheets freshness poller: one cheap Drive modifiedTime
+            # probe per connected sheet per tick; changed sheets requeue for
+            # ingestion (KB_SHEETS_POLL_ENABLED gates each tick at runtime).
+            _background_scheduler.register_task(
+                name="kb_sheets_poll",
+                func=poll_kb_sheet_documents,
+                interval_seconds=await KB_SHEETS_POLL_INTERVAL_SECONDS(),
+            )
 
             # Event-driven dispatch reconcilers (Plane 5). Only registered on
             # main-server pods; the scheduler's SET NX EX lock further

--- a/app/schemas/breeze_buddy/knowledge_base.py
+++ b/app/schemas/breeze_buddy/knowledge_base.py
@@ -150,6 +150,27 @@ class KbUsageResponse(BaseModel):
     templates: List[KbUsageTemplate]
 
 
+class AddSheetDocumentRequest(BaseModel):
+    """Connect a Google Sheet as a knowledge base document."""
+
+    sheet_url: str = Field(
+        ..., min_length=10, description="Full Google Sheets URL (or bare ID)."
+    )
+    ranges: Optional[List[str]] = Field(
+        None,
+        description="Sheet tabs / A1 ranges to sync. Omit to sync all tabs.",
+    )
+    name: Optional[str] = Field(
+        None, description="Display name; defaults to the spreadsheet title."
+    )
+
+
+class SheetsServiceAccountResponse(BaseModel):
+    """The service-account email merchants share their sheet with."""
+
+    email: str
+
+
 class QueryKnowledgeBaseRequest(BaseModel):
     """Retrieval-testing request ("hit testing")."""
 

--- a/app/services/knowledge_base/__init__.py
+++ b/app/services/knowledge_base/__init__.py
@@ -8,14 +8,18 @@ from app.services.knowledge_base.ingestion import (
 )
 from app.services.knowledge_base.retrieval import (
     get_full_kb_text,
+    get_kb_tab_text,
     get_kb_token_count,
+    list_kb_tabs,
     retrieve,
 )
 
 __all__ = [
     "get_full_kb_text",
+    "get_kb_tab_text",
     "get_kb_token_count",
     "kick_ingestion",
+    "list_kb_tabs",
     "process_pending_documents",
     "retrieve",
 ]

--- a/app/services/knowledge_base/chunking.py
+++ b/app/services/knowledge_base/chunking.py
@@ -14,6 +14,7 @@ prices/SKUs retrievable.
 
 import hashlib
 import re
+from itertools import zip_longest
 from typing import Any, Dict, List, Optional, Tuple
 
 from app.core.logger import logger
@@ -244,7 +245,14 @@ def chunk_prose(
 
 
 def chunk_table(table: TableData) -> List[PreparedChunk]:
-    """Row-as-chunk with headers prepended, plus one sheet-summary chunk."""
+    """Row-as-chunk with headers prepended, plus one sheet-summary chunk.
+
+    Headers can legitimately be blank — a tab mid-edit, a header cell that's
+    whitespace-only, or a sheet author who just never labeled a column. A
+    blank header must not cost the row itself: pairing falls back to the
+    bare cell value (no "label: " prefix) instead of discarding it, so a
+    tab never silently loses real data just because its header row does.
+    """
     chunks: List[PreparedChunk] = []
     headers = [h.strip() for h in table.headers]
 
@@ -255,9 +263,9 @@ def chunk_table(table: TableData) -> List[PreparedChunk]:
             continue
         non_empty_rows += 1
         pairs = [
-            f"{header}: {cell}"
-            for header, cell in zip(headers, cells)
-            if header and cell
+            f"{header}: {cell}" if header else cell
+            for header, cell in zip_longest(headers, cells, fillvalue="")
+            if cell
         ]
         if not pairs:
             continue
@@ -279,11 +287,13 @@ def chunk_table(table: TableData) -> List[PreparedChunk]:
                 metadata["row_part"] = part_index
             chunks.append(_make_chunk(part, metadata))
 
-    if headers and non_empty_rows:
+    if non_empty_rows:
+        column_names = ", ".join(h for h in headers if h)
         summary = (
             f"Table '{table.name}' contains {non_empty_rows} rows with columns: "
-            + ", ".join(h for h in headers if h)
-            + "."
+            f"{column_names}."
+            if column_names
+            else f"Table '{table.name}' contains {non_empty_rows} rows."
         )
         chunks.insert(0, _make_chunk(summary, {"table": table.name, "summary": True}))
 

--- a/app/services/knowledge_base/connectors/__init__.py
+++ b/app/services/knowledge_base/connectors/__init__.py
@@ -9,9 +9,11 @@ from typing import Dict
 
 from app.services.knowledge_base.connectors.base import KBConnector
 from app.services.knowledge_base.connectors.file_upload import FileUploadConnector
+from app.services.knowledge_base.connectors.google_sheets import GoogleSheetsConnector
 
 SOURCE_CONNECTORS: Dict[str, KBConnector] = {
     FileUploadConnector.source_type: FileUploadConnector(),
+    GoogleSheetsConnector.source_type: GoogleSheetsConnector(),
 }
 
 

--- a/app/services/knowledge_base/connectors/google_sheets.py
+++ b/app/services/knowledge_base/connectors/google_sheets.py
@@ -1,0 +1,310 @@
+"""
+Google Sheets connector: merchant-shared spreadsheet -> NormalizedContent.
+
+Auth model: the platform's service account; the merchant shares their sheet
+with the SA email as Viewer (lowest-friction B2B pattern — no OAuth flow).
+Data access is REST via the shared aiohttp factory; only token minting uses
+the google-auth library (sync, run in a thread, cached until near expiry).
+
+Sync model (see also sheets_poll.py): Sheets has no row-level diff API, so
+change detection is a cheap Drive ``files.get(modifiedTime)`` probe and a
+"changed" verdict triggers a full ``values.batchGet`` re-read; the ingestion
+worker's chunk-hash diff then re-embeds only rows that actually changed.
+"""
+
+import asyncio
+import datetime
+import hashlib
+import json
+import re
+from typing import Any, Dict, List, Optional, Tuple
+
+import aiohttp
+
+from app.core.config.static import GOOGLE_CREDENTIALS_JSON
+from app.core.logger import logger
+from app.core.transport.http_client import create_aiohttp_session
+from app.schemas.breeze_buddy.knowledge_base import KbDocument
+from app.services.knowledge_base.connectors.base import KBConnector
+from app.services.knowledge_base.types import NormalizedContent, TableData
+
+_SCOPES = [
+    "https://www.googleapis.com/auth/spreadsheets.readonly",
+    "https://www.googleapis.com/auth/drive.metadata.readonly",
+]
+_SHEETS_API = "https://sheets.googleapis.com/v4/spreadsheets"
+_DRIVE_API = "https://www.googleapis.com/drive/v3/files"
+
+_SPREADSHEET_URL_RE = re.compile(r"/spreadsheets/d/([a-zA-Z0-9_-]+)")
+
+MAX_SHEET_ROWS = 10_000
+MAX_SHEET_COLUMNS = 50
+
+# Token cache: (access_token, expiry_epoch). Minting is sync google-auth
+# work run in a thread; cached until 5 minutes before expiry.
+_token_cache: Optional[Tuple[str, float]] = None
+_token_lock = asyncio.Lock()
+
+_session: Optional[aiohttp.ClientSession] = None
+
+
+def _get_session() -> aiohttp.ClientSession:
+    """Lazily create/reuse the module's shared aiohttp session for all
+    Google API calls (connection reuse across poller probes and loads)."""
+    global _session
+    if _session is None or _session.closed:
+        _session = create_aiohttp_session(
+            timeout=aiohttp.ClientTimeout(total=60, connect=10)
+        )
+    return _session
+
+
+def _credentials_info() -> Dict[str, Any]:
+    """Parsed service-account JSON from env.
+
+    Uses the platform's existing ``GOOGLE_CREDENTIALS_JSON`` (already used by
+    Google/Gemini TTS and STT) — that SA also needs the Sheets/Drive readonly
+    scopes granted. Raises a curated ValueError when unset (surfaced as the
+    503 on the connect-sheet endpoint).
+    """
+    if not GOOGLE_CREDENTIALS_JSON:
+        raise ValueError(
+            "Google Sheets sync is not configured: set GOOGLE_CREDENTIALS_JSON"
+        )
+    return json.loads(GOOGLE_CREDENTIALS_JSON)
+
+
+def get_service_account_email() -> str:
+    """The SA email merchants must share their sheet with (Viewer)."""
+    return str(_credentials_info().get("client_email", ""))
+
+
+def parse_spreadsheet_id(url_or_id: str) -> str:
+    """Extract the spreadsheet ID from a full Sheets URL or bare ID.
+
+    Called by the add-sheet handler on whatever the merchant pasted into
+    the loom connect dialog; raises a user-facing ValueError (400) when
+    neither shape matches.
+    """
+    value = url_or_id.strip()
+    match = _SPREADSHEET_URL_RE.search(value)
+    if match:
+        return match.group(1)
+    if re.fullmatch(r"[a-zA-Z0-9_-]{20,}", value):
+        return value
+    raise ValueError(
+        "Could not parse a spreadsheet ID from the provided value; paste the "
+        "full Google Sheets URL"
+    )
+
+
+def _mint_token_sync() -> Tuple[str, float]:
+    """Mint a fresh OAuth access token from the SA credentials (sync).
+
+    google-auth is a sync library, so this runs via ``asyncio.to_thread``
+    from ``_get_access_token``. Returns (token, expiry_epoch); a missing
+    expiry assumes the standard ~1h lifetime minus safety margin.
+    """
+    from google.auth.transport.requests import Request
+    from google.oauth2 import service_account
+
+    credentials = service_account.Credentials.from_service_account_info(
+        _credentials_info(), scopes=_SCOPES
+    )
+    credentials.refresh(Request())
+    expiry = credentials.expiry
+    expiry_epoch = (
+        expiry.replace(tzinfo=datetime.timezone.utc).timestamp()
+        if expiry
+        else datetime.datetime.now(datetime.timezone.utc).timestamp() + 3000
+    )
+    return str(credentials.token), expiry_epoch
+
+
+async def _get_access_token() -> str:
+    """Cached SA access token, re-minted when <5 minutes from expiry.
+
+    Double-checked locking: the cheap check outside the lock serves the
+    common case without contention; the re-check inside prevents a
+    thundering herd of token mints when many probes race at expiry.
+    """
+    global _token_cache
+    now = datetime.datetime.now(datetime.timezone.utc).timestamp()
+    if _token_cache and _token_cache[1] - now > 300:
+        return _token_cache[0]
+    async with _token_lock:
+        now = datetime.datetime.now(datetime.timezone.utc).timestamp()
+        if _token_cache and _token_cache[1] - now > 300:
+            return _token_cache[0]
+        _token_cache = await asyncio.to_thread(_mint_token_sync)
+        return _token_cache[0]
+
+
+async def _api_get(url: str, params: Any = None) -> Dict[str, Any]:
+    """Authenticated GET against the Sheets/Drive APIs with error mapping.
+
+    Translates the statuses users actually hit into actionable messages:
+    403 -> "share with <SA email>" (the #1 onboarding mistake), 404 -> bad
+    URL, 429 -> rate limit (poller backs off by just failing the tick).
+    ValueError = user-fixable, RuntimeError = transient/ops.
+    """
+    token = await _get_access_token()
+    async with _get_session().get(
+        url, params=params, headers={"Authorization": f"Bearer {token}"}
+    ) as response:
+        if response.status == 403:
+            raise ValueError(
+                "Access denied. Share the sheet with "
+                f"{get_service_account_email()} (Viewer) and try again."
+            )
+        if response.status == 404:
+            raise ValueError("Spreadsheet not found — check the URL.")
+        if response.status == 429:
+            raise RuntimeError("Google Sheets API rate limit hit (429); retry later")
+        if response.status != 200:
+            body = await response.text()
+            raise RuntimeError(
+                f"Google API request failed ({response.status}): {body[:300]}"
+            )
+        return await response.json()
+
+
+async def fetch_spreadsheet_meta(spreadsheet_id: str) -> Dict[str, Any]:
+    """Validate access and return {title, sheet_titles} for the add-sheet flow."""
+    data = await _api_get(
+        f"{_SHEETS_API}/{spreadsheet_id}",
+        params={"fields": "properties.title,sheets.properties.title"},
+    )
+    return {
+        "title": data.get("properties", {}).get("title", "Untitled spreadsheet"),
+        "sheet_titles": [
+            s.get("properties", {}).get("title", "")
+            for s in data.get("sheets", [])
+            if s.get("properties", {}).get("title")
+        ],
+    }
+
+
+class GoogleSheetsConnector(KBConnector):
+    source_type = "google_sheet"
+
+    async def load(self, document: KbDocument) -> NormalizedContent:
+        """Fetch the sheet's current rows as TableData (one per tab).
+
+        The connector half of ingestion for google_sheet documents: one
+        ``values:batchGet`` for all configured ranges (or every tab when
+        none were pinned at connect time). The content hash over the
+        fetched values lets ingestion's row-level hash-diff re-embed only
+        edited rows.
+        """
+        spreadsheet_id = str(document.source_ref.get("spreadsheet_id") or "")
+        if not spreadsheet_id:
+            raise ValueError(
+                f"Document {document.id} has no spreadsheet_id in source_ref"
+            )
+
+        ranges: List[str] = list(document.source_ref.get("ranges") or [])
+        if not ranges:
+            meta = await fetch_spreadsheet_meta(spreadsheet_id)
+            ranges = meta["sheet_titles"]
+        if not ranges:
+            raise ValueError("Spreadsheet has no sheets to read")
+
+        data = await _api_get(
+            f"{_SHEETS_API}/{spreadsheet_id}/values:batchGet",
+            params=[("ranges", r) for r in ranges]
+            + [("majorDimension", "ROWS"), ("valueRenderOption", "FORMATTED_VALUE")],
+        )
+
+        tables: List[TableData] = []
+        for value_range in data.get("valueRanges", []):
+            raw_rows = value_range.get("values", [])
+            rows: List[List[str]] = [
+                [str(cell) for cell in row[:MAX_SHEET_COLUMNS]] for row in raw_rows
+            ][: MAX_SHEET_ROWS + 1]
+            if len(rows) < 2:
+                continue  # header-only or empty tab
+            # "'Sheet1'!A1:Z100" -> "Sheet1"
+            range_name = value_range.get("range", "")
+            sheet_name = range_name.split("!")[0].strip("'") or "sheet"
+
+            # Truncation is silent data loss from the operator's point of
+            # view — the agent answers from a partial tab and nothing says
+            # so. Log it loudly enough to be greppable.
+            if len(raw_rows) > MAX_SHEET_ROWS + 1:
+                logger.warning(
+                    f"Sheet tab '{sheet_name}' has {len(raw_rows) - 1} rows; "
+                    f"truncated to MAX_SHEET_ROWS={MAX_SHEET_ROWS}. "
+                    f"{len(raw_rows) - 1 - MAX_SHEET_ROWS} row(s) not ingested."
+                )
+            widest = max((len(row) for row in raw_rows), default=0)
+            if widest > MAX_SHEET_COLUMNS:
+                logger.warning(
+                    f"Sheet tab '{sheet_name}' has {widest} columns; truncated "
+                    f"to MAX_SHEET_COLUMNS={MAX_SHEET_COLUMNS}. "
+                    f"{widest - MAX_SHEET_COLUMNS} column(s) not ingested."
+                )
+
+            tables.append(TableData(name=sheet_name, headers=rows[0], rows=rows[1:]))
+
+        if not tables:
+            raise ValueError(
+                "No data rows found — the sheet needs a header row plus at "
+                "least one data row"
+            )
+
+        content_hash = hashlib.sha256(
+            json.dumps(
+                [[t.name, t.headers, t.rows] for t in tables], ensure_ascii=False
+            ).encode("utf-8")
+        ).hexdigest()
+        return NormalizedContent(tables=tables, content_hash=content_hash)
+
+    async def detect_change(self, document: KbDocument) -> bool:
+        """Cheap freshness probe: Drive modifiedTime vs the last sync time.
+
+        Probe failures split along ``_api_get``'s contract, because a
+        requeue is not free: it flips the document to PENDING, and
+        retrieval serves READY documents only — so a document being
+        re-read is a document whose chunks are invisible to the agent.
+
+        ValueError (403/404: unshared, deleted, bad URL) -> report changed.
+        The re-read fails too and records the real error on the document
+        row, which is what the operator needs to see.
+
+        RuntimeError / network (429, 5xx, timeouts) -> report UNCHANGED.
+        These are transient and usually fleet-wide: treating them as
+        changed would requeue every sheet at once and blank out otherwise
+        healthy KB content for the duration of a Google incident. Keep
+        serving the last good ingestion and re-probe on the next tick.
+        """
+        spreadsheet_id = str(document.source_ref.get("spreadsheet_id") or "")
+        if not spreadsheet_id or document.synced_at is None:
+            return True
+        try:
+            data = await _api_get(
+                f"{_DRIVE_API}/{spreadsheet_id}", params={"fields": "modifiedTime"}
+            )
+            modified_raw = data.get("modifiedTime")
+            if not modified_raw:
+                return True
+            modified_at = datetime.datetime.fromisoformat(
+                modified_raw.replace("Z", "+00:00")
+            )
+            synced_at = document.synced_at
+            if synced_at.tzinfo is None:
+                synced_at = synced_at.replace(tzinfo=datetime.timezone.utc)
+            return modified_at > synced_at
+        except ValueError as e:
+            logger.warning(
+                f"Sheets change probe rejected for document {document.id} "
+                f"(assuming changed so the re-read records it): {e}"
+            )
+            return True
+        except Exception as e:
+            logger.warning(
+                f"Sheets change probe failed transiently for document "
+                f"{document.id} (assuming unchanged, keeping last good "
+                f"ingestion): {e}"
+            )
+            return False

--- a/app/services/knowledge_base/retrieval.py
+++ b/app/services/knowledge_base/retrieval.py
@@ -29,9 +29,11 @@ from typing import List, Optional, Tuple
 from app.core.logger import logger
 from app.database.accessor.breeze_buddy.knowledge_base import (
     get_kb_full_text_rows,
+    get_kb_tab_rows,
     get_kb_token_total,
     get_knowledge_base_by_id,
     hybrid_search_chunks,
+    list_kb_tab_names,
 )
 from app.schemas.breeze_buddy.knowledge_base import EmbeddingConfig, RetrievedChunk
 from app.services.embeddings import get_embedding_provider
@@ -39,6 +41,14 @@ from app.services.redis import get_redis_service
 
 _FULL_TEXT_CACHE_TTL_SECONDS = 3600
 _TOKEN_TOTAL_CACHE_TTL_SECONDS = 3600
+_TAB_TEXT_CACHE_TTL_SECONDS = 3600
+_TAB_LIST_CACHE_TTL_SECONDS = 3600
+# Upper bound on a single tab's text handed to the LLM in one tool result.
+# ~8k tokens at ~4 chars/token — a tab can be up to MAX_SHEET_ROWS (10k) rows,
+# which would otherwise blow context/cost/latency in a single call. Over the
+# cap we truncate and flag it (get_full_kb_text refuses instead, but that path
+# is a boot-time whole-KB inject, not an on-demand fetch).
+_TAB_TEXT_MAX_CHARS = 32_000
 
 
 def _normalize_query(query: str) -> str:
@@ -217,3 +227,83 @@ async def get_full_kb_text(
         except Exception:
             pass
     return text, tokens
+
+
+async def get_kb_tab_text(kb_ids: List[str], tab_name: str) -> Tuple[str, bool]:
+    """Concatenated READY chunk text for one sheet tab, cached.
+
+    Returns ``(text, truncated)``. ``text`` is capped at
+    ``_TAB_TEXT_MAX_CHARS`` so a large tab (up to MAX_SHEET_ROWS rows) can't
+    dump tens of thousands of tokens into the LLM in a single tool result —
+    the same concern get_full_kb_text guards with ``max_tokens``, except a
+    tab is fetched on demand so we truncate rather than refuse. ``truncated``
+    tells the handler to warn the LLM to narrow the request.
+
+    Same version-stamped caching as get_full_kb_text — ingestion INCRs
+    kb:ver:{id} on every publish, so no explicit invalidation is needed
+    here; the cache key just becomes unreachable and expires via TTL.
+    """
+    if not kb_ids:
+        return "", False
+    versions = await _get_kb_versions(kb_ids)
+    cache_key = _versioned_key(f"kb:tab:{tab_name}", kb_ids, versions)
+
+    redis = None
+    try:
+        redis = await get_redis_service()
+        cached = await redis.get(cache_key)
+        if cached is not None:
+            payload = json.loads(cached)
+            return payload["text"], payload["truncated"]
+    except Exception:
+        redis = None
+
+    rows = await get_kb_tab_rows(kb_ids, tab_name)
+    sections: List[str] = []
+    current_doc = None
+    for document_name, chunk_text in rows:
+        if document_name != current_doc:
+            sections.append(f"\n### {document_name}\n")
+            current_doc = document_name
+        sections.append(chunk_text)
+    text = "\n".join(sections).strip()
+
+    truncated = len(text) > _TAB_TEXT_MAX_CHARS
+    if truncated:
+        text = text[:_TAB_TEXT_MAX_CHARS].rstrip()
+
+    if redis is not None:
+        try:
+            await redis.setex(
+                cache_key,
+                json.dumps({"text": text, "truncated": truncated}),
+                _TAB_TEXT_CACHE_TTL_SECONDS,
+            )
+        except Exception:
+            pass
+    return text, truncated
+
+
+async def list_kb_tabs(kb_ids: List[str]) -> List[str]:
+    """Distinct tab names available across these KBs, cached."""
+    if not kb_ids:
+        return []
+    versions = await _get_kb_versions(kb_ids)
+    cache_key = _versioned_key("kb:tabs", kb_ids, versions)
+
+    redis = None
+    try:
+        redis = await get_redis_service()
+        cached = await redis.get(cache_key)
+        if cached is not None:
+            return json.loads(cached)
+    except Exception:
+        redis = None
+
+    names = await list_kb_tab_names(kb_ids)
+    if redis is not None:
+        try:
+            await redis.setex(cache_key, json.dumps(names), _TAB_LIST_CACHE_TTL_SECONDS)
+        except Exception:
+            pass
+    return names

--- a/app/services/knowledge_base/sheets_poll.py
+++ b/app/services/knowledge_base/sheets_poll.py
@@ -1,0 +1,58 @@
+"""
+Scheduled Google Sheets freshness poller.
+
+Runs on the BackgroundTaskScheduler (distributed lock -> one pod per tick).
+For every READY google_sheet document past the debounce floor it does ONE
+cheap Drive ``files.get(modifiedTime)`` call; changed sheets are flipped back
+to PENDING and the ingestion worker re-reads them (chunk-hash diff re-embeds
+only edited rows). Merchants can always force it sooner with "Sync now".
+"""
+
+import asyncio
+
+from app.core.config.dynamic import (
+    KB_SHEETS_MIN_SYNC_INTERVAL_SECONDS,
+    KB_SHEETS_POLL_BATCH_SIZE,
+    KB_SHEETS_POLL_ENABLED,
+    KB_SHEETS_PROBE_SPACING_SECONDS,
+)
+from app.core.logger import logger
+from app.database.accessor.breeze_buddy.knowledge_base import (
+    get_sheet_documents_due_for_poll,
+    mark_kb_document_for_resync,
+)
+from app.services.knowledge_base.connectors import get_connector
+from app.services.knowledge_base.ingestion import kick_ingestion
+
+
+async def poll_sheet_documents() -> int:
+    """Probe connected sheets for changes; returns the number requeued."""
+    if not await KB_SHEETS_POLL_ENABLED():
+        return 0
+
+    min_age = await KB_SHEETS_MIN_SYNC_INTERVAL_SECONDS()
+    batch_size = await KB_SHEETS_POLL_BATCH_SIZE()
+    probe_spacing = await KB_SHEETS_PROBE_SPACING_SECONDS()
+    documents = await get_sheet_documents_due_for_poll(min_age, batch_size)
+    if not documents:
+        return 0
+
+    connector = get_connector("google_sheet")
+    changed = 0
+    for document in documents:
+        try:
+            if await connector.detect_change(document):
+                requeued = await mark_kb_document_for_resync(document.id)
+                if requeued is not None:
+                    changed += 1
+                    logger.info(
+                        f"Sheet document {document.id} ('{document.name}') "
+                        "changed at source; queued for re-sync"
+                    )
+        except Exception as e:
+            logger.warning(f"Sheets poll probe failed for document {document.id}: {e}")
+        await asyncio.sleep(probe_spacing)
+
+    if changed:
+        kick_ingestion()
+    return changed

--- a/docs/breeze_buddy/kb_tab_retrieval.md
+++ b/docs/breeze_buddy/kb_tab_retrieval.md
@@ -1,0 +1,226 @@
+# KB Tab Retrieval — What We Built and Why
+
+Companion to `docs/breeze_buddy/knowledge_base_overview.md` (read that first
+if you haven't). This describes the addition on branch `feat/kb-tab-retrieval`:
+two new builtin global functions, `get_tab_data` and `list_kb_tabs`, that let
+an LLM (or the custom-Python function calling it) pull the exact text of one
+already-ingested spreadsheet tab — no semantic search, no new tables, no
+second ingestion pipeline.
+
+## The problem this solves
+
+The KB's existing modes (`full_injection`, `auto_retrieve`, `tool`) all treat
+an ingested spreadsheet as an undifferentiated pool of row-chunks:
+`full_injection` dumps everything, `auto_retrieve`/`tool` semantically search
+across all rows regardless of which tab they came from. There was no way to
+say "give me exactly the Pricing tab's rows, deterministically, right now" —
+which is what you want when the conversation reaches a point where you know
+precisely which structured table is relevant (pricing, clinic directory,
+FAQ) and don't want to gamble on a similarity search picking the right rows.
+
+Two systems were considered and rejected before this one:
+
+- **PR #878** (`feat/data-sources-runtime-release`) — a parallel `data_source`
+  table, its own Google Sheets adapter, its own Redis cache, its own CRUD API.
+  Rejected because it duplicates everything the KB ingestion pipeline already
+  does (auth, fetch, cache, freshness) as a second system.
+- **This branch's own earlier `data_sources.py`** (on `feat/data-sources-on-demand-loading`)
+  — same problem, different shape: its own migration, its own connector
+  registry, its own `load_data_source` builtin.
+
+Both work by re-implementing "fetch a Google Sheet tab." This addition
+instead reads a tab straight out of data the KB **already ingested** — same
+`kb_chunk` table, same cache invalidation, same auth path, zero new storage.
+
+## How it works
+
+Every row-chunk from a Sheets ingestion already carries its source tab name:
+
+```python
+# chunking.py::chunk_table — already existed, unmodified by this work
+metadata = {"table": table.name, "row_key": f"{table.name}:{row_index}"}
+```
+
+So "give me the Pricing tab" is just: query `kb_chunk` filtered by
+`metadata->>'table' = 'Pricing'`, concatenate the READY rows in order, cache
+the result under the same version-stamped key scheme the KB already uses for
+`full_injection`. That's the whole mechanism — three thin layers cloned from
+existing code:
+
+```
+Template attaches a knowledge_base (as it does today)
+  │
+  LLM calls the builtin function  get_tab_data(tab_name="Pricing")
+  │
+  handlers/internal/kb_tab_data.py :: get_tab_data(context, args)
+  │   reads context.configurations.knowledge_base.knowledge_base_ids
+  │   (same field query_knowledge_base already reads)
+  │
+  services/knowledge_base/retrieval.py :: get_kb_tab_text(kb_ids, "Pricing")
+  │   version-stamped Redis cache (kb:tab:Pricing:<hash>), same pattern
+  │   as get_full_kb_text() — ingestion's existing INCR kb:ver:{id}
+  │   invalidates this for free, no new invalidation code
+  │   cache miss ↓
+  │
+  database/accessor/.../knowledge_base.py :: get_kb_tab_rows(kb_ids, "Pricing")
+  │   SELECT c.text, d.name FROM kb_chunk c JOIN kb_document d ...
+  │   WHERE c.kb_id = ANY($1) AND d.status = 'READY'
+  │     AND c.metadata->>'table' = $2
+  │   ORDER BY d.created_at, c.document_id, c.chunk_index
+  │
+  ↓
+  "### Health Companion Sheet\niPhone 15,$999\niPhone 16,$1099\n..."
+  returned to the LLM as the function-call result
+```
+
+`list_kb_tabs` is the same shape, one level up: `SELECT DISTINCT
+metadata->>'table' ...` — so the LLM (or your routing code) can discover
+valid tab names instead of guessing them and silently getting nothing back.
+
+## Files touched
+
+| Layer | File | What was added |
+|---|---|---|
+| Query | `app/database/queries/breeze_buddy/knowledge_base.py` | `get_kb_tab_rows_query`, `list_kb_tab_names_query` |
+| Accessor | `app/database/accessor/breeze_buddy/knowledge_base.py` | `get_kb_tab_rows`, `list_kb_tab_names` |
+| Retrieval/cache | `app/services/knowledge_base/retrieval.py` | `get_kb_tab_text`, `list_kb_tabs` |
+| Handlers | `app/ai/voice/agents/breeze_buddy/handlers/internal/kb_tab_data.py` (new) | `get_tab_data`, `list_tabs` |
+| Registration | `.../handlers/internal/builtin_dispatcher.py` | `BUILTIN_HANDLERS["get_tab_data"]`, `["list_kb_tabs"]` |
+
+Zero new migrations, zero new Pydantic config fields, zero new API routes —
+everything is authored directly in template JSON like any other builtin
+function. 16 new tests across the four layers, all passing; full suite
+(603 tests) green with no regressions.
+
+## Example: template configuration
+
+Attach a knowledge base as usual, then declare the two functions on whatever
+node(s) need them — exactly like adding `query_knowledge_base` or any other
+builtin:
+
+```json
+{
+  "configurations": {
+    "knowledge_base": {
+      "enabled": true,
+      "knowledge_base_ids": ["3f9a1c2e-...-a1b2"],
+      "mode": "tool"
+    }
+  },
+  "flow": {
+    "nodes": {
+      "pricing_inquiry": {
+        "task_messages": [
+          {"role": "system", "content": "Help the caller with pricing questions. Use get_tab_data to look up the current price list before answering; call list_kb_tabs first if you're unsure of the exact tab name."}
+        ],
+        "functions": [
+          {
+            "type": "builtin",
+            "name": "get_pricing_tab",
+            "handler": "get_tab_data",
+            "description": "Fetch the current pricing table as CSV-style text.",
+            "properties": {
+              "tab_name": {
+                "type": "string",
+                "description": "Exact tab name, e.g. 'Pricing'."
+              }
+            },
+            "required": ["tab_name"]
+          },
+          {
+            "type": "builtin",
+            "name": "list_kb_tabs",
+            "handler": "list_kb_tabs",
+            "description": "List the data tab names available in the knowledge base."
+          }
+        ]
+      }
+    }
+  }
+}
+```
+
+**On `mode`:** `get_tab_data`/`list_kb_tabs` only need the KB *attached*
+(`enabled` + `knowledge_base_ids`) — they ignore `mode` entirely, so any mode
+works, and they're available in both voice and chat (neither is in
+`CHAT_DISABLED_NAMES`). `mode: "tool"` is the natural pairing (the KB isn't
+auto-injected; the LLM pulls exactly the tab it needs), which is why the
+example uses it. Avoid pairing them with `full_injection` — or `auto` on a
+small KB that resolves to full injection — because there the whole KB is
+already in the prompt, so a `get_tab_data` call just re-hands the model a tab
+it already has.
+
+## Example: what the LLM actually sees
+
+Turn 1 — caller asks about price, LLM doesn't know the exact tab name yet:
+
+```
+LLM calls: list_kb_tabs()
+→ {"status": "success", "tabs": ["Overview", "Pricing", "Clinic Directory"]}
+
+LLM calls: get_pricing_tab(tab_name="Pricing")
+→ {
+    "status": "success",
+    "tab_name": "Pricing",
+    "content": "### Health Companion Sheet\niPhone 15 — Price: $999\niPhone 16 — Price: $1099\n..."
+  }
+
+LLM: "The iPhone 15 is $999 and the iPhone 16 is $1099."
+```
+
+A tab name that doesn't exist (typo, or the sheet hasn't been ingested with
+that tab yet) fails closed but informatively, not silently:
+
+```
+LLM calls: get_pricing_tab(tab_name="Pricng")
+→ {
+    "status": "not_found",
+    "message": "No tab named 'Pricng' was found. Call list_kb_tabs to see available tab names."
+  }
+```
+
+A DB/Redis hiccup fails open the same way every other KB path does — the
+call keeps going, the LLM just doesn't get that tab this turn:
+
+```
+→ {"status": "error", "message": "Tab lookup timed out; answer without it or tell the user you could not check."}
+```
+
+## Example: manual end-to-end verification
+
+1. Create a KB, ingest a Google Sheet that has a "Pricing" tab (existing KB
+   sheets connector — nothing new here).
+2. Attach the KB to a test template with the JSON above.
+3. Run a chat turn: `POST /breeze-buddy/chat/message` with something like
+   "how much is the iPhone 15" for that template/session.
+4. Confirm in logs: `[get_tab_data] loaded tab 'Pricing' for call ... (N chars)`,
+   and the assistant's reply reflects the sheet's actual price.
+5. Edit the sheet's Pricing tab, wait for `kb_sheets_poll` to pick up the
+   change (or trigger `POST .../documents/{id}/sync` manually), re-ask —
+   confirm the answer reflects the new price (proves the shared version-stamp
+   cache invalidation works without any new code for it).
+
+## What's intentionally not handled (v1 scope)
+
+- **Large tabs are truncated, not paginated**: `get_kb_tab_text` caps its
+  result at `_TAB_TEXT_MAX_CHARS` (~32K chars ≈ 8K tokens) so a tab of up to
+  `MAX_SHEET_ROWS` (10K) rows can't dump tens of thousands of tokens into the
+  LLM in one tool result. Over the cap, the first portion is returned with
+  `truncated: true` and a note telling the LLM to ask the user to narrow the
+  request. There's no cursor/offset to page through the rest — if you
+  routinely need whole large tabs, that's a `query_knowledge_base` (semantic)
+  job, not a `get_tab_data` one.
+- **Multi-document tab-name collisions**: if a KB ingests two sheets that
+  each have a tab called "Pricing," both get concatenated under one
+  `get_tab_data(tab_name="Pricing")` call. Fine for one-sheet-per-KB, which
+  is the assumed setup; add a `document_id`/`source` disambiguator later if
+  that assumption breaks.
+- **No index on `kb_chunk.metadata`**: the tab filter still narrows by
+  `kb_id` first via the existing index, so this is a bounded scan (≤25K
+  chunks per KB, the existing ingestion quota), not a full-table scan. Add a
+  functional index if this becomes measurably hot.
+- **Freshness is ingestion-paced, not live**: a tab's content is only as
+  fresh as the last successful re-ingestion (`kb_sheets_poll`, 15 min default
+  + 5 min debounce, or a manual re-sync). This is consistent with how the
+  rest of KB already behaves — not a new constraint introduced here — but
+  worth knowing if a tab like live pricing needs faster refresh than that.

--- a/docs/breeze_buddy/knowledge_base_overview.md
+++ b/docs/breeze_buddy/knowledge_base_overview.md
@@ -1,0 +1,142 @@
+# Knowledge Base (RAG) — How It Works
+
+This describes the existing pgvector-backed Knowledge Base system (three merged
+commits: `feat: knowledge base core`, `feat: knowledge base runtime`, plus the
+Google Sheets connector on `feat/knowledge-base-sheets`). It is the
+"embedding/RAG" system that templates attach via `configurations.knowledge_base`.
+Everything in this doc already exists on `upstream/release` — nothing here was
+built by this plan; it's the foundation the tab-retrieval addition (see
+`docs/breeze_buddy/kb_tab_retrieval.md`) builds on top of.
+
+## The shape of it
+
+A merchant-scoped **Knowledge Base** holds one or more **documents** (a file
+upload or a Google Sheet). Each document is split into **chunks** — for prose,
+heading-aware ~450-token chunks; for a spreadsheet, **one chunk per row**, with
+the tab name and column headers folded into the chunk text and metadata.
+Chunks are embedded and stored in Postgres with pgvector.
+
+```
+knowledge_base          (merchant/reseller-scoped entity)
+  └── kb_document        (one row per uploaded file or ingested Sheet tab range)
+        └── kb_chunk     (embedded rows/paragraphs; halfvec(768) + tsvector + trigram)
+```
+
+Migration: `app/database/migrations/034_knowledge_base.sql`.
+
+## Ingestion pipeline
+
+```
+Upload / Sync
+  → kb_document row inserted, status = PENDING
+  → scheduler task claims it (FOR UPDATE SKIP LOCKED, batched)
+  → connector.load()          — FileConnector or GoogleSheetsConnector
+  → build_chunks()            — chunking.py: prose or table rows
+  → hash-diff (SHA-256 per chunk) — only re-embed what actually changed
+  → embed changed chunks, upsert into kb_chunk
+  → status = READY
+  → bump_kb_version()         — INCR kb:ver:{kb_id} in Redis
+```
+
+Code: `app/services/knowledge_base/ingestion.py`, `chunking.py`,
+`connectors/{base,file_upload,google_sheets}.py`.
+
+**Why chunk hashing matters**: a 1,000-row sheet where 3 rows changed
+re-embeds only those 3 chunks — not the whole document. This is a real cost
+control, not an optimization detail; embedding calls are the expensive part
+of ingestion.
+
+**Sheets freshness**: `kb_sheets_poll` (a `BackgroundTaskScheduler` task)
+probes each ingested sheet's Drive `modifiedTime` on an interval (15 min
+default, 5 min debounce) and requeues the document to PENDING if it changed.
+There's also a manual `POST .../documents/{id}/sync` for "sync now."
+
+## What a chunk actually looks like
+
+For a spreadsheet row, `chunking.py::chunk_table` builds:
+
+```python
+text = f"{table.name} — col1: val1 | col2: val2 | ..."
+metadata = {"table": table.name, "row_key": f"{table.name}:{row_index}"}
+```
+
+So **every row-chunk carries its source tab name in `metadata.table`**. This
+one fact is the entire basis for the tab-retrieval addition — the data
+needed for deterministic "give me this tab's rows" was already there, just
+never queried that way.
+
+## Retrieval — four ways the LLM sees KB content
+
+Set per-template via `configurations.knowledge_base.mode`
+(`KnowledgeBaseConfig` in `template/types.py`):
+
+| Mode | Mechanism | When content reaches the LLM |
+|---|---|---|
+| `full_injection` | Whole KB text concatenated into the initial node's `role_messages`, fetched at call boot | Always in context from turn 1 |
+| `auto_retrieve` | `KnowledgeRetrievalProcessor` (a Pipecat frame processor) runs hybrid search per user turn, injects a transient system message that **replaces** (not accumulates) the previous one | Per-turn, LLM never sees it as a tool call |
+| `tool` | LLM explicitly calls the builtin `query_knowledge_base(query)` function | Only when the LLM decides to ask |
+| `auto` (default) | Resolves to `full_injection` if the KB is small enough (`full_injection_token_threshold`), else `auto_retrieve` | Decided once, at boot |
+
+Realtime speech-to-speech LLMs can't do mid-stream tool calls or injected
+system messages reliably, so they're restricted to `full_injection` and
+`tool` (`validate_template_compat` enforces this).
+
+## Hybrid retrieval — the actual search
+
+`app/services/knowledge_base/retrieval.py::retrieve()` is one SQL round trip
+that fuses three signals with Reciprocal Rank Fusion:
+
+| Leg | Index | Catches |
+|---|---|---|
+| Vector KNN | HNSW, `halfvec_cosine_ops` | Semantic similarity |
+| Full-text search | GIN, `tsvector` | Exact keyword matches |
+| Trigram | GIN, `gin_trgm_ops` | Typos, partial SKU matches |
+
+`score = Σ 1/(60 + rank_leg)` across whichever legs matched a chunk. Only
+`READY` chunks are ever served — chunks mid-re-embed or in an ERROR state are
+invisible to retrieval.
+
+Callers own their own timeout and **always fail open**: voice budgets ~0.4s,
+chat ~1s, tool mode ~5s. A KB miss or timeout means the LLM answers without
+that context, not that the call breaks.
+
+## The version-stamped cache — why it needs no invalidation logic
+
+`get_full_kb_text()` and `get_kb_token_count()` cache their results in Redis
+under a key that embeds the KB's current version counter:
+
+```python
+versions = [redis.get(f"kb:ver:{kb_id}") for kb_id in kb_ids]
+cache_key = f"{prefix}:{sha1(kb_ids + versions)}"
+```
+
+Ingestion does `INCR kb:ver:{kb_id}` on every successful publish. That's the
+entire invalidation mechanism — old cache keys aren't deleted, they just
+become unreachable once the version moves, and expire on their own via TTL.
+No `SCAN`/pattern-delete, no explicit cache-bust call anywhere in the
+ingestion path. This pattern is reused as-is by the tab-retrieval addition.
+
+## Key files
+
+| File | Role |
+|---|---|
+| `app/database/migrations/034_knowledge_base.sql` | Schema: 3 tables, HNSW + GIN indexes |
+| `app/services/knowledge_base/ingestion.py` | PENDING → READY pipeline |
+| `app/services/knowledge_base/chunking.py` | Prose + table chunking, hash-diff |
+| `app/services/knowledge_base/connectors/` | `FileConnector`, `GoogleSheetsConnector` |
+| `app/services/knowledge_base/retrieval.py` | `retrieve()`, `get_full_kb_text()`, `get_kb_token_count()` |
+| `app/database/accessor/breeze_buddy/knowledge_base.py` | DB access layer |
+| `app/database/queries/breeze_buddy/knowledge_base.py` | Raw parameterized SQL builders |
+| `app/ai/voice/agents/breeze_buddy/processors/knowledge_retrieval.py` | `KnowledgeRetrievalProcessor` (auto_retrieve mode) |
+| `app/ai/voice/agents/breeze_buddy/handlers/internal/query_knowledge_base.py` | `query_knowledge_base` builtin (tool mode) |
+| `app/ai/voice/agents/breeze_buddy/template/types.py` | `KnowledgeBaseConfig` |
+
+## What this system deliberately does not do
+
+- No tab-scoped retrieval — `full_injection`/`auto_retrieve`/`tool` all treat
+  a spreadsheet as an undifferentiated pool of row-chunks to search or dump.
+  There was no way to say "give me exactly the Pricing tab" — that's the gap
+  `kb_tab_retrieval.md` closes.
+- No separate "data source" abstraction — Sheets and files are both just
+  `kb_document`s. Anything ingested becomes chunks; there's no raw-fetch path
+  that bypasses ingestion.

--- a/tests/test_kb_chunking.py
+++ b/tests/test_kb_chunking.py
@@ -1,0 +1,110 @@
+"""Tests for chunk_table's handling of blank/missing header rows.
+
+Regression coverage for a live-discovered bug: a sheet tab whose header row
+is empty (or whitespace-only, e.g. a single space cell) produced ZERO
+chunks — every real data row was silently discarded, even when the rows
+themselves held real content. Root cause: chunk_table paired headers/cells
+with `zip()`, which yields nothing when `headers` is empty, and the
+downstream `if header and cell` filter dropped every cell whose header
+column was blank. Both combined to make row content vanish silently
+whenever a header cell was missing, with no warning anywhere.
+"""
+
+from app.services.knowledge_base.chunking import chunk_table
+from app.services.knowledge_base.types import TableData
+
+
+def test_blank_header_row_still_produces_chunks_from_real_data():
+    """headers=[] (fully empty first row) must not discard the data rows."""
+    table = TableData(
+        name="INF-001",
+        headers=[],
+        rows=[
+            ["Protocol ID", "INF-001"],
+            ["Condition", "Fever"],
+        ],
+    )
+    chunks = chunk_table(table)
+
+    row_chunks = [c for c in chunks if not c.metadata.get("summary")]
+    assert len(row_chunks) == 2
+    assert any("Protocol ID" in c.text and "INF-001" in c.text for c in row_chunks)
+    assert any("Condition" in c.text and "Fever" in c.text for c in row_chunks)
+    # every chunk still carries the table tag get_tab_data depends on
+    assert all(c.metadata.get("table") == "INF-001" for c in row_chunks)
+
+
+def test_whitespace_only_header_still_produces_chunks_from_real_data():
+    """A header cell that's just whitespace (e.g. '  ') strips to empty and
+    must be treated the same as a fully blank header, not silently dropped."""
+    table = TableData(
+        name="RESP-001",
+        headers=["  "],
+        rows=[["Cough for 3 days"], ["No fever reported"]],
+    )
+    chunks = chunk_table(table)
+
+    row_chunks = [c for c in chunks if not c.metadata.get("summary")]
+    assert len(row_chunks) == 2
+    assert any("Cough for 3 days" in c.text for c in row_chunks)
+
+
+def test_mixed_headers_some_blank_some_real_keeps_all_cells():
+    """A row with a real header for column 1 but a blank header for column 2
+    must keep both cells — the labeled one formatted, the unlabeled one bare."""
+    table = TableData(
+        name="Mixed",
+        headers=["Field", ""],
+        rows=[["Priority", "High"]],
+    )
+    chunks = chunk_table(table)
+
+    row_chunks = [c for c in chunks if not c.metadata.get("summary")]
+    assert len(row_chunks) == 1
+    text = row_chunks[0].text
+    assert "Field: Priority" in text
+    assert "High" in text
+
+
+def test_normal_header_row_unchanged():
+    """Existing, healthy tabs must format exactly as before this fix."""
+    table = TableData(
+        name="GI-001",
+        headers=["PROTOCOL OVERVIEW"],
+        rows=[["Protocol ID"], ["Condition"]],
+    )
+    chunks = chunk_table(table)
+
+    row_chunks = [c for c in chunks if not c.metadata.get("summary")]
+    assert len(row_chunks) == 2
+    assert row_chunks[0].text == "GI-001 — PROTOCOL OVERVIEW: Protocol ID"
+
+
+def test_summary_chunk_still_emitted_when_headers_are_blank():
+    """The tab-summary chunk (used by list_kb_tabs discovery) must not
+    silently disappear just because the header row happens to be blank."""
+    table = TableData(
+        name="INF-001",
+        headers=[],
+        rows=[["Protocol ID", "INF-001"]],
+    )
+    chunks = chunk_table(table)
+
+    summary_chunks = [c for c in chunks if c.metadata.get("summary")]
+    assert len(summary_chunks) == 1
+    assert "INF-001" in summary_chunks[0].text
+
+
+def test_fully_empty_row_still_skipped():
+    """A genuinely empty row (all cells blank) must still be skipped —
+    this fix is about blank HEADERS, not about resurrecting blank ROWS."""
+    table = TableData(
+        name="T",
+        headers=[],
+        rows=[["", ""], ["Real value", ""]],
+    )
+    chunks = chunk_table(table)
+
+    row_chunks = [c for c in chunks if not c.metadata.get("summary")]
+    assert len(row_chunks) == 1
+    assert "Real value" in row_chunks[0].text

--- a/tests/test_kb_rbac_reseller_read.py
+++ b/tests/test_kb_rbac_reseller_read.py
@@ -1,0 +1,83 @@
+"""Regression test for a live-discovered RBAC bug: validate_kb_access (used
+by GET/query/list/download) had no reseller-role bypass, while
+require_kb_write_access (used by upload/connect/delete) already did. A
+reseller-role user could write to any KB under their own reseller but
+could not even read it — backwards from intent, confirmed live via a
+minted reseller-scoped token against a real merchant-owned KB.
+"""
+
+from types import SimpleNamespace
+from typing import List, Optional, cast
+
+import pytest
+from fastapi import HTTPException
+
+from app.api.routers.breeze_buddy.knowledge_base.rbac import validate_kb_access
+from app.schemas import UserInfo
+
+
+def _reseller_user(
+    reseller_ids: List[str], merchant_ids: Optional[List[str]] = None
+) -> UserInfo:
+    return cast(
+        UserInfo,
+        SimpleNamespace(
+            username="e2e-reseller",
+            role="reseller",
+            reseller_ids=reseller_ids,
+            merchant_ids=merchant_ids or [],
+        ),
+    )
+
+
+def test_reseller_can_read_a_merchant_owned_kb_under_their_own_reseller():
+    """The exact scenario that failed live: reseller owns 'purvanchal-reseller',
+    KB belongs to merchant 'prayagraj_admin' under that reseller, reseller's
+    own merchant_ids is empty (correct for a pure reseller-role token)."""
+    user = _reseller_user(reseller_ids=["purvanchal-reseller"], merchant_ids=[])
+    # Must not raise.
+    validate_kb_access(user, "purvanchal-reseller", "prayagraj_admin", "read")
+
+
+def test_reseller_can_read_a_sibling_merchants_kb_under_same_reseller():
+    user = _reseller_user(reseller_ids=["purvanchal-reseller"], merchant_ids=[])
+    validate_kb_access(user, "purvanchal-reseller", "mirzapur", "read")
+
+
+def test_reseller_can_read_a_reseller_level_kb_with_no_merchant():
+    user = _reseller_user(reseller_ids=["purvanchal-reseller"], merchant_ids=[])
+    validate_kb_access(user, "purvanchal-reseller", None, "read")
+
+
+def test_reseller_still_blocked_from_a_different_reseller():
+    user = _reseller_user(reseller_ids=["purvanchal-reseller"], merchant_ids=[])
+    with pytest.raises(HTTPException) as exc_info:
+        validate_kb_access(user, "some-other-reseller", "some-merchant", "read")
+    assert exc_info.value.status_code == 403
+
+
+def test_merchant_role_still_blocked_from_sibling_merchant_kb():
+    """Non-reseller roles must NOT get this bypass — merchant-role users stay
+    scoped to their own merchant, exactly as before this fix."""
+    user = cast(
+        UserInfo,
+        SimpleNamespace(
+            username="e2e-merchant",
+            role="merchant",
+            reseller_ids=["purvanchal-reseller"],
+            merchant_ids=["mirzapur"],
+        ),
+    )
+    with pytest.raises(HTTPException) as exc_info:
+        validate_kb_access(user, "purvanchal-reseller", "prayagraj_admin", "read")
+    assert exc_info.value.status_code == 403
+
+
+def test_admin_still_bypasses_everything():
+    user = cast(
+        UserInfo,
+        SimpleNamespace(
+            username="e2e-admin", role="admin", reseller_ids=[], merchant_ids=[]
+        ),
+    )
+    validate_kb_access(user, "any-reseller", "any-merchant", "read")

--- a/tests/test_kb_sheets_credentials_fallback.py
+++ b/tests/test_kb_sheets_credentials_fallback.py
@@ -1,0 +1,33 @@
+"""Regression test: the Sheets connector's credentials source.
+
+Was a GOOGLE_SHEETS_SA_CREDENTIALS_JSON -> GCS_CREDENTIALS_JSON fallback
+chain requiring a dedicated, Sheets-only credentials var. Simplified to use
+the platform's existing general-purpose GOOGLE_CREDENTIALS_JSON directly
+(already used by Google/Gemini TTS and STT) -- no separate var to
+provision just to enable Sheets sync.
+"""
+
+import json
+
+import pytest
+
+from app.services.knowledge_base.connectors import google_sheets
+
+
+def test_uses_google_credentials_json(monkeypatch):
+    monkeypatch.setattr(
+        google_sheets,
+        "GOOGLE_CREDENTIALS_JSON",
+        json.dumps({"client_email": "sa@project.iam.gserviceaccount.com"}),
+    )
+
+    info = google_sheets._credentials_info()
+
+    assert info["client_email"] == "sa@project.iam.gserviceaccount.com"
+
+
+def test_raises_when_google_credentials_json_is_unset(monkeypatch):
+    monkeypatch.setattr(google_sheets, "GOOGLE_CREDENTIALS_JSON", "")
+
+    with pytest.raises(ValueError, match="GOOGLE_CREDENTIALS_JSON"):
+        google_sheets._credentials_info()

--- a/tests/test_kb_sheets_poll_batching.py
+++ b/tests/test_kb_sheets_poll_batching.py
@@ -1,0 +1,36 @@
+"""Regression test for a review finding (murdore, PR #896): the sheets
+poller's probe pacing was 4x over its own documented Drive quota, and the
+due-poll query had no batch bound, so a large backlog of connected sheets
+would be probed serially in a single tick with unbounded wall-clock and
+quota burn.
+"""
+
+import asyncio
+
+from app.core.config.dynamic import KB_SHEETS_PROBE_SPACING_SECONDS
+from app.database.queries.breeze_buddy.knowledge_base import (
+    get_sheet_documents_due_for_poll_query,
+)
+
+
+def test_probe_spacing_default_matches_documented_drive_quota():
+    """Quota is 60 read req/min/user; spacing must not exceed that rate."""
+    spacing = asyncio.run(KB_SHEETS_PROBE_SPACING_SECONDS())
+    requests_per_minute = 60 / spacing
+    assert requests_per_minute <= 60
+
+
+def test_due_for_poll_query_is_bounded_by_batch_size():
+    text, values = get_sheet_documents_due_for_poll_query(300, 50)
+
+    assert "LIMIT" in text
+    assert values == [300, 50]
+
+
+def test_due_for_poll_query_orders_oldest_synced_first():
+    """Bounding by LIMIT only drains fairly if the same stale tail isn't
+    starved every tick -- oldest-synced-first guarantees that."""
+    text, _ = get_sheet_documents_due_for_poll_query(300, 50)
+
+    assert 'ORDER BY "synced_at" NULLS FIRST' in text
+    assert text.index('ORDER BY "synced_at"') < text.index("LIMIT")

--- a/tests/test_kb_sheets_review_fixes.py
+++ b/tests/test_kb_sheets_review_fixes.py
@@ -1,0 +1,70 @@
+"""Regression tests for the PR-review fixes on the Google Sheets connector.
+
+The detect_change tests are the important ones: a transient Drive failure
+must NOT requeue the document, because a requeue flips it to PENDING and
+retrieval serves READY documents only — i.e. a Google incident would blank
+out otherwise-healthy KB content for every attached agent.
+"""
+
+import datetime
+from types import SimpleNamespace
+from typing import cast
+from unittest.mock import AsyncMock, patch
+
+from app.schemas.breeze_buddy.knowledge_base import KbDocument
+from app.services.knowledge_base.connectors.google_sheets import GoogleSheetsConnector
+
+_SYNCED_AT = datetime.datetime(2026, 7, 1, tzinfo=datetime.timezone.utc)
+
+
+def _doc() -> KbDocument:
+    return cast(
+        KbDocument,
+        SimpleNamespace(
+            id="doc-1",
+            source_ref={"spreadsheet_id": "sheet-abc"},
+            synced_at=_SYNCED_AT,
+        ),
+    )
+
+
+async def test_transient_failure_reports_unchanged_keeping_last_good_ingestion():
+    """429/5xx/network -> RuntimeError -> must NOT requeue (would blank the KB)."""
+    with patch(
+        "app.services.knowledge_base.connectors.google_sheets._api_get",
+        new=AsyncMock(side_effect=RuntimeError("rate limit hit (429)")),
+    ):
+        changed = await GoogleSheetsConnector().detect_change(_doc())
+
+    assert changed is False
+
+
+async def test_user_fixable_failure_reports_changed_so_the_reread_records_it():
+    """403/404 -> ValueError -> requeue, so the error lands on the document row."""
+    with patch(
+        "app.services.knowledge_base.connectors.google_sheets._api_get",
+        new=AsyncMock(side_effect=ValueError("Access denied. Share the sheet...")),
+    ):
+        changed = await GoogleSheetsConnector().detect_change(_doc())
+
+    assert changed is True
+
+
+async def test_modified_after_sync_reports_changed():
+    with patch(
+        "app.services.knowledge_base.connectors.google_sheets._api_get",
+        new=AsyncMock(return_value={"modifiedTime": "2026-07-02T00:00:00Z"}),
+    ):
+        changed = await GoogleSheetsConnector().detect_change(_doc())
+
+    assert changed is True
+
+
+async def test_modified_before_sync_reports_unchanged():
+    with patch(
+        "app.services.knowledge_base.connectors.google_sheets._api_get",
+        new=AsyncMock(return_value={"modifiedTime": "2026-06-30T00:00:00Z"}),
+    ):
+        changed = await GoogleSheetsConnector().detect_change(_doc())
+
+    assert changed is False

--- a/tests/test_kb_tab_accessor.py
+++ b/tests/test_kb_tab_accessor.py
@@ -1,0 +1,47 @@
+"""Accessor tests with run_parameterized_query mocked — no live DB."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.database.accessor.breeze_buddy.knowledge_base import (
+    get_kb_tab_rows,
+    list_kb_tab_names,
+)
+
+
+async def test_get_kb_tab_rows_returns_document_name_text_pairs():
+    fake_rows = [
+        {"document_name": "Health Companion Sheet", "text": "row1 text"},
+        {"document_name": "Health Companion Sheet", "text": "row2 text"},
+    ]
+    with patch(
+        "app.database.accessor.breeze_buddy.knowledge_base.run_parameterized_query",
+        new=AsyncMock(return_value=fake_rows),
+    ):
+        result = await get_kb_tab_rows(["kb-1"], "Pricing")
+
+    assert result == [
+        ("Health Companion Sheet", "row1 text"),
+        ("Health Companion Sheet", "row2 text"),
+    ]
+
+
+async def test_get_kb_tab_rows_logs_and_reraises_on_error():
+    with patch(
+        "app.database.accessor.breeze_buddy.knowledge_base.run_parameterized_query",
+        new=AsyncMock(side_effect=RuntimeError("db down")),
+    ):
+        with pytest.raises(RuntimeError, match="db down"):
+            await get_kb_tab_rows(["kb-1"], "Pricing")
+
+
+async def test_list_kb_tab_names_returns_flat_list():
+    fake_rows = [{"table_name": "Pricing"}, {"table_name": "Clinics"}]
+    with patch(
+        "app.database.accessor.breeze_buddy.knowledge_base.run_parameterized_query",
+        new=AsyncMock(return_value=fake_rows),
+    ):
+        result = await list_kb_tab_names(["kb-1"])
+
+    assert result == ["Pricing", "Clinics"]

--- a/tests/test_kb_tab_handlers.py
+++ b/tests/test_kb_tab_handlers.py
@@ -1,0 +1,140 @@
+"""Handler tests — retrieval layer mocked, TemplateContext stubbed."""
+
+from types import SimpleNamespace
+from typing import List, cast
+from unittest.mock import AsyncMock, patch
+
+from app.ai.voice.agents.breeze_buddy.handlers.internal.kb_tab_data import (
+    get_tab_data,
+    list_tabs,
+)
+from app.ai.voice.agents.breeze_buddy.services.knowledge_base import (
+    DEFAULT_KB_INSTRUCTION,
+)
+from app.ai.voice.agents.breeze_buddy.template.context import TemplateContext
+
+
+def _context_with_kb(
+    kb_ids: List[str], enabled: bool = True, injection_instruction=None
+) -> TemplateContext:
+    kb_config = SimpleNamespace(
+        enabled=enabled,
+        knowledge_base_ids=kb_ids,
+        injection_instruction=injection_instruction,
+    )
+    configurations = SimpleNamespace(knowledge_base=kb_config)
+    return cast(
+        TemplateContext,
+        SimpleNamespace(configurations=configurations, call_sid="CA123"),
+    )
+
+
+def _context_without_kb() -> TemplateContext:
+    configurations = SimpleNamespace(knowledge_base=None)
+    return cast(
+        TemplateContext,
+        SimpleNamespace(configurations=configurations, call_sid="CA123"),
+    )
+
+
+async def test_get_tab_data_errors_when_no_kb_attached():
+    result = await get_tab_data(_context_without_kb(), {"tab_name": "Pricing"})
+    assert result["status"] == "error"
+    assert "No knowledge base" in result["message"]
+
+
+async def test_get_tab_data_errors_when_tab_name_missing():
+    result = await get_tab_data(_context_with_kb(["kb-1"]), {})
+    assert result["status"] == "error"
+    assert "tab_name" in result["message"]
+
+
+async def test_get_tab_data_returns_content_on_success():
+    with patch(
+        "app.ai.voice.agents.breeze_buddy.handlers.internal.kb_tab_data.get_kb_tab_text",
+        new=AsyncMock(return_value=("iPhone 15,$999", False)),
+    ):
+        result = await get_tab_data(_context_with_kb(["kb-1"]), {"tab_name": "Pricing"})
+
+    assert result["status"] == "success"
+    assert result["content"] == "iPhone 15,$999"
+    assert "truncated" not in result
+    assert result["instruction"] == DEFAULT_KB_INSTRUCTION
+
+
+async def test_get_tab_data_uses_templates_custom_injection_instruction():
+    """Same untrusted-data framing query_knowledge_base already returns —
+    the LLM must be told to treat tab content as reference material, not
+    instructions, and a template-level override must win over the default."""
+    with patch(
+        "app.ai.voice.agents.breeze_buddy.handlers.internal.kb_tab_data.get_kb_tab_text",
+        new=AsyncMock(return_value=("iPhone 15,$999", False)),
+    ):
+        result = await get_tab_data(
+            _context_with_kb(["kb-1"], injection_instruction="Answer in Hindi only."),
+            {"tab_name": "Pricing"},
+        )
+
+    assert result["instruction"] == "Answer in Hindi only."
+
+
+async def test_get_tab_data_surfaces_truncation_notice():
+    with patch(
+        "app.ai.voice.agents.breeze_buddy.handlers.internal.kb_tab_data.get_kb_tab_text",
+        new=AsyncMock(return_value=("first part of a big tab", True)),
+    ):
+        result = await get_tab_data(_context_with_kb(["kb-1"]), {"tab_name": "Big"})
+
+    assert result["status"] == "success"
+    assert result["truncated"] is True
+    assert "narrow" in result["message"]
+
+
+async def test_get_tab_data_reports_empty_tab_as_not_found():
+    with patch(
+        "app.ai.voice.agents.breeze_buddy.handlers.internal.kb_tab_data.get_kb_tab_text",
+        new=AsyncMock(return_value=("", False)),
+    ):
+        result = await get_tab_data(
+            _context_with_kb(["kb-1"]), {"tab_name": "Nonexistent"}
+        )
+
+    assert result["status"] == "not_found"
+
+
+async def test_get_tab_data_fails_open_on_timeout():
+    async def _hang(*args, **kwargs):
+        import asyncio
+
+        await asyncio.sleep(10)
+
+    with (
+        patch(
+            "app.ai.voice.agents.breeze_buddy.handlers.internal.kb_tab_data.get_kb_tab_text",
+            new=_hang,
+        ),
+        patch(
+            "app.ai.voice.agents.breeze_buddy.handlers.internal.kb_tab_data._TAB_FETCH_TIMEOUT_SECS",
+            0.01,
+        ),
+    ):
+        result = await get_tab_data(_context_with_kb(["kb-1"]), {"tab_name": "Pricing"})
+
+    assert result["status"] == "error"
+    assert "timed out" in result["message"]
+
+
+async def test_list_tabs_returns_names():
+    with patch(
+        "app.ai.voice.agents.breeze_buddy.handlers.internal.kb_tab_data.list_kb_tabs",
+        new=AsyncMock(return_value=["Pricing", "Clinics"]),
+    ):
+        result = await list_tabs(_context_with_kb(["kb-1"]), {})
+
+    assert result["status"] == "success"
+    assert result["tabs"] == ["Pricing", "Clinics"]
+
+
+async def test_list_tabs_errors_when_no_kb_attached():
+    result = await list_tabs(_context_without_kb(), {})
+    assert result["status"] == "error"

--- a/tests/test_kb_tab_queries.py
+++ b/tests/test_kb_tab_queries.py
@@ -1,0 +1,45 @@
+"""Pure unit tests for the KB tab-scoped query builders — no DB needed."""
+
+from app.database.queries.breeze_buddy.knowledge_base import (
+    get_kb_tab_rows_query,
+    list_kb_tab_names_query,
+)
+
+
+def test_get_kb_tab_rows_query_binds_kb_ids_and_tab_name():
+    text, values = get_kb_tab_rows_query(["kb-1", "kb-2"], "Pricing")
+
+    assert values == [["kb-1", "kb-2"], "Pricing"]
+    assert "kb_chunk" in text
+    assert "kb_document" in text
+    assert "metadata" in text
+    assert "'table'" in text
+    assert "status" in text
+    assert "READY" in text
+    assert "chunk_index" in text
+
+
+def test_get_kb_tab_rows_query_matches_case_insensitively():
+    """An LLM calling get_tab_data("pricing") must still hit a tab actually
+    named "Pricing" — case is the one mismatch an LLM is likely to make even
+    when it got the name from list_kb_tabs, and this tool's entire value
+    proposition over semantic search is a deterministic hit."""
+    text, _ = get_kb_tab_rows_query(["kb-1"], "pricing")
+
+    assert "LOWER(" in text
+    assert "LOWER($2)" in text
+
+
+def test_list_kb_tab_names_query_binds_kb_ids():
+    text, values = list_kb_tab_names_query(["kb-1"])
+
+    assert values == [["kb-1"]]
+    assert "DISTINCT" in text
+    assert "metadata" in text
+    assert "'table'" in text
+
+
+def test_list_kb_tab_names_query_excludes_empty_string_tab_names():
+    text, _ = list_kb_tab_names_query(["kb-1"])
+
+    assert "!= ''" in text

--- a/tests/test_kb_tab_retrieval.py
+++ b/tests/test_kb_tab_retrieval.py
@@ -1,0 +1,112 @@
+"""Retrieval/cache tests — accessor and Redis both mocked."""
+
+from unittest.mock import AsyncMock, patch
+
+from app.services.knowledge_base import retrieval
+from app.services.knowledge_base.retrieval import get_kb_tab_text, list_kb_tabs
+
+
+async def test_get_kb_tab_text_returns_empty_for_no_kb_ids():
+    text, truncated = await get_kb_tab_text([], "Pricing")
+    assert text == ""
+    assert truncated is False
+
+
+async def test_get_kb_tab_text_concatenates_rows_with_document_headers():
+    fake_redis = AsyncMock()
+    fake_redis.get.return_value = None
+    with (
+        patch(
+            "app.services.knowledge_base.retrieval._get_kb_versions",
+            new=AsyncMock(return_value=["3"]),
+        ),
+        patch(
+            "app.services.knowledge_base.retrieval.get_redis_service",
+            new=AsyncMock(return_value=fake_redis),
+        ),
+        patch(
+            "app.services.knowledge_base.retrieval.get_kb_tab_rows",
+            new=AsyncMock(
+                return_value=[
+                    ("Health Companion Sheet", "iPhone 15,$999"),
+                    ("Health Companion Sheet", "iPhone 16,$1099"),
+                ]
+            ),
+        ),
+    ):
+        text, truncated = await get_kb_tab_text(["kb-1"], "Pricing")
+
+    assert "Health Companion Sheet" in text
+    assert "iPhone 15,$999" in text
+    assert "iPhone 16,$1099" in text
+    assert truncated is False
+    fake_redis.setex.assert_called_once()
+
+
+async def test_get_kb_tab_text_truncates_oversized_tab_and_flags_it():
+    fake_redis = AsyncMock()
+    fake_redis.get.return_value = None
+    huge_row = "x" * (retrieval._TAB_TEXT_MAX_CHARS + 5_000)
+    with (
+        patch(
+            "app.services.knowledge_base.retrieval._get_kb_versions",
+            new=AsyncMock(return_value=["3"]),
+        ),
+        patch(
+            "app.services.knowledge_base.retrieval.get_redis_service",
+            new=AsyncMock(return_value=fake_redis),
+        ),
+        patch(
+            "app.services.knowledge_base.retrieval.get_kb_tab_rows",
+            new=AsyncMock(return_value=[("Big Sheet", huge_row)]),
+        ),
+    ):
+        text, truncated = await get_kb_tab_text(["kb-1"], "Big")
+
+    assert truncated is True
+    assert len(text) <= retrieval._TAB_TEXT_MAX_CHARS
+
+
+async def test_get_kb_tab_text_returns_cached_value_on_hit():
+    fake_redis = AsyncMock()
+    fake_redis.get.return_value = '{"text": "cached tab text", "truncated": false}'
+    with (
+        patch(
+            "app.services.knowledge_base.retrieval._get_kb_versions",
+            new=AsyncMock(return_value=["3"]),
+        ),
+        patch(
+            "app.services.knowledge_base.retrieval.get_redis_service",
+            new=AsyncMock(return_value=fake_redis),
+        ),
+        patch(
+            "app.services.knowledge_base.retrieval.get_kb_tab_rows",
+            new=AsyncMock(side_effect=AssertionError("should not hit DB on cache hit")),
+        ),
+    ):
+        text, truncated = await get_kb_tab_text(["kb-1"], "Pricing")
+
+    assert text == "cached tab text"
+    assert truncated is False
+
+
+async def test_list_kb_tabs_returns_names_from_accessor():
+    fake_redis = AsyncMock()
+    fake_redis.get.return_value = None
+    with (
+        patch(
+            "app.services.knowledge_base.retrieval._get_kb_versions",
+            new=AsyncMock(return_value=["1"]),
+        ),
+        patch(
+            "app.services.knowledge_base.retrieval.get_redis_service",
+            new=AsyncMock(return_value=fake_redis),
+        ),
+        patch(
+            "app.services.knowledge_base.retrieval.list_kb_tab_names",
+            new=AsyncMock(return_value=["Pricing", "Clinics"]),
+        ),
+    ):
+        result = await list_kb_tabs(["kb-1"])
+
+    assert result == ["Pricing", "Clinics"]


### PR DESCRIPTION
## Summary

Closes the end-to-end path for **"load one Google Sheet tab, on demand, mid-conversation"** entirely inside the existing Knowledge Base — no second data-source table, no parallel ingestion pipeline, no separate Sheets auth.

The LLM calls `get_tab_data(tab_name="Pricing")` and gets that whole tab back deterministically, instead of gambling on semantic search returning the right rows. `list_kb_tabs()` makes valid tab names discoverable rather than guessed.

## What's bundled

**1. Google Sheets KB connector** — cherry-picked from `feat/knowledge-base-sheets` (also open standalone as #876; see note below). Share-to-service-account auth, `values:batchGet` load, Drive `modifiedTime` change detection, manual re-sync endpoint, `kb_sheets_poll` scheduler task. Each sheet tab normalizes to one `TableData` named after the tab.

**2. Tab-scoped retrieval on top of it** (new work in this PR):

| Layer | Added |
|---|---|
| Query | `get_kb_tab_rows_query`, `list_kb_tab_names_query` — filter `kb_chunk` by `metadata->>'table'`, READY docs only, ingestion order |
| Accessor | `get_kb_tab_rows`, `list_kb_tab_names` |
| Retrieval | `get_kb_tab_text`, `list_kb_tabs` — cached under the **same version-stamped Redis keys** as `get_full_kb_text` |
| Handlers | `get_tab_data`, `list_kb_tabs` builtins, registered in `BUILTIN_HANDLERS` |

## Why it needs no new infrastructure

`chunking.py::chunk_table` **already** tags every spreadsheet row-chunk with `metadata={"table": table.name, ...}`. The data was always there — it just was never queried that way. So this is a filtered variant of the existing full-injection read path, not a new system.

Cache invalidation is free: ingestion's existing `INCR kb:ver:{kb_id}` moves the version embedded in the cache key, so old keys become unreachable. No new invalidation code.

**No new tables, no new migrations, no new template config fields.** The functions are authored in template JSON like any other builtin.

## Template usage

```json
{
  "configurations": {
    "knowledge_base": { "enabled": true, "knowledge_base_ids": ["<kb-uuid>"], "mode": "tool" }
  },
  "flow": { "nodes": { "pricing_inquiry": { "functions": [
    { "type": "builtin", "name": "get_pricing_tab", "handler": "get_tab_data",
      "description": "Fetch the current pricing table.",
      "properties": { "tab_name": { "type": "string", "description": "Exact tab name, e.g. 'Pricing'." } },
      "required": ["tab_name"] },
    { "type": "builtin", "name": "list_kb_tabs", "handler": "list_kb_tabs",
      "description": "List available data tab names." }
  ] } } }
}
```

Existing KB modes (`auto` / `full_injection` / `auto_retrieve` / `tool`) are untouched. Works in **voice and chat** (neither name is in `CHAT_DISABLED_NAMES`).

## Validation

- `uv run pytest` — **603 passed**, 1 xfailed (16 new tests across query/accessor/retrieval/handler layers)
- `uv run pyrefly check` — **0 errors**
- `uv run black --check .` / `isort --check` — clean
- Drove the full dispatch path live (template JSON → `GlobalBuiltinFunction` → `builtin_function_dispatcher` → registry → handler) — returns `{"status":"success","tab_name":"Pricing","content":...}` and `(result, None)` = stay on node

## Docs

- `docs/breeze_buddy/knowledge_base_overview.md` — how the KB works (ingestion, chunking, 4 retrieval modes, hybrid search, version-stamped cache)
- `docs/breeze_buddy/kb_tab_retrieval.md` — this addition, with worked examples and known v1 limits

## Note on #876

This PR **contains** sheets connector commit (authorship preserved via `Co-Authored-By`), because the tab-retrieval feature is inert without it — a `google_sheet` document can't be ingested at all until that connector is registered, and CI requires exactly 1 commit per PR.

If #876 merges first, I'll rebase and drop the duplicated commit. Happy to split this instead if reviewers prefer — the tab-retrieval half is independently useful today for uploaded `.xlsx` worksheets.

## Known v1 limits (documented, deliberate)

- Tab names match **exact-string**; `list_kb_tabs` is the mitigation and the `not_found` message points the LLM to it
- Two documents in one KB with the same tab name concatenate — fine for one-sheet-per-KB, the assumed setup
- No index on `kb_chunk.metadata` — the filter narrows by `kb_id` first, so it's a bounded scan (≤25K chunks/KB quota)
- Freshness is ingestion-paced (`kb_sheets_poll`, 15min default), consistent with the rest of KB

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Google Sheets integration for knowledge bases, including connection, ingestion, synchronization, and service-account visibility.
  * Added tab-level knowledge retrieval, allowing assistants to list spreadsheet tabs and fetch specific tab contents.
  * Added document download links for uploaded files and connected spreadsheets.
  * Added configurable polling to keep connected Sheets knowledge bases up to date.

* **Documentation**
  * Added setup guidance and documentation for knowledge-base configuration, retrieval, and Google Sheets usage.

* **Tests**
  * Added coverage for tab retrieval, caching, handlers, and query behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->