### PR TITLE
feat(crm): POST /ingest/events — the push door and the extractor that reads it (A9 + A10)

### DIFF
--- a/app/crm/api.py
+++ b/app/crm/api.py
@@ -1,6 +1,6 @@
 """/crm root router (A5).
 
-Mounted in app/main.py at prefix "/crm" — OUTSIDE /agent/voice/breeze-buddy
+Mounted in app/main.py at the root — OUTSIDE /agent/voice/breeze-buddy
 (ADR 0006). Each module's api.py router is included here as it lands:
 
     from app.crm.identity import api as identity_api
@@ -18,6 +18,7 @@ from app.crm.outreach import api as outreach_api
 from app.crm.record import api as record_api
 
 router = APIRouter()
-router.include_router(identity_api.router, prefix="/customers", tags=["CRM Customers"])
-router.include_router(record_api.router, prefix="/customers", tags=["CRM Journey"])
-router.include_router(outreach_api.router, prefix="/workflows", tags=["CRM Workflows"])
+router.include_router(identity_api.router, prefix="/customers", tags=["Customers"])
+router.include_router(record_api.journey_router, prefix="/customers", tags=["Journey"])
+router.include_router(record_api.ingest_router, prefix="/ingest", tags=["Ingest"])
+router.include_router(outreach_api.router, prefix="/workflows", tags=["Workflows"])

--- a/app/crm/auth.py
+++ b/app/crm/auth.py
@@ -9,6 +9,10 @@ system, no merchant-facing RBAC until the console fast-follow. Two doors:
   ingest, A9): per-merchant token compared constant-time against
   ``merchants.s2s_token`` and then JWT-verified, mirroring the existing
   breeze webhook auth exactly.
+- ``verify_s2s_caller`` — what the push door actually depends on: a
+  wildcard-scoped relay JWT (the credential nautilus already holds for
+  the lead door), else the per-merchant token above. One door, two kinds
+  of caller; see its docstring for why the order is what it is.
 
 Webhook ingress from external providers (Shopify relay, WhatsApp) does NOT
 use these — it is signature-verified per source in record/api.py (A9).
@@ -24,7 +28,10 @@ from app.api.security.breeze_buddy.rbac_token import (
     rbac_token_manager,
 )
 from app.core.security.authorization import require_admin
-from app.database.accessor.breeze_buddy.merchants import get_merchant_s2s_token
+from app.database.accessor.breeze_buddy.merchants import (
+    check_merchant_identifier_exists,
+    get_merchant_s2s_token,
+)
 from app.schemas import UserInfo
 
 
@@ -70,3 +77,81 @@ async def verify_s2s_merchant(merchant_id: str, request: Request) -> str:
     # tokens even when the byte-compare still matches.
     rbac_token_manager.verify_rbac_token(stored_token)
     return merchant_id
+
+
+async def verify_s2s_caller(merchant_id: str, request: Request) -> str:
+    """Verify an s2s push for one merchant. Two kinds of caller, and this
+    is the only place that knows the difference.
+
+    1. **Relay token** — a wildcard-scoped RBAC JWT issued to a trusted
+       relay. Nautilus already holds one for the lead door
+       (``CLAIRVOYANCE_JWT_TOKEN``) and pushes Shopify facts with that
+       same credential, so the ingest door needs no new secret minted per
+       shop. Scope is read exactly as the lead door reads it
+       (``leads/rbac.py``): ``"*"`` on merchants or resellers, or the
+       merchant named outright.
+    2. **Per-merchant token** — the merchant has ``merchants.s2s_token``
+       provisioned (the WooCommerce plugin shape). Defers unchanged to
+       ``verify_s2s_merchant``: constant-time compare against the stored
+       value, then JWT-verify.
+
+    We branch on what the token CLAIMS, never on whether verification
+    failed, and that is load-bearing. Per-merchant tokens are themselves
+    RBAC JWTs (minted in ``merchants/handlers.py``), so a rotated one
+    still carries a good signature and still names its merchant — under a
+    "try the relay check, fall back when it fails" order it would never
+    fail, so it would be accepted until it expired and the byte-compare
+    that revoked it would be dead code. What a per-merchant token can
+    never carry is a wildcard: the mint hard-codes exactly one
+    merchant_id. So ``"*"`` is proof the caller is NOT a per-merchant
+    token, and only then is skipping the stored-value check safe — which
+    is also what keeps the relay's hot path free of a DB round trip.
+
+    Fails closed throughout: a DB error reading the stored token raises
+    rather than falling through to the weaker check.
+
+    Returns the merchant_id on success; raises HTTPException otherwise.
+    """
+    presented = _extract_token(request)
+    if not presented:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Missing s2s token",
+        )
+
+    # Local decode, no DB. Raises 401 on a bad signature, an expiry, or a
+    # widget/demo token.
+    caller = rbac_token_manager.verify_rbac_token(presented)
+
+    # A wildcard scope can only belong to a relay/admin credential, never
+    # to a per-merchant token — so there is no stored row it could have
+    # been revoked against, and no reason to pay for the lookup.
+    if (
+        caller.role == "admin"
+        or "*" in caller.merchant_ids
+        or "*" in caller.reseller_ids
+    ):
+        # Scope says "any merchant" — it does not say this one is real. On the
+        # narrow path the stored-token compare proves existence for free; here
+        # nothing does, so the envelope's merchant_id would be taken on the
+        # caller's word. T13 keeps merchant_id NOT NULL because "every event
+        # arrives through a merchant-owned door, so every row has an owner by
+        # construction" — a typo'd shop domain would quietly found a tenant
+        # that isn't one, and the belt would resolve customers under it. One
+        # indexed read, same 404 the narrow path gives, so the door stays
+        # non-enumerable the same way.
+        if not await check_merchant_identifier_exists(merchant_id):
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Integration not found",
+            )
+        return merchant_id
+
+    # Narrowly scoped: this may well BE the merchant's provisioned token,
+    # so it has to clear the stored value — the only instant revocation
+    # this system has. A merchant with nothing provisioned gets 404 from
+    # there, not a pass: missing/NULL is NO on a permission-adjacent
+    # check, and accepting the token's own claim instead would mean
+    # CLEARING a merchant's s2s_token widened its access instead of
+    # revoking it.
+    return await verify_s2s_merchant(merchant_id, request)

--- a/app/crm/identity/api.py
+++ b/app/crm/identity/api.py
@@ -1,4 +1,4 @@
-"""/crm/customers — the admin endpoints the console list + 360 read (A6).
+"""/customers — the admin endpoints the console list + 360 read (A6).
 
 Thin routes per module rules §1: auth via Depends, delegate to the
 accessor. Tenancy law: every query carries its merchant_id predicate.

--- a/app/crm/outreach/entry.py
+++ b/app/crm/outreach/entry.py
@@ -19,10 +19,13 @@ from app.crm.outreach.db import accessor
 from app.crm.outreach.enrol import enrol
 from app.crm.outreach.schemas import Workflow, WorkflowDefinition, WorkflowNode
 from app.crm.record.contracts import RawEvent
+from app.crm.shared.normalize import normalize_phone
 
-# Where a phone hides in an event payload, tried in order — the voice
-# mirrors use customer_mobile_number; external doors normalize to
-# customer.phone as extractors are registered per source.
+# Fallback only: where a phone hides in a payload when no extractor
+# handles were passed in (the voice mirrors, which send the flat shape).
+# An external door's letter arrives VERBATIM under the two-plane ruling,
+# so its phone is wherever that provider puts it — which is the source's
+# extractor's business, not this file's.
 _PHONE_PATHS = ("customer_mobile_number", "phone")
 
 # Small-facts cap (canon: context carries pointers "plus the few small
@@ -32,19 +35,38 @@ _CONTEXT_VALUE_MAX_CHARS = 256
 
 
 def _phone_from_payload(payload: dict) -> str | None:
+    """The number the sends will actually dial or message — normalized to
+    E.164 here, because resolve() normalizes only what it probes on and
+    context is a separate copy. Unnormalized, a bare "9876543210" would
+    resolve to +919876543210 for identity while the call node dialled the
+    bare form, and a suppression stored in E.164 would not match it."""
+    raw: str | None = None
     for key in _PHONE_PATHS:
         if payload.get(key):
-            return str(payload[key])
-    customer = payload.get("customer")
-    if isinstance(customer, dict) and customer.get("phone"):
-        return str(customer["phone"])
-    return None
+            raw = str(payload[key])
+            break
+    if raw is None:
+        customer = payload.get("customer")
+        if isinstance(customer, dict) and customer.get("phone"):
+            raw = str(customer["phone"])
+    if raw is None:
+        return None
+    return normalize_phone(raw) or raw
 
 
-async def consume_attributed_event(event: RawEvent, customer_id: str) -> None:
+async def consume_attributed_event(
+    event: RawEvent, customer_id: str, handles: Optional[dict] = None
+) -> None:
     """Match one just-attributed event against every live plan's entry and
     goal topics. customer_id arrives separately: the row object still
-    carries the pre-stamp value."""
+    carries the pre-stamp value.
+
+    ``handles`` is what the source's extractor already found. Taking it
+    rather than re-reading the payload keeps ONE source-aware discovery in
+    the system: the number the sends dial is then the same number identity
+    resolved on, so suppression matches by construction and a new source
+    needs no teaching here. The payload search stays as the fallback for
+    the voice mirrors, which resolve before this consumer exists."""
     flows = await accessor.live_workflows(event.merchant_id)
     entry_matches: List[Tuple[Workflow, WorkflowDefinition]] = []
     goal_matches: List[Workflow] = []
