### PR TITLE
feat(uap): POST /txns - merchant door to juspay agentic payments (UAP)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -347,3 +347,6 @@ BB_DISPATCH_QPS_JITTER_MS=200               # ±ms applied to every ZADD score
 #   halt all workers during an incident. Fails open (treated as true) if
 #   DevCycle/Redis is unreachable, so a sick infra layer can't silently halt
 #   dispatch. Leads stay queued until the flag flips back.
+
+JUSPAY_BASE_URL=https://sandbox.juspay.in
+JUSPAY_TXNS_TIMEOUT_SECONDS=30

--- a/app/ai/voice/agents/breeze_buddy/handlers/internal/builtin_dispatcher.py
+++ b/app/ai/voice/agents/breeze_buddy/handlers/internal/builtin_dispatcher.py
@@ -38,6 +38,10 @@ from app.ai.voice.agents.breeze_buddy.handlers.internal.stt import (
     mute_stt,
     unmute_stt,
 )
+from app.ai.voice.agents.breeze_buddy.handlers.internal.uap_order_status import (
+    uap_order_status,
+)
+from app.ai.voice.agents.breeze_buddy.handlers.internal.uap_pay import uap_pay
 from app.ai.voice.agents.breeze_buddy.handlers.internal.update_outcome import (
     update_outcome,
 )
@@ -58,6 +62,8 @@ BUILTIN_HANDLERS: Dict[str, Callable] = {
     "get_current_time": get_current_time,
     "hold_and_consult": hold_and_consult,
     "query_knowledge_base": query_knowledge_base,
+    "uap_order_status": uap_order_status,
+    "uap_pay": uap_pay,
     "update_outcome": update_outcome,
 }
 

--- a/app/ai/voice/agents/breeze_buddy/handlers/internal/uap_order_status.py
+++ b/app/ai/voice/agents/breeze_buddy/handlers/internal/uap_order_status.py
@@ -1,0 +1,63 @@
+"""Built-in global function: poll a Juspay order's payment status.
+
+Exposed from templates as:
+
+    {"type": "builtin", "name": "check_payment_status",
+     "handler": "uap_order_status",
+     "properties": {"order_id": {"type": "string"}},
+     "required": ["order_id"]}
+
+Read-only ``GET /orders/{order_id}`` with the reseller's UAP credential -
+the settlement poll for a draw fired by uap_pay. No approval gate needed:
+it moves no money. ``payment_status`` is CHARGED once the draw settled.
+"""
+
+from typing import Any, Dict
+from urllib.parse import quote
+
+from app.core.logger import logger
+from app.services.uap import client
+from app.services.uap.client import JuspayError
+from app.services.uap.credentials import load_uap_credentials
+
+
+async def uap_order_status(context: Any, args: Dict[str, Any]) -> Dict[str, Any]:
+    logger.info(f">>> [uap_order_status] START args={args}")
+    template = getattr(context.bot, "template", None)
+    reseller_id = getattr(template, "reseller_id", None)
+    if not reseller_id:
+        logger.error(">>> [uap_order_status] ABORT: template has no reseller_id")
+        return {"status": "error", "error": "template has no reseller_id"}
+
+    order_id = args.get("order_id")
+    if not isinstance(order_id, str) or not order_id:
+        logger.error(">>> [uap_order_status] ABORT: order_id missing from LLM args")
+        return {"status": "error", "error": "order_id is required"}
+
+    try:
+        creds = await load_uap_credentials(reseller_id)
+        logger.info(
+            f">>> [uap_order_status] GET /orders/{order_id} "
+            f"merchant_id={creds.merchant_id} base_url={creds.base_url}"
+        )
+        response = await client.request(
+            "GET",
+            f"/orders/{quote(order_id, safe='')}",
+            api_key=creds.api_key,
+            merchant_id=creds.merchant_id,
+            base_url=creds.base_url,
+        )
+    except (ValueError, JuspayError) as e:
+        logger.error(f">>> [uap_order_status] ABORT: order fetch failed: {e}")
+        return {"status": "error", "error": str(e)}
+
+    logger.info(f">>> [uap_order_status] full response={response}")
+    result = {
+        "status": "success",
+        "order_id": str(response.get("order_id") or order_id),
+        "payment_status": str(response.get("status") or "UNKNOWN"),
+        "amount": response.get("amount"),
+        "paid": str(response.get("status") or "").upper() == "CHARGED",
+    }
+    logger.info(f">>> [uap_order_status] DONE {result}")
+    return result

