### PR TITLE
feat(tts-catalog): static voice catalog with pre-generated previews

### DIFF
--- a/.claude/rules/voice-pipeline.md
+++ b/.claude/rules/voice-pipeline.md
@@ -12,7 +12,8 @@ paths:
 
 ## STT/TTS Providers
 - STT: Soniox (default), Deepgram, Sarvam, OpenAI, Google -- each has different endpoint detection behavior
-- TTS: ElevenLabs (default), Cartesia, Sarvam -- template-level voice configuration overrides
+- TTS: 7 runtime providers -- elevenlabs (default), cartesia, sarvam, gemini, google, soniox, dragontts (a caching proxy in front of the others, not itself voice-owning) -- voice config can be set template-level via `TTSConfig`, overriding global Redis defaults
+- Voice catalog (static `app/ai/voice/tts/catalog.json`, `GET /tts/voices`) covers only the 6 voice-owning providers -- dragontts is excluded since it proxies the others instead of owning voices
 - Provider selection can be static (env var), dynamic (Redis), or template-level
 - When adding a new provider, update: provider init code, config models in types.py, and the selection logic
 

--- a/.env.example
+++ b/.env.example
@@ -37,6 +37,31 @@ AZURE_OPENAI_MODEL="gpt-4o-automatic"
 KB_AZURE_OPENAI_ENDPOINT=
 KB_AZURE_OPENAI_API_KEY=
 GOOGLE_CREDENTIALS_JSON=
+
+# GCS Configuration (recordings bucket — service-account JSON for the client below)
+GCS_CREDENTIALS_JSON=
+GCS_BUCKET="atoms-sdk"
+
+# TTS Voice Catalog — preview storage. GCS is the only backend: previews are
+# uploaded to TTS_PREVIEW_GCS_BUCKET (separate from GCS_BUCKET above) and
+# served straight from that bucket. The voice list itself is static
+# (app/ai/voice/tts/catalog.json); generated previews are tracked in a
+# manifest.json stored alongside the WAVs.
+# TTS_PREVIEW_GCS_BUCKET is required to generate or serve previews. It is
+# validated lazily (at first use, not at import), so a deployment that never
+# touches the voice catalog still boots without it.
+# TTS_PREVIEW_PUBLIC_BASE_URL is optional — set it only when the bucket is
+# fronted by a CDN or custom domain. Left unset, previews are served from
+# https://storage.googleapis.com/<TTS_PREVIEW_GCS_BUCKET>/tts-previews/…
+# Changing it later requires regenerating previews (URLs are written into the
+# manifest at generation time): delete the stored manifest.json, then re-run
+# POST /tts/voices/reconcile.
+# SECURITY: TTS_PREVIEW_PUBLIC_BASE_URL is embedded verbatim into every preview
+# URL returned by the catalog endpoint (visible to any caller that can list
+# voices) — never put credentials, an auth token, or a signed-URL secret in it.
+TTS_PREVIEW_GCS_BUCKET=
+TTS_PREVIEW_PUBLIC_BASE_URL=  # optional CDN/custom-domain override, e.g. https://previews.example.com
+
 # AIC (AI Coustics) Audio Filter Configuration
 ENABLE_AIC_FILTER=true
 AIC_LICENSE_KEY=

--- a/app/ai/voice/tts/catalog.json
+++ b/app/ai/voice/tts/catalog.json
@@ -1,0 +1,116 @@
+{
+  "voices": [
+    {
+      "provider": "elevenlabs",
+      "voice_id": "fG9s0SXJb213f4UxVHyG",
+      "display_name": "Rachel",
+      "models": ["eleven_flash_v2_5"],
+      "languages": ["en-IN", "hi"],
+      "tags": ["female", "default"]
+    },
+    {
+      "provider": "cartesia",
+      "voice_id": "bec003e2-3cb3-429c-8468-206a393c67ad",
+      "display_name": "Cartesia Default",
+      "models": ["sonic-3.5"],
+      "languages": ["en"],
+      "tags": ["default"]
+    },
+    {
+      "provider": "sarvam",
+      "voice_id": "shreya",
+      "display_name": "Shreya",
+      "models": ["bulbul:v3"],
+      "languages": ["en-IN", "hi"],
+      "tags": ["female", "default"]
+    },
+    {
+      "provider": "sarvam",
+      "voice_id": "priya",
+      "display_name": "Priya",
+      "models": ["bulbul:v3"],
+      "languages": ["en-IN", "hi"],
+      "tags": ["female"]
+    },
+    {
+      "provider": "sarvam",
+      "voice_id": "rahul",
+      "display_name": "Rahul",
+      "models": ["bulbul:v3"],
+      "languages": ["en-IN", "hi"],
+      "tags": ["male"]
+    },
+    {
+      "provider": "sarvam",
+      "voice_id": "kavya",
+      "display_name": "Kavya",
+      "models": ["bulbul:v3"],
+      "languages": ["en-IN", "hi"],
+      "tags": ["female"]
+    },
+    {
+      "provider": "sarvam",
+      "voice_id": "amit",
+      "display_name": "Amit",
+      "models": ["bulbul:v3"],
+      "languages": ["en-IN", "hi"],
+      "tags": ["male"]
+    },
+    {
+      "provider": "soniox",
+      "voice_id": "Priya",
+      "display_name": "Priya",
+      "models": ["tts-rt-v1"],
+      "languages": ["en"],
+      "tags": ["female", "default"]
+    },
+    {
+      "provider": "google",
+      "voice_id": "en-IN-Chirp3-HD-Despina",
+      "display_name": "Despina (Chirp3 HD)",
+      "models": [],
+      "languages": ["en-IN"],
+      "tags": ["default"]
+    },
+    {
+      "provider": "gemini",
+      "voice_id": "Kore",
+      "display_name": "Kore",
+      "models": [],
+      "languages": [],
+      "tags": ["default"]
+    },
+    {
+      "provider": "gemini",
+      "voice_id": "Puck",
+      "display_name": "Puck",
+      "models": [],
+      "languages": [],
+      "tags": []
+    },
+    {
+      "provider": "gemini",
+      "voice_id": "Charon",
+      "display_name": "Charon",
+      "models": [],
+      "languages": [],
+      "tags": []
+    },
+    {
+      "provider": "gemini",
+      "voice_id": "Despina",
+      "display_name": "Despina",
+      "models": [],
+      "languages": [],
+      "tags": []
+    },
+    {
+      "provider": "gemini",
+      "voice_id": "Zephyr",
+      "display_name": "Zephyr",
+      "models": [],
+      "languages": [],
+      "tags": []
+    }
+  ]
+}

--- a/app/ai/voice/tts/catalog.py
+++ b/app/ai/voice/tts/catalog.py
@@ -1,0 +1,63 @@
+"""Static TTS voice catalog.
+
+The catalog is deliberately code, not rows in a table: voices are curated,
+change rarely, and belong under code review. ``catalog.json`` next to this
+module is the single source of truth for which voices exist; the preview
+manifest (which previews have been generated, and where) lives in preview
+storage — see ``app.services.preview_storage``.
+
+Adding/updating a voice = edit catalog.json, ship, then POST
+/tts/voices/reconcile to generate its previews (docs/TTS_VOICE_CATALOG.md).
+
+Curation notes (carried over from the original seed):
+- Deliberately excludes ids that only exist as dead/example references in the
+  codebase: "bQQWtYx9EodAqMdkrNAc" (unused ELEVENLABS_VOICE_ID fallback),
+  "iB2rIwm9cQCRGWoKDRtX" (template-generator example id), "manisha" (stale
+  sarvam fallback superseded by the "shreya" default).
+- sarvam speaker names verified against the installed pipecat SDK
+  (SarvamTTSSpeakerV3); gemini voice names verified against
+  GeminiTTSService.AVAILABLE_VOICES. Gemini "Despina" and google
+  "en-IN-Chirp3-HD-Despina" are distinct voices that share a human name.
+- google Chirp3-HD voice names encode model + locale, so those entries have
+  no models field; gemini's model comes from GEMINI_TTS_MODEL at synth time.
+"""
+
+import json
+import os
+from functools import lru_cache
+from typing import List
+
+from app.schemas.breeze_buddy.tts_catalog import CatalogVoiceEntry
+
+__all__ = ["get_enabled_voices", "get_all_voices", "CATALOG_PATH"]
+
+CATALOG_PATH = os.path.join(os.path.dirname(__file__), "catalog.json")
+
+
+@lru_cache(maxsize=1)
+def _load() -> tuple:
+    """Parse + validate catalog.json once per process.
+
+    Sync file I/O is confined to this first call; app startup primes the
+    cache from the lifespan (via a thread) so requests never touch the disk.
+    """
+    with open(CATALOG_PATH, encoding="utf-8") as f:
+        raw = json.load(f)
+    entries = tuple(CatalogVoiceEntry(**v) for v in raw["voices"])
+    seen: set = set()
+    for e in entries:
+        pair = (e.provider, e.voice_id)
+        if pair in seen:
+            raise ValueError(f"Duplicate catalog entry: {pair}")
+        seen.add(pair)
+    return entries
+
+
+def get_all_voices() -> List[CatalogVoiceEntry]:
+    """Every catalog entry, including disabled ones."""
+    return list(_load())
+
+
+def get_enabled_voices() -> List[CatalogVoiceEntry]:
+    """Catalog entries with enabled=true — the set served and reconciled."""
+    return [v for v in _load() if v.enabled]

