### PR TITLE
fix(commerce): honour ui_intents.urls.checkout_page on the render_ui path

### DIFF
--- a/app/ai/voice/agents/breeze_buddy/assist/commerce/ucp/intents.py
+++ b/app/ai/voice/agents/breeze_buddy/assist/commerce/ucp/intents.py
@@ -50,6 +50,7 @@ from app.ai.voice.agents.breeze_buddy.assist.commerce.ucp.roles import (
     ROLE_GET_PRODUCT,
     ROLE_SEARCH,
     ROLE_UPDATE_CART,
+    pick_checkout_url,
 )
 from app.ai.voice.agents.breeze_buddy.assist.commerce.ucp.upsell import run_cart_upsell
 from app.ai.voice.agents.breeze_buddy.chat.intents.router import (
@@ -678,15 +679,15 @@ def _cart_view_show_op(tool_name: str, result: Any, agent: Any) -> Dict[str, Any
         if payload.get(key) is not None:
             bind[prop] = f"$tool:{tool_name}#/{key}"
     props: Dict[str, Any] = {}
-    # Configured fixed destination (template ui_intents.urls.checkout_page,
-    # e.g. the storefront /cart page — cookie sync shows the built cart
-    # there) WINS over the tool's checkout-bound continue_url.
-    checkout_url = (
-        cfg.checkout_page_url
-        or payload.get("continue_url")
-        or agent.agent_state.get(cfg.checkout_url_key)
+    # Precedence (configured page → continue_url → reducer state) is
+    # shared with the model-driven path's ``render_ui._finalize_commerce``,
+    # which resolves the same three candidates from a BindingStore.
+    checkout_url = pick_checkout_url(
+        cfg.checkout_page_url,
+        payload.get("continue_url"),
+        agent.agent_state.get(cfg.checkout_url_key),
     )
-    if isinstance(checkout_url, str) and checkout_url:
+    if checkout_url:
         props["checkout"] = {"label": cfg.checkout_label, "url": checkout_url}
     return {
         "op": "show",

--- a/app/ai/voice/agents/breeze_buddy/assist/commerce/ucp/render_ui.py
+++ b/app/ai/voice/agents/breeze_buddy/assist/commerce/ucp/render_ui.py
@@ -25,6 +25,7 @@ from typing import Any, Dict, List, Optional
 
 from app.ai.voice.agents.breeze_buddy.assist.commerce.ucp.roles import (
     ROLE_SEARCH,
+    pick_checkout_url,
     resolve_role_map,
 )
 from app.ai.voice.agents.breeze_buddy.assist.commerce.ucp.step_labels import (
@@ -223,9 +224,11 @@ def _finalize_commerce(
     Layout is derived from the FINAL hydrated count (post items[]
     selection, post max_items cap): 1-2 products sit side by side; 3+
     scroll as a carousel. The CartView checkout button mirrors the
-    DIRECT-intent path: the bound cart payload's ``continue_url`` wins,
-    the reducer-state fallback (``ui_intents.state_keys.checkout_url``
-    role) next; no url anywhere → no button."""
+    DIRECT-intent path exactly: the configured fixed destination
+    (``ui_intents.urls.checkout_page``) wins, then the bound cart
+    payload's ``continue_url``, then the reducer-state fallback
+    (``ui_intents.state_keys.checkout_url`` role); no url anywhere →
+    no button."""
     if isinstance(hydrated_props.get("products"), list):
         hydrated_props["layout"] = (
             "grid" if len(hydrated_props["products"]) <= 2 else "carousel"
@@ -242,7 +245,8 @@ def _finalize_commerce(
             (getattr(ui_intents, "state_keys", None) or {}) if ui_intents else {}
         )
         labels = (getattr(ui_intents, "labels", None) or {}) if ui_intents else {}
-        checkout_url: Optional[str] = None
+        urls = (getattr(ui_intents, "urls", None) or {}) if ui_intents else {}
+        payload_url: Optional[Any] = None
         for ref in bind.values():
             parsed = parse_bind_ref(ref)
             if parsed is None:
@@ -251,12 +255,22 @@ def _finalize_commerce(
             if isinstance(payload, dict):
                 cu = payload.get("continue_url")
                 if isinstance(cu, str) and cu:
-                    checkout_url = cu
+                    payload_url = cu
                     break
-        if checkout_url is None and state_values:
-            fallback = state_values.get(state_keys.get("checkout_url", "checkout_url"))
-            if isinstance(fallback, str) and fallback:
-                checkout_url = fallback
+        # Precedence itself lives in ``roles.pick_checkout_url`` — shared
+        # with the DIRECT path's ``intents.py::_cart_view_show_op``, which
+        # resolves the same three candidates from different sources. It
+        # was duplicated, and this path silently lacked the configured
+        # tier, so one button had two destinations.
+        checkout_url = pick_checkout_url(
+            urls.get("checkout_page"),
+            payload_url,
+            (
+                state_values.get(state_keys.get("checkout_url", "checkout_url"))
+                if state_values
+                else None
+            ),
+        )
         if checkout_url:
             hydrated_props["checkout"] = {
                 "label": labels.get("checkout") or _DEFAULT_CHECKOUT_LABEL,

--- a/app/ai/voice/agents/breeze_buddy/assist/commerce/ucp/roles.py
+++ b/app/ai/voice/agents/breeze_buddy/assist/commerce/ucp/roles.py
@@ -21,7 +21,7 @@ matter.
 
 from __future__ import annotations
 
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 # Role → default tool name. The keys ARE the registry keys used across the
 # flavor; the values are the Stage-A UCP surface.
@@ -57,6 +57,40 @@ def resolve_role_map(template: Any) -> Dict[str, str]:
     }
 
 
+def pick_checkout_url(
+    configured: Any,
+    payload_url: Any,
+    state_url: Any,
+) -> Optional[str]:
+    """The CartView checkout button's destination — ONE precedence, for
+    every path that builds that button.
+
+    ``configured`` (``ui_intents.urls.checkout_page``) wins: a merchant
+    who names a page means it, and that page is typically their own
+    storefront cart, which the CartView cookie sync exists to populate.
+    Then the cart payload's ``continue_url``, then the reducer-state
+    fallback (the ``state_keys.checkout_url`` role). ``None`` when there
+    is nothing to point at — the caller renders no button rather than a
+    dead one.
+
+    Takes RESOLVED candidates rather than the sources, because the two
+    callers reach them differently: the DIRECT driver has one tool
+    payload plus the agent's state, the render_ui finalizer has a
+    BindingStore and bind refs. Only the ORDER is shared — and only the
+    order needed sharing: it was duplicated in both, so
+    ``urls.checkout_page`` shipped honoured on the DIRECT path and
+    ignored on the model-driven one, giving one button two destinations.
+
+    Non-string candidates are skipped rather than returned; template JSON
+    is merchant-edited, and a wrong-typed value should fall through to
+    the next tier, never become an href.
+    """
+    for candidate in (configured, payload_url, state_url):
+        if isinstance(candidate, str) and candidate:
+            return candidate
+    return None
+
+
 __all__ = [
     "DEFAULT_TOOLS",
     "ROLE_CREATE_CART",
@@ -64,5 +98,6 @@ __all__ = [
     "ROLE_GET_PRODUCT",
     "ROLE_SEARCH",
     "ROLE_UPDATE_CART",
+    "pick_checkout_url",
     "resolve_role_map",
 ]

--- a/tests/assist/test_commerce_intents.py
+++ b/tests/assist/test_commerce_intents.py
@@ -699,6 +699,104 @@ def test_checkout_page_url_config_overrides_continue_url():
     assert op["props"]["checkout"]["url"] == "https://shop.example/checkouts/abc"
 
 
+def test_checkout_page_url_config_applies_to_render_ui_path_too():
+    """The MODEL-DRIVEN render_ui path must resolve the CartView checkout
+    button with the SAME precedence as the DIRECT-intent path above.
+
+    It did not. ``_cart_view_show_op`` honoured
+    ``ui_intents.urls.checkout_page`` while ``_finalize_commerce`` never
+    read ``urls`` at all, so ONE button had TWO destinations: the
+    storefront /cart after a widget tap, the platform checkout after a
+    model-driven render. The model-driven path is the common one — every
+    cart tool's ``tool_ui_instructions`` render CartView through it — so
+    most shoppers got the destination the merchant had NOT configured,
+    skipping the page the CartView cookie sync exists to populate.
+
+    The model cannot paper over this: ``render_ui_tool`` deliberately
+    refuses to read ``checkout`` from model args (server policy), so the
+    fix has to live here.
+    """
+    from app.ai.voice.agents.breeze_buddy.assist.commerce.ucp.render_ui import (
+        _finalize_commerce,
+    )
+    from app.ai.voice.agents.breeze_buddy.assist.commerce.ucp.schemas import CartView
+    from app.ai.voice.agents.breeze_buddy.chat.ui.binding import BindingStore
+
+    store = BindingStore()
+    store.record(
+        "get_cart",
+        "tu1",
+        _envelope(
+            {**_cart_payload([]), "continue_url": "https://shop.example/checkouts/abc"}
+        ),
+    )
+    bind = {"cart_id": "$tool:get_cart#/id"}
+
+    def _checkout(template: Any, state_values: Optional[Dict[str, Any]] = None) -> Any:
+        props: Dict[str, Any] = {}
+        _finalize_commerce(
+            "CartView",
+            CartView,
+            props,
+            bind=bind,
+            store=store,
+            template=template,
+            state_values=state_values,
+        )
+        return props.get("checkout")
+
+    # 1. Configured fixed destination WINS over the tool's continue_url.
+    template = _template()
+    template.configurations.ui_intents = UiIntentsConfig(
+        urls={"checkout_page": "https://shop.example/cart"}
+    )
+    assert _checkout(template)["url"] == "https://shop.example/cart"
+
+    # 2. Unset → continue_url still wins. The pre-existing precedence for
+    #    every template that does NOT configure a page is untouched.
+    template.configurations.ui_intents = None
+    assert _checkout(template)["url"] == "https://shop.example/checkouts/abc"
+
+    # 3. Blank/non-string config is ignored rather than emitting an empty
+    #    href (template JSON is merchant-edited — "" is a live typo).
+    template.configurations.ui_intents = UiIntentsConfig(urls={"checkout_page": ""})
+    assert _checkout(template)["url"] == "https://shop.example/checkouts/abc"
+
+    # 4. Reducer-state fallback stays LAST: it applies only when neither a
+    #    configured page nor a continue_url is available.
+    empty = BindingStore()
+    empty.record("get_cart", "tu1", _envelope({"id": "gid://shopify/Cart/c1"}))
+    props: Dict[str, Any] = {}
+    _finalize_commerce(
+        "CartView",
+        CartView,
+        props,
+        bind=bind,
+        store=empty,
+        template=_template(),
+        state_values={"checkout_url": "https://shop.example/from-state"},
+    )
+    assert props["checkout"]["url"] == "https://shop.example/from-state"
+
+
+def test_pick_checkout_url_is_the_single_precedence_both_paths_share():
+    """The order lives in ONE place now. Duplicating it is what let the
+    configured tier ship on the DIRECT path and go missing on the
+    model-driven one."""
+    from app.ai.voice.agents.breeze_buddy.assist.commerce.ucp.roles import (
+        pick_checkout_url,
+    )
+
+    assert pick_checkout_url("/cfg", "/payload", "/state") == "/cfg"
+    assert pick_checkout_url(None, "/payload", "/state") == "/payload"
+    assert pick_checkout_url(None, None, "/state") == "/state"
+    assert pick_checkout_url(None, None, None) is None
+    # Empty and wrong-typed candidates fall through instead of becoming an
+    # href — template JSON is merchant-edited.
+    assert pick_checkout_url("", "/payload", "/state") == "/payload"
+    assert pick_checkout_url(0, ["/nope"], "/state") == "/state"
+
+
 class TestCartLineIntegrity:
     """``update_cart`` REPLACES the cart with the set we send, so how the
     desired set is built is a data-loss surface, not a formatting detail."""


### PR DESCRIPTION
## The bug

The CartView checkout button has **two destinations depending on how the card was produced**, and only one of them is the merchant's configured choice.

`ui_intents.urls.checkout_page` is documented in `template/types.py:1398` as overriding *"the CartView checkout button's destination … instead of the cart tool's checkout-bound `continue_url`"*. That was true on exactly one of the two code paths that build the button:

| How the card appeared | Code | Reads `urls.checkout_page`? |
|---|---|---|
| Shopper taps `+` / `−` / remove (DIRECT intent) | `intents.py::_cart_view_show_op` | ✅ configured page wins |
| Shopper types "show me my cart" (model-driven `render_ui`) | `render_ui.py::_finalize_commerce` | ❌ **never read `urls` at all** |

So the same shopper, on the same cart, got the storefront `/cart` after tapping "+" on a line and the platform's checkout after asking for their cart in words. **The model-driven path is the common one** — every cart tool's `tool_ui_instructions` renders CartView through it.

## Why it matters beyond inconsistency

The configured page is typically the storefront's own `/cart`, which is exactly the page CartView's cookie sync exists to populate — it pins the storefront `cart` cookie to the server-built cart so the native cart shows the assistant's items. Landing on the platform checkout instead **skips the page that work was for**, so roughly half of cart renders wasted it.

## Why the fix has to be server-side

There is no template-side workaround. `render_ui_tool.py:550` deliberately refuses to read `checkout` from model arguments — *"Server-policy props (e.g. commerce's CartView `checkout` button) are deliberately NOT read from args"*. That is the right call: the destination must never be model-chosen. It does mean the fix belongs in the finalizer.

## The change

**The root cause is duplication, not a missing line.** Both paths spelled the precedence out separately, so when the configured tier was added on 2026-08-03 it landed on one and not the other. Patching only the finalizer would leave the same trap armed for the next path.

The order now lives once, in `roles.pick_checkout_url`:

```
configured page  >  tool continue_url  >  reducer state  >  no button
```

`roles.py` is the right home: it already holds what both the intent driver and the registration hook need, and its docstring commits it to importing nothing from the rest of the flavor — which is also why `render_ui.py` can use it while staying import-free of `intents.py`.

The helper takes **resolved candidates** rather than sources, because the two callers reach them differently — one has a tool payload plus agent state, the other a `BindingStore` and bind refs. Only the order was ever shared, and only the order needed sharing.

### Behaviour

- Templates that do **not** configure a page are unaffected — `continue_url` still wins, asserted by test.
- The DIRECT path additionally gains the non-string guard: a wrong-typed value now falls through to the next tier rather than suppressing the button. Friendlier for merchant-edited template JSON, and the only behavioural delta on that path.
- Docstrings on both call sites updated to describe the real precedence.

## Layering

The fix is UCP-generic, not platform-specific. `grep -rn shopify app/…/commerce/ucp/` returns nothing — the protocol layer has zero platform references, and all Shopify code stays in `connectors/shopify/`. `continue_url` is a UCP cart-payload field, `urls` is a generic `Dict[str, str]` role map the engine never interprets, and `/cart` is only a value a merchant supplies.

## Verification

- **The new render_ui test fails against `release`** (asserts the configured page wins, gets the `continue_url`) and passes with this change — confirmed by reverting the finalizer and re-running. That run also leaves the **DIRECT-path test green**, isolating the defect to this path rather than to the shared helper.
- Coverage: configured page wins · unset keeps `continue_url` · blank config ignored · reducer-state fallback still last · plus a direct unit test of the helper's precedence.
- **Full suite: 1217 passed, 1 xfailed.**
- `black`, `isort`, `autoflake` clean; `pyrefly check` **0 errors**.

## Context

Found while turning commerce on for its first merchant, whose template sets `urls.checkout_page` to the storefront `/cart`. The DIRECT path did the right thing and the model-driven path did not, which is how the split surfaced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JtrUcWv8oqFfZpiQourEGU