### PR TITLE
fix(security): bound credential guessing and close the username-enumeration oracle (PT-16/18/19)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -151,6 +151,13 @@ ENFORCE_TELEPHONY_WEBHOOK_SIGNATURES=true
 # false in production so the SSRF egress guard blocks internal/metadata targets
 # regardless of ENVIRONMENT.
 SSRF_ALLOW_PRIVATE_EGRESS=false
+# Brute-force caps on the credential endpoints (/login, /auth/s2s/token,
+# /signup, /auth/accounts): fixed-window attempts per client IP and per
+# username/email, per hour. Set either to 0 to disable that dimension.
+# Enforcement fails open on a Redis outage so a Redis blip can't lock everyone
+# out of login (bcrypt cost still bounds throughput).
+AUTH_RATE_LIMIT_PER_IP_PER_HOUR=40
+AUTH_RATE_LIMIT_PER_USERNAME_PER_HOUR=15
 
 # Webhook Authentication
 ORDER_CONFIRMATION_WEBHOOK_SECRET_KEY=""

--- a/app/api/routers/breeze_buddy/auth/__init__.py
+++ b/app/api/routers/breeze_buddy/auth/__init__.py
@@ -13,9 +13,10 @@ Endpoints:
 For backward compatibility, old session-based logout is also supported.
 """
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Request
 from fastapi.responses import RedirectResponse
 
+from app.api.routers.breeze_buddy.auth.rate_limit import enforce_credential_rate_limit
 from app.api.security.breeze_buddy.rbac_token import get_current_user_with_rbac
 from app.schemas import (
     LaunchTokenRequest,
@@ -39,7 +40,7 @@ router = APIRouter()
 
 
 @router.post("/login", include_in_schema=False, response_model=TokenResponse)
-async def login(login_request: LoginRequest):
+async def login(login_request: LoginRequest, http_request: Request):
     """
     Login endpoint with JWT token-based authentication.
 
@@ -63,12 +64,14 @@ async def login(login_request: LoginRequest):
     Security:
         - Database users: bcrypt password hashing
         - Returns 401 if credentials are invalid or account is inactive
+        - Returns 429 if the caller IP or username is over the attempt cap
     """
+    await enforce_credential_rate_limit(http_request, login_request.username)
     return await login_handler(login_request)
 
 
 @router.post("/auth/s2s/token", response_model=S2STokenResponse)
-async def generate_s2s_token(request: S2STokenRequest):
+async def generate_s2s_token(request: S2STokenRequest, http_request: Request):
     """
     Generate long-lived token for Server-to-Server (S2S) authentication.
 
@@ -113,7 +116,9 @@ async def generate_s2s_token(request: S2STokenRequest):
     Security:
         - Returns 401 if credentials are invalid or account is inactive
         - Returns 403 if user is not an admin
