### PR TITLE
(fix): move intial greeting gen before make call to avoid rate limits

### DIFF
--- a/app/ai/voice/agents/breeze_buddy/dispatch/worker.py
+++ b/app/ai/voice/agents/breeze_buddy/dispatch/worker.py
@@ -23,7 +23,7 @@ import asyncio
 import random
 import uuid
 from datetime import datetime, timedelta, timezone
-from typing import Any, List, Optional, cast
+from typing import Any, Dict, List, Optional, cast
 
 import aiohttp
 
@@ -65,11 +65,10 @@ from app.ai.voice.agents.breeze_buddy.services.call_limiter import (
     record_outbound_call_attempt,
 )
 from app.ai.voice.agents.breeze_buddy.services.telephony.utils import get_voice_provider
+from app.ai.voice.agents.breeze_buddy.template.types import TemplateModel
+from app.ai.voice.agents.breeze_buddy.utils.common import _gemini_realtime_config
 from app.ai.voice.agents.breeze_buddy.utils.playground import (
     apply_playground_overrides,
-)
-from app.ai.voice.llm.realtime.gemini.opening_line import (
-    DEFAULT_GENERATION_TIMEOUT_SECONDS,
 )
 from app.core.concurrency import spawn_background_task
 from app.core.config import dynamic as dyn_cfg
@@ -94,6 +93,88 @@ from app.database.accessor import (
 )
 from app.schemas import ExecutionMode, LeadCallStatus
 from app.services.redis import get_redis_service
+
+# ---------------------------------------------------------------------------
+# Greeting pre-warm
+# ---------------------------------------------------------------------------
+
+# One retry on ANY failure — timeouts included. A first attempt that runs
+# out of time is usually cold-start (Live session connect + model warm-up),
+# so the retry frequently lands. Per-attempt caps: 15s for TTS greetings,
+# 30s for the Gemini Live opening line (measured: a 41-word greeting
+# generates in ~15s over Live — the TTS cap would fail most non-trivial
+# Live greetings). Worst-case channel-token hold is timeout + 0.5s pause
+# + timeout (~30.5s TTS / ~60.5s Live), only reached when generation is
+# fully degraded — which is when dials should pace down anyway.
+_GREETING_PREWARM_ATTEMPTS = 2
+_GREETING_PREWARM_RETRY_PAUSE_S = 0.5
+_GREETING_PREWARM_TIMEOUT_S = 15.0
+_GREETING_PREWARM_LIVE_TIMEOUT_S = 30.0
+
+
+async def _prewarm_initial_greeting_with_retry(
+    lead_id: str,
+    payload: Dict[str, Any],
+    template: TemplateModel,
+) -> None:
+    """
+    Pre-dial greeting preparation, AWAITED so audio is in Redis before the
+    phone rings: TTS synthesis for non-realtime templates and — via
+    generate_realtime_opening_line — the Gemini Live opening line
+    (per-TEMPLATE, normally generated at template-save time, so a cheap
+    Redis GET on the happy path).
+
+    Runs after every dispatch gate (rate-limit record, channel token, DB
+    number), immediately before the dial — TTS/generation spend is
+    proportional to actual dials. Each attempt is capped at
+    _GREETING_PREWARM_TIMEOUT_S (TTS) or _GREETING_PREWARM_LIVE_TIMEOUT_S
+    (Gemini Live opening line); the single retry fires on ANY failure —
+    timeout included — so the worst-case channel-token hold is
+    timeout + pause + timeout. Every failure path is fail-open: we dial
+    anyway and the answer-time path in agent setup retries synthesis as a
+    cache miss (worst case the caller hears the dial-tone fallback / LLM
+    speaks first).
+    """
+    greeting_expected = bool(
+        template.configurations and template.configurations.initial_greeting
+    )
+    timeout_s = (
+        _GREETING_PREWARM_LIVE_TIMEOUT_S
+        if _gemini_realtime_config(template) is not None
+        else _GREETING_PREWARM_TIMEOUT_S
+    )
+    for attempt in range(1, _GREETING_PREWARM_ATTEMPTS + 1):
+        try:
+            result = await asyncio.wait_for(
+                prepare_and_store_initial_greeting(
+                    lead_id=lead_id,
+                    payload=payload,
+                    template=template,
+                    generate_realtime_opening_line=True,
+                ),
+                timeout=timeout_s,
+            )
+            if result is not None or not greeting_expected:
+                return  # cached (or nothing configured) — done
+            logger.warning(
+                f"Greeting prewarm attempt {attempt}/{_GREETING_PREWARM_ATTEMPTS} "
+                f"fail-opened with no cached audio for lead {lead_id}; "
+                "answer-time path will retry"
+            )
+        except asyncio.TimeoutError:
+            logger.warning(
+                f"Greeting prewarm attempt {attempt}/{_GREETING_PREWARM_ATTEMPTS} "
+                f"timed out for lead {lead_id}; retrying — first attempts "
+                "often time out on cold-start"
+            )
+        except Exception as e:  # noqa: BLE001
+            logger.opt(exception=e).warning(
+                f"Greeting prewarm attempt {attempt}/{_GREETING_PREWARM_ATTEMPTS} "
+                f"failed for lead {lead_id}; answer-time path will retry"
+            )
+        if attempt < _GREETING_PREWARM_ATTEMPTS:
+            await asyncio.sleep(_GREETING_PREWARM_RETRY_PAUSE_S)
+
 
 # ---------------------------------------------------------------------------
 # Single dispatch worker
