### PR TITLE
feat(Database): Support for reader DB instance for all read operations

### DIFF
--- a/app/core/config/static.py
+++ b/app/core/config/static.py
@@ -141,9 +141,9 @@ GEMINI_TRANSLATION_MODEL = os.environ.get(
 TRANSLATION_TIMEOUT_SECONDS = int(os.environ.get("TRANSLATION_TIMEOUT_SECONDS", "30"))
 
 # --- STT Configuration ---
-STT_PROVIDER = os.environ.get(
-    "STT_PROVIDER", "google"
-).lower()  # "google", "assemblyai", "openai", "deepgram", "soniox", "elevenlabs", or "sarvam"
+STT_PROVIDER = (
+    os.environ.get("STT_PROVIDER", "google").lower()
+)  # "google", "assemblyai", "openai", "deepgram", "soniox", "elevenlabs", or "sarvam"
 ASSEMBLYAI_API_KEY = os.getenv("ASSEMBLYAI_API_KEY")
 OPENAI_STT_API_KEY = os.getenv("OPENAI_STT_API_KEY")
 OPENAI_STT_MODEL = os.environ.get(
@@ -255,6 +255,12 @@ POSTGRES_PASSWORD = os.getenv("POSTGRES_PASSWORD", "")
 POSTGRES_HOST = os.getenv("POSTGRES_HOST", "")
 POSTGRES_PORT = os.getenv("POSTGRES_PORT", "")
 POSTGRES_DB = os.getenv("POSTGRES_DB", "")
+
+# Read replica — when set, read queries are routed to this host instead of
+# the primary.  Leave empty (default) to keep all traffic on the primary
+# (safe fallback: read_pool will alias write_pool internally).
+POSTGRES_READER_HOST = os.getenv("POSTGRES_READER_HOST", "")
+POSTGRES_READER_PORT = os.getenv("POSTGRES_READER_PORT", POSTGRES_PORT)
 
 # Connection pool settings
 POSTGRES_POOL_SIZE = int(os.getenv("POSTGRES_POOL_SIZE", "5"))

--- a/app/database/__init__.py
+++ b/app/database/__init__.py
@@ -1,6 +1,17 @@
 """
 Database module for the application.
 This module contains database connection and models.
+
+Two pools are maintained:
+  write_pool  — connects to the PRIMARY (INSERT / UPDATE / DELETE / transactions).
+                Exposed as the module-level ``pool`` alias for backward compat.
+  read_pool   — connects to the READ REPLICA when POSTGRES_READER_HOST is set.
+                Falls back to ``write_pool`` (the same object) when the env var
+                is absent, so all existing behaviour is preserved with zero config
+                change.
+
+Use ``get_db_connection()``      for writes / transactions.
+Use ``get_read_db_connection()`` for plain SELECT queries.
 """
 
 from typing import Optional
@@ -14,98 +25,229 @@ from app.core.config.static import (
     POSTGRES_PASSWORD,
     POSTGRES_POOL_SIZE,
     POSTGRES_PORT,
+    POSTGRES_READER_HOST,
+    POSTGRES_READER_PORT,
     POSTGRES_USER,
 )
 from app.core.logger import logger
 from app.services.aws.kms import decrypt_kms
 
-pool = None
+# ---------------------------------------------------------------------------
+# Module-level pool references
+# ---------------------------------------------------------------------------
+# ``pool`` is kept as a public alias for ``write_pool`` so that any code
+# outside this module that imported ``pool`` directly continues to work.
+# ---------------------------------------------------------------------------
+
+write_pool: Optional[asyncpg.Pool] = None
+read_pool: Optional[asyncpg.Pool] = None
+
+# Backward-compat alias — always mirrors write_pool after initialisation.
+pool = write_pool
 
 
-async def init_db_pool(min_size: Optional[int] = None, max_size: Optional[int] = None):
+async def _create_pool(
+    host: str,
+    port: str,
+    min_size: int,
+    max_size: int,
+    decrypted_password: str,
+    label: str,
+) -> asyncpg.Pool:
+    """Create and return a single asyncpg pool.  Raises on failure."""
+    try:
+        p = await asyncpg.create_pool(
+            user=POSTGRES_USER,
+            password=decrypted_password,
+            database=POSTGRES_DB,
+            host=host,
+            port=port,
+            min_size=min_size,
+            max_size=max_size,
+        )
+        logger.info(f"{label} pool initialised successfully.")
+        return p
+    except Exception as e:
+        logger.error(f"{label} pool initialisation failed: {e}")
+        raise
+
+
+async def init_db_pool(
+    min_size: Optional[int] = None,
+    max_size: Optional[int] = None,
+) -> None:
     """
-    Initialize the database connection pool.
+    Initialise the write pool (primary) and, when POSTGRES_READER_HOST is
+    configured, a separate read pool (replica).
+
+    When POSTGRES_READER_HOST is absent the read pool is set to the same
+    object as the write pool — all queries go to the primary and the
+    application behaves exactly as before.
 
     Args:
-        min_size: Connections opened eagerly. Defaults to POSTGRES_POOL_SIZE.
-            Per-call bot subprocesses pass an explicit small size so each
-            child doesn't open the API pod's full pool.
-        max_size: Pool ceiling. Defaults to POSTGRES_POOL_SIZE +
+        min_size: Connections opened eagerly.  Defaults to POSTGRES_POOL_SIZE.
+            Per-call bot subprocesses pass an explicit small value so each
+            child process does not open the full API pod pool.
+        max_size: Pool ceiling.  Defaults to POSTGRES_POOL_SIZE +
             POSTGRES_MAX_OVERFLOW.
     """
-    global pool
-    if pool is None:
-        if min_size is None:
-            min_size = POSTGRES_POOL_SIZE
-        if max_size is None:
-            max_size = POSTGRES_POOL_SIZE + POSTGRES_MAX_OVERFLOW
-        db_env_vars = [
-            POSTGRES_USER,
-            POSTGRES_PASSWORD,
-            POSTGRES_HOST,
-            POSTGRES_PORT,
-            POSTGRES_DB,
-        ]
-        if not all(db_env_vars):
-            logger.warning(
-                "One or more database environment variables are missing. Skipping database initialization."
+    global write_pool, read_pool, pool
+
+    resolved_min = min_size if min_size is not None else POSTGRES_POOL_SIZE
+    resolved_max = (
+        max_size if max_size is not None else POSTGRES_POOL_SIZE + POSTGRES_MAX_OVERFLOW
+    )
+
+    required_vars = [
+        POSTGRES_USER,
+        POSTGRES_PASSWORD,
+        POSTGRES_HOST,
+        POSTGRES_PORT,
+        POSTGRES_DB,
+    ]
+    if not all(required_vars):
+        logger.warning(
+            "One or more database environment variables are missing. "
+            "Skipping database initialisation."
+        )
+        return
+
+    # KMS-decrypt the password once; reused for both pools.
+    decrypted_password = await decrypt_kms(POSTGRES_PASSWORD)
+    if decrypted_password is None:
+        logger.warning("KMS decryption failed — cannot initialise database pools.")
+        return
+
+    # ------------------------------------------------------------------
+    # Write pool (primary)
+    # ------------------------------------------------------------------
+    if write_pool is None:
+        write_pool = await _create_pool(
+            host=POSTGRES_HOST,
+            port=POSTGRES_PORT,
+            min_size=resolved_min,
+            max_size=resolved_max,
+            decrypted_password=decrypted_password,
+            label="Write",
+        )
+        # Keep the legacy ``pool`` alias in sync so callers that imported
+        # ``pool`` directly still get a live pool object.
+        pool = write_pool
+
+    # ------------------------------------------------------------------
+    # Read pool (replica)
+    # ------------------------------------------------------------------
+    if read_pool is None:
+        if POSTGRES_READER_HOST:
+            read_pool = await _create_pool(
+                host=POSTGRES_READER_HOST,
+                port=POSTGRES_READER_PORT or POSTGRES_PORT,
+                min_size=resolved_min,
+                max_size=resolved_max,
+                decrypted_password=decrypted_password,
+                label="Read",
             )
-            return
-
-        # Decrypt PostgreSQL password using KMS if needed
-        decrypted_postgres_password = await decrypt_kms(POSTGRES_PASSWORD)
-
-        # If decryption fails, use the original password
-        if decrypted_postgres_password is None:
-            logger.warning("KMS decryption failed, using original password")
-            return
-
-        try:
-            pool = await asyncpg.create_pool(
-                user=POSTGRES_USER,
-                password=decrypted_postgres_password,
-                database=POSTGRES_DB,
-                host=POSTGRES_HOST,
-                port=POSTGRES_PORT,
-                min_size=min_size,
-                max_size=max_size,
+        else:
+            # No replica configured — alias the write pool so run_read_query
+            # transparently routes to the primary.
+            read_pool = write_pool
+            logger.info(
+                "POSTGRES_READER_HOST not set — read_pool aliased to write_pool "
+                "(all queries routed to primary)."
             )
-            logger.info("Database pool initialized successfully.")
-        except Exception as e:
-            logger.error(f"Database pool initialization failed: {e}")
-            raise
+
+
+# ---------------------------------------------------------------------------
+# Connection generators
+# ---------------------------------------------------------------------------
 
 
 async def get_db_connection():
     """
-    Get a database connection from the pool.
+    Yield a connection from the WRITE pool (primary).
+
+    Use for INSERT / UPDATE / DELETE and any transaction that mixes reads
+    with writes.
     """
-    global pool
-    if pool is None:
+    global write_pool
+    if write_pool is None:
         await init_db_pool()
 
-    if pool is None:
-        raise RuntimeError("Database pool is not initialized")
+    if write_pool is None:
+        raise RuntimeError("Write pool is not initialised.")
 
-    async with pool.acquire() as connection:
+    async with write_pool.acquire() as connection:
         yield connection
 
 
-async def close_db_pool():
+async def get_read_db_connection():
     """
-    Close the database connection pool.
-    """
-    if pool:
-        try:
-            await pool.close()
-            logger.info("Database pool closed.")
-        except Exception as e:
-            logger.error(f"Failed to close database pool: {e}")
-            raise
+    Yield a connection from the READ pool (replica when configured, otherwise
+    the primary via the write_pool alias).
 
+    Use exclusively for plain SELECT queries where replica lag is acceptable.
+    Do NOT use inside a write transaction — call get_db_connection() instead.
+    """
+    global read_pool
+    if read_pool is None:
+        await init_db_pool()
+
+    if read_pool is None:
+        raise RuntimeError("Read pool is not initialised.")
+
+    async with read_pool.acquire() as connection:
+        yield connection
+
+
+# ---------------------------------------------------------------------------
+# Shutdown
+# ---------------------------------------------------------------------------
+
+
+async def close_db_pool() -> None:
+    """
+    Close both pools gracefully.
+
+    The read pool is only closed separately when it is a distinct object from
+    the write pool (i.e. POSTGRES_READER_HOST was configured).  This guard
+    prevents a double-close when the two are aliased to the same pool.
+    """
+    global write_pool, read_pool, pool
+
+    if read_pool is not None and read_pool is not write_pool:
+        try:
+            await read_pool.close()
+            logger.info("Read pool closed.")
+        except Exception as e:
+            logger.error(f"Failed to close read pool: {e}")
+            raise
+        finally:
+            read_pool = None
+
+    if write_pool is not None:
+        try:
+            await write_pool.close()
+            logger.info("Write pool closed.")
+        except Exception as e:
+            logger.error(f"Failed to close write pool: {e}")
+            raise
+        finally:
+            write_pool = None
+            pool = None
+            read_pool = None  # clear alias if it was pointing at write_pool
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
 
 __all__ = [
     "init_db_pool",
-    "get_db_connection",
     "close_db_pool",
+    "get_db_connection",
+    "get_read_db_connection",
+    # Pool references
+    "write_pool",
+    "read_pool",
+    "pool",
 ]

--- a/app/database/queries/__init__.py
+++ b/app/database/queries/__init__.py
@@ -1,25 +1,63 @@
 """
 Database query functions for the application.
+
+Two entry points are provided:
+
+  run_parameterized_query(query, values)
+      Executes on the WRITE pool (primary).
+      Use for INSERT, UPDATE, DELETE, and any query that must see the latest
+      committed data (e.g. a SELECT immediately after a write in the same
+      request cycle, or SELECT … FOR UPDATE).
+
+  run_read_query(query, values)
+      Executes on the READ pool (replica when POSTGRES_READER_HOST is set,
+      otherwise the primary via the write_pool alias — safe fallback with no
+      config change required).
+      Use for plain SELECT queries where a small replication lag is acceptable.
+
+Both functions raise exceptions on failure so that all accessor functions
+(which have their own try/except that log and re-raise) handle errors
+appropriately.
 """
 
 from typing import Any, List
 
 import asyncpg
 
-from app.database import get_db_connection
+from app.database import get_db_connection, get_read_db_connection
 
 
-# Helper function to execute parameterized queries
 async def run_parameterized_query(
     query_text: str, values: List[Any]
 ) -> List[asyncpg.Record]:
     """
-    Execute a parameterized query and return the results.
+    Execute a parameterized query on the WRITE pool (primary) and return all
+    result rows.
 
-    Raises exceptions on failure so callers can handle them appropriately
-    (all accessor functions have try/except that log and re-raise).
+    Use for INSERT / UPDATE / DELETE and for SELECT queries that must read
+    the latest committed data (e.g. post-write reads, locking queries).
     """
     async for conn in get_db_connection():
+        result = await conn.fetch(query_text, *values)
+        return result
+    return []
+
+
+async def run_read_query(query_text: str, values: List[Any]) -> List[asyncpg.Record]:
+    """
+    Execute a parameterized SELECT query on the READ pool (replica) and return
+    all result rows.
+
+    When POSTGRES_READER_HOST is not configured the read pool is aliased to
+    the write pool, so this function transparently routes to the primary with
+    no configuration change required.
+
+    Do NOT use this for:
+      - INSERT / UPDATE / DELETE
+      - SELECT … FOR UPDATE  (must hold a write-pool connection)
+      - Reads inside a write transaction that need to see uncommitted data
+    """
+    async for conn in get_read_db_connection():
         result = await conn.fetch(query_text, *values)
         return result
     return []


### PR DESCRIPTION
- Ensures reducing load on the primary DB instance to avoid downtime due to heavy analytic queries
- Faster retrievable of data for read operations as reader DB has no overhead of writing ,it just replicates from the primary DB
- Fallback prevents even if the reader_db_instance connection fails, fallsback to the primary instance at the start

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for routing read operations through a dedicated PostgreSQL read replica.
  * Added a separate read-query interface, with automatic fallback to the primary database when no replica is configured.
  * Added configurable read-replica host and port settings.

* **Bug Fixes**
  * Improved database pool cleanup and handling when configuration is incomplete or secure credential decryption fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->