### PR TITLE
feat(access): first-class resellers table + explicit access grants (migration 036, dual-write)

### DIFF
--- a/app/database/accessor/breeze_buddy/access_grants.py
+++ b/app/database/accessor/breeze_buddy/access_grants.py
@@ -1,0 +1,46 @@
+"""
+Accessor helpers for the normalized access-grant projection.
+
+These run on a caller-supplied connection so the grant-table writes share the
+transaction of the users/merchants row they project — either everything
+commits or nothing does. See queries.breeze_buddy.access_grants for the
+projection rules.
+"""
+
+from typing import List, Optional
+
+import asyncpg
+
+from app.database.queries.breeze_buddy.access_grants import (
+    ensure_reseller_query,
+    project_user_access_queries,
+)
+
+
+async def ensure_reseller_on_conn(
+    conn: asyncpg.Connection, reseller_id: str, name: Optional[str] = None
+) -> None:
+    """Create the resellers row for an umbrella slug if it is missing."""
+    query, values = ensure_reseller_query(reseller_id, name)
+    await conn.execute(query, *values)
+
+
+async def sync_user_access_on_conn(
+    conn: asyncpg.Connection,
+    user_id: str,
+    role: str,
+    reseller_ids: Optional[List[str]],
+    merchant_ids: Optional[List[str]],
+    created_by: Optional[str] = None,
+    username: Optional[str] = None,
+) -> None:
+    """Re-project one user's JSONB access arrays into the grant tables."""
+    for query, values in project_user_access_queries(
+        user_id=user_id,
+        role=role,
+        reseller_ids=reseller_ids,
+        merchant_ids=merchant_ids,
+        created_by=created_by,
+        username=username,
+    ):
+        await conn.execute(query, *values)

--- a/app/database/accessor/breeze_buddy/merchants.py
+++ b/app/database/accessor/breeze_buddy/merchants.py
@@ -9,6 +9,8 @@ decoders from decoder.breeze_buddy.merchants.
 from typing import List, Optional, Tuple
 
 from app.core.logger import logger
