### PR TITLE
feat(crm): workflow layer — plans, enrollments, walker, entry rules (W1–W5)

### DIFF
--- a/app/core/config/static.py
+++ b/app/core/config/static.py
@@ -742,3 +742,22 @@ HTTP_REQUEST_BLOCKED_CONTENT_TYPES = [
 
 # Maximum number of redirects to follow (0 to disable redirects)
 HTTP_REQUEST_MAX_REDIRECTS = int(os.environ.get("HTTP_REQUEST_MAX_REDIRECTS", "3"))
+
+# ---------------------------------------------------------------------------
+# CRM outreach — walker + run retention (canon T20; the corpus names the
+# mechanisms, these are the numbers). The walker's poll/batch come from the
+# shared CRM_WORKER_INTERVAL / CRM_WORKER_BATCH above (worker-runtime.md).
+# ---------------------------------------------------------------------------
+# The claim pushes wake_at this far ahead: the timer IS the lease (canon T20).
+CRM_WALKER_LEASE_SECONDS = int(os.environ.get("CRM_WALKER_LEASE_SECONDS", 300))
+
+# Consecutive failed claims before a run parks for a human.
+CRM_WALKER_MAX_ATTEMPTS = int(os.environ.get("CRM_WALKER_MAX_ATTEMPTS", 3))
+# Exited runs age out (canon T20 exited_at: the retention sweep is most
+# of what keeps the hot table small). Batched; leftovers go next tick.
+CRM_RUN_RETENTION_DAYS = int(os.environ.get("CRM_RUN_RETENTION_DAYS", 90))
+CRM_RUN_SWEEP_BATCH_SIZE = int(os.environ.get("CRM_RUN_SWEEP_BATCH_SIZE", 500))
+# How often the walker pauses its claim to run one sweep pass.
+CRM_RUN_SWEEP_INTERVAL_SECONDS = _positive_float(
+    "CRM_RUN_SWEEP_INTERVAL_SECONDS", 3600.0
+)

--- a/app/crm/api.py
+++ b/app/crm/api.py
@@ -14,8 +14,10 @@ because webhook ingress must stay reachable without a bearer token.
 from fastapi import APIRouter
 
 from app.crm.identity import api as identity_api
+from app.crm.outreach import api as outreach_api
 from app.crm.record import api as record_api
 
 router = APIRouter()
 router.include_router(identity_api.router, prefix="/customers", tags=["CRM Customers"])
 router.include_router(record_api.router, prefix="/customers", tags=["CRM Journey"])
+router.include_router(outreach_api.router, prefix="/workflows", tags=["CRM Workflows"])

--- a/app/crm/connectivity/contracts.py
+++ b/app/crm/connectivity/contracts.py
@@ -9,11 +9,12 @@ WhatsApp, Instagram and email are adapters behind send(), not packages.
 
 claim_sends/dispatch_send are the module's two callables for the shared
 drain-loop scaffold (design/worker-runtime.md): worker_main registers them
-as the "dispatcher" role. Small because nothing else calls in yet; the
-function that queues a message lands with the first producer. send() stays
+as the "dispatcher" role. queue_message() is how a producer (the walker's
+send node first) proposes a send: one queued row, no verdict. send() stays
 off this surface so that nothing outside can reach a provider.
 """
 
 from app.crm.connectivity.dispatch import claim_sends, dispatch_send
+from app.crm.connectivity.queue import queue_message
 
-__all__ = ["claim_sends", "dispatch_send"]
+__all__ = ["claim_sends", "dispatch_send", "queue_message"]

--- a/app/crm/connectivity/db/accessor.py
+++ b/app/crm/connectivity/db/accessor.py
@@ -3,16 +3,47 @@
 Every function self-scopes; see queries.py for why no transaction is needed.
 """
 
-from typing import List, Optional
+from typing import Any, Dict, List, Optional
 
 from app.crm.connectivity.db.decoder import decode_queued_message
 from app.crm.connectivity.db.queries import (
     apply_outcome_query,
     claim_queued_messages_query,
+    insert_message_query,
     requeue_stale_claims_query,
 )
 from app.crm.connectivity.schemas import QueuedMessage
 from app.crm.shared.db import crm_connection
+
+
+async def insert_message(
+    merchant_id: str,
+    customer_id: str,
+    channel: str,
+    sent_to_address: str,
+    source_kind: str,
+    source_id: Optional[str],
+    purpose_key: str,
+    template_id: Optional[str],
+    variables: Dict[str, Any],
+    dedupe_key: str,
+) -> Optional[str]:
+    """None = the dedupe unique absorbed it (a row already names this send)."""
+    query, values = insert_message_query(
+        merchant_id,
+        customer_id,
+        channel,
+        sent_to_address,
+        source_kind,
+        source_id,
+        purpose_key,
+        template_id,
+        variables,
+        dedupe_key,
+    )
+    async with crm_connection() as conn:
+        row = await conn.fetchrow(query, *values)
+    return str(row["id"]) if row else None
 
 
 async def claim_queued_messages(batch_size: int) -> List[QueuedMessage]:

--- a/app/crm/connectivity/db/queries.py
+++ b/app/crm/connectivity/db/queries.py
@@ -5,7 +5,8 @@ nothing here needs a transaction. The claim and the sweep are deliberately
 unscoped by merchant: one global queue, not a loop per tenant.
 """
 
-from typing import Any, List, Optional, Tuple
+import json
+from typing import Any, Dict, List, Optional, Tuple
 
 MESSAGE_TABLE = "crm_message"
 
@@ -17,6 +18,43 @@ CLAIMED_COLUMNS = """
     source_kind, source_id, purpose_key, template_id, variables,
     dedupe_key, attempt, next_attempt_at
 """
+
+
+def insert_message_query(
+    merchant_id: str,
+    customer_id: str,
+    channel: str,
+    sent_to_address: str,
+    source_kind: str,
+    source_id: Optional[str],
+    purpose_key: str,
+    template_id: Optional[str],
+    variables: Dict[str, Any],
+    dedupe_key: str,
+) -> Tuple[str, List[Any]]:
+    """One queued row, no verdict (gate-mechanics §1). The dedupe unique
+    (merchant_id, dedupe_key) absorbs a producer's retry: conflict = no
+    row returned, and the caller treats that as already queued."""
+    query = f"""
+        INSERT INTO {MESSAGE_TABLE}
+            (merchant_id, customer_id, channel, sent_to_address, source_kind,
+             source_id, purpose_key, template_id, variables, dedupe_key)
+        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9::jsonb, $10)
+        ON CONFLICT (merchant_id, dedupe_key) DO NOTHING
+        RETURNING id
+    """
+    return query, [
+        merchant_id,
+        customer_id,
+        channel,
+        sent_to_address,
+        source_kind,
+        source_id,
+        purpose_key,
+        template_id,
+        json.dumps(variables),
+        dedupe_key,
+    ]
 
 
 def claim_queued_messages_query(batch_size: int) -> Tuple[str, List[Any]]:

--- a/app/crm/connectivity/queue.py
+++ b/app/crm/connectivity/queue.py
@@ -1,0 +1,79 @@
+"""queue_message() — how anything outside connectivity proposes a send.
+
+Senders write a manifest row with status='queued' and NO verdict
+(design/gate-mechanics.md §1): the dispatcher claims it, runs the gate
+(B5, not built) and send(). This file decides what a proposed send must
+carry; the mechanics are in db/.
+
+Two code dictionaries live here because canon T16 dropped their CHECKs
+(the 027 scar: vocabulary in code, never in DDL) and named the first
+producer as the owner of the validating dictionary.
+"""
+
+from typing import Any, Dict, Optional
+
+from app.crm.connectivity.db import accessor
+from app.crm.shared.normalize import normalize_email, normalize_phone
+
+# T16 col 7. What caused the send; every funnel groups on this.
+SOURCE_KINDS = ("broadcast", "workflow", "agent", "transactional")
+
+# Channels whose address is a phone number; everything else is an email.
+_PHONE_CHANNELS = ("whatsapp", "sms", "voice", "rcs")
+
+# Purpose roots the gate's caps are set per (design/gate-mechanics.md §3);
+# the full dotted list is permission's (canon T14 CK), not ours.
+PURPOSE_ROOTS = ("marketing", "utility", "transactional", "authentication")
+
+
+def normalize_address(channel: str, address: str) -> Optional[str]:
+    """PURE: the writer normalizes (E.164 / lowercased email). A format
+    mismatch on a suppressed value is how someone who said stop gets
+    contacted, so an unparseable address is refused, never stored."""
+    if channel in _PHONE_CHANNELS:
+        return normalize_phone(address)
+    return normalize_email(address)
+
+
+def validate_proposal(source_kind: str, purpose_key: str) -> None:
+    """PURE: refuse a proposal the vocabulary does not know."""
+    if source_kind not in SOURCE_KINDS:
+        raise ValueError(f"unknown source_kind: {source_kind!r}")
+    root = purpose_key.split(".", 1)[0] if purpose_key else ""
+    if root not in PURPOSE_ROOTS:
+        raise ValueError(f"purpose_key must start with one of {PURPOSE_ROOTS}")
+
+
+async def queue_message(
+    *,
+    merchant_id: str,
+    customer_id: str,
+    channel: str,
+    address: str,
+    source_kind: str,
+    source_id: Optional[str],
+    purpose_key: str,
+    template_id: Optional[str],
+    variables: Dict[str, Any],
+    dedupe_key: str,
+) -> Optional[str]:
+    """Propose one send. Returns the new row's id, or None when
+    dedupe_key already names a row for this merchant — the producer's
+    retry was absorbed (T16 col 23), and it should carry on as if it
+    had queued. Raises ValueError on a proposal the vocabulary refuses."""
+    validate_proposal(source_kind, purpose_key)
+    sent_to = normalize_address(channel, address)
+    if sent_to is None:
+        raise ValueError(f"unusable {channel} address")
+    return await accessor.insert_message(
+        merchant_id,
+        customer_id,
+        channel,
+        sent_to,
+        source_kind,
+        source_id,
+        purpose_key,
+        template_id,
+        variables,
+        dedupe_key,
+    )

--- a/app/crm/outreach/api.py
+++ b/app/crm/outreach/api.py
@@ -1,0 +1,160 @@
+"""/crm/workflows — the admin surface for plans (W1, ADR 0007: phase 1 is
+ops/admin only; the merchant-facing builder is a console fast-follow).
+
+Thin routes per module rules §1: auth via Depends, delegate to plans.py.
+Tenancy law: merchant_id is a required query param on every route.
+"""
+
+from typing import Any, Dict, List, Literal, Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from pydantic import BaseModel, Field
+
+from app.core.logger.context import set_log_context
+from app.crm.auth import crm_admin_user
+from app.crm.outreach import plans, runs
+from app.crm.outreach.schemas import EnrollmentRun, Workflow, WorkflowSummary
+from app.schemas import UserInfo
+
+router = APIRouter()
+
+
+class WorkflowCreate(BaseModel):
+    name: str = Field(min_length=1, max_length=200)
+    definition: Dict[str, Any]
+
+
+class WorkflowStatusChange(BaseModel):
+    status: Literal["live", "paused", "archived"]
+
+
+@router.post("", response_model=Workflow, status_code=status.HTTP_201_CREATED)
+async def create_workflow_route(
+    body: WorkflowCreate,
+    merchant_id: str = Query(..., description="Tenant scope — required"),
+    current_user: UserInfo = Depends(crm_admin_user),
+) -> Workflow:
+    set_log_context(component="crm.workflows.create", merchant_id=merchant_id)
+    try:
+        return await plans.create_workflow(
+            merchant_id, body.name, body.definition, current_user.email
+        )
+    except plans.WorkflowValidationError as e:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=e.problems
+        )
+
+
+@router.get("", response_model=List[WorkflowSummary])
+async def list_workflows_route(
+    merchant_id: str = Query(..., description="Tenant scope — required"),
+    limit: int = Query(50, ge=1, le=200),
+    offset: int = Query(0, ge=0),
+    current_user: UserInfo = Depends(crm_admin_user),
+) -> List[WorkflowSummary]:
+    set_log_context(component="crm.workflows.list", merchant_id=merchant_id)
+    return await plans.list_workflows(merchant_id, limit, offset)
+
+
+@router.get("/{workflow_id}", response_model=Workflow)
+async def get_workflow_route(
+    workflow_id: str,
+    merchant_id: str = Query(..., description="Tenant scope — required"),
+    current_user: UserInfo = Depends(crm_admin_user),
+) -> Workflow:
+    set_log_context(component="crm.workflows.get", merchant_id=merchant_id)
+    workflow = await plans.get_workflow(merchant_id, workflow_id)
+    if workflow is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Workflow not found"
+        )
+    return workflow
+
+
+@router.put("/{workflow_id}/draft", response_model=Workflow)
+async def update_draft_route(
+    workflow_id: str,
+    body: WorkflowCreate,
+    merchant_id: str = Query(..., description="Tenant scope — required"),
+    current_user: UserInfo = Depends(crm_admin_user),
+) -> Workflow:
+    set_log_context(component="crm.workflows.draft", merchant_id=merchant_id)
+    try:
+        workflow = await plans.update_draft(merchant_id, workflow_id, body.definition)
+    except plans.WorkflowValidationError as e:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=e.problems
+        )
+    if workflow is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Workflow not found"
+        )
+    return workflow
+
+
+@router.post("/{workflow_id}/publish", response_model=Workflow)
+async def publish_workflow_route(
+    workflow_id: str,
+    merchant_id: str = Query(..., description="Tenant scope — required"),
+    current_user: UserInfo = Depends(crm_admin_user),
+) -> Workflow:
+    set_log_context(component="crm.workflows.publish", merchant_id=merchant_id)
+    try:
+        return await plans.publish_workflow(merchant_id, workflow_id)
+    except plans.WorkflowNotFound:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Workflow not found"
+        )
+    except plans.WorkflowValidationError as e:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=e.problems
+        )
+
+
+@router.post("/{workflow_id}/status", response_model=Workflow)
+async def set_workflow_status_route(
+    workflow_id: str,
+    body: WorkflowStatusChange,
+    merchant_id: str = Query(..., description="Tenant scope — required"),
+    current_user: UserInfo = Depends(crm_admin_user),
+) -> Workflow:
+    set_log_context(component="crm.workflows.status", merchant_id=merchant_id)
+    workflow = await plans.set_status(merchant_id, workflow_id, body.status)
+    if workflow is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Workflow not found (or archived)",
+        )
+    return workflow
+
+
+@router.get("/{workflow_id}/runs", response_model=List[EnrollmentRun])
+async def list_runs_route(
+    workflow_id: str,
+    merchant_id: str = Query(..., description="Tenant scope — required"),
+    run_status: Optional[Literal["waiting", "parked", "exited"]] = Query(
+        None, alias="status", description="parked = the triage view"
+    ),
+    limit: int = Query(50, ge=1, le=200),
+    offset: int = Query(0, ge=0),
+    current_user: UserInfo = Depends(crm_admin_user),
+) -> List[EnrollmentRun]:
+    set_log_context(component="crm.workflows.runs", merchant_id=merchant_id)
+    return await runs.list_runs(merchant_id, workflow_id, run_status, limit, offset)
+
+
+@router.post("/{workflow_id}/runs/{run_id}/resume", response_model=EnrollmentRun)
+async def resume_run_route(
+    workflow_id: str,
+    run_id: str,
+    merchant_id: str = Query(..., description="Tenant scope — required"),
+    current_user: UserInfo = Depends(crm_admin_user),
+) -> EnrollmentRun:
+    set_log_context(component="crm.workflows.resume", merchant_id=merchant_id)
+    run = await runs.resume_run(merchant_id, workflow_id, run_id)
+    if run is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Run not found, not parked, or not this merchant's",
+        )
+    return run

--- a/app/crm/outreach/contracts.py
+++ b/app/crm/outreach/contracts.py
@@ -1,0 +1,15 @@
+"""outreach module — public surface (module rules §1). The ONLY file other
+modules (and app/crm/worker_main.py) may import from app/crm/outreach.
+Logic-layer functions only, never accessors.
+
+  consume_attributed_event  — the entry-rules CONSUMER: the event worker's
+                              pass calls it per row, inside the row's
+                              savepoint, before the row's stamp.
+  claim_due_runs / walk_run — the walker's pair for the shared drain loop
+                              (CRM_ROLE=walker).
+"""
+
+from app.crm.outreach.entry import consume_attributed_event
+from app.crm.outreach.workers import claim_due_runs, walk_run
+
+__all__ = ["consume_attributed_event", "claim_due_runs", "walk_run"]

--- a/app/crm/outreach/db/__init__.py
+++ b/app/crm/outreach/db/__init__.py
@@ -1,0 +1,10 @@
+"""outreach's db layer door — the ONLY surface logic imports for db-world
+things (module rules §1): atomically() (the only boundary door), the
+opaque handle, domain-named errors. A logic file touches a handle in
+exactly ONE place: the txn parameter of an _in_txn body; accessors
+self-scope everything else. asyncpg exists only in shared/db and db/.
+"""
+
+from app.crm.shared.db import DbTxn, UniqueViolation, atomically
+
+__all__ = ["DbTxn", "UniqueViolation", "atomically"]

--- a/app/crm/outreach/db/accessor.py
+++ b/app/crm/outreach/db/accessor.py
@@ -1,0 +1,270 @@
+"""Outreach accessor — mechanical DB access ONLY (module rules §1).
+
+Executes exactly one query builder per function. Admission guards, node
+execution and publish laws live in the logic files (plans.py, enrol.py,
+walker.py, entry.py). Functions taking a ``conn`` run inside the caller's
+transaction; standalone single statements self-scope their own connection
+— the same shape as every other module's accessor.
+"""
+
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+
+import asyncpg
+
+from app.crm.outreach.db.decoder import (
+    decode_run,
+    decode_workflow,
+    decode_workflow_summary,
+)
+from app.crm.outreach.db.queries import (
+    admission_facts_query,
+    advance_run_query,
+    cancel_open_runs_query,
+    claim_due_runs_query,
+    exit_run_query,
+    get_workflow_query,
+    insert_enrollment_query,
+    insert_workflow_query,
+    list_runs_query,
+    list_workflows_query,
+    live_workflows_query,
+    occupied_nodes_query,
+    park_run_query,
+    publish_workflow_query,
+    record_run_error_query,
+    resume_run_on_event_query,
+    resume_run_query,
+    set_workflow_status_query,
+    source_event_used_query,
+    sweep_exited_runs_query,
+    update_draft_query,
+)
+from app.crm.outreach.schemas import EnrollmentRun, Workflow, WorkflowSummary
+from app.crm.shared.db import crm_connection
+
+
+async def insert_workflow(
+    merchant_id: str, name: str, draft: Dict[str, Any], created_by: Optional[str]
+) -> Workflow:
+    query, values = insert_workflow_query(merchant_id, name, draft, created_by)
+    async with crm_connection() as conn:
+        row = await conn.fetchrow(query, *values)
+    assert row is not None  # INSERT ... RETURNING always yields the row
+    return decode_workflow(row)
+
+
+async def update_draft(
+    merchant_id: str, workflow_id: str, draft: Dict[str, Any]
+) -> Optional[Workflow]:
+    query, values = update_draft_query(merchant_id, workflow_id, draft)
+    async with crm_connection() as conn:
+        row = await conn.fetchrow(query, *values)
+    return decode_workflow(row) if row else None
+
+
+async def get_workflow(merchant_id: str, workflow_id: str) -> Optional[Workflow]:
+    query, values = get_workflow_query(merchant_id, workflow_id)
+    async with crm_connection() as conn:
+        row = await conn.fetchrow(query, *values)
+    return decode_workflow(row) if row else None
+
+
+async def list_workflows(
+    merchant_id: str, limit: int, offset: int
+) -> List[WorkflowSummary]:
+    query, values = list_workflows_query(merchant_id, limit, offset)
+    async with crm_connection() as conn:
+        rows = await conn.fetch(query, *values)
+    return [decode_workflow_summary(row) for row in rows]
+
+
+async def workflow_for_publish(
+    conn: asyncpg.Connection, merchant_id: str, workflow_id: str
+) -> Optional[Workflow]:
+    """Runs inside the caller's publish atom (conn param) — the
+    validate-then-copy decision must read the same draft it publishes."""
+    query, values = get_workflow_query(merchant_id, workflow_id)
+    row = await conn.fetchrow(query, *values)
+    return decode_workflow(row) if row else None
+
+
+async def occupied_nodes(
+    conn: asyncpg.Connection, merchant_id: str, workflow_id: str
+) -> List[str]:
+    query, values = occupied_nodes_query(merchant_id, workflow_id)
+    rows = await conn.fetch(query, *values)
+    return [row["current_node"] for row in rows]
+
+
+async def apply_publish(
+    conn: asyncpg.Connection, merchant_id: str, workflow_id: str
+) -> Optional[Workflow]:
+    query, values = publish_workflow_query(merchant_id, workflow_id)
+    row = await conn.fetchrow(query, *values)
+    return decode_workflow(row) if row else None
+
+
+async def set_workflow_status(
+    merchant_id: str, workflow_id: str, status: str
+) -> Optional[Workflow]:
+    query, values = set_workflow_status_query(merchant_id, workflow_id, status)
+    async with crm_connection() as conn:
+        row = await conn.fetchrow(query, *values)
+    return decode_workflow(row) if row else None
+
+
+async def live_workflows(merchant_id: str) -> List[Workflow]:
+    query, values = live_workflows_query(merchant_id)
+    async with crm_connection() as conn:
+        rows = await conn.fetch(query, *values)
+    return [decode_workflow(row) for row in rows]
+
+
+async def admission_facts(
+    conn: asyncpg.Connection, merchant_id: str, workflow_id: str, customer_id: str
+) -> Dict[str, Any]:
+    query, values = admission_facts_query(merchant_id, workflow_id, customer_id)
+    row = await conn.fetchrow(query, *values)
+    return {
+        "runs": row["runs"] if row else 0,
+        "latest_entered_at": row["latest_entered_at"] if row else None,
+    }
+
+
+async def source_event_used(
+    conn: asyncpg.Connection,
+    merchant_id: str,
+    workflow_id: str,
+    customer_id: str,
+    source_event_id: str,
+) -> bool:
+    query, values = source_event_used_query(
+        merchant_id, workflow_id, customer_id, source_event_id
+    )
+    row = await conn.fetchrow(query, *values)
+    return bool(row["used"]) if row else False
+
+
+async def insert_enrollment(
+    conn: asyncpg.Connection,
+    merchant_id: str,
+    workflow_id: str,
+    workflow_version: int,
+    customer_id: str,
+    current_node: str,
+    wake_at: datetime,
+    context: Dict[str, Any],
+    enrollment_key: str,
+) -> EnrollmentRun:
+    query, values = insert_enrollment_query(
+        merchant_id,
+        workflow_id,
+        workflow_version,
+        customer_id,
+        current_node,
+        wake_at,
+        context,
+        enrollment_key,
+    )
+    row = await conn.fetchrow(query, *values)
+    assert row is not None  # INSERT ... RETURNING always yields the row
+    return decode_run(row)
+
+
+async def claim_due_runs(limit: int, lease_seconds: int) -> List[EnrollmentRun]:
+    """One statement — the lock, the lease push and the attempts count
+    commit together; Postgres runs it atomically, no wrapper needed."""
+    query, values = claim_due_runs_query(limit, lease_seconds)
+    async with crm_connection() as conn:
+        rows = await conn.fetch(query, *values)
+    return [decode_run(row) for row in rows]
+
+
+async def advance_run(
+    run_id: str, current_node: str, wake_at: datetime, context: Dict[str, Any]
+) -> None:
+    query, values = advance_run_query(run_id, current_node, wake_at, context)
+    async with crm_connection() as conn:
+        await conn.execute(query, *values)
+
+
+async def exit_run(
+    run_id: str,
+    exit_reason: str,
+    current_node: Optional[str] = None,
+    context: Optional[Dict[str, Any]] = None,
+) -> None:
+    query, values = exit_run_query(run_id, exit_reason, current_node, context)
+    async with crm_connection() as conn:
+        await conn.execute(query, *values)
+
+
+async def park_run(run_id: str, last_error: str) -> None:
+    query, values = park_run_query(run_id, last_error)
+    async with crm_connection() as conn:
+        await conn.execute(query, *values)
+
+
+async def record_run_error(run_id: str, last_error: str, retry_in_seconds: int) -> None:
+    query, values = record_run_error_query(run_id, last_error, retry_in_seconds)
+    async with crm_connection() as conn:
+        await conn.execute(query, *values)
+
+
+async def resume_run_on_event(
+    merchant_id: str,
+    workflow_id: str,
+    customer_id: str,
+    node_id: str,
+    context_patch: Dict[str, Any],
+) -> None:
+    query, values = resume_run_on_event_query(
+        merchant_id, workflow_id, customer_id, node_id, context_patch
+    )
+    async with crm_connection() as conn:
+        await conn.execute(query, *values)
+
+
+async def cancel_open_runs(
+    merchant_id: str,
+    workflow_id: str,
+    customer_id: str,
+    exit_reason: str,
+    occurred_at: Optional[datetime] = None,
+) -> int:
+    query, values = cancel_open_runs_query(
+        merchant_id, workflow_id, customer_id, exit_reason, occurred_at
+    )
+    async with crm_connection() as conn:
+        rows = await conn.fetch(query, *values)
+    return len(rows)
+
+
+async def list_runs(
+    merchant_id: str,
+    workflow_id: str,
+    status: Optional[str],
+    limit: int,
+    offset: int,
+) -> List[EnrollmentRun]:
+    query, values = list_runs_query(merchant_id, workflow_id, status, limit, offset)
+    async with crm_connection() as conn:
+        rows = await conn.fetch(query, *values)
+    return [decode_run(row) for row in rows]
+
+
+async def resume_run(
+    merchant_id: str, workflow_id: str, run_id: str
+) -> Optional[EnrollmentRun]:
+    query, values = resume_run_query(merchant_id, workflow_id, run_id)
+    async with crm_connection() as conn:
+        row = await conn.fetchrow(query, *values)
+    return decode_run(row) if row else None
+
+
+async def sweep_exited_runs(cutoff: datetime, batch: int) -> int:
+    query, values = sweep_exited_runs_query(cutoff, batch)
+    async with crm_connection() as conn:
+        rows = await conn.fetch(query, *values)
+    return len(rows)

--- a/app/crm/outreach/db/decoder.py
+++ b/app/crm/outreach/db/decoder.py
@@ -1,0 +1,56 @@
+"""Row -> domain shapes for the outreach module (module rules §1).
+DB-side translation only — never imported outside db/."""
+
+import json
+from typing import Any, Mapping
+
+from app.crm.outreach.schemas import EnrollmentRun, Workflow, WorkflowSummary
+
+
+def _jsonb(value: Any) -> Any:
+    """asyncpg hands jsonb back as text unless a codec is registered —
+    decode defensively, the record-module precedent."""
+    if isinstance(value, str):
+        return json.loads(value)
+    return value
+
+
+def decode_workflow_summary(row: Mapping[str, Any]) -> WorkflowSummary:
+    return WorkflowSummary(
+        id=row["id"],
+        merchant_id=row["merchant_id"],
+        name=row["name"],
+        status=row["status"],
+        version=row["version"],
+        created_by=row["created_by"],
+        created_at=row["created_at"],
+        updated_at=row["updated_at"],
+    )
+
+
+def decode_workflow(row: Mapping[str, Any]) -> Workflow:
+    return Workflow(
+        **decode_workflow_summary(row).model_dump(),
+        definition=_jsonb(row["definition"]),
+        draft=_jsonb(row["draft"]),
+    )
+
+
+def decode_run(row: Mapping[str, Any]) -> EnrollmentRun:
+    return EnrollmentRun(
+        id=row["id"],
+        merchant_id=row["merchant_id"],
+        workflow_id=row["workflow_id"],
+        workflow_version=row["workflow_version"],
+        customer_id=row["customer_id"],
+        status=row["status"],
+        current_node=row["current_node"],
+        wake_at=row["wake_at"],
+        entered_at=row["entered_at"],
+        exited_at=row["exited_at"],
+        exit_reason=row["exit_reason"],
+        context=_jsonb(row["context"]) or {},
+        enrollment_key=row["enrollment_key"],
+        attempts=row["attempts"],
+        last_error=row["last_error"],
+    )

--- a/app/crm/outreach/db/queries.py
+++ b/app/crm/outreach/db/queries.py
@@ -1,0 +1,394 @@
+"""SQL builders for crm_workflow (T19) and crm_workflow_enrollment (T20).
+$1 placeholders only — every value parameterized.
+"""
+
+import json
+from datetime import datetime
+from typing import Any, Dict, List, Optional, Tuple
+
+WORKFLOW_TABLE = "crm_workflow"
+ENROLLMENT_TABLE = "crm_workflow_enrollment"
+_WORKFLOW_SUMMARY_COLUMNS = """
+    id, merchant_id, name, status, version, created_by,
+    created_at, updated_at
+"""
+
+# Detail adds the two documents — the list never fetches them.
+_WORKFLOW_COLUMNS = _WORKFLOW_SUMMARY_COLUMNS + ", definition, draft"
+
+_RUN_COLUMNS = """
+    id, merchant_id, workflow_id, workflow_version, customer_id, status,
+    current_node, wake_at, entered_at, exited_at, exit_reason, context,
+    enrollment_key, attempts, last_error
+"""
+
+
+def insert_workflow_query(
+    merchant_id: str, name: str, draft: Dict[str, Any], created_by: Optional[str]
+) -> Tuple[str, List[Any]]:
+    """A new plan is born as a draft — the walker cannot see it until
+    publish copies draft -> definition."""
+    query = f"""
+        INSERT INTO {WORKFLOW_TABLE} (merchant_id, name, draft, created_by)
+        VALUES ($1, $2, $3::jsonb, $4)
+        RETURNING {_WORKFLOW_COLUMNS}
+    """
+    return query, [merchant_id, name, json.dumps(draft), created_by]
+
+
+def update_draft_query(
+    merchant_id: str, workflow_id: str, draft: Dict[str, Any]
+) -> Tuple[str, List[Any]]:
+    query = f"""
+        UPDATE {WORKFLOW_TABLE}
+        SET draft = $3::jsonb, updated_at = now()
+        WHERE merchant_id = $1 AND id = $2
+        RETURNING {_WORKFLOW_COLUMNS}
+    """
+    return query, [merchant_id, workflow_id, json.dumps(draft)]
+
+
+def get_workflow_query(merchant_id: str, workflow_id: str) -> Tuple[str, List[Any]]:
+    query = f"""
+        SELECT {_WORKFLOW_COLUMNS}
+        FROM {WORKFLOW_TABLE}
+        WHERE merchant_id = $1 AND id = $2
+    """
+    return query, [merchant_id, workflow_id]
+
+
+def list_workflows_query(
+    merchant_id: str, limit: int, offset: int
+) -> Tuple[str, List[Any]]:
+    query = f"""
+        SELECT {_WORKFLOW_SUMMARY_COLUMNS}
+        FROM {WORKFLOW_TABLE}
+        WHERE merchant_id = $1
+        ORDER BY created_at DESC, id DESC
+        LIMIT $2 OFFSET $3
+    """
+    return query, [merchant_id, limit, offset]
+
+
+def publish_workflow_query(merchant_id: str, workflow_id: str) -> Tuple[str, List[Any]]:
+    """Publish = copy draft -> definition, bump version (the audit stamp),
+    go/stay live. Runs inside the publish atom AFTER the validator said
+    yes — the WHERE re-checks a draft still exists so a racing publish
+    cannot double-bump."""
+    query = f"""
+        UPDATE {WORKFLOW_TABLE}
+        SET definition = draft,
+            draft = NULL,
+            version = version + 1,
+            status = CASE WHEN status = 'draft' THEN 'live' ELSE status END,
+            updated_at = now()
+        WHERE merchant_id = $1 AND id = $2 AND draft IS NOT NULL
+        RETURNING {_WORKFLOW_COLUMNS}
+    """
+    return query, [merchant_id, workflow_id]
+
+
+def set_workflow_status_query(
+    merchant_id: str, workflow_id: str, status: str
+) -> Tuple[str, List[Any]]:
+    query = f"""
+        UPDATE {WORKFLOW_TABLE}
+        SET status = $3, updated_at = now()
+        WHERE merchant_id = $1 AND id = $2 AND status <> 'archived'
+        RETURNING {_WORKFLOW_COLUMNS}
+    """
+    return query, [merchant_id, workflow_id, status]
+
+
+def live_workflows_query(merchant_id: str) -> Tuple[str, List[Any]]:
+    """The entry-rule processor's read: this merchant's live plans, on
+    the (merchant_id, status) index — the read runs once per attributed
+    event inside the event worker's pass, so it must never scan other
+    tenants' plans (nor validate them in Python)."""
+    query = f"""
+        SELECT {_WORKFLOW_COLUMNS}
+        FROM {WORKFLOW_TABLE}
+        WHERE merchant_id = $1 AND status = 'live'
+    """
+    return query, [merchant_id]
+
+
+def occupied_nodes_query(merchant_id: str, workflow_id: str) -> Tuple[str, List[Any]]:
+    """The publish validator's occupied-square read: node ids that waiting
+    or parked runs currently stand on — deleting one strands its tokens."""
+    query = f"""
+        SELECT DISTINCT current_node
+        FROM {ENROLLMENT_TABLE}
+        WHERE merchant_id = $1 AND workflow_id = $2 AND status <> 'exited'
+    """
+    return query, [merchant_id, workflow_id]
+
+
+def insert_enrollment_query(
+    merchant_id: str,
+    workflow_id: str,
+    workflow_version: int,
+    customer_id: str,
+    current_node: str,
+    wake_at: datetime,
+    context: Dict[str, Any],
+    enrollment_key: str,
+) -> Tuple[str, List[Any]]:
+    """The token is born. The partial unique (merchant, workflow, key)
+    WHERE not exited absorbs the enrol race — a UniqueViolation here
+    means 'already in flow', never an error."""
+    query = f"""
+        INSERT INTO {ENROLLMENT_TABLE}
+            (merchant_id, workflow_id, workflow_version, customer_id,
+             current_node, wake_at, context, enrollment_key)
+        VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb, $8)
+        RETURNING {_RUN_COLUMNS}
+    """
+    return query, [
+        merchant_id,
+        workflow_id,
+        workflow_version,
+        customer_id,
+        current_node,
+        wake_at,
+        json.dumps(context),
+        enrollment_key,
+    ]
+
+
+def admission_facts_query(
+    merchant_id: str, workflow_id: str, customer_id: str
+) -> Tuple[str, List[Any]]:
+    """Everything the admission guards need in one read: has she EVER run
+    this flow (reenter), when did her latest run begin (cooldown)."""
+    query = f"""
+        SELECT count(*) AS runs, max(entered_at) AS latest_entered_at
+        FROM {ENROLLMENT_TABLE}
+        WHERE merchant_id = $1 AND workflow_id = $2 AND customer_id = $3
+    """
+    return query, [merchant_id, workflow_id, customer_id]
+
+
+def source_event_used_query(
+    merchant_id: str, workflow_id: str, customer_id: str, source_event_id: str
+) -> Tuple[str, List[Any]]:
+    """Per-event idempotency for the entry processor: the window scan may
+    hand us the same event twice (at-least-once, by design); a run born
+    from it already existing — open OR exited — means skip."""
+    query = f"""
+        SELECT EXISTS (
+            SELECT 1 FROM {ENROLLMENT_TABLE}
+            WHERE merchant_id = $1 AND workflow_id = $2 AND customer_id = $3
+              AND context->>'source_event_id' = $4
+        ) AS used
+    """
+    return query, [merchant_id, workflow_id, customer_id, source_event_id]
+
+
+def claim_due_runs_query(limit: int, lease_seconds: int) -> Tuple[str, List[Any]]:
+    """The walker's claim — canon T20: wake_at is the timer AND the lease.
+    One statement: lock due tokens (SKIP LOCKED — replicas never collide),
+    push wake_at one lease window (a dead worker's row self-heals when the
+    clock passes again; no reaper), and count the claim against the run
+    (attempts++ BY the claim — a poison run that crashes its worker counts
+    against itself). A paused plan's rows are skipped, not claimed (canon
+    T19: "the sweeper skips its rows"), so a pause never burns attempts."""
+    query = f"""
+        UPDATE {ENROLLMENT_TABLE}
+        SET wake_at = now() + make_interval(secs => $2),
+            attempts = attempts + 1
+        WHERE id IN (
+            SELECT e.id FROM {ENROLLMENT_TABLE} e
+            WHERE e.status = 'waiting' AND e.wake_at <= now()
+              AND NOT EXISTS (
+                  SELECT 1 FROM {WORKFLOW_TABLE} w
+                  WHERE w.merchant_id = e.merchant_id AND w.id = e.workflow_id
+                    AND w.status = 'paused'
+              )
+            ORDER BY wake_at, id
+            LIMIT $1
+            FOR UPDATE SKIP LOCKED
+        )
+        RETURNING {_RUN_COLUMNS}
+    """
+    return query, [limit, lease_seconds]
+
+
+def advance_run_query(
+    run_id: str, current_node: str, wake_at: datetime, context: Dict[str, Any]
+) -> Tuple[str, List[Any]]:
+    """A successful step: move the token, set its next alarm, reset the
+    failure counter (only CONSECUTIVE failures park a run)."""
+    query = f"""
+        UPDATE {ENROLLMENT_TABLE}
+        SET current_node = $2, wake_at = $3, context = $4::jsonb,
+            attempts = 0, last_error = NULL
+        WHERE id = $1 AND status = 'waiting'
+    """
+    return query, [run_id, current_node, wake_at, json.dumps(context)]
+
+
+def exit_run_query(
+    run_id: str,
+    exit_reason: str,
+    current_node: Optional[str],
+    context: Optional[Dict[str, Any]],
+) -> Tuple[str, List[Any]]:
+    """An exit without a context KEEPS the row's context: the exited row's
+    pointers (source_event_id above all) are what source_event_used reads
+    to refuse a replayed entry event — wiping them would let the spine's
+    at-least-once redelivery enrol a second run from a stale checkout."""
+    query = f"""
+        UPDATE {ENROLLMENT_TABLE}
+        SET status = 'exited', exit_reason = $2, exited_at = now(),
+            wake_at = NULL,
+            current_node = COALESCE($3, current_node),
+            context = COALESCE($4::jsonb, context)
+        WHERE id = $1 AND status <> 'exited'
+    """
+    return query, [
+        run_id,
+        exit_reason,
+        current_node,
+        None if context is None else json.dumps(context),
+    ]
+
+
+def park_run_query(run_id: str, last_error: str) -> Tuple[str, List[Any]]:
+    """Errors park, never exit (canon) — held visible for the merchant,
+    resumable by a human."""
+    query = f"""
+        UPDATE {ENROLLMENT_TABLE}
+        SET status = 'parked', wake_at = NULL, last_error = $2
+        WHERE id = $1 AND status = 'waiting'
+    """
+    return query, [run_id, last_error]
+
+
+def record_run_error_query(
+    run_id: str, last_error: str, retry_in_seconds: int
+) -> Tuple[str, List[Any]]:
+    """A transient failure: the retry timer is written into wake_at (canon
+    T20: backoff with jitter), and the reason is kept for the screen."""
+    query = f"""
+        UPDATE {ENROLLMENT_TABLE}
+        SET last_error = $2,
+            wake_at = now() + make_interval(secs => $3)
+        WHERE id = $1 AND status = 'waiting'
+    """
+    return query, [run_id, last_error, retry_in_seconds]
+
+
+def resume_run_on_event_query(
+    merchant_id: str,
+    workflow_id: str,
+    customer_id: str,
+    node_id: str,
+    context_patch: Dict[str, Any],
+) -> Tuple[str, List[Any]]:
+    """W5: the reply reaches the token. Only a run still standing on the
+    listening square is touched — a late or repeated reply changes
+    nothing. The answer is recorded on the run BEFORE anything fires
+    (canon T20), and wake_at = now() hands it to the walker."""
+    query = f"""
+        UPDATE {ENROLLMENT_TABLE}
+        SET context = context || $5::jsonb, wake_at = now(), last_error = NULL
+        WHERE merchant_id = $1 AND workflow_id = $2 AND customer_id = $3
+          AND status = 'waiting' AND current_node = $4
+    """
+    return query, [
+        merchant_id,
+        workflow_id,
+        customer_id,
+        node_id,
+        json.dumps(context_patch),
+    ]
+
+
+def cancel_open_runs_query(
+    merchant_id: str,
+    workflow_id: str,
+    customer_id: str,
+    exit_reason: str,
+    occurred_at: Optional[datetime] = None,
+) -> Tuple[str, List[Any]]:
+    """Goal-cancel (canon: the goal event resolves OPEN enrolments — open
+    is waiting or parked; a parked run she has already satisfied must not
+    keep holding the open-run unique) — and the same shape ejects runs
+    when a flow is archived. Time-aware: only runs that began before the
+    goal event count, so a stale goal event redelivered later cannot end
+    a newer run; an unstamped event (occurred_at NULL) keeps today's
+    behaviour and ends every open run."""
+    query = f"""
+        UPDATE {ENROLLMENT_TABLE}
+        SET status = 'exited', exit_reason = $4, exited_at = now(),
+            wake_at = NULL
+        WHERE merchant_id = $1 AND workflow_id = $2 AND customer_id = $3
+          AND status <> 'exited'
+          AND ($5::timestamptz IS NULL OR entered_at < $5::timestamptz)
+        RETURNING id
+    """
+    return query, [merchant_id, workflow_id, customer_id, exit_reason, occurred_at]
+
+
+def list_runs_query(
+    merchant_id: str,
+    workflow_id: str,
+    status: Optional[str],
+    limit: int,
+    offset: int,
+) -> Tuple[str, List[Any]]:
+    """The ops read behind canon's 'last_error readable on the merchant's
+    screen': a flow's runs, newest first, optionally one status
+    (parked = the triage view)."""
+    status_predicate = "AND status = $3" if status else ""
+    limit_params = ("$4", "$5") if status else ("$3", "$4")
+    query = f"""
+        SELECT {_RUN_COLUMNS}
+        FROM {ENROLLMENT_TABLE}
+        WHERE merchant_id = $1 AND workflow_id = $2 {status_predicate}
+        ORDER BY entered_at DESC, id DESC
+        LIMIT {limit_params[0]} OFFSET {limit_params[1]}
+    """
+    params: List[Any] = [merchant_id, workflow_id]
+    if status:
+        params.append(status)
+    params.extend([limit, offset])
+    return query, params
+
+
+def resume_run_query(
+    merchant_id: str, workflow_id: str, run_id: str
+) -> Tuple[str, List[Any]]:
+    """Canon T20: parked runs are 'held for the merchant to see and
+    resume'. Resume = wake now, failure counter forgiven (only
+    CONSECUTIVE failures park); last_error stays visible until the next
+    successful step clears it — the human deserves to see what they
+    fixed. Only a parked run resumes; racing resumes are idempotent."""
+    query = f"""
+        UPDATE {ENROLLMENT_TABLE}
+        SET status = 'waiting', wake_at = now(), attempts = 0
+        WHERE merchant_id = $1 AND workflow_id = $2 AND id = $3
+          AND status = 'parked'
+        RETURNING {_RUN_COLUMNS}
+    """
+    return query, [merchant_id, workflow_id, run_id]
+
+
+def sweep_exited_runs_query(cutoff: datetime, batch: int) -> Tuple[str, List[Any]]:
+    """Canon T20 exited_at: 'the death clock — the retention sweep reads
+    it: exited rows age out on a partial index over exited_at, which is
+    most of what keeps the hot table small.' Batched so one sweep never
+    holds a long lock; housekeeping on the owner module's own table, all
+    tenants (the partition-drop shape, row-level)."""
+    query = f"""
+        DELETE FROM {ENROLLMENT_TABLE}
+        WHERE id IN (
+            SELECT id FROM {ENROLLMENT_TABLE}
+            WHERE status = 'exited' AND exited_at < $1
+            ORDER BY exited_at
+            LIMIT $2
+        )
+        RETURNING id
+    """
+    return query, [cutoff, batch]

