### PR TITLE
feat(crm): consent ledger, resolved state, and decision log

### DIFF
--- a/app/core/config/dynamic.py
+++ b/app/core/config/dynamic.py
@@ -774,3 +774,60 @@ async def DRAGONTTS_HEALTH_TIMEOUT_S() -> float:
 async def PLIVO_INR_CONVERSION_RATE() -> float:
     """Returns PLIVO_INR_CONVERSION_RATE from Redis"""
     return await get_config("PLIVO_INR_CONVERSION_RATE", 80.0, float)
+
+
+# ----------------------------------------------------------------------------
+# CRM permission windows (app/crm/permission).
+#
+# These are compliance numbers, not engineering tuning: they move when a
+# regulator, a jurisdiction or counsel's reading moves, and none of those wait
+# for a deploy train. Read once at the top of each consent write, so a change
+# lands on the next write.
+#
+# The canon fixes only the first two, and only loosely -- "~7 days" for India's
+# promotional grant and "~90 days" for the opt-out embargo. No document names a
+# lifetime for a confirm link; 24h is ours.
+#
+# Turning a knob never rewrites history: what a window decided is stored as a
+# concrete deadline on crm_consent_state.expires_at, so a row always shows the
+# window it was actually given, whatever the flag says later.
+# ----------------------------------------------------------------------------
+
+
+async def _positive_int(key: str, default: int) -> int:
+    """A zero or negative window inverts the rule it encodes — a -1 day
+    embargo lifted yesterday. Bad values fall back to the default."""
+    raw = await get_config(key, default, int)
+    try:
+        # bool first: int(True) is 1, so a Boolean-typed flag would silently
+        # become a one-day window instead of being rejected.
+        value = 0 if isinstance(raw, bool) else int(raw)
+    except (TypeError, ValueError):
+        value = 0
+    if value <= 0:
+        logger.warning(f"Invalid {key}; using {default}")
+        return default
+    return value
+
+
+async def CRM_MARKETING_GRANT_DAYS() -> int:
+    """How long a marketing consent grant stays live before it must be re-won.
+
+    Transactional permission has no clock at all and ignores this -- an OTP
+    that expires is a locked-out customer, the opposite of protecting her.
+    """
+    return await _positive_int("CRM_MARKETING_GRANT_DAYS", 7)
+
+
+async def CRM_REASK_EMBARGO_DAYS() -> int:
+    """How long after a withdrawal even asking again is refused.
+
+    Raising it is always safe. Lowering it shortens a quiet period the customer
+    was promised, so it wants the same care as any other compliance change.
+    """
+    return await _positive_int("CRM_REASK_EMBARGO_DAYS", 90)
+
+
+async def CRM_PENDING_CONFIRM_HOURS() -> int:
+    """How long a double-opt-in confirm link stays usable."""
+    return await _positive_int("CRM_PENDING_CONFIRM_HOURS", 24)

--- a/app/crm/api.py
+++ b/app/crm/api.py
@@ -14,8 +14,10 @@ because webhook ingress must stay reachable without a bearer token.
 from fastapi import APIRouter
 
 from app.crm.identity import api as identity_api
+from app.crm.permission import api as permission_api
 from app.crm.record import api as record_api
 
 router = APIRouter()
 router.include_router(identity_api.router, prefix="/customers", tags=["CRM Customers"])
 router.include_router(record_api.router, prefix="/customers", tags=["CRM Journey"])
+router.include_router(permission_api.router, prefix="/consent", tags=["CRM Consent"])

--- a/app/crm/permission/__init__.py
+++ b/app/crm/permission/__init__.py
@@ -1,0 +1,6 @@
+"""Namespace only — this file exports NOTHING, deliberately (module rules §1).
+
+Import by full path: `contracts.py` is the surface for other modules, and
+everything else is internal. A re-export hub here is a known scar — it hides
+the layer a name came from and makes the import graph unreviewable.
+"""

--- a/app/crm/permission/api.py
+++ b/app/crm/permission/api.py
@@ -1,0 +1,30 @@
+"""/crm/consent — the console's consent capture (B1).
+
+Thin route per module rules §1: auth via Depends, delegate to the logic file.
+"""
+
+from fastapi import APIRouter, Depends, HTTPException, status
+
+from app.core.logger.context import set_log_context
+from app.crm.auth import crm_admin_user
+from app.crm.permission.consent import CustomerNotInMerchant, record_consent
+from app.crm.permission.schemas import ConsentEventIn, ConsentReceipt
+from app.schemas import UserInfo
+
+router = APIRouter()
+
+
+@router.post("", response_model=ConsentReceipt, status_code=status.HTTP_201_CREATED)
+async def record_consent_route(
+    event: ConsentEventIn,
+    current_user: UserInfo = Depends(crm_admin_user),
+) -> ConsentReceipt:
+    """``states`` is empty when the stored answer refuses the event; the 201
+    still holds, because the attempt is in the ledger."""
+    set_log_context(component="crm.consent.record", merchant_id=event.merchant_id)
+    try:
+        return await record_consent(event)
+    except CustomerNotInMerchant as e:
+        # 404 on the pair, not 403: separating "wrong merchant" from "no such
+        # customer" would let a caller probe other tenants' ids.
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))

--- a/app/crm/permission/consent.py
+++ b/app/crm/permission/consent.py
@@ -1,0 +1,303 @@
+"""record_consent() — the single writer of both consent stores (B1).
+
+BUSINESS LOGIC ONLY — DB mechanics live in db/accessor.py. The event table
+answers "prove she agreed"; the state table answers "may I send right now".
+One transaction writes both, which is why they cannot disagree.
+
+The one asymmetry in the purpose tree: withdrawal cascades down it, a grant
+never does.
+"""
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import List, Optional, Sequence
+
+from app.core.config.dynamic import (
+    CRM_MARKETING_GRANT_DAYS,
+    CRM_PENDING_CONFIRM_HOURS,
+    CRM_REASK_EMBARGO_DAYS,
+)
+from app.core.logger import logger
+from app.core.logger.context import update_log_context
+from app.crm.permission.db import DbTxn, TenancyViolation, accessor, atomically
+from app.crm.permission.schemas import (
+    ConsentEventIn,
+    ConsentEventType,
+    ConsentReceipt,
+    ConsentStateRecord,
+    ConsentStatus,
+    PurposeKey,
+)
+
+
+class CustomerNotInMerchant(Exception):
+    """The (merchant_id, customer_id) pair in the request does not exist."""
+
+
+@dataclass(frozen=True)
+class ConsentPolicy:
+    """The windows one write uses, read once so a cascade cannot straddle a
+    flag flip."""
+
+    marketing_grant_days: int
+    reask_embargo_days: int
+    pending_confirm_hours: int
+
+
+async def load_policy() -> ConsentPolicy:
+    return ConsentPolicy(
+        marketing_grant_days=await CRM_MARKETING_GRANT_DAYS(),
+        reask_embargo_days=await CRM_REASK_EMBARGO_DAYS(),
+        pending_confirm_hours=await CRM_PENDING_CONFIRM_HOURS(),
+    )
+
+
+@dataclass(frozen=True)
+class StateWrite:
+    # str, not PurposeKey: a cascade may touch a stored purpose outside the
+    # code's vocabulary, and a withdrawal must still reach it.
+    purpose_key: str
+    status: ConsentStatus
+    expires_at: Optional[datetime]
+
+
+# ── the purpose tree ─────────────────────────────────────────────────────────
+
+
+def covers(ancestor: str, purpose_key: str) -> bool:
+    """True when a rule at ``ancestor`` governs ``purpose_key``. Self counts.
+
+    The trailing dot keeps ``marketing`` from swallowing ``marketingx``. Build
+    it with ``+``, never an f-string: these are str Enums, so ``f"{ancestor}."``
+    renders "PurposeKey.MARKETING." and matches nothing — a withdrawal would
+    silently stop cascading.
+    """
+    return purpose_key == ancestor or purpose_key.startswith(ancestor + ".")
+
+
+def ancestors_of(purpose_key: str) -> List[str]:
+    """Every key that governs this one, self included. The write path reads
+    all of them — a planner looking only downward cannot see the withdrawal
+    that should stop it."""
+    parts = purpose_key.split(".")
+    return [".".join(parts[: i + 1]) for i in range(len(parts))]
+
+
+def grant_expiry(
+    purpose_key: str, at: datetime, policy: ConsentPolicy
+) -> Optional[datetime]:
+    """Marketing permission is a parking ticket; transactional permission
+    lives with the account."""
+    if purpose_key.split(".", 1)[0] == PurposeKey.MARKETING:
+        return at + timedelta(days=policy.marketing_grant_days)
+    return None
+
+
+# ── event -> state (pure) ────────────────────────────────────────────────────
+
+
+def plan_consent(
+    event: ConsentEventIn,
+    acted_at: datetime,
+    now: datetime,
+    existing: Sequence[ConsentStateRecord],
+    policy: ConsentPolicy,
+) -> List[StateWrite]:
+    """Which state rows this event moves. PURE — no I/O.
+
+    Two clocks, deliberately. ``acted_at`` is when SHE acted — an import may
+    claim a date years ago, and a grant measured from it is already expired,
+    which is the safe direction. ``now`` is the write moment, and every window
+    WE promise is measured from it: an embargo backdated two years would be an
+    embargo that already lifted.
+
+    ``existing`` is the locked scope: rows that govern this purpose (its
+    ancestors) and rows it governs (its descendants).
+    """
+    purpose = event.purpose_key
+
+    # A withdrawal is never refused: it only ever reduces permission.
+    if event.event_type is ConsentEventType.WITHDRAW:
+        return _plan_withdrawal(purpose, existing, now, policy)
+
+    # Everything below moves toward permission, so stored refusals apply — and
+    # they apply from wherever they sit in the tree.
+    governing = [s for s in existing if covers(s.purpose_key, purpose)]
+
+    # A prohibition is the floor: nothing in this vocabulary lifts it.
+    if any(state.status is ConsentStatus.PROHIBITED for state in governing):
+        return []
+
+    if event.event_type is ConsentEventType.GRANT:
+        # Her own act, and the only thing that may overrule her own earlier
+        # withdrawal — the embargo protects her from us, not from herself.
+        return [_granted(purpose, acted_at, policy)]
+
+    if event.event_type is ConsentEventType.CONFIRM:
+        # A confirmation has to confirm something: a dead link is not a fresh
+        # yes, and treating it as one collapses double opt-in into single.
+        if not _live_pending_confirm(existing, purpose, now):
+            return []
+        return [_granted(purpose, acted_at, policy)]
+
+    if event.event_type is ConsentEventType.REQUEST:
+        # Asking must never CHANGE an answer. A pending row over a live grant
+        # reads as "not granted" at the gate, so the question itself would cut
+        # off sending; over a withdrawal it erases the "no" that every other
+        # refusal here reads, whether or not the embargo has lifted.
+        if any(_answer_still_stands(state, now) for state in governing):
+            return []
+        window = now + timedelta(hours=policy.pending_confirm_hours)
+        return [StateWrite(purpose, ConsentStatus.PENDING_CONFIRM, window)]
+
+    if event.event_type is ConsentEventType.IMPORT:
+        # Bulk data fills a gap or does nothing. It carries no act of hers, so
+        # it may not complete an unclicked opt-in, and it may not re-stamp a
+        # live grant — a nightly re-sync would otherwise keep a 7-day window
+        # alive forever.
+        if governing:
+            return []
+        return [_granted(purpose, acted_at, policy)]
+
+    # Fail closed. A sixth event type refuses until someone decides what it
+    # means; the default arm of a permission decision is never "grant".
+    return []
+
+
+def _granted(purpose: str, at: datetime, policy: ConsentPolicy) -> StateWrite:
+    return StateWrite(purpose, ConsentStatus.GRANTED, grant_expiry(purpose, at, policy))
+
+
+def _clock_still_running(state: ConsentStateRecord, at: datetime) -> bool:
+    """Has this row's one clock run out? A row with no clock never does — a
+    withdrawal we never agreed to lift, a grant with no expiry."""
+    return state.expires_at is None or state.expires_at > at
+
+
+def _answer_still_stands(state: ConsentStateRecord, at: datetime) -> bool:
+    """Has she already answered, in a way that still holds? A withdrawal stands
+    forever — asking again may not erase it. A grant stands while its clock
+    runs; once lapsed, the question is worth asking again."""
+    if state.status is ConsentStatus.WITHDRAWN:
+        return True
+    return state.status is ConsentStatus.GRANTED and _clock_still_running(state, at)
+
+
+def _live_pending_confirm(
+    existing: Sequence[ConsentStateRecord], purpose: str, at: datetime
+) -> bool:
+    """Was this exact purpose asked, and is the confirm link still alive?"""
+    return any(
+        state.purpose_key == purpose
+        and state.status is ConsentStatus.PENDING_CONFIRM
+        and _clock_still_running(state, at)
+        for state in existing
+    )
+
+
+def _plan_withdrawal(
+    purpose: str,
+    existing: Sequence[ConsentStateRecord],
+    at: datetime,
+    policy: ConsentPolicy,
+) -> List[StateWrite]:
+    embargo = at + timedelta(days=policy.reask_embargo_days)
+
+    # The named purpose is always written, even with no row yet: "no row" and
+    # "row saying no" are different answers.
+    touched = {purpose}
+    touched.update(s.purpose_key for s in existing if covers(purpose, s.purpose_key))
+
+    # A prohibition beneath her is permanent and not hers to lift; rewriting it
+    # would trade a standing bar for one that expires.
+    prohibited = {
+        s.purpose_key for s in existing if s.status is ConsentStatus.PROHIBITED
+    }
+
+    return [
+        StateWrite(key, ConsentStatus.WITHDRAWN, embargo)
+        for key in sorted(touched)
+        if key not in prohibited
+    ]
+
+
+# ── the single writer ────────────────────────────────────────────────────────
+
+
+async def record_consent(event: ConsentEventIn) -> ConsentReceipt:
+    """Every path in — STOP/START keywords, console capture, importers —
+    arrives here. Nothing else writes either table.
+
+    Tenancy is enforced by the composite FK on both tables: merchant_id and
+    customer_id both arrive in the request body, and (merchant_id, customer_id)
+    has to name a real pair — a plain id FK would accept any existing uuid and
+    file a real customer's withdrawal under a tenant that never reads it.
+    """
+    policy = await load_policy()
+    try:
+        return await atomically(_record_consent_in_txn, event, policy)
+    except TenancyViolation as e:
+        raise CustomerNotInMerchant(
+            f"customer {event.customer_id} does not belong to merchant "
+            f"{event.merchant_id!r}"
+        ) from e
+
+
+async def _record_consent_in_txn(
+    txn: DbTxn, event: ConsentEventIn, policy: ConsentPolicy
+) -> ConsentReceipt:
+    """ATOMIC: ledger row + every state row it moves — two stores that must
+    never disagree (canon 03).
+
+    One now() call, two named clocks: ``acted_at`` stamps the ledger and any
+    grant expiry (a backdated import expires on arrival — the safe direction),
+    ``now`` drives every window we promise.
+    """
+    now = datetime.now(timezone.utc)
+    acted_at = event.occurred_at or now
+    customer_id = str(event.customer_id)
+    channel = event.channel
+    purpose = event.purpose_key
+    update_log_context(customer_id=customer_id, merchant_id=event.merchant_id)
+
+    existing = await accessor.fetch_purpose_scope_for_update(
+        txn, event.merchant_id, customer_id, channel, purpose, ancestors_of(purpose)
+    )
+
+    writes = plan_consent(event, acted_at, now, existing, policy)
+    if not writes:
+        # .value on all three: these are str Enums, and an f-string renders
+        # "ConsentChannel.WHATSAPP" — not what anyone greps the logs for.
+        logger.info(
+            f"consent {event.event_type.value} refused by stored state "
+            f"({channel.value}/{purpose.value})"
+        )
+
+    ledger = await accessor.insert_consent_event(
+        txn,
+        event.merchant_id,
+        customer_id,
+        event.address,
+        event.event_type,
+        channel,
+        purpose,
+        acted_at,
+        event.artifact_ref,
+    )
+
+    states = []
+    for write in writes:
+        states.append(
+            await accessor.upsert_consent_state(
+                txn,
+                event.merchant_id,
+                customer_id,
+                channel,
+                write.purpose_key,
+                write.status,
+                write.expires_at,
+                str(ledger.id),
+            )
+        )
+
+    return ConsentReceipt(event=ledger, states=states)

