### PR TITLE
feat(auth): add /auth/launch-token for Nautilus dashboard handoff

### DIFF
--- a/app/api/routers/breeze_buddy/auth/__init__.py
+++ b/app/api/routers/breeze_buddy/auth/__init__.py
@@ -18,6 +18,8 @@ from fastapi.responses import RedirectResponse
 
 from app.api.security.breeze_buddy.rbac_token import get_current_user_with_rbac
 from app.schemas import (
+    LaunchTokenRequest,
+    LaunchTokenResponse,
     LoginRequest,
     S2STokenRequest,
     S2STokenResponse,
@@ -28,6 +30,7 @@ from app.schemas import (
 from .handlers import (
     generate_s2s_token_handler,
     get_user_info_handler,
+    launch_token_handler,
     login_handler,
     logout_handler,
 )
@@ -112,6 +115,55 @@ async def generate_s2s_token(request: S2STokenRequest):
         - Returns 403 if user is not an admin
     """
     return await generate_s2s_token_handler(request)
+
+
+@router.post("/auth/launch-token", response_model=LaunchTokenResponse)
+async def launch_token(
+    request: LaunchTokenRequest,
+    current_user: UserInfo = Depends(get_current_user_with_rbac),
+):
+    """
+    Mint a 1-hour merchant-scoped session JWT to launch the Loom dashboard.
+
+    Used by the Nautilus/Buddy Assist connector: a merchant clicks "Open
+    Dashboard" in the Shopify admin, Nautilus verifies the Shopify session,
+    then calls this endpoint to obtain a signed-in Loom launch URL.
+
+    **RBAC rules:**
+    - Admin: Can mint a launch token for any reseller/merchant.
+    - Reseller: Can only mint for a reseller_id within their own scope.
+    - Merchant/User tokens: Forbidden — this endpoint impersonates a
+      merchant session and must not be self-servable.
+
+    Request Body:
+        {
+            "reseller_id": "BB_ASSIST",
+            "merchant_id": "assist-example.myshopify.com",
+            "source": "nautilus",
+            "redirect": "/home"
+        }
+
+    Returns:
+        {
+            "access_token": "eyJ...",
+            "token_type": "Bearer",
+            "expires_in": 3600,
+            "launch_url": "https://<LOOM_APP_URL>/launch?token=...&redirect=%2Fhome"
+        }
+
+    Security:
+        - Returns 401 if the caller's token is invalid or expired.
+        - Returns 403 if the caller lacks scope over reseller_id.
+        - Returns 404 if the merchant doesn't exist, is inactive, or does not
+          belong to reseller_id (never distinguishes which, to avoid leaking
+          tenant existence).
+        - Returns 400 if source is unknown, or redirect is present but not a
+          safe relative path.
+        - Every mint is audit-logged with the caller id, reseller_id, and
+          merchant_id — this endpoint is impersonation by design and is
+          bounded by RBAC scope plus this log trail.
+    """
+    return await launch_token_handler(request, current_user)
 
 
 @router.get("/auth/me", response_model=UserInfo)

--- a/app/api/routers/breeze_buddy/auth/handlers.py
+++ b/app/api/routers/breeze_buddy/auth/handlers.py
@@ -8,19 +8,25 @@ This module contains the business logic for authentication operations:
 - Logout handling
 """
 
+import re
 from datetime import datetime, timedelta, timezone
+from urllib.parse import quote
 
 from fastapi import HTTPException, status
 
 from app.api.security.breeze_buddy.rbac_token import rbac_token_manager
 from app.core.config.static import (
     JWT_ACCESS_TOKEN_EXPIRE_MINUTES,
+    LOOM_APP_URL,
 )
 from app.core.logger import logger
 from app.core.security.password import verify_password
 from app.core.security.scope import resolve_merchant_ids, resolve_reseller_ids
+from app.database.accessor.breeze_buddy import merchants as merchant_accessors
 from app.database.accessor.breeze_buddy.users import get_user_by_username
 from app.schemas import (
+    LaunchTokenRequest,
+    LaunchTokenResponse,
     LoginRequest,
     S2STokenRequest,
     S2STokenResponse,
@@ -28,6 +34,24 @@ from app.schemas import (
     UserInfo,
     UserRole,
 )
+
+# Relative-path guard for the `redirect` param: strict allowlist rather than
+# a denylist. Must start with a single leading slash (not `//`), and contain
+# only a restricted character set. This intentionally rejects backslashes,
+# so WHATWG-URL-parser tricks like "/\evil.com" (which browsers normalize to
+# the protocol-relative "//evil.com" for special-scheme URLs) never validate.
+# Must match the equivalent guard in loom-v2 — the two services validate
+# independently and must not diverge.
+_REDIRECT_PATTERN = re.compile(r"^/(?!/)[A-Za-z0-9._~/-]*$")
+_REDIRECT_MAX_LENGTH = 512
+
+DEFAULT_LAUNCH_REDIRECT = "/home"
+
+# Upstream products allowed to mint a Loom launch token. The value is stamped
+# into the token's signed `src` claim (so it cannot be tampered with) and Loom
+# gates sign-in on it. Adding a new integration (e.g. euler, lighthouse) is a
+# one-line change here — Loom must separately enable it on its accept side.
+KNOWN_LAUNCH_SOURCES = frozenset({"nautilus"})
 
 
 async def login_handler(
@@ -276,6 +300,125 @@ async def get_user_info_handler(current_user: UserInfo) -> UserInfo:
         f"User info request from {current_user.username} (role: {current_user.role})"
     )
     return current_user
+
+
+async def _check_launch_token_access(current_user: UserInfo, reseller_id: str) -> None:
+    """Gate access to launch-token minting.
+
+    - Admin: can mint for any reseller/merchant.
+    - Reseller: can only mint for a reseller_id within their own resolved scope
+      (mirrors the owning-reseller check used for merchant create/update).
+    - Anyone else: forbidden — this endpoint impersonates a merchant session
+      and must not be reachable by merchant/user-role tokens.
+    """
+    if current_user.role == UserRole.ADMIN:
+        return
+
+    if current_user.role != UserRole.RESELLER:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Only admins and resellers can mint launch tokens",
+        )
+
+    allowed_reseller_ids = await resolve_reseller_ids(current_user)
+    if allowed_reseller_ids is not None and reseller_id not in allowed_reseller_ids:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="You can only mint launch tokens for resellers you own",
+        )
+
+
+async def launch_token_handler(
+    request: LaunchTokenRequest, current_user: UserInfo
+) -> LaunchTokenResponse:
+    """
+    Mint a 1-hour merchant-scoped Loom session JWT for the Nautilus connector.
+
+    Verifies the caller (admin or owning reseller) has scope over the
+    requested reseller, that the merchant exists/is active/belongs to that
+    reseller, then mints a virtual-subject merchant token
+    (``sub=f"merchant:{merchant_id}"``, no real ``users`` row) with a signed
+    ``src`` claim (the requesting product) that Loom gates sign-in on.
+
+    Args:
+        request: reseller_id, merchant_id, source, and optional redirect path
+        current_user: Authenticated caller (admin or reseller)
+
+    Returns:
+        LaunchTokenResponse with access_token, expires_in, and launch_url
+
+    Raises:
+        HTTPException: 403 if caller lacks scope for the reseller
+        HTTPException: 404 if merchant doesn't exist / is inactive / belongs
+            to a different reseller
+        HTTPException: 400 if source is unknown, or redirect is present but not
+            a safe relative path
+    """
+    if request.source not in KNOWN_LAUNCH_SOURCES:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Unknown launch source: {request.source!r}",
+        )
+
+    await _check_launch_token_access(current_user, request.reseller_id)
+
+    merchant = await merchant_accessors.get_merchant_by_merchant_identifier(
+        request.merchant_id
+    )
+    if (
+        not merchant
+        or not merchant.is_active
+        or merchant.reseller_id != request.reseller_id
+    ):
+        raise HTTPException(status_code=404, detail="Merchant not found")
+
+    redirect = (
+        request.redirect if request.redirect is not None else DEFAULT_LAUNCH_REDIRECT
+    )
+    if len(redirect) > _REDIRECT_MAX_LENGTH or not _REDIRECT_PATTERN.match(redirect):
+        raise HTTPException(
+            status_code=400,
+            detail="Invalid redirect: must be a relative path (e.g. /home)",
+        )
+
+    access_token = rbac_token_manager.create_access_token_with_rbac(
+        user_id=f"merchant:{request.merchant_id}",
+        username=f"merchant-{request.merchant_id}",
+        role=UserRole.MERCHANT,
+        reseller_ids=[request.reseller_id],
+        merchant_ids=[request.merchant_id],
+        owner_id=current_user.id,
+        src=request.source,
+        # Pin the impersonation window to a fixed 60 minutes rather than
+        # inheriting JWT_ACCESS_TOKEN_EXPIRE_MINUTES: this token grants a live
+        # merchant session, so its TTL must not silently drift if the shared
+        # login-session config is later retuned.
+        expires_delta=timedelta(minutes=60),
+    )
+
+    expires_in = 60 * 60  # fixed 60-minute window, decoupled from login config
+
+    launch_url = (
+        f"{LOOM_APP_URL.rstrip('/')}/launch"
+        f"?token={quote(access_token, safe='')}"
+        f"&redirect={quote(redirect, safe='')}"
+    )
+
+    # Mandatory audit log: launch-token minting is impersonation by design
+    # (an admin/reseller-token holder mints a live merchant session), so every
+    # mint must be attributable to the caller who requested it.
+    logger.info(
+        f"Launch token minted by caller={current_user.id} "
+        f"({current_user.username}, role={current_user.role}) "
+        f"for reseller_id={request.reseller_id} merchant_id={request.merchant_id}"
+    )
+
+    return LaunchTokenResponse(
+        access_token=access_token,
+        token_type="Bearer",
+        expires_in=expires_in,
+        launch_url=launch_url,
+    )
 
 
 async def logout_handler() -> dict:

