### PR TITLE
BZ-5359: feat: Migrate observers to evaluation table

### DIFF
--- a/app/ai/voice/agents/breeze_buddy/agent/__init__.py
+++ b/app/ai/voice/agents/breeze_buddy/agent/__init__.py
@@ -71,7 +71,11 @@ from app.ai.voice.agents.breeze_buddy.mcp import get_mcp_global_functions
 from app.ai.voice.agents.breeze_buddy.observability.tracing_setup import (
     create_root_span,
 )
-from app.ai.voice.agents.breeze_buddy.observers import ObserverManager, build_observers
+from app.ai.voice.agents.breeze_buddy.observers import (
+    ObserverManager,
+    build_observers,
+    resolve_observer_configs,
+)
 from app.ai.voice.agents.breeze_buddy.processors import (
     KnowledgeRetrievalProcessor,
     MetricsCollectorProcessor,
@@ -1462,8 +1466,8 @@ class Agent:
             )
 
         # ── Real-time observers ──────────────────────────────────
-        observers_config = (
-            self.configurations.observers if self.configurations else None
+        observers_config, observer_config_id = await resolve_observer_configs(
+            self.template
         )
         logger.info(
             f"Observer setup: "
@@ -1477,6 +1481,7 @@ class Agent:
                     template=self.template,
                     agent_context=self,
                     handler_map=self.flow_builder.handler_map,
+                    evaluation_config_id=observer_config_id,
                 )
                 if observer_instances:
                     self._observer_manager = ObserverManager(

--- a/app/ai/voice/agents/breeze_buddy/observers/__init__.py
+++ b/app/ai/voice/agents/breeze_buddy/observers/__init__.py
@@ -1,5 +1,10 @@
-from .factory import build_observers
+from .factory import build_observers, resolve_observer_configs
 from .manager import ObserverManager
 from .observer import RealtimeObserver
 
-__all__ = ["build_observers", "ObserverManager", "RealtimeObserver"]
+__all__ = [
+    "build_observers",
+    "resolve_observer_configs",
+    "ObserverManager",
+    "RealtimeObserver",
+]

--- a/app/ai/voice/agents/breeze_buddy/observers/factory.py
+++ b/app/ai/voice/agents/breeze_buddy/observers/factory.py
@@ -1,10 +1,11 @@
-"""Observer factory — builds RealtimeObserver instances from template config.
+"""Observer factory — builds RealtimeObserver instances from evaluation config.
 
 Uses existing ``get_llm_service()`` for LLM service creation and existing
 ``LLMConfiguration`` for config merging (inherit with override).
 """
 
-from typing import Any, Dict, List, Optional
+import json
+from typing import Any, Dict, List, Optional, Tuple
 
 from app.ai.voice.agents.breeze_buddy.llm import get_llm_service
 from app.ai.voice.agents.breeze_buddy.template.types import (
@@ -13,6 +14,9 @@ from app.ai.voice.agents.breeze_buddy.template.types import (
 )
 from app.ai.voice.llm.types import LLMConfiguration
 from app.core.logger import logger
+from app.database.accessor.breeze_buddy.evaluation_config import (
+    get_observer_evaluation_config,
+)
 
 from .observer import RealtimeObserver
 
@@ -45,11 +49,85 @@ def merge_llm_config(
     )
 
 
+def _legacy_observer_configs(template: Optional[TemplateModel]) -> List[ObserverConfig]:
+    observers = (
+        template.configurations.observers
+        if template and template.configurations
+        else None
+    )
+    return list(observers or [])
+
+
+async def resolve_observer_configs(
+    template: Optional[TemplateModel],
+) -> Tuple[List[ObserverConfig], Optional[str]]:
+    """Resolve observer configs, plus the evaluation_config row id they came from.
+
+    The id is what ``evaluation_result.evaluation_config_id`` (NOT NULL, FK)
+    needs when a detection is recorded. Every legacy-fallback path returns
+    ``None`` for it: those observers live only in the template JSON, so there is
+    no config row to point a result at, and the detection cannot be persisted.
+    """
+    if not template or not template.id:
+        return _legacy_observer_configs(template), None
+
+    try:
+        row = await get_observer_evaluation_config(str(template.id))
+    except Exception:
+        logger.exception(
+            f"Failed to load observer evaluation_config for template {template.id}; "
+            "using legacy config"
+        )
+        return _legacy_observer_configs(template), None
+
+    if not row:
+        return _legacy_observer_configs(template), None
+
+    config_id = str(row["id"]) if row.get("id") else None
+
+    if not row.get("enabled"):
+        logger.info(f"Observer evaluation_config disabled for template {template.id}")
+        return [], config_id
+
+    configuration = row.get("configuration") or {}
+    if isinstance(configuration, str):
+        try:
+            configuration = json.loads(configuration)
+        except json.JSONDecodeError:
+            logger.warning(
+                f"Observer evaluation_config is invalid JSON for template {template.id}; "
+                "using legacy config"
+            )
+            return _legacy_observer_configs(template), None
+
+    observer_rows = (
+        configuration.get("observers") if isinstance(configuration, dict) else None
+    )
+    if not isinstance(observer_rows, list):
+        logger.warning(
+            f"Observer evaluation_config has no observers array for template {template.id}; "
+            "using legacy config"
+        )
+        return _legacy_observer_configs(template), None
+
+    try:
+        return [
+            ObserverConfig.model_validate(observer) for observer in observer_rows
+        ], config_id
+    except Exception:
+        logger.exception(
+            f"Observer evaluation_config validation failed for template {template.id}; "
+            "using legacy config"
+        )
+        return _legacy_observer_configs(template), None
+
+
 async def build_observers(
     configs: List[ObserverConfig],
     template: Optional[TemplateModel],
     agent_context: Any,
     handler_map: Dict[str, Any],
+    evaluation_config_id: Optional[str] = None,
 ) -> List[RealtimeObserver]:
     """Build observer instances from template config."""
     template_llm = (
@@ -75,7 +153,13 @@ async def build_observers(
             merged_config = merge_llm_config(cfg.llm, template_llm)
             llm_service = await get_llm_service(merged_config, pooled=True)
             observers.append(
-                RealtimeObserver(cfg, llm_service, agent_context, handler_map)
+                RealtimeObserver(
+                    cfg,
+                    llm_service,
+                    agent_context,
+                    handler_map,
+                    evaluation_config_id=evaluation_config_id,
+                )
             )
             logger.info(
                 f"Built observer {cfg.name} with model="

--- a/app/ai/voice/agents/breeze_buddy/observers/manager.py
+++ b/app/ai/voice/agents/breeze_buddy/observers/manager.py
@@ -12,10 +12,10 @@ from typing import Any, List
 
 from pipecat.processors.aggregators.llm_context import LLMContext
 
-from app.ai.voice.agents.breeze_buddy.template.types import ActionType
 from app.core.logger import logger
 
 from .observer import RealtimeObserver
+from .utils import is_alert_action
 
 
 class ObserverManager:
@@ -86,21 +86,15 @@ class ObserverManager:
             if self._stopped:
                 return
 
-            def _is_alert(obs: RealtimeObserver) -> bool:
-                return (
-                    obs.config.action is not None
-                    and obs.config.action.type == ActionType.ALERT
-                )
-
             eligible = [
                 obs
                 for obs in self._observers
                 if event_name in obs.config.trigger_on
                 and self._turn_count >= obs.config.start_after_turn
                 and (
-                    _is_alert(obs)
+                    is_alert_action(obs.config.action)
                     and obs.name not in self._fired_alerts
-                    or not _is_alert(obs)
+                    or not is_alert_action(obs.config.action)
                     and obs.name not in self._acted
                 )
             ]
@@ -124,14 +118,23 @@ class ObserverManager:
                 return_exceptions=True,
             )
 
-            for obs, result in zip(eligible, results):
+            # Alerts first. An alert is a notification, not a terminal action —
+            # it never sets ``_action_taken``. Draining them before the
+            # terminal observers keeps a same-batch end_conversation from
+            # returning out of the loop while an alert that also detected is
+            # still waiting its turn. sorted() is stable, so config order still
+            # decides within each group.
+            for obs, result in sorted(
+                zip(eligible, results),
+                key=lambda pair: not is_alert_action(pair[0].config.action),
+            ):
                 if self._action_taken:
                     return
                 if isinstance(result, Exception):
                     logger.error(f"Observer {obs.name} check failed: {result}")
                     continue
                 if result is True:
-                    is_alert = _is_alert(obs)
+                    is_alert = is_alert_action(obs.config.action)
                     if is_alert:
                         self._fired_alerts.add(obs.name)
                     else:

--- a/app/ai/voice/agents/breeze_buddy/observers/observer.py
+++ b/app/ai/voice/agents/breeze_buddy/observers/observer.py
@@ -16,16 +16,42 @@ existing ``update_outcome_in_database`` hook and runs the configured
 """
 
 import time
-from typing import Any, Dict
+from datetime import datetime, timezone
+from typing import Any, Dict, Optional
 
 from pipecat.adapters.schemas.function_schema import FunctionSchema
 
 from app.ai.voice.agents.breeze_buddy.template.context import TemplateContext
-from app.ai.voice.agents.breeze_buddy.template.types import ActionType, ObserverConfig
+from app.ai.voice.agents.breeze_buddy.template.types import ObserverConfig
 from app.core.logger import logger
 
 from .llm import call_llm
-from .utils import set_outcome
+from .utils import is_alert_action, record_detection, set_outcome
+
+# What an observer LLM may put in the stored detection. Its tool arguments are
+# model-authored and can quote the transcript, so anything not named here is
+# dropped rather than written to evaluation_result.
+_DETECTION_ALLOWED_KEYS = ("reason", "confidence")
+_DETECTION_VALUE_MAX_CHARS = 300
+
+
+def _bounded_detection(raw: Any) -> Dict[str, Any]:
+    """Keep only known scalar detection fields, each length-capped."""
+    if not isinstance(raw, dict):
+        return {}
+    bounded: Dict[str, Any] = {}
+    for key in _DETECTION_ALLOWED_KEYS:
+        value = raw.get(key)
+        if isinstance(value, bool) or isinstance(value, (int, float)):
+            bounded[key] = value
+        elif isinstance(value, str) and value.strip():
+            bounded[key] = value[:_DETECTION_VALUE_MAX_CHARS]
+    # Only keys we refused — an allowed key that came in blank is simply empty,
+    # not something withheld.
+    dropped = sorted(set(raw) - set(_DETECTION_ALLOWED_KEYS))
+    if dropped:
+        bounded["dropped_keys"] = dropped
+    return bounded
 
 
 def _build_tool_from_action(config: "ObserverConfig") -> list[FunctionSchema]:
@@ -63,12 +89,14 @@ class RealtimeObserver:
         llm_service: Any,
         agent_context: Any,
         handler_map: Dict[str, Any],
+        evaluation_config_id: Optional[str] = None,
     ) -> None:
         self.config = config
         self.name = config.name
         self._llm_service = llm_service
         self._agent_context = agent_context
         self._handler_map = handler_map
+        self._evaluation_config_id = evaluation_config_id
         self._tools = _build_tool_from_action(config)
         self._last_detection: Dict[str, Any] = {}
 
@@ -103,7 +131,7 @@ class RealtimeObserver:
                 )
                 return False
 