--- a/app/ai/voice/agents/breeze_buddy/handlers/internal/uap_pay.py
+++ b/app/ai/voice/agents/breeze_buddy/handlers/internal/uap_pay.py
@@ -1,0 +1,279 @@
+"""Built-in global function: charge the customer's UPI agent via UAP /txns.
+
+Exposed from templates as:
+
+    {"type": "builtin", "name": "pay_with_upi_agent", "handler": "uap_pay",
+     "description": "...", "properties": {"journey_id": {"type": "string"}},
+     "required": ["journey_id"], "approval": {"prompt": "..."}}
+
+The LLM passes only the journey_id. The handler re-fetches that journey
+from NammaYatri (initiate) so the charged fare is authoritative at pay
+time - the LLM never controls a money value. NY base URL + rider token
+and the intent refs (``uap_action_id`` or ``uap_action_ref_id`` +
+``uap_payer_avpa``) come from template vars/secrets. The canonical is
+hardcoded around the fetched fare (see build_canonical in
+app/services/uap/txns.py). Credentials resolve from the template's
+reseller; point the ``uap`` credential's base_url and the ``ny_base``
+secret at ``/agent/voice/breeze-buddy/uap/mock`` to run the whole loop
+offline.
+"""
+
+import base64
+import hashlib
+import time
+from decimal import Decimal, InvalidOperation
+from typing import Any, Dict, Optional, Tuple
+from uuid import uuid4
+
+import aiohttp
+
+from app.core.config.static import JUSPAY_ACTION_ID, JUSPAY_MERCHANT_ID
+from app.core.logger import logger
+from app.core.transport.http_client import create_aiohttp_session
+from app.services.uap.client import JuspayError
+from app.services.uap.credentials import load_uap_credentials
+from app.services.uap.txns import build_canonical, create_txn
+
+_NY_TIMEOUT_SECONDS = 15
+
+
+def _normalize_amount(value: Any) -> Optional[str]:
+    """NY fares are numbers (40.0); the wire wants a two-decimal string."""
+    if not isinstance(value, (str, int, float)) or isinstance(value, bool):
+        return None
+    try:
+        return str(Decimal(str(value)).quantize(Decimal("0.01")))
+    except InvalidOperation:
+        return None
+
+
+async def _fetch_journey(
+    ny_base: str, rider_token: str, journey_id: str
+) -> Dict[str, Any]:
+    """POST /v2/multimodal/{journey_id}/initiate - exact fares for one journey."""
+    base = ny_base.rstrip("/").removesuffix("/v2")
+    url = f"{base}/v2/multimodal/{journey_id}/initiate"
+    logger.info(f">>> [uap_pay] NY fetch POST {url}")
+    async with create_aiohttp_session() as session:
+        async with session.post(
+            url,
+            json={},
+            headers={"token": rider_token, "Content-Type": "application/json"},
+            timeout=aiohttp.ClientTimeout(total=_NY_TIMEOUT_SECONDS),
+        ) as response:
+            body = await response.json(content_type=None)
+            if response.status >= 400:
+                raise RuntimeError(f"NY initiate HTTP {response.status}: {body}")
+            return body
+
+
+async def _confirm_journey(
+    ny_base: str, rider_token: str, journey_id: str, journey: Dict[str, Any]
+) -> Dict[str, Any]:
+    """POST /v2/multimodal/{journey_id}/confirm - tell NY to book the tickets.
+
+    One element per leg: skipBooking for non-bookable (walk) legs, one adult
+    ticket on each bookable leg. NY responds with orderSdkPayload carrying
+    ITS payment order (orderId + final amount) - the order that must turn
+    PAID for tickets to be issued.
+    """
+    elements = []
+    for leg in journey.get("legs") or []:
+        bookable = bool(leg.get("bookingAllowed"))
+        elements.append(
+            {
+                "journeyLegOrder": leg.get("order"),
+                "skipBooking": not bookable,
+                "ticketQuantity": 1 if bookable else None,
+                "childTicketQuantity": 0 if bookable else None,
+                "categorySelectionReq": None,
+                "crisSdkResponse": None,
+                "vehicleNumber": None,
+                "tripId": None,
+                "seatIds": None,
+            }
+        )
+    body = {"enableOffer": None, "journeyConfirmReqElements": elements}
+    base = ny_base.rstrip("/").removesuffix("/v2")
+    url = f"{base}/v2/multimodal/{journey_id}/confirm"
+    logger.info(f">>>>> [uap_pay] NY confirm POST {url} body={body}")
+    async with create_aiohttp_session() as session:
+        async with session.post(
+            url,
+            json=body,
+            headers={"token": rider_token, "Content-Type": "application/json"},
+            timeout=aiohttp.ClientTimeout(total=_NY_TIMEOUT_SECONDS),
+        ) as response:
+            payload = await response.json(content_type=None)
+            logger.info(
+                f">>>>> [uap_pay] NY confirm -> HTTP {response.status} body={payload}"
+            )
+            if response.status >= 400:
+                raise RuntimeError(f"NY confirm HTTP {response.status}: {payload}")
+            return payload
+
+
+def _canonical_fields(journey: Dict[str, Any]) -> Tuple[Optional[str], Dict[str, str]]:
+    """Amount + canonical overrides off the raw initiate response.
+
+    Returns (None, {}) while any bookable leg is still unpriced - the
+    draw must not fire on a journey NY hasn't finished pricing.
+    """
+    legs = [leg for leg in journey.get("legs") or [] if leg.get("bookingAllowed")]
+    if not legs or any(not leg.get("pricingId") for leg in legs):
+        return None, {}
+
+    amount = _normalize_amount((journey.get("estimatedMaxFare") or {}).get("amount"))
+    leg = legs[0]
+    extra = (leg.get("legExtraInfo") or {}).get("contents") or {}
+    route = (extra.get("routeInfo") or [{}])[0]
+    origin = (route.get("originStop") or {}).get("name") or "?"
+    destination = (route.get("destinationStop") or {}).get("name") or "?"
+    line = route.get("routeCode") or "?"
+    overrides = {
+        "sku": leg.get("pricingId") or "pricing-unknown",
+        "name": f"{leg.get('travelMode', 'Ticket')} {origin}-{destination} ({line}) - ADULT"[
+            :128
+        ],
+        "journey_id": str(journey.get("journeyId") or ""),
+        "leg_id": str(leg.get("journeyLegId") or ""),
+        "provider": extra.get("providerName") or "?",
+        "order_ref": str(journey.get("journeyId") or ""),
+    }
+    return amount, overrides
+
+
+async def uap_pay(context: Any, args: Dict[str, Any]) -> Dict[str, Any]:
+    logger.info(f">>> [uap_pay] step 1/6 START args={args}")
+    template = getattr(context.bot, "template", None)
+    reseller_id = getattr(template, "reseller_id", None)
+    if not reseller_id:
+        logger.error(">>> [uap_pay] ABORT: template has no reseller_id")
+        return {"status": "error", "error": "template has no reseller_id"}
+
+    journey_id = args.get("journey_id")
+    if not isinstance(journey_id, str) or not journey_id:
+        logger.error(">>> [uap_pay] ABORT: journey_id missing from LLM args")
+        return {"status": "error", "error": "journey_id is required"}
+
+    template_vars = getattr(context.bot, "template_vars", None) or {}
+    session_state = getattr(context.bot, "agent_state", None) or {}
+
+    def resolve(key: str):
+        value = session_state.get(key) or template_vars.get(key)
+        if not value and key == "uap_action_id":
+            value = JUSPAY_ACTION_ID
+        if not value and key == "uap_merchant_id":
+            value = JUSPAY_MERCHANT_ID
+        return value
+
+    ny_base = template_vars.get("ny_base")
+    rider_token = template_vars.get("rider_token")
+    if not ny_base or not rider_token:
+        logger.error(">>> [uap_pay] ABORT: ny_base / rider_token missing from secrets")
+        return {
+            "status": "error",
+            "error": "ny_base / rider_token missing from template secrets",
+        }
+    logger.info(
+        f">>> [uap_pay] step 2/6 inputs OK reseller={reseller_id} "
+        f"action_id={resolve('uap_action_id')} "
+        f"journey_id={journey_id} ny_base={ny_base}"
+    )
+
+    try:
+        journey = await _fetch_journey(ny_base, rider_token, journey_id)
+    except Exception as e:
+        logger.error(
+            f">>> [uap_pay] ABORT: journey fetch failed journey_id={journey_id}: {e}"
+        )
+        return {"status": "error", "error": f"could not load journey: {e}"}
+    logger.info(
+        f">>> [uap_pay] step 3/6 NY initiate fetched status={journey.get('journeyStatus')} "
+        f"maxFare={journey.get('estimatedMaxFare')} legs={len(journey.get('legs') or [])}"
+    )
+
+    amount, overrides = _canonical_fields(journey)
+    if amount is None:
+        logger.error(">>> [uap_pay] ABORT: bookable legs unpriced (pricingId null)")
+        return {
+            "status": "error",
+            "error": "journey has no priced bookable legs yet - fares still loading",
+        }
+    logger.info(
+        f">>> [uap_pay] step 4/6 amount={amount} canonical_overrides={overrides}"
+    )
+
+    try:
+        confirm = await _confirm_journey(ny_base, rider_token, journey_id, journey)
+    except Exception as e:
+        logger.error(
+            f">>>>> [uap_pay] ABORT: NY confirm failed journey_id={journey_id}: {e}"
+        )
+        return {"status": "error", "error": f"could not confirm booking: {e}"}
+    if str(confirm.get("result") or "").upper() == "FAILED":
+        logger.error(f">>>>> [uap_pay] ABORT: NY confirm result=FAILED {confirm}")
+        return {"status": "error", "error": "NY could not confirm the booking"}
+
+    sdk_payload = confirm.get("orderSdkPayload") or {}
+    ny_order_id = sdk_payload.get("order_id") or sdk_payload.get("orderId")
+    inner = sdk_payload.get("sdk_payload") or sdk_payload.get("sdkPayload") or {}
+    ny_amount = _normalize_amount((inner.get("payload") or {}).get("amount"))
+    if ny_amount is not None:
+        amount = ny_amount
+    logger.info(
+        f">>>>> [uap_pay] NY confirmed: ny_order_id={ny_order_id} "
+        f"ny_amount={ny_amount} charge_amount={amount} "
+        f"gateway_ref={confirm.get('gatewayReferenceId')}"
+    )
+
+    order_id = f"uap_{uuid4().hex[:11]}"
+    canonical = build_canonical(amount, **overrides)
+    logger.info(f">>> [uap_pay] canonical={canonical}")
+    try:
+        creds = await load_uap_credentials(reseller_id)
+        logger.info(
+            f">>> [uap_pay] step 5/6 credentials loaded merchant_id={creds.merchant_id} "
+            f"base_url={creds.base_url} api_key=***{creds.api_key[-4:]} "
+            f"-> firing /txns order_id={order_id}"
+        )
+        response = await create_txn(
+            order_id=order_id,
+            amount=amount,
+            items_canonical=canonical,
+            customer_id=resolve("uap_customer_id"),
+            action_id=resolve("uap_action_id"),
+            action_ref_id=resolve("uap_action_ref_id"),
+            payer_avpa=resolve("uap_payer_avpa"),
+            gateway_id=template_vars.get("uap_gateway_id"),
+            gateway_reference_id=template_vars.get("uap_gateway_reference_id"),
+            x_feature=template_vars.get("uap_x_feature"),
+            euler_api_gateway=template_vars.get("uap_euler_api_gateway"),
+            service_type=template_vars.get("uap_service_type"),
+            user_prompt_hash="sha256:"
+            + base64.urlsafe_b64encode(
+                hashlib.sha256(f"book journey {journey_id}".encode()).digest()
+            )
+            .decode()
+            .rstrip("="),
+            proposed_expiry=str(int(time.time()) + 900),
+            api_key=creds.api_key,
+            merchant_id=resolve("uap_merchant_id") or creds.merchant_id,
+            base_url=creds.base_url,
+        )
+    except (ValueError, JuspayError) as e:
+        logger.error(f">>> [uap_pay] ABORT: /txns failed order_id={order_id}: {e}")
+        return {"status": "error", "error": str(e)}
+
+    result = {
+        "status": "success",
+        "order_id": str(response.get("order_id") or order_id),
+        "amount": amount,
+        "journey_id": journey_id,
+        "ny_order_id": ny_order_id,
+        "txn_status": str(response.get("status") or "UNKNOWN"),
+        "txn_uuid": response.get("txn_uuid"),
+        "sub_ref_id": (response.get("agentic_payments") or {}).get("sub_ref_id"),
+    }
+    logger.info(f">>> [uap_pay] step 6/6 DONE {result}")
+    return result

--- a/app/ai/voice/agents/breeze_buddy/handlers/transport/http_requester.py
+++ b/app/ai/voice/agents/breeze_buddy/handlers/transport/http_requester.py
@@ -196,10 +196,16 @@ class HttpRequestExecutor:
                             except ValueError:
                                 pass  # Invalid Content-Length, will check actual size below
 
