### PR TITLE
fix(chat): Gemini 400 on parallel tool calls — per-part thought-signature re-attach + placeholder stamp

### DIFF
--- a/app/ai/voice/agents/breeze_buddy/chat/llm/gemini/adapter_patch.py
+++ b/app/ai/voice/agents/breeze_buddy/chat/llm/gemini/adapter_patch.py
@@ -46,22 +46,86 @@ adjacency of response-only user turns occurs exactly and only when one
 model turn made parallel calls (sequential exchanges always interleave a
 model turn between responses), so the merge can never join unrelated
 exchanges.
+
+THIRD correction (live 2026-08-26): upstream's
+``_apply_thought_signatures_to_messages`` probes ONLY ``parts[-1]`` of
+each model message when re-attaching a captured signature by bookmark.
+The chat cycle loop appends ONE assistant message carrying ALL of a
+cycle's parallel tool_calls, which adapts to ONE model Content with N
+functionCall parts — and Gemini attaches the thought signature "only to
+the first functionCall part" of a parallel batch (documented). So for
+any parallel cycle (N > 1) the bookmark references the FIRST part while
+upstream probes the LAST: the captured signature silently fails to
+re-attach ("Thought signatures to apply: 2 / Applied 1" in the crash
+logs), the whole batch reaches the wire unsigned, and Gemini 3 rejects
+the request:
+
+    400 INVALID_ARGUMENT: "Function call is missing a thought_signature
+    in functionCall parts. This is required for tools to work
+    correctly..."
+
+Fix: function_call-bookmarked signatures match against EVERY part of a
+candidate message (attaching to the exact part whose id matches — the
+part the signature was received on, as the docs require); text /
+inline_data bookmarks keep upstream's last-part semantics.
+
+FOURTH correction (same incident, defense in depth): after re-attachment
+and the merge pass, any model message that still carries functionCall
+parts with NO thought signature anywhere — Gemini emitted none for that
+cycle, a degenerate bookmark, or an INJECTED call (widget direct
+intents) — is stamped with Google's documented placeholder signature for
+client-modified histories, which "skips validation" server-side. This is
+a last-resort fallback: it never runs when the message already carries a
+real signature, and it only runs at all when a signature regime is
+active (at least one signature was captured this session). Anomalous
+stamps (anything that is not an injected direct intent) log one
+structured warning per request build.
 """
 
 from __future__ import annotations
 
+import base64
+from collections import Counter
 from typing import List
 
 from google.genai.types import Content
 from pipecat.adapters.services.gemini_adapter import GeminiLLMAdapter
 
-__all__ = ["AdjacentMergeGeminiAdapter"]
+from app.core.logger import logger
+
+__all__ = [
+    "AdjacentMergeGeminiAdapter",
+    "GEMINI_PLACEHOLDER_SIGNATURE_WIRE",
+    "PLACEHOLDER_THOUGHT_SIGNATURE",
+]
+
+# Google's documented dummy signature for histories the client has edited
+# or injected function calls into ("context engineering") — Gemini skips
+# strict thought-signature validation for parts carrying it. The docs
+# show it as this LITERAL string in the request JSON; the SDK's
+# ``Part.thought_signature`` is ``bytes`` serialized as UNPADDED
+# URL-SAFE base64, so the stored bytes are the urlsafe-b64 DECODE of the
+# literal — round-tripping to exactly the documented wire form (pinned
+# by test, and validated live against Vertex 2026-08-26: an injected
+# unsigned functionCall history 400s bare and passes with this stamp).
+GEMINI_PLACEHOLDER_SIGNATURE_WIRE = "context_engineering_is_the_way_to_go"
+PLACEHOLDER_THOUGHT_SIGNATURE: bytes = base64.urlsafe_b64decode(
+    GEMINI_PLACEHOLDER_SIGNATURE_WIRE
+)
+
+# tool_call_id prefix of widget direct-intent INJECTED calls
+# (chat/agent/direct.py) — unsigned by construction, so stamping them is
+# expected and never warns.
+_INJECTED_CALL_ID_PREFIX = "intent_"
 
 
 class AdjacentMergeGeminiAdapter(GeminiLLMAdapter):
-    """Gemini adapter whose parallel-call merge requires adjacency, and
-    whose adapted contents coalesce parallel-call responses into the one
-    user turn Vertex requires (see module docstring)."""
+    """Gemini adapter whose parallel-call merge requires adjacency, whose
+    adapted contents coalesce parallel-call responses into the one user
+    turn Vertex requires, whose signature re-attachment probes every part
+    of a parallel batch, and which stamps Google's documented placeholder
+    signature on any functionCall message still unsigned after all of the
+    above (see module docstring)."""
 
     def get_llm_invocation_params(self, *args, **kwargs):
         params = super().get_llm_invocation_params(*args, **kwargs)
@@ -99,6 +163,63 @@ class AdjacentMergeGeminiAdapter(GeminiLLMAdapter):
                 i += 1
         return out
 
+    def _apply_thought_signatures_to_messages(
+        self, thought_signature_dicts: list[dict], messages: List[Content]
+    ) -> None:
+        """Re-attach captured signatures by bookmark — EVERY part probed.
+
+        Third correction (module docstring): upstream probes only
+        ``parts[-1]`` per model message, which misses the first part of a
+        parallel batch — the exact part Gemini signs. Function_call
+        bookmarks here match against the part whose ``function_call.id``
+        equals the bookmark id, wherever it sits; text / inline_data
+        bookmarks keep upstream's last-part probe (a trailing signature
+        rides the last part by construction). Same in-order,
+        monotonically-advancing search as upstream otherwise.
+        """
+        if not thought_signature_dicts:
+            return
+
+        logger.debug(f"Thought signatures to apply: {len(thought_signature_dicts)}")
+
+        assistant_messages = [
+            message
+            for message in messages
+            if isinstance(message, Content) and message.role == "model"
+        ]
+
+        applied = 0
+        message_start_index = 0
+        for thought_signature_dict in thought_signature_dicts:
+            signature = thought_signature_dict.get("signature")
+            bookmark = thought_signature_dict.get("bookmark")
+            if not signature or not bookmark:
+                continue
+            function_call_id = bookmark.get("function_call")
+
+            for i in range(message_start_index, len(assistant_messages)):
+                message = assistant_messages[i]
+                if not message.parts:
+                    continue
+                matched_part = None
+                if function_call_id:
+                    for part in message.parts:
+                        fc = part.function_call
+                        if fc is not None and fc.id == function_call_id:
+                            matched_part = part
+                            break
+                elif self._thought_signature_bookmark_matches_part(
+                    bookmark, message.parts[-1]
+                ):
+                    matched_part = message.parts[-1]
+                if matched_part is not None:
+                    matched_part.thought_signature = signature
+                    applied += 1
+                    message_start_index = i + 1
+                    break
+
+        logger.debug(f"Applied {applied} thought signatures.")
+
     def _merge_parallel_tool_calls_for_thinking(
         self, thought_signature_dicts: list[dict], messages: List[Content]
     ) -> List[Content]:
@@ -107,14 +228,30 @@ class AdjacentMergeGeminiAdapter(GeminiLLMAdapter):
 
         # Same fast-exit as upstream: no function-call signatures means
         # either thinking is off or there are no function calls — merging
-        # is irrelevant either way.
+        # is irrelevant either way. (The placeholder stamp below still
+        # runs whenever ANY signature was captured: a text-bookmarked
+        # signature also proves the signature regime is active.)
         has_function_call_signatures = any(
             ts.get("bookmark", {}).get("function_call")
             for ts in thought_signature_dicts
         )
-        if not has_function_call_signatures:
-            return messages
+        if has_function_call_signatures:
+            messages = self._adjacent_merge(messages)
 
+        # Fourth correction (module docstring): last-resort placeholder
+        # stamp for functionCall messages that are STILL unsigned after
+        # re-attachment + merge. Only under an active signature regime —
+        # with no captured signatures at all (thinking off / non-signing
+        # model) behavior is unchanged.
+        if thought_signature_dicts:
+            self._stamp_unsigned_function_call_messages(
+                thought_signature_dicts, messages
+            )
+
+        return messages
+
+    @staticmethod
+    def _adjacent_merge(messages: List[Content]) -> List[Content]:
         def is_tool_call_message(msg: Content) -> bool:
             return bool(
                 msg.role == "model"
@@ -152,6 +289,91 @@ class AdjacentMergeGeminiAdapter(GeminiLLMAdapter):
                 i += 1
 
         return merged_messages
+
+    def _stamp_unsigned_function_call_messages(
+        self, thought_signature_dicts: list[dict], messages: List[Content]
+    ) -> None:
+        """Stamp Google's placeholder signature on still-unsigned batches.
+
+        A model message whose parts include functionCalls but carry NO
+        thought signature anywhere would 400 under Gemini 3's strict
+        current-turn validation. Messages with a real signature are never
+        touched — Gemini signs only the first part of a parallel batch,
+        and the documented contract is to echo that exact shape back.
+
+        Case per stamped message (for the warning):
+        - ``captured_not_reattached``: a captured signature's bookmark
+          references a call id INSIDE this message, yet nothing attached
+          — the re-attachment above regressed (tripwire; should be
+          unreachable now).
+        - ``injected_direct_intent``: every call id carries the widget
+          direct-intent prefix — an expected client injection; stamped
+          silently (this is the placeholder's documented purpose).
+        - ``no_signature_captured``: no captured signature references
+          this message — Gemini emitted none for that cycle, or the
+          bookmark id diverged from the persisted call id.
+
+        One structured warning per request build, and only when at least
+        one stamped message is anomalous (non-injected).
+        """
+        bookmarked_call_ids = {
+            (ts.get("bookmark") or {}).get("function_call")
+            for ts in thought_signature_dicts
+        }
+        bookmarked_call_ids.discard(None)
+
+        case_counts: Counter[str] = Counter()
+        function_names: set[str] = set()
+        total_parts = 0
+        for message in messages:
+            if not (
+                isinstance(message, Content)
+                and message.role == "model"
+                and message.parts
+            ):
+                continue
+            if any(part.thought_signature for part in message.parts):
+                continue
+            fc_parts = []
+            call_ids = set()
+            for part in message.parts:
+                fc = part.function_call
+                if fc is None:
+                    continue
+                fc_parts.append(part)
+                if fc.id:
+                    call_ids.add(fc.id)
+                if fc.name:
+                    function_names.add(fc.name)
+            if not fc_parts:
+                continue
+
+            if call_ids & bookmarked_call_ids:
+                case = "captured_not_reattached"
+            elif call_ids and all(
+                call_id.startswith(_INJECTED_CALL_ID_PREFIX) for call_id in call_ids
+            ):
+                case = "injected_direct_intent"
+            else:
+                case = "no_signature_captured"
+
+            for part in fc_parts:
+                part.thought_signature = PLACEHOLDER_THOUGHT_SIGNATURE
+            case_counts[case] += 1
+            total_parts += len(fc_parts)
+
+        if not case_counts:
+            return
+        if set(case_counts) == {"injected_direct_intent"}:
+            return
+        logger.warning(
+            f"[gemini_adapter] request built with {sum(case_counts.values())} "
+            f"unsigned functionCall message(s) ({total_parts} part(s); "
+            f"functions={sorted(function_names)}; cases={dict(case_counts)}; "
+            f"captured_signatures={len(thought_signature_dicts)}) — stamped "
+            f"placeholder thought_signature "
+            f"'{GEMINI_PLACEHOLDER_SIGNATURE_WIRE}'"
+        )
 
 
 def ensure_chat_gemini_adapter(service):

--- a/tests/test_gemini_adapter_patch.py
+++ b/tests/test_gemini_adapter_patch.py
@@ -27,7 +27,12 @@ from pipecat.processors.aggregators.llm_context import (
     LLMSpecificMessage,
 )
 
+from app.ai.voice.agents.breeze_buddy.chat.llm.gemini import (
+    adapter_patch as adapter_patch_module,
+)
 from app.ai.voice.agents.breeze_buddy.chat.llm.gemini.adapter_patch import (
+    GEMINI_PLACEHOLDER_SIGNATURE_WIRE,
+    PLACEHOLDER_THOUGHT_SIGNATURE,
     AdjacentMergeGeminiAdapter,
 )
 
@@ -233,22 +238,19 @@ def test_invocation_params_balanced_after_injected_intent():
     params = adapter.get_llm_invocation_params(context)
     contents = params["messages"]
     assert_call_response_pairing(contents)
-    # The search call kept its signature; the injected call has none.
-    signed = [
-        p.function_call.name
-        for c in contents
-        for p in (c.parts or [])
-        if getattr(p, "function_call", None) and getattr(p, "thought_signature", None)
-    ]
-    unsigned = [
-        p.function_call.name
+    # The search call kept its REAL signature; the injected call cannot
+    # have one, so it now carries Google's documented placeholder for
+    # client-injected calls (Gemini 3 strict validation would otherwise
+    # 400 it — see the stamp tests below; the stamp is silent for
+    # injected intents).
+    sig_by_name = {
+        p.function_call.name: p.thought_signature
         for c in contents
         for p in (c.parts or [])
         if getattr(p, "function_call", None)
-        and not getattr(p, "thought_signature", None)
-    ]
-    assert signed == ["search_catalog"]
-    assert unsigned == ["create_cart"]
+    }
+    assert sig_by_name["search_catalog"] == b"sig-bytes"
+    assert sig_by_name["create_cart"] == PLACEHOLDER_THOUGHT_SIGNATURE
 
 
 def test_parallel_call_responses_coalesce_into_one_user_turn():
@@ -360,3 +362,222 @@ def test_chat_adapter_swap_is_instance_local_and_voice_stays_stock():
     # Non-Gemini services pass through untouched.
     sentinel = object()
     assert ensure_chat_gemini_adapter(sentinel) is sentinel
+
+
+# ---------------------------------------------------------------------------
+# Thought-signature re-attachment + placeholder stamp (live 2026-08-26 crash:
+# 400 "Function call is missing a thought_signature in functionCall parts")
+# ---------------------------------------------------------------------------
+
+
+class _LogRecorder:
+    """Minimal stand-in for the module logger — records warning messages."""
+
+    def __init__(self) -> None:
+        self.warnings: List[str] = []
+
+    def warning(self, message: str, *args, **kwargs) -> None:
+        self.warnings.append(message)
+
+    def debug(self, message: str, *args, **kwargs) -> None:
+        pass
+
+
+def sig_message(call_id: str, raw: bytes) -> LLMSpecificMessage:
+    return LLMSpecificMessage(
+        llm="google",
+        message={
+            "type": "thought_signature",
+            "signature": raw,
+            "bookmark": {"function_call": call_id},
+        },
+    )
+
+
+def assistant_calls(*ids: str, name: str = "render_ui") -> dict:
+    return {
+        "role": "assistant",
+        "content": None,
+        "tool_calls": [
+            {
+                "id": call_id,
+                "type": "function",
+                "function": {"name": name, "arguments": "{}"},
+            }
+            for call_id in ids
+        ],
+    }
+
+
+def tool_result(call_id: str) -> dict:
+    return {
+        "role": "tool",
+        "tool_call_id": call_id,
+        "content": json.dumps({"status": "ok"}),
+    }
+
+
+def signatures_by_call_id(contents: list) -> dict:
+    return {
+        p.function_call.id: p.thought_signature
+        for c in contents
+        for p in (c.parts or [])
+        if getattr(p, "function_call", None)
+    }
+
+
+def test_parallel_batch_signature_reattaches_to_signed_part(monkeypatch):
+    """THE confirmed live crash (2026-08-26): a cycle emits parallel calls,
+    Gemini signs only the FIRST functionCall part, the cycle loop appends
+    ONE assistant message with all the calls — and upstream's re-attachment
+    probes only ``parts[-1]``, silently dropping the captured signature
+    ("Thought signatures to apply: 2 / Applied 1" in the crash log). The
+    patched adapter attaches by call id on ANY part, restoring the exact
+    shape Gemini emitted (first part signed, siblings bare — live-validated
+    against Vertex as accepted)."""
+    recorder = _LogRecorder()
+    monkeypatch.setattr(adapter_patch_module, "logger", recorder)
+    adapter = AdjacentMergeGeminiAdapter()
+    messages = [
+        {"role": "user", "content": "where is my order"},
+        assistant_calls("call_1", name="get_order_status"),
+        sig_message("call_1", b"real-sig-1"),
+        tool_result("call_1"),
+        assistant_calls("call_2", "call_3", "call_4"),
+        sig_message("call_2", b"real-sig-2"),
+        tool_result("call_2"),
+        tool_result("call_3"),
+        tool_result("call_4"),
+    ]
+    context = LLMContext(messages=cast(List[LLMContextMessage], messages))
+    contents = adapter.get_llm_invocation_params(context)["messages"]
+    assert_call_response_pairing(contents)
+    sigs = signatures_by_call_id(contents)
+    assert sigs == {
+        "call_1": b"real-sig-1",
+        "call_2": b"real-sig-2",  # first part of the batch — where Gemini put it
+        "call_3": None,
+        "call_4": None,
+    }
+    assert recorder.warnings == []
+
+
+def test_upstream_last_part_probe_misses_parallel_batch():
+    """Documents the upstream bug the re-attachment override exists for —
+    if this ever fails, pipecat probes all parts and the override can be
+    dropped."""
+    adapter = GeminiLLMAdapter()
+    batch = Content(role="model", parts=[fc_part("t", "c1"), fc_part("t", "c2")])
+    adapter._apply_thought_signatures_to_messages(
+        [{"signature": b"sig", "bookmark": {"function_call": "c1"}}], [batch]
+    )
+    assert batch.parts is not None
+    assert not any(
+        p.thought_signature for p in batch.parts
+    ), "upstream now attaches to non-last parts — override may be removable"
+
+
+def test_unsigned_batch_stamped_with_placeholder_and_warns(monkeypatch):
+    """No signature was captured for a cycle at all (Gemini emitted none /
+    the bookmark never made it into context): after re-attachment + merge
+    the batch is stamped with the documented placeholder and ONE structured
+    warning fires."""
+    recorder = _LogRecorder()
+    monkeypatch.setattr(adapter_patch_module, "logger", recorder)
+    adapter = AdjacentMergeGeminiAdapter()
+    messages = [
+        {"role": "user", "content": "hi"},
+        assistant_calls("call_1", name="get_order_status"),
+        sig_message("call_1", b"real-sig-1"),
+        tool_result("call_1"),
+        assistant_calls("call_9", "call_10"),  # signature never captured
+        tool_result("call_9"),
+        tool_result("call_10"),
+    ]
+    context = LLMContext(messages=cast(List[LLMContextMessage], messages))
+    contents = adapter.get_llm_invocation_params(context)["messages"]
+    sigs = signatures_by_call_id(contents)
+    assert sigs["call_1"] == b"real-sig-1"  # real signature untouched
+    assert sigs["call_9"] == PLACEHOLDER_THOUGHT_SIGNATURE
+    assert sigs["call_10"] == PLACEHOLDER_THOUGHT_SIGNATURE
+    assert len(recorder.warnings) == 1
+    assert "no_signature_captured" in recorder.warnings[0]
+    assert "render_ui" in recorder.warnings[0]
+
+
+def test_captured_not_reattached_tripwire(monkeypatch):
+    """A bookmark referencing a call INSIDE a still-unsigned message means
+    the re-attachment pass regressed — the stamp still saves the request
+    and the warning names the tripwire case. (Forced here via an empty
+    signature, which re-attachment skips.)"""
+    recorder = _LogRecorder()
+    monkeypatch.setattr(adapter_patch_module, "logger", recorder)
+    adapter = AdjacentMergeGeminiAdapter()
+    messages = [
+        {"role": "user", "content": "hi"},
+        assistant_calls("call_1", "call_2"),
+        sig_message("call_1", b""),  # captured but unattachable
+        sig_message("call_x", b"real"),  # keeps the fc-signature fast-path on
+        tool_result("call_1"),
+        tool_result("call_2"),
+    ]
+    context = LLMContext(messages=cast(List[LLMContextMessage], messages))
+    contents = adapter.get_llm_invocation_params(context)["messages"]
+    sigs = signatures_by_call_id(contents)
+    assert sigs["call_1"] == PLACEHOLDER_THOUGHT_SIGNATURE
+    assert sigs["call_2"] == PLACEHOLDER_THOUGHT_SIGNATURE
+    assert len(recorder.warnings) == 1
+    assert "captured_not_reattached" in recorder.warnings[0]
+
+
+def test_injected_only_stamp_is_silent(monkeypatch):
+    """Widget direct-intent injections (``intent_*`` call ids) are the
+    placeholder's documented use case — stamped, but never warned about."""
+    recorder = _LogRecorder()
+    monkeypatch.setattr(adapter_patch_module, "logger", recorder)
+    adapter = AdjacentMergeGeminiAdapter()
+    messages = [
+        {"role": "user", "content": "hi"},
+        assistant_calls("call_1", name="search_catalog"),
+        sig_message("call_1", b"real-sig-1"),
+        tool_result("call_1"),
+        assistant_calls("intent_abc", name="create_cart"),  # injected
+        tool_result("intent_abc"),
+    ]
+    context = LLMContext(messages=cast(List[LLMContextMessage], messages))
+    contents = adapter.get_llm_invocation_params(context)["messages"]
+    sigs = signatures_by_call_id(contents)
+    assert sigs["call_1"] == b"real-sig-1"
+    assert sigs["intent_abc"] == PLACEHOLDER_THOUGHT_SIGNATURE
+    assert recorder.warnings == []
+
+
+def test_no_signature_regime_means_no_stamp(monkeypatch):
+    """With no captured signatures at all (thinking off / non-signing
+    model), functionCall messages stay exactly as adapted — the stamp
+    never changes behavior outside an active signature regime."""
+    recorder = _LogRecorder()
+    monkeypatch.setattr(adapter_patch_module, "logger", recorder)
+    adapter = AdjacentMergeGeminiAdapter()
+    messages = [
+        {"role": "user", "content": "hi"},
+        assistant_calls("call_1", "call_2"),
+        tool_result("call_1"),
+        tool_result("call_2"),
+    ]
+    context = LLMContext(messages=cast(List[LLMContextMessage], messages))
+    contents = adapter.get_llm_invocation_params(context)["messages"]
+    sigs = signatures_by_call_id(contents)
+    assert sigs == {"call_1": None, "call_2": None}
+    assert recorder.warnings == []
+
+
+def test_placeholder_wire_form_is_documented_literal():
+    """Google documents the dummy signature as the LITERAL string in the
+    request JSON; the SDK serializes ``Part.thought_signature`` bytes as
+    unpadded url-safe base64 — this pins the round-trip against SDK
+    upgrades (live-validated: the bare history 400s, this stamp passes)."""
+    part = Part(thought_signature=PLACEHOLDER_THOUGHT_SIGNATURE)
+    wire = part.model_dump(mode="json", exclude_none=True)["thought_signature"]
+    assert wire == GEMINI_PLACEHOLDER_SIGNATURE_WIRE
+    assert wire == "context_engineering_is_the_way_to_go"


### PR DESCRIPTION
## The bug

Long multi-tool chat turns intermittently crash mid-turn with:

```
google.genai.errors.ClientError: 400 Bad Request
"Function call is missing a thought_signature in functionCall parts. …
 Additional data, function call `default_api:render_ui` , position 5."
```

The prompt-cache request fails first, the full-prefix retry replays the same contents and gets the same 400, and the turn ends FAILED. In-memory context, not persisted-history replay (zero `[gemini_signatures]` warnings in the crash logs).

## Diagnosis — the mechanism (confirmed from live logs + reproduced against Vertex)

The crash log shows the smoking gun directly: on the failing cycle the adapter logged
`Thought signatures to apply: 2` immediately followed by `Applied 1 thought signatures.` — a captured signature failed to re-attach, and the very next request 400'd. The SSE capture of the same turn shows **21 consecutive `function_call_started` events**: one cycle emitting a large parallel `render_ui` batch.

The chain:

1. **Gemini signs only the FIRST functionCall part of a parallel batch.** Google's thought-signature docs: "If the model generates parallel function calls in a response, the `thought_signature` is attached only to the first `functionCall` part." `stream.py` correctly captures that signature with a bookmark = that part's `function_call.id`.
2. **The chat cycle loop appends ONE assistant message carrying ALL of the cycle's tool_calls** (`agent/cycle.py`, mirroring `LLMAssistantContextAggregator`). Pipecat's `_from_standard_message` converts it to ONE model `Content` with N `functionCall` parts, order preserved.
3. **Upstream pipecat's `_apply_thought_signatures_to_messages` probes only `parts[-1]`** of each model message. Bookmark id = first part's id ≠ last part's id → no match → the signature is silently dropped ("to apply: 2 / Applied 1").
4. The batch message now has functionCall parts and **no signature anywhere**. The adjacent merge can't rescue it (it only folds unsigned messages *into* a signed head; this message has no signature and no signed neighbor).
5. Gemini 3 enforces strict validation on the current turn ("The first `functionCall` part in each step of the current turn must include its `thought_signature`") → 400, deterministic for that context. Hence the intermittency: **single-call cycles always work; any parallel-call cycle (N > 1) loses its signature with certainty** — whether a turn crashes depends only on whether the model happened to emit a parallel batch.

### Enumerated cases for an unsigned functionCall part reaching the wire

| # | Case | Status |
|---|------|--------|
| 1 | Parallel batch collapsed into one assistant message; bookmark references a non-last part; last-part-only probe misses | **Confirmed** (crash logs `2 captured / 1 applied` + 21-call SSE shape + local repro through the adapter) |
| 2 | Gemini emits no signature for a cycle at all (counts match but a batch is still unsigned) | Inferred, not observed |
| 3 | Degenerate bookmark — Gemini 3 trailing empty-text signature chunk yields `{"text": ""}`, which the apply-step treats as an unknown bookmark type and never matches | Inferred from code paths, not observed (zero "Unknown thought signature bookmark" warnings in logs) |
| 4 | Text-bookmarked signature whose text part is dropped by conversion (assistant message with both `content` and `tool_calls` — conversion keeps only the calls) | Inferred, not observed |
| 5 | Injected function calls the model never produced (widget direct intents, `intent_*` ids) — unsigned by construction | Known/expected (documented in the adapter since the adjacency fix) |

## The fix (chat-only adapter; voice untouched)

Two additions to `AdjacentMergeGeminiAdapter` (`adapter_patch.py`) — `stream.py` capture is correct and needed no changes:

**THIRD correction — per-part re-attachment.** `_apply_thought_signatures_to_messages` override: function_call-bookmarked signatures now match against **every** part of a candidate model message and attach to the part whose id matches — the exact part the signature was received on, as the docs require. Text/inline_data bookmarks keep upstream's last-part semantics; same in-order, monotonically-advancing search otherwise. This eliminates case 1 **with the real signature** (no reasoning degradation).

**FOURTH correction — placeholder stamp (last resort).** After re-attachment + merge, any model message still carrying only unsigned functionCall parts is stamped with Google's documented dummy signature for client-modified histories: `context_engineering_is_the_way_to_go` ("set the following dummy signatures … in the thought signature field to skip validation"). Guardrails:

- runs **only under an active signature regime** (≥1 captured signature this session) — thinking-off / Gemini-2.5 budget histories are byte-identical to before;
- **never touches a message that carries any real signature** — a model-signed parallel batch is echoed in its exact emitted shape (first part signed, siblings bare);
- injected direct-intent calls are stamped **silently** — that is the placeholder's documented purpose.

### The warning

One structured `logger.warning` per request build, fired **only** when a stamped message is anomalous (i.e. not an injected intent), naming: unsigned message count, part count, function names, the diagnosed case per the taxonomy above (`captured_not_reattached` — a tripwire that means the re-attachment pass regressed; `no_signature_captured`; `injected_direct_intent` counted but never warning-triggering alone), and how many signatures were captured. Example:

```
[gemini_adapter] request built with 1 unsigned functionCall message(s) (2 part(s);
functions=['render_ui']; cases={'no_signature_captured': 1}; captured_signatures=1)
— stamped placeholder thought_signature 'context_engineering_is_the_way_to_go'
```

## Wire-encoding verdict for the placeholder (verified empirically)

The SDK's `Part.thought_signature` is `bytes`, serialized to JSON as **unpadded url-safe base64**. Therefore:

- `Part(thought_signature=b"context_engineering_is_the_way_to_go")` puts `"Y29udGV4dF9lbmdpbmVlcmluZ19pc190aGVfd2F5X3RvX2dv"` on the wire — **not** the documented literal.
- The stamp stores `base64.urlsafe_b64decode("context_engineering_is_the_way_to_go")` (27 bytes), which round-trips to **exactly the documented literal** `"context_engineering_is_the_way_to_go"` in the request JSON. Pinned by test against SDK upgrades.

## Empirical validation against live Vertex (`gemini-3.6-flash`, project creds from the local .env; nothing committed)

| History shape | Result |
|---|---|
| Current-turn model message with 2 parallel `render_ui` calls, unsigned | **400** — exact production error reproduced |
| Same, both parts stamped with the urlsafe-decoded placeholder (wire = documented literal) | **passes** |
| Same, stamped with raw ASCII bytes (wire = standard-b64 of the literal) | also passes (server is lenient; we still ship the documented wire form) |
| Same, placeholder on the FIRST part only (the echo shape the re-attachment fix produces) | **passes** |

Not validated empirically: cases 2–4 end states in production traffic (they are structurally possible but were not present in the captured logs); the stamp covers them identically.

## Tests (`tests/test_gemini_adapter_patch.py`, 15 total — 8 existing kept green, 7 new)

- `test_parallel_batch_signature_reattaches_to_signed_part` — the confirmed live shape: real signature lands on the batch's first part, siblings stay bare, no placeholder, no warning.
- `test_upstream_last_part_probe_misses_parallel_batch` — documents the upstream pipecat bug (fails ⇒ override removable), style-matching the existing `test_upstream_adapter_still_hoists`.
- `test_unsigned_batch_stamped_with_placeholder_and_warns` — never-captured cycle: both parts stamped, real signature elsewhere untouched, exactly one warning with `no_signature_captured`.
- `test_captured_not_reattached_tripwire` — the regression tripwire case fires and stamps.
- `test_injected_only_stamp_is_silent` — `intent_*` calls stamped, zero warnings.
- `test_no_signature_regime_means_no_stamp` — no captured signatures ⇒ byte-identical behavior.
- `test_placeholder_wire_form_is_documented_literal` — pins the bytes→wire round-trip.
- Updated `test_invocation_params_balanced_after_injected_intent`: the injected call now carries the placeholder instead of going out bare (its previous "Vertex accepts unsigned for non-current turns" assumption is Gemini-2.5-era).

Rebased onto `release` after PR #1023 merged — the fixture repairs and migration fix this branch originally carried are now upstream, so the diff is exactly two files (`adapter_patch.py` + its tests). Full suite on the rebased branch: **1433 passed, 1 xfailed**; `check_migrations` clean.


Gates run: `black` / `isort --profile black` / `autoflake` clean, `pyrefly check` 0 errors, full pytest suite green (unpiped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DNdffo648u5Qg9Q5Ctftub


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Gemini handling of parallel tool calls and consecutive function responses.
  * Preserved thought signatures across matching calls and applied required placeholders when signatures are missing.
  * Added clearer diagnostics for injected intents and unexpected unsigned calls.

* **Tests**
  * Expanded coverage for signature preservation, placeholder behavior, injected calls, and related session handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