@@ -366,43 +447,6 @@ class Worker:
 
             if template:
                 template = apply_playground_overrides(locked, template)
-                # Pre-dial greeting preparation, AWAITED so audio is in
-                # Redis before the phone even rings: TTS synthesis for
-                # non-realtime templates, and — via
-                # generate_realtime_opening_line — the Gemini Live opening
-                # line. The Gemini greeting is per-TEMPLATE (static only),
-                # normally generated at template-save time, so that branch
-                # is a single Redis GET (~ms) on the happy path and only
-                # regenerates on a cache miss (TTL expiry / failed save-time
-                # generation). Throughput note (by design): a miss suspends
-                # THIS worker until the audio is ready (or the budget below
-                # expires), so the worker picks no further lead meanwhile
-                # and the lead lock stays held; the OTHER dispatch workers,
-                # the event loop, and every handler keep running. The
-                # generator bounds itself at
-                # DEFAULT_GENERATION_TIMEOUT_SECONDS; the outer wait_for is
-                # a backstop that also covers a hung non-generator step
-                # (e.g. a stuck Redis call). On timeout or failure we dial
-                # anyway (fail-open to LLM-speaks-first). No-ops (gate
-                # checks inside) for every greeting-less or variable-greeting
-                # template. Placed before number/channel acquisition so no
-                # channel capacity is held while generating.
-                try:
-                    await asyncio.wait_for(
-                        prepare_and_store_initial_greeting(
-                            lead_id=locked.id,
-                            payload=locked.payload or {},
-                            template=template,
-                            generate_realtime_opening_line=True,
-                        ),
-                        timeout=DEFAULT_GENERATION_TIMEOUT_SECONDS + 5.0,
-                    )
-                except asyncio.TimeoutError:
-                    logger.warning(
-                        f"Worker {self._uuid}: greeting prep for lead "
-                        f"{locked.id} exceeded the dispatch budget; dialing "
-                        "without a cached greeting (LLM will speak first)"
-                    )
 
             # Rate-limit PEEK before channel token. Read-only — we don't
             # record the attempt here, because we may still bail downstream
@@ -523,6 +567,36 @@ class Worker:
                     await _release_number(number.id, number.provider)
                     lock_released = await self._defer_and_release(locked.id, rl_defer)
                     return