@@ -84,7 +106,7 @@ async def consume_attributed_event(event: RawEvent, customer_id: str) -> None:
             {reply_key(node.id): None if answer is None else str(answer)},
         )
     for flow, definition in entry_matches:
-        await _try_enrol(flow, definition, event, customer_id)
+        await _try_enrol(flow, definition, event, customer_id, handles)
 
 
 def reply_key(node_id: str) -> str:
@@ -112,14 +134,18 @@ def _context_from_payload(payload: dict) -> dict:
 
 
 async def _try_enrol(
-    flow: Workflow, definition: WorkflowDefinition, event: RawEvent, customer_id: str
+    flow: Workflow,
+    definition: WorkflowDefinition,
+    event: RawEvent,
+    customer_id: str,
+    handles: Optional[dict] = None,
 ) -> None:
     admit, enrollment_key = _enrollment_key(definition, event, str(flow.id))
     if not admit:
         return  # a keyed plan without its key: a refusal, not an error
     context = _context_from_payload(event.payload)
     context["source_event_id"] = str(event.id)
-    phone = _phone_from_payload(event.payload)
+    phone = (handles or {}).get("phone") or _phone_from_payload(event.payload)
     if phone:
         context["phone"] = phone
     await enrol(

--- a/app/crm/record/api.py
+++ b/app/crm/record/api.py
@@ -1,24 +1,36 @@
-"""/crm/customers/{customer_id}/journey — the per-customer timeline (A12).
+"""The record module's two doors (/customers and /ingest): the per-customer journey view (A12) and the
+event ingest push door (A9).
 
-Thin route per module rules §1: auth via Depends, delegate straight to
-timeline.py. Tenancy law: merchant_id is a required query param.
+Thin routes per module rules §1. ``journey_router`` auths via
+Depends(crm_admin_user) and delegates to timeline.py; ``ingest_router``
+verifies the s2s caller and delegates to ingest.py — store first, 200
+fast, understand later, and nothing here parses the payload. Two routers,
+not one, because the two doors mount under different prefixes with
+different auth; the root router includes each exactly once.
+
+Tenancy law holds on both: merchant_id is a required query param on the
+journey read, and on ingest the merchant in the envelope IS the merchant
+the token was verified against.
 """
 
 from datetime import datetime
 from typing import List, Optional
 
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
 
+from app.core.logger import logger
 from app.core.logger.context import set_log_context
-from app.crm.auth import crm_admin_user
-from app.crm.record.schemas import JourneyCard
+from app.crm.auth import crm_admin_user, verify_s2s_caller
+from app.crm.record.ingest import ingest_event
+from app.crm.record.schemas import EventIn, EventReceipt, JourneyCard
 from app.crm.record.timeline import get_customer_journey
 from app.schemas import UserInfo
 
-router = APIRouter()
+journey_router = APIRouter()
+ingest_router = APIRouter()
 
 
-@router.get("/{customer_id}/journey", response_model=List[JourneyCard])
+@journey_router.get("/{customer_id}/journey", response_model=List[JourneyCard])
 async def get_customer_journey_route(
     customer_id: str,
     merchant_id: str = Query(..., description="Tenant scope — required"),
@@ -35,3 +47,70 @@ async def get_customer_journey_route(
     return await get_customer_journey(
         merchant_id, customer_id, limit, before_started_at, before_id
     )
+
+
+# A letter is stored verbatim and forever, so "store first" must not mean
+# "store anything of any size". Nothing in front of this app caps a request
+# body today (no ingress rule, no uvicorn flag), so the door does it.
+MAX_LETTER_BYTES = 1 * 1024 * 1024
+
+
+async def within_size_limit(request: Request) -> None:
+    """413 before the row exists. Declared beside the auth dependency for
+    the same reason: a door's limits belong on the door, not in a handler
+    that the next route beside it might forget to copy."""
+    declared = request.headers.get("content-length")
+    if declared and declared.isdigit() and int(declared) > MAX_LETTER_BYTES:
+        raise HTTPException(
+            status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            detail=f"Event exceeds {MAX_LETTER_BYTES} bytes",
+        )
+
+
+async def verified_caller(event: EventIn, request: Request) -> str:
+    """The ingest door's auth, as the route's declared dependency.
+
+    A dependency rather than a first line in the handler, because a route
+    without its auth dependency is a BLOCKER (design/ingest-doors): the
+    declaration is what makes the check impossible to forget when the next
+    route lands beside this one, and FastAPI runs it before the handler
+    body exists — so auth-before-store is the framework's guarantee, not a
+    convention this file has to keep.
+
+    It takes the parsed envelope because the merchant being claimed is IN
+    the body; FastAPI parses it once and hands the same object to the
+    handler.
+    """
+    return await verify_s2s_caller(event.merchant_id, request)
+
+
+@ingest_router.post("/events", response_model=EventReceipt)
+async def push_event_route(
+    event: EventIn,
+    _caller: str = Depends(verified_caller),
+    _size: None = Depends(within_size_limit),
+) -> EventReceipt:
+    set_log_context(component="crm.ingest.push", merchant_id=event.merchant_id)
+    try:
+        event_id = await ingest_event(
+            merchant_id=event.merchant_id,
+            source=event.source,
+            topic=event.topic,
+            external_id=event.external_id,
+            payload=event.payload,
+            occurred_at=event.occurred_at,
+            schema_version=event.schema_version,
+        )
+    except Exception as e:
+        # Front door fails CLOSED: a 200 here would silently drop the
+        # producer's event; 503 tells them to retry (dedupe makes the
+        # retry safe).
+        logger.error(
+            f"push door store failed for {event.source}/{event.topic} "
+            f"external_id={event.external_id}: {e}"
+        )
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Event store unavailable — retry with the same external_id",
+        )
+    return EventReceipt(id=event_id, duplicate=event_id is None)

--- a/app/crm/record/extractors/__init__.py
+++ b/app/crm/record/extractors/__init__.py
@@ -1,0 +1,26 @@
+"""source -> extractor: the single assembly point.
+
+One provider per file; this module is the only place that knows which
+source maps to which. A new channel is one import and one registry line —
+an unregistered source falls back to the flat shape, so a producer that
+speaks the house payload needs nothing here at all.
+
+Mirrors connectivity's ``providers/__init__.py`` holding ADAPTERS: same
+anatomy on both sides of the house.
+"""
+
+from typing import Any, Callable, Dict
+
+from app.crm.record.extractors import flat, shopify
+from app.crm.record.schemas import Extracted
+
+Extractor = Callable[[Dict[str, Any]], Extracted]
+
+EXTRACTORS: Dict[str, Extractor] = {
+    "lead-api": flat.extract,
+    "telephony": flat.extract,
+    "shopify": shopify.extract,
+}
+DEFAULT_EXTRACTOR: Extractor = flat.extract
+
+__all__ = ["EXTRACTORS", "DEFAULT_EXTRACTOR", "Extractor"]

--- a/app/crm/record/extractors/flat.py
+++ b/app/crm/record/extractors/flat.py
@@ -1,0 +1,31 @@
+"""The flat shape — handles and facts as top-level payload keys.
+
+Every buddy mirror (lead-api, telephony) sends it, and it is what a new
+producer gets by default: the name describes the PAYLOAD, not the
+producer. A source that can put ``customer_mobile_number`` at the top
+level needs no registration at all.
+"""
+
+from typing import Any, Dict
+
+from app.crm.record.schemas import Extracted
+
+# Producer's payload key -> canon attribute name (T05). A producer with a
+# different shape brings its own map.
+FACT_KEYS = {
+    "customer_name": "name",
+    "locale": "locale",
+    "timezone": "timezone",
+}
+
+
+def extract(payload: Dict[str, Any]) -> Extracted:
+    phone = payload.get("customer_mobile_number")
+    return Extracted(
+        handles={"phone": phone} if phone else {},
+        facts={
+            attribute: payload[key]
+            for key, attribute in FACT_KEYS.items()
+            if payload.get(key)
+        },
+    )

--- a/app/crm/record/extractors/shopify.py
+++ b/app/crm/record/extractors/shopify.py
@@ -1,0 +1,72 @@
+"""Shopify's own order/checkout body, as the relay forwards it.
+
+The relay is a pipe: it carries Shopify's words unopened, so the nesting
+arrives intact and this is where it gets read. Shopify puts a phone in up
+to four places and the top-level one is usually null — ``default_address``
+is the common home for a returning shopper — while a guest checkout
+carries no customer object at all, which is why the shipping address is
+the last fallback for both handle and name.
+
+Three handle kinds, matching the corpus's example for this extractor
+(shopify/checkouts.create -> phone, email, shopify_customer_id): the id is
+what lets a signed-in shopper's early checkout frames resolve before she
+has typed a number.
+
+The name is never defaulted. A placeholder like "Customer" would reach
+assert_facts as a genuine name claim and overwrite what we actually know
+about this person — absent is absent.
+"""
+
+from typing import Any, Dict
+
+from app.crm.record.schemas import Extracted
+from app.crm.shared.normalize import normalize_email, normalize_phone
+
+
+def extract(payload: Dict[str, Any]) -> Extracted:
+    customer = payload.get("customer") or {}
+    address = payload.get("shipping_address") or payload.get("billing_address") or {}
+    default_address = customer.get("default_address") or {}
+
+    # Most specific first: the customer record beats the shipping contact.
+    raw_phone = (
+        customer.get("phone")
+        or default_address.get("phone")
+        or payload.get("phone")
+        or address.get("phone")
+    )
+    raw_email = customer.get("email") or payload.get("email")
+
+    handles: Dict[str, str] = {}
+    if raw_phone:
+        phone = normalize_phone(str(raw_phone))
+        if phone:
+            handles["phone"] = phone
+    if raw_email:
+        email = normalize_email(str(raw_email))
+        if email:
+            handles["email"] = email
+
+    # Shopify's own customer id, when the shopper is signed in. It earns
+    # its line on the checkouts/update stream: the early frames carry no
+    # phone yet (she types it later) but they do carry this, so they
+    # resolve to the person instead of quarantining no_handle.
+    raw_customer_id = customer.get("id")
+    if raw_customer_id is not None:
+        handles["shopify_customer_id"] = str(raw_customer_id)
+
+    first = (
+        customer.get("first_name")
+        or default_address.get("first_name")
+        or address.get("first_name")
+        or ""
+    )
+    last = (
+        customer.get("last_name")
+        or default_address.get("last_name")
+        or address.get("last_name")
+        or ""
+    )
+    name = " ".join(part for part in (str(first), str(last)) if part).strip()
+
+    return Extracted(handles=handles, facts={"name": name} if name else {})

--- a/app/crm/record/ingest.py
+++ b/app/crm/record/ingest.py
@@ -8,9 +8,13 @@ duplicate is a silent no-op, exactly as the front-door law wants.
 handle (the voice mirror stamps at write); left None, the row sits on the
 pending queue (processed_at IS NULL) for the consumer to stamp (ADR 0020).
 
-Producers treat this as fire-and-forget: recording a fact must never
-break the operation that produced it, so this function logs and returns
-None on failure instead of raising.
+Two callers, two fail postures (module rules §6):
+
+- ``ingest_event`` — the push door (A9). Raises on store failure so the
+  API can 503 and the producer retries; returns None only on dedupe.
+- ``record_event`` — buddy-side mirrors. Fire-and-forget: recording a
+  fact must never break the operation that produced it, so it logs and
+  returns None on failure instead of raising.
 """
 
 import json
@@ -19,6 +23,31 @@ from typing import Any, Dict, Optional
 
 from app.core.logger import logger
 from app.crm.record.db import accessor
+
+
+async def ingest_event(
+    *,
+    merchant_id: str,
+    source: str,
+    topic: str,
+    external_id: str,
+    payload: Dict[str, Any],
+    occurred_at: Optional[datetime] = None,
+    schema_version: str = "1",
+    customer_id: Optional[str] = None,
+) -> Optional[str]:
+    """Store one letter, honestly: the new event id, None on duplicate,
+    a raised exception when the store failed."""
+    return await accessor.insert_event(
+        merchant_id,
+        source,
+        topic,
+        external_id,
+        json.dumps(payload, default=str),
+        schema_version,
+        occurred_at,
+        customer_id,
+    )
 
 
 async def record_event(
@@ -35,15 +64,15 @@ async def record_event(
     """Record one fact into the event spine. Returns the new event id,
     or None on duplicate / failure."""
     try:
-        return await accessor.insert_event(
-            merchant_id,
-            source,
-            topic,
-            external_id,
-            json.dumps(payload, default=str),
-            schema_version,
-            occurred_at,
-            customer_id,
+        return await ingest_event(
+            merchant_id=merchant_id,
+            source=source,
+            topic=topic,
+            external_id=external_id,
+            payload=payload,
+            occurred_at=occurred_at,
+            schema_version=schema_version,
+            customer_id=customer_id,
         )
     except Exception as e:
         logger.error(

--- a/app/crm/record/schemas.py
+++ b/app/crm/record/schemas.py
@@ -12,7 +12,7 @@ from datetime import datetime
 from typing import Any, Dict, Optional
 from uuid import UUID
 
-from pydantic import BaseModel
+from pydantic import AwareDatetime, BaseModel, ConfigDict, Field
 
 
 class JourneyCard(BaseModel):
@@ -52,3 +52,48 @@ class RawEvent(BaseModel):
     received_at: datetime
     occurred_at: Optional[datetime] = None
     customer_id: Optional[str] = None
+
+
+class EventIn(BaseModel):
+    """The envelope a producer fills in at the push door (A9) —
+    crm_event_raw's ingestion fields, nothing else. Payload is stored
+    verbatim (store first, understand later). ``customer_id`` is
+    deliberately absent: attribution is the consumer belt's job
+    (resolve()'s monopoly, ADR 0020).
+
+    The config line is load-bearing, not boilerplate:
+
+    - ``str_strip_whitespace`` runs before ``min_length``, so "   " fails
+      the same way "" does. Either would satisfy the DB's NOT NULL while
+      poisoning the dedupe UNIQUE (merchant_id, source, external_id).
+    - ``occurred_at`` is an AwareDatetime: a naive "2026-08-31T10:00:00"
+      is a 422, not a guess. asyncpg hands a naive value to a timestamptz
+      column as-is and Postgres reads it in the SESSION's zone, so a UTC
+      producer that omits the Z would be recorded 5.5 hours off on this
+      DB — and T13 col 9 measures triggered sends from this column, so a
+      shifted goal can let a rescue call go out after payment.
+    - ``extra="forbid"`` makes two silent failures loud: a smuggled
+      ``customer_id`` now 422s instead of being ignored (the producer
+      learns immediately that attribution isn't theirs to send), and a
+      typo'd ``occured_at`` 422s instead of vanishing while the row
+      quietly stores now().
+    """
+
+    model_config = ConfigDict(extra="forbid", str_strip_whitespace=True)
+
+    merchant_id: str = Field(min_length=1)
+    source: str = Field(min_length=1)
+    topic: str = Field(min_length=1)
+    external_id: str = Field(min_length=1)
+    payload: Dict[str, Any]
+    occurred_at: Optional[AwareDatetime] = None
+    schema_version: str = Field(default="1", min_length=1)
+
+
+class EventReceipt(BaseModel):
+    """The door's answer, 200 both ways: ``id`` for a newly stored
+    letter; ``duplicate=True`` (id None) when the dedupe UNIQUE already
+    holds it — a retry is success, not an error (module rules §4)."""
+
+    id: Optional[UUID] = None
+    duplicate: bool = False

--- a/app/crm/record/workers.py
+++ b/app/crm/record/workers.py
@@ -1,48 +1,19 @@
 """The event worker's pass (CRM_ROLE=event-worker, app/crm/worker_main.py):
 claim a batch, then per row extract -> resolve() -> assert_facts() -> entry
-rules -> stamp, one commit."""
+rules -> stamp, one commit.
+
+The pass knows no source by name: which extractor reads a payload is the
+registry's business (record/extractors), and this file only asks it."""
 
 from datetime import datetime, timezone
-from typing import Any, Callable, Dict, List, Optional
+from typing import Dict, List, Optional, Tuple
 
 from app.core.logger import logger
 from app.crm.identity.contracts import assert_facts, resolve as crm_resolve
 from app.crm.outreach.contracts import consume_attributed_event
 from app.crm.record.db import DbTxn, accessor, atomically, savepoint
-from app.crm.record.schemas import Extracted, RawEvent
-
-# Producer's payload key -> canon attribute name (T05). A producer with a
-# different shape brings its own map.
-FACT_KEYS = {
-    "customer_name": "name",
-    "locale": "locale",
-    "timezone": "timezone",
-}
-
-
-def _extract_flat(payload: Dict[str, Any]) -> Extracted:
-    """The flat shape: handles and facts as top-level keys. Every buddy
-    mirror (lead-api, telephony) sends it, and it is what a new producer
-    gets by default — the name describes the payload, not the producer."""
-    phone = payload.get("customer_mobile_number")
-    return Extracted(
-        handles={"phone": phone} if phone else {},
-        facts={
-            attribute: payload[key]
-            for key, attribute in FACT_KEYS.items()
-            if payload.get(key)
-        },
-    )
-
-
-# source -> extractor. A new channel is one registration here; an
-# unregistered source falls back to the flat shape.
-Extractor = Callable[[Dict[str, Any]], Extracted]
-EXTRACTORS: Dict[str, Extractor] = {
-    "lead-api": _extract_flat,
-    "telephony": _extract_flat,
-}
-DEFAULT_EXTRACTOR: Extractor = _extract_flat
+from app.crm.record.extractors import DEFAULT_EXTRACTOR, EXTRACTORS
+from app.crm.record.schemas import RawEvent
 
 
 async def run_pass(limit: int) -> List[RawEvent]:
@@ -71,34 +42,47 @@ async def _pass_in_txn(txn: DbTxn, limit: int) -> List[RawEvent]:
 async def _process_one(txn: DbTxn, event: RawEvent) -> None:
     """One row, inside the caller's savepoint. A quarantine stamped itself
     already and names no customer, so it returns early."""
-    customer_id = await _run_processor(txn, event)
+    customer_id, handles = await _run_processor(txn, event)
     if customer_id is None:
         return
-    await _consume_attributed_event(event, customer_id)
+    await _consume_attributed_event(event, customer_id, handles)
     await accessor.stamp_event(txn, str(event.id), customer_id)
 
 
-async def _consume_attributed_event(event: RawEvent, customer_id: str) -> None:
+async def _consume_attributed_event(
+    event: RawEvent, customer_id: str, handles: Dict[str, str]
+) -> None:
     """Entry-rules slot: per row, inside its savepoint, before its stamp, so a
-    poison rule costs one row per poll. A raise here leaves the row pending."""
-    await consume_attributed_event(event, customer_id)
+    poison rule costs one row per poll. A raise here leaves the row pending.
+
+    The extractor's handles ride along so the consumer never re-hunts what
+    this pass already found. Two searches would drift — and did: a Shopify
+    order with its phone only in customer.default_address resolved here and
+    then parked at the first call node, because the payload re-search did
+    not know that path."""
+    await consume_attributed_event(event, customer_id, handles)
 
 
-async def _run_processor(txn: DbTxn, event: RawEvent) -> Optional[str]:
+async def _run_processor(
+    txn: DbTxn, event: RawEvent
+) -> Tuple[Optional[str], Dict[str, str]]:
     """extract -> resolve() (or pass through a set customer_id) -> assert_facts().
-    Quarantines what it cannot attribute; a failed assert_facts never fails the row."""
+    Quarantines what it cannot attribute; a failed assert_facts never fails the row.
+
+    Returns the customer AND the handles the extractor found, so the one
+    source-aware discovery in the system is this one."""
     extract = EXTRACTORS.get(event.source, DEFAULT_EXTRACTOR)
     try:
         extracted = extract(event.payload)
     except Exception as e:
         await accessor.quarantine_event(txn, str(event.id), f"extractor_error: {e}")
-        return None
+        return None, {}
 
     customer_id = event.customer_id
     if not customer_id:
         if not extracted.handles:
             await accessor.quarantine_event(txn, str(event.id), "no_handle")
-            return None
+            return None, {}
         try:
             customer_id = str(
                 await crm_resolve(
@@ -110,7 +94,7 @@ async def _run_processor(txn: DbTxn, event: RawEvent) -> Optional[str]:
             )
         except ValueError as e:
             await accessor.quarantine_event(txn, str(event.id), f"unresolvable: {e}")
-            return None
+            return None, {}
 
     if extracted.facts:
         try:
@@ -123,7 +107,7 @@ async def _run_processor(txn: DbTxn, event: RawEvent) -> Optional[str]:
             )
         except Exception as e:
             logger.warning(f"event {event.id}: assert_facts failed, dropping: {e}")
-    return customer_id
+    return customer_id, extracted.handles
 
 
 def _log_queue_lag(events: List[RawEvent], limit: int) -> None:

--- a/app/main.py
+++ b/app/main.py
@@ -428,9 +428,12 @@ app.include_router(
     tags=["Feature Flags"],
 )
 
-# CRM (Buddy CPaaS) — mounted OUTSIDE /agent/voice/breeze-buddy (ADR 0006);
-# admin/S2S only in phase 1 (ADR 0007), auth wired per module router.
-app.include_router(crm_api.router, prefix="/crm", tags=["CRM"])
+# Customer-engagement doors — mounted OUTSIDE /agent/voice/breeze-buddy
+# (ADR 0006); admin/S2S only in phase 1 (ADR 0007), auth wired per module
+# router. No "crm" in the path: the never-words stay off every surface an
+# outside team or merchant can see (ADR 0022). The app/crm package and the
+# crm_* tables keep their internal names — those are invisible outside.
+app.include_router(crm_api.router, prefix="")
 
 # System health endpoints
 app.include_router(systems.router, prefix="", tags=["Systems"])

--- a/docs/ingest-api.md
+++ b/docs/ingest-api.md
@@ -1,0 +1,142 @@
+# Event ingestion API — `POST /ingest/events`
+
+The push door (A9) for services outside this repo: hand a fact to the
+event spine over HTTP and get a receipt. Your letter is stored verbatim and attributed to a customer moments
+later, by us. Store first, 200 fast, understand later.
+
+## Auth
+
+Send your token as either header:
+
+```
+Authorization: Bearer <token>
+x-s2s-token: <token>
+```
+
+Two kinds of caller are accepted, and the door decides by what the token
+claims — not by trying one and falling back:
+
+| Caller | Token | How it's checked |
+| ------ | ----- | ---------------- |
+| **Relay** — one service pushing for many merchants (e.g. the Shopify relay) | A wildcard-scoped RBAC JWT (`merchant_ids: ["*"]`, or an admin token). The same credential the lead API already takes. | Signature + expiry only. No per-merchant provisioning, no DB lookup. |
+| **Single merchant** — one integration, one tenant (e.g. the WooCommerce plugin) | The per-merchant JWT stored in `merchants.s2s_token`. | Compared constant-time against the stored value, then verified. Rotating the row revokes the old token on the next call. |
+
+Both token kinds are JWTs signed by the same key, so a valid signature
+alone proves nothing about which kind you hold. Only a wildcard scope
+does — the per-merchant mint always issues exactly one `merchant_id` —
+which is why a narrowly-scoped token must always clear the stored value.
+
+Failures: no token, bad signature, expired, or not the merchant's
+current stored token → **401**. Narrowly-scoped token for a merchant
+with nothing provisioned → **404**.
+
+## Request
+
+```bash
+curl -X POST https://<host>/ingest/events \
+  -H "Content-Type: application/json" \
+  -H "x-s2s-token: $S2S_TOKEN" \
+  -d '{
+    "merchant_id": "m_123",
+    "source":      "loyalty-svc",
+    "topic":       "order.placed",
+    "external_id": "order.placed:chk-88412",
+    "payload": {
+      "customer_mobile_number": "+919876543210",
+      "customer_name":          "Priya Sharma",
+      "order_id":               "42",
+      "amount":                 99900
+    },
+    "occurred_at": "2026-08-25T10:00:00Z"
+  }'
+```
+
+| Field            | Required | Notes                                                        |
+| ---------------- | -------- | ------------------------------------------------------------ |
+| `merchant_id`    | yes      | Tenant scope; must be within the token's scope               |
+| `source`         | yes      | Your system's name — stable, lowercase (`loyalty-svc`)       |
+| `topic`          | yes      | What happened (`order.placed`); routes the consumer belt     |
+| `external_id`    | yes      | YOUR id for this event — the dedupe key. **Topic-qualify it**, see below |
+| `payload`        | yes      | Any JSON object, stored verbatim and immutable. Standard keys below |
+| `occurred_at`    | no       | When it happened at the source. **ISO-8601 with an offset** (`2026-08-25T10:00:00Z` or `+05:30`) — a naive timestamp is a 422, because we will not guess your zone. Future values are clamped to `now()`; **omitted also becomes `now()`** (receive time), so downstream timers measure from arrival |
+| `schema_version` | no       | Defaults to `"1"`; bump when your payload shape changes      |
+
+Unknown fields are rejected with **422** — including `customer_id`,
+which is deliberately not accepted because attribution is the consumer
+belt's job (`resolve()`'s monopoly, ADR 0020). A typo'd field name is a
+422 rather than a silent drop, so `occured_at` fails loudly instead of
+quietly storing the receive time.
+
+### Naming the real producer
+
+`source` names **whose letter this is, not which pipe carried it**. The
+Shopify relay therefore sends `source: "shopify"` — not the name of the
+service doing the relaying — and derives `external_id` from ids Shopify
+itself issues (the order or checkout id), so either side can re-derive it
+for a replay or a parity join without reaching into the pipe's own
+database. The extractor registry keys on **`source`** (design/ingest-doors:
+several topics from one source dispatch inside that source's extractor),
+so the name chosen here decides which extractor reads the payload.
+
+### `external_id` — unique across ALL topics
+
+The dedupe key is `(merchant_id, source, external_id)`. **`topic` is not
+part of it.** If your natural id repeats across topics — one checkout id
+shared by the checkout, the order, and the cancellation — a bare id
+silently collides:
+
+```
+POST external_id="chk-88412"  topic="checkout.initiated"  → 200 {"duplicate": false}
+POST external_id="chk-88412"  topic="order.placed"        → 200 {"duplicate": true}   ← EATEN
+```
+
+The second event is dropped and the response still looks like success.
+Prefix the topic to keep them distinct:
+
+```
+"external_id": "checkout.initiated:chk-88412"
+"external_id": "order.placed:chk-88412"
+```
+
+If your source genuinely has no natural id, compose one — don't skip the
+field.
+
+### Standard payload keys
+
+One generic extractor reads every payload; there are no per-merchant
+decoders. It needs a handle to attribute the event to a customer:
+
+| Key | Required | Notes |
+| --- | -------- | ----- |
+| `customer_mobile_number` | yes | E.164, e.g. `+919876543210` |
+| `customer_name`          | yes | Display name |
+
+Without them the event stores fine and then **quarantines as `no_handle`**:
+no attribution → no enrolment → no call, and nothing in the journey. It
+fails silently and late, so treat these as required even though the
+envelope won't 422 on them.
+
+Every other **scalar** key (≤256 chars) rides into the template's
+`{placeholder}` variables — that's why fields like `item` and
+`cart_value` belong in the payload.
+
+## Responses
+
+| Status | Body                              | Meaning                                                          |
+| ------ | --------------------------------- | ---------------------------------------------------------------- |
+| 200    | `{"id": "<uuid>", "duplicate": false}` | Stored — `id` is this event's receipt                       |
+| 200    | `{"id": null, "duplicate": true}` | Already stored under `(merchant_id, source, external_id)` — success, not an error |
+| 401    | —                                 | No token, or invalid/expired/superseded                          |
+| 404    | —                                 | No per-merchant token provisioned for this merchant              |
+| 413    | —                                 | Event larger than 1 MB — split it; one event per fact          |
+| 422    | —                                 | Envelope invalid — blank or whitespace-only fields, non-object payload, or an unknown field |
+| 503    | —                                 | Store failed — retry with the SAME `external_id` (dedupe makes it safe) |
+
+## Producer rules of thumb
+
+- Retry 503s (same `external_id`, idempotent); treat `duplicate: true`
+  as success.
+- One event per fact — don't batch several facts into one payload; the
+  belt routes by `(source, topic)`.
+- Never rewrite a sent event: rows are immutable by trigger. New
+  information is a new event with a new `external_id`.

--- a/tests/crm/test_crm_auth.py
+++ b/tests/crm/test_crm_auth.py
@@ -1,14 +1,15 @@
-"""Token extraction for the s2s door (A5/A9 seam)."""
+"""Token extraction and the two s2s doors (A5/A9 seam)."""
 
 import asyncio
 from types import SimpleNamespace
-from typing import Dict, cast
+from typing import Dict, List, cast
 
 import pytest
 from fastapi import HTTPException, Request
 
 import app.crm.auth as crm_auth
-from app.crm.auth import _extract_token, verify_s2s_merchant
+from app.crm.auth import _extract_token, verify_s2s_caller, verify_s2s_merchant
+from app.schemas.breeze_buddy.auth import UserInfo, UserRole
 
 
 def _request(headers: Dict[str, str]) -> Request:
@@ -68,3 +69,162 @@ def test_s2s_valid_token_returns_merchant(monkeypatch: pytest.MonkeyPatch) -> No
     _s2s(monkeypatch, stored="tok")
     result = asyncio.run(verify_s2s_merchant("m1", _request({"x-s2s-token": "tok"})))
     assert result == "m1"
+
+
+# --- verify_s2s_caller: one door, two kinds of caller (A9) ---
+
+
+def _caller(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    stored: str | None,
+    merchant_ids: List[str] | None = None,
+    reseller_ids: List[str] | None = None,
+    role: UserRole = UserRole.MERCHANT,
+) -> None:
+    """Merchant has `stored` provisioned (or not); any presented token
+    decodes to a caller carrying the given scopes."""
+
+    async def fake_get(merchant_id: str) -> str | None:
+        return stored
+
+    def fake_verify(token: str) -> UserInfo:
+        return UserInfo(
+            id="u1",
+            username="caller",
+            role=role,
+            merchant_ids=merchant_ids or [],
+            reseller_ids=reseller_ids or [],
+        )
+
+    async def exists(merchant_id: str) -> bool:
+        return True
+
+    monkeypatch.setattr(crm_auth, "get_merchant_s2s_token", fake_get)
+    monkeypatch.setattr(crm_auth, "check_merchant_identifier_exists", exists)
+    monkeypatch.setattr(crm_auth.rbac_token_manager, "verify_rbac_token", fake_verify)
+
+
+@pytest.mark.parametrize(
+    "merchant_ids,reseller_ids,role",
+    [
+        (["*"], [], UserRole.RESELLER),  # wildcard on merchants — the relay
+        ([], ["*"], UserRole.RESELLER),  # wildcard on resellers
+        ([], [], UserRole.ADMIN),  # platform admin
+    ],
+)
+def test_caller_wildcard_token_accepted_without_touching_the_db(
+    monkeypatch: pytest.MonkeyPatch,
+    merchant_ids: List[str],
+    reseller_ids: List[str],
+    role: UserRole,
+) -> None:
+    # The relay's hot path. A wildcard can only belong to a relay/admin
+    # credential — the per-merchant mint hard-codes exactly one id — so
+    # there is no stored row it could have been revoked against, and no
+    # reason to pay for the read.
+    looked_up = False
+
+    async def spy_get(merchant_id: str) -> str | None:
+        nonlocal looked_up
+        looked_up = True
+        return "should-never-be-read"
+
+    _caller(
+        monkeypatch,
+        stored=None,
+        merchant_ids=merchant_ids,
+        reseller_ids=reseller_ids,
+        role=role,
+    )
+    monkeypatch.setattr(crm_auth, "get_merchant_s2s_token", spy_get)
+
+    assert asyncio.run(verify_s2s_caller("m1", _request({"x-s2s-token": "relay"})))
+    assert not looked_up
+
+
+def test_caller_wildcard_token_rejects_a_merchant_that_does_not_exist(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # "Any merchant" is not "this merchant is real". Without the existence
+    # read the envelope's merchant_id is taken on the caller's word, and a
+    # typo'd shop domain quietly founds a tenant the belt then resolves
+    # customers under. Same 404 the narrow path gives.
+    _caller(monkeypatch, stored=None, merchant_ids=["*"])
+
+    async def absent(merchant_id: str) -> bool:
+        return False
+
+    monkeypatch.setattr(crm_auth, "check_merchant_identifier_exists", absent)
+
+    with pytest.raises(HTTPException) as e:
+        asyncio.run(verify_s2s_caller("ghost-shop", _request({"x-s2s-token": "relay"})))
+    assert e.value.status_code == 404
+
+
+def test_caller_narrow_token_accepted_when_it_is_the_stored_one(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _caller(monkeypatch, stored="tok", merchant_ids=["m1"])
+    result = asyncio.run(verify_s2s_caller("m1", _request({"x-s2s-token": "tok"})))
+    assert result == "m1"
+
+
+def test_caller_rotated_out_token_is_401(monkeypatch: pytest.MonkeyPatch) -> None:
+    # THE guarantee the ordering exists for. Per-merchant tokens ARE RBAC
+    # JWTs, so this one still decodes and still names its merchant: under
+    # a "verify the JWT, fall back only when it throws" order it would be
+    # accepted until it expired, because it never throws. Only the
+    # byte-compare against the stored value catches it.
+    _caller(monkeypatch, stored="rotated-in", merchant_ids=["m1"])
+    with pytest.raises(HTTPException) as e:
+        asyncio.run(verify_s2s_caller("m1", _request({"x-s2s-token": "rotated-out"})))
+    assert e.value.status_code == 401
+
+
+def test_caller_narrow_token_with_nothing_provisioned_is_404(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Fail CLOSED: a NULL s2s_token is "missing", and missing is NO.
+    # Honouring the token's own claim here would mean CLEARING a
+    # merchant's token widened its access instead of revoking it.
+    _caller(monkeypatch, stored=None, merchant_ids=["m1"])
+    with pytest.raises(HTTPException) as e:
+        asyncio.run(verify_s2s_caller("m1", _request({"x-s2s-token": "t"})))
+    assert e.value.status_code == 404
+
+
+def test_caller_narrow_token_cannot_push_for_another_merchant(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Cross-tenant is closed by the byte-compare, not by a claim check:
+    # a token only ever matches the row it was minted for.
+    _caller(monkeypatch, stored="other-shops-token", merchant_ids=["m1"])
+    with pytest.raises(HTTPException) as e:
+        asyncio.run(
+            verify_s2s_caller("other-shop", _request({"x-s2s-token": "m1s-token"}))
+        )
+    assert e.value.status_code == 401
+
+
+def test_caller_no_token_is_401(monkeypatch: pytest.MonkeyPatch) -> None:
+    _caller(monkeypatch, stored=None, merchant_ids=["*"])
+    with pytest.raises(HTTPException) as e:
+        asyncio.run(verify_s2s_caller("m1", _request({})))
+    assert e.value.status_code == 401
+
+
+def test_caller_fails_closed_when_token_lookup_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # A DB blip must not demote a merchant to a weaker check — the error
+    # propagates instead of falling through to an accept.
+    _caller(monkeypatch, stored=None, merchant_ids=["m1"])
+
+    async def broken_get(merchant_id: str) -> str | None:
+        raise RuntimeError("pool exhausted")
+
+    monkeypatch.setattr(crm_auth, "get_merchant_s2s_token", broken_get)
+
+    with pytest.raises(RuntimeError):
+        asyncio.run(verify_s2s_caller("m1", _request({"x-s2s-token": "t"})))

--- a/tests/crm/test_event_ingest_api.py
+++ b/tests/crm/test_event_ingest_api.py
@@ -1,0 +1,304 @@
+"""The push door (A9) — POST /ingest/events: envelope validation,
+auth-before-store ordering, receipt shapes, and the two fail postures
+(front door raises -> 503; buddy mirror record_event stays fail-open)."""
+
+import asyncio
+import json
+from datetime import datetime, timezone
+from typing import Any, Dict, Optional
+
+import pytest
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.routing import APIRoute
+from fastapi.testclient import TestClient
+from pydantic import ValidationError
+
+import app.crm.record.api as record_api
+import app.crm.record.ingest as record_ingest
+from app.crm.record.api import push_event_route
+from app.crm.record.schemas import EventIn, EventReceipt
+
+
+def _event(**overrides: Any) -> EventIn:
+    fields: Dict[str, Any] = {
+        "merchant_id": "m1",
+        "source": "loyalty-svc",
+        "topic": "order.placed",
+        "external_id": "ord-42",
+        "payload": {"order_id": "42"},
+    }
+    fields.update(overrides)
+    return EventIn(**fields)
+
+
+def _event_body(**overrides: Any) -> Dict[str, Any]:
+    """The same envelope as a JSON body, for route-level tests."""
+    body: Dict[str, Any] = {
+        "merchant_id": "m1",
+        "source": "loyalty-svc",
+        "topic": "order.placed",
+        "external_id": "ord-42",
+        "payload": {"order_id": "42"},
+    }
+    body.update(overrides)
+    return body
+
+
+def _allow_auth(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_verify(merchant_id: str, request: Request) -> str:
+        return merchant_id
+
+    monkeypatch.setattr(record_api, "verify_s2s_caller", fake_verify)
+
+
+# --- EventIn: the envelope other teams fill in ---
+
+
+def test_event_in_defaults_schema_version_and_occurred_at() -> None:
+    event = _event()
+    assert event.schema_version == "1"
+    assert event.occurred_at is None
+
+
+@pytest.mark.parametrize("field", ["merchant_id", "source", "topic", "external_id"])
+@pytest.mark.parametrize("blank", ["", "   "])
+def test_event_in_rejects_blank_envelope_keys(field: str, blank: str) -> None:
+    # "" would still satisfy the DB's NOT NULL yet poison the dedupe
+    # UNIQUE (merchant_id, source, external_id) — reject at the door.
+    # "   " is the same hole wearing a hat: min_length=1 counts it as
+    # length 3, so str_strip_whitespace has to run first to close it.
+    with pytest.raises(ValidationError):
+        _event(**{field: blank})
+
+
+def test_event_in_strips_surrounding_whitespace() -> None:
+    # The strip is real, not just a rejection side effect — a padded id
+    # must dedupe against its clean twin, not sit beside it.
+    assert _event(external_id="  ord-42  ").external_id == "ord-42"
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("customer_id", "cus_1"),  # ADR 0020: attribution isn't theirs to send
+        ("occured_at", "2026-08-25T10:00:00Z"),  # typo'd occurred_at
+    ],
+)
+def test_event_in_rejects_unknown_fields(field: str, value: str) -> None:
+    # extra="forbid" turns two silent failures loud. Ignored, the smuggled
+    # customer_id teaches the producer a lie, and the typo'd timestamp
+    # vanishes while the row quietly stores now().
+    with pytest.raises(ValidationError):
+        _event(**{field: value})
+
+
+def test_event_in_rejects_naive_occurred_at() -> None:
+    # asyncpg hands a naive value to timestamptz as-is and Postgres reads
+    # it in the SESSION zone — a UTC producer omitting the Z lands hours
+    # off, and T13 col 9 measures triggered sends from this column.
+    with pytest.raises(ValidationError):
+        _event(occurred_at="2026-08-25T10:00:00")
+
+
+def test_event_in_accepts_offset_aware_occurred_at() -> None:
+    assert _event(occurred_at="2026-08-25T10:00:00Z").occurred_at is not None
+    assert _event(occurred_at="2026-08-25T10:00:00+05:30").occurred_at is not None
+
+
+# --- The route: auth, receipt shapes, fail posture ---
+
+
+def test_push_stores_letter_and_returns_id(monkeypatch: pytest.MonkeyPatch) -> None:
+    _allow_auth(monkeypatch)
+    seen: Dict[str, Any] = {}
+
+    async def fake_ingest(**kwargs: Any) -> Optional[str]:
+        seen.update(kwargs)
+        return "11111111-2222-3333-4444-555555555555"
+
+    monkeypatch.setattr(record_api, "ingest_event", fake_ingest)
+    occurred = datetime(2026, 8, 25, 10, 0, tzinfo=timezone.utc)
+    receipt = asyncio.run(push_event_route(_event(occurred_at=occurred), "m1"))
+
+    assert isinstance(receipt, EventReceipt)
+    assert str(receipt.id) == "11111111-2222-3333-4444-555555555555"
+    assert receipt.duplicate is False
+    assert seen["merchant_id"] == "m1"
+    assert seen["source"] == "loyalty-svc"
+    assert seen["topic"] == "order.placed"
+    assert seen["external_id"] == "ord-42"
+    assert seen["payload"] == {"order_id": "42"}
+    assert seen["occurred_at"] == occurred
+    assert seen["schema_version"] == "1"
+
+
+def test_push_duplicate_is_200_with_duplicate_receipt(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _allow_auth(monkeypatch)
+
+    async def fake_ingest(**kwargs: Any) -> Optional[str]:
+        return None  # dedupe conflict — the letter is already stored
+
+    monkeypatch.setattr(record_api, "ingest_event", fake_ingest)
+    receipt = asyncio.run(push_event_route(_event(), "m1"))
+
+    assert receipt.id is None
+    assert receipt.duplicate is True
+
+
+def test_push_rejected_auth_never_reaches_store(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Through the real route, not the handler function: auth is the route's
+    # declared dependency, so "before the store" is FastAPI's ordering
+    # guarantee rather than a line this file has to keep in place. Calling
+    # the handler directly would skip the very thing under test.
+    async def deny(merchant_id: str, request: Request) -> str:
+        raise HTTPException(status_code=401, detail="Invalid s2s token")
+
+    stored = False
+
+    async def fake_ingest(**kwargs: Any) -> Optional[str]:
+        nonlocal stored
+        stored = True
+        return None
+
+    monkeypatch.setattr(record_api, "verify_s2s_caller", deny)
+    monkeypatch.setattr(record_api, "ingest_event", fake_ingest)
+
+    app = FastAPI()
+    app.include_router(record_api.ingest_router, prefix="/ingest")
+    response = TestClient(app).post("/ingest/events", json=_event_body())
+
+    assert response.status_code == 401
+    assert stored is False
+
+
+def test_auth_is_declared_as_the_routes_dependency() -> None:
+    # design/ingest-doors: "a route without its auth dependency is a
+    # BLOCKER". Declared, not called in the body, so the next route added
+    # beside this one cannot quietly ship without it.
+    route = next(
+        r
+        for r in record_api.ingest_router.routes
+        if isinstance(r, APIRoute) and r.path == "/events"
+    )
+    assert record_api.verified_caller in [d.call for d in route.dependant.dependencies]
+
+
+def test_push_store_failure_is_503(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Front door fails CLOSED: the producer asked us to store and we
+    # couldn't — a 200 here would silently drop their event.
+    _allow_auth(monkeypatch)
+
+    async def broken_ingest(**kwargs: Any) -> Optional[str]:
+        raise RuntimeError("pool exhausted")
+
+    monkeypatch.setattr(record_api, "ingest_event", broken_ingest)
+
+    with pytest.raises(HTTPException) as e:
+        asyncio.run(push_event_route(_event(), "m1"))
+    assert e.value.status_code == 503
+
+
+def test_ingest_route_mounted_under_ingest() -> None:
+    from app.crm.api import router as crm_router
+
+    assert "/ingest/events" in {
+        getattr(route, "path", "") for route in crm_router.routes
+    }
+
+
+def test_journey_and_ingest_mount_once_each() -> None:
+    # The record module owns two routers precisely so the root can mount
+    # each under its own prefix. One shared `router` object included
+    # twice would expose /ingest/{customer_id}/journey and
+    # /customers/events as phantom surfaces and make OpenAPI lie.
+    from app.crm.api import router as crm_router
+
+    paths = [getattr(route, "path", "") for route in crm_router.routes]
+
+    assert "/customers/{customer_id}/journey" in paths
+    assert "/ingest/events" in paths
+    assert "/ingest/{customer_id}/journey" not in paths
+    assert "/customers/events" not in paths
+
+    # Path+method, not path alone: one path legitimately carries several
+    # verbs (GET /workflows lists, POST /workflows creates). A router
+    # included twice shows up as the same verb on the same path.
+    surface = [
+        (getattr(r, "path", ""), m)
+        for r in crm_router.routes
+        for m in sorted(getattr(r, "methods", []) or [])
+    ]
+    assert len(surface) == len(set(surface)), f"duplicate mounts: {surface}"
+
+
+# --- ingest.py: the raising variant vs the fail-open mirror door ---
+
+
+def test_ingest_event_serializes_payload_and_returns_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    seen: Dict[str, Any] = {}
+
+    async def fake_insert(*args: Any) -> Optional[str]:
+        seen["args"] = args
+        return "event-id"
+
+    monkeypatch.setattr(record_ingest.accessor, "insert_event", fake_insert)
+    result = asyncio.run(
+        record_ingest.ingest_event(
+            merchant_id="m1",
+            source="s",
+            topic="t",
+            external_id="x",
+            payload={"when": datetime(2026, 8, 25)},
+        )
+    )
+
+    assert result == "event-id"
+    assert seen["args"][4] == json.dumps({"when": datetime(2026, 8, 25)}, default=str)
+
+
+def test_ingest_event_raises_on_store_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def broken_insert(*args: Any) -> Optional[str]:
+        raise RuntimeError("db down")
+
+    monkeypatch.setattr(record_ingest.accessor, "insert_event", broken_insert)
+
+    with pytest.raises(RuntimeError):
+        asyncio.run(
+            record_ingest.ingest_event(
+                merchant_id="m1",
+                source="s",
+                topic="t",
+                external_id="x",
+                payload={},
+            )
+        )
+
+
+def test_record_event_stays_fail_open_on_store_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Regression guard for the refactor: buddy-side mirrors must never
+    # break the call that produced the fact (module rules §6).
+    async def broken_insert(*args: Any) -> Optional[str]:
+        raise RuntimeError("db down")
+
+    monkeypatch.setattr(record_ingest.accessor, "insert_event", broken_insert)
+
+    result = asyncio.run(
+        record_ingest.record_event(
+            merchant_id="m1",
+            source="s",
+            topic="t",
+            external_id="x",
+            payload={},
+        )
+    )
+    assert result is None

--- a/tests/crm/test_event_worker.py
+++ b/tests/crm/test_event_worker.py
@@ -26,10 +26,13 @@ from typing import Any, Dict, List, Optional, Tuple, cast
 
 import pytest
 
+import app.crm.record.extractors.flat as flat_extractor
+import app.crm.record.extractors.shopify as shopify_extractor
 import app.crm.record.workers as workers
 import app.crm.shared.worker as worker_mod
 from app.crm.record.db import DbTxn
-from app.crm.record.schemas import RawEvent
+from app.crm.record.extractors import EXTRACTORS
+from app.crm.record.schemas import Extracted, RawEvent
 from app.crm.shared.worker import run_drain_loop
 
 # ---------------------------------------------------------------------------
@@ -37,7 +40,9 @@ from app.crm.shared.worker import run_drain_loop
 # ---------------------------------------------------------------------------
 
 
-async def _no_plans_live(event: RawEvent, customer_id: str) -> None:
+async def _no_plans_live(
+    event: RawEvent, customer_id: str, handles: Dict[str, str]
+) -> None:
     """The entry-rules consumer with no plans live: the pass must run the
     same with or without outreach reacting."""
     return None
@@ -154,7 +159,7 @@ def test_a_raising_extractor_quarantines_rather_than_retrying_forever(
     def boom(payload: Dict[str, Any]) -> Any:
         raise KeyError("mandatory field missing")
 
-    monkeypatch.setitem(workers.EXTRACTORS, "lead-api", boom)
+    monkeypatch.setitem(EXTRACTORS, "lead-api", boom)
 
     _run(workers._process_one(_fake_txn(), _event()))
 
@@ -262,13 +267,13 @@ def test_a_registered_extractor_overrides_the_default(
     fake_accessor = _FakeAccessor()
     monkeypatch.setattr(workers, "accessor", fake_accessor)
 
-    def shopify(payload: Dict[str, Any]) -> workers.Extracted:
-        return workers.Extracted(
+    def shopify(payload: Dict[str, Any]) -> Extracted:
+        return Extracted(
             handles={"email": payload["contact_email"]},
             facts={"name": payload["contact_name"]},
         )
 
-    monkeypatch.setitem(workers.EXTRACTORS, "shopify", shopify)
+    monkeypatch.setitem(EXTRACTORS, "shopify", shopify)
 
     seen: Dict[str, Any] = {}
 
@@ -376,7 +381,9 @@ def test_entry_rules_run_per_row_before_that_row_is_stamped(
     order: List[str] = []
     seen: List[Tuple[str, str]] = []
 
-    async def fake_consume(event: RawEvent, customer_id: str) -> None:
+    async def fake_consume(
+        event: RawEvent, customer_id: str, handles: Dict[str, str]
+    ) -> None:
         order.append("consume")
         seen.append((event.id, customer_id))
 
@@ -401,7 +408,9 @@ def test_entry_rules_never_run_for_a_quarantined_row(
     fake_accessor = _FakeAccessor()
     monkeypatch.setattr(workers, "accessor", fake_accessor)
 
-    async def fail_consume(event: RawEvent, customer_id: str) -> None:
+    async def fail_consume(
+        event: RawEvent, customer_id: str, handles: Dict[str, str]
+    ) -> None:
         raise AssertionError("entry rules must not see an unattributed row")
 
     monkeypatch.setattr(workers, "_consume_attributed_event", fail_consume)
@@ -426,7 +435,9 @@ def test_a_failing_entry_rule_costs_its_own_row_only(
     async def fake_claim(conn: Any, limit: int) -> List[RawEvent]:
         return events
 
-    async def poison_first(event: RawEvent, customer_id: str) -> None:
+    async def poison_first(
+        event: RawEvent, customer_id: str, handles: Dict[str, str]
+    ) -> None:
         if event.id == "evt-1":
             raise RuntimeError("workflow rule blew up")
 
@@ -812,3 +823,175 @@ def test_heartbeat_counts_rows_since_the_last_beat(
     assert counted, "expected at least one heartbeat"
     # first beat precedes any work; a later one reports the batch just done
     assert any(n == 3 for _, n in counted)
+
+
+# --- the Shopify extractor: a pipe's letter, read at the belt ---
+
+
+def test_shopify_extractor_reads_the_nested_customer_phone() -> None:
+    # The relay forwards Shopify's body unopened, so the phone arrives
+    # nested and the top-level one is usually null.
+    extracted = shopify_extractor.extract(
+        {
+            "phone": None,
+            "customer": {
+                "first_name": "Priya",
+                "last_name": "Sharma",
+                "phone": "+91 98765 43210",
+            },
+            "shipping_address": {"phone": "9999999999"},
+        }
+    )
+    assert extracted.handles["phone"] == "+919876543210"  # normalized
+    assert extracted.facts == {"name": "Priya Sharma"}
+
+
+def test_shopify_extractor_falls_back_to_the_shipping_contact() -> None:
+    # A guest checkout carries no customer object at all.
+    extracted = shopify_extractor.extract(
+        {
+            "shipping_address": {
+                "first_name": "Rohan",
+                "last_name": "Mehta",
+                "phone": "9876543210",
+            }
+        }
+    )
+    assert extracted.handles["phone"] == "+919876543210"
+    assert extracted.facts == {"name": "Rohan Mehta"}
+
+
+def test_shopify_extractor_never_invents_a_name() -> None:
+    # A placeholder would reach assert_facts as a real name claim and
+    # overwrite what we actually know. Absent is absent.
+    extracted = shopify_extractor.extract({"customer": {"phone": "9876543210"}})
+    assert extracted.facts == {}
+
+
+def test_shopify_extractor_skips_an_unusable_phone() -> None:
+    # normalize_phone returns None rather than writing a bad handle; with
+    # nothing usable the row quarantines no_handle and stays replayable.
+    extracted = shopify_extractor.extract({"customer": {"phone": "n/a"}})
+    assert "phone" not in extracted.handles
+
+
+def test_shopify_extractor_takes_the_email_too() -> None:
+    extracted = shopify_extractor.extract(
+        {"customer": {"email": "  Priya@Example.COM  ", "phone": "9876543210"}}
+    )
+    assert extracted.handles["email"] == "priya@example.com"
+
+
+def test_shopify_source_is_registered() -> None:
+    # Without the registration a raw Shopify body falls to _extract_flat,
+    # which looks for a top-level customer_mobile_number that is not
+    # there — every order would quarantine no_handle.
+    assert EXTRACTORS["shopify"] is shopify_extractor.extract
+
+
+def test_shopify_extractor_takes_the_customer_id_handle() -> None:
+    # The corpus's own example for this extractor is
+    # shopify/checkouts.create -> {phone, email, shopify_customer_id}.
+    extracted = shopify_extractor.extract(
+        {"customer": {"id": 77, "phone": "9876543210"}}
+    )
+    assert extracted.handles["shopify_customer_id"] == "77"
+
+
+def test_shopify_extractor_resolves_a_phoneless_checkout_frame() -> None:
+    # The checkouts/update stream's early frames carry no phone — she
+    # types it later — but a signed-in shopper's customer id is there
+    # from the first frame. Without this handle those frames quarantine
+    # no_handle; with it they attribute to the person.
+    extracted = shopify_extractor.extract(
+        {"token": "chk-88412", "phone": None, "customer": {"id": 77}}
+    )
+    assert extracted.handles == {"shopify_customer_id": "77"}
+    assert extracted.facts == {}
+
+
+def test_shopify_extractor_omits_the_id_handle_for_a_guest() -> None:
+    # A guest checkout carries no customer object at all.
+    extracted = shopify_extractor.extract({"shipping_address": {"phone": "9876543210"}})
+    assert "shopify_customer_id" not in extracted.handles
+
+
+def test_shopify_extractor_reads_the_default_address() -> None:
+    # design/ingest-doors names customer.default_address.phone as this
+    # extractor's mapping: a returning shopper's number often lives only
+    # there, with the customer object itself carrying none.
+    extracted = shopify_extractor.extract(
+        {
+            "customer": {
+                "id": 77,
+                "phone": None,
+                "default_address": {
+                    "phone": "9876543210",
+                    "first_name": "Priya",
+                    "last_name": "Sharma",
+                },
+            }
+        }
+    )
+    assert extracted.handles["phone"] == "+919876543210"
+    assert extracted.facts == {"name": "Priya Sharma"}
+
+
+def test_shopify_extractor_prefers_the_customer_phone_over_default_address() -> None:
+    # Probe order is the law: most specific first.
+    extracted = shopify_extractor.extract(
+        {
+            "customer": {
+                "phone": "+919999999999",
+                "default_address": {"phone": "9876543210"},
+            }
+        }
+    )
+    assert extracted.handles["phone"] == "+919999999999"
+
+
+def test_pass_hands_the_extractors_handles_to_the_consumer() -> None:
+    # THE divergence this closes: the extractor searches four places for a
+    # phone, the consumer's own payload reader searches three — and the
+    # canonical Shopify order keeps its number in customer.default_address,
+    # which only the extractor knows. Resolved-then-parked was the result:
+    # identity found her, the call node could not.
+    import asyncio
+
+    seen: Dict[str, Any] = {}
+
+    async def fake_resolve(merchant_id, handles, evidence, source):  # type: ignore[no-untyped-def]
+        return "cus-1"
+
+    async def fake_facts(*a: Any, **k: Any) -> None:
+        return None
+
+    async def fake_consume(event, customer_id, handles):  # type: ignore[no-untyped-def]
+        seen["handles"] = handles
+
+    workers.crm_resolve = fake_resolve  # type: ignore[assignment]
+    workers.assert_facts = fake_facts  # type: ignore[assignment]
+    workers.consume_attributed_event = fake_consume  # type: ignore[assignment]
+
+    async def fake_stamp(*a: Any, **k: Any) -> None:
+        return None
+
+    workers.accessor.stamp_event = fake_stamp  # type: ignore[assignment]
+
+    event = RawEvent(
+        id="e1",
+        merchant_id="m1",
+        source="shopify",
+        topic="orders/create",
+        schema_version="1",
+        external_id="orders/create:1",
+        payload={
+            "phone": None,
+            "customer": {"id": 7, "default_address": {"phone": "9876543210"}},
+        },
+        received_at=datetime.now(timezone.utc),
+    )
+    asyncio.run(workers._process_one(None, event))  # type: ignore[arg-type]
+
+    # the number the sends will dial is the number identity resolved on
+    assert seen["handles"]["phone"] == "+919876543210"

--- a/tests/crm/test_workflow_admission.py
+++ b/tests/crm/test_workflow_admission.py
@@ -101,3 +101,24 @@ def test_context_passthrough_keeps_scalars_drops_structures() -> None:
     assert context["cart_value"] == 3499
     assert context["gift_wrap"] is True
     assert "line_items" not in context and "huge" not in context
+
+
+def test_context_phone_is_normalized_for_the_send_path() -> None:
+    # resolve() normalizes what it PROBES on, but context is a separate
+    # copy and it is what the call and send nodes actually dial. Left raw,
+    # identity would resolve to +919876543210 while the node dialled the
+    # bare form — and a suppression stored in E.164 would not match it,
+    # which is the one failure normalize-at-every-writer exists to stop.
+    from app.crm.outreach.entry import _phone_from_payload
+
+    assert (
+        _phone_from_payload({"customer_mobile_number": "9876543210"}) == "+919876543210"
+    )
+    assert _phone_from_payload({"phone": "+91 98765 43210"}) == "+919876543210"
+    assert (
+        _phone_from_payload({"customer": {"phone": "09876543210"}}) == "+919876543210"
+    )
+    # Unparseable is handed through, not dropped: the node then parks with
+    # a clear reason, which beats losing the number at this seam.
+    assert _phone_from_payload({"phone": "n/a"}) == "n/a"
+    assert _phone_from_payload({}) is None


### PR DESCRIPTION
## What

The HTTP door (A9) for services outside this repo — **and the extractor (A10) that makes what arrives through it usable.** Without both, the door stores Shopify letters that reach nobody.

Mounted at **`POST /ingest/events`**, per ADR 0022.

## The chain this completes

```
Shopify webhook → nautilus relays raw body (source=shopify) → /ingest/events → crm_event_raw
  → event worker → EXTRACTORS["shopify"] → _extract_shopify
  → resolve() → assert_facts() → entry rule → journey            ✓
```

Before the extractor, that chain broke at step two: an unregistered source falls back to `_extract_flat`, which reads a top-level `customer_mobile_number` that a raw Shopify order does not have (the phone is nested at `customer.phone`, and the top-level `phone` Shopify sends is usually `null`). Handles came back empty → `no_handle` → no resolve, no entry rule, no journey.

## Example

```bash
curl -X POST https://<host>/ingest/events \
  -H "Content-Type: application/json" \
  -H "x-s2s-token: $TOKEN" \
  -d '{
    "merchant_id": "acme.myshopify.com",
    "source":      "shopify",
    "topic":       "orders/create",
    "external_id": "orders/create:5234567890123",
    "occurred_at": "2026-08-31T09:14:22+05:30",
    "payload":     { "...raw Shopify order body..." }
  }'

# → 200 {"id":"e7b1…","duplicate":false}
# → same call again: 200 {"id":null,"duplicate":true}   ← success, not an error
```

## The door

```
POST /ingest/events
  ├─ EventIn validation
  │    extra="forbid"           smuggled customer_id / typo'd occured_at → 422
  │    str_strip_whitespace     "   " fails min_length the way "" does
  │    occurred_at aware        a naive timestamp → 422
  ├─ verify_s2s_caller          ◄── auth BEFORE store
  └─ INSERT crm_event_raw
       ON CONFLICT (merchant_id, source, external_id) DO NOTHING
       occurred_at = LEAST($7, now())     ← a future claim is clamped
       customer_id = NULL                 ← the door never attributes

200 stored · 200 duplicate · 401 bad token · 404 unknown merchant
422 bad envelope · 503 store failed (fails CLOSED, so the producer retries)
```

### Auth — one door, two kinds of caller

| caller | token | check |
|---|---|---|
| **relay** (one service, many merchants) | wildcard-scoped RBAC JWT — what the lead API already takes | signature + expiry, then merchant existence. No per-shop provisioning, no stored-token read. |
| **single merchant** (e.g. WooCommerce) | the JWT in `merchants.s2s_token` | constant-time compare against the stored value. Rotating the row revokes the old token on the next call. |

The branch is on **what the token claims**, never on whether verification failed. Per-merchant tokens *are* RBAC JWTs, so a rotated-out one still decodes and still names its merchant — a "try the relay check, fall back on error" order would accept it until it expired and the byte-compare that revoked it would be dead code. Only a wildcard proves the caller is not a per-merchant token, because the mint hard-codes exactly one `merchant_id`.

A wildcard says *"any merchant"*, not *"this merchant is real"* — so that path still confirms the merchant exists, or a typo'd shop domain quietly founds a tenant and the belt resolves customers under it.

### Envelope validation

`occurred_at` must carry an offset. Naive values reach `timestamptz` as-is and Postgres reads them in the **session's** zone — a UTC producer omitting the `Z` was recorded 5½ hours off, and T13 col 9 measures triggered sends from that column, so a shifted goal can let a rescue call go out after payment.

## The extractor

| | where it looks, in order |
|---|---|
| phone | `customer.phone` → `phone` → `shipping_address.phone` |
| email | `customer.email` → `email` |
| **`shopify_customer_id`** | `customer.id`, when the shopper is signed in |
| name | `customer.first/last_name` → `shipping_address.first/last_name` |

Three handle kinds, matching the corpus's own example for this extractor (`shopify/checkouts.create → {phone, email, shopify_customer_id}`). The id earns its line on the `checkouts/update` stream: the early frames carry **no phone yet** — she types it later — but a signed-in shopper's customer id is there from the first frame, so those frames resolve to the person instead of quarantining `no_handle`.

- **Guest checkouts carry no `customer` object at all** — hence the shipping-address fallback for both handle and name.
- **The name is never defaulted.** A placeholder like `"Customer"` would reach `assert_facts` as a genuine name claim and overwrite what we actually know about the person.
- **An unusable number is skipped, not written** — the row quarantines and stays replayable rather than resolving onto a malformed handle.

**The default extractor is untouched.** A producer that sends a top-level `customer_mobile_number` still needs no registration — that stays the zero-code path for new partners, and it is what `lead-api` and `telephony` use.

**Rows already quarantined are not stranded:** `payload` is verbatim and `replay()` re-runs the *current* extractor.

## ⚠️ Behaviour change outside `record/` — `outreach/entry.py`

Flagging this prominently because it is easy to miss in an ingest PR: **this changes how the outreach module builds run context.** `_phone_from_payload` now normalizes to E.164 before the value reaches `context["phone"]`, which is what the call and send nodes dial.

It closes a suppression bypass, not a cosmetic issue: run context kept a raw copy (`"9876543210"`) while identity and the suppression book store `+919876543210`, so the gate compared two spellings of one person and a STOP could be walked past. Unparseable values pass through unchanged so the node parks with a readable reason rather than the number vanishing.

Reviewed and agreed by the module owner. Detail below.

## Also: the number the sends actually dial

Found while tracing the above.

```
entry.py   context["phone"] = _phone_from_payload(event.payload)   ← was raw
nodes.py   phone = run.context.get("phone")     ← the call node dials this
nodes.py   address=str(phone)                   ← the send node messages this
```

`resolve()` normalizes what it **probes on**, but run context is a separate copy taken straight from the payload. A producer sending `"9876543210"` resolved to `+919876543210` for identity while the call node dialled the bare form — and a suppression stored in E.164 would not match it, which is the one failure *normalize at every writer* exists to prevent.

`_phone_from_payload` now normalizes, handing an unparseable value through unchanged so the node parks with a clear reason rather than the number being lost at this seam.

⚠️ This touches `outreach/entry.py`, which #1041 also touches — different function, should merge clean, but worth sequencing deliberately. Happy to drop it into a follow-up if you'd rather keep this PR to record/.

## Two fail postures (module rules §6)

`ingest_event` **raises** so the API can 503 and the producer retries. `record_event` stays **fire-and-forget** — recording a fact must never break the operation that produced it. Each pinned by its own regression test.

## Verification

**1623 tests pass** · pyrefly 0 errors · black/isort/autoflake · boundary + migration checks clean.
Route wiring smoke-tested by importing the app and listing mounts: exactly `/ingest/events`, `/customers`, `/customers/{id}`, `/customers/{id}/journey`, plus the workflow doors — no `crm` in any path or tag.

## Sequencing

juspay/nautilus#195 posts to `/ingest/events`. **This must deploy first**, or that relay 404s.

