### PR TITLE
feat(widget-voice): carry noise_cancellation on /voice/connect

### DIFF
--- a/app/api/routers/breeze_buddy/widget/handlers.py
+++ b/app/api/routers/breeze_buddy/widget/handlers.py
@@ -861,11 +861,20 @@ async def voice_connect_handler(
                 detail="Failed to start widget voice session. Try again shortly.",
             )
 
+        # Client audio flag: browser Krisp noise cancellation defaults ON;
+        # the template opts out via configurations.client_noise_cancellation
+        # = false. Same contract as the web-voice /connect response.
+        tpl_cfg = template.configurations
+        noise_cancellation = not (
+            tpl_cfg is not None and tpl_cfg.client_noise_cancellation is False
+        )
+
         return WidgetVoiceConnectResponse(
             room_url=session_info["room_url"],
             daily_token=session_info["token"],
             lead_id=lead_id,
             ttl_seconds=_DAILY_ROOM_TTL_SECONDS,
+            noise_cancellation=noise_cancellation,
         )
     finally:
         await lock.release()

--- a/app/schemas/breeze_buddy/chat.py
+++ b/app/schemas/breeze_buddy/chat.py
@@ -565,6 +565,13 @@ class WidgetVoiceConnectResponse(BaseModel):
         description="Daily room expiry (typ. 3600s). The widget_token "
         "outlives this; you can reconnect voice within the widget_token TTL.",
     )
+    noise_cancellation: bool = Field(
+        True,
+        description="Whether the client should apply browser-side (Krisp) "
+        "noise cancellation to the mic input. False only when the template "
+        "sets configurations.client_noise_cancellation=false. Mirrors the "
+        "same flag on the web-voice /connect response.",
+    )
 
 
 class WidgetVoiceEndResponse(BaseModel):


### PR DESCRIPTION
## What

Follow-up to #914: the widget's voice-attachment endpoint now carries the same client audio flag.

- `WidgetVoiceConnectResponse.noise_cancellation: bool = True` — `false` only when the template sets `configurations.client_noise_cancellation: false` (the field #914 introduced).
- `voice_connect_handler` stamps it from the template it **already loads** (`get_template_by_id_cached`) — zero extra DB/cache reads.

With this, both voice entry points (`/agent/voice/breeze-buddy/connect` and `/widget/session/{id}/voice/connect`) speak the identical contract, and the widget SDK can honor template opt-outs instead of hardcoding Krisp behavior.

## Blast radius

Additive response field with a `True` default — existing widget clients ignore unknown keys; nothing changes behavior until the SDK reads the flag (SDK change is on the console-redesign frontend branch, ships separately). No DB changes, no migration.

## Testing

`black` + `pyrefly` clean; schema smoke (default ON, opt-out settable); widget router import smoke.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added browser-based microphone noise cancellation settings to voice connections.
  * Noise cancellation is enabled by default and can be disabled through template configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->