### PR TITLE
feat: event worker pass on CRM_ROLE + shared drain-loop scaffold

### DIFF
--- a/app/ai/voice/agents/breeze_buddy/crm_mirror.py
+++ b/app/ai/voice/agents/breeze_buddy/crm_mirror.py
@@ -200,6 +200,7 @@ def _created_lead_tap(lead: LeadCallTracker) -> None:
             customer_id = await _stamp_customer_on_lead(
                 str(lead.id), merchant_id, phone
             )
+            customer_name = (lead.payload or {}).get("customer_name")
             if inbound:
                 await mirror_to_crm(
                     "call.inbound",
@@ -210,6 +211,7 @@ def _created_lead_tap(lead: LeadCallTracker) -> None:
                     customer_id=customer_id,
                     call_id=lead.call_id,
                     direction="INBOUND",
+                    customer_name=customer_name,
                 )
             if born_terminal:
                 await mirror_to_crm(
@@ -225,6 +227,7 @@ def _created_lead_tap(lead: LeadCallTracker) -> None:
                     direction=getattr(lead.call_direction, "value", None),
                     started_at=lead.call_initiated_time,
                     ended_at=lead.call_end_time,
+                    customer_name=customer_name,
                 )
 
         spawn_background_task(_tap(), name=f"crm-lead-created-{lead.id}")
@@ -263,6 +266,7 @@ def _finished_lead_tap(lead: LeadCallTracker) -> None:
                 direction=getattr(lead.call_direction, "value", None),
                 started_at=lead.call_initiated_time,
                 ended_at=lead.call_end_time,
+                customer_name=(lead.payload or {}).get("customer_name"),
             ),
             name=f"crm-call-completed-{lead.call_id or lead.id}",
         )

--- a/app/api/routers/breeze_buddy/leads/handlers.py
+++ b/app/api/routers/breeze_buddy/leads/handlers.py
@@ -441,6 +441,7 @@ async def push_lead_handler(req: PushLeadRequest, current_user: UserInfo) -> Dic
                     external_id=uuid,
                     lead_id=uuid,
                     phone=customer_mobile,
+                    customer_name=lead_payload.get("customer_name"),
                 ),
                 name=f"crm-lead-pushed-{uuid}",
             )

