### PR TITLE
feat(numbers): let merchants search and buy provider numbers

### DIFF
--- a/app/api/routers/breeze_buddy/numbers/rbac.py
+++ b/app/api/routers/breeze_buddy/numbers/rbac.py
@@ -44,25 +44,27 @@ def require_admin_or_reseller_access(
     current_user: UserInfo, operation: str = "perform this operation"
 ) -> None:
     """
-    Validate user is an admin or reseller.
+    Validate user is an admin, reseller, or merchant.
 
-    Gates provider number search/buy: purchasing spends real money, so it is
-    restricted to admin and reseller for now, not the full set resolve_buy_scope
-    is otherwise able to handle (merchant/user). resolve_buy_scope's
-    merchant/user branch stays in place, unused while this gate is active, so
-    widening access later is a one-line change here rather than new logic.
+    Gates provider number search/buy. Scope restriction per role is enforced
+    down the line by resolve_buy_scope, which owns tenant validation:
+    - admin: picks any (reseller_id, merchant_id) pair.
+    - reseller: reseller_id forced to their own umbrella; merchant_id, if
+      given, must sit under that umbrella.
+    - merchant/user: merchant_id forced into their JWT scope; reseller_id
+      is always derived from the merchant's record, never client-supplied.
 
     Raises:
-        HTTPException: 403 if user is neither admin nor reseller
+        HTTPException: 403 if user has no buy-capable role
     """
-    if current_user.role not in ("admin", "reseller"):
+    if current_user.role not in ("admin", "reseller", "merchant"):
         logger.warning(
             f"User {current_user.username} (role: {current_user.role}) "
             f"attempted to {operation}"
         )
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
-            detail=f"Admin or reseller access required to {operation}",
+            detail=f"Admin, reseller or merchant access required to {operation}",
         )
 
 

--- a/tests/test_numbers_rbac.py
+++ b/tests/test_numbers_rbac.py
@@ -323,15 +323,16 @@ async def test_user_role_follows_the_same_rules_as_merchant(patch_merchant_looku
 # ---------------------------------------------------------------------------
 # require_admin_or_reseller_access: the endpoint-level gate on search/buy.
 #
-# resolve_buy_scope above is still fully able to compute a valid scope for
-# merchant/user roles -- that logic is left in place, unused. This gate is
-# what currently keeps them from reaching it: buying spends real money, and
-# for now that is restricted to admin + reseller.
+# resolve_buy_scope above owns per-role scoping; this gate just guards the
+# entry. admin + reseller + merchant reach resolve_buy_scope; the plain
+# "user" role stays blocked because it carries no tenant scope of its own.
+# The function name is stale (kept to keep this change one line at the call
+# sites) -- the gate is "buy-capable role", not just admin/reseller.
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.parametrize("role", [UserRole.ADMIN, UserRole.RESELLER])
-def test_admin_and_reseller_pass_the_buy_gate(role):
+@pytest.mark.parametrize("role", [UserRole.ADMIN, UserRole.RESELLER, UserRole.MERCHANT])
+def test_admin_reseller_and_merchant_pass_the_buy_gate(role):
     from app.api.routers.breeze_buddy.numbers.rbac import (
         require_admin_or_reseller_access,
     )
@@ -339,8 +340,8 @@ def test_admin_and_reseller_pass_the_buy_gate(role):
     require_admin_or_reseller_access(make_user(role))  # must not raise
 
 
-@pytest.mark.parametrize("role", [UserRole.MERCHANT, UserRole.USER])
-def test_merchant_and_user_are_blocked_by_the_buy_gate(role):
+@pytest.mark.parametrize("role", [UserRole.USER])
+def test_plain_user_is_blocked_by_the_buy_gate(role):
     from app.api.routers.breeze_buddy.numbers.rbac import (
         require_admin_or_reseller_access,
     )


### PR DESCRIPTION
## Why

PR #897 shipped search + buy for provider numbers but gated both endpoints on `require_admin_or_reseller_access`, blocking merchant tokens. The original code comment in `rbac.py` already promised this widening was a one-line change — `resolve_buy_scope` implements merchant scoping and was left unreachable:

> resolve_buy_scope's merchant/user branch stays in place, unused while this gate is active, so widening access later is a one-line change here rather than new logic.

This is that one-line change.

## What

Add `"merchant"` to the role tuple in `require_admin_or_reseller_access`. Nothing else moves:

- The gate's only job is to keep the `user` role out (no tenant scope of its own).
- All actual scoping happens down the line in `resolve_buy_scope`, which already handles merchant tokens correctly:
  - `merchant_id` forced into the caller's JWT `merchant_ids` scope (or auto-picks when scope size is 1, 400s when ambiguous, 403s when out of scope).
  - `reseller_id` always derived from the resolved merchant's record — never client-supplied.

## Diff

- `app/api/routers/breeze_buddy/numbers/rbac.py` — gate now allows merchant; docstring updated to describe the per-role behaviour `resolve_buy_scope` already enforces (the function name is intentionally left stale — renaming would touch the import sites in `__init__.py` and bloat this PR).
- `tests/test_numbers_rbac.py` — gate tests updated: `admin / reseller / merchant` now pass, `user` still 403s.

## Verification

```
uv run --extra dev pytest tests/test_numbers_rbac.py -q      # 25 passed
uv run --extra dev pytest tests/test_buy_provider_number.py -q # 17 passed
uv run --extra dev black . --check                            # clean
uv run --extra dev isort . --profile black --check            # clean
```

(pyrefly was skipped locally only because the repo's own `pyproject.toml` excludes `**/.worktrees/**` paths where this worktree lives — code unchanged by that exclusion.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Merchant accounts can now access number purchasing alongside admin and reseller accounts.

* **Bug Fixes**
  * Standard user access remains blocked with an appropriate permission error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->