### PR TITLE
fix(campaigns): count first-attempt connects as dialed; report attempts made

### DIFF
--- a/app/api/routers/breeze_buddy/analytics/handlers.py
+++ b/app/api/routers/breeze_buddy/analytics/handlers.py
@@ -348,7 +348,12 @@ def _build_call_detail_result(tracker: Dict[str, Any]) -> CallDetailResult:
         recording_url=tracker.get("recording_url"),
         transcript=transcript,
         calling_provider=tracker.get("calling_provider"),
-        attempt_count=tracker.get("attempt_count"),
+        # Attempts MADE, not the stored 0-based retry counter: the column
+        # counts scheduled retries, so a first-attempt connect stores 0.
+        # +1 only when a call was actually initiated (ABORTed-without-dial
+        # leads honestly show 0).
+        attempt_count=(tracker.get("attempt_count") or 0)
+        + (1 if tracker.get("call_initiated_time") else 0),
         cost=tracker.get("cost"),
         payload=payload,
         call_initiated_time=tracker.get("call_initiated_time"),

--- a/app/database/queries/breeze_buddy/analytics.py
+++ b/app/database/queries/breeze_buddy/analytics.py
@@ -462,7 +462,11 @@ def get_call_details_records_query(
             lct.call_initiated_time,
             lct.call_end_time,
             lct.outcome,
-            lct.attempt_count + 1 as attempt_count,
+            -- attempts MADE: the stored column is a 0-based retry counter,
+            -- and never-dialed leads (ABORT before any call) must show 0
+            lct.attempt_count
+                + CASE WHEN lct.call_initiated_time IS NOT NULL THEN 1 ELSE 0 END
+                as attempt_count,
             ou.provider as calling_provider
         FROM "{LEAD_CALL_TRACKER_TABLE}" lct
         LEFT JOIN "{TELEPHONY_NUMBER_TABLE}" ou ON lct.telephony_number_id = ou.id

--- a/app/database/queries/breeze_buddy/campaigns.py
+++ b/app/database/queries/breeze_buddy/campaigns.py
@@ -106,7 +106,16 @@ def campaign_stats_query(campaign_ids: List[str]) -> Tuple[str, List[Any]]:
     honesty rule: a finished lead counts as picked unless its outcome is
     NO_ANSWER (BUSY etc. count as answered) — and never when it was ABORTed
     (a stopped campaign's leads finish with ABORT and zero attempts; counting
-    them as picked showed "Answered 1 / Dialed 0")."""
+    them as picked showed "Answered 1 / Dialed 0").
+
+    `dialed` = at least one call initiated. attempt_count alone is the WRONG
+    predicate for this: the stored column is 0-based (it counts scheduled
+    RETRIES — analytics displays attempt_count + 1), so a lead answered on
+    its first attempt finishes with attempt_count = 0 and a completed
+    campaign showed "0 / N dialed". call_initiated_time is stamped when a
+    call is initiated; the attempt_count > 0 arm keeps retried leads counted
+    even if that stamp is missing on an old row. ABORTed-without-dialing
+    leads have neither, so they stay out."""
     return (
         """
         SELECT
@@ -115,7 +124,9 @@ def campaign_stats_query(campaign_ids: List[str]) -> Tuple[str, List[Any]]:
             COUNT(*) FILTER (WHERE status = 'BACKLOG') AS backlog,
             COUNT(*) FILTER (WHERE status = 'PROCESSING') AS processing,
             COUNT(*) FILTER (WHERE status = 'FINISHED') AS finished,
-            COUNT(*) FILTER (WHERE attempt_count > 0) AS dialed,
+            COUNT(*) FILTER (
+                WHERE attempt_count > 0 OR call_initiated_time IS NOT NULL
+            ) AS dialed,
             COUNT(*) FILTER (
                 WHERE status = 'FINISHED'
                   AND outcome IS NOT NULL

--- a/tests/breeze_buddy/test_campaign_progress.py
+++ b/tests/breeze_buddy/test_campaign_progress.py
@@ -1,0 +1,70 @@
+"""
+Campaign progress correctness: `dialed` and per-lead attempt counts.
+
+The stored lead_call_tracker.attempt_count is a 0-BASED retry counter (a
+lead answered on its first attempt finishes with 0), so anything that
+means "attempts made" must add 1 when a call was actually initiated —
+and never for leads that finished without a dial (ABORT).
+"""
+
+from datetime import datetime, timezone
+from typing import Any, Dict
+
+from app.api.routers.breeze_buddy.analytics.handlers import (
+    _build_call_detail_result,
+)
+from app.database.queries.breeze_buddy.campaigns import (
+    campaign_stats_query,
+)
+
+_NOW = datetime(2026, 7, 21, 12, 0, tzinfo=timezone.utc)
+
+
+def _tracker(**over: Any) -> Dict[str, Any]:
+    base = {
+        "id": "lead-1",
+        "call_id": "call-1",
+        "request_id": None,
+        "template": "t",
+        "reseller_id": "rs",
+        "merchant_id": None,
+        "status": "FINISHED",
+        "outcome": "INTERESTED",
+        "recording_url": None,
+        "calling_provider": None,
+        "attempt_count": 0,
+        "cost": None,
+        "payload": None,
+        "meta_data": None,
+        "call_initiated_time": _NOW,
+        "created_at": _NOW,
+        "updated_at": _NOW,
+        "execution_mode": "TELEPHONY",
+        "call_direction": "OUTBOUND",
+    }
+    base.update(over)
+    return base
+
+
+def test_first_attempt_connect_counts_as_one_attempt():
+    r = _build_call_detail_result(_tracker(attempt_count=0))
+    assert r.attempt_count == 1
+
+
+def test_retried_lead_counts_stored_retries_plus_current():
+    r = _build_call_detail_result(_tracker(attempt_count=1))
+    assert r.attempt_count == 2
+
+
+def test_never_dialed_abort_shows_zero_attempts():
+    r = _build_call_detail_result(
+        _tracker(attempt_count=0, call_initiated_time=None, outcome="ABORT")
+    )
+    assert r.attempt_count == 0
+
+
+def test_dialed_predicate_covers_first_attempt_connects():
+    # Regression guard for "Completed campaign shows 0 / N dialed": the
+    # aggregate must not rely on attempt_count alone.
+    q, _ = campaign_stats_query(["c1"])
+    assert "attempt_count > 0 OR call_initiated_time IS NOT NULL" in q

--- a/tests/breeze_buddy/test_number_picker.py
+++ b/tests/breeze_buddy/test_number_picker.py
@@ -12,27 +12,21 @@ filter_numbers_by_rbac scopes reads: admins see the fleet; everyone else
 sees owned numbers plus the ids their templates pin.
 """
 
-import os
 from types import SimpleNamespace
 from typing import Any, Optional
 
 import pytest
 
-# Router import needs JWT env at module load time; these tests never mint or
-# verify tokens (same pattern as test_block_codec_visibility.py).
-os.environ.setdefault("JWT_SECRET_KEY", "test-secret-not-used-by-these-tests")
-os.environ.setdefault("JWT_ALGORITHM", "HS256")
-
 # Importing the dispatch package first initializes worker -> managers.calls in
 # the supported order; importing managers.calls directly trips the circular
 # import the dispatch/__init__ docstring warns about.
-import app.ai.voice.agents.breeze_buddy.dispatch  # noqa: E402,F401  (import order)
-import app.ai.voice.agents.breeze_buddy.managers.calls as calls_mod  # noqa: E402
-from app.api.routers.breeze_buddy.numbers.rbac import (  # noqa: E402
+import app.ai.voice.agents.breeze_buddy.dispatch  # noqa: F401  (import order)
+import app.ai.voice.agents.breeze_buddy.managers.calls as calls_mod
+from app.api.routers.breeze_buddy.numbers.rbac import (
     filter_numbers_by_rbac,
     require_number_in_tenant_scope,
 )
-from app.schemas import (  # noqa: E402
+from app.schemas import (
     CallProvider,
     TelephonyNumber,
     TelephonyNumberStatus,

--- a/tests/breeze_buddy/test_template_wire_alias.py
+++ b/tests/breeze_buddy/test_template_wire_alias.py
@@ -6,17 +6,13 @@ pin under BOTH keys (read-compat for old GET clients); operative old-key
 writes are logged [Deprecated].
 """
 
-import os
-
-os.environ.setdefault("JWT_SECRET_KEY", "test-secret")
-
-from app.ai.voice.agents.breeze_buddy.template.types import (  # noqa: E402
+from app.ai.voice.agents.breeze_buddy.template.types import (
     CreateTemplateRequest,
     HoldTransferConfig,
     ReplaceTemplateRequest,
     TemplateModel,
 )
-from app.schemas.breeze_buddy.analytics import AnalyticsType  # noqa: E402
+from app.schemas.breeze_buddy.analytics import AnalyticsType
 
 _FLOW = {"nodes": []}
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,16 @@
+"""Root test bootstrap: app env defaults.
+
+app.core.config.static snapshots env vars at first app import (e.g.
+``JWT_SECRET_KEY = os.getenv("JWT_SECRET_KEY", "")``), so the frozen
+value depends on which test module imports app code first. Per-file
+``os.environ`` setup is therefore import-order-dependent: a full-suite
+run can freeze "" before the file that sets the value is loaded, and
+JWTManager then refuses to construct during collection. pytest imports
+this conftest before any test module, so defaults set here always land
+first. Real environment values (CI) win over setdefault.
+"""
+
+import os
+
+os.environ.setdefault("JWT_SECRET_KEY", "test-secret-not-used-by-these-tests")
+os.environ.setdefault("JWT_ALGORITHM", "HS256")

--- a/tests/test_block_codec_visibility.py
+++ b/tests/test_block_codec_visibility.py
@@ -13,24 +13,16 @@ persistence path that emits ``visibility=internal`` text blocks.
 
 from __future__ import annotations
 
-import os
-
 from app.ai.voice.agents.breeze_buddy.chat.block_codec import (
     VISIBILITY_INTERNAL,
     blocks_to_llm_context_messages,
     filter_visible_blocks,
     internal_text_block,
 )
-
-# Handler import needs JWT_SECRET_KEY at module load time. Tests don't
-# verify tokens, so a dummy value is fine.
-os.environ.setdefault("JWT_SECRET_KEY", "test-secret-not-used-by-these-tests")
-os.environ.setdefault("JWT_ALGORITHM", "HS256")
-
-from app.api.routers.breeze_buddy.chat.handlers import (  # noqa: E402
+from app.api.routers.breeze_buddy.chat.handlers import (
     _sanitize_messages_for_widget,
 )
-from app.schemas.breeze_buddy.chat import ChatMessage, ChatMessageRole  # noqa: E402
+from app.schemas.breeze_buddy.chat import ChatMessage, ChatMessageRole
 
 
 def _mk(idx, **kwargs):

--- a/tests/test_seed_resume_context.py
+++ b/tests/test_seed_resume_context.py
@@ -12,11 +12,7 @@ Anthropic adapter's role merge (plan review, adversary:chat-design).
 
 from __future__ import annotations
 
-import os
 from typing import Any, Dict, List
-
-os.environ.setdefault("JWT_SECRET_KEY", "test-secret-not-used-by-these-tests")
-os.environ.setdefault("JWT_ALGORITHM", "HS256")
 
 import app.ai.voice.agents.breeze_buddy.chat.agent as agent_module
 from app.ai.voice.agents.breeze_buddy.chat.agent import ChatAgent


### PR DESCRIPTION
## What broke (prod screenshot: completed campaign showing "0 / 25 dialed")

`lead_call_tracker.attempt_count` is a **0-based retry counter** — it increments only when another attempt gets scheduled, so a lead answered on its first attempt finishes with `attempt_count = 0`. Three places treated the raw column as "attempts":

1. **`campaign_stats_query`**: `dialed = COUNT(attempt_count > 0)` → a fully-completed campaign showed **0 / 25 dialed** on the list, **Dialed 0** on the detail KPI, **0%** on the progress pill, and **Answer rate —** (it guards on dialed > 0). Now: `attempt_count > 0 OR call_initiated_time IS NOT NULL` — first-attempt connects count; ABORTed never-dialed leads still don't.
2. **call-details analytics** (campaign detail lead rows): emitted the raw counter → answered calls showed **"0 / 2" attempts**. `_build_call_detail_result` now reports attempts **made**: stored retries + 1 when a call was actually initiated, 0 for never-dialed leads. This fixes every call-details consumer consistently.
3. **CSV/records query**: hardcoded `attempt_count + 1`, which *over*counted never-dialed ABORT leads as 1 attempt — same CASE applied.

No frontend change needed for the numbers — the console renders `stats.dialed` and `attempt_count` verbatim, so list Progress, detail KPIs, answer rate, and per-lead attempts all correct themselves. (A separate loom PR reworks the detail leads table to the house table kit with 10-row paging.)

## Verification

- Synthetic lead shapes on the local DB (first-attempt connect / retried / abort-no-dial / backlog): new predicate counts **2/4** dialed where the old one said 1/4 and prod said 0.
- 4 regression tests (`tests/breeze_buddy/test_campaign_progress.py`); full suite green — the only failures are the pre-existing stale chat-analytics assertions, verified failing identically on the release baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected attempt counts to accurately reflect calls made, including first attempts and retries.
  * Leads that were never dialed now correctly display zero attempts.
  * Campaign “dialed” statistics now include leads whose first call connected, even when retry data is unavailable.

* **Tests**
  * Added coverage for attempt counting and campaign progress metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Review follow-up: deterministic test env bootstrap

A full local `pytest tests/breeze_buddy` run could die at collection: `app/core/config/static.py` snapshots `JWT_SECRET_KEY` at **first app import**, so the per-file `os.environ.setdefault(...)` blocks were import-order-dependent — whichever test module imported app code first froze the value, and a suite run could freeze `""` before the setting file loaded (JWTManager then refuses to construct). Pre-existing; CI was unaffected only because it exports real env vars.

Fix: new `tests/conftest.py` sets the defaults — pytest imports it before any test module, so collection order stops mattering. The five per-file `os.environ` blocks (and their now-stale `# noqa: E402` markers) are removed. Real environment values still win over `setdefault`. `tests/breeze_buddy` now: 146 passed, 1 xfailed (was: 2 collection errors); full suite matches the release baseline.