--- a/app/crm/outreach/enrol.py
+++ b/app/crm/outreach/enrol.py
@@ -1,0 +1,134 @@
+"""enrol() (W2) — the ONLY creator of workflow runs, both doors (reactive
+entry rules now, broadcasts in phase 2). Admission guards are the plan's
+own words (canon: entry carries reenter + cooldown, enforced for BOTH
+doors); the open-run partial unique absorbs every race.
+
+gather (admission facts) -> decide (PURE) -> apply (insert), one atom.
+"""
+
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, Optional, Tuple
+
+from app.core.logger import logger
+from app.crm.outreach.db import DbTxn, UniqueViolation, accessor, atomically
+from app.crm.outreach.nodes import is_wait
+from app.crm.outreach.schemas import EnrollmentRun, Workflow, WorkflowDefinition
+
+
+def _admission(
+    definition: WorkflowDefinition,
+    runs: int,
+    latest_entered_at: Optional[datetime],
+    now: datetime,
+) -> Tuple[bool, str]:
+    """PURE decide: may this customer start a run? Returns (admit, reason)
+    — the reason is logged, never stored (skips-with-rows are the
+    broadcast door's T18 concern, phase 2)."""
+    if runs and not definition.entry.reenter:
+        return False, "reenter_disabled"
+    if latest_entered_at is not None and definition.entry.cooldown_hours > 0:
+        cooled_at = latest_entered_at + timedelta(hours=definition.entry.cooldown_hours)
+        if now < cooled_at:
+            return False, "cooldown_active"
+    return True, "admitted"
+
+
+def _first_wake(definition: WorkflowDefinition, now: datetime) -> datetime:
+    """Arrival scheduling: the token arrives on nodes[0]; a wait node's
+    alarm is arrival + delay, an action node's alarm is now (the canon
+    'enrolled = waiting with an immediate wake'). "Is it a wait?" is the
+    registry's answer, never a type string — a wait_event first node used
+    to fall through here and enrol with a zero listening window."""
+    first = definition.nodes[0]
+    if is_wait(first) and first.minutes:
+        return now + timedelta(minutes=first.minutes)
+    return now
+
+
+async def enrol(
+    *,
+    merchant_id: str,
+    workflow: Workflow,
+    customer_id: str,
+    context: Dict[str, Any],
+    enrollment_key: Optional[str] = None,
+) -> Optional[EnrollmentRun]:
+    """Admit one customer into one live plan. Returns the run, or None
+    when a guard (or the open-run unique) said no — a refusal is a normal
+    outcome, never an error. context carries pointers + the small facts
+    the sends need ({source_event_id, phone, ...}), never payloads."""
+    if workflow.status != "live" or not workflow.definition:
+        logger.info(
+            f"enrol skipped: workflow {workflow.id} not live "
+            f"(status={workflow.status})"
+        )
+        return None
+    definition = WorkflowDefinition.model_validate(workflow.definition)
+    try:
+        return await atomically(
+            _enrol_in_txn,
+            merchant_id,
+            workflow,
+            definition,
+            customer_id,
+            context,
+            enrollment_key or customer_id,
+        )
+    except UniqueViolation:
+        # The open-run partial unique IS the race arbiter: two entry
+        # events, one token. Already in flow — a normal outcome.
+        logger.info(
+            f"enrol skipped: open run exists (workflow {workflow.id}, "
+            f"customer {customer_id})"
+        )
+        return None
+
+
+async def _enrol_in_txn(
+    txn: DbTxn,
+    merchant_id: str,
+    workflow: Workflow,
+    definition: WorkflowDefinition,
+    customer_id: str,
+    context: Dict[str, Any],
+    enrollment_key: str,
+) -> Optional[EnrollmentRun]:
+    """ATOMIC: the admission facts and the insert share one fate — the
+    guards must judge the same history the new row joins, and the
+    source-event idempotency read must not race a sibling tick."""
+    source_event_id = context.get("source_event_id")
+    if source_event_id and await accessor.source_event_used(
+        txn, merchant_id, str(workflow.id), customer_id, str(source_event_id)
+    ):
+        return None  # this event already made its run (at-least-once scan)
+
+    facts = await accessor.admission_facts(
+        txn, merchant_id, str(workflow.id), customer_id
+    )
+    now = datetime.now(timezone.utc)
+    admit, reason = _admission(
+        definition, facts["runs"], facts["latest_entered_at"], now
+    )
+    if not admit:
+        logger.info(
+            f"enrol skipped: {reason} (workflow {workflow.id}, "
+            f"customer {customer_id})"
+        )
+        return None
+
+    run = await accessor.insert_enrollment(
+        txn,
+        merchant_id,
+        str(workflow.id),
+        workflow.version,
+        customer_id,
+        definition.nodes[0].id,
+        _first_wake(definition, now),
+        context,
+        enrollment_key,
+    )
+    logger.info(
+        f"enrolled: run {run.id} (workflow {workflow.id}, "
+        f"customer {customer_id}, node {run.current_node})"
+    )
+    return run

