### PR TITLE
feat(stt): full provider STT config support for batch + realtime

### DIFF
--- a/app/ai/voice/stt/transcribe.py
+++ b/app/ai/voice/stt/transcribe.py
@@ -114,13 +114,20 @@ async def _deepgram(
     content_type: Optional[str],
     lang: Optional[str],
     model: Optional[str] = None,
+    options: Optional[Dict[str, Any]] = None,
 ) -> Transcription:
+    opts = options or {}
     applied_model = model or "nova-3"
     params = {
         "model": applied_model,
-        "smart_format": "true",
-        "language": lang or "multi",
+        "smart_format": str(opts.get("smart_format", True)).lower(),
+        "language": "multi" if opts.get("auto_detect_language") else (lang or "multi"),
     }
+    # Pre-recorded API tuning flags; streaming-only knobs (endpointing,
+    # utterance_end_ms) are intentionally not forwarded here.
+    for key in ("punctuate", "numerals", "profanity_filter", "diarize"):
+        if key in opts:
+            params[key] = str(opts[key]).lower()
     headers = {
         "Authorization": f"Token {DEEPGRAM_API_KEY}",
         "Content-Type": content_type or "audio/webm",
@@ -175,6 +182,7 @@ async def _soniox(
     filename: str,
     language: LanguageHint,
     model: Optional[str] = None,
+    options: Optional[Dict[str, Any]] = None,
 ) -> Transcription:
     """One-shot transcription via Soniox's async file API.
 
@@ -212,6 +220,13 @@ async def _soniox(
             hints = _soniox_lang_hints(language)
             if hints:
                 body["language_hints"] = hints
+            opts = options or {}
+            if opts.get("context"):
+                body["context"] = opts["context"]
+            if opts.get("enable_language_identification") is not None:
+                body["enable_language_identification"] = opts[
+                    "enable_language_identification"
+                ]
             cr = await client.post("/v1/transcriptions", json=body)
             cr.raise_for_status()
             transcription_id = cr.json()["id"]
@@ -268,6 +283,7 @@ async def transcribe_audio(
     model: Optional[str] = None,
     language: LanguageHint = None,
     filename: str = "audio.webm",
+    options: Optional[Dict[str, Any]] = None,
 ) -> Transcription:
     """Transcribe ``audio`` to text using the selected ``provider``.
 
@@ -283,6 +299,12 @@ async def transcribe_audio(
     (a Deepgram/Sarvam/Soniox model name would be meaningless to Whisper).
     The returned :class:`Transcription` reports the provider and model that
     actually produced the text, after any fallback.
+
+    ``options`` carries provider-specific extras validated at the API layer
+    (Soniox: ``context``, ``enable_language_identification``; Deepgram:
+    ``smart_format``/``punctuate``/``numerals``/``profanity_filter``/
+    ``diarize``/``auto_detect_language``; Sarvam: ``language_code``). Like
+    ``model``, they are never forwarded to the Whisper fallback.
     """
     if not audio:
         raise TranscriptionError("empty audio")
@@ -296,13 +318,14 @@ async def transcribe_audio(
     try:
         if p == "soniox" and SONIOX_API_KEY:
             # Pass the raw language (str | list) — Soniox takes a hints array.
-            return await _soniox(audio, content_type, filename, language, model)
-        if p == "deepgram" and DEEPGRAM_API_KEY:
-            return await _deepgram(audio, content_type, lang, model)
-        if p == "sarvam" and SARVAM_API_KEY:
-            return await _sarvam(
-                audio, content_type, filename, _sarvam_lang(language), model
+            return await _soniox(
+                audio, content_type, filename, language, model, options
             )
+        if p == "deepgram" and DEEPGRAM_API_KEY:
+            return await _deepgram(audio, content_type, lang, model, options)
+        if p == "sarvam" and SARVAM_API_KEY:
+            sarvam_lang = (options or {}).get("language_code") or _sarvam_lang(language)
+            return await _sarvam(audio, content_type, filename, sarvam_lang, model)
         if not OPENAI_STT_API_KEY:
             raise TranscriptionError(
                 f"no usable STT provider for '{provider}' (OPENAI_STT_API_KEY unset)"

--- a/app/api/routers/breeze_buddy/stt/handlers.py
+++ b/app/api/routers/breeze_buddy/stt/handlers.py
@@ -49,6 +49,44 @@ _WS_UNAUTHORIZED = 4401
 _WS_TIMEOUT = 4408
 
 
+def _batch_model_and_options(
+    request: TranscriptionRequest,
+) -> tuple[str | None, dict | None]:
+    """Resolve the effective model + provider extras for the batch core.
+
+    The selected provider's nested config wins over the flat ``model``
+    shortcut; only options meaningful to the one-shot provider APIs are
+    forwarded (streaming-only knobs like Deepgram endpointing stay behind).
+    """
+    provider = request.provider
+    if provider == STTProvider.SONIOX and request.soniox:
+        cfg = request.soniox
+        opts = {
+            key: value
+            for key, value in {
+                "context": cfg.context,
+                "enable_language_identification": cfg.enable_language_identification,
+            }.items()
+            if value is not None
+        }
+        return cfg.model or request.model, opts or None
+    if provider == STTProvider.DEEPGRAM and request.deepgram:
+        cfg = request.deepgram
+        return cfg.model, {
+            "smart_format": cfg.smart_format,
+            "punctuate": cfg.punctuate,
+            "numerals": cfg.numerals,
+            "profanity_filter": cfg.profanity_filter,
+            "diarize": cfg.diarize,
+            "auto_detect_language": cfg.auto_detect_language,
+        }
+    if provider == STTProvider.SARVAM and request.sarvam:
+        cfg = request.sarvam
+        opts = {"language_code": cfg.language_code} if cfg.language_code else None
+        return cfg.model or request.model, opts
+    return request.model, None
+
+
 async def handle_transcription_request(
     audio: UploadFile,
     request: TranscriptionRequest,
@@ -61,6 +99,8 @@ async def handle_transcription_request(
     ``transcribe_audio`` core (Soniox uses its async file API; Google — and any
     provider whose key is unset — falls back to Whisper inside that core). The
     response reports the provider/model that actually produced the text.
+    Provider-specific tuning arrives via the request's nested configs and is
+    resolved by :func:`_batch_model_and_options`.
     """
     max_bytes = await STT_MAX_AUDIO_BYTES()
     chunks: list[bytes] = []
@@ -83,14 +123,16 @@ async def handle_transcription_request(
             detail="Empty audio upload",
         )
 
+    model, provider_options = _batch_model_and_options(request)
     try:
         result = await transcribe_audio(
             data,
             audio.content_type,
             provider=request.provider.value,
-            model=request.model,
+            model=model,
             language=request.language,
             filename=audio.filename or "audio.webm",
+            options=provider_options,
         )
     except TranscriptionError as e:
         logger.warning(
@@ -110,27 +152,31 @@ async def handle_transcription_request(
 
 
 def _stream_configuration(request: TranscriptionStreamRequest) -> STTConfiguration:
-    """Map the stream config message onto the template ``STTConfiguration``."""
-    model = request.model
+    """Map the stream config message onto the template ``STTConfiguration``.
+
+    The selected provider's nested config passes through verbatim — full
+    parity with template STT settings (Soniox context, Deepgram endpointing,
+    ...). The flat ``model`` is a shortcut used only when the matching nested
+    config is absent; nested configs for other providers are dropped.
+    """
     provider = request.provider
+    model = request.model
+    soniox = request.soniox if provider == STTProvider.SONIOX else None
+    deepgram = request.deepgram if provider == STTProvider.DEEPGRAM else None
+    sarvam = request.sarvam if provider == STTProvider.SARVAM else None
+    if model:
+        if provider == STTProvider.SONIOX and soniox is None:
+            soniox = SonioxSTTConfig(model=model)
+        elif provider == STTProvider.DEEPGRAM and deepgram is None:
+            deepgram = DeepgramSTTConfig(model=model)
+        elif provider == STTProvider.SARVAM and sarvam is None:
+            sarvam = SarvamSTTConfig(model=model)
     return STTConfiguration(
         provider=provider,
         language=request.language,
-        soniox=(
-            SonioxSTTConfig(model=model)
-            if provider == STTProvider.SONIOX and model
-            else None
-        ),
-        deepgram=(
-            DeepgramSTTConfig(model=model)
-            if provider == STTProvider.DEEPGRAM and model
-            else None
-        ),
-        sarvam=(
-            SarvamSTTConfig(model=model)
-            if provider == STTProvider.SARVAM and model
-            else None
-        ),
+        soniox=soniox,
+        deepgram=deepgram,
+        sarvam=sarvam,
     )
 
 

--- a/app/schemas/breeze_buddy/stt.py
+++ b/app/schemas/breeze_buddy/stt.py
@@ -1,10 +1,16 @@
 """Schemas for the standalone (template-independent) STT endpoints."""
 
+import json
 from typing import List, Optional, Union
 
 from pydantic import BaseModel, Field, field_validator
 
-from app.ai.voice.agents.breeze_buddy.template.types import STTProvider
+from app.ai.voice.agents.breeze_buddy.template.types import (
+    DeepgramSTTConfig,
+    SarvamSTTConfig,
+    SonioxSTTConfig,
+    STTProvider,
+)
 
 
 class TranscriptionRequest(BaseModel):
@@ -13,11 +19,21 @@ class TranscriptionRequest(BaseModel):
     ``provider`` selects the STT provider; ``model`` optionally overrides that
     provider's default model, and ``language`` is a BCP-47 / ISO-639 hint.
     Values are trimmed; a blank ``model``/``language`` means "use the default".
+
+    Provider-specific tuning goes in the matching nested config (``soniox`` /
+    ``deepgram`` / ``sarvam``) — the same models templates use (e.g. Soniox
+    ``context``, Deepgram ``smart_format``/``numerals``, Sarvam
+    ``language_code``). In multipart form data these arrive as JSON strings.
+    When the selected provider's nested config is present it takes precedence
+    over the flat ``model`` shortcut; configs for other providers are ignored.
     """
 
     provider: STTProvider
     model: Optional[str] = None
     language: Optional[str] = None
+    soniox: Optional[SonioxSTTConfig] = None
+    deepgram: Optional[DeepgramSTTConfig] = None
+    sarvam: Optional[SarvamSTTConfig] = None
 
     @field_validator("provider", mode="before")
     @classmethod
@@ -33,6 +49,16 @@ class TranscriptionRequest(BaseModel):
             return value.strip() or None
         return value
 
+    @field_validator("soniox", "deepgram", "sarvam", mode="before")
+    @classmethod
+    def _parse_json_form_field(cls, value: object) -> object:
+        if isinstance(value, str):
+            stripped = value.strip()
+            if not stripped:
+                return None
+            return json.loads(stripped)
+        return value
+
 
 class TranscriptionStreamRequest(BaseModel):
     """First (JSON text) message on ``WS /agent/voice/breeze-buddy/stt/stream``.
@@ -41,6 +67,14 @@ class TranscriptionStreamRequest(BaseModel):
     at ``sample_rate``. ``language`` accepts a single code or a list (list is
     provider-dependent, e.g. Soniox hints). OpenAI has no realtime streaming
     path and is rejected; Sarvam streams are pinned to the platform rate.
+
+    Provider-specific tuning goes in the matching nested config (``soniox`` /
+    ``deepgram`` / ``sarvam``) — the same models templates use, passed through
+    to the streaming service builders verbatim (e.g. Soniox ``context`` and
+    ``enable_language_identification``, Deepgram ``endpointing_ms`` and
+    ``smart_format``). When the selected provider's nested config is present
+    it takes precedence over the flat ``model`` shortcut; configs for other
+    providers are ignored.
     """
 
     provider: STTProvider
@@ -52,6 +86,9 @@ class TranscriptionStreamRequest(BaseModel):
         le=48000,
         description="Sample rate (Hz) of the PCM16 mono audio frames.",
     )
+    soniox: Optional[SonioxSTTConfig] = None
+    deepgram: Optional[DeepgramSTTConfig] = None
+    sarvam: Optional[SarvamSTTConfig] = None
 
     @field_validator("provider", mode="before")
     @classmethod

--- a/tests/test_stt_stream.py
+++ b/tests/test_stt_stream.py
@@ -112,9 +112,9 @@ def stream_env(monkeypatch: pytest.MonkeyPatch) -> dict:
         return stub
 
     monkeypatch.setattr(handlers, "get_user_from_websocket", lambda ws: _USER)
-    monkeypatch.setattr(
-        handlers, "create_stt_from_config", AsyncMock(return_value=object())
-    )
+    create_mock = AsyncMock(return_value=object())
+    monkeypatch.setattr(handlers, "create_stt_from_config", create_mock)
+    created["create_stt"] = create_mock
     monkeypatch.setattr(handlers, "STT_STREAM_MAX_SECONDS", AsyncMock(return_value=300))
     monkeypatch.setattr(
         handlers, "STT_STREAM_IDLE_TIMEOUT_SECONDS", AsyncMock(return_value=60)
@@ -251,6 +251,34 @@ async def test_stream_feeds_audio_and_forwards_transcripts(stream_env: dict) -> 
     assert types[0] == "ready"
     assert "final" in types
     assert ws.closed is not None and ws.closed[0] == 1000
+
+
+async def test_stream_passes_nested_provider_config(stream_env: dict) -> None:
+    ws = FakeWebSocket(
+        json.dumps(
+            {
+                "provider": "soniox",
+                "soniox": {"context": "acme brands", "model": "stt-rt-v4"},
+            }
+        )
+    )
+    await handlers.handle_transcription_stream(as_ws(ws))
+
+    config = stream_env["create_stt"].await_args.args[0]
+    assert config.provider.value == "soniox"
+    assert config.soniox is not None
+    assert config.soniox.context == "acme brands"
+    assert config.soniox.model == "stt-rt-v4"
+
+
+async def test_stream_flat_model_builds_nested_config(stream_env: dict) -> None:
+    ws = FakeWebSocket(json.dumps({"provider": "deepgram", "model": "nova-3-medical"}))
+    await handlers.handle_transcription_stream(as_ws(ws))
+
+    config = stream_env["create_stt"].await_args.args[0]
+    assert config.deepgram is not None
+    assert config.deepgram.model == "nova-3-medical"
+    assert config.soniox is None
 
 
 async def test_stream_ends_when_client_send_fails(stream_env: dict) -> None:

--- a/tests/test_stt_transcribe_handler.py
+++ b/tests/test_stt_transcribe_handler.py
@@ -24,6 +24,54 @@ def test_request_normalizes_provider_and_blank_fields() -> None:
     assert request.language is None
 
 
+def test_request_parses_nested_config_from_json_string() -> None:
+    request = TranscriptionRequest.model_validate(
+        {"provider": "soniox", "soniox": '{"context": "brand names"}'}
+    )
+    assert request.soniox is not None
+    assert request.soniox.context == "brand names"
+
+    with pytest.raises(ValueError):
+        TranscriptionRequest.model_validate(
+            {"provider": "soniox", "soniox": "{not json"}
+        )
+
+
+def test_batch_model_and_options_resolution() -> None:
+    request = TranscriptionRequest.model_validate(
+        {"provider": "soniox", "model": "stt-async-v2", "soniox": {"context": "acme"}}
+    )
+    model, opts = handlers._batch_model_and_options(request)
+    assert model == "stt-async-v2"
+    assert opts == {"context": "acme"}
+
+    request = TranscriptionRequest.model_validate(
+        {
+            "provider": "deepgram",
+            "model": "ignored",
+            "deepgram": {"model": "nova-3-medical", "numerals": False},
+        }
+    )
+    model, opts = handlers._batch_model_and_options(request)
+    assert model == "nova-3-medical"
+    assert opts is not None
+    assert opts["numerals"] is False
+    assert "endpointing_ms" not in opts
+
+    request = TranscriptionRequest.model_validate(
+        {"provider": "sarvam", "sarvam": {"language_code": "hi-IN"}}
+    )
+    assert handlers._batch_model_and_options(request) == (
+        None,
+        {"language_code": "hi-IN"},
+    )
+
+    request = TranscriptionRequest.model_validate(
+        {"provider": "openai", "model": "whisper-1"}
+    )
+    assert handlers._batch_model_and_options(request) == ("whisper-1", None)
+
+
 @pytest.mark.parametrize(
     ("result_provider", "result_model"),
     [("deepgram", "nova-3"), ("openai", "whisper-1")],


### PR DESCRIPTION
Adds full provider-specific STT configuration to both standalone endpoints — the ask: template parity (e.g. Soniox `context`) for batch *and* realtime.

> **Stacked on #944** (review hardening) since it touches the same handler code — merge #944 first, then I'll retarget this to `release` (or retarget it manually; it becomes a clean 1-commit diff either way).

## Design

Rather than inventing new request fields, both request schemas embed the **template config models from `template/types.py`** (the documented source of truth): optional `soniox` / `deepgram` / `sarvam` nested configs on `TranscriptionRequest` and `TranscriptionStreamRequest`. Anything a template can tune, an API caller now can too — and new template fields inherit automatically.

**Precedence rule (documented in the schemas):** the selected provider's nested config wins over the flat `model` shortcut; nested configs for non-selected providers are ignored.

## Realtime (`WS /stt/stream`)

The config message accepts e.g.:
```json
{"provider": "soniox", "language": ["en", "hi"],
 "soniox": {"context": "{...brand terms...}", "model": "stt-rt-v4", "enable_language_identification": true}}
```
`_stream_configuration` passes the nested config verbatim into `create_stt_from_config`, so the stream behaves exactly like a template configured the same way (context, Deepgram `endpointing_ms`/`utterance_end_ms`/`smart_format`, Sarvam knobs — all live).

## Batch (`POST /stt/transcribe`)

Multipart form gains `soniox`/`deepgram`/`sarvam` fields as **JSON strings** (`-F 'soniox={"context": "..."}'`), parsed by a before-validator (bad JSON → 422). `_batch_model_and_options` resolves the effective model + an options dict for the core:

- **Soniox** (async file API): `context`, `enable_language_identification` forwarded on the job body.
- **Deepgram** (pre-recorded API): `smart_format`, `punctuate`, `numerals`, `profanity_filter`, `diarize`, `auto_detect_language` forwarded as query params; streaming-only knobs (`endpointing_ms`, `utterance_end_ms`) deliberately withheld.
- **Sarvam**: explicit `language_code` wins over the one derived from `language`.
- Options follow the same safety rule as `model`: **never forwarded to the Whisper fallback**.

## Tests

17 passing (4 new): JSON-string parsing incl. invalid JSON, the `_batch_model_and_options` resolution matrix (nested-wins, flag forwarding, no-config passthrough), nested-config passthrough to `create_stt_from_config`, and flat-model synthesis. black/isort/autoflake/pyrefly clean.

Staging note: Soniox *async-API* `context`/`enable_language_identification` pass-through should be verified in the staging smoke test alongside the realtime check — a rejected field degrades gracefully (falls back to Whisper) but should be confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Bj4ySkGkJ5zGdtLRbP4w4