### PR TITLE
feat(resellers): umbrella CRUD API + effective-access endpoint

### DIFF
--- a/app/api/routers/breeze_buddy/__init__.py
+++ b/app/api/routers/breeze_buddy/__init__.py
@@ -27,6 +27,9 @@ from app.api.routers.breeze_buddy.merchants import router as merchants_router
 from app.api.routers.breeze_buddy.numbers import router as numbers_router
 from app.api.routers.breeze_buddy.playground import router as playground_router
 
+# Reseller (umbrella) entities — first-class since migration 036
+from app.api.routers.breeze_buddy.resellers import router as resellers_router
+
 # Self-service signup and Google SSO (public, unauthenticated)
 from app.api.routers.breeze_buddy.signup import router as signup_router
 from app.api.routers.breeze_buddy.telephony import router as telephony_router
@@ -88,6 +91,9 @@ router.include_router(blacklist_router, prefix="", tags=["blacklist"])
 
 # Merchants (merchant identifiers - admin only)
 router.include_router(merchants_router, prefix="", tags=["merchants"])
+
+# Reseller (umbrella) entity management
+router.include_router(resellers_router, prefix="", tags=["resellers"])
 
 # E-commerce order webhooks (generic /webhook/{platform}/{merchant_id})
 router.include_router(webhooks_router, prefix="", tags=["webhooks"])

--- a/app/api/routers/breeze_buddy/merchants/__init__.py
+++ b/app/api/routers/breeze_buddy/merchants/__init__.py
@@ -63,6 +63,9 @@ async def list_merchants(
         None, description="Filter by merchant_id (partial match)"
     ),
     name: Optional[str] = Query(None, description="Filter by name (partial match)"),
