### PR TITLE
add template_id and template_name in deprecated field warnings

### DIFF
--- a/app/ai/voice/agents/breeze_buddy/template/types.py
+++ b/app/ai/voice/agents/breeze_buddy/template/types.py
@@ -12,13 +12,14 @@ from pydantic import (
     SecretStr,
     SerializationInfo,
     StringConstraints,
+    ValidationInfo,
     field_serializer,
     model_validator,
 )
 
 from app.ai.voice.agents.breeze_buddy.template.ui_catalog import ActionUnion, Icon
 from app.ai.voice.llm.types import LLMConfiguration
-from app.core.deprecation import log_deprecated_fields
+from app.core.deprecation import format_template_ref, log_deprecated_fields
 from app.core.logger import logger
 
 
@@ -326,12 +327,13 @@ class NoiseFilterConfig(BaseModel):
         return self
 
     @model_validator(mode="after")
-    def _warn_deprecated_fields(self) -> "NoiseFilterConfig":
+    def _warn_deprecated_fields(self, info: ValidationInfo) -> "NoiseFilterConfig":
         log_deprecated_fields(
             self,
             {
                 "type": "noise_filter.provider/noise_filter.model",
             },
+            context=info.context,
         )
         return self
 
@@ -1636,7 +1638,7 @@ class ConfigurationModel(BaseModel):
 
     @model_validator(mode="before")
     @classmethod
-    def _pre_validate(cls, data: Any) -> Any:
+    def _pre_validate(cls, data: Any, info: ValidationInfo) -> Any:
         """Pre-validation: auto-fill override providers + migrate flat IVR fields."""
         if not isinstance(data, dict):
             return data
@@ -1660,11 +1662,15 @@ class ConfigurationModel(BaseModel):
             if ivr:
                 data["ivr_configuration"] = ivr
                 # Log deprecation warnings for each migrated field
+                ctx = info.context if isinstance(info.context, dict) else {}
+                ref = format_template_ref(
+                    ctx.get("template_id"), ctx.get("template_name")
+                )
                 for old_field in ("ivr_greeting", "ivr_goodbye", "ivr_priority"):
                     if data.get(old_field) is not None:
                         new_field = old_field.replace("ivr_", "")
                         logger.warning(
-                            f"[Deprecated] field '{old_field}' is set. "
+                            f"[Deprecated] field '{old_field}' is set{ref}. "
                             f"Use 'ivr_configuration.{new_field}' instead."
                         )
 
@@ -1788,7 +1794,7 @@ class ConfigurationModel(BaseModel):
     )
 
     @model_validator(mode="after")
-    def _warn_deprecated_fields(self):
+    def _warn_deprecated_fields(self, info: ValidationInfo):
         log_deprecated_fields(
             self,
             {
@@ -1797,6 +1803,7 @@ class ConfigurationModel(BaseModel):
                 "payload_based_language_selection": "stt_configuration.payload_based_language_selection",
                 "mira_voice_id": "cartesia_voice_configurations.voice_id",
             },
+            context=info.context,
         )
         return self
 

--- a/app/core/deprecation.py
+++ b/app/core/deprecation.py
@@ -31,7 +31,7 @@ from __future__ import annotations
 
 import functools
 import inspect
-from typing import Any, Callable, Dict
+from typing import Any, Callable, Dict, Optional
 
 from pydantic import BaseModel
 
