### PR TITLE
fix: log errors when lead template or call execution config is missing

### DIFF
--- a/app/ai/voice/agents/breeze_buddy/dispatch/worker.py
+++ b/app/ai/voice/agents/breeze_buddy/dispatch/worker.py
@@ -331,6 +331,13 @@ class Worker:
                 if locked.template_id
                 else None
             )
+            if not template:
+                logger.error(
+                    f"Worker {self._uuid}: no template found for lead "
+                    f"{locked.id} (template_id={locked.template_id}, "
+                    f"reseller={locked.reseller_id}). Proceeding to dial "
+                    "without a template."
+                )
 
             if not await _run_pre_checks_for_lead(config, locked, template, session):
                 # _run_pre_checks_for_lead already set status to FINISHED on

--- a/app/ai/voice/agents/breeze_buddy/managers/calls.py
+++ b/app/ai/voice/agents/breeze_buddy/managers/calls.py
@@ -88,7 +88,7 @@ async def _get_lead_config(lead: LeadCallTracker) -> Optional[CallExecutionConfi
         else None
     )
     if not config:
-        logger.warning(
+        logger.error(
             f"No call execution config found for template: {lead.template} (template_id={lead.template_id})"
         )
     return config

--- a/app/api/routers/breeze_buddy/leads/handlers.py
+++ b/app/api/routers/breeze_buddy/leads/handlers.py
@@ -245,6 +245,11 @@ async def push_lead_handler(req: PushLeadRequest, current_user: UserInfo) -> Dic
                 req = req.model_copy(update={"merchant_id": template.merchant_id})
 
         if not template:
+            logger.error(
+                "Template not found for reseller %s (template_id=%s)",
+                req.reseller_id,
+                req.template_id,
+            )
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,
                 detail=f"Template not found for reseller: {req.reseller_id} "
@@ -287,6 +292,13 @@ async def push_lead_handler(req: PushLeadRequest, current_user: UserInfo) -> Dic
         config = await get_call_execution_config_by_template_id(str(template.id))
 
         if not config:
+            logger.error(
+                "Call execution config not found for template %s "
+                "(template_id=%s, reseller_id=%s)",
+                template.name,
+                template.id,
+                req.reseller_id,
+            )
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,
                 detail=f"Call execution config not found for template: {template.name}",


### PR DESCRIPTION
## Problem

A lead pushed against a missing template or missing call execution config was correctly rejected with a 404, but **nothing was logged at error level anywhere** — the `except HTTPException: raise` in `push_lead_handler` skips the catch-all `logger.error`, so the only trace was the uvicorn access-log 404. Worse, if the template was deleted *after* push, the dispatch worker proceeded **completely silently**: it acquired an outbound number and dialed the customer, with the first error appearing only at answer time in the template loader.

## Changes (logging only, no behavior change)

- `leads/handlers.py` — `push_lead_handler`: `logger.error` before the template-not-found 404 and the config-not-found 404 (the neighboring scope-mismatch branches already logged; these two didn't).
- `dispatch/worker.py` — `logger.error` when the template fetch returns `None` at dial time, making the dial-without-template path visible before the customer's phone rings.
- `managers/calls.py` — `_get_lead_config`: promote the missing-config log from `warning` to `error` (this path terminates the lead with outcome `NO_CONFIG`, which is an operational failure, not a warning).

## Testing

- Pre-commit hook: black / isort / autoflake / pyrefly all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XT9aDXcZ4r7uq2j8e3nfML

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error reporting when lead templates or call execution configurations are missing.
  * Added clearer diagnostic details for failed lead requests.
  * Preserved existing behavior and response status codes while improving issue visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->