### PR TITLE
feat(stt): harden realtime stream + full provider STT config support

### DIFF
--- a/app/ai/voice/stt/streaming.py
+++ b/app/ai/voice/stt/streaming.py
@@ -35,6 +35,13 @@ __all__ = ["StreamingTranscriber", "TranscriptEvent"]
 
 _STOP_TIMEOUT_SECONDS = 5.0
 
+# How long start() lets the pipeline run before declaring it healthy. Provider
+# connect/auth rejections typically surface within this window (as an
+# ErrorFrame or the runner task finishing), letting callers reject the stream
+# before telling the client it is ready. Healthy streams pay this once at
+# startup.
+_STARTUP_GRACE_SECONDS = 1.0
+
 
 @dataclass
 class TranscriptEvent:
@@ -80,7 +87,9 @@ class _TranscriptEmitter(FrameProcessor):
                 try:
                     await self._on_transcript(event)
                 except Exception as e:
-                    logger.warning("transcript callback failed: {}", e)
+                    logger.warning(
+                        "transcript callback failed ({}): {}", type(e).__name__, e
+                    )
 
         await self.push_frame(frame, direction)
 
@@ -112,10 +121,60 @@ class StreamingTranscriber:
         )
         self._runner = PipelineRunner(handle_sigint=False, force_gc=True)
         self._run_future: Optional[asyncio.Task] = None
+        self._failed = asyncio.Event()
+        self._failure: Optional[str] = None
+
+        @self._task.event_handler("on_pipeline_error")
+        async def _on_pipeline_error(task, frame):
+            self._failure = getattr(frame, "error", None) or "pipeline error"
+            self._failed.set()
+            logger.warning("streaming STT pipeline error: {}", self._failure)
+
+    @property
+    def failed(self) -> bool:
+        """True once the pipeline reported an error (e.g. provider died)."""
+        return self._failed.is_set()
 
     async def start(self) -> None:
-        """Start the pipeline (connects the provider websocket)."""
+        """Start the pipeline and fail fast on provider connect/auth errors.
+
+        Waits up to ``_STARTUP_GRACE_SECONDS`` for an early failure — a
+        pipeline ``ErrorFrame`` or the runner task finishing — and raises
+        ``RuntimeError`` so callers can reject the stream cleanly *before*
+        telling the client it is ready.
+        """
         self._run_future = asyncio.create_task(self._runner.run(self._task))
+        failure_wait = asyncio.create_task(self._failed.wait())
+        try:
+            await asyncio.wait(
+                {self._run_future, failure_wait},
+                timeout=_STARTUP_GRACE_SECONDS,
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+        finally:
+            if not failure_wait.done():
+                failure_wait.cancel()
+
+        if not self._failed.is_set() and not self._run_future.done():
+            return  # healthy: pipeline is running and reported no error
+
+        message = self._failure or ""
+        if self._run_future.done():
+            exc = self._run_future.exception()
+            if exc is not None:
+                message = message or f"{type(exc).__name__}: {exc}"
+            message = message or "pipeline ended during startup"
+        else:
+            await self._task.cancel()
+            try:
+                # Bounded wait: a runner stuck in non-cancellable provider
+                # I/O must not hang start() — the caller needs to reject the
+                # stream promptly either way.
+                await asyncio.wait_for(self._run_future, _STOP_TIMEOUT_SECONDS)
+            except Exception:
+                pass
+        self._run_future = None
+        raise RuntimeError(f"streaming STT failed to start: {message or 'unknown'}")
 
     async def feed(self, audio: bytes) -> None:
         """Queue one chunk of raw PCM16 mono audio for transcription."""
@@ -130,7 +189,12 @@ class StreamingTranscriber:
         )
 
     async def stop(self) -> None:
-        """Flush pending audio, wait for final transcripts, tear down."""
+        """Flush pending audio, wait for final transcripts, tear down.
+
+        Deliberately swallows teardown errors (logging them with type): this
+        runs on the WebSocket close path, which must never raise — a wedged
+        provider teardown should not prevent the client socket from closing.
+        """
         if self._run_future is None:
             return
         run_future, self._run_future = self._run_future, None
@@ -145,4 +209,4 @@ class StreamingTranscriber:
             except Exception:
                 pass
         except Exception as e:
-            logger.warning("streaming STT stop error: {}", e)
+            logger.warning("streaming STT stop error ({}): {}", type(e).__name__, e)

--- a/app/ai/voice/stt/transcribe.py
+++ b/app/ai/voice/stt/transcribe.py
@@ -114,13 +114,20 @@ async def _deepgram(
     content_type: Optional[str],
     lang: Optional[str],
     model: Optional[str] = None,
+    options: Optional[Dict[str, Any]] = None,
 ) -> Transcription:
+    opts = options or {}
     applied_model = model or "nova-3"
     params = {
         "model": applied_model,
-        "smart_format": "true",
-        "language": lang or "multi",
+        "smart_format": str(opts.get("smart_format", True)).lower(),
+        "language": "multi" if opts.get("auto_detect_language") else (lang or "multi"),
     }
