### PR TITLE
feat: Add inbound channels support

### DIFF
--- a/app/ai/voice/agents/breeze_buddy/dispatch/alerts.py
+++ b/app/ai/voice/agents/breeze_buddy/dispatch/alerts.py
@@ -220,6 +220,54 @@ async def raise_no_telephony_number(
     )
 
 
+async def raise_inbound_capacity_rejected(
+    telephony_number_id: str,
+    number: str,
+    reseller_id: Optional[str],
+    merchant_id: Optional[str],
+    maximum_channels: Optional[int],
+) -> None:
+    """
+    P1 — an inbound caller was turned away because the number had no free
+    channel.
+
+    Deliberately louder than the outbound capacity path, which only defers a
+    lead onto the schedule and costs nothing. Here a real customer heard a
+    busy message and hung up, so this is a revenue signal, not a queueing
+    signal. Throttled per number so a saturated DID pages once per 30 min
+    rather than once per rejected call.
+    """
+    await _send(
+        alert_name=f"inbound_capacity_rejected:{telephony_number_id}",
+        throttle_seconds=_THROTTLE_P1,
+        title="[P1] Breeze Buddy: inbound call rejected — no free channel",
+        fields=[
+            {"name": "Number", "value": number},
+            {"name": "Telephony number id", "value": telephony_number_id},
+            {"name": "Reseller", "value": reseller_id or "n/a"},
+            {"name": "Merchant", "value": merchant_id or "n/a"},
+            {"name": "maximum_channels", "value": str(maximum_channels)},
+            {
+                "name": "Effect",
+                "value": (
+                    "Callers to this number are hearing the busy message and "
+                    "being hung up on. Every rejection is a lost conversation."
+                ),
+            },
+            {
+                "name": "Action",
+                "value": (
+                    "Check `bb_channel_tokens_available` for this number. If "
+                    "saturation is real, raise `maximum_channels` (and the "
+                    "provider-side channel count) or add numbers. If tokens "
+                    "look wrong, suspect a leaked channel — check "
+                    "`channel_drift` alerts for the same number."
+                ),
+            },
+        ],
+    )
+
+
 async def raise_orphan_webhook(call_id: str, source: str) -> None:
     """
     P1 — telephony webhook arrived for a ``call_id`` that has no

--- a/app/ai/voice/agents/breeze_buddy/managers/calls.py
+++ b/app/ai/voice/agents/breeze_buddy/managers/calls.py
@@ -379,6 +379,55 @@ async def _release_number(number_id: str, provider: CallProvider):
         await decrement_telephony_number_channels(number_id)
 
 
+def _releases_capacity(lead: LeadCallTracker, provider: CallProvider) -> bool:
+    """
+    Whether this callback still owes the telephony number a channel back.
+
+    Outbound: the worker took a channel (``_acquire_number``) plus a Redis
+    dispatch token before dialling, for every dispatchable execution mode.
+
+    Inbound: only the Plivo answer path takes a channel
+    (``_admit_plivo_inbound_call``), and it does so as part of creating the
+    lead in PROCESSING. So release exactly once — when this callback is the
+    one moving the lead off PROCESSING. Anything already terminal when we
+    looked it up either never held a channel (CAPACITY_REJECTED, BLOCKED_*
+    and out-of-hours all write a FINISHED row at answer time, before or
+    instead of any acquire) or has already had it returned by an earlier
+    callback. Releasing for those invents capacity the number does not have,
+    which then lets us over-commit the trunk until someone notices.
+    """
+    if lead.call_direction == CallDirection.OUTBOUND:
+        return is_dispatchable(lead.execution_mode)
+    return provider == CallProvider.PLIVO and lead.status == LeadCallStatus.PROCESSING
+
+
+async def _release_call_resources(lead: LeadCallTracker) -> None:
+    """Give the telephony number its channel back once the call is over."""
+    if not lead.telephony_number_id:
+        logger.info(f"No telephony number id for lead: {lead.id}")
+        return
+
+    telephony_number = await get_telephony_number_by_id(lead.telephony_number_id)
+    if not telephony_number:
+        logger.error(
+            f"Could not find telephony number with id: "
+            f"{lead.telephony_number_id} to release."
+        )
+        return
+
+    if not _releases_capacity(lead, telephony_number.provider):
+        return
+
+    await _release_number(telephony_number.id, telephony_number.provider)
+
+    if lead.call_direction == CallDirection.OUTBOUND:
+        # Event-driven dispatch: return the token to the channel semaphore.
+        # Inbound never takes one — there the DB counter is the whole gate.
+        # Idempotent in aggregate — reconcile_channel_tokens trims any
+        # over-count caused by duplicate webhooks within 60s.
+        await release_channel_token(telephony_number.id)
+
+
 async def _retry_call(
     lead: LeadCallTracker, config: CallExecutionConfig, outcome: Optional[str] = None
 ):
@@ -514,20 +563,11 @@ async def reconcile_stuck_processing_leads():
                 call_end_time=datetime.now(timezone.utc),
             )
 
-            if (
-                locked_lead.telephony_number_id
-                and locked_lead.call_direction == CallDirection.OUTBOUND
-                and is_dispatchable(locked_lead.execution_mode)
-            ):
-                telephony_number = await get_telephony_number_by_id(
-                    locked_lead.telephony_number_id
-                )
-                if telephony_number:
-                    await _release_number(
-                        telephony_number.id, telephony_number.provider
-                    )
-                    # Event-driven dispatch: return token to channel semaphore.
-                    await release_channel_token(telephony_number.id)
+            # ``locked_lead`` is the pre-update snapshot: the lock was taken
+            # with expected_status=PROCESSING, so this sweep is by definition
+            # the callback transitioning the lead, and the inbound guard in
+            # _releases_capacity sees PROCESSING as intended.
+            await _release_call_resources(locked_lead)
 
             # Only retry outbound telephony calls - inbound and test calls should not be retried
             config = await _get_lead_config(locked_lead)
@@ -586,25 +626,10 @@ async def handle_call_completion(
             f"Failed to delete greeting audio from Redis for lead {lead.id}"
         )
 
-    # Always release telephony number (including transfers — bot leaves, cleanup happens here)
-    if (
-        lead.telephony_number_id
-        and lead.call_direction == CallDirection.OUTBOUND
-        and is_dispatchable(lead.execution_mode)
-    ):
-        telephony_number = await get_telephony_number_by_id(lead.telephony_number_id)
-        if telephony_number:
-            await _release_number(telephony_number.id, telephony_number.provider)
-            # Event-driven dispatch: return a token to the channel semaphore.
-            # Idempotent in aggregate — reconcile_channel_tokens trims any
-            # over-count caused by duplicate webhooks within 60s.
-            await release_channel_token(telephony_number.id)
-        else:
-            logger.error(
-                f"Could not find telephony number with id: {lead.telephony_number_id} to release."
-            )
-    else:
-        logger.info(f"No telephony number id for lead: {lead.id}")
+    # Always release telephony number (including transfers — bot leaves, cleanup happens here).
+    # Runs before the completion UPDATE below so the inbound guard in
+    # _releases_capacity still sees this lead as PROCESSING.
+    await _release_call_resources(lead)
 
     # Check if this is a transfer — for outcome override only
     is_transfer = (
@@ -689,25 +714,12 @@ async def handle_unanswered_calls(call_id: str):
             f"Failed to delete greeting audio from Redis for lead {lead.id}: {e}"
         )
 
-    # Release telephony number channel — do this before the FINISHED guard because the
-    # channel must be freed regardless of lead status. _release_number is idempotent
-    # (SQL uses GREATEST(0, ...)), so duplicate releases are safe.
-    if (
-        lead.telephony_number_id
-        and lead.call_direction == CallDirection.OUTBOUND
-        and is_dispatchable(lead.execution_mode)
-    ):
-        telephony_number = await get_telephony_number_by_id(lead.telephony_number_id)
-        if telephony_number:
-            await _release_number(telephony_number.id, telephony_number.provider)
-            # Event-driven dispatch: return token to channel semaphore.
-            await release_channel_token(telephony_number.id)
-        else:
-            logger.error(
-                f"Could not find telephony number with id: {lead.telephony_number_id} to release."
-            )
-    else:
-        logger.info(f"No telephony number id for lead: {lead.id}")
+    # Release telephony number channel — for outbound this runs before the FINISHED
+    # guard because the channel must be freed regardless of lead status, and
+    # _release_number is idempotent (SQL uses GREATEST(0, ...)). For inbound the
+    # guard in _releases_capacity is stricter: only a lead still PROCESSING here
+    # is holding a channel, so a duplicate or post-block callback releases nothing.
+    await _release_call_resources(lead)
 
     # Guard: if another callback already finished this lead, skip to avoid duplicate retries.
     # This happens when the lock race causes multiple calls for the same lead — each call's

--- a/app/ai/voice/agents/breeze_buddy/services/inbound_policy.py
+++ b/app/ai/voice/agents/breeze_buddy/services/inbound_policy.py
@@ -37,6 +37,14 @@ DEFAULT_TIMEZONE = "Asia/Kolkata"
 BLOCK_REDIRECT_PREFIX = "inbound_block_redirect:"
 BLOCK_REDIRECT_TTL = 120  # 2 minutes — enough for WS to connect
 
+# Outcome for inbound calls turned away because the telephony number had no
+# free channel. Distinct from BLOCKED_* (a policy decision the merchant
+# configured) because this one is a capacity failure we own: every occurrence
+# is a conversation lost to under-provisioning. Lives here, not in the answer
+# router, so the call-completion handlers can recognise it without importing
+# from the API layer.
+CAPACITY_REJECTED_OUTCOME = "CAPACITY_REJECTED"
+
 
 @dataclass
 class PolicyResult:
@@ -231,6 +239,7 @@ async def log_blocked_call(
     block_reason: Optional[str],
     block_message: Optional[str] = None,
     redirect_number: Optional[str] = None,
+    outcome: Optional[str] = None,
 ) -> None:
     """
     Log a blocked inbound call to lead_call_tracker.
