### PR TITLE
feat(voice): support for context-compactor in pipeline

### DIFF
--- a/app/ai/voice/agents/breeze_buddy/agent/context_compactor.py
+++ b/app/ai/voice/agents/breeze_buddy/agent/context_compactor.py
@@ -1,0 +1,267 @@
+"""Voice-side context compaction for MCP tool results.
+
+Chat compacts the large Shopify UCP catalog results via
+``compact_tool_results_universal`` (``chat/history/compactor.py``), which
+operates on ``role:"tool"`` messages. The voice pipeline stores MCP results
+differently: our MCP functions run with ``cancel_on_interruption=False``, so
+pipecat treats them as *async* tools and records the result on a
+``role:"developer"`` message inside an ``async_tool`` JSON envelope (see
+pipecat's ``LLMAssistantAggregator._handle_function_call_finished``). That
+envelope is invisible to the chat compactor, so voice needs its own wrapper
+that reads the envelope, resolves the tool name via the matching assistant
+``tool_call``, and rewrites only the inner ``result`` to a slim projection or
+stub. This reuses the chat compactor's projection/stub helpers so behavior
+stays consistent across both pipelines.
+"""
+
+import json
+from typing import Any, Dict, List, Optional
+
+from pipecat.processors.aggregators.llm_response_universal import (
+    LLMAssistantAggregator,
+    LLMContextAggregatorPair,
+    LLMUserAggregatorParams,
+)
+
+from app.ai.voice.agents.breeze_buddy.chat.history.compactor import (
+    _DEFAULT_RETENTION,
+    _project_content,
+    _stub_for,
+)
+from app.core.logger import logger
+
+
+def build_tool_context_maps(
+    configurations: Optional[Any],
+) -> tuple[Dict[str, str], Dict[str, List[str]], int]:
+    """Extract per-tool retention/projection policies from a template's MCP servers.
+
+    Mirrors the chat path (``chat/agent/tooling.py``): every server's
+    ``tool_context_retention`` / ``tool_context_projection`` maps are merged.
+    Templates that don't set the fields return empty maps, which makes the
+    compactor a no-op — so compaction is opt-in per template.
+
+    Also merges ``bypass_compaction_for_turns`` across servers by taking the
+    max — one server opting into a grace window shouldn't be zeroed out by
+    another server that left the field at its default.
+    """
+    retention: Dict[str, str] = {}
+    projection: Dict[str, List[str]] = {}
+    recent_keep = 0
+    mcp_config = getattr(configurations, "mcp", None) if configurations else None
+    servers = getattr(mcp_config, "servers", None) if mcp_config else None
+    for server in servers or []:
+        if getattr(server, "tool_context_retention", None):
+            retention.update(server.tool_context_retention)
+        if getattr(server, "tool_context_projection", None):
+            projection.update(server.tool_context_projection)
+        recent_keep = max(
+            recent_keep, getattr(server, "bypass_compaction_for_turns", 0) or 0
+        )
+    return retention, projection, recent_keep
+
+
+def _parse_async_tool(msg: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    """Parse a ``role:"developer"`` message's content into its async_tool envelope.
+
+    Returns ``None`` when the content isn't an ``async_tool`` envelope (for
+    example a plain developer note), in which case the message is left alone.
+    """
+    content = msg.get("content")
+    if not isinstance(content, str):
+        return None
+    try:
+        parsed = json.loads(content)
+    except (TypeError, ValueError):
+        return None
+    if not isinstance(parsed, dict) or parsed.get("type") != "async_tool":
+        return None
+    return parsed
+
+
+def _unwrap_result(result: Any) -> Any:
+    """Unwrap the Clairvoyance tool-result envelope into the payload.
+
+    MCP HTTP handlers return ``{"status": "success", "data": "<json string>"}``
+    (``mcp/__init__.py``), which is stored verbatim as the ``async_tool``
+    envelope's ``result``. The chat compactor projects against the *payload*
+    (``products[*].title`` etc.), so voice must strip the envelope before
+    projecting; otherwise every collection degrades to a stub. When ``data`` is
+    itself JSON-encoded, it is decoded so the keep-paths resolve against real
+    keys. The chat path achieves the same unwrapping via ``result_normalizer``.
+    Non-string and non-envelope values pass through unchanged.
+    """
+    if not isinstance(result, str):
+        return result
+    try:
+        obj = json.loads(result)
+    except (TypeError, ValueError):
+        return result
+    if isinstance(obj, dict) and "status" in obj and "data" in obj:
+        data = obj["data"]
+        if isinstance(data, str):
+            return data
+        return json.dumps(data, ensure_ascii=False)
+    return result
+
+
+def compact_voice_tool_results(
+    messages: List[Any],
+    retention: Optional[Dict[str, str]] = None,
+    recent_keep: int = 0,
+    projection: Optional[Dict[str, List[str]]] = None,
+) -> List[Any]:
+    """Compact stale ``role:"developer"`` async_tool results in a voice context.
+
+    Mirrors ``compact_tool_results_universal`` but targets the ``async_tool``
+    envelope shape pipecat's voice assistant aggregator stores for MCP tools.
+    Returns a new list; the input is never mutated.
+    """
+    if not messages:
+        return list(messages)
+    retention = retention or {}
+
+    call_index: Dict[str, Dict[str, Any]] = {}
+    for msg in messages:
+        if not isinstance(msg, dict) or msg.get("role") != "assistant":
+            continue
+        for call in msg.get("tool_calls") or []:
+            if not isinstance(call, dict):
+                continue
+            call_id = call.get("id")
+            fn = call.get("function")
+            if isinstance(call_id, str) and isinstance(fn, dict):
+                call_index[call_id] = {
+                    "name": fn.get("name", "?"),
+                    "arguments": fn.get("arguments"),
+                }
+
+    dev_positions: List[int] = [
+        i
+        for i, msg in enumerate(messages)
+        if isinstance(msg, dict)
+        and msg.get("role") == "developer"
+        and _parse_async_tool(msg) is not None
+    ]
+    keep_set = set(dev_positions[-recent_keep:]) if recent_keep > 0 else set()
+
+    n_compacted = 0
+    out: List[Any] = []
+    for i, msg in enumerate(messages):
+        if not (isinstance(msg, dict) and msg.get("role") == "developer"):
+            out.append(msg)
+            continue
+        envelope = _parse_async_tool(msg)
+        if envelope is None or i in keep_set:
+            out.append(msg)
+            continue
+        call_meta = call_index.get(envelope.get("tool_call_id") or "")
+        tool_name = call_meta["name"] if call_meta else None
+        if (
+            not tool_name
+            or retention.get(tool_name, _DEFAULT_RETENTION) != "last_turn_only"
+        ):
+            out.append(msg)
+            continue
+        keep_paths = (projection or {}).get(tool_name)
+        new_result: Optional[str] = None
+        if keep_paths:
+            new_result = _project_content(
+                _unwrap_result(envelope.get("result")), keep_paths
+            )
+        if new_result is None:
+            raw_args = call_meta.get("arguments") if call_meta else None
+            try:
+                parsed_args = (
+                    json.loads(raw_args) if isinstance(raw_args, str) else raw_args
+                )
+            except (TypeError, ValueError):
+                parsed_args = raw_args
+            new_result = _stub_for(tool_name, parsed_args)
+        new_envelope = {**envelope, "result": new_result}
+        out.append({**msg, "content": json.dumps(new_envelope, ensure_ascii=False)})
+        n_compacted += 1
+
+    if n_compacted:
+        logger.debug(
+            f"[context_compactor] (voice) rewrote {n_compacted} stale "
+            "async_tool result message(s) to stubs/projections"
+        )
+    return out
+
+
+class CompactedAssistantAggregator(LLMAssistantAggregator):
+    """Assistant aggregator that compacts stale MCP tool results before the
+    LLM runs.
+
+    Overrides ``_handle_function_call_finished`` to compact the shared context
+    right after a tool result is stored and *before* pipecat pushes the next
+    LLM inference (``push_context_frame``). This is deterministic because the
+    push happens later, in ``_handle_function_call_result``.
+
+    Compaction is a no-op when the template declared no ``tool_context_retention``
+    (empty map), keeping collections for non-MCP templates untouched.
+    """
+
+    def __init__(
+        self,
+        context: Any,
+        *,
+        retention: Optional[Dict[str, str]] = None,
+        projection: Optional[Dict[str, List[str]]] = None,
+        recent_keep: int = 0,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(context, **kwargs)
+        self._compact_retention = retention or {}
+        self._compact_projection = projection or {}
+        self._compact_recent_keep = recent_keep
+
+    async def _handle_function_call_finished(
+        self, frame: Any, in_progress_frame: Any
+    ) -> None:
+        await super()._handle_function_call_finished(frame, in_progress_frame)
+        if not self._compact_retention:
+            return
+        self._context.transform_messages(
+            lambda msgs: compact_voice_tool_results(
+                msgs,
+                retention=self._compact_retention,
+                recent_keep=self._compact_recent_keep,
+                projection=self._compact_projection,
+            )
+        )
+
+
+class CompactedContextAggregatorPair(LLMContextAggregatorPair):
+    """Context-aggregator pair whose assistant aggregator compacts MCP results.
+
+    The pair must hand back the *same* compacting assistant instance to the
+    pipeline and to event observers (``LLMContextAggregatorPair.assistant()``
+    is also what ``ObserversManager`` subscribes to for
+    ``on_assistant_turn_started/stopped``). Using this pair as a drop-in
+    replacement for ``LLMContextAggregatorPair`` keeps a single shared
+    instance, so assistant-turn observer events keep firing alongside
+    compaction.
+    """
+
+    def __init__(
+        self,
+        context: Any,
+        *,
+        retention: Optional[Dict[str, str]] = None,
+        projection: Optional[Dict[str, List[str]]] = None,
+        recent_keep: int = 0,
+        user_params: Optional[LLMUserAggregatorParams] = None,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(context, user_params=user_params)
+        self._compacted_assistant = CompactedAssistantAggregator(
+            context,
+            retention=retention,
+            projection=projection,
+            recent_keep=recent_keep,
+        )
+
+    def assistant(self) -> CompactedAssistantAggregator:
+        return self._compacted_assistant

--- a/app/ai/voice/agents/breeze_buddy/agent/pipeline.py
+++ b/app/ai/voice/agents/breeze_buddy/agent/pipeline.py
@@ -20,7 +20,6 @@ from pipecat.pipeline.pipeline import Pipeline
 from pipecat.pipeline.task import PipelineParams, PipelineTask
 from pipecat.processors.aggregators.llm_context import LLMContext
 from pipecat.processors.aggregators.llm_response_universal import (
-    LLMContextAggregatorPair,
     LLMUserAggregatorParams,
 )
 from pipecat.processors.frameworks.rtvi import (
@@ -42,6 +41,10 @@ from pipecat.turns.user_stop import (
 )
 from pipecat.turns.user_turn_strategies import UserTurnStrategies
 
+from app.ai.voice.agents.breeze_buddy.agent.context_compactor import (
+    CompactedContextAggregatorPair,
+    build_tool_context_maps,
+)
 from app.ai.voice.agents.breeze_buddy.llm import get_llm_service
 from app.ai.voice.agents.breeze_buddy.observability.tracing_setup import setup_tracing
 from app.ai.voice.agents.breeze_buddy.processors import (
@@ -277,6 +280,13 @@ async def build_pipeline(
     # app/ai/voice/agents/breeze_buddy/ to manage long conversation contexts.
     context = LLMContext()
 
+    # Per-tool context-compaction policy (voice analogue of the chat
+    # compactor). Empty maps (template didn't declare tool_context_retention)
+    # make the assistant compactor a no-op.
+    tool_retention, tool_projection, tool_recent_keep = build_tool_context_maps(
+        configurations
+    )
+
     # User-idle resolution is shared between realtime and standard pipelines:
     # both paths use the same aggregator-driven idle detection (timer lives
     # inside LLMUserAggregator; handler fires on on_user_turn_idle). Stream
@@ -308,8 +318,11 @@ async def build_pipeline(
         # UserStartedSpeakingFrame / UserStoppedSpeakingFrame from server-side
         # turn detection. user_idle still works because on_user_turn_idle
         # fires on the aggregator regardless of upstream source.
-        context_aggregator = LLMContextAggregatorPair(
+        context_aggregator = CompactedContextAggregatorPair(
             context,
+            retention=tool_retention,
+            projection=tool_projection,
+            recent_keep=tool_recent_keep,
             user_params=LLMUserAggregatorParams(user_idle_timeout=user_idle_timeout),
         )
         user_aggregator = context_aggregator.user()
@@ -475,8 +488,11 @@ async def build_pipeline(
     # The aggregator owns the idle timer (user_idle_timeout above); the
     # callback handler is wired via on_user_turn_idle below. Both were
     # resolved before the realtime branch.
-    context_aggregator = LLMContextAggregatorPair(
+    context_aggregator = CompactedContextAggregatorPair(
         context,
+        retention=tool_retention,
+        projection=tool_projection,
+        recent_keep=tool_recent_keep,
         user_params=LLMUserAggregatorParams(
             user_turn_strategies=user_turn_strategies,
             user_mute_strategies=user_mute_strategies,

--- a/app/ai/voice/agents/breeze_buddy/handlers/internal/builtin_dispatcher.py
+++ b/app/ai/voice/agents/breeze_buddy/handlers/internal/builtin_dispatcher.py
@@ -31,6 +31,9 @@ from app.ai.voice.agents.breeze_buddy.handlers.internal.get_current_time import 
 from app.ai.voice.agents.breeze_buddy.handlers.internal.hold_and_consult import (
     hold_and_consult,
 )
+from app.ai.voice.agents.breeze_buddy.handlers.internal.indian_number_to_speech import (
+    indian_number_to_speech_handler,
+)
 from app.ai.voice.agents.breeze_buddy.handlers.internal.query_knowledge_base import (
     query_knowledge_base,
 )
@@ -57,6 +60,7 @@ BUILTIN_HANDLERS: Dict[str, Callable] = {
     "end_conversation": end_conversation_global,
     "get_current_time": get_current_time,
     "hold_and_consult": hold_and_consult,
+    "indian_number_to_speech": indian_number_to_speech_handler,
     "query_knowledge_base": query_knowledge_base,
     "update_outcome": update_outcome,
 }

--- a/app/ai/voice/agents/breeze_buddy/handlers/internal/indian_number_to_speech.py
+++ b/app/ai/voice/agents/breeze_buddy/handlers/internal/indian_number_to_speech.py
@@ -1,0 +1,48 @@
+"""Indian Number to Speech Handler
+
+Built-in global function that converts a numeric price (in rupees) to its
+Indian-words spoken form. Registered as an LLM-callable builtin so the agent
+spells out a product price only when it is about to state it — instead of
+pre-converting every price in a catalogue result.
+"""
+
+from typing import Any, Dict
+
+from app.ai.voice.agents.breeze_buddy.template.context import TemplateContext
+from app.ai.voice.agents.breeze_buddy.template.transformation_function.utils import (
+    indian_number_to_speech,
+)
+from app.core.logger import logger
+
+
+async def indian_number_to_speech_handler(
+    context: TemplateContext,
+    args: Dict[str, Any],
+) -> Dict[str, Any]:
+    """Convert an amount in rupees to Indian words and return the spoken form.
+
+    Args:
+        context: Handler context with bot state access (unused).
+        args: LLM function arguments, must contain a numeric ``price`` in rupees.
+
+    Returns:
+        Dict with the spoken phrase, or an error dict on missing/invalid input.
+    """
+    price = args.get("price")
+    if price is None:
+        logger.warning("[indian_number_to_speech] missing 'price' argument")
+        return {"status": "error", "error": "Missing required argument 'price'."}
+
+    try:
+        spoken = indian_number_to_speech(float(price))
+    except (TypeError, ValueError) as e:
+        logger.warning(f"[indian_number_to_speech] invalid price {price!r}: {e}")
+        return {
+            "status": "error",
+            "error": f"Invalid price {price!r}: expected a number.",
+        }
+
+    logger.info(
+        f"[indian_number_to_speech] {price!r} -> '{spoken}' for call {context.call_sid}"
+    )
+    return {"status": "success", "price_in_words": spoken}

--- a/app/ai/voice/agents/breeze_buddy/template/types.py
+++ b/app/ai/voice/agents/breeze_buddy/template/types.py
@@ -1196,6 +1196,21 @@ class McpServerConfig(BaseModel):
             "part and it lives here in the template."
         ),
     )
+    bypass_compaction_for_turns: int = Field(
+        0,
+        ge=0,
+        description=(
+            "Number of most-recent ``last_turn_only`` tool results (voice "
+            "pipeline only) that are exempt from compaction — kept fully raw "
+            "instead of being projected/stubbed. Default 0 means every "
+            "eligible result compacts immediately, including the newest one "
+            "(prior hardcoded voice behavior). Safe to raise because "
+            "``tool_context_projection``/``tool_response_schemas`` already "
+            "shrink the per-call payload before it reaches context, unlike "
+            "chat's raw catalog results. When multiple MCP servers set this, "
+            "the largest value wins."
+        ),
+    )
     default_args: Dict[str, Any] = Field(
         default_factory=dict,
         description=(

--- a/tests/test_context_compactor.py
+++ b/tests/test_context_compactor.py
@@ -2,10 +2,12 @@
 # Test indexes into result dicts whose return type pyrefly can't infer tightly.
 """Tests for the conversation-context compactor.
 
-The compactor rewrites stale ``tool_result`` blocks in an Anthropic ``messages``
-array to 1-line stubs. The contract is narrow but easy to get wrong on
-edge cases (mixed roles, multi-block messages, missing tool_use linkage),
-so the cases here cover both the happy paths and the don't-blow-up paths.
+The chat compactor rewrites stale ``tool_result`` blocks in an Anthropic
+``messages`` array to 1-line stubs. The voice compactor does the same for the
+``role:"developer"`` ``async_tool`` envelope pipecat's assistant aggregator
+stores for MCP tools. The contract is narrow but easy to get wrong on edge
+cases (mixed roles, missing tool_call linkage), so the cases here cover both
+the happy paths and the don't-blow-up paths.
 """
 
 from __future__ import annotations
@@ -455,3 +457,354 @@ def test_universal_session_retention_untouched():
     ]
     out = compact_tool_results_universal(messages, retention={}, recent_keep=1)
     assert all("[pruned" not in (m.get("content") or "") for m in out)
+
+
+# ---------------------------------------------------------------------------
+# Voice variant — role:"developer" async_tool envelope (MCP tools)
+# ---------------------------------------------------------------------------
+
+from app.ai.voice.agents.breeze_buddy.agent.context_compactor import (  # noqa: E402
+    CompactedAssistantAggregator,
+    CompactedContextAggregatorPair,
+    build_tool_context_maps,
+    compact_voice_tool_results,
+)
+
+
+def _async_tool_envelope(call_id: str, result: dict) -> dict:
+    """The role:'developer' message pipecat stores for an async MCP tool call."""
+    return {
+        "role": "developer",
+        "content": json.dumps(
+            {
+                "type": "async_tool",
+                "tool_call_id": call_id,
+                "status": "finished",
+                "description": "the result",
+                "result": json.dumps(result),
+            }
+        ),
+    }
+
+
+def _voice_exchange(call_id: str, tool: str, result: dict) -> list:
+    return [
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "id": call_id,
+                    "type": "function",
+                    "function": {"name": tool, "arguments": '{"query":"red"}'},
+                }
+            ],
+        },
+        _async_tool_envelope(call_id, result),
+    ]
+
+
+def test_voice_compacts_stale_async_tool_results_recent_keep_zero():
+    """With recent_keep=0 (the voice default), ALL async_tool results —
+    including the latest — are compacted to a stub."""
+    messages = [
+        {"role": "user", "content": "find shoes"},
+        *_voice_exchange("c1", "search_catalog", {"products": [{"id": "p1"}] * 40}),
+        {"role": "user", "content": "more"},
+        *_voice_exchange("c2", "search_catalog", {"products": [{"id": "p2"}]}),
+    ]
+    out = compact_voice_tool_results(
+        messages, retention={"search_catalog": "last_turn_only"}, recent_keep=0
+    )
+    # Unlike the chat compactor's recent_keep=1, BOTH results are stubbed.
+    dev = [m for m in out if m.get("role") == "developer"]
+    stale = next(m for m in dev if "c1" in m["content"])
+    fresh = next(m for m in dev if "c2" in m["content"])
+    assert "[pruned: search_catalog(" in json.loads(stale["content"])["result"]
+    assert "[pruned: search_catalog(" in json.loads(fresh["content"])["result"]
+
+
+def test_voice_projection_keeps_identity_paths():
+    result = {
+        "products": [
+            {"id": "p1", "url": "https://s/p1", "description": "x" * 500},
+            {"id": "p2", "url": "https://s/p2", "description": "y" * 500},
+        ]
+    }
+    messages = [
+        *_voice_exchange("c1", "search_catalog", result),
+        *_voice_exchange("c2", "search_catalog", {"products": []}),
+    ]
+    out = compact_voice_tool_results(
+        messages,
+        retention={"search_catalog": "last_turn_only"},
+        recent_keep=0,
+        projection={"search_catalog": ["products[*].id", "products[*].url"]},
+    )
+    stale = json.loads(json.loads(out[1]["content"])["result"])
+    assert stale["products"] == [
+        {"id": "p1", "url": "https://s/p1"},
+        {"id": "p2", "url": "https://s/p2"},
+    ]
+    assert "_pruned" in stale
+
+
+def test_voice_session_tool_untouched():
+    messages = [
+        *_voice_exchange("c1", "get_cart", {"id": "cart1"}),
+        *_voice_exchange("c2", "get_cart", {"id": "cart1"}),
+    ]
+    out = compact_voice_tool_results(
+        messages,
+        retention={"get_cart": "session", "search_catalog": "last_turn_only"},
+        recent_keep=0,
+    )
+    assert all("[pruned" not in (m.get("content") or "") for m in out)
+
+
+def test_voice_non_async_developer_message_touched():
+    """A role:'developer' message that is NOT an async_tool envelope is left alone."""
+    messages = [
+        {"role": "developer", "content": json.dumps({"reasoning": "plain note"})},
+        *_voice_exchange("c1", "search_catalog", {"products": [{"id": "p1"}]}),
+        {"role": "user", "content": "ok"},
+    ]
+    out = compact_voice_tool_results(
+        messages, retention={"search_catalog": "last_turn_only"}, recent_keep=0
+    )
+    assert out[0]["content"] == json.dumps({"reasoning": "plain note"})
+    dev = next(m for m in out if m.get("role") == "developer" and "c1" in m["content"])
+    assert "[pruned: search_catalog" in json.loads(dev["content"])["result"]
+
+
+def test_voice_unknown_tool_defaults_to_no_compaction():
+    messages = [
+        *_voice_exchange("x1", "mystery_tool", {"big": "blob" * 200}),
+        *_voice_exchange("x2", "mystery_tool", {"big": "blob2" * 200}),
+    ]
+    out = compact_voice_tool_results(
+        messages, retention={"search_catalog": "last_turn_only"}, recent_keep=0
+    )
+    assert all("[pruned" not in (m.get("content") or "") for m in out)
+
+
+def test_voice_empty_retention_is_noop():
+    messages = [*_voice_exchange("c1", "search_catalog", {"products": []})]
+    out = compact_voice_tool_results(messages, retention=None, recent_keep=0)
+    assert out == messages
+
+
+def test_voice_does_not_mutate_input():
+    messages = [*_voice_exchange("c1", "search_catalog", {"products": [{"id": "p"}]})]
+    original = messages[1]["content"]
+    compact_voice_tool_results(
+        messages, retention={"search_catalog": "last_turn_only"}, recent_keep=0
+    )
+    assert messages[1]["content"] == original
+
+
+def test_build_tool_context_maps_from_config():
+    """Maps are pulled from the template's MCP server config (voice mirror of
+    chat tooling). A server with no fields yields empty maps (no-op)."""
+
+    class _Server:
+        tool_context_retention = {"search_catalog": "last_turn_only"}
+        tool_context_projection = {"search_catalog": ["products[*].id"]}
+
+    class _ServerEmpty:
+        tool_context_retention = None
+        tool_context_projection = None
+
+    class _Mcp:
+        servers = [_Server(), _ServerEmpty()]
+
+    class _Config:
+        mcp = _Mcp()
+
+    retention, projection = build_tool_context_maps(_Config())
+    assert retention == {"search_catalog": "last_turn_only"}
+    assert projection == {"search_catalog": ["products[*].id"]}
+
+    retention2, projection2 = build_tool_context_maps(None)
+    assert retention2 == {}
+    assert projection2 == {}
+
+
+def test_voice_projection_unwraps_status_data_envelope():
+    """MCP HTTP tool results are stored as ``{"status":"success","data":"<json>"}``
+    (mcp/__init__.py wraps them). The projection must unwrap that envelope so
+    ``products[*].title`` resolves against the real payload instead of stubbing.
+    This is the regression that made the voice agent reply 'I couldn't confirm'
+    despite search_catalog returning rich results."""
+    paylod = {
+        "products": [
+            {
+                "id": "p1",
+                "title": "Ayurvedic Medicine for Kidney",
+                "price": "999.00",
+                "description": "x" * 500,
+            },
+            {
+                "id": "p2",
+                "title": "GFR Powder",
+                "price": "699.00",
+                "description": "y" * 500,
+            },
+        ]
+    }
+    messages = [
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "id": "c1",
+                    "type": "function",
+                    "function": {
+                        "name": "search_catalog",
+                        "arguments": '{"query":"kidney"}',
+                    },
+                }
+            ],
+        },
+        {
+            "role": "developer",
+            "content": json.dumps(
+                {
+                    "type": "async_tool",
+                    "tool_call_id": "c1",
+                    "status": "finished",
+                    "description": "the result",
+                    "result": json.dumps(
+                        {"status": "success", "data": json.dumps(paylod)}
+                    ),
+                }
+            ),
+        },
+    ]
+    out = compact_voice_tool_results(
+        messages,
+        retention={"search_catalog": "last_turn_only"},
+        recent_keep=0,
+        projection={
+            "search_catalog": [
+                "products[*].id",
+                "products[*].title",
+                "products[*].price",
+            ]
+        },
+    )
+    dev = [
+        m
+        for m in out
+        if isinstance(m, dict) and m.get("role") == "developer" and "c1" in m["content"]
+    ]
+    envelope = json.loads(dev[0]["content"])
+    # NOT a stub — the titles were projected through the envelope.
+    assert "[pruned: search_catalog" not in envelope["result"]
+    projected = json.loads(envelope["result"])
+    assert projected["products"] == [
+        {"id": "p1", "title": "Ayurvedic Medicine for Kidney", "price": "999.00"},
+        {"id": "p2", "title": "GFR Powder", "price": "699.00"},
+    ]
+    assert "_pruned" in projected
+    assert "description" not in projected["products"][0]
+
+
+def test_voice_projection_unwraps_object_data_and_plain_result():
+    """_unwrap_result handles both a JSON-string ``data`` and an object
+    ``data``, and passes through a non-envelope result unchanged."""
+    object_data = {
+        "role": "developer",
+        "content": json.dumps(
+            {
+                "type": "async_tool",
+                "tool_call_id": "c2",
+                "status": "finished",
+                "description": "the result",
+                "result": json.dumps(
+                    {"status": "success", "data": {"products": [{"id": "p9"}]}}
+                ),
+            }
+        ),
+    }
+    messages = [
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "id": "c2",
+                    "type": "function",
+                    "function": {"name": "search_catalog", "arguments": "{}"},
+                }
+            ],
+        },
+        object_data,
+    ]
+    out = compact_voice_tool_results(
+        messages,
+        retention={"search_catalog": "last_turn_only"},
+        recent_keep=0,
+        projection={"search_catalog": ["products[*].id"]},
+    )
+    projected = json.loads(json.loads(out[1]["content"])["result"])
+    assert projected["products"] == [{"id": "p9"}]
+    assert "_pruned" in projected
+
+    plain = {
+        "role": "developer",
+        "content": json.dumps(
+            {
+                "type": "async_tool",
+                "tool_call_id": "c3",
+                "status": "finished",
+                "description": "the result",
+                "result": json.dumps({"products": [{"id": "p3"}]}),
+            }
+        ),
+    }
+    messages2 = [
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "id": "c3",
+                    "type": "function",
+                    "function": {"name": "search_catalog", "arguments": "{}"},
+                }
+            ],
+        },
+        plain,
+    ]
+    out2 = compact_voice_tool_results(
+        messages2,
+        retention={"search_catalog": "last_turn_only"},
+        recent_keep=0,
+        projection={"search_catalog": ["products[*].id"]},
+    )
+    projected2 = json.loads(json.loads(out2[1]["content"])["result"])
+    assert projected2["products"] == [{"id": "p3"}]
+    assert "_pruned" in projected2
+
+
+def test_pair_returns_compacting_assistant_shared_with_pipeline():
+    """CompactedContextAggregatorPair.assistant() yields the same compacting
+    instance the pipeline uses, so observer turn events keep firing."""
+    from pipecat.processors.aggregators.llm_context import LLMContext
+
+    ctx = LLMContext()
+    pair = CompactedContextAggregatorPair(
+        ctx,
+        retention={"search_catalog": "last_turn_only"},
+        projection={"search_catalog": ["products[*].id"]},
+        recent_keep=0,
+    )
+    assistant = pair.assistant()
+    assert isinstance(assistant, CompactedAssistantAggregator)
+    assert pair.assistant() is assistant
+    assert pair.user() is not None
+    assert assistant._compact_retention == {"search_catalog": "last_turn_only"}
+    assert assistant._compact_projection == {"search_catalog": ["products[*].id"]}
+    assert assistant._compact_recent_keep == 0