+from app.database import get_db_connection
+from app.database.accessor.breeze_buddy.access_grants import ensure_reseller_on_conn
 from app.database.decoder.breeze_buddy.merchants import decode_merchant
 from app.database.queries import run_parameterized_query
 from app.database.queries.breeze_buddy.merchants import (
@@ -73,13 +75,21 @@ async def create_merchant(
     )
 
     try:
-        result = await run_parameterized_query(query, values)
-        row = result[0] if result else None
+        async for conn in get_db_connection():
+            async with conn.transaction():
+                if reseller_id:
+                    # merchants.reseller_id carries an FK to resellers; keep
+                    # legacy callers working by materializing unknown umbrella
+                    # slugs as bare resellers rows.
+                    await ensure_reseller_on_conn(conn, reseller_id)
+                result = await conn.fetch(query, *values)
+            row = result[0] if result else None
 
-        if row:
-            logger.info(f"Created merchant entity: {merchant_id}")
-            return decode_merchant(row)
+            if row:
+                logger.info(f"Created merchant entity: {merchant_id}")
+                return decode_merchant(row)
 
+            return None
         return None
     except Exception as e:
         logger.error(f"Error creating merchant entity {merchant_id}: {e}")
@@ -286,13 +296,20 @@ async def update_merchant(
         return await get_merchant_by_merchant_identifier(merchant_id)
 
     try:
-        result = await run_parameterized_query(query, values)
-        row = result[0] if result else None
+        async for conn in get_db_connection():
+            async with conn.transaction():
+                if reseller_id:
+                    # Reassignment must satisfy the resellers FK; materialize
+                    # unknown umbrella slugs like create_merchant does.
+                    await ensure_reseller_on_conn(conn, reseller_id)
+                result = await conn.fetch(query, *values)
+            row = result[0] if result else None
 
-        if row:
-            logger.info(f"Updated merchant entity: {merchant_id}")
-            return decode_merchant(row)
+            if row:
+                logger.info(f"Updated merchant entity: {merchant_id}")
+                return decode_merchant(row)
 
+            return None
         return None
     except Exception as e:
         logger.error(f"Error updating merchant entity {merchant_id}: {e}")

--- a/app/database/accessor/breeze_buddy/users.py
+++ b/app/database/accessor/breeze_buddy/users.py
@@ -12,6 +12,10 @@ from typing import List, Optional, Tuple
 from app.core.logger import logger
 from app.core.security.password import hash_password
 from app.database import get_db_connection
+from app.database.accessor.breeze_buddy.access_grants import (
+    ensure_reseller_on_conn,
+    sync_user_access_on_conn,
+)
 from app.database.decoder.breeze_buddy.users import decode_user
 from app.database.queries import run_parameterized_query
 from app.database.queries.breeze_buddy.merchants import create_merchant_query
@@ -158,8 +162,19 @@ async def create_merchant_and_user_atomically(
 
     async for conn in get_db_connection():
         async with conn.transaction():
+            # The umbrella must exist before the merchants-row FK lands
+            # (BB_SELF_SIGNUP_RESELLER_ID may point at an unprovisioned slug).
+            await ensure_reseller_on_conn(conn, reseller_id)
             await conn.execute(merchant_q, *merchant_v)
             await conn.execute(user_q, *user_v)
+            await sync_user_access_on_conn(
+                conn,
+                user_id=user_id,
+                role=getattr(role, "value", role),
+                reseller_ids=[reseller_id],
+                merchant_ids=[merchant_id],
+                username=username,
+            )
         return
 
 
@@ -210,13 +225,28 @@ async def create_user(
     )
 
     try:
-        result = await run_parameterized_query(query, values)
-        row = result[0] if result else None
+        async for conn in get_db_connection():
+            async with conn.transaction():
+                result = await conn.fetch(query, *values)
+                row = result[0] if result else None
+                if row:
+                    # Keep the grant tables a projection of the JSONB arrays
+                    # (dual-write; arrays stay authoritative until cutover).
+                    await sync_user_access_on_conn(
+                        conn,
+                        user_id=id,
+                        role=getattr(role, "value", role),
+                        reseller_ids=reseller_ids,
+                        merchant_ids=merchant_ids,
+                        created_by=owner_id,
+                        username=username,
+                    )
 
-        if row:
-            logger.info(f"Created user account: {username} (role: {role})")
-            return decode_user(row)
+            if row:
+                logger.info(f"Created user account: {username} (role: {role})")
+                return decode_user(row)
 
+            return None
         return None
     except Exception as e:
         logger.error(f"Error creating user {username}: {e}")
@@ -346,14 +376,38 @@ async def update_user(
     if not values:
         return await get_user_by_id(user_id)
 
+    access_changed = reseller_ids is not None or merchant_ids is not None
+
     try:
-        result = await run_parameterized_query(query, values)
-        row = result[0] if result else None
+        async for conn in get_db_connection():
+            async with conn.transaction():
+                result = await conn.fetch(query, *values)
+                row = result[0] if result else None
+                if row and access_changed:
+                    # Re-project from the post-update arrays (RETURNING row),
+                    # so the grant tables track whatever the arrays now say.
+                    await sync_user_access_on_conn(
+                        conn,
+                        user_id=user_id,
+                        role=row["role"],
+                        reseller_ids=(
+                            json.loads(row["reseller_ids"])
+                            if row.get("reseller_ids")
+                            else []
+                        ),
+                        merchant_ids=(
+                            json.loads(row["merchant_ids"])
+                            if row.get("merchant_ids")
+                            else []
+                        ),
+                        username=row["username"],
+                    )
 
-        if row:
-            logger.info(f"Updated user: {user_id}")
-            return decode_user(row)
+            if row:
+                logger.info(f"Updated user: {user_id}")
+                return decode_user(row)
 
+            return None
         return None
     except Exception as e:
         logger.error(f"Error updating user {user_id}: {e}")

--- a/app/database/migrations/036_create_resellers_and_access_grants.sql
+++ b/app/database/migrations/036_create_resellers_and_access_grants.sql
@@ -1,0 +1,159 @@
+-- Access model v2, step 1 (2026-07-17): first-class resellers + explicit
+-- access grants.
+--
+-- Today an umbrella (reseller) exists only as strings: merchants.reseller_id
+-- points at users.id of a role='reseller' login (7 of 8 umbrella slugs in
+-- prod have no such row), and a user's access lives in two unconstrained
+-- JSONB arrays on users (merchant_ids / reseller_ids, with ["*"] wildcards).
+--
+-- This migration adds the normalized model and backfills it from those
+-- arrays. The JSONB columns REMAIN AUTHORITATIVE for now — accessors
+-- dual-write both representations, and the read cutover ships separately —
+-- so applying this migration changes no runtime behavior by itself.
+--
+--   resellers             umbrella entity; id = slug (equals users.id when a
+--                         reseller login exists, but a login is optional)
+--   user_reseller_access  umbrella grants; all_workspaces=true is the
+--                         explicit form of the old merchant_ids=["*"]
+--                         wildcard (every workspace under the umbrella,
+--                         present and future)
+--   user_merchant_access  explicit per-workspace membership rows
+--
+-- Wildcards with NO umbrella linkage (admin-style rows) intentionally
+-- produce no grant rows: global access is what role='admin' means.
+-- Array entries pointing at nonexistent merchants/resellers are dropped
+-- from the normalized projection (the arrays keep them until cutover).
+
+BEGIN;
+
+-- ============================================================================
+-- 1. resellers — the umbrella becomes a real entity
+-- ============================================================================
+CREATE TABLE IF NOT EXISTS resellers (
+    id VARCHAR(255) PRIMARY KEY,
+    name VARCHAR(255),
+    description TEXT,
+    is_active BOOLEAN NOT NULL DEFAULT true,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW() NOT NULL,
+    updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW() NOT NULL,
+    CONSTRAINT resellers_id_no_spaces CHECK (id !~ '\s')
+);
+
+CREATE INDEX IF NOT EXISTS idx_resellers_is_active ON resellers(is_active);
+
+COMMENT ON TABLE resellers IS
+    'Umbrella entities (workspaces group under a reseller). id is the slug '
+    'used by merchants.reseller_id; a users row with the same id is an '
+    'optional login for the umbrella, not the umbrella itself.';
+
+-- Backfill order matters: reseller logins first (they carry a display name),
+-- then slugs known only from merchants rows, then slugs that appear only
+-- inside users.reseller_ids arrays.
+INSERT INTO resellers (id, name)
+SELECT id, username FROM users WHERE role = 'reseller'
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO resellers (id, name)
+SELECT DISTINCT reseller_id, reseller_id
+FROM merchants
+WHERE reseller_id IS NOT NULL
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO resellers (id, name)
+SELECT DISTINCT rid, rid
+FROM users
+CROSS JOIN LATERAL jsonb_array_elements_text(reseller_ids) AS rid
+WHERE rid <> '*'
+ON CONFLICT (id) DO NOTHING;
+
+-- The self-serve umbrella (BB_SELF_SIGNUP_RESELLER_ID default) must exist
+-- before the merchants FK lands, and signup writes against it.
+INSERT INTO resellers (id, name, description)
+VALUES (
+    'breeze-self-serve',
+    'Breeze self-serve',
+    'Umbrella for self-registered merchants (see BB_SELF_SIGNUP_RESELLER_ID)'
+)
+ON CONFLICT (id) DO NOTHING;
+
+-- Real FK: every umbrella slug on merchants now references a real entity.
+-- NULL stays allowed (unassigned merchants). Deleting an umbrella that still
+-- owns merchants is refused (NO ACTION).
+ALTER TABLE merchants DROP CONSTRAINT IF EXISTS fk_merchants_reseller;
+ALTER TABLE merchants
+    ADD CONSTRAINT fk_merchants_reseller
+    FOREIGN KEY (reseller_id) REFERENCES resellers(id);
+
+-- ============================================================================
+-- 2. user_reseller_access — umbrella grants (wildcard becomes explicit)
+-- ============================================================================
+CREATE TABLE IF NOT EXISTS user_reseller_access (
+    user_id VARCHAR(255) NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    reseller_id VARCHAR(255) NOT NULL REFERENCES resellers(id) ON DELETE CASCADE,
+    all_workspaces BOOLEAN NOT NULL DEFAULT false,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW() NOT NULL,
+    created_by VARCHAR(255),
+    PRIMARY KEY (user_id, reseller_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_user_reseller_access_reseller
+    ON user_reseller_access(reseller_id);
+
+COMMENT ON COLUMN user_reseller_access.all_workspaces IS
+    'true = access to every workspace under this umbrella, present and '
+    'future (the explicit form of the legacy merchant_ids=["*"] wildcard); '
+    'false = plain umbrella affiliation with per-workspace rows deciding '
+    'workspace access.';
+
+INSERT INTO user_reseller_access (user_id, reseller_id, all_workspaces)
+SELECT u.id, rid, (u.merchant_ids ? '*')
+FROM users u
+CROSS JOIN LATERAL jsonb_array_elements_text(u.reseller_ids) AS rid
+JOIN resellers r ON r.id = rid
+WHERE rid <> '*'
+ON CONFLICT (user_id, reseller_id) DO NOTHING;
+
+-- A reseller login always holds an all-workspaces grant on its own umbrella.
+INSERT INTO user_reseller_access (user_id, reseller_id, all_workspaces)
+SELECT id, id, true FROM users WHERE role = 'reseller'
+ON CONFLICT (user_id, reseller_id) DO UPDATE SET all_workspaces = true;
+
+-- ============================================================================
+-- 3. user_merchant_access — explicit workspace membership
+-- ============================================================================
+CREATE TABLE IF NOT EXISTS user_merchant_access (
+    user_id VARCHAR(255) NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    merchant_id VARCHAR(255) NOT NULL
+        REFERENCES merchants(merchant_id) ON DELETE CASCADE,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW() NOT NULL,
+    created_by VARCHAR(255),
+    PRIMARY KEY (user_id, merchant_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_user_merchant_access_merchant
+    ON user_merchant_access(merchant_id);
+
+INSERT INTO user_merchant_access (user_id, merchant_id)
+SELECT u.id, mid
+FROM users u
+CROSS JOIN LATERAL jsonb_array_elements_text(u.merchant_ids) AS mid
+JOIN merchants m ON m.merchant_id = mid
+WHERE mid <> '*'
+ON CONFLICT (user_id, merchant_id) DO NOTHING;
+
+COMMIT;
+
+-- ────────────────────────────────────────────────────────────────────────────
+-- Deploy-race note. This migration must run BEFORE the dual-write pods roll.
+-- In the window between it committing and the last old pod draining, old pods
+-- can still write users/merchants; those writes land in the JSONB arrays but
+-- not in the grant tables. Two properties bound the risk:
+--   * the migration is a single transaction — a concurrent merchant insert
+--     with an unknown umbrella makes the FK addition fail and the WHOLE
+--     migration rolls back cleanly (re-run it), never half-applies;
+--   * every backfill statement above is idempotent (ON CONFLICT DO NOTHING).
+-- If any users/merchants writes did land during the roll, re-running the
+-- INSERT statements of sections 1–3 verbatim (psql, read-committed) after the
+-- deploy reconciles the grant tables. No quiesce is needed at this fleet's
+-- write rate.
+-- ────────────────────────────────────────────────────────────────────────────

--- a/app/database/queries/breeze_buddy/access_grants.py
+++ b/app/database/queries/breeze_buddy/access_grants.py
@@ -1,0 +1,157 @@
+"""
+Query builders for the normalized access-grant projection
+(``resellers`` / ``user_reseller_access`` / ``user_merchant_access``).
+
+Migration 036 introduced the normalized access model. During the transition
+the ``users.reseller_ids`` / ``users.merchant_ids`` JSONB arrays remain the
+authoritative representation; the statements built here keep the grant tables
+a faithful projection of them (dual-write). Read cutover ships separately.
+
+Projection rules (mirror the 036 backfill):
+- every non-``"*"`` entry of ``reseller_ids`` becomes a
+  ``user_reseller_access`` row; unknown umbrella slugs are materialized as
+  bare ``resellers`` rows first, exactly like the migration's array-derived
+  backfill (otherwise an admin assigning a not-yet-created umbrella would
+  leave the arrays asserting access the tables silently lack).
+  ``all_workspaces`` is true when ``merchant_ids`` contains ``"*"`` (the
+  legacy umbrella-wide wildcard)
+- a ``role='reseller'`` account always holds an all-workspaces grant on its
+  own umbrella (and the ``resellers`` row is auto-created for it)
+- every non-``"*"`` entry of ``merchant_ids`` that names an existing merchant
+  becomes a ``user_merchant_access`` row; unknown MERCHANTS are deliberately
+  skipped (a workspace is a heavyweight entity — a typo must not create one)
+
+Rows are upserted then pruned (never blanket-deleted) so ``created_at`` /
+``created_by`` survive for grants that persist across re-projections.
+
+All functions here are pure — they return (query, values) tuples and perform
+no I/O.
+"""
+
+from typing import Any, List, Optional, Tuple
+
+RESELLERS_TABLE = "resellers"
+
+
+def ensure_reseller_query(
+    reseller_id: str, name: Optional[str] = None
+) -> Tuple[str, List[Any]]:
+    """Insert a resellers row if the umbrella does not exist yet (no-op otherwise)."""
+    query = f"""
+        INSERT INTO {RESELLERS_TABLE} (id, name)
+        VALUES ($1, $2)
+        ON CONFLICT (id) DO NOTHING
+    """
+    return query, [reseller_id, name or reseller_id]
+
+
+def project_user_access_queries(
+    user_id: str,
+    role: str,
+    reseller_ids: Optional[List[str]],
+    merchant_ids: Optional[List[str]],
+    created_by: Optional[str] = None,
+    username: Optional[str] = None,
+) -> List[Tuple[str, List[Any]]]:
+    """Build the ordered statements that re-project one user's JSONB arrays
+    into the grant tables.
+
+    Execute inside the same transaction as the users-row write.
+
+    Returns:
+        List of (query, values) tuples, in execution order.
+    """
+    is_reseller = role == "reseller"
+    umbrella_ids = [r for r in (reseller_ids or []) if r != "*"]
+    workspace_ids = [m for m in (merchant_ids or []) if m != "*"]
+    all_workspaces = "*" in (merchant_ids or [])
+
+    # The keep-sets for pruning: everything the projection is about to assert.
+    kept_umbrellas = list(
+        dict.fromkeys(umbrella_ids + ([user_id] if is_reseller else []))
+    )
+    kept_workspaces = list(dict.fromkeys(workspace_ids))
+
+    statements: List[Tuple[str, List[Any]]] = []
+
+    if is_reseller:
+        # A reseller login implies its umbrella entity exists.
+        statements.append(ensure_reseller_query(user_id, username))
+
+    if umbrella_ids:
+        # Materialize unknown umbrella slugs first (same as the migration's
+        # array-derived backfill) so the grant below never silently drops one.
+        statements.append(
+            (
+                """
+                INSERT INTO resellers (id, name)
+                SELECT rid, rid FROM unnest($1::text[]) AS rid
+                ON CONFLICT (id) DO NOTHING
+                """,
+                [umbrella_ids],
+            )
+        )
+        statements.append(
+            (
+                """
+                INSERT INTO user_reseller_access
+                    (user_id, reseller_id, all_workspaces, created_by)
+                SELECT $1, r.id, $3, $4
+                FROM resellers r
+                WHERE r.id = ANY($2::text[])
+                ON CONFLICT (user_id, reseller_id)
+                DO UPDATE SET all_workspaces = EXCLUDED.all_workspaces
+                """,
+                [user_id, umbrella_ids, all_workspaces, created_by],
+            )
+        )
+
+    if is_reseller:
+        statements.append(
+            (
+                """
+                INSERT INTO user_reseller_access
+                    (user_id, reseller_id, all_workspaces, created_by)
+                VALUES ($1, $1, true, $2)
+                ON CONFLICT (user_id, reseller_id)
+                DO UPDATE SET all_workspaces = true
+                """,
+                [user_id, created_by],
+            )
+        )
+
+    if workspace_ids:
+        statements.append(
+            (
+                """
+                INSERT INTO user_merchant_access (user_id, merchant_id, created_by)
+                SELECT $1, m.merchant_id, $3
+                FROM merchants m
+                WHERE m.merchant_id = ANY($2::text[])
+                ON CONFLICT (user_id, merchant_id) DO NOTHING
+                """,
+                [user_id, workspace_ids, created_by],
+            )
+        )
+
+    # Prune grants the arrays no longer assert.
+    statements.append(
+        (
+            """
+            DELETE FROM user_reseller_access
+            WHERE user_id = $1 AND NOT (reseller_id = ANY($2::text[]))
+            """,
+            [user_id, kept_umbrellas],
+        )
+    )
+    statements.append(
+        (
+            """
+            DELETE FROM user_merchant_access
+            WHERE user_id = $1 AND NOT (merchant_id = ANY($2::text[]))
+            """,
+            [user_id, kept_workspaces],
+        )
+    )
+
+    return statements

--- a/tests/test_access_grant_projection.py
+++ b/tests/test_access_grant_projection.py
@@ -1,0 +1,166 @@
+"""Tests for the access-grant projection builders (dual-write step of the
+normalized access model, migration 036).
+
+The grant tables must remain a faithful projection of the authoritative
+JSONB arrays on users:
+
+- non-``"*"`` reseller_ids entries -> user_reseller_access rows, with
+  ``all_workspaces`` true iff merchant_ids carries the ``"*"`` wildcard
+- ``role='reseller'`` -> resellers row ensured + all-workspaces self-grant
+- non-``"*"`` merchant_ids entries -> user_merchant_access rows
+- unknown umbrella slugs are materialized as bare resellers rows first
+  (mirrors the migration's array-derived backfill); unknown MERCHANTS are
+  skipped — a typo must not create a workspace
+- admin-style wildcards (no umbrella linkage) -> no grant rows at all
+- rows the arrays no longer assert are pruned, surviving rows keep their
+  created_at/created_by (upsert-then-prune, never blanket delete)
+
+Pure query-builder tests — SQL string + params only, no DB.
+"""
+
+from __future__ import annotations
+
+from app.database.queries.breeze_buddy.access_grants import (
+    ensure_reseller_query,
+    project_user_access_queries,
+)
+
+
+def _sql(statements):
+    return [q for q, _ in statements]
+
+
+def _joined(statements):
+    return "\n".join(q for q, _ in statements)
+
+
+def _prune_sql(statements):
+    return "\n".join(q for q, _ in statements if q.strip().startswith("DELETE"))
+
+
+# ── ensure_reseller_query ────────────────────────────────────────────────────
+
+
+def test_ensure_reseller_defaults_name_to_slug() -> None:
+    query, params = ensure_reseller_query("breeze")
+    assert "INSERT INTO resellers" in query
+    assert "ON CONFLICT (id) DO NOTHING" in query
+    assert params == ["breeze", "breeze"]
+
+
+def test_ensure_reseller_uses_display_name_when_given() -> None:
+    _, params = ensure_reseller_query("breeze", "Breeze Labs")
+    assert params == ["breeze", "Breeze Labs"]
+
+
+# ── member accounts ──────────────────────────────────────────────────────────
+
+
+def test_member_projects_umbrella_affiliation_and_workspace_rows() -> None:
+    statements = project_user_access_queries(
+        user_id="alice",
+        role="user",
+        reseller_ids=["breeze"],
+        merchant_ids=["acme-store", "other-store"],
+        created_by="admin",
+    )
+    joined = _joined(statements)
+
+    # unknown umbrella slugs are materialized before the grant lands
+    viv = next(
+        (q, p) for q, p in statements if "INSERT INTO resellers" in q and "unnest" in q
+    )
+    assert viv[1] == [["breeze"]]
+    assert statements.index(viv) < next(
+        i for i, (q, _) in enumerate(statements) if "user_reseller_access" in q
+    )
+
+    # umbrella affiliation upsert, non-wildcard
+    ura = next((q, p) for q, p in statements if "INSERT INTO user_reseller_access" in q)
+    assert "DO UPDATE SET all_workspaces = EXCLUDED.all_workspaces" in ura[0]
+    assert ura[1] == ["alice", ["breeze"], False, "admin"]
+
+    # workspace membership rows are FK-safe (joined against merchants)
+    uma = next((q, p) for q, p in statements if "INSERT INTO user_merchant_access" in q)
+    assert "FROM merchants m" in uma[0]
+    assert uma[1] == ["alice", ["acme-store", "other-store"], "admin"]
+
+    # both prunes present, keeping exactly what was asserted
+    assert "DELETE FROM user_reseller_access" in joined
+    assert "DELETE FROM user_merchant_access" in joined
+    prune_r = next(p for q, p in statements if "DELETE FROM user_reseller_access" in q)
+    prune_m = next(p for q, p in statements if "DELETE FROM user_merchant_access" in q)
+    assert prune_r == ["alice", ["breeze"]]
+    assert prune_m == ["alice", ["acme-store", "other-store"]]
+
+    # no blanket deletes — surviving rows keep created_at/created_by
+    assert "WHERE user_id = $1 AND NOT" in _prune_sql(statements)
+
+
+def test_umbrella_wildcard_becomes_all_workspaces_grant() -> None:
+    statements = project_user_access_queries(
+        user_id="owner-login",
+        role="merchant",
+        reseller_ids=["breeze"],
+        merchant_ids=["*"],
+    )
+    ura = next(p for q, p in statements if "INSERT INTO user_reseller_access" in q)
+    assert ura == ["owner-login", ["breeze"], True, None]
+
+    # the "*" itself never lands in the membership table
+    assert not any("INSERT INTO user_merchant_access" in q for q, _ in statements)
+    prune_m = next(p for q, p in statements if "DELETE FROM user_merchant_access" in q)
+    assert prune_m == ["owner-login", []]  # empty keep-set -> prune all rows
+
+
+# ── reseller accounts ────────────────────────────────────────────────────────
+
+
+def test_reseller_gets_umbrella_row_and_all_workspaces_self_grant() -> None:
+    statements = project_user_access_queries(
+        user_id="breeze",
+        role="reseller",
+        reseller_ids=["breeze"],
+        merchant_ids=["*"],
+        username="breeze-admin",
+    )
+    sqls = _sql(statements)
+
+    # umbrella entity ensured first
+    assert "INSERT INTO resellers" in sqls[0]
+    assert statements[0][1] == ["breeze", "breeze-admin"]
+
+    # unconditional self-grant with all_workspaces forced true
+    self_grant = next((q, p) for q, p in statements if "VALUES ($1, $1, true, $2)" in q)
+    assert "DO UPDATE SET all_workspaces = true" in self_grant[0]
+    assert self_grant[1] == ["breeze", None]
+
+    # own umbrella is in the prune keep-set exactly once
+    prune_r = next(p for q, p in statements if "DELETE FROM user_reseller_access" in q)
+    assert prune_r == ["breeze", ["breeze"]]
+
+
+# ── admin-style wildcards ────────────────────────────────────────────────────
+
+
+def test_unlinked_wildcards_project_to_nothing() -> None:
+    statements = project_user_access_queries(
+        user_id="root",
+        role="admin",
+        reseller_ids=["*"],
+        merchant_ids=["*"],
+    )
+    # no inserts at all — global access is what role='admin' means
+    assert not any(q.strip().startswith("INSERT") for q, _ in statements)
+    # prunes still run with empty keep-sets so stale rows disappear
+    prune_params = [p for q, p in statements if q.strip().startswith("DELETE")]
+    assert prune_params == [["root", []], ["root", []]]
+
+
+def test_empty_arrays_prune_everything() -> None:
+    statements = project_user_access_queries(
+        user_id="ghost", role="user", reseller_ids=None, merchant_ids=None
+    )
+    assert not any(q.strip().startswith("INSERT") for q, _ in statements)
+    prune_params = [p for q, p in statements if q.strip().startswith("DELETE")]
+    assert prune_params == [["ghost", []], ["ghost", []]]


### PR DESCRIPTION
## What

Step 1 of the users/resellers access-model normalization. Today an umbrella (reseller) exists only as strings — `merchants.reseller_id` points at `users.id` of a `role='reseller'` login (**7 of 8 umbrella slugs in prod have no such row**), and a user's access lives in two unconstrained JSONB arrays (`merchant_ids` / `reseller_ids` with `["*"]` wildcards).

This PR adds the normalized model **without changing any read path**:

| Table | Meaning |
|---|---|
| `resellers` | Umbrella as a real entity. `id` = slug; a same-id `users` row is an optional login, not the umbrella itself |
| `user_reseller_access` | Umbrella grants. `all_workspaces=true` is the explicit form of the legacy `merchant_ids=["*"]` wildcard |
| `user_merchant_access` | Explicit per-workspace membership rows, FK-clean both sides, `ON DELETE CASCADE` |

Plus a **real FK**: `merchants.reseller_id → resellers(id)`.

## Migration 036 (backfill included)

- `resellers` backfilled from reseller logins (username as display name), `merchants.reseller_id` slugs, `reseller_ids` array entries, and a `breeze-self-serve` seed (the `BB_SELF_SIGNUP_RESELLER_ID` default must exist before the FK lands).
- Grants backfilled per the projection rules below. Idempotent (`IF NOT EXISTS` / `ON CONFLICT` / `DROP CONSTRAINT IF EXISTS`), single transaction.

## Dual-write (JSONB stays authoritative)

Accessors re-project a user's arrays into the grant tables inside the **same transaction** as the users-row write (`create_user`, `update_user`, `create_merchant_and_user_atomically`). Projection rules:

- non-`"*"` `reseller_ids` entries → `user_reseller_access` rows; `all_workspaces` iff `merchant_ids` carries `"*"`
- `role='reseller'` → resellers row ensured + all-workspaces self-grant
- non-`"*"` `merchant_ids` entries naming an existing merchant → `user_merchant_access` rows
- admin-style wildcards (no umbrella linkage) → no rows; global access is what `role='admin'` means
- upsert-then-prune, so surviving grants keep `created_at`/`created_by`

`create_merchant` / `update_merchant` auto-materialize unknown umbrella slugs as bare `resellers` rows so the new FK never breaks legacy callers.

## Ops flags (deploy)

- **Migration 036 must run on prod** via `scripts/migrate.py` (run `status` first). Until it runs, the new code's grant-table writes will fail → **deploy order: migrate, then roll pods**.
- If any *other* writer inserts `merchants` rows directly (scripts, or nautilus sharing this DB), it must now satisfy the `reseller_id` FK — unknown slugs need a `resellers` row first. Reviewer check requested.

## Verification

- Migration applied on a prod-seeded local DB; backfill spot-verified for every account shape (member, umbrella-wildcard owner, reseller login, admin).
- e2e over the API: user create/update/delete (incl. `merchant_ids→["*"]` re-projection with `created_at` preserved), reseller-role create (umbrella + self-grant), self-serve signup atomic path (**projects `all_workspaces=false`** — a self-serve merchant cannot see sibling workspaces), merchant create under a fresh umbrella (auto-vivify), cascade deletes.
- 7 pure query-builder tests; `pyrefly` clean; pre-commit hooks green.

## Confidence: 9/10

No read path changes; the JSONB arrays remain authoritative, so behavior is identical for every consumer. Residual risk sits in the FK (external writers, see ops flag) and in writes now being transactional (previously autocommit single statements).

---
Part 1 of the access-model series. Next: resellers CRUD + effective-access APIs, then the read cutover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added normalized reseller and merchant access grants.
  * Preserved existing user access while supporting wildcard and role-based access.
  * Added automatic reseller setup during merchant and user creation or updates.
  * Added transactional synchronization of access permissions.
* **Data Improvements**
  * Migrated existing access data into the new grant model.
  * Added referential integrity for merchant–reseller relationships.
* **Tests**
  * Added coverage for access projection, wildcard handling, pruning, and role-based grants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->