### PR TITLE
chore(db): drop the outbound_number compat view (migration 039)

### DIFF
--- a/app/database/migrations/039_drop_outbound_number_compat_view.sql
+++ b/app/database/migrations/039_drop_outbound_number_compat_view.sql
@@ -1,0 +1,14 @@
+-- Migration 039: Drop the outbound_number compatibility view
+-- Description: Migration 038 renamed outbound_number -> telephony_numbers and
+--   left an updatable VIEW under the old name so pods still running the
+--   pre-rename release kept working during the rolling deploy. That deploy
+--   completed on 2026-07-22 and every pod has been on post-rename code since;
+--   the view's rollback-insurance window is over.
+-- Safety: verified no live code references the bare outbound_number relation —
+--   the only matches in the repo are historical migration files (never
+--   re-run) and Plivo request payload keys (dict keys, not SQL).
+-- Note: this intentionally does NOT touch the wire-visible column names
+--   (template.outbound_number_id, lead_call_tracker.outbound_number_id) —
+--   those retire via the dual-field API window, not a DB migration.
+
+DROP VIEW IF EXISTS outbound_number;


### PR DESCRIPTION
## What

One migration, one statement: `DROP VIEW IF EXISTS outbound_number;`

## Why

Migration 038 (PR #934) renamed `outbound_number` → `telephony_numbers` and left an updatable compatibility VIEW under the old name so pods still running pre-rename code kept working during the rolling deploy. That deploy completed 2026-07-22; every pod has been on post-rename code since, and no rollback is contemplated. The view's insurance window is over.

## Safety checks done

- Swept the repo for references to the bare `outbound_number` relation (`FROM|JOIN|UPDATE|INTO|TABLE|VIEW outbound_number`): only historical migration files (never re-run) and Plivo request payload dict keys match. No live SQL touches the view.
- Applied on the local database: view dropped, `telephony_numbers` table and row count intact, `migrate.py status` clean.
- `IF EXISTS` guard makes the migration idempotent and safe on environments where the view was never created.

Wire-visible column names (`template.outbound_number_id`, `lead_call_tracker.outbound_number_id`) are untouched — they retire via the dual-field API window (separate PR).

## Prod

After merge, prod apply is the usual `scripts/migrate.py` run during the next release — no data movement, metadata-only drop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the legacy outbound number compatibility view now that the transition period is complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->