### PR TITLE
feat(observers): record observer actions in node traversal path

### DIFF
--- a/app/ai/voice/agents/breeze_buddy/observers/observer.py
+++ b/app/ai/voice/agents/breeze_buddy/observers/observer.py
@@ -126,12 +126,16 @@ class RealtimeObserver:
                 lead.metaData = {}
             lead.metaData["observer_triggered"] = self.name
 
+        action = self.config.action
+
+        # Record observer action in node traversal before set_outcome,
+        # so it's included when metaData is written to DB.
+        ctx = TemplateContext(self._agent_context)
+        ctx.record_observer_action(self.name, action.type, action.args)
+
         if lead and outcome:
             lead.outcome = outcome
-            ctx = TemplateContext(self._agent_context)
             await set_outcome(ctx, outcome, triggered_by=self.name)
-
-        action = self.config.action
         handler_name = action.handler or action.type
         handler = self._handler_map.get(handler_name)
 

--- a/app/ai/voice/agents/breeze_buddy/template/context.py
+++ b/app/ai/voice/agents/breeze_buddy/template/context.py
@@ -353,6 +353,57 @@ class TemplateContext:
             f"'{active_entry.get('node_name')}'"
         )
 
+    def record_observer_action(
+        self,
+        observer_name: str,
+        action_type: str,
+        action_args: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        """Record an observer-triggered action under the currently active node.
+
+        Appends an entry to the ``observer_actions`` list of the most recent
+        node traversal entry (the one with ``exited_at`` still None).
+
+        Args:
+            observer_name: Name of the observer that triggered (from config).
+            action_type: The action the observer executed (e.g. end_conversation).
+            action_args: Arguments from the observer's configured action.
+        """
+        if not self.lead or not self.lead.metaData:
+            return
+
+        if "node_traversal" not in self.lead.metaData:
+            return
+
+        active_entry = None
+        for entry in reversed(self.lead.metaData["node_traversal"]):
+            if entry.get("exited_at") is None:
+                active_entry = entry
+                break
+
+        if active_entry is None:
+            logger.warning(
+                f"Cannot record observer action '{observer_name}': "
+                "no active node entry found"
+            )
+            return
+
+        if "observer_actions" not in active_entry:
+            active_entry["observer_actions"] = []
+
+        active_entry["observer_actions"].append(
+            {
+                "observer_name": observer_name,
+                "action": action_type,
+                "triggered_at": self._get_ist_timestamp(),
+                "args": action_args,
+            }
+        )
+        logger.info(
+            f"Recorded observer action '{observer_name}' ({action_type}) "
+            f"under node '{active_entry.get('node_name')}'"
+        )
+
     def record_ivr_input(
         self,
         digit: str,


### PR DESCRIPTION
Add record_observer_action()  for recording observer-triggered actions under the active node's observer_actions list.

<img width="1728" height="889" alt="Screenshot 2026-07-16 at 1 08 08 PM" src="https://github.com/user-attachments/assets/3f450954-78eb-441a-b994-5b78d55d2a55" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Observer-triggered flow actions are now recorded as global function calls during node traversal.
  * Recorded calls include metadata identifying the observer and action type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->