--- a/app/api/security/breeze_buddy/rbac_token.py
+++ b/app/api/security/breeze_buddy/rbac_token.py
@@ -34,6 +34,7 @@ class BreezeBuddyRBACTokenManager:
         email: Optional[str] = None,
         owner_id: Optional[str] = None,
         expires_delta: Optional[timedelta] = None,
+        src: Optional[str] = None,
     ) -> str:
         """
         Create a JWT access token with Breeze Buddy RBAC information.
@@ -46,6 +47,8 @@ class BreezeBuddyRBACTokenManager:
             merchant_ids: List of accessible merchant identifiers (["*"] for all merchants under the reseller(s))
             email: User's email (optional)
             expires_delta: Optional custom expiration time
+            src: Optional provenance marker recorded on the token (e.g.
+                "nautilus" for Shopify-admin launch tokens)
 
         Returns:
             Encoded JWT token string with RBAC data
@@ -64,6 +67,9 @@ class BreezeBuddyRBACTokenManager:
             "permissions": permissions,
             "owner_id": owner_id,
         }
+
+        if src:
+            payload["src"] = src
 
         # Use the generic JWT manager to create the token
         return self.jwt_manager.create_access_token(payload, expires_delta)

--- a/app/core/config/static.py
+++ b/app/core/config/static.py
@@ -189,6 +189,9 @@ SONIOX_MAX_ENDPOINT_DELAY_MS = int(
 LIGHTHOUSE_APP_URL = os.environ.get("LIGHTHOUSE_APP_URL", "http://localhost:5173")
 
 
+LOOM_APP_URL = os.environ.get("LOOM_APP_URL", "https://breezebuddy.ai")
+
+
 AZURE_BREEZE_BUDDY_OPENAI_MODEL = os.environ.get(
     "AZURE_BREEZE_BUDDY_OPENAI_MODEL", "gpt-4o-automatic"
 )

--- a/app/schemas/__init__.py
+++ b/app/schemas/__init__.py
@@ -27,6 +27,8 @@ from app.schemas.breeze_buddy.analytics import (
 # Re-export commonly used schemas for backward compatibility
 from app.schemas.breeze_buddy.auth import (
     AuthTokenData,
+    LaunchTokenRequest,
+    LaunchTokenResponse,
     LoginRequest,
     LoginResponse,
     Permission,
@@ -90,6 +92,8 @@ from app.schemas.feature_flags import (
 __all__ = [
     # Auth
     "AuthTokenData",
+    "LaunchTokenRequest",
+    "LaunchTokenResponse",
     "LoginRequest",
     "LoginResponse",
     "Permission",

--- a/app/schemas/breeze_buddy/__init__.py
+++ b/app/schemas/breeze_buddy/__init__.py
@@ -15,6 +15,8 @@ from app.schemas.breeze_buddy.analytics import (
 )
 from app.schemas.breeze_buddy.auth import (
     AuthTokenData,
+    LaunchTokenRequest,
+    LaunchTokenResponse,
     LoginRequest,
     LoginResponse,
     Permission,
@@ -62,6 +64,8 @@ from app.schemas.breeze_buddy.users import (
 __all__ = [
     # Auth
     "AuthTokenData",
+    "LaunchTokenRequest",
+    "LaunchTokenResponse",
     "LoginRequest",
     "LoginResponse",
     "Permission",

--- a/app/schemas/breeze_buddy/auth.py
+++ b/app/schemas/breeze_buddy/auth.py
@@ -183,6 +183,42 @@ class User(BaseModel):
     updated_at: Optional[datetime] = None
 
 
+class LaunchTokenRequest(BaseModel):
+    """Request to mint a short-lived merchant-scoped Loom launch token.
+
+    Used by trusted callers (e.g. Nautilus/Buddy Assist) to hand a merchant
+    a signed-in Loom session without provisioning a real ``users`` row.
+    """
+
+    reseller_id: str = Field(..., description="Reseller that owns the merchant")
+    merchant_id: str = Field(..., description="Merchant to mint a session for")
+    source: str = Field(
+        ...,
+        description=(
+            "Requesting product (e.g. 'nautilus'). Stamped into the token's "
+            "signed 'src' claim and gated by Loom on sign-in. Must be a known "
+            "launch source."
+        ),
+    )
+    redirect: Optional[str] = Field(
+        None,
+        description=(
+            "Relative path Loom should land on after sign-in. Must start with a "
+            "single '/' and contain only [A-Za-z0-9._~/-] (relative, not "
+            "protocol-relative). Defaults to /home."
+        ),
+    )
+
+
+class LaunchTokenResponse(BaseModel):
+    """Response containing a 1-hour merchant-scoped session JWT for Loom."""
+
+    access_token: str
+    token_type: str = "Bearer"
+    expires_in: int  # seconds
+    launch_url: str
+
+
 class AuthTokenData(BaseModel):
     """Enhanced token data model for JWT payload with RBAC"""
 


### PR DESCRIPTION
Admin/owning-reseller gated endpoint minting a 60min merchant-role JWT (virtual subject, src="nautilus" claim, audit-logged) and a Loom launch URL. Strict redirect allowlist.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a secure launch-token flow for opening the Loom dashboard for a specific merchant.
  - Launch tokens expire after one hour and include a ready-to-use dashboard launch URL.
  - Added support for optional, validated redirect paths.
  - Restricted token creation to authorized administrators and reseller owners.
  - Added clear validation for inactive, missing, or unauthorized merchant access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->