--- a/app/crm/outreach/entry.py
+++ b/app/crm/outreach/entry.py
@@ -1,0 +1,153 @@
+"""The entry-rules consumer (W4 + W5) — outreach's subscription on the
+event spine: an attributed event whose topic matches a LIVE plan's entry
+starts a run (enrol()); one matching a plan's goal ends open runs
+(goal-cancel); one a wait_event node listens for wakes the run standing
+on that node with the answer written in its context (W5).
+
+A consumer is a function, not a loop (worker-runtime.md): the event
+worker's pass calls consume_attributed_event() per row, inside that row's
+savepoint, before its stamp. A raise here rolls back only that row, which
+stays pending and returns next poll. Our writes commit on their own
+(enrol() opens its own atom), so a replay is safe by idempotency — the
+source-event check and the open-run unique — not by that rollback.
+"""
+
+from typing import List, Optional, Tuple
+
+from app.core.logger import logger
+from app.crm.outreach.db import accessor
+from app.crm.outreach.enrol import enrol
+from app.crm.outreach.schemas import Workflow, WorkflowDefinition, WorkflowNode
+from app.crm.record.contracts import RawEvent
+
+# Where a phone hides in an event payload, tried in order — the voice
+# mirrors use customer_mobile_number; external doors normalize to
+# customer.phone as extractors are registered per source.
+_PHONE_PATHS = ("customer_mobile_number", "phone")
+
+# Small-facts cap (canon: context carries pointers "plus the few small
+# facts the sends will need" — never payload photocopies): scalars only,
+# short values only; the full letter already lives on the event row.
+_CONTEXT_VALUE_MAX_CHARS = 256
+
+
+def _phone_from_payload(payload: dict) -> str | None:
+    for key in _PHONE_PATHS:
+        if payload.get(key):
+            return str(payload[key])
+    customer = payload.get("customer")
+    if isinstance(customer, dict) and customer.get("phone"):
+        return str(customer["phone"])
+    return None
+
+
+async def consume_attributed_event(event: RawEvent, customer_id: str) -> None:
+    """Match one just-attributed event against every live plan's entry and
+    goal topics. customer_id arrives separately: the row object still
+    carries the pre-stamp value."""
+    flows = await accessor.live_workflows(event.merchant_id)
+    entry_matches: List[Tuple[Workflow, WorkflowDefinition]] = []
+    goal_matches: List[Workflow] = []
+    listening: List[Tuple[Workflow, WorkflowNode]] = []
+    for flow in flows:
+        definition = WorkflowDefinition.model_validate(flow.definition)
+        if definition.entry.topic == event.topic and _where_matches(
+            definition.entry.where, event.payload
+        ):
+            entry_matches.append((flow, definition))
+        if event.topic in definition.goal.topics:
+            goal_matches.append(flow)
+        for node in definition.nodes:
+            if node.type == "wait_event" and event.topic in node.topics:
+                listening.append((flow, node))
+
+    # Goal first: an order arriving right behind its checkout must not
+    # cancel the run that checkout is about to start. Then replies, then
+    # entries. Time-aware: only runs that began before the goal event end
+    # (decisions §5) — a stale goal redelivered by the spine cannot end a
+    # run born after it.
+    for flow in goal_matches:
+        await accessor.cancel_open_runs(
+            event.merchant_id,
+            str(flow.id),
+            customer_id,
+            "goal_met",
+            event.occurred_at,
+        )
+    for flow, node in listening:
+        answer = event.payload.get(node.key or "")
+        await accessor.resume_run_on_event(
+            event.merchant_id,
+            str(flow.id),
+            customer_id,
+            node.id,
+            {reply_key(node.id): None if answer is None else str(answer)},
+        )
+    for flow, definition in entry_matches:
+        await _try_enrol(flow, definition, event, customer_id)
+
+
+def reply_key(node_id: str) -> str:
+    """Where a wait_event node's answer lives in the run's context."""
+    return f"reply_{node_id}"
+
+
+def _where_matches(where: dict, payload: dict) -> bool:
+    return all(payload.get(key) == value for key, value in where.items())
+
+
+def _context_from_payload(payload: dict) -> dict:
+    """The template-variable bridge: merchants send standard identity keys
+    (customer_mobile_number, customer_name) plus whatever scalar keys
+    their call template references ({item}, {cart_value}); those small
+    facts ride context -> the lead payload -> template resolution."""
+    context = {}
+    for key, value in payload.items():
+        if not isinstance(value, (str, int, float, bool)):
+            continue  # nested objects/lists stay on the event row
+        if len(str(value)) > _CONTEXT_VALUE_MAX_CHARS:
+            continue
+        context[key] = value
+    return context
+
+
+async def _try_enrol(
+    flow: Workflow, definition: WorkflowDefinition, event: RawEvent, customer_id: str
+) -> None:
+    admit, enrollment_key = _enrollment_key(definition, event, str(flow.id))
+    if not admit:
+        return  # a keyed plan without its key: a refusal, not an error
+    context = _context_from_payload(event.payload)
+    context["source_event_id"] = str(event.id)
+    phone = _phone_from_payload(event.payload)
+    if phone:
+        context["phone"] = phone
+    await enrol(
+        merchant_id=event.merchant_id,
+        workflow=flow,
+        customer_id=customer_id,
+        context=context,
+        enrollment_key=enrollment_key,
+    )
+
+
+def _enrollment_key(
+    definition: WorkflowDefinition, event: RawEvent, workflow_id: str
+) -> Tuple[bool, Optional[str]]:
+    """PURE decide: (admit, key). No entry.key -> (True, None): enrol()
+    falls back to the customer id, canon's default. entry.key set -> the
+    payload's value for it. The author declared runs are per <field>; an
+    event without that field cannot honestly start one, so it is refused
+    like any other admission miss — never silently re-keyed to the
+    customer, which would coalesce what the author said to keep apart."""
+    field = definition.entry.key
+    if not field:
+        return True, None
+    value = event.payload.get(field)
+    if value in (None, ""):
+        logger.info(
+            f"enrol skipped: entry.key {field!r} missing in payload "
+            f"(workflow {workflow_id}, event {event.id})"
+        )
+        return False, None
+    return True, str(value)

