### PR TITLE
fix(ci): pin Yama action to v2.6.0 so litellm reviews honor the 15m timeout

### DIFF
--- a/.github/workflows/yama-review.yml
+++ b/.github/workflows/yama-review.yml
@@ -82,7 +82,18 @@ jobs:
         continue-on-error: true
         # External consumer → published action. For strict supply-chain
         # immutability pin the full commit SHA behind this ref.
-        uses: juspay/yama@v2.7.1
+        #
+        # Pinned to v2.6.0, NOT v2.7.x: v2.7.x bundles @juspay/neurolink 9.70.7,
+        # which drops the configured ai.timeout ("15m") on the litellm generate
+        # path — every call falls back to the 30s global default, and
+        # review-sized generations on private-large need longer than that, so
+        # large-PR reviews always fail with "timed out after 30000" and no
+        # verdict. v2.6.0 bundles neurolink 9.42.0, which propagates the
+        # timeout correctly — the same pin juspay/neurolink and juspay/dopamine
+        # use (their Yama runs pass on the same LiteLLM proxy + model). Only
+        # bump past v2.6.0 once a yama release bundles a neurolink that honors
+        # ai.timeout for litellm (or ships juspay/neurolink#1216's 5m default).
+        uses: juspay/yama@v2.6.0
         with:
           github-token: ${{ secrets.YAMA_GITHUB_TOKEN }}
           ai-provider: litellm


### PR DESCRIPTION
## What

Pins the Yama review action to `juspay/yama@v2.6.0` (from `v2.7.1`) as an **interim stopgap** until a yama release bundles `@juspay/neurolink` ≥ 10.1.1.

## Why — root cause, proven by instrumented reproduction

Yama reviews on large PRs (e.g. #922) fail with no verdict: every litellm generate dies with `litellm generate operation timed out after 30000` (runs [29732876602](https://github.com/juspay/clairvoyance/actions/runs/29732876602), [29751988538](https://github.com/juspay/clairvoyance/actions/runs/29751988538) — the latter with #927's `maxTokens` cap already in effect, ruling out the context-window theory).

Reproduced locally by building yama v2.7.1 from source, instrumenting it and its bundled `@juspay/neurolink@9.70.7` with probes, and running the CLI dry-run against PR #922. The configured timeout survives **every** yama and neurolink hop — `config.ai.timeout="15m"` / explore `"5m"` → `neurolink.generate` → `generateTextInternal` → `tryMCPGeneration` → `BaseProvider.generate` all show `"5m"` — and then arrives as `undefined` at the provider's timeout resolution. The captured stack pins the drop:

```
Utilities.getTimeout (options.timeout=undefined)
  ← LiteLLMProvider.getTimeout
  ← getTimeoutForOptions   (openaiChatCompletionsBase.ts:326 — `this.getTimeout((opts ?? {}) as never)`)
  ← Object.doGenerate      (openaiChatCompletionsBase.ts:394)
  ← ai@6 (AI SDK)
```

The litellm HTTP timeout is resolved inside the AI SDK's `doGenerate`, whose call options **cannot carry the caller's `timeout`**. It therefore always falls back to `DEFAULT_TIMEOUTS` — and 9.70.7 has no `litellm` entry, so the 30s global default applies to every call. Review-sized generations on `private-large` need longer than 30s → guaranteed failure, immune to any yama/workflow/config setting.

## Why v2.6.0 works

v2.6.0 bundles `@juspay/neurolink@9.42.0`, whose litellm path resolves the timeout from the caller's options (the configured 15m goes through). `juspay/neurolink` and `juspay/dopamine` pin v2.6.0 and review cleanly on the same LiteLLM proxy + `private-large` (e.g. neurolink [run 29738068272](https://github.com/juspay/neurolink/actions/runs/29738068272): zero timeout errors, verdict returned).

## Exit plan (this pin is temporary)

`@juspay/neurolink@10.1.1+` (released 2026-07-20) ships `litellm: "5m"` in `DEFAULT_TIMEOUTS.providers` (juspay/neurolink#1216), which raises exactly the resolution point identified above. A yama dependency-bump PR to neurolink 10.1.2 is in flight; once yama cuts a release with it, this pin is bumped **forward** to that tag and the downgrade is reverted.

## Verification

After merge, re-trigger Yama on PR #922 (close/reopen) — the run should complete with a verdict.
