### PR TITLE
feat(chat): UI-intent engine + widget config surface (quick replies, greeting tiles)

### DIFF
--- a/app/ai/voice/agents/breeze_buddy/chat/intents/__init__.py
+++ b/app/ai/voice/agents/breeze_buddy/chat/intents/__init__.py
@@ -1,0 +1,2 @@
+"""Widget ui_intent engine: policy routing (DIRECT / AGENT_TURN /
+CLIENT). Flavors under ``assist/`` register their policies lazily."""

--- a/app/ai/voice/agents/breeze_buddy/chat/intents/router.py
+++ b/app/ai/voice/agents/breeze_buddy/chat/intents/router.py
@@ -1,0 +1,715 @@
+"""Typed UI intents — the widget → server action channel (RFC-001 §3.3).
+
+Catalog-v2 data-bound components emit ``{intent, component_id, payload,
+display}`` actions instead of free-text ``to_assistant`` messages. This
+module is the **flavor-agnostic engine**:
+
+- The wire model + :func:`parse_ui_intent` (→ 422-shaped
+  :class:`IntentValidationError` on anything malformed, unknown, or not
+  enabled for the session's template).
+- The **intent policy registry** — which intents execute directly (no LLM
+  call), which convert into a structured agent turn, and which are
+  client-side only. The registry starts EMPTY; flavor packages under
+  ``breeze_buddy/assist/`` populate it via :func:`register_intents` when
+  :func:`ensure_flavor_intents` lazily imports them (mirror of
+  ``ui_catalog.ensure_group_loaded`` for schemas).
+- :func:`run_direct_intent` — the direct executor shell: the policy's
+  flavor-provided ``drive`` callable runs whitelisted tools through the
+  EXISTING pipeline (``inject_tool_args`` → MCP dispatch →
+  ``apply_result_pipeline`` → ``apply_state_reducers``, via
+  ``ChatAgent.run_direct_tool`` / :func:`run_persisted_tool`) with **no
+  LLM client constructed**, then a hydrated component (the policy's
+  ``show_op``) + ``turn_end`` streams over the same SSE shape a chat turn
+  uses.
+
+Like the session-state / ui-stream engines, this module is deliberately
+commerce-blind: cart tool names, payload schemas, and CartView emission
+live in ``assist/commerce/intents.py`` and register here on flavor load.
+Sessions whose template doesn't enable a flavor get the typed 422
+(``unknown_intent`` when the flavor was never loaded in this process,
+``flavor_not_enabled`` when it was loaded by another template) — either
+way the intent never executes.
+"""
+
+from __future__ import annotations
+
+import copy
+import importlib
+import json
+import uuid
+from dataclasses import dataclass, replace
+from enum import Enum
+from typing import (
+    Any,
+    AsyncIterator,
+    Awaitable,
+    Callable,
+    Dict,
+    Iterable,
+    List,
+    Optional,
+    Set,
+    Tuple,
+    Type,
+)
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
+
+from app.ai.voice.agents.breeze_buddy.chat.agent import ChatAgent
+from app.ai.voice.agents.breeze_buddy.chat.client_context import diff_state_patch
+from app.ai.voice.agents.breeze_buddy.chat.history.block_codec import (
+    assistant_turn_to_blocks,
+    internal_text_block,
+    plain_text_blocks,
+    tool_results_to_user_blocks,
+)
+from app.ai.voice.agents.breeze_buddy.chat.sse import SSEEvent
+from app.ai.voice.agents.breeze_buddy.chat.turn_core import (
+    build_render_template_vars,
+    resolve_session_catalog_version,
+)
+from app.ai.voice.agents.breeze_buddy.chat.ui.binding import resolve_show_op
+from app.ai.voice.agents.breeze_buddy.chat.ui.stream import (
+    summarize_ui_ops,
+    ui_op_dropped_event,
+    ui_op_event,
+)
+from app.ai.voice.agents.breeze_buddy.mcp import close_mcp_pool
+from app.ai.voice.agents.breeze_buddy.template.cache import get_template_by_id_cached
+
+# Same envelope helper the reducer engine + binding store use — one
+# definition of "success" across every result consumer.
+from app.ai.voice.agents.breeze_buddy.template.session_state import (
+    _is_tool_success,
+)
+from app.core.logger import logger
+from app.core.transport.http_client import create_aiohttp_session
+from app.database.accessor.breeze_buddy.chat_session import (
+    get_agent_session_state,
+    get_chat_session_by_id,
+    insert_chat_message,
+    update_chat_session_after_turn,
+    upsert_agent_session_state_merge,
+)
+from app.schemas.breeze_buddy.chat import ChatMessageRole, ChatSessionStatus
+
+# ---------------------------------------------------------------------------
+# Wire model
+# ---------------------------------------------------------------------------
+
+
+class UiIntent(BaseModel):
+    """The ``ui_intent`` body variant on ``POST /widget/session/{id}/message``
+    (RFC-001 §3.3). ``payload`` is validated per-intent (see the policy
+    table); ``display`` becomes the visible user bubble."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    intent: str = Field(..., min_length=1, max_length=64)
+    component_id: str = Field(..., min_length=1, max_length=128)
+    payload: Dict[str, Any] = Field(default_factory=dict)
+    display: Optional[str] = Field(None, max_length=500)
+
+
+# ---------------------------------------------------------------------------
+# Policy registry — populated by flavor packages on lazy load
+# ---------------------------------------------------------------------------
+
+
+class IntentRoute(str, Enum):
+    """How an intent is served (RFC-001 §3.3 policy table)."""
+
+    DIRECT = "direct"  # whitelisted tool execution, no LLM call
+    AGENT_TURN = "agent_turn"  # rewritten into a structured user turn
+    CLIENT = "client"  # widget-side only; server never executes
+
+
+# A DIRECT policy's tool driver: yields ``(sse_event, final_tool_name,
+# final_result)`` triples — events stream as they happen; the final
+# tool/result pair rides the last dispatch (see ``run_direct_intent``).
+DirectDriveFn = Callable[
+    ["ChatAgent", Any, Dict[str, Any], "ParsedIntent", str],
+    AsyncIterator[Tuple[Optional[SSEEvent], Optional[str], Any]],
+]
+
+# Builds the server-authored ``show`` op over the final (tool_name,
+# result, agent) — hydrated via the same resolver a LLM `show` op uses.
+# The agent carries both ``agent_state`` (reducer output) and ``template``
+# (per-template intent_tools overrides).
+ShowOpBuilderFn = Callable[[str, Any, "ChatAgent"], Dict[str, Any]]
+
+# Post-success follow-up surface (e.g. the commerce cart upsell): runs
+# AFTER the ack + primary component are on the wire, may dispatch its own
+# tools through the same pipeline, and returns ONE fully-resolved ui op
+# (or None for silence). The engine persists it as its own assistant row
+# and streams it before turn_end. Must be fail-open — a follow-up is
+# decoration, never allowed to fail the mutation turn.
+FollowupFn = Callable[
+    ["ChatAgent", Any, Dict[str, Any], "ParsedIntent", str, str, Any],
+    Awaitable[Optional[Dict[str, Any]]],
+]
+
+
+@dataclass(frozen=True)
+class IntentPolicy:
+    """One intent's routing + validation + (flavor-provided) execution.
+
+    ``flavor`` is stamped by :func:`register_intents` — sessions only see
+    intents whose flavor their template enables. DIRECT policies carry
+    ``drive`` (+ optionally ``show_op``); AGENT_TURN policies carry
+    ``agent_turn`` (the structured-user-message rewriter).
+    """
+
+    route: IntentRoute
+    payload_model: Type[BaseModel]
+    flavor: str = ""
+    default_display: Optional[str] = None
+    agent_turn: Optional[Callable[["ParsedIntent"], str]] = None
+    drive: Optional[DirectDriveFn] = None
+    show_op: Optional[ShowOpBuilderFn] = None
+    # Optional flavor-provided extractor: a shopper-displayable reason off
+    # a FAILED final result (e.g. the UCP messages[] "already sold out"
+    # warning). None / raising / no match → the generic copy. Only
+    # display-grade upstream text should come back from this — never raw
+    # error internals.
+    failure_message: Optional[Callable[[Any], Optional[str]]] = None
+    # Optional flavor-provided acknowledgement off the SUCCESSFUL final
+    # (parsed, tool_name, result): one short shopper-facing line ("Done.")
+    # persisted as the turn's assistant prose ALONGSIDE any rendered
+    # component — it keeps the turn visibly anchored after a later turn's
+    # component sweeps this one. None / raising → no bubble.
+    ack_message: Optional[Callable[["ParsedIntent", str, Any], Optional[str]]] = None
+    # Optional post-success follow-up (see FollowupFn): streamed and
+    # persisted AFTER the primary component so the shopper never waits on
+    # it. Skipped for silent policies (nothing visible to follow up on).
+    followup: Optional[FollowupFn] = None
+    # Silent intents (e.g. view_product's overlay fetch) leave NO visible
+    # trace in the thread: the user record persists internal-only (no
+    # bubble, no user_committed event) and the hydrated component is
+    # streamed live but never persisted as a replayable ui block. The
+    # tool exchange still persists — the agent keeps the context.
+    silent: bool = False
+    # Internal AGENT_TURN intents (e.g. enrich_product's overlay blurb)
+    # run a REAL LLM turn whose entire exchange persists with
+    # visibility=internal: the rewritten user instruction and the
+    # assistant prose stay in the LLM's context on later turns, but
+    # resume replay never shows them and no user_committed fires. The
+    # live SSE stream is unchanged — the widget routes the tokens where
+    # it wants them (the overlay, for enrich_product). DIRECT policies
+    # use `silent` instead; `internal` is the agent-turn counterpart.
+    internal: bool = False
+
+
+# Process-global registry. Starts empty; ``register_intents`` populates it
+# when a flavor's intents module is (lazily) imported. Additive-only —
+# per-session gating is the ``enabled_flavors`` check in parse_ui_intent.
+INTENT_POLICY: Dict[str, IntentPolicy] = {}
+
+# Flavor → intents module, the intent-side mirror of
+# ``ui_catalog.LAZY_GROUPS`` (which maps the same flavor names to schema
+# modules). Kept separate so a chat session that never sends a ui_intent
+# loads only the schemas, and vice versa.
+FLAVOR_INTENT_MODULES: Dict[str, str] = {
+    "commerce": "app.ai.voice.agents.breeze_buddy.assist.commerce.intents",
+}
+
+_LOADED_FLAVOR_INTENTS: Set[str] = set()
+
+
+def ensure_flavor_intents(flavors: Iterable[str]) -> None:
+    """Idempotently import (→ register) the intent modules for ``flavors``.
+
+    Unknown flavor names are ignored — callers pass a template's enabled
+    UI-catalog groups verbatim (``core`` etc. simply have no intents).
+    """
+    for flavor in flavors:
+        module_path = FLAVOR_INTENT_MODULES.get(flavor)
+        if module_path is None or flavor in _LOADED_FLAVOR_INTENTS:
+            continue
+        importlib.import_module(module_path)
+        _LOADED_FLAVOR_INTENTS.add(flavor)
+
+
+def register_intents(flavor: str, policies: Dict[str, IntentPolicy]) -> None:
+    """Register a flavor's intent policies (called at flavor import time).
+
+    Stamps ``flavor`` onto each policy. Idempotent for re-registration of
+    the same flavor; a cross-flavor name collision raises — intent names
+    are a global namespace on the wire.
+    """
+    for name, policy in policies.items():
+        existing = INTENT_POLICY.get(name)
+        if existing is not None and existing.flavor != flavor:
+            raise ValueError(
+                f"intent {name!r} already registered by flavor "
+                f"{existing.flavor!r}; refusing {flavor!r}"
+            )
+        INTENT_POLICY[name] = replace(policy, flavor=flavor)
+
+
+def template_enabled_flavors(template: Any) -> Set[str]:
+    """The template's enabled UI-catalog groups — the flavor scope used to
+    lazy-load and gate intents. Config absent → ``{"core"}`` (same default
+    as ``ui_catalog.resolve_allowlist``)."""
+    configurations = getattr(template, "configurations", None)
+    ui_cat = configurations.ui_catalog if configurations else None
+    if ui_cat is None:
+        return {"core"}
+    return set(ui_cat.enabled_groups or [])
+
+
+class IntentValidationError(ValueError):
+    """Typed 422 payload for the widget (rendered as a Message primitive).
+    ``detail`` is the HTTPException-ready body."""
+
+    def __init__(
+        self, code: str, message: str, errors: Optional[List[Dict[str, Any]]] = None
+    ) -> None:
+        super().__init__(message)
+        self.detail: Dict[str, Any] = {"code": code, "message": message}
+        if errors:
+            self.detail["errors"] = errors
+
+
+@dataclass(frozen=True)
+class ParsedIntent:
+    """A wire intent validated against its policy-table payload schema."""
+
+    intent: UiIntent
+    policy: IntentPolicy
+    payload: BaseModel
+
+
+def _structural_errors(exc: ValidationError) -> List[Dict[str, Any]]:
+    """Field paths + error kinds only — never input values (same privacy
+    contract as ui_op_dropped telemetry)."""
+    return [
+        {
+            "loc": ".".join(str(p) for p in err.get("loc", ())),
+            "type": err.get("type"),
+        }
+        for err in exc.errors()[:5]
+    ]
+
+
+def parse_ui_intent(
+    raw: Dict[str, Any], *, enabled_flavors: Optional[Set[str]] = None
+) -> ParsedIntent:
+    """Validate one raw ``ui_intent`` body against the wire model + the
+    per-intent payload schema. Raises :class:`IntentValidationError` (422
+    at the HTTP layer) for unknown intents, intents whose flavor the
+    session's template doesn't enable, or invalid payloads.
+
+    ``enabled_flavors`` is the template's flavor scope (see
+    :func:`template_enabled_flavors`); callers must run
+    :func:`ensure_flavor_intents` on it first so an enabled flavor's
+    intents are actually registered. ``None`` skips the flavor gate
+    (trusted/internal callers only).
+    """
+    try:
+        wire = UiIntent.model_validate(raw)
+    except ValidationError as exc:
+        raise IntentValidationError(
+            "invalid_intent", "Malformed ui_intent body", _structural_errors(exc)
+        ) from exc
+
+    policy = INTENT_POLICY.get(wire.intent)
+    if policy is None:
+        # Also the path taken when the intent's flavor was never loaded in
+        # this process — an unregistered intent is indistinguishable from
+        # an unknown one, and both are a typed 422.
+        raise IntentValidationError("unknown_intent", f"Unknown intent {wire.intent!r}")
+    if enabled_flavors is not None and policy.flavor not in enabled_flavors:
+        raise IntentValidationError(
+            "flavor_not_enabled",
+            f"Intent {wire.intent!r} requires the {policy.flavor!r} flavor, "
+            "which this template does not enable.",
+        )
+
+    try:
+        payload = policy.payload_model.model_validate(wire.payload)
+    except ValidationError as exc:
+        raise IntentValidationError(
+            "invalid_intent_payload",
+            f"Invalid payload for intent {wire.intent!r}",
+            _structural_errors(exc),
+        ) from exc
+
+    return ParsedIntent(intent=wire, policy=policy, payload=payload)
+
+
+def agent_turn_content(parsed: ParsedIntent) -> str:
+    """Rewrite an ``agent_turn``-routed intent into the structured user
+    message the LLM answers (RFC-001 §3.3), via the policy's flavor-provided
+    rewriter. Falling back to the visible display keeps a policy without a
+    rewriter from crashing the rewrite."""
+    if parsed.policy.agent_turn is not None:
+        return parsed.policy.agent_turn(parsed)
+    return parsed.intent.display or parsed.intent.intent
+
+
+# ---------------------------------------------------------------------------
+# Direct executor — engine shell + the seams flavor drivers build on
+# ---------------------------------------------------------------------------
+
+
+def error_events(code: str, message: str) -> List[SSEEvent]:
+    """Terminal ``intent_failed`` + ``turn_end`` pair for a DIRECT intent
+    that could not complete. Session stays ACTIVE — a failed intent must
+    not brick the conversation. Part of the flavor-driver surface
+    (drivers yield these on pre-dispatch failures).
+
+    Deliberately NOT the ``error`` SSE event: the widget renders
+    ``intent_failed`` as an in-thread notice with ``message`` (retrying
+    the identical intent fails identically — e.g. "already sold out"),
+    while ``error`` drives the delivery-failure banner with a Retry
+    affordance. ``message`` must therefore be shopper-displayable.
+    """
+    return [
+        SSEEvent(event="intent_failed", data={"code": code, "message": message}),
+        SSEEvent(event="turn_end", data={"session_status": "ACTIVE"}),
+    ]
+
+
+async def _persist_tool_step(session_id: str, call: Any, result_payload: Any) -> None:
+    """Persist one direct dispatch as the standard assistant(tool_use) +
+    user(tool_result) row pair, so replayed history stays fully answered
+    and the LLM sees the mutation on its next turn."""
+    await insert_chat_message(
+        session_id=session_id,
+        role=ChatMessageRole.ASSISTANT,
+        content=None,
+        content_blocks=assistant_turn_to_blocks("", [call]),
+    )
+    await insert_chat_message(
+        session_id=session_id,
+        role=ChatMessageRole.USER,
+        content=None,
+        content_blocks=tool_results_to_user_blocks(
+            [(call.tool_call_id, result_payload)]
+        ),
+    )
+
+
+async def run_persisted_tool(
+    agent: ChatAgent,
+    *,
+    tool_name: str,
+    args: Dict[str, Any],
+    node: Dict[str, Any],
+    prep: Any,
+    turn_id: str,
+) -> Tuple[List[SSEEvent], Any]:
+    """Dispatch ONE tool through the existing pipeline and persist it.
+
+    The engine-owned building block flavor drivers compose their tool
+    sequences from: ``ChatAgent.run_direct_tool`` (inject_tool_args →
+    dispatch → binding store → reducers) + the standard row-pair
+    persistence + the ``function_call_started`` / ``function_call_completed``
+    SSE pair. Returns ``(events, result_payload)``.
+    """
+    call, result = await agent.run_direct_tool(
+        tool_name=tool_name, args=args, node=node, prep=prep, turn_id=turn_id
+    )
+    await _persist_tool_step(agent.session_id, call, result)
+    events = [
+        SSEEvent(
+            event="function_call_started",
+            data={
+                "name": tool_name,
+                "args": dict(call.arguments),
+                "tool_call_id": call.tool_call_id,
+            },
+        ),
+        SSEEvent(
+            event="function_call_completed",
+            data={
+                "name": tool_name,
+                "tool_call_id": call.tool_call_id,
+                "result_summary": None,
+            },
+        ),
+    ]
+    return events, result
+
+
+async def run_direct_intent(
+    *, session_id: str, parsed: ParsedIntent
+) -> AsyncIterator[SSEEvent]:
+    """Serve one DIRECT-routed intent: the policy's flavor tools through
+    the existing pipeline, hydrated component + ``turn_end`` over SSE —
+    no LLM call.
+
+    Mirrors ``run_chat_turn``'s load-everything-itself shape (terminal
+    ``error`` + ``turn_end`` events instead of raising — the HTTP shell
+    pre-validates, the SSE stream has no status code to change). The
+    ``ChatAgent`` here is a dispatch chassis only: ``llm=None`` and no
+    ``_cycle_loop`` entry, so no LLM client is ever constructed. The
+    flavor content — which tools run and which component shows — comes
+    entirely off ``parsed.policy`` (``drive`` / ``show_op``).
+    """
+    session = await get_chat_session_by_id(session_id)
+    if session is None or session.status == ChatSessionStatus.ENDED:
+        yield SSEEvent(
+            event="error",
+            data={"code": "session_gone", "message": "Session no longer active"},
+        )
+        yield SSEEvent(event="turn_end", data={"session_status": "FAILED"})
+        return
+    template = await get_template_by_id_cached(session.template_id)
+    if template is None:
+        yield SSEEvent(
+            event="error",
+            data={"code": "template_missing", "message": "Template missing"},
+        )
+        yield SSEEvent(event="turn_end", data={"session_status": "FAILED"})
+        return
+
+    # Persist the visible user bubble + the full intent as an internal
+    # audit block: widget transcripts show only `display`; the LLM (and
+    # the audit trail) keep the typed intent via the internal block.
+    display = (
+        parsed.intent.display or parsed.policy.default_display or parsed.intent.intent
+    )
+    audit = json.dumps(
+        {"ui_intent": parsed.intent.model_dump(exclude_none=True)},
+        ensure_ascii=False,
+        default=str,
+    )
+    if parsed.policy.silent:
+        # No visible trace: the audit block (which carries the full typed
+        # intent) is the only record — internal visibility, so widget
+        # transcripts and resume replay skip the row entirely while the
+        # LLM still sees what the shopper did.
+        await insert_chat_message(
+            session_id=session_id,
+            role=ChatMessageRole.USER,
+            content=None,
+            content_blocks=[internal_text_block(audit)],
+        )
+    else:
+        user_msg = await insert_chat_message(
+            session_id=session_id,
+            role=ChatMessageRole.USER,
+            content=display,
+            content_blocks=[*plain_text_blocks(display), internal_text_block(audit)],
+        )
+        yield SSEEvent(
+            event="user_committed",
+            data={"idx": user_msg.idx if user_msg else None, "content": display},
+        )
+
+    state_row = await get_agent_session_state(session_id)
+    agent_state: Dict[str, Any] = state_row.data if state_row else {}
+    state_baseline = copy.deepcopy(agent_state)
+    persisted_vars = (
+        session.metadata.get("template_vars", {})
+        if isinstance(session.metadata, dict)
+        else {}
+    )
+    template_vars = await build_render_template_vars(template, persisted_vars)
+
+    agent = ChatAgent(
+        session_id=session_id,
+        template=template,
+        llm=None,  # direct path — no LLM client, ever
+        template_vars=template_vars,
+        agent_state=agent_state,
+        catalog_version=resolve_session_catalog_version(session.metadata),
+    )
+    agent.aiohttp_session = create_aiohttp_session()
+    agent.mcp_pool = {}
+    turn_id = uuid.uuid4().hex
+    try:
+        drive = parsed.policy.drive
+        if drive is None:
+            # Defensive — the HTTP layer only routes DIRECT policies here,
+            # and flavor registration provides ``drive`` for those.
+            for ev in error_events(
+                "invalid_intent", f"Intent {parsed.intent.intent!r} is not direct."
+            ):
+                yield ev
+            return
+        prep, node = await agent.prepare_direct_dispatch(session.current_node)
+
+        final_tool: Optional[str] = None
+        final_result: Any = None
+        async for event, tool_name, result in drive(agent, prep, node, parsed, turn_id):
+            if event is not None:
+                yield event
+            if tool_name is not None:
+                final_tool, final_result = tool_name, result
+        if final_tool is None:
+            # The driver already emitted the terminal error events. A read
+            # (e.g. get_cart) may still have run reducers — persist the
+            # delta so state doesn't silently regress.
+            reducer_patch = diff_state_patch(state_baseline, agent.agent_state)
+            if reducer_patch:
+                await upsert_agent_session_state_merge(
+                    chat_session_id=session_id, patch=reducer_patch
+                )
+            return
+
+        if not _is_tool_success(final_result):
+            logger.warning(
+                f"intent_router {session_id}: {parsed.intent.intent} via "
+                f"{final_tool} returned an error envelope"
+            )
+            # Prefer the flavor's display-grade reason (e.g. the UCP
+            # "already sold out" warning) — a precise message beats
+            # "please try again" copy for a failure that would repeat
+            # identically on retry.
+            message: Optional[str] = None
+            if parsed.policy.failure_message is not None:
+                try:
+                    message = parsed.policy.failure_message(final_result)
+                except Exception:  # noqa: BLE001 — extractor is best-effort
+                    message = None
+            for ev in error_events(
+                "intent_tool_failed",
+                message or "The update could not be completed. Please try again.",
+            ):
+                yield ev
+            return
+
+        # Hydrate the policy's component exactly the way a `show` op would
+        # — same resolver, same schema validation, same v:2 wire shape.
+        # Events are collected, not yielded: the acknowledgement bubble
+        # goes on the wire FIRST so the thread reads "Done." above the
+        # component (matching LLM turns, whose prose streams before UI).
+        hydrated_ops: List[Dict[str, Any]] = []
+        ui_events: List[SSEEvent] = []
+        if parsed.policy.show_op is not None:
+            show_op = parsed.policy.show_op(final_tool, final_result, agent)
+            resolved = resolve_show_op(show_op, agent.binding_store, agent.ui_allowlist)
+            if resolved.op is not None:
+                hydrated_ops.append(resolved.op)
+                ui_events.append(ui_op_event(resolved.op))
+            else:
+                ui_events.append(
+                    ui_op_dropped_event(
+                        json.dumps(show_op, ensure_ascii=False),
+                        resolved.error or "bind_unresolved",
+                    )
+                )
+
+        # Persist the reducer-driven state delta (key-scoped, same contract
+        # as _cycle_loop) and the assistant row anchoring this turn.
+        reducer_patch = diff_state_patch(state_baseline, agent.agent_state)
+        if reducer_patch:
+            await upsert_agent_session_state_merge(
+                chat_session_id=session_id, patch=reducer_patch
+            )
+
+        # Flavor acknowledgement (e.g. cart mutations): one short assistant
+        # line ("Done.") instead of a rendered component — persisted like
+        # any prose turn so resume replays it.
+        ack_text: Optional[str] = None
+        if parsed.policy.ack_message is not None and not parsed.policy.silent:
+            try:
+                ack_text = parsed.policy.ack_message(parsed, final_tool, final_result)
+            except Exception:  # noqa: BLE001 — ack is best-effort, never fatal
+                ack_text = None
+
+        assistant_idx: Optional[int] = None
+        # RFC-002 Phase B: render_ui sessions never write the legacy
+        # marker (replayed markers bred the F1 mimicry bug); the persisted
+        # tool exchange already carries the cart/product data. Fleet
+        # text-channel sessions keep it.
+        ui_summary = (
+            ""
+            if getattr(agent, "_render_ui_enabled", False)
+            else summarize_ui_ops(hydrated_ops)
+        )
+        if hydrated_ops or ack_text:
+            blocks: List[Dict[str, Any]] = (
+                [*plain_text_blocks(ack_text)] if ack_text else []
+            )
+            if ui_summary:
+                blocks.append(internal_text_block(ui_summary))
+            stored = await insert_chat_message(
+                session_id=session_id,
+                role=ChatMessageRole.ASSISTANT,
+                content=ack_text,
+                content_blocks=blocks or None,
+                # Silent intents: the component streamed to the live
+                # overlay only — never a replayable thread block.
+                ui_blocks=None if parsed.policy.silent else (hydrated_ops or None),
+            )
+            assistant_idx = stored.idx if stored else None
+            if ack_text:
+                yield SSEEvent(
+                    event="assistant_message",
+                    data={"idx": assistant_idx, "content": ack_text},
+                )
+        for ev in ui_events:
+            yield ev
+
+        # Post-success follow-up (e.g. cart upsell): runs with the ack +
+        # primary component ALREADY delivered, so its latency (LLM pick +
+        # search) is invisible — the turn simply stays open a moment
+        # longer. Fail-open: any error → no block, turn ends normally.
+        if parsed.policy.followup is not None and not parsed.policy.silent:
+            followup_op: Optional[Dict[str, Any]] = None
+            try:
+                followup_op = await parsed.policy.followup(
+                    agent, prep, node, parsed, turn_id, final_tool, final_result
+                )
+            except Exception:  # noqa: BLE001 — decoration, never fatal
+                logger.exception(
+                    f"intent_router {session_id}: followup for "
+                    f"{parsed.intent.intent} failed"
+                )
+            if followup_op is not None:
+                # The follow-up's own tool dispatches may have advanced
+                # reducer state past the delta persisted above — merge the
+                # full diff again (idempotent for unchanged keys).
+                followup_patch = diff_state_patch(state_baseline, agent.agent_state)
+                if followup_patch:
+                    await upsert_agent_session_state_merge(
+                        chat_session_id=session_id, patch=followup_patch
+                    )
+                await insert_chat_message(
+                    session_id=session_id,
+                    role=ChatMessageRole.ASSISTANT,
+                    content=None,
+                    content_blocks=None,
+                    ui_blocks=[followup_op],
+                )
+                yield ui_op_event(followup_op)
+
+        await update_chat_session_after_turn(
+            session_id=session_id, current_node=session.current_node
+        )
+        yield SSEEvent(
+            event="turn_end",
+            data={"session_status": "ACTIVE", "assistant_idx": assistant_idx},
+        )
+    finally:
+        if agent.aiohttp_session is not None:
+            await agent.aiohttp_session.close()
+            agent.aiohttp_session = None
+        await close_mcp_pool(agent.mcp_pool)
+        agent.mcp_pool = None
+
+
+__all__ = [
+    "UiIntent",
+    "IntentRoute",
+    "IntentPolicy",
+    "INTENT_POLICY",
+    "FLAVOR_INTENT_MODULES",
+    "register_intents",
+    "ensure_flavor_intents",
+    "template_enabled_flavors",
+    "IntentValidationError",
+    "ParsedIntent",
+    "parse_ui_intent",
+    "agent_turn_content",
+    "error_events",
+    "run_persisted_tool",
+    "run_direct_intent",
+    "DirectDriveFn",
+    "ShowOpBuilderFn",
+    "FollowupFn",
+]

--- a/app/api/routers/breeze_buddy/chat/cancel_bus.py
+++ b/app/api/routers/breeze_buddy/chat/cancel_bus.py
@@ -189,10 +189,11 @@ async def _subscriber_loop() -> None:
             logger.info("cancel_bus: subscriber cancelled (app shutdown)")
             raise
         except Exception as exc:
-            logger.error(
+            # loguru: no ``exc_info`` kwarg — it would re-format the message
+            # and crash on brace-bearing error text.
+            logger.exception(
                 f"cancel_bus: subscriber error ({exc!r}); "
-                f"reconnecting in {backoff:.1f}s",
-                exc_info=True,
+                f"reconnecting in {backoff:.1f}s"
             )
             await asyncio.sleep(backoff)
             backoff = min(backoff * 2, 30.0)

--- a/app/api/routers/breeze_buddy/chat/demo.py
+++ b/app/api/routers/breeze_buddy/chat/demo.py
@@ -27,13 +27,16 @@ from __future__ import annotations
 
 from fastapi import APIRouter, Depends, HTTPException, Request, status
 
+from app.ai.voice.agents.breeze_buddy.chat.turn_core import negotiate_catalog
 from app.ai.voice.agents.breeze_buddy.template.cache import get_template_by_id_cached
+from app.ai.voice.agents.breeze_buddy.template.ui_catalog import CATALOG_VERSION_V2
 from app.api.routers.breeze_buddy.chat.handlers import (
     approve_chat_tool_handler,
     create_chat_session_handler,
     end_chat_session_handler,
     load_chat_session_or_404,
     send_chat_message_handler,
+    serve_session_intent,
     validate_template_for_chat,
 )
 from app.api.security.breeze_buddy.demo_token import (
@@ -209,10 +212,23 @@ async def create_demo_session(
     # mid-create flag flip can't disagree with what's persisted in
     # metadata vs. the JWT.
     cap = await DEMO_MESSAGE_CAP_PER_SESSION()
+    # Demo pages ship the current widget build, so the client side of the
+    # catalog negotiation is implicitly "v2" — the template's capability is
+    # the only variable. Persisting the same server-owned ``widget`` block
+    # the real widget path uses keeps one resolver
+    # (resolve_session_catalog_version) across every surface.
+    catalog_active, ui_flavors = negotiate_catalog(template, CATALOG_VERSION_V2)
     create_req = CreateChatSessionRequest(
         template_id=template_id,
         template_vars=req.template_vars,
-        metadata={"demo": {"slug": req.slug, "cap": cap}},
+        metadata={
+            "demo": {"slug": req.slug, "cap": cap},
+            **(
+                {"widget": {"catalog_version": catalog_active}}
+                if catalog_active == CATALOG_VERSION_V2
+                else {}
+            ),
+        },
     )
     create_resp = await create_chat_session_handler(
         create_req, template, synthetic_user
@@ -229,6 +245,8 @@ async def create_demo_session(
         greeting=create_resp.greeting,
         demo_token=token,
         message_cap=cap,
+        catalog_active=catalog_active,
+        ui_flavors=ui_flavors,
     )
 
 
@@ -298,6 +316,14 @@ async def demo_send_message(
     be redundant.
     """
     await _enforce_demo_turn_budget(request, ctx, session_id)