+
+            # Greeting pre-warm as late as possible — after every gate,
+            # immediately before the dial — so TTS/generation spend is
+            # proportional to actual dials, not dispatch attempts. The
+            # channel token acquired above is held during the bounded
+            # wait (by design: dials pacing to generation capacity under
+            # degradation). Bounded and fail-open — a slow or hung
+            # generator never blocks the dial; the answer-time path
+            # retries synthesis as a cache miss.
+            if template:
+                try:
+                    await _prewarm_initial_greeting_with_retry(
+                        lead_id=locked.id,
+                        payload=locked.payload or {},
+                        template=template,
+                    )
+                except asyncio.CancelledError:
+                    # Cancellation (worker shutdown) mid-prewarm: none of
+                    # the explicit release paths below ran, and the outer
+                    # finally only releases the lead lock. Return the
+                    # channel token + DB number, then re-raise so the
+                    # cancellation propagates.
+                    logger.warning(
+                        f"Worker {self._uuid}: cancelled during greeting "
+                        f"prewarm for lead {locked.id}; releasing channel "
+                        "token + number"
+                    )
+                    await release_channel_token(number.id, token)
+                    await _release_number(number.id, number.provider)
+                    raise
 
             try:
                 call = await call_provider.make_call_async(

--- a/docs/BACKLOG_DISPATCHER_REDESIGN.md
+++ b/docs/BACKLOG_DISPATCHER_REDESIGN.md
@@ -98,6 +98,22 @@ if not number: ZADD now+10s; release_lock; continue
 token = BLPOP bb:channel:{number.id} timeout=10s
 if not token: ZADD now + jitter(1..3s); release_lock; continue
 
+# Greeting pre-warm — LATE position, after every gate and right before the
+# dial, so TTS/opening-line generation spend is proportional to actual dials,
+# not dispatch attempts (leads that bounce downstream never synthesize). TTS
+# for non-realtime templates; the Gemini Live opening line
+# (generate_realtime_opening_line=True) otherwise — normally a Redis GET.
+# Bounded per attempt: 15s for TTS greetings, 30s for the Gemini Live
+# opening line (measured ~15s for a 41-word Live greeting). One retry
+# fires on ANY failure — timeout included (a timed-out first attempt is
+# usually cold-start; the retry frequently lands). Worst-case token hold
+# ~30.5s TTS / ~60.5s Live. Fail-open after both attempts (dial anyway —
+# the answer-time path retries synthesis as a cache miss). The channel
+# token is held during the bounded wait — by design: under degradation
+# dials pace to generation capacity. Cancellation mid-prewarm releases
+# token + number, then re-raises.
+await prewarm_initial_greeting(lead, template)   # bounded, fail-open
+
 try:
   call_sid = provider.make_call(number, lead)
   UPDATE lead_call_tracker SET status='PROCESSING', call_id=call_sid
@@ -292,14 +308,14 @@ PR #722's knobs cover everything else (promoter tick, batch, worker count per sh
 | Worker `BLPOP` pickup | <10ms |
 | DB row lock CAS | 10–50ms |
 | Pre-checks (inline) | 300–1500ms |
-| Greeting TTS | 300–800ms |
 | Rate-limit + channel `BLPOP` | <50ms (good path) |
+| Greeting pre-warm (post-token, pre-`make_call`) | 300–800ms typical; happy-path cache GET ~ms; hard ceiling `DEFAULT_GENERATION_TIMEOUT_SECONDS`+5s then fail-open |
 | Provider `make_call` HTTP | 200–800ms |
 | **Time we send `make_call`** | **T + 800–3200ms** |
 | Carrier signalling → phone ringing | 1–4s |
 | **Time customer's phone rings** | **T + 2–7s** |
 
-**SLO: phone rings within 3–7s of `next_attempt_at`.** Carrier signalling dominates; software cannot get under the PSTN floor. Shaving inline pre-checks + TTS would change our internal "T → `make_call`" number but not the customer-visible "T → phone rings" bucket, so no software-side optimisation here is worth the complexity.
+**SLO: phone rings within 3–7s of `next_attempt_at`.** Carrier signalling dominates; software cannot get under the PSTN floor. Shaving inline pre-checks + TTS would change our internal "T → `make_call`" number but not the customer-visible "T → phone rings" bucket, so no software-side optimisation here is worth the complexity. The greeting pre-warm sits between channel-token acquisition and `make_call` — the token is held during its bounded wait (a degraded TTS/generation provider slows dials, never stops them: timeout fails open to LLM-speaks-first).
 
 ## 11. Scaling envelope
 

--- a/docs/GEMINI_LIVE.md
+++ b/docs/GEMINI_LIVE.md
@@ -136,10 +136,20 @@ the greeting disables it.
   cache (`template/cache.py`), so a removed/disabled greeting can't outlive its
   edit — invalidation is the correctness mechanism (no TTL).
 - **Call time (dispatch worker, pre-dial):** a single Redis `GET` on the happy
-  path. On a miss (failed save-time generation) the worker awaits generation
-  before dialing — bounded at 30 s (`DEFAULT_GENERATION_TIMEOUT_SECONDS`) with a
-  35 s outer backstop, suspending only that worker's slot, then dials fail-open
-  (LLM speaks first) on timeout.
+  path. The pre-warm runs after every dispatch gate (rate-limit record, channel
+  token, DB number) and immediately before `make_call`, so generation spend
+  tracks actual dials — and the channel token is held during the bounded wait,
+  which paces dials to generation capacity when the provider degrades. On a
+  miss (failed save-time generation) the worker awaits generation before
+  dialing: each attempt is capped at **30 s for the Live opening line**
+  (measured: a 41-word greeting generates in ~15 s over Live — the 15 s TTS
+  cap would fail most non-trivial greetings) vs 15 s for plain TTS, and the
+  single retry fires on ANY failure — timeout included, since a timed-out
+  first attempt is usually cold-start (session connect + model warm-up) and
+  the retry frequently lands. Worst-case channel-token hold is ~60.5 s for
+  Live / ~30.5 s for TTS. After both attempts it dials fail-open (LLM speaks
+  first). Cancellation (worker shutdown) mid-prewarm releases the channel
+  token + number before re-raising.
 - **Playback:** at connect the cached audio plays out-of-band immediately
   (telephony `playAudio` / Daily `OutputAudioRawFrame`), and the template's
   `initial_greeting` seeds the LLM context so Gemini never repeats the line.

--- a/tests/breeze_buddy/dispatch/conftest.py
+++ b/tests/breeze_buddy/dispatch/conftest.py
@@ -442,6 +442,9 @@ class DispatchHarness:
         # are still observed here so we can pin the race-rejection path).
         self.rate_limit_peeks: list[dict[str, str]] = []
         self.rate_limit_records: list[dict[str, str]] = []
+        # Templates whose greeting prep ran with the pre-dial
+        # generate_realtime_opening_line flag (see the greeting mock below).
+        self.opening_line_calls: List[Any] = []
         self.cas_succeeds: bool = True
         self.get_available_returns_none: bool = False
         # Captured alerts so tests can assert no-telephony-number throttled
@@ -597,9 +600,17 @@ class DispatchHarness:
         return (True, 0)
 
     async def prepare_and_store_initial_greeting(
-        self, lead_id: str, payload: Dict[str, Any], template: Any
-    ) -> None:
-        return None
+        self,
+        lead_id: str,
+        payload: Dict[str, Any],
+        template: Any,
+        generate_realtime_opening_line: bool = False,
+    ) -> Optional[str]:
+        if generate_realtime_opening_line:
+            self.opening_line_calls.append(
+                template.id if template is not None else None
+            )
+        return "ok"
 
     def apply_playground_overrides(
         self, lead: LeadCallTracker, template: Any, template_vars=None


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Voice greetings are now prepared closer to the start of each call, helping ensure the latest resolved greeting is used.
  - Greeting preparation is more resilient, with limited retry handling and graceful fallback when preparation cannot be completed.
  - Dispatch resources are managed more efficiently while greetings are being prepared, supporting smoother call initiation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->