--- a/app/crm/permission/contracts.py
+++ b/app/crm/permission/contracts.py
@@ -1,0 +1,9 @@
+"""permission module — public surface (module rules §1).
+
+The ONLY file other modules may import from app/crm/permission.
+"""
+
+from app.crm.permission.consent import CustomerNotInMerchant, record_consent
+from app.crm.permission.decisions import log_decision
+
+__all__ = ["record_consent", "log_decision", "CustomerNotInMerchant"]

--- a/app/crm/permission/db/__init__.py
+++ b/app/crm/permission/db/__init__.py
@@ -1,0 +1,13 @@
+"""permission's db layer door — the ONLY surface logic imports for db-world
+things (module rules §1): atomically(), the opaque handle, domain-named
+errors. asyncpg exists only in shared/db and db/ packages.
+"""
+
+import asyncpg
+
+from app.crm.shared.db import DbTxn, UniqueViolation, atomically
+
+# The tenancy FK: (merchant_id, customer_id) must name a real pair.
+TenancyViolation = asyncpg.ForeignKeyViolationError
+
+__all__ = ["DbTxn", "UniqueViolation", "TenancyViolation", "atomically"]

--- a/app/crm/permission/db/accessor.py
+++ b/app/crm/permission/db/accessor.py
@@ -1,0 +1,106 @@
+"""Permission accessor — mechanical DB access ONLY (module rules §1). One
+query builder, one decode, no business decisions."""
+
+from datetime import datetime
+from typing import List, Optional
+
+from app.crm.permission.db.decoder import (
+    decode_consent_event,
+    decode_consent_state,
+    decode_decision,
+)
+from app.crm.permission.db.queries import (
+    insert_consent_event_query,
+    insert_decision_query,
+    select_purpose_scope_for_update_query,
+    upsert_consent_state_query,
+)
+from app.crm.permission.schemas import (
+    ConsentEventRecord,
+    ConsentStateRecord,
+    DecisionRecord,
+)
+from app.crm.shared.db import DbTxn
+
+
+async def fetch_purpose_scope_for_update(
+    txn: DbTxn,
+    merchant_id: str,
+    customer_id: str,
+    channel: str,
+    purpose_key: str,
+    ancestors: List[str],
+) -> List[ConsentStateRecord]:
+    query, values = select_purpose_scope_for_update_query(
+        merchant_id, customer_id, channel, purpose_key, ancestors
+    )
+    rows = await txn.fetch(query, *values)
+    return [decode_consent_state(row) for row in rows]
+
+
+async def insert_consent_event(
+    txn: DbTxn,
+    merchant_id: str,
+    customer_id: str,
+    address: str,
+    event_type: str,
+    channel: str,
+    purpose_key: str,
+    occurred_at: datetime,
+    artifact_ref: Optional[str],
+) -> ConsentEventRecord:
+    query, values = insert_consent_event_query(
+        merchant_id,
+        customer_id,
+        address,
+        event_type,
+        channel,
+        purpose_key,
+        occurred_at,
+        artifact_ref,
+    )
+    row = await txn.fetchrow(query, *values)
+    if row is None:
+        raise RuntimeError("consent_event INSERT returned no row")
+    return decode_consent_event(row)
+
+
+async def upsert_consent_state(
+    txn: DbTxn,
+    merchant_id: str,
+    customer_id: str,
+    channel: str,
+    purpose_key: str,
+    status: str,
+    expires_at: Optional[datetime],
+    last_event_id: str,
+) -> ConsentStateRecord:
+    query, values = upsert_consent_state_query(
+        merchant_id,
+        customer_id,
+        channel,
+        purpose_key,
+        status,
+        expires_at,
+        last_event_id,
+    )
+    row = await txn.fetchrow(query, *values)
+    if row is None:
+        raise RuntimeError("consent_state UPSERT returned no row")
+    return decode_consent_state(row)
+
+
+async def insert_decision(
+    txn: DbTxn,
+    merchant_id: str,
+    customer_id: Optional[str],
+    decision_kind: str,
+    chosen_json: str,
+) -> DecisionRecord:
+    query, values = insert_decision_query(
+        merchant_id, customer_id, decision_kind, chosen_json
+    )
+    row = await txn.fetchrow(query, *values)
+    if row is None:
+        raise RuntimeError("decision_log INSERT returned no row")
+    return decode_decision(row)

--- a/app/crm/permission/db/decoder.py
+++ b/app/crm/permission/db/decoder.py
@@ -1,0 +1,27 @@
+"""Row -> schemas (module rules §1). DB-side translation only — never
+imported outside db/."""
+
+import json
+from typing import Any, Mapping
+
+from app.crm.permission.schemas import (
+    ConsentEventRecord,
+    ConsentStateRecord,
+    DecisionRecord,
+)
+
+
+def decode_consent_event(row: Mapping[str, Any]) -> ConsentEventRecord:
+    return ConsentEventRecord(**dict(row))
+
+
+def decode_consent_state(row: Mapping[str, Any]) -> ConsentStateRecord:
+    return ConsentStateRecord(**dict(row))
+
+
+def decode_decision(row: Mapping[str, Any]) -> DecisionRecord:
+    data = dict(row)
+    chosen = data.get("chosen")
+    # asyncpg hands jsonb back as str unless a codec is registered.
+    data["chosen"] = json.loads(chosen) if isinstance(chosen, str) else (chosen or {})
+    return DecisionRecord(**data)

