### PR TITLE
feat(wallet): add merchant wallet with credit ledger and admin recharge endpoint

### DIFF
--- a/app/api/routers/breeze_buddy/__init__.py
+++ b/app/api/routers/breeze_buddy/__init__.py
@@ -44,6 +44,7 @@ from app.api.routers.breeze_buddy.template_generator import (
 )
 from app.api.routers.breeze_buddy.templates import router as templates_router
 from app.api.routers.breeze_buddy.users import router as users_router
+from app.api.routers.breeze_buddy.wallet import router as wallet_router
 from app.api.routers.breeze_buddy.webhooks import router as webhooks_router
 from app.api.routers.breeze_buddy.websocket import router as websocket_router
 
@@ -100,6 +101,9 @@ router.include_router(blacklist_router, prefix="", tags=["blacklist"])
 
 # Merchants (merchant identifiers - admin only)
 router.include_router(merchants_router, prefix="", tags=["merchants"])
+
+# Wallet (merchant credit balance - admin only in this phase)
+router.include_router(wallet_router, prefix="", tags=["wallet"])
 
 # Reseller (umbrella) entity management
 router.include_router(resellers_router, prefix="", tags=["resellers"])

--- a/app/api/routers/breeze_buddy/wallet/__init__.py
+++ b/app/api/routers/breeze_buddy/wallet/__init__.py
@@ -1,0 +1,44 @@
+"""
+Wallet API endpoints.
+
+Admin-only endpoints for managing merchant wallet balances.
+"""
+
+from fastapi import APIRouter, Depends
+
+from app.api.security.breeze_buddy.rbac_token import get_current_user_with_rbac
+from app.schemas import UserInfo
+from app.schemas.breeze_buddy.wallets import (
+    WalletRechargeRequest,
+    WalletTransactionResponse,
+)
+
+from .handlers import recharge_wallet_handler
+
+router = APIRouter()
+
+
+@router.post("/wallet/{merchant_id}/recharge", response_model=WalletTransactionResponse)
+async def recharge_wallet(
+    merchant_id: str,
+    recharge_data: WalletRechargeRequest,
+    current_user: UserInfo = Depends(get_current_user_with_rbac),
+):
+    """
+    Add credits to a merchant's wallet.
+
+    **RBAC rules:**
+    - Admin only.
+
+    Args:
+        merchant_id: The merchant identifier whose wallet to recharge
+        recharge_data: Amount and currency of the recharge
+
+    Returns:
+        The created wallet_transactions ledger row
+
+    Raises:
+        HTTPException: 403 if not admin, 404 if merchant not found,
+            409 on duplicate ledger reference
+    """
+    return await recharge_wallet_handler(merchant_id, recharge_data, current_user)

--- a/app/api/routers/breeze_buddy/wallet/handlers.py
+++ b/app/api/routers/breeze_buddy/wallet/handlers.py
@@ -1,0 +1,69 @@
+"""
+Handlers for wallet endpoints.
+"""
+
+import asyncpg
+from fastapi import HTTPException
+
+from app.core.logger import logger
+from app.database.accessor.breeze_buddy import merchants as merchant_accessors
+from app.schemas import UserInfo, UserRole
+from app.schemas.breeze_buddy.wallets import (
+    WalletRechargeRequest,
+    WalletTransactionResponse,
+)
+from app.services.wallet import recharge
+from app.services.wallet.exceptions import (
+    InvalidRechargeAmountError,
+    UnsupportedCurrencyError,
+)
+
+
+def _check_recharge_access(current_user: UserInfo) -> None:
+    """Only admins can recharge a merchant's wallet in this phase."""
+    if current_user.role != UserRole.ADMIN:
+        raise HTTPException(
+            status_code=403, detail="Only admins can recharge a merchant's wallet"
+        )
+
+
+async def recharge_wallet_handler(
+    merchant_id: str,
+    recharge_data: WalletRechargeRequest,
+    current_user: UserInfo,
+) -> WalletTransactionResponse:
+    """Add credits to a merchant's wallet and record the ledger entry.
+
+    Admin-only. The resulting credits are computed by
+    services.wallet.recharge as amount * currency-map * wallet.conversion_rate.
+    """
+    _check_recharge_access(current_user)
+
+    merchant = await merchant_accessors.get_merchant_by_merchant_identifier(merchant_id)
+    if not merchant:
+        raise HTTPException(
+            status_code=404, detail=f"Merchant '{merchant_id}' not found"
+        )
+
+    try:
+        return await recharge(
+            merchant_id=merchant_id,
+            amount=recharge_data.amount,
+            currency=recharge_data.currency,
+            made_by=current_user.id,
+        )
+    except UnsupportedCurrencyError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    except InvalidRechargeAmountError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    except ValueError as e:
+        raise HTTPException(status_code=404, detail=str(e))
+    except asyncpg.UniqueViolationError:
+        raise HTTPException(
+            status_code=409, detail="Duplicate wallet transaction reference"
+        )
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error recharging wallet for merchant {merchant_id}: {e}")
+        raise HTTPException(status_code=500, detail="Failed to recharge wallet")

