### PR TITLE
feat(tts): per-tenant DragonTTS cache attribution metrics

### DIFF
--- a/app/ai/voice/agents/breeze_buddy/agent/__init__.py
+++ b/app/ai/voice/agents/breeze_buddy/agent/__init__.py
@@ -122,6 +122,7 @@ from app.ai.voice.agents.breeze_buddy.utils.transport.websockets import (
     close_websocket_safely,
 )
 from app.ai.voice.agents.breeze_buddy.utils.warm_transfer import set_transfer_flag
+from app.ai.voice.tts.dragontts import DragonTTSCacheStats, DragonTTSService
 from app.core.config.dynamic import BB_DAILY_AUDIO_OUT_10MS_CHUNKS
 from app.core.config.static import ENABLE_BREEZE_BUDDY_TRACING
 from app.core.logger import logger
@@ -132,12 +133,14 @@ from app.core.logger.context import (
 )
 from app.database.accessor import get_lead_by_call_id, update_lead_call_initiated_time
 from app.database.accessor.breeze_buddy.lead_call_tracker import (
+    append_metadata_field,
     update_lead_call_initiated_time_by_id,
     update_lead_template,
 )
 from app.database.accessor.breeze_buddy.template import get_template_by_id
 from app.schemas import CallProvider
 from app.schemas.breeze_buddy.core import ExecutionMode, LeadCallTracker
+from app.services.tts_cache_metrics import flush_call_cache_stats
 
 DEFAULT_OUTCOME = "BUSY"
 TTS_SPEAK_MAX_CHARS = 2000
@@ -220,6 +223,10 @@ class Agent:
 
         # Error tracking
         self.errors: List[Dict[str, Any]] = []
+
+        # DragonTTS cache attribution — one stats object per generation whose
+        # TTS routed through DragonTTS; flushed once at true call end.
+        self._dragontts_stats: List[DragonTTSCacheStats] = []
 
         # Widget voice-as-chat bridge (stream mode + a bound chat_session).
         # Constructed in _register_event_handlers once self.task exists; drives
@@ -1281,6 +1288,9 @@ class Agent:
                 self.pending_transfer = None
                 await apply_transfer(self, transfer)
 
+            # Persist DragonTTS cache attribution (stats-only, fail-open).
+            await self._flush_tts_cache_stats()
+
             # The Agent owns the ONE real teardown at true call end — per-generation
             # teardown is suppressed so transfers never drop the connection.
             # Telephony: close the raw ws (NonClosingWebSocket swallowed pipecat's
@@ -1294,6 +1304,46 @@ class Agent:
                 await force_teardown_daily_client(self._daily_client)
         finally:
             clear_log_context()
