### PR TITLE
fix: remove blocking calls from the asyncio event loop in telephony paths

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -127,6 +127,23 @@ POSTGRES_POOL_SIZE=5
 POSTGRES_MAX_OVERFLOW=10
 POSTGRES_POOL_RECYCLE=3600
 
+# Worker threads for offloaded blocking SDK calls (Plivo/Twilio/Exotel).
+# Default 48. Raise only if [PHASE] start_recording_background p99 climbs
+# without the provider API itself getting slower.
+#
+# Memory: threads are created LAZILY, so this is a ceiling, not a
+# preallocation — an idle pod holds none. Measured cost is ~37 KB RSS per
+# thread (+1.7 MB if all 48 are ever live at once).
+#
+# This is the loop's DEFAULT executor, so it is shared by every
+# asyncio.to_thread() / run_in_executor(None, ...) caller in the process:
+# Plivo recording, provider.make_call, Twilio conference, bcrypt, Google
+# token verify, GCS uploads, and sync global-function handlers
+# (template/global_function.py). Previously that pool was Python's default
+# of min(32, cpu_count + 4) = 5 threads on a 1-core pod, so raising it
+# relieves contention for all of them rather than adding any.
+BLOCKING_THREAD_POOL_SIZE=48
+
 # AWS Configuration
 SKIP_KMS_DECRYPT=false
 AWS_REGION="us-east-1"

--- a/app/ai/voice/agents/breeze_buddy/dispatch/worker.py
+++ b/app/ai/voice/agents/breeze_buddy/dispatch/worker.py
@@ -474,7 +474,7 @@ class Worker:
                     return
 
             try:
-                call = call_provider.make_call(
+                call = await call_provider.make_call_async(
                     customer_mobile,
                     number.number,
                     reseller_id=locked.reseller_id,

--- a/app/ai/voice/agents/breeze_buddy/handlers/internal/hold_and_consult.py
+++ b/app/ai/voice/agents/breeze_buddy/handlers/internal/hold_and_consult.py
@@ -248,15 +248,11 @@ async def hold_and_consult(
         )
 
         # ── 10. Initiate outbound call (blocking SDK → worker thread) ─────
-        loop = asyncio.get_event_loop()
-        call_result = await loop.run_in_executor(
-            None,
-            lambda: context.telephony_service.make_call(
-                customer_mobile_number=phone_number,
-                telephony_number=telephony_number,
-                reseller_id=outbound_template["reseller_id"],
-                template_name=outbound_template["name"],
-            ),
+        call_result = await context.telephony_service.make_call_async(
+            customer_mobile_number=phone_number,
+            telephony_number=telephony_number,
+            reseller_id=outbound_template["reseller_id"],
+            template_name=outbound_template["name"],
         )
         if not call_result or not call_result.get("sid"):
             subscribe_task.cancel()

--- a/app/ai/voice/agents/breeze_buddy/services/telephony/base_provider.py
+++ b/app/ai/voice/agents/breeze_buddy/services/telephony/base_provider.py
@@ -1,3 +1,4 @@
+import asyncio
 from abc import ABC, abstractmethod
 from typing import Any, Dict, Optional
 
@@ -41,8 +42,8 @@ class VoiceCallProvider(ABC):
         Initiate a call.
 
         This is intentionally synchronous — all provider SDKs (Twilio, Plivo,
-        Exotel) use blocking HTTP clients. The caller should be aware this
-        blocks the event loop briefly.
+        Exotel) use blocking HTTP clients. NEVER call this from an ``async def``:
+        use ``make_call_async`` instead, which offloads it to a worker thread.
 
         Args:
             customer_mobile_number: Phone number to call
@@ -50,6 +51,33 @@ class VoiceCallProvider(ABC):
             reseller_id: Optional merchant ID for tiered pod allocation
             template_name: Optional template name for WebSocket path routing
         """
+
+    async def make_call_async(
+        self,
+        customer_mobile_number: str,
+        telephony_number: str,
+        reseller_id: Optional[str] = None,
+        template_name: Optional[str] = None,
+    ) -> Optional[Dict[str, Any]]:
+        """
+        Await-able wrapper around ``make_call`` that keeps it off the event loop.
+
+        Every provider SDK below this line is synchronous — Plivo and Twilio
+        ship blocking REST clients, Exotel uses ``requests``. Calling
+        ``make_call`` directly from an ``async def`` freezes the single
+        uvicorn worker for the whole provider round-trip (~150-500ms), which
+        with ~20 concurrent dispatch workers starves every inbound answer
+        sharing the loop.
+
+        All callers in async context MUST use this instead of ``make_call``.
+        """
+        return await asyncio.to_thread(
+            self.make_call,
+            customer_mobile_number,
+            telephony_number,
+            reseller_id,
+            template_name,
+        )
 
     def set_completion_callback(self, callback):
         """

--- a/app/ai/voice/agents/breeze_buddy/services/telephony/exotel/exotel.py
+++ b/app/ai/voice/agents/breeze_buddy/services/telephony/exotel/exotel.py
@@ -101,7 +101,16 @@ class ExotelProvider(VoiceCallProvider):
             proxy_url = get_proxy_config()
             proxies = {"https": proxy_url, "http": proxy_url} if proxy_url else None
 
-            resp = requests.post(url, data=payload, proxies=proxies)
+            # Explicit timeout: this call now runs inside a worker thread (via
+            # make_call_async). uvicorn runs under asyncio.run, whose shutdown
+            # calls loop.shutdown_default_executor() -- which on Python 3.11
+            # has no timeout parameter (added in 3.12) and joins all pool
+            # threads unconditionally. A black-holed connection here would
+            # hang pod shutdown until Kubernetes SIGKILLs it. No existing
+            # timeout convention was found for outbound telephony HTTP calls
+            # elsewhere in this codebase (checked static.py and
+            # http_client.py), so this uses the 30s default per the fix plan.
+            resp = requests.post(url, data=payload, proxies=proxies, timeout=30)
             logger.info(f"Exotel API response status: {resp.status_code}")
             logger.info(f"Exotel API response headers: {dict(resp.headers)}")
             logger.info(f"Exotel API response content: {resp.text}")

--- a/app/ai/voice/agents/breeze_buddy/services/telephony/plivo/recording.py
+++ b/app/ai/voice/agents/breeze_buddy/services/telephony/plivo/recording.py
@@ -2,6 +2,7 @@
 Plivo recording functionality
 """
 
+import asyncio
 from io import BytesIO
 from typing import Optional
 
@@ -18,15 +19,14 @@ from app.core.logger import logger
 from app.core.transport.http_client import get_proxy_config
 
 
-def start_call_recording(call_uuid: str) -> bool:
+def _start_call_recording_blocking(call_uuid: str) -> bool:
     """
-    Start recording an active call via Plivo API.
+    Blocking implementation — DO NOT call this from an ``async def``.
 
-    Args:
-        call_uuid: The Plivo call UUID
-
-    Returns:
-        bool: True if recording started successfully, False otherwise
+    ``plivo.RestClient`` is a synchronous HTTP client. It has no ``await``
+    and cannot have one; while it waits ~166ms for Plivo's API, a single-
+    worker uvicorn process is completely frozen — no other call, callback,
+    or background task can run. Reach it only via ``start_call_recording``.
     """
     try:
         client = plivo.RestClient(PLIVO_AUTH_ID, PLIVO_AUTH_TOKEN)
@@ -46,8 +46,25 @@ def start_call_recording(call_uuid: str) -> bool:
         return True
 
     except Exception as e:
-        logger.error(f"Error starting Plivo recording: {e}", exc_info=True)
+        # logger.opt(exception=...) rather than exc_info=: loguru has no
+        # exc_info kwarg — it would be consumed as a str.format argument,
+        # dropping the traceback and raising KeyError whenever the Plivo
+        # error text contains braces (a JSON body, for instance).
+        logger.opt(exception=e).error(f"Error starting Plivo recording: {e}")
         return False
+
+
+async def start_call_recording(call_uuid: str) -> bool:
+    """
+    Start recording an active call via Plivo API, off the event loop.
+
+    Args:
+        call_uuid: The Plivo call UUID
+
+    Returns:
+        bool: True if recording started successfully, False otherwise
+    """
+    return await asyncio.to_thread(_start_call_recording_blocking, call_uuid)
 
 
 async def download_call_recording(
@@ -92,5 +109,5 @@ async def download_call_recording(
         return audio_file
 
     except Exception as e:
-        logger.error(f"Error downloading Plivo recording: {e}", exc_info=True)
+        logger.opt(exception=e).error(f"Error downloading Plivo recording: {e}")
         return None

--- a/app/ai/voice/agents/breeze_buddy/services/telephony/twilio/conference.py
+++ b/app/ai/voice/agents/breeze_buddy/services/telephony/twilio/conference.py
@@ -90,13 +90,19 @@ class TwilioConferenceService:
                 "error": error_message,
             }
 
-    def _get_conference_sid(
+    async def _get_conference_sid(
         self,
         conference_name: str,
         max_retries: int = 20,
         retry_delay: float = 2.0,
     ) -> Optional[str]:
         """Poll for conference SID until it exists or timeout.
+
+        Both halves of this loop used to freeze the event loop: ``time.sleep``
+        for the delay (up to max_retries x retry_delay = 40s by default) and
+        the synchronous Twilio SDK call for each poll. On a single-worker pod
+        that stopped every other call, callback, and dispatch task for the
+        whole window.
 
         Args:
             conference_name: Friendly name of the conference
@@ -112,8 +118,11 @@ class TwilioConferenceService:
 
         for attempt in range(max_retries):
             try:
-                conferences = self.client.conferences.list(
-                    friendly_name=conference_name, status="in-progress", limit=1
+                conferences = await asyncio.to_thread(
+                    self.client.conferences.list,
+                    friendly_name=conference_name,
+                    status="in-progress",
+                    limit=1,
                 )
 
                 if conferences:
@@ -126,13 +135,13 @@ class TwilioConferenceService:
                 logger.debug(
                     f"Conference not found yet (attempt {attempt + 1}/{max_retries})"
                 )
-                time.sleep(retry_delay)
+                await asyncio.sleep(retry_delay)
 
             except Exception as list_error:
                 logger.warning(
                     f"Error checking conference (attempt {attempt + 1}): {list_error}"
                 )
-                time.sleep(retry_delay)
+                await asyncio.sleep(retry_delay)
 
         logger.error(
             f"Conference '{conference_name}' not found after {max_retries} attempts"
@@ -262,9 +271,7 @@ class TwilioConferenceService:
                 }
 
             try:
-                loop = asyncio.get_event_loop()
-                is_present = await loop.run_in_executor(
-                    None,
+                is_present = await asyncio.to_thread(
                     self._is_participant_present,
                     conference_sid,
                     agent_call_sid,
@@ -327,7 +334,9 @@ class TwilioConferenceService:
         try:
             # Stage 1: Add agent to conference
             logger.info("[Stage 1/4] Calling agent and adding to conference...")
-            agent_result = self._add_agent_to_conference(
+            # Blocking Twilio SDK → worker thread.
+            agent_result = await asyncio.to_thread(
+                self._add_agent_to_conference,
                 conference_name,
                 agent_phone_number,
                 telephony_number,
@@ -346,7 +355,7 @@ class TwilioConferenceService:
 
             # Stage 2: Get conference SID
             logger.info("[Stage 2/4] Polling for conference creation...")
-            conference_sid = self._get_conference_sid(
+            conference_sid = await self._get_conference_sid(
                 conference_name,
                 max_retries=max_retries,
                 retry_delay=retry_delay,
@@ -393,9 +402,11 @@ class TwilioConferenceService:
 
             # Stage 4: Transfer customer to conference
             logger.info("[Stage 4/4] Transferring customer to conference...")
-            transfer_result = self._transfer_customer_to_conference(
-                customer_call_sid=customer_call_sid,
-                conference_name=conference_name,
+            # Blocking Twilio SDK → worker thread.
+            transfer_result = await asyncio.to_thread(
+                self._transfer_customer_to_conference,
+                customer_call_sid,
+                conference_name,
             )
 
             if not transfer_result["success"]:

--- a/app/api/routers/breeze_buddy/auth/handlers.py
+++ b/app/api/routers/breeze_buddy/auth/handlers.py
@@ -20,7 +20,7 @@ from app.core.config.static import (
     LOOM_APP_URL,
 )
 from app.core.logger import logger
-from app.core.security.password import verify_password
+from app.core.security.password import verify_password_async
 from app.core.security.scope import resolve_merchant_ids, resolve_reseller_ids
 from app.database.accessor.breeze_buddy import merchants as merchant_accessors
 from app.database.accessor.breeze_buddy.users import get_user_by_username
@@ -76,7 +76,7 @@ async def login_handler(
     if user:
         # Verify password first to prevent username enumeration
         # Both is_active and password checks return identical error messages
-        if not verify_password(login_request.password, user.password_hash):
+        if not await verify_password_async(login_request.password, user.password_hash):
             logger.warning(f"Failed login attempt for user: {login_request.username}")
             raise HTTPException(
                 status_code=status.HTTP_401_UNAUTHORIZED,
@@ -187,7 +187,7 @@ async def generate_s2s_token_handler(request: S2STokenRequest) -> S2STokenRespon
         )
 
     # Verify password
-    if not verify_password(request.password, user.password_hash):
+    if not await verify_password_async(request.password, user.password_hash):
         logger.warning(
             f"S2S token request failed: invalid password - {request.username}"
         )

--- a/app/api/routers/breeze_buddy/signup/handlers.py
+++ b/app/api/routers/breeze_buddy/signup/handlers.py
@@ -35,9 +35,11 @@ Security invariants (enforced here, never trusted from client):
   - No admin / reseller role is ever assigned by these handlers
 """
 
+import asyncio
 import re
 import secrets
 import string
+from typing import Any, Dict
 
 import asyncpg
 from fastapi import HTTPException, status
@@ -51,7 +53,7 @@ from app.core.config.static import (
     SELF_SIGNUP_RESELLER_ID,
 )
 from app.core.logger import logger
-from app.core.security.password import verify_password
+from app.core.security.password import verify_password_async
 from app.core.security.scope import resolve_merchant_ids, resolve_reseller_ids
 from app.database.accessor.breeze_buddy import (
     merchants as merchant_accessors,
@@ -70,7 +72,7 @@ from app.schemas.breeze_buddy.signup import (
 # ─────────────────────────────────────────────────────────────────────────────
 
 
-def _verify_google_id_token(id_token: str) -> dict:
+def _verify_google_id_token_blocking(id_token: str) -> Dict[str, Any]:
     """
     Verify a Google id_token and return its claims.
 
@@ -112,6 +114,17 @@ def _verify_google_id_token(id_token: str) -> dict:
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Invalid or expired Google token. Please sign in again.",
         )
+
+
+async def _verify_google_id_token(id_token: str) -> Dict[str, Any]:
+    """
+    Verify a Google id_token off the event loop.
+
+    ``verify_oauth2_token`` fetches Google's public signing certificates over
+    HTTPS with a synchronous client on cache miss (100-800ms). On a single-
+    worker pod that freezes every in-flight call and webhook for that window.
+    """
+    return await asyncio.to_thread(_verify_google_id_token_blocking, id_token)
 
 
 def _derive_username_from_email(email: str) -> str:
@@ -270,7 +283,7 @@ async def google_login_handler(request: GoogleAuthRequest) -> TokenResponse:
     account. If found, returns a JWT. If not found, raises HTTP 404 with
     `detail="no_account"` so the frontend can show the signup form.
     """
-    claims = _verify_google_id_token(request.id_token)
+    claims = await _verify_google_id_token(request.id_token)
     google_email: str = claims.get("email", "")
 
     if not google_email:
@@ -310,7 +323,7 @@ async def google_signup_handler(request: GoogleMerchantSignupRequest) -> TokenRe
     - A merchant entity with reseller_id = SELF_SIGNUP_RESELLER_ID
     - A user account with role = merchant, email = Google email, no password
     """
-    claims = _verify_google_id_token(request.id_token)
+    claims = await _verify_google_id_token(request.id_token)
     google_email: str = claims.get("email", "")
 
     if not google_email:
@@ -411,7 +424,7 @@ async def list_accounts_handler(
     login handler upstream, so no re-auth needed here).
     """
     if id_token:
-        claims = _verify_google_id_token(id_token)
+        claims = await _verify_google_id_token(id_token)
         resolved_email = claims.get("email", "")
         if not resolved_email:
             raise HTTPException(
@@ -475,7 +488,7 @@ async def select_account_handler(
 
     if id_token:
         # Google SSO: verify token and confirm email ownership
-        claims = _verify_google_id_token(id_token)
+        claims = await _verify_google_id_token(id_token)
         google_email = claims.get("email", "")
         if not google_email or google_email != target.email:
             raise HTTPException(
@@ -484,7 +497,7 @@ async def select_account_handler(
             )
     elif password:
         # Password: verify against stored hash
-        if not verify_password(password, target.password_hash):
+        if not await verify_password_async(password, target.password_hash):
             raise HTTPException(
                 status_code=status.HTTP_401_UNAUTHORIZED,
                 detail="Incorrect password.",

--- a/app/api/routers/breeze_buddy/telephony/answer/handlers.py
+++ b/app/api/routers/breeze_buddy/telephony/answer/handlers.py
@@ -55,12 +55,15 @@ from app.ai.voice.agents.breeze_buddy.services.telephony.plivo.recording import 
     start_call_recording,
 )
 from app.ai.voice.agents.breeze_buddy.template.types import TTSConfig
+from app.core.concurrency import spawn_background_task
 from app.core.config.dynamic import (
     BB_NOISE_CANCELLATION_ENABLED,
     BB_NOISE_CANCELLATION_LEVEL,
 )
 from app.core.config.static import APP_BASE_URL
 from app.core.logger import logger
+from app.core.logger.context import set_log_context
+from app.core.logger.timing import timed_phase
 from app.database.accessor import (
     get_call_execution_config_by_template_id,
     get_lead_by_call_id,
@@ -126,7 +129,8 @@ async def resolve_call_templates(
             error_status: int              (HTTP status code)
     """
     # Check if lead exists (outbound call)
-    lead = await get_lead_by_call_id(call_sid)
+    with timed_phase("lookup_lead"):
+        lead = await get_lead_by_call_id(call_sid)
     if lead:
         # Outbound call - look up template using template_id from lead (preferred) or fall back to name
         logger.info(f"[Answer] Outbound call detected, lead: {lead.id}")
@@ -154,13 +158,15 @@ async def resolve_call_templates(
         return {"error": "Missing To number", "error_status": 400}
 
     # Look up telephony number by phone number
-    telephony_number = await get_telephony_number_by_number(to_number)
+    with timed_phase("lookup_telephony_number"):
+        telephony_number = await get_telephony_number_by_number(to_number)
     if not telephony_number:
         logger.error(f"[Answer] No telephony number found for: {to_number}")
         return {"error": "Number not configured", "error_status": 404}
 
     # Get all templates for this telephony number
-    templates = await get_all_templates_by_telephony_number_id(telephony_number.id)
+    with timed_phase("fetch_templates"):
+        templates = await get_all_templates_by_telephony_number_id(telephony_number.id)
 
     if not templates:
         logger.error(
@@ -571,12 +577,65 @@ async def _build_provider_response(
     return await make_response(ws_url)
 
 
+# Plivo requires a 200–500ms gap between answering the call and issuing the
+# record API call, so the call is fully connected internally first. We keep
+# the 500ms — it just no longer happens on the answer's critical path.
+_RECORDING_SETTLE_SECONDS = 0.5
+
+
+async def _start_recording_after_delay(call_id: str, tag: str) -> None:
+    """Wait out Plivo's settle window, then start recording in a worker thread."""
+    try:
+        await asyncio.sleep(_RECORDING_SETTLE_SECONDS)
+        with timed_phase("start_recording_background"):
+            recording_started = await start_call_recording(call_id)
+        if not recording_started:
+            logger.error(f"[{tag}] Recording failed to start for call: {call_id}")
+    except Exception as e:
+        # See recording.py for why this is opt(exception=...) and not exc_info=.
+        logger.opt(exception=e).error(
+            f"[{tag}] Failed to start Plivo recording for call: {call_id} - {e}"
+        )
+
+
+def _kickoff_plivo_recording(call_id: str, tag: str) -> None:
+    """
+    Start call recording without making the answer response wait for it.
+
+    Returns instantly. Recording is not needed to build the XML we owe Plivo,
+    so it has no business sitting on the critical path — every millisecond
+    spent here is a millisecond the provider waits before connecting audio,
+    and past its answer-URL timeout it retries, creating a duplicate lead.
+    """
+    spawn_background_task(
+        _start_recording_after_delay(call_id, tag),
+        name=f"plivo-recording:{call_id}",
+    )
+
+
 # ---------------------------------------------------------------------------
 # Main handler
 # ---------------------------------------------------------------------------
 
 
 async def handle_provider_answer(request: Request, provider: str) -> Response:
+    """
+    Unified answer handler for all telephony providers (Exotel, Plivo).
+
+    Thin timing wrapper: ``answer_total`` is the number the telephony provider
+    actually experiences, i.e. how long it waited for our XML/JSON. Plivo's
+    answer-URL timeout is what turns a slow answer into a retry, and a retry
+    into a duplicate lead — so this is the headline metric.
+
+    Returns:
+        - Exotel: JSON ``{"url": "wss://..."}``
+        - Plivo:  XML ``<Stream>``
+    """
+    with timed_phase("answer_total", provider=provider):
+        return await _handle_provider_answer(request, provider)
+
+
+async def _handle_provider_answer(request: Request, provider: str) -> Response:
     """
     Unified answer handler for all telephony providers (Exotel, Plivo).
 
@@ -593,34 +652,37 @@ async def handle_provider_answer(request: Request, provider: str) -> Response:
         params = dict(await request.form())
 
     call_id, from_number, to_number = _extract_call_params(params, provider)
+
+    # Stamp the call identity into the contextvar log scope. Everything
+    # downstream of this line — resolve_call_templates, the policy loop,
+    # create_inbound_lead, and every [PHASE] line — inherits call_id
+    # automatically, because contextvars propagate across await.
+    #
+    # Both call_id and call_sid are stamped with the same value: the voice
+    # agent (agent/__init__.py) stamps call_sid=, not call_id=, so without
+    # both keys a dashboard filter on one field misses everything logged
+    # under the other. call_id is kept because other things on this branch
+    # reference it.
+    set_log_context(
+        call_id=str(call_id or ""),
+        call_sid=str(call_id or ""),
+        provider=provider,
+        flow="answer",
+    )
+
     logger.info(f"[{tag}] call_id={call_id}, from={from_number}, to={to_number}")
 
     if not call_id:
         logger.error(f"[{tag}] Missing call ID")
         return _error_response(provider, "Missing call identifier", 400)
 
-    # Plivo-specific: start recording
+    # Plivo-specific: start recording — fire-and-forget, off the critical path.
     if provider == "plivo":
-        try:
-            # Wait for call to be fully established before starting recording
-            # Plivo requires 200-500ms delay between answer and record API
-            # to ensure the call is fully connected internally
-            logger.info(
-                f"[{tag}] Waiting 500ms before starting recording for call: {call_id}"
-            )
-            await asyncio.sleep(0.5)  # 500ms delay (middle of 200-500ms range)
-
-            recording_started = start_call_recording(call_id)
-            if not recording_started:
-                logger.error(f"[{tag}] Recording failed to start for call: {call_id}")
-        except Exception as e:
-            logger.error(
-                f"[{tag}] Failed to start Plivo recording for call: {call_id} - {e}",
-                exc_info=True,
-            )
+        _kickoff_plivo_recording(call_id, tag)
 
     # Resolve templates
-    result = await resolve_call_templates(call_id, from_number, to_number)
+    with timed_phase("resolve_call_templates"):
+        result = await resolve_call_templates(call_id, from_number, to_number)
 
     if "error" in result:
         logger.error(f"[{tag}] {result['error']}")
@@ -642,29 +704,33 @@ async def handle_provider_answer(request: Request, provider: str) -> Response:
             allowed_templates = []
             last_block_result = None
 
-            for t in templates:
-                # Config is owned by the template (1:1 by template_id) —
-                # no name-based matching.
-                config = (
-                    await get_call_execution_config_by_template_id(str(t.id))
-                    if t.id
-                    else None
-                )
-                if not config:
-                    # No config for this template — allow by default
-                    allowed_templates.append(t)
-                    continue
+            with timed_phase("policy_loop", templates=len(templates)):
+                for t in templates:
+                    with timed_phase("policy_template", template=t.name):
+                        # Config is owned by the template (1:1 by template_id) —
+                        # no name-based matching.
+                        config = (
+                            await get_call_execution_config_by_template_id(str(t.id))
+                            if t.id
+                            else None
+                        )
+                        if not config:
+                            # No config for this template — allow by default
+                            allowed_templates.append(t)
+                            continue
 
-                policy = await check_inbound_policy(
-                    config,
-                    from_number,
-                    skip_rate_limit=is_ivr_mode,
-                )
-                if policy.allowed:
-                    allowed_templates.append(t)
-                else:
-                    last_block_result = policy
-                    logger.info(f"[{tag}] Template {t.name} blocked: {policy.reason}")
+                        policy = await check_inbound_policy(
+                            config,
+                            from_number,
+                            skip_rate_limit=is_ivr_mode,
+                        )
+                        if policy.allowed:
+                            allowed_templates.append(t)
+                        else:
+                            last_block_result = policy
+                            logger.info(
+                                f"[{tag}] Template {t.name} blocked: {policy.reason}"
+                            )
 
             if not allowed_templates:
                 # All templates blocked
@@ -763,12 +829,14 @@ async def handle_provider_answer(request: Request, provider: str) -> Response:
         # Create inbound lead early so it exists even if caller hangs up before
         # the WebSocket connects. This prevents orphan-call webhooks for normal
         # immediate-hangup behaviour.
-        await _create_inbound_lead_in_answer_handler(
-            call_id=call_id,
-            from_number=from_number,
-            templates=result.get("templates", []),
-        )
+        with timed_phase("create_inbound_lead"):
+            await _create_inbound_lead_in_answer_handler(
+                call_id=call_id,
+                from_number=from_number,
+                templates=result.get("templates", []),
+            )
 
-    return await _build_provider_response(
-        provider, result, call_id, from_number, to_number
-    )
+    with timed_phase("build_response"):
+        return await _build_provider_response(
+            provider, result, call_id, from_number, to_number
+        )

--- a/app/api/routers/breeze_buddy/telephony/callbacks/handlers.py
+++ b/app/api/routers/breeze_buddy/telephony/callbacks/handlers.py
@@ -37,6 +37,7 @@ from app.ai.voice.agents.breeze_buddy.utils.warm_transfer import (
 )
 from app.core.config.static import TWILIO_TEMPLATE_WEBSOCKET_URL
 from app.core.logger import logger
+from app.core.logger.context import set_log_context
 from app.database.accessor import get_lead_by_call_id
 
 
@@ -213,6 +214,17 @@ async def handle_callback_details_post(
             call_sid = form.get("call_uuid")
             provider_recording_url = form.get("record_url")
 
+    # call_sid= is stamped alongside call_id= so this trace joins with the
+    # voice agent's log lines (agent/__init__.py stamps call_sid=, not
+    # call_id=). call_id is kept because other things on this branch
+    # reference it.
+    set_log_context(
+        call_id=str(call_sid or ""),
+        call_sid=str(call_sid or ""),
+        provider=provider_lower,
+        flow="recording",
+    )
+
     if provider_recording_url and call_sid:
         # Ensure we have string values (form can return UploadFile)
         call_sid_str = str(call_sid) if not isinstance(call_sid, str) else call_sid
@@ -268,6 +280,22 @@ async def handle_callback_status(request: Request, provider: str) -> Response:
     elif provider.lower() == "plivo":
         call_sid = form.get("CallUUID")
         call_status = form.get("CallStatus")
+
+    # Post-connect half of the trace: the hangup/terminal webhook. Direction is
+    # included because inbound orphan webhooks and outbound duplicate-call
+    # webhooks look identical without it.
+    #
+    # call_sid= is stamped alongside call_id= so this trace joins with the
+    # voice agent's log lines (agent/__init__.py stamps call_sid=, not
+    # call_id=). call_id is kept because other things on this branch
+    # reference it.
+    set_log_context(
+        call_id=str(call_sid or ""),
+        call_sid=str(call_sid or ""),
+        provider=provider.lower(),
+        flow="status",
+        direction=str(form.get("Direction") or ""),
+    )
 
     # Terminal call statuses across all providers:
     # - completed, busy, failed, no-answer: universal (Twilio, Plivo, Exotel)

--- a/app/core/concurrency.py
+++ b/app/core/concurrency.py
@@ -1,0 +1,94 @@
+"""
+Helpers for keeping blocking work off the asyncio event loop.
+
+Why this module exists
+----------------------
+Each API pod runs uvicorn with a single worker: one event loop, one thread,
+at most one CPU core. Any synchronous call inside an ``async def`` freezes
+*every* other in-flight call for its full duration — there is no other
+thread to pick up the slack.
+
+On 27 Jul 2026 a single such line (``start_call_recording``, ~166 ms of
+blocking Plivo HTTP per call) capped a pod at ~6 calls/sec and produced a
+P1 orphan-alert storm (27 Jul 2026).
+
+The two remedies, and when to use which
+---------------------------------------
+``spawn_background_task(coro)``
+    The result is not needed to answer the request. Starts the coroutine and
+    returns immediately.
+
+``await asyncio.to_thread(fn, *args)``
+    The callable is synchronous and blocking (a sync SDK, ``requests``,
+    ``time.sleep``). Use it directly — there is deliberately no wrapper here,
+    because ``asyncio.to_thread`` is already the idiomatic, greppable name.
+
+They compose: ``spawn_background_task(_do_it())`` where ``_do_it`` internally does
+``await asyncio.to_thread(blocking_fn, ...)``. Both are required — the first
+so nobody waits, the second so the loop is never occupied.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Coroutine, Optional, Set
+
+from app.core.logger import logger
+
+# Strong references to in-flight background tasks.
+#
+# asyncio.create_task only keeps a *weak* reference to the task it returns.
+# If the caller drops its reference (which fire-and-forget by definition does),
+# the task can be garbage-collected mid-await and silently cancelled. Holding
+# it in a module-level set until the done-callback fires prevents that.
+# https://docs.python.org/3/library/asyncio-task.html#asyncio.create_task
+_background_tasks: Set[asyncio.Task] = set()
+
+
+def _log_background_failure(task: asyncio.Task) -> None:
+    """Drain the task's exception so it is logged, not swallowed by the GC."""
+    if task.cancelled():
+        return
+    exc = task.exception()
+    if exc is not None:
+        # ``logger`` is loguru, not stdlib logging: it has no ``exc_info``
+        # kwarg. Any kwarg passed here is used for ``str.format`` on the
+        # already-interpolated message, so passing exc_info=exc would raise
+        # KeyError whenever str(exc) contains braces (e.g. a dict/JSON body)
+        # and silently drop the traceback the rest of the time. Use
+        # ``logger.opt(exception=...)`` instead, which is loguru's actual
+        # mechanism for attaching a traceback to a log record.
+        logger.opt(exception=exc).error(
+            f"[background] task '{task.get_name()}' failed: {exc}"
+        )
+
+
+def spawn_background_task(
+    coro: Coroutine[Any, Any, Any], *, name: Optional[str] = None
+) -> asyncio.Task:
+    """
+    Run ``coro`` without awaiting it, keeping a strong reference until it ends.
+
+    Failures are logged and never propagate to the caller — a background task
+    must not be able to break the request that spawned it.
+
+    Note:
+        Background tasks are NOT drained at application shutdown. A spawned
+        coroutine must not assume the DB pool, Redis, or the logger are
+        still available late in the process lifecycle — it may still be
+        running (or start running) after shutdown has begun tearing those
+        down.
+
+    Args:
+        coro: The coroutine to run. Create it inline: ``spawn_background_task(f())``.
+        name: Optional task name, used in failure logs.
+
+    Returns:
+        The created ``asyncio.Task`` — useful in tests; production callers
+        can ignore it.
+    """
+    task = asyncio.create_task(coro, name=name)
+    _background_tasks.add(task)
+    task.add_done_callback(_background_tasks.discard)
+    task.add_done_callback(_log_background_failure)
+    return task

--- a/app/core/config/static.py
+++ b/app/core/config/static.py
@@ -268,6 +268,28 @@ POSTGRES_POOL_SIZE = int(os.getenv("POSTGRES_POOL_SIZE", "5"))
 POSTGRES_MAX_OVERFLOW = int(os.getenv("POSTGRES_MAX_OVERFLOW", "10"))
 POSTGRES_POOL_RECYCLE = int(os.getenv("POSTGRES_POOL_RECYCLE", "3600"))  # 1 hour
 
+# Worker threads available to asyncio.to_thread() for offloaded blocking work
+# (sync telephony SDKs: Plivo recording, provider.make_call, Twilio conference).
+# Python's default is min(32, cpu_count + 4) — only 5 threads on a 1-core pod,
+# which re-creates the queueing problem one layer down at ~30 calls/sec.
+# These threads are I/O-bound, so oversubscribing relative to cores is correct.
+# Threads are created lazily (~37 KB RSS each, +1.7 MB if all 48 go live).
+#
+# Shared pool caveat: this is the loop's DEFAULT executor, used by every
+# asyncio.to_thread()/run_in_executor(None, ...) caller. Note that
+# template/global_function.py wraps sync handlers in asyncio.wait_for --
+# which cancels the await but does NOT stop the worker thread, so a timed-out
+# global function keeps its slot until the handler actually returns. That
+# hazard predates this setting; a 48-slot pool tolerates it far better than
+# the 5-slot Python default it replaces.
+BLOCKING_THREAD_POOL_SIZE = int(os.getenv("BLOCKING_THREAD_POOL_SIZE", "48"))
+if BLOCKING_THREAD_POOL_SIZE < 1:
+    # ThreadPoolExecutor(max_workers=0) raises, which would kill startup with a
+    # stack trace pointing at main.py rather than at the misconfigured env var.
+    raise ValueError(
+        f"BLOCKING_THREAD_POOL_SIZE must be >= 1, got {BLOCKING_THREAD_POOL_SIZE}"
+    )
+
 # Daily voice bot subprocess (per-call child processes; see
 # breeze_buddy/services/daily). Kept next to the API pool settings above so
 # the two are tuned together.

--- a/app/core/logger/timing.py
+++ b/app/core/logger/timing.py
@@ -1,0 +1,70 @@
+"""
+Phase timing instrumentation.
+
+Emits one structured line per instrumented step:
+
+    [PHASE] resolve_call_templates elapsed_ms=8.4 call_id=abc123
+
+Why this exists: during the 27 Jul incident, per-call latency had to be
+reconstructed by matching timestamps across interleaved log lines from
+hundreds of concurrent calls. That produced two wrong root causes before
+real data arrived ("the policy loop is 98% of the latency" — measured at
+2.8%; "the DB pool is too small" — it wasn't). Attributing time directly
+to a named step removes the guesswork.
+
+Uses ``time.perf_counter`` (monotonic, unaffected by wall-clock changes).
+
+Cost (measured, not estimated)
+------------------------------
+``timed_phase`` costs **~35 us** per invocation against an ``enqueue=True``
+sink, which is how every sink in ``app/core/logger`` is configured. The
+inbound answer path emits **12 phase lines per call** (9 fixed + one
+``policy_template`` per template; 3 templates on the Namma Yatri number):
+
+    12 phases x 35 us = ~0.42 ms of event-loop CPU per call
+      10 calls/sec -> 4.2 ms/sec  = 0.42% of one core
+      25 calls/sec -> 10.6 ms/sec = 1.06% of one core
+      50 calls/sec -> 21.1 ms/sec = 2.11% of one core
+
+Backpressure: because every sink sets ``enqueue=True``, the formatting and
+write happen on loguru's own writer thread, so a slow stdout or log driver
+does NOT block the event loop. The trade-off is that loguru's queue is
+unbounded — sustained writer lag shows up as memory growth, not as latency.
+At 12 extra lines per call that headroom is large, but it is the thing to
+watch if log volume is ever increased further.
+
+
+Note: the emitted line inherits whatever ``set_log_context`` put in scope,
+so ``call_id`` appears automatically on the JSON sink without being passed
+as a field here.
+"""
+
+from __future__ import annotations
+
+import time
+from contextlib import contextmanager
+from typing import Any, Iterator
+
+from app.core.logger import logger
+
+
+@contextmanager
+def timed_phase(phase: str, **fields: Any) -> Iterator[None]:
+    """
+    Time the wrapped block and log ``[PHASE] <phase> elapsed_ms=<n>``.
+
+    The line is emitted in a ``finally``, so a block that raises is still
+    measured — that is usually the case you most want timing for.
+
+    Args:
+        phase: Step name. Keep it stable — log analysis aggregates by this
+            string, so renaming one breaks historical comparisons.
+        **fields: Extra ``key=value`` pairs appended to the line, in order.
+    """
+    start = time.perf_counter()
+    try:
+        yield
+    finally:
+        elapsed_ms = (time.perf_counter() - start) * 1000
+        extras = "".join(f" {key}={value}" for key, value in fields.items())
+        logger.info(f"[PHASE] {phase} elapsed_ms={elapsed_ms:.1f}{extras}")

--- a/app/core/security/password.py
+++ b/app/core/security/password.py
@@ -3,6 +3,7 @@ Password hashing and verification utilities using bcrypt.
 Provides secure password storage and validation for user authentication.
 """
 
+import asyncio
 from typing import Tuple
 
 import bcrypt
@@ -169,3 +170,22 @@ def check_password_hash(hashed_password: str, password: str) -> bool:
         True if password matches, False otherwise
     """
     return verify_password(password, hashed_password)
+
+
+# Async wrappers -- use these from any ``async def`` call site.
+#
+# ``bcrypt.hashpw``/``bcrypt.checkpw`` at BCRYPT_ROUNDS=12 take ~239-240ms on
+# typical hardware -- longer than the 166ms Plivo call that caused the
+# orphan-alert P1 (see app/core/concurrency.py). Each API pod runs a single
+# event loop with a single worker, so calling either synchronously from an
+# ``async def`` freezes every other in-flight call for that duration. bcrypt
+# releases the GIL, so offloading to a thread via ``asyncio.to_thread``
+# genuinely unblocks the loop even on a 1-core pod.
+async def hash_password_async(password: str) -> str:
+    """Hash a password using bcrypt, off the event loop. See module note above."""
+    return await asyncio.to_thread(hash_password, password)
+
+
+async def verify_password_async(plain_password: str, hashed_password: str) -> bool:
+    """Verify a password against a hash, off the event loop. See module note above."""
+    return await asyncio.to_thread(verify_password, plain_password, hashed_password)

--- a/app/database/accessor/breeze_buddy/users.py
+++ b/app/database/accessor/breeze_buddy/users.py
@@ -10,7 +10,7 @@ import json
 from typing import List, Optional, Tuple
 
 from app.core.logger import logger
-from app.core.security.password import hash_password
+from app.core.security.password import hash_password_async
 from app.database import get_db_connection
 from app.database.accessor.breeze_buddy.access_grants import (
     ensure_reseller_on_conn,
@@ -139,7 +139,7 @@ async def create_merchant_and_user_atomically(
     DB transaction.  Either both succeed or both are rolled back — no
     orphaned merchant rows if the user insert fails.
     """
-    password_hash = hash_password(password)
+    password_hash = await hash_password_async(password)
 
     merchant_q, merchant_v = create_merchant_query(
         merchant_id=merchant_id,
@@ -205,7 +205,7 @@ async def create_user(
     Returns:
         UserResponse if successful, None otherwise
     """
-    password_hash = hash_password(password)
+    password_hash = await hash_password_async(password)
 
     if reseller_ids is None:
         reseller_ids = []
@@ -362,7 +362,7 @@ async def update_user(
     Returns:
         UserResponse if successful, None if user not found
     """
-    password_hash = hash_password(password) if password else None
+    password_hash = await hash_password_async(password) if password else None
 
     query, values = update_user_query(
         user_id=user_id,

--- a/app/main.py
+++ b/app/main.py
@@ -1,4 +1,5 @@
 import asyncio
+from concurrent.futures import ThreadPoolExecutor
 from contextlib import asynccontextmanager
 from datetime import datetime, timezone
 
@@ -48,6 +49,7 @@ from app.core.config.static import (
     BB_RECONCILE_BACKLOG_INTERVAL_S,
     BB_RECONCILE_CHANNELS_INTERVAL_S,
     BB_RECONCILE_STUCK_PROCESSING_INTERVAL_S,
+    BLOCKING_THREAD_POOL_SIZE,
     BOT_MAX_DRAIN_SECONDS,
     CHAT_SESSION_END_TIMEOUT_LOOP_INTERVAL_SECONDS,
     CORS_ALLOWED_ORIGINS,
@@ -84,6 +86,18 @@ _background_scheduler = None
 async def lifespan(_app: FastAPI):
     """FastAPI lifespan manager that handles startup and shutdown tasks."""
     logger.info(f"Application startup... (POD_ROLE={POD_ROLE})")
+
+    # Size the executor backing asyncio.to_thread() before anything can use it.
+    # See BLOCKING_THREAD_POOL_SIZE in static.py for why the default is wrong.
+    asyncio.get_running_loop().set_default_executor(
+        ThreadPoolExecutor(
+            max_workers=BLOCKING_THREAD_POOL_SIZE,
+            thread_name_prefix="blocking",
+        )
+    )
+    logger.info(
+        f"Blocking-work thread pool sized to {BLOCKING_THREAD_POOL_SIZE} workers"
+    )
 
     # Initialize database and create tables if needed
     try:

--- a/tests/breeze_buddy/dispatch/conftest.py
+++ b/tests/breeze_buddy/dispatch/conftest.py
@@ -12,6 +12,7 @@ that monkeypatches the worker's DB/provider collaborators so a full
 
 from __future__ import annotations
 
+import asyncio
 import fnmatch
 from datetime import datetime, time as dtime, timedelta, timezone
 from typing import Any, Dict, List, Optional, Tuple
@@ -389,6 +390,11 @@ class CallRecorder:
             raise self._raise_exc
         self.calls.append({"to": to, "from": from_number, **kwargs})
         return {"sid": self._sid} if self._sid else {}
+
+    async def make_call_async(
+        self, to: str, from_number: str, **kwargs: Any
+    ) -> Dict[str, Any]:
+        return await asyncio.to_thread(self.make_call, to, from_number, **kwargs)
 
 
 class DispatchHarness:


### PR DESCRIPTION
Root cause of the 27 Jul 2026 P1 orphan-alert storm: start_call_recording() is a plain def using the synchronous plivo.RestClient, called inline from the async answer webhook. It froze the single-worker event loop ~166ms per call, capping each 1-core pod at ~6 calls/sec. Callers waited 15-50s in silence and hung up before their lead existed, firing 59+ P1 orphan alerts.

Measured locally (scripts/loadtest/, 1 uvicorn worker, real prod templates, identical ramp before and after). "races" = the caller's hangup arrived before our answer returned; each one is a P1 orphan alert in production:

    rate    before p50   before races   after p50   after races
    5/s        8.15s          14          0.07s         0
    10/s      25.52s         165          0.10s         0
    25/s      61.24s         331          0.30s         0
                             ---                       ---
                             510                         0

Recording still fires 801/801; the 500ms Plivo settle delay is preserved. Raw artefacts in docs/incidents/2026-07-27-orphan-alert-storm/.

Blocking calls removed (each pod runs uvicorn with one worker: one event loop, one thread, one core, so a synchronous call inside an async def freezes every concurrent call for its full duration):

  - start_call_recording (~166ms) -> async + asyncio.to_thread, kicked off via spawn_background so the answer no longer waits for it
  - provider.make_call (~150-500ms x 20 dispatch workers on the same loop) -> one make_call_async on the base class; all three providers inherit it
  - twilio conference _get_conference_sid time.sleep (up to 20 x 2s = 40s) -> asyncio.sleep + to_thread for the SDK polls
  - google id_token verification (100-800ms on cert-cache miss, 4 call sites)
  - bcrypt hashpw/checkpw (~240ms, 6 call sites) -- longer than the call that caused the incident

Diagnosability: set_log_context() already existed and was wired to both log sinks but was never called in the telephony path, so no answer-path log carried a call identifier. It is now called at the answer, status-callback and recording-callback entry points, emitting both call_id and call_sid so a call traces webhook-to-agent with one filter. Because contextvars propagate across await, every downstream line inherits it. timed_phase() adds [PHASE] timing so latency is attributed per step rather than inferred from gaps between lines.

Also:
  - size the default ThreadPoolExecutor explicitly (BLOCKING_THREAD_POOL_SIZE, default 48). Python's default is min(32, cpu_count+4) = 5 threads on a 1-core pod, which would re-create the queueing one layer down at ~30/sec
  - add an explicit 30s timeout to the Exotel requests.post; it now runs in a worker thread, and py3.11's shutdown_default_executor() has no timeout, so a black-holed connection would hang pod shutdown until SIGKILL
  - tests/test_no_blocking_calls_in_async.py: AST guard over 7 directories, fails CI on a new blocking call inside an async def. Verified in both directions (catches an injected regression, does not flag the sync helpers that are deliberate asyncio.to_thread targets)

Known, deliberately not addressed here: in-flight background tasks are not drained at shutdown, so a recording cancelled at SIGTERM is dropped silently (~3-4 per pod per deploy, zero when the existing SIGTERM drain is enabled). The "Waiting 500ms before starting recording" log line was removed -- re-key dashboards to [PHASE] start_recording_background.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved inbound call reliability by moving recording and telephony operations off the main request path.
  - Reduced delayed answers, orphan alerts, duplicate leads, and stuck leads during high call volumes.
  - Added timeouts for outbound telephony requests to prevent indefinitely stalled calls.
  - Improved responsiveness for login, signup, password verification, and account updates.

- **Monitoring**
  - Added clearer call-status logging and response timing information to support faster issue diagnosis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->