+    # Pre-recorded API tuning flags; streaming-only knobs (endpointing,
+    # utterance_end_ms) are intentionally not forwarded here.
+    for key in ("punctuate", "numerals", "profanity_filter", "diarize"):
+        if key in opts:
+            params[key] = str(opts[key]).lower()
     headers = {
         "Authorization": f"Token {DEEPGRAM_API_KEY}",
         "Content-Type": content_type or "audio/webm",
@@ -175,6 +182,7 @@ async def _soniox(
     filename: str,
     language: LanguageHint,
     model: Optional[str] = None,
+    options: Optional[Dict[str, Any]] = None,
 ) -> Transcription:
     """One-shot transcription via Soniox's async file API.
 
@@ -212,6 +220,13 @@ async def _soniox(
             hints = _soniox_lang_hints(language)
             if hints:
                 body["language_hints"] = hints
+            opts = options or {}
+            if opts.get("context"):
+                body["context"] = opts["context"]
+            if opts.get("enable_language_identification") is not None:
+                body["enable_language_identification"] = opts[
+                    "enable_language_identification"
+                ]
             cr = await client.post("/v1/transcriptions", json=body)
             cr.raise_for_status()
             transcription_id = cr.json()["id"]
@@ -268,6 +283,7 @@ async def transcribe_audio(
     model: Optional[str] = None,
     language: LanguageHint = None,
     filename: str = "audio.webm",
+    options: Optional[Dict[str, Any]] = None,
 ) -> Transcription:
     """Transcribe ``audio`` to text using the selected ``provider``.
 
@@ -283,12 +299,27 @@ async def transcribe_audio(
     (a Deepgram/Sarvam/Soniox model name would be meaningless to Whisper).
     The returned :class:`Transcription` reports the provider and model that
     actually produced the text, after any fallback.
+
+    ``options`` carries provider-specific extras validated at the API layer
+    (Soniox: ``context``, ``enable_language_identification``; Deepgram:
+    ``smart_format``/``punctuate``/``numerals``/``profanity_filter``/
+    ``diarize``/``auto_detect_language``; Sarvam: ``language_code``). Like
+    ``model``, they are never forwarded to the Whisper fallback.
+
+    **Strict mode**: when the caller pinned an explicit ``model`` or passed
+    ``options``, a different provider's transcript would silently violate what
+    was asked for — so the Whisper fail-open is disabled and provider failure
+    (or a missing API key) raises :class:`TranscriptionError` instead. The
+    fail-open fallback applies only to provider-default requests (e.g. widget
+    push-to-talk).
     """
     if not audio:
         raise TranscriptionError("empty audio")
 
     p = (provider or "").lower()
     lang = _short_lang(language)
+    # An explicit model/options pin disables the Whisper fail-open below.
+    strict = model is not None or bool(options)
     # Only pass ``model`` to the Whisper fallback when OpenAI was the intended
     # provider; other providers' model names don't apply to Whisper.
     fallback_model = model if p == "openai" else None
@@ -296,12 +327,23 @@ async def transcribe_audio(
     try:
         if p == "soniox" and SONIOX_API_KEY:
             # Pass the raw language (str | list) — Soniox takes a hints array.
-            return await _soniox(audio, content_type, filename, language, model)
+            return await _soniox(
+                audio, content_type, filename, language, model, options
+            )
         if p == "deepgram" and DEEPGRAM_API_KEY:
-            return await _deepgram(audio, content_type, lang, model)
+            return await _deepgram(audio, content_type, lang, model, options)
         if p == "sarvam" and SARVAM_API_KEY:
-            return await _sarvam(
-                audio, content_type, filename, _sarvam_lang(language), model
+            sarvam_lang = (options or {}).get("language_code") or _sarvam_lang(language)
+            return await _sarvam(audio, content_type, filename, sarvam_lang, model)
+        if strict and p != "openai":
+            # Reaching here means the pinned provider cannot run (key unset,
+            # or google which has no one-shot path/model knob). Honouring the
+            # request with Whisper would silently ignore the explicit
+            # model/options, so fail instead.
+            raise TranscriptionError(
+                f"provider '{provider}' cannot run with the requested "
+                "model/options (missing API key or unsupported provider); "
+                "not falling back to Whisper"
             )
         if not OPENAI_STT_API_KEY:
             raise TranscriptionError(
@@ -317,6 +359,13 @@ async def transcribe_audio(
     except TranscriptionError:
         raise
     except Exception as e:
+        if strict:
+            # The caller pinned a model/options; a Whisper transcript would
+            # not be what was asked for. Surface the failure instead.
+            raise TranscriptionError(
+                f"provider '{provider}' failed with the requested "
+                f"model/options: {e}"
+            ) from e
         # Recover with Whisper so the user still gets text (e.g. Sarvam rejecting
         # webm, or a Soniox job error/timeout).
         if p in ("soniox", "deepgram", "sarvam") and OPENAI_STT_API_KEY:

--- a/app/api/routers/breeze_buddy/stt/handlers.py
+++ b/app/api/routers/breeze_buddy/stt/handlers.py
@@ -39,10 +39,79 @@ from app.schemas.breeze_buddy.stt import (
 # Seconds the client gets to send the JSON config message after connecting.
 _STREAM_CONFIG_TIMEOUT_SECONDS = 10.0
 
+# Per-frame cap on binary audio messages. Generous for real clients (~2.5s of
+# 48kHz PCM16 mono) while bounding what one frame can buffer server-side.
+_MAX_CHUNK_BYTES = 256 * 1024
+
 # Application close codes (4xxx range is free for applications).
 _WS_BAD_REQUEST = 4400
 _WS_UNAUTHORIZED = 4401
 _WS_TIMEOUT = 4408
+
+
+def _effective_model(
+    cfg: SonioxSTTConfig | DeepgramSTTConfig | SarvamSTTConfig,
+    flat_model: str | None,
+) -> str | None:
+    """Uniform model precedence across providers.
+
+    A model *explicitly set* in the nested config wins; otherwise the flat
+    ``model`` shortcut fills in; otherwise ``None`` so the provider call's
+    own default applies. ``model_fields_set`` distinguishes "caller set the
+    nested model" from a schema default like Deepgram's ``nova-3-general`` —
+    a plain truthiness check would silently discard the flat model there,
+    and forwarding schema defaults would wrongly flip on strict mode (and
+    push template *streaming* model defaults into the batch path).
+    """
+    if "model" in cfg.model_fields_set and cfg.model:
+        return cfg.model
+    return flat_model
+
+
+def _batch_model_and_options(
+    request: TranscriptionRequest,
+) -> tuple[str | None, dict | None]:
+    """Resolve the effective model + provider extras for the batch core.
+
+    Model precedence is :func:`_effective_model`; only options meaningful to
+    the one-shot provider APIs are forwarded (streaming-only knobs like
+    Deepgram endpointing stay behind).
+    """
+    provider = request.provider
+    if provider == STTProvider.SONIOX and request.soniox:
+        cfg = request.soniox
+        opts = {
+            key: value
+            for key, value in {
+                "context": cfg.context,
+                "enable_language_identification": cfg.enable_language_identification,
+            }.items()
+            if value is not None
+        }
+        return _effective_model(cfg, request.model), opts or None
+    if provider == STTProvider.DEEPGRAM and request.deepgram:
+        cfg = request.deepgram
+        # Only explicitly-set flags are forwarded (schema defaults stay
+        # behind): keeps strict-mode semantics uniform with Soniox/Sarvam —
+        # an empty nested config pins nothing.
+        opts = {
+            key: getattr(cfg, key)
+            for key in (
+                "smart_format",
+                "punctuate",
+                "numerals",
+                "profanity_filter",
+                "diarize",
+                "auto_detect_language",
+            )
+            if key in cfg.model_fields_set
+        }
+        return _effective_model(cfg, request.model), opts or None
+    if provider == STTProvider.SARVAM and request.sarvam:
+        cfg = request.sarvam
+        opts = {"language_code": cfg.language_code} if cfg.language_code else None
+        return _effective_model(cfg, request.model), opts
+    return request.model, None
 
 
 async def handle_transcription_request(
@@ -57,7 +126,17 @@ async def handle_transcription_request(
     ``transcribe_audio`` core (Soniox uses its async file API; Google — and any
     provider whose key is unset — falls back to Whisper inside that core). The
     response reports the provider/model that actually produced the text.
+    Provider-specific tuning arrives via the request's nested configs and is
+    resolved by :func:`_batch_model_and_options`. Explicitly pinned
+    model/options run in strict mode: provider failure returns 502 instead of
+    silently degrading to a Whisper transcript.
     """
+    if request.provider == STTProvider.GOOGLE and request.model:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="model override is not supported for google",
+        )
+
     max_bytes = await STT_MAX_AUDIO_BYTES()
     chunks: list[bytes] = []
     total = 0
@@ -79,14 +158,16 @@ async def handle_transcription_request(
             detail="Empty audio upload",
         )
 
+    model, provider_options = _batch_model_and_options(request)
     try:
         result = await transcribe_audio(
             data,
             audio.content_type,
             provider=request.provider.value,
-            model=request.model,
+            model=model,
             language=request.language,
             filename=audio.filename or "audio.webm",
+            options=provider_options,
         )
     except TranscriptionError as e:
         logger.warning(
@@ -106,27 +187,41 @@ async def handle_transcription_request(
 
 
 def _stream_configuration(request: TranscriptionStreamRequest) -> STTConfiguration:
-    """Map the stream config message onto the template ``STTConfiguration``."""
-    model = request.model
+    """Map the stream config message onto the template ``STTConfiguration``.
+
+    The selected provider's nested config passes through — full parity with
+    template STT settings (Soniox context, Deepgram endpointing, ...). Model
+    precedence matches the batch path (:func:`_effective_model`): an
+    explicitly set nested model wins, otherwise the flat ``model`` shortcut
+    fills in. Nested configs for other providers are dropped.
+    """
     provider = request.provider
+    model = request.model
+    soniox = request.soniox if provider == STTProvider.SONIOX else None
+    deepgram = request.deepgram if provider == STTProvider.DEEPGRAM else None
+    sarvam = request.sarvam if provider == STTProvider.SARVAM else None
+    if model:
+        if provider == STTProvider.SONIOX:
+            if soniox is None:
+                soniox = SonioxSTTConfig(model=model)
+            elif "model" not in soniox.model_fields_set:
+                soniox = soniox.model_copy(update={"model": model})
+        elif provider == STTProvider.DEEPGRAM:
+            if deepgram is None:
+                deepgram = DeepgramSTTConfig(model=model)
+            elif "model" not in deepgram.model_fields_set:
+                deepgram = deepgram.model_copy(update={"model": model})
+        elif provider == STTProvider.SARVAM:
+            if sarvam is None:
+                sarvam = SarvamSTTConfig(model=model)
+            elif "model" not in sarvam.model_fields_set:
+                sarvam = sarvam.model_copy(update={"model": model})
     return STTConfiguration(
         provider=provider,
         language=request.language,
-        soniox=(
-            SonioxSTTConfig(model=model)
-            if provider == STTProvider.SONIOX and model
-            else None
-        ),
-        deepgram=(
-            DeepgramSTTConfig(model=model)
-            if provider == STTProvider.DEEPGRAM and model
-            else None
-        ),
-        sarvam=(
-            SarvamSTTConfig(model=model)
-            if provider == STTProvider.SARVAM and model
-            else None
-        ),
+        soniox=soniox,
+        deepgram=deepgram,
+        sarvam=sarvam,
     )
 
 
@@ -153,7 +248,10 @@ async def handle_transcription_stream(ws: WebSocket) -> None:
        flushes remaining finals and closes.
 
     Streams are bounded by ``STT_STREAM_MAX_SECONDS`` and
-    ``STT_STREAM_IDLE_TIMEOUT_SECONDS`` (both dynamic config).
+    ``STT_STREAM_IDLE_TIMEOUT_SECONDS`` (both dynamic config); individual
+    binary frames are capped at ``_MAX_CHUNK_BYTES``. Provider startup
+    failures are rejected with close code 4400 before ``ready`` is sent;
+    provider death or client send failures mid-stream close with 1011.
     """
     await ws.accept()
 
@@ -210,8 +308,10 @@ async def handle_transcription_stream(ws: WebSocket) -> None:
         await _reject_stream(ws, _WS_BAD_REQUEST, str(e), "provider unavailable")
         return
 
+    send_failed = asyncio.Event()
+
     async def _forward(event: TranscriptEvent) -> None:
-        await send_message(
+        ok = await send_message(
             ws,
             {
                 "type": "final" if event.is_final else "partial",
@@ -219,6 +319,10 @@ async def handle_transcription_stream(ws: WebSocket) -> None:
                 "language": event.language,
             },
         )
+        if not ok:
+            # Flag for the receive loop; transcripts are being dropped, so
+            # the stream must tear down rather than keep paying the provider.
+            send_failed.set()
 
     transcriber = StreamingTranscriber(
         stt_service, sample_rate=request.sample_rate, on_transcript=_forward
@@ -226,7 +330,19 @@ async def handle_transcription_stream(ws: WebSocket) -> None:
     max_seconds = await STT_STREAM_MAX_SECONDS()
     idle_timeout = await STT_STREAM_IDLE_TIMEOUT_SECONDS()
 
-    await transcriber.start()
+    try:
+        await transcriber.start()
+    except RuntimeError as e:
+        logger.warning(
+            "stt stream provider startup failed (provider={}, user={}): {}",
+            request.provider.value,
+            user.id,
+            e,
+        )
+        await _reject_stream(
+            ws, _WS_BAD_REQUEST, "provider connection failed", "provider unavailable"
+        )
+        return
     await send_message(ws, {"type": "ready"})
     logger.info(
         "stt stream started (provider={}, user={}, sample_rate={})",
@@ -239,6 +355,16 @@ async def handle_transcription_stream(ws: WebSocket) -> None:
     deadline = time.monotonic() + max_seconds
     try:
         while True:
+            if transcriber.failed:
+                await send_message(
+                    ws, {"type": "error", "message": "provider connection lost"}
+                )
+                close_code, close_reason = 1011, "provider error"
+                break
+            if send_failed.is_set():
+                close_code, close_reason = 1011, "client send failed"
+                break
+
             remaining = deadline - time.monotonic()
             if remaining <= 0:
                 await send_message(
@@ -272,6 +398,18 @@ async def handle_transcription_stream(ws: WebSocket) -> None:
 
             audio = message.get("bytes")
             if audio:
+                if len(audio) > _MAX_CHUNK_BYTES:
+                    await send_message(
+                        ws,
+                        {
+                            "type": "error",
+                            "message": (
+                                f"audio chunk exceeds {_MAX_CHUNK_BYTES} bytes"
+                            ),
+                        },
+                    )
+                    close_code, close_reason = _WS_BAD_REQUEST, "chunk too large"
+                    break
                 await transcriber.feed(audio)
                 continue
 
@@ -285,10 +423,14 @@ async def handle_transcription_stream(ws: WebSocket) -> None:
             if isinstance(control, dict) and control.get("type") == "stop":
                 break
     except Exception as e:
-        logger.error(
-            "stt stream failed (provider={}, user={}): {}",
+        # Broad by design: this loop must reach the close path below no
+        # matter what fails; logger.exception preserves the traceback for
+        # root-cause analysis.
+        logger.exception(
+            "stt stream failed (provider={}, user={}): {}: {}",
             request.provider.value,
             user.id,
+            type(e).__name__,
             e,
         )
         await send_message(ws, {"type": "error", "message": "Internal stream error"})

--- a/app/schemas/breeze_buddy/stt.py
+++ b/app/schemas/breeze_buddy/stt.py
@@ -1,10 +1,20 @@
 """Schemas for the standalone (template-independent) STT endpoints."""
 
+import json
 from typing import List, Optional, Union
 
 from pydantic import BaseModel, Field, field_validator
 
-from app.ai.voice.agents.breeze_buddy.template.types import STTProvider
+from app.ai.voice.agents.breeze_buddy.template.types import (
+    DeepgramSTTConfig,
+    SarvamSTTConfig,
+    SonioxSTTConfig,
+    STTProvider,
+)
+
+# Cap on a single provider-config JSON form field. Real configs are well
+# under 1 KiB; the cap bounds json.loads work on hostile multipart input.
+_MAX_CONFIG_JSON_BYTES = 64 * 1024
 
 
 class TranscriptionRequest(BaseModel):
@@ -13,11 +23,22 @@ class TranscriptionRequest(BaseModel):
     ``provider`` selects the STT provider; ``model`` optionally overrides that
     provider's default model, and ``language`` is a BCP-47 / ISO-639 hint.
     Values are trimmed; a blank ``model``/``language`` means "use the default".
+
+    Provider-specific tuning goes in the matching nested config (``soniox`` /
+    ``deepgram`` / ``sarvam``) — the same models templates use (e.g. Soniox
+    ``context``, Deepgram ``smart_format``/``numerals``, Sarvam
+    ``language_code``). In multipart form data these arrive as JSON strings.
+    A model explicitly set in the selected provider's nested config wins over
+    the flat ``model`` shortcut; otherwise the flat value fills in. Configs
+    for other providers are ignored.
     """
 
     provider: STTProvider
     model: Optional[str] = None
     language: Optional[str] = None
+    soniox: Optional[SonioxSTTConfig] = None
+    deepgram: Optional[DeepgramSTTConfig] = None
+    sarvam: Optional[SarvamSTTConfig] = None
 
     @field_validator("provider", mode="before")
     @classmethod
@@ -33,6 +54,28 @@ class TranscriptionRequest(BaseModel):
             return value.strip() or None
         return value
 
+    @field_validator("soniox", "deepgram", "sarvam", mode="before")
+    @classmethod
+    def _parse_json_form_field(cls, value: object) -> object:
+        if isinstance(value, str):
+            stripped = value.strip()
+            if not stripped:
+                return None
+            if len(stripped) > _MAX_CONFIG_JSON_BYTES:
+                raise ValueError(
+                    f"provider config exceeds {_MAX_CONFIG_JSON_BYTES} bytes"
+                )
+            try:
+                return json.loads(stripped)
+            except RecursionError:
+                # json.loads recurses per nesting level; pathological input
+                # (~1000 deep) raises RecursionError, which Pydantic would
+                # NOT convert to a validation error — it would surface as an
+                # unhandled 500. Re-raise as ValueError so it becomes a 422
+                # like any other bad JSON.
+                raise ValueError("JSON too deeply nested") from None
+        return value
+
 
 class TranscriptionStreamRequest(BaseModel):
     """First (JSON text) message on ``WS /agent/voice/breeze-buddy/stt/stream``.
@@ -41,6 +84,14 @@ class TranscriptionStreamRequest(BaseModel):
     at ``sample_rate``. ``language`` accepts a single code or a list (list is
     provider-dependent, e.g. Soniox hints). OpenAI has no realtime streaming
     path and is rejected; Sarvam streams are pinned to the platform rate.
+
+    Provider-specific tuning goes in the matching nested config (``soniox`` /
+    ``deepgram`` / ``sarvam``) — the same models templates use, passed through
+    to the streaming service builders verbatim (e.g. Soniox ``context`` and
+    ``enable_language_identification``, Deepgram ``endpointing_ms`` and
+    ``smart_format``). A model explicitly set in the selected provider's
+    nested config wins over the flat ``model`` shortcut; otherwise the flat
+    value fills in. Configs for other providers are ignored.
     """
 
     provider: STTProvider
@@ -52,6 +103,9 @@ class TranscriptionStreamRequest(BaseModel):
         le=48000,
         description="Sample rate (Hz) of the PCM16 mono audio frames.",
     )
+    soniox: Optional[SonioxSTTConfig] = None
+    deepgram: Optional[DeepgramSTTConfig] = None
+    sarvam: Optional[SarvamSTTConfig] = None
 
     @field_validator("provider", mode="before")
     @classmethod
@@ -83,7 +137,10 @@ class TranscriptionResponse(BaseModel):
 
     ``provider`` and ``model`` report what actually produced the transcript.
     They may differ from the request when the shared core falls back to OpenAI
-    Whisper (streaming-only provider, missing API key, or transient failure).
+    Whisper (streaming-only provider, missing API key, or transient failure) —
+    but only for provider-default requests: an explicit ``model`` or nested
+    provider config pins the request, and provider failure then returns 502
+    instead of degrading to Whisper.
     """
 
     text: str

--- a/tests/test_stt_stream.py
+++ b/tests/test_stt_stream.py
@@ -3,6 +3,7 @@
 import json
 from types import SimpleNamespace
 from typing import cast
+from unittest.mock import AsyncMock
 
 import pytest
 from fastapi import HTTPException, WebSocket
@@ -17,15 +18,24 @@ _USER = UserInfo(id="user-1", username="tester", role=UserRole.ADMIN)
 
 
 class FakeWebSocket:
-    """Minimal stand-in implementing the surface the stream handler uses."""
+    """Minimal stand-in implementing the surface the stream handler uses.
+
+    ``messages`` scripts what ``receive()`` yields after the config message;
+    once exhausted, a disconnect message is returned. ``fail_sends_after``
+    makes ``send_text`` raise once that many messages have been sent.
+    """
 
     def __init__(
         self,
         config_text: str,
         headers: dict | None = None,
         query: dict | None = None,
+        messages: list[dict] | None = None,
+        fail_sends_after: int | None = None,
     ):
         self._config_text = config_text
+        self._messages = list(messages or [])
+        self._fail_sends_after = fail_sends_after
         self.headers = headers or {}
         self.query_params = query or {}
         self.sent: list[dict] = []
@@ -39,7 +49,17 @@ class FakeWebSocket:
     async def receive_text(self) -> str:
         return self._config_text
 
+    async def receive(self) -> dict:
+        if self._messages:
+            return self._messages.pop(0)
+        return {"type": "websocket.disconnect"}
+
     async def send_text(self, text: str) -> None:
+        if (
+            self._fail_sends_after is not None
+            and len(self.sent) >= self._fail_sends_after
+        ):
+            raise RuntimeError("send failed")
         self.sent.append(json.loads(text))
 
     async def close(self, code: int = 1000, reason: str = "") -> None:
@@ -49,6 +69,58 @@ class FakeWebSocket:
 
 def as_ws(fake: FakeWebSocket) -> WebSocket:
     return cast(WebSocket, fake)
+
+
+class StubTranscriber:
+    """Replaces StreamingTranscriber so handler tests skip Pipecat entirely."""
+
+    def __init__(self, stt_service, *, sample_rate, on_transcript):
+        self.on_transcript = on_transcript
+        self.fed: list[bytes] = []
+        self.stopped = False
+        self.failed = False
+        self.start_error: str | None = None
+        self.emit_on_feed = False
+
+    async def start(self) -> None:
+        if self.start_error:
+            raise RuntimeError(self.start_error)
+
+    async def feed(self, audio: bytes) -> None:
+        self.fed.append(audio)
+        if self.emit_on_feed:
+            from app.ai.voice.stt.streaming import TranscriptEvent
+
+            await self.on_transcript(TranscriptEvent(text="hi", is_final=True))
+
+    async def stop(self) -> None:
+        self.stopped = True
+
+
+@pytest.fixture
+def stream_env(monkeypatch: pytest.MonkeyPatch) -> dict:
+    """Patch auth, provider factory, limits, and the transcriber."""
+    created: dict = {}
+
+    def _make(stt_service, *, sample_rate, on_transcript):
+        stub = StubTranscriber(
+            stt_service, sample_rate=sample_rate, on_transcript=on_transcript
+        )
+        created["transcriber"] = stub
+        for attr, value in created.get("presets", {}).items():
+            setattr(stub, attr, value)
+        return stub
+
+    monkeypatch.setattr(handlers, "get_user_from_websocket", lambda ws: _USER)
+    create_mock = AsyncMock(return_value=object())
+    monkeypatch.setattr(handlers, "create_stt_from_config", create_mock)
+    created["create_stt"] = create_mock
+    monkeypatch.setattr(handlers, "STT_STREAM_MAX_SECONDS", AsyncMock(return_value=300))
+    monkeypatch.setattr(
+        handlers, "STT_STREAM_IDLE_TIMEOUT_SECONDS", AsyncMock(return_value=60)
+    )
+    monkeypatch.setattr(handlers, "StreamingTranscriber", _make)
+    return created
 
 
 def test_stream_request_normalizes_and_bounds() -> None:
@@ -87,9 +159,7 @@ def test_websocket_auth_reads_header_then_query(
         rbac_token.get_user_from_websocket(as_ws(FakeWebSocket("")))
 
 
-async def test_stream_rejects_unauthenticated(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+async def test_stream_rejects_unauthenticated() -> None:
     ws = FakeWebSocket("{}")
     await handlers.handle_transcription_stream(as_ws(ws))
 
@@ -134,3 +204,117 @@ async def test_stream_rejects_sarvam_sample_rate_mismatch(
     assert ws.sent[-1]["type"] == "error"
     assert "sample_rate" in ws.sent[-1]["message"]
     assert ws.closed is not None and ws.closed[0] == 4400
+
+
+async def test_stream_rejects_provider_startup_failure(stream_env: dict) -> None:
+    stream_env["presets"] = {"start_error": "connect refused"}
+
+    ws = FakeWebSocket(json.dumps({"provider": "soniox"}))
+    await handlers.handle_transcription_stream(as_ws(ws))
+
+    assert all(event["type"] != "ready" for event in ws.sent)
+    assert ws.sent[-1]["type"] == "error"
+    assert "provider connection failed" in ws.sent[-1]["message"]
+    assert ws.closed is not None and ws.closed[0] == 4400
+
+
+async def test_stream_rejects_oversized_chunk(stream_env: dict) -> None:
+    big = b"x" * (handlers._MAX_CHUNK_BYTES + 1)
+    ws = FakeWebSocket(
+        json.dumps({"provider": "soniox"}),
+        messages=[{"type": "websocket.receive", "bytes": big}],
+    )
+    await handlers.handle_transcription_stream(as_ws(ws))
+
+    assert stream_env["transcriber"].fed == []
+    assert stream_env["transcriber"].stopped
+    assert ws.sent[-1]["type"] == "error"
+    assert "chunk exceeds" in ws.sent[-1]["message"]
+    assert ws.closed is not None and ws.closed[0] == 4400
+
+
+async def test_stream_feeds_audio_and_forwards_transcripts(stream_env: dict) -> None:
+    stream_env["presets"] = {"emit_on_feed": True}
+    chunk = b"\x00\x01" * 100
+    ws = FakeWebSocket(
+        json.dumps({"provider": "soniox"}),
+        messages=[
+            {"type": "websocket.receive", "bytes": chunk},
+            {"type": "websocket.receive", "text": json.dumps({"type": "stop"})},
+        ],
+    )
+    await handlers.handle_transcription_stream(as_ws(ws))
+
+    assert stream_env["transcriber"].fed == [chunk]
+    assert stream_env["transcriber"].stopped
+    types = [event["type"] for event in ws.sent]
+    assert types[0] == "ready"
+    assert "final" in types
+    assert ws.closed is not None and ws.closed[0] == 1000
+
+
+async def test_stream_passes_nested_provider_config(stream_env: dict) -> None:
+    ws = FakeWebSocket(
+        json.dumps(
+            {
+                "provider": "soniox",
+                "soniox": {"context": "acme brands", "model": "stt-rt-v4"},
+            }
+        )
+    )
+    await handlers.handle_transcription_stream(as_ws(ws))
+
+    config = stream_env["create_stt"].await_args.args[0]
+    assert config.provider.value == "soniox"
+    assert config.soniox is not None
+    assert config.soniox.context == "acme brands"
+    assert config.soniox.model == "stt-rt-v4"
+
+
+async def test_stream_flat_model_builds_nested_config(stream_env: dict) -> None:
+    ws = FakeWebSocket(json.dumps({"provider": "deepgram", "model": "nova-3-medical"}))
+    await handlers.handle_transcription_stream(as_ws(ws))
+
+    config = stream_env["create_stt"].await_args.args[0]
+    assert config.deepgram is not None
+    assert config.deepgram.model == "nova-3-medical"
+    assert config.soniox is None
+
+
+async def test_stream_flat_model_fills_nested_config_without_model(
+    stream_env: dict,
+) -> None:
+    ws = FakeWebSocket(
+        json.dumps(
+            {
+                "provider": "deepgram",
+                "model": "nova-3-medical",
+                "deepgram": {"endpointing_ms": 50},
+            }
+        )
+    )
+    await handlers.handle_transcription_stream(as_ws(ws))
+
+    config = stream_env["create_stt"].await_args.args[0]
+    assert config.deepgram is not None
+    assert config.deepgram.model == "nova-3-medical"
+    assert config.deepgram.endpointing_ms == 50
+
+
+async def test_stream_ends_when_client_send_fails(stream_env: dict) -> None:
+    stream_env["presets"] = {"emit_on_feed": True}
+    chunk = b"\x00\x01" * 100
+    # Allow only the "ready" send; the transcript forward then fails.
+    ws = FakeWebSocket(
+        json.dumps({"provider": "soniox"}),
+        messages=[
+            {"type": "websocket.receive", "bytes": chunk},
+            {"type": "websocket.receive", "bytes": chunk},
+        ],
+        fail_sends_after=1,
+    )
+    await handlers.handle_transcription_stream(as_ws(ws))
+
+    assert stream_env["transcriber"].stopped
+    assert ws.closed is not None and ws.closed[0] == 1011
+    assert ws.closed[1] == "client send failed"

--- a/tests/test_stt_transcribe_handler.py
+++ b/tests/test_stt_transcribe_handler.py
@@ -5,8 +5,10 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 import pytest
-from fastapi import UploadFile
+from fastapi import HTTPException, UploadFile
+from pydantic import ValidationError
 
+from app.ai.voice.stt import transcribe
 from app.api.routers.breeze_buddy.stt import handlers
 from app.schemas import UserInfo
 from app.schemas.breeze_buddy.auth import UserRole
@@ -22,6 +24,139 @@ def test_request_normalizes_provider_and_blank_fields() -> None:
     assert request.provider.value == "deepgram"
     assert request.model == "nova-3"
     assert request.language is None
+
+
+def test_request_parses_nested_config_from_json_string() -> None:
+    request = TranscriptionRequest.model_validate(
+        {"provider": "soniox", "soniox": '{"context": "brand names"}'}
+    )
+    assert request.soniox is not None
+    assert request.soniox.context == "brand names"
+
+    with pytest.raises(ValueError):
+        TranscriptionRequest.model_validate(
+            {"provider": "soniox", "soniox": "{not json"}
+        )
+
+
+def test_batch_model_and_options_resolution() -> None:
+    request = TranscriptionRequest.model_validate(
+        {"provider": "soniox", "model": "stt-async-v2", "soniox": {"context": "acme"}}
+    )
+    model, opts = handlers._batch_model_and_options(request)
+    assert model == "stt-async-v2"
+    assert opts == {"context": "acme"}
+
+    request = TranscriptionRequest.model_validate(
+        {
+            "provider": "deepgram",
+            "model": "ignored",
+            "deepgram": {"model": "nova-3-medical", "numerals": False},
+        }
+    )
+    model, opts = handlers._batch_model_and_options(request)
+    assert model == "nova-3-medical"
+    assert opts == {"numerals": False}
+
+    request = TranscriptionRequest.model_validate(
+        {"provider": "sarvam", "sarvam": {"language_code": "hi-IN"}}
+    )
+    assert handlers._batch_model_and_options(request) == (
+        None,
+        {"language_code": "hi-IN"},
+    )
+
+    request = TranscriptionRequest.model_validate(
+        {"provider": "openai", "model": "whisper-1"}
+    )
+    assert handlers._batch_model_and_options(request) == ("whisper-1", None)
+
+    # Deepgram nested config WITHOUT an explicit model: the flat model must
+    # win over the schema default ("nova-3-general"), same as other providers.
+    request = TranscriptionRequest.model_validate(
+        {
+            "provider": "deepgram",
+            "model": "nova-3-medical",
+            "deepgram": {"numerals": False},
+        }
+    )
+    model, opts = handlers._batch_model_and_options(request)
+    assert model == "nova-3-medical"
+    assert opts is not None and opts["numerals"] is False
+
+
+def test_hostile_json_config_is_422_not_500() -> None:
+    deep = "[" * 1500 + "]" * 1500
+    with pytest.raises(ValidationError):
+        TranscriptionRequest.model_validate({"provider": "soniox", "soniox": deep})
+
+    huge = '{"context": "' + "x" * (70 * 1024) + '"}'
+    with pytest.raises(ValidationError):
+        TranscriptionRequest.model_validate({"provider": "soniox", "soniox": huge})
+
+
+async def test_strict_mode_does_not_fall_back_to_whisper(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(transcribe, "SONIOX_API_KEY", "key")
+    monkeypatch.setattr(transcribe, "OPENAI_STT_API_KEY", "key")
+    monkeypatch.setattr(
+        transcribe, "_soniox", AsyncMock(side_effect=RuntimeError("boom"))
+    )
+    whisper = AsyncMock(
+        return_value=transcribe.Transcription(
+            text="hi", provider="openai", model="whisper-1"
+        )
+    )
+    monkeypatch.setattr(transcribe, "_openai", whisper)
+
+    # Explicit model pin: provider failure must raise, never degrade.
+    with pytest.raises(transcribe.TranscriptionError):
+        await transcribe.transcribe_audio(
+            b"x", None, provider="soniox", model="stt-rt-v4"
+        )
+    whisper.assert_not_awaited()
+
+    # Provider options pin behaves the same.
+    with pytest.raises(transcribe.TranscriptionError):
+        await transcribe.transcribe_audio(
+            b"x", None, provider="soniox", options={"context": "acme"}
+        )
+    whisper.assert_not_awaited()
+
+    # Provider-default requests keep the fail-open Whisper behavior.
+    result = await transcribe.transcribe_audio(b"x", None, provider="soniox")
+    assert result.provider == "openai"
+    whisper.assert_awaited()
+
+
+async def test_strict_mode_errors_when_provider_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(transcribe, "SONIOX_API_KEY", "")
+    monkeypatch.setattr(transcribe, "OPENAI_STT_API_KEY", "key")
+    whisper = AsyncMock(
+        return_value=transcribe.Transcription(
+            text="hi", provider="openai", model="whisper-1"
+        )
+    )
+    monkeypatch.setattr(transcribe, "_openai", whisper)
+
+    with pytest.raises(transcribe.TranscriptionError):
+        await transcribe.transcribe_audio(
+            b"x", None, provider="soniox", model="stt-rt-v4"
+        )
+    whisper.assert_not_awaited()
+
+
+async def test_google_model_override_rejected_with_400() -> None:
+    with pytest.raises(HTTPException) as exc:
+        await handlers.handle_transcription_request(
+            UploadFile(BytesIO(b"audio"), filename="clip.webm"),
+            TranscriptionRequest(provider="google", model="latest_long"),
+            _USER,
+        )
+    assert exc.value.status_code == 400
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Replaces #944 and #945 (closed) — same changes consolidated into one single-commit PR per repo convention, plus strict model pinning added per follow-up discussion.

## Part 1 — Realtime stream hardening (Tara-ag's review items on #941, all 3 MAJOR + 4 MINOR)

- **Ready-before-connect race**: `StreamingTranscriber` hooks Pipecat's `on_pipeline_error` (how provider websocket connect/auth failures actually surface — as `ErrorFrame`s) and `start()` waits a 1 s grace window. Failures now reject with **4400 "provider connection failed" before `ready` is ever sent**; the same signal exposes mid-stream provider death → `"provider connection lost"` + 1011 close instead of silently eating audio.
- **Dropped transcripts**: `_forward` checks `send_message`'s result; a failed send flags a shared event and the receive loop tears down with 1011 "client send failed" rather than dropping transcripts while paying the provider.
- **Chunk cap**: binary frames limited to **256 KiB** (~2.5 s of 48 kHz PCM16 mono); oversized → error event + 4400.
- **Logging hygiene**: exception class names in emitter/teardown logs, `logger.exception` (traceback preserved) in the receive loop, intentional swallow-on-close-path documented.

## Part 2 — Full provider STT configuration (batch + realtime)

Both request schemas embed the **template config models from `template/types.py`** (the source of truth) as optional nested `soniox` / `deepgram` / `sarvam` fields — anything a template can tune, an API caller now can (Soniox `context` + `enable_language_identification`, Deepgram model/formatting/endpointing, Sarvam `language_code`), and future template fields inherit automatically.

**Precedence** (documented): the selected provider's nested config wins over the flat `model` shortcut; other providers' configs are ignored.

- **Realtime**: nested config passes verbatim into `create_stt_from_config` — a stream with `{"soniox": {"context": "..."}}` behaves exactly like a template configured the same way.
- **Batch**: multipart form takes the configs as JSON strings (`-F 'soniox={"context": "..."}'`, bad JSON → 422). The core forwards what each one-shot API supports: Soniox async jobs get `context`/`enable_language_identification`; Deepgram pre-recorded gets `smart_format`/`punctuate`/`numerals`/`profanity_filter`/`diarize`/`auto_detect_language` (streaming-only knobs deliberately withheld); Sarvam takes explicit `language_code`.

## Part 3 — Strict model/options pinning (no silent degradation)

An explicit `model` or nested provider config now **disables the Whisper fail-open** in `transcribe_audio`: if the pinned provider fails or its API key is unset, the request raises `TranscriptionError` → **502**, instead of silently returning a Whisper transcript that ignores what was asked for. Provider-default requests (e.g. widget push-to-talk) keep the original "just works" fallback. `google` + `model` on the batch endpoint is rejected with **400**, mirroring the stream's existing rejection.

## Tests

20 passing: startup-failure rejection (asserts no `ready`), oversized-chunk rejection, client-send-failure teardown, happy-path feed→forward, JSON-string config parsing (incl. invalid JSON), `_batch_model_and_options` resolution matrix, nested-config passthrough, flat-model synthesis, strict-mode no-fallback on provider failure and on missing key (asserts Whisper never invoked), google+model → 400. black/isort/autoflake/pyrefly clean.

Pre-rollout staging checklist: live Soniox websocket smoke test for the stream, plus verifying the Soniox *async* API accepts `context`/`enable_language_identification` — with strict pinning a rejected field now surfaces as a 502 (by design) rather than degrading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Bj4ySkGkJ5zGdtLRbP4w4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added provider-specific transcription settings for batch and streaming requests.
  * Added stricter model and provider selection, with explicit failures instead of automatic Whisper fallback when settings are pinned.
  * Added streaming safeguards for provider startup failures, oversized audio chunks, and client delivery failures.

* **Bug Fixes**
  * Improved validation and error handling for malformed provider configuration.
  * Expanded transcription support for formatting, language detection, diarization, and related provider options.

* **Documentation**
  * Clarified streaming limits, close codes, and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->