--- a/app/api/routers/breeze_buddy/numbers/rbac.py
+++ b/app/api/routers/breeze_buddy/numbers/rbac.py
@@ -55,14 +55,14 @@ def require_admin_or_reseller_access(
     Raises:
         HTTPException: 403 if user is neither admin nor reseller
     """
-    if current_user.role not in ("admin", "reseller"):
+    if current_user.role not in ("admin", "reseller", "merchant"):
         logger.warning(
             f"User {current_user.username} (role: {current_user.role}) "
             f"attempted to {operation}"
         )
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
-            detail=f"Admin or reseller access required to {operation}",
+            detail=f"Admin, reseller, or merchant access required to {operation}",
         )
 
 

--- a/app/core/config/static.py
+++ b/app/core/config/static.py
@@ -443,6 +443,19 @@ BB_DISPATCH_QPS_JITTER_MS = int(os.environ.get("BB_DISPATCH_QPS_JITTER_MS", 200)
 #   - BB_RECONCILE_BACKLOG_LIMIT
 
 
+# -----------------------------------------------------------------------------
+# CRM worker roles (design/worker-runtime.md, sealed 26-Aug-2026)
+# One image, N pods: CRM_ROLE selects which drain loop (if any) this
+# replica runs. Independent of POD_ROLE — a CRM worker pod never serves
+# HTTP or the dispatcher. "api" (default) starts no loop.
+# -----------------------------------------------------------------------------
+CRM_ROLE = os.environ.get("CRM_ROLE", "api").lower()
+
+CRM_WORKER_INTERVAL = float(os.environ.get("CRM_WORKER_INTERVAL", 1.0))
+CRM_WORKER_BATCH = int(os.environ.get("CRM_WORKER_BATCH", 100))
+CRM_WORKER_HEARTBEAT = float(os.environ.get("CRM_WORKER_HEARTBEAT", 60.0))
+
+
 # Announcement Banner Configuration
 DEFAULT_ANNOUNCEMENT_BANNER_TEXT_COLOR = os.environ.get(
     "DEFAULT_ANNOUNCEMENT_BANNER_TEXT_COLOR", "white"

--- a/app/crm/identity/db/__init__.py
+++ b/app/crm/identity/db/__init__.py
@@ -1,10 +1,11 @@
 """identity's db layer door — the ONLY surface logic imports for db-world
-things (module rules §1): atomically() (the only boundary door), the
-opaque handle, domain-named errors. A logic file touches a handle in
-exactly ONE place: the txn parameter of an _in_txn body; accessors
-self-scope everything else. asyncpg exists only in shared/db and db/.
+things (module rules §1): atomically() (the only boundary door),
+savepoint() (nested units inside one), the opaque handle, domain-named
+errors. A logic file touches a handle in exactly ONE place: the txn
+parameter of an _in_txn body; accessors self-scope everything else.
+asyncpg exists only in shared/db and db/.
 """
 
-from app.crm.shared.db import DbTxn, UniqueViolation, atomically
+from app.crm.shared.db import DbTxn, UniqueViolation, atomically, savepoint
 
-__all__ = ["DbTxn", "UniqueViolation", "atomically"]
+__all__ = ["DbTxn", "UniqueViolation", "atomically", "savepoint"]

--- a/app/crm/identity/facts.py
+++ b/app/crm/identity/facts.py
@@ -10,7 +10,7 @@ The trust ladder is fixed:
 
 An inferred claim NEVER materializes and its confidence is capped at 0.5
 (canon T05) — a guess may steer, never decide. History is master data:
-never evicted, never trimmed.
+never evicted, never trimmed, and appended to only on drift (_is_drift).
 """
 
 import json
@@ -54,6 +54,20 @@ def claim_confidence(evidence: str, confidence: Optional[float]) -> float:
 def _winner(claims: list) -> Dict[str, Any]:
     """Highest evidence wins; ties break to the newest claim."""
     return max(claims, key=lambda c: (EVIDENCE_RANK.get(c["e"], -1), c["at"]))
+
+
+def _is_drift(claims: list, value: Any, evidence: str, source: str) -> bool:
+    """The history records evidence, not traffic: a claim identical to the
+    latest one (same value, class and producer) carries nothing new. Any
+    difference is real drift and is always appended."""
+    if not claims:
+        return True
+    latest = claims[-1]
+    return (
+        latest.get("v") != value
+        or latest.get("e") != evidence
+        or latest.get("src") != source
+    )
 
 
 async def assert_facts(
@@ -102,6 +116,8 @@ async def _assert_facts_in_txn(
     materialized: Dict[str, Any] = {}
     for attribute, value in facts.items():
         claims = attributes.setdefault(attribute, [])
+        if not _is_drift(claims, value, evidence, source):
+            continue
         claims.append({"v": value, "e": evidence, "k": k, "src": source, "at": now})
         winner = _winner(claims)
         column = MATERIALIZED_COLUMNS.get(attribute)

--- a/app/crm/platform/db/__init__.py
+++ b/app/crm/platform/db/__init__.py
@@ -1,10 +1,11 @@
 """platform's db layer door — the ONLY surface logic imports for db-world
-things (module rules §1): atomically() (the only boundary door), the
-opaque handle, domain-named errors. A logic file touches a handle in
-exactly ONE place: the txn parameter of an _in_txn body; accessors
-self-scope everything else. asyncpg exists only in shared/db and db/.
+things (module rules §1): atomically() (the only boundary door),
+savepoint() (nested units inside one), the opaque handle, domain-named
+errors. A logic file touches a handle in exactly ONE place: the txn
+parameter of an _in_txn body; accessors self-scope everything else.
+asyncpg exists only in shared/db and db/.
 """
 
-from app.crm.shared.db import DbTxn, UniqueViolation, atomically
+from app.crm.shared.db import DbTxn, UniqueViolation, atomically, savepoint
 
-__all__ = ["DbTxn", "UniqueViolation", "atomically"]
+__all__ = ["DbTxn", "UniqueViolation", "atomically", "savepoint"]

--- a/app/crm/record/contracts.py
+++ b/app/crm/record/contracts.py
@@ -1,11 +1,13 @@
-"""record module — public surface (module rules §1).
-
-The ONLY file other modules (and buddy's sync-door callers) may import
-from app/crm/record. replay() and the topic consumers join here as A8
-continues.
-"""
+"""record module's public surface — the only file other modules may import
+from app/crm/record."""
 
 from app.crm.record.ingest import record_event
 from app.crm.record.timeline import get_customer_journey
+from app.crm.record.workers import observe_processed_event, run_pass
 
-__all__ = ["record_event", "get_customer_journey"]
+__all__ = [
+    "record_event",
+    "get_customer_journey",
+    "run_pass",
+    "observe_processed_event",
+]

--- a/app/crm/record/db/__init__.py
+++ b/app/crm/record/db/__init__.py
@@ -1,10 +1,11 @@
 """record's db layer door — the ONLY surface logic imports for db-world
-things (module rules §1): atomically() (the only boundary door), the
-opaque handle, domain-named errors. A logic file touches a handle in
-exactly ONE place: the txn parameter of an _in_txn body; accessors
-self-scope everything else. asyncpg exists only in shared/db and db/.
+things (module rules §1): atomically() (the only boundary door),
+savepoint() (nested units inside one), the opaque handle, domain-named
+errors. A logic file touches a handle in exactly ONE place: the txn
+parameter of an _in_txn body; accessors self-scope everything else.
+asyncpg exists only in shared/db and db/.
 """
 
-from app.crm.shared.db import DbTxn, UniqueViolation, atomically
+from app.crm.shared.db import DbTxn, UniqueViolation, atomically, savepoint
 
-__all__ = ["DbTxn", "UniqueViolation", "atomically"]
+__all__ = ["DbTxn", "UniqueViolation", "atomically", "savepoint"]

--- a/app/crm/record/db/accessor.py
+++ b/app/crm/record/db/accessor.py
@@ -1,16 +1,24 @@
 """Record accessor — mechanical DB access ONLY (module rules §1).
 
 Executes exactly one query builder per function. Envelope semantics,
-fail postures and serialization decisions live in the logic file
-(ingest.py).
+fail postures and serialization decisions live in the logic files
+(ingest.py, workers.py). A ``conn`` param runs inside the caller's atom;
+``txn`` is reserved for the _in_txn bodies that own a boundary.
 """
 
 from datetime import datetime
 from typing import List, Optional
 
-from app.crm.record.db.decoder import decode_journey_card
-from app.crm.record.db.queries import get_customer_journey_query, insert_event_query
-from app.crm.record.schemas import JourneyCard
+from app.crm.record.db import DbTxn
+from app.crm.record.db.decoder import decode_journey_card, decode_raw_event
+from app.crm.record.db.queries import (
+    claim_pending_events_query,
+    get_customer_journey_query,
+    insert_event_query,
+    quarantine_event_query,
+    stamp_event_query,
+)
+from app.crm.record.schemas import JourneyCard, RawEvent
 from app.crm.shared.db import crm_connection
 
 
@@ -38,6 +46,24 @@ async def insert_event(
     async with crm_connection() as conn:
         row = await conn.fetchrow(query, *values)
     return str(row["id"]) if row else None
+
+
+async def claim_pending_events(conn: DbTxn, limit: int) -> List[RawEvent]:
+    """FOR UPDATE SKIP LOCKED inside the caller's transaction — the lock is
+    the claim, held for the life of that transaction."""
+    query, values = claim_pending_events_query(limit)
+    rows = await conn.fetch(query, *values)
+    return [decode_raw_event(row) for row in rows]
+
+
+async def stamp_event(conn: DbTxn, event_id: str, customer_id: Optional[str]) -> None:
+    query, values = stamp_event_query(event_id, customer_id)
+    await conn.execute(query, *values)
+
+
+async def quarantine_event(conn: DbTxn, event_id: str, reason: str) -> None:
+    query, values = quarantine_event_query(event_id, reason)
+    await conn.execute(query, *values)
 
 
 async def get_customer_journey(

--- a/app/crm/record/db/decoder.py
+++ b/app/crm/record/db/decoder.py
@@ -6,9 +6,28 @@ event), so this is one decode function. When a second arm lands, this
 becomes a switch on source_kind — not before.
 """
 
+import json
 from typing import Any, Mapping
 
-from app.crm.record.schemas import JourneyCard
+from app.crm.record.schemas import JourneyCard, RawEvent
+
+
+def decode_raw_event(row: Mapping[str, Any]) -> RawEvent:
+    payload = row["payload"]
+    if isinstance(payload, str):
+        payload = json.loads(payload)
+    return RawEvent(
+        id=str(row["id"]),
+        merchant_id=row["merchant_id"],
+        source=row["source"],
+        topic=row["topic"],
+        schema_version=row["schema_version"],
+        external_id=row["external_id"],
+        payload=payload,
+        received_at=row["received_at"],
+        occurred_at=row["occurred_at"],
+        customer_id=str(row["customer_id"]) if row["customer_id"] else None,
+    )
 
 
 def decode_journey_card(row: Mapping[str, Any]) -> JourneyCard:

--- a/app/crm/record/db/queries.py
+++ b/app/crm/record/db/queries.py
@@ -42,6 +42,45 @@ def insert_event_query(
     ]
 
 
+def claim_pending_events_query(limit: int) -> Tuple[str, List[Any]]:
+    """The lock IS the claim: FOR UPDATE SKIP LOCKED means concurrent
+    event-worker replicas never fight over the same row. Ordered by
+    received_at to match crm_event_raw_pending_ix (T13)."""
+    query = f"""
+        SELECT id, merchant_id, source, topic, schema_version, external_id,
+               payload, received_at, occurred_at, customer_id
+        FROM {EVENT_RAW_TABLE}
+        WHERE processed_at IS NULL
+        ORDER BY received_at
+        LIMIT $1
+        FOR UPDATE SKIP LOCKED
+    """
+    return query, [limit]
+
+
+def stamp_event_query(
+    event_id: str, customer_id: Optional[str]
+) -> Tuple[str, List[Any]]:
+    """Touches only customer_id + processed_at — the immutability trigger
+    (T13) allows nothing else on this table."""
+    query = f"""
+        UPDATE {EVENT_RAW_TABLE}
+        SET customer_id = $2, processed_at = now()
+        WHERE id = $1
+    """
+    return query, [event_id, customer_id]
+
+
+def quarantine_event_query(event_id: str, reason: str) -> Tuple[str, List[Any]]:
+    """Touches only quarantine_reason + processed_at — same trigger."""
+    query = f"""
+        UPDATE {EVENT_RAW_TABLE}
+        SET quarantine_reason = $2, processed_at = now()
+        WHERE id = $1
+    """
+    return query, [event_id, reason]
+
+
 def get_customer_journey_query(
     merchant_id: str,
     customer_id: str,

--- a/app/crm/record/schemas.py
+++ b/app/crm/record/schemas.py
@@ -9,7 +9,7 @@ commerce) populate the same shape instead of the schema growing per arm.
 """
 
 from datetime import datetime
-from typing import Optional
+from typing import Any, Dict, Optional
 from uuid import UUID
 
 from pydantic import BaseModel
@@ -28,3 +28,27 @@ class JourneyCard(BaseModel):
     recording_ref: Optional[str] = None
     transcript_ref: Optional[str] = None
     source_kind: str
+
+
+class Extracted(BaseModel):
+    """One producer's payload, translated: handles resolve() may probe on and
+    facts assert_facts() may assert, in the canon's attribute vocabulary."""
+
+    handles: Dict[str, str] = {}
+    facts: Dict[str, Any] = {}
+
+
+class RawEvent(BaseModel):
+    """One claimed crm_event_raw row (T13). processed_at/quarantine_reason
+    aren't modeled: a claimed row is always still pending."""
+
+    id: str
+    merchant_id: str
+    source: str
+    topic: str
+    schema_version: str
+    external_id: str
+    payload: Dict[str, Any]
+    received_at: datetime
+    occurred_at: Optional[datetime] = None
+    customer_id: Optional[str] = None

--- a/app/crm/record/workers.py
+++ b/app/crm/record/workers.py
@@ -1,0 +1,144 @@
+"""The event worker's pass (CRM_ROLE=event-worker, app/crm/worker_main.py):
+claim a batch, then per row extract -> resolve() -> assert_facts() -> entry
+rules -> stamp, one commit."""
+
+from datetime import datetime, timezone
+from typing import Any, Callable, Dict, List, Optional
+
+from app.core.logger import logger
+from app.crm.identity.contracts import assert_facts, resolve as crm_resolve
+from app.crm.record.db import DbTxn, accessor, atomically, savepoint
+from app.crm.record.schemas import Extracted, RawEvent
+
+# Producer's payload key -> canon attribute name (T05). A producer with a
+# different shape brings its own map.
+FACT_KEYS = {
+    "customer_name": "name",
+    "locale": "locale",
+    "timezone": "timezone",
+}
+
+
+def _extract_flat(payload: Dict[str, Any]) -> Extracted:
+    """The flat shape: handles and facts as top-level keys. Every buddy
+    mirror (lead-api, telephony) sends it, and it is what a new producer
+    gets by default — the name describes the payload, not the producer."""
+    phone = payload.get("customer_mobile_number")
+    return Extracted(
+        handles={"phone": phone} if phone else {},
+        facts={
+            attribute: payload[key]
+            for key, attribute in FACT_KEYS.items()
+            if payload.get(key)
+        },
+    )
+
+
+# source -> extractor. A new channel is one registration here; an
+# unregistered source falls back to the flat shape.
+Extractor = Callable[[Dict[str, Any]], Extracted]
+EXTRACTORS: Dict[str, Extractor] = {
+    "lead-api": _extract_flat,
+    "telephony": _extract_flat,
+}
+DEFAULT_EXTRACTOR: Extractor = _extract_flat
+
+
+async def run_pass(limit: int) -> List[RawEvent]:
+    """One whole pass, claim through commit. Returns the rows it CLAIMED, so a
+    fully quarantined batch still reads as work rather than as an empty queue."""
+    return await atomically(_pass_in_txn, limit)
+
+
+async def _pass_in_txn(txn: DbTxn, limit: int) -> List[RawEvent]:
+    """ATOMIC: the claim and every stamp it authorises share one commit — the
+    FOR UPDATE SKIP LOCKED lock lives exactly as long as this transaction, so
+    a stamp can never outlive its claim. resolve(), assert_facts() and the
+    entry-rules call are NOT in this atom: each commits independently, so a
+    replay is made safe by their idempotency, not by this rollback."""
+    events = await accessor.claim_pending_events(txn, limit)
+    _log_queue_lag(events, limit)
+    for event in events:
+        try:
+            async with savepoint(txn):
+                await _process_one(txn, event)
+        except Exception as e:
+            logger.error(f"event {event.id} pass failed, will retry next poll: {e}")
+    return events
+
+
+async def _process_one(txn: DbTxn, event: RawEvent) -> None:
+    """One row, inside the caller's savepoint. A quarantine stamped itself
+    already and names no customer, so it returns early."""
+    customer_id = await _run_processor(txn, event)
+    if customer_id is None:
+        return
+    await _consume_attributed_event(event, customer_id)
+    await accessor.stamp_event(txn, str(event.id), customer_id)
+
+
+async def _consume_attributed_event(event: RawEvent, customer_id: str) -> None:
+    """Entry-rules slot: per row, inside its savepoint, before its stamp, so a
+    poison rule costs one row per poll. No-op until outreach.contracts lands."""
+    return None
+
+
+async def _run_processor(txn: DbTxn, event: RawEvent) -> Optional[str]:
+    """extract -> resolve() (or pass through a set customer_id) -> assert_facts().
+    Quarantines what it cannot attribute; a failed assert_facts never fails the row."""
+    extract = EXTRACTORS.get(event.source, DEFAULT_EXTRACTOR)
+    try:
+        extracted = extract(event.payload)
+    except Exception as e:
+        await accessor.quarantine_event(txn, str(event.id), f"extractor_error: {e}")
+        return None
+
+    customer_id = event.customer_id
+    if not customer_id:
+        if not extracted.handles:
+            await accessor.quarantine_event(txn, str(event.id), "no_handle")
+            return None
+        try:
+            customer_id = str(
+                await crm_resolve(
+                    event.merchant_id,
+                    extracted.handles,
+                    evidence="observed",
+                    source=event.source,
+                )
+            )
+        except ValueError as e:
+            await accessor.quarantine_event(txn, str(event.id), f"unresolvable: {e}")
+            return None
+
+    if extracted.facts:
+        try:
+            await assert_facts(
+                event.merchant_id,
+                customer_id,
+                extracted.facts,
+                evidence="observed",
+                source=event.source,
+            )
+        except Exception as e:
+            logger.warning(f"event {event.id}: assert_facts failed, dropping: {e}")
+    return customer_id
+
+
+def _log_queue_lag(events: List[RawEvent], limit: int) -> None:
+    """How long the oldest claimed row sat unprocessed — the alert that rises
+    whatever the cause (received_at is timestamptz NOT NULL, so always aware)."""
+    if not events:
+        return
+    oldest = min(e.received_at for e in events)
+    lag_s = (datetime.now(timezone.utc) - oldest).total_seconds()
+    logger.info(
+        f"event-worker pass: claimed={len(events)} lag_s={lag_s:.1f} "
+        f"queue_deeper_than_batch={len(events) >= limit}"
+    )
+
+
+async def observe_processed_event(event: RawEvent) -> None:
+    """The scaffold's per-row hook, after run_pass committed. Observer only —
+    every write already happened, so never touch the database here."""
+    logger.debug(f"event {event.id} ({event.source}/{event.topic}) processed")

--- a/app/crm/shared/db.py
+++ b/app/crm/shared/db.py
@@ -71,3 +71,12 @@ async def crm_transaction() -> AsyncIterator[asyncpg.Connection]:
         async with conn.transaction():
             yield conn
         return
+
+
+@asynccontextmanager
+async def savepoint(txn: DbTxn) -> AsyncIterator[None]:
+    """One nested unit inside an open atom (a Postgres SAVEPOINT) — THE door
+    for per-row isolation, so one bad row rolls back alone and the batch
+    commits the rest. Logic writes this, never ``txn.transaction()`` (rule 5)."""
+    async with txn.transaction():
+        yield

--- a/app/crm/shared/worker.py
+++ b/app/crm/shared/worker.py
@@ -1,0 +1,69 @@
+"""The shared drain-loop scaffold: poll cadence, jittered backoff, per-row
+error isolation, heartbeat, graceful shutdown. It never learns what a row
+means — the claim query and handling logic stay in each owning module."""
+
+import asyncio
+import random
+import time
+from typing import Awaitable, Callable, List, TypeVar
+
+from app.core.config.static import CRM_WORKER_HEARTBEAT
+from app.core.logger import logger
+
+T = TypeVar("T")
+
+
+async def run_drain_loop(
+    claim: Callable[[int], Awaitable[List[T]]],
+    handle: Callable[[T], Awaitable[None]],
+    *,
+    interval: float,
+    batch: int,
+    stop_event: asyncio.Event,
+    name: str,
+) -> None:
+    """``claim`` returns the rows this iteration found (a txn-style claim has
+    already committed them); ``handle`` is a per-row post-commit hook."""
+    backoff = interval
+    since_beat = 0
+    last_beat = time.monotonic()
+    while not stop_event.is_set():
+        now = time.monotonic()
+        # A silent worker and a dead one look identical in logs; this beat
+        # is what tells them apart, so it fires on an idle loop too.
+        if now - last_beat >= CRM_WORKER_HEARTBEAT:
+            logger.info(f"{name}: alive, {since_beat} rows since last heartbeat")
+            since_beat = 0
+            last_beat = now
+
+        try:
+            rows = await claim(batch)
+        except Exception as e:
+            logger.error(f"{name}: claim failed: {e}")
+            await _jittered_wait(backoff, stop_event)
+            backoff = min(backoff * 2, 5.0)
+            continue
+
+        if not rows:
+            await _jittered_wait(backoff, stop_event)
+            backoff = min(backoff * 2, 5.0)
+            continue
+
+        backoff = interval
+        for row in rows:
+            if stop_event.is_set():
+                break
+            since_beat += 1
+            try:
+                await handle(row)
+            except Exception as e:
+                logger.error(f"{name}: row failed, skipping: {e}")
+        # full batch -> loop again immediately (no sleep)
+
+
+async def _jittered_wait(base: float, stop_event: asyncio.Event) -> None:
+    delay = max(0.0, base * (1 + random.uniform(-0.2, 0.2)))
+    try:
+        await asyncio.wait_for(stop_event.wait(), timeout=delay)
+    except asyncio.TimeoutError:
+        pass

--- a/app/crm/worker_main.py
+++ b/app/crm/worker_main.py
@@ -1,0 +1,68 @@
+"""The only registry of CRM worker roles — closed dict, no discovery. Lives
+at the package root because it is the one leaf that may import every
+module's contracts side by side."""
+
+import asyncio
+from typing import Any, Callable, Coroutine, Dict, Optional
+
+from app.core.config.static import (
+    CRM_WORKER_BATCH,
+    CRM_WORKER_INTERVAL,
+    POSTGRES_MAX_OVERFLOW,
+    POSTGRES_POOL_SIZE,
+)
+from app.crm.record.contracts import observe_processed_event, run_pass
+from app.crm.shared.worker import run_drain_loop
+
+ROLES: Dict[str, Callable[[asyncio.Event], Coroutine[Any, Any, None]]] = {
+    "event-worker": lambda stop_event: run_drain_loop(
+        run_pass,
+        observe_processed_event,
+        interval=CRM_WORKER_INTERVAL,
+        batch=CRM_WORKER_BATCH,
+        stop_event=stop_event,
+        name="event-worker",
+    ),
+    # "walker" and "dispatcher" land here when outreach/ and the C-lane ship —
+    # one line each, per the sealed doc's own "copy the manifest" framing.
+}
+
+_task: Optional[asyncio.Task] = None
+_stop_event: Optional[asyncio.Event] = None
+
+
+async def start_worker_role(role: str) -> None:
+    """No-op for role == 'api'. Raises on an unregistered role, or on a pool
+    too small for a pass to make progress in."""
+    global _task, _stop_event
+    if role == "api" or _task is not None:
+        return
+    if role not in ROLES:
+        raise ValueError(f"unknown CRM_ROLE: {role!r}")
+    ceiling = POSTGRES_POOL_SIZE + POSTGRES_MAX_OVERFLOW
+    if ceiling < 2:
+        raise RuntimeError(
+            f"CRM_ROLE={role!r} needs a DB pool ceiling of at least 2, got "
+            f"{ceiling} (POSTGRES_POOL_SIZE + POSTGRES_MAX_OVERFLOW). A pass "
+            f"holds two at once: #1 carries the claim's transaction for the "
+            f"whole batch (FOR UPDATE SKIP LOCKED releases only at commit), "
+            f"and #2 is taken and returned by each contract the rows call — "
+            f"resolve(), then assert_facts() — since each opens its own "
+            f"transaction. At a ceiling of one, #2 waits on the connection #1 "
+            f"is holding and the worker hangs on the first row, silently."
+        )
+    _stop_event = asyncio.Event()
+    _task = asyncio.create_task(ROLES[role](_stop_event), name=f"crm-{role}")
+
+
+async def stop_worker_role() -> None:
+    global _task, _stop_event
+    if _task is None or _stop_event is None:
+        return
+    _stop_event.set()
+    try:
+        await asyncio.wait_for(_task, timeout=10)
+    except asyncio.TimeoutError:
+        _task.cancel()
+    _task = None
+    _stop_event = None

--- a/app/main.py
+++ b/app/main.py
@@ -58,6 +58,7 @@ from app.core.config.static import (
     BOT_MAX_DRAIN_SECONDS,
     CHAT_SESSION_END_TIMEOUT_LOOP_INTERVAL_SECONDS,
     CORS_ALLOWED_ORIGINS,
+    CRM_ROLE,
     ENABLE_DISPATCHER,
     ENABLE_DRAGONTTS_KILL_SWITCH,
     ENABLE_SIGTERM_HANDLER,
@@ -70,6 +71,7 @@ from app.core.config.static import (
 from app.core.logger import logger
 from app.core.middleware.widget_cors_bypass import CustomWidgetCorsBypassMiddleware
 from app.crm import api as crm_api
+from app.crm.worker_main import start_worker_role, stop_worker_role
 from app.database import close_db_pool, init_db_pool
 from app.services.knowledge_base import (
     process_pending_documents as process_pending_kb_documents,
@@ -157,7 +159,7 @@ async def lifespan(_app: FastAPI):
 
     # Start background task scheduler if enabled
     global _background_scheduler
-    if await ENABLE_BACKGROUND_TASKS():
+    if CRM_ROLE == "api" and await ENABLE_BACKGROUND_TASKS():
         try:
             # Create scheduler instance with configurable loop interval
             _background_scheduler = BackgroundTaskScheduler(
@@ -251,6 +253,11 @@ async def lifespan(_app: FastAPI):
                 logger.info("No background tasks registered, scheduler not started")
         except Exception as e:
             logger.error(f"Failed to start background task scheduler: {e}")
+    elif CRM_ROLE != "api":
+        logger.info(
+            f"CRM_ROLE={CRM_ROLE}: background task scheduler not started "
+            "(a worker pod runs exactly one loop)"
+        )
     else:
         logger.info(
             "Background task scheduler disabled (ENABLE_BACKGROUND_TASKS=false)"
@@ -259,7 +266,9 @@ async def lifespan(_app: FastAPI):
     # Start the event-driven dispatcher (promoter + workers). Main-server
     # workload only by default. Channel-semaphore init is handled by the
     # reconciler — no separate boot-time initialisation logic. See §2.
-    if ENABLE_DISPATCHER:
+    # Gated on CRM_ROLE like the scheduler above: a pod is its role, so a
+    # CRM worker pod runs exactly one loop and never also dials voice.
+    if CRM_ROLE == "api" and ENABLE_DISPATCHER:
         try:
             # Fast cold-start: trigger one reconcile_channel_tokens immediately
             # so workers don't BLPOP on empty channel LISTs while waiting for
@@ -297,16 +306,42 @@ async def lifespan(_app: FastAPI):
             await start_analysis_worker()
         except Exception as e:
             logger.error(f"Failed to start conversation analysis worker: {e}")
+    elif CRM_ROLE != "api":
+        logger.info(
+            f"CRM_ROLE={CRM_ROLE}: event-driven dispatcher not started "
+            "(a worker pod runs exactly one loop)"
+        )
     else:
         logger.info("Event-driven dispatcher disabled (ENABLE_DISPATCHER=false)")
+
+    # CRM worker roles (design/worker-runtime.md): one image, N pods. A
+    # non-"api" CRM_ROLE runs its drain loop as an asyncio task in this
+    # process instead of serving HTTP — see app/crm/worker_main.py.
+    if CRM_ROLE != "api":
+        await start_worker_role(CRM_ROLE)
+        logger.info(f"CRM worker role '{CRM_ROLE}' started")
+    else:
+        logger.info("CRM_ROLE=api: no CRM worker loop started")
 
     yield
 
     logger.info("Application shutdown event triggered...")
 
+    # Stop the CRM worker role before scheduler/db close so an in-flight
+    # batch finishes (or times out) with the pool still open.
+    if CRM_ROLE != "api":
+        try:
+            logger.info(f"Stopping CRM worker role '{CRM_ROLE}'...")
+            await stop_worker_role()
+        except Exception as e:
+            logger.error(
+                f"Error stopping CRM worker role '{CRM_ROLE}': {e}", exc_info=True
+            )
+
     # Stop the event-driven dispatcher before scheduler/db close so any
-    # in-flight workers get their locks/tokens released cleanly.
-    if ENABLE_DISPATCHER:
+    # in-flight workers get their locks/tokens released cleanly. Mirrors
+    # the startup gate — only an api pod ever started these.
+    if CRM_ROLE == "api" and ENABLE_DISPATCHER:
         try:
             logger.info("Stopping event-driven dispatcher...")
             await stop_workers()

--- a/docs/crm/building-modules.md
+++ b/docs/crm/building-modules.md
@@ -21,7 +21,8 @@ app/crm/<module>/
                  #   -> apply, inside a boundary this file owns
   workers.py     # drain loops (only if the module owns one)
   db/            # ALL mechanics behind one hop — root stays the story
-    __init__.py  # the db door: re-exports transaction, DbTxn, domain errors
+    __init__.py  # the db door: re-exports transaction, savepoint, DbTxn,
+                 #   domain errors
     accessor.py  # execute one query builder per function; no decisions.
                  #   Splits as accessor_<table>.py when the module grows
     queries.py   # SQL builders — (sql, params), $1 placeholders. Splits as
@@ -32,8 +33,13 @@ app/crm/<module>/
 **The layer law:** `api -> logic -> db/accessor -> db/queries`.
 **The boundary law:** logic owns transaction scope (atomicity is business
 semantics) and imports db-world things ONLY from its module's `db/` door:
-`transaction()`, the opaque `DbTxn` handle, domain-named errors. Logic may
-open a boundary and pass the handle; it may never call anything on it.
+`transaction()`, `savepoint()`, the opaque `DbTxn` handle, domain-named
+errors. Logic may open a boundary and pass the handle; it may never speak
+the driver's API on it — not a query (that is the accessor's job), and not
+`txn.transaction()` for nesting. Nesting has its own door: a batch atom
+isolates one unit with `async with savepoint(txn):`, so a single bad row
+rolls back alone while the rest of the batch commits. CI rule 5 rejects
+every driver method on a `txn`/`conn` in a logic file, nesting included.
 `import asyncpg` is legal only in `shared/db.py` and `db/` packages —
 grep-enforced. Single statements and same-builder
 batch loops self-scope INSIDE accessors (`crm_connection`, db-internal —

--- a/tests/crm/test_event_worker.py
+++ b/tests/crm/test_event_worker.py
@@ -1,0 +1,803 @@
+"""The event worker end to end: the pass in app/crm/record/workers.py and the
+shared drain loop in app/crm/shared/worker.py that drives it.
+
+The pass: extractor registry -> resolve() -> assert_facts() -> entry rules ->
+one closing UPDATE, with a per-row savepoint that keeps one bad row from
+poisoning the batch. A quarantine is terminal (no second UPDATE); a
+fact-assertion failure must not fail the row (nothing downstream depends on
+it); an entry-rules failure MUST fail the row (an enrolment silently dropped
+is worse than a retry). Verified against workers.py's private
+_pass_in_txn/_process_one directly with a fake txn, so none of this needs a
+real database.
+
+The loop: full batches loop immediately, empty batches back off with jitter up
+to a 5s cap, a row failure never stops the batch, a claim failure backs off
+instead of crashing the worker, stop_event ends the loop within one interval,
+and a heartbeat proves an idle worker is still alive. Timing is asserted
+through a recording fake for asyncio.sleep-equivalents (the delays
+run_drain_loop ASKED for), not through wall-clock elapsed time: the loop's
+contract is the delays it chooses, and a CI box that stalls mid-test must not
+turn that contract red.
+"""
+
+import asyncio
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional, Tuple, cast
+
+import pytest
+
+import app.crm.record.workers as workers
+import app.crm.shared.worker as worker_mod
+from app.crm.record.db import DbTxn
+from app.crm.record.schemas import RawEvent
+from app.crm.shared.worker import run_drain_loop
+
+# ---------------------------------------------------------------------------
+# The pass (app/crm/record/workers.py)
+# ---------------------------------------------------------------------------
+
+
+class _FakeSavepoint:
+    async def __aenter__(self) -> "_FakeSavepoint":
+        return self
+
+    async def __aexit__(self, *exc: Any) -> bool:
+        return False
+
+
+class _FakeTxnImpl:
+    def transaction(self) -> _FakeSavepoint:
+        return _FakeSavepoint()
+
+
+def _fake_txn() -> DbTxn:
+    return cast(DbTxn, _FakeTxnImpl())
+
+
+class _FakeAccessor:
+    def __init__(self) -> None:
+        self.stamped: List[Tuple[str, Optional[str]]] = []
+        self.quarantined: List[Tuple[str, str]] = []
+
+    async def stamp_event(
+        self, conn: Any, event_id: str, customer_id: Optional[str]
+    ) -> None:
+        self.stamped.append((event_id, customer_id))
+
+    async def quarantine_event(self, conn: Any, event_id: str, reason: str) -> None:
+        self.quarantined.append((event_id, reason))
+
+
+def _event(
+    event_id: str = "evt-1",
+    source: str = "lead-api",
+    topic: str = "lead.pushed",
+    customer_id: Optional[str] = None,
+    payload: Optional[Dict[str, Any]] = None,
+) -> RawEvent:
+    return RawEvent(
+        id=event_id,
+        merchant_id="m1",
+        source=source,
+        topic=topic,
+        schema_version="1",
+        external_id=f"ext-{event_id}",
+        payload=(
+            payload
+            if payload is not None
+            else {"customer_mobile_number": "+919999999999"}
+        ),
+        received_at=datetime.now(timezone.utc),
+        customer_id=customer_id,
+    )
+
+
+def _run(coro: Any) -> Any:
+    return asyncio.run(coro)
+
+
+def test_missing_phone_quarantines_and_never_stamps(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_accessor = _FakeAccessor()
+    monkeypatch.setattr(workers, "accessor", fake_accessor)
+
+    event = _event(payload={"lead_id": "lead-1"})
+    _run(workers._process_one(_fake_txn(), event))
+
+    assert fake_accessor.quarantined == [("evt-1", "no_handle")]
+    # quarantine_event already stamped processed_at itself -- a second
+    # stamp_event call would be a redundant UPDATE.
+    assert fake_accessor.stamped == []
+
+
+def test_unresolvable_phone_quarantines_and_never_stamps(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_accessor = _FakeAccessor()
+    monkeypatch.setattr(workers, "accessor", fake_accessor)
+
+    async def fake_resolve(*args: Any, **kwargs: Any) -> str:
+        raise ValueError("no usable handle")
+
+    monkeypatch.setattr(workers, "crm_resolve", fake_resolve)
+
+    event = _event()
+    _run(workers._process_one(_fake_txn(), event))
+
+    assert len(fake_accessor.quarantined) == 1
+    eid, reason = fake_accessor.quarantined[0]
+    assert eid == "evt-1"
+    assert reason.startswith("unresolvable:")
+    assert fake_accessor.stamped == []
+
+
+def test_a_raising_extractor_quarantines_rather_than_retrying_forever(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A payload the registered extractor cannot read is deterministically
+    bad: retrying it every poll would stall the queue behind it."""
+    fake_accessor = _FakeAccessor()
+    monkeypatch.setattr(workers, "accessor", fake_accessor)
+
+    def boom(payload: Dict[str, Any]) -> Any:
+        raise KeyError("mandatory field missing")
+
+    monkeypatch.setitem(workers.EXTRACTORS, "lead-api", boom)
+
+    _run(workers._process_one(_fake_txn(), _event()))
+
+    assert len(fake_accessor.quarantined) == 1
+    assert fake_accessor.quarantined[0][1].startswith("extractor_error:")
+    assert fake_accessor.stamped == []
+
+
+def test_resolved_phone_asserts_canon_named_facts_from_payload(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The extractor translates the producer's wire key (customer_name)
+    into canon T05's attribute vocabulary (name) -- identity never learns
+    a producer's spelling."""
+    fake_accessor = _FakeAccessor()
+    monkeypatch.setattr(workers, "accessor", fake_accessor)
+
+    async def fake_resolve(merchant_id: str, handles: Dict[str, str], **kw: Any) -> str:
+        assert merchant_id == "m1"
+        assert handles == {"phone": "+919999999999"}
+        assert kw["evidence"] == "observed"  # a merchant push is testimony
+        return "cust-99"
+
+    facts_calls: List[Tuple[str, str, Dict[str, Any]]] = []
+
+    async def fake_assert_facts(
+        merchant_id: str, customer_id: str, facts: Dict[str, Any], **kw: Any
+    ) -> None:
+        facts_calls.append((merchant_id, customer_id, facts))
+
+    monkeypatch.setattr(workers, "crm_resolve", fake_resolve)
+    monkeypatch.setattr(workers, "assert_facts", fake_assert_facts)
+
+    event = _event(
+        payload={
+            "lead_id": "lead-1",
+            "customer_mobile_number": "+919999999999",
+            "customer_name": "Ravi",
+            "irrelevant": "x",
+        }
+    )
+    _run(workers._process_one(_fake_txn(), event))
+
+    assert facts_calls == [("m1", "cust-99", {"name": "Ravi"})]
+    assert fake_accessor.stamped == [("evt-1", "cust-99")]
+    assert fake_accessor.quarantined == []
+
+
+def test_no_row_is_minted_as_declared(monkeypatch: pytest.MonkeyPatch) -> None:
+    """ "declared" is the customer's OWN statement. A merchant push minted
+    at that rung could overwrite handles the customer gave us themselves
+    (ADR 0021's ladder), so no row this worker processes may sit there."""
+    monkeypatch.setattr(workers, "accessor", _FakeAccessor())
+
+    seen: List[str] = []
+
+    async def fake_resolve(merchant_id: str, handles: Dict[str, str], **kw: Any) -> str:
+        seen.append(kw["evidence"])
+        return "cust-1"
+
+    async def fake_assert_facts(
+        merchant_id: str, customer_id: str, facts: Dict[str, Any], **kw: Any
+    ) -> None:
+        seen.append(kw["evidence"])
+
+    monkeypatch.setattr(workers, "crm_resolve", fake_resolve)
+    monkeypatch.setattr(workers, "assert_facts", fake_assert_facts)
+
+    event = _event(
+        payload={"customer_mobile_number": "+919999999999", "customer_name": "Ravi"}
+    )
+    _run(workers._process_one(_fake_txn(), event))
+
+    assert seen == ["observed", "observed"]
+
+
+def test_unrecognized_source_falls_back_to_the_buddy_shape(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A source with no registration still resolves -- adding a channel is
+    a registration when its shape differs, never a prerequisite."""
+    fake_accessor = _FakeAccessor()
+    monkeypatch.setattr(workers, "accessor", fake_accessor)
+
+    seen: Dict[str, Any] = {}
+
+    async def fake_resolve(merchant_id: str, handles: Dict[str, str], **kw: Any) -> str:
+        seen["evidence"] = kw["evidence"]
+        seen["handles"] = handles
+        return "cust-1"
+
+    monkeypatch.setattr(workers, "crm_resolve", fake_resolve)
+
+    _run(workers._process_one(_fake_txn(), _event(source="mystery-source")))
+
+    assert seen["evidence"] == "observed"
+    assert seen["handles"] == {"phone": "+919999999999"}
+
+
+def test_a_registered_extractor_overrides_the_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A9's Shopify lane lands as one dict entry: the pass below it never
+    changes."""
+    fake_accessor = _FakeAccessor()
+    monkeypatch.setattr(workers, "accessor", fake_accessor)
+
+    def shopify(payload: Dict[str, Any]) -> workers.Extracted:
+        return workers.Extracted(
+            handles={"email": payload["contact_email"]},
+            facts={"name": payload["contact_name"]},
+        )
+
+    monkeypatch.setitem(workers.EXTRACTORS, "shopify", shopify)
+
+    seen: Dict[str, Any] = {}
+
+    async def fake_resolve(merchant_id: str, handles: Dict[str, str], **kw: Any) -> str:
+        seen["handles"] = handles
+        return "cust-7"
+
+    facts_calls: List[Dict[str, Any]] = []
+
+    async def fake_assert_facts(
+        merchant_id: str, customer_id: str, facts: Dict[str, Any], **kw: Any
+    ) -> None:
+        facts_calls.append(facts)
+
+    monkeypatch.setattr(workers, "crm_resolve", fake_resolve)
+    monkeypatch.setattr(workers, "assert_facts", fake_assert_facts)
+
+    event = _event(
+        source="shopify",
+        payload={"contact_email": "r@example.com", "contact_name": "Rhea"},
+    )
+    _run(workers._process_one(_fake_txn(), event))
+
+    assert seen["handles"] == {"email": "r@example.com"}
+    assert facts_calls == [{"name": "Rhea"}]
+    assert fake_accessor.stamped == [("evt-1", "cust-7")]
+
+
+def test_pretrusted_customer_id_skips_resolution_and_still_stamps(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A pre-resolved row (crm_mirror pass-through style) skips resolve()
+    entirely but still takes its closing stamp."""
+    fake_accessor = _FakeAccessor()
+    monkeypatch.setattr(workers, "accessor", fake_accessor)
+
+    async def fail_resolve(*args: Any, **kwargs: Any) -> str:
+        raise AssertionError("resolve() must not run for a pre-resolved row")
+
+    monkeypatch.setattr(workers, "crm_resolve", fail_resolve)
+
+    event = _event(customer_id="cust-42", payload={})
+    _run(workers._process_one(_fake_txn(), event))
+
+    assert fake_accessor.stamped == [("evt-1", "cust-42")]
+    assert fake_accessor.quarantined == []
+
+
+def test_pretrusted_customer_id_still_asserts_facts_from_payload(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Facts assertion runs for every row that lands on a customer_id,
+    regardless of whether that id was pass-through or freshly resolved --
+    a mirror's payload can carry profile claims independent of the phone
+    handle."""
+    fake_accessor = _FakeAccessor()
+    monkeypatch.setattr(workers, "accessor", fake_accessor)
+
+    fact_calls: List[Tuple[str, str, Dict[str, Any]]] = []
+
+    async def fake_assert_facts(
+        merchant_id: str, customer_id: str, facts: Dict[str, Any], **kw: Any
+    ) -> None:
+        fact_calls.append((merchant_id, customer_id, facts))
+
+    monkeypatch.setattr(workers, "assert_facts", fake_assert_facts)
+
+    event = _event(
+        customer_id="cust-42", payload={"customer_name": "Asha", "irrelevant": "x"}
+    )
+    _run(workers._process_one(_fake_txn(), event))
+
+    assert fact_calls == [("m1", "cust-42", {"name": "Asha"})]
+
+
+def test_assert_facts_failure_is_swallowed_and_stamp_still_proceeds(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Unlike a lost enrolment, a lost profile fact breaks nothing
+    downstream -- it must log and let the row complete, never fail the row
+    forever."""
+    fake_accessor = _FakeAccessor()
+    monkeypatch.setattr(workers, "accessor", fake_accessor)
+
+    async def failing_assert_facts(*args: Any, **kwargs: Any) -> None:
+        raise RuntimeError("facts db blew up")
+
+    monkeypatch.setattr(workers, "assert_facts", failing_assert_facts)
+
+    event = _event(customer_id="cust-42", payload={"customer_name": "Asha"})
+    _run(workers._process_one(_fake_txn(), event))
+
+    assert fake_accessor.stamped == [("evt-1", "cust-42")]
+
+
+def test_entry_rules_run_per_row_before_that_row_is_stamped(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The consumer sees the row's resolved customer_id and runs INSIDE
+    the row's savepoint, before the stamp -- so its write and the stamp
+    that marks the row done live or die together."""
+    fake_accessor = _FakeAccessor()
+    monkeypatch.setattr(workers, "accessor", fake_accessor)
+
+    order: List[str] = []
+    seen: List[Tuple[str, str]] = []
+
+    async def fake_consume(event: RawEvent, customer_id: str) -> None:
+        order.append("consume")
+        seen.append((event.id, customer_id))
+
+    async def spying_stamp(conn: Any, event_id: str, customer_id: Any) -> None:
+        order.append("stamp")
+        fake_accessor.stamped.append((event_id, customer_id))
+
+    monkeypatch.setattr(workers, "_consume_attributed_event", fake_consume)
+    monkeypatch.setattr(fake_accessor, "stamp_event", spying_stamp)
+
+    _run(workers._process_one(_fake_txn(), _event(customer_id="cust-42", payload={})))
+
+    assert order == ["consume", "stamp"]
+    assert seen == [("evt-1", "cust-42")]
+
+
+def test_entry_rules_never_run_for_a_quarantined_row(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A quarantined row names no customer, so there is nothing for a
+    workflow to attribute to."""
+    fake_accessor = _FakeAccessor()
+    monkeypatch.setattr(workers, "accessor", fake_accessor)
+
+    async def fail_consume(event: RawEvent, customer_id: str) -> None:
+        raise AssertionError("entry rules must not see an unattributed row")
+
+    monkeypatch.setattr(workers, "_consume_attributed_event", fail_consume)
+
+    _run(workers._process_one(_fake_txn(), _event(payload={"lead_id": "l1"})))
+
+    assert fake_accessor.quarantined == [("evt-1", "no_handle")]
+
+
+def test_a_failing_entry_rule_costs_its_own_row_only(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The sealed contract: a consumer failure raises out of _process_one,
+    the row's savepoint rolls back (so it stays pending and retries), and
+    the batch's other rows still commit. A batch-level slot would instead
+    have re-failed every row in the batch, forever."""
+    fake_accessor = _FakeAccessor()
+    monkeypatch.setattr(workers, "accessor", fake_accessor)
+
+    events = [_event("evt-1", customer_id="c1"), _event("evt-2", customer_id="c2")]
+
+    async def fake_claim(conn: Any, limit: int) -> List[RawEvent]:
+        return events
+
+    async def poison_first(event: RawEvent, customer_id: str) -> None:
+        if event.id == "evt-1":
+            raise RuntimeError("workflow rule blew up")
+
+    monkeypatch.setattr(
+        fake_accessor, "claim_pending_events", fake_claim, raising=False
+    )
+    monkeypatch.setattr(workers, "_consume_attributed_event", poison_first)
+
+    result = _run(workers._pass_in_txn(_fake_txn(), 10))
+
+    # evt-1 never reached its stamp; evt-2 completed normally.
+    assert fake_accessor.stamped == [("evt-2", "c2")]
+    # ...and the claim still reports both rows as work found.
+    assert [e.id for e in result] == ["evt-1", "evt-2"]
+
+
+def test_pass_returns_claimed_rows_even_when_every_row_failed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The return value is the scaffold's "was there work" signal. If it
+    only counted successes, a batch that was entirely quarantined would
+    look like an empty queue and trigger backoff while the queue is
+    actually full."""
+    events = [_event("evt-1"), _event("evt-2")]
+
+    async def fake_claim(conn: Any, limit: int) -> List[RawEvent]:
+        return events
+
+    async def fake_process_one(conn: Any, event: RawEvent) -> None:
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(workers.accessor, "claim_pending_events", fake_claim)
+    monkeypatch.setattr(workers, "_process_one", fake_process_one)
+
+    result = _run(workers._pass_in_txn(_fake_txn(), 10))
+
+    assert [e.id for e in result] == ["evt-1", "evt-2"]
+
+
+def test_one_failing_row_does_not_stop_the_rest_of_the_batch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Each row runs in its own savepoint under the pass's one
+    transaction, so an accessor outage on one row leaves the others to
+    commit."""
+    events = [_event("evt-1"), _event("evt-2")]
+
+    async def fake_claim(conn: Any, limit: int) -> List[RawEvent]:
+        return events
+
+    processed: List[str] = []
+
+    async def fake_process_one(conn: Any, event: RawEvent) -> None:
+        if event.id == "evt-1":
+            raise RuntimeError("boom")
+        processed.append(event.id)
+
+    monkeypatch.setattr(workers.accessor, "claim_pending_events", fake_claim)
+    monkeypatch.setattr(workers, "_process_one", fake_process_one)
+
+    _run(workers._pass_in_txn(_fake_txn(), 10))
+
+    assert processed == ["evt-2"]
+
+
+# ---------------------------------------------------------------------------
+# The drain loop (app/crm/shared/worker.py)
+# ---------------------------------------------------------------------------
+
+
+def _run_loop(coro: Any, timeout: float = 2.0) -> Any:
+    return asyncio.run(asyncio.wait_for(coro, timeout=timeout))
+
+
+class _RecordingWaits:
+    """Replaces _jittered_wait: records every delay the loop asked for and
+    returns instantly, so the tests assert the backoff CURVE without ever
+    sleeping."""
+
+    def __init__(self, stop_after: Optional[int] = None) -> None:
+        self.delays: List[float] = []
+        self._stop_after = stop_after
+
+    async def __call__(self, base: float, stop_event: asyncio.Event) -> None:
+        self.delays.append(base)
+        if self._stop_after is not None and len(self.delays) >= self._stop_after:
+            stop_event.set()
+
+
+def test_full_batches_loop_without_waiting(monkeypatch: pytest.MonkeyPatch) -> None:
+    waits = _RecordingWaits()
+    monkeypatch.setattr(worker_mod, "_jittered_wait", waits)
+
+    calls = {"n": 0}
+    stop_event = asyncio.Event()
+
+    async def claim(batch: int) -> List[int]:
+        calls["n"] += 1
+        if calls["n"] >= 5:
+            stop_event.set()
+        return [1]  # non-empty -> no backoff wait
+
+    async def handle(row: int) -> None:
+        pass
+
+    _run_loop(
+        run_drain_loop(
+            claim, handle, interval=1.0, batch=10, stop_event=stop_event, name="t"
+        )
+    )
+
+    assert calls["n"] == 5
+    assert waits.delays == []  # never waited between full batches
+
+
+def test_empty_batch_backs_off_doubling_to_the_cap(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    waits = _RecordingWaits(stop_after=8)
+    monkeypatch.setattr(worker_mod, "_jittered_wait", waits)
+
+    stop_event = asyncio.Event()
+
+    async def claim(batch: int) -> List[int]:
+        return []
+
+    async def handle(row: int) -> None:
+        pass
+
+    _run_loop(
+        run_drain_loop(
+            claim, handle, interval=0.5, batch=10, stop_event=stop_event, name="t"
+        )
+    )
+
+    # doubles from the interval, then pins at the 5s ceiling
+    assert waits.delays == [0.5, 1.0, 2.0, 4.0, 5.0, 5.0, 5.0, 5.0]
+
+
+def test_finding_work_resets_the_backoff(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A quiet stretch must not leave a busy worker polling every 5s."""
+    waits = _RecordingWaits()
+    monkeypatch.setattr(worker_mod, "_jittered_wait", waits)
+
+    stop_event = asyncio.Event()
+    script: List[List[int]] = [[], [], [], [1], [], []]
+    calls = {"n": 0}
+
+    async def claim(batch: int) -> List[int]:
+        i = calls["n"]
+        calls["n"] += 1
+        if i >= len(script):
+            stop_event.set()
+            return []
+        return script[i]
+
+    async def handle(row: int) -> None:
+        pass
+
+    _run_loop(
+        run_drain_loop(
+            claim, handle, interval=0.5, batch=10, stop_event=stop_event, name="t"
+        )
+    )
+
+    # 3 empties escalate; the row at index 3 resets; the next two start over
+    assert waits.delays[:3] == [0.5, 1.0, 2.0]
+    assert waits.delays[3:5] == [0.5, 1.0]
+
+
+def test_jittered_wait_stays_within_twenty_percent_of_its_base() -> None:
+    """The jitter itself, tested directly instead of through the loop."""
+    stop_event = asyncio.Event()
+    stop_event.set()  # returns immediately; we are asserting the CHOSEN delay
+
+    seen: List[float] = []
+    real_wait_for = asyncio.wait_for
+
+    async def spy(aw: Any, timeout: float) -> Any:
+        seen.append(timeout)
+        return await real_wait_for(aw, timeout=timeout)
+
+    async def scenario() -> None:
+        asyncio.wait_for = spy  # type: ignore[assignment]
+        try:
+            for _ in range(50):
+                await worker_mod._jittered_wait(1.0, stop_event)
+        finally:
+            asyncio.wait_for = real_wait_for  # type: ignore[assignment]
+
+    asyncio.run(scenario())
+
+    assert len(seen) == 50
+    assert all(0.8 <= d <= 1.2 for d in seen)
+    assert len(set(seen)) > 1  # actually jittered, not a constant
+
+
+def test_handle_exception_does_not_stop_the_next_row() -> None:
+    stop_event = asyncio.Event()
+    handled: List[int] = []
+    calls = {"n": 0}
+
+    async def claim(batch: int) -> List[int]:
+        calls["n"] += 1
+        if calls["n"] > 1:
+            stop_event.set()
+            return []
+        return [1, 2, 3]
+
+    async def handle(row: int) -> None:
+        if row == 1:
+            raise RuntimeError("row 1 blew up")
+        handled.append(row)
+
+    _run_loop(
+        run_drain_loop(
+            claim, handle, interval=0.001, batch=10, stop_event=stop_event, name="t"
+        )
+    )
+
+    assert handled == [2, 3]
+
+
+def test_claim_exception_backs_off_and_keeps_retrying(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    waits = _RecordingWaits()
+    monkeypatch.setattr(worker_mod, "_jittered_wait", waits)
+
+    stop_event = asyncio.Event()
+    calls = {"n": 0}
+
+    async def claim(batch: int) -> List[int]:
+        calls["n"] += 1
+        if calls["n"] < 3:
+            raise ConnectionError("db unreachable")
+        stop_event.set()
+        return []
+
+    async def handle(row: int) -> None:
+        pass
+
+    _run_loop(
+        run_drain_loop(
+            claim, handle, interval=0.5, batch=10, stop_event=stop_event, name="t"
+        )
+    )
+
+    assert calls["n"] == 3
+    # a failed claim backs off on the same curve as an empty one
+    assert waits.delays == [0.5, 1.0, 2.0]
+
+
+def test_stop_event_set_before_start_exits_without_claiming() -> None:
+    stop_event = asyncio.Event()
+    stop_event.set()
+    claimed = {"called": False}
+
+    async def claim(batch: int) -> List[int]:
+        claimed["called"] = True
+        return []
+
+    async def handle(row: int) -> None:
+        pass
+
+    _run_loop(
+        run_drain_loop(
+            claim, handle, interval=5.0, batch=10, stop_event=stop_event, name="t"
+        )
+    )
+
+    assert claimed["called"] is False
+
+
+def test_stop_event_mid_batch_stops_before_the_next_row() -> None:
+    """SIGTERM during a batch: the in-flight row finishes, the rest are
+    left claimed-but-pending for the next pod."""
+    stop_event = asyncio.Event()
+    handled: List[int] = []
+
+    async def claim(batch: int) -> List[int]:
+        return [1, 2, 3]
+
+    async def handle(row: int) -> None:
+        handled.append(row)
+        if row == 2:
+            stop_event.set()
+
+    _run_loop(
+        run_drain_loop(
+            claim, handle, interval=0.001, batch=10, stop_event=stop_event, name="t"
+        )
+    )
+
+    assert handled == [1, 2]
+
+
+def test_stop_event_during_a_wait_ends_the_loop() -> None:
+    """The wait must be interruptible: a shutdown cannot sit through a
+    full 5s backoff."""
+    stop_event = asyncio.Event()
+
+    async def claim(batch: int) -> List[int]:
+        return []
+
+    async def handle(row: int) -> None:
+        pass
+
+    async def scenario() -> None:
+        task = asyncio.create_task(
+            run_drain_loop(
+                claim, handle, interval=30.0, batch=10, stop_event=stop_event, name="t"
+            )
+        )
+        await asyncio.sleep(0)  # let it reach the wait
+        stop_event.set()
+        await task  # would hang for 30s if the wait ignored the event
+
+    _run_loop(scenario())
+
+
+def test_idle_worker_still_heartbeats(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A silent worker and a dead worker look identical in logs; the
+    heartbeat is what tells them apart, so it must fire with no rows."""
+    waits = _RecordingWaits(stop_after=3)
+    monkeypatch.setattr(worker_mod, "_jittered_wait", waits)
+    monkeypatch.setattr(worker_mod, "CRM_WORKER_HEARTBEAT", 0.0)
+
+    beats: List[str] = []
+    monkeypatch.setattr(
+        worker_mod.logger, "info", lambda msg, *a, **k: beats.append(str(msg))
+    )
+
+    stop_event = asyncio.Event()
+
+    async def claim(batch: int) -> List[int]:
+        return []
+
+    async def handle(row: int) -> None:
+        pass
+
+    _run_loop(
+        run_drain_loop(
+            claim, handle, interval=0.5, batch=10, stop_event=stop_event, name="ew"
+        )
+    )
+
+    assert any("ew: alive" in b for b in beats)
+
+
+def test_heartbeat_counts_rows_since_the_last_beat(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(worker_mod, "CRM_WORKER_HEARTBEAT", 0.0)
+
+    beats: List[str] = []
+    monkeypatch.setattr(
+        worker_mod.logger, "info", lambda msg, *a, **k: beats.append(str(msg))
+    )
+
+    stop_event = asyncio.Event()
+    calls = {"n": 0}
+
+    async def claim(batch: int) -> List[int]:
+        calls["n"] += 1
+        if calls["n"] > 2:
+            stop_event.set()
+            return []
+        return [1, 2, 3]
+
+    async def handle(row: int) -> None:
+        pass
+
+    _run_loop(
+        run_drain_loop(
+            claim, handle, interval=0.001, batch=10, stop_event=stop_event, name="ew"
+        )
+    )
+
+    counted: List[Tuple[str, int]] = [
+        (b, int(b.split("alive, ")[1].split(" rows")[0])) for b in beats if "alive" in b
+    ]
+    assert counted, "expected at least one heartbeat"
+    # first beat precedes any work; a later one reports the batch just done
+    assert any(n == 3 for _, n in counted)

--- a/tests/crm/test_facts.py
+++ b/tests/crm/test_facts.py
@@ -1,6 +1,15 @@
-"""assert_facts internals: the evidence ladder's winner logic and the
-canon's inferred-confidence cap (0.5)."""
+"""assert_facts internals: the evidence ladder's winner logic, the canon's
+inferred-confidence cap (0.5), and the drift-only append that keeps the
+assertion history a record of evidence rather than of traffic."""
 
+import asyncio
+import json
+from typing import Any, Dict, List, Optional, Tuple, cast
+
+import pytest
+
+import app.crm.identity.facts as facts
+from app.crm.identity.db import DbTxn
 from app.crm.identity.facts import _winner, claim_confidence
 
 
@@ -44,3 +53,140 @@ def test_declared_defaults_full_confidence() -> None:
 def test_confidence_clamped_to_unit_interval() -> None:
     assert claim_confidence("observed", 1.7) == 1.0
     assert claim_confidence("observed", -0.2) == 0.0
+
+
+# --- drift-only append -----------------------------------------------------
+#
+# The worker asserts on EVERY event, and the buddy mirrors put the
+# customer's name on all four voice topics. Appending unconditionally
+# grew one call cycle into 3-4 identical history entries, forever, and
+# made every later assertion rewrite an ever-longer jsonb array under a
+# row lock -- worst on exactly the busiest customers.
+
+
+class _FakeAccessor:
+    """Stands in for identity/db/accessor: holds one customer's attributes
+    and records what the atom wrote."""
+
+    def __init__(self, attributes: Optional[Dict[str, Any]] = None) -> None:
+        self.attributes: Dict[str, Any] = attributes if attributes is not None else {}
+        self.writes: List[Tuple[Dict[str, Any], Dict[str, Any]]] = []
+
+    async def fetch_attributes_for_update(
+        self, conn: Any, merchant_id: str, customer_id: str
+    ) -> Dict[str, Any]:
+        return {"attributes": json.loads(json.dumps(self.attributes))}
+
+    async def update_attributes(
+        self,
+        conn: Any,
+        merchant_id: str,
+        customer_id: str,
+        attributes_json: str,
+        materialized: Dict[str, Any],
+    ) -> None:
+        self.attributes = json.loads(attributes_json)
+        self.writes.append((self.attributes, materialized))
+
+
+def _assert(
+    fake: _FakeAccessor,
+    value: str,
+    evidence: str = "observed",
+    source: str = "lead-api",
+    at: str = "2026-08-27T08:12:35+00:00",
+    attribute: str = "name",
+) -> None:
+    asyncio.run(
+        facts._assert_facts_in_txn(
+            cast(DbTxn, object()),
+            "m1",
+            "cust-1",
+            {attribute: value},
+            evidence,
+            source,
+            at,
+            1.0,
+        )
+    )
+
+
+def test_repeating_an_identical_claim_appends_nothing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake = _FakeAccessor()
+    monkeypatch.setattr(facts, "accessor", fake)
+
+    _assert(fake, "Rhea", at="2026-08-27T08:12:35.946+00:00")
+    _assert(fake, "Rhea", at="2026-08-27T08:12:35.950+00:00")
+    _assert(fake, "Rhea", at="2026-08-27T08:12:35.953+00:00")
+
+    assert len(fake.attributes["name"]) == 1
+
+
+def test_a_changed_value_is_drift_and_is_appended(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake = _FakeAccessor()
+    monkeypatch.setattr(facts, "accessor", fake)
+
+    _assert(fake, "Rhea", at="2026-08-01T00:00:00+00:00")
+    _assert(fake, "Rhea Kapoor", at="2026-08-20T00:00:00+00:00")
+
+    claims = fake.attributes["name"]
+    assert [c["v"] for c in claims] == ["Rhea", "Rhea Kapoor"]
+    # Same evidence class, so the tie breaks to the newest claim.
+    assert fake.writes[-1][1] == {"display_name": "Rhea Kapoor"}
+
+
+def test_a_stronger_evidence_class_is_drift_even_at_the_same_value(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The value did not change but our confidence in it did -- that is
+    exactly what the history exists to record."""
+    fake = _FakeAccessor()
+    monkeypatch.setattr(facts, "accessor", fake)
+
+    _assert(fake, "Rhea", evidence="observed")
+    _assert(fake, "Rhea", evidence="declared")
+
+    claims = fake.attributes["name"]
+    assert [c["e"] for c in claims] == ["observed", "declared"]
+
+
+def test_a_different_producer_is_drift(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Two independent sources agreeing is corroboration worth keeping."""
+    fake = _FakeAccessor()
+    monkeypatch.setattr(facts, "accessor", fake)
+
+    _assert(fake, "Rhea", source="lead-api")
+    _assert(fake, "Rhea", source="telephony")
+
+    assert [c["src"] for c in fake.attributes["name"]] == ["lead-api", "telephony"]
+
+
+def test_a_value_returning_after_a_change_is_appended_again(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Drift is measured against the LATEST claim, not the whole history:
+    a value coming back is a real event and must flip the winner."""
+    fake = _FakeAccessor()
+    monkeypatch.setattr(facts, "accessor", fake)
+
+    _assert(fake, "Rhea", at="2026-08-01T00:00:00+00:00")
+    _assert(fake, "R. Kapoor", at="2026-08-02T00:00:00+00:00")
+    _assert(fake, "Rhea", at="2026-08-03T00:00:00+00:00")
+
+    assert [c["v"] for c in fake.attributes["name"]] == ["Rhea", "R. Kapoor", "Rhea"]
+    assert fake.writes[-1][1] == {"display_name": "Rhea"}
+
+
+def test_inferred_winner_never_materializes(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Canon T05: a guess may steer, never decide."""
+    fake = _FakeAccessor()
+    monkeypatch.setattr(facts, "accessor", fake)
+
+    _assert(fake, "Maybe Rhea", evidence="inferred")
+
+    assert len(fake.attributes["name"]) == 1
+    assert fake.writes[-1][1] == {}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added background CRM event processing with configurable polling intervals and batch sizes.
  * Added support for claiming, processing, retrying, stamping, and quarantining CRM events.
  * Added customer journey retrieval with paginated results.
  * Added a standardized CRM journey view for consistent event data.
  * Added graceful worker startup and shutdown controls.

* **Bug Fixes**
  * Isolated failures to individual events so other events continue processing.
  * Added retry handling for unexpected processing failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->