+    reseller_id: Optional[str] = Query(
+        None, description="Filter by owning reseller (exact match)"
+    ),
     is_active: Optional[bool] = Query(None, description="Filter by active status"),
     sort_by: str = Query(
         "created_at",
@@ -104,6 +107,7 @@ async def list_merchants(
         sort_by=sort_by,
         sort_order=sort_order,
         current_user=current_user,
+        reseller_id_filter=reseller_id,
     )
 
 

--- a/app/api/routers/breeze_buddy/merchants/handlers.py
+++ b/app/api/routers/breeze_buddy/merchants/handlers.py
@@ -165,8 +165,13 @@ async def get_all_merchants_handler(
     sort_by: str,
     sort_order: str,
     current_user: UserInfo,
+    reseller_id_filter: Optional[str] = None,
 ) -> MerchantListResponse:
-    """Get all merchant entities with pagination and filtering."""
+    """Get all merchant entities with pagination and filtering.
+
+    reseller_id_filter narrows to one umbrella; for scoped callers it
+    composes with their resolved merchant scope (a filter, not an escape).
+    """
     try:
         # Resolve merchant_ids scope (handles wildcard through owner chain)
         resolved = await resolve_merchant_ids(current_user)
@@ -179,6 +184,7 @@ async def get_all_merchants_handler(
                 is_active_filter=is_active_filter,
                 merchant_identifier_filter=merchant_identifier_filter,
                 name_filter=name_filter,
+                reseller_id_filter=reseller_id_filter,
                 sort_by=sort_by,
                 sort_order=sort_order,
             )
@@ -190,6 +196,7 @@ async def get_all_merchants_handler(
                 limit=limit,
                 merchant_identifier_filter=merchant_identifier_filter,
                 name_filter=name_filter,
+                reseller_id_filter=reseller_id_filter,
                 is_active_filter=is_active_filter,
                 sort_by=sort_by,
                 sort_order=sort_order,

--- a/app/api/routers/breeze_buddy/resellers/__init__.py
+++ b/app/api/routers/breeze_buddy/resellers/__init__.py
@@ -1,0 +1,123 @@
+"""
+Reseller (umbrella) entity API endpoints.
+
+The reseller entity is the umbrella itself (see migration 036); a users row
+with the same id and role='reseller' is an optional login for it.
+"""
+
+from typing import Optional
+
+from fastapi import APIRouter, Depends, Query
+
+from app.api.security.breeze_buddy.rbac_token import get_current_user_with_rbac
+from app.schemas import UserInfo
+from app.schemas.breeze_buddy.resellers import (
+    ResellerCreate,
+    ResellerListResponse,
+    ResellerResponse,
+    ResellerUpdate,
+)
+from app.schemas.breeze_buddy.users import DeleteUserResponse
+
+from .handlers import (
+    create_reseller_handler,
+    delete_reseller_handler,
+    get_all_resellers_handler,
+    get_reseller_by_id_handler,
+    update_reseller_handler,
+)
+
+router = APIRouter()
+
+
+@router.get("/resellers", response_model=ResellerListResponse)
+async def list_resellers(
+    page: int = Query(1, ge=1, description="Page number (1-indexed)"),
+    limit: int = Query(50, ge=1, le=100, description="Items per page"),
+    search: Optional[str] = Query(
+        None, description="Filter by id or name (partial match)"
+    ),
+    is_active: Optional[bool] = Query(None, description="Filter by active status"),
+    sort_by: str = Query(
+        "created_at",
+        description="Sort by field",
+        pattern="^(id|name|created_at|updated_at)$",
+    ),
+    sort_order: str = Query("desc", description="Sort order", pattern="^(asc|desc)$"),
+    current_user: UserInfo = Depends(get_current_user_with_rbac),
+):
+    """
+    List reseller entities with workspace/member counts.
+
+    **RBAC rules:**
+    - Admin: sees all umbrellas
+    - Reseller: sees their own umbrella
+    - Merchant/User: see umbrellas they hold grants on (display labels)
+    """
+    return await get_all_resellers_handler(
+        page=page,
+        limit=limit,
+        search=search,
+        is_active_filter=is_active,
+        sort_by=sort_by,
+        sort_order=sort_order,
+        current_user=current_user,
+    )
+
+
+@router.post("/reseller", response_model=ResellerResponse, status_code=201)
+async def create_reseller(
+    reseller_data: ResellerCreate,
+    current_user: UserInfo = Depends(get_current_user_with_rbac),
+):
+    """
+    Create a reseller (umbrella) entity. Admin only.
+
+    Does NOT create a login — create a users account (role='reseller') with
+    the same id through the users API if the umbrella needs one.
+
+    Raises:
+        403: If caller is not admin
+        409: If the id is already taken
+    """
+    return await create_reseller_handler(reseller_data, current_user)
+
+
+@router.get("/reseller/{reseller_id}", response_model=ResellerResponse)
+async def get_reseller(
+    reseller_id: str,
+    current_user: UserInfo = Depends(get_current_user_with_rbac),
+):
+    """Get one reseller entity (admin, or a caller with umbrella access)."""
+    return await get_reseller_by_id_handler(reseller_id, current_user)
+
+
+@router.put("/reseller/{reseller_id}", response_model=ResellerResponse)
+async def update_reseller(
+    reseller_id: str,
+    reseller_data: ResellerUpdate,
+    current_user: UserInfo = Depends(get_current_user_with_rbac),
+):
+    """
+    Update a reseller entity.
+
+    **RBAC rules:**
+    - Admin: any field
+    - Reseller: own umbrella only, name/description only
+    """
+    return await update_reseller_handler(reseller_id, reseller_data, current_user)
+
+
+@router.delete("/reseller/{reseller_id}", response_model=DeleteUserResponse)
+async def delete_reseller(
+    reseller_id: str,
+    current_user: UserInfo = Depends(get_current_user_with_rbac),
+):
+    """
+    Delete a reseller entity. Admin only.
+
+    Refused with 409 while workspaces still belong to the umbrella. Access
+    grants cascade; a same-id login row is untouched (delete it via the
+    users API if needed).
+    """
+    return await delete_reseller_handler(reseller_id, current_user)

--- a/app/api/routers/breeze_buddy/resellers/handlers.py
+++ b/app/api/routers/breeze_buddy/resellers/handlers.py
@@ -1,0 +1,202 @@
+"""
+Handlers for reseller (umbrella) entity endpoints.
+
+A reseller entity is the umbrella itself; a users row (role='reseller') with
+the same id is an optional login for it. Entity management is admin-first:
+
+- Admin: full CRUD
+- Reseller: sees / renames their own umbrella
+- Merchant/User: read-only visibility of umbrellas they hold grants on
+  (display labels for the console)
+"""
+
+from typing import Optional
+
+import asyncpg
+from fastapi import HTTPException
+
+from app.core.logger import logger
+from app.core.security.scope import resolve_reseller_ids
+from app.database.accessor.breeze_buddy import resellers as reseller_accessors
+from app.schemas import UserInfo, UserRole
+from app.schemas.breeze_buddy.resellers import (
+    ResellerCreate,
+    ResellerListResponse,
+    ResellerResponse,
+    ResellerUpdate,
+)
+from app.schemas.breeze_buddy.users import DeleteUserResponse
+
+
+async def _allowed_reseller_scope(current_user: UserInfo) -> Optional[list]:
+    """Resolve which umbrellas the caller may see (None = unrestricted)."""
+    if current_user.role == UserRole.ADMIN:
+        return None
+    return await resolve_reseller_ids(current_user)
+
+
+async def get_all_resellers_handler(
+    page: int,
+    limit: int,
+    search: Optional[str],
+    is_active_filter: Optional[bool],
+    sort_by: str,
+    sort_order: str,
+    current_user: UserInfo,
+) -> ResellerListResponse:
+    """List reseller entities, scoped to the caller's umbrella access."""
+    allowed = await _allowed_reseller_scope(current_user)
+
+    try:
+        resellers, total = await reseller_accessors.get_all_resellers(
+            page=page,
+            limit=limit,
+            id_or_name_filter=search,
+            is_active_filter=is_active_filter,
+            allowed_reseller_ids=allowed,
+            sort_by=sort_by,
+            sort_order=sort_order,
+        )
+        total_pages = (total + limit - 1) // limit if total > 0 else 0
+        return ResellerListResponse(
+            resellers=resellers,
+            total=total,
+            page=page,
+            limit=limit,
+            total_pages=total_pages,
+        )
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error fetching resellers: {e}")
+        raise HTTPException(status_code=500, detail="Internal server error")
+
+
+async def get_reseller_by_id_handler(
+    reseller_id: str, current_user: UserInfo
+) -> ResellerResponse:
+    """Get one reseller entity the caller has umbrella access to."""
+    allowed = await _allowed_reseller_scope(current_user)
+    if allowed is not None and reseller_id not in allowed:
+        raise HTTPException(
+            status_code=403, detail="You don't have access to this reseller"
+        )
+
+    try:
+        reseller = await reseller_accessors.get_reseller_by_id(reseller_id)
+        if not reseller:
+            raise HTTPException(status_code=404, detail="Reseller not found")
+        return reseller
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error fetching reseller {reseller_id}: {e}")
+        raise HTTPException(status_code=500, detail="Internal server error")
+
+
+async def create_reseller_handler(
+    reseller_data: ResellerCreate, current_user: UserInfo
+) -> ResellerResponse:
+    """Create a reseller entity (admin only; no login is created)."""
+    if current_user.role != UserRole.ADMIN:
+        raise HTTPException(
+            status_code=403, detail="Only admins can create reseller entities"
+        )
+
+    try:
+        reseller = await reseller_accessors.create_reseller(
+            id=reseller_data.id,
+            name=reseller_data.name,
+            description=reseller_data.description,
+            is_active=reseller_data.is_active,
+        )
+        if not reseller:
+            raise HTTPException(status_code=500, detail="Failed to create reseller")
+        return reseller
+    except asyncpg.UniqueViolationError:
+        raise HTTPException(
+            status_code=409,
+            detail=f"Reseller '{reseller_data.id}' already exists",
+        )
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error creating reseller {reseller_data.id}: {e}")
+        raise HTTPException(status_code=500, detail="Internal server error")
+
+
+async def update_reseller_handler(
+    reseller_id: str,
+    reseller_data: ResellerUpdate,
+    current_user: UserInfo,
+) -> ResellerResponse:
+    """Update a reseller entity.
+
+    - Admin: any field
+    - Reseller: own umbrella only, name/description only
+    """
+    if current_user.role == UserRole.RESELLER:
+        if reseller_id != current_user.id:
+            raise HTTPException(
+                status_code=403, detail="You can only modify your own umbrella"
+            )
+        if reseller_data.is_active is not None:
+            raise HTTPException(
+                status_code=403, detail="Only admins can change active status"
+            )
+    elif current_user.role != UserRole.ADMIN:
+        raise HTTPException(
+            status_code=403,
+            detail="Only admins and resellers can modify reseller entities",
+        )
+
+    try:
+        updated = await reseller_accessors.update_reseller(
+            reseller_id=reseller_id,
+            name=reseller_data.name,
+            description=reseller_data.description,
+            is_active=reseller_data.is_active,
+        )
+        if not updated:
+            raise HTTPException(status_code=404, detail="Reseller not found")
+        return updated
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error updating reseller {reseller_id}: {e}")
+        raise HTTPException(status_code=500, detail="Internal server error")
+
+
+async def delete_reseller_handler(
+    reseller_id: str, current_user: UserInfo
+) -> DeleteUserResponse:
+    """Delete a reseller entity (admin only).
+
+    Refused with 409 while merchants still reference the umbrella (FK).
+    Grant rows cascade; a same-id login row is untouched and reported.
+    """
+    if current_user.role != UserRole.ADMIN:
+        raise HTTPException(
+            status_code=403, detail="Only admins can delete reseller entities"
+        )
+
+    try:
+        deleted = await reseller_accessors.delete_reseller(reseller_id)
+        if not deleted:
+            raise HTTPException(status_code=404, detail="Reseller not found")
+        return DeleteUserResponse(
+            success=True,
+            message=f"Reseller '{reseller_id}' deleted",
+            deleted_id=reseller_id,
+        )
+    except asyncpg.ForeignKeyViolationError:
+        raise HTTPException(
+            status_code=409,
+            detail=f"Cannot delete reseller '{reseller_id}': workspaces still "
+            "belong to it. Reassign or delete them first.",
+        )
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error deleting reseller {reseller_id}: {e}")
+        raise HTTPException(status_code=500, detail="Internal server error")

--- a/app/api/routers/breeze_buddy/users/__init__.py
+++ b/app/api/routers/breeze_buddy/users/__init__.py
@@ -11,6 +11,7 @@ from fastapi import APIRouter, Depends, Query
 
 from app.api.security.breeze_buddy.rbac_token import get_current_user_with_rbac
 from app.schemas import UserInfo
+from app.schemas.breeze_buddy.resellers import UserAccessResponse
 from app.schemas.breeze_buddy.users import (
     DeleteUserResponse,
     UserCreate,
@@ -23,6 +24,7 @@ from .handlers import (
     create_user_handler,
     delete_user_handler,
     get_all_users_handler,
+    get_user_access_handler,
     get_user_by_id_handler,
     update_user_handler,
 )
@@ -153,6 +155,23 @@ async def get_user_account_by_id(
         500: If there's an error retrieving the user
     """
     return await get_user_by_id_handler(user_id, current_user)
+
+
+@router.get("/user/{user_id}/access", response_model=UserAccessResponse)
+async def get_user_access(
+    user_id: str,
+    current_user: UserInfo = Depends(get_current_user_with_rbac),
+):
+    """
+    Effective access for one user, from the normalized grant tables.
+
+    Returns the user's umbrella grants and every workspace they can reach,
+    each tagged 'explicit' (direct membership row) or 'inherited' (via an
+    all-workspaces umbrella grant). Admin accounts report unrestricted=true.
+
+    Visibility follows the same RBAC as GET /user/{user_id}.
+    """
+    return await get_user_access_handler(user_id, current_user)
 
 
 @router.put("/user/{user_id}", response_model=UserResponse)

--- a/app/api/routers/breeze_buddy/users/handlers.py
+++ b/app/api/routers/breeze_buddy/users/handlers.py
@@ -21,7 +21,12 @@ from app.core.security.scope import (
 )
 from app.database.accessor.breeze_buddy import users as user_accessors
 from app.database.accessor.breeze_buddy.merchants import get_merchants_by_reseller
+from app.database.accessor.breeze_buddy.resellers import (
+    get_user_umbrella_grants,
+    get_user_workspace_access,
+)
 from app.schemas import UserInfo, UserRole
+from app.schemas.breeze_buddy.resellers import UserAccessResponse
 from app.schemas.breeze_buddy.users import (
     DeleteUserResponse,
     UserCreate,
@@ -438,6 +443,40 @@ async def get_user_by_id_handler(user_id: str, current_user: UserInfo) -> UserRe
         raise
     except Exception as e:
         logger.error(f"Error fetching user {user_id}: {e}")
+        raise HTTPException(status_code=500, detail="Internal server error")
+
+
+async def get_user_access_handler(
+    user_id: str, current_user: UserInfo
+) -> UserAccessResponse:
+    """Effective access for one user, read from the normalized grant tables.
+
+    Explicit workspace membership and umbrella grants are reported as-is;
+    workspaces reachable through an all-workspaces umbrella grant appear with
+    source='inherited'. Visibility RBAC is exactly GET /user/{id}'s.
+    """
+    # Reuse the single-user RBAC gate (raises 403/404 as appropriate).
+    user = await get_user_by_id_handler(user_id, current_user)
+
+    if user.role == UserRole.ADMIN:
+        return UserAccessResponse(
+            user_id=user.id, role=user.role.value, unrestricted=True
+        )
+
+    try:
+        grants = await get_user_umbrella_grants(user.id)
+        workspaces = await get_user_workspace_access(user.id)
+        return UserAccessResponse(
+            user_id=user.id,
+            role=user.role.value,
+            unrestricted=False,
+            umbrella_grants=grants,
+            workspaces=workspaces,
+        )
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error fetching access for user {user_id}: {e}")
         raise HTTPException(status_code=500, detail="Internal server error")
 
 

--- a/app/database/accessor/breeze_buddy/merchants.py
+++ b/app/database/accessor/breeze_buddy/merchants.py
@@ -180,6 +180,7 @@ async def get_merchants_by_ids(
     limit: int = 50,
     merchant_identifier_filter: Optional[str] = None,
     name_filter: Optional[str] = None,
+    reseller_id_filter: Optional[str] = None,
     is_active_filter: Optional[bool] = None,
     sort_by: str = "created_at",
     sort_order: str = "desc",
@@ -192,6 +193,7 @@ async def get_merchants_by_ids(
         limit: Items per page
         merchant_identifier_filter: Additional filter by merchant_id (partial match)
         name_filter: Filter by name (partial match, case-insensitive)
+        reseller_id_filter: Filter by owning reseller (exact match)
         is_active_filter: Filter by active status
         sort_by: Field to sort by (merchant_id, name, created_at, updated_at)
         sort_order: Sort direction (asc, desc)
@@ -208,6 +210,7 @@ async def get_merchants_by_ids(
         limit=limit,
         merchant_identifier_filter=merchant_identifier_filter,
         name_filter=name_filter,
+        reseller_id_filter=reseller_id_filter,
         is_active_filter=is_active_filter,
         sort_by=sort_by,
         sort_order=sort_order,

--- a/app/database/accessor/breeze_buddy/resellers.py
+++ b/app/database/accessor/breeze_buddy/resellers.py
@@ -1,0 +1,196 @@
+"""
+Database accessor functions for reseller (umbrella) entity management.
+
+Uses queries from queries.breeze_buddy.resellers. Rows map straight onto
+ResellerResponse (the computed columns come from the SELECT itself).
+"""
+
+from typing import Any, List, Optional, Tuple
+
+from app.core.logger import logger
+from app.database.queries import run_parameterized_query
+from app.database.queries.breeze_buddy.resellers import (
+    create_reseller_query,
+    delete_reseller_query,
+    get_all_resellers_query,
+    get_reseller_by_id_query,
+    get_user_umbrella_grants_query,
+    get_user_workspace_access_query,
+    update_reseller_query,
+)
+from app.schemas.breeze_buddy.resellers import (
+    ResellerResponse,
+    UmbrellaGrant,
+    WorkspaceAccess,
+)
+
+
+def _decode_reseller(row: Any) -> ResellerResponse:
+    return ResellerResponse(
+        id=row["id"],
+        name=row.get("name"),
+        description=row.get("description"),
+        is_active=row["is_active"],
+        workspace_count=row.get("workspace_count") or 0,
+        member_count=row.get("member_count") or 0,
+        has_login=row.get("has_login") or False,
+        created_at=row.get("created_at"),
+        updated_at=row.get("updated_at"),
+    )
+
+
+async def get_reseller_by_id(reseller_id: str) -> Optional[ResellerResponse]:
+    """Get one reseller entity with computed columns."""
+    query, values = get_reseller_by_id_query(reseller_id)
+    try:
+        result = await run_parameterized_query(query, values)
+        row = result[0] if result else None
+        return _decode_reseller(row) if row else None
+    except Exception as e:
+        logger.error(f"Error fetching reseller {reseller_id}: {e}")
+        raise
+
+
+async def get_all_resellers(
+    page: int = 1,
+    limit: int = 50,
+    id_or_name_filter: Optional[str] = None,
+    is_active_filter: Optional[bool] = None,
+    allowed_reseller_ids: Optional[List[str]] = None,
+    sort_by: str = "created_at",
+    sort_order: str = "desc",
+) -> Tuple[List[ResellerResponse], int]:
+    """List resellers with pagination and RBAC scoping."""
+    query, count_query, values = get_all_resellers_query(
+        page=page,
+        limit=limit,
+        id_or_name_filter=id_or_name_filter,
+        is_active_filter=is_active_filter,
+        allowed_reseller_ids=allowed_reseller_ids,
+        sort_by=sort_by,
+        sort_order=sort_order,
+    )
+    try:
+        rows = await run_parameterized_query(query, values)
+        count_result = await run_parameterized_query(
+            count_query, values[:-2] if len(values) > 2 else []
+        )
+        count_row = count_result[0] if count_result else None
+
+        resellers = [_decode_reseller(row) for row in rows] if rows else []
+        total = count_row["total"] if count_row else 0
+        return resellers, total
+    except Exception as e:
+        logger.error(f"Error fetching resellers: {e}")
+        raise
+
+
+async def create_reseller(
+    id: str,
+    name: Optional[str] = None,
+    description: Optional[str] = None,
+    is_active: bool = True,
+) -> Optional[ResellerResponse]:
+    """Create a reseller entity (no login — that's a users-API concern)."""
+    query, values = create_reseller_query(
+        id=id, name=name, description=description, is_active=is_active
+    )
+    try:
+        result = await run_parameterized_query(query, values)
+        row = result[0] if result else None
+        if row:
+            logger.info(f"Created reseller entity: {id}")
+            # Fresh rows have no merchants/grants/login yet — decode directly.
+            return _decode_reseller(
+                dict(row)
+                | {"workspace_count": 0, "member_count": 0, "has_login": False}
+            )
+        return None
+    except Exception as e:
+        logger.error(f"Error creating reseller {id}: {e}")
+        raise
+
+
+async def update_reseller(
+    reseller_id: str,
+    name: Optional[str] = None,
+    description: Optional[str] = None,
+    is_active: Optional[bool] = None,
+) -> Optional[ResellerResponse]:
+    """Update a reseller entity; returns the refreshed row."""
+    query, values = update_reseller_query(
+        reseller_id=reseller_id,
+        name=name,
+        description=description,
+        is_active=is_active,
+    )
+    if not values:
+        return await get_reseller_by_id(reseller_id)
+
+    try:
+        result = await run_parameterized_query(query, values)
+        row = result[0] if result else None
+        if not row:
+            return None
+        logger.info(f"Updated reseller entity: {reseller_id}")
+        # Re-read for the computed columns.
+        return await get_reseller_by_id(reseller_id)
+    except Exception as e:
+        logger.error(f"Error updating reseller {reseller_id}: {e}")
+        raise
+
+
+async def delete_reseller(reseller_id: str) -> bool:
+    """Delete a reseller entity.
+
+    Raises asyncpg.ForeignKeyViolationError (mapped by the handler to 409)
+    while merchants still reference the umbrella. Grant rows cascade.
+    """
+    query, values = delete_reseller_query(reseller_id)
+    try:
+        result = await run_parameterized_query(query, values)
+        row = result[0] if result else None
+        if row:
+            logger.info(f"Deleted reseller entity: {reseller_id}")
+            return True
+        return False
+    except Exception as e:
+        logger.error(f"Error deleting reseller {reseller_id}: {e}")
+        raise
+
+
+async def get_user_umbrella_grants(user_id: str) -> List[UmbrellaGrant]:
+    """List a user's umbrella grants from the normalized tables."""
+    query, values = get_user_umbrella_grants_query(user_id)
+    try:
+        rows = await run_parameterized_query(query, values)
+        return [
+            UmbrellaGrant(
+                reseller_id=row["reseller_id"],
+                reseller_name=row.get("reseller_name"),
+                all_workspaces=row["all_workspaces"],
+            )
+            for row in rows or []
+        ]
+    except Exception as e:
+        logger.error(f"Error fetching umbrella grants for {user_id}: {e}")
+        raise
+
+
+async def get_user_workspace_access(user_id: str) -> List[WorkspaceAccess]:
+    """List every workspace a user can reach, explicit rows winning."""
+    query, values = get_user_workspace_access_query(user_id)
+    try:
+        rows = await run_parameterized_query(query, values)
+        return [
+            WorkspaceAccess(
+                merchant_id=row["merchant_id"],
+                name=row.get("name"),
+                source=row["source"],
+                via_reseller=row.get("via_reseller"),
+            )
+            for row in rows or []
+        ]
+    except Exception as e:
+        logger.error(f"Error fetching workspace access for {user_id}: {e}")
+        raise

--- a/app/database/queries/breeze_buddy/merchants.py
+++ b/app/database/queries/breeze_buddy/merchants.py
@@ -218,6 +218,7 @@ def get_merchants_by_ids_query(
     limit: int = 50,
     merchant_identifier_filter: Optional[str] = None,
     name_filter: Optional[str] = None,
+    reseller_id_filter: Optional[str] = None,
     is_active_filter: Optional[bool] = None,
     sort_by: str = "created_at",
     sort_order: str = "desc",
@@ -244,6 +245,11 @@ def get_merchants_by_ids_query(
         where_conditions.append(f"name ILIKE ${param_idx}")
         escaped = name_filter.replace("%", "\\%").replace("_", "\\_")
         params.append(f"%{escaped}%")
+        param_idx += 1
+
+    if reseller_id_filter:
+        where_conditions.append(f"reseller_id = ${param_idx}")
+        params.append(reseller_id_filter)
         param_idx += 1
 
     if is_active_filter is not None:

--- a/app/database/queries/breeze_buddy/resellers.py
+++ b/app/database/queries/breeze_buddy/resellers.py
@@ -1,0 +1,214 @@
+"""
+Database query builders for reseller (umbrella) entity operations.
+
+All functions here are pure — they return (query_string, values) tuples and
+perform no I/O. All async DB execution lives in the accessor layer.
+"""
+
+from datetime import datetime, timezone
+from typing import Any, List, Optional, Tuple
+
+RESELLERS_TABLE = "resellers"
+
+# Every read carries the same computed columns the console needs: workspace
+# count, grant-holder count, and whether a same-id reseller login exists.
+_RESELLER_SELECT = f"""
+    SELECT r.id, r.name, r.description, r.is_active, r.created_at, r.updated_at,
+           (SELECT COUNT(*) FROM merchants m
+             WHERE m.reseller_id = r.id) AS workspace_count,
+           (SELECT COUNT(*) FROM user_reseller_access ura
+             WHERE ura.reseller_id = r.id) AS member_count,
+           EXISTS (SELECT 1 FROM users u
+                    WHERE u.id = r.id AND u.role = 'reseller') AS has_login
+    FROM {RESELLERS_TABLE} r
+"""
+
+
+def get_reseller_by_id_query(reseller_id: str) -> Tuple[str, List[Any]]:
+    """Generate query to get one reseller with computed columns."""
+    query = f"{_RESELLER_SELECT} WHERE r.id = $1"
+    return query, [reseller_id]
+
+
+def get_all_resellers_query(
+    page: int = 1,
+    limit: int = 50,
+    id_or_name_filter: Optional[str] = None,
+    is_active_filter: Optional[bool] = None,
+    allowed_reseller_ids: Optional[List[str]] = None,
+    sort_by: str = "created_at",
+    sort_order: str = "desc",
+) -> Tuple[str, str, List[Any]]:
+    """Generate query to list resellers with pagination and RBAC filtering.
+
+    Args:
+        allowed_reseller_ids: RBAC scope — umbrellas the caller may see
+            (None = unrestricted, i.e. admin).
+
+    Returns:
+        Tuple of (query, count_query, values)
+    """
+    offset = (page - 1) * limit
+
+    where_conditions = []
+    params: list = []
+    param_idx = 1
+
+    if id_or_name_filter:
+        escaped = id_or_name_filter.replace("%", "\\%").replace("_", "\\_")
+        where_conditions.append(
+            f"(r.id ILIKE ${param_idx} OR r.name ILIKE ${param_idx})"
+        )
+        params.append(f"%{escaped}%")
+        param_idx += 1
+
+    if is_active_filter is not None:
+        where_conditions.append(f"r.is_active = ${param_idx}")
+        params.append(is_active_filter)
+        param_idx += 1
+
+    if allowed_reseller_ids is not None:
+        where_conditions.append(f"r.id = ANY(${param_idx}::text[])")
+        params.append(allowed_reseller_ids)
+        param_idx += 1
+
+    where_clause = f"WHERE {' AND '.join(where_conditions)}" if where_conditions else ""
+
+    valid_sort_fields = {"id", "name", "created_at", "updated_at"}
+    if sort_by not in valid_sort_fields:
+        sort_by = "created_at"
+    if sort_order.lower() not in {"asc", "desc"}:
+        sort_order = "desc"
+
+    query = f"""
+        {_RESELLER_SELECT}
+        {where_clause}
+        ORDER BY r.{sort_by} {sort_order.upper()}
+        LIMIT ${param_idx} OFFSET ${param_idx + 1}
+    """
+
+    count_query = f"SELECT COUNT(*) as total FROM {RESELLERS_TABLE} r {where_clause}"
+
+    params.extend([limit, offset])
+
+    return query, count_query, params
+
+
+def create_reseller_query(
+    id: str,
+    name: Optional[str] = None,
+    description: Optional[str] = None,
+    is_active: bool = True,
+) -> Tuple[str, List[Any]]:
+    """Generate query to create a reseller entity."""
+    now = datetime.now(timezone.utc)
+    query = f"""
+        INSERT INTO {RESELLERS_TABLE} (
+            id, name, description, is_active, created_at, updated_at
+        ) VALUES ($1, $2, $3, $4, $5, $6)
+        RETURNING id, name, description, is_active, created_at, updated_at
+    """
+    return query, [id, name, description, is_active, now, now]
+
+
+def update_reseller_query(
+    reseller_id: str,
+    name: Optional[str] = None,
+    description: Optional[str] = None,
+    is_active: Optional[bool] = None,
+) -> Tuple[str, List[Any]]:
+    """Generate query to update a reseller entity (id cannot be changed).
+
+    Returns:
+        Tuple of (query, values) — values is empty if no updates requested.
+    """
+    set_clauses = []
+    params: list = []
+    param_idx = 1
+
+    if name is not None:
+        set_clauses.append(f"name = ${param_idx}")
+        params.append(name)
+        param_idx += 1
+
+    if description is not None:
+        set_clauses.append(f"description = ${param_idx}")
+        params.append(description)
+        param_idx += 1
+
+    if is_active is not None:
+        set_clauses.append(f"is_active = ${param_idx}")
+        params.append(is_active)
+        param_idx += 1
+
+    if not set_clauses:
+        return "", []
+
+    set_clauses.append(f"updated_at = ${param_idx}")
+    params.append(datetime.now(timezone.utc))
+    param_idx += 1
+
+    params.append(reseller_id)
+
+    query = f"""
+        UPDATE {RESELLERS_TABLE}
+        SET {', '.join(set_clauses)}
+        WHERE id = ${param_idx}
+        RETURNING id, name, description, is_active, created_at, updated_at
+    """
+    return query, params
+
+
+def delete_reseller_query(reseller_id: str) -> Tuple[str, List[Any]]:
+    """Generate query to delete a reseller entity.
+
+    The merchants.reseller_id FK (NO ACTION) makes the delete fail while any
+    merchant still references the umbrella — the accessor maps that to a
+    conflict error. Grant rows cascade.
+    """
+    query = f"DELETE FROM {RESELLERS_TABLE} WHERE id = $1 RETURNING id"
+    return query, [reseller_id]
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Effective access (normalized read used by GET /user/{id}/access)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def get_user_umbrella_grants_query(user_id: str) -> Tuple[str, List[Any]]:
+    """Generate query to list a user's umbrella grants with display names."""
+    query = """
+        SELECT ura.reseller_id, r.name AS reseller_name, ura.all_workspaces
+        FROM user_reseller_access ura
+        LEFT JOIN resellers r ON r.id = ura.reseller_id
+        WHERE ura.user_id = $1
+        ORDER BY ura.reseller_id
+    """
+    return query, [user_id]
+
+
+def get_user_workspace_access_query(user_id: str) -> Tuple[str, List[Any]]:
+    """Generate query to list every workspace a user can reach.
+
+    Explicit membership rows win over inherited rows for the same workspace
+    (DISTINCT ON keeps the first by source ordering: 'explicit' < 'inherited').
+    """
+    query = """
+        SELECT DISTINCT ON (merchant_id)
+               merchant_id, name, source, via_reseller
+        FROM (
+            SELECT uma.merchant_id, m.name, 'explicit' AS source,
+                   NULL::varchar AS via_reseller
+            FROM user_merchant_access uma
+            JOIN merchants m ON m.merchant_id = uma.merchant_id
+            WHERE uma.user_id = $1
+            UNION ALL
+            SELECT m.merchant_id, m.name, 'inherited' AS source,
+                   ura.reseller_id AS via_reseller
+            FROM user_reseller_access ura
+            JOIN merchants m ON m.reseller_id = ura.reseller_id
+            WHERE ura.user_id = $1 AND ura.all_workspaces
+        ) access
+        ORDER BY merchant_id, source
+    """
+    return query, [user_id]

--- a/app/schemas/breeze_buddy/resellers.py
+++ b/app/schemas/breeze_buddy/resellers.py
@@ -1,0 +1,100 @@
+"""Request/response schemas for reseller (umbrella) endpoints."""
+
+from datetime import datetime
+from typing import List, Optional
+
+from pydantic import BaseModel, Field
+
+
+class ResellerCreate(BaseModel):
+    """Create a new reseller (umbrella) entity.
+
+    Creating a reseller entity does NOT create a login. A login for the
+    umbrella is an ordinary users row (role='reseller') with the same id,
+    created through the users API.
+    """
+
+    id: str = Field(
+        ...,
+        min_length=2,
+        max_length=255,
+        pattern=r"^\S+$",
+        description="Umbrella slug (no whitespace). Doubles as the login id "
+        "if a reseller login is created for this umbrella.",
+    )
+    name: Optional[str] = Field(
+        None, max_length=255, description="Optional display name"
+    )
+    description: Optional[str] = Field(None, description="Optional description")
+    is_active: bool = Field(True, description="Active status (default: true)")
+
+
+class ResellerUpdate(BaseModel):
+    """Update a reseller entity (id cannot be changed)."""
+
+    name: Optional[str] = Field(None, max_length=255)
+    description: Optional[str] = None
+    is_active: Optional[bool] = None
+
+
+class ResellerResponse(BaseModel):
+    """Reseller entity as returned by the API."""
+
+    id: str
+    name: Optional[str] = None
+    description: Optional[str] = None
+    is_active: bool = True
+    workspace_count: int = 0
+    member_count: int = Field(
+        0, description="Users holding an access grant on this umbrella"
+    )
+    has_login: bool = Field(
+        False, description="Whether a role='reseller' users row with this id exists"
+    )
+    created_at: Optional[datetime] = None
+    updated_at: Optional[datetime] = None
+
+
+class ResellerListResponse(BaseModel):
+    """Paginated reseller list."""
+
+    resellers: List[ResellerResponse]
+    total: int
+    page: int
+    limit: int
+    total_pages: int
+
+
+class UmbrellaGrant(BaseModel):
+    """One user_reseller_access row, resolved for display."""
+
+    reseller_id: str
+    reseller_name: Optional[str] = None
+    all_workspaces: bool = False
+
+
+class WorkspaceAccess(BaseModel):
+    """One workspace a user can reach, with how they reach it."""
+
+    merchant_id: str
+    name: Optional[str] = None
+    source: str = Field(
+        ...,
+        description="'explicit' (direct membership row) or 'inherited' "
+        "(via an all-workspaces umbrella grant)",
+    )
+    via_reseller: Optional[str] = Field(
+        None, description="Umbrella the access is inherited through (inherited only)"
+    )
+
+
+class UserAccessResponse(BaseModel):
+    """Effective access for one user, from the normalized grant tables."""
+
+    user_id: str
+    role: str
+    unrestricted: bool = Field(
+        False, description="True for admin accounts (no grant rows needed)"
+    )
+    umbrella_grants: List[UmbrellaGrant] = Field(default_factory=list)
+    workspaces: List[WorkspaceAccess] = Field(default_factory=list)

--- a/tests/test_resellers_queries.py
+++ b/tests/test_resellers_queries.py
@@ -1,0 +1,121 @@
+"""Tests for reseller (umbrella) entity query builders and the effective-access
+read queries (GET /user/{id}/access).
+
+Pure query-builder tests — SQL string + params only, no DB.
+"""
+
+from __future__ import annotations
+
+from app.database.queries.breeze_buddy.resellers import (
+    create_reseller_query,
+    delete_reseller_query,
+    get_all_resellers_query,
+    get_reseller_by_id_query,
+    get_user_umbrella_grants_query,
+    get_user_workspace_access_query,
+    update_reseller_query,
+)
+
+# ── list ─────────────────────────────────────────────────────────────────────
+
+
+def test_plain_list_has_no_filters_and_computed_columns() -> None:
+    query, count_query, params = get_all_resellers_query()
+    # no outer WHERE: the FROM..resellers line flows straight to ORDER BY
+    # (the computed-column subqueries have their own inner WHEREs)
+    outer = query.split("FROM resellers r")[1].split("ORDER BY")[0]
+    assert "WHERE" not in outer
+    assert params == [50, 0]
+    # the console columns ride every read
+    assert "workspace_count" in query
+    assert "member_count" in query
+    assert "has_login" in query
+    assert "COUNT(*) as total" in count_query
+
+
+def test_search_matches_id_or_name_with_escaping() -> None:
+    query, count_query, params = get_all_resellers_query(id_or_name_filter="bre_eze%")
+    assert "(r.id ILIKE $1 OR r.name ILIKE $1)" in query
+    assert params == ["%bre\\_eze\\%%", 50, 0]
+    assert "ILIKE $1" in count_query
+
+
+def test_rbac_scope_restricts_to_allowed_ids() -> None:
+    query, _, params = get_all_resellers_query(
+        allowed_reseller_ids=["breeze"], page=2, limit=10
+    )
+    assert "r.id = ANY($1::text[])" in query
+    assert params == [["breeze"], 10, 10]
+
+
+def test_admin_scope_is_unrestricted() -> None:
+    query, _, _ = get_all_resellers_query(allowed_reseller_ids=None)
+    assert "ANY(" not in query
+
+
+def test_sort_field_is_validated() -> None:
+    query, _, _ = get_all_resellers_query(sort_by="; DROP TABLE", sort_order="up")
+    assert "ORDER BY r.created_at DESC" in query
+
+
+# ── single row / mutations ───────────────────────────────────────────────────
+
+
+def test_get_by_id_carries_computed_columns() -> None:
+    query, params = get_reseller_by_id_query("breeze")
+    assert "WHERE r.id = $1" in query
+    assert "has_login" in query
+    assert params == ["breeze"]
+
+
+def test_create_returns_row() -> None:
+    query, params = create_reseller_query("breeze", "Breeze Labs", None, True)
+    assert "INSERT INTO resellers" in query
+    assert "RETURNING" in query
+    assert params[:4] == ["breeze", "Breeze Labs", None, True]
+
+
+def test_update_with_no_fields_is_a_noop() -> None:
+    query, params = update_reseller_query("breeze")
+    assert query == ""
+    assert params == []
+
+
+def test_update_sets_only_given_fields() -> None:
+    query, params = update_reseller_query("breeze", name="New Name")
+    set_clause = query.split("SET")[1].split("WHERE")[0]
+    assert "name = $1" in set_clause
+    assert "description" not in set_clause
+    assert "is_active" not in set_clause
+    assert "updated_at = $2" in set_clause
+    assert params[0] == "New Name"
+    assert params[-1] == "breeze"
+
+
+def test_delete_is_plain_and_fk_guarded_by_schema() -> None:
+    query, params = delete_reseller_query("breeze")
+    assert query.strip().startswith("DELETE FROM resellers")
+    assert "RETURNING id" in query
+    assert params == ["breeze"]
+
+
+# ── effective access ─────────────────────────────────────────────────────────
+
+
+def test_umbrella_grants_join_reseller_names() -> None:
+    query, params = get_user_umbrella_grants_query("alice")
+    assert "FROM user_reseller_access ura" in query
+    assert "LEFT JOIN resellers r" in query
+    assert params == ["alice"]
+
+
+def test_workspace_access_unions_explicit_and_inherited() -> None:
+    query, params = get_user_workspace_access_query("alice")
+    assert "'explicit' AS source" in query
+    assert "'inherited' AS source" in query
+    # inherited rows only flow through all-workspaces grants
+    assert "ura.all_workspaces" in query
+    # explicit membership wins on collision: DISTINCT ON ordered by source
+    assert "DISTINCT ON (merchant_id)" in query
+    assert "ORDER BY merchant_id, source" in query
+    assert params == ["alice"]


### PR DESCRIPTION
## What

Part 2 of the access-model series — **stacked on #920** (base = `feat/access-model-foundation`; merge #920 first, GitHub retargets this one to `release`, verify base after). Makes the new umbrella entity manageable and exposes the normalized access as an API.

### Reseller entity CRUD

| Route | RBAC |
|---|---|
| `GET /resellers` | admin: all · reseller: own umbrella · merchant/user: umbrellas they hold grants on (display labels) |
| `POST /reseller` | admin only — creates the umbrella **without** a login (a same-id `role='reseller'` users row remains the optional login, via the users API) |
| `GET /reseller/{id}` | admin or caller with umbrella access |
| `PUT /reseller/{id}` | admin: any field · reseller: own umbrella, name/description only |
| `DELETE /reseller/{id}` | admin only; **409 while workspaces still belong to it** (merchants FK); grant rows cascade |

List/read rows carry `workspace_count`, `member_count`, `has_login` — everything the console's Resellers surface needs in one call (today it fetches all merchants and groups client-side).

### Effective access

`GET /user/{id}/access` — the user's umbrella grants + every reachable workspace, each tagged `explicit` (direct membership row) or `inherited` (via an all-workspaces grant, with `via_reseller`). Explicit wins on collision. Visibility = exactly `GET /user/{id}`'s RBAC gate (reused, not re-implemented); admins report `unrestricted: true`. This powers the Settings "explicit vs inherited" UI.

### Merchants filter

`GET /merchants?reseller_id=` (exact match). For scoped callers it composes with their resolved merchant scope — narrows only, cannot widen (verified: reseller filtering a foreign umbrella gets 0 rows, not a leak).

## Verification

- e2e RBAC matrix on the local stack: per-role list scoping, dup 409, cross-umbrella rename 403, reseller `is_active` change 403, delete-with-workspaces 409, delete-empty 200.
- Access endpoint: explicit member (1 explicit row + umbrella affiliation), all-workspaces reseller (20 inherited rows via `breeze`).
- 12 pure query-builder tests; full suite 637 passed (the 2 `test_chat_analytics` failures pre-exist on the clean release tip); `pyrefly` clean; hooks green.

## Confidence: 8.5/10

All-new routes plus two additive params — no existing behavior changes except `GET /merchants` gaining an optional filter. Main risk is semantic: the read endpoints describe the **normalized** tables, which are only as fresh as #920's dual-write keeps them (in-sync by construction after its backfill).

---
Next: read cutover (scope resolution + users-list scoping from the grant tables, folding the parked `feat/users-workspace-scoping` semantics).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added reseller management with listing, creation, viewing, updating, and deletion.
  * Added filtering of merchants by reseller.
  * Added a user access view showing reseller grants and workspace access, including inherited access.
  * Added role-based access controls for reseller and user access operations.

* **Tests**
  * Added coverage for reseller queries, filtering, sorting, access resolution, and validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->