-            self._last_detection = tool_args or {}
+            self._last_detection = _bounded_detection(tool_args)
             # Capture the active node now — by the time execute_action
             # runs, the main LLM may have already transitioned.
             flow_mgr = getattr(self._agent_context, "flow_manager", None)
@@ -132,7 +160,7 @@ class RealtimeObserver:
         lead = self._agent_context.lead
         action = self.config.action
         handler_name = action.handler or (
-            "send_alert" if action.type == ActionType.ALERT else str(action.type.value)
+            "send_alert" if is_alert_action(action) else str(action.type.value)
         )
 
         if lead:
@@ -166,7 +194,7 @@ class RealtimeObserver:
             )
             return
 
-        if action.type == ActionType.ALERT:
+        if is_alert_action(action):
             call_sid = ctx.call_sid
             safe_detection = (
                 list(self._last_detection.keys())
@@ -199,5 +227,25 @@ class RealtimeObserver:
         logger.info(
             f"Observer {self.name} executing action: "
             f"{handler_name}, outcome={outcome}"
+        )
+        # Recorded before the handler runs: end_conversation tears the pipeline
+        # down, so anything after it never gets the chance to write. ``type``
+        # becomes the ``result`` column on evaluation_result.
+        await record_detection(
+            agent_context=self._agent_context,
+            evaluation_config_id=self._evaluation_config_id,
+            observer_name=self.name,
+            detection={
+                "type": self.name,
+                "label": self.name.replace("_", " ").title(),
+                "observer_name": self.name,
+                "triggered_at": datetime.now(timezone.utc).isoformat(),
+                "node": getattr(self, "_detected_at_node", None),
+                "action_type": action.type.value,
+                "handler": handler_name,
+                "args": action.args or {},
+                "outcome": outcome,
+                "detection": self._last_detection,
+            },
         )
         await handler(handler_args)

--- a/app/ai/voice/agents/breeze_buddy/observers/utils.py
+++ b/app/ai/voice/agents/breeze_buddy/observers/utils.py
@@ -1,9 +1,25 @@
 """Utility functions for observers."""
 
+from datetime import datetime, timezone
+from typing import Any, Dict, Optional
+
 from app.ai.voice.agents.breeze_buddy.template.context import TemplateContext
 from app.ai.voice.agents.breeze_buddy.template.hooks import HookConfig, HookRegistry
-from app.ai.voice.agents.breeze_buddy.template.types import FieldConfig, FieldSource
+from app.ai.voice.agents.breeze_buddy.template.types import (
+    ActionType,
+    FieldConfig,
+    FieldSource,
+    FlowAction,
+)
 from app.core.logger import logger
+from app.database.accessor.breeze_buddy.evaluation_result import (
+    save_evaluation_results,
+)
+
+
+def is_alert_action(action: Optional[FlowAction]) -> bool:
+    """Alerts are notifications, not terminal actions — they never end a call."""
+    return action is not None and action.type == ActionType.ALERT
 
 
 async def set_outcome(
@@ -37,3 +53,51 @@ async def set_outcome(
         triggered_by or "set_outcome",
         hook_config,
     )
+
+
+async def record_detection(
+    agent_context: Any,
+    evaluation_config_id: Optional[str],
+    observer_name: str,
+    detection: Dict[str, Any],
+) -> None:
+    """Persist one observer detection to ``evaluation_result``.
+
+    Best-effort: an analytics write must never stop the observer's real action,
+    so every failure path returns quietly.
+
+    ``evaluation_config_id`` is a NOT NULL FK, so observers still coming from
+    the legacy template JSON have no row to point at and cannot be stored.
+    """
+    lead = getattr(agent_context, "lead", None)
+    template = getattr(agent_context, "template", None)
+    template_id = getattr(lead, "template_id", None) or getattr(template, "id", None)
+    if not lead or not template_id:
+        return
+
+    source_id = str(getattr(lead, "id", None) or getattr(lead, "call_id", ""))
+    reseller_id = getattr(lead, "reseller_id", None)
+    if not source_id or not reseller_id:
+        return
+
+    if not evaluation_config_id:
+        logger.warning(
+            f"Observer {observer_name} detected but has no evaluation_config row; "
+            "detection not recorded"
+        )
+        return
+
+    detected_at = datetime.now(timezone.utc)
+    try:
+        await save_evaluation_results(
+            evaluation_config_id=evaluation_config_id,
+            evaluation_type="OBSERVER",
+            source_id=source_id,
+            reseller_id=str(reseller_id),
+            merchant_id=getattr(lead, "merchant_id", None),
+            template_id=str(template_id),
+            started_at=getattr(lead, "call_initiated_time", None) or detected_at,
+            results=[detection],
+        )
+    except Exception:
+        logger.exception(f"Failed to record observer detection for {observer_name}")

--- a/app/api/routers/breeze_buddy/analytics/__init__.py
+++ b/app/api/routers/breeze_buddy/analytics/__init__.py
@@ -37,6 +37,7 @@ from .handlers import (
     get_distinct_resellers,
     get_lead_based_analytics,
     get_lead_status_counts,
+    get_observer_based_analytics,
     get_outcome_counts,
     get_performance_analytics,
     get_telephony_numbers_analytics,
@@ -71,6 +72,7 @@ _ANALYTICS_HANDLERS: Dict[AnalyticsType, Callable[..., Awaitable]] = {
     AnalyticsType.CHATS_BY_HOUR: get_chats_by_hour_analytics,
     AnalyticsType.TOPIC_DASHBOARD: get_topic_dashboard_analytics,
     AnalyticsType.TOPIC_CONVERSATIONS: get_topic_conversations_analytics,
+    AnalyticsType.OBSERVER_BASED: get_observer_based_analytics,
 }
 
 

--- a/app/api/routers/breeze_buddy/analytics/handlers.py
+++ b/app/api/routers/breeze_buddy/analytics/handlers.py
@@ -3,10 +3,12 @@ Analytics service layer — all business logic for analytics endpoints.
 Database access is delegated to the accessor layer.
 """
 
+import asyncio
 import csv
 import io
 import json
-from datetime import datetime, timedelta
+from collections import Counter
+from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, List, Optional
 from uuid import UUID
 
@@ -41,6 +43,12 @@ from app.database.accessor.breeze_buddy.analytics.evaluation_result import (
     get_topic_conversations,
     get_topic_dashboard,
 )
+from app.database.accessor.breeze_buddy.analytics.observer_result import (
+    get_legacy_observer_detection_rows_from_db,
+    get_observer_aggregate_rows_from_db,
+    get_observer_detection_rows_from_db,
+    get_observer_eligible_conversation_count_from_db,
+)
 from app.database.accessor.breeze_buddy.chat_analytics import (
     get_chat_summary_from_db,
     get_chat_trends_from_db,
@@ -51,6 +59,37 @@ from app.database.accessor.breeze_buddy.telephony_number import (
 )
 from app.schemas import CallDetailGroupedResult, CallDetailResult, UserInfo
 from app.utils.common import parse_json
+
+
+def _pct(numerator: int, denominator: int) -> float:
+    return round((numerator / denominator) * 100, 2) if denominator else 0.0
+
+
+def _observer_action(row: Dict[str, Any]) -> str:
+    return row.get("handler") or row.get("action_type") or "unknown"
+
+
+def _observer_sort_key(row: Dict[str, Any]) -> datetime:
+    """Newest-first ordering key for merged detection rows.
+
+    Sorting the ISO strings instead put naive and tz-aware timestamps in the
+    wrong order (``+00:00`` sorts after a bare time) and floated rows with no
+    timestamp to the top. Rows without ``started_at`` sort last on a descending
+    sort.
+    """
+    started_at = row.get("started_at")
+    if not isinstance(started_at, datetime):
+        return datetime.min.replace(tzinfo=timezone.utc)
+    if started_at.tzinfo is None:
+        return started_at.replace(tzinfo=timezone.utc)
+    return started_at
+
+
+def _observer_started_iso(row: Dict[str, Any]) -> Optional[str]:
+    started_at = row.get("started_at")
+    if isinstance(started_at, datetime):
+        return started_at.isoformat()
+    return str(started_at) if started_at else None
 
 
 def parse_outcome_breakdown(outcome_breakdown: Any) -> Dict[str, int]:
@@ -346,6 +385,146 @@ async def get_chat_based_analytics(
         "filters_applied": filters,
         "time_granularity": None,
         "results": results,
+    }
+
+
+async def get_observer_based_analytics(
+    filters: Dict[str, Any], options: Dict[str, Any], current_user: UserInfo
+) -> Dict[str, Any]:
+    """Observer fire analytics from evaluation_result."""
+    limit = min(int(options.get("limit") or 1000), 1000)
+    # ``rows`` is capped and feeds only the "recent fires" list. Every count
+    # comes from the aggregate query instead, which groups in SQL over the full
+    # match set — deriving totals from a capped list under-reported them.
+    aggregates, rows, legacy_rows, eligible_conversations = await asyncio.gather(
+        get_observer_aggregate_rows_from_db(filters),
+        get_observer_detection_rows_from_db(filters, limit=limit),
+        get_legacy_observer_detection_rows_from_db(filters, limit=limit),
+        get_observer_eligible_conversation_count_from_db(filters),
+    )
+    rows = sorted([*rows, *legacy_rows], key=_observer_sort_key, reverse=True)[:limit]
+
+    total_fires = 0
+    by_observer: Dict[str, Dict[str, Any]] = {}
+    action_counts: Counter[str] = Counter()
+    outcome_counts: Counter[str] = Counter()
+    trend_counts: Counter[str] = Counter()
+
+    for group in aggregates:
+        observer_name = group.get("observer_name") or "unknown"
+        action = group.get("action") or "unknown"
+        outcome = group.get("outcome") or "unchanged"
+        day = group.get("day")
+        fires = int(group.get("fires") or 0)
+
+        total_fires += fires
+        action_counts[action] += fires
+        outcome_counts[outcome] += fires
+        if day:
+            trend_counts[day.isoformat()] += fires
+
+        entry = by_observer.setdefault(
+            observer_name,
+            {
+                "observer_name": observer_name,
+                "triggers": 0,
+                "actions": Counter(),
+                "outcomes": Counter(),
+                "last_triggered": None,
+                "last_source_id": None,
+            },
+        )
+        entry["triggers"] += fires
+        entry["actions"][action] += fires
+        entry["outcomes"][outcome] += fires
+
+        # Groups arrive unordered, so keep the newest rather than the first.
+        last = group.get("last_triggered")
+        if last and (
+            entry["last_triggered"] is None
+            or last.isoformat() > entry["last_triggered"]
+        ):
+            entry["last_triggered"] = last.isoformat()
+            entry["last_source_id"] = group.get("last_source_id")
+
+    observer_results = []
+    for observer_name, entry in by_observer.items():
+        top_action = entry["actions"].most_common(1)[0][0] if entry["actions"] else None
+        top_outcome = (
+            entry["outcomes"].most_common(1)[0][0] if entry["outcomes"] else None
+        )
+        observer_results.append(
+            {
+                "observer_name": observer_name,
+                "triggers": entry["triggers"],
+                "trigger_rate": _pct(entry["triggers"], eligible_conversations),
+                "top_action": top_action,
+                "top_outcome": top_outcome,
+                "last_triggered": entry["last_triggered"],
+                "last_source_id": entry["last_source_id"],
+            }
+        )
+    observer_results.sort(key=lambda item: (-item["triggers"], item["observer_name"]))
+
+    action_breakdown = [
+        {
+            "action": action,
+            "count": count,
+            "percentage": _pct(count, total_fires),
+        }
+        for action, count in action_counts.most_common()
+    ]
+    outcome_breakdown = [
+        {
+            "outcome": outcome,
+            "count": count,
+            "percentage": _pct(count, total_fires),
+        }
+        for outcome, count in outcome_counts.most_common()
+    ]
+    trend = [
+        {"date": day, "triggers": count}
+        for day, count in sorted(trend_counts.items(), key=lambda item: item[0])
+    ]
+    recent_limit = min(int(options.get("recent_limit") or 50), 50)
+    recent_fires = [
+        {
+            "source_id": row.get("source_id"),
+            "conversation_id": row.get("call_id") or row.get("source_id"),
+            "observer_name": row.get("observer_name"),
+            "action": _observer_action(row),
+            "outcome": row.get("outcome"),
+            "node": row.get("node"),
+            "triggered_at": _observer_started_iso(row),
+        }
+        for row in rows[:recent_limit]
+    ]
+
+    most_active = observer_results[0] if observer_results else None
+
+    return {
+        "type": "observer-based",
+        "filters_applied": filters,
+        "results": [
+            {
+                "summary": {
+                    "total_triggers": total_fires,
+                    "eligible_conversations": eligible_conversations,
+                    "trigger_rate": _pct(total_fires, eligible_conversations),
+                    "most_active_observer": (
+                        most_active["observer_name"] if most_active else None
+                    ),
+                    "most_active_triggers": (
+                        most_active["triggers"] if most_active else 0
+                    ),
+                },
+                "trend": trend,
+                "action_breakdown": action_breakdown,
+                "outcome_breakdown": outcome_breakdown,
+                "observers": observer_results,
+                "recent_fires": recent_fires,
+            }
+        ],
     }
 
 

--- a/app/api/routers/breeze_buddy/templates/handlers.py
+++ b/app/api/routers/breeze_buddy/templates/handlers.py
@@ -25,6 +25,7 @@ from app.core.logger import logger
 from app.database.accessor import get_telephony_number_by_id, get_template_in_scope
 from app.database.accessor.breeze_buddy.evaluation_config import (
     initialize_evaluation_config,
+    upsert_observer_evaluation_config,
 )
 from app.database.accessor.breeze_buddy.template import (
     check_template_usage,
@@ -41,6 +42,58 @@ from app.schemas.breeze_buddy.template import (
 )
 
 from .rbac import apply_hierarchical_template_filters, validate_template_access
+
+
+async def sync_observer_evaluation_config(
+    template_id: str,
+    configurations: Optional[Dict[str, Any]],
+    *,
+    raise_on_failure: bool = True,
+) -> None:
+    """Mirror ``configurations.observers`` into the OBSERVER evaluation_config row.
+
+    The runtime reads that row first, so this write is what makes an edit
+    actually take effect. Clients send the complete list every time, so the
+    first write also backfills the template's existing observers.
+
+    Row-level ``enabled`` stays ``True`` — the console toggles the per-observer
+    flag instead, and ``False`` here would silently drop every observer. A
+    request omitting ``observers`` is left alone so a partial PUT can't wipe the
+    row.
+
+    ``raise_on_failure`` is for the create path: the template row has already
+    committed, so a 500 there tells the caller the create failed when it did
+    not, and their retry hits the 409 duplicate guard instead. Creating without
+    the row only costs detection recording — observers still run off the
+    template JSON — so create logs and moves on.
+    """
+    if not configurations or "observers" not in configurations:
+        return
+
+    try:
+        await upsert_observer_evaluation_config(
+            template_id=template_id,
+            configuration={"observers": configurations.get("observers") or []},
+            enabled=True,
+        )
+    except Exception as e:
+        # On replace, staying quiet would report a config as live while calls
+        # keep using the previous one, and a retried PUT is idempotent — so fail
+        # loudly there. See ``raise_on_failure`` for why create differs.
+        logger.exception(
+            f"Failed to sync observers into evaluation_config for template "
+            f"{template_id}"
+        )
+        if not raise_on_failure:
+            return
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=(
+                "Template saved, but the observer configuration could not be "
+                "stored, so observers still run the previous config. Retry the "
+                "save."
+            ),
+        ) from e
 
 
 async def create_template_handler(
@@ -167,6 +220,10 @@ async def create_template_handler(
                     f"Failed to initialize topic evaluation for template "
                     f"{template.id}: {e}"
                 )
+
+        await sync_observer_evaluation_config(
+            str(template.id), configurations, raise_on_failure=False
+        )
 
         logger.info(
             f"Successfully created template with id: {template.id} containing flow "
@@ -532,6 +589,8 @@ async def replace_template_handler(
                     f"Failed to initialize topic evaluation for template "
                     f"{updated_template.id}: {e}"
                 )
+
+        await sync_observer_evaluation_config(template_id, configurations)
 
         # Cache invalidation is best-effort: the DB write has already
         # committed, so a Redis blip here must not surface as a 500 to a

--- a/app/database/accessor/breeze_buddy/analytics/observer_result.py
+++ b/app/database/accessor/breeze_buddy/analytics/observer_result.py
@@ -1,0 +1,62 @@
+"""Database access for observer analytics over evaluation_result."""
+
+from typing import Any, Dict, List
+
+from app.core.logger import logger
+from app.database.queries import run_parameterized_query
+from app.database.queries.breeze_buddy.analytics.observer_result import (
+    get_legacy_observer_detection_rows_query,
+    get_observer_aggregate_rows_query,
+    get_observer_detection_rows_query,
+    get_observer_eligible_conversation_count_query,
+)
+
+
+async def get_observer_detection_rows_from_db(
+    filters: Dict[str, Any],
+    limit: int = 10000,
+) -> List[Dict[str, Any]]:
+    try:
+        query, values = get_observer_detection_rows_query(filters, limit=limit)
+        rows = await run_parameterized_query(query, values)
+        return [dict(row) for row in rows]
+    except Exception as e:
+        logger.error(f"Error fetching observer detection rows: {e}")
+        raise
+
+
+async def get_legacy_observer_detection_rows_from_db(
+    filters: Dict[str, Any],
+    limit: int = 1000,
+) -> List[Dict[str, Any]]:
+    try:
+        query, values = get_legacy_observer_detection_rows_query(filters, limit=limit)
+        rows = await run_parameterized_query(query, values)
+        return [dict(row) for row in rows]
+    except Exception as e:
+        logger.error(f"Error fetching legacy observer detection rows: {e}")
+        raise
+
+
+async def get_observer_eligible_conversation_count_from_db(
+    filters: Dict[str, Any],
+) -> int:
+    try:
+        query, values = get_observer_eligible_conversation_count_query(filters)
+        rows = await run_parameterized_query(query, values)
+        return int(rows[0]["total"]) if rows else 0
+    except Exception as e:
+        logger.error(f"Error counting observer-eligible conversations: {e}")
+        raise
+
+
+async def get_observer_aggregate_rows_from_db(
+    filters: Dict[str, Any],
+) -> List[Dict[str, Any]]:
+    try:
+        query, values = get_observer_aggregate_rows_query(filters)
+        rows = await run_parameterized_query(query, values)
+        return [dict(row) for row in rows]
+    except Exception as e:
+        logger.error(f"Error aggregating observer detections: {e}")
+        raise

--- a/app/database/accessor/breeze_buddy/evaluation_config.py
+++ b/app/database/accessor/breeze_buddy/evaluation_config.py
@@ -7,10 +7,12 @@ from app.database.queries.breeze_buddy.evaluation_config import (
     add_discovered_topics_query,
     get_enabled_evaluations_query,
     get_evaluation_config_query,
+    get_observer_evaluation_config_query,
     has_enabled_evaluations_query,
     initialize_evaluation_config_query,
     set_evaluation_enabled_query,
     update_evaluation_configuration_query,
+    upsert_observer_evaluation_config_query,
 )
 
 
@@ -21,6 +23,24 @@ async def initialize_evaluation_config(template_id: str) -> None:
 
 async def get_evaluation_config(template_id: str) -> Optional[Dict[str, Any]]:
     query, values = get_evaluation_config_query(template_id)
+    rows = await run_parameterized_query(query, values)
+    return dict(rows[0]) if rows else None
+
+
+async def get_observer_evaluation_config(template_id: str) -> Optional[Dict[str, Any]]:
+    query, values = get_observer_evaluation_config_query(template_id)
+    rows = await run_parameterized_query(query, values)
+    return dict(rows[0]) if rows else None
+
+
+async def upsert_observer_evaluation_config(
+    template_id: str,
+    configuration: Dict[str, Any],
+    enabled: bool,
+) -> Optional[Dict[str, Any]]:
+    query, values = upsert_observer_evaluation_config_query(
+        template_id, configuration, enabled
+    )
     rows = await run_parameterized_query(query, values)
     return dict(rows[0]) if rows else None
 

--- a/app/database/migrations/046_add_observer_evaluation_type.sql
+++ b/app/database/migrations/046_add_observer_evaluation_type.sql
@@ -1,0 +1,1 @@
+ALTER TYPE evaluation_type ADD VALUE IF NOT EXISTS 'OBSERVER';

--- a/app/database/migrations/047_allow_observer_evaluation_config.sql
+++ b/app/database/migrations/047_allow_observer_evaluation_config.sql
@@ -1,0 +1,24 @@
+-- Observer configs are shaped { "observers": [...] }, not the { model,
+-- system_prompt } that 044 wrote the check for, so the TOPIC-only constraint
+-- rejects them. Widen it per evaluation_type.
+--
+-- Separate from 046 on purpose: Postgres refuses to use an enum value in the
+-- same transaction that added it, and the runner wraps each file in its own
+-- transaction. Merging these two files makes the migration fail.
+ALTER TABLE evaluation_config DROP CONSTRAINT evaluation_config_runtime_check;
+
+ALTER TABLE evaluation_config
+    ADD CONSTRAINT evaluation_config_runtime_check
+    CHECK (
+        (
+            evaluation_type = 'TOPIC'
+            AND jsonb_typeof(configuration -> 'model') = 'string'
+            AND btrim(COALESCE(configuration ->> 'model', '')) <> ''
+            AND jsonb_typeof(configuration -> 'system_prompt') = 'string'
+            AND btrim(COALESCE(configuration ->> 'system_prompt', '')) <> ''
+        )
+        OR (
+            evaluation_type = 'OBSERVER'
+            AND jsonb_typeof(configuration -> 'observers') = 'array'
+        )
+    );

--- a/app/database/migrations/048_backfill_observer_evaluation_config.sql
+++ b/app/database/migrations/048_backfill_observer_evaluation_config.sql
@@ -1,0 +1,31 @@
+-- Copy every template's observers into evaluation_config.
+--
+-- The runtime reads that row first and only falls back to the template JSON
+-- when none exists — but a detection cannot be stored on the fallback path,
+-- because evaluation_result.evaluation_config_id is a NOT NULL FK. Without this
+-- backfill, a template's detections stay unrecorded until someone happens to
+-- save it from the console.
+--
+-- Runs after 046 (adds the OBSERVER enum value) and 047 (widens the runtime
+-- check to accept the { "observers": [...] } shape) — both are required for
+-- these rows to insert at all.
+--
+-- ON CONFLICT DO NOTHING: rows the API has already written are the fresher
+-- copy, so this must never overwrite them. That also makes the migration safe
+-- to re-run.
+INSERT INTO evaluation_config (
+    template_id, evaluation_type, enabled, topics, configuration
+)
+SELECT
+    t.id,
+    'OBSERVER',
+    TRUE,
+    ARRAY[]::text[],
+    jsonb_build_object('observers', t.configurations -> 'observers')
+FROM template t
+-- Compared as jsonb rather than via jsonb_array_length: some templates hold a
+-- non-array under this key, and Postgres does not promise to evaluate the type
+-- check first, so the length call errors on them.
+WHERE jsonb_typeof(t.configurations -> 'observers') = 'array'
+  AND t.configurations -> 'observers' <> '[]'::jsonb
+ON CONFLICT (template_id, evaluation_type) DO NOTHING;

--- a/app/database/queries/breeze_buddy/analytics/observer_result.py
+++ b/app/database/queries/breeze_buddy/analytics/observer_result.py
@@ -1,0 +1,330 @@
+"""SQL for observer evaluation analytics."""
+
+from datetime import datetime, timedelta
+from typing import Any, Dict, List, Tuple
+
+from app.database.queries.breeze_buddy.analytics.analytics import (
+    TELEPHONY_NUMBER_TABLE,
+    build_analytics_where_clause,
+    convert_ist_to_utc,
+)
+
+
+def _provider_join(filters: Dict[str, Any]) -> str:
+    """``build_analytics_where_clause`` emits ``ou.provider`` for a provider
+    filter but leaves the join to the caller, so every query built on it must
+    add this or the SQL references an undefined alias."""
+    if not filters.get("provider"):
+        return ""
+    return f'LEFT JOIN "{TELEPHONY_NUMBER_TABLE}" ou ON lct.telephony_number_id = ou.id'
+
+
+def _observer_result_filters(
+    filters: Dict[str, Any],
+    *,
+    value_offset: int = 0,
+) -> Tuple[List[str], List[Any]]:
+    clauses = [
+        "er.status = 'COMPLETED'",
+        "er.evaluation_type = 'OBSERVER'",
+        "er.result IS NOT NULL",
+    ]
+    values: List[Any] = []
+
+    if filters.get("template") or filters.get("template_id"):
+        values.append(filters.get("template_id") or filters.get("template"))
+        clauses.append(f"er.template_id = ${len(values) + value_offset}::uuid")
+
+    if filters.get("reseller_id"):
+        values.append(filters["reseller_id"])
+        clauses.append(f"er.reseller_id = ${len(values) + value_offset}")
+
+    if filters.get("reseller_ids"):
+        values.append(filters["reseller_ids"])
+        clauses.append(f"er.reseller_id = ANY(${len(values) + value_offset})")
+
+    if filters.get("merchant_id"):
+        values.append(filters["merchant_id"])
+        clauses.append(f"er.merchant_id = ${len(values) + value_offset}")
+
+    if filters.get("merchant_ids"):
+        values.append(filters["merchant_ids"])
+        clauses.append(f"er.merchant_id = ANY(${len(values) + value_offset})")
+
+    if filters.get("observer_name"):
+        values.append(filters["observer_name"])
+        clauses.append(f"er.result = ${len(values) + value_offset}")
+
+    if filters.get("date_from"):
+        date_from = filters["date_from"]
+        if isinstance(date_from, datetime):
+            values.append(convert_ist_to_utc(date_from))
+        else:
+            values.append(
+                convert_ist_to_utc(datetime.combine(date_from, datetime.min.time()))
+            )
+        clauses.append(f"er.started_at >= ${len(values) + value_offset}")
+
+    if filters.get("date_to"):
+        date_to = filters["date_to"]
+        if isinstance(date_to, datetime):
+            values.append(convert_ist_to_utc(date_to))
+        else:
+            next_day_start_ist = datetime.combine(
+                date_to, datetime.min.time()
+            ) + timedelta(days=1)
+            values.append(convert_ist_to_utc(next_day_start_ist))
+        clauses.append(f"er.started_at < ${len(values) + value_offset}")
+
+    return clauses, values
+
+
+def get_observer_detection_rows_query(
+    filters: Dict[str, Any],
+    limit: int = 10000,
+) -> Tuple[str, List[Any]]:
+    clauses, values = _observer_result_filters(filters)
+    clauses.append("lct.execution_mode IN ('TELEPHONY', 'HOLD_TRANSFER')")
+    values.append(limit)
+    limit_index = len(values)
+    where = " AND ".join(clauses)
+    query = f"""
+        SELECT
+            er.source_id,
+            er.reseller_id,
+            er.merchant_id,
+            er.template_id::text AS template_id,
+            template.name AS template_name,
+            er.started_at,
+            er.result AS observer_name,
+            er.metadata AS detection,
+            er.metadata ->> 'handler' AS handler,
+            er.metadata ->> 'action_type' AS action_type,
+            er.metadata ->> 'outcome' AS outcome,
+            er.metadata ->> 'node' AS node,
+            lct.call_id
+        FROM evaluation_result er
+        LEFT JOIN template ON template.id = er.template_id
+        LEFT JOIN lead_call_tracker lct ON lct.id::text = er.source_id
+        WHERE {where}
+        ORDER BY er.started_at DESC, er.id DESC
+        LIMIT ${limit_index}
+    """
+    return query, values
+
+
+def get_legacy_observer_detection_rows_query(
+    filters: Dict[str, Any],
+    limit: int = 1000,
+) -> Tuple[str, List[Any]]:
+    conditions, values = build_analytics_where_clause(
+        filters, filter_execution_mode=False
+    )
+    conditions.extend(
+        [
+            "lct.execution_mode IN ('TELEPHONY', 'HOLD_TRANSFER')",
+            "lct.call_initiated_time IS NOT NULL",
+            "lct.outcome IS NOT NULL",
+            "observer.value ->> 'name' IS NOT NULL",
+            "COALESCE((observer.value ->> 'enabled')::boolean, TRUE)",
+            "observer_action.value #>> '{args,outcome}' = lct.outcome",
+            (
+                "NOT EXISTS ("
+                "SELECT 1 FROM evaluation_result er "
+                "WHERE er.evaluation_type = 'OBSERVER' "
+                "AND er.source_id = lct.id::text "
+                "AND er.result = observer.value ->> 'name'"
+                ")"
+            ),
+        ]
+    )
+
+    if filters.get("observer_name"):
+        values.append(filters["observer_name"])
+        conditions.append(f"observer.value ->> 'name' = ${len(values)}")
+
+    values.append(limit)
+    limit_index = len(values)
+    where = " AND ".join(conditions) if conditions else "TRUE"
+    # DISTINCT ON collapses the action lateral: an observer configured with
+    # more than one action whose args.outcome matches the call would otherwise
+    # yield a row per action, double-counting one fire. Keeping the first action
+    # mirrors the runtime, which reports a single action per detection.
+    query = f"""
+        SELECT *
+        FROM (
+            SELECT DISTINCT ON (lct.id, observer.value ->> 'name')
+            lct.id::text AS source_id,
+            lct.reseller_id,
+            lct.merchant_id,
+            lct.template_id::text AS template_id,
+            template.name AS template_name,
+            lct.call_initiated_time AS started_at,
+            observer.value ->> 'name' AS observer_name,
+            jsonb_build_object(
+                'type', observer.value ->> 'name',
+                'label', observer.value ->> 'name',
+                'observer_name', observer.value ->> 'name',
+                'handler', observer_action.value ->> 'handler',
+                'action_type', observer_action.value ->> 'type',
+                'outcome', lct.outcome,
+                'legacy_inferred', TRUE
+            ) AS detection,
+            observer_action.value ->> 'handler' AS handler,
+            observer_action.value ->> 'type' AS action_type,
+            lct.outcome,
+            NULL::text AS node,
+            lct.call_id
+        FROM lead_call_tracker lct
+        JOIN template ON template.id = lct.template_id
+        CROSS JOIN LATERAL jsonb_array_elements(
+            CASE
+                WHEN jsonb_typeof(template.configurations -> 'observers') = 'array'
+                    THEN template.configurations -> 'observers'
+                ELSE '[]'::jsonb
+            END
+        ) AS observer(value)
+        CROSS JOIN LATERAL jsonb_array_elements(
+            CASE
+                WHEN jsonb_typeof(observer.value -> 'actions') = 'array'
+                    THEN observer.value -> 'actions'
+                WHEN jsonb_typeof(observer.value -> 'action') = 'object'
+                    THEN jsonb_build_array(observer.value -> 'action')
+                ELSE '[]'::jsonb
+            END
+        ) AS observer_action(value)
+        {_provider_join(filters)}
+        WHERE {where}
+        ORDER BY lct.id, observer.value ->> 'name', lct.call_initiated_time DESC
+        ) legacy_fire
+        ORDER BY legacy_fire.started_at DESC, legacy_fire.source_id DESC
+        LIMIT ${limit_index}
+    """
+    return query, values
+
+
+def get_observer_eligible_conversation_count_query(
+    filters: Dict[str, Any],
+) -> Tuple[str, List[Any]]:
+    conditions, values = build_analytics_where_clause(
+        filters, filter_execution_mode=False
+    )
+    conditions.append("lct.execution_mode IN ('TELEPHONY', 'HOLD_TRANSFER')")
+    conditions.append("lct.call_initiated_time IS NOT NULL")
+    where = " AND ".join(conditions) if conditions else "TRUE"
+    query = f"""
+        SELECT COUNT(DISTINCT lct.id) AS total
+        FROM lead_call_tracker lct
+        {_provider_join(filters)}
+        WHERE {where}
+    """
+    return query, values
+
+
+def get_observer_aggregate_rows_query(
+    filters: Dict[str, Any],
+) -> Tuple[str, List[Any]]:
+    """Counts grouped in SQL, so totals are not capped by a row limit.
+
+    The detection-row queries fetch at most ``limit`` rows for the "recent
+    fires" list; deriving totals from that list under-reports every number once
+    a template crosses the cap. This aggregates the full match set instead —
+    one row per (observer, action, outcome, day), which stays small.
+    """
+    clauses, values = _observer_result_filters(filters)
+    clauses.append("lct.execution_mode IN ('TELEPHONY', 'HOLD_TRANSFER')")
+    new_where = " AND ".join(clauses)
+
+    legacy_conditions, legacy_values = build_analytics_where_clause(
+        filters, filter_execution_mode=False, value_offset=len(values)
+    )
+    legacy_conditions.extend(
+        [
+            "lct.execution_mode IN ('TELEPHONY', 'HOLD_TRANSFER')",
+            "lct.call_initiated_time IS NOT NULL",
+            "lct.outcome IS NOT NULL",
+            "observer.value ->> 'name' IS NOT NULL",
+            "COALESCE((observer.value ->> 'enabled')::boolean, TRUE)",
+            "observer_action.value #>> '{args,outcome}' = lct.outcome",
+            (
+                "NOT EXISTS ("
+                "SELECT 1 FROM evaluation_result er "
+                "WHERE er.evaluation_type = 'OBSERVER' "
+                "AND er.source_id = lct.id::text "
+                "AND er.result = observer.value ->> 'name'"
+                ")"
+            ),
+        ]
+    )
+    if filters.get("observer_name"):
+        legacy_values.append(filters["observer_name"])
+        legacy_conditions.append(
+            f"observer.value ->> 'name' = ${len(values) + len(legacy_values)}"
+        )
+    legacy_where = " AND ".join(legacy_conditions) if legacy_conditions else "TRUE"
+    values.extend(legacy_values)
+
+    query = f"""
+        WITH fires AS (
+            SELECT
+                er.source_id,
+                er.result AS observer_name,
+                COALESCE(
+                    er.metadata ->> 'handler',
+                    er.metadata ->> 'action_type',
+                    'unknown'
+                ) AS action,
+                COALESCE(NULLIF(er.metadata ->> 'outcome', ''), 'unchanged') AS outcome,
+                er.started_at
+            FROM evaluation_result er
+            LEFT JOIN lead_call_tracker lct ON lct.id::text = er.source_id
+            WHERE {new_where}
+
+            UNION ALL
+
+            SELECT * FROM (
+                SELECT DISTINCT ON (lct.id, observer.value ->> 'name')
+                    lct.id::text AS source_id,
+                    observer.value ->> 'name' AS observer_name,
+                    COALESCE(
+                        observer_action.value ->> 'handler',
+                        observer_action.value ->> 'type',
+                        'unknown'
+                    ) AS action,
+                    COALESCE(NULLIF(lct.outcome, ''), 'unchanged') AS outcome,
+                    lct.call_initiated_time AS started_at
+                FROM lead_call_tracker lct
+                JOIN template ON template.id = lct.template_id
+                CROSS JOIN LATERAL jsonb_array_elements(
+                    CASE
+                        WHEN jsonb_typeof(template.configurations -> 'observers') = 'array'
+                            THEN template.configurations -> 'observers'
+                        ELSE '[]'::jsonb
+                    END
+                ) AS observer(value)
+                CROSS JOIN LATERAL jsonb_array_elements(
+                    CASE
+                        WHEN jsonb_typeof(observer.value -> 'actions') = 'array'
+                            THEN observer.value -> 'actions'
+                        WHEN jsonb_typeof(observer.value -> 'action') = 'object'
+                            THEN jsonb_build_array(observer.value -> 'action')
+                        ELSE '[]'::jsonb
+                    END
+                ) AS observer_action(value)
+                {_provider_join(filters)}
+                WHERE {legacy_where}
+                ORDER BY lct.id, observer.value ->> 'name', lct.call_initiated_time DESC
+            ) legacy_fire
+        )
+        SELECT
+            observer_name,
+            action,
+            outcome,
+            (started_at AT TIME ZONE 'UTC')::date AS day,
+            COUNT(*) AS fires,
+            MAX(started_at) AS last_triggered,
+            (ARRAY_AGG(source_id ORDER BY started_at DESC))[1] AS last_source_id
+        FROM fires
+        GROUP BY observer_name, action, outcome, day
+    """
+    return query, values

--- a/app/database/queries/breeze_buddy/evaluation_config.py
+++ b/app/database/queries/breeze_buddy/evaluation_config.py
@@ -19,6 +19,36 @@ def get_evaluation_config_query(template_id: str) -> Tuple[str, List[Any]]:
     return query, [template_id]
 
 
+def get_observer_evaluation_config_query(template_id: str) -> Tuple[str, List[Any]]:
+    query = f"""
+        SELECT {_CONFIG_COLUMNS}
+        FROM evaluation_config
+        WHERE template_id = $1::uuid
+          AND evaluation_type = 'OBSERVER'
+    """
+    return query, [template_id]
+
+
+def upsert_observer_evaluation_config_query(
+    template_id: str,
+    configuration: Dict[str, Any],
+    enabled: bool,
+) -> Tuple[str, List[Any]]:
+    query = f"""
+        INSERT INTO evaluation_config (
+            template_id, evaluation_type, enabled, topics, configuration
+        )
+        VALUES ($1::uuid, 'OBSERVER', $2::boolean, ARRAY[]::text[], $3::jsonb)
+        ON CONFLICT (template_id, evaluation_type)
+        DO UPDATE SET
+            enabled = EXCLUDED.enabled,
+            topics = ARRAY[]::text[],
+            configuration = EXCLUDED.configuration
+        RETURNING {_CONFIG_COLUMNS}
+    """
+    return query, [template_id, enabled, json.dumps(configuration)]
+
+
 def initialize_evaluation_config_query(template_id: str) -> Tuple[str, List[Any]]:
     query = """
         INSERT INTO evaluation_config (

--- a/app/schemas/breeze_buddy/analytics.py
+++ b/app/schemas/breeze_buddy/analytics.py
@@ -31,6 +31,7 @@ class AnalyticsType(str, Enum):
     CHATS_BY_HOUR = "chats-by-hour"
     TOPIC_DASHBOARD = "topic-dashboard"
     TOPIC_CONVERSATIONS = "topic-conversations"
+    OBSERVER_BASED = "observer-based"
 
     @classmethod
     def _missing_(cls, value: object) -> Optional["AnalyticsType"]:
@@ -137,6 +138,9 @@ class AnalyticsFilters(BaseModel):
         None,
         max_length=200,
         description="Exact underlying stable keys when opening the virtual Other topic group",
+    )
+    observer_name: Optional[str] = Field(
+        None, description="Filter observer analytics by observer name"
     )
 
 

--- a/tests/test_realtime_observers.py
+++ b/tests/test_realtime_observers.py
@@ -1,7 +1,10 @@
 import asyncio
+from datetime import datetime, timezone
 from types import SimpleNamespace
+from typing import List, cast
 
 import pytest
+from fastapi import HTTPException
 from pipecat.processors.aggregators.llm_context import LLMContext
 
 from app.ai.voice.agents.breeze_buddy.observers import (
@@ -10,9 +13,30 @@ from app.ai.voice.agents.breeze_buddy.observers import (
 )
 from app.ai.voice.agents.breeze_buddy.observers.observer import (
     RealtimeObserver,
+    _bounded_detection,
     _build_tool_from_action,
 )
-from app.ai.voice.agents.breeze_buddy.template.types import ObserverConfig
+from app.ai.voice.agents.breeze_buddy.template.types import (
+    ObserverConfig,
+    TemplateModel,
+)
+from app.api.routers.breeze_buddy.templates import handlers as template_handlers
+
+
+def _legacy_template():
+    """Template stub carrying one legacy observer in ``configurations.observers``.
+
+    ``resolve_observer_configs`` only reads ``id`` and ``configurations.observers``,
+    so a namespace stands in for the full TemplateModel — cast so the checker
+    accepts it at the call site.
+    """
+    return cast(
+        TemplateModel,
+        SimpleNamespace(
+            id="template-1",
+            configurations=SimpleNamespace(observers=[_observer_config(name="legacy")]),
+        ),
+    )
 
 
 def _observer_config(**overrides):
@@ -39,6 +63,71 @@ async def test_build_observers_skips_disabled_config(monkeypatch):
     )
 
     assert observers == []
+
+
+async def test_resolve_observer_configs_prefers_evaluation_config(monkeypatch):
+    async def fake_get_observer_evaluation_config(template_id):
+        assert template_id == "template-1"
+        return {
+            "id": "config-1",
+            "enabled": True,
+            "configuration": {
+                "observers": [
+                    {
+                        "name": "table_observer",
+                        "system_prompt": "Detect from table.",
+                        "action": {"type": "alert", "handler": "send_alert"},
+                    }
+                ]
+            },
+        }
+
+    monkeypatch.setattr(
+        observer_factory,
+        "get_observer_evaluation_config",
+        fake_get_observer_evaluation_config,
+    )
+    template = _legacy_template()
+
+    configs, config_id = await observer_factory.resolve_observer_configs(template)
+
+    assert [config.name for config in configs] == ["table_observer"]
+    assert config_id == "config-1"
+
+
+async def test_resolve_observer_configs_disabled_table_config_blocks_legacy(
+    monkeypatch,
+):
+    async def fake_get_observer_evaluation_config(template_id):
+        return {"id": "config-1", "enabled": False, "configuration": {"observers": []}}
+
+    monkeypatch.setattr(
+        observer_factory,
+        "get_observer_evaluation_config",
+        fake_get_observer_evaluation_config,
+    )
+    template = _legacy_template()
+
+    assert await observer_factory.resolve_observer_configs(template) == ([], "config-1")
+
+
+async def test_resolve_observer_configs_falls_back_to_legacy_when_row_missing(
+    monkeypatch,
+):
+    async def fake_get_observer_evaluation_config(template_id):
+        return None
+
+    monkeypatch.setattr(
+        observer_factory,
+        "get_observer_evaluation_config",
+        fake_get_observer_evaluation_config,
+    )
+    template = _legacy_template()
+
+    configs, config_id = await observer_factory.resolve_observer_configs(template)
+
+    assert [config.name for config in configs] == ["legacy"]
+    assert config_id is None
 
 
 def test_action_derived_tool_uses_function_handler_with_empty_schema():
@@ -119,6 +208,62 @@ async def test_alert_observer_dispatches_through_send_alert_handler():
     assert lead.metaData["observer_triggered"] == "voicemail_detector"
 
 
+async def test_observer_action_records_detection_result(monkeypatch):
+    saved = {}
+    called = {}
+
+    async def fake_save_evaluation_results(**kwargs):
+        saved.update(kwargs)
+
+    async def noop(args):
+        called.update(args)
+
+    monkeypatch.setattr(
+        "app.ai.voice.agents.breeze_buddy.observers.utils.save_evaluation_results",
+        fake_save_evaluation_results,
+    )
+    started_at = datetime(2026, 8, 9, tzinfo=timezone.utc)
+    lead = SimpleNamespace(
+        id="lead-1",
+        call_id="CA123",
+        reseller_id="reseller-1",
+        merchant_id="merchant-1",
+        template_id="template-1",
+        call_initiated_time=started_at,
+        metaData={},
+        outcome=None,
+    )
+    agent_context = SimpleNamespace(
+        lead=lead,
+        template=SimpleNamespace(id="template-1"),
+        call_sid="CA123",
+        flow_manager=SimpleNamespace(current_node="greeting"),
+    )
+    observer = RealtimeObserver(
+        _observer_config(action={"type": "function", "handler": "noop"}),
+        llm_service=object(),
+        agent_context=agent_context,
+        handler_map={"noop": noop},
+        evaluation_config_id="config-1",
+    )
+    observer._last_detection = {"reason": "voicemail"}
+
+    await observer.execute_action()
+
+    assert called["detection"] == {"reason": "voicemail"}
+    assert saved["source_id"] == "lead-1"
+    assert saved["reseller_id"] == "reseller-1"
+    assert saved["merchant_id"] == "merchant-1"
+    assert saved["template_id"] == "template-1"
+    assert saved["started_at"] == started_at
+    assert saved["evaluation_type"] == "OBSERVER"
+    assert saved["evaluation_config_id"] == "config-1"
+    assert saved["results"][0]["type"] == "voicemail_detector"
+    assert saved["results"][0]["action_type"] == "function"
+    assert saved["results"][0]["handler"] == "noop"
+    assert saved["results"][0]["detection"] == {"reason": "voicemail"}
+
+
 async def test_observer_manager_stop_waits_before_cancel(monkeypatch):
     manager = observer_manager.ObserverManager(observers=[], llm_context=LLMContext())
 
@@ -143,3 +288,161 @@ async def test_observer_manager_stop_waits_before_cancel(monkeypatch):
     assert wait_call["timeout"] == 15
     assert task.cancelled()
     assert manager._pending == set()
+
+
+async def test_sync_observer_evaluation_config_writes_observers(monkeypatch):
+    calls = []
+
+    async def fake_upsert(template_id, configuration, enabled):
+        calls.append((template_id, configuration, enabled))
+
+    monkeypatch.setattr(
+        template_handlers, "upsert_observer_evaluation_config", fake_upsert
+    )
+
+    await template_handlers.sync_observer_evaluation_config(
+        "template-1", {"observers": [{"name": "voicemail_detector"}]}
+    )
+
+    assert calls == [
+        ("template-1", {"observers": [{"name": "voicemail_detector"}]}, True)
+    ]
+
+
+async def test_sync_observer_evaluation_config_writes_empty_list(monkeypatch):
+    calls = []
+
+    async def fake_upsert(template_id, configuration, enabled):
+        calls.append(configuration)
+
+    monkeypatch.setattr(
+        template_handlers, "upsert_observer_evaluation_config", fake_upsert
+    )
+
+    await template_handlers.sync_observer_evaluation_config(
+        "template-1", {"observers": []}
+    )
+
+    assert calls == [{"observers": []}]
+
+
+async def test_sync_observer_evaluation_config_skips_when_field_absent(monkeypatch):
+    async def fail_upsert(*args, **kwargs):
+        raise AssertionError("a PUT without observers must not touch the row")
+
+    monkeypatch.setattr(
+        template_handlers, "upsert_observer_evaluation_config", fail_upsert
+    )
+
+    await template_handlers.sync_observer_evaluation_config("template-1", {"llm": {}})
+    await template_handlers.sync_observer_evaluation_config("template-1", None)
+
+
+async def test_sync_observer_evaluation_config_raises_on_upsert_failure(monkeypatch):
+    """Silence here would report a config as live while calls use the old one."""
+
+    async def boom(*args, **kwargs):
+        raise RuntimeError("db down")
+
+    monkeypatch.setattr(template_handlers, "upsert_observer_evaluation_config", boom)
+
+    with pytest.raises(HTTPException) as excinfo:
+        await template_handlers.sync_observer_evaluation_config(
+            "template-1", {"observers": []}
+        )
+
+    assert excinfo.value.status_code == 500
+    assert "observer configuration" in excinfo.value.detail
+
+
+async def test_run_checks_fires_alert_before_terminal_observer():
+    """A terminal action must not swallow an alert detected in the same batch.
+
+    Config order puts the end_conversation observer first, which is exactly the
+    case that used to return out of the loop before the alert ran.
+    """
+    executed = []
+
+    def _fake_observer(name, action):
+        observer = SimpleNamespace(
+            name=name,
+            config=ObserverConfig.model_validate(
+                {
+                    "name": name,
+                    "system_prompt": "detect",
+                    "action": action,
+                    "trigger_on": ["on_user_turn_stopped"],
+                }
+            ),
+        )
+
+        async def check(_transcript):
+            return True
+
+        async def execute_action():
+            executed.append(name)
+
+        observer.check = check
+        observer.execute_action = execute_action
+        return observer
+
+    manager = observer_manager.ObserverManager(
+        observers=cast(
+            List[RealtimeObserver],
+            [
+                _fake_observer(
+                    "terminal", {"type": "function", "handler": "end_conversation"}
+                ),
+                _fake_observer("alerting", {"type": "alert", "handler": "send_alert"}),
+            ],
+        ),
+        llm_context=LLMContext(),
+    )
+
+    await manager._run_checks("on_user_turn_stopped")
+
+    assert executed == ["alerting", "terminal"]
+
+
+def test_bounded_detection_keeps_only_known_scalar_fields():
+    out = _bounded_detection(
+        {
+            "reason": "greeting mentions leaving a message",
+            "confidence": 0.91,
+            "transcript": "customer said their card number is 4111...",
+            "customer_name": "Gagan",
+        }
+    )
+
+    assert out["reason"] == "greeting mentions leaving a message"
+    assert out["confidence"] == 0.91
+    assert "transcript" not in out
+    assert "customer_name" not in out
+    assert out["dropped_keys"] == ["customer_name", "transcript"]
+
+
+def test_bounded_detection_truncates_long_values():
+    out = _bounded_detection({"reason": "x" * 5000})
+
+    assert len(out["reason"]) == 300
+
+
+def test_bounded_detection_handles_non_dict_and_empty():
+    assert _bounded_detection(None) == {}
+    assert _bounded_detection("voicemail") == {}
+    assert _bounded_detection({}) == {}
+    assert _bounded_detection({"reason": "   "}) == {}
+
+
+async def test_sync_observer_evaluation_config_can_swallow_on_create(monkeypatch):
+    """Create already committed the template; a 500 would make the caller retry
+    into the 409 duplicate guard, and the missing row only costs recording."""
+
+    async def boom(*args, **kwargs):
+        raise RuntimeError("db down")
+
+    monkeypatch.setattr(template_handlers, "upsert_observer_evaluation_config", boom)
+
+    await template_handlers.sync_observer_evaluation_config(
+        "template-1", {"observers": []}, raise_on_failure=False
+    )


### PR DESCRIPTION
- Migrate observers config to evaluation config table
- Migrate result to evaluation result table
- <img width="1728" height="880" alt="Screenshot 2026-08-09 at 6 20 06 PM" src="https://github.com/user-attachments/assets/929faf15-9462-466c-8833-40fb3943d74a" />
- <img width="1728" height="883" alt="Screenshot 2026-08-09 at 6 20 20 PM" src="https://github.com/user-attachments/assets/62eceec4-36c4-433e-a9c4-bf77bd59e644" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added observer-based analytics with trigger rates, action and outcome summaries, trends, rankings, recent alerts, and observer filtering.
  * Observer configurations now sync automatically when templates are created or replaced.
  * Observer detections are recorded for analytics and reporting.
* **Bug Fixes**
  * Alerts now run before terminal observer actions, ensuring all alerts are processed.
  * Improved configuration handling with support for disabled settings and legacy fallbacks.
* **Compatibility**
  * Existing topic evaluation data and configurations continue to work with the updated evaluation system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->