+
+    async def _flush_tts_cache_stats(self) -> None:
+        """Persist DragonTTS cache attribution at true call end (fail-open).
+
+        Writes per-call totals into ``lead.meta_data['tts_cache']`` and folds
+        the same numbers into the Redis day-counters that bb_ttscache_rollup
+        aggregates into ``tts_cache_daily``. Stats must never fail a call.
+        """
+        try:
+            stats_list = [s for s in self._dragontts_stats if s.has_data]
+            if not stats_list or not self.lead:
+                return
+            for stats in stats_list:
+                await flush_call_cache_stats(
+                    stats,
+                    reseller_id=self.lead.reseller_id,
+                    merchant_id=self.lead.merchant_id,
+                    template_id=self.lead.template_id,
+                )
+            meta: Dict[str, Any]
+            if len(stats_list) == 1:
+                meta = stats_list[0].as_meta()
+            else:
+                # Rare: agent transfer rebuilt TTS — one entry per generation,
+                # combined totals on top so dashboards read one shape.
+                hit_words = sum(s.hit_words for s in stats_list)
+                miss_words = sum(s.miss_words for s in stats_list)
+                total = hit_words + miss_words
+                meta = {
+                    "provider": ",".join(dict.fromkeys(s.provider for s in stats_list)),
+                    "hit_requests": sum(s.hit_requests for s in stats_list),
+                    "miss_requests": sum(s.miss_requests for s in stats_list),
+                    "hit_words": hit_words,
+                    "miss_words": miss_words,
+                    "cache_word_ratio": round(hit_words / total, 4) if total else None,
+                    "generations": [s.as_meta() for s in stats_list],
+                }
+            await append_metadata_field(self.lead.id, {"tts_cache": meta})
+        except Exception as e:
+            logger.warning(f"TTS cache stats flush failed (ignored): {e}")
 
     async def _run_generation(self) -> None:
         """Build and run one pipeline generation via the cold-start path.
@@ -1312,6 +1362,8 @@ class Agent:
         )
         if not is_stream:
             assert llm is not None, "LLM is required in agent mode"
+        if isinstance(tts, DragonTTSService):
+            self._dragontts_stats.append(tts.cache_stats)
 
         # Knowledge base runtime resolution (fail-open). Stream mode goes
         # through the chat brain, which has its own KB hooks; realtime LLMs

--- a/app/ai/voice/tts/dragontts.py
+++ b/app/ai/voice/tts/dragontts.py
@@ -25,7 +25,7 @@ from __future__ import annotations
 
 from collections.abc import AsyncGenerator
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Any, Dict, Optional
 
 import httpx
 from pipecat.frames.frames import (
@@ -49,6 +49,7 @@ if TYPE_CHECKING:
 __all__ = [
     "DragonTTSConfig",
     "DragonTTSService",
+    "DragonTTSCacheStats",
     "build_dragontts_tts",
     "_generate_dragontts_audio",
 ]
@@ -56,6 +57,82 @@ __all__ = [
 
 # Params DragonTTS folds into the cache key and applies per nested provider.
 _PARAM_FIELDS = ("speed", "volume", "emotion", "pitch", "style_prompt")
+
+
+def _word_count(text: str) -> int:
+    """Whitespace word count — mirrors DragonTTS's own ``_wc`` so our numbers
+    reconcile with its ``/stats/daily`` words_served/words_synthesized."""
+    return len(text.split())
+
+
+@dataclass
+class DragonTTSCacheStats:
+    """Per-call cache attribution built from DragonTTS ``X-Cache`` headers.
+
+    One instance lives on each :class:`DragonTTSService` (one per pipeline
+    generation). ``record`` is called once per aggregated sentence; a turn is
+    the set of sentences sharing a pipecat ``context_id``. Any non-HIT status
+    (MISS, MISS-STITCH, UNKNOWN) counts as a miss — words the nested provider
+    actually synthesized.
+    """
+
+    provider: str  # nested provider, e.g. "cartesia"
+    model: str  # nested model, e.g. "sonic-3.5"
+    hit_requests: int = 0
+    miss_requests: int = 0
+    hit_words: int = 0
+    miss_words: int = 0
+    # context_id -> {"hits", "misses", "hit_words", "miss_words"}; insertion
+    # order == turn order. Capped so a runaway call can't bloat meta_data.
+    turns: Dict[str, Dict[str, int]] = field(default_factory=dict)
+
+    _MAX_TURNS = 200
+
+    def record(self, *, context_id: str, words: int, status: str) -> None:
+        is_hit = status == "HIT"
+        if is_hit:
+            self.hit_requests += 1
+            self.hit_words += words
+        else:
+            self.miss_requests += 1
+            self.miss_words += words
+        turn = self.turns.get(context_id)
+        if turn is None:
+            if len(self.turns) >= self._MAX_TURNS:
+                return
+            turn = {"hits": 0, "misses": 0, "hit_words": 0, "miss_words": 0}
+            self.turns[context_id] = turn
+        if is_hit:
+            turn["hits"] += 1
+            turn["hit_words"] += words
+        else:
+            turn["misses"] += 1
+            turn["miss_words"] += words
+
+    @property
+    def total_words(self) -> int:
+        return self.hit_words + self.miss_words
+
+    @property
+    def has_data(self) -> bool:
+        return bool(self.hit_requests or self.miss_requests)
+
+    def as_meta(self) -> Dict[str, Any]:
+        """Compact dict for ``lead.meta_data['tts_cache']``."""
+        total = self.total_words
+        return {
+            "provider": self.provider,
+            "model": self.model,
+            "hit_requests": self.hit_requests,
+            "miss_requests": self.miss_requests,
+            "hit_words": self.hit_words,
+            "miss_words": self.miss_words,
+            "cache_word_ratio": round(self.hit_words / total, 4) if total else None,
+            "turns": [
+                {"turn": i + 1, **counters}
+                for i, counters in enumerate(self.turns.values())
+            ],
+        }
 
 
 def _collect_params(resolved: "TTSConfig") -> dict:
@@ -177,6 +254,12 @@ class DragonTTSService(TTSService):
         self._language = language or ""
         self._params = dict(params or {})
         self._client: httpx.AsyncClient | None = None
+        # Cache attribution from X-Cache response headers. The agent reads this
+        # off the service at call end; stats must never break the audio path.
+        nested_provider, _, nested_model = model_id.partition(":")
+        self.cache_stats = DragonTTSCacheStats(
+            provider=nested_provider or model_id, model=nested_model
+        )
 
     def language_to_service_language(self, language: Language) -> str | None:
         """DragonTTS accepts a plain language code — no provider mapping needed."""
@@ -230,6 +313,14 @@ class DragonTTSService(TTSService):
                 "POST", f"{self._url}/tts/stream", json=body
             ) as response:
                 response.raise_for_status()
+                try:
+                    self.cache_stats.record(
+                        context_id=context_id,
+                        words=_word_count(text),
+                        status=response.headers.get("X-Cache", "UNKNOWN"),
+                    )
+                except Exception as stats_err:  # stats are best-effort only
+                    logger.warning(f"DragonTTS cache-stats record failed: {stats_err}")
                 async for chunk in response.aiter_bytes():
                     if not chunk:
                         continue

--- a/app/api/routers/breeze_buddy/analytics/__init__.py
+++ b/app/api/routers/breeze_buddy/analytics/__init__.py
@@ -34,6 +34,7 @@ from .handlers import (
     get_outbound_numbers_analytics,
     get_outcome_counts,
     get_performance_analytics,
+    handle_tts_cache_analytics,
 )
 from .rbac import apply_hierarchical_filters
 
@@ -58,6 +59,7 @@ _ANALYTICS_HANDLERS: Dict[AnalyticsType, Callable[..., Awaitable]] = {
     AnalyticsType.ATTEMPTS_TO_CONNECT: get_attempts_to_connect_analytics,
     AnalyticsType.CALLS_BY_HOUR: get_calls_by_hour_analytics,
     AnalyticsType.CHATS_BY_HOUR: get_chats_by_hour_analytics,
+    AnalyticsType.TTS_CACHE: handle_tts_cache_analytics,
 }
 
 

--- a/app/api/routers/breeze_buddy/analytics/handlers.py
+++ b/app/api/routers/breeze_buddy/analytics/handlers.py
@@ -8,6 +8,7 @@ import io
 import json
 from datetime import datetime, timedelta
 from typing import Any, Dict, List, Optional
+from zoneinfo import ZoneInfo
 
 from starlette.responses import StreamingResponse
 
@@ -34,6 +35,10 @@ from app.database.accessor.breeze_buddy.chat_analytics import (
     get_chat_summary_from_db,
     get_chat_trends_from_db,
     get_chats_by_hour_from_db,
+)
+from app.database.accessor.breeze_buddy.tts_cache import (
+    get_tts_cache_daily,
+    round_ratio,
 )
 from app.schemas import CallDetailGroupedResult, CallDetailResult, UserInfo
 from app.utils.common import parse_json
@@ -1026,4 +1031,78 @@ async def get_distinct_merchant_ids(
         "results": {
             "merchant_ids": merchant_ids,
         },
+    }
+
+
+async def handle_tts_cache_analytics(
+    filters: Dict[str, Any],
+    options: Dict[str, Any],
+    current_user: UserInfo,
+) -> Dict[str, Any]:
+    """DragonTTS cache hit/miss attribution, optionally grouped.
+
+    DragonTTS sits as a caching proxy in front of the nested TTS provider
+    (cartesia/elevenlabs/sarvam/gemini): a "hit" is a request served from
+    cache, a "miss" is one the nested provider actually had to synthesize.
+
+    ``options.group_by`` (one of "provider", "merchant", "template", "date")
+    controls the aggregation dimension in the accessor; anything else is
+    treated as ungrouped (one row per date_ist + provider).
+    """
+    db_filters: Dict[str, Any] = {
+        k: v
+        for k, v in filters.items()
+        if k in ("date_from", "date_to", "reseller_ids", "merchant_ids", "template_id")
+    }
+
+    # apply_hierarchical_filters validates the singular reseller_id /
+    # merchant_id forms but leaves them singular (and skips injecting the
+    # user's scope when one is present). The query builder only filters on
+    # the plural keys, so fold singular into plural here — singular wins
+    # over plural because RBAC validated only the singular when both were
+    # sent. Without this, a scoped caller passing reseller_id would get an
+    # UNSCOPED query (cross-tenant leak).
+    if filters.get("reseller_id"):
+        db_filters["reseller_ids"] = [filters["reseller_id"]]
+    if filters.get("merchant_id"):
+        db_filters["merchant_ids"] = [filters["merchant_id"]]
+
+    # AnalyticsFilters.provider is a List[str]; the query builder matches a
+    # list via = ANY(...) and a scalar via equality, so pass through as-is.
+    provider = filters.get("provider")
+    if provider:
+        db_filters["provider"] = provider
+
+    # Unbounded queries scan the whole table as history accumulates — default
+    # to the last 90 IST days when the caller supplies no date filter at all.
+    if not db_filters.get("date_from") and not db_filters.get("date_to"):
+        db_filters["date_from"] = (
+            datetime.now(ZoneInfo("Asia/Kolkata")) - timedelta(days=90)
+        ).date()
+
+    group_by = options.get("group_by")
+    if group_by in ("provider", "merchant", "template", "date"):
+        db_filters["group_by"] = group_by
+
+    rows = await get_tts_cache_daily(db_filters)
+
+    hit_requests = sum(row.get("hit_requests") or 0 for row in rows)
+    miss_requests = sum(row.get("miss_requests") or 0 for row in rows)
+    hit_words = sum(row.get("hit_words") or 0 for row in rows)
+    miss_words = sum(row.get("miss_words") or 0 for row in rows)
+
+    summary = {
+        "hit_requests": hit_requests,
+        "miss_requests": miss_requests,
+        "hit_words": hit_words,
+        "miss_words": miss_words,
+        "request_hit_rate": round_ratio(hit_requests, hit_requests + miss_requests),
+        "word_cache_ratio": round_ratio(hit_words, hit_words + miss_words),
+    }
+
+    return {
+        "type": "tts-cache",
+        "filters_applied": filters,
+        "results": rows,
+        "summary": summary,
     }

--- a/app/core/config/static.py
+++ b/app/core/config/static.py
@@ -374,6 +374,10 @@ BB_RECONCILE_BACKLOG_INTERVAL_S = int(
     os.environ.get("BB_RECONCILE_BACKLOG_INTERVAL_S", 60)
 )
 BB_REAP_PROCESSING_INTERVAL_S = int(os.environ.get("BB_REAP_PROCESSING_INTERVAL_S", 30))
+# DragonTTS cache-attribution rollup cadence (Redis day counters -> Postgres)
+BB_TTSCACHE_ROLLUP_INTERVAL_S = int(
+    os.environ.get("BB_TTSCACHE_ROLLUP_INTERVAL_S", 900)
+)
 BB_RECONCILE_CHANNELS_INTERVAL_S = int(
     os.environ.get("BB_RECONCILE_CHANNELS_INTERVAL_S", 60)
 )

--- a/app/database/accessor/breeze_buddy/tts_cache.py
+++ b/app/database/accessor/breeze_buddy/tts_cache.py
@@ -1,0 +1,120 @@
+"""
+Database accessor functions for TTS-cache daily metrics.
+
+This module provides business logic for tts_cache_daily operations,
+using queries from queries.breeze_buddy.tts_cache and the decoder from
+decoder.breeze_buddy.tts_cache.
+"""
+
+from datetime import date
+from typing import Any, Dict, List, Optional
+
+from app.core.logger import logger
+from app.database.decoder.breeze_buddy.tts_cache import decode_tts_cache_daily_row
+from app.database.queries import run_parameterized_query
+from app.database.queries.breeze_buddy.tts_cache import (
+    get_tts_cache_daily_query,
+    upsert_tts_cache_daily_query,
+)
+
+
+async def upsert_tts_cache_daily(
+    date_ist: date,
+    provider: str,
+    reseller_id: str,
+    merchant_id: Optional[str],
+    template_id: Optional[str],
+    hit_requests: int,
+    miss_requests: int,
+    hit_words: int,
+    miss_words: int,
+) -> None:
+    """Upsert one day's TTS-cache attribution row.
+
+    Args:
+        date_ist: The IST calendar day this row aggregates.
+        provider: The NESTED provider behind DragonTTS (e.g. cartesia,
+            elevenlabs, sarvam, gemini) -- not "dragontts" itself.
+        reseller_id: Reseller the activity is attributed to.
+        merchant_id: Merchant the activity is attributed to, if known.
+        template_id: Template the activity is attributed to, if known.
+        hit_requests, miss_requests, hit_words, miss_words: ABSOLUTE
+            running totals for the day, as held in the Redis source
+            counters. This upsert overwrites, it never increments.
+
+    Raises on failure so the ``bb_ttscache_rollup`` background task can log
+    and handle a failed rollup tick rather than silently losing it.
+    """
+    query, values = upsert_tts_cache_daily_query(
+        date_ist=date_ist,
+        provider=provider,
+        reseller_id=reseller_id,
+        merchant_id=merchant_id,
+        template_id=template_id,
+        hit_requests=hit_requests,
+        miss_requests=miss_requests,
+        hit_words=hit_words,
+        miss_words=miss_words,
+    )
+
+    try:
+        await run_parameterized_query(query, values)
+    except Exception as e:
+        logger.error(
+            f"Error upserting tts_cache_daily for date_ist={date_ist} "
+            f"provider={provider} reseller_id={reseller_id}: {e}"
+        )
+        raise
+
+
+def round_ratio(numerator: int, denominator: int) -> Optional[float]:
+    """Round numerator/denominator to 4dp, or None when denominator is 0.
+
+    Canonical implementation — the analytics handler imports this for its
+    summary totals so both layers round identically.
+    """
+    if not denominator:
+        return None
+    return round(numerator / denominator, 4)
+
+
+async def get_tts_cache_daily(filters: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """Fetch tts_cache_daily rows (raw or grouped, per filters['group_by']).
+
+    Each returned dict is enriched with two derived rates, rounded to 4dp
+    and None when their denominator is 0:
+      - request_hit_rate = hit_requests / (hit_requests + miss_requests)
+      - word_cache_ratio = hit_words / (hit_words + miss_words)
+
+    Args:
+        filters: See get_tts_cache_daily_query for supported keys
+            (date_from, date_to, reseller_ids, merchant_ids, template_id,
+            provider, group_by).
+
+    Returns:
+        List of decoded rows, each augmented with request_hit_rate and
+        word_cache_ratio.
+    """
+    query, values = get_tts_cache_daily_query(filters)
+
+    try:
+        rows = await run_parameterized_query(query, values)
+    except Exception as e:
+        logger.error(f"Error fetching tts_cache_daily with filters {filters}: {e}")
+        raise
+
+    results: List[Dict[str, Any]] = []
+    for row in rows or []:
+        decoded = decode_tts_cache_daily_row(row)
+        hit_requests = decoded.get("hit_requests") or 0
+        miss_requests = decoded.get("miss_requests") or 0
+        hit_words = decoded.get("hit_words") or 0
+        miss_words = decoded.get("miss_words") or 0
+
+        decoded["request_hit_rate"] = round_ratio(
+            hit_requests, hit_requests + miss_requests
+        )
+        decoded["word_cache_ratio"] = round_ratio(hit_words, hit_words + miss_words)
+        results.append(decoded)
+
+    return results

--- a/app/database/decoder/breeze_buddy/tts_cache.py
+++ b/app/database/decoder/breeze_buddy/tts_cache.py
@@ -1,0 +1,30 @@
+"""Decoder for tts_cache_daily rows (migration 036).
+
+Unlike most breeze_buddy decoders, this returns a plain dict rather than a
+Pydantic model: the SELECT shape varies with the caller's `group_by` filter
+(raw per-row columns vs. an aggregate with only date_ist + optionally one
+dimension column + the four summed counters), so there is no single fixed
+response schema to decode into.
+"""
+
+from typing import Any, Dict
+
+import asyncpg
+
+
+def decode_tts_cache_daily_row(row: asyncpg.Record) -> Dict[str, Any]:
+    """Convert a tts_cache_daily row (raw or aggregate) into a plain dict.
+
+    Date/datetime columns are converted to ISO-format strings, matching how
+    other decoders in this package hand dates to callers that eventually
+    serialize to JSON. Any other columns present (id, provider, reseller_id,
+    merchant_id, template_id, the four counters) pass through as-is.
+    """
+    decoded: Dict[str, Any] = dict(row)
+
+    for key in ("date_ist", "created_at", "updated_at"):
+        value = decoded.get(key)
+        if value is not None and hasattr(value, "isoformat"):
+            decoded[key] = value.isoformat()
+
+    return decoded

--- a/app/database/migrations/036_create_tts_cache_daily.sql
+++ b/app/database/migrations/036_create_tts_cache_daily.sql
@@ -1,0 +1,47 @@
+-- Migration 036: Durable per-day aggregates of DragonTTS cache attribution.
+--
+-- DragonTTS sits in front of the actual speech-synthesis provider and caches
+-- previously-synthesized sentences so repeat phrases (greetings, canned
+-- prompts, etc.) skip a round-trip to the underlying TTS vendor. This table
+-- is the durable landing zone for that attribution data: one row per
+-- (date_ist, provider, reseller_id, merchant_id, template_id) tuple, holding
+-- hit/miss sentence-request counts and hit/miss word counts for the day.
+--
+-- ``provider`` here is the NESTED provider behind DragonTTS -- i.e. the real
+-- vendor DragonTTS would have called on a cache miss (cartesia, elevenlabs,
+-- sarvam, gemini, ...) -- NOT "dragontts" itself.
+--
+-- Rows are upserted by the ``bb_ttscache_rollup`` background task, which
+-- periodically flushes the shared Redis day-counters (fast, ephemeral,
+-- TTL 3 days) into this table. Because the Redis counters
+-- hold full-day running totals rather than deltas, the upsert always writes
+-- the ABSOLUTE current total for the day -- it overwrites, it does not
+-- increment. merchant_id / template_id are nullable: some cache activity
+-- (e.g. shared/global prompts) is not attributable to a single merchant or
+-- template.
+
+CREATE TABLE IF NOT EXISTS tts_cache_daily (
+    id            BIGSERIAL PRIMARY KEY,
+    date_ist      DATE         NOT NULL,
+    provider      VARCHAR(50)  NOT NULL,
+    reseller_id   VARCHAR(255) NOT NULL,
+    merchant_id   VARCHAR(255),
+    template_id   VARCHAR(255),
+    hit_requests  INTEGER NOT NULL DEFAULT 0,
+    miss_requests INTEGER NOT NULL DEFAULT 0,
+    hit_words     INTEGER NOT NULL DEFAULT 0,
+    miss_words    INTEGER NOT NULL DEFAULT 0,
+    created_at    TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    updated_at    TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+);
+
+-- Expression unique index (COALESCE on the nullable dimensions) is the
+-- upsert conflict target -- a plain column unique constraint can't express
+-- "NULL == NULL" identity for merchant_id/template_id the way this rollup
+-- needs, since two rows both missing merchant_id for the same day/provider/
+-- reseller must still collide instead of accumulating duplicates.
+CREATE UNIQUE INDEX IF NOT EXISTS uq_tts_cache_daily ON tts_cache_daily
+    (date_ist, provider, reseller_id, COALESCE(merchant_id, ''), COALESCE(template_id, ''));
+
+CREATE INDEX IF NOT EXISTS idx_tts_cache_daily_date
+    ON tts_cache_daily (date_ist);

--- a/app/database/queries/breeze_buddy/tts_cache.py
+++ b/app/database/queries/breeze_buddy/tts_cache.py
@@ -1,0 +1,161 @@
+"""
+Database query functions for TTS-cache daily metrics (migration 036).
+
+This module contains ONLY query generation functions.
+Business logic should be in accessor/breeze_buddy/tts_cache.py
+"""
+
+from datetime import date
+from typing import Any, Dict, List, Optional, Tuple
+
+TTS_CACHE_DAILY_TABLE = "tts_cache_daily"
+
+# Maps a caller-facing `group_by` value to the dimension column to GROUP BY
+# alongside date_ist. None means "date only" -- no extra dimension column.
+_GROUP_BY_DIMENSION_COLUMN: Dict[str, Optional[str]] = {
+    "provider": "provider",
+    "merchant": "merchant_id",
+    "template": "template_id",
+    "date": None,
+}
+
+
+def upsert_tts_cache_daily_query(
+    date_ist: date,
+    provider: str,
+    reseller_id: str,
+    merchant_id: Optional[str],
+    template_id: Optional[str],
+    hit_requests: int,
+    miss_requests: int,
+    hit_words: int,
+    miss_words: int,
+) -> Tuple[str, List[Any]]:
+    """Generate an upsert query for one day's TTS-cache attribution row.
+
+    The incoming counters are ABSOLUTE day totals (the Redis source holds
+    full-day running totals, not deltas) so the ON CONFLICT arm overwrites
+    rather than increments. The conflict target mirrors the
+    `uq_tts_cache_daily` expression unique index exactly -- COALESCE on the
+    nullable merchant_id/template_id dimensions so two rows both missing one
+    of those still collide as the same logical bucket.
+    """
+    query = f"""
+        INSERT INTO {TTS_CACHE_DAILY_TABLE} (
+            date_ist, provider, reseller_id, merchant_id, template_id,
+            hit_requests, miss_requests, hit_words, miss_words, updated_at
+        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, NOW())
+        ON CONFLICT (date_ist, provider, reseller_id, COALESCE(merchant_id, ''), COALESCE(template_id, ''))
+        DO UPDATE SET
+            hit_requests = EXCLUDED.hit_requests,
+            miss_requests = EXCLUDED.miss_requests,
+            hit_words = EXCLUDED.hit_words,
+            miss_words = EXCLUDED.miss_words,
+            updated_at = NOW()
+        RETURNING id
+    """
+    values = [
+        date_ist,
+        provider,
+        reseller_id,
+        merchant_id,
+        template_id,
+        hit_requests,
+        miss_requests,
+        hit_words,
+        miss_words,
+    ]
+    return query, values
+
+
+def get_tts_cache_daily_query(filters: Dict[str, Any]) -> Tuple[str, List[Any]]:
+    """Generate a SELECT query for tts_cache_daily rows.
+
+    Supported filters:
+      - date_from / date_to: inclusive date_ist range
+      - reseller_ids: List[str], matched via = ANY(...)
+      - merchant_ids: List[str], matched via = ANY(...)
+      - template_id: exact match
+      - provider: scalar (exact match) or List[str] (= ANY(...))
+      - group_by: optional, one of "provider" | "merchant" | "template" |
+        "date". When present, returns an aggregate query that SUMs the four
+        counters and GROUPs BY date_ist plus the chosen dimension column
+        (no extra dimension column for "date").
+
+    Returns:
+        Tuple of (query, values). Ungrouped rows are ordered by
+        date_ist DESC, provider; grouped rows by date_ist DESC (then the
+        dimension column, if any).
+    """
+    conditions: List[str] = []
+    values: List[Any] = []
+
+    if filters.get("date_from"):
+        values.append(filters["date_from"])
+        conditions.append(f"date_ist >= ${len(values)}")
+
+    if filters.get("date_to"):
+        values.append(filters["date_to"])
+        conditions.append(f"date_ist <= ${len(values)}")
+
+    if filters.get("reseller_ids"):
+        values.append(filters["reseller_ids"])
+        conditions.append(f"reseller_id = ANY(${len(values)})")
+
+    if filters.get("merchant_ids"):
+        values.append(filters["merchant_ids"])
+        conditions.append(f"merchant_id = ANY(${len(values)})")
+
+    if filters.get("template_id"):
+        values.append(filters["template_id"])
+        conditions.append(f"template_id = ${len(values)}")
+
+    if filters.get("provider"):
+        provider = filters["provider"]
+        values.append(provider)
+        if isinstance(provider, list):
+            conditions.append(f"provider = ANY(${len(values)})")
+        else:
+            conditions.append(f"provider = ${len(values)}")
+
+    where_clause = " WHERE " + " AND ".join(conditions) if conditions else ""
+
+    group_by = filters.get("group_by")
+    if group_by not in _GROUP_BY_DIMENSION_COLUMN:
+        group_by = None
+
+    if group_by:
+        dimension_column = _GROUP_BY_DIMENSION_COLUMN[group_by]
+        if dimension_column is None:
+            select_columns = "date_ist"
+            group_columns = "date_ist"
+            order_clause = "ORDER BY date_ist DESC"
+        else:
+            select_columns = f"date_ist, {dimension_column}"
+            group_columns = f"date_ist, {dimension_column}"
+            order_clause = f"ORDER BY date_ist DESC, {dimension_column}"
+
+        query = f"""
+            SELECT
+                {select_columns},
+                SUM(hit_requests) as hit_requests,
+                SUM(miss_requests) as miss_requests,
+                SUM(hit_words) as hit_words,
+                SUM(miss_words) as miss_words
+            FROM {TTS_CACHE_DAILY_TABLE}
+            {where_clause}
+            GROUP BY {group_columns}
+            {order_clause}
+        """
+    else:
+        query = f"""
+            SELECT
+                id, date_ist, provider, reseller_id, merchant_id, template_id,
+                hit_requests, miss_requests, hit_words, miss_words,
+                created_at, updated_at
+            FROM {TTS_CACHE_DAILY_TABLE}
+            {where_clause}
+            ORDER BY date_ist DESC, provider
+        """
+
+    return query, values

--- a/app/main.py
+++ b/app/main.py
@@ -45,6 +45,7 @@ from app.core.config.static import (
     BB_RECONCILE_BACKLOG_INTERVAL_S,
     BB_RECONCILE_CHANNELS_INTERVAL_S,
     BB_RECONCILE_STUCK_PROCESSING_INTERVAL_S,
+    BB_TTSCACHE_ROLLUP_INTERVAL_S,
     BOT_MAX_DRAIN_SECONDS,
     CHAT_SESSION_END_TIMEOUT_LOOP_INTERVAL_SECONDS,
     CORS_ALLOWED_ORIGINS,
@@ -68,6 +69,7 @@ from app.services.redis import (
     get_redis_service,
     is_redis_configured,
 )
+from app.services.tts_cache_metrics.rollup import rollup_tts_cache_daily
 
 # Flag to indicate if pod is draining (no new connections accepted)
 _is_draining = False
@@ -148,6 +150,16 @@ async def lifespan(_app: FastAPI):
                 name="kb_ingestion",
                 func=process_pending_kb_documents,
                 interval_seconds=await KB_INGESTION_INTERVAL_SECONDS(),
+            )
+
+            # DragonTTS cache-attribution rollup: Redis day counters ->
+            # tts_cache_daily upserts (absolute totals, idempotent). Covers
+            # today + yesterday each tick, so the finished day finalizes
+            # shortly after IST midnight.
+            _background_scheduler.register_task(
+                name="bb_ttscache_rollup",
+                func=rollup_tts_cache_daily,
+                interval_seconds=BB_TTSCACHE_ROLLUP_INTERVAL_S,
             )
 
             # Event-driven dispatch reconcilers (Plane 5). Only registered on

--- a/app/schemas/breeze_buddy/analytics.py
+++ b/app/schemas/breeze_buddy/analytics.py
@@ -27,6 +27,7 @@ class AnalyticsType(str, Enum):
     ATTEMPTS_TO_CONNECT = "attempts-to-connect"
     CALLS_BY_HOUR = "calls-by-hour"
     CHATS_BY_HOUR = "chats-by-hour"
+    TTS_CACHE = "tts-cache"
 
 
 class TimeGranularity(str, Enum):

--- a/app/services/tts_cache_metrics/__init__.py
+++ b/app/services/tts_cache_metrics/__init__.py
@@ -1,0 +1,136 @@
+"""Redis day-counters for DragonTTS cache attribution.
+
+Per-call cache stats (built from DragonTTS ``X-Cache`` headers by
+``DragonTTSService``) are flushed here once at call end: four ``HINCRBY``s
+into one hash per IST day. The ``bb_ttscache_rollup`` background task reads
+these hashes and upserts absolute day totals into the ``tts_cache_daily``
+table, so a hash only needs to outlive the rollup cadence (TTL 3 days).
+
+Key:    ``ttscache:daily:{YYYY-MM-DD}`` (IST date)
+Field:  ``{nested_provider}|{reseller_id}|{merchant_id}|{template_id}|{metric}``
+        (``-`` when merchant/template is unknown)
+Value:  integer running total for the day.
+
+Everything here is stats-only and fail-open: a Redis hiccup must never affect
+a live call, so ``flush_call_cache_stats`` logs and swallows all errors.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple, cast
+from zoneinfo import ZoneInfo
+
+from app.core.logger import logger
+from app.services.redis import get_redis_service
+
+if TYPE_CHECKING:
+    from app.ai.voice.tts.dragontts import DragonTTSCacheStats
+
+IST = ZoneInfo("Asia/Kolkata")
+
+DAY_KEY_PREFIX = "ttscache:daily:"
+DAY_KEY_TTL_SECONDS = 3 * 24 * 3600
+
+# Metric name -> DragonTTSCacheStats attribute.
+_METRIC_ATTRS = {
+    "hit_req": "hit_requests",
+    "miss_req": "miss_requests",
+    "hit_words": "hit_words",
+    "miss_words": "miss_words",
+}
+
+# (provider, reseller_id, merchant_id, template_id) -> {metric: value}
+DayCounters = Dict[Tuple[str, str, Optional[str], Optional[str]], Dict[str, int]]
+
+
+def ist_date_str(now: Optional[datetime] = None) -> str:
+    """Current (or given) moment as an IST calendar date string."""
+    moment = now if now is not None else datetime.now(IST)
+    return moment.astimezone(IST).strftime("%Y-%m-%d")
+
+
+def day_key(date_str: str) -> str:
+    return f"{DAY_KEY_PREFIX}{date_str}"
+
+
+def _field(
+    provider: str,
+    reseller_id: str,
+    merchant_id: Optional[str],
+    template_id: Optional[str],
+    metric: str,
+) -> str:
+    return "|".join(
+        [provider, reseller_id, merchant_id or "-", template_id or "-", metric]
+    )
+
+
+async def flush_call_cache_stats(
+    stats: "DragonTTSCacheStats",
+    *,
+    reseller_id: str,
+    merchant_id: Optional[str],
+    template_id: Optional[str],
+) -> None:
+    """Fold one call's cache stats into today's IST day hash. Fail-open."""
+    if not stats.has_data:
+        return
+    try:
+        redis = await get_redis_service()
+        client: Any = cast(Any, await redis.get_client())
+        key = day_key(ist_date_str())
+        async with client.pipeline(transaction=False) as pipe:
+            for metric, attr in _METRIC_ATTRS.items():
+                value = getattr(stats, attr)
+                if value:
+                    pipe.hincrby(
+                        key,
+                        _field(
+                            stats.provider,
+                            reseller_id,
+                            merchant_id,
+                            template_id,
+                            metric,
+                        ),
+                        value,
+                    )
+            pipe.expire(key, DAY_KEY_TTL_SECONDS)
+            await pipe.execute()
+        logger.info(
+            f"TTS cache stats flushed: provider={stats.provider} "
+            f"hits={stats.hit_requests}/{stats.hit_words}w "
+            f"misses={stats.miss_requests}/{stats.miss_words}w"
+        )
+    except Exception as e:
+        logger.warning(f"TTS cache stats flush failed (ignored): {e}")
+
+
+async def read_day_counters(date_str: str) -> DayCounters:
+    """Read one day's hash into {(provider, reseller, merchant, template): counters}.
+
+    Malformed fields are skipped with a warning. ``-`` sentinels come back as
+    ``None`` so callers can store real NULLs. Raises on Redis errors — the
+    rollup task decides how to handle those.
+    """
+    redis = await get_redis_service()
+    client: Any = cast(Any, await redis.get_client())
+    raw: Dict[str, Any] = await client.hgetall(day_key(date_str))
+    counters: DayCounters = {}
+    for field_name, value in raw.items():
+        parts = field_name.split("|")
+        if len(parts) != 5 or parts[4] not in _METRIC_ATTRS:
+            logger.warning(f"Skipping malformed ttscache field: {field_name!r}")
+            continue
+        provider, reseller_id, merchant_id, template_id, metric = parts
+        combo = (
+            provider,
+            reseller_id,
+            None if merchant_id == "-" else merchant_id,
+            None if template_id == "-" else template_id,
+        )
+        try:
+            counters.setdefault(combo, {})[metric] = int(value)
+        except (TypeError, ValueError):
+            logger.warning(f"Skipping non-integer ttscache value: {field_name!r}")
+    return counters

