### PR TITLE
feat: configurable LLM provider for topic evaluation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,6 +30,9 @@ BREEZE_BUDDY_DAILY_API_URL=  # Optional: Falls back to DAILY_API_URL
 AZURE_OPENAI_API_KEY=
 AZURE_OPENAI_ENDPOINT=
 AZURE_OPENAI_MODEL="gpt-4o-automatic"
+
+OPENAI_GATEWAY_BASE_URL=
+OPENAI_GATEWAY_API_KEY=
 # KB embeddings (azure_openai is the default provider for new knowledge bases).
 # Separate keys from the LLM's AZURE_OPENAI_* above ON PURPOSE — rotating or
 # repointing one must never silently move the other. Both are dynamic config:

--- a/app/ai/voice/agents/breeze_buddy/services/conversation_analysis/topics/extractor.py
+++ b/app/ai/voice/agents/breeze_buddy/services/conversation_analysis/topics/extractor.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, List, Mapping, Optional
 from pipecat.processors.aggregators.llm_context import LLMContext
 
 from app.ai.voice.agents.breeze_buddy.llm import get_llm_service
-from app.ai.voice.llm import LLMConfiguration, LLMProvider
+from app.ai.voice.llm import LLMConfiguration, LLMProvider, LLMSdk
 from app.schemas.breeze_buddy.conversation_analysis import TopicExtractionResult
 from app.services.live_config.store import get_config
 
