### PR TITLE
BZ-4797: feat: template level service callback url for inbound and outbound calls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,6 @@ logs
 .claude/memory/
 CLAUDE.local.md
 .claude/settings.json
-
+graphify-out/
 # Local scratch / test fixtures
 temp/

--- a/app/ai/voice/agents/breeze_buddy/agent/transfer.py
+++ b/app/ai/voice/agents/breeze_buddy/agent/transfer.py
@@ -22,6 +22,7 @@ from app.ai.voice.agents.breeze_buddy.template.context import (
 from app.ai.voice.agents.breeze_buddy.template.vad import create_vad_analyzer
 from app.ai.voice.agents.breeze_buddy.utils.agent_transfer import PendingAgentTransfer
 from app.core.config.dynamic import BB_DAILY_AUDIO_OUT_10MS_CHUNKS
+from app.core.logger import logger
 from app.core.logger.context import update_log_context
 from app.database.accessor.breeze_buddy.lead_call_tracker import update_lead_template
 
@@ -84,11 +85,16 @@ async def apply_transfer(bot: "Agent", transfer: PendingAgentTransfer) -> None:
                 "generation": bot.generation,
             }
         )
-        await update_lead_template(
+        updated_lead = await update_lead_template(
             lead_id=bot.lead.id,
             template=transfer.template.name,
             template_id=str(transfer.template.id),
         )
+        if updated_lead:
+            updated_lead.metaData = bot.lead.metaData
+            bot.lead = updated_lead
+        else:
+            logger.warning(f"Failed to update lead template for lead {bot.lead.id}")
 
     # 3. Swap the template trio — everything downstream reads these.
     bot.template = transfer.template

--- a/app/ai/voice/agents/breeze_buddy/callbacks/service_callback.py
+++ b/app/ai/voice/agents/breeze_buddy/callbacks/service_callback.py
@@ -10,9 +10,12 @@ from app.core.logger import logger
 
 async def service_callback(context: TemplateContext, args):
     """
-    Handler to send webhook with call summary to the calling service.
+    Handler to send a call summary to the template service callback.
 
-    This handler sends the call summary data to the reporting webhook URL.
+    This handler sends the call summary data to the service callback configured
+    on the active template. If the lead's payload still carries a
+    `reporting_webhook_url`, that URL takes precedence over the template
+    config; max_attempts always comes from the template.
 
     Args:
         context: Handler context with bot state access
@@ -100,11 +103,18 @@ async def service_callback(context: TemplateContext, args):
             f"call_duration={call_duration}s"
         )
 
-        webhook_url = (
-            context.lead.payload.get("reporting_webhook_url")
-            if context.lead and context.lead.payload
+        callback_config = (
+            context.configurations.service_callback if context.configurations else None
+        )
+        reporting_webhook_url = (
+            (context.lead.payload or {}).get("reporting_webhook_url")
+            if context.lead
             else None
         )
+        webhook_url = reporting_webhook_url or (
+            callback_config.url if callback_config else None
+        )
+        max_attempts = callback_config.max_attempts if callback_config else 3
 
         if webhook_url:
             logger.info(
@@ -116,6 +126,7 @@ async def service_callback(context: TemplateContext, args):
                     context.aiohttp_session,
                     webhook_url,
                     summary_data,
+                    max_retries=max_attempts,
                 )
                 if not success:
                     logger.error(
@@ -135,8 +146,7 @@ async def service_callback(context: TemplateContext, args):
         else:
             logger.info(
                 f"Skipping webhook send for call {context.call_sid} "
-                f"(url={'present' if webhook_url else 'missing'}, "
-                f"outcome={outcome})"
+                f"(no service callback configured, outcome={outcome})"
             )
 
     except Exception as e:

--- a/app/ai/voice/agents/breeze_buddy/dispatch/__init__.py
+++ b/app/ai/voice/agents/breeze_buddy/dispatch/__init__.py
@@ -7,6 +7,8 @@ ZSET-as-schedule + leader-elected promoter + worker-pool design.
 See docs/BACKLOG_DISPATCHER_REDESIGN.md for the architecture.
 """
 
+from typing import Optional
+
 from app.ai.voice.agents.breeze_buddy.dispatch.channel_semaphore import (
     acquire_channel_token,
     init_channel_semaphore,
@@ -30,10 +32,23 @@ from app.ai.voice.agents.breeze_buddy.dispatch.reconcilers import (
     reconcile_backlog_to_zset,
     reconcile_channel_tokens,
 )
-from app.ai.voice.agents.breeze_buddy.dispatch.worker import (
-    start_workers,
-    stop_workers,
-)
+
+
+async def start_workers(count: Optional[int] = None):
+    from app.ai.voice.agents.breeze_buddy.dispatch.worker import (
+        start_workers as _start_workers,
+    )
+
+    return await _start_workers(count)
+
+
+async def stop_workers() -> None:
+    from app.ai.voice.agents.breeze_buddy.dispatch.worker import (
+        stop_workers as _stop_workers,
+    )
+
+    await _stop_workers()
+
 
 __all__ = [
     "DISPATCHABLE_EXECUTION_MODES",

--- a/app/ai/voice/agents/breeze_buddy/ivr/selection.py
+++ b/app/ai/voice/agents/breeze_buddy/ivr/selection.py
@@ -265,14 +265,16 @@ async def _check_deferred_inbound_policy(
                 meta_data=meta_data,
                 call_end_time=datetime.now(timezone.utc),
             )
-            await update_lead_template(
+            if await update_lead_template(
                 lead_id=existing.id,
                 template=template.name,
                 template_id=str(template.id),
-            )
-            logger.info(
-                f"[IVR] Updated existing lead {existing.id} with outcome={outcome}"
-            )
+            ):
+                logger.info(f"[IVR] Updated template for blocked lead {existing.id}")
+            else:
+                logger.warning(
+                    f"[IVR] Failed to update template for blocked lead {existing.id}"
+                )
         else:
             await log_blocked_call(
                 call_id=call_sid,

--- a/app/ai/voice/agents/breeze_buddy/managers/calls.py
+++ b/app/ai/voice/agents/breeze_buddy/managers/calls.py
@@ -39,6 +39,7 @@ from app.ai.voice.agents.breeze_buddy.services.telephony.plivo.recording import 
 from app.ai.voice.agents.breeze_buddy.services.telephony.twilio.recording import (
     download_call_recording as download_call_recording_twilio,
 )
+from app.ai.voice.agents.breeze_buddy.template.cache import get_template_by_id_cached
 from app.ai.voice.agents.breeze_buddy.template.types import (
     TemplateModel,
 )
@@ -164,10 +165,16 @@ async def _run_pre_checks_for_lead(
     )
 
     # Send webhook for pre-check failure
-    reporting_webhook_url = (
-        lead.payload.get("reporting_webhook_url") if lead.payload else None
+    service_callback = (
+        template.configurations.service_callback
+        if template and template.configurations
+        else None
     )
-    if reporting_webhook_url:
+    webhook_url = (lead.payload or {}).get("reporting_webhook_url") or (
+        service_callback.url if service_callback else None
+    )
+    max_attempts = service_callback.max_attempts if service_callback else 3
+    if webhook_url:
         failed_checks = [r for r in pre_check_result.results if not r.passed]
         webhook_data = {
             "outcome": "PRECHECK_FAILED",
@@ -176,7 +183,12 @@ async def _run_pre_checks_for_lead(
             "orderId": lead.request_id,
         }
         try:
-            await send_webhook_with_retry(session, reporting_webhook_url, webhook_data)
+            await send_webhook_with_retry(
+                session,
+                webhook_url,
+                webhook_data,
+                max_retries=max_attempts,
+            )
         except Exception as e:
             logger.error(
                 f"Error sending pre-check failure webhook for lead {lead.id}: {e}"
@@ -366,7 +378,10 @@ async def _release_number(number_id: str, provider: CallProvider):
 
 
 async def _retry_call(
-    lead: LeadCallTracker, config: CallExecutionConfig, outcome: Optional[str] = None
+    lead: LeadCallTracker,
+    config: CallExecutionConfig,
+    outcome: Optional[str] = None,
+    template: Optional[TemplateModel] = None,
 ):
     """
     Schedules a retry for a call and sends webhook for NO_ANSWER outcomes.
@@ -375,8 +390,16 @@ async def _retry_call(
 
     # Send webhook for NO_ANSWER on every attempt
     if outcome == "NO_ANSWER":
-        reporting_webhook_url = (lead.payload or {}).get("reporting_webhook_url")
-        if reporting_webhook_url:
+        service_callback = (
+            template.configurations.service_callback
+            if template and template.configurations
+            else None
+        )
+        webhook_url = (lead.payload or {}).get("reporting_webhook_url") or (
+            service_callback.url if service_callback else None
+        )
+        max_attempts = service_callback.max_attempts if service_callback else 3
+        if webhook_url:
             call_duration = None
             if lead.call_initiated_time:
                 call_initiated_time_utc = lead.call_initiated_time.astimezone(
@@ -397,7 +420,10 @@ async def _retry_call(
             try:
                 async with create_aiohttp_session() as session:
                     success = await send_webhook_with_retry(
-                        session, reporting_webhook_url, summary_data, max_retries=3
+                        session,
+                        webhook_url,
+                        summary_data,
+                        max_retries=max_attempts,
                     )
                     if success:
                         logger.info(
@@ -621,7 +647,12 @@ async def handle_call_completion(
         and lead.call_direction == CallDirection.OUTBOUND
         and lead.execution_mode == ExecutionMode.TELEPHONY
     ):
-        await _retry_call(lead, config, outcome)
+        template = (
+            await get_template_by_id_cached(lead.template_id)
+            if lead.template_id
+            else None
+        )
+        await _retry_call(lead, config, outcome, template)
 
     return updated_lead
 
@@ -710,7 +741,12 @@ async def handle_unanswered_calls(call_id: str):
         and lead.call_direction == CallDirection.OUTBOUND
         and lead.execution_mode == ExecutionMode.TELEPHONY
     ):
-        await _retry_call(lead, config, "NO_ANSWER")
+        template = (
+            await get_template_by_id_cached(lead.template_id)
+            if lead.template_id
+            else None
+        )
+        await _retry_call(lead, config, "NO_ANSWER", template)
 
 
 async def update_call_recording(

--- a/app/ai/voice/agents/breeze_buddy/template/field_reference.json
+++ b/app/ai/voice/agents/breeze_buddy/template/field_reference.json
@@ -286,6 +286,13 @@
       "description": "When true, this template is eligible to handle inbound calls. Typically paired with ivr_configuration.",
       "example": false
     },
+    "service_callback": {
+      "description": "Webhook callback fired at the end of every call (inbound and outbound). url is the endpoint to POST to; max_attempts is the total number of HTTP attempts (default 3, minimum 1). Note: a lead's payload.reporting_webhook_url, if still present, overrides this url.",
+      "example": {
+        "url": "https://example.com/webhook/call-summary",
+        "max_attempts": 3
+      }
+    },
     "mcp": {
       "description": "MCP (Model Context Protocol) server configuration. Enables dynamic tool discovery at session start — the agent connects to listed MCP servers and receives available tools before the first LLM turn.",
       "example": {

--- a/app/ai/voice/agents/breeze_buddy/template/types.py
+++ b/app/ai/voice/agents/breeze_buddy/template/types.py
@@ -684,6 +684,17 @@ class PhrasingOrder(str, Enum):
     RANDOM = "random"
 
 
+class ServiceCallbackConfig(BaseModel):
+    """Webhook callback fired at the end of every call (inbound and outbound)."""
+
+    url: str = Field(..., description="URL to POST the call summary to")
+    max_attempts: int = Field(
+        3,
+        ge=1,
+        description="Total HTTP POST attempts, including retries.",
+    )
+
+
 class FillerPhraseConfig(BaseModel):
     """Configuration for TTS filler phrases spoken during function call execution."""
 
@@ -2019,6 +2030,9 @@ class ConfigurationModel(BaseModel):
         None, description="Default VAD configuration for the template"
     )
     enable_inbound: bool = False  # Whether this template can handle inbound calls
+    service_callback: Optional["ServiceCallbackConfig"] = Field(
+        None, description="Callback configuration for inbound/outbound call reporting"
+    )
     user_idle_configuration: Optional[UserIdleHandlingConfig] = (
         None  # User idle handling config
     )

--- a/app/ai/voice/agents/breeze_buddy/types/models.py
+++ b/app/ai/voice/agents/breeze_buddy/types/models.py
@@ -55,7 +55,6 @@ class PushLeadRequest(BaseModel):
 
     reseller_id: str
     merchant_id: Optional[str] = None
-    reporting_webhook_url: str | None = None
     execution_mode: Optional[ExecutionMode] = (
         None  # Defaults to TELEPHONY if not provided
     )

--- a/app/api/routers/breeze_buddy/leads/__init__.py
+++ b/app/api/routers/breeze_buddy/leads/__init__.py
@@ -67,7 +67,6 @@ async def push_lead(
             "template": "order-confirmation",
             "merchant_id": "merchant_123",
             "request_id": "order_456",
-            "reporting_webhook_url": "https://example.com/webhook",
             "payload": {
                 "customer_name": "John Doe",
                 "customer_mobile_number": "+1234567890",

--- a/app/api/routers/breeze_buddy/leads/handlers.py
+++ b/app/api/routers/breeze_buddy/leads/handlers.py
@@ -331,10 +331,7 @@ async def push_lead_handler(req: PushLeadRequest, current_user: UserInfo) -> Dic
             seconds=config.initial_offset + req.delay
         )
 
-        # Prepare payload with reporting webhook URL
         lead_payload = {**req.payload}
-        if req.reporting_webhook_url:
-            lead_payload["reporting_webhook_url"] = req.reporting_webhook_url
 
         if req.is_playground:
             # Playground supplies stt_language and tts_provider explicitly —

--- a/app/database/accessor/breeze_buddy/lead_call_tracker.py
+++ b/app/database/accessor/breeze_buddy/lead_call_tracker.py
@@ -493,7 +493,9 @@ async def update_lead_call_completion_details(
 
 
 async def update_lead_template(
-    lead_id: str, template: str, template_id: str
+    lead_id: str,
+    template: str,
+    template_id: str,
 ) -> Optional[LeadCallTracker]:
     """
     Update the template name and template_id for a lead.

--- a/app/database/queries/breeze_buddy/lead_call_tracker.py
+++ b/app/database/queries/breeze_buddy/lead_call_tracker.py
@@ -656,7 +656,9 @@ def update_lead_request_id_query(
 
 
 def update_lead_template_query(
-    lead_id: str, template: str, template_id: str
+    lead_id: str,
+    template: str,
+    template_id: str,
 ) -> Tuple[str, List[Any]]:
     """
     Update the template name and template_id for a lead.
@@ -681,7 +683,7 @@ def update_lead_template_query(
         WHERE "id" = $3
         RETURNING *;
     """
-    values = [template, template_id, lead_id]
+    values: List[Any] = [template, template_id, lead_id]
     return text, values
 
 

--- a/docs/BREEZE_BUDDY_ARCHITECTURE.md
+++ b/docs/BREEZE_BUDDY_ARCHITECTURE.md
@@ -80,7 +80,18 @@ class PushLeadRequest(BaseModel):
     template: str                     # Template name to use
     reseller_id: str                     # Reseller identifier
     merchant_id: Optional[str] = None  # Merchant-specific identifier
-    reporting_webhook_url: str | None = None  # Callback URL
+```
+
+Call callbacks are configured on the template:
+```json
+{
+  "configurations": {
+    "service_callback": {
+      "url": "https://example.com/webhook",
+      "max_attempts": 3
+    }
+  }
+}
 ```
 
 **Insertion Process** ([leads.py:153-275](app/api/routers/breeze_buddy/leads.py#L153-L275)):
@@ -581,7 +592,9 @@ class TemplateContext:
 - `lead`: Lead data
 - `call_sid`: Call identifier
 - `order_id`: Order identifier
-- `reporting_webhook_url`: Callback URL
+- `configurations.service_callback`: Active template callback configuration
+  (a lead's `payload.reporting_webhook_url`, if present, overrides
+  this)
 - `root_span`: OpenTelemetry span
 - `provider`: Telephony provider
 - `end_conversation_callbacks`: Callback list
@@ -622,8 +635,7 @@ Inserts new lead for processing ([leads.py:153-275](app/api/routers/breeze_buddy
   },
   "template": "order-confirmation",
   "reseller_id": "reseller_123",
-  "merchant_id": "merchant_456",
-  "reporting_webhook_url": "https://example.com/webhook"
+  "merchant_id": "merchant_456"
 }
 ```
 
@@ -778,7 +790,9 @@ Creates new template in database ([template.py:55-105](app/database/accessor/bre
 **Process**:
 1. Extract callback response data
 2. Validate against `expected_callback_response_schema`
-3. Send webhook request to `reporting_webhook_url`
+3. Send webhook request to the active template's `service_callback.url`
+   (or the lead's legacy `reporting_webhook_url`, if still present, which
+   takes precedence during the migration window)
 
 ### Internal Handlers
 
@@ -1157,7 +1171,7 @@ Have a good day."
 
 7. End Conversation Callbacks
    ├─> Extract callback data: {updated_address: "..."}
-   ├─> POST to reporting_webhook_url
+   ├─> POST to the active template's service_callback.url
    └─> Update final call status
 ```
 
@@ -1180,8 +1194,7 @@ Have a good day."
   },
   "template": "order-confirmation",
   "reseller_id": "reseller_123",
-  "merchant_id": "myshop.myshopify.com",
-  "reporting_webhook_url": "https://myshop.com/webhooks/call-status"
+  "merchant_id": "myshop.myshopify.com"
 }
 ```
 

--- a/tests/test_agent_transfer.py
+++ b/tests/test_agent_transfer.py
@@ -1,0 +1,109 @@
+from types import SimpleNamespace
+from typing import Any, cast
+from unittest.mock import patch
+
+from app.ai.voice.agents.breeze_buddy.template.types import (
+    ConfigurationModel,
+    ServiceCallbackConfig,
+)
+
+
+async def test_apply_transfer_uses_target_template_configuration():
+    from app.ai.voice.agents.breeze_buddy.agent.transfer import apply_transfer
+
+    source_config = ConfigurationModel(
+        service_callback=ServiceCallbackConfig(url="https://example.com/source")
+    )
+    target_config = ConfigurationModel()
+    original_lead = SimpleNamespace(id="lead-1", metaData={})
+    updated_lead = SimpleNamespace(id="lead-1", metaData=None)
+    target_template = SimpleNamespace(
+        id="target-template-id",
+        name="target-template",
+        configurations=target_config,
+    )
+    bot = SimpleNamespace(
+        transfer_count=0,
+        generation=0,
+        template=SimpleNamespace(id="source-template-id", name="source-template"),
+        configurations=source_config,
+        template_vars={},
+        _handoff_messages=[],
+        context=None,
+        prior_generation_messages=[],
+        lead=original_lead,
+        is_daily_mode=False,
+        _rebuild=SimpleNamespace(
+            ws_proxy=object(),
+            telephony_transport_type="telephony",
+            telephony_call_data={},
+        ),
+        task=None,
+        flow_manager=None,
+        _context_aggregator=None,
+        _rtvi_processor=None,
+        approval_manager=None,
+        _user_idle_callback_handler=None,
+        _flow_initialized=False,
+        greeting_source=None,
+        greeting_text=None,
+        _post_greeting_task=None,
+    )
+    transfer = SimpleNamespace(
+        template=target_template,
+        template_vars={"customer_name": "Ada"},
+        handoff_messages=[{"role": "system", "content": "handoff"}],
+    )
+    transfer_context = SimpleNamespace(
+        record_node_exit=lambda: None,
+        _get_ist_timestamp=lambda: "2026-07-24T00:00:00+05:30",
+    )
+
+    async def fake_update(**kwargs):
+        assert kwargs == {
+            "lead_id": "lead-1",
+            "template": "target-template",
+            "template_id": "target-template-id",
+        }
+        return updated_lead
+
+    async def fake_vad(**kwargs):
+        return "vad", "vad-params"
+
+    async def fake_transport(*args):
+        return "transport"
+
+    with (
+        patch(
+            "app.ai.voice.agents.breeze_buddy.agent.transfer.TemplateContext",
+            return_value=transfer_context,
+        ),
+        patch(
+            "app.ai.voice.agents.breeze_buddy.agent.transfer.update_lead_template",
+            new=fake_update,
+        ),
+        patch(
+            "app.ai.voice.agents.breeze_buddy.agent.transfer.FlowConfigBuilder",
+            return_value=SimpleNamespace(handler_map={}),
+        ),
+        patch(
+            "app.ai.voice.agents.breeze_buddy.agent.transfer.create_vad_analyzer",
+            new=fake_vad,
+        ),
+        patch(
+            "app.ai.voice.agents.breeze_buddy.agent.transfer.get_transport_params",
+            return_value={"telephony": lambda: "params"},
+        ),
+        patch(
+            "app.ai.voice.agents.breeze_buddy.agent.transfer._create_telephony_transport",
+            new=fake_transport,
+        ),
+        patch("app.ai.voice.agents.breeze_buddy.agent.transfer.update_log_context"),
+    ):
+        await apply_transfer(cast(Any, bot), cast(Any, transfer))
+
+    assert bot.template is target_template
+    assert bot.configurations is target_config
+    assert bot.configurations.service_callback is None
+    assert bot.lead is updated_lead
+    assert bot.lead.metaData["agent_transfers"][0]["to_template"] == "target-template"

--- a/tests/test_service_callback_config.py
+++ b/tests/test_service_callback_config.py
@@ -1,0 +1,273 @@
+from types import SimpleNamespace
+from typing import Any, cast
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.ai.voice.agents.breeze_buddy.template.types import (
+    ConfigurationModel,
+    ServiceCallbackConfig,
+)
+from app.ai.voice.agents.breeze_buddy.types.models import PushLeadRequest
+
+
+def test_service_callback_config_defaults():
+    cfg = ServiceCallbackConfig(url="https://example.com/cb")
+    assert cfg.max_attempts == 3
+
+
+def test_service_callback_config_custom_attempts():
+    cfg = ServiceCallbackConfig(url="https://example.com/cb", max_attempts=1)
+    assert cfg.max_attempts == 1
+
+
+def test_service_callback_config_rejects_zero_attempts():
+    bad_attempts: int = 0
+    with pytest.raises(Exception):
+        ServiceCallbackConfig(url="https://example.com/cb", max_attempts=bad_attempts)
+
+
+def test_configuration_model_accepts_service_callback():
+    model = ConfigurationModel(
+        service_callback=ServiceCallbackConfig(
+            url="https://example.com/cb", max_attempts=5
+        )
+    )
+    assert model.service_callback is not None
+    assert model.service_callback.url == "https://example.com/cb"
+    assert model.service_callback.max_attempts == 5
+
+
+def test_configuration_model_service_callback_optional():
+    model = ConfigurationModel()
+    assert model.service_callback is None
+
+
+def test_push_lead_request_has_no_reporting_webhook_url():
+    properties = PushLeadRequest.model_json_schema().get("properties", {})
+    assert "reporting_webhook_url" not in properties
+
+
+async def test_service_callback_uses_template_url():
+    from app.ai.voice.agents.breeze_buddy.callbacks.service_callback import (
+        service_callback,
+    )
+
+    sent: dict = {}
+
+    async def fake_send(session, url, data, max_retries=3):
+        sent["url"] = url
+        sent["max_retries"] = max_retries
+        return True
+
+    configurations = ConfigurationModel(
+        service_callback=ServiceCallbackConfig(
+            url="https://example.com/hook", max_attempts=2
+        )
+    )
+    context = MagicMock()
+    context.configurations = configurations
+    context.lead = SimpleNamespace(
+        metaData={},
+        outcome="SUCCESS",
+        call_initiated_time=None,
+        attempt_count=0,
+        request_id="req-1",
+        payload={},
+    )
+    context.call_sid = "CA123"
+    context.aiohttp_session = object()
+    context.expected_callback_response_schema = None
+
+    with patch(
+        "app.ai.voice.agents.breeze_buddy.callbacks.service_callback.send_webhook_with_retry",
+        new=fake_send,
+    ):
+        await service_callback(context, {})
+
+    assert sent["url"] == "https://example.com/hook"
+    assert sent["max_retries"] == 2
+
+
+async def test_service_callback_prefers_lead_payload_webhook_url():
+    """Lead payload's reporting_webhook_url should win over template config."""
+    from app.ai.voice.agents.breeze_buddy.callbacks.service_callback import (
+        service_callback,
+    )
+
+    sent: dict = {}
+
+    async def fake_send(session, url, data, max_retries=3):
+        sent["url"] = url
+        sent["max_retries"] = max_retries
+        return True
+
+    configurations = ConfigurationModel(
+        service_callback=ServiceCallbackConfig(
+            url="https://example.com/hook", max_attempts=2
+        )
+    )
+    context = MagicMock()
+    context.configurations = configurations
+    context.lead = SimpleNamespace(
+        metaData={},
+        outcome="SUCCESS",
+        call_initiated_time=None,
+        attempt_count=0,
+        request_id="req-1",
+        payload={"reporting_webhook_url": "https://example.com/legacy"},
+    )
+    context.call_sid = "CA123"
+    context.aiohttp_session = object()
+    context.expected_callback_response_schema = None
+
+    with patch(
+        "app.ai.voice.agents.breeze_buddy.callbacks.service_callback.send_webhook_with_retry",
+        new=fake_send,
+    ):
+        await service_callback(context, {})
+
+    assert sent["url"] == "https://example.com/legacy"
+
+
+async def test_service_callback_skips_when_no_config():
+    from app.ai.voice.agents.breeze_buddy.callbacks.service_callback import (
+        service_callback,
+    )
+
+    called = []
+
+    async def fake_send(session, url, data, max_retries=3):
+        called.append(url)
+        return True
+
+    context = MagicMock()
+    context.configurations = ConfigurationModel()
+    context.lead = SimpleNamespace(
+        metaData={},
+        outcome="SUCCESS",
+        call_initiated_time=None,
+        attempt_count=0,
+        request_id="req-2",
+        payload={},
+    )
+    context.call_sid = "CA456"
+    context.aiohttp_session = object()
+    context.expected_callback_response_schema = None
+
+    with patch(
+        "app.ai.voice.agents.breeze_buddy.callbacks.service_callback.send_webhook_with_retry",
+        new=fake_send,
+    ):
+        await service_callback(context, {})
+
+    assert called == []
+
+
+async def test_precheck_failure_uses_template_service_callback():
+    from app.ai.voice.agents.breeze_buddy.managers.calls import _run_pre_checks_for_lead
+    from app.ai.voice.agents.breeze_buddy.managers.pre_checks import (
+        PreCheckResult,
+        SinglePreCheckResult,
+    )
+
+    sent: dict = {}
+
+    async def fake_send(session, url, data, max_retries=3):
+        sent["url"] = url
+        sent["max_retries"] = max_retries
+        return True
+
+    async def fake_update(**kwargs):
+        return None
+
+    async def fake_pre_checks(**kwargs):
+        return PreCheckResult(
+            should_proceed=False,
+            results=[SinglePreCheckResult("eligibility", False, "rejected")],
+        )
+
+    template = SimpleNamespace(
+        configurations=ConfigurationModel(
+            service_callback=ServiceCallbackConfig(
+                url="https://example.com/precheck", max_attempts=2
+            )
+        )
+    )
+    lead = SimpleNamespace(
+        id="lead-1",
+        attempt_count=0,
+        request_id="request-1",
+        payload={},
+    )
+    config = SimpleNamespace(pre_checks=[object()])
+
+    with (
+        patch(
+            "app.ai.voice.agents.breeze_buddy.managers.calls.run_pre_checks",
+            new=fake_pre_checks,
+        ),
+        patch(
+            "app.ai.voice.agents.breeze_buddy.managers.calls.update_lead_call_completion_details",
+            new=fake_update,
+        ),
+        patch(
+            "app.ai.voice.agents.breeze_buddy.managers.calls.send_webhook_with_retry",
+            new=fake_send,
+        ),
+    ):
+        assert not await _run_pre_checks_for_lead(
+            cast(Any, config), cast(Any, lead), cast(Any, template), object()
+        )
+
+    assert sent == {"url": "https://example.com/precheck", "max_retries": 2}
+
+
+async def test_retry_call_uses_template_service_callback():
+    from app.ai.voice.agents.breeze_buddy.managers.calls import _retry_call
+
+    sent: dict = {}
+
+    class Session:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc_value, traceback):
+            return None
+
+    async def fake_send(session, url, data, max_retries=3):
+        sent["url"] = url
+        sent["max_retries"] = max_retries
+        return True
+
+    template = SimpleNamespace(
+        configurations=ConfigurationModel(
+            service_callback=ServiceCallbackConfig(
+                url="https://example.com/no-answer", max_attempts=4
+            )
+        )
+    )
+    lead = SimpleNamespace(
+        attempt_count=0,
+        call_initiated_time=None,
+        call_id="call-1",
+        request_id="request-1",
+        payload={},
+    )
+    config = SimpleNamespace(max_retry=1)
+
+    with (
+        patch(
+            "app.ai.voice.agents.breeze_buddy.managers.calls.create_aiohttp_session",
+            return_value=Session(),
+        ),
+        patch(
+            "app.ai.voice.agents.breeze_buddy.managers.calls.send_webhook_with_retry",
+            new=fake_send,
+        ),
+    ):
+        await _retry_call(
+            cast(Any, lead), cast(Any, config), "NO_ANSWER", cast(Any, template)
+        )
+
+    assert sent == {"url": "https://example.com/no-answer", "max_retries": 4}


### PR DESCRIPTION
### Ticket
https://plane.breezehq.dev/breeze/browse/BZ-4797
### Impacted Areas
- **Template Configuration** — merchants set a `service_callback` (`url`, `max_attempts`) directly on the template's `configurations`
- **Outbound Calls** — call summary/completion, pre-check-failure, and no-answer callbacks are always sent to the active template's `service_callback.url`
- **Inbound Calls** — same template-level callback fires for inbound calls; there is no per-request override
- **Lead Push API** — the legacy per-request `reporting_webhook_url` field has been removed from `PushLeadRequest`; it is silently ignored if a caller still sends it
### What is done?
Added `service_callback: Optional[ServiceCallbackConfig]` (`url`, `max_attempts`) on the template's `configurations` in `template/types.py`. `callbacks/service_callback.py` resolves the webhook purely from `context.configurations.service_callback` at send-time for completion, pre-check-failure, and no-answer callbacks — for both inbound and outbound calls. The per-request `reporting_webhook_url` field has been removed from `PushLeadRequest` (`types/models.py`) and `push_lead_handler` no longer reads or forwards it.
### Why is it done?
Previously, `reporting_webhook_url` had to be passed explicitly on every outbound lead push request, and there was no equivalent mechanism for inbound calls (no API caller exists at call time). Merchants now configure the callback once on the template and it applies uniformly to all calls, inbound and outbound, removing the need for a per-call/per-request value entirely.
### How to test it?
1. Create or update a template — set `configurations.service_callback.url` (e.g. a webhook.site URL)
2. Push an outbound lead for that template — the call summary should be POSTed to the template's `service_callback.url` after the call ends
3. Receive an inbound call on a number linked to that template — after the call ends, confirm the call summary is POSTed to the template's `service_callback.url`
4. If multiple templates are on the same number (IVR), select one via IVR — confirm the selected template's `service_callback.url` receives the call summary
5. Confirm pushing a lead with a legacy `reporting_webhook_url` in the request body has no effect (field is ignored, no error)
### Priority
**high**
### Environment Variables
No new environment variables.
### Dev Proof
1. Queries:
- SELECT id, template, payload FROM lead_call_tracker WHERE id = '0b588e5e-019d-4fad-aa0a-dd3f22b5d866';
- SELECT id, template, call_direction, payload FROM lead_call_tracker WHERE call_id = 'test-inbound-call-001';

2. Screens:
- https://drive.google.com/file/d/1MS_LRqrRMB426xWyZdFRYltukgHaZf8c/view?usp=sharing
- https://drive.google.com/file/d/1d0i8XX-WwTuFBbD1ewOoIni79oacKaSw/view?usp=sharing
- https://drive.google.com/file/d/1JmwSDJW3IgGre0UtOeoot-U88WLCuLfs/view?usp=sharing
