### PR TITLE
feat(stt): realtime transcription over WebSocket

### DIFF
--- a/app/ai/voice/stt/streaming.py
+++ b/app/ai/voice/stt/streaming.py
@@ -1,0 +1,148 @@
+"""Realtime (streaming) speech-to-text.
+
+Counterpart to :mod:`transcribe` (one-shot clips): this module drives the same
+*streaming* Pipecat STT services the voice pipeline uses, but without a full
+agent pipeline. A :class:`StreamingTranscriber` wraps a minimal two-node
+pipeline — provider STT service → transcript emitter — is fed raw PCM16 mono
+audio chunks, and reports interim/final transcripts through an async callback
+as the provider produces them.
+
+Only continuously-streaming services work here (Soniox, Deepgram, Sarvam,
+Google). Segmented services (OpenAI Whisper) need VAD frames that this
+minimal pipeline does not produce.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from typing import Awaitable, Callable, Optional
+
+from pipecat.frames.frames import (
+    Frame,
+    InputAudioRawFrame,
+    InterimTranscriptionFrame,
+    TranscriptionFrame,
+)
+from pipecat.pipeline.pipeline import Pipeline
+from pipecat.pipeline.runner import PipelineRunner
+from pipecat.pipeline.task import PipelineParams, PipelineTask
+from pipecat.processors.frame_processor import FrameDirection, FrameProcessor
+
+from app.core.logger import logger
+
+__all__ = ["StreamingTranscriber", "TranscriptEvent"]
+
+_STOP_TIMEOUT_SECONDS = 5.0
+
+
+@dataclass
+class TranscriptEvent:
+    """A single interim or final transcript produced during a stream."""
+
+    text: str
+    is_final: bool
+    language: Optional[str] = None
+
+
+TranscriptCallback = Callable[[TranscriptEvent], Awaitable[None]]
+
+
+class _TranscriptEmitter(FrameProcessor):
+    """Sink forwarding interim/final transcription frames to a callback.
+
+    Callback errors are logged and swallowed so a slow or broken consumer can
+    never wedge the STT service's frame loop.
+    """
+
+    def __init__(self, on_transcript: TranscriptCallback, **kwargs):
+        super().__init__(**kwargs)
+        self._on_transcript = on_transcript
+
+    async def process_frame(self, frame: Frame, direction: FrameDirection):
+        await super().process_frame(frame, direction)
+
+        if direction == FrameDirection.DOWNSTREAM:
+            event: Optional[TranscriptEvent] = None
+            if isinstance(frame, InterimTranscriptionFrame) and frame.text:
+                event = TranscriptEvent(
+                    text=frame.text,
+                    is_final=False,
+                    language=str(frame.language) if frame.language else None,
+                )
+            elif isinstance(frame, TranscriptionFrame) and frame.text:
+                event = TranscriptEvent(
+                    text=frame.text,
+                    is_final=True,
+                    language=str(frame.language) if frame.language else None,
+                )
+            if event is not None:
+                try:
+                    await self._on_transcript(event)
+                except Exception as e:
+                    logger.warning("transcript callback failed: {}", e)
+
+        await self.push_frame(frame, direction)
+
+
+class StreamingTranscriber:
+    """Feeds raw PCM16 mono audio to a streaming STT service.
+
+    Usage: ``await start()``, then ``await feed(chunk)`` for each audio chunk;
+    transcripts arrive on ``on_transcript`` as the provider emits them.
+    ``await stop()`` flushes and tears down (safe to call more than once).
+    """
+
+    def __init__(
+        self,
+        stt_service,
+        *,
+        sample_rate: int,
+        on_transcript: TranscriptCallback,
+    ):
+        self._sample_rate = sample_rate
+        pipeline = Pipeline([stt_service, _TranscriptEmitter(on_transcript)])
+        # cancel_on_idle_timeout=False: the default idle watchdog waits for
+        # bot/user speaking frames that never occur in this two-node pipeline
+        # and would cancel a healthy stream mid-way.
+        self._task = PipelineTask(
+            pipeline,
+            params=PipelineParams(audio_in_sample_rate=sample_rate),
+            cancel_on_idle_timeout=False,
+        )
+        self._runner = PipelineRunner(handle_sigint=False, force_gc=True)
+        self._run_future: Optional[asyncio.Task] = None
+
+    async def start(self) -> None:
+        """Start the pipeline (connects the provider websocket)."""
+        self._run_future = asyncio.create_task(self._runner.run(self._task))
+
+    async def feed(self, audio: bytes) -> None:
+        """Queue one chunk of raw PCM16 mono audio for transcription."""
+        if not audio:
+            return
+        await self._task.queue_frame(
+            InputAudioRawFrame(
+                audio=audio,
+                sample_rate=self._sample_rate,
+                num_channels=1,
+            )
+        )
+
+    async def stop(self) -> None:
+        """Flush pending audio, wait for final transcripts, tear down."""
+        if self._run_future is None:
+            return
+        run_future, self._run_future = self._run_future, None
+        try:
+            await self._task.stop_when_done()
+            await asyncio.wait_for(run_future, timeout=_STOP_TIMEOUT_SECONDS)
+        except asyncio.TimeoutError:
+            logger.warning("streaming STT did not stop gracefully; cancelling")
+            await self._task.cancel()
+            try:
+                await run_future
+            except Exception:
+                pass
+        except Exception as e:
+            logger.warning("streaming STT stop error: {}", e)

--- a/app/api/routers/breeze_buddy/stt/__init__.py
+++ b/app/api/routers/breeze_buddy/stt/__init__.py
@@ -3,23 +3,25 @@
 Routes under ``/agent/voice/breeze-buddy/stt``:
 
 - ``POST /transcribe``   one-shot audio-clip -> transcript
+- ``WS /stream``         realtime audio stream -> partial/final transcripts
 
 Unlike the widget push-to-talk route (``/widget/session/{id}/transcribe``),
-this endpoint is bound to no widget session and no template: the caller passes
-the STT ``provider`` and (optionally) ``model``/``language`` directly. It sits
-behind the standard RBAC bearer auth, so both interactive dashboard users and
-machine (S2S) callers can reach it.
+these endpoints are bound to no widget session and no template: the caller
+passes the STT ``provider`` and (optionally) ``model``/``language`` directly.
+Both sit behind the standard RBAC bearer auth, so interactive dashboard users
+and machine (S2S) callers can reach them (the WebSocket accepts the token via
+``Authorization`` header or ``?token=`` query param).
 """
 
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, File, Form, UploadFile
+from fastapi import APIRouter, Depends, File, Form, UploadFile, WebSocket
 
 from app.api.security.breeze_buddy.rbac_token import get_current_user_with_rbac
 from app.schemas import UserInfo
 from app.schemas.breeze_buddy.stt import TranscriptionRequest, TranscriptionResponse
 
