### PR TITLE
fix(voice): guarantee a terminal turn-end for interrupted voice turns

### DIFF
--- a/app/ai/voice/agents/breeze_buddy/chat/voice_bridge.py
+++ b/app/ai/voice/agents/breeze_buddy/chat/voice_bridge.py
@@ -287,6 +287,8 @@ class WidgetVoiceBridge:
             logger.warning(
                 f"[voice-bridge] session {self.session_id} lock busy; skipping turn"
             )
+            # The busy `error` IS this turn's terminal signal (the client resets
+            # its turn state on it), so no `turn-end` is owed on this path.
             await self._emit_rtvi(
                 _RTVI_ERROR, {"code": "busy", "message": "One moment, please."}
             )
@@ -295,15 +297,24 @@ class WidgetVoiceBridge:
             return
 
         events = make_events()
+        # Did this turn emit a terminal RTVI event (`turn-end` or `error`)? If not
+        # — a barge-in/teardown CancelledError or a supersession unwinds the
+        # stream without one — the finally synthesizes a `turn-end`. Guarantees
+        # the client ALWAYS gets exactly one terminal signal per turn, so an
+        # interrupted turn can't leave it hanging (stuck "Speaking" / a streaming
+        # transcript bubble). This is the root fix: the client no longer has to
+        # infer the end of an interrupted turn.
+        terminal_emitted = False
         try:
-            await self._consume_events(events, gen)
+            terminal_emitted = await self._consume_events(events, gen)
         except asyncio.CancelledError:
             # Barge-in / teardown. The CancelledError thrown into the async
             # generator already ran its finally (aiohttp + MCP close) as it
             # propagated; the next turn's repair heals any dangling tool_use.
-            # Uncancel so the shielded lock release below isn't re-cancelled
-            # (Python 3.11 cancel-counter gotcha — same fix the chat SSE stream
-            # uses); we don't re-raise, the turn is done.
+            # Uncancel so the shielded emits below aren't re-cancelled (Python
+            # 3.11 cancel-counter gotcha — same fix the chat SSE stream uses);
+            # we don't re-raise, the turn is done. `terminal_emitted` stays False
+            # → the finally sends the synthetic `turn-end`.
             cur = asyncio.current_task()
             if cur is not None:
                 try:
@@ -318,7 +329,18 @@ class WidgetVoiceBridge:
             await self._emit_rtvi(
                 _RTVI_ERROR, {"code": "internal", "message": "voice turn failed"}
             )
+            terminal_emitted = True
         finally:
+            # Synthesize the terminal `turn-end` for interrupted / superseded
+            # turns. Shielded like the lock release so a cancellation landing here
+            # still delivers it (`_emit_rtvi` swallows its own errors).
+            if not terminal_emitted:
+                try:
+                    await asyncio.shield(
+                        self._emit_rtvi(_RTVI_TURN_END, {"status": None})
+                    )
+                except Exception:  # noqa: BLE001
+                    pass
             # Shield the release so a cancellation that lands here still issues
             # the Redis DEL (else the lock lingers until its 180s TTL and the
             # next turn / message 409s).
@@ -329,16 +351,24 @@ class WidgetVoiceBridge:
             if self._inflight is asyncio.current_task():
                 self._inflight = None
 
-    async def _consume_events(self, events: Any, gen: int) -> None:
-        """Adapt one chat-brain SSE stream into TTS frames + RTVI events."""
+    async def _consume_events(self, events: Any, gen: int) -> bool:
+        """Adapt one chat-brain SSE stream into TTS frames + RTVI events.
+
+        Returns True iff a terminal RTVI event (``turn-end`` or ``error``) was
+        emitted for this turn. ``_drive`` uses this to synthesize a ``turn-end``
+        when the stream exits WITHOUT one (a supersession here, or a barge-in /
+        teardown ``CancelledError`` raised through this generator) — so the
+        client is never left without a terminal signal.
+        """
         agg = _SentenceAggregator()
         filler_fired = False
+        terminal_emitted = False
         async for ev in events:
             if gen != self._generation:
                 # Superseded by a newer turn without a task cancel (rare).
                 # Close the generator so its aiohttp/MCP pool is released.
                 await events.aclose()
-                return
+                return terminal_emitted
             if ev.event == "assistant_token":
                 delta = ev.data.get("delta", "") if isinstance(ev.data, dict) else ""
                 for chunk in agg.push(delta):
@@ -418,6 +448,7 @@ class WidgetVoiceBridge:
                     ev.data.get("session_status") if isinstance(ev.data, dict) else None
                 )
                 await self._emit_rtvi(_RTVI_TURN_END, {"status": status})
+                terminal_emitted = True
             elif ev.event == "error":
                 data = ev.data if isinstance(ev.data, dict) else {}
                 await self._emit_rtvi(
@@ -427,8 +458,10 @@ class WidgetVoiceBridge:
                         "message": data.get("message", "voice turn error"),
                     },
                 )
+                terminal_emitted = True
             # user_committed / node_transition are intentionally not echoed: the
             # user transcript already reaches the widget from STT via pipecat RTVI.
+        return terminal_emitted
 
     # -- emission helpers ---------------------------------------------------
 

