### PR TITLE
feat(templates): add version lineage, families and drift-safe bulk operations

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,6 +98,7 @@ Breeze Buddy is the template-driven telephony agent. These patterns MUST be foll
 - Variables use `{placeholder}` syntax, resolved from lead payload at runtime
 - Node transitions are LLM-driven via function calls with optional async hooks
 - Template types defined in `breeze_buddy/template/types.py` -- this is the source of truth for all template models
+- Every template write appends a snapshot to `template_version` (lineage); `family_id` groups templates for admin bulk update (`POST /templates/bulk/update`, JSON merge patch + node_patches) and bulk rollback (`POST /templates/bulk/rollback`, drift-guarded). Never UPDATE `template.flow` directly -- always go through the accessor so the version row is written. Family propagation: editing a family's parent template (`PUT /templates/families/{id}`) snapshots into `template_family_version`; `POST /templates/families/{id}/propagate/preview` three-way merges that edit into every child (base = the family revision in `template.derived_from_base_version`) and `.../propagate/apply` writes it as one `op_type='propagation'` bulk op, revertible via `POST /templates/bulk/rollback` (`also_revert_family` also restores the parent). Merge primitives live in `template/merge.py` -- pure functions, no I/O
 
 ### Lead Processing Flow
 1. Lead inserted via `/push/lead/v2` -> validated -> stored as BACKLOG

--- a/app/ai/voice/agents/breeze_buddy/template/field_reference.json
+++ b/app/ai/voice/agents/breeze_buddy/template/field_reference.json
@@ -18,6 +18,14 @@
       "description": "Optional merchant sub-namespace within the reseller. Null for reseller-level templates.",
       "example": "merchant-42"
     },
+    "family_id": {
+      "description": "Read-only. Groups this template with other templates for admin bulk update/rollback (see POST /templates/bulk/update, POST /templates/bulk/rollback). Set via POST /templates/families, never editable via PUT.",
+      "example": "fam-cod-confirmation"
+    },
+    "current_version": {
+      "description": "Read-only. Monotonically increasing version number; every write appends a snapshot row to template_version. Starts at 1.",
+      "example": 3
+    },
     "name": {
       "description": "Human-readable display name shown in dashboards and logs.",
       "example": "COD Confirmation – Hindi+English"

--- a/app/ai/voice/agents/breeze_buddy/template/merge.py
+++ b/app/ai/voice/agents/breeze_buddy/template/merge.py
@@ -1,0 +1,277 @@
+"""Three-way merge of a family's parent-template edit into one child.
+
+Pure functions, no I/O. See docs/TEMPLATE_LINEAGE.md §6.1: for every field
+the family edit changed (parent != base), the child's current value decides
+the outcome — equal to base means the merchant never customized it (auto
+apply), equal to parent means it is already there (no-op), anything else is
+a conflict for a human. Fields the family edit did NOT change are never
+reported: the child keeps them untouched.
+
+Field paths are the conflict unit and the address used to write the
+resolution back:
+
+    flow.<key>                        top-level flow key (never 'nodes')
+    flow.nodes.<node_name>            a whole node (added / removed / absent
+                                      from the child)
+    flow.nodes.<node_name>.<key>      one key of a node all three sides have
+    configurations.<key>              top-level configurations key
+"""
+
+import copy
+from typing import Any, Dict, List, Optional, Tuple
+
+from app.schemas.breeze_buddy.template_version import (
+    ChildMergeOutcome,
+    MergeFieldChange,
+    MergeFieldConflict,
+)
+
+# Distinguishes "key absent" from "key present with value None" — the
+# difference between deleting a field and setting it to JSON null.
+_MISSING = object()
+
+
+def parse_field_path(field_path: str) -> Tuple[str, ...]:
+    """Validate + split a field path. Raises ValueError if unsupported."""
+    parts = tuple(field_path.split("."))
+    if (
+        len(parts) == 2
+        and parts[0] in ("flow", "configurations")
+        and parts[1]
+        # 'flow.nodes' is never a leaf: nodes are addressed by node_name
+        and not (parts[0] == "flow" and parts[1] == "nodes")
+    ):
+        return parts
+    if (
+        len(parts) in (3, 4)
+        and parts[0] == "flow"
+        and parts[1] == "nodes"
+        and all(parts[2:])
+    ):
+        return parts
+    raise ValueError(f"unsupported field_path '{field_path}'")
+
+
+def _check_key(container: str, key: Any) -> None:
+    if not isinstance(key, str) or not key or "." in key:
+        raise ValueError(
+            f"'{key}' in {container} is not addressable by the merge field-path "
+            "grammar (keys and node names must be non-empty and contain no '.')"
+        )
+
+
+def _same(a: Any, b: Any) -> bool:
+    if a is _MISSING or b is _MISSING:
+        return a is b
+    return a == b
+
+
+def _nodes_by_name(flow: Optional[Dict[str, Any]]) -> Dict[str, Dict[str, Any]]:
+    nodes = (flow or {}).get("nodes")
+    if not isinstance(nodes, list):
+        return {}
+    by_name: Dict[str, Dict[str, Any]] = {}
+    for node in nodes:
+        if not isinstance(node, dict):
+            continue
+        name = node.get("node_name")
+        if name is None:
+            continue
+        # Not validated here: a child-only node (merchant addition) must
+        # never abort the merge, even if its name contains a '.'. Only
+        # names that can become a field path (base/parent union) are
+        # validated, in _merge_nodes.
+        by_name[name] = node
+    return by_name
+
+
+def _flow_top_level(flow: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+    return {k: v for k, v in (flow or {}).items() if k != "nodes"}
+
+
+def _classify(
+    field_path: str,
+    base: Any,
+    parent: Any,
+    child: Any,
+    outcome: ChildMergeOutcome,
+) -> None:
+    if _same(base, parent):
+        return  # the family edit did not touch this field
+    if _same(child, parent):
+        outcome.noop.append(field_path)
+        return
+    if _same(child, base):
+        outcome.auto_apply.append(
+            MergeFieldChange(field_path=field_path, op="remove", value=None)
+            if parent is _MISSING
+            else MergeFieldChange(field_path=field_path, op="set", value=parent)
+        )
+        return
+    outcome.conflicts.append(
+        MergeFieldConflict(
+            field_path=field_path,
+            base=None if base is _MISSING else base,
+            parent=None if parent is _MISSING else parent,
+            child=None if child is _MISSING else child,
+            base_present=base is not _MISSING,
+            parent_present=parent is not _MISSING,
+            child_present=child is not _MISSING,
+        )
+    )
+
+
+def _merge_dict(
+    prefix: str,
+    base: Dict[str, Any],
+    parent: Dict[str, Any],
+    child: Dict[str, Any],
+    outcome: ChildMergeOutcome,
+) -> None:
+    for key in sorted(set(base) | set(parent)):
+        _check_key(prefix, key)
+        _classify(
+            f"{prefix}.{key}",
+            base.get(key, _MISSING),
+            parent.get(key, _MISSING),
+            child.get(key, _MISSING),
+            outcome,
+        )
+
+
+def _merge_nodes(
+    base: Dict[str, Dict[str, Any]],
+    parent: Dict[str, Dict[str, Any]],
+    child: Dict[str, Dict[str, Any]],
+    outcome: ChildMergeOutcome,
+) -> None:
+    # Validate before sorting, not inside the loop: node_name is a JSON value,
+    # so a family flow holding {"node_name": 5} would make sorted() raise
+    # TypeError, which escapes the per-child `except ValueError` in the
+    # propagation accessor and fails the whole preview/apply instead of
+    # reporting one bad child.
+    names = set(base) | set(parent)
+    for name in names:
+        _check_key("flow.nodes", name)
+    for name in sorted(names):
+        base_node = base.get(name, _MISSING)
+        parent_node = parent.get(name, _MISSING)
+        child_node = child.get(name, _MISSING)
+        # isinstance rather than `is not _MISSING`: same test (the maps only
+        # ever hold dicts) but it narrows the type for the _merge_dict call.
+        if not (
+            isinstance(base_node, dict)
+            and isinstance(parent_node, dict)
+            and isinstance(child_node, dict)
+        ):
+            # Added, removed, or absent from the child: the whole node is the
+            # unit, so a "take parent" resolution writes a complete node.
+            _classify(f"flow.nodes.{name}", base_node, parent_node, child_node, outcome)
+            continue
+        _merge_dict(f"flow.nodes.{name}", base_node, parent_node, child_node, outcome)
+
+
+def merge_family_into_child(
+    *,
+    base_flow: Dict[str, Any],
+    base_configurations: Optional[Dict[str, Any]],
+    parent_flow: Dict[str, Any],
+    parent_configurations: Optional[Dict[str, Any]],
+    child_flow: Dict[str, Any],
+    child_configurations: Optional[Dict[str, Any]],
+) -> ChildMergeOutcome:
+    """Classify every field the family edit changed, for one child.
+
+    ``base_*`` is the family content the child last synced from (see the
+    NULL-sync rule in the plan / accessor), ``parent_*`` the family's current
+    content, ``child_*`` the child's own current content.
+    """
+    outcome = ChildMergeOutcome()
+    _merge_dict(
+        "flow",
+        _flow_top_level(base_flow),
+        _flow_top_level(parent_flow),
+        _flow_top_level(child_flow),
+        outcome,
+    )
+    _merge_nodes(
+        _nodes_by_name(base_flow),
+        _nodes_by_name(parent_flow),
+        _nodes_by_name(child_flow),
+        outcome,
+    )
+    _merge_dict(
+        "configurations",
+        base_configurations or {},
+        parent_configurations or {},
+        child_configurations or {},
+        outcome,
+    )
+    return outcome
+
+
+def _set_or_remove(
+    container: Dict[str, Any], key: str, change: MergeFieldChange
+) -> None:
+    if change.op == "remove":
+        container.pop(key, None)
+    else:
+        container[key] = copy.deepcopy(change.value)
+
+
+def apply_merge_decisions(
+    flow: Dict[str, Any],
+    configurations: Optional[Dict[str, Any]],
+    changes: List[MergeFieldChange],
+) -> Tuple[Dict[str, Any], Optional[Dict[str, Any]]]:
+    """Write auto-applied + resolved changes onto the child's OWN content.
+
+    Never mutates the inputs. Raises ValueError for a node-key path whose
+    node is absent from the child (the merge only emits those for nodes all
+    three sides have, so this means the caller hand-built a bad path).
+    """
+    new_flow: Dict[str, Any] = copy.deepcopy(flow) if flow else {}
+    new_configurations = (
+        copy.deepcopy(configurations) if configurations is not None else None
+    )
+    for change in changes:
+        parts = parse_field_path(change.field_path)
+        if parts[0] == "configurations":
+            if new_configurations is None:
+                new_configurations = {}
+            _set_or_remove(new_configurations, parts[1], change)
+            continue
+        if len(parts) == 2:
+            _set_or_remove(new_flow, parts[1], change)
+            continue
+        node_name = parts[2]
+        nodes = new_flow.get("nodes")
+        if not isinstance(nodes, list):
+            nodes = []
+        index = next(
+            (
+                i
+                for i, n in enumerate(nodes)
+                if isinstance(n, dict) and n.get("node_name") == node_name
+            ),
+            None,
+        )
+        if len(parts) == 3:
+            if change.op == "remove":
+                if index is not None:
+                    nodes.pop(index)
+            elif index is None:
+                nodes.append(copy.deepcopy(change.value))
+            else:
+                nodes[index] = copy.deepcopy(change.value)
+        else:
+            if index is None:
+                raise ValueError(
+                    f"cannot apply '{change.field_path}': node '{node_name}' "
+                    "not in flow"
+                )
+            node = dict(nodes[index])
+            _set_or_remove(node, parts[3], change)
+            nodes[index] = node
+        new_flow["nodes"] = nodes
+    return new_flow, new_configurations

--- a/app/ai/voice/agents/breeze_buddy/template/patch.py
+++ b/app/ai/voice/agents/breeze_buddy/template/patch.py
@@ -1,0 +1,100 @@
+"""Patching primitives for bulk template updates.
+
+RFC 7386 JSON Merge Patch semantics: dict patches merge recursively, a
+``None`` value deletes the key, any non-dict patch value replaces the
+target outright — including arrays, which are replaced wholesale. Because
+``flow.nodes`` is an array, whole-flow merge patches cannot edit one node;
+``node_patches`` addresses nodes by ``node_name`` for that.
+"""
+
+import copy
+from typing import Any, Dict, Optional, Tuple
+
+from app.ai.voice.agents.breeze_buddy.template.types import (
+    ConfigurationModel,
+    FlowMode,
+)
+
+
+def apply_merge_patch(target: Optional[Dict[str, Any]], patch: Any) -> Any:
+    if not isinstance(patch, dict):
+        return copy.deepcopy(patch)
+    result: Dict[str, Any] = dict(target) if isinstance(target, dict) else {}
+    for key, value in patch.items():
+        if value is None:
+            result.pop(key, None)
+        else:
+            result[key] = apply_merge_patch(result.get(key), value)
+    return result
+
+
+def apply_template_patches(
+    flow: Dict[str, Any],
+    configurations: Optional[Dict[str, Any]],
+    flow_patch: Optional[Dict[str, Any]],
+    node_patches: Optional[Dict[str, Dict[str, Any]]],
+    configurations_patch: Optional[Dict[str, Any]],
+) -> Tuple[Dict[str, Any], Optional[Dict[str, Any]]]:
+    """Apply the three patch kinds to one template's current state.
+
+    Raises ValueError when node_patches references a node_name the flow
+    does not contain — bulk ops must fail loudly, not skip silently.
+    """
+    new_flow = copy.deepcopy(flow)
+    if flow_patch:
+        new_flow = apply_merge_patch(new_flow, flow_patch)
+
+    if node_patches:
+        nodes = new_flow.get("nodes") or []
+        by_name = {
+            n.get("node_name"): i for i, n in enumerate(nodes) if isinstance(n, dict)
+        }
+        for node_name, node_patch in node_patches.items():
+            if node_name not in by_name:
+                raise ValueError(f"node_patches references unknown node '{node_name}'")
+            idx = by_name[node_name]
+            nodes[idx] = apply_merge_patch(nodes[idx], node_patch)
+        new_flow["nodes"] = nodes
+
+    new_configurations = (
+        copy.deepcopy(configurations) if configurations is not None else None
+    )
+    if configurations_patch:
+        new_configurations = apply_merge_patch(
+            new_configurations or {}, configurations_patch
+        )
+
+    return new_flow, new_configurations
+
+
+def validate_patched_template(
+    flow: Dict[str, Any],
+    configurations: Optional[Dict[str, Any]],
+    template_id: str,
+    template_name: str,
+) -> Optional[str]:
+    """Same flow-shape rules as the create/replace handlers, plus a full
+    ConfigurationModel validation. Returns an error message or None."""
+    if not flow:
+        return "Flow structure is required"
+    if flow.get("mode") == FlowMode.DIRECT.value:
+        if "system_prompt" not in flow:
+            return "system_prompt must be specified in direct-mode flow structure"
+    else:
+        if "initial_node" not in flow:
+            return "initial_node must be specified in flow structure"
+        if "nodes" not in flow or not flow["nodes"]:
+            return "nodes must be specified in flow structure"
+
+    if configurations is not None:
+        try:
+            ConfigurationModel.model_validate(
+                configurations,
+                context={
+                    "template_id": template_id,
+                    "template_name": template_name,
+                },
+            )
+        except Exception as exc:  # pydantic ValidationError and friends
+            return f"configurations invalid after patch: {exc}"
+    return None

--- a/app/ai/voice/agents/breeze_buddy/template/types.py
+++ b/app/ai/voice/agents/breeze_buddy/template/types.py
@@ -2936,6 +2936,11 @@ class TemplateModel(BaseModel):
     merchant_id: Optional[str] = None
     created_at: Optional[Any] = None
     updated_at: Optional[Any] = None
+    # Lineage (read-only; written via versioning/bulk endpoints only).
+    # ReplaceTemplateRequest has extra="ignore", so GET→PUT round-trips
+    # strip these automatically — do NOT add them to the request models.
+    family_id: Optional[str] = None
+    current_version: int = 1
 
     # Editable fields (these match ReplaceTemplateRequest field names 1:1).
     name: str

--- a/app/ai/voice/agents/breeze_buddy/utils/secrets.py
+++ b/app/ai/voice/agents/breeze_buddy/utils/secrets.py
@@ -5,6 +5,7 @@ These utilities ensure sensitive data (API keys, tokens, passwords) are never
 exposed in API responses while allowing updates to preserve existing values.
 """
 
+import copy
 from typing import Any, Dict, Optional
 
 from app.ai.voice.agents.breeze_buddy.template.types import TemplateModel
@@ -18,7 +19,8 @@ SECRETS_MASK = "******"
 # field_serializer in ``template/types.py`` emits 10 asterisks; accept the
 # 6-asterisk top-level form too in case a UI client normalises everything to
 # one shape. Either form means "value unchanged — keep what's in DB".
-_AUTH_MASK_VALUES = frozenset({SECRETS_MASK, "**********"})
+AUTH_SECRET_MASK = "**********"
+_AUTH_MASK_VALUES = frozenset({SECRETS_MASK, AUTH_SECRET_MASK})
 
 # The three SecretStr fields on ``HttpAuthConfig``. If the schema gains
 # another secret-typed auth field, add it here.
@@ -77,6 +79,63 @@ def merge_secrets(
             merged[key] = value
 
     return merged if merged else None
+
+
+def contains_masked_literal(value: Any) -> bool:
+    """True if ``value`` is (or, for a dict/list/tuple, contains anywhere
+    nested within it) one of the known masked-secret placeholders
+    (``SECRETS_MASK`` or the 10-asterisk ``HttpAuthConfig`` serializer form).
+
+    Used to catch a client round-tripping a masked API response value back
+    as a "real" edit (e.g. a family-propagation "custom" resolution built
+    from the masked preview) instead of supplying the actual value or
+    explicitly choosing to keep the existing one.
+    """
+    if isinstance(value, str):
+        return value in _AUTH_MASK_VALUES
+    if isinstance(value, dict):
+        return any(contains_masked_literal(v) for v in value.values())
+    if isinstance(value, (list, tuple)):
+        return any(contains_masked_literal(v) for v in value)
+    return False
+
+
+def mask_mcp_auth_secrets(
+    configurations: Optional[Dict[str, Any]],
+) -> Optional[Dict[str, Any]]:
+    """Return a copy of ``configurations`` with every MCP auth secret replaced
+    by the mask ``HttpAuthConfig``'s field_serializer emits.
+
+    Write-time enforcement of the "family content never holds a real secret"
+    invariant (docs/TEMPLATE_LINEAGE.md): ``template_family`` /
+    ``template_family_version`` store configurations as a plain dict, so
+    masking only on read leaves the real token at rest in the row and in every
+    snapshot. Applied before the family INSERT/UPDATE instead, a family row
+    can never hold one in the first place.
+
+    Only ``configurations.mcp.servers[*].auth`` is walked -- the same set of
+    fields and the same single HttpAuthConfig location as
+    ``merge_masked_mcp_auth``. Extend both together if the schema grows
+    another auth-bearing path.
+    """
+    if not configurations:
+        return configurations
+    servers = ((configurations.get("mcp") or {}).get("servers")) or []
+    if not any(
+        isinstance(s, dict) and isinstance(s.get("auth"), dict) for s in servers
+    ):
+        return configurations
+    masked = copy.deepcopy(configurations)
+    for server in ((masked.get("mcp") or {}).get("servers")) or []:
+        if not isinstance(server, dict):
+            continue
+        auth = server.get("auth")
+        if not isinstance(auth, dict):
+            continue
+        for field in _AUTH_SECRET_FIELDS:
+            if auth.get(field) is not None:
+                auth[field] = AUTH_SECRET_MASK
+    return masked
 
 
 def merge_masked_mcp_auth(
@@ -191,6 +250,13 @@ def mask_template_secrets(template: TemplateModel) -> TemplateModel:
         id=template.id,
         reseller_id=template.reseller_id,
         merchant_id=template.merchant_id,
+        # Lineage fields (read-only) must be carried through the masked copy,
+        # same rationale as ``supported_channels`` below -- otherwise version
+        # list/get/rollback responses would report the ``TemplateModel``
+        # default (``current_version=1``, ``family_id=None``) instead of the
+        # template's actual lineage state.
+        family_id=template.family_id,
+        current_version=template.current_version,
         name=template.name,
         flow=template.flow,
         expected_payload_schema=template.expected_payload_schema,

--- a/app/api/routers/breeze_buddy/templates/__init__.py
+++ b/app/api/routers/breeze_buddy/templates/__init__.py
@@ -41,6 +41,17 @@ from .rbac import require_admin_or_reseller_owner
 
 router = APIRouter()
 
+from .bulk import router as bulk_router  # noqa: E402
+
+# bulk BEFORE versions: versions has POST /templates/{template_id}/rollback,
+# which would otherwise capture /templates/bulk/rollback with
+# template_id="bulk" (routes match in inclusion order).
+router.include_router(bulk_router)
+
+from .versions import router as versions_router  # noqa: E402
+
+router.include_router(versions_router)
+
 
 @router.post("/templates", status_code=status.HTTP_201_CREATED)
 async def create_template(
@@ -110,6 +121,10 @@ async def list_templates(
         None, ge=1, le=100, description="Page size. Omit to return all."
     ),
     search: Optional[str] = Query(None, description="Case-insensitive name search."),
+    unassigned: bool = Query(
+        False,
+        description="When true, only return templates not yet assigned to any family.",
+    ),
     current_user: UserInfo = Depends(get_current_user_with_rbac),
 ):
     """
@@ -152,6 +167,7 @@ async def list_templates(
         page=page,
         limit=limit,
         search=search,
+        unassigned=unassigned,
     )
 
 

--- a/app/api/routers/breeze_buddy/templates/bulk.py
+++ b/app/api/routers/breeze_buddy/templates/bulk.py
@@ -1,0 +1,203 @@
+"""Admin-only routes: family assignment, bulk update/rollback, op ledger."""
+
+from fastapi import APIRouter, Depends, Query
+
+from app.api.security.breeze_buddy.rbac_token import get_current_user_with_rbac
+from app.core.security.authorization import require_admin
+from app.schemas import UserInfo
+from app.schemas.breeze_buddy.template_version import (
+    BulkOpListResponse,
+    BulkRollbackRequest,
+    BulkRollbackResponse,
+    BulkUpdateRequest,
+    BulkUpdateResponse,
+    CreateFamilyRequest,
+    FamilyListResponse,
+    FamilyResponse,
+    FamilyVersionDetailResponse,
+    FamilyVersionListResponse,
+    PropagateApplyRequest,
+    PropagationPreviewResponse,
+    RollbackFamilyRequest,
+    UpdateFamilyMembersRequest,
+    UpdateFamilyRequest,
+)
+
+from .bulk_handlers import (
+    bulk_rollback_handler,
+    bulk_update_handler,
+    create_family_handler,
+    get_family_handler,
+    get_family_version_handler,
+    list_bulk_ops_handler,
+    list_families_handler,
+    list_family_versions_handler,
+    propagate_apply_handler,
+    propagate_preview_handler,
+    rollback_family_handler,
+    update_family_handler,
+    update_family_members_handler,
+)
+
+router = APIRouter()
+
+
+@router.post("/templates/families", response_model=FamilyResponse, status_code=201)
+async def create_family(
+    body: CreateFamilyRequest,
+    current_user: UserInfo = Depends(get_current_user_with_rbac),
+):
+    """Create a family: name + base (parent) template + initial members. Admin only."""
+    require_admin(current_user)
+    return await create_family_handler(body, current_user)
+
+
+@router.get("/templates/families", response_model=FamilyListResponse)
+async def list_families(
+    current_user: UserInfo = Depends(get_current_user_with_rbac),
+):
+    """List all global families (admin-managed). Admin only."""
+    require_admin(current_user)
+    return await list_families_handler(current_user)
+
+
+@router.get("/templates/families/{family_id}", response_model=FamilyResponse)
+async def get_family(
+    family_id: str,
+    current_user: UserInfo = Depends(get_current_user_with_rbac),
+):
+    """One family: parent template content inline + all members with
+    versions (global admin-managed). Admin only."""
+    require_admin(current_user)
+    return await get_family_handler(family_id, current_user)
+
+
+@router.put("/templates/families/{family_id}", response_model=FamilyResponse)
+async def update_family(
+    family_id: str,
+    body: UpdateFamilyRequest,
+    current_user: UserInfo = Depends(get_current_user_with_rbac),
+):
+    """Edit the family's parent template content (bumps base_version). Admin only."""
+    require_admin(current_user)
+    return await update_family_handler(family_id, body, current_user)
+
+
+@router.patch("/templates/families/{family_id}/members", response_model=FamilyResponse)
+async def update_family_members(
+    family_id: str,
+    body: UpdateFamilyMembersRequest,
+    current_user: UserInfo = Depends(get_current_user_with_rbac),
+):
+    """Add/remove member templates. Admin only."""
+    require_admin(current_user)
+    return await update_family_members_handler(family_id, body, current_user)
+
+
+@router.post("/templates/bulk/update", response_model=BulkUpdateResponse)
+async def bulk_update(
+    body: BulkUpdateRequest,
+    current_user: UserInfo = Depends(get_current_user_with_rbac),
+):
+    """Apply a JSON merge patch to every template in a family (or explicit id
+    list). All-or-nothing; use dry_run=true to preview. Admin only."""
+    require_admin(current_user)
+    return await bulk_update_handler(body, current_user)
+
+
+@router.post("/templates/bulk/rollback", response_model=BulkRollbackResponse)
+async def bulk_rollback(
+    body: BulkRollbackRequest,
+    current_user: UserInfo = Depends(get_current_user_with_rbac),
+):
+    """Revert a completed bulk update. Refuses if any member was edited
+    afterwards, unless force=true. Admin only."""
+    require_admin(current_user)
+    return await bulk_rollback_handler(body, current_user)
+
+
+@router.get("/templates/bulk/ops", response_model=BulkOpListResponse)
+async def list_bulk_ops(
+    limit: int = Query(50, ge=1, le=200),
+    offset: int = Query(0, ge=0),
+    current_user: UserInfo = Depends(get_current_user_with_rbac),
+):
+    """Ledger of bulk operations (admin only) — source of rollback targets."""
+    require_admin(current_user)
+    return await list_bulk_ops_handler(limit, offset)
+
+
+@router.get(
+    "/templates/families/{family_id}/versions",
+    response_model=FamilyVersionListResponse,
+)
+async def list_family_versions(
+    family_id: str,
+    limit: int = Query(50, ge=1, le=200),
+    offset: int = Query(0, ge=0),
+    current_user: UserInfo = Depends(get_current_user_with_rbac),
+):
+    """History of the family's parent template (newest base_version first). Admin only."""
+    require_admin(current_user)
+    return await list_family_versions_handler(family_id, limit, offset, current_user)
+
+
+@router.get(
+    "/templates/families/{family_id}/versions/{base_version}",
+    response_model=FamilyVersionDetailResponse,
+)
+async def get_family_version(
+    family_id: str,
+    base_version: int,
+    current_user: UserInfo = Depends(get_current_user_with_rbac),
+):
+    """One historical revision of the family's parent template. Admin only."""
+    require_admin(current_user)
+    return await get_family_version_handler(family_id, base_version, current_user)
+
+
+@router.post("/templates/families/{family_id}/rollback", response_model=FamilyResponse)
+async def rollback_family(
+    family_id: str,
+    body: RollbackFamilyRequest,
+    current_user: UserInfo = Depends(get_current_user_with_rbac),
+):
+    """Restore an older parent-template revision as a NEW base_version.
+    Children are untouched — run propagate/preview afterwards to carry the
+    restore into them. Admin only."""
+    require_admin(current_user)
+    return await rollback_family_handler(family_id, body, current_user)
+
+
+@router.post(
+    "/templates/families/{family_id}/propagate/preview",
+    response_model=PropagationPreviewResponse,
+)
+async def propagate_preview(
+    family_id: str,
+    page: int = Query(1, ge=1, description="1-based page number"),
+    limit: int = Query(50, ge=1, le=200, description="Children per page"),
+    current_user: UserInfo = Depends(get_current_user_with_rbac),
+):
+    """Three-way merge the family's current parent template into one page of
+    children: per-child auto-applies, no-ops and conflicts. Writes nothing.
+    Paginate with ``page`` / ``limit`` for large families. Admin only."""
+    require_admin(current_user)
+    return await propagate_preview_handler(family_id, page, limit, current_user)
+
+
+@router.post(
+    "/templates/families/{family_id}/propagate/apply",
+    response_model=BulkUpdateResponse,
+)
+async def propagate_apply(
+    family_id: str,
+    body: PropagateApplyRequest,
+    current_user: UserInfo = Depends(get_current_user_with_rbac),
+):
+    """Apply the previewed merge with the lead's conflict resolutions: one
+    transaction, one bulk_op_id, a version snapshot per changed child.
+    409 if anything moved since the preview, 422 if conflicts are
+    unresolved. Reversible via POST /templates/bulk/rollback. Admin only."""
+    require_admin(current_user)
+    return await propagate_apply_handler(family_id, body, current_user)

--- a/app/api/routers/breeze_buddy/templates/bulk_handlers.py
+++ b/app/api/routers/breeze_buddy/templates/bulk_handlers.py
@@ -1,0 +1,506 @@
+"""Handlers for family assignment and bulk template operations (admin only)."""
+
+import asyncio
+import json
+from typing import NoReturn
+
+import asyncpg
+from fastapi import HTTPException, status
+
+from app.ai.voice.agents.breeze_buddy.template.cache import invalidate_template
+from app.ai.voice.agents.breeze_buddy.template.patch import validate_patched_template
+from app.core.logger import logger
+from app.database.accessor.breeze_buddy.template import (
+    get_template_by_id,
+    get_template_raw_configurations,
+)
+from app.database.accessor.breeze_buddy.template_version import (
+    PreOpSnapshotVanished,
+    apply_family_propagation,
+    bulk_rollback_templates,
+    bulk_update_templates,
+    create_template_family,
+    get_bulk_op,
+    get_family_version,
+    get_template_family,
+    list_bulk_ops,
+    list_family_versions,
+    list_template_families,
+    preview_family_propagation,
+    rollback_family_to_version,
+    update_family_members,
+    update_template_family,
+)
+from app.schemas import UserInfo
+from app.schemas.breeze_buddy.template_version import (
+    BulkOpListResponse,
+    BulkRollbackRequest,
+    BulkRollbackResponse,
+    BulkUpdateRequest,
+    BulkUpdateResponse,
+    CreateFamilyRequest,
+    FamilyListResponse,
+    FamilyResponse,
+    FamilyVersionDetailResponse,
+    FamilyVersionListResponse,
+    PropagateApplyRequest,
+    PropagationPreviewResponse,
+    RollbackFamilyRequest,
+    UpdateFamilyMembersRequest,
+    UpdateFamilyRequest,
+)
+
+
+def _abort(status_code: int, message: str, results) -> NoReturn:
+    raise HTTPException(
+        status_code=status_code,
+        detail={"message": message, "results": [r.model_dump() for r in results]},
+    )
+
+
+async def _invalidate_all(template_ids):
+    """Best-effort, concurrent: a bulk op can touch hundreds of templates and
+    the caller is already holding the HTTP response open. One failed Redis
+    round trip must not abort the others (the cache is a soft dependency —
+    a stale entry expires on its own TTL)."""
+    ids = list(template_ids)
+    if not ids:
+        return
+    outcomes = await asyncio.gather(
+        *(invalidate_template(tid) for tid in ids), return_exceptions=True
+    )
+    for tid, outcome in zip(ids, outcomes):
+        if isinstance(outcome, BaseException):
+            logger.warning(f"cache invalidation failed for {tid}: {outcome}")
+
+
+async def create_family_handler(
+    body: CreateFamilyRequest, current_user: UserInfo
+) -> FamilyResponse:
+    # Resolve the parent template content: inline fields, or copied from an
+    # existing template (content columns only — never secrets/routing).
+    flow = body.flow
+    eps = body.expected_payload_schema
+    ecrs = body.expected_callback_response_schema
+    configurations = body.configurations
+    channels = body.supported_channels
+    if body.copy_base_from_template_id:
+        source = await get_template_by_id(body.copy_base_from_template_id)
+        if not source:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Source template not found: {body.copy_base_from_template_id}",
+            )
+        flow = flow or source.flow
+        eps = eps or source.expected_payload_schema
+        ecrs = ecrs or source.expected_callback_response_schema
+        if configurations is None and source.configurations:
+            # The RAW column, not source.configurations.model_dump(): the
+            # decoded model fills in every Pydantic default, which would
+            # copy ~10 keys the source template never set into the family
+            # parent (and into every snapshot of it).
+            #
+            # Secrets are handled a layer down: create_template_family runs
+            # mask_mcp_auth_secrets over this, so any MCP auth token becomes
+            # an inert placeholder. The family parent is reference-only
+            # content (never rendered into a live call), and a member
+            # template's own secrets override it at call time.
+            configurations = await get_template_raw_configurations(
+                body.copy_base_from_template_id
+            )
+        channels = channels or list(source.supported_channels)
+    validation_error = validate_patched_template(
+        flow or {}, configurations, template_id="family", template_name=body.name
+    )
+    if validation_error:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail=validation_error
+        )
+    try:
+        family = await create_template_family(
+            name=body.name,
+            description=body.description,
+            flow=flow or {},
+            expected_payload_schema=eps,
+            expected_callback_response_schema=ecrs,
+            configurations=configurations,
+            supported_channels=channels or ["voice"],
+            member_template_ids=body.member_template_ids,
+            created_by=current_user.username,
+        )
+    except asyncpg.UniqueViolationError:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=f"A family named '{body.name}' already exists",
+        )
+    except ValueError as e:
+        # Member list rejected (missing template, or cross-reseller): the
+        # family was not created either.
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(e)
+        ) from e
+    if family is None:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to create family",
+        )
+    if body.member_template_ids:
+        # assign_family (called by create_template_family) sets
+        # template.family_id but never busts the per-template cache;
+        # best-effort invalidate so a cached read doesn't serve a stale
+        # family_id right after assignment.
+        await _invalidate_all(body.member_template_ids)
+    logger.info(
+        f"Admin {current_user.username} created family {family.id} "
+        f"('{body.name}', {len(body.member_template_ids)} members)"
+    )
+    return family
+
+
+async def _load_family_or_404(family_id: str) -> FamilyResponse:
+    family = await get_template_family(family_id)
+    if family is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Family not found: {family_id}",
+        )
+    return family
+
+
+async def update_family_handler(
+    family_id: str, body: UpdateFamilyRequest, current_user: UserInfo
+) -> FamilyResponse:
+    existing = await _load_family_or_404(family_id)
+    if body.flow is not None or body.configurations is not None:
+        # Validation only: `existing` is the decoded (default-filled) view,
+        # which is a superset of what is stored and therefore safe to
+        # validate against. What gets PERSISTED for an unsent field is the
+        # raw stored column — update_template_family carries it over.
+        validation_error = validate_patched_template(
+            (body.flow if body.flow is not None else existing.flow) or {},
+            (
+                body.configurations
+                if body.configurations is not None
+                else existing.configurations
+            ),
+            template_id="family",
+            template_name=(body.name if body.name is not None else existing.name),
+        )
+        if validation_error:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST, detail=validation_error
+            )
+    # Unset fields are passed through as None ("leave this column alone")
+    # rather than echoed back from `existing`.
+    family = await update_template_family(
+        family_id,
+        name=body.name,
+        description=body.description,
+        flow=body.flow,
+        expected_payload_schema=body.expected_payload_schema,
+        expected_callback_response_schema=body.expected_callback_response_schema,
+        configurations=body.configurations,
+        supported_channels=body.supported_channels,
+        updated_by=current_user.username,
+    )
+    if family is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Family not found: {family_id}",
+        )
+    logger.info(
+        f"Admin {current_user.username} updated family {family_id} "
+        f"(base_version -> {family.base_version})"
+    )
+    return family
+
+
+async def get_family_handler(family_id: str, current_user: UserInfo) -> FamilyResponse:
+    family = await _load_family_or_404(family_id)
+    return family
+
+
+async def list_families_handler(current_user: UserInfo) -> FamilyListResponse:
+    return FamilyListResponse(families=await list_template_families())
+
+
+async def update_family_members_handler(
+    family_id: str, body: UpdateFamilyMembersRequest, current_user: UserInfo
+) -> FamilyResponse:
+    try:
+        family = await update_family_members(
+            family_id, add=body.add_template_ids, remove=body.remove_template_ids
+        )
+    except ValueError as e:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(e)
+        ) from e
+    if family is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Family not found: {family_id}",
+        )
+    # assign_family / the remove path change template.family_id but never
+    # bust the per-template cache; best-effort invalidate every added and
+    # removed member so a cached read doesn't serve a stale family_id.
+    changed_member_ids = list(body.add_template_ids) + list(body.remove_template_ids)
+    if changed_member_ids:
+        await _invalidate_all(changed_member_ids)
+    logger.info(
+        f"Admin {current_user.username} updated members of family {family_id} "
+        f"(+{len(body.add_template_ids)}/-{len(body.remove_template_ids)})"
+    )
+    return family
+
+
+async def bulk_update_handler(
+    body: BulkUpdateRequest, current_user: UserInfo
+) -> BulkUpdateResponse:
+    patch_json = json.dumps(
+        {
+            "flow_patch": body.flow_patch,
+            "node_patches": body.node_patches,
+            "configurations_patch": body.configurations_patch,
+        }
+    )
+    resp = await bulk_update_templates(
+        template_ids=body.template_ids,
+        family_id=body.family_id,
+        flow_patch=body.flow_patch,
+        node_patches=body.node_patches,
+        configurations_patch=body.configurations_patch,
+        patch_json=patch_json,
+        changed_by=current_user.username,
+        dry_run=body.dry_run,
+    )
+    if resp.status == "completed":
+        await _invalidate_all([r.template_id for r in resp.results])
+        logger.info(
+            f"Bulk update {resp.bulk_op_id} by {current_user.username}: "
+            f"{len(resp.results)} templates updated"
+        )
+    elif resp.status == "failed":
+        # 422 with the full per-template error report
+        _abort(
+            status.HTTP_422_UNPROCESSABLE_ENTITY,
+            "Bulk update aborted; no template was modified",
+            resp.results,
+        )
+    return resp
+
+
+async def list_bulk_ops_handler(limit: int, offset: int) -> BulkOpListResponse:
+    return BulkOpListResponse(ops=await list_bulk_ops(limit, offset))
+
+
+async def bulk_rollback_handler(
+    body: BulkRollbackRequest, current_user: UserInfo
+) -> BulkRollbackResponse:
+    op = await get_bulk_op(body.bulk_op_id)
+    if op is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Bulk op not found: {body.bulk_op_id}",
+        )
+    if op.op_type not in ("bulk_update", "propagation") or op.status != "completed":
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=(
+                f"Bulk op {body.bulk_op_id} is {op.op_type}/{op.status}; only "
+                "completed bulk_update or propagation ops can be rolled back"
+            ),
+        )
+    if body.also_revert_family and op.op_type != "propagation":
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=(
+                "also_revert_family is only valid for propagation ops; "
+                f"{body.bulk_op_id} is {op.op_type}"
+            ),
+        )
+    if body.also_revert_family and op.from_base_version is None:
+        # force can't help here: there is no prior family revision to
+        # restore, so the generic "retry with force=true" 409 below would
+        # be misleading.
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=(
+                "family has no prior version to restore (this propagation "
+                "created base_version 1); re-run without also_revert_family"
+            ),
+        )
+    try:
+        resp = await bulk_rollback_templates(
+            body.bulk_op_id,
+            changed_by=current_user.username,
+            force=body.force,
+            also_revert_family=body.also_revert_family,
+            op=op,
+        )
+    except PreOpSnapshotVanished as e:
+        # A member was deleted mid-rollback; the transaction rolled back, so
+        # nothing was reverted. Same 409 shape as the pruned-snapshot abort.
+        logger.opt(exception=e).warning(
+            f"Bulk rollback of {body.bulk_op_id} aborted: template "
+            f"{e.template_id} vanished mid-transaction"
+        )
+        _abort(
+            status.HTTP_409_CONFLICT,
+            (
+                "Bulk rollback aborted: pre-op snapshot missing for template "
+                f"{e.template_id} (deleted while the rollback ran); nothing "
+                "was reverted"
+            ),
+            [],
+        )
+    if resp.status == "failed":
+        # Distinct all-or-nothing abort reasons share status="failed":
+        # drifted heads (retryable with force=true), pruned pre-op snapshots,
+        # and (propagation-only) a pruned family snapshot -- none of the
+        # latter two are retryable, so force does not override them.
+        # Distinguish by inspecting the error tag each accessor path stamps
+        # onto its per-template results.
+        family_snapshot_missing = any(
+            r.error and "family snapshot missing" in r.error for r in resp.results
+        )
+        if family_snapshot_missing:
+            _abort(
+                status.HTTP_409_CONFLICT,
+                (
+                    "Bulk rollback aborted: the family revision this "
+                    "propagation started from was pruned by retention; "
+                    "nothing was reverted"
+                ),
+                resp.results,
+            )
+        missing_snapshots = any(
+            r.error and "pre-op snapshot missing" in r.error for r in resp.results
+        )
+        if missing_snapshots:
+            _abort(
+                status.HTTP_409_CONFLICT,
+                (
+                    "Bulk rollback aborted: pre-op snapshot missing (pruned "
+                    "by retention) for one or more templates; nothing was "
+                    "reverted"
+                ),
+                resp.results,
+            )
+        _abort(
+            status.HTTP_409_CONFLICT,
+            (
+                "Bulk rollback aborted (templates edited after the bulk op); "
+                "retry with force=true to override"
+            ),
+            resp.results,
+        )
+    await _invalidate_all([r.template_id for r in resp.results])
+    logger.info(
+        f"Bulk rollback {resp.bulk_op_id} by {current_user.username} "
+        f"reverted op {body.bulk_op_id} across {len(resp.results)} templates"
+    )
+    return resp
+
+
+async def list_family_versions_handler(
+    family_id: str, limit: int, offset: int, current_user: UserInfo
+) -> FamilyVersionListResponse:
+    family = await _load_family_or_404(family_id)
+    versions, total = await list_family_versions(family_id, limit, offset)
+    return FamilyVersionListResponse(
+        family_id=family_id,
+        base_version=family.base_version,
+        versions=versions,
+        total=total,
+    )
+
+
+async def get_family_version_handler(
+    family_id: str, base_version: int, current_user: UserInfo
+) -> FamilyVersionDetailResponse:
+    await _load_family_or_404(family_id)
+    found = await get_family_version(family_id, base_version)
+    if found is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Version {base_version} not found for family {family_id}",
+        )
+    snapshot, meta = found
+    return FamilyVersionDetailResponse(meta=meta, snapshot=snapshot)
+
+
+async def rollback_family_handler(
+    family_id: str, body: RollbackFamilyRequest, current_user: UserInfo
+) -> FamilyResponse:
+    await _load_family_or_404(family_id)
+    restored = await rollback_family_to_version(
+        family_id, body.base_version, current_user.username
+    )
+    if restored is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Version {body.base_version} not found for family {family_id}",
+        )
+    logger.info(
+        f"Admin {current_user.username} rolled family {family_id} back to "
+        f"base_version {body.base_version} (new base_version "
+        f"{restored.base_version})"
+    )
+    # The parent template is reference-only content — no member template
+    # changed, so there is no per-template cache to invalidate here.
+    return restored
+
+
+async def propagate_preview_handler(
+    family_id: str, page: int, limit: int, current_user: UserInfo
+) -> PropagationPreviewResponse:
+    preview = await preview_family_propagation(family_id, page=page, limit=limit)
+    if preview is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Family not found: {family_id}",
+        )
+    logger.info(
+        f"Admin {current_user.username} previewed propagation of family "
+        f"{family_id} to_base_version {preview.to_base_version}: "
+        f"{len(preview.children)} children (page {page}/{limit}), {preview.conflict_count} conflicts"
+    )
+    return preview
+
+
+async def propagate_apply_handler(
+    family_id: str, body: PropagateApplyRequest, current_user: UserInfo
+) -> BulkUpdateResponse:
+    await _load_family_or_404(family_id)
+    resp = await apply_family_propagation(
+        family_id=family_id,
+        expected_base_version=body.expected_base_version,
+        expected_current_versions=body.expected_current_versions,
+        resolutions=body.resolutions,
+        changed_by=current_user.username,
+    )
+    if resp.status == "drift":
+        _abort(
+            status.HTTP_409_CONFLICT,
+            (
+                "Propagation aborted: the family or a child changed since "
+                "the preview; nothing was written. Re-run propagate/preview"
+            ),
+            resp.results,
+        )
+    if resp.status in ("unresolved", "failed"):
+        _abort(
+            status.HTTP_422_UNPROCESSABLE_ENTITY,
+            (
+                "Propagation aborted: unresolved conflicts"
+                if resp.status == "unresolved"
+                else "Propagation aborted; no template was modified"
+            ),
+            resp.results,
+        )
+    await _invalidate_all([r.template_id for r in resp.results])
+    logger.info(
+        f"Propagation {resp.bulk_op_id} by {current_user.username} on family "
+        f"{family_id}: {len(resp.results)} children"
+    )
+    return resp