@@ -238,11 +247,13 @@ async def log_blocked_call(
     Fire-and-forget: callers should wrap this in asyncio.create_task().
     Fails silently — never breaks call blocking behavior.
 
-    Outcome is set to BLOCKED_REJECT or BLOCKED_REDIRECT based on block_action.
-    Status is set to FINISHED since blocked calls are terminal.
+    Outcome defaults to BLOCKED_REJECT or BLOCKED_REDIRECT based on
+    block_action; pass ``outcome`` to record a non-policy refusal such as
+    CAPACITY_REJECTED. Status is set to FINISHED since blocked calls are
+    terminal.
     """
     try:
-        outcome = (
+        outcome = outcome or (
             "BLOCKED_REDIRECT"
             if block_action == InboundBlockAction.REDIRECT and redirect_number
             else "BLOCKED_REJECT"

--- a/app/api/routers/breeze_buddy/telephony/answer/handlers.py
+++ b/app/api/routers/breeze_buddy/telephony/answer/handlers.py
@@ -37,6 +37,9 @@ from urllib.parse import quote
 from fastapi import Request, Response
 from starlette.responses import HTMLResponse
 
+from app.ai.voice.agents.breeze_buddy.dispatch.alerts import (
+    raise_inbound_capacity_rejected,
+)
 from app.ai.voice.agents.breeze_buddy.ivr.selection import (
     IVR_CONFIG_CACHE_PREFIX,
     IVR_CONFIG_CACHE_TTL,
@@ -47,6 +50,7 @@ from app.ai.voice.agents.breeze_buddy.services.agent_router.client import (
     safe_allocate_pod,
 )
 from app.ai.voice.agents.breeze_buddy.services.inbound_policy import (
+    CAPACITY_REJECTED_OUTCOME,
     check_inbound_policy,
     log_blocked_call,
     set_block_redirect,
@@ -72,7 +76,9 @@ from app.database.accessor.breeze_buddy.lead_call_tracker import (
     create_lead_call_tracker,
 )
 from app.database.accessor.breeze_buddy.telephony_number import (
+    decrement_telephony_number_channels,
     get_telephony_number_by_number,
+    increment_telephony_number_channels,
 )
 from app.database.accessor.breeze_buddy.template import (
     get_all_templates_by_telephony_number_id,
@@ -82,6 +88,7 @@ from app.schemas import (
     IVR_OPTIONS_TEMPLATE,
     UNKNOWN_TEMPLATE,
     CallDirection,
+    CallProvider,
     InboundBlockAction,
     LeadCallStatus,
 )
@@ -229,6 +236,10 @@ async def resolve_call_templates(
         "ivr_greeting": ivr_greeting,
         "ivr_goodbye": ivr_goodbye,
         "reseller_id": first_template.reseller_id if first_template else None,
+        # Already fetched above; returned so the answer handler can gate on
+        # channel capacity without a second lookup, and so acquire and release
+        # agree on the same row (and therefore the same provider).
+        "telephony_number": telephony_number,
     }
 
 
@@ -413,11 +424,52 @@ def _build_block_response(
     )
 
 
+_INBOUND_CAPACITY_MESSAGE = (
+    "Sorry, all our agents are currently busy. Please try again later."
+)
+
+
+def _build_capacity_rejection_response() -> Response:
+    """Turn away a Plivo inbound call that found no free channel.
+
+    Answers the call, speaks, then hangs up — the same shape as the policy
+    block response above. The cheaper
+    ``<PreAnswer><Speak/></PreAnswer><Hangup reason="busy"/>`` is not billed,
+    but the call is never answered, so the message rides as early media, which
+    plenty of carriers strip. Delivering the message is the point of this
+    response, so we pay for the answered leg.
+    """
+    xml = f"""<?xml version="1.0" encoding="UTF-8"?>
+<Response>
+    <Speak>{html_escape(_INBOUND_CAPACITY_MESSAGE)}</Speak>
+    <Hangup/>
+</Response>"""
+    return HTMLResponse(content=xml, media_type="application/xml")
+
+
+async def _admit_plivo_inbound_call(telephony_number_id: str) -> bool:
+    """Take one channel for an inbound Plivo call.
+
+    Same gate outbound uses in ``_acquire_number``: the atomic
+    ``channels = channels + 1 WHERE channels < maximum_channels`` update, which
+    returns no row when the number is already at its ceiling. Both directions
+    therefore share one counter, so an inbound call genuinely reduces what
+    outbound can dial and vice versa.
+
+    Returns False when at capacity — and also when the UPDATE itself failed,
+    because the accessor collapses both into None. That makes inbound
+    admission fail *closed* on a DB outage, matching outbound (where the
+    worker simply defers the lead). The visible difference is that an inbound
+    caller hears the busy message instead of waiting invisibly in a queue.
+    """
+    return await increment_telephony_number_channels(telephony_number_id) is not None
+
+
 async def _create_inbound_lead_in_answer_handler(
     call_id: str,
     from_number: str,
     templates: list,
-) -> None:
+) -> bool:
     """Create an inbound lead in the answer handler before returning XML.
 
     This ensures the lead exists in the database even if the caller hangs
@@ -428,10 +480,15 @@ async def _create_inbound_lead_in_answer_handler(
     later in the WebSocket handler if the user chooses a different one.
 
     Errors are swallowed — the answer response must not be blocked by a
-    DB write failure.
+    DB write failure. The boolean is reported, not raised, purely so the
+    Plivo capacity gate can hand its channel back: without a PROCESSING row
+    there is nothing for the call-end callbacks or
+    ``reconcile_stuck_processing_leads`` to decrement, so a silently failed
+    insert would strand that channel forever. Callers that did not take a
+    channel can ignore the result, exactly as before.
     """
     if not templates:
-        return
+        return False
 
     first_template = templates[0]
     is_ivr_mode = len(templates) > 1
@@ -445,7 +502,7 @@ async def _create_inbound_lead_in_answer_handler(
 
     lead_id = str(uuid.uuid4())
     try:
-        await create_lead_call_tracker(
+        lead = await create_lead_call_tracker(
             id=lead_id,
             reseller_id=first_template.reseller_id,
             template=lead_template_name,
@@ -463,11 +520,17 @@ async def _create_inbound_lead_in_answer_handler(
             ),
             call_direction=CallDirection.INBOUND,
         )
+        if not lead:
+            # The accessor logs and returns None rather than raising.
+            logger.error(f"[Answer] Failed to create inbound lead for {call_id}")
+            return False
         logger.info(f"[Answer] Created inbound lead {lead_id} for call_id {call_id}")
+        return True
     except Exception as e:
         logger.error(
             f"[Answer] Failed to create inbound lead for call_id {call_id}: {e}"
         )
+        return False
 
 
 async def _build_provider_response(
@@ -826,15 +889,89 @@ async def _handle_provider_answer(request: Request, provider: str) -> Response:
                     {"id": str(t.id), "name": t.name} for t in allowed_templates
                 ]
 
+        # ── Channel capacity gate (Plivo inbound only) ────────────────────
+        # After policy, so a blacklisted / out-of-hours caller never consumes
+        # a channel and capacity rejections stay separable from policy blocks
+        # in analytics. Before the lead insert, so a rejected call leaves
+        # exactly one terminal row (written by log_blocked_call) instead of a
+        # PROCESSING row we would then have to close.
+        telephony_number = result.get("telephony_number")
+        gated_number_id: Optional[str] = None
+        if (
+            provider == "plivo"
+            and telephony_number is not None
+            and telephony_number.provider == CallProvider.PLIVO
+        ):
+            with timed_phase("acquire_inbound_channel"):
+                admitted = await _admit_plivo_inbound_call(str(telephony_number.id))
+
+            if not admitted:
+                logger.info(
+                    f"[{tag}] No free channel on {telephony_number.number} "
+                    f"for call {call_id}; rejecting as busy"
+                )
+                # Owner fields come off the same post-policy template list the
+                # lead would have been created from, so the rejected row lands
+                # in the same analytics scope as a served call.
+                allowed = result.get("templates") or []
+                first = allowed[0] if allowed else None
+                spawn_background_task(
+                    log_blocked_call(
+                        call_id=call_id,
+                        from_number=from_number,
+                        to_number=to_number,
+                        provider=provider,
+                        reseller_id=first.reseller_id if first else "",
+                        merchant_id=first.merchant_id if first else None,
+                        template_name=first.name if first else UNKNOWN_TEMPLATE,
+                        template_id=str(first.id) if first else None,
+                        telephony_number_id=str(telephony_number.id),
+                        block_action=None,
+                        block_reason="channel_capacity_exhausted",
+                        block_message=_INBOUND_CAPACITY_MESSAGE,
+                        outcome=CAPACITY_REJECTED_OUTCOME,
+                    ),
+                    name=f"log-capacity-rejection:{call_id}",
+                )
+                spawn_background_task(
+                    raise_inbound_capacity_rejected(
+                        telephony_number_id=str(telephony_number.id),
+                        number=telephony_number.number,
+                        reseller_id=first.reseller_id if first else None,
+                        merchant_id=first.merchant_id if first else None,
+                        maximum_channels=telephony_number.maximum_channels,
+                    ),
+                    name=f"alert-capacity-rejection:{call_id}",
+                )
+                return _build_capacity_rejection_response()
+
+            gated_number_id = str(telephony_number.id)
+
         # Create inbound lead early so it exists even if caller hangs up before
         # the WebSocket connects. This prevents orphan-call webhooks for normal
         # immediate-hangup behaviour.
+        #
+        # The lead is created PROCESSING, which is what the release side keys
+        # on: whichever callback moves it off PROCESSING returns the channel.
         with timed_phase("create_inbound_lead"):
-            await _create_inbound_lead_in_answer_handler(
+            lead_created = await _create_inbound_lead_in_answer_handler(
                 call_id=call_id,
                 from_number=from_number,
                 templates=result.get("templates", []),
             )
+
+        # No PROCESSING row means nothing will ever decrement the channel we
+        # just took — not the call-end callbacks (they look the lead up by
+        # call_id) and not reconcile_stuck_processing_leads (it scans for
+        # PROCESSING). Hand it straight back. The call itself is fine and
+        # proceeds as normal; it is simply untracked from here on.
+        if gated_number_id and not lead_created:
+            logger.error(
+                f"[{tag}] Inbound lead insert failed for call {call_id} after "
+                f"taking a channel on {gated_number_id}; returning the channel "
+                "so it is not stranded. The call will proceed untracked."
+            )
+            await decrement_telephony_number_channels(gated_number_id)
 
     with timed_phase("build_response"):
         return await _build_provider_response(


### PR DESCRIPTION
Extends the existing outbound channel capacity accounting (`telephony_numbers.channels` / `maximum_channels`) to inbound Plivo calls:

- Acquire capacity before streaming an inbound call; reject with "all agents busy" XML when the number is at capacity
- Slack alert on every capacity rejection (throttled per number)
- Release capacity on completion, setup failure, and stale-call cleanup
- Include active inbound Plivo calls in channel reconciliation
- Focused inbound capacity and lifecycle tests

Replaces #1006 (closed when the branch was rebuilt).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added channel-capacity controls for inbound calls, preventing calls from exceeding configured telephony limits.
  * Capacity-rejected calls now receive a distinct outcome and are recorded for analytics.
  * Added clearer handling for busy capacity, including operational alerts.
* **Bug Fixes**
  * Improved retry safety to prevent duplicate lead creation, policy checks, and resource allocation.
  * Ensured call resources are released correctly after completed, failed, unanswered, or rejected calls.
* **Tests**
  * Added coverage for capacity limits, concurrent calls, retries, failure handling, and resource recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->