### PR TITLE
fix(security): close cross-tenant read and write paths across the RBAC layer (PT-02/08/09/13/14/15/20)

### DIFF
--- a/app/ai/voice/agents/breeze_buddy/agent/inbound.py
+++ b/app/ai/voice/agents/breeze_buddy/agent/inbound.py
@@ -5,7 +5,7 @@ from datetime import datetime
 from typing import Any, Dict, Optional, Tuple
 
 from app.core.logger import logger
-from app.database.accessor import get_lead_by_call_id
+from app.database.accessor import get_lead_by_call_id, mask_phone
 from app.database.accessor.breeze_buddy.lead_call_tracker import (
     create_lead_call_tracker,
 )
@@ -141,13 +141,12 @@ async def create_lead_from_template_id(
         )
         return existing_lead, None
 
-    # Load template by ID
-    template = await get_template_by_id(template_id)
-    if not template:
-        logger.error(f"Template not found for template_id: {template_id}")
-        return None, "Template not found"
-
-    # Get from_number from call_data or URL query params (for Plivo)
+    # Resolve the call's own numbers BEFORE anything is looked up by
+    # template_id. The caller gets error_reason back verbatim as the WebSocket
+    # close reason, so a template fetch placed ahead of this check is an
+    # oracle: omit the dialed number and "Template not found" vs "Missing 'to'
+    # number" tells an unauthenticated caller whether a template_id is real
+    # (PT-02). Order is load-bearing here, not stylistic.
     start_data = call_data.get("start", {})
     custom_params = call_data.get("custom_parameters") or start_data.get(
         "custom_parameters", {}
@@ -159,6 +158,49 @@ async def create_lead_from_template_id(
         or custom_params.get("from_number")
         or url_params.get("from_number", "unknown")
     )
+    to_number = (
+        start_data.get("to")
+        or call_data.get("to")
+        or custom_params.get("to_number")
+        or url_params.get("to_number")
+    )
+    if not to_number:
+        logger.error(
+            f"Could not determine dialed 'to' number for template_id "
+            f"{template_id}; refusing to build flow"
+        )
+        return None, "Missing 'to' number"
+
+    # SECURITY: the template_id here is attacker-influenceable on the
+    # unauthenticated media WebSocket (Plivo reads it straight from the URL
+    # query params). Scope it to the number that was actually dialed — a call
+    # may only build the template registered to its own inbound number, never
+    # an arbitrary UUID (PT-02).
+    #
+    # "No such template" and "someone else's template" deliberately return the
+    # SAME reason. They are the same answer to the only question the caller is
+    # entitled to ask, and splitting them would rebuild the enumeration oracle
+    # one level down: a distinct "not found" would confirm which UUIDs exist.
+    # The distinction is kept in the logs, where it is useful and not reachable
+    # by the caller.
+    template = await get_template_by_id(template_id)
+    telephony_number = await get_telephony_number_by_number(to_number)
+    if (
+        not template
+        or not telephony_number
+        or template.telephony_number_id != str(telephony_number.id)
+    ):
+        # Mask the dialed number: phone numbers are PII, and this line fires on
+        # every probe attempt, so it is exactly the log an attacker's traffic
+        # fills up. The last 4 digits are enough to correlate with a call record.
+        if not template:
+            logger.error(f"Template not found for template_id: {template_id}")
+        else:
+            logger.error(
+                f"Template {template_id} is not associated with dialed number "
+                f"{mask_phone(to_number)}; refusing to build flow"
+            )
+        return None, "Template not authorized for this number"
 
     # Create lead with the selected template
     lead_id = str(uuid.uuid4())

--- a/app/api/routers/breeze_buddy/chat/rbac.py
+++ b/app/api/routers/breeze_buddy/chat/rbac.py
@@ -13,6 +13,7 @@ from typing import Optional
 from fastapi import HTTPException, status
 
 from app.core.logger import logger
+from app.core.security.authorization import merchant_scope_permitted
 from app.schemas import UserInfo
 from app.schemas.breeze_buddy.chat import ChatSession
 
@@ -54,19 +55,24 @@ def validate_chat_create_access(
             detail=f"Access denied to reseller {reseller_id}",
         )
 
-    if merchant_id:
-        if (
-            merchant_id not in current_user.merchant_ids
-            and "*" not in current_user.merchant_ids
-        ):
-            logger.warning(
-                f"User {current_user.username} attempted to {operation} "
-                f"for unauthorized merchant: {merchant_id}"
-            )
-            raise HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN,
-                detail=f"Access denied to merchant {merchant_id}",
-            )
+    # Null merchant_id marks a reseller-scoped create: only reseller-role
+    # accounts (or admin, above) may create it — never every merchant sharing the
+    # reseller (PT-15). Mirrors validate_chat_session_access so the create path
+    # can't be looser than the access path (which would otherwise let a merchant
+    # persist a reseller-scoped session it then 404s on).
+    if not merchant_scope_permitted(current_user, merchant_id):
+        logger.warning(
+            f"User {current_user.username} attempted to {operation} "
+            f"for unauthorized merchant: {merchant_id}"
+        )
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=(
+                f"Access denied to merchant {merchant_id}"
+                if merchant_id
+                else "Access denied to reseller-scoped chat session"
+            ),
+        )
 
 
 def validate_chat_session_access(
@@ -103,16 +109,14 @@ def validate_chat_session_access(
             status_code=status.HTTP_404_NOT_FOUND, detail="Chat session not found"
         )
 
-    if session.merchant_id:
-        if (
-            session.merchant_id not in current_user.merchant_ids
-            and "*" not in current_user.merchant_ids
-        ):
-            logger.warning(
-                f"User {current_user.username} attempted to {operation} "
-                f"chat session {session.id} for unauthorized merchant: "
-                f"{session.merchant_id}"
-            )
-            raise HTTPException(
-                status_code=status.HTTP_404_NOT_FOUND, detail="Chat session not found"
-            )
+    # Null merchant_id (reseller-scoped session) is reachable only by
+    # reseller-role accounts or admin, not every merchant in the reseller (PT-15).
+    if not merchant_scope_permitted(current_user, session.merchant_id):
+        logger.warning(
+            f"User {current_user.username} attempted to {operation} "
+            f"chat session {session.id} for unauthorized merchant: "
+            f"{session.merchant_id}"
+        )
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Chat session not found"
+        )