--- a/app/crm/permission/db/queries.py
+++ b/app/crm/permission/db/queries.py
@@ -1,0 +1,123 @@
+"""SQL builders for the permission module (module rules §1). $1
+placeholders only — every value parameterized."""
+
+from datetime import datetime
+from typing import Any, List, Optional, Tuple
+
+CRM_DECISION_LOG_TABLE = "crm_decision_log"
+CRM_CONSENT_EVENT_TABLE = "crm_consent_event"
+CRM_CONSENT_STATE_TABLE = "crm_consent_state"
+
+_DECISION_LOG_COLUMNS = (
+    "id, merchant_id, customer_id, decision_kind, chosen, decided_at"
+)
+_CONSENT_EVENT_COLUMNS = (
+    "id, merchant_id, customer_id, address, event_type, "
+    "channel, purpose_key, occurred_at, artifact_ref"
+)
+_CONSENT_STATE_COLUMNS = (
+    "merchant_id, customer_id, channel, purpose_key, status, expires_at, last_event_id"
+)
+
+
+def insert_decision_query(
+    merchant_id: str,
+    customer_id: Optional[str],
+    decision_kind: str,
+    chosen_json: str,
+) -> Tuple[str, List[Any]]:
+    # decided_at is left to its DEFAULT: the clock is the moment the decision
+    # was reached, and a caller-supplied time would let a row claim otherwise.
+    sql = f"""
+        INSERT INTO {CRM_DECISION_LOG_TABLE}
+            (merchant_id, customer_id, decision_kind, chosen)
+        VALUES ($1, $2::uuid, $3, $4::jsonb)
+        RETURNING {_DECISION_LOG_COLUMNS}
+    """
+    return sql, [merchant_id, customer_id, decision_kind, chosen_json]
+
+
+def insert_consent_event_query(
+    merchant_id: str,
+    customer_id: str,
+    address: str,
+    event_type: str,
+    channel: str,
+    purpose_key: str,
+    occurred_at: datetime,
+    artifact_ref: Optional[str],
+) -> Tuple[str, List[Any]]:
+    # occurred_at is required: the column is NOT NULL and its DEFAULT cannot
+    # fire, because this statement always names it.
+    sql = f"""
+        INSERT INTO {CRM_CONSENT_EVENT_TABLE}
+            (merchant_id, customer_id, address, event_type,
+             channel, purpose_key, occurred_at, artifact_ref)
+        VALUES ($1, $2::uuid, $3, $4, $5, $6, $7, $8)
+        RETURNING {_CONSENT_EVENT_COLUMNS}
+    """
+    return sql, [
+        merchant_id,
+        customer_id,
+        address,
+        event_type,
+        channel,
+        purpose_key,
+        occurred_at,
+        artifact_ref,
+    ]
+
+
+def select_purpose_scope_for_update_query(
+    merchant_id: str,
+    customer_id: str,
+    channel: str,
+    purpose_key: str,
+    ancestors: List[str],
+) -> Tuple[str, List[Any]]:
+    # Both directions: ancestors govern this purpose, descendants are governed
+    # by it. starts_with rather than LIKE — the `_` in transactional.order_update
+    # is a LIKE wildcard. ORDER BY is where deterministic lock order belongs.
+    sql = f"""
+        SELECT {_CONSENT_STATE_COLUMNS}
+        FROM {CRM_CONSENT_STATE_TABLE}
+        WHERE merchant_id = $1
+          AND customer_id = $2::uuid
+          AND channel = $3
+          AND (purpose_key = ANY($4::text[]) OR starts_with(purpose_key, $5))
+        ORDER BY purpose_key
+        FOR UPDATE
+    """
+    return sql, [merchant_id, customer_id, channel, ancestors, purpose_key + "."]
+
+
+def upsert_consent_state_query(
+    merchant_id: str,
+    customer_id: str,
+    channel: str,
+    purpose_key: str,
+    status: str,
+    expires_at: Optional[datetime],
+    last_event_id: str,
+) -> Tuple[str, List[Any]]:
+    sql = f"""
+        INSERT INTO {CRM_CONSENT_STATE_TABLE}
+            (merchant_id, customer_id, channel, purpose_key,
+             status, expires_at, last_event_id)
+        VALUES ($1, $2::uuid, $3, $4, $5, $6, $7::uuid)
+        ON CONFLICT (merchant_id, customer_id, channel, purpose_key)
+        DO UPDATE SET
+            status = EXCLUDED.status,
+            expires_at = EXCLUDED.expires_at,
+            last_event_id = EXCLUDED.last_event_id
+        RETURNING {_CONSENT_STATE_COLUMNS}
+    """
+    return sql, [
+        merchant_id,
+        customer_id,
+        channel,
+        purpose_key,
+        status,
+        expires_at,
+        last_event_id,
+    ]

--- a/app/crm/permission/decisions.py
+++ b/app/crm/permission/decisions.py
@@ -1,0 +1,36 @@
+"""log_decision() — every automated verdict, written as it is made (B4).
+
+Nothing can rebuild this table later: the inputs a decision saw are gone by
+the time anyone asks about it. One row per verdict, allow and refuse alike.
+"""
+
+import json
+from typing import Any, Dict, Optional
+
+from app.crm.permission.db import DbTxn, accessor
+from app.crm.permission.schemas import DecisionKind, DecisionRecord
+
+
+async def log_decision(
+    txn: DbTxn,
+    *,
+    merchant_id: str,
+    decision_kind: DecisionKind,
+    chosen: Dict[str, Any],
+    customer_id: Optional[str] = None,
+) -> DecisionRecord:
+    """Append one decision inside a transaction the caller already owns.
+
+    There is deliberately no variant that opens its own: a decision that
+    commits separately can outlive the thing it authorised, leaving the log
+    asserting a send that never happened. ``chosen`` must carry a verdict —
+    the table CHECKs it, and `default=str` keeps non-JSON natives (the clocks
+    a check compared against) from breaking the dump.
+    """
+    return await accessor.insert_decision(
+        txn,
+        merchant_id,
+        customer_id,
+        decision_kind,
+        json.dumps(chosen, default=str, allow_nan=False),
+    )

--- a/app/crm/permission/schemas.py
+++ b/app/crm/permission/schemas.py
@@ -1,0 +1,164 @@
+"""Leaf shapes for the permission module (module rules §1).
+
+Vocabularies are enums, not free text: channel and purpose are closed sets
+with legal meaning, and purpose is mirrored by a CHECK on both consent
+tables. ConsentEventIn normalizes its address and refuses a naive or
+future occurred_at — every expiry is measured from that field.
+"""
+
+from datetime import datetime, timedelta, timezone
+from enum import Enum
+from typing import Any, Callable, Dict, List, Optional
+from uuid import UUID
+
+from pydantic import (
+    AwareDatetime,
+    BaseModel,
+    StringConstraints,
+    field_validator,
+    model_validator,
+)
+from typing_extensions import Annotated
+
+from app.crm.shared.normalize import normalize_email, normalize_phone
+
+# min_length alone counts characters, so " " passes it.
+NonBlankStr = Annotated[str, StringConstraints(strip_whitespace=True, min_length=1)]
+
+CLOCK_SKEW_MINUTES = 5
+
+
+class DecisionKind(str, Enum):
+    SEND_OR_HOLD = "send_or_hold"
+    IDENTITY_MERGE = "identity_merge"
+
+
+class DecisionRecord(BaseModel):
+    id: int
+    merchant_id: str
+    customer_id: Optional[UUID] = None
+    decision_kind: DecisionKind
+    chosen: Dict[str, Any]
+    decided_at: datetime
+
+
+class ConsentChannel(str, Enum):
+    """Deliberately not a DB constraint: a new channel is a deploy, not a
+    migration."""
+
+    WHATSAPP = "whatsapp"
+    SMS = "sms"
+    EMAIL = "email"
+    VOICE = "voice"
+    INSTAGRAM = "instagram"
+
+
+class PurposeKey(str, Enum):
+    """A dotted tree. A rule at an ancestor governs everything beneath it:
+    withdrawal cascades down, a grant never does."""
+
+    MARKETING = "marketing"
+    MARKETING_PROMOTIONAL = "marketing.promotional"
+    MARKETING_PROMOTIONAL_WINBACK = "marketing.promotional.winback"
+    TRANSACTIONAL = "transactional"
+    TRANSACTIONAL_ORDER_UPDATE = "transactional.order_update"
+    TRANSACTIONAL_AUTH = "transactional.auth"
+
+
+class ConsentEventType(str, Enum):
+    """EXPIRE is absent on purpose: expiry is arithmetic, and no human
+    performed it."""
+
+    REQUEST = "REQUEST"
+    GRANT = "GRANT"
+    WITHDRAW = "WITHDRAW"
+    IMPORT = "IMPORT"
+    CONFIRM = "CONFIRM"
+
+
+class ConsentStatus(str, Enum):
+    """Four things that were done. `expired` is not here — it is checked
+    against the clock on every read."""
+
+    GRANTED = "granted"
+    WITHDRAWN = "withdrawn"
+    PROHIBITED = "prohibited"
+    PENDING_CONFIRM = "pending_confirm"
+
+
+_ADDRESS_NORMALIZERS: Dict[ConsentChannel, Callable[[str], Optional[str]]] = {
+    ConsentChannel.WHATSAPP: normalize_phone,
+    ConsentChannel.SMS: normalize_phone,
+    ConsentChannel.VOICE: normalize_phone,
+    ConsentChannel.EMAIL: normalize_email,
+}
+
+
+class ConsentEventIn(BaseModel):
+    merchant_id: NonBlankStr
+    customer_id: UUID
+    address: NonBlankStr
+    event_type: ConsentEventType
+    channel: ConsentChannel
+    purpose_key: PurposeKey
+    occurred_at: Optional[AwareDatetime] = None
+    artifact_ref: Optional[str] = None
+
+    @field_validator("occurred_at")
+    @classmethod
+    def _cannot_be_in_the_future(cls, value: Optional[datetime]) -> Optional[datetime]:
+        if value is None:
+            return value
+        limit = datetime.now(timezone.utc) + timedelta(minutes=CLOCK_SKEW_MINUTES)
+        if value > limit:
+            raise ValueError("occurred_at cannot be in the future")
+        return value
+
+    @model_validator(mode="after")
+    def _normalize_address(self) -> "ConsentEventIn":
+        normalizer = _ADDRESS_NORMALIZERS.get(self.channel)
+        if normalizer is None:
+            return self
+        normalized = normalizer(self.address)
+        if normalized is None:
+            raise ValueError(
+                f"address {self.address!r} is not a valid {self.channel.value} handle"
+            )
+        self.address = normalized
+        return self
+
+
+class ConsentEventRecord(BaseModel):
+    """A row as stored. channel and purpose_key are plain str, not the enums:
+    the table has no CHECK on them, so a row written around the module must
+    still decode — a strict enum here would turn one bad row into a customer
+    who can no longer record a STOP."""
+
+    id: UUID
+    merchant_id: str
+    customer_id: UUID
+    address: str
+    event_type: ConsentEventType
+    channel: str
+    purpose_key: str
+    occurred_at: datetime
+    artifact_ref: Optional[str] = None
+
+
+class ConsentStateRecord(BaseModel):
+    """As stored — see ConsentEventRecord on why the vocabularies are str."""
+
+    merchant_id: str
+    customer_id: UUID
+    channel: str
+    purpose_key: str
+    status: ConsentStatus
+    expires_at: Optional[datetime] = None
+    last_event_id: Optional[UUID] = None
+
+
+class ConsentReceipt(BaseModel):
+    """A WITHDRAW moves several states; a refused event moves none."""
+
+    event: ConsentEventRecord
+    states: List[ConsentStateRecord]

