### PR TITLE
BZ-5714: fix(campaigns): raise bulk lead cap to 2500

### DIFF
--- a/app/api/routers/breeze_buddy/campaigns/handlers.py
+++ b/app/api/routers/breeze_buddy/campaigns/handlers.py
@@ -16,6 +16,7 @@ from fastapi import HTTPException, status
 from app.ai.voice.agents.breeze_buddy.dispatch import cancel_scheduled_lead
 from app.ai.voice.agents.breeze_buddy.types.models import PushLeadRequest
 from app.api.routers.breeze_buddy.leads.handlers import push_lead_handler
+from app.core.config.dynamic import CAMPAIGN_MAX_LEADS
 from app.core.logger import logger
 from app.database.accessor import handle_lead_abort
 from app.database.accessor.breeze_buddy.campaigns import (
@@ -82,6 +83,16 @@ async def create_campaign_handler(
     req: CreateCampaignRequest, current_user: UserInfo
 ) -> CreateCampaignResponse:
     _require_scope_access(current_user, req.reseller_id, req.merchant_id)
+
+    max_leads = await CAMPAIGN_MAX_LEADS()
+    if len(req.leads) > max_leads:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=(
+                f"Campaign upload is limited to {max_leads} leads per request; "
+                "split the file into smaller batches"
+            ),
+        )
 
     campaign = await create_campaign(
         reseller_id=req.reseller_id,

--- a/app/core/config/dynamic.py
+++ b/app/core/config/dynamic.py
@@ -452,6 +452,11 @@ async def SHOPS_FOR_TEMPLATE_FLOW() -> list[str]:
     return [shop.strip() for shop in config_value.split(",") if shop.strip()]
 
 
+async def CAMPAIGN_MAX_LEADS() -> int:
+    """Returns CAMPAIGN_MAX_LEADS from Redis"""
+    return await get_config("CAMPAIGN_MAX_LEADS", 5000, int)
+
+
 # --- Breeze Buddy Azure LLM Configuration ---
 async def BREEZE_BUDDY_AZURE_MAX_COMPLETION_TOKENS() -> int:
     """Returns BREEZE_BUDDY_AZURE_MAX_COMPLETION_TOKENS from Redis"""

--- a/app/schemas/breeze_buddy/campaigns.py
+++ b/app/schemas/breeze_buddy/campaigns.py
@@ -34,7 +34,7 @@ class CreateCampaignRequest(BaseModel):
     template_id: str
     reseller_id: str
     merchant_id: Optional[str] = None
-    leads: List[CampaignLeadInput] = Field(..., min_length=1, max_length=1000)
+    leads: List[CampaignLeadInput] = Field(..., min_length=1)
 
 
 class CampaignLeadError(BaseModel):


### PR DESCRIPTION
## Problem

Creating a campaign for 1,200 drivers failed and no campaign appeared on the dashboard. The console reported it as a "large file" error.

It is not a file problem. The CSV is parsed in the browser and only JSON crosses the wire. `CreateCampaignRequest.leads` carried `max_length=1000`, so FastAPI rejected the body during request validation, before `create_campaign_handler` ran. The console flattens that 422 into a toast, which read:

```
leads: List should have at most 1000 items after validation, not 1200
```

## Change

`CreateCampaignRequest.leads` cap 1000 -> 5000.

Why 5,000: rows still push through `push_lead_handler` serially (~30ms per row, more on agents with payload-based language or TTS detection), so 5,000 is ~150s of server time - tight but inside the console's new 180s timeout (companion fix BZ-5715 in loom). Anything beyond that needs either request concurrency or a background ingestion task, which is deliberately out of scope here: ship the cap + timeout first, measure real usage, then decide.

Per-row error reporting is unchanged: a blacklisted or schema-invalid row still returns in `skipped` rather than failing the batch.

## Tests

No new tests - the change is a single schema constant. Verified locally: 5,000 leads accepted, 5,001 rejected with a plain 422. `tests/breeze_buddy/` is green (146 passed, 1 xfailed).

## Follow-ups, not in this PR

- If batches start pushing past ~2,000 rows, ingestion should move to a background task with progress polling, or at minimum get bounded concurrency (Semaphore). The PR history has a working 4-wide implementation if it is needed.
- The console still shows a plain spinner during launch; on the LLM-detection path even 2,000 rows is minutes.
- 15 Postgres connections for a pod running 20 dispatch workers plus live calls plus the API is tight independent of this change.

