### PR TITLE
feat(chat): ui-intent engine (chat/intents) + widget config surface

### DIFF
--- a/app/ai/voice/agents/breeze_buddy/chat/agent/runtime.py
+++ b/app/ai/voice/agents/breeze_buddy/chat/agent/runtime.py
@@ -48,19 +48,26 @@ def _chip_labels(raw: Any) -> List[str]:
     return labels[:5]
 
 
-def _partition_gated_calls(
-    tool_calls: List[Any],
+def is_approval_gated(
+    tool_name: str,
     approval_map: Dict[str, Any],
     node: Dict[str, Any],
-) -> Tuple[List[Any], List[Any]]:
-    """Split a tool-call batch into (gated, ungated) for HITL.
+) -> bool:
+    """Whether ``tool_name`` is HITL-gated for a dispatch in ``node``.
 
     A gated name shadowed by a per-node function in the CURRENT node is
-    treated as UNGATED: in that node the LLM calls the per-node function
-    (which the author did not gate), not the gated global of the same name.
-    Non-shadow nodes are unaffected — a gated global is still gated. This
-    keeps chat consistent with voice, whose wrapper gates only globals.
+    treated as UNGATED: in that node the caller reaches the per-node
+    function (which the author did not gate), not the gated global of the
+    same name. Non-shadow nodes are unaffected — a gated global is still
+    gated. This keeps chat consistent with voice, whose wrapper gates only
+    globals.
+
+    The single definition of "is this call gated", shared by the LLM path
+    (:func:`_partition_gated_calls`) and the no-LLM direct/intent path — a
+    tool must not be gated on one surface and free on the other.
     """
+    if tool_name not in approval_map:
+        return False
     # ``node["functions"]`` holds FlowsFunctionSchema objects in flow mode
     # (FlowConfigBuilder._build_node runs every per-node function through
     # _build_function_schema) — NOT plain dicts. Match the idiom used by
@@ -72,15 +79,23 @@ def _partition_gated_calls(
         for fn in (node.get("functions") or [])
         if isinstance(fn, FlowsFunctionSchema)
     }
+    return tool_name not in node_fn_names
+
+
+def _partition_gated_calls(
+    tool_calls: List[Any],
+    approval_map: Dict[str, Any],
+    node: Dict[str, Any],
+) -> Tuple[List[Any], List[Any]]:
+    """Split a tool-call batch into (gated, ungated) for HITL — see
+    :func:`is_approval_gated` for the shadowing rule."""
     gated = [
-        c
-        for c in tool_calls
-        if c.function_name in approval_map and c.function_name not in node_fn_names
+        c for c in tool_calls if is_approval_gated(c.function_name, approval_map, node)
     ]
     ungated = [
         c
         for c in tool_calls
-        if c.function_name not in approval_map or c.function_name in node_fn_names
+        if not is_approval_gated(c.function_name, approval_map, node)
     ]
     return gated, ungated
 

--- a/app/ai/voice/agents/breeze_buddy/chat/intents/__init__.py
+++ b/app/ai/voice/agents/breeze_buddy/chat/intents/__init__.py
@@ -1,0 +1,2 @@
+"""Widget ui_intent engine: policy routing (DIRECT / AGENT_TURN /
+CLIENT). Flavors under ``assist/`` register their policies lazily."""

--- a/app/ai/voice/agents/breeze_buddy/chat/intents/router.py
+++ b/app/ai/voice/agents/breeze_buddy/chat/intents/router.py
@@ -1,0 +1,786 @@
+"""Typed UI intents — the widget → server action channel (RFC-001 §3.3).
+
+Catalog-v2 data-bound components emit ``{intent, component_id, payload,
+display}`` actions instead of free-text ``to_assistant`` messages. This
+module is the **flavor-agnostic engine**:
+
+- The wire model + :func:`parse_ui_intent` (→ 422-shaped
+  :class:`IntentValidationError` on anything malformed, unknown, or not
+  enabled for the session's template).
+- The **intent policy registry** — which intents execute directly (no LLM
+  call), which convert into a structured agent turn, and which are
+  client-side only. The registry starts EMPTY; flavor packages under
+  ``breeze_buddy/assist/`` populate it via :func:`register_intents` when
+  :func:`ensure_flavor_intents` lazily imports them (mirror of
+  ``ui_catalog.ensure_group_loaded`` for schemas).
+- :func:`run_direct_intent` — the direct executor shell: the policy's
+  flavor-provided ``drive`` callable runs whitelisted tools through the
+  EXISTING pipeline (``inject_tool_args`` → MCP dispatch →
+  ``apply_result_pipeline`` → ``apply_state_reducers``, via
+  ``ChatAgent.run_direct_tool`` / :func:`run_persisted_tool`) with **no
+  LLM client constructed**, then a hydrated component (the policy's
+  ``show_op``) + ``turn_end`` streams over the same SSE shape a chat turn
+  uses.
+
+Like the session-state / ui-stream engines, this module is deliberately
+flavor-blind: tool names, payload schemas, and which component gets
+emitted live in the flavor's own ``intents`` module and register here on
+flavor load. Sessions whose template doesn't enable a flavor get the typed 422
+(``unknown_intent`` when the flavor was never loaded in this process,
+``flavor_not_enabled`` when it was loaded by another template) — either
+way the intent never executes.
+"""
+
+from __future__ import annotations
+
+import copy
+import importlib
+import json
+import uuid
+from dataclasses import dataclass, replace
+from enum import Enum
+from typing import (
+    Any,
+    AsyncIterator,
+    Awaitable,
+    Callable,
+    Dict,
+    Iterable,
+    List,
+    Optional,
+    Set,
+    Tuple,
+    Type,
+)
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
+
+from app.ai.voice.agents.breeze_buddy.chat.agent import ChatAgent
+from app.ai.voice.agents.breeze_buddy.chat.agent.runtime import is_approval_gated
+from app.ai.voice.agents.breeze_buddy.chat.client_context import diff_state_patch
+from app.ai.voice.agents.breeze_buddy.chat.history.block_codec import (
+    assistant_turn_to_blocks,
+    internal_text_block,
+    plain_text_blocks,
+    tool_results_to_user_blocks,
+)
+from app.ai.voice.agents.breeze_buddy.chat.sse import SSEEvent
+from app.ai.voice.agents.breeze_buddy.chat.turn_core import (
+    build_render_template_vars,
+    resolve_session_catalog_version,
+)
+from app.ai.voice.agents.breeze_buddy.chat.ui.binding import resolve_show_op
+from app.ai.voice.agents.breeze_buddy.chat.ui.stream import (
+    summarize_ui_ops,
+    ui_op_dropped_event,
+    ui_op_event,
+)
+from app.ai.voice.agents.breeze_buddy.mcp import close_mcp_pool
+from app.ai.voice.agents.breeze_buddy.template.cache import get_template_by_id_cached
+
+# Same envelope helper the reducer engine + binding store use — one
+# definition of "success" across every result consumer.
+from app.ai.voice.agents.breeze_buddy.template.session_state import (
+    _is_tool_success,
+)
+from app.core.logger import logger
+from app.core.transport.http_client import create_aiohttp_session
+from app.database.accessor.breeze_buddy.chat_session import (
+    get_agent_session_state,
+    get_chat_session_by_id,
+    insert_chat_message,
+    update_chat_session_after_turn,
+    upsert_agent_session_state_merge,
+)
+from app.schemas.breeze_buddy.chat import ChatMessageRole, ChatSessionStatus
+
+# ---------------------------------------------------------------------------
+# Wire model
+# ---------------------------------------------------------------------------
+
+
+class UiIntent(BaseModel):
+    """The ``ui_intent`` body variant on ``POST /widget/session/{id}/message``
+    (RFC-001 §3.3). ``payload`` is validated per-intent (see the policy
+    table); ``display`` becomes the visible user bubble."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    intent: str = Field(..., min_length=1, max_length=64)
+    component_id: str = Field(..., min_length=1, max_length=128)
+    payload: Dict[str, Any] = Field(default_factory=dict)
+    display: Optional[str] = Field(None, max_length=500)
+
+
+# ---------------------------------------------------------------------------
+# Policy registry — populated by flavor packages on lazy load
+# ---------------------------------------------------------------------------
+
+
+class IntentRoute(str, Enum):
+    """How an intent is served (RFC-001 §3.3 policy table)."""
+
+    DIRECT = "direct"  # whitelisted tool execution, no LLM call
+    AGENT_TURN = "agent_turn"  # rewritten into a structured user turn
+    CLIENT = "client"  # widget-side only; server never executes
+
+
+# A DIRECT policy's tool driver: yields ``(sse_event, final_tool_name,
+# final_result)`` triples — events stream as they happen; the final
+# tool/result pair rides the last dispatch (see ``run_direct_intent``).
+DirectDriveFn = Callable[
+    ["ChatAgent", Any, Dict[str, Any], "ParsedIntent", str],
+    AsyncIterator[Tuple[Optional[SSEEvent], Optional[str], Any]],
+]
+
+# Builds the server-authored ``show`` op over the final (tool_name,
+# result, agent) — hydrated via the same resolver a LLM `show` op uses.
+# The agent carries both ``agent_state`` (reducer output) and ``template``
+# (per-template ui_intents overrides).
+ShowOpBuilderFn = Callable[[str, Any, "ChatAgent"], Dict[str, Any]]
+
+# Post-success follow-up surface (a flavor's "and here's a related thing"
+# panel): runs AFTER the ack + primary component are on the wire, may
+# dispatch its own tools through the same pipeline, and returns ONE
+# fully-resolved ui op (or None for silence). The engine persists it as its
+# own assistant row and streams it before turn_end. Must be fail-open — a
+# follow-up is decoration, never allowed to fail the mutation turn.
+FollowupFn = Callable[
+    ["ChatAgent", Any, Dict[str, Any], "ParsedIntent", str, str, Any],
+    Awaitable[Optional[Dict[str, Any]]],
+]
+
+
+@dataclass(frozen=True)
+class IntentPolicy:
+    """One intent's routing + validation + (flavor-provided) execution.
+
+    ``flavor`` is stamped by :func:`register_intents` — sessions only see
+    intents whose flavor their template enables. DIRECT policies carry
+    ``drive`` (+ optionally ``show_op``); AGENT_TURN policies carry
+    ``agent_turn`` (the structured-user-message rewriter).
+    """
+
+    route: IntentRoute
+    payload_model: Type[BaseModel]
+    flavor: str = ""
+    default_display: Optional[str] = None
+    agent_turn: Optional[Callable[["ParsedIntent"], str]] = None
+    drive: Optional[DirectDriveFn] = None
+    show_op: Optional[ShowOpBuilderFn] = None
+    # Optional flavor-provided extractor: a user-displayable reason off a
+    # FAILED final result (upstream backends often carry a precise one in a
+    # warnings/messages array). None / raising / no match → the generic
+    # copy. Only display-grade upstream text should come back from this —
+    # never raw error internals.
+    failure_message: Optional[Callable[[Any], Optional[str]]] = None
+    # Optional flavor-provided acknowledgement off the SUCCESSFUL final
+    # (parsed, tool_name, result): one short user-facing line ("Done.")
+    # persisted as the turn's assistant prose ALONGSIDE any rendered
+    # component — it keeps the turn visibly anchored after a later turn's
+    # component sweeps this one. None / raising → no bubble.
+    ack_message: Optional[Callable[["ParsedIntent", str, Any], Optional[str]]] = None
+    # Optional post-success follow-up (see FollowupFn): streamed and
+    # persisted AFTER the primary component so the user never waits on
+    # it. Skipped for silent policies (nothing visible to follow up on).
+    followup: Optional[FollowupFn] = None
+    # Silent intents (a detail fetch behind a full-panel overlay, say)
+    # leave NO visible trace in the thread: the user record persists
+    # internal-only (no bubble, no user_committed event) and the hydrated
+    # component is streamed live but never persisted as a replayable ui
+    # block. The tool exchange still persists — the agent keeps the context.
+    silent: bool = False
+    # Internal AGENT_TURN intents run a REAL LLM turn whose entire exchange
+    # persists with visibility=internal: the rewritten user instruction and
+    # the assistant prose stay in the LLM's context on later turns, but
+    # resume replay never shows them and no user_committed fires. The live
+    # SSE stream is unchanged — the widget routes the tokens wherever it
+    # wants them. DIRECT policies use `silent` instead; `internal` is the
+    # agent-turn counterpart.
+    internal: bool = False
+
+
+# Process-global registry. Starts empty; ``register_intents`` populates it
+# when a flavor's intents module is (lazily) imported. Additive-only —
+# per-session gating is the ``enabled_flavors`` check in parse_ui_intent.
+INTENT_POLICY: Dict[str, IntentPolicy] = {}
+
+# Flavor → intents module, the intent-side mirror of
+# ``ui_catalog.LAZY_GROUPS`` (which maps the same flavor names to schema
+# modules). Kept separate so a chat session that never sends a ui_intent
+# loads only the schemas, and vice versa.
+FLAVOR_INTENT_MODULES: Dict[str, str] = {
+    "commerce": "app.ai.voice.agents.breeze_buddy.assist.commerce.intents",
+}
+
+# Attempted flavors — successes AND failures. A failed import must not be
+# retried per request: Python drops the half-initialised module from
+# sys.modules, so an unguarded retry re-raises on every call for the life of
+# the process. A broken flavor needs a deploy, not another import.
+_LOADED_FLAVOR_INTENTS: Set[str] = set()
+
+
+def ensure_flavor_intents(flavors: Iterable[str]) -> None:
+    """Idempotently import (→ register) the intent modules for ``flavors``.
+
+    Unknown flavor names are ignored — callers pass a template's enabled
+    UI-catalog groups verbatim (``core`` etc. simply have no intents).
+
+    Fail-open by contract: a flavor module that is absent (its layer has not
+    shipped yet) or raises on import leaves its intents unregistered, which
+    is precisely the ``unknown_intent`` 422 this module already documents —
+    the same answer a template gets for an intent nobody ever defined.
+    Propagating the ImportError instead would turn a deployment gap into an
+    unhandled 500 on a public widget route.
+    """
+    for flavor in flavors:
+        module_path = FLAVOR_INTENT_MODULES.get(flavor)
+        if module_path is None or flavor in _LOADED_FLAVOR_INTENTS:
+            continue
+        try:
+            importlib.import_module(module_path)
+        except Exception:  # noqa: BLE001 — fail-open; intents 422 instead
+            logger.exception(
+                f"intents: flavor {flavor!r} failed to load from "
+                f"{module_path!r}; its intents stay unregistered and will "
+                "answer 'unknown_intent'"
+            )
+        # Marked either way — see _LOADED_FLAVOR_INTENTS.
+        _LOADED_FLAVOR_INTENTS.add(flavor)
+
+
+def register_intents(flavor: str, policies: Dict[str, IntentPolicy]) -> None:
+    """Register a flavor's intent policies (called at flavor import time).
+
+    Stamps ``flavor`` onto each policy. Idempotent for re-registration of
+    the same flavor; a cross-flavor name collision raises — intent names
+    are a global namespace on the wire.
+    """
+    for name, policy in policies.items():
+        existing = INTENT_POLICY.get(name)
+        if existing is not None and existing.flavor != flavor:
+            raise ValueError(
+                f"intent {name!r} already registered by flavor "
+                f"{existing.flavor!r}; refusing {flavor!r}"
+            )
+        INTENT_POLICY[name] = replace(policy, flavor=flavor)
+
+
+def template_enabled_flavors(template: Any) -> Set[str]:
+    """The template's enabled UI-catalog groups — the flavor scope used to
+    lazy-load and gate intents. Config absent → ``{"core"}`` (same default
+    as ``ui_catalog.resolve_allowlist``)."""
+    configurations = getattr(template, "configurations", None)
+    ui_cat = configurations.ui_catalog if configurations else None
+    if ui_cat is None:
+        return {"core"}
+    return set(ui_cat.enabled_groups or [])
+
+
+class IntentValidationError(ValueError):
+    """Typed 422 payload for the widget (rendered as a Message primitive).
+    ``detail`` is the HTTPException-ready body."""
+
+    def __init__(
+        self, code: str, message: str, errors: Optional[List[Dict[str, Any]]] = None
+    ) -> None:
+        super().__init__(message)
+        self.detail: Dict[str, Any] = {"code": code, "message": message}
+        if errors:
+            self.detail["errors"] = errors
+
+
+class IntentApprovalRequired(RuntimeError):
+    """A DIRECT policy tried to dispatch an approval-gated tool.
+
+    Raised by :func:`run_persisted_tool` BEFORE dispatch and converted into
+    the terminal ``intent_failed`` pair by :func:`run_direct_intent`. The
+    no-LLM path has nowhere to put an approval card (there is no assistant
+    turn to suspend), so a gated tool fails closed here and the user is
+    pointed at the chat surface, which does have the HITL flow.
+    """
+
+    def __init__(self, tool_name: str) -> None:
+        super().__init__(f"tool {tool_name!r} requires human approval")
+        self.tool_name = tool_name
+
+
+@dataclass(frozen=True)
+class ParsedIntent:
+    """A wire intent validated against its policy-table payload schema."""
+
+    intent: UiIntent
+    policy: IntentPolicy
+    payload: BaseModel
+
+
+def _structural_errors(exc: ValidationError) -> List[Dict[str, Any]]:
+    """Field paths + error kinds only — never input values (same privacy
+    contract as ui_op_dropped telemetry)."""
+    return [
+        {
+            "loc": ".".join(str(p) for p in err.get("loc", ())),
+            "type": err.get("type"),
+        }
+        for err in exc.errors()[:5]
+    ]
+
+
+def parse_ui_intent(
+    raw: Dict[str, Any], *, enabled_flavors: Optional[Set[str]] = None
+) -> ParsedIntent:
+    """Validate one raw ``ui_intent`` body against the wire model + the
+    per-intent payload schema. Raises :class:`IntentValidationError` (422
+    at the HTTP layer) for unknown intents, intents whose flavor the
+    session's template doesn't enable, or invalid payloads.
+
+    ``enabled_flavors`` is the template's flavor scope (see
+    :func:`template_enabled_flavors`); callers must run
+    :func:`ensure_flavor_intents` on it first so an enabled flavor's
+    intents are actually registered. ``None`` skips the flavor gate
+    (trusted/internal callers only).
+    """
+    try:
+        wire = UiIntent.model_validate(raw)
+    except ValidationError as exc:
+        raise IntentValidationError(
+            "invalid_intent", "Malformed ui_intent body", _structural_errors(exc)
+        ) from exc
+
+    policy = INTENT_POLICY.get(wire.intent)
+    if policy is None:
+        # Also the path taken when the intent's flavor was never loaded in
+        # this process — an unregistered intent is indistinguishable from
+        # an unknown one, and both are a typed 422.
+        raise IntentValidationError("unknown_intent", f"Unknown intent {wire.intent!r}")
+    if enabled_flavors is not None and policy.flavor not in enabled_flavors:
+        raise IntentValidationError(
+            "flavor_not_enabled",
+            f"Intent {wire.intent!r} requires the {policy.flavor!r} flavor, "
+            "which this template does not enable.",
+        )
+
+    try:
+        payload = policy.payload_model.model_validate(wire.payload)
+    except ValidationError as exc:
+        raise IntentValidationError(
+            "invalid_intent_payload",
+            f"Invalid payload for intent {wire.intent!r}",
+            _structural_errors(exc),
+        ) from exc
+
+    return ParsedIntent(intent=wire, policy=policy, payload=payload)
+
+
+def agent_turn_content(parsed: ParsedIntent) -> str:
+    """Rewrite an ``agent_turn``-routed intent into the structured user
+    message the LLM answers (RFC-001 §3.3), via the policy's flavor-provided
+    rewriter. Falling back to the visible display keeps a policy without a
+    rewriter from crashing the rewrite."""
+    if parsed.policy.agent_turn is not None:
+        return parsed.policy.agent_turn(parsed)
+    return parsed.intent.display or parsed.intent.intent
+
+
+# ---------------------------------------------------------------------------
+# Direct executor — engine shell + the seams flavor drivers build on
+# ---------------------------------------------------------------------------
+
+
+def error_events(code: str, message: str) -> List[SSEEvent]:
+    """Terminal ``intent_failed`` + ``turn_end`` pair for a DIRECT intent
+    that could not complete. Session stays ACTIVE — a failed intent must
+    not brick the conversation. Part of the flavor-driver surface
+    (drivers yield these on pre-dispatch failures).
+
+    Deliberately NOT the ``error`` SSE event: the widget renders
+    ``intent_failed`` as an in-thread notice with ``message`` (the intent
+    itself was rejected, and retrying it unchanged fails identically),
+    while ``error`` drives the delivery-failure banner with a Retry
+    affordance. ``message`` must therefore be user-displayable.
+    """
+    return [
+        SSEEvent(event="intent_failed", data={"code": code, "message": message}),
+        SSEEvent(event="turn_end", data={"session_status": "ACTIVE"}),
+    ]
+
+
+async def _persist_tool_step(session_id: str, call: Any, result_payload: Any) -> None:
+    """Persist one direct dispatch as the standard assistant(tool_use) +
+    user(tool_result) row pair, so replayed history stays fully answered
+    and the LLM sees the mutation on its next turn."""
+    await insert_chat_message(
+        session_id=session_id,
+        role=ChatMessageRole.ASSISTANT,
+        content=None,
+        content_blocks=assistant_turn_to_blocks("", [call]),
+    )
+    await insert_chat_message(
+        session_id=session_id,
+        role=ChatMessageRole.USER,
+        content=None,
+        content_blocks=tool_results_to_user_blocks(
+            [(call.tool_call_id, result_payload)]
+        ),
+    )
+
+
+async def _merge_state_delta(
+    session_id: str, baseline: Dict[str, Any], current: Dict[str, Any]
+) -> None:
+    """Persist the reducer-driven state delta (key-scoped merge, same
+    contract as ``_cycle_loop``).
+
+    Idempotent for unchanged keys and always diffed from the SAME baseline,
+    so calling it again after a follow-up advances state further just writes
+    a superset.
+    """
+    patch = diff_state_patch(baseline, current)
+    if patch:
+        await upsert_agent_session_state_merge(chat_session_id=session_id, patch=patch)
+
+
+async def run_persisted_tool(
+    agent: ChatAgent,
+    *,
+    tool_name: str,
+    args: Dict[str, Any],
+    node: Dict[str, Any],
+    prep: Any,
+    turn_id: str,
+) -> Tuple[List[SSEEvent], Any]:
+    """Dispatch ONE tool through the existing pipeline and persist it.
+
+    The engine-owned building block flavor drivers compose their tool
+    sequences from: ``ChatAgent.run_direct_tool`` (inject_tool_args →
+    dispatch → binding store → reducers) + the standard row-pair
+    persistence + the ``function_call_started`` / ``function_call_completed``
+    SSE pair. Returns ``(events, result_payload)``.
+
+    HITL is enforced HERE, not in each driver: this is the single choke
+    point every DIRECT policy dispatches through, so a template that gates
+    a tool behind human approval gates it on both surfaces. Without this a
+    tool would be gated when the LLM calls it and free when a component
+    button fires it — and chat has no second line of defence, since
+    ``handles_approval_externally`` disables the handler-level gate that
+    voice relies on.
+    """
+    if is_approval_gated(tool_name, agent._approval_map, node):
+        raise IntentApprovalRequired(tool_name)
+    call, result = await agent.run_direct_tool(
+        tool_name=tool_name, args=args, node=node, prep=prep, turn_id=turn_id
+    )
+    await _persist_tool_step(agent.session_id, call, result)
+    events = [
+        SSEEvent(
+            event="function_call_started",
+            data={
+                "name": tool_name,
+                # The driver's args, NOT ``call.arguments`` — the latter is
+                # post-injection (tool_arg_injection pulls identifiers and
+                # generated values out of agent_session_state, which stays
+                # server-internal). The LLM path emits pre-injection args
+                # here too; both surfaces tell the client the same thing.
+                "args": dict(args),
+                "tool_call_id": call.tool_call_id,
+            },
+        ),
+        SSEEvent(
+            event="function_call_completed",
+            data={
+                "name": tool_name,
+                "tool_call_id": call.tool_call_id,
+                "result_summary": None,
+            },
+        ),
+    ]
+    return events, result
+
+
+async def run_direct_intent(
+    *, session_id: str, parsed: ParsedIntent
+) -> AsyncIterator[SSEEvent]:
+    """Serve one DIRECT-routed intent: the policy's flavor tools through
+    the existing pipeline, hydrated component + ``turn_end`` over SSE —
+    no LLM call.
+
+    Mirrors ``run_chat_turn``'s load-everything-itself shape (terminal
+    ``error`` + ``turn_end`` events instead of raising — the HTTP shell
+    pre-validates, the SSE stream has no status code to change). The
+    ``ChatAgent`` here is a dispatch chassis only: ``llm=None`` and no
+    ``_cycle_loop`` entry, so no LLM client is ever constructed. The
+    flavor content — which tools run and which component shows — comes
+    entirely off ``parsed.policy`` (``drive`` / ``show_op``).
+    """
+    session = await get_chat_session_by_id(session_id)
+    if session is None or session.status == ChatSessionStatus.ENDED:
+        yield SSEEvent(
+            event="error",
+            data={"code": "session_gone", "message": "Session no longer active"},
+        )
+        yield SSEEvent(event="turn_end", data={"session_status": "FAILED"})
+        return
+    template = await get_template_by_id_cached(session.template_id)
+    if template is None:
+        yield SSEEvent(
+            event="error",
+            data={"code": "template_missing", "message": "Template missing"},
+        )
+        yield SSEEvent(event="turn_end", data={"session_status": "FAILED"})
+        return
+
+    # Persist the visible user bubble + the full intent as an internal
+    # audit block: widget transcripts show only `display`; the LLM (and
+    # the audit trail) keep the typed intent via the internal block.
+    display = (
+        parsed.intent.display or parsed.policy.default_display or parsed.intent.intent
+    )
+    audit = json.dumps(
+        {"ui_intent": parsed.intent.model_dump(exclude_none=True)},
+        ensure_ascii=False,
+        default=str,
+    )
+    if parsed.policy.silent:
+        # No visible trace: the audit block (which carries the full typed
+        # intent) is the only record — internal visibility, so widget
+        # transcripts and resume replay skip the row entirely while the
+        # LLM still sees what the user did.
+        await insert_chat_message(
+            session_id=session_id,
+            role=ChatMessageRole.USER,
+            content=None,
+            content_blocks=[internal_text_block(audit)],
+        )
+    else:
+        user_msg = await insert_chat_message(
+            session_id=session_id,
+            role=ChatMessageRole.USER,
+            content=display,
+            content_blocks=[*plain_text_blocks(display), internal_text_block(audit)],
+        )
+        yield SSEEvent(
+            event="user_committed",
+            data={"idx": user_msg.idx if user_msg else None, "content": display},
+        )
+
+    state_row = await get_agent_session_state(session_id)
+    agent_state: Dict[str, Any] = state_row.data if state_row else {}
+    state_baseline = copy.deepcopy(agent_state)
+    persisted_vars = (
+        session.metadata.get("template_vars", {})
+        if isinstance(session.metadata, dict)
+        else {}
+    )
+    template_vars = await build_render_template_vars(template, persisted_vars)
+
+    agent = ChatAgent(
+        session_id=session_id,
+        template=template,
+        llm=None,  # direct path — no LLM client, ever
+        template_vars=template_vars,
+        agent_state=agent_state,
+        catalog_version=resolve_session_catalog_version(session.metadata),
+    )
+    agent.aiohttp_session = create_aiohttp_session()
+    agent.mcp_pool = {}
+    turn_id = uuid.uuid4().hex
+    try:
+        drive = parsed.policy.drive
+        if drive is None:
+            # Defensive — the HTTP layer only routes DIRECT policies here,
+            # and flavor registration provides ``drive`` for those.
+            for ev in error_events(
+                "invalid_intent", f"Intent {parsed.intent.intent!r} is not direct."
+            ):
+                yield ev
+            return
+        prep, node = await agent.prepare_direct_dispatch(session.current_node)
+
+        final_tool: Optional[str] = None
+        final_result: Any = None
+        try:
+            async for event, tool_name, result in drive(
+                agent, prep, node, parsed, turn_id
+            ):
+                if event is not None:
+                    yield event
+                if tool_name is not None:
+                    final_tool, final_result = tool_name, result
+        except IntentApprovalRequired as exc:
+            logger.warning(
+                f"intent_router {session_id}: {parsed.intent.intent} needs "
+                f"approval for {exc.tool_name} — refusing the direct path"
+            )
+            await _merge_state_delta(session_id, state_baseline, agent.agent_state)
+            for ev in error_events(
+                "intent_requires_approval",
+                "This action needs to be confirmed first. Ask the assistant "
+                "in the chat and approve it there.",
+            ):
+                yield ev
+            return
+
+        # Persist the reducer delta on EVERY outcome, before branching on
+        # the result. Each dispatch's tool rows are already committed by
+        # run_persisted_tool, so returning early without this would leave
+        # agent_session_state behind what history says happened — a later
+        # turn would then re-derive identifiers the reducers had already
+        # captured. The LLM path persists unconditionally too (_cycle_loop).
+        await _merge_state_delta(session_id, state_baseline, agent.agent_state)
+
+        if final_tool is None:
+            # The driver already emitted the terminal error events.
+            return
+
+        if not _is_tool_success(final_result):
+            logger.warning(
+                f"intent_router {session_id}: {parsed.intent.intent} via "
+                f"{final_tool} returned an error envelope"
+            )
+            # Prefer the flavor's display-grade reason off the upstream
+            # payload — a precise message beats "please try again" copy for
+            # a failure that would repeat identically on retry.
+            message: Optional[str] = None
+            if parsed.policy.failure_message is not None:
+                try:
+                    message = parsed.policy.failure_message(final_result)
+                except Exception:  # noqa: BLE001 — extractor is best-effort
+                    message = None
+            for ev in error_events(
+                "intent_tool_failed",
+                message or "The update could not be completed. Please try again.",
+            ):
+                yield ev
+            return
+
+        # Hydrate the policy's component exactly the way a `show` op would
+        # — same resolver, same schema validation, same v:2 wire shape.
+        # Events are collected, not yielded: the acknowledgement bubble
+        # goes on the wire FIRST so the thread reads "Done." above the
+        # component (matching LLM turns, whose prose streams before UI).
+        hydrated_ops: List[Dict[str, Any]] = []
+        ui_events: List[SSEEvent] = []
+        if parsed.policy.show_op is not None:
+            show_op = parsed.policy.show_op(final_tool, final_result, agent)
+            resolved = resolve_show_op(show_op, agent.binding_store, agent.ui_allowlist)
+            if resolved.op is not None:
+                hydrated_ops.append(resolved.op)
+                ui_events.append(ui_op_event(resolved.op))
+            else:
+                ui_events.append(
+                    ui_op_dropped_event(
+                        json.dumps(show_op, ensure_ascii=False),
+                        resolved.error or "bind_unresolved",
+                    )
+                )
+
+        # Flavor acknowledgement: one short assistant line ("Done.")
+        # alongside the rendered component — persisted like any prose turn
+        # so resume replays it.
+        ack_text: Optional[str] = None
+        if parsed.policy.ack_message is not None and not parsed.policy.silent:
+            try:
+                ack_text = parsed.policy.ack_message(parsed, final_tool, final_result)
+            except Exception:  # noqa: BLE001 — ack is best-effort, never fatal
+                ack_text = None
+
+        assistant_idx: Optional[int] = None
+        # RFC-002 Phase B: render_ui sessions never write the legacy
+        # marker (replayed markers bred the F1 mimicry bug); the persisted
+        # tool exchange already carries the underlying data. Fleet
+        # text-channel sessions keep it.
+        ui_summary = (
+            ""
+            if getattr(agent, "_render_ui_enabled", False)
+            else summarize_ui_ops(hydrated_ops)
+        )
+        if hydrated_ops or ack_text:
+            blocks: List[Dict[str, Any]] = (
+                [*plain_text_blocks(ack_text)] if ack_text else []
+            )
+            if ui_summary:
+                blocks.append(internal_text_block(ui_summary))
+            stored = await insert_chat_message(
+                session_id=session_id,
+                role=ChatMessageRole.ASSISTANT,
+                content=ack_text,
+                content_blocks=blocks or None,
+                # Silent intents: the component streamed to the live
+                # overlay only — never a replayable thread block.
+                ui_blocks=None if parsed.policy.silent else (hydrated_ops or None),
+            )
+            assistant_idx = stored.idx if stored else None
+            if ack_text:
+                yield SSEEvent(
+                    event="assistant_message",
+                    data={"idx": assistant_idx, "content": ack_text},
+                )
+        for ev in ui_events:
+            yield ev
+
+        # Post-success follow-up: runs with the ack + primary component
+        # ALREADY delivered, so its latency (which may include its own LLM
+        # call and tool dispatches) is invisible — the turn simply stays
+        # open a moment longer. Fail-open: any error → no block, turn ends
+        # normally.
+        if parsed.policy.followup is not None and not parsed.policy.silent:
+            followup_op: Optional[Dict[str, Any]] = None
+            try:
+                followup_op = await parsed.policy.followup(
+                    agent, prep, node, parsed, turn_id, final_tool, final_result
+                )
+            except Exception:  # noqa: BLE001 — decoration, never fatal
+                logger.exception(
+                    f"intent_router {session_id}: followup for "
+                    f"{parsed.intent.intent} failed"
+                )
+            if followup_op is not None:
+                # The follow-up's own tool dispatches may have advanced
+                # reducer state past the delta persisted above — merge the
+                # full diff again (idempotent for unchanged keys).
+                await _merge_state_delta(session_id, state_baseline, agent.agent_state)
+                await insert_chat_message(
+                    session_id=session_id,
+                    role=ChatMessageRole.ASSISTANT,
+                    content=None,
+                    content_blocks=None,
+                    ui_blocks=[followup_op],
+                )
+                yield ui_op_event(followup_op)
+
+        await update_chat_session_after_turn(
+            session_id=session_id, current_node=session.current_node
+        )
+        yield SSEEvent(
+            event="turn_end",
+            data={"session_status": "ACTIVE", "assistant_idx": assistant_idx},
+        )
+    finally:
+        if agent.aiohttp_session is not None:
+            await agent.aiohttp_session.close()
+            agent.aiohttp_session = None
+        await close_mcp_pool(agent.mcp_pool)
+        agent.mcp_pool = None
+
+
+__all__ = [
+    "UiIntent",
+    "IntentRoute",
+    "IntentPolicy",
+    "INTENT_POLICY",
+    "FLAVOR_INTENT_MODULES",
+    "register_intents",
+    "ensure_flavor_intents",
+    "template_enabled_flavors",
+    "IntentValidationError",
+    "IntentApprovalRequired",
+    "ParsedIntent",
+    "parse_ui_intent",
+    "agent_turn_content",
+    "error_events",
+    "run_persisted_tool",
+    "run_direct_intent",
+    "DirectDriveFn",
+    "ShowOpBuilderFn",
+    "FollowupFn",
+]

--- a/app/ai/voice/agents/breeze_buddy/template/ui_catalog.py
+++ b/app/ai/voice/agents/breeze_buddy/template/ui_catalog.py
@@ -73,6 +73,8 @@ from pydantic import (
     model_validator,
 )
 
+from app.core.logger import logger
+
 CATALOG_VERSION: str = "v1"
 
 # Wire value a catalog-v2-capable widget sends at session create (RFC-001
@@ -1040,8 +1042,12 @@ LAZY_GROUPS: Dict[str, str] = {
     "commerce": "app.ai.voice.agents.breeze_buddy.assist.commerce.schemas",
 }
 
-# Fast-path guard only — ``importlib.import_module`` is already idempotent
-# via sys.modules; this just skips the call on the hot path.
+# Attempted groups — both the successes (``importlib.import_module`` is
+# already idempotent via sys.modules; this skips the call on the hot path)
+# and the failures, which must NOT be retried per request: Python drops a
+# failed module from sys.modules, so an unguarded retry re-raises on every
+# call for the life of the process. A broken flavor needs a deploy to fix,
+# not another import.
 _LOADED_LAZY_GROUPS: Set[str] = set()
 
 
@@ -1052,11 +1058,26 @@ def ensure_group_loaded(group: str) -> None:
     process-global and additive-only: loading a flavor never mutates or
     removes existing catalog entries, so per-session gating stays purely
     allowlist-driven.
+
+    Fail-open by contract: a flavor module that is absent (its layer has
+    not shipped yet) or raises on import must not take down the request.
+    The group simply registers nothing, so ``resolve_allowlist`` yields the
+    core primitives and the session degrades to v1 — the same outcome as a
+    template that never enabled the group — instead of surfacing an
+    ImportError as a 500 from whatever endpoint happened to touch it.
     """
     module_path = LAZY_GROUPS.get(group)
     if module_path is None or group in _LOADED_LAZY_GROUPS:
         return
-    importlib.import_module(module_path)
+    try:
+        importlib.import_module(module_path)
+    except Exception:  # noqa: BLE001 — fail-open; a flavor is never load-bearing
+        logger.exception(
+            f"ui_catalog: flavor group {group!r} failed to load from "
+            f"{module_path!r}; its components stay unregistered and sessions "
+            "enabling it degrade to the core catalog"
+        )
+    # Marked either way — see _LOADED_LAZY_GROUPS.
     _LOADED_LAZY_GROUPS.add(group)
 
 

--- a/app/api/routers/breeze_buddy/chat/cancel_bus.py
+++ b/app/api/routers/breeze_buddy/chat/cancel_bus.py
@@ -189,10 +189,11 @@ async def _subscriber_loop() -> None:
             logger.info("cancel_bus: subscriber cancelled (app shutdown)")
             raise
         except Exception as exc:
-            logger.error(
+            # loguru: no ``exc_info`` kwarg — it would re-format the message
+            # and crash on brace-bearing error text.
+            logger.exception(
                 f"cancel_bus: subscriber error ({exc!r}); "
-                f"reconnecting in {backoff:.1f}s",
-                exc_info=True,
+                f"reconnecting in {backoff:.1f}s"
             )
             await asyncio.sleep(backoff)
             backoff = min(backoff * 2, 30.0)

--- a/app/api/routers/breeze_buddy/chat/demo.py
+++ b/app/api/routers/breeze_buddy/chat/demo.py
@@ -27,13 +27,16 @@ from __future__ import annotations
 
 from fastapi import APIRouter, Depends, HTTPException, Request, status
 
+from app.ai.voice.agents.breeze_buddy.chat.turn_core import negotiate_catalog
 from app.ai.voice.agents.breeze_buddy.template.cache import get_template_by_id_cached
+from app.ai.voice.agents.breeze_buddy.template.ui_catalog import CATALOG_VERSION_V2
 from app.api.routers.breeze_buddy.chat.handlers import (
     approve_chat_tool_handler,
     create_chat_session_handler,
     end_chat_session_handler,
     load_chat_session_or_404,
     send_chat_message_handler,
+    serve_session_intent,
     validate_template_for_chat,
 )
 from app.api.security.breeze_buddy.demo_token import (
@@ -209,10 +212,23 @@ async def create_demo_session(
     # mid-create flag flip can't disagree with what's persisted in
     # metadata vs. the JWT.
     cap = await DEMO_MESSAGE_CAP_PER_SESSION()
+    # Demo pages ship the current widget build, so the client side of the
+    # catalog negotiation is implicitly "v2" — the template's capability is
+    # the only variable. Persisting the same server-owned ``widget`` block
+    # the real widget path uses keeps one resolver
+    # (resolve_session_catalog_version) across every surface.
+    catalog_active, ui_flavors = negotiate_catalog(template, CATALOG_VERSION_V2)
     create_req = CreateChatSessionRequest(
         template_id=template_id,
         template_vars=req.template_vars,
-        metadata={"demo": {"slug": req.slug, "cap": cap}},
+        metadata={
+            "demo": {"slug": req.slug, "cap": cap},
+            **(
+                {"widget": {"catalog_version": catalog_active}}
+                if catalog_active == CATALOG_VERSION_V2
+                else {}
+            ),
+        },
     )
     create_resp = await create_chat_session_handler(
         create_req, template, synthetic_user
@@ -229,6 +245,8 @@ async def create_demo_session(
         greeting=create_resp.greeting,
         demo_token=token,
         message_cap=cap,
+        catalog_active=catalog_active,
+        ui_flavors=ui_flavors,
     )
 
 
@@ -298,6 +316,14 @@ async def demo_send_message(
     be redundant.
     """
     await _enforce_demo_turn_budget(request, ctx, session_id)
+
+    # Typed UI intent body (RFC-001 §3.3) — same validate + policy-route
+    # path the widget uses, so demo pages exercise the full intent stack.
+    if req.ui_intent is not None:
+        session = await load_chat_session_or_404(session_id)
+        return await serve_session_intent(
+            session, session_id, req.ui_intent, context=req.context
+        )
 
     return await send_chat_message_handler(session_id, req, access_check=None)
 

--- a/app/api/routers/breeze_buddy/chat/handlers.py
+++ b/app/api/routers/breeze_buddy/chat/handlers.py
@@ -25,11 +25,22 @@ from app.ai.voice.agents.breeze_buddy.chat.client_context import (
 from app.ai.voice.agents.breeze_buddy.chat.history.block_codec import (
     filter_visible_blocks,
 )
+from app.ai.voice.agents.breeze_buddy.chat.intents.router import (
+    IntentRoute,
+    IntentValidationError,
+    ParsedIntent,
+    agent_turn_content,
+    ensure_flavor_intents,
+    parse_ui_intent,
+    run_direct_intent,
+    template_enabled_flavors,
+)
 from app.ai.voice.agents.breeze_buddy.chat.metrics import TurnMetrics
 from app.ai.voice.agents.breeze_buddy.chat.sse import SSEEvent, format_sse
 from app.ai.voice.agents.breeze_buddy.chat.turn_core import (
     build_render_template_vars,
     resolve_llm_configuration,
+    resolve_session_catalog_version,
     run_chat_approval_continuation,
     run_chat_turn,
 )
@@ -38,6 +49,7 @@ from app.ai.voice.agents.breeze_buddy.template.transformation_function import (
     TEMPLATE_FUNCTION_REGISTRY,
 )
 from app.ai.voice.agents.breeze_buddy.template.types import TemplateModel
+from app.ai.voice.agents.breeze_buddy.template.ui_catalog import CATALOG_VERSION_V2
 from app.api.routers.breeze_buddy.analytics.rbac import apply_hierarchical_filters
 from app.core.logger import logger
 from app.database.accessor.breeze_buddy.chat_session import (
@@ -372,13 +384,72 @@ async def get_chat_session_handler(session: ChatSession) -> GetChatSessionRespon
     )
 
 
+async def apply_piggyback_context(
+    session_id: str, template: Any, context: Any
+) -> Optional[str]:
+    """Persist an optional state/facts patch riding with a message or intent
+    (CLIENT_CONTEXT_UPDATES.md §5.2); returns the requested placement.
+
+    Persisted under the caller's lock BEFORE the turn builds, so the turn
+    re-reads it on THIS turn (vs. the standalone /context endpoint, which
+    lands next turn). Allowlist-gated by the template policy; an
+    unconfigured template silently no-ops. The 413 must surface here,
+    before the SSE stream opens, so this validation stays in the HTTP shell
+    (voice never sends a piggyback context, so run_chat_turn omits it).
+
+    Shared by the message path and the DIRECT-intent path — an intent's
+    piggybacked context has to land before its tools dispatch, or
+    inject_tool_args reads stale identifiers.
+    """
+    if context is None:
+        return None
+    cc_config = (
+        template.configurations.client_context if template.configurations else None
+    )
+    state_row = await get_agent_session_state(session_id)
+    agent_state: Dict[str, Any] = state_row.data if state_row else {}
+    try:
+        state_patch, facts_patch, replace_facts, _, _ = compute_context_patch(
+            agent_state,
+            state=context.state,
+            facts=context.facts,
+            merge=context.merge,
+            config=cc_config,
+        )
+    except ClientContextTooLarge as exc:
+        raise HTTPException(
+            status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            detail=str(exc),
+        ) from exc
+    # Persist via the atomic merge (message-bound, no revision) so a
+    # concurrent standalone /context push isn't clobbered; the turn's own
+    # write excludes the client-context keys. ``facts_patch`` is None only
+    # when the push carried no facts; an empty {} (a merge='replace' facts
+    # clear) IS a real write, so gate on ``is not None``.
+    if state_patch or facts_patch is not None:
+        await merge_client_context(
+            session_id,
+            state_patch=state_patch,
+            facts_patch=facts_patch,
+            revision=None,
+            replace_facts=replace_facts,
+        )
+    return context.placement
+
+
 async def send_chat_message_handler(
     session_id: str,
     req: SendChatMessageRequest,
     *,
     access_check: Optional[Callable[[ChatSession], None]] = None,
+    internal: bool = False,
 ) -> StreamingResponse:
     """Drive one turn; stream SSE events until ``turn_end``.
+
+    ``internal`` — the turn is an internal AGENT_TURN intent (see
+    ``IntentPolicy.internal``): the exchange persists with
+    visibility=internal and no ``user_committed`` fires. Only
+    ``serve_session_intent`` sets this; the HTTP routes never expose it.
 
     Multi-pod safe: the per-session Redis lock guarantees one driver
     at a time. The lock is acquired before the SSE response opens so
@@ -447,52 +518,9 @@ async def send_chat_message_handler(
                 ),
             )
 
-        # Piggyback context patch (CLIENT_CONTEXT_UPDATES.md §5.2): an
-        # optional state/facts update riding with this message. Persisted
-        # under the lock BEFORE the turn builds, so ``run_chat_turn`` re-reads
-        # it on THIS turn (vs. the standalone /context endpoint, which lands
-        # next turn). Allowlist-gated by the template policy; an unconfigured
-        # template silently no-ops. The 413 must surface here, before the SSE
-        # stream opens, so this validation stays in the HTTP shell (voice
-        # never sends a piggyback context, so run_chat_turn omits it).
-        context_placement: Optional[str] = None
-        if req.context is not None:
-            cc_config = (
-                template.configurations.client_context
-                if template.configurations
-                else None
-            )
-            state_row = await get_agent_session_state(session_id)
-            agent_state: Dict[str, Any] = state_row.data if state_row else {}
-            try:
-                state_patch, facts_patch, replace_facts, _, _ = compute_context_patch(
-                    agent_state,
-                    state=req.context.state,
-                    facts=req.context.facts,
-                    merge=req.context.merge,
-                    config=cc_config,
-                )
-            except ClientContextTooLarge as exc:
-                raise HTTPException(
-                    status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
-                    detail=str(exc),
-                ) from exc
-            # Persist via the atomic merge (message-bound, no revision) so a
-            # concurrent standalone /context push isn't clobbered; the turn's
-            # own write (agent.py) excludes the client-context keys.
-            # ``run_chat_turn`` re-loads agent_state below, so it sees this
-            # patch on THIS turn. ``facts_patch`` is None only when the push
-            # carried no facts; an empty {} (a merge='replace' facts clear) IS
-            # a real write, so gate on ``is not None``.
-            if state_patch or facts_patch is not None:
-                await merge_client_context(
-                    session_id,
-                    state_patch=state_patch,
-                    facts_patch=facts_patch,
-                    revision=None,
-                    replace_facts=replace_facts,
-                )
-            context_placement = req.context.placement
+        context_placement = await apply_piggyback_context(
+            session_id, template, req.context
+        )
 
         # Phase-0 measurement (docs/widget/UI_FAST_RELIABLE_GENERIC_PLAN.md):
         # observe the turn's SSE stream and log one [CHAT_METRICS] line at the
@@ -517,7 +545,197 @@ async def send_chat_message_handler(
                     session_id=session_id,
                     user_content=req.content,
                     context_placement=context_placement,
+                    internal=internal,
                 ),
+            ),
+            media_type="text/event-stream",
+            headers={
+                "Cache-Control": "no-cache, no-transform",
+                "X-Accel-Buffering": "no",
+                "Connection": "keep-alive",
+            },
+        )
+        lock_handed_off = True
+        return response
+    finally:
+        if not lock_handed_off:
+            await lock.release()
+
+
+async def serve_session_intent(
+    session: Any,
+    session_id: str,
+    raw_intent: Dict[str, Any],
+    *,
+    context: Any = None,
+    voice_live: bool = False,
+):
+    """Validate + policy-route one raw ``ui_intent`` dict and serve it.
+
+    The shared engine behind every intent surface — the widget's dedicated
+    ``POST /intent`` route, the ``ui_intent`` body variant on ``/message``
+    (the door for surfaces with no intent route of their own, i.e. the demo
+    router), and any future caller. Routing them all through here is what
+    keeps the surfaces from drifting apart. Unknown intent / flavor not
+    enabled / invalid payload → 422 with a typed error the widget renders
+    in-thread. Intent policies are flavor content, lazy-loaded per the
+    template's enabled UI-catalog groups — a template without a flavor
+    never loads (nor matches) that flavor's intents.
+
+    ``voice_live`` — the session currently has a voice attachment. DIRECT
+    intents still execute (no LLM turn is involved; the mutation lands in
+    history, so the voice brain sees it next turn). AGENT_TURN intents
+    would inject a competing chat turn into a live voice conversation, so
+    they 409 with the typed ``voice_live`` code instead.
+    """
+    template = await get_template_by_id_cached(session.template_id)
+    if template is None:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=(
+                f"Template '{session.template_id}' for session "
+                f"'{session_id}' no longer exists"
+            ),
+        )
+    if resolve_session_catalog_version(session.metadata) != CATALOG_VERSION_V2:
+        # v1 sessions never see v2 emission — a stray intent from a
+        # mismatched client fails closed rather than half-rendering. Checked
+        # BEFORE the flavor load + parse: a session that can never execute an
+        # intent shouldn't pay for a flavor import, and the version mismatch
+        # is the accurate diagnosis to return (parsing first would report
+        # ``unknown_intent`` for a name the client is simply not allowed to
+        # send yet).
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail={
+                "code": "catalog_version_unsupported",
+                "message": (
+                    "ui_intent requires a session created with " "catalog_version 'v2'."
+                ),
+            },
+        )
+    flavors = template_enabled_flavors(template)
+    ensure_flavor_intents(flavors)
+    try:
+        parsed = parse_ui_intent(raw_intent, enabled_flavors=flavors)
+    except IntentValidationError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=exc.detail,
+        ) from exc
+    if parsed.policy.route is IntentRoute.CLIENT:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail={
+                "code": "client_side_intent",
+                "message": (
+                    f"Intent {parsed.intent.intent!r} is handled by the "
+                    "widget itself; no server call is expected."
+                ),
+            },
+        )
+    if parsed.policy.route is IntentRoute.DIRECT:
+        return await send_chat_intent_handler(
+            session_id, parsed, context=context, access_check=None
+        )
+    if voice_live:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={
+                "code": "voice_live",
+                "message": (
+                    f"Intent {parsed.intent.intent!r} needs an agent turn, "
+                    "which can't run while a voice attachment is live. End "
+                    "voice first, or ask the agent by speaking."
+                ),
+            },
+        )
+    # agent_turn — rewrite into the structured user turn and serve it as
+    # a normal chat turn. Internal policies persist the whole exchange
+    # with visibility=internal — the LLM keeps the context; resume replay
+    # never shows it.
+    return await send_chat_message_handler(
+        session_id,
+        SendChatMessageRequest(content=agent_turn_content(parsed), context=context),
+        access_check=None,
+        internal=parsed.policy.internal,
+    )
+
+
+async def send_chat_intent_handler(
+    session_id: str,
+    parsed: ParsedIntent,
+    *,
+    context: Any = None,
+    access_check: Optional[Callable[[ChatSession], None]] = None,
+) -> StreamingResponse:
+    """Drive one DIRECT-routed UI intent (RFC-001 §3.3); stream SSE until
+    ``turn_end``. The no-LLM sibling of ``send_chat_message_handler`` —
+    same per-session lock, same SSE scaffolding, same metrics observer;
+    the events come from ``run_direct_intent`` instead of a chat turn.
+    The caller (widget route) has already validated + policy-routed the
+    intent and checked the session's catalog version.
+
+    ``context`` — the same optional piggybacked state/facts patch
+    ``/message`` accepts. Applied under the lock BEFORE the intent's tools
+    dispatch, so ``inject_tool_args`` sees the client's latest identifiers
+    rather than the previous turn's.
+    """
+    lock = RedisLock(_lock_key(session_id), ttl_seconds=_SESSION_LOCK_TTL_SECONDS)
+    try:
+        await lock.acquire()
+    except LockAcquireError:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=(
+                "Another turn is already in flight for this session. "
+                "Wait for the previous /message stream to complete and retry."
+            ),
+        )
+
+    lock_handed_off = False
+    try:
+        fresh = await get_chat_session_by_id(session_id)
+        if fresh is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Chat session '{session_id}' not found",
+            )
+        if access_check is not None:
+            access_check(fresh)
+        if fresh.status == ChatSessionStatus.ENDED:
+            raise HTTPException(
+                status_code=status.HTTP_410_GONE,
+                detail=f"Chat session '{session_id}' has ended",
+            )
+
+        template = await get_template_by_id_cached(fresh.template_id)
+        if template is None:
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail=(
+                    f"Template '{fresh.template_id}' for chat session "
+                    f"'{session_id}' no longer exists"
+                ),
+            )
+
+        # Under the lock, before run_direct_intent loads agent_state — the
+        # intent's tools must dispatch against the client's just-pushed
+        # state, not the previous turn's. Raises 413 before the SSE stream
+        # opens, same as the message path.
+        await apply_piggyback_context(session_id, template, context)
+
+        turn_metrics = TurnMetrics(
+            session_id=session_id,
+            template_id=template.id,
+            t0=time.monotonic(),
+        )
+        response = StreamingResponse(
+            _turn_sse_stream(
+                session_id=session_id,
+                lock=lock,
+                turn_metrics=turn_metrics,
+                events=run_direct_intent(session_id=session_id, parsed=parsed),
             ),
             media_type="text/event-stream",
             headers={
@@ -602,9 +820,12 @@ async def _turn_sse_stream(
             # Full exception (incl. SDK / DB internals) goes to logs; the
             # SSE payload is intentionally generic — provider stack traces,
             # internal URLs, and SQL strings should not reach the client.
-            logger.error(
-                f"chat turn stream for session {session_id} crashed: {exc}",
-                exc_info=True,
+            # NOTE: loguru — never pass ``exc_info=True`` (any kwarg makes
+            # loguru re-``.format()`` the message, and provider error text
+            # routinely contains ``{...}`` JSON → KeyError from inside the
+            # logging call, killing this generator mid-stream).
+            logger.exception(
+                f"chat turn stream for session {session_id} crashed: {exc}"
             )
             yield format_sse(
                 SSEEvent(

--- a/app/api/routers/breeze_buddy/widget/__init__.py
+++ b/app/api/routers/breeze_buddy/widget/__init__.py
@@ -4,6 +4,7 @@ Routes under ``/agent/voice/breeze-buddy/widget``:
 
 - ``POST /widget/session``                              create
 - ``POST /widget/session/{id}/message``                 chat turn (SSE)
+- ``POST /widget/session/{id}/intent``                  typed UI intent (SSE)
 - ``POST /widget/session/{id}/cancel``                  cancel in-flight turn
 - ``POST /widget/session/{id}/context``                 push state/facts (no LLM turn)
 - ``POST /widget/session/{id}/voice/connect``           open voice attachment
@@ -36,6 +37,7 @@ from app.schemas.breeze_buddy.chat import (
     SendChatMessageRequest,
     UpdateWidgetContextRequest,
     UpdateWidgetContextResponse,
+    WidgetIntentRequest,
     WidgetSessionStateResponse,
     WidgetTranscribeResponse,
     WidgetVoiceConnectResponse,
@@ -48,6 +50,7 @@ from .handlers import (
     create_widget_session_handler,
     end_widget_session_handler,
     get_widget_session_state_handler,
+    send_widget_intent_handler,
     send_widget_message_handler,
     transcribe_widget_audio_handler,
     update_widget_context_handler,
@@ -75,6 +78,11 @@ async def widget_get_preflight(session_id: str) -> Response:
 
 @router.options("/session/{session_id}/message")
 async def widget_message_preflight(session_id: str) -> Response:
+    return options_cors_response()
+
+
+@router.options("/session/{session_id}/intent")
+async def widget_intent_preflight(session_id: str) -> Response:
     return options_cors_response()
 
 
@@ -146,6 +154,28 @@ async def send_widget_message(
     ctx: WidgetSessionContext = Depends(require_widget_session),
 ):
     return await send_widget_message_handler(session_id, req, request, ctx)
+
+
+@router.post(
+    "/session/{session_id}/intent",
+    summary="Serve one typed UI intent (SSE) — dedicated catalog-v2 route",
+)
+async def send_widget_intent(
+    session_id: str,
+    req: WidgetIntentRequest,
+    request: Request,
+    ctx: WidgetSessionContext = Depends(require_widget_session),
+):
+    """Typed component action (RFC-001 §3.3 Stage B).
+
+    Direct intents execute the whitelisted tool pipeline with no LLM call;
+    agent-turn intents stream a normal chat turn. Which intents exist is
+    supplied by the flavor packages the session's template enables. Both
+    routes respond with the same SSE stream shape as ``/message``. Unlike
+    ``/message``, DIRECT intents are also accepted while a voice
+    attachment is live.
+    """
+    return await send_widget_intent_handler(session_id, req, request, ctx)
 
 
 @router.post(

--- a/app/api/routers/breeze_buddy/widget/handlers.py
+++ b/app/api/routers/breeze_buddy/widget/handlers.py
@@ -20,6 +20,7 @@ same session.
 from __future__ import annotations
 
 import uuid
+from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
 
 from fastapi import HTTPException, Request, UploadFile, status
@@ -29,11 +30,20 @@ from app.ai.voice.agents.breeze_buddy.chat.client_context import (
     ClientContextTooLarge,
     compute_context_patch,
 )
+from app.ai.voice.agents.breeze_buddy.chat.turn_core import (
+    negotiate_catalog,
+    resolve_session_catalog_version,
+)
 from app.ai.voice.agents.breeze_buddy.services.daily.daily import (
     daily_completion_function,
     start_daily_session,
 )
 from app.ai.voice.agents.breeze_buddy.template.cache import get_template_by_id_cached
+from app.ai.voice.agents.breeze_buddy.template.ui_catalog import (
+    CATALOG_VERSION,
+    CATALOG_VERSION_V2,
+    LAZY_GROUPS,
+)
 from app.ai.voice.stt import TranscriptionError, transcribe_audio
 from app.api.routers.breeze_buddy.chat.handlers import (
     approve_chat_tool_handler,
@@ -42,6 +52,7 @@ from app.api.routers.breeze_buddy.chat.handlers import (
     end_chat_session_handler,
     load_chat_session_or_404,
     send_chat_message_handler,
+    serve_session_intent,
     validate_template_for_chat,
 )
 from app.api.routers.breeze_buddy.widget_common import (
@@ -91,11 +102,13 @@ from app.schemas.breeze_buddy.chat import (
     CreateChatSessionRequest,
     CreateWidgetSessionRequest,
     CreateWidgetSessionResponse,
+    GreetingTileWire,
     QuickReplyWire,
     SendChatMessageRequest,
     UpdateWidgetContextRequest,
     UpdateWidgetContextResponse,
     WidgetChannel,
+    WidgetIntentRequest,
     WidgetSessionStateResponse,
     WidgetTranscribeResponse,
     WidgetVoiceConnectResponse,
@@ -150,18 +163,29 @@ def _is_redirect_action(action: object) -> bool:
     return getattr(action, "type", None) == "open_url"
 
 
-def _extract_widget_config(
-    template: object,
-) -> tuple[List[QuickReplyWire], bool]:
-    """Extract quick-reply options and enable_text_input flag from a template.
+@dataclass(frozen=True)
+class _WidgetSurface:
+    """The template-derived presentation surface a widget session starts with.
 
-    Returns a ``(quick_replies, enable_text_input)`` tuple. Reads directly
-    from ``configurations.quick_replies`` and ``configurations.enable_text_input``;
-    both default to ``([], True)`` when the template defines neither.
+    A named record rather than a tuple on purpose: this grew from two fields
+    to three (greeting tiles) and is read from both the create and the resume
+    path, so positional unpacking is one field away from silently swapping
+    two values at a call site. Add new surface fields HERE, with a default,
+    and every reader keeps working.
     """
+
+    quick_replies: List[QuickReplyWire] = field(default_factory=list)
+    enable_text_input: bool = True
+    greeting_tiles: List[GreetingTileWire] = field(default_factory=list)
+
+
+def _extract_widget_config(template: object) -> _WidgetSurface:
+    """Read the widget presentation surface off a template's
+    ``configurations``; every field falls back to its neutral default when
+    the template configures none of it."""
     configurations = getattr(template, "configurations", None)
     if configurations is None:
-        return [], True
+        return _WidgetSurface()
     quick_replies: List[QuickReplyWire] = [
         QuickReplyWire(
             label=qr.label,
@@ -180,8 +204,14 @@ def _extract_widget_config(
         )
         for qr in (getattr(configurations, "quick_replies", None) or [])
     ]
-    enable_text_input: bool = getattr(configurations, "enable_text_input", True)
-    return quick_replies, enable_text_input
+    return _WidgetSurface(
+        quick_replies=quick_replies,
+        enable_text_input=getattr(configurations, "enable_text_input", True),
+        greeting_tiles=[
+            GreetingTileWire(label=t.label, prompt=t.prompt, image_url=t.image_url)
+            for t in (getattr(configurations, "greeting_tiles", None) or [])
+        ],
+    )
 
 
 def _template_voice_enabled(template: object) -> bool:
@@ -229,6 +259,12 @@ async def create_widget_session_handler(
     # Chat is the entry channel; voice opt-in is checked at /voice/connect.
     validate_template_for_chat(template)
 
+    # Catalog-version negotiation (RFC-001 §3.4): active = client-requested
+    # ∩ template-capable. The NEGOTIATED version (not the client's raw ask)
+    # is what gets persisted — so a v2 embed on a data-bound-free template
+    # runs a clean v1 session instead of a v2 session that can never emit.
+    catalog_active, ui_flavors = negotiate_catalog(template, body.catalog_version)
+
     synthetic_user = _synthetic_widget_user(cfg.id)
     create_req = CreateChatSessionRequest(
         template_id=cfg.template_id,
@@ -241,6 +277,15 @@ async def create_widget_session_handler(
             "widget": {
                 "widget_config_id": cfg.id,
                 "public_widget_key_prefix": cfg.public_widget_key[:6],
+                # Stored on the server-owned widget block so client metadata
+                # can't spoof it; ChatAgent + the intent router gate every v2
+                # behavior (data-bound prompt section, show-op hydration,
+                # ui_intent bodies) on this persisted value.
+                **(
+                    {"catalog_version": catalog_active}
+                    if catalog_active == CATALOG_VERSION_V2
+                    else {}
+                ),
             },
         },
     )
@@ -254,7 +299,7 @@ async def create_widget_session_handler(
         ttl_minutes=DEFAULT_WIDGET_TOKEN_TTL_MINUTES,
     )
 
-    quick_replies, enable_text_input = _extract_widget_config(template)
+    surface = _extract_widget_config(template)
 
     return CreateWidgetSessionResponse(
         session_id=create_resp.session_id,
@@ -265,9 +310,12 @@ async def create_widget_session_handler(
         greeting=create_resp.greeting,
         widget_token=widget_token,
         ttl_seconds=DEFAULT_WIDGET_TOKEN_TTL_MINUTES * 60,
-        quick_replies=quick_replies,
-        enable_text_input=enable_text_input,
+        quick_replies=surface.quick_replies,
+        greeting_tiles=surface.greeting_tiles,
+        enable_text_input=surface.enable_text_input,
         voice_enabled=_template_voice_enabled(template),
+        catalog_active=catalog_active,
+        ui_flavors=ui_flavors,
     )
 
 
@@ -324,7 +372,73 @@ async def send_widget_message_handler(
             ),
         )
 
+    # Typed UI intent body (RFC-001 §3.3): validate + policy-route BEFORE
+    # any LLM involvement. Alternate door for surfaces without a dedicated
+    # intent route; embeds should POST /intent. Both funnel into
+    # serve_session_intent, so the two stay behaviourally identical.
+    if req.ui_intent is not None:
+        return await serve_session_intent(
+            session, session_id, req.ui_intent, context=req.context
+        )
+
     return await send_chat_message_handler(session_id, req, access_check=None)
+
+
+# ---------------------------------------------------------------------------
+# POST /widget/session/{id}/intent
+# ---------------------------------------------------------------------------
+
+
+async def send_widget_intent_handler(
+    session_id: str,
+    req: WidgetIntentRequest,
+    request: Request,
+    ctx: WidgetSessionContext,
+):
+    """Serve one typed UI intent on the dedicated route (SSE response).
+
+    Same gate order as ``send_widget_message_handler`` (config-active 401 →
+    IP limit → ownership → 410 ENDED → 409 voice-live), then the shared
+    validate + policy-route path. Rides the same "message" rate bucket —
+    an intent is a turn, not a side channel.
+    """
+    cfg = await get_widget_config_by_id(ctx.widget_config_id)
+    if cfg is None or not cfg.active:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Widget configuration not found or inactive",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    await enforce_widget_ip_limit(
+        request=request,
+        bucket="message",
+        limit=cfg.max_messages_per_ip_hour,
+        widget_config_id=cfg.id,
+    )
+
+    session = await get_chat_session_by_id(session_id)
+    if session is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Widget session '{session_id}' not found",
+        )
+    assert_widget_session_ownership(session, ctx)
+    if session.status == ChatSessionStatus.ENDED:
+        raise HTTPException(
+            status_code=status.HTTP_410_GONE,
+            detail=f"Widget session '{session_id}' has ended",
+        )
+
+    # NO channel gate here (unlike /message): DIRECT intents are legal
+    # during a live voice attachment — serve_session_intent 409s only the
+    # AGENT_TURN routes when voice is live.
+    return await serve_session_intent(
+        session,
+        session_id,
+        req.as_ui_intent(),
+        voice_live=session.current_channel != WidgetChannel.CHAT,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -833,10 +947,11 @@ async def voice_connect_handler(
         try:
             session_info = await start_daily_session(lead_id, enable_recording=False)
         except Exception as exc:
-            logger.error(
+            # loguru: no ``exc_info`` kwarg — it would re-format the message
+            # and crash on brace-bearing provider error text.
+            logger.exception(
                 f"widget voice: start_daily_session failed for lead {lead_id}: "
-                f"{exc}",
-                exc_info=True,
+                f"{exc}"
             )
             # Rollback channel back to CHAT so the user can retry.
             try:
@@ -1026,7 +1141,7 @@ async def get_widget_session_state_handler(
     messages: List[ChatMessage] = await list_chat_messages_for_session(session_id)
 
     template = await get_template_by_id_cached(session.template_id)
-    quick_replies, enable_text_input = _extract_widget_config(template)
+    surface = _extract_widget_config(template)
 
     template_vars: Dict[str, Any] = (
         session.metadata.get("template_vars", {})
@@ -1048,15 +1163,31 @@ async def get_widget_session_state_handler(
     # cards after a reload (lazy expiry — the accessor filters expires_at).
     pending_approvals = await list_pending_tool_approvals(session_id)
 
+    # The persisted (negotiated-at-create) catalog version is the truth on
+    # resume; the flavor list is re-derived from the template so a config
+    # change between create and reload is reflected.
+    catalog_active = (
+        resolve_session_catalog_version(session.metadata) or CATALOG_VERSION
+    )
+    ui_flavors: List[str] = []
+    if catalog_active == CATALOG_VERSION_V2:
+        configurations = getattr(template, "configurations", None)
+        ui_cat = getattr(configurations, "ui_catalog", None) if configurations else None
+        enabled_groups = list(ui_cat.enabled_groups or []) if ui_cat is not None else []
+        ui_flavors = [g for g in enabled_groups if g in LAZY_GROUPS]
+
     return WidgetSessionStateResponse(
         session_id=session_id,
         status=session.status,
         current_channel=session.current_channel,
         current_node=session.current_node,
         messages=messages,
-        quick_replies=quick_replies,
-        enable_text_input=enable_text_input,
+        quick_replies=surface.quick_replies,
+        greeting_tiles=surface.greeting_tiles,
+        enable_text_input=surface.enable_text_input,
         voice_enabled=_template_voice_enabled(template),
+        catalog_active=catalog_active,
+        ui_flavors=ui_flavors,
         template_vars=template_vars,
         metadata=session.metadata or {},
         client_context=client_context,

--- a/app/schemas/breeze_buddy/chat.py
+++ b/app/schemas/breeze_buddy/chat.py
@@ -9,7 +9,7 @@ from datetime import datetime
 from enum import Enum
 from typing import Any, Dict, List, Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 from app.ai.voice.agents.breeze_buddy.template.ui_catalog import ActionUnion, Icon
 
@@ -292,9 +292,19 @@ class ClientContextPatch(BaseModel):
 
 
 class SendChatMessageRequest(BaseModel):
-    """Body of ``POST /session/{id}/message``."""
+    """Body of ``POST /session/{id}/message``.
 
-    content: str = Field(..., min_length=1, description="The user's message text.")
+    Two variants: a plain user turn (``content`` required) or a typed UI
+    intent (``ui_intent`` set, ``content`` may be empty — RFC-001 §3.3).
+    """
+
+    content: str = Field(
+        "",
+        description=(
+            "The user's message text. May be empty ONLY when ``ui_intent`` "
+            "is provided."
+        ),
+    )
     context: Optional[ClientContextPatch] = Field(
         None,
         description=(
@@ -303,6 +313,57 @@ class SendChatMessageRequest(BaseModel):
             "atomically with the message instead of a separate /context call."
         ),
     )
+    ui_intent: Optional[Dict[str, Any]] = Field(
+        None,
+        description=(
+            "Typed component action (catalog v2): {intent, component_id, "
+            "payload, display}. Validated + policy-routed server-side by "
+            "chat/intents/router.py — direct intents execute whitelisted "
+            "tools with no LLM turn; agent_turn intents rewrite into a "
+            "structured user message. The set of intents is supplied by the "
+            "flavor packages the template enables. Kept as an open dict here "
+            "so the schema layer stays decoupled from the router's "
+            "per-intent models (which own the 422-typed validation)."
+        ),
+    )
+
+    @model_validator(mode="after")
+    def _require_content_or_intent(self) -> "SendChatMessageRequest":
+        # Preserves the historical min_length=1 contract for plain turns
+        # while allowing the RFC-001 `{"content":"", "ui_intent":{…}}` body.
+        if not self.content and self.ui_intent is None:
+            raise ValueError("content must be non-empty unless ui_intent is set")
+        return self
+
+
+class WidgetIntentRequest(BaseModel):
+    """Body of ``POST /widget/session/{id}/intent`` — the dedicated typed
+    intent route (RFC-001 §3.3 Stage B). The intent fields ride at the top
+    level (no ``content`` wrapper); per-intent payload validation happens in
+    ``chat/intents/router.py``, which owns the typed 422 contract.
+
+    The ``ui_intent`` body variant on ``/message`` is the same thing behind
+    a different door: it lets a surface that has no dedicated intent route
+    (the demo router) send intents over the message endpoint it already
+    has. Both funnel into ``serve_session_intent``; embeds should prefer
+    this route.
+    """
+
+    intent: str = Field(..., min_length=1, max_length=64)
+    component_id: str = Field(..., min_length=1, max_length=128)
+    payload: Dict[str, Any] = Field(default_factory=dict)
+    display: Optional[str] = Field(None, max_length=500)
+
+    def as_ui_intent(self) -> Dict[str, Any]:
+        """The dict shape ``parse_ui_intent`` validates — one wire model."""
+        body: Dict[str, Any] = {
+            "intent": self.intent,
+            "component_id": self.component_id,
+            "payload": self.payload,
+        }
+        if self.display is not None:
+            body["display"] = self.display
+        return body
 
 
 class GetChatSessionResponse(BaseModel):
@@ -421,6 +482,18 @@ class CreateDemoSessionResponse(BaseModel):
     greeting: Optional[GreetingMessage] = None
     demo_token: str = Field(..., description="Bearer token for follow-up calls.")
     message_cap: int = Field(..., description="Max assistant turns before 429.")
+    catalog_active: str = Field(
+        "v1",
+        description=(
+            "Negotiated UI catalog version — 'v2' when the demo template "
+            "enables data-bound components (demo pages always run a "
+            "v2-capable widget build, so the template is the only variable)."
+        ),
+    )
+    ui_flavors: List[str] = Field(
+        default_factory=list,
+        description="Lazy UI flavor groups the demo template enables.",
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -449,6 +522,17 @@ class CreateWidgetSessionRequest(BaseModel):
     metadata: Dict[str, Any] = Field(
         default_factory=dict,
         description="Opaque caller context, persisted on chat_session.metadata.",
+    )
+    catalog_version: Optional[str] = Field(
+        None,
+        description=(
+            "UI catalog version the embed supports (RFC-001 §3.4). 'v2' "
+            "enables data-bound components (show-op hydration + typed "
+            "intents) for this session; absent/other = v1 (server prunes "
+            "data-bound components — prompt and wire stay v1-compatible). "
+            "Persisted on chat_session.metadata under the server-owned "
+            "'widget' block."
+        ),
     )
 
 
@@ -487,6 +571,18 @@ class QuickReplyWire(BaseModel):
     )
 
 
+class GreetingTileWire(BaseModel):
+    """One visual quick-tap tile on the greeting screen (2026-08-03).
+
+    Mirrors ``GreetingTileOption`` from the template ``ConfigurationModel``
+    — image-backed sibling of the quick-reply pill. Tapping sends
+    ``prompt`` to the agent; ``label`` is the visible bubble text."""
+
+    label: str = Field(..., description="Tile caption shown to the user.")
+    prompt: str = Field(..., description="Message sent to the agent on tap.")
+    image_url: str = Field(..., description="Tile image URL (merchant CDN).")
+
+
 class CreateWidgetSessionResponse(BaseModel):
     """Body of ``POST /widget/session``.
 
@@ -512,6 +608,14 @@ class CreateWidgetSessionResponse(BaseModel):
             "Empty list when the template defines no quick replies."
         ),
     )
+    greeting_tiles: List[GreetingTileWire] = Field(
+        default_factory=list,
+        description=(
+            "Visual quick-tap tiles from configurations.greeting_tiles — "
+            "shown on the greeting screen below the initial greeting. "
+            "Empty list when the template defines none."
+        ),
+    )
     enable_text_input: bool = Field(
         True,
         description=(
@@ -528,6 +632,26 @@ class CreateWidgetSessionResponse(BaseModel):
             "'voice' is in the template's supported_channels (the same gate "
             "/voice/connect enforces). The embed shows the voice-mode button "
             "only when True; the server stays the enforcement point."
+        ),
+    )
+    catalog_active: str = Field(
+        "v1",
+        description=(
+            "The NEGOTIATED UI catalog version for this session (RFC-001 "
+            "§3.4): the intersection of what the client requested "
+            "(catalog_version in the create body) and what the template's "
+            "ui_catalog config can serve (data-bound components enabled). "
+            "'v2' ⇔ show-op hydration + typed intents are live; the embed "
+            "should eagerly preload the ui_flavors chunks."
+        ),
+    )
+    ui_flavors: List[str] = Field(
+        default_factory=list,
+        description=(
+            "Lazy UI flavor groups the template enables (e.g. ['commerce']) "
+            "— the embed preloads these code-split chunks so the first "
+            "hydrated component renders without a chunk-fetch stall. Empty "
+            "when catalog_active is 'v1'."
         ),
     )
 
@@ -617,6 +741,14 @@ class WidgetSessionStateResponse(BaseModel):
             "Empty list when the template defines no quick replies."
         ),
     )
+    greeting_tiles: List[GreetingTileWire] = Field(
+        default_factory=list,
+        description=(
+            "Visual quick-tap tiles from configurations.greeting_tiles — "
+            "shown on the greeting screen below the initial greeting. "
+            "Empty list when the template defines none."
+        ),
+    )
     enable_text_input: bool = Field(
         True,
         description=(
@@ -632,6 +764,22 @@ class WidgetSessionStateResponse(BaseModel):
             "Whether this merchant's template offers a voice mode — i.e. "
             "'voice' is in the template's supported_channels. Lets the embed "
             "restore the voice-mode button after a reload without re-deriving."
+        ),
+    )
+    catalog_active: str = Field(
+        "v1",
+        description=(
+            "The session's negotiated UI catalog version (persisted at "
+            "create time) — same semantics as the create response's "
+            "catalog_active, re-echoed so a reloaded embed can restore "
+            "intent affordances and preload flavor chunks."
+        ),
+    )
+    ui_flavors: List[str] = Field(
+        default_factory=list,
+        description=(
+            "Lazy UI flavor groups the template enables. Mirrors the create "
+            "response so the resume path preloads the same chunks."
         ),
     )
     template_vars: Dict[str, Any] = Field(default_factory=dict)

--- a/tests/test_direct_intent_engine.py
+++ b/tests/test_direct_intent_engine.py
@@ -1,0 +1,267 @@
+"""Engine guarantees of the DIRECT (no-LLM) intent path.
+
+Contracts the flavor drivers cannot enforce for themselves, so the engine
+has to:
+
+1. The reducer state delta is persisted on EVERY outcome, not just
+   success. Each dispatch's tool rows are already committed by the time
+   the outcome is known, so an early return without the merge leaves
+   ``agent_session_state`` behind what history says happened.
+2. An approval-gated tool is refused. Chat disables the handler-level
+   gate (``handles_approval_externally``), so the pre-dispatch check is
+   the only one there is — and the no-LLM path has no turn to suspend an
+   approval card on.
+3. ``function_call_started`` carries the caller's args, never the
+   post-injection ones (those pull server-internal identifiers out of
+   agent_session_state).
+4. A flavor whose module is absent or broken fails OPEN: its intents stay
+   unregistered (→ the typed ``unknown_intent`` 422), never an ImportError
+   escaping onto a public widget route.
+5. DIRECT intents are legal during a live voice attachment ONLY because
+   both surfaces serialise on the same per-session Redis lock.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+
+import pytest
+from pydantic import BaseModel
+
+import app.ai.voice.agents.breeze_buddy.chat.intents.router as router
+from app.ai.voice.agents.breeze_buddy.chat.agent.runtime import is_approval_gated
+from app.ai.voice.agents.breeze_buddy.chat.intents.router import (
+    IntentApprovalRequired,
+    IntentPolicy,
+    IntentRoute,
+    ParsedIntent,
+    UiIntent,
+    ensure_flavor_intents,
+    parse_ui_intent,
+    run_persisted_tool,
+)
+
+
+class _Payload(BaseModel):
+    pass
+
+
+class _Call:
+    """Stand-in for FunctionCallFromLLM."""
+
+    def __init__(self, tool_call_id: str, arguments: Dict[str, Any]):
+        self.tool_call_id = tool_call_id
+        self.arguments = arguments
+        self.function_name = "probe_tool"
+
+
+class _StubAgent:
+    """Dispatch chassis stub — only what run_persisted_tool touches."""
+
+    def __init__(self, approval_map: Dict[str, Any] | None = None):
+        self.session_id = "sess-1"
+        self._approval_map = approval_map or {}
+        self.dispatched: List[Tuple[str, Dict[str, Any]]] = []
+
+    async def run_direct_tool(self, *, tool_name, args, node, prep, turn_id):
+        self.dispatched.append((tool_name, dict(args)))
+        # The real run_direct_tool builds the call with POST-injection args.
+        injected = {**args, "cart_id": "SERVER-INTERNAL-ID"}
+        return _Call("call-1", injected), {"ok": True}
+
+
+@pytest.mark.asyncio
+async def test_started_event_carries_caller_args_not_injected(monkeypatch):
+    async def _noop_persist(*_a, **_k):
+        return None
+
+    monkeypatch.setattr(router, "_persist_tool_step", _noop_persist)
+    agent = _StubAgent()
+    events, _ = await run_persisted_tool(
+        agent,  # type: ignore[arg-type]
+        tool_name="probe_tool",
+        args={"sku": "ABC"},
+        node={},
+        prep=None,
+        turn_id="t1",
+    )
+    started = next(e for e in events if e.event == "function_call_started")
+    assert started.data["args"] == {"sku": "ABC"}
+    # The injected identifier reached the tool but NOT the wire.
+    assert agent.dispatched == [("probe_tool", {"sku": "ABC"})]
+    assert "cart_id" not in started.data["args"]
+
+
+@pytest.mark.asyncio
+async def test_gated_tool_is_refused_before_dispatch(monkeypatch):
+    async def _noop_persist(*_a, **_k):
+        return None
+
+    monkeypatch.setattr(router, "_persist_tool_step", _noop_persist)
+    agent = _StubAgent(approval_map={"probe_tool": object()})
+    with pytest.raises(IntentApprovalRequired) as exc:
+        await run_persisted_tool(
+            agent,  # type: ignore[arg-type]
+            tool_name="probe_tool",
+            args={},
+            node={},
+            prep=None,
+            turn_id="t1",
+        )
+    assert exc.value.tool_name == "probe_tool"
+    # Fail-closed: the tool never ran.
+    assert agent.dispatched == []
+
+
+def test_gate_honours_per_node_shadowing():
+    """Same rule the LLM path uses — a gated global shadowed by a per-node
+    function of the same name is ungated in that node."""
+    approval_map = {"probe_tool": object()}
+    assert is_approval_gated("probe_tool", approval_map, {}) is True
+    assert is_approval_gated("other_tool", approval_map, {}) is False
+
+    class _Schema:
+        name = "probe_tool"
+
+    # A plain object is not a FlowsFunctionSchema, so it must NOT shadow.
+    assert is_approval_gated("probe_tool", approval_map, {"functions": [_Schema()]})
+
+
+@pytest.mark.asyncio
+async def test_state_delta_persists_on_every_outcome(monkeypatch):
+    """A driver whose first tool advances state and whose last tool FAILS
+    must still persist the delta — history already has both tool rows."""
+    merged: List[Dict[str, Any]] = []
+
+    async def _capture_merge(*, chat_session_id, patch):
+        merged.append(patch)
+
+    async def _drive(agent, prep, node, parsed_intent, turn_id):
+        # First dispatch succeeds and advances reducer state...
+        agent.agent_state["cart_id"] = "DISCOVERED-BY-FIRST-TOOL"
+        yield (None, "first_tool", {"ok": True})
+        # ...second dispatch fails, which used to discard the delta.
+        yield (None, "second_tool", {"status": "error"})
+
+    parsed = ParsedIntent(
+        intent=UiIntent(intent="probe", component_id="c1"),
+        policy=IntentPolicy(
+            route=IntentRoute.DIRECT,
+            payload_model=_Payload,
+            flavor="testflavor",
+            drive=_drive,
+        ),
+        payload=_Payload(),
+    )
+
+    _install_direct_intent_stubs(monkeypatch, _capture_merge)
+
+    events = [
+        ev async for ev in router.run_direct_intent(session_id="sess-1", parsed=parsed)
+    ]
+
+    assert merged == [{"cart_id": "DISCOVERED-BY-FIRST-TOOL"}]
+    names = [e.event for e in events]
+    assert "intent_failed" in names and names[-1] == "turn_end"
+
+
+def test_broken_flavor_module_fails_open_to_unknown_intent(monkeypatch):
+    """A flavor whose module is missing (its layer hasn't shipped) or raises
+    on import must degrade to the typed 422, not surface an ImportError as a
+    500 from a public widget route."""
+    monkeypatch.setitem(
+        router.FLAVOR_INTENT_MODULES, "brokenflavor", "no.such.module.anywhere"
+    )
+    monkeypatch.setattr(router, "_LOADED_FLAVOR_INTENTS", set())
+
+    ensure_flavor_intents(["brokenflavor"])  # must not raise
+
+    with pytest.raises(router.IntentValidationError) as exc:
+        parse_ui_intent(
+            {"intent": "whatever", "component_id": "c1"},
+            enabled_flavors={"brokenflavor"},
+        )
+    assert exc.value.detail["code"] == "unknown_intent"
+
+
+def test_failed_flavor_import_is_not_retried_per_request(monkeypatch):
+    """Python drops a failed module from sys.modules, so an unguarded retry
+    would re-raise on every request for the life of the process."""
+    attempts = {"n": 0}
+
+    def _explode(_path):
+        attempts["n"] += 1
+        raise RuntimeError("flavor module is broken")
+
+    monkeypatch.setitem(
+        router.FLAVOR_INTENT_MODULES, "brokenflavor", "no.such.module.anywhere"
+    )
+    monkeypatch.setattr(router, "_LOADED_FLAVOR_INTENTS", set())
+    monkeypatch.setattr(router.importlib, "import_module", _explode)
+
+    for _ in range(3):
+        ensure_flavor_intents(["brokenflavor"])
+    assert attempts["n"] == 1
+
+
+def test_direct_intent_and_voice_turn_share_one_session_lock():
+    """DIRECT intents are deliberately allowed while a voice attachment is
+    live (widget/handlers.py skips the channel gate). That is only safe
+    because the voice bridge and the intent handler contend for the SAME
+    Redis key — they serialise rather than interleaving their writes to
+    chat_message / agent_session_state. Pin the two key builders together so
+    an edit to one can't silently un-serialise them.
+    """
+    from app.ai.voice.agents.breeze_buddy.chat import voice_bridge
+    from app.api.routers.breeze_buddy.chat import handlers as ch
+
+    assert ch._lock_key("sess-abc") == voice_bridge._lock_key("sess-abc")
+    assert ch._lock_key("sess-abc") == "chat:session:sess-abc:lock"
+
+
+def _install_direct_intent_stubs(monkeypatch, capture_merge):
+    """Neutralize every DB/network call run_direct_intent makes."""
+
+    class _Session:
+        status = "ACTIVE"
+        template_id = "tpl-1"
+        current_node = "start"
+        metadata: Dict[str, Any] = {}
+
+    class _Agent:
+        def __init__(self, **kwargs):
+            self.session_id = "sess-1"
+            self.agent_state = dict(kwargs.get("agent_state") or {})
+            self.aiohttp_session = None
+            self.mcp_pool = None
+            self._approval_map = {}
+
+        async def prepare_direct_dispatch(self, _node):
+            return None, {}
+
+    async def _get_session(_sid):
+        return _Session()
+
+    async def _get_template(_tid):
+        return object()
+
+    async def _get_state(_sid):
+        return None
+
+    async def _build_vars(_tpl, _persisted):
+        return {}
+
+    async def _noop(*_a, **_k):
+        return None
+
+    monkeypatch.setattr(router, "get_chat_session_by_id", _get_session)
+    monkeypatch.setattr(router, "get_template_by_id_cached", _get_template)
+    monkeypatch.setattr(router, "get_agent_session_state", _get_state)
+    monkeypatch.setattr(router, "build_render_template_vars", _build_vars)
+    monkeypatch.setattr(router, "resolve_session_catalog_version", lambda _m: "v2")
+    monkeypatch.setattr(router, "insert_chat_message", _noop)
+    monkeypatch.setattr(router, "update_chat_session_after_turn", _noop)
+    monkeypatch.setattr(router, "close_mcp_pool", _noop)
+    monkeypatch.setattr(router, "create_aiohttp_session", lambda: None)
+    monkeypatch.setattr(router, "upsert_agent_session_state_merge", capture_merge)
+    monkeypatch.setattr(router, "ChatAgent", _Agent)

--- a/tests/test_quick_reply_redirect.py
+++ b/tests/test_quick_reply_redirect.py
@@ -25,7 +25,10 @@ from app.ai.voice.agents.breeze_buddy.template.ui_catalog import (
     ToAssistantAction,
     validate_props,
 )
-from app.api.routers.breeze_buddy.widget.handlers import _extract_widget_config
+from app.api.routers.breeze_buddy.widget.handlers import (
+    _extract_widget_config,
+    _WidgetSurface,
+)
 from app.schemas.breeze_buddy.chat import QuickReplyWire
 
 # ---------------------------------------------------------------------------
@@ -138,7 +141,9 @@ def _template_with_quick_replies(options):
 
 def test_handler_message_pill_falls_back_to_label():
     template = _template_with_quick_replies([QuickReplyOption(label="Track my order")])
-    replies, enable_text_input = _extract_widget_config(template)
+    surface = _extract_widget_config(template)
+    replies = surface.quick_replies
+    enable_text_input = surface.enable_text_input
     assert enable_text_input is True
     assert replies[0].value == "Track my order"  # label fallback
     assert replies[0].action is None
@@ -156,7 +161,7 @@ def test_handler_redirect_pill_has_null_value_and_passes_action():
             )
         ]
     )
-    replies, _ = _extract_widget_config(template)
+    replies = _extract_widget_config(template).quick_replies
     # Redirect pills don't message the agent — value is always None.
     assert replies[0].value is None
     assert isinstance(replies[0].action, OpenUrlAction)
@@ -164,7 +169,11 @@ def test_handler_redirect_pill_has_null_value_and_passes_action():
 
 
 def test_handler_no_configurations_returns_defaults():
-    assert _extract_widget_config(SimpleNamespace(configurations=None)) == ([], True)
+    # Neutral defaults — a template configuring none of this yields an
+    # empty surface, not None or a partial record.
+    assert (
+        _extract_widget_config(SimpleNamespace(configurations=None)) == _WidgetSurface()
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -213,7 +222,7 @@ def test_handler_passes_icon_through_for_message_pill():
             )
         ]
     )
-    replies, _ = _extract_widget_config(template)
+    replies = _extract_widget_config(template).quick_replies
     # Icon is presentational — it survives regardless of value/action.
     assert replies[0].value == "Show me what's on sale"
     assert isinstance(replies[0].icon, Icon)
@@ -230,7 +239,7 @@ def test_handler_passes_icon_through_for_redirect_pill():
             )
         ]
     )
-    replies, _ = _extract_widget_config(template)
+    replies = _extract_widget_config(template).quick_replies
     assert replies[0].value is None  # redirect pill
     assert isinstance(replies[0].icon, Icon)
     assert replies[0].icon.alt == "My account"
@@ -238,5 +247,5 @@ def test_handler_passes_icon_through_for_redirect_pill():
 
 def test_handler_pill_without_icon_emits_none():
     template = _template_with_quick_replies([QuickReplyOption(label="Track my order")])
-    replies, _ = _extract_widget_config(template)
+    replies = _extract_widget_config(template).quick_replies
     assert replies[0].icon is None

--- a/tests/test_turn_sse_stream_errors.py
+++ b/tests/test_turn_sse_stream_errors.py
@@ -1,0 +1,83 @@
+"""Regression tests for ``_turn_sse_stream``'s crash path.
+
+The 2026-07-28 live incident: the agent's turn raised a Gemini
+``ClientError`` whose text contains a brace dict (``{'message': ...}``).
+The except-branch's ``logger.error(..., exc_info=True)`` call — a loguru
+misuse: any kwarg makes loguru re-``.format()`` the message — then raised
+KeyError from INSIDE the logging call, killing the generator before the
+graceful ``error`` + ``turn_end FAILED`` frames went out. The client saw
+a raw aborted stream ("network error" / turn_exception) instead of the
+designed degradation.
+"""
+
+import json
+import time
+from typing import cast
+
+import pytest
+
+import app.api.routers.breeze_buddy.chat.handlers as ch
+from app.ai.voice.agents.breeze_buddy.chat.metrics import TurnMetrics
+from app.services.redis.locks import RedisLock
+
+
+class _StubLock:
+    def __init__(self):
+        self.released = False
+
+    async def release(self):
+        self.released = True
+
+
+def _parse_frames(chunks):
+    """format_sse output → list of (event, data-dict)."""
+    frames = []
+    for chunk in chunks:
+        event = None
+        data = None
+        for line in chunk.strip().splitlines():
+            if line.startswith("event:"):
+                event = line.split(":", 1)[1].strip()
+            elif line.startswith("data:"):
+                data = json.loads(line.split(":", 1)[1].strip())
+        frames.append((event, data))
+    return frames
+
+
+@pytest.mark.asyncio
+async def test_brace_bearing_exception_still_yields_graceful_frames(monkeypatch):
+    """An exception whose str contains ``{'message': ...}`` (every Gemini
+    API error) must produce the masked ``error`` frame + ``turn_end
+    FAILED`` — not crash the generator from inside logging."""
+
+    async def _persist_noop(_metrics):
+        return None
+
+    monkeypatch.setattr(ch, "_persist_turn_metrics", _persist_noop)
+
+    async def exploding_events():
+        yield ch.SSEEvent(event="assistant_token", data={"text": "hi"})
+        raise RuntimeError(
+            "400 Bad Request. {'message': '{\"error\": {\"code\": 400}}', "
+            "'status': 'Bad Request'}"
+        )
+
+    lock = _StubLock()
+    metrics = TurnMetrics(session_id="sess-test", template_id=None, t0=time.monotonic())
+    chunks = [
+        chunk
+        async for chunk in ch._turn_sse_stream(
+            session_id="sess-test",
+            lock=cast(RedisLock, lock),
+            turn_metrics=metrics,
+            events=exploding_events(),
+        )
+    ]
+    frames = _parse_frames(chunks)
+    assert frames[0] == ("assistant_token", {"text": "hi"})
+    assert frames[1][0] == "error"
+    # Provider internals must be masked, not leaked.
+    assert frames[1][1] == {"code": "internal", "message": "Internal server error"}
+    assert frames[2] == ("turn_end", {"session_status": "FAILED"})
+    assert metrics.status == "FAILED"
+    assert lock.released

--- a/tests/test_ui_catalog_groups.py
+++ b/tests/test_ui_catalog_groups.py
@@ -247,3 +247,45 @@ def test_validate_props_rejects_empty_kpi_label():
     so the widget never renders a blank metric label."""
     with pytest.raises(ValidationError):
         validate_props("KPI", {"label": "", "value": "42"})
+
+
+# ---------------------------------------------------------------------------
+# Lazy flavor-group loading — fail-open
+# ---------------------------------------------------------------------------
+
+
+def test_lazy_group_with_broken_module_degrades_to_core(monkeypatch):
+    """A flavor group whose module is absent (its layer hasn't shipped yet)
+    or raises on import must leave the catalog untouched and resolve to the
+    core allowlist — never surface the ImportError as a 500 from whichever
+    endpoint happened to touch the group.
+    """
+    import app.ai.voice.agents.breeze_buddy.template.ui_catalog as uc
+
+    monkeypatch.setitem(uc.LAZY_GROUPS, "brokenflavor", "no.such.module.anywhere")
+    monkeypatch.setattr(uc, "_LOADED_LAZY_GROUPS", set())
+
+    uc.ensure_group_loaded("brokenflavor")  # must not raise
+
+    allowlist = resolve_allowlist(enabled_groups=["core", "brokenflavor"])
+    assert allowlist == resolve_allowlist(enabled_groups=["core"])
+
+
+def test_failed_lazy_group_import_is_not_retried(monkeypatch):
+    """Python drops a failed module from sys.modules; without marking the
+    attempt, every request would re-import and re-raise."""
+    import app.ai.voice.agents.breeze_buddy.template.ui_catalog as uc
+
+    attempts = {"n": 0}
+
+    def _explode(_path):
+        attempts["n"] += 1
+        raise RuntimeError("flavor module is broken")
+
+    monkeypatch.setitem(uc.LAZY_GROUPS, "brokenflavor", "no.such.module.anywhere")
+    monkeypatch.setattr(uc, "_LOADED_LAZY_GROUPS", set())
+    monkeypatch.setattr(uc.importlib, "import_module", _explode)
+
+    for _ in range(3):
+        uc.ensure_group_loaded("brokenflavor")
+    assert attempts["n"] == 1


### PR DESCRIPTION
Layer 3 of the commerce-buddy backend chain, raised as a **plain PR against `release`** (no stacking). Builds on the generative-UI engine merged in #975.

## What this adds

**`chat/intents/` (new package)** — `router.py` is the generic ui-intent engine: the DIRECT / AGENT_TURN / CLIENT policies, direct-dispatch persistence, reducer patches, and post-turn followup hooks. Flavors register their policies at import time through a lazy string registry; the `commerce` entry stays **dormant** until the flavor package lands in the next layer, so nothing commerce-specific ships here.

**Chat handlers** — the `ui_intent` route, turn-metrics persistence, and graceful SSE error frames. The last one is a real fix: an exception whose message contained a brace could crash the stream mid-generator, and the client would see a truncated response with no error frame. Plus demo + `cancel_bus` plumbing.

**Widget handlers + schemas** — the widget-config wire: quick replies, `enable_text_input`, and greeting tiles, returned on **both** the create-session and widget-state responses (they previously disagreed).

## Scope

One commit, +1338 / −28 across 10 files. `chat/intents/router.py` is 715 of those lines; the rest is handlers, schemas, and two test files.

## Verification

- **864 passed**, pyrefly **0 errors**, black/isort clean.
- 4 `tests/test_chat_analytics.py` failures are **pre-existing on `release`** — I checked out bare `origin/release` and reproduced all 4 there with none of this branch's code. They trace to the analytics package refactor in `d886d73`; this branch touches no analytics files. Not introduced here, but worth a look from whoever owns that refactor.

Rebased onto `release` @ `ef8d8ab`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JtrUcWv8oqFfZpiQourEGU


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added typed UI intent support for chat and widgets, including direct actions and agent-assisted requests.
  - Added intent validation, acknowledgements, follow-up responses, and streamed UI updates.
  - Added catalog version negotiation, active catalog status, enabled UI flavors, and greeting tiles to session responses.
  - Added a dedicated widget intent endpoint with support during live voice sessions.
- **Bug Fixes**
  - Improved error handling so failed streamed responses preserve prior events, report a safe error, and close sessions cleanly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->