--- a/app/api/routers/breeze_buddy/configurations/rbac.py
+++ b/app/api/routers/breeze_buddy/configurations/rbac.py
@@ -8,6 +8,7 @@ from typing import List, Optional
 from fastapi import HTTPException, status
 
 from app.core.logger import logger
+from app.core.security.authorization import merchant_scope_permitted
 from app.schemas import UserInfo
 
 
@@ -66,19 +67,22 @@ def validate_config_access(
             detail=f"Access denied to reseller {reseller_id}",
         )
 
-    # Check merchant identifier access (only if merchant_id is provided)
-    if (
-        merchant_id
-        and merchant_id not in current_user.merchant_ids
-        and "*" not in current_user.merchant_ids
-    ):
+    # Check merchant identifier access. A null merchant_id marks a
+    # reseller-scoped (reseller-wide) config: only reseller-role accounts (or
+    # admin, handled above) may act on it — a merchant/user role must not fall
+    # through the old `if merchant_id:` skip (PT-14/PT-15).
+    if not merchant_scope_permitted(current_user, merchant_id):
         logger.warning(
             f"User {current_user.username} attempted to {operation} configuration "
             f"for unauthorized merchant: {merchant_id}"
         )
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
-            detail=f"Access denied to merchant {merchant_id}",
+            detail=(
+                f"Access denied to merchant {merchant_id}"
+                if merchant_id
+                else "Access denied to reseller-scoped configuration"
+            ),
         )
 
 
@@ -108,9 +112,13 @@ def filter_configs_by_rbac(configs: List, current_user: UserInfo) -> List:
         has_reseller_access = ("*" in current_user.reseller_ids) or (
             config_reseller_id in current_user.reseller_ids
         )
-        has_merchant_access = ("*" in current_user.merchant_ids) or (
-            config_merchant_id in current_user.merchant_ids
-        )
+        # Same rule the single-object path enforces (validate_config_access), so
+        # a config a caller may GET is a config they can also see in the list.
+        # The inline check this replaces excluded null-merchant configs from the
+        # list for every caller — including the reseller who owns them — because
+        # `None in [...]` is False. It matched the null-merchant rule only by
+        # accident, and would have drifted the moment that rule changed.
+        has_merchant_access = merchant_scope_permitted(current_user, config_merchant_id)
         if has_reseller_access and has_merchant_access:
             filtered.append(config)
 

--- a/app/api/routers/breeze_buddy/leads/rbac.py
+++ b/app/api/routers/breeze_buddy/leads/rbac.py
@@ -8,6 +8,7 @@ from typing import Any, Optional
 from fastapi import HTTPException, status
 
 from app.core.logger import logger
+from app.core.security.authorization import merchant_scope_permitted
 from app.schemas import UserInfo
 
 
@@ -47,20 +48,23 @@ def validate_lead_access(
             detail=f"Access denied to reseller {reseller_id}",
         )
 
-    # Check merchant access (if merchant_id is specified)
-    if merchant_id:
-        if (
-            merchant_id not in current_user.merchant_ids
-            and "*" not in current_user.merchant_ids
-        ):
-            logger.warning(
-                f"User {current_user.username} attempted to {operation} leads "
-                f"for unauthorized merchant: {merchant_id}"
-            )
-            raise HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN,
-                detail=f"Access denied to merchant {merchant_id}",
-            )
+    # Check merchant scope. A null merchant_id marks a reseller-scoped write:
+    # only reseller-role accounts (or admin, above) may create it — never every
+    # merchant sharing the reseller (PT-15). Mirrors validate_lead_read_access so
+    # the write path can't be looser than the read path.
+    if not merchant_scope_permitted(current_user, merchant_id):
+        logger.warning(
+            f"User {current_user.username} attempted to {operation} leads "
+            f"for unauthorized merchant: {merchant_id}"
+        )
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=(
+                f"Access denied to merchant {merchant_id}"
+                if merchant_id
+                else "Access denied to reseller-scoped lead"
+            ),
+        )
 
 
 def validate_lead_read_access(
@@ -94,19 +98,17 @@ def validate_lead_read_access(
             status_code=status.HTTP_404_NOT_FOUND, detail=f"Lead not found"
         )
 
-    # Check shop access
-    if lead.merchant_id:
-        if (
-            lead.merchant_id not in current_user.merchant_ids
-            and "*" not in current_user.merchant_ids
-        ):
-            logger.warning(
-                f"User {current_user.username} attempted to {operation} lead {lead.id} "
-                f"for unauthorized merchant: {lead.merchant_id}"
-            )
-            raise HTTPException(
-                status_code=status.HTTP_404_NOT_FOUND, detail=f"Lead not found"
-            )
+    # Check shop access. A null merchant_id marks a reseller-scoped lead: only
+    # reseller-role accounts (or admin, above) may read it — not every merchant
+    # sharing the reseller (PT-15).
+    if not merchant_scope_permitted(current_user, lead.merchant_id):
+        logger.warning(
+            f"User {current_user.username} attempted to {operation} lead {lead.id} "
+            f"for unauthorized merchant: {lead.merchant_id}"
+        )
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Lead not found"
+        )
 
 
 def validate_recording_access(
@@ -146,17 +148,15 @@ def validate_recording_access(
             detail=f"Recording not found for call_sid: {call_sid}",
         )
 
-    # Check merchant access (if merchant_id is specified)
-    if merchant_id:
-        if (
-            merchant_id not in current_user.merchant_ids
-            and "*" not in current_user.merchant_ids
-        ):
-            logger.warning(
-                f"User {current_user.username} attempted to access recording "
-                f"for unauthorized merchant: {merchant_id} (call_sid: {call_sid})"
-            )
-            raise HTTPException(
-                status_code=status.HTTP_404_NOT_FOUND,
-                detail=f"Recording not found for call_sid: {call_sid}",
-            )
+    # Check merchant access. Null merchant_id (reseller-scoped recording) is
+    # reachable only by reseller-role accounts or admin, never every merchant in
+    # the reseller (PT-15).
+    if not merchant_scope_permitted(current_user, merchant_id):
+        logger.warning(
+            f"User {current_user.username} attempted to access recording "
+            f"for unauthorized merchant: {merchant_id} (call_sid: {call_sid})"
+        )
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Recording not found for call_sid: {call_sid}",
+        )