@@ -29,10 +29,21 @@ def resolve_topic_evaluation_configuration(
     else:
         raw = {}
 
+    provider = str(raw.get("provider") or LLMProvider.OPENAI.value).strip()
+    if provider not in [p.value for p in LLMProvider]:
+        raise ValueError(f"Unsupported topic evaluator provider: {provider}")
+    sdk = str(raw.get("sdk") or "").strip() or None
+    if sdk and sdk not in [s.value for s in LLMSdk]:
+        raise ValueError(f"Unsupported topic evaluator sdk: {sdk}")
     model = str(raw.get("model") or "").strip()
     if not model:
         raise ValueError("evaluation_config.model is required")
     system_prompt = str(raw.get("system_prompt") or "").strip()[:50000] or None
+    region = str(raw.get("region") or "").strip() or None
+    if provider == LLMProvider.GOOGLE_VERTEX and not region:
+        raise ValueError(
+            "evaluation_config.region is required for google_vertex provider"
+        )
     settings = raw.get("settings")
     settings = dict(settings) if isinstance(settings, Mapping) else {}
 
@@ -43,22 +54,28 @@ def resolve_topic_evaluation_configuration(
     temperature = min(2.0, max(0.0, temperature))
 
     try:
-        max_output_tokens = int(settings.get("max_output_tokens", 10000))
+        max_output_tokens = int(settings.get("max_output_tokens", 16384))
     except (TypeError, ValueError, OverflowError):
-        max_output_tokens = 10000
-    max_output_tokens = min(10000, max(128, max_output_tokens))
+        max_output_tokens = 16384
+    max_output_tokens = min(16384, max(128, max_output_tokens))
 
-    try:
-        max_topics = int(settings["max_topics"])
-    except (KeyError, TypeError, ValueError, OverflowError) as exc:
-        raise ValueError(
-            "evaluation_config.settings.max_topics must be an integer"
-        ) from exc
-    max_topics = min(5, max(1, max_topics))
+    max_topics = settings.get("max_topics")
+    if max_topics is not None:
+        try:
+            max_topics = int(max_topics)
+        except (TypeError, ValueError, OverflowError) as exc:
+            raise ValueError(
+                "evaluation_config.settings.max_topics must be an integer"
+            ) from exc
+        if max_topics < 1:
+            raise ValueError("evaluation_config.settings.max_topics must be >= 1")
 
     return {
+        "provider": provider,
+        "sdk": sdk,
         "model": model,
         "system_prompt": system_prompt,
+        "region": region,
         "settings": {
             "temperature": temperature,
             "max_output_tokens": max_output_tokens,
@@ -96,16 +113,27 @@ async def _request_llm(
     transcript: str,
     runtime: Mapping[str, Any],
 ) -> Dict[str, Any]:
-    base_url = (await get_config("LITELLM_BASE_URL", "", str)).strip()
-    if not base_url:
-        raise RuntimeError("Grid base URL is not configured; set LITELLM_BASE_URL")
-    base_url = base_url.rstrip("/").removesuffix("/chat/completions")
+    endpoint = None
+    api_key_name = None
+    if runtime["provider"] == LLMProvider.OPENAI.value:
+        endpoint = (await get_config("LITELLM_BASE_URL", "", str)).strip()
+        api_key_name = "GRID_API_KEY"
+        if not endpoint:
+            endpoint = (await get_config("OPENAI_GATEWAY_BASE_URL", "", str)).strip()
+            api_key_name = "OPENAI_GATEWAY_API_KEY"
+        if not endpoint:
+            raise RuntimeError(
+                "OpenAI gateway base URL is not configured; set OPENAI_GATEWAY_BASE_URL"
+            )
+        endpoint = endpoint.rstrip("/").removesuffix("/chat/completions")
     llm = await get_llm_service(
         LLMConfiguration(
-            provider=LLMProvider.OPENAI,
+            provider=runtime["provider"],
+            sdk=runtime.get("sdk"),
             model=runtime["model"],
-            endpoint=base_url,
-            api_key_name="GRID_API_KEY",
+            region=runtime.get("region"),
+            endpoint=endpoint,
+            api_key_name=api_key_name,
             temperature=runtime["settings"]["temperature"],
             max_tokens=runtime["settings"]["max_output_tokens"],
         )
@@ -116,7 +144,7 @@ async def _request_llm(
         system_instruction=prompt + "\n\n" + _PROMPT_ONLY_RESPONSE_INSTRUCTION,
     )
     if not content:
-        raise ValueError("Grid topic extraction returned no content")
+        raise ValueError("Topic evaluator returned no content")
     return _decode_json_object(content)
 
 
@@ -148,7 +176,7 @@ def topic_labels_to_catalog(labels: Optional[List[str]]) -> List[Dict[str, str]]
 
 def normalize_topics(
     raw: Dict[str, Any],
-    max_topics: int,
+    max_topics: Optional[int],
     existing_topics: Optional[List[Dict[str, Any]]] = None,
 ) -> List[Dict[str, Any]]:
     parsed = TopicExtractionResult.model_validate(raw)
@@ -185,7 +213,7 @@ def normalize_topics(
                 "evidence_turns": sorted(set(topic.evidence_turns)),
             }
         )
-        if len(normalized) >= min(5, max(1, max_topics)):
+        if max_topics is not None and len(normalized) >= max_topics:
             break
     return normalized
 
@@ -245,7 +273,14 @@ async def extract_topics(
         raise ValueError(
             "evaluation_config has no system_prompt; update the global default row"
         )
-    prompt = base_prompt.replace("{max_topics}", str(max_topics)).replace(
+    prompt = base_prompt
+    if max_topics is None:
+        prompt = prompt.replace(
+            "Return no more than {max_topics} topics.",
+            "Return every distinct topic identified.",
+        )
+    prompt = prompt.replace("{max_topics}", str(max_topics or "unlimited"))
+    prompt = prompt.replace(
         "{accepted_topics}",
         json.dumps(approved_catalog, ensure_ascii=False),
     )

--- a/app/api/routers/breeze_buddy/topics/handlers.py
+++ b/app/api/routers/breeze_buddy/topics/handlers.py
@@ -72,7 +72,7 @@ async def update_topic_configuration_handler(
     template_id: str,
     request: UpdateTopicConfigurationRequest,
 ) -> TopicConfigurationResponse:
-    patch = request.model_dump(exclude_unset=True)
+    patch = request.model_dump(exclude_unset=True, mode="json")
     if not patch:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
@@ -90,6 +90,9 @@ async def update_topic_configuration_handler(
         existing = resolve_topic_evaluation_configuration(current.get("configuration"))
         if "settings" in patch:
             patch["settings"] = {**existing["settings"], **patch["settings"]}
+        if "provider" in patch and patch["provider"] != existing["provider"]:
+            patch.setdefault("sdk", None)
+            patch.setdefault("region", None)
         resolved = resolve_topic_evaluation_configuration({**existing, **patch})
     except (TypeError, ValueError) as exc:
         raise HTTPException(

--- a/app/database/migrations/065_topic_evaluation_no_default_max_topics.sql
+++ b/app/database/migrations/065_topic_evaluation_no_default_max_topics.sql
@@ -1,0 +1,15 @@
+UPDATE evaluation_config
+SET configuration = jsonb_set(
+    jsonb_set(
+        configuration #- '{settings,max_topics}',
+        '{model}',
+        '"open-large-sa"'
+    ),
+    '{settings,max_output_tokens}',
+    '16384'
+)
+WHERE evaluation_type = 'TOPIC'
+  AND (
+    template_id IS NULL
+    OR configuration ->> 'model' = 'minimaxai/minimax-m2'
+  );

--- a/app/schemas/breeze_buddy/conversation_analysis.py
+++ b/app/schemas/breeze_buddy/conversation_analysis.py
@@ -6,6 +6,8 @@ from uuid import UUID
 
 from pydantic import BaseModel, Field, field_validator
 
+from app.ai.voice.llm import LLMProvider, LLMSdk
+
 
 class ConversationChannel(str, Enum):
     VOICE = "VOICE"
@@ -44,11 +46,22 @@ class TopicCatalogResponse(BaseModel):
 
 
 class UpdateTopicConfigurationRequest(BaseModel):
+    provider: Optional[LLMProvider] = None
+    sdk: Optional[LLMSdk] = None
     model: Optional[str] = Field(None, max_length=200)
+    region: Optional[str] = Field(None, max_length=100)
     system_prompt: Optional[str] = Field(None, max_length=50000)
     settings: Optional[Dict[str, Any]] = None
 
-    @field_validator("model", "system_prompt", "settings", mode="before")
+    @field_validator(
+        "provider",
+        "sdk",
+        "model",
+        "region",
+        "system_prompt",
+        "settings",
+        mode="before",
+    )
     @classmethod
     def reject_null(cls, value: Any) -> Any:
         if value is None:
@@ -60,7 +73,10 @@ class UpdateTopicConfigurationRequest(BaseModel):
 
 class TopicConfigurationResponse(BaseModel):
     template_id: UUID
+    provider: LLMProvider
+    sdk: Optional[LLMSdk] = None
     model: str
+    region: Optional[str] = None
     system_prompt: str
     settings: Dict[str, Any]
 


### PR DESCRIPTION
## What

Makes the post-conversation topic evaluator's LLM configurable per template instead of hardcoded to the OpenAI-compatible Grid gateway.

- `evaluation_config.configuration` now accepts `provider`, `sdk`, and `region` alongside `model`, `system_prompt`, and `settings`
- Provider is validated against the shared `LLMProvider` enum (`azure`, `openai`, `google_vertex`); unknown values are rejected, `region` is required for `google_vertex`, and `sdk=anthropic` selects Claude on Vertex
- The extractor dispatches through the shared `get_llm_service` factory (`app/ai/voice/agents/breeze_buddy/llm`), so the evaluator picks up Azure, Gemini on Vertex, and Claude on Vertex support for free
- `endpoint` and `api_key_name` are resolved by the backend only, never accepted from the API: `openai` always routes through the OpenAI-compatible gateway (the legacy `LITELLM_BASE_URL` + `GRID_API_KEY` pair while it is set, otherwise `OPENAI_GATEWAY_BASE_URL` + `OPENAI_GATEWAY_API_KEY`; no config change is needed to deploy, and envs can move to the new names by setting them and dropping the old pair), `azure`/`google_vertex` use their existing static/env defaults. An admin-supplied pair could exfiltrate any config secret to an arbitrary URL.
- `PATCH /templates/{template_id}/topics/configuration` (admin-only) accepts the new fields; switching `provider` resets `sdk`/`region` unless the patch supplies them
- `settings.max_topics` is now optional (omit for no cap); values below 1 are rejected instead of silently clamped
- Migration `065` moves the default row to `open-large-sa` / 16384 tokens / no `max_topics`, and also migrates per-template rows still on the retired `minimaxai/minimax-m2` default (per-template rows are full copies of the default taken at enable time)


## Verified locally

Through the running app for each provider: admin PATCH → chat session via API → agent replies → `/end` → queue → analysis worker → `evaluation_result` rows COMPLETED (openai, azure, google_vertex). Also verified the openai path with legacy-only and new-only config keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XvPLxqAFRgxcc1xnzW1svD