--- a/app/ai/voice/tts/preview.py
+++ b/app/ai/voice/tts/preview.py
@@ -1,0 +1,603 @@
+"""Browser-playable preview synthesis for the TTS voice catalog.
+
+Deliberately separate from the runtime telephony path (generate_audio ->
+convert_to_mulaw, 8 kHz mulaw): previews are WAV 16-bit mono at the
+provider's native/requested PCM rate. Never touches runtime dispatch.
+
+Flow: ``resolve_preview_config`` first resolves one immutable preview
+specification (model defaults, provider knobs, dynamic toggles), then that
+same specification drives BOTH ``content_key`` hashing and
+``generate_preview`` synthesis — so a configuration change always changes
+the key, and a stored preview can never look current after the config that
+produced it has moved on.
+
+Exception to that resolution: when a catalog voice omits ``models``, the
+elevenlabs/cartesia/sarvam/soniox model fallback reads the static
+``BB_SPEECH_PROVIDER_DEFAULTS`` dict (or ``ELEVENLABS_MODEL_ID``) rather
+than the Redis-overridable ``BB_VOICE_PROVIDER_DEFAULTS`` tier —
+deliberate, since a preview pins one catalog voice/model rather than
+tracking the live runtime default; see the per-branch comments in
+``resolve_preview_config``.
+
+Each ``_synthesize_<provider>_pcm`` branch mirrors the request shape of the
+corresponding ``_generate_<provider>_audio`` helper in this package (same
+auth, URL, payload, and residency handling) but asks the provider for
+browser-friendly PCM instead of the telephony formats those helpers use.
+"""
+
+import asyncio
+import base64
+import hashlib
+import io
+import json
+import wave
+from typing import Optional
+
+import httpx
+from pipecat.services.soniox.tts import language_to_soniox_tts_language
+from pipecat.transcriptions.language import Language
+from websockets.asyncio.client import connect as websocket_connect
+
+from app.ai.voice.tts.soniox import SONIOX_TTS_SYNTH_TIMEOUT_SECS, SONIOX_TTS_WS_URL
+from app.core.config.dynamic import (
+    BB_ENABLE_ELEVENLABS_INDIAN_RESIDENCY,
+    BB_SARVAM_TTS_ENABLE_PREPROCESSING,
+    BB_SPEECH_PROVIDER_DEFAULTS,
+    GEMINI_TTS_MODEL,
+)
+from app.core.config.static import (
+    CARTESIA_API_KEY,
+    ELEVENLABS_API_KEY,
+    ELEVENLABS_INDIAN_RESIDENCY_API_KEY,
+    ELEVENLABS_MODEL_ID,
+    GOOGLE_CREDENTIALS_JSON,
+    SARVAM_API_KEY,
+    SONIOX_API_KEY,
+)
+from app.core.logger import logger
+
+__all__ = [
+    "PreviewGenerationError",
+    "CANONICAL_SENTENCES",
+    "sentence_for",
+    "resolve_preview_config",
+    "content_key",
+    "pcm_to_wav",
+    "wav_to_pcm",
+    "generate_preview",
+]
+
+# Gemini/Google Chirp TTS native streaming sample rate — fixed by the API.
+_GEMINI_SAMPLE_RATE = 24_000
+_GOOGLE_SAMPLE_RATE = 24_000
+
+CANONICAL_SENTENCES: dict[str, str] = {
+    "en": "Hi, this is a quick preview of my voice. I can help confirm your order and answer questions.",
+    "hi": "नमस्ते, यह मेरी आवाज़ की एक छोटी झलक है। मैं आपका ऑर्डर कन्फर्म करने में मदद कर सकती हूँ।",
+    "ta": "வணக்கம், இது என் குரலின் ஒரு சிறிய முன்னோட்டம். உங்கள் ஆர்டரை உறுதிப்படுத்த உதவுகிறேன்.",
+    "te": "నమస్తే, ఇది నా గొంతు యొక్క చిన్న ప్రివ్యూ. మీ ఆర్డర్‌ను నిర్ధారించడంలో సహాయం చేస్తాను.",
+    "kn": "ನಮಸ್ಕಾರ, ಇದು ನನ್ನ ಧ್ವನಿಯ ಸಣ್ಣ ಮುನ್ನೋಟ. ನಿಮ್ಮ ಆರ್ಡರ್ ದೃಢೀಕರಿಸಲು ಸಹಾಯ ಮಾಡುತ್ತೇನೆ.",
+}
+
+
+def sentence_for(language: str) -> str:
+    """Canonical preview sentence for a language, falling back bare-code ->
+    English (e.g. "en-IN" -> "en", unknown -> "en")."""
+    lang = (language or "en").lower()
+    return CANONICAL_SENTENCES.get(lang) or CANONICAL_SENTENCES.get(
+        lang.split("-")[0], CANONICAL_SENTENCES["en"]
+    )
+
+
+async def resolve_preview_config(
+    provider: str,
+    voice_id: str,
+    model: Optional[str],
+    language: str,
+    style_params: Optional[dict],
+) -> dict:
+    """Resolve the effective synthesis configuration for one preview.
+
+    Fills in every input that determines the audio output: catalog model or
+    the provider's default, dynamic toggles (ElevenLabs residency, Sarvam
+    preprocessing), Sarvam payload knobs, fixed sample rates. The returned
+    dict is the single spec that both ``content_key`` and
+    ``generate_preview`` consume, so hashing and synthesis can never see
+    different configurations.
+    """
+    style = style_params or {}
+    text = sentence_for(language)
+    cfg: dict = {
+        "provider": provider,
+        "voice_id": voice_id,
+        "language": language,
+        "text": text,
+        "style_params": style,
+        "format": "wav",
+    }
+    if provider == "elevenlabs":
+        cfg["model"] = model or ELEVENLABS_MODEL_ID
+        cfg["indian_residency"] = await BB_ENABLE_ELEVENLABS_INDIAN_RESIDENCY()
+        cfg["voice_settings"] = {"stability": 0.5, "similarity_boost": 0.75}
+    elif provider == "cartesia":
+        # Static-dict fallback only — deliberately skips BB_VOICE_PROVIDER_DEFAULTS'
+        # Redis override tier since preview always targets one specific catalog
+        # voice/model, not "the currently configured runtime default".
+        cfg["model"] = model or BB_SPEECH_PROVIDER_DEFAULTS.get("cartesia", {}).get(
+            "model"
+        )
+        cfg["sample_rate"] = 16000
+    elif provider == "sarvam":
+        # sarvam_defaults is the static-dict tier only — same rationale as
+        # the cartesia branch above.
+        cfg["payload"] = _sarvam_payload(
+            voice_id=voice_id,
+            model=model,
+            language_code=language or "en-IN",
+            text=text,
+            sarvam_defaults=BB_SPEECH_PROVIDER_DEFAULTS.get("sarvam", {}),
+            enable_preprocessing=await BB_SARVAM_TTS_ENABLE_PREPROCESSING(),
+        )
+        cfg["model"] = cfg["payload"]["model"]
+    elif provider == "gemini":
+        cfg["model"] = model or await GEMINI_TTS_MODEL()
+        cfg["sample_rate"] = _GEMINI_SAMPLE_RATE
+    elif provider == "google":
+        # Chirp3-HD voice names encode model + locale; no separate model.
+        cfg["model"] = None
+        cfg["sample_rate"] = _GOOGLE_SAMPLE_RATE
+    elif provider == "soniox":
+        # Static-dict fallback only — same rationale as cartesia above.
+        cfg["model"] = model or BB_SPEECH_PROVIDER_DEFAULTS.get("soniox", {}).get(
+            "model"
+        )
+        cfg["sample_rate"] = 16000
+    else:
+        raise ValueError(f"Unsupported provider: {provider}")
+    return cfg
+
+
+def content_key(config: dict) -> str:
+    """Deterministic 16-hex-char key over a resolved preview configuration.
+
+    Takes the output of ``resolve_preview_config`` — never raw catalog
+    inputs — so the key changes whenever anything that affects the audio
+    does (resolved model, dynamic toggles, payload knobs, sentence text).
+    """
+    payload = json.dumps(config, sort_keys=True, default=str)
+    return hashlib.sha256(payload.encode()).hexdigest()[:16]
+
+
+def pcm_to_wav(pcm: bytes, sample_rate: int) -> bytes:
+    """Wrap raw 16-bit mono PCM in a WAV container at the given rate."""
+    buf = io.BytesIO()
+    with wave.open(buf, "wb") as w:
+        w.setnchannels(1)
+        w.setsampwidth(2)
+        w.setframerate(sample_rate)
+        w.writeframes(pcm)
+    return buf.getvalue()
+
+
+def wav_to_pcm(data: bytes) -> tuple[bytes, int]:
+    """Extract (frames, sample_rate) from WAV bytes; raw PCM passes through.
+
+    Providers that return a full WAV container (Sarvam's REST API does by
+    default) must be unwrapped before ``pcm_to_wav`` re-wraps, or the inner
+    header ends up as a click of garbage PCM at the start of the preview.
+    """
+    if not data.startswith(b"RIFF"):
+        return data, 16000
+    with wave.open(io.BytesIO(data)) as w:
+        return w.readframes(w.getnframes()), w.getframerate()
+
+
+class PreviewGenerationError(Exception):
+    """Raised when a provider fails to synthesize a preview for a voice."""
+
+    def __init__(self, provider: str, voice_id: str, cause: str):
+        self.provider = provider
+        self.voice_id = voice_id
+        self.cause = cause
+        super().__init__(
+            f"Preview generation failed for provider={provider} voice_id={voice_id}: {cause}"
+        )
+
+
+async def generate_preview(config: dict) -> tuple[bytes, str]:
+    """Synthesize one preview WAV from a resolved configuration.
+
+    Returns (wav_bytes, content_key) where the key is derived from the same
+    ``config`` that drove synthesis (see ``resolve_preview_config``).
+    """
+    key = content_key(config)
+    pcm, rate = await _synthesize_pcm(config)
+    return pcm_to_wav(pcm, rate), key
+
+
+async def _synthesize_pcm(config: dict) -> tuple[bytes, int]:
+    provider = config["provider"]
+    voice_id = config["voice_id"]
+    try:
+        if provider == "cartesia":
+            return await _synthesize_cartesia_pcm(config)
+        if provider == "elevenlabs":
+            return await _synthesize_elevenlabs_pcm(config)
+        if provider == "sarvam":
+            return await _synthesize_sarvam_pcm(config)
+        if provider == "gemini":
+            return await _synthesize_gemini_pcm(config)
+        if provider == "google":
+            return await _synthesize_google_pcm(config)
+        if provider == "soniox":
+            return await _synthesize_soniox_pcm(config)
+        raise ValueError(f"Unsupported provider: {provider}")
+    except Exception as exc:
+        raise PreviewGenerationError(provider, voice_id, str(exc)) from exc
+
+
+async def _synthesize_cartesia_pcm(config: dict) -> tuple[bytes, int]:
+    """Mirrors `_generate_cartesia_audio`'s request shape (URL, headers,
+    payload) — already requests pcm_s16le @ 16000. Model/voice/language arrive
+    pre-resolved from `resolve_preview_config`, which deliberately skips that
+    helper's BB_VOICE_PROVIDER_DEFAULTS Redis tier."""
+    if not CARTESIA_API_KEY:
+        raise ValueError("CARTESIA_API_KEY is required for Cartesia preview synthesis")
+
+    url = "https://api.cartesia.ai/tts/bytes"
+    headers = {
+        "X-API-Key": CARTESIA_API_KEY,
+        "Cartesia-Version": "2024-06-10",
+        "Content-Type": "application/json",
+    }
+    payload = {
+        "model_id": config["model"],
+        "transcript": config["text"],
+        "voice": {"mode": "id", "id": config["voice_id"]},
+        "language": config["language"],
+        "output_format": {
+            "container": "raw",
+            "encoding": "pcm_s16le",
+            "sample_rate": config["sample_rate"],
+        },
+    }
+
+    logger.info(
+        f"Synthesizing preview with Cartesia "
+        f"[voice_id={config['voice_id']}, model={config['model']}]"
+    )
+
+    async with httpx.AsyncClient() as client:
+        response = await client.post(url, json=payload, headers=headers, timeout=30.0)
+        response.raise_for_status()
+        return response.content, config["sample_rate"]
+
+
+async def _synthesize_elevenlabs_pcm(config: dict) -> tuple[bytes, int]:
+    """Mirrors `_generate_elevenlabs_audio`'s auth/residency split, requesting
+    pcm_16000 instead of ulaw_8000. Residency comes pre-resolved in the
+    config so synthesis matches what was hashed."""
+    if config["indian_residency"]:
+        api_key = ELEVENLABS_INDIAN_RESIDENCY_API_KEY
+        base_url = "https://api.in.residency.elevenlabs.io"
+        if not api_key:
+            raise ValueError(
+                "ELEVENLABS_INDIAN_RESIDENCY_API_KEY is required when use_indian_residency is True"
+            )
+    else:
+        api_key = ELEVENLABS_API_KEY
+        base_url = "https://api.elevenlabs.io"
+        if not api_key:
+            raise ValueError(
+                "ELEVENLABS_API_KEY is required for ElevenLabs preview synthesis"
+            )
+
+    url = f"{base_url}/v1/text-to-speech/{config['voice_id']}?output_format=pcm_16000"
+    # Intentional divergence from the mirrored helper: it sets
+    # "Accept: audio/basic" (the u-law MIME type) to match its ulaw_8000
+    # request. That header is stale here — output_format=pcm_16000 in the
+    # URL governs the response format, so the header is dropped rather than
+    # sent with a mismatched MIME type.
+    headers = {
+        "xi-api-key": api_key,
+        "Content-Type": "application/json",
+    }
+    payload = {
+        "text": config["text"],
+        "model_id": config["model"],
+        "voice_settings": config["voice_settings"],
+    }
+
+    logger.info(
+        f"Synthesizing preview with ElevenLabs (pcm_16000) "
+        f"[voice_id={config['voice_id']}, model_id={config['model']}, "
+        f"indian_residency={config['indian_residency']}]"
+    )
+
+    async with httpx.AsyncClient() as client:
+        response = await client.post(url, json=payload, headers=headers, timeout=30.0)
+        response.raise_for_status()
+        return response.content, 16000
+
+
+def _sarvam_payload(
+    *,
+    voice_id: str,
+    model: Optional[str],
+    language_code: str,
+    text: str,
+    sarvam_defaults: dict,
+    enable_preprocessing: bool,
+) -> dict:
+    """Pure payload builder for `POST /text-to-speech`, kept separate from the
+    network call so the v3 field-omission rule and language qualification can
+    be unit tested directly.
+
+    Bulbul V3 rejects pitch/loudness outright (confirmed via the API's own
+    error): "Pitch and loudness parameters are currently not supported for
+    the Bulbul V3 model. Please do not pass these values." Earlier models
+    (e.g. bulbul:v2) accept both, so only omit them for v3.
+
+    target_language_code also only accepts region-qualified codes (the API's
+    validation error enumerates an all-"xx-IN" set: as-IN, bn-IN, ..., hi-IN,
+    ..., ur-IN) but the catalog stores bare codes (e.g. "hi", "en"). Sarvam is
+    India-region-only, so qualifying any bare code with "-IN" is safe here.
+    """
+    final_model = model or sarvam_defaults.get("model")
+    qualified_language_code = (
+        language_code if "-" in language_code else f"{language_code}-IN"
+    )
+    payload = {
+        "inputs": [text],
+        "target_language_code": qualified_language_code,
+        "speaker": voice_id,
+        "pace": sarvam_defaults.get("speed", 0.9),
+        "speech_sample_rate": 16000,
+        "enable_preprocessing": enable_preprocessing,
+        "model": final_model,
+    }
+    if not (final_model or "").startswith("bulbul:v3"):
+        payload["pitch"] = sarvam_defaults.get("pitch", 0.0)
+        payload["loudness"] = 1.5
+    return payload
+
+
+async def _synthesize_sarvam_pcm(config: dict) -> tuple[bytes, int]:
+    """Mirrors `_generate_sarvam_audio`, posting the exact payload that was
+    hashed into the content key. Sarvam's REST API returns base64 WAV (its
+    default codec), so the container is stripped here — `generate_preview`
+    adds exactly one WAV header."""
+    if not SARVAM_API_KEY:
+        raise ValueError("SARVAM_API_KEY is required for Sarvam preview synthesis")
+
+    url = "https://api.sarvam.ai/text-to-speech"
+    headers = {
+        "api-subscription-key": SARVAM_API_KEY,
+        "Content-Type": "application/json",
+    }
+    payload = config["payload"]
+
+    logger.info(
+        f"Synthesizing preview with Sarvam "
+        f"[voice_id={config['voice_id']}, language={config['language']}]"
+    )
+
+    async with httpx.AsyncClient() as client:
+        response = await client.post(url, json=payload, headers=headers, timeout=30.0)
+        response.raise_for_status()
+        result = response.json()
+
+        audio_base64 = (result.get("audios") or [None])[0]
+        if not audio_base64:
+            raise Exception("No audio returned from Sarvam API")
+
+        return wav_to_pcm(base64.b64decode(audio_base64))
+
+
+async def _synthesize_gemini_pcm(config: dict) -> tuple[bytes, int]:
+    """Mirrors `_generate_gemini_audio`'s streaming_synthesize + credential
+    handling, but returns native 24 kHz PCM (no downsample — pcm_to_wav
+    takes the rate) and honours an optional style prompt."""
+    from google.cloud import texttospeech_v1
+    from google.oauth2 import service_account
+
+    credentials_json = GOOGLE_CREDENTIALS_JSON
+    if not credentials_json:
+        raise ValueError(
+            "GOOGLE_CREDENTIALS_JSON is required for Gemini TTS pre-synthesis"
+        )
+
+    final_voice = config["voice_id"] or "Kore"
+    style_prompt = config["style_params"].get("style_prompt")
+
+    logger.info(
+        f"Synthesizing preview with Gemini "
+        f"[voice={final_voice}, model={config['model']}, lang={config['language'] or 'en-IN'}]"
+    )
+
+    json_account_info = json.loads(credentials_json)
+    creds = service_account.Credentials.from_service_account_info(json_account_info)
+    client = texttospeech_v1.TextToSpeechAsyncClient(credentials=creds)
+
+    try:
+        voice_params = texttospeech_v1.VoiceSelectionParams(
+            language_code=config["language"] or "en-IN",
+            name=final_voice,
+            model_name=config["model"],
+        )
+
+        streaming_config = texttospeech_v1.StreamingSynthesizeConfig(
+            voice=voice_params,
+            streaming_audio_config=texttospeech_v1.StreamingAudioConfig(
+                audio_encoding=texttospeech_v1.AudioEncoding.PCM,
+                sample_rate_hertz=_GEMINI_SAMPLE_RATE,
+            ),
+        )
+
+        async def _request_generator():
+            yield texttospeech_v1.StreamingSynthesizeRequest(
+                streaming_config=streaming_config
+            )
+            synthesis_params: dict = {"text": config["text"]}
+            if style_prompt:
+                synthesis_params["prompt"] = style_prompt
+            yield texttospeech_v1.StreamingSynthesizeRequest(
+                input=texttospeech_v1.StreamingSynthesisInput(**synthesis_params)
+            )
+
+        chunks: list[bytes] = []
+        streaming_responses = await client.streaming_synthesize(_request_generator())
+        async for response in streaming_responses:
+            if response.audio_content:
+                chunks.append(response.audio_content)
+
+        pcm_24k = b"".join(chunks)
+
+        if not pcm_24k:
+            raise RuntimeError(
+                "Gemini TTS returned empty audio — check credentials and voice settings"
+            )
+
+        return pcm_24k, _GEMINI_SAMPLE_RATE
+    finally:
+        await client.transport.grpc_channel.close()  # type: ignore[union-attr]
+
+
+async def _synthesize_google_pcm(config: dict) -> tuple[bytes, int]:
+    """Mirrors `_generate_google_audio`'s streaming_synthesize + credential
+    handling, but returns native 24 kHz PCM (no downsample)."""
+    from google.cloud import texttospeech_v1
+    from google.oauth2 import service_account
+
+    credentials_json = GOOGLE_CREDENTIALS_JSON
+    if not credentials_json:
+        raise ValueError(
+            "GOOGLE_CREDENTIALS_JSON is required for Google TTS pre-synthesis"
+        )
+
+    final_voice = config["voice_id"] or "en-IN-Chirp3-HD-Despina"
+    final_language = config["language"] or "en-IN"
+
+    logger.info(
+        f"Synthesizing preview with Google "
+        f"[voice={final_voice}, lang={final_language}]"
+    )
+
+    json_account_info = json.loads(credentials_json)
+    creds = service_account.Credentials.from_service_account_info(json_account_info)
+    client = texttospeech_v1.TextToSpeechAsyncClient(credentials=creds)
+
+    try:
+        voice_params = texttospeech_v1.VoiceSelectionParams(
+            language_code=final_language,
+            name=final_voice,
+        )
+
+        streaming_config = texttospeech_v1.StreamingSynthesizeConfig(
+            voice=voice_params,
+            streaming_audio_config=texttospeech_v1.StreamingAudioConfig(
+                audio_encoding=texttospeech_v1.AudioEncoding.PCM,
+                sample_rate_hertz=_GOOGLE_SAMPLE_RATE,
+            ),
+        )
+
+        async def _request_generator():
+            yield texttospeech_v1.StreamingSynthesizeRequest(
+                streaming_config=streaming_config
+            )
+            yield texttospeech_v1.StreamingSynthesizeRequest(
+                input=texttospeech_v1.StreamingSynthesisInput(text=config["text"])
+            )
+
+        chunks: list[bytes] = []
+        streaming_responses = await client.streaming_synthesize(_request_generator())
+        async for response in streaming_responses:
+            if response.audio_content:
+                chunks.append(response.audio_content)
+
+        pcm_24k = b"".join(chunks)
+
+        if not pcm_24k:
+            raise RuntimeError(
+                "Google TTS returned empty audio — check credentials and voice settings"
+            )
+
+        return pcm_24k, _GOOGLE_SAMPLE_RATE
+    finally:
+        await client.transport.grpc_channel.close()  # type: ignore[union-attr]
+
+
+async def _synthesize_soniox_pcm(config: dict) -> tuple[bytes, int]:
+    """Mirrors `_generate_soniox_audio`'s one-shot WS protocol — already
+    requests pcm_s16le @ 16000."""
+    if not SONIOX_API_KEY:
+        raise ValueError("SONIOX_API_KEY is required for Soniox TTS")
+
+    voice = config["voice_id"] or "Priya"
+    sample_rate = config["sample_rate"]
+    language = config["language"]
+
+    if language:
+        try:
+            lang_enum = Language(language)
+        except ValueError:
+            logger.warning(
+                f"Invalid Soniox language code '{language}', falling back to EN"
+            )
+            lang_enum = Language.EN
+    else:
+        lang_enum = Language.EN
+
+    soniox_lang = language_to_soniox_tts_language(lang_enum) or "en"
+
+    config_msg = {
+        "api_key": SONIOX_API_KEY,
+        "stream_id": "preview",
+        "model": config["model"],
+        "voice": voice,
+        "language": soniox_lang,
+        "audio_format": "pcm_s16le",
+        "sample_rate": sample_rate,
+    }
+    text_msg = {"text": config["text"], "text_end": True, "stream_id": "preview"}
+
+    logger.info(
+        f"Synthesizing preview with Soniox (pcm_s16le {sample_rate}) "
+        f"[voice_id={voice}, model={config['model']}, language={soniox_lang}]"
+    )
+
+    audio_chunks: list[bytes] = []
+    try:
+        async with asyncio.timeout(SONIOX_TTS_SYNTH_TIMEOUT_SECS):
+            async with websocket_connect(SONIOX_TTS_WS_URL) as ws:
+                await ws.send(json.dumps(config_msg))
+                await ws.send(json.dumps(text_msg))
+
+                async for raw in ws:
+                    try:
+                        msg = json.loads(raw)
+                    except json.JSONDecodeError:
+                        continue
+
+                    error_code = msg.get("error_code")
+                    if error_code is not None:
+                        error_message = msg.get("error_message", "")
+                        raise Exception(
+                            f"Soniox TTS error {error_code}: {error_message}"
+                        )
+
+                    audio_b64 = msg.get("audio")
+                    if audio_b64:
+                        audio_chunks.append(base64.b64decode(audio_b64))
+
+                    if msg.get("terminated"):
+                        break
+    except asyncio.TimeoutError:
+        raise Exception(
+            f"Soniox TTS synth timed out after {SONIOX_TTS_SYNTH_TIMEOUT_SECS}s"
+        )
+
+    if not audio_chunks:
+        raise Exception("No audio returned from Soniox TTS")
+
+    return b"".join(audio_chunks), sample_rate