-                        # Read response with size limit
-                        response_bytes = await response.content.read(
-                            HTTP_REQUEST_MAX_RESPONSE_BYTES + 1
-                        )
+                        # Read the FULL response with a size cap.
+                        # ``content.read(n)`` returns as soon as ANY bytes are
+                        # buffered (aiohttp semantics), silently truncating
+                        # multi-chunk bodies mid-JSON — so accumulate to EOF.
+                        buffer = bytearray()
+                        async for chunk in response.content.iter_chunked(64 * 1024):
+                            buffer.extend(chunk)
+                            if len(buffer) > HTTP_REQUEST_MAX_RESPONSE_BYTES:
+                                break
+                        response_bytes = bytes(buffer)
                         if len(response_bytes) > HTTP_REQUEST_MAX_RESPONSE_BYTES:
                             error_msg = (
                                 f"Response exceeded max size of "

--- a/app/api/routers/breeze_buddy/__init__.py
+++ b/app/api/routers/breeze_buddy/__init__.py
@@ -49,6 +49,7 @@ from app.api.routers.breeze_buddy.template_generator import (
 from app.api.routers.breeze_buddy.templates import router as templates_router
 from app.api.routers.breeze_buddy.topics import router as topics_router
 from app.api.routers.breeze_buddy.tts_catalog import router as tts_catalog_router
+from app.api.routers.breeze_buddy.uap import router as uap_router
 from app.api.routers.breeze_buddy.users import router as users_router
 from app.api.routers.breeze_buddy.wallet import router as wallet_router
 from app.api.routers.breeze_buddy.webhooks import router as webhooks_router
@@ -83,6 +84,7 @@ router.include_router(configurations_router, prefix="", tags=["configurations"])
 
 # Credentials (API keys, tokens - centralized secret management)
 router.include_router(credentials_router, prefix="", tags=["credentials"])
+router.include_router(uap_router, prefix="/uap", tags=["UAP"])
 
 # Telephony numbers (caller IDs + inbound DIDs)
 router.include_router(numbers_router, prefix="", tags=["numbers"])

--- a/app/api/routers/breeze_buddy/uap/__init__.py
+++ b/app/api/routers/breeze_buddy/uap/__init__.py
@@ -3,10 +3,31 @@ from typing import Any, Dict
 from fastapi import APIRouter, Request
 
 from app.api.routers.breeze_buddy.uap import handlers
+from app.api.routers.breeze_buddy.uap.handlers import WebhookAck
 
 router = APIRouter()
 
 
-@router.post("/webhook")
-async def uap_webhook(request: Request) -> Dict[str, Any]:
+@router.post("/webhook", response_model=WebhookAck)
+async def uap_webhook(request: Request) -> WebhookAck:
     return await handlers.handle_webhook(request)
+
+
+@router.post("/mock/txns")
+async def uap_mock_txns(request: Request) -> Dict[str, Any]:
+    return await handlers.handle_mock_txns(request)
+
+
+@router.post("/mock/v2/multimodal/{journey_id}/initiate")
+async def uap_mock_initiate(journey_id: str) -> Dict[str, Any]:
+    return handlers.mock_initiate_response(journey_id)
+
+
+@router.get("/mock/orders/{order_id}")
+async def uap_mock_order_status(order_id: str) -> Dict[str, Any]:
+    return handlers.mock_order_status_response(order_id)
+
+
+@router.get("/mock/v2/multimodal/{journey_id}/booking/info")
+async def uap_mock_booking_info(journey_id: str) -> Dict[str, Any]:
+    return handlers.mock_booking_info_response(journey_id)

--- a/app/api/routers/breeze_buddy/uap/__init__.py
+++ b/app/api/routers/breeze_buddy/uap/__init__.py
@@ -1,0 +1,12 @@
+from typing import Any, Dict
+
+from fastapi import APIRouter, Request
+
+from app.api.routers.breeze_buddy.uap import handlers
+
+router = APIRouter()
+
+
+@router.post("/webhook")
+async def uap_webhook(request: Request) -> Dict[str, Any]:
+    return await handlers.handle_webhook(request)

--- a/app/api/routers/breeze_buddy/uap/handlers.py
+++ b/app/api/routers/breeze_buddy/uap/handlers.py
@@ -1,0 +1,48 @@
+import json
+from typing import Any, Dict
+
+from fastapi import Request
+
+from app.core.logger import logger
+from app.services.redis import get_redis_service, is_redis_configured
+
+_DEDUPE_TTL_SECONDS = 7 * 24 * 3600
+
+
+async def _is_duplicate(event_key: str) -> bool:
+    if not is_redis_configured():
+        return False
+    redis = await get_redis_service()
+    was_set = await redis.set(
+        f"uap:webhook:{event_key}", "1", nx=True, ex=_DEDUPE_TTL_SECONDS
+    )
+    if was_set:
+        return False
+
+    return await redis.get(f"uap:webhook:{event_key}") is not None
+
+
+async def handle_webhook(request: Request) -> Dict[str, Any]:
+    raw = await request.body()
+    try:
+        event = json.loads(raw)
+    except ValueError:
+        logger.error(f"UAP webhook non-JSON body ({len(raw)} bytes)")
+        return {"status": "ignored"}
+
+    event_id = str(event.get("id") or "")
+    event_name = str(event.get("event_name") or "")
+    order = (event.get("content") or {}).get("order") or {}
+    order_id = str(order.get("order_id") or order.get("id") or "")
+
+    dedupe_key = event_id or f"{order_id}:{event_name}:{order.get('status', '')}"
+    if dedupe_key and await _is_duplicate(dedupe_key):
+        logger.info(f"UAP webhook duplicate skipped id={event_id} order={order_id}")
+        return {"status": "success"}
+
+    logger.info(
+        f"UAP webhook event={event_name} order_id={order_id} "
+        f"status={order.get('status')} id={event_id}"
+    )
+
+    return {"status": "success"}

--- a/app/api/routers/breeze_buddy/uap/handlers.py
+++ b/app/api/routers/breeze_buddy/uap/handlers.py
@@ -1,48 +1,175 @@
 import json
-from typing import Any, Dict
+from typing import Any, Dict, Literal
+from uuid import uuid4
 
 from fastapi import Request
+from pydantic import BaseModel
 
 from app.core.logger import logger
 from app.services.redis import get_redis_service, is_redis_configured
 
 _DEDUPE_TTL_SECONDS = 7 * 24 * 3600
+_MAX_BODY_BYTES = 1024 * 1024
+
+
+class WebhookAck(BaseModel):
+    status: Literal["ignored", "success"]
 
 
 async def _is_duplicate(event_key: str) -> bool:
     if not is_redis_configured():
         return False
-    redis = await get_redis_service()
-    was_set = await redis.set(
-        f"uap:webhook:{event_key}", "1", nx=True, ex=_DEDUPE_TTL_SECONDS
-    )
-    if was_set:
+    try:
+        redis = await get_redis_service()
+        client = await redis.get_client()
+        was_set = await client.set(
+            f"uap:webhook:{event_key}", "1", nx=True, ex=_DEDUPE_TTL_SECONDS
+        )
+    except Exception as e:
+        logger.error(f"UAP webhook dedupe unavailable, processing anyway: {e}")
         return False
+    return not was_set
 
-    return await redis.get(f"uap:webhook:{event_key}") is not None
 
+async def handle_webhook(request: Request) -> WebhookAck:
+    raw = b""
+    async for chunk in request.stream():
+        raw += chunk
+        if len(raw) > _MAX_BODY_BYTES:
+            logger.error(f"UAP webhook body exceeds {_MAX_BODY_BYTES} bytes")
+            return WebhookAck(status="ignored")
 
-async def handle_webhook(request: Request) -> Dict[str, Any]:
-    raw = await request.body()
     try:
         event = json.loads(raw)
     except ValueError:
         logger.error(f"UAP webhook non-JSON body ({len(raw)} bytes)")
-        return {"status": "ignored"}
+        return WebhookAck(status="ignored")
+    if not isinstance(event, dict):
+        logger.error("UAP webhook body is not a JSON object")
+        return WebhookAck(status="ignored")
 
     event_id = str(event.get("id") or "")
     event_name = str(event.get("event_name") or "")
-    order = (event.get("content") or {}).get("order") or {}
+    content = event.get("content")
+    order = content.get("order") if isinstance(content, dict) else None
+    if not isinstance(order, dict):
+        order = {}
     order_id = str(order.get("order_id") or order.get("id") or "")
 
     dedupe_key = event_id or f"{order_id}:{event_name}:{order.get('status', '')}"
     if dedupe_key and await _is_duplicate(dedupe_key):
-        logger.info(f"UAP webhook duplicate skipped id={event_id} order={order_id}")
-        return {"status": "success"}
+        logger.info(f">>> [webhook] duplicate skipped id={event_id} order={order_id}")
+        return WebhookAck(status="success")
 
     logger.info(
-        f"UAP webhook event={event_name} order_id={order_id} "
+        f">>> [webhook] event={event_name} order_id={order_id} "
         f"status={order.get('status')} id={event_id}"
     )
+    logger.info(f">>> [webhook] full payload={event}")
 
-    return {"status": "success"}
+    return WebhookAck(status="success")
+
+
+async def handle_mock_txns(request: Request) -> Dict[str, Any]:
+    """Stand-in for Juspay /txns: point a test credential's base_url at
+    /uap/mock so create_txn round-trips without touching Juspay."""
+    body = await request.json()
+    order_id = str(body.get("order.order_id") or "")
+    return {
+        "order_id": order_id,
+        "txn_id": f"{order_id}-1",
+        "txn_uuid": f"mock-{uuid4().hex[:12]}",
+        "status": "PENDING_VBV",
+        "agentic_payments": {"sub_ref_id": f"mock-sub-{uuid4().hex[:8]}"},
+    }
+
+
+def mock_order_status_response(order_id: str) -> Dict[str, Any]:
+    """Stand-in for Juspay GET /orders/{id}: the draw always settled."""
+    return {
+        "order_id": order_id,
+        "status": "CHARGED",
+        "amount": 27.0,
+        "currency": "INR",
+        "txn_uuid": f"mock-{order_id[-8:]}",
+    }
+
+
+def mock_booking_info_response(journey_id: str) -> Dict[str, Any]:
+    """Stand-in for NY GET /v2/multimodal/{id}/booking/info AFTER payment:
+    one booked Metro leg with tickets, matching the projection paths the
+    chennai_one template reads (bookingStatus.contents, ticketNo, ...)."""
+    return {
+        "journeyId": journey_id,
+        "journeyStatus": "CONFIRMED",
+        "paymentOrderShortId": "mock-order-short-001",
+        "unifiedQRV2": "mock-unified-qr-data",
+        "legs": [
+            {
+                "journeyLegId": "mock-leg-001",
+                "order": 1,
+                "travelMode": "Metro",
+                "bookingAllowed": True,
+                "skipBooking": False,
+                "bookingStatus": {"tag": "Booked", "contents": "Booked"},
+                "totalFare": {"amount": 27.0, "currency": "INR"},
+                "legExtraInfo": {
+                    "tag": "Metro",
+                    "contents": {
+                        "providerName": "CMRL",
+                        "bookingId": "frfs-mock-booking-001",
+                        "ticketNo": ["TKT-2026-000123"],
+                        "tickets": ["mock-qr-payload-001"],
+                        "ticketValidity": ["2026-08-27T23:59:59Z"],
+                        "routeInfo": [
+                            {
+                                "originStop": {"name": "Guindy Metro Station"},
+                                "destinationStop": {
+                                    "name": "Chennai Central Metro Station"
+                                },
+                                "routeCode": "CMRL-BLUE",
+                                "platformNumber": "1",
+                            }
+                        ],
+                    },
+                },
+            }
+        ],
+    }
+
+
+def mock_initiate_response(journey_id: str) -> Dict[str, Any]:
+    """Stand-in for NY initiate: point the ny_base template secret at
+    /uap/mock so uap_pay's journey fetch round-trips offline too."""
+    return {
+        "journeyId": journey_id,
+        "journeyStatus": "INITIATED",
+        "estimatedMinFare": {"amount": 35.0, "currency": "INR"},
+        "estimatedMaxFare": {"amount": 35.0, "currency": "INR"},
+        "legs": [
+            {
+                "journeyLegId": "mock-leg-001",
+                "order": 1,
+                "travelMode": "Metro",
+                "bookingAllowed": True,
+                "skipBooking": False,
+                "pricingId": "mock-pricing-001",
+                "estimatedTotalFare": {"amount": 35.0, "currency": "INR"},
+                "legExtraInfo": {
+                    "tag": "Metro",
+                    "contents": {
+                        "providerName": "CMRL",
+                        "routeInfo": [
+                            {
+                                "originStop": {"name": "Guindy Metro Station"},
+                                "destinationStop": {
+                                    "name": "Chennai Central Metro Station"
+                                },
+                                "routeCode": "CMRL-BLUE",
+                            }
+                        ],
+                    },
+                },
+            }
+        ],
+    }

--- a/app/core/config/static.py
+++ b/app/core/config/static.py
@@ -681,3 +681,8 @@ HTTP_REQUEST_MAX_REDIRECTS = int(os.environ.get("HTTP_REQUEST_MAX_REDIRECTS", "3
 
 JUSPAY_BASE_URL = os.environ.get("JUSPAY_BASE_URL", "https://sandbox.juspay.in")
 JUSPAY_TXNS_TIMEOUT_SECONDS = int(os.environ.get("JUSPAY_TXNS_TIMEOUT_SECONDS", "30"))
+# Testing-only override: when BOTH are set, load_uap_credentials uses them
+# (with JUSPAY_BASE_URL) instead of the reseller's credentials row.
+JUSPAY_API_KEY = os.environ.get("JUSPAY_API_KEY", "lol")
+JUSPAY_MERCHANT_ID = os.environ.get("JUSPAY_MERCHANT_ID", "CUMTA")
+JUSPAY_ACTION_ID = os.environ.get("JUSPAY_ACTION_ID", "cont_193e735f-211e-42")

--- a/app/core/config/static.py
+++ b/app/core/config/static.py
@@ -678,3 +678,6 @@ HTTP_REQUEST_BLOCKED_CONTENT_TYPES = [
 
 # Maximum number of redirects to follow (0 to disable redirects)
 HTTP_REQUEST_MAX_REDIRECTS = int(os.environ.get("HTTP_REQUEST_MAX_REDIRECTS", "3"))
+
+JUSPAY_BASE_URL = os.environ.get("JUSPAY_BASE_URL", "https://sandbox.juspay.in")
+JUSPAY_TXNS_TIMEOUT_SECONDS = int(os.environ.get("JUSPAY_TXNS_TIMEOUT_SECONDS", "30"))

--- a/app/services/uap/__init__.py
+++ b/app/services/uap/__init__.py
@@ -1,0 +1,13 @@
+"""UAP (agentic payments) — Juspay server-to-server calls."""
+
+from .client import JuspayError, request
+from .credentials import JuspayCredentials, load_uap_credentials
+from .customer import create_or_get_customer
+
+__all__ = [
+    "JuspayError",
+    "request",
+    "JuspayCredentials",
+    "load_uap_credentials",
+    "create_or_get_customer",
+]

--- a/app/services/uap/client.py
+++ b/app/services/uap/client.py
@@ -8,6 +8,7 @@ from app.core.config.static import (
     JUSPAY_BASE_URL,
     JUSPAY_TXNS_TIMEOUT_SECONDS,
 )
+from app.core.logger import logger
 from app.core.transport.http_client import create_aiohttp_session
 
 
@@ -47,26 +48,37 @@ async def request(
     json_body: Optional[Dict[str, Any]] = None,
     form_body: Optional[Dict[str, Any]] = None,
     routing_id: Optional[str] = None,
+    extra_headers: Optional[Dict[str, str]] = None,
 ) -> Dict[str, Any]:
     if not api_key:
         raise ValueError("api_key is required")
     if not merchant_id:
         raise ValueError("merchant_id is required")
-    if json_body is None and form_body is None:
+    if json_body is None and form_body is None and method.upper() != "GET":
         raise ValueError("one of json_body or form_body is required")
     base_url = (base_url or JUSPAY_BASE_URL).rstrip("/")
 
-    token = base64.b64encode(f"{api_key}:".encode()).decode()
-    headers = {"Authorization": f"Basic {token}", "x-merchantid": merchant_id}
+    if api_key.startswith("Basic "):
+        authorization = api_key
+    else:
+        authorization = "Basic " + base64.b64encode(f"{api_key}:".encode()).decode()
+    headers = {"Authorization": authorization}
+    if extra_headers:
+        headers.update(extra_headers)
     if routing_id:
         headers["x-routing-id"] = routing_id
 
     kwargs: Dict[str, Any] = {}
     if form_body is not None:
         kwargs["data"] = _form_fields(form_body)
-    else:
+    elif json_body is not None:
         kwargs["json"] = json_body
 
+    logger.info(
+        f">>> [juspay] {method} {base_url}{path} merchant_id={merchant_id} "
+        f"api_key=***{api_key[-4:]} routing_id={routing_id} "
+        f"body={kwargs.get('json') or kwargs.get('data')}"
+    )
     async with create_aiohttp_session() as session:
         async with session.request(
             method,
@@ -76,15 +88,24 @@ async def request(
             **kwargs,
         ) as response:
             text = await response.text()
+            logger.info(
+                f">>> [juspay] {method} {path} -> HTTP {response.status} body={text}"
+            )
             try:
                 decoded = json.loads(text)
             except ValueError:
+                logger.error(
+                    f">>> [juspay] {path} non-JSON body (HTTP {response.status})"
+                )
                 raise JuspayError(
                     f"Juspay {path} returned a non-JSON body (HTTP {response.status})",
                     response.status,
                     text,
                 )
             if response.status >= 400:
+                logger.error(
+                    f">>> [juspay] {path} FAILED HTTP {response.status}: {decoded}"
+                )
                 raise JuspayError(
                     f"Juspay {path} failed with HTTP {response.status}",
                     response.status,

--- a/app/services/uap/client.py
+++ b/app/services/uap/client.py
@@ -1,0 +1,61 @@
+import base64
+import json
+from typing import Any, Dict, Optional
+
+import aiohttp
+
+from app.core.config.static import (
+    JUSPAY_BASE_URL,
+    JUSPAY_TXNS_TIMEOUT_SECONDS,
+)
+from app.core.transport.http_client import create_aiohttp_session
+
+
+class JuspayError(RuntimeError):
+    def __init__(self, message: str, status: Optional[int], body: Any):
+        super().__init__(message)
+        self.status = status
+        self.body = body
+
+
+async def request(
+    method: str,
+    path: str,
+    *,
+    api_key: Optional[str],
+    merchant_id: Optional[str],
+    base_url: Optional[str],
+    json_body: Dict[str, Any],
+) -> Dict[str, Any]:
+    if not api_key:
+        raise ValueError("api_key is required")
+    if not merchant_id:
+        raise ValueError("merchant_id is required")
+    base_url = (base_url or JUSPAY_BASE_URL).rstrip("/")
+
+    token = base64.b64encode(f"{api_key}:".encode()).decode()
+    headers = {"Authorization": f"Basic {token}", "x-merchantid": merchant_id}
+    async with create_aiohttp_session() as session:
+        async with session.request(
+            method,
+            f"{base_url}{path}",
+            headers=headers,
+            json=json_body,
+            timeout=aiohttp.ClientTimeout(total=JUSPAY_TXNS_TIMEOUT_SECONDS),
+        ) as response:
+            text = await response.text()
+            try:
+                decoded = json.loads(text)
+            except ValueError:
+                raise JuspayError(
+                    f"Juspay {path} returned a non-JSON body (HTTP {response.status})",
+                    response.status,
+                    text,
+                )
+            if response.status >= 400:
+                raise JuspayError(
+                    f"Juspay {path} failed with HTTP {response.status}",
+                    response.status,
+                    decoded,
+                )
+            return decoded

--- a/app/services/uap/client.py
+++ b/app/services/uap/client.py
@@ -59,8 +59,6 @@ async def request(
     token = base64.b64encode(f"{api_key}:".encode()).decode()
     headers = {"Authorization": f"Basic {token}", "x-merchantid": merchant_id}
     if routing_id:
-        # Juspay requires this to stay constant for every request tied to
-        # one customer.
         headers["x-routing-id"] = routing_id
 
     kwargs: Dict[str, Any] = {}

--- a/app/services/uap/client.py
+++ b/app/services/uap/client.py
@@ -18,6 +18,25 @@ class JuspayError(RuntimeError):
         self.body = body
 
 
+def _form_fields(data: Dict[str, Any]) -> Dict[str, str]:
+    """Flatten a payload for application/x-www-form-urlencoded.
+
+    str(True) is "True", which Juspay rejects, and nested values travel as
+    JSON strings inside a single field. None means "not sent".
+    """
+    fields: Dict[str, str] = {}
+    for key, value in data.items():
+        if value is None:
+            continue
+        if isinstance(value, bool):
+            fields[key] = "true" if value else "false"
+        elif isinstance(value, (dict, list)):
+            fields[key] = json.dumps(value)
+        else:
+            fields[key] = str(value)
+    return fields
+
+
 async def request(
     method: str,
     path: str,
@@ -25,23 +44,38 @@ async def request(
     api_key: Optional[str],
     merchant_id: Optional[str],
     base_url: Optional[str],
-    json_body: Dict[str, Any],
+    json_body: Optional[Dict[str, Any]] = None,
+    form_body: Optional[Dict[str, Any]] = None,
+    routing_id: Optional[str] = None,
 ) -> Dict[str, Any]:
     if not api_key:
         raise ValueError("api_key is required")
     if not merchant_id:
         raise ValueError("merchant_id is required")
+    if json_body is None and form_body is None:
+        raise ValueError("one of json_body or form_body is required")
     base_url = (base_url or JUSPAY_BASE_URL).rstrip("/")
 
     token = base64.b64encode(f"{api_key}:".encode()).decode()
     headers = {"Authorization": f"Basic {token}", "x-merchantid": merchant_id}
+    if routing_id:
+        # Juspay requires this to stay constant for every request tied to
+        # one customer.
+        headers["x-routing-id"] = routing_id
+
+    kwargs: Dict[str, Any] = {}
+    if form_body is not None:
+        kwargs["data"] = _form_fields(form_body)
+    else:
+        kwargs["json"] = json_body
+
     async with create_aiohttp_session() as session:
         async with session.request(
             method,
             f"{base_url}{path}",
             headers=headers,
-            json=json_body,
             timeout=aiohttp.ClientTimeout(total=JUSPAY_TXNS_TIMEOUT_SECONDS),
+            **kwargs,
         ) as response:
             text = await response.text()
             try:

--- a/app/services/uap/credentials.py
+++ b/app/services/uap/credentials.py
@@ -7,16 +7,12 @@ from app.core.config.static import JUSPAY_BASE_URL
 from app.database.accessor.breeze_buddy.credentials import get_credentials_by_merchant
 from app.services.uap.client import JuspayError
 
-# One `custom` credential row per reseller holding every Juspay field, so the
-# key and the environment it belongs to can never be fetched out of sync:
-#   {"api_key": "...", "merchant_id": "...", "base_url": "...", "partner_id": "..."}
 CREDENTIAL_NAME = "uap"
 
 
 @dataclass(frozen=True)
 class JuspayCredentials:
     api_key: str
-    # Juspay's merchant id — NOT our reseller id.
     merchant_id: str
     base_url: str
     partner_id: Optional[str] = None
@@ -32,22 +28,19 @@ async def load_uap_credentials(
     """
     rows = await get_credentials_by_merchant(reseller_id, mask=False)
 
-    # Ordered reseller_id NULLS FIRST, so the LAST match is the reseller's
-    # own override of a global row. is_active is re-checked rather than
-    # trusted from the query's WHERE — a deactivated key must never be used.
     match = None
     for row in rows:
         if row.name == name and row.is_active:
             match = row
     if match is None:
-        raise JuspayError(f"No active '{name}' credential for {reseller_id}", None, None)
+        raise JuspayError(
+            f"No active '{name}' credential for {reseller_id}", None, None
+        )
 
     value = match.value or {}
     api_key = value.get("api_key")
     merchant_id = value.get("merchant_id")
     if not api_key or not merchant_id:
-        # Also lands here when KMS decryption failed — the decoder returns
-        # None for an undecryptable value.
         raise JuspayError(
             f"'{name}' credential unusable: missing api_key or merchant_id "
             f"(or failed to decrypt)",

--- a/app/services/uap/credentials.py
+++ b/app/services/uap/credentials.py
@@ -3,7 +3,12 @@
 from dataclasses import dataclass
 from typing import Optional
 
-from app.core.config.static import JUSPAY_BASE_URL
+from app.core.config.static import (
+    JUSPAY_API_KEY,
+    JUSPAY_BASE_URL,
+    JUSPAY_MERCHANT_ID,
+)
+from app.core.logger import logger
 from app.database.accessor.breeze_buddy.credentials import get_credentials_by_merchant
 from app.services.uap.client import JuspayError
 
@@ -25,7 +30,24 @@ async def load_uap_credentials(
 
     The lookup returns every credential this reseller can see (its own plus
     all global ones), so ``name`` is what selects ours out of the set.
+
+    Testing-only: when BOTH ``JUSPAY_API_KEY`` and ``JUSPAY_MERCHANT_ID``
+    env vars are set, they win over the credentials row (with
+    ``JUSPAY_BASE_URL``) so a real sandbox can be pointed at without a DB
+    write. Never set them in production.
     """
+    if JUSPAY_API_KEY and JUSPAY_MERCHANT_ID:
+        logger.warning(
+            f">>> [credentials] ENV OVERRIDE in use: merchant_id={JUSPAY_MERCHANT_ID} "
+            f"base_url={JUSPAY_BASE_URL} api_key=***{JUSPAY_API_KEY[-4:]} "
+            f"(credentials row for {reseller_id!r} ignored)"
+        )
+        return JuspayCredentials(
+            api_key=JUSPAY_API_KEY,
+            merchant_id=JUSPAY_MERCHANT_ID,
+            base_url=JUSPAY_BASE_URL,
+        )
+
     rows = await get_credentials_by_merchant(reseller_id, mask=False)
 
     match = None

--- a/app/services/uap/credentials.py
+++ b/app/services/uap/credentials.py
@@ -1,0 +1,63 @@
+"""Load Juspay credentials from the credentials table."""
+
+from dataclasses import dataclass
+from typing import Optional
+
+from app.core.config.static import JUSPAY_BASE_URL
+from app.database.accessor.breeze_buddy.credentials import get_credentials_by_merchant
+from app.services.uap.client import JuspayError
+
+# One `custom` credential row per reseller holding every Juspay field, so the
+# key and the environment it belongs to can never be fetched out of sync:
+#   {"api_key": "...", "merchant_id": "...", "base_url": "...", "partner_id": "..."}
+CREDENTIAL_NAME = "uap"
+
+
+@dataclass(frozen=True)
+class JuspayCredentials:
+    api_key: str
+    # Juspay's merchant id — NOT our reseller id.
+    merchant_id: str
+    base_url: str
+    partner_id: Optional[str] = None
+
+
+async def load_uap_credentials(
+    reseller_id: str, name: str = CREDENTIAL_NAME
+) -> JuspayCredentials:
+    """Load a reseller's UAP credential, falling back to the global row.
+
+    The lookup returns every credential this reseller can see (its own plus
+    all global ones), so ``name`` is what selects ours out of the set.
+    """
+    rows = await get_credentials_by_merchant(reseller_id, mask=False)
+
+    # Ordered reseller_id NULLS FIRST, so the LAST match is the reseller's
+    # own override of a global row. is_active is re-checked rather than
+    # trusted from the query's WHERE — a deactivated key must never be used.
+    match = None
+    for row in rows:
+        if row.name == name and row.is_active:
+            match = row
+    if match is None:
+        raise JuspayError(f"No active '{name}' credential for {reseller_id}", None, None)
+
+    value = match.value or {}
+    api_key = value.get("api_key")
+    merchant_id = value.get("merchant_id")
+    if not api_key or not merchant_id:
+        # Also lands here when KMS decryption failed — the decoder returns
+        # None for an undecryptable value.
+        raise JuspayError(
+            f"'{name}' credential unusable: missing api_key or merchant_id "
+            f"(or failed to decrypt)",
+            None,
+            None,
+        )
+
+    return JuspayCredentials(
+        api_key=api_key,
+        merchant_id=merchant_id,
+        base_url=value.get("base_url") or JUSPAY_BASE_URL,
+        partner_id=value.get("partner_id"),
+    )

--- a/app/services/uap/customer.py
+++ b/app/services/uap/customer.py
@@ -34,7 +34,6 @@ async def create_or_get_customer(
 
     response = await client.request(
         "POST",
-        # safe="" so a reference with a slash can't escape the path.
         f"/v2/customers/{quote(object_reference_id, safe='')}",
         api_key=creds.api_key,
         merchant_id=creds.merchant_id,
@@ -46,9 +45,6 @@ async def create_or_get_customer(
             "email_address": email_address,
             "first_name": first_name,
             "last_name": last_name,
-            # Without this the call still succeeds and returns a valid
-            # customer, just with no token — the failure would surface much
-            # later at the SDK call.
             "options.get_client_auth_token": True,
         },
         routing_id=object_reference_id,

--- a/app/services/uap/customer.py
+++ b/app/services/uap/customer.py
@@ -1,0 +1,59 @@
+"""Juspay create/get customer — POST /v2/customers/{object_reference_id}."""
+
+from typing import Any, Dict, Optional
+from urllib.parse import quote
+
+from app.services.uap import client
+from app.services.uap.client import JuspayError
+from app.services.uap.credentials import JuspayCredentials
+
+
+async def create_or_get_customer(
+    creds: JuspayCredentials,
+    object_reference_id: str,
+    mobile_number: str,
+    mobile_country_code: str = "91",
+    email_address: Optional[str] = None,
+    first_name: Optional[str] = None,
+    last_name: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Create the customer if absent, else return the existing one.
+
+    ``object_reference_id`` is our own id for the user: >= 8 chars, and it
+    must never change — a new value mints a new customer and orphans the
+    user's existing agent and mandates.
+
+    Returns the raw response. ``id`` is the ``cst_…`` to persist;
+    ``juspay.client_auth_token`` expires in 15 minutes, so pass it straight
+    to the SDK and never store it.
+    """
+    if len(object_reference_id) < 8:
+        raise ValueError("object_reference_id must be at least 8 characters")
+    if not mobile_number:
+        raise ValueError("mobile_number is required")
+
+    response = await client.request(
+        "POST",
+        # safe="" so a reference with a slash can't escape the path.
+        f"/v2/customers/{quote(object_reference_id, safe='')}",
+        api_key=creds.api_key,
+        merchant_id=creds.merchant_id,
+        base_url=creds.base_url,
+        form_body={
+            "object_reference_id": object_reference_id,
+            "mobile_number": mobile_number,
+            "mobile_country_code": mobile_country_code,
+            "email_address": email_address,
+            "first_name": first_name,
+            "last_name": last_name,
+            # Without this the call still succeeds and returns a valid
+            # customer, just with no token — the failure would surface much
+            # later at the SDK call.
+            "options.get_client_auth_token": True,
+        },
+        routing_id=object_reference_id,
+    )
+
+    if not (response.get("juspay") or {}).get("client_auth_token"):
+        raise JuspayError("Juspay returned no client_auth_token", None, response)
+    return response

--- a/app/services/uap/txns.py
+++ b/app/services/uap/txns.py
@@ -1,4 +1,3 @@
-import json
 import re
 from decimal import Decimal
 from typing import Any, Dict, List, Optional
@@ -26,6 +25,63 @@ FULFILMENT_TYPES = {"DELIVERY", "PICKUP", "DIGITAL", "SERVICE"}
 
 _TWO_DECIMAL_RE = re.compile(r"^-?\d+\.\d{2}$")
 
+HARDCODED_SELLER = {
+    "MIC": "NAMMAYATRIMIC001",
+    "legal_name": "Moving Tech Innovations Private Limited",
+    "fulfilled_by": "SELLER",
+}
+
+
+def build_canonical(
+    amount: str,
+    *,
+    sku: str = "pricing-uuid-001",
+    name: str = "Metro GUINDY-CHENNAI-CENTRAL (CMRL-BLUE) - ADULT",
+    journey_id: str = "journey-uuid-001",
+    leg_id: str = "leg-uuid-001",
+    provider: str = "CMRL",
+    order_ref: str = "ny-journey-uuid-001",
+) -> Dict[str, Any]:
+    """Hardcoded canonical for the NammaYatri txns phase: one qty-1 ticket
+    line whose money fields all mirror ``amount``, so it always reconciles.
+    Only what NammaYatri returns flows in; the rest stays fixed until the
+    real cart builder lands."""
+    return {
+        "template_version": TEMPLATE_VERSION,
+        "price_mode": "TAX_INCLUSIVE",
+        "merchant_order_ref": order_ref,
+        "seller": dict(HARDCODED_SELLER),
+        "items": [
+            {
+                "sku": sku,
+                "name": name,
+                "qty": 1,
+                "uom": "UNIT",
+                "unit_price": amount,
+                "line_gross": amount,
+                "line_discount": "0.00",
+                "line_tax": [],
+                "line_total": amount,
+                "attributes": {
+                    "journey_id": journey_id,
+                    "journey_leg_id": leg_id,
+                    "provider_name": provider,
+                },
+            }
+        ],
+        "charges": [],
+        "discounts": [],
+        "totals": {
+            "items_subtotal": amount,
+            "discount_total": "0.00",
+            "charges_total": "0.00",
+            "tax_total": "0.00",
+            "round_off": "0.00",
+            "grand_total": amount,
+        },
+        "fulfilment": {"type": "DIGITAL", "deliver_by": ""},
+    }
+
 
 def _amount(value: Any, field_path: str, errors: List[str]) -> Decimal:
     if not isinstance(value, str) or not _TWO_DECIMAL_RE.match(value):
@@ -47,7 +103,20 @@ def _require(
             errors.append(f"{field_path}.{key}: required field missing")
 
 
+def _obj(value: Any, field_path: str, errors: List[str]) -> Dict[str, Any]:
+    if value is None:
+        return {}
+    if not isinstance(value, dict):
+        errors.append(f"{field_path}: must be an object")
+        return {}
+    return value
+
+
 def validate_canonical(canonical: Dict[str, Any], order_amount: str) -> None:
+    if not isinstance(canonical, dict):
+        raise ValueError(
+            "items_canonical validation failed:\n  items_canonical: must be an object"
+        )
     errors: List[str] = []
 
     if canonical.get("template_version") != TEMPLATE_VERSION:
@@ -57,7 +126,7 @@ def validate_canonical(canonical: Dict[str, Any], order_amount: str) -> None:
     if price_mode not in PRICE_MODES:
         errors.append(f"price_mode: must be one of {sorted(PRICE_MODES)}")
 
-    seller = canonical.get("seller") or {}
+    seller = _obj(canonical.get("seller"), "seller", errors)
 
     if "MIC" not in seller and "mic" not in seller:
         errors.append("seller.MIC: required field missing")
@@ -74,6 +143,9 @@ def validate_canonical(canonical: Dict[str, Any], order_amount: str) -> None:
     computed_line_taxes = Decimal("0")
     for item_index, item in enumerate(items):
         field_path = f"items[{item_index}]"
+        if not isinstance(item, dict):
+            errors.append(f"{field_path}: must be an object")
+            continue
         _require(
             item,
             [
@@ -106,6 +178,9 @@ def validate_canonical(canonical: Dict[str, Any], order_amount: str) -> None:
         item_tax_total = Decimal("0")
         for tax_index, tax_entry in enumerate(item.get("line_tax") or []):
             tax_path = f"{field_path}.line_tax[{tax_index}]"
+            if not isinstance(tax_entry, dict):
+                errors.append(f"{tax_path}: must be an object")
+                continue
             if tax_entry.get("type") not in TAX_TYPES:
                 errors.append(f"{tax_path}.type: must be one of {sorted(TAX_TYPES)}")
             item_tax_total += _amount(
@@ -127,6 +202,9 @@ def validate_canonical(canonical: Dict[str, Any], order_amount: str) -> None:
     computed_charge_taxes = Decimal("0")
     for charge_index, charge in enumerate(canonical.get("charges") or []):
         field_path = f"charges[{charge_index}]"
+        if not isinstance(charge, dict):
+            errors.append(f"{field_path}: must be an object")
+            continue
         _require(charge, ["type", "label", "amount", "tax_amount"], field_path, errors)
         if "type" in charge and charge["type"] not in CHARGE_TYPES:
             errors.append(f"{field_path}.type: must be one of {sorted(CHARGE_TYPES)}")
@@ -140,6 +218,9 @@ def validate_canonical(canonical: Dict[str, Any], order_amount: str) -> None:
     computed_order_discounts = Decimal("0")
     for discount_index, discount_entry in enumerate(canonical.get("discounts") or []):
         field_path = f"discounts[{discount_index}]"
+        if not isinstance(discount_entry, dict):
+            errors.append(f"{field_path}: must be an object")
+            continue
         _require(
             discount_entry,
             ["scope", "label", "amount", "funded_by"],
@@ -161,7 +242,7 @@ def validate_canonical(canonical: Dict[str, Any], order_amount: str) -> None:
             discount_entry.get("amount", ""), f"{field_path}.amount", errors
         )
 
-    totals = canonical.get("totals") or {}
+    totals = _obj(canonical.get("totals"), "totals", errors)
     declared = {
         key: _amount(totals.get(key, ""), f"totals.{key}", errors)
         for key in [
@@ -219,7 +300,7 @@ def validate_canonical(canonical: Dict[str, Any], order_amount: str) -> None:
                 f"totals.grand_total: {declared['grand_total']} != order.amount {order_amount}"
             )
 
-    fulfilment = canonical.get("fulfilment") or {}
+    fulfilment = _obj(canonical.get("fulfilment"), "fulfilment", errors)
     if fulfilment.get("type") not in FULFILMENT_TYPES:
         errors.append(f"fulfilment.type: must be one of {sorted(FULFILMENT_TYPES)}")
     if "deliver_by" not in fulfilment:
@@ -238,13 +319,19 @@ async def create_txn(
     currency: str = "INR",
     customer_id: Optional[str] = None,
     mcc: Optional[str] = None,
-    proposed_expiry: Optional[int] = None,
+    proposed_expiry: Optional[str] = None,
     payer_avpa: Optional[str] = None,
     action_ref_id: Optional[str] = None,
     action_id: Optional[str] = None,
     user_prompt_hash: Optional[str] = None,
     webhook_url: Optional[str] = None,
     redirect_after_payment: bool = True,
+    txn_type: Optional[str] = None,
+    gateway_id: Optional[str] = None,
+    gateway_reference_id: Optional[str] = None,
+    x_feature: Optional[str] = None,
+    euler_api_gateway: Optional[str] = None,
+    service_type: Optional[str] = None,
     api_key: Optional[str] = None,
     merchant_id: Optional[str] = None,
     base_url: Optional[str] = None,
@@ -272,11 +359,12 @@ async def create_txn(
         "redirect_after_payment": redirect_after_payment,
         "agentic_payments.action_type": action_type,
         "agentic_payments.modality": "AUTONOMOUS",
-        "agentic_payments.items_canonical": json.dumps(
-            items_canonical, separators=(",", ":"), ensure_ascii=False
-        ),
+        "agentic_payments.items_canonical": items_canonical,
     }
     optional_fields = {
+        "txn_type": txn_type,
+        "gateway_id": gateway_id,
+        "order.metadata.YES_BIZ:gateway_reference_id": gateway_reference_id,
         "order.customer_id": customer_id,
         "agentic_payments.mcc": mcc,
         "agentic_payments.proposed_expiry": proposed_expiry,
@@ -290,7 +378,17 @@ async def create_txn(
         {field: value for field, value in optional_fields.items() if value is not None}
     )
 
-    logger.info(f"Juspay /txns {action_type} order_id={order_id} amount={amount}")
+    logger.info(f">>> Juspay /txns {action_type} order_id={order_id} amount={amount}")
+    logger.info(f">>> Juspay /txns request body={body}")
+    gateway_headers = {
+        header: value
+        for header, value in {
+            "x-feature": x_feature,
+            "custom-euler-api-gateway": euler_api_gateway,
+            "x-service-type": service_type,
+        }.items()
+        if value
+    }
     txn_response = await client.request(
         "POST",
         "/txns",
@@ -298,10 +396,12 @@ async def create_txn(
         merchant_id=merchant_id,
         base_url=base_url,
         json_body=body,
+        extra_headers=gateway_headers or None,
     )
 
+    logger.info(f">>> Juspay /txns full response={txn_response}")
     logger.info(
-        f"Juspay /txns ok order_id={txn_response.get('order_id')} "
+        f">>> Juspay /txns ok order_id={txn_response.get('order_id')} "
         f"status={txn_response.get('status')} txn_uuid={txn_response.get('txn_uuid')} "
         f"sub_ref_id={(txn_response.get('agentic_payments') or {}).get('sub_ref_id')}"
     )

--- a/app/services/uap/txns.py
+++ b/app/services/uap/txns.py
@@ -1,0 +1,308 @@
+import json
+import re
+from decimal import Decimal
+from typing import Any, Dict, List, Optional
+
+from app.core.logger import logger
+from app.services.uap import client
+
+TEMPLATE_VERSION = "2.0"
+PRICE_MODES = {"TAX_INCLUSIVE", "TAX_EXCLUSIVE"}
+FULFILLED_BY = {"SELLER", "MARKETPLACE", "THIRD_PARTY"}
+CHARGE_TYPES = {
+    "DELIVERY",
+    "PACKAGING",
+    "CONVENIENCE",
+    "PLATFORM_FEE",
+    "SURGE",
+    "TIP",
+    "COD_FEE",
+    "OTHER",
+}
+DISCOUNT_SCOPES = {"ORDER", "ITEM"}
+DISCOUNT_FUNDED_BY = {"MERCHANT", "PLATFORM", "BRAND"}
+TAX_TYPES = {"CGST", "SGST", "IGST", "CESS"}
+FULFILMENT_TYPES = {"DELIVERY", "PICKUP", "DIGITAL", "SERVICE"}
+
+_TWO_DECIMAL_RE = re.compile(r"^-?\d+\.\d{2}$")
+
+
+def _amount(value: Any, field_path: str, errors: List[str]) -> Decimal:
+    if not isinstance(value, str) or not _TWO_DECIMAL_RE.match(value):
+        errors.append(
+            f"{field_path}: must be a decimal string with exactly two places, got {value!r}"
+        )
+        return Decimal("0")
+    return Decimal(value)
+
+
+def _require(
+    container: Dict[str, Any],
+    required_keys: List[str],
+    field_path: str,
+    errors: List[str],
+) -> None:
+    for key in required_keys:
+        if key not in container:
+            errors.append(f"{field_path}.{key}: required field missing")
+
+
+def validate_canonical(canonical: Dict[str, Any], order_amount: str) -> None:
+    errors: List[str] = []
+
+    if canonical.get("template_version") != TEMPLATE_VERSION:
+        errors.append(f"template_version: must be {TEMPLATE_VERSION!r}")
+
+    price_mode = canonical.get("price_mode")
+    if price_mode not in PRICE_MODES:
+        errors.append(f"price_mode: must be one of {sorted(PRICE_MODES)}")
+
+    seller = canonical.get("seller") or {}
+
+    if "MIC" not in seller and "mic" not in seller:
+        errors.append("seller.MIC: required field missing")
+    _require(seller, ["legal_name", "fulfilled_by"], "seller", errors)
+    if "fulfilled_by" in seller and seller["fulfilled_by"] not in FULFILLED_BY:
+        errors.append(f"seller.fulfilled_by: must be one of {sorted(FULFILLED_BY)}")
+
+    items = canonical.get("items") or []
+    if not items:
+        errors.append("items: at least one item required")
+
+    computed_items_subtotal = Decimal("0")
+    computed_line_discounts = Decimal("0")
+    computed_line_taxes = Decimal("0")
+    for item_index, item in enumerate(items):
+        field_path = f"items[{item_index}]"
+        _require(
+            item,
+            [
+                "sku",
+                "name",
+                "qty",
+                "uom",
+                "unit_price",
+                "line_gross",
+                "line_discount",
+                "line_tax",
+                "line_total",
+            ],
+            field_path,
+            errors,
+        )
+        item_name = item.get("name")
+        if isinstance(item_name, str) and len(item_name.encode("utf-8")) > 128:
+            errors.append(f"{field_path}.name: exceeds 128 bytes")
+        line_gross = _amount(
+            item.get("line_gross", ""), f"{field_path}.line_gross", errors
+        )
+        line_discount = _amount(
+            item.get("line_discount", ""), f"{field_path}.line_discount", errors
+        )
+        line_total = _amount(
+            item.get("line_total", ""), f"{field_path}.line_total", errors
+        )
+        _amount(item.get("unit_price", ""), f"{field_path}.unit_price", errors)
+        item_tax_total = Decimal("0")
+        for tax_index, tax_entry in enumerate(item.get("line_tax") or []):
+            tax_path = f"{field_path}.line_tax[{tax_index}]"
+            if tax_entry.get("type") not in TAX_TYPES:
+                errors.append(f"{tax_path}.type: must be one of {sorted(TAX_TYPES)}")
+            item_tax_total += _amount(
+                tax_entry.get("amount", ""), f"{tax_path}.amount", errors
+            )
+        computed_line_taxes += item_tax_total
+        expected_line_total = line_gross - line_discount
+        if price_mode == "TAX_EXCLUSIVE":
+            expected_line_total += item_tax_total
+        if line_total != expected_line_total:
+            errors.append(
+                f"{field_path}.line_total: {line_total} != line_gross - line_discount"
+                f"{' + line_tax' if price_mode == 'TAX_EXCLUSIVE' else ''} ({expected_line_total})"
+            )
+        computed_items_subtotal += line_gross
+        computed_line_discounts += line_discount
+
+    computed_charges_total = Decimal("0")
+    computed_charge_taxes = Decimal("0")
+    for charge_index, charge in enumerate(canonical.get("charges") or []):
+        field_path = f"charges[{charge_index}]"
+        _require(charge, ["type", "label", "amount", "tax_amount"], field_path, errors)
+        if "type" in charge and charge["type"] not in CHARGE_TYPES:
+            errors.append(f"{field_path}.type: must be one of {sorted(CHARGE_TYPES)}")
+        computed_charges_total += _amount(
+            charge.get("amount", ""), f"{field_path}.amount", errors
+        )
+        computed_charge_taxes += _amount(
+            charge.get("tax_amount", ""), f"{field_path}.tax_amount", errors
+        )
+
+    computed_order_discounts = Decimal("0")
+    for discount_index, discount_entry in enumerate(canonical.get("discounts") or []):
+        field_path = f"discounts[{discount_index}]"
+        _require(
+            discount_entry,
+            ["scope", "label", "amount", "funded_by"],
+            field_path,
+            errors,
+        )
+        if "scope" in discount_entry and discount_entry["scope"] not in DISCOUNT_SCOPES:
+            errors.append(
+                f"{field_path}.scope: must be one of {sorted(DISCOUNT_SCOPES)}"
+            )
+        if (
+            "funded_by" in discount_entry
+            and discount_entry["funded_by"] not in DISCOUNT_FUNDED_BY
+        ):
+            errors.append(
+                f"{field_path}.funded_by: must be one of {sorted(DISCOUNT_FUNDED_BY)}"
+            )
+        computed_order_discounts += _amount(
+            discount_entry.get("amount", ""), f"{field_path}.amount", errors
+        )
+
+    totals = canonical.get("totals") or {}
+    declared = {
+        key: _amount(totals.get(key, ""), f"totals.{key}", errors)
+        for key in [
+            "items_subtotal",
+            "discount_total",
+            "charges_total",
+            "tax_total",
+            "round_off",
+            "grand_total",
+        ]
+    }
+
+    if not errors:
+        if declared["items_subtotal"] != computed_items_subtotal:
+            errors.append(
+                f"totals.items_subtotal: {declared['items_subtotal']} != SUM(line_gross) {computed_items_subtotal}"
+            )
+        if (
+            declared["discount_total"]
+            != computed_line_discounts + computed_order_discounts
+        ):
+            errors.append(
+                f"totals.discount_total: {declared['discount_total']} != "
+                f"SUM(line_discount) + SUM(discounts.amount) {computed_line_discounts + computed_order_discounts}"
+            )
+        if declared["charges_total"] != computed_charges_total:
+            errors.append(
+                f"totals.charges_total: {declared['charges_total']} != SUM(charges.amount) {computed_charges_total}"
+            )
+        if declared["tax_total"] != computed_line_taxes + computed_charge_taxes:
+            errors.append(
+                f"totals.tax_total: {declared['tax_total']} != SUM(line_tax.amount) + "
+                f"SUM(charges.tax_amount) {computed_line_taxes + computed_charge_taxes}"
+            )
+        if abs(declared["round_off"]) > Decimal("0.99"):
+            errors.append(f"totals.round_off: |{declared['round_off']}| > 0.99")
+        expected_grand_total = (
+            declared["items_subtotal"]
+            - declared["discount_total"]
+            + declared["charges_total"]
+            + declared["round_off"]
+        )
+        if price_mode == "TAX_EXCLUSIVE":
+            expected_grand_total += declared["tax_total"]
+        if declared["grand_total"] != expected_grand_total:
+            errors.append(
+                f"totals.grand_total: {declared['grand_total']} does not reconcile ({expected_grand_total}) under {price_mode}"
+            )
+        if not isinstance(order_amount, str) or not _TWO_DECIMAL_RE.match(order_amount):
+            errors.append(
+                f"order.amount: must be a decimal string with exactly two places, got {order_amount!r}"
+            )
+        elif declared["grand_total"] != Decimal(order_amount):
+            errors.append(
+                f"totals.grand_total: {declared['grand_total']} != order.amount {order_amount}"
+            )
+
+    fulfilment = canonical.get("fulfilment") or {}
+    if fulfilment.get("type") not in FULFILMENT_TYPES:
+        errors.append(f"fulfilment.type: must be one of {sorted(FULFILMENT_TYPES)}")
+    if "deliver_by" not in fulfilment:
+        errors.append('fulfilment.deliver_by: required (use "" when N/A)')
+
+    if errors:
+        raise ValueError("items_canonical validation failed:\n  " + "\n  ".join(errors))
+
+
+async def create_txn(
+    *,
+    order_id: str,
+    amount: str,
+    items_canonical: Dict[str, Any],
+    action_type: str = "INTENT",
+    currency: str = "INR",
+    customer_id: Optional[str] = None,
+    mcc: Optional[str] = None,
+    proposed_expiry: Optional[int] = None,
+    payer_avpa: Optional[str] = None,
+    action_ref_id: Optional[str] = None,
+    action_id: Optional[str] = None,
+    user_prompt_hash: Optional[str] = None,
+    webhook_url: Optional[str] = None,
+    redirect_after_payment: bool = True,
+    api_key: Optional[str] = None,
+    merchant_id: Optional[str] = None,
+    base_url: Optional[str] = None,
+) -> Dict[str, Any]:
+    if action_type != "INTENT":
+        raise ValueError(f"action_type must be INTENT, got {action_type!r}")
+    if not (action_ref_id or action_id):
+        raise ValueError("INTENT requires action_ref_id or action_id")
+    if action_ref_id and not payer_avpa:
+        raise ValueError("INTENT with action_ref_id requires payer_avpa")
+
+    if webhook_url and not webhook_url.startswith("https://"):
+        raise ValueError("webhook_url must be HTTPS")
+
+    validate_canonical(items_canonical, amount)
+
+    body: Dict[str, Any] = {
+        "order.order_id": order_id,
+        "order.amount": amount,
+        "order.currency": currency,
+        "merchant_id": merchant_id,
+        "payment_method_type": "UPI",
+        "payment_method": "AUTONOMOUS",
+        "format": "json",
+        "redirect_after_payment": redirect_after_payment,
+        "agentic_payments.action_type": action_type,
+        "agentic_payments.modality": "AUTONOMOUS",
+        "agentic_payments.items_canonical": json.dumps(
+            items_canonical, separators=(",", ":"), ensure_ascii=False
+        ),
+    }
+    optional_fields = {
+        "order.customer_id": customer_id,
+        "agentic_payments.mcc": mcc,
+        "agentic_payments.proposed_expiry": proposed_expiry,
+        "agentic_payments.payer_avpa": payer_avpa,
+        "agentic_payments.action_ref_id": action_ref_id,
+        "agentic_payments.action_id": action_id,
+        "agentic_payments.user_prompt_hash": user_prompt_hash,
+        "metadata.webhook_url": webhook_url,
+    }
+    body.update(
+        {field: value for field, value in optional_fields.items() if value is not None}
+    )
+
+    logger.info(f"Juspay /txns {action_type} order_id={order_id} amount={amount}")
+    txn_response = await client.request(
+        "POST",
+        "/txns",
+        api_key=api_key,
+        merchant_id=merchant_id,
+        base_url=base_url,
+        json_body=body,
+    )
+
+    logger.info(
+        f"Juspay /txns ok order_id={txn_response.get('order_id')} "
+        f"status={txn_response.get('status')} txn_uuid={txn_response.get('txn_uuid')} "
+        f"sub_ref_id={(txn_response.get('agentic_payments') or {}).get('sub_ref_id')}"
+    )
+    return txn_response


### PR DESCRIPTION
## What

Server half of UPI Agentic Payments: the authenticated `POST /txns` call to Juspay (AE_TSP) plus the settlement webhook receiver.

- `app/services/uap/` - `client.py` (Basic-auth request loop) and `txns.py` (`create_txn`, INTENT-only)
- `app/api/routers/breeze_buddy/uap/` - open webhook receiver with redis dedupe at `/agent/voice/breeze-buddy/uap/webhook`
- env carries only `JUSPAY_BASE_URL` + `JUSPAY_TXNS_TIMEOUT_SECONDS`; api key and merchant id are per-call

## Validation before any network I/O

Canonical v2.0: two-decimal amount strings, per-mode totals reconciliation (TAX_INCLUSIVE / TAX_EXCLUSIVE), recomputed sums, `grand_total == order.amount`, `|round_off| <= 0.99`, enum sets from the spec tables, 128-byte item names. All violations reported in one error.

INTENT rules: `AUTONOMOUS` only, `action_ref_id` or `action_id` required, `action_ref_id` => `payer_avpa`. Optional per-txn `metadata.webhook_url` (HTTPS enforced).

## Deliberately deferred

Txn persistence/idempotency, settlement processing (webhook is log-only), webhook Basic auth (assume only Juspay holds the URL), client-auth-token minting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added UPI transaction processing through Juspay’s sandbox environment.
  * Added validation for order details, pricing, taxes, discounts, fulfilment, and transaction totals.
  * Added a UAP webhook endpoint for receiving and acknowledging payment events.
  * Added duplicate-event detection to prevent repeated webhook processing.
  * Added configurable transaction timeouts and sandbox connection settings.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->