### PR TITLE
fix(security): password policy, credential rate limiting and token revocation (PT-16/18/19/21/22/24)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -142,6 +142,14 @@ TWILIO_ACCOUNT_SID=""
 TWILIO_AUTH_TOKEN=""
 
 # Webhook Authentication
+
+# Brute-force caps on the credential endpoints (/login, /auth/s2s/token,
+# /signup, /auth/accounts): fixed-window attempts per client IP and per
+# username/email, per hour. Set either to 0 to disable that dimension.
+# Enforcement fails open on a Redis outage so a Redis blip can't lock everyone
+# out of login (bcrypt cost still bounds throughput).
+AUTH_RATE_LIMIT_PER_IP_PER_HOUR=40
+AUTH_RATE_LIMIT_PER_USERNAME_PER_HOUR=15
 ORDER_CONFIRMATION_WEBHOOK_SECRET_KEY=""
 ORDER_CONFIRMATION_TOKEN=""
 

--- a/app/api/routers/breeze_buddy/auth/__init__.py
+++ b/app/api/routers/breeze_buddy/auth/__init__.py
@@ -13,10 +13,15 @@ Endpoints:
 For backward compatibility, old session-based logout is also supported.
 """
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Request
 from fastapi.responses import RedirectResponse
+from fastapi.security import HTTPAuthorizationCredentials
 
-from app.api.security.breeze_buddy.rbac_token import get_current_user_with_rbac
+from app.api.routers.breeze_buddy.auth.rate_limit import enforce_credential_rate_limit
+from app.api.security.breeze_buddy.rbac_token import (
+    get_current_user_with_rbac,
+    security,
+)
 from app.schemas import (
     LaunchTokenRequest,
     LaunchTokenResponse,
@@ -39,7 +44,7 @@ router = APIRouter()
 
 
 @router.post("/login", include_in_schema=False, response_model=TokenResponse)
-async def login(login_request: LoginRequest):
+async def login(login_request: LoginRequest, http_request: Request):
     """
     Login endpoint with JWT token-based authentication.
 
@@ -63,12 +68,14 @@ async def login(login_request: LoginRequest):
     Security:
         - Database users: bcrypt password hashing
         - Returns 401 if credentials are invalid or account is inactive
+        - Returns 429 if the caller IP or username is over the attempt cap
     """
+    await enforce_credential_rate_limit(http_request, login_request.username)
     return await login_handler(login_request)
 
 
 @router.post("/auth/s2s/token", response_model=S2STokenResponse)
-async def generate_s2s_token(request: S2STokenRequest):
+async def generate_s2s_token(request: S2STokenRequest, http_request: Request):
     """
     Generate long-lived token for Server-to-Server (S2S) authentication.
 
@@ -113,7 +120,9 @@ async def generate_s2s_token(request: S2STokenRequest):
     Security:
         - Returns 401 if credentials are invalid or account is inactive
         - Returns 403 if user is not an admin
+        - Returns 429 if the caller IP or username is over the attempt cap
     """
+    await enforce_credential_rate_limit(http_request, request.username)
     return await generate_s2s_token_handler(request)
 
 
@@ -199,44 +208,44 @@ async def get_current_user_info(
 
 
 @router.post("/auth/logout")
-async def logout_user():
+async def logout_user(
+    credentials: HTTPAuthorizationCredentials = Depends(security),
+    current_user: UserInfo = Depends(get_current_user_with_rbac),
+):
     """
-    Logout endpoint for JWT token-based authentication.
+    Log out a JWT-authenticated user.
 
-    Since JWT tokens are stateless and stored client-side:
-    - Backend cannot invalidate the token (no session to destroy)
-    - Client must delete the token from localStorage/cookies
-    - Token will naturally expire after its lifetime
+    The presented token is added to the server-side revocation denylist (keyed
+    by a hash of the token, with a TTL equal to its remaining lifetime), so it
+    can no longer authenticate even though its signature stays valid until its
+    natural expiry (PT-22). Clients should still discard their stored copy.
 
-    This endpoint exists for:
-    - API consistency (REST convention)
-    - Future enhancements (e.g., token blacklisting)
-    - Logging logout events
-
-    Client-side logout steps:
-    1. Call this endpoint (optional, for logging)
-    2. Remove token from localStorage/cookies
-    3. Redirect to login page
-    4. Clear any user state in application
+    Client contract: **treat every response here as a completed sign-out** and
+    clear the stored token and UI state unconditionally. The route authenticates
+    the caller, so it answers 401 when the token is already expired, already
+    revoked (a repeated logout), or otherwise invalid — all of which mean the
+    session is gone, not that logout failed.
 
     Returns:
-        {
+        200 {
             "success": true,
-            "message": "Logout acknowledged. Client should clear token from storage.",
-            "instructions": {
-                "step_1": "Remove token from localStorage or cookies",
-                "step_2": "Clear user state in your application",
-                "step_3": "Redirect to login page",
-                "note": "Token remains valid until expiration but client discards it"
-            }
+            "message": "Logout successful. Token has been revoked server-side.",
+            "revoked": true
         }
-
-    Note:
-        The actual logout happens client-side by removing the token.
-        The token remains technically valid until expiration, but the client
-        discards it and can no longer use it.
+        200 {
+            "success": false,
+            "message": "Logged out locally, but the token could not be revoked
+                        server-side and remains valid until it expires.",
+            "revoked": false
+        }
+            The denylist write failed (Redis unavailable) or the token carried
+            no usable ``exp``. Reported honestly rather than as a success,
+            because the token really does still authenticate.
+        401
+            Token missing, expired, invalid, or already revoked. Sign-out is
+            complete; discard local credentials.
     """
-    return await logout_handler()
+    return await logout_handler(credentials.credentials)
 
 
 @router.get("/logout", include_in_schema=False)

--- a/app/api/routers/breeze_buddy/auth/handlers.py
+++ b/app/api/routers/breeze_buddy/auth/handlers.py
@@ -12,6 +12,7 @@ import re
 from datetime import datetime, timedelta, timezone
 from urllib.parse import quote
 
+import jwt as pyjwt
 from fastapi import HTTPException, status
 
 from app.api.security.breeze_buddy.rbac_token import rbac_token_manager
@@ -20,8 +21,9 @@ from app.core.config.static import (
     LOOM_APP_URL,
 )
 from app.core.logger import logger
-from app.core.security.password import verify_password_async
+from app.core.security.password import DUMMY_PASSWORD_HASH, verify_password_async
 from app.core.security.scope import resolve_merchant_ids, resolve_reseller_ids
+from app.core.security.token_revocation import revoke_token
 from app.database.accessor.breeze_buddy import merchants as merchant_accessors
 from app.database.accessor.breeze_buddy.users import get_user_by_username
 from app.schemas import (
@@ -77,7 +79,7 @@ async def login_handler(
         # Verify password first to prevent username enumeration
         # Both is_active and password checks return identical error messages
         if not await verify_password_async(login_request.password, user.password_hash):
-            logger.warning(f"Failed login attempt for user: {login_request.username}")
+            logger.warning("Failed login attempt: wrong password")
             raise HTTPException(
                 status_code=status.HTTP_401_UNAUTHORIZED,
                 detail="Invalid username or password",
@@ -85,7 +87,7 @@ async def login_handler(
 
         # Check account status after password verification
         if not user.is_active:
-            logger.warning(f"Inactive user attempted login: {login_request.username}")
+            logger.warning("Failed login attempt: account inactive")
             raise HTTPException(
                 status_code=status.HTTP_401_UNAUTHORIZED,
                 detail="Invalid username or password",
@@ -149,8 +151,17 @@ async def login_handler(
             expires_in=expires_in,
         )
 
-    # Authentication failed
-    logger.warning(f"Failed login attempt for unknown user: {login_request.username}")
+    # Authentication failed: no such user. Still spend one bcrypt against a
+    # dummy hash so an unknown username can't be distinguished from a wrong
+    # password by response timing (username-enumeration oracle, PT-16). Uses the
+    # async wrapper for the same reason the real check does: this branch is the
+    # one an attacker can drive at will, so running bcrypt inline here would
+    # freeze the event loop for ~240ms per guess.
+    await verify_password_async(login_request.password, DUMMY_PASSWORD_HASH)
+    # The username is the user's email address, so it never goes to the logs:
+    # these lines are attacker-driven, which makes them both a PII sink and a
+    # place an attacker can write arbitrary text into our retained logs.
+    logger.warning("Failed login attempt: no such user")
     raise HTTPException(
         status_code=status.HTTP_401_UNAUTHORIZED,
         detail="Invalid username or password",
@@ -181,23 +192,25 @@ async def generate_s2s_token_handler(request: S2STokenRequest) -> S2STokenRespon
     # Authenticate user
     user = await get_user_by_username(request.username)
     if not user:
-        logger.warning(f"S2S token request failed: user not found - {request.username}")
+        # Spend one bcrypt against a dummy hash before failing so an unknown
+        # username is timing-indistinguishable from a wrong password — this path
+        # would otherwise reveal whether an admin account exists (PT-16).
+        await verify_password_async(request.password, DUMMY_PASSWORD_HASH)
+        logger.warning("S2S token request failed: no such user")
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid credentials"
         )
 
     # Verify password
     if not await verify_password_async(request.password, user.password_hash):
-        logger.warning(
-            f"S2S token request failed: invalid password - {request.username}"
-        )
+        logger.warning("S2S token request failed: wrong password")
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid credentials"
         )
 
     # Check if user is active
     if not user.is_active:
-        logger.warning(f"S2S token request failed: inactive user - {request.username}")
+        logger.warning("S2S token request failed: account inactive")
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Account is inactive. Please contact administrator.",
@@ -205,9 +218,7 @@ async def generate_s2s_token_handler(request: S2STokenRequest) -> S2STokenRespon
 
     # Security restriction: Only admins can generate S2S tokens
     if user.role != UserRole.ADMIN:
-        logger.warning(
-            f"S2S token request denied: non-admin user - {request.username} (role: {user.role})"
-        )
+        logger.warning(f"S2S token request denied: non-admin user (role: {user.role})")
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Only admin users can generate S2S tokens. Please contact your administrator.",
@@ -421,27 +432,59 @@ async def launch_token_handler(
     )
 
 
-async def logout_handler() -> dict:
+async def logout_handler(token: str) -> dict:
     """
     Handle logout for JWT token-based authentication.
 
-    Since JWT tokens are stateless and stored client-side:
-    - Backend cannot invalidate the token (no session to destroy)
-    - Client must delete the token from localStorage/cookies
-    - Token will naturally expire after its lifetime
+    The token is added to the server-side revocation denylist (keyed by a hash
+    of the token, with a TTL equal to its remaining lifetime), so it can no
+    longer authenticate even though its signature is still valid (PT-22).
 
     Returns:
-        Success message with logout instructions
+        Success message.
     """
-    logger.info("Logout endpoint called (token-based auth - client-side logout)")
+    try:
+        payload = pyjwt.decode(
+            token,
+            rbac_token_manager.jwt_manager.secret_key,
+            algorithms=[rbac_token_manager.jwt_manager.algorithm],
+            options={"verify_exp": False},
+        )
+        exp = int(payload.get("exp", 0))
+        if exp <= 0:
+            # A token carrying no usable expiry is exactly the one that must be
+            # denylisted — nothing else will ever invalidate it. Defaulting to 0
+            # would hand revoke_token a negative TTL, which it reads as "already
+            # expired", so it skips the write and returns True and this handler
+            # reports a revocation that never happened.
+            raise ValueError("token has no usable exp claim; cannot bound its TTL")
+        revoked = await revoke_token(token, exp)
+    except Exception as e:
+        logger.opt(exception=e).error("Logout: failed to revoke token")
+        revoked = False
+
+    logger.info(f"Logout endpoint called (token revoked={revoked})")
+
+    if not revoked:
+        # Do not claim a revocation that did not happen: revoke_token returns
+        # False when the denylist write fails (RedisService.setex swallows
+        # RedisError), and the token stays valid until it expires. A client
+        # that believed the old message would treat a live token as dead.
+        logger.error(
+            "Logout: token could NOT be added to the revocation denylist; it "
+            "remains valid until expiry"
+        )
+        return {
+            "success": False,
+            "message": (
+                "Logged out locally, but the token could not be revoked "
+                "server-side and remains valid until it expires."
+            ),
+            "revoked": False,
+        }
 
     return {
         "success": True,
-        "message": "Logout acknowledged. Client should clear token from storage.",
-        "instructions": {
-            "step_1": "Remove token from localStorage or cookies",
-            "step_2": "Clear user state in your application",
-            "step_3": "Redirect to login page",
-            "note": "Token remains valid until expiration but client discards it",
-        },
+        "message": "Logout successful. Token has been revoked server-side.",
+        "revoked": True,
     }

--- a/app/api/routers/breeze_buddy/auth/rate_limit.py
+++ b/app/api/routers/breeze_buddy/auth/rate_limit.py
@@ -1,0 +1,126 @@
+"""Brute-force rate limiting for the unauthenticated credential endpoints.
+
+Applied to ``/login``, ``/auth/s2s/token``, ``/signup`` and ``/auth/accounts``.
+Two independent fixed-window caps run before the password is ever checked:
+
+- **per client IP** (shared across all four endpoints, so an attacker can't
+  dodge the cap by spreading guesses across endpoints), and
+- **per username / email**, so a distributed guess against one account is
+  bounded even from many source IPs.
+
+This is defence-in-depth layered on top of the bcrypt cost and the timing
+equalization (PT-16) — it caps the *number* of online guesses per window; the
+bcrypt cost and the dummy-hash timing path handle per-guess cost and the
+enumeration oracle.
+
+The per-username bucket increments for any identifier string (existing account
+or not), so a ``429`` never reveals whether an account exists — it is not an
+enumeration oracle. The identifier is **SHA-256 hashed** before it becomes a
+Redis key, so an attacker-supplied username of arbitrary length can neither
+inflate key memory nor smuggle bytes into the key space — every key is a fixed
+64-hex-char digest.
+
+**Deployment requirement (per-IP cap).** The client IP is the last-hop
+``X-Forwarded-For`` value (see :func:`client_ip`). That is correct only behind a
+trusted proxy that *overwrites* inbound XFF (Cloud Run / the ingress nginx do);
+if these endpoints were ever exposed without such a proxy, a client could spoof
+``X-Forwarded-For`` to burn a victim's per-IP bucket. The per-username cap is
+unaffected by XFF and keeps a distributed guess bounded regardless.
+
+**Fail-open on Redis trouble.** ``check_rate_limit`` is called with the default
+``fail_closed=False``: if Redis is down or unconfigured the request is allowed.
+Unlike the anonymous, LLM-cost-amplifying widget endpoints (which fail closed),
+locking every operator — including admins trying to fix the incident — out of
+login during a Redis blip is worse than briefly losing this defence-in-depth
+layer; the bcrypt cost still bounds throughput. Flip the caps to tune, or raise
+them in code if a deployment wants a fail-closed posture here.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from typing import Optional
+
+from fastapi import HTTPException, Request, status
+
+from app.api.routers.breeze_buddy.widget_common import client_ip
+from app.core.config.static import (
+    AUTH_RATE_LIMIT_PER_IP_PER_HOUR,
+    AUTH_RATE_LIMIT_PER_USERNAME_PER_HOUR,
+)
+from app.core.logger import logger
+from app.services.redis.rate_limit import check_rate_limit
+
+_WINDOW_SECONDS = 3600
+_PREFIX = "auth"
+
+
+def _too_many(retry_after_seconds: int) -> HTTPException:
+    # Identical response whether the IP or the username cap tripped, and whether
+    # or not the account exists — nothing here distinguishes those cases.
+    return HTTPException(
+        status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+        detail="Too many authentication attempts. Please try again later.",
+        headers={"Retry-After": str(retry_after_seconds)},
+    )
+
+
+async def enforce_credential_rate_limit(
+    request: Request, identifier: Optional[str]
+) -> None:
+    """Raise ``429`` when the caller's IP or the target identifier is over cap.
+
+    Args:
+        request: The inbound request, used to derive the client IP (last-hop
+            ``X-Forwarded-For`` via :func:`client_ip`).
+        identifier: Username or email the request targets. May be ``None``/empty
+            (e.g. an SSO-only account-list call); the per-username cap is then
+            skipped and only the per-IP cap applies.
+    """
+    # Hash the IP before it becomes either a Redis key or a log field. An IP
+    # address is personal data, and check_rate_limit logs its own ``identifier``
+    # verbatim on the Redis-unavailable and Redis-error paths, so passing the raw
+    # value would leak it there as well as here. The digest is deterministic, so
+    # the per-IP bucket is still shared across pods.
+    ip_key = hashlib.sha256(client_ip(request).encode("utf-8")).hexdigest()
+    ip_decision = await check_rate_limit(
+        bucket="credential_ip",
+        identifier=ip_key,
+        limit=AUTH_RATE_LIMIT_PER_IP_PER_HOUR,
+        window_seconds=_WINDOW_SECONDS,
+        prefix=_PREFIX,
+    )
+    if not ip_decision.allowed:
+        logger.warning(
+            f"auth rate limit hit (per-IP {ip_decision.count}/{ip_decision.limit}) "
+            f"for ip hash {ip_key[:16]}"
+        )
+        raise _too_many(ip_decision.retry_after_seconds)
+
+    username = (identifier or "").strip().lower()
+    if not username:
+        return
+
+    # Hash the attacker-supplied identifier so the Redis key is a fixed-length
+    # digest — an arbitrarily long username can't inflate key memory or inject
+    # bytes into the key space. Hashing is deterministic, so the per-username
+    # bucket is still shared across pods.
+    username_key = hashlib.sha256(username.encode("utf-8")).hexdigest()
+
+    user_decision = await check_rate_limit(
+        bucket="credential_user",
+        identifier=username_key,
+        limit=AUTH_RATE_LIMIT_PER_USERNAME_PER_HOUR,
+        window_seconds=_WINDOW_SECONDS,
+        prefix=_PREFIX,
+    )
+    if not user_decision.allowed:
+        # Log a bounded prefix of the *hashed* identifier. It is stable across
+        # requests, so ops can still correlate repeated hits on one bucket, and
+        # no username or email address reaches the logs.
+        logger.warning(
+            f"auth rate limit hit (per-username "
+            f"{user_decision.count}/{user_decision.limit}) for "
+            f"identifier hash {username_key[:16]}"
+        )
+        raise _too_many(user_decision.retry_after_seconds)

--- a/app/api/routers/breeze_buddy/chat/demo.py
+++ b/app/api/routers/breeze_buddy/chat/demo.py
@@ -47,6 +47,7 @@ from app.api.routers.breeze_buddy.widget.handlers import (
     _extract_widget_config,
     _surface_wire,
 )
+from app.api.routers.breeze_buddy.widget_common import client_ip
 from app.api.security.breeze_buddy.demo_token import (
     DemoSessionContext,
     mint_demo_token,
@@ -85,28 +86,11 @@ router = APIRouter()
 _RATE_WINDOW_SECONDS = 3600
 
 
-def _client_ip(request: Request) -> str:
-    """Best-effort caller IP for rate-limit keying.
-
-    Honours ``X-Forwarded-For`` (first hop) when present so a load
-    balancer / reverse proxy doesn't make every visitor share one
-    bucket. Falls back to ``request.client.host``. Returns ``unknown``
-    if both are missing — treated as one shared bucket, which is the
-    safest default.
-    """
-    forwarded = request.headers.get("x-forwarded-for")
-    if forwarded:
-        return forwarded.split(",")[0].strip() or "unknown"
-    if request.client and request.client.host:
-        return request.client.host
-    return "unknown"
-
-
 async def _enforce_ip_limit(*, request: Request, bucket: str, limit: int) -> None:
     """Raise 429 with ``Retry-After`` if ``request``'s IP is over ``limit``."""
     decision = await check_rate_limit(
         bucket=bucket,
-        identifier=_client_ip(request),
+        identifier=client_ip(request),
         limit=limit,
         window_seconds=_RATE_WINDOW_SECONDS,
         prefix="demo",

--- a/app/api/routers/breeze_buddy/signup/__init__.py
+++ b/app/api/routers/breeze_buddy/signup/__init__.py
@@ -13,8 +13,9 @@ Endpoints:
   POST /auth/switch-account — switch to sibling account (authenticated)
 """
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Request
 
+from app.api.routers.breeze_buddy.auth.rate_limit import enforce_credential_rate_limit
 from app.api.security.breeze_buddy.rbac_token import get_current_user_with_rbac
 from app.schemas import TokenResponse, UserInfo
 from app.schemas.breeze_buddy.signup import (
@@ -46,7 +47,10 @@ router = APIRouter()
     summary="Merchant self-service registration (username/password)",
     tags=["signup"],
 )
-async def signup_with_password(request: MerchantSignupRequest) -> TokenResponse:
+async def signup_with_password(
+    request: MerchantSignupRequest, http_request: Request
+) -> TokenResponse:
+    await enforce_credential_rate_limit(http_request, request.username)
     return await signup_with_password_handler(request)
 
 
@@ -77,9 +81,12 @@ async def google_signup(request: GoogleMerchantSignupRequest) -> TokenResponse:
     summary="List all accounts for an email (account picker)",
     tags=["signup"],
 )
-async def list_accounts(request: ListAccountsRequest) -> AccountsResponse:
+async def list_accounts(
+    request: ListAccountsRequest, http_request: Request
+) -> AccountsResponse:
+    await enforce_credential_rate_limit(http_request, request.email)
     accounts = await list_accounts_handler(
-        id_token=request.id_token, email=request.email
+        id_token=request.id_token, email=request.email, password=request.password
     )
     return AccountsResponse(accounts=accounts)
 
@@ -90,7 +97,14 @@ async def list_accounts(request: ListAccountsRequest) -> AccountsResponse:
     summary="Select an account and mint JWT",
     tags=["signup"],
 )
-async def select_account(request: SelectAccountRequest) -> TokenResponse:
+async def select_account(
+    request: SelectAccountRequest, http_request: Request
+) -> TokenResponse:
+    # This endpoint verifies a password too, so it needs the same cap as
+    # /auth/accounts and /auth/login. Without it an attacker who knows an
+    # account_id can guess passwords here at full speed and never touch a
+    # rate-limited route (PT-19). Bucketed on the account being targeted.
+    await enforce_credential_rate_limit(http_request, request.account_id)
     return await select_account_handler(
         account_id=request.account_id,
         id_token=request.id_token,

--- a/app/api/routers/breeze_buddy/signup/handlers.py
+++ b/app/api/routers/breeze_buddy/signup/handlers.py
@@ -53,7 +53,7 @@ from app.core.config.static import (
     SELF_SIGNUP_RESELLER_ID,
 )
 from app.core.logger import logger
-from app.core.security.password import verify_password_async
+from app.core.security.password import DUMMY_PASSWORD_HASH, verify_password_async
 from app.core.security.scope import resolve_merchant_ids, resolve_reseller_ids
 from app.database.accessor.breeze_buddy import (
     merchants as merchant_accessors,
@@ -66,6 +66,12 @@ from app.schemas.breeze_buddy.signup import (
     GoogleMerchantSignupRequest,
     MerchantSignupRequest,
 )
+
+# Fixed bcrypt budget for the account-list password check. Every request spends
+# exactly this many verifications regardless of how many accounts share the
+# email, so response time cannot be used to count them (PT-16). Raising it costs
+# latency on every call; lowering it truncates multi-account emails sooner.
+ACCOUNT_PASSWORD_CHECK_BUDGET = 5
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Helpers
@@ -411,17 +417,20 @@ async def google_signup_handler(request: GoogleMerchantSignupRequest) -> TokenRe
 async def list_accounts_handler(
     id_token: str | None,
     email: str | None,
+    password: str | None = None,
 ) -> list:
     """
-    Return all user accounts that share a given email address.
+    Return the user accounts that share a given email address.
 
-    Called immediately after Google OAuth or password auth succeeds to
-    give the frontend a list of accounts the user can pick from.
+    Called immediately after Google OAuth or password auth to give the
+    frontend a list of accounts the user can pick from.
 
-    For Google flows: pass `id_token` — the backend verifies it and
-    extracts the email.
-    For password flows: pass `email` directly (already verified by the
-    login handler upstream, so no re-auth needed here).
+    For Google flows: pass `id_token` — the backend verifies it.
+    For password flows: pass `email` AND `password`. The password is
+    verified here so this endpoint cannot be used anonymously to enumerate
+    accounts / PII by email (PT-16). Only accounts whose password matches
+    are returned; any failure yields an identical generic 401 so registration
+    status is not disclosed.
     """
     if id_token:
         claims = await _verify_google_id_token(id_token)
@@ -431,15 +440,54 @@ async def list_accounts_handler(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail="Google account does not have an email address.",
             )
-    elif email:
-        resolved_email = email
+        users = await user_accessors.get_users_by_email(resolved_email)
+        matched = [u for u in users if u.is_active]
+    elif email and password:
+        # Fetch unconditionally so an unregistered email takes the same code
+        # path/timing as a registered one with a wrong password (PT-16).
+        #
+        # The bcrypt count must also be CONSTANT, not just non-zero: verifying
+        # once per candidate leaks the *number* of accounts sharing an email
+        # through response time (N accounts => N bcrypts, 0 => 1). We therefore
+        # spend exactly ACCOUNT_PASSWORD_CHECK_BUDGET verifications on every
+        # request, padding with the dummy hash.
+        users = await user_accessors.get_users_by_email(email)
+        candidates = [u for u in users if u.is_active][:ACCOUNT_PASSWORD_CHECK_BUDGET]
+        if len(users) > ACCOUNT_PASSWORD_CHECK_BUDGET:
+            # Pathological (one email, many accounts): the tail is not checked,
+            # which is preferred over reintroducing a variable-time oracle.
+            logger.warning(
+                f"account-list: {len(users)} accounts share an email; only the "
+                f"first {ACCOUNT_PASSWORD_CHECK_BUDGET} are password-checked"
+            )
+        matched = [
+            u
+            for u in candidates
+            # Substitute the dummy hash for any user missing a password hash so
+            # such an account can never match and never triggers an error path
+            # (defensive: password_hash is NOT NULL today, so this is unreached).
+            if await verify_password_async(
+                password, u.password_hash or DUMMY_PASSWORD_HASH
+            )
+            and u.password_hash
+        ]
+        for _ in range(ACCOUNT_PASSWORD_CHECK_BUDGET - len(candidates)):
+            await verify_password_async(password, DUMMY_PASSWORD_HASH)
+        if not matched:
+            # No email in the message: failed attempts are attacker-controlled,
+            # so interpolating it both logs PII and lets an attacker write
+            # arbitrary addresses into our retained logs. Request-correlation
+            # context is enough to trace a single caller.
+            logger.warning("Failed account-list attempt")
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Invalid email or password.",
+            )
     else:
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-            detail="Either id_token or email must be provided.",
+            detail="Provide either id_token, or email together with password.",
         )
-
-    users = await user_accessors.get_users_by_email(resolved_email)
 
     return [
         AccountSummary(
@@ -451,8 +499,7 @@ async def list_accounts_handler(
             reseller_ids=u.reseller_ids,
             is_active=u.is_active,
         )
-        for u in users
-        if u.is_active
+        for u in matched
     ]
 
 
@@ -496,7 +543,16 @@ async def select_account_handler(
                 detail="Google account does not match the selected account.",
             )
     elif password:
-        # Password: verify against stored hash
+        # Password: verify against stored hash. An SSO-only account may have no
+        # usable hash; bcrypt raises ValueError on an empty hash, which would
+        # surface as a 500. Spend a dummy verification so this branch stays
+        # timing-indistinguishable from a wrong password, then 401.
+        if not target.password_hash:
+            await verify_password_async(password, DUMMY_PASSWORD_HASH)
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Incorrect password.",
+            )
         if not await verify_password_async(password, target.password_hash):
             raise HTTPException(
                 status_code=status.HTTP_401_UNAUTHORIZED,

--- a/app/api/routers/breeze_buddy/stt/handlers.py
+++ b/app/api/routers/breeze_buddy/stt/handlers.py
@@ -256,7 +256,7 @@ async def handle_transcription_stream(ws: WebSocket) -> None:
     await ws.accept()
 
     try:
-        user = get_user_from_websocket(ws)
+        user = await get_user_from_websocket(ws)
     except HTTPException as e:
         await _reject_stream(ws, _WS_UNAUTHORIZED, str(e.detail), "unauthorized")
         return

--- a/app/api/routers/breeze_buddy/webhooks/breeze/services.py
+++ b/app/api/routers/breeze_buddy/webhooks/breeze/services.py
@@ -87,7 +87,7 @@ async def handle_breeze(
     # rejected even though it still matches the presented value (this is how it
     # is "revoked": let it expire or re-register the merchant to mint a fresh
     # one).
-    rbac_token_manager.verify_rbac_token(stored_token)
+    await rbac_token_manager.verify_rbac_token(stored_token)
 
     try:
         order = json.loads(raw_body) if raw_body else {}

--- a/app/api/routers/breeze_buddy/webhooks/woocommerce/services.py
+++ b/app/api/routers/breeze_buddy/webhooks/woocommerce/services.py
@@ -89,7 +89,7 @@ async def handle_woocommerce(
     # The stored token is a JWT — verify it so an expired/rotated token is
     # rejected even though its HMAC still matches (this is how it is "revoked":
     # let it expire or re-register the merchant to mint a fresh one).
-    rbac_token_manager.verify_rbac_token(token)
+    await rbac_token_manager.verify_rbac_token(token)
 
     try:
         order = json.loads(raw_body) if raw_body else {}

--- a/app/api/routers/breeze_buddy/widget_common.py
+++ b/app/api/routers/breeze_buddy/widget_common.py
@@ -41,6 +41,16 @@ from app.services.redis.rate_limit import check_rate_limit
 _RATE_WINDOW_SECONDS = 3600
 _RATE_LIMIT_PREFIX = "widget"
 
+# The Origin header is spoofable from a non-browser client and the
+# public_widget_key is public, so per-IP limits alone don't bound a merchant's
+# aggregate spend once an attacker rotates source IPs (PT-18). This multiplier
+# turns each per-IP cap into an additional key-wide (cross-IP) cap, so no single
+# action can be amplified past `multiplier x per-IP limit` no matter how many
+# IPs are used. Each action keeps its own counter (see
+# _enforce_widget_aggregate_limit), so the ceiling on a key is the sum of its
+# per-action caps rather than one shared budget.
+_WIDGET_AGGREGATE_MULTIPLIER = 20
+
 
 def client_ip(request: Request) -> str:
     """Best-effort caller IP for rate-limit keying.
@@ -137,6 +147,41 @@ async def _enforce_widget_ip_limit(
     )
 
 
+async def _enforce_widget_aggregate_limit(
+    *, bucket: str, limit: int, widget_config_id: str
+) -> None:
+    """Raise 429 when one public_widget_key exceeds this action's cross-IP cap.
+
+    Keyed on ``widget_config_id`` ONLY (no client IP), so rotating source IPs
+    cannot escape it (PT-18). Fail-closed on Redis outage, like the per-IP cap.
+
+    Note the cap is *per action type*, not one shared budget: the bucket name is
+    part of the key, so ``message`` and ``transcribe`` each carry their own
+    cross-IP ceiling. That is deliberate — the per-action limits differ by an
+    order of magnitude, and collapsing them into one counter would let cheap
+    calls exhaust the budget for expensive ones. It does mean total spend on a
+    key is bounded by the *sum* of the per-action caps, not by any single one.
+    """
+    decision = await check_rate_limit(
+        bucket=f"{bucket}:agg",
+        identifier=widget_config_id,
+        limit=limit,
+        window_seconds=_RATE_WINDOW_SECONDS,
+        prefix=_RATE_LIMIT_PREFIX,
+        fail_closed=True,
+    )
+    if decision.allowed:
+        return
+    raise HTTPException(
+        status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+        detail=(
+            f"Widget usage limit hit ({decision.count}/{decision.limit} per hour "
+            "for this widget). Try again later."
+        ),
+        headers={"Retry-After": str(decision.retry_after_seconds)},
+    )
+
+
 async def resolve_widget_config_for_request(
     *,
     request: Request,
@@ -205,6 +250,13 @@ async def resolve_widget_config_for_request(
         limit=effective_limit,
         widget_config_id=cfg.id,
     )
+    # Cross-IP aggregate cap so IP rotation can't run up unbounded spend on this
+    # merchant's public_widget_key (PT-18).
+    await _enforce_widget_aggregate_limit(
+        bucket=rate_bucket,
+        limit=effective_limit * _WIDGET_AGGREGATE_MULTIPLIER,
+        widget_config_id=cfg.id,
+    )
     return cfg
 
 
@@ -224,6 +276,12 @@ async def enforce_widget_ip_limit(
         request=request,
         bucket=bucket,
         limit=limit,
+        widget_config_id=widget_config_id,
+    )
+    # Cross-IP aggregate cap on this follow-up action too (PT-18).
+    await _enforce_widget_aggregate_limit(
+        bucket=bucket,
+        limit=limit * _WIDGET_AGGREGATE_MULTIPLIER,
         widget_config_id=widget_config_id,
     )
 

--- a/app/api/routers/feature_flags/rbac.py
+++ b/app/api/routers/feature_flags/rbac.py
@@ -17,7 +17,7 @@ async def get_current_user_with_role(
             status_code=401,
             detail="Authorization header missing",
         )
-    return rbac_token_manager.verify_rbac_token(credentials.credentials)
+    return await rbac_token_manager.verify_rbac_token(credentials.credentials)
 
 
 def require_admin(current_user: UserInfo) -> None:

--- a/app/api/security/breeze_buddy/rbac_token.py
+++ b/app/api/security/breeze_buddy/rbac_token.py
@@ -12,6 +12,7 @@ from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 
 from app.core.logger import logger
 from app.core.security.jwt import jwt_manager
+from app.core.security.token_revocation import is_token_revoked
 from app.schemas import UserInfo, UserRole
 
 # HTTP Bearer security scheme
@@ -74,9 +75,13 @@ class BreezeBuddyRBACTokenManager:
         # Use the generic JWT manager to create the token
         return self.jwt_manager.create_access_token(payload, expires_delta)
 
-    def verify_rbac_token(self, token: str) -> UserInfo:
+    async def verify_rbac_token(self, token: str) -> UserInfo:
         """
         Verify and decode a JWT token with Breeze Buddy RBAC information.
+
+        Also enforces server-side revocation (denylist) and a per-request user
+        liveness recheck, so a logged-out/forged token can be killed and a
+        disabled/deleted account's tokens stop working (PT-22).
 
         Args:
             token: JWT token string
@@ -143,6 +148,43 @@ class BreezeBuddyRBACTokenManager:
                     detail="Could not validate credentials",
                     headers={"WWW-Authenticate": "Bearer"},
                 )
+
+            # Server-side revocation: a token that was logged out or explicitly
+            # revoked is rejected regardless of its (still-valid) signature.
+            if await is_token_revoked(token):
+                logger.warning(f"RBAC verifier: rejected revoked token for {user_id}")
+                raise HTTPException(
+                    status_code=status.HTTP_401_UNAUTHORIZED,
+                    detail="Could not validate credentials",
+                    headers={"WWW-Authenticate": "Bearer"},
+                )
+
+            # Liveness recheck: a disabled/deleted account's outstanding tokens
+            # (including long-lived S2S tokens, whose ``sub`` is the minting
+            # user) must stop working immediately.
+            #
+            # Exception: launch tokens (POST /auth/launch-token) authenticate a
+            # *virtual* merchant subject ("merchant:<id>") that has no backing
+            # ``users`` row by design, so a users-table liveness probe would
+            # always fail closed for them. They are bounded instead by a fixed
+            # 60-minute TTL, the merchant liveness check performed at mint time,
+            # the signed ``src`` provenance claim, and the revocation denylist
+            # checked just above (which still applies to them). Keep this
+            # prefix in lockstep with the ``sub`` minted in launch_token_handler.
+            # Imported lazily to avoid a module-load import cycle with the DB
+            # accessor layer.
+            if not str(user_id).startswith("merchant:"):
+                from app.database.accessor.breeze_buddy.users import is_user_active
+
+                if not await is_user_active(user_id):
+                    logger.warning(
+                        f"RBAC verifier: rejected token for inactive/deleted user {user_id}"
+                    )
+                    raise HTTPException(
+                        status_code=status.HTTP_401_UNAUTHORIZED,
+                        detail="Could not validate credentials",
+                        headers={"WWW-Authenticate": "Bearer"},
+                    )
 
             # Extract Breeze Buddy RBAC data
             # Normalize legacy "shop" role to "user" for old JWTs still in circulation
@@ -269,10 +311,10 @@ async def get_current_user_with_rbac(
             headers={"WWW-Authenticate": "Bearer"},
         )
 
-    return rbac_token_manager.verify_rbac_token(credentials.credentials)
+    return await rbac_token_manager.verify_rbac_token(credentials.credentials)
 
 
-def get_user_from_websocket(websocket: WebSocket) -> UserInfo:
+async def get_user_from_websocket(websocket: WebSocket) -> UserInfo:
     """Authenticate a WebSocket connection with the standard RBAC bearer token.
 
     The FastAPI ``Depends(HTTPBearer())`` guards are HTTP-only, so WebSocket
@@ -295,7 +337,7 @@ def get_user_from_websocket(websocket: WebSocket) -> UserInfo:
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Missing credentials",
         )
-    return rbac_token_manager.verify_rbac_token(token)
+    return await rbac_token_manager.verify_rbac_token(token)
 
 
 async def get_active_user(

--- a/app/core/config/static.py
+++ b/app/core/config/static.py
@@ -540,6 +540,20 @@ ENABLE_SIGTERM_HANDLER = (
 BOT_MAX_DRAIN_SECONDS = int(os.environ.get("BOT_MAX_DRAIN_SECONDS", "25"))
 
 # Redis Configuration
+# Brute-force rate limiting for the unauthenticated credential endpoints
+# (/login, /auth/s2s/token, /signup, /auth/accounts). Fixed-window caps per
+# client IP and per username/email, layered on top of bcrypt + the timing
+# equalization (PT-16) so online guessing is bounded. Set a cap to 0 to disable
+# that dimension. Enforcement fails OPEN on a Redis outage (see
+# app/api/routers/breeze_buddy/auth/rate_limit.py) so a Redis blip can't lock
+# every operator out of login.
+AUTH_RATE_LIMIT_PER_IP_PER_HOUR = int(
+    os.environ.get("AUTH_RATE_LIMIT_PER_IP_PER_HOUR", "40")
+)
+AUTH_RATE_LIMIT_PER_USERNAME_PER_HOUR = int(
+    os.environ.get("AUTH_RATE_LIMIT_PER_USERNAME_PER_HOUR", "15")
+)
+
 REDIS_HOST = os.getenv("REDIS_HOST", "")
 REDIS_PORT = os.getenv("REDIS_PORT", "")
 REDIS_CLUSTER_NODES = os.getenv("REDIS_CLUSTER_NODES", "")

--- a/app/core/security/password/__init__.py
+++ b/app/core/security/password/__init__.py
@@ -1,0 +1,45 @@
+"""Password handling: bcrypt primitives and the shared strength policy.
+
+Two concerns, deliberately kept in separate modules but exported from one
+package so callers import from a single place:
+
+- ``password``        -> bcrypt hashing/verification (``hash_password``,
+                         ``verify_password``, their ``_async`` wrappers, and
+                         ``DUMMY_PASSWORD_HASH``)
+- ``password_policy`` -> the strength rules enforced wherever a password is
+                         set (``validate_password_strength``)
+
+Import from the package (``from app.core.security.password import ...``)
+rather than reaching into the submodules, so the internal split can change
+without touching call sites.
+"""
+
+from app.core.security.password.password import (
+    DUMMY_PASSWORD_HASH,
+    PasswordHasher,
+    check_password_hash,
+    generate_password_hash,
+    hash_password,
+    hash_password_async,
+    verify_password,
+    verify_password_async,
+)
+from app.core.security.password.password_policy import (
+    MAX_PASSWORD_BYTES,
+    MIN_PASSWORD_LENGTH,
+    validate_password_strength,
+)
+
+__all__ = [
+    "DUMMY_PASSWORD_HASH",
+    "MAX_PASSWORD_BYTES",
+    "MIN_PASSWORD_LENGTH",
+    "PasswordHasher",
+    "check_password_hash",
+    "generate_password_hash",
+    "hash_password",
+    "hash_password_async",
+    "validate_password_strength",
+    "verify_password",
+    "verify_password_async",
+]

--- a/app/core/security/password/password.py
+++ b/app/core/security/password/password.py
@@ -36,11 +36,10 @@ class PasswordHasher:
         if not password or not isinstance(password, str):
             raise ValueError("Password must be a non-empty string")
 
-        if len(password) > 72:
-            # bcrypt has a 72-byte password limit
-            logger.warning(
-                "Password exceeds 72 characters, will be truncated by bcrypt"
-            )
+        if len(password.encode("utf-8")) > 72:
+            # bcrypt silently truncates beyond 72 bytes — reject rather than
+            # hash a truncated password (PT-24).
+            raise ValueError("Password exceeds bcrypt's 72-byte limit")
 
         try:
             # Generate salt and hash password
@@ -189,3 +188,17 @@ async def hash_password_async(password: str) -> str:
 async def verify_password_async(plain_password: str, hashed_password: str) -> bool:
     """Verify a password against a hash, off the event loop. See module note above."""
     return await asyncio.to_thread(verify_password, plain_password, hashed_password)
+
+
+# A throwaway bcrypt hash. Auth handlers run verify_password against this on the
+# no-such-user branch so an unknown username costs the same bcrypt time as a real
+# wrong-password check, closing the username-enumeration timing oracle (PT-16).
+#
+# It is a literal rather than hash_password(secrets.token_urlsafe(32)) because
+# that ran a full cost-12 bcrypt (~240ms) at *import* time, once per worker cold
+# start, delaying readiness on every process spawn. Verification against this
+# constant costs exactly the same as against a real hash — cost is encoded in the
+# `$2b$12$` prefix — so the timing-oracle defence is unchanged; only the one-time
+# generation moved to authoring time. Generated with bcrypt.gensalt(rounds=12)
+# from a random token that was discarded, so no plaintext can ever match it.
+DUMMY_PASSWORD_HASH = "$2b$12$.TwTi1MaeS6pyuwvuDBNhehyd1cXh6HKhQqst/Zq9.KobZiF/v0YS"

--- a/app/core/security/password/password_policy.py
+++ b/app/core/security/password/password_policy.py
@@ -1,0 +1,99 @@
+"""
+Shared password-strength policy for self-signup and admin-created accounts.
+
+One policy, enforced everywhere a password is set, so the bar can't drift
+between signup and user management. The check is self-contained (no external
+breach-API call in the request path) — it enforces a strong minimum length,
+character-class diversity, a small embedded deny-list of the most common
+passwords, and rejects passwords that contain the user's own identifiers.
+bcrypt's 72-byte truncation is treated as an error rather than silently
+accepted (PT-24).
+"""
+
+import re
+from typing import List, Optional
+
+MIN_PASSWORD_LENGTH = 12
+MAX_PASSWORD_BYTES = 72  # bcrypt silently truncates beyond this — reject instead.
+
+# A tiny high-signal deny-list. Not exhaustive (a full breach corpus belongs in
+# an offline check), but blocks the passwords guessed first.
+_COMMON_PASSWORDS = frozenset(
+    {
+        "password",
+        "password1",
+        "password123",
+        "passw0rd",
+        "123456",
+        "12345678",
+        "123456789",
+        "1234567890",
+        "qwerty",
+        "qwerty123",
+        "111111",
+        "abc123",
+        "letmein",
+        "welcome",
+        "welcome1",
+        "admin",
+        "admin123",
+        "iloveyou",
+        "monkey",
+        "dragon",
+        "football",
+        "changeme",
+        "secret",
+        "master",
+        "google",
+        "whatever",
+        "trustno1",
+    }
+)
+
+_UPPER = re.compile(r"[A-Z]")
+_LOWER = re.compile(r"[a-z]")
+_DIGIT = re.compile(r"\d")
+_SYMBOL = re.compile(r"[^A-Za-z0-9]")
+
+
+def validate_password_strength(
+    password: str, *, disallowed_substrings: Optional[List[str]] = None
+) -> None:
+    """Raise ValueError if the password is too weak.
+
+    Args:
+        password: The candidate password.
+        disallowed_substrings: Identifiers (username, merchant_id, email
+            local-part) the password must not contain — case-insensitive.
+    """
+    if not isinstance(password, str) or not password:
+        raise ValueError("Password must be a non-empty string.")
+
+    if len(password.encode("utf-8")) > MAX_PASSWORD_BYTES:
+        raise ValueError(
+            f"Password must be at most {MAX_PASSWORD_BYTES} bytes "
+            "(bcrypt truncates longer passwords)."
+        )
+
+    if len(password) < MIN_PASSWORD_LENGTH:
+        raise ValueError(
+            f"Password must be at least {MIN_PASSWORD_LENGTH} characters long."
+        )
+
+    classes = sum(bool(rx.search(password)) for rx in (_UPPER, _LOWER, _DIGIT, _SYMBOL))
+    if classes < 3:
+        raise ValueError(
+            "Password must include at least three of: uppercase, lowercase, "
+            "digit, and symbol."
+        )
+
+    if password.lower() in _COMMON_PASSWORDS:
+        raise ValueError("This password is too common. Choose a different one.")
+
+    lowered = password.lower()
+    for raw in disallowed_substrings or []:
+        piece = (raw or "").strip().lower()
+        if piece and piece in lowered:
+            raise ValueError(
+                "Password must not contain your username, email, or merchant id."
+            )

--- a/app/core/security/token_revocation.py
+++ b/app/core/security/token_revocation.py
@@ -1,0 +1,52 @@
+"""
+Server-side JWT revocation denylist (Redis-backed).
+
+Keyed by a SHA-256 hash of the raw token, so it retroactively covers every
+already-issued token without needing a `jti` claim or a re-mint. Entries are
+stored with a TTL equal to the token's remaining lifetime, so the denylist
+self-cleans as tokens expire.
+
+Fail-open on Redis errors: a Redis outage must not lock out every user (tokens
+still expire naturally, and this denylist is one layer among several). The
+liveness recheck and short-TTL guidance in PT-22 complement it.
+"""
+
+import hashlib
+import math
+import time
+
+from app.core.logger import logger
+from app.services.redis.client import get_redis_service
+
+_REVOKED_PREFIX = "jwt:revoked:"
+
+
+def _denylist_key(token: str) -> str:
+    return _REVOKED_PREFIX + hashlib.sha256(token.encode("utf-8")).hexdigest()
+
+
+async def revoke_token(token: str, exp: int) -> bool:
+    """Add a token to the denylist until its own expiry. Returns success."""
+    # Round up rather than truncate: int() turns a token with 0.4s of life left
+    # into ttl == 0, which takes the "already expired" path below and reports
+    # success without ever writing the denylist entry — while the token still
+    # authenticates for the remainder of that second.
+    ttl = math.ceil(exp - time.time())
+    if ttl <= 0:
+        return True  # genuinely expired — nothing to revoke
+    try:
+        redis = await get_redis_service()
+        return await redis.setex(_denylist_key(token), "1", ttl_seconds=ttl)
+    except Exception as e:
+        logger.error(f"Failed to revoke JWT: {e}")
+        return False
+
+
+async def is_token_revoked(token: str) -> bool:
+    """True if the token has been revoked. Fails open (False) on Redis error."""
+    try:
+        redis = await get_redis_service()
+        return await redis.exists(_denylist_key(token))
+    except Exception as e:
+        logger.error(f"Token revocation check failed (failing open): {e}")
+        return False

--- a/app/database/accessor/breeze_buddy/users.py
+++ b/app/database/accessor/breeze_buddy/users.py
@@ -34,6 +34,7 @@ from app.database.queries.breeze_buddy.users import (
 )
 from app.schemas.breeze_buddy.auth import UserInDB, UserRole
 from app.schemas.breeze_buddy.users import UserResponse
+from app.services.redis.client import get_redis_service
 
 
 async def check_username_exists(username: str) -> bool:
@@ -120,6 +121,71 @@ async def get_user_in_db_by_id(user_id: str) -> Optional[UserInDB]:
     except Exception as e:
         logger.error(f"Error fetching user by id '{user_id}': {e}")
         raise
+
+
+# Short-lived cache so the per-request liveness recheck (PT-22) is not a DB
+# round-trip on every authenticated call.
+#
+# Disabling an account takes effect immediately on the happy path, because
+# update/delete call invalidate_user_active_cache(). The TTL bounds the
+# WORST case only — if that invalidation is lost (Redis blip, or an account
+# disabled by a path that bypasses the accessor), a cached "active" answer can
+# survive at most this many seconds. It is deliberately not the primary
+# control: token revocation (token_revocation.py) is uncached and is the
+# hard-stop for a compromised token.
+_USER_ACTIVE_CACHE_TTL = 10
+_USER_ACTIVE_CACHE_PREFIX = "user_active:"
+
+
+async def is_user_active(user_id: str) -> bool:
+    """Return whether a user exists and is active.
+
+    Cached in Redis for a few seconds. A *Redis* failure fails OPEN: the cache is
+    only an optimisation, and the authoritative DB read still runs behind it.
+
+    A *database* failure fails CLOSED. Returning True there would accept tokens
+    belonging to disabled and deleted users for as long as the database was
+    unreachable, which is precisely the window an attacker with a stolen token
+    wants. Failing closed costs little in practice: every authenticated handler
+    reads the database anyway, so a database outage is not a state in which
+    requests would otherwise be served.
+    """
+    cache_key = f"{_USER_ACTIVE_CACHE_PREFIX}{user_id}"
+    try:
+        redis = await get_redis_service()
+        cached = await redis.get(cache_key)
+        if cached is not None:
+            return cached == "1"
+    except Exception as e:
+        logger.error(f"user-active cache read failed for {user_id}: {e}")
+
+    try:
+        user = await get_user_in_db_by_id(user_id)
+        active = bool(user and user.is_active)
+    except Exception as e:
+        logger.opt(exception=e).error(
+            "user-active DB lookup failed for {} (failing closed)", user_id
+        )
+        return False
+
+    try:
+        redis = await get_redis_service()
+        await redis.setex(
+            cache_key, "1" if active else "0", ttl_seconds=_USER_ACTIVE_CACHE_TTL
+        )
+    except Exception as e:
+        logger.error(f"user-active cache write failed for {user_id}: {e}")
+
+    return active
+
+
+async def invalidate_user_active_cache(user_id: str) -> None:
+    """Drop the cached liveness flag so a status change takes effect at once."""
+    try:
+        redis = await get_redis_service()
+        await redis.delete(f"{_USER_ACTIVE_CACHE_PREFIX}{user_id}")
+    except Exception as e:
+        logger.error(f"user-active cache invalidation failed for {user_id}: {e}")
 
 
 async def create_merchant_and_user_atomically(
@@ -405,6 +471,10 @@ async def update_user(
 
             if row:
                 logger.info(f"Updated user: {user_id}")
+                if is_active is not None:
+                    # Status changed — drop the liveness cache so a disable
+                    # takes effect on the very next request (PT-22).
+                    await invalidate_user_active_cache(user_id)
                 return decode_user(row)
 
             return None
@@ -434,6 +504,8 @@ async def delete_user(user_id: str) -> bool:
 
         if row:
             logger.info(f"Deleted user: {user_id}")
+            # Cut off any outstanding tokens for the deleted user immediately.
+            await invalidate_user_active_cache(user_id)
             return True
 
         check_query = "SELECT role FROM users WHERE id = $1"

--- a/app/schemas/breeze_buddy/auth.py
+++ b/app/schemas/breeze_buddy/auth.py
@@ -6,6 +6,13 @@ from typing import List, Optional
 
 from pydantic import BaseModel, Field
 
+# PT-21. Every path that mints a long-lived S2S token must bound it by this,
+# not by its own literal — there is more than one such path (POST /auth/s2s/token
+# and POST /merchant with issue_token=true), and they both hand the value
+# straight to rbac_token_manager.create_access_token_with_rbac. A per-schema
+# literal is how the two drifted to 365 and 365000 in the first place.
+MAX_S2S_TOKEN_LIFETIME_DAYS = 365
+
 
 class TokenData(BaseModel):
     """Token data model for JWT payload (legacy)"""
@@ -61,7 +68,10 @@ class LoginRequest(BaseModel):
     """Login request model"""
 
     username: str
-    password: str
+    # min_length=1: bcrypt's verifier rejects an empty plaintext with
+    # ValueError, which would surface as a 500 instead of the generic 401.
+    # Fail at the schema boundary (422) so it never reaches verify_password.
+    password: str = Field(..., min_length=1)
 
 
 class LoginResponse(BaseModel):
@@ -83,9 +93,13 @@ class S2STokenRequest(BaseModel):
     """S2S token generation request model"""
 
     username: str
-    password: str
+    # See LoginRequest.password — empty plaintext must 422, never reach bcrypt.
+    password: str = Field(..., min_length=1)
     token_lifetime_days: int = Field(
-        default=365, ge=1, le=365000, description="Token lifetime in days (1-365000)"
+        default=MAX_S2S_TOKEN_LIFETIME_DAYS,
+        ge=1,
+        le=MAX_S2S_TOKEN_LIFETIME_DAYS,
+        description=f"Token lifetime in days (1-{MAX_S2S_TOKEN_LIFETIME_DAYS})",
     )
     reseller_ids: Optional[List[str]] = Field(
         default=None,

--- a/app/schemas/breeze_buddy/merchants.py
+++ b/app/schemas/breeze_buddy/merchants.py
@@ -5,6 +5,8 @@ from typing import List, Optional
 
 from pydantic import BaseModel, Field
 
+from app.schemas.breeze_buddy.auth import MAX_S2S_TOKEN_LIFETIME_DAYS
+
 
 class MerchantCreate(BaseModel):
     """Create a new merchant entity (business entity).
@@ -35,11 +37,19 @@ class MerchantCreate(BaseModel):
         "merchant row, and return it (once) in the response. Used e.g. as the "
         "webhook HMAC secret. Requires a reseller_id.",
     )
+    # PT-21. This mints a real RBAC JWT through the same helper as
+    # POST /auth/s2s/token (merchants/handlers.py: create_access_token_with_rbac),
+    # so it takes the same cap. It previously defaulted to 3650 days and allowed
+    # 365000 — and unlike /auth/s2s/token, which is admin-only, this endpoint is
+    # reachable by resellers too.
     token_lifetime_days: int = Field(
-        default=3650,
+        default=MAX_S2S_TOKEN_LIFETIME_DAYS,
         ge=1,
-        le=365000,
-        description="Lifetime of the issued token in days (only when issue_token).",
+        le=MAX_S2S_TOKEN_LIFETIME_DAYS,
+        description=(
+            "Lifetime of the issued token in days (only when issue_token). "
+            f"Capped at {MAX_S2S_TOKEN_LIFETIME_DAYS} (PT-21)."
+        ),
     )
 
 

--- a/app/schemas/breeze_buddy/signup.py
+++ b/app/schemas/breeze_buddy/signup.py
@@ -16,7 +16,12 @@ Security notes:
 import re
 from typing import List, Optional
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
+
+from app.core.security.password import (
+    MIN_PASSWORD_LENGTH,
+    validate_password_strength,
+)
 
 
 class MerchantSignupRequest(BaseModel):
@@ -55,13 +60,26 @@ class MerchantSignupRequest(BaseModel):
     )
     password: str = Field(
         ...,
-        min_length=8,
-        description="Password (minimum 8 characters).",
+        min_length=MIN_PASSWORD_LENGTH,
+        description=f"Password (minimum {MIN_PASSWORD_LENGTH} characters, "
+        "with at least three character classes).",
     )
     email: Optional[str] = Field(
         None,
         description="Optional email address.",
     )
+
+    @model_validator(mode="after")
+    def _validate_password_policy(self) -> "MerchantSignupRequest":
+        validate_password_strength(
+            self.password,
+            disallowed_substrings=[
+                self.username,
+                self.merchant_id,
+                (self.email or "").split("@")[0],
+            ],
+        )
+        return self
 
     @field_validator("merchant_id")
     @classmethod
@@ -154,6 +172,21 @@ class ListAccountsRequest(BaseModel):
     email: Optional[str] = Field(
         None, description="Email address (for password flows)."
     )
+    password: Optional[str] = Field(
+        None,
+        description="Password — required together with email; proves ownership "
+        "of at least one account under that email.",
+    )
+
+    @model_validator(mode="after")
+    def _require_proof(self) -> "ListAccountsRequest":
+        # The email branch must prove ownership (password); otherwise this
+        # endpoint is an anonymous account/PII enumeration oracle (PT-16).
+        if self.id_token:
+            return self
+        if self.email and self.password:
+            return self
+        raise ValueError("Provide either id_token, or email together with password.")
 
 
 class AccountSummary(BaseModel):
@@ -184,7 +217,11 @@ class SelectAccountRequest(BaseModel):
     id_token: Optional[str] = Field(
         None, description="Google id_token (for SSO flows)."
     )
-    password: Optional[str] = Field(None, description="Password (for password flows).")
+    # min_length=1 so an explicitly-empty password 422s at the boundary rather
+    # than reaching bcrypt, which raises ValueError -> 500 instead of 401.
+    password: Optional[str] = Field(
+        None, min_length=1, description="Password (for password flows)."
+    )
 
 
 class SwitchAccountRequest(BaseModel):

--- a/app/schemas/breeze_buddy/users.py
+++ b/app/schemas/breeze_buddy/users.py
@@ -8,8 +8,12 @@ import re
 from datetime import datetime
 from typing import List, Optional
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 
+from app.core.security.password import (
+    MIN_PASSWORD_LENGTH,
+    validate_password_strength,
+)
 from app.schemas.breeze_buddy.auth import UserRole
 
 
@@ -25,7 +29,7 @@ class UserCreate(BaseModel):
     username: str = Field(
         ..., min_length=3, max_length=50, description="Unique username"
     )
-    password: str = Field(..., min_length=8, description="Password")
+    password: str = Field(..., min_length=MIN_PASSWORD_LENGTH, description="Password")
     email: Optional[str] = Field(None, description="Email address")
     role: UserRole = Field(
         ..., description="User role: admin, reseller, merchant, user"
@@ -47,17 +51,40 @@ class UserCreate(BaseModel):
             raise ValueError("ID must not contain spaces")
         return v
 
+    @model_validator(mode="after")
+    def _validate_password_policy(self) -> "UserCreate":
+        validate_password_strength(
+            self.password,
+            disallowed_substrings=[
+                self.username,
+                self.id,
+                (self.email or "").split("@")[0],
+            ],
+        )
+        return self
+
 
 class UserUpdate(BaseModel):
     """User account update request."""
 
-    password: Optional[str] = Field(None, min_length=8, description="New password")
+    password: Optional[str] = Field(
+        None, min_length=MIN_PASSWORD_LENGTH, description="New password"
+    )
     email: Optional[str] = Field(None, description="Email address")
     reseller_ids: Optional[List[str]] = Field(None, description="Updated reseller IDs")
     merchant_ids: Optional[List[str]] = Field(
         None, description="Updated merchant identifiers"
     )
     is_active: Optional[bool] = Field(None, description="Account status")
+
+    @model_validator(mode="after")
+    def _validate_password_policy(self) -> "UserUpdate":
+        if self.password is not None:
+            validate_password_strength(
+                self.password,
+                disallowed_substrings=[(self.email or "").split("@")[0]],
+            )
+        return self
 
 
 class UserResponse(BaseModel):

--- a/app/services/redis/rate_limit.py
+++ b/app/services/redis/rate_limit.py
@@ -115,7 +115,19 @@ async def check_rate_limit(
         if count == 1:
             # New bucket — set TTL just past the window edge so the key
             # is readable for the full window before Redis evicts it.
-            await redis.expire(key, window_seconds + 5)
+            #
+            # If the TTL never lands, drop the counter. INCR and EXPIRE are two
+            # round trips, and only the count == 1 branch ever sets a TTL, so a
+            # key that survives a failed EXPIRE is immortal: no later call can
+            # repair it, and once it climbs past `limit` a fail_closed caller
+            # (the widget caps) would 429 that key forever rather than for one
+            # window. Deleting costs at most one under-counted request.
+            if not await redis.expire(key, window_seconds + 5):
+                logger.warning(
+                    f"rate_limit: could not set TTL on bucket={bucket!r}; "
+                    "dropping the counter rather than leaving it immortal"
+                )
+                await redis.delete(key)
     except Exception as exc:
         if fail_closed:
             logger.warning(

--- a/tests/test_auth_enumeration.py
+++ b/tests/test_auth_enumeration.py
@@ -1,0 +1,211 @@
+"""PT-16: the credential endpoints must not leak which accounts exist.
+
+Covers the account-listing ownership proof, the constant bcrypt budget
+(so response time can't count accounts sharing an email), and the single
+dummy verification spent on the no-such-user branch of /login and /auth/s2s/token.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException
+from pydantic import ValidationError
+
+from app.schemas import (
+    UserInfo,
+    UserRole,
+)
+
+
+def _user(role: str, resellers, merchants, owner_id=None) -> UserInfo:
+    return UserInfo(
+        id="u1",
+        username="u1",
+        role=UserRole(role),
+        email=None,
+        reseller_ids=list(resellers),
+        merchant_ids=list(merchants),
+        permissions=[],
+        owner_id=owner_id,
+    )
+
+
+# ── PT-16: account listing requires proof of ownership ────────────────────
+def test_list_accounts_request_requires_password_with_email():
+    from app.schemas.breeze_buddy.signup import ListAccountsRequest
+
+    with pytest.raises(ValidationError):
+        ListAccountsRequest(email="victim@company.com")  # no password
+    ListAccountsRequest(email="v@c.com", password="x")  # ok
+    ListAccountsRequest(id_token="tok")  # ok
+
+
+# ── PT-16: account listing spends constant bcrypt work (no timing oracle) ────
+def _count_bcrypts(monkeypatch, users):
+    """Patch the accessor + verifier and return a counter of verify calls."""
+    from app.api.routers.breeze_buddy.signup import handlers
+
+    async def _users(_email):
+        return users
+
+    calls = {"n": 0}
+
+    # The handler awaits the async wrapper (bcrypt is offloaded to a thread so a
+    # guessing flood can't freeze the event loop), so the spy has to be async and
+    # patched over that name — patching the sync one would silently count zero.
+    async def _verify_spy(_pw, _hash):
+        calls["n"] += 1
+        return False
+
+    monkeypatch.setattr(handlers.user_accessors, "get_users_by_email", _users)
+    monkeypatch.setattr(handlers, "verify_password_async", _verify_spy)
+    return handlers, calls
+
+
+async def test_list_accounts_bcrypt_count_is_constant_regardless_of_account_count(
+    monkeypatch,
+):
+    """The bcrypt count must not vary with how many accounts share an email.
+
+    Verifying once per candidate leaks the account *count* through response
+    time. Asserting only "at least one bcrypt for an unknown email" (the
+    earlier version of this test) passed while that leak was live.
+    """
+    from app.api.routers.breeze_buddy.signup.handlers import (
+        ACCOUNT_PASSWORD_CHECK_BUDGET as BUDGET,
+    )
+
+    counts = []
+    for n_users in (0, 1, 3, BUDGET, BUDGET + 4):
+        users = [
+            SimpleNamespace(is_active=True, password_hash="$2b$12$x")
+            for _ in range(n_users)
+        ]
+        handlers, calls = _count_bcrypts(monkeypatch, users)
+        with pytest.raises(HTTPException) as e:
+            await handlers.list_accounts_handler(
+                id_token=None, email="probe@x.com", password="whatever"
+            )
+        assert e.value.status_code == 401
+        counts.append(calls["n"])
+
+    assert counts == [BUDGET] * 5, f"bcrypt count varies with account count: {counts}"
+
+
+async def test_list_accounts_user_without_password_hash_no_500(monkeypatch):
+    from app.api.routers.breeze_buddy.signup import handlers
+
+    async def _one_user(_email):
+        return [SimpleNamespace(is_active=True, password_hash=None)]
+
+    monkeypatch.setattr(handlers.user_accessors, "get_users_by_email", _one_user)
+
+    # Real verify_password runs against the dummy-hash fallback: a None hash must
+    # never crash (500); it just never matches, yielding a generic 401.
+    with pytest.raises(HTTPException) as e:
+        await handlers.list_accounts_handler(
+            id_token=None, email="sso@x.com", password="whatever"
+        )
+    assert e.value.status_code == 401
+
+
+# ── PT-16: /login and /auth/s2s/token spend one bcrypt on an unknown user ─────
+async def test_login_unknown_user_spends_one_bcrypt(monkeypatch):
+    from app.api.routers.breeze_buddy.auth import handlers
+    from app.schemas.breeze_buddy.auth import LoginRequest
+
+    async def _no_user(_username):
+        return None
+
+    calls = {"n": 0}
+
+    async def _verify_spy(_pw, _hash):
+        calls["n"] += 1
+        return False
+
+    monkeypatch.setattr(handlers, "get_user_by_username", _no_user)
+    monkeypatch.setattr(handlers, "verify_password_async", _verify_spy)
+
+    with pytest.raises(HTTPException) as e:
+        await handlers.login_handler(LoginRequest(username="ghost", password="x"))
+    assert e.value.status_code == 401
+    # An unknown username must still cost one bcrypt so it is timing-
+    # indistinguishable from a real account with a wrong password.
+    assert calls["n"] == 1
+
+
+async def test_s2s_unknown_user_spends_one_bcrypt(monkeypatch):
+    from app.api.routers.breeze_buddy.auth import handlers
+    from app.schemas.breeze_buddy.auth import S2STokenRequest
+
+    async def _no_user(_username):
+        return None
+
+    calls = {"n": 0}
+
+    async def _verify_spy(_pw, _hash):
+        calls["n"] += 1
+        return False
+
+    monkeypatch.setattr(handlers, "get_user_by_username", _no_user)
+    monkeypatch.setattr(handlers, "verify_password_async", _verify_spy)
+
+    with pytest.raises(HTTPException) as e:
+        await handlers.generate_s2s_token_handler(
+            S2STokenRequest(username="ghost", password="x", token_lifetime_days=30)
+        )
+    assert e.value.status_code == 401
+    # The s2s path would otherwise leak whether an admin account exists.
+    assert calls["n"] == 1
+
+
+def test_dummy_password_hash_is_a_real_bcrypt_hash_that_never_matches():
+    # The constant is now a literal rather than a hash computed at import. If it
+    # were ever mistyped, verify_password would fail fast instead of spending
+    # bcrypt time, and the no-such-user branch would become measurably quicker
+    # than a wrong-password one — reopening the enumeration oracle it exists to
+    # close. Assert both halves: correct shape, and it matches nothing.
+    from app.core.security.password import DUMMY_PASSWORD_HASH, verify_password
+
+    assert DUMMY_PASSWORD_HASH.startswith("$2b$12$")
+    assert len(DUMMY_PASSWORD_HASH) == 60
+    for guess in ("password", "admin", "12345678", DUMMY_PASSWORD_HASH):
+        assert verify_password(guess, DUMMY_PASSWORD_HASH) is False
+    # The empty plaintext never reaches here — LoginRequest.password carries
+    # min_length=1 precisely so bcrypt's ValueError can't surface as a 500.
+    with pytest.raises(ValueError):
+        verify_password("", DUMMY_PASSWORD_HASH)
+
+
+def test_dummy_hash_costs_the_same_as_a_real_one():
+    # Same cost factor as freshly-hashed credentials, so the dummy verification
+    # is time-indistinguishable from a real failed check.
+    from app.core.security.password import DUMMY_PASSWORD_HASH, hash_password
+
+    real = hash_password("SomeRealPassword!23")
+    assert real.split("$")[2] == DUMMY_PASSWORD_HASH.split("$")[2]
+
+
+async def test_select_account_is_rate_limited(monkeypatch):
+    # /auth/select-account verifies a password, so leaving it uncapped let an
+    # attacker who knows an account_id guess at full speed while /auth/accounts
+    # and /login were throttled.
+    from app.api.routers.breeze_buddy import signup as signup_router
+
+    calls: list = []
+
+    async def _spy(request, identifier):
+        calls.append(identifier)
+
+    async def _handler(**kwargs):
+        return SimpleNamespace(access_token="t")
+
+    monkeypatch.setattr(signup_router, "enforce_credential_rate_limit", _spy)
+    monkeypatch.setattr(signup_router, "select_account_handler", _handler)
+
+    req = SimpleNamespace(account_id="acct-1", id_token=None, password="hunter2")
+    http_req = SimpleNamespace(headers={}, client=SimpleNamespace(host="203.0.113.9"))
+    await signup_router.select_account(req, http_req)  # pyrefly: ignore
+    assert calls == ["acct-1"], "the credential cap must run before verification"

--- a/tests/test_auth_failure_modes.py
+++ b/tests/test_auth_failure_modes.py
@@ -1,0 +1,168 @@
+"""What the auth-hardening layers do when their infrastructure misbehaves.
+
+Two failure modes are deliberately asymmetric and are easy to get backwards, so
+they are pinned here:
+
+* ``is_user_active`` — a Redis failure fails OPEN (the cache is only an
+  optimisation and the authoritative read still runs), a database failure fails
+  CLOSED (returning True there would accept tokens for disabled and deleted
+  users for the whole outage).
+* ``check_rate_limit`` — INCR and EXPIRE are two round trips and only the first
+  request in a window sets the TTL, so a counter that survives a failed EXPIRE
+  can never be repaired and would 429 a fail-closed caller forever.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.database.accessor.breeze_buddy import users as users_accessor
+from app.services.redis import rate_limit as svc
+
+
+class _RedisMiss:
+    """Cache that answers "not cached" and accepts writes."""
+
+    def __init__(self):
+        self.writes: list = []
+
+    async def get(self, key):
+        return None
+
+    async def setex(self, key, value, ttl_seconds=None):
+        self.writes.append((key, value))
+        return True
+
+
+def _patch_redis(monkeypatch, redis):
+    async def _get():
+        return redis
+
+    monkeypatch.setattr(users_accessor, "get_redis_service", _get)
+
+
+# ── is_user_active ────────────────────────────────────────────────────────
+async def test_db_failure_fails_closed(monkeypatch):
+    _patch_redis(monkeypatch, _RedisMiss())
+
+    async def _boom(user_id):
+        raise RuntimeError("database unreachable")
+
+    monkeypatch.setattr(users_accessor, "get_user_in_db_by_id", _boom)
+    # The security-relevant direction: an unreachable database must not be a
+    # window in which a revoked or deactivated account keeps authenticating.
+    assert await users_accessor.is_user_active("u1") is False
+
+
+async def test_redis_read_failure_still_consults_the_database(monkeypatch):
+    async def _boom_redis():
+        raise RuntimeError("redis down")
+
+    monkeypatch.setattr(users_accessor, "get_redis_service", _boom_redis)
+
+    class _Active:
+        is_active = True
+
+    async def _db(user_id):
+        return _Active()
+
+    monkeypatch.setattr(users_accessor, "get_user_in_db_by_id", _db)
+    # Redis is only a cache: losing it degrades latency, never correctness.
+    assert await users_accessor.is_user_active("u1") is True
+
+
+async def test_inactive_user_is_reported_inactive(monkeypatch):
+    _patch_redis(monkeypatch, _RedisMiss())
+
+    class _Disabled:
+        is_active = False
+
+    async def _db(user_id):
+        return _Disabled()
+
+    monkeypatch.setattr(users_accessor, "get_user_in_db_by_id", _db)
+    assert await users_accessor.is_user_active("u1") is False
+
+
+async def test_missing_user_is_reported_inactive(monkeypatch):
+    _patch_redis(monkeypatch, _RedisMiss())
+
+    async def _db(user_id):
+        return None
+
+    monkeypatch.setattr(users_accessor, "get_user_in_db_by_id", _db)
+    assert await users_accessor.is_user_active("deleted") is False
+
+
+# ── check_rate_limit TTL repair ───────────────────────────────────────────
+class _FakeLimiterRedis:
+    def __init__(self, *, expire_ok: bool = True):
+        self.counts: dict = {}
+        self.expire_ok = expire_ok
+        self.deleted: list = []
+
+    async def incr(self, key):
+        self.counts[key] = self.counts.get(key, 0) + 1
+        return self.counts[key]
+
+    async def expire(self, key, seconds):
+        return self.expire_ok
+
+    async def delete(self, key):
+        self.deleted.append(key)
+        self.counts.pop(key, None)
+        return True
+
+
+@pytest.fixture(autouse=True)
+def _redis_configured(monkeypatch):
+    monkeypatch.setattr(svc, "is_redis_configured", lambda: True)
+
+
+async def test_counter_is_dropped_when_its_ttl_cannot_be_set(monkeypatch):
+    fake = _FakeLimiterRedis(expire_ok=False)
+
+    async def _get():
+        return fake
+
+    monkeypatch.setattr(svc, "get_redis_service", _get)
+    decision = await svc.check_rate_limit(
+        bucket="b", identifier="i", limit=5, window_seconds=60, fail_closed=True
+    )
+    # The request itself is still allowed — the point is that the key does not
+    # survive without a TTL, because nothing downstream could ever repair it.
+    assert decision.allowed is True
+    assert fake.deleted, "counter without a TTL must be deleted, not left immortal"
+    assert fake.counts == {}
+
+
+async def test_normal_path_keeps_the_counter(monkeypatch):
+    fake = _FakeLimiterRedis(expire_ok=True)
+
+    async def _get():
+        return fake
+
+    monkeypatch.setattr(svc, "get_redis_service", _get)
+    for _ in range(3):
+        decision = await svc.check_rate_limit(
+            bucket="b", identifier="i", limit=5, window_seconds=60
+        )
+    assert decision.allowed is True
+    assert fake.deleted == []
+    assert list(fake.counts.values()) == [3]
+
+
+async def test_over_limit_still_denies(monkeypatch):
+    fake = _FakeLimiterRedis(expire_ok=True)
+
+    async def _get():
+        return fake
+
+    monkeypatch.setattr(svc, "get_redis_service", _get)
+    decisions = [
+        await svc.check_rate_limit(
+            bucket="b", identifier="i", limit=2, window_seconds=60
+        )
+        for _ in range(3)
+    ]
+    assert [d.allowed for d in decisions] == [True, True, False]

--- a/tests/test_auth_rate_limit.py
+++ b/tests/test_auth_rate_limit.py
@@ -1,0 +1,141 @@
+"""Brute-force rate limiting on the credential endpoints (PT-16 hardening).
+
+Covers ``enforce_credential_rate_limit``: per-IP and per-username fixed-window
+caps, short-circuit ordering, the empty-identifier case, and the fail-open
+posture when Redis is unavailable.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from types import SimpleNamespace
+from typing import cast
+
+import pytest
+from fastapi import HTTPException, Request
+
+from app.api.routers.breeze_buddy.auth import rate_limit as rl
+from app.services.redis.rate_limit import RateLimitDecision
+
+
+def _req(xff: str | None = None, host: str = "203.0.113.7") -> Request:
+    headers = {"x-forwarded-for": xff} if xff else {}
+    return cast(
+        Request, SimpleNamespace(headers=headers, client=SimpleNamespace(host=host))
+    )
+
+
+def _decision(allowed: bool) -> RateLimitDecision:
+    return RateLimitDecision(allowed=allowed, count=99, limit=40, retry_after_seconds=1)
+
+
+def _fake_check(deny_buckets: set[str], recorder: list):
+    async def _check(*, bucket, identifier, limit, window_seconds, prefix, **kwargs):
+        recorder.append((bucket, identifier))
+        return _decision(bucket not in deny_buckets)
+
+    return _check
+
+
+async def test_blocks_when_ip_over_cap(monkeypatch):
+    seen: list = []
+    monkeypatch.setattr(rl, "check_rate_limit", _fake_check({"credential_ip"}, seen))
+    with pytest.raises(HTTPException) as e:
+        await rl.enforce_credential_rate_limit(_req(), "alice")
+    assert e.value.status_code == 429
+    assert (e.value.headers or {}).get("Retry-After") == "1"
+    # Must short-circuit on the IP cap — never even touch the username bucket.
+    assert [b for b, _ in seen] == ["credential_ip"]
+
+
+async def test_blocks_when_username_over_cap(monkeypatch):
+    seen: list = []
+    monkeypatch.setattr(rl, "check_rate_limit", _fake_check({"credential_user"}, seen))
+    with pytest.raises(HTTPException) as e:
+        await rl.enforce_credential_rate_limit(_req(), "Alice@Example.com")
+    assert e.value.status_code == 429
+    # Username is normalised (lower/stripped) then SHA-256 hashed before keying.
+    expected = hashlib.sha256(b"alice@example.com").hexdigest()
+    assert seen[1] == ("credential_user", expected)
+
+
+async def test_long_username_is_hashed_to_bounded_key(monkeypatch):
+    # A pathologically long identifier must not become a giant Redis key: it is
+    # hashed to a fixed 64-hex-char digest regardless of input size.
+    seen: list = []
+    monkeypatch.setattr(rl, "check_rate_limit", _fake_check(set(), seen))
+    await rl.enforce_credential_rate_limit(_req(), "x" * 100_000)
+    bucket, identifier = seen[1]
+    assert bucket == "credential_user"
+    assert len(identifier) == 64
+    assert identifier == hashlib.sha256(b"x" * 100_000).hexdigest()
+
+
+async def test_allows_when_under_cap(monkeypatch):
+    seen: list = []
+    monkeypatch.setattr(rl, "check_rate_limit", _fake_check(set(), seen))
+    await rl.enforce_credential_rate_limit(_req(), "bob")  # no raise
+    assert [b for b, _ in seen] == ["credential_ip", "credential_user"]
+
+
+async def test_empty_identifier_skips_username_bucket(monkeypatch):
+    seen: list = []
+    monkeypatch.setattr(rl, "check_rate_limit", _fake_check(set(), seen))
+    await rl.enforce_credential_rate_limit(_req(), None)  # SSO-only, no email
+    assert [b for b, _ in seen] == ["credential_ip"]
+
+
+async def test_ip_key_uses_last_forwarded_hop(monkeypatch):
+    # A client-supplied XFF chain must not let the caller escape their bucket:
+    # only the last (trusted-proxy-written) hop is used as the identifier.
+    seen: list = []
+    monkeypatch.setattr(rl, "check_rate_limit", _fake_check(set(), seen))
+    await rl.enforce_credential_rate_limit(_req(xff="1.1.1.1, 2.2.2.2, 9.9.9.9"), "bob")
+    assert seen[0] == ("credential_ip", hashlib.sha256(b"9.9.9.9").hexdigest())
+
+
+async def test_ip_is_hashed_before_it_becomes_a_key_or_a_log_field(monkeypatch):
+    # An IP address is personal data. check_rate_limit logs its own `identifier`
+    # verbatim when Redis is missing or erroring, so the raw value must never be
+    # handed to it — the digest goes in instead, and the raw IP appears nowhere.
+    seen: list = []
+    monkeypatch.setattr(rl, "check_rate_limit", _fake_check(set(), seen))
+    await rl.enforce_credential_rate_limit(_req(host="198.51.100.42"), "bob")
+    bucket, identifier = seen[0]
+    assert bucket == "credential_ip"
+    assert identifier == hashlib.sha256(b"198.51.100.42").hexdigest()
+    assert "198.51.100.42" not in identifier
+
+
+async def test_denied_logs_carry_no_raw_identifier(monkeypatch):
+    # The 429 log lines are the ones an operator actually reads, and they were
+    # the two places raw PII leaked: the client IP and a 64-char prefix of the
+    # username. Both must now be digests.
+    emitted: list[str] = []
+    monkeypatch.setattr(rl.logger, "warning", lambda m, *a, **k: emitted.append(str(m)))
+
+    monkeypatch.setattr(rl, "check_rate_limit", _fake_check({"credential_ip"}, []))
+    with pytest.raises(HTTPException):
+        await rl.enforce_credential_rate_limit(_req(host="198.51.100.42"), "bob")
+
+    monkeypatch.setattr(rl, "check_rate_limit", _fake_check({"credential_user"}, []))
+    with pytest.raises(HTTPException):
+        await rl.enforce_credential_rate_limit(
+            _req(host="198.51.100.42"), "victim@company.com"
+        )
+
+    joined = "\n".join(emitted)
+    assert "198.51.100.42" not in joined
+    assert "victim@company.com" not in joined
+    assert "victim" not in joined
+    assert "ip hash" in joined and "identifier hash" in joined
+
+
+async def test_fails_open_when_redis_unconfigured(monkeypatch):
+    # The real check_rate_limit returns allowed=True when Redis isn't configured,
+    # so enforcement (which uses the default fail_closed=False) must allow the
+    # request — availability of login beats this defence-in-depth layer.
+    from app.services.redis import rate_limit as svc
+
+    monkeypatch.setattr(svc, "is_redis_configured", lambda: False)
+    await rl.enforce_credential_rate_limit(_req(), "carol")  # no raise

--- a/tests/test_password_policy.py
+++ b/tests/test_password_policy.py
@@ -1,0 +1,48 @@
+"""PT-24: the password strength policy enforced wherever a password is set."""
+
+from __future__ import annotations
+
+import pytest
+
+from app.core.security.password import validate_password_strength
+from app.schemas import (
+    UserInfo,
+    UserRole,
+)
+
+
+def _user(role: str, resellers, merchants, owner_id=None) -> UserInfo:
+    return UserInfo(
+        id="u1",
+        username="u1",
+        role=UserRole(role),
+        email=None,
+        reseller_ids=list(resellers),
+        merchant_ids=list(merchants),
+        permissions=[],
+        owner_id=owner_id,
+    )
+
+
+# ── PT-24: password policy ────────────────────────────────────────────────
+def test_password_policy_rejects_weak_and_common():
+    with pytest.raises(ValueError):
+        validate_password_strength("short1!")  # too short
+    with pytest.raises(ValueError):
+        validate_password_strength("password123")  # common + low diversity
+    with pytest.raises(ValueError):
+        validate_password_strength("alllowercaseletters")  # one class
+
+
+def test_password_policy_rejects_containing_username():
+    with pytest.raises(ValueError):
+        validate_password_strength("Acme!Secret99", disallowed_substrings=["acme"])
+
+
+def test_password_policy_rejects_over_72_bytes():
+    with pytest.raises(ValueError):
+        validate_password_strength("Aa1!" + "€" * 30)  # >72 utf-8 bytes
+
+
+def test_password_policy_accepts_strong_unique():
+    validate_password_strength("Zx9!vBnq2_Lp")  # 12 chars, 3+ classes, uncommon

--- a/tests/test_stt_stream.py
+++ b/tests/test_stt_stream.py
@@ -17,6 +17,11 @@ from app.schemas.breeze_buddy.stt import TranscriptionStreamRequest
 _USER = UserInfo(id="user-1", username="tester", role=UserRole.ADMIN)
 
 
+async def _ws_user(_ws: WebSocket) -> UserInfo:
+    """Async stand-in for get_user_from_websocket (now a coroutine)."""
+    return _USER
+
+
 class FakeWebSocket:
     """Minimal stand-in implementing the surface the stream handler uses.
 
@@ -111,7 +116,7 @@ def stream_env(monkeypatch: pytest.MonkeyPatch) -> dict:
             setattr(stub, attr, value)
         return stub
 
-    monkeypatch.setattr(handlers, "get_user_from_websocket", lambda ws: _USER)
+    monkeypatch.setattr(handlers, "get_user_from_websocket", _ws_user)
     create_mock = AsyncMock(return_value=object())
     monkeypatch.setattr(handlers, "create_stt_from_config", create_mock)
     created["create_stt"] = create_mock
@@ -138,25 +143,30 @@ def test_stream_request_normalizes_and_bounds() -> None:
         )
 
 
-def test_websocket_auth_reads_header_then_query(
+async def test_websocket_auth_reads_header_then_query(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     seen: list[str] = []
+
+    async def _verify(token: str) -> UserInfo:
+        seen.append(token)
+        return _USER
+
     monkeypatch.setattr(
         rbac_token.rbac_token_manager,
         "verify_rbac_token",
-        lambda token: seen.append(token) or _USER,
+        _verify,
     )
 
     ws = FakeWebSocket("", headers={"authorization": "Bearer header-token"})
-    assert rbac_token.get_user_from_websocket(as_ws(ws)) is _USER
+    assert await rbac_token.get_user_from_websocket(as_ws(ws)) is _USER
 
     ws = FakeWebSocket("", query={"token": "query-token"})
-    assert rbac_token.get_user_from_websocket(as_ws(ws)) is _USER
+    assert await rbac_token.get_user_from_websocket(as_ws(ws)) is _USER
     assert seen == ["header-token", "query-token"]
 
     with pytest.raises(HTTPException):
-        rbac_token.get_user_from_websocket(as_ws(FakeWebSocket("")))
+        await rbac_token.get_user_from_websocket(as_ws(FakeWebSocket("")))
 
 
 async def test_stream_rejects_unauthenticated() -> None:
@@ -171,7 +181,7 @@ async def test_stream_rejects_unauthenticated() -> None:
 async def test_stream_rejects_invalid_config(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr(handlers, "get_user_from_websocket", lambda ws: _USER)
+    monkeypatch.setattr(handlers, "get_user_from_websocket", _ws_user)
 
     ws = FakeWebSocket(json.dumps({"provider": "not-a-provider"}))
     await handlers.handle_transcription_stream(as_ws(ws))
@@ -183,7 +193,7 @@ async def test_stream_rejects_invalid_config(
 async def test_stream_rejects_openai_provider(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr(handlers, "get_user_from_websocket", lambda ws: _USER)
+    monkeypatch.setattr(handlers, "get_user_from_websocket", _ws_user)
 
     ws = FakeWebSocket(json.dumps({"provider": "openai"}))
     await handlers.handle_transcription_stream(as_ws(ws))
@@ -196,7 +206,7 @@ async def test_stream_rejects_openai_provider(
 async def test_stream_rejects_sarvam_sample_rate_mismatch(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr(handlers, "get_user_from_websocket", lambda ws: _USER)
+    monkeypatch.setattr(handlers, "get_user_from_websocket", _ws_user)
 
     ws = FakeWebSocket(json.dumps({"provider": "sarvam", "sample_rate": 8000}))
     await handlers.handle_transcription_stream(as_ws(ws))

--- a/tests/test_token_lifetime_revocation.py
+++ b/tests/test_token_lifetime_revocation.py
@@ -1,0 +1,172 @@
+"""PT-21 (S2S lifetime cap on both mint paths) and PT-22 (revocation denylist)."""
+
+from __future__ import annotations
+
+import pytest
+
+from app.core.security import token_revocation
+from app.schemas import (
+    UserInfo,
+    UserRole,
+)
+
+
+def _user(role: str, resellers, merchants, owner_id=None) -> UserInfo:
+    return UserInfo(
+        id="u1",
+        username="u1",
+        role=UserRole(role),
+        email=None,
+        reseller_ids=list(resellers),
+        merchant_ids=list(merchants),
+        permissions=[],
+        owner_id=owner_id,
+    )
+
+
+# ── PT-21: S2S token lifetime cap ─────────────────────────────────────────
+def test_s2s_token_lifetime_capped_at_365():
+    from pydantic import ValidationError
+
+    from app.schemas.breeze_buddy.auth import S2STokenRequest
+
+    # Build via dict so the over-cap value is validated at runtime (not a static
+    # literal the type checker rejects up front).
+    over_cap = {"username": "a", "password": "b", "token_lifetime_days": 365000}
+    with pytest.raises(ValidationError):
+        S2STokenRequest.model_validate(over_cap)
+    S2STokenRequest.model_validate(
+        {"username": "a", "password": "b", "token_lifetime_days": 365}
+    )  # ok
+
+
+def test_merchant_issue_token_lifetime_capped_at_365():
+    """The OTHER S2S mint path.
+
+    POST /merchant with issue_token=true calls the same
+    rbac_token_manager.create_access_token_with_rbac as /auth/s2s/token, but it
+    is reachable by resellers, not just admins. It used to default to 3650 days
+    and allow 365000, so the PT-21 cap covered one of the two paths.
+    """
+    from pydantic import ValidationError
+
+    from app.schemas.breeze_buddy.auth import (
+        MAX_S2S_TOKEN_LIFETIME_DAYS,
+        S2STokenRequest,
+    )
+    from app.schemas.breeze_buddy.merchants import MerchantCreate
+
+    base = {"merchant_id": "mrc001", "reseller_id": "r1", "issue_token": True}
+    for over_cap in (MAX_S2S_TOKEN_LIFETIME_DAYS + 1, 3650, 365000):
+        with pytest.raises(ValidationError):
+            MerchantCreate.model_validate({**base, "token_lifetime_days": over_cap})
+
+    MerchantCreate.model_validate(
+        {**base, "token_lifetime_days": MAX_S2S_TOKEN_LIFETIME_DAYS}
+    )  # ok
+    # The default is the sharp edge: nobody has to ask for a long-lived token.
+    assert (
+        MerchantCreate.model_validate(base).token_lifetime_days
+        <= MAX_S2S_TOKEN_LIFETIME_DAYS
+    )
+    # Both paths must read the same constant, or they drift again.
+    assert (
+        MerchantCreate.model_fields["token_lifetime_days"].default
+        == S2STokenRequest.model_fields["token_lifetime_days"].default
+    )
+
+
+# ── PT-22: token revocation denylist ──────────────────────────────────────
+class _FakeRedis:
+    def __init__(self):
+        self.store = {}
+
+    async def setex(self, key, value, ttl_seconds=None):
+        self.store[key] = value
+        return True
+
+    async def exists(self, key):
+        return key in self.store
+
+
+async def test_revoke_then_is_revoked(monkeypatch):
+    fake = _FakeRedis()
+
+    async def _get():
+        return fake
+
+    monkeypatch.setattr(token_revocation, "get_redis_service", _get)
+    import time
+
+    token = "sometoken"
+    assert await token_revocation.is_token_revoked(token) is False
+    await token_revocation.revoke_token(token, int(time.time()) + 3600)
+    assert await token_revocation.is_token_revoked(token) is True
+    assert await token_revocation.is_token_revoked("other") is False
+
+
+async def test_is_token_revoked_fails_open_on_redis_error(monkeypatch):
+    async def _boom():
+        raise RuntimeError("redis down")
+
+    monkeypatch.setattr(token_revocation, "get_redis_service", _boom)
+    assert await token_revocation.is_token_revoked("x") is False
+
+
+async def test_revoke_token_rounds_ttl_up_instead_of_truncating(monkeypatch):
+    # int() truncation turns "0.4s of life left" into ttl == 0, which takes the
+    # already-expired path and reports success without writing anything. A token
+    # that is still valid must always get a denylist entry.
+    fake = _FakeRedis()
+    ttls: list = []
+
+    async def _get():
+        return fake
+
+    original_setex = fake.setex
+
+    async def _spy(key, value, ttl_seconds=None):
+        ttls.append(ttl_seconds)
+        return await original_setex(key, value, ttl_seconds=ttl_seconds)
+
+    fake.setex = _spy  # pyrefly: ignore
+    monkeypatch.setattr(token_revocation, "get_redis_service", _get)
+
+    import time
+
+    token = "expiring-imminently"
+    assert await token_revocation.revoke_token(token, int(time.time()) + 1) is True
+    assert ttls and all(t >= 1 for t in ttls)
+    assert await token_revocation.is_token_revoked(token) is True
+
+
+async def test_revoke_token_reports_success_only_for_genuinely_expired(monkeypatch):
+    fake = _FakeRedis()
+
+    async def _get():
+        return fake
+
+    monkeypatch.setattr(token_revocation, "get_redis_service", _get)
+    import time
+
+    # Comfortably in the past: nothing to revoke, and nothing is written.
+    assert await token_revocation.revoke_token("stale", int(time.time()) - 60) is True
+    assert fake.store == {}
+
+
+async def test_logout_refuses_to_claim_revocation_for_a_token_with_no_exp(monkeypatch):
+    # `payload.get("exp", 0)` used to hand revoke_token a 0, which it read as a
+    # negative TTL -> "already expired" -> True. The handler then answered
+    # revoked=true for a token that was never denylisted and never expires.
+    from app.api.routers.breeze_buddy.auth import handlers as h
+
+    monkeypatch.setattr(
+        h.pyjwt, "decode", lambda *a, **k: {"sub": "u1"}
+    )  # no exp claim
+
+    async def _must_not_run(*a, **k):
+        raise AssertionError("revoke_token must not be called without a usable exp")
+
+    monkeypatch.setattr(h, "revoke_token", _must_not_run)
+    result = await h.logout_handler("token-without-exp")
+    assert result.get("revoked") is False


### PR DESCRIPTION
Independent PR — targets `release` directly and shares no file with #987, #988, #989 or #990. Merge in any order.

**Replaces #991, #992 and #993**, which were chained. Those three are combined here because their dependencies are real, not stylistic:

- the PT-16 timing fix imports `DUMMY_PASSWORD_HASH` from the password module PT-24 introduces
- the PT-22 logout revocation edits the same two auth-router files (`auth/__init__.py`, `auth/handlers.py`) as the PT-16 rate-limit wiring

Split apart, none of the three builds on its own.

Independent of the other pentest PRs — targets release, merges in any order.

These three findings are one PR because they are genuinely coupled, not to save
review effort: the PT-16 timing fix imports DUMMY_PASSWORD_HASH from the password
module PT-24 introduces, and the PT-22 logout revocation edits the same two
auth-router files as the PT-16 rate-limit wiring. Splitting them would produce
PRs that do not build alone.

PT-24 — no password strength requirement existed. Verified on release: 'password',
'12345678' and the user's own address were all accepted. Adds a policy applied at
both schema boundaries: length, 3-of-4 character classes, a common-password and
identifier deny-list, and an explicit 72-byte guard because bcrypt silently
truncates past that. password.py becomes a package so the bcrypt primitives and
the policy live in separate modules behind one import path.

PT-16 — /auth/accounts required no proof of ownership on the email branch, and
/login and /auth/s2s/token returned faster for an unknown username than for a
wrong password because the no-such-user branch skipped bcrypt. Both now spend one
verification against a shared dummy hash; the account-listing path spends a
constant budget regardless of how many accounts share an email, since verifying
once per candidate leaks the count through response time. Fixed-window per-IP and
per-username caps bound online guessing.

PT-18 — a cross-IP aggregate cap per public_widget_key, so distributing an attack
across source addresses does not buy unlimited attempts.
PT-19 — the chat-demo client IP is derived from the trusted last XFF hop.

PT-22 — logout was a no-op: a stolen token stayed valid for its full lifetime.
Adds a revocation denylist keyed by a hash of the token with a TTL equal to its
remaining lifetime, plus a per-request is_active liveness recheck. verify_rbac_token
and get_user_from_websocket become coroutines because the check is a Redis
round-trip; four `await` additions elsewhere are that change and nothing else.

PT-21 — the 365-day S2S cap. There are two mint paths: POST /auth/s2s/token
(admin-only) and POST /merchant with issue_token=true, which resellers can reach
and which defaulted to 3650 days and allowed 365000. Both now read
MAX_S2S_TOKEN_LIFETIME_DAYS rather than their own literal.

Rate limiting and the liveness recheck both fail OPEN on a Redis outage. That is
deliberate and bounded: a Redis blip losing the cap beats one locking every
operator out, and bcrypt still bounds throughput underneath.

951 tests pass on this branch.

---

### Independence, verified

All five clairvoyance PRs were trial-merged against each other — **10 of 10 pairs merge with no conflict**, so any merge order works. The four config blocks that previously collided now sit at four distinct anchors in `static.py`, hundreds of lines apart.

Merging all five reproduces the original #930 tree: `static.py` is identical content in a different order, `.env.example` differs only by one now-meaningless banner comment, and the combined suite runs **992 passed**.

Evidence recordings for the three findings are in the comment below.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Enhancements**
  * Added brute-force protection for login, signup, account lookup, and service-token requests, with configurable IP and identifier limits.
  * Logout now revokes tokens server-side, and revoked or inactive credentials are rejected.
  * Improved protection against account enumeration through consistent password verification.
  * Added stronger password requirements and prevented empty passwords.
  * Capped service-token lifetimes at 365 days.

* **Bug Fixes**
  * Improved authentication for WebSocket and webhook requests.
  * Added aggregate rate limits for widget traffic.
  * Improved handling of inactive and passwordless accounts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->