--- a/app/api/routers/breeze_buddy/__init__.py
+++ b/app/api/routers/breeze_buddy/__init__.py
@@ -43,6 +43,7 @@ from app.api.routers.breeze_buddy.template_generator import (
     router as template_generator_router,
 )
 from app.api.routers.breeze_buddy.templates import router as templates_router
+from app.api.routers.breeze_buddy.tts_catalog import router as tts_catalog_router
 from app.api.routers.breeze_buddy.users import router as users_router
 from app.api.routers.breeze_buddy.wallet import router as wallet_router
 from app.api.routers.breeze_buddy.webhooks import router as webhooks_router
@@ -98,6 +99,9 @@ router.include_router(playground_router, prefix="", tags=["playground"])
 
 # Blacklist (blocked phone numbers - admin only)
 router.include_router(blacklist_router, prefix="", tags=["blacklist"])
+
+# TTS voice catalog (enabled voices, provider+language filters)
+router.include_router(tts_catalog_router, prefix="", tags=["tts-catalog"])
 
 # Merchants (merchant identifiers - admin only)
 router.include_router(merchants_router, prefix="", tags=["merchants"])

--- a/app/api/routers/breeze_buddy/tts_catalog/__init__.py
+++ b/app/api/routers/breeze_buddy/tts_catalog/__init__.py
@@ -1,0 +1,82 @@
+"""
+RESTful TTS voice catalog endpoints.
+
+Endpoints:
+- GET  /tts/voices           - List enabled voices, optionally filtered by provider/language
+- POST /tts/voices/reconcile - Regenerate stale/missing previews for enabled voices (admin only)
+"""
+
+from typing import Literal, Optional
+
+from fastapi import APIRouter, Depends, Header, Query, Response
+
+from app.api.routers.breeze_buddy.numbers.rbac import require_admin_access
+from app.api.security.breeze_buddy.rbac_token import get_current_user_with_rbac
+from app.schemas import UserInfo
+from app.schemas.breeze_buddy.tts_catalog import (
+    ReconcileReportResponse,
+    VoicesResponse,
+)
+
+from . import handlers
+
+router = APIRouter()
+
+# NOTE: FastAPI's Query(enum=...) only annotates the OpenAPI schema on this
+# FastAPI version — it does not reject invalid values at runtime, so a Literal
+# is needed to enforce the 422 the test pins. Values must be spelled out
+# statically (mirroring CATALOG_PROVIDERS) rather than built from the tuple —
+# pyrefly rejects `Literal[some_tuple_variable]` as not-a-type.
+ProviderFilter = Literal[
+    "elevenlabs", "cartesia", "sarvam", "gemini", "google", "soniox"
+]
+
+
+@router.get("/tts/voices", response_model=VoicesResponse)
+async def list_voices(
+    response: Response,
+    provider: Optional[ProviderFilter] = Query(None),
+    language: Optional[str] = Query(None, min_length=2, max_length=16),
+    if_none_match: Optional[str] = Header(None),
+    current_user: UserInfo = Depends(get_current_user_with_rbac),
+):
+    """
+    List enabled TTS voices.
+
+    Query Parameters:
+    - provider: Optional filter by provider (elevenlabs, cartesia, sarvam,
+      gemini, google, soniox)
+    - language: Optional filter by language code (bare or regional, e.g.
+      "en" matches "en-IN")
+
+    Response is cached client-side for 5 minutes; a matching If-None-Match
+    header returns 304 with no body.
+    """
+    body, etag = await handlers.list_voices_handler(provider, language)
+    response.headers["Cache-Control"] = "private, max-age=300"
+    response.headers["ETag"] = etag
+    if if_none_match == etag:
+        return Response(
+            status_code=304,
+            headers={"ETag": etag, "Cache-Control": "private, max-age=300"},
+        )
+    return body
+
+
+@router.post("/tts/voices/reconcile", response_model=ReconcileReportResponse)
+async def reconcile_voices(
+    current_user: UserInfo = Depends(get_current_user_with_rbac),
+):
+    """
+    Regenerate stale or missing previews for every enabled voice.
+
+    For each enabled voice and language, skips generation when a stored
+    preview already matches the current content key; otherwise generates and
+    stores a fresh preview. Failures are recorded per-language rather than
+    aborting the run.
+
+    Permissions:
+    - Admin only
+    """
+    require_admin_access(current_user, "reconcile tts voice previews")
+    return await handlers.reconcile_previews_handler()

--- a/app/api/routers/breeze_buddy/tts_catalog/handlers.py
+++ b/app/api/routers/breeze_buddy/tts_catalog/handlers.py
@@ -1,0 +1,224 @@
+"""Handlers for the TTS voice catalog endpoints:
+- GET  /tts/voices           — filtered, ETag-cached voice catalog listing.
+- POST /tts/voices/reconcile — admin-only preview generation reconciliation.
+
+Voices come from the static catalog (app/ai/voice/tts/catalog.json); which
+previews exist for them comes from the preview-storage manifest. There is
+no database involved.
+"""
+
+import asyncio
+import hashlib
+import json
+from typing import Optional
+
+from app.ai.voice.tts.catalog import get_enabled_voices
+from app.ai.voice.tts.preview import (
+    content_key,
+    generate_preview,
+    resolve_preview_config,
+)
+from app.core.config.dynamic import BB_VOICE_PROVIDER_DEFAULTS
+from app.core.logger import logger
+from app.schemas.breeze_buddy.tts_catalog import (
+    CATALOG_PROVIDERS,
+    CatalogVoice,
+    VoicePreview,
+    VoicesResponse,
+)
+from app.services.preview_storage import (
+    load_manifest,
+    load_manifest_fresh,
+    manifest_key,
+    store_preview,
+    update_previews,
+)
+
+from .matching import language_matches
+
+GEMINI_FALLBACK_DEFAULT = "Kore"  # gemini has no BB_SPEECH_PROVIDER_DEFAULTS entry
+
+# No rate-limit infra exists in the TTS layer; pace generation calls gently.
+RECONCILE_DELAY_SECS = 1.0
+
+# Cap on provider error text echoed back to the admin caller in the reconcile
+# report. The full exception is always logged server-side.
+ERROR_DETAIL_LIMIT = 300
+
+
+def _public_error(exc: Exception) -> str:
+    """Exception summary safe to persist in the manifest.
+
+    The manifest lives in the public preview location, so anything written
+    into it is world-readable. A raw provider error body is not: it can echo
+    back request fragments and, for a misbehaving provider, header or
+    credential material. Only the exception's class name goes to storage; the
+    message survives in the admin-only report and the server log.
+    """
+    return type(exc).__name__
+
+
+async def _resolve_defaults() -> dict[str, Optional[str]]:
+    """Per-provider default voice_id, fetched concurrently (each lookup hits
+    Redis)."""
+    configs = await asyncio.gather(
+        *(BB_VOICE_PROVIDER_DEFAULTS(p) for p in CATALOG_PROVIDERS)
+    )
+    defaults: dict[str, Optional[str]] = {
+        p: (cfg or {}).get("voice_id") for p, cfg in zip(CATALOG_PROVIDERS, configs)
+    }
+    defaults["gemini"] = defaults.get("gemini") or GEMINI_FALLBACK_DEFAULT
+    return defaults
+
+
+async def list_voices_handler(
+    provider: Optional[str], language: Optional[str]
+) -> tuple[VoicesResponse, str]:
+    """Build the filtered voice listing plus its ETag."""
+    manifest, defaults = await asyncio.gather(load_manifest(), _resolve_defaults())
+
+    filtered = [
+        v
+        for v in get_enabled_voices()
+        if (not provider or v.provider == provider)
+        and (not language or language_matches(language, v.languages))
+    ]
+
+    voices = []
+    for v in filtered:
+        raw_previews = manifest.get(manifest_key(v.provider, v.voice_id), [])
+        previews = [
+            VoicePreview(language=p["language"], url=p["url"])
+            for p in raw_previews
+            if p.get("url") and not p.get("error")
+        ]
+        voices.append(
+            CatalogVoice(
+                provider=v.provider,
+                voice_id=v.voice_id,
+                display_name=v.display_name,
+                models=v.models,
+                languages=v.languages,
+                tags=v.tags,
+                is_default=(defaults.get(v.provider) == v.voice_id),
+                previews=previews,
+            )
+        )
+
+    # ETag must identify the representation actually returned (RFC 7232):
+    # hash the filter params plus the full response content — which already
+    # folds in the resolved defaults (is_default) and manifest state
+    # (previews) — so any change to catalog, defaults, or previews yields a
+    # distinct ETag for the affected filtered views.
+    stamp = json.dumps(
+        [provider, language, [v.model_dump() for v in voices]], sort_keys=True
+    )
+    etag = '"' + hashlib.sha256(stamp.encode()).hexdigest()[:16] + '"'
+    return VoicesResponse(voices=voices), etag
+
+
+async def reconcile_previews_handler() -> dict:
+    """Regenerate stale/missing previews for every enabled voice.
+
+    For each voice, walks its languages (or a single "en" pass for
+    language-agnostic voices), skipping any language whose manifest entry
+    already matches the current content_key and has a url. Any failure —
+    generation or storage — is recorded against that language rather than
+    aborting the run, so one broken voice doesn't block the rest. A failed
+    regeneration never evicts a previously working preview: the last-known-good
+    entry stays in the manifest (its stale content_key makes the next
+    reconcile retry) so GET /tts/voices keeps serving the old audio meanwhile.
+
+    The manifest is read fresh (not via the GET path's fail-soft TTL cache):
+    a backend read failure aborts here — before any paid provider call — and a
+    corrupt manifest file loads as empty (logged), so this run regenerates and
+    the successful write repairs it.
+    """
+    manifest = await load_manifest_fresh()
+    report = []
+    for v in get_enabled_voices():
+        langs = v.languages or ["en"]  # language-agnostic voices get one 'en' preview
+        model = v.models[0] if v.models else None
+        previews = list(manifest.get(manifest_key(v.provider, v.voice_id), []))
+        changed = False
+        for lang in langs:
+            existing = next((p for p in previews if p.get("language") == lang), None)
+            key = None
+            entry = None
+            try:
+                config = await resolve_preview_config(
+                    v.provider, v.voice_id, model, lang, v.style_params
+                )
+                key = content_key(config)
+                if (
+                    existing
+                    and existing.get("content_key") == key
+                    and existing.get("url")
+                ):
+                    report.append(
+                        {
+                            "provider": v.provider,
+                            "voice_id": v.voice_id,
+                            "language": lang,
+                            "action": "skipped",
+                        }
+                    )
+                    continue
+                wav, key = await generate_preview(config)
+                url = await store_preview(v.provider, v.voice_id, lang, key, wav)
+                entry = {
+                    "language": lang,
+                    "url": url,
+                    "content_key": key,
+                    "format": "wav",
+                }
+                report.append(
+                    {
+                        "provider": v.provider,
+                        "voice_id": v.voice_id,
+                        "language": lang,
+                        "action": "generated",
+                    }
+                )
+            except Exception as e:
+                logger.exception(
+                    f"tts previews: generation failed for "
+                    f"{v.provider}/{v.voice_id} [{lang}]"
+                )
+                report.append(
+                    {
+                        "provider": v.provider,
+                        "voice_id": v.voice_id,
+                        "language": lang,
+                        "action": "failed",
+                        "error": str(e)[:ERROR_DETAIL_LIMIT],
+                    }
+                )
+                if not (existing and existing.get("url")):
+                    entry = {
+                        "language": lang,
+                        "error": _public_error(e),
+                        "content_key": key,
+                    }
+            if entry is not None:
+                previews = [p for p in previews if p.get("language") != lang] + [entry]
+                changed = True
+            await asyncio.sleep(RECONCILE_DELAY_SECS)
+        if changed:
+            try:
+                await update_previews(v.provider, v.voice_id, previews)
+            except Exception as e:
+                logger.exception(
+                    f"tts previews: manifest write failed for "
+                    f"{v.provider}/{v.voice_id}"
+                )
+                report.append(
+                    {
+                        "provider": v.provider,
+                        "voice_id": v.voice_id,
+                        "language": "*",
+                        "action": "manifest_write_failed",
+                        "error": str(e)[:ERROR_DETAIL_LIMIT],
+                    }
+                )
+    return {"report": report}

