### PR TITLE
(fix): gemini live call not getting cut after completion

### DIFF
--- a/app/ai/voice/llm/realtime/factory.py
+++ b/app/ai/voice/llm/realtime/factory.py
@@ -152,6 +152,7 @@ async def get_realtime_llm_service(llm_config: LLMConfiguration) -> Any:
             thinking_level=realtime.thinking_level,
             silence_duration_ms=realtime.silence_duration_ms,
             function_call_timeout_secs=function_call_timeout,
+            endframe_deferral_timeout_secs=realtime.endframe_deferral_timeout_secs,
         )
         logger.info(
             f"Resolving Gemini Live LLM service: model={gemini_config.model}, "

--- a/app/ai/voice/llm/realtime/gemini_realtime.py
+++ b/app/ai/voice/llm/realtime/gemini_realtime.py
@@ -54,6 +54,7 @@ class GeminiRealtimeConfig:
     thinking_level: Optional[str] = None
     silence_duration_ms: Optional[int] = None
     function_call_timeout_secs: float = 10.0
+    endframe_deferral_timeout_secs: float = 1.0
 
 
 def build_gemini_realtime_llm(config: GeminiRealtimeConfig) -> GeminiLiveLLMService:
@@ -79,11 +80,18 @@ def build_gemini_realtime_llm(config: GeminiRealtimeConfig) -> GeminiLiveLLMServ
         settings_kwargs["vad"] = GeminiVADParams(
             silence_duration_ms=config.silence_duration_ms
         )
-    return GeminiLiveLLMService(
+    service = GeminiLiveLLMService(
         api_key=config.api_key,
         settings=GeminiLiveLLMService.Settings(**settings_kwargs),
         function_call_timeout_secs=config.function_call_timeout_secs,
     )
+    # Cap pipecat's EndFrame deferral so finish_call/end_conversation actually
+    # hang up the line (the default 30s leaves it open until the customer
+    # hangs up). pipecat exposes no constructor param for this — it's a class
+    # constant — so override it per-instance. Template-configurable via
+    # realtime.endframe_deferral_timeout_secs (default 1.0s; 0 = immediate).
+    service._END_FRAME_DEFERRAL_TIMEOUT_SECS = config.endframe_deferral_timeout_secs
+    return service
 
 
 def has_realtime_llm(llm_config: Any) -> bool:

--- a/app/ai/voice/llm/types.py
+++ b/app/ai/voice/llm/types.py
@@ -83,6 +83,16 @@ class RealtimeConfig(BaseModel):
         "recommends 500–800ms). Only applied when set; otherwise Gemini's "
         "server-side VAD default applies. Not used by OpenAI/xAI/Azure.",
     )
+    endframe_deferral_timeout_secs: float = Field(
+        1.0,
+        description="Gemini Live only. Cap (seconds) on the deferred EndFrame "
+        "queued by finish_call/end_conversation. pipecat otherwise parks it "
+        "for up to 30s while the bot considers itself mid-turn (turn_complete "
+        "rarely arrives for a function-call-only turn such as finish_call), "
+        "leaving the telephony line open until the customer hangs up. "
+        "Defaults to 1.0s when unset; set 0 for an immediate release. "
+        "Not used by OpenAI/xAI/Azure.",
+    )
     endpoint: Optional[str] = Field(
         None,
         description="Provider-specific endpoint URL override (currently used "


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable control over how long Gemini Live may defer end-of-frame processing.
  * The default delay is one second; nonpositive values trigger immediate handling.
  * The setting can be adjusted dynamically, with invalid values safely falling back to the default.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->