--- a/app/api/routers/breeze_buddy/templates/handlers.py
+++ b/app/api/routers/breeze_buddy/templates/handlers.py
@@ -151,6 +151,7 @@ async def create_template_handler(
             is_active=template_data.is_active,
             supported_channels=list(template_data.supported_channels),
             now=now,
+            changed_by=current_user.username,
         )
 
         if not template:
@@ -201,6 +202,7 @@ async def list_templates_handler(
     page: Optional[int] = None,
     limit: Optional[int] = None,
     search: Optional[str] = None,
+    unassigned: bool = False,
 ) -> TemplateListResponse:
     """
     List templates with RBAC enforcement.
@@ -233,6 +235,8 @@ async def list_templates_handler(
             filters["merchant_id"] = merchant_id
         if not include_inactive:
             filters["is_active"] = True
+        if unassigned:
+            filters["family_id_is_null"] = True
 
         # Apply RBAC filtering (validates access and injects user's accessible merchants/shops)
         filters = apply_hierarchical_template_filters(filters, current_user)
@@ -516,6 +520,7 @@ async def replace_template_handler(
             merchant_id=template_data.merchant_id,
             supported_channels=supported_channels,
             now=now,
+            changed_by=current_user.username,
         )
 
         if not updated_template:

--- a/app/api/routers/breeze_buddy/templates/version_handlers.py
+++ b/app/api/routers/breeze_buddy/templates/version_handlers.py
@@ -1,0 +1,113 @@
+"""Handlers for template version (lineage) endpoints."""
+
+import asyncpg
+from fastapi import HTTPException, status
+
+from app.ai.voice.agents.breeze_buddy.template.cache import invalidate_template
+from app.ai.voice.agents.breeze_buddy.utils.secrets import mask_template_secrets
+from app.core.logger import logger
+from app.database.accessor.breeze_buddy.template import get_template_by_id
+from app.database.accessor.breeze_buddy.template_version import (
+    get_template_version,
+    list_template_versions,
+    rollback_template_to_version,
+)
+from app.schemas import UserInfo
+from app.schemas.breeze_buddy.template_version import (
+    RollbackTemplateRequest,
+    TemplateVersionDetailResponse,
+    TemplateVersionListResponse,
+)
+
+from .rbac import require_admin_or_reseller_owner, validate_template_access
+
+
+async def _load_and_authorize(template_id: str, current_user: UserInfo, operation: str):
+    template = await get_template_by_id(template_id)
+    if not template:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Template not found: {template_id}",
+        )
+    validate_template_access(
+        current_user, template.reseller_id, template.merchant_id, operation=operation
+    )
+    return template
+
+
+async def list_template_versions_handler(
+    template_id: str, limit: int, offset: int, current_user: UserInfo
+) -> TemplateVersionListResponse:
+    template = await _load_and_authorize(
+        template_id, current_user, "list template versions"
+    )
+    versions, total = await list_template_versions(template_id, limit, offset)
+    return TemplateVersionListResponse(
+        template_id=template_id,
+        current_version=template.current_version,
+        versions=versions,
+        total=total,
+    )
+
+
+async def get_template_version_handler(
+    template_id: str, version: int, current_user: UserInfo
+) -> TemplateVersionDetailResponse:
+    await _load_and_authorize(template_id, current_user, "read template version")
+    found = await get_template_version(template_id, version)
+    if found is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Version {version} not found for template {template_id}",
+        )
+    snapshot, meta = found
+    return TemplateVersionDetailResponse(
+        meta=meta, snapshot=mask_template_secrets(snapshot)
+    )
+
+
+async def rollback_template_handler(
+    template_id: str, body: RollbackTemplateRequest, current_user: UserInfo
+):
+    template = await _load_and_authorize(template_id, current_user, "rollback template")
+    require_admin_or_reseller_owner(
+        current_user, template.reseller_id, operation="rollback template"
+    )
+    try:
+        new_head = await rollback_template_to_version(
+            template_id, body.version, changed_by=current_user.username
+        )
+    except (asyncpg.UniqueViolationError, asyncpg.ForeignKeyViolationError) as e:
+        # loguru has no exc_info kwarg -- logger.opt(exception=...) is what
+        # actually attaches the traceback. The asyncpg message can carry
+        # constraint names and parameter values, so it stays in the log only.
+        logger.opt(exception=e).error(f"Rollback failed for template {template_id}")
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=(
+                f"Rollback to version {body.version} conflicts with current data "
+                "(name uniqueness or telephony number)"
+            ),
+        ) from e
+    except Exception as e:
+        logger.opt(exception=e).error(f"Rollback failed for template {template_id}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Rollback failed",
+        ) from e
+    if new_head is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Version {body.version} not found for template {template_id}",
+        )
+    try:
+        await invalidate_template(template_id)
+    except Exception as cache_exc:
+        logger.warning(
+            f"Template cache invalidation failed for {template_id}: {cache_exc}"
+        )
+    logger.info(
+        f"User {current_user.username} rolled back template {template_id} "
+        f"to version {body.version} (new head v{new_head.current_version})"
+    )
+    return mask_template_secrets(new_head)

--- a/app/api/routers/breeze_buddy/templates/versions.py
+++ b/app/api/routers/breeze_buddy/templates/versions.py
@@ -1,0 +1,60 @@
+"""Routes for template version history and rollback."""
+
+from fastapi import APIRouter, Depends, Query
+
+from app.ai.voice.agents.breeze_buddy.template.types import TemplateModel
+from app.api.security.breeze_buddy.rbac_token import get_current_user_with_rbac
+from app.schemas import UserInfo
+from app.schemas.breeze_buddy.template_version import (
+    RollbackTemplateRequest,
+    TemplateVersionDetailResponse,
+    TemplateVersionListResponse,
+)
+
+from .version_handlers import (
+    get_template_version_handler,
+    list_template_versions_handler,
+    rollback_template_handler,
+)
+
+router = APIRouter()
+
+
+@router.get(
+    "/templates/{template_id}/versions",
+    response_model=TemplateVersionListResponse,
+)
+async def list_template_versions(
+    template_id: str,
+    limit: int = Query(50, ge=1, le=200),
+    offset: int = Query(0, ge=0),
+    current_user: UserInfo = Depends(get_current_user_with_rbac),
+):
+    """Version history (metadata only). Newest first."""
+    return await list_template_versions_handler(
+        template_id, limit, offset, current_user
+    )
+
+
+@router.get(
+    "/templates/{template_id}/versions/{version}",
+    response_model=TemplateVersionDetailResponse,
+)
+async def get_template_version(
+    template_id: str,
+    version: int,
+    current_user: UserInfo = Depends(get_current_user_with_rbac),
+):
+    """Full snapshot of one version (secrets masked)."""
+    return await get_template_version_handler(template_id, version, current_user)
+
+
+@router.post("/templates/{template_id}/rollback", response_model=TemplateModel)
+async def rollback_template(
+    template_id: str,
+    body: RollbackTemplateRequest,
+    current_user: UserInfo = Depends(get_current_user_with_rbac),
+):
+    """Restore an older version as the NEW head (appends a version; history
+    is never rewritten). Admin or reseller owner."""
+    return await rollback_template_handler(template_id, body, current_user)

--- a/app/core/config/static.py
+++ b/app/core/config/static.py
@@ -281,6 +281,11 @@ POSTGRES_POOL_SIZE = int(os.getenv("POSTGRES_POOL_SIZE", "5"))
 POSTGRES_MAX_OVERFLOW = int(os.getenv("POSTGRES_MAX_OVERFLOW", "10"))
 POSTGRES_POOL_RECYCLE = int(os.getenv("POSTGRES_POOL_RECYCLE", "3600"))  # 1 hour
 
+# Number of most-recent template_version snapshots retained per template.
+# Minimum 2: rollback needs the head snapshot and its predecessor, and a 0
+# would prune the snapshot written for the head in the same transaction.
+TEMPLATE_VERSION_RETENTION = max(2, int(os.getenv("TEMPLATE_VERSION_RETENTION", "10")))
+
 # Worker threads available to asyncio.to_thread() for offloaded blocking work
 # (sync telephony SDKs: Plivo recording, provider.make_call, Twilio conference).
 # Python's default is min(32, cpu_count + 4) — only 5 threads on a 1-core pod,

--- a/app/database/accessor/breeze_buddy/template.py
+++ b/app/database/accessor/breeze_buddy/template.py
@@ -11,6 +11,10 @@ from app.ai.voice.agents.breeze_buddy.template.types import (
     TemplateModel,
 )
 from app.core.logger import logger
+from app.database import get_db_connection
+from app.database.accessor.breeze_buddy.template_version import (
+    insert_template_version_on_conn,
+)
 from app.database.decoder.breeze_buddy.template import decode_template
 from app.database.queries import run_parameterized_query
 from app.database.queries.breeze_buddy.call_execution_config import (
@@ -78,6 +82,7 @@ async def create_template(
     telephony_number_id: Optional[str] = None,
     is_active: bool = True,
     supported_channels: Optional[List[str]] = None,
+    changed_by: Optional[str] = None,
 ) -> Optional[TemplateModel]:
     """Create a new template with flow stored as JSON."""
     logger.info(f"Creating template with ID: {template_id}")
@@ -121,16 +126,19 @@ async def create_template(
             now,
         )
 
-        result = await run_parameterized_query(query, values)
-        if result and get_row_count(result) > 0:
-            decoded_result = decode_template(result[0])
+        async for conn in get_db_connection():
+            async with conn.transaction():
+                row = await conn.fetchrow(query, *values)
+                if row is None:
+                    logger.error("Failed to create template")
+                    return None
+                await insert_template_version_on_conn(
+                    conn, row, change_source="create", changed_by=changed_by
+                )
+            decoded_result = decode_template(row)
             if decoded_result:
                 logger.info(f"Template created successfully: {decoded_result.id}")
-            else:
-                logger.error("Template decoding failed after creation")
             return decoded_result
-
-        logger.error("Failed to create template")
         return None
 
     except Exception as e:
@@ -254,6 +262,8 @@ async def get_templates_list(
                     name=row["name"],
                     is_active=row["is_active"],
                     supported_channels=list(row["supported_channels"]),
+                    family_id=(str(row["family_id"]) if row.get("family_id") else None),
+                    current_version=row.get("current_version") or 1,
                     created_at=row["created_at"],
                     updated_at=row["updated_at"],
                 )
@@ -308,6 +318,28 @@ async def get_template_by_id(template_id: str) -> Optional[TemplateModel]:
         return None
 
 
+async def get_template_raw_configurations(
+    template_id: str,
+) -> Optional[Dict[str, Any]]:
+    """The ``configurations`` column exactly as stored.
+
+    ``get_template_by_id`` decodes through ``ConfigurationModel``, which
+    materialises every Pydantic default. Callers that COPY a template's
+    configuration into another row (family create) must persist what was
+    actually stored, not the default-filled view of it.
+    """
+    try:
+        query, values = get_template_by_id_query(template_id)
+        result = await run_parameterized_query(query, values)
+        if not result:
+            return None
+        raw = result[0]["configurations"]
+        return json.loads(raw) if isinstance(raw, str) else raw
+    except Exception as e:
+        logger.error(f"Error reading raw configurations for {template_id}: {e}")
+        raise
+
+
 async def get_template_merchant_id(template_id: str) -> Optional[str]:
     """Return only the merchant that owns a template.
 