--- a/app/api/routers/breeze_buddy/tts_catalog/matching.py
+++ b/app/api/routers/breeze_buddy/tts_catalog/matching.py
@@ -1,0 +1,10 @@
+def language_matches(filter_code: str, voice_languages: list[str]) -> bool:
+    """Bare-code <-> regional matching. Empty voice_languages = language-agnostic."""
+    if not voice_languages:
+        return True
+    f = filter_code.strip().lower()
+    for lang in voice_languages:
+        lv = lang.strip().lower()
+        if lv == f or lv.startswith(f + "-") or f.startswith(lv + "-"):
+            return True
+    return False

--- a/app/core/config/static.py
+++ b/app/core/config/static.py
@@ -44,6 +44,19 @@ GOOGLE_CREDENTIALS_JSON = os.environ.get("GOOGLE_CREDENTIALS_JSON", "")
 GCS_CREDENTIALS_JSON = os.environ.get("GCS_CREDENTIALS_JSON", "")
 GCS_BUCKET = os.environ.get("GCS_BUCKET", "atoms-sdk")
 
+# TTS Voice Catalog — preview storage (GCS only). Separate from GCS_BUCKET
+# above (which is the recordings bucket) so previews can live in their own.
+#
+# Deliberately NOT validated at import: previews are one optional feature, and
+# raising here would stop every deployment that never uses the voice catalog
+# from booting. When the bucket is unset the catalog simply serves voices
+# without previews (see preview_storage.load_manifest, which fails soft), and
+# any attempt to *write* a preview raises with a message naming this variable.
+TTS_PREVIEW_GCS_BUCKET = os.environ.get("TTS_PREVIEW_GCS_BUCKET", "")
+# Optional: front the bucket with a CDN/custom domain. Defaults to the bucket's
+# own public URL.
+TTS_PREVIEW_PUBLIC_BASE_URL = os.environ.get("TTS_PREVIEW_PUBLIC_BASE_URL", "")
+
 ENABLE_AIC_FILTER = os.environ.get("ENABLE_AIC_FILTER", "false").lower() == "true"
 AIC_LICENSE_KEY = os.environ.get("AIC_LICENSE_KEY", "")
 # Breeze Buddy AIC License Key

