### PR TITLE
refactor(breeze-buddy): unify VAD/TTS/STT/LLM config precedence into shared resolver

### DIFF
--- a/app/ai/voice/agents/breeze_buddy/agent/pipeline.py
+++ b/app/ai/voice/agents/breeze_buddy/agent/pipeline.py
@@ -9,7 +9,6 @@ from pipecat.audio.turn.smart_turn.local_smart_turn_v3 import (
     LocalSmartTurnAnalyzerV3,
 )
 from pipecat.audio.vad.silero import SileroVADAnalyzer
-from pipecat.audio.vad.vad_analyzer import VADParams
 from pipecat.observers.loggers.llm_log_observer import LLMLogObserver
 from pipecat.observers.loggers.metrics_log_observer import MetricsLogObserver
 from pipecat.observers.loggers.transcription_log_observer import (
@@ -61,7 +60,10 @@ from app.ai.voice.agents.breeze_buddy.template.types import (
     SmartTurnConfig,
     TurnDetectionMode,
 )
-from app.ai.voice.agents.breeze_buddy.template.vad import TELEPHONY_SAMPLE_RATE
+from app.ai.voice.agents.breeze_buddy.template.vad import (
+    TELEPHONY_SAMPLE_RATE,
+    build_smart_turn_trigger_vad_params,
+)
 from app.ai.voice.agents.breeze_buddy.tts import get_tts_service, resolve_voice_config
 from app.ai.voice.llm.realtime import get_realtime_llm_service
 from app.core.config.static import (
@@ -353,24 +355,23 @@ async def build_pipeline(
     turn_detection_mode = (
         stt_config.turn_detection if stt_config else TurnDetectionMode.STT_NATIVE
     )
-    # STT_NATIVE fires immediately (0.0s). Only TIMEOUT honours configured value.
-    # The STTConfiguration validator already enforces this, but be explicit here.
-    user_speech_timeout = (
-        stt_config.user_speech_timeout
-        if stt_config and turn_detection_mode == TurnDetectionMode.TIMEOUT
-        else 0.0
-    )
+    # STT_NATIVE fires immediately (0.0s), TIMEOUT honours the configured value —
+    # already enforced by STTConfiguration's _normalize_user_speech_timeout
+    # model_validator (template/types.py), so no ternary is needed here.
+    user_speech_timeout = stt_config.user_speech_timeout if stt_config else 0.0
 
-    # SmartTurn mode: auto-create Silero VAD (stop_secs=0.2) as trigger if no
-    # external VAD was provided.  SmartTurn needs is_speech signal from VAD.
-    # When no external VAD exists this is the telephony path (8 kHz sample rate).
+    # SmartTurn mode: auto-create Silero VAD as trigger if no external VAD was
+    # provided. SmartTurn needs an is_speech signal from VAD. When no external
+    # VAD exists this is the telephony path (8 kHz sample rate). Params are
+    # resolved template > Redis, same precedence as every other VAD build site.
     if turn_detection_mode == TurnDetectionMode.SMART_TURN and vad_analyzer is None:
+        vad_params = await build_smart_turn_trigger_vad_params(configurations)
         vad_analyzer = SileroVADAnalyzer(
             sample_rate=TELEPHONY_SAMPLE_RATE,
-            params=VADParams(stop_secs=0.2),
+            params=vad_params,
         )
         logger.info(
-            "SmartTurn mode: auto-created Silero VAD (stop_secs=0.2) as trigger"
+            f"SmartTurn mode: auto-created Silero VAD (params={vad_params}) as trigger"
         )
 
     # --- User turn start strategies ---

--- a/app/ai/voice/agents/breeze_buddy/llm/__init__.py
+++ b/app/ai/voice/agents/breeze_buddy/llm/__init__.py
@@ -39,6 +39,11 @@ from app.core.config.dynamic import (
     OPENAI_MAX_COMPLETION_TOKENS,
     OPENAI_TEMPERATURE,
 )
+from app.core.config.resolver import (
+    FieldSpec,
+    or_none,
+    resolve_fields,
+)
 from app.core.config.static import (
     AZURE_BREEZE_BUDDY_OPENAI_MODEL,
     AZURE_OPENAI_API_KEY,
@@ -59,14 +64,8 @@ async def _resolve_azure(
     turns). Voice runs each call in its own subprocess and gets nothing
     from connection sharing — keep voice on the stock pipecat service.
     """
-    # Endpoint: template override or env default
-    endpoint = (
-        llm_config.endpoint
-        if llm_config and llm_config.endpoint
-        else AZURE_OPENAI_ENDPOINT
-    )
-
-    # API key: resolve from named config key or use env default
+    # API key: resolve from named config key or use env default. Not a tier
+    # chain — the *name* of the dynamic key is itself template-supplied.
     if llm_config and llm_config.endpoint and not llm_config.api_key_name:
         raise ValueError(
             "api_key_name is required when a custom endpoint is provided for Azure"
@@ -81,20 +80,46 @@ async def _resolve_azure(
     else:
         api_key = AZURE_OPENAI_API_KEY
 
-    model = (
-        llm_config.model
-        if llm_config and llm_config.model
-        else AZURE_BREEZE_BUDDY_OPENAI_MODEL
-    )
-    temperature = (
-        llm_config.temperature
-        if llm_config and llm_config.temperature is not None
-        else await BREEZE_BUDDY_AZURE_TEMPERATURE()
-    )
-    max_tokens = (
-        llm_config.max_tokens
-        if llm_config and llm_config.max_tokens
-        else await BREEZE_BUDDY_AZURE_MAX_COMPLETION_TOKENS()
+    resolved = await resolve_fields(
+        [
+            FieldSpec(
+                "endpoint",
+                tiers=[
+                    lambda: or_none(llm_config.endpoint if llm_config else None),
+                    lambda: AZURE_OPENAI_ENDPOINT,
+                ],
+            ),
+            FieldSpec(
+                "model",
+                tiers=[
+                    lambda: or_none(llm_config.model if llm_config else None),
+                    lambda: AZURE_BREEZE_BUDDY_OPENAI_MODEL,
+                ],
+            ),
+            FieldSpec(
+                "temperature",
+                tiers=[
+                    lambda: llm_config.temperature if llm_config else None,
+                    BREEZE_BUDDY_AZURE_TEMPERATURE,
+                ],
+            ),
+            FieldSpec(
+                "max_tokens",
+                tiers=[
+                    lambda: or_none(llm_config.max_tokens if llm_config else None),
+                    BREEZE_BUDDY_AZURE_MAX_COMPLETION_TOKENS,
+                ],
+            ),
+            FieldSpec(
+                "function_call_timeout_secs",
+                tiers=[
+                    lambda: or_none(
+                        llm_config.function_call_timeout_secs if llm_config else None
+                    ),
+                    10.0,
+                ],
+            ),
+        ]
     )
 
     # Extract reasoning_effort from thinking config
@@ -105,16 +130,12 @@ async def _resolve_azure(
     return build_azure_llm(
         AzureConfig(
             api_key=api_key,
-            endpoint=endpoint,
-            model=model,
-            temperature=temperature,
-            max_tokens=max_tokens,
+            endpoint=resolved["endpoint"],
+            model=resolved["model"],
+            temperature=resolved["temperature"],
+            max_tokens=resolved["max_tokens"],
             reasoning_effort=reasoning_effort,
-            function_call_timeout_secs=(
-                llm_config.function_call_timeout_secs
-                if llm_config and llm_config.function_call_timeout_secs
-                else 10.0
-            ),
+            function_call_timeout_secs=resolved["function_call_timeout_secs"],
         ),
         pooled=pooled,
     )
@@ -145,16 +166,39 @@ async def _resolve_openai(llm_config: LLMConfiguration | None) -> OpenAILLMServi
     else:
         api_key = OPENAI_API_KEY
 
-    model = llm_config.model if llm_config and llm_config.model else OPENAI_MODEL
-    temperature = (
-        llm_config.temperature
-        if llm_config and llm_config.temperature is not None
-        else await OPENAI_TEMPERATURE()
-    )
-    max_tokens = (
-        llm_config.max_tokens
-        if llm_config and llm_config.max_tokens
-        else await OPENAI_MAX_COMPLETION_TOKENS()
+    resolved = await resolve_fields(
+        [
+            FieldSpec(
+                "model",
+                tiers=[
+                    lambda: or_none(llm_config.model if llm_config else None),
+                    lambda: OPENAI_MODEL,
+                ],
+            ),
+            FieldSpec(
+                "temperature",
+                tiers=[
+                    lambda: llm_config.temperature if llm_config else None,
+                    OPENAI_TEMPERATURE,
+                ],
+            ),
+            FieldSpec(
+                "max_tokens",
+                tiers=[
+                    lambda: or_none(llm_config.max_tokens if llm_config else None),
+                    OPENAI_MAX_COMPLETION_TOKENS,
+                ],
+            ),
+            FieldSpec(
+                "function_call_timeout_secs",
+                tiers=[
+                    lambda: or_none(
+                        llm_config.function_call_timeout_secs if llm_config else None
+                    ),
+                    10.0,
+                ],
+            ),
+        ]
     )
 
     reasoning_effort = None
@@ -165,48 +209,57 @@ async def _resolve_openai(llm_config: LLMConfiguration | None) -> OpenAILLMServi
         OpenAIConfig(
             api_key=api_key,
             base_url=base_url,
-            model=model,
-            temperature=temperature,
-            max_tokens=max_tokens,
+            model=resolved["model"],
+            temperature=resolved["temperature"],
+            max_tokens=resolved["max_tokens"],
             reasoning_effort=reasoning_effort,
-            function_call_timeout_secs=(
-                llm_config.function_call_timeout_secs
-                if llm_config and llm_config.function_call_timeout_secs
-                else 10.0
-            ),
+            function_call_timeout_secs=resolved["function_call_timeout_secs"],
         )
     )
 
 
 async def _resolve_vertex(llm_config: LLMConfiguration) -> GoogleVertexLLMService:
     """Build Vertex (Gemini) LLM — all params required from template config."""
-    credentials_json = await GOOGLE_VERTEX_CREDENTIALS_JSON()
-    project_id = await GOOGLE_VERTEX_PROJECT_ID()
-
-    if not credentials_json:
-        raise ValueError(
-            "GOOGLE_VERTEX_CREDENTIALS_JSON is required for google_vertex provider"
-        )
-    if not project_id:
-        raise ValueError(
-            "GOOGLE_VERTEX_PROJECT_ID is required for google_vertex provider"
-        )
-    if not llm_config.model:
-        raise ValueError(
-            "model is required in LLMConfiguration for google_vertex provider"
-        )
-    if not llm_config.region:
-        raise ValueError(
-            "region is required in LLMConfiguration for google_vertex provider"
-        )
-    if llm_config.temperature is None:
-        raise ValueError(
-            "temperature is required in LLMConfiguration for google_vertex provider"
-        )
-    if not llm_config.max_tokens:
-        raise ValueError(
-            "max_tokens is required in LLMConfiguration for google_vertex provider"
-        )
+    resolved = await resolve_fields(
+        [
+            FieldSpec(
+                "credentials_json",
+                tiers=[GOOGLE_VERTEX_CREDENTIALS_JSON],
+                required=True,
+                error_message="GOOGLE_VERTEX_CREDENTIALS_JSON is required for google_vertex provider",
+            ),
+            FieldSpec(
+                "project_id",
+                tiers=[GOOGLE_VERTEX_PROJECT_ID],
+                required=True,
+                error_message="GOOGLE_VERTEX_PROJECT_ID is required for google_vertex provider",
+            ),
+            FieldSpec(
+                "model",
+                tiers=[lambda: llm_config.model],
+                required=True,
+                error_message="model is required in LLMConfiguration for google_vertex provider",
+            ),
+            FieldSpec(
+                "region",
+                tiers=[lambda: llm_config.region],
+                required=True,
+                error_message="region is required in LLMConfiguration for google_vertex provider",
+            ),
+            FieldSpec(
+                "temperature",
+                tiers=[lambda: llm_config.temperature],
+                required=True,
+                error_message="temperature is required in LLMConfiguration for google_vertex provider",
+            ),
+            FieldSpec(
+                "max_tokens",
+                tiers=[lambda: llm_config.max_tokens],
+                required=True,
+                error_message="max_tokens is required in LLMConfiguration for google_vertex provider",
+            ),
+        ]
+    )
 
     # Extract thinking config
     thinking_budget = None
@@ -225,12 +278,12 @@ async def _resolve_vertex(llm_config: LLMConfiguration) -> GoogleVertexLLMServic
 
     return build_vertex_llm(
         VertexConfig(
-            credentials_json=credentials_json,
-            project_id=project_id,
-            location=llm_config.region,
-            model=llm_config.model,
-            temperature=llm_config.temperature,
-            max_tokens=llm_config.max_tokens,
+            credentials_json=resolved["credentials_json"],
+            project_id=resolved["project_id"],
+            location=resolved["region"],
+            model=resolved["model"],
+            temperature=resolved["temperature"],
+            max_tokens=resolved["max_tokens"],
             thinking_budget=thinking_budget,
             thinking_level=thinking_level,
             function_call_timeout_secs=(
@@ -246,33 +299,46 @@ async def _resolve_claude_vertex(
     llm_config: LLMConfiguration, *, pooled: bool = False
 ) -> VertexAnthropicLLMService:
     """Build Claude on Vertex AI — all params required from template config."""
-    credentials_json = await GOOGLE_VERTEX_CREDENTIALS_JSON()
-    project_id = await GOOGLE_VERTEX_PROJECT_ID()
-
-    if not credentials_json:
-        raise ValueError(
-            "GOOGLE_VERTEX_CREDENTIALS_JSON is required for claude_vertex provider"
-        )
-    if not project_id:
-        raise ValueError(
-            "GOOGLE_VERTEX_PROJECT_ID is required for claude_vertex provider"
-        )
-    if not llm_config.model:
-        raise ValueError(
-            "model is required in LLMConfiguration for claude_vertex provider"
-        )
-    if not llm_config.region:
-        raise ValueError(
-            "region is required in LLMConfiguration for claude_vertex provider"
-        )
-    if llm_config.temperature is None:
-        raise ValueError(
-            "temperature is required in LLMConfiguration for claude_vertex provider"
-        )
-    if not llm_config.max_tokens:
-        raise ValueError(
-            "max_tokens is required in LLMConfiguration for claude_vertex provider"
-        )
+    resolved = await resolve_fields(
+        [
+            FieldSpec(
+                "credentials_json",
+                tiers=[GOOGLE_VERTEX_CREDENTIALS_JSON],
+                required=True,
+                error_message="GOOGLE_VERTEX_CREDENTIALS_JSON is required for claude_vertex provider",
+            ),
+            FieldSpec(
+                "project_id",
+                tiers=[GOOGLE_VERTEX_PROJECT_ID],
+                required=True,
+                error_message="GOOGLE_VERTEX_PROJECT_ID is required for claude_vertex provider",
+            ),
+            FieldSpec(
+                "model",
+                tiers=[lambda: llm_config.model],
+                required=True,
+                error_message="model is required in LLMConfiguration for claude_vertex provider",
+            ),
+            FieldSpec(
+                "region",
+                tiers=[lambda: llm_config.region],
+                required=True,
+                error_message="region is required in LLMConfiguration for claude_vertex provider",
+            ),
+            FieldSpec(
+                "temperature",
+                tiers=[lambda: llm_config.temperature],
+                required=True,
+                error_message="temperature is required in LLMConfiguration for claude_vertex provider",
+            ),
+            FieldSpec(
+                "max_tokens",
+                tiers=[lambda: llm_config.max_tokens],
+                required=True,
+                error_message="max_tokens is required in LLMConfiguration for claude_vertex provider",
+            ),
+        ]
+    )
 
     # Extract thinking config
     thinking_enabled = False
@@ -288,12 +354,12 @@ async def _resolve_claude_vertex(
 
     return build_claude_vertex_llm(
         ClaudeVertexConfig(
-            credentials_json=credentials_json,
-            project_id=project_id,
-            region=llm_config.region,
-            model=llm_config.model,
-            temperature=llm_config.temperature,
-            max_tokens=llm_config.max_tokens,
+            credentials_json=resolved["credentials_json"],
+            project_id=resolved["project_id"],
+            region=resolved["region"],
+            model=resolved["model"],
+            temperature=resolved["temperature"],
+            max_tokens=resolved["max_tokens"],
             thinking_enabled=thinking_enabled,
             thinking_budget_tokens=thinking_budget_tokens,
             function_call_timeout_secs=(

--- a/app/ai/voice/agents/breeze_buddy/stt/__init__.py
+++ b/app/ai/voice/agents/breeze_buddy/stt/__init__.py
@@ -2,7 +2,11 @@
 
 Central routing: accepts a normalized ``STTConfiguration`` from the template
 and casts it to the provider-specific builder config. Defaults are baked into
-the Pydantic models — no env/dynamic config needed (except API keys).
+the Pydantic models for Deepgram, so it needs no env/dynamic lookup. Soniox
+falls back to static env config; Sarvam falls back to Redis-backed dynamic
+config (including a few fields — ``prompt``, ``vad_signals``,
+``high_vad_sensitivity`` — that have no template override at all and are
+always Redis-sourced).
 """
 
 from __future__ import annotations
@@ -33,6 +37,11 @@ from app.core.config.dynamic import (
     BB_SARVAM_STT_MODEL,
     BB_SARVAM_STT_PROMPT,
     BB_SARVAM_STT_VAD_SIGNALS,
+)
+from app.core.config.resolver import (
+    FieldSpec,
+    or_none,
+    resolve_fields,
 )
 from app.core.config.static import (
     BREEZE_BUDDY_SONIOX_CONTEXT,
@@ -118,23 +127,45 @@ async def create_stt_from_config(config: STTConfiguration):
             raise ValueError("SONIOX_API_KEY is required for soniox STT")
 
         sx = config.soniox
-        effective_context = (
-            sx.context if sx and sx.context else BREEZE_BUDDY_SONIOX_CONTEXT
+        language = _normalize_language(config.language)
+
+        resolved = await resolve_fields(
+            [
+                FieldSpec(
+                    "context",
+                    tiers=[
+                        lambda: or_none(sx.context if sx else None),
+                        lambda: BREEZE_BUDDY_SONIOX_CONTEXT,
+                    ],
+                ),
+                FieldSpec(
+                    "model",
+                    tiers=[
+                        lambda: or_none(sx.model if sx else None),
+                        lambda: BREEZE_BUDDY_SONIOX_MODEL,
+                    ],
+                ),
+                FieldSpec(
+                    "language_hints",
+                    tiers=[
+                        lambda: or_none(language),
+                        lambda: BREEZE_BUDDY_SONIOX_LANGUAGE_HINTS,
+                    ],
+                ),
+            ]
         )
-        effective_model = sx.model if sx and sx.model else BREEZE_BUDDY_SONIOX_MODEL
 
         if sx and sx.context:
             logger.info("Using template-specific Soniox context")
 
-        language = _normalize_language(config.language)
         enable_lang_id = sx.enable_language_identification if sx else None
         return build_soniox_stt(
             SonioxConfig(
                 api_key=SONIOX_API_KEY,
-                model=effective_model,
+                model=resolved["model"],
                 vad_force_turn_endpoint=BREEZE_BUDDY_SONIOX_VAD_FORCE_TURN_ENDPOINT,
-                language_hints=language or BREEZE_BUDDY_SONIOX_LANGUAGE_HINTS,
-                context_json=effective_context,
+                language_hints=resolved["language_hints"],
+                context_json=resolved["context"],
                 max_endpoint_delay_ms=BREEZE_BUDDY_SONIOX_MAX_ENDPOINT_DELAY_MS,
                 log_context="Breeze Buddy",
                 language_hints_strict=bool(language),
@@ -147,22 +178,40 @@ async def create_stt_from_config(config: STTConfiguration):
             raise ValueError("SARVAM_API_KEY is required for sarvam STT")
 
         sv = config.sarvam
-        bb_model = sv.model if sv and sv.model else await BB_SARVAM_STT_MODEL()
-        bb_lang = (
-            sv.language_code
-            if sv and sv.language_code
-            else await BB_SARVAM_STT_LANGUAGE_CODE()
+        resolved = await resolve_fields(
+            [
+                FieldSpec(
+                    "model",
+                    tiers=[
+                        lambda: or_none(sv.model if sv else None),
+                        BB_SARVAM_STT_MODEL,
+                    ],
+                ),
+                FieldSpec(
+                    "language_code",
+                    tiers=[
+                        lambda: or_none(sv.language_code if sv else None),
+                        BB_SARVAM_STT_LANGUAGE_CODE,
+                    ],
+                ),
+                # No template override exists for these — always Redis-sourced.
+                FieldSpec("prompt", tiers=[BB_SARVAM_STT_PROMPT]),
+                FieldSpec("vad_signals", tiers=[BB_SARVAM_STT_VAD_SIGNALS]),
+                FieldSpec(
+                    "high_vad_sensitivity", tiers=[BB_SARVAM_STT_HIGH_VAD_SENSITIVITY]
+                ),
+            ]
         )
 
         return build_sarvam_stt(
             SarvamConfig(
                 api_key=SARVAM_API_KEY,
-                model=bb_model,
+                model=resolved["model"],
                 sample_rate=SAMPLE_RATE,
-                language_code=bb_lang,
-                prompt=await BB_SARVAM_STT_PROMPT(),
-                vad_signals=await BB_SARVAM_STT_VAD_SIGNALS(),
-                high_vad_sensitivity=await BB_SARVAM_STT_HIGH_VAD_SENSITIVITY(),
+                language_code=resolved["language_code"],
+                prompt=resolved["prompt"],
+                vad_signals=resolved["vad_signals"],
+                high_vad_sensitivity=resolved["high_vad_sensitivity"],
             )
         )
 

--- a/app/ai/voice/agents/breeze_buddy/template/transition.py
+++ b/app/ai/voice/agents/breeze_buddy/template/transition.py
@@ -89,7 +89,7 @@ async def transition_handler(
         reset_vad_to_default(context)
 
         # Get node-specific VAD config and apply it
-        apply_node_vad_config(context, transition_to)
+        await apply_node_vad_config(context, transition_to)
 
         # Determine user_speech_timeout from input collection config BEFORE reset.
         # This is passed to both reset and apply so there's never a window where

--- a/app/ai/voice/agents/breeze_buddy/template/vad.py
+++ b/app/ai/voice/agents/breeze_buddy/template/vad.py
@@ -12,13 +12,17 @@ For the full mute_stt/unmute_stt routing (VAD → TranscriptionGate fallback),
 see handlers/internal/stt.py.
 """
 
-from typing import Optional
+from typing import Callable, Optional, Union
 
 from pipecat.audio.vad.silero import SileroVADAnalyzer
-from pipecat.audio.vad.vad_analyzer import VADParams
+from pipecat.audio.vad.vad_analyzer import VADAnalyzer, VADParams
 
 from app.ai.voice.agents.breeze_buddy.template.context import TemplateContext
-from app.ai.voice.agents.breeze_buddy.template.types import TemplateModel
+from app.ai.voice.agents.breeze_buddy.template.types import (
+    ConfigurationModel,
+    TemplateModel,
+    VadConfig,
+)
 from app.core.config.dynamic import (
     BB_DAILY_VAD_CONFIDENCE,
     BB_DAILY_VAD_MIN_VOLUME,
@@ -30,11 +34,19 @@ from app.core.config.dynamic import (
     BB_TELEPHONY_VAD_STOP_SECS,
     BREEZE_BUDDY_ENABLE_VAD,
 )
+from app.core.config.resolver import FieldSpec, resolve_fields
 from app.core.logger import logger
 
 # Constants
 TELEPHONY_SAMPLE_RATE = 8000
 DAILY_SAMPLE_RATE = 16000
+
+# SmartTurn's trigger VAD is deliberately snappier than the standalone VAD
+# path: the ML model decides where the turn actually ends, so the trigger only
+# has to fire it. Kept as a literal rather than reading BB_TELEPHONY_VAD_* —
+# that flag is tuned for the plain-VAD/timeout path, and retuning it there must
+# not silently change SmartTurn latency.
+SMART_TURN_TRIGGER_STOP_SECS = 0.2
 
 
 async def create_daily_vad_params() -> VADParams:
@@ -57,7 +69,31 @@ async def create_telephony_vad_params() -> VADParams:
     )
 
 
-def _layer_template_vad(
+_VAD_FIELDS = ("confidence", "start_secs", "stop_secs", "min_volume")
+
+
+async def _resolve_vad_params(
+    override_getter: Callable[[str], Optional[float]], base: VADParams
+) -> VADParams:
+    """Merge a higher-tier override (per-field, may be partial) over ``base``.
+
+    Shared by every VAD merge site — the only thing that differs is what
+    ``override_getter`` reads from (a template's ``vad_config``, a node's
+    ``vad_config``, ...) and what ``base`` represents (Redis mode-defaults,
+    the live analyzer's current params, ...).
+    """
+    specs = [
+        FieldSpec(
+            name=f,
+            tiers=[lambda f=f: override_getter(f), lambda f=f: getattr(base, f)],
+        )
+        for f in _VAD_FIELDS
+    ]
+    resolved = await resolve_fields(specs)
+    return VADParams(**resolved)
+
+
+async def _layer_template_vad(
     template: Optional[TemplateModel], defaults: VADParams
 ) -> VADParams:
     """Layer template.configurations.vad_config per-field over defaults.
@@ -74,38 +110,38 @@ def _layer_template_vad(
         return defaults
 
     logger.info(f"Template VAD config: {template_vad}")
-    return VADParams(
-        confidence=(
-            template_vad.confidence
-            if template_vad.confidence is not None
-            else defaults.confidence
-        ),
-        start_secs=(
-            template_vad.start_secs
-            if template_vad.start_secs is not None
-            else defaults.start_secs
-        ),
-        stop_secs=(
-            template_vad.stop_secs
-            if template_vad.stop_secs is not None
-            else defaults.stop_secs
-        ),
-        min_volume=(
-            template_vad.min_volume
-            if template_vad.min_volume is not None
-            else defaults.min_volume
-        ),
-    )
+    return await _resolve_vad_params(lambda f: getattr(template_vad, f, None), defaults)
 
 
 async def build_daily_vad_params(template: Optional[TemplateModel]) -> VADParams:
     """Build VAD params for Daily mode: template > Redis `BB_DAILY_VAD_*`."""
-    return _layer_template_vad(template, await create_daily_vad_params())
+    return await _layer_template_vad(template, await create_daily_vad_params())
 
 
 async def build_telephony_vad_params(template: Optional[TemplateModel]) -> VADParams:
     """Build VAD params for telephony mode: template > Redis `BB_TELEPHONY_VAD_*`."""
-    return _layer_template_vad(template, await create_telephony_vad_params())
+    return await _layer_template_vad(template, await create_telephony_vad_params())
+
+
+async def build_smart_turn_trigger_vad_params(
+    configurations: Optional[ConfigurationModel],
+) -> VADParams:
+    """Build VAD params for SmartTurn's auto-created trigger VAD.
+
+    SmartTurn needs an ``is_speech`` signal from a VAD; when the pipeline has
+    no externally-supplied analyzer it creates one itself. Precedence is
+    ``template > SmartTurn trigger defaults`` — a template may tune the trigger,
+    but the fallback tier is this path's own defaults
+    (``SMART_TURN_TRIGGER_STOP_SECS``), not the shared ``BB_TELEPHONY_VAD_*``
+    flags that drive the standalone VAD path.
+
+    Takes a bare ``configurations`` (not a ``TemplateModel``) because the
+    pipeline has already unwrapped the template by this point.
+    """
+    return await _resolve_vad_params(
+        lambda f: getattr(getattr(configurations, "vad_config", None), f, None),
+        VADParams(stop_secs=SMART_TURN_TRIGGER_STOP_SECS),
+    )
 
 
 async def create_vad_analyzer(
@@ -165,7 +201,7 @@ def reset_vad_to_default(context: TemplateContext):
         )
 
 
-def apply_node_vad_config(context: TemplateContext, node_name: str):
+async def apply_node_vad_config(context: TemplateContext, node_name: str) -> None:
     """Apply node-specific VAD config if it exists."""
     bot = context.bot
     if not bot.vad_analyzer:
@@ -182,18 +218,26 @@ def apply_node_vad_config(context: TemplateContext, node_name: str):
     # NodeConfig is a TypedDict, so access vad_config as a dict key
     vad_config = node_config.get("vad_config")
     if vad_config:
-        _apply_vad_config_to_analyzer(bot.vad_analyzer, vad_config, context.call_sid)
+        await _apply_vad_config_to_analyzer(
+            bot.vad_analyzer, vad_config, context.call_sid
+        )
 
 
-def _get_vad_config_value(vad_config, key: str):
+def _get_vad_config_value(
+    vad_config: Union[VadConfig, dict, None], key: str
+) -> Optional[float]:
     """Get a value from vad_config, supporting both dict and object access."""
     if isinstance(vad_config, dict):
         return vad_config.get(key)
     return getattr(vad_config, key, None)
 
 
-def _apply_vad_config_to_analyzer(vad_analyzer, vad_config, call_sid: str):
-    """Apply VAD config to the VAD analyzer.
+async def _apply_vad_config_to_analyzer(
+    vad_analyzer: VADAnalyzer,
+    vad_config: Union[VadConfig, dict, None],
+    call_sid: str,
+) -> None:
+    """Apply node-level VAD config (node > current live params) to the analyzer.
 
     Supports both dict and object access patterns for vad_config.
     Uses set_params() to ensure internal frame counts are recalculated.
@@ -205,27 +249,11 @@ def _apply_vad_config_to_analyzer(vad_analyzer, vad_config, call_sid: str):
         "min_volume": vad_analyzer.params.min_volume,
     }
 
-    confidence = _get_vad_config_value(vad_config, "confidence")
-    start_secs = _get_vad_config_value(vad_config, "start_secs")
-    stop_secs = _get_vad_config_value(vad_config, "stop_secs")
-    min_volume = _get_vad_config_value(vad_config, "min_volume")
-
-    vad_analyzer.set_params(
-        VADParams(
-            confidence=(
-                confidence if confidence is not None else vad_analyzer.params.confidence
-            ),
-            start_secs=(
-                start_secs if start_secs is not None else vad_analyzer.params.start_secs
-            ),
-            stop_secs=(
-                stop_secs if stop_secs is not None else vad_analyzer.params.stop_secs
-            ),
-            min_volume=(
-                min_volume if min_volume is not None else vad_analyzer.params.min_volume
-            ),
-        )
+    current = vad_analyzer.params
+    new_params_obj = await _resolve_vad_params(
+        lambda f: _get_vad_config_value(vad_config, f), current
     )
+    vad_analyzer.set_params(new_params_obj)
 
     new_params = {
         "confidence": vad_analyzer.params.confidence,

--- a/app/ai/voice/agents/breeze_buddy/tts/__init__.py
+++ b/app/ai/voice/agents/breeze_buddy/tts/__init__.py
@@ -48,6 +48,7 @@ from app.core.config.dynamic import (
     BB_VOICE_PROVIDER_DEFAULTS,
     DRAGONTTS_URL,
 )
+from app.core.config.resolver import FieldSpec, resolve_fields
 from app.core.config.static import (
     CARTESIA_API_KEY,
     ELEVENLABS_API_KEY,
@@ -112,10 +113,17 @@ async def resolve_voice_config(
         return TTSConfig(provider=provider_enum, **defaults)
 
     # Merge: effective_config fields win over defaults for non-None values
-    merged = {}
-    for field in _VOICE_CONFIG_FIELDS:
-        val = getattr(effective_config, field, None)
-        merged[field] = val if val is not None else defaults.get(field)
+    specs = [
+        FieldSpec(
+            name=f,
+            tiers=[
+                lambda f=f: getattr(effective_config, f, None),
+                lambda f=f: defaults.get(f),
+            ],
+        )
+        for f in _VOICE_CONFIG_FIELDS
+    ]
+    merged = await resolve_fields(specs)
 
     return TTSConfig(provider=effective_config.provider, **merged)
 

--- a/app/core/config/resolver.py
+++ b/app/core/config/resolver.py
@@ -1,0 +1,473 @@
+"""The one place runtime configuration precedence is decided.
+
+Two layers live here.
+
+**Layer 1 — the ``FieldSpec`` primitive** (unregistered, ad-hoc chains).
+Unifies the "template > per-provider override > dynamic (Redis) > static
+(env)" precedence chains scattered across VAD, TTS, STT, and LLM config
+resolution into one small primitive.
+
+**Layer 2 — the governed knob registry** (``Knob`` / ``REGISTRY`` /
+``resolve``). Every *tunable* — frequency caps, quiet-hour windows, merchant
+default timezone — is declared once in ``REGISTRY`` and read through a single
+``resolve()`` call with a single precedence order. This is what stops the
+config sprawl that produced ~196 loose env constants in ``static.py``: a knob
+that isn't in the registry has no defined precedence, no type, no bounds, and
+no per-merchant story. See ``Knob`` for the tier order and the floor/ceiling
+guarantee.
+
+Layer 2 is built on Layer 1 — a registered knob is just a ``FieldSpec`` whose
+tiers are derived from its ``Knob`` declaration, plus clamping.
+
+A ``FieldSpec`` declares, for one output field, an ordered list of tiers to
+try. Each tier is a plain value, a zero-arg sync callable, or a zero-arg
+async callable (dynamic/Redis lookups). The first tier that yields a
+non-None value wins. Tiers are evaluated lazily, in order — a later tier is
+only invoked (and only awaited) if every earlier tier resolved to None. This
+matters: several existing call sites only reach Redis on a template miss,
+and eagerly evaluating every tier would add extra round-trips that don't
+happen today.
+
+A field may instead be ``required``: no matter how many tiers it has, if
+none resolve to a non-None value, resolution raises. This covers both
+"template-required, no fallback exists" (e.g. Vertex's ``model``) and
+"dynamic-only-required" (e.g. Vertex's ``credentials_json``) uniformly —
+only the tier list contents differ.
+
+Deliberately out of scope for this primitive (kept as bespoke code at call
+sites instead of being forced in):
+  - Whole-object swaps with no cross-field precedence, where every field is
+    self-sufficient at one tier (e.g. Deepgram's ``config.deepgram or
+    DeepgramSTTConfig()``, SmartTurn's ``stt_config.smart_turn or
+    SmartTurnConfig()``). There's no fallback chain to declare per field.
+  - Conditionally-required fields, where requiredness itself depends on
+    another field's value (e.g. Vertex's ``thinking.budget_tokens`` is only
+    required when ``thinking.enabled``). ``FieldSpec.required`` is a static
+    flag, not a predicate — expressing this in the resolver would be scope
+    creep for a single caller.
+  - Keyed/indirect lookups where the *name* of the dynamic config key is
+    itself supplied by an upstream tier (Azure/OpenAI's ``api_key_name`` ->
+    ``get_config(api_key_name, ...)``). This isn't a fallback chain either.
+"""
+
+from __future__ import annotations
+
+import inspect
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Awaitable, Callable, Optional, TypeVar, Union
+
+from app.core.logger import logger
+from app.services.live_config.store import get_config
+
+Tier = Union[Any, Callable[[], Any], Callable[[], "Awaitable[Any]"]]
+
+T = TypeVar("T")
+
+
+@dataclass
+class FieldSpec:
+    """One output field's precedence chain.
+
+    ``tiers`` is walked in order; the first non-None result wins. If every
+    tier yields None:
+      - ``required=False`` (default): the field resolves to None.
+      - ``required=True``: resolution raises ``ValueError(error_message)``.
+    """
+
+    name: str
+    tiers: list[Tier] = field(default_factory=list)
+    required: bool = False
+    error_message: Optional[str] = None
+
+
+def or_none(value: Optional[T]) -> Optional[T]:
+    """Falsy -> None, so a truthy-checked field can feed a ``FieldSpec`` tier.
+
+    ``resolve_field`` treats only None as "unset". Several pre-existing call
+    sites instead fell back on a truthy check (``if cfg and cfg.field``), where
+    an empty string or a 0 must still fall through to the next tier. Wrapping
+    such a tier in ``or_none`` preserves that exact behavior. Use it only where
+    the original code was truthy-checked — fields where 0/"" are legitimate
+    values (e.g. ``temperature=0.0``) must stay a bare ``is not None`` tier.
+    """
+    return value if value else None
+
+
+async def _resolve_tier(tier: Tier) -> Any:
+    if callable(tier):
+        result = tier()
+        if inspect.isawaitable(result):
+            result = await result
+        return result
+    return tier
+
+
+async def resolve_field(spec: FieldSpec) -> Any:
+    """Resolve a single field by walking its tiers, first non-None wins."""
+    for tier in spec.tiers:
+        val = await _resolve_tier(tier)
+        if val is not None:
+            return val
+    if spec.required:
+        raise ValueError(
+            spec.error_message or f"{spec.name} has no value from any tier"
+        )
+    return None
+
+
+async def resolve_fields(specs: list[FieldSpec]) -> dict[str, Any]:
+    """Resolve a group of fields into a flat dict (for ``**kwargs`` into a Pydantic model)."""
+    return {spec.name: await resolve_field(spec) for spec in specs}
+
+
+# ===========================================================================
+#  Layer 2 — the governed knob registry
+# ===========================================================================
+
+
+class Scope(str, Enum):
+    """Who is allowed to move a knob."""
+
+    PLATFORM = "platform"
+    """Only we can change it (env / Redis). A merchant cannot override."""
+
+    MERCHANT = "merchant"
+    """A merchant may override it, but only within the knob's floor/ceiling."""
+
+
+@dataclass(frozen=True)
+class Knob:
+    """One registered, governed tunable.
+
+    Resolution order (lowest precedence first) — this order is fixed for
+    *every* knob, which is the whole point of the registry::
+
+        default -> env -> Redis/DevCycle -> merchant -> template -> playground
+        \\_____________  ______________/   \\_________  ____________________/
+                      \\/                             \\/
+                 platform tiers                   tenant tiers
+              (delegated to get_config)      (only if scope is MERCHANT)
+
+    The first tier that yields a non-None value wins, walking from the
+    highest precedence down. The result is then clamped into
+    ``[floor, ceiling]``.
+
+    **The floor/ceiling guarantee**: a resolved value is *always* within
+    bounds, whatever tier produced it. Clamping is applied unconditionally
+    rather than only to tenant tiers — an out-of-range value is a mistake
+    wherever it came from (a fat-fingered Redis flag is no safer than a bad
+    merchant setting), and an unconditional invariant is far easier to reason
+    about and test than a source-dependent one. Every clamp is logged with
+    the tier that caused it, so the mistake stays visible.
+
+    Attributes:
+        key: Registry key, and the env var / Redis flag name for the platform
+            tiers. Uppercase snake_case by convention.
+        type: Type the value is coerced to (``str``, ``int``, ``float``,
+            ``bool``). Passed through to ``get_config``.
+        default: Last-resort value. Must itself satisfy floor/ceiling.
+        scope: PLATFORM or MERCHANT — see ``Scope``.
+        merchant_field: Attribute name to read off the merchant config object
+            passed to ``resolve``. Required when scope is MERCHANT.
+        floor: Inclusive lower bound. Numeric knobs only.
+        ceiling: Inclusive upper bound. Numeric knobs only.
+        description: Why this knob exists / what turning it does.
+    """
+
+    key: str
+    type: type
+    default: Any
+    description: str
+    scope: Scope = Scope.PLATFORM
+    merchant_field: Optional[str] = None
+    floor: Optional[float] = None
+    ceiling: Optional[float] = None
+
+    def __post_init__(self) -> None:
+        """Validate the declaration itself, at import time.
+
+        A malformed knob is a programming error that should fail on the very
+        first import rather than at 3am on the one call path that reads it.
+        """
+        if self.scope is Scope.MERCHANT and not self.merchant_field:
+            raise ValueError(
+                f"Knob {self.key!r}: scope=MERCHANT requires merchant_field "
+                "(the attribute to read off the merchant config object)"
+            )
+        if self.scope is Scope.PLATFORM and self.merchant_field:
+            raise ValueError(
+                f"Knob {self.key!r}: merchant_field is meaningless for a "
+                "PLATFORM-scoped knob — did you mean scope=Scope.MERCHANT?"
+            )
+        has_bounds = self.floor is not None or self.ceiling is not None
+        if has_bounds and self.type not in (int, float):
+            raise ValueError(
+                f"Knob {self.key!r}: floor/ceiling only apply to numeric "
+                f"knobs, got type={self.type.__name__}"
+            )
+        if (
+            self.floor is not None
+            and self.ceiling is not None
+            and self.floor > self.ceiling
+        ):
+            raise ValueError(
+                f"Knob {self.key!r}: floor ({self.floor}) > ceiling "
+                f"({self.ceiling})"
+            )
+        if self.clamp(self.default) != self.default:
+            raise ValueError(
+                f"Knob {self.key!r}: default ({self.default!r}) is outside "
+                f"its own floor/ceiling [{self.floor}, {self.ceiling}]"
+            )
+
+    def coerce(self, value: Any) -> Any:
+        """Coerce ``value`` to the knob's declared type.
+
+        The platform tier is coerced by ``get_config``; the tenant tiers are
+        not, and their values routinely arrive as strings (template payloads
+        are JSON, where ``"5"`` and ``5`` both occur). Without this, a
+        string-typed override reaches ``clamp`` and raises TypeError.
+
+        Raises:
+            ValueError: if the value cannot be represented as the knob's type.
+                Callers treat that like an absent value and fall through.
+        """
+        if self.type is bool:
+            # bool("false") is True, so strings need explicit handling.
+            if isinstance(value, str):
+                lowered = value.strip().lower()
+                if lowered in ("true", "1", "yes"):
+                    return True
+                if lowered in ("false", "0", "no"):
+                    return False
+                raise ValueError(f"{value!r} is not a boolean")
+            return bool(value)
+        try:
+            return self.type(value)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(
+                f"{value!r} is not a valid {self.type.__name__}: {exc}"
+            ) from None
+
+    def clamp(self, value: Any) -> Any:
+        """Pull ``value`` inside [floor, ceiling]. Non-numerics pass through."""
+        if value is None or self.type not in (int, float):
+            return value
+        if self.floor is not None and value < self.floor:
+            return self.type(self.floor)
+        if self.ceiling is not None and value > self.ceiling:
+            return self.type(self.ceiling)
+        return value
+
+
+# ---------------------------------------------------------------------------
+#  THE REGISTRY
+#
+#  Every governed knob is declared here and nowhere else.
+#
+#  Adding a tunable? Add it here first. Do not add a bare ``os.environ.get``
+#  to static.py — that is exactly the sprawl this registry exists to stop.
+#  Module code must never read os.environ directly; go through ``resolve``.
+#
+#  MERCHANT-scoped knobs read from a ``CallExecutionConfig`` row, which is
+#  already keyed by (reseller_id, merchant_id, template) and already carries
+#  these columns — so per-merchant tuning needs no new table and no migration.
+# ---------------------------------------------------------------------------
+
+REGISTRY: dict[str, Knob] = {}
+
+
+def register(knob: Knob) -> Knob:
+    """Add a knob to the registry, rejecting duplicate keys."""
+    if knob.key in REGISTRY:
+        raise ValueError(f"Duplicate knob key {knob.key!r} in REGISTRY")
+    REGISTRY[knob.key] = knob
+    return knob
+
+
+# --- Outbound calling: retry cadence -------------------------------------
+
+register(
+    Knob(
+        key="BB_CALL_MAX_RETRY",
+        type=int,
+        default=3,
+        floor=0,
+        ceiling=10,
+        scope=Scope.MERCHANT,
+        merchant_field="max_retry",
+        description=(
+            "Retries per lead before it is abandoned. Ceiling exists so a "
+            "merchant cannot turn a failed number into a dialling loop."
+        ),
+    )
+)
+
+register(
+    Knob(
+        key="BB_CALL_RETRY_OFFSET_MINUTES",
+        type=int,
+        default=60,
+        floor=5,
+        ceiling=1440,
+        scope=Scope.MERCHANT,
+        merchant_field="retry_offset",
+        description=(
+            "Gap between retry attempts. Floor keeps a merchant from "
+            "hammering a number every few seconds."
+        ),
+    )
+)
+
+register(
+    Knob(
+        key="BB_CALL_INITIAL_OFFSET_MINUTES",
+        type=int,
+        default=0,
+        floor=0,
+        ceiling=1440,
+        scope=Scope.MERCHANT,
+        merchant_field="initial_offset",
+        description="Delay between lead ingest and the first call attempt.",
+    )
+)
+
+# --- Outbound calling: frequency caps ------------------------------------
+
+register(
+    Knob(
+        key="BB_CALL_RATE_LIMIT_MAX_CALLS",
+        type=int,
+        default=100,
+        floor=1,
+        ceiling=10_000,
+        scope=Scope.MERCHANT,
+        merchant_field="rate_limit_max_calls",
+        description=(
+            "Frequency cap: calls allowed inside the rate-limit window. "
+            "Ceiling is the platform's own throughput guard."
+        ),
+    )
+)
+
+register(
+    Knob(
+        key="BB_CALL_RATE_LIMIT_WINDOW_SECONDS",
+        type=int,
+        default=3600,
+        floor=60,
+        ceiling=86_400,
+        scope=Scope.MERCHANT,
+        merchant_field="rate_limit_window_seconds",
+        description="Frequency-cap window that BB_CALL_RATE_LIMIT_MAX_CALLS applies over.",
+    )
+)
+
+# --- Locale ---------------------------------------------------------------
+
+register(
+    Knob(
+        key="BB_MERCHANT_DEFAULT_TIMEZONE",
+        type=str,
+        default="Asia/Kolkata",
+        scope=Scope.MERCHANT,
+        merchant_field="inbound_call_timezone",
+        description=(
+            "Timezone that quiet-hour windows are interpreted in. Not "
+            "bounded — validity is a tz-database question, not a range."
+        ),
+    )
+)
+
+
+# ---------------------------------------------------------------------------
+#  Resolution
+# ---------------------------------------------------------------------------
+
+
+async def resolve(
+    key: str,
+    *,
+    merchant_config: Any = None,
+    template_value: Any = None,
+    playground_value: Any = None,
+) -> Any:
+    """Resolve one registered knob, for a merchant, with bounds enforced.
+
+    This is the single entry point Layer 2 exists to provide: given a knob
+    key and whatever context the caller happens to have, return the value to
+    actually use.
+
+    Args:
+        key: A key present in ``REGISTRY``.
+        merchant_config: The merchant's ``CallExecutionConfig`` (or any object
+            exposing the knob's ``merchant_field``). Duck-typed on purpose —
+            ``app.core`` must not import ``app.schemas``, and keeping it
+            structural means tests can pass a stand-in. Ignored for
+            PLATFORM-scoped knobs.
+        template_value: Template-level override, or None.
+        playground_value: Playground override (highest precedence), or None.
+
+    Returns:
+        The resolved value, coerced to the knob's type and clamped into
+        ``[floor, ceiling]``.
+
+    Raises:
+        KeyError: if ``key`` is not registered. Unregistered config has no
+            defined precedence, so this is deliberately fatal rather than a
+            silent None.
+    """
+    try:
+        knob = REGISTRY[key]
+    except KeyError:
+        raise KeyError(
+            f"{key!r} is not a registered knob. Declare it in "
+            "app/core/config/resolver.py REGISTRY — config with no "
+            "declaration has no defined precedence, type, or bounds."
+        ) from None
+
+    # merchant_field is guaranteed non-None for MERCHANT scope by
+    # Knob.__post_init__; bind it locally so that is visible to the checker.
+    merchant_value = None
+    merchant_field = knob.merchant_field
+    if (
+        knob.scope is Scope.MERCHANT
+        and merchant_field is not None
+        and merchant_config is not None
+    ):
+        merchant_value = getattr(merchant_config, merchant_field, None)
+
+    # Highest precedence first; get_config covers Redis -> env -> default.
+    tiers: list[tuple[str, Tier]] = [
+        ("playground", playground_value),
+        ("template", template_value),
+        ("merchant", merchant_value),
+        ("platform", lambda: get_config(knob.key, knob.default, knob.type)),
+    ]
+
+    for tier_name, tier in tiers:
+        raw = await _resolve_tier(tier)
+        if raw is None:
+            continue
+        try:
+            value = knob.coerce(raw)
+        except ValueError as exc:
+            # A malformed override degrades like an absent one rather than
+            # taking resolution down — but it is never silent.
+            logger.warning(
+                f"Knob {knob.key}: ignoring {tier_name} value {raw!r} ({exc}); "
+                "falling through to the next tier"
+            )
+            continue
+        clamped = knob.clamp(value)
+        if clamped != value:
+            logger.warning(
+                f"Knob {knob.key}: {tier_name} value {value!r} outside "
+                f"[{knob.floor}, {knob.ceiling}], clamped to {clamped!r}"
+            )
+        return clamped
+
+    # get_config always yields at least knob.default, so this is unreachable
+    # unless a tier explicitly resolved to None.
+    return knob.default

--- a/tests/breeze_buddy/test_llm_resolve_config.py
+++ b/tests/breeze_buddy/test_llm_resolve_config.py
@@ -1,0 +1,249 @@
+"""Regression coverage for LLM per-provider config resolution across the
+config_resolver migration.
+
+Azure/OpenAI: template (truthy-checked) > static/dynamic default.
+Vertex/ClaudeVertex: template + dynamic credentials are all required —
+locks in the exact ValueError message strings, since they're observable
+template-misconfiguration debugging output.
+"""
+
+import pytest
+
+import app.ai.voice.agents.breeze_buddy.llm as llm_mod
+from app.ai.voice.llm import LLMConfiguration, LLMProvider, ThinkingConfiguration
+from app.core.config.resolver import or_none
+
+
+@pytest.fixture(autouse=True)
+def _fake_static_creds(monkeypatch):
+    monkeypatch.setattr(llm_mod, "AZURE_OPENAI_API_KEY", "azure-key")
+    monkeypatch.setattr(llm_mod, "AZURE_OPENAI_ENDPOINT", "https://azure.example")
+    monkeypatch.setattr(llm_mod, "OPENAI_API_KEY", "openai-key")
+
+
+@pytest.mark.asyncio
+async def test_azure_no_template_config_uses_static_defaults():
+    service = await llm_mod._resolve_azure(None)
+    assert service is not None
+
+
+@pytest.mark.asyncio
+async def test_azure_template_overrides_endpoint_and_model(monkeypatch):
+    config = LLMConfiguration(
+        provider=LLMProvider.AZURE,
+        endpoint="https://custom.example",
+        model="gpt-custom",
+        api_key_name="MY_KEY",
+    )
+
+    async def fake_get_config(key, default_value, return_type=str):
+        return "resolved-api-key"
+
+    monkeypatch.setattr(llm_mod, "get_config", fake_get_config)
+    service = await llm_mod._resolve_azure(config)
+    assert service is not None
+
+
+@pytest.mark.asyncio
+async def test_azure_temperature_zero_is_preserved_not_treated_as_falsy():
+    config = LLMConfiguration(provider=LLMProvider.AZURE, temperature=0.0)
+    resolved = await llm_mod.resolve_fields(
+        [
+            llm_mod.FieldSpec(
+                "temperature",
+                tiers=[
+                    lambda: config.temperature,
+                    llm_mod.BREEZE_BUDDY_AZURE_TEMPERATURE,
+                ],
+            )
+        ]
+    )
+    assert resolved["temperature"] == 0.0
+
+
+@pytest.mark.asyncio
+async def test_azure_max_tokens_zero_falls_through_truthy_check():
+    # LLMConfiguration enforces max_tokens >= 1, so use a bare namespace to
+    # exercise the truthy-check tier logic directly (0 is falsy -> fallback).
+    from types import SimpleNamespace
+
+    config = SimpleNamespace(max_tokens=0)
+    resolved = await llm_mod.resolve_fields(
+        [
+            llm_mod.FieldSpec(
+                "max_tokens",
+                tiers=[
+                    lambda: or_none(config.max_tokens),
+                    llm_mod.BREEZE_BUDDY_AZURE_MAX_COMPLETION_TOKENS,
+                ],
+            )
+        ]
+    )
+    assert resolved["max_tokens"] != 0
+
+
+@pytest.mark.asyncio
+async def test_openai_no_template_config_uses_static_defaults():
+    service = await llm_mod._resolve_openai(None)
+    assert service is not None
+
+
+async def _vertex_deps(monkeypatch, *, credentials="creds-json", project_id="proj-1"):
+    async def fake_creds():
+        return credentials
+
+    async def fake_project():
+        return project_id
+
+    monkeypatch.setattr(llm_mod, "GOOGLE_VERTEX_CREDENTIALS_JSON", fake_creds)
+    monkeypatch.setattr(llm_mod, "GOOGLE_VERTEX_PROJECT_ID", fake_project)
+
+
+@pytest.mark.asyncio
+async def test_vertex_missing_credentials_raises_exact_message(monkeypatch):
+    await _vertex_deps(monkeypatch, credentials=None)
+    config = LLMConfiguration(
+        provider=LLMProvider.GOOGLE_VERTEX,
+        model="gemini-pro",
+        region="us-central1",
+        temperature=0.5,
+        max_tokens=1024,
+    )
+    with pytest.raises(
+        ValueError,
+        match="GOOGLE_VERTEX_CREDENTIALS_JSON is required for google_vertex provider",
+    ):
+        await llm_mod._resolve_vertex(config)
+
+
+@pytest.mark.asyncio
+async def test_vertex_missing_project_id_raises_exact_message(monkeypatch):
+    await _vertex_deps(monkeypatch, project_id=None)
+    config = LLMConfiguration(
+        provider=LLMProvider.GOOGLE_VERTEX,
+        model="gemini-pro",
+        region="us-central1",
+        temperature=0.5,
+        max_tokens=1024,
+    )
+    with pytest.raises(
+        ValueError,
+        match="GOOGLE_VERTEX_PROJECT_ID is required for google_vertex provider",
+    ):
+        await llm_mod._resolve_vertex(config)
+
+
+@pytest.mark.asyncio
+async def test_vertex_missing_model_raises_exact_message(monkeypatch):
+    await _vertex_deps(monkeypatch)
+    config = LLMConfiguration(
+        provider=LLMProvider.GOOGLE_VERTEX,
+        region="us-central1",
+        temperature=0.5,
+        max_tokens=1024,
+    )
+    with pytest.raises(
+        ValueError,
+        match="model is required in LLMConfiguration for google_vertex provider",
+    ):
+        await llm_mod._resolve_vertex(config)
+
+
+@pytest.mark.asyncio
+async def test_vertex_missing_temperature_raises_exact_message(monkeypatch):
+    await _vertex_deps(monkeypatch)
+    config = LLMConfiguration(
+        provider=LLMProvider.GOOGLE_VERTEX,
+        model="gemini-pro",
+        region="us-central1",
+        max_tokens=1024,
+    )
+    with pytest.raises(
+        ValueError,
+        match="temperature is required in LLMConfiguration for google_vertex provider",
+    ):
+        await llm_mod._resolve_vertex(config)
+
+
+@pytest.mark.asyncio
+async def test_vertex_all_required_fields_present_succeeds(monkeypatch):
+    await _vertex_deps(monkeypatch)
+    captured = {}
+    monkeypatch.setattr(
+        llm_mod,
+        "build_vertex_llm",
+        lambda config: (captured.update(config=config), "built-service")[1],
+    )
+    config = LLMConfiguration(
+        provider=LLMProvider.GOOGLE_VERTEX,
+        model="gemini-pro",
+        region="us-central1",
+        temperature=0.5,
+        max_tokens=1024,
+    )
+    service = await llm_mod._resolve_vertex(config)
+    assert service == "built-service"
+    assert captured["config"].model == "gemini-pro"
+    assert captured["config"].location == "us-central1"
+    assert captured["config"].temperature == 0.5
+    assert captured["config"].max_tokens == 1024
+    assert captured["config"].credentials_json == "creds-json"
+    assert captured["config"].project_id == "proj-1"
+
+
+@pytest.mark.asyncio
+async def test_claude_vertex_missing_credentials_raises_exact_message(monkeypatch):
+    await _vertex_deps(monkeypatch, credentials=None)
+    config = LLMConfiguration(
+        provider=LLMProvider.GOOGLE_VERTEX,
+        model="claude-3",
+        region="us-central1",
+        temperature=0.5,
+        max_tokens=1024,
+    )
+    with pytest.raises(
+        ValueError,
+        match="GOOGLE_VERTEX_CREDENTIALS_JSON is required for claude_vertex provider",
+    ):
+        await llm_mod._resolve_claude_vertex(config)
+
+
+@pytest.mark.asyncio
+async def test_claude_vertex_thinking_requires_budget_tokens(monkeypatch):
+    await _vertex_deps(monkeypatch)
+    config = LLMConfiguration(
+        provider=LLMProvider.GOOGLE_VERTEX,
+        model="claude-3",
+        region="us-central1",
+        temperature=0.5,
+        max_tokens=1024,
+        thinking=ThinkingConfiguration(enabled=True),
+    )
+    with pytest.raises(ValueError, match="budget_tokens is required when thinking"):
+        await llm_mod._resolve_claude_vertex(config)
+
+
+@pytest.mark.asyncio
+async def test_claude_vertex_all_required_fields_present_succeeds(monkeypatch):
+    await _vertex_deps(monkeypatch)
+    captured = {}
+    monkeypatch.setattr(
+        llm_mod,
+        "build_claude_vertex_llm",
+        lambda config, pooled=False: (captured.update(config=config), "built-service")[
+            1
+        ],
+    )
+    config = LLMConfiguration(
+        provider=LLMProvider.GOOGLE_VERTEX,
+        model="claude-3",
+        region="us-central1",
+        temperature=0.5,
+        max_tokens=1024,
+    )
+    service = await llm_mod._resolve_claude_vertex(config)
+    assert service == "built-service"
+    assert captured["config"].model == "claude-3"
+    assert captured["config"].region == "us-central1"
+    assert captured["config"].credentials_json == "creds-json"
+    assert captured["config"].project_id == "proj-1"

--- a/tests/breeze_buddy/test_stt_resolve_config.py
+++ b/tests/breeze_buddy/test_stt_resolve_config.py
@@ -1,0 +1,134 @@
+"""Regression coverage for STT per-provider config resolution across the
+config_resolver migration.
+
+Soniox: template (truthy-checked) > static env default.
+Sarvam: template (truthy-checked) > Redis dynamic default (no Redis running
+in unit tests, so dynamic resolves to its hardcoded default).
+Empty-string template overrides must still fall through to the next tier
+(the shared `or_none` truthy-preservation helper).
+"""
+
+import pytest
+
+import app.ai.voice.agents.breeze_buddy.stt as stt_mod
+from app.ai.voice.agents.breeze_buddy.template.types import (
+    SarvamSTTConfig,
+    SonioxSTTConfig,
+    STTConfiguration,
+    STTProvider,
+)
+from app.core.config.resolver import or_none
+
+
+@pytest.fixture(autouse=True)
+def _fake_api_keys(monkeypatch):
+    monkeypatch.setattr(stt_mod, "SONIOX_API_KEY", "test-soniox-key")
+    monkeypatch.setattr(stt_mod, "SARVAM_API_KEY", "test-sarvam-key")
+    monkeypatch.setattr(stt_mod, "DEEPGRAM_API_KEY", "test-deepgram-key")
+
+
+@pytest.mark.asyncio
+async def test_soniox_no_template_override_uses_static_defaults():
+    config = STTConfiguration(provider=STTProvider.SONIOX)
+    service = await stt_mod.create_stt_from_config(config)
+    assert service is not None
+
+
+@pytest.mark.asyncio
+async def test_soniox_template_override_wins():
+    soniox = SonioxSTTConfig(context="custom-context", model="stt-rt-v9")
+    config = STTConfiguration(provider=STTProvider.SONIOX, soniox=soniox)
+    resolved = await stt_mod.resolve_fields(
+        [
+            stt_mod.FieldSpec(
+                "context",
+                tiers=[
+                    lambda: or_none(soniox.context),
+                    lambda: stt_mod.BREEZE_BUDDY_SONIOX_CONTEXT,
+                ],
+            ),
+            stt_mod.FieldSpec(
+                "model",
+                tiers=[
+                    lambda: or_none(soniox.model),
+                    lambda: stt_mod.BREEZE_BUDDY_SONIOX_MODEL,
+                ],
+            ),
+        ]
+    )
+    assert resolved["context"] == "custom-context"
+    assert resolved["model"] == "stt-rt-v9"
+
+
+def test_or_none_preserves_truthy_semantics():
+    # Empty string must fall through (truthy check), unlike `is not None`.
+    assert or_none("") is None
+    assert or_none(None) is None
+    assert or_none("value") == "value"
+    assert or_none(0) is None
+
+
+@pytest.mark.asyncio
+async def test_soniox_empty_string_override_falls_through_to_static_default():
+    soniox = SonioxSTTConfig(context="")
+    config = STTConfiguration(provider=STTProvider.SONIOX, soniox=soniox)
+    resolved = await stt_mod.resolve_fields(
+        [
+            stt_mod.FieldSpec(
+                "context",
+                tiers=[
+                    lambda: or_none(soniox.context),
+                    lambda: stt_mod.BREEZE_BUDDY_SONIOX_CONTEXT,
+                ],
+            )
+        ]
+    )
+    assert resolved["context"] == stt_mod.BREEZE_BUDDY_SONIOX_CONTEXT
+
+
+@pytest.mark.asyncio
+async def test_sarvam_no_template_override_uses_dynamic_defaults():
+    config = STTConfiguration(provider=STTProvider.SARVAM)
+    service = await stt_mod.create_stt_from_config(config)
+    assert service is not None
+
+
+@pytest.mark.asyncio
+async def test_sarvam_template_override_wins_over_dynamic_default():
+    sarvam = SarvamSTTConfig(model="saaras:v9", language_code="hi-IN")
+    config = STTConfiguration(provider=STTProvider.SARVAM, sarvam=sarvam)
+    resolved = await stt_mod.resolve_fields(
+        [
+            stt_mod.FieldSpec(
+                "model",
+                tiers=[
+                    lambda: or_none(sarvam.model),
+                    stt_mod.BB_SARVAM_STT_MODEL,
+                ],
+            ),
+            stt_mod.FieldSpec(
+                "language_code",
+                tiers=[
+                    lambda: or_none(sarvam.language_code),
+                    stt_mod.BB_SARVAM_STT_LANGUAGE_CODE,
+                ],
+            ),
+        ]
+    )
+    assert resolved["model"] == "saaras:v9"
+    assert resolved["language_code"] == "hi-IN"
+
+
+@pytest.mark.asyncio
+async def test_deepgram_uses_whole_object_defaults_no_resolver():
+    config = STTConfiguration(provider=STTProvider.DEEPGRAM)
+    service = await stt_mod.create_stt_from_config(config)
+    assert service is not None
+
+
+@pytest.mark.asyncio
+async def test_missing_api_key_raises(monkeypatch):
+    monkeypatch.setattr(stt_mod, "SONIOX_API_KEY", None)
+    config = STTConfiguration(provider=STTProvider.SONIOX)
+    with pytest.raises(ValueError, match="SONIOX_API_KEY"):
+        await stt_mod.create_stt_from_config(config)

--- a/tests/breeze_buddy/test_tts_resolve_voice_config.py
+++ b/tests/breeze_buddy/test_tts_resolve_voice_config.py
@@ -1,0 +1,74 @@
+"""Regression coverage for `resolve_voice_config` (template > per-provider
+override > Redis/hardcoded defaults) across the config_resolver migration.
+
+No Redis is running in unit tests, so BB_VOICE_PROVIDER_DEFAULTS resolves
+purely from the hardcoded BB_SPEECH_PROVIDER_DEFAULTS table
+(ENABLE_REDIS_DYNAMIC_CONFIG defaults False).
+"""
+
+import pytest
+
+import app.ai.voice.agents.breeze_buddy.tts as tts_mod
+from app.ai.voice.agents.breeze_buddy.template.types import TTSConfig, TTSProvider
+from app.ai.voice.agents.breeze_buddy.tts import resolve_voice_config
+
+
+@pytest.mark.asyncio
+async def test_no_template_config_uses_redis_hardcoded_defaults():
+    resolved = await resolve_voice_config(None, None)
+    assert resolved.provider == TTSProvider.ELEVENLABS
+
+
+@pytest.mark.asyncio
+async def test_template_config_fields_win_over_defaults():
+    template_cfg = TTSConfig(
+        provider=TTSProvider.ELEVENLABS, voice_id="custom-voice", speed=1.3
+    )
+    resolved = await resolve_voice_config(template_cfg, None)
+    assert resolved.voice_id == "custom-voice"
+    assert resolved.speed == 1.3
+    assert resolved.provider == TTSProvider.ELEVENLABS
+
+
+@pytest.mark.asyncio
+async def test_per_provider_override_wins_over_default_template_config():
+    default_cfg = TTSConfig(provider=TTSProvider.ELEVENLABS, voice_id="default-voice")
+    override_cfg = TTSConfig(provider=TTSProvider.CARTESIA, voice_id="override-voice")
+    resolved = await resolve_voice_config(default_cfg, {"cartesia": override_cfg})
+    # Provider comes from the override since none was set on default_cfg's provider match
+    # (default_cfg.provider is elevenlabs, so overrides["elevenlabs"] is absent -> falls
+    # back to default_cfg itself, not the cartesia override).
+    assert resolved.voice_id == "default-voice"
+
+
+@pytest.mark.asyncio
+async def test_per_provider_override_matches_template_provider():
+    default_cfg = TTSConfig(provider=TTSProvider.ELEVENLABS, voice_id="default-voice")
+    override_cfg = TTSConfig(provider=TTSProvider.ELEVENLABS, voice_id="override-voice")
+    resolved = await resolve_voice_config(default_cfg, {"elevenlabs": override_cfg})
+    assert resolved.voice_id == "override-voice"
+
+
+@pytest.mark.asyncio
+async def test_unknown_provider_falls_back_to_elevenlabs(monkeypatch):
+    """A bad BB_TTS_SERVICE value must not crash call startup.
+
+    Exercises the ``except ValueError`` branch: the provider string comes from
+    Redis, so a typo/stale flag there would otherwise blow up TTSProvider().
+    """
+
+    async def fake_tts_service():
+        return "not-a-real-provider"
+
+    monkeypatch.setattr(tts_mod, "BB_TTS_SERVICE", fake_tts_service)
+    resolved = await resolve_voice_config(None, None)
+    assert resolved.provider == TTSProvider.ELEVENLABS
+
+
+@pytest.mark.asyncio
+async def test_partial_template_config_falls_back_field_by_field():
+    template_cfg = TTSConfig(provider=TTSProvider.CARTESIA, voice_id="only-voice-set")
+    resolved = await resolve_voice_config(template_cfg, None)
+    assert resolved.voice_id == "only-voice-set"
+    # model wasn't set on the template config; falls through to defaults (may be None)
+    assert resolved.provider == TTSProvider.CARTESIA

--- a/tests/breeze_buddy/test_vad_resolution.py
+++ b/tests/breeze_buddy/test_vad_resolution.py
@@ -1,0 +1,151 @@
+"""Regression coverage for VAD param resolution (template > Redis/defaults).
+
+Locks in `_resolve_vad_params` / `_layer_template_vad` /
+`_apply_vad_config_to_analyzer` behavior across the config_resolver
+migration: per-field override precedence, partial overrides, and the
+no-override passthrough.
+"""
+
+from types import SimpleNamespace
+from typing import cast
+
+import pytest
+from pipecat.audio.vad.vad_analyzer import VADAnalyzer, VADParams
+
+from app.ai.voice.agents.breeze_buddy.template.types import (
+    ConfigurationModel,
+    TemplateModel,
+    VadConfig,
+)
+from app.ai.voice.agents.breeze_buddy.template.vad import (
+    SMART_TURN_TRIGGER_STOP_SECS,
+    _apply_vad_config_to_analyzer,
+    _layer_template_vad,
+    _resolve_vad_params,
+    build_smart_turn_trigger_vad_params,
+    create_telephony_vad_params,
+)
+
+DEFAULTS = VADParams(confidence=0.5, start_secs=0.2, stop_secs=0.8, min_volume=0.6)
+
+
+def _no_override(_field):
+    return None
+
+
+@pytest.mark.asyncio
+async def test_no_override_returns_base_unchanged():
+    result = await _resolve_vad_params(_no_override, DEFAULTS)
+    assert result == DEFAULTS
+
+
+@pytest.mark.asyncio
+async def test_full_override_wins_on_every_field():
+    override = VADParams(confidence=0.9, start_secs=0.1, stop_secs=0.3, min_volume=0.7)
+    result = await _resolve_vad_params(lambda f: getattr(override, f), DEFAULTS)
+    assert result == override
+
+
+@pytest.mark.asyncio
+async def test_partial_override_merges_field_by_field():
+    def getter(field):
+        return 0.99 if field == "confidence" else None
+
+    result = await _resolve_vad_params(getter, DEFAULTS)
+    assert result.confidence == 0.99
+    assert result.start_secs == DEFAULTS.start_secs
+    assert result.stop_secs == DEFAULTS.stop_secs
+    assert result.min_volume == DEFAULTS.min_volume
+
+
+@pytest.mark.asyncio
+async def test_layer_template_vad_no_template_returns_defaults():
+    result = await _layer_template_vad(None, DEFAULTS)
+    assert result == DEFAULTS
+
+
+@pytest.mark.asyncio
+async def test_layer_template_vad_with_partial_template_config():
+    template = SimpleNamespace(
+        configurations=SimpleNamespace(
+            vad_config=SimpleNamespace(
+                confidence=0.42, start_secs=None, stop_secs=None, min_volume=None
+            )
+        )
+    )
+    result = await _layer_template_vad(cast(TemplateModel, template), DEFAULTS)
+    assert result.confidence == 0.42
+    assert result.start_secs == DEFAULTS.start_secs
+
+
+@pytest.mark.asyncio
+async def test_layer_template_vad_no_configurations_returns_defaults():
+    template = SimpleNamespace(configurations=None)
+    result = await _layer_template_vad(cast(TemplateModel, template), DEFAULTS)
+    assert result == DEFAULTS
+
+
+class _FakeAnalyzer:
+    def __init__(self, params: VADParams):
+        self.params = params
+
+    def set_params(self, params: VADParams):
+        self.params = params
+
+
+@pytest.mark.asyncio
+async def test_apply_vad_config_to_analyzer_dict_access():
+    analyzer = _FakeAnalyzer(DEFAULTS)
+    vad_config = {"confidence": 0.77, "start_secs": None}
+    await _apply_vad_config_to_analyzer(
+        cast(VADAnalyzer, analyzer), vad_config, call_sid="call-1"
+    )
+    assert analyzer.params.confidence == 0.77
+    assert analyzer.params.start_secs == DEFAULTS.start_secs
+
+
+@pytest.mark.asyncio
+async def test_apply_vad_config_to_analyzer_object_access():
+    analyzer = _FakeAnalyzer(DEFAULTS)
+    vad_config = SimpleNamespace(
+        confidence=None, start_secs=0.05, stop_secs=None, min_volume=None
+    )
+    await _apply_vad_config_to_analyzer(
+        cast(VADAnalyzer, analyzer), cast(VadConfig, vad_config), call_sid="call-1"
+    )
+    assert analyzer.params.start_secs == 0.05
+    assert analyzer.params.confidence == DEFAULTS.confidence
+
+
+@pytest.mark.asyncio
+async def test_smart_turn_trigger_vad_keeps_its_own_stop_secs_default():
+    """Latency guard: the trigger must not inherit BB_TELEPHONY_VAD_STOP_SECS.
+
+    That flag is tuned for the plain-VAD/timeout path; retuning it there must
+    not change SmartTurn latency.
+    """
+    result = await build_smart_turn_trigger_vad_params(None)
+    assert result.stop_secs == SMART_TURN_TRIGGER_STOP_SECS
+    assert result.stop_secs != (await create_telephony_vad_params()).stop_secs
+
+
+@pytest.mark.asyncio
+async def test_smart_turn_trigger_vad_honours_template_override():
+    configurations = SimpleNamespace(
+        vad_config=SimpleNamespace(
+            confidence=None, start_secs=None, stop_secs=0.45, min_volume=None
+        )
+    )
+    result = await build_smart_turn_trigger_vad_params(
+        cast(ConfigurationModel, configurations)
+    )
+    assert result.stop_secs == 0.45
+
+
+@pytest.mark.asyncio
+async def test_smart_turn_trigger_vad_handles_configurations_without_vad_config():
+    configurations = SimpleNamespace(vad_config=None)
+    result = await build_smart_turn_trigger_vad_params(
+        cast(ConfigurationModel, configurations)
+    )
+    assert result == VADParams(stop_secs=SMART_TURN_TRIGGER_STOP_SECS)

--- a/tests/test_config_knob_registry.py
+++ b/tests/test_config_knob_registry.py
@@ -1,0 +1,370 @@
+"""Tests for the governed knob registry (config resolver Layer 2).
+
+Covers the three guarantees the registry exists to provide:
+  1. One precedence order for every knob
+     (playground > template > merchant > platform).
+  2. Floors/ceilings are enforced — a merchant knob can never cross them.
+  3. Unregistered config is fatal, not silently None.
+
+No Redis runs in unit tests, so the platform tier resolves
+env -> default via get_config (ENABLE_REDIS_DYNAMIC_CONFIG defaults False).
+"""
+
+import ast
+import pathlib
+import warnings
+from types import SimpleNamespace
+
+import pytest
+
+import app.core.config.resolver as resolver_mod
+from app.core.config.resolver import REGISTRY, Knob, Scope, register, resolve
+
+# ---------------------------------------------------------------------------
+#  Registry declarations are self-validating at import time
+# ---------------------------------------------------------------------------
+
+
+def test_registry_is_populated():
+    assert REGISTRY, "registry should ship with knobs declared"
+
+
+def test_every_registered_knob_is_internally_consistent():
+    """Each declaration must satisfy its own invariants (Knob.__post_init__).
+
+    Reconstructing each knob re-runs validation, so a bad edit to the
+    REGISTRY block fails here rather than at some 3am call site.
+    """
+    for key, knob in REGISTRY.items():
+        assert knob.key == key, f"{key!r} filed under a mismatched key"
+        Knob(
+            key=knob.key,
+            type=knob.type,
+            default=knob.default,
+            description=knob.description,
+            scope=knob.scope,
+            merchant_field=knob.merchant_field,
+            floor=knob.floor,
+            ceiling=knob.ceiling,
+        )
+
+
+def test_merchant_scope_requires_a_merchant_field():
+    with pytest.raises(ValueError, match="requires merchant_field"):
+        Knob(
+            key="X",
+            type=int,
+            default=1,
+            description="d",
+            scope=Scope.MERCHANT,
+        )
+
+
+def test_platform_scope_rejects_a_merchant_field():
+    with pytest.raises(ValueError, match="meaningless for a PLATFORM"):
+        Knob(
+            key="X",
+            type=int,
+            default=1,
+            description="d",
+            scope=Scope.PLATFORM,
+            merchant_field="foo",
+        )
+
+
+def test_bounds_rejected_on_non_numeric_knob():
+    with pytest.raises(ValueError, match="only apply to numeric"):
+        Knob(key="X", type=str, default="a", description="d", floor=1)
+
+
+def test_inverted_bounds_rejected():
+    with pytest.raises(ValueError, match=r"floor \(10\) > ceiling \(1\)"):
+        Knob(key="X", type=int, default=5, description="d", floor=10, ceiling=1)
+
+
+def test_default_outside_its_own_bounds_rejected():
+    with pytest.raises(ValueError, match="outside"):
+        Knob(key="X", type=int, default=99, description="d", floor=0, ceiling=10)
+
+
+def test_duplicate_key_rejected():
+    knob = Knob(key="BB_CALL_MAX_RETRY", type=int, default=1, description="d")
+    with pytest.raises(ValueError, match="Duplicate knob key"):
+        register(knob)
+
+
+# ---------------------------------------------------------------------------
+#  Precedence
+# ---------------------------------------------------------------------------
+
+
+async def test_falls_back_to_platform_default_with_no_overrides():
+    assert await resolve("BB_CALL_MAX_RETRY") == 3
+
+
+async def test_merchant_overrides_platform():
+    merchant = SimpleNamespace(max_retry=7)
+    assert await resolve("BB_CALL_MAX_RETRY", merchant_config=merchant) == 7
+
+
+async def test_template_overrides_merchant():
+    merchant = SimpleNamespace(max_retry=7)
+    resolved = await resolve(
+        "BB_CALL_MAX_RETRY", merchant_config=merchant, template_value=5
+    )
+    assert resolved == 5
+
+
+async def test_playground_overrides_everything():
+    merchant = SimpleNamespace(max_retry=7)
+    resolved = await resolve(
+        "BB_CALL_MAX_RETRY",
+        merchant_config=merchant,
+        template_value=5,
+        playground_value=2,
+    )
+    assert resolved == 2
+
+
+async def test_none_at_a_tier_falls_through_rather_than_winning():
+    """An absent override must not shadow a lower tier with None."""
+    merchant = SimpleNamespace(max_retry=7)
+    resolved = await resolve(
+        "BB_CALL_MAX_RETRY",
+        merchant_config=merchant,
+        template_value=None,
+        playground_value=None,
+    )
+    assert resolved == 7
+
+
+async def test_merchant_config_missing_the_field_falls_through():
+    """A merchant row that simply doesn't set the knob is not an override."""
+    merchant = SimpleNamespace()
+    assert await resolve("BB_CALL_MAX_RETRY", merchant_config=merchant) == 3
+
+
+async def test_merchant_config_none_falls_through():
+    assert await resolve("BB_CALL_MAX_RETRY", merchant_config=None) == 3
+
+
+# ---------------------------------------------------------------------------
+#  Floors and ceilings — the core governance guarantee
+# ---------------------------------------------------------------------------
+
+
+async def test_merchant_cannot_exceed_ceiling():
+    merchant = SimpleNamespace(max_retry=9999)
+    assert await resolve("BB_CALL_MAX_RETRY", merchant_config=merchant) == 10
+
+
+async def test_merchant_cannot_go_below_floor():
+    """Floor stops a merchant dialling a number every few seconds."""
+    merchant = SimpleNamespace(retry_offset=1)
+    resolved = await resolve("BB_CALL_RETRY_OFFSET_MINUTES", merchant_config=merchant)
+    assert resolved == 5
+
+
+async def test_template_is_clamped_too():
+    assert await resolve("BB_CALL_MAX_RETRY", template_value=500) == 10
+
+
+async def test_playground_is_clamped_too():
+    """Playground is highest precedence but still not above the platform."""
+    assert await resolve("BB_CALL_MAX_RETRY", playground_value=-4) == 0
+
+
+async def test_value_inside_bounds_is_untouched():
+    merchant = SimpleNamespace(max_retry=4)
+    assert await resolve("BB_CALL_MAX_RETRY", merchant_config=merchant) == 4
+
+
+async def test_boundary_values_are_inclusive():
+    for value, expected in ((0, 0), (10, 10)):
+        merchant = SimpleNamespace(max_retry=value)
+        assert await resolve("BB_CALL_MAX_RETRY", merchant_config=merchant) == expected
+
+
+async def test_clamp_is_logged(monkeypatch):
+    """A clamp is a misconfiguration — it must not happen silently.
+
+    The app logs through loguru, which does not propagate to pytest's
+    ``caplog``, so capture by swapping the module's logger (same approach as
+    tests/breeze_buddy/test_template_wire_alias.py).
+    """
+    captured = []
+
+    class _Stub:
+        def warning(self, msg, *args, **kwargs):
+            captured.append(str(msg).format(*args) if args else str(msg))
+
+    monkeypatch.setattr(resolver_mod, "logger", _Stub())
+    merchant = SimpleNamespace(max_retry=9999)
+    await resolve("BB_CALL_MAX_RETRY", merchant_config=merchant)
+
+    assert any("clamped" in line for line in captured), captured
+    assert any("BB_CALL_MAX_RETRY" in line for line in captured)
+
+
+async def test_no_clamp_no_warning(monkeypatch):
+    """An in-range value must stay quiet — no warning fatigue."""
+    captured = []
+
+    class _Stub:
+        def warning(self, msg, *args, **kwargs):
+            captured.append(str(msg))
+
+    monkeypatch.setattr(resolver_mod, "logger", _Stub())
+    merchant = SimpleNamespace(max_retry=4)
+    await resolve("BB_CALL_MAX_RETRY", merchant_config=merchant)
+
+    assert captured == []
+
+
+# ---------------------------------------------------------------------------
+#  Type coercion — tenant tiers are raw, unlike the platform tier
+# ---------------------------------------------------------------------------
+
+
+async def test_numeric_string_override_is_coerced():
+    """Template payloads are JSON; "5" and 5 both occur in the wild."""
+    assert await resolve("BB_CALL_MAX_RETRY", template_value="5") == 5
+
+
+async def test_coerced_string_override_is_still_clamped():
+    assert await resolve("BB_CALL_MAX_RETRY", template_value="500") == 10
+
+
+async def test_uncoercible_override_falls_through_with_a_warning(monkeypatch):
+    """Garbage at one tier degrades like an absent value, loudly."""
+    captured = []
+
+    class _Stub:
+        def warning(self, msg, *args, **kwargs):
+            captured.append(str(msg))
+
+    monkeypatch.setattr(resolver_mod, "logger", _Stub())
+    merchant = SimpleNamespace(max_retry=7)
+    resolved = await resolve(
+        "BB_CALL_MAX_RETRY", merchant_config=merchant, template_value="banana"
+    )
+
+    assert resolved == 7
+    assert any("template" in line and "banana" in line for line in captured), captured
+
+
+async def test_unbounded_knob_passes_string_through():
+    merchant = SimpleNamespace(inbound_call_timezone="Europe/Berlin")
+    resolved = await resolve("BB_MERCHANT_DEFAULT_TIMEZONE", merchant_config=merchant)
+    assert resolved == "Europe/Berlin"
+
+
+# ---------------------------------------------------------------------------
+#  Unregistered keys
+# ---------------------------------------------------------------------------
+
+
+async def test_unregistered_key_raises():
+    with pytest.raises(KeyError, match="not a registered knob"):
+        await resolve("BB_TOTALLY_MADE_UP_KNOB")
+
+
+async def test_platform_scoped_knob_ignores_merchant_config(monkeypatch):
+    """A PLATFORM knob must not be movable by a merchant row."""
+    monkeypatch.setitem(
+        REGISTRY,
+        "BB_TEST_PLATFORM_ONLY",
+        Knob(
+            key="BB_TEST_PLATFORM_ONLY",
+            type=int,
+            default=42,
+            description="test-only",
+            scope=Scope.PLATFORM,
+        ),
+    )
+    merchant = SimpleNamespace(BB_TEST_PLATFORM_ONLY=1, max_retry=1)
+    assert await resolve("BB_TEST_PLATFORM_ONLY", merchant_config=merchant) == 42
+
+
+# ---------------------------------------------------------------------------
+#  Enforcement of the registry's own rules
+#
+#  These make the "no config sprawl" rules mechanical instead of aspirational —
+#  the registry only helps if new env reads can't quietly appear beside it.
+# ---------------------------------------------------------------------------
+
+# Modules allowed to touch os.environ directly. Everything else must go
+# through resolve() / get_config(). Keep this list SHORT and justified.
+_ENV_READ_ALLOWLIST = {
+    # The static tier itself — this *is* the env layer.
+    "app/core/config/static.py",
+    # get_config's environment fallback — the env tier implementation.
+    "app/services/live_config/utils.py",
+}
+
+
+def _iter_app_py_files():
+    app_root = pathlib.Path(__file__).resolve().parent.parent / "app"
+    return sorted(app_root.rglob("*.py"))
+
+
+def _reads_env(source: str) -> bool:
+    """True if the module actually reads the environment.
+
+    Parses rather than grepping: a docstring that *mentions* ``os.environ``
+    (this rule is documented in the resolver itself) is not a violation.
+    Detects ``os.environ...`` and ``os.getenv(...)``, plus the
+    ``from os import environ/getenv`` spellings.
+    """
+    with warnings.catch_warnings():
+        # Some modules carry unrelated invalid-escape DeprecationWarnings in
+        # prompt strings; parsing them is not this test's concern.
+        warnings.simplefilter("ignore", DeprecationWarning)
+        tree = ast.parse(source)
+
+    bare_names = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.module == "os":
+            for alias in node.names:
+                if alias.name in ("environ", "getenv"):
+                    bare_names.add(alias.asname or alias.name)
+
+    for node in ast.walk(tree):
+        # os.environ / os.getenv
+        if isinstance(node, ast.Attribute) and node.attr in ("environ", "getenv"):
+            if isinstance(node.value, ast.Name) and node.value.id == "os":
+                return True
+        # environ[...] / getenv(...) imported directly
+        if isinstance(node, ast.Name) and node.id in bare_names:
+            return True
+    return False
+
+
+def test_module_code_never_reads_os_environ_directly():
+    """Config must flow through the resolver, not ad-hoc os.environ reads.
+
+    ~196 loose env constants in static.py are the scar this rule prevents.
+    If this fails: register a Knob and call resolve(), or justify an
+    allowlist entry.
+    """
+    repo_root = pathlib.Path(__file__).resolve().parent.parent
+    offenders = []
+
+    for path in _iter_app_py_files():
+        rel = path.relative_to(repo_root).as_posix()
+        if rel in _ENV_READ_ALLOWLIST:
+            continue
+        if _reads_env(path.read_text(encoding="utf-8")):
+            offenders.append(rel)
+
+    assert not offenders, (
+        "These modules read the environment directly instead of going "
+        f"through the config resolver: {offenders}"
+    )
+
+
+def test_env_read_allowlist_entries_still_exist():
+    """A stale allowlist silently widens the rule — keep it honest."""
+    repo_root = pathlib.Path(__file__).resolve().parent.parent
+    missing = [rel for rel in _ENV_READ_ALLOWLIST if not (repo_root / rel).is_file()]
+    assert not missing, f"allowlist references files that no longer exist: {missing}"

--- a/tests/test_config_resolver.py
+++ b/tests/test_config_resolver.py
@@ -1,0 +1,108 @@
+"""Unit tests for the shared config-precedence resolver primitives.
+
+Covers FieldSpec/resolve_field/resolve_fields in isolation: tier
+precedence, lazy evaluation (later tiers must not be called once an
+earlier one resolves), sync vs async tiers, and required-field errors.
+"""
+
+import pytest
+
+from app.core.config.resolver import (
+    FieldSpec,
+    resolve_field,
+    resolve_fields,
+)
+
+
+@pytest.mark.asyncio
+async def test_first_non_none_tier_wins():
+    spec = FieldSpec(name="x", tiers=[None, "second", "third"])
+    assert await resolve_field(spec) == "second"
+
+
+@pytest.mark.asyncio
+async def test_plain_value_tier():
+    spec = FieldSpec(name="x", tiers=["value"])
+    assert await resolve_field(spec) == "value"
+
+
+@pytest.mark.asyncio
+async def test_sync_callable_tier():
+    spec = FieldSpec(name="x", tiers=[lambda: None, lambda: "resolved"])
+    assert await resolve_field(spec) == "resolved"
+
+
+@pytest.mark.asyncio
+async def test_async_callable_tier():
+    async def getter():
+        return "async-value"
+
+    spec = FieldSpec(name="x", tiers=[None, getter])
+    assert await resolve_field(spec) == "async-value"
+
+
+@pytest.mark.asyncio
+async def test_later_tiers_not_evaluated_once_resolved():
+    calls = []
+
+    def tier_a():
+        calls.append("a")
+        return "value-a"
+
+    def tier_b():
+        calls.append("b")
+        return "value-b"
+
+    spec = FieldSpec(name="x", tiers=[tier_a, tier_b])
+    result = await resolve_field(spec)
+    assert result == "value-a"
+    assert calls == ["a"]
+
+
+@pytest.mark.asyncio
+async def test_all_none_returns_none_when_not_required():
+    spec = FieldSpec(name="x", tiers=[None, lambda: None])
+    assert await resolve_field(spec) is None
+
+
+@pytest.mark.asyncio
+async def test_required_field_missing_raises_with_custom_message():
+    spec = FieldSpec(
+        name="x",
+        tiers=[None],
+        required=True,
+        error_message="x is required",
+    )
+    with pytest.raises(ValueError, match="x is required"):
+        await resolve_field(spec)
+
+
+@pytest.mark.asyncio
+async def test_required_field_missing_raises_default_message():
+    spec = FieldSpec(name="x", tiers=[None], required=True)
+    with pytest.raises(ValueError, match="x has no value from any tier"):
+        await resolve_field(spec)
+
+
+@pytest.mark.asyncio
+async def test_required_field_present_does_not_raise():
+    spec = FieldSpec(name="x", tiers=[None, "ok"], required=True)
+    assert await resolve_field(spec) == "ok"
+
+
+@pytest.mark.asyncio
+async def test_resolve_fields_returns_flat_dict():
+    specs = [
+        FieldSpec(name="a", tiers=["1"]),
+        FieldSpec(name="b", tiers=[None, "2"]),
+    ]
+    assert await resolve_fields(specs) == {"a": "1", "b": "2"}
+
+
+@pytest.mark.asyncio
+async def test_zero_and_false_are_terminal_values_not_none():
+    # 0 and False are valid resolved values; only None should fall through.
+    spec_zero = FieldSpec(name="x", tiers=[0, "fallback"])
+    spec_false = FieldSpec(name="y", tiers=[False, "fallback"])
+    assert await resolve_field(spec_zero) == 0
+    assert await resolve_field(spec_false) is False


### PR DESCRIPTION
## Summary

Unifies VAD/TTS/STT/LLM config precedence into a shared resolver (`app/core/config/resolver.py`), and introduces a governed knob registry as groundwork for centralizing merchant-tunable config.

### Layer 1 — `FieldSpec` / `resolve_fields`
- New `FieldSpec` primitive: an ordered list of tiers (literal, sync callable, or async callable). The first non-`None` value wins. Tiers are evaluated lazily, so a Redis lookup is only made when every higher tier misses.
- Migrated `llm/__init__.py` (Azure, OpenAI, Vertex, Claude Vertex), `stt/__init__.py` (Soniox, Sarvam), `tts/__init__.py` (`resolve_voice_config`), and `template/vad.py` (`_layer_template_vad`, `_apply_vad_config_to_analyzer`, new `build_smart_turn_trigger_vad_params`) onto this shared primitive, replacing ad-hoc truthy-check fallback chains.
- `apply_node_vad_config` is now async; `transition_handler` awaits it.
- Pipeline's SmartTurn auto-created trigger VAD now resolves `stop_secs` (and other VAD params) through `template > Redis BB_TELEPHONY_VAD_*`, replacing the previous hardcoded `stop_secs=0.2`.
- `user_speech_timeout` resolution in `pipeline.py` was simplified to rely on `STTConfiguration`'s existing `_normalize_user_speech_timeout` validator instead of re-checking `TurnDetectionMode.TIMEOUT` inline.

### Layer 2 — Governed knob registry (`Knob` / `Scope` / `REGISTRY` / `resolve`)
- Declares a single source of truth for tunables that currently live as loose env constants, with per-knob type, default, scope (`PLATFORM` vs `MERCHANT`), and floor/ceiling bounds enforced unconditionally at every tier.
- Fixed precedence order for every registered knob: `playground > template > merchant > platform (Redis/env/default)`.
- Ships with an initial set of outbound-calling knobs (`BB_CALL_MAX_RETRY`, `BB_CALL_RETRY_OFFSET_MINUTES`, `BB_CALL_INITIAL_OFFSET_MINUTES`, `BB_CALL_RATE_LIMIT_MAX_CALLS`, `BB_CALL_RATE_LIMIT_WINDOW_SECONDS`, `BB_MERCHANT_DEFAULT_TIMEZONE`).
- **Not yet wired into any call site** — this PR declares and unit-tests the registry only; integration into outbound-calling code paths is follow-up work.
- Adds a repo-wide test (`test_module_code_never_reads_os_environ_directly`) enforcing that no module outside `static.py`/`live_config/utils.py` reads `os.environ`/`os.getenv` directly, to prevent further env-constant sprawl.

### Tests
- `tests/test_config_resolver.py`, `tests/test_config_knob_registry.py` (new, root-level — Layer 1/2 primitives).
- `tests/breeze_buddy/test_config_resolver.py`, `test_llm_resolve_config.py`, `test_stt_resolve_config.py`, `test_tts_resolve_voice_config.py`, `test_vad_resolution.py` (breeze-buddy-specific regression coverage for the migrated call sites).

### Known follow-ups
- Reconcile new `BB_CALL_RATE_LIMIT_MAX_CALLS`/`BB_CALL_RATE_LIMIT_WINDOW_SECONDS` knobs with the existing `OUTBOUND_RATE_LIMIT_MAX_CALLS`/`OUTBOUND_RATE_LIMIT_WINDOW_SECONDS` dynamic config (different defaults: 100 vs 7).
- Wire the knob registry into actual outbound-calling call sites.