--- a/app/services/tts_cache_metrics/rollup.py
+++ b/app/services/tts_cache_metrics/rollup.py
@@ -1,0 +1,52 @@
+"""Rollup: Redis TTS-cache day counters -> ``tts_cache_daily`` upserts.
+
+Registered as the ``bb_ttscache_rollup`` background task. The scheduler's
+distributed lock makes each tick single-pod. Every tick upserts today AND
+yesterday (IST): yesterday's re-upsert finalizes the finished day right after
+midnight and self-heals a missed tick — the upsert writes absolute day totals,
+so re-running is idempotent.
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timedelta
+
+from app.core.logger import logger
+from app.database.accessor.breeze_buddy.tts_cache import upsert_tts_cache_daily
+from app.services.tts_cache_metrics import IST, ist_date_str, read_day_counters
+
+
+async def rollup_tts_cache_daily() -> None:
+    """Upsert Redis day counters into ``tts_cache_daily`` for today + yesterday."""
+    now_ist = datetime.now(IST)
+    for date_str in (ist_date_str(now_ist), ist_date_str(now_ist - timedelta(days=1))):
+        try:
+            counters = await read_day_counters(date_str)
+        except Exception as e:
+            logger.error(f"ttscache rollup: reading {date_str} failed: {e}")
+            continue
+        if not counters:
+            continue
+        upserted = failed = 0
+        for (provider, reseller_id, merchant_id, template_id), m in counters.items():
+            try:
+                await upsert_tts_cache_daily(
+                    date_ist=date.fromisoformat(date_str),
+                    provider=provider,
+                    reseller_id=reseller_id,
+                    merchant_id=merchant_id,
+                    template_id=template_id,
+                    hit_requests=m.get("hit_req", 0),
+                    miss_requests=m.get("miss_req", 0),
+                    hit_words=m.get("hit_words", 0),
+                    miss_words=m.get("miss_words", 0),
+                )
+                upserted += 1
+            except Exception:
+                # Already logged (with context) by the accessor; keep going so
+                # one bad row can't block the rest of the day's combos.
+                failed += 1
+        logger.info(
+            f"ttscache rollup {date_str}: {upserted} rows upserted"
+            + (f", {failed} failed" if failed else "")
+        )

--- a/docs/TTS_CACHE_METRICS.md
+++ b/docs/TTS_CACHE_METRICS.md
@@ -1,0 +1,230 @@
+# TTS Cache Metrics (DragonTTS Attribution)
+
+**What this answers:** for every call, every day, every template — how many of the
+words the agent spoke were served from the DragonTTS cache (**HIT**) versus
+actually synthesized by the real TTS provider behind it (**MISS**)?
+
+Before this feature, DragonTTS knew its own global hit rate but nothing about
+*whose* traffic it was (no tenant identity reaches DragonTTS), and clairvoyance
+threw the per-sentence `X-Cache` response header away. Now the header is
+captured on the clairvoyance side, where `reseller_id` / `merchant_id` /
+`template_id` / `lead_id` are all known — giving per-call, per-turn, and
+per-day attribution **without any change to the DragonTTS repo**.
+
+---
+
+## 1. The signal: DragonTTS already tells us HIT or MISS
+
+The live pipeline sends TTS one **aggregated sentence at a time** to
+`POST /tts/stream`. Every response comes back stamped by DragonTTS:
+
+```text
+POST /tts/stream   {"transcript": "Your order will arrive tomorrow.", ...}
+← 200 OK
+  X-Cache: HIT            ← served from cache; the real provider did nothing
+  <audio chunks>
+
+POST /tts/stream   {"transcript": "Hi Ramesh, calling about order 4821.", ...}
+← 200 OK
+  X-Cache: MISS           ← Cartesia/ElevenLabs/... actually synthesized this
+  <audio chunks>
+```
+
+Notes on semantics:
+
+- **All-or-nothing per sentence.** DragonTTS's partial "stitch" paths
+  (`MISS-STITCH`) are disabled/retired in config — a sentence is either fully
+  cached or fully synthesized. A *turn* can still mix, because one turn is
+  several sentences.
+- **Single-flight coalescing:** if two calls request the same uncached
+  sentence simultaneously, DragonTTS synthesizes once; the trigger gets
+  `MISS`, the waiter gets `HIT`. So our MISS counts measure *real provider
+  work* (and reconcile with DragonTTS's own `/stats/daily`).
+- Any non-HIT status is counted as a miss.
+
+## 2. End-to-end architecture
+
+```mermaid
+flowchart LR
+    subgraph CALL["During the call (per sentence)"]
+        A[DragonTTSService.run_tts] -->|POST /tts/stream| D[(DragonTTS)]
+        D -->|"X-Cache: HIT/MISS + audio"| A
+        A -->|count words per header,<br/>group by turn| S[DragonTTSCacheStats<br/>in-memory, per call]
+    end
+
+    subgraph END["At call end (once)"]
+        S --> M["lead_call_tracker.meta_data.tts_cache<br/>(per-call + per-turn record)"]
+        S -->|4x HINCRBY| R[("Redis hash<br/>ttscache:daily:{IST-date}<br/>TTL 3 days")]
+    end
+
+    subgraph ROLLUP["Every 15 min (one pod via distributed lock)"]
+        R -->|HGETALL, absolute totals| T[("Postgres<br/>tts_cache_daily<br/>kept forever")]
+    end
+
+    subgraph READ["Dashboards"]
+        T --> API["POST /analytics type=tts-cache<br/>(RBAC: admin / reseller / merchant)"]
+        M --> DRILL["Per-call drilldown<br/>(turns beside transcription)"]
+    end
+```
+
+Division of labor: **Redis is the counter, Postgres is the record.** Postgres
+is bad at hot counters (row locks + MVCC dead tuples on every increment);
+Redis `HINCRBY` is an atomic, lock-free, in-place increment. So ~200k tiny
+per-call increments/day are absorbed by Redis, and Postgres receives ~96 clean
+upserts per combo per day from a single writer (the rollup task).
+
+## 3. Life of one call
+
+```mermaid
+sequenceDiagram
+    participant P as Pipecat pipeline
+    participant TTS as DragonTTSService
+    participant DT as DragonTTS
+    participant AG as Agent (call end)
+    participant RD as Redis
+    participant PG as Postgres
+
+    loop each aggregated sentence
+        P->>TTS: run_tts(text, context_id)
+        TTS->>DT: POST /tts/stream
+        DT-->>TTS: X-Cache: HIT|MISS + audio
+        TTS->>TTS: cache_stats.record(words, status, turn=context_id)
+    end
+    Note over TTS: zero I/O added to the audio path —<br/>counters live in memory on the service
+
+    P-->>AG: generation loop ends (true call end)
+    AG->>PG: append_metadata_field(lead_id, {tts_cache: totals + turns})
+    AG->>RD: pipeline: HINCRBY x4 + EXPIRE (fail-open)
+
+    loop every 15 min, today + yesterday
+        RD-->>PG: rollup: HGETALL → upsert absolute day totals
+    end
+```
+
+## 4. What is stored where
+
+### 4.1 Redis — one hash per IST day (TTL 3 days)
+
+A Redis **hash** is a dictionary stored under one key. The **field name
+encodes the dimensions** (pipe-delimited, `-` for unknown), the **value is the
+running count**:
+
+```text
+KEY   ttscache:daily:2026-07-18
+FIELD {provider}|{reseller_id}|{merchant_id}|{template_id}|{metric}
+
+  cartesia|res_a|merchant_12|tmpl-9f3e|hit_req      9421   sentences from cache
+  cartesia|res_a|merchant_12|tmpl-9f3e|miss_req     1310   sentences synthesized
+  cartesia|res_a|merchant_12|tmpl-9f3e|hit_words   71204   words from cache
+  cartesia|res_a|merchant_12|tmpl-9f3e|miss_words   9876   words the provider generated
+```
+
+- `provider` is the **nested** provider behind DragonTTS (`cartesia`,
+  `elevenlabs`, `sarvam`, `gemini`) — the whole point is seeing through the
+  proxy.
+- Written once per call (4 `HINCRBY`s in one pipeline), not per sentence.
+- Size does not grow with call volume — only with distinct
+  provider × reseller × merchant × template combos (a few hundred fields).
+- TTL 3 days = safety margin only; once the rollup has copied a day into
+  Postgres, the Redis copy is scratch.
+
+### 4.2 Postgres — per-call record (existing `meta_data` JSONB, no new table)
+
+Merged into `lead_call_tracker.meta_data` under `tts_cache` at call end,
+next to `transcription` — lay the two side by side for per-turn attribution:
+
+```json
+{
+  "provider": "cartesia",
+  "model": "sonic-3.5",
+  "hit_requests": 9,  "miss_requests": 3,
+  "hit_words": 74,    "miss_words": 21,
+  "cache_word_ratio": 0.779,
+  "turns": [
+    {"turn": 1, "hits": 2, "misses": 0, "hit_words": 15, "miss_words": 0},
+    {"turn": 2, "hits": 3, "misses": 1, "hit_words": 28, "miss_words": 7},
+    {"turn": 3, "hits": 4, "misses": 2, "hit_words": 31, "miss_words": 14}
+  ]
+}
+```
+
+(Turn = the set of sentences sharing one pipecat `context_id`; capped at 200
+turns per call. Rare agent-transfer calls with a rebuilt TTS store combined
+totals plus a `generations` list.)
+
+### 4.3 Postgres — `tts_cache_daily` (migration `036`, kept forever)
+
+One row per `(date_ist, provider, reseller_id, merchant_id, template_id)`;
+~one row per active template per day. Counters are **absolute day totals**
+(overwritten, never incremented, so rollup re-runs are idempotent):
+
+| date_ist | provider | reseller_id | merchant_id | template_id | hit_requests | miss_requests | hit_words | miss_words |
+|---|---|---|---|---|---|---|---|---|
+| 2026-07-17 | cartesia | res_a | merchant_12 | tmpl-9f3e | 9421 | 1310 | 71204 | 9876 |
+| 2026-07-17 | elevenlabs | res_a | merchant_45 | tmpl-77aa | 2210 | 840 | 16780 | 6540 |
+
+Hit rates are computed at read time: word cache ratio for row 1 =
+71204 / (71204 + 9876) = **87.8%** — i.e. Cartesia only synthesized ~12% of
+what that template spoke that day. Weekly = SUM over 7 days of rows. The
+upsert's `ON CONFLICT` target matches the `COALESCE` expression unique index
+so NULL merchant/template collapse into one bucket instead of duplicating.
+
+## 5. API
+
+`POST /analytics` with `{"type": "tts-cache", "filters": {...}, "options": {...}}`.
+
+- Filters: `date_from` / `date_to` (IST dates), `reseller_id(s)`,
+  `merchant_id(s)`, `template_id`, `provider`.
+- `options.group_by`: `provider` | `merchant` | `template` | `date`.
+  Grouping by **template** answers "how much is caching working per template"
+  — it directly shows where `{variable}` personalization is defeating the
+  cache.
+- Response: `results` rows (each with derived `request_hit_rate` and
+  `word_cache_ratio`) plus an overall `summary`.
+- RBAC comes from the standard `apply_hierarchical_filters` flow: admin sees
+  all, reseller sees their merchants, merchant sees themselves. The handler
+  normalizes the singular `reseller_id`/`merchant_id` filter forms into the
+  plural keys the query filters on (the singular form deliberately wins when
+  both are sent, since RBAC validates only the singular in that case).
+
+## 6. Failure behavior (deliberate trade-offs)
+
+| Event | Effect |
+|---|---|
+| Redis hiccup during a call's flush | That one call's counters are dropped, logged, call unaffected (everything is fail-open; nothing in the audio/teardown path can raise) |
+| Agent pod killed mid-call (deploy) | That call never reaches its end-of-call flush → its counts are missing. Stats-only trade-off; graceful SIGTERM drains flush normally |
+| App deployment / pod rolling | No effect on counters — pods hold zero counter state; Redis and Postgres live outside the deployment |
+| Rollup tick missed (pods cycling) | Nothing lost — counters keep accumulating; next tick upserts the same running totals (absolute + idempotent) |
+| Redis down briefly | Lose the not-yet-rolled-up increments (≤15 min worth) plus the full stats of any call whose end-of-call flush happened during the outage (flushes are fail-open, not retried) |
+| Redis fully wiped mid-day | Day restarts from 0; next rollup would overwrite the DB row downward (known edge; hardening option: `GREATEST(existing, EXCLUDED.x)` in the upsert, valid because within-day counters only grow) |
+
+## 7. Code map
+
+| Piece | Location |
+|---|---|
+| Header capture + per-call stats | `app/ai/voice/tts/dragontts.py` (`DragonTTSCacheStats`, `run_tts`) |
+| Call-end flush (meta_data + Redis) | `app/ai/voice/agents/breeze_buddy/agent/__init__.py` (`_flush_tts_cache_stats`) |
+| Redis day counters | `app/services/tts_cache_metrics/__init__.py` |
+| Rollup task (`bb_ttscache_rollup`, 900s) | `app/services/tts_cache_metrics/rollup.py`, registered in `app/main.py` |
+| Table + three-layer DB | `app/database/migrations/036_create_tts_cache_daily.sql`, `app/database/{queries,accessor,decoder}/breeze_buddy/tts_cache.py` |
+| Analytics type `tts_cache` | `app/schemas/breeze_buddy/analytics.py`, `app/api/routers/breeze_buddy/analytics/{handlers.py,__init__.py}` |
+
+## 8. Verifying on an environment
+
+1. Apply migration 036; deploy.
+2. Make a playground call on a DragonTTS template.
+3. `lead_call_tracker.meta_data -> 'tts_cache'` shows totals + turns.
+4. `redis-cli HGETALL ttscache:daily:$(TZ=Asia/Kolkata date +%F)` shows
+   incremented fields (keys are IST-dated).
+5. After a rollup tick (≤15 min): row appears in `tts_cache_daily`.
+6. `POST /analytics {"type": "tts-cache"}` as admin and as a scoped reseller
+   token — scoped results must differ.
+
+## 9. Out of scope (deliberately)
+
+- The one-shot `/tts/bytes` path (`_generate_dragontts_audio`, greetings) is
+  not counted — only the live streaming conversation.
+- Non-DragonTTS templates (direct ElevenLabs/Cartesia/...) have no cache and
+  write nothing here.
+- DragonTTS's own `/stats/daily` remains the admin-side global cross-check;
+  our per-tenant numbers should reconcile with it.


### PR DESCRIPTION
Capture the X-Cache header per sentence in DragonTTSService and attribute cached vs synthesized words per call/turn (lead meta_data.tts_cache), accumulate day counters in Redis (ttscache:daily:{IST-date}, TTL 3d), and roll them up every 15 min into tts_cache_daily (migration 036) via the bb_ttscache_rollup task. Expose analytics type "tts_cache" with RBAC scoping and provider/merchant/template/date grouping. Docs in docs/TTS_CACHE_METRICS.md.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added DragonTTS cache tracking for call-level hit/miss requests and synthesized words.
  * Added daily cache metrics storage and automated rollups.
  * Added TTS cache analytics with filtering, grouping, summaries, and hit-rate metrics.
  * Added cache attribution details to call metadata.

* **Documentation**
  * Added documentation covering cache attribution, reporting, storage, and API usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->