@@ -98,9 +98,28 @@ def deprecated(
     return decorator
 
 
+def _sanitize(value: Any) -> str:
+    """Strip control characters so metadata can't corrupt log records."""
+    return "".join(ch for ch in str(value) if ch.isprintable())
+
+
+def format_template_ref(
+    template_id: Optional[str] = None,
+    template_name: Optional[str] = None,
+) -> str:
+    """Build a ``" (template_id=..., template_name='...')"`` log suffix."""
+    if not template_id:
+        return ""
+    ref = f" (template_id={_sanitize(template_id)}"
+    if template_name:
+        ref += f", template_name='{_sanitize(template_name)}'"
+    return ref + ")"
+
+
 def log_deprecated_fields(
     instance: BaseModel,
     field_map: Dict[str, str],
+    context: Optional[Dict[str, Any]] = None,
 ) -> None:
     """Log warnings for deprecated Pydantic fields that were explicitly set.
 
@@ -114,6 +133,8 @@ def log_deprecated_fields(
     Args:
         instance: The Pydantic model instance to check.
         field_map: Mapping of ``{deprecated_field: replacement_path}``.
+        context: Optional identity info (e.g. Pydantic validation context
+            with ``template_id`` / ``template_name``) appended to the message.
 
     Example::
 
@@ -128,6 +149,9 @@ def log_deprecated_fields(
                 })
                 return self
     """
+    ctx = context if isinstance(context, dict) else {}
+    ref = format_template_ref(ctx.get("template_id"), ctx.get("template_name"))
+
     for old_field, new_path in field_map.items():
         if old_field in instance.model_fields_set:
             value = getattr(instance, old_field, None)
@@ -141,9 +165,10 @@ def log_deprecated_fields(
             except Exception:
                 length = -1
             logger.warning(
-                "[Deprecated] field '{}' is set (type: {}, length: {}). Use '{}' instead.",
+                "[Deprecated] field '{}' is set (type: {}, length: {}){}. Use '{}' instead.",
                 old_field,
                 type_name,
                 length,
+                ref,
                 new_path,
             )

--- a/app/database/decoder/breeze_buddy/template.py
+++ b/app/database/decoder/breeze_buddy/template.py
@@ -12,6 +12,7 @@ from app.ai.voice.agents.breeze_buddy.template.types import (
     ConfigurationModel,
     TemplateModel,
 )
+from app.core.deprecation import format_template_ref
 from app.core.logger import logger
 
 
@@ -32,7 +33,9 @@ def _to_provider_config(provider: str, raw: Dict[str, Any]) -> Dict[str, Any]:
     return {k: v for k, v in cfg.items() if v is not None}
 
 
-def _migrate_legacy_voice_config(data: Dict[str, Any]) -> Dict[str, Any]:
+def _migrate_legacy_voice_config(
+    data: Dict[str, Any], template_id: str = "", template_name: str = ""
+) -> Dict[str, Any]:
     """Convert old-format voice fields to the new unified tts_configuration.
 
     Handles templates stored with the old schema:
@@ -44,6 +47,8 @@ def _migrate_legacy_voice_config(data: Dict[str, Any]) -> Dict[str, Any]:
     Transforms them into tts_configuration + tts_configuration_overrides.
     Already-migrated templates (with tts_configuration) pass through unchanged.
     """
+    ref = format_template_ref(template_id, template_name)
+
     if "tts_configuration" in data and data["tts_configuration"]:
         # Already in new format — strip old fields if present
         for old_key in [
@@ -66,7 +71,7 @@ def _migrate_legacy_voice_config(data: Dict[str, Any]) -> Dict[str, Any]:
         )
         default_provider = LEGACY_VOICE_TO_PROVIDER.get(name)
         logger.warning(
-            f"[Deprecated] field 'tts_voice_name' is set (value: '{name}'). "
+            f"[Deprecated] field 'tts_voice_name' is set (value: '{name}'){ref}. "
             "Use 'tts_configuration.provider' instead."
         )
 
@@ -77,17 +82,17 @@ def _migrate_legacy_voice_config(data: Dict[str, Any]) -> Dict[str, Any]:
 
     if old_cartesia:
         logger.warning(
-            "[Deprecated] field 'cartesia_voice_configurations' is set. "
+            f"[Deprecated] field 'cartesia_voice_configurations' is set{ref}. "
             "Use 'tts_configuration_overrides.cartesia' instead."
         )
     if old_elevenlabs:
         logger.warning(
-            "[Deprecated] field 'elevenlabs_voice_configurations' is set. "
+            f"[Deprecated] field 'elevenlabs_voice_configurations' is set{ref}. "
             "Use 'tts_configuration_overrides.elevenlabs' instead."
         )
     if old_mira_voice_id:
         logger.warning(
-            "[Deprecated] field 'mira_voice_id' is set. "
+            f"[Deprecated] field 'mira_voice_id' is set{ref}. "
             "Use 'tts_configuration_overrides.cartesia.voice_id' instead."
         )
 
@@ -173,10 +178,20 @@ def decode_template(result: asyncpg.Record) -> Optional[TemplateModel]:
             configurations_data = json.loads(configurations_data)
 
         # Migrate old voice fields to new unified voice_config
-        configurations_data = _migrate_legacy_voice_config(configurations_data)
+        configurations_data = _migrate_legacy_voice_config(
+            configurations_data,
+            template_id=str(result["id"]),
+            template_name=result["name"],
+        )
 
-        # Create ConfigurationModel from the parsed data
-        configurations = ConfigurationModel(**configurations_data)
+        # Create ConfigurationModel from the parsed data.
+        configurations = ConfigurationModel.model_validate(
+            configurations_data,
+            context={
+                "template_id": str(result["id"]),
+                "template_name": result["name"],
+            },
+        )
 
     # Parse secrets from JSONB (can be str, dict, or None)
     secrets_data = result.get("secrets")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deprecation warnings for legacy voice configuration fields.
  * Warnings now include relevant template details, making migration issues easier to identify.
  * Added contextual information to warnings across legacy voice, language, speech-to-text, and text-to-speech settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->