### PR TITLE
feat(chat): scope flavor registries per template instead of per process

### DIFF
--- a/app/ai/voice/agents/breeze_buddy/assist/commerce/connectors/__init__.py
+++ b/app/ai/voice/agents/breeze_buddy/assist/commerce/connectors/__init__.py
@@ -3,4 +3,27 @@
 Each connector registers into the UCP layer's hooks (``ucp/hooks.py``) and
 is otherwise invisible: the protocol modules never import a connector, so
 adding a platform is adding a package here, never editing UCP code.
+
+Adding connector #2
+-------------------
+
+Read ``ucp/hooks.py``'s module docstring first — there is one thing that
+must change before a second platform is correct, and it is not obvious
+from this package.
+
+Short version: of the three seams, only ``resolve_media`` filters on the
+template's ``flavor.<protocol>.connectors``. ``normalize_variants`` and
+``repair_description`` do not, so **today Shopify's quirks run for every
+commerce tenant**. With one connector that is harmless (the quirks have
+narrow triggers and a foreign payload never matches). With two it is a
+silent cross-platform bug, so scoping those two chains is part of the
+work of adding a connector, not a follow-up to it.
+
+Registering a connector is a side effect of importing its package; the
+flavor's ``__init__`` does that import. A new connector therefore needs:
+
+1. its package here, registering into the hooks it actually implements;
+2. an import from ``assist/commerce/__init__.py``;
+3. its name documented as a legal ``flavor.<protocol>.connectors`` value;
+4. the variant/description chains scoped (see above).
 """

--- a/app/ai/voice/agents/breeze_buddy/assist/commerce/ucp/hooks.py
+++ b/app/ai/voice/agents/breeze_buddy/assist/commerce/ucp/hooks.py
@@ -20,10 +20,34 @@ Sniffing is right where a wrong guess is free, and wrong where it costs.
 The media seam reaches the network, so a look-alike gateway (any storefront
 whose product URLs are also ``/products/{handle}``) would pay a dead fetch
 per product view — that seam therefore accepts an ``allowed`` connector
-allowlist from the template's ``flavor.<protocol>.connectors``. The variant
-and description seams are pure functions with narrow triggers, run from
-inside Pydantic validators where no template is in scope, so they stay
-sniff-only; give them an allowlist the day one of them grows teeth.
+allowlist from the template's ``flavor.<protocol>.connectors``.
+
+⚠️ **BEFORE YOU ADD A SECOND CONNECTOR — read this.**
+
+Only the media chain honours that allowlist. The variant and description
+chains are name-free (see ``_VARIANT_NORMALIZERS`` /
+``_DESCRIPTION_REPAIRS`` below), so **every registered normalizer and
+repair runs for every commerce tenant**, whatever their template declared.
+
+With one connector that is harmless: today's two quirks have narrow
+triggers (a placeholder variant title, re-flattened description text) and a
+gateway from any other platform simply never matches them. With two it is a
+bug — the second platform's tenants get the first platform's quirks applied
+to their data, silently, with no template opting in.
+
+So connector #2 is the trigger to scope these chains. The reason it wasn't
+done up front is that both run from inside Pydantic validators
+(``schemas.ProductP`` / ``_html_to_display_text``) where no template is in
+scope, so the allowlist cannot simply be passed down as an argument the way
+``resolve_media`` takes it. The intended shape is a ``contextvar`` set once
+per turn from the resolved ``flavor.<protocol>.connectors`` and read here —
+deliberately deferred until there is a real second connector to test it
+against, because a contextvar that leaks or goes unset across async task
+boundaries fails silently in exactly the direction that hurts (quirks
+applied to a tenant that never asked for them).
+
+Until then: keep new quirks narrow-triggered and platform-specific enough
+that a foreign payload cannot match them.
 """
 
 from __future__ import annotations
