### PR TITLE
fix(security): SSRF egress guard on every server-side fetch (PT-03/07/11/17)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -139,6 +139,11 @@ BREEZE_MCP_ENDPOINT_PATH="/ai/neurolink"
 # enable it (per-deployment) when template authorship is fully trusted.
 ENABLE_CUSTOM_PYTHON_FUNCTIONS=false
 TWILIO_ACCOUNT_SID=""
+
+# Allow server-side egress to private/loopback ranges. LOCAL DEV ONLY — leave
+# false in production so the SSRF egress guard blocks internal/metadata targets
+# regardless of ENVIRONMENT.
+SSRF_ALLOW_PRIVATE_EGRESS=false
 TWILIO_AUTH_TOKEN=""
 
 # CRM outbound send (app/crm/connectivity). Per-merchant WhatsApp tokens and

--- a/app/ai/voice/agents/breeze_buddy/handlers/transport/http_handler.py
+++ b/app/ai/voice/agents/breeze_buddy/handlers/transport/http_handler.py
@@ -41,6 +41,27 @@ from app.ai.voice.agents.breeze_buddy.template.types import (
 from app.core.logger import logger
 
 
+def _authority_region(url_template: str) -> str:
+    """Return the part of a URL *template* that determines scheme+host.
+
+    ``urlparse`` only fills ``netloc`` when the string contains ``//``, so a
+    template like ``{base_url}/orders`` parses with an empty netloc — an
+    LLM-sourced placeholder spanning the scheme and host would slip past a
+    netloc-based check entirely. Here the authority is taken as everything
+    before the first ``/``, ``?`` or ``#`` that follows ``://`` (or from the
+    start of the string when the template carries no scheme of its own).
+
+    ``https://api.example.com/{order_id}`` -> ``api.example.com`` (path
+    placeholder, allowed); ``{base_url}/orders`` -> ``{base_url}`` (caught).
+    """
+    candidate = url_template.strip()
+    if "://" in candidate:
+        candidate = candidate.split("://", 1)[1]
+    for separator in ("/", "?", "#"):
+        candidate = candidate.split(separator, 1)[0]
+    return candidate
+
+
 async def http_function_handler(
     context: TemplateContext,
     args: Dict[str, Any],
@@ -103,6 +124,30 @@ async def http_function_handler(
                 "status": "error",
                 "error": f"Missing required arguments: {', '.join(missing_args)}",
             }, None
+
+        # SECURITY: never let an LLM-chosen value determine the URL *host* — a
+        # prompt-injected argument in the host position is an SSRF primitive on
+        # any channel (PT-17). Placeholders in the path/query are fine; the host
+        # is not. Checked against the raw (unresolved) URL template.
+        host_part = _authority_region(config.http_request.url or "")
+        for field_name, field_cfg in config.expected_fields.items():
+            if field_cfg.source != FieldSource.LLM:
+                continue
+            arg_name = field_cfg.value or field_name
+            if f"{{{field_name}}}" in host_part or (
+                arg_name and f"{{{arg_name}}}" in host_part
+            ):
+                logger.error(
+                    f"[{function_name}] LLM-sourced field '{field_name}' used in "
+                    "URL host position — refusing"
+                )
+                return {
+                    "status": "error",
+                    "error": (
+                        "Template misconfiguration: an LLM-sourced field cannot "
+                        "be used in the URL host."
+                    ),
+                }, None
 
         # Step 1: Resolve expected_fields using FieldResolver
         resolver = FieldResolver(context=context, args=args)

--- a/app/ai/voice/agents/breeze_buddy/handlers/transport/http_requester.py
+++ b/app/ai/voice/agents/breeze_buddy/handlers/transport/http_requester.py
@@ -20,11 +20,10 @@ is kept and returned to the caller — the LLM never sees intermediate events.
 
 import asyncio
 import base64
-import ipaddress
 import json
 from collections.abc import Awaitable
 from typing import Any, Callable, Dict, Optional, Tuple
-from urllib.parse import urlencode, urlparse
+from urllib.parse import urlencode
 
 import aiohttp
 from pydantic import SecretStr
@@ -38,12 +37,12 @@ from app.ai.voice.agents.breeze_buddy.template.types import (
     HttpRequestConfig,
 )
 from app.core.config.static import (
-    ENVIRONMENT,
     HTTP_REQUEST_BLOCKED_CONTENT_TYPES,
     HTTP_REQUEST_MAX_REDIRECTS,
     HTTP_REQUEST_MAX_RESPONSE_BYTES,
 )
 from app.core.logger import logger
+from app.core.security.ssrf import SSRFError, ssrf_safe_request, validate_egress_url
 
 
 class HttpRequestExecutor:
@@ -122,8 +121,9 @@ class HttpRequestExecutor:
             # Build full URL with query params
             url = self._build_url_with_params(resolved_url, resolved_query_params)
 
-            # SSRF Protection: Validate the resolved URL before making the request
-            self._validate_resolved_url(url)
+            # SSRF Protection: resolve + validate the URL (shared egress guard,
+            # blocks DNS names that resolve to internal/metadata addresses).
+            await validate_egress_url(url)
 
             # Execute with retry
             for attempt in range(1, config.max_retries + 1):
@@ -132,14 +132,17 @@ class HttpRequestExecutor:
                         f"HTTP {config.method.value} request to {url} (attempt {attempt}/{config.max_retries})"
                     )
 
-                    async with self.session.request(
-                        method=config.method.value,
-                        url=url,
+                    # ssrf_safe_request re-validates every redirect hop so a
+                    # public host can't 302 the request to an internal/metadata
+                    # target (PT-07).
+                    async with ssrf_safe_request(
+                        self.session,
+                        config.method.value,
+                        url,
                         headers=headers,
                         json=resolved_body if resolved_body else None,
                         timeout=aiohttp.ClientTimeout(total=config.timeout),
                         max_redirects=HTTP_REQUEST_MAX_REDIRECTS,
-                        allow_redirects=HTTP_REQUEST_MAX_REDIRECTS > 0,
                     ) as response:
                         status = response.status
 
@@ -243,17 +246,22 @@ class HttpRequestExecutor:
                     logger.warning(
                         f"HTTP {config.method.value} timeout after {config.timeout}s (attempt {attempt})"
                     )
-                except aiohttp.TooManyRedirects:
+                except SSRFError as e:
+                    # A security rejection must abort, not retry. SSRFError is
+                    # not an aiohttp.ClientError, so without this branch it fell
+                    # into the generic handler below and the request body was
+                    # replayed up to max_retries times at a blocked target.
+                    # This also replaces the old aiohttp.TooManyRedirects
+                    # branch: ssrf_safe_request follows redirects itself and
+                    # raises SSRFError when the hop budget is exhausted, so
+                    # aiohttp never raises that exception here any more.
                     logger.error(
-                        f"HTTP {config.method.value} exceeded max redirects "
-                        f"({HTTP_REQUEST_MAX_REDIRECTS}), not retrying"
+                        f"HTTP {config.method.value} blocked by egress guard, "
+                        f"not retrying: {e}"
                     )
                     if fire_and_forget:
                         return None
-                    return (
-                        0,
-                        f"Too many redirects (max: {HTTP_REQUEST_MAX_REDIRECTS})",
-                    )
+                    return (0, f"Request blocked by egress policy: {e}")
                 except aiohttp.ClientError as e:
                     logger.warning(
                         f"HTTP {config.method.value} client error: {e} (attempt {attempt})"
@@ -456,87 +464,6 @@ class HttpRequestExecutor:
         query_string = urlencode(clean_params, doseq=True)
         separator = "&" if "?" in url else "?"
         return f"{url}{separator}{query_string}"
-
-    @staticmethod
-    def _validate_resolved_url(url: str) -> None:
-        """
-        Validate resolved URL to prevent SSRF attacks.
-
-        This runs AFTER template variable substitution, validating the actual URL
-        that will be used for the HTTP request.
-
-        Security checks:
-        - HTTPS only (no HTTP)
-        - Block localhost in production
-        - Block private IP ranges (RFC1918, loopback, link-local)
-
-        Args:
-            url: Fully resolved URL (no template variables)
-
-        Raises:
-            ValueError: If URL fails security validation
-        """
-        # Parse URL
-        try:
-            parsed = urlparse(url)
-        except Exception as e:
-            raise ValueError(f"Invalid URL format: {e}")
-
-        # Check 1: HTTPS only
-        if parsed.scheme != "https":
-            raise ValueError(
-                f"Only HTTPS URLs are allowed for security. Got scheme: {parsed.scheme}"
-            )
-
-        # Check 2: Must have hostname
-        if not parsed.hostname:
-            raise ValueError("URL must have a valid hostname")
-
-        hostname = parsed.hostname.lower()
-
-        # Check 3: Block localhost (production only)
-        is_production = ENVIRONMENT.lower() in ("production", "prod")
-        if is_production:
-            localhost_patterns = ["localhost", "127.0.0.1", "::1", "0.0.0.0"]
-            if hostname in localhost_patterns:
-                raise ValueError(
-                    f"Requests to localhost are not allowed in production: {hostname}"
-                )
-
-        # Check 4: Block private/reserved IP addresses
-        # Try to parse as IP address
-        try:
-            ip = ipaddress.ip_address(hostname)
-
-            # Block loopback (127.0.0.0/8, ::1)
-            if ip.is_loopback:
-                raise ValueError(
-                    f"Requests to loopback addresses are not allowed: {ip}"
-                )
-
-            # Block private IPs (10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16)
-            if ip.is_private:
-                raise ValueError(
-                    f"Requests to private IP addresses are not allowed: {ip}"
-                )
-
-            # Block link-local (169.254.0.0/16, fe80::/10)
-            if ip.is_link_local:
-                raise ValueError(
-                    f"Requests to link-local addresses are not allowed: {ip}"
-                )
-
-            # Block all non-global IPs (comprehensive check)
-            if not ip.is_global:
-                raise ValueError(
-                    f"Requests to non-global IP addresses are not allowed: {ip}"
-                )
-
-        except ValueError as ip_error:
-            # If it's already a validation error we raised, re-raise it
-            if "not allowed" in str(ip_error):
-                raise
-            # Otherwise, hostname is not an IP - it's a domain name, which is allowed
 
     def _resolve_template_json_safe(
         self, template_str: str, resolved_fields: dict

--- a/app/ai/voice/agents/breeze_buddy/managers/pre_checks/http.py
+++ b/app/ai/voice/agents/breeze_buddy/managers/pre_checks/http.py
@@ -106,9 +106,14 @@ async def _fetch_mcp_response(
     if not isinstance(arguments, dict):
         return None, "mcp_arguments did not resolve to an object"
 
-    server_params = _build_server_params(server, context)
+    # _build_server_params runs the shared SSRF egress guard on the resolved URL
+    # before it attaches any decrypted credential header, so awaiting it here is
+    # the validation — the separate pre-flight check this replaces called a
+    # method that no longer exists. SSRFError subclasses ValueError, so a
+    # rejected destination still degrades into a reason for _apply_default
+    # rather than propagating out of the pre-check.
     try:
-        HttpRequestExecutor._validate_resolved_url(server_params.url)
+        server_params = await _build_server_params(server, context)
     except ValueError as e:
         return None, f"MCP server URL rejected: {e}"
 

--- a/app/ai/voice/agents/breeze_buddy/mcp/__init__.py
+++ b/app/ai/voice/agents/breeze_buddy/mcp/__init__.py
@@ -48,6 +48,7 @@ from app.ai.voice.agents.breeze_buddy.template.types import (
     ToolUiHint,
 )
 from app.core.logger import logger
+from app.core.security.ssrf import SSRFError, validate_egress_url
 
 # --- HITL approval for MCP tools -------------------------------------------
 # Watchdog budget for a gated MCP tool: approval wait + the handler's dispatch
@@ -252,6 +253,24 @@ def _create_direct_http_tool_handler(
     """
 
     async def handler(args: Dict[str, Any], flow_manager: Any) -> FlowResult:
+        # SECURITY: _build_server_params validated this URL at flow-BUILD time,
+        # but this handler runs per tool call — potentially minutes later and
+        # many times. Re-validate here, because the DNS answer can change in
+        # between (rebinding) and because this path attaches tenant credentials
+        # from server_params.headers. Validation happens before those headers
+        # are assembled, so a host that fails never has credentials built for
+        # it at all (PT-03).
+        try:
+            await validate_egress_url(server_params.url)
+        except SSRFError as e:
+            logger.error(
+                f"[BUDDY_MCP] direct {tool_name!r} blocked by egress guard: {e}"
+            )
+            return cast(
+                FlowResult,
+                {"status": "error", "data": f"Request blocked by egress policy: {e}"},
+            )
+
         merged_args = _deep_merge_defaults(args, default_args or {})
         body = {
             "jsonrpc": "2.0",
@@ -274,7 +293,11 @@ def _create_direct_http_tool_handler(
             server_params.timeout.total_seconds() if server_params.timeout else 30.0
         )
         try:
-            async with httpx.AsyncClient(timeout=timeout_s) as client:
+            # follow_redirects=False is httpx's default, but state it: a silent
+            # upgrade would send the credentialed POST to an unvalidated host.
+            async with httpx.AsyncClient(
+                timeout=timeout_s, follow_redirects=False
+            ) as client:
                 resp = await client.post(server_params.url, json=body, headers=headers)
         except Exception as e:
             logger.warning(f"[BUDDY_MCP] direct {tool_name!r} transport failed: {e}")
@@ -543,7 +566,7 @@ def _build_auth_headers(
     return {}
 
 
-def _build_server_params(
+async def _build_server_params(
     server: McpServerConfig,
     template_vars: Dict[str, Any],
 ) -> StreamableHttpParameters:
@@ -552,8 +575,16 @@ def _build_server_params(
     Shared by the voice loader (per-call clients) and the chat session pool
     (per-turn persistent clients). Substitutes ``{variable}`` placeholders in
     the URL and auth fields from ``template_vars``.
+
+    SECURITY: the resolved URL is a template-controlled destination that we are
+    about to attach decrypted tenant credentials to (via ``_build_auth_headers``)
+    and hit at flow-build time. It MUST pass the shared SSRF egress guard first —
+    https-only, no internal/loopback/link-local/metadata targets — so it cannot
+    be pointed at cloud metadata or an internal service (PT-03). Validation
+    happens before any credential header is built.
     """
     resolved_url = _resolve_placeholders(server.url, template_vars)
+    await validate_egress_url(resolved_url)
     if resolved_url != server.url:
         # Don't log the resolved URL — it can contain customer-identifying
         # values (e.g. shop subdomain). Operators can correlate via the
@@ -595,7 +626,7 @@ async def _load_server_tools(
 
     Each tool handler creates a fresh MCPClient per invocation for thread safety.
     """
-    server_params = _build_server_params(server, template_vars)
+    server_params = await _build_server_params(server, template_vars)
     # Prefer the stable name; fall back to the raw template URL (with
     # placeholders) rather than the resolved URL to avoid logging
     # customer-identifying substitutions.
@@ -810,7 +841,7 @@ async def get_mcp_global_functions_cached(
             continue
 
         try:
-            server_params = _build_server_params(server, template_vars)
+            server_params = await _build_server_params(server, template_vars)
         except Exception as e:
             logger.error(
                 f"[BUDDY_MCP] chat: failed to build server params for "

--- a/app/ai/voice/agents/breeze_buddy/services/telephony/exotel/recording.py
+++ b/app/ai/voice/agents/breeze_buddy/services/telephony/exotel/recording.py
@@ -7,9 +7,19 @@ from typing import Optional
 
 import aiohttp
 
-from app.core.config.static import EXOTEL_API_KEY, EXOTEL_API_TOKEN
+from app.core.config.static import EXOTEL_API_KEY, EXOTEL_API_TOKEN, EXOTEL_SUBDOMAIN
 from app.core.logger import logger
+from app.core.security.ssrf import ssrf_safe_request
 from app.core.transport.http_client import get_proxy_config
+
+# Only ever send Exotel credentials to Exotel's own hosts (configured subdomain
+# host + the general exotel.com suffix).
+_EXOTEL_HOST_SUFFIXES = tuple(
+    {
+        EXOTEL_SUBDOMAIN.split("//")[-1].split("/")[0].strip() or "api.exotel.com",
+        "exotel.com",
+    }
+)
 
 
 async def download_call_recording(
@@ -34,9 +44,16 @@ async def download_call_recording(
 
         logger.info(f"Downloading Exotel recording from: {recording_url}")
 
+        # SSRF: never send Exotel credentials to a non-Exotel or internal host,
+        # even if a forged webhook supplied the URL (PT-05).
         async with aiohttp.ClientSession() as session:
-            async with session.get(
-                recording_url, auth=auth, proxy=proxy_url
+            async with ssrf_safe_request(
+                session,
+                "GET",
+                recording_url,
+                auth=auth,
+                allowed_host_suffixes=_EXOTEL_HOST_SUFFIXES,
+                proxy=proxy_url,
             ) as response:
                 if response.status != 200:
                     logger.error(

--- a/app/ai/voice/agents/breeze_buddy/services/telephony/plivo/recording.py
+++ b/app/ai/voice/agents/breeze_buddy/services/telephony/plivo/recording.py
@@ -16,7 +16,11 @@ from app.core.config.static import (
     PLIVO_RECORDING_TIME_LIMIT,
 )
 from app.core.logger import logger
+from app.core.security.ssrf import ssrf_safe_request
 from app.core.transport.http_client import get_proxy_config
+
+# Only ever send Plivo BasicAuth to Plivo's own hosts.
+_PLIVO_HOST_SUFFIXES = ("plivo.com",)
 
 
 def _start_call_recording_blocking(call_uuid: str) -> bool:
@@ -89,9 +93,16 @@ async def download_call_recording(
 
         logger.info(f"Downloading Plivo recording from: {recording_url}")
 
+        # SSRF: never send Plivo credentials to a non-Plivo or internal host,
+        # even if a forged webhook supplied the URL (PT-05).
         async with aiohttp.ClientSession() as session:
-            async with session.get(
-                recording_url, auth=auth, proxy=proxy_url
+            async with ssrf_safe_request(
+                session,
+                "GET",
+                recording_url,
+                auth=auth,
+                allowed_host_suffixes=_PLIVO_HOST_SUFFIXES,
+                proxy=proxy_url,
             ) as response:
                 if response.status != 200:
                     logger.error(

--- a/app/ai/voice/agents/breeze_buddy/services/telephony/twilio/recording.py
+++ b/app/ai/voice/agents/breeze_buddy/services/telephony/twilio/recording.py
@@ -9,7 +9,11 @@ import aiohttp
 
 from app.core.config.static import TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN
 from app.core.logger import logger
+from app.core.security.ssrf import ssrf_safe_request
 from app.core.transport.http_client import get_proxy_config
+
+# Only ever send Twilio BasicAuth to Twilio's own hosts (recordings + media CDN).
+_TWILIO_HOST_SUFFIXES = ("twilio.com", "twiliocdn.com")
 
 
 async def download_call_recording(
@@ -34,9 +38,18 @@ async def download_call_recording(
 
         logger.info(f"Downloading Twilio recording from: {recording_url}")
 
+        # SSRF: never send the master Twilio credentials to a host that is not
+        # Twilio's own, and never to an internal/metadata address, even if a
+        # forged webhook supplied the URL (PT-05). Auth is stripped on any
+        # off-allow-list redirect.
         async with aiohttp.ClientSession() as session:
-            async with session.get(
-                recording_url, auth=auth, proxy=proxy_url
+            async with ssrf_safe_request(
+                session,
+                "GET",
+                recording_url,
+                auth=auth,
+                allowed_host_suffixes=_TWILIO_HOST_SUFFIXES,
+                proxy=proxy_url,
             ) as response:
                 if response.status != 200:
                     logger.error(

--- a/app/ai/voice/agents/breeze_buddy/utils/common.py
+++ b/app/ai/voice/agents/breeze_buddy/utils/common.py
@@ -6,6 +6,7 @@ import re
 from datetime import datetime, timezone
 from io import BytesIO
 from typing import Any, Dict, List, Optional, Tuple, cast
+from urllib.parse import urlparse
 
 from pipecat.frames.frames import OutputAudioRawFrame
 from pydub import AudioSegment
@@ -14,6 +15,12 @@ from app.ai.voice.llm.types import RealtimeLLMProvider
 from app.core.config.static import ORDER_CONFIRMATION_WEBHOOK_SECRET_KEY
 from app.core.logger import logger
 from app.core.security.sha import calculate_hmac_sha256
+from app.core.security.ssrf import (
+    SSRFError,
+    redact_url,
+    ssrf_safe_request,
+    validate_egress_url,
+)
 from app.services.redis.client import get_redis_service
 
 
@@ -156,6 +163,27 @@ async def send_webhook_with_retry(
     Returns:
         bool: True if successful, False if all attempts failed
     """
+    # SSRF: the webhook URL comes from lead payloads (reporting_webhook_url) and
+    # is dereferenced here — possibly long after it was accepted. Validate at
+    # delivery time so a URL that resolves to an internal/metadata address (or
+    # rebound DNS) is rejected with zero network attempts (PT-11).
+    #
+    # allow_http=True deliberately: PT-11 is about the resolved *address*, not
+    # the scheme, and this path had no scheme restriction before. Defaulting to
+    # https-only here would silently drop outcome webhooks for every tenant
+    # still posting to an http endpoint. Plaintext delivery is logged instead.
+    try:
+        await validate_egress_url(url, allow_http=True)
+    except SSRFError as exc:
+        logger.error(f"Webhook URL failed SSRF validation, not sending: {exc}")
+        return False
+
+    if urlparse(url).scheme == "http":
+        logger.warning(
+            f"Reporting webhook delivered over plaintext http: {redact_url(url)} — the "
+            "signed payload is readable in transit; migrate this tenant to https"
+        )
+
     payload = json.dumps(data, separators=(",", ":"), ensure_ascii=False)
     signature = calculate_hmac_sha256(payload, ORDER_CONFIRMATION_WEBHOOK_SECRET_KEY)
     headers = {"Content-Type": "application/json"}
@@ -164,8 +192,22 @@ async def send_webhook_with_retry(
 
     for attempt in range(1, max_retries + 1):
         try:
-            logger.info(f"Webhook attempt {attempt}/{max_retries} to {url}")
-            async with session.post(url, json=data, headers=headers) as response:
+            logger.info(f"Webhook attempt {attempt}/{max_retries} to {redact_url(url)}")
+            # max_redirects=0: a reporting webhook is a fixed, tenant-configured
+            # destination, so there is no legitimate reason to follow a 30x —
+            # and following one replays the signed lead payload to a host the
+            # tenant never configured. Per-hop revalidation would still block an
+            # internal target, but the payload would already have left for any
+            # public one. Refuse the redirect outright instead.
+            async with ssrf_safe_request(
+                session,
+                "POST",
+                url,
+                json=data,
+                headers=headers,
+                allow_http=True,
+                max_redirects=0,
+            ) as response:
                 if response.status == 200:
                     logger.info(f"Webhook succeeded on attempt {attempt}")
                     return True
@@ -174,6 +216,11 @@ async def send_webhook_with_retry(
                     logger.warning(
                         f"Webhook attempt {attempt} failed. Status: {response.status}, Body: {response_text}"
                     )
+        except SSRFError as e:
+            # Egress was refused — retrying re-sends the signed payload at the
+            # same blocked target, so stop here rather than burning the budget.
+            logger.error(f"Webhook blocked by egress guard, not retrying: {e}")
+            return False
         except Exception as e:
             logger.error(f"Webhook attempt {attempt} error: {e}", exc_info=True)
 
@@ -181,7 +228,7 @@ async def send_webhook_with_retry(
         if attempt < max_retries:
             logger.info(f"Retrying webhook (attempt {attempt + 1}/{max_retries})...")
 
-    logger.error(f"All {max_retries} webhook attempts failed for {url}")
+    logger.error(f"All {max_retries} webhook attempts failed for {redact_url(url)}")
     return False
 
 

--- a/app/core/config/static.py
+++ b/app/core/config/static.py
@@ -338,6 +338,13 @@ AWS_SECRET_ACCESS_KEY = os.getenv("AWS_SECRET_ACCESS_KEY", "")
 CREDENTIAL_ENCRYPTION_KEY = os.getenv("CREDENTIAL_ENCRYPTION_KEY", "")
 
 # JWT Authentication Configuration
+# Local-dev escape hatch for the SSRF egress guard (app/core/security/ssrf.py):
+# when true, egress to private/loopback ranges is permitted. Defaults to false
+# so the secure posture never depends on ENVIRONMENT being set correctly.
+SSRF_ALLOW_PRIVATE_EGRESS = os.environ.get(
+    "SSRF_ALLOW_PRIVATE_EGRESS", "false"
+).lower() in ("1", "true", "yes")
+
 JWT_SECRET_KEY = os.getenv("JWT_SECRET_KEY", "")
 JWT_ALGORITHM = os.getenv("JWT_ALGORITHM", "")
 JWT_ACCESS_TOKEN_EXPIRE_MINUTES = int(

--- a/app/core/security/ssrf.py
+++ b/app/core/security/ssrf.py
@@ -1,0 +1,349 @@
+"""
+Shared SSRF-safe egress validation for all outbound HTTP sinks.
+
+Every place the platform fetches an operator/tenant/LLM-influenced URL must run
+it through :func:`validate_egress_url` BEFORE the request, and must re-validate
+every redirect hop (or disable redirects). The validator resolves the hostname
+and rejects the request if *any* resolved address is loopback, private
+(RFC1918 / IPv6 ULA), link-local (includes the 169.254.169.254 cloud-metadata
+address), multicast, reserved, or otherwise non-global. Resolving here — rather
+than trusting a bare IP-literal check — closes the "DNS name that resolves to an
+internal address" bypass and, because we validate the exact addresses that were
+resolved, narrows the DNS-rebinding window.
+
+Design notes:
+- Resolution runs off the event loop via ``asyncio.to_thread`` (getaddrinfo is
+  blocking). If *every* A/AAAA record must be public for the request to proceed,
+  a single poisoned record fails the whole request (fail closed) — this defeats
+  mixed good/bad record rebinding tricks.
+- ``SSRF_ALLOW_PRIVATE_EGRESS=true`` relaxes the private/loopback checks for
+  local development only. It defaults to false so production is secure by
+  default, regardless of ENVIRONMENT.
+- The validation half (``validate_egress_url``, ``ip_block_reason``,
+  ``host_matches_allowlist``) is client-agnostic and can guard any HTTP library.
+  Only ``ssrf_safe_request`` binds to aiohttp; a caller using httpx or requests
+  should call ``validate_egress_url`` per hop with redirects disabled and, where
+  credentials are attached, a host allow-list.
+"""
+
+import asyncio
+import ipaddress
+import socket
+from contextlib import asynccontextmanager
+from typing import Any, AsyncIterator, List, Optional, Sequence
+from urllib.parse import urljoin, urlparse
+
+import aiohttp
+
+from app.core.config.static import SSRF_ALLOW_PRIVATE_EGRESS
+from app.core.logger import logger
+
+_REDIRECT_STATUSES = frozenset({301, 302, 303, 307, 308})
+# 301/302/303 turn the follow-up request into a bodyless GET; 307/308 are the
+# two that promise to preserve method and body.
+_REWRITE_TO_GET = frozenset({301, 302, 303})
+_BODY_KWARGS = frozenset({"json", "data", "content"})
+
+# Headers that may survive a credential-dropping redirect hop. Everything else a
+# caller supplied is withheld, because auth material is not confined to a known
+# set of names (``Authorization`` and ``Cookie`` but also ``X-Api-Key``,
+# ``X-Auth-Token``, provider-specific header credentials, ...). An allow-list
+# fails closed; a deny-list would leak any header we forgot to enumerate.
+_SAFE_REDIRECT_HEADERS = frozenset(
+    {"accept", "accept-encoding", "accept-language", "content-type", "user-agent"}
+)
+
+# Local-dev escape hatch: allow egress to private/loopback ranges. Off by
+# default so the secure posture does not depend on ENVIRONMENT being set right.
+_ALLOW_PRIVATE_EGRESS = SSRF_ALLOW_PRIVATE_EGRESS
+
+
+class SSRFError(ValueError):
+    """Raised when a URL fails SSRF egress validation."""
+
+
+def redact_url(url: str) -> str:
+    """Return ``url`` with its query string and userinfo removed.
+
+    A destination URL is not safe to log: tenants routinely authenticate a
+    receiver with a shared secret in the query string (``?token=…``) or with
+    HTTP Basic userinfo (``https://user:pass@host/…``). Scheme, host, port and
+    path are kept, which is what an operator actually needs to diagnose a
+    rejection. Never raises — this is used to build error messages and log
+    lines, and must not become a second failure mode.
+    """
+    try:
+        parts = urlparse(url)
+        netloc = parts.hostname or ""
+        if parts.port:
+            netloc = f"{netloc}:{parts.port}"
+        if parts.username:
+            netloc = f"REDACTED@{netloc}"
+        redacted = parts._replace(netloc=netloc, query="", fragment="")
+        return redacted.geturl() + ("?REDACTED" if parts.query else "")
+    except Exception:  # pragma: no cover - defensive; logging must not break
+        return "<unparseable url>"
+
+
+def ip_block_reason(ip_str: str) -> Optional[str]:
+    """Return a human reason if the IP must not be reached, else None.
+
+    Blocks loopback, private (RFC1918 + IPv6 ULA), link-local (which includes
+    the 169.254.169.254 / fe80:: cloud-metadata addresses), multicast,
+    reserved, unspecified, and any address that is not globally routable.
+    """
+    try:
+        ip = ipaddress.ip_address(ip_str)
+    except ValueError:
+        # Not an IP — caller resolves names before reaching here.
+        return f"not an IP address: {ip_str!r}"
+
+    if _ALLOW_PRIVATE_EGRESS:
+        return None
+
+    # IPv4-mapped IPv6 (e.g. ::ffff:169.254.169.254) — unwrap and re-check.
+    mapped = getattr(ip, "ipv4_mapped", None)
+    if mapped is not None:
+        return ip_block_reason(str(mapped))
+
+    if ip.is_loopback:
+        return f"loopback address {ip}"
+    if ip.is_link_local:
+        return f"link-local address {ip} (includes cloud metadata)"
+    if ip.is_private:
+        return f"private address {ip}"
+    if ip.is_multicast:
+        return f"multicast address {ip}"
+    if ip.is_reserved:
+        return f"reserved address {ip}"
+    if ip.is_unspecified:
+        return f"unspecified address {ip}"
+    if not ip.is_global:
+        return f"non-global address {ip}"
+    return None
+
+
+async def _resolve_host(hostname: str, port: int) -> List[str]:
+    """Resolve a hostname to all its IP addresses (off the event loop)."""
+
+    def _lookup() -> List[str]:
+        infos = socket.getaddrinfo(hostname, port or None, proto=socket.IPPROTO_TCP)
+        return [str(info[4][0]) for info in infos]
+
+    return await asyncio.to_thread(_lookup)
+
+
+async def validate_egress_url(url: str, *, allow_http: bool = False) -> List[str]:
+    """Validate a URL is safe for server-side egress; return its resolved IPs.
+
+    Args:
+        url: Fully resolved URL (no template placeholders left).
+        allow_http: Permit plain http:// (default: https only). Only set this
+            for providers that genuinely require http.
+
+    Returns:
+        The list of resolved IP strings (all validated as public).
+
+    Raises:
+        SSRFError: If the scheme is disallowed, the host is missing, resolution
+            fails, or any resolved address is non-public.
+    """
+    try:
+        parsed = urlparse(url)
+    except Exception as exc:  # pragma: no cover - urlparse rarely raises
+        raise SSRFError(f"Invalid URL: {exc}") from exc
+
+    scheme = (parsed.scheme or "").lower()
+    allowed_schemes = ("http", "https") if allow_http else ("https",)
+    if scheme not in allowed_schemes:
+        raise SSRFError(f"Disallowed URL scheme {scheme!r}; allowed: {allowed_schemes}")
+
+    hostname = parsed.hostname
+    if not hostname:
+        raise SSRFError("URL has no hostname")
+
+    # If the host is already an IP literal, validate it directly. The block
+    # decision must live OUTSIDE this try/except: SSRFError subclasses
+    # ValueError, so raising it inside would be swallowed by `except ValueError`
+    # and the literal would fall through to resolution (a fragile, dead fast
+    # path). Only the literal-detection call may raise the ValueError we catch.
+    is_ip_literal = False
+    try:
+        ipaddress.ip_address(hostname)
+        is_ip_literal = True
+    except ValueError:
+        pass  # Not a literal — resolve it below.
+
+    if is_ip_literal:
+        reason = ip_block_reason(hostname)
+        if reason:
+            raise SSRFError(f"Blocked egress to {reason}")
+        return [hostname]
+
+    try:
+        resolved = await _resolve_host(hostname, parsed.port or 0)
+    except (socket.gaierror, OSError) as exc:
+        raise SSRFError(f"Could not resolve host {hostname!r}: {exc}") from exc
+
+    if not resolved:
+        raise SSRFError(f"Host {hostname!r} resolved to no addresses")
+
+    for ip_str in resolved:
+        reason = ip_block_reason(ip_str)
+        if reason:
+            logger.warning(f"SSRF egress blocked: {hostname!r} resolved to {reason}")
+            raise SSRFError(f"Blocked egress to {hostname!r} — resolves to {reason}")
+
+    return resolved
+
+
+def host_matches_allowlist(url: str, allowed_suffixes: List[str]) -> bool:
+    """True if the URL host equals or is a subdomain of an allow-listed suffix.
+
+    Used to gate attaching provider/tenant credentials to an outbound URL: never
+    send secrets to a host that is not on the allow-list.
+    """
+    try:
+        host = (urlparse(url).hostname or "").lower().rstrip(".")
+    except Exception:
+        return False
+    if not host:
+        return False
+    for suffix in allowed_suffixes:
+        s = suffix.lower().lstrip(".").rstrip(".")
+        if not s:
+            continue
+        if host == s or host.endswith("." + s):
+            return True
+    return False
+
+
+def _without_credential_headers(kwargs: dict, target: str) -> dict:
+    """Return ``kwargs`` with caller headers reduced to :data:`_SAFE_REDIRECT_HEADERS`.
+
+    Used on redirect hops that leave the allow-list or change host, so header
+    credentials cannot follow the request to a host the caller never chose.
+    """
+    headers = kwargs.get("headers")
+    if not headers:
+        return kwargs
+    kept = {
+        k: v for k, v in dict(headers).items() if k.lower() in _SAFE_REDIRECT_HEADERS
+    }
+    dropped = sorted(set(dict(headers)) - set(kept))
+    if dropped:
+        logger.warning(
+            f"ssrf_safe_request: withholding {dropped} on cross-host redirect "
+            f"to {urlparse(target).hostname!r}"
+        )
+    return {**kwargs, "headers": kept}
+
+
+@asynccontextmanager
+async def ssrf_safe_request(
+    session: aiohttp.ClientSession,
+    method: str,
+    url: str,
+    *,
+    auth: Optional[aiohttp.BasicAuth] = None,
+    allowed_host_suffixes: Optional[Sequence[str]] = None,
+    allow_http: bool = False,
+    max_redirects: int = 3,
+    **kwargs: Any,
+) -> AsyncIterator[aiohttp.ClientResponse]:
+    """Issue an aiohttp request with SSRF validation on every hop.
+
+    Redirects are followed manually so each hop is re-validated (aiohttp's own
+    redirect following would skip the check). Behaviour:
+
+    - Every hop (initial + each redirect target) is passed through
+      :func:`validate_egress_url`, so an internal/metadata target is blocked at
+      any point in the chain.
+    - When ``allowed_host_suffixes`` is given, the *initial* host must be on the
+      allow-list (hard gate). On a redirect that leaves the allow-list, ``auth``
+      is stripped so credentials never travel to a non-allow-listed host, but
+      the (credential-free) fetch may still follow to e.g. a public CDN.
+
+    - Redirect method/body semantics follow the browser rule rather than
+      replaying the original request: 301/302/303 rewrite a non-GET/HEAD method
+      to GET and drop the body, and only 307/308 preserve both. Replaying a POST
+      body onto a redirect target is how a signed payload ends up somewhere the
+      caller never addressed.
+    - Exhausting ``max_redirects`` raises, rather than handing back the final
+      3xx as though it were the answer.
+
+    The yielded response must be consumed inside the ``async with`` block.
+    """
+    # This function always drives redirects itself, so a caller-supplied
+    # allow_redirects would both collide with the explicit argument below
+    # (TypeError: multiple values) and ask for something it cannot have.
+    if kwargs.pop("allow_redirects", None) is not None:
+        logger.warning(
+            "ssrf_safe_request: ignoring caller-supplied allow_redirects; "
+            "redirects are followed manually so every hop can be revalidated"
+        )
+
+    current = url
+    cur_method = method
+    prev_host: Optional[str] = None
+    for hop in range(max_redirects + 1):
+        await validate_egress_url(current, allow_http=allow_http)
+
+        send_auth = auth
+        drop_credentials = False
+        if allowed_host_suffixes is not None and not host_matches_allowlist(
+            current, list(allowed_host_suffixes)
+        ):
+            if hop == 0:
+                raise SSRFError(
+                    "Refusing request: initial host not on allow-list: "
+                    f"{redact_url(current)}"
+                )
+            send_auth = None  # off-allow-list redirect target — never send creds
+            drop_credentials = True
+
+        # Drop credentials whenever the host changes across a redirect.
+        cur_host = urlparse(current).hostname
+        if prev_host is not None and cur_host != prev_host:
+            send_auth = None
+            drop_credentials = True
+        prev_host = cur_host
+
+        # Header-borne credentials must be withheld on the same hops that drop
+        # ``auth``; otherwise a bearer token or session cookie passed via
+        # ``headers`` still reaches an attacker-controlled redirect target.
+        send_kwargs = kwargs
+        if drop_credentials:
+            send_kwargs = _without_credential_headers(kwargs, current)
+
+        response = await session.request(
+            cur_method, current, auth=send_auth, allow_redirects=False, **send_kwargs
+        )
+        location = response.headers.get("Location")
+        if response.status in _REDIRECT_STATUSES and location:
+            if hop >= max_redirects:
+                response.release()
+                raise SSRFError(
+                    f"Too many redirects while fetching {redact_url(url)!r} "
+                    f"(limit {max_redirects})"
+                )
+            response.release()
+            current = urljoin(current, location)
+            if response.status in _REWRITE_TO_GET and cur_method.upper() not in (
+                "GET",
+                "HEAD",
+            ):
+                # 301/302/303: the redirected request is a GET with no body.
+                # Repeating the original method and payload would re-POST it to
+                # a host the caller never addressed.
+                cur_method = "GET"
+                kwargs = {k: v for k, v in kwargs.items() if k not in _BODY_KWARGS}
+            continue
+
+        try:
+            yield response
+        finally:
+            response.release()
+        return
+
+    raise SSRFError(f"Too many redirects while fetching {url!r}")

--- a/tests/test_mcp_approval.py
+++ b/tests/test_mcp_approval.py
@@ -14,6 +14,9 @@ from __future__ import annotations
 from types import SimpleNamespace
 from typing import Any, Dict, List, Optional
 
+import pytest
+
+from app.ai.voice.agents.breeze_buddy import mcp as _mcp_module
 from app.ai.voice.agents.breeze_buddy.mcp import (
     _gate_mcp_handler,
     _mcp_approval_timeout_secs,
@@ -29,6 +32,19 @@ from app.ai.voice.agents.breeze_buddy.template.types import (
     StateReducer,
     ToolArgInjection,
 )
+
+
+@pytest.fixture(autouse=True)
+def _bypass_ssrf_egress(monkeypatch):
+    """These tests use placeholder MCP hostnames to exercise approval-map /
+    tool-loading logic. SSRF egress validation (tested separately in
+    tests/test_ssrf_egress.py) would otherwise reject the unresolvable host.
+    """
+
+    async def _ok(url, *args, **kwargs):
+        return ["203.0.113.10"]
+
+    monkeypatch.setattr(_mcp_module, "validate_egress_url", _ok)
 
 
 class _FakeManager:

--- a/tests/test_ssrf_egress.py
+++ b/tests/test_ssrf_egress.py
@@ -1,0 +1,357 @@
+"""SSRF egress guard (PT-03/05/07/11).
+
+Covers the shared ``app.core.security.ssrf`` validator: scheme enforcement,
+IP-literal blocking, DNS-name resolution + validation (the bypass the pentest
+flagged), and the redirect-following helper's per-hop revalidation.
+"""
+
+from __future__ import annotations
+
+import socket
+from typing import cast
+
+import aiohttp
+import pytest
+
+from app.core.security import ssrf
+from app.core.security.ssrf import (
+    SSRFError,
+    host_matches_allowlist,
+    ip_block_reason,
+    ssrf_safe_request,
+    validate_egress_url,
+)
+
+
+@pytest.fixture(autouse=True)
+def _force_private_egress_blocked(monkeypatch):
+    """Pin the escape hatch off for this module.
+
+    ``_ALLOW_PRIVATE_EGRESS`` is read from the environment at import time, so a
+    developer with ``SSRF_ALLOW_PRIVATE_EGRESS=true`` locally would otherwise see
+    every one of these assertions invert.
+    """
+    monkeypatch.setattr(ssrf, "_ALLOW_PRIVATE_EGRESS", False)
+
+
+def test_ip_block_reason_flags_metadata_and_private():
+    assert ip_block_reason("169.254.169.254")  # cloud metadata (link-local)
+    assert ip_block_reason("10.1.2.3")
+    assert ip_block_reason("127.0.0.1")
+    assert ip_block_reason("::1")
+    assert ip_block_reason("fd00::1")  # IPv6 ULA
+    assert ip_block_reason("::ffff:169.254.169.254")  # IPv4-mapped metadata
+    assert ip_block_reason("1.1.1.1") is None  # public
+
+
+async def test_validate_egress_url_rejects_http_scheme():
+    with pytest.raises(SSRFError):
+        await validate_egress_url("http://example.com/x")
+
+
+async def test_validate_egress_url_rejects_ip_literal_private():
+    for url in (
+        "https://10.0.0.5/x",
+        "https://127.0.0.1/x",
+        "https://169.254.169.254/latest/meta-data/",
+        "https://[::1]/x",
+    ):
+        with pytest.raises(SSRFError):
+            await validate_egress_url(url)
+
+
+async def test_validate_egress_url_allows_public_ip_literal():
+    assert await validate_egress_url("https://1.1.1.1/x") == ["1.1.1.1"]
+
+
+async def test_validate_egress_url_ip_literal_private_short_circuits(monkeypatch):
+    # Regression: SSRFError subclasses ValueError, so a blocked IP literal must
+    # be raised by the fast path directly — never swallowed and re-resolved via
+    # getaddrinfo (which would be a fragile, dead fast path).
+    def _fail(*a, **k):
+        raise AssertionError("resolution must not run for a blocked IP literal")
+
+    monkeypatch.setattr(ssrf.socket, "getaddrinfo", _fail)
+    with pytest.raises(SSRFError):
+        await validate_egress_url("https://127.0.0.1/x")
+
+
+async def test_validate_egress_url_blocks_dns_name_resolving_to_internal(monkeypatch):
+    # The exact bypass PT-07 describes: a DNS name that resolves to an internal
+    # address must be rejected, not allowed on the "it's not an IP literal" path.
+    def fake_getaddrinfo(host, port, *a, **k):
+        return [(socket.AF_INET, None, None, "", ("169.254.169.254", 0))]
+
+    monkeypatch.setattr(ssrf.socket, "getaddrinfo", fake_getaddrinfo)
+    with pytest.raises(SSRFError):
+        await validate_egress_url("https://evil.internal.test/x")
+
+
+async def test_validate_egress_url_allows_dns_name_resolving_to_public(monkeypatch):
+    def fake_getaddrinfo(host, port, *a, **k):
+        return [(socket.AF_INET, None, None, "", ("8.8.8.8", 0))]
+
+    monkeypatch.setattr(ssrf.socket, "getaddrinfo", fake_getaddrinfo)
+    assert await validate_egress_url("https://api.example.com/x") == ["8.8.8.8"]
+
+
+async def test_validate_egress_url_fails_closed_on_resolution_error(monkeypatch):
+    def boom(host, port, *a, **k):
+        raise socket.gaierror("no such host")
+
+    monkeypatch.setattr(ssrf.socket, "getaddrinfo", boom)
+    with pytest.raises(SSRFError):
+        await validate_egress_url("https://does-not-resolve.example/x")
+
+
+def test_host_allowlist_suffix_confusion_is_rejected():
+    assert host_matches_allowlist("https://api.twilio.com/x", ["twilio.com"])
+    assert host_matches_allowlist("https://twilio.com/x", ["twilio.com"])
+    # Must use a dot boundary — a lookalike domain must NOT match.
+    assert not host_matches_allowlist(
+        "https://evil-twilio.com.attacker.net/x", ["twilio.com"]
+    )
+    assert not host_matches_allowlist("https://nottwilio.com/x", ["twilio.com"])
+
+
+# ── ssrf_safe_request: per-hop redirect revalidation (the core PT-07 fix) ────
+class _FakeResp:
+    """Minimal stand-in for aiohttp.ClientResponse used by ssrf_safe_request."""
+
+    def __init__(self, status: int, headers: dict | None = None):
+        self.status = status
+        self.headers = headers or {}
+        self.released = False
+
+    def release(self) -> None:
+        self.released = True
+
+
+class _FakeSession:
+    """Returns queued responses and records the auth each hop was issued with.
+
+    Public IP literals (8.8.8.8 / 1.1.1.1) are used as hosts so ssrf_safe_request
+    validates them without any DNS resolution.
+    """
+
+    def __init__(self, responses):
+        self._responses = list(responses)
+        self.requests: list[dict] = []
+
+    async def request(self, method, url, *, auth=None, allow_redirects=True, **kwargs):
+        self.requests.append(
+            {"method": method, "url": url, "auth": auth, "kwargs": kwargs}
+        )
+        return self._responses.pop(0)
+
+
+async def test_ssrf_safe_request_blocks_redirect_to_metadata():
+    # A 302 whose Location is the cloud-metadata address must be blocked at the
+    # redirect hop. aiohttp's own redirect following would skip the check — this
+    # helper re-validates every hop, so the metadata fetch never goes out.
+    session = _FakeSession([_FakeResp(302, {"Location": "https://169.254.169.254/"})])
+    with pytest.raises(SSRFError):
+        async with ssrf_safe_request(
+            cast(aiohttp.ClientSession, session), "GET", "https://8.8.8.8/start"
+        ):
+            pass  # pragma: no cover - the redirect hop must raise before the body
+    # Only the first (public) hop was issued; the metadata hop was rejected
+    # before any request left the process.
+    assert len(session.requests) == 1
+
+
+async def test_ssrf_safe_request_strips_auth_on_offsite_redirect():
+    # A redirect leaving the allow-list must drop credentials, so a 302 can't
+    # exfiltrate provider creds to an attacker-controlled (but public) host.
+    auth = aiohttp.BasicAuth("user", "secret")
+    session = _FakeSession(
+        [
+            _FakeResp(302, {"Location": "https://1.1.1.1/next"}),
+            _FakeResp(200, {}),
+        ]
+    )
+    async with ssrf_safe_request(
+        cast(aiohttp.ClientSession, session),
+        "GET",
+        "https://8.8.8.8/start",
+        auth=auth,
+        allowed_host_suffixes=["8.8.8.8"],
+    ) as resp:
+        assert resp.status == 200
+    # First hop (on the allow-list) carried the creds; the off-allow-list
+    # redirect target was fetched with auth stripped.
+    assert session.requests[0]["auth"] is auth
+    assert session.requests[1]["auth"] is None
+
+
+# ── redirect method/body semantics and the hop-budget contract ───────────────
+async def test_302_rewrites_post_to_get_and_drops_the_body():
+    """301/302/303 must not replay the payload at the redirect target.
+
+    Repeating method+body on every hop is how a signed POST ends up delivered
+    to a host the caller never addressed. Browsers and aiohttp both downgrade
+    these three to a bodyless GET; only 307/308 promise to preserve them.
+    """
+    session = _FakeSession(
+        [_FakeResp(302, {"Location": "https://1.1.1.1/next"}), _FakeResp(200, {})]
+    )
+    async with ssrf_safe_request(
+        cast(aiohttp.ClientSession, session),
+        "POST",
+        "https://8.8.8.8/start",
+        json={"lead": "sensitive"},
+    ) as resp:
+        assert resp.status == 200
+    first, second = session.requests
+    assert first["method"] == "POST" and first["kwargs"].get("json")
+    assert second["method"] == "GET"
+    assert "json" not in second["kwargs"]
+
+
+async def test_307_preserves_method_and_body():
+    session = _FakeSession(
+        [_FakeResp(307, {"Location": "https://1.1.1.1/next"}), _FakeResp(200, {})]
+    )
+    async with ssrf_safe_request(
+        cast(aiohttp.ClientSession, session),
+        "POST",
+        "https://8.8.8.8/start",
+        json={"lead": "sensitive"},
+    ) as resp:
+        assert resp.status == 200
+    assert session.requests[1]["method"] == "POST"
+    assert session.requests[1]["kwargs"].get("json") == {"lead": "sensitive"}
+
+
+async def test_exhausting_the_hop_budget_raises_instead_of_returning_the_3xx():
+    """The old loop yielded the final 3xx, so callers saw a redirect as success."""
+    session = _FakeSession(
+        [
+            _FakeResp(302, {"Location": "https://1.1.1.1/a"}),
+            _FakeResp(302, {"Location": "https://8.8.8.8/b"}),
+        ]
+    )
+    with pytest.raises(SSRFError, match="Too many redirects"):
+        async with ssrf_safe_request(
+            cast(aiohttp.ClientSession, session),
+            "GET",
+            "https://8.8.8.8/start",
+            max_redirects=1,
+        ):
+            pass  # pragma: no cover - must raise before yielding
+
+
+async def test_max_redirects_zero_refuses_the_first_redirect():
+    """What the signed reporting webhook passes: no hop is legitimate."""
+    session = _FakeSession([_FakeResp(302, {"Location": "https://1.1.1.1/next"})])
+    with pytest.raises(SSRFError, match="Too many redirects"):
+        async with ssrf_safe_request(
+            cast(aiohttp.ClientSession, session),
+            "POST",
+            "https://8.8.8.8/hook",
+            json={"lead": "sensitive"},
+            max_redirects=0,
+        ):
+            pass  # pragma: no cover
+    assert len(session.requests) == 1  # nothing followed the redirect
+
+
+async def test_caller_supplied_allow_redirects_does_not_explode():
+    """It used to raise TypeError: multiple values for 'allow_redirects'."""
+    session = _FakeSession([_FakeResp(200, {})])
+    async with ssrf_safe_request(
+        cast(aiohttp.ClientSession, session),
+        "GET",
+        "https://8.8.8.8/x",
+        allow_redirects=True,
+    ) as resp:
+        assert resp.status == 200
+
+
+# ── the call-time guard on the direct-HTTP MCP handler ──────────────────────
+async def test_direct_http_mcp_handler_revalidates_at_call_time(monkeypatch):
+    """_build_server_params validates at flow-BUILD time; this runs per call.
+
+    The gap the review found: this handler attaches tenant credentials from
+    server_params.headers and posts with httpx, so a name that resolved to a
+    public address when the flow was built — and to an internal one by the time
+    the tool is invoked — reached an internal service with credentials on it.
+    """
+    from mcp.client.session_group import StreamableHttpParameters
+
+    from app.ai.voice.agents.breeze_buddy.mcp import _create_direct_http_tool_handler
+
+    def resolves_internal(host, port, *a, **k):
+        return [(socket.AF_INET, None, None, "", ("169.254.169.254", 0))]
+
+    monkeypatch.setattr(ssrf.socket, "getaddrinfo", resolves_internal)
+
+    def must_not_be_called(*a, **k):  # pragma: no cover - asserts absence
+        raise AssertionError("httpx client was constructed for a blocked host")
+
+    import app.ai.voice.agents.breeze_buddy.mcp as mcp_mod
+
+    monkeypatch.setattr(mcp_mod.httpx, "AsyncClient", must_not_be_called)
+
+    handler = _create_direct_http_tool_handler(
+        StreamableHttpParameters(
+            url="https://rebound.example/mcp",
+            headers={"Authorization": "Bearer tenant-secret"},
+        ),
+        "some_tool",
+    )
+    result = await handler({}, None)
+    assert result["status"] == "error"
+    assert "egress policy" in result["data"]
+
+
+# ── a rejection must not become the leak ──────────────────────────────────
+def test_redact_url_strips_query_and_userinfo():
+    """Destination URLs are not safe to log: tenants authenticate receivers
+    with a query token or Basic userinfo, so both must be stripped while the
+    host and path an operator needs for triage survive."""
+    assert (
+        ssrf.redact_url("https://hook.example.com/cb?token=s3cret&id=7")
+        == "https://hook.example.com/cb?REDACTED"
+    )
+    assert (
+        ssrf.redact_url("https://user:pw@hook.example.com/cb")
+        == "https://REDACTED@hook.example.com/cb"
+    )
+    assert (
+        ssrf.redact_url("http://hook.example.com:8080/a/b")
+        == "http://hook.example.com:8080/a/b"
+    )
+    # A helper used to build error messages must never raise.
+    assert ssrf.redact_url("::::not a url::::")
+
+
+async def test_allowlist_rejection_message_does_not_carry_the_query_string():
+    """The allow-list refusal fires on the guard's own success path, so its
+    message is written to logs routinely — it must not embed the secret."""
+    session = cast(aiohttp.ClientSession, _FakeSession([]))
+    with pytest.raises(SSRFError) as exc:
+        async with ssrf_safe_request(
+            session,
+            "GET",
+            "https://1.1.1.1/x?token=s3cret",
+            allowed_host_suffixes=["trusted.example.com"],
+        ):
+            pass  # pragma: no cover - must raise before yielding
+    assert "s3cret" not in str(exc.value)
+    assert "REDACTED" in str(exc.value)
+
+
+async def test_redirect_budget_message_does_not_carry_the_query_string():
+    """Same for the hop-budget error, which embeds the original URL."""
+    session = _FakeSession([_FakeResp(302, {"Location": "https://1.1.1.1/next"})])
+    with pytest.raises(SSRFError) as exc:
+        async with ssrf_safe_request(
+            cast(aiohttp.ClientSession, session),
+            "GET",
+            "https://8.8.8.8/start?token=s3cret",
+            max_redirects=0,
+        ):
+            pass  # pragma: no cover - must raise before yielding
+    assert "s3cret" not in str(exc.value)
+    assert "REDACTED" in str(exc.value)

--- a/tests/test_tool_pipeline.py
+++ b/tests/test_tool_pipeline.py
@@ -42,6 +42,22 @@ def _boom(value, args):
 
 
 @pytest.fixture(autouse=True)
+def _bypass_ssrf_egress(monkeypatch):
+    """These tests drive the response pipeline through a placeholder MCP host.
+
+    The direct-HTTP handler now revalidates egress at call time, which would
+    reject `http://x/mcp` before any of the projection/transform behaviour under
+    test here runs. The guard itself is covered in tests/test_ssrf_egress.py,
+    including a case asserting this handler refuses a rebinding host.
+    """
+
+    async def _ok(url, *args, **kwargs):
+        return ["203.0.113.10"]
+
+    monkeypatch.setattr(mcp_mod, "validate_egress_url", _ok)
+
+
+@pytest.fixture(autouse=True)
 def _register_test_transforms():
     added = {"test_append_z": _append_z, "test_boom": _boom}
     saved = {k: TRANSFORM_REGISTRY[k] for k in added if k in TRANSFORM_REGISTRY}


### PR DESCRIPTION
Independent of the other pentest PRs — targets release, merges in any order.

Four code paths dereference a URL that a template author, a lead payload or the
LLM can influence, and none checked where it pointed: MCP server URLs (hit at
flow-build time with decrypted tenant credentials attached), HttpRequestExecutor,
the reporting-webhook sender, and the three telephony recording downloads.

Adds one shared guard (app/core/security/ssrf.py) rather than four checks:
resolve the host, deny private/loopback/link-local/metadata, require https by
default, and revalidate on every redirect hop so a public host cannot 30x the
request onto an internal target. Credentials are stripped when a redirect leaves
the allow-list.

PT-12 lives here rather than with the telephony signature work because the
recording downloads are an egress concern: the fix is ssrf_safe_request around a
credentialed fetch, so it shares all its code with this guard and none with
callback authentication.

Two deliberate choices:
- validate_egress_url runs BEFORE _build_auth_headers in the MCP path, so a
  hostile server URL never gets the tenant's credentials attached even briefly.
- the webhook sender passes allow_http=True. PT-11 is about the resolved
  address, not the scheme, and this path never restricted the scheme before;
  https-only here would silently drop outcome webhooks for every tenant still on
  http. Plaintext delivery is logged instead.

_build_server_params becomes async because resolution is a DNS round-trip.

Tests: 11 reserved ranges, scheme and hostname cases, per-hop redirect
revalidation, credential stripping. 942 pass on this branch.



---

### Independent by construction

This PR targets `release` directly. It shares no file with any other pentest PR, and all five were trial-merged pairwise — **10 of 10 pairs merge with no conflict**, so they can land in any order.

The four config blocks that previously forced a chain (`static.py`, `.env.example`) now sit at four distinct anchors hundreds of lines apart, each next to the settings it belongs with, so independent branches auto-merge instead of colliding.

Merging all five reproduces the original #930 tree — `static.py` is identical content in a different order, `.env.example` differs only by one now-meaningless banner comment — and the combined suite runs **992 passed**.

Evidence recording is in the comment below.