### PR DESCRIPTION
- adds context_compactor for voice
- configurable per template

- The voice compactor imports the entire dedup logic from the chat compactor: the projection grammar (a.b, a[*].b), the keep-path parser, the JSON projection, the 1-line stub formatter, and the retention policy. Nothing there was rewritten. context_compactor.py only adds the voice-specific plumbing around it.

- Chat and voice store tool results in different shapes. Chat stores them as role: "tool" messages. Voice stores them as role: "developer" messages wrapped in a JSON "async_tool" envelope (because voice tools run async). The chat compactor's entry points only look for role:"tool" — so they'd never even see a voice tool result. A wrapper is required just to find and unwrap the voice messages.

- The chat compactor only shrinks, it can't reach the middle of a tool result. For voice, the result is a developer message containing {tool_call_id, status, result} where result is itself a JSON string. To compact it, we must parse that inner envelope, resolve which tool it is, and rewrite only the inner result. That "extract the inner result and rebuild" step doesn't exist in the chat compactor 
-. Chat compacts when it's called directly. Voice needs it to run automatically inside the aggregator — specifically between "tool result stored" and "LLM re-triggered" — or the huge payload ships to the LLM before compaction. So we subclass the aggregator and hook compaction into that exact spot.

- When projection fails, voice needs the tool re-callable via the same async-tool envelope, and compaction is gated by template maps (retention/projection). All of that is build on top of the shared chat engine, not a reimplementation of it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved voice assistant context management by compacting older tool results while preserving relevant recent information.
  * Added tool-specific projections and concise summaries for retained context.
  * Applied consistent context handling across voice assistant pipeline modes.

* **Bug Fixes**
  * Prevented unrelated messages and unsupported tool results from being altered.
  * Preserved tool-result information while reducing unnecessary context size.

* **Tests**
  * Added comprehensive coverage for voice tool-result compaction, retention settings, projections, and pipeline integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->