### PR TITLE
feat(template): honor context_retention/projection for global functions

### DIFF
--- a/app/ai/voice/agents/breeze_buddy/chat/agent.py
+++ b/app/ai/voice/agents/breeze_buddy/chat/agent.py
@@ -441,9 +441,10 @@ class ChatAgent:
                             "function; it will NOT be approval-gated."
                         )
 
-        # Aggregate per-tool context-retention policy across every MCP server
-        # the template declares. Used by llm_driver to compact stale
-        # tool_result blocks in the messages array before each LLM call —
+        # Aggregate per-tool context-retention policy from two sources — every
+        # MCP server the template declares (below) AND every global function
+        # that sets it inline (further below). Used by llm_driver to compact
+        # stale tool_result blocks in the messages array before each LLM call —
         # bounds input-token cost as a session accumulates tool calls.
         # Tools not in the map default to ``session`` (no compaction).
         #
@@ -461,6 +462,26 @@ class ChatAgent:
                     tool_retention.update(server.tool_context_retention)
                 if server.tool_context_projection:
                     tool_projection.update(server.tool_context_projection)
+
+        # Bridge: global HTTP/builtin/custom functions declare the SAME per-tool
+        # policy inline via BaseGlobalFunction.context_retention /
+        # .context_projection, keyed by their own function name. Merge them into
+        # the same maps so the tool-agnostic context_compactor treats
+        # global-function results exactly like MCP tool results — no separate
+        # code path. ``flow`` is a raw dict (TemplateModel.flow: Dict[str, Any]);
+        # direct-mode global functions live at ``flow["functions"]``.
+        for fn in self.template.flow.get("functions") or []:
+            if not isinstance(fn, dict):
+                continue
+            fn_name = fn.get("name")
+            if not fn_name:
+                continue
+            fn_retention = fn.get("context_retention")
+            if fn_retention:
+                tool_retention[fn_name] = fn_retention
+            fn_projection = fn.get("context_projection")
+            if fn_projection:
+                tool_projection[fn_name] = fn_projection
 
         return _PreparedTools(
             flow_config=flow_config,

--- a/app/ai/voice/agents/breeze_buddy/template/types.py
+++ b/app/ai/voice/agents/breeze_buddy/template/types.py
@@ -1036,6 +1036,14 @@ class McpServerConfig(BaseModel):
     tool_context_retention: Dict[str, Literal["last_turn_only", "session"]] = Field(
         default_factory=dict,
         description=(
+            "SCOPE — MCP-server tools ONLY. This field lives on "
+            "``McpServerConfig`` and is aggregated in chat/agent.py by "
+            "iterating ``configurations.mcp.servers``. It does NOT read global "
+            "HTTP / builtin / custom functions. For those, set the per-function "
+            "``context_retention`` / ``context_projection`` on "
+            "``BaseGlobalFunction`` — chat/agent.py merges them into the SAME "
+            "retention map this feeds, so the tool-agnostic context_compactor "
+            "handles MCP and global-function results identically.\n"
             "Per-tool conversation-context retention policy, applied at "
             "message-prep time before the LLM call. Keys are the registered "
             "tool names: the raw upstream MCP name, except a tool whose name "
@@ -1058,6 +1066,8 @@ class McpServerConfig(BaseModel):
     tool_context_projection: Dict[str, List[str]] = Field(
         default_factory=dict,
         description=(
+            "SCOPE — MCP-server tools ONLY (same as ``tool_context_retention``). "
+            "For global functions use ``BaseGlobalFunction.context_projection``.\n"
             "Per-tool identity keep-list, paired with ``last_turn_only`` "
             "retention. Keys follow the same rule as ``tool_context_retention`` "
             "(raw upstream MCP tool name; ``<server.name>_<name>`` only when "
@@ -2114,6 +2124,32 @@ class BaseGlobalFunction(BaseModel):
             "names from handlers/transport/utils/response_transform.py."
         ),
     )
+    context_retention: Optional[Literal["last_turn_only", "session"]] = Field(
+        default=None,
+        description=(
+            "Per-function chat-context retention — the global-function twin of "
+            "``McpServerConfig.tool_context_retention``. The context_compactor "
+            "is tool-agnostic (it keys stale tool_result blocks by name), so a "
+            "value here is merged into the same retention map as MCP tools in "
+            "chat/agent.py and compacted identically. ``None`` (default) = "
+            "``session`` (kept full — unchanged behavior). Set "
+            "``last_turn_only`` for heavy / easily-re-derived results (searches, "
+            "fare calendars) so older calls collapse to a stub/projection and "
+            "don't accumulate token cost across a session."
+        ),
+    )
+    context_projection: Optional[List[str]] = Field(
+        default=None,
+        description=(
+            "Per-function identity keep-list paired with "
+            "``context_retention='last_turn_only'`` — the global-function twin "
+            "of ``McpServerConfig.tool_context_projection``. Stale results are "
+            "compacted to ONLY these keep-paths (grammar: ``a.b`` descends, "
+            "``a[*].b`` iterates a list) instead of a 1-line stub, so durable "
+            "referents survive follow-up turns at ~1% of the tokens. ``None`` = "
+            "fall back to the stub."
+        ),
+    )
 
 
 class GlobalHttpFunction(BaseGlobalFunction):
@@ -2123,6 +2159,15 @@ class GlobalHttpFunction(BaseGlobalFunction):
     Global functions are registered with FlowManager and can be called by the LLM
     from any node in the conversation. Unlike hooks (fire-and-forget), global
     functions wait for the HTTP response and return data to the LLM.
+
+    Context management: keep results lean at the source with
+    ``expected_response_schema`` (a JMESPath whitelist) — it trims the payload
+    *before* it ever enters the context. For cross-turn hygiene, declare
+    ``context_retention='last_turn_only'`` (+ optional ``context_projection``)
+    on the function: unlike the MCP-server-scoped ``tool_context_retention``,
+    these per-function fields (on ``BaseGlobalFunction``) ARE honored for global
+    functions — chat/agent.py merges them into the same map the tool-agnostic
+    context_compactor consumes.
 
     Example:
         {

--- a/docs/CONTEXT_PROJECTION.md
+++ b/docs/CONTEXT_PROJECTION.md
@@ -1,5 +1,22 @@
 # Tool-result context projection (chat mode)
 
+> **Two config sources, one engine.** The compactor (`compact_tool_results`) is
+> **tool-agnostic** — it keys stale `tool_result` blocks by tool *name* and
+> knows nothing about MCP vs global functions. Only the *config* comes from two
+> places, both merged in `chat/agent.py`:
+>
+> 1. **MCP tools** — `McpServerConfig.tool_context_retention` /
+>    `tool_context_projection` (aggregated over `configurations.mcp.servers`).
+> 2. **Global HTTP / builtin / custom functions** — the per-function
+>    `context_retention` / `context_projection` on `BaseGlobalFunction`
+>    (aggregated over `flow["functions"]`).
+>
+> So a global-function template (no MCP servers) can now opt into
+> `last_turn_only` + projection too. Still prefer trimming at the source with
+> each function's `expected_response_schema` (JMESPath whitelist) — that keeps
+> the payload small *before* it enters context; retention is the cross-turn
+> backstop for what does land.
+
 ## Problem
 
 Chat-mode MCP tools like `search_catalog` return large payloads (~33k tokens

--- a/tests/test_context_compactor.py
+++ b/tests/test_context_compactor.py
@@ -10,6 +10,8 @@ so the cases here cover both the happy paths and the don't-blow-up paths.
 
 from __future__ import annotations
 
+import json
+
 from app.ai.voice.agents.breeze_buddy.chat.context_compactor import (
     compact_tool_results,
 )
@@ -350,3 +352,57 @@ def test_projection_non_json_content_falls_back_to_stub():
     )
     # Unparseable content can't be projected → stub keeps it bounded.
     assert "[pruned: search_catalog" in out[1]["content"][0]["content"]
+
+
+# ---------------------------------------------------------------------------
+# Bridge — global-function results compact identically to MCP tools
+# ---------------------------------------------------------------------------
+#
+# The compactor keys by tool NAME only; it is agnostic to whether the tool is
+# an MCP tool or a global HTTP/builtin/custom function. So a global function's
+# policy (aggregated from BaseGlobalFunction.context_retention /
+# .context_projection in chat/agent.py) compacts its stale results exactly like
+# an MCP tool's. These lock that behavior in.
+
+
+def test_global_function_result_compacts_like_mcp_tool():
+    messages = [
+        {"role": "user", "content": "flights DEL to BOM tomorrow"},
+        _assistant_with_tool_use("f1", "search_flights", {"from_code": "DEL"}),
+        _user_with_tool_result("f1", '{"flights":["a","b"]}' * 200),  # bulky
+        {"role": "assistant", "content": "Here are flights."},
+        {"role": "user", "content": "and BLR to DEL?"},
+        _assistant_with_tool_use("f2", "search_flights", {"from_code": "BLR"}),
+        _user_with_tool_result("f2", '{"flights":["c"]}' * 200),  # bulky, NEWEST
+    ]
+    out = compact_tool_results(
+        messages, retention={"search_flights": "last_turn_only"}, recent_keep=1
+    )
+    # Older search stubbed, newest intact — identical to the MCP catalog case.
+    assert "[pruned: search_flights" in out[2]["content"][0]["content"]
+    assert len(out[6]["content"][0]["content"]) > 1000
+
+
+def test_global_function_projection_keeps_identity_paths():
+    big = {
+        "flights": [
+            {"id": "6E-123", "priceText": "5,717", "junk": "x" * 5000},
+            {"id": "AI-456", "priceText": "6,000", "junk": "y" * 5000},
+        ]
+    }
+    messages = [
+        _assistant_with_tool_use("f1", "search_flights", {"q": 1}),
+        _user_with_tool_result("f1", json.dumps(big)),
+        _assistant_with_tool_use("f2", "search_flights", {"q": 2}),
+        _user_with_tool_result("f2", json.dumps(big)),
+    ]
+    out = compact_tool_results(
+        messages,
+        retention={"search_flights": "last_turn_only"},
+        recent_keep=1,
+        projection={"search_flights": ["flights[*].id", "flights[*].priceText"]},
+    )
+    stale = out[1]["content"][0]["content"]
+    assert "6E-123" in stale and "5,717" in stale  # identity kept
+    assert "junk" not in stale  # heavy field dropped
+    assert len(stale) < 500  # tiny vs the original ~10k


### PR DESCRIPTION
## Problem

The `context_compactor` is **tool-agnostic** — it keys stale `tool_result` blocks by tool *name* and doesn't care if a tool is MCP or a global function. But the retention/projection **config** was aggregated only from `McpServerConfig` (`chat/agent.py`, iterating `configurations.mcp.servers`). So global HTTP / builtin / custom functions (`flow.functions`) could never opt into `last_turn_only` compaction — their results were always retained full, and a **global-function-only template** (no MCP servers) got no compaction at all. I hit this building a global-HTTP-function flight template: `search_flights` results accumulated in context with no way to bound them.

## Fix — one engine, two config sources

- **`types.py`** — add `context_retention` / `context_projection` to `BaseGlobalFunction` (the global-function twins of the `McpServerConfig` fields).
- **`chat/agent.py`** — merge each global function's inline policy into the **same** `tool_retention` / `tool_projection` maps the compactor already consumes, right after the MCP-server aggregation. No new code path; the tool-agnostic compactor handles both identically.
- **docs** — clarify scope on the two `McpServerConfig` fields + `GlobalHttpFunction`, and rewrite the `docs/CONTEXT_PROJECTION.md` callout (tool-agnostic engine, two config sources).
- **tests** — `test_context_compactor.py`: global-function results stub + project identically to MCP tools (16 passing).

## Why it matters for future authors (human or AI)

Before: the fields' docstrings were pure-MCP and silent about the gap, so an author building a global-function template could set them expecting benefits and get nothing, silently. Now the path exists and the docstrings cross-reference it both ways.

## Risk

Additive only — the MCP aggregation and the compactor are untouched; global functions with no policy set behave exactly as before (`session`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)