### PR TITLE
fix(stt): harden realtime stream — startup confirmation, send-failure teardown, chunk cap

### DIFF
--- a/app/ai/voice/stt/streaming.py
+++ b/app/ai/voice/stt/streaming.py
@@ -35,6 +35,13 @@ __all__ = ["StreamingTranscriber", "TranscriptEvent"]
 
 _STOP_TIMEOUT_SECONDS = 5.0
 
+# How long start() lets the pipeline run before declaring it healthy. Provider
+# connect/auth rejections typically surface within this window (as an
+# ErrorFrame or the runner task finishing), letting callers reject the stream
+# before telling the client it is ready. Healthy streams pay this once at
+# startup.
+_STARTUP_GRACE_SECONDS = 1.0
+
 
 @dataclass
 class TranscriptEvent:
@@ -80,7 +87,9 @@ class _TranscriptEmitter(FrameProcessor):
                 try:
                     await self._on_transcript(event)
                 except Exception as e:
-                    logger.warning("transcript callback failed: {}", e)
+                    logger.warning(
+                        "transcript callback failed ({}): {}", type(e).__name__, e
+                    )
 
         await self.push_frame(frame, direction)
 
@@ -112,10 +121,57 @@ class StreamingTranscriber:
         )
         self._runner = PipelineRunner(handle_sigint=False, force_gc=True)
         self._run_future: Optional[asyncio.Task] = None
+        self._failed = asyncio.Event()
+        self._failure: Optional[str] = None
+
+        @self._task.event_handler("on_pipeline_error")
+        async def _on_pipeline_error(task, frame):
+            self._failure = getattr(frame, "error", None) or "pipeline error"
+            self._failed.set()
+            logger.warning("streaming STT pipeline error: {}", self._failure)
+
+    @property
+    def failed(self) -> bool:
+        """True once the pipeline reported an error (e.g. provider died)."""
+        return self._failed.is_set()
 
     async def start(self) -> None:
-        """Start the pipeline (connects the provider websocket)."""
+        """Start the pipeline and fail fast on provider connect/auth errors.
+
+        Waits up to ``_STARTUP_GRACE_SECONDS`` for an early failure — a
+        pipeline ``ErrorFrame`` or the runner task finishing — and raises
+        ``RuntimeError`` so callers can reject the stream cleanly *before*
+        telling the client it is ready.
+        """
         self._run_future = asyncio.create_task(self._runner.run(self._task))
+        failure_wait = asyncio.create_task(self._failed.wait())
+        try:
+            await asyncio.wait(
+                {self._run_future, failure_wait},
+                timeout=_STARTUP_GRACE_SECONDS,
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+        finally:
+            if not failure_wait.done():
+                failure_wait.cancel()
+
+        if not self._failed.is_set() and not self._run_future.done():
+            return  # healthy: pipeline is running and reported no error
+
+        message = self._failure or ""
+        if self._run_future.done():
+            exc = self._run_future.exception()
+            if exc is not None:
+                message = message or f"{type(exc).__name__}: {exc}"
+            message = message or "pipeline ended during startup"
+        else:
+            await self._task.cancel()
+            try:
+                await self._run_future
+            except Exception:
+                pass
+        self._run_future = None
+        raise RuntimeError(f"streaming STT failed to start: {message or 'unknown'}")
 
     async def feed(self, audio: bytes) -> None:
         """Queue one chunk of raw PCM16 mono audio for transcription."""
@@ -130,7 +186,12 @@ class StreamingTranscriber:
         )
 
     async def stop(self) -> None:
-        """Flush pending audio, wait for final transcripts, tear down."""
+        """Flush pending audio, wait for final transcripts, tear down.
+
+        Deliberately swallows teardown errors (logging them with type): this
+        runs on the WebSocket close path, which must never raise — a wedged
+        provider teardown should not prevent the client socket from closing.
+        """
         if self._run_future is None:
             return
         run_future, self._run_future = self._run_future, None
@@ -145,4 +206,4 @@ class StreamingTranscriber:
             except Exception:
                 pass
         except Exception as e:
-            logger.warning("streaming STT stop error: {}", e)
+            logger.warning("streaming STT stop error ({}): {}", type(e).__name__, e)

