### PR TITLE
(feat): add 0 downtime support during pod restarts

### DIFF
--- a/app/ai/voice/tts/dragontts.py
+++ b/app/ai/voice/tts/dragontts.py
@@ -55,7 +55,18 @@ __all__ = [
 
 
 # Params DragonTTS folds into the cache key and applies per nested provider.
-_PARAM_FIELDS = ("speed", "volume", "emotion", "pitch", "style_prompt")
+# enable_ssml_parsing MUST be here: without it, the cached/dragontts path drops
+# the flag and ElevenLabs parses <break/> as plain text (SSML only "worked" on the
+# direct ElevenLabs path, which forwards it separately). It selects a distinct
+# warm SSML socket + cache key inside DragonTTS.
+_PARAM_FIELDS = (
+    "speed",
+    "volume",
+    "emotion",
+    "pitch",
+    "style_prompt",
+    "enable_ssml_parsing",
+)
 
 
 def _collect_params(resolved: "TTSConfig") -> dict:

--- a/docs/dragonTTS.md
+++ b/docs/dragonTTS.md
@@ -1,0 +1,319 @@
+# DragonTTS — Technical Architecture
+
+> Cached text-to-speech proxy. Serves repeated synthesis from a local cache to
+> cut latency and cost; falls back to a live provider on a miss and tees the
+> result back into the cache. Multi-provider (Cartesia / ElevenLabs / Sarvam /
+> Gemini), FastAPI, SQLite + filesystem blobs on a persistent volume.
+>
+> **Path convention:** code paths are relative to the DragonTTS app root
+> (`clairvoyance/dragontts/`) — so `app/main.py` = `clairvoyance/dragontts/app/main.py`.
+> `endpoints.md`, `dragontts-scaling-and-isolation.md`, and `deploy/k8s/deployment.yaml`
+> live in the **standalone dragonTTS repo**. This doc is the *how it works inside* reference.
+
+---
+
+## 1. At a glance
+
+| | |
+|---|---|
+| **Role** | TTS caching proxy in front of Cartesia / ElevenLabs / Sarvam / Gemini |
+| **Stack** | FastAPI + uvicorn (4 workers, uvloop), SQLite (metadata) + filesystem (audio blobs) |
+| **Storage** | SQLite DB + sharded blob dir on a **RWO PVC** (single pod, zonal disk) |
+| **Cache policy (prod)** | **write-through ON** |
+| **Native audio** | `pcm_s16le` @ 16 kHz for every provider (μ-law 8 kHz produced on serve) |
+| **Primary caller** | Clairvoyance (`enable_tts_caching` templates) |
+| **Deploy** | GKE, dedicated `dragontts-pool` (e2-standard-4), 100 Gi PVC, single replica |
+
+> **Single pod, zero user-facing downtime** — on restart, clairvoyance falls back
+> to its upstream TTS while DragonTTS drains and recycles (§6). **One 100 Gi PVC**
+> holds the whole cache; no DB server or object store to operate (§3). **Cache
+> HIT ≈ ~1 ms**; a MISS pays only the provider synth time (warm sockets keep
+> time-to-first-byte ~100–300 ms) — see §2.
+
+Two read paths, both cache-backed:
+- **`POST /tts/bytes`** — one-shot: returns the full clip (HIT serves cached bytes; MISS synthesizes, stores via write-through, returns).
+- **`POST /tts/stream`** — low-TTFB streaming: MISS streams provider chunks live **and** tees them into the cache; HIT streams the cached blob.
+
+---
+
+## 2. Request flow
+
+```
+                ┌──────────── /tts/bytes (one-shot) ────────────┐
+caller ───────► │  derive key → cache lookup                     │
+                │    HIT  → serve cached bytes (convert-on-serve)│ ─────► caller
+                │    MISS → synth (provider) → write-through     │
+                │          → store blob+row → serve              │
+                └────────────────────────────────────────────────┘
+
+                ┌──────────── /tts/stream (low TTFB) ────────────┐
+caller ───────► │  derive key → cache lookup                     │
+                │    HIT  → stream cached blob                   │ ─────► caller
+                │    MISS → stream provider chunks live (tee)    │
+                │          → accumulate → store blob+row on done  │
+                └────────────────────────────────────────────────┘
+```
+
+- **Single-flight:** an in-process `_inflight` future map de-dupes identical MISSes — concurrent identical requests share one synth, not N.
+- **Resilience:** per-provider bulkhead (concurrency cap + optional rate limit); provider HTTP/network failures map to **502/503, never 500**.
+
+### Latency profile
+The cache exists to make the common case (a repeat phrase) effectively instant,
+and to keep even a MISS cheap:
+
+| Path | Latency | Why |
+|---|---|---|
+| **HIT** (`/tts/bytes` or `/tts/stream`) | **~1 ms** | A blob read (served from the OS page cache when hot) + on-serve format conversion. No synth, no provider network call. |
+| **MISS → first audio byte** (TTFB, `/tts/stream`) | **~100–300 ms** | The provider **socket is already warm** (pre-connected pool), so there's no TLS/handshake per request — only the provider's own time to start generating. |
+| **MISS → full clip** | **~0.4–1.5 s** | Just the provider's synth time for the phrase (varies by provider + length); the result is teed into the cache as it streams, so the *next* request for it is a ~1 ms HIT. |
+
+So a MISS adds only the **synthesis** time, not connection setup — the warm pools
+are what keep TTFB low — and every MISS converts the phrase into an ~1 ms HIT
+for all future calls (same or later conversations).
+
+---
+
+## 3. Storage layer (SQLite + filesystem on RWO PVC)
+
+### Two stores, one volume
+- **`SQLiteMetadataStore`** (`data/dragontts.db`) — cache keys → blob paths, hit counts, TTLs, request/latency analytics rollups.
+- **`FilesystemBlobStore`** (`data/blobs`, content-addressed + sharded `ab/cd/<key>`) — the audio bytes.
+
+Both live on the same **RWO (ReadWriteOnce) PVC** — a zonal GKE persistent disk that mounts to exactly one node/pod.
+
+### Why this storage: SQLite + filesystem on an RWO PVC
+A single-pod cache service wants the **simplest durable store** — an embedded DB
++ a filesystem on a persistent disk.
+
+**Why a PVC (persistent volume):**
+- **Survives restarts** — the cache persists across pod restarts and deploys, so a warm cache comes back instead of cold-starting (and re-paying for synth) on every rollout.
+- **Cheap + fast** — a zonal persistent disk is inexpensive *block* storage with the IOPS/latency SQLite wants; no network hop, no separate service to run.
+- **One volume, two stores** — the SQLite DB and the blob dir share one mount; nothing else to provision, operate, or bill.
+
+**Why SQLite + filesystem:**
+- **Embedded** — no DB server process to run, tune, or pay for; the metadata store is just a file on the volume, transactional and fast for this read-heavy cache workload.
+- **Hot reads via the OS page cache** — frequently-served blobs come straight from kernel memory, which is why a HIT is ~1 ms (no app-level cache needed).
+- **Atomic writes** — the blob store writes each blob via **temp file + `fsync` + `os.replace`** (atomic rename), so a reader never sees a half-written blob, and the blob is durable before the metadata row that references it commits.
+
+> **Single disk, single zone:** the PVC attaches to one node in one zone (the
+> disk's zone is load-bearing — see `dragontts-scaling-and-isolation.md`). A
+> **cache doesn't need HA** — its *caller* (clairvoyance) tolerates a DragonTTS
+> restart via upstream fallback (§6), so the single-pod / single-disk choice
+> costs no user-facing downtime.
+
+### Native format + convert-on-serve
+Every provider synthesizes to **`pcm_s16le` @ 16 kHz** (ElevenLabs `output_format=pcm_16000`; Gemini emits 24 kHz and is resampled 24k→16k). The cache key is **format-agnostic**, so one native entry serves every requested format: a telephony caller asking for μ-law 8 kHz gets the 16 kHz PCM entry converted on serve (`app/audio/format.py`). This keeps the cache small and format-neutral.
+
+---
+
+## 4. Caching
+
+### Write-through (ON in prod)
+Every MISS synthesizes, stores (blob + row), then returns. There is **no frequency gate** — every unique phrase is cached on first miss. Combined with length-scaled TTL, the cache self-bounds by time.
+
+### Cache key
+Derived (in `app/cache/key.py`) from: `provider:model`, `voice_id`, `language`, `output_format`, **canonical params**, and normalized text. `canonical_params` is a sorted-JSON of the non-default tuning params, so different speeds / SSML-on-vs-off / pitches get **distinct keys** (no collision, no stale wrong-rate audio).
+
+### Length-scaled TTL
+Every stored entry gets a TTL that scales with phrase length — longer phrases
+cost more to re-synthesize, so they're preserved longer; short ones age out
+faster. There is no "permanent" tier.
+
+```
+ttl(words) = clamp(BASE + PER_WORD × words, BASE, MAX)
+
+BASE     = 172800s   (48h floor — min TTL for any phrase)
+PER_WORD = 21600s    (+6h per word)
+MAX      = 518400s   (6d cap)
+```
+
+Worked examples: 1 word → 54h · 5 words → 78h · 10 words → 108h · 16+ words → 144h (6d, capped).
+
+Env knobs (`CACHE_TTL_*`):
+- `CACHE_TTL_BASE_SECONDS` (48h) — floor / minimum TTL.
+- `CACHE_TTL_PER_WORD_SECONDS` (6h) — added per word.
+- `CACHE_TTL_MAX_SECONDS` (6d) — hard cap.
+- `TTL_PURGE_INTERVAL_SECONDS` (20 min) — cadence of the purge sweep.
+- Set `CACHE_TTL_BASE_SECONDS ≤ 0` to **disable TTL entirely** (entries never expire; no purge runs).
+
+A background purge loop deletes expired **rows + their blob files** every
+`TTL_PURGE_INTERVAL_SECONDS` (default 20 min). Pre-existing rows with no TTL
+(created before this feature, under the legacy flat `TTL_SECONDS=0` knob — now
+superseded and unused) are handled by `POST /cache/backfill-ttl`: a one-shot,
+idempotent op that assigns each NULL-TTL row a randomized 48–72h expiry so they
+age out gradually (randomized, not flat, to avoid a synchronized re-synth spike).
+
+> Note: `MAX_CACHE_BYTES` (default `0` = unlimited) exists in config but is
+> **not enforced** by any eviction loop today — cache growth is bounded by TTL,
+> not by size.
+
+---
+
+## 5. Providers & warm pools
+
+| Provider | Transport (synth / stream) | Native | Default model | Tuning params |
+|---|---|---|---|---|
+| **Cartesia** | HTTP `/tts/bytes` / **WS pool** (context multiplex) | pcm 16k | `sonic-3.5` | `speed`, `volume`, `emotion` |
+| **ElevenLabs** | HTTP `/v1/text-to-speech/{voice}` / **multi-context WS pool** | pcm 16k (`pcm_16000`) | `eleven_flash_v2_5` | `speed`, `enable_ssml_parsing` |
+| **Sarvam** | HTTP `/text-to-speech` / **WS pool** (LIFO, not multiplexed) | pcm 16k | `bulbul:v3` | `speed`(→pace), `pitch` |
+| **Gemini** | gRPC `streaming_synthesize` (24k→16k resample) | pcm 16k | `gemini-3.1-flash-tts-preview` | `style_prompt` |
+
+### Warm socket pools (low TTFB on stream misses)
+Streaming misses reuse **persistent, pre-warmed sockets** instead of a fresh handshake each time:
+- **Cartesia** — one socket multiplexes many utterances by `context_id`.
+- **ElevenLabs** — multi-context WS, pooled **per `(voice_id, model_id, enable_ssml_parsing)`**; up to **5 concurrent contexts per socket** (server-enforced). `enable_ssml_parsing` is a **connect-time** socket setting (an SSML-on socket parses `<break/>` for *all* its utterances), so on/off can't share a socket.
+- **Sarvam** — WS, **not** multiplexed (one utterance per socket at a time); a LIFO stack of warm connections.
+- **Gemini** — process-cached gRPC channel; cancels the stream on early abandon so HTTP/2 concurrency isn't exhausted.
+
+Only the **default** voice/model is pre-warmed at startup; other voices warm lazily on their first streaming miss, then stay warm (auto-reconnect on drop). Pool sizes default to 2 each (`*_stream_pool_size`).
+
+### Param forwarding (clairvoyance → DragonTTS)
+Clairvoyance's `tts_configuration` carries the tuning knobs; its DragonTTS client (`_collect_params`) forwards the **6 param fields** into the request `params` dict: `speed, volume, emotion, pitch, style_prompt, enable_ssml_parsing`. DragonTTS applies the ones relevant to the nested provider and folds all of them into the cache key. (`language` is a top-level request field, not a param.)
+
+### SSML (ElevenLabs)
+`enable_ssml_parsing=true` makes ElevenLabs honor `<break time="Ns"/>` etc. as real pauses instead of reading the tags aloud. DragonTTS honors it on **both** paths:
+- **`/tts/stream`** — selects the SSML warm socket (connect-URI query param).
+- **`/tts/bytes`** — sends `enable_ssml_parsing: true` in the HTTP body, **and** routes the synth through the WS stream path (smoother render) before caching.
+SSML-on gets its own cache key (distinct from SSML-off/absent), so an SSML HIT never serves a plain-text render.
+
+---
+
+## 6. Graceful shutdown & kill switch
+
+Goal: when a pod is terminating, **(1) stop new traffic first, (2) let in-flight requests finish, (3) then die** — no cut streams, no requests routed to a dying pod.
+
+### The drain sequence
+```
+k8s preStop  ──►  GET /drain
+                   1. enable kill switch  (mark draining → /ready 503  +  POST clairvoyance bypass)
+                   2. send Slack alert    (🛑 kill switch activated, awaited ≤2s)
+k8s SIGTERM  ──►  uvicorn stops accepting; drains in-flight HTTP/stream
+                   (≤ --timeout-graceful-shutdown 100s in the Dockerfile — the OPERATIVE drain)
+                 lifespan shutdown (every worker):
+                   3. wait_for_inflight_drain  (backstop — normally instant, since uvicorn
+                      already drained; capped at GRACEFUL_DRAIN_MAX_SECONDS 120s)
+                   4. cleanup             (flush metrics, WAL checkpoint, close pools/DB)
+```
+
+**Two-layer drain timeout.** uvicorn's `--timeout-graceful-shutdown=100` (Dockerfile) is the budget that actually protects in-flight requests — it runs *first*, waiting up to **100s** for live HTTP/stream tasks to finish before lifespan shutdown is even called. `GRACEFUL_DRAIN_MAX_SECONDS=120` is a *backstop* in the lifespan phase: by then uvicorn has already drained the HTTP tasks the ASGI gauge tracks, so `wait_for_inflight_drain` normally returns immediately (inflight≈0); its 120s ceiling only binds for work uvicorn doesn't account for. So `terminationGracePeriodSeconds` must exceed **100s (uvicorn) + preStop (~8s) + lifespan cleanup (~2s) ≈ 110s** — **150 is comfortable headroom**. (The 120 backstop is intentionally ≥ uvicorn's 100 so the lifespan phase is never the binding constraint.)
+
+- **`/drain`** (`app/api/v1/health.py`) is the preStop hook. It is **idempotent** and gated by `ENABLE_GRACEFUL_DRAIN`.
+- **`/ready`** returns **503 while draining** (so k8s stops routing new traffic); **`/health` stays 200** (liveness — don't restart the pod mid-drain).
+- **Kill switch** (`app/drain.py` `notify_clairvoyance`): POSTs `{"action":"kill_switch"}` to clairvoyance's admin endpoint (`/agent/voice/breeze-buddy/admin/dragontts/manage`) with `Authorization: Bearer <JWT>`. **One-way** — DragonTTS only ever engages the bypass; **restore is a manual operator action** on clairvoyance (it does NOT auto-restore on startup).
+
+### Why the inflight gauge is a pure-ASGI middleware
+The in-flight counter **must** stay >0 for the entire lifetime of a streamed response. `@app.middleware("http")` (Starlette's `BaseHTTPMiddleware`) **can't** do this — its dispatch returns *after* the response object is built but *before* a `StreamingResponse` streams its body, so a `finally: decr()` fires mid-stream and the gauge hits 0 prematurely → shutdown proceeds → streams get cut.
+
+`InflightTrackingMiddleware` (`app/main.py`) is a **pure-ASGI** middleware that wraps `send` and decrements **only on the terminal ASGI message** (`http.response.body` with `more_body=false`) or `http.disconnect`, with a `done` guard + `finally` for exactly-once decrement. Verified: gauge = 1 during a stream, 0 only after.
+
+### Clairvoyance consumer-side kill switch (the real gate)
+Clairvoyance independently watches DragonTTS: a scheduler task probes `/health` (~60s); on failure it one-way marks a Redis flag `dragontts:health = "0"`, and `enable_tts_caching` templates then **bypass DragonTTS and use their upstream provider directly** (no user-facing silence). DragonTTS's `/drain` flip is the *instant* version of this (no 60s lag); the monitor is the backstop.
+
+### ✅ Zero-downtime despite a single-pod architecture
+DragonTTS runs as **one replica** — yet a pod restart causes **no user-facing
+TTS downtime**. The trick isn't HA at the DragonTTS layer; it's **graceful
+degradation at its caller** (clairvoyance):
+
+1. **Before the pod dies**, `/drain` flips the clairvoyance kill switch →
+   clairvoyance routes `enable_tts_caching` TTS to its **upstream provider
+   directly**, bypassing DragonTTS entirely.
+2. **In-flight** DragonTTS requests drain to completion (ASGI inflight gauge +
+   `wait_for_inflight_drain`), so no live stream is cut.
+3. **During the restart window**, clairvoyance keeps serving TTS from upstream —
+   callers still get audio (just uncached: marginally higher latency/cost, **no
+   silence, no errors**).
+4. **New pod up** → operator restores the flag → caching resumes.
+
+So the single-pod choice buys simplicity **without** trading away availability:
+the blast radius of a DragonTTS restart is a *temporary cache bypass*, never a
+TTS outage.
+
+### ⚠️ Wiring required in the Deployment (operational)
+The code is inert until the manifest wires it. `deploy/k8s/deployment.yaml` needs (applied via kubectl — creds are never baked into the image):
+```yaml
+terminationGracePeriodSeconds: 150       # > uvicorn --timeout-graceful-shutdown (100) + preStop ~8s + lifespan cleanup
+lifecycle:
+  preStop:
+    httpGet: {path: /drain, port: 8000}
+livenessProbe:  {httpGet: {path: /health, port: 8000}}
+readinessProbe: {httpGet: {path: /ready,  port: 8000}}
+env:
+  - {name: CLAIRVOYANCE_URL,       value: ...}   # kubectl-injected
+  - {name: CLAIRVOYANCE_JWT_TOKEN, value: ...}   # long-lived admin JWT (watch expiry!)
+```
+Until these are applied, `/drain`, `/ready`, and `graceful_drain` do nothing in prod.
+
+---
+
+## 7. Resilience
+
+- **Per-provider bulkhead** (`provider_max_concurrent_synths`, default 24): caps in-flight synth/stream calls per provider so a slow/hung provider can't starve the others. Over-budget calls wait up to `provider_bulkhead_wait_timeout_ms` (2500ms) then **503** (with `Retry-After`). Per-provider overrides via `PROVIDER_RESILIENCE` JSON env.
+- **Error mapping**: provider `HTTPStatusError`/`ProviderError` → **502**; connection errors → **503**. Never a bare 500.
+- **Stream fallback**: ElevenLabs WS stream falls back to one-shot HTTP synth only if nothing has streamed yet (can't safely fall back mid-stream).
+
+---
+
+## 8. Metrics & observability
+
+- **Write-behind metrics** (`metrics_write_behind_enabled`): HIT touch/metric updates are batched + flushed every 500ms / 64 items (and on graceful shutdown) so a HIT returns audio without awaiting a SQLite write.
+- **Latency sampling** (`metrics_latency_sample_rate`, default 0.3): a fraction of requests are timed (synth, total, cache-serve, TTFB) for the avg/p95 rollup; rows pruned after `metrics_latency_retention_days` (14).
+- **Endpoints**: `/stats` (cache economics + session), `/stats/daily` (day-wise), `/stats/latency` (per-provider/day avg-p95 + derived `miss_overhead_us`).
+- **Slack daily summary**: once/day at `slack_summary_time_utc` (16:30 UTC = 10 PM IST) — hit rate, words-from-cache %, est. cost saved (INR), PVC usage. Manual trigger: `POST /slack-summary`. Webhook absent ⇒ feature off.
+
+---
+
+## 9. Memory management
+
+- **`MALLOC_ARENA_MAX=4`** (Dockerfile): caps glibc malloc arenas so freed audio/resample buffers return to the OS instead of fragmenting across ~100 arenas (the RSS-creep cause on a 4-worker pod).
+- **Periodic `malloc_trim`** (`malloc_trim_interval_seconds`, default 300): each worker runs `gc.collect()` + `malloc_trim(0)` to hand freed heap back to the OS. No effect on audio quality or concurrency — it only releases already-freed memory. Skipped silently on non-glibc (musl).
+- **WAL checkpoint**: a loop checkpoints the SQLite `-wal` file every 5 min (and on shutdown) so it stays bounded while worker connections are held open.
+
+---
+
+## 10. Deployment / infra
+
+- **Cluster**: GKE `breeze-automatic-mum-01` (asia-south1), namespace `beta`, deployment `dragontts`, **single replica**.
+- **Node pool**: dedicated `dragontts-pool` (e2-standard-4, 4 vCPU/16 GB, CPU limit 3000m), isolated from clairvoyance/redis. **Zonal** — the PVC's zone is load-bearing (a new pool must land in the same zone or the disk won't attach). See `dragontts-scaling-and-isolation.md`.
+- **PVC**: 100 Gi RWO persistent disk → `data/` (SQLite db + blobs). Don't delete `data/` while the server runs; clear via `POST /cache/clear`.
+- **Image**: built/pushed by `.github/workflows/dragontts-docker-publish.yml` (context `dragontts/`, own `Dockerfile`/`pyproject`/`uv.lock`) to `asia-south1-docker.pkg.dev/breeze-automatic-prod/dragontts/dragontts`. Clairvoyance's `.dockerignore` excludes `dragontts/` so it never ships in the clairvoyance image.
+- **Secrets**: provider keys + `CLAIRVOYANCE_JWT_TOKEN` are **kubectl-injected in prod**, never in the image or `deployment.yaml`.
+
+### Run locally
+```bash
+cp .env.example .env        # fill provider keys
+uv sync
+uv run uvicorn app.main:app --reload    # http://127.0.0.1:8000
+```
+
+### Port-forward to prod (for curls — see `endpoints.md`)
+```bash
+kubectl -n beta port-forward deployment/dragontts 18000:8000
+```
+
+---
+
+## 11. Configuration reference (key envs)
+
+| Env | Default | Purpose |
+|---|---|---|
+| `ENABLE_WRITE_THROUGH` | `true` | store every MISS into the cache |
+| `CACHE_TTL_BASE_SECONDS` | `172800` | length-scaled TTL floor (48h) |
+| `CACHE_TTL_PER_WORD_SECONDS` | `21600` | +TTL per word |
+| `CACHE_TTL_MAX_SECONDS` | `518400` | TTL cap (6d) |
+| `TTL_PURGE_INTERVAL_SECONDS` | `1200` | expired-entry purge cadence |
+| `SPLIT_AT_SYMBOLS` / `_STREAM` | `""` | per-sentence split (OFF) |
+| `*_STREAM_POOL_SIZE` | `2` | warm socket pool size per provider |
+| `MALLOC_TRIM_ENABLED` / `_INTERVAL_SECONDS` | `true` / `300` | RSS-creep mitigation |
+| `ENABLE_GRACEFUL_DRAIN` | `true` | master switch for the drain flow |
+| `--timeout-graceful-shutdown` *(Dockerfile)* | `100` | **operative** in-flight HTTP/stream drain after SIGTERM (runs *before* lifespan) |
+| `GRACEFUL_DRAIN_MAX_SECONDS` | `120` | lifespan-phase drain *backstop* — normally instant (uvicorn already drained); ceiling only binds for work uvicorn doesn't track |
+| `CLAIRVOYANCE_URL` / `CLAIRVOYANCE_JWT_TOKEN` | `""` | kill-switch target + admin JWT (kubectl-injected) |
+| `CLAIRVOYANCE_KILL_SWITCH_TIMEOUT` | `5.0` | kill-switch POST timeout |
+| `SLACK_WEBHOOK_URL` | `""` | daily summary + kill-switch alerts (off if empty) |
+
+---
+
+## 12. Related docs
+- `endpoints.md` — full API + curl reference.
+- `dragontts-scaling-and-isolation.md` — dedicated node-pool + PVC migration runbook.
+- Clairvoyance side: the kill-switch consumer (`dragontts:health` flag) + admin endpoint live in `clairvoyance/app/ai/voice/agents/breeze_buddy/tts/dragontts/`.

--- a/dragontts/.env.example
+++ b/dragontts/.env.example
@@ -29,3 +29,16 @@ SPLIT_AT_SYMBOLS_STREAM=  # /tts/stream path; empty = OFF
 # Only split when EVERY resulting part has >= this many words (a lone single-word
 # part isn't worth caching alone, so the whole phrase stays one entry).
 SPLIT_MIN_WORDS_PER_PART=2
+
+# --- Graceful drain / clairvoyance kill switch ---
+# On shutdown (preStop -> GET /drain) dragontts tells clairvoyance to bypass it
+# (enable_tts_caching templates fall back to their upstream TTS), then drains
+# in-flight requests, then exits. Restore is MANUAL (operator POSTs action=
+# restore) — dragontts does NOT auto-restore on startup.
+# Clairvoyance admin auth is HTTPBearer + require_admin, so a clairvoyance admin
+# JWT goes here. Leave empty to disable the notify calls (clean dev default).
+# In prod these are kubectl-injected — NEVER baked into the image/deployment.yaml.
+# Use a long-lived service JWT: clairvoyance JWTs expire, and an expired token
+# makes the kill-switch call 401 (clairvoyance's ~60s health monitor is backstop).
+CLAIRVOYANCE_URL=
+CLAIRVOYANCE_JWT_TOKEN=

--- a/dragontts/Dockerfile
+++ b/dragontts/Dockerfile
@@ -26,4 +26,4 @@ USER appuser
 
 EXPOSE 8000
 
-CMD ["uv", "run", "uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000", "--workers", "4", "--loop", "uvloop", "--no-access-log", "--limit-concurrency", "1024"]
+CMD ["uv", "run", "uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000", "--workers", "4", "--loop", "uvloop", "--no-access-log", "--limit-concurrency", "1024", "--timeout-graceful-shutdown", "100"]

--- a/dragontts/app/api/v1/health.py
+++ b/dragontts/app/api/v1/health.py
@@ -1,8 +1,10 @@
-"""Health + introspection endpoints."""
+"""Health, readiness, and graceful-drain endpoints."""
 
 from __future__ import annotations
 
-from fastapi import APIRouter, Request
+from fastapi import APIRouter, HTTPException, Request
+
+from app.drain import engage_drain, is_draining
 
 router = APIRouter()
 
@@ -15,3 +17,22 @@ async def health(request: Request):
 @router.get("/providers")
 async def providers(request: Request):
     return {"providers": request.app.state.registry.configured()}
+
+
+@router.get("/ready")
+async def ready() -> dict:
+    """Readiness probe. 503 while draining so k8s stops routing NEW traffic to
+    this pod (complements endpoint removal on termination). Stays 200 on the
+    liveness probe (/health) so k8s doesn't restart the pod mid-drain."""
+    if is_draining():
+        raise HTTPException(status_code=503, detail="draining")
+    return {"status": "ready"}
+
+
+@router.get("/drain")
+async def drain() -> dict:
+    """k8s preStop hook. Marks the pod draining, fires the kill-switch Slack
+    alert, and tells clairvoyance to bypass us BEFORE SIGTERM arrives — then
+    the lifespan shutdown waits for in-flight requests to finish. See app.drain."""
+    await engage_drain()
+    return {"status": "draining"}

--- a/dragontts/app/core/config.py
+++ b/dragontts/app/core/config.py
@@ -25,13 +25,13 @@ PROVIDER_DEFAULTS: dict[str, dict] = {
         "voice_id": "shreya",
         "model": "bulbul:v3",
         "language": "en-IN",
-        "speed": 0.9,
+        "speed": 1.0,
         "pitch": 0.0,
     },
     "elevenlabs": {
         "voice_id": "fG9s0SXJb213f4UxVHyG",
         "model": "eleven_flash_v2_5",
-        "speed": 1.15,
+        "speed": 1.0,
         "language": "en",
         # SSML off by default. Listed here so canonical_params collapses an
         # explicit False with "absent" into ONE cache key (both = plain-text
@@ -239,6 +239,33 @@ class Settings(BaseSettings):
     # rounded to the nearest ₹ — no paisa). Rates above stay $/word; only the
     # shown figure is converted. Adjust if the FX rate drifts.
     slack_usd_to_inr: float = 96.0
+
+    # --- Graceful drain / clairvoyance kill switch ---
+    # On shutdown (k8s preStop -> GET /drain) dragontts FIRST tells clairvoyance
+    # to bypass it (so enable_tts_caching templates fall back to their upstream
+    # TTS provider), THEN drains its in-flight requests, THEN exits. Restore is
+    # MANUAL: an operator POSTs action=restore to clairvoyance's admin endpoint —
+    # dragontts does NOT auto-restore on startup. Clairvoyance's admin endpoint is
+    # HTTPBearer + require_admin, so a clairvoyance admin JWT must be supplied
+    # (env-injected in prod, never baked
+    # into the image). Empty CLAIRVOYANCE_URL => the notify calls are skipped
+    # (no-op), so the feature degrades cleanly when unconfigured.
+    clairvoyance_url: str = ""
+    clairvoyance_jwt_token: str = ""
+    clairvoyance_manage_path: str = "/agent/voice/breeze-buddy/admin/dragontts/manage"
+    # Short timeout so the /drain preStop hook returns fast (k8s waits on it
+    # before SIGTERM). Best-effort: clairvoyance's own ~60s health monitor is the
+    # backstop if this call fails.
+    clairvoyance_kill_switch_timeout: float = 5.0
+    enable_graceful_drain: bool = True
+    # Lifespan-phase BACKSTOP for in-flight drain. uvicorn's --timeout-graceful-
+    # shutdown (100s in the Dockerfile) runs FIRST and drains the in-flight HTTP/
+    # stream tasks the ASGI gauge tracks; by the time lifespan shutdown calls
+    # wait_for_inflight_drain, inflight is usually already ~0 and this returns
+    # instantly. The 120s ceiling only binds for in-flight work uvicorn doesn't
+    # account for. terminationGracePeriodSeconds must therefore exceed uvicorn's
+    # 100s + preStop (~8s) + lifespan cleanup (~2s) — ~110 minimum, 150 comfortable.
+    graceful_drain_max_seconds: int = 120
 
     @property
     def configured_providers(self) -> list[str]:

--- a/dragontts/app/drain.py
+++ b/dragontts/app/drain.py
@@ -1,0 +1,194 @@
+"""Graceful-drain coordinator: tell clairvoyance to bypass us, then drain.
+
+k8s termination sequence we participate in:
+
+1. preStop hook -> ``GET /drain`` (this runs ONCE, served by one worker). In
+   strict order we: (a) enable the kill switch — mark draining (readiness 503)
+   and POST clairvoyance's admin "kill_switch" so its ``enable_tts_caching``
+   templates bypass dragontts and use their upstream provider — THEN (b) send
+   the Slack alert. No new TTS traffic reaches us.
+2. SIGTERM -> uvicorn stops accepting, lifespan shutdown runs in EVERY worker.
+   Each worker waits for its own in-flight requests (the gauge below) to finish
+   up to ``settings.graceful_drain_max_seconds``, then the existing cleanup
+   (metrics flush, checkpoint, pool close) proceeds.
+3. Restore is MANUAL: an operator POSTs ``action=restore`` to clairvoyance's
+   admin endpoint. dragontts does NOT auto-restore on startup, so caching stays
+   bypassed (upstream TTS) until someone explicitly re-enables it.
+
+The drain flag + Slack + clairvoyance call are once-only by design, so it's fine
+that ``/drain`` is handled by a single worker. The in-flight gauge is per
+process (per worker), which is exactly the granularity each worker drains on
+SIGTERM — see app/main.py.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+
+import httpx
+
+from app.core.config import settings
+from app.core.logging import logger
+
+# --- drain flag (process-local) ---------------------------------------------
+# Read by GET /ready (503 while draining) so k8s pulls the pod out of the
+# Service endpoints. Best-effort across the 4 workers (only the one that served
+# /drain sets it); k8s removes a terminating pod from endpoints regardless, so
+# this is belt-and-suspenders, not the primary new-traffic gate.
+_is_draining: bool = False
+
+# --- in-flight gauge (process-local) ----------------------------------------
+# Inc'd by the HTTP middleware around every request, dec'd on completion. The
+# SIGTERM shutdown path waits for this to reach 0 (capped) so live /tts/stream
+# responses finish before pools/db close. Single event loop => plain int is safe
+# (inc/dec happen between awaits, atomically at the Python level).
+_inflight: int = 0
+
+
+def is_draining() -> bool:
+    return _is_draining
+
+
+def mark_draining() -> None:
+    global _is_draining
+    _is_draining = True
+
+
+def incr_inflight() -> None:
+    global _inflight
+    _inflight += 1
+
+
+def decr_inflight() -> None:
+    global _inflight
+    if _inflight > 0:
+        _inflight -= 1
+
+
+def inflight() -> int:
+    return _inflight
+
+
+async def notify_clairvoyance() -> bool:
+    """POST clairvoyance's dragontts manage endpoint to ENABLE the kill switch.
+
+    One-way: dragontts only ever engages the kill switch (bypass). Restore is a
+    manual operator action on clairvoyance's admin endpoint — never done here.
+    Best-effort: never raises. Returns True on a 2xx, False otherwise. A missing
+    ``clairvoyance_url``/token is a clean no-op (feature degrades off), so an
+    unconfigured or dev box never depends on clairvoyance being reachable.
+    """
+    if not settings.clairvoyance_url or not settings.clairvoyance_jwt_token:
+        logger.info("clairvoyance kill-switch skipped (CLAIRVOYANCE_URL/JWT not set)")
+        return False
+    url = settings.clairvoyance_url.rstrip("/") + settings.clairvoyance_manage_path
+    headers = {"Authorization": f"Bearer {settings.clairvoyance_jwt_token}"}
+    try:
+        async with httpx.AsyncClient(
+            timeout=settings.clairvoyance_kill_switch_timeout
+        ) as client:
+            resp = await client.post(
+                url, json={"action": "kill_switch"}, headers=headers
+            )
+        ok = resp.is_success
+        (logger.info if ok else logger.warning)(
+            f"clairvoyance kill-switch -> HTTP {resp.status_code} "
+            f"({'ok' if ok else resp.text[:160]})"
+        )
+        return ok
+    except Exception as e:  # noqa: BLE001 — best-effort; monitor is the backstop
+        logger.warning(f"clairvoyance kill-switch failed: {e}")
+        return False
+
+
+async def send_kill_switch_slack(*, clairvoyance_ok: bool, inflight_n: int) -> None:
+    """Fire the 🛑 kill-switch-activated Slack alert (best-effort, never raises)."""
+    try:
+        from app.alerts.slack import slack_alert  # lazy: avoid any import cycle
+
+        pod = os.environ.get("HOSTNAME", "unknown")
+        await slack_alert.send(
+            title="🛑 DragonTTS kill switch activated before pod shutdown",
+            fields=[
+                {
+                    "name": "Trigger",
+                    "value": (
+                        "Activated by DragonTTS itself on its preStop /drain hook "
+                        "— the pod is shutting down next"
+                    ),
+                },
+                {
+                    "name": "Clairvoyance bypass",
+                    "value": (
+                        "sent ✓"
+                        if clairvoyance_ok
+                        else "failed/skipped (monitor is backstop)"
+                    ),
+                },
+                {"name": "In-flight at trigger", "value": f"{inflight_n} request(s)"},
+                {"name": "Pod", "value": pod},
+            ],
+            fallback_text=(
+                f"DragonTTS kill switch activated by DragonTTS before pod "
+                f"shutdown on {pod} "
+                f"(clairvoyance bypass={'sent' if clairvoyance_ok else 'failed'}, "
+                f"{inflight_n} in-flight)"
+            ),
+        )
+    except Exception as e:  # noqa: BLE001 — never block drain on an alert
+        logger.warning(f"kill-switch Slack alert failed: {e}")
+
+
+async def engage_drain() -> bool:
+    """Run the /drain sequence, strictly ordered:
+
+    1. enable the kill switch — mark draining (readiness 503) + tell clairvoyance
+       to bypass us so no new TTS calls arrive,
+    2. send the Slack alert,
+    3. (SIGTERM, in lifespan shutdown) drain in-flight requests,
+    4. shutdown (pool/db cleanup).
+
+    The alert is AWAITED (bounded) so it's guaranteed sent before draining
+    begins, but a slow/down webhook can't stall preStop past the grace budget.
+    """
+    if not settings.enable_graceful_drain:
+        logger.info("/drain skipped (ENABLE_GRACEFUL_DRAIN=false)")
+        return False
+    if _is_draining:
+        logger.info("/drain already engaged — no-op")
+        return False
+    # 1) Kill switch FIRST.
+    mark_draining()
+    clairvoyance_ok = await notify_clairvoyance()
+    # 2) Alert (after the kill switch is enabled).
+    try:
+        await asyncio.wait_for(
+            send_kill_switch_slack(
+                clairvoyance_ok=clairvoyance_ok, inflight_n=inflight()
+            ),
+            timeout=2.0,
+        )
+    except asyncio.TimeoutError:
+        logger.warning("kill-switch Slack alert timed out — proceeding with drain")
+    return clairvoyance_ok
+
+
+async def wait_for_inflight_drain() -> None:
+    """On SIGTERM: wait for in-flight requests to finish, capped at the budget."""
+    if not settings.enable_graceful_drain:
+        return
+    budget = settings.graceful_drain_max_seconds
+    # Poll at a fine cadence so short requests finish quickly and we don't hold
+    # the full budget when there's nothing left to drain.
+    deadline = asyncio.get_running_loop().time() + budget
+    while _inflight > 0 and asyncio.get_running_loop().time() < deadline:
+        logger.info(f"shutdown drain: waiting on {_inflight} in-flight request(s)")
+        await asyncio.sleep(0.25)
+    if _inflight > 0:
+        logger.warning(
+            f"shutdown drain: {_inflight} request(s) still in-flight after "
+            f"{budget}s budget — proceeding with cleanup"
+        )
+    else:
+        logger.info("shutdown drain: all in-flight requests complete")

--- a/dragontts/app/main.py
+++ b/dragontts/app/main.py
@@ -14,11 +14,17 @@ import gc
 from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
 from app.api.v1 import cache as cache_api, health, tts
 from app.cache.service import CacheService
 from app.core.config import settings
 from app.core.logging import logger
+from app.drain import (
+    decr_inflight,
+    incr_inflight,
+    wait_for_inflight_drain,
+)
 from app.providers.registry import ProviderRegistry
 from app.storage.filesystem import FilesystemBlobStore
 from app.storage.sqlite import SQLiteMetadataStore
@@ -165,6 +171,10 @@ async def lifespan(app: FastAPI):
         await malloc_trim_task
     except (asyncio.CancelledError, Exception):
         pass
+    # Let in-flight requests (live /tts/stream) finish before we tear down the
+    # cache/pools — the preStop /drain already flipped clairvoyance off so no
+    # NEW traffic is arriving. Capped at graceful_drain_max_seconds.
+    await wait_for_inflight_drain()
     await cache.stop()  # flush write-behind metrics (graceful shutdown loses none)
     try:
         await metadata.checkpoint()  # compact the WAL before worker conns close
@@ -178,3 +188,62 @@ app = FastAPI(title="DragonTTS", version="0.1.0", lifespan=lifespan)
 app.include_router(tts.router)
 app.include_router(cache_api.router)
 app.include_router(health.router)
+
+
+class InflightTrackingMiddleware:
+    """Pure-ASGI per-process in-flight gauge for the SIGTERM graceful drain.
+
+    Increments on every HTTP request start and decrements ONLY when the response
+    is fully sent — i.e. on the terminal ASGI body message
+    (``http.response.body`` with ``more_body`` false) or on ``http.disconnect``.
+
+    This MUST be a pure-ASGI middleware, NOT ``@app.middleware("http")`` (which
+    compiles to ``BaseHTTPMiddleware``). BaseHTTPMiddleware's dispatch returns
+    to its caller immediately after ``call_next`` produces the Response object
+    but BEFORE ``await response(scope, receive, send)`` streams a
+    StreamingResponse's body. A ``finally: decr_inflight()`` in that dispatch
+    therefore fires while /tts/stream is still emitting chunks, hitting 0
+    prematurely and letting ``wait_for_inflight_drain()`` return mid-stream on
+    SIGTERM — closing the Cartesia/DB/sockets under live streams.
+
+    Decrementing on the terminal message keeps the gauge honest for the entire
+    streamed lifetime. The ``done`` guard + ``finally`` safety net guarantee
+    exactly-once decrement.
+    """
+
+    def __init__(self, app: ASGIApp) -> None:
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        incr_inflight()
+        done = False
+
+        async def send_wrapper(message: Message) -> None:
+            await send(message)
+            nonlocal done
+            if done:
+                return
+            mtype = message.get("type")
+            if mtype == "http.response.body" and not message.get("more_body", False):
+                done = True
+                decr_inflight()
+            elif mtype == "http.disconnect":
+                done = True
+                decr_inflight()
+
+        try:
+            await self.app(scope, receive, send_wrapper)
+        finally:
+            if not done:
+                # App returned/raised without a terminal body message — never
+                # double-decr.
+                decr_inflight()
+
+
+# add_middleware applies LIFO: the last-added middleware is outermost, so this
+# observes the terminal message actually sent to the client.
+app.add_middleware(InflightTrackingMiddleware)

--- a/dragontts/app/providers/elevenlabs.py
+++ b/dragontts/app/providers/elevenlabs.py
@@ -12,7 +12,7 @@ requested ``output_format`` (e.g. μ-law 8 kHz for telephony) before caching.
 
 Two paths:
 - :meth:`synth` — one-shot HTTP ``/v1/text-to-speech/{voice}`` (used by
-  ``/tts/bytes`` misses).
+  ``/tts/bytes`` misses, stitch, and the warmer).
 - :meth:`stream_synth` — the warm multi-context WebSocket pool
   (:mod:`app.providers.elevenlabs_pool`), low TTFB on ``/tts/stream`` misses.
   Falls back to one-shot HTTP if no warm socket is available.
@@ -73,11 +73,20 @@ class ElevenLabsProvider(BaseTTSProvider):
         self._pools: dict[tuple[str, str], elevenlabs_pool.ElevenLabsStreamPool] = {}
 
     def _voice_settings(self, params: dict) -> dict:
-        # Caller-supplied voice_settings win; otherwise mirror the one-shot defaults.
+        # Caller-supplied voice_settings win; otherwise mirror the one-shot
+        # defaults. speed is ALWAYS set (explicit, else the DragonTTS default) so
+        # an OMITTED speed and an EXPLICIT speed==default yield identical audio —
+        # canonical_params collapses the latter to "absent", so they must sound
+        # the same or one cache key would serve different-speed audio.
+        speed = (params or {}).get("speed")
+        if speed is None:
+            speed = PROVIDER_DEFAULTS.get("elevenlabs", {}).get("speed", 1.0)
         vs = (params or {}).get("voice_settings")
         if isinstance(vs, dict) and vs:
+            vs = dict(vs)
+            vs.setdefault("speed", speed)
             return vs
-        return {"stability": 0.5, "similarity_boost": 0.75}
+        return {"stability": 0.5, "similarity_boost": 0.75, "speed": speed}
 
     def _get_pool(
         self, voice_id: str, model_id: str, enable_ssml_parsing: bool = False


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added readiness and drain endpoints to support graceful service shutdowns.
  * Active requests now finish before the service shuts down, within a configurable limit.
  * Added optional shutdown notifications and kill-switch integration.
  * Added support for forwarding SSML parsing settings to nested voice providers.

* **Bug Fixes**
  * Voice speed settings are now preserved and applied correctly for ElevenLabs.
  * Expanded validation for Gemini configuration and function-call settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->