### PR TITLE
send speed in the initial_greeting audio

### DIFF
--- a/app/ai/voice/agents/breeze_buddy/template/types.py
+++ b/app/ai/voice/agents/breeze_buddy/template/types.py
@@ -425,6 +425,16 @@ class TTSConfig(BaseModel):
         None, description="TTS language code (e.g. 'en', 'hi', 'en-IN')"
     )
     speed: Optional[float] = Field(None, description="Speed/pace multiplier")
+    stability: Optional[float] = Field(
+        None,
+        description=("Voice stability, 0.0-1.0 — lower is more"),
+    )
+    similarity_boost: Optional[float] = Field(
+        None,
+        description=(
+            "Similarity boost, 0.0-1.0 — how closely the output matches the original voice sample"
+        ),
+    )
     volume: Optional[float] = Field(
         None, description="Volume multiplier (Cartesia only, range 0.5-2.0)"
     )

--- a/app/ai/voice/agents/breeze_buddy/tts/__init__.py
+++ b/app/ai/voice/agents/breeze_buddy/tts/__init__.py
@@ -64,6 +64,8 @@ _VOICE_CONFIG_FIELDS = (
     "model",
     "language",
     "speed",
+    "stability",
+    "similarity_boost",
     "volume",
     "emotion",
     "pitch",
@@ -187,7 +189,7 @@ async def get_tts_service(voice_config: TTSConfig):
     logger.info(
         f"Building TTS service: provider={provider}, voice_id={voice_config.voice_id}, "
         f"model={voice_config.model}, speed={voice_config.speed}, language={voice_config.language}, "
-        f"enable_ssml_parsing={voice_config.enable_ssml_parsing}"
+        f"enable_ssml_parsing={voice_config.enable_ssml_parsing}, stability={voice_config.stability}, similarity_boost={voice_config.similarity_boost}"
     )
 
     # Emoji stripping applies to EVERY provider/flow. pipecat runs these filters
@@ -224,6 +226,8 @@ async def get_tts_service(voice_config: TTSConfig):
                 voice_id=voice_config.voice_id or "",
                 model=voice_config.model or "eleven_flash_v2_5",
                 speed=voice_config.speed or 1.0,
+                stability=voice_config.stability,
+                similarity_boost=voice_config.similarity_boost,
                 language=_parse_language(voice_config.language, Language.EN_IN),
                 aggregate_sentences=aggregate,
                 enable_ssml_parsing=bool(voice_config.enable_ssml_parsing),
@@ -348,6 +352,12 @@ async def generate_audio(
     resolved = await resolve_voice_config(voice_config, overrides)
     provider = resolved.provider.value
 
+    logger.info(
+        f"TTS resolved config: provider={provider}, "
+        f"voice_id={resolved.voice_id}, model={resolved.model}, "
+        f"language={resolved.language}, speed={resolved.speed}, volume={resolved.volume}"
+    )
+
     # Batch synth calls the provider API directly, bypassing the pipecat TTS
     # service (and its EmojiTextFilter), so strip emoji here too. The caller
     # stores the display text separately — the greeting bubble keeps its emoji.
@@ -392,6 +402,12 @@ async def generate_audio(
             voice_id=resolved.voice_id,
             model_id=resolved.model,
             use_indian_residency=use_indian_residency,
+            speed=resolved.speed,
+            stability=resolved.stability,
+            similarity_boost=resolved.similarity_boost,
+            language=(
+                _parse_language(resolved.language) if resolved.language else None
+            ),
         )
         input_format = "ulaw"
     elif provider == "cartesia":

--- a/app/ai/voice/tts/dragontts.py
+++ b/app/ai/voice/tts/dragontts.py
@@ -67,6 +67,8 @@ _PARAM_FIELDS = (
     "pitch",
     "style_prompt",
     "enable_ssml_parsing",
+    "similarity_boost",
+    "stability",
 )
 
 

--- a/app/ai/voice/tts/elevenlabs.py
+++ b/app/ai/voice/tts/elevenlabs.py
@@ -6,7 +6,10 @@ from dataclasses import dataclass
 from typing import Optional, Sequence
 
 import httpx
-from pipecat.services.elevenlabs.tts import ElevenLabsTTSService
+from pipecat.services.elevenlabs.tts import (
+    ElevenLabsTTSService,
+    language_to_elevenlabs_language,
+)
 from pipecat.services.tts_service import TextAggregationMode
 from pipecat.transcriptions.language import Language
 
@@ -30,6 +33,8 @@ class ElevenLabsConfig:
     voice_id: str
     model: str
     speed: float = 1.0
+    stability: Optional[float] = None
+    similarity_boost: Optional[float] = None
     language: Language = Language.EN_IN
     text_filters: Optional[Sequence] = None
     aggregate_sentences: bool = True
@@ -49,6 +54,8 @@ def build_elevenlabs_tts(config: ElevenLabsConfig):
         enable_ssml_parsing=config.enable_ssml_parsing,
         settings=ElevenLabsTTSService.Settings(
             speed=config.speed,
+            stability=config.stability,
+            similarity_boost=config.similarity_boost,
             language=config.language,
         ),
         text_filters=text_filters,
@@ -65,6 +72,10 @@ async def _generate_elevenlabs_audio(
     voice_id: str | None = None,
     model_id: str | None = None,
     use_indian_residency: bool = True,
+    speed: float | None = None,
+    stability: float | None = None,
+    similarity_boost: float | None = None,
+    language: Language | None = None,
 ) -> bytes:
     """Synthesize audio using ElevenLabs TTS API.
 
@@ -75,6 +86,11 @@ async def _generate_elevenlabs_audio(
         use_indian_residency: If True, uses Indian residency API endpoint and key.
                              If False, uses default global API endpoint and key.
                              Defaults to True.
+        speed: Optional playback speed, so a pre-synthesized greeting matches the
+               speed the live pipeline uses.
+        stability: Optional voice stability (0.0-1.0). Omitted when None.
+        similarity_boost: Optional similarity boost (0.0-1.0). Omitted when None.
+        language: Optional language, so the greeting matches the live pipeline.
 
     Returns:
         Audio bytes in ulaw_8000 format
@@ -104,15 +120,31 @@ async def _generate_elevenlabs_audio(
         "Accept": "audio/basic",
     }
 
-    payload = {
+    voice_settings: dict[str, float] = {}
+    for key, value in (
+        ("speed", speed),
+        ("stability", stability),
+        ("similarity_boost", similarity_boost),
+    ):
+        if value is not None:
+            voice_settings[key] = value
+
+    payload: dict = {
         "text": text,
         "model_id": final_model_id,
-        "voice_settings": {"stability": 0.5, "similarity_boost": 0.75},
     }
+    if voice_settings:
+        payload["voice_settings"] = voice_settings
+
+    language_code = language_to_elevenlabs_language(language) if language else None
+    if language_code:
+        payload["language_code"] = language_code
 
     logger.info(
         f"Synthesizing greeting with ElevenLabs (ulaw_8000): {text[:50]}... "
-        f"[voice_id={final_voice_id}, model_id={final_model_id}, indian_residency={use_indian_residency}]"
+        f"[voice_id={final_voice_id}, model_id={final_model_id}, "
+        f"indian_residency={use_indian_residency}, voice_settings={voice_settings}, "
+        f"language_code={language_code}]"
     )
 
     async with httpx.AsyncClient() as client:

--- a/dragontts/app/providers/elevenlabs.py
+++ b/dragontts/app/providers/elevenlabs.py
@@ -82,20 +82,28 @@ class ElevenLabsProvider(BaseTTSProvider):
         ] = {}
 
     def _voice_settings(self, params: dict) -> dict:
-        # Caller-supplied voice_settings win; otherwise mirror the one-shot
-        # defaults. speed is ALWAYS set (explicit, else the DragonTTS default) so
-        # an OMITTED speed and an EXPLICIT speed==default yield identical audio —
-        # canonical_params collapses the latter to "absent", so they must sound
-        # the same or one cache key would serve different-speed audio.
-        speed = (params or {}).get("speed")
+        # Caller-supplied voice_settings win; otherwise build from the flat
+        # tuning params. speed is ALWAYS set (explicit, else the DragonTTS
+        # default) so an OMITTED speed and an EXPLICIT speed==default yield
+        # identical audio — canonical_params collapses the latter to "absent",
+        # so they must sound the same or one cache key would serve
+        # different-speed audio.
+        params = params or {}
+        speed = params.get("speed")
         if speed is None:
             speed = PROVIDER_DEFAULTS.get("elevenlabs", {}).get("speed", 1.0)
-        vs = (params or {}).get("voice_settings")
+        vs = params.get("voice_settings")
         if isinstance(vs, dict) and vs:
             vs = dict(vs)
             vs.setdefault("speed", speed)
             return vs
-        return {"stability": 0.5, "similarity_boost": 0.75, "speed": speed}
+        settings: dict = {"speed": speed}
+        for key in ("stability", "similarity_boost"):
+            value = params.get(key)
+            if value is not None:
+                settings[key] = value
+        logger.info(f"ElevenLabs voice_settings: {settings}")
+        return settings
 
     def _get_pool(
         self,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Voice synthesis now applies configured speech speed and language settings when using ElevenLabs.
  - Improved support for language-specific voice generation.

- **Bug Fixes**
  - Resolved voice provider settings are now consistently passed to batch synthesis.
  - Added clearer logging of applied voice configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->