--- a/app/database/migrations/055_create_crm_consent.sql
+++ b/app/database/migrations/055_create_crm_consent.sql
@@ -1,0 +1,121 @@
+-- 055: permission — crm_consent_event + crm_consent_state (T07/T08, canon/03-permission.md) — the two consent stores.
+--
+-- The event table is the legal record: prove she agreed, possibly years later.
+-- The state table is the resolved answer the send gate reads on every message.
+-- record_consent() writes both in one transaction, which is the only reason
+-- they can never disagree. They ship together for the same reason.
+
+-- The permission slips, as they were given.
+--
+-- address is the handle the consent was collected against, and it is required:
+-- permission belongs to a way of reaching someone, not to the person. When a
+-- number is reassigned to a stranger, this is what stops the new holder
+-- inheriting the old holder's opt-in. It cannot be filled in later.
+-- There is no EXPIRE event type: expiry is arithmetic on the state table, and
+-- no human performed it.
+-- channel and purpose_key carry no CHECK: both grow with the product, and a
+-- constraint means a new value cannot be used until someone writes a migration
+-- (the 027 scar, building-modules law 11). The vocabulary lives in schemas.py.
+--
+-- What makes that safe is that the READ models type them as plain str while
+-- ConsentEventIn keeps the enums — so the API refuses an unknown value at the
+-- front door, and a row written around the module still decodes rather than
+-- breaking every later read for that customer.
+--
+-- event_type and status DO keep theirs: closed status enums, not vocabularies,
+-- which law 11 requires a CHECK on.
+CREATE TABLE crm_consent_event (
+    id           uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    merchant_id  text NOT NULL,
+    customer_id  uuid NOT NULL,
+    address      text NOT NULL,
+    event_type   text NOT NULL
+                 CHECK (event_type IN ('REQUEST', 'GRANT', 'WITHDRAW',
+                                       'IMPORT', 'CONFIRM')),
+    channel      text NOT NULL,
+    purpose_key  text NOT NULL,
+    occurred_at  timestamptz NOT NULL DEFAULT now(),
+    artifact_ref text,
+
+    -- Composite, not REFERENCES crm_customer (id). Both ids arrive in the same
+    -- request body, and a plain id FK accepts any existing uuid — so a wrong
+    -- merchant_id would plant a real customer's withdrawal in a tenant that
+    -- never reads it. 049 declares UNIQUE (merchant_id, id) for exactly this.
+    --
+    -- RESTRICT: a customer with consent history cannot be hard-deleted, because
+    -- this ledger is the answer to "prove she agreed" years later. Erasure is
+    -- the soft path (crm_customer.status = 'erased'), not a DELETE.
+    FOREIGN KEY (merchant_id, customer_id)
+        REFERENCES crm_customer (merchant_id, id) ON DELETE RESTRICT
+);
+
+-- One customer's slips, newest first.
+CREATE INDEX crm_consent_event_merchant_customer_ix
+    ON crm_consent_event (merchant_id, customer_id, occurred_at DESC);
+
+-- Nothing may edit or remove a slip. A correction is a new event, never an
+-- edit, because the question this table answers is "what did she actually
+-- agree to, and when" — and an edited answer is not evidence.
+CREATE OR REPLACE FUNCTION crm_consent_event_append_only()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    RAISE EXCEPTION
+        'crm_consent_event is append-only: % refused. A correction is a new '
+        'event (WITHDRAW/CONFIRM), never an edit.', TG_OP;
+END;
+$$;
+
+CREATE TRIGGER crm_consent_event_no_update
+    BEFORE UPDATE ON crm_consent_event
+    FOR EACH ROW EXECUTE FUNCTION crm_consent_event_append_only();
+
+CREATE TRIGGER crm_consent_event_no_delete
+    BEFORE DELETE ON crm_consent_event
+    FOR EACH ROW EXECUTE FUNCTION crm_consent_event_append_only();
+
+
+-- The resolved answer, one row per question the gate can ask.
+--
+-- The primary key spells out what permission means here: one merchant, one
+-- customer, one channel, one purpose.
+-- There is no `expired` status. Expiry is checked against the clock on every
+-- read, so it cannot be briefly wrong between a grant lapsing and a job
+-- noticing. A refusal is stored rather than inferred: never having been asked
+-- and having been told no are different answers, and only one can be fixed by
+-- asking again.
+-- expires_at is the single clock a row may carry; what it means follows from
+-- the status.
+-- last_event_id points at the slip that produced this row, so this table can be
+-- discarded and rebuilt from the event table alone.
+-- The gate reads here, so tolerant decoding matters most on this table.
+CREATE TABLE crm_consent_state (
+    merchant_id   text NOT NULL,
+    customer_id   uuid NOT NULL,
+    channel       text NOT NULL,
+    purpose_key   text NOT NULL,
+    status        text NOT NULL
+                  CHECK (status IN ('granted', 'withdrawn',
+                                    'prohibited', 'pending_confirm')),
+    expires_at    timestamptz,
+    last_event_id uuid REFERENCES crm_consent_event (id),
+    PRIMARY KEY (merchant_id, customer_id, channel, purpose_key),
+    -- RESTRICT, not CASCADE. A cascade here would be unreachable anyway — the
+    -- ledger's FK refuses the customer delete first, and the append-only trigger
+    -- refuses clearing the ledger to get past it — so it only advertised an
+    -- erasure path that does not exist. Both tables now say the same thing.
+    FOREIGN KEY (merchant_id, customer_id)
+        REFERENCES crm_customer (merchant_id, id) ON DELETE RESTRICT
+);
+
+-- No secondary index here on purpose. The gate's probe filters on
+-- (merchant_id, customer_id, channel), which is a leading prefix of the primary
+-- key, so the PK's own btree already serves it — a separate index would be a
+-- second copy maintained on every write for nothing.
+--
+-- An expires_at index is also deliberately absent. Nothing queries it yet, and
+-- because the upsert rewrites expires_at on every repeat write, indexing that
+-- column would make each of those a non-HOT update: new entries in every index
+-- instead of none. It can be added with the re-ask sweep that needs it, shaped
+-- for that query — probably (merchant_id, expires_at) rather than a global one.

--- a/app/database/migrations/056_create_crm_decision_log.sql
+++ b/app/database/migrations/056_create_crm_decision_log.sql
@@ -1,0 +1,55 @@
+-- 056: permission — crm_decision_log (T14, canon/03-permission.md)
+--
+-- One row per automated verdict, allow and refuse alike. Nothing can rebuild
+-- this table later: the inputs a decision saw are gone by the time anyone asks
+-- about it, so the reasoning is written as the decision is made or not at all.
+--
+-- `chosen` is the decider's working state dumped as-is — no schema beyond the
+-- required verdict, because the only reader is a person on an audit day.
+-- customer_id carries no FK on purpose: an audit record has to survive the
+-- customer row being erased or merged away.
+--
+-- jsonb_typeof before the key test, because `?` on an array asks whether the
+-- array CONTAINS that string: '["verdict"]' passes `chosen ? 'verdict'` while
+-- having no verdict field at all, and the audit read would find nothing there.
+CREATE TABLE crm_decision_log (
+    id            bigserial PRIMARY KEY,
+    merchant_id   text NOT NULL,
+    customer_id   uuid,
+    decision_kind text NOT NULL
+                  CHECK (decision_kind IN ('send_or_hold', 'identity_merge')),
+    chosen        jsonb NOT NULL
+                  CHECK (jsonb_typeof(chosen) = 'object' AND chosen ? 'verdict'),
+    decided_at    timestamptz NOT NULL DEFAULT now()
+);
+
+-- The why-didn't-it-send read: one customer's verdicts, newest first.
+CREATE INDEX crm_decision_log_merchant_customer_ix
+    ON crm_decision_log (merchant_id, customer_id, decided_at DESC);
+
+-- Same append-only rule as the consent ledger, for the same reason: this table
+-- is the only account of why a message was sent or held, and the inputs that
+-- produced the verdict are gone by the time anyone asks. A row that can be
+-- edited afterwards is not an audit record — it is a claim about one.
+--
+-- Row triggers, so TRUNCATE and partition/table drops still pass. Retention on
+-- a table this size is a bulk operation, not a DELETE per verdict, and pruning
+-- old rows wholesale is a different act from rewriting one.
+CREATE OR REPLACE FUNCTION crm_decision_log_append_only()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    RAISE EXCEPTION
+        'crm_decision_log is append-only: % refused. A verdict is what the '
+        'gate decided at that moment; a later one is a new row.', TG_OP;
+END;
+$$;
+
+CREATE TRIGGER crm_decision_log_no_update
+    BEFORE UPDATE ON crm_decision_log
+    FOR EACH ROW EXECUTE FUNCTION crm_decision_log_append_only();
+
+CREATE TRIGGER crm_decision_log_no_delete
+    BEFORE DELETE ON crm_decision_log
+    FOR EACH ROW EXECUTE FUNCTION crm_decision_log_append_only();

--- a/scripts/check_crm_boundaries.py
+++ b/scripts/check_crm_boundaries.py
@@ -49,6 +49,9 @@ TABLE_OWNERS = {
     "platform_identity": "platform",
     "crm_event_raw": "record",
     "crm_journey_event": "record",
+    "crm_decision_log": "permission",
+    "crm_consent_event": "permission",
+    "crm_consent_state": "permission",
 }
 
 # Pre-existing legacy inversions, allowlisted and CLOSED to additions

--- a/tests/crm/__init__.py
+++ b/tests/crm/__init__.py
@@ -1,0 +1,1 @@
+"""Package marker for pytest — one directory per app/crm module."""

--- a/tests/crm/permission/__init__.py
+++ b/tests/crm/permission/__init__.py
@@ -1,0 +1,1 @@
+"""Package marker for pytest. Tests import by full path, same as the module."""