@@ -349,6 +381,9 @@ async def replace_template(
     merchant_id: Optional[str],
     now,
     supported_channels: Optional[List[str]] = None,
+    changed_by: Optional[str] = None,
+    change_source: str = "manual_edit",
+    bulk_op_id: Optional[str] = None,
 ) -> Optional[TemplateModel]:
     """
     Update an existing template.
@@ -411,17 +446,23 @@ async def replace_template(
             now,
         )
 
-        result = await run_parameterized_query(query, values)
-
-        if result and get_row_count(result) > 0:
-            decoded_result = decode_template(result[0])
+        async for conn in get_db_connection():
+            async with conn.transaction():
+                row = await conn.fetchrow(query, *values)
+                if row is None:
+                    logger.error(f"Failed to update template: {template_id}")
+                    return None
+                await insert_template_version_on_conn(
+                    conn,
+                    row,
+                    change_source=change_source,
+                    bulk_op_id=bulk_op_id,
+                    changed_by=changed_by,
+                )
+            decoded_result = decode_template(row)
             if decoded_result:
                 logger.info(f"Template updated successfully: {decoded_result.id}")
-            else:
-                logger.error("Template decoding failed after update")
             return decoded_result
-
-        logger.error(f"Failed to update template: {template_id}")
         return None
 
     except Exception as e:
@@ -527,6 +568,8 @@ async def delete_template_if_not_referenced(
                 merchant_id=row.get("merchant_id"),
                 name=row["name"],
                 is_active=row["is_active"],
+                family_id=(str(row["family_id"]) if row.get("family_id") else None),
+                current_version=row.get("current_version") or 1,
                 created_at=row["created_at"],
                 updated_at=row["updated_at"],
             )

--- a/app/database/accessor/breeze_buddy/template_version.py
+++ b/app/database/accessor/breeze_buddy/template_version.py
@@ -1,0 +1,1670 @@
+"""Accessors for template versioning: snapshot insert, reads, rollback."""
+
+import copy
+import json
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional, Set, Tuple
+from uuid import uuid4
+
+from app.ai.voice.agents.breeze_buddy.template.merge import (
+    apply_merge_decisions,
+    merge_family_into_child,
+)
+from app.ai.voice.agents.breeze_buddy.template.patch import (
+    apply_template_patches,
+    validate_patched_template,
+)
+from app.ai.voice.agents.breeze_buddy.template.types import (
+    ConfigurationModel,
+    TemplateModel,
+)
+from app.ai.voice.agents.breeze_buddy.utils.secrets import (
+    contains_masked_literal,
+    mask_mcp_auth_secrets,
+)
+from app.core.config.static import TEMPLATE_VERSION_RETENTION
+from app.core.logger import logger
+from app.database import get_db_connection
+from app.database.decoder.breeze_buddy.template import decode_template
+from app.database.decoder.breeze_buddy.template_version import (
+    decode_template_version_meta,
+)
+from app.database.queries import run_parameterized_query
+from app.database.queries.breeze_buddy.template import (
+    assign_family_query,
+    count_family_member_contents_query,
+    get_family_member_contents_query,
+    get_family_templates_for_update_query,
+    get_template_head_versions_query,
+    get_templates_for_update_query,
+    restore_template_head_query,
+    set_template_derived_base_version_query,
+    set_templates_derived_base_version_query,
+    update_template_bulk_fields_query,
+)
+from app.database.queries.breeze_buddy.template_version import (
+    count_family_members_query,
+    count_missing_preop_snapshots_bulk_query,
+    get_bulk_op_by_id_query,
+    get_bulk_op_touched_versions_query,
+    get_family_members_query,
+    get_family_version_snapshot_query,
+    get_family_versions_count_query,
+    get_family_versions_query,
+    get_missing_preop_snapshots_query,
+    get_template_family_for_update_query,
+    get_template_family_query,
+    get_template_version_snapshot_query,
+    get_template_versions_count_query,
+    get_template_versions_query,
+    insert_bulk_op_query,
+    insert_template_family_query,
+    insert_template_family_version_query,
+    insert_template_version_query,
+    list_bulk_ops_query,
+    list_template_families_query,
+    mark_bulk_op_rolled_back_query,
+    prune_family_versions_query,
+    prune_template_versions_query,
+    remove_family_members_query,
+    update_template_family_query,
+)
+from app.schemas.breeze_buddy.template_version import (
+    BulkOpSummary,
+    BulkRollbackResponse,
+    BulkTemplateResult,
+    BulkUpdateResponse,
+    ChildMergeOutcome,
+    FamilyMember,
+    FamilyResponse,
+    FamilyVersionMetadata,
+    FamilyVersionSnapshot,
+    MergeFieldChange,
+    PropagationChildPreview,
+    PropagationPreviewResponse,
+    PropagationResolution,
+    TemplateVersionMetadata,
+)
+
+
+def _as_json_str(value: Any) -> Optional[str]:
+    """asyncpg returns JSONB as str; accept dict for direct-construction paths."""
+    if value is None:
+        return None
+    if isinstance(value, str):
+        return value
+    return json.dumps(value)
+
+
+async def insert_template_version_on_conn(
+    conn,
+    head_row: Any,
+    change_source: str,
+    bulk_op_id: Optional[str] = None,
+    changed_by: Optional[str] = None,
+) -> None:
+    """Snapshot a head-table RETURNING row as an immutable version.
+
+    MUST run on the same connection/transaction as the head write so the
+    head bump and its snapshot commit or roll back together.
+    """
+    query, values = insert_template_version_query(
+        str(head_row["id"]),
+        head_row["current_version"],
+        head_row["reseller_id"],
+        head_row["merchant_id"],
+        head_row["name"],
+        _as_json_str(head_row["flow"]) or "{}",
+        _as_json_str(head_row["expected_payload_schema"]),
+        _as_json_str(head_row["expected_callback_response_schema"]),
+        _as_json_str(head_row["configurations"]),
+        _as_json_str(head_row["secrets"]),
+        (
+            str(head_row["telephony_number_id"])
+            if head_row["telephony_number_id"]
+            else None
+        ),
+        head_row["is_active"],
+        list(head_row["supported_channels"]),
+        change_source,
+        bulk_op_id,
+        changed_by,
+    )
+    await conn.fetchrow(query, *values)
+    # Retention: keep only the newest TEMPLATE_VERSION_RETENTION versions.
+    # Same transaction as the insert; the query's guard clause never prunes
+    # snapshots an active bulk op still needs for rollback.
+    prune_q, prune_v = prune_template_versions_query(
+        str(head_row["id"]),
+        head_row["current_version"],
+        TEMPLATE_VERSION_RETENTION,
+    )
+    await conn.execute(prune_q, *prune_v)
+
+
+async def list_template_versions(
+    template_id: str, limit: int = 50, offset: int = 0
+) -> Tuple[List[TemplateVersionMetadata], int]:
+    try:
+        query, values = get_template_versions_query(template_id, limit, offset)
+        rows = await run_parameterized_query(query, values)
+        count_q, count_v = get_template_versions_count_query(template_id)
+        count_rows = await run_parameterized_query(count_q, count_v)
+        total = count_rows[0]["total"] if count_rows else 0
+        return [decode_template_version_meta(r) for r in (rows or [])], total
+    except Exception as e:
+        logger.error(f"Error listing versions for template {template_id}: {e}")
+        raise
+
+
+async def get_template_version(
+    template_id: str, version: int
+) -> Optional[Tuple[TemplateModel, TemplateVersionMetadata]]:
+    try:
+        query, values = get_template_version_snapshot_query(template_id, version)
+        rows = await run_parameterized_query(query, values)
+        if not rows:
+            return None
+        row = rows[0]
+        snapshot = decode_template(row)
+        if snapshot is None:
+            return None
+        meta = decode_template_version_meta(
+            {
+                "template_id": row["id"],
+                "version": row["version"],
+                "change_source": row["change_source"],
+                "bulk_op_id": row.get("bulk_op_id"),
+                "changed_by": row.get("changed_by"),
+                "created_at": row["created_at"],
+            }
+        )
+        return snapshot, meta
+    except Exception as e:
+        logger.error(f"Error getting version {version} of template {template_id}: {e}")
+        raise
+
+
+class PreOpSnapshotVanished(Exception):
+    """Raised inside ``bulk_rollback_templates``' transaction when a member's
+    pre-op snapshot disappeared between the all-or-nothing pre-check and the
+    restore loop (a concurrent template DELETE cascades its version rows).
+
+    Must be a raise, not a return: a plain ``return`` inside
+    ``async with conn.transaction()`` COMMITS, which would leave the already
+    restored siblings written and the op marked rolled_back. Unwinding out of
+    the transaction rolls the whole rollback back; the handler turns it into
+    the same 409 the pruned-snapshot pre-check produces.
+    """
+
+    def __init__(self, template_id: str) -> None:
+        super().__init__(template_id)
+        self.template_id = template_id
+
+
+async def _rollback_on_conn(
+    conn,
+    template_id: str,
+    version: int,
+    changed_by: Optional[str],
+    change_source: str,
+    bulk_op_id: Optional[str],
+) -> Optional[TemplateModel]:
+    snap_q, snap_v = get_template_version_snapshot_query(template_id, version)
+    snap = await conn.fetchrow(snap_q, *snap_v)
+    if snap is None:
+        return None
+    restore_q, restore_v = restore_template_head_query(
+        template_id,
+        snap["reseller_id"],
+        snap["merchant_id"],
+        snap["name"],
+        _as_json_str(snap["flow"]) or "{}",
+        _as_json_str(snap["expected_payload_schema"]),
+        _as_json_str(snap["expected_callback_response_schema"]),
+        _as_json_str(snap["configurations"]),
+        _as_json_str(snap["secrets"]),
+        (str(snap["telephony_number_id"]) if snap["telephony_number_id"] else None),
+        snap["is_active"],
+        list(snap["supported_channels"]),
+        datetime.now(timezone.utc),
+    )
+    head = await conn.fetchrow(restore_q, *restore_v)
+    if head is None:
+        return None
+    await insert_template_version_on_conn(
+        conn,
+        head,
+        change_source=change_source,
+        bulk_op_id=bulk_op_id,
+        changed_by=changed_by,
+    )
+    return decode_template(head)
+
+
+async def rollback_template_to_version(
+    template_id: str,
+    version: int,
+    changed_by: Optional[str],
+) -> Optional[TemplateModel]:
+    """Restore an older snapshot as the new head (+ new version row).
+
+    Raises on DB conflicts (unique name, FK on telephony_number_id) so the
+    handler can surface a 409 instead of silently half-applying.
+    """
+    async for db_conn in get_db_connection():
+        async with db_conn.transaction():
+            return await _rollback_on_conn(
+                db_conn, template_id, version, changed_by, "rollback", None
+            )
+    return None
+
+
+def _assert_all_assigned(family_id: str, requested: List[str], rows: Any) -> List[str]:
+    """``assign_family_query`` returns only the rows it actually adopted.
+
+    Anything absent is either a missing/deleted template ID, or a template
+    that already belongs to a *different* family (the query's WHERE clause
+    excludes those).
+    """
+    assigned = {str(r["id"]) for r in (rows or [])}
+    rejected = sorted(set(requested) - assigned)
+    if rejected:
+        raise ValueError(
+            f"cannot add templates to family {family_id}: "
+            f"{', '.join(rejected)} — template IDs are missing, deleted, "
+            "or already assigned to a different family"
+        )
+    return sorted(assigned)
+
+
+async def assign_family(family_id: str, template_ids: List[str]) -> List[str]:
+    try:
+        query, values = assign_family_query(
+            family_id, template_ids, datetime.now(timezone.utc)
+        )
+        rows = await run_parameterized_query(query, values)
+        return _assert_all_assigned(family_id, template_ids, rows)
+    except Exception as e:
+        logger.error(f"Error assigning family {family_id}: {e}")
+        raise
+
+
+def _json_col(row: Any, key: str) -> Optional[Dict[str, Any]]:
+    value = row.get(key)
+    if isinstance(value, str):
+        return json.loads(value)
+    return value
+
+
+def _mask_family_configurations(
+    configurations: Optional[Dict[str, Any]],
+) -> Optional[Dict[str, Any]]:
+    """Round-trip ``configurations`` through ``ConfigurationModel`` (no
+    ``reveal_secrets`` context) so MCP auth secrets (token/password/
+    api_key_value) come back masked, mirroring how ``GET /templates/{id}``
+    masks them. ``template_family.configurations`` is stored as a plain
+    dict (unlike ``template``, which round-trips through the head-table
+    decoder's ``ConfigurationModel``), so without this step a family read
+    would serialize whatever was persisted verbatim -- including any
+    plaintext secret that slipped in via a copy-from-template create.
+
+    Falls back to the raw dict on validation failure (logged) so a legacy
+    or malformed shape can't 500 a family read.
+    """
+    if configurations is None:
+        return None
+    try:
+        model = ConfigurationModel.model_validate(configurations)
+        return model.model_dump(exclude_none=True, mode="json")
+    except Exception as exc:
+        logger.warning(
+            f"Failed to mask family configurations, falling back to raw dict: {exc}"
+        )
+        return configurations
+
+
+def _decode_family(
+    row: Any, members: List[FamilyMember], member_count: Optional[int] = None
+) -> FamilyResponse:
+    return FamilyResponse(
+        id=str(row["id"]),
+        name=row["name"],
+        description=row.get("description"),
+        flow=_json_col(row, "flow") or {},
+        expected_payload_schema=_json_col(row, "expected_payload_schema"),
+        expected_callback_response_schema=_json_col(
+            row, "expected_callback_response_schema"
+        ),
+        configurations=_mask_family_configurations(_json_col(row, "configurations")),
+        supported_channels=list(row.get("supported_channels") or ["voice"]),
+        base_version=row.get("base_version") or 1,
+        members=members,
+        member_count=len(members) if member_count is None else member_count,
+        created_by=row.get("created_by"),
+        updated_by=row.get("updated_by"),
+        created_at=row["created_at"],
+        updated_at=row.get("updated_at"),
+    )
+
+
+async def insert_family_version_on_conn(
+    conn, family_row: Any, changed_by: Optional[str]
+) -> None:
+    """Snapshot a template_family RETURNING row as an immutable family version.
+
+    MUST run on the same connection/transaction as the family write. The row
+    is copied verbatim: template_family holds no secrets column and its
+    configurations are mask-level by construction, so the snapshot carries
+    exactly the same trust level as the family row itself.
+    """
+    query, values = insert_template_family_version_query(
+        str(family_row["id"]),
+        family_row["base_version"],
+        family_row["name"],
+        family_row.get("description"),
+        _as_json_str(family_row["flow"]) or "{}",
+        _as_json_str(family_row["expected_payload_schema"]),
+        _as_json_str(family_row["expected_callback_response_schema"]),
+        _as_json_str(family_row["configurations"]),
+        list(family_row["supported_channels"] or ["voice"]),
+        changed_by,
+    )
+    await conn.fetchrow(query, *values)
+    prune_q, prune_v = prune_family_versions_query(
+        str(family_row["id"]),
+        family_row["base_version"],
+        TEMPLATE_VERSION_RETENTION,
+    )
+    await conn.execute(prune_q, *prune_v)
+
+
+def _decode_family_member(row: Any) -> FamilyMember:
+    return FamilyMember(
+        template_id=str(row["id"]),
+        name=row["name"],
+        reseller_id=row["reseller_id"],
+        merchant_id=row.get("merchant_id"),
+        current_version=row.get("current_version") or 1,
+        derived_from_base_version=row.get("derived_from_base_version"),
+    )
+
+
+async def _load_family_members_on_conn(conn, family_id: str) -> List[FamilyMember]:
+    """Same as ``_load_family_members`` but on an open connection — required
+    inside a transaction, where a second pooled connection would not yet see
+    the uncommitted membership changes."""
+    query, values = get_family_members_query(family_id)
+    rows = await conn.fetch(query, *values)
+    return [_decode_family_member(r) for r in (rows or [])]
+
+
+async def _load_family_members(family_id: str) -> List[FamilyMember]:
+    query, values = get_family_members_query(family_id)
+    rows = await run_parameterized_query(query, values)
+    return [_decode_family_member(r) for r in (rows or [])]
+
+
+async def create_template_family(
+    *,
+    name: str,
+    description: Optional[str],
+    flow: Dict[str, Any],
+    expected_payload_schema: Optional[Dict[str, Any]],
+    expected_callback_response_schema: Optional[Dict[str, Any]],
+    configurations: Optional[Dict[str, Any]],
+    supported_channels: List[str],
+    member_template_ids: List[str],
+    created_by: Optional[str],
+) -> Optional[FamilyResponse]:
+    family_id = str(uuid4())
+    # Write-time enforcement of the "family content never holds a real
+    # secret" invariant: masking on read alone would still leave a token
+    # supplied inline by an admin at rest in template_family and in every
+    # template_family_version snapshot.
+    configurations = mask_mcp_auth_secrets(configurations)
+    query, values = insert_template_family_query(
+        family_id,
+        name,
+        description,
+        json.dumps(flow),
+        (
+            json.dumps(expected_payload_schema)
+            if expected_payload_schema is not None
+            else None
+        ),
+        (
+            json.dumps(expected_callback_response_schema)
+            if expected_callback_response_schema is not None
+            else None
+        ),
+        json.dumps(configurations) if configurations is not None else None,
+        supported_channels,
+        created_by,
+    )
+    async for conn in get_db_connection():
+        async with conn.transaction():
+            row = await conn.fetchrow(query, *values)
+            if row is None:
+                return None
+            # base_version 1 must exist as a snapshot: it is the merge base
+            # for any child that derives from the family's first revision.
+            await insert_family_version_on_conn(conn, row, created_by)
+            if member_template_ids:
+                assign_q, assign_v = assign_family_query(
+                    family_id, member_template_ids, datetime.now(timezone.utc)
+                )
+                # Raises out of the transaction (so the family is not created
+                # either) if any requested member is missing or belongs to a
+                # different reseller.
+                _assert_all_assigned(
+                    family_id,
+                    member_template_ids,
+                    await conn.fetch(assign_q, *assign_v),
+                )
+            return _decode_family(
+                row, await _load_family_members_on_conn(conn, family_id)
+            )
+    return None
+
+
+async def update_template_family(
+    family_id: str,
+    *,
+    name: Optional[str] = None,
+    description: Optional[str] = None,
+    flow: Optional[Dict[str, Any]] = None,
+    expected_payload_schema: Optional[Dict[str, Any]] = None,
+    expected_callback_response_schema: Optional[Dict[str, Any]] = None,
+    configurations: Optional[Dict[str, Any]] = None,
+    supported_channels: Optional[List[str]] = None,
+    updated_by: Optional[str] = None,
+) -> Optional[FamilyResponse]:
+    """``None`` for any field means "leave that column as it is".
+
+    Unchanged columns are carried over from the row locked here, NOT from a
+    decoded ``FamilyResponse``: the decoder round-trips configurations
+    through ``ConfigurationModel``, which materialises every Pydantic
+    default, so echoing that back would rewrite the stored configuration
+    with keys the caller never set — and snapshot them into history — on a
+    PUT that only changed the name. Reading under ``FOR UPDATE`` also makes
+    the read-modify-write atomic against a concurrent edit.
+    """
+    # Same invariant as create_template_family: never persist a real secret
+    # into the family row or its snapshot.
+    configurations = mask_mcp_auth_secrets(configurations)
+    async for conn in get_db_connection():
+        async with conn.transaction():
+            lock_q, lock_v = get_template_family_for_update_query(family_id)
+            current = await conn.fetchrow(lock_q, *lock_v)
+            if current is None:
+                return None
+            query, values = update_template_family_query(
+                family_id,
+                name if name is not None else current["name"],
+                description if description is not None else current["description"],
+                (
+                    json.dumps(flow)
+                    if flow is not None
+                    else (_as_json_str(current["flow"]) or "{}")
+                ),
+                (
+                    json.dumps(expected_payload_schema)
+                    if expected_payload_schema is not None
+                    else _as_json_str(current["expected_payload_schema"])
+                ),
+                (
+                    json.dumps(expected_callback_response_schema)
+                    if expected_callback_response_schema is not None
+                    else _as_json_str(current["expected_callback_response_schema"])
+                ),
+                (
+                    json.dumps(configurations)
+                    if configurations is not None
+                    else _as_json_str(current["configurations"])
+                ),
+                (
+                    supported_channels
+                    if supported_channels is not None
+                    else list(current["supported_channels"] or ["voice"])
+                ),
+                updated_by,
+                datetime.now(timezone.utc),
+            )
+            row = await conn.fetchrow(query, *values)
+            if row is None:
+                return None
+            # Same transaction as the base_version bump: head and history
+            # can never diverge (docs/TEMPLATE_LINEAGE.md §4).
+            await insert_family_version_on_conn(conn, row, updated_by)
+            return _decode_family(
+                row, await _load_family_members_on_conn(conn, family_id)
+            )
+    return None
+
+
+async def get_template_family(family_id: str) -> Optional[FamilyResponse]:
+    query, values = get_template_family_query(family_id)
+    rows = await run_parameterized_query(query, values)
+    if not rows:
+        return None
+    return _decode_family(rows[0], await _load_family_members(family_id))
+
+
+async def list_template_families() -> List[FamilyResponse]:
+    """List all families WITHOUT their member rows (global, admin-only).
+
+    The listing carries ``member_count`` only: loading every member of every
+    family was one query per family (N+1) plus a member list the list screen
+    never renders. ``GET /templates/families/{id}`` remains the place that
+    returns the full ``members`` array.
+    """
+    query, values = list_template_families_query()
+    rows = await run_parameterized_query(query, values)
+    if not rows:
+        return []
+    count_q, count_v = count_family_members_query([str(r["id"]) for r in rows])
+    counts = {
+        str(c["family_id"]): c["member_count"]
+        for c in (await run_parameterized_query(count_q, count_v) or [])
+    }
+    return [_decode_family(r, [], counts.get(str(r["id"]), 0)) for r in rows]
+
+
+async def update_family_members(
+    family_id: str, add: List[str], remove: List[str]
+) -> Optional[FamilyResponse]:
+    if add:
+        await assign_family(family_id, add)
+    if remove:
+        query, values = remove_family_members_query(
+            family_id, remove, datetime.now(timezone.utc)
+        )
+        await run_parameterized_query(query, values)
+    return await get_template_family(family_id)
+
+
+async def bulk_update_templates(
+    *,
+    template_ids: Optional[List[str]],
+    family_id: Optional[str],
+    flow_patch: Optional[Dict[str, Any]],
+    node_patches: Optional[Dict[str, Dict[str, Any]]],
+    configurations_patch: Optional[Dict[str, Any]],
+    patch_json: str,
+    changed_by: Optional[str],
+    dry_run: bool,
+) -> BulkUpdateResponse:
+    """All-or-nothing bulk patch. Each member's OWN current state is patched
+    (merge patch preserves everything the patch doesn't mention), validated,
+    then written + snapshotted under one bulk_op_id in one transaction."""
+    if configurations_patch is not None and contains_masked_literal(
+        configurations_patch
+    ):
+        # Same rule the propagation "custom" resolution enforces: a client
+        # that built this patch from a masked read (GET /templates/{id} masks
+        # MCP auth secrets) would otherwise persist the literal "**********"
+        # over every member's real token and break MCP auth at runtime. The
+        # merge-patch semantics already mean "omit the field to keep the
+        # existing value", so there is nothing to substitute here.
+        return BulkUpdateResponse(
+            status="failed",
+            results=[
+                BulkTemplateResult(
+                    template_id="",
+                    name="",
+                    error=(
+                        "configurations_patch contains a masked secret "
+                        "placeholder; omit the field to keep each template's "
+                        "existing value, or send the real one"
+                    ),
+                )
+            ],
+        )
+    async for conn in get_db_connection():
+        async with conn.transaction():
+            if family_id:
+                lock_q, lock_v = get_family_templates_for_update_query(family_id)
+            else:
+                lock_q, lock_v = get_templates_for_update_query(template_ids or [])
+            members = await conn.fetch(lock_q, *lock_v)
+            if template_ids:
+                # All-or-nothing: an ID that no longer exists must fail the
+                # op, not silently drop out of it and report "completed" for
+                # the rest.
+                found = {str(r["id"]) for r in members}
+                missing = [tid for tid in template_ids if tid not in found]
+                if missing:
+                    return BulkUpdateResponse(
+                        status="failed",
+                        results=[
+                            BulkTemplateResult(
+                                template_id=tid,
+                                name="",
+                                error="template not found",
+                            )
+                            for tid in missing
+                        ],
+                    )
+            if not members:
+                return BulkUpdateResponse(
+                    status="failed",
+                    results=[
+                        BulkTemplateResult(
+                            template_id="",
+                            name="",
+                            error=f"family {family_id} has no member templates",
+                        )
+                    ],
+                )
+
+            patched: List[Tuple[Any, Dict[str, Any], Optional[Dict[str, Any]]]] = []
+            errors: List[BulkTemplateResult] = []
+            for row in members:
+                flow = (
+                    json.loads(row["flow"])
+                    if isinstance(row["flow"], str)
+                    else dict(row["flow"] or {})
+                )
+                configurations = row["configurations"]
+                if isinstance(configurations, str):
+                    configurations = json.loads(configurations)
+                try:
+                    new_flow, new_configurations = apply_template_patches(
+                        flow,
+                        configurations,
+                        flow_patch,
+                        node_patches,
+                        configurations_patch,
+                    )
+                    err = validate_patched_template(
+                        new_flow, new_configurations, str(row["id"]), row["name"]
+                    )
+                except ValueError as exc:
+                    err = str(exc)
+                    new_flow, new_configurations = flow, configurations
+                if err:
+                    errors.append(
+                        BulkTemplateResult(
+                            template_id=str(row["id"]),
+                            name=row["name"],
+                            from_version=row["current_version"],
+                            error=err,
+                        )
+                    )
+                else:
+                    patched.append((row, new_flow, new_configurations))
+
+            if errors:
+                # abort: report every error, write nothing
+                return BulkUpdateResponse(status="failed", results=errors)
+
+            if dry_run:
+                return BulkUpdateResponse(
+                    status="dry_run",
+                    results=[
+                        BulkTemplateResult(
+                            template_id=str(row["id"]),
+                            name=row["name"],
+                            from_version=row["current_version"],
+                            to_version=row["current_version"] + 1,
+                            preview_flow=new_flow,
+                            preview_configurations=_mask_family_configurations(
+                                new_configurations
+                            ),
+                        )
+                        for row, new_flow, new_configurations in patched
+                    ],
+                )
+
+            op_id = str(uuid4())
+            op_q, op_v = insert_bulk_op_query(
+                op_id,
+                "bulk_update",
+                family_id,
+                [str(r["id"]) for r, _, _ in patched],
+                patch_json,
+                "completed",
+                None,
+                changed_by,
+            )
+            op_row = await conn.fetchrow(op_q, *op_v)
+
+            results: List[BulkTemplateResult] = []
+            now = datetime.now(timezone.utc)
+            for row, new_flow, new_configurations in patched:
+                upd_q, upd_v = update_template_bulk_fields_query(
+                    str(row["id"]),
+                    json.dumps(new_flow),
+                    (
+                        json.dumps(new_configurations)
+                        if new_configurations is not None
+                        else None
+                    ),
+                    now,
+                )
+                head = await conn.fetchrow(upd_q, *upd_v)
+                await insert_template_version_on_conn(
+                    conn,
+                    head,
+                    change_source="bulk_update",
+                    bulk_op_id=op_id,
+                    changed_by=changed_by,
+                )
+                results.append(
+                    BulkTemplateResult(
+                        template_id=str(row["id"]),
+                        name=row["name"],
+                        from_version=row["current_version"],
+                        to_version=head["current_version"],
+                    )
+                )
+            return BulkUpdateResponse(
+                status="completed", bulk_op_id=str(op_row["id"]), results=results
+            )
+    return BulkUpdateResponse(status="failed", results=[])
+
+
+async def bulk_rollback_templates(
+    bulk_op_id: str,
+    changed_by: Optional[str],
+    force: bool,
+    also_revert_family: bool = False,
+    op: Optional[BulkOpSummary] = None,
+) -> BulkRollbackResponse:
+    """Revert every template touched by a bulk_update / propagation op to its
+    pre-op snapshot (version - 1), as new versions under a new bulk_rollback
+    op.
+
+    ``op`` is the ledger row the handler already loaded for its 404/409
+    preconditions; passing it avoids a second read and keeps the reverted
+    children's ``derived_from_base_version`` correct for propagation ops.
+    When it is None only the plain content revert runs.
+    """
+
+    def _fail(results: List[BulkTemplateResult]) -> BulkRollbackResponse:
+        return BulkRollbackResponse(
+            status="failed",
+            bulk_op_id="",
+            reverted_bulk_op_id=bulk_op_id,
+            results=results,
+        )
+
+    async for conn in get_db_connection():
+        async with conn.transaction():
+            touched_q, touched_v = get_bulk_op_touched_versions_query(bulk_op_id)
+            touched = await conn.fetch(touched_q, *touched_v)
+            if not touched:
+                return _fail([])
+
+            head_q, head_v = get_template_head_versions_query(
+                [str(t["template_id"]) for t in touched]
+            )
+            heads = {
+                str(r["id"]): r["current_version"]
+                for r in await conn.fetch(head_q, *head_v)
+            }
+
+            drifted = [
+                BulkTemplateResult(
+                    template_id=str(t["template_id"]),
+                    name="",
+                    from_version=heads.get(str(t["template_id"])),
+                    error=(
+                        f"drifted: head is v{heads.get(str(t['template_id']))}, "
+                        f"bulk op wrote v{t['version']}"
+                    ),
+                )
+                for t in touched
+                if heads.get(str(t["template_id"])) != t["version"]
+            ]
+            if drifted and not force:
+                return _fail(drifted)
+
+            # All-or-nothing pre-check: verify every touched member's pre-op
+            # snapshot still exists BEFORE writing anything. Without this, a
+            # member whose snapshot was pruned by retention would silently
+            # report "pre-op snapshot missing" while its siblings were
+            # already restored and the op was still marked rolled_back --
+            # dropping retention protection for the whole op on a partial
+            # failure. force=true overrides the drift guard above but never
+            # this: there's nothing to restore for a pruned snapshot.
+            missing_q, missing_v = get_missing_preop_snapshots_query(bulk_op_id)
+            missing_rows = await conn.fetch(missing_q, *missing_v)
+            if missing_rows:
+                missing_ids = {str(r["template_id"]) for r in missing_rows}
+                return _fail(
+                    [
+                        BulkTemplateResult(
+                            template_id=str(t["template_id"]),
+                            name="",
+                            from_version=heads.get(str(t["template_id"])),
+                            error="pre-op snapshot missing (pruned)",
+                        )
+                        for t in touched
+                        if str(t["template_id"]) in missing_ids
+                    ]
+                )
+
+            is_propagation = op is not None and op.op_type == "propagation"
+            family_target: Optional[int] = None
+            if op is not None and is_propagation:
+                if op.family_id is not None and op.from_base_version is not None:
+                    family_target = op.from_base_version
+            if also_revert_family:
+                # All-or-nothing pre-check, mirroring the pruned-snapshot one:
+                # a return inside the transaction still COMMITS, so the family
+                # snapshot must be proven to exist before anything is written.
+                if op is None or not is_propagation or family_target is None:
+                    return _fail(
+                        [
+                            BulkTemplateResult(
+                                template_id="",
+                                name="",
+                                error=(
+                                    "also_revert_family is only valid for a "
+                                    "propagation op with a from_base_version"
+                                ),
+                            )
+                        ]
+                    )
+                # Lock the family row now, in this transaction, so a
+                # concurrent PUT /templates/families/{id} cannot interleave
+                # with the restore below (same pattern as
+                # apply_family_propagation).
+                lock_q, lock_v = get_template_family_for_update_query(str(op.family_id))
+                await conn.fetchrow(lock_q, *lock_v)
+                probe_q, probe_v = get_family_version_snapshot_query(
+                    str(op.family_id), family_target
+                )
+                if await conn.fetchrow(probe_q, *probe_v) is None:
+                    return _fail(
+                        [
+                            BulkTemplateResult(
+                                template_id="",
+                                name="",
+                                error=(
+                                    f"family snapshot missing: family "
+                                    f"{op.family_id} base_version {family_target} "
+                                    "was pruned by retention"
+                                ),
+                            )
+                        ]
+                    )
+
+            new_op_id = str(uuid4())
+            op_q, op_v = insert_bulk_op_query(
+                new_op_id,
+                "bulk_rollback",
+                None,
+                [str(t["template_id"]) for t in touched],
+                None,
+                "completed",
+                bulk_op_id,
+                changed_by,
+            )
+            op_row = await conn.fetchrow(op_q, *op_v)
+
+            results: List[BulkTemplateResult] = []
+            for t in touched:
+                tid = str(t["template_id"])
+                restored = await _rollback_on_conn(
+                    conn,
+                    tid,
+                    t["version"] - 1,
+                    changed_by,
+                    change_source="bulk_rollback",
+                    bulk_op_id=new_op_id,
+                )
+                if restored is None:
+                    # The pre-check above proved every snapshot existed, so
+                    # this means the template was deleted between the touched
+                    # read and the FOR UPDATE lock (its version rows cascade),
+                    # which force=true no longer guards against. Abort the
+                    # whole transaction rather than reporting "completed" on a
+                    # partial restore.
+                    raise PreOpSnapshotVanished(tid)
+                results.append(
+                    BulkTemplateResult(
+                        template_id=tid,
+                        name=restored.name,
+                        from_version=heads.get(tid),
+                        to_version=restored.current_version,
+                    )
+                )
+
+            family_reverted_to: Optional[int] = None
+            if op is not None and is_propagation:
+                # The children now carry pre-propagation content again, so
+                # their sync pointer must go back too — otherwise the next
+                # merge would use the wrong base.
+                derived_target = op.from_base_version
+                if also_revert_family and family_target is not None:
+                    restored_family = await _rollback_family_on_conn(
+                        conn, str(op.family_id), family_target, changed_by
+                    )
+                    family_reverted_to = family_target
+                    if restored_family is not None:
+                        # The restore appended a NEW family revision whose
+                        # content equals from_base_version. Children match it
+                        # exactly, so they derive from IT — pointing them at
+                        # the old number would flag every member as "behind"
+                        # a parent they are identical to.
+                        derived_target = restored_family.base_version
+                # op.template_ids, not `touched`: the propagation advanced the
+                # pointer for every child it covered, including those whose
+                # content the merge left unchanged (no version row, so absent
+                # from `touched`). Resetting only the touched ones would leave
+                # the unchanged children claiming to derive from a family
+                # revision the rollback just undid, and the next propagation
+                # would merge them against the wrong base.
+                reset_q, reset_v = set_templates_derived_base_version_query(
+                    op.template_ids, derived_target
+                )
+                await conn.execute(reset_q, *reset_v)
+
+            mark_q, mark_v = mark_bulk_op_rolled_back_query(bulk_op_id)
+            await conn.fetchrow(mark_q, *mark_v)
+
+            return BulkRollbackResponse(
+                status="completed",
+                bulk_op_id=str(op_row["id"]),
+                reverted_bulk_op_id=bulk_op_id,
+                results=results,
+                family_reverted_to_base_version=family_reverted_to,
+            )
+    return _fail([])
+
+
+def _decode_bulk_op(row: Any) -> BulkOpSummary:
+    return BulkOpSummary(
+        id=str(row["id"]),
+        op_type=row["op_type"],
+        family_id=(str(row["family_id"]) if row.get("family_id") else None),
+        template_ids=[str(t) for t in row["template_ids"]],
+        status=row["status"],
+        reverted_bulk_op_id=(
+            str(row["reverted_bulk_op_id"]) if row.get("reverted_bulk_op_id") else None
+        ),
+        initiated_by=row.get("initiated_by"),
+        created_at=row["created_at"],
+        from_base_version=row.get("from_base_version"),
+        to_base_version=row.get("to_base_version"),
+    )
+
+
+async def get_bulk_op(bulk_op_id: str) -> Optional[BulkOpSummary]:
+    try:
+        query, values = get_bulk_op_by_id_query(bulk_op_id)
+        rows = await run_parameterized_query(query, values)
+        return _decode_bulk_op(rows[0]) if rows else None
+    except Exception as e:
+        logger.error(f"Error loading bulk op {bulk_op_id}: {e}")
+        raise
+
+
+async def list_bulk_ops(limit: int = 50, offset: int = 0) -> List[BulkOpSummary]:
+    try:
+        query, values = list_bulk_ops_query(limit, offset)
+        rows = await run_parameterized_query(query, values)
+        ops = [_decode_bulk_op(r) for r in (rows or [])]
+        # Only completed bulk_update ops are rollback candidates; the count
+        # tells the UI how many of that op's members already lost their
+        # pre-op snapshot to retention and can't be rolled back. One
+        # aggregate query for the whole page instead of one query per op.
+        rollback_candidate_ids = [
+            op.id
+            for op in ops
+            if op.op_type in ("bulk_update", "propagation") and op.status == "completed"
+        ]
+        if rollback_candidate_ids:
+            count_q, count_v = count_missing_preop_snapshots_bulk_query(
+                rollback_candidate_ids
+            )
+            count_rows = await run_parameterized_query(count_q, count_v)
+            missing_by_op = {
+                str(r["bulk_op_id"]): r["missing"] for r in (count_rows or [])
+            }
+            candidate_ids = set(rollback_candidate_ids)
+            for op in ops:
+                if op.id in candidate_ids:
+                    # absent from missing_by_op == zero missing snapshots
+                    op.rollback_unavailable_count = missing_by_op.get(op.id, 0)
+        return ops
+    except Exception as e:
+        logger.error(f"Error listing bulk ops: {e}")
+        raise
+
+
+def _decode_family_version_meta(row: Any) -> FamilyVersionMetadata:
+    return FamilyVersionMetadata(
+        family_id=str(row["family_id"]),
+        base_version=row["base_version"],
+        name=row["name"],
+        changed_by=row.get("changed_by"),
+        created_at=row["created_at"],
+    )
+
+
+async def list_family_versions(
+    family_id: str, limit: int = 50, offset: int = 0
+) -> Tuple[List[FamilyVersionMetadata], int]:
+    try:
+        query, values = get_family_versions_query(family_id, limit, offset)
+        rows = await run_parameterized_query(query, values)
+        count_q, count_v = get_family_versions_count_query(family_id)
+        count_rows = await run_parameterized_query(count_q, count_v)
+        total = count_rows[0]["total"] if count_rows else 0
+        return [_decode_family_version_meta(r) for r in (rows or [])], total
+    except Exception as e:
+        logger.error(f"Error listing versions for family {family_id}: {e}")
+        raise
+
+
+def _decode_family_version_snapshot(row: Any) -> FamilyVersionSnapshot:
+    return FamilyVersionSnapshot(
+        name=row["name"],
+        description=row.get("description"),
+        flow=_json_col(row, "flow") or {},
+        expected_payload_schema=_json_col(row, "expected_payload_schema"),
+        expected_callback_response_schema=_json_col(
+            row, "expected_callback_response_schema"
+        ),
+        # Same masking as _decode_family: a family version is read back
+        # through ConfigurationModel with no reveal_secrets context.
+        configurations=_mask_family_configurations(_json_col(row, "configurations")),
+        supported_channels=list(row.get("supported_channels") or ["voice"]),
+    )
+
+
+async def get_family_version(
+    family_id: str, base_version: int
+) -> Optional[Tuple[FamilyVersionSnapshot, FamilyVersionMetadata]]:
+    try:
+        query, values = get_family_version_snapshot_query(family_id, base_version)
+        rows = await run_parameterized_query(query, values)
+        if not rows:
+            return None
+        row = rows[0]
+        return _decode_family_version_snapshot(row), _decode_family_version_meta(row)
+    except Exception as e:
+        logger.error(
+            f"Error getting base_version {base_version} of family {family_id}: {e}"
+        )
+        raise
+
+
+async def _rollback_family_on_conn(
+    conn, family_id: str, base_version: int, changed_by: Optional[str]
+) -> Optional[FamilyResponse]:
+    snap_q, snap_v = get_family_version_snapshot_query(family_id, base_version)
+    snap = await conn.fetchrow(snap_q, *snap_v)
+    if snap is None:
+        return None
+    # Restoring goes through the normal family UPDATE, which bumps
+    # base_version: the restore is a NEW revision, never history surgery.
+    upd_q, upd_v = update_template_family_query(
+        family_id,
+        snap["name"],
+        snap.get("description"),
+        _as_json_str(snap["flow"]) or "{}",
+        _as_json_str(snap["expected_payload_schema"]),
+        _as_json_str(snap["expected_callback_response_schema"]),
+        _as_json_str(snap["configurations"]),
+        list(snap["supported_channels"] or ["voice"]),
+        changed_by,
+        datetime.now(timezone.utc),
+    )
+    row = await conn.fetchrow(upd_q, *upd_v)
+    if row is None:
+        return None
+    await insert_family_version_on_conn(conn, row, changed_by)
+    return _decode_family(row, await _load_family_members_on_conn(conn, family_id))
+
+
+async def rollback_family_to_version(
+    family_id: str,
+    base_version: int,
+    changed_by: Optional[str],
+) -> Optional[FamilyResponse]:
+    """Restore an older family snapshot as a NEW base_version.
+
+    Returns None when the requested snapshot does not exist.
+    """
+    async for db_conn in get_db_connection():
+        async with db_conn.transaction():
+            return await _rollback_family_on_conn(
+                db_conn, family_id, base_version, changed_by
+            )
+    return None
+
+
+async def _resolve_merge_base(
+    fetch_snapshot,
+    family_id: str,
+    child_derived: Optional[int],
+    previous_base_version: Optional[int],
+    parent_flow: Dict[str, Any],
+    parent_configurations: Optional[Dict[str, Any]],
+) -> Tuple[Dict[str, Any], Optional[Dict[str, Any]], Optional[int], str]:
+    """Pick the family snapshot the three-way merge uses as its base.
+
+    Order:
+      1. the family version the child last synced from
+         (``derived_from_base_version``);
+      2. the family version immediately before the one being propagated —
+         used both when the child has never been propagated to
+         (``derived_from_base_version IS NULL``) and when its snapshot was
+         pruned by retention. A never-synced child can only honestly be
+         claimed to be in sync with everything EXCEPT the edit being
+         propagated right now: basing on family v1 would replay every
+         historical family change as a conflict against a merchant who
+         never opted into them, and basing on the child's own content would
+         make every field a no-op and propagate nothing;
+      3. the parent content itself — no base is available at all, so the
+         merge sees parent == base and reports nothing. Safe by
+         construction: a child is never silently overwritten.
+
+    ``fetch_snapshot`` is ``async (family_id, base_version) -> Optional[row]``
+    so preview (pooled read) and apply (inside the transaction) share this
+    logic.
+    """
+    for candidate, source in (
+        (child_derived, "derived"),
+        (previous_base_version, "previous_version"),
+    ):
+        if candidate is None or candidate < 1:
+            continue
+        row = await fetch_snapshot(family_id, candidate)
+        if row is not None:
+            return (
+                _json_col(row, "flow") or {},
+                _json_col(row, "configurations"),
+                candidate,
+                source,
+            )
+    return (
+        copy.deepcopy(parent_flow),
+        copy.deepcopy(parent_configurations),
+        None,
+        "parent_fallback",
+    )
+
+
+def _mask_preview_configuration_values(
+    outcome: ChildMergeOutcome,
+    base_configurations: Optional[Dict[str, Any]],
+    parent_configurations: Optional[Dict[str, Any]],
+    child_configurations: Optional[Dict[str, Any]],
+) -> None:
+    """Mask every ``configurations.*`` value that leaves the accessor:
+    conflicts' ``base``/``parent``/``child`` AND every ``auto_applied``
+    entry's ``value``.
+
+    Children (unlike families) hold real MCP auth secrets. Family-side
+    values are *supposed* to already be mask-level (``template_family`` is
+    round-tripped through ``ConfigurationModel`` on every write), but
+    ``_mask_family_configurations``'s own docstring documents a path for a
+    plaintext secret to slip in anyway (a copy-from-template create before
+    that masking existed, or a legacy row) — so base/parent are re-masked
+    here too, for defense in depth. The merge itself already ran on the raw
+    values, so classification stays correct; only what leaves the accessor
+    is masked.
+    """
+    masked_base = _mask_family_configurations(base_configurations) or {}
+    masked_parent = _mask_family_configurations(parent_configurations) or {}
+    masked_child = _mask_family_configurations(child_configurations) or {}
+
+    def _key(field_path: str) -> str:
+        return field_path.split(".", 1)[1]
+
+    for conflict in outcome.conflicts:
+        if not conflict.field_path.startswith("configurations."):
+            continue
+        key = _key(conflict.field_path)
+        if conflict.base_present and key in masked_base:
+            conflict.base = masked_base[key]
+        if conflict.parent_present and key in masked_parent:
+            conflict.parent = masked_parent[key]
+        if conflict.child_present and key in masked_child:
+            conflict.child = masked_child[key]
+
+    for change in outcome.auto_apply:
+        # auto_apply's ``value`` is always the parent-side value (see
+        # merge.py's _classify: the branch only fires when child == base,
+        # so the change carried forward is parent's), except for
+        # op="remove" where value is already None.
+        if change.op != "set" or not change.field_path.startswith("configurations."):
+            continue
+        key = _key(change.field_path)
+        if key in masked_parent:
+            change.value = masked_parent[key]
+
+
+async def preview_family_propagation(
+    family_id: str,
+    page: int = 1,
+    limit: int = 50,
+) -> Optional[PropagationPreviewResponse]:
+    """Three-way merge the family's current content into one page of children.
+
+    Writes nothing, locks nothing (docs/TEMPLATE_LINEAGE.md §6.3 step 2).
+
+    ``page`` / ``limit`` enable streaming large families: the UI fetches
+    successive pages, accumulates the per-child data, and defers apply until
+    all pages are loaded and every conflict is resolved.
+    """
+    try:
+        fam_q, fam_v = get_template_family_query(family_id)
+        fam_rows = await run_parameterized_query(fam_q, fam_v)
+        if not fam_rows:
+            return None
+        family = fam_rows[0]
+        to_base_version = family.get("base_version") or 1
+        previous_base_version = to_base_version - 1 if to_base_version > 1 else None
+        parent_flow = _json_col(family, "flow") or {}
+        parent_configurations = _json_col(family, "configurations")
+
+        # Total member count for pagination metadata
+        count_q, count_v = count_family_member_contents_query(family_id)
+        count_rows = await run_parameterized_query(count_q, count_v)
+        total_members = int(count_rows[0]["total"]) if count_rows else 0
+
+        offset = (page - 1) * limit
+        members_q, members_v = get_family_member_contents_query(
+            family_id, limit=limit, offset=offset
+        )
+        members = await run_parameterized_query(members_q, members_v)
+
+        async def fetch_snapshot(fid: str, base_version: int):
+            q, v = get_family_version_snapshot_query(fid, base_version)
+            rows = await run_parameterized_query(q, v)
+            return rows[0] if rows else None
+
+        children: List[PropagationChildPreview] = []
+        conflict_count = 0
+        expected_current_versions: Dict[str, int] = {}
+        for row in members or []:
+            template_id = str(row["id"])
+            current_version = row.get("current_version") or 1
+            expected_current_versions[template_id] = current_version
+            derived = row.get("derived_from_base_version")
+            base_flow, base_configurations, base_version_used, base_source = (
+                await _resolve_merge_base(
+                    fetch_snapshot,
+                    family_id,
+                    derived,
+                    previous_base_version,
+                    parent_flow,
+                    parent_configurations,
+                )
+            )
+            child_configurations = _json_col(row, "configurations")
+            preview = PropagationChildPreview(
+                template_id=template_id,
+                name=row["name"],
+                merchant_id=row.get("merchant_id"),
+                current_version=current_version,
+                derived_from_base_version=derived,
+                merge_base_version=base_version_used,
+                base_source=base_source,
+            )
+            try:
+                outcome = merge_family_into_child(
+                    base_flow=base_flow,
+                    base_configurations=base_configurations,
+                    parent_flow=parent_flow,
+                    parent_configurations=parent_configurations,
+                    child_flow=_json_col(row, "flow") or {},
+                    child_configurations=child_configurations,
+                )
+            except ValueError as exc:
+                preview.error = str(exc)
+                children.append(preview)
+                continue
+            _mask_preview_configuration_values(
+                outcome,
+                base_configurations,
+                parent_configurations,
+                child_configurations,
+            )
+            preview.auto_applied = outcome.auto_apply
+            preview.noop = outcome.noop
+            preview.conflicts = outcome.conflicts
+            conflict_count += len(outcome.conflicts)
+            children.append(preview)
+
+        has_more = (offset + len(members or [])) < total_members
+
+        return PropagationPreviewResponse(
+            family_id=family_id,
+            to_base_version=to_base_version,
+            from_base_version=previous_base_version,
+            children=children,
+            conflict_count=conflict_count,
+            expected_current_versions=expected_current_versions,
+            total_members=total_members,
+            page=page,
+            limit=limit,
+            has_more=has_more,
+        )
+    except Exception as e:
+        logger.error(f"Error previewing propagation for family {family_id}: {e}")
+        raise
+
+
+async def apply_family_propagation(
+    *,
+    family_id: str,
+    expected_base_version: int,
+    expected_current_versions: Dict[str, int],
+    resolutions: List[PropagationResolution],
+    changed_by: Optional[str],
+) -> BulkUpdateResponse:
+    """Write the previewed merge into every child, all-or-nothing.
+
+    Re-runs the three-way merge from scratch inside one transaction with
+    ``FOR UPDATE`` locks on the family and all members — the preview is
+    stateless, so the merge that gets applied is recomputed from the
+    just-locked rows and the client's expectations are only assertions
+    (docs/TEMPLATE_LINEAGE.md §6.3 step 4).
+    """
+    resolution_index: Dict[Tuple[str, str], PropagationResolution] = {
+        (r.template_id, r.field_path): r for r in resolutions
+    }
+    used: Set[Tuple[str, str]] = set()
+    async for conn in get_db_connection():
+        async with conn.transaction():
+            fam_q, fam_v = get_template_family_for_update_query(family_id)
+            family = await conn.fetchrow(fam_q, *fam_v)
+            if family is None:
+                return BulkUpdateResponse(status="failed", results=[])
+            to_base_version = family["base_version"]
+            if to_base_version != expected_base_version:
+                return BulkUpdateResponse(
+                    status="drift",
+                    results=[
+                        BulkTemplateResult(
+                            template_id="",
+                            name="",
+                            error=(
+                                f"family base_version is {to_base_version}, the "
+                                f"preview was computed at {expected_base_version}; "
+                                "re-run propagate/preview"
+                            ),
+                        )
+                    ],
+                )
+            previous_base_version = to_base_version - 1 if to_base_version > 1 else None
+            parent_flow = _json_col(family, "flow") or {}
+            parent_configurations = _json_col(family, "configurations")
+
+            members_q, members_v = get_family_templates_for_update_query(family_id)
+            members = await conn.fetch(members_q, *members_v)
+            if not members:
+                return BulkUpdateResponse(status="completed", results=[])
+
+            drifted = [
+                BulkTemplateResult(
+                    template_id=str(row["id"]),
+                    name=row["name"],
+                    from_version=row["current_version"],
+                    error=(
+                        # Preview is paginated; apply is not. An uncovered
+                        # member means the caller applied without loading
+                        # every preview page, or the member joined the
+                        # family after the preview was built.
+                        "not covered by this preview — load every preview "
+                        "page before applying (or the member joined the "
+                        "family after the preview was built)"
+                        if str(row["id"]) not in expected_current_versions
+                        else (
+                            f"drifted: head is v{row['current_version']}, preview "
+                            f"saw v{expected_current_versions[str(row['id'])]}"
+                        )
+                    ),
+                )
+                for row in members
+                if expected_current_versions.get(str(row["id"]))
+                != row["current_version"]
+            ]
+            if drifted:
+                return BulkUpdateResponse(status="drift", results=drifted)
+
+            async def fetch_snapshot(fid: str, base_version: int):
+                q, v = get_family_version_snapshot_query(fid, base_version)
+                return await conn.fetchrow(q, *v)
+
+            planned: List[
+                Tuple[Any, Optional[Dict[str, Any]], Optional[Dict[str, Any]]]
+            ] = []
+            unresolved: List[BulkTemplateResult] = []
+            errors: List[BulkTemplateResult] = []
+            for row in members:
+                template_id = str(row["id"])
+                base_flow, base_configurations, _base_version, _source = (
+                    await _resolve_merge_base(
+                        fetch_snapshot,
+                        family_id,
+                        row.get("derived_from_base_version"),
+                        previous_base_version,
+                        parent_flow,
+                        parent_configurations,
+                    )
+                )
+                child_flow = _json_col(row, "flow") or {}
+                child_configurations = _json_col(row, "configurations")
+                try:
+                    outcome = merge_family_into_child(
+                        base_flow=base_flow,
+                        base_configurations=base_configurations,
+                        parent_flow=parent_flow,
+                        parent_configurations=parent_configurations,
+                        child_flow=child_flow,
+                        child_configurations=child_configurations,
+                    )
+                except ValueError as exc:
+                    errors.append(
+                        BulkTemplateResult(
+                            template_id=template_id,
+                            name=row["name"],
+                            from_version=row["current_version"],
+                            error=str(exc),
+                        )
+                    )
+                    continue
+
+                changes: List[MergeFieldChange] = list(outcome.auto_apply)
+                missing: List[str] = []
+                for conflict in outcome.conflicts:
+                    key = (template_id, conflict.field_path)
+                    resolution = resolution_index.get(key)
+                    if resolution is None:
+                        missing.append(conflict.field_path)
+                        continue
+                    used.add(key)
+                    if resolution.choice == "child":
+                        continue
+                    if resolution.choice == "parent":
+                        take_op = "set" if conflict.parent_present else "remove"
+                        take_value = (
+                            conflict.parent if conflict.parent_present else None
+                        )
+                    else:
+                        take_op = "set"
+                        take_value = resolution.value
+                    if (
+                        take_op == "set"
+                        and conflict.field_path.startswith("configurations.")
+                        and contains_masked_literal(take_value)
+                    ):
+                        # Two ways a masked literal reaches this point:
+                        # "custom" resolutions built from the preview (which
+                        # masks configurations.* conflict values), and "parent"
+                        # resolutions, since family configurations are
+                        # mask-level by construction -- mask_mcp_auth_secrets
+                        # runs on every family write. Never persist it: that
+                        # would overwrite the child's real MCP auth secret
+                        # with the literal "**********" and silently break
+                        # auth at runtime. Treat it as "unchanged" instead,
+                        # mirroring merge_masked_mcp_auth's semantics --
+                        # substitute the child's current raw value at this
+                        # field path, so the non-secret part of the same
+                        # parent edit still applies.
+                        if not conflict.child_present:
+                            missing.append(
+                                f"{conflict.field_path} (resolved value "
+                                "contains a masked secret placeholder with "
+                                "no existing child value to restore -- "
+                                "resubmit as choice='custom' with the real "
+                                "value)"
+                            )
+                            continue
+                        take_value = conflict.child
+                    changes.append(
+                        MergeFieldChange(
+                            field_path=conflict.field_path,
+                            op=take_op,
+                            value=take_value,
+                        )
+                    )
+                if missing:
+                    unresolved.append(
+                        BulkTemplateResult(
+                            template_id=template_id,
+                            name=row["name"],
+                            from_version=row["current_version"],
+                            error="unresolved conflicts: " + ", ".join(sorted(missing)),
+                        )
+                    )
+                    continue
+                if not changes:
+                    # Nothing to write (no changes, or every conflict resolved
+                    # "keep child") — still marked as synced below.
+                    planned.append((row, None, None))
+                    continue
+                try:
+                    new_flow, new_configurations = apply_merge_decisions(
+                        child_flow, child_configurations, changes
+                    )
+                except ValueError as exc:
+                    errors.append(
+                        BulkTemplateResult(
+                            template_id=template_id,
+                            name=row["name"],
+                            from_version=row["current_version"],
+                            error=str(exc),
+                        )
+                    )
+                    continue
+                err = validate_patched_template(
+                    new_flow, new_configurations, template_id, row["name"]
+                )
+                if err:
+                    errors.append(
+                        BulkTemplateResult(
+                            template_id=template_id,
+                            name=row["name"],
+                            from_version=row["current_version"],
+                            error=err,
+                        )
+                    )
+                    continue
+                planned.append((row, new_flow, new_configurations))
+
+            if unresolved:
+                return BulkUpdateResponse(status="unresolved", results=unresolved)
+            if errors:
+                return BulkUpdateResponse(status="failed", results=errors)
+            stale = sorted(
+                f"{tid}:{path}" for tid, path in set(resolution_index) - used
+            )
+            if stale:
+                # A resolution the merge never produced means the client is
+                # working from a stale preview; applying anyway would write a
+                # different merge than the human approved.
+                return BulkUpdateResponse(
+                    status="failed",
+                    results=[
+                        BulkTemplateResult(
+                            template_id="",
+                            name="",
+                            error=(
+                                "resolutions match no conflict (stale preview): "
+                                + ", ".join(stale)
+                            ),
+                        )
+                    ],
+                )
+
+            op_id = str(uuid4())
+            patch_json = json.dumps(
+                {
+                    "propagation": {
+                        "family_id": family_id,
+                        "from_base_version": previous_base_version,
+                        "to_base_version": to_base_version,
+                        "resolutions": [r.model_dump() for r in resolutions],
+                    }
+                }
+            )
+            op_q, op_v = insert_bulk_op_query(
+                op_id,
+                "propagation",
+                family_id,
+                # Every child the op COVERED, not just the ones whose content
+                # changed: the sync pointer below is advanced for all of them,
+                # so a rollback has to reset all of them too (content restore
+                # stays driven by the touched version rows, which only the
+                # written children have).
+                [str(row["id"]) for row, _, _ in planned],
+                patch_json,
+                "completed",
+                None,
+                changed_by,
+                previous_base_version,
+                to_base_version,
+            )
+            op_row = await conn.fetchrow(op_q, *op_v)
+
+            results: List[BulkTemplateResult] = []
+            now = datetime.now(timezone.utc)
+            for row, new_flow, new_configurations in planned:
+                template_id = str(row["id"])
+                to_version = row["current_version"]
+                if new_flow is not None:
+                    upd_q, upd_v = update_template_bulk_fields_query(
+                        template_id,
+                        json.dumps(new_flow),
+                        (
+                            json.dumps(new_configurations)
+                            if new_configurations is not None
+                            else None
+                        ),
+                        now,
+                    )
+                    head = await conn.fetchrow(upd_q, *upd_v)
+                    await insert_template_version_on_conn(
+                        conn,
+                        head,
+                        change_source="bulk_update",
+                        bulk_op_id=op_id,
+                        changed_by=changed_by,
+                    )
+                    to_version = head["current_version"]
+                sync_q, sync_v = set_template_derived_base_version_query(
+                    template_id, to_base_version
+                )
+                await conn.execute(sync_q, *sync_v)
+                results.append(
+                    BulkTemplateResult(
+                        template_id=template_id,
+                        name=row["name"],
+                        from_version=row["current_version"],
+                        to_version=to_version,
+                    )
+                )
+            return BulkUpdateResponse(
+                status="completed", bulk_op_id=str(op_row["id"]), results=results
+            )
+    return BulkUpdateResponse(status="failed", results=[])

--- a/app/database/decoder/breeze_buddy/template.py
+++ b/app/database/decoder/breeze_buddy/template.py
@@ -222,6 +222,8 @@ def decode_template(result: asyncpg.Record) -> Optional[TemplateModel]:
         ),
         is_active=result["is_active"],
         supported_channels=list(supported_channels),
+        family_id=(str(result["family_id"]) if result.get("family_id") else None),
+        current_version=result.get("current_version") or 1,
         created_at=result["created_at"],
         updated_at=result["updated_at"],
     )

--- a/app/database/decoder/breeze_buddy/template_version.py
+++ b/app/database/decoder/breeze_buddy/template_version.py
@@ -1,0 +1,16 @@
+"""Decoder for template_version rows."""
+
+from typing import Any
+
+from app.schemas.breeze_buddy.template_version import TemplateVersionMetadata
+
+
+def decode_template_version_meta(row: Any) -> TemplateVersionMetadata:
+    return TemplateVersionMetadata(
+        template_id=str(row["template_id"]),
+        version=row["version"],
+        change_source=row["change_source"],
+        bulk_op_id=(str(row["bulk_op_id"]) if row.get("bulk_op_id") else None),
+        changed_by=row.get("changed_by"),
+        created_at=row["created_at"],
+    )

--- a/app/database/migrations/046_add_template_versioning_and_family.sql
+++ b/app/database/migrations/046_add_template_versioning_and_family.sql
@@ -1,0 +1,205 @@
+-- Migration: Template lineage (versioning) + family grouping for bulk operations
+-- Description:
+--   1. template: add current_version (head pointer) and family_id (bulk-op grouping)
+--   2. template_bulk_op: one row per bulk update / bulk rollback (scope, patch, status)
+--   3. template_version: append-only full snapshot of every template state.
+--      History is never mutated; rollback appends a new version whose content
+--      equals an older snapshot.
+--   4. Backfill: current state of every existing template becomes version 1.
+
+ALTER TABLE template
+    ADD COLUMN IF NOT EXISTS current_version INTEGER NOT NULL DEFAULT 1;
+
+ALTER TABLE template
+    ADD COLUMN IF NOT EXISTS family_id UUID;
+
+CREATE INDEX IF NOT EXISTS idx_template_family_id
+    ON template(family_id)
+    WHERE family_id IS NOT NULL;
+
+-- Family is a first-class entity: named group that CONTAINS its base
+-- (parent) template inline — same content columns as `template`.
+-- Deliberately omitted from the copy: reseller_id/merchant_id (families are
+-- platform-wide / admin-managed, not reseller-scoped — individual member
+-- templates retain their own reseller_id),
+-- telephony_number_id/is_active (the parent is not in the template table,
+-- so it structurally cannot take calls or leads), and secrets (children
+-- hold their own; duplicating them here is risk with no benefit).
+CREATE TABLE IF NOT EXISTS template_family (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    name VARCHAR NOT NULL,
+    description TEXT,
+    -- embedded parent template content (mirrors template's content columns)
+    flow JSONB NOT NULL DEFAULT '{}',
+    expected_payload_schema JSONB,
+    expected_callback_response_schema JSONB,
+    configurations JSONB,
+    supported_channels TEXT[] NOT NULL DEFAULT ARRAY['voice']::text[],
+    -- bumped on every parent-content edit; children record what they derive from
+    base_version INTEGER NOT NULL DEFAULT 1,
+    created_by VARCHAR(255),
+    updated_by VARCHAR(255),
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+-- family_id becomes a real FK now that the table exists. SET NULL keeps
+-- member templates alive if a family is ever deleted.
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conname = 'fk_template_family_id'
+          AND conrelid = 'template'::regclass
+    ) THEN
+        ALTER TABLE template
+            ADD CONSTRAINT fk_template_family_id
+            FOREIGN KEY (family_id) REFERENCES template_family(id) ON DELETE SET NULL;
+    END IF;
+END $$;
+
+CREATE TABLE IF NOT EXISTS template_bulk_op (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    op_type VARCHAR(20) NOT NULL CHECK (op_type IN ('bulk_update', 'bulk_rollback')),
+    family_id UUID,
+    template_ids UUID[] NOT NULL,
+    -- {"flow_patch": ..., "node_patches": ..., "configurations_patch": ...}
+    patch JSONB,
+    status VARCHAR(20) NOT NULL DEFAULT 'completed'
+        CHECK (status IN ('completed', 'rolled_back')),
+    -- set on a bulk_rollback op: which bulk_update op it reverted
+    reverted_bulk_op_id UUID REFERENCES template_bulk_op(id),
+    initiated_by VARCHAR(255),
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_template_bulk_op_family_id
+    ON template_bulk_op(family_id);
+
+CREATE TABLE IF NOT EXISTS template_version (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    template_id UUID NOT NULL REFERENCES template(id) ON DELETE CASCADE,
+    version INTEGER NOT NULL,
+    -- Full snapshot of every editable template column at this version.
+    reseller_id VARCHAR(255),
+    merchant_id VARCHAR(255),
+    name VARCHAR NOT NULL,
+    flow JSONB NOT NULL,
+    expected_payload_schema JSONB,
+    expected_callback_response_schema JSONB,
+    configurations JSONB,
+    secrets JSONB,
+    -- deliberately NO FK: history must survive later number deletion
+    telephony_number_id UUID,
+    is_active BOOLEAN,
+    supported_channels TEXT[] NOT NULL,
+    change_source VARCHAR(20) NOT NULL CHECK (
+        change_source IN ('backfill', 'create', 'manual_edit',
+                          'bulk_update', 'rollback', 'bulk_rollback')
+    ),
+    bulk_op_id UUID REFERENCES template_bulk_op(id),
+    changed_by VARCHAR(255),
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    CONSTRAINT uq_template_version UNIQUE (template_id, version)
+);
+
+CREATE INDEX IF NOT EXISTS idx_template_version_template_id
+    ON template_version(template_id, version DESC);
+
+CREATE INDEX IF NOT EXISTS idx_template_version_bulk_op_id
+    ON template_version(bulk_op_id)
+    WHERE bulk_op_id IS NOT NULL;
+
+-- Backfill: snapshot the current state of every template as version 1.
+INSERT INTO template_version (
+    template_id, version, reseller_id, merchant_id, name, flow,
+    expected_payload_schema, expected_callback_response_schema,
+    configurations, secrets, telephony_number_id, is_active,
+    supported_channels, change_source
+)
+SELECT id, 1, reseller_id, merchant_id, name, flow,
+       expected_payload_schema, expected_callback_response_schema,
+       configurations, secrets, telephony_number_id, is_active,
+       supported_channels, 'backfill'
+FROM template
+ON CONFLICT (template_id, version) DO NOTHING;
+
+-- ---------------------------------------------------------------------------
+-- PHASE 2 (family propagation, docs/TEMPLATE_LINEAGE.md §6)
+-- Every statement below is idempotent: this file may already have been
+-- applied from this branch before Phase 2 was appended.
+-- ---------------------------------------------------------------------------
+
+-- Append-only snapshot of the family's parent-template content per
+-- base_version. The three-way merge needs the OLD parent content as its
+-- merge base; this also gives the parent a viewable history, same shape as
+-- template_version. Content is stored verbatim from template_family, which
+-- is mask-level by construction (no secrets column, configurations never
+-- written with reveal_secrets).
+CREATE TABLE IF NOT EXISTS template_family_version (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    family_id UUID NOT NULL REFERENCES template_family(id) ON DELETE CASCADE,
+    base_version INTEGER NOT NULL,
+    name VARCHAR NOT NULL,
+    description TEXT,
+    flow JSONB NOT NULL,
+    expected_payload_schema JSONB,
+    expected_callback_response_schema JSONB,
+    configurations JSONB,
+    supported_channels TEXT[] NOT NULL,
+    changed_by VARCHAR(255),
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    CONSTRAINT uq_template_family_version UNIQUE (family_id, base_version)
+);
+
+CREATE INDEX IF NOT EXISTS idx_template_family_version_family_id
+    ON template_family_version(family_id, base_version DESC);
+
+-- Which family revision each child was last synced to. NULL = never
+-- propagated to (the merge falls back to the previous family version; see
+-- Task 14's NULL-sync rule). Deliberately NOT backfilled: existing members
+-- have never been through a propagation, and claiming otherwise would make
+-- the first merge treat their own content as "already synced".
+ALTER TABLE template
+    ADD COLUMN IF NOT EXISTS derived_from_base_version INTEGER;
+
+-- Ledger: which family revision a propagation moved children FROM / TO.
+-- from_base_version is what `POST /templates/bulk/rollback` restores the
+-- family to when also_revert_family=true, and what children's
+-- derived_from_base_version is reset to on revert.
+ALTER TABLE template_bulk_op
+    ADD COLUMN IF NOT EXISTS from_base_version INTEGER;
+
+ALTER TABLE template_bulk_op
+    ADD COLUMN IF NOT EXISTS to_base_version INTEGER;
+
+-- op_type gains 'propagation'. A CHECK constraint cannot be altered in
+-- place, so drop-and-re-add inside a guarded block. Two names are dropped:
+-- the auto-generated one Postgres assigns to the inline CHECK in the
+-- CREATE TABLE above (fresh apply), and the explicit one added here
+-- (re-run of this file). Both DROPs are IF EXISTS, so the block is
+-- idempotent and safe on a database that has never seen 046.
+DO $$
+BEGIN
+    ALTER TABLE template_bulk_op
+        DROP CONSTRAINT IF EXISTS template_bulk_op_op_type_check;
+    ALTER TABLE template_bulk_op
+        DROP CONSTRAINT IF EXISTS chk_template_bulk_op_op_type;
+    ALTER TABLE template_bulk_op
+        ADD CONSTRAINT chk_template_bulk_op_op_type
+        CHECK (op_type IN ('bulk_update', 'bulk_rollback', 'propagation'));
+END $$;
+
+-- Backfill: every existing family's current content becomes the snapshot
+-- for its current base_version, so a child that derives from it has a
+-- merge base from day one.
+INSERT INTO template_family_version (
+    family_id, base_version, name, description, flow,
+    expected_payload_schema, expected_callback_response_schema,
+    configurations, supported_channels, changed_by
+)
+SELECT id, base_version, name, description, flow,
+       expected_payload_schema, expected_callback_response_schema,
+       configurations, supported_channels, COALESCE(updated_by, created_by)
+FROM template_family
+ON CONFLICT (family_id, base_version) DO NOTHING;

--- a/app/database/queries/breeze_buddy/template.py
+++ b/app/database/queries/breeze_buddy/template.py
@@ -36,7 +36,7 @@ def get_template_in_scope_query(
         SELECT id,
                reseller_id,
                merchant_id,
-               name, flow, expected_payload_schema, expected_callback_response_schema, configurations, secrets, telephony_number_id, is_active, supported_channels, created_at, updated_at
+               name, flow, expected_payload_schema, expected_callback_response_schema, configurations, secrets, telephony_number_id, is_active, supported_channels, family_id, current_version, created_at, updated_at
         FROM {TEMPLATE_TABLE}
         WHERE {" AND ".join(conditions)}
     """
@@ -74,7 +74,7 @@ def create_template_query(
     query = f"""
         INSERT INTO {TEMPLATE_TABLE} (id, reseller_id, merchant_id, name, flow, expected_payload_schema, expected_callback_response_schema, configurations, secrets, telephony_number_id, is_active, supported_channels, created_at, updated_at)
         VALUES ($1, $2, $3, $4, $5::jsonb, $6::jsonb, $7::jsonb, $8::jsonb, $9::jsonb, $10, $11, $12, $13, $14)
-        RETURNING id, reseller_id, merchant_id, name, flow, expected_payload_schema, expected_callback_response_schema, configurations, secrets, telephony_number_id, is_active, supported_channels, created_at, updated_at
+        RETURNING id, reseller_id, merchant_id, name, flow, expected_payload_schema, expected_callback_response_schema, configurations, secrets, telephony_number_id, is_active, supported_channels, family_id, current_version, created_at, updated_at
     """
 
     return query, [
@@ -113,7 +113,8 @@ def delete_template_if_not_referenced_query(template_id: str) -> tuple[str, list
         )
         DELETE FROM {TEMPLATE_TABLE}
         WHERE id IN (SELECT id FROM can_delete)
-        RETURNING id, reseller_id, merchant_id, name, is_active, created_at, updated_at
+        RETURNING id, reseller_id, merchant_id, name, is_active, family_id,
+                  current_version, created_at, updated_at
     """
     return query, [template_id]
 
@@ -150,6 +151,12 @@ def _build_template_list_conditions(
     if "is_active" in filters:
         values.append(filters["is_active"])
         conditions.append(f"is_active = ${len(values)}")
+
+    if filters.get("family_id_is_null"):
+        # Unassigned agents only — used by the family pickers so admins
+        # cannot accidentally add an agent that already belongs to another
+        # family.
+        conditions.append("family_id IS NULL")
 
     if filters.get("search"):
         values.append(f"%{filters['search']}%")
@@ -190,7 +197,7 @@ def get_templates_list_query(filters: Dict[str, Any]) -> Tuple[str, List[Any]]:
         SELECT id,
                reseller_id,
                merchant_id,
-               name, is_active, supported_channels, created_at, updated_at
+               name, is_active, supported_channels, family_id, current_version, created_at, updated_at
         FROM {TEMPLATE_TABLE}
         {where_clause}
         ORDER BY {order_by}
@@ -229,7 +236,7 @@ def get_template_by_id_query(template_id: str) -> Tuple[str, List[Any]]:
         SELECT id,
                reseller_id,
                merchant_id,
-               name, flow, expected_payload_schema, expected_callback_response_schema, configurations, secrets, telephony_number_id, is_active, supported_channels, created_at, updated_at
+               name, flow, expected_payload_schema, expected_callback_response_schema, configurations, secrets, telephony_number_id, is_active, supported_channels, family_id, current_version, created_at, updated_at
         FROM {TEMPLATE_TABLE}
         WHERE id = $1
         LIMIT 1
@@ -275,7 +282,7 @@ def get_template_by_telephony_number_id_query(
         SELECT id,
                reseller_id,
                merchant_id,
-               name, flow, expected_payload_schema, expected_callback_response_schema, configurations, secrets, telephony_number_id, is_active, supported_channels, created_at, updated_at
+               name, flow, expected_payload_schema, expected_callback_response_schema, configurations, secrets, telephony_number_id, is_active, supported_channels, family_id, current_version, created_at, updated_at
         FROM {TEMPLATE_TABLE}
         WHERE {' AND '.join(conditions)}
         LIMIT 1
@@ -304,7 +311,7 @@ def get_all_templates_by_telephony_number_id_query(
         SELECT id,
                reseller_id,
                merchant_id,
-               name, flow, expected_payload_schema, expected_callback_response_schema, configurations, telephony_number_id, is_active, supported_channels, created_at, updated_at
+               name, flow, expected_payload_schema, expected_callback_response_schema, configurations, telephony_number_id, is_active, supported_channels, family_id, current_version, created_at, updated_at
         FROM {TEMPLATE_TABLE}
         WHERE telephony_number_id = $1
         AND is_active = TRUE
@@ -396,12 +403,13 @@ def replace_template_query(
             reseller_id = $9,
             merchant_id = $10,
             supported_channels = $11,
+            current_version = current_version + 1,
             updated_at = $12
         WHERE id = $13
         RETURNING id,
                   reseller_id,
                   merchant_id,
-                  name, flow, expected_payload_schema, expected_callback_response_schema, configurations, secrets, telephony_number_id, is_active, supported_channels, created_at, updated_at
+                  name, flow, expected_payload_schema, expected_callback_response_schema, configurations, secrets, telephony_number_id, is_active, supported_channels, family_id, current_version, created_at, updated_at
     """
 
     return query, [
@@ -417,5 +425,220 @@ def replace_template_query(
         merchant_id,
         supported_channels,
         updated_at,
+        template_id,
+    ]
+
+
+def get_templates_for_update_query(template_ids: List[str]) -> Tuple[str, List[Any]]:
+    """Lock + load full head rows for a bulk operation (row locks prevent a
+    concurrent PUT from interleaving between read and write)."""
+    query = f"""
+        SELECT id, reseller_id, merchant_id, name, flow,
+               expected_payload_schema, expected_callback_response_schema,
+               configurations, secrets, telephony_number_id, is_active,
+               supported_channels, family_id, current_version,
+               created_at, updated_at
+        FROM {TEMPLATE_TABLE}
+        WHERE id = ANY($1::uuid[])
+        ORDER BY id
+        FOR UPDATE
+    """
+    return query, [template_ids]
+
+
+def update_template_bulk_fields_query(
+    template_id: str, flow_json: str, configurations_json: Optional[str], now
+) -> Tuple[str, List[Any]]:
+    """Bulk update touches only flow + configurations (patched values);
+    identity, secrets, pins, channels are never bulk-edited."""
+    query = f"""
+        UPDATE {TEMPLATE_TABLE}
+        SET flow = $1::jsonb,
+            configurations = $2::jsonb,
+            current_version = current_version + 1,
+            updated_at = $3
+        WHERE id = $4
+        RETURNING id, reseller_id, merchant_id, name, flow,
+                  expected_payload_schema, expected_callback_response_schema,
+                  configurations, secrets, telephony_number_id, is_active,
+                  supported_channels, family_id, current_version,
+                  created_at, updated_at
+    """
+    return query, [flow_json, configurations_json, now, template_id]
+
+
+_FAMILY_MEMBER_COLUMNS = (
+    "id, reseller_id, merchant_id, name, flow, "
+    "expected_payload_schema, expected_callback_response_schema, "
+    "configurations, secrets, telephony_number_id, is_active, "
+    "supported_channels, family_id, current_version, "
+    "derived_from_base_version, created_at, updated_at"
+)
+
+
+def get_family_templates_for_update_query(family_id: str) -> Tuple[str, List[Any]]:
+    query = f"""
+        SELECT {_FAMILY_MEMBER_COLUMNS}
+        FROM {TEMPLATE_TABLE}
+        WHERE family_id = $1
+        ORDER BY id
+        FOR UPDATE
+    """
+    return query, [family_id]
+
+
+def get_family_member_contents_query(
+    family_id: str,
+    limit: Optional[int] = None,
+    offset: int = 0,
+) -> Tuple[str, List[Any]]:
+    """Read-only twin of ``get_family_templates_for_update_query`` — same
+    columns, no ``FOR UPDATE``. Propagation preview must not take row locks:
+    it writes nothing and must never block a concurrent PUT.
+
+    ``limit`` / ``offset`` enable paginated preview: pass them together to
+    fetch one page of members; omit both to fetch all (legacy / apply path).
+    """
+    values: List[Any] = [family_id]
+    query = f"""
+        SELECT {_FAMILY_MEMBER_COLUMNS}
+        FROM {TEMPLATE_TABLE}
+        WHERE family_id = $1
+        ORDER BY id
+    """
+    if limit is not None:
+        values.append(limit)
+        query += f"\n        LIMIT ${len(values)}"
+        values.append(offset)
+        query += f"\n        OFFSET ${len(values)}"
+    return query, values
+
+
+def count_family_member_contents_query(family_id: str) -> Tuple[str, List[Any]]:
+    """Total number of template members in a family — for pagination metadata."""
+    query = f"""
+        SELECT COUNT(*) AS total
+        FROM {TEMPLATE_TABLE}
+        WHERE family_id = $1
+    """
+    return query, [family_id]
+
+
+def set_template_derived_base_version_query(
+    template_id: str, base_version: Optional[int]
+) -> Tuple[str, List[Any]]:
+    """Record which family revision a child is now synced to.
+
+    Lineage metadata, not content: deliberately does NOT bump
+    current_version and is not part of the version snapshot — the template's
+    content is unchanged by this statement.
+    """
+    query = f"""
+        UPDATE {TEMPLATE_TABLE}
+        SET derived_from_base_version = $1
+        WHERE id = $2
+    """
+    return query, [base_version, template_id]
+
+
+def set_templates_derived_base_version_query(
+    template_ids: List[str], base_version: Optional[int]
+) -> Tuple[str, List[Any]]:
+    """Bulk form, used when a propagation is reverted."""
+    query = f"""
+        UPDATE {TEMPLATE_TABLE}
+        SET derived_from_base_version = $1
+        WHERE id = ANY($2::uuid[])
+    """
+    return query, [base_version, template_ids]
+
+
+def assign_family_query(
+    family_id: str, template_ids: List[str], now
+) -> Tuple[str, List[Any]]:
+    """Adopt templates into a family.
+
+    Families are global admin-managed groups: any existing template can be
+    assigned regardless of reseller, provided it is not already a member of
+    a *different* family.  Templates already in *this* family are a no-op.
+    Templates belonging to another family are excluded by the WHERE clause
+    and therefore absent from RETURNING id, which causes _assert_all_assigned
+    to raise a 409 with a clear message.
+    """
+    query = f"""
+        UPDATE {TEMPLATE_TABLE}
+        SET family_id = $1,
+            updated_at = $2
+        WHERE id = ANY($3::uuid[])
+          AND (family_id IS NULL OR family_id = $1::uuid)
+        RETURNING id
+    """
+    return query, [family_id, now, template_ids]
+
+
+def get_template_head_versions_query(template_ids: List[str]) -> Tuple[str, List[Any]]:
+    """Lock + read just the head version numbers for a bulk rollback's drift
+    check (row locks prevent a concurrent edit racing the rollback)."""
+    query = f"""
+        SELECT id, current_version
+        FROM {TEMPLATE_TABLE}
+        WHERE id = ANY($1::uuid[])
+        FOR UPDATE
+    """
+    return query, [template_ids]
+
+
+def restore_template_head_query(
+    template_id: str,
+    reseller_id: str,
+    merchant_id: Optional[str],
+    name: str,
+    flow_json: str,
+    expected_payload_schema_json: Optional[str],
+    expected_callback_response_schema_json: Optional[str],
+    configurations_json: Optional[str],
+    secrets_json: Optional[str],
+    telephony_number_id: Optional[str],
+    is_active: bool,
+    supported_channels: List[str],
+    now,
+) -> Tuple[str, List[Any]]:
+    """Rollback write: restore all editable columns from a snapshot and bump
+    current_version (rollback is itself a new version, never history surgery)."""
+    query = f"""
+        UPDATE {TEMPLATE_TABLE}
+        SET reseller_id = $1,
+            merchant_id = $2,
+            name = $3,
+            flow = $4::jsonb,
+            expected_payload_schema = $5::jsonb,
+            expected_callback_response_schema = $6::jsonb,
+            configurations = $7::jsonb,
+            secrets = $8::jsonb,
+            telephony_number_id = $9,
+            is_active = $10,
+            supported_channels = $11,
+            current_version = current_version + 1,
+            updated_at = $12
+        WHERE id = $13
+        RETURNING id, reseller_id, merchant_id, name, flow,
+                  expected_payload_schema, expected_callback_response_schema,
+                  configurations, secrets, telephony_number_id, is_active,
+                  supported_channels, family_id, current_version,
+                  created_at, updated_at
+    """
+    return query, [
+        reseller_id,
+        merchant_id,
+        name,
+        flow_json,
+        expected_payload_schema_json,
+        expected_callback_response_schema_json,
+        configurations_json,
+        secrets_json,
+        telephony_number_id,
+        is_active,
+        supported_channels,
+        now,
         template_id,
     ]

--- a/app/database/queries/breeze_buddy/template_version.py
+++ b/app/database/queries/breeze_buddy/template_version.py
@@ -1,0 +1,512 @@
+"""SQL queries for template versioning (lineage) and bulk operations."""
+
+from typing import Any, List, Optional, Tuple
+
+TEMPLATE_VERSION_TABLE = "template_version"
+TEMPLATE_BULK_OP_TABLE = "template_bulk_op"
+
+
+def insert_template_version_query(
+    template_id: str,
+    version: int,
+    reseller_id: str,
+    merchant_id: Optional[str],
+    name: str,
+    flow_json: str,
+    expected_payload_schema_json: Optional[str],
+    expected_callback_response_schema_json: Optional[str],
+    configurations_json: Optional[str],
+    secrets_json: Optional[str],
+    telephony_number_id: Optional[str],
+    is_active: bool,
+    supported_channels: List[str],
+    change_source: str,
+    bulk_op_id: Optional[str],
+    changed_by: Optional[str],
+) -> Tuple[str, List[Any]]:
+    query = f"""
+        INSERT INTO {TEMPLATE_VERSION_TABLE} (
+            template_id, version, reseller_id, merchant_id, name, flow,
+            expected_payload_schema, expected_callback_response_schema,
+            configurations, secrets, telephony_number_id, is_active,
+            supported_channels, change_source, bulk_op_id, changed_by
+        )
+        VALUES ($1, $2, $3, $4, $5, $6::jsonb, $7::jsonb, $8::jsonb,
+                $9::jsonb, $10::jsonb, $11, $12, $13, $14, $15, $16)
+        RETURNING id, template_id, version, change_source, bulk_op_id,
+                  changed_by, created_at
+    """
+    return query, [
+        template_id,
+        version,
+        reseller_id,
+        merchant_id,
+        name,
+        flow_json,
+        expected_payload_schema_json,
+        expected_callback_response_schema_json,
+        configurations_json,
+        secrets_json,
+        telephony_number_id,
+        is_active,
+        supported_channels,
+        change_source,
+        bulk_op_id,
+        changed_by,
+    ]
+
+
+def get_template_versions_query(
+    template_id: str, limit: int, offset: int
+) -> Tuple[str, List[Any]]:
+    query = f"""
+        SELECT template_id, version, change_source, bulk_op_id,
+               changed_by, created_at
+        FROM {TEMPLATE_VERSION_TABLE}
+        WHERE template_id = $1
+        ORDER BY version DESC
+        LIMIT $2 OFFSET $3
+    """
+    return query, [template_id, limit, offset]
+
+
+def get_template_versions_count_query(template_id: str) -> Tuple[str, List[Any]]:
+    return (
+        f"SELECT COUNT(*) AS total FROM {TEMPLATE_VERSION_TABLE} WHERE template_id = $1",
+        [template_id],
+    )
+
+
+def get_template_version_snapshot_query(
+    template_id: str, version: int
+) -> Tuple[str, List[Any]]:
+    # template_id AS id + created_at AS updated_at let decode_template
+    # (decoder/breeze_buddy/template.py) decode a snapshot row unchanged.
+    query = f"""
+        SELECT template_id AS id,
+               version, version AS current_version,
+               reseller_id, merchant_id, name, flow,
+               expected_payload_schema, expected_callback_response_schema,
+               configurations, secrets, telephony_number_id, is_active,
+               supported_channels, change_source, bulk_op_id, changed_by,
+               created_at, created_at AS updated_at
+        FROM {TEMPLATE_VERSION_TABLE}
+        WHERE template_id = $1 AND version = $2
+        LIMIT 1
+    """
+    return query, [template_id, version]
+
+
+def insert_bulk_op_query(
+    op_id: str,
+    op_type: str,
+    family_id: Optional[str],
+    template_ids: List[str],
+    patch_json: Optional[str],
+    status: str,
+    reverted_bulk_op_id: Optional[str],
+    initiated_by: Optional[str],
+    from_base_version: Optional[int] = None,
+    to_base_version: Optional[int] = None,
+) -> Tuple[str, List[Any]]:
+    """``from_base_version``/``to_base_version`` are set only by propagation
+    ops (which family revision the children moved from / to); the two
+    Phase-1 call sites leave them NULL."""
+    query = f"""
+        INSERT INTO {TEMPLATE_BULK_OP_TABLE} (
+            id, op_type, family_id, template_ids, patch, status,
+            reverted_bulk_op_id, initiated_by, from_base_version,
+            to_base_version
+        )
+        VALUES ($1, $2, $3, $4::uuid[], $5::jsonb, $6, $7, $8, $9, $10)
+        RETURNING id, op_type, family_id, template_ids, status,
+                  reverted_bulk_op_id, initiated_by, from_base_version,
+                  to_base_version, created_at
+    """
+    return query, [
+        op_id,
+        op_type,
+        family_id,
+        template_ids,
+        patch_json,
+        status,
+        reverted_bulk_op_id,
+        initiated_by,
+        from_base_version,
+        to_base_version,
+    ]
+
+
+def get_bulk_op_by_id_query(bulk_op_id: str) -> Tuple[str, List[Any]]:
+    query = f"""
+        SELECT id, op_type, family_id, template_ids, patch, status,
+               reverted_bulk_op_id, initiated_by, from_base_version,
+               to_base_version, created_at
+        FROM {TEMPLATE_BULK_OP_TABLE}
+        WHERE id = $1
+        LIMIT 1
+    """
+    return query, [bulk_op_id]
+
+
+def list_bulk_ops_query(limit: int, offset: int) -> Tuple[str, List[Any]]:
+    query = f"""
+        SELECT id, op_type, family_id, template_ids, patch, status,
+               reverted_bulk_op_id, initiated_by, from_base_version,
+               to_base_version, created_at
+        FROM {TEMPLATE_BULK_OP_TABLE}
+        ORDER BY created_at DESC
+        LIMIT $1 OFFSET $2
+    """
+    return query, [limit, offset]
+
+
+def mark_bulk_op_rolled_back_query(bulk_op_id: str) -> Tuple[str, List[Any]]:
+    query = f"""
+        UPDATE {TEMPLATE_BULK_OP_TABLE}
+        SET status = 'rolled_back'
+        WHERE id = $1
+        RETURNING id, status
+    """
+    return query, [bulk_op_id]
+
+
+def get_bulk_op_touched_versions_query(bulk_op_id: str) -> Tuple[str, List[Any]]:
+    query = f"""
+        SELECT template_id, version
+        FROM {TEMPLATE_VERSION_TABLE}
+        WHERE bulk_op_id = $1
+        ORDER BY template_id
+    """
+    return query, [bulk_op_id]
+
+
+def prune_template_versions_query(
+    template_id: str, current_version: int, keep: int
+) -> Tuple[str, List[Any]]:
+    """Retention: keep only the newest ``keep`` versions of a template.
+
+    Rollback-safety guard: never deletes rows an active (completed, not yet
+    rolled back) bulk op still needs — each member's bulk-written version
+    AND its immediate predecessor (the pre-op snapshot bulk rollback
+    restores), and nothing else. Runs in the same transaction as the
+    snapshot insert.
+    """
+    query = f"""
+        DELETE FROM {TEMPLATE_VERSION_TABLE} tv
+        WHERE tv.template_id = $1
+          AND tv.version <= $2::integer - $3::integer
+          AND NOT EXISTS (
+                SELECT 1
+                FROM {TEMPLATE_VERSION_TABLE} bv
+                JOIN {TEMPLATE_BULK_OP_TABLE} op ON op.id = bv.bulk_op_id
+                WHERE bv.template_id = tv.template_id
+                  AND op.status = 'completed'
+                  AND tv.version >= bv.version - 1
+                  AND tv.version <= bv.version
+          )
+    """
+    return query, [template_id, current_version, keep]
+
+
+def count_missing_preop_snapshots_bulk_query(
+    bulk_op_ids: List[str],
+) -> Tuple[str, List[Any]]:
+    """How many templates touched by each op can no longer be rolled back
+    (their pre-op snapshot was pruned by retention), for many ops in one round
+    trip — ``list_bulk_ops`` would otherwise run one count per completed op in
+    the page. Ops with zero missing snapshots are simply absent from the result
+    set; the caller defaults them to 0.
+    """
+    query = f"""
+        SELECT bv.bulk_op_id AS bulk_op_id, COUNT(*) AS missing
+        FROM {TEMPLATE_VERSION_TABLE} bv
+        WHERE bv.bulk_op_id = ANY($1::uuid[])
+          AND NOT EXISTS (
+                SELECT 1 FROM {TEMPLATE_VERSION_TABLE} pv
+                WHERE pv.template_id = bv.template_id
+                  AND pv.version = bv.version - 1
+          )
+        GROUP BY bv.bulk_op_id
+    """
+    return query, [bulk_op_ids]
+
+
+def get_missing_preop_snapshots_query(bulk_op_id: str) -> Tuple[str, List[Any]]:
+    """Template ids touched by this op whose pre-op snapshot (version - 1)
+    was pruned by retention and so can't be restored. Used as an
+    all-or-nothing pre-check inside ``bulk_rollback_templates`` — run BEFORE
+    any restore write so a partially-prunable op aborts cleanly with zero
+    writes instead of reverting some members and reporting others as errors.
+    """
+    query = f"""
+        SELECT bv.template_id
+        FROM {TEMPLATE_VERSION_TABLE} bv
+        WHERE bv.bulk_op_id = $1
+          AND NOT EXISTS (
+                SELECT 1 FROM {TEMPLATE_VERSION_TABLE} pv
+                WHERE pv.template_id = bv.template_id
+                  AND pv.version = bv.version - 1
+          )
+    """
+    return query, [bulk_op_id]
+
+
+TEMPLATE_FAMILY_TABLE = "template_family"
+
+
+_FAMILY_COLUMNS = (
+    "id, name, description, flow, expected_payload_schema, "
+    "expected_callback_response_schema, configurations, supported_channels, "
+    "base_version, created_by, updated_by, created_at, updated_at"
+)
+
+
+def insert_template_family_query(
+    family_id: str,
+    name: str,
+    description: Optional[str],
+    flow_json: str,
+    expected_payload_schema_json: Optional[str],
+    expected_callback_response_schema_json: Optional[str],
+    configurations_json: Optional[str],
+    supported_channels: List[str],
+    created_by: Optional[str],
+) -> Tuple[str, List[Any]]:
+    query = f"""
+        INSERT INTO {TEMPLATE_FAMILY_TABLE}
+            (id, name, description, flow,
+             expected_payload_schema, expected_callback_response_schema,
+             configurations, supported_channels, created_by)
+        VALUES ($1, $2, $3, $4::jsonb, $5::jsonb, $6::jsonb, $7::jsonb, $8, $9)
+        RETURNING {_FAMILY_COLUMNS}
+    """
+    return query, [
+        family_id,
+        name,
+        description,
+        flow_json,
+        expected_payload_schema_json,
+        expected_callback_response_schema_json,
+        configurations_json,
+        supported_channels,
+        created_by,
+    ]
+
+
+def update_template_family_query(
+    family_id: str,
+    name: str,
+    description: Optional[str],
+    flow_json: str,
+    expected_payload_schema_json: Optional[str],
+    expected_callback_response_schema_json: Optional[str],
+    configurations_json: Optional[str],
+    supported_channels: List[str],
+    updated_by: Optional[str],
+    now,
+) -> Tuple[str, List[Any]]:
+    """Edit the family's parent template content; bumps base_version."""
+    query = f"""
+        UPDATE {TEMPLATE_FAMILY_TABLE}
+        SET name = $1,
+            description = $2,
+            flow = $3::jsonb,
+            expected_payload_schema = $4::jsonb,
+            expected_callback_response_schema = $5::jsonb,
+            configurations = $6::jsonb,
+            supported_channels = $7,
+            base_version = base_version + 1,
+            updated_by = $8,
+            updated_at = $9
+        WHERE id = $10
+        RETURNING {_FAMILY_COLUMNS}
+    """
+    return query, [
+        name,
+        description,
+        flow_json,
+        expected_payload_schema_json,
+        expected_callback_response_schema_json,
+        configurations_json,
+        supported_channels,
+        updated_by,
+        now,
+        family_id,
+    ]
+
+
+def get_template_family_query(family_id: str) -> Tuple[str, List[Any]]:
+    query = f"""
+        SELECT {_FAMILY_COLUMNS}
+        FROM {TEMPLATE_FAMILY_TABLE}
+        WHERE id = $1
+        LIMIT 1
+    """
+    return query, [family_id]
+
+
+def list_template_families_query() -> Tuple[str, List[Any]]:
+    """List all families (global, admin-managed — no reseller scoping)."""
+    query = f"""
+        SELECT {_FAMILY_COLUMNS}
+        FROM {TEMPLATE_FAMILY_TABLE}
+        ORDER BY name
+    """
+    return query, []
+
+
+def get_family_members_query(family_id: str) -> Tuple[str, List[Any]]:
+    query = """
+        SELECT id, name, reseller_id, merchant_id, current_version, derived_from_base_version
+        FROM template
+        WHERE family_id = $1
+        ORDER BY name
+    """
+    return query, [family_id]
+
+
+def count_family_members_query(family_ids: List[str]) -> Tuple[str, List[Any]]:
+    """Member counts for a page of families in one round trip — the list
+    endpoint only renders the count, so loading every member row per family
+    was both an N+1 and a payload the caller throws away. Families with no
+    members are absent from the result; the caller defaults them to 0."""
+    query = """
+        SELECT family_id, COUNT(*) AS member_count
+        FROM template
+        WHERE family_id = ANY($1::uuid[])
+        GROUP BY family_id
+    """
+    return query, [family_ids]
+
+
+def remove_family_members_query(
+    family_id: str, template_ids: List[str], now
+) -> Tuple[str, List[Any]]:
+    query = """
+        UPDATE template
+        SET family_id = NULL,
+            derived_from_base_version = NULL,
+            updated_at = $2
+        WHERE family_id = $1 AND id = ANY($3::uuid[])
+        RETURNING id
+    """
+    return query, [family_id, now, template_ids]
+
+
+TEMPLATE_FAMILY_VERSION_TABLE = "template_family_version"
+
+
+_FAMILY_VERSION_COLUMNS = (
+    "family_id, base_version, name, description, flow, "
+    "expected_payload_schema, expected_callback_response_schema, "
+    "configurations, supported_channels, changed_by, created_at"
+)
+
+
+def insert_template_family_version_query(
+    family_id: str,
+    base_version: int,
+    name: str,
+    description: Optional[str],
+    flow_json: str,
+    expected_payload_schema_json: Optional[str],
+    expected_callback_response_schema_json: Optional[str],
+    configurations_json: Optional[str],
+    supported_channels: List[str],
+    changed_by: Optional[str],
+) -> Tuple[str, List[Any]]:
+    """Append-only snapshot of the family's parent content AT base_version."""
+    query = f"""
+        INSERT INTO {TEMPLATE_FAMILY_VERSION_TABLE} (
+            family_id, base_version, name, description, flow,
+            expected_payload_schema, expected_callback_response_schema,
+            configurations, supported_channels, changed_by
+        )
+        VALUES ($1, $2, $3, $4, $5::jsonb, $6::jsonb, $7::jsonb, $8::jsonb, $9, $10)
+        RETURNING id, family_id, base_version, changed_by, created_at
+    """
+    return query, [
+        family_id,
+        base_version,
+        name,
+        description,
+        flow_json,
+        expected_payload_schema_json,
+        expected_callback_response_schema_json,
+        configurations_json,
+        supported_channels,
+        changed_by,
+    ]
+
+
+def get_family_versions_query(
+    family_id: str, limit: int, offset: int
+) -> Tuple[str, List[Any]]:
+    query = f"""
+        SELECT family_id, base_version, name, changed_by, created_at
+        FROM {TEMPLATE_FAMILY_VERSION_TABLE}
+        WHERE family_id = $1
+        ORDER BY base_version DESC
+        LIMIT $2 OFFSET $3
+    """
+    return query, [family_id, limit, offset]
+
+
+def get_family_versions_count_query(family_id: str) -> Tuple[str, List[Any]]:
+    return (
+        f"SELECT COUNT(*) AS total FROM {TEMPLATE_FAMILY_VERSION_TABLE} "
+        "WHERE family_id = $1",
+        [family_id],
+    )
+
+
+def get_family_version_snapshot_query(
+    family_id: str, base_version: int
+) -> Tuple[str, List[Any]]:
+    query = f"""
+        SELECT {_FAMILY_VERSION_COLUMNS}
+        FROM {TEMPLATE_FAMILY_VERSION_TABLE}
+        WHERE family_id = $1 AND base_version = $2
+        LIMIT 1
+    """
+    return query, [family_id, base_version]
+
+
+def prune_family_versions_query(
+    family_id: str, base_version: int, keep: int
+) -> Tuple[str, List[Any]]:
+    """Retention: keep only the newest ``keep`` family versions.
+
+    Guard: never deletes a version an active (completed, not yet rolled
+    back) propagation op still needs — the version it moved children FROM
+    (what ``also_revert_family`` restores, and what children's
+    ``derived_from_base_version`` is reset to) and the version it moved
+    them TO. Runs in the same transaction as the snapshot insert.
+    """
+    query = f"""
+        DELETE FROM {TEMPLATE_FAMILY_VERSION_TABLE} fv
+        WHERE fv.family_id = $1
+          AND fv.base_version <= $2::integer - $3::integer
+          AND NOT EXISTS (
+                SELECT 1
+                FROM {TEMPLATE_BULK_OP_TABLE} op
+                WHERE op.family_id = fv.family_id
+                  AND op.op_type = 'propagation'
+                  AND op.status = 'completed'
+                  AND fv.base_version IN (op.from_base_version, op.to_base_version)
+          )
+    """
+    return query, [family_id, base_version, keep]
+
+
+def get_template_family_for_update_query(family_id: str) -> Tuple[str, List[Any]]:
+    """Lock the family row for a propagation apply, so a concurrent
+    ``PUT /templates/families/{id}`` cannot bump base_version mid-merge."""
+    query = f"""
+        SELECT {_FAMILY_COLUMNS}
+        FROM {TEMPLATE_FAMILY_TABLE}
+        WHERE id = $1
+        FOR UPDATE
+    """
+    return query, [family_id]

--- a/app/schemas/breeze_buddy/template.py
+++ b/app/schemas/breeze_buddy/template.py
@@ -18,6 +18,8 @@ class TemplateMetadata(BaseModel):
     merchant_id: Optional[str] = None
     name: str
     is_active: bool
+    family_id: Optional[str] = None
+    current_version: int = 1
     supported_channels: List[str] = ["voice"]
     created_at: datetime
     updated_at: datetime

--- a/app/schemas/breeze_buddy/template_version.py
+++ b/app/schemas/breeze_buddy/template_version.py
@@ -1,0 +1,342 @@
+"""Schemas for template versioning (lineage) endpoints."""
+
+from datetime import datetime
+from typing import Any, Dict, List, Literal, Optional
+
+from pydantic import BaseModel, Field, model_validator
+
+from app.ai.voice.agents.breeze_buddy.template.types import TemplateModel
+
+
+class TemplateVersionMetadata(BaseModel):
+    template_id: str
+    version: int
+    change_source: str
+    bulk_op_id: Optional[str] = None
+    changed_by: Optional[str] = None
+    created_at: datetime
+
+
+class TemplateVersionListResponse(BaseModel):
+    template_id: str
+    current_version: int
+    versions: List[TemplateVersionMetadata]
+    total: int
+
+
+class TemplateVersionDetailResponse(BaseModel):
+    meta: TemplateVersionMetadata
+    snapshot: TemplateModel
+
+
+class RollbackTemplateRequest(BaseModel):
+    version: int = Field(ge=1)
+
+
+class CreateFamilyRequest(BaseModel):
+    name: str
+    description: Optional[str] = None
+    # Parent template content, inline (mirrors template's content columns)...
+    flow: Optional[Dict[str, Any]] = None
+    expected_payload_schema: Optional[Dict[str, Any]] = None
+    expected_callback_response_schema: Optional[Dict[str, Any]] = None
+    configurations: Optional[Dict[str, Any]] = None
+    supported_channels: Optional[List[str]] = None
+    # ...or copied from an existing template (content columns only —
+    # secrets / routing columns are never copied into a family).
+    copy_base_from_template_id: Optional[str] = None
+    member_template_ids: List[str] = Field(default_factory=list)
+
+    @model_validator(mode="after")
+    def _require_base_content(self) -> "CreateFamilyRequest":
+        if not self.flow and not self.copy_base_from_template_id:
+            raise ValueError(
+                "provide flow (parent template content) or copy_base_from_template_id"
+            )
+        return self
+
+
+class UpdateFamilyRequest(BaseModel):
+    """PUT body: edit the family's parent template content (bumps base_version).
+    Omitted fields keep their persisted values."""
+
+    name: Optional[str] = None
+    description: Optional[str] = None
+    flow: Optional[Dict[str, Any]] = None
+    expected_payload_schema: Optional[Dict[str, Any]] = None
+    expected_callback_response_schema: Optional[Dict[str, Any]] = None
+    configurations: Optional[Dict[str, Any]] = None
+    supported_channels: Optional[List[str]] = None
+
+
+class FamilyMember(BaseModel):
+    template_id: str
+    name: str
+    reseller_id: str
+    merchant_id: Optional[str] = None
+    current_version: int
+    # NULL until the child has been through a propagation; the family
+    # screen renders it as "never synced".
+    derived_from_base_version: Optional[int] = None
+
+
+class FamilyResponse(BaseModel):
+    id: str
+    name: str
+    description: Optional[str] = None
+    # the embedded parent template
+    flow: Dict[str, Any] = Field(default_factory=dict)
+    expected_payload_schema: Optional[Dict[str, Any]] = None
+    expected_callback_response_schema: Optional[Dict[str, Any]] = None
+    configurations: Optional[Dict[str, Any]] = None
+    supported_channels: List[str] = Field(default_factory=lambda: ["voice"])
+    base_version: int = 1
+    # The listing endpoint fills member_count and leaves members empty (one
+    # aggregate query instead of one member query per family); the detail
+    # endpoint returns both.
+    members: List[FamilyMember] = Field(default_factory=list)
+    member_count: int = 0
+    created_by: Optional[str] = None
+    updated_by: Optional[str] = None
+    created_at: datetime
+    updated_at: Optional[datetime] = None
+
+
+class FamilyListResponse(BaseModel):
+    families: List[FamilyResponse]
+
+
+class UpdateFamilyMembersRequest(BaseModel):
+    add_template_ids: List[str] = Field(default_factory=list)
+    remove_template_ids: List[str] = Field(default_factory=list)
+
+
+class BulkUpdateRequest(BaseModel):
+    family_id: Optional[str] = None
+    template_ids: Optional[List[str]] = Field(default=None, min_length=1)
+    flow_patch: Optional[Dict[str, Any]] = None
+    node_patches: Optional[Dict[str, Dict[str, Any]]] = None
+    configurations_patch: Optional[Dict[str, Any]] = None
+    dry_run: bool = False
+
+    @model_validator(mode="after")
+    def _validate_scope_and_patch(self) -> "BulkUpdateRequest":
+        if bool(self.family_id) == bool(self.template_ids):
+            raise ValueError("provide exactly one of family_id or template_ids")
+        if not (self.flow_patch or self.node_patches or self.configurations_patch):
+            raise ValueError(
+                "at least one of flow_patch, node_patches, configurations_patch is required"
+            )
+        # A merge patch replaces arrays wholesale — 'nodes' in flow_patch would
+        # silently overwrite every member's full node list. Node edits are only
+        # allowed through node_patches (addressed by node_name).
+        if self.flow_patch and "nodes" in self.flow_patch:
+            raise ValueError(
+                "flow_patch must not contain 'nodes'; use node_patches to edit nodes"
+            )
+        return self
+
+
+class BulkTemplateResult(BaseModel):
+    template_id: str
+    name: str
+    from_version: Optional[int] = None
+    to_version: Optional[int] = None
+    error: Optional[str] = None
+    # dry_run only: this member's patched content, so callers can preview the
+    # effect of the patch without applying it. None on real (non-dry_run)
+    # results — the patch is already persisted, so a preview is redundant.
+    preview_flow: Optional[Dict[str, Any]] = None
+    preview_configurations: Optional[Dict[str, Any]] = None
+
+
+class BulkUpdateResponse(BaseModel):
+    status: str  # "completed" | "dry_run" | "failed"
+    bulk_op_id: Optional[str] = None
+    results: List[BulkTemplateResult]
+
+
+class BulkRollbackRequest(BaseModel):
+    bulk_op_id: str
+    force: bool = False  # override the drifted-template guard
+    # propagation ops only: also restore the family's parent template to the
+    # revision the propagation started from (as a NEW family base_version,
+    # same transaction as the children's revert).
+    also_revert_family: bool = False
+
+
+class BulkRollbackResponse(BaseModel):
+    status: str
+    bulk_op_id: str  # the new bulk_rollback op
+    reverted_bulk_op_id: str
+    results: List[BulkTemplateResult]
+    # set when also_revert_family reverted the family content too
+    family_reverted_to_base_version: Optional[int] = None
+
+
+class BulkOpSummary(BaseModel):
+    id: str
+    op_type: str
+    family_id: Optional[str] = None
+    template_ids: List[str]
+    status: str
+    reverted_bulk_op_id: Optional[str] = None
+    initiated_by: Optional[str] = None
+    created_at: datetime
+    # propagation ops only: which family revision children moved from / to
+    from_base_version: Optional[int] = None
+    to_base_version: Optional[int] = None
+    # Computed (list_bulk_ops only): for completed bulk_update ops, how many
+    # touched templates can no longer be rolled back because their pre-op
+    # snapshot was pruned by retention. None for bulk_rollback / non-completed
+    # ops, where the concept doesn't apply.
+    rollback_unavailable_count: Optional[int] = None
+
+
+class BulkOpListResponse(BaseModel):
+    ops: List[BulkOpSummary]
+
+
+class MergeFieldChange(BaseModel):
+    """One field the propagation will write into a child.
+
+    ``op="remove"`` deletes the field/node (the family edit removed it);
+    ``value`` is then always None.
+    """
+
+    field_path: str
+    op: Literal["set", "remove"] = "set"
+    value: Any = None
+
+
+class MergeFieldConflict(BaseModel):
+    """One field the merchant customized where the family also changed it.
+
+    The ``*_present`` flags disambiguate "the value is JSON null" from "the
+    field does not exist on that side" — the difference between setting a
+    key to null and deleting it.
+    """
+
+    field_path: str
+    base: Any = None
+    parent: Any = None
+    child: Any = None
+    base_present: bool = True
+    parent_present: bool = True
+    child_present: bool = True
+
+
+class ChildMergeOutcome(BaseModel):
+    auto_apply: List[MergeFieldChange] = Field(default_factory=list)
+    noop: List[str] = Field(default_factory=list)
+    conflicts: List[MergeFieldConflict] = Field(default_factory=list)
+
+
+class FamilyVersionMetadata(BaseModel):
+    family_id: str
+    base_version: int
+    name: str
+    changed_by: Optional[str] = None
+    created_at: datetime
+
+
+class FamilyVersionSnapshot(BaseModel):
+    """The family's parent-template content at one base_version."""
+
+    name: str
+    description: Optional[str] = None
+    flow: Dict[str, Any] = Field(default_factory=dict)
+    expected_payload_schema: Optional[Dict[str, Any]] = None
+    expected_callback_response_schema: Optional[Dict[str, Any]] = None
+    configurations: Optional[Dict[str, Any]] = None
+    supported_channels: List[str] = Field(default_factory=lambda: ["voice"])
+
+
+class FamilyVersionListResponse(BaseModel):
+    family_id: str
+    base_version: int  # the family's current (head) base_version
+    versions: List[FamilyVersionMetadata]
+    total: int
+
+
+class FamilyVersionDetailResponse(BaseModel):
+    meta: FamilyVersionMetadata
+    snapshot: FamilyVersionSnapshot
+
+
+class RollbackFamilyRequest(BaseModel):
+    base_version: int = Field(ge=1)
+
+
+class PropagationChildPreview(BaseModel):
+    template_id: str
+    name: str
+    merchant_id: Optional[str] = None
+    current_version: int
+    derived_from_base_version: Optional[int] = None
+    # Which family version the merge actually used as its base, and why.
+    merge_base_version: Optional[int] = None
+    base_source: str  # "derived" | "previous_version" | "parent_fallback"
+    auto_applied: List[MergeFieldChange] = Field(default_factory=list)
+    noop: List[str] = Field(default_factory=list)
+    conflicts: List[MergeFieldConflict] = Field(default_factory=list)
+    # Set when this child could not be merged at all (e.g. an unaddressable
+    # key); the rest of the preview still renders.
+    error: Optional[str] = None
+
+
+class PropagationPreviewResponse(BaseModel):
+    """Stateless preview: no token, no server-side state. The UI posts
+    ``to_base_version`` and ``expected_current_versions`` back to apply,
+    which re-runs this exact merge and uses them as concurrency assertions.
+
+    Pagination: ``total_members`` / ``page`` / ``limit`` / ``has_more``
+    support large families. The UI fetches one page at a time, accumulates
+    the per-child data, and defers apply until all pages are loaded and every
+    conflict on every page is resolved.
+    """
+
+    family_id: str
+    to_base_version: int  # the family revision being propagated
+    from_base_version: Optional[int] = None
+    children: List[PropagationChildPreview] = Field(default_factory=list)
+    conflict_count: int = 0
+    expected_current_versions: Dict[str, int] = Field(default_factory=dict)
+    # Pagination metadata
+    total_members: int = 0
+    page: int = 1
+    limit: int = 50
+    has_more: bool = False
+
+
+class PropagationResolution(BaseModel):
+    """One human decision on one conflict from the preview.
+
+    ``parent`` takes the family's new value (deleting the field when the
+    family edit deleted it), ``child`` keeps the merchant's value and writes
+    nothing, ``custom`` sets ``value`` verbatim.
+    """
+
+    template_id: str
+    field_path: str
+    choice: Literal["parent", "child", "custom"]
+    value: Any = None
+
+    @model_validator(mode="after")
+    def _custom_requires_value(self) -> "PropagationResolution":
+        if self.choice == "custom" and self.value is None:
+            raise ValueError(
+                "choice='custom' requires a non-null value; to delete a field "
+                "resolve the removal conflict with choice='parent'"
+            )
+        return self
+
+
+class PropagateApplyRequest(BaseModel):
+    """Optimistic concurrency: both expectations come straight from the
+    preview response. Apply re-runs the merge and refuses (409) if either
+    moved, because the human approved a merge computed from that state."""
+
+    expected_base_version: int = Field(ge=1)
+    expected_current_versions: Dict[str, int]
+    resolutions: List[PropagationResolution] = Field(default_factory=list)

--- a/docs/BREEZE_BUDDY_ARCHITECTURE.md
+++ b/docs/BREEZE_BUDDY_ARCHITECTURE.md
@@ -686,6 +686,33 @@ Creates new template from JSON ([template.py:55-123](app/api/routers/breeze_budd
 - Prevents duplicate templates
 - Validates flow structure
 
+#### 2a. Template Versioning & Family/Bulk Routers
+**Location**: [api/routers/breeze_buddy/templates/versions.py](app/api/routers/breeze_buddy/templates/versions.py), [api/routers/breeze_buddy/templates/bulk.py](app/api/routers/breeze_buddy/templates/bulk.py)
+
+Every write to a template (`PUT /templates/{template_id}`, and the bulk/rollback routes below) appends an immutable snapshot row to `template_version` instead of mutating history in place — see [docs/TEMPLATE_LINEAGE.md](TEMPLATE_LINEAGE.md) for the full design.
+
+**Version history endpoints** ([versions.py](app/api/routers/breeze_buddy/templates/versions.py)):
+- `GET /templates/{template_id}/versions` — version metadata list, newest first
+- `GET /templates/{template_id}/versions/{version}` — full snapshot of one version (secrets masked)
+- `POST /templates/{template_id}/rollback` — restore an older version as the new head (appends a version; history is never rewritten)
+
+**Family & bulk endpoints** ([bulk.py](app/api/routers/breeze_buddy/templates/bulk.py), admin-only unless noted; family reads are reseller-RBAC'd):
+- `POST /templates/families` — create a family: name + base (parent) template + initial members
+- `GET /templates/families` — list families with base-template info (reseller-scoped for non-admins)
+- `GET /templates/families/{family_id}` — one family: parent content inline + all members with versions
+- `PUT /templates/families/{family_id}` — edit the family's parent template content (bumps `base_version`, snapshots the old content into `template_family_version`)
+- `PATCH /templates/families/{family_id}/members` — add/remove member templates
+- `GET /templates/families/{family_id}/versions` — parent's own version history
+- `GET /templates/families/{family_id}/versions/{n}` — one historical parent snapshot
+- `POST /templates/families/{family_id}/rollback` — restore an older parent revision as a new `base_version` (members untouched)
+- `POST /templates/families/{family_id}/propagate/preview` — three-way merge of the parent's latest edit into every member (base = each member's `derived_from_base_version`); returns auto-applies, no-ops, and conflicts, writes nothing
+- `POST /templates/families/{family_id}/propagate/apply` — writes the resolved merge into every member as one `op_type='propagation'` bulk op
+- `POST /templates/bulk/update` — apply a JSON merge patch (+ `node_patches`) to every template in a family (or an explicit id list); all-or-nothing, supports `dry_run=true` to preview
+- `POST /templates/bulk/rollback` — revert a completed `bulk_update` or `propagation` op via its `bulk_op_id`; refuses if a member was edited afterwards unless `force=true` (drift guard); `also_revert_family: true` also restores the parent for a propagation op (422 if that propagation has no prior family revision, 409 if the revision was pruned)
+- `GET /templates/bulk/ops` — ledger of bulk operations, the source of rollback targets (`rollback_unavailable_count` flags pruned pre-op snapshots)
+
+**Never** `UPDATE template SET flow = ...` directly — always go through `app/database/accessor/breeze_buddy/template.py` so the corresponding `template_version` row is written.
+
 ### Database Layer
 
 #### 1. Template Accessor

--- a/docs/TEMPLATE_LINEAGE.md
+++ b/docs/TEMPLATE_LINEAGE.md
@@ -1,0 +1,332 @@
+# Template Lineage & Family — Architecture
+
+**Status:** Phase 1 + Phase 2 implemented · **Owner:** Voice Platform · **Last updated:** 2026-08-13
+
+Safe **bulk update** and **bulk rollback** of Breeze Buddy templates on PROD, without losing any template's individual system prompts or configuration.
+
+---
+
+## 1. Problem
+
+Every voice/chat agent is a template (`template` table, one row each). Today:
+
+- `PUT /templates/{id}` **overwrites the row in place** — there is no history. Once an edit lands, the previous state is gone forever.
+- Templates that serve the same use case for different merchants have **different system prompts and configs**, so there is no safe way to change one shared setting (e.g. a TTS provider, a compliance line in a prompt) across 200 templates at once.
+- If a change misbehaves on PROD, there is **nothing to roll back to**.
+
+What we verified about today's system (important for the design):
+
+- The `template` row is the single source of truth at runtime. **Nothing snapshots it**: voice reads it from Postgres at call connect, chat/widget read it via a 60-second Redis cache on every turn.
+- The **only writers** of the table are the templates REST endpoints. There is exactly one write path to intercept.
+
+## 2. Concepts
+
+| Concept | What it is | What it answers |
+|---|---|---|
+| **Lineage** (vertical) | Append-only version history of one template. Every write becomes version N+1; old versions are never modified. | *"What did this template look like before? What can I roll back to?"* |
+| **Family** (horizontal) | A first-class entity (`template_family` row): a named group of templates for the same use case across merchants. The family row **contains the base (parent) template itself** — same content columns as `template` — as the canonical reference the children derive from. | *"Which templates should this bulk operation touch, and what is the canonical template they derive from?"* |
+
+Analogy: a family is a repo, the base template is `main`, each member template is a merchant's branch, lineage is the commit log. Rollback is a `revert` (a new commit that restores old content) — never history rewriting.
+
+## 3. What we add (and what we don't touch)
+
+```mermaid
+graph LR
+    subgraph existing ["EXISTING - modified"]
+        T["template<br>head - what runtime reads<br>+ current_version<br>+ family_id"]
+    end
+    subgraph new ["NEW tables"]
+        TF["template_family<br>family + embedded parent template<br>flow, configurations, base_version"]
+        TV["template_version<br>append-only snapshots"]
+        BO["template_bulk_op<br>bulk operation ledger"]
+    end
+    subgraph untouched ["UNTOUCHED"]
+        RT["Voice / Chat / Widget runtime<br>still reads template head by id"]
+    end
+    T -->|family_id FK - member of a family| TF
+    T -->|every write appends a snapshot| TV
+    BO -->|groups versions written by one bulk op| TV
+    RT --> T
+```
+
+**Runtime is untouched.** Calls, chat turns, and widget sessions keep reading the head row exactly as today. Versioning happens entirely on the write path.
+
+### 3.1 Columns added to existing `template` table
+
+| Column | Type | Purpose |
+|---|---|---|
+| `current_version` | `INTEGER NOT NULL DEFAULT 1` | Head pointer; bumped atomically on every write |
+| `family_id` | `UUID NULL`, FK → `template_family(id)` | Membership in a family. `NULL` = not in any family (nothing changes for that template) |
+
+### 3.2 New table: `template_version` (the lineage)
+
+One row per template state, ever. Written in the **same transaction** as the head update — the two can never diverge.
+
+| Column | Purpose |
+|---|---|
+| `template_id`, `version` | Which template, which version (unique together) |
+| `reseller_id`, `merchant_id`, `name`, `flow`, `expected_payload_schema`, `expected_callback_response_schema`, `configurations`, `secrets`, `telephony_number_id`, `is_active`, `supported_channels` | **Full snapshot** of every editable column at that version (full copy, not a diff → rollback is a single-row read, no chain replay) |
+| `change_source` | `backfill` \| `create` \| `manual_edit` \| `bulk_update` \| `rollback` \| `bulk_rollback` |
+| `bulk_op_id` | Set when a bulk operation wrote this version |
+| `changed_by`, `created_at` | Audit trail |
+
+Storage is a non-issue: templates are KB-sized JSONB (TOAST-compressed). Migration backfills **version 1 = current state** for every existing template.
+
+**Retention — only the last 10 versions per template are kept.** The snapshot insert and the prune run in the same transaction, so the table self-maintains (no cron, no trigger):
+
+```sql
+DELETE FROM template_version tv
+WHERE tv.template_id = $1
+  AND tv.version <= $2 - 10          -- $2 = the current_version just written
+  AND NOT EXISTS (                   -- rollback-safety guard, see below
+        SELECT 1
+        FROM template_version bv
+        JOIN template_bulk_op op ON op.id = bv.bulk_op_id
+        WHERE bv.template_id = tv.template_id
+          AND op.status = 'completed'
+          AND tv.version >= bv.version - 1
+          AND tv.version <= bv.version
+  );
+```
+
+- The limit is config-driven, not hardcoded: the `10` is a bind parameter fed into the DELETE from the `TEMPLATE_VERSION_RETENTION` env var (read once at startup in `app/core/config/static.py`, default 10). The pruning itself happens entirely in Postgres; the env var only supplies the number, so retention can be changed without a code deploy.
+- **Rollback-safety guard:** bulk rollback restores each member's *pre-op* snapshot (`bulk-written version − 1`). Without a guard, 10+ edits to a child *after* a propagation would prune that snapshot and silently destroy the ability to bulk-revert. The `NOT EXISTS` clause therefore never deletes versions still needed by an active (`completed`, not-yet-rolled-back) bulk op — the bulk-written version and the one immediately before it.
+- **UI warning (frontend requirement):** the version dropdown holds at most 10 entries. On the bulk-ops screen, any op whose pre-op snapshots are no longer fully present (possible for *older* ops once a newer bulk op takes over the protection) must show a warning badge: *"rollback no longer available for N of M templates — history pruned."* Attempting such a rollback also fails loudly server-side (the missing snapshot is reported per template), so the badge is a courtesy, not the only line of defense.
+
+The same retention limit applies to `template_family_version` (`TEMPLATE_VERSION_RETENTION` family revisions per family), with the analogous guard: a revision referenced by a completed propagation op's `from_base_version` or `to_base_version` is never pruned, because that is exactly what a bulk rollback with `also_revert_family` restores.
+
+**Deletion:** `template_version.template_id` references `template(id)` with `ON DELETE CASCADE` — deleting a template deletes its history with it. This keeps today's delete semantics unchanged (delete is already admin-only and blocked while any `call_execution_config` or active lead references the template). If we ever need audit history to outlive deletion, the follow-up is soft-delete on `template` (an `is_deleted` flag), not orphaned version rows.
+
+**Concurrency:** version numbers can never collide. Every write uses a single atomic `UPDATE template SET ... , current_version = current_version + 1 ... RETURNING current_version` — Postgres serializes concurrent updates on the same row, so two simultaneous PUTs get N+1 and N+2, never the same number. The snapshot insert uses the RETURNING value inside the same transaction, and `UNIQUE (template_id, version)` is the hard backstop. Bulk operations additionally take `FOR UPDATE` row locks on all members, because they read-patch-validate-write across multiple statements.
+
+### 3.3 New table: `template_family` (the family, containing its parent template)
+
+The family is a first-class row that **contains the base (parent) template inline** — the same content columns as the `template` table. Opening a family shows the canonical template directly: no join, no separate template row that could be dialed or deleted independently. `family_id` on member templates is a foreign key to this table's `id` (created by `POST /templates/families`, never a free-floating UUID).
+
+Families are **global admin-managed groups**: they have no `reseller_id`. Members can come from any reseller or merchant — the individual `template` rows each retain their own `reseller_id` / `merchant_id` for tenancy purposes at runtime.
+
+| Column | Purpose |
+|---|---|
+| `id` | The `family_id` members point at |
+| `name`, `description` | Human-readable identity (e.g. "order-confirmation") — what shows up in listings |
+| `flow`, `expected_payload_schema`, `expected_callback_response_schema`, `configurations`, `supported_channels` | **The parent template's content** — mirrors the `template` table's content columns |
+| `base_version` | Bumped on every edit of the parent content — children record which revision they derived from |
+| `created_by`, `created_at`, `updated_by`, `updated_at` | Audit trail — `updated_at`/`updated_by` answer *"when did we last update the family template, and who"* |
+
+**Deliberately NOT copied from `template`:** `reseller_id`, `merchant_id` (a family is global — members bring their own tenancy), `telephony_number_id` + `is_active` (the parent is not in the `template` table at all, so it structurally *cannot* receive calls or leads — stronger than any flag), and `secrets` (children hold their own real secrets; duplicating them at family level is risk with no benefit).
+
+**How children relate to it:** a child is created by copying the family's content into a new `template` row (scoped to any merchant) and then customizing — different prompt wording, language, voice. The parent stays the readable reference of what the family *should* look like; children are its merchant-specific variations.
+
+**Where you view it:** `GET /templates/families` lists every family with name, `base_version`, and `updated_at`. `GET /templates/families/{id}` returns the parent template content inline plus all members with their `current_version` — so at a glance: *this is the family, this is the parent template, this is when it last changed, these are the children derived from it.* Editing the parent goes through `PUT /templates/families/{id}` (bumps `base_version`). The bulk-op ledger joins here too via `template_bulk_op.family_id`.
+
+### 3.4 New table: `template_bulk_op` (the ledger)
+
+One row per bulk operation — this is what makes bulk rollback possible: it remembers exactly which templates were touched and with what patch.
+
+| Column | Purpose |
+|---|---|
+| `op_type` | `bulk_update` \| `bulk_rollback` \| `propagation` |
+| `family_id`, `template_ids` | Scope of the operation |
+| `patch` | The JSON patch that was applied (audit / reproducibility) |
+| `status` | `completed` \| `rolled_back` |
+| `reverted_bulk_op_id` | On a rollback op: which update op it reverted |
+| `from_base_version`, `to_base_version` | Propagation ops only: which family revision the children moved from / to. `from_base_version` is what `also_revert_family` restores the family to, and what the reverted children's `derived_from_base_version` is reset to |
+| `initiated_by`, `created_at` | Audit trail |
+
+**Why no per-template from/to versions here:** they are not duplicated into the ledger — every `template_version` row written by a bulk op carries that op's `bulk_op_id`. So the exact per-template versions come from `template_version` directly (`WHERE bulk_op_id = ...` gives each `(template_id, to_version)` pair, and the pre-op state is simply `to_version - 1`). That query is exactly how bulk rollback resolves what to restore; one source of truth, indexed.
+
+## 4. Write path — before vs after
+
+```mermaid
+graph TB
+    subgraph before ["TODAY"]
+        A1["PUT /templates/:id"] --> B1["UPDATE template row<br>old state destroyed"]
+        B1 --> C1["invalidate Redis cache"]
+    end
+    subgraph after ["WITH LINEAGE - one DB transaction"]
+        A2["PUT /templates/:id<br>or rollback / bulk op"] --> B2["UPDATE template head<br>current_version N to N+1"]
+        B2 --> B3["INSERT snapshot v N+1<br>into template_version"]
+        B3 --> C2["commit, then invalidate Redis cache"]
+    end
+```
+
+Applies uniformly to all writes — manual PUT, single rollback, bulk update, bulk rollback. Each just uses a different `change_source`. The API contract of the existing endpoints does not change (new fields on responses are read-only and ignored on PUT round-trips).
+
+## 5. How bulk update keeps per-template customizations
+
+The core trick: we do **not** copy one template onto the others. Each template's **own current state** is patched with a **JSON merge patch** — only the keys named in the patch change; everything else (each merchant's unique prompt, language, voice) is untouched.
+
+- `configurations_patch` — merge-patch the `configurations` JSONB (e.g. switch TTS provider everywhere).
+- `flow_patch` — merge-patch top-level flow keys (e.g. direct-mode `system_prompt`).
+- `node_patches` — because `flow.nodes` is an array (merge patch would replace it wholesale), nodes are addressed **by `node_name`**: patch node `greeting` in every member, whatever else its flow contains.
+
+**Guardrail:** a `flow_patch` containing the `nodes` key is **rejected with 422**. A merge patch would silently replace every member's entire node list — the exact thing this design exists to prevent. Node edits go through `node_patches` only; `flow_patch` is for top-level flow keys (e.g. direct-mode `system_prompt`).
+
+```mermaid
+graph TB
+    REQ["POST /templates/bulk/update<br>family_id or template_ids + patches + dry_run"] --> LOCK["Load and row-lock all members<br>blocks concurrent PUTs"]
+    LOCK --> PATCH["For EACH member:<br>apply patches to its OWN current state"]
+    PATCH --> VAL{"All members valid?<br>flow shape + Pydantic config validation"}
+    VAL -->|any invalid| FAIL["422 - abort ALL<br>nothing written<br>per-template errors returned"]
+    VAL -->|valid + dry_run| PREVIEW["Return preview<br>nothing written"]
+    VAL -->|valid| WRITE["One transaction:<br>ledger row, then per member<br>head update to vN+1 plus snapshot"]
+    WRITE --> CACHE["Invalidate Redis cache per member"]
+    CACHE --> DONE["Return bulk_op_id and per-template<br>from_version / to_version"]
+```
+
+**All-or-nothing:** if the patch breaks even one template's validation, the entire operation aborts and PROD is untouched. `dry_run=true` previews the result without writing.
+
+## 6. Editing the family from the dashboard — propagation & merge conflicts — **built (Phase 2)**
+
+Section 5's explicit patches are the low-level mechanism. The **dashboard workflow** builds on top of it: the team lead opens the family, edits the **parent template** directly, and the system carries that edit into every child — surfacing merge conflicts for manual resolution where a merchant customized the same spot.
+
+```mermaid
+graph TB
+    EDIT["Team lead edits the FAMILY template<br>in the dashboard - PUT families/:id<br>base_version N to N+1"] --> PREVIEW["propagate/preview<br>three-way merge per child, per field<br>base = family at child's synced version"]
+    PREVIEW --> CLASS{"Per changed field,<br>per child"}
+    CLASS -->|child never customized it| AUTO["auto-apply<br>parent's new value"]
+    CLASS -->|child already matches| NOOP["no-op"]
+    CLASS -->|merchant customized<br>the same field| CONFLICT["CONFLICT<br>base vs parent vs child"]
+    AUTO --> SHOW["Preview screen per child:<br>auto-merged + conflicts<br>nothing written yet"]
+    NOOP --> SHOW
+    CONFLICT --> SHOW
+    SHOW --> RESOLVE["Lead resolves each conflict:<br>keep child / take parent / custom value"]
+    RESOLVE --> APPLY["propagate/apply<br>one transaction, one bulk_op_id<br>snapshot per child"]
+    APPLY --> DONE["Children updated, caches busted<br>reversible via bulk/rollback"]
+```
+
+### 6.1 The merge is three-way, per field (like git, but on JSON fields, not text lines)
+
+For every field the lead changed on the parent, compared per child:
+
+| Child's current value | Outcome |
+|---|---|
+| Still equals the **old** family value (merchant never touched it) | **Auto-apply** the parent's new value |
+| Already equals the **new** value | No-op |
+| Something else (merchant customized this exact field) | **CONFLICT** — needs a human decision |
+
+The conflict unit is a JSON field (e.g. the `greeting` node's prompt string), not a text line. For long prompts the UI can render an intra-string text diff for readability, but resolution replaces the whole field: **keep child's value**, **take parent's value**, or **enter a custom value**.
+
+### 6.2 What this needs in the schema (Phase 2 additions)
+
+| Addition | Why |
+|---|---|
+| `template_family_version` table — **shipped in migration `046`** | Full snapshot of the parent content per `base_version` — the merge needs the **old** parent value as its base, and this also gives the parent a viewable history (same shape as `template_version`) |
+| `template.derived_from_base_version` — **shipped in migration `046`** | Which family revision each child was last synced to — the merge base is the family snapshot at *this* version, so children that skipped an earlier propagation still merge correctly (the skipped changes simply show up in this round). This is **head-only metadata** — it is **not** part of the `template_version` snapshot (content is versioned; the sync pointer is bookkeeping, restored explicitly on rollback via `also_revert_family`) |
+
+### 6.3 The flow, end to end
+
+1. Lead edits the parent → `PUT /templates/families/{id}` (bumps `base_version`, snapshots the old content into `template_family_version`).
+2. `POST /templates/families/{id}/propagate/preview` — computes the three-way merge for every child; **writes nothing**. Returns per child: auto-applied fields, no-ops, and conflicts (each with base/parent/child values).
+3. UI shows the preview; lead resolves each conflict.
+4. `POST /templates/families/{id}/propagate/apply` with the resolutions — the per-child results become per-child patches fed into the **same bulk machinery as section 5**: one all-or-nothing transaction, one `bulk_op_id`, a version snapshot per child, `derived_from_base_version` updated, caches invalidated.
+5. Regret it? `POST /templates/bulk/rollback {bulk_op_id}` — same drift-guarded rollback as any bulk op.
+
+Propagation is implemented — see §8.2 for the endpoints and §6.4 for the merge specifics as built.
+
+### 6.4 Merge specifics (as built)
+
+**The conflict unit is a field path.** Four shapes: `flow.<key>` (top-level flow key), `flow.nodes.<node_name>` (a whole node — used when the node was added or removed on one side, or is absent from the child), `flow.nodes.<node_name>.<key>` (one key of a node all three sides have), `configurations.<key>`.
+
+**Add / remove.** A key or node the family edit added auto-applies when the child does not have it, no-ops when the child already has the same value, conflicts otherwise. A key or node the family edit removed auto-removes when the child's copy is untouched, no-ops when the child already dropped it, conflicts when the merchant customized it. Anything only the child has is never touched.
+
+**Merge base, including never-synced children.** The base is the family snapshot at the child's `derived_from_base_version`. If that is `NULL` (the child predates propagation or joined the family without one) or the snapshot was pruned, the base is the family revision immediately before the one being propagated. A never-synced child can only honestly be treated as in sync with everything except the edit happening right now: basing on v1 would replay every historical family change as a conflict against a merchant who never opted into them, and basing on the child's own content would classify every field as a no-op and propagate nothing. If no base is available at all, the parent content itself is used, which makes the merge a no-op — a child is never silently overwritten.
+
+**Preview is stateless.** No preview token, nothing cached server-side. The preview echoes the family's `base_version` (wire field `to_base_version`) and every child's `current_version`; apply re-runs the identical merge under `FOR UPDATE` locks and treats those echoes as optimistic-concurrency assertions — 409 if the family or any child moved, 409 if a template joined the family in between, 422 if any conflict is unresolved or if a resolution matches no conflict (a stale preview). The preview response also flags each change with `auto_applied` so the UI can distinguish an auto-merge from a conflict that still needs a decision.
+
+**Secrets.** Family versions store the family row verbatim, and that row is mask-level by construction: the family has no `secrets` column, and every family write runs `mask_mcp_auth_secrets` over `configurations` first, so `template_family` / `template_family_version` can never hold a real MCP auth token even if an admin pastes one into the create/update body. Children do hold real secrets, so the preview masks the child-side value of every `configurations.*` conflict — and the base/parent sides too. The merge itself compares raw values, so classification stays correct. Neither a `parent` nor a `custom` resolution can write a masked placeholder into a child: for a `configurations.*` field whose resolved value contains one, apply keeps the child's existing raw value (422 if the child has none, so the real value must be resubmitted).
+
+## 7. Rollback
+
+### 7.1 Single template
+
+`POST /templates/{id}/rollback {version: N}` → snapshot N is written back as a **new** version (history stays append-only, so a rollback can itself be rolled back).
+
+### 7.2 Bulk rollback
+
+```mermaid
+graph TB
+    REQ["POST /templates/bulk/rollback<br>bulk_op_id + optional force"] --> LOAD["Load ledger row:<br>every template + version the op wrote"]
+    LOAD --> DRIFT{"Drift check:<br>is each template's head still<br>the version the op wrote?"}
+    DRIFT -->|edited after the bulk op, no force| ABORT["409 - abort, list drifted templates<br>blind restore would destroy that edit"]
+    DRIFT -->|clean or force=true| RESTORE["One transaction, per member:<br>restore pre-op snapshot vN-1<br>as a new version"]
+    RESTORE --> LEDGER["New ledger row bulk_rollback<br>original op marked rolled_back"]
+    LEDGER --> CACHE["Invalidate caches"]
+    CACHE --> DONE["Done - every member back<br>to its own pre-op state"]
+```
+
+The **drift guard** is the PROD-safety centerpiece: rollback refuses to clobber a manual edit that landed after the bulk update, unless explicitly forced.
+
+## 8. API surface — mapped to the dashboard flows
+
+Existing five template endpoints (`POST/GET/PUT/DELETE /templates…`) are unchanged. Every new endpoint below exists for a specific moment in a dashboard flow — nothing is speculative.
+
+### 8.1 Template screen (any template — family member or not)
+
+The per-template version UI. Ships with Phase 1, needs zero family features.
+
+| Method & Path | Who | When the dashboard calls it |
+|---|---|---|
+| `GET /templates/{id}/versions` | template access | Opening a template: populates the **version dropdown** (up to 10 entries — version, who changed it, when, why: `manual_edit`/`rollback`/`bulk_update`) |
+| `GET /templates/{id}/versions/{n}` | template access | User picks an old version in the dropdown: shows/diffs that version's full content (secrets masked) |
+| `POST /templates/{id}/rollback` | admin / reseller owner | The **"Restore this version"** button next to the dropdown — restores version n as a NEW head version |
+
+(A normal save on this screen is the existing `PUT /templates/{id}` — it now auto-appends a version, no frontend change needed.)
+
+### 8.2 Family screen
+
+Create/manage families; the lead's edit-and-propagate flow (§6). All family endpoints are **admin-only** — families are global admin-managed groups with no reseller scoping.
+
+| Method & Path | Who | When the dashboard calls it |
+|---|---|---|
+| `POST /templates/families` | **admin** | **"Create family"** dialog — name + parent content (or `copy_base_from_template_id` to seed from an existing template) + initial member selection. Validates the flow shape same as a template create |
+| `GET /templates/families` | **admin** | The **family list page** — name, `base_version`, last updated, member count |
+| `GET /templates/families/{id}` | **admin** | Opening a family: parent template rendered inline + member list with each child's `current_version` |
+| `PUT /templates/families/{id}` | **admin** | Lead hits **"Save"** after editing the parent — bumps `base_version`, snapshots the old parent content, re-validates flow shape. Step 1 of §6 |
+| `PATCH /templates/families/{id}/members` | **admin** | **"Add / remove members"** on the family detail page |
+| `GET /templates/families/{id}/versions` | **admin** | Family screen version dropdown — history of the parent template |
+| `GET /templates/families/{id}/versions/{n}` | **admin** | Viewing/diffing one historical parent revision |
+| `POST /templates/families/{id}/rollback` | **admin** | **"Restore this revision"** on the family screen — restores parent content as a NEW `base_version`. Children are untouched; run propagate/preview afterwards to carry it into them |
+| `POST /templates/families/{id}/propagate/preview` | **admin** | Fires automatically after the save (or on **"Apply to children"**): three-way merge of the edit into all children — returns auto-merges + **conflicts**, writes nothing. Powers the preview/conflict screen |
+| `POST /templates/families/{id}/propagate/apply` | **admin** | Lead finished resolving conflicts, hits **"Apply"**: writes all children in one transaction as `op_type='propagation'`, returns the `bulk_op_id` the UI must keep/show for revert |
+
+### 8.3 Rollout history & revert screen
+
+| Method & Path | Who | When the dashboard calls it |
+|---|---|---|
+| `GET /templates/bulk/ops` | **admin** | The **rollout history page**: every bulk apply/revert with scope, patch, who, when. Ops whose pre-op snapshots were pruned (retention, §3.2) get the **"rollback no longer available for N of M templates"** warning badge, via `rollback_unavailable_count` on the op row |
+| `POST /templates/bulk/rollback` | **admin** | The **"Revert this rollout"** button on a history row — drift-guarded (409 lists children edited after the rollout → the UI's force-confirm dialog sends `force: true`). Also reverts `propagation` ops (the family's own bulk mechanism). The **"also revert the family template"** checkbox sends `also_revert_family: true` — propagation-ops only (422 otherwise); 422 if that propagation has no `from_base_version` at all (it created `base_version` 1, so there is nothing to restore to); 409 if a `from_base_version` exists but that family revision was pruned by retention |
+
+### 8.4 Not in the dashboard: the ops escape hatch
+
+| Method & Path | Who | What it's for |
+|---|---|---|
+| `POST /templates/bulk/update` | **admin only, API-only** | Hand-written merge patch applied to a family / explicit template list (`dry_run` supported). **The dashboard never calls this.** It exists for ops emergencies — e.g. a dead webhook URL failing calls across 200 templates *right now*: one API call fixes them without the family-edit → preview → resolve ceremony. Everything it writes still goes through the same ledger + snapshots, so it stays revertible like any rollout |
+
+## 9. PROD operating playbook
+
+```mermaid
+graph LR
+    A["1. Create family with base template<br>and members - one-time per use case"] --> B["2. bulk/update<br>dry_run=true"]
+    B --> C["3. Review per-template preview"]
+    C --> D["4. bulk/update for real<br>keep the bulk_op_id"]
+    D --> E["5. Canary call / chat"]
+    E --> F{"OK?"}
+    F -->|yes| G["Done"]
+    F -->|no| H["bulk/rollback with bulk_op_id<br>every member back to pre-op state"]
+```
+
+**Rollout order:** run migration first (purely additive — old code ignores the new columns), then deploy the code. In-flight calls behave exactly as with today's PUT: they keep the config they loaded at connect.
+
+## 10. Phasing & explicitly out of scope
+
+**Phase 1 (implemented):** lineage, families with embedded parent, explicit bulk patch + bulk rollback. **Phase 2 (implemented):** dashboard propagation with three-way merge + conflict-resolution API (§6), `template_family_version`, `derived_from_base_version`, family version history + rollback, bulk rollback of propagation ops including `also_revert_family`.
+
+Remaining follow-ups (not built):
+
+- **Version pinning on calls** — stamping the template version onto `lead_call_tracker` so every historical call is traceable to the exact content that ran it. Small follow-up.
+- UI for version diffing.
+
+---
+
+*Implementation-level companion (schemas, SQL, task breakdown, tests): `docs/superpowers/plans/2026-08-03-template-lineage-versioning.md`.*

--- a/questions.md
+++ b/questions.md
@@ -1,0 +1,59 @@
+# Questions for team lead — Template Lineage & Family
+
+*(My notes before our review. Current status: everything below is already built and working on the feature branch — nothing is merged yet, so any answer can still change the design cheaply.)*
+
+## 1. Family table stores the template content inside it — confirm this is what you wanted
+
+You told me the family table should store the template itself, not just an ID. So `template_family` now has the same content columns as `template` (flow, configurations, schemas, supported channels). The parent template is NOT a row in the `template` table — which also means it can never receive a call by accident. Is this what you had in mind?
+
+## 2. I also created a `template_family_version` table — so the family template itself can be reverted. Was that right?
+
+While building, I realized: child templates get version history and rollback, but the family's own template content had no history — if someone edits the family template wrongly, there was no way to get the old content back. So I added a `template_family_version` table (same idea as `template_version`: every time someone edits the family, the old content is saved, and there's a rollback API for it). It's also needed later for the merge feature. Is this table OK, or do you think it's too much?
+
+## 3. When someone reverts a bulk operation, should the FAMILY template also revert automatically?
+
+Today it works like this: reverting a bulk operation puts every CHILD template back to its previous version. That holds as long as each child's pre-operation snapshot still exists — for an older rollout whose snapshots have since been pruned by retention, the revert is refused outright (all-or-nothing: it reports the affected members and writes nothing, rather than reverting some children and leaving others). But the family template stays as it is, because maybe the lead wants to fix the family content and re-apply instead of losing his edit. I made the family revert OPTIONAL — a checkbox on the revert screen ("also revert the family template"). Question: should it stay optional like this, or should the family always revert together with the children automatically?
+
+## 4. Bulk operation history has no description field — should we add one?
+
+The rollout history page shows: which family, which templates, what changed (the exact patch), who did it, and when. But there's no place to write a human note like "added recording disclosure line to all greetings". Should I add an optional description box when applying, so the history is easier to read later? (One small column, easy to add now since nothing is deployed.)
+
+## 5. We keep only the last 10 versions of each template — is 10 the right number?
+
+Old versions get deleted automatically (with a safety rule: versions needed for reverting a recent bulk operation are never deleted). The number 10 is configurable by env variable. Should it stay 10? And should the family template versions use the same limit?
+
+## 6. Merge conflicts are resolved field-by-field, not line-by-line — OK?
+
+When a family update conflicts with a merchant's own edit, the person resolving picks per FIELD (for example, the whole greeting prompt): keep the merchant's text, take the family's text, or write a combined/custom text. We don't merge individual lines inside a prompt automatically, because auto-merged prompts can come out grammatically broken and go straight into live calls. Is that acceptable?
+
+## 7. The raw bulk-update API is admin-only and not shown in the dashboard — OK?
+
+There are two ways to change many templates: (a) the dashboard flow — edit family, preview, resolve conflicts, apply; (b) a raw API where an admin sends a JSON patch directly — meant only for emergencies (like a dead webhook URL on 200 templates at 2 AM). The dashboard never uses (b). Keep it that way?
+
+## 8. Secrets are never copied into the family — confirming
+
+When a family is created by copying an existing template, we deliberately do NOT copy secrets, and auth tokens inside configurations are stored and returned masked. Merchants' real secrets stay only on their own templates. Just confirming this matches what you expect.
+
+## 9. Should the Families tab and its read APIs be admin-only, or stay viewable for everyone?
+
+Right now it's split: creating/editing families and running bulk operations is admin-only, but *viewing* families (the Families tab, and the two read APIs behind it) is open to any console user — scoped to their own reseller, so nobody can see another reseller's families. The idea was that non-admins might find it useful to see what the canonical family template looks like. Should it stay like this, or do you want the whole Families tab and its read endpoints locked to admin-only as well? (The Rollouts tab with the revert button is already admin-only either way.)
+
+## 10. Only `flow` and `configurations` flow from family into child templates — is that enough?
+
+When a family update is applied to children (bulk update today, the merge flow later), only two things can be pushed into the children: the flow (prompts/nodes) and the configurations (voice, language, STT/TTS settings). Everything else NEVER flows: payload schema, callback schema, supported channels, names, phone number pins, secrets, active flag. My reasoning: payload/callback schemas are the contract with each merchant's integration — bulk-changing them could suddenly start rejecting merchants' lead pushes; and routing/identity/secrets being bulk-editable is how one mistake becomes a 200-template outage. Question: is flow + configurations enough, or do you see a case where the payload schema should also propagate (e.g. all merchants of one use case share the exact same payload format)?
+
+## 11. New dashboard tabs — is the visibility split right?
+
+Five new screens were added to the dashboard. Current visibility:
+
+- **Families** (list + create): under Tools in the sidebar, visible to all console users — but the list only shows families of the user's own reseller, and the Create button appears for admins only.
+- **Family detail** (parent template, members, family version history): visible to users with access to that family's reseller; all edit actions admin-only.
+- **Propagation flow** (preview → resolve conflicts → apply): opened from family detail; every action admin-only.
+- **Rollouts** (bulk history + revert): lives in the sidebar's admin section — admin-only tab.
+- **Template version history** (view old versions + restore): on each template, visible to whoever can access that template; restore is admin/reseller-owner only.
+
+In short: viewing is open (but scoped to your own reseller), changing anything is admin-only. Same split as question 9 — should the two viewing tabs (Families, template versions) also become admin-only, or is this split fine?
+
+## 12. Families exist under a reseller only — not under a merchant. Is that the right scope?
+
+Currently a family always belongs to a reseller (`reseller_id` on the family), and its members are templates from that reseller's merchants. There is no merchant-level family — because the whole idea was grouping the same use case ACROSS merchants. A merchant-level user can't create or own a family. Is reseller-only scoping right, or do you see a case where a single merchant with many templates would need their own family (e.g. one big merchant with 20 templates of the same flow)? If yes, we'd add an optional merchant_id to the family.


### PR DESCRIPTION
Every template write now appends an immutable snapshot to template_version (same transaction as the head bump), giving each template a viewable and restorable history capped at TEMPLATE_VERSION_RETENTION versions, with rollback-needed snapshots exempt from pruning.

Templates group into reseller-scoped families (template_family embeds the parent's content and can never take calls). Editing the parent snapshots into template_family_version; propagation three-way-merges that edit into every member (base = each child's derived_from_base_version), previews before writing, surfaces per-field conflicts for resolution, and applies as one revertible op_type='propagation' bulk operation. Bulk rollback restores every touched template to its own pre-op version, drift-guarded (409), optionally reverting the family template too.

Config secrets stay masked on every family/preview read path and masked literals can never be persisted back. Migration 046 is idempotent and backfills v1 for existing templates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added template version history with snapshot viewing and rollback.
  * Added template families for shared content, membership management, and lineage tracking.
  * Added bulk updates, dry-run previews, operation history, and bulk rollback.
  * Added parent-to-child propagation previews with drift detection and conflict resolution.
  * Templates now display family and current-version metadata.
* **Security**
  * Sensitive values remain masked in version snapshots, previews, and copied content.
* **Documentation**
  * Added guidance for versioning, families, propagation, rollback, and bulk operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->