@@ -49,7 +73,9 @@ VariantNormalizerFn = Callable[[List[Dict[str, Any]]], Optional[List[Dict[str, A
 DescriptionRepairFn = Callable[[str], Optional[str]]
 
 # Media resolvers are (connector_name, fn) so a template can name the ones
-# it wants; the other two chains are name-free because nothing filters them.
+# it wants. The other two chains are name-free — which is exactly what
+# connector #2 has to change; see the warning in the module docstring
+# before adding one.
 _MEDIA_RESOLVERS: List[Tuple[str, MediaResolverFn]] = []
 _VARIANT_NORMALIZERS: List[VariantNormalizerFn] = []
 _DESCRIPTION_REPAIRS: List[DescriptionRepairFn] = []
@@ -63,13 +89,24 @@ def register_media_resolver(connector: str, fn: MediaResolverFn) -> None:
 
 
 def register_variant_normalizer(fn: VariantNormalizerFn) -> None:
-    """Add a variant-list normalizer (idempotent for the same object)."""
+    """Add a variant-list normalizer (idempotent for the same object).
+
+    ⚠️ Takes no connector name, so this normalizer runs for EVERY commerce
+    tenant regardless of their ``flavor.<protocol>.connectors``. Fine while
+    one connector exists; scope this chain when adding a second (module
+    docstring).
+    """
     if all(existing is not fn for existing in _VARIANT_NORMALIZERS):
         _VARIANT_NORMALIZERS.append(fn)
 
 
 def register_description_repair(fn: DescriptionRepairFn) -> None:
-    """Add a description repair (idempotent for the same object)."""
+    """Add a description repair (idempotent for the same object).
+
+    ⚠️ Same caveat as :func:`register_variant_normalizer`: unscoped, so it
+    applies to every commerce tenant until connector #2 forces the chains
+    to carry connector names (module docstring).
+    """
     if all(existing is not fn for existing in _DESCRIPTION_REPAIRS):
         _DESCRIPTION_REPAIRS.append(fn)
 
@@ -106,7 +143,12 @@ async def resolve_media(
 
 def normalize_variants(well_formed: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     """First connector with an opinion wins; otherwise the list is
-    projected as UCP delivered it."""
+    projected as UCP delivered it.
+
+    No allowlist parameter: called from a Pydantic validator with no
+    template in scope. That is the constraint connector #2 has to solve —
+    see the module docstring.
+    """
     for fn in _VARIANT_NORMALIZERS:
         try:
             normalized = fn(well_formed)
@@ -119,7 +161,10 @@ def normalize_variants(well_formed: List[Dict[str, Any]]) -> List[Dict[str, Any]
 
 
 def repair_description(text: str) -> str:
-    """Apply every registered repair in order; each may decline (None)."""
+    """Apply every registered repair in order; each may decline (None).
+
+    Unscoped for the same reason as :func:`normalize_variants`.
+    """
     for fn in _DESCRIPTION_REPAIRS:
         try:
             repaired = fn(text)

--- a/app/ai/voice/agents/breeze_buddy/assist/commerce/ucp/intents.py
+++ b/app/ai/voice/agents/breeze_buddy/assist/commerce/ucp/intents.py
@@ -43,6 +43,14 @@ from pydantic import BaseModel, ConfigDict, Field, model_validator
 from app.ai.voice.agents.breeze_buddy.assist.commerce.ucp.media import (
     resolve_product_media,
 )
+from app.ai.voice.agents.breeze_buddy.assist.commerce.ucp.roles import (
+    DEFAULT_TOOLS,
+    ROLE_CREATE_CART,
+    ROLE_GET_CART,
+    ROLE_GET_PRODUCT,
+    ROLE_SEARCH,
+    ROLE_UPDATE_CART,
+)
 from app.ai.voice.agents.breeze_buddy.assist.commerce.ucp.upsell import run_cart_upsell
 from app.ai.voice.agents.breeze_buddy.chat.intents.router import (
     IntentPolicy,
@@ -71,11 +79,14 @@ from app.core.logger import logger
 # state_keys.checkout_url, labels.checkout).
 # ---------------------------------------------------------------------------
 
-_TOOL_CREATE_CART = "create_cart"
-_TOOL_UPDATE_CART = "update_cart"
-_TOOL_GET_CART = "get_cart"
-_TOOL_GET_PRODUCT = "get_product"
-_TOOL_SEARCH = "search_catalog"
+# The role names and their default tool bindings are declared once in
+# ``roles.py`` — the same table the engine resolves flavor registries
+# through, so the driver and the metadata can never drift apart.
+_TOOL_CREATE_CART = DEFAULT_TOOLS[ROLE_CREATE_CART]
+_TOOL_UPDATE_CART = DEFAULT_TOOLS[ROLE_UPDATE_CART]
+_TOOL_GET_CART = DEFAULT_TOOLS[ROLE_GET_CART]
+_TOOL_GET_PRODUCT = DEFAULT_TOOLS[ROLE_GET_PRODUCT]
+_TOOL_SEARCH = DEFAULT_TOOLS[ROLE_SEARCH]
 _STATE_CART_ID = "cart_id"
 _STATE_CHECKOUT_URL = "checkout_url"
 _CHECKOUT_LABEL = "Review and checkout"

--- a/app/ai/voice/agents/breeze_buddy/assist/commerce/ucp/render_ui.py
+++ b/app/ai/voice/agents/breeze_buddy/assist/commerce/ucp/render_ui.py
@@ -23,6 +23,17 @@ from __future__ import annotations
 
 from typing import Any, Dict, List, Optional
 
+from app.ai.voice.agents.breeze_buddy.assist.commerce.ucp.roles import (
+    ROLE_SEARCH,
+    resolve_role_map,
+)
+from app.ai.voice.agents.breeze_buddy.assist.commerce.ucp.step_labels import (
+    COMMERCE_GROUP,
+)
+from app.ai.voice.agents.breeze_buddy.chat.flavors import (
+    register_flavor_roles,
+    role_key,
+)
 from app.ai.voice.agents.breeze_buddy.chat.ui.binding import (
     BindingStore,
     parse_bind_ref,
@@ -262,7 +273,10 @@ COMMERCE_RENDER_UI_PACK = RenderUiFlavorPack(
     link_description=_LINK_DESC,
     bind_example=_BIND_EXAMPLE,
     link_untrusted_fallback_hint=_LINK_FALLBACK_HINT,
-    default_force_after=["search_catalog"],
+    # A ROLE, not a tool name: the engine binds it through the template
+    # (see roles.py), so the think-step still fires for a merchant whose
+    # gateway calls the search tool something else.
+    default_force_after=[role_key(ROLE_SEARCH)],
     summarize=_summarize_commerce,
     finalize_hydrated=_finalize_commerce,
     merge_repeat_render=_merge_repeat_grid,
@@ -275,8 +289,13 @@ def register_commerce_render_ui_pack() -> None:
 
     Idempotent (same-key overwrite) — safe on re-import.
     """
-    register_render_ui_flavor_pack("commerce", COMMERCE_RENDER_UI_PACK)
-    register_selector_transform("feature_variant", _feature_variant_entry)
+    register_render_ui_flavor_pack(COMMERCE_GROUP, COMMERCE_RENDER_UI_PACK)
+    register_selector_transform(
+        COMMERCE_GROUP, "feature_variant", _feature_variant_entry
+    )
+    # How this flavor's roles bind to tool names on a given template — the
+    # table every other registration above is keyed against.
+    register_flavor_roles(COMMERCE_GROUP, resolve_role_map)
 
 
 __all__ = [

--- a/app/ai/voice/agents/breeze_buddy/assist/commerce/ucp/roles.py
+++ b/app/ai/voice/agents/breeze_buddy/assist/commerce/ucp/roles.py
@@ -1,0 +1,68 @@
+"""UCP tool roles — what this flavor calls its tools, and how a template
+rebinds them.
+
+A ROLE is the flavor's name for a job ("search the catalog"); the TOOL is
+whatever the merchant's gateway actually exposes for it. The UCP defaults
+below are what the pilot templates speak, and
+``configurations.ui_intents.tools`` overrides any of them per template.
+
+Everything the flavor registers into an engine registry — step labels,
+annotations, verifiers, result annotators — is keyed by these role names,
+not by tool names, and the engine resolves them through the binding here
+(see ``chat/flavors.py``). That is what keeps a merchant whose gateway
+calls it ``find_products`` from silently losing the cart verifier, the
+read-only annotation and the step label that ``search_catalog`` gets.
+
+This module deliberately imports nothing from the rest of the flavor: it
+is the one piece both the intent driver and the registration hook need,
+and a dependency in either direction would make the lazy-load order
+matter.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+# Role → default tool name. The keys ARE the registry keys used across the
+# flavor; the values are the Stage-A UCP surface.
+ROLE_SEARCH = "search"
+ROLE_GET_PRODUCT = "get_product"
+ROLE_CREATE_CART = "create_cart"
+ROLE_UPDATE_CART = "update_cart"
+ROLE_GET_CART = "get_cart"
+
+DEFAULT_TOOLS: Dict[str, str] = {
+    ROLE_SEARCH: "search_catalog",
+    ROLE_GET_PRODUCT: "get_product",
+    ROLE_CREATE_CART: "create_cart",
+    ROLE_UPDATE_CART: "update_cart",
+    ROLE_GET_CART: "get_cart",
+}
+
+
+def resolve_role_map(template: Any) -> Dict[str, str]:
+    """``{role: tool_name}`` for ``template`` — the UCP defaults with the
+    template's ``configurations.ui_intents.tools`` overlaid.
+
+    Unknown keys in the template block are ignored: it may carry roles for
+    another flavor sharing the same template.
+    """
+    configurations = getattr(template, "configurations", None)
+    ui_intents = getattr(configurations, "ui_intents", None)
+    overrides = getattr(ui_intents, "tools", None) or {}
+    if not isinstance(overrides, dict):
+        return dict(DEFAULT_TOOLS)
+    return {
+        role: overrides.get(role) or default for role, default in DEFAULT_TOOLS.items()
+    }
+
+
+__all__ = [
+    "DEFAULT_TOOLS",
+    "ROLE_CREATE_CART",
+    "ROLE_GET_CART",
+    "ROLE_GET_PRODUCT",
+    "ROLE_SEARCH",
+    "ROLE_UPDATE_CART",
+    "resolve_role_map",
+]

--- a/app/ai/voice/agents/breeze_buddy/assist/commerce/ucp/schemas.py
+++ b/app/ai/voice/agents/breeze_buddy/assist/commerce/ucp/schemas.py
@@ -502,28 +502,6 @@ class ProductDetail(_CatalogBase):
     product: ProductDetailP
 
 
-class LinkButton(_CatalogBase):
-    """Single link CTA — the link-only answer ("just give me the checkout
-    link") without rendering a whole CartView.
-
-    Literal component (like QuickReplies), but the URL is NOT
-    model-trusted: ``execute_render_ui`` rejects any url that is neither
-    in the template's ``trusted_link_urls`` allowlist nor present
-    verbatim in THIS turn's tool results — the model selects links, it
-    never authors them. Clicking fires the widget's ``open_url`` route
-    (Handoff popup semantics, host-page intercept preserved).
-
-    ``text_channel=False``: the trust check lives ONLY in the render_ui
-    function path, so a hand-typed ``<ui_stream>`` add is rejected at
-    parse (``render_ui_only:LinkButton``) — the dual-read window must not
-    be an arbitrary-URL injection surface."""
-
-    text_channel: ClassVar[bool] = False
-
-    label: str = Field(..., min_length=1, max_length=40)
-    url: str = Field(..., min_length=8, max_length=2048, pattern=r"^https://")
-
-
 # ---------------------------------------------------------------------------
 # Registration — runs once, at (lazy) import time. Templates opt in via
 # ``ui_catalog.enabled_groups += ["commerce"]``; the LLM drives these with
@@ -540,7 +518,6 @@ register_primitives(
         "ProductCard": ProductCard,
         "CartView": CartView,
         "ProductDetail": ProductDetail,
-        "LinkButton": LinkButton,
     },
 )
 
@@ -563,6 +540,17 @@ register_commerce_render_ui_prompt()
 # CartView checkout stamping) — see assist/commerce/render_ui.py.
 register_commerce_render_ui_pack()
 
+# On adding a SECOND flavor: these register_* calls are the whole
+# registration surface, and every one now takes the flavor's group as its
+# first argument, so a second flavor is additive — it registers under its
+# own group and the two never see each other's vocabulary (chat/flavors.py).
+#
+# Collapsing them into one declarative FlavorManifest has been considered
+# and deliberately NOT done: it buys no behaviour, and a manifest that must
+# apply transactionally (half a flavor registered is worse than none) is
+# more machinery than five call sites justify. Revisit only if flavor #3
+# makes the boilerplate a real cost.
+
 
 __all__ = [
     "MoneyP",
@@ -577,5 +565,4 @@ __all__ = [
     "CartView",
     "ProductDetailP",
     "ProductDetail",
-    "LinkButton",
 ]

--- a/app/ai/voice/agents/breeze_buddy/assist/commerce/ucp/step_labels.py
+++ b/app/ai/voice/agents/breeze_buddy/assist/commerce/ucp/step_labels.py
@@ -17,18 +17,32 @@ from __future__ import annotations
 
 from typing import Any, Dict, Optional, Tuple
 
+from app.ai.voice.agents.breeze_buddy.assist.commerce.ucp.roles import (
+    ROLE_CREATE_CART,
+    ROLE_GET_CART,
+    ROLE_GET_PRODUCT,
+    ROLE_SEARCH,
+    ROLE_UPDATE_CART,
+)
+from app.ai.voice.agents.breeze_buddy.chat.flavors import role_key
 from app.ai.voice.agents.breeze_buddy.chat.steps.labels import (
     register_step_labels,
     register_step_summarizer,
 )
 
+COMMERCE_GROUP = "commerce"
+
+# ``role_key(...)`` entries follow the template's binding, so a merchant
+# whose gateway names the search tool something else still gets
+# "Searching the catalog…" instead of the humanizer. ``lookup_catalog`` is
+# NOT a rebindable role, so it is keyed by its literal name.
 COMMERCE_STEP_LABELS: Dict[str, Tuple[str, str]] = {
-    "search_catalog": ("Searching the catalog", "Searched the catalog"),
+    role_key(ROLE_SEARCH): ("Searching the catalog", "Searched the catalog"),
     "lookup_catalog": ("Looking up products", "Looked up products"),
-    "get_product": ("Checking the product", "Checked the product"),
-    "create_cart": ("Updating your cart", "Updated your cart"),
-    "update_cart": ("Updating your cart", "Updated your cart"),
-    "get_cart": ("Checking your cart", "Checked your cart"),
+    role_key(ROLE_GET_PRODUCT): ("Checking the product", "Checked the product"),
+    role_key(ROLE_CREATE_CART): ("Updating your cart", "Updated your cart"),
+    role_key(ROLE_UPDATE_CART): ("Updating your cart", "Updated your cart"),
+    role_key(ROLE_GET_CART): ("Checking your cart", "Checked your cart"),
 }
 
 
@@ -56,11 +70,12 @@ def register_commerce_step_labels() -> None:
     Idempotent (dict update of the same entries; summarizer dedupe) —
     safe on re-import.
     """
-    register_step_labels(COMMERCE_STEP_LABELS)
-    register_step_summarizer(summarize_commerce_step_result)
+    register_step_labels(COMMERCE_GROUP, COMMERCE_STEP_LABELS)
+    register_step_summarizer(COMMERCE_GROUP, summarize_commerce_step_result)
 
 
 __all__ = [
+    "COMMERCE_GROUP",
     "COMMERCE_STEP_LABELS",
     "register_commerce_step_labels",
     "summarize_commerce_step_result",

--- a/app/ai/voice/agents/breeze_buddy/assist/commerce/ucp/tool_meta.py
+++ b/app/ai/voice/agents/breeze_buddy/assist/commerce/ucp/tool_meta.py
@@ -21,6 +21,17 @@ from __future__ import annotations
 
 from typing import Any, Dict, List, Optional
 
+from app.ai.voice.agents.breeze_buddy.assist.commerce.ucp.roles import (
+    ROLE_CREATE_CART,
+    ROLE_GET_CART,
+    ROLE_GET_PRODUCT,
+    ROLE_SEARCH,
+    ROLE_UPDATE_CART,
+)
+from app.ai.voice.agents.breeze_buddy.assist.commerce.ucp.step_labels import (
+    COMMERCE_GROUP,
+)
+from app.ai.voice.agents.breeze_buddy.chat.flavors import role_key
 from app.ai.voice.agents.breeze_buddy.chat.steps.verification import (
     register_tool_verifier,
 )
@@ -106,18 +117,26 @@ def register_commerce_tool_meta() -> None:
     Idempotent — same values / same function objects on re-import.
     """
     register_tool_annotations(
+        COMMERCE_GROUP,
         {
-            "search_catalog": "read_only",
+            role_key(ROLE_SEARCH): "read_only",
+            # Not a rebindable role — keyed by its literal tool name.
             "lookup_catalog": "read_only",
-            "get_product": "read_only",
-            "get_cart": "read_only",
-            "create_cart": "idempotent",
-            "update_cart": "idempotent",
-        }
+            role_key(ROLE_GET_PRODUCT): "read_only",
+            role_key(ROLE_GET_CART): "read_only",
+            role_key(ROLE_CREATE_CART): "idempotent",
+            role_key(ROLE_UPDATE_CART): "idempotent",
+        },
     )
-    register_tool_verifier("search_catalog", _verify_search_catalog)
-    register_tool_verifier("create_cart", _verify_cart_mutation)
-    register_tool_verifier("update_cart", _verify_cart_mutation)
+    register_tool_verifier(
+        COMMERCE_GROUP, role_key(ROLE_SEARCH), _verify_search_catalog
+    )
+    register_tool_verifier(
+        COMMERCE_GROUP, role_key(ROLE_CREATE_CART), _verify_cart_mutation
+    )
+    register_tool_verifier(
+        COMMERCE_GROUP, role_key(ROLE_UPDATE_CART), _verify_cart_mutation
+    )
     # Baseline search annotation (RFC-003 baseline mode): matched_via /
     # matched_variant stamped from THIS turn's live results — lazy import
     # keeps the annotator's regex tables out of non-commerce processes.
@@ -125,7 +144,9 @@ def register_commerce_tool_meta() -> None:
         annotate_search_result,
     )
 
-    register_result_annotator("search_catalog", annotate_search_result)
+    register_result_annotator(
+        COMMERCE_GROUP, role_key(ROLE_SEARCH), annotate_search_result
+    )
 
 
 __all__ = ["register_commerce_tool_meta"]

--- a/app/ai/voice/agents/breeze_buddy/assist/commerce/ucp/upsell.py
+++ b/app/ai/voice/agents/breeze_buddy/assist/commerce/ucp/upsell.py
@@ -316,7 +316,12 @@ async def _run(
                 "items": selectors,
             },
         }
-        resolved = resolve_show_op(show_op, agent.binding_store, agent.ui_allowlist)
+        resolved = resolve_show_op(
+            show_op,
+            agent.binding_store,
+            agent.ui_allowlist,
+            agent.ui_flavor_groups,
+        )
         if resolved.op is None:
             logger.warning(
                 f"cart_upsell: grid resolve dropped ({resolved.error}) — skipping"

--- a/app/ai/voice/agents/breeze_buddy/chat/agent/approval.py
+++ b/app/ai/voice/agents/breeze_buddy/chat/agent/approval.py
@@ -168,7 +168,7 @@ class ApprovalTurnMixin:
             # turn brackets its tool run exactly like _cycle_loop does, so
             # the widget's step list covers HITL resumes too.
             running_label, approved_done_label = resolve_step_label(
-                approval.function_name
+                approval.function_name, self._flavor_scope
             )
             yield step_started_event(
                 step_id=approval.tool_call_id,
@@ -289,7 +289,9 @@ class ApprovalTurnMixin:
             },
         )
         if approved and approved_done_label is not None:
-            step_summary, step_count = summarize_step_result(result_payload)
+            step_summary, step_count = summarize_step_result(
+                result_payload, self._flavor_scope
+            )
             yield step_completed_event(
                 step_id=approval.tool_call_id,
                 status=resolve_step_status(result_payload),

--- a/app/ai/voice/agents/breeze_buddy/chat/agent/core.py
+++ b/app/ai/voice/agents/breeze_buddy/chat/agent/core.py
@@ -23,6 +23,10 @@ from app.ai.voice.agents.breeze_buddy.chat.agent.runtime import (  # noqa: F401
     _tools_schema,
 )
 from app.ai.voice.agents.breeze_buddy.chat.agent.tooling import ToolDispatchMixin
+from app.ai.voice.agents.breeze_buddy.chat.flavors import (
+    FlavorScope,
+    resolve_flavor_scope,
+)
 from app.ai.voice.agents.breeze_buddy.chat.history.block_codec import (
     internal_text_block,
     plain_text_blocks,
@@ -172,6 +176,15 @@ class ChatAgent(
         self._ui_flavor_groups: List[str] = (
             list(ui_cat.enabled_groups or []) if ui_cat is not None else []
         )
+        # The gate every flavor registry is read through: which groups this
+        # template enabled, and which tool it bound each flavor role to
+        # (``ui_intents.tools``). Resolved once — the registries are
+        # process-global and shared with every other merchant in this
+        # worker, so reading them unscoped is what leaks one template's
+        # vocabulary into another's turn.
+        self._flavor_scope: FlavorScope = resolve_flavor_scope(
+            self.template, self._ui_flavor_groups
+        )
         # Catalog-version negotiation (RFC-001 §3.4). Only sessions that
         # declared "v2" at create time may see data-bound components: on a
         # v1 (or unversioned / voice) session they're pruned from the
@@ -223,7 +236,14 @@ class ChatAgent(
         force_after = getattr(render_ui_cfg, "force_after", None)
         if force_after is None:
             _pack = resolve_render_ui_flavor_pack(self._ui_flavor_groups)
-            force_after = _pack.default_force_after if _pack else None
+            # A pack names its own ROLES here, so the think-step still
+            # fires on a template that rebound the role to another tool.
+            # Template-provided force_after stays literal — the author
+            # wrote the tool names they meant.
+            force_after = [
+                self._flavor_scope.tool_for(name)
+                for name in (_pack.default_force_after if _pack else None) or []
+            ]
         self._render_ui_force_after: Set[str] = set(force_after or [])
         # LinkButton URL allowlist (template config) — the other trusted
         # source is THIS turn's tool results, checked at execute time.
@@ -392,3 +412,15 @@ class ChatAgent(
     def ui_allowlist(self) -> Set[str]:
         """The resolved (and catalog-version-pruned) primitive allowlist."""
         return self._ui_allowlist
+
+    @property
+    def ui_flavor_groups(self) -> List[str]:
+        """This template's enabled flavor groups — the scope key every
+        flavor registry is read through (see ``chat/flavors.py``)."""
+        return self._ui_flavor_groups
+
+    @property
+    def flavor_scope(self) -> FlavorScope:
+        """This turn's resolved flavor scope: which registered vocabulary
+        applies, and which tool each flavor role is bound to."""
+        return self._flavor_scope

--- a/app/ai/voice/agents/breeze_buddy/chat/agent/cycle.py
+++ b/app/ai/voice/agents/breeze_buddy/chat/agent/cycle.py
@@ -620,7 +620,9 @@ class CycleLoopMixin:
                 for call in ungated_calls:
                     is_mutation = (
                         call.function_name not in _NEUTRAL_TOOLS
-                        and not is_read_only(call.function_name, self.template)
+                        and not is_read_only(
+                            call.function_name, self.template, self._flavor_scope
+                        )
                     )
                     if is_mutation and mutated_by is not None:
                         deferred = {
@@ -634,7 +636,7 @@ class CycleLoopMixin:
                             ),
                         }
                         running_label, done_label = resolve_step_label(
-                            call.function_name
+                            call.function_name, self._flavor_scope
                         )
                         yield step_started_event(
                             step_id=call.tool_call_id,
@@ -673,7 +675,9 @@ class CycleLoopMixin:
                     # flips the same line in place. Sits ABOVE
                     # function_call_started/completed (the tool-level wire
                     # events), which stay unchanged.
-                    running_label, done_label = resolve_step_label(call.function_name)
+                    running_label, done_label = resolve_step_label(
+                        call.function_name, self._flavor_scope
+                    )
                     yield step_started_event(
                         step_id=call.tool_call_id,
                         label=running_label,
@@ -694,7 +698,9 @@ class CycleLoopMixin:
                             "result_summary": _summarize_result(result_payload),
                         },
                     )
-                    step_summary, step_count = summarize_step_result(result_payload)
+                    step_summary, step_count = summarize_step_result(
+                        result_payload, self._flavor_scope
+                    )
                     yield step_completed_event(
                         step_id=call.tool_call_id,
                         status=resolve_step_status(result_payload),
@@ -995,7 +1001,7 @@ class CycleLoopMixin:
         self._plans_emitted += 1
         steps = []
         for i, tool in enumerate(plan):
-            running_label, _done = resolve_step_label(tool)
+            running_label, _done = resolve_step_label(tool, self._flavor_scope)
             steps.append(
                 {"id": f"plan-{seq}-{i}", "tool": tool, "label": running_label}
             )

--- a/app/ai/voice/agents/breeze_buddy/chat/agent/tooling.py
+++ b/app/ai/voice/agents/breeze_buddy/chat/agent/tooling.py
@@ -267,12 +267,22 @@ class ToolDispatchMixin:
         ):
             normalized = normalize(call.function_name, raw[0])
             return (
-                run_result_annotators(call.function_name, args_for_handler, normalized),
+                run_result_annotators(
+                    call.function_name,
+                    args_for_handler,
+                    normalized,
+                    self._flavor_scope,
+                ),
                 raw[1],
             )
         normalized = normalize(call.function_name, raw)
         return (
-            run_result_annotators(call.function_name, args_for_handler, normalized),
+            run_result_annotators(
+                call.function_name,
+                args_for_handler,
+                normalized,
+                self._flavor_scope,
+            ),
             None,
         )
 
@@ -290,7 +300,9 @@ class ToolDispatchMixin:
         hydrate off an unverified result. Verifiers are pure code checks
         registered by flavor modules (see chat/verification.py).
         """
-        failure = run_tool_verifiers(tool_name, injected_args, result_payload)
+        failure = run_tool_verifiers(
+            tool_name, injected_args, result_payload, self._flavor_scope
+        )
         if failure is None:
             return result_payload
         logger.warning(
@@ -312,7 +324,10 @@ class ToolDispatchMixin:
         tool_execution = getattr(configurations, "tool_execution", None)
         if getattr(tool_execution, "parallel_read_only", None) is False:
             return False
-        return all(is_read_only(c.function_name, self.template) for c in calls)
+        return all(
+            is_read_only(c.function_name, self.template, self._flavor_scope)
+            for c in calls
+        )
 
     async def _fan_out_read_only(
         self: "ChatAgent",
@@ -349,7 +364,9 @@ class ToolDispatchMixin:
                 injections=arg_injection_rules,
                 turn_id=self._turn_id,
             )
-            running_label, done_label = resolve_step_label(call.function_name)
+            running_label, done_label = resolve_step_label(
+                call.function_name, self._flavor_scope
+            )
             done_labels[call.tool_call_id] = done_label
             yield step_started_event(
                 step_id=call.tool_call_id,
@@ -390,7 +407,9 @@ class ToolDispatchMixin:
                             "result_summary": _summarize_result(result_payload),
                         },
                     )
-                    step_summary, step_count = summarize_step_result(result_payload)
+                    step_summary, step_count = summarize_step_result(
+                        result_payload, self._flavor_scope
+                    )
                     yield step_completed_event(
                         step_id=call.tool_call_id,
                         status=resolve_step_status(result_payload),
@@ -411,8 +430,9 @@ class ToolDispatchMixin:
             return None
         store = self._binding_store
         allowlist = self._ui_allowlist
+        flavor_groups = self._ui_flavor_groups
 
         def _resolve(op: Dict[str, Any]):
-            return resolve_show_op(op, store, allowlist)
+            return resolve_show_op(op, store, allowlist, flavor_groups)
 
         return _resolve

--- a/app/ai/voice/agents/breeze_buddy/chat/flavors.py
+++ b/app/ai/voice/agents/breeze_buddy/chat/flavors.py
@@ -1,0 +1,195 @@
+"""Flavor scoping — which registered vocabulary applies to THIS session.
+
+Flavors (commerce today) register their vocabulary into process-global
+registries at lazy import time: step labels, result summarizers, tool
+annotations, verifiers, result annotators, selector transforms. That is
+the right lifecycle — a worker imports a flavor once and every session on
+a template that enables it pays nothing further — but a process-global
+registry read process-globally is a leak: the FIRST commerce template to
+warm a worker changes tool behaviour for every OTHER merchant sharing
+that process, none of whom enabled the flavor.
+
+This module is the gate. Two independent things have to be true before a
+flavor's entry applies to a tool call:
+
+1. **The template enabled the group.** Every flavor registry is keyed by
+   catalog group (``configurations.ui_catalog.enabled_groups``), the same
+   key the render_ui pack and prompt section already use, and every
+   resolver consults only the groups in the caller's :class:`FlavorScope`.
+   A session with no flavor groups sees engine defaults, always.
+
+2. **The entry matches the tool by ROLE, not by name.** A flavor names
+   its tools ("search_catalog"), but a template may bind that role to a
+   different tool via ``configurations.ui_intents.tools`` — and then the
+   flavor's verifier, annotation and step label silently stopped
+   applying, because the registries were keyed on the flavor's default
+   name while dispatch used the template's. Flavors register a role map
+   here; the scope inverts it, so a remapped tool keeps its metadata.
+
+A registry key is therefore EITHER a role or a literal tool name, and the
+two live in separate namespaces: role keys are written :func:`role_key`
+(``"role:search"``), literal keys are the bare tool name. Keeping them
+apart is not cosmetic — a flavor's role name is not always its tool name
+(commerce's ``search`` role binds to ``search_catalog``), so a shared
+namespace would let a merchant's unrelated tool that happens to be called
+``search`` inherit the catalog role's verifier, annotation and label.
+
+The scope is resolved ONCE per turn (the agent holds it) and passed down.
+Nothing here is cached across templates: the role map depends on template
+config, and templates change under a live process.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, Iterator, Mapping, Optional, Sequence, Tuple
+
+from app.core.logger import logger
+
+# ``template -> {role: tool_name}`` for one flavor group. Called once per
+# turn per enabled group, so it must be cheap and side-effect free.
+RoleMapFn = Callable[[Any], Mapping[str, str]]
+
+_ROLE_MAPS: Dict[str, RoleMapFn] = {}
+
+# Namespace marker for role-keyed registry entries. Roles and tool names
+# share a key space otherwise, and they are NOT interchangeable: a role is
+# a job the template binds to a tool, so ``search`` (commerce's catalog
+# role, bound to ``search_catalog``) must never be matched by a merchant's
+# unrelated tool that happens to be named ``search``.
+ROLE_PREFIX = "role:"
+
+
+def role_key(role: str) -> str:
+    """The registry key for ``role``.
+
+    Flavors write ``role_key(ROLE_SEARCH)`` for entries that follow the
+    template's binding and a bare tool name for entries that do not — the
+    distinction is explicit at the registration site precisely because
+    getting it wrong is silent.
+    """
+    return f"{ROLE_PREFIX}{role}"
+
+
+def register_flavor_roles(group: str, fn: RoleMapFn) -> None:
+    """Declare how ``group`` binds its tool ROLES for a given template.
+
+    Called by a flavor package at (lazy) import time, alongside its other
+    registrations. Idempotent — same-key overwrite on re-import.
+
+    A group that registers no role map still works: its registry entries
+    then match tool names literally, which is exactly the behaviour of a
+    flavor whose tools are not template-rebindable.
+    """
+    _ROLE_MAPS[group] = fn
+
+
+@dataclass(frozen=True)
+class FlavorScope:
+    """The flavor vocabulary one session may see.
+
+    ``groups`` is the template's enabled catalog groups, in order —
+    resolution walks them and the first hit wins, mirroring
+    ``resolve_render_ui_flavor_pack``. ``roles`` maps ``(group,
+    tool_name) -> role`` and ``tools`` its inverse; both are derived from
+    the registered role maps under one specific template.
+    """
+
+    groups: Tuple[str, ...] = ()
+    roles: Mapping[Tuple[str, str], str] = field(default_factory=dict)
+    tools: Mapping[Tuple[str, str], str] = field(default_factory=dict)
+
+    def role_for(self, group: str, tool_name: str) -> Optional[str]:
+        """The role ``tool_name`` is bound to in ``group``, if any."""
+        return self.roles.get((group, tool_name))
+
+    def tool_for(self, role_or_name: str) -> str:
+        """Resolve a :func:`role_key` to the tool this template bound it
+        to; a bare tool name passes through untouched.
+
+        Lets a flavor name its own ROLES in config-facing defaults (e.g.
+        the render_ui pack's ``default_force_after``) and still point at
+        whatever tool the template bound them to, without a literal name
+        ever being mistaken for a role.
+        """
+        if not role_or_name.startswith(ROLE_PREFIX):
+            return role_or_name
+        role = role_or_name[len(ROLE_PREFIX) :]
+        for group in self.groups:
+            bound = self.tools.get((group, role))
+            if bound is not None:
+                return bound
+        return role
+
+
+# The scope of a session with no flavor enabled. Also the default for every
+# resolver, so a call site that forgets to pass one degrades to engine
+# behaviour rather than leaking somebody else's vocabulary.
+EMPTY_SCOPE = FlavorScope()
+
+
+def resolve_flavor_scope(template: Any, groups: Optional[Sequence[str]]) -> FlavorScope:
+    """Build the scope for ``template`` over its enabled ``groups``.
+
+    Fail-open per group, in the safe direction: a role map that raises
+    costs that group its role bindings and never the turn. Its
+    role-keyed entries then match NOTHING (only literal-keyed ones still
+    resolve), and anything resolved through :meth:`FlavorScope.tool_for`
+    — the forced render_ui think-step — goes unbound. The flavor loses
+    vocabulary; no other template gains any.
+    """
+    if not groups:
+        return EMPTY_SCOPE
+    roles: Dict[Tuple[str, str], str] = {}
+    tools: Dict[Tuple[str, str], str] = {}
+    for group in groups:
+        role_map_fn = _ROLE_MAPS.get(group)
+        if role_map_fn is None:
+            continue
+        try:
+            mapping = role_map_fn(template)
+        except Exception:  # noqa: BLE001 — a flavor is never load-bearing
+            logger.exception(
+                f"flavors: role map for group {group!r} raised; its entries "
+                "will match tool names literally for this turn"
+            )
+            continue
+        for role, tool_name in (mapping or {}).items():
+            if not isinstance(role, str) or not isinstance(tool_name, str):
+                continue
+            # First role wins a tool name: a template that binds two roles
+            # to one tool gets the earlier role's metadata rather than an
+            # arbitrary one.
+            roles.setdefault((group, tool_name), role)
+            tools[(group, role)] = tool_name
+    return FlavorScope(groups=tuple(groups), roles=roles, tools=tools)
+
+
+def scoped_keys(tool_name: str, scope: FlavorScope) -> Iterator[Tuple[str, str]]:
+    """The ``(group, key)`` candidates for ``tool_name``, in priority order.
+
+    Per enabled group: the ROLE key this template bound the tool to (when
+    it bound one), then the literal tool name. Callers try each against
+    their own group-keyed registry and stop at the first hit.
+
+    The two candidates cannot collide — role keys carry
+    :data:`ROLE_PREFIX` — so a tool only ever picks up a role's metadata
+    by actually being bound to that role.
+    """
+    for group in scope.groups:
+        role = scope.roles.get((group, tool_name))
+        if role is not None:
+            yield group, role_key(role)
+        yield group, tool_name
+
+
+__all__ = [
+    "EMPTY_SCOPE",
+    "ROLE_PREFIX",
+    "FlavorScope",
+    "RoleMapFn",
+    "role_key",
+    "register_flavor_roles",
+    "resolve_flavor_scope",
+    "scoped_keys",
+]

--- a/app/ai/voice/agents/breeze_buddy/chat/intents/router.py
+++ b/app/ai/voice/agents/breeze_buddy/chat/intents/router.py
@@ -665,7 +665,12 @@ async def run_direct_intent(
         ui_events: List[SSEEvent] = []
         if parsed.policy.show_op is not None:
             show_op = parsed.policy.show_op(final_tool, final_result, agent)
-            resolved = resolve_show_op(show_op, agent.binding_store, agent.ui_allowlist)
+            resolved = resolve_show_op(
+                show_op,
+                agent.binding_store,
+                agent.ui_allowlist,
+                agent.ui_flavor_groups,
+            )
             if resolved.op is not None:
                 hydrated_ops.append(resolved.op)
                 ui_events.append(ui_op_event(resolved.op))

--- a/app/ai/voice/agents/breeze_buddy/chat/steps/labels.py
+++ b/app/ai/voice/agents/breeze_buddy/chat/steps/labels.py
@@ -10,16 +10,28 @@ best-effort completion summary.
 Flavors register their labels lazily — mirroring
 ``ui_catalog.register_primitives`` — via :func:`register_step_labels` from
 a module imported on ``ui_catalog.ensure_group_loaded(<flavor>)`` (see
-``assist/commerce/step_labels.py``). Unregistered tools fall back to a
+``assist/commerce/ucp/step_labels.py``). Unregistered tools fall back to a
 generic humanizer so a step line never surfaces a raw ``search_foobar``
 string. NO flavor-specific logic lives here: completion summaries come
 from flavor-registered summarizers (:func:`register_step_summarizer` —
 commerce's reads its ``products`` / ``line_items`` shapes); with none
 registered a step completes with no summary. Everything vertical belongs
 in the flavor registries.
+
+Registration is per catalog GROUP and keyed by tool ROLE (see
+``chat/flavors.py``): a label applies only to sessions whose template
+enabled that group, and follows the tool the template bound the role to.
+Without the group gate the first commerce template to warm a worker would
+relabel every other merchant's steps.
 """
 
 from typing import Any, Callable, List, Mapping, Optional, Tuple
+
+from app.ai.voice.agents.breeze_buddy.chat.flavors import (
+    EMPTY_SCOPE,
+    FlavorScope,
+    scoped_keys,
+)
 
 # Same envelope helper the reducers / intent engine use — one definition of
 # "success" across every result consumer. Private-name import is deliberate
@@ -30,25 +42,31 @@ from app.ai.voice.agents.breeze_buddy.template.session_state import _is_tool_suc
 # Label registry — process-global, additive-only (like ui_catalog's catalog).
 # ---------------------------------------------------------------------------
 
-# tool_name → (running_label, done_label)
-# Engine tools ship first-class labels: render_ui is not a shopper-visible
-# "tool" — from the shopper's side it IS the response being generated, so
-# its step must never read "Rendering the ui" (the humanizer's output).
-_STEP_LABELS: dict[str, Tuple[str, str]] = {
+# Engine tools ship first-class labels, ungrouped because they belong to
+# every session: render_ui is not a shopper-visible "tool" — from the
+# shopper's side it IS the response being generated, so its step must never
+# read "Rendering the ui" (the humanizer's output).
+_ENGINE_STEP_LABELS: dict[str, Tuple[str, str]] = {
     "render_ui": ("Generating response", "Generated response"),
 }
 
+# group → (role or tool_name) → (running_label, done_label)
+_STEP_LABELS: dict[str, dict[str, Tuple[str, str]]] = {}
 
-def register_step_labels(mapping: Mapping[str, Tuple[str, str]]) -> None:
-    """Register ``tool_name → (running_label, done_label)`` entries.
+
+def register_step_labels(group: str, mapping: Mapping[str, Tuple[str, str]]) -> None:
+    """Register ``role → (running_label, done_label)`` entries for ``group``.
 
     Called by a flavor's lazily-imported module (mirrors
-    ``ui_catalog.register_primitives``). Idempotent — re-registration
-    overwrites the same entries; it never removes existing ones, so
-    per-session behaviour stays deterministic regardless of which flavors
-    a process has loaded.
+    ``ui_catalog.register_primitives``). Keys are roles the flavor
+    declared via ``register_flavor_roles``, or literal tool names for
+    tools it does not expose as rebindable roles.
+
+    Idempotent — re-registration overwrites the same entries; it never
+    removes existing ones, so per-session behaviour stays deterministic
+    regardless of which flavors a process has loaded.
     """
-    _STEP_LABELS.update(mapping)
+    _STEP_LABELS.setdefault(group, {}).update(mapping)
 
 
 # A few irregular / doubling verbs common in tool names. Everything else
@@ -104,12 +122,21 @@ def _humanize(tool_name: str) -> Tuple[str, str]:
     return gerund.capitalize(), past.capitalize()
 
 
-def resolve_step_label(tool_name: str) -> Tuple[str, str]:
-    """``(running_label, done_label)`` for a tool — registered entry when a
-    flavor provided one, generic humanizer fallback otherwise."""
-    registered = _STEP_LABELS.get(tool_name)
-    if registered is not None:
-        return registered
+def resolve_step_label(
+    tool_name: str, scope: FlavorScope = EMPTY_SCOPE
+) -> Tuple[str, str]:
+    """``(running_label, done_label)`` for a tool — an entry registered by
+    one of ``scope``'s enabled flavors, generic humanizer otherwise.
+
+    A session with no flavor enabled always gets the humanizer: another
+    template's labels are never in scope, however warm the process is."""
+    engine = _ENGINE_STEP_LABELS.get(tool_name)
+    if engine is not None:
+        return engine
+    for group, key in scoped_keys(tool_name, scope):
+        registered = _STEP_LABELS.get(group, {}).get(key)
+        if registered is not None:
+            return registered
     return _humanize(tool_name)
 
 
@@ -138,33 +165,44 @@ def resolve_step_status(result: Any) -> str:
 # (commerce: a ``products`` list → "N results", ``line_items`` → cart
 # wording); the engine knows none.
 StepSummarizerFn = Callable[[Any], Tuple[Optional[str], Optional[int]]]
-_STEP_SUMMARIZERS: List[StepSummarizerFn] = []
+
+# group → summarizers, tried in registration order within the group.
+_STEP_SUMMARIZERS: dict[str, List[StepSummarizerFn]] = {}
 
 
-def register_step_summarizer(fn: StepSummarizerFn) -> None:
+def register_step_summarizer(group: str, fn: StepSummarizerFn) -> None:
     """Register a flavor's ``result → (summary, count)`` summarizer.
 
     Same lazy lifecycle as :func:`register_step_labels`; re-registering
     the same function is a no-op (idempotent on re-import).
     """
-    if fn not in _STEP_SUMMARIZERS:
-        _STEP_SUMMARIZERS.append(fn)
+    fns = _STEP_SUMMARIZERS.setdefault(group, [])
+    if fn not in fns:
+        fns.append(fn)
 
 
-def summarize_step_result(result: Any) -> Tuple[Optional[str], Optional[int]]:
+def summarize_step_result(
+    result: Any, scope: FlavorScope = EMPTY_SCOPE
+) -> Tuple[Optional[str], Optional[int]]:
     """Best-effort ``(summary, count)`` for a ``step_completed`` event.
 
-    Runs the flavor-registered summarizers in order; the first one that
-    recognizes the result shape wins. Nothing registered (or nothing
-    recognized) yields ``(None, None)`` and the event omits both fields —
-    the engine itself reads no result keys.
+    Runs the summarizers of ``scope``'s enabled flavors in order; the
+    first one that recognizes the result shape wins. Nothing registered
+    (or nothing recognized) yields ``(None, None)`` and the event omits
+    both fields — the engine itself reads no result keys.
+
+    The group gate matters more here than anywhere else in this module: a
+    summarizer matches on result SHAPE, not on tool name, so an ungated
+    one would caption unrelated tools on unrelated templates the moment
+    their payload happened to carry a familiar key.
     """
     if not isinstance(result, dict):
         return None, None
-    for summarizer in _STEP_SUMMARIZERS:
-        summary, count = summarizer(result)
-        if summary is not None or count is not None:
-            return summary, count
+    for group in scope.groups:
+        for summarizer in _STEP_SUMMARIZERS.get(group, ()):
+            summary, count = summarizer(result)
+            if summary is not None or count is not None:
+                return summary, count
     return None, None
 
 

--- a/app/ai/voice/agents/breeze_buddy/chat/steps/verification.py
+++ b/app/ai/voice/agents/breeze_buddy/chat/steps/verification.py
@@ -17,39 +17,61 @@ same lazy-load hook as step labels / annotations) and must be pure and
 fast — no I/O, no model calls. A verifier raising is treated as
 "verification unavailable" (fail-open with a log), never as a tool
 failure: a buggy check must not take down a healthy tool.
+
+Registration is per catalog GROUP and keyed by tool ROLE (see
+``chat/flavors.py``). Both halves of that gate are load-bearing here,
+because this is the one registry that can turn a SUCCESSFUL call into an
+error: ungated, a commerce verifier would reject another merchant's
+differently-shaped result on a template that never enabled commerce; and
+unbound by role, a template that renamed the tool would silently lose the
+check it was relying on.
 """
 
 from __future__ import annotations
 
 from typing import Any, Callable, Dict, List, Optional
 
+from app.ai.voice.agents.breeze_buddy.chat.flavors import (
+    EMPTY_SCOPE,
+    FlavorScope,
+    scoped_keys,
+)
 from app.ai.voice.agents.breeze_buddy.template.session_state import _is_tool_success
 from app.core.logger import logger
 
 # (args, post-pipeline result) → error message, or None when satisfied.
 VerifierFn = Callable[[Dict[str, Any], Any], Optional[str]]
 
-_VERIFIERS: Dict[str, List[VerifierFn]] = {}
+# group → (role or tool_name) → verifiers
+_VERIFIERS: Dict[str, Dict[str, List[VerifierFn]]] = {}
 
 
-def register_tool_verifier(tool_name: str, fn: VerifierFn) -> None:
-    """Attach one post-condition verifier to ``tool_name`` (additive;
-    idempotent for the same function object)."""
-    fns = _VERIFIERS.setdefault(tool_name, [])
+def register_tool_verifier(group: str, role: str, fn: VerifierFn) -> None:
+    """Attach one post-condition verifier to ``role`` within ``group``
+    (additive; idempotent for the same function object)."""
+    fns = _VERIFIERS.setdefault(group, {}).setdefault(role, [])
     if fn not in fns:
         fns.append(fn)
 
 
 def run_tool_verifiers(
-    tool_name: str, args: Dict[str, Any], result: Any
+    tool_name: str,
+    args: Dict[str, Any],
+    result: Any,
+    scope: FlavorScope = EMPTY_SCOPE,
 ) -> Optional[str]:
-    """Run every verifier for ``tool_name``; first failure message wins.
+    """Run the verifiers ``scope`` puts in play for ``tool_name``; first
+    failure message wins.
 
     Already-failed results skip verification entirely — the tool already
     failed (canonical envelope read: status="error" OR "failed"); there is
     nothing to post-condition.
     """
-    fns = _VERIFIERS.get(tool_name)
+    fns: Optional[List[VerifierFn]] = None
+    for group, key in scoped_keys(tool_name, scope):
+        fns = _VERIFIERS.get(group, {}).get(key)
+        if fns:
+            break
     if not fns:
         return None
     if not _is_tool_success(result):

--- a/app/ai/voice/agents/breeze_buddy/chat/tools/annotations.py
+++ b/app/ai/voice/agents/breeze_buddy/chat/tools/annotations.py
@@ -13,48 +13,68 @@ CODE instead of trusting the model:
 
 Resolution order (first hit wins):
   1. The template's ``configurations.tool_execution.annotations`` override.
-  2. The process-global registry (flavor modules register their tool
-     surfaces at lazy-load time, e.g. commerce's UCP tools).
+  2. The registry of a flavor group this template enabled (flavor modules
+     register their tool surfaces at lazy-load time, e.g. commerce's UCP
+     tools), matched by ROLE so a template that rebound the tool keeps its
+     safety class.
   3. ``destructive`` — the safe default: an unknown tool never
      accidentally runs in parallel.
 
 Like the step-label registry, this module is flavor-blind: it holds the
-mechanism; names come from flavor packages and templates.
+mechanism; names come from flavor packages and templates. The group gate
+(see ``chat/flavors.py``) is what stops a commerce annotation reclassifying
+a same-named tool on a template that never enabled commerce — it decides
+parallel fan-out and mutation serialization, so a wrong ``read_only`` runs
+somebody else's mutations concurrently.
 """
 
 from __future__ import annotations
 
 from typing import Any, Dict, Literal
 
+from app.ai.voice.agents.breeze_buddy.chat.flavors import (
+    EMPTY_SCOPE,
+    FlavorScope,
+    scoped_keys,
+)
+
 ToolAnnotation = Literal["read_only", "idempotent", "destructive"]
 
 _VALID: frozenset = frozenset(("read_only", "idempotent", "destructive"))
 
-# Process-global registry — additive-only, populated by flavor modules at
-# (lazy) import time. Per-template overrides never mutate this.
-_ANNOTATIONS: Dict[str, ToolAnnotation] = {}
+# group → (role or tool_name) → annotation. Additive-only, populated by
+# flavor modules at (lazy) import time. Per-template overrides never
+# mutate this.
+_ANNOTATIONS: Dict[str, Dict[str, ToolAnnotation]] = {}
 
 
-def register_tool_annotations(annotations: Dict[str, ToolAnnotation]) -> None:
-    """Register default annotations for a set of tool names (flavor hook).
+def register_tool_annotations(
+    group: str, annotations: Dict[str, ToolAnnotation]
+) -> None:
+    """Register default annotations for a group's tool roles (flavor hook).
 
     Idempotent for identical re-registration; a conflicting re-register
-    raises — two flavors disagreeing about a tool's safety class is a
-    packaging bug, not a runtime preference.
+    within the same group raises — two flavors disagreeing about a tool's
+    safety class is a packaging bug, not a runtime preference. Different
+    groups may of course annotate the same name differently; that is the
+    whole point of scoping them.
     """
+    registered = _ANNOTATIONS.setdefault(group, {})
     for name, annotation in annotations.items():
         if annotation not in _VALID:
             raise ValueError(f"invalid tool annotation {annotation!r} for {name!r}")
-        existing = _ANNOTATIONS.get(name)
+        existing = registered.get(name)
         if existing is not None and existing != annotation:
             raise ValueError(
-                f"tool {name!r} already annotated {existing!r}; refusing "
-                f"{annotation!r}"
+                f"tool {name!r} already annotated {existing!r} in group "
+                f"{group!r}; refusing {annotation!r}"
             )
-        _ANNOTATIONS[name] = annotation
+        registered[name] = annotation
 
 
-def resolve_tool_annotation(tool_name: str, template: Any = None) -> ToolAnnotation:
+def resolve_tool_annotation(
+    tool_name: str, template: Any = None, scope: FlavorScope = EMPTY_SCOPE
+) -> ToolAnnotation:
     """The effective annotation for ``tool_name`` under ``template``."""
     configurations = getattr(template, "configurations", None)
     tool_execution = getattr(configurations, "tool_execution", None)
@@ -65,11 +85,17 @@ def resolve_tool_annotation(tool_name: str, template: Any = None) -> ToolAnnotat
             # pyrefly sees `override` as plain str off the dict; the
             # membership check above IS the narrowing.
             return override  # type: ignore[return-value]
-    return _ANNOTATIONS.get(tool_name, "destructive")
+    for group, key in scoped_keys(tool_name, scope):
+        annotation = _ANNOTATIONS.get(group, {}).get(key)
+        if annotation is not None:
+            return annotation
+    return "destructive"
 
 
-def is_read_only(tool_name: str, template: Any = None) -> bool:
-    return resolve_tool_annotation(tool_name, template) == "read_only"
+def is_read_only(
+    tool_name: str, template: Any = None, scope: FlavorScope = EMPTY_SCOPE
+) -> bool:
+    return resolve_tool_annotation(tool_name, template, scope) == "read_only"
 
 
 __all__ = [

--- a/app/ai/voice/agents/breeze_buddy/chat/tools/result_annotators.py
+++ b/app/ai/voice/agents/breeze_buddy/chat/tools/result_annotators.py
@@ -12,31 +12,51 @@ Contract: annotators are pure and fast (no I/O, no model calls), must only
 ADD keys (never mutate existing values — rendered VALUES stay tool-sourced,
 RFC-001), and fail open: a raising annotator logs and returns the result
 untouched.
+
+Registration is per catalog GROUP and keyed by tool ROLE (see
+``chat/flavors.py``): an annotator runs only for sessions whose template
+enabled its flavor, and follows the tool the template bound the role to.
 """
 
 from __future__ import annotations
 
-from typing import Any, Callable, Dict, List
+from typing import Any, Callable, Dict, List, Optional
 
+from app.ai.voice.agents.breeze_buddy.chat.flavors import (
+    EMPTY_SCOPE,
+    FlavorScope,
+    scoped_keys,
+)
 from app.core.logger import logger
 
 # (args, post-pipeline result) → annotated result (same object or enriched copy).
 AnnotatorFn = Callable[[Dict[str, Any], Any], Any]
 
-_ANNOTATORS: Dict[str, List[AnnotatorFn]] = {}
+# group → (role or tool_name) → annotators
+_ANNOTATORS: Dict[str, Dict[str, List[AnnotatorFn]]] = {}
 
 
-def register_result_annotator(tool_name: str, fn: AnnotatorFn) -> None:
-    """Attach one annotator to ``tool_name`` (additive; idempotent for the
-    same function object)."""
-    fns = _ANNOTATORS.setdefault(tool_name, [])
+def register_result_annotator(group: str, role: str, fn: AnnotatorFn) -> None:
+    """Attach one annotator to ``role`` within ``group`` (additive;
+    idempotent for the same function object)."""
+    fns = _ANNOTATORS.setdefault(group, {}).setdefault(role, [])
     if fn not in fns:
         fns.append(fn)
 
 
-def run_result_annotators(tool_name: str, args: Dict[str, Any], result: Any) -> Any:
-    """Run every annotator for ``tool_name`` in registration order."""
-    fns = _ANNOTATORS.get(tool_name)
+def run_result_annotators(
+    tool_name: str,
+    args: Dict[str, Any],
+    result: Any,
+    scope: FlavorScope = EMPTY_SCOPE,
+) -> Any:
+    """Run the annotators ``scope`` puts in play for ``tool_name``, in
+    registration order."""
+    fns: Optional[List[AnnotatorFn]] = None
+    for group, key in scoped_keys(tool_name, scope):
+        fns = _ANNOTATORS.get(group, {}).get(key)
+        if fns:
+            break
     if not fns:
         return result
     for fn in fns:

--- a/app/ai/voice/agents/breeze_buddy/chat/ui/binding.py
+++ b/app/ai/voice/agents/breeze_buddy/chat/ui/binding.py
@@ -28,6 +28,7 @@ from typing import (
     Dict,
     List,
     Optional,
+    Sequence,
     Set,
     Tuple,
     Union,
@@ -175,26 +176,43 @@ class BindingStore:
 # transform only recombines fields the entry itself carries. Registered by
 # flavor packages at lazy load (same lifecycle as the other flavor
 # registries); the engine knows only the mechanism.
-_SELECTOR_TRANSFORMS: Dict[str, Callable[[Dict[str, Any], str], Dict[str, Any]]] = {}
+SelectorTransformFn = Callable[[Dict[str, Any], str], Dict[str, Any]]
+
+# group → selector key → transform. Group-keyed for the same reason the
+# other flavor registries are (see ``chat/flavors.py``): these keys splice
+# into the LLM-facing ``render_ui`` schema, so an ungated registry would
+# advertise a commerce selector to every merchant sharing the process.
+_SELECTOR_TRANSFORMS: Dict[str, Dict[str, SelectorTransformFn]] = {}
 
 
 def register_selector_transform(
-    key: str, transform: Callable[[Dict[str, Any], str], Dict[str, Any]]
+    group: str, key: str, transform: SelectorTransformFn
 ) -> None:
     """Register a flavor's per-entry selector transform for ``key``.
 
     Idempotent on re-import (same-key overwrite)."""
-    _SELECTOR_TRANSFORMS[key] = transform
+    _SELECTOR_TRANSFORMS.setdefault(group, {})[key] = transform
 
 
-def selector_extension_keys() -> List[str]:
-    """The registered extra selector keys (beyond ``id``) — the render_ui
-    schema and arg parsing accept exactly these."""
-    return list(_SELECTOR_TRANSFORMS)
+def selector_extension_keys(
+    flavor_groups: Optional[Sequence[str]] = None,
+) -> List[str]:
+    """The extra selector keys (beyond ``id``) registered by the enabled
+    flavor groups — the render_ui schema and arg parsing accept exactly
+    these. No groups, no extensions."""
+    keys: List[str] = []
+    for group in flavor_groups or ():
+        for key in _SELECTOR_TRANSFORMS.get(group, {}):
+            if key not in keys:
+                keys.append(key)
+    return keys
 
 
 def _select_list_props(
-    hydrated: Dict[str, Any], schema: Any, bound_keys: Set[str]
+    hydrated: Dict[str, Any],
+    schema: Any,
+    bound_keys: Set[str],
+    flavor_groups: Optional[Sequence[str]] = None,
 ) -> None:
     """Model-directed selection over bound lists (runs BEFORE capping).
 
@@ -227,6 +245,10 @@ def _select_list_props(
             selectors.append(entry)
     if not selectors:
         return
+    transforms: Dict[str, SelectorTransformFn] = {}
+    for group in flavor_groups or ():
+        for sel_key, transform in _SELECTOR_TRANSFORMS.get(group, {}).items():
+            transforms.setdefault(sel_key, transform)
     for key in bound_keys:
         value = hydrated.get(key)
         if not isinstance(value, list):
@@ -240,7 +262,7 @@ def _select_list_props(
             entry = by_id.get(sel["id"])
             if entry is None:
                 continue
-            for sel_key, transform in _SELECTOR_TRANSFORMS.items():
+            for sel_key, transform in transforms.items():
                 sel_value = sel.get(sel_key)
                 if isinstance(sel_value, str) and sel_value:
                     entry = transform(entry, sel_value)
@@ -296,6 +318,7 @@ def resolve_show_op(
     op: Dict[str, Any],
     store: BindingStore,
     allowlist: Optional[Set[str]] = None,
+    flavor_groups: Optional[Sequence[str]] = None,
 ) -> OpResult:
     """Hydrate one parsed ``show`` op against this turn's binding store.
 
@@ -349,7 +372,7 @@ def resolve_show_op(
         hydrated[prop] = value
         bound_keys.add(prop)
 
-    _select_list_props(hydrated, schema, bound_keys)
+    _select_list_props(hydrated, schema, bound_keys, flavor_groups)
     _cap_list_props(hydrated, schema, bound_keys)
 
     try:

--- a/app/ai/voice/agents/breeze_buddy/chat/ui/render_ui_tool.py
+++ b/app/ai/voice/agents/breeze_buddy/chat/ui/render_ui_tool.py
@@ -32,6 +32,9 @@ from typing import Any, Callable, Dict, List, Optional, Set
 
 from pipecat_flows import FlowsFunctionSchema
 
+from app.ai.voice.agents.breeze_buddy.chat.client_context import (
+    strip_client_context_keys,
+)
 from app.ai.voice.agents.breeze_buddy.chat.ui.binding import (
     BindingStore,
     parse_bind_ref,
@@ -267,13 +270,16 @@ def build_render_ui_schema(
                 or _ITEMS_DESC_GENERIC,
                 "items": {
                     "type": "object",
-                    # Extra selector keys come from the flavor-registered
-                    # transforms (commerce: feature_variant) — the schema
-                    # advertises exactly what the selection engine honors.
+                    # Extra selector keys come from the transforms
+                    # registered by THIS session's flavor groups (commerce:
+                    # feature_variant) — the schema advertises exactly what
+                    # the selection engine will honor for this template,
+                    # and nothing another template's flavor registered.
                     "properties": {
                         "id": {"type": "string"},
                         **{
-                            key: {"type": "string"} for key in selector_extension_keys()
+                            key: {"type": "string"}
+                            for key in selector_extension_keys(flavor_groups)
                         },
                     },
                     "required": ["id"],
@@ -351,23 +357,59 @@ def _payload_contains_url(payload: Any, url: str, depth: int = _URL_SCAN_DEPTH) 
     return False
 
 
+def _tool_sourced_state(
+    state_values: Optional[Dict[str, Any]], template: Any
+) -> Dict[str, Any]:
+    """``state_values`` minus everything the STOREFRONT can write.
+
+    The state scan below treats a URL as trusted because
+    ``agent_session_state`` is reducer-built over tool payloads. That is
+    true of most of it, but two parts are shopper-controlled: the
+    ``_client_context`` facts namespace, and any top-level key the
+    template listed in ``client_context.state_allowlist`` (the push
+    validates key NAMES, never values). Left in, a compromised storefront
+    page could write an arbitrary URL into state and have the assistant
+    render it as a trusted CTA — defeating ``trusted_link_urls``.
+
+    ⚠️ Removal is by KEY, and a state key is a single slot: if a template
+    ever allowlists a key that its reducers ALSO write real tool URLs
+    into, the genuine value is dropped along with the untrusted one and
+    the link is refused. No template does that today (none configures
+    ``client_context`` at all). The provenance-tracking fix — reducers
+    writing into a trusted sub-namespace — is the correct answer if that
+    day comes; this is the cheap one that closes the hole.
+    """
+    if not state_values:
+        return {}
+    scannable = strip_client_context_keys(state_values)
+    configurations = getattr(template, "configurations", None)
+    client_context = getattr(configurations, "client_context", None)
+    allowlist = getattr(client_context, "state_allowlist", None) or ()
+    if not allowlist:
+        return scannable
+    return {k: v for k, v in scannable.items() if k not in set(allowlist)}
+
+
 def url_is_trusted(
     url: str,
     store: BindingStore,
     trusted_urls: Optional[Set[str]],
     state_values: Optional[Dict[str, Any]] = None,
+    template: Any = None,
 ) -> bool:
     """LinkButton trust rule: exact match against the template's
     ``trusted_link_urls`` allowlist, verbatim presence in THIS turn's
-    tool results, OR verbatim presence in reducer state — the model
-    selects links, it never authors them. State qualifies because
-    ``agent_session_state`` is written only by the template's reducers
-    over tool payloads (e.g. ``policy_links`` captured from an earlier
-    cart call), so a state-sourced URL has the same tool provenance as a
-    this-turn one."""
+    tool results, OR verbatim presence in the TOOL-SOURCED part of
+    reducer state — the model selects links, it never authors them.
+
+    State qualifies only after :func:`_tool_sourced_state` removes the
+    storefront-writable keys: a reducer-captured URL (e.g. ``policy_links``
+    from an earlier cart call) has real tool provenance, a browser-pushed
+    one has none."""
     if trusted_urls and url in trusted_urls:
         return True
-    if state_values and _payload_contains_url(state_values, url):
+    scannable = _tool_sourced_state(state_values, template)
+    if scannable and _payload_contains_url(scannable, url):
         return True
     return any(_payload_contains_url(payload, url) for payload in store.payloads())
 
@@ -488,7 +530,7 @@ def execute_render_ui(
     items = args.get("items")
     if isinstance(items, list) and items:
         selectors: List[Dict[str, Any]] = []
-        extension_keys = selector_extension_keys()
+        extension_keys = selector_extension_keys(flavor_groups)
         for entry in items:
             if isinstance(entry, str) and entry:
                 selectors.append({"id": entry})
@@ -540,7 +582,7 @@ def execute_render_ui(
                 component=component,
             )
         url = link["url"]
-        if not url_is_trusted(url, store, trusted_urls, state_values):
+        if not url_is_trusted(url, store, trusted_urls, state_values, template):
             pack = _resolve_pack(flavor_groups)
             hint = (
                 "use one of: " + ", ".join(sorted(trusted_urls))
@@ -610,7 +652,7 @@ def execute_render_ui(
         }
         if parent:
             op["parent"] = parent
-        result = resolve_show_op(op, store, allowlist)
+        result = resolve_show_op(op, store, allowlist, flavor_groups)
         if result.op is None:
             return RenderUiOutcome(
                 fn_result={

--- a/app/ai/voice/agents/breeze_buddy/template/field_reference.json
+++ b/app/ai/voice/agents/breeze_buddy/template/field_reference.json
@@ -527,7 +527,7 @@
   },
   "UiIntentsConfig": {
     "tools": {
-      "description": "Flavor tool role -> actual tool name on this template's MCP/function surface (commerce roles: create_cart, update_cart, get_cart, get_product, search).",
+      "description": "Flavor tool role -> actual tool name on this template's MCP/function surface (commerce roles: create_cart, update_cart, get_cart, get_product, search). Also binds the role's flavor metadata: step label, safety annotation (read_only/idempotent, which drives parallel fan-out) and post-condition verifier follow the tool named here, so a role must name a tool that does that role's job.",
       "example": {
         "create_cart": "shopify_cart_create"
       }

--- a/app/ai/voice/agents/breeze_buddy/template/types.py
+++ b/app/ai/voice/agents/breeze_buddy/template/types.py
@@ -1364,12 +1364,24 @@ class UiIntentsConfig(BaseModel):
     MCP exposes differently-named cart tools (or whose reducers persist
     different state keys) run the same DIRECT intent executors without
     code changes.
+
+    ``tools`` is load-bearing beyond the DIRECT path: it is also how the
+    engine decides which tool a flavor's step label, safety annotation and
+    post-condition verifier attach to (see ``chat/flavors.py``). That is
+    the point — a rebound tool keeps the metadata it needs — but it means
+    a role must name a tool that actually does that role's job. Binding
+    ``search`` to a mutating tool, say, marks that tool ``read_only`` and
+    makes it eligible for parallel fan-out.
     """
 
     tools: Dict[str, str] = Field(
         default_factory=dict,
         description="Flavor tool role → actual tool name on this template's "
-        "MCP/function surface.",
+        "MCP/function surface. Binds the role's flavor METADATA too — its "
+        "step label, safety annotation (read_only/idempotent, which drives "
+        "parallel fan-out) and post-condition verifier follow the tool "
+        "named here. Point a role at a tool that does a different job and "
+        "it inherits the wrong safety class and post-conditions.",
     )
     state_keys: Dict[str, str] = Field(
         default_factory=dict,

--- a/app/ai/voice/agents/breeze_buddy/template/ui_catalog.py
+++ b/app/ai/voice/agents/breeze_buddy/template/ui_catalog.py
@@ -365,6 +365,33 @@ class QuickReplies(_CatalogBase):
     )
 
 
+class LinkButton(_CatalogBase):
+    """Single link CTA — the link-only answer ("just give me the checkout
+    link") without rendering a whole component around it.
+
+    Literal component (like QuickReplies), but the URL is NOT
+    model-trusted: ``execute_render_ui`` rejects any url that is neither
+    in the template's ``render_ui.trusted_link_urls`` allowlist nor
+    present verbatim in THIS turn's tool results — the model selects
+    links, it never authors them. Clicking fires the widget's ``open_url``
+    route (Handoff popup semantics, host-page intercept preserved).
+
+    Core, not flavor-owned: the trust rule, the config key and the three
+    engine call sites that special-case it are all engine-side, so the
+    schema belongs here too. A flavor may still supply its own wording
+    for the LLM-facing ``link`` arg through its render_ui pack.
+
+    ``text_channel=False``: the trust check lives ONLY in the render_ui
+    function path, so a hand-typed ``<ui_stream>`` add is rejected at
+    parse (``render_ui_only:LinkButton``) — the dual-read window must not
+    be an arbitrary-URL injection surface."""
+
+    text_channel: ClassVar[bool] = False
+
+    label: str = Field(..., min_length=1, max_length=40)
+    url: str = Field(..., min_length=8, max_length=2048, pattern=r"^https://")
+
+
 # ---------------------------------------------------------------------------
 # Data primitives (group: core)
 # ---------------------------------------------------------------------------
@@ -889,6 +916,7 @@ UI_CATALOG: Dict[str, Type[_CatalogBase]] = {
     "Button": Button,
     "Buttons": Buttons,
     "QuickReplies": QuickReplies,
+    "LinkButton": LinkButton,
     # Data (core)
     "Table": Table,
     # Typed (core)
@@ -938,6 +966,7 @@ PRIMITIVE_GROUPS: Dict[str, List[str]] = {
         "Button",
         "Buttons",
         "QuickReplies",
+        "LinkButton",
         "Table",
         "Message",
         "Handoff",
@@ -979,6 +1008,16 @@ PRIMITIVE_GROUPS: Dict[str, List[str]] = {
 }
 
 
+# Reverse index: primitive name → owning group. Seeded from the static
+# groups above and extended by ``register_primitives``, which uses it to
+# reject a name two groups both claim. Keeping it here (rather than
+# scanning ``PRIMITIVE_GROUPS`` per lookup) makes ``group_for`` O(1) — it
+# runs per rendered node.
+_GROUP_OF: Dict[str, str] = {
+    name: group for group, members in PRIMITIVE_GROUPS.items() for name in members
+}
+
+
 # Order in which primitives appear in the system-prompt rendering. Listed
 # composite-first so the LLM defaults to Tile for list items, then core
 # building blocks for freeform composition. Lazily-registered data-bound
@@ -1002,6 +1041,7 @@ PRIMITIVE_RENDER_ORDER: List[str] = [
     "Button",
     "Buttons",
     "QuickReplies",
+    "LinkButton",
     "Handoff",
     # Data
     "Table",
@@ -1094,10 +1134,25 @@ def register_primitives(
     re-import) without duplicating group-member or render-order entries.
     ``render_order`` defaults to the mapping's insertion order; names
     append at the END of ``PRIMITIVE_RENDER_ORDER`` (see the note there).
+
+    A name already owned by a DIFFERENT group raises. ``UI_CATALOG`` is a
+    flat process-global map while the allowlist is per-template, so a
+    second group claiming an existing name would silently hand its schema
+    to every template that enabled the first — the kind of packaging bug
+    that surfaces as one merchant's component validating against
+    another's fields. Two groups wanting the same concept means promoting
+    it to ``core``, not registering it twice.
     """
     members = PRIMITIVE_GROUPS.setdefault(group, [])
     for name, schema in primitives.items():
+        owner = _GROUP_OF.get(name)
+        if owner is not None and owner != group:
+            raise ValueError(
+                f"UI primitive {name!r} is already registered by group "
+                f"{owner!r}; group {group!r} cannot claim it"
+            )
         UI_CATALOG[name] = schema
+        _GROUP_OF[name] = group
         if name not in members:
             members.append(name)
     for name in render_order if render_order is not None else list(primitives):
@@ -1112,10 +1167,7 @@ def register_primitives(
 
 def group_for(type_name: str) -> Optional[str]:
     """Return the group name a primitive belongs to, or None if unknown."""
-    for group_name, members in PRIMITIVE_GROUPS.items():
-        if type_name in members:
-            return group_name
-    return None
+    return _GROUP_OF.get(type_name)
 
 
 def is_known_type(type_name: str) -> bool:

--- a/tests/assist/test_commerce_schemas.py
+++ b/tests/assist/test_commerce_schemas.py
@@ -34,13 +34,12 @@ from app.ai.voice.agents.breeze_buddy.template.ui_prompt import (
 # be idempotent).
 ensure_group_loaded("commerce")
 
-COMMERCE = {"ProductCard", "ProductGrid", "CartView", "ProductDetail", "LinkButton"}
-# The subset the LLM is prompted with — ProductDetail is server_only,
+COMMERCE = {"ProductCard", "ProductGrid", "CartView", "ProductDetail"}
+# The subset the LLM is prompted with — ProductDetail is server_only and
 # ProductCard was retired to server_only 2026-07-30 (a ProductGrid of one
-# IS a card now that layout is count-derived), and LinkButton is
-# render_ui-only (text_channel=False): all registered + allowlisted, but
-# never rendered into the text-channel prompt sections.
-PROMPTED = COMMERCE - {"ProductDetail", "ProductCard", "LinkButton"}
+# IS a card now that layout is count-derived): registered + allowlisted,
+# but never rendered into the text-channel prompt sections.
+PROMPTED = COMMERCE - {"ProductDetail", "ProductCard"}
 
 
 # ---------------------------------------------------------------------------
@@ -60,9 +59,9 @@ def test_commerce_group_lists_exactly_the_registered_components():
 
 
 def test_data_bound_flags():
-    # LinkButton is the literal exception: commerce group, but its props
-    # are model-authored (URL trust-checked in render_ui, not bound).
-    assert data_bound_names() == COMMERCE - {"LinkButton"}
+    # Every commerce primitive is data-bound; LinkButton (the literal,
+    # model-authored one) now lives in core.
+    assert data_bound_names() == COMMERCE
     assert is_data_bound("ProductGrid")
     assert not is_data_bound("LinkButton")
     assert not is_data_bound("Tile")

--- a/tests/assist/test_lazy_loading.py
+++ b/tests/assist/test_lazy_loading.py
@@ -24,7 +24,7 @@ from app.ai.voice.agents.breeze_buddy.template.types import UiCatalogConfig
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 
-COMMERCE = {"ProductGrid", "ProductCard", "CartView", "ProductDetail", "LinkButton"}
+COMMERCE = {"ProductGrid", "ProductCard", "CartView", "ProductDetail"}
 
 # Runs a full core-only session surface (ChatAgent init → allowlist →
 # prompt section render) and asserts no assist module was imported; then

--- a/tests/test_agent_fanout_verification.py
+++ b/tests/test_agent_fanout_verification.py
@@ -56,6 +56,7 @@ def _patch_agent_attr(monkeypatch, name, value):
 
 
 from app.ai.voice.agents.breeze_buddy.chat.agent import ChatAgent, _PreparedTools
+from app.ai.voice.agents.breeze_buddy.chat.flavors import resolve_flavor_scope
 from app.ai.voice.agents.breeze_buddy.chat.steps import (
     verification as verification_module,
 )
@@ -75,6 +76,17 @@ import app.ai.voice.agents.breeze_buddy.assist.commerce.ucp.schemas  # noqa: F40
 
 _NODE: Dict[str, Any] = {"name": "start", "functions": []}
 
+# Every commerce annotation / verifier is registered under the "commerce"
+# catalog group and keyed by ROLE, so a session only sees them if its
+# template enabled the group (chat/flavors.py). These tests exercise the
+# commerce tool surface, so they run as a commerce-enabled session.
+_COMMERCE_UI_CATALOG = SimpleNamespace(
+    enabled_groups=["core", "commerce"],
+    enabled_primitives=None,
+    disabled_primitives=None,
+)
+_COMMERCE_SCOPE = resolve_flavor_scope(None, ["commerce"])
+
 _PREP = _PreparedTools(
     flow_config={}, global_funcs=[], tool_retention=None, tool_projection=None
 )
@@ -85,7 +97,7 @@ def _configurations(**overrides: Any) -> SimpleNamespace:
         state_reducers=[],
         tool_arg_injection=[],
         client_context=None,
-        ui_catalog=None,
+        ui_catalog=_COMMERCE_UI_CATALOG,
         ui_intents=None,
         tool_execution=None,
     )
@@ -95,7 +107,12 @@ def _configurations(**overrides: Any) -> SimpleNamespace:
 
 def _make_agent(configurations: Any = None) -> ChatAgent:
     template = TemplateModel.model_construct(
-        id="tpl-1", name="t", flow={}, configurations=configurations
+        id="tpl-1",
+        name="t",
+        flow={},
+        configurations=(
+            configurations if configurations is not None else _configurations()
+        ),
     )
     agent = ChatAgent(
         session_id="sess-1",
@@ -191,10 +208,14 @@ async def _run_cycle(
 
 def test_annotation_precedence():
     # Flavor registry (loaded via the commerce import above).
-    assert resolve_tool_annotation("search_catalog") == "read_only"
-    assert resolve_tool_annotation("update_cart") == "idempotent"
+    assert (
+        resolve_tool_annotation("search_catalog", None, _COMMERCE_SCOPE) == "read_only"
+    )
+    assert resolve_tool_annotation("update_cart", None, _COMMERCE_SCOPE) == "idempotent"
     # Unknown tool → destructive (never accidentally parallel).
-    assert resolve_tool_annotation("mystery_tool") == "destructive"
+    assert (
+        resolve_tool_annotation("mystery_tool", None, _COMMERCE_SCOPE) == "destructive"
+    )
     # Template override beats the registry.
     template = SimpleNamespace(
         configurations=SimpleNamespace(
@@ -203,22 +224,27 @@ def test_annotation_precedence():
             )
         )
     )
-    assert resolve_tool_annotation("search_catalog", template) == "destructive"
-    assert resolve_tool_annotation("my_read", template) == "read_only"
+    assert (
+        resolve_tool_annotation("search_catalog", template, _COMMERCE_SCOPE)
+        == "destructive"
+    )
+    assert resolve_tool_annotation("my_read", template, _COMMERCE_SCOPE) == "read_only"
     # Invalid override value falls through to the registry/default.
     bad = SimpleNamespace(
         configurations=SimpleNamespace(
             tool_execution=SimpleNamespace(annotations={"search_catalog": "fast"})
         )
     )
-    assert resolve_tool_annotation("search_catalog", bad) == "read_only"
+    assert (
+        resolve_tool_annotation("search_catalog", bad, _COMMERCE_SCOPE) == "read_only"
+    )
 
 
 def test_conflicting_registration_raises():
-    register_tool_annotations({"annot_probe": "read_only"})
-    register_tool_annotations({"annot_probe": "read_only"})  # idempotent
+    register_tool_annotations("probe", {"annot_probe": "read_only"})
+    register_tool_annotations("probe", {"annot_probe": "read_only"})  # idempotent
     try:
-        register_tool_annotations({"annot_probe": "destructive"})
+        register_tool_annotations("probe", {"annot_probe": "destructive"})
     except ValueError:
         pass
     else:  # pragma: no cover
@@ -355,10 +381,12 @@ def test_raising_verifier_fails_open(monkeypatch):
     def _boom(_args, _result):
         raise RuntimeError("bad verifier")
 
-    register_tool_verifier("failopen_tool", _boom)
-    assert run_tool_verifiers("failopen_tool", {}, {"ok": True}) is None
+    register_tool_verifier("commerce", "failopen_tool", _boom)
+    assert (
+        run_tool_verifiers("failopen_tool", {}, {"ok": True}, _COMMERCE_SCOPE) is None
+    )
     # Cleanup so other tests never see the probe verifier.
-    verification_module._VERIFIERS.pop("failopen_tool", None)
+    verification_module._VERIFIERS["commerce"].pop("failopen_tool", None)
 
 
 def test_error_envelopes_skip_verification():
@@ -368,6 +396,7 @@ def test_error_envelopes_skip_verification():
             "update_cart",
             {"cart": {"line_items": [{"item": {"id": "v9"}, "quantity": 2}]}},
             {"status": "error", "error": "upstream 500"},
+            _COMMERCE_SCOPE,
         )
         is None
     )

--- a/tests/test_agent_step_events.py
+++ b/tests/test_agent_step_events.py
@@ -46,6 +46,8 @@ def _patch_agent_attr(monkeypatch, name, value):
             monkeypatch.setattr(_mod, name, value)
 
 
+from types import SimpleNamespace  # isort: skip
+
 from app.ai.voice.agents.breeze_buddy.chat.agent import ChatAgent, _PreparedTools
 from app.ai.voice.agents.breeze_buddy.template.types import TemplateModel
 
@@ -57,8 +59,24 @@ _PREP = _PreparedTools(
 
 
 def _make_agent() -> ChatAgent:
+    # Enables the "probe" group so the summarizer registered in
+    # test_registered_flavor_summarizer_feeds_step_completed is in scope.
     template = TemplateModel.model_construct(
-        id="tpl-1", name="t", flow={}, configurations=None
+        id="tpl-1",
+        name="t",
+        flow={},
+        configurations=SimpleNamespace(
+            state_reducers=[],
+            tool_arg_injection=[],
+            client_context=None,
+            ui_catalog=SimpleNamespace(
+                enabled_groups=["core", "probe"],
+                enabled_primitives=None,
+                disabled_primitives=None,
+            ),
+            ui_intents=None,
+            tool_execution=None,
+        ),
     )
     agent = ChatAgent(
         session_id="sess-1",
@@ -174,11 +192,13 @@ async def test_registered_flavor_summarizer_feeds_step_completed(monkeypatch):
             return f"{len(rows)} rows", len(rows)
         return None, None
 
-    step_labels.register_step_summarizer(_rows_summarizer)
+    # Registered under the group this test's template enables — a
+    # summarizer is only ever consulted for sessions in its own flavor.
+    step_labels.register_step_summarizer("probe", _rows_summarizer)
     try:
         events = await _run_turn(monkeypatch, "fetch_report", {"rows": [{}, {}]})
         completed = next(ev for ev in events if ev.event == "step_completed")
         assert completed.data["summary"] == "2 rows"
         assert completed.data["count"] == 2
     finally:
-        step_labels._STEP_SUMMARIZERS.remove(_rows_summarizer)
+        step_labels._STEP_SUMMARIZERS["probe"].remove(_rows_summarizer)

--- a/tests/test_flavor_scoping.py
+++ b/tests/test_flavor_scoping.py
@@ -1,0 +1,297 @@
+"""Flavor registries are per-template, not per-process.
+
+Every flavor registry is process-global and filled at lazy import time, so
+the FIRST commerce template to warm a worker used to change tool behaviour
+for every other merchant sharing that process — none of whom enabled the
+flavor. This module pins both halves of the gate:
+
+* **Group scope** — a session whose template did not enable ``commerce``
+  sees engine defaults for the very same tool names, with the flavor fully
+  loaded in the same process (which the import below guarantees).
+* **Role binding** — a template that points a flavor ROLE at its own
+  gateway's tool name keeps the metadata registered for that role.
+
+The contamination tests deliberately assert on tool names commerce also
+uses (``search_catalog``, ``get_cart``, ``update_cart``): overlapping names
+across merchants are the realistic case, and the whole point is that the
+overlap no longer matters.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from app.ai.voice.agents.breeze_buddy.chat.flavors import (
+    EMPTY_SCOPE,
+    resolve_flavor_scope,
+    role_key,
+)
+from app.ai.voice.agents.breeze_buddy.chat.steps.labels import (
+    resolve_step_label,
+    summarize_step_result,
+)
+from app.ai.voice.agents.breeze_buddy.chat.steps.verification import run_tool_verifiers
+from app.ai.voice.agents.breeze_buddy.chat.tools.annotations import (
+    is_read_only,
+    resolve_tool_annotation,
+)
+from app.ai.voice.agents.breeze_buddy.chat.tools.result_annotators import (
+    run_result_annotators,
+)
+from app.ai.voice.agents.breeze_buddy.chat.ui.binding import selector_extension_keys
+from app.ai.voice.agents.breeze_buddy.chat.ui.render_ui_tool import (
+    build_render_ui_schema,
+)
+from app.ai.voice.agents.breeze_buddy.template.ui_catalog import (
+    UI_CATALOG,
+    group_for,
+    register_primitives,
+)
+
+# Warms the flavor into this process exactly like a live commerce session
+# would — every assertion below runs with the registries POPULATED.
+import app.ai.voice.agents.breeze_buddy.assist.commerce  # noqa: F401  isort: skip
+
+_COMMERCE = resolve_flavor_scope(None, ["commerce"])
+
+
+def _template(tools: dict | None = None) -> SimpleNamespace:
+    return SimpleNamespace(
+        configurations=SimpleNamespace(
+            ui_intents=SimpleNamespace(tools=tools) if tools else None,
+            tool_execution=None,
+        )
+    )
+
+
+# ---------------------------------------------------------------------------
+# Group scope — a non-commerce session is untouched by the loaded flavor
+# ---------------------------------------------------------------------------
+
+
+class TestNoCrossTemplateContamination:
+    def test_step_labels_stay_generic(self):
+        assert resolve_step_label("get_product", EMPTY_SCOPE) == (
+            "Getting the product",
+            "Got the product",
+        )
+        assert resolve_step_label("get_cart", EMPTY_SCOPE) == (
+            "Getting the cart",
+            "Got the cart",
+        )
+
+    def test_shape_keyed_summarizer_never_runs(self):
+        # The dangerous one: it matches on payload SHAPE, so any tool
+        # returning a ``products`` or ``line_items`` list would have been
+        # captioned with commerce wording.
+        assert summarize_step_result({"products": [{}, {}]}, EMPTY_SCOPE) == (
+            None,
+            None,
+        )
+        assert summarize_step_result({"line_items": [{}]}, EMPTY_SCOPE) == (None, None)
+
+    def test_annotations_stay_destructive(self):
+        # Annotations drive parallel fan-out and mutation serialization —
+        # a leaked ``read_only`` would run a stranger's mutations
+        # concurrently.
+        assert resolve_tool_annotation("search_catalog", None, EMPTY_SCOPE) == (
+            "destructive"
+        )
+        assert not is_read_only("get_cart", None, EMPTY_SCOPE)
+
+    def test_verifiers_never_rewrite_a_success(self):
+        # The worst failure mode: a SUCCESSFUL call turned into an error
+        # envelope before the store, reducers and LLM ever see it, purely
+        # because another merchant's flavor is warm in this worker.
+        foreign_success = {"status": "success", "items": [{"sku": "a"}]}
+        assert run_tool_verifiers("search_catalog", {}, foreign_success) is None
+        assert (
+            run_tool_verifiers("search_catalog", {}, foreign_success, _COMMERCE)
+            == "search result carries no products array"
+        )
+
+    def test_result_annotators_do_not_stamp_foreign_results(self):
+        result = {"products": [{"id": "p1", "title": "Anything"}]}
+        assert run_result_annotators("search_catalog", {"query": "x"}, result) is result
+
+    def test_selector_keys_stay_out_of_the_render_ui_schema(self):
+        # These splice into the LLM-facing tool schema, so a leak changes
+        # what every other merchant's model is told it may send.
+        assert selector_extension_keys(None) == []
+        assert selector_extension_keys(["core"]) == []
+        assert selector_extension_keys(["commerce"]) == ["feature_variant"]
+
+        core_schema = build_render_ui_schema(
+            ["Table"], handler=None, flavor_groups=["core"]
+        )
+        assert set(core_schema.properties["items"]["items"]["properties"]) == {"id"}
+        commerce_schema = build_render_ui_schema(
+            ["ProductGrid"], handler=None, flavor_groups=["commerce"]
+        )
+        assert "feature_variant" in (
+            commerce_schema.properties["items"]["items"]["properties"]
+        )
+
+
+# ---------------------------------------------------------------------------
+# Role binding — metadata follows the tool the template actually calls
+# ---------------------------------------------------------------------------
+
+
+class TestRoleBinding:
+    """A template may bind a flavor role to its own gateway's tool name via
+    ``ui_intents.tools``. Before role binding, dispatch used the template's
+    name while the registries were keyed on the flavor's default — so the
+    merchant silently lost the verifier, got ``destructive`` (no fan-out)
+    and a humanized step label."""
+
+    REBOUND = {"search": "find_products", "get_cart": "fetch_basket"}
+
+    @pytest.fixture
+    def scope(self):
+        return resolve_flavor_scope(_template(self.REBOUND), ["commerce"])
+
+    def test_verifier_follows_the_rebound_tool(self, scope):
+        assert (
+            run_tool_verifiers("find_products", {}, {"status": "success"}, scope)
+            == "search result carries no products array"
+        )
+
+    def test_annotation_follows_the_rebound_tool(self, scope):
+        assert resolve_tool_annotation("find_products", None, scope) == "read_only"
+        assert is_read_only("fetch_basket", None, scope)
+
+    def test_step_label_follows_the_rebound_tool(self, scope):
+        assert resolve_step_label("fetch_basket", scope) == (
+            "Checking your cart",
+            "Checked your cart",
+        )
+
+    def test_result_annotator_follows_the_rebound_tool(self, scope):
+        annotated = run_result_annotators(
+            "find_products",
+            {"query": "leggings"},
+            {"products": [{"id": "p1", "title": "Flowmesh Leggings"}]},
+            scope,
+        )
+        assert annotated["products"][0].get("matched_via")
+
+    def test_unbound_roles_keep_their_defaults(self, scope):
+        # Only `search` and `get_cart` were rebound; the rest still match
+        # on the UCP default names.
+        assert resolve_tool_annotation("update_cart", None, scope) == "idempotent"
+        assert resolve_step_label("get_product", scope) == (
+            "Checking the product",
+            "Checked the product",
+        )
+
+    def test_the_flavors_own_default_name_no_longer_matches(self, scope):
+        # The flavor's default names are what THIS template bound
+        # elsewhere, so they are just unknown tools here. Checked for both
+        # a role whose name differs from its default tool (`search` ->
+        # `search_catalog`) and one where they coincide (`get_cart`) — the
+        # second only holds because role keys are namespaced.
+        assert resolve_tool_annotation("search_catalog", None, scope) == "destructive"
+        assert resolve_tool_annotation("get_cart", None, scope) == "destructive"
+        assert resolve_step_label("get_cart", scope) == (
+            "Getting the cart",
+            "Got the cart",
+        )
+
+    def test_force_after_maps_through_the_binding(self, scope):
+        # The pack names a ROLE KEY; the engine resolves it to this
+        # template's tool so the forced render_ui think-step still fires.
+        assert scope.tool_for(role_key("search")) == "find_products"
+        assert scope.tool_for(role_key("update_cart")) == "update_cart"
+        # A bare name is a literal tool, never re-read as a role — so the
+        # plain string "search" cannot resolve to the catalog tool.
+        assert scope.tool_for("search") == "search"
+        assert scope.tool_for("not_a_role") == "not_a_role"
+
+
+class TestRoleNamesAreNotToolNames:
+    """A ROLE is a job the template binds to a tool; a tool name is a tool
+    name. They share no key space, so a merchant's unrelated tool cannot
+    inherit a role's metadata just by being named after it.
+
+    ``search`` is the case that matters: it is commerce's catalog role,
+    but its default tool is ``search_catalog`` — so a knowledge-base or
+    order-lookup tool literally named ``search`` is a realistic collision
+    on a commerce template, and it would pick up the catalog verifier,
+    which rewrites a SUCCESSFUL result into an error envelope."""
+
+    @pytest.fixture
+    def scope(self):
+        return resolve_flavor_scope(_template(), ["core", "commerce"])
+
+    def test_a_tool_named_after_a_role_gets_nothing(self, scope):
+        assert resolve_tool_annotation("search", None, scope) == "destructive"
+        assert resolve_step_label("search", scope) == ("Searching", "Searched")
+
+    def test_and_its_successful_result_is_not_rewritten(self, scope):
+        knowledge_base_hit = {"status": "success", "answers": [{"a": "30 days"}]}
+        assert run_tool_verifiers("search", {}, knowledge_base_hit, scope) is None
+
+    def test_while_the_actual_bound_tool_still_resolves(self, scope):
+        # The role is bound to search_catalog by default, so THAT keeps
+        # every piece of its metadata.
+        assert resolve_tool_annotation("search_catalog", None, scope) == "read_only"
+        assert (
+            run_tool_verifiers("search_catalog", {}, {"status": "success"}, scope)
+            == "search result carries no products array"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Fail-open + degradation
+# ---------------------------------------------------------------------------
+
+
+def test_a_raising_role_map_costs_only_the_binding():
+    from app.ai.voice.agents.breeze_buddy.chat import flavors
+
+    def _boom(_template):
+        raise RuntimeError("bad role map")
+
+    flavors.register_flavor_roles("explosive", _boom)
+    try:
+        scope = resolve_flavor_scope(None, ["explosive", "commerce"])
+        # The turn survives, commerce still resolves, and the broken
+        # group's entries fall back to literal name matching.
+        assert scope.groups == ("explosive", "commerce")
+        assert resolve_tool_annotation("get_product", None, scope) == "read_only"
+    finally:
+        flavors._ROLE_MAPS.pop("explosive", None)
+
+
+def test_no_groups_means_no_flavor_at_all():
+    assert resolve_flavor_scope(_template(), None) is EMPTY_SCOPE
+    assert resolve_flavor_scope(_template(), []) is EMPTY_SCOPE
+
+
+# ---------------------------------------------------------------------------
+# Catalog ownership
+# ---------------------------------------------------------------------------
+
+
+def test_two_groups_cannot_claim_the_same_primitive():
+    # UI_CATALOG is a flat process-global map while the allowlist is
+    # per-template, so a silent overwrite would hand one merchant's
+    # component schema to another's session.
+    with pytest.raises(ValueError, match="already registered by group"):
+        register_primitives("impostor", {"ProductGrid": UI_CATALOG["ProductGrid"]})
+
+
+def test_reregistering_within_the_same_group_is_still_fine():
+    register_primitives("commerce", {"ProductGrid": UI_CATALOG["ProductGrid"]})
+    assert group_for("ProductGrid") == "commerce"
+
+
+def test_link_button_belongs_to_core():
+    # The engine hardcodes LinkButton (render_ui component list, url trust
+    # check, summary shape) and owns its config key, so the schema lives
+    # in core — a flavor that wants different wording supplies it through
+    # its render_ui pack instead.
+    assert group_for("LinkButton") == "core"

--- a/tests/test_render_ui_phase_a.py
+++ b/tests/test_render_ui_phase_a.py
@@ -1,6 +1,8 @@
 """RFC-002 Phase A unit tests: render_ui tool, plan enforcer, baseline
 search annotation, and the metrics counters."""
 
+from types import SimpleNamespace
+
 from app.ai.voice.agents.breeze_buddy.assist.commerce.ucp.annotator import (
     annotate_search_result,
 )
@@ -172,6 +174,92 @@ def test_link_button_accepts_url_from_reducer_state():
     )
     assert out.decision == "rendered"
     assert out.ops[0]["props"]["url"] == "https://shop.example/policies/refunds"
+
+
+def _link_args(url: str) -> dict:
+    return {"component": "LinkButton", "link": {"label": "Tap", "url": url}}
+
+
+def test_link_button_ignores_storefront_pushed_context_state():
+    """The ``_client_context`` namespace is written by storefront JS over
+    /widget/session/{id}/context — key-allowlisted, values unvalidated. A
+    URL that is ONLY there has no tool provenance, so it must not satisfy
+    the trust rule; otherwise a compromised page could have the assistant
+    render an attacker link as a trusted CTA."""
+    evil = "https://evil.example/pay"
+    out = execute_render_ui(
+        _link_args(evil),
+        store=_store(),
+        allowlist=ALLOW,
+        components=COMPS,
+        op_id="root",
+        trusted_urls=set(),
+        state_values={"_client_context": {"page_url": evil}},
+    )
+    assert out.decision == "error"
+    assert "untrusted url" in out.fn_result["error"]
+
+
+def test_link_button_ignores_client_allowlisted_state_keys():
+    """Same for the top-level keys a template lets the storefront push
+    (``client_context.state_allowlist``) — the push validates key NAMES,
+    never values."""
+    evil = "https://evil.example/pay"
+    template = SimpleNamespace(
+        configurations=SimpleNamespace(
+            client_context=SimpleNamespace(state_allowlist=["cart_id"])
+        )
+    )
+    out = execute_render_ui(
+        _link_args(evil),
+        store=_store(),
+        allowlist=ALLOW,
+        components=COMPS,
+        op_id="root",
+        trusted_urls=set(),
+        state_values={"cart_id": evil},
+        template=template,
+    )
+    assert out.decision == "error"
+
+
+def test_link_button_still_accepts_reducer_state_on_a_context_template():
+    """The strip is by key: a template that allowlists SOME keys keeps
+    trusting the reducer-written ones it did not allowlist."""
+    url = "https://shop.example/policies/refunds"
+    template = SimpleNamespace(
+        configurations=SimpleNamespace(
+            client_context=SimpleNamespace(state_allowlist=["cart_id"])
+        )
+    )
+    out = execute_render_ui(
+        _link_args(url),
+        store=_store(),
+        allowlist=ALLOW,
+        components=COMPS,
+        op_id="root",
+        trusted_urls=set(),
+        state_values={"cart_id": "c1", "policy_links": [{"url": url}]},
+        template=template,
+    )
+    assert out.decision == "rendered"
+    assert out.ops[0]["props"]["url"] == url
+
+
+def test_link_button_trusted_urls_win_over_the_state_strip():
+    """The static allowlist is checked first and is unaffected — the
+    commerce pilot's links come from there."""
+    url = "https://shop.example/cart"
+    out = execute_render_ui(
+        _link_args(url),
+        store=_store(),
+        allowlist=ALLOW,
+        components=COMPS,
+        op_id="root",
+        trusted_urls={url},
+        state_values={"_client_context": {"page_url": url}},
+    )
+    assert out.decision == "rendered"
 
 
 def test_link_button_rejects_untrusted_url():

--- a/tests/test_step_failed_status.py
+++ b/tests/test_step_failed_status.py
@@ -12,6 +12,7 @@ a plan past a failed step while the widget paints it red.
 
 from __future__ import annotations
 
+from app.ai.voice.agents.breeze_buddy.chat.flavors import resolve_flavor_scope
 from app.ai.voice.agents.breeze_buddy.chat.steps.enforcer import PlanEnforcer
 from app.ai.voice.agents.breeze_buddy.chat.steps.verification import (
     register_tool_verifier,
@@ -36,14 +37,17 @@ def test_verifier_skips_failed_result():
         calls["n"] += 1
         return "should never run on a failed result"
 
-    register_tool_verifier("probe_failed_skip", _verifier)
+    register_tool_verifier("probe", "probe_failed_skip", _verifier)
+    scope = resolve_flavor_scope(None, ["probe"])
     # A failed backend body must skip verification entirely — the tool
     # already failed; there is nothing to post-condition.
-    assert run_tool_verifiers("probe_failed_skip", {}, {"status": "failed"}) is None
+    assert (
+        run_tool_verifiers("probe_failed_skip", {}, {"status": "failed"}, scope) is None
+    )
     assert calls["n"] == 0
     # A successful result still runs the verifier.
     assert (
-        run_tool_verifiers("probe_failed_skip", {}, {"ok": True})
+        run_tool_verifiers("probe_failed_skip", {}, {"ok": True}, scope)
         == "should never run on a failed result"
     )
     assert calls["n"] == 1

--- a/tests/test_step_labels.py
+++ b/tests/test_step_labels.py
@@ -1,14 +1,24 @@
 """chat/step_labels — label resolution (fallback + registered) and the
-generic step-completion summarizer."""
+generic step-completion summarizer.
+
+Flavor entries are group-scoped and role-keyed, so most assertions here
+run against an explicit scope; the ones that DON'T are the point — they
+pin that a session which never enabled the flavor is unaffected by it,
+however warm the process is."""
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+
+from app.ai.voice.agents.breeze_buddy.chat.flavors import resolve_flavor_scope
 from app.ai.voice.agents.breeze_buddy.chat.steps.labels import (
     register_step_labels,
     resolve_step_label,
     resolve_step_status,
     summarize_step_result,
 )
+
+_COMMERCE = resolve_flavor_scope(None, ["commerce"])
 
 # ---------------------------------------------------------------------------
 # resolve_step_label — generic humanizer fallback
@@ -59,8 +69,19 @@ def test_fallback_empty_name_is_safe():
 
 
 def test_registered_labels_win_over_humanizer():
-    register_step_labels({"frobnicate_widget": ("Frobnicating", "Frobnicated")})
-    assert resolve_step_label("frobnicate_widget") == ("Frobnicating", "Frobnicated")
+    register_step_labels(
+        "probe", {"frobnicate_widget": ("Frobnicating", "Frobnicated")}
+    )
+    scope = resolve_flavor_scope(None, ["probe"])
+    assert resolve_step_label("frobnicate_widget", scope) == (
+        "Frobnicating",
+        "Frobnicated",
+    )
+    # ...but only for a session that enabled the group.
+    assert resolve_step_label("frobnicate_widget") == (
+        "Frobnicating the widget",
+        "Frobnicated the widget",
+    )
 
 
 def test_commerce_registration_hook():
@@ -68,17 +89,47 @@ def test_commerce_registration_hook():
     # does) must register the commerce labels as a side effect.
     import app.ai.voice.agents.breeze_buddy.assist.commerce.ucp.schemas  # noqa: F401
 
-    assert resolve_step_label("lookup_catalog") == (
+    assert resolve_step_label("lookup_catalog", _COMMERCE) == (
         "Looking up products",
         "Looked up products",
     )
-    assert resolve_step_label("update_cart") == (
+    assert resolve_step_label("update_cart", _COMMERCE) == (
         "Updating your cart",
         "Updated your cart",
     )
-    assert resolve_step_label("get_cart") == (
+    assert resolve_step_label("get_cart", _COMMERCE) == (
         "Checking your cart",
         "Checked your cart",
+    )
+
+
+def test_commerce_labels_are_invisible_without_the_group():
+    # The registry is process-global; the SCOPE is what makes it apply.
+    # A merchant who never enabled commerce gets the humanizer for the
+    # very same tool names.
+    import app.ai.voice.agents.breeze_buddy.assist.commerce.ucp.schemas  # noqa: F401
+
+    assert resolve_step_label("get_cart") == ("Getting the cart", "Got the cart")
+    assert resolve_step_label("update_cart") == (
+        "Updating the cart",
+        "Updated the cart",
+    )
+
+
+def test_commerce_labels_follow_a_rebound_role():
+    # A template whose gateway calls the search tool something else still
+    # gets the commerce label — registration is keyed by ROLE.
+    import app.ai.voice.agents.breeze_buddy.assist.commerce.ucp.schemas  # noqa: F401
+
+    template = SimpleNamespace(
+        configurations=SimpleNamespace(
+            ui_intents=SimpleNamespace(tools={"search": "find_products"})
+        )
+    )
+    scope = resolve_flavor_scope(template, ["commerce"])
+    assert resolve_step_label("find_products", scope) == (
+        "Searching the catalog",
+        "Searched the catalog",
     )
 
 
@@ -104,28 +155,40 @@ def test_status_ok_default():
 
 
 def test_summary_products_list():
-    summary, count = summarize_step_result({"products": [{}, {}, {}]})
+    summary, count = summarize_step_result({"products": [{}, {}, {}]}, _COMMERCE)
     assert summary == "3 results"
     assert count == 3
 
 
 def test_summary_products_singular():
-    assert summarize_step_result({"products": [{}]}) == ("1 result", 1)
+    assert summarize_step_result({"products": [{}]}, _COMMERCE) == ("1 result", 1)
 
 
 def test_summary_line_items():
-    summary, count = summarize_step_result({"id": "c1", "line_items": [{}, {}]})
+    summary, count = summarize_step_result(
+        {"id": "c1", "line_items": [{}, {}]}, _COMMERCE
+    )
     assert summary == "cart updated · 2 items"
     assert count == 2
 
 
 def test_summary_products_precedence_over_line_items():
-    summary, count = summarize_step_result({"products": [{}], "line_items": [{}, {}]})
+    summary, count = summarize_step_result(
+        {"products": [{}], "line_items": [{}, {}]}, _COMMERCE
+    )
     assert (summary, count) == ("1 result", 1)
 
 
 def test_summary_omitted_for_other_shapes():
-    assert summarize_step_result({"status": "success"}) == (None, None)
-    assert summarize_step_result("text") == (None, None)
-    assert summarize_step_result(None) == (None, None)
-    assert summarize_step_result({"products": "not-a-list"}) == (None, None)
+    assert summarize_step_result({"status": "success"}, _COMMERCE) == (None, None)
+    assert summarize_step_result("text", _COMMERCE) == (None, None)
+    assert summarize_step_result(None, _COMMERCE) == (None, None)
+    assert summarize_step_result({"products": "not-a-list"}, _COMMERCE) == (None, None)
+
+
+def test_summary_omitted_entirely_without_the_group():
+    # The shape-keyed summarizer is the likeliest of these registries to
+    # fire on a stranger's payload — any tool returning a ``products``
+    # list would have been captioned. Out of scope, it never runs.
+    assert summarize_step_result({"products": [{}, {}]}) == (None, None)
+    assert summarize_step_result({"line_items": [{}]}) == (None, None)

--- a/tests/test_ui_binding.py
+++ b/tests/test_ui_binding.py
@@ -301,7 +301,11 @@ def test_items_selection_runs_before_max_items_cap():
 def test_items_feature_variant_rederives_hero_and_stamps_id():
     """RFC-003 §4 variant continuity: feature_variant re-derives the card
     hero (price) from that variant record and stamps featured_variant_id;
-    an unknown variant id is fail-open (entry untouched)."""
+    an unknown variant id is fail-open (entry untouched).
+
+    The transform is registered by the commerce group, so the op must be
+    resolved with that group in scope — a template without it gets plain
+    id selection (asserted at the end)."""
     payload = {
         "products": [
             {
@@ -317,7 +321,7 @@ def test_items_feature_variant_rederives_hero_and_stamps_id():
     }
     store = _store_with("search_catalog", payload)
     op = _grid_show_op(props={"items": [{"id": "p1", "feature_variant": "v-pink"}]})
-    result = resolve_show_op(op, store)
+    result = resolve_show_op(op, store, None, ["commerce"])
     assert result.error is None
     assert result.op is not None
     entry = result.op["props"]["products"][0]
@@ -325,12 +329,22 @@ def test_items_feature_variant_rederives_hero_and_stamps_id():
     assert entry["price"]["amount"] == 1099.0
     # Unknown variant id → untouched entry, no stamp, original hero.
     op2 = _grid_show_op(props={"items": [{"id": "p1", "feature_variant": "v-nope"}]})
-    result2 = resolve_show_op(op2, store)
+    result2 = resolve_show_op(op2, store, None, ["commerce"])
     assert result2.error is None
     assert result2.op is not None
     entry2 = result2.op["props"]["products"][0]
     assert "featured_variant_id" not in entry2
     assert entry2["price"]["amount"] == 999.0
+    # Out of scope, the selector key is inert: the entry is selected by id
+    # and nothing re-derives it.
+    result3 = resolve_show_op(
+        _grid_show_op(props={"items": [{"id": "p1", "feature_variant": "v-pink"}]}),
+        store,
+    )
+    assert result3.op is not None
+    entry3 = result3.op["props"]["products"][0]
+    assert "featured_variant_id" not in entry3
+    assert entry3["price"]["amount"] == 999.0
 
 
 def test_resolve_unresolved_tool_drops_with_reason():


### PR DESCRIPTION
## Why

The flavor registries — step labels, result summarizers, tool annotations, verifiers, result annotators, selector transforms — are process-global and filled at lazy import time. That lifecycle is right. Reading them process-globally was not: the **first commerce template to warm a worker changed tool behaviour for every other merchant sharing that process**, none of whom enabled the flavor.

Measured on `release`, with commerce loaded, for a **core-only** session:

| registry | before | after commerce loads |
|---|---|---|
| step label `get_product` | `Getting the product` | `Checking the product` |
| summary `{"products":[..2..]}` | `(None, None)` | `("2 results", 2)` |
| annotation `search_catalog` | `destructive` | `read_only` |
| verifier `search_catalog` (**success**) | `None` | `"search result carries no products array"` |
| selector keys in `render_ui` schema | `[]` | `["feature_variant"]` |

Severity, worst first:

- **The verifier rewrites a SUCCESS into an error envelope** before the binding store, reducers and LLM context ever see it.
- **The summarizer is the likeliest to fire** — it matches on payload *shape* and never checks the tool name, so any tool returning a `products` or `line_items` list gets commerce wording.
- **The annotation decides parallel fan-out**, so a leaked `read_only` runs a stranger's mutations concurrently.

Nothing is live today: no commerce template exists in prod, so the registries stay empty and every merchant sees engine defaults. **This arms on the first template sync, not on a deploy.**

## What changed

Two things must now be true before a flavor entry applies to a call.

**1. The template enabled the GROUP.** Every registry is keyed by catalog group — the same key the render_ui pack and prompt section already used — and every resolver takes a `FlavorScope` (new `chat/flavors.py`) resolved once per turn on the agent. `EMPTY_SCOPE` is the default argument, so a call site that forgets to pass one degrades to engine behaviour rather than leaking someone else's vocabulary.

**2. The entry matches the tool by ROLE.** Separately from the leak, a template that rebound a role via `ui_intents.tools` **silently lost its metadata**: dispatch used the template's tool name while the registries were keyed on the flavor's default, so a merchant whose gateway calls it `find_products` got no cart verifier, `destructive` (no fan-out) and a humanized step label. Flavors now declare a role map (`assist/commerce/ucp/roles.py`, one table shared with the intent driver) and the scope inverts it.

Role keys are namespaced (`role_key(ROLE_SEARCH)` → `"role:search"`) and live in a separate key space from literal tool names. That matters because a flavor's role name is not always its tool name — commerce's `search` role binds to `search_catalog` — so a shared namespace would let a merchant's unrelated tool that happens to be called `search` inherit the catalog role's verifier, annotation and label.

Also here, because both are prerequisites for a second flavor and both are small:

- **`register_primitives` raises when a second group claims a name another group owns.** `UI_CATALOG` is a flat process-global map while the allowlist is per-template, so a silent overwrite would hand one merchant's component schema to another's session. Verified zero collisions exist today. `group_for()` is now an O(1) index.
- **`LinkButton` moves from `commerce` into `core`.** The engine hardcodes it in three places and owns its config key, so commerce owning the schema was the layering inversion.

**The LinkButton move widened a latent surface, so this PR closes it.** `url_is_trusted` treated all of `agent_session_state` as tool-provenanced, but two parts of it are storefront-writable: the `_client_context` facts namespace and any key in `client_context.state_allowlist` (the push validates key NAMES, never values). A compromised storefront page could write a URL into state and have the assistant render it as a trusted CTA, defeating `trusted_link_urls`. The state scan now runs over the tool-sourced part only. Reducer-written URLs (the cross-turn `policy_links` flow) still qualify; the static `trusted_link_urls` leg is checked first and untouched.

Known limit, commented at the strip: removal is by KEY, and a state key is one slot. A template that allowlists a key its reducers ALSO write real tool URLs into would lose the genuine value too. No template does that today — none configures `client_context` at all. Provenance tracking is the correct fix if that changes.

## Risk

- **Commerce pilot: unaffected end to end** — same labels, annotations, summaries, forced think-step. Its LinkButton URLs come from `trusted_link_urls`, which the trust change doesn't touch.
- **`LinkButton` now appears in the `render_ui` component enum for a core template** — but only one with `render_ui.enabled`, which no fleet template sets (default `false`). The text-channel prompt is byte-identical either way (`text_channel=False`).
- `ui_intents.tools` now also binds a role's safety annotation and verifier. That is the feature, but it's a semantic expansion of an existing config key, so `types.py` and `field_reference.json` document it.
- No config-model fields added.

## Tests

`tests/test_flavor_scoping.py` (21 tests) pins both halves of the gate **with the flavor deliberately warm in the process** — the contamination assertions use tool names commerce also registers, because overlapping names are the realistic case and the point is that the overlap no longer matters. Covers: no cross-template contamination on all six registries; role binding follows a rebound tool while unbound roles keep their defaults; a tool named after a role inherits nothing; a raising role map costs only the binding, never the turn; the catalog duplicate-name raise.

Four new trust-scan tests in `test_render_ui_phase_a.py`; the two that matter were verified to FAIL without the fix.

**1202 passed**, pyrefly 0 errors, black/isort/autoflake clean.

The before/after table was produced by running the same probe against `release` and against this branch.