### PR TITLE
fix: expire and clean up lead greeting cache

### DIFF
--- a/app/ai/voice/agents/breeze_buddy/managers/calls.py
+++ b/app/ai/voice/agents/breeze_buddy/managers/calls.py
@@ -574,6 +574,18 @@ async def handle_call_completion(
         await raise_orphan_webhook(call_id=call_id, source="call_completion")
         return
 
+    # Clean up greeting audio from Redis if it exists — do this regardless of status
+    # since the delete is idempotent and prevents Redis key leaks from completed calls.
+    try:
+        redis = await get_redis_service()
+        greeting_key = f"greeting:{lead.id}"
+        await redis.delete(greeting_key)
+        logger.info(f"Deleted greeting audio from Redis for lead {lead.id}")
+    except Exception as e:
+        logger.opt(exception=e).warning(
+            f"Failed to delete greeting audio from Redis for lead {lead.id}"
+        )
+
     # Always release telephony number (including transfers — bot leaves, cleanup happens here)
     if (
         lead.telephony_number_id

--- a/app/ai/voice/agents/breeze_buddy/managers/utils.py
+++ b/app/ai/voice/agents/breeze_buddy/managers/utils.py
@@ -15,6 +15,7 @@ from app.ai.voice.agents.breeze_buddy.template.types import (
 )
 from app.ai.voice.agents.breeze_buddy.tts import generate_audio
 from app.ai.voice.agents.breeze_buddy.utils.common import greeting_has_variables
+from app.core.config.dynamic import LEAD_GREETING_CACHE_TTL_SECONDS
 from app.core.logger import logger
 from app.services.redis.client import get_redis_service
 
@@ -166,9 +167,10 @@ async def prepare_and_store_initial_greeting(
                 "audio": base64.b64encode(greeting_audio).decode("utf-8"),
                 "text": resolved_greeting,
             }
-            await redis.set(
+            await redis.setex(
                 key=lead_greeting_key,
                 value=json.dumps(greeting_data),
+                ttl_seconds=await LEAD_GREETING_CACHE_TTL_SECONDS(),
             )
             logger.info(f"Stored dynamic greeting in Redis for lead {lead_id}")
             return resolved_greeting

--- a/app/core/config/dynamic.py
+++ b/app/core/config/dynamic.py
@@ -384,6 +384,11 @@ async def BB_TTS_SERVICE() -> str:
     return await get_config("BREEZE_BUDDY_TTS_SERVICE", "elevenlabs", str)
 
 
+async def LEAD_GREETING_CACHE_TTL_SECONDS() -> int:
+    """TTL for lead-specific synthesized greeting audio. Default: two days."""
+    return await get_config("LEAD_GREETING_CACHE_TTL_SECONDS", 2 * 24 * 60 * 60, int)
+
+
 async def GEMINI_TTS_MODEL() -> str:
     """Returns the default Gemini TTS model name from Redis.
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Temporary greeting audio is now automatically removed after a completed call.
  * Greeting audio data expires after six hours to reduce stale content.
  * Cleanup failures no longer interrupt call completion processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->