### PR TITLE
fix(analytics): honest voice metrics, IST buckets, chat analytics rebuild, chat session scoping

### DIFF
--- a/app/api/routers/breeze_buddy/analytics/__init__.py
+++ b/app/api/routers/breeze_buddy/analytics/__init__.py
@@ -24,6 +24,7 @@ from .handlers import (
     get_call_details_grouped_analytics,
     get_calls_by_hour_analytics,
     get_chat_based_analytics,
+    get_chats_by_hour_analytics,
     get_conversion_analytics,
     get_distinct_merchant_ids,
     get_distinct_outcomes,
@@ -56,6 +57,7 @@ _ANALYTICS_HANDLERS: Dict[AnalyticsType, Callable[..., Awaitable]] = {
     AnalyticsType.DISTINCT_MERCHANT_IDS: get_distinct_merchant_ids,
     AnalyticsType.ATTEMPTS_TO_CONNECT: get_attempts_to_connect_analytics,
     AnalyticsType.CALLS_BY_HOUR: get_calls_by_hour_analytics,
+    AnalyticsType.CHATS_BY_HOUR: get_chats_by_hour_analytics,
 }
 
 

--- a/app/api/routers/breeze_buddy/analytics/handlers.py
+++ b/app/api/routers/breeze_buddy/analytics/handlers.py
@@ -33,6 +33,7 @@ from app.database.accessor.breeze_buddy.analytics import (
 from app.database.accessor.breeze_buddy.chat_analytics import (
     get_chat_summary_from_db,
     get_chat_trends_from_db,
+    get_chats_by_hour_from_db,
 )
 from app.schemas import CallDetailGroupedResult, CallDetailResult, UserInfo
 from app.utils.common import parse_json
@@ -166,6 +167,9 @@ async def get_chat_based_analytics(
             data_point: Dict[str, Any] = {
                 "conversations_started": row["conversations_started"] or 0,
                 "ended_conversations": row["ended_conversations"] or 0,
+                "total_messages": row.get("total_messages") or 0,
+                "user_messages": row.get("user_messages") or 0,
+                "assistant_messages": row.get("assistant_messages") or 0,
             }
             _format_time_bucket(data_point, row["time_bucket"], time_granularity)
             results.append(data_point)
@@ -195,18 +199,38 @@ async def get_chat_based_analytics(
         row = rows[0] if rows else {}
         total_conversations = row.get("total_conversations") or 0
         total_messages = row.get("total_messages") or 0
+        avg_session_seconds = row.get("avg_session_seconds")
+        median_reply_ms = row.get("median_reply_ms")
         results = [
             {
                 "total_conversations": total_conversations,
                 "active_conversations": row.get("active_conversations") or 0,
                 "idle_conversations": row.get("idle_conversations") or 0,
                 "ended_conversations": row.get("ended_conversations") or 0,
+                "user_ended_conversations": row.get("user_ended_conversations") or 0,
+                "idle_timeout_conversations": row.get("idle_timeout_conversations")
+                or 0,
                 "total_agents": row.get("total_agents") or 0,
                 "total_messages": total_messages,
+                "user_messages": row.get("user_messages") or 0,
+                "assistant_messages": row.get("assistant_messages") or 0,
                 "avg_messages_per_conversation": (
                     round(total_messages / total_conversations, 2)
                     if total_conversations
                     else 0.0
+                ),
+                # session span = first-to-last activity; NULL (→ None) when
+                # no sessions matched, so the UI can show an em dash
+                "avg_session_seconds": (
+                    round(float(avg_session_seconds), 1)
+                    if avg_session_seconds is not None
+                    else None
+                ),
+                # median time-to-first-token across assistant turns
+                "median_reply_ms": (
+                    round(float(median_reply_ms), 1)
+                    if median_reply_ms is not None
+                    else None
                 ),
             }
         ]
@@ -216,6 +240,20 @@ async def get_chat_based_analytics(
         "filters_applied": filters,
         "time_granularity": None,
         "results": results,
+    }
+
+
+async def get_chats_by_hour_analytics(
+    filters: Dict[str, Any],
+    options: Dict[str, Any],
+    current_user: UserInfo,
+) -> Dict[str, Any]:
+    """Distribution of conversations started by hour-of-day (0-23, IST)."""
+    hours = await get_chats_by_hour_from_db(filters)
+    return {
+        "type": "chats-by-hour",
+        "filters_applied": filters,
+        "results": hours,
     }
 
 
@@ -631,15 +669,15 @@ async def get_performance_analytics(
         elif "busy" in outcome_lower:
             calls_busy += count
 
+    # Picked = calls a human answered. BUSY counts as picked (customer
+    # answered and cut the call); only NO-ANSWER comes out.
     calls_picked = total_calls - calls_no_answer
 
     success_rate = summary.get("success_rate", 0.0)
 
-    answer_rate = (
-        ((calls_picked + calls_no_answer) / total_calls * 100)
-        if total_calls > 0
-        else 0.0
-    )
+    # (The previous formula added no_answer back into the numerator, so
+    # answer_rate was always exactly 100%.)
+    answer_rate = (calls_picked / total_calls * 100) if total_calls > 0 else 0.0
 
     failure_rate = (failed_calls / total_calls * 100) if total_calls > 0 else 0.0
 

--- a/app/api/routers/breeze_buddy/chat/__init__.py
+++ b/app/api/routers/breeze_buddy/chat/__init__.py
@@ -115,6 +115,20 @@ async def list_sessions(
     template_id: Optional[str] = Query(
         default=None, description="Filter to one agent/template."
     ),
+    merchant_id: Optional[str] = Query(
+        default=None,
+        description=(
+            "Narrow to one merchant (workspace). Admins use it to view a "
+            "single workspace; scoped users are already limited by RBAC."
+        ),
+    ),
+    reseller_id: Optional[str] = Query(
+        default=None,
+        description=(
+            "Narrow to one reseller (all its merchants). Admins use it to "
+            "view a reseller umbrella; scoped users are limited by RBAC."
+        ),
+    ),
     status_filter: Optional[ChatSessionStatus] = Query(
         default=None, alias="status", description="Filter by session status."
     ),
@@ -144,6 +158,8 @@ async def list_sessions(
     return await list_chat_sessions_handler(
         current_user,
         template_id=template_id,
+        merchant_id=merchant_id,
+        reseller_id=reseller_id,
         session_status=status_filter,
         date_from=date_from,
         date_to=date_to,

--- a/app/api/routers/breeze_buddy/chat/handlers.py
+++ b/app/api/routers/breeze_buddy/chat/handlers.py
@@ -871,6 +871,8 @@ async def list_chat_sessions_handler(
     current_user: UserInfo,
     *,
     template_id: Optional[str] = None,
+    merchant_id: Optional[str] = None,
+    reseller_id: Optional[str] = None,
     session_status: Optional[ChatSessionStatus] = None,
     date_from: Optional[datetime] = None,
     date_to: Optional[datetime] = None,
@@ -881,11 +883,17 @@ async def list_chat_sessions_handler(
 
     Scoped to the caller's accessible resellers/merchants via the shared
     analytics ``apply_hierarchical_filters`` (admins see all; a user with no
-    assignments gets 403). All filtering + pagination happens in SQL.
+    assignments gets 403). A client ``merchant_id`` narrows within that scope
+    — for admins it selects one workspace (kept by apply_hierarchical_filters);
+    scoped users can't widen past their RBAC. All filtering happens in SQL.
     """
     filters: Dict[str, Any] = {}
     if template_id:
         filters["template_id"] = template_id
+    if merchant_id:
+        filters["merchant_id"] = merchant_id
+    if reseller_id:
+        filters["reseller_id"] = reseller_id
     if session_status is not None:
         filters["status"] = session_status.value
     if date_from is not None:

--- a/app/database/accessor/breeze_buddy/chat_analytics.py
+++ b/app/database/accessor/breeze_buddy/chat_analytics.py
@@ -11,6 +11,7 @@ from app.database.queries import run_parameterized_query
 from app.database.queries.breeze_buddy.chat_analytics import (
     get_chat_analytics_summary_query,
     get_chat_analytics_trends_query,
+    get_chats_by_hour_query,
 )
 
 
@@ -38,4 +39,22 @@ async def get_chat_trends_from_db(
         return [dict(row) for row in rows] if rows else []
     except Exception as e:
         logger.error(f"Error fetching chat analytics trends: {e}", exc_info=True)
+        raise
+
+
+async def get_chats_by_hour_from_db(filters: Dict[str, Any]) -> Dict[str, int]:
+    """Conversations started by hour-of-day (IST). Returns a dict
+    hour ("0".."23") -> count, zero-filled for all 24 hours (mirrors
+    ``get_calls_by_hour_from_db``)."""
+    query, values = get_chats_by_hour_query(filters)
+    try:
+        rows = await run_parameterized_query(query, values)
+        hours: Dict[str, int] = {str(h): 0 for h in range(24)}
+        for row in rows or []:
+            hour = row["hour"]
+            if hour is not None and 0 <= hour <= 23:
+                hours[str(hour)] = row["count"] or 0
+        return hours
+    except Exception as e:
+        logger.error(f"Error fetching chats-by-hour: {e}", exc_info=True)
         raise

--- a/app/database/queries/breeze_buddy/analytics.py
+++ b/app/database/queries/breeze_buddy/analytics.py
@@ -106,8 +106,8 @@ def build_analytics_where_clause(
     Returns:
         Tuple of (conditions list, values list)
     """
-    conditions = []
-    values = []
+    conditions: List[str] = []
+    values: List[Any] = []
 
     # Filter by execution_mode to exclude test calls from analytics.
     # HOLD_TRANSFER is included so hold & consult outbound legs appear in
@@ -138,20 +138,20 @@ def build_analytics_where_clause(
         conditions.append(f"lct.{date_column} < ${len(values) + value_offset}")
 
     # Standard column filters
-    # Template filter - supports BOTH template name and template_id for backward compatibility
+    # Template filter — ID ONLY (2026-07-13): name-based filtering removed;
+    # template names are mutable display strings, not identifiers. The
+    # `template` key survives only as a UUID-carrying alias of template_id
+    # (the schema validator rejects names; this raise is defense-in-depth so
+    # a bypassing caller can never silently get UNSCOPED analytics).
     if "template" in filters and filters["template"]:
         template_value = filters["template"]
-        # Auto-detect if it's a UUID (template_id) or a name (template)
-        if is_uuid(template_value):
-            # Filter by template_id (UUID)
-            values.append(template_value)
-            conditions.append(f"lct.template_id = ${len(values) + value_offset}::UUID")
-            logger.debug(f"Filtering by template_id (UUID): {template_value}")
-        else:
-            # Filter by template name (backward compat)
-            values.append(template_value)
-            conditions.append(f"lct.template = ${len(values) + value_offset}")
-            logger.debug(f"Filtering by template name: {template_value}")
+        if not is_uuid(template_value):
+            raise ValueError(
+                "analytics template filter must be a template UUID; "
+                "name-based filtering was removed"
+            )
+        values.append(template_value)
+        conditions.append(f"lct.template_id = ${len(values) + value_offset}::UUID")
 
     # Explicit template_id filter (takes precedence if both provided)
     if "template_id" in filters and filters["template_id"]:
@@ -202,6 +202,19 @@ def build_analytics_where_clause(
         for key, value in filters["payload_filters"].items():
             # Skip invalid keys silently to prevent SQL injection
             if not is_valid_payload_filter_key(key):
+                continue
+            if key == "customer_mobile_number" and isinstance(value, str):
+                # Phone search: digits-contained match. Stored numbers carry
+                # '+'/country-code prefixes the caller can't know, so exact
+                # equality never matched (console search bug, 2026-07-14).
+                digits = "".join(ch for ch in value if ch.isdigit())
+                if not digits:
+                    continue
+                values.append(f"%{digits}%")
+                conditions.append(
+                    "regexp_replace(lct.payload->>'customer_mobile_number', '\\D', '', 'g') "
+                    f"LIKE ${len(values) + value_offset}"
+                )
                 continue
             values.append(value)
             conditions.append(f"lct.payload->>'{key}' = ${len(values) + value_offset}")
@@ -746,7 +759,8 @@ def get_attempts_to_connect_query(filters: Dict[str, Any]) -> Tuple[str, List[An
 
     Attempt ordinal is derived with ROW_NUMBER over attempt_count (then time) so it
     is robust regardless of how attempt_count is based. A "connected" attempt is any
-    row whose outcome is set and not NO_ANSWER / BUSY.
+    row whose outcome is set and not NO_ANSWER / BUSY / ABORT (aborted leads were
+    cancelled — often with zero dials — and must not read as a first-attempt pick).
     """
     conditions, values = build_analytics_where_clause(filters)
     where_clause = " WHERE " + " AND ".join(conditions) if conditions else ""
@@ -779,7 +793,7 @@ def get_attempts_to_connect_query(filters: Dict[str, Any]) -> Tuple[str, List[An
         picked AS (
             SELECT request_id, MIN(attempt_no) AS pick_attempt
             FROM attempts
-            WHERE outcome IS NOT NULL AND outcome NOT IN ('NO_ANSWER', 'BUSY')
+            WHERE outcome IS NOT NULL AND outcome NOT IN ('NO_ANSWER', 'BUSY', 'ABORT')
             GROUP BY request_id
         )
         SELECT
@@ -795,8 +809,9 @@ def get_calls_by_hour_query(filters: Dict[str, Any]) -> Tuple[str, List[Any]]:
     """
     Distribution of calls by hour-of-day (0-23), derived from call_initiated_time.
     Honors all standard filters including call_direction; test calls are excluded by
-    build_analytics_where_clause. Hour is extracted in the DB session timezone, matching
-    the day-bucketing used by the trends query (IST conversion is a shared fast-follow).
+    build_analytics_where_clause. Hour is extracted after an explicit shift to
+    Asia/Kolkata so buckets are IST regardless of the DB session timezone —
+    the UI labels this chart "IST".
     """
     conditions, values = build_analytics_where_clause(filters)
     conditions.append("lct.call_initiated_time IS NOT NULL")
@@ -810,7 +825,7 @@ def get_calls_by_hour_query(filters: Dict[str, Any]) -> Tuple[str, List[Any]]:
 
     text = f"""
         SELECT
-            EXTRACT(HOUR FROM lct.call_initiated_time)::int AS hour,
+            EXTRACT(HOUR FROM (lct.call_initiated_time AT TIME ZONE 'Asia/Kolkata'))::int AS hour,
             COUNT(*) as count
         FROM "{LEAD_CALL_TRACKER_TABLE}" lct
         {join_clause}

--- a/app/database/queries/breeze_buddy/chat_analytics.py
+++ b/app/database/queries/breeze_buddy/chat_analytics.py
@@ -18,6 +18,7 @@ from app.database.queries.breeze_buddy.analytics import convert_ist_to_utc, is_u
 
 CHAT_SESSION_TABLE = "chat_session"
 CHAT_MESSAGE_TABLE = "chat_message"
+CHAT_TURN_METRICS_TABLE = "chat_turn_metrics"
 
 
 def build_chat_analytics_where_clause(
@@ -120,13 +121,44 @@ def get_chat_analytics_summary_query(
             ORDER BY total_conversations DESC
         """
     else:
+        # CTE per source table — the grouped LEFT JOIN shape can't carry
+        # AVG/percentile safely (message fan-out would weight sessions by
+        # their message count), so sessions, messages, and turn metrics
+        # each aggregate on their own and the single-row results cross-join.
         text = f"""
-            SELECT
-                {_AGG_METRICS},
-                COUNT(DISTINCT cs.template_id) AS total_agents
-            FROM {CHAT_SESSION_TABLE} cs
-            LEFT JOIN {CHAT_MESSAGE_TABLE} m ON m.session_id = cs.id
-            {where}
+            WITH base AS (
+                SELECT cs.* FROM {CHAT_SESSION_TABLE} cs
+                {where}
+            ),
+            sess AS (
+                SELECT
+                    COUNT(*) AS total_conversations,
+                    COUNT(*) FILTER (WHERE b.status = 'ACTIVE') AS active_conversations,
+                    COUNT(*) FILTER (WHERE b.status = 'IDLE') AS idle_conversations,
+                    COUNT(*) FILTER (WHERE b.status = 'ENDED') AS ended_conversations,
+                    COUNT(*) FILTER (WHERE b.ended_reason = 'user_ended') AS user_ended_conversations,
+                    COUNT(*) FILTER (WHERE b.ended_reason = 'idle_timeout') AS idle_timeout_conversations,
+                    COUNT(DISTINCT b.template_id) AS total_agents,
+                    AVG(EXTRACT(EPOCH FROM (b.last_activity_at - b.created_at))) AS avg_session_seconds
+                FROM base b
+            ),
+            msg AS (
+                SELECT
+                    COUNT(*) AS total_messages,
+                    COUNT(*) FILTER (WHERE m.role = 'user') AS user_messages,
+                    COUNT(*) FILTER (WHERE m.role = 'assistant') AS assistant_messages
+                FROM {CHAT_MESSAGE_TABLE} m
+                JOIN base b ON b.id = m.session_id
+            ),
+            turn AS (
+                SELECT
+                    percentile_cont(0.5) WITHIN GROUP (ORDER BY t.ttft_ms) AS median_reply_ms
+                FROM {CHAT_TURN_METRICS_TABLE} t
+                JOIN base b ON b.id = t.session_id
+                WHERE t.ttft_ms IS NOT NULL
+            )
+            SELECT sess.*, msg.*, turn.*
+            FROM sess, msg, turn
         """
     return text, values
 
@@ -134,7 +166,14 @@ def get_chat_analytics_summary_query(
 def get_chat_analytics_trends_query(
     filters: Dict[str, Any], time_granularity: str = "day"
 ) -> Tuple[str, List[Any]]:
-    """Time-bucketed "chats started" series (conversations created per bucket)."""
+    """Time-bucketed chat series: conversations created per bucket, plus
+    message volume per bucket.
+
+    Messages are bucketed by the MESSAGE's own created_at (a real
+    messages-per-day series), while belonging to the session universe the
+    filters select — a session-start bucket would pile a long session's
+    whole thread onto its first day.
+    """
     conditions, values = build_chat_analytics_where_clause(filters)
     where = " WHERE " + " AND ".join(conditions) if conditions else ""
     # Whitelisted — never interpolate raw user input into SQL.
@@ -144,13 +183,59 @@ def get_chat_analytics_trends_query(
         else "month" if time_granularity == "month" else "day"
     )
     text = f"""
+        WITH base AS (
+            SELECT cs.id, cs.created_at, cs.status
+            FROM {CHAT_SESSION_TABLE} cs
+            {where}
+        ),
+        sess AS (
+            SELECT
+                DATE_TRUNC('{date_trunc}', b.created_at) AS time_bucket,
+                COUNT(*) AS conversations_started,
+                COUNT(*) FILTER (WHERE b.status = 'ENDED') AS ended_conversations
+            FROM base b
+            GROUP BY 1
+        ),
+        msg AS (
+            SELECT
+                DATE_TRUNC('{date_trunc}', m.created_at) AS time_bucket,
+                COUNT(*) AS total_messages,
+                COUNT(*) FILTER (WHERE m.role = 'user') AS user_messages,
+                COUNT(*) FILTER (WHERE m.role = 'assistant') AS assistant_messages
+            FROM {CHAT_MESSAGE_TABLE} m
+            JOIN base b ON b.id = m.session_id
+            GROUP BY 1
+        )
         SELECT
-            DATE_TRUNC('{date_trunc}', cs.created_at) AS time_bucket,
-            COUNT(*) AS conversations_started,
-            COUNT(*) FILTER (WHERE cs.status = 'ENDED') AS ended_conversations
+            COALESCE(s.time_bucket, g.time_bucket) AS time_bucket,
+            COALESCE(s.conversations_started, 0) AS conversations_started,
+            COALESCE(s.ended_conversations, 0) AS ended_conversations,
+            COALESCE(g.total_messages, 0) AS total_messages,
+            COALESCE(g.user_messages, 0) AS user_messages,
+            COALESCE(g.assistant_messages, 0) AS assistant_messages
+        FROM sess s
+        FULL OUTER JOIN msg g ON g.time_bucket = s.time_bucket
+        ORDER BY 1 ASC
+    """
+    return text, values
+
+
+def get_chats_by_hour_query(filters: Dict[str, Any]) -> Tuple[str, List[Any]]:
+    """Distribution of conversations started by hour-of-day (0-23), IST.
+
+    Hour is extracted after an explicit shift to Asia/Kolkata so the buckets
+    match the IST calendar-day filtering regardless of the DB session
+    timezone (the voice calls-by-hour query does the same).
+    """
+    conditions, values = build_chat_analytics_where_clause(filters)
+    where = " WHERE " + " AND ".join(conditions) if conditions else ""
+    text = f"""
+        SELECT
+            EXTRACT(HOUR FROM (cs.created_at AT TIME ZONE 'Asia/Kolkata'))::int AS hour,
+            COUNT(*) AS count
         FROM {CHAT_SESSION_TABLE} cs
         {where}
-        GROUP BY time_bucket
-        ORDER BY time_bucket ASC
+        GROUP BY 1
+        ORDER BY 1
     """
     return text, values

--- a/app/schemas/breeze_buddy/analytics.py
+++ b/app/schemas/breeze_buddy/analytics.py
@@ -4,7 +4,7 @@ from datetime import date, datetime
 from enum import Enum
 from typing import Any, Dict, List, Literal, Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 
 class AnalyticsType(str, Enum):
@@ -26,6 +26,7 @@ class AnalyticsType(str, Enum):
     DISTINCT_MERCHANT_IDS = "distinct-merchant-ids"
     ATTEMPTS_TO_CONNECT = "attempts-to-connect"
     CALLS_BY_HOUR = "calls-by-hour"
+    CHATS_BY_HOUR = "chats-by-hour"
 
 
 class TimeGranularity(str, Enum):
@@ -40,12 +41,34 @@ class AnalyticsFilters(BaseModel):
     """Filters for analytics queries - all filters applied with AND logic"""
 
     template: Optional[str] = Field(
-        None, description="Filter by template name (e.g., 'order-confirmation')"
+        None,
+        description=(
+            "Deprecated alias of template_id — must be a template UUID. "
+            "Filtering by template NAME was removed 2026-07-13: names are "
+            "mutable display strings, not identifiers."
+        ),
     )
     template_id: Optional[str] = Field(
         None,
         description="Filter by template UUID (chat analytics key off template_id, which has no name column)",
     )
+
+    @field_validator("template")
+    @classmethod
+    def _template_must_be_uuid(cls, v: Optional[str]) -> Optional[str]:
+        if v is None:
+            return v
+        import uuid
+
+        try:
+            uuid.UUID(v)
+        except (ValueError, AttributeError, TypeError):
+            raise ValueError(
+                "filtering analytics by template name is no longer supported — "
+                "pass the template UUID (template_id)"
+            )
+        return v
+
     # New field names
     merchant_id: Optional[str] = Field(
         None, description="Filter by single merchant identifier"


### PR DESCRIPTION
## What

Analytics correctness batch — every change is about numbers telling the truth. **Dashboards will visibly change** where the old numbers were wrong; that's the point, but flag it to anyone watching those charts:

### Voice metrics
- **`answer_rate` was mathematically always 100%** — the old formula added `no_answer` back into the numerator (`(picked + no_answer) / total`). Now `picked / total`. BUSY stays "picked" (the customer answered and cut the call); only NO-ANSWER counts as unanswered.
- **attempts-to-connect**: `ABORT` no longer reads as a connected first attempt — aborted leads were cancelled, often with zero dials.
- **calls-by-hour** buckets after an explicit `AT TIME ZONE 'Asia/Kolkata'` shift instead of inheriting the DB session timezone (chart is labeled IST in the console).
- **Template filter is id-only end-to-end** (follow-through of #888/#889): the schema validator rejects template *names* with a clear 422; the WHERE builder raises rather than silently returning unscoped analytics if bypassed. ⚠️ Any caller still filtering by template name gets an error instead of wrong data — the legacy dashboard already sends UUIDs.
- **Phone search fixed**: `payload_filters.customer_mobile_number` is now a digits-contained match; stored numbers carry `+`/country-code prefixes, so exact equality never matched anything.

### Chat analytics (rebuilt as CTE aggregates)
- Summary: role-split message counts, `ended_reason` split (user-ended vs idle-timeout), `avg_session_seconds` (first-to-last activity), `median_reply_ms` from `chat_turn_metrics` TTFT.
- Trends: per-bucket total/user/assistant message counts.
- New **`chats-by-hour`** analytics type (IST, same shape as calls-by-hour).

### Chat session scoping
`GET /chat/sessions` takes optional `merchant_id` / `reseller_id` to narrow **within** the caller's RBAC scope — admins use it to pick one workspace; scoped users cannot widen past `apply_hierarchical_filters` (narrowing only).

## Not in this PR

No DB changes or migrations — all queries run against existing tables/columns. The `campaign_id` analytics filter is in #911 (campaigns); if both are open, whichever merges second needs a trivial rebase (adjacent hunks in the WHERE builder / filter schema).

## Testing

- `black --check` + `pyrefly check` clean; smoke test asserts chats-by-hour is registered, template-name filter is rejected, UUID accepted, scoping params present.
- All rebuilt chat queries curl-verified against a local prod-seeded DB (15/15 probe); console analytics pages (global + per-agent, voice + chat) ran on exactly these endpoints for days of local use (31/31 probe).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Planned follow-up (tracked, not in this PR)

The deprecated `template` filter alias (UUID-enforced here) will be **removed entirely** in a later pass — `AnalyticsFilters` will expose only `template_id`. Sequence: sweep console/legacy callers to `template_id`, then drop the field + validator + WHERE-builder branch. Tracked in the console repo at `docs/redesign/api-gaps.md#22` (user call 2026-07-17).
