### PR TITLE
feat(crm): outbound message manifest and dispatch worker

### DIFF
--- a/app/core/config/static.py
+++ b/app/core/config/static.py
@@ -1,3 +1,4 @@
+import math
 import os
 
 # --- Configuration ---
@@ -443,6 +444,40 @@ BB_DISPATCH_QPS_JITTER_MS = int(os.environ.get("BB_DISPATCH_QPS_JITTER_MS", 200)
 #   - BB_RECONCILE_BACKLOG_LIMIT
 
 
+def _positive_int(env_var: str, default: int) -> int:
+    """Read a positive int, falling back to the default on garbage or <1.
+
+    Lenient rather than fatal: a bad dial should not stop a pod from booting.
+    But it must not be honoured either — a zero here would dead-letter every
+    message on its first attempt, or expire a claim lease mid-send.
+    """
+    raw = os.environ.get(env_var)
+    if raw is None:
+        return default
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        return default
+    return value if value >= 1 else default
+
+
+def _positive_float(env_var: str, default: float) -> float:
+    """Read a positive finite float, falling back to the default.
+
+    Same leniency as _positive_int. Finite matters: 'inf' parses and compares
+    > 0, and an infinite poll interval is a worker that sleeps forever after
+    its first empty poll — draining nothing and raising nothing.
+    """
+    raw = os.environ.get(env_var)
+    if raw is None:
+        return default
+    try:
+        value = float(raw)
+    except (TypeError, ValueError):
+        return default
+    return value if math.isfinite(value) and value > 0 else default
+
+
 # -----------------------------------------------------------------------------
 # CRM worker roles (design/worker-runtime.md, sealed 26-Aug-2026)
 # One image, N pods: CRM_ROLE selects which drain loop (if any) this
@@ -451,9 +486,25 @@ BB_DISPATCH_QPS_JITTER_MS = int(os.environ.get("BB_DISPATCH_QPS_JITTER_MS", 200)
 # -----------------------------------------------------------------------------
 CRM_ROLE = os.environ.get("CRM_ROLE", "api").lower()
 
-CRM_WORKER_INTERVAL = float(os.environ.get("CRM_WORKER_INTERVAL", 1.0))
-CRM_WORKER_BATCH = int(os.environ.get("CRM_WORKER_BATCH", 100))
-CRM_WORKER_HEARTBEAT = float(os.environ.get("CRM_WORKER_HEARTBEAT", 60.0))
+CRM_WORKER_INTERVAL = _positive_float("CRM_WORKER_INTERVAL", 1.0)
+CRM_WORKER_BATCH = _positive_int("CRM_WORKER_BATCH", 100)
+CRM_WORKER_HEARTBEAT = _positive_float("CRM_WORKER_HEARTBEAT", 60.0)
+
+# CRM outbound dispatcher (runs only when CRM_ROLE=dispatcher; loop mechanics
+# ride CRM_WORKER_BATCH/CRM_WORKER_INTERVAL like every role). It currently
+# calls send() with no permission check in front of it — a dummy send only.
+
+# How long a worker may hold a row before it is assumed dead and requeued.
+# Must exceed the slowest realistic provider call.
+CRM_DISPATCH_STALE_MINUTES = _positive_int("CRM_DISPATCH_STALE_MINUTES", 5)
+
+# Bounded so one undeliverable message cannot earn a provider rate-limit ban
+# for every other merchant sharing that sender.
+CRM_DISPATCH_MAX_ATTEMPTS = _positive_int("CRM_DISPATCH_MAX_ATTEMPTS", 3)
+
+# Retry backoff: a provider answering "you are sending too fast" must be
+# obeyed, so each attempt waits twice as long as the last.
+CRM_DISPATCH_RETRY_BASE_SECONDS = _positive_int("CRM_DISPATCH_RETRY_BASE_SECONDS", 30)
 
 
 # Announcement Banner Configuration

--- a/app/crm/connectivity/__init__.py
+++ b/app/crm/connectivity/__init__.py
@@ -1,0 +1,2 @@
+# Exports nothing on purpose: a re-export hub here becomes a merge-conflict
+# magnet and an import cycle. The public surface is contracts.py.

--- a/app/crm/connectivity/contracts.py
+++ b/app/crm/connectivity/contracts.py
@@ -1,0 +1,19 @@
+"""connectivity — the public surface.
+
+The only file other modules and app/crm/worker_main.py may import.
+
+This module owns everything between "we want to send something" and "the
+provider took it": connector accounts, the endpoints under them, templates,
+the message table, send() and the dispatch pass. It is channel-agnostic —
+WhatsApp, Instagram and email are adapters behind send(), not packages.
+
+claim_sends/dispatch_send are the module's two callables for the shared
+drain-loop scaffold (design/worker-runtime.md): worker_main registers them
+as the "dispatcher" role. Small because nothing else calls in yet; the
+function that queues a message lands with the first producer. send() stays
+off this surface so that nothing outside can reach a provider.
+"""
+
+from app.crm.connectivity.dispatch import claim_sends, dispatch_send
+
+__all__ = ["claim_sends", "dispatch_send"]

--- a/app/crm/connectivity/db/__init__.py
+++ b/app/crm/connectivity/db/__init__.py
@@ -1,0 +1,9 @@
+"""The db door — the only db-world names logic may import.
+
+Nothing here opens a transaction today (every statement is a single UPDATE);
+the door still re-exports these so the first one has somewhere to import from.
+"""
+
+from app.crm.shared.db import DbTxn, UniqueViolation, atomically
+
+__all__ = ["DbTxn", "UniqueViolation", "atomically"]

--- a/app/crm/connectivity/db/accessor.py
+++ b/app/crm/connectivity/db/accessor.py
@@ -1,0 +1,48 @@
+"""Mechanical DB access only — one query builder per function, no decisions.
+
+Every function self-scopes; see queries.py for why no transaction is needed.
+"""
+
+from typing import List, Optional
+
+from app.crm.connectivity.db.decoder import decode_queued_message
+from app.crm.connectivity.db.queries import (
+    apply_outcome_query,
+    claim_queued_messages_query,
+    requeue_stale_claims_query,
+)
+from app.crm.connectivity.schemas import QueuedMessage
+from app.crm.shared.db import crm_connection
+
+
+async def claim_queued_messages(batch_size: int) -> List[QueuedMessage]:
+    query, values = claim_queued_messages_query(batch_size)
+    async with crm_connection() as conn:
+        rows = await conn.fetch(query, *values)
+    return [decode_queued_message(row) for row in rows]
+
+
+async def requeue_stale_claims(stale_minutes: int) -> List[str]:
+    """Returns the ids released, not just a count — a reclaimed message is the
+    first thing anyone investigating a possible double send asks about."""
+    query, values = requeue_stale_claims_query(stale_minutes)
+    async with crm_connection() as conn:
+        rows = await conn.fetch(query, *values)
+    return [str(row["id"]) for row in rows]
+
+
+async def apply_outcome(
+    message_id: str,
+    status: str,
+    reason: Optional[str],
+    provider_message_id: Optional[str],
+    mark_sent: bool,
+    retry_after_seconds: Optional[int] = None,
+) -> bool:
+    """False means the row was no longer ours — another worker reclaimed it."""
+    query, values = apply_outcome_query(
+        message_id, status, reason, provider_message_id, mark_sent, retry_after_seconds
+    )
+    async with crm_connection() as conn:
+        row = await conn.fetchrow(query, *values)
+    return row is not None

--- a/app/crm/connectivity/db/decoder.py
+++ b/app/crm/connectivity/db/decoder.py
@@ -1,0 +1,50 @@
+"""Database rows -> domain shapes. Never imported outside this db package."""
+
+import json
+from typing import Any, Dict, Mapping
+
+from app.crm.connectivity.schemas import QueuedMessage
+
+
+def _load_variables(value: Any) -> Dict[str, Any]:
+    """Parse the stored variables blob. Total: always a dict, never raises.
+
+    A batch is decoded after the claim commits but outside the per-message
+    error handling, so raising here strands every row in the batch — they get
+    reclaimed, decoded, and raise again, forever. One bad row would stall the
+    queue permanently.
+
+    The column is plain jsonb, so 42 or [1, 2] are legal values. Non-dicts are
+    dropped rather than converted, since dict() would turn [["a", 1]] into
+    {"a": 1} and invent a variable. The driver returns jsonb as a string
+    today; the non-string branch covers a codec being registered later.
+    """
+    if isinstance(value, str):
+        try:
+            value = json.loads(value)
+        except (TypeError, ValueError):
+            return {}
+    return dict(value) if isinstance(value, dict) else {}
+
+
+def _uuid_or_none(value: Any) -> Any:
+    return str(value) if value is not None else None
+
+
+def decode_queued_message(row: Mapping[str, Any]) -> QueuedMessage:
+    return QueuedMessage(
+        id=str(row["id"]),
+        merchant_id=row["merchant_id"],
+        customer_id=str(row["customer_id"]),
+        channel=row["channel"],
+        sent_to_address=row["sent_to_address"],
+        binding_id=_uuid_or_none(row["binding_id"]),
+        source_kind=row["source_kind"],
+        source_id=_uuid_or_none(row["source_id"]),
+        purpose_key=row["purpose_key"],
+        template_id=row["template_id"],
+        variables=_load_variables(row["variables"]),
+        dedupe_key=row["dedupe_key"],
+        attempt=row["attempt"],
+        next_attempt_at=row["next_attempt_at"],
+    )

--- a/app/crm/connectivity/db/queries.py
+++ b/app/crm/connectivity/db/queries.py
@@ -1,0 +1,107 @@
+"""SQL builders for crm_message. $1 placeholders only, never interpolation.
+
+Every builder emits a single statement, which Postgres runs atomically — so
+nothing here needs a transaction. The claim and the sweep are deliberately
+unscoped by merchant: one global queue, not a loop per tenant.
+"""
+
+from typing import Any, List, Optional, Tuple
+
+MESSAGE_TABLE = "crm_message"
+
+# Named once so the claim's RETURNING and the decoder cannot drift apart.
+# next_attempt_at rides along for the queue-lag log line: how long the oldest
+# row sat past due is the alert that rises whatever the cause.
+CLAIMED_COLUMNS = """
+    id, merchant_id, customer_id, channel, sent_to_address, binding_id,
+    source_kind, source_id, purpose_key, template_id, variables,
+    dedupe_key, attempt, next_attempt_at
+"""
+
+
+def claim_queued_messages_query(batch_size: int) -> Tuple[str, List[Any]]:
+    """Take up to ``batch_size`` queued rows for this worker.
+
+    SKIP LOCKED steps over rows another worker holds instead of waiting, so
+    the loop is safe on every pod at once.
+
+    attempt increments HERE, not after the send, so a worker killed mid-send
+    still spends one — otherwise a message that reliably crashes workers is
+    retried forever.
+    """
+    query = f"""
+        UPDATE {MESSAGE_TABLE}
+           SET status = 'sending',
+               claimed_at = now(),
+               attempt = attempt + 1
+         WHERE id IN (
+               SELECT id
+                 FROM {MESSAGE_TABLE}
+                WHERE status = 'queued'
+                  AND next_attempt_at <= now()
+                ORDER BY next_attempt_at
+                LIMIT $1
+                FOR UPDATE SKIP LOCKED
+         )
+        RETURNING {CLAIMED_COLUMNS}
+    """
+    return query, [batch_size]
+
+
+def requeue_stale_claims_query(stale_minutes: int) -> Tuple[str, List[Any]]:
+    """Requeue rows whose worker never came back.
+
+    Without this a pod restart leaves rows marked in-flight forever: invisible
+    to the queue, never sent, and nothing raises.
+    """
+    query = f"""
+        UPDATE {MESSAGE_TABLE}
+           SET status = 'queued',
+               claimed_at = NULL,
+               reason = 'reclaimed_stale_claim'
+         WHERE status = 'sending'
+           AND claimed_at < now() - make_interval(mins => $1::int)
+        RETURNING id
+    """
+    return query, [stale_minutes]
+
+
+def apply_outcome_query(
+    message_id: str,
+    status: str,
+    reason: Optional[str],
+    provider_message_id: Optional[str],
+    mark_sent: bool,
+    retry_after_seconds: Optional[int],
+) -> Tuple[str, List[Any]]:
+    """Record what happened to a claimed message.
+
+    ``AND status = 'sending'`` keeps a slow send from overwriting a row the
+    sweep already reassigned; zero rows is the right answer there. COALESCE
+    stops a later failure erasing an id an earlier attempt earned.
+    ``retry_after_seconds`` is set only when requeuing; NULL leaves
+    next_attempt_at alone, since a terminal outcome has no next attempt.
+    """
+    query = f"""
+        UPDATE {MESSAGE_TABLE}
+           SET status = $2,
+               reason = $3,
+               provider_message_id = COALESCE($4, provider_message_id),
+               claimed_at = NULL,
+               sent_at = CASE WHEN $5 THEN now() ELSE sent_at END,
+               next_attempt_at = CASE
+                   WHEN $6::int IS NULL THEN next_attempt_at
+                   ELSE now() + make_interval(secs => $6::int)
+               END
+         WHERE id = $1
+           AND status = 'sending'
+        RETURNING id
+    """
+    return query, [
+        message_id,
+        status,
+        reason,
+        provider_message_id,
+        mark_sent,
+        retry_after_seconds,
+    ]

--- a/app/crm/connectivity/dispatch.py
+++ b/app/crm/connectivity/dispatch.py
@@ -1,0 +1,260 @@
+"""Outbound dispatch — claims queued messages and hands each to send().
+
+Producers only queue; this decides. That split exists so the permission
+check happens at send time rather than compose time, and so a customer who
+opts out in between is still honoured.
+
+The loop itself is not here: claim_sends()/dispatch_send() plug into the
+shared drain-loop scaffold (app/crm/shared/worker.py) as the "dispatcher"
+role in app/crm/worker_main.py. This file owns only what a row means.
+
+TODO: no permission check yet — may_contact() does not exist. It belongs in
+_dispatch_one before send(), and a refusal must write a 'blocked' row rather
+than retry. This phase ships demo sends without it by explicit scope decision
+(see the PR thread with Swaroop); the gate structure lands with B5.
+"""
+
+import random
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import List, Optional, Sequence
+
+from app.core.config.static import (
+    CRM_DISPATCH_MAX_ATTEMPTS,
+    CRM_DISPATCH_RETRY_BASE_SECONDS,
+    CRM_DISPATCH_STALE_MINUTES,
+)
+from app.core.logger import logger
+from app.core.logger.context import set_log_context
+from app.crm.connectivity.db import accessor
+from app.crm.connectivity.schemas import QueuedMessage, SendOutcome
+from app.crm.connectivity.send import send
+
+LOG_COMPONENT = "crm.connectivity.dispatch"
+
+# Batch size is operator-configurable and the stale sweep is unbounded, so
+# never interpolate a whole id list into a log line — one bad tick would
+# emit a multi-megabyte record.
+LOG_ID_SAMPLE = 100
+
+# Ceiling on the exponential backoff. Not a config knob: at the default three
+# attempts it is never reached, and it exists only so that raising
+# CRM_DISPATCH_MAX_ATTEMPTS cannot silently park a message for hours.
+RETRY_MAX_SECONDS = 300
+
+# 'failed' is the provider refusing for good; 'dead' is us running out of
+# retries. A merchant asking why nothing arrived needs to know which.
+STATUS_QUEUED = "queued"
+STATUS_ACCEPTED = "accepted"
+STATUS_FAILED = "failed"
+STATUS_DEAD = "dead"
+
+REASON_SEND_ERROR = "send_error"
+REASON_ATTEMPTS_EXHAUSTED = "max_attempts_exhausted"
+REASON_PROVIDER_REJECTED = "provider_rejected"
+
+
+def sample_ids(ids: Sequence[str], limit: int = LOG_ID_SAMPLE) -> str:
+    """Render ids for a log line, bounded. The full set is always recoverable
+    from the rows themselves; an unbounded log line is not worth it."""
+    if len(ids) <= limit:
+        return ", ".join(ids)
+    return f"{', '.join(ids[:limit])} … +{len(ids) - limit} more"
+
+
+def backoff_seconds(attempt: int, base: int, cap: int) -> int:
+    """How long a retry waits. Exponential from ``base``, capped.
+
+    ``attempt`` is already incremented by the claim, so the first retry uses
+    the base delay rather than zero. Retrying a rate-limited send immediately
+    is the one response guaranteed to make it fail again.
+    """
+    return min(base * 2 ** max(attempt - 1, 0), cap)
+
+
+@dataclass(frozen=True)
+class DispatchPlan:
+    status: str
+    reason: Optional[str]
+    provider_message_id: Optional[str]
+    mark_sent: bool
+    # Only set when requeuing; a terminal outcome has no next attempt.
+    retry_after_seconds: Optional[int] = None
+
+
+def plan_for_outcome(
+    outcome: SendOutcome, attempt: int, max_attempts: int
+) -> DispatchPlan:
+    """Decide what one attempt means for the row.
+
+    Pure, so the whole retry policy is testable without a database.
+    ``attempt`` already counts this try — the claim increments it.
+    """
+    if outcome.status == STATUS_ACCEPTED:
+        return DispatchPlan(
+            status=STATUS_ACCEPTED,
+            reason=None,
+            provider_message_id=outcome.provider_message_id,
+            mark_sent=True,
+        )
+
+    # A row with no reason is a support ticket nobody can answer.
+    reason = outcome.reason or REASON_PROVIDER_REJECTED
+
+    if not outcome.retryable:
+        return DispatchPlan(
+            status=STATUS_FAILED,
+            reason=reason,
+            provider_message_id=outcome.provider_message_id,
+            mark_sent=False,
+        )
+
+    if attempt >= max_attempts:
+        # Our reason, not the provider's last error — we stopped, they didn't.
+        return DispatchPlan(
+            status=STATUS_DEAD,
+            reason=REASON_ATTEMPTS_EXHAUSTED,
+            provider_message_id=outcome.provider_message_id,
+            mark_sent=False,
+        )
+
+    # Requeue, but not immediately: the delay is what makes a retry a retry
+    # rather than a second helping of whatever just failed.
+    #
+    # Note this is at-least-once, not exactly-once. The dedupe key stops a
+    # producer creating a second ROW; it cannot stop this row reaching the
+    # provider twice — if the provider accepted the attempt and we lost the
+    # response, the retry sends again. That risk is bounded by the claim
+    # lease, not eliminated.
+    return DispatchPlan(
+        status=STATUS_QUEUED,
+        reason=reason,
+        provider_message_id=outcome.provider_message_id,
+        mark_sent=False,
+        retry_after_seconds=backoff_seconds(
+            attempt, CRM_DISPATCH_RETRY_BASE_SECONDS, RETRY_MAX_SECONDS
+        ),
+    )
+
+
+def _jittered(seconds: Optional[int]) -> Optional[int]:
+    """Spread retries by +-20%, so a provider outage does not produce a
+    synchronised stampede when every backed-off row comes due at once."""
+    if seconds is None:
+        return None
+    return max(1, round(seconds * random.uniform(0.8, 1.2)))
+
+
+async def claim_sends(batch: int) -> List[QueuedMessage]:
+    """The scaffold's claim: sweep stale leases, then claim up to ``batch``.
+
+    Lease-style, not txn-style — the claim commits before any send happens
+    (holding a transaction across a provider call would pin a pooled
+    connection for as long as the network takes), and the stale sweep is
+    what expires a dead worker's lease.
+    """
+    # Reset per pass, so the previous message's ids can't leak into this
+    # pass's claim and sweep lines.
+    set_log_context(component=LOG_COMPONENT)
+
+    # Reclaim first so rows abandoned by a dead worker rejoin this batch
+    # instead of waiting another tick.
+    reclaimed = await accessor.requeue_stale_claims(CRM_DISPATCH_STALE_MINUTES)
+    if reclaimed:
+        # Named, not counted: these are the rows a double-send investigation
+        # starts from.
+        logger.warning(
+            f"crm dispatch reclaimed {len(reclaimed)} stale claim(s): "
+            f"{sample_ids(reclaimed)}"
+        )
+
+    messages = await accessor.claim_queued_messages(batch)
+    _log_queue_lag(messages, batch)
+    return messages
+
+
+def _log_queue_lag(messages: Sequence[QueuedMessage], limit: int) -> None:
+    """How long the oldest claimed row sat past due — the alert that rises
+    whatever the cause. Measured from next_attempt_at (timestamptz NOT NULL,
+    so always aware), not created_at: a retry serving out its backoff is
+    waiting on purpose, and on-purpose waiting is not lag."""
+    if not messages:
+        return
+    oldest = min(m.next_attempt_at for m in messages)
+    lag_s = (datetime.now(timezone.utc) - oldest).total_seconds()
+    logger.info(
+        f"crm dispatch claimed {len(messages)} message(s) lag_s={lag_s:.1f} "
+        f"queue_deeper_than_batch={len(messages) >= limit}: "
+        f"{sample_ids([m.id for m in messages])}"
+    )
+
+
+async def dispatch_send(message: QueuedMessage) -> None:
+    """The scaffold's per-row handler: one claimed message, send to outcome."""
+    await _dispatch_one(message, CRM_DISPATCH_MAX_ATTEMPTS)
+
+
+async def _dispatch_one(message: QueuedMessage, max_attempts: int) -> None:
+    """Work one claimed message.
+
+    Never raises: the rest of the batch is already claimed, so an escaping
+    exception would strand it until those claims expire.
+
+    Nothing is wrapped in a transaction. Holding one across the provider call
+    would pin a pooled connection for as long as the network takes, and one
+    slow provider could then starve the app behind the connection pooler.
+    """
+    # Structured, so a log search can filter by message or merchant instead of
+    # substring-matching the text. Every line below inherits these fields.
+    set_log_context(
+        component=LOG_COMPONENT,
+        message_id=message.id,
+        merchant_id=message.merchant_id,
+        customer_id=message.customer_id,
+        dedupe_key=message.dedupe_key,
+        channel=message.channel,
+        attempt=message.attempt,
+    )
+    try:
+        outcome = await send(message)
+    except Exception as e:
+        # Retryable, not rejected: we don't know whether the provider saw it.
+        # opt(exception=) not exc_info=True — loguru drops the latter's stack.
+        logger.opt(exception=e).error(f"send raised for message {message.id}")
+        outcome = SendOutcome(
+            status=STATUS_FAILED, reason=REASON_SEND_ERROR, retryable=True
+        )
+
+    # message.attempt already counts this try — the claim incremented it.
+    plan = plan_for_outcome(outcome, message.attempt, max_attempts)
+
+    try:
+        applied = await accessor.apply_outcome(
+            message.id,
+            plan.status,
+            plan.reason,
+            plan.provider_message_id,
+            plan.mark_sent,
+            _jittered(plan.retry_after_seconds),
+        )
+    except Exception as e:
+        # Leave it claimed; the sweep will hand it to another worker.
+        # opt(exception=) not exc_info=True — loguru drops the latter's stack.
+        logger.opt(exception=e).error(
+            f"could not record outcome for message {message.id}"
+        )
+        return
+
+    if not applied:
+        # Our send outlasted the claim window and the row already belongs to
+        # someone else. Their outcome wins.
+        logger.warning(
+            f"message {message.id} was reclaimed mid-send — "
+            f"outcome '{plan.status}' discarded"
+        )
+        return
+
+    logger.info(
+        f"message {message.id} -> {plan.status}"
+        + (f" ({plan.reason})" if plan.reason else "")
+    )

--- a/app/crm/connectivity/schemas.py
+++ b/app/crm/connectivity/schemas.py
@@ -1,0 +1,43 @@
+"""Leaf shapes for the connectivity module. Imports nothing internal."""
+
+from datetime import datetime
+from typing import Any, Dict, Literal, Optional
+
+from pydantic import BaseModel
+
+
+class QueuedMessage(BaseModel):
+    """One claimed outbound attempt, as the dispatcher works on it."""
+
+    id: str
+    merchant_id: str
+    customer_id: str
+    channel: str
+    sent_to_address: str
+    binding_id: Optional[str] = None
+    source_kind: str
+    source_id: Optional[str] = None
+    # Unused until the permission check lands: it grants per purpose, not per
+    # customer, so the gate cannot answer without this.
+    purpose_key: str
+    template_id: Optional[str] = None
+    variables: Dict[str, Any] = {}
+    dedupe_key: str
+    attempt: int = 0
+    # When the row became eligible (timestamptz NOT NULL). Carried for the
+    # queue-lag metric, not for any dispatch decision.
+    next_attempt_at: datetime
+
+
+class SendOutcome(BaseModel):
+    """What a connector reports back.
+
+    Deliberately says what the provider did, not what the row should become —
+    that decision stays in dispatch.py. ``reason`` is shown to merchants, so
+    "error" is not a reason.
+    """
+
+    status: Literal["accepted", "failed"]
+    provider_message_id: Optional[str] = None
+    reason: Optional[str] = None
+    retryable: bool = False

--- a/app/crm/connectivity/send.py
+++ b/app/crm/connectivity/send.py
@@ -1,0 +1,40 @@
+"""The provider seam — a dummy for now.
+
+By convention the module's only provider call site: keeping real channel
+adapters behind this file is what lets the manifest answer "did we contact
+this person?" without auditing the whole module.
+
+A real adapter maps the provider's response onto SendOutcome:
+accepted with the provider's message id, or failed with its error code and
+whether retrying could plausibly differ (429 and 5xx yes, bad template no).
+
+TODO before the first real adapter: wrap this call in asyncio.wait_for at the
+dispatcher's call site — one timeout no adapter can forget — well under
+CRM_DISPATCH_STALE_MINUTES, and treat a timeout as a retryable failure. A send
+that outlives its lease gets claimed by a second worker while the first is
+still sending, and the customer receives the message twice. A dummy send
+cannot exceed the lease, which is the only reason nothing enforces this yet.
+"""
+
+from uuid import uuid4
+
+from app.core.logger import logger
+from app.crm.connectivity.schemas import QueuedMessage, SendOutcome
+
+
+async def send(message: QueuedMessage) -> SendOutcome:
+    """Pretend to hand ``message`` to its provider.
+
+    Change the return value by hand to exercise the retry and give-up paths.
+    """
+    provider_message_id = f"dummy-{uuid4().hex[:16]}"
+    # Address masked and variable values omitted — no PII in logs.
+    logger.info(
+        f"[dummy send] channel={message.channel} "
+        f"to=***{message.sent_to_address[-4:]} "
+        f"purpose={message.purpose_key} template={message.template_id} "
+        f"variables={sorted(message.variables)} "
+        f"merchant={message.merchant_id} message={message.id} "
+        f"-> {provider_message_id}"
+    )
+    return SendOutcome(status="accepted", provider_message_id=provider_message_id)

--- a/app/crm/worker_main.py
+++ b/app/crm/worker_main.py
@@ -11,6 +11,7 @@ from app.core.config.static import (
     POSTGRES_MAX_OVERFLOW,
     POSTGRES_POOL_SIZE,
 )
+from app.crm.connectivity.contracts import claim_sends, dispatch_send
 from app.crm.record.contracts import observe_processed_event, run_pass
 from app.crm.shared.worker import run_drain_loop
 
@@ -23,8 +24,16 @@ ROLES: Dict[str, Callable[[asyncio.Event], Coroutine[Any, Any, None]]] = {
         stop_event=stop_event,
         name="event-worker",
     ),
-    # "walker" and "dispatcher" land here when outreach/ and the C-lane ship —
-    # one line each, per the sealed doc's own "copy the manifest" framing.
+    "dispatcher": lambda stop_event: run_drain_loop(
+        claim_sends,
+        dispatch_send,
+        interval=CRM_WORKER_INTERVAL,
+        batch=CRM_WORKER_BATCH,
+        stop_event=stop_event,
+        name="dispatcher",
+    ),
+    # "walker" lands here when outreach/ ships — one line, per the sealed
+    # doc's own "copy the manifest" framing.
 }
 
 _task: Optional[asyncio.Task] = None

--- a/app/database/migrations/056_create_crm_message.sql
+++ b/app/database/migrations/056_create_crm_message.sql
@@ -1,0 +1,183 @@
+-- 056: crm_message — one row per outbound send attempt, on any channel.
+--
+-- A blocked or failed attempt is still a row: this table is what answers
+-- "why didn't my customer get the message", so an attempt that never reached
+-- a provider has to be as visible as one that did.
+--
+-- Places this deliberately does NOT do the obvious thing:
+--
+-- 1. Not partitioned. A partitioned table's unique constraints must include
+--    the partition key, which would break the dedupe index below. Partition
+--    later, when volume actually calls for it.
+-- 2. No format check on sent_to_address. It holds a phone number, an email or
+--    an account id depending on the channel, so any check would have to
+--    branch on channel — and channel values must stay changeable without a
+--    migration. Writers normalise instead.
+-- 3. No trigger forcing status to move forward only. Delivery receipts do
+--    arrive out of order and will need that rule, but the dispatcher moves
+--    rows backwards on purpose when it reclaims an abandoned one.
+--
+-- And two places this KNOWINGLY departed from the written table spec when
+-- first recorded. RULED 29-Aug-2026: canon T16 was amended to adopt both, so
+-- these notes are now the trail of how the spec got there, not open questions:
+--
+-- 4. customer_id carries a composite FK, where the spec says "No FK"
+--    (justified there by partitioning + high volume: stamped at write, never
+--    joined at read). We are not partitioned (see 1), so the FK costs little,
+--    and it buys something real: without it a wrong merchant_id would file a
+--    message against a customer belonging to another tenant, and every
+--    journey read for that customer would then be wrong. Revisit when
+--    partitioning lands — a composite FK is one of the things that makes
+--    partitioning harder.
+-- 5. No CHECK on source_kind, where the spec marks it CK with a fixed list
+--    (broadcast · workflow · agent · transactional). The migration-027 scar
+--    says vocabulary lives in code and never in a CHECK, because a CHECK is
+--    exactly what made a new channel a migration rather than a deploy. We
+--    followed the scar. NOTE the gap that leaves: "vocabulary in code" means
+--    a code dictionary validates it somewhere, and today NOTHING validates
+--    source_kind at all — that dictionary must land with the first producer.
+
+CREATE TABLE crm_message (
+    id                  uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    merchant_id         text NOT NULL,
+    customer_id         uuid NOT NULL,
+    -- Frozen at send time even as the customer's own contact details change,
+    -- so an audit can always say where a message actually went.
+    sent_to_address     text NOT NULL,
+    -- Stored rather than derived from binding_id, because a message refused
+    -- before a route was picked has no binding and permission is per channel.
+    channel             text NOT NULL,
+    -- Which configured endpoint it left on. Null on refused rows, and on
+    -- every row until endpoints exist.
+    binding_id          uuid,
+    -- What caused this send, e.g. a broadcast, a workflow run, an agent
+    -- reply, or the event that triggered it. Every funnel metric groups by
+    -- these two.
+    source_kind         text NOT NULL,
+    source_id           uuid,
+    -- The declared reason for contacting them, checked against what they
+    -- agreed to. Not null because the permission check cannot answer without
+    -- it, and an unanswerable check has to refuse.
+    purpose_key         text NOT NULL,
+    -- The provider renders the final text from these, so we never store a
+    -- rendered string: it would only ever be our guess at their render.
+    template_id         text,
+    -- Plain jsonb accepts scalars and arrays too; the decoder drops anything
+    -- that is not an object rather than the table rejecting the write.
+    variables           jsonb NOT NULL DEFAULT '{}'::jsonb,
+    --   queued -> sending -> blocked | accepted -> sent -> delivered -> read
+    --   sending -> failed -> dead
+    -- 'failed' is the provider refusing; 'dead' is us running out of retries.
+    status              text NOT NULL DEFAULT 'queued'
+                        CHECK (status IN ('queued', 'sending', 'blocked',
+                                          'accepted', 'sent', 'delivered',
+                                          'read', 'failed', 'dead')),
+    -- Holds either our refusal (no_consent, quiet_hours) or the provider's
+    -- error code. A row is refused by us or by them, never both, so a second
+    -- column would always be null.
+    reason              text,
+    provider_message_id text,
+    attempt             smallint NOT NULL DEFAULT 0,
+    -- The provider's own charge from the delivery receipt, never our
+    -- rate-card arithmetic.
+    cost_micros         bigint,
+    -- Points at the permission decision that authorised this send. No foreign
+    -- key: that table is not on this branch yet.
+    decision_id         bigint,
+    -- Not null and no default: the producer must name the logical send.
+    -- Every real producer has a natural key (the triggering event,
+    -- enrolment:node), and an omittable column is a protection silently
+    -- skipped.
+    dedupe_key          text NOT NULL,
+    -- Set while a worker holds the row; doubles as the lease that lets an
+    -- abandoned row be spotted and requeued.
+    claimed_at          timestamptz,
+    -- When this row may next be attempted. now() for a new message, pushed
+    -- into the future by a retry. The gate's quiet-hours deferral will write
+    -- its next_allowed_at here too.
+    next_attempt_at     timestamptz NOT NULL DEFAULT now(),
+    -- No updated_at: every state below stamps its own timestamp, so a generic
+    -- "something changed" would say less and cost a trigger on every write.
+    created_at          timestamptz NOT NULL DEFAULT now(),
+    sent_at             timestamptz,
+    delivered_at        timestamptz,
+    -- Only channels that report reads ever fill this.
+    read_at             timestamptz,
+    -- Composite so a message can never be attached to another tenant's
+    -- customer; a plain customer_id reference would accept any uuid.
+    FOREIGN KEY (merchant_id, customer_id)
+        REFERENCES crm_customer (merchant_id, id)
+);
+
+-- The only thing between a producer running twice and a customer getting the
+-- same message twice. Total, not partial: the column is NOT NULL, so there is
+-- no row this misses.
+CREATE UNIQUE INDEX crm_message_merchant_dedupe_uq
+    ON crm_message (merchant_id, dedupe_key);
+
+-- The queue itself: due first, across all tenants. Filtering AND sorting on
+-- next_attempt_at is what makes a retry wait its turn — on created_at it
+-- would keep its original timestamp and jump ahead of every fresh message.
+-- For a new row the two are equal, so FIFO fairness is unchanged.
+CREATE INDEX crm_message_queued_ix
+    ON crm_message (next_attempt_at)
+    WHERE status = 'queued';
+
+-- Finding rows whose worker never came back.
+CREATE INDEX crm_message_claimed_ix
+    ON crm_message (claimed_at)
+    WHERE status = 'sending';
+
+-- Analytics. Both are merchant-first so a tenant's slice is a range scan
+-- rather than a filter over everyone's rows, and both carry created_at DESC
+-- because every reporting question is time-bounded ("last 7 days") or
+-- newest-first.
+--
+-- Serves: one merchant's messages, newest first · counts grouped by status
+-- for a merchant over a window · platform-wide totals grouped by merchant,
+-- which can aggregate in index order instead of sorting.
+CREATE INDEX crm_message_merchant_created_ix
+    ON crm_message (merchant_id, created_at DESC);
+
+-- The per-customer drill-down behind a merchant's view of one person.
+CREATE INDEX crm_message_merchant_customer_ix
+    ON crm_message (merchant_id, customer_id, created_at DESC);
+
+-- One real provider message is one row. A WRITE rule, not a read index, and
+-- this table already writes the column — deferring it to the receipt walker
+-- would land the rule after the writes it governs.
+--
+-- DELIBERATELY NOT merchant-scoped: the one exception to "merchant_id first
+-- in every unique index". That law protects OUR identifiers, unique only
+-- within a tenant. A provider id is unique worldwide, so scoping it per
+-- merchant would let two tenants each record the same real message.
+CREATE UNIQUE INDEX crm_message_provider_id_uq
+    ON crm_message (provider_message_id)
+    WHERE provider_message_id IS NOT NULL;
+
+-- What was proposed is frozen; only the delivery envelope moves. An audit
+-- record whose contents can be rewritten afterwards is a claim about what we
+-- sent, not evidence of it — and intent alone does not stop an UPDATE.
+CREATE OR REPLACE FUNCTION crm_message_immutable() RETURNS trigger AS $$
+BEGIN
+    IF NEW.id              IS DISTINCT FROM OLD.id
+       OR NEW.merchant_id     IS DISTINCT FROM OLD.merchant_id
+       OR NEW.customer_id     IS DISTINCT FROM OLD.customer_id
+       OR NEW.sent_to_address IS DISTINCT FROM OLD.sent_to_address
+       OR NEW.channel         IS DISTINCT FROM OLD.channel
+       OR NEW.source_kind     IS DISTINCT FROM OLD.source_kind
+       OR NEW.source_id       IS DISTINCT FROM OLD.source_id
+       OR NEW.purpose_key     IS DISTINCT FROM OLD.purpose_key
+       OR NEW.template_id     IS DISTINCT FROM OLD.template_id
+       OR NEW.variables       IS DISTINCT FROM OLD.variables
+       OR NEW.dedupe_key      IS DISTINCT FROM OLD.dedupe_key
+       OR NEW.created_at      IS DISTINCT FROM OLD.created_at THEN
+        RAISE EXCEPTION 'crm_message: these fields are immutable and one of them changed — id, merchant_id, customer_id, sent_to_address, channel, source_kind, source_id, purpose_key, template_id, variables, dedupe_key, created_at';
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER crm_message_immutable_guard
+    BEFORE UPDATE ON crm_message
+    FOR EACH ROW EXECUTE FUNCTION crm_message_immutable();

--- a/app/main.py
+++ b/app/main.py
@@ -93,7 +93,7 @@ _background_scheduler = None
 @asynccontextmanager
 async def lifespan(_app: FastAPI):
     """FastAPI lifespan manager that handles startup and shutdown tasks."""
-    logger.info(f"Application startup... (POD_ROLE={POD_ROLE})")
+    logger.info(f"Application startup... (POD_ROLE={POD_ROLE}, CRM_ROLE={CRM_ROLE})")
 
     # Size the executor backing asyncio.to_thread() before anything can use it.
     # See BLOCKING_THREAD_POOL_SIZE in static.py for why the default is wrong.

--- a/scripts/check_crm_boundaries.py
+++ b/scripts/check_crm_boundaries.py
@@ -49,6 +49,7 @@ TABLE_OWNERS = {
     "platform_identity": "platform",
     "crm_event_raw": "record",
     "crm_journey_event": "record",
+    "crm_message": "connectivity",
 }
 
 # Pre-existing legacy inversions, allowlisted and CLOSED to additions

--- a/tests/crm/test_dispatch.py
+++ b/tests/crm/test_dispatch.py
@@ -1,0 +1,511 @@
+"""The dispatcher's retry policy, its plumbing, its SQL builders, and the DDL."""
+
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+
+from app.core.config.static import _positive_float, _positive_int
+from app.crm.connectivity import dispatch
+from app.crm.connectivity.db.decoder import (
+    _load_variables,
+    decode_queued_message,
+)
+from app.crm.connectivity.db.queries import (
+    CLAIMED_COLUMNS,
+    apply_outcome_query,
+    claim_queued_messages_query,
+    requeue_stale_claims_query,
+)
+from app.crm.connectivity.dispatch import (
+    REASON_ATTEMPTS_EXHAUSTED,
+    REASON_PROVIDER_REJECTED,
+    REASON_SEND_ERROR,
+    RETRY_MAX_SECONDS,
+    STATUS_ACCEPTED,
+    STATUS_DEAD,
+    STATUS_FAILED,
+    STATUS_QUEUED,
+    _jittered,
+    backoff_seconds,
+    plan_for_outcome,
+    sample_ids,
+)
+from app.crm.connectivity.schemas import QueuedMessage, SendOutcome
+from scripts.check_crm_boundaries import TABLE_OWNERS
+
+MIGRATION = Path("app/database/migrations/056_create_crm_message.sql")
+
+
+def _ddl() -> str:
+    """The migration with comment prose stripped: a structural assertion that
+    passes on the paragraph explaining an absence proves nothing."""
+    return "\n".join(
+        line
+        for line in MIGRATION.read_text().splitlines()
+        if not line.lstrip().startswith("--")
+    )
+
+
+# --- the retry policy -------------------------------------------------------
+
+
+def test_accepted_records_the_provider_id_and_stamps_sent() -> None:
+    plan = plan_for_outcome(
+        SendOutcome(status="accepted", provider_message_id="wamid.X"), 1, 3
+    )
+    assert plan.status == STATUS_ACCEPTED
+    assert plan.provider_message_id == "wamid.X"
+    assert plan.mark_sent is True
+    assert plan.reason is None
+
+
+def test_retryable_failure_goes_back_on_the_queue() -> None:
+    plan = plan_for_outcome(
+        SendOutcome(status="failed", reason="rate_limited", retryable=True), 1, 3
+    )
+    assert plan.status == STATUS_QUEUED
+    assert plan.reason == "rate_limited"
+    assert plan.mark_sent is False
+
+
+def test_retryable_failure_goes_dead_on_the_last_attempt() -> None:
+    plan = plan_for_outcome(
+        SendOutcome(status="failed", reason="rate_limited", retryable=True), 3, 3
+    )
+    # 'dead' (we stopped trying), not 'failed' (the wire said no).
+    assert plan.status == STATUS_DEAD
+    assert plan.reason == REASON_ATTEMPTS_EXHAUSTED
+
+
+def test_permanent_failure_never_retries_however_many_attempts_remain() -> None:
+    plan = plan_for_outcome(
+        SendOutcome(status="failed", reason="template_not_approved"), 1, 99
+    )
+    assert plan.status == STATUS_FAILED
+    assert plan.reason == "template_not_approved"
+
+
+def test_failure_without_a_reason_still_records_one() -> None:
+    plan = plan_for_outcome(SendOutcome(status="failed"), 1, 3)
+    assert plan.reason == REASON_PROVIDER_REJECTED
+
+
+def test_a_send_that_never_reports_cannot_be_marked_sent() -> None:
+    for outcome in (
+        SendOutcome(status="failed", reason="boom", retryable=True),
+        SendOutcome(status="failed", reason="boom"),
+    ):
+        assert plan_for_outcome(outcome, 1, 3).mark_sent is False
+
+
+# --- the plumbing never raises -----------------------------------------------
+# The policy (plan_for_outcome) is pure and pinned above; these pin the paths
+# AROUND it — the never-raises contract that keeps a claimed batch alive.
+
+
+def _message(attempt: int = 1) -> QueuedMessage:
+    return QueuedMessage(
+        id="m-1",
+        merchant_id="m-1000",
+        customer_id="c-1",
+        channel="whatsapp",
+        sent_to_address="+919812345678",
+        source_kind="broadcast",
+        purpose_key="utility.order_update",
+        dedupe_key="k-1",
+        attempt=attempt,
+        next_attempt_at=datetime.now(timezone.utc),
+    )
+
+
+async def test_an_accepted_send_records_the_outcome(monkeypatch) -> None:
+    written = {}
+
+    async def fake_send(message):
+        written["sent"] = message.id
+        return SendOutcome(status="accepted", provider_message_id="wamid.T")
+
+    async def record_outcome(message_id, status, reason, pmid, mark_sent, retry):
+        written.update(status=status, mark_sent=mark_sent)
+        return True
+
+    monkeypatch.setattr(dispatch, "send", fake_send)
+    monkeypatch.setattr(dispatch.accessor, "apply_outcome", record_outcome)
+    await dispatch._dispatch_one(_message(), 3)
+    assert written["sent"] == "m-1"
+    assert written["status"] == STATUS_ACCEPTED
+    assert written["mark_sent"] is True
+
+
+async def test_a_raising_send_becomes_a_retryable_send_error(monkeypatch) -> None:
+    written = {}
+
+    async def broken_send(message):
+        raise RuntimeError("wire fell over")
+
+    async def record_outcome(message_id, status, reason, pmid, mark_sent, retry):
+        written.update(status=status, reason=reason, retry=retry)
+        return True
+
+    monkeypatch.setattr(dispatch, "send", broken_send)
+    monkeypatch.setattr(dispatch.accessor, "apply_outcome", record_outcome)
+    await dispatch._dispatch_one(_message(attempt=1), 3)
+    # We don't know whether the provider saw it, so it requeues with a delay.
+    assert written["status"] == STATUS_QUEUED
+    assert written["reason"] == REASON_SEND_ERROR
+    assert written["retry"] is not None and written["retry"] >= 1
+
+
+async def test_a_reclaimed_row_discards_the_late_outcome(monkeypatch) -> None:
+    calls = []
+
+    async def fake_send(message):
+        return SendOutcome(status="accepted", provider_message_id="wamid.L")
+
+    async def reclaimed(message_id, status, reason, pmid, mark_sent, retry):
+        calls.append(status)
+        return False  # the sweep already handed this row to another worker
+
+    monkeypatch.setattr(dispatch, "send", fake_send)
+    monkeypatch.setattr(dispatch.accessor, "apply_outcome", reclaimed)
+    await dispatch._dispatch_one(_message(), 3)
+    # Discarded means one write attempt, no retry, no raise — their row now.
+    assert calls == [STATUS_ACCEPTED]
+
+
+def test_jitter_stays_in_bounds_and_never_reaches_zero() -> None:
+    assert _jittered(None) is None
+    for _ in range(500):
+        spread = _jittered(30)
+        assert spread is not None and 24 <= spread <= 36  # +-20% of 30
+        # An instant retry is the one thing jitter must never produce.
+        floor = _jittered(1)
+        assert floor is not None and floor >= 1
+
+
+# --- the SQL builders -------------------------------------------------------
+
+
+def test_claim_is_race_safe_across_pods() -> None:
+    query, values = claim_queued_messages_query(25)
+    assert "FOR UPDATE SKIP LOCKED" in query
+    assert "status = 'queued'" in query
+    assert "LIMIT $1" in query
+    assert values == [25]
+
+
+# --- log lines stay bounded --------------------------------------------------
+
+
+def test_sample_ids_lists_everything_when_it_fits() -> None:
+    assert sample_ids(["a", "b"], limit=10) == "a, b"
+    assert sample_ids([], limit=10) == ""
+
+
+def test_sample_ids_truncates_and_says_how_many_it_hid() -> None:
+    # Batch size is operator-tunable and the stale sweep is unbounded, so an
+    # uncapped join could emit a multi-megabyte log record.
+    out = sample_ids([f"id-{n}" for n in range(1000)], limit=3)
+    assert out == "id-0, id-1, id-2 … +997 more"
+    assert len(out) < 200
+
+
+# --- the worker role --------------------------------------------------------
+# Loop mechanics (pacing, backoff, heartbeat, per-row isolation) belong to
+# the shared scaffold and are pinned in test_event_worker.py; here we pin
+# only that the dispatcher is wired into it.
+
+
+def test_dispatcher_is_a_registered_worker_role() -> None:
+    # start_worker_role raises on an unregistered role, so without this entry
+    # a CRM_ROLE=dispatcher pod crashes at boot.
+    from app.crm.worker_main import ROLES
+
+    assert "dispatcher" in ROLES
+
+
+def test_contracts_export_the_scaffold_pair() -> None:
+    # worker_main may import only the module's contracts — the claim/handle
+    # pair must be reachable there, not by deep import.
+    from app.crm.connectivity import contracts
+
+    assert callable(contracts.claim_sends)
+    assert callable(contracts.dispatch_send)
+
+
+# --- the dials read from the environment -------------------------------------
+
+
+def test_a_bad_dial_falls_back_instead_of_stopping_the_pod(monkeypatch) -> None:
+    # Lenient by choice: raising here would fail the pod at import, and a
+    # mistyped retry dial should not be able to do that.
+    for bad in ("", "fast", "1.5", "0", "-1"):
+        monkeypatch.setenv("DIAL", bad)
+        assert _positive_int("DIAL", 25) == 25
+    monkeypatch.delenv("DIAL")
+    assert _positive_int("DIAL", 25) == 25
+    monkeypatch.setenv("DIAL", "50")
+    assert _positive_int("DIAL", 25) == 50
+
+
+def test_a_bad_float_dial_falls_back_too(monkeypatch) -> None:
+    # Guards CRM_WORKER_INTERVAL/HEARTBEAT. 'inf' is the dangerous one: it
+    # parses, it compares > 0, and an infinite poll interval is a worker that
+    # sleeps forever after its first empty poll.
+    for bad in ("", "slow", "0", "-0.5", "inf", "-inf", "nan"):
+        monkeypatch.setenv("DIAL", bad)
+        assert _positive_float("DIAL", 1.0) == 1.0
+    monkeypatch.delenv("DIAL")
+    assert _positive_float("DIAL", 1.0) == 1.0
+    monkeypatch.setenv("DIAL", "0.25")
+    assert _positive_float("DIAL", 1.0) == 0.25
+
+
+def test_retry_waits_longer_each_attempt_then_caps() -> None:
+    # Retrying a rate-limited send instantly is the one response guaranteed
+    # to make it fail again.
+    assert backoff_seconds(1, 30, RETRY_MAX_SECONDS) == 30
+    assert backoff_seconds(2, 30, RETRY_MAX_SECONDS) == 60
+    assert backoff_seconds(3, 30, RETRY_MAX_SECONDS) == 120
+    # The ceiling only binds if MAX_ATTEMPTS is raised well past its default.
+    assert backoff_seconds(9, 30, RETRY_MAX_SECONDS) == RETRY_MAX_SECONDS
+
+
+def test_requeue_carries_a_delay_and_terminal_outcomes_do_not() -> None:
+    requeued = plan_for_outcome(
+        SendOutcome(status="failed", reason="131049", retryable=True), 1, 3
+    )
+    assert requeued.status == STATUS_QUEUED
+    assert requeued.retry_after_seconds and requeued.retry_after_seconds > 0
+
+    for terminal in (
+        plan_for_outcome(SendOutcome(status="accepted"), 1, 3),
+        plan_for_outcome(SendOutcome(status="failed", reason="bad_template"), 1, 3),
+        plan_for_outcome(
+            SendOutcome(status="failed", reason="131049", retryable=True), 3, 3
+        ),
+    ):
+        assert terminal.retry_after_seconds is None
+
+
+def test_claim_returns_when_rows_came_due_for_the_lag_metric() -> None:
+    # The lag log line reads next_attempt_at off the claimed row; dropping it
+    # from CLAIMED_COLUMNS would fail the decoder on every claimed batch.
+    assert "next_attempt_at" in CLAIMED_COLUMNS
+
+
+def test_queue_filters_and_orders_by_when_a_row_is_due() -> None:
+    # Ordering by created_at would send a requeued row to the FRONT on its
+    # original timestamp, retrying it ahead of every fresh message.
+    query, _ = claim_queued_messages_query(25)
+    assert "next_attempt_at <= now()" in query
+    assert "ORDER BY next_attempt_at" in query
+    assert "ORDER BY created_at" not in query
+
+
+def test_only_a_requeue_moves_the_next_attempt_time() -> None:
+    query, values = apply_outcome_query(
+        "m-1", "queued", "rate_limited", None, False, 30
+    )
+    assert "make_interval(secs => $6::int)" in query
+    assert values[5] == 30
+
+
+def test_claim_burns_an_attempt_so_a_dead_worker_cannot_loop_forever() -> None:
+    query, _ = claim_queued_messages_query(10)
+    assert "attempt = attempt + 1" in query
+
+
+def test_outcome_write_is_guarded_by_the_claim() -> None:
+    query, values = apply_outcome_query("m-1", "accepted", None, "wamid.X", True, None)
+    assert "status = 'sending'" in query
+    assert values == ["m-1", "accepted", None, "wamid.X", True, None]
+
+
+def test_outcome_write_never_erases_a_known_provider_id() -> None:
+    query, _ = apply_outcome_query("m-1", "queued", "rate_limited", None, False, 30)
+    assert "COALESCE($4, provider_message_id)" in query
+
+
+def test_stale_sweep_targets_only_expired_claims() -> None:
+    query, values = requeue_stale_claims_query(5)
+    assert "status = 'sending'" in query
+    assert "make_interval(mins => $1::int)" in query
+    assert values == [5]
+
+
+def test_builders_parameterize_every_value() -> None:
+    # A mismatch is an unbound $n or, worse, a value that got interpolated.
+    for query, values in (
+        claim_queued_messages_query(25),
+        requeue_stale_claims_query(5),
+        apply_outcome_query("m-1", "failed", "nope", None, False, None),
+    ):
+        placeholders = set(re.findall(r"\$(\d+)", query))
+        assert placeholders == {str(n) for n in range(1, len(values) + 1)}
+
+
+# --- the decoder can never stop the queue -----------------------------------
+
+
+def test_load_variables_is_total() -> None:
+    # A raise here would strand a whole claimed batch in 'sending', forever.
+    cases = [
+        ('{"name":"Priya"}', {"name": "Priya"}),  # the live path
+        ("{}", {}),
+        ('{"a":{"b":1}}', {"a": {"b": 1}}),
+        ("42", {}),
+        ("[1,2]", {}),
+        ("null", {}),
+        ('"hi"', {}),
+        ("not json at all", {}),
+        ("", {}),
+        (None, {}),
+        ({"a": 1}, {"a": 1}),  # if a jsonb codec is ever registered
+        (42, {}),
+        (3.14, {}),
+        (True, {}),
+        (["a", "b"], {}),
+    ]
+    for value, expected in cases:
+        assert _load_variables(value) == expected, value
+
+
+def test_load_variables_refuses_to_invent_variables() -> None:
+    # dict([["a", 1]]) == {"a": 1} would post a variable nobody wrote.
+    assert _load_variables([["a", 1]]) == {}
+    assert _load_variables([("a", 1)]) == {}
+
+
+def test_decoded_variables_do_not_alias_the_row() -> None:
+    row = {"a": 1}
+    decoded = _load_variables(row)
+    decoded["b"] = 2
+    assert row == {"a": 1}
+
+
+# --- the table --------------------------------------------------------------
+
+
+def test_manifest_is_owned_by_connectivity() -> None:
+    assert TABLE_OWNERS["crm_message"] == "connectivity"
+
+
+def test_dedupe_key_is_mandatory_and_unique_per_merchant() -> None:
+    # The only thing between a crash-retry and a duplicate send, so it covers
+    # every row: NOT NULL with no default, and a total (not partial) unique.
+    sql = _ddl()
+    assert "dedupe_key          text NOT NULL" in sql
+    assert "crm_message (merchant_id, dedupe_key);" in sql
+    assert "WHERE dedupe_key IS NOT NULL" not in sql
+
+
+def test_expected_columns_are_all_present() -> None:
+    sql = _ddl()
+    for column in (
+        "binding_id",
+        "purpose_key",
+        "cost_micros",
+        "decision_id",
+        "attempt",
+        "source_kind",
+        "source_id",
+        "provider_message_id",
+        "delivered_at",
+        "read_at",
+    ):
+        assert column in sql, column
+
+
+def test_decision_id_matches_the_diary_pages() -> None:
+    # The permission decision table keys on a bigserial; a uuid would not join.
+    sql = _ddl()
+    assert "decision_id         bigint" in sql
+
+
+def test_variables_shape_is_enforced_in_code_not_in_the_table() -> None:
+    # Any JSON value is a legal row; _load_variables neutralises the rest.
+    sql = _ddl()
+    assert "variables           jsonb NOT NULL" in sql
+    assert "jsonb_typeof" not in sql
+
+
+def test_purpose_key_cannot_be_null() -> None:
+    # A mandatory gate input, and missing inputs must fail closed.
+    sql = _ddl()
+    assert "purpose_key         text NOT NULL" in sql
+
+
+def test_proposal_fields_are_immutable_by_trigger() -> None:
+    sql = _ddl()
+    assert "crm_message_immutable_guard" in sql
+    for frozen in ("sent_to_address", "purpose_key", "variables", "dedupe_key"):
+        assert f"NEW.{frozen}" in sql, frozen
+    # The envelope must stay writable, or the dispatcher cannot work.
+    for mutable in ("status", "claimed_at", "next_attempt_at", "provider_message_id"):
+        assert f"NEW.{mutable} " not in sql, mutable
+
+
+def test_the_work_queue_is_a_partial_index() -> None:
+    sql = _ddl()
+    assert "crm_message_queued_ix" in sql
+    assert "WHERE status = 'queued'" in sql
+    assert "crm_message_claimed_ix" in sql
+
+
+def test_index_set_is_exactly_what_is_read() -> None:
+    # Three for the loop, two for analytics. The delivery-receipt index ships
+    # with the walker that queries it — an unused index is a write cost.
+    sql = _ddl()
+    created = set(re.findall(r"CREATE (?:UNIQUE )?INDEX (\w+)", sql))
+    assert created == {
+        "crm_message_merchant_dedupe_uq",
+        "crm_message_queued_ix",
+        "crm_message_claimed_ix",
+        "crm_message_merchant_created_ix",
+        "crm_message_merchant_customer_ix",
+        "crm_message_provider_id_uq",
+    }
+
+
+def test_one_provider_message_is_one_row() -> None:
+    # A write rule, not a read index: recording the same provider id twice
+    # must be impossible. Not merchant-scoped on purpose — a provider id is
+    # globally unique, so scoping it per tenant would let two merchants each
+    # record the same real message.
+    sql = _ddl()
+    assert "crm_message (provider_message_id)" in sql
+    assert "(merchant_id, provider_message_id)" not in sql
+
+
+def test_analytics_indexes_are_merchant_first_and_time_ordered() -> None:
+    # merchant-first makes a tenant's slice a range scan, not a filter over
+    # everyone; created_at DESC matches how every report reads.
+    sql = _ddl()
+    assert "crm_message (merchant_id, created_at DESC)" in sql
+    assert "crm_message (merchant_id, customer_id, created_at DESC)" in sql
+
+
+def test_no_touch_trigger_because_there_is_no_updated_at() -> None:
+    # Every state stamps its own clock; same choice as crm_event_raw (051).
+    sql = _ddl()
+    assert "updated_at" not in sql
+    assert "crm_touch_updated_at" not in sql
+    assert "crm_message_immutable_guard" in sql
+
+
+def test_status_is_a_closed_enum_but_channel_is_not() -> None:
+    # Format CHECKs are required; vocabulary CHECKs are the 027 scar.
+    sql = _ddl()
+    assert "CHECK (status IN (" in sql
+    for state in ("queued", "sending", "blocked", "accepted", "sent", "dead"):
+        assert f"'{state}'" in sql, state
+    # Vocabulary in a CHECK is the migration-027 scar.
+    assert "CHECK (channel" not in sql
+    assert "CHECK (source_kind" not in sql
+
+
+def test_customer_fk_is_composite_so_a_message_cannot_cross_tenants() -> None:
+    sql = _ddl()
+    assert "FOREIGN KEY (merchant_id, customer_id)" in sql
+    assert "REFERENCES crm_customer (merchant_id, id)" in sql


### PR DESCRIPTION
- Note: send() is a dummy; the real adapter and inbound webhooks land separately.
- Adds app/crm/connectivity and the crm_message table it owns — one row per attempted transmission on any channel, refused attempts included, so the console can answer why nothing arrived.
- The dispatcher rides #1020's shared drain-loop scaffold: claim_sends()/dispatch_send() register as the "dispatcher" role in worker_main.py, one ROLES line per design/worker-runtime.md. Lease-style claim — FOR UPDATE SKIP LOCKED, commit, send outside any transaction; the stale sweep expires a dead worker's lease. No Redis lock, so throughput scales by replicas. The claim logs queue lag from next_attempt_at.
- Retries back off instead of firing instantly: next_attempt_at both filters and orders the queue, so a retry waits (30s, 60s, 120s) and stops jumping ahead of fresh messages.
- One real provider message is one row: a partial UNIQUE on provider_message_id, deliberately not merchant-scoped since a provider id is globally unique.
- Hardens the shared CRM_WORKER_* dials with lenient parsing (a typo'd value falls back to its default instead of failing the pod at import); loguru handlers use opt(exception=e), the only form that emits a stack.
- Migration 056. 160 tests. check_crm_boundaries clean.

dev proof:
[
<img width="2498" height="605" alt="Screenshot 2026-08-26 at 5 13 10 PM" src="https://github.com/user-attachments/assets/fbec96b4-c389-4ad7-8946-9d5acfe613ae" />
](url)
<img width="1129" height="265" alt="Screenshot 2026-08-26 at 6 01 21 PM" src="https://github.com/user-attachments/assets/81bb851f-03b6-44b6-bb30-752896c07faf" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added outbound CRM message dispatching with batching, retries, throttling, stale-claim recovery, and graceful worker lifecycle management.
  * Added configurable CRM role and dispatch controls, including batch size, retry limits, delays, and timeouts.
  * Added persistent outbound message tracking with delivery status, deduplication, provider details, and retry state.
  * Added a provider connectivity interface with accepted delivery responses.

* **Bug Fixes**
  * Added safeguards to prevent unmasked personally identifiable information in CRM logs.

* **Documentation**
  * Updated CRM boundary documentation to reflect 11 enforced rules and provider integration requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->