--- a/app/main.py
+++ b/app/main.py
@@ -31,6 +31,7 @@ from app.ai.voice.agents.breeze_buddy.tts.dragontts.monitor import (
 
 # Database imports
 from app.ai.voice.llm._pools import close_all_pools as close_llm_http_pools
+from app.ai.voice.tts.catalog import get_enabled_voices as load_tts_voice_catalog
 from app.api.routers import breeze_buddy, devcycle, feature_flags, systems
 from app.api.routers.breeze_buddy.chat import cancel_bus as chat_cancel_bus
 
@@ -109,6 +110,18 @@ async def lifespan(_app: FastAPI):
         await chat_cancel_bus.start_subscriber()
     except Exception as e:
         logger.error(f"Failed to start chat cancel-bus subscriber: {e}")
+
+    # TTS voice catalog startup: parse/validate catalog.json. It touches the
+    # filesystem, so it runs here (in a thread) instead of at module import.
+    # Deliberately NOT wrapped in try/except like the external services above:
+    # catalog.json is checked-in code, so a broken file is a bad build that
+    # must fail deployment — swallowing it would serve 500s per request
+    # instead (lru_cache doesn't memoize exceptions, so the failed load would
+    # also retry blocking disk I/O on the event loop for every call).
+    def _prepare_tts_catalog() -> None:
+        load_tts_voice_catalog()
+
+    await asyncio.to_thread(_prepare_tts_catalog)
 
     # DevCycle feature flags are initialized by parent process (run.py) before uvicorn starts
     # Worker processes only need to read from Redis using get_config()
@@ -355,6 +368,9 @@ app.include_router(
 
 # System health endpoints
 app.include_router(systems.router, prefix="", tags=["Systems"])
+
+# TTS voice-catalog previews are served straight from the GCS bucket's public
+# URL, so this app exposes no /tts-previews route.
 
 
 # Root endpoint - health check

--- a/app/schemas/breeze_buddy/tts_catalog.py
+++ b/app/schemas/breeze_buddy/tts_catalog.py
@@ -1,0 +1,77 @@
+from typing import List, Literal, Optional
+
+from pydantic import BaseModel, Field, field_validator
+
+CATALOG_PROVIDERS: tuple[str, ...] = (
+    "elevenlabs",
+    "cartesia",
+    "sarvam",
+    "gemini",
+    "google",
+    "soniox",
+)
+
+
+class CatalogVoiceEntry(BaseModel):
+    """One curated voice as authored in app/ai/voice/tts/catalog.json.
+
+    Internal representation — previews are not part of the entry; they are
+    tracked in the preview-storage manifest and merged in at read time.
+    """
+
+    provider: str
+    voice_id: str
+    display_name: str
+    models: List[str] = Field(default_factory=list)
+    languages: List[str] = Field(default_factory=list)
+    tags: List[str] = Field(default_factory=list)
+    enabled: bool = True
+    residency: Optional[str] = None
+    style_params: Optional[dict] = None
+
+    @field_validator("provider")
+    @classmethod
+    def _provider_known(cls, v: str) -> str:
+        if v not in CATALOG_PROVIDERS:
+            raise ValueError(
+                f"Unknown provider {v!r}; must be one of {CATALOG_PROVIDERS}"
+            )
+        return v
+
+
+class VoicePreview(BaseModel):
+    language: str
+    url: str
+
+
+class CatalogVoice(BaseModel):
+    provider: str
+    voice_id: str
+    display_name: str
+    models: List[str] = Field(default_factory=list)
+    languages: List[str] = Field(default_factory=list)
+    tags: List[str] = Field(default_factory=list)
+    is_default: bool = False
+    previews: List[VoicePreview] = Field(default_factory=list)
+
+
+class VoicesResponse(BaseModel):
+    voices: List[CatalogVoice]
+
+
+class ReconcileEntry(BaseModel):
+    """One (voice, language) outcome from a preview reconcile run."""
+
+    provider: str
+    voice_id: str
+    # "*" when the failure isn't language-specific (e.g. a manifest write).
+    language: str
+    action: Literal["skipped", "generated", "failed", "manifest_write_failed"]
+    # Present only on the failure actions. Bounded provider error text; the
+    # manifest itself stores just the exception class name (see the reconcile
+    # handler's _public_error).
+    error: Optional[str] = None
+
+
+class ReconcileReportResponse(BaseModel):
+    report: List[ReconcileEntry]

--- a/app/services/preview_storage.py
+++ b/app/services/preview_storage.py
@@ -1,0 +1,262 @@
+"""GCS-backed preview storage for the TTS voice catalog.
+
+GCS is the only backend. A local-filesystem mode existed briefly but was
+removed: it served previews through the app itself while GCS serves them
+straight from the bucket, so the two paths had materially different URL,
+caching and concurrency behaviour and only the GCS one is ever exercised in
+a deployed environment.
+
+Parallel to `app.services.gcp.storage.upload_file_to_gcs` / `GCSStorage` —
+deliberately not reusing `GCSStorage` here. That class hardcodes its bucket
+to the global `GCS_BUCKET` (the recordings bucket, default "atoms-sdk") with
+no constructor param to target a different one, and `upload_file_to_gcs`
+only ever returns a URL for that same bucket. Previews need their own
+bucket (`TTS_PREVIEW_GCS_BUCKET`), so this module calls `get_gcs_bucket()`
+directly — already bucket-name-parameterized and unmodified — instead of
+touching any existing storage code.
+
+Path shape: `tts-previews/{provider}/{voice_id}/{language}-{key}.wav`.
+
+Besides the WAVs themselves, this module owns the **preview manifest** —
+`tts-previews/manifest.json`, stored in the same backend. It maps
+"provider/voice_id" to that voice's preview entries
+(`{language, url, content_key, format}` or `{language, error, content_key}`)
+and is the only mutable state in the catalog system: the voice list itself
+is static (app/ai/voice/tts/catalog.json) and the manifest records which
+previews have been generated for it. Reads are TTL-cached in-process
+(matching the endpoint's 5-minute Cache-Control); writes always
+read-modify-write fresh, and a load failure during a write aborts rather
+than risking overwriting a good manifest with a partial one. The manifest
+lives in the public preview location by design, so nothing sensitive may be
+written into it: public preview URLs, content-key hashes, and — for a voice
+whose preview failed — the exception's class name only, never the provider's
+error body (see `_public_error` in the reconcile handler).
+"""
+
+import asyncio
+import json
+import re
+import time
+from typing import Optional
+
+from google.api_core.exceptions import NotFound
+
+from app.core.config.static import (
+    TTS_PREVIEW_GCS_BUCKET,
+    TTS_PREVIEW_PUBLIC_BASE_URL,
+)
+from app.core.logger import logger
+from app.services.gcp.storage.client import get_gcs_bucket
+
+__all__ = [
+    "store_preview",
+    "load_manifest",
+    "load_manifest_fresh",
+    "update_previews",
+    "MANIFEST_NAME",
+]
+
+MANIFEST_NAME = "manifest.json"
+
+# Matches the endpoint's `Cache-Control: max-age=300`: a manifest written by
+# another pod becomes visible here within the same window clients already
+# tolerate for staleness.
+MANIFEST_CACHE_TTL_SECS = 300.0
+
+# Read/written only from coroutines on the single asyncio event loop (never
+# inside the asyncio.to_thread closures below), so cooperative scheduling makes
+# a lock unnecessary; concurrent writers are last-write-wins (see
+# update_previews).
+_manifest_cache: Optional[tuple[float, dict]] = None
+
+# Voice IDs are UUIDs/base62/speaker names, languages are BCP-47-ish, keys
+# are hex — none of those legitimately need "/", "\", or "..". Reject
+# anything else so these values (which flow straight into filesystem paths
+# and GCS blob names) can't escape their directory.
+_COMPONENT_RE = re.compile(r"[A-Za-z0-9._-]+")
+
+
+def _validate_component(name: str, value: str) -> str:
+    if not value or not _COMPONENT_RE.fullmatch(value) or ".." in value:
+        raise ValueError(
+            f"Invalid preview path component {name}={value!r}: must be "
+            "non-empty, match [A-Za-z0-9._-]+, and not contain '..'"
+        )
+    return value
+
+
+def _rel_path(provider: str, voice_id: str, language: str, key: str) -> str:
+    provider = _validate_component("provider", provider)
+    voice_id = _validate_component("voice_id", voice_id)
+    language = _validate_component("language", language)
+    key = _validate_component("key", key)
+    return f"{provider}/{voice_id}/{language}-{key}.wav"
+
+
+def _public_url(rel: str) -> str:
+    # Previews are served directly from the bucket, so the default is the
+    # bucket's own public URL. TTS_PREVIEW_PUBLIC_BASE_URL overrides it for
+    # deployments that front the bucket with a CDN or custom domain.
+    #
+    # The bucket name is interpolated into the URL without percent-encoding.
+    # That is safe because _require_bucket() has already rejected any name
+    # outside [A-Za-z0-9._-]. Validating beats quoting here: an unencodable
+    # bucket name is a misconfiguration that GCS itself would reject, and
+    # quoting it would hide that behind a well-formed URL that 404s.
+    path = f"tts-previews/{rel}"
+    if TTS_PREVIEW_PUBLIC_BASE_URL:
+        return f"{TTS_PREVIEW_PUBLIC_BASE_URL.rstrip('/')}/{path}"
+    return f"https://storage.googleapis.com/{_require_bucket()}/{path}"
+
+
+async def store_preview(
+    provider: str, voice_id: str, language: str, key: str, wav: bytes
+) -> str:
+    """Persist a preview WAV and return its public URL."""
+    rel = _rel_path(provider, voice_id, language, key)
+    return await _store_gcs(rel, wav, content_type="audio/wav")
+
+
+def _require_bucket() -> str:
+    """Return the previews bucket, or explain precisely what is unconfigured.
+
+    Also rejects a bucket name that isn't URL-safe, so `_public_url` can
+    interpolate it verbatim. GCS bucket names are already constrained to this
+    character set, so a name that fails here would fail at GCS too — better to
+    say so than to emit a URL that silently 404s.
+    """
+    if not TTS_PREVIEW_GCS_BUCKET:
+        raise RuntimeError(
+            "TTS_PREVIEW_GCS_BUCKET is not set — preview storage is unconfigured. "
+            "Set it to the previews bucket (it is intentionally separate from "
+            "GCS_BUCKET, the recordings bucket)."
+        )
+    if not _COMPONENT_RE.fullmatch(TTS_PREVIEW_GCS_BUCKET):
+        raise RuntimeError(
+            f"TTS_PREVIEW_GCS_BUCKET={TTS_PREVIEW_GCS_BUCKET!r} is not a valid "
+            "GCS bucket name — expected only [A-Za-z0-9._-]."
+        )
+    return TTS_PREVIEW_GCS_BUCKET
+
+
+async def _store_gcs(rel: str, data: bytes, content_type: str) -> str:
+    destination_path = f"tts-previews/{rel}"
+    _require_bucket()
+
+    def _upload() -> None:
+        bucket = get_gcs_bucket(TTS_PREVIEW_GCS_BUCKET)
+        if not bucket:
+            raise RuntimeError(
+                f"Failed to access GCS bucket '{TTS_PREVIEW_GCS_BUCKET}' for preview upload"
+            )
+        blob = bucket.blob(destination_path)
+        blob.upload_from_string(data, content_type=content_type)
+
+    await asyncio.to_thread(_upload)
+    logger.info(f"Preview uploaded to gs://{TTS_PREVIEW_GCS_BUCKET}/{destination_path}")
+    return _public_url(rel)
+
+
+# ---------------------------------------------------------------------------
+# Preview manifest
+# ---------------------------------------------------------------------------
+
+
+def manifest_key(provider: str, voice_id: str) -> str:
+    """Manifest map key for one voice."""
+    return f"{provider}/{voice_id}"
+
+
+async def load_manifest() -> dict:
+    """Read the preview manifest, TTL-cached per process.
+
+    Fails soft to the last cached value (or {}) on backend errors — the
+    catalog endpoint should degrade to voices-without-previews rather than
+    500 when storage hiccups. Writers never use this; see `update_previews`.
+    """
+    global _manifest_cache
+    now = time.monotonic()
+    if _manifest_cache and now - _manifest_cache[0] < MANIFEST_CACHE_TTL_SECS:
+        return _manifest_cache[1]
+    try:
+        data = await load_manifest_fresh()
+    except Exception:
+        logger.exception("tts previews: manifest load failed")
+        return _manifest_cache[1] if _manifest_cache else {}
+    _manifest_cache = (now, data)
+    return data
+
+
+async def load_manifest_fresh() -> dict:
+    """Read the manifest from the backend, bypassing the cache.
+
+    Raises on backend errors so read-modify-write callers abort instead of
+    clobbering good state with a partial manifest. A *missing* manifest is
+    just {}; a manifest that exists but doesn't parse is treated as corrupt:
+    logged loudly and returned as {} so the next successful write repairs it
+    (self-healing), rather than wedging every future write behind the same
+    parse error.
+    """
+    return await _load_manifest_gcs()
+
+
+def _parse_manifest(raw: str) -> dict:
+    try:
+        data = json.loads(raw)
+    except ValueError:
+        logger.exception(
+            "tts previews: manifest.json is corrupt — treating as empty; "
+            "the next successful reconcile write will replace it"
+        )
+        return {}
+    if not isinstance(data, dict):
+        logger.error(
+            "tts previews: manifest.json root is not an object — treating as "
+            "empty; the next successful reconcile write will replace it"
+        )
+        return {}
+    return data
+
+
+async def _load_manifest_gcs() -> dict:
+    destination_path = f"tts-previews/{MANIFEST_NAME}"
+    _require_bucket()
+
+    def _download() -> dict:
+        bucket = get_gcs_bucket(TTS_PREVIEW_GCS_BUCKET)
+        if not bucket:
+            raise RuntimeError(
+                f"Failed to access GCS bucket '{TTS_PREVIEW_GCS_BUCKET}' for manifest read"
+            )
+        blob = bucket.blob(destination_path)
+        if not blob.exists():
+            return {}
+        try:
+            raw = blob.download_as_bytes()
+        except NotFound:
+            # Deleted between exists() and download — same as never existing.
+            return {}
+        return _parse_manifest(raw.decode("utf-8"))
+
+    return await asyncio.to_thread(_download)
+
+
+async def _store_manifest(manifest: dict) -> None:
+    payload = json.dumps(manifest, indent=2, sort_keys=True).encode("utf-8")
+    await _store_gcs(MANIFEST_NAME, payload, content_type="application/json")
+
+
+async def update_previews(provider: str, voice_id: str, previews: list) -> None:
+    """Replace one voice's preview entries and persist the manifest.
+
+    Fresh read-modify-write (never through the TTL cache) so sequential
+    updates within one reconcile run compose; the cache is refreshed on
+    success so the writing pod serves the new state immediately. Concurrent
+    reconciles on different pods are last-write-wins per manifest — an
+    accepted trade for an admin-only, idempotent operation.
+    """
+    global _manifest_cache
+    manifest = dict(await load_manifest_fresh())
+    manifest[manifest_key(provider, voice_id)] = previews
+    await _store_manifest(manifest)
+    _manifest_cache = (time.monotonic(), manifest)

--- a/docs/TTS_VOICE_CATALOG.md
+++ b/docs/TTS_VOICE_CATALOG.md
@@ -1,0 +1,270 @@
+# TTS Voice Catalog
+
+## What it is
+
+The TTS voice catalog is a curated list of "safe to offer in the dashboard" TTS
+voices, separate from the raw provider/voice/model combinations a merchant
+template can already reference directly. It is **static, versioned data** —
+`app/ai/voice/tts/catalog.json`, parsed and validated once per process by
+`app/ai/voice/tts/catalog.py` — not a database table. Voices are curated,
+change rarely, and belong under code review: adding or editing one is a normal
+PR with rollback for free.
+
+One entry per `(provider, voice_id)`:
+
+```json
+{
+  "provider": "elevenlabs",
+  "voice_id": "fG9s0SXJb213f4UxVHyG",
+  "display_name": "Rachel",
+  "models": ["eleven_flash_v2_5"],
+  "languages": ["en-IN", "hi"],
+  "tags": ["female", "default"]
+}
+```
+
+Optional fields: `enabled` (default `true`), `residency`, `style_params`.
+Entries are validated against `CatalogVoiceEntry`
+(`app/schemas/breeze_buddy/tts_catalog.py`); unknown providers and duplicate
+`(provider, voice_id)` pairs fail loading (and the test suite —
+`tests/test_tts_catalog_static.py`). A catalog that fails to parse or
+validate **fails app startup** (the lifespan primes it without a fallback):
+it's checked-in code, so a broken file is a bad build, not a runtime
+condition to limp through.
+
+The only **mutable** state in the system is the *preview manifest* —
+`tts-previews/manifest.json`, stored in the same backend as the preview WAVs
+(`app/services/preview_storage.py`). It maps `"provider/voice_id"` to that
+voice's generated preview entries (`{language, url, content_key, format}`, or
+`{language, error, content_key}` for a failed attempt). The reconcile endpoint
+is its only writer.
+
+The catalog covers the 6 **voice-owning** providers: `elevenlabs`, `cartesia`,
+`sarvam`, `gemini`, `google`, `soniox`. `dragontts` is a caching proxy: the app
+forwards `model: "<provider>:<model>"` as-is (`app/ai/voice/tts/dragontts.py`);
+the external DragonTTS service parses the compound id server-side. It owns no
+voices, so it's deliberately excluded from the catalog and from
+`ProviderFilter` on the listing endpoint (`provider=dragontts` is a `422`, not
+an empty result).
+
+Two endpoints, both mounted under the Breeze Buddy router
+(`app/api/routers/breeze_buddy/tts_catalog/__init__.py`, included with prefix
+`/agent/voice/breeze-buddy` in `app/main.py`):
+
+- **`GET /agent/voice/breeze-buddy/tts/voices`** — list enabled catalog voices,
+  optionally filtered by `provider` (exact match, one of the 6) and/or
+  `language` (bare/regional match, see below). Requires any authenticated RBAC
+  user (`get_current_user_with_rbac`), not admin-only. Response is ETag-cached
+  client-side for 5 minutes (`Cache-Control: private, max-age=300`); a matching
+  `If-None-Match` gets a `304` with no body. The ETag hashes the filter params
+  plus the full response content, which folds in both the resolved per-provider
+  defaults (`is_default`) and the manifest state (`previews`) — so a Redis
+  default flip or a reconcile run yields new ETags. Each returned voice carries
+  an `is_default` flag (does this voice match the provider's current live
+  default per `BB_VOICE_PROVIDER_DEFAULTS`, fetched concurrently for all 6
+  providers; `gemini` has no `BB_SPEECH_PROVIDER_DEFAULTS` entry, so an empty
+  lookup falls back to `GEMINI_FALLBACK_DEFAULT = "Kore"` in `handlers.py`) and
+  a `previews[]` array of `{language, url}` pairs — only previews that
+  generated successfully are exposed; failed/pending ones are omitted from the
+  response (still visible internally in the manifest).
+- **`POST /agent/voice/breeze-buddy/tts/voices/reconcile`** — admin-only
+  (`require_admin_access`, 403 for non-admin). Walks every enabled catalog
+  voice and regenerates any preview whose manifest `content_key` doesn't match
+  the hash of the voice's *resolved* preview configuration, or whose preview is
+  simply missing. See "Ops notes" for throttling and failure handling.
+
+Previews themselves are short, browser-playable WAV clips (16-bit mono,
+native/requested PCM rate wrapped as WAV exactly once — providers that return a
+WAV container, like Sarvam, are unwrapped first) of a canonical per-language
+sentence, synthesized by `app/ai/voice/tts/preview.py` and persisted by
+`app/services/preview_storage.py`. This path is deliberately separate from the
+runtime telephony TTS dispatch (mu-law 8 kHz) — it never touches the live call
+pipeline.
+
+## Add a voice
+
+1. **Add an entry to `app/ai/voice/tts/catalog.json`** (see the shape above).
+   `models`/`languages`/`tags` can be empty lists where they don't apply:
+   gemini voices carry `models: []` because the model comes from
+   `GEMINI_TTS_MODEL` at synth time; google Chirp3-HD voices encode model +
+   locale into the voice name itself (e.g. `en-IN-Chirp3-HD-Despina`).
+
+   Verify the id against the real provider surface before adding it — the
+   current sarvam speakers were checked against the installed pipecat SDK's
+   `SarvamTTSSpeakerV3` enum, and the gemini names against
+   `GeminiTTSService.AVAILABLE_VOICES` (`pipecat.services.google.tts`).
+
+2. **Run the tests** (`uv run pytest tests/test_tts_catalog_static.py`) — they
+   enforce provider validity, `(provider, voice_id)` uniqueness, and that every
+   hardcoded provider default (`BB_SPEECH_PROVIDER_DEFAULTS`) stays covered.
+
+3. **Ship it** (normal PR + deploy). The voice is immediately visible to
+   `GET /tts/voices` — with `previews: []` until reconciled.
+
+4. **Trigger preview generation** against the deployed environment:
+
+   ```bash
+   curl -X POST https://<host>/agent/voice/breeze-buddy/tts/voices/reconcile \
+     -H "Authorization: Bearer <admin JWT>"
+   ```
+
+   Mint an admin JWT via the login endpoint (`POST
+   /agent/voice/breeze-buddy/login`) or, for a scripted credential, `POST
+   /agent/voice/breeze-buddy/auth/s2s/token` (admin-only, up to 365 days).
+
+5. **Verify:**
+
+   ```bash
+   curl "https://<host>/agent/voice/breeze-buddy/tts/voices?provider=elevenlabs" \
+     -H "Authorization: Bearer <JWT>"
+   ```
+
+   Confirm the new voice appears with a non-empty `previews[]` array for each
+   of its configured languages (or a single `en` entry if `languages` is
+   empty).
+
+To **remove** a voice from the picker without deleting its entry (and its
+curation history), set `"enabled": false` and ship.
+
+There is deliberately **no no-deploy prod path** anymore: the old
+insert-a-row-live escape hatch traded review for speed and is exactly what the
+static design removes. An urgent voice addition is a one-line JSON PR.
+
+## Preview storage config
+
+Previews are stored in **GCS only** — there is no local-filesystem backend.
+Two env vars govern it (`app/core/config/static.py`, read once at import — not
+a live Redis toggle):
+
+| Var | Default | Purpose |
+|---|---|---|
+| `TTS_PREVIEW_GCS_BUCKET` | `""` | GCS bucket for previews. Unset = previews disabled: the catalog still serves voices (without preview URLs) and any attempt to *write* a preview raises naming this variable. Deliberately **not** validated at import, so deployments that never use the voice catalog still boot. |
+| `TTS_PREVIEW_PUBLIC_BASE_URL` | `""` | Optional. Overrides the host previews are served from, for deployments fronting the bucket with a CDN or custom domain. When unset, URLs default to the bucket's own public URL (`https://storage.googleapis.com/<bucket>/...`). |
+
+`TTS_PREVIEW_GCS_BUCKET` is deliberately a separate bucket from the general
+`GCS_BUCKET` (default `"atoms-sdk"`, used for call recordings) —
+`preview_storage.py` calls `get_gcs_bucket()` directly with its own bucket name
+rather than reusing `GCSStorage`/`upload_file_to_gcs`, since those are
+hardcoded to `GCS_BUCKET`.
+
+Objects are stored at `{provider}/{voice_id}/{language}-{key}.wav`, plus
+`manifest.json`, all under the `tts-previews/` prefix. Previews are served
+straight from the bucket, so the app exposes no `/tts-previews` route.
+
+**Changing `TTS_PREVIEW_PUBLIC_BASE_URL` requires regenerating previews.** The
+served URL is computed once, at generation time, and written into the manifest
+— it isn't derived on read. To force full regeneration: delete the
+`tts-previews/manifest.json` blob, then re-run the reconcile endpoint.
+
+**GCS bucket expectation:** the upload code never calls `make_public()` or
+generates a signed URL — it uploads and trusts the constructed URL to be
+reachable. The bucket (or whatever fronts `TTS_PREVIEW_PUBLIC_BASE_URL`, e.g. a
+CDN) must already allow public/anonymous read on the `tts-previews/` prefix
+before use in prod, or every preview URL will 403 for end users. This is an
+operational precondition the app doesn't check. The manifest lives in that same
+public location by design — it contains only public preview URLs and
+content-key hashes.
+
+All four path components (`provider`, `voice_id`, `language`, `key`) are
+validated against `[A-Za-z0-9._-]+` and rejected if they contain `..`, so
+neither backend's path can be escaped by a crafted value.
+
+**Content-key naming, and why regenerated audio can never be served stale:**
+`resolve_preview_config()` in `app/ai/voice/tts/preview.py` first resolves the
+*effective* synthesis configuration — catalog model or the provider's default,
+dynamic toggles (ElevenLabs Indian residency, Sarvam preprocessing), the full
+Sarvam request payload, fixed sample rates, and the canonical sentence — and
+`content_key()` SHA-256-hashes that resolved config (truncated to 16 hex
+chars). The same config object then drives synthesis, so hashing and synthesis
+can never disagree. During reconcile, the freshly computed key is compared
+against the manifest entry's `content_key` for the same language: a match (with
+a populated `url`) means "skip, still fresh"; anything else — missing,
+mismatched, or a prior failure — triggers regeneration. Because the key is a
+pure function of everything that affects the audio (and nothing else — no
+timestamp), any change forces a *different* key → a *different* storage path.
+The new audio is written there and the manifest URL updated; the old blob is
+left behind unreferenced. A client can therefore never be served stale audio at
+a URL the catalog is currently advertising.
+
+**Manifest read/write semantics:** `GET /tts/voices` reads the manifest through
+a per-process TTL cache (300 s, matching the endpoint's `Cache-Control`) and
+*fails soft* — on a storage error it serves the last cached value (or no
+previews) rather than a 500. Reconcile goes the other way: it starts from a
+*fresh* read (a backend failure aborts the run **before any paid provider
+call**), and every `update_previews` does a fresh read-modify-write that
+**fails hard** if the manifest can't be read, so a transient storage error can
+never cause a partial manifest to overwrite a good one. A manifest that exists
+but doesn't *parse* is treated as corrupt, not transient: logged loudly and
+loaded as `{}`, so that run regenerates previews and its successful write
+repairs the file (self-healing) instead of every future write wedging behind
+the same parse error. Concurrent reconciles on different pods are
+last-write-wins per manifest — an accepted trade for an admin-only, idempotent
+operation (just re-run it).
+
+## Language filter semantics
+
+`language_matches(filter_code, voice_languages)`
+(`app/api/routers/breeze_buddy/tts_catalog/matching.py`) governs
+`GET /tts/voices?language=...`:
+
+- **Empty `voice_languages`** (e.g. every gemini voice in the catalog has
+  `languages: []`) means the voice is language-agnostic — it matches any
+  filter value, including no filter at all.
+- Otherwise, matching is case-insensitive and works **both directions** across
+  the bare/regional boundary: a bare filter (`en`) matches a regional voice
+  language (`en-IN`), and a regional filter (`en-IN`) matches a bare voice
+  language (`en`), in addition to an exact match.
+- The boundary check requires the literal `-`, so it's not a naive string
+  prefix: filtering on `en` does **not** match a voice language of `enx-XX`.
+
+`provider` is a separate, exact-match filter — a `Literal` of the 6 catalog
+providers, so `provider=dragontts` (or any provider outside the 6) is a `422`,
+not an empty result.
+
+## Curation notes — never add these voice_ids
+
+Each looks plausible in the codebase but is dead or unreachable (see also the
+docstring in `app/ai/voice/tts/catalog.py`):
+
+- `app/core/config/static.py`'s `ELEVENLABS_VOICE_ID` (default
+  `"bQQWtYx9EodAqMdkrNAc"`), and the identical default echoed into
+  `.env.example` — nothing in the runtime TTS dispatch or catalog code reads
+  this var.
+- `app/core/config/static.py`'s `GOOGLE_BRET_VOICE` / `GOOGLE_MIA_VOICE` —
+  declared with env-overridable defaults, never read anywhere else.
+- The template generator's placeholder `voice_id: "iB2rIwm9cQCRGWoKDRtX"`
+  (`app/ai/voice/agents/breeze_buddy/template/generator/prompts.py`) — a
+  made-up example id used only inside LLM prompt examples.
+- Sarvam's inline `"manisha"` fallback (`SARVAM_TTS_VOICE_ID()` in
+  `app/core/config/dynamic.py`, and the `.get("voice_id", "manisha")` default
+  in `app/ai/voice/tts/sarvam.py`) — unreachable in practice, since
+  `BB_SPEECH_PROVIDER_DEFAULTS["sarvam"]["voice_id"]` is always `"shreya"`.
+
+## Ops notes
+
+- **Reconcile is idempotent.** Any voice/language whose manifest `content_key`
+  already matches the current resolved config is skipped with zero provider
+  calls; only missing or stale previews trigger synthesis and storage. Safe to
+  re-run at any time, including immediately after a failed run.
+- **Reconcile is throttled to one provider call per second**
+  (`RECONCILE_DELAY_SECS = 1.0`, applied via `asyncio.sleep` after each
+  generate+store attempt, not after a skip) — there's no dedicated rate-limit
+  infrastructure in the TTS layer, so this fixed pacing is the only protection
+  against tripping a provider's rate limit during a full reconcile run.
+- **Per-voice/per-language failures are recorded, not hidden — and never
+  destructive.** A failure adds a `"failed"` entry (error message truncated to
+  300 chars) to the response `report[]`. If the voice had **no** working
+  preview for that language, an error entry (`content_key`, no `url`) is
+  persisted; if it **did** have one, the last-known-good entry is left
+  untouched — `GET /tts/voices` keeps serving the old audio, and its stale
+  `content_key` makes the next reconcile retry. A failed *manifest write* for
+  one voice is likewise logged and reported (`"manifest_write_failed"`)
+  without aborting the remaining voices. Re-running reconcile retries
+  whatever's still failed, missing, or stale.
+- **ElevenLabs residency toggle:** `resolve_preview_config()` resolves
+  residency for every ElevenLabs voice from the global
+  `BB_ENABLE_ELEVENLABS_INDIAN_RESIDENCY` Redis toggle — and because that
+  resolved value is part of the hashed config, flipping the toggle changes
+  every ElevenLabs content key, so the next reconcile regenerates all
+  ElevenLabs previews through the new endpoint/key. The per-voice `residency`
+  field in catalog.json is informational; preview generation doesn't read it.

