### PR TITLE
(fix): add language thinking and other params for gemini live

### DIFF
--- a/app/ai/voice/agents/breeze_buddy/agent/__init__.py
+++ b/app/ai/voice/agents/breeze_buddy/agent/__init__.py
@@ -123,6 +123,7 @@ from app.ai.voice.agents.breeze_buddy.utils.transport.websockets import (
     close_websocket_safely,
 )
 from app.ai.voice.agents.breeze_buddy.utils.warm_transfer import set_transfer_flag
+from app.ai.voice.llm.realtime.gemini_realtime import has_realtime_llm
 from app.core.config.dynamic import BB_DAILY_AUDIO_OUT_10MS_CHUNKS
 from app.core.config.static import ENABLE_BREEZE_BUDDY_TRACING
 from app.core.logger import logger
@@ -719,8 +720,15 @@ class Agent:
         self.greeting_source = greeting_result.source
         self.greeting_text = greeting_result.text
 
-        # Start post-greeting idle timer if greeting was sent
-        if self.greeting_source and self.configurations:
+        # Realtime LLMs use server-side turn detection plus the pipeline's
+        # UserIdleController. Their user-turn events can arrive after speech
+        # begins, so this separate wall-clock timer could expire mid-response
+        # and trigger a false idle recovery or reconnect.
+        if (
+            self.greeting_source
+            and self.configurations
+            and not has_realtime_llm(self.configurations.llm_configurations)
+        ):
             user_idle_config = getattr(
                 self.configurations, "user_idle_configuration", None
             )
@@ -1101,9 +1109,14 @@ class Agent:
             self.greeting_source = greeting_result.source
             self.greeting_text = greeting_result.text
 
-            # Mirror telephony: start post-greeting idle timer so the bot
-            # re-engages if the user stays silent after the greeting.
-            if self.greeting_source and self.configurations:
+            # Mirror the telephony fallback for non-realtime pipelines.
+            # Realtime LLMs rely on server-side turn detection and the
+            # UserIdleController to avoid the timer race described above.
+            if (
+                self.greeting_source
+                and self.configurations
+                and not has_realtime_llm(self.configurations.llm_configurations)
+            ):
                 user_idle_config = getattr(
                     self.configurations, "user_idle_configuration", None
                 )

--- a/app/ai/voice/agents/breeze_buddy/agent/utils.py
+++ b/app/ai/voice/agents/breeze_buddy/agent/utils.py
@@ -63,6 +63,10 @@ async def send_initial_greeting(
             template=template,
             provider=provider,
         )
+        if greeting_result and greeting_result.get("skipped"):
+            # Intentional no-playback (dial_tone disabled for a realtime LLM that
+            # speaks first). Not a failure — skip media send + error tracking.
+            return GreetingResult(source=None, text=None)
         if not greeting_result:
             logger.warning("Failed to prepare greeting payload, skipping initial audio")
             track_error(

--- a/app/ai/voice/agents/breeze_buddy/template/field_reference.json
+++ b/app/ai/voice/agents/breeze_buddy/template/field_reference.json
@@ -209,6 +209,7 @@
       "description": "Browser-side (Daily Krisp) noise cancellation for web voice sessions. null/true = ON (platform default), false = opt out. Returned to web clients on the /connect response as `noise_cancellation`; echo cancellation is always forced client-side and has no knob.",
       "example": false
     },
+    "dial_tone":                  { "description": "Whether to play the dial-tone fallback when no initial greeting audio is cached. true (default) keeps legacy behaviour — a short dial tone plays so the caller knows the line is live. Set false for speech-to-speech realtime LLMs (e.g. Gemini Live): with no cached greeting, nothing plays out-of-band and the realtime LLM speaks first, avoiding the dial tone colliding with its opening response.", "example": false },
     "keyword_filter": {
       "description": "Suppresses short STT filler transcriptions (e.g. 'hmm', 'ok') produced while the bot is speaking, preventing false interruption triggers.",
       "example": {

--- a/app/ai/voice/agents/breeze_buddy/template/types.py
+++ b/app/ai/voice/agents/breeze_buddy/template/types.py
@@ -2034,6 +2034,18 @@ class ConfigurationModel(BaseModel):
             "cancellation itself is always forced client-side and has no knob."
         ),
     )