+        - Returns 429 if the caller IP or username is over the attempt cap
     """
+    await enforce_credential_rate_limit(http_request, request.username)
     return await generate_s2s_token_handler(request)
 
 

--- a/app/api/routers/breeze_buddy/auth/handlers.py
+++ b/app/api/routers/breeze_buddy/auth/handlers.py
@@ -20,7 +20,7 @@ from app.core.config.static import (
     LOOM_APP_URL,
 )
 from app.core.logger import logger
-from app.core.security.password import verify_password_async
+from app.core.security.password import DUMMY_PASSWORD_HASH, verify_password_async
 from app.core.security.scope import resolve_merchant_ids, resolve_reseller_ids
 from app.database.accessor.breeze_buddy import merchants as merchant_accessors
 from app.database.accessor.breeze_buddy.users import get_user_by_username
@@ -149,7 +149,13 @@ async def login_handler(
             expires_in=expires_in,
         )
 
-    # Authentication failed
+    # Authentication failed: no such user. Still spend one bcrypt against a
+    # dummy hash so an unknown username can't be distinguished from a wrong
+    # password by response timing (username-enumeration oracle, PT-16). Uses the
+    # async wrapper for the same reason the real check does: this branch is the
+    # one an attacker can drive at will, so running bcrypt inline here would
+    # freeze the event loop for ~240ms per guess.
+    await verify_password_async(login_request.password, DUMMY_PASSWORD_HASH)
     logger.warning(f"Failed login attempt for unknown user: {login_request.username}")
     raise HTTPException(
         status_code=status.HTTP_401_UNAUTHORIZED,
@@ -181,6 +187,10 @@ async def generate_s2s_token_handler(request: S2STokenRequest) -> S2STokenRespon
     # Authenticate user
     user = await get_user_by_username(request.username)
     if not user:
+        # Spend one bcrypt against a dummy hash before failing so an unknown
+        # username is timing-indistinguishable from a wrong password — this path
+        # would otherwise reveal whether an admin account exists (PT-16).
+        await verify_password_async(request.password, DUMMY_PASSWORD_HASH)
         logger.warning(f"S2S token request failed: user not found - {request.username}")
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid credentials"

--- a/app/api/routers/breeze_buddy/auth/rate_limit.py
+++ b/app/api/routers/breeze_buddy/auth/rate_limit.py
@@ -1,0 +1,119 @@
+"""Brute-force rate limiting for the unauthenticated credential endpoints.
+
+Applied to ``/login``, ``/auth/s2s/token``, ``/signup`` and ``/auth/accounts``.
+Two independent fixed-window caps run before the password is ever checked:
+
+- **per client IP** (shared across all four endpoints, so an attacker can't
+  dodge the cap by spreading guesses across endpoints), and
+- **per username / email**, so a distributed guess against one account is
+  bounded even from many source IPs.
+
+This is defence-in-depth layered on top of the bcrypt cost and the timing
+equalization (PT-16) — it caps the *number* of online guesses per window; the
+bcrypt cost and the dummy-hash timing path handle per-guess cost and the
+enumeration oracle.
+
+The per-username bucket increments for any identifier string (existing account
+or not), so a ``429`` never reveals whether an account exists — it is not an
+enumeration oracle. The identifier is **SHA-256 hashed** before it becomes a
+Redis key, so an attacker-supplied username of arbitrary length can neither
+inflate key memory nor smuggle bytes into the key space — every key is a fixed
+64-hex-char digest.
+
+**Deployment requirement (per-IP cap).** The client IP is the last-hop
+``X-Forwarded-For`` value (see :func:`client_ip`). That is correct only behind a
+trusted proxy that *overwrites* inbound XFF (Cloud Run / the ingress nginx do);
+if these endpoints were ever exposed without such a proxy, a client could spoof
+``X-Forwarded-For`` to burn a victim's per-IP bucket. The per-username cap is
+unaffected by XFF and keeps a distributed guess bounded regardless.
+
+**Fail-open on Redis trouble.** ``check_rate_limit`` is called with the default
+``fail_closed=False``: if Redis is down or unconfigured the request is allowed.
+Unlike the anonymous, LLM-cost-amplifying widget endpoints (which fail closed),
+locking every operator — including admins trying to fix the incident — out of
+login during a Redis blip is worse than briefly losing this defence-in-depth
+layer; the bcrypt cost still bounds throughput. Flip the caps to tune, or raise
+them in code if a deployment wants a fail-closed posture here.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from typing import Optional
+
+from fastapi import HTTPException, Request, status
+
+from app.api.routers.breeze_buddy.widget_common import client_ip
+from app.core.config.static import (
+    AUTH_RATE_LIMIT_PER_IP_PER_HOUR,
+    AUTH_RATE_LIMIT_PER_USERNAME_PER_HOUR,
+)
+from app.core.logger import logger
+from app.services.redis.rate_limit import check_rate_limit
+
+_WINDOW_SECONDS = 3600
+_PREFIX = "auth"
+
+
+def _too_many(retry_after_seconds: int) -> HTTPException:
+    # Identical response whether the IP or the username cap tripped, and whether
+    # or not the account exists — nothing here distinguishes those cases.
+    return HTTPException(
+        status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+        detail="Too many authentication attempts. Please try again later.",
+        headers={"Retry-After": str(retry_after_seconds)},
+    )
+
+
+async def enforce_credential_rate_limit(
+    request: Request, identifier: Optional[str]
+) -> None:
+    """Raise ``429`` when the caller's IP or the target identifier is over cap.
+
+    Args:
+        request: The inbound request, used to derive the client IP (last-hop
+            ``X-Forwarded-For`` via :func:`client_ip`).
+        identifier: Username or email the request targets. May be ``None``/empty
+            (e.g. an SSO-only account-list call); the per-username cap is then
+            skipped and only the per-IP cap applies.
+    """
+    ip = client_ip(request)
+    ip_decision = await check_rate_limit(
+        bucket="credential_ip",
+        identifier=ip,
+        limit=AUTH_RATE_LIMIT_PER_IP_PER_HOUR,
+        window_seconds=_WINDOW_SECONDS,
+        prefix=_PREFIX,
+    )
+    if not ip_decision.allowed:
+        logger.warning(
+            f"auth rate limit hit (per-IP {ip_decision.count}/{ip_decision.limit}) "
+            f"for {ip!r}"
+        )
+        raise _too_many(ip_decision.retry_after_seconds)
+
+    username = (identifier or "").strip().lower()
+    if not username:
+        return
+
+    # Hash the attacker-supplied identifier so the Redis key is a fixed-length
+    # digest — an arbitrarily long username can't inflate key memory or inject
+    # bytes into the key space. Hashing is deterministic, so the per-username
+    # bucket is still shared across pods.
+    username_key = hashlib.sha256(username.encode("utf-8")).hexdigest()
+
+    user_decision = await check_rate_limit(
+        bucket="credential_user",
+        identifier=username_key,
+        limit=AUTH_RATE_LIMIT_PER_USERNAME_PER_HOUR,
+        window_seconds=_WINDOW_SECONDS,
+        prefix=_PREFIX,
+    )
+    if not user_decision.allowed:
+        # Log a bounded prefix of the raw username (not the hash) for ops
+        # triage without letting a huge identifier bloat the log line.
+        logger.warning(
+            f"auth rate limit hit (per-username "
+            f"{user_decision.count}/{user_decision.limit}) for {username[:64]!r}"
+        )
+        raise _too_many(user_decision.retry_after_seconds)