--- a/app/api/routers/breeze_buddy/numbers/handlers.py
+++ b/app/api/routers/breeze_buddy/numbers/handlers.py
@@ -243,6 +243,11 @@ async def get_number_handler(number_id: str, current_user: UserInfo) -> Telephon
                 detail=f"Telephony number {number_id} not found",
             )
 
+        # Ownership/visibility is enforced by the sole caller via
+        # filter_numbers_by_rbac — the single number-visibility rule, which 404s
+        # out-of-scope ids (PT-13 IDOR) without leaking existence and, unlike a
+        # bare ownership gate, still surfaces numbers a caller's template pins.
+        # This handler is a pure fetch, consistent with list_numbers_handler.
         return number
 
     except HTTPException:

--- a/app/api/routers/breeze_buddy/numbers/rbac.py
+++ b/app/api/routers/breeze_buddy/numbers/rbac.py
@@ -13,6 +13,14 @@ from app.database.accessor.breeze_buddy.merchants import (
 )
 from app.schemas import TelephonyNumber, UserInfo
 
+# NOTE: number visibility has exactly one enforcement point —
+# ``filter_numbers_by_rbac``, applied by the router to both the list and the
+# single-number read. A second coarse gate used to live here
+# (``validate_number_access``); it was removed because it was pin-blind (it
+# denied a merchant the shared-pool number its own template pins) and answered
+# 403 where the router answers 404, leaking existence. Do not reintroduce a
+# parallel check: add to ``number_in_rbac_scope`` instead, so one rule governs.
+
 
 def require_admin_access(
     current_user: UserInfo, operation: str = "perform this operation"

--- a/app/api/routers/breeze_buddy/templates/__init__.py
+++ b/app/api/routers/breeze_buddy/templates/__init__.py
@@ -37,7 +37,7 @@ from .handlers import (
     list_templates_handler,
     replace_template_handler,
 )
-from .rbac import require_admin_or_reseller_owner
+from .rbac import validate_template_access
 
 router = APIRouter()
 
@@ -88,9 +88,15 @@ async def create_template(
             "message": "Template 'order-confirmation' created successfully with 5 nodes"
         }
     """
-    # RBAC: Check permission to create template for this reseller
-    require_admin_or_reseller_owner(
-        current_user, template_data.reseller_id, operation="create templates"
+    # RBAC: enforce BOTH reseller AND merchant scope from the request body.
+    # Authorizing on reseller membership alone let any merchant in the shared
+    # reseller plant a template into another merchant's namespace, or
+    # reseller-wide with a null merchant_id (PT-09).
+    validate_template_access(
+        current_user,
+        template_data.reseller_id,
+        template_data.merchant_id,
+        operation="create template",
     )
 
     return await create_template_handler(template_data, current_user)

--- a/app/api/routers/breeze_buddy/templates/handlers.py
+++ b/app/api/routers/breeze_buddy/templates/handlers.py
@@ -375,12 +375,19 @@ async def replace_template_handler(
             if template_data.reseller_id is not None
             else existing_template.reseller_id
         )
-        if reseller_id != existing_template.reseller_id:
+        # Re-validate on ANY move of the (reseller, merchant) ownership — not
+        # just a reseller change — so a caller cannot reassign a template they
+        # own into a foreign merchant's namespace under the same reseller (PT-09).
+        destination_merchant_id = template_data.merchant_id
+        if (
+            reseller_id != existing_template.reseller_id
+            or destination_merchant_id != existing_template.merchant_id
+        ):
             validate_template_access(
                 current_user,
                 reseller_id,
-                template_data.merchant_id,
-                operation="move template to reseller",
+                destination_merchant_id,
+                operation="move template to reseller/merchant",
             )
 
         # If the (reseller, merchant, name) identity changes, it must not

--- a/app/api/routers/breeze_buddy/templates/rbac.py
+++ b/app/api/routers/breeze_buddy/templates/rbac.py
@@ -8,6 +8,7 @@ from typing import Any, Dict, List, Optional
 from fastapi import HTTPException, status
 
 from app.core.logger import logger
+from app.core.security.authorization import merchant_scope_permitted
 from app.schemas import UserInfo
 
 
@@ -45,20 +46,24 @@ def validate_template_access(
             status_code=status.HTTP_403_FORBIDDEN,
             detail=f"Access denied to reseller {reseller_id}",
         )
-    # Check merchant access (if merchant_id is specified)
-    if merchant_id:
-        if (
-            merchant_id not in current_user.merchant_ids
-            and "*" not in current_user.merchant_ids
-        ):
-            logger.warning(
-                f"User {current_user.username} attempted to {operation} template "
-                f"for unauthorized merchant: {merchant_id}"
-            )
-            raise HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN,
-                detail=f"Access denied to merchant {merchant_id}",
-            )
+    # Check merchant access. A null merchant_id marks a reseller-scoped
+    # template: only reseller-role accounts (or admin, above) may act on it. A
+    # merchant/user role targeting either a foreign merchant_id OR a null
+    # merchant_id is denied — this is the linchpin authz check for template
+    # create/update (PT-09) and reads (PT-15).
+    if not merchant_scope_permitted(current_user, merchant_id):
+        logger.warning(
+            f"User {current_user.username} attempted to {operation} template "
+            f"for unauthorized merchant: {merchant_id}"
+        )
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=(
+                f"Access denied to merchant {merchant_id}"
+                if merchant_id
+                else "Access denied to reseller-scoped template"
+            ),
+        )
 
 
 def filter_templates_by_rbac(templates: List, current_user: UserInfo) -> List:
@@ -88,54 +93,17 @@ def filter_templates_by_rbac(templates: List, current_user: UserInfo) -> List:
             or template.reseller_id in current_user.reseller_ids
         )
 
-        # Check merchant access (templates might not have merchant_id)
-        if template.merchant_id:
-            has_merchant_access = (
-                "*" in current_user.merchant_ids
-                or template.merchant_id in current_user.merchant_ids
-            )
-        else:
-            # Templates without merchant_id are accessible if reseller access granted
-            has_merchant_access = True
+        # Merchant scope: a null merchant_id (reseller-scoped template) is
+        # visible only to reseller-role accounts, not every merchant sharing the
+        # reseller (PT-15).
+        has_merchant_access = merchant_scope_permitted(
+            current_user, template.merchant_id
+        )
 
         if has_reseller_access and has_merchant_access:
             filtered.append(template)
 
     return filtered
-
-
-def require_admin_or_reseller_owner(
-    current_user: UserInfo, reseller_id: str, operation: str = "perform this operation"
-) -> None:
-    """
-    Require user to be admin or reseller owner.
-
-    Used for create/update operations on templates.
-
-    Args:
-        current_user: Current authenticated user
-        reseller_id: Reseller ID being modified
-        operation: Operation being performed (for error message)
-
-    Raises:
-        HTTPException: 403 if user lacks permission
-    """
-    # Admin has full access
-    if current_user.role == "admin":
-        return
-
-    # Reseller owners can manage their own templates
-    if reseller_id in current_user.reseller_ids or "*" in current_user.reseller_ids:
-        return
-
-    logger.warning(
-        f"User {current_user.username} (role: {current_user.role}) "
-        f"attempted to {operation} for unauthorized reseller: {reseller_id}"
-    )
-    raise HTTPException(
-        status_code=status.HTTP_403_FORBIDDEN,
-        detail=f"Access denied to {operation} for reseller {reseller_id}",
-    )
 
 
 def apply_hierarchical_template_filters(

--- a/app/api/routers/breeze_buddy/users/handlers.py
+++ b/app/api/routers/breeze_buddy/users/handlers.py
@@ -17,7 +17,9 @@ from fastapi import HTTPException
 from app.core.logger import logger
 from app.core.security.scope import (
     resolve_merchant_ids,
+    resolve_reseller_ids,
     validate_merchant_ids_subset,
+    validate_reseller_ids_subset,
 )
 from app.database.accessor.breeze_buddy import users as user_accessors
 from app.database.accessor.breeze_buddy.merchants import (
@@ -119,6 +121,14 @@ async def _check_create_access(
             raise HTTPException(
                 status_code=403, detail="Merchants can only create user accounts"
             )
+
+        # Validate reseller_ids are within the merchant's own scope. Previously
+        # skipped entirely — a merchant could plant a foreign reseller_id into a
+        # sub-user and then log in as that user to escalate into the victim
+        # reseller's scope (PT-08). Runs BEFORE the wildcard merchant_ids
+        # early-return so that path cannot bypass the reseller check.
+        allowed_resellers = await resolve_reseller_ids(current_user)
+        validate_reseller_ids_subset(reseller_ids, allowed_resellers)
 
         # Validate merchant_ids are within merchant's scope
         # If merchant has wildcard merchant_ids, they can assign wildcard to users

--- a/app/core/security/authorization.py
+++ b/app/core/security/authorization.py
@@ -8,12 +8,38 @@ Scope resolution (resolve_merchant_ids, resolve_reseller_ids, etc.)
 has been moved to app.core.security.scope.
 """
 
-from typing import List
+from typing import List, Optional
 
 from fastapi import HTTPException, status
 
 from app.core.logger import logger
 from app.schemas import UserInfo, UserRole
+
+
+def merchant_scope_permitted(
+    current_user: UserInfo, merchant_id: Optional[str]
+) -> bool:
+    """
+    Decide whether the caller's merchant scope covers an object with this
+    merchant_id, assuming the caller already passed the reseller-scope check.
+
+    A null/empty merchant_id marks a reseller-scoped row. It must NEVER be
+    treated as "no merchant restriction" for merchant/user-role callers — only a
+    reseller-role account (or admin) may touch reseller-scoped rows.
+    Merchant/user roles must own the specific merchant_id.
+
+    Admin is answered here rather than relied upon at the call site. Every
+    current caller does return early for admin, so this changes no behaviour
+    today; it means a future caller that forgets the guard fails by denying an
+    admin nothing rather than by denying admins reseller-scoped rows.
+    """
+    if current_user.role == UserRole.ADMIN:
+        return True
+    if merchant_id:
+        return (
+            merchant_id in current_user.merchant_ids or "*" in current_user.merchant_ids
+        )
+    return current_user.role == UserRole.RESELLER
 
 
 def check_permission(current_user: UserInfo, required_permission: str) -> bool:

--- a/app/core/security/scope.py
+++ b/app/core/security/scope.py
@@ -59,27 +59,33 @@ async def _resolve_user_scopes(
     if not has_merchant_wildcard:
         return merchant_ids if merchant_ids else []
 
-    # Case: Wildcard merchants → walk up the owner chain to find scope
+    # Case: Wildcard merchants → walk up the owner chain to find scope.
+    # A broken owner chain must FAIL CLOSED (return []) — only a positively
+    # confirmed admin owner may yield unrestricted (None). Returning None here
+    # let a wildcard token whose owner is missing/unresolvable mint platform-wide
+    # merchant access (PT-20).
     if not owner_id:
-        # No owner to narrow scope — treat as unrestricted
-        logger.info(
-            f"User {username} has wildcard merchant_ids with no owner_id — granting unrestricted access"
+        logger.warning(
+            f"User {username} has wildcard merchant_ids with no owner_id — "
+            "denying (failing closed)"
         )
-        return None
+        return []
 
     try:
         owner = await get_user_by_id(owner_id)
     except Exception as e:
-        logger.error(f"Failed to resolve owner {owner_id} for user {username}: {e}")
-        return None  # Can't resolve → grant unrestricted rather than lock out
+        logger.error(
+            f"Failed to resolve owner {owner_id} for user {username}: {e} — "
+            "denying (failing closed)"
+        )
+        return []  # Can't resolve → deny rather than grant unrestricted
 
     if not owner:
-        # Owner not in DB (deleted admin/account) — treat as admin-equivalent
-        logger.info(
+        logger.warning(
             f"User {username} has owner_id {owner_id} but owner not found in DB — "
-            "granting unrestricted merchant access"
+            "denying merchant access (failing closed)"
         )
-        return None
+        return []
 
     # Owner is admin → truly unrestricted
     if owner.role == UserRole.ADMIN:
@@ -153,6 +159,22 @@ async def resolve_merchant_ids(user: UserInfo) -> Optional[List[str]]:
     )
 
 
+def _validate_ids_subset(
+    requested_ids: List[str],
+    allowed_ids: Optional[List[str]],
+    error_message: str,
+) -> None:
+    """Shared subset check behind the merchant_ids / reseller_ids validators."""
+    if allowed_ids is None:
+        return  # Unrestricted access
+
+    if not all(rid in allowed_ids for rid in requested_ids):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=error_message,
+        )
+
+
 def validate_merchant_ids_subset(
     requested_ids: List[str],
     allowed_ids: Optional[List[str]],
@@ -168,14 +190,30 @@ def validate_merchant_ids_subset(
     Raises:
         HTTPException: 403 if requested_ids are not a subset of allowed_ids
     """
-    if allowed_ids is None:
-        return  # Unrestricted access
+    _validate_ids_subset(requested_ids, allowed_ids, error_message)
 
-    if not all(mid in allowed_ids for mid in requested_ids):
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail=error_message,
-        )
+
+def validate_reseller_ids_subset(
+    requested_ids: List[str],
+    allowed_ids: Optional[List[str]],
+    error_message: str = "Cannot assign reseller_ids outside your scope",
+) -> None:
+    """Validate that requested reseller_ids are a subset of allowed IDs.
+
+    Same subset rule as the merchant variant, kept as its own entry point so
+    reseller-scope call sites don't read as merchant-scope ones. The check is
+    identical by nature — that is exactly why calling the merchant validator on
+    reseller data went unnoticed and stayed correct only by accident.
+
+    Args:
+        requested_ids: The reseller_ids being requested
+        allowed_ids: The allowed reseller_ids (None = unrestricted)
+        error_message: Error message for 403 response
+
+    Raises:
+        HTTPException: 403 if requested_ids are not a subset of allowed_ids
+    """
+    _validate_ids_subset(requested_ids, allowed_ids, error_message)
 
 
 async def _resolve_reseller_scopes(
@@ -209,29 +247,31 @@ async def _resolve_reseller_scopes(
     if "*" not in reseller_ids:
         return reseller_ids if reseller_ids else []
 
-    # Wildcard → walk up the owner chain
+    # Wildcard → walk up the owner chain. Fail CLOSED on a broken chain — only a
+    # confirmed admin owner yields unrestricted (None). Returning None on a
+    # missing/unresolvable owner minted platform-wide reseller access (PT-20).
     if not owner_id:
-        # No owner to narrow scope — treat as unrestricted
-        logger.info(
-            f"User {username} has wildcard reseller_ids with no owner_id — granting unrestricted access"
+        logger.warning(
+            f"User {username} has wildcard reseller_ids with no owner_id — "
+            "denying (failing closed)"
         )
-        return None
+        return []
 
     try:
         owner = await get_user_by_id(owner_id)
     except Exception as e:
         logger.error(
-            f"Failed to resolve owner {owner_id} for reseller_ids of user {username}: {e}"
+            f"Failed to resolve owner {owner_id} for reseller_ids of user "
+            f"{username}: {e} — denying (failing closed)"
         )
-        return None  # Can't resolve → grant unrestricted rather than lock out
+        return []  # Can't resolve → deny rather than grant unrestricted
 
     if not owner:
-        # Owner not in DB (deleted admin/account) — treat as admin-equivalent
-        logger.info(
+        logger.warning(
             f"User {username} has owner_id {owner_id} but owner not found in DB — "
-            "granting unrestricted reseller access"
+            "denying reseller access (failing closed)"
         )
-        return None
+        return []
 
     # Owner is admin → truly unrestricted
     if owner.role == UserRole.ADMIN:

--- a/tests/test_pentest_authz.py
+++ b/tests/test_pentest_authz.py
@@ -1,0 +1,401 @@
+"""Cross-tenant authorization: the read AND write paths.
+
+PT-02 (inbound template scope), PT-08 (mass-assignment), PT-09 (template
+merchant scope), PT-13 (numbers IDOR), PT-14/PT-15 (null-merchant skip),
+PT-20 (scope fail-closed).
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Optional, Sequence
+
+import pytest
+from fastapi import HTTPException
+
+from app.core.security import scope
+from app.core.security.authorization import merchant_scope_permitted
+from app.schemas import (
+    CallProvider,
+    TelephonyNumber,
+    TelephonyNumberStatus,
+    UserInfo,
+    UserRole,
+)
+
+
+def _user(
+    role: str,
+    resellers: Sequence[str],
+    merchants: Sequence[str],
+    owner_id: Optional[str] = None,
+) -> UserInfo:
+    return UserInfo(
+        id="u1",
+        username="u1",
+        role=UserRole(role),
+        email=None,
+        reseller_ids=list(resellers),
+        merchant_ids=list(merchants),
+        permissions=[],
+        owner_id=owner_id,
+    )
+
+
+# ── PT-15: null-merchant scope ────────────────────────────────────────────
+def test_merchant_scope_permitted_null_merchant_denies_merchant_role():
+    u = _user("merchant", ["breeze"], ["m1"])
+    assert merchant_scope_permitted(u, None) is False
+
+
+def test_merchant_scope_permitted_null_merchant_allows_reseller_role():
+    u = _user("reseller", ["breeze"], ["*"])
+    assert merchant_scope_permitted(u, None) is True
+
+
+def test_merchant_scope_permitted_specific_merchant_unaffected():
+    u = _user("merchant", ["breeze"], ["m1"])
+    assert merchant_scope_permitted(u, "m1") is True
+    assert merchant_scope_permitted(u, "m2") is False
+
+
+# ── PT-09: template create authorizes on merchant, not just reseller ──────
+def test_validate_template_access_denies_foreign_merchant_same_reseller():
+    from app.api.routers.breeze_buddy.templates.rbac import validate_template_access
+
+    u = _user("merchant", ["breeze"], ["acme"])
+    with pytest.raises(HTTPException) as e:
+        validate_template_access(u, "breeze", "victim-merchant", operation="create")
+    assert e.value.status_code == 403
+
+
+def test_validate_template_access_denies_null_merchant_for_merchant_role():
+    from app.api.routers.breeze_buddy.templates.rbac import validate_template_access
+
+    u = _user("merchant", ["breeze"], ["acme"])
+    with pytest.raises(HTTPException) as e:
+        validate_template_access(u, "breeze", None, operation="create")
+    # Assert the status, not just "some HTTPException": a 404/500 from an
+    # unrelated failure inside the validator would satisfy a bare raises().
+    assert e.value.status_code == 403
+
+
+def test_validate_template_access_allows_own_merchant():
+    from app.api.routers.breeze_buddy.templates.rbac import validate_template_access
+
+    u = _user("merchant", ["breeze"], ["acme"])
+    validate_template_access(u, "breeze", "acme", operation="create")  # no raise
+
+
+# ── PT-14: reseller-wide config toggle requires reseller/admin ────────────
+def test_validate_config_access_denies_reseller_wide_toggle_for_merchant():
+    from app.api.routers.breeze_buddy.configurations.rbac import validate_config_access
+
+    u = _user("merchant", ["breeze"], ["acme"])
+    with pytest.raises(HTTPException) as e:
+        validate_config_access(u, "breeze", None, operation="toggle")
+    assert e.value.status_code == 403
+
+
+def test_validate_config_access_allows_reseller_wide_toggle_for_reseller():
+    from app.api.routers.breeze_buddy.configurations.rbac import validate_config_access
+
+    u = _user("reseller", ["breeze"], ["*"])
+    validate_config_access(u, "breeze", None, operation="toggle")  # no raise
+
+
+# ── PT-13: numbers IDOR ───────────────────────────────────────────────────
+def _num(reseller_id: Optional[str], merchant_id: Optional[str]) -> TelephonyNumber:
+    return TelephonyNumber(
+        id="n",
+        number="+918000000000",
+        provider=CallProvider.PLIVO,
+        status=TelephonyNumberStatus.AVAILABLE,
+        channels=0,
+        maximum_channels=4,
+        reseller_id=reseller_id,
+        merchant_id=merchant_id,
+    )
+
+
+def test_filter_numbers_by_rbac_scopes_to_tenant():
+    from app.api.routers.breeze_buddy.numbers.rbac import filter_numbers_by_rbac
+
+    u = _user("merchant", ["r1"], ["m1"])
+    nums = [_num("r1", "m1"), _num("r1", "other"), _num("r2", None), _num(None, None)]
+    out = filter_numbers_by_rbac(nums, u)
+    assert [n.merchant_id for n in out] == ["m1"]
+
+
+# These assert on filter_numbers_by_rbac — the single control the router
+# actually applies to both /numbers and /numbers/{id}. They previously targeted
+# a second helper that had no callers, so they proved nothing about the
+# endpoints; see the note in numbers/rbac.py.
+def test_numbers_cross_tenant_number_not_visible():
+    from app.api.routers.breeze_buddy.numbers.rbac import filter_numbers_by_rbac
+
+    u = _user("merchant", ["r1"], ["m1"])
+    foreign = _num("r2", "other-merchant")
+    assert filter_numbers_by_rbac([foreign], u) == []
+
+
+def test_numbers_null_reseller_number_visible_only_to_admin():
+    from app.api.routers.breeze_buddy.numbers.rbac import filter_numbers_by_rbac
+
+    orphan = _num(None, None)
+    assert filter_numbers_by_rbac([orphan], _user("merchant", ["r1"], ["m1"])) == []
+    assert filter_numbers_by_rbac([orphan], _user("reseller", ["r1"], ["*"])) == []
+    assert filter_numbers_by_rbac([orphan], _user("admin", [], [])) == [orphan]
+
+
+def test_numbers_reseller_pool_hidden_from_merchant_role():
+    from app.api.routers.breeze_buddy.numbers.rbac import filter_numbers_by_rbac
+
+    # A merchant carries the umbrella reseller_id as workspace membership, but
+    # that must not expose a reseller-pool (null merchant_id) number (PT-14/15).
+    pool = _num("r1", None)
+    assert filter_numbers_by_rbac([pool], _user("merchant", ["r1"], ["m1"])) == []
+
+
+def test_numbers_reseller_pool_visible_to_reseller_role():
+    from app.api.routers.breeze_buddy.numbers.rbac import filter_numbers_by_rbac
+
+    pool = _num("r1", None)
+    assert filter_numbers_by_rbac([pool], _user("reseller", ["r1"], ["*"])) == [pool]
+
+
+def test_numbers_pinned_shared_pool_number_stays_visible_to_merchant():
+    from app.api.routers.breeze_buddy.numbers.rbac import filter_numbers_by_rbac
+
+    # The pin-aware behaviour that the removed coarse gate would have broken:
+    # a merchant must still see a shared-pool number its own template pins.
+    pool = _num("r1", None)
+    u = _user("merchant", ["r1"], ["m1"])
+    assert filter_numbers_by_rbac([pool], u, [pool.id]) == [pool]
+
+
+# ── PT-20: scope resolution fails closed on a broken owner chain ──────────
+async def test_resolve_merchant_ids_fails_closed_when_owner_missing(monkeypatch):
+    async def _none(_id):
+        return None
+
+    monkeypatch.setattr(scope, "get_user_by_id", _none)
+    u = _user("merchant", ["r1"], ["*"], owner_id="deleted-owner")
+    # Broken chain must deny (empty list), never grant wildcard (None).
+    assert await scope.resolve_merchant_ids(u) == []
+
+
+async def test_resolve_reseller_ids_fails_closed_no_owner(monkeypatch):
+    u = _user("merchant", ["*"], ["m1"], owner_id=None)
+    assert await scope.resolve_reseller_ids(u) == []
+
+
+# ── PT-02: inbound template scope fails closed when dialed number is absent ──
+async def test_create_lead_from_template_id_fails_closed_without_to_number(monkeypatch):
+    from datetime import datetime
+
+    from app.ai.voice.agents.breeze_buddy.agent import inbound
+
+    async def _no_existing(_call_sid):
+        return None
+
+    async def _template(_tid):
+        return SimpleNamespace(
+            id="tmpl-1", telephony_number_id="num-1", name="t", reseller_id="r1"
+        )
+
+    called = {"outbound": 0, "template": 0}
+
+    async def _outbound_spy(_number):
+        called["outbound"] += 1
+        return None
+
+    async def _template_spy(tid):
+        called["template"] += 1
+        return await _template(tid)
+
+    monkeypatch.setattr(inbound, "get_lead_by_call_id", _no_existing)
+    monkeypatch.setattr(inbound, "get_template_by_id", _template_spy)
+    monkeypatch.setattr(inbound, "get_telephony_number_by_number", _outbound_spy)
+
+    lead, error = await inbound.create_lead_from_template_id(
+        template_id="any-uuid",
+        call_sid="cs1",
+        call_data={},  # no to/to_number anywhere
+        call_initiated_time=datetime(2020, 1, 1),
+        url_query_params={},
+    )
+    assert lead is None
+    assert error == "Missing 'to' number"
+    # Must fail closed BEFORE any number lookup — never fall through to build.
+    assert called["outbound"] == 0
+    # And before the template lookup. The reason string is handed back as the
+    # WebSocket close reason on an unauthenticated socket, so a template fetch
+    # ahead of this check would let a caller who omits 'to' tell a real
+    # template_id ("Missing 'to' number") from a bogus one ("Template not
+    # found") — an enumeration oracle, which is what PT-02 is about.
+    assert called["template"] == 0
+
+
+async def test_create_lead_from_template_id_hides_whether_template_exists(monkeypatch):
+    """A bogus template_id and a foreign one must be indistinguishable.
+
+    Both reach the caller as the same WebSocket close reason. If "not found"
+    were reported separately, the oracle closed above would simply move one
+    step down: supply a valid dialed number and the error text would confirm
+    which UUIDs exist.
+    """
+    from datetime import datetime
+
+    from app.ai.voice.agents.breeze_buddy.agent import inbound
+
+    async def _no_existing(_call_sid):
+        return None
+
+    async def _number(_n):
+        return SimpleNamespace(id="num-1")
+
+    monkeypatch.setattr(inbound, "get_lead_by_call_id", _no_existing)
+    monkeypatch.setattr(inbound, "get_telephony_number_by_number", _number)
+
+    async def _run() -> Optional[str]:
+        _lead, err = await inbound.create_lead_from_template_id(
+            template_id="some-uuid",
+            call_sid="cs1",
+            call_data={"to": "+918000000000"},
+            call_initiated_time=datetime(2020, 1, 1),
+            url_query_params={},
+        )
+        return err
+
+    # (a) template does not exist at all
+    async def _missing(_tid):
+        return None
+
+    monkeypatch.setattr(inbound, "get_template_by_id", _missing)
+    err_missing = await _run()
+
+    # (b) template exists but belongs to a different inbound number
+    async def _foreign(_tid):
+        return SimpleNamespace(
+            id="tmpl-1",
+            telephony_number_id="someone-elses-number",
+            name="t",
+            reseller_id="r1",
+            merchant_id=None,
+        )
+
+    monkeypatch.setattr(inbound, "get_template_by_id", _foreign)
+    err_foreign = await _run()
+
+    assert err_missing == err_foreign == "Template not authorized for this number"
+
+
+# ── PT-15: WRITE/CREATE paths hardened like their READ siblings ───────────────
+def test_validate_lead_access_write_denies_merchant_role_null_merchant():
+    # The WRITE check (POST /leads) must not be looser than the read check: a
+    # merchant-role caller omitting merchant_id can no longer create a
+    # reseller-scoped lead against a reseller-scoped template.
+    from app.api.routers.breeze_buddy.leads.rbac import validate_lead_access
+
+    u = _user("merchant", ["breeze"], ["acme"])
+    with pytest.raises(HTTPException) as e:
+        validate_lead_access(u, "breeze", None, operation="create")
+    assert e.value.status_code == 403
+
+
+def test_validate_lead_access_write_allows_reseller_role_null_merchant():
+    from app.api.routers.breeze_buddy.leads.rbac import validate_lead_access
+
+    u = _user("reseller", ["breeze"], ["*"])
+    validate_lead_access(u, "breeze", None, operation="create")  # no raise
+
+
+def test_validate_lead_access_write_allows_own_merchant():
+    from app.api.routers.breeze_buddy.leads.rbac import validate_lead_access
+
+    u = _user("merchant", ["breeze"], ["acme"])
+    validate_lead_access(u, "breeze", "acme", operation="create")  # no raise
+
+
+def test_validate_chat_create_access_denies_merchant_role_null_merchant():
+    # The CREATE check (POST /chat/session) mirrors validate_chat_session_access:
+    # a merchant-role caller can no longer persist a reseller-scoped session it
+    # would then 404 on for itself.
+    from app.api.routers.breeze_buddy.chat.rbac import validate_chat_create_access
+
+    u = _user("merchant", ["breeze"], ["acme"])
+    with pytest.raises(HTTPException) as e:
+        validate_chat_create_access(u, "breeze", None, operation="create")
+    assert e.value.status_code == 403
+
+
+def test_validate_chat_create_access_allows_reseller_role_null_merchant():
+    from app.api.routers.breeze_buddy.chat.rbac import validate_chat_create_access
+
+    u = _user("reseller", ["breeze"], ["*"])
+    validate_chat_create_access(u, "breeze", None, operation="create")  # no raise
+
+
+# ── review follow-ups (round 2) ───────────────────────────────────────────
+def test_merchant_scope_permitted_allows_admin_for_any_merchant():
+    # Every current call site returns early for admin, so this is defence in
+    # depth: a future caller that forgets the guard must not lock admins out of
+    # reseller-scoped rows.
+    admin = _user("admin", [], [])
+    assert merchant_scope_permitted(admin, None) is True
+    assert merchant_scope_permitted(admin, "") is True
+    assert merchant_scope_permitted(admin, "some-merchant-they-do-not-list") is True
+
+
+def test_validate_reseller_ids_subset_rejects_out_of_scope():
+    with pytest.raises(HTTPException) as e:
+        scope.validate_reseller_ids_subset(["victim-reseller"], ["own-reseller"])
+    assert e.value.status_code == 403
+    assert "reseller_ids" in e.value.detail
+    # None means unrestricted (admin-owned chain), same contract as the
+    # merchant variant.
+    scope.validate_reseller_ids_subset(["anything"], None)  # no raise
+    scope.validate_reseller_ids_subset(["own-reseller"], ["own-reseller"])  # no raise
+
+
+def _cfg(reseller_id: str, merchant_id: Optional[str]) -> SimpleNamespace:
+    return SimpleNamespace(reseller_id=reseller_id, merchant_id=merchant_id)
+
+
+def test_filter_configs_by_rbac_matches_the_single_object_rule():
+    """List and GET must agree about reseller-scoped (null-merchant) configs.
+
+    The inline check this replaced hid null-merchant configs from the reseller
+    that owns them, while validate_config_access happily returned the same row
+    on a direct GET.
+    """
+    from app.api.routers.breeze_buddy.configurations.rbac import filter_configs_by_rbac
+
+    reseller_wide = _cfg("breeze", None)
+    acme = _cfg("breeze", "acme")
+    foreign = _cfg("breeze", "globex")
+
+    reseller = _user("reseller", ["breeze"], ["acme", "globex"])
+    visible = filter_configs_by_rbac([reseller_wide, acme, foreign], reseller)
+    assert reseller_wide in visible
+
+    merchant = _user("merchant", ["breeze"], ["acme"])
+    visible = filter_configs_by_rbac([reseller_wide, acme, foreign], merchant)
+    assert visible == [acme]  # no reseller-wide row, no foreign merchant
+
+
+def test_reseller_scoped_denials_name_the_scope_not_a_none_merchant():
+    from app.api.routers.breeze_buddy.chat.rbac import validate_chat_create_access
+    from app.api.routers.breeze_buddy.leads.rbac import validate_lead_access
+
+    u = _user("merchant", ["breeze"], ["acme"])
+    with pytest.raises(HTTPException) as e:
+        validate_chat_create_access(u, "breeze", None, operation="create")
+    assert e.value.status_code == 403
+    assert "None" not in e.value.detail and "reseller-scoped" in e.value.detail
+
+    with pytest.raises(HTTPException) as e:
+        validate_lead_access(u, "breeze", None, operation="create")
+    assert e.value.status_code == 403
+    assert "None" not in e.value.detail and "reseller-scoped" in e.value.detail


### PR DESCRIPTION
Independent of the other pentest PRs — targets release, merges in any order.
Touches no file any other pentest PR touches.

A cluster of tenancy holes with one root cause: a null merchant_id was treated
as "no constraint" instead of "reseller-scoped". Verified on release — a
merchant-role user reads a reseller-wide template (merchant_id IS NULL) that is
strictly wider than their own scope.

- PT-09/14/15: template, configuration, lead, chat and numbers RBAC treat a null
  merchant_id as reseller-scoped and deny it to merchant/user roles — on the
  write and create paths as well as the reads, so a write can never be looser
  than the read it mirrors (validate_lead_access, validate_chat_create_access)
- PT-13: /numbers gets real RBAC filtering plus an ownership check
- PT-08: the merchant user-create branch validates reseller_ids against the
  caller's own scope. It previously skipped the check, so a merchant could plant
  a foreign reseller_id into a sub-user and log in as that user to escalate. The
  check runs BEFORE the wildcard merchant_ids early-return, or that path bypasses
  it.
- PT-20: scope resolution fails closed on a broken owner chain rather than
  resolving to an empty, permissive scope
- PT-02: inbound template lookup is scoped to the dialed number, so an
  unauthenticated media WebSocket cannot name an arbitrary template

Tests: 22 cases across the null-merchant rule, the numbers IDOR, the write paths
and fail-closed scope resolution. 953 pass on this branch.



---

### Independent by construction

This PR targets `release` directly. It shares no file with any other pentest PR, and all five were trial-merged pairwise — **10 of 10 pairs merge with no conflict**, so they can land in any order.

The four config blocks that previously forced a chain (`static.py`, `.env.example`) now sit at four distinct anchors hundreds of lines apart, each next to the settings it belongs with, so independent branches auto-merge instead of colliding.

Merging all five reproduces the original #930 tree — `static.py` is identical content in a different order, `.env.example` differs only by one now-meaningless banner comment — and the combined suite runs **992 passed**.

Evidence recording is in the comment below.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened access controls across chats, leads, configurations, templates, users, and phone numbers.
  * Prevented unauthorized access to reseller- and merchant-scoped resources.
  * Improved protection against invalid template assignments and unauthorized inbound lead creation.
  * Ensured unresolved access scopes fail safely instead of granting broad access.
  * Added clearer, scope-specific authorization errors while preserving appropriate response behavior.

* **Tests**
  * Added comprehensive regression coverage for authorization, tenant filtering, scope validation, and administrative access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->