--- a/tests/crm/permission/test_consent.py
+++ b/tests/crm/permission/test_consent.py
@@ -1,0 +1,504 @@
+"""The consent laws (B1), as pure functions — no database needed.
+
+plan_consent is the whole of the business logic: five event types, and what
+each one is allowed to do to a stored answer.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence
+from uuid import UUID
+
+import pytest
+from pydantic import ValidationError
+
+from app.crm.permission import consent
+from app.crm.permission.consent import ConsentPolicy
+from app.crm.permission.schemas import (
+    ConsentEventIn,
+    ConsentEventType,
+    ConsentStateRecord,
+    ConsentStatus,
+)
+
+NOW = datetime(2026, 8, 23, 12, 0, tzinfo=timezone.utc)
+MERCHANT = "m_123"
+CUSTOMER = UUID("00000000-0000-0000-0000-000000000777")
+MIGRATIONS = Path(__file__).resolve().parents[3] / "app/database/migrations"
+CONSENT_DDL = (MIGRATIONS / "055_create_crm_consent.sql").read_text()
+
+# Not the shipped defaults, so a window hardcoded back into the planner fails
+# here instead of quietly agreeing with it.
+POLICY = ConsentPolicy(
+    marketing_grant_days=5, reask_embargo_days=45, pending_confirm_hours=6
+)
+
+
+def _event(
+    event_type: ConsentEventType, purpose: str, **overrides: Any
+) -> ConsentEventIn:
+    body: Dict[str, Any] = {
+        "merchant_id": MERCHANT,
+        "customer_id": CUSTOMER,
+        "address": "+919812340000",
+        "event_type": event_type,
+        "channel": "whatsapp",
+        "purpose_key": purpose,
+    }
+    body.update(overrides)
+    return ConsentEventIn(**body)
+
+
+def _state(
+    purpose: str, status: ConsentStatus, expires_at: Optional[datetime] = None
+) -> ConsentStateRecord:
+    return ConsentStateRecord(
+        merchant_id=MERCHANT,
+        customer_id=CUSTOMER,
+        channel="whatsapp",
+        purpose_key=purpose,
+        status=status,
+        expires_at=expires_at,
+    )
+
+
+def _plan(
+    event_type: ConsentEventType,
+    purpose: str,
+    existing: Sequence[ConsentStateRecord] = (),
+    acted_at: datetime = NOW,
+) -> List[consent.StateWrite]:
+    """acted_at defaults to the write clock — the live-capture case."""
+    return consent.plan_consent(
+        _event(event_type, purpose), acted_at, NOW, list(existing), POLICY
+    )
+
+
+# ── the purpose tree ─────────────────────────────────────────────────────────
+
+
+def test_a_rule_governs_itself_and_everything_beneath_it() -> None:
+    assert consent.covers("marketing", "marketing")
+    assert consent.covers("marketing", "marketing.promotional.winback")
+
+
+def test_a_rule_never_governs_upward() -> None:
+    assert not consent.covers("marketing.promotional", "marketing")
+
+
+def test_prefix_collisions_are_not_ancestry() -> None:
+    """`marketing` must not swallow a hypothetical `marketingx`."""
+    assert not consent.covers("marketing", "marketingx.promotional")
+
+
+def test_ancestors_run_from_the_root_down_to_the_key() -> None:
+    assert consent.ancestors_of("marketing.promotional.winback") == [
+        "marketing",
+        "marketing.promotional",
+        "marketing.promotional.winback",
+    ]
+    assert consent.ancestors_of("marketing") == ["marketing"]
+
+
+# ── WITHDRAW ─────────────────────────────────────────────────────────────────
+
+
+def test_a_withdrawal_cascades_down_the_tree() -> None:
+    existing = [
+        _state("marketing", ConsentStatus.GRANTED),
+        _state("marketing.promotional", ConsentStatus.GRANTED),
+        _state("marketing.promotional.winback", ConsentStatus.GRANTED),
+    ]
+    writes = _plan(ConsentEventType.WITHDRAW, "marketing", existing)
+    assert [w.purpose_key for w in writes] == [
+        "marketing",
+        "marketing.promotional",
+        "marketing.promotional.winback",
+    ]
+    assert {w.status for w in writes} == {ConsentStatus.WITHDRAWN}
+
+
+def test_a_withdrawal_writes_its_row_even_when_none_existed() -> None:
+    """'No row' and 'row saying no' are different answers, and only one of
+    them is fixable by asking."""
+    writes = _plan(ConsentEventType.WITHDRAW, "marketing.promotional")
+    assert [w.purpose_key for w in writes] == ["marketing.promotional"]
+    assert writes[0].status is ConsentStatus.WITHDRAWN
+    assert writes[0].expires_at == NOW + timedelta(days=POLICY.reask_embargo_days)
+
+
+def test_a_withdrawal_is_never_refused() -> None:
+    """It only ever reduces permission, so nothing blocks recording it."""
+    existing = [_state("marketing", ConsentStatus.PROHIBITED)]
+    writes = _plan(ConsentEventType.WITHDRAW, "marketing.promotional", existing)
+    assert [w.status for w in writes] == [ConsentStatus.WITHDRAWN]
+
+
+def test_a_cascade_does_not_downgrade_a_prohibition_beneath_it() -> None:
+    """A prohibition is permanent; rewriting it would trade a standing bar for
+    one that expires in 45 days."""
+    existing = [
+        _state("marketing", ConsentStatus.GRANTED),
+        _state("marketing.promotional", ConsentStatus.PROHIBITED),
+    ]
+    writes = _plan(ConsentEventType.WITHDRAW, "marketing", existing)
+    assert [w.purpose_key for w in writes] == ["marketing"]
+
+
+# ── GRANT ────────────────────────────────────────────────────────────────────
+
+
+def test_a_grant_answers_exactly_the_question_asked() -> None:
+    """A grant NEVER cascades — anything else manufactures permission."""
+    existing = [_state("marketing.promotional", ConsentStatus.WITHDRAWN)]
+    writes = _plan(ConsentEventType.GRANT, "marketing", existing)
+    assert [w.purpose_key for w in writes] == ["marketing"]
+
+
+def test_marketing_permission_is_a_parking_ticket() -> None:
+    writes = _plan(ConsentEventType.GRANT, "marketing.promotional")
+    assert writes[0].expires_at == NOW + timedelta(days=POLICY.marketing_grant_days)
+
+
+def test_transactional_permission_lives_with_the_account() -> None:
+    """A suppressed OTP is a locked-out customer — the opposite of protecting
+    her."""
+    writes = _plan(ConsentEventType.GRANT, "transactional.auth")
+    assert writes[0].expires_at is None
+
+
+def test_her_own_yes_outranks_her_own_earlier_no() -> None:
+    """The embargo protects her from us, not from herself: refusing a START
+    would lock her out of a list she is asking to rejoin."""
+    existing = [_state("marketing", ConsentStatus.WITHDRAWN, NOW + timedelta(days=44))]
+    writes = _plan(ConsentEventType.GRANT, "marketing", existing)
+    assert [w.status for w in writes] == [ConsentStatus.GRANTED]
+
+
+# ── IMPORT ───────────────────────────────────────────────────────────────────
+
+
+def test_import_grants_when_nothing_refused_it() -> None:
+    """The migrating list works on day one."""
+    writes = _plan(ConsentEventType.IMPORT, "marketing.promotional")
+    assert writes[0].status is ConsentStatus.GRANTED
+
+
+def test_import_never_resurrects_a_withdrawal_at_the_same_purpose() -> None:
+    existing = [_state("marketing.promotional", ConsentStatus.WITHDRAWN)]
+    assert _plan(ConsentEventType.IMPORT, "marketing.promotional", existing) == []
+
+
+def test_import_never_resurrects_a_withdrawal_on_an_ancestor() -> None:
+    """The common shape: she withdraws `marketing` owning no leaf rows, then a
+    bulk list imports `marketing.promotional`."""
+    existing = [_state("marketing", ConsentStatus.WITHDRAWN, NOW + timedelta(days=44))]
+    assert _plan(ConsentEventType.IMPORT, "marketing.promotional", existing) == []
+
+
+def test_import_is_refused_long_after_the_embargo_has_lifted() -> None:
+    """The embargo governs asking, not importing: bulk data never overwrites
+    an act she performed, however old."""
+    stale = [_state("marketing", ConsentStatus.WITHDRAWN, NOW - timedelta(days=400))]
+    assert _plan(ConsentEventType.IMPORT, "marketing", stale) == []
+
+
+# ── REQUEST / CONFIRM ────────────────────────────────────────────────────────
+
+
+def test_request_opens_a_confirm_window() -> None:
+    writes = _plan(ConsentEventType.REQUEST, "marketing.promotional")
+    assert writes[0].status is ConsentStatus.PENDING_CONFIRM
+    assert writes[0].expires_at == NOW + timedelta(hours=POLICY.pending_confirm_hours)
+
+
+def test_we_may_not_re_ask_inside_the_embargo() -> None:
+    """The stored 'no' survives, which is the point — a pending row written
+    over it would erase the refusal the gate reads."""
+    existing = [_state("marketing", ConsentStatus.WITHDRAWN, NOW + timedelta(days=44))]
+    assert _plan(ConsentEventType.REQUEST, "marketing", existing) == []
+
+
+def test_a_withdrawal_with_no_clock_is_one_we_never_agreed_to_lift() -> None:
+    forever = [_state("marketing", ConsentStatus.WITHDRAWN, None)]
+    assert _plan(ConsentEventType.REQUEST, "marketing", forever) == []
+
+
+def test_confirm_completes_a_live_request() -> None:
+    existing = [
+        _state(
+            "marketing.promotional",
+            ConsentStatus.PENDING_CONFIRM,
+            NOW + timedelta(hours=1),
+        )
+    ]
+    writes = _plan(ConsentEventType.CONFIRM, "marketing.promotional", existing)
+    assert writes[0].status is ConsentStatus.GRANTED
+
+
+def test_a_confirm_with_nothing_pending_confirms_nothing() -> None:
+    """Without a prior REQUEST there was no double opt-in to complete, and the
+    ledger could not show one."""
+    assert _plan(ConsentEventType.CONFIRM, "marketing.promotional") == []
+
+
+def test_a_confirm_link_that_died_does_not_still_open_the_door() -> None:
+    """A click months later — or a mail scanner replaying the URL — is not a
+    fresh yes."""
+    dead = [
+        _state(
+            "marketing.promotional",
+            ConsentStatus.PENDING_CONFIRM,
+            NOW - timedelta(days=29),
+        )
+    ]
+    assert _plan(ConsentEventType.CONFIRM, "marketing.promotional", dead) == []
+
+
+def test_a_confirm_needs_the_pending_row_at_its_own_purpose() -> None:
+    """A pending question about offers is not one about winbacks."""
+    elsewhere = [
+        _state("marketing", ConsentStatus.PENDING_CONFIRM, NOW + timedelta(hours=1))
+    ]
+    assert _plan(ConsentEventType.CONFIRM, "marketing.promotional", elsewhere) == []
+
+
+# ── the prohibition floor ────────────────────────────────────────────────────
+
+
+def test_a_prohibition_on_an_ancestor_stops_everything_below_it() -> None:
+    existing = [_state("marketing", ConsentStatus.PROHIBITED)]
+    for event_type in (
+        ConsentEventType.GRANT,
+        ConsentEventType.IMPORT,
+        ConsentEventType.REQUEST,
+        ConsentEventType.CONFIRM,
+    ):
+        assert _plan(event_type, "marketing.promotional", existing) == [], event_type
+
+
+# ── what a caller may hand us ────────────────────────────────────────────────
+
+
+def test_an_unknown_channel_or_purpose_cannot_be_constructed() -> None:
+    with pytest.raises(ValidationError, match="channel"):
+        _event(ConsentEventType.GRANT, "marketing", channel="telepathy")
+    with pytest.raises(ValidationError, match="purpose_key"):
+        _event(ConsentEventType.GRANT, "marketing.made_up")
+
+
+def test_a_naive_timestamp_is_refused() -> None:
+    """Bound into a timestamptz it would resolve against the POD's timezone,
+    so the same payload would store a different instant on an IST pod."""
+    with pytest.raises(ValidationError, match="occurred_at"):
+        _event(ConsentEventType.GRANT, "marketing", occurred_at="2026-08-23T12:00:00")
+
+
+def test_a_timestamp_in_the_future_is_refused() -> None:
+    """Every expiry is measured from this field, so an unbounded value defeats
+    the expiry policy — a 2099 import grants marketing until 2099."""
+    with pytest.raises(ValidationError, match="future"):
+        _event(ConsentEventType.IMPORT, "marketing", occurred_at="2099-01-01T00:00:00Z")
+
+
+def test_a_backdated_import_fails_safe() -> None:
+    """A CSV collected two years ago is normal, and the grant it produces has
+    already expired."""
+    long_ago = NOW - timedelta(days=730)
+    writes = _plan(ConsentEventType.IMPORT, "marketing", acted_at=long_ago)
+    expires_at = writes[0].expires_at
+    assert expires_at is not None and expires_at < NOW
+
+
+def test_an_address_is_stored_in_one_spelling() -> None:
+    """Its job is to be compared against the customer's handle later; two
+    spellings of one number are two strangers."""
+    spellings = ["+919812340000", "+91 98123 40000", "9812340000", "09812340000"]
+    stored = {
+        _event(ConsentEventType.GRANT, "marketing", address=s).address
+        for s in spellings
+    }
+    assert stored == {"+919812340000"}
+
+    email = _event(
+        ConsentEventType.GRANT,
+        "marketing",
+        channel="email",
+        address=" User@Example.COM ",
+    )
+    assert email.address == "user@example.com"
+
+
+def test_an_unusable_address_is_refused_rather_than_stored_wrong() -> None:
+    with pytest.raises(ValidationError, match="not a valid whatsapp handle"):
+        _event(ConsentEventType.GRANT, "marketing", address="not-a-number")
+
+
+def test_a_whitespace_only_field_is_not_a_value() -> None:
+    """min_length counts characters, so ' ' passes it — and ' ' as a
+    merchant_id creates a tenant nothing will ever read from."""
+    with pytest.raises(ValidationError):
+        _event(ConsentEventType.GRANT, "marketing", merchant_id="   ")
+
+
+# ── code and schema agree ────────────────────────────────────────────────────
+
+
+def test_the_closed_status_enums_match_the_migration_checks() -> None:
+    """Drift means the code writes a value the table refuses. Only the status
+    enums are constrained — law 11 requires a CHECK on exactly that shape."""
+    for member in list(ConsentStatus) + list(ConsentEventType):
+        assert f"'{member.value}'" in CONSENT_DDL, member
+
+
+def test_the_vocabularies_have_no_database_check() -> None:
+    """Law 11: channel and purpose both grow with the product, so a new value
+    is a deploy, not a migration (the 027 scar)."""
+    for column in ("channel", "purpose_key"):
+        assert f"CHECK ({column}" not in CONSENT_DDL, column
+
+
+def test_an_unknown_vocabulary_value_is_refused_at_the_front_door() -> None:
+    """The table is permissive; the request model is not. Unknown values are
+    stopped where a human can be told why."""
+    with pytest.raises(ValidationError, match="purpose_key"):
+        _event(ConsentEventType.GRANT, "marketing.made_up")
+    with pytest.raises(ValidationError, match="channel"):
+        _event(ConsentEventType.GRANT, "marketing", channel="rcs")
+
+
+def test_a_stored_value_outside_the_vocabulary_still_decodes() -> None:
+    """The reason the reads are str and not enums. A row written around the
+    module — a backfill, or a newer pod after a rollback — must not make every
+    later read raise, because one of those reads is how a STOP gets recorded."""
+    stranger = ConsentStateRecord(
+        merchant_id=MERCHANT,
+        customer_id=CUSTOMER,
+        channel="rcs",
+        purpose_key="marketing.future_thing",
+        status=ConsentStatus.GRANTED,
+    )
+    assert stranger.purpose_key == "marketing.future_thing"
+
+
+def test_a_withdrawal_still_cascades_over_a_purpose_the_code_does_not_know() -> None:
+    """And it must be able to WITHDRAW it, not just read past it."""
+    existing = [
+        _state("marketing", ConsentStatus.GRANTED),
+        _state("marketing.future_thing", ConsentStatus.GRANTED),
+    ]
+    writes = _plan(ConsentEventType.WITHDRAW, "marketing", existing)
+    assert [w.purpose_key for w in writes] == ["marketing", "marketing.future_thing"]
+    assert {w.status for w in writes} == {ConsentStatus.WITHDRAWN}
+
+
+def test_expire_is_not_an_event_type() -> None:
+    """Expiry is arithmetic; no human performed it, so no ledger row claims
+    one did."""
+    assert "EXPIRE" not in {e.value for e in ConsentEventType}
+
+
+def test_asking_never_takes_away_an_answer_she_already_gave() -> None:
+    """A pending row over a live grant reads as 'not granted' at the gate, so
+    a re-confirmation campaign would cut off sending to a consented customer.
+    Worse one level down: asking about a leaf shadows a grant on its parent."""
+    granted = [_state("marketing", ConsentStatus.GRANTED, NOW + timedelta(days=4))]
+    assert _plan(ConsentEventType.REQUEST, "marketing", granted) == []
+    assert _plan(ConsentEventType.REQUEST, "marketing.promotional", granted) == []
+
+
+def test_a_replayed_confirm_does_not_renew_the_window() -> None:
+    """The first CONFIRM consumed the pending row; a redelivered webhook finds
+    a granted row and changes nothing."""
+    already = [_state("marketing", ConsentStatus.GRANTED, NOW + timedelta(days=5))]
+    assert _plan(ConsentEventType.CONFIRM, "marketing", already) == []
+
+
+def test_asking_is_allowed_once_a_grant_has_lapsed() -> None:
+    """A lapsed grant is a gap, not an answer — re-permission is the point."""
+    lapsed = [_state("marketing", ConsentStatus.GRANTED, NOW - timedelta(days=1))]
+    writes = _plan(ConsentEventType.REQUEST, "marketing", lapsed)
+    assert [w.status for w in writes] == [ConsentStatus.PENDING_CONFIRM]
+
+
+def test_asking_never_overwrites_a_no_even_after_the_embargo_lifts() -> None:
+    """A pending row over a withdrawal deletes the only thing IMPORT reads, so
+    the next bulk sync would re-grant someone who opted out."""
+    old = [_state("marketing", ConsentStatus.WITHDRAWN, NOW - timedelta(days=400))]
+    assert _plan(ConsentEventType.REQUEST, "marketing", old) == []
+
+
+def test_an_import_cannot_complete_an_unclicked_double_opt_in() -> None:
+    """IMPORT carries no act of hers, so it must not finish what a REQUEST
+    started — that is the CONFIRM branch's whole job."""
+    pending = [
+        _state("marketing", ConsentStatus.PENDING_CONFIRM, NOW + timedelta(hours=1))
+    ]
+    assert _plan(ConsentEventType.IMPORT, "marketing", pending) == []
+
+
+def test_a_nightly_re_import_cannot_keep_a_grant_alive_forever() -> None:
+    """Re-stamping a live grant on every sync means the marketing window never
+    expires for any list synced more often than the window."""
+    live = [_state("marketing", ConsentStatus.GRANTED, NOW + timedelta(days=2))]
+    assert _plan(ConsentEventType.IMPORT, "marketing", live) == []
+
+
+def test_an_unrecognised_event_type_grants_nothing() -> None:
+    """Fail closed: the default arm of a permission decision is never 'grant'.
+    A sixth event type refuses until someone decides what it means."""
+    event = _event(ConsentEventType.GRANT, "marketing")
+    object.__setattr__(event, "event_type", "SHOUT")
+    assert consent.plan_consent(event, NOW, NOW, [], POLICY) == []
+
+
+def test_a_backdated_withdrawal_still_promises_a_full_embargo() -> None:
+    """The embargo is a promise WE make now. Measured from a date two years
+    ago it would arrive already lifted — and overwrite a live one."""
+    writes = _plan(
+        ConsentEventType.WITHDRAW, "marketing", acted_at=NOW - timedelta(days=730)
+    )
+    assert writes[0].expires_at == NOW + timedelta(days=POLICY.reask_embargo_days)
+
+
+def test_a_backdated_confirm_cannot_revive_a_dead_link() -> None:
+    """Liveness is judged at the write moment, not at a caller-supplied one."""
+    dead = [
+        _state("marketing", ConsentStatus.PENDING_CONFIRM, NOW - timedelta(days=10))
+    ]
+    assert (
+        _plan(
+            ConsentEventType.CONFIRM,
+            "marketing",
+            dead,
+            acted_at=NOW - timedelta(days=20),
+        )
+        == []
+    )
+
+
+def test_a_customer_with_consent_history_cannot_be_hard_deleted() -> None:
+    """Both FKs say RESTRICT, and they say it explicitly.
+
+    The ledger answers "prove she agreed" years later, so a DELETE that took it
+    with the customer would destroy the evidence. A CASCADE on the state table
+    would have been unreachable regardless — the ledger's FK refuses the delete
+    first — so it only advertised an erasure path that does not exist. Erasure
+    is the soft path: crm_customer.status = 'erased'.
+    """
+    assert CONSENT_DDL.count("ON DELETE RESTRICT") == 2
+    assert "ON DELETE CASCADE" not in CONSENT_DDL
+
+
+def test_both_tables_key_tenancy_on_the_composite_pair() -> None:
+    """A plain id FK accepts any existing uuid, so a wrong merchant_id would
+    file a real customer's withdrawal under a tenant that never reads it."""
+    # comment lines out: the prose explains why the plain form is wrong, and
+    # would otherwise match the assertion it is explaining
+    ddl = "\n".join(
+        line for line in CONSENT_DDL.splitlines() if not line.lstrip().startswith("--")
+    )
+    assert ddl.count("REFERENCES crm_customer (merchant_id, id)") == 2
+    assert "REFERENCES crm_customer (id)" not in ddl

