### PR TITLE
fix(leads): map redbus legacy template name to its template_id

### DIFF
--- a/app/ai/voice/agents/breeze_buddy/types/models.py
+++ b/app/ai/voice/agents/breeze_buddy/types/models.py
@@ -2,9 +2,18 @@ from io import BytesIO
 from typing import Any, Dict, List, NamedTuple, Optional
 from uuid import UUID
 
-from pydantic import BaseModel, field_validator
+from pydantic import BaseModel, field_validator, model_validator
 
 from app.schemas.breeze_buddy.core import ExecutionMode
+
+# TEMPORARY HACK — remove once redbus migrates to template_id.
+# redbus is the one legacy merchant still sending the removed `template`
+# (name) field in lead pushes. This is NOT name-based template resolution:
+# it is a hardcoded alias applied only on an exact name match. Do not add
+# other merchants or names here.
+_REDBUS_LEGACY_TEMPLATE_ALIASES: Dict[str, str] = {
+    "redbus-refund-eligibility-verification": "12d435c1-d044-40c9-8c2b-f9a379e8f871",
+}
 
 
 class CallRecordingResult(NamedTuple):
@@ -15,11 +24,24 @@ class CallRecordingResult(NamedTuple):
 class PushLeadRequest(BaseModel):
     """Lead push request. Templates are identified by id ONLY — name-based
     resolution was removed; a legacy ``template`` field in the body is
-    ignored (pydantic drops unknown fields)."""
+    ignored (pydantic drops unknown fields). Sole exception: the hardcoded
+    redbus alias in ``_REDBUS_LEGACY_TEMPLATE_ALIASES`` above."""
 
     request_id: str
     payload: Dict[str, Any]
     template_id: str
+
+    @model_validator(mode="before")
+    @classmethod
+    def _apply_redbus_legacy_template_alias(cls, data: Any) -> Any:
+        # TEMPORARY HACK — see _REDBUS_LEGACY_TEMPLATE_ALIASES.
+        if isinstance(data, dict) and not data.get("template_id"):
+            template_name = data.get("template")
+            if isinstance(template_name, str):
+                alias = _REDBUS_LEGACY_TEMPLATE_ALIASES.get(template_name)
+                if alias:
+                    data["template_id"] = alias
+        return data
 
     @field_validator("template_id")
     @classmethod


### PR DESCRIPTION
## Summary
- Template resolution is id-only since the name-lookup removal, but redbus (one legacy merchant) still pushes leads with the removed `template` (name) field and needs time to migrate.
- Adds a **temporary, hardcoded alias** in `PushLeadRequest` (`model_validator(mode="before")`): an exact match on `template: "redbus-refund-eligibility-verification"` injects `template_id: 12d435c1-d044-40c9-8c2b-f9a379e8f871`, only when no `template_id` was sent.
- This does **not** reintroduce name-based resolution — no DB lookup by name anywhere; it's a static string swap at request-parse time. Downstream id-only pipeline (template fetch, reseller/merchant ownership checks, config resolution) is unchanged, so a different merchant sending this name would still hit the existing ownership 404.
- Remove once redbus migrates to `template_id`.

## Behavior
- redbus legacy name, no `template_id` → mapped to the template id ✅
- Explicit `template_id` always wins over the alias ✅
- Any other/unknown template name → normal 422 (`template_id` missing) ✅
- Non-string `template` value → clean 422, no crash ✅

## Testing
- 608 tests passed, pyrefly clean, black/isort clean
- Model-level verification of all cases above

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C4RctW5HP6i4PYmG8f46E6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with legacy template references when creating push leads.
  * Legacy template names are now automatically resolved to the appropriate template identifier when no identifier is provided.
  * Existing template identifier validation remains enforced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->