### PR TITLE
fix(format): black/isort dragontts.py so PR Build Check passes on merge commits

### DIFF
--- a/app/api/routers/breeze_buddy/dragontts.py
+++ b/app/api/routers/breeze_buddy/dragontts.py
@@ -22,9 +22,9 @@ from app.core.security.authorization import require_admin
 from app.schemas import UserInfo
 from app.schemas.breeze_buddy.dragontts import (
     DragonTTSStatus,
-    ManageDragonTTSResponse,
     ManageDragonTTSAction,
     ManageDragonTTSRequest,
+    ManageDragonTTSResponse,
 )
 
 router = APIRouter()
@@ -34,7 +34,7 @@ router = APIRouter()
 async def manage_dragon_tts(
     body: ManageDragonTTSRequest,
     current_user: UserInfo = Depends(get_current_user_with_rbac),
-    ) -> ManageDragonTTSResponse:
+) -> ManageDragonTTSResponse:
     """Manage the DragonTTS health flag: ``kill_switch`` -> bypass caching,
     ``restore`` -> resume caching."""
     require_admin(current_user)


### PR DESCRIPTION
## What

Runs black + isort on `app/api/routers/breeze_buddy/dragontts.py` (2-line mechanical diff: import order + one closing-paren indent).

## Why

Commit `2013061` (`(feat): add kill switch for dragon tts`) landed on `release` with this file unformatted — it fails both `black --check` and `isort --check-only`. Since **PR Build Check** runs those checks on the PR *merge commit*, every open PR that includes this commit in its merge base now fails CI through no fault of its own (first observed on #922 after a rebase: [run 29760251813](https://github.com/juspay/clairvoyance/actions/runs/29760251813) — `would reformat .../dragontts.py`).

## Verification

On this branch: `black --check .`, `isort . --profile black --check-only`, `autoflake --check`, and `pyrefly check` all pass repo-wide.

After merge, affected PRs need a rebase or close/reopen so their merge commit picks this up.