--- a/tests/test_preview_storage.py
+++ b/tests/test_preview_storage.py
@@ -1,0 +1,173 @@
+"""Preview storage tests.
+
+GCS is the only backend, so these run against an in-memory stub bucket rather
+than a temp directory. The stub records blob paths/content types and keeps
+bytes in a dict, which is enough to exercise URL construction, manifest
+round-tripping, corruption self-healing and the fail-soft/fail-hard split.
+"""
+
+import pytest
+
+from app.services import preview_storage
+
+BUCKET = "my-preview-bucket"
+
+
+class _StubBlob:
+    def __init__(self, store: dict, path: str, calls: dict):
+        self._store = store
+        self._path = path
+        self._calls = calls
+
+    def upload_from_string(self, data, content_type=None):
+        self._store[self._path] = (
+            data if isinstance(data, bytes) else str(data).encode("utf-8")
+        )
+        self._calls["path"] = self._path
+        self._calls["data"] = self._store[self._path]
+        self._calls["content_type"] = content_type
+
+    def exists(self):
+        return self._path in self._store
+
+    def download_as_bytes(self):
+        return self._store[self._path]
+
+
+class _StubBucket:
+    def __init__(self, store: dict, calls: dict):
+        self._store = store
+        self._calls = calls
+
+    def blob(self, path):
+        return _StubBlob(self._store, path, self._calls)
+
+
+@pytest.fixture()
+def gcs(monkeypatch):
+    """In-memory GCS: returns the blob store plus a record of the last call."""
+    store: dict = {}
+    calls: dict = {}
+
+    def _get_bucket(bucket_name):
+        calls["bucket_name"] = bucket_name
+        return _StubBucket(store, calls)
+
+    monkeypatch.setattr(preview_storage, "get_gcs_bucket", _get_bucket)
+    monkeypatch.setattr(preview_storage, "TTS_PREVIEW_GCS_BUCKET", BUCKET)
+    monkeypatch.setattr(preview_storage, "TTS_PREVIEW_PUBLIC_BASE_URL", "")
+    monkeypatch.setattr(preview_storage, "_manifest_cache", None)
+    return {"store": store, "calls": calls}
+
+
+# ── URL construction ────────────────────────────────────────────────────────
+@pytest.mark.asyncio
+async def test_store_returns_bucket_public_url_by_default(gcs):
+    """With no CDN override the URL points straight at the bucket — previews
+    are served by GCS, not by this app."""
+    url = await preview_storage.store_preview(
+        "elevenlabs", "v9", "hi", "abc", b"RIFFdata"
+    )
+    assert url == (
+        f"https://storage.googleapis.com/{BUCKET}/tts-previews/elevenlabs/v9/hi-abc.wav"
+    )
+    assert gcs["calls"]["bucket_name"] == BUCKET
+    assert gcs["calls"]["path"] == "tts-previews/elevenlabs/v9/hi-abc.wav"
+    assert gcs["calls"]["data"] == b"RIFFdata"
+    assert gcs["calls"]["content_type"] == "audio/wav"
+
+
+@pytest.mark.asyncio
+async def test_public_base_url_overrides_bucket_url(gcs, monkeypatch):
+    """Deployments fronting the bucket with a CDN/custom domain override the
+    host; the object path is unchanged."""
+    monkeypatch.setattr(
+        preview_storage, "TTS_PREVIEW_PUBLIC_BASE_URL", "https://cdn.example.com"
+    )
+    url = await preview_storage.store_preview(
+        "cartesia", "v1", "en", "k123", b"RIFFdata"
+    )
+    assert url == "https://cdn.example.com/tts-previews/cartesia/v1/en-k123.wav"
+
+
+@pytest.mark.asyncio
+async def test_missing_bucket_raises_naming_the_variable(gcs, monkeypatch):
+    """Unconfigured previews must fail with an actionable message rather than
+    a generic GCS error — config is validated lazily so unrelated deployments
+    still boot."""
+    monkeypatch.setattr(preview_storage, "TTS_PREVIEW_GCS_BUCKET", "")
+    with pytest.raises(RuntimeError, match="TTS_PREVIEW_GCS_BUCKET"):
+        await preview_storage.store_preview("cartesia", "v1", "en", "k", b"x")
+
+
+@pytest.mark.asyncio
+async def test_non_url_safe_bucket_rejected(gcs, monkeypatch):
+    """The bucket name is interpolated into the public URL unencoded. A name
+    outside [A-Za-z0-9._-] must fail loudly here — percent-encoding it would
+    turn a misconfiguration into a well-formed URL that 404s at GCS."""
+    monkeypatch.setattr(preview_storage, "TTS_PREVIEW_GCS_BUCKET", "bad bucket/../x")
+    with pytest.raises(RuntimeError, match="not a valid GCS bucket name"):
+        await preview_storage.store_preview("cartesia", "v1", "en", "k", b"x")
+    assert gcs["store"] == {}
+
+
+@pytest.mark.asyncio
+async def test_path_traversal_component_rejected(gcs):
+    with pytest.raises(ValueError):
+        await preview_storage.store_preview("cartesia", "../evil", "en", "k", b"x")
+    assert gcs["store"] == {}
+
+
+# ── manifest ────────────────────────────────────────────────────────────────
+@pytest.mark.asyncio
+async def test_manifest_missing_reads_as_empty(gcs):
+    assert await preview_storage.load_manifest() == {}
+
+
+@pytest.mark.asyncio
+async def test_update_previews_round_trips_through_manifest(gcs):
+    entries = [
+        {"language": "en", "url": "https://cdn/x.wav", "content_key": "k1"},
+    ]
+    await preview_storage.update_previews("cartesia", "v1", entries)
+    assert await preview_storage.load_manifest() == {"cartesia/v1": entries}
+    # persisted, not just cached: a fresh read from the backend sees it too
+    assert (await preview_storage.load_manifest_fresh()) == {"cartesia/v1": entries}
+
+
+@pytest.mark.asyncio
+async def test_update_previews_composes_across_voices(gcs):
+    """Sequential updates read-modify-write fresh — the second voice must not
+    clobber the first."""
+    await preview_storage.update_previews("cartesia", "v1", [{"language": "en"}])
+    await preview_storage.update_previews("sarvam", "shreya", [{"language": "hi"}])
+    manifest = await preview_storage.load_manifest_fresh()
+    assert set(manifest) == {"cartesia/v1", "sarvam/shreya"}
+
+
+@pytest.mark.asyncio
+async def test_load_manifest_fails_soft_but_update_fails_hard(gcs, monkeypatch):
+    """GET path degrades to {} on storage errors; the reconcile write path
+    must abort instead of overwriting good state with a partial manifest."""
+
+    async def boom():
+        raise RuntimeError("storage down")
+
+    monkeypatch.setattr(preview_storage, "load_manifest_fresh", boom)
+    assert await preview_storage.load_manifest() == {}
+    with pytest.raises(RuntimeError):
+        await preview_storage.update_previews("cartesia", "v1", [])
+
+
+@pytest.mark.asyncio
+async def test_corrupt_manifest_self_heals(gcs):
+    """A manifest that exists but doesn't parse loads as {} (logged) instead
+    of raising — so reconcile can regenerate and its successful write repairs
+    the file, rather than every future write failing forever."""
+    gcs["store"]["tts-previews/manifest.json"] = b"{not json"
+    assert await preview_storage.load_manifest_fresh() == {}
+
+    await preview_storage.update_previews("cartesia", "v1", [{"language": "en"}])
+    assert await preview_storage.load_manifest_fresh() == {
+        "cartesia/v1": [{"language": "en"}]
+    }