--- a/app/crm/outreach/nodes.py
+++ b/app/crm/outreach/nodes.py
@@ -1,0 +1,290 @@
+"""The node vocabulary — ONE registry (modules/05-outreach, ruled 31 Aug
+2026): every square the board speaks is one entry here, carrying the three
+things a type must answer — how the publish validator checks it, what the
+walker does when the token lands on it, and whether landing on it means
+waiting. The validator iterates NODE_TYPES, the walker dispatches through
+it, enrol() asks it for the first alarm; none of them matches type
+strings. Adding a type = one entry + one word in the schema's Literal, and
+a test pins the two together so a half-added type fails CI instead of
+shipping a walker that doesn't speak what the validator accepted.
+Precedent: record's EXTRACTORS registry.
+
+Where each action lands:
+  wait — time passes; the alarm was set on arrival (arrival scheduling).
+  wait_event — the alarm OR an event, whichever first (W5): the consumer
+         writes the answer into context[reply_<node>] and wakes the run;
+         the edge whose `on` equals the answer is taken, else "timeout".
+  call — a normal buddy lead into today's dispatch machine (ADR 0010:
+         voice stays outside the gate, governed by its existing checks —
+         DND, blacklist, calling hours), enrollment_id stamped after
+         insert (the 050 customer-stamp pattern; the accessor's created
+         hooks give the lead its customer stamp + lead.pushed mirror for
+         free). The Redis schedule nudge is deliberately skipped — the
+         dispatch reconciler heals within 60s, and outreach importing
+         app.ai for a best-effort ZADD is a coupling not worth one minute
+         of latency on a 30-minute flow.
+  send — proposes one manifest row, status queued, NO verdict
+         (gate-mechanics §1: the dispatcher gate-checks at the last
+         responsible moment). dedupe_key = run:node, so a lease retry is
+         absorbed by the manifest's unique (canon T16 col 23).
+"""
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Any, Awaitable, Callable, Dict, List, Optional
+from uuid import NAMESPACE_URL, uuid5
+
+from app.core.logger import logger
+from app.crm.connectivity.contracts import queue_message
+from app.crm.outreach.db import UniqueViolation
+from app.crm.outreach.schemas import EnrollmentRun, WorkflowDefinition, WorkflowNode
+from app.database.accessor import (
+    create_lead_call_tracker,
+    get_call_execution_config_by_template_id,
+    get_template_by_id,
+    update_lead_enrollment_id,
+)
+from app.schemas.breeze_buddy.core import ExecutionMode, LeadCallStatus
+
+# The walker's own bookkeeping in a run's context — never a template
+# variable, never a lead payload key: pointers, the phone (re-added under
+# its canonical key by the call node), per-node results and answers.
+_BOOKKEEPING_KEYS = ("source_event_id", "phone", "customer_mobile_number")
+_BOOKKEEPING_PREFIXES = ("lead_", "message_", "reply_")
+
+# Facts the lead machine consumes itself, not the template: kept in the
+# call payload, dropped from send variables.
+_LEAD_ONLY_KEYS = ("reporting_webhook_url",)
+
+# The merchant's own id for the thing this call is about. Buddy's reporter
+# echoes lead.request_id back to the merchant as orderId on every outcome
+# webhook — nautilus matches it to the Shopify order, so it must be THEIR
+# id, not ours. The run id is the fallback for a plan with no order.
+_REQUEST_ID_KEYS = ("order_id", "request_id")
+
+Validate = Callable[[WorkflowNode, WorkflowDefinition], List[str]]
+Execute = Callable[
+    [EnrollmentRun, WorkflowNode, WorkflowDefinition], Awaitable[Dict[str, Any]]
+]
+
+
+class NodeParked(Exception):
+    """A deterministic execution failure: parking is the honest outcome
+    (a missing template, a module not yet deployed). Transient failures
+    raise anything else and retry on the lease."""
+
+
+@dataclass(frozen=True)
+class NodeSpec:
+    """What one word of the vocabulary must answer. execute is None for a
+    wait: landing on it IS the action (the alarm), so is_wait and execute
+    are two views of one fact and the registry test pins them together."""
+
+    validate: Validate
+    execute: Optional[Execute]
+    is_wait: bool
+
+
+def is_wait(node: WorkflowNode) -> bool:
+    """The one place that answers "does landing here mean waiting?" —
+    enrol()'s first alarm, the walker's step and its next alarm all ask
+    this; none may match a type string."""
+    return NODE_TYPES[node.type].is_wait
+
+
+# --- validate: per-type publish laws (graph laws stay in plans.py) ---
+
+
+def _validate_wait(node: WorkflowNode, definition: WorkflowDefinition) -> List[str]:
+    if not (node.minutes and node.minutes > 0):
+        return [f"wait node {node.id} needs minutes > 0"]
+    return []
+
+
+def _validate_send(node: WorkflowNode, definition: WorkflowDefinition) -> List[str]:
+    problems = []
+    if not node.template:
+        problems.append(f"send node {node.id} needs a template")
+    if not node.channel:
+        problems.append(f"send node {node.id} needs a channel")
+    if not definition.purpose_key:
+        problems.append(
+            f"send node {node.id}: the plan needs a purpose_key "
+            "(what its sends are for, e.g. utility.order.cod_confirm)"
+        )
+    return problems
+
+
+def _validate_call(node: WorkflowNode, definition: WorkflowDefinition) -> List[str]:
+    if not node.template_id:
+        return [f"call node {node.id} needs a template_id"]
+    return []
+
+
+def _validate_wait_event(
+    node: WorkflowNode, definition: WorkflowDefinition
+) -> List[str]:
+    problems = []
+    if not (node.minutes and node.minutes > 0):
+        problems.append(f"wait_event node {node.id} needs minutes > 0")
+    if not node.topics:
+        problems.append(f"wait_event node {node.id} needs topics")
+    if not node.key:
+        problems.append(f"wait_event node {node.id} needs a payload key")
+    return problems
+
+
+# --- execute: what the walker does when the token lands ---
+
+
+async def execute_call(
+    run: EnrollmentRun, node: WorkflowNode, definition: WorkflowDefinition
+) -> Dict[str, Any]:
+    """ADR 0010: enqueue a lead into today's dispatch machine. The lead is
+    idempotent per visit via a deterministic id — a lease-retry after a
+    crash re-issues the same insert and the PK absorbs it."""
+    phone = run.context.get("phone")
+    if not phone:
+        raise NodeParked(f"call node {node.id}: no phone in run context")
+
+    template = await get_template_by_id(str(node.template_id))
+    if template is None:
+        raise NodeParked(f"call node {node.id}: template {node.template_id} not found")
+    if template.merchant_id is not None and template.merchant_id != run.merchant_id:
+        raise NodeParked(f"call node {node.id}: template belongs to another merchant")
+    config = await get_call_execution_config_by_template_id(str(template.id))
+    if config is None:
+        raise NodeParked(
+            f"call node {node.id}: no call_execution_config for template "
+            f"{template.name}"
+        )
+
+    # Deterministic per (run, node): a lease-retry after a crash between
+    # the insert and the advance re-issues the SAME id, and the PK (plus
+    # the UniqueViolation below) absorbs the duplicate — exactly-once
+    # calls without a coordination table.
+    lead_id = str(uuid5(NAMESPACE_URL, f"crm-workflow-lead:{run.id}:{node.id}"))
+
+    next_attempt_at = datetime.now(timezone.utc) + timedelta(
+        seconds=config.initial_offset
+    )
+    # The template-variable bridge: every small fact the entry processor
+    # carried (item, cart_value, ...) reaches the agent via the lead
+    # payload — {placeholder}s in the template resolve from these keys.
+    # reporting_webhook_url rides too: the lead machine reads it from the
+    # lead payload to report the call's outcome back to the merchant.
+    payload: Dict[str, Any] = run_facts(run.context)
+    payload["customer_mobile_number"] = phone
+
+    try:
+        lead = await create_lead_call_tracker(
+            id=lead_id,
+            reseller_id=template.reseller_id,
+            template=template.name,
+            template_id=str(template.id),
+            merchant_id=run.merchant_id,
+            next_attempt_at=next_attempt_at,
+            payload=payload,
+            attempt_count=0,
+            meta_data={
+                "workflow_id": str(run.workflow_id),
+                "enrollment_id": str(run.id),
+            },
+            request_id=lead_request_id(run.context, str(run.id)),
+            execution_mode=ExecutionMode.TELEPHONY,
+            status=LeadCallStatus.BACKLOG,
+        )
+        if lead is None:
+            raise RuntimeError(f"call node {node.id}: lead insert returned None")
+    except UniqueViolation:
+        logger.info(
+            f"walker: run {run.id} lead {lead_id} already exists "
+            f"(lease retry) — continuing"
+        )
+    await update_lead_enrollment_id(lead_id, str(run.id))
+    logger.info(f"walker: run {run.id} pushed lead {lead_id} (node {node.id})")
+    return {f"lead_{node.id}": lead_id}
+
+
+async def execute_send(
+    run: EnrollmentRun, node: WorkflowNode, definition: WorkflowDefinition
+) -> Dict[str, Any]:
+    """Propose the send; never call a provider (04-connectivity: one call
+    site, send(), inside connectivity). A None from queue_message means a
+    lease retry re-proposed the same run:node and the manifest already has
+    it — carry on."""
+    phone = run.context.get("phone")
+    if not phone:
+        raise NodeParked(f"send node {node.id}: no phone in run context")
+    if not (node.channel and node.template):
+        raise NodeParked(f"send node {node.id}: needs channel and template")
+    if not definition.purpose_key:
+        raise NodeParked(f"send node {node.id}: plan has no purpose_key")
+
+    dedupe_key = f"{run.id}:{node.id}"
+    try:
+        message_id = await queue_message(
+            merchant_id=run.merchant_id,
+            customer_id=str(run.customer_id),
+            channel=node.channel,
+            address=str(phone),
+            source_kind="workflow",
+            source_id=str(run.id),
+            purpose_key=definition.purpose_key,
+            template_id=node.template,
+            variables=send_variables(run.context),
+            dedupe_key=dedupe_key,
+        )
+    except ValueError as e:
+        raise NodeParked(f"send node {node.id}: {e}") from e
+    if message_id is None:
+        logger.info(
+            f"walker: run {run.id} send {dedupe_key} already queued (lease retry)"
+        )
+        return {}
+    logger.info(f"walker: run {run.id} queued message {message_id} (node {node.id})")
+    return {f"message_{node.id}": message_id}
+
+
+# --- the small pure helpers the actions share ---
+
+
+def lead_request_id(context: Dict[str, Any], run_id: str) -> str:
+    """PURE: the merchant's order/request id from the run's facts, else
+    a traceable wf-<run id>."""
+    for key in _REQUEST_ID_KEYS:
+        value = context.get(key)
+        if value not in (None, ""):
+            return str(value)
+    return f"wf-{run_id}"
+
+
+def run_facts(context: Dict[str, Any]) -> Dict[str, Any]:
+    """PURE: the run's small facts = context minus the walker's own
+    bookkeeping. The ONE filter both the call payload and the send
+    variables derive from, so they can never disagree on what is ours."""
+    return {
+        key: value
+        for key, value in context.items()
+        if key not in _BOOKKEEPING_KEYS and not key.startswith(_BOOKKEEPING_PREFIXES)
+    }
+
+
+def send_variables(context: Dict[str, Any]) -> Dict[str, Any]:
+    """PURE: the template's fill-ins = the run's facts minus what only
+    the lead machine reads."""
+    return {
+        key: value
+        for key, value in run_facts(context).items()
+        if key not in _LEAD_ONLY_KEYS
+    }
+
+
+# --- THE registry: the vocabulary, one entry per word ---
+
+NODE_TYPES: Dict[str, NodeSpec] = {
+    "wait": NodeSpec(validate=_validate_wait, execute=None, is_wait=True),
+    "send": NodeSpec(validate=_validate_send, execute=execute_send, is_wait=False),
+    "call": NodeSpec(validate=_validate_call, execute=execute_call, is_wait=False),
+    "wait_event": NodeSpec(validate=_validate_wait_event, execute=None, is_wait=True),
+}

--- a/app/crm/outreach/plans.py
+++ b/app/crm/outreach/plans.py
@@ -1,0 +1,163 @@
+"""Plan lifecycle (W1): create draft -> edit draft -> publish -> pause /
+archive. The publish validator is what makes the walker's live reads safe
+— it blocks the unsafe edit classes (canon T19): a document that strands
+waiting tokens, an edge into nowhere, vocabulary the walker doesn't speak.
+
+gather -> decide (PURE, returns the problems) -> apply.
+"""
+
+from typing import Any, Dict, List, Optional
+
+from app.core.logger import logger
+from app.crm.outreach.db import DbTxn, accessor, atomically
+from app.crm.outreach.nodes import NODE_TYPES
+from app.crm.outreach.schemas import Workflow, WorkflowDefinition, WorkflowSummary
+
+TIMEOUT = "timeout"
+
+
+def validate_definition(
+    raw: Dict[str, Any],
+    occupied_nodes: Optional[List[str]] = None,
+    live_entry: Optional[Dict[str, Any]] = None,
+) -> List[str]:
+    """PURE decide: every law the document must satisfy, as a list of
+    human-readable problems (empty = valid). occupied_nodes are the
+    squares open tokens stand on — publish must not delete one, and while
+    any exist the entry rule (live_entry) must not change under them
+    (canon T19: no changing entry semantics mid-flight).
+    """
+    try:
+        definition = WorkflowDefinition.model_validate(raw)
+    except Exception as e:  # pydantic's message is already precise
+        return [f"definition shape invalid: {e}"]
+
+    problems: List[str] = []
+    node_ids = [node.id for node in definition.nodes]
+    seen = set()
+    for node_id in node_ids:
+        if node_id in seen:
+            problems.append(f"duplicate node id: {node_id}")
+        seen.add(node_id)
+
+    # Per-type laws come from the registry (nodes.py) — the same table the
+    # walker executes from, so validator and walker cannot disagree.
+    for node in definition.nodes:
+        problems.extend(NODE_TYPES[node.type].validate(node, definition))
+
+    node_types = {node.id: node.type for node in definition.nodes}
+    for src, dst in ((edge[0], edge[1]) for edge in definition.edges):
+        if src not in seen:
+            problems.append(f"edge from unknown node: {src}")
+        if dst not in seen:
+            problems.append(f"edge to unknown node: {dst}")
+    for src, arrows in definition.outgoing().items():
+        labels = [on for _, on in arrows]
+        if node_types.get(src) == "wait_event":
+            if None in labels:
+                problems.append(f"every edge out of wait_event {src} needs an on")
+            if len(set(labels)) != len(labels):
+                problems.append(f"wait_event {src} has two edges with the same on")
+        else:
+            if any(on is not None for on in labels):
+                problems.append(f"only a wait_event node may label its edges ({src})")
+            if len(arrows) > 1:
+                problems.append(f"node {src} has {len(arrows)} outgoing edges")
+
+    if occupied_nodes and live_entry is not None:
+        if raw.get("entry") != live_entry:
+            problems.append(
+                "entry rule changed while runs are open — pause the plan and "
+                "let them finish, or publish the entry change as a new plan"
+            )
+
+    for occupied in occupied_nodes or []:
+        if occupied not in seen:
+            problems.append(
+                f"node {occupied} has waiting runs standing on it — "
+                "publishing a document without it strands every one"
+            )
+
+    return problems
+
+
+async def create_workflow(
+    merchant_id: str, name: str, definition: Dict[str, Any], created_by: Optional[str]
+) -> Workflow:
+    """A new plan is born as a draft. Shape/law problems are rejected at
+    the door — a draft may be imperfect only in ways publish will catch,
+    never in ways that break the editor."""
+    problems = validate_definition(definition)
+    if problems:
+        raise WorkflowValidationError(problems)
+    return await accessor.insert_workflow(merchant_id, name, definition, created_by)
+
+
+async def update_draft(
+    merchant_id: str, workflow_id: str, definition: Dict[str, Any]
+) -> Optional[Workflow]:
+    problems = validate_definition(definition)
+    if problems:
+        raise WorkflowValidationError(problems)
+    return await accessor.update_draft(merchant_id, workflow_id, definition)
+
+
+async def publish_workflow(merchant_id: str, workflow_id: str) -> Workflow:
+    return await atomically(_publish_in_txn, merchant_id, workflow_id)
+
+
+async def _publish_in_txn(txn: DbTxn, merchant_id: str, workflow_id: str) -> Workflow:
+    """ATOMIC: the validate and the copy share one fate — the document the
+    validator approved must be the exact document that becomes live, and
+    the occupied-squares read must not race a walker moving tokens."""
+    workflow = await accessor.workflow_for_publish(txn, merchant_id, workflow_id)
+    if workflow is None:
+        raise WorkflowNotFound(workflow_id)
+    if not workflow.draft:
+        raise WorkflowValidationError(["nothing to publish — draft is empty"])
+    occupied = await accessor.occupied_nodes(txn, merchant_id, workflow_id)
+    live_entry = (workflow.definition or {}).get("entry")
+    problems = validate_definition(
+        workflow.draft, occupied_nodes=occupied, live_entry=live_entry
+    )
+    if problems:
+        raise WorkflowValidationError(problems)
+    published = await accessor.apply_publish(txn, merchant_id, workflow_id)
+    if published is None:  # a racing publish consumed the draft first
+        raise WorkflowValidationError(["draft already published"])
+    logger.info(
+        f"workflow published: {workflow_id} v{published.version} "
+        f"(merchant {merchant_id})"
+    )
+    return published
+
+
+async def set_status(
+    merchant_id: str, workflow_id: str, status: str
+) -> Optional[Workflow]:
+    """live <-> paused, or archived (terminal). Archiving force-exits open
+    runs as 'ejected' at the walker's next claim — the paused/archived
+    check happens there, so no sweep is needed here."""
+    if status not in ("live", "paused", "archived"):
+        raise WorkflowValidationError([f"unknown status: {status}"])
+    return await accessor.set_workflow_status(merchant_id, workflow_id, status)
+
+
+async def get_workflow(merchant_id: str, workflow_id: str) -> Optional[Workflow]:
+    return await accessor.get_workflow(merchant_id, workflow_id)
+
+
+async def list_workflows(
+    merchant_id: str, limit: int, offset: int
+) -> List[WorkflowSummary]:
+    return await accessor.list_workflows(merchant_id, limit, offset)
+
+
+class WorkflowValidationError(Exception):
+    def __init__(self, problems: List[str]):
+        self.problems = problems
+        super().__init__("; ".join(problems))
+
+
+class WorkflowNotFound(Exception):
+    pass

