### PR TITLE
feat(buddy-assist): add copilot scope foundation

### DIFF
--- a/app/database/accessor/breeze_buddy/template.py
+++ b/app/database/accessor/breeze_buddy/template.py
@@ -21,6 +21,7 @@ from app.database.queries.breeze_buddy.template import (
     create_template_query,
     delete_template_if_not_referenced_query,
     get_all_templates_by_telephony_number_id_query,
+    get_merchant_by_template_id_query,
     get_template_by_id_query,
     get_template_by_telephony_number_id_query,
     get_template_in_scope_query,
@@ -305,6 +306,33 @@ async def get_template_by_id(template_id: str) -> Optional[TemplateModel]:
     except Exception as e:
         logger.error(f"Error getting template by ID: {e}", exc_info=True)
         return None
+
+
+async def get_template_merchant_id(template_id: str) -> Optional[str]:
+    """Return only the merchant that owns a template.
+
+    This is used by scope/authorization checks where loading the full template
+    would unnecessarily hydrate flow/configuration/secrets.
+    """
+    logger.info(f"Getting template merchant by ID: {template_id}")
+
+    try:
+        query, values = get_merchant_by_template_id_query(template_id)
+        result = await run_parameterized_query(query, values)
+
+        if not result or get_row_count(result) == 0:
+            logger.info(f"No template merchant found for ID: {template_id}")
+            return None
+
+        merchant_id = result[0]["merchant_id"]
+        return str(merchant_id) if merchant_id is not None else None
+
+    except Exception as e:
+        logger.error(
+            f"Error getting template merchant by ID: {template_id}: {e}",
+            exc_info=True,
+        )
+        raise
 
 
 async def replace_template(

--- a/app/database/queries/breeze_buddy/template.py
+++ b/app/database/queries/breeze_buddy/template.py
@@ -238,6 +238,18 @@ def get_template_by_id_query(template_id: str) -> Tuple[str, List[Any]]:
     return query, [template_id]
 
 
+def get_merchant_by_template_id_query(template_id: str) -> Tuple[str, List[Any]]:
+    """Generate query to read only a template's owning merchant."""
+    query = f"""
+        SELECT merchant_id
+        FROM {TEMPLATE_TABLE}
+        WHERE id = $1
+        LIMIT 1
+    """
+
+    return query, [template_id]
+
+
 def get_template_by_telephony_number_id_query(
     telephony_number_id: str,
     enable_inbound_only: bool = False,

--- a/app/schemas/breeze_buddy/copilot.py
+++ b/app/schemas/breeze_buddy/copilot.py
@@ -1,0 +1,152 @@
+"""Schemas for Buddy Copilot scope resolution."""
+
+from __future__ import annotations
+
+from datetime import date
+from enum import Enum
+from typing import Dict, List, Optional
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field, computed_field, field_validator
+
+DEFAULT_COPILOT_TIMEZONE = "Asia/Kolkata"
+COPILOT_SCOPE_METADATA_KEY = "copilot"
+
+
+class CopilotCapability(str, Enum):
+    """Read-only capabilities enabled in the Phase 1 scope contract."""
+
+    ANALYTICS_SUMMARY = "get_analytics_summary"
+    QUERY_CONVERSATIONS = "query_conversations"
+    CONVERSATION_DETAIL = "get_conversation_detail"
+
+
+class CopilotDateRangeSource(str, Enum):
+    """Where the resolved date range came from."""
+
+    REQUEST = "request"
+    DEFAULT = "default"
+
+
+class CopilotRequestedDateRange(BaseModel):
+    """Optional dashboard-provided date range for Copilot data reads."""
+
+    date_from: date
+    date_to: date
+
+    @field_validator("date_to")
+    @classmethod
+    def validate_order(cls, value: date, info) -> date:
+        date_from = info.data.get("date_from")
+        if date_from and value < date_from:
+            raise ValueError("date_to must be on or after date_from")
+        return value
+
+
+class CopilotScopeRequest(BaseModel):
+    """Dashboard-requested data context for Buddy Copilot.
+
+    The browser may request a merchant/template/date scope, but the resolver
+    remains authoritative and returns the immutable CopilotScope.
+    """
+
+    data_merchant_id: Optional[str] = Field(
+        default=None,
+        description="Selected merchant whose analytics/conversations are queried.",
+    )
+    data_template_id: Optional[str] = Field(
+        default=None,
+        description="Optional selected agent/template under data_merchant_id.",
+    )
+    timezone: str = DEFAULT_COPILOT_TIMEZONE
+    date_range: Optional[CopilotRequestedDateRange] = None
+
+    @field_validator("data_merchant_id", "data_template_id")
+    @classmethod
+    def strip_optional_strings(cls, value: Optional[str]) -> Optional[str]:
+        if value is None:
+            return None
+        stripped = value.strip()
+        return stripped or None
+
+    @field_validator("data_template_id")
+    @classmethod
+    def validate_data_template_id(cls, value: Optional[str]) -> Optional[str]:
+        if value is None:
+            return None
+        try:
+            UUID(value)
+        except ValueError as exc:
+            raise ValueError("data_template_id must be a valid UUID") from exc
+        return value
+
+    @field_validator("timezone")
+    @classmethod
+    def validate_timezone(cls, value: str) -> str:
+        stripped = value.strip()
+        if not stripped:
+            raise ValueError("timezone must not be empty")
+        return stripped
+
+
+class CopilotActorScope(BaseModel):
+    """Authenticated actor snapshot used for audit and downstream policy."""
+
+    model_config = ConfigDict(frozen=True)
+
+    user_id: str
+    username: str
+    role: str
+    permissions: tuple[str, ...] = Field(default_factory=tuple)
+    reseller_ids: tuple[str, ...] = Field(default_factory=tuple)
+    merchant_ids: tuple[str, ...] = Field(default_factory=tuple)
+
+
+class CopilotDataScope(BaseModel):
+    """Selected merchant data scope for analytics and conversation reads."""
+
+    model_config = ConfigDict(frozen=True)
+
+    data_merchant_id: str
+    data_template_id: Optional[str] = None
+
+
+class CopilotDateWindow(BaseModel):
+    """Timezone-aware date window normalized exactly once by the resolver."""
+
+    model_config = ConfigDict(frozen=True)
+
+    timezone: str
+    date_from: date
+    date_to: date
+    source: CopilotDateRangeSource
+
+    @computed_field
+    @property
+    def label(self) -> str:
+        """Human-readable description derived from the resolved window."""
+        if self.source == CopilotDateRangeSource.DEFAULT:
+            return "Last 7 days"
+        return f"{self.date_from.isoformat()} to {self.date_to.isoformat()}"
+
+
+class CopilotScope(BaseModel):
+    """Immutable data contract injected into Buddy Copilot sessions and tools."""
+
+    model_config = ConfigDict(frozen=True)
+
+    actor: CopilotActorScope
+    data: CopilotDataScope
+    date_window: CopilotDateWindow
+    capabilities: tuple[CopilotCapability, ...]
+
+    def session_metadata(self) -> Dict[str, Dict[str, object]]:
+        """Return semantic scope metadata for the normal Assist chat session."""
+        return {COPILOT_SCOPE_METADATA_KEY: self.model_dump(mode="json")}
+
+
+class CopilotResolvedScopeResponse(BaseModel):
+    """Serializable envelope returned by later Copilot session endpoints."""
+
+    scope: CopilotScope
+    warnings: List[str] = Field(default_factory=list)

--- a/app/services/breeze_buddy/__init__.py
+++ b/app/services/breeze_buddy/__init__.py
@@ -1,0 +1,1 @@
+"""Breeze Buddy service modules."""

--- a/app/services/breeze_buddy/copilot/__init__.py
+++ b/app/services/breeze_buddy/copilot/__init__.py
@@ -1,0 +1,11 @@
+"""Buddy Copilot backend foundation."""
+
+from app.services.breeze_buddy.copilot.scope import (
+    CopilotScopeError,
+    resolve_copilot_scope,
+)
+
+__all__ = [
+    "CopilotScopeError",
+    "resolve_copilot_scope",
+]

--- a/app/services/breeze_buddy/copilot/scope.py
+++ b/app/services/breeze_buddy/copilot/scope.py
@@ -1,0 +1,201 @@
+"""Buddy Copilot data scope resolver."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from inspect import isawaitable
+from typing import Awaitable, Callable, List, Optional
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+from app.core.security.scope import resolve_merchant_ids
+from app.database.accessor.breeze_buddy.template import get_template_merchant_id
+from app.schemas import UserInfo
+from app.schemas.breeze_buddy.copilot import (
+    DEFAULT_COPILOT_TIMEZONE,
+    CopilotActorScope,
+    CopilotCapability,
+    CopilotDataScope,
+    CopilotDateRangeSource,
+    CopilotDateWindow,
+    CopilotRequestedDateRange,
+    CopilotScope,
+    CopilotScopeRequest,
+)
+
+TemplateMerchantLoader = Callable[[str], Awaitable[Optional[str]] | Optional[str]]
+MerchantScopeResolver = Callable[
+    [UserInfo], Awaitable[Optional[List[str]]] | Optional[List[str]]
+]
+
+_PHASE_ONE_CAPABILITIES = (
+    CopilotCapability.ANALYTICS_SUMMARY,
+    CopilotCapability.QUERY_CONVERSATIONS,
+    CopilotCapability.CONVERSATION_DETAIL,
+)
+
+
+class CopilotScopeError(Exception):
+    """Fail-closed scope resolution error."""
+
+    def __init__(self, code: str, message: str, *, status_code: int = 400) -> None:
+        super().__init__(message)
+        self.code = code
+        self.message = message
+        self.status_code = status_code
+
+
+def _actor_scope(current_user: UserInfo) -> CopilotActorScope:
+    return CopilotActorScope(
+        user_id=current_user.id,
+        username=current_user.username,
+        role=(
+            current_user.role.value
+            if hasattr(current_user.role, "value")
+            else str(current_user.role)
+        ),
+        permissions=tuple(current_user.permissions),
+        reseller_ids=tuple(current_user.reseller_ids),
+        merchant_ids=tuple(current_user.merchant_ids),
+    )
+
+
+async def _resolve_allowed_merchant_ids(
+    current_user: UserInfo,
+    merchant_scope_resolver: MerchantScopeResolver,
+) -> Optional[List[str]]:
+    resolved = merchant_scope_resolver(current_user)
+    if isawaitable(resolved):
+        return await resolved
+    return resolved
+
+
+async def _resolve_data_merchant_id(
+    request: CopilotScopeRequest,
+    current_user: UserInfo,
+    merchant_scope_resolver: MerchantScopeResolver,
+) -> str:
+    allowed_merchant_ids = await _resolve_allowed_merchant_ids(
+        current_user, merchant_scope_resolver
+    )
+
+    requested = request.data_merchant_id
+    if requested:
+        if allowed_merchant_ids is None or requested in allowed_merchant_ids:
+            return requested
+        raise CopilotScopeError(
+            "unauthorized_merchant",
+            "Access denied to the selected Copilot data merchant.",
+            status_code=403,
+        )
+
+    if allowed_merchant_ids is not None and len(allowed_merchant_ids) == 1:
+        return allowed_merchant_ids[0]
+
+    raise CopilotScopeError(
+        "ambiguous_merchant",
+        "A selected data_merchant_id is required for Buddy Copilot.",
+        status_code=400,
+    )
+
+
+def _resolve_date_window(
+    requested: Optional[CopilotRequestedDateRange],
+    timezone: str,
+    now: Optional[datetime],
+) -> CopilotDateWindow:
+    try:
+        tzinfo = ZoneInfo(timezone or DEFAULT_COPILOT_TIMEZONE)
+    except (ValueError, ZoneInfoNotFoundError) as exc:
+        raise CopilotScopeError(
+            "invalid_timezone",
+            "Buddy Copilot requires a valid IANA timezone.",
+            status_code=400,
+        ) from exc
+
+    normalized_now = now or datetime.now(tzinfo)
+    if normalized_now.tzinfo is None:
+        normalized_now = normalized_now.replace(tzinfo=tzinfo)
+    else:
+        normalized_now = normalized_now.astimezone(tzinfo)
+
+    if requested is not None:
+        return CopilotDateWindow(
+            timezone=timezone,
+            date_from=requested.date_from,
+            date_to=requested.date_to,
+            source=CopilotDateRangeSource.REQUEST,
+        )
+
+    date_to = normalized_now.date()
+    date_from = date_to - timedelta(days=6)
+    return CopilotDateWindow(
+        timezone=timezone or DEFAULT_COPILOT_TIMEZONE,
+        date_from=date_from,
+        date_to=date_to,
+        source=CopilotDateRangeSource.DEFAULT,
+    )
+
+
+async def _load_template_merchant_id(
+    template_merchant_loader: TemplateMerchantLoader,
+    template_id: str,
+) -> Optional[str]:
+    merchant_id = template_merchant_loader(template_id)
+    if isawaitable(merchant_id):
+        return await merchant_id
+    return merchant_id
+
+
+async def _validate_data_template(
+    data: CopilotDataScope,
+    template_merchant_loader: TemplateMerchantLoader,
+) -> None:
+    if not data.data_template_id:
+        return
+
+    template_merchant_id = await _load_template_merchant_id(
+        template_merchant_loader,
+        data.data_template_id,
+    )
+    if template_merchant_id != data.data_merchant_id:
+        raise CopilotScopeError(
+            "unauthorized_template",
+            "Selected Copilot data template was not found or does not belong "
+            "to the selected merchant.",
+            status_code=403,
+        )
+
+
+async def resolve_copilot_scope(
+    request: CopilotScopeRequest,
+    current_user: UserInfo,
+    *,
+    now: Optional[datetime] = None,
+    template_merchant_loader: Optional[TemplateMerchantLoader] = None,
+    merchant_scope_resolver: Optional[MerchantScopeResolver] = None,
+) -> CopilotScope:
+    """Resolve the immutable Buddy Copilot data scope.
+
+    Dashboard-provided data scope is treated as a request, never authority.
+    """
+    data = CopilotDataScope(
+        data_merchant_id=await _resolve_data_merchant_id(
+            request,
+            current_user,
+            merchant_scope_resolver or resolve_merchant_ids,
+        ),
+        data_template_id=request.data_template_id,
+    )
+    await _validate_data_template(
+        data,
+        template_merchant_loader or get_template_merchant_id,
+    )
+
+    date_window = _resolve_date_window(request.date_range, request.timezone, now)
+
+    return CopilotScope(
+        actor=_actor_scope(current_user),
+        data=data,
+        date_window=date_window,
+        capabilities=_PHASE_ONE_CAPABILITIES,
+    )

--- a/docs/breeze_buddy/copilot/scope_foundation.md
+++ b/docs/breeze_buddy/copilot/scope_foundation.md
@@ -1,0 +1,174 @@
+# Buddy Copilot Scope Foundation
+
+## Purpose
+
+Buddy Copilot brings the existing Buddy Assist chat experience into the
+dashboard as a read-only copilot for merchant analytics and conversation
+inspection. The important backend boundary is that the chat runtime identity is
+not the same thing as the merchant data scope.
+
+This PR establishes that boundary in Clairvoyance. It defines the server-owned
+scope object that later session creation and tool execution work can attach to a
+normal Buddy Assist chat session as `metadata.copilot`.
+
+## Architecture In Brief
+
+Buddy Copilot is split across the dashboard, the normal Assist runtime, and
+scoped backend tools.
+
+```text
+Loom dashboard
+  -> selected merchant and optional selected agent
+  -> Clairvoyance scope resolver
+  -> normal Buddy Assist chat session
+  -> metadata.copilot
+  -> guarded read-only Copilot tools
+  -> typed results/events for Loom rendering
+```
+
+Loom owns the visible user context: the dashboard login, selected merchant, and
+optional selected agent. Clairvoyance treats that context as a request, not as
+authority.
+
+The Buddy Assist template owns runtime behavior: prompt, rules, refusal policy,
+and chat-agent behavior. That template's merchant id is runtime identity only.
+It must not become analytics or conversation data scope.
+
+Future Copilot tools will load the resolved scope from `metadata.copilot` and
+use only `scope.data.data_merchant_id` and optional
+`scope.data.data_template_id` for analytics and conversation reads.
+
+## What This PR Adds
+
+### Scope Request
+
+The dashboard can request a Copilot data scope with:
+
+```json
+{
+  "data_merchant_id": "merchant-1",
+  "data_template_id": "11111111-1111-4111-8111-111111111111",
+  "timezone": "Asia/Kolkata",
+  "date_range": {
+    "date_from": "2026-07-01",
+    "date_to": "2026-07-30"
+  }
+}
+```
+
+`data_merchant_id` is the merchant whose analytics or conversations should be
+queried. `data_template_id` is optional; when it is missing, the scope means all
+agents under the selected data merchant. When present, `data_template_id` must
+be a UUID-shaped template id before the resolver attempts ownership lookup.
+
+### Resolved Scope
+
+The resolver returns an immutable `CopilotScope` with:
+
+- `actor`: authenticated user snapshot for downstream audit and policy.
+- `data`: selected merchant and optional selected agent/template.
+- `date_window`: normalized date range and timezone.
+- `capabilities`: read-only Phase 1 capability names.
+
+The resolved scope can be injected into the normal chat session as:
+
+```json
+{
+  "copilot": {
+    "actor": {},
+    "data": {
+      "data_merchant_id": "merchant-1",
+      "data_template_id": "11111111-1111-4111-8111-111111111111"
+    },
+    "date_window": {},
+    "capabilities": []
+  }
+}
+```
+
+This shape is intentionally semantic. It avoids generic `merchant_id` fields in
+the data object so callers do not confuse Copilot data scope with
+`chat_session.merchant_id`.
+
+### Merchant Scope Validation
+
+The resolver validates the requested `data_merchant_id` against the
+authenticated user's resolved merchant scope.
+
+If the request includes a selected merchant and the user can access it, the
+resolver accepts it. If the selected merchant is outside the user's scope, the
+resolver rejects it.
+
+If the request does not include a merchant, the resolver auto-selects only when
+the authenticated user resolves to exactly one concrete merchant. Multi-merchant
+and unrestricted scopes must provide an explicit selected merchant to avoid
+ambiguous data access.
+
+### Template Ownership Validation
+
+When `data_template_id` is provided, the resolver verifies that the template
+belongs to `data_merchant_id`. The request schema rejects non-UUID
+`data_template_id` values before any database lookup is attempted.
+
+```text
+template.merchant_id == data_merchant_id
+```
+
+This check is required because the dashboard-provided merchant/template pair is
+not authority. A malformed or tampered request could otherwise pair one
+merchant's id with another merchant's template id.
+
+The ownership lookup uses a lightweight template accessor that selects only
+`merchant_id`. It deliberately avoids loading the full template flow,
+configuration, or secrets for an authorization check.
+
+### Date Window Normalization
+
+The resolver accepts an explicit date range or falls back to the previous seven
+calendar days in the requested timezone. The default window includes today as
+`date_to` and six earlier days as `date_from`.
+
+Invalid date ordering is rejected by schema validation. Invalid timezone names
+are rejected as scope errors.
+
+### Authenticated Dashboard Assumption
+
+This PR does not add a backend analytics-permission gate inside Copilot scope
+resolution. The dashboard owns Copilot visibility and only shows the Copilot
+entry point to users that should have access to it.
+
+Clairvoyance still validates the data boundary after authentication:
+
+- selected merchant must be in the user's resolved merchant scope
+- optional selected template must belong to the selected merchant
+- ambiguous merchant scope must be made explicit
+
+## Invariants
+
+- Copilot data reads must use `scope.data.data_merchant_id`.
+- Optional agent drill-down must use `scope.data.data_template_id`.
+- `chat_session.merchant_id` must not be used as Copilot data scope.
+- The dashboard Assist template merchant must not be used as Copilot data
+  scope.
+- Runtime template/merchant identity is not stored in `metadata.copilot`.
+- Missing `data_template_id` means all agents under `data_merchant_id`.
+- A provided `data_template_id` must be owned by `data_merchant_id`.
+
+## Files In This PR
+
+```text
+app/schemas/breeze_buddy/copilot.py
+app/services/breeze_buddy/copilot/scope.py
+app/database/queries/breeze_buddy/template.py
+app/database/accessor/breeze_buddy/template.py
+tests/test_copilot_scope.py
+```
+
+## Out Of Scope
+
+This PR does not create Copilot chat sessions, provision the dashboard Assist
+template, register tools, execute analytics queries, stream typed events, or add
+Loom UI. Those later pieces should consume the scope contract defined here.
+
+The next backend slices can rely on `metadata.copilot` as the stable handoff
+between session creation and tool execution.

--- a/tests/test_copilot_scope.py
+++ b/tests/test_copilot_scope.py
@@ -1,0 +1,342 @@
+"""Tests for Buddy Copilot data scope foundation."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import date, datetime
+
+import pytest
+from pydantic import ValidationError
+
+from app.database.accessor.breeze_buddy.template import get_template_merchant_id
+from app.schemas import UserInfo, UserRole
+from app.schemas.breeze_buddy.copilot import (
+    CopilotDateRangeSource,
+    CopilotRequestedDateRange,
+    CopilotScopeRequest,
+)
+from app.services.breeze_buddy.copilot.scope import (
+    CopilotScopeError,
+    resolve_copilot_scope,
+)
+
+DATA_TEMPLATE_ID = "11111111-1111-4111-8111-111111111111"
+MISSING_TEMPLATE_ID = "22222222-2222-4222-8222-222222222222"
+
+
+def _user(
+    *,
+    role: UserRole = UserRole.MERCHANT,
+    merchant_ids: list[str] | None = None,
+    permissions: list[str] | None = None,
+) -> UserInfo:
+    return UserInfo(
+        id="user-1",
+        username="tester",
+        role=role,
+        reseller_ids=["reseller-1"],
+        merchant_ids=merchant_ids or ["merchant-1"],
+        permissions=permissions or ["analytics:own"],
+    )
+
+
+def _template_merchant_loader(mapping: dict[str, str | None]):
+    async def load(template_id: str) -> str | None:
+        return mapping.get(template_id)
+
+    return load
+
+
+def _merchant_scope(merchant_ids: list[str] | None):
+    async def resolve(_user: UserInfo):
+        return merchant_ids
+
+    return resolve
+
+
+def _templates(
+    *,
+    data_merchant: str | None = "merchant-1",
+) -> dict[str, str | None]:
+    return {DATA_TEMPLATE_ID: data_merchant}
+
+
+def test_resolves_authorized_scope_with_data_filters():
+    scope = asyncio.run(
+        resolve_copilot_scope(
+            CopilotScopeRequest(
+                data_merchant_id="merchant-1",
+                data_template_id=DATA_TEMPLATE_ID,
+                date_range=CopilotRequestedDateRange(
+                    date_from=date(2026, 7, 1),
+                    date_to=date(2026, 7, 27),
+                ),
+            ),
+            _user(),
+            template_merchant_loader=_template_merchant_loader(_templates()),
+            merchant_scope_resolver=_merchant_scope(["merchant-1"]),
+        )
+    )
+
+    assert scope.data.data_merchant_id == "merchant-1"
+    assert scope.data.data_template_id == DATA_TEMPLATE_ID
+    assert scope.session_metadata()["copilot"]["data"] == {
+        "data_merchant_id": "merchant-1",
+        "data_template_id": DATA_TEMPLATE_ID,
+    }
+
+
+def test_scope_metadata_does_not_include_runtime_identity():
+    scope = asyncio.run(
+        resolve_copilot_scope(
+            CopilotScopeRequest(data_merchant_id="merchant-1"),
+            _user(),
+            template_merchant_loader=_template_merchant_loader(_templates()),
+            merchant_scope_resolver=_merchant_scope(["merchant-1"]),
+        )
+    )
+
+    metadata = scope.session_metadata()["copilot"]
+    data_metadata = metadata["data"]
+
+    assert "runtime_merchant_id" not in metadata
+    assert "runtime_template_id" not in metadata
+    assert isinstance(data_metadata, dict)
+    assert "merchant_id" not in data_metadata
+
+
+def test_resolves_authenticated_user_without_analytics_permission():
+    scope = asyncio.run(
+        resolve_copilot_scope(
+            CopilotScopeRequest(data_merchant_id="merchant-1"),
+            _user(permissions=["read:own_data"]),
+            template_merchant_loader=_template_merchant_loader(_templates()),
+            merchant_scope_resolver=_merchant_scope(["merchant-1"]),
+        )
+    )
+
+    assert scope.data.data_merchant_id == "merchant-1"
+
+
+def test_rejects_unauthorized_selected_merchant():
+    with pytest.raises(CopilotScopeError) as exc:
+        asyncio.run(
+            resolve_copilot_scope(
+                CopilotScopeRequest(data_merchant_id="merchant-2"),
+                _user(merchant_ids=["merchant-1"]),
+                template_merchant_loader=_template_merchant_loader(_templates()),
+                merchant_scope_resolver=_merchant_scope(["merchant-1"]),
+            )
+        )
+
+    assert exc.value.code == "unauthorized_merchant"
+    assert exc.value.status_code == 403
+
+
+def test_requires_selected_merchant_when_scope_is_ambiguous():
+    with pytest.raises(CopilotScopeError) as exc:
+        asyncio.run(
+            resolve_copilot_scope(
+                CopilotScopeRequest(),
+                _user(
+                    role=UserRole.RESELLER,
+                    merchant_ids=["merchant-1", "merchant-2"],
+                ),
+                template_merchant_loader=_template_merchant_loader(_templates()),
+                merchant_scope_resolver=_merchant_scope(["merchant-1", "merchant-2"]),
+            )
+        )
+
+    assert exc.value.code == "ambiguous_merchant"
+
+
+def test_auto_selects_single_authorized_merchant():
+    scope = asyncio.run(
+        resolve_copilot_scope(
+            CopilotScopeRequest(),
+            _user(merchant_ids=["merchant-1"]),
+            template_merchant_loader=_template_merchant_loader(_templates()),
+            merchant_scope_resolver=_merchant_scope(["merchant-1"]),
+            now=datetime(2026, 7, 27, 12, 0),
+        )
+    )
+
+    assert scope.data.data_merchant_id == "merchant-1"
+
+
+def test_rejects_data_template_from_another_merchant():
+    with pytest.raises(CopilotScopeError) as exc:
+        asyncio.run(
+            resolve_copilot_scope(
+                CopilotScopeRequest(
+                    data_merchant_id="merchant-1",
+                    data_template_id=DATA_TEMPLATE_ID,
+                ),
+                _user(),
+                template_merchant_loader=_template_merchant_loader(
+                    _templates(data_merchant="merchant-2")
+                ),
+                merchant_scope_resolver=_merchant_scope(["merchant-1"]),
+            )
+        )
+
+    assert exc.value.code == "unauthorized_template"
+    assert exc.value.status_code == 403
+
+
+def test_rejects_missing_or_unowned_data_template():
+    with pytest.raises(CopilotScopeError) as exc:
+        asyncio.run(
+            resolve_copilot_scope(
+                CopilotScopeRequest(
+                    data_merchant_id="merchant-1",
+                    data_template_id=MISSING_TEMPLATE_ID,
+                ),
+                _user(),
+                template_merchant_loader=_template_merchant_loader(_templates()),
+                merchant_scope_resolver=_merchant_scope(["merchant-1"]),
+            )
+        )
+
+    assert exc.value.code == "unauthorized_template"
+    assert exc.value.status_code == 403
+
+
+def test_rejects_reseller_level_data_template_for_drilldown():
+    with pytest.raises(CopilotScopeError) as exc:
+        asyncio.run(
+            resolve_copilot_scope(
+                CopilotScopeRequest(
+                    data_merchant_id="merchant-1",
+                    data_template_id=DATA_TEMPLATE_ID,
+                ),
+                _user(),
+                template_merchant_loader=_template_merchant_loader(
+                    _templates(data_merchant=None)
+                ),
+                merchant_scope_resolver=_merchant_scope(["merchant-1"]),
+            )
+        )
+
+    assert exc.value.code == "unauthorized_template"
+
+
+def test_default_date_window_uses_last_seven_days_in_timezone():
+    scope = asyncio.run(
+        resolve_copilot_scope(
+            CopilotScopeRequest(
+                data_merchant_id="merchant-1",
+                timezone="Asia/Kolkata",
+            ),
+            _user(),
+            template_merchant_loader=_template_merchant_loader(_templates()),
+            merchant_scope_resolver=_merchant_scope(["merchant-1"]),
+            now=datetime(2026, 7, 27, 12, 0),
+        )
+    )
+
+    assert scope.date_window.date_from == date(2026, 7, 21)
+    assert scope.date_window.date_to == date(2026, 7, 27)
+    assert scope.date_window.source == CopilotDateRangeSource.DEFAULT
+
+
+def test_requested_date_range_is_preserved():
+    scope = asyncio.run(
+        resolve_copilot_scope(
+            CopilotScopeRequest(
+                data_merchant_id="merchant-1",
+                date_range=CopilotRequestedDateRange(
+                    date_from=date(2026, 7, 10),
+                    date_to=date(2026, 7, 12),
+                ),
+            ),
+            _user(),
+            template_merchant_loader=_template_merchant_loader(_templates()),
+            merchant_scope_resolver=_merchant_scope(["merchant-1"]),
+        )
+    )
+
+    assert scope.date_window.date_from == date(2026, 7, 10)
+    assert scope.date_window.date_to == date(2026, 7, 12)
+    assert scope.date_window.source == CopilotDateRangeSource.REQUEST
+
+
+def test_malformed_timezone_is_rejected_as_scope_error():
+    with pytest.raises(CopilotScopeError) as exc:
+        asyncio.run(
+            resolve_copilot_scope(
+                CopilotScopeRequest(data_merchant_id="merchant-1", timezone="../UTC"),
+                _user(),
+                template_merchant_loader=_template_merchant_loader(_templates()),
+                merchant_scope_resolver=_merchant_scope(["merchant-1"]),
+            )
+        )
+
+    assert exc.value.code == "invalid_timezone"
+    assert exc.value.status_code == 400
+
+
+def test_invalid_date_range_is_rejected_by_schema():
+    with pytest.raises(ValidationError):
+        CopilotRequestedDateRange(
+            date_from=date(2026, 7, 12),
+            date_to=date(2026, 7, 10),
+        )
+
+
+def test_invalid_data_template_id_is_rejected_by_schema():
+    with pytest.raises(ValidationError):
+        CopilotScopeRequest(
+            data_merchant_id="merchant-1",
+            data_template_id="not-a-uuid",
+        )
+
+
+def test_unrestricted_merchant_scope_still_requires_selection():
+    with pytest.raises(CopilotScopeError) as exc:
+        asyncio.run(
+            resolve_copilot_scope(
+                CopilotScopeRequest(),
+                _user(role=UserRole.ADMIN, merchant_ids=["*"]),
+                template_merchant_loader=_template_merchant_loader(_templates()),
+                merchant_scope_resolver=_merchant_scope(None),
+            )
+        )
+
+    assert exc.value.code == "ambiguous_merchant"
+
+
+def test_selected_merchant_can_use_shared_unrestricted_scope():
+    scope = asyncio.run(
+        resolve_copilot_scope(
+            CopilotScopeRequest(data_merchant_id="merchant-2"),
+            _user(role=UserRole.ADMIN, merchant_ids=["*"]),
+            template_merchant_loader=_template_merchant_loader(_templates()),
+            merchant_scope_resolver=_merchant_scope(None),
+            now=datetime(2026, 7, 27, 12, 0),
+        )
+    )
+
+    assert scope.data.data_merchant_id == "merchant-2"
+
+
+def test_template_accessor_reads_only_template_merchant(monkeypatch):
+    captured: dict[str, object] = {}
+
+    async def run_query(query: str, values: list[object]):
+        captured["query"] = query
+        captured["values"] = values
+        return [{"merchant_id": "merchant-1"}]
+
+    monkeypatch.setattr(
+        "app.database.accessor.breeze_buddy.template.run_parameterized_query",
+        run_query,
+    )
+
+    merchant_id = asyncio.run(get_template_merchant_id("template-1"))
+
+    assert merchant_id == "merchant-1"
+    assert captured["values"] == ["template-1"]
+    assert "SELECT merchant_id" in str(captured["query"])
+    assert "flow" not in str(captured["query"])
+    assert "secrets" not in str(captured["query"])


### PR DESCRIPTION
## Plan Doc
- https://docs.breezehq.dev/share/ihhc3sovfu/p/buddy-copilot-via-buddy-assist-runtime-technical-approach-yk8TusKfHp

## Ticket
- https://plane.breezehq.dev/breeze/browse/BZN-40679/

## New Features

- Added Buddy Copilot data-scope resolution for authenticated users, separating dashboard-selected analytics/conversation scope from the normal Assist chat runtime.
- Added support for explicit or default date windows covering the previous seven days.
- Added validation for analytics permission, merchant access, strict one-agent template ownership, ambiguous merchant selection, invalid date ranges, and invalid timezones.
- Added structured scope responses with supported Copilot capabilities and optional warnings.
- Added semantic `metadata.copilot` scope metadata so Assist chat can carry `data_merchant_id` and optional `data_template_id` without mixing them with `chat_session.merchant_id` or runtime merchant/template identity.
- Added lightweight template ownership lookup via `SELECT merchant_id` so Copilot authorization checks do not hydrate full template flow/configuration/secrets.

## Tests

- Added focused backend coverage for authorization, merchant RBAC, data template ownership, runtime/data separation, timezone/date-window behavior, metadata shape, and lightweight template ownership lookup.