--- a/tests/test_tts_catalog_endpoint.py
+++ b/tests/test_tts_catalog_endpoint.py
@@ -1,0 +1,129 @@
+# tests/test_tts_catalog_endpoint.py
+# JWT env bootstrap lives in tests/conftest.py — it has to run before any test
+# module imports `app.`, which a module-level setdefault here cannot guarantee.
+from typing import get_args
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.api.routers.breeze_buddy.tts_catalog import ProviderFilter, handlers, router
+from app.api.security.breeze_buddy.rbac_token import get_current_user_with_rbac
+from app.schemas.breeze_buddy.tts_catalog import CATALOG_PROVIDERS, CatalogVoiceEntry
+
+VOICES = [
+    CatalogVoiceEntry(
+        provider="elevenlabs",
+        voice_id="fG9s0SXJb213f4UxVHyG",
+        display_name="Rachel",
+        models=["eleven_flash_v2_5"],
+        languages=["en-IN", "hi"],
+        tags=["female"],
+    ),
+    CatalogVoiceEntry(
+        provider="gemini",
+        voice_id="Kore",
+        display_name="Kore",
+        languages=[],
+    ),
+]
+
+MANIFEST = {
+    "elevenlabs/fG9s0SXJb213f4UxVHyG": [
+        {
+            "language": "en-IN",
+            "url": "https://p/1.wav",
+            "content_key": "k",
+            "format": "wav",
+        }
+    ],
+    "gemini/Kore": [{"language": "en", "error": "boom", "content_key": "k2"}],
+}
+
+
+@pytest.fixture()
+def client(monkeypatch):
+    async def fake_manifest():
+        return MANIFEST
+
+    async def fake_defaults(provider):
+        return {"voice_id": "fG9s0SXJb213f4UxVHyG"} if provider == "elevenlabs" else {}
+
+    monkeypatch.setattr(handlers, "get_enabled_voices", lambda: VOICES)
+    monkeypatch.setattr(handlers, "load_manifest", fake_manifest)
+    monkeypatch.setattr(handlers, "BB_VOICE_PROVIDER_DEFAULTS", fake_defaults)
+    app = FastAPI()
+    app.include_router(router)
+    app.dependency_overrides[get_current_user_with_rbac] = lambda: {"user": "t"}
+    return TestClient(app)
+
+
+def test_contract_shape_and_is_default(client):
+    r = client.get("/tts/voices")
+    assert r.status_code == 200
+    voices = r.json()["voices"]
+    el = next(v for v in voices if v["provider"] == "elevenlabs")
+    assert el["is_default"] is True
+    assert el["previews"] == [{"language": "en-IN", "url": "https://p/1.wav"}]
+    assert "content_key" not in str(r.json())  # internal fields never leak
+
+
+def test_provider_filter_rejects_dragontts(client):
+    assert (
+        client.get("/tts/voices", params={"provider": "dragontts"}).status_code == 422
+    )
+
+
+def test_language_filter_bare_code(client):
+    voices = client.get("/tts/voices", params={"language": "en"}).json()["voices"]
+    assert {v["provider"] for v in voices} == {
+        "elevenlabs",
+        "gemini",
+    }  # gemini = agnostic
+    voices = client.get("/tts/voices", params={"language": "ta"}).json()["voices"]
+    assert {v["provider"] for v in voices} == {"gemini"}
+
+
+def test_etag_304(client):
+    r1 = client.get("/tts/voices")
+    etag = r1.headers["etag"]
+    assert r1.headers["cache-control"] == "private, max-age=300"
+    r2 = client.get("/tts/voices", headers={"If-None-Match": etag})
+    assert r2.status_code == 304
+
+
+def test_etag_differs_by_filter(client):
+    r1 = client.get("/tts/voices")
+    r2 = client.get("/tts/voices", params={"provider": "gemini"})
+    assert r1.headers["etag"] != r2.headers["etag"]
+
+
+def test_etag_304_respects_filter(client):
+    r1 = client.get("/tts/voices", params={"provider": "gemini"})
+    etag = r1.headers["etag"]
+    r2 = client.get(
+        "/tts/voices", params={"provider": "gemini"}, headers={"If-None-Match": etag}
+    )
+    assert r2.status_code == 304
+
+
+def test_etag_changes_when_default_changes(client, monkeypatch):
+    """A Redis default flip must invalidate cached representations — the ETag
+    hashes the response content, which folds in is_default."""
+    etag_before = client.get("/tts/voices").headers["etag"]
+
+    async def other_defaults(provider):
+        return {}  # elevenlabs default removed
+
+    monkeypatch.setattr(handlers, "BB_VOICE_PROVIDER_DEFAULTS", other_defaults)
+    etag_after = client.get("/tts/voices").headers["etag"]
+    assert etag_before != etag_after
+
+
+def test_error_only_previews_render_as_no_previews(client):
+    r = client.get("/tts/voices", params={"provider": "gemini"})
+    assert r.json()["voices"][0]["previews"] == []
+
+
+def test_provider_filter_literal_matches_catalog_providers():
+    assert set(get_args(ProviderFilter)) == set(CATALOG_PROVIDERS)

--- a/tests/test_tts_catalog_matching.py
+++ b/tests/test_tts_catalog_matching.py
@@ -1,0 +1,32 @@
+# tests/test_tts_catalog_matching.py
+from app.api.routers.breeze_buddy.tts_catalog.matching import language_matches
+
+
+def test_exact_match():
+    assert language_matches("en-IN", ["en-IN", "hi"])
+
+
+def test_bare_filter_matches_regional_voice():
+    assert language_matches("en", ["en-IN"])
+
+
+def test_regional_filter_matches_bare_voice():
+    assert language_matches("en-IN", ["en"])
+
+
+def test_no_match_across_languages():
+    assert not language_matches("hi", ["en-IN", "ta-IN"])
+
+
+def test_empty_languages_is_language_agnostic():  # Gemini voices
+    assert language_matches("hi", [])
+    assert language_matches("en-IN", [])
+
+
+def test_case_insensitive():
+    assert language_matches("EN-in", ["en-IN"])
+
+
+def test_no_prefix_false_positive():
+    # "en" must not match "enx" style codes
+    assert not language_matches("en", ["enx-XX"])

--- a/tests/test_tts_catalog_reconcile.py
+++ b/tests/test_tts_catalog_reconcile.py
@@ -1,0 +1,228 @@
+# tests/test_tts_catalog_reconcile.py
+# JWT env bootstrap lives in tests/conftest.py — see the note there.
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.ai.voice.tts.preview import PreviewGenerationError, content_key
+from app.api.routers.breeze_buddy.tts_catalog import handlers, router
+from app.api.security.breeze_buddy.rbac_token import get_current_user_with_rbac
+from app.schemas import UserInfo, UserRole
+from app.schemas.breeze_buddy.tts_catalog import CatalogVoiceEntry
+
+ADMIN_USER = UserInfo(id="admin-1", username="admin", role=UserRole.ADMIN)
+NON_ADMIN_USER = UserInfo(id="merchant-1", username="merchant1", role=UserRole.MERCHANT)
+
+
+async def fake_resolve_preview_config(provider, voice_id, model, language, style):
+    """Pure stand-in for resolve_preview_config — no dynamic-config lookups."""
+    return {
+        "provider": provider,
+        "voice_id": voice_id,
+        "model": model,
+        "language": language,
+        "style_params": style or {},
+        "format": "wav",
+    }
+
+
+CURRENT_KEY = content_key(
+    {
+        "provider": "elevenlabs",
+        "voice_id": "current",
+        "model": "m1",
+        "language": "en",
+        "style_params": {},
+        "format": "wav",
+    }
+)
+
+VOICES = [
+    CatalogVoiceEntry(
+        provider="elevenlabs",
+        voice_id="current",
+        display_name="Current",
+        models=["m1"],
+        languages=["en"],
+    ),
+    CatalogVoiceEntry(
+        provider="elevenlabs",
+        voice_id="missing",
+        display_name="Missing",
+        models=["m1"],
+        languages=["en"],
+    ),
+    CatalogVoiceEntry(
+        provider="elevenlabs",
+        voice_id="broken",
+        display_name="Broken",
+        models=["m1"],
+        languages=["en"],
+    ),
+    # Has a working preview under a STALE content key, and regeneration fails:
+    # the last-known-good entry must survive.
+    CatalogVoiceEntry(
+        provider="elevenlabs",
+        voice_id="degraded",
+        display_name="Degraded",
+        models=["m1"],
+        languages=["en"],
+    ),
+]
+
+MANIFEST = {
+    "elevenlabs/current": [
+        {
+            "language": "en",
+            "url": "https://p/current.wav",
+            "content_key": CURRENT_KEY,
+            "format": "wav",
+        }
+    ],
+    "elevenlabs/degraded": [
+        {
+            "language": "en",
+            "url": "https://p/degraded-old.wav",
+            "content_key": "stale-key",
+            "format": "wav",
+        }
+    ],
+}
+
+
+@pytest.fixture()
+def updates(monkeypatch):
+    """Captures every update_previews(provider, voice_id, previews) call."""
+    captured: dict[tuple[str, str], list[dict]] = {}
+
+    async def fake_load_manifest_fresh():
+        return dict(MANIFEST)
+
+    async def fake_generate_preview(config):
+        if config["voice_id"] in ("broken", "degraded"):
+            raise PreviewGenerationError(
+                config["provider"], config["voice_id"], "synth failed"
+            )
+        return b"RIFF-fake-wav", content_key(config)
+
+    async def fake_store_preview(provider, voice_id, language, key, wav):
+        return f"https://p/{voice_id}.wav"
+
+    async def fake_update_previews(provider, voice_id, previews):
+        captured[(provider, voice_id)] = previews
+
+    monkeypatch.setattr(handlers, "get_enabled_voices", lambda: VOICES)
+    monkeypatch.setattr(handlers, "load_manifest_fresh", fake_load_manifest_fresh)
+    monkeypatch.setattr(handlers, "resolve_preview_config", fake_resolve_preview_config)
+    monkeypatch.setattr(handlers, "generate_preview", fake_generate_preview)
+    monkeypatch.setattr(handlers, "store_preview", fake_store_preview)
+    monkeypatch.setattr(handlers, "update_previews", fake_update_previews)
+    monkeypatch.setattr(handlers, "RECONCILE_DELAY_SECS", 0)
+    return captured
+
+
+@pytest.fixture()
+def client_with_fakes(updates):
+    app = FastAPI()
+    app.include_router(router)
+    app.dependency_overrides[get_current_user_with_rbac] = lambda: ADMIN_USER
+    client = TestClient(app)
+    client.updates = updates  # type: ignore[attr-defined]
+    return client
+
+
+def test_reconcile_actions(client_with_fakes):
+    r = client_with_fakes.post("/tts/voices/reconcile")
+    assert r.status_code == 200
+    actions = {(x["voice_id"], x["language"]): x["action"] for x in r.json()["report"]}
+    assert actions[("current", "en")] == "skipped"
+    assert actions[("missing", "en")] == "generated"
+    assert actions[("broken", "en")] == "failed"
+
+
+def test_reconcile_skip_leaves_previews_unpersisted(client_with_fakes):
+    client_with_fakes.post("/tts/voices/reconcile")
+    assert ("elevenlabs", "current") not in client_with_fakes.updates
+
+
+def test_reconcile_generated_persists_content_key_and_url(client_with_fakes):
+    client_with_fakes.post("/tts/voices/reconcile")
+    previews = client_with_fakes.updates[("elevenlabs", "missing")]
+    entry = next(p for p in previews if p["language"] == "en")
+    assert entry["url"] == "https://p/missing.wav"
+    assert entry["content_key"]
+    assert entry["format"] == "wav"
+
+
+def test_reconcile_failed_persists_error_entry(client_with_fakes):
+    r = client_with_fakes.post("/tts/voices/reconcile")
+    broken_report = next(x for x in r.json()["report"] if x["voice_id"] == "broken")
+    assert broken_report["action"] == "failed"
+    assert "error" in broken_report and broken_report["error"]
+
+    previews = client_with_fakes.updates[("elevenlabs", "broken")]
+    entry = next(p for p in previews if p["language"] == "en")
+    assert "error" in entry
+    assert entry["content_key"]
+    assert "url" not in entry
+
+
+def test_reconcile_manifest_error_carries_no_provider_message(client_with_fakes):
+    """The manifest is world-readable, so a failed entry may record only the
+    exception's class name. The provider's message stays in the admin-only
+    report (and the server log), never in storage."""
+    r = client_with_fakes.post("/tts/voices/reconcile")
+
+    broken_report = next(x for x in r.json()["report"] if x["voice_id"] == "broken")
+    assert "synth failed" in broken_report["error"]  # admin caller keeps detail
+
+    entry = next(
+        p
+        for p in client_with_fakes.updates[("elevenlabs", "broken")]
+        if p["language"] == "en"
+    )
+    assert entry["error"] == "PreviewGenerationError"
+    assert "synth failed" not in entry["error"]
+
+
+def test_reconcile_failure_preserves_last_known_good_preview(client_with_fakes):
+    """A failed regeneration must not evict a previously working preview:
+    the stale-key entry stays (so GET keeps serving the old audio) and the
+    stale key makes the next reconcile retry."""
+    r = client_with_fakes.post("/tts/voices/reconcile")
+    rep = next(x for x in r.json()["report"] if x["voice_id"] == "degraded")
+    assert rep["action"] == "failed"
+    # nothing persisted for this voice — the manifest entry is untouched
+    assert ("elevenlabs", "degraded") not in client_with_fakes.updates
+
+
+def test_reconcile_manifest_write_failure_is_isolated(updates, monkeypatch):
+    """A failing manifest write for one voice is reported, not raised — the
+    remaining voices still reconcile."""
+
+    async def failing_update_previews(provider, voice_id, previews):
+        if voice_id == "missing":
+            raise RuntimeError("gcs down")
+        updates[(provider, voice_id)] = previews
+
+    monkeypatch.setattr(handlers, "update_previews", failing_update_previews)
+    app = FastAPI()
+    app.include_router(router)
+    app.dependency_overrides[get_current_user_with_rbac] = lambda: ADMIN_USER
+    client = TestClient(app)
+
+    r = client.post("/tts/voices/reconcile")
+    assert r.status_code == 200
+    failures = [x for x in r.json()["report"] if x["action"] == "manifest_write_failed"]
+    assert [f["voice_id"] for f in failures] == ["missing"]
+    # the voice after the failing one still got persisted
+    assert ("elevenlabs", "broken") in updates
+
+
+def test_reconcile_requires_admin():
+    app = FastAPI()
+    app.include_router(router)
+    app.dependency_overrides[get_current_user_with_rbac] = lambda: NON_ADMIN_USER
+    client = TestClient(app)
+    r = client.post("/tts/voices/reconcile")
+    assert r.status_code == 403

