### PR TITLE
fix(chat): stop losing UI ops — recover unwrapped op-lines, allow mailto/tel CTAs, persist drop evidence

### DIFF
--- a/app/ai/voice/agents/breeze_buddy/chat/metrics.py
+++ b/app/ai/voice/agents/breeze_buddy/chat/metrics.py
@@ -32,6 +32,11 @@ from app.core.logger import logger
 # unbounded.
 _MAX_DROP_REASONS = 20
 
+# Cap persisted per-drop evidence entries (chat_turn_metrics.drops). Sized to
+# the real distribution — observed turns drop 0-1 ops; 10 already means the
+# turn is pathological and the first 10 tell the story.
+_MAX_DROP_DETAILS = 10
+
 
 class TurnMetrics:
     """Accumulates structural metrics for one chat turn.
@@ -66,6 +71,11 @@ class TurnMetrics:
         self.prose_chars = 0
         self.ui_chars = 0
         self.drop_reasons: List[str] = []
+        # Per-drop evidence for chat_turn_metrics.drops (migration 041):
+        # [{"sig": {...}, "reason": str, "raw": str}]. ``raw`` is the dropped
+        # line itself — transcript-class content, persisted to the DB beside
+        # the session, NEVER echoed into the [CHAT_METRICS] log line.
+        self.drops: List[dict] = []
         self.status: Optional[str] = None
         # The assistant chat_message.idx this turn produced (from the
         # turn_end event). Keys the persisted chat_turn_metrics row
@@ -101,6 +111,15 @@ class TurnMetrics:
             elif name == "ui_op_dropped":
                 self.ui_dropped += 1
                 reason = data.get("reason")
+                if len(self.drops) < _MAX_DROP_DETAILS:
+                    raw = data.get("raw")
+                    self.drops.append(
+                        {
+                            "sig": data.get("op"),
+                            "reason": reason if isinstance(reason, str) else None,
+                            "raw": raw if isinstance(raw, str) else None,
+                        }
+                    )
                 if (
                     isinstance(reason, str)
                     and len(self.drop_reasons) < _MAX_DROP_REASONS

--- a/app/ai/voice/agents/breeze_buddy/chat/ui_healer.py
+++ b/app/ai/voice/agents/breeze_buddy/chat/ui_healer.py
@@ -76,6 +76,22 @@ _PROP_ALIASES: Dict[Tuple[str, str], str] = {
 }
 
 
+def _rule_infer_missing_op(
+    op: Dict[str, Any], ctx: HealerContext
+) -> Tuple[Dict[str, Any], Optional[str]]:
+    """Line missing the ``op`` discriminator but carrying ``type`` + ``id``
+    (the shape of an ``add``) → default to ``add``. Real-traffic drops show
+    the LLM occasionally omits the key on otherwise-valid ops
+    (``unknown_op:None`` telemetry). Anything less add-shaped stays
+    untouched and drops downstream — we won't guess remove/replace."""
+    if "op" in op:
+        return op, None
+    if isinstance(op.get("type"), str) and isinstance(op.get("id"), str):
+        op["op"] = "add"
+        return op, "inferred_missing_op:add"
+    return op, None
+
+
 def _rule_rename_prop_aliases(
     op: Dict[str, Any], ctx: HealerContext
 ) -> Tuple[Dict[str, Any], Optional[str]]:
@@ -231,13 +247,15 @@ def _rule_drop_orphan_add(
 # ---------------------------------------------------------------------------
 
 
-# Order matters: rename aliases first (so Tag.label → Tag.text doesn't
+# Order matters: infer a missing ``op`` first (every later rule gates on
+# ``op == "add"``); then rename aliases (so Tag.label → Tag.text doesn't
 # get stripped); then strip remaining unknowns; then per-primitive
 # coercions; then dedupe last (the rename can mutate id-bearing props
 # in theory). Drops run after, gating on the cleaned-up shape.
 _TRANSFORM_RULES: List[
     Callable[[Dict[str, Any], HealerContext], Tuple[Dict[str, Any], Optional[str]]]
 ] = [
+    _rule_infer_missing_op,
     _rule_rename_prop_aliases,
     _rule_strip_unknown_props,
     _rule_button_default_label,

--- a/app/ai/voice/agents/breeze_buddy/chat/ui_stream.py
+++ b/app/ai/voice/agents/breeze_buddy/chat/ui_stream.py
@@ -29,6 +29,8 @@ import re
 from dataclasses import dataclass, field
 from typing import Any, Callable, Dict, Iterator, List, Literal, Optional, Set, Union
 
+from pydantic import ValidationError
+
 from app.ai.voice.agents.breeze_buddy.chat.sse import SSEEvent
 from app.ai.voice.agents.breeze_buddy.template.ui_catalog import (
     is_known_type,
@@ -40,6 +42,35 @@ _log = logging.getLogger(__name__)
 _OPEN = "<ui_stream>"
 _CLOSE = "</ui_stream>"
 _CARRY_MAX = max(len(_OPEN), len(_CLOSE)) - 1
+
+# Compact op markers ("+" add / "~" replace / "-" remove) and the verbose
+# ``{"op": ...}`` verbs. Used to recognize a bare SpecStream op-line the LLM
+# emitted WITHOUT the ``<ui_stream>`` wrapper, so it can be recovered into the
+# op path instead of leaking to the user as raw JSON. See ``_is_op_line``.
+_OP_MARKERS: Set[str] = {"+", "~", "-"}
+_OP_VERBS: Set[str] = {"add", "replace", "remove"}
+
+
+def _is_op_line(text: str) -> bool:
+    """True iff ``text`` is a bare SpecStream op-line.
+
+    Conservative on purpose: the line must parse to a JSON **object** carrying
+    an op marker (compact ``{"+"|"~"|"-": …}`` or verbose
+    ``{"op": "add"|"replace"|"remove", …}``). Ordinary prose — even prose that
+    contains braces or a stray JSON value — never matches, so nothing that
+    isn't genuinely UI gets diverted out of the visible reply.
+    """
+    if not text.startswith("{"):
+        return False
+    try:
+        obj = json.loads(text)
+    except (ValueError, TypeError):
+        return False
+    if not isinstance(obj, dict):
+        return False
+    if _OP_MARKERS & obj.keys():
+        return True
+    return obj.get("op") in _OP_VERBS
 
 
 # ---------------------------------------------------------------------------
@@ -91,6 +122,10 @@ class UiStreamExtractor:
         self._carry: str = ""
         # Partial JSONL line accumulator (active while INSIDE).
         self._line_buf: str = ""
+        # OUTSIDE accumulator: holds only a pending line that STARTS with "{"
+        # (a possible bare op-line) until a newline decides op-vs-prose. Prose
+        # never sits here — it streams immediately — so smoothness is preserved.
+        self._out_line_buf: str = ""
 
     def feed(self, delta: str) -> Iterator[YieldItem]:
         """Process one text delta. Yields zero or more text/op_line items."""
@@ -108,9 +143,14 @@ class UiStreamExtractor:
         ``<ui_stream>`` but never closed it.
         """
         if self._state == "OUTSIDE":
-            if self._carry:
-                yield TextOut(value=self._carry)
+            # A held partial op-line (no trailing newline) + any marker-prefix
+            # carry. Route through the op recogniser so a wrapper-less final op
+            # is recovered rather than leaked; anything else falls back to prose.
+            leftover = self._out_line_buf + self._carry
+            self._out_line_buf = ""
             self._carry = ""
+            if leftover:
+                yield from self._emit_outside_line(leftover)
             return
         partial = self._line_buf + self._carry
         _log.warning(
@@ -128,18 +168,19 @@ class UiStreamExtractor:
             if self._state == "OUTSIDE":
                 idx = buffer.find(_OPEN)
                 if idx != -1:
-                    if idx > 0:
-                        yield TextOut(value=buffer[:idx])
+                    # Definite boundary before the open marker — flush any held
+                    # partial op-line too, then switch INSIDE.
+                    yield from self._emit_outside(buffer[:idx], flush_partial=True)
                     buffer = buffer[idx + len(_OPEN) :]
                     self._state = "INSIDE"
                     continue
                 hold = _tail_marker_prefix(buffer, _OPEN)
                 if hold:
-                    if len(buffer) > hold:
-                        yield TextOut(value=buffer[:-hold])
+                    body = buffer[:-hold] if len(buffer) > hold else ""
+                    yield from self._emit_outside(body, flush_partial=False)
                     self._carry = buffer[-hold:]
                 else:
-                    yield TextOut(value=buffer)
+                    yield from self._emit_outside(buffer, flush_partial=False)
                     self._carry = ""
                 return
 
@@ -177,6 +218,50 @@ class UiStreamExtractor:
             if line:
                 yield JsonlOpLine(raw=line)
             buffer = buffer[newline_idx + 1 :]
+
+    def _emit_outside(self, text: str, flush_partial: bool) -> Iterator[YieldItem]:
+        """Emit OUTSIDE (non-block) text, recovering a bare op-line the LLM
+        forgot to wrap in ``<ui_stream>``.
+
+        Prose streams immediately for smoothness; only a line that *starts*
+        with ``{`` is held (until its newline) so we can decide op-vs-prose. A
+        recovered op-line is yielded as ``JsonlOpLine`` — the same item a
+        wrapped line produces — so it flows through the identical heal/render
+        path and shows as UI instead of leaking as raw JSON. ``flush_partial``
+        forces a held partial line out (used when a definite ``<ui_stream>``
+        boundary follows).
+        """
+        self._out_line_buf += text
+        while self._out_line_buf:
+            starts_brace = self._out_line_buf.lstrip().startswith("{")
+            newline_idx = self._out_line_buf.find("\n")
+            if not starts_brace:
+                # Definitely prose — stream up to the newline, or all of it.
+                if newline_idx == -1:
+                    yield TextOut(value=self._out_line_buf)
+                    self._out_line_buf = ""
+                    return
+                yield TextOut(value=self._out_line_buf[: newline_idx + 1])
+                self._out_line_buf = self._out_line_buf[newline_idx + 1 :]
+                continue
+            # Might be a bare op-line — need the whole line to know.
+            if newline_idx == -1:
+                if flush_partial:
+                    yield from self._emit_outside_line(self._out_line_buf)
+                    self._out_line_buf = ""
+                return
+            line = self._out_line_buf[: newline_idx + 1]
+            self._out_line_buf = self._out_line_buf[newline_idx + 1 :]
+            yield from self._emit_outside_line(line)
+
+    def _emit_outside_line(self, line: str) -> Iterator[YieldItem]:
+        """Classify one OUTSIDE line: a bare op-line is recovered as a
+        ``JsonlOpLine`` (so it renders); anything else is prose (``TextOut``)."""
+        stripped = line.strip()
+        if _is_op_line(stripped):
+            yield JsonlOpLine(raw=stripped)
+        elif line:
+            yield TextOut(value=line)
 
 
 def _tail_marker_prefix(buffer: str, marker: str) -> int:
@@ -490,7 +575,18 @@ def parse_op_line(line: str, *, allowlist: Optional[Set[str]] = None) -> OpResul
     if op_kind == "add":
         try:
             validated = validate_props(op["type"], props)
-        except Exception as exc:  # ValidationError + defensive
+        except ValidationError as exc:
+            # Structural detail only — field paths + pydantic error kinds,
+            # never input values (privacy contract shared with
+            # ``ui_op_dropped_event``). This is what makes drop telemetry
+            # actionable: "Button:action.OpenUrlAction.url:url_scheme"
+            # diagnoses itself; a bare "ValidationError" does not.
+            details = ";".join(
+                f"{'.'.join(str(p) for p in err.get('loc', ()))}:{err.get('type')}"
+                for err in exc.errors()[:5]
+            )
+            return OpResult(error=f"props_validation_failed:{op['type']}:{details}")
+        except Exception as exc:  # defensive
             return OpResult(error=f"props_validation_failed: {type(exc).__name__}")
         # Replace props with the model_dump so downstream callers see
         # normalized values (enum → string, HttpUrl → str, defaults filled).
@@ -546,18 +642,33 @@ def healer_applied_event(line: str, note: str) -> SSEEvent:
     )
 
 
+# Cap on the raw dropped line carried in the event — a pathological repeat
+# expansion can't bloat the SSE frame or the persisted drops row.
+_DROP_RAW_MAX = 2000
+
+
 def ui_op_dropped_event(line: str, reason: str) -> SSEEvent:
     """Observability event — fired when a line failed validation and was
     dropped. Widget ignores.
 
-    Emits a structural-only op signature (never the resolved payload) and the
-    first line of ``reason`` — Pydantic errors echo ``input_value`` on later
-    lines, so we drop those here too (defense-in-depth alongside the metrics
-    layer's own truncation).
+    Emits a structural-only op signature and the first line of ``reason`` —
+    Pydantic errors echo ``input_value`` on later lines, so we drop those
+    here too (defense-in-depth alongside the metrics layer's own truncation).
+
+    ``raw`` carries the dropped line itself (capped) so the metrics observer
+    can persist it beside the transcript (chat_turn_metrics.drops, migration
+    041) — that row is what makes drops diagnosable from the dashboard
+    without log archaeology. Same-session assistant-generated content only;
+    it must never be copied into log lines.
     """
     first_reason = reason.split("\n", 1)[0][:200]
     return SSEEvent(
-        event="ui_op_dropped", data={"op": _op_signature(line), "reason": first_reason}
+        event="ui_op_dropped",
+        data={
+            "op": _op_signature(line),
+            "reason": first_reason,
+            "raw": line[:_DROP_RAW_MAX],
+        },
     )
 
 
@@ -621,9 +732,19 @@ def process_op_line(
     for line in expanded:
         if healer is not None:
             result = healer(line, session_state or {})
+            # A ``dropped_*`` note is the drop's reason, not a repair —
+            # surface it as ``ui_op_dropped`` (below) rather than
+            # ``healer_applied``, so healer drops land in the SAME funnel
+            # counter as validator drops. Before this, healer drops were
+            # invisible in ``ui_dropped`` — the badge under-counted.
+            drop_note: Optional[str] = None
             for note in result.notes:
-                events.append(healer_applied_event(line, note))
+                if note.startswith("dropped_"):
+                    drop_note = drop_note or note
+                else:
+                    events.append(healer_applied_event(line, note))
             if result.drop:
+                events.append(ui_op_dropped_event(line, drop_note or "healer_drop"))
                 continue
             if result.line is not None:
                 line = result.line

--- a/app/ai/voice/agents/breeze_buddy/template/ui_catalog.py
+++ b/app/ai/voice/agents/breeze_buddy/template/ui_catalog.py
@@ -39,13 +39,15 @@ body rows; locale-aware reformatting is the upstream tool's job.
 from __future__ import annotations
 
 from enum import Enum
-from typing import Any, Dict, List, Literal, Optional, Set, Type, Union
+from typing import Annotated, Any, Dict, List, Literal, Optional, Set, Type, Union
 
 from pydantic import (
+    AnyUrl,
     BaseModel,
     ConfigDict,
     Field,
     HttpUrl,
+    UrlConstraints,
     field_validator,
     model_validator,
 )
@@ -85,17 +87,28 @@ class ToAssistantAction(BaseModel):
     )
 
 
+# Schemes a click action may open. ``mailto:`` / ``tel:`` hand off to the
+# OS mail/phone handler — support-contact CTAs ("email us", "call us") are
+# a top real-traffic emission and used to drop on HttpUrl's http/https-only
+# rule. ``javascript:``/``data:`` and everything else stay rejected.
+# Display assets (``Image.src``, ``Icon.url``) remain HttpUrl-only.
+OpenableUrl = Annotated[
+    AnyUrl, UrlConstraints(allowed_schemes=["http", "https", "mailto", "tel"])
+]
+
+
 class OpenUrlAction(BaseModel):
-    """Open ``url``. Server-provided URLs only.
+    """Open ``url``. Server-provided URLs only (http/https/mailto/tel).
 
     ``target`` controls where it opens: ``new_tab`` (default — preserves the
     historical behavior) or ``same_tab`` to navigate the current page (e.g.
-    a checkout redirect)."""
+    a checkout redirect). ``mailto:``/``tel:`` URLs open the OS handler
+    regardless of target."""
 
     model_config = ConfigDict(extra="forbid")
 
     type: Literal["open_url"] = "open_url"
-    url: HttpUrl
+    url: OpenableUrl
     target: Literal["new_tab", "same_tab"] = Field(
         "new_tab",
         description=(

--- a/app/api/routers/breeze_buddy/chat/handlers.py
+++ b/app/api/routers/breeze_buddy/chat/handlers.py
@@ -113,6 +113,7 @@ async def _persist_turn_metrics(metrics: TurnMetrics) -> None:
             ui_chars=metrics.ui_chars,
             status=metrics.status,
             phase=metrics.phase,
+            drops=metrics.drops or None,
         )
     except Exception as exc:  # noqa: BLE001 - telemetry must not break a turn
         logger.warning(

--- a/app/database/accessor/breeze_buddy/chat_session.py
+++ b/app/database/accessor/breeze_buddy/chat_session.py
@@ -499,10 +499,12 @@ async def record_chat_turn_metrics(
     ui_chars: int,
     status: Optional[str],
     phase: str,
+    drops: Optional[List[Dict[str, Any]]] = None,
 ) -> Optional[ChatTurnMetrics]:
     """Upsert one turn's structural metrics, keyed by the assistant idx.
 
-    Mirrors the router's ``[CHAT_METRICS]`` log line into a joinable row. The
+    Mirrors the router's ``[CHAT_METRICS]`` log line into a joinable row,
+    plus the per-drop evidence array (``drops``, migration 041). The
     caller (router stream ``finally``) treats this as best-effort — it wraps
     the call so a write failure never affects the turn. Per accessor
     convention this still logs + re-raises; the router swallows.
@@ -522,6 +524,7 @@ async def record_chat_turn_metrics(
         ui_chars=ui_chars,
         status=status,
         phase=phase,
+        drops_json=json.dumps(drops) if drops else None,
     )
     try:
         result = await run_parameterized_query(query, values)

--- a/app/database/decoder/breeze_buddy/chat_session.py
+++ b/app/database/decoder/breeze_buddy/chat_session.py
@@ -131,5 +131,6 @@ def decode_chat_turn_metrics(row: asyncpg.Record) -> Optional[ChatTurnMetrics]:
         ui_chars=row.get("ui_chars") or 0,
         status=row.get("status"),
         phase=row.get("phase") or "baseline",
+        drops=cast(Optional[List[Dict[str, Any]]], parse_json(row, "drops")),
         created_at=row["created_at"],
     )

--- a/app/database/migrations/041_add_drops_to_chat_turn_metrics.sql
+++ b/app/database/migrations/041_add_drops_to_chat_turn_metrics.sql
@@ -1,0 +1,22 @@
+-- Migration 041: Persist per-drop evidence on chat_turn_metrics.
+--
+-- 032 stores per-turn *counts* (ui_dropped) — enough to see THAT ops were
+-- dropped, never WHAT. Diagnosing the real-traffic mailto: Button class took
+-- log archaeology plus transcript inference to reconstruct the dropped op.
+-- This column keeps the evidence next to the count: a jsonb array of
+--
+--   {"sig":    {"op":"add","id":"email_btn","type":"Button"},
+--    "reason": "props_validation_failed:Button:action.OpenUrlAction.url:url_scheme",
+--    "raw":    "<the dropped JSONL line, capped>"}
+--
+-- Deliberate amendment to 032's "no payload content" note: ``raw`` is
+-- assistant-GENERATED op content for this same session — the identical
+-- sensitivity class as chat_message.content one join away (same session FK,
+-- same cascade delete, same read path). It never contains user-typed text
+-- the transcript doesn't already hold. Logs stay structural-only; the raw
+-- evidence lives ONLY here, under transcript retention/access rules.
+--
+-- NULL (not '[]') when a turn dropped nothing — keeps the common row narrow.
+
+ALTER TABLE chat_turn_metrics
+    ADD COLUMN IF NOT EXISTS drops jsonb;

--- a/app/database/queries/breeze_buddy/chat_session.py
+++ b/app/database/queries/breeze_buddy/chat_session.py
@@ -32,7 +32,7 @@ _AGENT_STATE_COLUMNS = """
 _TURN_METRICS_COLUMNS = """
     session_id, idx, ttft_ms, ttfui_ms, ttlui_ms, total_ms,
     ui_ops, ui_dropped, healer_applied, tool_calls,
-    prose_chars, ui_chars, status, phase, created_at
+    prose_chars, ui_chars, status, phase, drops, created_at
 """
 
 
@@ -554,21 +554,23 @@ def record_chat_turn_metrics_query(
     ui_chars: int,
     status: Optional[str],
     phase: str,
+    drops_json: Optional[str] = None,
 ) -> Tuple[str, List[Any]]:
     """Upsert one turn's structural metrics, keyed by the assistant idx.
 
     ON CONFLICT keeps the write idempotent — a re-emit for the same
-    (session_id, idx) overwrites rather than erroring. The values are the
-    same fields the router's ``TurnMetrics`` already computed for the
-    ``[CHAT_METRICS]`` log line; nothing here is payload content.
+    (session_id, idx) overwrites rather than erroring. The counters mirror
+    the router's ``TurnMetrics``; ``drops_json`` is the per-drop evidence
+    array (migration 041) — transcript-class content, see the migration
+    header for the sensitivity rationale. None when nothing dropped.
     """
     query = f"""
         INSERT INTO {CHAT_TURN_METRICS_TABLE} (
             session_id, idx, ttft_ms, ttfui_ms, ttlui_ms, total_ms,
             ui_ops, ui_dropped, healer_applied, tool_calls,
-            prose_chars, ui_chars, status, phase
+            prose_chars, ui_chars, status, phase, drops
         )
-        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
+        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15::jsonb)
         ON CONFLICT (session_id, idx) DO UPDATE SET
             ttft_ms = EXCLUDED.ttft_ms,
             ttfui_ms = EXCLUDED.ttfui_ms,
@@ -581,7 +583,8 @@ def record_chat_turn_metrics_query(
             prose_chars = EXCLUDED.prose_chars,
             ui_chars = EXCLUDED.ui_chars,
             status = EXCLUDED.status,
-            phase = EXCLUDED.phase
+            phase = EXCLUDED.phase,
+            drops = EXCLUDED.drops
         RETURNING {_TURN_METRICS_COLUMNS}
     """
     return query, [
@@ -599,6 +602,7 @@ def record_chat_turn_metrics_query(
         ui_chars,
         status,
         phase,
+        drops_json,
     ]
 
 

--- a/app/schemas/breeze_buddy/chat.py
+++ b/app/schemas/breeze_buddy/chat.py
@@ -167,13 +167,27 @@ class AgentSessionState(BaseModel):
     updated_at: Optional[datetime] = None
 
 
+class ChatTurnDrop(BaseModel):
+    """One dropped UI op's evidence (``chat_turn_metrics.drops`` entries,
+    migration 041). ``sig`` is the structural op signature
+    (op/id/type or a content hash); ``reason`` the structured drop reason
+    (e.g. ``props_validation_failed:Button:action.OpenUrlAction.url:url_scheme``);
+    ``raw`` the dropped JSONL line itself (capped) — transcript-class
+    content, surfaced in the log-detail UI so drops diagnose themselves."""
+
+    sig: Optional[Dict[str, Any]] = None
+    reason: Optional[str] = None
+    raw: Optional[str] = None
+
+
 class ChatTurnMetrics(BaseModel):
-    """One row of ``chat_turn_metrics`` (migration 032).
+    """One row of ``chat_turn_metrics`` (migration 032 + 041).
 
     A joinable mirror of the structural ``[CHAT_METRICS]`` log line, keyed by
     the assistant ``chat_message.idx`` the turn produced so the
-    conversational-log UI can show latency next to each assistant turn. Every
-    field is a timing, a count, or a status — no payload content.
+    conversational-log UI can show latency next to each assistant turn.
+    Counters/timings are structural; ``drops`` carries per-drop evidence
+    (see :class:`ChatTurnDrop`).
     """
 
     session_id: str
@@ -190,6 +204,7 @@ class ChatTurnMetrics(BaseModel):
     ui_chars: int = 0
     status: Optional[str] = None
     phase: str = "baseline"
+    drops: Optional[List[ChatTurnDrop]] = None
     created_at: Optional[datetime] = None
 
 

--- a/tests/test_ui_healer.py
+++ b/tests/test_ui_healer.py
@@ -186,3 +186,23 @@ def test_healer_alias_does_not_override_canonical_when_both_present():
     assert out["props"]["text"] == "explicit"
     # `label` was stripped (unknown prop), not renamed.
     assert "label" not in out["props"]
+
+
+def test_healer_infers_missing_op_as_add():
+    """LLM omitted the `op` discriminator on an add-shaped line → healed."""
+    import json
+
+    r = heal_op_line(
+        '{"id":"x","type":"Text","parent":"root","props":{"text":"hi"}}',
+        _ctx(known_ids={"root"}),
+    )
+    assert r.drop is False
+    assert "inferred_missing_op:add" in r.notes
+    assert json.loads(r.line)["op"] == "add"  # type: ignore[arg-type]
+
+
+def test_healer_does_not_infer_op_without_type_and_id():
+    """Anything less add-shaped passes through untouched (drops downstream)."""
+    r = heal_op_line('{"id":"x","props":{}}', _ctx())
+    assert r.drop is False
+    assert r.notes == []

--- a/tests/test_ui_stream.py
+++ b/tests/test_ui_stream.py
@@ -412,3 +412,221 @@ def test_summarize_handles_unknown_type_gracefully():
     ]
     out = summarize_ui_ops(ops)
     assert "1 FutureThingy" in out
+
+
+# ---------------------------------------------------------------------------
+# Recovery of BARE op-lines emitted WITHOUT the <ui_stream> wrapper
+# ---------------------------------------------------------------------------
+#
+# The LLM stochastically forgets to wrap its SpecStream ops. Without recovery
+# those lines leak to the user as raw JSON. The extractor now routes a bare
+# op-line into the same JsonlOpLine path a wrapped line takes, so it renders as
+# UI; genuine prose is untouched and still streams smoothly.
+
+
+def _feed_all(deltas):
+    """Feed each delta then flush; return the flat list of yielded items."""
+    ex = UiStreamExtractor()
+    out: list = []
+    for d in deltas:
+        out.extend(ex.feed(d))
+    out.extend(ex.flush())
+    return out
+
+
+def test_bare_op_lines_recovered_as_op_not_prose():
+    items = _feed_all(
+        [
+            '{"+":"root:Card@root"}\n',
+            '{"+":"t:Text@root","text":"hi"}\n',
+        ]
+    )
+    assert all(isinstance(i, JsonlOpLine) for i in items)
+    assert items[0].raw == '{"+":"root:Card@root"}'
+    assert items[1].raw == '{"+":"t:Text@root","text":"hi"}'
+
+
+def test_verbose_bare_op_line_recovered():
+    items = _feed_all(['{"op":"add","id":"r","type":"Stack"}\n'])
+    assert len(items) == 1 and isinstance(items[0], JsonlOpLine)
+
+
+def test_prose_is_never_recovered_as_op():
+    items = _feed_all(["Here are the cheapest days to fly.\n"])
+    assert items == [TextOut(value="Here are the cheapest days to fly.\n")]
+
+
+def test_prose_with_braces_stays_prose():
+    # Looks jsonish but has no op marker → must remain visible prose.
+    items = _feed_all(['{"note":"not an op"}\n'])
+    assert len(items) == 1 and isinstance(items[0], TextOut)
+
+
+def test_bare_op_line_split_across_deltas_is_recovered():
+    items = _feed_all(['{"+":"root:', 'Card@root","variant":"hi', 'ghlighted"}\n'])
+    assert len(items) == 1 and isinstance(items[0], JsonlOpLine)
+    assert items[0].raw == '{"+":"root:Card@root","variant":"highlighted"}'
+
+
+def test_mixed_prose_then_bare_ops():
+    items = _feed_all(
+        [
+            "Best deal below:\n",
+            '{"+":"c:Card@root"}\n',
+            '{"+":"t:Text@c","text":"IndiGo"}\n',
+        ]
+    )
+    kinds = [type(i).__name__ for i in items]
+    assert kinds == ["TextOut", "JsonlOpLine", "JsonlOpLine"]
+    assert items[0].value == "Best deal below:\n"
+
+
+def test_final_bare_op_line_without_newline_recovered_on_flush():
+    # No trailing newline — must still be recovered (not leaked) at flush.
+    items = _feed_all(['{"+":"root:Card@root"}'])
+    assert len(items) == 1 and isinstance(items[0], JsonlOpLine)
+
+
+def test_wrapped_ops_still_work_after_recovery_change():
+    # Regression: the explicit <ui_stream> path is unchanged.
+    items = _feed_all(
+        [
+            "here <ui_stream>\n",
+            '{"op":"add","id":"root","type":"Stack"}\n',
+            "</ui_stream> done",
+        ]
+    )
+    kinds = [type(i).__name__ for i in items]
+    assert kinds == ["TextOut", "JsonlOpLine", "TextOut"]
+    assert items[0].value == "here "
+    assert items[2].value == " done"
+
+
+def test_prose_streams_immediately_without_newline():
+    # A prose delta with no newline must emit right away (no buffering stall).
+    ex = UiStreamExtractor()
+    out = list(ex.feed("streaming prose no newline yet"))
+    assert out == [TextOut(value="streaming prose no newline yet")]
+
+
+# ---------------------------------------------------------------------------
+# Contact-CTA URL schemes (mailto/tel) + structured drop reasons
+# ---------------------------------------------------------------------------
+
+
+def test_parse_button_mailto_action_validates():
+    line = (
+        '{"op":"add","id":"b1","type":"Button","parent":"root",'
+        '"props":{"label":"Email us","action":{"type":"open_url",'
+        '"url":"mailto:support@example.com"}}}'
+    )
+    r = parse_op_line(line)
+    assert r.error is None
+    assert r.op["props"]["action"]["url"].startswith("mailto:")
+
+
+def test_parse_button_tel_action_validates():
+    line = (
+        '{"op":"add","id":"b1","type":"Button","parent":"root",'
+        '"props":{"label":"Call us","action":{"type":"open_url",'
+        '"url":"tel:+911234567890"}}}'
+    )
+    r = parse_op_line(line)
+    assert r.error is None
+    assert r.op["props"]["action"]["url"].startswith("tel:")
+
+
+def test_parse_button_javascript_scheme_still_drops():
+    line = (
+        '{"op":"add","id":"b1","type":"Button","parent":"root",'
+        '"props":{"label":"x","action":{"type":"open_url",'
+        '"url":"javascript:alert(1)"}}}'
+    )
+    r = parse_op_line(line)
+    assert r.op is None
+    assert r.error and r.error.startswith("props_validation_failed")
+
+
+def test_parse_validation_error_reason_names_failing_field():
+    """Drop reasons must carry the type + field path so [CHAT_METRICS]
+    drop_reasons is diagnosable without payload access."""
+    line = (
+        '{"op":"add","id":"t1","type":"Tag","parent":"root",'
+        '"props":{"text":"new","weight":"bold"}}'
+    )
+    r = parse_op_line(line)
+    assert r.op is None
+    assert r.error.startswith("props_validation_failed:Tag:")
+    assert "weight" in r.error
+    # Structural only — the offending input value never appears.
+    assert "bold" not in r.error
+
+
+# ---------------------------------------------------------------------------
+# Drop funnel — ui_op_dropped carries evidence; healer drops join the funnel
+# ---------------------------------------------------------------------------
+
+
+def test_validator_drop_event_carries_raw_line():
+    line = (
+        '{"op":"add","id":"b1","type":"Button","parent":"root",'
+        '"props":{"label":"x","action":{"type":"open_url","url":"ftp://no"}}}'
+    )
+    dropped = [e for e in process_op_line(line) if e.event == "ui_op_dropped"]
+    assert len(dropped) == 1
+    assert dropped[0].data["raw"] == line
+    assert dropped[0].data["op"] == {"op": "add", "id": "b1", "type": "Button"}
+    assert dropped[0].data["reason"].startswith("props_validation_failed:Button:")
+
+
+def test_healer_drop_emits_ui_op_dropped_not_healer_applied():
+    """Healer drops must land in the SAME funnel counter as validator drops —
+    they were previously invisible in ui_dropped."""
+    from app.ai.voice.agents.breeze_buddy.chat.ui_healer import (
+        HealerContext,
+        make_healer_fn,
+    )
+
+    ctx = HealerContext(session_data={}, known_ids={"root"})
+    line = '{"op":"add","id":"x","type":"NotARealPrimitive","parent":"root"}'
+    events = process_op_line(line, healer=make_healer_fn(ctx), known_ids={"root"})
+    names = [e.event for e in events]
+    assert "ui_op_dropped" in names
+    assert "healer_applied" not in names
+    drop = next(e for e in events if e.event == "ui_op_dropped")
+    assert drop.data["reason"].startswith("dropped_unknown_type")
+    assert drop.data["raw"] == line
+
+
+def test_healer_repair_note_still_emits_healer_applied():
+    from app.ai.voice.agents.breeze_buddy.chat.ui_healer import (
+        HealerContext,
+        make_healer_fn,
+    )
+
+    ctx = HealerContext(session_data={}, known_ids={"root"})
+    line = '{"op":"add","id":"t","type":"Tag","parent":"root","props":{"label":"hi"}}'
+    events = process_op_line(line, healer=make_healer_fn(ctx), known_ids={"root"})
+    names = [e.event for e in events]
+    assert "healer_applied" in names
+    assert "ui_op" in names
+    assert "ui_op_dropped" not in names
+
+
+def test_turn_metrics_collects_drop_details_but_logs_stay_structural():
+    from app.ai.voice.agents.breeze_buddy.chat.metrics import TurnMetrics
+    from app.ai.voice.agents.breeze_buddy.chat.ui_stream import ui_op_dropped_event
+
+    line = (
+        '{"op":"add","id":"email_btn","type":"Button","parent":"root",'
+        '"props":{"label":"Email us","action":{"type":"open_url",'
+        '"url":"mailto:x@y.com"}}}'
+    )
+    tm = TurnMetrics(session_id="s", template_id="t", t0=0.0)
+    tm.observe(ui_op_dropped_event(line, "props_validation_failed:Button:action"))
+    assert tm.ui_dropped == 1
+    assert len(tm.drops) == 1
+    assert tm.drops[0]["sig"] == {"op": "add", "id": "email_btn", "type": "Button"}
+    assert tm.drops[0]["raw"] == line
+    # The log line must never carry the raw payload.
+    assert "mailto" not in ";".join(tm.drop_reasons)


### PR DESCRIPTION
## Problem

Real traffic (Amirandsons fleet template `9c6e7f0c…`) showed ~1 dropped UI op per turn for days — 35 of 36 dropped turns in the sweep were the same class: the agent says *"I've put the button below for you"*, emits a `Button` with `action.open_url.url = "mailto:…"`, and the op dies in validation because `OpenUrlAction.url` was `HttpUrl` (http/https only). The customer never sees the CTA. Two compounding observability gaps: the drop reason logged only `ValidationError` (no field), and the dropped payload survived nowhere — diagnosis required log archaeology + transcript inference.

## Fixes

**Rendering**
- Recover bare SpecStream op-lines emitted without the `<ui_stream>` wrapper (original scope of this PR)
- `ui_catalog`: `OpenUrlAction.url` accepts `http`/`https`/`mailto`/`tel`; `javascript:`/`data:` still rejected; `Image.src`/`Icon.url` remain http-only
- `ui_healer`: infer a missing `"op"` discriminator on add-shaped lines (the `unknown_op:None` class)

**Drop funnel observability**
- Structured drop reasons: `props_validation_failed:Button:action.OpenUrlAction.url:url_scheme` instead of a bare exception class name — field paths + error kinds only, never input values
- Healer drops now emit `ui_op_dropped` (previously invisible in the `ui_dropped` counter)
- **Migration 041**: persist per-drop evidence `{sig, reason, raw}` to `chat_turn_metrics.drops`, exposed on the transcript API — the dashboard's `dropped` chip can show *what* dropped and why. `raw` is transcript-class content (same session FK / cascade delete / access path as `chat_message`); log lines stay structural-only.

## Tests
128 passing across `test_ui_stream` / `test_ui_healer` / `test_voice_ui_stream` / `test_compact_wire_form` / `test_ui_catalog_groups`, including new coverage: mailto/tel validate, `javascript:` still drops, drop reasons name the failing field (and never echo values), healer drops join the funnel, `TurnMetrics` collects drop evidence while the `[CHAT_METRICS]` log stays structural.

Companion loom PR renders the drop evidence in the conversations log detail and routes `mailto:`/`tel:` through `location.href` in the widget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AFyUPCEEeKe5hsdMmy4j8k