--- a/tests/crm/permission/test_consent_api.py
+++ b/tests/crm/permission/test_consent_api.py
@@ -1,0 +1,147 @@
+"""POST /crm/consent — the HTTP contract.
+
+Auth and status codes only. The request model's own rules are covered
+precisely in test_consent.py; here we prove they run before the writer does.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Awaitable, Callable, Dict, Iterator
+from uuid import UUID, uuid4
+
+import httpx
+import pytest
+from fastapi import FastAPI
+
+from app.crm.auth import crm_admin_user
+from app.crm.permission import api as consent_api
+from app.crm.permission.consent import CustomerNotInMerchant
+from app.crm.permission.schemas import (
+    ConsentEventIn,
+    ConsentEventRecord,
+    ConsentReceipt,
+)
+from app.schemas import UserInfo
+from app.schemas.breeze_buddy.auth import UserRole
+
+CUSTOMER = uuid4()
+LEDGER_ID = UUID("00000000-0000-0000-0000-0000000abcde")
+
+Writer = Callable[[ConsentEventIn], Awaitable[ConsentReceipt]]
+
+
+def _body(**overrides: Any) -> Dict[str, Any]:
+    body: Dict[str, Any] = {
+        "merchant_id": "m_123",
+        "customer_id": str(CUSTOMER),
+        "address": "+919812340000",
+        "event_type": "GRANT",
+        "channel": "whatsapp",
+        "purpose_key": "marketing",
+    }
+    body.update(overrides)
+    return body
+
+
+async def _writer(event: ConsentEventIn) -> ConsentReceipt:
+    return ConsentReceipt(
+        event=ConsentEventRecord(
+            id=LEDGER_ID,
+            merchant_id=event.merchant_id,
+            customer_id=event.customer_id,
+            address=event.address,
+            event_type=event.event_type,
+            channel=event.channel,
+            purpose_key=event.purpose_key,
+            occurred_at="2026-08-24T12:00:00Z",
+        ),
+        states=[],
+    )
+
+
+def _app(writer: Writer) -> FastAPI:
+    app = FastAPI()
+    app.include_router(consent_api.router, prefix="/crm/consent")
+    app.dependency_overrides[crm_admin_user] = lambda: UserInfo(
+        id="u_1", username="ops", role=UserRole.ADMIN
+    )
+    consent_api.record_consent = writer  # type: ignore[assignment]
+    return app
+
+
+async def _post(app: FastAPI, body: Dict[str, Any]) -> httpx.Response:
+    """Driven in the test's own event loop, so the writer the route awaits is
+    the one this test installed."""
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://crm") as client:
+        return await client.post("/crm/consent", json=body)
+
+
+@pytest.fixture(autouse=True)
+def _restore_writer() -> Iterator[None]:
+    original = consent_api.record_consent
+    yield
+    consent_api.record_consent = original  # type: ignore[assignment]
+
+
+async def test_a_recorded_slip_comes_back_201_with_its_ledger_id() -> None:
+    response = await _post(_app(_writer), _body())
+    assert response.status_code == 201
+    assert response.json()["event"]["id"] == str(LEDGER_ID)
+
+
+async def test_the_address_is_normalized_before_the_writer_sees_it() -> None:
+    """The route is where a human-typed number enters, so this is where the
+    one spelling gets settled."""
+    seen: Dict[str, str] = {}
+
+    async def writer(event: ConsentEventIn) -> ConsentReceipt:
+        seen["address"] = event.address
+        return await _writer(event)
+
+    await _post(_app(writer), _body(address="+91 98123 40000"))
+    assert seen["address"] == "+919812340000"
+
+
+async def test_the_route_is_closed_without_an_admin() -> None:
+    """The one dependency between this endpoint and anyone forging or
+    withdrawing consent for any merchant."""
+    app = FastAPI()
+    app.include_router(consent_api.router, prefix="/crm/consent")
+    consent_api.record_consent = _writer  # type: ignore[assignment]
+    assert (await _post(app, _body())).status_code in (401, 403)
+
+
+async def test_a_malformed_body_is_422_before_the_writer_runs() -> None:
+    """No connection taken and no ledger row for a request that was never
+    valid — and the error names what it would have accepted."""
+    called = False
+
+    async def writer(event: ConsentEventIn) -> ConsentReceipt:
+        nonlocal called
+        called = True
+        return await _writer(event)
+
+    response = await _post(_app(writer), _body(channel="telepathy"))
+    assert response.status_code == 422
+    assert not called
+    for channel in ("whatsapp", "sms", "email", "voice", "instagram"):
+        assert channel in response.text
+
+
+async def test_a_refused_event_is_still_201_with_no_states() -> None:
+    """The attempt is evidence: the ledger row is written even when the stored
+    answer refuses the change, so bulk callers count states, not responses."""
+    response = await _post(_app(_writer), _body(event_type="IMPORT"))
+    assert response.status_code == 201
+    assert response.json()["states"] == []
+
+
+async def test_a_customer_from_another_merchant_is_404_not_500() -> None:
+    """Tenancy is enforced by the composite FK; the caller should see the pair
+    is wrong rather than a server error."""
+
+    async def writer(event: ConsentEventIn) -> ConsentReceipt:
+        raise CustomerNotInMerchant("nope")
+
+    assert (await _post(_app(writer), _body())).status_code == 404

--- a/tests/crm/permission/test_consent_queries.py
+++ b/tests/crm/permission/test_consent_queries.py
@@ -1,0 +1,114 @@
+"""Query builders for the consent tables: param binding and SQL shape."""
+
+from datetime import datetime, timezone
+
+from app.crm.permission.db.queries import (
+    CRM_CONSENT_EVENT_TABLE,
+    insert_consent_event_query,
+    select_purpose_scope_for_update_query,
+    upsert_consent_state_query,
+)
+from app.crm.permission.schemas import ConsentChannel, PurposeKey
+
+MOMENT = datetime(2026, 8, 23, 12, 0, tzinfo=timezone.utc)
+
+
+def test_ledger_insert_binds_every_value_and_returns_the_row() -> None:
+    sql, params = insert_consent_event_query(
+        "m_123",
+        "c_777",
+        "+919812340000",
+        "GRANT",
+        "whatsapp",
+        "marketing.promotional",
+        MOMENT,
+        "evt_51",
+    )
+    assert f"INSERT INTO {CRM_CONSENT_EVENT_TABLE}" in sql
+    assert "$8" in sql and "$9" not in sql
+    assert "RETURNING" in sql
+    assert params == [
+        "m_123",
+        "c_777",
+        "+919812340000",
+        "GRANT",
+        "whatsapp",
+        "marketing.promotional",
+        MOMENT,
+        "evt_51",
+    ]
+
+
+def test_the_time_is_always_bound_never_left_to_the_database() -> None:
+    """The column DEFAULT cannot fire — the insert always names occurred_at —
+    so the caller resolves the time. That is also what keeps one write on one
+    clock."""
+    sql, params = insert_consent_event_query(
+        "m_123", "c_777", "+91", "IMPORT", "whatsapp", "marketing", MOMENT, None
+    )
+    assert "COALESCE" not in sql and "now()" not in sql
+    assert params[6] == MOMENT
+
+
+def test_scope_read_locks_both_directions_of_the_tree() -> None:
+    """Down because a withdrawal cascades; up because a rule above this
+    purpose governs it."""
+    sql, params = select_purpose_scope_for_update_query(
+        "m_123",
+        "c_777",
+        "whatsapp",
+        "marketing.promotional",
+        ["marketing", "marketing.promotional"],
+    )
+    assert "FOR UPDATE" in sql
+    assert "purpose_key = ANY($4::text[]) OR starts_with(purpose_key, $5)" in sql
+    assert "channel = $3" in sql
+    assert params[3] == ["marketing", "marketing.promotional"]
+    assert params[4] == "marketing.promotional."
+
+
+def test_the_prefix_match_is_exact_not_a_like_pattern() -> None:
+    """`transactional.order_update` contains an underscore, which LIKE reads
+    as a single-character wildcard."""
+    sql, _ = select_purpose_scope_for_update_query(
+        "m_123", "c_777", "whatsapp", "transactional.order_update", ["transactional"]
+    )
+    assert "starts_with" in sql and "LIKE" not in sql
+
+
+def test_the_scope_read_orders_its_locks() -> None:
+    """Lock order belongs here — by the time the writes are sorted the rows
+    are already locked."""
+    sql, _ = select_purpose_scope_for_update_query(
+        "m_123", "c_777", "whatsapp", "marketing", ["marketing"]
+    )
+    assert sql.index("ORDER BY purpose_key") < sql.index("FOR UPDATE")
+
+
+def test_state_upsert_targets_the_four_column_key() -> None:
+    sql, params = upsert_consent_state_query(
+        "m_123", "c_777", "whatsapp", "marketing", "withdrawn", MOMENT, "evt_1"
+    )
+    assert "ON CONFLICT (merchant_id, customer_id, channel, purpose_key)" in sql
+    assert "last_event_id = EXCLUDED.last_event_id" in sql
+    assert params[4] == "withdrawn"
+
+
+def test_the_builders_survive_enum_members_not_just_strings() -> None:
+    """These are str Enums, so an f-string renders 'PurposeKey.MARKETING', not
+    'marketing'. The prefix and the lock key are built with + and join for
+    exactly that reason.
+
+    This is a regression test, not a hypothetical: the trap was fixed in
+    covers(), documented there, and then reintroduced here. A caller that
+    forgets .value would otherwise get a prefix matching zero rows — so a
+    withdrawal would stop cascading, silently, with no error anywhere.
+    """
+    _, params = select_purpose_scope_for_update_query(
+        "m_123",
+        "c_777",
+        ConsentChannel.WHATSAPP,
+        PurposeKey.MARKETING,
+        [PurposeKey.MARKETING],
+    )
+    assert params[4] == "marketing."

--- a/tests/crm/permission/test_consent_writer.py
+++ b/tests/crm/permission/test_consent_writer.py
@@ -1,0 +1,264 @@
+"""record_consent()'s boundary — order and stapling, with a faked connection.
+
+What is under test: the lock comes before the read, the read reaches both
+directions of the tree, and every state row points at the ledger row written
+in the same transaction.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Any, Awaitable, Callable, Dict, List, Optional, Sequence
+from uuid import UUID
+
+import pytest
+
+from app.crm.permission import consent
+from app.crm.permission.consent import ConsentPolicy
+from app.crm.permission.schemas import (
+    ConsentEventIn,
+    ConsentEventType,
+    ConsentReceipt,
+    ConsentStatus,
+)
+
+Txn = Callable[..., Awaitable[Any]]
+
+NOW = datetime(2026, 8, 23, 12, 0, tzinfo=timezone.utc)
+MERCHANT = "m_123"
+CUSTOMER = UUID("00000000-0000-0000-0000-000000000777")
+LEDGER_ID = UUID("00000000-0000-0000-0000-0000000abcde")
+POLICY = ConsentPolicy(
+    marketing_grant_days=5, reask_embargo_days=45, pending_confirm_hours=6
+)
+
+
+def _event(event_type: ConsentEventType, purpose: str, **kw: Any) -> ConsentEventIn:
+    body: Dict[str, Any] = {
+        "merchant_id": MERCHANT,
+        "customer_id": CUSTOMER,
+        "address": "+919812340000",
+        "event_type": event_type,
+        "channel": "whatsapp",
+        "purpose_key": purpose,
+        "occurred_at": NOW,
+    }
+    body.update(kw)
+    return ConsentEventIn(**body)
+
+
+def _state_row(purpose: str, status: str) -> Dict[str, Any]:
+    return {
+        "merchant_id": MERCHANT,
+        "customer_id": CUSTOMER,
+        "channel": "whatsapp",
+        "purpose_key": purpose,
+        "status": status,
+        "expires_at": None,
+        "last_event_id": LEDGER_ID,
+    }
+
+
+class FakeConn:
+    """Routes on the SQL the builders produce, so the real query-selection
+    path is exercised rather than a hand-wired accessor."""
+
+    def __init__(self, scope: Sequence[Dict[str, Any]] = ()) -> None:
+        self.scope = list(scope)
+        self.calls: List[str] = []
+        self.upserted: List[Dict[str, Any]] = []
+        self.scope_params: List[Any] = []
+        self.event_params: List[Any] = []
+
+    async def fetch(self, query: str, *values: Any) -> List[Dict[str, Any]]:
+        self.calls.append("select")
+        assert "FOR UPDATE" in query
+        self.scope_params = list(values)
+        return self.scope
+
+    async def fetchrow(self, query: str, *values: Any) -> Optional[Dict[str, Any]]:
+        if "crm_consent_event" in query:
+            self.calls.append("insert")
+            self.event_params = list(values)
+            # The real INSERT binds $7 into a NOT NULL column with no COALESCE,
+            # so a None here is a constraint violation. Modelling a fallback
+            # the SQL does not have is how a test proves the fake, not the code.
+            assert values[6] is not None
+            return {
+                "id": LEDGER_ID,
+                "merchant_id": values[0],
+                "customer_id": CUSTOMER,
+                "address": values[2],
+                "event_type": values[3],
+                "channel": values[4],
+                "purpose_key": values[5],
+                "occurred_at": values[6],
+                "artifact_ref": values[7],
+            }
+        self.calls.append("upsert")
+        row = {
+            "merchant_id": values[0],
+            "customer_id": CUSTOMER,
+            "channel": values[2],
+            "purpose_key": values[3],
+            "status": values[4],
+            "expires_at": values[5],
+            "last_event_id": UUID(values[6]),
+        }
+        self.upserted.append(row)
+        return row
+
+
+async def _record(conn: FakeConn, event: ConsentEventIn) -> ConsentReceipt:
+    """FakeConn duck-types the handle; widening here keeps every call site free
+    of a repeated ignore."""
+    txn: Any = conn
+    return await consent._record_consent_in_txn(txn, event, POLICY)
+
+
+async def _fixed_policy() -> ConsentPolicy:
+    return POLICY
+
+
+@pytest.fixture
+def conn() -> FakeConn:
+    return FakeConn()
+
+
+async def test_the_scope_is_read_before_anything_is_written(conn: FakeConn) -> None:
+    """Order is the guarantee: the scope is read under FOR UPDATE, the ledger
+    row is appended, and only then does any state row move."""
+    await _record(conn, _event(ConsentEventType.GRANT, "marketing"))
+    assert conn.calls == ["select", "insert", "upsert"]
+
+
+async def test_the_locked_scope_reaches_upward_as_well_as_down(
+    conn: FakeConn,
+) -> None:
+    """Reading only downward is how a bulk import walked past a parent's
+    withdrawal."""
+    await _record(
+        conn, _event(ConsentEventType.IMPORT, "marketing.promotional.winback")
+    )
+    assert conn.scope_params[3] == [
+        "marketing",
+        "marketing.promotional",
+        "marketing.promotional.winback",
+    ]
+    assert conn.scope_params[4] == "marketing.promotional.winback."
+
+
+async def test_every_state_row_points_at_the_event_row_just_written(
+    conn: FakeConn,
+) -> None:
+    """The state asserts, the event row proves — last_event_id is the thread."""
+    await _record(conn, _event(ConsentEventType.GRANT, "marketing"))
+    assert conn.upserted[0]["last_event_id"] == LEDGER_ID
+
+
+async def test_a_withdrawal_writes_one_state_row_per_governed_purpose() -> None:
+    conn = FakeConn(
+        [
+            _state_row("marketing", "granted"),
+            _state_row("marketing.promotional", "granted"),
+        ]
+    )
+    receipt = await _record(conn, _event(ConsentEventType.WITHDRAW, "marketing"))
+    assert len(receipt.states) == 2
+    assert all(s.status is ConsentStatus.WITHDRAWN for s in receipt.states)
+
+
+async def test_a_refused_event_still_leaves_a_ledger_row() -> None:
+    """The attempt is evidence: the record keeps what the importer tried."""
+    conn = FakeConn([_state_row("marketing.promotional", "withdrawn")])
+    receipt = await _record(
+        conn, _event(ConsentEventType.IMPORT, "marketing.promotional")
+    )
+    assert conn.calls.count("insert") == 1
+    assert "upsert" not in conn.calls
+    assert receipt.states == []
+
+
+async def test_one_write_uses_one_clock(conn: FakeConn) -> None:
+    """A caller who omits the time still binds one, and the expiry derives
+    from the same instant — asserted on the BOUND PARAMETER, since a receipt
+    assertion would only prove what the fake handed back."""
+    undated = _event(ConsentEventType.GRANT, "marketing", occurred_at=None)
+    receipt = await _record(conn, undated)
+
+    assert conn.event_params[6] is not None
+    assert conn.event_params[6].tzinfo is not None
+    window = conn.upserted[0]["expires_at"] - receipt.event.occurred_at
+    assert window == timedelta(days=POLICY.marketing_grant_days)
+
+
+async def test_a_cascade_stamps_one_embargo_date_on_every_row() -> None:
+    """The policy is read once, not once per row."""
+    conn = FakeConn(
+        [
+            _state_row("marketing", "granted"),
+            _state_row("marketing.promotional", "granted"),
+            _state_row("marketing.promotional.winback", "granted"),
+        ]
+    )
+    receipt = await _record(conn, _event(ConsentEventType.WITHDRAW, "marketing"))
+    assert len({s.expires_at for s in receipt.states}) == 1
+
+
+async def test_the_windows_are_read_before_the_boundary_opens(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A flag lookup is network I/O; doing it inside the transaction would
+    hold row locks across a Redis round-trip."""
+    order: List[str] = []
+
+    async def watched_policy() -> ConsentPolicy:
+        order.append("flags")
+        return POLICY
+
+    async def watched_txn(fn: Txn, *args: Any, **kwargs: Any) -> Any:
+        order.append("txn")
+        return await fn(FakeConn(), *args, **kwargs)
+
+    monkeypatch.setattr(consent, "load_policy", watched_policy)
+    monkeypatch.setattr(consent, "atomically", watched_txn)
+
+    await consent.record_consent(_event(ConsentEventType.GRANT, "marketing"))
+    assert order == ["flags", "txn"]
+
+
+async def test_record_consent_runs_both_stores_in_one_boundary(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    conn = FakeConn()
+
+    async def one_txn(fn: Txn, *args: Any, **kwargs: Any) -> Any:
+        return await fn(conn, *args, **kwargs)
+
+    monkeypatch.setattr(consent, "atomically", one_txn)
+    monkeypatch.setattr(consent, "load_policy", _fixed_policy)
+
+    receipt = await consent.record_consent(_event(ConsentEventType.GRANT, "marketing"))
+
+    assert conn.calls == ["select", "insert", "upsert"]
+    assert receipt.event.id == LEDGER_ID
+    assert len(receipt.states) == 1
+
+
+async def test_the_refusal_log_names_values_not_enum_reprs(
+    conn: FakeConn, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An operator greps this line for 'whatsapp', not for
+    'ConsentChannel.WHATSAPP'. f-strings on a str Enum render the repr.
+
+    The module uses loguru, which does not feed pytest's caplog, so the sink
+    is replaced rather than captured.
+    """
+    lines: List[str] = []
+    monkeypatch.setattr(consent.logger, "info", lambda msg: lines.append(msg))
+
+    conn.scope = [_state_row("marketing", "withdrawn")]
+    await _record(conn, _event(ConsentEventType.IMPORT, "marketing"))
+    logged = "".join(lines)
+    assert "(whatsapp/marketing)" in logged
+    assert "ConsentChannel" not in logged and "PurposeKey" not in logged

--- a/tests/crm/permission/test_decisions.py
+++ b/tests/crm/permission/test_decisions.py
@@ -1,0 +1,122 @@
+"""The decision log (B4): what reaches the database."""
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+import pytest
+
+from app.crm.permission import decisions
+from app.crm.permission.db.queries import CRM_DECISION_LOG_TABLE, insert_decision_query
+from app.crm.permission.schemas import DecisionKind
+
+NOW = datetime(2026, 8, 23, tzinfo=timezone.utc)
+MIGRATIONS = Path(__file__).resolve().parents[3] / "app/database/migrations"
+DECISION_DDL = (MIGRATIONS / "056_create_crm_decision_log.sql").read_text()
+
+
+class FakeConn:
+    def __init__(self) -> None:
+        self.rows: List[Tuple[Any, ...]] = []
+
+    async def fetchrow(self, query: str, *values: Any) -> Optional[Dict[str, Any]]:
+        self.rows.append(values)
+        return {
+            "id": 84121,
+            "merchant_id": values[0],
+            "customer_id": values[1],
+            "decision_kind": values[2],
+            "chosen": values[3],
+            "decided_at": NOW,
+        }
+
+
+@pytest.fixture
+def conn() -> FakeConn:
+    return FakeConn()
+
+
+def test_the_insert_is_parameterized_and_returns_the_row() -> None:
+    sql, params = insert_decision_query("m_123", "c_777", "send_or_hold", "{}")
+    assert f"INSERT INTO {CRM_DECISION_LOG_TABLE}" in sql
+    assert "RETURNING" in sql
+    assert params == ["m_123", "c_777", "send_or_hold", "{}"]
+
+
+def test_decided_at_is_left_to_the_database() -> None:
+    """The clock is the moment the decision was reached; a caller-supplied time
+    would let a row claim a moment it was not decided at."""
+    sql, params = insert_decision_query("m_123", None, "send_or_hold", "{}")
+    assert "decided_at" not in sql.split("VALUES")[0]
+    assert len(params) == 4
+
+
+async def test_the_reasoning_is_serialized_with_the_enum_value(conn: FakeConn) -> None:
+    record = await decisions.log_decision(
+        conn,  # type: ignore[arg-type]
+        merchant_id="m_123",
+        customer_id="00000000-0000-0000-0000-000000000777",
+        decision_kind=DecisionKind.SEND_OR_HOLD,
+        chosen={"verdict": "block", "reason": "quiet_hours", "at": NOW},
+    )
+    _, _, kind, chosen_json = conn.rows[0]
+    assert kind == "send_or_hold"  # the value, never the Enum repr
+    ink = json.loads(chosen_json)
+    assert ink["reason"] == "quiet_hours"
+    assert ink["at"].startswith("2026-08-23")  # non-JSON natives survive
+    assert record.id == 84121
+
+
+async def test_a_non_finite_number_is_refused_before_postgres_sees_it(
+    conn: FakeConn,
+) -> None:
+    """A sent/limit ratio can produce NaN; json.dumps would emit bare NaN, which
+    the ::jsonb cast rejects — inside the caller's transaction, taking the
+    business write down with it."""
+    with pytest.raises(ValueError):
+        await decisions.log_decision(
+            conn,  # type: ignore[arg-type]
+            merchant_id="m_123",
+            decision_kind=DecisionKind.SEND_OR_HOLD,
+            chosen={"verdict": "block", "ratio": float("nan")},
+        )
+
+
+async def test_every_decision_kind_reaches_the_database_as_its_value(
+    conn: FakeConn,
+) -> None:
+    for kind in DecisionKind:
+        await decisions.log_decision(
+            conn,  # type: ignore[arg-type]
+            merchant_id="m_123",
+            decision_kind=kind,
+            chosen={"verdict": "recorded"},
+        )
+    assert {row[2] for row in conn.rows} == {k.value for k in DecisionKind}
+
+
+def test_the_decision_kind_enum_matches_the_migration_check() -> None:
+    for kind in DecisionKind:
+        assert f"'{kind.value}'" in DECISION_DDL, kind
+
+
+def test_a_row_cannot_exist_without_a_verdict() -> None:
+    """Law 9: the invariant lives in the table, not in a second Python guard."""
+    assert "chosen ? 'verdict'" in DECISION_DDL
+
+
+def test_a_json_array_does_not_satisfy_the_verdict_check() -> None:
+    """`?` on an array asks whether it CONTAINS the string, so '["verdict"]'
+    passes the key test while having no verdict field — the audit read would
+    find nothing where the constraint promised something."""
+    assert "jsonb_typeof(chosen) = 'object'" in DECISION_DDL
+
+
+def test_the_decision_log_refuses_edits_and_deletes() -> None:
+    """A verdict that can be rewritten afterwards is a claim about an audit
+    record, not one. Same rule as the consent ledger."""
+    for trigger in ("crm_decision_log_no_update", "crm_decision_log_no_delete"):
+        assert trigger in DECISION_DDL, trigger
+    assert "BEFORE UPDATE ON crm_decision_log" in DECISION_DDL
+    assert "BEFORE DELETE ON crm_decision_log" in DECISION_DDL

--- a/tests/crm/permission/test_policy.py
+++ b/tests/crm/permission/test_policy.py
@@ -1,0 +1,57 @@
+"""The CRM_* consent windows: what a bad flag value may not do.
+
+These are compliance windows, live-tunable through DevCycle, and a wrong one
+is silent — the deadline is stored concretely on the row, so fixing the flag
+does not repair rows already written.
+"""
+
+from typing import Any, Awaitable, Callable, Dict
+
+import pytest
+
+from app.core.config import dynamic
+from app.crm.permission.consent import load_policy
+
+GetConfig = Callable[..., Awaitable[Any]]
+
+
+def _flags(values: Dict[str, Any]) -> GetConfig:
+    """Signature mirrors the real get_config; a drift here would hide one
+    there."""
+
+    async def get_config(key: str, default_value: Any, return_type: type = str) -> Any:
+        return values.get(key, default_value)
+
+    return get_config
+
+
+async def test_the_defaults_are_the_documented_windows(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """get_config swallows a flag-store outage and falls through to these, so a
+    Redis failure never blocks recording a STOP."""
+    monkeypatch.setattr(dynamic, "get_config", _flags({}))
+    policy = await load_policy()
+    assert (policy.marketing_grant_days, policy.reask_embargo_days) == (7, 90)
+    assert policy.pending_confirm_hours == 24
+
+
+async def test_a_sane_override_is_honoured(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(dynamic, "get_config", _flags({"CRM_REASK_EMBARGO_DAYS": 30}))
+    assert (await load_policy()).reask_embargo_days == 30
+
+
+@pytest.mark.parametrize("bad", [0, -1, "", "soon", None, True, False])
+async def test_a_window_that_would_invert_the_rule_is_refused(
+    monkeypatch: pytest.MonkeyPatch, bad: object
+) -> None:
+    """Zero or negative is not a shorter rule, it is the absence of one: a -1
+    day embargo lifted yesterday.
+
+    `True` is the regression case. convert_type(True, int) returns 1, so
+    picking DevCycle's default Boolean variable type instead of Number would
+    turn the 90-day embargo into 24 hours — and take the success path, so not
+    even a warning would be logged.
+    """
+    monkeypatch.setattr(dynamic, "get_config", _flags({"CRM_REASK_EMBARGO_DAYS": bad}))
+    assert await dynamic.CRM_REASK_EMBARGO_DAYS() == 90


### PR DESCRIPTION
Adds app/crm/permission — the compliance core's storage layer (B1 + B4).

Two stores, one writer. crm_consent_event is the append-only ledger that answers "prove she agreed"; crm_consent_state is the resolved answer to "may I send right now". record_consent() writes both in one boundary, which is the only reason they cannot drift. crm_decision_log ships with log_decision() so B5 is purely the gate.

The laws live in plan_consent(), pure and tested without a database: withdrawal cascades DOWN the purpose tree and a grant never does; IMPORT fills a gap or does nothing; REQUEST may not change an answer either way; CONFIRM needs a live pending row; marketing grants expire, transactional does not; anything unrecognised grants nothing.

Tenancy is a composite FK to crm_customer (merchant_id, id) on both tables — the plain id form accepts any existing uuid, so a wrong merchant_id would file a real withdrawal under a tenant that never reads it.

Migrations 054, 055. 162 tests. check_crm_boundaries clean. Test plan in docs/crm/permission-api-testing.md.

dev proof:
<img width="1282" height="997" alt="Screenshot 2026-08-25 at 3 16 49 AM" src="https://github.com/user-attachments/assets/66681234-4d0a-4b93-8950-06fb24fe8988" />
<img width="1289" height="963" alt="Screenshot 2026-08-25 at 3 11 26 AM" src="https://github.com/user-attachments/assets/1a40696c-e1ef-4bfd-8072-c2dfe8dedfdd" />
<img width="1486" height="140" alt="Screenshot 2026-08-18 at 7 17 04 PM" src="https://github.com/user-attachments/assets/8aa3cfeb-5210-4eb1-a237-427ff7c2c0b2" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added secured CRM consent capture through `POST /crm/consent`.
  * Supports requests, grants, withdrawals, imports, and confirmations with validation and normalized contact details.
  * Added consent history, current permission status, and automated decision records.
  * Added configurable permission windows with defaults of 7 days, 90 days, and 24 hours.
* **Security**
  * Enforces ownership checks and prevents unauthorized consent changes.
  * Preserves immutable consent and decision records for auditing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->