### PR TITLE
feat(assist): commerce flavor — UCP cart/catalog intents, upsell, media, schemas

### DIFF
--- a/app/ai/voice/agents/breeze_buddy/assist/__init__.py
+++ b/app/ai/voice/agents/breeze_buddy/assist/__init__.py
@@ -1,0 +1,20 @@
+"""Assist-product flavor packages.
+
+Each subpackage bundles one vertical flavor's entire server surface —
+data-bound component schemas, typed UI-intent policy, and any
+flavor-specific execution glue — behind lazy-load hooks. The core
+engines stay flavor-agnostic:
+
+- ``template/ui_catalog.py`` maps lazy group names to flavor schema
+  modules (``LAZY_GROUPS`` + ``ensure_group_loaded``); a flavor's
+  schemas import (and self-register) only when a template enables that
+  group.
+- ``chat/intent_router.py`` maps flavors to intent modules
+  (``FLAVOR_INTENT_MODULES`` + ``ensure_flavor_intents``); a flavor's
+  intent policy registers only when a session on a flavor-enabled
+  template sends a ``ui_intent``.
+
+A process that never sees a flavor-enabled template never imports the
+flavor package, and deleting a flavor directory removes the flavor
+wholesale (its group simply stops resolving).
+"""

--- a/app/ai/voice/agents/breeze_buddy/assist/commerce/__init__.py
+++ b/app/ai/voice/agents/breeze_buddy/assist/commerce/__init__.py
@@ -1,0 +1,46 @@
+"""Commerce flavor (Component Catalog v2, RFC-001) — the lazy-load entry.
+
+Structure follows the protocol/platform split:
+
+- ``ucp/`` — the protocol layer, and the only layer with opinions about
+  commerce. Speaks Universal Commerce Protocol: tool roles (create_cart /
+  update_cart / get_cart / get_product / search_catalog, all
+  template-overridable via ``configurations.ui_intents.tools``), the wire
+  projections and component schemas, the typed ui-intent policy table, the
+  UI copy, step labels and tool annotations. No module here names a
+  platform.
+- ``connectors/`` — one package per platform that serves UCP (``shopify``
+  today). A connector only ever registers into ``ucp/hooks.py`` and is
+  never imported by the protocol layer, so adding a platform means adding
+  a package, never editing UCP code. With zero connectors loaded the
+  flavor still works — the hooks fall through to pure-UCP behavior.
+
+Importing THIS module is what registers the flavor: the UI catalog
+primitives, the intent policies, the render_ui pack, the selector
+transform, the step summarizer, the tool annotations, and then every
+connector. Both lazy registries (``ui_catalog.LAZY_GROUPS`` and
+``intents.router.FLAVOR_INTENT_MODULES``) point here, so a commerce
+template gets the whole flavor consistently no matter which surface
+touches it first.
+
+Import order between the two is irrelevant (and isort owns it anyway):
+the hook lists are read at CALL time, never at import time, so a
+connector registering before or after the protocol modules load makes no
+difference.
+"""
+
+from __future__ import annotations
+
+# Platform connectors — register into the ucp hooks on import.
+from app.ai.voice.agents.breeze_buddy.assist.commerce.connectors import (  # noqa: F401
+    shopify,
+)
+
+# Protocol layer — schemas pulls in render_ui / ui_prompt / step_labels /
+# tool_meta; intents pulls in media / upsell.
+from app.ai.voice.agents.breeze_buddy.assist.commerce.ucp import (  # noqa: F401
+    intents,
+    schemas,
+)
+
+__all__ = ["schemas", "intents", "shopify"]

--- a/app/ai/voice/agents/breeze_buddy/assist/commerce/connectors/__init__.py
+++ b/app/ai/voice/agents/breeze_buddy/assist/commerce/connectors/__init__.py
@@ -1,0 +1,6 @@
+"""Platform connectors for the commerce flavor.
+
+Each connector registers into the UCP layer's hooks (``ucp/hooks.py``) and
+is otherwise invisible: the protocol modules never import a connector, so
+adding a platform is adding a package here, never editing UCP code.
+"""

--- a/app/ai/voice/agents/breeze_buddy/assist/commerce/connectors/shopify/__init__.py
+++ b/app/ai/voice/agents/breeze_buddy/assist/commerce/connectors/shopify/__init__.py
@@ -1,0 +1,34 @@
+"""Shopify connector — the only place in this flavor that knows Shopify.
+
+Registration is a side effect of import; the flavor's package __init__
+imports this module after the UCP layer is loaded.
+"""
+
+from __future__ import annotations
+
+from app.ai.voice.agents.breeze_buddy.assist.commerce.connectors.shopify.media import (
+    resolve_gallery,
+)
+from app.ai.voice.agents.breeze_buddy.assist.commerce.connectors.shopify.quirks import (
+    repair_flattened_description,
+    suppress_default_title_variant,
+)
+from app.ai.voice.agents.breeze_buddy.assist.commerce.ucp.hooks import (
+    register_description_repair,
+    register_media_resolver,
+    register_variant_normalizer,
+)
+
+# The name a template uses in ``flavor.<protocol>.connectors``.
+CONNECTOR_NAME = "shopify"
+
+register_media_resolver(CONNECTOR_NAME, resolve_gallery)
+register_variant_normalizer(suppress_default_title_variant)
+register_description_repair(repair_flattened_description)
+
+__all__ = [
+    "CONNECTOR_NAME",
+    "resolve_gallery",
+    "repair_flattened_description",
+    "suppress_default_title_variant",
+]

--- a/app/ai/voice/agents/breeze_buddy/assist/commerce/connectors/shopify/media.py
+++ b/app/ai/voice/agents/breeze_buddy/assist/commerce/connectors/shopify/media.py
@@ -1,0 +1,170 @@
+"""Shopify gallery resolver — one UCP media hook.
+
+UCP media is canonical and wins whenever it already carries a gallery; on
+a gateway that ships full media this resolver never fires. Today's Shopify
+UCP gateway projects exactly one image per product (probed live: search,
+get_product, and every variant's media all carry 1), while the
+storefront's public product JSON carries the merchant's full curated
+gallery (18 images on the probe product).
+
+Self-selecting: the product's own ``url`` is the only input, and anything
+that isn't a ``/products/{handle}`` path returns None immediately — so a
+non-Shopify store loaded alongside this connector simply never matches.
+No configuration, and no Shopify knowledge outside this file.
+
+No LLM anywhere: one deterministic HTTP GET per View, fail-open (any error
+→ the single UCP image the shopper already had).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import ipaddress
+import socket
+from typing import Any, Dict, List, Optional
+from urllib.parse import urlsplit
+
+from app.ai.voice.agents.breeze_buddy.assist.commerce.ucp.media import (
+    MAX_GALLERY_IMAGES,
+)
+from app.core.logger import logger
+
+_FETCH_TIMEOUT_S = 3.0
+_RESOLVE_TIMEOUT_S = 1.0
+
+
+def _is_public_ip(addr: str) -> bool:
+    """False for anything that could reach infrastructure rather than the
+    public internet — loopback, RFC1918, link-local (incl. the cloud
+    metadata endpoint 169.254.169.254), CGNAT, multicast, reserved."""
+    try:
+        ip = ipaddress.ip_address(addr)
+    except ValueError:
+        return False
+    return not (
+        ip.is_private
+        or ip.is_loopback
+        or ip.is_link_local
+        or ip.is_multicast
+        or ip.is_reserved
+        or ip.is_unspecified
+    )
+
+
+def _handle_url(product_url: str) -> Optional[str]:
+    """``https://host/products/{handle}[...]`` → the public product-JSON
+    URL, or None when the path isn't a Shopify product page.
+
+    The product ``url`` is upstream-controlled data, and this function is
+    the gate on an outbound request the SERVER makes — so it is deliberately
+    strict about the host, not just the path:
+
+    - userinfo is dropped (``user:secret@host`` would otherwise be fetched
+      AND logged);
+    - a non-default port is refused — storefronts are :443, and an explicit
+      port is how you reach an internal service;
+    - an IP-literal host must be publicly routable, which rejects the cloud
+      metadata endpoint and every RFC1918 address.
+
+    A hostname that RESOLVES to a private address is caught separately (see
+    :func:`_host_resolves_public`) — that needs I/O, so it can't live here.
+    """
+    try:
+        parts = urlsplit(product_url)
+    except ValueError:
+        return None
+    if parts.scheme not in ("http", "https"):
+        return None
+    try:
+        host, port = parts.hostname, parts.port
+    except ValueError:  # malformed port
+        return None
+    if not host:
+        return None
+    if port not in (None, 443):
+        return None
+    # An IP literal never belongs to a storefront; allow only public ones.
+    try:
+        ipaddress.ip_address(host)
+    except ValueError:
+        pass  # a name — resolution is checked before the fetch
+    else:
+        if not _is_public_ip(host):
+            return None
+    segments = [s for s in parts.path.split("/") if s]
+    try:
+        ix = segments.index("products")
+    except ValueError:
+        return None
+    if ix + 1 >= len(segments):
+        return None
+    handle = segments[ix + 1]
+    return f"https://{host}/products/{handle}.json"
+
+
+async def _host_resolves_public(host: str) -> bool:
+    """True when every A/AAAA record for ``host`` is publicly routable.
+
+    Closes the DNS half of the SSRF gate: ``evil.example`` resolving to
+    127.0.0.1 or 169.254.169.254 passes the syntactic check in
+    :func:`_handle_url` but must not be fetched. Fail CLOSED — a lookup
+    that errors or times out means we don't fetch.
+    """
+    try:
+        loop = asyncio.get_running_loop()
+        async with asyncio.timeout(_RESOLVE_TIMEOUT_S):
+            infos = await loop.getaddrinfo(host, 443, proto=socket.IPPROTO_TCP)
+    except Exception:  # noqa: BLE001 — fail closed
+        return False
+    addrs = [info[4][0] for info in infos if info[4]]
+    return bool(addrs) and all(_is_public_ip(addr) for addr in addrs)
+
+
+async def resolve_gallery(
+    aiohttp_session: Any, product: Dict[str, Any]
+) -> Optional[List[Dict[str, str]]]:
+    """Gallery for ``product`` off the storefront product JSON, or None
+    when this isn't a Shopify product / nothing better exists / anything
+    fails."""
+    url = product.get("url")
+    if not isinstance(url, str) or not url:
+        return None
+    json_url = _handle_url(url)
+    if json_url is None or aiohttp_session is None:
+        return None
+    host = urlsplit(json_url).hostname or ""
+    if not await _host_resolves_public(host):
+        logger.warning(
+            f"shopify media resolver: refusing fetch, {host!r} does not "
+            "resolve to a public address"
+        )
+        return None
+    try:
+        async with asyncio.timeout(_FETCH_TIMEOUT_S):
+            # No redirects: a 302 to an internal host would sidestep every
+            # check above, and a storefront product JSON never needs one.
+            async with aiohttp_session.get(json_url, allow_redirects=False) as resp:
+                if resp.status != 200:
+                    return None
+                data = await resp.json(content_type=None)
+    except Exception:  # noqa: BLE001 — strictly fail-open decoration
+        # json_url is already sanitized (no userinfo) by _handle_url.
+        logger.warning(f"shopify media resolver: fetch failed for {json_url}")
+        return None
+    images = (
+        data.get("product", {}).get("images")
+        if isinstance(data, dict) and isinstance(data.get("product"), dict)
+        else None
+    )
+    if not isinstance(images, list):
+        return None
+    gallery = [
+        {"type": "image", "url": img["src"]}
+        for img in images
+        if isinstance(img, dict) and isinstance(img.get("src"), str) and img["src"]
+    ][:MAX_GALLERY_IMAGES]
+    # A 0/1-image gallery is no improvement over the wire's own hero.
+    return gallery if len(gallery) > 1 else None
+
+
+__all__ = ["resolve_gallery"]

--- a/app/ai/voice/agents/breeze_buddy/assist/commerce/connectors/shopify/quirks.py
+++ b/app/ai/voice/agents/breeze_buddy/assist/commerce/connectors/shopify/quirks.py
@@ -1,0 +1,63 @@
+"""Shopify data-shape quirks — two UCP projection hooks.
+
+Both repair damage that exists on the Shopify UCP gateway specifically,
+not in UCP itself, so neither belongs in the protocol layer: a gateway
+that ships clean data must not pay for either.
+
+Both are conservative and self-selecting — they return None ("no opinion")
+unless they positively recognise the shape they exist to fix.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Dict, List, Optional
+
+# 1. An emoji glued directly onto a word/punctuation was a list-item
+#    boundary (the merchant's per-feature bullet emoji) → line break BEFORE
+#    the emoji. Emoji-after-emoji ("🔥❄️") and emoji after a space stay put,
+#    so genuinely inline emoji survive.
+_GLUED_EMOJI_RE = re.compile(
+    r"(?<=[0-9A-Za-z.,:;!?%)\"'’”–—-])" r"(?=[☀-➿⬀-⯿\U0001F000-\U0001FAFF])"
+)
+# 2. A lowercase run (≥3 letters) immediately followed by a Capitalized
+#    word was a lost paragraph boundary ("youFrom") → blank line. The ≥3
+#    floor keeps camel-case brands ("iPhone", "YouTube") intact — real prose
+#    always has whitespace after sentence punctuation.
+_LOST_PARAGRAPH_RE = re.compile(r"(?<=[a-z]{3})(?=[A-Z][a-z])")
+
+
+def repair_flattened_description(text: str) -> Optional[str]:
+    """Recover block boundaries the gateway destroyed upstream.
+
+    Live-observed: Shopify's UCP gateway ships some descriptions ALREADY
+    tag-stripped, with the block boundaries lost — "…wherever you go🔥❄️
+    Keeps…", "…move with youFrom early…" — so there are no tags left for
+    the protocol layer's HTML→text conversion to turn into newlines.
+    """
+    repaired = _LOST_PARAGRAPH_RE.sub("\n\n", _GLUED_EMOJI_RE.sub("\n", text))
+    return repaired if repaired != text else None
+
+
+def suppress_default_title_variant(
+    well_formed: List[Dict[str, Any]],
+) -> Optional[List[Dict[str, Any]]]:
+    """Drop Shopify's variantless-product pseudo-variant.
+
+    Shopify manufactures a single variant titled the literal "Default
+    Title" for products with no options (one-size socks, bottles). It is
+    NOT a real choice: projecting it made the picker render a nonsense
+    "Choose an option → Default Title" step (live 2026-08-03). Such
+    products project ``variants=[]`` + ``default_variant_id`` instead —
+    the widget's existing direct-add path (card AND detail overlay both
+    already handle that shape).
+    """
+    if (
+        len(well_formed) == 1
+        and str(well_formed[0].get("title", "")).strip().lower() == "default title"
+    ):
+        return []
+    return None
+
+
+__all__ = ["repair_flattened_description", "suppress_default_title_variant"]

--- a/app/ai/voice/agents/breeze_buddy/assist/commerce/ucp/__init__.py
+++ b/app/ai/voice/agents/breeze_buddy/assist/commerce/ucp/__init__.py
@@ -1,0 +1,9 @@
+"""UCP — the protocol layer of the commerce flavor.
+
+Everything here speaks Universal Commerce Protocol and nothing else: tool
+roles (create_cart / update_cart / get_cart / get_product / search_catalog,
+all template-overridable), the wire projections, the intent policies, and
+the UI copy. No module in this package names a platform; where a real
+gateway needs platform knowledge to interpret, the seam is a hook in
+``hooks.py`` and the answer lives under ``connectors/``.
+"""

--- a/app/ai/voice/agents/breeze_buddy/assist/commerce/ucp/annotator.py
+++ b/app/ai/voice/agents/breeze_buddy/assist/commerce/ucp/annotator.py
@@ -1,0 +1,182 @@
+"""Baseline search annotation (RFC-003 §3 baseline mode — NOT OKF).
+
+Code-only matching of the shopper's ask against THIS turn's live UCP search
+results: product titles, tags, and variant option values are all in the
+payload already, so ``matched_via`` / ``matched_variant`` work for every
+merchant with zero sync. Stage ① (alias expansion) and the wider OKF
+vocabulary are the Stage-2 opt-in; this annotator is the 90%.
+
+Contract (result_annotators): ADD keys only — a matched product entry gains
+
+    "matched_via":     "exact" | "fuzzy"
+    "matched_variant": {"id": …, "title": …}     (when the ask names a
+                                                  variant-distinguishing
+                                                  token, e.g. "pink")
+
+and the payload gains a compact top-level ``match`` summary. The model
+passes ``matched_variant.id`` through as ``items[].feature_variant`` in
+``render_ui`` (code decides when the query decided); rendered values stay
+tool-sourced — a wrong match can only mis-EMPHASIZE, never mis-render.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Dict, List, Optional, Set, Tuple
+
+from app.ai.voice.agents.breeze_buddy.template.session_state import (
+    _unwrap_tool_payload,
+)
+
+# Query noise: intent verbs, filler, price-ask scaffolding. Tokens the
+# catalog can't match on and that would dilute exact/fuzzy scoring.
+_STOPWORDS = frozenset("""
+    a an the me my i you your we our do does have has any some show see want
+    need looking look for of in on with and or to under below above over
+    around about price priced rs inr rupees than is are it this that please
+    buy get find them there available
+    """.split())
+
+_TOKEN_RE = re.compile(r"[a-z0-9]+")
+
+# Cap matched products annotated per page — the whole page is 10 today;
+# annotation on everything would mean the query didn't discriminate.
+_MAX_MATCHED = 6
+
+
+def _tokens(text: str) -> List[str]:
+    return [t for t in _TOKEN_RE.findall(text.lower()) if len(t) >= 2]
+
+
+def _query_tokens(query: str) -> List[str]:
+    return [t for t in _tokens(query) if t not in _STOPWORDS and not t.isdigit()]
+
+
+def _product_haystack(product: Dict[str, Any]) -> Set[str]:
+    parts: List[str] = [str(product.get("title") or "")]
+    tags = product.get("tags")
+    if isinstance(tags, list):
+        parts.extend(str(t) for t in tags)
+    ptype = product.get("product_type")
+    if isinstance(ptype, str):
+        parts.append(ptype)
+    out: Set[str] = set()
+    for part in parts:
+        out.update(_tokens(part))
+    return out
+
+
+def _variant_tokens(variant: Dict[str, Any]) -> Set[str]:
+    """Tokens that can distinguish one variant: its title ("S / Pink") plus
+    any option values (``options``/``selected_options`` shapes)."""
+    parts: List[str] = [str(variant.get("title") or "")]
+    for key in ("options", "selected_options", "option_values"):
+        val = variant.get(key)
+        if isinstance(val, list):
+            for entry in val:
+                if isinstance(entry, str):
+                    parts.append(entry)
+                elif isinstance(entry, dict):
+                    v = entry.get("value") or entry.get("name")
+                    if isinstance(v, str):
+                        parts.append(v)
+        elif isinstance(val, dict):
+            parts.extend(str(v) for v in val.values() if isinstance(v, str))
+    out: Set[str] = set()
+    for part in parts:
+        out.update(_tokens(part))
+    return out
+
+
+def _match_variant(
+    product: Dict[str, Any], query_tokens: Set[str]
+) -> Optional[Dict[str, Any]]:
+    """The variant whose DISTINGUISHING tokens intersect the ask.
+
+    A token shared by every variant of the product (e.g. the product name
+    riding each variant title) distinguishes nothing and is ignored — only
+    tokens that separate one variant from its siblings count, so "pink"
+    picks the pink variant and "shorts" picks none.
+    """
+    variants = product.get("variants")
+    if not isinstance(variants, list) or len(variants) < 2:
+        return None
+    token_sets: List[Tuple[Dict[str, Any], Set[str]]] = []
+    for variant in variants:
+        if isinstance(variant, dict) and variant.get("id"):
+            token_sets.append((variant, _variant_tokens(variant)))
+    if len(token_sets) < 2:
+        return None
+    common = set.intersection(*(ts for _, ts in token_sets))
+    best: Optional[Dict[str, Any]] = None
+    best_hits = 0
+    for variant, ts in token_sets:
+        hits = len((ts - common) & query_tokens)
+        if hits > best_hits:
+            best, best_hits = variant, hits
+    if best is None:
+        return None
+    return {"id": best.get("id"), "title": best.get("title")}
+
+
+def annotate_search_result(args: Dict[str, Any], result: Any) -> Any:
+    """The registered annotator for ``search_catalog`` (baseline mode)."""
+    query = args.get("query")
+    if not isinstance(query, str) or not query.strip():
+        return result
+    payload = _unwrap_tool_payload(result)
+    products = payload.get("products") if isinstance(payload, dict) else None
+    if not isinstance(products, list) or not products:
+        return result
+
+    q_tokens = set(_query_tokens(query))
+    if not q_tokens:
+        return result
+
+    scored: List[Tuple[int, bool, Dict[str, Any]]] = []
+    for product in products:
+        if not isinstance(product, dict):
+            continue
+        haystack = _product_haystack(product)
+        variant_match = _match_variant(product, q_tokens)
+        hay_hits = len(q_tokens & haystack)
+        hits = hay_hits + (1 if variant_match else 0)
+        if hits == 0:
+            continue
+        exact = q_tokens <= (
+            haystack | (_variant_tokens_all(product) if variant_match else set())
+        )
+        scored.append((hits, exact, product))
+        if variant_match and variant_match.get("id"):
+            product["matched_variant"] = variant_match
+
+    if not scored:
+        return result
+    scored.sort(key=lambda t: (t[1], t[0]), reverse=True)
+    top_hits = scored[0][0]
+    matched_ids: List[str] = []
+    for hits, exact, product in scored[:_MAX_MATCHED]:
+        # Annotate the leaders; a lone straggler token match on rank 9 is
+        # noise, not a match.
+        if hits * 2 < top_hits:
+            continue
+        product["matched_via"] = "exact" if exact else "fuzzy"
+        pid = product.get("id")
+        if isinstance(pid, str):
+            matched_ids.append(pid)
+    if matched_ids and isinstance(payload, dict):
+        payload["match"] = {"query": query, "matched_ids": matched_ids}
+    return result
+
+
+def _variant_tokens_all(product: Dict[str, Any]) -> Set[str]:
+    variants = product.get("variants")
+    out: Set[str] = set()
+    if isinstance(variants, list):
+        for variant in variants:
+            if isinstance(variant, dict):
+                out.update(_variant_tokens(variant))
+    return out
+
+
+__all__ = ["annotate_search_result"]

--- a/app/ai/voice/agents/breeze_buddy/assist/commerce/ucp/hooks.py
+++ b/app/ai/voice/agents/breeze_buddy/assist/commerce/ucp/hooks.py
@@ -1,0 +1,144 @@
+"""Connector seams on the UCP layer.
+
+UCP is the protocol this flavor speaks; a *connector* is a platform that
+serves it. The protocol layer must stay platform-blind —
+so wherever a real gateway's data needs platform knowledge to interpret,
+the UCP module calls a hook here and connectors register into it.
+
+Three seams, each with the same contract: the chain is EMPTY by default
+(pure-UCP behavior — the projections work with no connector loaded), each
+hook is asked in registration order, the first one to express an opinion
+wins, and a hook that raises is skipped with a log rather than failing the
+request. A connector is decoration over a protocol that already works.
+
+Hooks self-select on the data they are handed rather than on declared
+configuration — the media resolvers, for instance, return None the moment a
+product URL isn't a path they recognise. That keeps the flavor zero-config:
+enabling ``commerce`` is the only switch a template throws.
+
+Sniffing is right where a wrong guess is free, and wrong where it costs.
+The media seam reaches the network, so a look-alike gateway (any storefront
+whose product URLs are also ``/products/{handle}``) would pay a dead fetch
+per product view — that seam therefore accepts an ``allowed`` connector
+allowlist from the template's ``flavor.<protocol>.connectors``. The variant
+and description seams are pure functions with narrow triggers, run from
+inside Pydantic validators where no template is in scope, so they stay
+sniff-only; give them an allowlist the day one of them grows teeth.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Awaitable, Callable, Dict, Iterable, List, Optional, Tuple
+
+from app.core.logger import logger
+
+# (aiohttp_session, product) → gallery media list, or None for "no opinion"
+# (the UCP payload's own media stands).
+MediaResolverFn = Callable[
+    [Any, Dict[str, Any]], Awaitable[Optional[List[Dict[str, str]]]]
+]
+
+# well-formed variant dicts → the list to project, or None for "no opinion".
+# Lets a connector suppress variants a platform manufactures but that are
+# not real choices for the shopper.
+VariantNormalizerFn = Callable[[List[Dict[str, Any]]], Optional[List[Dict[str, Any]]]]
+
+# display text → repaired display text, or None for "no opinion". For
+# gateways that damage description text upstream (e.g. shipping it already
+# tag-stripped, with the block boundaries lost).
+DescriptionRepairFn = Callable[[str], Optional[str]]
+
+# Media resolvers are (connector_name, fn) so a template can name the ones
+# it wants; the other two chains are name-free because nothing filters them.
+_MEDIA_RESOLVERS: List[Tuple[str, MediaResolverFn]] = []
+_VARIANT_NORMALIZERS: List[VariantNormalizerFn] = []
+_DESCRIPTION_REPAIRS: List[DescriptionRepairFn] = []
+
+
+def register_media_resolver(connector: str, fn: MediaResolverFn) -> None:
+    """Add a gallery resolver under ``connector``'s name (idempotent for
+    the same function object)."""
+    if all(existing is not fn for _, existing in _MEDIA_RESOLVERS):
+        _MEDIA_RESOLVERS.append((connector, fn))
+
+
+def register_variant_normalizer(fn: VariantNormalizerFn) -> None:
+    """Add a variant-list normalizer (idempotent for the same object)."""
+    if all(existing is not fn for existing in _VARIANT_NORMALIZERS):
+        _VARIANT_NORMALIZERS.append(fn)
+
+
+def register_description_repair(fn: DescriptionRepairFn) -> None:
+    """Add a description repair (idempotent for the same object)."""
+    if all(existing is not fn for existing in _DESCRIPTION_REPAIRS):
+        _DESCRIPTION_REPAIRS.append(fn)
+
+
+async def resolve_media(
+    aiohttp_session: Any,
+    product: Dict[str, Any],
+    *,
+    allowed: Optional[Iterable[str]] = None,
+) -> Optional[List[Dict[str, str]]]:
+    """First connector to produce a gallery wins; None when none does.
+
+    ``allowed`` is the template's declared connector list. ``None`` or
+    empty keeps the zero-config default (every resolver self-selects);
+    naming connectors restricts the chain to those, which is how a gateway
+    that merely LOOKS like another platform avoids a dead fetch.
+    """
+    allowlist = set(allowed) if allowed else None
+    for connector, fn in _MEDIA_RESOLVERS:
+        if allowlist is not None and connector not in allowlist:
+            continue
+        try:
+            gallery = await fn(aiohttp_session, product)
+        except Exception:  # noqa: BLE001 — a connector is never load-bearing
+            logger.warning(f"commerce media resolver {connector!r} raised; skipping")
+            continue
+        # ``is not None`` (not truthiness): an empty list is a deliberate
+        # "this platform has no gallery, stop asking", same contract the
+        # other two chains use.
+        if gallery is not None:
+            return gallery
+    return None
+
+
+def normalize_variants(well_formed: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """First connector with an opinion wins; otherwise the list is
+    projected as UCP delivered it."""
+    for fn in _VARIANT_NORMALIZERS:
+        try:
+            normalized = fn(well_formed)
+        except Exception:  # noqa: BLE001
+            logger.warning("commerce variant normalizer raised; skipping")
+            continue
+        if normalized is not None:
+            return normalized
+    return well_formed
+
+
+def repair_description(text: str) -> str:
+    """Apply every registered repair in order; each may decline (None)."""
+    for fn in _DESCRIPTION_REPAIRS:
+        try:
+            repaired = fn(text)
+        except Exception:  # noqa: BLE001
+            logger.warning("commerce description repair raised; skipping")
+            continue
+        if repaired is not None:
+            text = repaired
+    return text
+
+
+__all__ = [
+    "MediaResolverFn",
+    "VariantNormalizerFn",
+    "DescriptionRepairFn",
+    "register_media_resolver",
+    "register_variant_normalizer",
+    "register_description_repair",
+    "resolve_media",
+    "normalize_variants",
+    "repair_description",
+]

--- a/app/ai/voice/agents/breeze_buddy/assist/commerce/ucp/intents.py
+++ b/app/ai/voice/agents/breeze_buddy/assist/commerce/ucp/intents.py
@@ -1,0 +1,761 @@
+"""Commerce UI-intent policy + direct cart executor (RFC-001 §3.3).
+
+The flavor half of ``chat/intent_router.py``: per-intent payload schemas,
+the policy table (add_to_cart / remove_line / set_qty / view_product →
+DIRECT, enrich_product → AGENT_TURN internal, checkout → CLIENT), the
+Stage-A UCP cart tool-name / state-key constants, and the CartView
+``show``-op emission.
+
+Lazy-loaded flavor module: importing it registers the policies into the
+intent engine (see ``register_intents`` at the bottom). The import happens
+only via ``intent_router.ensure_flavor_intents`` — i.e. only when a
+session on a commerce-enabled template sends a ``ui_intent``.
+
+Tool names / state keys / labels resolve per-template through the
+``configurations.ui_intents`` block (Stage B); the UCP defaults below
+apply when the block (or an individual role) is absent — the Beyond Bound
+pilot template's reducers/injections speak exactly these default names.
+
+Payload compatibility policy
+----------------------------
+Payloads are produced by our own versioned widget; additive fields must
+never break older/newer servers. Per-intent payload models therefore use
+``extra="ignore"``: required-field validation stays strict (that is the
+real safety), while unknown extra keys are accepted and dropped, with one
+structured WARNING per request listing the dropped key NAMES (never
+values) so payload drift stays visible in telemetry without breaking
+shoppers. The captured widget emissions live in
+``tests/assist/fixtures/intent_payloads.json`` (mirrored byte-identically
+in the loom repo at
+``packages/client-sdk/src/lib/chat/__fixtures__/intent_payloads.json``) —
+update both fixtures and both repos' contract tests when an emission
+changes.
+"""
+
+from __future__ import annotations
+
+import copy
+from dataclasses import dataclass, field
+from typing import Any, AsyncIterator, Dict, List, Optional, Tuple
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from app.ai.voice.agents.breeze_buddy.assist.commerce.ucp.media import (
+    resolve_product_media,
+)
+from app.ai.voice.agents.breeze_buddy.assist.commerce.ucp.upsell import run_cart_upsell
+from app.ai.voice.agents.breeze_buddy.chat.intents.router import (
+    IntentPolicy,
+    IntentRoute,
+    ParsedIntent,
+    error_events,
+    register_intents,
+    run_persisted_tool,
+)
+from app.ai.voice.agents.breeze_buddy.chat.sse import SSEEvent
+
+# Same envelope helpers the engine + binding store use — one definition of
+# "success" / "payload" across every result consumer. Private-name import
+# is deliberate (same posture as chat/ui_binding.py): re-implementing them
+# here would drift.
+from app.ai.voice.agents.breeze_buddy.template.session_state import (
+    _is_tool_success,
+    _unwrap_tool_payload,
+)
+from app.core.logger import logger
+
+# ---------------------------------------------------------------------------
+# Cart tool roles — UCP defaults, overridable per template via
+# ``configurations.ui_intents`` (roles: tools.create_cart /
+# tools.update_cart / tools.get_cart, state_keys.cart_id /
+# state_keys.checkout_url, labels.checkout).
+# ---------------------------------------------------------------------------
+
+_TOOL_CREATE_CART = "create_cart"
+_TOOL_UPDATE_CART = "update_cart"
+_TOOL_GET_CART = "get_cart"
+_TOOL_GET_PRODUCT = "get_product"
+_TOOL_SEARCH = "search_catalog"
+_STATE_CART_ID = "cart_id"
+_STATE_CHECKOUT_URL = "checkout_url"
+_CHECKOUT_LABEL = "Review and checkout"
+
+
+@dataclass(frozen=True)
+class CartToolConfig:
+    """The commerce driver's resolved tool/state/label roles for one
+    template. Defaults = the UCP Stage-A surface."""
+
+    create_cart: str = _TOOL_CREATE_CART
+    update_cart: str = _TOOL_UPDATE_CART
+    get_cart: str = _TOOL_GET_CART
+    get_product: str = _TOOL_GET_PRODUCT
+    search: str = _TOOL_SEARCH
+    cart_id_key: str = _STATE_CART_ID
+    checkout_url_key: str = _STATE_CHECKOUT_URL
+    checkout_label: str = _CHECKOUT_LABEL
+    # Optional fixed destination for the CartView checkout button
+    # (template `ui_intents.urls.checkout_page`). Set it to the
+    # storefront's /cart page to land shoppers on the native cart (the
+    # CartView cookie sync makes it show the buddy-built items) instead
+    # of the tool's checkout-bound continue_url. None = continue_url.
+    checkout_page_url: Optional[str] = None
+    # Post-add upsell (template `flavor.ucp.features.upsell`). OPT-IN:
+    # off unless the merchant asks for it, because it spends an extra LLM
+    # call + catalog search on every add_to_cart and puts merchandising
+    # the merchant did not choose into their thread.
+    upsell_enabled: bool = False
+    # Platform connectors this template's gateway needs
+    # (`flavor.ucp.connectors`). Empty = every registered connector
+    # self-selects on the payload, which is right whenever the platform is
+    # unambiguous; naming them stops a look-alike gateway paying for a
+    # connector that will never match.
+    connectors: Tuple[str, ...] = ()
+
+
+# The protocol dialect this flavor speaks — the key it reads out of the
+# template's ``configurations.flavor`` map, and the name of its own package
+# directory. A second dialect would be a sibling package + a second key.
+UCP_PROTOCOL = "ucp"
+
+
+@dataclass(frozen=True)
+class _FlavorBlock:
+    """The resolved ``flavor.ucp`` block, defaulted when absent."""
+
+    connectors: Tuple[str, ...] = ()
+    features: Dict[str, bool] = field(default_factory=dict)
+
+
+def _resolve_flavor_block(configurations: Any) -> _FlavorBlock:
+    """Read ``configurations.flavor["ucp"]``; every field optional."""
+    flavors = getattr(configurations, "flavor", None) or {}
+    if not isinstance(flavors, dict):
+        return _FlavorBlock()
+    block = flavors.get(UCP_PROTOCOL)
+    if block is None:
+        # The engine can't validate these keys (it doesn't know any
+        # flavor's protocols), so the flavor that owns them says so. The
+        # likely typo is `flavor.commerce` — every OTHER flavor-keyed
+        # surface (ui_catalog.enabled_groups, LAZY_GROUPS,
+        # FLAVOR_INTENT_MODULES) keys on the flavor name, this one keys on
+        # the protocol — and it would otherwise read as "everything off".
+        if flavors:
+            logger.warning(
+                f"commerce: configurations.flavor has no {UCP_PROTOCOL!r} "
+                f"block (found {sorted(flavors)!r}); connectors will "
+                "self-select and every optional feature stays off"
+            )
+        return _FlavorBlock()
+    return _FlavorBlock(
+        connectors=tuple(getattr(block, "connectors", None) or ()),
+        features=dict(getattr(block, "features", None) or {}),
+    )
+
+
+def resolve_cart_config(template: Any) -> CartToolConfig:
+    """Overlay the template's ``configurations.ui_intents`` block (if
+    any) onto the UCP defaults. Unknown roles in the block are ignored —
+    they may belong to another flavor sharing the same template."""
+    configurations = getattr(template, "configurations", None)
+    flavor = _resolve_flavor_block(configurations)
+    cfg = getattr(configurations, "ui_intents", None)
+    if cfg is None:
+        return CartToolConfig(
+            upsell_enabled=bool(flavor.features.get("upsell", False)),
+            connectors=tuple(flavor.connectors or ()),
+        )
+    tools = cfg.tools or {}
+    keys = cfg.state_keys or {}
+    labels = cfg.labels or {}
+    urls = getattr(cfg, "urls", None) or {}
+    return CartToolConfig(
+        create_cart=tools.get("create_cart", _TOOL_CREATE_CART),
+        update_cart=tools.get("update_cart", _TOOL_UPDATE_CART),
+        get_cart=tools.get("get_cart", _TOOL_GET_CART),
+        get_product=tools.get("get_product", _TOOL_GET_PRODUCT),
+        search=tools.get("search", _TOOL_SEARCH),
+        cart_id_key=keys.get("cart_id", _STATE_CART_ID),
+        checkout_url_key=keys.get("checkout_url", _STATE_CHECKOUT_URL),
+        checkout_label=labels.get("checkout", _CHECKOUT_LABEL),
+        checkout_page_url=urls.get("checkout_page"),
+        upsell_enabled=bool(flavor.features.get("upsell", False)),
+        connectors=tuple(flavor.connectors or ()),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Per-intent payload schemas
+#
+# Each schema explicitly covers every field the widget emits TODAY (see
+# the payload-compatibility policy in the module docstring and the
+# contract fixtures in tests/assist/fixtures/intent_payloads.json).
+# Unknown extra keys — a newer widget talking to this server — are
+# accepted, dropped, and logged by the shared base class below.
+# ---------------------------------------------------------------------------
+
+
+class _IntentPayload(BaseModel):
+    """Shared base for per-intent payload schemas.
+
+    ``extra="ignore"``: payloads come from our own versioned widget, so an
+    unknown key is expected version skew (additive field), never hostile
+    input — required-field validation stays strict, unknown keys are
+    dropped. The before-validator logs ONE structured WARNING per request
+    listing the dropped key names (structural only — key names, never
+    values, same privacy contract as ``_structural_errors``) so drift is
+    visible in telemetry without 422-ing shoppers.
+    """
+
+    model_config = ConfigDict(extra="ignore")
+
+    @model_validator(mode="before")
+    @classmethod
+    def _warn_dropped_keys(cls, data: Any) -> Any:
+        if isinstance(data, dict):
+            dropped = sorted(key for key in data if key not in cls.model_fields)
+            if dropped:
+                logger.warning(
+                    f"ui_intent payload drift: {cls.__name__} dropped unknown "
+                    f"keys {dropped} (key names only; values never logged)"
+                )
+        return data
+
+
+class AddToCartPayload(_IntentPayload):
+    """Widget emission (ProductCard): variant_id + qty + product_id."""
+
+    variant_id: str = Field(..., min_length=1, max_length=256)
+    qty: int = Field(1, ge=1, le=99)
+    # Sent by ProductCard for audit/re-resolution context; unused by the
+    # cart driver (the variant GID alone addresses the line).
+    product_id: Optional[str] = Field(None, max_length=256)
+
+
+class RemoveLinePayload(_IntentPayload):
+    """Widget emission (CartView): line_id [+ variant_id] [+ cart_id]."""
+
+    line_id: str = Field(..., min_length=1, max_length=256)
+    # CartView includes these when known; audit-only context for the driver
+    # (line_id alone addresses the line; cart_id comes from session state).
+    variant_id: Optional[str] = Field(None, max_length=256)
+    cart_id: Optional[str] = Field(None, max_length=512)
+
+
+class SetQtyPayload(_IntentPayload):
+    """Widget emission (CartView): line_id + variant_id + qty [+ cart_id]."""
+
+    line_id: str = Field(..., min_length=1, max_length=256)
+    qty: int = Field(..., ge=0, le=99, description="0 removes the line.")
+    # CartView includes these when known; audit-only context for the driver.
+    variant_id: Optional[str] = Field(None, max_length=256)
+    cart_id: Optional[str] = Field(None, max_length=512)
+
+
+class ViewProductPayload(_IntentPayload):
+    """Widget emission (ProductCard): product_id + title [+ url]."""
+
+    product_id: str = Field(..., min_length=1, max_length=256)
+    title: Optional[str] = Field(None, max_length=200)
+    # Storefront product URL, sent when the hydrated ProductP carried one.
+    # Audit/handoff context only — the agent turn is built from
+    # product_id + title.
+    url: Optional[str] = Field(None, max_length=2048)
+    # Variant continuity: the variant the card's hero was re-derived from
+    # (render_ui ``items[].feature_variant`` stamps it on ProductP). The
+    # widget preselects it in the detail overlay CLIENT-side; the server
+    # models it so the emission parses drift-free (audit context only).
+    featured_variant_id: Optional[str] = Field(None, max_length=256)
+    # The card's search-sourced variant list (id/title/available/price).
+    # Live gateways commonly wrap a get-product-details call that
+    # returns ONLY the selected variant — this relay lets the detail
+    # overlay still offer the full size axis. Display-only provenance:
+    # variant ids are client-authored in add_to_cart anyway, and the
+    # deterministic cart verifier is the backstop for a bogus id.
+    variants: Optional[List[Dict[str, Any]]] = Field(None, max_length=24)
+
+
+class EnrichProductPayload(_IntentPayload):
+    """Widget emission (detail overlay, background): product_id [+ title].
+
+    Fired by the store AFTER the view_product hydration lands — the
+    rewritten agent turn asks for a short "Buddy says" note that streams
+    into the open overlay. The product data itself is already in the
+    LLM's context (the view_product tool exchange persisted just before),
+    so the payload only needs to identify the product.
+    """
+
+    product_id: str = Field(..., min_length=1, max_length=256)
+    title: Optional[str] = Field(None, max_length=200)
+
+
+def _enrich_product_agent_turn(parsed: ParsedIntent) -> str:
+    """Rewrite enrich_product into the internal instruction the LLM answers.
+
+    The brief IS the overlay's body copy (2026-07-31 minimalist redesign
+    — the raw merchant description is no longer shown): a compact
+    markdown product brief, grounded in the product data already in
+    context (the get_product exchange from the view fetch). Markdown-only
+    contract: no tools, no UI calls; the widget drops any op/step frames
+    from this turn defensively.
+    """
+    payload = parsed.payload
+    assert isinstance(payload, EnrichProductPayload)  # policy table guarantees
+    label = (
+        f'"{payload.title}" ({payload.product_id})'
+        if payload.title
+        else (payload.product_id)
+    )
+    return (
+        "[Background enrichment — a system request, not the shopper speaking.] "
+        f"The shopper just opened the product detail view for {label}. "
+        "Write the product brief that view shows below the price and "
+        "add-to-cart button, in markdown, under 90 words total: one "
+        "sentence on what it is and who it's for, then 2-4 tight bullet "
+        "points (fabric/feel, standout details, fit or sizing guidance, "
+        "what it pairs with). Ground every claim in the product data "
+        "already in this conversation; do not invent specifics; skip "
+        "anything the data doesn't support. Do not repeat the product "
+        "title or price — they're already on screen. Do not call any "
+        "tools. Markdown text only — no headings, no links, no images, "
+        "and no greeting."
+    )
+
+
+class CheckoutPayload(_IntentPayload):
+    """Client-routed — the widget opens the storefront cart URL itself;
+    the schema exists so an (unexpected) server-side arrival still 422s
+    with a typed error instead of a KeyError."""
+
+    url: Optional[str] = Field(None, max_length=2048)
+
+
+async def _drive_view_product(
+    agent: Any,
+    prep: Any,
+    node: Dict[str, Any],
+    parsed: ParsedIntent,
+    turn_id: str,
+) -> AsyncIterator[Tuple[Optional[SSEEvent], Optional[str], Any]]:
+    """view_product (DIRECT) → one deterministic ``get_product`` read.
+
+    Feeds the widget's full-panel detail overlay: the overlay opens with a
+    skeleton on click; this fetch hydrates the server-only ProductDetail
+    component through the standard show-op resolver. No LLM in the loop —
+    the "which call" decision is the template's ``ui_intents`` mapping.
+    """
+    payload = parsed.payload
+    assert isinstance(payload, ViewProductPayload)  # policy table guarantees
+    cfg = resolve_cart_config(agent.template)
+    events, result = await run_persisted_tool(
+        agent,
+        tool_name=cfg.get_product,
+        args={"catalog": {"id": payload.product_id}},
+        node=node,
+        prep=prep,
+        turn_id=turn_id,
+    )
+    for ev in events:
+        yield ev, None, None
+    # Binding enrichment: re-record an ENRICHED payload so the hydrated
+    # ProductDetail is richer than the raw wire read. The persisted
+    # tool_result stays the original — the LLM's context is untouched;
+    # only this turn's binding store (which the show-op resolves against)
+    # sees the merge. Two grafts compose here:
+    #   (a) variants — single-variant read + a multi-variant card: the
+    #       payload-relayed axis replaces the lone variant (A6).
+    #   (b) media — the gateway ships ONE image per product; the media
+    #       resolver (assist/commerce/media.py, no LLM) fills the full
+    #       gallery, and is a no-op when UCP media is already rich.
+    if _is_tool_success(result):
+        unwrapped = _unwrap_tool_payload(result)
+        product = unwrapped.get("product") if isinstance(unwrapped, dict) else None
+        if isinstance(product, dict):
+            enriched: Optional[Dict[str, Any]] = None
+
+            def _enriched_product() -> Dict[str, Any]:
+                nonlocal enriched
+                if enriched is None:
+                    enriched = copy.deepcopy(unwrapped)
+                    assert isinstance(enriched, dict)  # mirror of unwrapped
+                ep = enriched["product"]
+                assert isinstance(ep, dict)  # mirror of `product`
+                return ep
+
+            if (
+                payload.variants
+                and len([v for v in (product.get("variants") or []) if v]) <= 1
+                and len(payload.variants) > 1
+            ):
+                ep = _enriched_product()
+                ep["variants"] = payload.variants
+                ep.pop("default_variant_id", None)
+
+            gallery = await resolve_product_media(
+                agent.aiohttp_session, product, connectors=cfg.connectors
+            )
+            if gallery:
+                _enriched_product()["media"] = gallery
+
+            if enriched is not None:
+                agent.binding_store.record(cfg.get_product, None, enriched)
+    yield None, cfg.get_product, result
+
+
+def _product_detail_show_op(tool_name: str, result: Any, agent: Any) -> Dict[str, Any]:
+    """Server-authored ``show ProductDetail`` over the get_product result —
+    same resolver/validation path as every LLM-authored show op."""
+    return {
+        "op": "show",
+        "id": "root",
+        "component": "ProductDetail",
+        "bind": {"product": f"$tool:{tool_name}#/product"},
+    }
+
+
+# ---------------------------------------------------------------------------
+# Direct cart executor (driven by intent_router.run_direct_intent)
+# ---------------------------------------------------------------------------
+
+
+def _cart_lines(cart_payload: Any) -> List[Dict[str, Any]]:
+    """The ``line_items`` array off a post-pipeline cart payload."""
+    if isinstance(cart_payload, dict) and isinstance(
+        cart_payload.get("line_items"), list
+    ):
+        return [ln for ln in cart_payload["line_items"] if isinstance(ln, dict)]
+    return []
+
+
+def _line_variant_id(line: Dict[str, Any]) -> Optional[str]:
+    item = line.get("item")
+    if isinstance(item, dict) and isinstance(item.get("id"), str):
+        return item["id"]
+    return None
+
+
+class UnaddressableCartLine(Exception):
+    """A cart line could not be re-encoded into ``update_cart``'s desired set.
+
+    ``update_cart`` REPLACES the cart with the set we send, so a line we
+    silently skip is a line we DELETE. Refusing the mutation is the only
+    safe answer: the shopper retries or edits on the storefront, versus
+    losing a line they never touched and getting no error.
+    """
+
+    def __init__(self, line: Dict[str, Any]) -> None:
+        super().__init__(f"cart line {line.get('id')!r} cannot be re-encoded")
+        self.line_id = line.get("id")
+
+
+def _desired_line_items(
+    lines: List[Dict[str, Any]],
+) -> List[Tuple[Optional[str], Dict[str, Any]]]:
+    """Re-encode current cart lines as ``update_cart``'s full desired set,
+    each entry paired with the cart-line id it came from.
+
+    The pairing matters: ``line_items[].id`` is the LINE and ``item.id`` the
+    variant, and a cart may legitimately hold two lines of the same variant
+    (different attributes/properties). Mutations must therefore select on
+    the line id — keying on the variant would hit every line sharing it.
+
+    Raises :class:`UnaddressableCartLine` rather than skipping a line — see
+    that exception's docstring.
+    """
+    desired: List[Tuple[Optional[str], Dict[str, Any]]] = []
+    for line in lines:
+        variant_id = _line_variant_id(line)
+        qty = line.get("quantity")
+        if variant_id is None or not isinstance(qty, int):
+            raise UnaddressableCartLine(line)
+        line_id = line.get("id")
+        desired.append(
+            (
+                line_id if isinstance(line_id, str) else None,
+                {"item": {"id": variant_id}, "quantity": qty},
+            )
+        )
+    return desired
+
+
+async def _drive_cart_tools(
+    agent: Any,
+    prep: Any,
+    node: Dict[str, Any],
+    parsed: ParsedIntent,
+    turn_id: str,
+) -> AsyncIterator[Tuple[Optional[SSEEvent], Optional[str], Any]]:
+    """Run the per-intent cart tool sequence, yielding ``(sse_event,
+    final_tool_name, final_result)`` triples — events stream as they
+    happen; the final tool/result pair rides the last dispatch. On a
+    pre-dispatch failure (missing cart, unknown line) the terminal error
+    events are yielded and no final pair is produced.
+
+    ``update_cart``'s ``line_items`` is the FULL desired set (UCP), so the
+    mutating intents against an existing cart read it back first
+    (``get_cart``) and re-encode — the read rides the same pipeline, so
+    transforms/reducers apply uniformly.
+    """
+    payload = parsed.payload
+    cfg = resolve_cart_config(agent.template)
+    cart_id = agent.agent_state.get(cfg.cart_id_key)
+
+    async def _run(tool_name: str, args: Dict[str, Any]) -> Tuple[List[SSEEvent], Any]:
+        return await run_persisted_tool(
+            agent, tool_name=tool_name, args=args, node=node, prep=prep, turn_id=turn_id
+        )
+
+    if isinstance(payload, AddToCartPayload) and cart_id is None:
+        # First add — no cart yet: create it with the one line.
+        events, result = await _run(
+            cfg.create_cart,
+            {
+                "cart": {
+                    "line_items": [
+                        {
+                            "item": {"id": payload.variant_id},
+                            "quantity": payload.qty,
+                        }
+                    ]
+                }
+            },
+        )
+        for ev in events:
+            yield ev, None, None
+        yield None, cfg.create_cart, result
+        return
+
+    # Every other direct mutation needs the current lines to build the
+    # full desired set. Args stay minimal — the template's
+    # tool_arg_injection fills `id` from state (only_if_missing).
+    events, get_result = await _run(cfg.get_cart, {})
+    for ev in events:
+        yield ev, None, None
+    if not _is_tool_success(get_result):
+        for ev in error_events(
+            "intent_tool_failed", "Could not load the current cart."
+        ):
+            yield ev, None, None
+        return
+    lines = _cart_lines(_unwrap_tool_payload(get_result))
+    try:
+        pairs = _desired_line_items(lines)
+    except UnaddressableCartLine as exc:
+        # Fail closed: shipping a lossy replacement set would delete the
+        # line we can't encode, without the shopper ever asking.
+        logger.warning(
+            f"commerce cart: line {exc.line_id!r} is not re-encodable; "
+            "refusing the update rather than dropping it"
+        )
+        for ev in error_events(
+            "intent_cart_unsupported",
+            "This cart has an item we can't update from here. "
+            "Please make the change on the cart page.",
+        ):
+            yield ev, None, None
+        return
+
+    if isinstance(payload, AddToCartPayload):
+        for _line_id, entry in pairs:
+            if entry["item"]["id"] == payload.variant_id:
+                entry["quantity"] += payload.qty
+                break
+        else:
+            pairs.append(
+                (None, {"item": {"id": payload.variant_id}, "quantity": payload.qty})
+            )
+        desired = [entry for _line_id, entry in pairs]
+    elif isinstance(payload, (RemoveLinePayload, SetQtyPayload)):
+        # Select by LINE id, never by variant — two lines can share a
+        # variant, and keying on it would remove/retitle both.
+        new_qty = 0 if isinstance(payload, RemoveLinePayload) else payload.qty
+        for line_id, entry in pairs:
+            if line_id is not None and line_id == payload.line_id:
+                entry["quantity"] = new_qty
+                break
+        else:
+            for ev in error_events(
+                "intent_line_not_found",
+                "That item is no longer in the cart.",
+            ):
+                yield ev, None, None
+            return
+        desired = [entry for _line_id, entry in pairs if entry["quantity"] > 0]
+    else:  # pragma: no cover — policy table guarantees a cart payload here
+        for ev in error_events(
+            "invalid_intent", f"Intent {parsed.intent.intent!r} is not direct."
+        ):
+            yield ev, None, None
+        return
+
+    events, update_result = await _run(
+        cfg.update_cart, {"cart": {"line_items": desired}}
+    )
+    for ev in events:
+        yield ev, None, None
+    yield None, cfg.update_cart, update_result
+
+
+def _cart_failure_message(result: Any) -> Optional[str]:
+    """Shopper-displayable reason off a failed cart result.
+
+    The UCP cart payload carries a ``messages[]`` array of display-grade
+    entries — e.g. ``{"type":"warning","content_type":"plain","code":
+    "merchandise_out_of_stock","content":"The product '…' is already sold
+    out."}`` on a create/update that silently skipped a line (which the
+    deterministic verifier converts into an error envelope carrying the
+    raw payload under ``unverified_result``). Only those plain-content
+    entries are returned — never envelope internals; ``None`` falls back
+    to the engine's generic copy.
+    """
+    candidates: List[Any] = []
+    if isinstance(result, dict):
+        # unverified_result may be the raw post-pipeline dict OR still the
+        # {status, data} envelope (test fixtures / non-projected servers) —
+        # check both the unwrapped and verbatim forms.
+        unverified = result.get("unverified_result")
+        if isinstance(unverified, dict):
+            candidates.append(_unwrap_tool_payload(unverified))
+            candidates.append(unverified)
+        candidates.append(_unwrap_tool_payload(result))
+        candidates.append(result)
+    for candidate in candidates:
+        if not isinstance(candidate, dict):
+            continue
+        messages = candidate.get("messages")
+        if not isinstance(messages, list):
+            continue
+        for entry in messages:
+            if not isinstance(entry, dict):
+                continue
+            if entry.get("type") not in ("warning", "error"):
+                continue
+            if entry.get("content_type", "plain") != "plain":
+                continue
+            content = entry.get("content")
+            if isinstance(content, str) and content.strip():
+                return content.strip()[:200]
+    return None
+
+
+def _cart_ack(parsed: ParsedIntent, tool_name: str, result: Any) -> str:
+    """Cart mutations acknowledge with one plain line ABOVE the rendered
+    cart (2026-07-30 user spec). The fresh CartView sweeps earlier cart
+    blocks client-side, so this line is what keeps old mutation turns
+    visibly anchored after their cart card vanishes."""
+    return "Done."
+
+
+def _cart_view_show_op(tool_name: str, result: Any, agent: Any) -> Dict[str, Any]:
+    """Server-authored ``show CartView`` op over the final cart result.
+
+    Binds only pointers that exist in the payload (an absent optional field
+    must not fail the whole op — RFC drops on ANY unresolved bind); the
+    checkout handoff is a literal prop built from the cart's
+    ``continue_url`` (falling back to reducer state) since the UCP payload
+    has no ``{label, url}`` object to point at.
+    """
+    cfg = resolve_cart_config(agent.template)
+    payload = _unwrap_tool_payload(result)
+    payload = payload if isinstance(payload, dict) else {}
+    bind: Dict[str, str] = {"cart_id": f"$tool:{tool_name}#/id"}
+    for prop, key in (
+        ("line_items", "line_items"),
+        ("totals", "totals"),
+        ("cart_token", "cart_token"),
+    ):
+        if payload.get(key) is not None:
+            bind[prop] = f"$tool:{tool_name}#/{key}"
+    props: Dict[str, Any] = {}
+    # Configured fixed destination (template ui_intents.urls.checkout_page,
+    # e.g. the storefront /cart page — cookie sync shows the built cart
+    # there) WINS over the tool's checkout-bound continue_url.
+    checkout_url = (
+        cfg.checkout_page_url
+        or payload.get("continue_url")
+        or agent.agent_state.get(cfg.checkout_url_key)
+    )
+    if isinstance(checkout_url, str) and checkout_url:
+        props["checkout"] = {"label": cfg.checkout_label, "url": checkout_url}
+    return {
+        "op": "show",
+        "id": "root",
+        "component": "CartView",
+        "bind": bind,
+        "props": props,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Registration — runs once, at (lazy) import time
+# ---------------------------------------------------------------------------
+
+register_intents(
+    "commerce",
+    {
+        "add_to_cart": IntentPolicy(
+            IntentRoute.DIRECT,
+            AddToCartPayload,
+            default_display="Add to cart",
+            drive=_drive_cart_tools,
+            show_op=_cart_view_show_op,
+            failure_message=_cart_failure_message,
+            ack_message=_cart_ack,
+            # Adds only — qty tweaks and removals must not re-pitch. The
+            # upsell streams AFTER the CartView (see upsell.py), so the
+            # mutation's perceived latency is unchanged.
+            followup=run_cart_upsell,
+        ),
+        "remove_line": IntentPolicy(
+            IntentRoute.DIRECT,
+            RemoveLinePayload,
+            default_display="Remove from cart",
+            drive=_drive_cart_tools,
+            show_op=_cart_view_show_op,
+            failure_message=_cart_failure_message,
+            ack_message=_cart_ack,
+        ),
+        "set_qty": IntentPolicy(
+            IntentRoute.DIRECT,
+            SetQtyPayload,
+            default_display="Update quantity",
+            drive=_drive_cart_tools,
+            show_op=_cart_view_show_op,
+            failure_message=_cart_failure_message,
+            ack_message=_cart_ack,
+        ),
+        "view_product": IntentPolicy(
+            IntentRoute.DIRECT,
+            ViewProductPayload,
+            default_display="View product",
+            drive=_drive_view_product,
+            show_op=_product_detail_show_op,
+            # Full-panel overlay UX: nothing appears in the chat thread —
+            # no user bubble, no persisted ui block (the tool exchange
+            # still persists so the agent knows what the shopper viewed).
+            silent=True,
+        ),
+        "enrich_product": IntentPolicy(
+            IntentRoute.AGENT_TURN,
+            EnrichProductPayload,
+            agent_turn=_enrich_product_agent_turn,
+            # Background overlay blurb: the whole turn (instruction +
+            # prose) persists visibility=internal — the LLM keeps the
+            # context, resume replay never shows it, no user_committed.
+            internal=True,
+        ),
+        "checkout": IntentPolicy(IntentRoute.CLIENT, CheckoutPayload),
+    },
+)
+
+
+__all__ = [
+    "AddToCartPayload",
+    "RemoveLinePayload",
+    "SetQtyPayload",
+    "ViewProductPayload",
+    "EnrichProductPayload",
+    "CheckoutPayload",
+    "CartToolConfig",
+    "resolve_cart_config",
+]

--- a/app/ai/voice/agents/breeze_buddy/assist/commerce/ucp/media.py
+++ b/app/ai/voice/agents/breeze_buddy/assist/commerce/ucp/media.py
@@ -1,0 +1,43 @@
+"""Product media resolution — the UCP side of the gallery seam.
+
+**UCP media is canonical and WINS whenever it already carries a gallery**
+(more than one entry): on a gateway that ships full media this module is a
+pure no-op and no connector is ever consulted. Only when the wire ships a
+single hero image do we ask the registered connectors whether the platform
+exposes the merchant's full curated gallery somewhere else.
+
+This module knows no platform. Resolvers live under ``connectors/`` and
+register via :func:`..hooks.register_media_resolver`; with none registered
+the wire's own media stands, which is the correct pure-UCP behavior.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable, List, Optional
+
+from app.ai.voice.agents.breeze_buddy.assist.commerce.ucp.hooks import resolve_media
+
+# Mirrors schemas._MAX_DETAIL_IMAGES — the ProductDetailP projection caps
+# there anyway; capping here too keeps the recorded binding payload lean.
+MAX_GALLERY_IMAGES = 8
+
+
+async def resolve_product_media(
+    aiohttp_session: Any,
+    product: Dict[str, Any],
+    *,
+    connectors: Optional[Iterable[str]] = None,
+) -> Optional[List[Dict[str, str]]]:
+    """Return a gallery media list for ``product``, or ``None`` when the
+    wire is already rich / no connector can do better / anything fails.
+
+    ``connectors`` is the template's declared allowlist (empty/None = every
+    registered resolver self-selects).
+    """
+    media = product.get("media")
+    if isinstance(media, list) and len(media) > 1:
+        return None  # UCP already ships a gallery — canonical data wins
+    return await resolve_media(aiohttp_session, product, allowed=connectors)
+
+
+__all__ = ["resolve_product_media", "MAX_GALLERY_IMAGES"]

--- a/app/ai/voice/agents/breeze_buddy/assist/commerce/ucp/render_ui.py
+++ b/app/ai/voice/agents/breeze_buddy/assist/commerce/ucp/render_ui.py
@@ -1,0 +1,285 @@
+"""Commerce render_ui flavor pack (group: commerce).
+
+The engine (``chat/ui/render_ui_tool.py``) owns the render_ui MECHANISM;
+everything commerce-shaped about that surface lives here (moved verbatim
+out of the engine, 2026-08-05): the LLM-facing arg descriptions that
+coach in shop vocabulary (products, carts, checkout links, variant
+featuring), the function-response summarizer that knows the commerce
+prop shapes (``products`` / ``product`` / ``line_items`` + id/title/
+variant referents), and the post-hydration projection policy (layout by
+product count; the CartView checkout button stamped from the bound cart
+payload's ``continue_url`` with the ``ui_intents``-role state fallback).
+
+Lazy-loaded with the rest of the flavor: ``schemas.py`` — the module
+``ui_catalog.ensure_group_loaded("commerce")`` imports — calls
+:func:`register_commerce_render_ui_pack` alongside the component
+registration, before any schema build or render executes. Deliberately
+import-free of ``intents.py`` (the ``ui_intents`` role read is inlined,
+mirroring ``resolve_cart_config`` defaults) so loading the schemas never
+drags in the chat intent stack — see ``assist/__init__``.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from app.ai.voice.agents.breeze_buddy.chat.ui.binding import (
+    BindingStore,
+    parse_bind_ref,
+    register_selector_transform,
+)
+from app.ai.voice.agents.breeze_buddy.chat.ui.render_ui_tool import (
+    RenderUiFlavorPack,
+    register_render_ui_flavor_pack,
+)
+
+# Summary caps — the function response is the model's UI memory (the
+# structured replacement for the old ``[ui rendered: …]`` marker); it must
+# stay ~50-80 tokens, never a payload echo.
+_SUMMARY_ITEMS_CAP = 8
+_SUMMARY_TITLE_CAP = 60
+
+_TOOL_DESC = (
+    "Render UI for the shopper THIS turn. Call it once. Values are "
+    "filled from this turn's tool results — you author selectors "
+    "only. When a search returned products, default to showing "
+    "them. decision='no_ui' renders nothing (empty results or a "
+    "purely conversational reply)."
+)
+_BIND_DESC = (
+    "Data bindings into THIS turn's tool results, e.g. "
+    "[{'prop':'products','ref':'$tool:search_catalog#/products'}]. "
+    "CartView binds cart_id/line_items/totals/cart_token off "
+    "the cart tool result the same way; its checkout button "
+    "is automatic — never author it."
+)
+_ITEMS_DESC = (
+    "ProductGrid selection: which bound products to show, in "
+    "this order (ids from THIS turn's results). Use when the "
+    "shopper asked for specific product(s); omit for "
+    "open-ended browsing. feature_variant: a variant id from "
+    "that product's variants to feature as the card hero "
+    "(e.g. the pink one the shopper asked for) — prefer the "
+    "search result's matched_variant when present."
+)
+_QUICK_DESC = (
+    "QuickReplies content (only with component='QuickReplies'): 2-5 "
+    "short strings — each is exactly what the shopper sees on the "
+    "pill AND what comes back as their next message when tapped."
+)
+_QUICK_RIDER_DESC = (
+    "Optional, attachable to ANY call: 2-5 short follow-up "
+    "strings shown as tappable pills UNDER your final reply — "
+    "each is exactly what the shopper sees AND what comes back "
+    "as their next message when tapped. Attach them to the "
+    "render_ui call that accompanies your reply; placement is "
+    "automatic. Labels <=4 words; never duplicate an action "
+    "already available on UI rendered this turn (cards already "
+    "carry Add to cart / View)."
+)
+_LINK_DESC = (
+    "LinkButton content (only with component='LinkButton'): a single "
+    "link CTA for link-only answers (e.g. 'just give me the checkout "
+    "link'). url must be one of the trusted URLs below or a URL from "
+    "THIS turn's tool results — anything else is rejected."
+)
+_BIND_EXAMPLE = "[{'prop':'products','ref':'$tool:search_catalog#/products'}]"
+_LINK_FALLBACK_HINT = "pass the store's configured checkout URL"
+
+_DEFAULT_CHECKOUT_LABEL = "Review and checkout"
+
+
+def _feature_variant_entry(entry: Dict[str, Any], variant_id: str) -> Dict[str, Any]:
+    """Re-derive a product entry's HERO from one of its own tool-sourced
+    variant records (RFC-003 §4: "pink card, not black-with-a-footnote").
+
+    Registered as the ``feature_variant`` selector transform (see
+    ``binding.register_selector_transform``) — runs per selected entry
+    during ``items[]`` selection. Only fields the variant record actually
+    carries are rewritten (price / image); everything stays tool-sourced
+    by construction — an unknown ``variant_id`` returns the entry
+    untouched (fail-open, same posture as unknown selection ids)."""
+    variants = entry.get("variants")
+    if not isinstance(variants, list):
+        return entry
+    variant = next(
+        (v for v in variants if isinstance(v, dict) and v.get("id") == variant_id),
+        None,
+    )
+    if variant is None:
+        return entry
+    out = dict(entry)
+    out["featured_variant_id"] = variant_id
+    price = variant.get("price")
+    if price is not None:
+        out["price"] = price
+    for key in ("image", "image_url", "featured_image"):
+        img = variant.get(key)
+        if img:
+            out["image"] = (
+                {"src": img, "alt": out.get("title")} if isinstance(img, str) else img
+            )
+            break
+    return out
+
+
+def _merge_repeat_grid(
+    component: str,
+    prev_props: Dict[str, Any],
+    new_props: Dict[str, Any],
+) -> Optional[tuple]:
+    """Repeat-render policy: a SECOND ProductGrid this turn merges
+    value-level into the first (works across different searches —
+    hydrated values need no bind re-resolution), dedupes on product id,
+    caps at 12, restamps layout from the combined count. One combined
+    product display per turn, never stacked surfaces. Other components
+    return ``None`` — no merge."""
+    if component != "ProductGrid":
+        return None
+    prev_products = [
+        p for p in (prev_props.get("products") or []) if isinstance(p, dict)
+    ]
+    seen_ids = {p.get("id") for p in prev_products}
+    extra = [
+        p
+        for p in (new_props.get("products") or [])
+        if isinstance(p, dict) and p.get("id") not in seen_ids
+    ]
+    merged_products = (prev_products + extra)[:12]
+    merged = dict(prev_props)
+    merged["products"] = merged_products
+    merged["layout"] = "grid" if len(merged_products) <= 2 else "carousel"
+    return merged, (
+        "combined with this turn's earlier product display — one display per turn"
+    )
+
+
+def _summarize_commerce(
+    component: str, props: Dict[str, Any]
+) -> Optional[Dict[str, Any]]:
+    """Commerce prop shapes → the model's UI memory. ``items`` carries
+    id + title (+ featured_variant) so referents like "the green one" and
+    follow-up ``items[]`` selections resolve without re-searching. Full
+    gid stays authoritative — it's the referent the model reuses in
+    items[]/view_product. Returns ``None`` for non-commerce shapes
+    (QuickReplies, LinkButton) — the engine's generic summary handles
+    them."""
+    result: Dict[str, Any] = {"status": "ok", "rendered": component}
+    products = props.get("products")
+    if isinstance(products, list):
+        result["count"] = len(products)
+        items: List[Dict[str, Any]] = []
+        for entry in products[:_SUMMARY_ITEMS_CAP]:
+            if not isinstance(entry, dict):
+                continue
+            item: Dict[str, Any] = {
+                "id": entry.get("id"),
+                "title": str(entry.get("title", ""))[:_SUMMARY_TITLE_CAP],
+            }
+            fv = entry.get("featured_variant_id")
+            if fv:
+                item["featured_variant"] = fv
+            items.append(item)
+        result["items"] = items
+        return result
+    if isinstance(props.get("product"), dict):
+        p = props["product"]
+        result["items"] = [
+            {
+                "id": p.get("id"),
+                "title": str(p.get("title", ""))[:_SUMMARY_TITLE_CAP],
+            }
+        ]
+        return result
+    if isinstance(props.get("line_items"), list):  # CartView
+        result["count"] = len(props["line_items"])
+        return result
+    return None
+
+
+def _finalize_commerce(
+    component: str,
+    schema_cls: Any,
+    hydrated_props: Dict[str, Any],
+    *,
+    bind: Dict[str, str],
+    store: BindingStore,
+    template: Any,
+    state_values: Optional[Dict[str, Any]],
+) -> None:
+    """Post-hydration projection policy — server-authored, never the model.
+
+    Layout is derived from the FINAL hydrated count (post items[]
+    selection, post max_items cap): 1-2 products sit side by side; 3+
+    scroll as a carousel. The CartView checkout button mirrors the
+    DIRECT-intent path: the bound cart payload's ``continue_url`` wins,
+    the reducer-state fallback (``ui_intents.state_keys.checkout_url``
+    role) next; no url anywhere → no button."""
+    if isinstance(hydrated_props.get("products"), list):
+        hydrated_props["layout"] = (
+            "grid" if len(hydrated_props["products"]) <= 2 else "carousel"
+        )
+    if (
+        schema_cls is not None
+        and "checkout" in schema_cls.model_fields
+        and not hydrated_props.get("checkout")
+    ):
+        ui_intents = getattr(
+            getattr(template, "configurations", None), "ui_intents", None
+        )
+        state_keys = (
+            (getattr(ui_intents, "state_keys", None) or {}) if ui_intents else {}
+        )
+        labels = (getattr(ui_intents, "labels", None) or {}) if ui_intents else {}
+        checkout_url: Optional[str] = None
+        for ref in bind.values():
+            parsed = parse_bind_ref(ref)
+            if parsed is None:
+                continue
+            payload = store.resolve(parsed.tool_name, parsed.tool_use_id)
+            if isinstance(payload, dict):
+                cu = payload.get("continue_url")
+                if isinstance(cu, str) and cu:
+                    checkout_url = cu
+                    break
+        if checkout_url is None and state_values:
+            fallback = state_values.get(state_keys.get("checkout_url", "checkout_url"))
+            if isinstance(fallback, str) and fallback:
+                checkout_url = fallback
+        if checkout_url:
+            hydrated_props["checkout"] = {
+                "label": labels.get("checkout") or _DEFAULT_CHECKOUT_LABEL,
+                "url": checkout_url,
+            }
+
+
+COMMERCE_RENDER_UI_PACK = RenderUiFlavorPack(
+    tool_description=_TOOL_DESC,
+    bind_description=_BIND_DESC,
+    items_description=_ITEMS_DESC,
+    quick_replies_description=_QUICK_DESC,
+    quick_replies_rider_description=_QUICK_RIDER_DESC,
+    link_description=_LINK_DESC,
+    bind_example=_BIND_EXAMPLE,
+    link_untrusted_fallback_hint=_LINK_FALLBACK_HINT,
+    default_force_after=["search_catalog"],
+    summarize=_summarize_commerce,
+    finalize_hydrated=_finalize_commerce,
+    merge_repeat_render=_merge_repeat_grid,
+)
+
+
+def register_commerce_render_ui_pack() -> None:
+    """Register the commerce pack into the render_ui flavor registry, and
+    the ``feature_variant`` selector transform into the binding engine.
+
+    Idempotent (same-key overwrite) — safe on re-import.
+    """
+    register_render_ui_flavor_pack("commerce", COMMERCE_RENDER_UI_PACK)
+    register_selector_transform("feature_variant", _feature_variant_entry)
+
+
+__all__ = [
+    "COMMERCE_RENDER_UI_PACK",
+    "register_commerce_render_ui_pack",
+]

--- a/app/ai/voice/agents/breeze_buddy/assist/commerce/ucp/schemas.py
+++ b/app/ai/voice/agents/breeze_buddy/assist/commerce/ucp/schemas.py
@@ -1,0 +1,581 @@
+"""Commerce component schemas (group: commerce) — Component Catalog v2 (RFC-001).
+
+Data-bound: the LLM emits a `show` op naming the component + bindings into
+THIS turn's post-pipeline tool results; the server pointer-walks, validates
+against these schemas, and emits an ordinary hydrated `add` op (`v:2`).
+Prices / titles / URLs are tool-sourced by construction — the LLM cannot
+inject values into bound props.
+
+Sub-schemas are projections of the UCP tool shapes. They deliberately relax
+`_CatalogBase`'s extra='forbid' to extra='ignore' (projection semantics —
+tool payloads carry fields the component doesn't render) and carry a small
+mode='before' lift so the RAW UCP shape (`price_range.min`, `media[0].url`,
+cart lines' `item.title` / `quantity`) validates without requiring every
+template to add a response projection first. Hydration itself stays a pure
+pointer walk (see chat/ui_binding.py).
+
+Lazy-loaded flavor module: importing it registers the components into the
+flavor-agnostic catalog (see ``register_primitives`` at the bottom). The
+import happens only via ``ui_catalog.ensure_group_loaded("commerce")`` —
+i.e. only in processes that resolve a commerce-enabled template.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, ClassVar, Dict, List, Literal, Optional
+
+from pydantic import BaseModel, ConfigDict, Field, HttpUrl, model_validator
+
+from app.ai.voice.agents.breeze_buddy.assist.commerce.ucp.hooks import (
+    normalize_variants,
+    repair_description,
+)
+from app.ai.voice.agents.breeze_buddy.assist.commerce.ucp.render_ui import (
+    register_commerce_render_ui_pack,
+)
+from app.ai.voice.agents.breeze_buddy.assist.commerce.ucp.step_labels import (
+    register_commerce_step_labels,
+)
+from app.ai.voice.agents.breeze_buddy.assist.commerce.ucp.tool_meta import (
+    register_commerce_tool_meta,
+)
+from app.ai.voice.agents.breeze_buddy.assist.commerce.ucp.ui_prompt import (
+    register_commerce_render_ui_prompt,
+)
+
+# Private-name import is deliberate (same posture as ui_binding's
+# session_state imports): _CatalogBase is the catalog's schema contract
+# (extra='forbid' + the data_bound ClassVar) and re-declaring it here
+# would drift.
+from app.ai.voice.agents.breeze_buddy.template.ui_catalog import (
+    _CatalogBase,
+    register_primitives,
+)
+
+
+def _strip_amount_grouping(v: Any) -> Any:
+    """Normalize a {amount: "1,699.00"} dict — live UCP storefronts emit
+    comma-GROUPED amount strings (INR lakh/thousand grouping) that fail
+    pydantic float parsing. Commas are always grouping on the UCP wire
+    (dot is the decimal separator), so stripping them is lossless."""
+    if isinstance(v, dict):
+        amount = v.get("amount")
+        if isinstance(amount, str) and "," in amount:
+            out = dict(v)
+            out["amount"] = amount.replace(",", "")
+            return out
+    return v
+
+
+class MoneyP(BaseModel):
+    """Money projection — rendered client-side (e.g. "₹1,699") from
+    ``currency``. Accepts a bare number as shorthand for {amount}."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    amount: float
+    currency: str = "INR"
+
+    @model_validator(mode="before")
+    @classmethod
+    def _lift_bare_number(cls, v: Any) -> Any:
+        if isinstance(v, (int, float)):
+            return {"amount": v}
+        return _strip_amount_grouping(v)
+
+
+class MediaP(BaseModel):
+    """Image projection: {src, alt}. Accepts the UCP media entry shape
+    ({url, alt_text?}) via the lift below."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    src: HttpUrl
+    alt: Optional[str] = None
+
+    @model_validator(mode="before")
+    @classmethod
+    def _lift_ucp_media(cls, v: Any) -> Any:
+        if isinstance(v, dict) and "src" not in v and "url" in v:
+            out = dict(v)
+            out["src"] = out.pop("url")
+            if "alt" not in out and out.get("alt_text"):
+                out["alt"] = out.pop("alt_text")
+            return out
+        return v
+
+
+_UNAVAILABLE_STATES = ("unavailable", "out_of_stock", "sold_out")
+
+
+def _variant_available(variant: Dict[str, Any]) -> bool:
+    """Best-effort availability read off a UCP variant entry. Absent field
+    counts as available (conservative — the storefront enforces stock).
+
+    Live Beyond Bound wire shape (2026-07-28): availability is a NESTED
+    object — ``{"availability": {"available": bool}}`` — alongside the
+    older bool / state-string encodings. All three are handled; anything
+    unrecognized stays available (the deterministic cart verifier is the
+    backstop for a variant that turns out unbuyable)."""
+    availability = variant.get("availability", variant.get("available"))
+    if availability is None:
+        return True
+    if isinstance(availability, bool):
+        return availability
+    if isinstance(availability, dict):
+        inner = availability.get("available")
+        if isinstance(inner, bool):
+            return inner
+        state = availability.get("state") or availability.get("status")
+        if isinstance(state, str):
+            return state.lower() not in _UNAVAILABLE_STATES
+        return True
+    if isinstance(availability, str):
+        return availability.lower() not in _UNAVAILABLE_STATES
+    return True
+
+
+class VariantP(BaseModel):
+    """One purchasable variant option — projection of the UCP product
+    ``variants[]`` entry. Feeds the widget's inline variant picker
+    (multi-variant add-to-cart happens client-side, deterministically —
+    no agent turn)."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    id: str
+    title: Optional[str] = None  # e.g. "S / Black"
+    available: bool = True
+    price: Optional[MoneyP] = None
+
+    @model_validator(mode="before")
+    @classmethod
+    def _lift_ucp_variant(cls, v: Any) -> Any:
+        if not isinstance(v, dict):
+            return v
+        out = dict(v)
+        if "available" not in out:
+            out["available"] = _variant_available(out)
+        return out
+
+
+# Hard cap on projected variants — bounds the hydrated payload; a picker
+# past this many options is the storefront page's job (View still works).
+_MAX_PROJECTED_VARIANTS = 24
+
+
+class ProductP(BaseModel):
+    """One product as rendered by ProductCard / ProductGrid. A projection of
+    the UCP catalog product (search_catalog / lookup_catalog entries)."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    id: str
+    title: str
+    url: Optional[str] = None
+    image: Optional[MediaP] = None  # {src, alt}
+    price: MoneyP
+    list_price: Optional[MoneyP] = None
+    tags: List[str] = Field(default_factory=list)  # ≤3 rendered
+    availability: Optional[str] = None
+    variant_axes: Optional[str] = None  # e.g. "S / M / L · 3 colours"
+    # Enables the built-in add_to_cart intent on single-variant products
+    # (widget renders the secondary action only when present).
+    default_variant_id: Optional[str] = None
+    # Multi-variant products: the widget's inline picker options. Empty for
+    # single-variant products (default_variant_id covers those).
+    variants: List[VariantP] = Field(default_factory=list)
+    # Variant-continuity anchor (RFC-003 §4): set by the selection stage when
+    # a render_ui items[] entry featured a variant — the card's hero fields
+    # were re-derived from that variant record, the picker preselects it,
+    # and view_product/add_to_cart carry it forward.
+    featured_variant_id: Optional[str] = None
+
+    @model_validator(mode="before")
+    @classmethod
+    def _lift_ucp_product(cls, v: Any) -> Any:
+        """Accept the raw UCP catalog shape: ``price_range.min`` → price,
+        ``list_price_range.min`` → list_price, ``media[0]`` → image, and
+        project ``variants[]``: ALL well-formed entries ship (capped) —
+        the widget's Add-to-cart always confirms through the variant
+        picker (2026-07-30 UX), so even a single-available product needs
+        its option data (one-chip confirm). Exactly ONE available variant
+        additionally sets ``default_variant_id`` (the direct-add fallback
+        for payloads with no variant data at all). No-ops when the
+        canonical keys are already present."""
+        if not isinstance(v, dict):
+            return v
+        out = dict(v)
+        if "price" not in out and isinstance(out.get("price_range"), dict):
+            out["price"] = out["price_range"].get("min")
+        if "list_price" not in out and isinstance(out.get("list_price_range"), dict):
+            out["list_price"] = out["list_price_range"].get("min")
+        media = out.get("media")
+        if "image" not in out and isinstance(media, list) and media:
+            out["image"] = media[0]
+        variants = out.get("variants")
+        if isinstance(variants, list):
+            well_formed = [
+                va
+                for va in variants
+                if isinstance(va, dict) and isinstance(va.get("id"), str)
+            ]
+            available = [va for va in well_formed if _variant_available(va)]
+            if "default_variant_id" not in out and len(available) == 1:
+                out["default_variant_id"] = available[0]["id"]
+            # ALL well-formed entries project (malformed ones are filtered,
+            # never failing the whole product; the cap bounds the payload)
+            # — the picker is the confirm step for every add, so even a
+            # one-available product ships its options. EXCEPT the lone
+            # "Default Title" pseudo-variant: not a real choice, so it
+            # never reaches the picker (a connector may suppress it).
+            # Use the normalizer's OUTPUT, not just its truthiness — a
+            # connector may filter the list rather than clear it, and the
+            # card's picker must agree with the detail overlay's (which
+            # projects the same call below).
+            out["variants"] = normalize_variants(well_formed)[:_MAX_PROJECTED_VARIANTS]
+        return out
+
+
+class CartLineP(BaseModel):
+    """One cart line as rendered by CartView. A projection of the UCP cart
+    ``line_items[]`` entry."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    id: str
+    title: str
+    variant_title: Optional[str] = None
+    image: Optional[MediaP] = None
+    qty: int
+    line_total: MoneyP
+    variant_id: Optional[str] = None  # enables set_qty / remove_line intents
+
+    @model_validator(mode="before")
+    @classmethod
+    def _lift_ucp_cart_line(cls, v: Any) -> Any:
+        """Accept the raw UCP cart line: ``item.title`` → title,
+        ``item.image_url`` → image, ``quantity`` → qty, the ``totals[]``
+        entry with type=='total' → line_total, ``item.id`` → variant_id."""
+        if not isinstance(v, dict):
+            return v
+        out = dict(v)
+        item = out.get("item") if isinstance(out.get("item"), dict) else {}
+        if "title" not in out and item.get("title"):
+            out["title"] = item["title"]
+        if "variant_title" not in out and item.get("variant_title"):
+            out["variant_title"] = item["variant_title"]
+        if "image" not in out and item.get("image_url"):
+            out["image"] = {"src": item["image_url"], "alt": out.get("title")}
+        if "qty" not in out and "quantity" in out:
+            out["qty"] = out["quantity"]
+        if "line_total" not in out:
+            totals = out.get("totals")
+            if isinstance(totals, list):
+                total = next(
+                    (
+                        t
+                        for t in totals
+                        if isinstance(t, dict) and t.get("type") == "total"
+                    ),
+                    None,
+                )
+                if total is not None:
+                    out["line_total"] = total
+        if "variant_id" not in out and item.get("id"):
+            out["variant_id"] = item["id"]
+        return out
+
+
+class CartTotalP(BaseModel):
+    """One row of the cart's ``totals[]`` — matches the UCP shape directly."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    type: str
+    amount: float
+    currency: str = "INR"
+
+    @model_validator(mode="before")
+    @classmethod
+    def _normalize_amount(cls, v: Any) -> Any:
+        return _strip_amount_grouping(v)
+
+
+class CheckoutP(BaseModel):
+    """Checkout handoff rendered inside CartView (label + URL). The widget
+    owns the popup/open semantics — no Handoff op needed."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    label: str = "Checkout"
+    url: HttpUrl
+
+
+class ProductCard(_CatalogBase):
+    """Data-bound single-product card — bind ``product`` to one tool-result product.
+
+    The widget renders media/title/price and the built-in ``view_product``
+    (+ ``add_to_cart`` when single-variant) intents.
+
+    RETIRED from the LLM surface 2026-07-30 (``server_only``): with layout
+    server-derived from the hydrated count, a ProductGrid of one IS a card
+    (full-width via the widget's :only-child rule) — the card-vs-grid
+    presentation choice stops being the model's. The component stays in the
+    catalog for replayed persisted ops and as the grid's building block."""
+
+    data_bound: ClassVar[bool] = True
+    server_only: ClassVar[bool] = True
+
+    product: ProductP
+    density: Optional[Literal["default", "spacious"]] = "default"
+
+
+class GridItemSelector(BaseModel):
+    """One ``items[]`` selection entry (RFC-003 §4 — the model authors
+    SELECTORS, never values). ``feature_variant`` names a variant id from
+    that product's tool-sourced variants; the selection stage re-derives the
+    card hero (image/price) from that variant record and stamps
+    ``featured_variant_id`` for downstream continuity."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    id: str
+    feature_variant: Optional[str] = None
+
+
+class ProductGrid(_CatalogBase):
+    """Data-bound product list — bind ``products`` to a tool-result product array.
+
+    Server caps it at ``max_items`` (default 10 = one full UCP search page,
+    so the rendered grid matches the LLM's context exactly); each
+    card carries the same built-in intents as ProductCard."""
+
+    data_bound: ClassVar[bool] = True
+    # ``items`` is the selection DIRECTIVE (applied then stripped server-side
+    # in _select_list_props / resolve_show_op) — never a render prop.
+    selection_field: ClassVar[Optional[str]] = "items"
+
+    products: List[ProductP] = Field(..., min_length=1, max_length=12)
+    max_items: int = Field(10, ge=1, le=12)
+    layout: Optional[Literal["grid", "carousel"]] = "grid"
+    items: Optional[List[GridItemSelector]] = Field(
+        None,
+        max_length=12,
+        description=(
+            "Optional selection: render ONLY the bound products whose id is "
+            "listed here, in THIS order (ids from this turn's tool result; "
+            "unknown ids are ignored, all-unknown renders the full list). "
+            "feature_variant additionally makes that variant the card hero."
+        ),
+    )
+
+
+class CartView(_CatalogBase):
+    """Data-bound cart render — bind cart fields off the cart tool result.
+
+    Renders header, line rows (with ``remove_line`` / ``set_qty`` intents),
+    totals, the checkout handoff button, and the cart-cookie side-effect
+    (widget-internal, driven by ``cart_token``) — replacing the
+    hand-composed 5-op cart litany."""
+
+    data_bound: ClassVar[bool] = True
+
+    cart_id: str
+    line_items: List[CartLineP] = Field(default_factory=list)
+    totals: List[CartTotalP] = Field(default_factory=list)
+    checkout: Optional[CheckoutP] = None
+    cart_token: Optional[str] = None
+
+
+_TAG_RE = re.compile(r"<[^>]+>")
+# Block-level boundaries become line breaks so merchant formatting
+# (headings, paragraphs, list items) survives the tag strip — the widget
+# renders the description `pre-wrap`.
+_BLOCK_TAG_RE = re.compile(
+    r"</?(?:p|div|br|li|ul|ol|h[1-6]|tr|table|blockquote)[^>]*>",
+    re.IGNORECASE,
+)
+
+
+def _html_to_display_text(html: str) -> Optional[str]:
+    """Merchant description HTML → display-grade plain text: block tags
+    become newlines, remaining tags drop, upstream-flattened boundaries
+    are repaired, per-line whitespace collapses, blank runs shrink to one
+    empty line, capped."""
+    text = _TAG_RE.sub(" ", _BLOCK_TAG_RE.sub("\n", html))
+    # Gateways that ship descriptions ALREADY tag-stripped leave nothing
+    # for the conversion above to work with; a connector may know how to
+    # recover the lost boundaries.
+    text = repair_description(text)
+    lines = [" ".join(line.split()) for line in text.split("\n")]
+    collapsed: List[str] = []
+    for line in lines:
+        if line:
+            collapsed.append(line)
+        elif collapsed and collapsed[-1] != "":
+            collapsed.append("")
+    out = "\n".join(collapsed).strip()[:_MAX_DETAIL_DESCRIPTION]
+    return out or None
+
+
+# Bound the hydrated detail payload: description prose and gallery images.
+_MAX_DETAIL_DESCRIPTION = 1500
+_MAX_DETAIL_IMAGES = 8
+
+
+class ProductDetailP(BaseModel):
+    """Server projection of ONE full product for the detail overlay
+    (full-panel PDP the widget opens on View). Lifts the UCP
+    ``get_product`` payload's ``product`` object: description arrives as
+    ``{"html": …}`` (tags stripped to plain text here — the widget never
+    renders merchant HTML), price is ``price_range.min``, compare-at is
+    ``list_price_range.min``, gallery is the product-level ``media``.
+    Unlike ProductP, ALL well-formed variants project (capped) — the
+    picker in the detail view is the primary buy path."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    id: str
+    title: str
+    description: Optional[str] = None
+    url: Optional[HttpUrl] = None
+    price: Optional[MoneyP] = None
+    compare_at: Optional[MoneyP] = None
+    images: List[MediaP] = Field(default_factory=list)
+    tags: List[str] = Field(default_factory=list)
+    variants: List[VariantP] = Field(default_factory=list)
+    default_variant_id: Optional[str] = None
+
+    @model_validator(mode="before")
+    @classmethod
+    def _lift_ucp_detail(cls, v: Any) -> Any:
+        if not isinstance(v, dict):
+            return v
+        out = dict(v)
+        desc = out.get("description")
+        if isinstance(desc, dict):
+            html = desc.get("html")
+            out["description"] = (
+                _html_to_display_text(html) if isinstance(html, str) else None
+            )
+        if "price" not in out and isinstance(out.get("price_range"), dict):
+            out["price"] = out["price_range"].get("min")
+        if "compare_at" not in out and isinstance(out.get("list_price_range"), dict):
+            out["compare_at"] = out["list_price_range"].get("min")
+        if "images" not in out and isinstance(out.get("media"), list):
+            out["images"] = [
+                m
+                for m in out["media"]
+                if isinstance(m, dict)
+                and m.get("url")
+                and m.get("type", "image") == "image"
+            ][:_MAX_DETAIL_IMAGES]
+        raw_variants = out.get("variants")
+        if isinstance(raw_variants, list):
+            well_formed = [
+                entry
+                for entry in raw_variants
+                if isinstance(entry, dict) and entry.get("id")
+            ][:_MAX_PROJECTED_VARIANTS]
+            if "default_variant_id" not in out and len(well_formed) == 1:
+                out["default_variant_id"] = well_formed[0]["id"]
+            # A connector may suppress a platform-manufactured
+            # pseudo-variant here (an optionless product's lone fake
+            # choice): default_variant_id is set above, and the overlay's
+            # option pills must not render a choice that isn't one.
+            out["variants"] = normalize_variants(well_formed)
+        return out
+
+
+class ProductDetail(_CatalogBase):
+    """Server-only full product view — hydrated by the `view_product`
+    DIRECT intent into the widget's full-panel overlay. Never offered to
+    the LLM (``server_only``): the prompt renders no entry for it, so the
+    model cannot emit it; the allowlist still validates it so the server
+    path hydrates through the same show-op resolver as everything else."""
+
+    data_bound: ClassVar[bool] = True
+    server_only: ClassVar[bool] = True
+
+    product: ProductDetailP
+
+
+class LinkButton(_CatalogBase):
+    """Single link CTA — the link-only answer ("just give me the checkout
+    link") without rendering a whole CartView.
+
+    Literal component (like QuickReplies), but the URL is NOT
+    model-trusted: ``execute_render_ui`` rejects any url that is neither
+    in the template's ``trusted_link_urls`` allowlist nor present
+    verbatim in THIS turn's tool results — the model selects links, it
+    never authors them. Clicking fires the widget's ``open_url`` route
+    (Handoff popup semantics, host-page intercept preserved).
+
+    ``text_channel=False``: the trust check lives ONLY in the render_ui
+    function path, so a hand-typed ``<ui_stream>`` add is rejected at
+    parse (``render_ui_only:LinkButton``) — the dual-read window must not
+    be an arbitrary-URL injection surface."""
+
+    text_channel: ClassVar[bool] = False
+
+    label: str = Field(..., min_length=1, max_length=40)
+    url: str = Field(..., min_length=8, max_length=2048, pattern=r"^https://")
+
+
+# ---------------------------------------------------------------------------
+# Registration — runs once, at (lazy) import time. Templates opt in via
+# ``ui_catalog.enabled_groups += ["commerce"]``; the LLM drives these with
+# `show` ops, never hand-typed `add` props. Render order matches the old
+# in-catalog placement (ProductGrid → ProductCard → CartView) — position in
+# the global order is irrelevant for data-bound components (they render in
+# their own prompt subsection), only their relative order matters.
+# ---------------------------------------------------------------------------
+
+register_primitives(
+    "commerce",
+    {
+        "ProductGrid": ProductGrid,
+        "ProductCard": ProductCard,
+        "CartView": CartView,
+        "ProductDetail": ProductDetail,
+        "LinkButton": LinkButton,
+    },
+)
+
+# Step-progress labels ride the same lazy hook: any process that resolves a
+# commerce-enabled template gets the UCP tool → step-line labels alongside
+# the component registration (see assist/commerce/step_labels.py).
+register_commerce_step_labels()
+
+# Tool safety metadata (annotations + deterministic verifiers) rides the
+# same hook — see assist/commerce/tool_meta.py.
+register_commerce_tool_meta()
+
+# The render_ui prompt vocabulary rides the same hook — the engine keeps
+# only the flavor-neutral contract; the shopper/product/cart copy is
+# this flavor's (see assist/commerce/ui_prompt.py).
+register_commerce_render_ui_prompt()
+
+# The render_ui SURFACE pack too: schema arg vocabulary, the commerce
+# prop-shape summarizer, and post-hydration projection policy (layout,
+# CartView checkout stamping) — see assist/commerce/render_ui.py.
+register_commerce_render_ui_pack()
+
+
+__all__ = [
+    "MoneyP",
+    "MediaP",
+    "VariantP",
+    "ProductP",
+    "CartLineP",
+    "CartTotalP",
+    "CheckoutP",
+    "ProductCard",
+    "ProductGrid",
+    "CartView",
+    "ProductDetailP",
+    "ProductDetail",
+    "LinkButton",
+]

--- a/app/ai/voice/agents/breeze_buddy/assist/commerce/ucp/step_labels.py
+++ b/app/ai/voice/agents/breeze_buddy/assist/commerce/ucp/step_labels.py
@@ -1,0 +1,67 @@
+"""Commerce step-progress labels (group: commerce).
+
+Tool-name → (running_label, done_label) entries for the live step lines
+("Searching the catalog…" → "Searched the catalog ✓") shown while a
+commerce agent turn executes UCP tools. Names match the Stage-A UCP tool
+surface used by ``intents.py`` and the pilot templates.
+
+Lazy-loaded with the rest of the flavor: ``schemas.py`` — the module
+``ui_catalog.ensure_group_loaded("commerce")`` imports — calls
+:func:`register_commerce_step_labels` right after registering the
+component schemas, so any commerce-enabled session resolves these labels
+with no extra import hook. Non-commerce sessions never load this module
+and fall back to the generic humanizer in ``chat/step_labels.py``.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional, Tuple
+
+from app.ai.voice.agents.breeze_buddy.chat.steps.labels import (
+    register_step_labels,
+    register_step_summarizer,
+)
+
+COMMERCE_STEP_LABELS: Dict[str, Tuple[str, str]] = {
+    "search_catalog": ("Searching the catalog", "Searched the catalog"),
+    "lookup_catalog": ("Looking up products", "Looked up products"),
+    "get_product": ("Checking the product", "Checked the product"),
+    "create_cart": ("Updating your cart", "Updated your cart"),
+    "update_cart": ("Updating your cart", "Updated your cart"),
+    "get_cart": ("Checking your cart", "Checked your cart"),
+}
+
+
+def summarize_commerce_step_result(
+    result: Any,
+) -> Tuple[Optional[str], Optional[int]]:
+    """Commerce result shapes → the ``step_completed`` summary/count: a
+    ``products`` list becomes "N results", a ``line_items`` list becomes
+    "cart updated · N items". Anything else defers (``(None, None)``)."""
+    products = result.get("products")
+    if isinstance(products, list):
+        n = len(products)
+        return f"{n} result{'' if n == 1 else 's'}", n
+    line_items = result.get("line_items")
+    if isinstance(line_items, list):
+        n = len(line_items)
+        return f"cart updated · {n} item{'' if n == 1 else 's'}", n
+    return None, None
+
+
+def register_commerce_step_labels() -> None:
+    """Register the commerce labels + result summarizer into the common
+    step registries.
+
+    Idempotent (dict update of the same entries; summarizer dedupe) —
+    safe on re-import.
+    """
+    register_step_labels(COMMERCE_STEP_LABELS)
+    register_step_summarizer(summarize_commerce_step_result)
+
+
+__all__ = [
+    "COMMERCE_STEP_LABELS",
+    "register_commerce_step_labels",
+    "summarize_commerce_step_result",
+]

--- a/app/ai/voice/agents/breeze_buddy/assist/commerce/ucp/tool_meta.py
+++ b/app/ai/voice/agents/breeze_buddy/assist/commerce/ucp/tool_meta.py
@@ -1,0 +1,131 @@
+"""Commerce tool metadata — annotations + deterministic verifiers.
+
+The flavor half of ``chat/tool_annotations.py`` and
+``chat/verification.py`` for the UCP tool surface. Lazy-loaded with the
+rest of the flavor (``schemas.py`` calls :func:`register_commerce_tool_meta`
+alongside the step-label registration), so any commerce-enabled process
+gets the safety metadata with no extra import hook.
+
+Annotations: catalog/cart READS are ``read_only`` (parallel-safe fan-out
+for multi-search turns); cart MUTATIONS are ``idempotent`` (each dispatch
+carries the per-turn idempotency hash injected by the session-state
+policy) — retried safely but always serialized.
+
+Verifiers: pure post-condition CODE checks over (args, post-pipeline
+result) — the reliability mechanism that catches silent partial failures
+(a cart update that quietly dropped a line, a stock-capped quantity)
+before the model narrates success or a component renders wrong data.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from app.ai.voice.agents.breeze_buddy.chat.steps.verification import (
+    register_tool_verifier,
+)
+from app.ai.voice.agents.breeze_buddy.chat.tools.annotations import (
+    register_tool_annotations,
+)
+from app.ai.voice.agents.breeze_buddy.chat.tools.result_annotators import (
+    register_result_annotator,
+)
+
+# Same envelope helper the reducer engine / binding store / intents use.
+from app.ai.voice.agents.breeze_buddy.template.session_state import (
+    _unwrap_tool_payload,
+)
+
+
+def _verify_search_catalog(args: Dict[str, Any], result: Any) -> Optional[str]:
+    """A successful search must carry a ``products`` array (possibly
+    empty). Anything else means the upstream shape changed — better a
+    typed error the model can react to than a hydration mystery later."""
+    payload = _unwrap_tool_payload(result)
+    if not isinstance(payload, dict) or not isinstance(payload.get("products"), list):
+        return "search result carries no products array"
+    return None
+
+
+def _requested_lines(args: Dict[str, Any]) -> List[Dict[str, Any]]:
+    cart = args.get("cart")
+    if not isinstance(cart, dict):
+        return []
+    lines = cart.get("line_items")
+    if not isinstance(lines, list):
+        return []
+    out: List[Dict[str, Any]] = []
+    for line in lines:
+        if not isinstance(line, dict):
+            continue
+        item = line.get("item")
+        variant = item.get("id") if isinstance(item, dict) else None
+        qty = line.get("quantity")
+        if isinstance(variant, str) and isinstance(qty, int):
+            out.append({"id": variant, "qty": qty})
+    return out
+
+
+def _result_quantities(result: Any) -> Dict[str, int]:
+    payload = _unwrap_tool_payload(result)
+    lines = payload.get("line_items") if isinstance(payload, dict) else None
+    out: Dict[str, int] = {}
+    for line in lines if isinstance(lines, list) else []:
+        if not isinstance(line, dict):
+            continue
+        item = line.get("item")
+        variant = item.get("id") if isinstance(item, dict) else None
+        qty = line.get("quantity")
+        if isinstance(variant, str) and isinstance(qty, int):
+            out[variant] = out.get(variant, 0) + qty
+    return out
+
+
+def _verify_cart_mutation(args: Dict[str, Any], result: Any) -> Optional[str]:
+    """Every requested line must appear in the returned cart with the
+    requested quantity (qty 0 = removal must be absent). Catches the
+    silent partial-apply class: stock caps, dropped lines, upstream
+    truncation — the model gets a precise diff to act on."""
+    requested = _requested_lines(args)
+    if not requested:
+        return None  # free-form call — nothing to post-condition
+    actual = _result_quantities(result)
+    for want in requested:
+        got = actual.get(want["id"], 0)
+        if got != want["qty"]:
+            return (
+                f"cart update did not fully apply: requested quantity "
+                f"{want['qty']} for {want['id']}, cart shows {got}"
+            )
+    return None
+
+
+def register_commerce_tool_meta() -> None:
+    """Register annotations + verifiers for the UCP tool surface.
+
+    Idempotent — same values / same function objects on re-import.
+    """
+    register_tool_annotations(
+        {
+            "search_catalog": "read_only",
+            "lookup_catalog": "read_only",
+            "get_product": "read_only",
+            "get_cart": "read_only",
+            "create_cart": "idempotent",
+            "update_cart": "idempotent",
+        }
+    )
+    register_tool_verifier("search_catalog", _verify_search_catalog)
+    register_tool_verifier("create_cart", _verify_cart_mutation)
+    register_tool_verifier("update_cart", _verify_cart_mutation)
+    # Baseline search annotation (RFC-003 baseline mode): matched_via /
+    # matched_variant stamped from THIS turn's live results — lazy import
+    # keeps the annotator's regex tables out of non-commerce processes.
+    from app.ai.voice.agents.breeze_buddy.assist.commerce.ucp.annotator import (
+        annotate_search_result,
+    )
+
+    register_result_annotator("search_catalog", annotate_search_result)
+
+
+__all__ = ["register_commerce_tool_meta"]

--- a/app/ai/voice/agents/breeze_buddy/assist/commerce/ucp/ui_prompt.py
+++ b/app/ai/voice/agents/breeze_buddy/assist/commerce/ucp/ui_prompt.py
@@ -1,0 +1,73 @@
+"""Commerce render_ui prompt vocabulary (group: commerce).
+
+The engine's ``template/ui_prompt.py`` owns only the flavor-neutral
+render_ui behavioral contract; the copy that makes it land for a
+storefront — shoppers, products, carts, checkout links, variant
+coaching — is this flavor's and registers here under the ``commerce``
+catalog group (moved verbatim out of the engine, 2026-08-04). The
+section REPLACES the generic block wholesale, so it must restate the
+full contract in commerce vocabulary, not just add to it.
+
+Lazy-loaded with the rest of the flavor: ``schemas.py`` — the module
+``ui_catalog.ensure_group_loaded("commerce")`` imports — calls
+:func:`register_commerce_render_ui_prompt` alongside the component
+registration, and the chat agent resolves its allowlist (which triggers
+that import) in ``__init__``, before any prompt splice. Non-commerce
+sessions never load this module and get the generic contract.
+"""
+
+from __future__ import annotations
+
+from app.ai.voice.agents.breeze_buddy.template.ui_prompt import (
+    register_render_ui_flavor_section,
+)
+
+COMMERCE_RENDER_UI_SECTION = (
+    "## Showing UI (render_ui tool)\n"
+    "You show shoppers products, carts, and quick replies ONLY by calling "
+    "the render_ui function — never by writing markup, JSON, op lines, or "
+    "any <ui_stream> text in your reply. Prose is for words; render_ui is "
+    "for UI.\n"
+    "- After a successful catalog search you will be required to call "
+    "render_ui exactly once: render a component, or pass decision='no_ui' "
+    "with a short reason when showing nothing serves the shopper better.\n"
+    "- Bind data, never retype it: bind=[{prop:'products', "
+    "ref:'$tool:search_catalog#/products'}]. The server fills every value "
+    "(price, image, stock) from THIS turn's tool results.\n"
+    "- When the shopper asked for something specific, select with "
+    "items=[{id,...}] — ids from this turn's results, in the order to "
+    "show. If a result carries matched_variant (the shopper named a color/"
+    "size), pass its id as that item's feature_variant so the card leads "
+    "with the right variant.\n"
+    "- For a link-only answer (e.g. 'just give me the checkout link') "
+    "render LinkButton with link={label, url} instead of pasting the URL "
+    "in prose — the url must be the store's checkout URL or one from "
+    "THIS turn's tool results.\n"
+    "- After render_ui succeeds, write at most ONE short line; never "
+    "repeat names or prices the UI already shows. The function response "
+    "tells you exactly what rendered — use its ids for follow-ups "
+    "('the green one').\n"
+)
+
+# Splices into the forced-final chips contract's dedup rule: never
+# suggest a chip duplicating an action already on this turn's UI.
+COMMERCE_CHIP_DEDUP_EXAMPLES = " (Add to cart, View, a checkout button)"
+
+
+def register_commerce_render_ui_prompt() -> None:
+    """Register the commerce render_ui section into the prompt registry.
+
+    Idempotent (same-key overwrite) — safe on re-import.
+    """
+    register_render_ui_flavor_section(
+        "commerce",
+        COMMERCE_RENDER_UI_SECTION,
+        chip_dedup_examples=COMMERCE_CHIP_DEDUP_EXAMPLES,
+    )
+
+
+__all__ = [
+    "COMMERCE_CHIP_DEDUP_EXAMPLES",
+    "COMMERCE_RENDER_UI_SECTION",
+    "register_commerce_render_ui_prompt",
+]

--- a/app/ai/voice/agents/breeze_buddy/assist/commerce/ucp/upsell.py
+++ b/app/ai/voice/agents/breeze_buddy/assist/commerce/ucp/upsell.py
@@ -1,0 +1,374 @@
+"""Post-add cart upsell — the "Goes well with" carousel (2026-07-31).
+
+**OPT-IN** — off unless the template sets ``flavor.ucp.features.upsell``.
+Merchandising is a merchant's call, not a side effect of enabling the
+commerce flavor, and the feature spends a real budget per add_to_cart (one
+micro-LLM call + one catalog search). A merchant who hasn't opted in pays
+nothing: the gate returns before any work.
+
+Once on, it fires as the ``add_to_cart`` policy's ``followup`` after the
+CartView is already on the wire, so the recommendation costs the shopper no
+perceived latency. No further configuration — one flag is the whole surface:
+
+- **What to recommend** — a micro-LLM call (same pooled Gemini service the
+  chat turns use, minimal thinking, strict JSON out) proposes 1-2
+  complement CATEGORIES from the live cart contents. This is the one
+  decision that needs world knowledge ("top + leggings in cart → socks")
+  and the one that killed every static approach: platform-native recs were
+  probed live and rejected (the gateway's ``related`` returns substitutes —
+  more leggings after adding leggings; ``complementary`` is empty unless
+  the merchant hand-curates pairings), and per-merchant maps don't
+  scale (user directive: no dictionaries).
+- **Validation** — the UCP catalog search itself: a category the store
+  doesn't sell returns zero rows (probed: "skateboards" → 0, no fuzzy
+  junk), so an LLM miss degrades to silence, never to junk cards.
+- **Size intelligence** — deterministic: candidates keep the shopper's
+  just-added size when they have a matching size axis ("XL" leggings →
+  only tops available in XL survive; a product whose size axis matches but
+  has no stock in that size is DROPPED), and the matching variant is
+  stamped via the grid's ``items[].feature_variant`` selector so the
+  card's Add is one tap in the right size (the existing A6
+  featured_variant_id continuity — no picker detour).
+
+Everything here is fail-open: any error or timeout yields ``None`` (no
+upsell block) — a recommendation must never fail the mutation turn.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import re
+from typing import Any, Dict, List, Optional
+
+from app.core.logger import logger
+
+# Overall wall-clock budget for the whole followup (LLM pick + search +
+# resolve); the picker gets its own tighter slice. Generous on purpose —
+# the cart is already rendered while this runs.
+_UPSELL_TIMEOUT_S = 10.0
+_PICK_TIMEOUT_S = 5.0
+_MAX_ITEMS = 6
+
+_PICK_SCHEMA: Dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "queries": {
+            "type": "array",
+            "items": {"type": "string"},
+            "maxItems": 2,
+        }
+    },
+    "required": ["queries"],
+}
+
+# Sentinel: candidate has the shopper's size axis but no stock in their
+# size — recommending it would dead-end at an unbuyable size.
+_DROP = object()
+
+
+def _line_title(line: Dict[str, Any]) -> Optional[str]:
+    item = line.get("item")
+    if isinstance(item, dict) and isinstance(item.get("title"), str):
+        return item["title"]
+    return None
+
+
+def _added_line_title(lines: List[Dict[str, Any]], variant_id: str) -> Optional[str]:
+    for line in lines:
+        item = line.get("item")
+        if isinstance(item, dict) and item.get("id") == variant_id:
+            title = item.get("title")
+            if isinstance(title, str):
+                return title
+    return None
+
+
+def _title_tokens(title: str) -> set:
+    return {tok.lower() for tok in re.split(r"[^A-Za-z0-9]+", title) if tok}
+
+
+def _is_size_axis(name: Any) -> bool:
+    return isinstance(name, str) and "size" in name.lower()
+
+
+def match_size_variant(product: Dict[str, Any], added_tokens: set) -> Any:
+    """Size-continuity filter for one candidate product.
+
+    Returns the available variant id matching the shopper's size token
+    (→ ``feature_variant`` stamp), ``None`` when the product has no
+    comparable size axis (no size options at all, or a disjoint vocabulary
+    like sock sizing — keep it, the picker handles the choice), or the
+    module ``_DROP`` sentinel when the size axis matches the shopper's
+    size but that size has no available variant.
+    """
+    options = product.get("options")
+    size_axis = next(
+        (
+            o
+            for o in (options if isinstance(options, list) else [])
+            if isinstance(o, dict) and _is_size_axis(o.get("name"))
+        ),
+        None,
+    )
+    if size_axis is None:
+        return None
+    values = [
+        str(v.get("label"))
+        for v in (size_axis.get("values") or [])
+        if isinstance(v, dict) and v.get("label") is not None
+    ]
+    match = next((v for v in values if v.lower() in added_tokens), None)
+    if match is None:
+        return None
+
+    # Local import — schemas is flavor-internal and cycle-free, but the
+    # availability decoder is the single source of truth for every
+    # encoding the live UCP ships (nested {available}, {state}, bare bool).
+    from app.ai.voice.agents.breeze_buddy.assist.commerce.ucp.schemas import (
+        _variant_available,
+    )
+
+    variants = product.get("variants")
+    for variant in variants if isinstance(variants, list) else []:
+        if not isinstance(variant, dict) or not isinstance(variant.get("id"), str):
+            continue
+        vopts = variant.get("options")
+        has_size = any(
+            isinstance(o, dict)
+            and _is_size_axis(o.get("name"))
+            and str(o.get("label", "")).lower() == match.lower()
+            for o in (vopts if isinstance(vopts, list) else [])
+        )
+        if has_size and _variant_available(variant):
+            return variant["id"]
+    return _DROP
+
+
+def build_upsell_selectors(
+    products: List[Any],
+    *,
+    added_tokens: set,
+    cart_titles: List[str],
+    max_items: int = _MAX_ITEMS,
+) -> List[Dict[str, str]]:
+    """The deterministic curation pass over raw search candidates →
+    ``ProductGrid.items`` selectors (id + optional feature_variant).
+
+    Drops: malformed entries, products already in the cart (candidate
+    title prefixing a cart line title — line titles carry the variant
+    suffix), and size-axis matches with no stock in the shopper's size.
+    """
+    lowered_cart = [t.lower() for t in cart_titles]
+    selectors: List[Dict[str, str]] = []
+    for product in products:
+        if not isinstance(product, dict) or not isinstance(product.get("id"), str):
+            continue
+        title = product.get("title")
+        if isinstance(title, str) and title:
+            if any(ct.startswith(title.lower()) for ct in lowered_cart):
+                continue
+        feature = match_size_variant(product, added_tokens)
+        if feature is _DROP:
+            continue
+        entry: Dict[str, str] = {"id": product["id"]}
+        if isinstance(feature, str):
+            entry["feature_variant"] = feature
+        selectors.append(entry)
+        if len(selectors) >= max_items:
+            break
+    return selectors
+
+
+async def _pick_complement_queries(
+    template: Any, cart_titles: List[str], added_title: str
+) -> List[str]:
+    """One-shot Gemini call: cart contents in, 1-2 complement category
+    queries out (strict JSON schema, minimal thinking). Reuses the pooled
+    chat service — no new client, no new credentials path."""
+    from google.genai.types import GenerateContentConfig
+
+    from app.ai.voice.agents.breeze_buddy.chat.turn_core import (
+        resolve_llm_configuration,
+    )
+    from app.ai.voice.agents.breeze_buddy.llm import get_llm_service
+
+    service = await get_llm_service(resolve_llm_configuration(template), pooled=True)
+    model = service._settings.model
+    # Gemini-only micro-call: the google-genai client is the one with
+    # `.aio` (the service union also covers Anthropic/OpenAI engines —
+    # those templates simply skip the upsell rather than growing three
+    # provider one-shot paths for a decoration).
+    client: Any = service._client
+    if not isinstance(model, str) or not hasattr(client, "aio"):
+        return []
+
+    lines = "\n".join(
+        f"- {t}" + (" (just added)" if t == added_title else "") for t in cart_titles
+    )
+    prompt = (
+        "You are a shopping assistant for an online store. A shopper just "
+        "added an item to their cart.\n\n"
+        f"Cart contents:\n{lines}\n\n"
+        "Suggest 1-2 SHORT product-category search queries (1-3 words "
+        'each, e.g. "socks" or "sports bra") for COMPLEMENTARY products '
+        "that would complete this shopper's outfit or order. Never suggest "
+        "a category already covered by the cart. Prefer the most natural "
+        "next purchase.\n\n"
+        'Return JSON: {"queries": [...]}'
+    )
+    response = await asyncio.wait_for(
+        client.aio.models.generate_content(
+            model=model,
+            contents=prompt,
+            config=GenerateContentConfig(
+                response_mime_type="application/json",
+                response_schema=_PICK_SCHEMA,
+                thinking_config={"thinking_level": "minimal"},
+                temperature=0.2,
+            ),
+        ),
+        timeout=_PICK_TIMEOUT_S,
+    )
+    try:
+        data = json.loads(response.text or "{}")
+    except (TypeError, ValueError):
+        return []
+    queries = data.get("queries")
+    if not isinstance(queries, list):
+        return []
+    return [q.strip() for q in queries if isinstance(q, str) and q.strip()][:2]
+
+
+async def _run(
+    agent: Any,
+    prep: Any,
+    node: Dict[str, Any],
+    parsed: Any,
+    turn_id: str,
+    final_tool: str,
+    final_result: Any,
+) -> Optional[Dict[str, Any]]:
+    # Runtime imports from the sibling module: intents.py imports THIS
+    # module at load time to wire the policy, so upsell must not import
+    # intents at module scope (cycle). By call time it's fully loaded.
+    from app.ai.voice.agents.breeze_buddy.assist.commerce.ucp.intents import (
+        AddToCartPayload,
+        _cart_lines,
+        _unwrap_tool_payload,
+        resolve_cart_config,
+    )
+    from app.ai.voice.agents.breeze_buddy.chat.intents.router import run_persisted_tool
+    from app.ai.voice.agents.breeze_buddy.chat.ui.binding import resolve_show_op
+
+    payload = parsed.payload
+    if not isinstance(payload, AddToCartPayload):
+        return None
+
+    lines = _cart_lines(_unwrap_tool_payload(final_result))
+    cart_titles = [t for t in (_line_title(ln) for ln in lines) if t]
+    added_title = _added_line_title(lines, payload.variant_id)
+    if not cart_titles or added_title is None:
+        return None
+
+    queries = await _pick_complement_queries(agent.template, cart_titles, added_title)
+    if not queries:
+        return None
+
+    cfg = resolve_cart_config(agent.template)
+    added_tokens = _title_tokens(added_title)
+    for query in queries:
+        # The search exchange persists like any other direct dispatch (the
+        # LLM must know what's on screen when the shopper says "add the
+        # socks"), but its function_call events are NOT streamed — the
+        # upsell should feel ambient, not like a running tool step.
+        _events, result = await run_persisted_tool(
+            agent,
+            tool_name=cfg.search,
+            args={"catalog": {"query": query}},
+            node=node,
+            prep=prep,
+            turn_id=turn_id,
+        )
+        unwrapped = _unwrap_tool_payload(result)
+        products = unwrapped.get("products") if isinstance(unwrapped, dict) else None
+        if not isinstance(products, list) or not products:
+            continue
+        selectors = build_upsell_selectors(
+            products, added_tokens=added_tokens, cart_titles=cart_titles
+        )
+        if not selectors:
+            continue
+        show_op = {
+            # id MUST be "root": every widget ui block hosts exactly one op
+            # tree anchored at id "root" (ui_state drops any other
+            # parentless add — live bug 2026-07-31, invisible upsell). The
+            # SDK store routes upsell-marked ops into their OWN block
+            # (appendUiOp isUpsellGridAdd branch), so this root never
+            # collides with the CartView's root from the same turn.
+            "op": "show",
+            "id": "root",
+            "component": "ProductGrid",
+            "bind": {"products": f"$tool:{cfg.search}#/products"},
+            "props": {
+                "layout": "carousel",
+                "max_items": _MAX_ITEMS,
+                "items": selectors,
+            },
+        }
+        resolved = resolve_show_op(show_op, agent.binding_store, agent.ui_allowlist)
+        if resolved.op is None:
+            logger.warning(
+                f"cart_upsell: grid resolve dropped ({resolved.error}) — skipping"
+            )
+            return None
+        op = resolved.op
+        # Post-resolve server stamps (never part of the LLM-facing schema):
+        # the heading the widget renders above the carousel, and the marker
+        # the store's cart-family sweep keys on. Persisted verbatim in
+        # ui_blocks, so resume sweeps identically.
+        props = op.setdefault("props", {})
+        # "✨ Picked for you": the sparkle is the de-facto AI signifier and
+        # "for you" carries the personalization — without the clinical
+        # "AI-recommended" phrasing (user spec 2026-07-31).
+        props["heading"] = "✨ Picked for you"
+        props["context"] = "cart_upsell"
+        return op
+    return None
+
+
+async def run_cart_upsell(
+    agent: Any,
+    prep: Any,
+    node: Dict[str, Any],
+    parsed: Any,
+    turn_id: str,
+    final_tool: str,
+    final_result: Any,
+) -> Optional[Dict[str, Any]]:
+    """``IntentPolicy.followup`` entry — see module docstring. Returns the
+    resolved, stamped ProductGrid op or ``None``; never raises.
+
+    OPT-IN: returns immediately unless the template sets
+    ``flavor.ucp.features.upsell``. The gate is here rather than on the
+    policy because policies register once per process while the flag is
+    per-template — and it is checked BEFORE any work, so a merchant who
+    hasn't opted in pays nothing (no LLM call, no catalog search).
+    """
+    from app.ai.voice.agents.breeze_buddy.assist.commerce.ucp.intents import (
+        resolve_cart_config,
+    )
+
+    if not resolve_cart_config(getattr(agent, "template", None)).upsell_enabled:
+        return None
+    try:
+        return await asyncio.wait_for(
+            _run(agent, prep, node, parsed, turn_id, final_tool, final_result),
+            timeout=_UPSELL_TIMEOUT_S,
+        )
+    except Exception:  # noqa: BLE001 — recommendations are strictly best-effort
+        logger.exception("cart_upsell: followup failed — no upsell block")
+        return None
+
+
+__all__ = ["run_cart_upsell", "build_upsell_selectors", "match_size_variant"]

--- a/app/ai/voice/agents/breeze_buddy/chat/intents/router.py
+++ b/app/ai/voice/agents/breeze_buddy/chat/intents/router.py
@@ -205,12 +205,15 @@ class IntentPolicy:
 # per-session gating is the ``enabled_flavors`` check in parse_ui_intent.
 INTENT_POLICY: Dict[str, IntentPolicy] = {}
 
-# Flavor → intents module, the intent-side mirror of
-# ``ui_catalog.LAZY_GROUPS`` (which maps the same flavor names to schema
-# modules). Kept separate so a chat session that never sends a ui_intent
-# loads only the schemas, and vice versa.
+# Flavor → the module whose import registers that flavor's intents. The
+# intent-side mirror of ``ui_catalog.LAZY_GROUPS``, and deliberately the
+# SAME target: a flavor package registers its whole surface (schemas,
+# intents, connectors) in one import, so a template can't end up with half
+# a flavor depending on which endpoint it touched first. Still lazy where
+# it counts — a process that never serves a flavor-enabled template never
+# imports the package at all.
 FLAVOR_INTENT_MODULES: Dict[str, str] = {
-    "commerce": "app.ai.voice.agents.breeze_buddy.assist.commerce.intents",
+    "commerce": "app.ai.voice.agents.breeze_buddy.assist.commerce",
 }
 
 # Attempted flavors — successes AND failures. A failed import must not be

--- a/app/ai/voice/agents/breeze_buddy/template/field_reference.json
+++ b/app/ai/voice/agents/breeze_buddy/template/field_reference.json
@@ -447,7 +447,7 @@
       }
     },
     "ui_intents": {
-      "description": "Per-template overrides for the tool names, state keys, labels, and URLs a flavor's DIRECT ui_intent executors use (RFC-001 §3.3 Stage B). Role → value maps; unset roles keep the flavor's defaults (commerce: create_cart/update_cart/get_cart, cart_id/checkout_url, 'Review and checkout'). urls.checkout_page (optional) fixes the CartView checkout button's destination — e.g. the storefront /cart page, which the cart-cookie sync populates — instead of the cart tool's checkout-bound continue_url. Only set roles that DIFFER from the flavor defaults. Fields documented under UiIntentsConfig.",
+      "description": "Per-template overrides for the tool names, state keys, labels, and URLs a flavor's DIRECT ui_intent executors use (RFC-001 §3.3 Stage B). Role → value maps; unset roles keep the flavor's defaults (commerce: create_cart/update_cart/get_cart, cart_id/checkout_url, 'Review and checkout'). urls.checkout_page (optional) fixes the CartView checkout button's destination — e.g. the storefront /cart page, which the cart-cookie sync populates — instead of the cart tool's checkout-bound continue_url. Only set roles that DIFFER from the flavor defaults. Connectors and optional features live on `flavor`, not here. Fields documented under UiIntentsConfig.",
       "example": {
         "urls": {
           "checkout_page": "https://www.thebeyondbound.com/cart"
@@ -475,6 +475,19 @@
           "image_url": "https://cdn.example.com/hiit.jpg"
         }
       ]
+    },
+    "flavor": {
+      "description": "Protocol dialect → which platform connectors serve it and which optional flavor features are on. Keyed exactly the way the flavor packages are laid out on disk (assist/<flavor>/<protocol>/ + assist/<flavor>/connectors/<name>/), so config and code read the same. Absent, or a protocol left unset, means connectors self-select on the payload and every optional feature is OFF. The engine never interprets the keys — a flavor resolves its own protocol block by name. Fields documented under FlavorProtocolConfig.",
+      "example": {
+        "ucp": {
+          "connectors": [
+            "shopify"
+          ],
+          "features": {
+            "upsell": true
+          }
+        }
+      }
     }
   },
   "RenderUiConfig": {
@@ -1144,6 +1157,20 @@
       "interruption": {
         "mode": "enabled",
         "min_words": 2
+      }
+    }
+  },
+  "FlavorProtocolConfig": {
+    "connectors": {
+      "description": "Platform connectors to consult for this protocol, by name. EMPTY (the default) means every registered connector self-selects on the data it is handed — correct when the platform is unambiguous from the payload. Name them explicitly when a connector would otherwise mis-fire on a look-alike gateway: e.g. a non-Shopify store whose product URLs are also /products/{handle} would cost a dead storefront fetch on every product view.",
+      "example": [
+        "shopify"
+      ]
+    },
+    "features": {
+      "description": "Optional flavor features → on/off. OPT-IN by contract: every feature is OFF unless turned on here, so enabling a flavor never silently starts extra behaviour on an existing merchant. Commerce/ucp: 'upsell' streams a complementary ProductGrid after a successful add_to_cart — one extra LLM call plus a catalog search per add, run after the cart component is already on the wire so the shopper never waits on it.",
+      "example": {
+        "upsell": true
       }
     }
   }

--- a/app/ai/voice/agents/breeze_buddy/template/types.py
+++ b/app/ai/voice/agents/breeze_buddy/template/types.py
@@ -1296,6 +1296,49 @@ class UiCatalogConfig(BaseModel):
     )
 
 
+class FlavorProtocolConfig(BaseModel):
+    """One protocol dialect of a flavor: which platform connectors serve it
+    and which optional features are on.
+
+    Mirrors the flavor package layout — ``assist/<flavor>/<protocol>/`` is
+    the protocol layer, ``assist/<flavor>/connectors/<name>/`` are the
+    platforms that serve it — so config and code read the same way::
+
+        "flavor": {"ucp": {"connectors": ["shopify"],
+                           "features": {"upsell": true}}}
+
+    The engine treats both fields opaquely: it never knows which protocols,
+    connectors, or features exist. A flavor resolves its own block by name
+    and falls back to its defaults for anything unset.
+    """
+
+    connectors: List[str] = Field(
+        default_factory=list,
+        description=(
+            "Platform connectors to consult for this protocol, by name. "
+            "EMPTY (the default) means every registered connector "
+            "self-selects on the data it is handed — correct when the "
+            "platform is unambiguous from the payload. Name them "
+            "explicitly when a connector would otherwise mis-fire on a "
+            "look-alike gateway (e.g. a non-Shopify store whose product "
+            "URLs are also /products/{handle}, which would cost a dead "
+            "storefront fetch per product view)."
+        ),
+    )
+    features: Dict[str, bool] = Field(
+        default_factory=dict,
+        description=(
+            "Optional flavor features → on/off. OPT-IN by contract: every "
+            "feature is OFF unless turned on here, so enabling a flavor "
+            "never silently starts extra behaviour on an existing "
+            "merchant. Commerce/ucp: 'upsell' streams a complementary "
+            "ProductGrid after a successful add_to_cart (one extra LLM "
+            "call + catalog search per add, run after the cart is already "
+            "on the wire)."
+        ),
+    )
+
+
 class UiIntentsConfig(BaseModel):
     """Per-template overrides for flavor ``ui_intent`` executors
     (RFC-001 §3.3 Stage B) — the no-LLM DIRECT path where the widget
@@ -1792,6 +1835,20 @@ class ConfigurationModel(BaseModel):
             "use (RFC-001 §3.3 Stage B). Absent = each flavor's built-in "
             "defaults (commerce: create_cart/update_cart/get_cart, "
             "cart_id/checkout_url, 'Review and checkout')."
+        ),
+    )
+    flavor: Optional[Dict[str, "FlavorProtocolConfig"]] = Field(
+        None,
+        description=(
+            "Optional. Protocol dialect → which platform connectors serve "
+            "it and which optional features are on, keyed the same way the "
+            "flavor packages are laid out on disk::\n\n"
+            '    "flavor": {"ucp": {"connectors": ["shopify"],\n'
+            '                       "features": {"upsell": true}}}\n\n'
+            "Absent (or a protocol left unset) = connectors self-select on "
+            "the payload and every optional feature is OFF. The engine "
+            "never interprets the keys — a flavor resolves its own "
+            "protocol block by name."
         ),
     )
     tool_execution: Optional["ToolExecutionConfig"] = Field(

--- a/app/ai/voice/agents/breeze_buddy/template/ui_catalog.py
+++ b/app/ai/voice/agents/breeze_buddy/template/ui_catalog.py
@@ -1039,7 +1039,7 @@ PRIMITIVE_RENDER_ORDER: List[str] = [
 
 
 LAZY_GROUPS: Dict[str, str] = {
-    "commerce": "app.ai.voice.agents.breeze_buddy.assist.commerce.schemas",
+    "commerce": "app.ai.voice.agents.breeze_buddy.assist.commerce",
 }
 
 # Attempted groups — both the successes (``importlib.import_module`` is

--- a/tests/assist/__init__.py
+++ b/tests/assist/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the assist-product flavor packages (lazy-loaded commerce)."""

--- a/tests/assist/fixtures/intent_payloads.json
+++ b/tests/assist/fixtures/intent_payloads.json
@@ -1,0 +1,89 @@
+{
+  "_readme": [
+    "Contract fixtures: the EXACT ui_intent payload JSON bodies the widget builds",
+    "(RFC-001 §3.3). One list per intent; each entry is a captured emission shape",
+    "(incl. the url / product_id / cart_id optional-field variants).",
+    "Builders live in the loom repo at",
+    "packages/breeze-buddy-assist-widget/src/lib/ui/commerce/helpers.ts.",
+    "This file is mirrored byte-identically in the loom repo at",
+    "packages/client-sdk/src/lib/chat/__fixtures__/intent_payloads.json —",
+    "update BOTH copies (and both repos' contract tests) when an emission changes."
+  ],
+  "view_product": [
+    {
+      "product_id": "gid://shopify/Product/9967507833123",
+      "title": "Ribbed Trail Socks",
+      "url": "https://beyond-bound.example/products/ribbed-trail-socks"
+    },
+    {
+      "product_id": "gid://shopify/Product/9967507833123",
+      "title": "Ribbed Trail Socks"
+    },
+    {
+      "product_id": "gid://shopify/Product/9967507833123",
+      "title": "Ribbed Trail Socks",
+      "url": "https://beyond-bound.example/products/ribbed-trail-socks",
+      "featured_variant_id": "gid://shopify/ProductVariant/11",
+      "variants": [
+        {
+          "id": "gid://shopify/ProductVariant/11",
+          "title": "S",
+          "available": true,
+          "price": {
+            "amount": 934,
+            "currency": "INR"
+          }
+        },
+        {
+          "id": "gid://shopify/ProductVariant/12",
+          "title": "M",
+          "available": false
+        }
+      ]
+    }
+  ],
+  "enrich_product": [
+    {
+      "product_id": "gid://shopify/Product/9967507833123",
+      "title": "Ribbed Trail Socks"
+    },
+    {
+      "product_id": "gid://shopify/Product/9967507833123"
+    }
+  ],
+  "add_to_cart": [
+    {
+      "variant_id": "gid://shopify/ProductVariant/54224673210659",
+      "qty": 1,
+      "product_id": "gid://shopify/Product/9967507833123"
+    }
+  ],
+  "set_qty": [
+    {
+      "line_id": "gid://shopify/CartLine/2a54e56d-9038-4f5e-8d5e-6a4b2d3f9c11",
+      "variant_id": "gid://shopify/ProductVariant/54224673210659",
+      "qty": 2,
+      "cart_id": "gid://shopify/Cart/hWN2h0jP3rDIzW0Yc8jQe9Jw?key=abc123"
+    },
+    {
+      "line_id": "gid://shopify/CartLine/2a54e56d-9038-4f5e-8d5e-6a4b2d3f9c11",
+      "variant_id": "gid://shopify/ProductVariant/54224673210659",
+      "qty": 2
+    }
+  ],
+  "remove_line": [
+    {
+      "line_id": "gid://shopify/CartLine/2a54e56d-9038-4f5e-8d5e-6a4b2d3f9c11",
+      "variant_id": "gid://shopify/ProductVariant/54224673210659",
+      "cart_id": "gid://shopify/Cart/hWN2h0jP3rDIzW0Yc8jQe9Jw?key=abc123"
+    },
+    {
+      "line_id": "gid://shopify/CartLine/2a54e56d-9038-4f5e-8d5e-6a4b2d3f9c11"
+    }
+  ],
+  "checkout": [
+    {
+      "url": "https://beyond-bound.example/cart/c/hWN2h0jP3rDIzW0Yc8jQe9Jw?key=abc123"
+    }
+  ]
+}

--- a/tests/assist/test_commerce_intents.py
+++ b/tests/assist/test_commerce_intents.py
@@ -1,0 +1,788 @@
+"""Tests for the commerce UI-intent flavor on the typed intent engine
+(RFC-001 §3.3).
+
+Covers: per-intent payload validation (typed 422 errors), the registered
+policy table + agent-turn rewrite, and run_direct_intent's no-LLM
+execution — MCP dispatch is mocked at ``ChatAgent._dispatch_tool_call``
+so the REAL inject_tool_args → binding-store → apply_state_reducers path
+runs, and the emitted stream is asserted end-to-end: user bubble → cart
+tools → hydrated CartView (v:2) → turn_end.
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from typing import Any, Dict, List, Optional, cast
+
+import pytest
+
+from app.ai.voice.agents.breeze_buddy.assist.commerce.ucp import intents as ci
+from app.ai.voice.agents.breeze_buddy.chat.agent import ChatAgent
+from app.ai.voice.agents.breeze_buddy.chat.intents import router as ir
+from app.ai.voice.agents.breeze_buddy.chat.sse import SSEEvent
+
+# Importing ``ci`` above registered the commerce policies; the public
+# loader must agree (and stay idempotent).
+ir.ensure_flavor_intents(["commerce"])
+
+# Load template package first — same circular-import precaution as the
+# sibling chat-layer tests.
+from app.ai.voice.agents.breeze_buddy.template.types import (
+    StateReducer,
+    ToolArgInjection,
+    UiCatalogConfig,
+    UiIntentsConfig,
+)
+from app.schemas.breeze_buddy.chat import ChatSessionStatus
+
+# ---------------------------------------------------------------------------
+# parse_ui_intent — payload validation
+# ---------------------------------------------------------------------------
+
+
+def _wire(intent: str, payload: Dict[str, Any], **extra) -> Dict[str, Any]:
+    return {"intent": intent, "component_id": "pg1", "payload": payload, **extra}
+
+
+def test_parse_valid_add_to_cart():
+    parsed = ir.parse_ui_intent(
+        _wire(
+            "add_to_cart",
+            {"variant_id": "gid://shopify/ProductVariant/123", "qty": 2},
+            display="Add High Support Sports Bra — M",
+        )
+    )
+    assert parsed.policy.route is ir.IntentRoute.DIRECT
+    assert isinstance(parsed.payload, ci.AddToCartPayload)
+    assert parsed.payload.qty == 2
+    assert parsed.intent.display == "Add High Support Sports Bra — M"
+
+
+def test_parse_qty_defaults_to_one():
+    parsed = ir.parse_ui_intent(_wire("add_to_cart", {"variant_id": "v1"}))
+    assert isinstance(parsed.payload, ci.AddToCartPayload)
+    assert parsed.payload.qty == 1
+
+
+def test_parse_unknown_intent_raises_typed_error():
+    with pytest.raises(ir.IntentValidationError) as exc:
+        ir.parse_ui_intent(_wire("teleport", {}))
+    assert exc.value.detail["code"] == "unknown_intent"
+
+
+def test_parse_invalid_payload_raises_structural_errors_only():
+    with pytest.raises(ir.IntentValidationError) as exc:
+        ir.parse_ui_intent(_wire("add_to_cart", {"qty": "lots"}))
+    detail = exc.value.detail
+    assert detail["code"] == "invalid_intent_payload"
+    locs = {e["loc"] for e in detail["errors"]}
+    assert "variant_id" in locs
+    assert "lots" not in json.dumps(detail)  # never echoes input values
+
+
+def test_parse_ignores_extra_payload_keys():
+    """Payload-compat policy (see intents.py docstring): unknown extra keys
+    are accepted and dropped — never a 422. Drift logging is covered in
+    test_intent_payload_contract.py."""
+    parsed = ir.parse_ui_intent(
+        _wire("add_to_cart", {"variant_id": "v1", "price": 1.0})
+    )
+    assert isinstance(parsed.payload, ci.AddToCartPayload)
+    assert "price" not in parsed.payload.model_dump()
+
+
+def test_parse_rejects_malformed_wire_body():
+    with pytest.raises(ir.IntentValidationError) as exc:
+        ir.parse_ui_intent({"intent": "add_to_cart"})  # no component_id
+    assert exc.value.detail["code"] == "invalid_intent"
+
+
+def test_parse_set_qty_allows_zero():
+    parsed = ir.parse_ui_intent(_wire("set_qty", {"line_id": "l1", "qty": 0}))
+    assert isinstance(parsed.payload, ci.SetQtyPayload)
+    assert parsed.payload.qty == 0
+
+
+# ---------------------------------------------------------------------------
+# Policy table + agent-turn rewrite
+# ---------------------------------------------------------------------------
+
+
+def test_policy_routes_match_rfc_table():
+    routes = {name: p.route.value for name, p in ir.INTENT_POLICY.items()}
+    assert routes == {
+        "add_to_cart": "direct",
+        "remove_line": "direct",
+        "set_qty": "direct",
+        "view_product": "direct",
+        "enrich_product": "agent_turn",
+        "checkout": "client",
+    }
+
+
+def test_view_product_is_direct_and_silent():
+    """view_product drives the full-panel detail overlay: DIRECT (a
+    deterministic get_product read — no LLM), silent (no visible thread
+    trace), hydrating the server-only ProductDetail component."""
+    parsed = ir.parse_ui_intent(
+        _wire(
+            "view_product",
+            {"product_id": "gid://shopify/Product/9", "title": "Trail Shoe"},
+        )
+    )
+    assert parsed.policy.route is ir.IntentRoute.DIRECT
+    assert parsed.policy.silent is True
+    assert parsed.policy.drive is not None
+    assert parsed.policy.show_op is not None
+    op = parsed.policy.show_op("get_product", {"product": {}}, cast(Any, object()))
+    assert op["component"] == "ProductDetail"
+    assert op["bind"] == {"product": "$tool:get_product#/product"}
+
+
+def test_enrich_product_is_internal_agent_turn():
+    """enrich_product (the overlay's markdown product brief) is an
+    AGENT_TURN with internal persistence: the rewritten instruction names
+    the product, forbids tools, and demands grounded markdown output."""
+    parsed = ir.parse_ui_intent(
+        _wire(
+            "enrich_product",
+            {"product_id": "gid://shopify/Product/9", "title": "Trail Shoe"},
+        )
+    )
+    assert parsed.policy.route is ir.IntentRoute.AGENT_TURN
+    assert parsed.policy.internal is True
+    assert parsed.policy.silent is False  # silent is the DIRECT-only flag
+    rewritten = ir.agent_turn_content(parsed)
+    assert '"Trail Shoe" (gid://shopify/Product/9)' in rewritten
+    assert "Do not call any tools" in rewritten
+    assert "markdown" in rewritten
+    assert "Ground every claim" in rewritten
+
+
+def test_enrich_product_rewrite_without_title_uses_id_only():
+    parsed = ir.parse_ui_intent(
+        _wire("enrich_product", {"product_id": "gid://shopify/Product/9"})
+    )
+    rewritten = ir.agent_turn_content(parsed)
+    assert "gid://shopify/Product/9" in rewritten
+    assert '""' not in rewritten  # no empty-quote artifact when title absent
+
+
+# ---------------------------------------------------------------------------
+# run_direct_intent — mocked MCP dispatch, real pipeline glue
+# ---------------------------------------------------------------------------
+
+
+def _envelope(payload: dict, status: str = "success") -> dict:
+    return {"status": status, "data": json.dumps(payload)}
+
+
+def _cart_payload(lines: List[dict]) -> dict:
+    return {
+        "id": "gid://shopify/Cart/c1?key=k",
+        "continue_url": "https://shop.example/cart",
+        "totals": [{"type": "total", "amount": 3398.0}],
+        "line_items": lines,
+        "cart_token": "c1%3Fkey%3Dk",
+    }
+
+
+def _cart_line(variant: str, qty: int, title: str = "Bra - M") -> dict:
+    return {
+        "id": f"line-{variant[-1]}",
+        "quantity": qty,
+        "item": {
+            "id": variant,
+            "title": title,
+            "image_url": "https://cdn.example/bra.jpg",
+            "price": 1699.0,
+        },
+        "totals": [{"type": "total", "amount": 1699.0 * qty}],
+    }
+
+
+def _template() -> Any:
+    """Duck-typed template (typed Any so it passes where TemplateModel is
+    annotated): real reducer/injection/ui_catalog configs, no flow
+    (ChatAgent tolerates flow=None on the direct path)."""
+    reducers = [
+        StateReducer(
+            tool_name=t,
+            set_paths={"cart_id": "id", "checkout_url": "continue_url"},
+        )
+        for t in ("create_cart", "update_cart", "get_cart")
+    ]
+    injections = [
+        ToolArgInjection(tool_name=t, set_paths={"id": "state.data.cart_id"})
+        for t in ("update_cart", "get_cart")
+    ]
+    return SimpleNamespace(
+        id="t1",
+        flow=None,
+        configurations=SimpleNamespace(
+            state_reducers=reducers,
+            tool_arg_injection=injections,
+            client_context=None,
+            ui_catalog=UiCatalogConfig(enabled_groups=["core", "commerce"]),
+        ),
+    )
+
+
+def _session(catalog_version: Optional[str] = "v2") -> SimpleNamespace:
+    widget: Dict[str, Any] = {}
+    if catalog_version:
+        widget["catalog_version"] = catalog_version
+    return SimpleNamespace(
+        status=ChatSessionStatus.ACTIVE,
+        current_node=None,
+        template_id="t1",
+        metadata={"template_vars": {}, "widget": widget},
+    )
+
+
+class _Recorder:
+    """Captures dispatches + persisted rows for assertions."""
+
+    def __init__(self, responses: Dict[str, List[dict]]) -> None:
+        self.responses = responses
+        self.dispatched: List[tuple] = []
+        self.inserted: List[Dict[str, Any]] = []
+        self.state_patches: List[Dict[str, Any]] = []
+
+
+def _patch_boundary(
+    monkeypatch,
+    recorder: _Recorder,
+    *,
+    session: Optional[SimpleNamespace] = None,
+    initial_state: Optional[Dict[str, Any]] = None,
+    template: Optional[Any] = None,
+):
+    session = session or _session()
+    template = template or _template()
+
+    async def _get_session(session_id):
+        return session
+
+    async def _get_template(template_id):
+        return template
+
+    async def _get_state(session_id):
+        return SimpleNamespace(data=dict(initial_state)) if initial_state else None
+
+    async def _vars(tpl, persisted):
+        return {}
+
+    async def _insert(**kwargs):
+        recorder.inserted.append(kwargs)
+        return SimpleNamespace(idx=len(recorder.inserted))
+
+    async def _upsert(*, chat_session_id, patch):
+        recorder.state_patches.append(patch)
+
+    async def _after_turn(*, session_id, current_node):
+        return None
+
+    async def _close_pool(pool):
+        return None
+
+    class _FakeHttpSession:
+        async def close(self):
+            return None
+
+    async def _prepare(self, current_node):
+        return SimpleNamespace(global_funcs=[]), {"name": "start", "functions": []}
+
+    async def _dispatch(self, call, node, global_funcs, injected_args=None):
+        recorder.dispatched.append((call.function_name, injected_args))
+        return recorder.responses[call.function_name].pop(0), None
+
+    monkeypatch.setattr(ir, "get_chat_session_by_id", _get_session)
+    monkeypatch.setattr(ir, "get_template_by_id_cached", _get_template)
+    monkeypatch.setattr(ir, "get_agent_session_state", _get_state)
+    monkeypatch.setattr(ir, "build_render_template_vars", _vars)
+    monkeypatch.setattr(ir, "insert_chat_message", _insert)
+    monkeypatch.setattr(ir, "upsert_agent_session_state_merge", _upsert)
+    monkeypatch.setattr(ir, "update_chat_session_after_turn", _after_turn)
+    monkeypatch.setattr(ir, "close_mcp_pool", _close_pool)
+    monkeypatch.setattr(ir, "create_aiohttp_session", lambda: _FakeHttpSession())
+    monkeypatch.setattr(ChatAgent, "prepare_direct_dispatch", _prepare)
+    monkeypatch.setattr(ChatAgent, "_dispatch_tool_call", _dispatch)
+
+
+async def _collect(agen) -> List[SSEEvent]:
+    return [ev async for ev in agen]
+
+
+async def test_add_to_cart_without_cart_creates_and_hydrates(monkeypatch):
+    new_cart = _cart_payload([_cart_line("gid://shopify/ProductVariant/9", 1)])
+    recorder = _Recorder({"create_cart": [_envelope(new_cart)]})
+    _patch_boundary(monkeypatch, recorder)
+
+    parsed = ir.parse_ui_intent(
+        _wire(
+            "add_to_cart",
+            {"variant_id": "gid://shopify/ProductVariant/9"},
+            display="Add High Support Sports Bra — M",
+        )
+    )
+    events = await _collect(ir.run_direct_intent(session_id="s1", parsed=parsed))
+
+    # The "Done." acknowledgement precedes the cart op on the wire so the
+    # bubble renders ABOVE the component (the ack is what keeps this turn
+    # anchored after a later mutation's CartView sweeps this one).
+    assert [e.event for e in events] == [
+        "user_committed",
+        "function_call_started",
+        "function_call_completed",
+        "assistant_message",
+        "ui_op",
+        "turn_end",
+    ]
+    # No cart in state → create_cart with the one line, nothing else.
+    assert [d[0] for d in recorder.dispatched] == ["create_cart"]
+    assert recorder.dispatched[0][1] == {
+        "cart": {
+            "line_items": [
+                {"item": {"id": "gid://shopify/ProductVariant/9"}, "quantity": 1}
+            ]
+        }
+    }
+    # Hydrated CartView — v2 wire shape, checkout from continue_url,
+    # cart_token for the widget-side cookie effect.
+    op = events[4].data["op"]
+    assert op["op"] == "add" and op["type"] == "CartView" and op["v"] == 2
+    props = op["props"]
+    assert props["cart_id"] == "gid://shopify/Cart/c1?key=k"
+    assert props["line_items"][0]["qty"] == 1
+    assert props["checkout"] == {
+        "label": "Review and checkout",
+        "url": "https://shop.example/cart",
+    }
+    assert props["cart_token"] == "c1%3Fkey%3Dk"
+    # Reducers persisted the lifted identifiers.
+    assert recorder.state_patches == [
+        {
+            "cart_id": "gid://shopify/Cart/c1?key=k",
+            "checkout_url": "https://shop.example/cart",
+        }
+    ]
+    # user bubble shows `display`; the typed intent rides an internal block.
+    assert events[0].data["content"] == "Add High Support Sports Bra — M"
+    user_row = recorder.inserted[0]
+    internal = user_row["content_blocks"][1]
+    assert internal.get("visibility") == "internal"
+    assert "add_to_cart" in internal["text"]
+    # One assistant row carries BOTH the ack prose and the cart block —
+    # resume replays them as a text bubble + a (sweepable) ui block.
+    assert recorder.inserted[-1]["content"] == "Done."
+    assert recorder.inserted[-1]["ui_blocks"] == [op]
+    assert events[3].data == {
+        "idx": len(recorder.inserted),
+        "content": "Done.",
+    }
+    assert events[5].data == {
+        "session_status": "ACTIVE",
+        "assistant_idx": len(recorder.inserted),
+    }
+
+
+async def test_add_to_cart_with_cart_merges_full_desired_set(monkeypatch):
+    existing = _cart_payload([_cart_line("gid://shopify/ProductVariant/9", 1)])
+    updated = _cart_payload(
+        [
+            _cart_line("gid://shopify/ProductVariant/9", 1),
+            _cart_line("gid://shopify/ProductVariant/7", 2, title="Leggings"),
+        ]
+    )
+    recorder = _Recorder(
+        {"get_cart": [_envelope(existing)], "update_cart": [_envelope(updated)]}
+    )
+    _patch_boundary(
+        monkeypatch,
+        recorder,
+        initial_state={"cart_id": "gid://shopify/Cart/c1?key=k"},
+    )
+
+    parsed = ir.parse_ui_intent(
+        _wire("add_to_cart", {"variant_id": "gid://shopify/ProductVariant/7", "qty": 2})
+    )
+    events = await _collect(ir.run_direct_intent(session_id="s1", parsed=parsed))
+
+    assert [d[0] for d in recorder.dispatched] == ["get_cart", "update_cart"]
+    # get_cart's id was injected from state (arg-injection reuse).
+    assert recorder.dispatched[0][1] == {"id": "gid://shopify/Cart/c1?key=k"}
+    # update_cart carries the FULL desired set: existing line kept, new added.
+    assert recorder.dispatched[1][1]["cart"]["line_items"] == [
+        {"item": {"id": "gid://shopify/ProductVariant/9"}, "quantity": 1},
+        {"item": {"id": "gid://shopify/ProductVariant/7"}, "quantity": 2},
+    ]
+    op = next(e for e in events if e.event == "ui_op").data["op"]
+    assert op["type"] == "CartView"
+    assert len(op["props"]["line_items"]) == 2
+
+
+async def test_add_to_cart_same_variant_increments_qty(monkeypatch):
+    existing = _cart_payload([_cart_line("gid://shopify/ProductVariant/9", 1)])
+    recorder = _Recorder(
+        {"get_cart": [_envelope(existing)], "update_cart": [_envelope(existing)]}
+    )
+    _patch_boundary(monkeypatch, recorder, initial_state={"cart_id": "c"})
+
+    parsed = ir.parse_ui_intent(
+        _wire("add_to_cart", {"variant_id": "gid://shopify/ProductVariant/9"})
+    )
+    await _collect(ir.run_direct_intent(session_id="s1", parsed=parsed))
+    assert recorder.dispatched[1][1]["cart"]["line_items"] == [
+        {"item": {"id": "gid://shopify/ProductVariant/9"}, "quantity": 2}
+    ]
+
+
+async def test_remove_line_omits_the_line(monkeypatch):
+    existing = _cart_payload(
+        [
+            _cart_line("gid://shopify/ProductVariant/9", 1),
+            _cart_line("gid://shopify/ProductVariant/7", 2),
+        ]
+    )
+    after = _cart_payload([_cart_line("gid://shopify/ProductVariant/7", 2)])
+    recorder = _Recorder(
+        {"get_cart": [_envelope(existing)], "update_cart": [_envelope(after)]}
+    )
+    _patch_boundary(monkeypatch, recorder, initial_state={"cart_id": "c"})
+
+    parsed = ir.parse_ui_intent(_wire("remove_line", {"line_id": "line-9"}))
+    events = await _collect(ir.run_direct_intent(session_id="s1", parsed=parsed))
+    assert recorder.dispatched[1][1]["cart"]["line_items"] == [
+        {"item": {"id": "gid://shopify/ProductVariant/7"}, "quantity": 2}
+    ]
+    assert any(e.event == "ui_op" for e in events)
+
+
+async def test_set_qty_changes_quantity(monkeypatch):
+    existing = _cart_payload([_cart_line("gid://shopify/ProductVariant/9", 1)])
+    recorder = _Recorder(
+        {"get_cart": [_envelope(existing)], "update_cart": [_envelope(existing)]}
+    )
+    _patch_boundary(monkeypatch, recorder, initial_state={"cart_id": "c"})
+
+    parsed = ir.parse_ui_intent(_wire("set_qty", {"line_id": "line-9", "qty": 5}))
+    await _collect(ir.run_direct_intent(session_id="s1", parsed=parsed))
+    assert recorder.dispatched[1][1]["cart"]["line_items"] == [
+        {"item": {"id": "gid://shopify/ProductVariant/9"}, "quantity": 5}
+    ]
+
+
+async def test_unknown_line_errors_without_mutation(monkeypatch):
+    existing = _cart_payload([_cart_line("gid://shopify/ProductVariant/9", 1)])
+    recorder = _Recorder({"get_cart": [_envelope(existing)]})
+    _patch_boundary(monkeypatch, recorder, initial_state={"cart_id": "c"})
+
+    parsed = ir.parse_ui_intent(_wire("remove_line", {"line_id": "nope"}))
+    events = await _collect(ir.run_direct_intent(session_id="s1", parsed=parsed))
+    assert [d[0] for d in recorder.dispatched] == ["get_cart"]  # no update_cart
+    # Business failures ride the in-thread `intent_failed` event, never
+    # the `error` event (which drives the delivery-failure banner).
+    failed = next(e for e in events if e.event == "intent_failed")
+    assert failed.data["code"] == "intent_line_not_found"
+    assert not any(e.event == "error" for e in events)
+    assert events[-1].event == "turn_end"
+    assert events[-1].data["session_status"] == "ACTIVE"
+
+
+async def test_tool_error_envelope_ends_cleanly(monkeypatch):
+    recorder = _Recorder({"create_cart": [_envelope({}, status="error")]})
+    _patch_boundary(monkeypatch, recorder)
+
+    parsed = ir.parse_ui_intent(_wire("add_to_cart", {"variant_id": "v1"}))
+    events = await _collect(ir.run_direct_intent(session_id="s1", parsed=parsed))
+    failed = next(e for e in events if e.event == "intent_failed")
+    assert failed.data["code"] == "intent_tool_failed"
+    assert events[-1].data["session_status"] == "ACTIVE"
+    assert not any(e.event == "ui_op" for e in events)
+
+
+async def test_sold_out_add_surfaces_the_ucp_warning(monkeypatch):
+    """Live regression (CoreFlex Tee, 2026-07-28): create_cart 'succeeds'
+    with an EMPTY cart + a UCP messages[] sold-out warning. The verifier
+    converts the result to an error envelope; the shopper must see the
+    precise warning text in-thread, not generic retry copy."""
+    empty_sold_out_cart = {
+        "id": "gid://shopify/Cart/c9",
+        "continue_url": "https://shop.example/cart",
+        "line_items": [],
+        "totals": [{"type": "total", "amount": 0.0}],
+        "messages": [
+            {
+                "type": "warning",
+                "content_type": "plain",
+                "code": "merchandise_out_of_stock",
+                "content": "The product 'CoreFlex Tee - Mehendi - L' is already sold out.",
+            }
+        ],
+    }
+    recorder = _Recorder({"create_cart": [_envelope(empty_sold_out_cart)]})
+    _patch_boundary(monkeypatch, recorder)
+
+    parsed = ir.parse_ui_intent(
+        _wire(
+            "add_to_cart", {"variant_id": "gid://shopify/ProductVariant/53511605420323"}
+        )
+    )
+    events = await _collect(ir.run_direct_intent(session_id="s1", parsed=parsed))
+    failed = next(e for e in events if e.event == "intent_failed")
+    assert failed.data["code"] == "intent_tool_failed"
+    assert failed.data["message"] == (
+        "The product 'CoreFlex Tee - Mehendi - L' is already sold out."
+    )
+    assert not any(e.event == "ui_op" for e in events)
+    assert events[-1].data["session_status"] == "ACTIVE"
+
+
+async def test_ui_intents_config_overrides_names_and_labels(monkeypatch):
+    """A template's ``configurations.ui_intents`` renames the cart tools,
+    state keys, and checkout label without code changes; unset roles keep
+    the UCP defaults (get_cart below stays the default name)."""
+    template = _template()
+    template.configurations.ui_intents = UiIntentsConfig(
+        tools={"create_cart": "shop_cart_create", "update_cart": "shop_cart_update"},
+        state_keys={"cart_id": "shop_cart_id"},
+        labels={"checkout": "Go to checkout"},
+    )
+    existing = _cart_payload([_cart_line("gid://shopify/ProductVariant/9", 1)])
+    updated = _cart_payload(
+        [
+            _cart_line("gid://shopify/ProductVariant/9", 1),
+            _cart_line("gid://shopify/ProductVariant/7", 1, title="Leggings"),
+        ]
+    )
+    recorder = _Recorder(
+        {"get_cart": [_envelope(existing)], "shop_cart_update": [_envelope(updated)]}
+    )
+    _patch_boundary(
+        monkeypatch,
+        recorder,
+        template=template,
+        # cart id lives under the RENAMED state key — the default key being
+        # absent proves the driver read the configured one.
+        initial_state={"shop_cart_id": "gid://shopify/Cart/c1?key=k"},
+    )
+
+    parsed = ir.parse_ui_intent(
+        _wire("add_to_cart", {"variant_id": "gid://shopify/ProductVariant/7"})
+    )
+    events = await _collect(ir.run_direct_intent(session_id="s1", parsed=parsed))
+
+    # Existing cart (found under the renamed key) → get_cart (default name,
+    # role unset) then the RENAMED update tool. create path never fires.
+    assert [d[0] for d in recorder.dispatched] == ["get_cart", "shop_cart_update"]
+    op = next(e for e in events if e.event == "ui_op").data["op"]
+    assert op["type"] == "CartView"
+    assert op["props"]["checkout"]["label"] == "Go to checkout"
+
+
+def test_agent_prunes_data_bound_components_without_v2():
+    """Catalog-version negotiation: a session that didn't declare v2 loses
+    the data-bound components from the allowlist (prompt + show ops both
+    gate on it); a v2 session keeps them."""
+    v1_agent = ChatAgent(
+        session_id="s1", template=_template(), llm=None, catalog_version=None
+    )
+    assert v1_agent.ui_allowlist & {"ProductCard", "ProductGrid", "CartView"} == set()
+    v2_agent = ChatAgent(
+        session_id="s1", template=_template(), llm=None, catalog_version="v2"
+    )
+    assert {"ProductCard", "ProductGrid", "CartView"} <= v2_agent.ui_allowlist
+
+
+def test_agent_show_resolver_gated_on_v2():
+    assert (
+        ChatAgent(
+            session_id="s1", template=_template(), llm=None, catalog_version=None
+        )._show_resolver()
+        is None
+    )
+    assert (
+        ChatAgent(
+            session_id="s1", template=_template(), llm=None, catalog_version="v2"
+        )._show_resolver()
+        is not None
+    )
+
+
+async def test_ended_session_fails_terminally(monkeypatch):
+    recorder = _Recorder({})
+    ended = _session()
+    ended.status = ChatSessionStatus.ENDED
+    _patch_boundary(monkeypatch, recorder, session=ended)
+
+    parsed = ir.parse_ui_intent(_wire("add_to_cart", {"variant_id": "v1"}))
+    events = await _collect(ir.run_direct_intent(session_id="s1", parsed=parsed))
+    assert [e.event for e in events] == ["error", "turn_end"]
+    assert events[1].data["session_status"] == "FAILED"
+    assert recorder.dispatched == []
+
+
+def test_add_to_cart_payload_accepts_widget_shape():
+    """ProductCard sends product_id alongside variant_id/qty (RFC-001 widget
+    shape); the schema must accept it (regression: extra_forbidden 422)."""
+    from app.ai.voice.agents.breeze_buddy.assist.commerce.ucp.intents import (
+        AddToCartPayload,
+        RemoveLinePayload,
+        SetQtyPayload,
+    )
+
+    p = AddToCartPayload.model_validate(
+        {
+            "variant_id": "gid://shopify/ProductVariant/54224673210659",
+            "qty": 1,
+            "product_id": "gid://shopify/Product/9967507833123",
+        }
+    )
+    assert p.product_id and p.qty == 1
+
+    r = RemoveLinePayload.model_validate(
+        {
+            "line_id": "line-1",
+            "variant_id": "gid://shopify/ProductVariant/1",
+            "cart_id": "gid://shopify/Cart/x?key=y",
+        }
+    )
+    assert r.line_id == "line-1"
+
+    s = SetQtyPayload.model_validate(
+        {
+            "line_id": "line-1",
+            "qty": 3,
+            "variant_id": "gid://shopify/ProductVariant/1",
+            "cart_id": "gid://shopify/Cart/x?key=y",
+        }
+    )
+    assert s.qty == 3
+
+
+def test_checkout_page_url_config_overrides_continue_url():
+    """ui_intents.urls.checkout_page (2026-08-03): a configured fixed
+    destination (e.g. the storefront /cart page — the CartView cookie
+    sync makes it show the built cart) WINS over the tool's
+    checkout-bound continue_url; unset keeps continue_url (today's
+    default — the template does NOT set it yet)."""
+    from app.ai.voice.agents.breeze_buddy.assist.commerce.ucp.intents import (
+        _cart_view_show_op,
+        resolve_cart_config,
+    )
+
+    template = _template()
+    template.configurations.ui_intents = UiIntentsConfig(
+        urls={"checkout_page": "https://shop.example/cart"}
+    )
+    assert (
+        resolve_cart_config(template).checkout_page_url == "https://shop.example/cart"
+    )
+
+    class _Agent:
+        agent_state: dict = {}
+        template = None
+
+    agent = _Agent()
+    agent.template = template
+    result = _envelope(
+        {**_cart_payload([]), "continue_url": "https://shop.example/checkouts/abc"}
+    )
+    op = _cart_view_show_op("update_cart", result, agent)
+    assert op["props"]["checkout"]["url"] == "https://shop.example/cart"
+
+    # Unset → continue_url keeps winning (current live behavior).
+    template.configurations.ui_intents = None
+    op = _cart_view_show_op("update_cart", result, agent)
+    assert op["props"]["checkout"]["url"] == "https://shop.example/checkouts/abc"
+
+
+class TestCartLineIntegrity:
+    """``update_cart`` REPLACES the cart with the set we send, so how the
+    desired set is built is a data-loss surface, not a formatting detail."""
+
+    def test_unencodable_line_raises_instead_of_being_dropped(self):
+        from app.ai.voice.agents.breeze_buddy.assist.commerce.ucp.intents import (
+            UnaddressableCartLine,
+            _desired_line_items,
+        )
+
+        # A line the gateway ships without item.id (bundle / gift wrap), and
+        # one whose quantity arrives as a string — silently skipping either
+        # would DELETE it from the shopper's cart.
+        for bad in (
+            {"id": "line-2", "item": {}, "quantity": 1},
+            {"id": "line-2", "item": {"id": "v2"}, "quantity": "2"},
+        ):
+            lines = [
+                {"id": "line-1", "item": {"id": "v1"}, "quantity": 1},
+                bad,
+            ]
+            with pytest.raises(UnaddressableCartLine):
+                _desired_line_items(lines)
+
+    def test_desired_set_pairs_each_entry_with_its_line_id(self):
+        from app.ai.voice.agents.breeze_buddy.assist.commerce.ucp.intents import (
+            _desired_line_items,
+        )
+
+        lines = [
+            {"id": "line-A", "item": {"id": "v9"}, "quantity": 1},
+            {"id": "line-B", "item": {"id": "v9"}, "quantity": 3},
+        ]
+        pairs = _desired_line_items(lines)
+        assert [line_id for line_id, _ in pairs] == ["line-A", "line-B"]
+        # Same variant on both lines — the pairing is the only way to tell
+        # them apart downstream.
+        assert all(e["item"]["id"] == "v9" for _, e in pairs)
+
+
+class TestDuplicateVariantLines:
+    """A cart may hold two lines of the SAME variant (different
+    attributes). Mutations select on the line id; keying on the variant
+    would hit both."""
+
+    @staticmethod
+    def _apply(payload, lines):
+        """Mirror of the driver's mutation block against a desired set."""
+        from app.ai.voice.agents.breeze_buddy.assist.commerce.ucp.intents import (
+            RemoveLinePayload,
+            _desired_line_items,
+        )
+
+        pairs = _desired_line_items(lines)
+        new_qty = 0 if isinstance(payload, RemoveLinePayload) else payload.qty
+        for line_id, entry in pairs:
+            if line_id is not None and line_id == payload.line_id:
+                entry["quantity"] = new_qty
+                break
+        return [e for _, e in pairs if e["quantity"] > 0]
+
+    def test_remove_one_line_keeps_its_same_variant_sibling(self):
+        from app.ai.voice.agents.breeze_buddy.assist.commerce.ucp.intents import (
+            RemoveLinePayload,
+        )
+
+        lines = [
+            {"id": "line-A", "item": {"id": "v9"}, "quantity": 1},
+            {"id": "line-B", "item": {"id": "v9"}, "quantity": 3},
+        ]
+        out = self._apply(RemoveLinePayload(line_id="line-A"), lines)
+        assert out == [{"item": {"id": "v9"}, "quantity": 3}]
+
+    def test_set_qty_touches_only_the_named_line(self):
+        from app.ai.voice.agents.breeze_buddy.assist.commerce.ucp.intents import (
+            SetQtyPayload,
+        )
+
+        lines = [
+            {"id": "line-A", "item": {"id": "v9"}, "quantity": 1},
+            {"id": "line-B", "item": {"id": "v9"}, "quantity": 3},
+        ]
+        out = self._apply(SetQtyPayload(line_id="line-A", qty=5), lines)
+        assert out == [
+            {"item": {"id": "v9"}, "quantity": 5},
+            {"item": {"id": "v9"}, "quantity": 3},
+        ]

--- a/tests/assist/test_commerce_media.py
+++ b/tests/assist/test_commerce_media.py
@@ -1,0 +1,166 @@
+"""Unit pins for the product-media seam.
+
+Two layers, tested where each one lives:
+
+* ``ucp/media.py`` — the protocol-level decision (UCP media wins when it
+  already carries a gallery; otherwise ask the connectors) and fail-open.
+* ``connectors/shopify/media.py`` — handle-URL derivation, the only
+  Shopify knowledge in the flavor. The live storefront fetch is covered by
+  the wire check, not here.
+"""
+
+import pytest
+
+from app.ai.voice.agents.breeze_buddy.assist.commerce.connectors.shopify.media import (
+    _handle_url,
+)
+from app.ai.voice.agents.breeze_buddy.assist.commerce.ucp.media import (
+    resolve_product_media,
+)
+
+
+class TestShopifyHandleUrl:
+    def test_plain_product_url(self):
+        assert (
+            _handle_url("https://shop.example/products/flowmesh-leggings")
+            == "https://shop.example/products/flowmesh-leggings.json"
+        )
+
+    def test_url_with_collection_prefix_and_query(self):
+        assert (
+            _handle_url("https://shop.example/collections/sale/products/tee?variant=1")
+            == "https://shop.example/products/tee.json"
+        )
+
+    def test_non_product_paths_and_junk(self):
+        assert _handle_url("https://shop.example/pages/contact") is None
+        assert _handle_url("https://shop.example/products/") is None
+        assert _handle_url("not a url") is None
+
+
+class TestResolveDecision:
+    @pytest.mark.asyncio
+    async def test_rich_ucp_media_is_a_noop(self):
+        product = {
+            "url": "https://shop.example/products/x",
+            "media": [{"url": "a"}, {"url": "b"}],
+        }
+        # session=None would crash any fetch attempt — proving no fetch runs.
+        assert await resolve_product_media(None, product) is None
+
+    @pytest.mark.asyncio
+    async def test_no_url_or_no_session_fails_open(self):
+        assert await resolve_product_media(None, {"media": [{"url": "a"}]}) is None
+        assert (
+            await resolve_product_media(
+                None, {"url": "https://shop.example/products/x", "media": []}
+            )
+            is None
+        )
+
+
+class TestProtocolLayerHasNoConnector:
+    """The UCP layer must not name a platform — the whole point of the
+    connectors/ split. A regression here means platform code crept back
+    into the protocol module."""
+
+    def test_ucp_media_module_is_platform_blind(self):
+        from pathlib import Path
+
+        import app.ai.voice.agents.breeze_buddy.assist.commerce.ucp as ucp_pkg
+
+        for path in Path(ucp_pkg.__file__).parent.glob("*.py"):
+            source = path.read_text().lower()
+            assert (
+                "shopify" not in source
+            ), f"{path.name} names a platform; it belongs in connectors/"
+
+
+class TestOutboundFetchIsGated:
+    """``product.url`` is upstream-controlled data driving a request the
+    SERVER makes, so the host is gated, not just the path shape."""
+
+    def test_ip_literal_hosts_that_could_reach_infra_are_refused(self):
+        for hostile in (
+            "http://169.254.169.254/products/x",  # cloud metadata endpoint
+            "https://127.0.0.1/products/x",
+            "https://10.0.0.5/products/x",
+            "https://192.168.1.1/products/x",
+            "https://[::1]/products/x",
+            "https://0.0.0.0/products/x",
+        ):
+            assert _handle_url(hostile) is None, hostile
+
+    def test_public_ip_literal_is_allowed(self):
+        assert (
+            _handle_url("https://93.184.216.34/products/x")
+            == "https://93.184.216.34/products/x.json"
+        )
+
+    def test_userinfo_is_stripped_not_forwarded_or_logged(self):
+        built = _handle_url("https://user:secret@shop.example/products/x")
+        assert built == "https://shop.example/products/x.json"
+        assert "secret" not in built
+
+    def test_explicit_non_https_port_is_refused(self):
+        assert _handle_url("https://shop.example:8000/products/x") is None
+        assert _handle_url("https://shop.example:9200/products/x") is None
+        # The default port, stated explicitly, is still fine.
+        assert (
+            _handle_url("https://shop.example:443/products/x")
+            == "https://shop.example/products/x.json"
+        )
+
+    @pytest.mark.asyncio
+    async def test_name_resolving_to_a_private_address_is_not_fetched(
+        self, monkeypatch
+    ):
+        from app.ai.voice.agents.breeze_buddy.assist.commerce.connectors.shopify import (  # noqa: E501
+            media as shopify_media,
+        )
+
+        class _Session:
+            def get(self, *_a, **_k):
+                raise AssertionError("must not fetch a private-resolving host")
+
+        async def _private(_host):
+            return False
+
+        monkeypatch.setattr(shopify_media, "_host_resolves_public", _private)
+        product = {"url": "https://evil.example/products/x", "media": []}
+        assert await shopify_media.resolve_gallery(_Session(), product) is None
+
+    @pytest.mark.asyncio
+    async def test_redirects_are_not_followed(self, monkeypatch):
+        """A 302 to an internal host would sidestep every check above."""
+        from app.ai.voice.agents.breeze_buddy.assist.commerce.connectors.shopify import (  # noqa: E501
+            media as shopify_media,
+        )
+
+        seen = {}
+
+        class _Resp:
+            status = 404
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *_a):
+                return False
+
+            async def json(self, **_k):
+                return {}
+
+        class _Session:
+            def get(self, url, **kwargs):
+                seen.update(url=url, **kwargs)
+                return _Resp()
+
+        async def _public(_host):
+            return True
+
+        monkeypatch.setattr(shopify_media, "_host_resolves_public", _public)
+        await shopify_media.resolve_gallery(
+            _Session(), {"url": "https://shop.example/products/x", "media": []}
+        )
+        assert seen["allow_redirects"] is False

--- a/tests/assist/test_commerce_schemas.py
+++ b/tests/assist/test_commerce_schemas.py
@@ -1,0 +1,493 @@
+"""Tests for the commerce catalog group + data-bound prompt rendering
+(catalog v2, RFC-001).
+
+Covers: lazy group registration / render order / data_bound flags, the
+UCP-shape lifts on the sub-schemas, allowlist resolution with the
+commerce group, and the "### Data-bound components" prompt subsection —
+including the no-regression guarantee for v1 templates (§9.3).
+"""
+
+from __future__ import annotations
+
+from app.ai.voice.agents.breeze_buddy.assist.commerce.ucp.schemas import (
+    CartLineP,
+    CartTotalP,
+    MoneyP,
+    ProductP,
+)
+from app.ai.voice.agents.breeze_buddy.template.ui_catalog import (
+    PRIMITIVE_GROUPS,
+    PRIMITIVE_RENDER_ORDER,
+    UI_CATALOG,
+    data_bound_names,
+    ensure_group_loaded,
+    group_for,
+    is_data_bound,
+    resolve_allowlist,
+)
+from app.ai.voice.agents.breeze_buddy.template.ui_prompt import (
+    render_primitives_section,
+)
+
+# Registration is a lazy-import side effect; the schemas import above
+# already triggered it, but go through the public loader anyway (it must
+# be idempotent).
+ensure_group_loaded("commerce")
+
+COMMERCE = {"ProductCard", "ProductGrid", "CartView", "ProductDetail", "LinkButton"}
+# The subset the LLM is prompted with — ProductDetail is server_only,
+# ProductCard was retired to server_only 2026-07-30 (a ProductGrid of one
+# IS a card now that layout is count-derived), and LinkButton is
+# render_ui-only (text_channel=False): all registered + allowlisted, but
+# never rendered into the text-channel prompt sections.
+PROMPTED = COMMERCE - {"ProductDetail", "ProductCard", "LinkButton"}
+
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
+
+
+def test_commerce_components_registered_in_catalog():
+    for name in COMMERCE:
+        assert name in UI_CATALOG
+        assert name in PRIMITIVE_RENDER_ORDER
+        assert group_for(name) == "commerce"
+
+
+def test_commerce_group_lists_exactly_the_registered_components():
+    assert set(PRIMITIVE_GROUPS["commerce"]) == COMMERCE
+
+
+def test_data_bound_flags():
+    # LinkButton is the literal exception: commerce group, but its props
+    # are model-authored (URL trust-checked in render_ui, not bound).
+    assert data_bound_names() == COMMERCE - {"LinkButton"}
+    assert is_data_bound("ProductGrid")
+    assert not is_data_bound("LinkButton")
+    assert not is_data_bound("Tile")
+    assert not is_data_bound("NoSuchThing")
+
+
+def test_resolve_allowlist_with_commerce_group():
+    allowlist = resolve_allowlist(enabled_groups=["core", "commerce"])
+    assert COMMERCE <= allowlist
+    assert "Tile" not in allowlist  # composite not enabled
+
+
+def test_resolve_default_excludes_commerce():
+    assert resolve_allowlist() & COMMERCE == set()
+
+
+# ---------------------------------------------------------------------------
+# Sub-schema UCP lifts
+# ---------------------------------------------------------------------------
+
+
+def test_cart_line_lifts_raw_ucp_shape():
+    line = CartLineP.model_validate(
+        {
+            "id": "line1",
+            "quantity": 3,
+            "item": {
+                "id": "gid://shopify/ProductVariant/5",
+                "title": "Tee - L",
+                "image_url": "https://cdn.example/tee.jpg",
+                "price": 899.0,
+            },
+            "totals": [
+                {"type": "subtotal", "amount": 2697.0},
+                {"type": "total", "amount": 2697.0},
+            ],
+        }
+    )
+    assert line.title == "Tee - L"
+    assert line.qty == 3
+    assert line.line_total.amount == 2697.0
+    assert line.variant_id == "gid://shopify/ProductVariant/5"
+    assert line.image is not None and str(line.image.src).endswith("tee.jpg")
+
+
+def test_cart_line_canonical_shape_passes_through():
+    line = CartLineP.model_validate(
+        {
+            "id": "line1",
+            "title": "Tee",
+            "qty": 1,
+            "line_total": {"amount": 899.0, "currency": "INR"},
+        }
+    )
+    assert line.line_total.currency == "INR"
+
+
+# ---------------------------------------------------------------------------
+# Prompt rendering — data-bound subsection
+# ---------------------------------------------------------------------------
+
+
+def test_data_bound_subsection_renders_when_allowlisted():
+    section = render_primitives_section(
+        resolve_allowlist(enabled_groups=["core", "composite", "commerce"])
+    )
+    assert "### Data-bound components" in section
+    for name in PROMPTED:
+        assert f"**{name}**" in section
+    # server_only: allowlisted but invisible to the LLM.
+    assert "**ProductDetail**" not in section
+    # The show-op grammar + exactly one example.
+    assert '"$tool:<tool_name>#<json-pointer>"' in section
+    assert section.count('"op":"show"') == 2  # grammar skeleton + 1 example
+    assert '"bind":{"products":"$tool:search_catalog#/products"}' in section
+
+
+def test_data_bound_subsection_stays_within_token_budget():
+    section = render_primitives_section(
+        resolve_allowlist(enabled_groups=["core", "composite", "commerce"])
+    )
+    start = section.index("### Data-bound components")
+    subsection = section[start : section.index("Action shape")].rstrip()
+    assert len(subsection.splitlines()) <= 40
+
+
+def test_data_bound_components_have_no_add_style_entry():
+    """Commerce components must not render as ordinary add-op entries —
+    the LLM reaches them only via `show`."""
+    section = render_primitives_section(
+        resolve_allowlist(enabled_groups=["core", "commerce"])
+    )
+    head, _, _tail = section.partition("### Data-bound components")
+    for name in COMMERCE:
+        assert f"**{name}**" not in head
+
+
+def test_v1_section_unchanged_without_commerce():
+    """§9.3 — no prompt regression for v1 templates: the rendered section
+    for a commerce-free allowlist is byte-identical whether or not the
+    commerce group exists in the catalog (i.e. no subsection leaks)."""
+    section = render_primitives_section(
+        resolve_allowlist(enabled_groups=["core", "composite"])
+    )
+    assert "### Data-bound components" not in section
+    assert "ProductGrid" not in section
+    assert "show" not in section.split("Action shape")[0].lower() or True
+    # The classic anchors are still present and ordered.
+    assert section.index("**Tile**") < section.index("**Carousel**")
+
+
+# ---------------------------------------------------------------------------
+# Money amount normalization (live UCP storefront shape)
+# ---------------------------------------------------------------------------
+
+
+def test_money_accepts_comma_grouped_amount_string():
+    # Live UCP storefronts emit INR-grouped amount strings ("1,699.00")
+    # which fail bare pydantic float parsing — the projection strips the
+    # grouping commas (dot stays the decimal separator on the wire).
+    money = MoneyP.model_validate({"amount": "1,699.00", "currency": "INR"})
+    assert money.amount == 1699.0
+    plain = MoneyP.model_validate({"amount": "934.00"})
+    assert plain.amount == 934.0
+
+
+def test_cart_total_accepts_comma_grouped_amount_string():
+    total = CartTotalP.model_validate(
+        {"type": "total", "amount": "2,697.00", "currency": "INR"}
+    )
+    assert total.amount == 2697.0
+
+
+# ---------------------------------------------------------------------------
+# Variant projection (inline picker feed)
+# ---------------------------------------------------------------------------
+
+_UCP_PRODUCT_BASE = {
+    "id": "gid://shopify/Product/1",
+    "title": "Trail Shoe",
+    "price_range": {"min": {"amount": 4999.0, "currency": "INR"}},
+}
+
+
+def test_single_available_variant_projects_default_id_and_options():
+    # 2026-07-30: options ALWAYS project (Add-to-cart confirms through the
+    # picker even for one-available products); default_variant_id still
+    # marks the single available choice for data-less fallbacks.
+    product = ProductP.model_validate(
+        {
+            **_UCP_PRODUCT_BASE,
+            "variants": [
+                {"id": "gid://shopify/ProductVariant/1", "availability": "available"},
+                {"id": "gid://shopify/ProductVariant/2", "availability": "sold_out"},
+            ],
+        }
+    )
+    assert product.default_variant_id == "gid://shopify/ProductVariant/1"
+    assert [v.id for v in product.variants] == [
+        "gid://shopify/ProductVariant/1",
+        "gid://shopify/ProductVariant/2",
+    ]
+
+
+def test_multi_variant_projects_picker_options_with_availability():
+    product = ProductP.model_validate(
+        {
+            **_UCP_PRODUCT_BASE,
+            "variants": [
+                {
+                    "id": "gid://shopify/ProductVariant/1",
+                    "title": "S / Black",
+                    "availability": "available",
+                    "price": {"amount": "4,999.00", "currency": "INR"},
+                },
+                {
+                    "id": "gid://shopify/ProductVariant/2",
+                    "title": "M / Black",
+                    "availability": "sold_out",
+                },
+                {"id": "gid://shopify/ProductVariant/3", "title": "L / Black"},
+                "not-a-dict",  # malformed entry filtered, never fatal
+                {"title": "no id — filtered"},
+            ],
+        }
+    )
+    assert product.default_variant_id is None
+    assert [v.id for v in product.variants] == [
+        "gid://shopify/ProductVariant/1",
+        "gid://shopify/ProductVariant/2",
+        "gid://shopify/ProductVariant/3",
+    ]
+    assert [v.available for v in product.variants] == [True, False, True]
+    assert product.variants[0].price is not None
+    assert product.variants[0].price.amount == 4999.0  # comma-grouping stripped
+
+
+def test_variant_projection_caps_option_count():
+    product = ProductP.model_validate(
+        {
+            **_UCP_PRODUCT_BASE,
+            "variants": [
+                {"id": f"gid://shopify/ProductVariant/{i}"} for i in range(40)
+            ],
+        }
+    )
+    assert len(product.variants) == 24
+
+
+def test_variant_availability_nested_object_shape():
+    """Live Beyond Bound wire (2026-07-28): variant availability arrives
+    as a NESTED object — {"availability": {"available": bool}}. A sold-out
+    size must project available=False so the picker disables it (the
+    CoreFlex Tee regression: L rendered buyable, add came back empty)."""
+    product = ProductP.model_validate(
+        {
+            **_UCP_PRODUCT_BASE,
+            "variants": [
+                {
+                    "id": "gid://shopify/ProductVariant/1",
+                    "title": "S",
+                    "availability": {"available": True},
+                },
+                {
+                    "id": "gid://shopify/ProductVariant/2",
+                    "title": "M",
+                    "availability": {"available": True},
+                },
+                {
+                    "id": "gid://shopify/ProductVariant/3",
+                    "title": "L",
+                    "availability": {"available": False},
+                },
+                {
+                    "id": "gid://shopify/ProductVariant/4",
+                    "title": "XL",
+                    "availability": {"state": "sold_out"},
+                },
+            ],
+        }
+    )
+    assert [v.available for v in product.variants] == [True, True, False, False]
+    # And the single-available projection respects the nested shape too.
+    single = ProductP.model_validate(
+        {
+            **_UCP_PRODUCT_BASE,
+            "variants": [
+                {
+                    "id": "gid://shopify/ProductVariant/1",
+                    "availability": {"available": True},
+                },
+                {
+                    "id": "gid://shopify/ProductVariant/2",
+                    "availability": {"available": False},
+                },
+            ],
+        }
+    )
+    assert single.default_variant_id == "gid://shopify/ProductVariant/1"
+    assert [v.available for v in single.variants] == [True, False]
+
+
+# ---------------------------------------------------------------------------
+# ProductDetailP projection (full-panel detail overlay)
+# ---------------------------------------------------------------------------
+
+
+def test_product_detail_lifts_live_get_product_shape():
+    """Mirror of the live Beyond Bound get_product `product` payload
+    (2026-07-28): {html} description, price_range/list_price_range,
+    product-level media, variants with nested availability."""
+    from app.ai.voice.agents.breeze_buddy.assist.commerce.ucp.schemas import (
+        ProductDetailP,
+    )
+
+    detail = ProductDetailP.model_validate(
+        {
+            "id": "gid://shopify/Product/1",
+            "title": "Bundle of 3 Socks - Black",
+            "description": {
+                "html": "<p>Overview</p><p>Microfibre <b>comfort</b></p><ul><li>Anti-slip grip</li></ul>"
+            },
+            "url": "https://www.thebeyondbound.com/products/socks",
+            "price_range": {"min": {"amount": "909.00", "currency": "INR"}},
+            "list_price_range": {"min": {"amount": "1,299.00", "currency": "INR"}},
+            "media": [
+                {"type": "image", "url": "https://cdn.example/a.jpg"},
+                {"type": "video", "url": "https://cdn.example/clip.mp4"},
+                {"type": "image", "url": "https://cdn.example/b.jpg"},
+            ],
+            "variants": [
+                {
+                    "id": "gid://shopify/ProductVariant/1",
+                    "title": "S",
+                    "availability": {"available": True},
+                    "price": {"amount": "909.00", "currency": "INR"},
+                },
+                {
+                    "id": "gid://shopify/ProductVariant/2",
+                    "title": "M",
+                    "availability": {"available": False},
+                },
+                "not-a-dict",
+            ],
+        }
+    )
+    # Block tags become line breaks (merchant formatting survives the
+    # strip); inline tags drop; the widget renders pre-wrap.
+    assert detail.description == "Overview\n\nMicrofibre comfort\n\nAnti-slip grip"
+    assert detail.price is not None and detail.price.amount == 909.0
+    assert detail.compare_at is not None and detail.compare_at.amount == 1299.0
+    # Video entries are dropped; only images feed the gallery.
+    assert [str(m.src) for m in detail.images] == [
+        "https://cdn.example/a.jpg",
+        "https://cdn.example/b.jpg",
+    ]
+    # ALL well-formed variants project (sold-out included — the picker
+    # disables them), malformed entries dropped.
+    assert [(v.id, v.available) for v in detail.variants] == [
+        ("gid://shopify/ProductVariant/1", True),
+        ("gid://shopify/ProductVariant/2", False),
+    ]
+    assert detail.default_variant_id is None
+
+
+def test_description_repairs_upstream_flattened_boundaries():
+    """Live BB Bottle shape (2026-07-29): the UCP gateway ships some
+    descriptions ALREADY tag-stripped with block boundaries lost — bullet
+    emojis glued onto the previous word ("go🔥❄️ Keeps") and paragraphs
+    fused ("youFrom"). The repair heuristics restore line structure
+    without touching camel-case brand names."""
+    from app.ai.voice.agents.breeze_buddy.assist.commerce.ucp.schemas import (
+        _html_to_display_text,
+    )
+
+    flattened = (
+        "Perfect from gym to boardrooms. Features: 🖤 1 litre capacity – "
+        "wherever you go🔥❄️ Keeps drinks hot for 12 hours – Your way🛡️ "
+        "Stainless steel body – rust-resistant🎯 Leak-proof – Designed to "
+        "move with youFrom early morning workouts, it matches your pace. "
+        "Disclaimer: Colours may vary."
+    )
+    assert _html_to_display_text(flattened) == (
+        "Perfect from gym to boardrooms. Features: 🖤 1 litre capacity – "
+        "wherever you go\n"
+        "🔥❄️ Keeps drinks hot for 12 hours – Your way\n"
+        "🛡️ Stainless steel body – rust-resistant\n"
+        "🎯 Leak-proof – Designed to move with you\n"
+        "\n"
+        "From early morning workouts, it matches your pace. "
+        "Disclaimer: Colours may vary."
+    )
+    # Camel-case brand names and inline emoji (after a space) are intact.
+    assert _html_to_display_text("an iPhone case") == "an iPhone case"
+    assert _html_to_display_text("watch on YouTube") == "watch on YouTube"
+    assert _html_to_display_text("Good vibes ✨ always") == "Good vibes ✨ always"
+
+
+def test_product_detail_single_variant_sets_default_id():
+    from app.ai.voice.agents.breeze_buddy.assist.commerce.ucp.schemas import (
+        ProductDetailP,
+    )
+
+    detail = ProductDetailP.model_validate(
+        {
+            "id": "gid://shopify/Product/1",
+            "title": "Socks",
+            "variants": [{"id": "gid://shopify/ProductVariant/9"}],
+        }
+    )
+    assert detail.default_variant_id == "gid://shopify/ProductVariant/9"
+    assert len(detail.variants) == 1
+
+
+def test_lone_default_title_variant_projects_direct_add_shape():
+    """Shopify's variantless-product pseudo-variant (live 2026-08-03:
+    one-size socks rendered a nonsense "Choose an option → Default Title"
+    picker): a lone "Default Title" variant projects variants=[] +
+    default_variant_id — the widget's existing direct-add path. A real
+    lone variant (an actual named option) keeps projecting for the
+    confirm picker."""
+    product = ProductP.model_validate(
+        {
+            **_UCP_PRODUCT_BASE,
+            "variants": [
+                {
+                    "id": "gid://shopify/ProductVariant/77",
+                    "title": "Default Title",
+                    "availability": "available",
+                }
+            ],
+        }
+    )
+    assert product.variants == []
+    assert product.default_variant_id == "gid://shopify/ProductVariant/77"
+
+    # Contrast: a real named lone variant still ships its option.
+    real = ProductP.model_validate(
+        {
+            **_UCP_PRODUCT_BASE,
+            "variants": [
+                {
+                    "id": "gid://shopify/ProductVariant/78",
+                    "title": "One Size / Black",
+                    "availability": "available",
+                }
+            ],
+        }
+    )
+    assert [v.id for v in real.variants] == ["gid://shopify/ProductVariant/78"]
+
+
+def test_product_detail_lone_default_title_hides_option_pills():
+    from app.ai.voice.agents.breeze_buddy.assist.commerce.ucp.schemas import (
+        ProductDetailP,
+    )
+
+    detail = ProductDetailP.model_validate(
+        {
+            "id": "gid://shopify/Product/9",
+            "title": "Peach in Progress – White",
+            "variants": [
+                {"id": "gid://shopify/ProductVariant/9", "title": "Default Title"}
+            ],
+        }
+    )
+    assert detail.variants == []
+    assert detail.default_variant_id == "gid://shopify/ProductVariant/9"

--- a/tests/assist/test_commerce_upsell.py
+++ b/tests/assist/test_commerce_upsell.py
@@ -1,0 +1,163 @@
+"""Unit pins for the cart-upsell deterministic curation pass
+(assist/commerce/ucp/upsell.py): size-continuity filtering + feature-variant
+stamping + already-in-cart exclusion. The LLM picker and the search
+round-trip are exercised live (e2e wire check), not here."""
+
+import pytest
+
+from app.ai.voice.agents.breeze_buddy.assist.commerce.ucp.upsell import (
+    build_upsell_selectors,
+    match_size_variant,
+)
+
+
+def _product(pid, title, sizes_available=None, options=None):
+    """Candidate with a Size axis; ``sizes_available`` maps label → bool."""
+    sizes_available = sizes_available or {}
+    return {
+        "id": pid,
+        "title": title,
+        "options": (
+            options
+            if options is not None
+            else [{"name": "Size", "values": [{"label": s} for s in sizes_available]}]
+        ),
+        "variants": [
+            {
+                "id": f"{pid}-{label}",
+                "title": label,
+                "options": [{"name": "Size", "label": label}],
+                "availability": {"available": avail},
+            }
+            for label, avail in sizes_available.items()
+        ],
+    }
+
+
+ADDED_TOKENS = {"effortless", "leggings", "black", "xl"}
+
+
+class TestMatchSizeVariant:
+    def test_available_size_match_returns_variant_id(self):
+        p = _product("p1", "Zipper Vest", {"M": True, "XL": True})
+        assert match_size_variant(p, ADDED_TOKENS) == "p1-XL"
+
+    def test_matching_size_sold_out_drops(self):
+        from app.ai.voice.agents.breeze_buddy.assist.commerce.ucp import upsell
+
+        p = _product("p1", "Zipper Vest", {"M": True, "XL": False})
+        assert match_size_variant(p, ADDED_TOKENS) is upsell._DROP
+
+    def test_no_size_axis_keeps_unstamped(self):
+        p = _product("p1", "Sipper Bottle", options=[])
+        assert match_size_variant(p, ADDED_TOKENS) is None
+
+    def test_disjoint_size_vocabulary_keeps_unstamped(self):
+        # Sock sizing ("Free Size") shares no label with the added apparel
+        # size — keep the product, let the picker handle the choice.
+        p = _product("p1", "Crew Socks", {"Free Size": True})
+        assert match_size_variant(p, ADDED_TOKENS) is None
+
+
+class TestBuildUpsellSelectors:
+    def test_stamps_filters_and_excludes_cart(self):
+        products = [
+            _product("keep", "Zipper Vest", {"XL": True}),
+            _product("soldout", "Mesh Top", {"XL": False}),
+            _product("incart", "Effortless Leggings - Black", {"XL": True}),
+            _product("nosize", "Sipper Bottle", options=[]),
+        ]
+        selectors = build_upsell_selectors(
+            products,
+            added_tokens=ADDED_TOKENS,
+            cart_titles=["Effortless Leggings - Black - XL"],
+        )
+        assert selectors == [
+            {"id": "keep", "feature_variant": "keep-XL"},
+            {"id": "nosize"},
+        ]
+
+    def test_caps_at_max_items(self):
+        products = [_product(f"p{i}", f"Vest {i}", {"XL": True}) for i in range(10)]
+        selectors = build_upsell_selectors(
+            products, added_tokens=ADDED_TOKENS, cart_titles=[], max_items=3
+        )
+        assert len(selectors) == 3
+
+    def test_malformed_entries_skipped(self):
+        selectors = build_upsell_selectors(
+            [None, {"title": "no id"}, 42],
+            added_tokens=ADDED_TOKENS,
+            cart_titles=[],
+        )
+        assert selectors == []
+
+
+class TestOptInGate:
+    """The upsell is merchandising, so it is OFF unless the template asks
+    for it (``flavor.ucp.features.upsell``). Enabling the commerce flavor
+    must not silently start spending an LLM call + catalog search on every
+    add_to_cart, nor put recommendations a merchant didn't choose into
+    their thread.
+    """
+
+    @staticmethod
+    def _agent(features):
+        from types import SimpleNamespace
+
+        return SimpleNamespace(
+            template=SimpleNamespace(
+                configurations=SimpleNamespace(
+                    ui_intents=None,
+                    flavor={"ucp": SimpleNamespace(connectors=[], features=features)},
+                )
+            )
+        )
+
+    @pytest.mark.asyncio
+    async def test_off_by_default_and_does_no_work(self, monkeypatch):
+        from app.ai.voice.agents.breeze_buddy.assist.commerce.ucp import upsell
+
+        async def _must_not_run(*_a, **_k):
+            raise AssertionError("_run must not be reached when opted out")
+
+        monkeypatch.setattr(upsell, "_run", _must_not_run)
+        # No features block at all, and an explicit false — both stay off.
+        for features in ({}, {"upsell": False}):
+            assert (
+                await upsell.run_cart_upsell(
+                    self._agent(features), None, {}, None, "t1", "update_cart", {}
+                )
+                is None
+            )
+
+    @pytest.mark.asyncio
+    async def test_opted_in_template_runs_it(self, monkeypatch):
+        from app.ai.voice.agents.breeze_buddy.assist.commerce.ucp import upsell
+
+        async def _fake_run(*_a, **_k):
+            return {"op": "add", "type": "ProductGrid"}
+
+        monkeypatch.setattr(upsell, "_run", _fake_run)
+        assert await upsell.run_cart_upsell(
+            self._agent({"upsell": True}), None, {}, None, "t1", "update_cart", {}
+        ) == {"op": "add", "type": "ProductGrid"}
+
+    @pytest.mark.asyncio
+    async def test_missing_template_stays_off(self, monkeypatch):
+        """A caller without a resolvable template must not accidentally
+        opt in — fail closed, not open."""
+        from types import SimpleNamespace
+
+        from app.ai.voice.agents.breeze_buddy.assist.commerce.ucp import upsell
+
+        async def _must_not_run(*_a, **_k):
+            raise AssertionError("_run must not be reached without a template")
+
+        monkeypatch.setattr(upsell, "_run", _must_not_run)
+        assert (
+            await upsell.run_cart_upsell(
+                SimpleNamespace(template=None), None, {}, None, "t1", "update_cart", {}
+            )
+            is None
+        )

--- a/tests/assist/test_intent_payload_contract.py
+++ b/tests/assist/test_intent_payload_contract.py
@@ -1,0 +1,169 @@
+"""Widget ↔ backend ui_intent payload contract (RFC-001 §3.3).
+
+The fixtures in ``fixtures/intent_payloads.json`` are the EXACT payload
+JSON bodies the widget's commerce components build (one list per intent,
+covering every optional-field variant). Every fixture entry MUST parse
+through :func:`parse_ui_intent` — a failure here means the widget and the
+per-intent schemas in ``assist/commerce/ucp/intents.py`` have drifted, which
+is exactly the class of bug that shipped two 422s to shoppers.
+
+NOTE: the fixture file must stay in sync with the loom repo copy at
+``packages/client-sdk/src/lib/chat/__fixtures__/intent_payloads.json`` —
+update both (and both repos' contract tests) when payloads change.
+
+Also guards the ``extra="ignore"`` payload policy: an unknown extra key
+(a newer widget talking to an older server) parses fine, is dropped from
+the model, and logs one structured WARNING naming the dropped keys —
+never their values.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, List, Tuple
+
+import pytest
+
+from app.ai.voice.agents.breeze_buddy.assist.commerce.ucp import intents as ci
+from app.ai.voice.agents.breeze_buddy.chat.intents import router as ir
+
+# Importing ``ci`` registered the commerce policies; keep the public
+# loader idempotent-checked like the sibling test module.
+ir.ensure_flavor_intents(["commerce"])
+
+FIXTURE_PATH = Path(__file__).parent / "fixtures" / "intent_payloads.json"
+
+PAYLOAD_MODELS = {
+    "add_to_cart": ci.AddToCartPayload,
+    "remove_line": ci.RemoveLinePayload,
+    "set_qty": ci.SetQtyPayload,
+    "view_product": ci.ViewProductPayload,
+    "enrich_product": ci.EnrichProductPayload,
+    "checkout": ci.CheckoutPayload,
+}
+
+
+def _load_fixtures() -> Dict[str, List[Dict[str, Any]]]:
+    with FIXTURE_PATH.open(encoding="utf-8") as fh:
+        raw = json.load(fh)
+    return {k: v for k, v in raw.items() if not k.startswith("_")}
+
+
+def _fixture_cases() -> List[Tuple[str, int, Dict[str, Any]]]:
+    return [
+        (intent, i, payload)
+        for intent, payloads in sorted(_load_fixtures().items())
+        for i, payload in enumerate(payloads)
+    ]
+
+
+def test_fixtures_cover_every_registered_commerce_intent():
+    """One fixture list per registered intent — a new intent without a
+    captured emission (or a fixture for a dropped intent) fails here."""
+    assert set(_load_fixtures()) == set(ir.INTENT_POLICY)
+    assert set(_load_fixtures()) == set(PAYLOAD_MODELS)
+
+
+@pytest.mark.parametrize(
+    "intent,variant,payload",
+    _fixture_cases(),
+    ids=[f"{intent}[{i}]" for intent, i, _ in _fixture_cases()],
+)
+def test_widget_emission_parses(intent: str, variant: int, payload: Dict[str, Any]):
+    """Every captured widget payload parses via parse_ui_intent with no
+    IntentValidationError AND with every sent key accepted (nothing
+    silently dropped for TODAY's known emissions)."""
+    parsed = ir.parse_ui_intent(
+        {"intent": intent, "component_id": "pg1", "payload": dict(payload)},
+        enabled_flavors={"commerce"},
+    )
+    assert isinstance(parsed.payload, PAYLOAD_MODELS[intent])
+    # Known fields must be modeled explicitly — a fixture key missing from
+    # the schema would be dropped (drift WARNING in prod); fail loudly here.
+    assert set(payload) <= set(PAYLOAD_MODELS[intent].model_fields)
+    # Round-trip: the modeled values match what the widget sent.
+    dumped = parsed.payload.model_dump(exclude_none=True)
+    for key, value in payload.items():
+        assert dumped[key] == value
+
+
+def test_unknown_extra_key_parses_and_logs_drop(monkeypatch):
+    """extra="ignore" regression guard: a future-widget extra key must not
+    422; it is dropped and one WARNING names the dropped keys (values are
+    never logged)."""
+    warnings: List[str] = []
+
+    class _Recorder:
+        def warning(self, message: str, *args: Any, **kwargs: Any) -> None:
+            warnings.append(message)
+
+    monkeypatch.setattr(ci, "logger", _Recorder())
+
+    parsed = ir.parse_ui_intent(
+        {
+            "intent": "view_product",
+            "component_id": "pg1",
+            "payload": {
+                "product_id": "gid://shopify/Product/1",
+                "title": "Trail Socks",
+                "url": "https://shop.example/products/socks",
+                "future_field": "SECRET-VALUE",
+                "another_new_key": 42,
+            },
+        },
+        enabled_flavors={"commerce"},
+    )
+    assert isinstance(parsed.payload, ci.ViewProductPayload)
+    assert parsed.payload.url == "https://shop.example/products/socks"
+    assert not hasattr(parsed.payload, "future_field")
+    assert "future_field" not in parsed.payload.model_dump()
+
+    assert len(warnings) == 1  # single structured WARNING per request
+    assert "ViewProductPayload" in warnings[0]
+    assert "future_field" in warnings[0]
+    assert "another_new_key" in warnings[0]
+    assert "SECRET-VALUE" not in warnings[0]  # key names only, never values
+    assert "42" not in warnings[0]
+
+
+def test_required_field_validation_stays_strict():
+    """The compat policy loosens UNKNOWN keys only — a missing/invalid
+    required field is still a typed 422."""
+    with pytest.raises(ir.IntentValidationError) as exc:
+        ir.parse_ui_intent(
+            {
+                "intent": "add_to_cart",
+                "component_id": "pg1",
+                "payload": {"qty": 1, "someday_field": True},
+            },
+            enabled_flavors={"commerce"},
+        )
+    assert exc.value.detail["code"] == "invalid_intent_payload"
+    assert any(e["loc"] == "variant_id" for e in exc.value.detail["errors"])
+
+
+# ---------------------------------------------------------------------------
+# Cross-repo checksum pin
+# ---------------------------------------------------------------------------
+
+# sha256 of fixtures/intent_payloads.json. The loom repo pins the SAME
+# constant over ITS byte-identical copy (client-sdk
+# src/lib/chat/__tests__/intent-fixture-checksum.test.ts). Editing either
+# copy fails that repo's CI until the constant is bumped — and bumping it
+# is the reviewer's cue to update the other repo in the same change.
+INTENT_FIXTURE_SHA256 = (
+    "98be2907cebd786f9a5b85d62e6628f9d030e04479fe5f9375d9b9f85fd061ac"
+)
+
+
+def test_fixture_checksum_matches_cross_repo_pin():
+    import hashlib
+
+    digest = hashlib.sha256(FIXTURE_PATH.read_bytes()).hexdigest()
+    assert digest == INTENT_FIXTURE_SHA256, (
+        "intent_payloads.json changed — update INTENT_FIXTURE_SHA256 here AND "
+        "the identical pin + fixture copy in the loom repo "
+        "(packages/client-sdk/src/lib/chat/__fixtures__/ + "
+        "__tests__/intent-fixture-checksum.test.ts)."
+    )

--- a/tests/assist/test_lazy_loading.py
+++ b/tests/assist/test_lazy_loading.py
@@ -1,0 +1,211 @@
+"""Lazy flavor loading — the two-way conditional-load guarantee.
+
+(a) A process that only ever resolves core templates must never import
+    ``assist.commerce`` (asserted in a subprocess so no sibling test's
+    load leaks in), and loading commerce later must not change the
+    core-only prompt section (lru_cache-key stability: loading only ever
+    ADDS types; a core allowlist never names them).
+(b) Enabling the group loads + registers the components; the loaders are
+    idempotent; intents from a non-enabled flavor 422 with a typed error.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from app.ai.voice.agents.breeze_buddy.chat.intents import router as ir
+from app.ai.voice.agents.breeze_buddy.template import ui_catalog as uc
+from app.ai.voice.agents.breeze_buddy.template.types import UiCatalogConfig
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+COMMERCE = {"ProductGrid", "ProductCard", "CartView", "ProductDetail", "LinkButton"}
+
+# Runs a full core-only session surface (ChatAgent init → allowlist →
+# prompt section render) and asserts no assist module was imported; then
+# enables commerce IN THE SAME PROCESS and asserts (1) the module loads,
+# (2) the core-only section render is byte-identical to the pre-load one.
+_CORE_ONLY_SCRIPT = """
+import sys
+from types import SimpleNamespace
+
+from app.ai.voice.agents.breeze_buddy.chat.agent import ChatAgent
+from app.ai.voice.agents.breeze_buddy.template.ui_prompt import (
+    render_primitives_section,
+)
+from app.ai.voice.agents.breeze_buddy.template.ui_catalog import resolve_allowlist
+
+template = SimpleNamespace(id="t-core", flow=None, configurations=None)
+agent = ChatAgent(
+    session_id="s-core", template=template, llm=None, catalog_version="v2"
+)
+section_before = render_primitives_section(agent.ui_allowlist)
+assert "ProductGrid" not in section_before
+assert "### Data-bound components" not in section_before
+
+_ASSIST_PREFIX = "app.ai.voice.agents.breeze_buddy.assist"
+assist_modules = [m for m in sys.modules if m.startswith(_ASSIST_PREFIX)]
+assert not assist_modules, f"assist leaked into a core-only process: {assist_modules}"
+
+# Now a commerce template shows up in the same process: the flavor loads,
+# and the ALREADY-CACHED core section stays byte-identical (loading only
+# ever adds types; the core allowlist never contains commerce names).
+allow = resolve_allowlist(enabled_groups=["core", "commerce"])
+assert "app.ai.voice.agents.breeze_buddy.assist.commerce.ucp.schemas" in sys.modules
+assert {"ProductGrid", "ProductCard", "CartView", "ProductDetail"} <= allow
+section_after = render_primitives_section(
+    ChatAgent(
+        session_id="s-core-2", template=template, llm=None, catalog_version="v2"
+    ).ui_allowlist
+)
+assert section_after == section_before, "core prompt section changed after flavor load"
+print("OK")
+"""
+
+
+def test_core_only_process_never_imports_commerce():
+    proc = subprocess.run(
+        [sys.executable, "-c", _CORE_ONLY_SCRIPT],
+        cwd=_REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=300,
+    )
+    assert proc.returncode == 0, f"stdout:\n{proc.stdout}\nstderr:\n{proc.stderr}"
+    assert "OK" in proc.stdout
+
+
+# ---------------------------------------------------------------------------
+# Load-on-enable + idempotency (in-process; loading may already have
+# happened via a sibling test — these assert converged end state only)
+# ---------------------------------------------------------------------------
+
+
+def test_enabling_commerce_loads_and_registers():
+    allow = uc.resolve_allowlist(enabled_groups=["core", "commerce"])
+    assert COMMERCE <= allow
+    assert set(uc.PRIMITIVE_GROUPS["commerce"]) == COMMERCE
+    assert uc.is_known_type("CartView")
+    assert uc.is_data_bound("ProductGrid")
+    module = uc.LAZY_GROUPS["commerce"]
+    assert module in sys.modules
+
+
+def test_commerce_render_ui_prompt_registers_with_group_load():
+    # The flavor's render_ui vocabulary rides the same lazy hook as the
+    # schemas: once the group is loaded, prompt splicing for a
+    # commerce-enabled template gets the shopper copy, not the generic
+    # engine contract.
+    from app.ai.voice.agents.breeze_buddy.template.ui_prompt import (
+        render_render_ui_section,
+    )
+
+    uc.ensure_group_loaded("commerce")
+    section = render_render_ui_section("forced_final", ["commerce"])
+    assert "You show shoppers products, carts, and quick replies" in section
+    assert "(Add to cart, View, a checkout button)" in section
+    assert "<plan>" in section  # engine-owned plan instruction still rides
+    # And a template without the group still gets the generic contract.
+    generic = render_render_ui_section("forced_final", ["core"])
+    assert "shopper" not in generic
+
+
+def test_commerce_render_ui_pack_registers_with_group_load():
+    # The render_ui surface pack (schema vocabulary + summarizer +
+    # projection policy) rides the same lazy hook as the schemas.
+    from app.ai.voice.agents.breeze_buddy.chat.ui.render_ui_tool import (
+        build_render_ui_schema,
+    )
+
+    uc.ensure_group_loaded("commerce")
+    schema = build_render_ui_schema(
+        ["ProductGrid"], handler=None, flavor_groups=["commerce"]
+    )
+    assert "shopper" in schema.description
+    assert "ProductGrid selection" in schema.properties["items"]["description"]
+
+
+def test_ensure_group_loaded_is_idempotent():
+    uc.ensure_group_loaded("commerce")
+    uc.ensure_group_loaded("commerce")
+    assert [n for n in uc.PRIMITIVE_GROUPS["commerce"]].count("CartView") == 1
+    assert uc.PRIMITIVE_RENDER_ORDER.count("ProductGrid") == 1
+    # Re-registration must not duplicate either.
+    import app.ai.voice.agents.breeze_buddy.assist.commerce.ucp.schemas as cs
+
+    uc.register_primitives(
+        "commerce", {"CartView": cs.CartView}, render_order=["CartView"]
+    )
+    assert uc.PRIMITIVE_RENDER_ORDER.count("CartView") == 1
+    assert uc.PRIMITIVE_GROUPS["commerce"].count("CartView") == 1
+
+
+def test_unknown_group_is_a_noop():
+    before = set(uc.UI_CATALOG)
+    uc.ensure_group_loaded("healthcare")  # not a lazy group — ignored
+    assert set(uc.UI_CATALOG) == before
+
+
+# ---------------------------------------------------------------------------
+# Intent flavor gating — typed 422s for sessions without the flavor
+# ---------------------------------------------------------------------------
+
+
+def _wire(intent: str) -> dict:
+    return {
+        "intent": intent,
+        "component_id": "pg1",
+        "payload": {"variant_id": "v1"},
+    }
+
+
+def test_intent_from_unenabled_flavor_is_typed_422():
+    ir.ensure_flavor_intents(["commerce"])
+    with pytest.raises(ir.IntentValidationError) as exc:
+        ir.parse_ui_intent(_wire("add_to_cart"), enabled_flavors={"core"})
+    assert exc.value.detail["code"] == "flavor_not_enabled"
+
+
+def test_intent_passes_when_flavor_enabled():
+    ir.ensure_flavor_intents(["commerce"])
+    parsed = ir.parse_ui_intent(
+        _wire("add_to_cart"), enabled_flavors={"core", "commerce"}
+    )
+    assert parsed.policy.flavor == "commerce"
+    assert parsed.policy.route is ir.IntentRoute.DIRECT
+
+
+def test_unknown_intent_stays_unknown_regardless_of_flavors():
+    with pytest.raises(ir.IntentValidationError) as exc:
+        ir.parse_ui_intent(_wire("teleport"), enabled_flavors={"core", "commerce"})
+    assert exc.value.detail["code"] == "unknown_intent"
+
+
+def test_ensure_flavor_intents_ignores_unknown_flavors():
+    ir.ensure_flavor_intents(["core", "no_such_flavor"])  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# template_enabled_flavors — the scope handed to the intent gate
+# ---------------------------------------------------------------------------
+
+
+def test_template_enabled_flavors_defaults_to_core():
+    assert ir.template_enabled_flavors(SimpleNamespace(configurations=None)) == {"core"}
+    assert ir.template_enabled_flavors(
+        SimpleNamespace(configurations=SimpleNamespace(ui_catalog=None))
+    ) == {"core"}
+
+
+def test_template_enabled_flavors_reads_enabled_groups():
+    template = SimpleNamespace(
+        configurations=SimpleNamespace(
+            ui_catalog=UiCatalogConfig(enabled_groups=["core", "commerce"])
+        )
+    )
+    assert ir.template_enabled_flavors(template) == {"core", "commerce"}

--- a/tests/assist/test_serve_session_intent.py
+++ b/tests/assist/test_serve_session_intent.py
@@ -1,0 +1,193 @@
+"""serve_session_intent — the shared HTTP-layer intent router (RFC-001
+§3.3 Stage B).
+
+Covers the surface-independent policy seams the widget /intent route and
+the demo router both ride: catalog gating, CLIENT rejection, and the
+voice-live rule (DIRECT executes during a live voice attachment;
+AGENT_TURN 409s with the typed ``voice_live`` code). The heavy handlers
+(``send_chat_intent_handler`` / ``send_chat_message_handler``) are
+monkeypatched — their internals are covered by the run_direct_intent
+tests; here only the routing decision is under test.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any, Dict
+
+import pytest
+from fastapi import HTTPException
+
+import app.ai.voice.agents.breeze_buddy.assist.commerce.ucp.intents  # noqa: F401
+from app.ai.voice.agents.breeze_buddy.chat.intents.router import ensure_flavor_intents
+from app.ai.voice.agents.breeze_buddy.template.types import UiCatalogConfig
+from app.api.routers.breeze_buddy.chat import handlers as ch
+
+ensure_flavor_intents(["commerce"])
+
+
+def _template() -> Any:
+    return SimpleNamespace(
+        id="t1",
+        configurations=SimpleNamespace(
+            ui_catalog=UiCatalogConfig(enabled_groups=["core", "commerce"]),
+        ),
+    )
+
+
+def _session(catalog_version: str = "v2") -> SimpleNamespace:
+    return SimpleNamespace(
+        template_id="t1",
+        metadata={"widget": {"catalog_version": catalog_version}},
+    )
+
+
+@pytest.fixture()
+def routed(monkeypatch):
+    """Patch the terminal handlers; record which route served the intent."""
+    calls: Dict[str, Any] = {}
+
+    async def _get_template(template_id):
+        return _template()
+
+    async def _direct(session_id, parsed, context=None, access_check=None):
+        calls["direct"] = parsed.intent.intent
+        # The piggybacked context patch must reach the direct path too —
+        # it applies before dispatch so injection sees fresh identifiers.
+        calls["direct_context"] = context
+        return "DIRECT_SSE"
+
+    async def _agent(session_id, req, access_check=None, internal=False):
+        calls["agent_turn"] = req.content
+        calls["internal"] = internal
+        return "AGENT_SSE"
+
+    monkeypatch.setattr(ch, "get_template_by_id_cached", _get_template)
+    monkeypatch.setattr(ch, "send_chat_intent_handler", _direct)
+    monkeypatch.setattr(ch, "send_chat_message_handler", _agent)
+    return calls
+
+
+def _add_to_cart() -> Dict[str, Any]:
+    return {
+        "intent": "add_to_cart",
+        "component_id": "pg1",
+        "payload": {"variant_id": "gid://shopify/ProductVariant/1"},
+    }
+
+
+def _view_product() -> Dict[str, Any]:
+    return {
+        "intent": "view_product",
+        "component_id": "pg1",
+        "payload": {"product_id": "gid://shopify/Product/1", "title": "Shoe"},
+    }
+
+
+@pytest.fixture
+def agent_turn_view_product(monkeypatch):
+    """view_product is DIRECT since the detail-overlay work — re-pin it to
+    an AGENT_TURN policy for the router-branch tests below (monkeypatch
+    restores the real policy afterwards; the global table stays clean)."""
+    from app.ai.voice.agents.breeze_buddy.assist.commerce.ucp.intents import (
+        ViewProductPayload,
+    )
+    from app.ai.voice.agents.breeze_buddy.chat.intents.router import (
+        INTENT_POLICY,
+        IntentPolicy,
+        IntentRoute,
+    )
+
+    def _turn(parsed):
+        payload = parsed.payload
+        return f"Tell me about {payload.title} ({payload.product_id})"
+
+    monkeypatch.setitem(
+        INTENT_POLICY,
+        "view_product",
+        IntentPolicy(
+            IntentRoute.AGENT_TURN,
+            ViewProductPayload,
+            flavor="commerce",
+            agent_turn=_turn,
+        ),
+    )
+
+
+async def test_direct_intent_executes_during_voice(routed):
+    result = await ch.serve_session_intent(
+        _session(), "s1", _add_to_cart(), voice_live=True
+    )
+    assert result == "DIRECT_SSE"
+    assert routed["direct"] == "add_to_cart"
+
+
+async def test_agent_turn_intent_409s_during_voice(routed, agent_turn_view_product):
+    with pytest.raises(HTTPException) as exc:
+        await ch.serve_session_intent(
+            _session(), "s1", _view_product(), voice_live=True
+        )
+    assert exc.value.status_code == 409
+    detail = exc.value.detail
+    assert isinstance(detail, dict) and detail["code"] == "voice_live"
+    assert "agent_turn" not in routed
+
+
+async def test_agent_turn_intent_serves_normally_without_voice(
+    routed, agent_turn_view_product
+):
+    result = await ch.serve_session_intent(_session(), "s1", _view_product())
+    assert result == "AGENT_SSE"
+    assert routed["agent_turn"] == "Tell me about Shoe (gid://shopify/Product/1)"
+    # A plain (non-internal) AGENT_TURN policy must not opt into internal
+    # persistence.
+    assert routed["internal"] is False
+
+
+def _enrich_product() -> Dict[str, Any]:
+    return {
+        "intent": "enrich_product",
+        "component_id": "pd1",
+        "payload": {"product_id": "gid://shopify/Product/1", "title": "Shoe"},
+    }
+
+
+async def test_enrich_product_routes_agent_turn_with_internal_persistence(routed):
+    """The real (unpatched) enrich_product policy: AGENT_TURN + the
+    internal flag plumbed through to send_chat_message_handler."""
+    result = await ch.serve_session_intent(_session(), "s1", _enrich_product())
+    assert result == "AGENT_SSE"
+    assert routed["internal"] is True
+    assert "Shoe" in routed["agent_turn"]
+    assert "Do not call any tools" in routed["agent_turn"]
+
+
+async def test_enrich_product_409s_during_voice(routed):
+    with pytest.raises(HTTPException) as exc:
+        await ch.serve_session_intent(
+            _session(), "s1", _enrich_product(), voice_live=True
+        )
+    assert exc.value.status_code == 409
+    detail = exc.value.detail
+    assert isinstance(detail, dict) and detail["code"] == "voice_live"
+    assert "agent_turn" not in routed
+
+
+async def test_v1_session_gets_typed_catalog_422(routed):
+    with pytest.raises(HTTPException) as exc:
+        await ch.serve_session_intent(_session("v1"), "s1", _add_to_cart())
+    assert exc.value.status_code == 422
+    detail = exc.value.detail
+    assert isinstance(detail, dict) and detail["code"] == "catalog_version_unsupported"
+
+
+async def test_client_intent_gets_typed_422(routed):
+    with pytest.raises(HTTPException) as exc:
+        await ch.serve_session_intent(
+            _session(),
+            "s1",
+            {"intent": "checkout", "component_id": "cv1", "payload": {}},
+        )
+    assert exc.value.status_code == 422
+    detail = exc.value.detail
+    assert isinstance(detail, dict) and detail["code"] == "client_side_intent"

--- a/tests/assist/test_ucp_connector_seam.py
+++ b/tests/assist/test_ucp_connector_seam.py
@@ -1,0 +1,162 @@
+"""The UCP ↔ connector seam contract.
+
+UCP is the protocol; a connector is a platform that serves it. The seam
+has to hold three properties or the split is cosmetic:
+
+1. **Empty chain = pure UCP.** With no connector registered the
+   projections still work — a gateway that ships clean data pays nothing.
+2. **First opinion wins**, and "no opinion" (None) falls through to the
+   next connector, then to UCP's own behavior.
+3. **A connector is never load-bearing** — one that raises is skipped, not
+   propagated. A broken platform hook must not fail a shopper's request.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.ai.voice.agents.breeze_buddy.assist.commerce.ucp import hooks
+
+
+@pytest.fixture
+def empty_chains(monkeypatch):
+    """Run against a pristine seam — the real Shopify connector registers
+    process-globally as soon as any sibling test imports the flavor."""
+    monkeypatch.setattr(hooks, "_MEDIA_RESOLVERS", [])
+    monkeypatch.setattr(hooks, "_VARIANT_NORMALIZERS", [])
+    monkeypatch.setattr(hooks, "_DESCRIPTION_REPAIRS", [])
+
+
+class TestEmptyChainIsPureUcp:
+    @pytest.mark.asyncio
+    async def test_no_media_resolver_means_no_gallery(self, empty_chains):
+        assert await hooks.resolve_media(None, {"url": "https://x/products/y"}) is None
+
+    def test_no_normalizer_projects_variants_verbatim(self, empty_chains):
+        variants = [{"id": "v1", "title": "Default Title"}]
+        assert hooks.normalize_variants(variants) == variants
+
+    def test_no_repair_returns_text_unchanged(self, empty_chains):
+        assert hooks.repair_description("plain text") == "plain text"
+
+
+class TestFirstOpinionWins:
+    def test_none_falls_through_to_the_next_connector(self, empty_chains):
+        hooks.register_variant_normalizer(lambda _v: None)
+        hooks.register_variant_normalizer(lambda _v: [{"id": "second"}])
+        assert hooks.normalize_variants([{"id": "orig"}]) == [{"id": "second"}]
+
+    def test_repairs_compose_in_order(self, empty_chains):
+        hooks.register_description_repair(lambda t: t + " one")
+        hooks.register_description_repair(lambda t: t + " two")
+        assert hooks.repair_description("start") == "start one two"
+
+
+class TestConnectorIsNeverLoadBearing:
+    @pytest.mark.asyncio
+    async def test_raising_media_resolver_is_skipped(self, empty_chains):
+        def _boom(_session, _product):
+            raise RuntimeError("connector is broken")
+
+        hooks.register_media_resolver("brokenconnector", _boom)
+        # Does not raise — falls through to "no gallery".
+        assert await hooks.resolve_media(None, {"url": "u"}) is None
+
+    def test_raising_normalizer_falls_back_to_ucp(self, empty_chains):
+        def _boom(_v):
+            raise RuntimeError("connector is broken")
+
+        hooks.register_variant_normalizer(_boom)
+        variants = [{"id": "v1"}]
+        assert hooks.normalize_variants(variants) == variants
+
+    def test_raising_repair_leaves_text_intact(self, empty_chains):
+        def _boom(_t):
+            raise RuntimeError("connector is broken")
+
+        hooks.register_description_repair(_boom)
+        assert hooks.repair_description("text") == "text"
+
+
+class TestConnectorAllowlist:
+    """``flavor.<protocol>.connectors`` narrows the media chain. Empty or
+    unset keeps the zero-config default: every resolver self-selects."""
+
+    @staticmethod
+    async def _always(_session, _product):
+        return [{"type": "image", "url": "a"}, {"type": "image", "url": "b"}]
+
+    @pytest.mark.asyncio
+    async def test_unset_allowlist_consults_everyone(self, empty_chains):
+        hooks.register_media_resolver("someplatform", self._always)
+        assert await hooks.resolve_media(None, {}) is not None
+        # An explicitly empty list means the same thing as unset.
+        assert await hooks.resolve_media(None, {}, allowed=[]) is not None
+
+    @pytest.mark.asyncio
+    async def test_named_allowlist_skips_everyone_else(self, empty_chains):
+        hooks.register_media_resolver("someplatform", self._always)
+        assert await hooks.resolve_media(None, {}, allowed=["other"]) is None
+        assert await hooks.resolve_media(None, {}, allowed=["someplatform"]) is not None
+
+
+class TestBothProjectionsHonourTheNormalizer:
+    """ProductP (card) and ProductDetailP (overlay) call the SAME hook, so
+    a filtering normalizer must produce the same variant set in both — a
+    card whose picker disagrees with the overlay's is a bug the shopper
+    sees."""
+
+    def test_filtering_normalizer_applies_to_card_and_detail_alike(self, empty_chains):
+        from app.ai.voice.agents.breeze_buddy.assist.commerce.ucp.schemas import (
+            ProductDetailP,
+            ProductP,
+        )
+
+        hooks.register_variant_normalizer(lambda vs: [vs[0]] if vs else None)
+        raw = {
+            "id": "p1",
+            "title": "Tee",
+            "price_range": {"min": {"amount": 4999.0, "currency": "INR"}},
+            "variants": [
+                {"id": "v1", "title": "S", "availability": "available"},
+                {"id": "v2", "title": "M", "availability": "available"},
+            ],
+        }
+        card = [v.id for v in ProductP.model_validate(dict(raw)).variants]
+        detail = [v.id for v in ProductDetailP.model_validate(dict(raw)).variants]
+        assert card == detail == ["v1"]
+
+
+class TestEmptyGalleryEndsTheChain:
+    @pytest.mark.asyncio
+    async def test_empty_list_is_an_opinion_not_a_pass(self, empty_chains):
+        """`[]` means "this platform has no gallery, stop asking" — the
+        same contract the other two chains use."""
+
+        async def _no_gallery(_s, _p):
+            return []
+
+        async def _would_run(_s, _p):
+            raise AssertionError("chain must stop at the first opinion")
+
+        hooks.register_media_resolver("first", _no_gallery)
+        hooks.register_media_resolver("second", _would_run)
+        assert await hooks.resolve_media(None, {}) == []
+
+
+def test_flavor_block_tolerates_an_explicit_null():
+    """Every sibling config block (ui_intents, ui_catalog, render_ui) is
+    null-tolerant; `"flavor": null` must not fail the whole template
+    decode and take the merchant's agent down with it."""
+    from app.ai.voice.agents.breeze_buddy.template.types import ConfigurationModel
+
+    assert ConfigurationModel.model_validate({"flavor": None}).flavor is None
+
+
+def test_registration_is_idempotent(empty_chains):
+    def _fn(_v):
+        return None
+
+    hooks.register_variant_normalizer(_fn)
+    hooks.register_variant_normalizer(_fn)
+    assert hooks._VARIANT_NORMALIZERS.count(_fn) == 1

--- a/tests/test_agent_fanout_verification.py
+++ b/tests/test_agent_fanout_verification.py
@@ -1,0 +1,373 @@
+# pyrefly: ignore-errors
+# Duck-typed monkeypatching over ChatAgent internals — same limitation as
+# tests/test_agent_step_events.py (whose harness this mirrors).
+"""Phase-2 loop mechanics: tool annotations, read-only parallel fan-out,
+and deterministic verification hooks.
+
+- Annotation resolution: template override > flavor registry > the
+  'destructive' safe default.
+- Fan-out: a cycle whose ungated calls are ALL read_only dispatches them
+  CONCURRENTLY; mixed batches and the template kill-switch stay strictly
+  sequential; tool results enter the LLM context in ORIGINAL call order
+  regardless of completion order.
+- Verification: a failing post-condition converts the result into the
+  structured error envelope before the context/reducers/binding store see
+  it, and flips the step line to error; a RAISING verifier fails open.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from types import SimpleNamespace
+from typing import Any, Dict, List
+
+from pipecat.frames.frames import FunctionCallFromLLM
+from pipecat.processors.aggregators.llm_context import LLMContext
+
+import app.ai.voice.agents.breeze_buddy.chat.agent as agent_module
+from app.ai.voice.agents.breeze_buddy.chat.agent import (
+    approval as agent_approval,
+    context as agent_context,
+    core as agent_core,
+    cycle as agent_cycle,
+    render_ui as agent_render_ui,
+    tooling as agent_tooling,
+)
+from app.ai.voice.agents.breeze_buddy.chat.llm import driver as llm_driver
+
+# agent.py is a package of subsystem modules now — a patched seam must
+# land on every submodule that calls it (autoflake prunes unused
+# imports per module, hence the hasattr guard).
+_AGENT_MODULES = (
+    agent_core,
+    agent_cycle,
+    agent_approval,
+    agent_render_ui,
+    agent_context,
+    agent_tooling,
+)
+
+
+def _patch_agent_attr(monkeypatch, name, value):
+    for _mod in _AGENT_MODULES:
+        if hasattr(_mod, name):
+            monkeypatch.setattr(_mod, name, value)
+
+
+from app.ai.voice.agents.breeze_buddy.chat.agent import ChatAgent, _PreparedTools
+from app.ai.voice.agents.breeze_buddy.chat.steps import (
+    verification as verification_module,
+)
+from app.ai.voice.agents.breeze_buddy.chat.steps.verification import (
+    register_tool_verifier,
+    run_tool_verifiers,
+)
+from app.ai.voice.agents.breeze_buddy.chat.tools.annotations import (
+    register_tool_annotations,
+    resolve_tool_annotation,
+)
+from app.ai.voice.agents.breeze_buddy.template.types import TemplateModel
+
+# Importing the commerce schemas registers the flavor's annotations +
+# verifiers (search_catalog read_only, cart mutation post-conditions).
+import app.ai.voice.agents.breeze_buddy.assist.commerce.ucp.schemas  # noqa: F401  isort: skip
+
+_NODE: Dict[str, Any] = {"name": "start", "functions": []}
+
+_PREP = _PreparedTools(
+    flow_config={}, global_funcs=[], tool_retention=None, tool_projection=None
+)
+
+
+def _configurations(**overrides: Any) -> SimpleNamespace:
+    base: Dict[str, Any] = dict(
+        state_reducers=[],
+        tool_arg_injection=[],
+        client_context=None,
+        ui_catalog=None,
+        ui_intents=None,
+        tool_execution=None,
+    )
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+def _make_agent(configurations: Any = None) -> ChatAgent:
+    template = TemplateModel.model_construct(
+        id="tpl-1", name="t", flow={}, configurations=configurations
+    )
+    agent = ChatAgent(
+        session_id="sess-1",
+        template=template,
+        llm=object(),
+        template_vars={},
+    )
+    agent._turn_id = "turn-1"
+    return agent
+
+
+def _patch_db(monkeypatch) -> None:
+    async def _noop(**_kwargs):
+        return None
+
+    _patch_agent_attr(monkeypatch, "insert_chat_message", _noop)
+    _patch_agent_attr(monkeypatch, "update_chat_session_after_turn", _noop)
+    _patch_agent_attr(monkeypatch, "upsert_agent_session_state_merge", _noop)
+
+
+def _patch_stream(monkeypatch, cycles: List[List[tuple]]) -> None:
+    calls = {"n": 0}
+
+    async def _stream(_llm, _context, **_kwargs):
+        script = cycles[calls["n"]]
+        calls["n"] += 1
+        for event in script:
+            yield event
+
+    monkeypatch.setattr(llm_driver, "stream", _stream)
+
+
+def _tool_call(name: str, call_id: str) -> FunctionCallFromLLM:
+    return FunctionCallFromLLM(
+        function_name=name,
+        tool_call_id=call_id,
+        arguments={"query": "bras"},
+        context=None,
+    )
+
+
+class _ConcurrencyProbe:
+    """Dispatch stub that records the max number of overlapping calls."""
+
+    def __init__(self, results: Dict[str, Any], delay: float = 0.02) -> None:
+        self.results = results
+        self.delay = delay
+        self.active = 0
+        self.max_active = 0
+        self.completion_order: List[str] = []
+
+    def patch(self, monkeypatch) -> None:
+        probe = self
+
+        async def _dispatch(self_agent, call, _node, _funcs, injected_args=None):
+            probe.active += 1
+            probe.max_active = max(probe.max_active, probe.active)
+            try:
+                await asyncio.sleep(probe.delay)
+                return probe.results[call.tool_call_id], None
+            finally:
+                probe.active -= 1
+                probe.completion_order.append(call.tool_call_id)
+
+        monkeypatch.setattr(ChatAgent, "_dispatch_tool_call", _dispatch)
+
+
+async def _run_cycle(
+    monkeypatch,
+    calls: List[FunctionCallFromLLM],
+    probe: _ConcurrencyProbe,
+    configurations: Any = None,
+):
+    _patch_stream(
+        monkeypatch,
+        [
+            [("tool_call", c) for c in calls],
+            [("text", "All done.")],
+        ],
+    )
+    _patch_db(monkeypatch)
+    probe.patch(monkeypatch)
+    agent = _make_agent(configurations)
+    context = LLMContext(messages=[{"role": "user", "content": "find bras"}])
+    events = [ev async for ev in agent._cycle_loop(context, dict(_NODE), _PREP)]
+    return events, context
+
+
+# ---------------------------------------------------------------------------
+# Annotation resolution
+# ---------------------------------------------------------------------------
+
+
+def test_annotation_precedence():
+    # Flavor registry (loaded via the commerce import above).
+    assert resolve_tool_annotation("search_catalog") == "read_only"
+    assert resolve_tool_annotation("update_cart") == "idempotent"
+    # Unknown tool → destructive (never accidentally parallel).
+    assert resolve_tool_annotation("mystery_tool") == "destructive"
+    # Template override beats the registry.
+    template = SimpleNamespace(
+        configurations=SimpleNamespace(
+            tool_execution=SimpleNamespace(
+                annotations={"search_catalog": "destructive", "my_read": "read_only"}
+            )
+        )
+    )
+    assert resolve_tool_annotation("search_catalog", template) == "destructive"
+    assert resolve_tool_annotation("my_read", template) == "read_only"
+    # Invalid override value falls through to the registry/default.
+    bad = SimpleNamespace(
+        configurations=SimpleNamespace(
+            tool_execution=SimpleNamespace(annotations={"search_catalog": "fast"})
+        )
+    )
+    assert resolve_tool_annotation("search_catalog", bad) == "read_only"
+
+
+def test_conflicting_registration_raises():
+    register_tool_annotations({"annot_probe": "read_only"})
+    register_tool_annotations({"annot_probe": "read_only"})  # idempotent
+    try:
+        register_tool_annotations({"annot_probe": "destructive"})
+    except ValueError:
+        pass
+    else:  # pragma: no cover
+        raise AssertionError("conflicting annotation must raise")
+
+
+# ---------------------------------------------------------------------------
+# Parallel fan-out
+# ---------------------------------------------------------------------------
+
+
+async def test_all_read_only_batch_dispatches_concurrently(monkeypatch):
+    calls = [_tool_call("search_catalog", "fc-1"), _tool_call("lookup_catalog", "fc-2")]
+    probe = _ConcurrencyProbe(
+        {
+            "fc-1": {"products": [1, 2]},
+            "fc-2": {"products": [3]},
+        }
+    )
+    events, context = await _run_cycle(monkeypatch, calls, probe)
+
+    assert probe.max_active == 2  # genuinely overlapped
+    names = [ev.event for ev in events]
+    assert names.count("step_started") == 2
+    assert names.count("step_completed") == 2
+    assert names.count("function_call_completed") == 2
+    # Both step_started lines precede any completion (batch appears together).
+    assert max(i for i, n in enumerate(names) if n == "step_started") < min(
+        i for i, n in enumerate(names) if n == "step_completed"
+    )
+
+    # Tool results enter the LLM context in ORIGINAL call order.
+    tool_msgs = [
+        m
+        for m in context.get_messages()
+        if isinstance(m, dict) and m.get("role") == "tool"
+    ]
+    assert [m["tool_call_id"] for m in tool_msgs] == ["fc-1", "fc-2"]
+
+
+async def test_mixed_batch_stays_sequential(monkeypatch):
+    calls = [_tool_call("search_catalog", "fc-1"), _tool_call("update_cart", "fc-2")]
+    probe = _ConcurrencyProbe(
+        {
+            "fc-1": {"products": []},
+            # update_cart with free-form args (no cart.line_items) — the
+            # commerce verifier no-ops on those.
+            "fc-2": {"ok": True},
+        }
+    )
+    events, _context = await _run_cycle(monkeypatch, calls, probe)
+    assert probe.max_active == 1
+    assert probe.completion_order == ["fc-1", "fc-2"]
+
+
+async def test_template_kill_switch_disables_fanout(monkeypatch):
+    calls = [_tool_call("search_catalog", "fc-1"), _tool_call("lookup_catalog", "fc-2")]
+    probe = _ConcurrencyProbe({"fc-1": {"products": []}, "fc-2": {"products": []}})
+    _events, _context = await _run_cycle(
+        monkeypatch,
+        calls,
+        probe,
+        configurations=_configurations(
+            tool_execution=SimpleNamespace(parallel_read_only=False)
+        ),
+    )
+    assert probe.max_active == 1
+
+
+# ---------------------------------------------------------------------------
+# Verification hooks
+# ---------------------------------------------------------------------------
+
+
+async def test_failed_verification_becomes_error_envelope(monkeypatch):
+    # update_cart asked for qty 2 of a variant; the cart came back with 1.
+    call = FunctionCallFromLLM(
+        function_name="update_cart",
+        tool_call_id="fc-1",
+        arguments={"cart": {"line_items": [{"item": {"id": "v9"}, "quantity": 2}]}},
+        context=None,
+    )
+    probe = _ConcurrencyProbe(
+        {
+            "fc-1": {
+                "status": "success",
+                "data": json.dumps(
+                    {"line_items": [{"item": {"id": "v9"}, "quantity": 1}]}
+                ),
+            }
+        }
+    )
+    events, context = await _run_cycle(monkeypatch, [call], probe)
+
+    completed = next(ev for ev in events if ev.event == "step_completed")
+    assert completed.data["status"] == "error"
+    tool_msg = next(
+        m
+        for m in context.get_messages()
+        if isinstance(m, dict) and m.get("role") == "tool"
+    )
+    body = json.loads(tool_msg["content"])
+    assert body["status"] == "error"
+    assert "verification failed" in body["error"]
+    assert "requested quantity 2" in body["error"]
+    # Original payload preserved for the model to reason over.
+    assert "unverified_result" in body
+
+
+async def test_satisfied_verification_passes_result_through(monkeypatch):
+    call = FunctionCallFromLLM(
+        function_name="update_cart",
+        tool_call_id="fc-1",
+        arguments={"cart": {"line_items": [{"item": {"id": "v9"}, "quantity": 2}]}},
+        context=None,
+    )
+    payload = {
+        "status": "success",
+        "data": json.dumps({"line_items": [{"item": {"id": "v9"}, "quantity": 2}]}),
+    }
+    probe = _ConcurrencyProbe({"fc-1": payload})
+    events, context = await _run_cycle(monkeypatch, [call], probe)
+    completed = next(ev for ev in events if ev.event == "step_completed")
+    assert completed.data["status"] == "ok"
+    tool_msg = next(
+        m
+        for m in context.get_messages()
+        if isinstance(m, dict) and m.get("role") == "tool"
+    )
+    assert json.loads(tool_msg["content"]) == payload
+
+
+def test_raising_verifier_fails_open(monkeypatch):
+    def _boom(_args, _result):
+        raise RuntimeError("bad verifier")
+
+    register_tool_verifier("failopen_tool", _boom)
+    assert run_tool_verifiers("failopen_tool", {}, {"ok": True}) is None
+    # Cleanup so other tests never see the probe verifier.
+    verification_module._VERIFIERS.pop("failopen_tool", None)
+
+
+def test_error_envelopes_skip_verification():
+    # A tool that already failed is not re-judged (no double error).
+    assert (
+        run_tool_verifiers(
+            "update_cart",
+            {"cart": {"line_items": [{"item": {"id": "v9"}, "quantity": 2}]}},
+            {"status": "error", "error": "upstream 500"},
+        )
+        is None
+    )

--- a/tests/test_render_ui_phase_a.py
+++ b/tests/test_render_ui_phase_a.py
@@ -1,0 +1,1225 @@
+"""RFC-002 Phase A unit tests: render_ui tool, plan enforcer, baseline
+search annotation, and the metrics counters."""
+
+from app.ai.voice.agents.breeze_buddy.assist.commerce.ucp.annotator import (
+    annotate_search_result,
+)
+from app.ai.voice.agents.breeze_buddy.chat.agent import (
+    approval as agent_approval,
+    context as agent_context,
+    core as agent_core,
+    cycle as agent_cycle,
+    render_ui as agent_render_ui,
+    tooling as agent_tooling,
+)
+from app.ai.voice.agents.breeze_buddy.chat.llm import driver as llm_driver
+from app.ai.voice.agents.breeze_buddy.chat.metrics import TurnMetrics
+from app.ai.voice.agents.breeze_buddy.chat.sse import SSEEvent
+from app.ai.voice.agents.breeze_buddy.chat.steps.enforcer import PlanEnforcer
+from app.ai.voice.agents.breeze_buddy.chat.ui.binding import BindingStore
+from app.ai.voice.agents.breeze_buddy.chat.ui.render_ui_tool import (
+    execute_render_ui,
+    render_ui_components,
+)
+from app.ai.voice.agents.breeze_buddy.template.ui_catalog import (
+    ensure_group_loaded,
+    resolve_allowlist,
+)
+
+# agent.py is a package of subsystem modules now — a patched seam must
+# land on every submodule that calls it (autoflake prunes unused
+# imports per module, hence the hasattr guard).
+_AGENT_MODULES = (
+    agent_core,
+    agent_cycle,
+    agent_approval,
+    agent_render_ui,
+    agent_context,
+    agent_tooling,
+)
+
+
+def _patch_agent_attr(monkeypatch, name, value):
+    for _mod in _AGENT_MODULES:
+        if hasattr(_mod, name):
+            monkeypatch.setattr(_mod, name, value)
+
+
+ensure_group_loaded("commerce")
+ALLOW = resolve_allowlist(enabled_groups=["core", "commerce"])
+COMPS = render_ui_components(ALLOW, True)
+
+
+def _store(products=None):
+    store = BindingStore()
+    store.record(
+        "search_catalog",
+        "t1",
+        {
+            "products": products
+            or [
+                {
+                    "id": "p1",
+                    "title": "CoreFlex Shorts",
+                    "price": {"amount": 999.0},
+                    "variants": [
+                        {
+                            "id": "v-black",
+                            "title": "S / Black",
+                            "price": {"amount": 999.0},
+                        },
+                        {
+                            "id": "v-pink",
+                            "title": "S / Pink",
+                            "price": {"amount": 1099.0},
+                        },
+                    ],
+                },
+                {"id": "p2", "title": "AeroShield Jacket", "price": {"amount": 4999.0}},
+            ]
+        },
+    )
+    return store
+
+
+# ---------------------------------------------------------------- render_ui
+
+
+def test_components_exclude_server_only_and_include_quick_replies():
+    assert "ProductGrid" in COMPS
+    assert "QuickReplies" in COMPS
+    assert "LinkButton" in COMPS
+    assert "ProductDetail" not in COMPS  # server_only stays server-only
+
+
+def test_link_button_renders_with_config_trusted_url():
+    out = execute_render_ui(
+        {
+            "component": "LinkButton",
+            "link": {
+                "label": "Review and checkout",
+                "url": "https://shop.example/cart",
+            },
+        },
+        store=BindingStore(),  # no tool calls this turn — allowlist carries it
+        allowlist=ALLOW,
+        components=COMPS,
+        op_id="root",
+        trusted_urls={"https://shop.example/cart"},
+    )
+    assert out.decision == "rendered"
+    op = out.ops[0]
+    assert op["type"] == "LinkButton" and op["v"] == 2
+    assert op["props"] == {
+        "label": "Review and checkout",
+        "url": "https://shop.example/cart",
+    }
+    assert out.fn_result["url"] == "https://shop.example/cart"
+
+
+def test_link_button_accepts_url_from_this_turns_tool_results():
+    products = [
+        {
+            "id": "p1",
+            "title": "CoreFlex Shorts",
+            "url": "https://shop.example/products/coreflex-shorts",
+            "price": {"amount": 999.0},
+        }
+    ]
+    out = execute_render_ui(
+        {
+            "component": "LinkButton",
+            "link": {
+                "label": "View product",
+                "url": "https://shop.example/products/coreflex-shorts",
+            },
+        },
+        store=_store(products),
+        allowlist=ALLOW,
+        components=COMPS,
+        op_id="root",
+        trusted_urls=set(),
+    )
+    assert out.decision == "rendered"
+    assert out.ops[0]["props"]["url"] == "https://shop.example/products/coreflex-shorts"
+
+
+def test_link_button_accepts_url_from_reducer_state():
+    """Reducer state (e.g. policy_links captured from an earlier cart
+    call) has tool provenance — a state-sourced URL renders even when no
+    tool ran THIS turn."""
+    out = execute_render_ui(
+        {
+            "component": "LinkButton",
+            "link": {
+                "label": "Refund policy",
+                "url": "https://shop.example/policies/refunds",
+            },
+        },
+        store=_store(),
+        allowlist=ALLOW,
+        components=COMPS,
+        op_id="root",
+        trusted_urls=set(),
+        state_values={
+            "policy_links": [
+                {
+                    "type": "refund_policy",
+                    "url": "https://shop.example/policies/refunds",
+                }
+            ]
+        },
+    )
+    assert out.decision == "rendered"
+    assert out.ops[0]["props"]["url"] == "https://shop.example/policies/refunds"
+
+
+def test_link_button_rejects_untrusted_url():
+    out = execute_render_ui(
+        {
+            "component": "LinkButton",
+            "link": {"label": "Click me", "url": "https://evil.example/phish"},
+        },
+        store=_store(),
+        allowlist=ALLOW,
+        components=COMPS,
+        op_id="root",
+        trusted_urls={"https://shop.example/cart"},
+    )
+    assert out.decision == "error"
+    assert out.ops == []
+    assert "untrusted url" in out.fn_result["error"]
+
+
+def test_link_button_requires_link_payload():
+    out = execute_render_ui(
+        {"component": "LinkButton"},
+        store=BindingStore(),
+        allowlist=ALLOW,
+        components=COMPS,
+        op_id="root",
+        trusted_urls={"https://shop.example/cart"},
+    )
+    assert out.decision == "error"
+    assert "LinkButton needs link=" in out.fn_result["error"]
+
+
+def test_render_grid_with_selection_and_hero():
+    out = execute_render_ui(
+        {
+            "component": "ProductGrid",
+            "bind": [{"prop": "products", "ref": "$tool:search_catalog#/products"}],
+            "items": [{"id": "p1", "feature_variant": "v-pink"}],
+        },
+        store=_store(),
+        allowlist=ALLOW,
+        components=COMPS,
+        op_id="root",
+        flavor_groups=["commerce"],
+    )
+    assert out.decision == "rendered"
+    op = out.ops[0]
+    assert op["id"] == "root" and op["type"] == "ProductGrid" and op["v"] == 2
+    entry = op["props"]["products"][0]
+    assert entry["featured_variant_id"] == "v-pink"
+    assert entry["price"]["amount"] == 1099.0
+    assert "items" not in op["props"]
+    # Function response = compact UI memory (the marker replacement).
+    assert out.fn_result["rendered"] == "ProductGrid"
+    assert out.fn_result["items"][0]["featured_variant"] == "v-pink"
+
+
+def test_no_ui_is_a_legal_payload():
+    out = execute_render_ui(
+        {"decision": "no_ui", "reason": "cart already visible"},
+        store=_store(),
+        allowlist=ALLOW,
+        components=COMPS,
+        op_id="root",
+    )
+    assert out.decision == "no_ui"
+    assert out.ops == []
+    assert out.fn_result == {
+        "status": "ok",
+        "decision": "no_ui",
+        "reason": "cart already visible",
+    }
+
+
+def test_errors_are_structured_never_raised():
+    store = _store()
+    # missing component AND no decision
+    out = execute_render_ui(
+        {}, store=store, allowlist=ALLOW, components=COMPS, op_id="root"
+    )
+    assert out.fn_result["status"] == "error"
+    # unknown component
+    out = execute_render_ui(
+        {"component": "Hologram"},
+        store=store,
+        allowlist=ALLOW,
+        components=COMPS,
+        op_id="root",
+    )
+    assert "Hologram" in out.fn_result["error"]
+    # data-bound without bind
+    out = execute_render_ui(
+        {"component": "ProductGrid"},
+        store=store,
+        allowlist=ALLOW,
+        components=COMPS,
+        op_id="root",
+    )
+    assert "data-bound" in out.fn_result["error"]
+    # malformed ref
+    out = execute_render_ui(
+        {"component": "ProductGrid", "bind": [{"prop": "products", "ref": "products"}]},
+        store=store,
+        allowlist=ALLOW,
+        components=COMPS,
+        op_id="root",
+    )
+    assert "bad bind ref" in out.fn_result["error"]
+    # unresolved bind (tool didn't run this turn)
+    out = execute_render_ui(
+        {
+            "component": "ProductGrid",
+            "bind": [{"prop": "products", "ref": "$tool:get_cart#/products"}],
+        },
+        store=store,
+        allowlist=ALLOW,
+        components=COMPS,
+        op_id="root",
+    )
+    assert "bind_unresolved" in out.fn_result["error"]
+
+
+def test_quick_replies_literal_path_with_parent():
+    """Canonical form: one STRING per chip — shown AND sent back."""
+    out = execute_render_ui(
+        {
+            "component": "QuickReplies",
+            "quick_replies": ["Show more", "Checkout"],
+        },
+        store=_store(),
+        allowlist=ALLOW,
+        components=COMPS,
+        op_id="rui1",
+        parent="root",
+    )
+    assert out.decision == "rendered"
+    op = out.ops[0]
+    assert op["type"] == "QuickReplies" and op["parent"] == "root"
+    assert op["props"]["items"] == [{"label": "Show more"}, {"label": "Checkout"}]
+    assert out.fn_result["count"] == 2
+
+
+def test_quick_replies_object_form_tolerated():
+    """The retired {label, value} object form still renders (stragglers /
+    replayed calls) — just no longer advertised in the schema."""
+    out = execute_render_ui(
+        {
+            "component": "QuickReplies",
+            "quick_replies": [
+                {"label": "Show more"},
+                {"label": "Checkout", "value": "go to checkout"},
+            ],
+        },
+        store=_store(),
+        allowlist=ALLOW,
+        components=COMPS,
+        op_id="rui1",
+        parent="root",
+    )
+    assert out.decision == "rendered"
+    items = out.ops[0]["props"]["items"]
+    assert [i["label"] for i in items] == ["Show more", "Checkout"]
+    assert items[1]["value"] == "go to checkout"
+
+
+def test_object_form_bind_tolerated():
+    out = execute_render_ui(
+        {
+            "component": "ProductGrid",
+            "bind": {"products": "$tool:search_catalog#/products"},
+        },
+        store=_store(),
+        allowlist=ALLOW,
+        components=COMPS,
+        op_id="root",
+    )
+    assert out.decision == "rendered"
+    assert out.fn_result["count"] == 2
+
+
+# ---------------------------------------------------------------- enforcer
+
+
+def test_enforcer_stays_advisory_for_single_step_or_unknown_tools():
+    enf = PlanEnforcer()
+    assert not enf.start(["search_catalog"], {"search_catalog"})
+    assert not enf.start(["search_catalog", "hallucinated"], {"search_catalog"})
+    assert not enf.active
+
+
+def test_enforcer_constrains_advances_and_finishes():
+    enf = PlanEnforcer()
+    tools = {"search_catalog", "update_cart", "revise_plan"}
+    assert enf.start(["search_catalog", "update_cart"], tools)
+    assert enf.constraining
+    assert enf.allowed_names("revise_plan") == ["search_catalog", "revise_plan"]
+    enf.on_tool_result("update_cart", True)  # off-step result: ignored
+    assert enf.cursor == 0
+    enf.on_tool_result("search_catalog", True)
+    assert enf.allowed_names("revise_plan") == ["update_cart", "revise_plan"]
+    enf.on_tool_result("update_cart", True)
+    assert not enf.constraining  # plan exhausted → cycles are free again
+
+
+def test_enforcer_retry_then_require_revise():
+    enf = PlanEnforcer()
+    tools = {"search_catalog", "update_cart"}
+    enf.start(["search_catalog", "update_cart"], tools)
+    enf.on_tool_result("search_catalog", False)  # fail #1 → retry same step
+    assert enf.allowed_names("revise_plan") == ["search_catalog", "revise_plan"]
+    assert not enf.revise_required
+    enf.on_tool_result("search_catalog", False)  # fail #2 → revise required
+    assert enf.revise_required
+    assert enf.allowed_names("revise_plan") == ["revise_plan"]
+    effective = enf.revise(["update_cart"], tools)
+    assert effective == ["update_cart"]
+    assert not enf.revise_required
+    assert enf.allowed_names("revise_plan") == ["update_cart", "revise_plan"]
+
+
+def test_enforcer_revise_drops_unknown_and_can_empty():
+    enf = PlanEnforcer()
+    tools = {"a", "b"}
+    enf.start(["a", "b"], tools)
+    enf.on_tool_result("a", True)
+    effective = enf.revise(["nope"], tools)  # unknown dropped → plan ends
+    assert effective == ["a"]
+    assert not enf.constraining
+
+
+# ---------------------------------------------------------------- annotator
+
+
+def _search_result():
+    return {
+        "products": [
+            {
+                "id": "p1",
+                "title": "CoreFlex Shorts",
+                "tags": ["gym"],
+                "variants": [
+                    {
+                        "id": "v-b",
+                        "title": "S / Black",
+                        "options": [{"value": "Black"}],
+                    },
+                    {"id": "v-p", "title": "S / Pink", "options": [{"value": "Pink"}]},
+                ],
+            },
+            {"id": "p2", "title": "AeroShield Jacket", "tags": [], "variants": []},
+        ]
+    }
+
+
+def test_annotator_marks_product_and_variant():
+    out = annotate_search_result({"query": "pink shorts"}, _search_result())
+    p1, p2 = out["products"]
+    assert p1["matched_via"] == "exact"
+    assert p1["matched_variant"]["id"] == "v-p"
+    assert "matched_via" not in p2
+    assert out["match"]["matched_ids"] == ["p1"]
+
+
+def test_annotator_ignores_shared_variant_tokens():
+    """'shorts' rides every variant title — it must not pick a variant."""
+    out = annotate_search_result({"query": "shorts"}, _search_result())
+    assert "matched_variant" not in out["products"][0]
+    assert out["products"][0]["matched_via"] == "exact"
+
+
+def test_annotator_noops_without_signal():
+    result = _search_result()
+    assert annotate_search_result({"query": "   "}, result) is result
+    assert annotate_search_result({}, result) is result
+    assert (
+        annotate_search_result({"query": "show me"}, result) is result
+    )  # stopwords only
+    weird = {"products": "not-a-list"}
+    assert annotate_search_result({"query": "pink"}, weird) is weird
+
+
+# ---------------------------------------------------------------- metrics
+
+
+def test_metrics_counts_render_ui_signals():
+    m = TurnMetrics(session_id="s", template_id="t", t0=0.0)
+    m.observe(SSEEvent(event="function_call_started", data={"name": "render_ui"}))
+    m.observe(SSEEvent(event="function_call_started", data={"name": "search_catalog"}))
+    m.observe(SSEEvent(event="ui_decision", data={"decision": "no_ui", "reason": "x"}))
+    m.observe(SSEEvent(event="ui_decision", data={"decision": "rendered"}))
+    m.observe(SSEEvent(event="force_fallback", data={"allowed": ["render_ui"]}))
+    assert m.render_ui_calls == 1
+    assert m.tool_calls == 2
+    assert m.ui_no_ui == 1
+    assert m.force_fallbacks == 1
+
+
+# ----------------------------------------------------------- prompt splice
+
+
+def test_render_ui_section_carries_the_plan_instruction():
+    """The render_ui section REPLACES the data-bound subsection that
+    normally carries the <plan> instruction — if it doesn't bring the
+    instruction along, the model never emits plans in render_ui mode and
+    enforcement stays silently dormant (caught live in A7)."""
+    from app.ai.voice.agents.breeze_buddy.template.ui_prompt import (
+        render_render_ui_section,
+    )
+
+    section = render_render_ui_section()
+    assert "<plan>" in section
+    assert "render_ui" in section  # still the render_ui contract
+
+
+def test_link_button_rejected_on_the_text_channel():
+    """text_channel=False wire gate: the URL trust check lives ONLY in the
+    render_ui path, so a hand-typed <ui_stream> add of LinkButton must be
+    rejected at parse — otherwise the dual-read window is an
+    arbitrary-URL injection surface."""
+    from app.ai.voice.agents.breeze_buddy.chat.ui.stream import parse_op_line
+
+    result = parse_op_line(
+        '{"op":"add","id":"root","type":"LinkButton",'
+        '"props":{"label":"Checkout","url":"https://evil.example/phish"}}',
+        allowlist=ALLOW,
+    )
+    assert result.op is None
+    assert result.error == "render_ui_only:LinkButton"
+
+
+def test_render_ui_sessions_never_write_the_legacy_marker():
+    """Phase B: the ``[ui rendered: …]`` marker in replayed history is what
+    bred the F1 mimicry bug — render_ui sessions get their UI memory from
+    the function response instead, so the marker write-path is off for
+    them. Fleet text-channel sessions keep it (their only UI memory)."""
+    from app.ai.voice.agents.breeze_buddy.chat.agent import ChatAgent
+    from app.ai.voice.agents.breeze_buddy.template.types import (
+        ConfigurationModel,
+        RenderUiConfig,
+        TemplateModel,
+    )
+
+    ops = [
+        {"op": "add", "id": "root", "type": "Tile", "props": {"title": "Mug"}, "v": 2}
+    ]
+
+    def agent_with(render_ui: bool) -> ChatAgent:
+        cfg = ConfigurationModel.model_construct(
+            render_ui=RenderUiConfig(enabled=render_ui)
+        )
+        template = TemplateModel.model_construct(
+            id="tpl-b", name="t", flow={}, configurations=cfg
+        )
+        return ChatAgent(
+            session_id="s-b",
+            template=template,
+            llm=object(),
+            template_vars={},
+            catalog_version="v2",
+        )
+
+    assert agent_with(True)._ui_summary(ops) == ""
+    legacy = agent_with(False)._ui_summary(ops)
+    assert legacy.startswith("[ui rendered:")
+
+
+async def test_text_channel_ops_dropped_on_render_ui_sessions(monkeypatch):
+    """Phase D hard cutover: a render_ui session's <ui_stream> text op is
+    dropped observably (ui_op_dropped reason=text_channel_retired), never
+    rendered — the function call is the ONLY UI channel. Fleet text-channel
+    sessions (render_ui_tool off) keep the dual path untouched."""
+    from pipecat.processors.aggregators.llm_context import LLMContext
+
+    from app.ai.voice.agents.breeze_buddy.chat.agent import ChatAgent, _PreparedTools
+    from app.ai.voice.agents.breeze_buddy.template.types import (
+        ConfigurationModel,
+        RenderUiConfig,
+        TemplateModel,
+    )
+
+    op_line = (
+        '<ui_stream>{"op":"add","id":"root","type":"QuickReplies",'
+        '"props":{"items":[{"label":"A"},{"label":"B"}]}}</ui_stream>'
+    )
+
+    async def _stream(_llm, _context, **_kwargs):
+        yield ("text", op_line)
+
+    monkeypatch.setattr(llm_driver, "stream", _stream)
+
+    async def _noop(**_kwargs):
+        return None
+
+    _patch_agent_attr(monkeypatch, "insert_chat_message", _noop)
+    _patch_agent_attr(monkeypatch, "update_chat_session_after_turn", _noop)
+    _patch_agent_attr(monkeypatch, "upsert_agent_session_state_merge", _noop)
+
+    cfg = ConfigurationModel.model_construct(render_ui=RenderUiConfig(enabled=True))
+    template = TemplateModel.model_construct(
+        id="tpl-cut", name="t", flow={}, configurations=cfg
+    )
+    agent = ChatAgent(
+        session_id="s-cut",
+        template=template,
+        llm=object(),
+        template_vars={},
+        catalog_version="v2",
+    )
+    agent._turn_id = "turn-cut"
+    prep = _PreparedTools(
+        flow_config={}, global_funcs=[], tool_retention=None, tool_projection=None
+    )
+    context = LLMContext(messages=[{"role": "user", "content": "hi"}])
+    node = {"name": "start", "functions": []}
+
+    events = [ev async for ev in agent._cycle_loop(context, node, prep)]
+    kinds = [ev.event for ev in events]
+    assert "ui_op" not in kinds
+    dropped = [ev for ev in events if ev.event == "ui_op_dropped"]
+    assert len(dropped) == 1
+    assert dropped[0].data["reason"] == "text_channel_retired"
+
+
+# ---------------------------------------------------------------------------
+# Forced final chips cycle (template render_ui.quick_replies='forced_final')
+# ---------------------------------------------------------------------------
+
+
+def _chips_agent(monkeypatch, mode, responses):
+    """A render_ui ChatAgent wired to a scripted llm_driver.stream.
+
+    ``responses[i]`` is the list of driver events the i-th LLM call yields.
+    Returns (agent, prep, calls, inserted): ``calls`` records each call's
+    forcing/thinking kwargs + the context tail it saw; ``inserted`` records
+    every insert_chat_message row in write order.
+    """
+    from app.ai.voice.agents.breeze_buddy.chat.agent import ChatAgent, _PreparedTools
+    from app.ai.voice.agents.breeze_buddy.chat.ui.render_ui_tool import (
+        build_render_ui_schema,
+    )
+    from app.ai.voice.agents.breeze_buddy.template.types import (
+        ConfigurationModel,
+        RenderUiConfig,
+        TemplateModel,
+    )
+
+    calls: list = []
+
+    async def _stream(_llm, context, **kwargs):
+        tail = [
+            {"role": m.get("role"), "content": m.get("content")}
+            for m in context.get_messages()[-2:]
+            if isinstance(m, dict)
+        ]
+        idx = len(calls)
+        calls.append(
+            {
+                "allowed": kwargs.get("allowed_function_names"),
+                "thinking": kwargs.get("thinking_level_override"),
+                "tail": tail,
+            }
+        )
+        for event in responses[idx] if idx < len(responses) else []:
+            yield event
+
+    monkeypatch.setattr(llm_driver, "stream", _stream)
+
+    inserted: list = []
+
+    async def _insert(**kwargs):
+        inserted.append(kwargs)
+        return None
+
+    _patch_agent_attr(monkeypatch, "insert_chat_message", _insert)
+
+    async def _noop(**_kwargs):
+        return None
+
+    _patch_agent_attr(monkeypatch, "update_chat_session_after_turn", _noop)
+    _patch_agent_attr(monkeypatch, "upsert_agent_session_state_merge", _noop)
+
+    cfg = ConfigurationModel.model_construct(
+        render_ui=RenderUiConfig(enabled=True, quick_replies=mode)
+    )
+    template = TemplateModel.model_construct(
+        id="tpl-chips", name="t", flow={}, configurations=cfg
+    )
+    agent = ChatAgent(
+        session_id="s-chips",
+        template=template,
+        llm=object(),
+        template_vars={},
+        catalog_version="v2",
+    )
+    agent._turn_id = "turn-chips"
+    agent._ui_allowlist = set(ALLOW)
+    prep = _PreparedTools(
+        flow_config={},
+        global_funcs=[build_render_ui_schema(list(COMPS), agent._render_ui_handler)],
+        tool_retention=None,
+        tool_projection=None,
+    )
+    return agent, prep, calls, inserted
+
+
+async def _run_chips_turn(agent, prep):
+    from pipecat.processors.aggregators.llm_context import LLMContext
+
+    context = LLMContext(messages=[{"role": "user", "content": "hi"}])
+    node = {"name": "start", "functions": []}
+    return [ev async for ev in agent._cycle_loop(context, node, prep)]
+
+
+def _rui_call(args, call_id="t-chips"):
+    from pipecat.frames.frames import FunctionCallFromLLM
+
+    return (
+        "tool_call",
+        FunctionCallFromLLM(
+            function_name="render_ui",
+            tool_call_id=call_id,
+            arguments=args,
+            context=None,
+        ),
+    )
+
+
+def _chips_args():
+    return {
+        "component": "QuickReplies",
+        "quick_replies": ["Best Sellers", "Leggings"],
+    }
+
+
+async def test_forced_final_chips_paint_below_the_prose(monkeypatch):
+    """The happy path: prose cycle → forced chips cycle. The bubble anchors
+    (assistant_message) BEFORE the chips ui_op — the exact inversion of the
+    live-observed chips-above-prose bug — and the chips cycle runs forced
+    (allowed=[render_ui]) on MINIMAL thinking. Cycle 1 is minimal too
+    (cycle-graded thinking: the routing cycle of a fresh turn)."""
+    agent, prep, calls, inserted = _chips_agent(
+        monkeypatch,
+        "forced_final",
+        responses=[
+            [("text", "Here you go!")],
+            [_rui_call(_chips_args())],
+        ],
+    )
+    events = await _run_chips_turn(agent, prep)
+    kinds = [ev.event for ev in events]
+
+    assert len(calls) == 2
+    assert calls[0]["allowed"] is None and calls[0]["thinking"] == "minimal"
+    assert calls[1]["allowed"] == ["render_ui"]
+    assert calls[1]["thinking"] == "minimal"
+    # The chips call saw: its own prose, then the user-role nudge
+    # (alternation-safe for Vertex; identical on next-turn replay).
+    assert calls[1]["tail"][0] == {"role": "assistant", "content": "Here you go!"}
+    assert calls[1]["tail"][1]["role"] == "user"
+    assert "final check" in calls[1]["tail"][1]["content"]
+
+    assert kinds.index("assistant_message") < kinds.index("ui_op")
+    op = next(ev.data["op"] for ev in events if ev.event == "ui_op")
+    assert op["type"] == "QuickReplies"
+    end = next(ev.data for ev in events if ev.event == "turn_end")
+    assert end["session_status"] == "ACTIVE"
+
+    # Persist order mirrors the wire: prose row → internal nudge row →
+    # chips tool rows → chips-only ui row (resume repaints below the prose).
+    prose_row = inserted[0]
+    assert prose_row["content"] == "Here you go!"
+    nudge_row = inserted[1]
+    assert nudge_row["content"] is None
+    assert nudge_row["content_blocks"][0]["visibility"] == "internal"
+    assert "final check" in nudge_row["content_blocks"][0]["text"]
+    last_row = inserted[-1]
+    assert last_row["ui_blocks"] and last_row["ui_blocks"][0]["type"] == "QuickReplies"
+
+
+async def test_forced_final_no_ui_is_a_legal_chips_outcome(monkeypatch):
+    """no_ui resolves the chips slot: no ui_op, no third cycle, healthy end
+    — forcing mandates the DECISION, never the display."""
+    agent, prep, calls, inserted = _chips_agent(
+        monkeypatch,
+        "forced_final",
+        responses=[
+            [("text", "Anything else?")],
+            [_rui_call({"decision": "no_ui", "reason": "nothing to suggest"})],
+        ],
+    )
+    events = await _run_chips_turn(agent, prep)
+    kinds = [ev.event for ev in events]
+    assert len(calls) == 2
+    assert "ui_op" not in kinds
+    decisions = [ev.data for ev in events if ev.event == "ui_decision"]
+    assert decisions and decisions[-1]["decision"] == "no_ui"
+    assert (
+        next(ev.data for ev in events if ev.event == "turn_end")["session_status"]
+        == "ACTIVE"
+    )
+
+
+async def test_chips_cycle_rejects_other_components_once_then_corrects(monkeypatch):
+    """The chips slot is QuickReplies-or-no_ui: a grid in the tail gets a
+    structured error and ONE corrective forced cycle — bounded, and the
+    turn can never end with a second grid below the reply."""
+    agent, prep, calls, inserted = _chips_agent(
+        monkeypatch,
+        "forced_final",
+        responses=[
+            [("text", "Done!")],
+            [_rui_call({"component": "ProductGrid"}, call_id="bad")],
+            [_rui_call(_chips_args(), call_id="good")],
+        ],
+    )
+    events = await _run_chips_turn(agent, prep)
+    kinds = [ev.event for ev in events]
+    assert len(calls) == 3
+    assert calls[1]["allowed"] == calls[2]["allowed"] == ["render_ui"]
+    assert kinds.count("ui_op") == 1
+    op = next(ev.data["op"] for ev in events if ev.event == "ui_op")
+    assert op["type"] == "QuickReplies"
+    # The rejected call's function response carries the slot contract.
+    error_results = [
+        row
+        for row in inserted
+        if row.get("content_blocks")
+        and any(
+            b.get("type") == "tool_result" and "end-of-turn" in str(b.get("content"))
+            for b in row["content_blocks"]
+        )
+    ]
+    assert error_results
+
+
+async def test_chips_give_up_after_two_bad_cycles(monkeypatch):
+    """Two invalid chips cycles → give up: chips skipped, turn still ends
+    ACTIVE with the reply intact. Hard bound — no drift toward the old
+    unbounded-loop failure class."""
+    agent, prep, calls, inserted = _chips_agent(
+        monkeypatch,
+        "forced_final",
+        responses=[
+            [("text", "Done!")],
+            [_rui_call({"component": "ProductGrid"}, call_id="bad1")],
+            [_rui_call({"component": "ProductGrid"}, call_id="bad2")],
+        ],
+    )
+    events = await _run_chips_turn(agent, prep)
+    kinds = [ev.event for ev in events]
+    assert len(calls) == 3
+    assert "ui_op" not in kinds
+    assert (
+        next(ev.data for ev in events if ev.event == "turn_end")["session_status"]
+        == "ACTIVE"
+    )
+
+
+async def test_chips_malformed_skips_chips_never_retries_unforced(monkeypatch):
+    """A chips cycle that produces NO call skips chips (observable via
+    force_fallback context=final_quick_replies) — never the generic
+    unforced retry, which would stream a SECOND bubble after the reply."""
+    agent, prep, calls, inserted = _chips_agent(
+        monkeypatch,
+        "forced_final",
+        responses=[
+            [("text", "All set.")],
+            [("finish_reason", "MALFORMED_FUNCTION_CALL")],
+        ],
+    )
+    events = await _run_chips_turn(agent, prep)
+    kinds = [ev.event for ev in events]
+    assert len(calls) == 2  # no third (unforced) call
+    assert "ui_op" not in kinds
+    fallback = next(ev.data for ev in events if ev.event == "force_fallback")
+    assert fallback["context"] == "final_quick_replies"
+    assert kinds.count("assistant_message") == 1
+    assert (
+        next(ev.data for ev in events if ev.event == "turn_end")["session_status"]
+        == "ACTIVE"
+    )
+
+
+async def test_forced_final_harvests_mid_turn_quick_replies(monkeypatch):
+    """Rider design (2026-08-03): a mid-turn chips call is HARVESTED —
+    the call returns ok+deferred, the held chips flush BELOW the final
+    prose, and the forced end-of-turn cycle never runs (one LLM cycle
+    saved on every turn where the model attached chips itself)."""
+    agent, prep, calls, inserted = _chips_agent(
+        monkeypatch,
+        "forced_final",
+        responses=[
+            [_rui_call(_chips_args(), call_id="early")],
+            [("text", "Here's the rundown.")],
+            [_rui_call(_chips_args(), call_id="never-runs")],
+        ],
+    )
+    events = await _run_chips_turn(agent, prep)
+    assert len(calls) == 2  # NO forced chips cycle
+    ops = [ev.data["op"] for ev in events if ev.event == "ui_op"]
+    assert len(ops) == 1 and ops[0]["type"] == "QuickReplies"
+    kinds = [ev.event for ev in events]
+    # chips paint AFTER the final prose bubble (placement is server-owned)
+    assert kinds.index("assistant_message") < kinds.index("ui_op")
+    deferred = [
+        row
+        for row in inserted
+        if row.get("content_blocks")
+        and any(
+            b.get("type") == "tool_result"
+            and "follow-ups saved" in str(b.get("content"))
+            for b in row["content_blocks"]
+        )
+    ]
+    assert deferred  # positive deferral result, never a ban error
+
+
+async def test_harvested_chips_after_prose_never_double_bubbles(monkeypatch):
+    """Live 2026-07-31 regression, rider era: the model writes its
+    greeting AND attaches chips in one cycle. The harvest returns a
+    positive deferral (an error here bred a rephrased second greeting),
+    any post-harvest ramble is suppressed, and the held chips flush after
+    the single final bubble — no forced cycle."""
+    agent, prep, calls, inserted = _chips_agent(
+        monkeypatch,
+        "forced_final",
+        responses=[
+            # Cycle 1: prose + a chips call in one breath (harvested).
+            [("text", "Hey! Welcome."), _rui_call(_chips_args(), call_id="early")],
+            # Cycle 2: the model rambles a rephrased greeting anyway —
+            # suppression must drop it.
+            [("text", "Hey there! Welcome again.")],
+            # Would-be forced chips cycle — must never run.
+            [_rui_call(_chips_args(), call_id="never-runs")],
+        ],
+    )
+    events = await _run_chips_turn(agent, prep)
+    assert len(calls) == 2  # ramble cycle ran; forced chips cycle did NOT
+    tokens = "".join(ev.data["delta"] for ev in events if ev.event == "assistant_token")
+    assert "Welcome again" not in tokens  # duplicate prose dropped
+    bubbles = [ev for ev in events if ev.event == "assistant_message"]
+    assert len(bubbles) == 1
+    assert bubbles[0].data["content"] == "Hey! Welcome."
+    ops = [ev.data["op"] for ev in events if ev.event == "ui_op"]
+    assert len(ops) == 1 and ops[0]["type"] == "QuickReplies"
+
+
+async def test_componentless_chips_call_harvests_and_single_visible_row(monkeypatch):
+    """The bare quick_replies-with-no-component shape (Flash's natural
+    emission, live 2026-07-31) is a first-class rider now: harvested,
+    suppression armed, chips flushed from the held labels. Also pins the
+    double-persist fix: the prose is VISIBLE on exactly one row (the
+    pre-chips row); the gate row demotes it to internal."""
+    agent, prep, calls, inserted = _chips_agent(
+        monkeypatch,
+        "forced_final",
+        responses=[
+            [
+                ("text", "Hey! Welcome."),
+                _rui_call({"quick_replies": ["A", "B"]}, call_id="bare"),
+            ],
+            [("text", "Hey there! Welcome again.")],
+            [_rui_call(_chips_args(), call_id="never-runs")],
+        ],
+    )
+    events = await _run_chips_turn(agent, prep)
+    assert len(calls) == 2  # no forced chips cycle
+    tokens = "".join(ev.data["delta"] for ev in events if ev.event == "assistant_token")
+    assert "Welcome again" not in tokens  # suppression armed by the harvest
+    bubbles = [ev for ev in events if ev.event == "assistant_message"]
+    assert len(bubbles) == 1
+    ops = [ev.data["op"] for ev in events if ev.event == "ui_op"]
+    assert len(ops) == 1 and ops[0]["type"] == "QuickReplies"
+    labels = [i.get("label") for i in (ops[0].get("props") or {}).get("items", [])]
+    assert labels == ["A", "B"]  # the model's own harvested labels
+    visible = [row["content"] for row in inserted if row.get("content")]
+    assert visible == ["Hey! Welcome."]  # ONE visible copy — resume shows it once
+
+
+async def test_model_choice_default_runs_no_extra_cycle(monkeypatch):
+    """Absent config = today's behavior exactly: one cycle, no forcing, no
+    nudge rows, fleet untouched."""
+    agent, prep, calls, inserted = _chips_agent(
+        monkeypatch,
+        None,
+        responses=[[("text", "Hello!")]],
+    )
+    events = await _run_chips_turn(agent, prep)
+    kinds = [ev.event for ev in events]
+    assert len(calls) == 1
+    assert calls[0]["allowed"] is None
+    assert kinds.count("assistant_message") == 1
+    assert "force_fallback" not in kinds
+
+
+async def test_quick_replies_off_removes_the_component(monkeypatch):
+    """mode='off': the handler rejects QuickReplies as unknown — the
+    component is gone from this session's render_ui surface."""
+    agent, prep, calls, inserted = _chips_agent(
+        monkeypatch,
+        "off",
+        responses=[[("text", "unused")]],
+    )
+    result = await agent._render_ui_handler(_chips_args())
+    assert result["status"] == "error"
+    assert "unknown component" in result["error"]
+
+
+def test_quick_replies_mode_validates():
+    import pytest
+    from pydantic import ValidationError
+
+    from app.ai.voice.agents.breeze_buddy.template.types import RenderUiConfig
+
+    assert RenderUiConfig(quick_replies="forced_final").quick_replies == "forced_final"
+    # Any-typed payload keeps the deliberately-invalid literal out of the
+    # static type check (pyrefly) while pydantic still rejects it.
+    bad: dict = {"quick_replies": "always"}
+    with pytest.raises(ValidationError):
+        RenderUiConfig(**bad)
+
+
+def test_render_ui_section_documents_the_chips_contract():
+    from app.ai.voice.agents.breeze_buddy.template.ui_prompt import (
+        render_render_ui_section,
+    )
+
+    forced = render_render_ui_section("forced_final")
+    assert "END of your turn" in forced
+    assert "never render" in forced
+    default = render_render_ui_section()
+    assert "END of your turn" not in default
+
+
+# ---------------------------------------------------------------------------
+# Server-derived layout (2026-07-30): never a model choice
+# ---------------------------------------------------------------------------
+
+
+def test_layout_is_server_policy_not_model_choice():
+    """``layout`` is gone from the render_ui schema; the server stamps it
+    from the FINAL hydrated count — 1-2 products sit side by side, 3+
+    scroll as a carousel. A model-passed layout arg is ignored."""
+    from app.ai.voice.agents.breeze_buddy.chat.ui.render_ui_tool import (
+        build_render_ui_schema,
+    )
+
+    schema = build_render_ui_schema(list(COMPS), handler=None)
+    assert "layout" not in schema.properties
+
+    out = execute_render_ui(
+        {
+            "component": "ProductGrid",
+            "bind": [{"prop": "products", "ref": "$tool:search_catalog#/products"}],
+            "layout": "carousel",  # ignored — 2 products stay side by side
+        },
+        store=_store(),
+        allowlist=ALLOW,
+        components=COMPS,
+        op_id="root",
+        flavor_groups=["commerce"],
+    )
+    assert out.decision == "rendered"
+    assert out.ops[0]["props"]["layout"] == "grid"
+
+    three = [
+        {"id": f"p{i}", "title": f"P{i}", "price": {"amount": 100.0 + i}}
+        for i in range(3)
+    ]
+    out = execute_render_ui(
+        {
+            "component": "ProductGrid",
+            "bind": [{"prop": "products", "ref": "$tool:search_catalog#/products"}],
+        },
+        store=_store(three),
+        allowlist=ALLOW,
+        components=COMPS,
+        op_id="root",
+        flavor_groups=["commerce"],
+    )
+    assert out.decision == "rendered"
+    assert out.ops[0]["props"]["layout"] == "carousel"
+
+
+def test_layout_stamp_respects_items_selection():
+    """The stamp uses the POST-selection count: picking 2 of 3 bound
+    products yields a side-by-side grid, not a carousel."""
+    three = [
+        {"id": f"p{i}", "title": f"P{i}", "price": {"amount": 100.0 + i}}
+        for i in range(3)
+    ]
+    out = execute_render_ui(
+        {
+            "component": "ProductGrid",
+            "bind": [{"prop": "products", "ref": "$tool:search_catalog#/products"}],
+            "items": [{"id": "p0"}, {"id": "p2"}],
+        },
+        store=_store(three),
+        allowlist=ALLOW,
+        components=COMPS,
+        op_id="root",
+        flavor_groups=["commerce"],
+    )
+    assert out.decision == "rendered"
+    assert [p["id"] for p in out.ops[0]["props"]["products"]] == ["p0", "p2"]
+    assert out.ops[0]["props"]["layout"] == "grid"
+
+
+# ---------------------------------------------------------------------------
+# ProductCard retirement (2026-07-30): one product component, count decides
+# ---------------------------------------------------------------------------
+
+
+def test_product_card_retired_from_llm_surface():
+    """ProductCard is server_only now: gone from render_ui's component
+    enum and from every prompt section; the model gets exactly one product
+    component and the count decides presentation."""
+    assert "ProductCard" not in COMPS
+    out = execute_render_ui(
+        {
+            "component": "ProductCard",
+            "bind": [{"prop": "product", "ref": "$tool:get_product#/product"}],
+        },
+        store=_store(),
+        allowlist=ALLOW,
+        components=COMPS,
+        op_id="root",
+    )
+    assert out.fn_result["status"] == "error"
+    assert "unknown component" in out.fn_result["error"]
+
+
+def test_single_object_bind_hydrates_as_one_element_grid():
+    """get_product's singular ``product`` feeds ProductGrid.products via
+    the singleton→list coercion: one-element grid, layout 'grid' (the
+    widget renders it as a full-width card)."""
+    store = BindingStore()
+    store.record(
+        "get_product",
+        "t9",
+        {"product": {"id": "p9", "title": "BB Bottle", "price": {"amount": 799.0}}},
+    )
+    out = execute_render_ui(
+        {
+            "component": "ProductGrid",
+            "bind": [{"prop": "products", "ref": "$tool:get_product#/product"}],
+        },
+        store=store,
+        allowlist=ALLOW,
+        components=COMPS,
+        op_id="root",
+    )
+    assert out.decision == "rendered"
+    props = out.ops[0]["props"]
+    assert [p["id"] for p in props["products"]] == ["p9"]
+    assert props["layout"] == "grid"
+    assert out.fn_result["count"] == 1
+
+
+async def test_rider_on_component_call_is_stripped_and_held(monkeypatch):
+    """quick_replies attached to a REAL component render (the model's
+    natural grid+chips-in-one-call shape): the rider is harvested for the
+    end-of-turn flush and the component call proceeds without it — NOT
+    the chips-only deferral path."""
+    agent, prep, calls, inserted = _chips_agent(
+        monkeypatch, "forced_final", responses=[]
+    )
+    result = await agent._render_ui_handler(
+        {"component": "ProductGrid", "quick_replies": ["Sizing help"], "bind": []}
+    )
+    assert agent._held_chips == ["Sizing help"]
+    # The component path ran (bind fails in this dataless fixture — that's
+    # fine); the chips-only deferral did not.
+    assert result.get("deferred") is None
+
+
+def _tool_call(name, args, call_id):
+    from pipecat.frames.frames import FunctionCallFromLLM
+
+    return (
+        "tool_call",
+        FunctionCallFromLLM(
+            function_name=name, tool_call_id=call_id, arguments=args, context=None
+        ),
+    )
+
+
+async def test_parallel_mutations_run_solo(monkeypatch):
+    """Mutations-run-solo guard (2026-08-03): two state mutations in one
+    parallel batch were both authored from the same pre-batch snapshot —
+    for UCP carts the second silently REVERTS the first. The first
+    dispatches; the second is deferred with a structured soft error and
+    never reaches dispatch."""
+    agent, prep, calls, inserted = _chips_agent(
+        monkeypatch,
+        None,
+        responses=[
+            [
+                _tool_call("update_cart", {}, "m1"),
+                _tool_call("update_cart", {}, "m2"),
+            ],
+            [("text", "Done!")],
+        ],
+    )
+    dispatched = []
+
+    async def _fake_dispatch(call, node, global_funcs, injected_args=None):
+        dispatched.append(call.function_name)
+        return {"status": "ok"}, None
+
+    monkeypatch.setattr(agent, "_dispatch_tool_call", _fake_dispatch)
+    events = await _run_chips_turn(agent, prep)
+    assert dispatched == ["update_cart"]  # second mutation never dispatched
+    deferred = [
+        row
+        for row in inserted
+        if row.get("content_blocks")
+        and any(
+            b.get("type") == "tool_result" and "not executed" in str(b.get("content"))
+            for b in row["content_blocks"]
+        )
+    ]
+    assert deferred
+    # Wire pairing stays balanced: both calls got function_call_completed.
+    completed = [ev for ev in events if ev.event == "function_call_completed"]
+    assert len(completed) == 2
+
+
+async def test_single_label_rider_still_flushes(monkeypatch):
+    """Live 2026-08-03: Flash attached exactly ONE decisive chip ("Add BB
+    Bottle to cart") and the old QuickReplies min_length=2 silently
+    discarded it, ending the turn chipless. A single follow-up is
+    legitimate — it must render."""
+    agent, prep, calls, inserted = _chips_agent(
+        monkeypatch,
+        "forced_final",
+        responses=[
+            [
+                ("text", "The BB Bottle is ₹1,189."),
+                _rui_call({"quick_replies": ["Add BB Bottle to cart"]}, call_id="one"),
+            ],
+            # post-tool cycle produces nothing further
+            [],
+        ],
+    )
+    events = await _run_chips_turn(agent, prep)
+    assert len(calls) == 2  # rider flushed at turn end; no forced cycle
+    ops = [ev.data["op"] for ev in events if ev.event == "ui_op"]
+    assert len(ops) == 1 and ops[0]["type"] == "QuickReplies"
+    labels = [i.get("label") for i in (ops[0].get("props") or {}).get("items", [])]
+    assert labels == ["Add BB Bottle to cart"]

--- a/tests/test_step_labels.py
+++ b/tests/test_step_labels.py
@@ -1,0 +1,131 @@
+"""chat/step_labels — label resolution (fallback + registered) and the
+generic step-completion summarizer."""
+
+from __future__ import annotations
+
+from app.ai.voice.agents.breeze_buddy.chat.steps.labels import (
+    register_step_labels,
+    resolve_step_label,
+    resolve_step_status,
+    summarize_step_result,
+)
+
+# ---------------------------------------------------------------------------
+# resolve_step_label — generic humanizer fallback
+# ---------------------------------------------------------------------------
+
+
+def test_fallback_humanizes_verb_object_names():
+    assert resolve_step_label("scan_shelf") == (
+        "Scanning the shelf",
+        "Scanned the shelf",
+    )
+
+
+def test_fallback_search_catalog_shape():
+    # The canonical example from the UX spec. (The commerce flavor registers
+    # the same strings explicitly; the fallback must match it unaided.)
+    running, done = resolve_step_label("search_catalog")
+    assert running == "Searching the catalog"
+    assert done == "Searched the catalog"
+
+
+def test_fallback_e_drop_and_multiword_object():
+    assert resolve_step_label("update_shipping_address") == (
+        "Updating the shipping address",
+        "Updated the shipping address",
+    )
+
+
+def test_fallback_irregular_verb():
+    assert resolve_step_label("get_order") == ("Getting the order", "Got the order")
+
+
+def test_fallback_single_word_tool():
+    # Single-word names still produce something human-ish, never a raw echo;
+    # exact conjugation is best-effort.
+    running, done = resolve_step_label("search")
+    assert running == "Searching"
+    assert done == "Searched"
+
+
+def test_fallback_empty_name_is_safe():
+    assert resolve_step_label("") == ("Working", "Done")
+
+
+# ---------------------------------------------------------------------------
+# resolve_step_label — registry
+# ---------------------------------------------------------------------------
+
+
+def test_registered_labels_win_over_humanizer():
+    register_step_labels({"frobnicate_widget": ("Frobnicating", "Frobnicated")})
+    assert resolve_step_label("frobnicate_widget") == ("Frobnicating", "Frobnicated")
+
+
+def test_commerce_registration_hook():
+    # Importing the flavor schemas module (what ensure_group_loaded("commerce")
+    # does) must register the commerce labels as a side effect.
+    import app.ai.voice.agents.breeze_buddy.assist.commerce.ucp.schemas  # noqa: F401
+
+    assert resolve_step_label("lookup_catalog") == (
+        "Looking up products",
+        "Looked up products",
+    )
+    assert resolve_step_label("update_cart") == (
+        "Updating your cart",
+        "Updated your cart",
+    )
+    assert resolve_step_label("get_cart") == (
+        "Checking your cart",
+        "Checked your cart",
+    )
+
+
+# ---------------------------------------------------------------------------
+# resolve_step_status
+# ---------------------------------------------------------------------------
+
+
+def test_status_error_envelope():
+    assert resolve_step_status({"status": "error", "error": "boom"}) == "error"
+    assert resolve_step_status({"status": "failed"}) == "error"
+
+
+def test_status_ok_default():
+    assert resolve_step_status({"products": []}) == "ok"
+    assert resolve_step_status("plain string result") == "ok"
+    assert resolve_step_status({"status": "success"}) == "ok"
+
+
+# ---------------------------------------------------------------------------
+# summarize_step_result — generic keys only
+# ---------------------------------------------------------------------------
+
+
+def test_summary_products_list():
+    summary, count = summarize_step_result({"products": [{}, {}, {}]})
+    assert summary == "3 results"
+    assert count == 3
+
+
+def test_summary_products_singular():
+    assert summarize_step_result({"products": [{}]}) == ("1 result", 1)
+
+
+def test_summary_line_items():
+    summary, count = summarize_step_result({"id": "c1", "line_items": [{}, {}]})
+    assert summary == "cart updated · 2 items"
+    assert count == 2
+
+
+def test_summary_products_precedence_over_line_items():
+    summary, count = summarize_step_result({"products": [{}], "line_items": [{}, {}]})
+    assert (summary, count) == ("1 result", 1)
+
+
+def test_summary_omitted_for_other_shapes():
+    assert summarize_step_result({"status": "success"}) == (None, None)
+    assert summarize_step_result("text") == (None, None)
+    assert summarize_step_result(None) == (None, None)
+    assert summarize_step_result({"products": "not-a-list"}) == (None, None)

--- a/tests/test_ui_binding.py
+++ b/tests/test_ui_binding.py
@@ -1,0 +1,517 @@
+"""Tests for catalog-v2 server-side data binding (RFC-001).
+
+Covers the bind-ref grammar, RFC 6901 pointer walks, the per-turn
+BindingStore, and resolve_show_op — hydration, schema validation,
+max_items capping, and the bind_unresolved / bind_validation_failed
+error family.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from app.ai.voice.agents.breeze_buddy.chat.ui.binding import (
+    BindingStore,
+    parse_bind_ref,
+    resolve_json_pointer,
+    resolve_show_op,
+)
+
+# Load template package first so its __init__ chain completes before any
+# `chat/*` module import drags in field_resolver mid-load (same trap as
+# the sibling ui_stream / session_state tests).
+from app.ai.voice.agents.breeze_buddy.template.ui_catalog import ensure_group_loaded
+
+# The commerce components these fixtures bind against are a lazily-loaded
+# flavor group — register them the way a commerce-enabled template
+# resolution would.
+ensure_group_loaded("commerce")
+
+# ---------------------------------------------------------------------------
+# Fixtures — post-pipeline (projected/transformed) tool results
+# ---------------------------------------------------------------------------
+
+
+def _envelope(payload: dict, status: str = "success") -> dict:
+    """The dispatcher's FlowResult envelope (MCP shape: JSON-string data)."""
+    return {"status": status, "data": json.dumps(payload)}
+
+
+PRODUCTS_FIXTURE = {
+    "products": [
+        {
+            "id": "gid://shopify/Product/1",
+            "title": "High Support Sports Bra",
+            "url": "https://shop.example/products/bra",
+            "image": {"src": "https://cdn.example/bra.jpg", "alt": "Bra"},
+            "price": {"amount": 1699.0, "currency": "INR"},
+            "tags": ["bestseller"],
+        },
+        {
+            "id": "gid://shopify/Product/2",
+            "title": "Seamless Leggings",
+            "price": {"amount": 2199.0, "currency": "INR"},
+        },
+    ]
+}
+
+
+def _store_with(name: str, payload: dict, tool_use_id: str = "toolu_1"):
+    store = BindingStore()
+    assert store.record(name, tool_use_id, _envelope(payload))
+    return store
+
+
+# ---------------------------------------------------------------------------
+# parse_bind_ref — grammar
+# ---------------------------------------------------------------------------
+
+
+def test_parse_bind_ref_plain():
+    ref = parse_bind_ref("$tool:search_catalog#/products")
+    assert ref is not None
+    assert ref.tool_name == "search_catalog"
+    assert ref.tool_use_id is None
+    assert ref.pointer == "/products"
+
+
+def test_parse_bind_ref_with_tool_use_id():
+    ref = parse_bind_ref("$tool:update_cart@toolu_abc123#/line_items")
+    assert ref is not None
+    assert ref.tool_name == "update_cart"
+    assert ref.tool_use_id == "toolu_abc123"
+    assert ref.pointer == "/line_items"
+
+
+def test_parse_bind_ref_whole_payload_pointer():
+    ref = parse_bind_ref("$tool:get_cart#")
+    assert ref is not None
+    assert ref.pointer == ""
+
+
+def test_parse_bind_ref_nested_pointer():
+    ref = parse_bind_ref("$tool:search_catalog#/products/0/price")
+    assert ref is not None
+    assert ref.pointer == "/products/0/price"
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        "search_catalog#/products",  # missing $tool: prefix
+        "$tool:search_catalog",  # missing # pointer separator
+        "$tool:#/products",  # empty tool name
+        "$tool:search catalog#/products",  # space in tool name
+        "$tool:search_catalog#products",  # pointer must start with /
+        "$state:cart_id#/",  # unknown scheme
+        42,  # not a string
+    ],
+)
+def test_parse_bind_ref_rejects_bad_grammar(bad):
+    assert parse_bind_ref(bad) is None
+
+
+# ---------------------------------------------------------------------------
+# resolve_json_pointer — RFC 6901 walks
+# ---------------------------------------------------------------------------
+
+
+def test_pointer_walks_dicts_and_lists():
+    doc = {"a": [{"b": 7}]}
+    value, found = resolve_json_pointer(doc, "/a/0/b")
+    assert found and value == 7
+
+
+def test_pointer_empty_returns_whole_doc():
+    doc = {"a": 1}
+    value, found = resolve_json_pointer(doc, "")
+    assert found and value is doc
+
+
+def test_pointer_unescapes_tilde_tokens():
+    doc = {"a/b": {"c~d": 3}}
+    value, found = resolve_json_pointer(doc, "/a~1b/c~0d")
+    assert found and value == 3
+
+
+@pytest.mark.parametrize(
+    "pointer",
+    ["/missing", "/a/5", "/a/x", "/a/0/b/deeper", "/a/00"],
+)
+def test_pointer_misses_report_not_found(pointer):
+    doc = {"a": [{"b": 1}]}
+    _, found = resolve_json_pointer(doc, pointer)
+    assert not found
+
+
+# ---------------------------------------------------------------------------
+# BindingStore
+# ---------------------------------------------------------------------------
+
+
+def test_store_unwraps_envelope_and_resolves_latest():
+    store = BindingStore()
+    store.record("search_catalog", "t1", _envelope({"products": ["old"]}))
+    store.record("search_catalog", "t2", _envelope({"products": ["new"]}))
+    assert store.resolve("search_catalog") == {"products": ["new"]}
+    assert store.resolve("search_catalog", "t1") == {"products": ["old"]}
+
+
+def test_store_skips_error_envelopes():
+    store = BindingStore()
+    assert not store.record("update_cart", "t1", _envelope({}, status="error"))
+    assert store.resolve("update_cart") is None
+
+
+def test_store_unknown_tool_resolves_none():
+    store = BindingStore()
+    assert store.resolve("never_ran") is None
+
+
+# ---------------------------------------------------------------------------
+# resolve_show_op — hydration + validation + caps
+# ---------------------------------------------------------------------------
+
+
+def _grid_show_op(**overrides):
+    op = {
+        "op": "show",
+        "id": "pg1",
+        "component": "ProductGrid",
+        "bind": {"products": "$tool:search_catalog#/products"},
+        "props": {"max_items": 6, "layout": "carousel"},
+    }
+    op.update(overrides)
+    return op
+
+
+def test_resolve_hydrates_product_grid():
+    store = _store_with("search_catalog", PRODUCTS_FIXTURE)
+    result = resolve_show_op(_grid_show_op(), store)
+    assert result.error is None
+    op = result.op
+    assert op is not None
+    assert op["op"] == "add"
+    assert op["type"] == "ProductGrid"
+    assert op["v"] == 2
+    props = op["props"]
+    assert props["layout"] == "carousel"
+    assert [p["title"] for p in props["products"]] == [
+        "High Support Sports Bra",
+        "Seamless Leggings",
+    ]
+    # Hydrated values are schema-normalised (HttpUrl → str, defaults filled).
+    assert props["products"][0]["image"]["src"] == "https://cdn.example/bra.jpg"
+    assert props["products"][0]["price"] == {"amount": 1699.0, "currency": "INR"}
+
+
+def test_resolve_caps_bound_list_at_max_items():
+    many = {
+        "products": [
+            {"id": f"p{i}", "title": f"P{i}", "price": {"amount": 1.0}}
+            for i in range(10)
+        ]
+    }
+    store = _store_with("search_catalog", many)
+    op = _grid_show_op(props={"max_items": 3})
+    result = resolve_show_op(op, store)
+    assert result.error is None
+    assert result.op is not None
+    assert len(result.op["props"]["products"]) == 3
+
+
+def test_resolve_caps_default_max_items_from_schema():
+    many = {
+        "products": [
+            {"id": f"p{i}", "title": f"P{i}", "price": {"amount": 1.0}}
+            for i in range(12)
+        ]
+    }
+    store = _store_with("search_catalog", many)
+    result = resolve_show_op(_grid_show_op(props={}), store)
+    assert result.error is None
+    assert result.op is not None
+    # ProductGrid.max_items defaults to 10 (= one full UCP search page,
+    # so LLM context and the rendered grid always agree — user decision
+    # 2026-07-29 "everything 10").
+    assert len(result.op["props"]["products"]) == 10
+
+
+def _many_products(n: int) -> dict:
+    return {
+        "products": [
+            {"id": f"p{i}", "title": f"P{i}", "price": {"amount": 1.0}}
+            for i in range(n)
+        ]
+    }
+
+
+def test_items_selects_by_id_regardless_of_rank():
+    """Fuzzy-search fix: the shopper's product may sit at ANY rank in the
+    page — items[] picks it (and orders the render) by id."""
+    store = _store_with("search_catalog", _many_products(10))
+    op = _grid_show_op(props={"items": [{"id": "p7"}, {"id": "p2"}]})
+    result = resolve_show_op(op, store)
+    assert result.error is None
+    assert result.op is not None
+    assert [p["id"] for p in result.op["props"]["products"]] == ["p7", "p2"]
+    # Selection directive is applied server-side, never a render prop.
+    assert "items" not in result.op["props"]
+
+
+def test_items_unknown_entries_are_ignored():
+    """A mangled id selects nothing — the model cannot inject items; the
+    well-formed ids still render."""
+    store = _store_with("search_catalog", _many_products(4))
+    op = _grid_show_op(props={"items": [{"id": "p3"}, {"id": "gid://bogus/999"}]})
+    result = resolve_show_op(op, store)
+    assert result.error is None
+    assert result.op is not None
+    assert [p["id"] for p in result.op["props"]["products"]] == ["p3"]
+
+
+def test_items_all_unknown_falls_open_to_full_list():
+    """Every id bogus → filter ignored entirely; the full (capped) tool
+    list beats an empty render."""
+    store = _store_with("search_catalog", _many_products(3))
+    op = _grid_show_op(props={"items": [{"id": "nope-1"}, {"id": "nope-2"}]})
+    result = resolve_show_op(op, store)
+    assert result.error is None
+    assert result.op is not None
+    assert [p["id"] for p in result.op["props"]["products"]] == ["p0", "p1", "p2"]
+
+
+def test_items_selection_runs_before_max_items_cap():
+    store = _store_with("search_catalog", _many_products(12))
+    op = _grid_show_op(
+        props={
+            "items": [{"id": "p11"}, {"id": "p10"}, {"id": "p9"}],
+            "max_items": 2,
+        }
+    )
+    result = resolve_show_op(op, store)
+    assert result.error is None
+    assert result.op is not None
+    # Selection first (rank-independent), then the cap applies to it.
+    assert [p["id"] for p in result.op["props"]["products"]] == ["p11", "p10"]
+
+
+def test_items_feature_variant_rederives_hero_and_stamps_id():
+    """RFC-003 §4 variant continuity: feature_variant re-derives the card
+    hero (price) from that variant record and stamps featured_variant_id;
+    an unknown variant id is fail-open (entry untouched)."""
+    payload = {
+        "products": [
+            {
+                "id": "p1",
+                "title": "CoreFlex Shorts",
+                "price": {"amount": 999.0},
+                "variants": [
+                    {"id": "v-black", "title": "S / Black", "price": {"amount": 999.0}},
+                    {"id": "v-pink", "title": "S / Pink", "price": {"amount": 1099.0}},
+                ],
+            }
+        ]
+    }
+    store = _store_with("search_catalog", payload)
+    op = _grid_show_op(props={"items": [{"id": "p1", "feature_variant": "v-pink"}]})
+    result = resolve_show_op(op, store)
+    assert result.error is None
+    assert result.op is not None
+    entry = result.op["props"]["products"][0]
+    assert entry["featured_variant_id"] == "v-pink"
+    assert entry["price"]["amount"] == 1099.0
+    # Unknown variant id → untouched entry, no stamp, original hero.
+    op2 = _grid_show_op(props={"items": [{"id": "p1", "feature_variant": "v-nope"}]})
+    result2 = resolve_show_op(op2, store)
+    assert result2.error is None
+    assert result2.op is not None
+    entry2 = result2.op["props"]["products"][0]
+    assert "featured_variant_id" not in entry2
+    assert entry2["price"]["amount"] == 999.0
+
+
+def test_resolve_unresolved_tool_drops_with_reason():
+    store = BindingStore()  # search_catalog never ran this turn
+    result = resolve_show_op(_grid_show_op(), store)
+    assert result.op is None
+    assert result.error == "bind_unresolved:search_catalog:/products"
+
+
+def test_resolve_unresolved_pointer_drops_with_reason():
+    store = _store_with("search_catalog", {"items": []})
+    result = resolve_show_op(_grid_show_op(), store)
+    assert result.op is None
+    assert result.error == "bind_unresolved:search_catalog:/products"
+
+
+def test_resolve_stale_disambiguator_drops():
+    store = _store_with("search_catalog", PRODUCTS_FIXTURE, tool_use_id="t1")
+    op = _grid_show_op(bind={"products": "$tool:search_catalog@t9#/products"})
+    result = resolve_show_op(op, store)
+    assert result.op is None
+    assert result.error is not None and result.error.startswith("bind_unresolved:")
+
+
+def test_resolve_invalid_hydrated_props_fail_validation():
+    # products missing required fields → schema failure, structural detail only.
+    store = _store_with("search_catalog", {"products": [{"nope": True}]})
+    result = resolve_show_op(_grid_show_op(props={}), store)
+    assert result.op is None
+    assert result.error is not None
+    assert result.error.startswith("bind_validation_failed:ProductGrid:")
+    assert "nope" not in result.error  # never echoes input values
+
+
+def test_resolve_rejects_non_data_bound_component():
+    store = _store_with("search_catalog", PRODUCTS_FIXTURE)
+    result = resolve_show_op(_grid_show_op(component="Tile"), store)
+    assert result.op is None
+    assert result.error is not None and "Tile" in result.error
+
+
+def test_resolve_respects_allowlist():
+    store = _store_with("search_catalog", PRODUCTS_FIXTURE)
+    result = resolve_show_op(_grid_show_op(), store, allowlist={"CartView"})
+    assert result.op is None
+    assert result.error == "show_component_disabled:ProductGrid"
+
+
+def test_resolve_carries_parent_through():
+    store = _store_with("search_catalog", PRODUCTS_FIXTURE)
+    result = resolve_show_op(_grid_show_op(parent="root"), store)
+    assert result.error is None
+    assert result.op is not None
+    assert result.op["parent"] == "root"
+
+
+def test_resolve_cart_view_from_raw_ucp_shape():
+    """CartLineP's UCP lift: raw cart lines (item.title / quantity / totals)
+    validate without a template projection."""
+    cart = {
+        "id": "gid://shopify/Cart/c1?key=k1",
+        "line_items": [
+            {
+                "id": "line1",
+                "quantity": 2,
+                "item": {
+                    "id": "gid://shopify/ProductVariant/9",
+                    "title": "High Support Sports Bra - M",
+                    "image_url": "https://cdn.example/bra.jpg",
+                    "price": 1699.0,
+                },
+                "totals": [{"type": "total", "amount": 3398.0}],
+            }
+        ],
+        "totals": [{"type": "total", "amount": 3398.0}],
+        "cart_token": "c1%3Fkey%3Dk1",
+    }
+    store = _store_with("update_cart", cart)
+    op = {
+        "op": "show",
+        "id": "root",
+        "component": "CartView",
+        "bind": {
+            "cart_id": "$tool:update_cart#/id",
+            "line_items": "$tool:update_cart#/line_items",
+            "totals": "$tool:update_cart#/totals",
+            "cart_token": "$tool:update_cart#/cart_token",
+        },
+        "props": {
+            "checkout": {
+                "label": "Review and checkout",
+                "url": "https://shop.example/cart",
+            }
+        },
+    }
+    result = resolve_show_op(op, store)
+    assert result.error is None
+    assert result.op is not None
+    props = result.op["props"]
+    assert props["cart_id"] == "gid://shopify/Cart/c1?key=k1"
+    line = props["line_items"][0]
+    assert line["title"] == "High Support Sports Bra - M"
+    assert line["qty"] == 2
+    assert line["line_total"] == {"amount": 3398.0, "currency": "INR"}
+    assert line["variant_id"] == "gid://shopify/ProductVariant/9"
+    assert props["checkout"]["url"] == "https://shop.example/cart"
+    assert props["cart_token"] == "c1%3Fkey%3Dk1"
+
+
+def test_resolve_product_grid_from_raw_ucp_shape():
+    """ProductP's UCP lift: price_range.min → price, media[0] → image."""
+    raw = {
+        "products": [
+            {
+                "id": "gid://shopify/Product/7",
+                "title": "Trail Shoe",
+                "price_range": {"min": {"amount": 4999.0, "currency": "INR"}},
+                "media": [{"url": "https://cdn.example/shoe.jpg", "alt_text": "Shoe"}],
+            }
+        ]
+    }
+    store = _store_with("search_catalog", raw)
+    result = resolve_show_op(_grid_show_op(props={}), store)
+    assert result.error is None
+    assert result.op is not None
+    product = result.op["props"]["products"][0]
+    assert product["price"] == {"amount": 4999.0, "currency": "INR"}
+    assert product["image"] == {"src": "https://cdn.example/shoe.jpg", "alt": "Shoe"}
+
+
+def test_resolve_projects_default_variant_id_for_single_variant():
+    """Exactly one available variant → its GID lands in default_variant_id
+    (drives the widget's built-in add_to_cart); multi-variant products get
+    None (routed through view_product instead)."""
+    raw = {
+        "products": [
+            {
+                "id": "p-single",
+                "title": "One Size Cap",
+                "price": {"amount": 499.0},
+                "variants": [{"id": "gid://shopify/ProductVariant/11"}],
+            },
+            {
+                "id": "p-multi",
+                "title": "Sports Bra",
+                "price": {"amount": 1699.0},
+                "variants": [
+                    {
+                        "id": "gid://shopify/ProductVariant/21",
+                        "availability": "available",
+                    },
+                    {
+                        "id": "gid://shopify/ProductVariant/22",
+                        "availability": "available",
+                    },
+                ],
+            },
+            {
+                "id": "p-one-left",
+                "title": "Last Colour Tee",
+                "price": {"amount": 899.0},
+                "variants": [
+                    {
+                        "id": "gid://shopify/ProductVariant/31",
+                        "availability": "sold_out",
+                    },
+                    {
+                        "id": "gid://shopify/ProductVariant/32",
+                        "availability": "available",
+                    },
+                ],
+            },
+        ]
+    }
+    store = _store_with("search_catalog", raw)
+    result = resolve_show_op(_grid_show_op(props={}), store)
+    assert result.error is None
+    assert result.op is not None
+    by_id = {p["id"]: p for p in result.op["props"]["products"]}
+    assert by_id["p-single"]["default_variant_id"] == "gid://shopify/ProductVariant/11"
+    assert "default_variant_id" not in by_id["p-multi"]  # exclude_none dump
+    assert (
+        by_id["p-one-left"]["default_variant_id"] == "gid://shopify/ProductVariant/32"
+    )

--- a/tests/test_ui_stream_show.py
+++ b/tests/test_ui_stream_show.py
@@ -1,0 +1,281 @@
+"""Tests for the catalog-v2 ``show`` op path through ui_stream (RFC-001).
+
+Covers parse_op_line's show branch (component gating, bind-ref grammar,
+props collisions, parent rules), process_op_line's resolver threading
+(healer bypass, no-resolver suppression, hydrated emission), the
+data_bound `add`-op rejection, and the RFC §9.2 golden test: a fixture
+search_catalog result + a show ProductGrid line → the exact hydrated op.
+"""
+
+from __future__ import annotations
+
+import json
+
+from app.ai.voice.agents.breeze_buddy.chat.ui.binding import (
+    BindingStore,
+    resolve_show_op,
+)
+from app.ai.voice.agents.breeze_buddy.chat.ui.healer import (
+    HealerContext,
+    make_healer_fn,
+)
+from app.ai.voice.agents.breeze_buddy.chat.ui.stream import (
+    parse_op_line,
+    process_op_line,
+)
+
+# Load template package first — same circular-import precaution as the
+# sibling ui_stream / ui_binding tests.
+from app.ai.voice.agents.breeze_buddy.template.ui_catalog import ensure_group_loaded
+
+# The commerce components these fixtures target are a lazily-loaded flavor
+# group — register them the way a commerce-enabled template resolution
+# would.
+ensure_group_loaded("commerce")
+
+ALLOW = {"Stack", "Tile", "ProductGrid", "ProductCard", "CartView"}
+
+
+def _show_line(**overrides) -> str:
+    op = {
+        "op": "show",
+        "id": "root",
+        "component": "ProductGrid",
+        "bind": {"products": "$tool:search_catalog#/products"},
+        "props": {"max_items": 6, "layout": "carousel"},
+    }
+    op.update(overrides)
+    return json.dumps(op)
+
+
+# ---------------------------------------------------------------------------
+# parse_op_line — show branch
+# ---------------------------------------------------------------------------
+
+
+def test_show_parses_unhydrated_with_marker():
+    result = parse_op_line(_show_line(), allowlist=ALLOW)
+    assert result.error is None
+    assert result.op is not None
+    assert result.op["op"] == "show"  # unhydrated — resolver marker
+    assert result.op["bind"] == {"products": "$tool:search_catalog#/products"}
+
+
+def test_show_unknown_component():
+    result = parse_op_line(_show_line(component="MysteryGrid"), allowlist=ALLOW)
+    assert result.error == "show_unknown_component:'MysteryGrid'"
+
+
+def test_show_component_disabled():
+    result = parse_op_line(_show_line(), allowlist={"Stack", "Tile"})
+    assert result.error == "show_component_disabled:ProductGrid"
+
+
+def test_show_component_not_data_bound():
+    result = parse_op_line(_show_line(component="Tile"), allowlist=ALLOW)
+    assert result.error == "show_component_not_data_bound:Tile"
+
+
+def test_show_missing_bind():
+    line = json.dumps({"op": "show", "id": "root", "component": "ProductGrid"})
+    result = parse_op_line(line, allowlist=ALLOW)
+    assert result.error == "show_missing_bind"
+
+
+def test_show_bad_bind_ref():
+    result = parse_op_line(
+        _show_line(bind={"products": "search_catalog/products"}), allowlist=ALLOW
+    )
+    assert result.error == "bad_bind_ref:products"
+
+
+def test_show_bind_props_collision():
+    result = parse_op_line(
+        _show_line(props={"products": [], "layout": "grid"}), allowlist=ALLOW
+    )
+    assert result.error == "bind_props_collision:products"
+
+
+def test_show_parent_rules_match_add():
+    assert parse_op_line(_show_line(id="root"), allowlist=ALLOW).error is None
+    assert (
+        parse_op_line(_show_line(id="pg9"), allowlist=ALLOW).error == "missing_parent"
+    )
+    assert (
+        parse_op_line(_show_line(id="pg9", parent="root"), allowlist=ALLOW).error
+        is None
+    )
+
+
+def test_add_of_data_bound_component_is_rejected():
+    line = json.dumps(
+        {
+            "op": "add",
+            "id": "root",
+            "type": "ProductGrid",
+            "props": {"products": [{"id": "x", "title": "T", "price": 1}]},
+        }
+    )
+    result = parse_op_line(line, allowlist=ALLOW)
+    assert result.error == "data_bound_requires_show:ProductGrid"
+
+
+# ---------------------------------------------------------------------------
+# process_op_line — resolver threading
+# ---------------------------------------------------------------------------
+
+
+def _envelope(payload: dict) -> dict:
+    return {"status": "success", "data": json.dumps(payload)}
+
+
+SEARCH_FIXTURE = {
+    "products": [
+        {
+            "id": "gid://shopify/Product/1",
+            "title": "High Support Sports Bra",
+            "url": "https://shop.example/products/bra",
+            "image": {"src": "https://cdn.example/bra.jpg", "alt": "Bra"},
+            "price": {"amount": 1699.0, "currency": "INR"},
+            "tags": ["bestseller"],
+        },
+        {
+            "id": "gid://shopify/Product/2",
+            "title": "Seamless Leggings",
+            "price": {"amount": 2199.0, "currency": "INR"},
+        },
+    ]
+}
+
+
+def _resolver(store: BindingStore, allowlist=None):
+    def _resolve(op):
+        return resolve_show_op(op, store, allowlist)
+
+    return _resolve
+
+
+def test_process_show_without_resolver_drops():
+    events = process_op_line(_show_line(id="root"), allowlist=ALLOW)
+    assert [e.event for e in events] == ["ui_op_dropped"]
+    assert events[0].data["reason"] == "show_no_resolver"
+
+
+def test_process_show_hydrates_and_emits_ui_op():
+    store = BindingStore()
+    store.record("search_catalog", "t1", _envelope(SEARCH_FIXTURE))
+    events = process_op_line(
+        _show_line(id="root"),
+        allowlist=ALLOW,
+        show_resolver=_resolver(store, ALLOW),
+    )
+    assert [e.event for e in events] == ["ui_op"]
+    op = events[0].data["op"]
+    assert op["op"] == "add" and op["type"] == "ProductGrid" and op["v"] == 2
+
+
+def test_process_show_unresolved_bind_drops_with_reason():
+    events = process_op_line(
+        _show_line(id="root"),
+        allowlist=ALLOW,
+        show_resolver=_resolver(BindingStore(), ALLOW),
+    )
+    assert [e.event for e in events] == ["ui_op_dropped"]
+    assert events[0].data["reason"] == "bind_unresolved:search_catalog:/products"
+
+
+def test_process_show_bypasses_healer():
+    """The healer must never touch a show op — validate-or-drop only. A
+    show line with an invalid ref drops even though a healer is active,
+    and no healer_applied event fires for it."""
+    store = BindingStore()
+    store.record("search_catalog", "t1", _envelope(SEARCH_FIXTURE))
+    healer = make_healer_fn(HealerContext(session_data={}, known_ids=set()))
+    bad = _show_line(id="root", bind={"products": "not-a-ref"})
+    events = process_op_line(
+        bad,
+        healer=healer,
+        known_ids=set(),
+        allowlist=ALLOW,
+        show_resolver=_resolver(store, ALLOW),
+    )
+    assert [e.event for e in events] == ["ui_op_dropped"]
+    assert events[0].data["reason"] == "bad_bind_ref:products"
+
+    # And a valid show line passes through the same healer-armed path
+    # untouched (no healer_applied noise).
+    events = process_op_line(
+        _show_line(id="root"),
+        healer=healer,
+        known_ids=set(),
+        allowlist=ALLOW,
+        show_resolver=_resolver(store, ALLOW),
+    )
+    assert [e.event for e in events] == ["ui_op"]
+
+
+def test_process_show_with_parent_anchors_root():
+    """A hydrated show parented to `root` gets the same Stack-root
+    injection as any add op — the anchoring path is shared."""
+    store = BindingStore()
+    store.record("search_catalog", "t1", _envelope(SEARCH_FIXTURE))
+    events = process_op_line(
+        _show_line(id="pg1", parent="root"),
+        known_ids=set(),
+        allowlist=ALLOW,
+        show_resolver=_resolver(store, ALLOW),
+    )
+    assert [e.event for e in events] == ["ui_op", "ui_op"]
+    assert events[0].data["op"]["id"] == "root"  # injected Stack anchor
+    assert events[1].data["op"]["type"] == "ProductGrid"
+
+
+# ---------------------------------------------------------------------------
+# Golden test (RFC-001 §9.2): fixture search_catalog result + show line →
+# EXACT hydrated op.
+# ---------------------------------------------------------------------------
+
+
+def test_golden_search_to_hydrated_product_grid():
+    store = BindingStore()
+    store.record("search_catalog", "toolu_01", _envelope(SEARCH_FIXTURE))
+    line = (
+        '{"op":"show","id":"root","component":"ProductGrid",'
+        '"bind":{"products":"$tool:search_catalog#/products"},'
+        '"props":{"max_items":6,"layout":"carousel"}}'
+    )
+    events = process_op_line(
+        line, allowlist=ALLOW, show_resolver=_resolver(store, ALLOW)
+    )
+    assert len(events) == 1 and events[0].event == "ui_op"
+    assert events[0].data["op"] == {
+        "op": "add",
+        "id": "root",
+        "type": "ProductGrid",
+        "props": {
+            "products": [
+                {
+                    "id": "gid://shopify/Product/1",
+                    "title": "High Support Sports Bra",
+                    "url": "https://shop.example/products/bra",
+                    "image": {"src": "https://cdn.example/bra.jpg", "alt": "Bra"},
+                    "price": {"amount": 1699.0, "currency": "INR"},
+                    "tags": ["bestseller"],
+                    # Stage-B variant projection: empty for products whose
+                    # payload names no (or one) variant — same
+                    # empty-collection precedent as tags.
+                    "variants": [],
+                },
+                {
+                    "id": "gid://shopify/Product/2",
+                    "title": "Seamless Leggings",
+                    "price": {"amount": 2199.0, "currency": "INR"},
+                    "tags": [],
+                    "variants": [],
+                },
+            ],
+            "max_items": 6,
+            "layout": "carousel",
+        },
+        "v": 2,
+    }


### PR DESCRIPTION
Layer 4 — the commerce flavor pack. Plain PR against `release`, on top of the generative-UI engine (#975) and the ui-intent engine (#983).

## What this is

Every layer before this deliberately shipped mechanism with no vocabulary: the engine knows *how* to render a component, dispatch a direct intent, summarize a step, or transform a selector — it just doesn't know what a cart is. This PR is the other half: the `commerce` flavor registers into all of those seams and nothing else.

**`assist/commerce/`** — `schemas.py` is the lazy-load entry point (`ui_catalog.ensure_group_loaded("commerce")` imports it, which registers everything else):
- `intents.py` — the 6 ui-intent policies (`add_to_cart`, `remove_line`, `set_qty`, `view_product` DIRECT; `enrich_product` AGENT_TURN; `checkout` CLIENT), their payload models, cart drivers, and the CartView show-op builder.
- `render_ui.py` — the render_ui flavor pack (tool/bind/items copy, repeat-grid merge, summarizer, post-hydration projection) plus the `feature_variant` selector transform.
- `ui_prompt.py` — the commerce render_ui prompt section.
- `step_labels.py`, `tool_meta.py`, `annotator.py`, `media.py`, `upsell.py` — step summaries, tool annotations, media handling, and the post-cart upsell follow-up.

## Scope + risk

**25 files, +7013, and every one of them is an addition — no existing file is modified.** The flavor is reached only through registries that already shipped, so a template that doesn't set `enabled_groups: ["commerce"]` never imports any of it and behaves exactly as it does today. Voice, telephony, and every existing chat template are untouched by construction.

This is also what makes the `commerce` registry entries in `LAZY_GROUPS` / `FLAVOR_INTENT_MODULES` resolve for the first time — they were dormant (and fail-open) until now.

## Verification

- **1088 passed**, pyrefly **0 errors**, black/isort/autoflake clean.
- ~2000 of those lines are the tests: intent policies + payload contract, lazy loading, schemas, upsell, media, plus the engine-side suites this flavor exercises (render_ui phase A, ui binding, ui stream show, step labels, fan-out verification).
- The 4 `tests/test_chat_analytics.py` failures are **pre-existing on `release`** (from the `d886d73` analytics package refactor) — reproducible on a bare `origin/release` checkout with none of this branch's code. This PR touches no analytics files.

Rebased onto `release` @ `df12f01`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JtrUcWv8oqFfZpiQourEGU


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added commerce support for product search, product details, variants, pricing, availability, and media galleries.
  * Added interactive product grids, cart views, checkout links, and cart actions such as adding, removing, and updating quantities.
  * Added clearer live progress labels and concise summaries for catalog and cart activity.
  * Added relevant product upsell suggestions after items are added to the cart.
  * Added support for commerce experiences to load only when enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->