--- a/app/crm/outreach/runs.py
+++ b/app/crm/outreach/runs.py
@@ -1,0 +1,67 @@
+"""Run operations (W2/W3 operability) — the reads and the one human verb
+canon T20 promises: runs are visible ("last_error readable on the
+merchant's screen"), parked runs are "held for the merchant to see and
+RESUME — errors never silently discard a run", and exited rows age out
+("the retention sweep reads exited_at ... most of what keeps the hot
+table small").
+
+Trivial logic today — each function is one accessor call — but api.py
+and workers.py cross through here, never db/ directly (the contracts
+seam every module keeps).
+"""
+
+from datetime import datetime, timedelta, timezone
+from typing import List, Optional
+
+from app.core.config.static import (
+    CRM_RUN_RETENTION_DAYS,
+    CRM_RUN_SWEEP_BATCH_SIZE,
+)
+from app.core.logger import logger
+from app.crm.outreach.db import accessor
+from app.crm.outreach.schemas import EnrollmentRun
+
+_LISTABLE_STATUSES = ("waiting", "parked", "exited")
+
+
+async def list_runs(
+    merchant_id: str,
+    workflow_id: str,
+    status: Optional[str],
+    limit: int,
+    offset: int,
+) -> List[EnrollmentRun]:
+    if status is not None and status not in _LISTABLE_STATUSES:
+        raise ValueError(f"unknown run status: {status}")
+    return await accessor.list_runs(merchant_id, workflow_id, status, limit, offset)
+
+
+async def resume_run(
+    merchant_id: str, workflow_id: str, run_id: str
+) -> Optional[EnrollmentRun]:
+    """Revive one parked run: wake now, failure counter forgiven. Returns
+    None when the run isn't parked (or isn't this merchant's) — the
+    walker claims it on its next tick."""
+    run = await accessor.resume_run(merchant_id, workflow_id, run_id)
+    if run:
+        logger.info(f"run resumed by operator: {run_id} (merchant {merchant_id})")
+    return run
+
+
+async def run_retention_sweep_tick() -> None:
+    """One pass of the retention sweep — housekeeping on the walker pod
+    (workers.py runs it hourly beside the drain loop). Cheap
+    when there is nothing to delete (one probe of the exited_at partial
+    index); batched so a large backlog never holds a long lock —
+    leftovers go next pass."""
+    try:
+        cutoff = datetime.now(timezone.utc) - timedelta(days=CRM_RUN_RETENTION_DAYS)
+        swept = await accessor.sweep_exited_runs(cutoff, CRM_RUN_SWEEP_BATCH_SIZE)
+        if swept:
+            logger.info(
+                f"run retention sweep: removed {swept} exited runs "
+                f"older than {CRM_RUN_RETENTION_DAYS}d"
+            )
+    except Exception as e:
+        # The sweep loop keeps calling us; a bad pass must not kill the pod.
+        logger.error(f"run retention sweep failed: {e}")

--- a/app/crm/outreach/schemas.py
+++ b/app/crm/outreach/schemas.py
@@ -1,0 +1,138 @@
+"""Leaf shapes for the outreach module (module rules §1). Imports nothing
+internal — db/decoder.py is the only place a row becomes one of these.
+
+The definition models mirror canon T19's document sections exactly:
+{entry, nodes, edges, goal, exits}. Pydantic checks SHAPE here; the graph
+LAWS (unique node ids, edges reference real nodes, branching only out of
+a wait_event node) live in plans.validate_definition — a pure decide
+function, testable without a database.
+"""
+
+from datetime import datetime
+from typing import Any, Dict, List, Literal, Optional, Tuple, Union
+from uuid import UUID
+
+from pydantic import BaseModel, Field
+
+
+class WorkflowEntry(BaseModel):
+    """Which event admits a customer, and the admission guards enforced
+    for both doors (canon: entry carries reenter + cooldown)."""
+
+    topic: str = Field(min_length=1)
+    # Optional payload condition: every key must equal (orders/create AND
+    # payload.gateway = COD). Empty = topic alone admits.
+    where: Dict[str, Any] = Field(default_factory=dict)
+    reenter: bool = False
+    cooldown_hours: float = Field(24.0, ge=0)
+    # What a run is ABOUT (canon T20 col 13, ruled 31 Aug 2026): the payload
+    # field whose value keys the open-run unique. Omitted = the customer id
+    # (bursts coalesce: one abandonment conversation); "order_id" = one run
+    # per order (WISMO: two parcels, two parallel threads).
+    key: Optional[str] = Field(None, min_length=1)
+
+
+class WorkflowGoal(BaseModel):
+    """The 'she did the thing' topics: any one of them ends every open
+    run for the customer (match=customer; keyed matching lands with the
+    WISMO-style flows)."""
+
+    topics: List[str] = Field(min_length=1)
+
+
+class WorkflowExits(BaseModel):
+    """The run's hard ceiling: entered_at + max_age_days -> timed_out."""
+
+    # > 0 or every run times out on its first claim (now - entered_at is
+    # always positive); rejected at model_validate, so publish refuses it.
+    max_age_days: float = Field(7.0, gt=0)
+
+
+class WorkflowNode(BaseModel):
+    """One square of the board. Vocabulary is code, not CHECKs:
+    wait (minutes) · send (channel + template, via connectivity) ·
+    call (template_id, via buddy's lead machine — ADR 0010) ·
+    wait_event (topics + key + minutes: waits for an event OR the timer,
+    whichever first; the branch taken is the edge whose `on` equals the
+    event's payload[key], or "timeout")."""
+
+    id: str = Field(min_length=1)
+    type: Literal["wait", "send", "call", "wait_event"]
+    minutes: Optional[float] = None
+    channel: Optional[str] = None
+    template: Optional[str] = None
+    template_id: Optional[str] = None
+    topics: List[str] = Field(default_factory=list)
+    key: Optional[str] = None
+
+
+# An arrow: [from, to] or [from, to, on]. `on` labels a branch out of a
+# wait_event node ("YES", "NO", "timeout"); every other node has one plain
+# arrow.
+WorkflowEdge = Union[Tuple[str, str], Tuple[str, str, str]]
+
+
+class WorkflowDefinition(BaseModel):
+    """THE plan, whole (canon T19). nodes[0] is the start square —
+    explicit convention, stated here once. Node ids are minted by the
+    author and never regenerated (the publish validator's first law)."""
+
+    entry: WorkflowEntry
+    nodes: List[WorkflowNode] = Field(min_length=1)
+    edges: List[WorkflowEdge] = Field(default_factory=list)
+    goal: WorkflowGoal
+    exits: WorkflowExits = Field(default_factory=WorkflowExits)
+    # What the plan's sends are for (canon T16 col 9, NOT NULL on the
+    # manifest; the gate checks it against the grant). Required once the
+    # plan has a send node; the send node copies it onto every row.
+    purpose_key: Optional[str] = None
+
+    def outgoing(self) -> Dict[str, List[Tuple[str, Optional[str]]]]:
+        """node id -> [(next node id, on)], in document order."""
+        table: Dict[str, List[Tuple[str, Optional[str]]]] = {}
+        for edge in self.edges:
+            src, dst = edge[0], edge[1]
+            on = edge[2] if len(edge) == 3 else None
+            table.setdefault(src, []).append((dst, on))
+        return table
+
+
+class WorkflowSummary(BaseModel):
+    """List shape — the jsonb documents are never fetched for lists
+    (the identity CrmCustomerSummary precedent)."""
+
+    id: UUID
+    merchant_id: str
+    name: str
+    status: str
+    version: int
+    created_by: Optional[str]
+    created_at: datetime
+    updated_at: datetime
+
+
+class Workflow(WorkflowSummary):
+    """Detail shape — carries both documents."""
+
+    definition: Optional[Dict[str, Any]]
+    draft: Optional[Dict[str, Any]]
+
+
+class EnrollmentRun(BaseModel):
+    """One person's run — the token (canon T20)."""
+
+    id: UUID
+    merchant_id: str
+    workflow_id: UUID
+    workflow_version: int
+    customer_id: UUID
+    status: str
+    current_node: str
+    wake_at: Optional[datetime]
+    entered_at: datetime
+    exited_at: Optional[datetime]
+    exit_reason: Optional[str]
+    context: Dict[str, Any]
+    enrollment_key: str
+    attempts: int
+    last_error: Optional[str]

--- a/app/crm/outreach/walker.py
+++ b/app/crm/outreach/walker.py
@@ -1,0 +1,157 @@
+"""The walker (W3) — the clock that moves tokens. NOT an engine (canon:
+"wake_at + the live document IS the engine"): claim due runs off the
+partial index, read the plan LIVE, execute the current node, write the
+next alarm. Correctness rides the wake_at lease + idempotent writes,
+never worker uniqueness — scale is replicas.
+
+The node vocabulary — what each square does when the token lands, and
+whether landing means waiting — lives in nodes.py (NODE_TYPES); the walker
+dispatches through it and never matches a type string.
+
+The goal is re-checked at every claim BEFORE acting (canon: never "did
+you forget?" to someone who just paid) — the entry processor's
+goal-cancel is the fast path; this is the belt-and-suspenders.
+"""
+
+import random
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, List, Optional, Tuple
+
+from app.core.config.static import (
+    CRM_WALKER_LEASE_SECONDS,
+    CRM_WALKER_MAX_ATTEMPTS,
+)
+from app.core.logger import logger
+from app.crm.outreach.db import accessor
+from app.crm.outreach.entry import reply_key
+from app.crm.outreach.nodes import NODE_TYPES, NodeParked, is_wait
+from app.crm.outreach.plans import TIMEOUT
+from app.crm.outreach.schemas import EnrollmentRun, WorkflowDefinition, WorkflowNode
+from app.crm.record.contracts import customer_has_event
+
+# One claim executes consecutive immediate nodes (call -> next wait) in a
+# single visit; the bound is a runaway-document guard, not a feature.
+_MAX_STEPS_PER_VISIT = 10
+
+# Transient-failure retry: exponential from the lease, capped, ±20% jitter
+# (canon T20: "backoff with jitter written into wake_at").
+_RETRY_CAP_SECONDS = 3600
+
+
+def retry_delay_seconds(attempts: int, base: int) -> int:
+    """PURE: how long the next retry waits. attempts already counts this
+    claim, so the first retry waits one base."""
+    delay = min(base * 2 ** max(attempts - 1, 0), _RETRY_CAP_SECONDS)
+    return max(1, round(delay * random.uniform(0.8, 1.2)))
+
+
+async def claim_due_runs(batch: int) -> List[EnrollmentRun]:
+    """The walker's claim for the drain loop (worker-runtime.md): the
+    wake_at lease push — one UPDATE that moves the alarm one lease window
+    forward IS the lock, so replicas never collide and a crashed claim
+    self-heals when the pushed alarm comes due again."""
+    return await accessor.claim_due_runs(batch, CRM_WALKER_LEASE_SECONDS)
+
+
+async def walk_run(run: EnrollmentRun) -> None:
+    """Move one claimed token as far as it can go this visit. The claim
+    already pushed wake_at one lease window, so every failure path below
+    retries by simply doing nothing — the clock brings the run back."""
+    try:
+        workflow = await accessor.get_workflow(run.merchant_id, str(run.workflow_id))
+        if workflow is None or workflow.status == "archived":
+            await accessor.exit_run(str(run.id), "ejected")
+            return
+        if workflow.status == "paused" or not workflow.definition:
+            return  # the lease push IS the snooze; re-checked next wake
+        definition = WorkflowDefinition.model_validate(workflow.definition)
+        await _advance(run, definition)
+    except NodeParked as e:
+        await accessor.park_run(str(run.id), str(e))
+        logger.warning(f"walker: run {run.id} parked — {e}")
+    except Exception as e:
+        if run.attempts >= CRM_WALKER_MAX_ATTEMPTS:
+            await accessor.park_run(str(run.id), f"attempts exhausted: {e}")
+            logger.error(f"walker: run {run.id} parked after retries — {e}")
+        else:
+            retry_in = retry_delay_seconds(run.attempts, CRM_WALKER_LEASE_SECONDS)
+            await accessor.record_run_error(str(run.id), str(e), retry_in)
+            logger.warning(f"walker: run {run.id} retries in {retry_in}s — {e}")
+
+
+async def _advance(run: EnrollmentRun, definition: WorkflowDefinition) -> None:
+    nodes = {node.id: node for node in definition.nodes}
+    outgoing = definition.outgoing()
+    now = datetime.now(timezone.utc)
+
+    # The hard ceiling first: a run older than the plan's max age exits
+    # timed_out no matter which square it stands on.
+    max_age = timedelta(days=definition.exits.max_age_days)
+    if now - run.entered_at > max_age:
+        await accessor.exit_run(str(run.id), "timed_out")
+        return
+
+    # Goal re-check at fire time — one indexed EXISTS via record's
+    # contract, never a foreign SELECT.
+    if await customer_has_event(
+        run.merchant_id,
+        str(run.customer_id),
+        definition.goal.topics,
+        run.entered_at,
+    ):
+        await accessor.exit_run(str(run.id), "goal_met")
+        return
+
+    current_id = run.current_node
+    context = dict(run.context)
+    for _ in range(_MAX_STEPS_PER_VISIT):
+        node = nodes.get(current_id)
+        if node is None:
+            # The publish validator forbids stranding, so this is drift
+            # (e.g. a run parked across an archive/re-create) — honest park.
+            raise NodeParked(f"node {current_id} not in live definition")
+
+        execute = NODE_TYPES[node.type].execute
+        if execute is not None:  # a wait's action IS the alarm
+            context.update(await execute(run, node, definition))
+
+        next_id = pick_next(node, outgoing.get(current_id, []), context)
+        if next_id is None:
+            await accessor.exit_run(
+                str(run.id), "completed", current_node=current_id, context=context
+            )
+            return
+
+        next_node = nodes.get(next_id)
+        if next_node is None:
+            raise NodeParked(f"edge points at unknown node {next_id}")
+        if is_wait(next_node) and next_node.minutes:
+            # Arrival scheduling: the wait's alarm starts now.
+            await accessor.advance_run(
+                str(run.id),
+                next_id,
+                datetime.now(timezone.utc) + timedelta(minutes=next_node.minutes),
+                context,
+            )
+            return
+        current_id = next_id  # action node: execute in this same visit
+
+    raise NodeParked(
+        f"{_MAX_STEPS_PER_VISIT} immediate nodes in one visit — runaway document"
+    )
+
+
+def pick_next(
+    node: WorkflowNode, arrows: List[Tuple[str, Optional[str]]], context: Dict[str, Any]
+) -> Optional[str]:
+    """PURE: which arrow leaves this square. A plain node has one. A
+    wait_event node takes the arrow labelled with its answer, or
+    "timeout" when the alarm fired first; no matching arrow = the end."""
+    if node.type != "wait_event":
+        return arrows[0][0] if arrows else None
+    answer = context.get(reply_key(node.id))
+    wanted = TIMEOUT if answer is None else answer
+    for dst, on in arrows:
+        if on == wanted:
+            return dst
+    return None

--- a/app/crm/outreach/workers.py
+++ b/app/crm/outreach/workers.py
@@ -1,0 +1,36 @@
+"""The walker role's two callables for the shared drain loop (registered
+in app/crm/worker_main.py under CRM_ROLE=walker). Loop mechanics are the
+scaffold's; this module supplies the claim (the wake_at lease push, canon
+T20) and the handler (walker.py).
+
+The retention sweep (canon T20 exited_at: "exited rows age out") is
+housekeeping on the same loop, not a second one: the claim callable runs
+one sweep pass every CRM_RUN_SWEEP_INTERVAL_SECONDS before it claims. The table's owner keeps its own
+table small, and the pod still runs exactly one loop.
+
+The entry-rules CONSUMER is deliberately not here: a consumer is a function
+the event worker's pass calls (entry.py), never a loop of ours.
+"""
+
+import time
+from typing import List
+
+from app.core.config.static import CRM_RUN_SWEEP_INTERVAL_SECONDS
+from app.crm.outreach import walker
+from app.crm.outreach.runs import run_retention_sweep_tick
+from app.crm.outreach.schemas import EnrollmentRun
+from app.crm.outreach.walker import walk_run
+
+_last_sweep_at = float("-inf")
+
+
+async def claim_due_runs(batch: int) -> List[EnrollmentRun]:
+    global _last_sweep_at
+    now = time.monotonic()
+    if now - _last_sweep_at >= CRM_RUN_SWEEP_INTERVAL_SECONDS:
+        _last_sweep_at = now
+        await run_retention_sweep_tick()
+    return await walker.claim_due_runs(batch)
+
+
+__all__ = ["claim_due_runs", "walk_run"]

--- a/app/crm/record/contracts.py
+++ b/app/crm/record/contracts.py
@@ -1,13 +1,16 @@
 """record module's public surface — the only file other modules may import
-from app/crm/record."""
+from app/crm/record.
 
+The event worker's pass (workers.py: run_pass, observe_processed_event) is
+deliberately NOT exported here. workers.py calls outreach's entry-rules
+consumer, and outreach imports this file — exporting the pass here would
+close an import cycle. app/crm/worker_main.py, the one composition root,
+takes the pass from workers.py directly.
+"""
+
+from app.crm.record.events import customer_has_event
 from app.crm.record.ingest import record_event
+from app.crm.record.schemas import RawEvent
 from app.crm.record.timeline import get_customer_journey
-from app.crm.record.workers import observe_processed_event, run_pass
 
-__all__ = [
-    "record_event",
-    "get_customer_journey",
-    "run_pass",
-    "observe_processed_event",
-]
+__all__ = ["RawEvent", "record_event", "get_customer_journey", "customer_has_event"]

--- a/app/crm/record/db/accessor.py
+++ b/app/crm/record/db/accessor.py
@@ -13,6 +13,7 @@ from app.crm.record.db import DbTxn
 from app.crm.record.db.decoder import decode_journey_card, decode_raw_event
 from app.crm.record.db.queries import (
     claim_pending_events_query,
+    customer_has_event_query,
     get_customer_journey_query,
     insert_event_query,
     quarantine_event_query,
@@ -79,3 +80,12 @@ async def get_customer_journey(
     async with crm_connection() as conn:
         rows = await conn.fetch(query, *values)
     return [decode_journey_card(row) for row in rows]
+
+
+async def customer_has_event(
+    merchant_id: str, customer_id: str, topics: List[str], since: datetime
+) -> bool:
+    query, values = customer_has_event_query(merchant_id, customer_id, topics, since)
+    async with crm_connection() as conn:
+        row = await conn.fetchrow(query, *values)
+    return bool(row["found"]) if row else False

--- a/app/crm/record/db/queries.py
+++ b/app/crm/record/db/queries.py
@@ -108,3 +108,22 @@ def get_customer_journey_query(
         LIMIT ${len(values)}
     """
     return query, values
+
+
+def customer_has_event_query(
+    merchant_id: str, customer_id: str, topics: List[str], since: datetime
+) -> Tuple[str, List[Any]]:
+    """The walker's goal re-check at fire time: did she do the thing after
+    the run began? One EXISTS on the stamped customer index. A producer
+    that omits occurred_at must not defeat the check (NULL > x is NULL,
+    never true) — the envelope's received_at stands in."""
+    query = f"""
+        SELECT EXISTS (
+            SELECT 1 FROM {EVENT_RAW_TABLE}
+            WHERE merchant_id = $1
+              AND customer_id = $2
+              AND topic = ANY($3)
+              AND COALESCE(occurred_at, received_at) > $4
+        ) AS found
+    """
+    return query, [merchant_id, customer_id, topics, since]

