### PR TITLE
fix(breeze_buddy): guard handle_call_completion against duplicate finished-lead callbacks

### DIFF
--- a/app/ai/voice/agents/breeze_buddy/managers/calls.py
+++ b/app/ai/voice/agents/breeze_buddy/managers/calls.py
@@ -498,6 +498,15 @@ async def handle_call_completion(
         await raise_orphan_webhook(call_id=call_id, source="call_completion")
         return
 
+    # Guard: if a concurrent callback already finished this lead, skip to avoid
+    # redundant DB updates, redundant outbound number releases, and duplicate
+    # retry scheduling caused by racing completion callbacks for the same lead.
+    if lead.status == LeadCallStatus.FINISHED:
+        logger.info(
+            f"Lead {lead.id} is already FINISHED for call_id: {call_id}, skipping duplicate completion callback."
+        )
+        return lead
+
     # Always release outbound number (including transfers — bot leaves, cleanup happens here)
     if lead.outbound_number_id:
         outbound_number = await get_outbound_number_by_id(lead.outbound_number_id)


### PR DESCRIPTION
## Summary
Adds a status guard in `handle_call_completion` (`app/ai/voice/agents/breeze_buddy/managers/calls.py`), placed immediately after the lead lookup. If `lead.status == LeadCallStatus.FINISHED`, the function logs an info message and returns the lead immediately, short-circuiting before:
- redundant DB updates
- redundant outbound number releases
- duplicate retry scheduling

This resolves DB row-locking and contention issues seen during concurrent call completion callbacks for the same lead (racing webhooks/callbacks arriving independently for a lead that has already been marked FINISHED).

## Files changed
- `app/ai/voice/agents/breeze_buddy/managers/calls.py` — added early-return guard in `handle_call_completion`

## Verification
- `uv run black --check .` — pass
- `uv run isort . --profile black --check-only` — pass
- `uv run pyrefly check` — pass (no new errors introduced)

## Note for reviewer
This branch currently has 2 commits ahead of `release`: an empty auto-generated `chore: start tara task ...` commit created when the branch was provisioned, and this fix commit. Per repo convention, PRs must contain exactly 1 commit (enforced in CI) — squashing would require a force-push, which is outside this automation's permitted actions. Please squash-merge, or let me know if you'd like the branch squashed before merge.

## Discussion
Original Slack thread: https://slack.com/archives/C09ST3HSDT6/p1784636128369249


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate call-completion processing when multiple completion events occur simultaneously.
  * Avoided redundant updates, number releases, and retry scheduling for already completed calls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->