--- a/app/api/routers/breeze_buddy/stt/handlers.py
+++ b/app/api/routers/breeze_buddy/stt/handlers.py
@@ -39,6 +39,10 @@ from app.schemas.breeze_buddy.stt import (
 # Seconds the client gets to send the JSON config message after connecting.
 _STREAM_CONFIG_TIMEOUT_SECONDS = 10.0
 
+# Per-frame cap on binary audio messages. Generous for real clients (~2.5s of
+# 48kHz PCM16 mono) while bounding what one frame can buffer server-side.
+_MAX_CHUNK_BYTES = 256 * 1024
+
 # Application close codes (4xxx range is free for applications).
 _WS_BAD_REQUEST = 4400
 _WS_UNAUTHORIZED = 4401
@@ -153,7 +157,10 @@ async def handle_transcription_stream(ws: WebSocket) -> None:
        flushes remaining finals and closes.
 
     Streams are bounded by ``STT_STREAM_MAX_SECONDS`` and
-    ``STT_STREAM_IDLE_TIMEOUT_SECONDS`` (both dynamic config).
+    ``STT_STREAM_IDLE_TIMEOUT_SECONDS`` (both dynamic config); individual
+    binary frames are capped at ``_MAX_CHUNK_BYTES``. Provider startup
+    failures are rejected with close code 4400 before ``ready`` is sent;
+    provider death or client send failures mid-stream close with 1011.
     """
     await ws.accept()
 
@@ -210,8 +217,10 @@ async def handle_transcription_stream(ws: WebSocket) -> None:
         await _reject_stream(ws, _WS_BAD_REQUEST, str(e), "provider unavailable")
         return
 
+    send_failed = asyncio.Event()
+
     async def _forward(event: TranscriptEvent) -> None:
-        await send_message(
+        ok = await send_message(
             ws,
             {
                 "type": "final" if event.is_final else "partial",
@@ -219,6 +228,10 @@ async def handle_transcription_stream(ws: WebSocket) -> None:
                 "language": event.language,
             },
         )
+        if not ok:
+            # Flag for the receive loop; transcripts are being dropped, so
+            # the stream must tear down rather than keep paying the provider.
+            send_failed.set()
 
     transcriber = StreamingTranscriber(
         stt_service, sample_rate=request.sample_rate, on_transcript=_forward
@@ -226,7 +239,19 @@ async def handle_transcription_stream(ws: WebSocket) -> None:
     max_seconds = await STT_STREAM_MAX_SECONDS()
     idle_timeout = await STT_STREAM_IDLE_TIMEOUT_SECONDS()
 
-    await transcriber.start()
+    try:
+        await transcriber.start()
+    except RuntimeError as e:
+        logger.warning(
+            "stt stream provider startup failed (provider={}, user={}): {}",
+            request.provider.value,
+            user.id,
+            e,
+        )
+        await _reject_stream(
+            ws, _WS_BAD_REQUEST, "provider connection failed", "provider unavailable"
+        )
+        return
     await send_message(ws, {"type": "ready"})
     logger.info(
         "stt stream started (provider={}, user={}, sample_rate={})",
@@ -239,6 +264,16 @@ async def handle_transcription_stream(ws: WebSocket) -> None:
     deadline = time.monotonic() + max_seconds
     try:
         while True:
+            if transcriber.failed:
+                await send_message(
+                    ws, {"type": "error", "message": "provider connection lost"}
+                )
+                close_code, close_reason = 1011, "provider error"
+                break
+            if send_failed.is_set():
+                close_code, close_reason = 1011, "client send failed"
+                break
+
             remaining = deadline - time.monotonic()
             if remaining <= 0:
                 await send_message(
@@ -272,6 +307,18 @@ async def handle_transcription_stream(ws: WebSocket) -> None:
 
             audio = message.get("bytes")
             if audio:
+                if len(audio) > _MAX_CHUNK_BYTES:
+                    await send_message(
+                        ws,
+                        {
+                            "type": "error",
+                            "message": (
+                                f"audio chunk exceeds {_MAX_CHUNK_BYTES} bytes"
+                            ),
+                        },
+                    )
+                    close_code, close_reason = _WS_BAD_REQUEST, "chunk too large"
+                    break
                 await transcriber.feed(audio)
                 continue
 
@@ -285,10 +332,14 @@ async def handle_transcription_stream(ws: WebSocket) -> None:
             if isinstance(control, dict) and control.get("type") == "stop":
                 break
     except Exception as e:
-        logger.error(
-            "stt stream failed (provider={}, user={}): {}",
+        # Broad by design: this loop must reach the close path below no
+        # matter what fails; logger.exception preserves the traceback for
+        # root-cause analysis.
+        logger.exception(
+            "stt stream failed (provider={}, user={}): {}: {}",
             request.provider.value,
             user.id,
+            type(e).__name__,
             e,
         )
         await send_message(ws, {"type": "error", "message": "Internal stream error"})

--- a/tests/test_stt_stream.py
+++ b/tests/test_stt_stream.py
@@ -3,6 +3,7 @@
 import json
 from types import SimpleNamespace
 from typing import cast
+from unittest.mock import AsyncMock
 
 import pytest
 from fastapi import HTTPException, WebSocket
@@ -17,15 +18,24 @@ _USER = UserInfo(id="user-1", username="tester", role=UserRole.ADMIN)
 
 
 class FakeWebSocket:
-    """Minimal stand-in implementing the surface the stream handler uses."""
+    """Minimal stand-in implementing the surface the stream handler uses.
+
+    ``messages`` scripts what ``receive()`` yields after the config message;
+    once exhausted, a disconnect message is returned. ``fail_sends_after``
+    makes ``send_text`` raise once that many messages have been sent.
+    """
 
     def __init__(
         self,
         config_text: str,
         headers: dict | None = None,
         query: dict | None = None,
+        messages: list[dict] | None = None,
+        fail_sends_after: int | None = None,
     ):
         self._config_text = config_text
+        self._messages = list(messages or [])
+        self._fail_sends_after = fail_sends_after
         self.headers = headers or {}
         self.query_params = query or {}
         self.sent: list[dict] = []
@@ -39,7 +49,17 @@ class FakeWebSocket:
     async def receive_text(self) -> str:
         return self._config_text
 
+    async def receive(self) -> dict:
+        if self._messages:
+            return self._messages.pop(0)
+        return {"type": "websocket.disconnect"}
+
     async def send_text(self, text: str) -> None:
+        if (
+            self._fail_sends_after is not None
+            and len(self.sent) >= self._fail_sends_after
+        ):
+            raise RuntimeError("send failed")
         self.sent.append(json.loads(text))
 
     async def close(self, code: int = 1000, reason: str = "") -> None:
@@ -49,6 +69,58 @@ class FakeWebSocket:
 
 def as_ws(fake: FakeWebSocket) -> WebSocket:
     return cast(WebSocket, fake)
+
+
+class StubTranscriber:
+    """Replaces StreamingTranscriber so handler tests skip Pipecat entirely."""
+
+    def __init__(self, stt_service, *, sample_rate, on_transcript):
+        self.on_transcript = on_transcript
+        self.fed: list[bytes] = []
+        self.stopped = False
+        self.failed = False
+        self.start_error: str | None = None
+        self.emit_on_feed = False
+
+    async def start(self) -> None:
+        if self.start_error:
+            raise RuntimeError(self.start_error)
+
+    async def feed(self, audio: bytes) -> None:
+        self.fed.append(audio)
+        if self.emit_on_feed:
+            from app.ai.voice.stt.streaming import TranscriptEvent
+
+            await self.on_transcript(TranscriptEvent(text="hi", is_final=True))
+
+    async def stop(self) -> None:
+        self.stopped = True
+
+
+@pytest.fixture
+def stream_env(monkeypatch: pytest.MonkeyPatch) -> dict:
+    """Patch auth, provider factory, limits, and the transcriber."""
+    created: dict = {}
+
+    def _make(stt_service, *, sample_rate, on_transcript):
+        stub = StubTranscriber(
+            stt_service, sample_rate=sample_rate, on_transcript=on_transcript
+        )
+        created["transcriber"] = stub
+        for attr, value in created.get("presets", {}).items():
+            setattr(stub, attr, value)
+        return stub
+
+    monkeypatch.setattr(handlers, "get_user_from_websocket", lambda ws: _USER)
+    monkeypatch.setattr(
+        handlers, "create_stt_from_config", AsyncMock(return_value=object())
+    )
+    monkeypatch.setattr(handlers, "STT_STREAM_MAX_SECONDS", AsyncMock(return_value=300))
+    monkeypatch.setattr(
+        handlers, "STT_STREAM_IDLE_TIMEOUT_SECONDS", AsyncMock(return_value=60)
+    )
+    monkeypatch.setattr(handlers, "StreamingTranscriber", _make)
+    return created
 
 
 def test_stream_request_normalizes_and_bounds() -> None:
@@ -87,9 +159,7 @@ def test_websocket_auth_reads_header_then_query(
         rbac_token.get_user_from_websocket(as_ws(FakeWebSocket("")))
 
 
-async def test_stream_rejects_unauthenticated(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+async def test_stream_rejects_unauthenticated() -> None:
     ws = FakeWebSocket("{}")
     await handlers.handle_transcription_stream(as_ws(ws))
 
@@ -134,3 +204,69 @@ async def test_stream_rejects_sarvam_sample_rate_mismatch(
     assert ws.sent[-1]["type"] == "error"
     assert "sample_rate" in ws.sent[-1]["message"]
     assert ws.closed is not None and ws.closed[0] == 4400
+
+
+async def test_stream_rejects_provider_startup_failure(stream_env: dict) -> None:
+    stream_env["presets"] = {"start_error": "connect refused"}
+
+    ws = FakeWebSocket(json.dumps({"provider": "soniox"}))
+    await handlers.handle_transcription_stream(as_ws(ws))
+
+    assert all(event["type"] != "ready" for event in ws.sent)
+    assert ws.sent[-1]["type"] == "error"
+    assert "provider connection failed" in ws.sent[-1]["message"]
+    assert ws.closed is not None and ws.closed[0] == 4400
+
+
+async def test_stream_rejects_oversized_chunk(stream_env: dict) -> None:
+    big = b"x" * (handlers._MAX_CHUNK_BYTES + 1)
+    ws = FakeWebSocket(
+        json.dumps({"provider": "soniox"}),
+        messages=[{"type": "websocket.receive", "bytes": big}],
+    )
+    await handlers.handle_transcription_stream(as_ws(ws))
+
+    assert stream_env["transcriber"].fed == []
+    assert stream_env["transcriber"].stopped
+    assert ws.sent[-1]["type"] == "error"
+    assert "chunk exceeds" in ws.sent[-1]["message"]
+    assert ws.closed is not None and ws.closed[0] == 4400
+
+
+async def test_stream_feeds_audio_and_forwards_transcripts(stream_env: dict) -> None:
+    stream_env["presets"] = {"emit_on_feed": True}
+    chunk = b"\x00\x01" * 100
+    ws = FakeWebSocket(
+        json.dumps({"provider": "soniox"}),
+        messages=[
+            {"type": "websocket.receive", "bytes": chunk},
+            {"type": "websocket.receive", "text": json.dumps({"type": "stop"})},
+        ],
+    )
+    await handlers.handle_transcription_stream(as_ws(ws))
+
+    assert stream_env["transcriber"].fed == [chunk]
+    assert stream_env["transcriber"].stopped
+    types = [event["type"] for event in ws.sent]
+    assert types[0] == "ready"
+    assert "final" in types
+    assert ws.closed is not None and ws.closed[0] == 1000
+
+
+async def test_stream_ends_when_client_send_fails(stream_env: dict) -> None:
+    stream_env["presets"] = {"emit_on_feed": True}
+    chunk = b"\x00\x01" * 100
+    # Allow only the "ready" send; the transcript forward then fails.
+    ws = FakeWebSocket(
+        json.dumps({"provider": "soniox"}),
+        messages=[
+            {"type": "websocket.receive", "bytes": chunk},
+            {"type": "websocket.receive", "bytes": chunk},
+        ],
+        fail_sends_after=1,
+    )
+    await handlers.handle_transcription_stream(as_ws(ws))
+
+    assert stream_env["transcriber"].stopped
+    assert ws.closed is not None and ws.closed[0] == 1011
+    assert ws.closed[1] == "client send failed"


### PR DESCRIPTION
Follow-up to #941, addressing Tara-ag's review comments (3 MAJOR, 4 MINOR — all were non-blocking, all addressed).

## MAJOR items

**Ready-before-connection race** — `StreamingTranscriber` now hooks the pipeline's `on_pipeline_error` event (fires on `ErrorFrame`, which is how Pipecat surfaces provider websocket connect/auth failures) and `start()` waits a 1 s grace window for an early error or runner exit. On failure the handler rejects with close code **4400 / "provider connection failed" before `ready` is ever sent**. The same signal is exposed as a `failed` property, so a provider that dies mid-stream now produces a clear `"provider connection lost"` error + 1011 close on the next loop iteration instead of silently eating audio. (Healthy streams pay the 1 s once at startup — the reviewer's `shield`-with-timeout shape, chosen because Pipecat has no positive "provider connected" event to await.)

**Dropped transcript events** — `_forward` checks `send_message`'s boolean; a failed send flags a shared `asyncio.Event` and the receive loop tears down with **1011 / "client send failed"** rather than dropping transcripts while continuing to pay the provider.

**Unbounded audio chunks** — binary frames are now capped at **256 KiB** per frame (~2.5 s of 48 kHz PCM16 mono, generous for any real client) with an error event + 4400 close on violation.

## MINOR items

- Emitter callback and teardown logging now include the exception class name.
- The receive loop's broad catch uses `logger.exception` (full traceback preserved for root-cause analysis) and documents why it stays broad (the close path must always be reached).
- `stop()`'s intentional swallow-on-teardown behavior is documented in its docstring, with exception types logged.

## Tests

New stub-transcriber fixture drives the handler without Pipecat: startup-failure rejection (no `ready` emitted), oversized-chunk rejection, the audio→feed→transcript-forward happy path, and client-send-failure teardown. 13 tests passing; black/isort/autoflake/pyrefly clean.

The staging smoke test with a real Soniox websocket recommended in the review is still the remaining pre-rollout step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Bj4ySkGkJ5zGdtLRbP4w4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added safeguards against oversized audio chunks in realtime transcription.
  * Improved handling and reporting of provider connection failures.
  * Added clearer detection of client delivery failures during streaming.

* **Bug Fixes**
  * Realtime streams now close promptly when transcription providers or client sends fail.
  * Improved error reporting for streaming and transcript delivery failures.

* **Tests**
  * Added coverage for startup failures, oversized audio, successful transcription, and client send failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->