--- a/tests/test_tts_catalog_static.py
+++ b/tests/test_tts_catalog_static.py
@@ -1,0 +1,77 @@
+# tests/test_tts_catalog_static.py — invariants of the checked-in catalog.
+import pytest
+
+from app.ai.voice.tts.catalog import get_all_voices, get_enabled_voices
+from app.ai.voice.tts.preview import content_key, resolve_preview_config
+from app.core.config.dynamic import BB_SPEECH_PROVIDER_DEFAULTS
+from app.schemas.breeze_buddy.tts_catalog import CATALOG_PROVIDERS
+
+
+def test_catalog_parses_and_validates():
+    voices = get_all_voices()
+    assert voices, "catalog.json must not be empty"
+    assert all(v.provider in CATALOG_PROVIDERS for v in voices)
+
+
+def test_catalog_pairs_unique():
+    pairs = [(v.provider, v.voice_id) for v in get_all_voices()]
+    assert len(pairs) == len(set(pairs))
+
+
+def test_enabled_subset():
+    assert {(v.provider, v.voice_id) for v in get_enabled_voices()} <= {
+        (v.provider, v.voice_id) for v in get_all_voices()
+    }
+
+
+def test_catalog_covers_static_provider_defaults():
+    """Every hardcoded default voice must exist in the catalog — otherwise the
+    picker can't show the voice a template actually falls back to. (The old
+    seed script guaranteed this at seed time; now it's a code invariant.)"""
+    catalog_pairs = {(v.provider, v.voice_id) for v in get_enabled_voices()}
+    for provider in CATALOG_PROVIDERS:
+        default_voice = BB_SPEECH_PROVIDER_DEFAULTS.get(provider, {}).get("voice_id")
+        if default_voice:
+            assert (
+                provider,
+                default_voice,
+            ) in catalog_pairs, (
+                f"static default {provider}/{default_voice} missing from catalog.json"
+            )
+    # gemini has no BB_SPEECH_PROVIDER_DEFAULTS entry; the handler falls back
+    # to "Kore", which must therefore exist too.
+    assert ("gemini", "Kore") in catalog_pairs
+
+
+def test_catalog_has_voices_without_an_explicit_model():
+    """The `model or <default>` fallback in resolve_preview_config is live, not
+    dead: catalog entries are allowed to omit `models`, and several do. This
+    pins that so the fallback never becomes untested-and-unreachable without
+    someone noticing."""
+    without = [v for v in get_enabled_voices() if not v.models]
+    assert without, (
+        "no catalog voice omits `models` — if that is now intentional, the "
+        "model-fallback branches in resolve_preview_config are dead and should "
+        "be removed rather than left untested"
+    )
+
+
+@pytest.mark.asyncio
+async def test_model_fallback_resolves_for_every_modelless_voice():
+    """A voice with no `models` must still resolve to a complete, hashable
+    preview config. Exercises the `model=None` path per provider."""
+    for v in (v for v in get_enabled_voices() if not v.models):
+        cfg = await resolve_preview_config(
+            v.provider, v.voice_id, None, (v.languages or ["en"])[0], v.style_params
+        )
+        assert cfg["provider"] == v.provider
+        assert cfg["voice_id"] == v.voice_id
+        assert "model" in cfg, f"{v.provider}/{v.voice_id} resolved without a model key"
+        # google encodes the model in the voice name, so None is correct there;
+        # every other provider must have filled the fallback in.
+        if v.provider != "google":
+            assert cfg["model"], (
+                f"{v.provider}/{v.voice_id} has no catalog model and the "
+                "fallback produced nothing"
+            )
+        assert content_key(cfg), "resolved config must be hashable to a content key"

--- a/tests/test_tts_preview.py
+++ b/tests/test_tts_preview.py
@@ -1,0 +1,140 @@
+import io
+import wave
+
+from app.ai.voice.tts.preview import (
+    _sarvam_payload,
+    content_key,
+    pcm_to_wav,
+    sentence_for,
+    wav_to_pcm,
+)
+
+
+def _cfg(**overrides) -> dict:
+    cfg = {
+        "provider": "cartesia",
+        "voice_id": "v1",
+        "model": "sonic-3.5",
+        "language": "en",
+        "style_params": {},
+        "format": "wav",
+    }
+    cfg.update(overrides)
+    return cfg
+
+
+def test_content_key_stable_and_sensitive():
+    a = content_key(_cfg())
+    assert a == content_key(_cfg())
+    assert len(a) == 16
+    assert a != content_key(_cfg(language="hi"))
+    assert a != content_key(_cfg(style_params={"emotion": "happy"}))
+
+
+def test_content_key_sensitive_to_resolved_model():
+    # The key hashes the RESOLVED configuration — a provider-default model
+    # change must invalidate previews generated under the old default.
+    assert content_key(_cfg(model="sonic-3.5")) != content_key(_cfg(model="sonic-4"))
+
+
+def test_pcm_to_wav_header():
+    wav = pcm_to_wav(b"\x00\x01" * 1600, 16000)
+    with wave.open(io.BytesIO(wav)) as w:
+        assert (
+            w.getnchannels() == 1
+            and w.getframerate() == 16000
+            and w.getsampwidth() == 2
+        )
+
+
+def test_wav_to_pcm_round_trip_strips_container():
+    # Providers that return a full WAV (Sarvam) must be unwrapped before
+    # generate_preview re-wraps — exactly one header in the output.
+    pcm = b"\x00\x01" * 1600
+    frames, rate = wav_to_pcm(pcm_to_wav(pcm, 22050))
+    assert frames == pcm
+    assert rate == 22050
+    assert not frames.startswith(b"RIFF")
+
+
+def test_wav_to_pcm_passes_raw_pcm_through():
+    raw = b"\x00\x01" * 100
+    frames, rate = wav_to_pcm(raw)
+    assert frames == raw
+    assert rate == 16000
+
+
+def test_sentence_localized_with_fallback():
+    assert sentence_for("hi") != sentence_for("en")
+    assert sentence_for("en-IN") == sentence_for("en")  # bare-code fallback
+    assert sentence_for("xx") == sentence_for("en")  # unknown -> English
+
+
+def test_sarvam_payload_omits_pitch_loudness_for_bulbul_v3():
+    # Bulbul V3 rejects these fields outright (confirmed against the live API):
+    # "Pitch and loudness parameters are currently not supported for the
+    # Bulbul V3 model. Please do not pass these values."
+    payload = _sarvam_payload(
+        voice_id="shreya",
+        model="bulbul:v3",
+        language_code="en-IN",
+        text="hi",
+        sarvam_defaults={"model": "bulbul:v3", "speed": 0.9, "pitch": 0.0},
+        enable_preprocessing=True,
+    )
+    assert "pitch" not in payload
+    assert "loudness" not in payload
+    assert payload["pace"] == 0.9
+    assert payload["model"] == "bulbul:v3"
+
+
+def test_sarvam_payload_keeps_pitch_loudness_for_non_v3():
+    payload = _sarvam_payload(
+        voice_id="shreya",
+        model="bulbul:v2",
+        language_code="en-IN",
+        text="hi",
+        sarvam_defaults={"model": "bulbul:v2", "speed": 0.9, "pitch": 0.0},
+        enable_preprocessing=True,
+    )
+    assert payload["pitch"] == 0.0
+    assert payload["loudness"] == 1.5
+
+
+def test_sarvam_payload_region_qualifies_bare_language_code():
+    # Sarvam's target_language_code only accepts region-qualified codes (its
+    # validation error enumerates an all-"xx-IN" set: as-IN, bn-IN, ..., hi-IN,
+    # ..., ur-IN), but the catalog stores bare codes like "hi".
+    payload = _sarvam_payload(
+        voice_id="amit",
+        model="bulbul:v3",
+        language_code="hi",
+        text="hi",
+        sarvam_defaults={"model": "bulbul:v3", "speed": 0.9, "pitch": 0.0},
+        enable_preprocessing=True,
+    )
+    assert payload["target_language_code"] == "hi-IN"
+
+
+def test_sarvam_payload_leaves_already_qualified_language_code_unchanged():
+    payload = _sarvam_payload(
+        voice_id="amit",
+        model="bulbul:v3",
+        language_code="hi-IN",
+        text="hi",
+        sarvam_defaults={"model": "bulbul:v3", "speed": 0.9, "pitch": 0.0},
+        enable_preprocessing=True,
+    )
+    assert payload["target_language_code"] == "hi-IN"
+
+
+def test_sarvam_payload_region_qualifies_bare_english_code():
+    payload = _sarvam_payload(
+        voice_id="amit",
+        model="bulbul:v3",
+        language_code="en",
+        text="hi",
+        sarvam_defaults={"model": "bulbul:v3", "speed": 0.9, "pitch": 0.0},
+        enable_preprocessing=True,
+    )
+    assert payload["target_language_code"] == "en-IN"


### PR DESCRIPTION
## What

Curated TTS voice catalog for the dashboard voice picker — **stored as static versioned data, not a database table** (reworked from the original DB design per review):

- **`app/ai/voice/tts/catalog.json`** is the single source of truth for which voices exist (14 curated voices across elevenlabs / cartesia / sarvam / gemini / google / soniox). Adding a voice = a one-line JSON PR under code review.
- The only mutable state is the **preview manifest** (`tts-previews/manifest.json`), stored alongside the preview WAVs in pluggable storage (local disk served at `/tts-previews`, or a dedicated GCS bucket).

## Endpoints

- `GET /tts/voices` — provider/language-filtered listing, `is_default` per provider (defaults resolved **concurrently**), ETag over the full representation (folds in resolved defaults + manifest state, so a Redis default flip or reconcile run invalidates caches), `Cache-Control: private, max-age=300`.
- `POST /tts/voices/reconcile` (admin-only) — regenerates stale/missing previews. Per-voice synthesis **and manifest-write** failures are reported in the response, never abort the run.

## Key design points

- **Resolved-config hashing**: `resolve_preview_config()` resolves the effective synthesis config (model defaults, ElevenLabs residency + Sarvam preprocessing toggles, full Sarvam payload) and that same spec drives both `content_key` hashing and synthesis — a config change can never leave a stale preview looking current.
- **Sarvam WAV unwrap**: Sarvam's REST API returns a WAV container; it's now stripped so every preview carries exactly one WAV header.
- **Fail-fast config**: storage mode and conditional GCS vars validated at startup.
- **Manifest semantics**: reads TTL-cached + fail-soft (endpoint degrades instead of 500); writes read-modify-write fresh + fail-hard (a transient storage error can't clobber a good manifest).
- **No filesystem I/O at import**: catalog parse + preview-dir creation run in the FastAPI lifespan; static mount uses `check_dir=False`; local writes are atomic (`os.replace`).

## Review-comment resolution

All 14 Copilot/CodeRabbit comments addressed: 6 dissolved with the DB layer's removal (query-builder pattern, accessor sentinels, upsert loop), 8 fixed in code (ETag defaults, `asyncio.gather`, GCS fail-fast, generic error messages, resolved-config hashing, lifespan makedirs, atomic writes, Sarvam double-wrap).

## Tests

851 passed, 1 xfailed. The 4 `test_chat_analytics` failures are **pre-existing on `release`** — `a5a185a` rebuilt the analytics queries without updating their tests — and are fixed separately in juspay/clairvoyance#973. This PR touches no chat or analytics file. pyrefly clean. Frontend consumer (loom PR juspay/loom#239) needs zero changes — the `GET /tts/voices` response shape is unchanged.

Docs: `docs/TTS_VOICE_CATALOG.md` (architecture, add-a-voice runbook, ops notes).

## Post-rework hardening (self-review round)

An adversarial multi-agent review of the squashed diff confirmed and fixed three additional issues before human review:

1. **Failed regeneration no longer evicts a working preview** — previously a transient synth error replaced a last-known-good manifest entry with an error-only entry, silently dropping the preview from `GET /tts/voices`. Now the old entry survives (its stale key retries next reconcile). Pinned by `test_reconcile_failure_preserves_last_known_good_preview`.
2. **Broken catalog.json fails startup** — the lifespan no longer swallows catalog load errors (which would have degraded into per-request blocking reloads + 500s, since `lru_cache` doesn't memoize exceptions).
3. **Corrupt manifest.json self-heals** — a parse failure loads as `{}` (logged loudly) so the next successful reconcile write repairs the file; backend read errors still abort reconcile *before* any paid provider call. Pinned by `test_corrupt_manifest_self_heals`.