+    dial_tone: bool = Field(
+        True,
+        description=(
+            "Whether to play the dial-tone fallback when no initial greeting "
+            "audio is cached. True (default) preserves legacy behaviour — a "
+            "short dial tone plays so the caller knows the line is live. Set "
+            "False for speech-to-speech realtime LLMs (e.g. Gemini Live) so "
+            "that, when no greeting is cached, nothing plays out-of-band and "
+            "the realtime LLM speaks first (avoids the dial tone colliding "
+            "with the LLM's opening response)."
+        ),
+    )
     keyword_filter: Optional[KeywordFilterConfig] = Field(
         None,
         description="Keyword filter to suppress specific transcriptions while bot is active",

--- a/app/ai/voice/agents/breeze_buddy/utils/common.py
+++ b/app/ai/voice/agents/breeze_buddy/utils/common.py
@@ -480,8 +480,26 @@ async def prepare_initial_greeting_payload(
                         f"Deleted dynamic greeting from Redis for lead {lead.id}"
                     )
 
-        # 3. Fall back to dial tone if no greeting audio found
+        # 3. Fall back to dial tone if no greeting audio found.
+        # Gated by configurations.dial_tone (default True). Realtime
+        # (speech-to-speech) LLMs set it False so that, with no cached greeting,
+        # nothing plays out-of-band and the LLM speaks first.
         if not mulaw_data:
+            configs = template.configurations if template else None
+            dial_tone_enabled = getattr(configs, "dial_tone", True) if configs else True
+            if not dial_tone_enabled:
+                logger.info(
+                    "No greeting audio found and dial_tone disabled; playing "
+                    "nothing (LLM will speak first)"
+                )
+                # Distinct from a failure (None): callers must treat this as an
+                # intentional no-playback, not an error.
+                return {
+                    "payload": None,
+                    "greeting_source": None,
+                    "greeting_text": None,
+                    "skipped": True,
+                }
             logger.info("No greeting audio found, using dial tone")
             wav_file_path = (
                 "app/ai/voice/agents/breeze_buddy/static/audio/dial-tone.wav"

--- a/app/ai/voice/llm/realtime/factory.py
+++ b/app/ai/voice/llm/realtime/factory.py
@@ -148,11 +148,17 @@ async def get_realtime_llm_service(llm_config: LLMConfiguration) -> Any:
             api_key=api_key,
             model=realtime.model or DEFAULT_GEMINI_REALTIME_MODEL,
             voice=realtime.voice,
+            language=realtime.language,
+            thinking_level=realtime.thinking_level,
+            silence_duration_ms=realtime.silence_duration_ms,
             function_call_timeout_secs=function_call_timeout,
         )
         logger.info(
             f"Resolving Gemini Live LLM service: model={gemini_config.model}, "
-            f"voice={gemini_config.voice or 'default'}"
+            f"voice={gemini_config.voice or 'default'}, "
+            f"language={gemini_config.language or 'auto'}, "
+            f"thinking_level={gemini_config.thinking_level or 'default'}, "
+            f"silence_duration_ms={gemini_config.silence_duration_ms or 'default'}"
         )
         return build_gemini_realtime_llm(gemini_config)
 

--- a/app/ai/voice/llm/realtime/gemini_realtime.py
+++ b/app/ai/voice/llm/realtime/gemini_realtime.py
@@ -1,14 +1,14 @@
 """Google Gemini Live (voice-to-voice) realtime LLM builder.
 
 Wraps pipecat's ``GeminiLiveLLMService`` (Gemini Developer API) with the glue
-needed to construct it from BB's ``LLMConfiguration``. The service handles
-audio in/out, transcription, turn detection, and function calling natively;
-no separate STT or TTS service is wired into the pipeline when this is in use.
+to construct it from BB's ``LLMConfiguration``.
+The service handles audio in/out, transcription, turn detection, and function
+calling natively; no separate STT or TTS service is wired into the pipeline
+when this is in use.
 
-The model id on ``RealtimeConfig.model`` selects the model. Developer-API
-native-audio previews are used (server-side VAD handles turn detection), e.g.
-``gemini-2.5-flash-native-audio-preview-12-2025`` and
-``gemini-3.1-flash-live-preview``.
+The model id on ``RealtimeConfig.model`` selects the model. Production uses
+``gemini-3.1-flash-live-preview`` (Developer API; server-side VAD handles turn
+detection), which is also the default when a template omits the model field.
 
 As with the other realtime providers, ``system_instruction`` and ``tools`` are
 NOT set here — pipecat-flows' FlowManager pushes them via frames after the
@@ -18,17 +18,25 @@ pipeline starts, and the Gemini Live service reconnects to register them.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Optional
+from typing import Any, Optional
 
-from pipecat.services.google.gemini_live.llm import GeminiLiveLLMService
+from google.genai.types import ThinkingConfig
+from pipecat.services.google.gemini_live.llm import (
+    GeminiLiveLLMService,
+    GeminiVADParams,
+)
 
 from app.core.logger import logger
 
-__all__ = ["GeminiRealtimeConfig", "build_gemini_realtime_llm"]
+__all__ = [
+    "GeminiRealtimeConfig",
+    "build_gemini_realtime_llm",
+    "has_realtime_llm",
+]
 
-# Default model — the Developer-API 2.5 native-audio preview. Used when a
-# template omits the model field.
-DEFAULT_GEMINI_REALTIME_MODEL = "gemini-2.5-flash-native-audio-preview-12-2025"
+# Default model — Gemini 3.1 Flash Live (Developer API). This is the only
+# realtime model used in production; templates may override via realtime.model.
+DEFAULT_GEMINI_REALTIME_MODEL = "gemini-3.1-flash-live-preview"
 
 # Default voice — a neutral Gemini prebuilt voice. Templates can override via
 # ``realtime.voice``.
@@ -42,17 +50,54 @@ class GeminiRealtimeConfig:
     api_key: str
     model: str = DEFAULT_GEMINI_REALTIME_MODEL
     voice: Optional[str] = None
+    language: Optional[str] = None
+    thinking_level: Optional[str] = None
+    silence_duration_ms: Optional[int] = None
     function_call_timeout_secs: float = 10.0
 
 
 def build_gemini_realtime_llm(config: GeminiRealtimeConfig) -> GeminiLiveLLMService:
-    """Create a GeminiLiveLLMService (Developer API) instance."""
+    """Create a ``GeminiLiveLLMService`` (Developer API) instance."""
     voice = config.voice or DEFAULT_GEMINI_REALTIME_VOICE
     logger.info(
-        f"Building Gemini Live realtime LLM: model={config.model}, voice={voice}"
+        f"Building Gemini Live realtime LLM: model={config.model}, voice={voice}, "
+        f"language={config.language or 'auto'}, "
+        f"thinking_level={config.thinking_level or 'default'}, "
+        f"silence_duration_ms={config.silence_duration_ms or 'default'}"
     )
+    # All optional params are passed conditionally: unset → pipecat/Gemini
+    # defaults apply. Settings.language's type disallows None; thinking and vad
+    # default to the model's behavior when omitted.
+    settings_kwargs: dict = {"model": config.model, "voice": voice}
+    if config.language:
+        settings_kwargs["language"] = config.language
+    if config.thinking_level:
+        settings_kwargs["thinking"] = ThinkingConfig(
+            thinking_level=config.thinking_level
+        )
+    if config.silence_duration_ms is not None:
+        settings_kwargs["vad"] = GeminiVADParams(
+            silence_duration_ms=config.silence_duration_ms
+        )
     return GeminiLiveLLMService(
         api_key=config.api_key,
-        settings=GeminiLiveLLMService.Settings(model=config.model, voice=voice),
+        settings=GeminiLiveLLMService.Settings(**settings_kwargs),
         function_call_timeout_secs=config.function_call_timeout_secs,
     )
+
+
+def has_realtime_llm(llm_config: Any) -> bool:
+    """True when the template uses a speech-to-speech realtime LLM.
+
+    Realtime LLMs (e.g. Gemini Live) run STT/TTS/turn-detection server-side,
+    so BB does not receive a reliable user-turn-start event at speech onset.
+    The agent-owned post-greeting timer can therefore race a short reply and
+    force a realtime reconnect that drops in-flight audio. The realtime LLM
+    listens continuously and needs no separate wall-clock timer, so this extra
+    timer is skipped.
+
+    Args:
+        llm_config: The ``LLMConfiguration`` (``configurations.llm_configurations``);
+            ``None`` when unset.
+    """
+    return bool(llm_config and llm_config.realtime is not None)

--- a/app/ai/voice/llm/types.py
+++ b/app/ai/voice/llm/types.py
@@ -59,6 +59,30 @@ class RealtimeConfig(BaseModel):
         "(e.g. 'alloy', 'echo' for OpenAI; 'Ara', 'Rex' for xAI). "
         "Falls back to the provider service's default when unset.",
     )
+    language: Optional[str] = Field(
+        None,
+        description="BCP-47 language code for realtime audio output (e.g. 'hi' "
+        "Hindi, 'ta' Tamil, 'hi-IN'). Sent to Gemini Live as "
+        "speechConfig.languageCode on the wire whenever set; native-audio "
+        "models (2.5) auto-detect and ignore it, non-native-audio Live models "
+        "(e.g. gemini-3.1-flash-live-preview) may honor it — undocumented, "
+        "confirm with a live test. Not used by OpenAI/xAI/Azure.",
+    )
+    thinking_level: Optional[str] = Field(
+        None,
+        description="Gemini 3.x Live reasoning level: 'minimal', 'low', "
+        "'medium', or 'high' (3.1-flash-live defaults to 'minimal' for lowest "
+        "latency). Only applied when set; otherwise the model default applies. "
+        "Gemini 2.5 native-audio uses thinking_budget and ignores this. "
+        "Not used by OpenAI/xAI/Azure.",
+    )
+    silence_duration_ms: Optional[int] = Field(
+        None,
+        description="Gemini Live server-side VAD end-of-speech threshold in "
+        "milliseconds (how long a pause ends the user's turn; 3.1-flash-live "
+        "recommends 500–800ms). Only applied when set; otherwise Gemini's "
+        "server-side VAD default applies. Not used by OpenAI/xAI/Azure.",
+    )
     endpoint: Optional[str] = Field(
         None,
         description="Provider-specific endpoint URL override (currently used "

--- a/docs/GEMINI_LIVE.md
+++ b/docs/GEMINI_LIVE.md
@@ -1,0 +1,158 @@
+# Gemini Live — production realtime integration
+
+Gemini Live is Breeze Buddy's speech-to-speech **realtime LLM** provider. It runs
+STT + LLM + TTS + turn-detection **server-side** over one persistent WebSocket, so
+the BB pipeline wires a single `GeminiLiveLLMService` in place of the usual
+separate STT → LLM → TTS chain. This is the lowest-latency path for telephony and
+widget voice.
+
+> For the **standalone test harness** (no Pipecat pipeline, mic/speaker against the
+> raw API), see [`GEMINI_LIVE_TEST.md`](./GEMINI_LIVE_TEST.md).
+
+## Where it lives
+
+| Concern | File |
+| --- | --- |
+| Builder (`GeminiRealtimeConfig` → `GeminiLiveLLMService`) | `app/ai/voice/llm/realtime/gemini_realtime.py` |
+| Provider factory (resolves api key, forwards params) | `app/ai/voice/llm/realtime/factory.py` |
+| `RealtimeConfig` fields (provider/model/voice/language/thinking/silence) | `app/ai/voice/llm/types.py` |
+| Pipeline wiring (realtime branch) | `app/ai/voice/agents/breeze_buddy/agent/pipeline.py` (`is_realtime`) |
+| Agent glue (greeting and idle handling) | `app/ai/voice/agents/breeze_buddy/agent/__init__.py` |
+
+Surface: **Gemini Developer API only** (no Vertex in production). Auth via the
+Gemini API key resolved in the factory.
+
+## Model & voice defaults
+
+- Default model: `gemini-3.1-flash-live-preview` (Developer API; server-side VAD).
+  Templates override via `realtime.model`.
+- Default voice: `Kore`. Override via `realtime.voice`.
+
+## Configuration
+
+Set on the template's `configurations.llm_configurations.realtime`:
+
+```jsonc
+"llm_configurations": {
+  "realtime": {
+    "provider": "gemini",
+    "model": "gemini-3.1-flash-live-preview",   // optional; default above
+    "voice": "Kore",                            // optional; default Kore
+    "language": "hi",                           // optional; BCP-47, see note
+    "thinking_level": "minimal",                // optional; minimal|low|medium|high
+    "silence_duration_ms": 600                  // optional; server-side VAD end-of-speech
+  }
+}
+```
+
+### Realtime field reference
+
+- **`model`** — Gemini Live model id. Defaults to `gemini-3.1-flash-live-preview`.
+- **`voice`** — Gemini prebuilt voice name. Defaults to `Kore`.
+- **`language`** — BCP-47 code (`hi`, `ta`, `hi-IN`, …). Sent on the wire only when
+  set. *Caveat:* on the 3.1 live model the effect is undocumented; Hindi output
+  normally comes from the system prompt, not this field. Confirm with a live test.
+- **`thinking_level`** — Gemini 3.x reasoning depth: `minimal` / `low` / `medium` /
+  `high`. 3.1-flash-live defaults to `minimal` for lowest latency. Ignored by 2.5
+  native-audio. **Not validated** today — a typo passes through and fails at the
+  Gemini API on first turn, so set it carefully.
+- **`silence_duration_ms`** — server-side VAD end-of-speech threshold (ms): how long
+  a pause ends the user's turn. **The dominant per-turn latency lever.** Recommend
+  **500–800 ms**. Do **not** go below ~400 — natural Hindi/Hinglish pauses are
+  150–400 ms, so 100–200 ms will cut the caller off mid-sentence and *increase*
+  false interruptions (the opposite of "fewer unnecessary turns"). Unset → Gemini's
+  server-side default.
+
+All four optional fields are forwarded only when set; unset → pipecat/Gemini
+defaults apply (`factory.py` → `gemini_realtime.py`).
+
+## Pipeline topology
+
+```
+transport.input()  →  LLMUserAggregator  →  GeminiLiveLLMService  →  transport.output()  →  assistant_aggregator
+```
+
+No separate STT or TTS service is created (`pipeline.py` realtime branch returns
+`(None, realtime_llm, None)`). Gemini emits transcription + turn-start/stop frames
+from its server-side STT/VAD; the user aggregator's default strategies react to
+those (it is given no custom strategies).
+
+## Noise cancellation (AIC)
+
+Already wired — **no code change needed**. The transport input filter
+(`agent/transport.py`, `get_transport_params`) attaches an `AICFilter` to **every**
+transport (8 kHz model for telephony, 16 kHz for Daily), and the realtime pipeline
+uses that same `transport.input()`. Enable per template:
+
+```jsonc
+"noise_filter": { "enable": true, "provider": "aic", "model": "noise_cancellation" }
+// or "voice_focus" to isolate the foreground speaker
+```
+
+Prerequisites: `BREEZE_BUDDY_AIC_LICENSE_KEY` set and the model file present
+(`transport.py` logs a warning and proceeds without filtering if either is
+missing). AIC adds a small processing cost — weigh against the min-latency goal.
+
+## Greeting behaviour & `dial_tone`
+
+The opening greeting can be played two ways:
+
+1. **Out-of-band** (default when a greeting is cached): BB synthesizes the
+   `initial_greeting` and pushes it directly to the transport (telephony `playAudio`
+   / Daily `OutputAudioRawFrame`). Fast — no wait for Gemini's first token.
+2. **Gemini speaks first**: when no greeting is cached and the realtime LLM should
+   open, Gemini generates the first utterance.
+
+When there is **no cached greeting**, BB historically falls back to a `dial-tone.wav`
+(`utils/common.py`). For realtime that collides with Gemini's own opening response,
+so set:
+
+```jsonc
+"dial_tone": false   // under configurations; default true (legacy)
+```
+
+Effect: no greeting cached + `dial_tone:false` → **nothing** plays out-of-band and
+the realtime LLM speaks first. A cached greeting always plays regardless of this
+flag. (Default `true` preserves legacy behaviour for non-realtime templates.)
+
+> ⚠️ **Known issue (pre-fix):** returning `None` from the greeting-prep skip path is
+> currently treated by `send_initial_greeting` as a *failure* and recorded into
+> `lead.metaData.errors`. So a realtime template with no cached greeting logs a
+> spurious "Failed to prepare greeting payload" error on every call. Fix pending —
+> the skip must be distinguished from a real failure.
+
+## Idle handling
+
+Realtime **skips** the agent-owned post-greeting idle timer
+(`_is_realtime_llm()` guards both telephony and Daily call sites): that wall-clock
+timer raced Gemini's latency-delayed turn-start signal and re-fired "are you
+there?" mid-reply, dropping in-flight audio (the original "not listening" bug).
+
+Realtime instead relies on the aggregator's `on_user_turn_idle`
+(`pipeline.py`, `UserIdleController`).
+
+> ⚠️ **Known gap:** the idle controller arms only on `BotStoppedSpeakingFrame`. The
+> out-of-band telephony greeting emits no such frame, and the initial node does not
+> respond immediately after a pre-played greeting — so a caller who picks up and
+> **stays silent after the greeting** may receive no nudge and no BUSY outcome until
+> the provider's own timeout. Verify with a silent-caller test.
+
+## Latency notes
+
+- **`silence_duration_ms`** is the dominant per-turn lever (see above).
+- The **system prompt + tools are sent once**, at connect/reconnect — not per turn.
+  The ~33 KB prompt is amortized by server-side KV cache; it is not a per-turn cost.
+- The greeting plays **out-of-band for speed**, which means **no barge-in during the
+  greeting** — Gemini can't interrupt a `playAudio`. Speech during the greeting
+  isn't honoured until it ends. (Routing the greeting through Gemini's output would
+  enable barge-in, at the cost of greeting latency.)
+- Verified end-to-end: post-greeting user turn → bot reply at ~0.03 s TTFB (the wait
+  is the VAD `silence_duration_ms`, not the pipeline).
+
+## Open items
+
+- Spurious greeting-prep error on the no-greeting realtime path (see `dial_tone`).
+- Silent-after-greeting idle gap (see Idle handling).
+- No Pydantic validation on `thinking_level` / bounds on `silence_duration_ms`.
+- Undocumented `language` effect on the 3.1 live model.
+- `_is_realtime_llm()` duplicates realtime-detection logic in `pipeline.py` — DRY.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional language selection for Gemini real-time voice interactions.
  * Added configurable thinking levels and silence duration for voice activity detection.
  * Updated the default Gemini real-time model to `gemini-3.1-flash-live-preview`.
  * Added an option to disable fallback dial-tone playback when no greeting audio is available.
  * Improved real-time voice startup so Gemini can begin speaking without duplicating a pre-played greeting.
  * Default provider behavior is preserved when these settings are not specified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->