### PR TITLE
feat(buddy-assist): add native Human Assist data layer and schema

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -275,6 +275,11 @@ BACKGROUND_TASKS_LOOP_INTERVAL_SECONDS=15  # How often the scheduler checks for 
 ENABLE_BB_LANGFUSE_MONITORING_LOOP=false  # Enable/disable Langfuse score monitoring task only (default: false)
 SCORE_CHECK_INTERVAL_SECONDS=600  # Check interval for Langfuse scores (10 minutes)
 
+# Human Assist lifecycle sweep (claim-deadline timeouts, disconnected customers).
+# Static (not Redis-backed) since dynamic config is shared by voice-agent and
+# master Clairvoyance pods alike, and this loop must only run on the master.
+ENABLE_HUMAN_ASSIST_LIFECYCLE_LOOP=false  # default: false; set true only on the master Clairvoyance deployment
+
 DAILY_SUMMARY_HOUR = "21" # Hour of the day (0-23) to send daily summary alerts (default: 21 for 9 PM)
 
 # Outbound Rate Limiting (sliding window per phone number)

--- a/app/api/routers/breeze_buddy/chat/handlers.py
+++ b/app/api/routers/breeze_buddy/chat/handlers.py
@@ -1155,10 +1155,16 @@ async def get_chat_transcript_handler(
     """
     messages = await list_chat_messages_for_session(session.id)
     turn_metrics = await list_chat_turn_metrics_for_session(session.id)
+    evaluation_messages = [
+        {"role": m.role.value, "content": m.content}
+        for m in messages
+        if (m.sender_type or "") not in {"human", "system", "internal"}
+    ]
     return ChatTranscriptResponse(
         session_id=session.id,
         template_id=session.template_id,
         status=session.status,
         messages=_sanitize_messages_for_widget(messages),
+        evaluation_messages=evaluation_messages,
         turn_metrics=turn_metrics,
     )

--- a/app/core/config/dynamic.py
+++ b/app/core/config/dynamic.py
@@ -207,6 +207,54 @@ async def CHAT_HISTORY_REPLAY_LIMIT() -> int:
     return await get_config("CHAT_HISTORY_REPLAY_LIMIT", 100, int)
 
 
+async def HUMAN_ASSIST_CLAIM_TIMEOUT_SECONDS() -> int:
+    """How long a native Human Assist ticket may remain unclaimed.
+
+    PostgreSQL ``claim_deadline_at`` is authoritative; this value is read only
+    when the ticket is created. Default: five minutes.
+    """
+    return await get_config("HUMAN_ASSIST_CLAIM_TIMEOUT_SECONDS", 300, int)
+
+
+async def HUMAN_ASSIST_CUSTOMER_DISCONNECT_TIMEOUT_SECONDS() -> int:
+    """Close an active ticket after storefront heartbeats stop for this long.
+
+    A grace window avoids treating normal same-site navigations as a tab close.
+    Default: 45 seconds.
+    """
+    return await get_config("HUMAN_ASSIST_CUSTOMER_DISCONNECT_TIMEOUT_SECONDS", 45, int)
+
+
+async def HUMAN_ASSIST_PLATFORM_OPERATION_TIMEOUT_SECONDS() -> int:
+    """Maximum duration of one external Human Assist adapter operation.
+
+    This must remain comfortably below the non-renewing per-session lock TTL.
+    Default: 30 seconds.
+    """
+    return await get_config("HUMAN_ASSIST_PLATFORM_OPERATION_TIMEOUT_SECONDS", 30, int)
+
+
+async def HUMAN_ASSIST_LIFECYCLE_LOOP_INTERVAL_SECONDS() -> int:
+    """How often the Human Assist lifecycle sweep checks for claim-deadline
+    timeouts and disconnected customers.
+
+    NOTE: ``BackgroundTaskScheduler.register_task`` reads ``interval_seconds``
+    once at startup and never re-reads it, so a DevCycle/Redis change here
+    only takes effect after the next pod restart — unlike the thresholds
+    above, this is not truly live-tunable. Kept alongside them anyway for
+    operational consistency. Default: five seconds, substantially tighter
+    than the shared background-task cadence
+    (``BACKGROUND_TASKS_LOOP_INTERVAL_SECONDS`` in static config).
+
+    Whether the sweep runs at all is gated separately by
+    ``ENABLE_HUMAN_ASSIST_LIFECYCLE_LOOP`` in static config — a plain env
+    flag, not Redis-backed, because Redis/DevCycle config is shared by
+    voice-agent pods and master Clairvoyance alike, and this loop must only
+    run on the master.
+    """
+    return await get_config("HUMAN_ASSIST_LIFECYCLE_LOOP_INTERVAL_SECONDS", 30, int)
+
+
 async def WIDGET_STT_MAX_AUDIO_BYTES() -> int:
     """Max audio upload accepted by ``POST /widget/session/{id}/transcribe``
     (push-to-talk). Clips are short; the default 10 MB sits well under

--- a/app/core/config/static.py
+++ b/app/core/config/static.py
@@ -618,6 +618,15 @@ BACKGROUND_TASKS_LOOP_INTERVAL_SECONDS = int(
 ENABLE_BB_LANGFUSE_MONITORING_LOOP = (
     os.environ.get("ENABLE_BB_LANGFUSE_MONITORING_LOOP", "false").lower() == "true"
 )
+
+# Human Assist lifecycle sweep (claim-deadline timeouts, disconnected
+# customers — see docs/HUMAN_ASSIST_PLATFORM_ORCHESTRATOR.md). Static, not
+# Redis-backed: dynamic config is shared by voice-agent and master
+# Clairvoyance pods alike, but this loop should only run on the master.
+# Default false; set true via env only on the master Clairvoyance deployment.
+ENABLE_HUMAN_ASSIST_LIFECYCLE_LOOP = (
+    os.environ.get("ENABLE_HUMAN_ASSIST_LIFECYCLE_LOOP", "false").lower() == "true"
+)
 SCORE_CHECK_INTERVAL_SECONDS = int(
     os.environ.get("SCORE_CHECK_INTERVAL_SECONDS", "600")
 )  # 10 minutes

--- a/app/database/accessor/breeze_buddy/chat_session.py
+++ b/app/database/accessor/breeze_buddy/chat_session.py
@@ -26,10 +26,12 @@ from app.database.queries.breeze_buddy.chat_session import (
     get_agent_session_state_query,
     get_chat_session_by_id_query,
     insert_chat_message_query,
+    list_chat_messages_after_idx_query,
     list_chat_messages_for_session_query,
     list_chat_sessions_query,
     list_chat_turn_metrics_for_session_query,
     list_idle_chat_sessions_query,
+    list_visible_chat_messages_for_session_query,
     merge_client_context_query,
     record_chat_turn_metrics_query,
     set_chat_session_voice_lead_query,
@@ -229,6 +231,7 @@ async def insert_chat_message(
     content: Optional[str] = None,
     content_blocks: Optional[List[Dict[str, Any]]] = None,
     ui_blocks: Optional[List[Dict[str, Any]]] = None,
+    sender_type: Optional[str] = None,
 ) -> Optional[ChatMessage]:
     """Append one message; idx is auto-allocated atomically by the query.
 
@@ -243,6 +246,9 @@ async def insert_chat_message(
     during an assistant turn. Consumed only by the widget resume path
     to repaint Tiles/Carousels — the LLM never sees this column. Pass
     ``None`` (default) on user turns and on assistant turns without UI.
+
+    ``sender_type`` (migration 044) is Human Assist attribution
+    (customer/buddy/human/system/internal); ``None`` for ordinary chat.
     """
     query, values = insert_chat_message_query(
         session_id=session_id,
@@ -252,6 +258,7 @@ async def insert_chat_message(
             json.dumps(content_blocks) if content_blocks is not None else None
         ),
         ui_blocks_json=(json.dumps(ui_blocks) if ui_blocks else None),
+        sender_type=sender_type,
     )
     try:
         result = await run_parameterized_query(query, values)
@@ -286,6 +293,49 @@ async def list_chat_messages_for_session(
         return messages
     except Exception as e:
         logger.error(f"Error listing chat messages for session {session_id}: {e}")
+        raise
+
+
+async def list_visible_chat_messages_for_session(session_id: str) -> List[ChatMessage]:
+    """Widget-visible full history for session resume.
+
+    Excludes internal rows and the idx=0 rollover continuity summary —
+    see ``list_visible_chat_messages_for_session_query`` for details.
+    Dedicated to the widget resume caller so
+    ``list_chat_messages_for_session`` keeps returning the unfiltered
+    log for its other callers (transcript export, LLM-context replay).
+    """
+    query, values = list_visible_chat_messages_for_session_query(session_id)
+    try:
+        rows = await run_parameterized_query(query, values)
+        return [
+            decoded
+            for row in rows or []
+            if (decoded := decode_chat_message(row)) is not None
+        ]
+    except Exception as e:
+        logger.opt(exception=e).error(
+            f"Error listing visible chat messages for session {session_id}"
+        )
+        raise
+
+
+async def list_chat_messages_after_idx(
+    session_id: str, after_idx: int
+) -> List[ChatMessage]:
+    query, values = list_chat_messages_after_idx_query(session_id, after_idx)
+    try:
+        rows = await run_parameterized_query(query, values)
+        return [
+            decoded
+            for row in rows or []
+            if (decoded := decode_chat_message(row)) is not None
+        ]
+    except Exception as e:
+        logger.opt(exception=e).error(
+            f"Error listing chat messages after idx {after_idx} "
+            f"for session {session_id}"
+        )
         raise
 
 

--- a/app/database/accessor/breeze_buddy/human_assist.py
+++ b/app/database/accessor/breeze_buddy/human_assist.py
@@ -1,0 +1,435 @@
+"""Database accessors for platform-agnostic Human Assist."""
+
+import asyncio
+import random
+from datetime import datetime
+from typing import Any, Dict, List, Optional, Tuple
+
+import asyncpg
+
+from app.core.logger import logger
+from app.database.decoder.breeze_buddy.chat_session import decode_chat_message
+from app.database.decoder.breeze_buddy.human_assist import (
+    decode_human_assist_conversation,
+)
+from app.database.queries import run_parameterized_query
+from app.database.queries.breeze_buddy.human_assist import (
+    claim_human_assist_conversation_query,
+    close_human_assist_conversation_query,
+    create_human_assist_conversation_query,
+    get_active_human_assist_for_session_query,
+    get_human_assist_conversation_query,
+    get_human_assist_scope_signature_query,
+    insert_human_assist_platform_message_query,
+    list_due_human_assist_query,
+    list_human_assist_conversations_query,
+    list_human_assist_transcript_query,
+    merge_human_assist_metadata_query,
+    rollover_human_assist_session_query,
+    touch_human_assist_activity_query,
+    touch_human_assist_customer_query,
+)
+from app.schemas.breeze_buddy.chat import ChatMessage
+from app.schemas.breeze_buddy.human_assist import HumanAssistConversation
+
+
+async def _one(
+    query: str, values: List[Any], *, context: str
+) -> Optional[HumanAssistConversation]:
+    try:
+        rows = await run_parameterized_query(query, values)
+        return decode_human_assist_conversation(rows[0]) if rows else None
+    except Exception as e:
+        logger.opt(exception=e).error(f"Error {context}")
+        raise
+
+
+async def create_human_assist_conversation(
+    *,
+    chat_session_id: str,
+    claim_timeout_seconds: int,
+    metadata: Dict[str, Any],
+    notification_content: str,
+    notification_blocks: List[Dict[str, Any]],
+    sender_type: str,
+) -> Optional[HumanAssistConversation]:
+    query, values = create_human_assist_conversation_query(
+        chat_session_id=chat_session_id,
+        claim_timeout_seconds=claim_timeout_seconds,
+        metadata=metadata,
+        notification_content=notification_content,
+        notification_blocks=notification_blocks,
+        sender_type=sender_type,
+    )
+    return await _one(
+        query,
+        values,
+        context=f"creating human_assist conversation for chat_session {chat_session_id}",
+    )
+
+
+async def rollover_human_assist_session(
+    *,
+    chat_session_id: str,
+    claim_timeout_seconds: int,
+    conversation_metadata: Dict[str, Any],
+    context_content: str,
+    context_blocks: List[Dict[str, Any]],
+    context_sender_type: str,
+    notification_content: str,
+    notification_blocks: List[Dict[str, Any]],
+    notification_sender_type: str,
+) -> Optional[HumanAssistConversation]:
+    query, values = rollover_human_assist_session_query(
+        chat_session_id=chat_session_id,
+        claim_timeout_seconds=claim_timeout_seconds,
+        conversation_metadata=conversation_metadata,
+        context_content=context_content,
+        context_blocks=context_blocks,
+        context_sender_type=context_sender_type,
+        notification_content=notification_content,
+        notification_blocks=notification_blocks,
+        notification_sender_type=notification_sender_type,
+    )
+    return await _one(
+        query,
+        values,
+        context=f"rolling over human_assist session for chat_session {chat_session_id}",
+    )
+
+
+async def get_human_assist_conversation(
+    conversation_id: str,
+    *,
+    include_stats: bool = False,
+) -> Optional[HumanAssistConversation]:
+    query, values = get_human_assist_conversation_query(
+        conversation_id,
+        include_stats=include_stats,
+    )
+    return await _one(
+        query,
+        values,
+        context=f"fetching human_assist conversation {conversation_id}",
+    )
+
+
+async def get_active_human_assist_for_session(
+    chat_session_id: str,
+) -> Optional[HumanAssistConversation]:
+    query, values = get_active_human_assist_for_session_query(chat_session_id)
+    return await _one(
+        query,
+        values,
+        context=f"fetching active human_assist conversation for chat_session {chat_session_id}",
+    )
+
+
+async def merge_human_assist_metadata(
+    conversation_id: str,
+    metadata: Dict[str, Any],
+) -> Optional[HumanAssistConversation]:
+    query, values = merge_human_assist_metadata_query(conversation_id, metadata)
+    return await _one(
+        query,
+        values,
+        context=f"merging human_assist metadata for conversation {conversation_id}",
+    )
+
+
+_TALLY_KEYS = (
+    "pending_total",
+    "open_total",
+    "closed_total",
+    "timed_out_total",
+    "active_total",
+)
+
+
+async def list_human_assist_conversations(
+    *,
+    statuses: Optional[List[str]],
+    reseller_id: Optional[str],
+    merchant_id: Optional[str],
+    reseller_ids: Optional[List[str]],
+    merchant_ids: Optional[List[str]],
+    search: Optional[str] = None,
+    limit: int,
+    offset: int,
+) -> Tuple[List[HumanAssistConversation], int, Dict[str, int]]:
+    """Return one page plus the tab tallies for the whole scope.
+
+    ``list_human_assist_conversations_query`` always returns exactly one row
+    even when the page is empty (filtered out, or paged past the end): its
+    ``tallies`` CTE is an ungrouped aggregate (always one row) and its
+    ``page`` CTE is joined with ``LEFT JOIN ... ON TRUE``, so ``total`` and
+    every tab tally stay correct straight from that single statement.
+    """
+    scope = (
+        f"reseller={reseller_id or reseller_ids} merchant={merchant_id or merchant_ids}"
+    )
+    query, values = list_human_assist_conversations_query(
+        statuses=statuses,
+        reseller_id=reseller_id,
+        merchant_id=merchant_id,
+        reseller_ids=reseller_ids,
+        merchant_ids=merchant_ids,
+        search=search,
+        limit=limit,
+        offset=offset,
+    )
+    try:
+        rows = await run_parameterized_query(query, values)
+    except Exception as e:
+        logger.opt(exception=e).error(
+            f"Error listing human_assist conversations for {scope}"
+        )
+        raise
+    conversations = [
+        decoded
+        for row in rows or []
+        if row.get("id") is not None
+        if (decoded := decode_human_assist_conversation(row)) is not None
+    ]
+    counts = {key: int(rows[0][key] or 0) for key in _TALLY_KEYS}
+    return conversations, int(rows[0]["total"] or 0), counts
+
+
+async def list_human_assist_transcript(
+    session_id: str,
+    after_idx: Optional[int] = None,
+    limit: Optional[int] = None,
+) -> List[ChatMessage]:
+    """Inbox transcript for a ticket, optionally only rows after ``after_idx``."""
+    query, values = list_human_assist_transcript_query(session_id, after_idx, limit)
+    try:
+        rows = await run_parameterized_query(query, values)
+    except Exception as e:
+        logger.opt(exception=e).error(
+            f"Error listing human_assist transcript for session {session_id}"
+        )
+        raise
+    return [
+        decoded
+        for row in rows or []
+        if (decoded := decode_chat_message(row)) is not None
+    ]
+
+
+async def claim_human_assist_conversation(
+    conversation_id: str,
+    opened_by: str,
+    *,
+    notification_content: str,
+    notification_blocks: List[Dict[str, Any]],
+    sender_type: str,
+) -> Optional[HumanAssistConversation]:
+    query, values = claim_human_assist_conversation_query(
+        conversation_id,
+        opened_by,
+        notification_content,
+        notification_blocks,
+        sender_type,
+    )
+    return await _one(
+        query,
+        values,
+        context=f"claiming human_assist conversation {conversation_id} by {opened_by}",
+    )
+
+
+async def touch_human_assist_customer(
+    chat_session_id: str,
+    *,
+    mark_activity: bool = False,
+) -> Optional[HumanAssistConversation]:
+    query, values = touch_human_assist_customer_query(
+        chat_session_id,
+        mark_activity=mark_activity,
+    )
+    return await _one(
+        query,
+        values,
+        context=f"touching human_assist customer activity for chat_session {chat_session_id}",
+    )
+
+
+async def insert_human_assist_platform_message(
+    *,
+    session_id: str,
+    role: str,
+    content: str,
+    content_blocks: List[Dict[str, Any]],
+    sender_type: Optional[str],
+    max_attempts: int = 3,
+) -> Optional[ChatMessage]:
+    """Insert one provider-normalized message.
+
+    ``idx`` is allocated as ``MAX(idx) + 1`` inside the INSERT, so two
+    concurrent inserts for the same session can race and collide on the
+    ``(session_id, idx)`` primary key, raising ``UniqueViolationError``.
+    Retry a few times here rather than dropping the message.
+    """
+    query, values = insert_human_assist_platform_message_query(
+        session_id=session_id,
+        role=role,
+        content=content,
+        content_blocks=content_blocks,
+        sender_type=sender_type,
+    )
+    for attempt in range(1, max_attempts + 1):
+        try:
+            rows = await run_parameterized_query(query, values)
+            return decode_chat_message(rows[0]) if rows else None
+        except asyncpg.UniqueViolationError as e:
+            if attempt == max_attempts:
+                logger.opt(exception=e).error(
+                    f"Error inserting human_assist message for session "
+                    f"{session_id}: idx race exhausted {max_attempts} retries"
+                )
+                raise
+            await asyncio.sleep(random.uniform(0.01, 0.05) * attempt)
+            continue
+        except Exception as e:
+            logger.opt(exception=e).error(
+                f"Error inserting human_assist message for session {session_id}"
+            )
+            raise
+
+
+async def touch_human_assist_activity(
+    conversation_id: str,
+    opened_by: Optional[str] = None,
+) -> Optional[HumanAssistConversation]:
+    query, values = touch_human_assist_activity_query(conversation_id, opened_by)
+    return await _one(
+        query,
+        values,
+        context=f"touching human_assist activity for conversation {conversation_id}",
+    )
+
+
+async def close_human_assist_conversation(
+    conversation_id: str,
+    *,
+    terminal_status: str,
+    close_reason: str,
+    closed_by: Optional[str],
+    allowed_statuses: List[str],
+    notification_content: Optional[str],
+    notification_blocks: Optional[List[Dict[str, Any]]],
+    notification_sender_type: Optional[str],
+    end_session: bool = False,
+) -> Optional[HumanAssistConversation]:
+    query, values = close_human_assist_conversation_query(
+        conversation_id,
+        terminal_status=terminal_status,
+        close_reason=close_reason,
+        closed_by=closed_by,
+        allowed_statuses=allowed_statuses,
+        notification_content=notification_content,
+        notification_blocks=notification_blocks,
+        notification_sender_type=notification_sender_type,
+        end_session=end_session,
+    )
+    return await _one(
+        query,
+        values,
+        context=f"closing human_assist conversation {conversation_id} ({close_reason})",
+    )
+
+
+async def get_human_assist_scope_signature(
+    *,
+    reseller_id: Optional[str],
+    merchant_id: Optional[str],
+    reseller_ids: Optional[List[str]],
+    merchant_ids: Optional[List[str]],
+) -> Tuple[Optional[datetime], int]:
+    query, values = get_human_assist_scope_signature_query(
+        reseller_id=reseller_id,
+        merchant_id=merchant_id,
+        reseller_ids=reseller_ids,
+        merchant_ids=merchant_ids,
+    )
+    try:
+        rows = await run_parameterized_query(query, values)
+    except Exception as e:
+        logger.opt(exception=e).error(
+            f"Error fetching human_assist scope signature for "
+            f"reseller={reseller_id or reseller_ids} "
+            f"merchant={merchant_id or merchant_ids}"
+        )
+        raise
+    if not rows:
+        return None, 0
+    return rows[0].get("latest_activity_at"), int(rows[0].get("ticket_count") or 0)
+
+
+async def list_due_human_assist_claims(
+    cutoff: datetime,
+    limit: int = 100,
+    *,
+    exclude_ids: Optional[List[str]] = None,
+) -> List[HumanAssistConversation]:
+    query, values = list_due_human_assist_query(
+        claim_deadline_before=cutoff,
+        limit=limit,
+        exclude_ids=exclude_ids,
+    )
+    try:
+        rows = await run_parameterized_query(query, values)
+    except Exception as e:
+        logger.opt(exception=e).error(
+            f"Error listing due human_assist claims before {cutoff}"
+        )
+        raise
+    return [
+        decoded
+        for row in rows or []
+        if (decoded := decode_human_assist_conversation(row)) is not None
+    ]
+
+
+async def list_stale_human_assist_customers(
+    cutoff: datetime,
+    limit: int = 100,
+    *,
+    exclude_ids: Optional[List[str]] = None,
+) -> List[HumanAssistConversation]:
+    query, values = list_due_human_assist_query(
+        customer_seen_before=cutoff,
+        limit=limit,
+        exclude_ids=exclude_ids,
+    )
+    try:
+        rows = await run_parameterized_query(query, values)
+    except Exception as e:
+        logger.opt(exception=e).error(
+            f"Error listing stale human_assist customers before {cutoff}"
+        )
+        raise
+    return [
+        decoded
+        for row in rows or []
+        if (decoded := decode_human_assist_conversation(row)) is not None
+    ]
+
+
+__all__ = [
+    "claim_human_assist_conversation",
+    "close_human_assist_conversation",
+    "create_human_assist_conversation",
+    "get_active_human_assist_for_session",
+    "get_human_assist_conversation",
+    "get_human_assist_scope_signature",
+    "insert_human_assist_platform_message",
+    "list_due_human_assist_claims",
+    "list_human_assist_conversations",
+    "list_human_assist_transcript",
+    "list_stale_human_assist_customers",
+    "merge_human_assist_metadata",
+    "rollover_human_assist_session",
+    "touch_human_assist_activity",
+    "touch_human_assist_customer",
+]

--- a/app/database/accessor/breeze_buddy/widget_config.py
+++ b/app/database/accessor/breeze_buddy/widget_config.py
@@ -34,6 +34,8 @@ async def create_widget_config(
     max_concurrent_per_ip: int,
     max_voice_sessions_per_ip_hour: int,
     active: bool,
+    human_assist_enabled: bool = False,
+    human_assist_platform: str = "native",
 ) -> Optional[WidgetConfigResponse]:
     query, values = create_widget_config_query(
         reseller_id=reseller_id,
@@ -45,6 +47,8 @@ async def create_widget_config(
         max_messages_per_ip_hour=max_messages_per_ip_hour,
         max_concurrent_per_ip=max_concurrent_per_ip,
         max_voice_sessions_per_ip_hour=max_voice_sessions_per_ip_hour,
+        human_assist_enabled=human_assist_enabled,
+        human_assist_platform=human_assist_platform,
         active=active,
     )
     try:
@@ -160,6 +164,8 @@ async def update_widget_config(
     max_messages_per_ip_hour: Optional[int] = None,
     max_concurrent_per_ip: Optional[int] = None,
     max_voice_sessions_per_ip_hour: Optional[int] = None,
+    human_assist_enabled: Optional[bool] = None,
+    human_assist_platform: Optional[str] = None,
     active: Optional[bool] = None,
 ) -> Optional[WidgetConfigResponse]:
     query, values = update_widget_config_query(
@@ -170,6 +176,8 @@ async def update_widget_config(
         max_messages_per_ip_hour=max_messages_per_ip_hour,
         max_concurrent_per_ip=max_concurrent_per_ip,
         max_voice_sessions_per_ip_hour=max_voice_sessions_per_ip_hour,
+        human_assist_enabled=human_assist_enabled,
+        human_assist_platform=human_assist_platform,
         active=active,
     )
     if not values:

--- a/app/database/decoder/breeze_buddy/chat_session.py
+++ b/app/database/decoder/breeze_buddy/chat_session.py
@@ -43,6 +43,7 @@ def decode_chat_session(row: asyncpg.Record) -> Optional[ChatSession]:
         metadata=metadata,
         current_channel=WidgetChannel(channel_raw),
         voice_lead_id=str(voice_lead_id_raw) if voice_lead_id_raw else None,
+        handoff_happened=bool(row.get("handoff_happened", False)),
         created_at=row["created_at"],
         last_activity_at=row["last_activity_at"],
         ended_at=row.get("ended_at"),
@@ -68,6 +69,7 @@ def decode_chat_message(row: asyncpg.Record) -> Optional[ChatMessage]:
         content=row.get("content"),
         content_blocks=blocks_raw,
         ui_blocks=ui_raw,
+        sender_type=row.get("sender_type"),
         created_at=row["created_at"],
     )
 

--- a/app/database/decoder/breeze_buddy/human_assist.py
+++ b/app/database/decoder/breeze_buddy/human_assist.py
@@ -1,0 +1,72 @@
+"""Row decoders for platform-agnostic Human Assist."""
+
+from typing import Optional
+
+import asyncpg
+
+from app.schemas.breeze_buddy.human_assist import (
+    HumanAssistCloseReason,
+    HumanAssistConversation,
+    HumanAssistStatus,
+)
+from app.utils.common import parse_json
+
+
+def decode_human_assist_conversation(
+    row: asyncpg.Record,
+) -> Optional[HumanAssistConversation]:
+    if not row:
+        return None
+    widget_config_id = row.get("widget_config_id")
+    if widget_config_id is None:
+        return None
+    try:
+        status = HumanAssistStatus(row["status"])
+    except ValueError:
+        return None
+    requested_at = row.get("requested_at")
+    claim_deadline_at = row.get("claim_deadline_at")
+    customer_last_seen_at = row.get("customer_last_seen_at")
+    last_activity_at = row.get("last_activity_at")
+    if (
+        requested_at is None
+        or claim_deadline_at is None
+        or customer_last_seen_at is None
+        or last_activity_at is None
+    ):
+        return None
+    close_reason = row.get("close_reason")
+    try:
+        decoded_close_reason = (
+            HumanAssistCloseReason(close_reason) if close_reason else None
+        )
+    except ValueError:
+        decoded_close_reason = None
+    metadata = parse_json(row, "metadata") or {}
+    preview = row.get("preview")
+    if isinstance(preview, str) and len(preview) > 160:
+        preview = preview[:160].rstrip() + "…"
+    return HumanAssistConversation(
+        id=str(row["id"]),
+        chat_session_id=str(row["chat_session_id"]),
+        widget_config_id=str(widget_config_id),
+        reseller_id=row["reseller_id"],
+        merchant_id=row.get("merchant_id"),
+        platform=str(metadata.get("platform") or "native"),
+        status=status,
+        requested_at=requested_at,
+        claim_deadline_at=claim_deadline_at,
+        opened_at=row.get("opened_at"),
+        opened_by=row.get("opened_by"),
+        closed_at=row.get("closed_at"),
+        closed_by=row.get("closed_by"),
+        close_reason=decoded_close_reason,
+        last_activity_at=last_activity_at,
+        customer_last_seen_at=customer_last_seen_at,
+        metadata=metadata,
+        message_count=row.get("message_count") or 0,
+        preview=preview,
+    )
+
+
+__all__ = ["decode_human_assist_conversation"]

--- a/app/database/decoder/breeze_buddy/widget_config.py
+++ b/app/database/decoder/breeze_buddy/widget_config.py
@@ -16,6 +16,8 @@ def decode_widget_config(row) -> WidgetConfigResponse:
         max_messages_per_ip_hour=row["max_messages_per_ip_hour"],
         max_concurrent_per_ip=row["max_concurrent_per_ip"],
         max_voice_sessions_per_ip_hour=row["max_voice_sessions_per_ip_hour"],
+        human_assist_enabled=row.get("human_assist_enabled", False),
+        human_assist_platform=row.get("human_assist_platform") or "native",
         active=row.get("active", True),
         created_at=row.get("created_at"),
         updated_at=row.get("updated_at"),

--- a/app/database/migrations/046_native_human_assist.sql
+++ b/app/database/migrations/046_native_human_assist.sql
@@ -1,0 +1,152 @@
+-- Buddy Human Assist persistence and platform orchestration.
+--
+-- A Human Assist ticket is the chat_session that owns its transcript. Repeat
+-- handoffs roll into a new session, so there is no separate ticket table or
+-- second identifier. Lifecycle and platform state live under
+-- chat_session.metadata.human_assist.
+-- The platform key is not constrained to an enum list so future adapters do
+-- not require a schema migration.
+
+BEGIN;
+
+ALTER TABLE chat_message
+    ADD COLUMN IF NOT EXISTS sender_type varchar(20);
+
+COMMENT ON COLUMN chat_message.sender_type IS
+    'Human Assist message attribution: customer, buddy, human, system, or '
+    'internal. NULL for ordinary (non-Live-Assist) chat messages; human rows '
+    'are excluded from AI evaluation.';
+
+ALTER TABLE chat_message
+    ADD CONSTRAINT chat_message_sender_type_check
+    CHECK (
+        sender_type IS NULL
+        OR sender_type IN ('customer', 'buddy', 'human', 'system', 'internal')
+    );
+
+ALTER TABLE chat_session
+    ADD COLUMN IF NOT EXISTS handoff_happened boolean NOT NULL DEFAULT FALSE;
+
+COMMENT ON COLUMN chat_session.handoff_happened IS
+    'Durable fact that at least one Human Assist handoff was requested in this session.';
+
+ALTER TABLE widget_config
+    ADD COLUMN IF NOT EXISTS human_assist_enabled boolean NOT NULL DEFAULT FALSE;
+
+COMMENT ON COLUMN widget_config.human_assist_enabled IS
+    'Per-merchant switch controlling whether Buddy may create native Human Assist tickets.';
+
+ALTER TABLE widget_config
+    ADD COLUMN IF NOT EXISTS human_assist_platform varchar(64)
+    NOT NULL DEFAULT 'native';
+
+COMMENT ON COLUMN widget_config.human_assist_platform IS
+    'Registered Human Assist adapter used for new handoffs. Existing active '
+    'conversations retain the platform snapshot in their metadata JSONB.';
+
+-- Replace the migration-030 channel constraint so HUMAN becomes a first-class
+-- routing state alongside CHAT and VOICE.
+ALTER TABLE chat_session
+    DROP CONSTRAINT IF EXISTS chat_session_current_channel_check;
+
+ALTER TABLE chat_session
+    ADD CONSTRAINT chat_session_current_channel_check
+    CHECK (current_channel IN ('CHAT', 'VOICE', 'HUMAN', 'ENDED'));
+
+ALTER TABLE chat_session
+    DROP CONSTRAINT IF EXISTS chat_session_ended_reason_check;
+
+ALTER TABLE chat_session
+    ADD CONSTRAINT chat_session_ended_reason_check CHECK (
+        ended_reason IS NULL
+        OR ended_reason IN (
+            'user_ended',
+            'idle_timeout',
+            'human_assist_rollover'
+        )
+    );
+
+ALTER TABLE chat_session
+    ADD CONSTRAINT chat_session_human_assist_record_check CHECK (
+        metadata->'human_assist' IS NULL
+        OR (
+            jsonb_typeof(metadata->'human_assist') = 'object'
+            AND metadata #>> '{human_assist,status}' IN (
+                'PENDING', 'OPEN', 'CLOSED', 'TIMED_OUT'
+            )
+            AND NULLIF(
+                metadata #>> '{human_assist,widget_config_id}',
+                ''
+            ) IS NOT NULL
+            AND NULLIF(
+                metadata #>> '{human_assist,requested_at}',
+                ''
+            ) IS NOT NULL
+            AND NULLIF(
+                metadata #>> '{human_assist,claim_deadline_at}',
+                ''
+            ) IS NOT NULL
+            AND NULLIF(
+                metadata #>> '{human_assist,customer_last_seen_at}',
+                ''
+            ) IS NOT NULL
+            AND (
+                metadata #>> '{human_assist,close_reason}' IS NULL
+                OR metadata #>> '{human_assist,close_reason}' IN (
+                    'merchant_closed',
+                    'claim_timeout',
+                    'customer_disconnected',
+                    'session_ended',
+                    'platform_closed',
+                    'platform_error'
+                )
+            )
+            AND (
+                (
+                    metadata #>> '{human_assist,status}' IN ('PENDING', 'OPEN')
+                    AND metadata #>> '{human_assist,closed_at}' IS NULL
+                )
+                OR (
+                    metadata #>> '{human_assist,status}' IN (
+                        'CLOSED', 'TIMED_OUT'
+                    )
+                    AND metadata #>> '{human_assist,closed_at}' IS NOT NULL
+                )
+            )
+        ) IS TRUE
+    );
+
+ALTER TABLE chat_session
+    ADD CONSTRAINT chat_session_handoff_record_check CHECK (
+        handoff_happened = FALSE
+        OR metadata->'human_assist' IS NOT NULL
+    );
+
+COMMENT ON COLUMN chat_session.metadata IS
+    'Session metadata. Human Assist sessions store their ticket lifecycle under '
+    'the human_assist key; the chat_session UUID is also the Human Assist ID.';
+
+CREATE INDEX idx_chat_session_human_assist_inbox
+    ON chat_session (
+        reseller_id,
+        merchant_id,
+        ((metadata #>> '{human_assist,status}')),
+        last_activity_at DESC
+    )
+    WHERE metadata ? 'human_assist';
+
+CREATE INDEX idx_chat_session_human_assist_claim_deadline
+    ON chat_session ((metadata #>> '{human_assist,claim_deadline_at}'))
+    WHERE metadata #>> '{human_assist,status}' = 'PENDING';
+
+CREATE INDEX idx_chat_session_human_assist_customer_seen
+    ON chat_session ((metadata #>> '{human_assist,customer_last_seen_at}'))
+    WHERE metadata #>> '{human_assist,status}' IN ('PENDING', 'OPEN');
+
+COMMENT ON INDEX idx_chat_session_human_assist_claim_deadline IS
+    'Supports ordered pending-ticket claim-timeout sweeps.';
+
+COMMENT ON INDEX idx_chat_session_human_assist_customer_seen IS
+    'Supports ordered disconnected-customer sweeps.';
+
+COMMIT;

--- a/app/database/queries/breeze_buddy/chat_session.py
+++ b/app/database/queries/breeze_buddy/chat_session.py
@@ -17,12 +17,13 @@ CHAT_TURN_METRICS_TABLE = "chat_turn_metrics"
 _SESSION_COLUMNS = """
     id, template_id, reseller_id, merchant_id,
     status, outcome, current_node, metadata,
-    current_channel, voice_lead_id,
+    current_channel, voice_lead_id, handoff_happened,
     created_at, last_activity_at, ended_at, ended_reason
 """
 
 _MESSAGE_COLUMNS = """
-    session_id, idx, role, content, content_blocks, ui_blocks, created_at
+    session_id, idx, role, content, content_blocks, ui_blocks,
+    sender_type, created_at
 """
 
 _AGENT_STATE_COLUMNS = """
@@ -97,6 +98,7 @@ def end_chat_session_query(
     query = f"""
         UPDATE {CHAT_SESSION_TABLE}
         SET status = 'ENDED',
+            current_channel = 'ENDED',
             outcome = COALESCE($1, outcome),
             ended_at = COALESCE(ended_at, now()),
             ended_reason = COALESCE(ended_reason, $2),
@@ -142,12 +144,17 @@ def list_idle_chat_sessions_query(
     """Sessions whose last_activity_at < cutoff and status ∈ statuses.
 
     Ordered ascending so the oldest are processed first by the sweeper.
+    Excludes current_channel='HUMAN' — those tickets have their own
+    claim-deadline/disconnect sweep and a relayed message doesn't bump
+    last_activity_at, so this generic sweep would force-end a live
+    human conversation as a false idle timeout.
     """
     query = f"""
         SELECT {_SESSION_COLUMNS}
         FROM {CHAT_SESSION_TABLE}
         WHERE status = ANY($1)
           AND last_activity_at < $2
+          AND current_channel IS DISTINCT FROM 'HUMAN'
         ORDER BY last_activity_at ASC
         LIMIT $3
     """
@@ -342,6 +349,7 @@ def insert_chat_message_query(
     content: Optional[str],
     content_blocks_json: Optional[str] = None,
     ui_blocks_json: Optional[str] = None,
+    sender_type: Optional[str] = None,
 ) -> Tuple[str, List[Any]]:
     """Insert one message with auto-allocated idx (per-session monotonic).
 
@@ -357,10 +365,14 @@ def insert_chat_message_query(
     ``ui_blocks_json`` (migration 030) is the SpecStream ui_op list
     serialised to a JSON string. Consumed only by the widget resume
     path to repaint Tiles/Carousels; the LLM never sees this column.
+
+    ``sender_type`` (migration 044) is Human Assist attribution
+    (customer/buddy/human/system/internal); ``None`` for ordinary chat.
     """
     query = f"""
         INSERT INTO {CHAT_MESSAGE_TABLE} (
-            session_id, idx, role, content, content_blocks, ui_blocks
+            session_id, idx, role, content, content_blocks, ui_blocks,
+            sender_type
         )
         VALUES (
             $1,
@@ -370,11 +382,47 @@ def insert_chat_message_query(
                  WHERE session_id = $1),
                 0
             ),
-            $2, $3, $4::jsonb, $5::jsonb
+            $2, $3, $4::jsonb, $5::jsonb, $6
         )
         RETURNING {_MESSAGE_COLUMNS}
     """
-    return query, [session_id, role, content, content_blocks_json, ui_blocks_json]
+    return query, [
+        session_id,
+        role,
+        content,
+        content_blocks_json,
+        ui_blocks_json,
+        sender_type,
+    ]
+
+
+def list_chat_messages_after_idx_query(
+    session_id: str,
+    after_idx: int,
+) -> Tuple[str, List[Any]]:
+    """Visible delivery log after a caller's last observed message index.
+
+    Excludes internal rows and, for a session that rolled over from a
+    prior one, the idx=0 continuity summary (LLM-only context, never
+    shown to the customer/widget) — detected via chat_session's own
+    ``human_assist_lineage`` marker rather than a per-message tag.
+    """
+    query = f"""
+        SELECT {_MESSAGE_COLUMNS}
+        FROM {CHAT_MESSAGE_TABLE} m
+        WHERE m.session_id = $1
+          AND m.idx > $2
+          AND COALESCE(m.sender_type, '') <> 'internal'
+          AND NOT (
+              m.idx = 0
+              AND EXISTS (
+                  SELECT 1 FROM {CHAT_SESSION_TABLE} cs
+                  WHERE cs.id = $1 AND cs.metadata ? 'human_assist_lineage'
+              )
+          )
+        ORDER BY m.idx ASC
+    """
+    return query, [session_id, after_idx]
 
 
 def list_chat_messages_for_session_query(
@@ -397,19 +445,72 @@ def list_chat_messages_for_session_query(
         """
         return query, [session_id]
 
-    # Take the last ``limit`` rows (DESC + LIMIT) then re-sort ASC so
-    # the caller gets chronological order.
+    # Keep the rollover continuity row pinned even after a long human
+    # exchange pushes idx=0 outside the normal replay window. A session's
+    # own human_assist_lineage marker (set once, at rollover time) identifies
+    # it — idx=0 is deterministically where rollover_human_assist_session_query
+    # inserts the continuity row, so no per-message tag is needed.
     query = f"""
-        SELECT {_MESSAGE_COLUMNS} FROM (
+        WITH recent AS MATERIALIZED (
             SELECT {_MESSAGE_COLUMNS}
             FROM {CHAT_MESSAGE_TABLE}
             WHERE session_id = $1
             ORDER BY idx DESC
             LIMIT $2
-        ) recent
+        ),
+        rollover_context AS (
+            SELECT {_MESSAGE_COLUMNS}
+            FROM {CHAT_MESSAGE_TABLE} m
+            WHERE m.session_id = $1
+              AND m.idx = 0
+              AND EXISTS (
+                  SELECT 1 FROM {CHAT_SESSION_TABLE} cs
+                  WHERE cs.id = $1 AND cs.metadata ? 'human_assist_lineage'
+              )
+        )
+        SELECT {_MESSAGE_COLUMNS}
+        FROM (
+            SELECT * FROM recent
+            UNION ALL
+            SELECT * FROM rollover_context context_row
+            WHERE NOT EXISTS (
+                SELECT 1 FROM recent
+                WHERE recent.idx = context_row.idx
+            )
+        ) history
         ORDER BY idx ASC
     """
     return query, [session_id, limit]
+
+
+def list_visible_chat_messages_for_session_query(
+    session_id: str,
+) -> Tuple[str, List[Any]]:
+    """Widget-visible full history for session resume.
+
+    Same visibility rules as ``list_chat_messages_after_idx_query``:
+    excludes internal rows and, for a session that rolled over from a
+    prior one, the idx=0 continuity summary (LLM-only context, never
+    shown to the customer/widget). Scoped to its own query (rather than
+    folded into ``list_chat_messages_for_session_query``) so the other
+    callers of that function — transcript export, LLM-context replay —
+    keep their existing unfiltered behavior.
+    """
+    query = f"""
+        SELECT {_MESSAGE_COLUMNS}
+        FROM {CHAT_MESSAGE_TABLE} m
+        WHERE m.session_id = $1
+          AND COALESCE(m.sender_type, '') <> 'internal'
+          AND NOT (
+              m.idx = 0
+              AND EXISTS (
+                  SELECT 1 FROM {CHAT_SESSION_TABLE} cs
+                  WHERE cs.id = $1 AND cs.metadata ? 'human_assist_lineage'
+              )
+          )
+        ORDER BY m.idx ASC
+    """
+    return query, [session_id]
 
 
 # -- agent_session_state ------------------------------------------------------

--- a/app/database/queries/breeze_buddy/human_assist.py
+++ b/app/database/queries/breeze_buddy/human_assist.py
@@ -1,0 +1,936 @@
+"""Parameterized SQL builders for platform-agnostic Human Assist.
+
+Each Human Assist ticket is its ``chat_session``. Ticket lifecycle data is kept
+under ``chat_session.metadata.human_assist`` so the transcript and ticket share
+one durable identifier and no second persistence table is needed.
+"""
+
+import json
+from datetime import datetime
+from typing import Any, Dict, List, Optional, Tuple
+
+HUMAN_ASSIST_RECORD_KEY = "human_assist"
+
+
+def _visible_messages(alias: str = "m") -> str:
+    """Inbox-visible message predicate; internal rows never surface."""
+    return f"AND COALESCE({alias}.sender_type, '') <> 'internal'"
+
+
+_VISIBLE_MESSAGE_FILTER = _visible_messages()
+
+
+# Waiting tickets lead, ordered by how soon their claim deadline expires;
+# everything else falls back to most-recent activity.
+def _order_by(alias: str = "cs") -> str:
+    return f"""
+            CASE {alias}.human_assist_status
+                WHEN 'PENDING' THEN 0
+                WHEN 'OPEN' THEN 1
+                ELSE 2
+            END,
+            CASE
+                WHEN {alias}.human_assist_status = 'PENDING'
+                THEN {alias}.metadata #>> '{{human_assist,claim_deadline_at}}'
+            END ASC,
+            {alias}.last_activity_at DESC
+"""
+
+
+def _columns(alias: str = "cs") -> str:
+    record = f"{alias}.metadata->'{HUMAN_ASSIST_RECORD_KEY}'"
+    return f"""
+        {alias}.id AS id,
+        {alias}.id AS chat_session_id,
+        NULLIF({record}->>'widget_config_id', '')::uuid AS widget_config_id,
+        {alias}.reseller_id,
+        {alias}.merchant_id,
+        {record}->>'status' AS status,
+        NULLIF({record}->>'requested_at', '')::timestamptz AS requested_at,
+        NULLIF({record}->>'claim_deadline_at', '')::timestamptz
+            AS claim_deadline_at,
+        NULLIF({record}->>'opened_at', '')::timestamptz AS opened_at,
+        {record}->>'opened_by' AS opened_by,
+        NULLIF({record}->>'closed_at', '')::timestamptz AS closed_at,
+        {record}->>'closed_by' AS closed_by,
+        {record}->>'close_reason' AS close_reason,
+        {alias}.last_activity_at,
+        NULLIF({record}->>'customer_last_seen_at', '')::timestamptz
+            AS customer_last_seen_at,
+        COALESCE({record}->'metadata', '{{}}'::jsonb) AS metadata
+    """
+
+
+def _utc_timestamp(expression: str) -> str:
+    """Canonical sortable UTC timestamp stored in Human Assist JSONB."""
+    return (
+        f"to_char(({expression}) AT TIME ZONE 'UTC', "
+        '\'YYYY-MM-DD"T"HH24:MI:SS.US"Z"\')'
+    )
+
+
+def _scope_filters(
+    *,
+    reseller_id: Optional[str],
+    merchant_id: Optional[str],
+    reseller_ids: Optional[List[str]],
+    merchant_ids: Optional[List[str]],
+    start_idx: int,
+) -> Tuple[List[str], List[Any], int]:
+    """Reseller/merchant scope WHERE clauses shared by the Inbox list, count,
+    and scope-signature queries. An exact ``reseller_id``/``merchant_id``
+    takes precedence over the ``ANY(...)`` list form when both are given.
+    Returns ``(clauses, values, next_idx)`` so callers can keep binding
+    further placeholders (e.g. ``LIMIT``/``OFFSET``) after this scope.
+    """
+    clauses: List[str] = []
+    values: List[Any] = []
+    idx = start_idx
+    if reseller_id:
+        clauses.append(f"cs.reseller_id = ${idx}")
+        values.append(reseller_id)
+        idx += 1
+    elif reseller_ids is not None:
+        clauses.append(f"cs.reseller_id = ANY(${idx})")
+        values.append(reseller_ids)
+        idx += 1
+    if merchant_id:
+        clauses.append(f"cs.merchant_id = ${idx}")
+        values.append(merchant_id)
+        idx += 1
+    elif merchant_ids is not None:
+        clauses.append(f"cs.merchant_id = ANY(${idx})")
+        values.append(merchant_ids)
+        idx += 1
+    return clauses, values, idx
+
+
+def create_human_assist_conversation_query(
+    *,
+    chat_session_id: str,
+    claim_timeout_seconds: int,
+    metadata: Dict[str, Any],
+    notification_content: str,
+    notification_blocks: List[Dict[str, Any]],
+    sender_type: str,
+) -> Tuple[str, List[Any]]:
+    """Turn a first-handoff chat session into its own pending ticket."""
+    query = f"""
+        WITH created AS (
+            UPDATE chat_session cs
+            SET current_channel = 'HUMAN',
+                handoff_happened = TRUE,
+                last_activity_at = now(),
+                metadata = jsonb_set(
+                    cs.metadata,
+                    '{{{HUMAN_ASSIST_RECORD_KEY}}}',
+                    jsonb_build_object(
+                        'widget_config_id', wc.id::text,
+                        'status', 'PENDING',
+                        'requested_at', {_utc_timestamp("now()")},
+                        'claim_deadline_at',
+                            {_utc_timestamp(
+                                "now() + make_interval("
+                                "secs => $2::double precision)"
+                            )},
+                        'customer_last_seen_at', {_utc_timestamp("now()")},
+                        'metadata',
+                            $3::jsonb || jsonb_build_object(
+                                'platform', wc.human_assist_platform
+                            )
+                    ),
+                    TRUE
+                )
+            FROM widget_config wc
+            WHERE cs.id = $1::uuid
+              AND wc.id::text = NULLIF(
+                  cs.metadata #>> '{{widget,widget_config_id}}',
+                  ''
+              )
+              AND cs.status <> 'ENDED'
+              AND cs.current_channel = 'CHAT'
+              AND cs.handoff_happened = FALSE
+              AND cs.metadata->'{HUMAN_ASSIST_RECORD_KEY}' IS NULL
+              AND wc.active = TRUE
+              AND wc.human_assist_enabled = TRUE
+            RETURNING cs.*
+        ),
+        notification AS (
+            INSERT INTO chat_message (
+                session_id,
+                idx,
+                role,
+                content,
+                content_blocks,
+                sender_type
+            )
+            SELECT
+                created.id,
+                COALESCE(
+                    (
+                        SELECT MAX(message.idx) + 1
+                        FROM chat_message message
+                        WHERE message.session_id = created.id
+                    ),
+                    0
+                ),
+                'assistant',
+                $4,
+                $5::jsonb,
+                $6
+            FROM created
+            RETURNING session_id
+        )
+        SELECT {_columns("created")}
+        FROM created
+        JOIN notification ON notification.session_id = created.id
+    """
+    return (
+        query,
+        [
+            chat_session_id,
+            max(1, int(claim_timeout_seconds)),
+            json.dumps(metadata),
+            notification_content,
+            json.dumps(notification_blocks),
+            sender_type,
+        ],
+    )
+
+
+def rollover_human_assist_session_query(
+    *,
+    chat_session_id: str,
+    claim_timeout_seconds: int,
+    conversation_metadata: Dict[str, Any],
+    context_content: str,
+    context_blocks: List[Dict[str, Any]],
+    context_sender_type: str,
+    notification_content: str,
+    notification_blocks: List[Dict[str, Any]],
+    notification_sender_type: str,
+) -> Tuple[str, List[Any]]:
+    """Atomically roll a repeat handoff into a new session/ticket.
+
+    Generic agent state is copied so cart, checkout, and client-context data
+    survive. The previous session is ended only when the new session and its
+    continuity message were created successfully.
+    """
+    query = f"""
+        WITH source AS MATERIALIZED (
+            SELECT
+                cs.*,
+                wc.id AS widget_config_id,
+                wc.human_assist_platform
+            FROM chat_session cs
+            JOIN widget_config wc
+              ON wc.id::text = NULLIF(
+                  cs.metadata #>> '{{widget,widget_config_id}}',
+                  ''
+              )
+            WHERE cs.id = $1::uuid
+              AND cs.status <> 'ENDED'
+              AND cs.current_channel = 'CHAT'
+              AND cs.handoff_happened = TRUE
+              AND COALESCE(
+                  cs.metadata #>> '{{{HUMAN_ASSIST_RECORD_KEY},status}}',
+                  ''
+              ) NOT IN ('PENDING', 'OPEN')
+              AND wc.active = TRUE
+              AND wc.human_assist_enabled = TRUE
+            FOR UPDATE OF cs
+        ),
+        created_session AS (
+            INSERT INTO chat_session (
+                template_id,
+                reseller_id,
+                merchant_id,
+                metadata,
+                current_channel,
+                handoff_happened
+            )
+            SELECT
+                source.template_id,
+                source.reseller_id,
+                source.merchant_id,
+                (source.metadata - '{HUMAN_ASSIST_RECORD_KEY}')
+                    || jsonb_build_object(
+                        'human_assist_lineage',
+                        COALESCE(
+                            source.metadata->'human_assist_lineage',
+                            '{{}}'::jsonb
+                        ) || jsonb_build_object(
+                            'previous_session_id', source.id::text,
+                            'root_session_id', COALESCE(
+                                source.metadata #>>
+                                    '{{human_assist_lineage,root_session_id}}',
+                                source.id::text
+                            )
+                        ),
+                        '{HUMAN_ASSIST_RECORD_KEY}',
+                        jsonb_build_object(
+                            'widget_config_id',
+                                source.widget_config_id::text,
+                            'status', 'PENDING',
+                            'requested_at', {_utc_timestamp("now()")},
+                            'claim_deadline_at',
+                                {_utc_timestamp(
+                                    "now() + make_interval("
+                                    "secs => $2::double precision)"
+                                )},
+                            'customer_last_seen_at',
+                                {_utc_timestamp("now()")},
+                            'metadata',
+                                $3::jsonb || jsonb_build_object(
+                                    'platform',
+                                        source.human_assist_platform,
+                                    'previous_chat_session_id',
+                                        source.id::text
+                                )
+                        )
+                    ),
+                'HUMAN',
+                TRUE
+            FROM source
+            RETURNING *
+        ),
+        copied_state AS (
+            INSERT INTO agent_session_state (
+                chat_session_id,
+                data,
+                updated_at
+            )
+            SELECT created_session.id, state.data, now()
+            FROM created_session
+            JOIN source ON TRUE
+            JOIN agent_session_state state
+              ON state.chat_session_id = source.id
+            RETURNING chat_session_id
+        ),
+        context_message AS (
+            INSERT INTO chat_message (
+                session_id,
+                idx,
+                role,
+                content,
+                content_blocks,
+                sender_type
+            )
+            SELECT
+                created_session.id,
+                0,
+                'assistant',
+                $4,
+                $5::jsonb,
+                $6
+            FROM created_session
+            RETURNING session_id
+        ),
+        notification AS (
+            INSERT INTO chat_message (
+                session_id,
+                idx,
+                role,
+                content,
+                content_blocks,
+                sender_type
+            )
+            SELECT
+                created_session.id,
+                1,
+                'assistant',
+                $7,
+                $8::jsonb,
+                $9
+            FROM created_session
+            JOIN context_message
+              ON context_message.session_id = created_session.id
+            RETURNING session_id
+        ),
+        ended_source AS (
+            UPDATE chat_session previous
+            SET status = 'ENDED',
+                current_channel = 'ENDED',
+                ended_at = COALESCE(previous.ended_at, now()),
+                ended_reason = COALESCE(
+                    previous.ended_reason,
+                    'human_assist_rollover'
+                ),
+                last_activity_at = now(),
+                metadata = previous.metadata || jsonb_build_object(
+                    'human_assist_successor_session_id',
+                    created_session.id::text
+                )
+            FROM created_session
+            JOIN notification
+              ON notification.session_id = created_session.id
+            WHERE previous.id = $1::uuid
+              AND previous.status <> 'ENDED'
+              AND previous.current_channel = 'CHAT'
+            RETURNING previous.id
+        )
+        SELECT {_columns("created_session")}
+        FROM created_session
+        JOIN ended_source ON TRUE
+    """
+    return (
+        query,
+        [
+            chat_session_id,
+            max(1, int(claim_timeout_seconds)),
+            json.dumps(conversation_metadata),
+            context_content,
+            json.dumps(context_blocks),
+            context_sender_type,
+            notification_content,
+            json.dumps(notification_blocks),
+            notification_sender_type,
+        ],
+    )
+
+
+def merge_human_assist_metadata_query(
+    conversation_id: str,
+    metadata: Dict[str, Any],
+) -> Tuple[str, List[Any]]:
+    query = f"""
+        UPDATE chat_session cs
+        SET metadata = jsonb_set(
+                cs.metadata,
+                '{{{HUMAN_ASSIST_RECORD_KEY},metadata}}',
+                COALESCE(
+                    cs.metadata
+                        #> '{{{HUMAN_ASSIST_RECORD_KEY},metadata}}',
+                    '{{}}'::jsonb
+                ) || $2::jsonb,
+                TRUE
+            ),
+            last_activity_at = now()
+        WHERE cs.id = $1::uuid
+          AND cs.metadata ? '{HUMAN_ASSIST_RECORD_KEY}'
+        RETURNING {_columns("cs")}
+    """
+    return query, [conversation_id, json.dumps(metadata)]
+
+
+def get_human_assist_conversation_query(
+    conversation_id: str,
+    *,
+    include_stats: bool = False,
+) -> Tuple[str, List[Any]]:
+    stats = (
+        f"""
+               (SELECT COUNT(*) FROM chat_message m
+                WHERE m.session_id = cs.id
+                {_VISIBLE_MESSAGE_FILTER}) AS message_count,
+               (SELECT m.content FROM chat_message m
+                WHERE m.session_id = cs.id
+                  AND m.content IS NOT NULL
+                {_VISIBLE_MESSAGE_FILTER}
+                ORDER BY m.idx DESC LIMIT 1) AS preview
+        """
+        if include_stats
+        else "0::bigint AS message_count, NULL::text AS preview"
+    )
+    query = f"""
+        SELECT {_columns("cs")},
+               {stats}
+        FROM chat_session cs
+        WHERE cs.id = $1::uuid
+          AND cs.metadata ? '{HUMAN_ASSIST_RECORD_KEY}'
+    """
+    return query, [conversation_id]
+
+
+def get_active_human_assist_for_session_query(
+    chat_session_id: str,
+) -> Tuple[str, List[Any]]:
+    query = f"""
+        SELECT {_columns("cs")}
+        FROM chat_session cs
+        WHERE cs.id = $1::uuid
+          AND cs.metadata #>> '{{{HUMAN_ASSIST_RECORD_KEY},status}}'
+              IN ('PENDING', 'OPEN')
+    """
+    return query, [chat_session_id]
+
+
+def list_human_assist_conversations_query(
+    *,
+    statuses: Optional[List[str]],
+    reseller_id: Optional[str],
+    merchant_id: Optional[str],
+    reseller_ids: Optional[List[str]],
+    merchant_ids: Optional[List[str]],
+    search: Optional[str],
+    limit: int,
+    offset: int,
+) -> Tuple[str, List[Any]]:
+    """One round trip: the page, its total, and every status tally.
+
+    ``scoped`` is evaluated once and reused for the per-status tab counts
+    and for the filtered page, so the Inbox never issues a query per tab.
+    The message-count/preview lateral runs only over the ``limit`` rows
+    that are actually returned, not over everything the scope matches.
+    """
+    scope_where: List[str] = [f"cs.metadata ? '{HUMAN_ASSIST_RECORD_KEY}'"]
+    # $1 statuses, $2 search — always bound so the SQL shape stays stable.
+    values: List[Any] = [statuses, search or None]
+    scope_clauses, scope_values, idx = _scope_filters(
+        reseller_id=reseller_id,
+        merchant_id=merchant_id,
+        reseller_ids=reseller_ids,
+        merchant_ids=merchant_ids,
+        start_idx=3,
+    )
+    scope_where.extend(scope_clauses)
+    values.extend(scope_values)
+
+    scope_where_sql = f"WHERE {' AND '.join(scope_where)}"
+    query = f"""
+        WITH scoped AS MATERIALIZED (
+            SELECT cs.id,
+                   cs.reseller_id,
+                   cs.merchant_id,
+                   cs.last_activity_at,
+                   cs.metadata,
+                   cs.metadata #>> '{{{HUMAN_ASSIST_RECORD_KEY},status}}'
+                       AS human_assist_status
+            FROM chat_session cs
+            {scope_where_sql}
+        ),
+        tallies AS (
+            SELECT
+                COUNT(*) FILTER (
+                    WHERE human_assist_status = 'PENDING'
+                ) AS pending_total,
+                COUNT(*) FILTER (
+                    WHERE human_assist_status = 'OPEN'
+                ) AS open_total,
+                COUNT(*) FILTER (
+                    WHERE human_assist_status = 'CLOSED'
+                ) AS closed_total,
+                COUNT(*) FILTER (
+                    WHERE human_assist_status = 'TIMED_OUT'
+                ) AS timed_out_total,
+                COUNT(*) FILTER (
+                    WHERE human_assist_status IN ('PENDING', 'OPEN')
+                ) AS active_total
+            FROM scoped
+        ),
+        filtered AS (
+            SELECT cs.*
+            FROM scoped cs
+            WHERE ($1::text[] IS NULL OR cs.human_assist_status = ANY($1::text[]))
+              AND (
+                  $2::text IS NULL
+                  OR cs.id::text ILIKE '%' || $2::text || '%'
+              )
+        ),
+        page AS (
+            SELECT cs.*
+            FROM filtered cs
+            ORDER BY {_order_by("cs")}
+            LIMIT ${idx} OFFSET ${idx + 1}
+        )
+        SELECT {_columns("page")},
+               stats.message_count,
+               stats.preview,
+               (SELECT COUNT(*) FROM filtered) AS total,
+               tallies.pending_total,
+               tallies.open_total,
+               tallies.closed_total,
+               tallies.timed_out_total,
+               tallies.active_total
+        FROM tallies
+        LEFT JOIN page ON TRUE
+        LEFT JOIN LATERAL (
+            SELECT COUNT(*) AS message_count,
+                   (
+                       SELECT m2.content
+                       FROM chat_message m2
+                       WHERE m2.session_id = page.id
+                         AND m2.content IS NOT NULL
+                       {_visible_messages("m2")}
+                       ORDER BY m2.idx DESC
+                       LIMIT 1
+                   ) AS preview
+            FROM chat_message m
+            WHERE m.session_id = page.id
+            {_VISIBLE_MESSAGE_FILTER}
+        ) stats ON TRUE
+        ORDER BY {_order_by("page")}
+    """
+    values.extend([limit, offset])
+    return query, values
+
+
+def list_human_assist_transcript_query(
+    session_id: str,
+    after_idx: Optional[int] = None,
+    limit: Optional[int] = None,
+) -> Tuple[str, List[Any]]:
+    """Inbox-visible transcript, optionally only the tail after ``after_idx``.
+
+    Unlike the widget delivery log this keeps the rollover continuity row —
+    the Inbox renders it as the "previous chat summary" card. ``limit`` caps
+    the number of rows returned (still ordered ascending by idx); ``None``
+    preserves the existing unbounded read.
+    """
+    query = """
+        SELECT session_id, idx, role, content, created_at,
+               content_blocks, ui_blocks, sender_type
+        FROM chat_message m
+        WHERE m.session_id = $1::uuid
+          AND ($2::int IS NULL OR m.idx > $2::int)
+          AND COALESCE(m.sender_type, '') <> 'internal'
+        ORDER BY m.idx ASC
+        LIMIT $3::int
+    """
+    return query, [session_id, after_idx, limit]
+
+
+def get_human_assist_scope_signature_query(
+    *,
+    reseller_id: Optional[str],
+    merchant_id: Optional[str],
+    reseller_ids: Optional[List[str]],
+    merchant_ids: Optional[List[str]],
+) -> Tuple[str, List[Any]]:
+    """Cheap revision for repairing a missed Inbox pub/sub wake-up."""
+    where: List[str] = [f"cs.metadata ? '{HUMAN_ASSIST_RECORD_KEY}'"]
+    scope_clauses, values, _idx = _scope_filters(
+        reseller_id=reseller_id,
+        merchant_id=merchant_id,
+        reseller_ids=reseller_ids,
+        merchant_ids=merchant_ids,
+        start_idx=1,
+    )
+    where.extend(scope_clauses)
+    query = f"""
+        SELECT COUNT(*)::bigint AS ticket_count,
+               MAX(cs.last_activity_at) AS latest_activity_at
+        FROM chat_session cs
+        WHERE {' AND '.join(where)}
+    """
+    return query, values
+
+
+def claim_human_assist_conversation_query(
+    conversation_id: str,
+    opened_by: str,
+    notification_content: str,
+    notification_blocks: List[Dict[str, Any]],
+    sender_type: str,
+) -> Tuple[str, List[Any]]:
+    record = f"cs.metadata->'{HUMAN_ASSIST_RECORD_KEY}'"
+    query = f"""
+        WITH claimed AS (
+            UPDATE chat_session cs
+            SET metadata = jsonb_set(
+                    cs.metadata,
+                    '{{{HUMAN_ASSIST_RECORD_KEY}}}',
+                    {record} || jsonb_build_object(
+                        'status', 'OPEN',
+                        'opened_at', COALESCE(
+                            NULLIF({record}->>'opened_at', '')::timestamptz,
+                            now()
+                        ),
+                        'opened_by', COALESCE(
+                            NULLIF({record}->>'opened_by', ''),
+                            $2::text
+                        )
+                    ),
+                    FALSE
+                ),
+                last_activity_at = now()
+            WHERE cs.id = $1::uuid
+              AND {record}->>'status' = 'PENDING'
+              AND {record}->>'claim_deadline_at' > {_utc_timestamp("now()")}
+            RETURNING cs.*
+        ),
+        notification AS (
+            INSERT INTO chat_message (
+                session_id,
+                idx,
+                role,
+                content,
+                content_blocks,
+                sender_type
+            )
+            SELECT
+                claimed.id,
+                COALESCE(
+                    (
+                        SELECT MAX(message.idx) + 1
+                        FROM chat_message message
+                        WHERE message.session_id = claimed.id
+                    ),
+                    0
+                ),
+                'assistant',
+                $3,
+                $4::jsonb,
+                $5
+            FROM claimed
+            RETURNING session_id
+        )
+        SELECT {_columns("claimed")}
+        FROM claimed
+        JOIN notification ON notification.session_id = claimed.id
+    """
+    return query, [
+        conversation_id,
+        opened_by,
+        notification_content,
+        json.dumps(notification_blocks),
+        sender_type,
+    ]
+
+
+def touch_human_assist_customer_query(
+    chat_session_id: str,
+    *,
+    mark_activity: bool,
+) -> Tuple[str, List[Any]]:
+    record = f"cs.metadata->'{HUMAN_ASSIST_RECORD_KEY}'"
+    query = f"""
+        UPDATE chat_session cs
+        SET metadata = jsonb_set(
+                cs.metadata,
+                '{{{HUMAN_ASSIST_RECORD_KEY}}}',
+                {record} || jsonb_build_object(
+                    'customer_last_seen_at', {_utc_timestamp("now()")}
+                ),
+                FALSE
+            ),
+            last_activity_at = CASE
+                WHEN $2::boolean THEN now()
+                ELSE cs.last_activity_at
+            END
+        WHERE cs.id = $1::uuid
+          AND {record}->>'status' IN ('PENDING', 'OPEN')
+        RETURNING {_columns("cs")}
+    """
+    return query, [chat_session_id, mark_activity]
+
+
+def insert_human_assist_platform_message_query(
+    *,
+    session_id: str,
+    role: str,
+    content: str,
+    content_blocks: List[Dict[str, Any]],
+    sender_type: Optional[str],
+) -> Tuple[str, List[Any]]:
+    """Insert one provider-normalized message.
+
+    No dedup key exists yet (the only shipped adapter, native, never
+    supplies an external id) — add one via a migration when a real
+    webhook-based adapter needs it. A genuine ``(session_id, idx)``
+    primary-key race (concurrent inserts computing the same next
+    ``idx``) still raises; callers retry with a fresh ``idx``.
+    """
+    query = """
+        INSERT INTO chat_message (
+            session_id,
+            idx,
+            role,
+            content,
+            content_blocks,
+            sender_type
+        )
+        VALUES (
+            $1::uuid,
+            COALESCE(
+                (
+                    SELECT MAX(message.idx) + 1
+                    FROM chat_message message
+                    WHERE message.session_id = $1::uuid
+                ),
+                0
+            ),
+            $2,
+            $3,
+            $4::jsonb,
+            $5
+        )
+        RETURNING session_id, idx, role, content, created_at,
+                  content_blocks, NULL::jsonb AS ui_blocks, sender_type
+    """
+    return query, [
+        session_id,
+        role,
+        content,
+        json.dumps(content_blocks),
+        sender_type,
+    ]
+
+
+def touch_human_assist_activity_query(
+    conversation_id: str,
+    opened_by: Optional[str] = None,
+) -> Tuple[str, List[Any]]:
+    record = f"cs.metadata->'{HUMAN_ASSIST_RECORD_KEY}'"
+    owner_clause = f"AND {record}->>'opened_by' = $2" if opened_by is not None else ""
+    values: List[Any] = [conversation_id]
+    if opened_by is not None:
+        values.append(opened_by)
+    query = f"""
+        UPDATE chat_session cs
+        SET last_activity_at = now()
+        WHERE cs.id = $1::uuid
+          AND {record}->>'status' = 'OPEN'
+          {owner_clause}
+        RETURNING {_columns("cs")}
+    """
+    return query, values
+
+
+def close_human_assist_conversation_query(
+    conversation_id: str,
+    *,
+    terminal_status: str,
+    close_reason: str,
+    closed_by: Optional[str],
+    allowed_statuses: List[str],
+    notification_content: Optional[str],
+    notification_blocks: Optional[List[Dict[str, Any]]],
+    notification_sender_type: Optional[str],
+    end_session: bool,
+) -> Tuple[str, List[Any]]:
+    record = f"cs.metadata->'{HUMAN_ASSIST_RECORD_KEY}'"
+    query = f"""
+        WITH closed AS (
+            UPDATE chat_session cs
+            SET metadata = jsonb_set(
+                    cs.metadata,
+                    '{{{HUMAN_ASSIST_RECORD_KEY}}}',
+                    {record} || jsonb_build_object(
+                        'status', $2::text,
+                        'closed_at', COALESCE(
+                            NULLIF({record}->>'closed_at', '')::timestamptz,
+                            now()
+                        ),
+                        'closed_by', COALESCE(
+                            NULLIF({record}->>'closed_by', ''),
+                            $3::text
+                        ),
+                        'close_reason', COALESCE(
+                            NULLIF({record}->>'close_reason', ''),
+                            $4::text
+                        )
+                    ),
+                    FALSE
+                ),
+                status = CASE
+                    WHEN $9::boolean THEN 'ENDED'
+                    ELSE cs.status
+                END,
+                current_channel = CASE
+                    WHEN $9::boolean OR cs.status = 'ENDED' THEN 'ENDED'
+                    ELSE 'CHAT'
+                END,
+                ended_at = CASE
+                    WHEN $9::boolean THEN COALESCE(cs.ended_at, now())
+                    ELSE cs.ended_at
+                END,
+                ended_reason = CASE
+                    WHEN $9::boolean THEN COALESCE(cs.ended_reason, 'user_ended')
+                    ELSE cs.ended_reason
+                END,
+                last_activity_at = now()
+            WHERE cs.id = $1::uuid
+              AND {record}->>'status' = ANY($5::text[])
+            RETURNING cs.*
+        ),
+        notification AS (
+            INSERT INTO chat_message (
+                session_id,
+                idx,
+                role,
+                content,
+                content_blocks,
+                sender_type
+            )
+            SELECT
+                closed.id,
+                COALESCE(
+                    (
+                        SELECT MAX(message.idx) + 1
+                        FROM chat_message message
+                        WHERE message.session_id = closed.id
+                    ),
+                    0
+                ),
+                'assistant',
+                $6,
+                $7::jsonb,
+                $8
+            FROM closed
+            WHERE $6::text IS NOT NULL
+            RETURNING session_id
+        )
+        SELECT {_columns("closed")}
+        FROM closed
+    """
+    return query, [
+        conversation_id,
+        terminal_status,
+        closed_by,
+        close_reason,
+        allowed_statuses,
+        notification_content,
+        json.dumps(notification_blocks) if notification_blocks is not None else None,
+        notification_sender_type,
+        end_session,
+    ]
+
+
+def list_due_human_assist_query(
+    *,
+    claim_deadline_before: Optional[datetime] = None,
+    customer_seen_before: Optional[datetime] = None,
+    limit: int = 100,
+    exclude_ids: Optional[List[str]] = None,
+) -> Tuple[str, List[Any]]:
+    status = f"cs.metadata #>> '{{{HUMAN_ASSIST_RECORD_KEY},status}}'"
+    claim_deadline = (
+        f"cs.metadata #>> '{{{HUMAN_ASSIST_RECORD_KEY},claim_deadline_at}}'"
+    )
+    customer_last_seen = (
+        f"cs.metadata #>> '{{{HUMAN_ASSIST_RECORD_KEY},customer_last_seen_at}}'"
+    )
+    exclusion = "AND NOT (cs.id = ANY($2::uuid[]))" if exclude_ids else ""
+    limit_placeholder = "$3" if exclude_ids else "$2"
+    values: List[Any]
+    if claim_deadline_before is not None:
+        query = f"""
+            SELECT {_columns("cs")}
+            FROM chat_session cs
+            WHERE {status} = 'PENDING'
+              AND {claim_deadline} <= {_utc_timestamp("$1::timestamptz")}
+              {exclusion}
+            ORDER BY {claim_deadline} ASC
+            LIMIT {limit_placeholder}
+        """
+        values = [claim_deadline_before]
+        if exclude_ids:
+            values.append(exclude_ids)
+        values.append(limit)
+        return query, values
+
+    query = f"""
+        SELECT {_columns("cs")}
+        FROM chat_session cs
+        WHERE {status} IN ('PENDING', 'OPEN')
+          AND {customer_last_seen} <= {_utc_timestamp("$1::timestamptz")}
+          {exclusion}
+        ORDER BY {customer_last_seen} ASC
+        LIMIT {limit_placeholder}
+    """
+    values = [customer_seen_before]
+    if exclude_ids:
+        values.append(exclude_ids)
+    values.append(limit)
+    return query, values

--- a/app/database/queries/breeze_buddy/widget_config.py
+++ b/app/database/queries/breeze_buddy/widget_config.py
@@ -13,7 +13,8 @@ WIDGET_CONFIG_TABLE = "widget_config"
 _COLUMNS = (
     "id, reseller_id, merchant_id, public_widget_key, template_id, "
     "allowed_origins, max_sessions_per_ip_hour, max_messages_per_ip_hour, "
-    "max_concurrent_per_ip, max_voice_sessions_per_ip_hour, active, "
+    "max_concurrent_per_ip, max_voice_sessions_per_ip_hour, "
+    "human_assist_enabled, human_assist_platform, active, "
     "created_at, updated_at"
 )
 
@@ -30,15 +31,19 @@ def create_widget_config_query(
     max_concurrent_per_ip: int,
     max_voice_sessions_per_ip_hour: int,
     active: bool,
+    human_assist_enabled: bool = False,
+    human_assist_platform: str = "native",
 ) -> Tuple[str, List[Any]]:
     query = f"""
         INSERT INTO {WIDGET_CONFIG_TABLE} (
             reseller_id, merchant_id, public_widget_key, template_id,
             allowed_origins, max_sessions_per_ip_hour, max_messages_per_ip_hour,
             max_concurrent_per_ip, max_voice_sessions_per_ip_hour,
+            human_assist_enabled, human_assist_platform,
             active, created_at, updated_at
         ) VALUES (
-            $1, $2, $3, $4::uuid, $5, $6, $7, $8, $9, $10, $11, $12
+            $1, $2, $3, $4::uuid, $5, $6, $7, $8, $9, $10, $11, $12,
+            $13, $14
         )
         RETURNING {_COLUMNS}
     """
@@ -53,6 +58,8 @@ def create_widget_config_query(
         int(max_messages_per_ip_hour),
         int(max_concurrent_per_ip),
         int(max_voice_sessions_per_ip_hour),
+        bool(human_assist_enabled),
+        human_assist_platform,
         bool(active),
         now,
         now,
@@ -156,6 +163,8 @@ def update_widget_config_query(
     max_messages_per_ip_hour: Optional[int] = None,
     max_concurrent_per_ip: Optional[int] = None,
     max_voice_sessions_per_ip_hour: Optional[int] = None,
+    human_assist_enabled: Optional[bool] = None,
+    human_assist_platform: Optional[str] = None,
     active: Optional[bool] = None,
 ) -> Tuple[str, List[Any]]:
     """Returns ("", []) if no fields were provided — callers should treat
@@ -192,6 +201,16 @@ def update_widget_config_query(
     if max_voice_sessions_per_ip_hour is not None:
         set_clauses.append(f"max_voice_sessions_per_ip_hour = ${idx}")
         params.append(int(max_voice_sessions_per_ip_hour))
+        idx += 1
+
+    if human_assist_enabled is not None:
+        set_clauses.append(f"human_assist_enabled = ${idx}")
+        params.append(bool(human_assist_enabled))
+        idx += 1
+
+    if human_assist_platform is not None:
+        set_clauses.append(f"human_assist_platform = ${idx}")
+        params.append(human_assist_platform)
         idx += 1
 
     if active is not None:

--- a/app/schemas/breeze_buddy/chat.py
+++ b/app/schemas/breeze_buddy/chat.py
@@ -34,6 +34,7 @@ class ChatEndedReason(str, Enum):
 
     USER_ENDED = "user_ended"
     IDLE_TIMEOUT = "idle_timeout"
+    HUMAN_ASSIST_ROLLOVER = "human_assist_rollover"
 
 
 class WidgetChannel(str, Enum):
@@ -45,6 +46,7 @@ class WidgetChannel(str, Enum):
 
     CHAT = "CHAT"
     VOICE = "VOICE"
+    HUMAN = "HUMAN"
     ENDED = "ENDED"
 
 
@@ -119,6 +121,7 @@ class ChatSession(BaseModel):
     metadata: Dict[str, Any] = Field(default_factory=dict)
     current_channel: WidgetChannel = WidgetChannel.CHAT
     voice_lead_id: Optional[str] = None
+    handoff_happened: bool = False
     created_at: Optional[datetime] = None
     last_activity_at: Optional[datetime] = None
     ended_at: Optional[datetime] = None
@@ -141,6 +144,11 @@ class ChatMessage(BaseModel):
     — the LLM never sees prior ui_ops, by design. ``None`` on user
     turns, on assistant turns that emitted no UI, and on rows written
     before migration 030.
+
+    ``sender_type`` (migration 044) is Human Assist attribution —
+    customer, buddy, human, system, or internal — layered on top of
+    ``role`` (which stays a strict user/assistant LLM turn shape).
+    ``None`` for ordinary, non-Live-Assist chat messages.
     """
 
     session_id: str
@@ -149,6 +157,7 @@ class ChatMessage(BaseModel):
     content: Optional[str] = None
     content_blocks: Optional[List[Dict[str, Any]]] = None
     ui_blocks: Optional[List[Dict[str, Any]]] = None
+    sender_type: Optional[str] = None
     created_at: Optional[datetime] = None
 
 
@@ -391,6 +400,13 @@ class ChatTranscriptResponse(BaseModel):
     template_id: str
     status: ChatSessionStatus
     messages: List[ChatMessage]
+    evaluation_messages: List[Dict[str, Any]] = Field(
+        default_factory=list,
+        description=(
+            "Customer and Buddy prose supplied to AI evaluators. Human-agent, "
+            "system, internal, and explicitly excluded rows are omitted."
+        ),
+    )
     turn_metrics: List[ChatTurnMetrics] = Field(
         default_factory=list,
         description="Per-turn latency/UI metrics (migration 032), one per "
@@ -785,6 +801,16 @@ class WidgetVoiceEndResponse(BaseModel):
     lead_id: Optional[str] = None
 
 
+class WidgetSessionRollover(BaseModel):
+    """Authenticated recovery credentials for a durable successor session."""
+
+    session_id: str
+    previous_session_id: str
+    current_channel: WidgetChannel
+    widget_token: str
+    ttl_seconds: int
+
+
 class WidgetSessionStateResponse(BaseModel):
     """Body of ``GET /widget/session/{id}``.
 
@@ -873,6 +899,14 @@ class WidgetSessionStateResponse(BaseModel):
             "Empty when nothing is awaiting a decision."
         ),
     )
+    session_rollover: Optional[WidgetSessionRollover] = Field(
+        None,
+        description=(
+            "Successor-session credentials when this session ended during a "
+            "repeat Human Assist handoff. Lets the widget recover if the "
+            "original SSE rollover frame was lost."
+        ),
+    )
 
 
 class WidgetTranscribeResponse(BaseModel):
@@ -922,6 +956,7 @@ __all__ = [
     "UpdateWidgetContextResponse",
     "WidgetVoiceConnectResponse",
     "WidgetVoiceEndResponse",
+    "WidgetSessionRollover",
     "WidgetSessionStateResponse",
     "WidgetTranscribeResponse",
 ]

--- a/app/schemas/breeze_buddy/human_assist.py
+++ b/app/schemas/breeze_buddy/human_assist.py
@@ -1,0 +1,109 @@
+"""Platform-agnostic Human Assist ticket and inbox API models."""
+
+from datetime import datetime
+from enum import Enum
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, Field
+
+from app.schemas.breeze_buddy.chat import ChatMessage, WidgetChannel
+
+
+class HumanAssistStatus(str, Enum):
+    PENDING = "PENDING"
+    OPEN = "OPEN"
+    CLOSED = "CLOSED"
+    TIMED_OUT = "TIMED_OUT"
+
+
+class HumanAssistCloseReason(str, Enum):
+    MERCHANT_CLOSED = "merchant_closed"
+    CLAIM_TIMEOUT = "claim_timeout"
+    CUSTOMER_DISCONNECTED = "customer_disconnected"
+    SESSION_ENDED = "session_ended"
+    PLATFORM_CLOSED = "platform_closed"
+    PLATFORM_ERROR = "platform_error"
+
+
+class HumanAssistConversation(BaseModel):
+    id: str
+    chat_session_id: str
+    widget_config_id: str
+    reseller_id: str
+    merchant_id: Optional[str] = None
+    platform: str = "native"
+    status: HumanAssistStatus
+    requested_at: datetime
+    claim_deadline_at: datetime
+    opened_at: Optional[datetime] = None
+    opened_by: Optional[str] = None
+    closed_at: Optional[datetime] = None
+    closed_by: Optional[str] = None
+    close_reason: Optional[HumanAssistCloseReason] = None
+    last_activity_at: datetime
+    customer_last_seen_at: datetime
+    metadata: Dict[str, Any] = Field(default_factory=dict)
+    message_count: int = 0
+    preview: Optional[str] = None
+
+
+class HumanAssistStatusCounts(BaseModel):
+    """Scope-wide tallies powering the Inbox tabs without a query per tab."""
+
+    pending: int = 0
+    open: int = 0
+    closed: int = 0
+    timed_out: int = 0
+    active: int = 0
+
+
+class HumanAssistConversationList(BaseModel):
+    conversations: List[HumanAssistConversation]
+    total: int
+    active_total: int
+    counts: HumanAssistStatusCounts = Field(default_factory=HumanAssistStatusCounts)
+    page: int
+    limit: int
+
+
+class HumanAssistConversationDetail(BaseModel):
+    conversation: HumanAssistConversation
+    messages: List[ChatMessage]
+    #: Set when the caller passed ``after_idx``; messages hold only the tail.
+    incremental: bool = False
+
+
+class HumanAssistHumanMessageRequest(BaseModel):
+    content: str = Field(..., min_length=1, max_length=20_000)
+
+
+class HumanAssistWidgetUpdates(BaseModel):
+    conversation_id: Optional[str] = None
+    status: Optional[HumanAssistStatus] = None
+    platform: Optional[str] = None
+    current_channel: WidgetChannel
+    messages: List[ChatMessage] = Field(default_factory=list)
+
+
+class HumanAssistPlatformInfo(BaseModel):
+    key: str
+    display_name: str
+    description: str
+
+
+class HumanAssistPlatformList(BaseModel):
+    platforms: List[HumanAssistPlatformInfo]
+
+
+__all__ = [
+    "HumanAssistCloseReason",
+    "HumanAssistConversation",
+    "HumanAssistConversationDetail",
+    "HumanAssistConversationList",
+    "HumanAssistHumanMessageRequest",
+    "HumanAssistPlatformInfo",
+    "HumanAssistPlatformList",
+    "HumanAssistStatus",
+    "HumanAssistStatusCounts",
+    "HumanAssistWidgetUpdates",
+]

--- a/app/schemas/breeze_buddy/widget_config.py
+++ b/app/schemas/breeze_buddy/widget_config.py
@@ -35,6 +35,12 @@ class WidgetConfigCreate(BaseModel):
     max_messages_per_ip_hour: int = Field(600, ge=0)
     max_concurrent_per_ip: int = Field(4, ge=0)
     max_voice_sessions_per_ip_hour: int = Field(10, ge=0)
+    human_assist_enabled: bool = False
+    human_assist_platform: str = Field(
+        "native",
+        pattern=r"^[a-z][a-z0-9_]{0,63}$",
+        description="Registered platform adapter used for new handoffs.",
+    )
     active: bool = Field(True, description="Inactive rows behave like 404.")
 
 
@@ -51,6 +57,10 @@ class WidgetConfigUpdate(BaseModel):
     max_messages_per_ip_hour: Optional[int] = Field(None, ge=0)
     max_concurrent_per_ip: Optional[int] = Field(None, ge=0)
     max_voice_sessions_per_ip_hour: Optional[int] = Field(None, ge=0)
+    human_assist_enabled: Optional[bool] = None
+    human_assist_platform: Optional[str] = Field(
+        None, pattern=r"^[a-z][a-z0-9_]{0,63}$"
+    )
     active: Optional[bool] = None
 
 
@@ -67,6 +77,8 @@ class WidgetConfigResponse(BaseModel):
     max_messages_per_ip_hour: int = 600
     max_concurrent_per_ip: int = 4
     max_voice_sessions_per_ip_hour: int = 10
+    human_assist_enabled: bool = False
+    human_assist_platform: str = "native"
     active: bool = True
     created_at: Optional[datetime] = None
     updated_at: Optional[datetime] = None

--- a/docs/HUMAN_ASSIST_PLATFORM_ORCHESTRATOR.md
+++ b/docs/HUMAN_ASSIST_PLATFORM_ORCHESTRATOR.md
@@ -1,0 +1,255 @@
+# Human Assist Platform Orchestrator
+
+## Goal
+
+Human Assist has one durable lifecycle and many possible delivery platforms.
+Native Loom Inbox is the first adapter. Telegram, Slack, Re:amaze, or another
+provider can be added without duplicating ticket state, timeout handling,
+message storage, ownership, or Buddy-resume behavior.
+
+The integration boundary has exactly three asynchronous operations:
+
+1. `handoff` — open the provider-side conversation with the Buddy/customer
+   transcript.
+2. `conversation` — carry a customer, merchant, or provider message in either
+   direction.
+3. `end_conversation` — close from the customer, merchant, provider, timeout,
+   session, or system side.
+
+## Runtime shape
+
+```text
+Buddy handoff / customer message / merchant action / provider callback
+                              |
+                              v
+                  HumanAssistOrchestrator
+        state, ownership, transcript, timeout, close rules
+                              |
+                              v
+                     platform registry
+                              |
+             +----------------+----------------+
+             |                                 |
+             v                                 v
+       Native Inbox                    Future adapter
+    three operations only             three operations only
+```
+
+`HumanAssistOrchestrator` is the only lifecycle owner. It resolves the platform
+snapshotted on the ticket and invokes the corresponding adapter. An adapter
+does provider I/O and normalizes provider messages; it does not write canonical
+ticket state or chat rows.
+
+## Responsibilities
+
+| Concern | Owner |
+| --- | --- |
+| Ticket creation, state transitions, deadlines, and agent ownership | Orchestrator + PostgreSQL |
+| Canonical customer, Buddy, and human transcript | Existing `chat_message` storage |
+| Per-session mutation serialization | Orchestrator + Redis lock |
+| Provider API calls and provider payload normalization | Selected adapter |
+| Platform credentials and webhook authentication | Provider integration |
+| Human-message exclusion from Buddy evaluation | Shared Human Assist filtering |
+| Returning the completed human conversation to Buddy context | Existing transcript |
+
+PostgreSQL remains authoritative. Redis is coordination only and is never the
+sole copy of ownership, deadlines, messages, or terminal state.
+
+## Platform selection
+
+The merchant-facing Inbox reads `GET /human-assist/platforms`. The response is
+generated from the adapter registry, so Inbox does not contain a hardcoded
+platform list.
+
+A platform button updates `widget_config.human_assist_platform`. The choice is:
+
+- scoped to the selected merchant's active widget configurations;
+- applied only to new handoffs; and
+- snapshotted in
+  `chat_session.metadata.human_assist.metadata.platform`.
+
+An active conversation therefore continues on its original platform even when
+the merchant changes the destination for later tickets.
+
+## Adding a platform
+
+Create one adapter module, set its registry metadata, and implement the three
+operations:
+
+```python
+class ExampleHumanAssistPlatform(HumanAssistPlatform):
+    spec = HumanAssistPlatformSpec(
+        key="example",
+        display_name="Example",
+        description="Route new handoffs to Example.",
+    )
+
+    async def handoff(self, context, event):
+        # Create the provider conversation and pass event.transcript if needed.
+        return PlatformOperationResult(conversation_ref="provider-ticket-id")
+
+    async def conversation(self, context, event):
+        # Deliver outbound events or normalize event.raw_payload inbound.
+        return PlatformOperationResult(messages=(...))
+
+    async def end_conversation(self, context, event):
+        # Resolve provider state for any event.initiator.
+        return PlatformOperationResult(provider_state={"resolved": True})
+```
+
+Register one instance in `app/services/human_assist/platforms/__init__.py`.
+Its key then becomes available through the platform API and automatically
+appears as an Inbox button. Platform keys are validated by shape instead of a
+database enum, so registering an adapter requires no schema migration.
+
+Provider callback handlers should authenticate the provider request, resolve
+the internal conversation, and pass the raw event to
+`relay_platform_human_assist_event` or `end_platform_human_assist`. The selected
+adapter's `conversation` or `end_conversation` operation performs the
+provider-specific interpretation.
+
+## Lifecycle details
+
+### Handoff
+
+The orchestrator filters out human-agent rows, creates the authoritative
+pending ticket, and calls the selected adapter with the Buddy/customer
+history. Provider references and state are merged into the ticket's existing
+metadata JSONB. A provider failure closes the ticket as `platform_error` and
+returns control to Buddy.
+
+The first Human Assist request uses the customer's current `chat_session`. If
+that session has already had a handoff, the next request atomically:
+
+1. asks Buddy's configured LLM for a compact continuity summary;
+2. creates a new `chat_session` with the same template, tenant, widget
+   metadata, and copied `agent_session_state`;
+3. stores the continuity summary as an internal-context Buddy message;
+4. ends the previous session with `human_assist_rollover`; and
+5. makes the new session its own pending Human Assist ticket.
+
+The `chat_session` UUID is also the Human Assist ticket ID. This context is not
+a handoff reason or a second ticket record. Buddy replay and the merchant
+Inbox read it from the canonical `chat_message` transcript, and future
+adapters receive it in the handoff event's transcript. It is hidden from the
+customer transcript and excluded from Buddy evaluation. A dedicated
+`session_rollover` SSE event
+carries the replacement `session_id` and a new session-bound widget token so
+the embed can switch to the new chat without using credentials from the ended
+session. `human_assist_status` remains a public lifecycle-only event.
+The limited Buddy history query pins this internal continuity row, so a long
+human exchange cannot push it out of the replay window before Buddy resumes.
+
+### Conversation
+
+All directions use the same operation:
+
+- `customer` sends storefront text toward the provider;
+- `merchant` sends a claimed Inbox response toward the customer/provider; and
+- `platform` normalizes an authenticated provider event into canonical
+  customer or human messages.
+
+The orchestrator persists the normalized output tagged with `sender_type`
+(a typed `chat_message` column: customer, buddy, human, system, or
+internal). Human rows remain visible in the transcript but are excluded
+when Buddy performance is evaluated. The platform itself is not re-tagged
+per message — it is already snapshotted once on the ticket
+(`chat_session.metadata.human_assist.metadata.platform`).
+
+### End conversation
+
+The same operation receives an explicit initiator:
+
+- `customer` for storefront disconnect;
+- `merchant` for the Inbox close button;
+- `platform` for provider-side close;
+- `timeout` when nobody claims the ticket;
+- `session` when the underlying session ends; or
+- `system` for orchestration/provider failure.
+
+The orchestrator attempts provider cleanup and then closes the authoritative
+ticket, restoring Buddy or ending the session according to the close reason.
+A provider cleanup failure is recorded in the ticket metadata but does not
+trap the merchant in an uncloseable ticket. Because the human exchange is in
+the existing chat transcript, Buddy has that context after merchant close
+without a transcript copy.
+
+For native storefront presence, the open SSE stream refreshes
+`customer_last_seen_at`. If the stream disappears, the lifecycle sweep closes
+the ticket after `HUMAN_ASSIST_CUSTOMER_DISCONNECT_TIMEOUT_SECONDS`. This grace
+period avoids falsely closing a ticket during a page refresh or same-site
+navigation; no browser polling or immediate `pagehide` close is used.
+`HUMAN_ASSIST_LIFECYCLE_LOOP_INTERVAL_SECONDS` controls sweep resolution, and
+the shared scheduler wakes at the tighter of that value and its general
+background-task cadence. See [Configuration](#configuration) below for where
+each of these values lives and how live-tunable it actually is.
+
+## Configuration
+
+| Name | Location | Default | Live-tunable? |
+| --- | --- | --- | --- |
+| `HUMAN_ASSIST_CLAIM_TIMEOUT_SECONDS` | `app/core/config/dynamic.py` | 300s (5 min) | Yes — read once per ticket, at creation/rollover time |
+| `HUMAN_ASSIST_CUSTOMER_DISCONNECT_TIMEOUT_SECONDS` | `app/core/config/dynamic.py` | 45s | Yes — read on every lifecycle sweep tick |
+| `HUMAN_ASSIST_PLATFORM_OPERATION_TIMEOUT_SECONDS` | `app/core/config/dynamic.py` | 30s | Yes — read on every adapter call |
+| `HUMAN_ASSIST_LIFECYCLE_LOOP_INTERVAL_SECONDS` | `app/core/config/dynamic.py` | 5s | No in practice — `BackgroundTaskScheduler.register_task` binds `interval_seconds` once at startup and never re-reads it, so a change only takes effect after the next pod restart |
+
+All four are DevCycle/Redis-backed `dynamic.py` accessors (`get_config(...)`),
+which lets them share the same override mechanism as every other runtime
+knob even though the last one is not actually live-tunable. Its own docstring
+carries that caveat so the inconsistency is documented at the source, not
+just here.
+
+## All db schema's to be created or used
+
+| Classification | Schema object | Purpose |
+| --- | --- | --- |
+| Created by migration 044 | `idx_chat_session_human_assist_inbox` | Scoped Inbox status/activity reads |
+| Created by migration 044 | `idx_chat_session_human_assist_claim_deadline` | Ordered pending-ticket timeout sweeps |
+| Created by migration 044 | `idx_chat_session_human_assist_customer_seen` | Ordered disconnected-customer sweeps |
+| Altered by migration 044 | `chat_message.sender_type` varchar | Buddy/customer/human/system/internal attribution; `NULL` for ordinary chat |
+| Created by migration 044 | `chat_message_sender_type_check` constraint | Validates `sender_type` against the five known values |
+| Altered by migration 044 | `chat_session.handoff_happened` boolean | Durable record that a handoff occurred |
+| Altered by migration 044 | `chat_session.metadata.human_assist` JSONB record constraints | Durable status, ownership, deadlines, platform snapshot, provider state, and close details |
+| Created by migration 044 | `chat_session_human_assist_record_check` and `chat_session_handoff_record_check` constraints | Validate lifecycle shape and require a durable record when handoff history is set |
+| Altered by migration 044 | `chat_session.current_channel` constraint | Adds the `HUMAN` routing state |
+| Altered by migration 044 | `widget_config.human_assist_enabled` boolean | Merchant enable/disable setting |
+| Altered by migration 044 | `widget_config.human_assist_platform` varchar | Open-ended adapter key for new handoffs |
+| Altered by migration 044 | `chat_session.ended_reason` constraint | Adds `human_assist_rollover` for repeat-handoff session replacement |
+| Reused | `chat_session` and `chat_message` | Canonical session and complete transcript |
+| Reused | `agent_session_state` | Copies generic cart, checkout, and client-context state into the successor session |
+| Not created | Separate Human Assist ticket table | Avoided; one `chat_session` is one ticket and uses the same UUID |
+| Not created | Per-platform ticket/message tables | Avoided; adapters share the authoritative lifecycle and transcript |
+| Not created | Platform enum or platform registry table | Avoided; the code registry allows new adapters without schema changes |
+| Not created | `platform_message_id` dedup key | No shipped adapter supplies an external id yet (native never does); add via a migration when a real webhook-based adapter needs it |
+
+### Migration locking
+
+Migration 044's five `CHECK` constraints use plain `ADD CONSTRAINT`, matching
+every other constraint migration in this codebase — none of them use the
+`NOT VALID` / `VALIDATE CONSTRAINT` split. That split only lightens the lock
+(`SHARE UPDATE EXCLUSIVE` instead of `ACCESS EXCLUSIVE` for the pre-existing-row
+scan) when the `ADD CONSTRAINT ... NOT VALID` and its later
+`VALIDATE CONSTRAINT` run in separate transactions. The migration runner
+(`scripts/migrate.py`) wraps an entire migration file in one
+`conn.transaction()` regardless of the file's own `BEGIN`/`COMMIT`, so the
+split would provide no real benefit here — `chat_session`, `chat_message`,
+and `widget_config` are under `ACCESS EXCLUSIVE` for this migration's entire
+runtime either way. `CREATE INDEX CONCURRENTLY` is not used for the same
+reason: Postgres refuses to run it inside any transaction block, and this
+runner never runs migration statements outside one.
+
+## Defensive decoding
+
+`decode_human_assist_conversation` treats a persisted row it cannot safely
+represent as absent rather than raising: a null `widget_config_id`, an
+unrecognized `status` or `close_reason`, or a missing `requested_at` /
+`claim_deadline_at` / `customer_last_seen_at` / `last_activity_at` all
+short-circuit to `None`.
+Every caller (`list_human_assist_conversations`,
+`get_human_assist_conversation`, `list_due_human_assist_claims`,
+`list_stale_human_assist_customers`, ...) already filters `None` decode
+results, so one malformed row is silently skipped instead of failing the
+whole Inbox list, transcript fetch, or sweep. The `chat_session_human_assist_record_check`
+constraint above is the primary integrity guarantee; this is defense in
+depth for rows written before the constraint existed or by a path that
+bypassed it.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added native Human Assist support for customer handoffs, conversations, agent claiming, messaging, and closure.
  * Added configurable Human Assist platform settings for widgets.
  * Added conversation status, ownership, handoff, sender attribution, transcript, and rollover details.
  * Added support for continuing conversations across session rollovers while preserving context.
  * Added configurable timeout and lifecycle settings for claims, customer disconnects, and platform operations.

* **Documentation**
  * Added guidance for Human Assist lifecycle management, platform selection, messaging, and session handoffs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->