### PR TITLE
fix(stt): flatten /transcribe form fields so multipart requests validate

### DIFF
--- a/app/api/routers/breeze_buddy/stt/__init__.py
+++ b/app/api/routers/breeze_buddy/stt/__init__.py
@@ -13,9 +13,11 @@ and machine (S2S) callers can reach them (the WebSocket accepts the token via
 ``Authorization`` header or ``?token=`` query param).
 """
 
-from typing import Annotated
+from typing import Any, Dict, List, Optional
 
 from fastapi import APIRouter, Depends, File, Form, UploadFile, WebSocket
+from fastapi.exceptions import RequestValidationError
+from pydantic import ValidationError
 
 from app.api.security.breeze_buddy.rbac_token import get_current_user_with_rbac
 from app.schemas import UserInfo
@@ -26,14 +28,71 @@ from .handlers import handle_transcription_request, handle_transcription_stream
 router = APIRouter(prefix="/stt", tags=["stt"])
 
 
+# Cap on how much of an invalid value a 422 echoes back in ``input``: the
+# nested-config form fields accept JSON strings up to 64 KiB, and a
+# validation failure should not reflect that much caller data into the
+# error body.
+_MAX_ERROR_INPUT_CHARS = 200
+
+
+def _body_errors(exc: ValidationError) -> List[Dict[str, Any]]:
+    """Re-shape manual-validation errors to FastAPI's native 422 format.
+
+    Prefix ``loc`` with ``body`` (as FastAPI's own request validation does),
+    drop ``ctx`` (its values may not be JSON-serializable), and truncate
+    long string ``input`` echoes.
+    """
+    errors: List[Dict[str, Any]] = []
+    for err in exc.errors(include_url=False):
+        cleaned: Dict[str, Any] = {k: v for k, v in err.items() if k != "ctx"}
+        cleaned["loc"] = ("body", *err["loc"])
+        value = cleaned.get("input")
+        if isinstance(value, str) and len(value) > _MAX_ERROR_INPUT_CHARS:
+            cleaned["input"] = value[:_MAX_ERROR_INPUT_CHARS] + "…[truncated]"
+        errors.append(cleaned)
+    return errors
+
+
 @router.post(
     "/transcribe",
     response_model=TranscriptionResponse,
     summary="Transcribe an audio clip to text (provider/model chosen per-request)",
 )
 async def transcribe(
-    request: Annotated[TranscriptionRequest, Form()],
-    audio: UploadFile = File(...),
+    audio: UploadFile = File(
+        ..., description="Audio clip: WAV, MP3, WebM/Opus, M4A, OGG, FLAC."
+    ),
+    provider: str = Form(
+        ...,
+        description=(
+            "STT provider: soniox | deepgram | sarvam | openai | google "
+            "(case-insensitive, trimmed)."
+        ),
+    ),
+    model: Optional[str] = Form(
+        None,
+        description="Model id override; blank/omitted = the provider's default.",
+    ),
+    language: Optional[str] = Form(
+        None,
+        description="BCP-47 / ISO-639 language hint; blank/omitted = auto-detect.",
+    ),
+    soniox: Optional[str] = Form(
+        None,
+        description=(
+            "JSON-encoded SonioxSTTConfig, e.g. "
+            '{"context": "Breeze Buddy, UPI"}. A model set here wins over '
+            "the flat model field."
+        ),
+    ),
+    deepgram: Optional[str] = Form(
+        None,
+        description="JSON-encoded DeepgramSTTConfig (smart_format, numerals, ...).",
+    ),
+    sarvam: Optional[str] = Form(
+        None,
+        description="JSON-encoded SarvamSTTConfig (language_code, ...).",
+    ),
     current_user: UserInfo = Depends(get_current_user_with_rbac),
 ) -> TranscriptionResponse:
     """One-shot speech-to-text, independent of any widget session or template.
@@ -42,7 +101,27 @@ async def transcribe(
     ``sarvam`` | ``openai`` | ``google``) and optional ``model``/``language``;
     get the transcript back. The response reports the provider and model that
     actually produced the text (OpenAI Whisper when the core falls back).
+
+    The form fields are declared individually rather than as
+    ``Annotated[TranscriptionRequest, Form()]``: with a ``File`` param in the
+    same signature, FastAPI 0.115 embeds the form model under its param name
+    (expecting a ``request`` object field) instead of flattening it — a shape
+    multipart form data cannot express, so every upload would 422.
+    ``TranscriptionRequest`` still does all the validation below.
     """
+    try:
+        request = TranscriptionRequest.model_validate(
+            {
+                "provider": provider,
+                "model": model,
+                "language": language,
+                "soniox": soniox,
+                "deepgram": deepgram,
+                "sarvam": sarvam,
+            }
+        )
+    except ValidationError as exc:
+        raise RequestValidationError(_body_errors(exc)) from None
     return await handle_transcription_request(audio, request, current_user)
 
 


### PR DESCRIPTION
## Problem

`POST /agent/voice/breeze-buddy/stt/transcribe` rejects **every** request in production with:

```json
{"detail": [{"type": "missing", "loc": ["body", "request"], "msg": "Field required", "input": null}]}
```

Root cause: the endpoint declared its form fields as `request: Annotated[TranscriptionRequest, Form()]` alongside `audio: UploadFile = File(...)`. FastAPI only flattens a `Form()` Pydantic model when it is the *sole* body parameter — with the `File` param present, FastAPI 0.115 embeds the model under its param name, so validation demands a `request` **object** field. Multipart form data cannot express a nested object, so no client payload can satisfy the endpoint:

- flattened fields (what the dashboard and the docs use) → 422 `body.request` missing
- `request` as a JSON string form field → 422 `model_attributes_type` (Pydantic won't parse a string into the model)

Reproduced on the exact pinned versions (fastapi 0.115.12, pydantic 2.12.5, python-multipart 0.0.22).

## Fix

Declare the form fields individually (`provider`, `model`, `language`, `soniox`, `deepgram`, `sarvam`) and run them through `TranscriptionRequest.model_validate(...)` — the schema and all its field validators (JSON-string parsing, blank-to-none, provider normalization, config-size caps) still do the validation. `ValidationError` is re-raised as `RequestValidationError` with `body`-prefixed locs (and non-serializable `ctx` dropped), so 422 responses keep FastAPI's native shape.

The WS `/stream` endpoint parses its config message manually and is unaffected. No other endpoint uses the Form-model + File pattern.

## Verification

TestClient against this router (auth overridden, handler mocked at the router boundary):

| Case | Result |
|---|---|
| Dashboard's flattened multipart shape (`provider` + `model` + `soniox` JSON string) | 200, parsed request carries provider enum, model, `soniox.context` |
| Unknown provider | 422 `body.provider` with enum message |
| Malformed nested-config JSON | 422 `body.soniox` |
| Minimal (`provider` only) | 200 |

Also: `black` / `isort` clean, `pyrefly check` 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Bj4ySkGkJ5zGdtLRbP4w4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for audio transcription requests.
  * Malformed or incomplete form submissions now return consistent, standard validation errors.
  * Preserved existing transcription and streaming behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->