--- a/app/database/accessor/breeze_buddy/merchants.py
+++ b/app/database/accessor/breeze_buddy/merchants.py
@@ -11,6 +11,12 @@ from typing import List, Optional, Tuple
 from app.core.logger import logger
 from app.database import get_db_connection
 from app.database.accessor.breeze_buddy.access_grants import ensure_reseller_on_conn
+from app.database.accessor.breeze_buddy.wallets import (
+    create_wallet_on_conn,
+    delete_wallet_on_conn,
+    get_wallet_for_update_on_conn,
+    update_wallet_reseller_id_on_conn,
+)
 from app.database.decoder.breeze_buddy.merchants import decode_merchant
 from app.database.queries import run_parameterized_query
 from app.database.queries.breeze_buddy.merchants import (
@@ -83,6 +89,10 @@ async def create_merchant(
                     # slugs as bare resellers rows.
                     await ensure_reseller_on_conn(conn, reseller_id)
                 result = await conn.fetch(query, *values)
+                if result:
+                    # Every merchant must have exactly one wallet row; create
+                    # it in the same transaction so it can never be missing.
+                    await create_wallet_on_conn(conn, merchant_id, reseller_id)
             row = result[0] if result else None
 
             if row:
@@ -306,6 +316,13 @@ async def update_merchant(
                     # unknown umbrella slugs like create_merchant does.
                     await ensure_reseller_on_conn(conn, reseller_id)
                 result = await conn.fetch(query, *values)
+                if result and reseller_id:
+                    # Keep the wallet's denormalized reseller_id in sync so
+                    # reseller-scoped wallet queries stay accurate after
+                    # a merchant is reassigned to a different reseller.
+                    await update_wallet_reseller_id_on_conn(
+                        conn, merchant_id, reseller_id
+                    )
             row = result[0] if result else None
 
             if row:
@@ -323,11 +340,20 @@ async def delete_merchant(merchant_id: str) -> bool:
     """Delete merchant entity by merchant_id.
 
     Returns True if deleted, False if not found.
-    Raises ValueError if users still reference this merchant_id.
+    Raises ValueError if users still reference this merchant_id, or if the
+    merchant's wallet has a non-zero balance.
     Raises exception on database errors.
 
-    Note: Uses atomic CTE to check dependencies and delete in a single
-    operation to prevent TOCTOU race conditions.
+    Wallet handling: the wallet row is locked and checked in the same
+    transaction as the merchant delete. If balance_credits > 0, deletion is
+    refused. If balance_credits == 0, the wallet row is deleted alongside
+    the merchant. wallet_transactions rows are NEVER touched -- the ledger
+    has no FK to wallets/merchants and is preserved permanently as an
+    append-only audit record, regardless of merchant/wallet lifecycle.
+
+    Note: the merchant delete itself still uses the existing atomic CTE
+    (dependency_check + delete_operation) to check user references and
+    delete in one round trip, avoiding TOCTOU races.
 
     Args:
         merchant_id: The merchant identifier to delete
@@ -338,25 +364,39 @@ async def delete_merchant(merchant_id: str) -> bool:
     query, values = delete_merchant_query(merchant_id)
 
     try:
-        result = await run_parameterized_query(query, values)
-        row = result[0] if result else None
+        async for conn in get_db_connection():
+            async with conn.transaction():
+                wallet = await get_wallet_for_update_on_conn(conn, merchant_id)
+                if wallet and wallet.balance_credits > 0:
+                    raise ValueError(
+                        f"Cannot delete merchant entity '{merchant_id}': "
+                        f"wallet has a non-zero balance ({wallet.balance_credits} credits)"
+                    )
 
-        if row:
-            user_count = row["user_count"]
-            deleted_count = row["deleted_count"]
+                rows = await conn.fetch(query, *values)
+                row = rows[0] if rows else None
 
-            if user_count > 0:
-                raise ValueError(
-                    f"Cannot delete merchant entity '{merchant_id}': {user_count} user(s) still reference it"
-                )
+                if row and row["user_count"] > 0:
+                    raise ValueError(
+                        f"Cannot delete merchant entity '{merchant_id}': "
+                        f"{row['user_count']} user(s) still reference it"
+                    )
+
+                deleted_count = row["deleted_count"] if row else 0
+
+                if deleted_count > 0 and wallet:
+                    # Merchant delete succeeded and a wallet existed
+                    # (balance already verified == 0 above) -- remove it too.
+                    await delete_wallet_on_conn(conn, merchant_id)
 
             if deleted_count > 0:
                 logger.info(f"Deleted merchant entity: {merchant_id}")
                 return True
 
             return False
-
         return False
+    except ValueError:
+        raise
     except Exception as e:
         logger.error(f"Error deleting merchant entity {merchant_id}: {e}")
         raise

--- a/app/database/accessor/breeze_buddy/wallets.py
+++ b/app/database/accessor/breeze_buddy/wallets.py
@@ -1,0 +1,176 @@
+"""
+Database accessor functions for wallet + wallet_transactions management.
+
+This module provides business logic for wallet operations, using queries
+from queries.breeze_buddy.wallets and decoders from decoder.breeze_buddy.wallets.
+"""
+
+from decimal import Decimal
+from typing import Optional
+
+import asyncpg
+
+from app.core.logger import logger
+from app.database import get_db_connection
+from app.database.decoder.breeze_buddy.wallets import (
+    decode_wallet,
+    decode_wallet_transaction,
+)
+from app.database.queries import run_parameterized_query
+from app.database.queries.breeze_buddy.wallets import (
+    create_wallet_query,
+    delete_wallet_query,
+    get_wallet_for_update_query,
+    get_wallet_query,
+    insert_wallet_transaction_query,
+    update_wallet_balance_query,
+    update_wallet_reseller_id_query,
+)
+from app.schemas.breeze_buddy.wallets import WalletResponse, WalletTransactionResponse
+
+
+async def create_wallet_on_conn(
+    conn: asyncpg.Connection, merchant_id: str, reseller_id: Optional[str] = None
+) -> None:
+    """Create a wallet row for a newly created merchant.
+
+    Intended to be called inside the same transaction used by
+    accessor.breeze_buddy.merchants.create_merchant, so a merchant can
+    never exist without a corresponding wallet row.
+    """
+    query, values = create_wallet_query(merchant_id, reseller_id)
+    await conn.execute(query, *values)
+
+
+async def update_wallet_reseller_id_on_conn(
+    conn: asyncpg.Connection, merchant_id: str, reseller_id: Optional[str]
+) -> None:
+    """Sync a wallet's denormalized reseller_id after a merchant's
+    reseller_id is reassigned.
+
+    Intended to be called inside the same transaction used by
+    accessor.breeze_buddy.merchants.update_merchant. No-ops silently if the
+    merchant has no wallet row (should not happen in practice).
+    """
+    query, values = update_wallet_reseller_id_query(merchant_id, reseller_id)
+    await conn.execute(query, *values)
+
+
+async def get_wallet(merchant_id: str) -> Optional[WalletResponse]:
+    """Fetch a merchant's wallet (no locking).
+
+    Args:
+        merchant_id: The merchant identifier to look up
+
+    Returns:
+        WalletResponse if found, None otherwise
+    """
+    query, values = get_wallet_query(merchant_id)
+
+    try:
+        result = await run_parameterized_query(query, values)
+        row = result[0] if result else None
+        return decode_wallet(row) if row else None
+    except Exception as e:
+        logger.error(f"Error fetching wallet for merchant {merchant_id}: {e}")
+        raise
+
+
+async def get_wallet_for_update_on_conn(
+    conn: asyncpg.Connection, merchant_id: str
+) -> Optional[WalletResponse]:
+    """Fetch and lock (SELECT ... FOR UPDATE) a merchant's wallet on an
+    existing connection/transaction owned by the caller.
+
+    Intended for use inside accessor.breeze_buddy.merchants.delete_merchant's
+    transaction, to safely read balance_credits before deciding whether the
+    merchant (and its wallet) may be deleted.
+    """
+    query, values = get_wallet_for_update_query(merchant_id)
+    rows = await conn.fetch(query, *values)
+    row = rows[0] if rows else None
+    return decode_wallet(row) if row else None
+
+
+async def delete_wallet_on_conn(conn: asyncpg.Connection, merchant_id: str) -> None:
+    """Delete a wallet row on an existing connection/transaction owned by
+    the caller.
+
+    Callers MUST verify balance_credits == 0 first (e.g. via
+    get_wallet_for_update_on_conn in the same transaction). wallet_transactions
+    rows are never touched -- the ledger has no FK to wallets and is
+    intentionally preserved as a permanent append-only record.
+    """
+    query, values = delete_wallet_query(merchant_id)
+    await conn.execute(query, *values)
+
+
+async def apply_recharge(
+    merchant_id: str,
+    credits_delta: Decimal,
+    amount: Decimal,
+    currency: str,
+    gateway: str,
+    gateway_ref_id: str,
+    made_by: Optional[str] = None,
+) -> WalletTransactionResponse:
+    """Recharge a merchant's wallet and append a ledger row.
+
+    Locks the wallet row (SELECT ... FOR UPDATE) for the duration of the
+    transaction to prevent lost updates from concurrent recharges/deductions,
+    then inserts an 'addition' row into wallet_transactions and updates the
+    cached balance_credits on wallets.
+
+    The number of credits to add (credits_delta) must already be computed by
+    the caller (see services.wallet.conversion.compute_credits) -- this
+    accessor has no knowledge of currency conversion. Likewise, gateway and
+    gateway_ref_id must be supplied by the caller -- this accessor has no
+    knowledge of which payment gateway (or "manual") initiated the recharge,
+    so it never needs to change as new gateways are added.
+
+    Raises:
+        ValueError: if no wallet exists for merchant_id.
+        Exception: on database errors.
+    """
+    try:
+        async for conn in get_db_connection():
+            async with conn.transaction():
+                wallet_query, wallet_values = get_wallet_for_update_query(merchant_id)
+                wallet_rows = await conn.fetch(wallet_query, *wallet_values)
+                wallet_row = wallet_rows[0] if wallet_rows else None
+
+                if not wallet_row:
+                    raise ValueError(f"No wallet found for merchant '{merchant_id}'")
+
+                credit_balance_after = wallet_row["balance_credits"] + credits_delta
+
+                txn_query, txn_values = insert_wallet_transaction_query(
+                    merchant_id=merchant_id,
+                    type_="addition",
+                    credits_delta=credits_delta,
+                    credit_balance_after=credit_balance_after,
+                    amount=amount,
+                    currency=currency,
+                    gateway=gateway,
+                    gateway_ref_id=gateway_ref_id,
+                    made_by=made_by,
+                )
+                txn_rows = await conn.fetch(txn_query, *txn_values)
+
+                balance_query, balance_values = update_wallet_balance_query(
+                    merchant_id, credit_balance_after
+                )
+                await conn.fetch(balance_query, *balance_values)
+
+            txn_row = txn_rows[0]
+            logger.info(
+                f"Recharged wallet for merchant {merchant_id}: "
+                f"+{credits_delta} credits (balance now {credit_balance_after})"
+            )
+            return decode_wallet_transaction(txn_row)
+        raise ValueError("Failed to acquire database connection")
+    except ValueError:
+        raise
+    except Exception as e:
+        logger.error(f"Error recharging wallet for merchant {merchant_id}: {e}")
+        raise

--- a/app/database/decoder/breeze_buddy/wallets.py
+++ b/app/database/decoder/breeze_buddy/wallets.py
@@ -1,0 +1,48 @@
+"""
+Wallet entity decoders - response builders for wallet-related queries.
+"""
+
+from app.schemas.breeze_buddy.wallets import WalletResponse, WalletTransactionResponse
+
+
+def decode_wallet(row) -> WalletResponse:
+    """Build WalletResponse from a wallets database row.
+
+    Args:
+        row: Database row containing a wallet
+
+    Returns:
+        WalletResponse instance
+    """
+    return WalletResponse(
+        merchant_id=row["merchant_id"],
+        reseller_id=row.get("reseller_id"),
+        balance_credits=row["balance_credits"],
+        conversion_rate=row["conversion_rate"],
+        created_at=row.get("created_at"),
+        updated_at=row.get("updated_at"),
+    )
+
+
+def decode_wallet_transaction(row) -> WalletTransactionResponse:
+    """Build WalletTransactionResponse from a wallet_transactions database row.
+
+    Args:
+        row: Database row containing a wallet ledger entry
+
+    Returns:
+        WalletTransactionResponse instance
+    """
+    return WalletTransactionResponse(
+        id=row["id"],
+        merchant_id=row["merchant_id"],
+        type=row["type"],
+        credits_delta=row["credits_delta"],
+        credit_balance_after=row["credit_balance_after"],
+        amount=row.get("amount"),
+        currency=row.get("currency"),
+        gateway=row.get("gateway"),
+        gateway_ref_id=row.get("gateway_ref_id"),
+        made_by=row.get("made_by"),
+        created_at=row["created_at"],
+    )

--- a/app/database/migrations/043_create_wallets.sql
+++ b/app/database/migrations/043_create_wallets.sql
@@ -1,0 +1,44 @@
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS wallets (
+    merchant_id VARCHAR(255) PRIMARY KEY REFERENCES merchants(merchant_id),
+    reseller_id VARCHAR(255),
+    balance_credits NUMERIC(14, 4) NOT NULL DEFAULT 0,
+    conversion_rate NUMERIC(6, 2) NOT NULL DEFAULT 1.0,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW() NOT NULL,
+    updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW() NOT NULL
+);
+
+-- Backfill a wallet row for every merchant that already existed before this
+-- migration ran. New merchants get a wallet automatically via
+-- create_wallet_on_conn() inside create_merchant()'s transaction.
+INSERT INTO wallets (merchant_id, reseller_id, balance_credits, conversion_rate, created_at, updated_at)
+SELECT merchant_id, reseller_id, 0, 1.0, NOW(), NOW()
+FROM merchants
+ON CONFLICT (merchant_id) DO NOTHING;
+
+-- No FK on merchant_id: wallet_transactions is an append-only ledger that
+-- must outlive its parent wallet/merchant rows (both can be hard-deleted
+-- once a wallet's balance reaches 0, per delete_merchant()'s business
+-- logic). The column stays indexed for lookups, just not FK-constrained.
+CREATE TABLE IF NOT EXISTS wallet_transactions (
+    id BIGSERIAL PRIMARY KEY,
+    merchant_id VARCHAR(255) NOT NULL,
+    type VARCHAR(20) NOT NULL CHECK (type IN ('addition', 'deduction')),
+    credits_delta NUMERIC(14, 4) NOT NULL,
+    credit_balance_after NUMERIC(14, 4) NOT NULL,
+    amount NUMERIC(14, 4),
+    currency VARCHAR(3),
+    gateway VARCHAR(50),
+    gateway_ref_id VARCHAR(255),
+    usage_metadata JSONB,
+    made_by VARCHAR(255),
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW() NOT NULL,
+    UNIQUE (gateway, gateway_ref_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_wallet_txn_merchant_created ON wallet_transactions(merchant_id, created_at DESC);
+-- Note: no separate index on (gateway, gateway_ref_id) here — the UNIQUE
+-- constraint above already creates that index automatically.
+
+COMMIT;

--- a/app/database/queries/breeze_buddy/wallets.py
+++ b/app/database/queries/breeze_buddy/wallets.py
@@ -1,0 +1,135 @@
+"""
+Database query functions for wallet + wallet_transactions management.
+
+This module contains ONLY query generation functions.
+Business logic should be in accessor/breeze_buddy/wallets.py
+"""
+
+from datetime import datetime, timezone
+from typing import Any, List, Optional, Tuple
+
+WALLETS_TABLE = "wallets"
+WALLET_TRANSACTIONS_TABLE = "wallet_transactions"
+
+
+def create_wallet_query(
+    merchant_id: str, reseller_id: Optional[str] = None
+) -> Tuple[str, List[Any]]:
+    """Generate query to create a wallet row for a newly created merchant."""
+    query = f"""
+        INSERT INTO {WALLETS_TABLE} (
+            merchant_id, reseller_id, balance_credits, conversion_rate,
+            created_at, updated_at
+        ) VALUES ($1, $2, 0, 1.0, $3, $3)
+        RETURNING merchant_id, reseller_id, balance_credits, conversion_rate,
+                  created_at, updated_at
+    """
+    now = datetime.now(timezone.utc)
+    return query, [merchant_id, reseller_id, now]
+
+
+def get_wallet_query(merchant_id: str) -> Tuple[str, List[Any]]:
+    """Generate query to fetch a wallet row (no locking)."""
+    query = f"""
+        SELECT merchant_id, reseller_id, balance_credits, conversion_rate,
+               created_at, updated_at
+        FROM {WALLETS_TABLE}
+        WHERE merchant_id = $1
+    """
+    return query, [merchant_id]
+
+
+def get_wallet_for_update_query(merchant_id: str) -> Tuple[str, List[Any]]:
+    """Generate query to fetch a wallet row and lock it for the duration of
+    the enclosing transaction (SELECT ... FOR UPDATE)."""
+    query = f"""
+        SELECT merchant_id, reseller_id, balance_credits, conversion_rate,
+               created_at, updated_at
+        FROM {WALLETS_TABLE}
+        WHERE merchant_id = $1
+        FOR UPDATE
+    """
+    return query, [merchant_id]
+
+
+def update_wallet_reseller_id_query(
+    merchant_id: str, reseller_id: Optional[str]
+) -> Tuple[str, List[Any]]:
+    """Generate query to sync a wallet's denormalized reseller_id after a
+    merchant's reseller_id is reassigned."""
+    query = f"""
+        UPDATE {WALLETS_TABLE}
+        SET reseller_id = $1, updated_at = $2
+        WHERE merchant_id = $3
+        RETURNING merchant_id, reseller_id, balance_credits, conversion_rate,
+                  created_at, updated_at
+    """
+    now = datetime.now(timezone.utc)
+    return query, [reseller_id, now, merchant_id]
+
+
+def update_wallet_balance_query(
+    merchant_id: str, new_balance: Any
+) -> Tuple[str, List[Any]]:
+    """Generate query to set a wallet's cached balance_credits."""
+    query = f"""
+        UPDATE {WALLETS_TABLE}
+        SET balance_credits = $1, updated_at = $2
+        WHERE merchant_id = $3
+        RETURNING merchant_id, reseller_id, balance_credits, conversion_rate,
+                  created_at, updated_at
+    """
+    now = datetime.now(timezone.utc)
+    return query, [new_balance, now, merchant_id]
+
+
+def delete_wallet_query(merchant_id: str) -> Tuple[str, List[Any]]:
+    """Generate query to delete a wallet row.
+
+    Callers must ensure balance_credits == 0 before calling this -- the
+    ledger (wallet_transactions) is intentionally left untouched, since it
+    has no FK to wallets/merchants and must survive as a permanent
+    append-only record regardless of merchant/wallet lifecycle.
+    """
+    query = f"""
+        DELETE FROM {WALLETS_TABLE}
+        WHERE merchant_id = $1
+        RETURNING merchant_id
+    """
+    return query, [merchant_id]
+
+
+def insert_wallet_transaction_query(
+    merchant_id: str,
+    type_: str,
+    credits_delta: Any,
+    credit_balance_after: Any,
+    amount: Optional[Any] = None,
+    currency: Optional[str] = None,
+    gateway: Optional[str] = None,
+    gateway_ref_id: Optional[str] = None,
+    made_by: Optional[str] = None,
+) -> Tuple[str, List[Any]]:
+    """Generate query to append a row to the wallet_transactions ledger."""
+    query = f"""
+        INSERT INTO {WALLET_TRANSACTIONS_TABLE} (
+            merchant_id, type, credits_delta, credit_balance_after,
+            amount, currency, gateway, gateway_ref_id, made_by, created_at
+        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+        RETURNING id, merchant_id, type, credits_delta, credit_balance_after,
+                  amount, currency, gateway, gateway_ref_id, made_by, created_at
+    """
+    now = datetime.now(timezone.utc)
+    values = [
+        merchant_id,
+        type_,
+        credits_delta,
+        credit_balance_after,
+        amount,
+        currency,
+        gateway,
+        gateway_ref_id,
+        made_by,
+        now,
+    ]
+    return query, values

--- a/app/schemas/breeze_buddy/wallets.py
+++ b/app/schemas/breeze_buddy/wallets.py
@@ -1,0 +1,47 @@
+"""Request/response schemas for the wallet recharge endpoint."""
+
+from datetime import datetime
+from decimal import Decimal
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+
+class WalletRechargeRequest(BaseModel):
+    """Admin request to add credits to a merchant's wallet."""
+
+    amount: Decimal = Field(
+        ...,
+        gt=Decimal(0),
+        description="Amount paid, in the given currency. Must be > 0.",
+    )
+    currency: str = Field(
+        ..., min_length=3, max_length=3, description="ISO currency code, e.g. INR"
+    )
+
+
+class WalletResponse(BaseModel):
+    """A merchant's wallet (current cached balance state)."""
+
+    merchant_id: str
+    reseller_id: Optional[str] = None
+    balance_credits: Decimal
+    conversion_rate: Decimal
+    created_at: Optional[datetime] = None
+    updated_at: Optional[datetime] = None
+
+
+class WalletTransactionResponse(BaseModel):
+    """A single wallet ledger entry (row from wallet_transactions)."""
+
+    id: int
+    merchant_id: str
+    type: str
+    credits_delta: Decimal
+    credit_balance_after: Decimal
+    amount: Optional[Decimal] = None
+    currency: Optional[str] = None
+    gateway: Optional[str] = None
+    gateway_ref_id: Optional[str] = None
+    made_by: Optional[str] = None
+    created_at: Optional[datetime] = None

--- a/app/services/wallet/__init__.py
+++ b/app/services/wallet/__init__.py
@@ -1,0 +1,5 @@
+"""Wallet domain services: currency conversion and recharge orchestration."""
+
+from app.services.wallet.recharge import recharge
+
+__all__ = ["recharge"]

--- a/app/services/wallet/conversion.py
+++ b/app/services/wallet/conversion.py
@@ -1,0 +1,37 @@
+"""
+Currency conversion logic for the wallet feature.
+
+Pure domain logic, no database or I/O access. Converts a paid amount in a
+given currency into platform credits using a static currency-to-credits map
+combined with the merchant-specific conversion_rate multiplier stored on
+wallets.conversion_rate.
+"""
+
+from decimal import Decimal
+from typing import Dict
+
+from app.services.wallet.exceptions import UnsupportedCurrencyError
+
+# How many credits 1 unit of each currency is worth, before applying the
+# merchant-specific conversion_rate multiplier.
+CURRENCY_TO_CREDITS: Dict[str, Decimal] = {
+    "INR": Decimal(1),
+    "USD": Decimal(60),
+}
+
+
+def compute_credits(
+    amount: Decimal, currency: str, conversion_rate: Decimal
+) -> Decimal:
+    """Compute the number of credits an amount paid in a given currency is
+    worth, for a merchant with the given conversion_rate.
+
+    credits = amount * CURRENCY_TO_CREDITS[currency] * conversion_rate
+
+    Raises:
+        UnsupportedCurrencyError: if currency is not in CURRENCY_TO_CREDITS.
+    """
+    currency = currency.upper()
+    if currency not in CURRENCY_TO_CREDITS:
+        raise UnsupportedCurrencyError(currency)
+    return amount * CURRENCY_TO_CREDITS[currency] * conversion_rate

--- a/app/services/wallet/exceptions.py
+++ b/app/services/wallet/exceptions.py
@@ -1,0 +1,22 @@
+"""Exceptions for wallet domain services."""
+
+
+class UnsupportedCurrencyError(Exception):
+    """Raised when a currency has no entry in the currency-to-credits map."""
+
+    def __init__(self, currency: str):
+        self.currency = currency
+        super().__init__(f"Unsupported currency: {currency}")
+
+
+class InvalidRechargeAmountError(Exception):
+    """Raised when a recharge amount is not strictly positive.
+
+    services.wallet.recharge is a public function and can be called directly
+    (bypassing WalletRechargeRequest's Pydantic validation), so this invariant
+    is re-checked at the service layer as well.
+    """
+
+    def __init__(self, amount):
+        self.amount = amount
+        super().__init__(f"Recharge amount must be positive, got {amount}")

--- a/app/services/wallet/recharge.py
+++ b/app/services/wallet/recharge.py
@@ -1,0 +1,66 @@
+"""
+Wallet recharge orchestration.
+
+Owns the full recharge operation: fetching the merchant's conversion_rate,
+computing the credits to add via services.wallet.conversion, and persisting
+the recharge through the database accessor layer. This mirrors the pattern
+used by services.knowledge_base.ingestion, which similarly owns a full
+operation and calls the accessor layer directly.
+"""
+
+from decimal import Decimal
+from typing import Optional
+from uuid import uuid4
+
+from app.database.accessor.breeze_buddy import wallets as wallets_accessor
+from app.schemas.breeze_buddy.wallets import WalletTransactionResponse
+from app.services.wallet import conversion
+from app.services.wallet.exceptions import InvalidRechargeAmountError
+
+
+async def recharge(
+    merchant_id: str,
+    amount: Decimal,
+    currency: str,
+    made_by: Optional[str] = None,
+) -> WalletTransactionResponse:
+    """Add credits to a merchant's wallet and record the ledger entry.
+
+    Raises:
+        InvalidRechargeAmountError: if amount is not strictly positive.
+        ValueError: if no wallet exists for merchant_id.
+        UnsupportedCurrencyError: if currency has no credits mapping.
+        Exception: on database errors.
+    """
+    # Re-check the positive-amount invariant here even though
+    # WalletRechargeRequest already enforces gt=0 -- recharge() is a public
+    # service function and can be called directly, bypassing that request
+    # schema's validation.
+    if amount <= 0:
+        raise InvalidRechargeAmountError(amount)
+
+    wallet = await wallets_accessor.get_wallet(merchant_id)
+    if not wallet:
+        raise ValueError(f"No wallet found for merchant '{merchant_id}'")
+
+    # Normalize once here so the same value is used for both the credits
+    # computation and what gets persisted to the immutable ledger row.
+    currency = currency.upper()
+    credits_delta = conversion.compute_credits(amount, currency, wallet.conversion_rate)
+
+    # This is currently the only recharge path (admin-triggered, no payment
+    # gateway yet), so gateway/gateway_ref_id are generated here directly.
+    # When a real gateway (e.g. Juspay/Stripe) is added, this is the only
+    # place that needs to change -- the accessor layer stays untouched.
+    gateway = "manual"
+    gateway_ref_id = str(uuid4())
+
+    return await wallets_accessor.apply_recharge(
+        merchant_id=merchant_id,
+        credits_delta=credits_delta,
+        amount=amount,
+        currency=currency,
+        gateway=gateway,
+        gateway_ref_id=gateway_ref_id,
+        made_by=made_by,
+    )


### PR DESCRIPTION

- Add wallets + wallet_transactions tables (migration 043), with wallets backfilled for all existing merchants and auto-created for new ones inside create_merchant()'s transaction
- Block merchant deletion once a wallet row exists (FK RESTRICT, no CASCADE) to preserve financial history
- Add app/services/wallet/ (conversion, recharge) sitting between the router and the accessor layer, matching the knowledge_base service pattern used elsewhere in the codebase
- Support INR/USD currency-to-credit conversion combined with a per-merchant conversion_rate multiplier
- Sync wallets.reseller_id whenever a merchant's reseller_id changes
- Add POST /wallet/{merchant_id}/recharge (admin-only) to add credits and record an immutable ledger entry with row-level locking (SELECT ... FOR UPDATE) to prevent lost updates under concurrency
- Keep gateway/gateway_ref_id generation in the service layer (not the accessor) so future payment-gateway integrations require no accessor changes

Dev Proof:

<img width="1489" height="289" alt="image" src="https://github.com/user-attachments/assets/3b2f8c6f-4268-4455-9ab3-cd5d30e63867" />
<img width="1710" height="683" alt="image" src="https://github.com/user-attachments/assets/61b3f56e-7f4c-43c6-9faa-e2a7488b6840" />
<img width="588" height="1124" alt="image" src="https://github.com/user-attachments/assets/fdee6f1f-07e7-4a38-9e8b-f6ed933273e9" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added merchant wallets with balances and transaction history.
  * Added admin-only wallet recharge functionality with currency conversion and validation.
  * Wallets are automatically created for new merchants and kept synchronized when merchant ownership changes.
  * Added clear handling for invalid currencies, missing wallets, and recharge failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->