--- a/app/api/routers/breeze_buddy/chat/demo.py
+++ b/app/api/routers/breeze_buddy/chat/demo.py
@@ -39,6 +39,7 @@ from app.api.routers.breeze_buddy.chat.handlers import (
     serve_session_intent,
     validate_template_for_chat,
 )
+from app.api.routers.breeze_buddy.widget_common import client_ip
 from app.api.security.breeze_buddy.demo_token import (
     DemoSessionContext,
     mint_demo_token,
@@ -77,28 +78,11 @@ router = APIRouter()
 _RATE_WINDOW_SECONDS = 3600
 
 
-def _client_ip(request: Request) -> str:
-    """Best-effort caller IP for rate-limit keying.
-
-    Honours ``X-Forwarded-For`` (first hop) when present so a load
-    balancer / reverse proxy doesn't make every visitor share one
-    bucket. Falls back to ``request.client.host``. Returns ``unknown``
-    if both are missing — treated as one shared bucket, which is the
-    safest default.
-    """
-    forwarded = request.headers.get("x-forwarded-for")
-    if forwarded:
-        return forwarded.split(",")[0].strip() or "unknown"
-    if request.client and request.client.host:
-        return request.client.host
-    return "unknown"
-
-
 async def _enforce_ip_limit(*, request: Request, bucket: str, limit: int) -> None:
     """Raise 429 with ``Retry-After`` if ``request``'s IP is over ``limit``."""
     decision = await check_rate_limit(
         bucket=bucket,
-        identifier=_client_ip(request),
+        identifier=client_ip(request),
         limit=limit,
         window_seconds=_RATE_WINDOW_SECONDS,
         prefix="demo",

--- a/app/api/routers/breeze_buddy/signup/__init__.py
+++ b/app/api/routers/breeze_buddy/signup/__init__.py
@@ -13,8 +13,9 @@ Endpoints:
   POST /auth/switch-account — switch to sibling account (authenticated)
 """
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Request
 
+from app.api.routers.breeze_buddy.auth.rate_limit import enforce_credential_rate_limit
 from app.api.security.breeze_buddy.rbac_token import get_current_user_with_rbac
 from app.schemas import TokenResponse, UserInfo
 from app.schemas.breeze_buddy.signup import (
@@ -46,7 +47,10 @@ router = APIRouter()
     summary="Merchant self-service registration (username/password)",
     tags=["signup"],
 )
-async def signup_with_password(request: MerchantSignupRequest) -> TokenResponse:
+async def signup_with_password(
+    request: MerchantSignupRequest, http_request: Request
+) -> TokenResponse:
+    await enforce_credential_rate_limit(http_request, request.username)
     return await signup_with_password_handler(request)
 
 
@@ -77,9 +81,12 @@ async def google_signup(request: GoogleMerchantSignupRequest) -> TokenResponse:
     summary="List all accounts for an email (account picker)",
     tags=["signup"],
 )
-async def list_accounts(request: ListAccountsRequest) -> AccountsResponse:
+async def list_accounts(
+    request: ListAccountsRequest, http_request: Request
+) -> AccountsResponse:
+    await enforce_credential_rate_limit(http_request, request.email)
     accounts = await list_accounts_handler(
-        id_token=request.id_token, email=request.email
+        id_token=request.id_token, email=request.email, password=request.password
     )
     return AccountsResponse(accounts=accounts)
 

--- a/app/api/routers/breeze_buddy/signup/handlers.py
+++ b/app/api/routers/breeze_buddy/signup/handlers.py
@@ -53,7 +53,7 @@ from app.core.config.static import (
     SELF_SIGNUP_RESELLER_ID,
 )
 from app.core.logger import logger
-from app.core.security.password import verify_password_async
+from app.core.security.password import DUMMY_PASSWORD_HASH, verify_password_async
 from app.core.security.scope import resolve_merchant_ids, resolve_reseller_ids
 from app.database.accessor.breeze_buddy import (
     merchants as merchant_accessors,
@@ -66,6 +66,12 @@ from app.schemas.breeze_buddy.signup import (
     GoogleMerchantSignupRequest,
     MerchantSignupRequest,
 )
+
+# Fixed bcrypt budget for the account-list password check. Every request spends
+# exactly this many verifications regardless of how many accounts share the
+# email, so response time cannot be used to count them (PT-16). Raising it costs
+# latency on every call; lowering it truncates multi-account emails sooner.
+ACCOUNT_PASSWORD_CHECK_BUDGET = 5
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Helpers
@@ -411,17 +417,20 @@ async def google_signup_handler(request: GoogleMerchantSignupRequest) -> TokenRe
 async def list_accounts_handler(
     id_token: str | None,
     email: str | None,
+    password: str | None = None,
 ) -> list:
     """
-    Return all user accounts that share a given email address.
+    Return the user accounts that share a given email address.
 
-    Called immediately after Google OAuth or password auth succeeds to
-    give the frontend a list of accounts the user can pick from.
+    Called immediately after Google OAuth or password auth to give the
+    frontend a list of accounts the user can pick from.
 
-    For Google flows: pass `id_token` — the backend verifies it and
-    extracts the email.
-    For password flows: pass `email` directly (already verified by the
-    login handler upstream, so no re-auth needed here).
+    For Google flows: pass `id_token` — the backend verifies it.
+    For password flows: pass `email` AND `password`. The password is
+    verified here so this endpoint cannot be used anonymously to enumerate
+    accounts / PII by email (PT-16). Only accounts whose password matches
+    are returned; any failure yields an identical generic 401 so registration
+    status is not disclosed.
     """
     if id_token:
         claims = await _verify_google_id_token(id_token)
@@ -431,15 +440,50 @@ async def list_accounts_handler(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail="Google account does not have an email address.",
             )
-    elif email:
-        resolved_email = email
+        users = await user_accessors.get_users_by_email(resolved_email)
+        matched = [u for u in users if u.is_active]
+    elif email and password:
+        # Fetch unconditionally so an unregistered email takes the same code
+        # path/timing as a registered one with a wrong password (PT-16).
+        #
+        # The bcrypt count must also be CONSTANT, not just non-zero: verifying
+        # once per candidate leaks the *number* of accounts sharing an email
+        # through response time (N accounts => N bcrypts, 0 => 1). We therefore
+        # spend exactly ACCOUNT_PASSWORD_CHECK_BUDGET verifications on every
+        # request, padding with the dummy hash.
+        users = await user_accessors.get_users_by_email(email)
+        candidates = [u for u in users if u.is_active][:ACCOUNT_PASSWORD_CHECK_BUDGET]
+        if len(users) > ACCOUNT_PASSWORD_CHECK_BUDGET:
+            # Pathological (one email, many accounts): the tail is not checked,
+            # which is preferred over reintroducing a variable-time oracle.
+            logger.warning(
+                f"account-list: {len(users)} accounts share an email; only the "
+                f"first {ACCOUNT_PASSWORD_CHECK_BUDGET} are password-checked"
+            )
+        matched = [
+            u
+            for u in candidates
+            # Substitute the dummy hash for any user missing a password hash so
+            # such an account can never match and never triggers an error path
+            # (defensive: password_hash is NOT NULL today, so this is unreached).
+            if await verify_password_async(
+                password, u.password_hash or DUMMY_PASSWORD_HASH
+            )
+            and u.password_hash
+        ]
+        for _ in range(ACCOUNT_PASSWORD_CHECK_BUDGET - len(candidates)):
+            await verify_password_async(password, DUMMY_PASSWORD_HASH)
+        if not matched:
+            logger.warning(f"Failed account-list attempt for email: {email}")
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Invalid email or password.",
+            )
     else:
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-            detail="Either id_token or email must be provided.",
+            detail="Provide either id_token, or email together with password.",
         )
-
-    users = await user_accessors.get_users_by_email(resolved_email)
 
     return [
         AccountSummary(
@@ -451,8 +495,7 @@ async def list_accounts_handler(
             reseller_ids=u.reseller_ids,
             is_active=u.is_active,
         )
-        for u in users
-        if u.is_active
+        for u in matched
     ]
 
 
@@ -496,7 +539,16 @@ async def select_account_handler(
                 detail="Google account does not match the selected account.",
             )
     elif password:
-        # Password: verify against stored hash
+        # Password: verify against stored hash. An SSO-only account may have no
+        # usable hash; bcrypt raises ValueError on an empty hash, which would
+        # surface as a 500. Spend a dummy verification so this branch stays
+        # timing-indistinguishable from a wrong password, then 401.
+        if not target.password_hash:
+            await verify_password_async(password, DUMMY_PASSWORD_HASH)
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Incorrect password.",
+            )
         if not await verify_password_async(password, target.password_hash):
             raise HTTPException(
                 status_code=status.HTTP_401_UNAUTHORIZED,

--- a/app/api/routers/breeze_buddy/widget_common.py
+++ b/app/api/routers/breeze_buddy/widget_common.py
@@ -41,6 +41,13 @@ from app.services.redis.rate_limit import check_rate_limit
 _RATE_WINDOW_SECONDS = 3600
 _RATE_LIMIT_PREFIX = "widget"
 
+# The Origin header is spoofable from a non-browser client and the
+# public_widget_key is public, so per-IP limits alone don't bound a merchant's
+# aggregate spend once an attacker rotates source IPs (PT-18). This multiplier
+# turns each per-IP cap into an additional key-wide (cross-IP) cap so total
+# spend per public_widget_key stays bounded regardless of how many IPs are used.
+_WIDGET_AGGREGATE_MULTIPLIER = 20
+
 
 def client_ip(request: Request) -> str:
     """Best-effort caller IP for rate-limit keying.
@@ -137,6 +144,34 @@ async def _enforce_widget_ip_limit(
     )
 
 
+async def _enforce_widget_aggregate_limit(
+    *, bucket: str, limit: int, widget_config_id: str
+) -> None:
+    """Raise 429 when a single public_widget_key exceeds its cross-IP cap.
+
+    Keyed on ``widget_config_id`` ONLY (no client IP), so rotating source IPs
+    cannot escape it (PT-18). Fail-closed on Redis outage, like the per-IP cap.
+    """
+    decision = await check_rate_limit(
+        bucket=f"{bucket}:agg",
+        identifier=widget_config_id,
+        limit=limit,
+        window_seconds=_RATE_WINDOW_SECONDS,
+        prefix=_RATE_LIMIT_PREFIX,
+        fail_closed=True,
+    )
+    if decision.allowed:
+        return
+    raise HTTPException(
+        status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+        detail=(
+            f"Widget usage limit hit ({decision.count}/{decision.limit} per hour "
+            "for this widget). Try again later."
+        ),
+        headers={"Retry-After": str(decision.retry_after_seconds)},
+    )
+
+
 async def resolve_widget_config_for_request(
     *,
     request: Request,
@@ -205,6 +240,13 @@ async def resolve_widget_config_for_request(
         limit=effective_limit,
         widget_config_id=cfg.id,
     )
+    # Cross-IP aggregate cap so IP rotation can't run up unbounded spend on this
+    # merchant's public_widget_key (PT-18).
+    await _enforce_widget_aggregate_limit(
+        bucket=rate_bucket,
+        limit=effective_limit * _WIDGET_AGGREGATE_MULTIPLIER,
+        widget_config_id=cfg.id,
+    )
     return cfg
 
 
@@ -224,6 +266,12 @@ async def enforce_widget_ip_limit(
         request=request,
         bucket=bucket,
         limit=limit,
+        widget_config_id=widget_config_id,
+    )
+    # Cross-IP aggregate cap on this follow-up action too (PT-18).
+    await _enforce_widget_aggregate_limit(
+        bucket=bucket,
+        limit=limit * _WIDGET_AGGREGATE_MULTIPLIER,
         widget_config_id=widget_config_id,
     )
 

--- a/app/core/config/static.py
+++ b/app/core/config/static.py
@@ -535,6 +535,20 @@ SSRF_ALLOW_PRIVATE_EGRESS = os.environ.get(
     "SSRF_ALLOW_PRIVATE_EGRESS", "false"
 ).lower() in ("1", "true", "yes")
 
+# Brute-force rate limiting for the unauthenticated credential endpoints
+# (/login, /auth/s2s/token, /signup, /auth/accounts). Fixed-window caps per
+# client IP and per username/email, layered on top of bcrypt + the timing
+# equalization (PT-16) so online guessing is bounded. Set a cap to 0 to disable
+# that dimension. Enforcement fails OPEN on a Redis outage (see
+# app/api/routers/breeze_buddy/auth/rate_limit.py) so a Redis blip can't lock
+# every operator out of login.
+AUTH_RATE_LIMIT_PER_IP_PER_HOUR = int(
+    os.environ.get("AUTH_RATE_LIMIT_PER_IP_PER_HOUR", "40")
+)
+AUTH_RATE_LIMIT_PER_USERNAME_PER_HOUR = int(
+    os.environ.get("AUTH_RATE_LIMIT_PER_USERNAME_PER_HOUR", "15")
+)
+
 ENABLE_BREEZE_BUDDY_USER_INTERRUPTION = (
     os.environ.get("ENABLE_BREEZE_BUDDY_USER_INTERRUPTION", "false").lower() == "true"
 )

--- a/tests/test_auth_enumeration.py
+++ b/tests/test_auth_enumeration.py
@@ -1,0 +1,160 @@
+"""PT-16: the credential endpoints must not leak which accounts exist.
+
+Covers the account-listing ownership proof, the constant bcrypt budget
+(so response time can't count accounts sharing an email), and the single
+dummy verification spent on the no-such-user branch of /login and /auth/s2s/token.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException
+
+from app.schemas import (
+    UserInfo,
+    UserRole,
+)
+
+
+def _user(role: str, resellers, merchants, owner_id=None) -> UserInfo:
+    return UserInfo(
+        id="u1",
+        username="u1",
+        role=UserRole(role),
+        email=None,
+        reseller_ids=list(resellers),
+        merchant_ids=list(merchants),
+        permissions=[],
+        owner_id=owner_id,
+    )
+
+
+# ── PT-16: account listing requires proof of ownership ────────────────────
+def test_list_accounts_request_requires_password_with_email():
+    from app.schemas.breeze_buddy.signup import ListAccountsRequest
+
+    with pytest.raises(Exception):
+        ListAccountsRequest(email="victim@company.com")  # no password
+    ListAccountsRequest(email="v@c.com", password="x")  # ok
+    ListAccountsRequest(id_token="tok")  # ok
+
+
+# ── PT-16: account listing spends constant bcrypt work (no timing oracle) ────
+def _count_bcrypts(monkeypatch, users):
+    """Patch the accessor + verifier and return a counter of verify calls."""
+    from app.api.routers.breeze_buddy.signup import handlers
+
+    async def _users(_email):
+        return users
+
+    calls = {"n": 0}
+
+    # The handler awaits the async wrapper (bcrypt is offloaded to a thread so a
+    # guessing flood can't freeze the event loop), so the spy has to be async and
+    # patched over that name — patching the sync one would silently count zero.
+    async def _verify_spy(_pw, _hash):
+        calls["n"] += 1
+        return False
+
+    monkeypatch.setattr(handlers.user_accessors, "get_users_by_email", _users)
+    monkeypatch.setattr(handlers, "verify_password_async", _verify_spy)
+    return handlers, calls
+
+
+async def test_list_accounts_bcrypt_count_is_constant_regardless_of_account_count(
+    monkeypatch,
+):
+    """The bcrypt count must not vary with how many accounts share an email.
+
+    Verifying once per candidate leaks the account *count* through response
+    time. Asserting only "at least one bcrypt for an unknown email" (the
+    earlier version of this test) passed while that leak was live.
+    """
+    from app.api.routers.breeze_buddy.signup.handlers import (
+        ACCOUNT_PASSWORD_CHECK_BUDGET as BUDGET,
+    )
+
+    counts = []
+    for n_users in (0, 1, 3, BUDGET, BUDGET + 4):
+        users = [
+            SimpleNamespace(is_active=True, password_hash="$2b$12$x")
+            for _ in range(n_users)
+        ]
+        handlers, calls = _count_bcrypts(monkeypatch, users)
+        with pytest.raises(HTTPException) as e:
+            await handlers.list_accounts_handler(
+                id_token=None, email="probe@x.com", password="whatever"
+            )
+        assert e.value.status_code == 401
+        counts.append(calls["n"])
+
+    assert counts == [BUDGET] * 5, f"bcrypt count varies with account count: {counts}"
+
+
+async def test_list_accounts_user_without_password_hash_no_500(monkeypatch):
+    from app.api.routers.breeze_buddy.signup import handlers
+
+    async def _one_user(_email):
+        return [SimpleNamespace(is_active=True, password_hash=None)]
+
+    monkeypatch.setattr(handlers.user_accessors, "get_users_by_email", _one_user)
+
+    # Real verify_password runs against the dummy-hash fallback: a None hash must
+    # never crash (500); it just never matches, yielding a generic 401.
+    with pytest.raises(HTTPException) as e:
+        await handlers.list_accounts_handler(
+            id_token=None, email="sso@x.com", password="whatever"
+        )
+    assert e.value.status_code == 401
+
+
+# ── PT-16: /login and /auth/s2s/token spend one bcrypt on an unknown user ─────
+async def test_login_unknown_user_spends_one_bcrypt(monkeypatch):
+    from app.api.routers.breeze_buddy.auth import handlers
+    from app.schemas.breeze_buddy.auth import LoginRequest
+
+    async def _no_user(_username):
+        return None
+
+    calls = {"n": 0}
+
+    async def _verify_spy(_pw, _hash):
+        calls["n"] += 1
+        return False
+
+    monkeypatch.setattr(handlers, "get_user_by_username", _no_user)
+    monkeypatch.setattr(handlers, "verify_password_async", _verify_spy)
+
+    with pytest.raises(HTTPException) as e:
+        await handlers.login_handler(LoginRequest(username="ghost", password="x"))
+    assert e.value.status_code == 401
+    # An unknown username must still cost one bcrypt so it is timing-
+    # indistinguishable from a real account with a wrong password.
+    assert calls["n"] == 1
+
+
+async def test_s2s_unknown_user_spends_one_bcrypt(monkeypatch):
+    from app.api.routers.breeze_buddy.auth import handlers
+    from app.schemas.breeze_buddy.auth import S2STokenRequest
+
+    async def _no_user(_username):
+        return None
+
+    calls = {"n": 0}
+
+    async def _verify_spy(_pw, _hash):
+        calls["n"] += 1
+        return False
+
+    monkeypatch.setattr(handlers, "get_user_by_username", _no_user)
+    monkeypatch.setattr(handlers, "verify_password_async", _verify_spy)
+
+    with pytest.raises(HTTPException) as e:
+        await handlers.generate_s2s_token_handler(
+            S2STokenRequest(username="ghost", password="x", token_lifetime_days=30)
+        )
+    assert e.value.status_code == 401
+    # The s2s path would otherwise leak whether an admin account exists.
+    assert calls["n"] == 1

--- a/tests/test_auth_rate_limit.py
+++ b/tests/test_auth_rate_limit.py
@@ -1,0 +1,104 @@
+"""Brute-force rate limiting on the credential endpoints (PT-16 hardening).
+
+Covers ``enforce_credential_rate_limit``: per-IP and per-username fixed-window
+caps, short-circuit ordering, the empty-identifier case, and the fail-open
+posture when Redis is unavailable.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from types import SimpleNamespace
+from typing import cast
+
+import pytest
+from fastapi import HTTPException, Request
+
+from app.api.routers.breeze_buddy.auth import rate_limit as rl
+from app.services.redis.rate_limit import RateLimitDecision
+
+
+def _req(xff: str | None = None, host: str = "203.0.113.7") -> Request:
+    headers = {"x-forwarded-for": xff} if xff else {}
+    return cast(
+        Request, SimpleNamespace(headers=headers, client=SimpleNamespace(host=host))
+    )
+
+
+def _decision(allowed: bool) -> RateLimitDecision:
+    return RateLimitDecision(allowed=allowed, count=99, limit=40, retry_after_seconds=1)
+
+
+def _fake_check(deny_buckets: set[str], recorder: list):
+    async def _check(*, bucket, identifier, limit, window_seconds, prefix, **kwargs):
+        recorder.append((bucket, identifier))
+        return _decision(bucket not in deny_buckets)
+
+    return _check
+
+
+async def test_blocks_when_ip_over_cap(monkeypatch):
+    seen: list = []
+    monkeypatch.setattr(rl, "check_rate_limit", _fake_check({"credential_ip"}, seen))
+    with pytest.raises(HTTPException) as e:
+        await rl.enforce_credential_rate_limit(_req(), "alice")
+    assert e.value.status_code == 429
+    assert (e.value.headers or {}).get("Retry-After") == "1"
+    # Must short-circuit on the IP cap — never even touch the username bucket.
+    assert [b for b, _ in seen] == ["credential_ip"]
+
+
+async def test_blocks_when_username_over_cap(monkeypatch):
+    seen: list = []
+    monkeypatch.setattr(rl, "check_rate_limit", _fake_check({"credential_user"}, seen))
+    with pytest.raises(HTTPException) as e:
+        await rl.enforce_credential_rate_limit(_req(), "Alice@Example.com")
+    assert e.value.status_code == 429
+    # Username is normalised (lower/stripped) then SHA-256 hashed before keying.
+    expected = hashlib.sha256(b"alice@example.com").hexdigest()
+    assert seen[1] == ("credential_user", expected)
+
+
+async def test_long_username_is_hashed_to_bounded_key(monkeypatch):
+    # A pathologically long identifier must not become a giant Redis key: it is
+    # hashed to a fixed 64-hex-char digest regardless of input size.
+    seen: list = []
+    monkeypatch.setattr(rl, "check_rate_limit", _fake_check(set(), seen))
+    await rl.enforce_credential_rate_limit(_req(), "x" * 100_000)
+    bucket, identifier = seen[1]
+    assert bucket == "credential_user"
+    assert len(identifier) == 64
+    assert identifier == hashlib.sha256(b"x" * 100_000).hexdigest()
+
+
+async def test_allows_when_under_cap(monkeypatch):
+    seen: list = []
+    monkeypatch.setattr(rl, "check_rate_limit", _fake_check(set(), seen))
+    await rl.enforce_credential_rate_limit(_req(), "bob")  # no raise
+    assert [b for b, _ in seen] == ["credential_ip", "credential_user"]
+
+
+async def test_empty_identifier_skips_username_bucket(monkeypatch):
+    seen: list = []
+    monkeypatch.setattr(rl, "check_rate_limit", _fake_check(set(), seen))
+    await rl.enforce_credential_rate_limit(_req(), None)  # SSO-only, no email
+    assert [b for b, _ in seen] == ["credential_ip"]
+
+
+async def test_ip_key_uses_last_forwarded_hop(monkeypatch):
+    # A client-supplied XFF chain must not let the caller escape their bucket:
+    # only the last (trusted-proxy-written) hop is used as the identifier.
+    seen: list = []
+    monkeypatch.setattr(rl, "check_rate_limit", _fake_check(set(), seen))
+    await rl.enforce_credential_rate_limit(_req(xff="1.1.1.1, 2.2.2.2, 9.9.9.9"), "bob")
+    assert seen[0] == ("credential_ip", "9.9.9.9")
+
+
+async def test_fails_open_when_redis_unconfigured(monkeypatch):
+    # The real check_rate_limit returns allowed=True when Redis isn't configured,
+    # so enforcement (which uses the default fail_closed=False) must allow the
+    # request — availability of login beats this defence-in-depth layer.
+    from app.services.redis import rate_limit as svc
+
+    monkeypatch.setattr(svc, "is_redis_configured", lambda: False)
+    await rl.enforce_credential_rate_limit(_req(), "carol")  # no raise


### PR DESCRIPTION
Part **6 of 7** splitting #930 (BB-DEEPDIVE-2026-001 backend remediation) into reviewable pieces.

**Base:** `fix/pt-password-policy` — this is a stacked chain, merge in order 1→7.

6 of 7 splitting the BB-DEEPDIVE-2026-001 remediation (was #930).

The credential endpoints could be guessed without limit, and they told an
attacker which accounts existed in two different ways.

- PT-16 enumeration: /auth/accounts required no proof of ownership on the
  email branch. It now requires the password.
- PT-16 timing: /login and /auth/s2s/token returned faster for an unknown
  username than for a wrong password, because the no-such-user branch skipped
  bcrypt. Both now spend one verification against a shared dummy hash. The
  account-listing path spends a constant budget of verifications regardless of
  how many accounts share an email — verifying once per candidate leaks the
  count through response time.
- PT-16 guessing: fixed-window per-IP and per-username caps on /login,
  /auth/s2s/token, /signup and /auth/accounts.
- PT-18: a cross-IP aggregate cap per public_widget_key, so distributing an
  attack across source addresses does not buy unlimited attempts.
- PT-19: the chat-demo client IP is derived from the trusted last XFF hop
  rather than the first, which the client controls.

Rate limiting fails OPEN on a Redis outage. That is deliberate: a Redis blip
locking every operator out of login is a worse outcome than a temporary loss
of the cap, and bcrypt still bounds throughput underneath it.

The dummy verification uses the async wrapper for the same reason the real
check does — this is the branch an attacker drives, so running bcrypt inline
would freeze the event loop for ~240ms per guess.

Tests: tests/test_auth_rate_limit.py and tests/test_auth_enumeration.py
(constant bcrypt budget, one bcrypt on the unknown-user branch of both routes).


---

### Split integrity

#930 was 57 files / +5040/-2776 in one commit. The seven slices reassemble **byte-for-byte** into that tree (verified with `git diff` over `app/`, `.env.example`, `pyproject.toml`, `uv.lock`), and every one of the original 36 pentest tests is routed into exactly one slice — asserted by the splitter, so a dropped test fails the build rather than quietly reducing coverage.

Each slice was verified independently on its own branch:

| slice | commits vs base | black / isort / autoflake | pyrefly | tests |
|---|---|---|---|---|
| 1 ssrf-egress | 1 | OK | 0 errors | 942 passed |
| 2 python-sandbox | 1 | OK | 0 errors | 949 passed |
| 3 telephony-signatures | 1 | OK | 0 errors | 950 passed |
| 4 rbac-tenancy | 1 | OK | 0 errors | 972 passed |
| 5 password-policy | 1 | OK | 0 errors | 976 passed |
| 6 auth-rate-limit | 1 | OK | 0 errors | 988 passed |
| 7 token-revocation | 1 | OK | 0 errors | 992 passed |

The count rises monotonically because each slice adds its own tests and breaks none of the earlier ones.

Attack-side proof for this slice is posted as a comment below.
