### PR TITLE
fix(voice): stop Daily teardown from deadlocking the event loop

### DIFF
--- a/app/ai/voice/agents/breeze_buddy/utils/transport/daily_keepalive.py
+++ b/app/ai/voice/agents/breeze_buddy/utils/transport/daily_keepalive.py
@@ -19,21 +19,35 @@ the one real teardown at true call end via :func:`force_teardown_daily_client`
 (mirroring telephony's final ``close_websocket_safely``).
 """
 
+import asyncio
 from typing import Any, Callable
 
 from app.core.logger import logger
+
+# Real teardown deadlines. Generous — a healthy leave/release finishes in
+# well under a second; the timeout only exists so a pathological native
+# hang strands one executor thread instead of the caller.
+_LEAVE_TIMEOUT_SECS = 10
+_CLEANUP_TIMEOUT_SECS = 15
 
 
 def hold_daily_client(client: Any) -> Callable[[], None]:
     """Neutralise a ``DailyTransportClient``'s ``leave()``/``cleanup()``.
 
     Replaces both with no-ops so per-generation pipeline teardown cannot drop the
-    Daily connection. Returns a ``restore()`` that puts the original methods back
-    (not required for teardown — :func:`force_teardown_daily_client` uses the
-    low-level ``_leave``/``_cleanup`` which are left untouched).
+    Daily connection. The originals are stashed on the client so
+    :func:`force_teardown_daily_client` can run the REAL async ``cleanup()`` at
+    true call end — that method (pipecat's) is the only path that cancels the
+    event/audio/video callback tasks and releases the native ``CallClient`` off
+    the event loop. Returns a ``restore()`` that puts the original methods back.
     """
     original_leave = client.leave
     original_cleanup = client.cleanup
+
+    # Stash for force_teardown_daily_client. Attribute names are
+    # namespaced to avoid colliding with pipecat internals.
+    client._bb_held_leave = original_leave
+    client._bb_held_cleanup = original_cleanup
 
     async def _suppressed_leave(*args: Any, **kwargs: Any) -> None:
         logger.debug("[daily_keepalive] suppressed DailyTransportClient.leave()")
@@ -54,20 +68,59 @@ def hold_daily_client(client: Any) -> Callable[[], None]:
 async def force_teardown_daily_client(client: Any) -> None:
     """Really leave the room and release the CallClient at true call end.
 
-    Bypasses the join/leave refcount (bumped high by the no-op ``leave()`` +
-    per-generation joins) by calling the low-level ``_leave``/``_cleanup``
-    directly. Best-effort: failures are logged, never raised, so call teardown is
-    never blocked.
+    Best-effort with hard deadlines: failures are logged, never raised, so
+    call teardown is never blocked.
+
+    Two hard-won constraints shape this function:
+
+    1. ``CallClient.release()`` is a BLOCKING native call that waits for the
+       client's worker threads to finish — and those threads may need the
+       GIL / event loop to deliver their final callbacks. Calling it on the
+       event-loop thread therefore deadlocks the entire server (every HTTP
+       request hangs; observed in local dev after each widget voice call).
+       It must only ever run off-loop.
+
+    2. pipecat's async ``DailyTransportClient.cleanup()`` is the one method
+       that BOTH cancels the event/audio/video callback tasks (otherwise
+       reported as dangling by PipelineTask) AND runs ``release()`` in an
+       executor. Since :func:`hold_daily_client` no-ops ``cleanup`` on the
+       instance, we call the stashed original here.
     """
+    # Leave the room via the low-level _leave (bypasses the join/leave
+    # refcount, which the no-op leave() left inflated).
     try:
         leave = getattr(client, "_leave", None)
         if leave is not None:
-            await leave()
+            await asyncio.wait_for(leave(), timeout=_LEAVE_TIMEOUT_SECS)
+    except asyncio.TimeoutError:
+        logger.warning(
+            f"[daily_keepalive] force leave timed out after {_LEAVE_TIMEOUT_SECS}s; "
+            "continuing to cleanup"
+        )
     except Exception as exc:  # noqa: BLE001 - teardown must never raise
         logger.warning(f"[daily_keepalive] force leave failed: {exc}")
+
+    # Real cleanup: cancel callback tasks + release the native client
+    # off-loop, via the original (pre-hold) async cleanup().
     try:
-        cleanup = getattr(client, "_cleanup", None)
+        cleanup = getattr(client, "_bb_held_cleanup", None)
         if cleanup is not None:
-            cleanup()
+            await asyncio.wait_for(cleanup(), timeout=_CLEANUP_TIMEOUT_SECS)
+        else:
+            # Client was never held (shouldn't happen) — fall back to the
+            # raw release, still strictly off-loop.
+            raw_cleanup = getattr(client, "_cleanup", None)
+            if raw_cleanup is not None:
+                await asyncio.wait_for(
+                    asyncio.to_thread(raw_cleanup), timeout=_CLEANUP_TIMEOUT_SECS
+                )
+    except asyncio.TimeoutError:
+        # The native client is stranded (leaked worker threads), but the
+        # event loop stays healthy and the next voice session gets a fresh
+        # CallClient.
+        logger.warning(
+            f"[daily_keepalive] client cleanup timed out after "
+            f"{_CLEANUP_TIMEOUT_SECS}s; native client leaked but loop unblocked"
+        )
     except Exception as exc:  # noqa: BLE001 - teardown must never raise
         logger.warning(f"[daily_keepalive] force cleanup failed: {exc}")

--- a/app/main.py
+++ b/app/main.py
@@ -291,6 +291,20 @@ async def lifespan(_app: FastAPI):
     # Close Redis connections
     await close_redis_connections()
 
+    # LAST: flush + stop loguru's enqueue=True sinks. Each enqueued sink
+    # owns a multiprocessing SimpleQueue/Event/Lock; if their worker
+    # threads are still alive at interpreter exit, resource_tracker
+    # reports the SemLocks as "leaked semaphore objects". complete()
+    # drains pending records, remove() joins the workers and frees the
+    # primitives deterministically. Nothing may log through loguru after
+    # this point, which is why it sits at the very end of shutdown.
+    try:
+        logger.info("Shutdown complete; flushing log queues.")
+        await logger.complete()
+        await asyncio.to_thread(logger.remove)
+    except Exception:  # noqa: BLE001 - never block process exit on logging
+        pass
+
 
 app = FastAPI(title="Breeze Automatic Server", version=__version__, lifespan=lifespan)
 


### PR DESCRIPTION
## Problem

After every **widget voice session** ended, the whole server froze: every subsequent HTTP request (chat sessions, admin APIs, everything) hung forever with no error and no log output. The process stayed alive and the port stayed open, so nothing restarted it. Reproduced consistently in local dev; the freeze timeline matches the voice teardown to the second.

## Root cause

`force_teardown_daily_client` called the **sync** `DailyTransportClient._cleanup()`, which runs daily-python's `CallClient.release()` — a **blocking native call** — on the event-loop thread. `release()` waits for the native client's worker threads to wind down, but those threads need the GIL/event loop to deliver their final callbacks. Circular wait → the loop thread never returns from native code → uvicorn can never serve another request.

A second symptom of the same shortcut: the event/audio callback consumer tasks were never cancelled (`PipelineTask ... dangling tasks detected: [DailyTransport#0::DailyTransportClient::event_callback_task, ...audio_callback_task]` right before each freeze), because task cancellation lives in the **async** `cleanup()` that `hold_daily_client` had no-op'd.

## Fix

- `hold_daily_client` now stashes the original `leave`/`cleanup` on the client.
- `force_teardown_daily_client` runs the stashed **original async `cleanup()`** — pipecat's own teardown, which cancels the event/audio/video callback tasks and then runs `release()` **in an executor**, off-loop. Falls back to `asyncio.to_thread(_cleanup)` if the client was never held.
- Both the room-leave and the cleanup carry hard timeouts (10s / 15s): a pathological native hang now strands one worker thread and logs a warning instead of freezing the API.

With the server surviving teardown, **sequential voice attachments on one widget session work**: the lead-reuse + channel-flip design in the widget voice connect/end handlers was already correct — it just never got a live server back after session #1.

## Also: leaked semaphore warnings on shutdown

`resource_tracker: There appear to be 16 leaked semaphore objects` on every SIGTERM. Traced (by instrumenting `SemLock.__init__` at import) to loguru's two `enqueue=True` sinks — each owns a multiprocessing SimpleQueue/Event/Lock whose worker threads were still alive at interpreter exit. Lifespan shutdown now ends with `logger.complete()` + `logger.remove()`, which drains and joins them deterministically.

## Verification

- Unit-level: fake client modeling the blocking release — suppression during pipeline generations holds; true teardown leaves the room, cancels tasks, and releases off-loop.
- SIGTERM cycle against a live local instance: clean shutdown, `Shutdown complete; flushing log queues.` as the final line, zero leaked-semaphore warnings (previously present on every run).
- Live widget chat end-to-end against a local server on this branch.
- Not yet verified on this branch: a real end-to-end voice call (needs a Daily room + mic). The deadlock mechanism and fix were established on an identical code version locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CM8is9p6ACYacERnB7iNkg

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved voice session reliability by preventing keep-alive handling from blocking or prematurely ending active browser sessions.
  * Added safeguards to ensure stalled connection cleanup does not delay application responsiveness.
  * Improved shutdown handling so queued logs are flushed reliably before the application exits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->