+
+    # Typed UI intent body (RFC-001 §3.3) — same validate + policy-route
+    # path the widget uses, so demo pages exercise the full intent stack.
+    if req.ui_intent is not None:
+        session = await load_chat_session_or_404(session_id)
+        return await serve_session_intent(
+            session, session_id, req.ui_intent, context=req.context
+        )
 
     return await send_chat_message_handler(session_id, req, access_check=None)
 

--- a/app/api/routers/breeze_buddy/chat/handlers.py
+++ b/app/api/routers/breeze_buddy/chat/handlers.py
@@ -25,11 +25,22 @@ from app.ai.voice.agents.breeze_buddy.chat.client_context import (
 from app.ai.voice.agents.breeze_buddy.chat.history.block_codec import (
     filter_visible_blocks,
 )
+from app.ai.voice.agents.breeze_buddy.chat.intents.router import (
+    IntentRoute,
+    IntentValidationError,
+    ParsedIntent,
+    agent_turn_content,
+    ensure_flavor_intents,
+    parse_ui_intent,
+    run_direct_intent,
+    template_enabled_flavors,
+)
 from app.ai.voice.agents.breeze_buddy.chat.metrics import TurnMetrics
 from app.ai.voice.agents.breeze_buddy.chat.sse import SSEEvent, format_sse
 from app.ai.voice.agents.breeze_buddy.chat.turn_core import (
     build_render_template_vars,
     resolve_llm_configuration,
+    resolve_session_catalog_version,
     run_chat_approval_continuation,
     run_chat_turn,
 )
@@ -38,6 +49,7 @@ from app.ai.voice.agents.breeze_buddy.template.transformation_function import (
     TEMPLATE_FUNCTION_REGISTRY,
 )
 from app.ai.voice.agents.breeze_buddy.template.types import TemplateModel
+from app.ai.voice.agents.breeze_buddy.template.ui_catalog import CATALOG_VERSION_V2
 from app.api.routers.breeze_buddy.analytics.rbac import apply_hierarchical_filters
 from app.core.logger import logger
 from app.database.accessor.breeze_buddy.chat_session import (
@@ -377,8 +389,14 @@ async def send_chat_message_handler(
     req: SendChatMessageRequest,
     *,
     access_check: Optional[Callable[[ChatSession], None]] = None,
+    internal: bool = False,
 ) -> StreamingResponse:
     """Drive one turn; stream SSE events until ``turn_end``.
+
+    ``internal`` — the turn is an internal AGENT_TURN intent (see
+    ``IntentPolicy.internal``): the exchange persists with
+    visibility=internal and no ``user_committed`` fires. Only
+    ``serve_session_intent`` sets this; the HTTP routes never expose it.
 
     Multi-pod safe: the per-session Redis lock guarantees one driver
     at a time. The lock is acquired before the SSE response opens so
@@ -517,7 +535,176 @@ async def send_chat_message_handler(
                     session_id=session_id,
                     user_content=req.content,
                     context_placement=context_placement,
+                    internal=internal,
                 ),
+            ),
+            media_type="text/event-stream",
+            headers={
+                "Cache-Control": "no-cache, no-transform",
+                "X-Accel-Buffering": "no",
+                "Connection": "keep-alive",
+            },
+        )
+        lock_handed_off = True
+        return response
+    finally:
+        if not lock_handed_off:
+            await lock.release()
+
+
+async def serve_session_intent(
+    session: Any,
+    session_id: str,
+    raw_intent: Dict[str, Any],
+    *,
+    context: Any = None,
+    voice_live: bool = False,
+):
+    """Validate + policy-route one raw ``ui_intent`` dict and serve it.
+
+    The shared engine behind every intent surface — the widget's dedicated
+    ``POST /intent`` route, the widget's legacy ``/message`` ``ui_intent``
+    body variant, and the demo router. Unknown intent / flavor not enabled
+    / invalid payload → 422 with a typed error the widget renders
+    in-thread. Intent policies are flavor content, lazy-loaded per the
+    template's enabled UI-catalog groups — a template without a flavor
+    never loads (nor matches) that flavor's intents.
+
+    ``voice_live`` — the session currently has a voice attachment. DIRECT
+    intents still execute (no LLM turn is involved; the mutation lands in
+    history, so the voice brain sees it next turn). AGENT_TURN intents
+    would inject a competing chat turn into a live voice conversation, so
+    they 409 with the typed ``voice_live`` code instead.
+    """
+    template = await get_template_by_id_cached(session.template_id)
+    if template is None:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=(
+                f"Template '{session.template_id}' for session "
+                f"'{session_id}' no longer exists"
+            ),
+        )
+    flavors = template_enabled_flavors(template)
+    ensure_flavor_intents(flavors)
+    try:
+        parsed = parse_ui_intent(raw_intent, enabled_flavors=flavors)
+    except IntentValidationError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=exc.detail,
+        ) from exc
+    if resolve_session_catalog_version(session.metadata) != CATALOG_VERSION_V2:
+        # v1 sessions never see v2 emission — a stray intent from a
+        # mismatched client fails closed rather than half-rendering.
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail={
+                "code": "catalog_version_unsupported",
+                "message": (
+                    "ui_intent requires a session created with " "catalog_version 'v2'."
+                ),
+            },
+        )
+    if parsed.policy.route is IntentRoute.CLIENT:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail={
+                "code": "client_side_intent",
+                "message": (
+                    f"Intent {parsed.intent.intent!r} is handled by the "
+                    "widget itself; no server call is expected."
+                ),
+            },
+        )
+    if parsed.policy.route is IntentRoute.DIRECT:
+        return await send_chat_intent_handler(session_id, parsed, access_check=None)
+    if voice_live:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={
+                "code": "voice_live",
+                "message": (
+                    f"Intent {parsed.intent.intent!r} needs an agent turn, "
+                    "which can't run while a voice attachment is live. End "
+                    "voice first, or ask the agent by speaking."
+                ),
+            },
+        )
+    # agent_turn — rewrite into the structured user turn and serve it as
+    # a normal chat turn. Internal policies (enrich_product's overlay
+    # blurb) persist the whole exchange with visibility=internal — the
+    # LLM keeps the context; resume replay never shows it.
+    return await send_chat_message_handler(
+        session_id,
+        SendChatMessageRequest(content=agent_turn_content(parsed), context=context),
+        access_check=None,
+        internal=parsed.policy.internal,
+    )
+
+
+async def send_chat_intent_handler(
+    session_id: str,
+    parsed: ParsedIntent,
+    *,
+    access_check: Optional[Callable[[ChatSession], None]] = None,
+) -> StreamingResponse:
+    """Drive one DIRECT-routed UI intent (RFC-001 §3.3); stream SSE until
+    ``turn_end``. The no-LLM sibling of ``send_chat_message_handler`` —
+    same per-session lock, same SSE scaffolding, same metrics observer;
+    the events come from ``run_direct_intent`` instead of a chat turn.
+    The caller (widget route) has already validated + policy-routed the
+    intent and checked the session's catalog version.
+    """
+    lock = RedisLock(_lock_key(session_id), ttl_seconds=_SESSION_LOCK_TTL_SECONDS)
+    try:
+        await lock.acquire()
+    except LockAcquireError:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=(
+                "Another turn is already in flight for this session. "
+                "Wait for the previous /message stream to complete and retry."
+            ),
+        )
+
+    lock_handed_off = False
+    try:
+        fresh = await get_chat_session_by_id(session_id)
+        if fresh is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Chat session '{session_id}' not found",
+            )
+        if access_check is not None:
+            access_check(fresh)
+        if fresh.status == ChatSessionStatus.ENDED:
+            raise HTTPException(
+                status_code=status.HTTP_410_GONE,
+                detail=f"Chat session '{session_id}' has ended",
+            )
+
+        template = await get_template_by_id_cached(fresh.template_id)
+        if template is None:
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail=(
+                    f"Template '{fresh.template_id}' for chat session "
+                    f"'{session_id}' no longer exists"
+                ),
+            )
+
+        turn_metrics = TurnMetrics(
+            session_id=session_id,
+            template_id=template.id,
+            t0=time.monotonic(),
+        )
+        response = StreamingResponse(
+            _turn_sse_stream(
+                session_id=session_id,
+                lock=lock,
+                turn_metrics=turn_metrics,
+                events=run_direct_intent(session_id=session_id, parsed=parsed),
             ),
             media_type="text/event-stream",
             headers={
@@ -602,9 +789,12 @@ async def _turn_sse_stream(
             # Full exception (incl. SDK / DB internals) goes to logs; the
             # SSE payload is intentionally generic — provider stack traces,
             # internal URLs, and SQL strings should not reach the client.
-            logger.error(
-                f"chat turn stream for session {session_id} crashed: {exc}",
-                exc_info=True,
+            # NOTE: loguru — never pass ``exc_info=True`` (any kwarg makes
+            # loguru re-``.format()`` the message, and provider error text
+            # routinely contains ``{...}`` JSON → KeyError from inside the
+            # logging call, killing this generator mid-stream).
+            logger.exception(
+                f"chat turn stream for session {session_id} crashed: {exc}"
             )
             yield format_sse(
                 SSEEvent(

--- a/app/api/routers/breeze_buddy/widget/__init__.py
+++ b/app/api/routers/breeze_buddy/widget/__init__.py
@@ -4,6 +4,7 @@ Routes under ``/agent/voice/breeze-buddy/widget``:
 
 - ``POST /widget/session``                              create
 - ``POST /widget/session/{id}/message``                 chat turn (SSE)
+- ``POST /widget/session/{id}/intent``                  typed UI intent (SSE)
 - ``POST /widget/session/{id}/cancel``                  cancel in-flight turn
 - ``POST /widget/session/{id}/context``                 push state/facts (no LLM turn)
 - ``POST /widget/session/{id}/voice/connect``           open voice attachment
@@ -36,6 +37,7 @@ from app.schemas.breeze_buddy.chat import (
     SendChatMessageRequest,
     UpdateWidgetContextRequest,
     UpdateWidgetContextResponse,
+    WidgetIntentRequest,
     WidgetSessionStateResponse,
     WidgetTranscribeResponse,
     WidgetVoiceConnectResponse,
@@ -48,6 +50,7 @@ from .handlers import (
     create_widget_session_handler,
     end_widget_session_handler,
     get_widget_session_state_handler,
+    send_widget_intent_handler,
     send_widget_message_handler,
     transcribe_widget_audio_handler,
     update_widget_context_handler,
@@ -75,6 +78,11 @@ async def widget_get_preflight(session_id: str) -> Response:
 
 @router.options("/session/{session_id}/message")
 async def widget_message_preflight(session_id: str) -> Response:
+    return options_cors_response()
+
+
+@router.options("/session/{session_id}/intent")
+async def widget_intent_preflight(session_id: str) -> Response:
     return options_cors_response()
 
 
@@ -146,6 +154,27 @@ async def send_widget_message(
     ctx: WidgetSessionContext = Depends(require_widget_session),
 ):
     return await send_widget_message_handler(session_id, req, request, ctx)
+
+
+@router.post(
+    "/session/{session_id}/intent",
+    summary="Serve one typed UI intent (SSE) — dedicated catalog-v2 route",
+)
+async def send_widget_intent(
+    session_id: str,
+    req: WidgetIntentRequest,
+    request: Request,
+    ctx: WidgetSessionContext = Depends(require_widget_session),
+):
+    """Typed component action (RFC-001 §3.3 Stage B).
+
+    Direct intents (cart mutations) execute the whitelisted tool pipeline
+    with no LLM call; agent-turn intents stream a normal chat turn. Both
+    respond with the same SSE stream shape as ``/message``. Unlike
+    ``/message``, DIRECT intents are also accepted while a voice
+    attachment is live.
+    """
+    return await send_widget_intent_handler(session_id, req, request, ctx)
 
 
 @router.post(

--- a/app/api/routers/breeze_buddy/widget/handlers.py
+++ b/app/api/routers/breeze_buddy/widget/handlers.py
@@ -29,11 +29,20 @@ from app.ai.voice.agents.breeze_buddy.chat.client_context import (
     ClientContextTooLarge,
     compute_context_patch,
 )
+from app.ai.voice.agents.breeze_buddy.chat.turn_core import (
+    negotiate_catalog,
+    resolve_session_catalog_version,
+)
 from app.ai.voice.agents.breeze_buddy.services.daily.daily import (
     daily_completion_function,
     start_daily_session,
 )
 from app.ai.voice.agents.breeze_buddy.template.cache import get_template_by_id_cached
+from app.ai.voice.agents.breeze_buddy.template.ui_catalog import (
+    CATALOG_VERSION,
+    CATALOG_VERSION_V2,
+    LAZY_GROUPS,
+)
 from app.ai.voice.stt import TranscriptionError, transcribe_audio
 from app.api.routers.breeze_buddy.chat.handlers import (
     approve_chat_tool_handler,
@@ -42,6 +51,7 @@ from app.api.routers.breeze_buddy.chat.handlers import (
     end_chat_session_handler,
     load_chat_session_or_404,
     send_chat_message_handler,
+    serve_session_intent,
     validate_template_for_chat,
 )
 from app.api.routers.breeze_buddy.widget_common import (
@@ -91,11 +101,13 @@ from app.schemas.breeze_buddy.chat import (
     CreateChatSessionRequest,
     CreateWidgetSessionRequest,
     CreateWidgetSessionResponse,
+    GreetingTileWire,
     QuickReplyWire,
     SendChatMessageRequest,
     UpdateWidgetContextRequest,
     UpdateWidgetContextResponse,
     WidgetChannel,
+    WidgetIntentRequest,
     WidgetSessionStateResponse,
     WidgetTranscribeResponse,
     WidgetVoiceConnectResponse,
@@ -152,16 +164,17 @@ def _is_redirect_action(action: object) -> bool:
 
 def _extract_widget_config(
     template: object,
-) -> tuple[List[QuickReplyWire], bool]:
-    """Extract quick-reply options and enable_text_input flag from a template.
+) -> tuple[List[QuickReplyWire], bool, List[GreetingTileWire]]:
+    """Extract quick replies, enable_text_input, and greeting tiles from a
+    template.
 
-    Returns a ``(quick_replies, enable_text_input)`` tuple. Reads directly
-    from ``configurations.quick_replies`` and ``configurations.enable_text_input``;
-    both default to ``([], True)`` when the template defines neither.
+    Returns a ``(quick_replies, enable_text_input, greeting_tiles)`` tuple.
+    Reads directly from the template's ``configurations``; defaults to
+    ``([], True, [])`` when unset.
     """
     configurations = getattr(template, "configurations", None)
     if configurations is None:
-        return [], True
+        return [], True, []
     quick_replies: List[QuickReplyWire] = [
         QuickReplyWire(
             label=qr.label,
@@ -181,7 +194,11 @@ def _extract_widget_config(
         for qr in (getattr(configurations, "quick_replies", None) or [])
     ]
     enable_text_input: bool = getattr(configurations, "enable_text_input", True)
-    return quick_replies, enable_text_input
+    greeting_tiles: List[GreetingTileWire] = [
+        GreetingTileWire(label=t.label, prompt=t.prompt, image_url=t.image_url)
+        for t in (getattr(configurations, "greeting_tiles", None) or [])
+    ]
+    return quick_replies, enable_text_input, greeting_tiles
 
 
 def _template_voice_enabled(template: object) -> bool:
@@ -229,6 +246,12 @@ async def create_widget_session_handler(
     # Chat is the entry channel; voice opt-in is checked at /voice/connect.
     validate_template_for_chat(template)
 
+    # Catalog-version negotiation (RFC-001 §3.4): active = client-requested
+    # ∩ template-capable. The NEGOTIATED version (not the client's raw ask)
+    # is what gets persisted — so a v2 embed on a data-bound-free template
+    # runs a clean v1 session instead of a v2 session that can never emit.
+    catalog_active, ui_flavors = negotiate_catalog(template, body.catalog_version)
+
     synthetic_user = _synthetic_widget_user(cfg.id)
     create_req = CreateChatSessionRequest(
         template_id=cfg.template_id,
@@ -241,6 +264,15 @@ async def create_widget_session_handler(
             "widget": {
                 "widget_config_id": cfg.id,
                 "public_widget_key_prefix": cfg.public_widget_key[:6],
+                # Stored on the server-owned widget block so client metadata
+                # can't spoof it; ChatAgent + the intent router gate every v2
+                # behavior (data-bound prompt section, show-op hydration,
+                # ui_intent bodies) on this persisted value.
+                **(
+                    {"catalog_version": catalog_active}
+                    if catalog_active == CATALOG_VERSION_V2
+                    else {}
+                ),
             },
         },
     )
@@ -254,7 +286,7 @@ async def create_widget_session_handler(
         ttl_minutes=DEFAULT_WIDGET_TOKEN_TTL_MINUTES,
     )
 
-    quick_replies, enable_text_input = _extract_widget_config(template)
+    quick_replies, enable_text_input, greeting_tiles = _extract_widget_config(template)
 
     return CreateWidgetSessionResponse(
         session_id=create_resp.session_id,
@@ -266,8 +298,11 @@ async def create_widget_session_handler(
         widget_token=widget_token,
         ttl_seconds=DEFAULT_WIDGET_TOKEN_TTL_MINUTES * 60,
         quick_replies=quick_replies,
+        greeting_tiles=greeting_tiles,
         enable_text_input=enable_text_input,
         voice_enabled=_template_voice_enabled(template),
+        catalog_active=catalog_active,
+        ui_flavors=ui_flavors,
     )
 
 
@@ -324,7 +359,72 @@ async def send_widget_message_handler(
             ),
         )
 
+    # Typed UI intent body (RFC-001 §3.3): validate + policy-route BEFORE
+    # any LLM involvement. Legacy body variant — new embeds POST the
+    # dedicated /intent route; both funnel into serve_session_intent.
+    if req.ui_intent is not None:
+        return await serve_session_intent(
+            session, session_id, req.ui_intent, context=req.context
+        )
+
     return await send_chat_message_handler(session_id, req, access_check=None)
+
+
+# ---------------------------------------------------------------------------
+# POST /widget/session/{id}/intent
+# ---------------------------------------------------------------------------
+
+
+async def send_widget_intent_handler(
+    session_id: str,
+    req: WidgetIntentRequest,
+    request: Request,
+    ctx: WidgetSessionContext,
+):
+    """Serve one typed UI intent on the dedicated route (SSE response).
+
+    Same gate order as ``send_widget_message_handler`` (config-active 401 →
+    IP limit → ownership → 410 ENDED → 409 voice-live), then the shared
+    validate + policy-route path. Rides the same "message" rate bucket —
+    an intent is a turn, not a side channel.
+    """
+    cfg = await get_widget_config_by_id(ctx.widget_config_id)
+    if cfg is None or not cfg.active:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Widget configuration not found or inactive",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    await enforce_widget_ip_limit(
+        request=request,
+        bucket="message",
+        limit=cfg.max_messages_per_ip_hour,
+        widget_config_id=cfg.id,
+    )
+
+    session = await get_chat_session_by_id(session_id)
+    if session is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Widget session '{session_id}' not found",
+        )
+    assert_widget_session_ownership(session, ctx)
+    if session.status == ChatSessionStatus.ENDED:
+        raise HTTPException(
+            status_code=status.HTTP_410_GONE,
+            detail=f"Widget session '{session_id}' has ended",
+        )
+
+    # NO channel gate here (unlike /message): DIRECT intents are legal
+    # during a live voice attachment — serve_session_intent 409s only the
+    # AGENT_TURN routes when voice is live.
+    return await serve_session_intent(
+        session,
+        session_id,
+        req.as_ui_intent(),
+        voice_live=session.current_channel != WidgetChannel.CHAT,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -833,10 +933,11 @@ async def voice_connect_handler(
         try:
             session_info = await start_daily_session(lead_id, enable_recording=False)
         except Exception as exc:
-            logger.error(
+            # loguru: no ``exc_info`` kwarg — it would re-format the message
+            # and crash on brace-bearing provider error text.
+            logger.exception(
                 f"widget voice: start_daily_session failed for lead {lead_id}: "
-                f"{exc}",
-                exc_info=True,
+                f"{exc}"
             )
             # Rollback channel back to CHAT so the user can retry.
             try:
@@ -1026,7 +1127,7 @@ async def get_widget_session_state_handler(
     messages: List[ChatMessage] = await list_chat_messages_for_session(session_id)
 
     template = await get_template_by_id_cached(session.template_id)
-    quick_replies, enable_text_input = _extract_widget_config(template)
+    quick_replies, enable_text_input, greeting_tiles = _extract_widget_config(template)
 
     template_vars: Dict[str, Any] = (
         session.metadata.get("template_vars", {})
@@ -1048,6 +1149,19 @@ async def get_widget_session_state_handler(
     # cards after a reload (lazy expiry — the accessor filters expires_at).
     pending_approvals = await list_pending_tool_approvals(session_id)
 
+    # The persisted (negotiated-at-create) catalog version is the truth on
+    # resume; the flavor list is re-derived from the template so a config
+    # change between create and reload is reflected.
+    catalog_active = (
+        resolve_session_catalog_version(session.metadata) or CATALOG_VERSION
+    )
+    ui_flavors: List[str] = []
+    if catalog_active == CATALOG_VERSION_V2:
+        configurations = getattr(template, "configurations", None)
+        ui_cat = getattr(configurations, "ui_catalog", None) if configurations else None
+        enabled_groups = list(ui_cat.enabled_groups or []) if ui_cat is not None else []
+        ui_flavors = [g for g in enabled_groups if g in LAZY_GROUPS]
+
     return WidgetSessionStateResponse(
         session_id=session_id,
         status=session.status,
@@ -1055,8 +1169,11 @@ async def get_widget_session_state_handler(
         current_node=session.current_node,
         messages=messages,
         quick_replies=quick_replies,
+        greeting_tiles=greeting_tiles,
         enable_text_input=enable_text_input,
         voice_enabled=_template_voice_enabled(template),
+        catalog_active=catalog_active,
+        ui_flavors=ui_flavors,
         template_vars=template_vars,
         metadata=session.metadata or {},
         client_context=client_context,

--- a/app/schemas/breeze_buddy/chat.py
+++ b/app/schemas/breeze_buddy/chat.py
@@ -9,7 +9,7 @@ from datetime import datetime
 from enum import Enum
 from typing import Any, Dict, List, Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 from app.ai.voice.agents.breeze_buddy.template.ui_catalog import ActionUnion, Icon
 
@@ -292,9 +292,19 @@ class ClientContextPatch(BaseModel):
 
 
 class SendChatMessageRequest(BaseModel):
-    """Body of ``POST /session/{id}/message``."""
+    """Body of ``POST /session/{id}/message``.
 
-    content: str = Field(..., min_length=1, description="The user's message text.")
+    Two variants: a plain user turn (``content`` required) or a typed UI
+    intent (``ui_intent`` set, ``content`` may be empty — RFC-001 §3.3).
+    """
+
+    content: str = Field(
+        "",
+        description=(
+            "The user's message text. May be empty ONLY when ``ui_intent`` "
+            "is provided."
+        ),
+    )
     context: Optional[ClientContextPatch] = Field(
         None,
         description=(
@@ -303,6 +313,52 @@ class SendChatMessageRequest(BaseModel):
             "atomically with the message instead of a separate /context call."
         ),
     )
+    ui_intent: Optional[Dict[str, Any]] = Field(
+        None,
+        description=(
+            "Typed component action (catalog v2): {intent, component_id, "
+            "payload, display}. Validated + policy-routed server-side by "
+            "chat/intent_router.py — direct intents execute cart tools with "
+            "no LLM turn; agent_turn intents rewrite into a structured user "
+            "message. Kept as an open dict here so the schema layer stays "
+            "decoupled from the router's per-intent models (which own the "
+            "422-typed validation)."
+        ),
+    )
+
+    @model_validator(mode="after")
+    def _require_content_or_intent(self) -> "SendChatMessageRequest":
+        # Preserves the historical min_length=1 contract for plain turns
+        # while allowing the RFC-001 `{"content":"", "ui_intent":{…}}` body.
+        if not self.content and self.ui_intent is None:
+            raise ValueError("content must be non-empty unless ui_intent is set")
+        return self
+
+
+class WidgetIntentRequest(BaseModel):
+    """Body of ``POST /widget/session/{id}/intent`` — the dedicated typed
+    intent route (RFC-001 §3.3 Stage B). The intent fields ride at the top
+    level (no ``content`` wrapper); per-intent payload validation happens in
+    ``chat/intent_router.py``, which owns the typed 422 contract. The legacy
+    ``/message`` ``ui_intent`` body variant remains accepted for older
+    embeds.
+    """
+
+    intent: str = Field(..., min_length=1, max_length=64)
+    component_id: str = Field(..., min_length=1, max_length=128)
+    payload: Dict[str, Any] = Field(default_factory=dict)
+    display: Optional[str] = Field(None, max_length=500)
+
+    def as_ui_intent(self) -> Dict[str, Any]:
+        """The dict shape ``parse_ui_intent`` validates — one wire model."""
+        body: Dict[str, Any] = {
+            "intent": self.intent,
+            "component_id": self.component_id,
+            "payload": self.payload,
+        }
+        if self.display is not None:
+            body["display"] = self.display
+        return body
 
 
 class GetChatSessionResponse(BaseModel):
@@ -421,6 +477,18 @@ class CreateDemoSessionResponse(BaseModel):
     greeting: Optional[GreetingMessage] = None
     demo_token: str = Field(..., description="Bearer token for follow-up calls.")
     message_cap: int = Field(..., description="Max assistant turns before 429.")
+    catalog_active: str = Field(
+        "v1",
+        description=(
+            "Negotiated UI catalog version — 'v2' when the demo template "
+            "enables data-bound components (demo pages always run a "
+            "v2-capable widget build, so the template is the only variable)."
+        ),
+    )
+    ui_flavors: List[str] = Field(
+        default_factory=list,
+        description="Lazy UI flavor groups the demo template enables.",
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -449,6 +517,17 @@ class CreateWidgetSessionRequest(BaseModel):
     metadata: Dict[str, Any] = Field(
         default_factory=dict,
         description="Opaque caller context, persisted on chat_session.metadata.",
+    )
+    catalog_version: Optional[str] = Field(
+        None,
+        description=(
+            "UI catalog version the embed supports (RFC-001 §3.4). 'v2' "
+            "enables data-bound components (show-op hydration + typed "
+            "intents) for this session; absent/other = v1 (server prunes "
+            "data-bound components — prompt and wire stay v1-compatible). "
+            "Persisted on chat_session.metadata under the server-owned "
+            "'widget' block."
+        ),
     )
 
 
@@ -487,6 +566,18 @@ class QuickReplyWire(BaseModel):
     )
 
 
+class GreetingTileWire(BaseModel):
+    """One visual quick-tap tile on the greeting screen (2026-08-03).
+
+    Mirrors ``GreetingTileOption`` from the template ``ConfigurationModel``
+    — image-backed sibling of the quick-reply pill. Tapping sends
+    ``prompt`` to the agent; ``label`` is the visible bubble text."""
+
+    label: str = Field(..., description="Tile caption shown to the user.")
+    prompt: str = Field(..., description="Message sent to the agent on tap.")
+    image_url: str = Field(..., description="Tile image URL (merchant CDN).")
+
+
 class CreateWidgetSessionResponse(BaseModel):
     """Body of ``POST /widget/session``.
 
@@ -512,6 +603,14 @@ class CreateWidgetSessionResponse(BaseModel):
             "Empty list when the template defines no quick replies."
         ),
     )
+    greeting_tiles: List[GreetingTileWire] = Field(
+        default_factory=list,
+        description=(
+            "Visual quick-tap tiles from configurations.greeting_tiles — "
+            "shown on the greeting screen below the initial greeting. "
+            "Empty list when the template defines none."
+        ),
+    )
     enable_text_input: bool = Field(
         True,
         description=(
@@ -528,6 +627,26 @@ class CreateWidgetSessionResponse(BaseModel):
             "'voice' is in the template's supported_channels (the same gate "
             "/voice/connect enforces). The embed shows the voice-mode button "
             "only when True; the server stays the enforcement point."
+        ),
+    )
+    catalog_active: str = Field(
+        "v1",
+        description=(
+            "The NEGOTIATED UI catalog version for this session (RFC-001 "
+            "§3.4): the intersection of what the client requested "
+            "(catalog_version in the create body) and what the template's "
+            "ui_catalog config can serve (data-bound components enabled). "
+            "'v2' ⇔ show-op hydration + typed intents are live; the embed "
+            "should eagerly preload the ui_flavors chunks."
+        ),
+    )
+    ui_flavors: List[str] = Field(
+        default_factory=list,
+        description=(
+            "Lazy UI flavor groups the template enables (e.g. ['commerce']) "
+            "— the embed preloads these code-split chunks so the first "
+            "hydrated component renders without a chunk-fetch stall. Empty "
+            "when catalog_active is 'v1'."
         ),
     )
 
@@ -617,6 +736,14 @@ class WidgetSessionStateResponse(BaseModel):
             "Empty list when the template defines no quick replies."
         ),
     )
+    greeting_tiles: List[GreetingTileWire] = Field(
+        default_factory=list,
+        description=(
+            "Visual quick-tap tiles from configurations.greeting_tiles — "
+            "shown on the greeting screen below the initial greeting. "
+            "Empty list when the template defines none."
+        ),
+    )
     enable_text_input: bool = Field(
         True,
         description=(
@@ -632,6 +759,22 @@ class WidgetSessionStateResponse(BaseModel):
             "Whether this merchant's template offers a voice mode — i.e. "
             "'voice' is in the template's supported_channels. Lets the embed "
             "restore the voice-mode button after a reload without re-deriving."
+        ),
+    )
+    catalog_active: str = Field(
+        "v1",
+        description=(
+            "The session's negotiated UI catalog version (persisted at "
+            "create time) — same semantics as the create response's "
+            "catalog_active, re-echoed so a reloaded embed can restore "
+            "intent affordances and preload flavor chunks."
+        ),
+    )
+    ui_flavors: List[str] = Field(
+        default_factory=list,
+        description=(
+            "Lazy UI flavor groups the template enables. Mirrors the create "
+            "response so the resume path preloads the same chunks."
         ),
     )
     template_vars: Dict[str, Any] = Field(default_factory=dict)

--- a/tests/test_quick_reply_redirect.py
+++ b/tests/test_quick_reply_redirect.py
@@ -138,7 +138,7 @@ def _template_with_quick_replies(options):
 
 def test_handler_message_pill_falls_back_to_label():
     template = _template_with_quick_replies([QuickReplyOption(label="Track my order")])
-    replies, enable_text_input = _extract_widget_config(template)
+    replies, enable_text_input, _tiles = _extract_widget_config(template)
     assert enable_text_input is True
     assert replies[0].value == "Track my order"  # label fallback
     assert replies[0].action is None
@@ -156,7 +156,7 @@ def test_handler_redirect_pill_has_null_value_and_passes_action():
             )
         ]
     )
-    replies, _ = _extract_widget_config(template)
+    replies, _, _tiles = _extract_widget_config(template)
     # Redirect pills don't message the agent — value is always None.
     assert replies[0].value is None
     assert isinstance(replies[0].action, OpenUrlAction)
@@ -164,7 +164,11 @@ def test_handler_redirect_pill_has_null_value_and_passes_action():
 
 
 def test_handler_no_configurations_returns_defaults():
-    assert _extract_widget_config(SimpleNamespace(configurations=None)) == ([], True)
+    assert _extract_widget_config(SimpleNamespace(configurations=None)) == (
+        [],
+        True,
+        [],
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -213,7 +217,7 @@ def test_handler_passes_icon_through_for_message_pill():
             )
         ]
     )
-    replies, _ = _extract_widget_config(template)
+    replies, _, _tiles = _extract_widget_config(template)
     # Icon is presentational — it survives regardless of value/action.
     assert replies[0].value == "Show me what's on sale"
     assert isinstance(replies[0].icon, Icon)
@@ -230,7 +234,7 @@ def test_handler_passes_icon_through_for_redirect_pill():
             )
         ]
     )
-    replies, _ = _extract_widget_config(template)
+    replies, _, _tiles = _extract_widget_config(template)
     assert replies[0].value is None  # redirect pill
     assert isinstance(replies[0].icon, Icon)
     assert replies[0].icon.alt == "My account"
@@ -238,5 +242,5 @@ def test_handler_passes_icon_through_for_redirect_pill():
 
 def test_handler_pill_without_icon_emits_none():
     template = _template_with_quick_replies([QuickReplyOption(label="Track my order")])
-    replies, _ = _extract_widget_config(template)
+    replies, _, _tiles = _extract_widget_config(template)
     assert replies[0].icon is None

--- a/tests/test_turn_sse_stream_errors.py
+++ b/tests/test_turn_sse_stream_errors.py
@@ -1,0 +1,83 @@
+"""Regression tests for ``_turn_sse_stream``'s crash path.
+
+The 2026-07-28 live incident: the agent's turn raised a Gemini
+``ClientError`` whose text contains a brace dict (``{'message': ...}``).
+The except-branch's ``logger.error(..., exc_info=True)`` call — a loguru
+misuse: any kwarg makes loguru re-``.format()`` the message — then raised
+KeyError from INSIDE the logging call, killing the generator before the
+graceful ``error`` + ``turn_end FAILED`` frames went out. The client saw
+a raw aborted stream ("network error" / turn_exception) instead of the
+designed degradation.
+"""
+
+import json
+import time
+from typing import cast
+
+import pytest
+
+import app.api.routers.breeze_buddy.chat.handlers as ch
+from app.ai.voice.agents.breeze_buddy.chat.metrics import TurnMetrics
+from app.services.redis.locks import RedisLock
+
+
+class _StubLock:
+    def __init__(self):
+        self.released = False
+
+    async def release(self):
+        self.released = True
+
+
+def _parse_frames(chunks):
+    """format_sse output → list of (event, data-dict)."""
+    frames = []
+    for chunk in chunks:
+        event = None
+        data = None
+        for line in chunk.strip().splitlines():
+            if line.startswith("event:"):
+                event = line.split(":", 1)[1].strip()
+            elif line.startswith("data:"):
+                data = json.loads(line.split(":", 1)[1].strip())
+        frames.append((event, data))
+    return frames
+
+
+@pytest.mark.asyncio
+async def test_brace_bearing_exception_still_yields_graceful_frames(monkeypatch):
+    """An exception whose str contains ``{'message': ...}`` (every Gemini
+    API error) must produce the masked ``error`` frame + ``turn_end
+    FAILED`` — not crash the generator from inside logging."""
+
+    async def _persist_noop(_metrics):
+        return None
+
+    monkeypatch.setattr(ch, "_persist_turn_metrics", _persist_noop)
+
+    async def exploding_events():
+        yield ch.SSEEvent(event="assistant_token", data={"text": "hi"})
+        raise RuntimeError(
+            "400 Bad Request. {'message': '{\"error\": {\"code\": 400}}', "
+            "'status': 'Bad Request'}"
+        )
+
+    lock = _StubLock()
+    metrics = TurnMetrics(session_id="sess-test", template_id=None, t0=time.monotonic())
+    chunks = [
+        chunk
+        async for chunk in ch._turn_sse_stream(
+            session_id="sess-test",
+            lock=cast(RedisLock, lock),
+            turn_metrics=metrics,
+            events=exploding_events(),
+        )
+    ]
+    frames = _parse_frames(chunks)
+    assert frames[0] == ("assistant_token", {"text": "hi"})
+    assert frames[1][0] == "error"
+    # Provider internals must be masked, not leaked.
+    assert frames[1][1] == {"code": "internal", "message": "Internal server error"}
+    assert frames[2] == ("turn_end", {"session_status": "FAILED"})
+    assert metrics.status == "FAILED"
+    assert lock.released


### PR DESCRIPTION
- intent_router (new): the generic ui_intent engine — per-intent
  policies (DIRECT / AGENT_TURN / CLIENT), direct dispatch persistence,
  reducer patches, and post-turn followup hooks. Flavors register
  policies at import via a lazy string registry; the 'commerce' entry
  stays dormant until the flavor package lands in the next layer.
- chat handlers: ui_intent route, turn-metrics persistence, graceful SSE
  error frames (brace-bearing exceptions can no longer crash the stream
  mid-generator); demo + cancel_bus plumbing.
- widget handlers + schemas: widget config wire — quick replies,
  enable_text_input, and greeting tiles (visual quick-taps) on BOTH the
  create-session and widget-state responses.

Tests: quick-reply redirect (config extract triple), SSE stream errors.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01JtrUcWv8oqFfZpiQourEGU

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JtrUcWv8oqFfZpiQourEGU