--- a/app/crm/record/events.py
+++ b/app/crm/record/events.py
@@ -1,0 +1,19 @@
+"""Attributed-event reads — owned by the record module, consumed by the
+outreach walker (the goal re-check at fire time).
+
+Trivial today — one query, one decode, no decisions — but contracts.py
+re-exports from here rather than db/accessor directly (the timeline.py
+seam): cross-module callers never depend on a mechanical accessor
+signature.
+"""
+
+from datetime import datetime
+from typing import List
+
+from app.crm.record.db import accessor
+
+
+async def customer_has_event(
+    merchant_id: str, customer_id: str, topics: List[str], since: datetime
+) -> bool:
+    return await accessor.customer_has_event(merchant_id, customer_id, topics, since)

--- a/app/crm/record/workers.py
+++ b/app/crm/record/workers.py
@@ -7,6 +7,7 @@ from typing import Any, Callable, Dict, List, Optional
 
 from app.core.logger import logger
 from app.crm.identity.contracts import assert_facts, resolve as crm_resolve
+from app.crm.outreach.contracts import consume_attributed_event
 from app.crm.record.db import DbTxn, accessor, atomically, savepoint
 from app.crm.record.schemas import Extracted, RawEvent
 
@@ -79,8 +80,8 @@ async def _process_one(txn: DbTxn, event: RawEvent) -> None:
 
 async def _consume_attributed_event(event: RawEvent, customer_id: str) -> None:
     """Entry-rules slot: per row, inside its savepoint, before its stamp, so a
-    poison rule costs one row per poll. No-op until outreach.contracts lands."""
-    return None
+    poison rule costs one row per poll. A raise here leaves the row pending."""
+    await consume_attributed_event(event, customer_id)
 
 
 async def _run_processor(txn: DbTxn, event: RawEvent) -> Optional[str]:

--- a/app/crm/worker_main.py
+++ b/app/crm/worker_main.py
@@ -12,7 +12,8 @@ from app.core.config.static import (
     POSTGRES_POOL_SIZE,
 )
 from app.crm.connectivity.contracts import claim_sends, dispatch_send
-from app.crm.record.contracts import observe_processed_event, run_pass
+from app.crm.outreach.contracts import claim_due_runs, walk_run
+from app.crm.record.workers import observe_processed_event, run_pass
 from app.crm.shared.worker import run_drain_loop
 
 ROLES: Dict[str, Callable[[asyncio.Event], Coroutine[Any, Any, None]]] = {
@@ -32,8 +33,14 @@ ROLES: Dict[str, Callable[[asyncio.Event], Coroutine[Any, Any, None]]] = {
         stop_event=stop_event,
         name="dispatcher",
     ),
-    # "walker" lands here when outreach/ ships — one line, per the sealed
-    # doc's own "copy the manifest" framing.
+    "walker": lambda stop_event: run_drain_loop(
+        claim_due_runs,
+        walk_run,
+        interval=CRM_WORKER_INTERVAL,
+        batch=CRM_WORKER_BATCH,
+        stop_event=stop_event,
+        name="walker",
+    ),
 }
 
 _task: Optional[asyncio.Task] = None

--- a/app/database/accessor/__init__.py
+++ b/app/database/accessor/__init__.py
@@ -49,6 +49,7 @@ from .breeze_buddy.lead_call_tracker import (
     update_lead_call_id_by_id,
     update_lead_call_initiated_time,
     update_lead_call_recording_url,
+    update_lead_enrollment_id,
     update_lead_template,
 )
 from .breeze_buddy.telephony_number import (
@@ -104,6 +105,7 @@ __all__ = [
     "delete_call_execution_config",
     "calling_activation_for_merchant",
     "create_lead_call_tracker",
+    "update_lead_enrollment_id",
     "append_metadata_field",
     "acquire_lock_on_lead_by_id",
     "release_lock_on_lead_by_id",

--- a/app/database/accessor/breeze_buddy/lead_call_tracker.py
+++ b/app/database/accessor/breeze_buddy/lead_call_tracker.py
@@ -34,6 +34,7 @@ from app.database.queries.breeze_buddy.lead_call_tracker import (
     update_lead_call_initiated_time_query,
     update_lead_call_recording_url_query,
     update_lead_customer_id_query,
+    update_lead_enrollment_id_query,
     update_lead_payload_query,
     update_lead_request_id_query,
     update_lead_template_query,
@@ -485,6 +486,20 @@ async def stamp_lead_customer(lead_id: str, customer_id: str) -> bool:
         return False
     except Exception as e:
         logger.error(f"Error stamping customer_id on lead {lead_id}: {e}")
+        return False
+
+
+async def update_lead_enrollment_id(lead_id: str, enrollment_id: str) -> bool:
+    """
+    Stamp the workflow run onto a lead (ADR 0010). False = not stamped:
+    the lead already carries a run, or the row is missing.
+    """
+    try:
+        query_text, values = update_lead_enrollment_id_query(lead_id, enrollment_id)
+        result = await run_parameterized_query(query_text, values)
+        return bool(result and get_row_count(result) > 0)
+    except Exception as e:
+        logger.error(f"Error stamping enrollment_id on lead {lead_id}: {e}")
         return False
 
 

--- a/app/database/migrations/057_create_crm_workflow.sql
+++ b/app/database/migrations/057_create_crm_workflow.sql
@@ -1,0 +1,45 @@
+-- 057: crm_workflow (canon T19, W1) — the plan: ONE document a walker
+-- reads live. Many customers walk the same one; edits reach everyone not
+-- yet past them.
+--
+-- definition jsonb is THE plan, whole: {entry, nodes, edges, goal, exits}
+-- — sections of one document, never columns. Node ids are minted once at
+-- creation and NEVER regenerated: enrollment.current_node resolves
+-- against this live document, and a regenerated id strands every waiting
+-- run (enforced by the publish validator in outreach/plans.py, not DDL —
+-- graph shape is vocabulary, and vocabulary lives in code).
+--
+-- draft is Dittofeed's two-column trick: edits land here; publish copies
+-- draft -> definition and bumps version. A half-finished edit can never
+-- become the document walkers read. version is an AUDIT stamp ("she
+-- entered under v3"), never an execution pin.
+--
+-- status CHECK is canon-mandated (T19 keys column: CK). paused = no new
+-- enrolments AND the walker skips its runs; archived = open runs
+-- force-exited as 'ejected'.
+
+CREATE TABLE crm_workflow (
+    id          uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    merchant_id text NOT NULL,
+    name        text NOT NULL,
+    definition  jsonb,
+    draft       jsonb,
+    status      text NOT NULL DEFAULT 'draft'
+                CHECK (status IN ('draft', 'live', 'paused', 'archived')),
+    version     integer NOT NULL DEFAULT 0,
+    created_by  text,
+    created_at  timestamptz NOT NULL DEFAULT now(),
+    updated_at  timestamptz NOT NULL DEFAULT now(),
+    -- a flow may only run once a published document exists
+    CHECK (status = 'draft' OR definition IS NOT NULL)
+);
+
+CREATE INDEX crm_workflow_merchant_ix ON crm_workflow (merchant_id);
+
+-- The entry-rule processor's read: live plans, per merchant, every tick.
+CREATE INDEX crm_workflow_status_ix ON crm_workflow (merchant_id, status);
+
+-- Tenant-pinned FK target (the 049 merge-FK precedent): enrollment rows
+-- reference (merchant_id, id), so a run can never point across a tenant
+-- boundary. merchant_id first per the unique-index tenancy law.
+CREATE UNIQUE INDEX crm_workflow_tenant_pin_ux ON crm_workflow (merchant_id, id);

--- a/app/database/migrations/058_create_crm_workflow_enrollment.sql
+++ b/app/database/migrations/058_create_crm_workflow_enrollment.sql
@@ -1,0 +1,86 @@
+-- 058: crm_workflow_enrollment (canon T20, W2) — one person's run through
+-- a workflow: the board-game token, the only stateful row in outreach.
+--
+-- wake_at is the timer AND the lease (canon: "this is what replaces a
+-- workflow engine"): the walker's claim pushes it forward one lease
+-- window, so a dead worker's row self-heals when the clock passes again —
+-- no reaper. The partial index below IS the walker's work queue.
+--
+-- attempts is incremented BY the claim — a poison run that crashes its
+-- worker counts against itself; exhausted -> 'parked' with last_error
+-- readable on the merchant's screen. Errors park, never exit.
+--
+-- context carries POINTERS to the spark plus the few small facts the
+-- sends need ({source_event_id, phone, ...}) — never payload photocopies;
+-- the event row already stores the letter verbatim.
+--
+-- Deliberate deviations from canon T20, each with its reason:
+--   * exit_reason adds 'completed' (canon lists goal_met · timed_out ·
+--     withdrawn · ejected): a run that executes its last node without the
+--     goal firing is finished-without-converting — the funnel's
+--     denominator. None of canon's four values is truthful for it;
+--     canon amendment proposed to Swaroop 25 Aug 2026.
+--   * the open-run unique is (merchant_id, workflow_id, enrollment_key),
+--     not canon's (workflow_id, enrollment_key) — merchant_id must be
+--     the first column of every unique index on crm_* tables (tenancy
+--     law); workflow-scoped uniqueness is preserved.
+--   * source_broadcast_id is a bare column: its canon FK targets
+--     crm_broadcast (T17), which lands in phase 2 — the FK arrives with
+--     that table's migration.
+
+CREATE TABLE crm_workflow_enrollment (
+    id                  uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    merchant_id         text NOT NULL,
+    workflow_id         uuid NOT NULL,
+    workflow_version    integer NOT NULL,
+    customer_id         uuid NOT NULL,
+    status              text NOT NULL DEFAULT 'waiting'
+                        CHECK (status IN ('waiting', 'parked', 'exited')),
+    current_node        text NOT NULL,
+    wake_at             timestamptz,
+    entered_at          timestamptz NOT NULL DEFAULT now(),
+    exited_at           timestamptz,
+    exit_reason         text
+                        CHECK (exit_reason IN
+                          ('goal_met', 'timed_out', 'withdrawn',
+                           'ejected', 'completed')),
+    context             jsonb NOT NULL DEFAULT '{}'::jsonb,
+    enrollment_key      text NOT NULL,
+    attempts            smallint NOT NULL DEFAULT 0,
+    last_error          text,
+    source_broadcast_id uuid,
+    CONSTRAINT crm_workflow_enrollment_workflow_fk
+        FOREIGN KEY (merchant_id, workflow_id)
+        REFERENCES crm_workflow (merchant_id, id),
+    -- an exited run always says why; a waiting run always has an alarm
+    CHECK (status <> 'exited' OR exit_reason IS NOT NULL),
+    CHECK (status <> 'waiting' OR wake_at IS NOT NULL)
+);
+
+CREATE INDEX crm_workflow_enrollment_merchant_ix
+    ON crm_workflow_enrollment (merchant_id);
+
+CREATE INDEX crm_workflow_enrollment_customer_ix
+    ON crm_workflow_enrollment (customer_id);
+
+-- THE walker's work queue: due tokens, keyset-ordered, nothing else.
+CREATE INDEX crm_workflow_enrollment_due_ix
+    ON crm_workflow_enrollment (wake_at, id)
+    WHERE status = 'waiting';
+
+-- One OPEN run per (workflow, key); key defaults to the customer id.
+-- Keyed runs are how two open orders get two live flows (canon).
+CREATE UNIQUE INDEX crm_workflow_enrollment_open_ux
+    ON crm_workflow_enrollment (merchant_id, workflow_id, enrollment_key)
+    WHERE status <> 'exited';
+
+-- The retention sweep's read: exited rows age out on this index — most
+-- of what keeps the hot table small (canon).
+-- Canon's IX on source_broadcast_id (the FK waits for T17, phase 2).
+CREATE INDEX crm_workflow_enrollment_broadcast_ix
+    ON crm_workflow_enrollment (merchant_id, source_broadcast_id)
+    WHERE source_broadcast_id IS NOT NULL;
+
+CREATE INDEX crm_workflow_enrollment_retention_ix
+    ON crm_workflow_enrollment (exited_at)
+    WHERE status = 'exited';

--- a/app/database/migrations/059_add_enrollment_id_to_lead_call_tracker.sql
+++ b/app/database/migrations/059_add_enrollment_id_to_lead_call_tracker.sql
@@ -1,0 +1,22 @@
+-- 059: lead_call_tracker.enrollment_id (ADR 0010, W3) — the stamp that
+-- ties a call to the workflow run that caused it.
+--
+-- One nullable column: the walker's call node creates a normal buddy lead
+-- (today's dispatch machine, unchanged — ADR 0010: voice stays outside
+-- the gate, governed by its existing checks) and stamps the run's id so
+-- funnels join runs <-> calls. NULL is truthful: every non-workflow lead
+-- (nautilus pushes, inbound, playground) never has one. Forward-only,
+-- no backfill.
+--
+-- Deliberately NO foreign key: a schema-level reference from buddy's
+-- table into a crm table would import the boundary into the DDL (the 050
+-- customer_id precedent, same reasoning).
+
+ALTER TABLE lead_call_tracker ADD COLUMN enrollment_id uuid;
+
+-- The funnel's read is WHERE enrollment_id = ANY(runs of flow X) — the
+-- partial index keeps it off the fat table's back. Plain CREATE INDEX
+-- accepted at current table size (the 050 precedent and reasoning).
+CREATE INDEX lead_call_tracker_enrollment_ix
+    ON lead_call_tracker (enrollment_id)
+    WHERE enrollment_id IS NOT NULL;

--- a/app/database/queries/breeze_buddy/lead_call_tracker.py
+++ b/app/database/queries/breeze_buddy/lead_call_tracker.py
@@ -328,6 +328,22 @@ def update_lead_call_id_by_id_query(
     return text, values
 
 
+def update_lead_enrollment_id_query(
+    lead_id: str, enrollment_id: str
+) -> Tuple[str, List[Any]]:
+    """
+    Stamp the CRM workflow run (ADR 0010) onto the lead it caused — once;
+    a lead is never re-attributed to another run.
+    """
+    text = f"""
+        UPDATE "{LEAD_CALL_TRACKER_TABLE}"
+        SET "enrollment_id" = $1, "updated_at" = NOW()
+        WHERE "id" = $2 AND "enrollment_id" IS NULL
+        RETURNING *;
+    """
+    return text, [enrollment_id, lead_id]
+
+
 def update_lead_customer_id_query(
     lead_id: str, customer_id: str
 ) -> Tuple[str, List[Any]]:

--- a/scripts/check_crm_boundaries.py
+++ b/scripts/check_crm_boundaries.py
@@ -50,6 +50,8 @@ TABLE_OWNERS = {
     "crm_event_raw": "record",
     "crm_journey_event": "record",
     "crm_message": "connectivity",
+    "crm_workflow": "outreach",
+    "crm_workflow_enrollment": "outreach",
 }
 
 # Pre-existing legacy inversions, allowlisted and CLOSED to additions

--- a/tests/crm/test_event_worker.py
+++ b/tests/crm/test_event_worker.py
@@ -37,6 +37,17 @@ from app.crm.shared.worker import run_drain_loop
 # ---------------------------------------------------------------------------
 
 
+async def _no_plans_live(event: RawEvent, customer_id: str) -> None:
+    """The entry-rules consumer with no plans live: the pass must run the
+    same with or without outreach reacting."""
+    return None
+
+
+@pytest.fixture(autouse=True)
+def _no_outreach(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(workers, "consume_attributed_event", _no_plans_live)
+
+
 class _FakeSavepoint:
     async def __aenter__(self) -> "_FakeSavepoint":
         return self

--- a/tests/crm/test_queue_message.py
+++ b/tests/crm/test_queue_message.py
@@ -1,0 +1,90 @@
+"""queue_message: the first producer's obligations — the vocabulary refuses
+what it does not know, the writer normalizes the address, and the dedupe
+unique makes a retry a no-op (None), never a second row."""
+
+import asyncio
+from typing import Any, List, Optional
+
+import pytest
+
+import app.crm.connectivity.queue as queue
+from app.crm.connectivity.db.queries import insert_message_query
+
+
+def _proposal(**overrides: Any) -> dict:
+    base = dict(
+        merchant_id="m1",
+        customer_id="c1",
+        channel="whatsapp",
+        address="98450 12345",
+        source_kind="workflow",
+        source_id="run-1",
+        purpose_key="utility.order.cod_confirm",
+        template_id="cod_confirm",
+        variables={"name": "Priya"},
+        dedupe_key="run-1:ask",
+    )
+    base.update(overrides)
+    return base
+
+
+def test_unknown_source_kind_is_refused() -> None:
+    with pytest.raises(ValueError):
+        queue.validate_proposal("cron", "utility.order")
+
+
+def test_purpose_must_start_with_a_known_root() -> None:
+    with pytest.raises(ValueError):
+        queue.validate_proposal("workflow", "cod_confirm")
+    queue.validate_proposal("workflow", "utility.order.cod_confirm")
+
+
+def test_writer_normalizes_the_address() -> None:
+    assert queue.normalize_address("whatsapp", "98450 12345") == "+919845012345"
+    assert queue.normalize_address("email", " Priya@Shop.IN ") == "priya@shop.in"
+    assert queue.normalize_address("whatsapp", "hello") is None
+
+
+def test_insert_is_a_queued_row_absorbed_by_the_dedupe_unique() -> None:
+    sql, values = insert_message_query(
+        "m1",
+        "c1",
+        "whatsapp",
+        "+919845012345",
+        "workflow",
+        "run-1",
+        "utility.order",
+        "cod_confirm",
+        {"name": "Priya"},
+        "run-1:ask",
+    )
+    assert "ON CONFLICT (merchant_id, dedupe_key) DO NOTHING" in sql
+    assert "status" not in sql  # the column default: queued, no verdict
+    assert values[-1] == "run-1:ask" and values[8] == '{"name": "Priya"}'
+
+
+def test_queue_message_returns_id_then_none_on_retry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    seen: List[str] = []
+
+    async def fake_insert(*args: Any) -> Optional[str]:
+        seen.append(args[3])  # the normalized address
+        return "msg-1" if len(seen) == 1 else None
+
+    monkeypatch.setattr(queue.accessor, "insert_message", fake_insert)
+    first = asyncio.run(queue.queue_message(**_proposal()))
+    second = asyncio.run(queue.queue_message(**_proposal()))
+    assert (first, second) == ("msg-1", None)
+    assert seen == ["+919845012345", "+919845012345"]
+
+
+def test_unusable_address_is_refused_before_any_write(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def never(*args: Any) -> Optional[str]:
+        raise AssertionError("must not write")
+
+    monkeypatch.setattr(queue.accessor, "insert_message", never)
+    with pytest.raises(ValueError):
+        asyncio.run(queue.queue_message(**_proposal(address="hello")))

--- a/tests/crm/test_worker_runtime.py
+++ b/tests/crm/test_worker_runtime.py
@@ -1,0 +1,302 @@
+"""The walker role: its registration, the hourly sweep riding its claim; and
+the entry-rules consumer: one row in,
+goal before entry, unmatched topics ignored, and a failure that propagates
+(the event worker's savepoint is what isolates it — never a swallow here)."""
+
+import asyncio
+import uuid
+from datetime import datetime, timezone
+from typing import Any, List
+
+import pytest
+
+import app.crm.outreach.entry as entry
+import app.crm.outreach.workers as outreach_workers
+from app.crm.outreach.nodes import send_variables
+from app.crm.outreach.schemas import Workflow, WorkflowDefinition
+from app.crm.outreach.walker import pick_next
+from app.crm.record.contracts import RawEvent
+from app.crm.worker_main import ROLES
+
+NOW = datetime(2026, 8, 26, 14, 0, tzinfo=timezone.utc)
+
+
+# --- the role ---
+
+
+def test_walker_is_a_registered_role() -> None:
+    assert "walker" in ROLES
+
+
+def test_claim_sweeps_once_an_hour_then_claims(monkeypatch: pytest.MonkeyPatch) -> None:
+    seen: List[str] = []
+
+    async def fake_claim(batch: int) -> List[Any]:
+        seen.append(f"claim:{batch}")
+        return []
+
+    async def fake_sweep() -> None:
+        seen.append("sweep")
+
+    monkeypatch.setattr(outreach_workers.walker, "claim_due_runs", fake_claim)
+    monkeypatch.setattr(outreach_workers, "run_retention_sweep_tick", fake_sweep)
+    monkeypatch.setattr(outreach_workers, "_last_sweep_at", float("-inf"))
+
+    async def main() -> None:
+        await outreach_workers.claim_due_runs(50)
+        await outreach_workers.claim_due_runs(50)  # within the hour: no sweep
+
+    asyncio.run(main())
+    assert seen == ["sweep", "claim:50", "claim:50"]
+
+
+# --- the consumer ---
+
+
+def _flow(topic: str = "checkout.initiated", goal: str = "order.placed") -> Workflow:
+    return Workflow(
+        id=uuid.uuid4(),
+        merchant_id="m1",
+        name="rescue",
+        status="live",
+        version=1,
+        created_by=None,
+        created_at=NOW,
+        updated_at=NOW,
+        draft=None,
+        definition={
+            "entry": {"topic": topic},
+            "nodes": [{"id": "w", "type": "wait", "minutes": 30}],
+            "edges": [],
+            "goal": {"topics": [goal]},
+        },
+    )
+
+
+def _event(topic: str, merchant_id: str = "m1") -> RawEvent:
+    return RawEvent(
+        id=str(uuid.uuid4()),
+        merchant_id=merchant_id,
+        source="lead-api",
+        topic=topic,
+        schema_version="1",
+        external_id=f"{topic}:chk-1",
+        payload={"customer_mobile_number": "+919845012345", "cart_value": 1999},
+        received_at=NOW,
+        occurred_at=NOW,
+    )
+
+
+def _wire(monkeypatch: pytest.MonkeyPatch, flow: Workflow, calls: List[Any]) -> None:
+    async def live_workflows(merchant_id: str) -> List[Workflow]:
+        # The read is tenant-scoped in SQL: another merchant sees no plans.
+        return [flow] if merchant_id == flow.merchant_id else []
+
+    async def cancel_open_runs(*args: Any) -> int:
+        calls.append(("cancel", args))
+        return 1
+
+    async def resume_run_on_event(*args: Any) -> None:
+        calls.append(("resume", args))
+
+    monkeypatch.setattr(entry.accessor, "resume_run_on_event", resume_run_on_event)
+
+    async def fake_enrol(**kwargs: Any) -> object:
+        calls.append(("enrol", kwargs))
+        return object()
+
+    monkeypatch.setattr(entry.accessor, "live_workflows", live_workflows)
+    monkeypatch.setattr(entry.accessor, "cancel_open_runs", cancel_open_runs)
+    monkeypatch.setattr(entry, "enrol", fake_enrol)
+
+
+def test_entry_topic_enrols_with_phone_and_small_facts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: List[Any] = []
+    _wire(monkeypatch, _flow(), calls)
+    event = _event("checkout.initiated")
+    asyncio.run(entry.consume_attributed_event(event, "cust-1"))
+    ((kind, kwargs),) = calls
+    assert kind == "enrol"
+    assert kwargs["customer_id"] == "cust-1"
+    assert kwargs["context"]["phone"] == "+919845012345"
+    assert kwargs["context"]["cart_value"] == 1999
+    assert kwargs["context"]["source_event_id"] == event.id
+
+
+def test_goal_topic_cancels_open_runs(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: List[Any] = []
+    _wire(monkeypatch, _flow(), calls)
+    asyncio.run(entry.consume_attributed_event(_event("order.placed"), "cust-1"))
+    assert calls[0][0] == "cancel" and calls[0][1][2] == "cust-1"
+    assert calls[0][1][4] == NOW  # the goal's occurred_at bounds the cancel
+
+
+def test_goal_runs_before_entry_when_a_topic_is_both(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: List[Any] = []
+    _wire(monkeypatch, _flow(topic="order.placed", goal="order.placed"), calls)
+    asyncio.run(entry.consume_attributed_event(_event("order.placed"), "cust-1"))
+    assert [kind for kind, _ in calls] == ["cancel", "enrol"]
+
+
+def test_unmatched_topic_and_other_merchant_do_nothing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: List[Any] = []
+    _wire(monkeypatch, _flow(), calls)
+    asyncio.run(entry.consume_attributed_event(_event("payment.refunded"), "c"))
+    asyncio.run(entry.consume_attributed_event(_event("checkout.initiated", "m2"), "c"))
+    assert calls == []
+
+
+def test_a_failure_propagates_to_the_row_savepoint(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: List[Any] = []
+    _wire(monkeypatch, _flow(), calls)
+
+    async def broken_enrol(**kwargs: Any) -> object:
+        raise RuntimeError("db hiccup")
+
+    monkeypatch.setattr(entry, "enrol", broken_enrol)
+    with pytest.raises(RuntimeError):
+        asyncio.run(entry.consume_attributed_event(_event("checkout.initiated"), "c"))
+
+
+# --- W5: entry.where and wait_event ---
+
+_COD_DEFINITION = {
+    "entry": {"topic": "orders/create", "where": {"gateway": "COD"}},
+    "nodes": [
+        {
+            "id": "ask",
+            "type": "wait_event",
+            "topics": ["button.reply"],
+            "key": "button_id",
+            "minutes": 60,
+        },
+        {"id": "confirm", "type": "wait", "minutes": 1},
+        {"id": "call", "type": "wait", "minutes": 1},
+    ],
+    "edges": [["ask", "confirm", "YES"], ["ask", "call", "timeout"]],
+    "goal": {"topics": ["order.confirmed"]},
+}
+
+
+def _cod_flow() -> Workflow:
+    flow = _flow()
+    return flow.model_copy(update={"definition": _COD_DEFINITION})
+
+
+def _event_with(topic: str, payload: dict) -> RawEvent:
+    return _event(topic).model_copy(update={"payload": payload})
+
+
+def test_entry_where_admits_only_matching_payloads(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: List[Any] = []
+    _wire(monkeypatch, _cod_flow(), calls)
+    asyncio.run(
+        entry.consume_attributed_event(
+            _event_with("orders/create", {"gateway": "prepaid"}), "c"
+        )
+    )
+    assert calls == []
+    asyncio.run(
+        entry.consume_attributed_event(
+            _event_with("orders/create", {"gateway": "COD"}), "c"
+        )
+    )
+    assert calls[0][0] == "enrol"
+
+
+def test_reply_wakes_the_run_standing_on_the_listening_node(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: List[Any] = []
+    flow = _cod_flow()
+    _wire(monkeypatch, flow, calls)
+    asyncio.run(
+        entry.consume_attributed_event(
+            _event_with("button.reply", {"button_id": "YES"}), "cust-1"
+        )
+    )
+    ((kind, args),) = calls
+    assert kind == "resume"
+    assert args == ("m1", str(flow.id), "cust-1", "ask", {"reply_ask": "YES"})
+
+
+def test_pick_next_takes_the_answer_edge_or_timeout() -> None:
+    definition = WorkflowDefinition.model_validate(_COD_DEFINITION)
+    ask = definition.nodes[0]
+    arrows = definition.outgoing()["ask"]
+    assert pick_next(ask, arrows, {"reply_ask": "YES"}) == "confirm"
+    assert pick_next(ask, arrows, {}) == "call"
+    assert pick_next(ask, arrows, {"reply_ask": "MAYBE"}) is None
+    assert pick_next(definition.nodes[1], [("call", None)], {}) == "call"
+
+
+# --- the send node proposes one manifest row ---
+
+
+def test_send_variables_are_the_small_facts_only() -> None:
+    context = {
+        "phone": "+91…",
+        "customer_mobile_number": "98450 12345",
+        "source_event_id": "e1",
+        "name": "Priya",
+        "cart_value": 1999,
+        "lead_call": "L1",
+        "message_ask": "M1",
+        "reply_reply": "YES",
+    }
+    assert send_variables(context) == {"name": "Priya", "cart_value": 1999}
+
+
+# --- entry.key: what a run is about (canon T20 col 13, ruled 31 Aug 2026) ---
+
+
+def _keyed_flow() -> Workflow:
+    flow = _flow(topic="orders/create", goal="order.confirmed")
+    definition = dict(flow.definition or {})
+    definition["entry"] = {"topic": "orders/create", "key": "order_id"}
+    return flow.model_copy(update={"definition": definition})
+
+
+def test_entry_key_hands_the_payload_field_to_enrol(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: List[Any] = []
+    _wire(monkeypatch, _keyed_flow(), calls)
+    asyncio.run(
+        entry.consume_attributed_event(
+            _event_with("orders/create", {"order_id": 4501}), "cust-1"
+        )
+    )
+    ((kind, kwargs),) = calls
+    assert kind == "enrol" and kwargs["enrollment_key"] == "4501"
+
+
+def test_no_entry_key_means_the_customer_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: List[Any] = []
+    _wire(monkeypatch, _flow(), calls)
+    asyncio.run(entry.consume_attributed_event(_event("checkout.initiated"), "c"))
+    assert calls[0][1]["enrollment_key"] is None  # enrol() -> customer id
+
+
+def test_keyed_plan_refuses_an_event_without_the_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: List[Any] = []
+    _wire(monkeypatch, _keyed_flow(), calls)
+    for payload in ({"cart_value": 1}, {"order_id": ""}, {"order_id": None}):
+        asyncio.run(
+            entry.consume_attributed_event(_event_with("orders/create", payload), "c")
+        )
+    assert calls == []

--- a/tests/crm/test_workflow_admission.py
+++ b/tests/crm/test_workflow_admission.py
@@ -1,0 +1,103 @@
+"""W2 admission guards (canon: entry carries reenter + cooldown, enforced
+for both doors) and arrival scheduling — pure decide functions."""
+
+from datetime import datetime, timedelta, timezone
+
+from app.crm.outreach.enrol import _admission, _first_wake
+from app.crm.outreach.schemas import WorkflowDefinition
+
+NOW = datetime(2026, 8, 26, 14, 0, tzinfo=timezone.utc)
+
+
+def _definition(reenter: bool = True, cooldown_hours: float = 0.0, first_node=None):
+    return WorkflowDefinition.model_validate(
+        {
+            "entry": {
+                "topic": "checkout.initiated",
+                "reenter": reenter,
+                "cooldown_hours": cooldown_hours,
+            },
+            "nodes": [
+                first_node or {"id": "wait-30m", "type": "wait", "minutes": 30},
+            ],
+            "edges": [],
+            "goal": {"topics": ["order.placed"]},
+        }
+    )
+
+
+def test_first_run_admits() -> None:
+    admit, reason = _admission(_definition(), 0, None, NOW)
+    assert admit and reason == "admitted"
+
+
+def test_reenter_disabled_blocks_second_run() -> None:
+    admit, reason = _admission(
+        _definition(reenter=False), 1, NOW - timedelta(days=2), NOW
+    )
+    assert not admit and reason == "reenter_disabled"
+
+
+def test_cooldown_blocks_inside_window() -> None:
+    admit, reason = _admission(
+        _definition(cooldown_hours=24), 1, NOW - timedelta(hours=5), NOW
+    )
+    assert not admit and reason == "cooldown_active"
+
+
+def test_cooldown_admits_after_window() -> None:
+    admit, reason = _admission(
+        _definition(cooldown_hours=24), 1, NOW - timedelta(hours=25), NOW
+    )
+    assert admit
+
+
+def test_first_wake_of_wait_node_is_arrival_plus_delay() -> None:
+    assert _first_wake(_definition(), NOW) == NOW + timedelta(minutes=30)
+
+
+def test_first_wake_of_wait_event_node_is_arrival_plus_delay() -> None:
+    # The MAJOR from the 31 Aug review: a plan whose FIRST square listens
+    # (wait_event) used to enrol with wake_at = now — the walker claimed
+    # it at once, saw no reply, took the timeout edge, and the listening
+    # window was silently zero.
+    definition = _definition(
+        first_node={
+            "id": "listen",
+            "type": "wait_event",
+            "topics": ["payment.confirmed"],
+            "key": "status",
+            "minutes": 30,
+        }
+    )
+    assert _first_wake(definition, NOW) == NOW + timedelta(minutes=30)
+
+
+def test_first_wake_of_action_node_is_immediate() -> None:
+    definition = _definition(
+        first_node={"id": "call-now", "type": "call", "template_id": "t"}
+    )
+    assert _first_wake(definition, NOW) == NOW
+
+
+def test_context_passthrough_keeps_scalars_drops_structures() -> None:
+    """The template-variable bridge: standard identity keys + the
+    merchant's scalar facts ride to the lead payload; nested payload
+    stays on the event row (pointers, not photocopies)."""
+    from app.crm.outreach.entry import _context_from_payload
+
+    context = _context_from_payload(
+        {
+            "customer_mobile_number": "+919845012345",
+            "customer_name": "Priya",
+            "item": "washing machine",
+            "cart_value": 3499,
+            "gift_wrap": True,
+            "line_items": [{"sku": "WM-1"}],  # nested -> dropped
+            "huge": "x" * 500,  # oversized -> dropped
+        }
+    )
+    assert context["item"] == "washing machine"
+    assert context["cart_value"] == 3499
+    assert context["gift_wrap"] is True
+    assert "line_items" not in context and "huge" not in context

--- a/tests/crm/test_workflow_decoder.py
+++ b/tests/crm/test_workflow_decoder.py
@@ -1,0 +1,56 @@
+"""Row -> shape translation for the outreach module, including the
+jsonb-as-text defensive path (the record-module precedent)."""
+
+import json
+from datetime import datetime, timezone
+from uuid import uuid4
+
+from app.crm.outreach.db.decoder import decode_run, decode_workflow
+
+NOW = datetime(2026, 8, 26, 14, 0, tzinfo=timezone.utc)
+
+
+def test_decode_run_parses_string_context() -> None:
+    run_id, wf_id, cust_id = uuid4(), uuid4(), uuid4()
+    row = {
+        "id": run_id,
+        "merchant_id": "m1",
+        "workflow_id": wf_id,
+        "workflow_version": 3,
+        "customer_id": cust_id,
+        "status": "waiting",
+        "current_node": "wait-30m",
+        "wake_at": NOW,
+        "entered_at": NOW,
+        "exited_at": None,
+        "exit_reason": None,
+        "context": json.dumps({"source_event_id": "e-501", "phone": "+91"}),
+        "enrollment_key": str(cust_id),
+        "attempts": 0,
+        "last_error": None,
+    }
+    run = decode_run(row)
+    assert run.context["phone"] == "+91"
+    assert run.customer_id == cust_id
+    assert run.status == "waiting"
+
+
+def test_decode_workflow_carries_both_documents() -> None:
+    wf_id = uuid4()
+    definition = {"entry": {"topic": "t"}, "nodes": []}
+    row = {
+        "id": wf_id,
+        "merchant_id": "m1",
+        "name": "checkout-rescue",
+        "status": "live",
+        "version": 3,
+        "created_by": "ops@x",
+        "created_at": NOW,
+        "updated_at": NOW,
+        "definition": json.dumps(definition),
+        "draft": None,
+    }
+    workflow = decode_workflow(row)
+    assert workflow.definition == definition
+    assert workflow.draft is None
+    assert workflow.version == 3

--- a/tests/crm/test_workflow_nodes.py
+++ b/tests/crm/test_workflow_nodes.py
@@ -1,0 +1,32 @@
+"""The node vocabulary registry (modules/05-outreach, ruled 31 Aug 2026):
+the schema's Literal and NODE_TYPES are two halves of one language, pinned
+together here so a type added to only one side fails CI."""
+
+from typing import get_args
+
+from app.crm.outreach.nodes import NODE_TYPES, is_wait
+from app.crm.outreach.schemas import WorkflowNode
+
+
+def _literal_words() -> set:
+    return set(get_args(WorkflowNode.model_fields["type"].annotation))
+
+
+def test_registry_and_schema_literal_speak_the_same_words() -> None:
+    assert set(NODE_TYPES) == _literal_words()
+
+
+def test_a_wait_has_no_action_and_an_action_is_not_a_wait() -> None:
+    # is_wait and execute are two views of one fact: landing on a wait IS
+    # the action (the alarm); every other type must do something.
+    for word, spec in NODE_TYPES.items():
+        assert spec.is_wait == (spec.execute is None), word
+        assert callable(spec.validate), word
+
+
+def test_is_wait_answers_for_every_word() -> None:
+    answers = {
+        word: is_wait(WorkflowNode(id="n", type=word))  # type: ignore[arg-type]
+        for word in NODE_TYPES
+    }
+    assert answers == {"wait": True, "wait_event": True, "send": False, "call": False}

--- a/tests/crm/test_workflow_plans.py
+++ b/tests/crm/test_workflow_plans.py
@@ -1,0 +1,205 @@
+"""W1 publish-validator laws: the exact edit classes canon T19 says the
+validator must block, each as a red test."""
+
+from app.crm.outreach.plans import validate_definition
+
+
+def _definition(**overrides):
+    base = {
+        "entry": {"topic": "checkout.initiated", "reenter": True, "cooldown_hours": 0},
+        "nodes": [
+            {"id": "wait-30m", "type": "wait", "minutes": 30},
+            {"id": "rescue-call", "type": "call", "template_id": "tpl-1"},
+        ],
+        "edges": [["wait-30m", "rescue-call"]],
+        "goal": {"topics": ["order.placed"]},
+    }
+    base.update(overrides)
+    return base
+
+
+def test_valid_definition_passes() -> None:
+    assert validate_definition(_definition()) == []
+
+
+def test_duplicate_node_ids_fail() -> None:
+    problems = validate_definition(
+        _definition(
+            nodes=[
+                {"id": "a", "type": "wait", "minutes": 5},
+                {"id": "a", "type": "call", "template_id": "t"},
+            ],
+            edges=[],
+        )
+    )
+    assert any("duplicate node id" in p for p in problems)
+
+
+def test_edge_to_unknown_node_fails() -> None:
+    problems = validate_definition(_definition(edges=[["wait-30m", "ghost"]]))
+    assert any("unknown node: ghost" in p for p in problems)
+
+
+def test_two_plain_edges_out_of_one_node_fail() -> None:
+    problems = validate_definition(
+        _definition(
+            nodes=[
+                {"id": "a", "type": "wait", "minutes": 1},
+                {"id": "b", "type": "wait", "minutes": 1},
+                {"id": "c", "type": "wait", "minutes": 1},
+            ],
+            edges=[["a", "b"], ["a", "c"]],
+        )
+    )
+    assert any("2 outgoing edges" in p for p in problems)
+
+
+def test_wait_without_minutes_fails() -> None:
+    problems = validate_definition(
+        _definition(nodes=[{"id": "w", "type": "wait"}], edges=[])
+    )
+    assert any("needs minutes" in p for p in problems)
+
+
+def test_call_without_template_id_fails() -> None:
+    problems = validate_definition(
+        _definition(nodes=[{"id": "c", "type": "call"}], edges=[])
+    )
+    assert any("needs a template_id" in p for p in problems)
+
+
+def test_send_without_template_fails() -> None:
+    problems = validate_definition(
+        _definition(nodes=[{"id": "s", "type": "send"}], edges=[])
+    )
+    assert any("needs a template" in p for p in problems)
+
+
+def test_unknown_node_type_fails_shape() -> None:
+    problems = validate_definition(
+        _definition(nodes=[{"id": "x", "type": "teleport"}], edges=[])
+    )
+    assert any("shape invalid" in p for p in problems)
+
+
+def test_exit_ceiling_must_be_positive() -> None:
+    for bad in (0, -1):
+        problems = validate_definition(_definition(exits={"max_age_days": bad}))
+        assert problems and "shape invalid" in problems[0]
+    assert validate_definition(_definition(exits={"max_age_days": 0.5})) == []
+
+
+def test_cooldown_cannot_be_negative() -> None:
+    entry = {"topic": "checkout.initiated", "reenter": True, "cooldown_hours": -1}
+    problems = validate_definition(_definition(entry=entry))
+    assert problems and "shape invalid" in problems[0]
+
+
+def test_occupied_node_deletion_fails() -> None:
+    """The stranding law: a document that removes a square waiting tokens
+    stand on must not publish."""
+    problems = validate_definition(_definition(), occupied_nodes=["old-node"])
+    assert any("waiting runs standing on it" in p for p in problems)
+
+
+def test_occupied_node_kept_passes() -> None:
+    assert validate_definition(_definition(), occupied_nodes=["wait-30m"]) == []
+
+
+def test_publish_refuses_an_entry_change_while_runs_are_open() -> None:
+    draft = {
+        "entry": {"topic": "cart.abandoned"},
+        "nodes": [{"id": "w", "type": "wait", "minutes": 30}],
+        "edges": [],
+        "goal": {"topics": ["order.placed"]},
+    }
+    live_entry = {"topic": "checkout.initiated"}
+    assert validate_definition(draft, occupied_nodes=["w"], live_entry=live_entry)
+    assert not validate_definition(draft, occupied_nodes=[], live_entry=live_entry)
+    assert not validate_definition(draft, occupied_nodes=["w"], live_entry=None)
+
+
+_COD = {
+    "entry": {"topic": "orders/create", "where": {"gateway": "COD"}},
+    "nodes": [
+        {
+            "id": "ask",
+            "type": "wait_event",
+            "topics": ["button.reply"],
+            "key": "button_id",
+            "minutes": 60,
+        },
+        {"id": "confirm", "type": "wait", "minutes": 1},
+        {"id": "call", "type": "wait", "minutes": 1},
+    ],
+    "edges": [["ask", "confirm", "YES"], ["ask", "call", "timeout"]],
+    "goal": {"topics": ["order.confirmed"]},
+}
+
+
+def test_wait_event_with_labelled_edges_passes() -> None:
+    assert validate_definition(_COD) == []
+
+
+def test_wait_event_needs_topics_key_and_minutes() -> None:
+    bad = {**_COD, "nodes": [{"id": "ask", "type": "wait_event"}, *_COD["nodes"][1:]]}
+    problems = validate_definition(bad)
+    assert any("needs minutes" in p for p in problems)
+    assert any("needs topics" in p for p in problems)
+    assert any("needs a payload key" in p for p in problems)
+
+
+def test_edges_out_of_wait_event_must_be_labelled_and_distinct() -> None:
+    unlabelled = {**_COD, "edges": [["ask", "confirm"]]}
+    assert any("needs an on" in p for p in validate_definition(unlabelled))
+    twice = {**_COD, "edges": [["ask", "confirm", "YES"], ["ask", "call", "YES"]]}
+    assert any("same on" in p for p in validate_definition(twice))
+
+
+def test_only_wait_event_may_label_edges() -> None:
+    bad = {**_COD, "edges": [["ask", "confirm", "YES"], ["confirm", "call", "YES"]]}
+    assert any("only a wait_event" in p for p in validate_definition(bad))
+
+
+def test_send_node_needs_channel_and_a_plan_purpose() -> None:
+    bare = _definition(
+        nodes=[{"id": "ask", "type": "send", "template": "cod_confirm"}], edges=[]
+    )
+    problems = validate_definition(bare)
+    assert any("needs a channel" in p for p in problems)
+    assert any("purpose_key" in p for p in problems)
+    full = _definition(
+        nodes=[
+            {
+                "id": "ask",
+                "type": "send",
+                "template": "cod_confirm",
+                "channel": "whatsapp",
+            }
+        ],
+        edges=[],
+        purpose_key="utility.order.cod_confirm",
+    )
+    assert validate_definition(full) == []
+
+
+def test_entry_key_is_document_vocabulary() -> None:
+    keyed = {
+        "topic": "checkout.initiated",
+        "reenter": True,
+        "cooldown_hours": 0,
+        "key": "order_id",
+    }
+    assert validate_definition(_definition(entry=keyed)) == []
+    empty = {**keyed, "key": ""}
+    problems = validate_definition(_definition(entry=empty))
+    assert problems and "shape invalid" in problems[0]
+
+
+def test_changing_entry_key_mid_flight_is_blocked() -> None:
+    live_entry = {"topic": "checkout.initiated", "reenter": True, "cooldown_hours": 0}
+    keyed = {**live_entry, "key": "order_id"}
+    problems = validate_definition(
+        _definition(entry=keyed), occupied_nodes=["wait-30m"], live_entry=live_entry
+    )
+    assert any("entry rule changed" in p for p in problems)

--- a/tests/crm/test_workflow_queries.py
+++ b/tests/crm/test_workflow_queries.py
@@ -1,0 +1,111 @@
+"""Query-builder laws for the outreach module: $1 params only, tenancy
+predicates present, the claim's lease semantics, idempotent stamps."""
+
+import json
+from datetime import datetime, timezone
+
+from app.crm.outreach.db.queries import (
+    admission_facts_query,
+    cancel_open_runs_query,
+    claim_due_runs_query,
+    exit_run_query,
+    insert_enrollment_query,
+    live_workflows_query,
+    park_run_query,
+    publish_workflow_query,
+    record_run_error_query,
+    source_event_used_query,
+)
+from app.crm.record.db.queries import customer_has_event_query
+
+NOW = datetime(2026, 8, 26, 14, 0, tzinfo=timezone.utc)
+
+
+def test_claim_is_lease_and_attempt_in_one_statement() -> None:
+    sql, params = claim_due_runs_query(25, 300)
+    assert "FOR UPDATE SKIP LOCKED" in sql
+    assert "make_interval(secs => $2)" in sql
+    assert "attempts = attempts + 1" in sql
+    assert "e.status = 'waiting' AND e.wake_at <= now()" in sql
+    assert params == [25, 300]
+
+
+def test_enrollment_insert_binds_everything_positionally() -> None:
+    sql, params = insert_enrollment_query(
+        "m1", "wf-1", 3, "c-1", "wait-30m", NOW, {"phone": "+91"}, "c-1"
+    )
+    assert "$8" in sql and "$9" not in sql
+    assert params[0] == "m1"  # merchant first — tenancy reads first
+    assert json.loads(params[6]) == {"phone": "+91"}
+
+
+def test_goal_cancel_ends_every_open_run_including_parked() -> None:
+    sql, params = cancel_open_runs_query("m1", "wf-1", "c-1", "goal_met")
+    assert "status <> 'exited'" in sql and "status = 'waiting'" not in sql
+    assert params[0] == "m1"
+
+
+def test_goal_cancel_is_time_aware_and_null_safe() -> None:
+    sql, params = cancel_open_runs_query("m1", "wf-1", "c-1", "goal_met", NOW)
+    assert "$5::timestamptz IS NULL OR entered_at < $5::timestamptz" in sql
+    assert params[4] == NOW
+    _, params = cancel_open_runs_query("m1", "wf-1", "c-1", "goal_met")
+    assert params[4] is None  # unstamped goal keeps today's behaviour
+
+
+def test_live_workflows_read_is_merchant_scoped() -> None:
+    sql, params = live_workflows_query("m1")
+    assert "merchant_id = $1 AND status = 'live'" in sql
+    assert params == ["m1"]
+
+
+def test_publish_requires_a_draft_to_exist() -> None:
+    sql, _ = publish_workflow_query("m1", "wf-1")
+    assert "draft IS NOT NULL" in sql
+    assert "version = version + 1" in sql
+
+
+def test_park_only_moves_waiting_runs() -> None:
+    sql, _ = park_run_query("en-1", "boom")
+    assert "status = 'waiting'" in sql and "'parked'" in sql
+
+
+def test_exit_never_reexits() -> None:
+    sql, _ = exit_run_query("en-1", "completed", None, {})
+    assert "status <> 'exited'" in sql
+
+
+def test_exit_without_context_keeps_the_rows_pointers() -> None:
+    sql, params = exit_run_query("en-1", "goal_met", None, None)
+    assert "context = COALESCE($4::jsonb, context)" in sql
+    assert params[3] is None  # NULL -> COALESCE keeps source_event_id
+    _, params = exit_run_query("en-1", "completed", "n1", {"reply_x": "YES"})
+    assert json.loads(params[3]) == {"reply_x": "YES"}
+
+
+def test_admission_and_source_reads_are_merchant_first() -> None:
+    for sql, params in (
+        admission_facts_query("m1", "wf-1", "c-1"),
+        source_event_used_query("m1", "wf-1", "c-1", "e-1"),
+    ):
+        assert "merchant_id = $1" in sql
+        assert params[0] == "m1"
+
+
+def test_claim_skips_paused_plans_and_counts_the_claim() -> None:
+    sql, values = claim_due_runs_query(50, 300)
+    assert "w.status = 'paused'" in sql and "NOT EXISTS" in sql
+    assert "attempts = attempts + 1" in sql
+    assert values == [50, 300]
+
+
+def test_transient_error_writes_the_retry_into_wake_at() -> None:
+    sql, values = record_run_error_query("r-1", "boom", 600)
+    assert "wake_at = now() + make_interval(secs => $3)" in sql
+    assert values == ["r-1", "boom", 600]
+
+
+def test_goal_recheck_survives_a_null_occurred_at() -> None:
+    sql, params = customer_has_event_query("m1", "c-1", ["order.placed"], NOW)
+    assert "COALESCE(occurred_at, received_at) > $4" in sql
+    assert params == ["m1", "c-1", ["order.placed"], NOW]

--- a/tests/crm/test_workflow_runs.py
+++ b/tests/crm/test_workflow_runs.py
@@ -1,0 +1,82 @@
+"""Run-operations laws: resume touches only parked rows, the sweep only
+old exited rows (batched), the list is merchant-first."""
+
+from datetime import datetime, timezone
+
+import pytest
+
+from app.crm.outreach.db.queries import (
+    list_runs_query,
+    resume_run_query,
+    sweep_exited_runs_query,
+)
+from app.crm.outreach.nodes import lead_request_id, run_facts, send_variables
+from app.crm.outreach.runs import list_runs
+from app.crm.outreach.walker import retry_delay_seconds
+
+NOW = datetime(2026, 8, 26, 14, 0, tzinfo=timezone.utc)
+
+
+def test_resume_touches_only_parked_runs_of_this_merchant() -> None:
+    sql, params = resume_run_query("m1", "wf-1", "en-1")
+    assert "status = 'parked'" in sql
+    assert "merchant_id = $1" in sql and params[0] == "m1"
+    assert "attempts = 0" in sql and "wake_at = now()" in sql
+    # last_error deliberately survives (the operator sees what they
+    # fixed) — the SET clause must not touch it; RETURNING may list it
+    set_clause = sql.split("WHERE")[0]
+    assert "last_error" not in set_clause
+
+
+def test_sweep_deletes_only_old_exited_rows_batched() -> None:
+    sql, params = sweep_exited_runs_query(NOW, 500)
+    assert "status = 'exited'" in sql
+    assert "exited_at < $1" in sql
+    assert "LIMIT $2" in sql  # batched — never a long lock
+    assert params == [NOW, 500]
+
+
+def test_list_runs_is_merchant_first_with_optional_status() -> None:
+    sql, params = list_runs_query("m1", "wf-1", None, 50, 0)
+    assert "merchant_id = $1" in sql and params == ["m1", "wf-1", 50, 0]
+    sql, params = list_runs_query("m1", "wf-1", "parked", 50, 0)
+    assert "status = $3" in sql and params == ["m1", "wf-1", "parked", 50, 0]
+
+
+@pytest.mark.asyncio
+async def test_list_runs_rejects_unknown_status() -> None:
+    with pytest.raises(ValueError):
+        await list_runs("m1", "wf-1", "vanished", 50, 0)
+
+
+def test_retry_delay_doubles_from_the_lease_and_stays_within_jitter() -> None:
+    for attempts, base_expected in ((1, 300), (2, 600), (3, 1200), (20, 3600)):
+        delay = retry_delay_seconds(attempts, 300)
+        assert round(base_expected * 0.8) <= delay <= round(base_expected * 1.2)
+
+
+def test_call_payload_and_send_variables_share_one_bookkeeping_filter() -> None:
+    context = {
+        "source_event_id": "e-1",
+        "phone": "+91",
+        "customer_mobile_number": "+91",
+        "lead_call": "l-1",
+        "message_ask": "m-1",
+        "reply_ask": "YES",
+        "reporting_webhook_url": "https://merchant/report",
+        "cart_value": 1999,
+    }
+    facts = run_facts(context)
+    assert facts == {
+        "reporting_webhook_url": "https://merchant/report",
+        "cart_value": 1999,
+    }
+    assert send_variables(context) == {"cart_value": 1999}
+
+
+def test_lead_request_id_is_the_merchants_order_id_else_the_run() -> None:
+    assert lead_request_id({"order_id": "o-1001"}, "r-1") == "o-1001"
+    assert lead_request_id({"order_id": 4567}, "r-1") == "4567"
+    assert lead_request_id({"request_id": "req-9"}, "r-1") == "req-9"
+    assert lead_request_id({"order_id": ""}, "r-1") == "wf-r-1"
+    assert lead_request_id({}, "r-1") == "wf-r-1"


### PR DESCRIPTION
Completes the outreach module's phase-2-pulled-forward core so reactive
voice flows run end to end (the go-live path: event -> wait ->
silence -> call), per canon T19/T20 and ADR 0010.

Corpus tasks:
- W1  crm_workflow (055): the plan as ONE live-read document {entry, nodes, edges, goal, exits}; draft->publish with version as an audit stamp; publish validator blocks the unsafe edit classes (duplicate node ids, edges into nowhere, deleting an occupied square,
  >1 outgoing edge until W5); admin API under /crm/workflows.
- W2  crm_workflow_enrollment (056) + enrol(): one token per run; wake_at is the timer AND the lease (no reaper); admission guards (reenter/cooldown) at the door; open-run partial unique absorbs every race; source-event idempotency for at-least-once feeds.
- W3  the walker: single-statement SKIP LOCKED claim (lock+lease+ attempts), arrival scheduling, goal re-check at fire time, errors park-never-exit; call nodes enqueue a normal buddy lead (ADR 0010 — existing dispatch machine, existing checks) with a deterministic id (lease retries cannot double-call) and stamp enrollment_id (057); send nodes park honestly until connectivity (C3/C4) deploys.
- W4  entry-rule processor: stamped spine events matching live plans -> enrol(); goal topics -> cancel open runs (goal_met).
- Run operability (canon T20's promises, complete): runs list API with parked-triage filter, resume for parked runs, and the exited-rows retention sweep (batched, 90d knob, rides the walker deployment).

Merchant contract wired in: standard payload keys
(customer_mobile_number/customer_name -> one generic extractor path); every other scalar payload key rides run context into the lead payload as template variables.

Record module gains two read contracts (recent_attributed_events, customer_has_event) via an events.py logic seam — cross-module reads go through contracts, never foreign SELECTs.

Per-worker flags (CRM_WALKER_ENABLED / CRM_ENTRY_RULES_ENABLED) so A2's dedicated pods enable exactly their own loop.

Every position taken beyond the corpus — two canon deviations ('completed' exit reason, merchant-first open-run unique), the open-question positions, and this week's contract rulings — is catalogued in docs/crm/decisions_taken.md for corpus review.

Verified: live two-customer race (goal-cancel -> no call; silence ->
one lead, enrollment-stamped, template variables through), park -> list -> resume -> re-claim cycle incl. cross-tenant refusal, retention sweep (old exited row removed, fresh kept), idempotent re-ticks, 111 crm tests, pyrefly clean, boundary + migration checkers green (the 052-054 duplicate numbers are release's own pre-existing collision).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added CRM workflow management for creating, editing, publishing, pausing, archiving, and listing workflows.
  * Added workflow enrollment tracking with run history, status filtering, and parked-run resumption.
  * Workflows can enroll customers from matching events, cancel runs on goal events, and create call tasks.
  * Added scheduled processing for due workflow steps, retries, failure handling, and retention cleanup.
* **Documentation**
  * Added CRM workflow behavior and operational decision documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->