### PR TITLE
fix(ci): cap Yama ai.maxTokens to 16000 so large PRs fit the model window

### DIFF
--- a/yama.config.yaml
+++ b/yama.config.yaml
@@ -31,6 +31,16 @@ display:
 ai:
   # provider/model OMITTED on purpose — controlled by the workflow.
   temperature: 0.2 # deterministic, review-grade output
+  # Cap review-generation OUTPUT tokens. @juspay/yama's default ai.maxTokens is
+  # 128000 (DefaultConfig.ts); on the private-large model (262144 ctx) that
+  # leaves only ~134K for INPUT, so medium/large PRs (diff + explored context +
+  # project rules) exceed the window and the LiteLLM call never returns — every
+  # generate dies on the client-side timeout and the review fails with no
+  # verdict. A review never emits anywhere near 128K output tokens, so cap it
+  # at 16000 — this raises the usable input ceiling to ~246K and lets large
+  # diffs be reviewed. Same fix as juspay/neurolink@31181493. (The explore
+  # worker defaults to 32000, which is unaffected.)
+  maxTokens: 16000
   timeout: "15m"
   retryAttempts: 3
 


### PR DESCRIPTION
## What

Adds `ai.maxTokens: 16000` to `yama.config.yaml` — the same fix `juspay/neurolink` shipped in [`31181493`](https://github.com/juspay/neurolink/commit/31181493) ("fix(ci): cap Yama ai.maxTokens to 16000 so large PRs fit the model window") and `juspay/dopamine` inherited when its workflows were aligned with neurolink.

## Why — root cause of the Yama review outage on large PRs

Yama's default `ai.maxTokens` is **128000** (`DefaultConfig.ts`). On the `private-large` model (262144-token context) that reserves nearly half the window for output, leaving only ~134K for **input**. A medium/large PR (diff + explored context + project rules) exceeds that budget, the LiteLLM call for the main code-review generate never returns, and every attempt dies on neurolink's 30s client-side timeout — so the run ends with **no verdict** and the required check fails as an infrastructure error.

Evidence from [run 29732876602](https://github.com/juspay/clairvoyance/actions/runs/29732876602) (PR #922, 18m42s, failed):

- Small explore calls intermittently succeed; the main `code-review generate` fails **all 3 attempts** with `litellm generate operation timed out after 30000`.
- Small clairvoyance PRs pass with the identical workflow/model — only large PRs fail, exactly matching an input-budget overflow rather than a flat provider outage.
- A successful neurolink Yama run from today ([run 29738068272](https://github.com/juspay/neurolink/actions/runs/29738068272)) on the same LiteLLM proxy + `private-large` + same 30s client timeout shows **zero** timeout errors and returns a verdict — the `maxTokens` cap is the operative difference.

A review never emits anywhere near 128K output tokens; capping at 16000 raises the usable input ceiling to ~246K so large diffs fit. The explore worker's own default (32000) is unaffected.

## Note

`juspay/neurolink#1216` (litellm entry in `DEFAULT_TIMEOUTS.providers`, merged today) lengthens the client timeout in future neurolink releases, but does not address this failure mode: an over-window request doesn't complete no matter how long the client waits. This config cap is the fix that works with the currently pinned `juspay/yama@v2.7.1` → `@juspay/neurolink@9.70.7`.

## Verification

After merge, re-trigger Yama on PR #922 (close/reopen or push) so its checkout picks up the capped config from `release`.
