### PR TITLE
fix(security): verify provider signatures on telephony webhooks and pin recording hosts (PT-05/12/23)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -161,6 +161,23 @@ META_WHATSAPP_GRAPH_VERSION=v23.0
 # one dial and the others must follow.
 CRM_MESSAGE_SEND_TIMEOUT_SECONDS=20
 
+# Enforce provider signature/token verification on ALL telephony webhooks
+# (Twilio X-Twilio-Signature, Plivo V3 signature, Exotel auth_token). Secure by
+# default. Requires TWILIO_AUTH_TOKEN / PLIVO_AUTH_TOKEN / EXOTEL_WEBHOOK_AUTH_TOKEN
+# and a correct APP_BASE_URL for the providers in use. Set to false ONLY as a
+# temporary operational escape hatch — never in production.
+ENFORCE_TELEPHONY_WEBHOOK_SIGNATURES=true
+
+# Public path prefix an ingress strips before requests reach this app. Providers
+# sign the externally-visible URL, so if https://host/agent/voice/... is proxied
+# to /... internally, set this to "/agent/voice" or every legitimate webhook is
+# rejected. Leave empty when no path rewriting happens. Not read from
+# X-Forwarded-Prefix on purpose — that header is caller-controlled.
+# Unquoted on purpose: loaders that do not strip quotes (docker-compose
+# env_file, `export $(cat .env)`) would read `""` as two literal characters and
+# prepend them to every reconstructed URL, rejecting every legitimate webhook.
+TELEPHONY_WEBHOOK_PATH_PREFIX=
+
 # Webhook Authentication
 ORDER_CONFIRMATION_WEBHOOK_SECRET_KEY=""
 ORDER_CONFIRMATION_TOKEN=""

--- a/app/ai/voice/agents/breeze_buddy/services/telephony/exotel/exotel.py
+++ b/app/ai/voice/agents/breeze_buddy/services/telephony/exotel/exotel.py
@@ -1,5 +1,6 @@
 import json
 from typing import Any, Dict, Optional
+from urllib.parse import quote
 
 import requests
 from fastapi import Response, WebSocket
@@ -18,10 +19,37 @@ from app.core.config.static import (
     EXOTEL_API_TOKEN,
     EXOTEL_SUBDOMAIN,
     EXOTEL_TEMPLATE_APPLET_APP_ID,
+    EXOTEL_WEBHOOK_AUTH_TOKEN,
 )
 from app.core.logger import logger
+from app.core.security.webhook_signature import redact_query_param
 from app.core.transport.http_client import get_proxy_config
+from app.database.queries.breeze_buddy.blacklisted_numbers import mask_phone
 from app.schemas import CallProvider, TelephonyConfig
+
+_EXOTEL_STATUS_CALLBACK_PATH = "/agent/voice/breeze-buddy/exotel/callback/status"
+
+
+def _exotel_status_callback_url(base_url: str) -> str:
+    """Build the Exotel status-callback URL, carrying the shared auth token.
+
+    Exotel does not sign its webhooks, so ``verify_provider_webhook`` checks a
+    shared secret supplied as the ``auth_token`` query parameter. That token has
+    to be embedded in the URL we register with Exotel — it is the only channel
+    by which Exotel can present it. When no token is configured the URL is left
+    bare, which the verifier rejects (fail-closed) unless signature enforcement
+    is explicitly disabled.
+    """
+    url = base_url.rstrip("/") + _EXOTEL_STATUS_CALLBACK_PATH
+    if not EXOTEL_WEBHOOK_AUTH_TOKEN:
+        logger.error(
+            "EXOTEL_WEBHOOK_AUTH_TOKEN is unset — Exotel status callbacks will be "
+            "rejected while ENFORCE_TELEPHONY_WEBHOOK_SIGNATURES is enabled (the "
+            "default). Set it (and keep it in sync with this deployment) or "
+            "Exotel outcome/retry handling will not run."
+        )
+        return url
+    return f"{url}?auth_token={quote(EXOTEL_WEBHOOK_AUTH_TOKEN, safe='')}"
 
 
 class ExotelProvider(VoiceCallProvider):
@@ -86,15 +114,29 @@ class ExotelProvider(VoiceCallProvider):
             "From": customer_mobile_number,
             "CallerId": telephony_number,
             "Url": flow_url,
-            "StatusCallback": (
-                self.APP_BASE_URL + "/agent/voice/breeze-buddy/exotel/callback/status"
-            ),
+            # Exotel has no request-signing scheme, so the status callback is
+            # authenticated by a shared token carried in the URL we hand it.
+            # verify_provider_webhook() reads it from ``auth_token``; without it
+            # every status callback 401s and outcome/retry handling stops.
+            "StatusCallback": _exotel_status_callback_url(self.APP_BASE_URL),
         }
 
         url = f"https://{self.EXOTEL_API_KEY}:{self.EXOTEL_API_TOKEN}@{self.EXOTEL_SUBDOMAIN}/v1/Accounts/{self.EXOTEL_ACCOUNT_SID}/Calls/connect.json"
 
         logger.info(f"Making Exotel API call to: {self.EXOTEL_SUBDOMAIN}")
-        logger.info(f"Payload: {payload}")
+        # Never log this payload raw. "StatusCallback" carries the shared
+        # webhook secret as a query parameter, and "From"/"CallerId" are phone
+        # numbers. Both would otherwise land in every log sink on every
+        # outbound call.
+        logger.info(
+            "Payload: {}",
+            {
+                **payload,
+                "From": mask_phone(customer_mobile_number),
+                "CallerId": mask_phone(telephony_number),
+                "StatusCallback": redact_query_param(payload["StatusCallback"]),
+            },
+        )
 
         try:
             # Use centralized proxy configuration

--- a/app/api/routers/breeze_buddy/telephony/answer/__init__.py
+++ b/app/api/routers/breeze_buddy/telephony/answer/__init__.py
@@ -10,13 +10,15 @@ Endpoints:
 - GET/POST /{provider}/answer - Unified answer handler
 
 Authentication:
-- Exotel: Requires `auth_token` query parameter matching EXOTEL_WEBHOOK_AUTH_TOKEN env var
-- Plivo: No authentication (Plivo validates via answer_url configuration)
+- Exotel: constant-time `auth_token` query-param check against EXOTEL_WEBHOOK_AUTH_TOKEN
+- Plivo: X-Plivo-Signature-V3/V2 HMAC verification against PLIVO_AUTH_TOKEN
+Both go through the shared ``verify_provider_webhook`` (fail-closed if the
+provider's secret is unset).
 """
 
 from fastapi import APIRouter, HTTPException, Request
 
-from app.core.config.static import EXOTEL_WEBHOOK_AUTH_TOKEN
+from app.core.security.webhook_signature import verify_provider_webhook
 
 from .handlers import handle_provider_answer
 
@@ -57,14 +59,9 @@ async def provider_answer(request: Request, provider: str):
             detail=f"Provider '{provider}' is not supported for answer webhooks",
         )
 
-    # Exotel requires auth token verification
-    if provider_lower == "exotel":
-        auth_token = request.query_params.get("auth_token")
-        if not EXOTEL_WEBHOOK_AUTH_TOKEN:
-            raise HTTPException(
-                status_code=401, detail="Webhook authentication not configured"
-            )
-        if auth_token != EXOTEL_WEBHOOK_AUTH_TOKEN:
-            raise HTTPException(status_code=401, detail="Invalid auth token")
+    # Verify the provider webhook before dispatching (Exotel: constant-time
+    # auth_token compare; Plivo: X-Plivo-Signature HMAC). Previously Plivo had
+    # NO authentication and Exotel used a non-constant-time compare (PT-23).
+    await verify_provider_webhook(request, provider_lower)
 
     return await handle_provider_answer(request, provider_lower)

--- a/app/api/routers/breeze_buddy/telephony/callbacks/handlers.py
+++ b/app/api/routers/breeze_buddy/telephony/callbacks/handlers.py
@@ -38,6 +38,7 @@ from app.ai.voice.agents.breeze_buddy.utils.warm_transfer import (
 from app.core.config.static import TWILIO_TEMPLATE_WEBSOCKET_URL
 from app.core.logger import logger
 from app.core.logger.context import set_log_context
+from app.core.security.webhook_signature import verify_provider_webhook
 from app.database.accessor import get_lead_by_call_id
 
 
@@ -59,8 +60,14 @@ async def handle_callback_details_get(
         200 OK response
 
     Raises:
-        HTTPException: 404 if provider is not supported
+        HTTPException: 401 if the webhook fails provider authentication
+            (checked first), 404 if the provider is not supported
     """
+    # Authenticate the provider webhook before trusting any of its data — an
+    # unauthenticated caller must not be able to inject a recording URL that the
+    # server then fetches with master provider credentials (PT-05).
+    await verify_provider_webhook(request, provider)
+
     query_params = dict(request.query_params)
     logger.info(f"Received call-details with {provider} query params: {query_params}")
 
@@ -87,6 +94,11 @@ async def handle_call_transfer(
     request: Request, provider: str, action: str
 ) -> Response:
     """Unified transfer callback — dispatches by provider + action."""
+    # Authenticate before dispatching — an unauthenticated caller must not be
+    # able to forge transfer callbacks (e.g. the Exotel dial-up path discloses
+    # the live human-agent phone number) (PT-12).
+    await verify_provider_webhook(request, provider)
+
     provider_lower = provider.lower()
 
     if action == "dial-up":
@@ -174,8 +186,13 @@ async def handle_callback_details_post(
         200 OK response
 
     Raises:
-        HTTPException: 404 if provider is not supported
+        HTTPException: 401 if the webhook fails provider authentication
+            (checked first), 404 if the provider is not supported
     """
+    # Authenticate before trusting the recording URL / call SID in the body
+    # (PT-05).
+    await verify_provider_webhook(request, provider)
+
     form = await request.form()
     logger.info(f"Received callback from {provider} with form data: {form}")
 
@@ -267,6 +284,11 @@ async def handle_callback_status(request: Request, provider: str) -> Response:
     Returns:
         200 OK response
     """
+    # Authenticate before acting on the status — a forged status callback could
+    # release a live call's pod (DoS), force retries (toll fraud), or fabricate
+    # outcomes (PT-12).
+    await verify_provider_webhook(request, provider)
+
     form = await request.form()
     logger.info(f"Received callback from {provider} with form data: {form}")
 
@@ -393,6 +415,9 @@ async def handle_twilio_twiml_fallback(request: Request) -> HTMLResponse:
     Returns:
         TwiML XML with <Connect><Stream> pointing to static WebSocket URL
     """
+    # Authenticate — this is a Twilio webhook and must carry a valid signature.
+    await verify_provider_webhook(request, "twilio")
+
     form = await request.form()
     call_sid = form.get("CallSid", "unknown")
     error_code = form.get("ErrorCode", "")

--- a/app/core/config/static.py
+++ b/app/core/config/static.py
@@ -554,6 +554,26 @@ EXOTEL_API_KEY = os.getenv("EXOTEL_API_KEY", "")
 EXOTEL_API_TOKEN = os.getenv("EXOTEL_API_TOKEN", "")
 # Exotel Webhook Authentication - required for inbound webhook security
 EXOTEL_WEBHOOK_AUTH_TOKEN = os.getenv("EXOTEL_WEBHOOK_AUTH_TOKEN", "")
+
+# Enforce provider signature/token verification on all telephony webhooks
+# (Twilio X-Twilio-Signature, Plivo V3 signature, Exotel auth_token). Secure by
+# default; only set to "false" as a temporary operational escape hatch. Requires
+# TWILIO_AUTH_TOKEN / PLIVO_AUTH_TOKEN / EXOTEL_WEBHOOK_AUTH_TOKEN and a correct
+# APP_BASE_URL to be configured for the corresponding providers.
+ENFORCE_TELEPHONY_WEBHOOK_SIGNATURES = (
+    os.environ.get("ENFORCE_TELEPHONY_WEBHOOK_SIGNATURES", "true").lower() == "true"
+)
+
+# Public path prefix that an ingress strips before the request reaches us.
+# Twilio and Plivo sign the exact externally-visible URL, so if the ingress
+# rewrites e.g. https://host/agent/voice/x -> /x, the path we see is not the
+# path that was signed and every legitimate webhook fails verification. This is
+# deliberately an env var and NOT read from X-Forwarded-Prefix: that header is
+# caller-controlled, and letting a caller choose the string that goes into the
+# signed message turns the verifier into a signature oracle.
+TELEPHONY_WEBHOOK_PATH_PREFIX = os.environ.get(
+    "TELEPHONY_WEBHOOK_PATH_PREFIX", ""
+).rstrip("/")
 AWS_VAYU_URL = os.environ.get("AWS_VAYU_URL")
 AWS_VAYU_READ_API_KEY = os.environ.get("AWS_VAYU_READ_API_KEY")
 AWS_VAYU_WRITE_API_KEY = os.environ.get("AWS_VAYU_WRITE_API_KEY")

--- a/app/core/logger/__init__.py
+++ b/app/core/logger/__init__.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import re
 import sys
 from typing import Optional
 
@@ -12,15 +13,52 @@ logger.remove()
 from app.core.config.static import ENVIRONMENT, PROD_LOG_LEVEL
 from app.core.logger.context import get_log_context
 
+# Query parameters whose VALUE is a credential rather than data. Exotel's
+# webhook shared secret travels in the URL — the only channel Exotel offers —
+# so any log line carrying that URL (Uvicorn's access log, or a handler logging
+# its own query params) would otherwise write the secret to the sink on every
+# inbound callback. Anyone who could read logs could then forge callbacks, which
+# is precisely the attack the signature verification closes.
+_SENSITIVE_QUERY_PARAMS = ("auth_token",)
+
+_SENSITIVE_QUERY_RE = re.compile(
+    r"(?i)\b("
+    + "|".join(_SENSITIVE_QUERY_PARAMS)
+    + r")"
+    # ``k=v`` in a URL/access-log line, or ``'k': 'v'`` from a logged dict.
+    r"(\s*['\"]?\s*[:=]\s*['\"]?)([^&\s,}\"'<>]+)"
+)
+
+
+def redact_sensitive_query_params(message: str) -> str:
+    """Replace credential-bearing query-parameter values in a log line.
+
+    Operates on free-form text rather than a parsed URL because the lines that
+    carry the secret are not URLs: an access-log line is a request line, and a
+    handler may log ``dict(request.query_params)``. Never raises — a logging
+    helper must not be able to break a log call.
+    """
+    try:
+        return _SENSITIVE_QUERY_RE.sub(r"\1\2REDACTED", message)
+    except Exception:  # pragma: no cover - defensive; never break a log call
+        return message
+
 
 # Patcher to inject log context into extra BEFORE enqueueing
 # This is critical because enqueue=True processes logs in a background thread
 # where contextvars are not propagated. The patcher runs in the calling thread.
 # Defined at module level so it can be reused in configure_session_logger()
 def log_context_patcher(record):
-    """Inject log context into record['extra'] for both dev and prod formatting."""
+    """Inject log context into record['extra'] for both dev and prod formatting.
+
+    Also redacts credential-bearing query parameters. This is the one chokepoint
+    every record passes through — app-level ``logger.*`` calls and Uvicorn
+    records forwarded by :class:`InterceptHandler` alike — in both dev and JSON
+    formatting, so a secret cannot reach a sink by any route.
+    """
     ctx = get_log_context()
     record["extra"]["_log_context"] = ctx
+    record["message"] = redact_sensitive_query_params(record["message"])
 
 
 def json_sink(message):
@@ -88,6 +126,8 @@ class InterceptHandler(logging.Handler):
         # Bind log context to forwarded logs
         # This ensures pipecat/library logs also get the log context
         log_context = get_log_context()
+        # Redaction happens in log_context_patcher, which every record passes
+        # through — no need to repeat it here.
         logger.opt(depth=depth, exception=record.exc_info).bind(
             _log_context=log_context
         ).log(level, record.getMessage())

--- a/app/core/security/webhook_signature.py
+++ b/app/core/security/webhook_signature.py
@@ -1,0 +1,215 @@
+"""
+Shared telephony webhook authentication.
+
+Every provider callback/answer/recording webhook must prove it came from the
+real provider before the server acts on it. Twilio and Plivo sign their
+requests (HMAC over the exact public URL + params); Exotel uses a shared secret
+token on the query string. This module centralises verification so all webhook
+routes share one correct, constant-time implementation.
+
+Signature reconstruction uses ``APP_BASE_URL`` — the canonical public base the
+providers were configured with — rather than ``request.url``, which behind a
+load balancer reflects an internal host that differs from what the provider
+actually signed.
+
+Enforcement is on by default (secure). ``ENFORCE_TELEPHONY_WEBHOOK_SIGNATURES``
+exists only as an operational escape hatch; even when a provider's secret is
+unset the verifier fails closed (rejects) rather than silently allowing.
+"""
+
+import hmac
+from typing import Mapping, Optional
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
+
+from fastapi import HTTPException, Request, status
+
+from app.core.config.static import (
+    APP_BASE_URL,
+    ENFORCE_TELEPHONY_WEBHOOK_SIGNATURES,
+    EXOTEL_WEBHOOK_AUTH_TOKEN,
+    PLIVO_AUTH_TOKEN,
+    TELEPHONY_WEBHOOK_PATH_PREFIX,
+    TWILIO_AUTH_TOKEN,
+)
+from app.core.logger import logger
+
+REDACTED = "REDACTED"
+
+
+def redact_query_param(url: str, param: str = "auth_token") -> str:
+    """Return ``url`` with ``param``'s value replaced by ``REDACTED``.
+
+    The Exotel status-callback URL carries the shared webhook secret as a query
+    parameter — that is the only channel Exotel offers — so the URL itself is
+    secret-bearing and must never reach a log sink. Use this anywhere such a URL
+    is logged. Returns the input unchanged if it cannot be parsed, since a
+    logging helper must not raise.
+    """
+    try:
+        parts = urlsplit(url)
+        if not parts.query:
+            return url
+        pairs = [
+            (k, REDACTED if k == param else v)
+            for k, v in parse_qsl(parts.query, keep_blank_values=True)
+        ]
+        return urlunsplit(
+            (parts.scheme, parts.netloc, parts.path, urlencode(pairs), parts.fragment)
+        )
+    except Exception:  # pragma: no cover - defensive; never break a log call
+        return url
+
+
+def reconstruct_public_url(request: Request) -> str:
+    """Rebuild the exact URL the provider signed (public base + path + query).
+
+    ``TELEPHONY_WEBHOOK_PATH_PREFIX`` covers the ingress-rewrite case: providers
+    sign the externally-visible URL, so when a proxy strips a prefix before the
+    request reaches us, ``request.url.path`` is shorter than what was signed and
+    every legitimate webhook would be rejected. The prefix comes from config
+    rather than ``X-Forwarded-Prefix`` on purpose — see static.py.
+    """
+    if APP_BASE_URL:
+        base = APP_BASE_URL.rstrip("/")
+        url = f"{base}{TELEPHONY_WEBHOOK_PATH_PREFIX}{request.url.path}"
+    else:
+        # No configured public base — best effort. Signature checks will only
+        # pass in dev if the provider signed this exact host, which is fine.
+        logger.warning(
+            "APP_BASE_URL is unset; reconstructing webhook URL from request.url "
+            "which may not match the signed URL behind a proxy"
+        )
+        url = str(request.url).split("?", 1)[0]
+    query = request.url.query
+    return f"{url}?{query}" if query else url
+
+
+def verify_exotel_token(token: Optional[str]) -> bool:
+    """Constant-time compare of the Exotel webhook token. Fails closed if unset.
+
+    Both operands are encoded to UTF-8 first: ``hmac.compare_digest`` raises
+    ``TypeError`` on ``str`` containing non-ASCII, and the token is caller-
+    supplied, so comparing strings would let anyone turn a controlled 401 into
+    an unhandled 500 by sending a non-ASCII ``auth_token``.
+    """
+    if not EXOTEL_WEBHOOK_AUTH_TOKEN:
+        return False
+    return hmac.compare_digest(
+        (token or "").encode("utf-8"), EXOTEL_WEBHOOK_AUTH_TOKEN.encode("utf-8")
+    )
+
+
+def verify_twilio_signature(
+    url: str, params: Mapping[str, str], signature: Optional[str]
+) -> bool:
+    """Verify an X-Twilio-Signature header. Fails closed if the token is unset."""
+    if not TWILIO_AUTH_TOKEN or not signature:
+        return False
+    try:
+        from twilio.request_validator import RequestValidator
+
+        validator = RequestValidator(TWILIO_AUTH_TOKEN)
+        return bool(validator.validate(url, dict(params), signature))
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.warning(f"Twilio signature validation error: {exc}")
+        return False
+
+
+def verify_plivo_signature(
+    method: str, url: str, headers: Mapping[str, str], params: Mapping[str, str]
+) -> bool:
+    """Verify a Plivo V3 (preferred) or V2 signature. Fails closed if unset."""
+    if not PLIVO_AUTH_TOKEN:
+        return False
+    try:
+        import plivo.utils as plivo_utils
+
+        v3_sig = headers.get("X-Plivo-Signature-V3")
+        v3_nonce = headers.get("X-Plivo-Signature-V3-Nonce")
+        if v3_sig and v3_nonce:
+            return bool(
+                plivo_utils.validate_v3_signature(
+                    method.upper(),
+                    url,
+                    v3_nonce,
+                    PLIVO_AUTH_TOKEN,
+                    v3_sig,
+                    dict(params) or None,
+                )
+            )
+        v2_sig = headers.get("X-Plivo-Signature-V2")
+        v2_nonce = headers.get("X-Plivo-Signature-V2-Nonce")
+        if v2_sig and v2_nonce:
+            return bool(
+                plivo_utils.validate_signature(url, v2_nonce, v2_sig, PLIVO_AUTH_TOKEN)
+            )
+        return False
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.warning(f"Plivo signature validation error: {exc}")
+        return False
+
+
+async def verify_provider_webhook(request: Request, provider: str) -> None:
+    """Authenticate a provider webhook; raise HTTPException(401) on failure.
+
+    Reads form data for POST requests (Starlette caches the body so callers may
+    still read it again). Dispatches to the per-provider verifier.
+    """
+    if not ENFORCE_TELEPHONY_WEBHOOK_SIGNATURES:
+        logger.warning(
+            f"Telephony webhook signature enforcement is DISABLED for {provider} "
+            "(ENFORCE_TELEPHONY_WEBHOOK_SIGNATURES=false) — do not run this in production"
+        )
+        return
+
+    provider = provider.lower()
+    url = reconstruct_public_url(request)
+
+    if provider == "exotel":
+        if not verify_exotel_token(request.query_params.get("auth_token")):
+            _reject(provider)
+        return
+
+    params: dict[str, str] = {}
+    if request.method == "POST":
+        try:
+            form = await request.form()
+            # Keep only real string fields. Twilio and Plivo sign an
+            # ``application/x-www-form-urlencoded`` body, so every signed field
+            # is a string; a multipart part arrives as ``UploadFile``, and
+            # ``str(upload_file)`` would put a Python repr into the signature
+            # base string, silently failing verification for a request that was
+            # never signed that way. Dropping it fails closed on the same path.
+            params = {k: v for k, v in form.items() if isinstance(v, str)}
+            dropped = len(form) - len(params)
+            if dropped:
+                logger.warning(
+                    f"{provider} webhook carried {dropped} non-text form field(s); "
+                    "ignored for signature verification (providers sign urlencoded "
+                    "bodies only)"
+                )
+        except Exception:
+            params = {}
+
+    if provider == "twilio":
+        # Twilio signs the full URL (incl. query) for GET and URL+form for POST.
+        sig = request.headers.get("X-Twilio-Signature")
+        if not verify_twilio_signature(url, params, sig):
+            _reject(provider)
+        return
+
+    if provider == "plivo":
+        if not verify_plivo_signature(request.method, url, request.headers, params):
+            _reject(provider)
+        return
+
+    # Unknown provider — fail closed.
+    _reject(provider)
+
+
+def _reject(provider: str) -> None:
+    logger.warning(f"Rejected unauthenticated/forged {provider} webhook request")
+    raise HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="Webhook signature verification failed",
+    )

--- a/tests/e2e_security/README.md
+++ b/tests/e2e_security/README.md
@@ -1,0 +1,32 @@
+# Security end-to-end suites
+
+These launch the **real application** with Uvicorn on loopback and drive the
+**real mounted routes** over real HTTP, with provider signatures produced by the
+providers' own SDKs. Unit tests build Starlette requests in process; only these
+prove the wiring behaves when a real client talks to a real server.
+
+```bash
+uv run pytest tests/e2e_security/ -v
+```
+
+## Isolation
+
+Every run uses an explicit allowlisted environment (`conftest.sealed_env`). The
+developer's environment and `.env` are **not** inherited — either could carry a
+real database URL or provider credential into the run. Postgres, Redis, the
+dispatcher, background tasks and tracing are all off; all credentials are
+synthetic values defined in `conftest.py`.
+
+Nothing here may contact a non-loopback address. The SSRF suite asserts on a
+local server's request ledger, which is the only way to show that a blocked
+destination was never contacted — a mocked transport cannot demonstrate that.
+
+## What these cannot prove
+
+- Real Twilio/Plivo/Exotel delivery from provider infrastructure.
+- Deployed ingress path-prefix rewriting (`TELEPHONY_WEBHOOK_PATH_PREFIX`).
+- Redirect-hop re-validation: strict mode blocks the loopback first hop, and the
+  private-egress hatch disables per-hop checks, so neither posture exercises it
+  over real sockets. Covered deterministically in `tests/test_ssrf_egress.py`.
+
+`test_ssrf_egress_e2e.py` skips until the SSRF egress guard lands (PR #987).

--- a/tests/e2e_security/conftest.py
+++ b/tests/e2e_security/conftest.py
@@ -1,0 +1,149 @@
+"""Hermetic launch harness for the security E2E suites.
+
+Launches the REAL application with Uvicorn on loopback and drives it over real
+HTTP. Everything is sealed: an explicit allowlisted environment (no ``.env`` is
+read), no Postgres, no Redis, no background workers, no provider hosts, and only
+synthetic credentials invented here. Nothing in this package may contact a
+non-loopback address.
+"""
+
+import os
+import socket
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Dict, Iterator, Optional
+
+import httpx
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# Synthetic, non-secret values. Never reuse a real provider credential here.
+TWILIO_TOKEN = "twilio-e2e-synthetic-token"
+PLIVO_TOKEN = "plivo-e2e-synthetic-token"
+EXOTEL_TOKEN = "exotel-e2e-synthetic-token"
+
+
+def free_port() -> int:
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return int(s.getsockname()[1])
+
+
+def sealed_env(port: int, extra: Optional[Dict[str, str]] = None) -> Dict[str, str]:
+    """Explicit allowlist. Inheriting the developer's environment is forbidden:
+    it can carry a real ``DATABASE_URL`` or provider credential into the run."""
+    env = {
+        "PATH": os.environ["PATH"],
+        "HOME": os.environ.get("HOME", "/tmp"),
+        "PYTHONPATH": str(REPO_ROOT),
+        "PYTHONUNBUFFERED": "1",
+        "JWT_SECRET_KEY": "e2e-local-not-a-real-secret",
+        "JWT_ALGORITHM": "HS256",
+        "SKIP_KMS_DECRYPT": "true",
+        "APP_BASE_URL": f"http://127.0.0.1:{port}",
+        "TELEPHONY_WEBHOOK_PATH_PREFIX": "",
+        "ENFORCE_TELEPHONY_WEBHOOK_SIGNATURES": "true",
+        "TWILIO_AUTH_TOKEN": TWILIO_TOKEN,
+        "PLIVO_AUTH_TOKEN": PLIVO_TOKEN,
+        "EXOTEL_WEBHOOK_AUTH_TOKEN": EXOTEL_TOKEN,
+        "SSRF_ALLOW_PRIVATE_EGRESS": "false",
+        # every stateful / background subsystem off
+        "POSTGRES_HOST": "",
+        "POSTGRES_PORT": "",
+        "POSTGRES_DB": "",
+        "POSTGRES_USER": "",
+        "POSTGRES_PASSWORD": "",
+        "REDIS_HOST": "",
+        "REDIS_PORT": "",
+        "REDIS_CLUSTER_NODES": "",
+        "ENABLE_REDIS_DYNAMIC_CONFIG": "false",
+        "ENABLE_BACKGROUND_TASKS": "false",
+        "ENABLE_DISPATCHER": "false",
+        "ENABLE_VOICE_AGENT_POOL": "false",
+        "ENABLE_DAILY_ROOM_POOL": "false",
+        "ENABLE_DRAGONTTS_KILL_SWITCH": "false",
+        "ENABLE_TRACING": "false",
+        "OTEL_SDK_DISABLED": "true",
+        "UVICORN_RELOAD": "false",
+    }
+    if extra:
+        env.update(extra)
+    return env
+
+
+class LaunchedApp:
+    """A running Uvicorn process serving the real ASGI app on loopback."""
+
+    def __init__(self, base: str, log_path: Path):
+        self.base = base
+        self._log_path = log_path
+
+    @property
+    def log(self) -> str:
+        return self._log_path.read_text()
+
+
+@pytest.fixture(scope="session")
+def launched_app(tmp_path_factory) -> Iterator[LaunchedApp]:
+    port = free_port()
+    log_path = tmp_path_factory.mktemp("e2e") / "api-server.log"
+    log_file = open(log_path, "w")
+    proc = subprocess.Popen(
+        [
+            sys.executable,
+            "-m",
+            "uvicorn",
+            "app.main:app",
+            "--host",
+            "127.0.0.1",
+            "--port",
+            str(port),
+            "--log-level",
+            "info",
+        ],
+        cwd=str(REPO_ROOT),
+        env=sealed_env(port),
+        stdout=log_file,
+        stderr=subprocess.STDOUT,
+        # Hand the child only the pipes above — not whatever descriptors this
+        # pytest process happens to hold open.
+        close_fds=True,
+    )
+    base = f"http://127.0.0.1:{port}"
+    try:
+        deadline = time.time() + 120
+        # One client for the whole probe loop; a per-iteration client leaks a
+        # connection pool on every retry.
+        with httpx.Client(timeout=2.0) as probe:
+            while True:
+                if proc.poll() is not None:
+                    log_file.flush()
+                    pytest.fail(
+                        f"app exited rc={proc.returncode}\n{log_path.read_text()[-3000:]}"
+                    )
+                if time.time() > deadline:
+                    pytest.fail(
+                        f"app never became healthy\n{log_path.read_text()[-3000:]}"
+                    )
+                try:
+                    if probe.get(f"{base}/health").status_code == 200:
+                        break
+                except Exception:
+                    time.sleep(0.4)
+        yield LaunchedApp(base, log_path)
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=15)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+        log_file.close()
+
+
+@pytest.fixture(scope="session")
+def client(launched_app: LaunchedApp) -> Iterator[httpx.Client]:
+    with httpx.Client(base_url=launched_app.base, timeout=20.0) as c:
+        yield c

--- a/tests/e2e_security/test_ssrf_egress_e2e.py
+++ b/tests/e2e_security/test_ssrf_egress_e2e.py
@@ -1,0 +1,166 @@
+"""End-to-end proof that the SSRF egress guard blocks before a packet leaves.
+
+Runs against a REAL loopback HTTP server, asserting on that server's request
+ledger — the only way to show a blocked destination was never contacted, which
+a mocked transport cannot demonstrate.
+
+Skipped until the SSRF egress guard lands (PR #987). Once both are on
+``release`` this runs alongside the telephony suite from the same directory.
+"""
+
+import asyncio
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from typing import Any, Iterator, List, Tuple, cast
+
+import pytest
+
+ssrf = pytest.importorskip(
+    "app.core.security.ssrf",
+    reason="SSRF egress guard not on this branch yet (arrives with PR #987)",
+)
+
+
+class _RecordingServer(HTTPServer):
+    """Owns its own request ledger, so no state is shared between tests."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.hits: List[str] = []
+
+
+class _Recorder(BaseHTTPRequestHandler):
+    def do_GET(self):
+        cast(_RecordingServer, self.server).hits.append(f"{self.command} {self.path}")
+        body = json.dumps({"ok": True}).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    do_POST = do_GET
+
+    def log_message(self, format: str, *args: Any) -> None:
+        """Silence stderr access logging; signature matches the base class."""
+
+
+@pytest.fixture
+def recorder() -> Iterator[Tuple[str, List[str]]]:
+    srv = _RecordingServer(("127.0.0.1", 0), _Recorder)
+    threading.Thread(target=srv.serve_forever, daemon=True).start()
+    try:
+        yield f"http://127.0.0.1:{srv.server_address[1]}", srv.hits
+    finally:
+        srv.shutdown()
+        srv.server_close()
+
+
+@pytest.mark.parametrize(
+    "ip,label",
+    [
+        ("127.0.0.1", "loopback"),
+        ("169.254.169.254", "cloud metadata"),
+        ("10.0.0.5", "RFC1918"),
+        ("192.168.1.1", "RFC1918"),
+        ("::1", "IPv6 loopback"),
+        ("::ffff:169.254.169.254", "IPv4-mapped metadata"),
+    ],
+)
+def test_non_public_addresses_are_blocked(ip, label):
+    assert ssrf.ip_block_reason(ip) is not None, f"{label} {ip} must be blocked"
+
+
+def test_loopback_url_is_rejected_over_real_dns(recorder):
+    base, _ = recorder
+    with pytest.raises(ssrf.SSRFError):
+        asyncio.run(ssrf.validate_egress_url(base + "/x", allow_http=True))
+
+
+def test_hostname_resolving_to_loopback_is_rejected(recorder):
+    base, _ = recorder
+    port = base.rsplit(":", 1)[1]
+    with pytest.raises(ssrf.SSRFError):
+        asyncio.run(
+            ssrf.validate_egress_url(f"http://localhost:{port}/x", allow_http=True)
+        )
+
+
+def test_cloud_metadata_is_rejected():
+    with pytest.raises(ssrf.SSRFError):
+        asyncio.run(
+            ssrf.validate_egress_url(
+                "http://169.254.169.254/latest/meta-data/", allow_http=True
+            )
+        )
+
+
+def test_plain_http_is_rejected_unless_explicitly_allowed():
+    with pytest.raises(ssrf.SSRFError):
+        asyncio.run(ssrf.validate_egress_url("http://example.com/"))
+
+
+def test_blocked_request_never_reaches_the_socket(recorder):
+    """The assertion that matters: zero bytes reached the destination."""
+    base, hits = recorder
+
+    async def go():
+        import aiohttp
+
+        async with aiohttp.ClientSession() as s:
+            async with ssrf.ssrf_safe_request(
+                s, "GET", base + "/probe", allow_http=True
+            ):
+                pass
+
+    with pytest.raises(ssrf.SSRFError):
+        asyncio.run(go())
+    assert hits == [], "guard must block before any connection is made"
+
+
+def test_mcp_precheck_rejects_a_private_server_without_contacting_it(recorder):
+    """Covers the pre-check MCP path, which validates via ``_build_server_params``
+    before a credential header is ever assembled."""
+    base, hits = recorder
+    port = base.rsplit(":", 1)[1]
+
+    from app.ai.voice.agents.breeze_buddy.handlers.transport.http_requester import (
+        HttpRequestExecutor,
+    )
+    from app.ai.voice.agents.breeze_buddy.managers.pre_checks.http import (
+        _fetch_mcp_response,
+    )
+    from app.ai.voice.agents.breeze_buddy.template.types import McpServerConfig
+    from app.schemas import PreCheckConfig
+
+    # https:// so the scheme gate passes and the IP policy is what decides.
+    server = McpServerConfig(
+        name="e2e-sim",
+        url=f"https://127.0.0.1:{port}/mcp",
+        headers={"X-Tenant-Secret": "must-never-egress"},
+    )
+    pre_check = PreCheckConfig(
+        name="e2e",
+        type="external_api",
+        mcp=server,
+        mcp_tool="lookup",
+        mcp_arguments={"q": "x"},
+    )
+
+    async def go():
+        import aiohttp
+
+        async with aiohttp.ClientSession() as s:
+            return await _fetch_mcp_response(pre_check, {}, HttpRequestExecutor(s))
+
+    payload, reason = asyncio.run(go())
+    assert payload is None
+    assert "MCP server URL rejected" in (reason or "")
+    assert hits == [], "credentialed MCP call must not reach a blocked destination"
+
+
+def test_mcp_server_url_must_be_https(recorder):
+    base, _ = recorder
+    with pytest.raises(ssrf.SSRFError, match="(?i)scheme"):
+        asyncio.run(ssrf.validate_egress_url(base + "/mcp"))

--- a/tests/e2e_security/test_telephony_webhooks_e2e.py
+++ b/tests/e2e_security/test_telephony_webhooks_e2e.py
@@ -1,0 +1,257 @@
+"""End-to-end proof that telephony webhook verification holds on the real app.
+
+These drive the actual mounted routes over real HTTP sockets, with signatures
+produced by the providers' own SDKs. Unit tests build Starlette requests in
+process; only this suite proves the wiring — router mounting, form parsing,
+canonical URL reconstruction and the 401 short-circuit — behaves as intended
+when a real client talks to a real server.
+"""
+
+from typing import Dict
+
+import pytest
+
+from tests.e2e_security.conftest import EXOTEL_TOKEN, PLIVO_TOKEN, TWILIO_TOKEN
+
+STATUS = "/agent/voice/breeze-buddy/{p}/callback/status"
+ANSWER = "/agent/voice/breeze-buddy/{p}/answer"
+FALLBACK = "/agent/voice/breeze-buddy/twilio/callback/twiml-fallback"
+
+TWILIO_FORM = {"CallSid": "CA-e2e-synthetic", "CallStatus": "ringing"}
+PLIVO_FORM = {"CallUUID": "PL-e2e-synthetic", "CallStatus": "ringing"}
+
+
+def twilio_sig(url: str, params: Dict[str, str], token: str = TWILIO_TOKEN) -> str:
+    from twilio.request_validator import RequestValidator
+
+    return RequestValidator(token).compute_signature(url, params)
+
+
+def plivo_v3(
+    url: str, params: Dict[str, str], nonce: str, token: str = PLIVO_TOKEN
+) -> str:
+    from plivo.utils.signature_v3 import construct_post_url, get_signature_v3
+
+    base = construct_post_url(url, params).decode("utf-8")
+    return get_signature_v3(token.encode("utf-8"), base, nonce.encode("utf-8")).decode(
+        "utf-8"
+    )
+
+
+# --------------------------------------------------------------------------
+# Exotel — shared-secret token on the query string
+# --------------------------------------------------------------------------
+
+
+def test_exotel_status_without_token_is_rejected(client):
+    r = client.post(
+        STATUS.format(p="exotel"), data={"CallSid": "EX1", "Status": "in-progress"}
+    )
+    assert r.status_code == 401
+
+
+def test_exotel_status_with_wrong_token_is_rejected(client):
+    r = client.post(
+        STATUS.format(p="exotel") + "?auth_token=wrong-token",
+        data={"CallSid": "EX1", "Status": "in-progress"},
+    )
+    assert r.status_code == 401
+
+
+def test_exotel_status_with_correct_token_passes_the_verifier(client):
+    r = client.post(
+        STATUS.format(p="exotel") + f"?auth_token={EXOTEL_TOKEN}",
+        data={"CallSid": "EX1", "Status": "in-progress"},
+    )
+    assert r.status_code != 401
+
+
+# --------------------------------------------------------------------------
+# Twilio — HMAC signature
+# --------------------------------------------------------------------------
+
+
+def test_twilio_status_without_signature_is_rejected(client):
+    assert client.post(STATUS.format(p="twilio"), data=TWILIO_FORM).status_code == 401
+
+
+def test_twilio_status_with_forged_signature_is_rejected(client):
+    r = client.post(
+        STATUS.format(p="twilio"),
+        data=TWILIO_FORM,
+        headers={"X-Twilio-Signature": "AAAAforgedAAAA="},
+    )
+    assert r.status_code == 401
+
+
+def test_twilio_status_with_sdk_generated_signature_passes(client, launched_app):
+    url = f"{launched_app.base}{STATUS.format(p='twilio')}"
+    r = client.post(
+        STATUS.format(p="twilio"),
+        data=TWILIO_FORM,
+        headers={"X-Twilio-Signature": twilio_sig(url, TWILIO_FORM)},
+    )
+    assert r.status_code != 401
+
+
+def test_twilio_signature_binds_the_form_fields(client, launched_app):
+    """Sign one payload, send another: the signature must not still validate."""
+    url = f"{launched_app.base}{STATUS.format(p='twilio')}"
+    sig = twilio_sig(url, TWILIO_FORM)
+    tampered = dict(TWILIO_FORM, CallStatus="completed")
+    r = client.post(
+        STATUS.format(p="twilio"), data=tampered, headers={"X-Twilio-Signature": sig}
+    )
+    assert r.status_code == 401
+
+
+def test_twilio_signature_is_checked_against_app_base_url_not_the_host_header(client):
+    """A signature computed for another origin must not authenticate here.
+
+    Sends a hostile ``Host`` header *and* a signature computed for that same
+    hostile origin. If the verifier reconstructed the signed URL from the
+    request's host, the two would agree and this would authenticate. It must be
+    rejected, because the URL is rebuilt from the configured ``APP_BASE_URL``.
+    """
+    hostile = "attacker.example.com"
+    r = client.post(
+        STATUS.format(p="twilio"),
+        data=TWILIO_FORM,
+        headers={
+            "Host": hostile,
+            "X-Twilio-Signature": twilio_sig(
+                f"https://{hostile}{STATUS.format(p='twilio')}", TWILIO_FORM
+            ),
+        },
+    )
+    assert r.status_code == 401, (
+        "signature validated against the attacker-supplied Host header — "
+        "the canonical URL must come from APP_BASE_URL"
+    )
+
+
+# --------------------------------------------------------------------------
+# Plivo — V3 signature
+# --------------------------------------------------------------------------
+
+
+def test_plivo_status_without_signature_is_rejected(client):
+    assert client.post(STATUS.format(p="plivo"), data=PLIVO_FORM).status_code == 401
+
+
+def test_plivo_status_with_valid_v3_signature_passes(client, launched_app):
+    url = f"{launched_app.base}{STATUS.format(p='plivo')}"
+    nonce = "e2e-nonce-12345"
+    r = client.post(
+        STATUS.format(p="plivo"),
+        data=PLIVO_FORM,
+        headers={
+            "X-Plivo-Signature-V3": plivo_v3(url, PLIVO_FORM, nonce),
+            "X-Plivo-Signature-V3-Nonce": nonce,
+        },
+    )
+    assert r.status_code != 401
+
+
+# --------------------------------------------------------------------------
+# Other guarded routes
+# --------------------------------------------------------------------------
+
+
+def test_twiml_fallback_rejects_a_forged_signature(client):
+    r = client.post(
+        FALLBACK, data=TWILIO_FORM, headers={"X-Twilio-Signature": "forged"}
+    )
+    assert r.status_code == 401
+
+
+def test_answer_route_rejects_an_unsupported_provider_before_auth(client):
+    assert client.post(ANSWER.format(p="twilio"), data=TWILIO_FORM).status_code == 404
+
+
+def test_answer_route_rejects_unsigned_plivo(client):
+    assert client.post(ANSWER.format(p="plivo"), data=PLIVO_FORM).status_code == 401
+
+
+def test_answer_route_rejects_wrong_exotel_token(client):
+    assert (
+        client.post(ANSWER.format(p="exotel") + "?auth_token=nope", data={}).status_code
+        == 401
+    )
+
+
+def test_unknown_provider_fails_closed(client):
+    assert client.post(STATUS.format(p="vonage"), data={}).status_code == 401
+
+
+# --------------------------------------------------------------------------
+# Log hygiene — the reason this suite exists at all
+# --------------------------------------------------------------------------
+
+
+def _log_after(launched_app, predicate, attempts: int = 25) -> str:
+    """Poll the server log until the child process has flushed what we need."""
+    import time
+
+    log = ""
+    for _ in range(attempts):
+        log = launched_app.log
+        if predicate(log):
+            return log
+        time.sleep(0.2)
+    return log
+
+
+def test_hmac_tokens_never_appear_in_logs(client, launched_app):
+    # Drive traffic here rather than relying on other tests having run.
+    client.post(
+        STATUS.format(p="twilio"),
+        data=TWILIO_FORM,
+        headers={"X-Twilio-Signature": "forged"},
+    )
+    client.post(STATUS.format(p="plivo"), data=PLIVO_FORM)
+    log = launched_app.log
+    assert TWILIO_TOKEN not in log
+    assert PLIVO_TOKEN not in log
+
+
+def test_exotel_shared_secret_is_not_written_to_the_access_log(client, launched_app):
+    """Regression: Exotel's secret rides in the query string, so Uvicorn's raw
+    request line would leak it on every inbound callback. The log patcher
+    redacts it; anyone who can read logs must not be able to forge callbacks.
+
+    Self-contained on purpose — it issues the request it asserts about, so it
+    cannot pass merely because an earlier test happened to run first.
+    """
+    client.post(
+        STATUS.format(p="exotel") + f"?auth_token={EXOTEL_TOKEN}",
+        data={"CallSid": "EX-log-check", "Status": "in-progress"},
+    )
+    log = _log_after(launched_app, lambda l: "auth_token=" in l)
+    assert "auth_token=REDACTED" in log, "access log line was never observed"
+    assert EXOTEL_TOKEN not in log, "Exotel shared secret leaked into the logs"
+
+
+def test_call_details_handler_does_not_log_the_secret(client, launched_app):
+    """The call-details handler logs ``dict(request.query_params)`` itself.
+
+    That is an app-level ``logger.*`` call, which does NOT pass through
+    ``InterceptHandler`` — so redacting only intercepted records would miss it.
+    Redaction lives in the patcher precisely so both routes are covered.
+    """
+    client.get(
+        f"/agent/voice/breeze-buddy/exotel/callback/details?auth_token={EXOTEL_TOKEN}"
+        "&CallSid=EX-details-log-check"
+    )
+    log = _log_after(launched_app, lambda l: "EX-details-log-check" in l)
+    assert "EX-details-log-check" in log, "handler log line was never observed"
+    assert EXOTEL_TOKEN not in log, "handler leaked the Exotel secret into the logs"
+
+
+def test_non_ascii_exotel_token_yields_401_not_500(client):
+    """A caller-supplied non-ASCII token must not crash the verifier."""
+    r = client.post(
+        STATUS.format(p="exotel") + "?auth_token=%C3%A9%D1%82%D0%BE",
+        data={"CallSid": "EX-non-ascii", "Status": "in-progress"},
+    )
+    assert r.status_code == 401, f"expected a controlled 401, got {r.status_code}"

--- a/tests/test_pentest_telephony_auth.py
+++ b/tests/test_pentest_telephony_auth.py
@@ -1,0 +1,340 @@
+"""PT-05/PT-23: telephony webhook authentication.
+
+Covers all three verifiers, not just Exotel. Signatures here are produced by the
+providers' own SDK signing code (``RequestValidator.compute_signature``,
+``get_signature_v3``, and the documented V2 HMAC), so a test passing means we
+verify what the provider actually sends — not what we assume it sends.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac as hmac_mod
+from typing import Optional
+
+import pytest
+from fastapi import HTTPException
+from starlette.requests import Request
+
+from app.core.security import webhook_signature as ws
+
+TOKEN = "auth-token-under-test"
+BASE = "https://calls.example.com"
+
+
+# ── request construction ──────────────────────────────────────────────────
+def _request(
+    method: str,
+    path: str,
+    query: str = "",
+    headers: Optional[dict] = None,
+    body: bytes = b"",
+) -> Request:
+    """Build a real Starlette Request the verifier can consume."""
+    raw_headers = [(k.lower().encode(), v.encode()) for k, v in (headers or {}).items()]
+    if body:
+        raw_headers.append(
+            (b"content-type", b"application/x-www-form-urlencoded"),
+        )
+    scope = {
+        "type": "http",
+        "http_version": "1.1",
+        "method": method,
+        "scheme": "https",
+        "server": ("internal-host", 8000),
+        "path": path,
+        "raw_path": path.encode(),
+        "query_string": query.encode(),
+        "headers": raw_headers,
+        "client": ("10.0.0.1", 51234),
+    }
+
+    async def receive():
+        return {"type": "http.request", "body": body, "more_body": False}
+
+    return Request(scope, receive)
+
+
+def _sign_plivo_v3(method: str, url: str, nonce: str, params: dict) -> str:
+    import plivo.utils.signature_v3 as sig3
+
+    if method.upper() == "GET":
+        base = sig3.construct_get_url(url, dict(params)).decode("utf-8")
+    else:
+        base = sig3.construct_post_url(url, dict(params)).decode("utf-8")
+    return sig3.get_signature_v3(TOKEN.encode("utf-8"), base, nonce).decode("utf-8")
+
+
+def _sign_plivo_v2(url: str, nonce: str) -> str:
+    """V2 signs the URL with the query string REMOVED (see plivo.utils)."""
+    from urllib.parse import urlsplit, urlunsplit
+
+    parts = urlsplit(url)
+    base = urlunsplit((parts.scheme, parts.netloc, parts.path, "", ""))
+    digest = hmac_mod.new(
+        TOKEN.encode(), (base + nonce).encode(), hashlib.sha256
+    ).digest()
+    return base64.b64encode(digest).decode().strip()
+
+
+@pytest.fixture
+def enforced(monkeypatch):
+    """Enforcement on, all provider secrets set, canonical public base."""
+    monkeypatch.setattr(ws, "ENFORCE_TELEPHONY_WEBHOOK_SIGNATURES", True)
+    monkeypatch.setattr(ws, "APP_BASE_URL", BASE)
+    monkeypatch.setattr(ws, "TELEPHONY_WEBHOOK_PATH_PREFIX", "")
+    monkeypatch.setattr(ws, "TWILIO_AUTH_TOKEN", TOKEN)
+    monkeypatch.setattr(ws, "PLIVO_AUTH_TOKEN", TOKEN)
+    monkeypatch.setattr(ws, "EXOTEL_WEBHOOK_AUTH_TOKEN", TOKEN)
+
+
+# ── PT-23/05: constant-time exotel token + fail-closed when unset ─────────
+def test_verify_exotel_token(monkeypatch):
+    monkeypatch.setattr(ws, "EXOTEL_WEBHOOK_AUTH_TOKEN", "s3cret")
+    assert ws.verify_exotel_token("s3cret") is True
+    assert ws.verify_exotel_token("wrong") is False
+    assert ws.verify_exotel_token(None) is False
+    monkeypatch.setattr(ws, "EXOTEL_WEBHOOK_AUTH_TOKEN", "")
+    assert ws.verify_exotel_token("s3cret") is False  # fail closed when unset
+
+
+def test_verify_exotel_token_rejects_non_ascii_without_raising(monkeypatch):
+    """``hmac.compare_digest`` raises TypeError on non-ASCII ``str`` operands.
+
+    The token is caller-supplied, so comparing strings would let anyone turn a
+    controlled 401 into an unhandled 500 by sending a non-ASCII ``auth_token``.
+    """
+    monkeypatch.setattr(ws, "EXOTEL_WEBHOOK_AUTH_TOKEN", "s3cret")
+    assert ws.verify_exotel_token("é") is False
+    assert ws.verify_exotel_token("токен") is False
+    assert ws.verify_exotel_token("🙂") is False
+
+    # ...and a non-ASCII secret still matches itself.
+    monkeypatch.setattr(ws, "EXOTEL_WEBHOOK_AUTH_TOKEN", "sé cret")
+    assert ws.verify_exotel_token("sé cret") is True
+    assert ws.verify_exotel_token("se cret") is False
+
+
+# ── Secrets must never reach a log sink ───────────────────────────────────
+def test_redaction_covers_urls_access_log_lines_and_logged_dicts():
+    """One chokepoint has to cover every shape the secret arrives in."""
+    from app.core.logger import redact_sensitive_query_params as redact
+
+    access_line = (
+        '1.2.3.4:5 - "POST /exotel/callback/status?auth_token=SEKRIT HTTP/1.1" 200'
+    )
+    assert "SEKRIT" not in redact(access_line)
+    assert "auth_token=REDACTED" in redact(access_line)
+
+    url = "https://host/p?auth_token=SEKRIT&CallSid=X"
+    assert "SEKRIT" not in redact(url)
+    assert "CallSid=X" in redact(url)  # non-secret params survive
+
+    # dict(request.query_params) as a handler would log it
+    logged_dict = "query params: {'auth_token': 'SEKRIT', 'CallSid': 'CA1'}"
+    assert "SEKRIT" not in redact(logged_dict)
+    assert "CA1" in redact(logged_dict)
+
+    assert redact("nothing sensitive here") == "nothing sensitive here"
+
+
+# ── Twilio ────────────────────────────────────────────────────────────────
+def test_verify_twilio_signature_accepts_a_real_signature(monkeypatch):
+    from twilio.request_validator import RequestValidator
+
+    monkeypatch.setattr(ws, "TWILIO_AUTH_TOKEN", TOKEN)
+    url = f"{BASE}/agent/voice/breeze-buddy/twilio/callback"
+    params = {"CallSid": "CA123", "CallStatus": "completed"}
+    sig = RequestValidator(TOKEN).compute_signature(url, params)
+
+    assert ws.verify_twilio_signature(url, params, sig) is True
+    # Any mutation of the signed material must break it.
+    assert ws.verify_twilio_signature(url, {**params, "CallSid": "CA9"}, sig) is False
+    assert ws.verify_twilio_signature(url + "x", params, sig) is False
+    assert ws.verify_twilio_signature(url, params, "not-a-signature") is False
+
+
+def test_verify_twilio_signature_fails_closed_without_token_or_header(monkeypatch):
+    monkeypatch.setattr(ws, "TWILIO_AUTH_TOKEN", "")
+    assert ws.verify_twilio_signature(BASE, {}, "anything") is False
+    monkeypatch.setattr(ws, "TWILIO_AUTH_TOKEN", TOKEN)
+    assert ws.verify_twilio_signature(BASE, {}, None) is False
+
+
+# ── Plivo ─────────────────────────────────────────────────────────────────
+@pytest.mark.parametrize("method", ["GET", "POST"])
+def test_verify_plivo_v3_signature(monkeypatch, method):
+    monkeypatch.setattr(ws, "PLIVO_AUTH_TOKEN", TOKEN)
+    url = f"{BASE}/agent/voice/breeze-buddy/plivo/answer?x=1"
+    params = {"CallUUID": "uuid-1"} if method == "POST" else {}
+    nonce = "12345"
+    sig = _sign_plivo_v3(method, url, nonce, params)
+    headers = {"X-Plivo-Signature-V3": sig, "X-Plivo-Signature-V3-Nonce": nonce}
+
+    assert ws.verify_plivo_signature(method, url, headers, params) is True
+    bad = {**headers, "X-Plivo-Signature-V3": "AAAA"}
+    assert ws.verify_plivo_signature(method, url, bad, params) is False
+
+
+def test_verify_plivo_v2_accepts_a_url_carrying_a_query_string(monkeypatch):
+    """The full URL (query included) is the right thing to hand the V2 helper.
+
+    ``plivo.utils.validate_signature`` re-parses the URI and drops the query
+    itself, so splitting at "?" before calling it would be redundant. Pinning it
+    here so the behaviour is checked rather than assumed.
+    """
+    monkeypatch.setattr(ws, "PLIVO_AUTH_TOKEN", TOKEN)
+    url = f"{BASE}/agent/voice/breeze-buddy/plivo/answer?CallUUID=uuid-1&x=2"
+    nonce = "99887"
+    headers = {
+        "X-Plivo-Signature-V2": _sign_plivo_v2(url, nonce),
+        "X-Plivo-Signature-V2-Nonce": nonce,
+    }
+    assert ws.verify_plivo_signature("POST", url, headers, {}) is True
+
+
+def test_verify_plivo_fails_closed(monkeypatch):
+    monkeypatch.setattr(ws, "PLIVO_AUTH_TOKEN", "")
+    assert ws.verify_plivo_signature("GET", BASE, {}, {}) is False
+    monkeypatch.setattr(ws, "PLIVO_AUTH_TOKEN", TOKEN)
+    # No signature headers at all — an unsigned request must not pass.
+    assert ws.verify_plivo_signature("GET", BASE, {}, {}) is False
+
+
+# ── URL reconstruction ────────────────────────────────────────────────────
+def test_reconstruct_public_url_uses_configured_base_not_request_host(monkeypatch):
+    monkeypatch.setattr(ws, "APP_BASE_URL", BASE)
+    monkeypatch.setattr(ws, "TELEPHONY_WEBHOOK_PATH_PREFIX", "")
+    req = _request("GET", "/agent/voice/x", query="a=1")
+    assert ws.reconstruct_public_url(req) == f"{BASE}/agent/voice/x?a=1"
+
+
+def test_reconstruct_public_url_restores_a_stripped_ingress_prefix(monkeypatch):
+    """A path-rewriting proxy would otherwise break every legitimate webhook."""
+    monkeypatch.setattr(ws, "APP_BASE_URL", BASE)
+    monkeypatch.setattr(ws, "TELEPHONY_WEBHOOK_PATH_PREFIX", "/telephony")
+    req = _request("POST", "/agent/voice/x")
+    assert ws.reconstruct_public_url(req) == f"{BASE}/telephony/agent/voice/x"
+
+
+def test_reconstruct_public_url_ignores_caller_supplied_forwarded_prefix(monkeypatch):
+    """X-Forwarded-Prefix is attacker-controlled; honouring it would let a
+    caller choose part of the string that goes into the signature base."""
+    monkeypatch.setattr(ws, "APP_BASE_URL", BASE)
+    monkeypatch.setattr(ws, "TELEPHONY_WEBHOOK_PATH_PREFIX", "")
+    req = _request("GET", "/x", headers={"X-Forwarded-Prefix": "/evil"})
+    assert ws.reconstruct_public_url(req) == f"{BASE}/x"
+
+
+def test_reconstruct_public_url_falls_back_to_request_url_when_base_unset(monkeypatch):
+    """With APP_BASE_URL unset there is no canonical base to rebuild from.
+
+    The fallback uses the request's own URL, which behind a proxy is an internal
+    host and will not match what the provider signed — so verification fails
+    closed with a 401 rather than admitting anything. Pinned here because the
+    fallback is a deliberate trade-off, not an accident: making it fatal would
+    turn a misconfiguration into a boot failure.
+    """
+    monkeypatch.setattr(ws, "APP_BASE_URL", "")
+    monkeypatch.setattr(ws, "TELEPHONY_WEBHOOK_PATH_PREFIX", "")
+
+    # Query string preserved...
+    req = _request("GET", "/x", query="a=1")
+    assert ws.reconstruct_public_url(req) == "https://internal-host:8000/x?a=1"
+
+    # ...and absent when there is none.
+    assert ws.reconstruct_public_url(_request("GET", "/x")) == (
+        "https://internal-host:8000/x"
+    )
+
+
+# ── secret redaction ──────────────────────────────────────────────────────
+def test_redact_query_param_hides_the_exotel_token():
+    url = f"{BASE}/cb?CallSid=CA1&auth_token=s3cret&x=2"
+    out = ws.redact_query_param(url)
+    assert "s3cret" not in out
+    assert "CallSid=CA1" in out and "x=2" in out
+
+
+def test_redact_query_param_is_a_noop_without_a_query():
+    assert ws.redact_query_param(f"{BASE}/cb") == f"{BASE}/cb"
+
+
+# ── verify_provider_webhook dispatch ──────────────────────────────────────
+async def test_provider_name_is_case_insensitive(enforced):
+    """A mixed-case path segment must not fall through to the unknown-provider
+    reject branch — that would 401 legitimate traffic."""
+    req = _request("GET", "/agent/voice/x", query=f"auth_token={TOKEN}")
+    await ws.verify_provider_webhook(req, "ExOtEl")  # must not raise
+
+
+async def test_unknown_provider_is_rejected(enforced):
+    req = _request("GET", "/agent/voice/x")
+    with pytest.raises(HTTPException) as exc:
+        await ws.verify_provider_webhook(req, "acmetel")
+    assert exc.value.status_code == 401
+
+
+async def test_exotel_webhook_without_token_is_rejected(enforced):
+    req = _request("GET", "/agent/voice/x", query="auth_token=wrong")
+    with pytest.raises(HTTPException) as exc:
+        await ws.verify_provider_webhook(req, "exotel")
+    assert exc.value.status_code == 401
+
+
+async def test_twilio_post_webhook_end_to_end(enforced):
+    from twilio.request_validator import RequestValidator
+
+    path = "/agent/voice/breeze-buddy/twilio/callback"
+    params = {"CallSid": "CA123", "RecordingUrl": "https://api.twilio.com/r.mp3"}
+    sig = RequestValidator(TOKEN).compute_signature(f"{BASE}{path}", params)
+    body = b"CallSid=CA123&RecordingUrl=https%3A%2F%2Fapi.twilio.com%2Fr.mp3"
+
+    req = _request("POST", path, headers={"X-Twilio-Signature": sig}, body=body)
+    await ws.verify_provider_webhook(req, "twilio")  # must not raise
+
+    forged = _request("POST", path, headers={"X-Twilio-Signature": "bogus"}, body=body)
+    with pytest.raises(HTTPException):
+        await ws.verify_provider_webhook(forged, "twilio")
+
+
+async def test_multipart_file_field_does_not_poison_the_signature_base(enforced):
+    """A file part must be ignored, not stringified into the signature base.
+
+    ``str(UploadFile)`` yields a Python repr with a memory address in it. Folding
+    that into the params would make verification fail for a request whose signed
+    text fields are perfectly valid — and fail differently on every run.
+    """
+    from twilio.request_validator import RequestValidator
+
+    path = "/agent/voice/breeze-buddy/twilio/callback"
+    signed = {"CallSid": "CA123"}
+    sig = RequestValidator(TOKEN).compute_signature(f"{BASE}{path}", signed)
+
+    boundary = "----pytestboundary"
+    body = (
+        f"--{boundary}\r\n"
+        'Content-Disposition: form-data; name="CallSid"\r\n\r\n'
+        "CA123\r\n"
+        f"--{boundary}\r\n"
+        'Content-Disposition: form-data; name="Recording"; filename="r.wav"\r\n'
+        "Content-Type: audio/wav\r\n\r\n"
+        "RIFFfake\r\n"
+        f"--{boundary}--\r\n"
+    ).encode()
+
+    req = _request("POST", path, headers={"X-Twilio-Signature": sig}, body=body)
+    # _request only sets the urlencoded content-type; override for multipart.
+    req.scope["headers"] = [
+        (k, v) for k, v in req.scope["headers"] if k != b"content-type"
+    ] + [(b"content-type", f"multipart/form-data; boundary={boundary}".encode())]
+
+    await ws.verify_provider_webhook(req, "twilio")  # must not raise
+
+
+async def test_enforcement_disabled_lets_an_unsigned_webhook_through(monkeypatch):
+    """The escape hatch must be the only thing that can open this path."""
+    monkeypatch.setattr(ws, "ENFORCE_TELEPHONY_WEBHOOK_SIGNATURES", False)
+    req = _request("GET", "/agent/voice/x")
+    await ws.verify_provider_webhook(req, "twilio")  # must not raise


### PR DESCRIPTION
Independent of the other pentest PRs — targets release, merges in any order.

The callback and answer routes accepted any caller: anyone who knew a URL could
drive call state. Verified on release — unsigned POSTs to the twilio, plivo and
exotel status callbacks are all accepted.

verify_provider_webhook (new) validates Twilio X-Twilio-Signature, Plivo V3
signatures and the Exotel auth token, and is applied to every callback and
answer route. Token comparison is constant-time and fails CLOSED when the
expected token is unset, so a missing env var denies rather than admits.

Enforcement is on by default via ENFORCE_TELEPHONY_WEBHOOK_SIGNATURES. It exists
to avoid a hard outage during rollout, not as a supported posture.

PT-12 (recording host pinning) is NOT here: its fix is built on the SSRF egress
guard, so it ships in that PR instead of forcing a dependency between the two.

932 tests pass on this branch.



---

### Independent by construction

This PR targets `release` directly. It shares no file with any other pentest PR, and all five were trial-merged pairwise — **10 of 10 pairs merge with no conflict**, so they can land in any order.

The four config blocks that previously forced a chain (`static.py`, `.env.example`) now sit at four distinct anchors hundreds of lines apart, each next to the settings it belongs with, so independent branches auto-merge instead of colliding.

Merging all five reproduces the original #930 tree — `static.py` is identical content in a different order, `.env.example` differs only by one now-meaningless banner comment — and the combined suite runs **992 passed**.

Evidence recording is in the comment below.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added authentication for telephony webhooks from Twilio, Plivo, and Exotel.
  * Added support for deployment-specific webhook URL prefixes.
  * Added secure Exotel callback URLs and safer logging that masks sensitive information.

* **Bug Fixes**
  * Invalid, missing, or tampered webhook credentials are now rejected before callbacks are processed.

* **Tests**
  * Added coverage for provider signatures, token validation, URL reconstruction, and failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->