--- a/tests/test_voice_bridge.py
+++ b/tests/test_voice_bridge.py
@@ -319,6 +319,64 @@ async def test_error_event_emits_rtvi_error(monkeypatch):
 
 
 # ---------------------------------------------------------------------------
+# WidgetVoiceBridge — terminal-event guarantee (every turn emits exactly one)
+# ---------------------------------------------------------------------------
+
+
+async def test_interrupted_turn_still_emits_terminal_turn_end(monkeypatch):
+    """Root-cause guard: an interrupted turn (barge-in / teardown / a ui-action
+    tap that cancels the in-flight turn) must STILL emit exactly one terminal
+    ``turn-end`` — even though the brain's own ``turn_end`` never arrives — so
+    the client is never left hanging (stuck 'Speaking' / streaming bubble)."""
+    gate = asyncio.Event()
+
+    async def _gen(*, session_id, user_content, llm=None, context_placement=None):
+        yield SSEEvent("assistant_token", {"delta": "First sentence here. "})
+        await gate.wait()  # cancelled before this releases
+        yield SSEEvent("turn_end", {"session_status": "ACTIVE"})
+
+    monkeypatch.setattr(vb, "run_chat_turn", _gen)
+    bridge, _, emit = _make_bridge()
+    await bridge.handle_user_turn("hi")
+    await asyncio.sleep(0.02)
+    await bridge.cancel_inflight()
+    await bridge._drain()
+    ends = _emitted(emit, "turn-end")
+    assert len(ends) == 1 and ends[0] == {"status": None}
+
+
+async def test_stream_ending_without_turn_end_synthesizes_one(monkeypatch):
+    """A brain stream that completes without a ``turn_end`` event still yields a
+    terminal ``turn-end`` for the client."""
+    monkeypatch.setattr(
+        vb,
+        "run_chat_turn",
+        _stub_run_chat_turn(
+            SSEEvent("assistant_token", {"delta": "Done, but no explicit end."}),
+        ),
+    )
+    bridge, _, emit = _make_bridge()
+    await _run_one_turn(bridge)
+    assert len(_emitted(emit, "turn-end")) == 1
+
+
+async def test_normal_turn_end_not_doubled(monkeypatch):
+    """The brain's own ``turn_end`` must NOT be duplicated by the synthetic
+    fallback — exactly one terminal event per turn."""
+    monkeypatch.setattr(
+        vb,
+        "run_chat_turn",
+        _stub_run_chat_turn(
+            SSEEvent("assistant_token", {"delta": "Hello."}),
+            SSEEvent("turn_end", {"session_status": "ACTIVE"}),
+        ),
+    )
+    bridge, _, emit = _make_bridge()
+    await _run_one_turn(bridge)
+    assert len(_emitted(emit, "turn-end")) == 1
+
+
+# ---------------------------------------------------------------------------
 # WidgetVoiceBridge — greeting gating
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Problem

In widget voice mode the UI sometimes **freezes** mid-conversation: the footer sticks on **"Speaking"**, the assistant transcript bubble stays in its streaming ("Cooking…") state, and the transcript stops moving in both user and assistant terms. It happens *sometimes* — specifically when a bot turn is **interrupted or cancelled**.

## Root cause

`WidgetVoiceBridge` only emits a terminal RTVI event (`turn-end` / `error`) on the **happy path** — the chat brain's own `turn_end` event. Two exit paths emitted **nothing**:

- **Interruption / teardown** (`_drive`): the `CancelledError` from a barge-in, an `aclose()`, or a **ui-action tap (carousel/product) that cancels the in-flight turn via `_drain`** is caught and swallowed — no `turn-end`, no `error`.
- **Supersession** (`_consume_events`): the generation-mismatch branch `return`s early without a terminal event.

The client (widget + SDK) is a stateless 1:1 forwarder of these signals and has no way to *infer* the end of an interrupted turn — pipecat exposes no "bot interrupted" event to translate. So it waits forever, and the UI hangs.

## Fix

Guarantee **exactly one terminal event per turn**:

- `_consume_events` now returns whether it emitted a terminal event (`turn-end` or `error`).
- `_drive`'s `finally` synthesizes a `turn-end` (`{"status": None}`) when the turn ended **without** one — i.e. an interrupted / superseded / stream-ended-without-`turn_end` turn. Shielded like the lock release so a landing cancellation still delivers it.
- The lock-busy path and the exception path already emit their own terminal signal, so they're excluded (no double-emit).

This fixes it **at the source**: the client can now rely on always receiving a terminal event and no longer needs timeout/watchdog heuristics to recover. The corresponding client-side change (loom) drops that heuristic and keeps only the deterministic handling.

## Tests

`tests/test_voice_bridge.py`:
- `test_interrupted_turn_still_emits_terminal_turn_end` — barge-in/cancel still emits exactly one `turn-end`.
- `test_stream_ending_without_turn_end_synthesizes_one` — a stream with no `turn_end` still yields one.
- `test_normal_turn_end_not_doubled` — the happy path is not duplicated.

All 23 voice-bridge tests pass; black / isort / pyrefly / field-reference coverage clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured voice interactions always deliver exactly one terminal signal per turn.
  * Added fallback handling so interrupted or incomplete streams still end cleanly.
  * Prevented duplicate completion signals when a normal turn already provides one.

* **Tests**
  * Added coverage for interrupted turns, incomplete streams, and duplicate-signal prevention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->