-from .handlers import handle_transcription_request
+from .handlers import handle_transcription_request, handle_transcription_stream
 
 router = APIRouter(prefix="/stt", tags=["stt"])
 
@@ -42,6 +44,16 @@ async def transcribe(
     actually produced the text (OpenAI Whisper when the core falls back).
     """
     return await handle_transcription_request(audio, request, current_user)
+
+
+@router.websocket("/stream")
+async def transcribe_stream(ws: WebSocket) -> None:
+    """Realtime speech-to-text: stream PCM16 audio in, get transcripts out.
+
+    See :func:`handle_transcription_stream` for the message protocol
+    (auth -> JSON config -> binary audio -> partial/final events -> stop).
+    """
+    await handle_transcription_stream(ws)
 
 
 __all__ = ["router"]

--- a/app/api/routers/breeze_buddy/stt/handlers.py
+++ b/app/api/routers/breeze_buddy/stt/handlers.py
@@ -1,12 +1,48 @@
 """Handlers for the standalone (template-independent) STT endpoints."""
 
-from fastapi import HTTPException, UploadFile, status
+import asyncio
+import json
+import time
 
+from fastapi import HTTPException, UploadFile, WebSocket, WebSocketDisconnect, status
+from pydantic import ValidationError
+
+from app.ai.voice.agents.breeze_buddy.stt import create_stt_from_config
+from app.ai.voice.agents.breeze_buddy.template.types import (
+    DeepgramSTTConfig,
+    SarvamSTTConfig,
+    SonioxSTTConfig,
+    STTConfiguration,
+    STTProvider,
+)
+from app.ai.voice.agents.breeze_buddy.utils.transport.websockets import (
+    close_websocket_safely,
+    send_message,
+)
 from app.ai.voice.stt import TranscriptionError, transcribe_audio
-from app.core.config.dynamic import STT_MAX_AUDIO_BYTES
+from app.ai.voice.stt.streaming import StreamingTranscriber, TranscriptEvent
+from app.api.security.breeze_buddy.rbac_token import get_user_from_websocket
+from app.core.config.dynamic import (
+    STT_MAX_AUDIO_BYTES,
+    STT_STREAM_IDLE_TIMEOUT_SECONDS,
+    STT_STREAM_MAX_SECONDS,
+)
+from app.core.config.static import SAMPLE_RATE
 from app.core.logger import logger
 from app.schemas import UserInfo
-from app.schemas.breeze_buddy.stt import TranscriptionRequest, TranscriptionResponse
+from app.schemas.breeze_buddy.stt import (
+    TranscriptionRequest,
+    TranscriptionResponse,
+    TranscriptionStreamRequest,
+)
+
+# Seconds the client gets to send the JSON config message after connecting.
+_STREAM_CONFIG_TIMEOUT_SECONDS = 10.0
+
+# Application close codes (4xxx range is free for applications).
+_WS_BAD_REQUEST = 4400
+_WS_UNAUTHORIZED = 4401
+_WS_TIMEOUT = 4408
 
 
 async def handle_transcription_request(
@@ -67,3 +103,198 @@ async def handle_transcription_request(
     return TranscriptionResponse(
         text=result.text, provider=result.provider, model=result.model
     )
+
+
+def _stream_configuration(request: TranscriptionStreamRequest) -> STTConfiguration:
+    """Map the stream config message onto the template ``STTConfiguration``."""
+    model = request.model
+    provider = request.provider
+    return STTConfiguration(
+        provider=provider,
+        language=request.language,
+        soniox=(
+            SonioxSTTConfig(model=model)
+            if provider == STTProvider.SONIOX and model
+            else None
+        ),
+        deepgram=(
+            DeepgramSTTConfig(model=model)
+            if provider == STTProvider.DEEPGRAM and model
+            else None
+        ),
+        sarvam=(
+            SarvamSTTConfig(model=model)
+            if provider == STTProvider.SARVAM and model
+            else None
+        ),
+    )
+
+
+async def _reject_stream(ws: WebSocket, code: int, message: str, reason: str) -> None:
+    """Send a final error event and close the stream."""
+    await send_message(ws, {"type": "error", "message": message})
+    await close_websocket_safely(ws, code=code, reason=reason)
+
+
+async def handle_transcription_stream(ws: WebSocket) -> None:
+    """Realtime speech-to-text over WebSocket.
+
+    Protocol:
+
+    1. Client connects with the RBAC bearer token (``Authorization`` header or
+       ``?token=`` query param).
+    2. Client sends one JSON text message — :class:`TranscriptionStreamRequest`
+       (``provider``, optional ``model``/``language``/``sample_rate``).
+    3. Server replies ``{"type": "ready"}``, then the client streams binary
+       frames of raw PCM16 mono audio at ``sample_rate``.
+    4. Server pushes ``{"type": "partial" | "final", "text", "language"}``
+       events as the provider produces them.
+    5. Client sends ``{"type": "stop"}`` (or disconnects) to end; the server
+       flushes remaining finals and closes.
+
+    Streams are bounded by ``STT_STREAM_MAX_SECONDS`` and
+    ``STT_STREAM_IDLE_TIMEOUT_SECONDS`` (both dynamic config).
+    """
+    await ws.accept()
+
+    try:
+        user = get_user_from_websocket(ws)
+    except HTTPException as e:
+        await _reject_stream(ws, _WS_UNAUTHORIZED, str(e.detail), "unauthorized")
+        return
+
+    try:
+        raw_config = await asyncio.wait_for(
+            ws.receive_text(), timeout=_STREAM_CONFIG_TIMEOUT_SECONDS
+        )
+    except (WebSocketDisconnect, asyncio.TimeoutError):
+        await close_websocket_safely(ws, code=_WS_BAD_REQUEST, reason="no config")
+        return
+
+    try:
+        request = TranscriptionStreamRequest.model_validate_json(raw_config)
+    except ValidationError as e:
+        await _reject_stream(
+            ws, _WS_BAD_REQUEST, f"Invalid stream config: {e}", "invalid config"
+        )
+        return
+
+    if request.provider == STTProvider.OPENAI:
+        await _reject_stream(
+            ws,
+            _WS_BAD_REQUEST,
+            "openai has no realtime streaming path; use POST /stt/transcribe",
+            "unsupported provider",
+        )
+        return
+    if request.provider == STTProvider.GOOGLE and request.model:
+        await _reject_stream(
+            ws,
+            _WS_BAD_REQUEST,
+            "model override is not supported for google streams",
+            "invalid config",
+        )
+        return
+    if request.provider == STTProvider.SARVAM and request.sample_rate != SAMPLE_RATE:
+        await _reject_stream(
+            ws,
+            _WS_BAD_REQUEST,
+            f"sarvam streams require sample_rate={SAMPLE_RATE}",
+            "invalid config",
+        )
+        return
+
+    try:
+        stt_service = await create_stt_from_config(_stream_configuration(request))
+    except ValueError as e:
+        await _reject_stream(ws, _WS_BAD_REQUEST, str(e), "provider unavailable")
+        return
+
+    async def _forward(event: TranscriptEvent) -> None:
+        await send_message(
+            ws,
+            {
+                "type": "final" if event.is_final else "partial",
+                "text": event.text,
+                "language": event.language,
+            },
+        )
+
+    transcriber = StreamingTranscriber(
+        stt_service, sample_rate=request.sample_rate, on_transcript=_forward
+    )
+    max_seconds = await STT_STREAM_MAX_SECONDS()
+    idle_timeout = await STT_STREAM_IDLE_TIMEOUT_SECONDS()
+
+    await transcriber.start()
+    await send_message(ws, {"type": "ready"})
+    logger.info(
+        "stt stream started (provider={}, user={}, sample_rate={})",
+        request.provider.value,
+        user.id,
+        request.sample_rate,
+    )
+
+    close_code, close_reason = 1000, "done"
+    deadline = time.monotonic() + max_seconds
+    try:
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                await send_message(
+                    ws,
+                    {
+                        "type": "error",
+                        "message": f"stream exceeded the {max_seconds}s limit",
+                    },
+                )
+                close_code, close_reason = _WS_TIMEOUT, "max duration exceeded"
+                break
+
+            try:
+                message = await asyncio.wait_for(
+                    ws.receive(), timeout=min(float(idle_timeout), remaining)
+                )
+            except asyncio.TimeoutError:
+                if deadline - time.monotonic() <= 0:
+                    detail = f"stream exceeded the {max_seconds}s limit"
+                    close_reason = "max duration exceeded"
+                else:
+                    detail = f"no client data for {idle_timeout}s"
+                    close_reason = "idle timeout"
+                await send_message(ws, {"type": "error", "message": detail})
+                close_code = _WS_TIMEOUT
+                break
+
+            if message["type"] == "websocket.disconnect":
+                close_code, close_reason = 1000, "client disconnected"
+                break
+
+            audio = message.get("bytes")
+            if audio:
+                await transcriber.feed(audio)
+                continue
+
+            text = message.get("text")
+            if not text:
+                continue
+            try:
+                control = json.loads(text)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(control, dict) and control.get("type") == "stop":
+                break
+    except Exception as e:
+        logger.error(
+            "stt stream failed (provider={}, user={}): {}",
+            request.provider.value,
+            user.id,
+            e,
+        )
+        await send_message(ws, {"type": "error", "message": "Internal stream error"})
+        close_code, close_reason = 1011, "internal error"
+    finally:
+        # stop() flushes the provider's trailing finals through _forward
+        # before the socket closes.
+        await transcriber.stop()
+        await close_websocket_safely(ws, code=close_code, reason=close_reason)

--- a/app/api/security/breeze_buddy/rbac_token.py
+++ b/app/api/security/breeze_buddy/rbac_token.py
@@ -7,7 +7,7 @@ from datetime import timedelta
 from typing import List, Optional
 
 import jwt as pyjwt
-from fastapi import Depends, HTTPException, status
+from fastapi import Depends, HTTPException, WebSocket, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 
 from app.core.logger import logger
@@ -264,6 +264,32 @@ async def get_current_user_with_rbac(
         )
 
     return rbac_token_manager.verify_rbac_token(credentials.credentials)
+
+
+def get_user_from_websocket(websocket: WebSocket) -> UserInfo:
+    """Authenticate a WebSocket connection with the standard RBAC bearer token.
+
+    The FastAPI ``Depends(HTTPBearer())`` guards are HTTP-only, so WebSocket
+    routes call this directly after ``accept()``. Token sources, in order:
+    the ``Authorization: Bearer`` header, then a ``token`` query parameter
+    (browser WebSocket clients cannot set headers).
+
+    Raises:
+        HTTPException: 401 when the token is missing or invalid — callers
+        translate this into a WebSocket close.
+    """
+    auth_header = websocket.headers.get("authorization") or ""
+    token = ""
+    if auth_header.lower().startswith("bearer "):
+        token = auth_header[len("bearer ") :].strip()
+    if not token:
+        token = (websocket.query_params.get("token") or "").strip()
+    if not token:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Missing credentials",
+        )
+    return rbac_token_manager.verify_rbac_token(token)
 
 
 async def get_active_user(

--- a/app/core/config/dynamic.py
+++ b/app/core/config/dynamic.py
@@ -224,6 +224,20 @@ async def STT_MAX_AUDIO_BYTES() -> int:
     return await get_config("STT_MAX_AUDIO_BYTES", 10 * 1024 * 1024, int)
 
 
+async def STT_STREAM_MAX_SECONDS() -> int:
+    """Hard cap on a single realtime transcription stream
+    (``WS /stt/stream``). Bounds provider websocket cost per connection;
+    long-running use cases should reconnect."""
+    return await get_config("STT_STREAM_MAX_SECONDS", 300, int)
+
+
+async def STT_STREAM_IDLE_TIMEOUT_SECONDS() -> int:
+    """Close a realtime transcription stream when the client sends nothing
+    (no audio, no control message) for this long. Keeps abandoned
+    connections from holding provider websockets open."""
+    return await get_config("STT_STREAM_IDLE_TIMEOUT_SECONDS", 60, int)
+
+
 async def SONIOX_ASYNC_MODEL() -> str:
     """Soniox async/file model for one-shot (push-to-talk) transcription.
 

--- a/app/schemas/breeze_buddy/stt.py
+++ b/app/schemas/breeze_buddy/stt.py
@@ -1,8 +1,8 @@
 """Schemas for the standalone (template-independent) STT endpoints."""
 
-from typing import Optional
+from typing import List, Optional, Union
 
-from pydantic import BaseModel, field_validator
+from pydantic import BaseModel, Field, field_validator
 
 from app.ai.voice.agents.breeze_buddy.template.types import STTProvider
 
@@ -31,6 +31,50 @@ class TranscriptionRequest(BaseModel):
     def _blank_to_none(cls, value: object) -> object:
         if isinstance(value, str):
             return value.strip() or None
+        return value
+
+
+class TranscriptionStreamRequest(BaseModel):
+    """First (JSON text) message on ``WS /agent/voice/breeze-buddy/stt/stream``.
+
+    After this message the client sends binary frames of raw PCM16 mono audio
+    at ``sample_rate``. ``language`` accepts a single code or a list (list is
+    provider-dependent, e.g. Soniox hints). OpenAI has no realtime streaming
+    path and is rejected; Sarvam streams are pinned to the platform rate.
+    """
+
+    provider: STTProvider
+    model: Optional[str] = None
+    language: Optional[Union[str, List[str]]] = None
+    sample_rate: int = Field(
+        16000,
+        ge=8000,
+        le=48000,
+        description="Sample rate (Hz) of the PCM16 mono audio frames.",
+    )
+
+    @field_validator("provider", mode="before")
+    @classmethod
+    def _normalize_provider(cls, value: object) -> object:
+        if isinstance(value, str):
+            return value.strip().lower()
+        return value
+
+    @field_validator("model", mode="before")
+    @classmethod
+    def _blank_to_none(cls, value: object) -> object:
+        if isinstance(value, str):
+            return value.strip() or None
+        return value
+
+    @field_validator("language", mode="before")
+    @classmethod
+    def _blank_language_to_none(cls, value: object) -> object:
+        if isinstance(value, str):
+            return value.strip() or None
+        if isinstance(value, list):
+            cleaned = [v.strip() for v in value if isinstance(v, str) and v.strip()]
+            return cleaned or None
         return value
 
 

--- a/tests/test_stt_stream.py
+++ b/tests/test_stt_stream.py
@@ -1,0 +1,136 @@
+"""Tests for the realtime STT stream: schema, WS auth shim, protocol edges."""
+
+import json
+from types import SimpleNamespace
+from typing import cast
+
+import pytest
+from fastapi import HTTPException, WebSocket
+
+from app.api.routers.breeze_buddy.stt import handlers
+from app.api.security.breeze_buddy import rbac_token
+from app.schemas import UserInfo
+from app.schemas.breeze_buddy.auth import UserRole
+from app.schemas.breeze_buddy.stt import TranscriptionStreamRequest
+
+_USER = UserInfo(id="user-1", username="tester", role=UserRole.ADMIN)
+
+
+class FakeWebSocket:
+    """Minimal stand-in implementing the surface the stream handler uses."""
+
+    def __init__(
+        self,
+        config_text: str,
+        headers: dict | None = None,
+        query: dict | None = None,
+    ):
+        self._config_text = config_text
+        self.headers = headers or {}
+        self.query_params = query or {}
+        self.sent: list[dict] = []
+        self.closed: tuple[int, str] | None = None
+        self.accepted = False
+        self.client_state = SimpleNamespace(name="CONNECTED")
+
+    async def accept(self) -> None:
+        self.accepted = True
+
+    async def receive_text(self) -> str:
+        return self._config_text
+
+    async def send_text(self, text: str) -> None:
+        self.sent.append(json.loads(text))
+
+    async def close(self, code: int = 1000, reason: str = "") -> None:
+        self.closed = (code, reason)
+        self.client_state = SimpleNamespace(name="DISCONNECTED")
+
+
+def as_ws(fake: FakeWebSocket) -> WebSocket:
+    return cast(WebSocket, fake)
+
+
+def test_stream_request_normalizes_and_bounds() -> None:
+    request = TranscriptionStreamRequest.model_validate(
+        {"provider": " SONIOX ", "model": "  ", "language": ["en", " ", "hi "]}
+    )
+    assert request.provider.value == "soniox"
+    assert request.model is None
+    assert request.language == ["en", "hi"]
+    assert request.sample_rate == 16000
+
+    with pytest.raises(ValueError):
+        TranscriptionStreamRequest.model_validate(
+            {"provider": "soniox", "sample_rate": 4000}
+        )
+
+
+def test_websocket_auth_reads_header_then_query(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    seen: list[str] = []
+    monkeypatch.setattr(
+        rbac_token.rbac_token_manager,
+        "verify_rbac_token",
+        lambda token: seen.append(token) or _USER,
+    )
+
+    ws = FakeWebSocket("", headers={"authorization": "Bearer header-token"})
+    assert rbac_token.get_user_from_websocket(as_ws(ws)) is _USER
+
+    ws = FakeWebSocket("", query={"token": "query-token"})
+    assert rbac_token.get_user_from_websocket(as_ws(ws)) is _USER
+    assert seen == ["header-token", "query-token"]
+
+    with pytest.raises(HTTPException):
+        rbac_token.get_user_from_websocket(as_ws(FakeWebSocket("")))
+
+
+async def test_stream_rejects_unauthenticated(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    ws = FakeWebSocket("{}")
+    await handlers.handle_transcription_stream(as_ws(ws))
+
+    assert ws.accepted
+    assert ws.sent[-1]["type"] == "error"
+    assert ws.closed is not None and ws.closed[0] == 4401
+
+
+async def test_stream_rejects_invalid_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(handlers, "get_user_from_websocket", lambda ws: _USER)
+
+    ws = FakeWebSocket(json.dumps({"provider": "not-a-provider"}))
+    await handlers.handle_transcription_stream(as_ws(ws))
+
+    assert ws.sent[-1]["type"] == "error"
+    assert ws.closed is not None and ws.closed[0] == 4400
+
+
+async def test_stream_rejects_openai_provider(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(handlers, "get_user_from_websocket", lambda ws: _USER)
+
+    ws = FakeWebSocket(json.dumps({"provider": "openai"}))
+    await handlers.handle_transcription_stream(as_ws(ws))
+
+    assert ws.sent[-1]["type"] == "error"
+    assert "realtime" in ws.sent[-1]["message"]
+    assert ws.closed is not None and ws.closed[0] == 4400
+
+
+async def test_stream_rejects_sarvam_sample_rate_mismatch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(handlers, "get_user_from_websocket", lambda ws: _USER)
+
+    ws = FakeWebSocket(json.dumps({"provider": "sarvam", "sample_rate": 8000}))
+    await handlers.handle_transcription_stream(as_ws(ws))
+
+    assert ws.sent[-1]["type"] == "error"
+    assert "sample_rate" in ws.sent[-1]["message"]
+    assert ws.closed is not None and ws.closed[0] == 4400


### PR DESCRIPTION
Second follow-up to #872 (after #940): adds realtime streaming transcription alongside the one-shot endpoint. Recording/usage-metering intentionally deferred per earlier discussion.

## What this adds

**`WS /agent/voice/breeze-buddy/stt/stream`** — template- and session-independent realtime STT:

1. Client connects with the standard RBAC bearer token — `Authorization` header or `?token=` query param (browser `WebSocket` cannot set headers).
2. Sends one JSON config message: `{"provider": "soniox", "model": null, "language": "en" | ["en","hi"], "sample_rate": 16000}`.
3. Server replies `{"type": "ready"}`; client streams binary frames of raw PCM16 mono audio.
4. Server pushes `{"type": "partial" | "final", "text", "language"}` events live as the provider emits them.
5. `{"type": "stop"}` (or disconnect) ends the stream; trailing finals are flushed before close.

## How it works

- **`StreamingTranscriber`** (`app/ai/voice/stt/streaming.py`): reuses the *same* streaming Pipecat STT services the voice pipeline uses (via `create_stt_from_config`) in a minimal two-node pipeline — provider service → transcript-emitter sink — fed by `PipelineTask.queue_frame(InputAudioRawFrame)`. Graceful teardown via `stop_when_done()` (flushes provider finals) with a cancel fallback; `cancel_on_idle_timeout=False` because the default watchdog waits for bot/user speaking frames that never occur here.
- **WS auth shim**: `get_user_from_websocket` in `rbac_token.py` — the `HTTPBearer` dependency is HTTP-only, so WS routes call the same `verify_rbac_token` directly. 401 → close code 4401.
- **Provider support**: soniox / deepgram / sarvam / google. `openai` is rejected with a clear error (its Whisper service is segmented and needs VAD frames). Sarvam is pinned to the platform `SAMPLE_RATE` (its builder hardcodes it); soniox/deepgram take the client's rate through `PipelineParams`. Google rejects a `model` override (no model knob in its builder).
- **Bounds** (dynamic config, tunable without deploy): `STT_STREAM_MAX_SECONDS` (default 300), `STT_STREAM_IDLE_TIMEOUT_SECONDS` (default 60), 10s config-message timeout. App close codes: 4400 bad request, 4401 unauthorized, 4408 timeout/limit.

## Tests

`tests/test_stt_stream.py` (9 total with existing handler tests, all passing): schema normalization + sample-rate bounds, WS auth via header/query/missing, and the protocol rejection paths (unauthenticated, invalid config, openai, sarvam rate mismatch) driven through a fake WebSocket. black/isort/autoflake/pyrefly clean.

Live end-to-end against real provider websockets needs API keys — verified logic paths only; recommend a staging smoke test with Soniox before rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Bj4ySkGkJ5zGdtLRbP4w4