### PR TITLE
feat(widget): one `widget` surface block on the session responses

### DIFF
--- a/app/ai/voice/agents/breeze_buddy/chat/agent/core.py
+++ b/app/ai/voice/agents/breeze_buddy/chat/agent/core.py
@@ -303,15 +303,24 @@ class ChatAgent(
         self._in_chips_cycle = False
         self._quick_replies_rendered = False
         # _turn_prose_streamed — visible prose reached the client this turn.
+        # _turn_answered — an ANSWER (prose from a cycle that called no DATA
+        #   tool) reached the client this turn. Strictly narrower than
+        #   _turn_prose_streamed, which narration ("Let me check…") also
+        #   sets. The two are NOT interchangeable: keying a "the reply is
+        #   already delivered" decision on mere prose treats an opener as a
+        #   reply, and every such decision then fires a turn too early.
         # _suppress_extra_prose — set when a chips-only call was harvested
-        #   AFTER prose already streamed: the reply is delivered, so any
-        #   FURTHER prose the model generates before turn end is duplicate
-        #   sign-off and gets dropped (the old ban's error text bred a
-        #   rephrased duplicate greeting — live 2026-07-31).
+        #   AFTER the reply was delivered: any FURTHER prose the model
+        #   generates before turn end is duplicate sign-off and gets
+        #   dropped (the old ban's error text bred a rephrased duplicate
+        #   greeting — live 2026-07-31). Armed off _turn_answered, NOT
+        #   _turn_prose_streamed: armed by narration it silenced the real
+        #   answer that had not been written yet, killing the whole turn.
         # _held_chips — rider-harvested quick replies (chips attached to a
         #   mid-turn render_ui call, or a chips-only call): flushed below
         #   the final prose at turn end, skipping the forced chips cycle.
         self._turn_prose_streamed = False
+        self._turn_answered = False
         self._suppress_extra_prose = False
         self._held_chips: Optional[List[str]] = None
 

--- a/app/ai/voice/agents/breeze_buddy/chat/agent/cycle.py
+++ b/app/ai/voice/agents/breeze_buddy/chat/agent/cycle.py
@@ -27,6 +27,7 @@ from pipecat.processors.aggregators.llm_context import (
 from pipecat_flows import FlowsFunctionSchema
 
 from app.ai.voice.agents.breeze_buddy.chat.agent.runtime import (  # noqa: F401
+    _ANSWER_NUDGE,
     _CHIPS_NUDGE,
     _MAX_TOOL_CYCLES,
     _chip_labels,
@@ -94,6 +95,13 @@ if TYPE_CHECKING:
     from app.ai.voice.agents.breeze_buddy.chat.agent.core import ChatAgent
 
 
+# render_ui / revise_plan are the engine's own harness tools: they present
+# or re-plan, they never fetch. A cycle that calls only these is not doing
+# work the model is waiting on, so prose beside them is a reply, not an
+# announcement of work to come.
+_HARNESS_TOOLS = frozenset({RENDER_UI_TOOL_NAME, REVISE_PLAN_TOOL_NAME})
+
+
 class CycleLoopMixin:
     async def _cycle_loop(
         self: "ChatAgent",
@@ -117,6 +125,19 @@ class CycleLoopMixin:
         node_name = cast(str, node["name"])
 
         assistant_text_chunks: List[str] = []
+        # Prose splits into two kinds, and only one of them ends a turn.
+        # NARRATION is prose from a cycle that ALSO called tools ("Let me
+        # find those for you") — it streams ahead of the work and is not
+        # an answer to anything. An ANSWER is prose from a cycle that
+        # called nothing: the model had its results and spoke.
+        #
+        # Both club into the single user-facing row below (one bubble per
+        # turn — splitting them into two rows re-introduces the duplicate
+        # reply on resume fixed 2026-07-31). The distinction exists purely
+        # so the turn-completion test below reads intent instead of
+        # inspecting whether ANY text happens to exist.
+        answered = False
+        answer_retried = False
         # ui_ops accumulator (Sprint 1.7) — captures each SpecStream op the
         # LLM emits during this user turn. Persisted alongside the assistant
         # message so the widget resume path can repaint Tiles/Carousels
@@ -323,9 +344,43 @@ class CycleLoopMixin:
                             event="assistant_token", data={"delta": out.value}
                         )
 
-            assistant_text_chunks.extend(turn_text)
-            if turn_text:
+            # No DATA tool in this cycle means the model already had
+            # everything it needed when it spoke — this is the answer.
+            # render_ui / revise_plan don't count: they present or re-plan,
+            # they never fetch, and the normal shape of a reply is prose +
+            # a render_ui in one cycle.
+            cycle_answers = not any(
+                call.function_name not in _HARNESS_TOOLS for call in tool_calls
+            )
+            # Narration belongs to the gate row this cycle is about to
+            # write (below), IN FRONT of the tool_use it preceded — which
+            # is where it actually happened. Accumulating it here too
+            # persisted it TWICE, and the LLM sees both copies on replay:
+            # once correctly pre-tool, once fused to the answer. Turn 2
+            # then mimicked the fused shape and stopped announcing early
+            # (measured 2026-08-09: 3/3 sessions, turn 1 announced, turn 2
+            # did not). Each piece of prose is written exactly once.
+            #
+            # Both flags key off the STRIPPED prose, never raw ``turn_text``
+            # truthiness. ``turn_text`` holds every non-empty delta, so a
+            # lone "\n" or a cycle whose text was entirely <ui_stream>
+            # markers is a non-empty list carrying no prose at all — and
+            # three such shapes are live-observed here: an empty Vertex
+            # candidate (see the MALFORMED branch below), a <plan>-only
+            # cycle when the template has plan_enforcement off, and the
+            # marker-mimicry bug (see ``_ui_summary``). Counting one of
+            # those as "the model answered" skips the recovery nudge below
+            # and lets the turn end with an empty reply.
+            cycle_prose = strip_ui_stream_markers("".join(turn_text)).strip()
+            if cycle_prose:
                 self._turn_prose_streamed = True
+                if cycle_answers:
+                    assistant_text_chunks.extend(turn_text)
+                    answered = True
+                    # Mirrored onto the agent so the render_ui handler can
+                    # read the same fact — a chips-only call must know
+                    # whether a REPLY exists, not merely whether prose does.
+                    self._turn_answered = True
             if allowed and not tool_calls:
                 if self._in_chips_cycle:
                     # The forced chips cycle produced no call. Never retry
@@ -391,6 +446,46 @@ class CycleLoopMixin:
                         f"{cycle + 1}"
                     )
                     continue
+                if (
+                    not answered
+                    and not answer_retried
+                    and not self._internal_turn
+                    and self._turn_prose_streamed
+                ):
+                    # Narration without an answer: the model opened with
+                    # "Let me check…", did its work, and stopped without
+                    # replying (live 2026-08-09 — a search that matched
+                    # nothing; the opener sat in context and it behaved as
+                    # if it had already spoken). Ending here would leave
+                    # the shopper an acknowledgement and no reply. Give it
+                    # exactly one unforced cycle to answer — bounded like
+                    # the MALFORMED-call fallback, so a mute model costs
+                    # one extra cycle, never a loop.
+                    answer_retried = True
+                    # Un-arm prose suppression for the cycle we are about to
+                    # buy. Suppression drops text before it is streamed,
+                    # accumulated OR persisted, so a recovery cycle that ran
+                    # with it still set could not produce a reply by
+                    # construction — it would burn an LLM call and end the
+                    # turn exactly as mute as before.
+                    self._suppress_extra_prose = False
+                    logger.warning(
+                        f"ChatAgent {self.session_id}: turn produced "
+                        "narration but no answer; nudging once"
+                    )
+                    context.add_message(
+                        cast(
+                            LLMContextMessage,
+                            {"role": "user", "content": _ANSWER_NUDGE},
+                        )
+                    )
+                    await insert_chat_message(
+                        session_id=self.session_id,
+                        role=ChatMessageRole.USER,
+                        content=None,
+                        content_blocks=[internal_text_block(_ANSWER_NUDGE)],
+                    )
+                    continue
                 chips_prose = strip_ui_stream_markers(
                     "".join(assistant_text_chunks)
                 ).strip()
@@ -400,6 +495,17 @@ class CycleLoopMixin:
                     and not self._internal_turn
                     and not self._chips_attempted
                     and not self._quick_replies_rendered
+                    # `answered`, not `chips_prose` alone: chips follow a
+                    # REPLY. Keyed on "is there any text" they would fire on
+                    # a turn whose only prose was the opener, ending it with
+                    # an acknowledgement and four suggestions.
+                    and answered
+                    # …and `chips_prose` as well, because this branch
+                    # PERSISTS it as the turn's reply row and emits it as
+                    # assistant_message. `answered` already implies non-empty
+                    # stripped prose; keeping the original guard makes that
+                    # an invariant of this branch rather than a fact one has
+                    # to re-derive from the flag's definition upstream.
                     and chips_prose
                 ):
                     # Forced final chips cycle (template quick_replies=
@@ -454,8 +560,10 @@ class CycleLoopMixin:
                         # the old min_length=2 with no fallback).
                     # No rider — fall back to the forced chips cycle. The
                     # nudge rides an internal USER row (widget read paths
-                    # filter it; the LLM sees it live and on replay —
-                    # Vertex requires user/model alternation).
+                    # filter it — see _sanitize_messages_for_widget, applied
+                    # on both the /chat and /widget resume routes; the LLM
+                    # sees it live and on replay — Vertex requires
+                    # user/model alternation).
                     context.add_message(
                         cast(
                             LLMContextMessage,
@@ -477,7 +585,11 @@ class CycleLoopMixin:
             # block — the LLM keeps the referential memory ("the green
             # one") on its next turn, but every widget-facing read path
             # filters it out so it never shows up in the chat bubble.
-            visible_text = strip_ui_stream_markers("".join(turn_text))
+            # ``.strip()`` matches the turn-end row's twin: without it a
+            # cycle whose only text was whitespace persisted a blank
+            # VISIBLE block and a non-null content column — an empty bubble
+            # on resume for every turn the model led with a stray newline.
+            visible_text = strip_ui_stream_markers("".join(turn_text)).strip()
             ui_summary = self._ui_summary(turn_ui_ops)
 
             # In-memory LLM context still gets the augmented text — this
@@ -504,7 +616,20 @@ class CycleLoopMixin:
             # reads filter them.
             assistant_blocks = assistant_turn_to_blocks("", tool_calls)
             if visible_text:
-                assistant_blocks.insert(0, internal_text_block(visible_text))
+                # Narration (prose ahead of a DATA call) is the shopper's
+                # first bubble and is persisted ONLY here, so it renders on
+                # resume exactly where it streamed — above the component.
+                # Prose beside a harness-only call (render_ui) is part of
+                # the ANSWER, which the turn-end row owns; keep that copy
+                # internal or resume replays the reply twice (2026-07-31).
+                assistant_blocks.insert(
+                    0,
+                    (
+                        internal_text_block(visible_text)
+                        if (cycle_answers or self._internal_turn)
+                        else plain_text_blocks(visible_text)[0]
+                    ),
+                )
             if ui_summary and assistant_blocks:
                 # Insert the internal summary block right after the
                 # visible text block so concatenation order on read
@@ -522,10 +647,15 @@ class CycleLoopMixin:
                 gate_row = await insert_chat_message(
                     session_id=self.session_id,
                     role=ChatMessageRole.ASSISTANT,
-                    # content stays None: the visible copy of any prose
-                    # belongs to the turn's user-facing row (see the
-                    # internal-demotion comment above).
-                    content=None,
+                    # Narration is this row's own bubble, so the
+                    # denormalised column carries it. Answer prose still
+                    # belongs to the turn's user-facing row (None here) —
+                    # see the block-visibility choice above.
+                    content=(
+                        None
+                        if (cycle_answers or self._internal_turn)
+                        else (visible_text or None)
+                    ),
                     content_blocks=assistant_blocks,
                     # Tool-rendered ops are HELD off mid-turn gate rows (they
                     # used to scatter across whichever gate row came next):
@@ -535,6 +665,22 @@ class CycleLoopMixin:
                     ui_blocks=self._row_ui_blocks(turn_ui_ops, include_tool_ops=False),
                 )
                 gate_assistant_idx = gate_row.idx if gate_row else None
+                if visible_text and not (cycle_answers or self._internal_turn):
+                    # This gate row was written VISIBLE — it is the shopper's
+                    # narration bubble, a row of its own. Every other visible
+                    # assistant row on every surface is announced with an
+                    # assistant_message carrying its idx (the early-chips row
+                    # above, the turn-end row, the intent router's row); this
+                    # one was the sole exception, so the live stream and a
+                    # later resume disagreed: one bubble live, two after a
+                    # reload, and a client that commits its bubble from
+                    # assistant_message.content (the documented contract —
+                    # docs/CHAT_MODE.md "Full assistant turn") dropped the
+                    # narration text entirely at turn end.
+                    yield SSEEvent(
+                        event="assistant_message",
+                        data={"idx": gate_assistant_idx, "content": visible_text},
+                    )
 
             # Mirror LLMAssistantContextAggregator: append assistant message
             # carrying tool_calls, then a tool-result per call. Universal

--- a/app/ai/voice/agents/breeze_buddy/chat/agent/render_ui.py
+++ b/app/ai/voice/agents/breeze_buddy/chat/agent/render_ui.py
@@ -106,9 +106,15 @@ class RenderUiHandlerMixin:
             ):
                 # Chips-only call: nothing else to render. Positive result
                 # (not an error — errors bred rephrased-reply rambles); if
-                # the reply already streamed, trailing prose is duplicate
+                # the REPLY already streamed, trailing prose is duplicate
                 # sign-off and gets suppressed.
-                if self._turn_prose_streamed:
+                #
+                # Keyed on _turn_answered, not _turn_prose_streamed: an
+                # opener ("Let me check…") is prose but not a reply, and
+                # suppressing after one silenced the answer that had not
+                # been written yet — the turn then ended with no answer
+                # row, no assistant_message, and these very chips dropped.
+                if self._turn_answered:
                     self._suppress_extra_prose = True
                 return {
                     "status": "ok",

--- a/app/ai/voice/agents/breeze_buddy/chat/agent/runtime.py
+++ b/app/ai/voice/agents/breeze_buddy/chat/agent/runtime.py
@@ -31,6 +31,26 @@ _CHIPS_NUDGE = (
     "duplicate an action already available on UI rendered this turn.)"
 )
 
+# Recovery nudge for a turn that ran tools and then went quiet without
+# ever replying. Deliberately says nothing about WHY the model stopped:
+# templates differ (one may have it announce work before a call, another
+# may not), and engine copy that assumes a template's convention is the
+# same layering inversion the flavor registries exist to prevent. It
+# states only the engine-level fact — no reply has been produced yet —
+# which is true for every template.
+#
+# Same internal-USER-row mechanics as _CHIPS_NUDGE (keeps user/model
+# alternation, invisible to widget reads); fires at most once per turn.
+# "Invisible" rests entirely on the caller sanitizing: every widget-facing
+# read must route through ``_sanitize_messages_for_widget``. Both the
+# /chat resume route and the /widget resume route do — the widget one only
+# since the split was audited, having served raw rows before that.
+_ANSWER_NUDGE = (
+    "(you have not replied to the user yet. Reply now in prose, using "
+    "what the tools returned. If nothing matched, say so plainly and "
+    "offer the closest alternatives you did find.)"
+)
+
 
 def _chip_labels(raw: Any) -> List[str]:
     """Lift a `quick_replies` arg (strings canonical; {'label': …} dicts

--- a/app/api/routers/breeze_buddy/chat/demo.py
+++ b/app/api/routers/breeze_buddy/chat/demo.py
@@ -39,6 +39,14 @@ from app.api.routers.breeze_buddy.chat.handlers import (
     serve_session_intent,
     validate_template_for_chat,
 )
+
+# TODO(widget-surface): these three belong in widget_common.py once this
+# lands — a router importing another router's privates is a smell we accept
+# only while this change is unreleased.
+from app.api.routers.breeze_buddy.widget.handlers import (
+    _extract_widget_config,
+    _surface_wire,
+)
 from app.api.security.breeze_buddy.demo_token import (
     DemoSessionContext,
     mint_demo_token,
@@ -247,6 +255,17 @@ async def create_demo_session(
         message_cap=cap,
         catalog_active=catalog_active,
         ui_flavors=ui_flavors,
+        # Demo pages get the SAME surface block as the widget. Before this
+        # block existed the demo response carried only catalog_active +
+        # ui_flavors, so a demo page structurally could not render quick
+        # replies or greeting tiles its template defined — the asymmetry
+        # the one-block shape exists to prevent.
+        widget=_surface_wire(
+            _extract_widget_config(template),
+            template,
+            catalog_active=catalog_active,
+            ui_flavors=ui_flavors,
+        ),
     )
 
 

--- a/app/api/routers/breeze_buddy/widget/handlers.py
+++ b/app/api/routers/breeze_buddy/widget/handlers.py
@@ -46,6 +46,7 @@ from app.ai.voice.agents.breeze_buddy.template.ui_catalog import (
 )
 from app.ai.voice.stt import TranscriptionError, transcribe_audio
 from app.api.routers.breeze_buddy.chat.handlers import (
+    _sanitize_messages_for_widget,
     approve_chat_tool_handler,
     cancel_chat_turn_handler,
     create_chat_session_handler,
@@ -110,6 +111,7 @@ from app.schemas.breeze_buddy.chat import (
     WidgetChannel,
     WidgetIntentRequest,
     WidgetSessionStateResponse,
+    WidgetSurfaceWire,
     WidgetTranscribeResponse,
     WidgetVoiceConnectResponse,
     WidgetVoiceEndResponse,
@@ -214,6 +216,28 @@ def _extract_widget_config(template: object) -> _WidgetSurface:
     )
 
 
+def _surface_wire(
+    surface: _WidgetSurface,
+    template: object,
+    *,
+    catalog_active: str,
+    ui_flavors: List[str],
+) -> WidgetSurfaceWire:
+    """The one-block form of the session's presentation surface.
+
+    Built from exactly the same values the flat response fields carry, so
+    the two can never disagree while both are on the wire.
+    """
+    return WidgetSurfaceWire(
+        quick_replies=surface.quick_replies,
+        greeting_tiles=surface.greeting_tiles,
+        enable_text_input=surface.enable_text_input,
+        voice_enabled=_template_voice_enabled(template),
+        catalog_active=catalog_active,
+        ui_flavors=ui_flavors,
+    )
+
+
 def _template_voice_enabled(template: object) -> bool:
     """Whether the widget should offer a voice mode for this template.
 
@@ -310,12 +334,18 @@ async def create_widget_session_handler(
         greeting=create_resp.greeting,
         widget_token=widget_token,
         ttl_seconds=DEFAULT_WIDGET_TOKEN_TTL_MINUTES * 60,
+        # Flat fields: retained for embeds already in the wild (cached
+        # bundles we don't control the refresh of). New embeds read
+        # ``widget`` — same values, one block.
         quick_replies=surface.quick_replies,
         greeting_tiles=surface.greeting_tiles,
         enable_text_input=surface.enable_text_input,
         voice_enabled=_template_voice_enabled(template),
         catalog_active=catalog_active,
         ui_flavors=ui_flavors,
+        widget=_surface_wire(
+            surface, template, catalog_active=catalog_active, ui_flavors=ui_flavors
+        ),
     )
 
 
@@ -1181,13 +1211,24 @@ async def get_widget_session_state_handler(
         status=session.status,
         current_channel=session.current_channel,
         current_node=session.current_node,
-        messages=messages,
+        # Same sanitize the /chat resume + transcript routes apply. This
+        # route had been serving raw rows, so every LLM-context-only block
+        # the agent persists — chips/answer nudges, rendered-UI summaries,
+        # Gemini thought signatures — shipped verbatim to whoever holds the
+        # widget token, on the one resume endpoint the embed actually calls.
+        # The reference embed reads `content` and ignores `content_blocks`,
+        # so it renders nothing either way; a third-party embed that reads
+        # blocks was drawing the engine's own prompt text as a user bubble.
+        messages=_sanitize_messages_for_widget(messages),
         quick_replies=surface.quick_replies,
         greeting_tiles=surface.greeting_tiles,
         enable_text_input=surface.enable_text_input,
         voice_enabled=_template_voice_enabled(template),
         catalog_active=catalog_active,
         ui_flavors=ui_flavors,
+        widget=_surface_wire(
+            surface, template, catalog_active=catalog_active, ui_flavors=ui_flavors
+        ),
         template_vars=template_vars,
         metadata=session.metadata or {},
         client_context=client_context,

--- a/app/schemas/breeze_buddy/chat.py
+++ b/app/schemas/breeze_buddy/chat.py
@@ -469,73 +469,6 @@ class CreateDemoSessionRequest(BaseModel):
     template_vars: Dict[str, Any] = Field(default_factory=dict)
 
 
-class CreateDemoSessionResponse(BaseModel):
-    """Body of ``POST /chat/demo/session``.
-
-    Mirrors ``CreateChatSessionResponse`` plus the demo-only fields the
-    client needs to drive subsequent ``/message`` SSE calls.
-    """
-
-    session_id: str
-    status: ChatSessionStatus
-    current_node: Optional[str] = None
-    greeting: Optional[GreetingMessage] = None
-    demo_token: str = Field(..., description="Bearer token for follow-up calls.")
-    message_cap: int = Field(..., description="Max assistant turns before 429.")
-    catalog_active: str = Field(
-        "v1",
-        description=(
-            "Negotiated UI catalog version — 'v2' when the demo template "
-            "enables data-bound components (demo pages always run a "
-            "v2-capable widget build, so the template is the only variable)."
-        ),
-    )
-    ui_flavors: List[str] = Field(
-        default_factory=list,
-        description="Lazy UI flavor groups the demo template enables.",
-    )
-
-
-# ---------------------------------------------------------------------------
-# Unified widget-mode schemas (CHAT_MODE.md §14)
-#
-# One conversation, one widget_token, two channels (CHAT ↔ VOICE). The
-# session_id always refers to the canonical chat_session row that owns
-# the conversation; voice is a transient attachment that drains back
-# into the same row at end_conversation.
-# ---------------------------------------------------------------------------
-
-
-class CreateWidgetSessionRequest(BaseModel):
-    """Body of ``POST /widget/session``."""
-
-    public_widget_key: str = Field(
-        ...,
-        min_length=10,
-        description="Opaque per-merchant widget key (server-generated, see widget_config).",
-    )
-    template_vars: Dict[str, Any] = Field(
-        default_factory=dict,
-        description="Render-time variables (customer_name, etc.). "
-        "Same shape as the RBAC chat path's template_vars.",
-    )
-    metadata: Dict[str, Any] = Field(
-        default_factory=dict,
-        description="Opaque caller context, persisted on chat_session.metadata.",
-    )
-    catalog_version: Optional[str] = Field(
-        None,
-        description=(
-            "UI catalog version the embed supports (RFC-001 §3.4). 'v2' "
-            "enables data-bound components (show-op hydration + typed "
-            "intents) for this session; absent/other = v1 (server prunes "
-            "data-bound components — prompt and wire stay v1-compatible). "
-            "Persisted on chat_session.metadata under the server-owned "
-            "'widget' block."
-        ),
-    )
-
-
 class QuickReplyWire(BaseModel):
     """One quick-reply option returned in the widget session-create response.
 
@@ -581,6 +514,130 @@ class GreetingTileWire(BaseModel):
     label: str = Field(..., description="Tile caption shown to the user.")
     prompt: str = Field(..., description="Message sent to the agent on tap.")
     image_url: str = Field(..., description="Tile image URL (merchant CDN).")
+
+
+class WidgetSurfaceWire(BaseModel):
+    """Everything the embed needs to paint its chrome for one session.
+
+    One block instead of six sibling fields hand-copied across the create,
+    resume, and demo responses — a seventh surface field is added HERE and
+    every surface gets it, instead of being forgotten on one of them (which
+    is exactly what happened to the demo response).
+
+    ADDITIVE, not a replacement: the same values keep riding at the top
+    level of each response for now. Embeds in the wild are cached bundles
+    we do not control the refresh of, so the flat fields can only be
+    removed once telemetry says no client reads them. New embeds should
+    read this block.
+    """
+
+    quick_replies: List[QuickReplyWire] = Field(
+        default_factory=list,
+        description="Static quick-reply pills; empty when none configured.",
+    )
+    greeting_tiles: List[GreetingTileWire] = Field(
+        default_factory=list,
+        description="Visual quick-tap tiles for the greeting screen.",
+    )
+    enable_text_input: bool = Field(
+        True, description="False hides the composer (pills/tiles only)."
+    )
+    voice_enabled: bool = Field(
+        False,
+        description=(
+            "Template permits a voice attachment. Advisory — the server "
+            "stays the enforcement point at /voice/connect."
+        ),
+    )
+    catalog_active: str = Field(
+        "v1",
+        description=(
+            "Negotiated UI catalog version for this session: client-requested "
+            "∩ template-capable. 'v2' ⇔ show-op hydration + typed intents."
+        ),
+    )
+    ui_flavors: List[str] = Field(
+        default_factory=list,
+        description=(
+            "Lazy UI flavor groups the template enables — preload these "
+            "code-split chunks. Empty when catalog_active is 'v1'."
+        ),
+    )
+
+
+class CreateDemoSessionResponse(BaseModel):
+    """Body of ``POST /chat/demo/session``.
+
+    Mirrors ``CreateChatSessionResponse`` plus the demo-only fields the
+    client needs to drive subsequent ``/message`` SSE calls.
+    """
+
+    session_id: str
+    status: ChatSessionStatus
+    current_node: Optional[str] = None
+    greeting: Optional[GreetingMessage] = None
+    demo_token: str = Field(..., description="Bearer token for follow-up calls.")
+    message_cap: int = Field(..., description="Max assistant turns before 429.")
+    catalog_active: str = Field(
+        "v1",
+        description=(
+            "Negotiated UI catalog version — 'v2' when the demo template "
+            "enables data-bound components (demo pages always run a "
+            "v2-capable widget build, so the template is the only variable)."
+        ),
+    )
+    ui_flavors: List[str] = Field(
+        default_factory=list,
+        description="Lazy UI flavor groups the demo template enables.",
+    )
+    widget: WidgetSurfaceWire = Field(
+        default_factory=WidgetSurfaceWire,
+        description=(
+            "The session's presentation surface in one block. Preferred over "
+            "the flat sibling fields above, which are retained for embeds "
+            "already in the wild and will be removed once nothing reads them."
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Unified widget-mode schemas (CHAT_MODE.md §14)
+#
+# One conversation, one widget_token, two channels (CHAT ↔ VOICE). The
+# session_id always refers to the canonical chat_session row that owns
+# the conversation; voice is a transient attachment that drains back
+# into the same row at end_conversation.
+# ---------------------------------------------------------------------------
+
+
+class CreateWidgetSessionRequest(BaseModel):
+    """Body of ``POST /widget/session``."""
+
+    public_widget_key: str = Field(
+        ...,
+        min_length=10,
+        description="Opaque per-merchant widget key (server-generated, see widget_config).",
+    )
+    template_vars: Dict[str, Any] = Field(
+        default_factory=dict,
+        description="Render-time variables (customer_name, etc.). "
+        "Same shape as the RBAC chat path's template_vars.",
+    )
+    metadata: Dict[str, Any] = Field(
+        default_factory=dict,
+        description="Opaque caller context, persisted on chat_session.metadata.",
+    )
+    catalog_version: Optional[str] = Field(
+        None,
+        description=(
+            "UI catalog version the embed supports (RFC-001 §3.4). 'v2' "
+            "enables data-bound components (show-op hydration + typed "
+            "intents) for this session; absent/other = v1 (server prunes "
+            "data-bound components — prompt and wire stay v1-compatible). "
+            "Persisted on chat_session.metadata under the server-owned "
+            "'widget' block."
+        ),
+    )
 
 
 class CreateWidgetSessionResponse(BaseModel):
@@ -652,6 +709,14 @@ class CreateWidgetSessionResponse(BaseModel):
             "— the embed preloads these code-split chunks so the first "
             "hydrated component renders without a chunk-fetch stall. Empty "
             "when catalog_active is 'v1'."
+        ),
+    )
+    widget: WidgetSurfaceWire = Field(
+        default_factory=WidgetSurfaceWire,
+        description=(
+            "The session's presentation surface in one block. Preferred over "
+            "the flat sibling fields above, which are retained for embeds "
+            "already in the wild and will be removed once nothing reads them."
         ),
     )
 
@@ -780,6 +845,14 @@ class WidgetSessionStateResponse(BaseModel):
         description=(
             "Lazy UI flavor groups the template enables. Mirrors the create "
             "response so the resume path preloads the same chunks."
+        ),
+    )
+    widget: WidgetSurfaceWire = Field(
+        default_factory=WidgetSurfaceWire,
+        description=(
+            "The session's presentation surface in one block. Preferred over "
+            "the flat sibling fields above, which are retained for embeds "
+            "already in the wild and will be removed once nothing reads them."
         ),
     )
     template_vars: Dict[str, Any] = Field(default_factory=dict)

--- a/tests/test_render_ui_phase_a.py
+++ b/tests/test_render_ui_phase_a.py
@@ -1311,3 +1311,238 @@ async def test_single_label_rider_still_flushes(monkeypatch):
     assert len(ops) == 1 and ops[0]["type"] == "QuickReplies"
     labels = [i.get("label") for i in (ops[0].get("props") or {}).get("items", [])]
     assert labels == ["Add BB Bottle to cart"]
+
+
+# ---------------------------------------------------------------------------
+# Narration is not an answer (2026-08-09)
+#
+# A template may have the model announce work before it calls a tool
+# ("Let me find those for you"). That prose streams ahead of the search,
+# which is the point — but it is NOT a reply, and the turn-completion
+# test used to accept any prose as one. Live consequence: a search that
+# matched nothing ended the turn on the acknowledgement plus four quick
+# replies, with no answer and no products (metrics: prose_chars=41,
+# ui_no_ui=2, render_ui_calls=3).
+# ---------------------------------------------------------------------------
+
+
+def _search_call(query="x", call_id="s-1"):
+    from pipecat.frames.frames import FunctionCallFromLLM
+
+    return (
+        "tool_call",
+        FunctionCallFromLLM(
+            function_name="search_catalog",
+            tool_call_id=call_id,
+            arguments={"catalog": {"query": query}},
+            context=None,
+        ),
+    )
+
+
+async def test_narration_then_silence_gets_one_recovery_cycle(monkeypatch):
+    """Prose + a DATA tool call is narration. If the model then stops
+    without replying, the turn must not end on the announcement — it gets
+    exactly one more unforced cycle to answer."""
+    agent, prep, calls, inserted = _chips_agent(
+        monkeypatch,
+        "forced_final",
+        responses=[
+            # cycle 1: announces, then searches → narration, not a reply
+            [("text", "Let me check our store for those colors."), _search_call()],
+            # cycle 2: model goes quiet without answering
+            [],
+            # cycle 3: nudged — now it actually answers
+            [("text", "We don't carry those, but we do have light grey.")],
+            # cycle 4: forced chips
+            [_rui_call(_chips_args(), call_id="c-1")],
+        ],
+    )
+    events = await _run_chips_turn(agent, prep)
+
+    visible = [m for m in inserted if m.get("role") == "assistant" and m.get("content")]
+    assert visible, "the turn must persist an answer, not end on the announcement"
+    # Announcement and answer are separate rows, in the order they
+    # happened — the announcement rides the row carrying the tool_use it
+    # preceded. Writing either text twice is what taught the model to stop
+    # announcing on turn 2 (measured 3/3 sessions, 2026-08-09).
+    assert len(visible) == 2
+    assert visible[0]["content"] == "Let me check our store for those colors."
+    assert "light grey" in visible[1]["content"]
+    assert "Let me check our store" not in visible[1]["content"]
+
+
+async def test_narration_alone_never_arms_the_chips_cycle(monkeypatch):
+    """Chips follow a REPLY. A turn whose only prose was the announcement
+    must not end as acknowledgement + suggestions."""
+    agent, prep, calls, inserted = _chips_agent(
+        monkeypatch,
+        "forced_final",
+        responses=[
+            [("text", "Let me check our store for those colors."), _search_call()],
+            [],  # silent
+            [],  # silent again after the one nudge — give up, don't loop
+        ],
+    )
+    events = await _run_chips_turn(agent, prep)
+
+    chips = [e for e in events if e.event == "ui_op"]
+    assert not chips, "no reply was produced, so nothing to suggest follow-ups to"
+    # Bounded: the nudge fires once, never in a loop.
+    assert len(calls) == 3
+
+
+async def test_prose_beside_render_ui_is_still_a_reply(monkeypatch):
+    """render_ui presents, it never fetches — so prose in the same cycle
+    is the answer, and must not be mistaken for narration (which would
+    cost every normal turn an extra LLM call)."""
+    agent, prep, calls, inserted = _chips_agent(
+        monkeypatch,
+        "forced_final",
+        responses=[
+            [
+                ("text", "The BB Bottle is Rs 1,189."),
+                _rui_call({"quick_replies": ["Add to cart"]}, call_id="r-1"),
+            ],
+            [],
+        ],
+    )
+    await _run_chips_turn(agent, prep)
+    assert len(calls) == 2, "a normal reply turn must not gain a recovery cycle"
+
+
+async def test_a_tool_less_template_never_triggers_recovery(monkeypatch):
+    """Scaling check: a client with no tools at all (plain conversational
+    UI). Every prose cycle is an answer by construction, so the recovery
+    path is inert — it can never add a cycle for them."""
+    agent, prep, calls, inserted = _chips_agent(
+        monkeypatch,
+        "forced_final",
+        responses=[
+            [("text", "We're open 9 to 6, Monday through Saturday.")],
+            [_rui_call(_chips_args(), call_id="c-2")],
+        ],
+    )
+    await _run_chips_turn(agent, prep)
+    assert len(calls) == 2
+    visible = [m for m in inserted if m.get("role") == "assistant" and m.get("content")]
+    assert visible and "9 to 6" in visible[-1]["content"]
+
+
+# ---------------------------------------------------------------------------
+# Narration is not a reply — the four places that conflated the two.
+#
+# The turn loop asks "has the model replied yet?" in four spots. Each one
+# had been reading a proxy for that fact rather than the fact itself, and
+# each proxy is true for an OPENER, which is prose but not a reply. Every
+# test below fails on the pre-fix code.
+# ---------------------------------------------------------------------------
+
+
+async def test_chips_only_call_after_narration_does_not_kill_the_turn(monkeypatch):
+    """The dead-turn regression.
+
+    A chips-only render_ui is the ONLY way a model can author chips in
+    forced_final (QuickReplies leaves the component enum), and it can land
+    mid-turn — after the opener, before the answer. Suppression armed on
+    'any prose streamed' fired on the opener and then silenced the real
+    answer, which had not been written yet: no reply row, no
+    assistant_message, and the harvested chips discarded with it.
+
+    Suppression must key on a REPLY having been delivered.
+    """
+    agent, prep, calls, inserted = _chips_agent(
+        monkeypatch,
+        "forced_final",
+        responses=[
+            # cycle 1: opener + a DATA tool → narration
+            [("text", "Let me check our store for those."), _search_call()],
+            # cycle 2: chips-only rider, no component — the arming shape
+            [_rui_call({"quick_replies": ["Best Sellers", "Leggings"]}, call_id="r-1")],
+            # cycle 3: the actual answer
+            [("text", "We have it in light grey.")],
+        ],
+    )
+    events = await _run_chips_turn(agent, prep)
+
+    visible = [m for m in inserted if m.get("role") == "assistant" and m.get("content")]
+    assert any(
+        "light grey" in m["content"] for m in visible
+    ), "the answer must survive a mid-turn chips-only call"
+    kinds = [e.event for e in events]
+    assert "assistant_message" in kinds, "the turn must announce its reply"
+    assert "ui_op" in kinds, "harvested chips must still paint, not vanish"
+
+
+async def test_recovery_cycle_can_actually_speak(monkeypatch):
+    """The nudge buys one cycle; suppression would make that cycle mute by
+    construction (it drops text before streaming, accumulation AND
+    persistence). Un-arming is what makes the recovery cycle worth its
+    LLM call."""
+    agent, prep, calls, inserted = _chips_agent(
+        monkeypatch,
+        "forced_final",
+        responses=[
+            [("text", "One moment."), _search_call()],
+            # chips-only call arms suppression under the old rule
+            [_rui_call({"quick_replies": ["Best Sellers"]}, call_id="r-1")],
+            [],  # silent → nudge fires here
+            [("text", "Found three in stock.")],  # the recovered answer
+        ],
+    )
+    await _run_chips_turn(agent, prep)
+
+    visible = [m for m in inserted if m.get("role") == "assistant" and m.get("content")]
+    assert any("Found three" in m["content"] for m in visible)
+
+
+async def test_whitespace_only_cycle_is_not_an_answer(monkeypatch):
+    """``turn_text`` holds every non-empty delta, so a lone newline is a
+    non-empty list carrying no prose. Counting it as a reply skipped the
+    recovery nudge and persisted an empty bubble."""
+    agent, prep, calls, inserted = _chips_agent(
+        monkeypatch,
+        "forced_final",
+        responses=[
+            [("text", "Let me look that up."), _search_call()],
+            [("text", "\n\n")],  # degenerate: no prose at all
+            [("text", "Here are three options.")],  # nudged into replying
+            [_rui_call(_chips_args(), call_id="c-1")],
+        ],
+    )
+    await _run_chips_turn(agent, prep)
+
+    rows = [m for m in inserted if m.get("role") == "assistant"]
+    assert not any(
+        (m.get("content") or "").strip() == "" and m.get("content") is not None
+        for m in rows
+    ), "no assistant row may carry blank content"
+    visible = [m for m in rows if m.get("content")]
+    assert any("three options" in m["content"] for m in visible)
+
+
+async def test_narration_row_is_announced_on_the_wire(monkeypatch):
+    """The narration row persists VISIBLE, so it is a bubble of its own on
+    resume. Without a matching assistant_message the live stream and the
+    resume disagree — one bubble live, two after a reload — and a client
+    that commits its bubble from assistant_message.content drops the
+    narration text entirely."""
+    agent, prep, calls, inserted = _chips_agent(
+        monkeypatch,
+        "model_choice",
+        responses=[
+            [("text", "Let me check our store."), _search_call()],
+            [("text", "We have three in light grey.")],
+        ],
+    )
+    events = await _run_chips_turn(agent, prep)
+
+    announced = [
+        e.data.get("content") for e in events if e.event == "assistant_message"
+    ]
+    visible = [m for m in inserted if m.get("role") == "assistant" and m.get("content")]
+    assert len(visible) == 2, "narration and answer are separate rows"
+    # Every visible row has an assistant_message carrying its text.
+    assert "Let me check our store." in announced
+    assert any("light grey" in (c or "") for c in announced)
+    assert len(announced) == len(visible)

--- a/tests/test_widget_surface_block.py
+++ b/tests/test_widget_surface_block.py
@@ -1,0 +1,149 @@
+"""The one ``widget`` surface block on the session responses.
+
+The block exists so a seventh presentation field is added in ONE place and
+every surface gets it, instead of being hand-copied across create, resume
+and demo and forgotten on one of them — which is exactly what had happened
+to the demo response.
+
+It ships ADDITIVE: the same values keep riding at the top level of each
+response, because embeds in the wild are cached bundles whose refresh we
+do not control. So the property that actually has to hold is PARITY — the
+block and the flat fields can never disagree while both are on the wire.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from app.api.routers.breeze_buddy.widget.handlers import _surface_wire, _WidgetSurface
+from app.schemas.breeze_buddy.chat import (
+    CreateDemoSessionResponse,
+    CreateWidgetSessionResponse,
+    GreetingTileWire,
+    QuickReplyWire,
+    WidgetSessionStateResponse,
+    WidgetSurfaceWire,
+)
+
+_QUICK = [QuickReplyWire(label="Track order", value="where is my order")]
+_TILES = [
+    GreetingTileWire(
+        label="Shop tops", prompt="show me tops", image_url="https://x/i.png"
+    )
+]
+
+
+def _surface() -> _WidgetSurface:
+    return _WidgetSurface(
+        quick_replies=list(_QUICK),
+        greeting_tiles=list(_TILES),
+        enable_text_input=False,
+    )
+
+
+def _template(voice: bool = False) -> SimpleNamespace:
+    return SimpleNamespace(
+        configurations=None,
+        supported_channels=["chat", "voice"] if voice else ["chat"],
+    )
+
+
+def test_block_carries_the_same_values_as_the_flat_fields():
+    surface = _surface()
+    template = _template(voice=True)
+    block = _surface_wire(
+        surface, template, catalog_active="v2", ui_flavors=["commerce"]
+    )
+    # Field-for-field against the SAME sources the flat response fields are
+    # built from — the two are constructed from one surface object, so a
+    # future edit that feeds one and not the other fails here.
+    assert [q.label for q in block.quick_replies] == [q.label for q in _QUICK]
+    assert [t.label for t in block.greeting_tiles] == [t.label for t in _TILES]
+    assert block.enable_text_input is surface.enable_text_input
+    assert block.voice_enabled is True
+    assert block.catalog_active == "v2"
+    assert block.ui_flavors == ["commerce"]
+
+
+def test_every_session_response_exposes_the_block():
+    # The demo response is the one that used to lack the surface fields
+    # entirely; the block is what makes the three symmetrical.
+    for model in (
+        CreateWidgetSessionResponse,
+        WidgetSessionStateResponse,
+        CreateDemoSessionResponse,
+    ):
+        assert "widget" in model.model_fields, model.__name__
+
+
+def test_block_defaults_are_safe_for_a_bare_template():
+    # A template with no widget config at all still produces a legal block:
+    # empty pills/tiles, composer ON, voice OFF, v1 catalog. A default that
+    # hid the composer would lock a shopper out of a working session.
+    block = _surface_wire(
+        _WidgetSurface(quick_replies=[], greeting_tiles=[], enable_text_input=True),
+        _template(),
+        catalog_active="v1",
+        ui_flavors=[],
+    )
+    assert block == WidgetSurfaceWire()
+
+
+def test_demo_response_defaults_the_block_when_unset():
+    # Constructed without ``widget`` (older call sites / tests), the model
+    # must still serialize a complete block rather than null.
+    resp = CreateDemoSessionResponse.model_construct(session_id="s1")
+    assert CreateDemoSessionResponse.model_fields["widget"].default_factory is not None
+    assert resp is not None
+
+
+def test_widget_resume_strips_llm_context_only_blocks():
+    """The embed's resume route must sanitize like the /chat routes do.
+
+    The agent persists ``visibility=internal`` blocks so the LLM keeps
+    referential memory across turns — rendered-UI summaries, the chips and
+    answer nudges, Gemini thought signatures. Those are engine internals.
+    This route had been returning rows verbatim, so they shipped to
+    whoever holds the widget token; the reference embed reads ``content``
+    and ignores ``content_blocks``, but a third-party one drawing blocks
+    rendered the engine's own prompt text as a chat bubble.
+
+    Pinned on the handler module's binding, so re-pointing it at an
+    unsanitized read fails here rather than in production.
+    """
+    from app.ai.voice.agents.breeze_buddy.chat.history.block_codec import (
+        internal_text_block,
+        plain_text_blocks,
+    )
+    from app.api.routers.breeze_buddy.widget import handlers as widget_handlers
+    from app.schemas.breeze_buddy.chat import ChatMessage, ChatMessageRole
+
+    nudge = ChatMessage.model_construct(
+        idx=1,
+        role=ChatMessageRole.USER,
+        content=None,
+        content_blocks=[internal_text_block("(you have not replied to the user yet.)")],
+        ui_blocks=None,
+    )
+    reply = ChatMessage.model_construct(
+        idx=2,
+        role=ChatMessageRole.ASSISTANT,
+        content="We have three in light grey.",
+        content_blocks=[
+            plain_text_blocks("We have three in light grey.")[0],
+            internal_text_block("[ui rendered: ProductGrid]"),
+        ],
+        ui_blocks=None,
+    )
+
+    cleaned = widget_handlers._sanitize_messages_for_widget([nudge, reply])
+
+    # The internal-only row is gone entirely; the reply survives with its
+    # visible text and without the summary.
+    assert len(cleaned) == 1
+    assert cleaned[0].content == "We have three in light grey."
+    blocks = cleaned[0].content_blocks or []
+    assert all(b.get("visibility") != "internal" for b in blocks)
+    serialized = str(cleaned)
+    assert "you have not replied" not in serialized
+    assert "ui rendered" not in serialized


### PR DESCRIPTION
## Why

The widget's presentation surface — quick replies, greeting tiles, composer visibility, voice availability, catalog version, UI flavors — is six sibling fields hand-copied across three responses: session create, session resume, and the demo session. Adding a seventh means remembering three call sites.

That has already gone wrong once. The **demo response carried only `catalog_active` + `ui_flavors`**, so a demo page structurally could not render quick replies or greeting tiles its own template defined. Nobody noticed, because nothing ties the three responses together.

This nests the same values in one `widget` block. A new surface field is added in one place and every surface gets it.

## What changed

- `WidgetSurfaceWire` (+ `QuickReplyWire` / `GreetingTileWire`) in the API schema layer, so the wire shape is stable independent of internal template-model refactors.
- `_surface_wire(surface, template, *, catalog_active, ui_flavors)` builds it from **exactly the values the flat fields are built from** — one `_WidgetSurface` object, one `catalog_active`, one `ui_flavors` — so the block and the flat fields cannot disagree while both are on the wire.
- Wired into all three responses. The demo response gains the four surface fields it was missing.

## Compatibility

**Additive. Nothing is removed or changed.** Every flat field keeps emitting the identical value it does today — verified field-for-field, and pinned by a test rather than by inspection.

The flat fields stay because embeds in the wild are cached bundles whose refresh we don't control. They can only be dropped once telemetry says nothing reads them. New embeds should read `widget`.

The client side (loom `readSurface()`) prefers the block and falls back to flat, so it works against either backend — **no lockstep deploy**, and this can land alone.

## One thing to flag

`demo.py` imports `_extract_widget_config` / `_surface_wire` from the widget router — a router reaching into another router's privates. It carries a `TODO(widget-surface)` to move all three into `widget_common.py`. I left it as an import rather than duplicating the logic, because a second copy is exactly how the demo response drifted in the first place. Happy to do the move here instead if you'd rather not merge the smell.

## Tests

New `tests/test_widget_surface_block.py`: block/flat parity from a shared surface object, all three response models expose the block, a bare template still yields a safe default (composer ON, voice OFF, v1 — a default that hid the composer would lock a shopper out), and the block serializes complete rather than null when unset.

**1206 passed**, pyrefly 0 errors, black/isort/autoflake clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a unified `widget` surface to demo, widget creation, and session resume responses.
  * Exposed widget presentation details, capabilities, catalog version, and UI options in one consistent response block.
  * Added support for greeting tiles and quick replies in widget response data.
  * Preserved existing response fields for compatibility.

* **Bug Fixes**
  * Added safe defaults for widget data when templates provide limited configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->