### PR TITLE
feat(crm): WhatsApp send via Meta Cloud API behind channel adapters

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -141,6 +141,26 @@ ENABLE_CUSTOM_PYTHON_FUNCTIONS=false
 TWILIO_ACCOUNT_SID=""
 TWILIO_AUTH_TOKEN=""
 
+# CRM outbound send (app/crm/connectivity). Per-merchant WhatsApp tokens and
+# phone number ids are NOT here — they are connector data, read from the vault
+# at send time. These only choose the endpoint and the deadline.
+#
+# Point the base URL at a local stub to exercise the whole dispatcher without
+# sending anything to Meta; seed a vault credential + installation + binding
+# by hand (migration 060 is the authoritative shape of the three rows).
+META_WHATSAPP_GRAPH_BASE_URL=https://graph.facebook.com
+META_WHATSAPP_GRAPH_VERSION=v23.0
+# Ceiling on one provider call AND on the gate probe before it (each gets its
+# own deadline on this constant). Sends are worked SERIALLY per dispatcher, so
+# the real law is batch-wide: CRM_DISPATCH_BATCH (default 20) × 2 × this timeout
+# must stay under CRM_DISPATCH_STALE_MINUTES (default 15m) — a pass that
+# outlives its claims gets the unworked tail reassigned to a second worker,
+# and the customer receives the message twice. The trade-off of the longer
+# lease: it is also how long a dead worker's claimed rows wait before the
+# sweep hands them to a live one. The test suite pins the inequality; nudge
+# one dial and the others must follow.
+CRM_MESSAGE_SEND_TIMEOUT_SECONDS=20
+
 # Webhook Authentication
 ORDER_CONFIRMATION_WEBHOOK_SECRET_KEY=""
 ORDER_CONFIRMATION_TOKEN=""

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ uv run autoflake --in-place --remove-all-unused-imports --remove-unused-variable
 uv run pyrefly check                # Type check
 uv run pytest tests/                # Tests
 uv run python scripts/check_migrations.py       # Migration numbering guard
-uv run python scripts/check_crm_boundaries.py   # CRM boundary guard (10 rules)
+uv run python scripts/check_crm_boundaries.py   # CRM boundary guard (11 rules)
 ```
 
 ## Building modules & making code changes — READ THIS FIRST

--- a/app/api/routers/breeze_buddy/credentials/handlers.py
+++ b/app/api/routers/breeze_buddy/credentials/handlers.py
@@ -8,6 +8,7 @@ from fastapi import HTTPException, status
 
 from app.core.logger import logger
 from app.database.accessor import (
+    CredentialInUseError,
     create_credential,
     delete_credential,
     get_all_credentials,
@@ -155,7 +156,10 @@ async def update_credential_handler(
 
 async def delete_credential_handler(credential_id: str, current_user: UserInfo) -> None:
     """Delete a credential."""
-    logger.info(f"User {current_user.username} deleting credential: {credential_id}")
+    # bind() rather than interpolation: credential_id lands as a structured
+    # field a log search can filter on.
+    log = logger.bind(credential_id=credential_id)
+    log.info(f"User {current_user.username} deleting credential")
 
     try:
         existing = await get_credential_by_id(credential_id, mask=True)
@@ -172,12 +176,25 @@ async def delete_credential_handler(credential_id: str, current_user: UserInfo) 
                 detail=f"Credential {credential_id} not found",
             )
 
-        logger.info(f"Credential {credential_id} deleted successfully")
+        log.info("Credential deleted successfully")
 
     except HTTPException:
         raise
+    except CredentialInUseError as exc:
+        # The credential exists and is still wired to something — a connector
+        # installation holds it. 409, not 500: the request was understood and
+        # deliberately refused, and the caller can act on it by disconnecting
+        # the connector first. The accessor translated the driver's FK
+        # violation, so this layer knows credentials, not Postgres.
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=(
+                f"Credential {credential_id} is in use by a connector and "
+                f"cannot be deleted. Disconnect the connector first."
+            ),
+        ) from exc
     except Exception as e:
-        logger.error(f"Error deleting credential {credential_id}: {e}", exc_info=True)
+        log.opt(exception=e).error("Error deleting credential")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to delete credential.",

--- a/app/core/config/static.py
+++ b/app/core/config/static.py
@@ -240,6 +240,7 @@ CHAT_SESSION_END_TIMEOUT_LOOP_INTERVAL_SECONDS = int(
 # infrequent. The *tuning* knobs (caps, rate limits, token TTL) live in
 # dynamic.py and can be dialed without a restart.
 def _parse_demo_templates(raw: str) -> dict[str, str]:
+    """Parse 'slug:template_id,slug:template_id' pairs; malformed entries are skipped."""
     out: dict[str, str] = {}
     for entry in (raw or "").split(","):
         entry = entry.strip()
@@ -490,13 +491,30 @@ CRM_WORKER_INTERVAL = _positive_float("CRM_WORKER_INTERVAL", 1.0)
 CRM_WORKER_BATCH = _positive_int("CRM_WORKER_BATCH", 100)
 CRM_WORKER_HEARTBEAT = _positive_float("CRM_WORKER_HEARTBEAT", 60.0)
 
-# CRM outbound dispatcher (runs only when CRM_ROLE=dispatcher; loop mechanics
-# ride CRM_WORKER_BATCH/CRM_WORKER_INTERVAL like every role). It currently
-# calls send() with no permission check in front of it — a dummy send only.
+# CRM outbound dispatcher (runs only when CRM_ROLE=dispatcher; pacing rides
+# CRM_WORKER_INTERVAL, but the batch is its own dial below). send() reaches
+# real providers behind a thin permission slice: dispatch._gate probes
+# platform suppression before every send and fails CLOSED. The full
+# may_contact() — consent, purpose, quiet hours — replaces the gate's body
+# at B5; the seam is already load-bearing.
+
+# The dispatcher's own batch — deliberately NOT CRM_WORKER_BATCH (100).
+# Sends are serial and each may spend the full send timeout, so claiming a
+# batch is a promise to finish batch × timeout of work inside the claim
+# lease. At 100 that promise breaks (100 × 20s ≫ the lease) and another pod's
+# sweep re-sends the unworked tail while this pod still holds it — a REAL
+# duplicate message, which no outcome guard can undo.
+CRM_DISPATCH_BATCH = _positive_int("CRM_DISPATCH_BATCH", 20)
 
 # How long a worker may hold a row before it is assumed dead and requeued.
-# Must exceed the slowest realistic provider call.
-CRM_DISPATCH_STALE_MINUTES = _positive_int("CRM_DISPATCH_STALE_MINUTES", 5)
+# Must exceed a whole batch of worst-case sends — CRM_DISPATCH_BATCH × 2 ×
+# CRM_MESSAGE_SEND_TIMEOUT_SECONDS, the 2 because each message may burn one
+# timeout in the gate probe and another in send() — since rows claimed at
+# the head of a pass sit in 'sending' while the tail is worked. Defaults
+# give 20 × 2 × 20s = 800s against 900s — the bound the test suite pins so
+# no dial can drift past the others. The only cost of a longer lease is how
+# long a genuinely dead worker's rows wait for rescue.
+CRM_DISPATCH_STALE_MINUTES = _positive_int("CRM_DISPATCH_STALE_MINUTES", 15)
 
 # Bounded so one undeliverable message cannot earn a provider rate-limit ban
 # for every other merchant sharing that sender.
@@ -506,6 +524,22 @@ CRM_DISPATCH_MAX_ATTEMPTS = _positive_int("CRM_DISPATCH_MAX_ATTEMPTS", 3)
 # obeyed, so each attempt waits twice as long as the last.
 CRM_DISPATCH_RETRY_BASE_SECONDS = _positive_int("CRM_DISPATCH_RETRY_BASE_SECONDS", 30)
 
+# The ceiling on ONE provider call, applied by send() so that no adapter can
+# forget it — and separately on the gate probe before it (dispatch._gate),
+# which reads the same pool. Must stay well under CRM_DISPATCH_STALE_MINUTES:
+# a send that outlives its claim gets the row reassigned to a second worker
+# while the first is still sending, and the customer receives the message
+# twice.
+CRM_MESSAGE_SEND_TIMEOUT_SECONDS = _positive_int("CRM_MESSAGE_SEND_TIMEOUT_SECONDS", 20)
+
+# Meta WhatsApp Cloud API. Only the endpoint lives here — the access token and
+# the phone number id are per-merchant connector data, read from the vault at
+# send time. Pointing the base URL at a local stub is how the dispatcher is
+# exercised end to end without sending anything to Meta.
+META_WHATSAPP_GRAPH_BASE_URL = os.environ.get(
+    "META_WHATSAPP_GRAPH_BASE_URL", "https://graph.facebook.com"
+)
+META_WHATSAPP_GRAPH_VERSION = os.environ.get("META_WHATSAPP_GRAPH_VERSION", "v23.0")
 
 # Announcement Banner Configuration
 DEFAULT_ANNOUNCEMENT_BANNER_TEXT_COLOR = os.environ.get(

--- a/app/crm/connectivity/channels.py
+++ b/app/crm/connectivity/channels.py
@@ -1,0 +1,46 @@
+"""What the platform knows about each channel, adapter-independent.
+
+One registry, one entry per channel the CRM can speak. The metadata here is
+everything OUTSIDE the send door that varies by channel — today only which
+handle kind the permission gate probes; W8's pacing and quality-tier
+defaults join as fields on Channel, not as new dicts scattered per file.
+
+Why this file and not providers/__init__: rule 11 confines providers/
+behind send.py, so anything dispatch (or later, pacing) needs per channel
+must live outside the confined package. The two registries are pinned
+against drift in the test suite instead: every adapter channel has an entry
+HERE (ADAPTERS ⊆ CHANNELS), and a channel without one fails closed at the
+gate.
+
+shared/redact.py's mask branch stays where it is on purpose: its default is
+mask-everything, so an unregistered channel already fails safe — and
+folding it here would make shared/ import connectivity.
+"""
+
+from dataclasses import dataclass
+from typing import Dict, Optional
+
+
+@dataclass(frozen=True)
+class Channel:
+    """One channel's adapter-independent metadata."""
+
+    # The platform_identity handle kind the gate probes for suppression —
+    # a suppressed value on this kind of handle is what "STOP" wrote.
+    gate_handle_kind: str
+
+
+CHANNELS: Dict[str, Channel] = {
+    "whatsapp": Channel(gate_handle_kind="phone"),
+}
+
+
+def gate_handle_kind_for(channel: str) -> Optional[str]:
+    """The handle kind the gate probes for ``channel``.
+
+    None means unregistered, and the gate fails CLOSED on it
+    (dispatch._gate) — a channel this registry cannot describe must not
+    slip past the one check a person who said STOP is protected by.
+    """
+    entry = CHANNELS.get(channel)
+    return entry.gate_handle_kind if entry else None

--- a/app/crm/connectivity/db/accessor.py
+++ b/app/crm/connectivity/db/accessor.py
@@ -3,16 +3,27 @@
 Every function self-scopes; see queries.py for why no transaction is needed.
 """
 
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
-from app.crm.connectivity.db.decoder import decode_queued_message
+from app.crm.connectivity.db.decoder import (
+    decode_binding,
+    decode_installation,
+    decode_queued_message,
+)
 from app.crm.connectivity.db.queries import (
     apply_outcome_query,
+    binding_by_id_query,
     claim_queued_messages_query,
     insert_message_query,
+    installation_by_id_query,
+    primary_binding_query,
     requeue_stale_claims_query,
 )
-from app.crm.connectivity.schemas import QueuedMessage
+from app.crm.connectivity.schemas import (
+    ChannelBinding,
+    ConnectorInstallation,
+    QueuedMessage,
+)
 from app.crm.shared.db import crm_connection
 
 
@@ -47,19 +58,26 @@ async def insert_message(
 
 
 async def claim_queued_messages(batch_size: int) -> List[QueuedMessage]:
+    """Take up to ``batch_size`` due rows for this worker; the claim spends an attempt."""
     query, values = claim_queued_messages_query(batch_size)
     async with crm_connection() as conn:
         rows = await conn.fetch(query, *values)
     return [decode_queued_message(row) for row in rows]
 
 
-async def requeue_stale_claims(stale_minutes: int) -> List[str]:
-    """Returns the ids released, not just a count — a reclaimed message is the
-    first thing anyone investigating a possible double send asks about."""
-    query, values = requeue_stale_claims_query(stale_minutes)
+async def requeue_stale_claims(
+    stale_minutes: int, max_attempts: int
+) -> Tuple[List[str], List[str]]:
+    """(requeued ids, ids dead on reclaim) — ids, not counts, because a
+    reclaimed message is the first thing anyone investigating a possible
+    double send asks about, and a dead-on-reclaim one is a row that was
+    really attempted max times without a recorded answer."""
+    query, values = requeue_stale_claims_query(stale_minutes, max_attempts)
     async with crm_connection() as conn:
         rows = await conn.fetch(query, *values)
-    return [str(row["id"]) for row in rows]
+    requeued = [str(row["id"]) for row in rows if row["status"] == "queued"]
+    dead = [str(row["id"]) for row in rows if row["status"] != "queued"]
+    return requeued, dead
 
 
 async def apply_outcome(
@@ -68,12 +86,44 @@ async def apply_outcome(
     reason: Optional[str],
     provider_message_id: Optional[str],
     mark_sent: bool,
+    attempt: int,
     retry_after_seconds: Optional[int] = None,
 ) -> bool:
-    """False means the row was no longer ours — another worker reclaimed it."""
+    """False means the row was no longer ours — another worker reclaimed it
+    (``attempt`` is the claim's generation; a stale claim's write misses)."""
     query, values = apply_outcome_query(
-        message_id, status, reason, provider_message_id, mark_sent, retry_after_seconds
+        message_id,
+        status,
+        reason,
+        provider_message_id,
+        mark_sent,
+        attempt,
+        retry_after_seconds,
     )
     async with crm_connection() as conn:
         row = await conn.fetchrow(query, *values)
     return row is not None
+
+
+async def get_binding(
+    merchant_id: str, channel: str, binding_id: Optional[str]
+) -> Optional[ChannelBinding]:
+    """The pipe a message leaves on: the one it named, or the merchant's
+    default for that channel."""
+    if binding_id:
+        query, values = binding_by_id_query(merchant_id, binding_id, channel)
+    else:
+        query, values = primary_binding_query(merchant_id, channel)
+    async with crm_connection() as conn:
+        row = await conn.fetchrow(query, *values)
+    return decode_binding(row) if row is not None else None
+
+
+async def get_installation(
+    merchant_id: str, installation_id: str
+) -> Optional[ConnectorInstallation]:
+    """The account behind a pipe, merchant-scoped; None if it is not this tenant's."""
+    query, values = installation_by_id_query(merchant_id, installation_id)
+    async with crm_connection() as conn:
+        row = await conn.fetchrow(query, *values)
+    return decode_installation(row) if row is not None else None

--- a/app/crm/connectivity/db/decoder.py
+++ b/app/crm/connectivity/db/decoder.py
@@ -1,50 +1,63 @@
 """Database rows -> domain shapes. Never imported outside this db package."""
 
-import json
-from typing import Any, Dict, Mapping
+from typing import Any, Mapping
 
-from app.crm.connectivity.schemas import QueuedMessage
-
-
-def _load_variables(value: Any) -> Dict[str, Any]:
-    """Parse the stored variables blob. Total: always a dict, never raises.
-
-    A batch is decoded after the claim commits but outside the per-message
-    error handling, so raising here strands every row in the batch — they get
-    reclaimed, decoded, and raise again, forever. One bad row would stall the
-    queue permanently.
-
-    The column is plain jsonb, so 42 or [1, 2] are legal values. Non-dicts are
-    dropped rather than converted, since dict() would turn [["a", 1]] into
-    {"a": 1} and invent a variable. The driver returns jsonb as a string
-    today; the non-string branch covers a codec being registered later.
-    """
-    if isinstance(value, str):
-        try:
-            value = json.loads(value)
-        except (TypeError, ValueError):
-            return {}
-    return dict(value) if isinstance(value, dict) else {}
-
-
-def _uuid_or_none(value: Any) -> Any:
-    return str(value) if value is not None else None
+from app.crm.connectivity.schemas import (
+    ChannelBinding,
+    ConnectorInstallation,
+    QueuedMessage,
+)
+from app.crm.shared.decode import jsonb_object, uuid_or_none
 
 
 def decode_queued_message(row: Mapping[str, Any]) -> QueuedMessage:
+    """One claimed crm_message row -> QueuedMessage."""
     return QueuedMessage(
         id=str(row["id"]),
         merchant_id=row["merchant_id"],
         customer_id=str(row["customer_id"]),
         channel=row["channel"],
         sent_to_address=row["sent_to_address"],
-        binding_id=_uuid_or_none(row["binding_id"]),
+        binding_id=uuid_or_none(row["binding_id"]),
         source_kind=row["source_kind"],
-        source_id=_uuid_or_none(row["source_id"]),
+        source_id=uuid_or_none(row["source_id"]),
         purpose_key=row["purpose_key"],
         template_id=row["template_id"],
-        variables=_load_variables(row["variables"]),
+        # Totality matters most here: a whole batch is decoded after its claim
+        # commits but outside the per-message error handling, so one raise
+        # would strand every row in it — permanently (see shared/decode.py).
+        variables=jsonb_object(row["variables"]),
         dedupe_key=row["dedupe_key"],
         attempt=row["attempt"],
         next_attempt_at=row["next_attempt_at"],
+    )
+
+
+def decode_installation(row: Mapping[str, Any]) -> ConnectorInstallation:
+    """One crm_connector_installation row -> ConnectorInstallation."""
+    return ConnectorInstallation(
+        id=str(row["id"]),
+        merchant_id=row["merchant_id"],
+        connector_key=row["connector_key"],
+        external_account_id=row["external_account_id"],
+        display_label=row["display_label"],
+        credential_id=uuid_or_none(row["credential_id"]),
+        status=row["status"],
+        token_expires_at=row["token_expires_at"],
+    )
+
+
+def decode_binding(row: Mapping[str, Any]) -> ChannelBinding:
+    """One crm_channel_binding row -> ChannelBinding."""
+    return ChannelBinding(
+        id=str(row["id"]),
+        merchant_id=row["merchant_id"],
+        channel=row["channel"],
+        installation_id=str(row["installation_id"]),
+        address=row["address"],
+        # An unreadable capabilities blob must not refuse a send: an empty
+        # dict means "declares nothing", which every caller already handles.
+        capabilities=jsonb_object(row["capabilities"]),
+        is_primary=row["is_primary"],
+        status=row["status"],
     )

--- a/app/crm/connectivity/db/queries.py
+++ b/app/crm/connectivity/db/queries.py
@@ -3,16 +3,30 @@
 Every builder emits a single statement, which Postgres runs atomically — so
 nothing here needs a transaction. The claim and the sweep are deliberately
 unscoped by merchant: one global queue, not a loop per tenant.
+
+The vault is deliberately absent: it belongs to app/database, so send.py
+reads it through that layer's accessor, never SQL from here.
 """
 
 import json
 from typing import Any, Dict, List, Optional, Tuple
 
 MESSAGE_TABLE = "crm_message"
+INSTALLATION_TABLE = "crm_connector_installation"
+BINDING_TABLE = "crm_channel_binding"
+
+INSTALLATION_COLUMNS = """
+    id, merchant_id, connector_key, external_account_id, display_label,
+    credential_id, status, token_expires_at
+"""
+
+BINDING_COLUMNS = """
+    id, merchant_id, channel, installation_id, address, capabilities,
+    is_primary, status
+"""
 
 # Named once so the claim's RETURNING and the decoder cannot drift apart.
-# next_attempt_at rides along for the queue-lag log line: how long the oldest
-# row sat past due is the alert that rises whatever the cause.
+# next_attempt_at rides along for the queue-lag log line.
 CLAIMED_COLUMNS = """
     id, merchant_id, customer_id, channel, sent_to_address, binding_id,
     source_kind, source_id, purpose_key, template_id, variables,
@@ -86,22 +100,35 @@ def claim_queued_messages_query(batch_size: int) -> Tuple[str, List[Any]]:
     return query, [batch_size]
 
 
-def requeue_stale_claims_query(stale_minutes: int) -> Tuple[str, List[Any]]:
-    """Requeue rows whose worker never came back.
+def requeue_stale_claims_query(
+    stale_minutes: int, max_attempts: int
+) -> Tuple[str, List[Any]]:
+    """Requeue rows whose worker never came back — unless they are out of
+    attempts, in which case they die here.
 
-    Without this a pod restart leaves rows marked in-flight forever: invisible
-    to the queue, never sent, and nothing raises.
+    Without the requeue, a pod restart leaves rows in-flight forever:
+    invisible to the queue, never sent, and nothing raises.
+
+    Without the attempt check, the sweep loops forever on a row whose outcome
+    can never be RECORDED (a duplicate provider_message_id makes apply_outcome
+    raise every lap) — claimed, really sent, left 'sending', reclaimed, really
+    sent again. The claim spends an attempt per lap, so the ceiling that
+    bounds retries bounds this too, and dead-by-sweep gets the same reason as
+    dead-by-retry: we stopped, the provider didn't.
     """
     query = f"""
         UPDATE {MESSAGE_TABLE}
-           SET status = 'queued',
-               claimed_at = NULL,
-               reason = 'reclaimed_stale_claim'
+           SET status = CASE WHEN attempt >= $2::int
+                             THEN 'dead' ELSE 'queued' END,
+               reason = CASE WHEN attempt >= $2::int
+                             THEN 'max_attempts_exhausted'
+                             ELSE 'reclaimed_stale_claim' END,
+               claimed_at = NULL
          WHERE status = 'sending'
            AND claimed_at < now() - make_interval(mins => $1::int)
-        RETURNING id
+        RETURNING id, status
     """
-    return query, [stale_minutes]
+    return query, [stale_minutes, max_attempts]
 
 
 def apply_outcome_query(
@@ -110,13 +137,19 @@ def apply_outcome_query(
     reason: Optional[str],
     provider_message_id: Optional[str],
     mark_sent: bool,
+    attempt: int,
     retry_after_seconds: Optional[int],
 ) -> Tuple[str, List[Any]]:
     """Record what happened to a claimed message.
 
-    ``AND status = 'sending'`` keeps a slow send from overwriting a row the
-    sweep already reassigned; zero rows is the right answer there. COALESCE
-    stops a later failure erasing an id an earlier attempt earned.
+    The WHERE clause pins the write to the claim that did the send. Status
+    alone is not enough: the sweep can requeue a stale row and a second
+    worker reclaim it, putting it back in 'sending' under a NEW claim, and
+    the first worker's late outcome would overwrite it. The claim increments
+    ``attempt``, making it a claim-generation token — an expired claim's
+    write matches zero rows, the same "their outcome wins" answer.
+
+    COALESCE stops a later failure erasing an id an earlier attempt earned.
     ``retry_after_seconds`` is set only when requeuing; NULL leaves
     next_attempt_at alone, since a terminal outcome has no next attempt.
     """
@@ -133,6 +166,7 @@ def apply_outcome_query(
                END
          WHERE id = $1
            AND status = 'sending'
+           AND attempt = $7::int
         RETURNING id
     """
     return query, [
@@ -142,4 +176,62 @@ def apply_outcome_query(
         provider_message_id,
         mark_sent,
         retry_after_seconds,
+        attempt,
     ]
+
+
+def primary_binding_query(merchant_id: str, channel: str) -> Tuple[str, List[Any]]:
+    """The merchant's default pipe on a channel.
+
+    Only 'active': a paused or retired pipe must produce NO route rather than
+    fall through to another number — sending from an unexpected address is
+    worse than not sending. is_primary is partial-unique per (merchant,
+    channel), so this never has to choose between two rows.
+    """
+    query = f"""
+        SELECT {BINDING_COLUMNS}
+          FROM {BINDING_TABLE}
+         WHERE merchant_id = $1
+           AND channel = $2
+           AND is_primary
+           AND status = 'active'
+    """
+    return query, [merchant_id, channel]
+
+
+def binding_by_id_query(
+    merchant_id: str, binding_id: str, channel: str
+) -> Tuple[str, List[Any]]:
+    """One named pipe, scoped to its merchant AND channel in the WHERE clause
+    rather than checked afterwards.
+
+    The channel filter is not redundant with the id: binding_id is a bare
+    uuid with no FK, so a row could name a binding of a DIFFERENT channel,
+    whose address would then reach this channel's adapter as if it were its
+    own kind of endpoint. A mismatch must be 'no route'.
+    """
+    query = f"""
+        SELECT {BINDING_COLUMNS}
+          FROM {BINDING_TABLE}
+         WHERE merchant_id = $1
+           AND id = $2::uuid
+           AND channel = $3
+           AND status = 'active'
+    """
+    return query, [merchant_id, binding_id, channel]
+
+
+def installation_by_id_query(
+    merchant_id: str, installation_id: str
+) -> Tuple[str, List[Any]]:
+    """The account behind a pipe. Status is NOT filtered here — the caller
+    decides what an unhealthy installation means, and a route that silently
+    disappeared would be reported as 'no connection' when the truth is
+    'connection revoked'."""
+    query = f"""
+        SELECT {INSTALLATION_COLUMNS}
+          FROM {INSTALLATION_TABLE}
+         WHERE merchant_id = $1
+           AND id = $2::uuid
+    """
+    return query, [merchant_id, installation_id]

--- a/app/crm/connectivity/dispatch.py
+++ b/app/crm/connectivity/dispatch.py
@@ -8,12 +8,13 @@ The loop itself is not here: claim_sends()/dispatch_send() plug into the
 shared drain-loop scaffold (app/crm/shared/worker.py) as the "dispatcher"
 role in app/crm/worker_main.py. This file owns only what a row means.
 
-TODO: no permission check yet — may_contact() does not exist. It belongs in
-_dispatch_one before send(), and a refusal must write a 'blocked' row rather
-than retry. This phase ships demo sends without it by explicit scope decision
-(see the PR thread with Swaroop); the gate structure lands with B5.
+The gate exists as a thin slice: _gate() below probes platform suppression
+(fail closed) before every send, and a refusal writes a 'blocked' row. The
+full may_contact() — consent, purpose, quiet hours — replaces _gate's body
+with B5; the call site never changes.
 """
 
+import asyncio
 import random
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -23,12 +24,22 @@ from app.core.config.static import (
     CRM_DISPATCH_MAX_ATTEMPTS,
     CRM_DISPATCH_RETRY_BASE_SECONDS,
     CRM_DISPATCH_STALE_MINUTES,
+    CRM_MESSAGE_SEND_TIMEOUT_SECONDS,
 )
 from app.core.logger import logger
 from app.core.logger.context import set_log_context
+from app.crm.connectivity.channels import gate_handle_kind_for
 from app.crm.connectivity.db import accessor
-from app.crm.connectivity.schemas import QueuedMessage, SendOutcome
+from app.crm.connectivity.reasons import (
+    REASON_ATTEMPTS_EXHAUSTED,
+    REASON_GATE_UNAVAILABLE,
+    REASON_PROVIDER_REJECTED,
+    REASON_SEND_ERROR,
+    REASON_SUPPRESSED,
+)
+from app.crm.connectivity.schemas import QueuedMessage, SendOutcome, SendToken
 from app.crm.connectivity.send import send
+from app.crm.platform.contracts import is_suppressed
 
 LOG_COMPONENT = "crm.connectivity.dispatch"
 
@@ -42,16 +53,18 @@ LOG_ID_SAMPLE = 100
 # CRM_DISPATCH_MAX_ATTEMPTS cannot silently park a message for hours.
 RETRY_MAX_SECONDS = 300
 
-# 'failed' is the provider refusing for good; 'dead' is us running out of
-# retries. A merchant asking why nothing arrived needs to know which.
+# 'failed' is the provider refusing for good; 'blocked' is US refusing
+# (gate, no route); 'dead' is us running out of retries. A merchant asking
+# why nothing arrived needs to know which (T16 col 12).
 STATUS_QUEUED = "queued"
 STATUS_ACCEPTED = "accepted"
 STATUS_FAILED = "failed"
+STATUS_BLOCKED = "blocked"
 STATUS_DEAD = "dead"
 
-REASON_SEND_ERROR = "send_error"
-REASON_ATTEMPTS_EXHAUSTED = "max_attempts_exhausted"
-REASON_PROVIDER_REJECTED = "provider_rejected"
+# All REASON_* words live in reasons.py — one file, one name per failure
+# mode. Channel metadata (which handle kind the gate probes) lives in
+# channels.py — one registry, pinned ADAPTERS ⊆ CHANNELS by the test suite.
 
 
 def sample_ids(ids: Sequence[str], limit: int = LOG_ID_SAMPLE) -> str:
@@ -98,6 +111,16 @@ def plan_for_outcome(
             mark_sent=True,
         )
 
+    if outcome.status == STATUS_BLOCKED:
+        # OUR refusal: terminal, nothing was sent, and retrying cannot
+        # change what WE decided (T16: blocked vs failed vs dead).
+        return DispatchPlan(
+            status=STATUS_BLOCKED,
+            reason=outcome.reason or REASON_GATE_UNAVAILABLE,
+            provider_message_id=None,
+            mark_sent=False,
+        )
+
     # A row with no reason is a support ticket nobody can answer.
     reason = outcome.reason or REASON_PROVIDER_REJECTED
 
@@ -118,14 +141,13 @@ def plan_for_outcome(
             mark_sent=False,
         )
 
-    # Requeue, but not immediately: the delay is what makes a retry a retry
-    # rather than a second helping of whatever just failed.
+    # Requeue with a delay — the delay is what makes it a retry rather than a
+    # second helping of whatever just failed.
     #
-    # Note this is at-least-once, not exactly-once. The dedupe key stops a
-    # producer creating a second ROW; it cannot stop this row reaching the
-    # provider twice — if the provider accepted the attempt and we lost the
-    # response, the retry sends again. That risk is bounded by the claim
-    # lease, not eliminated.
+    # At-least-once, not exactly-once: the dedupe key stops a producer
+    # creating a second ROW, but if the provider accepted an attempt whose
+    # response we lost, the retry sends again. Bounded by the claim lease,
+    # not eliminated.
     return DispatchPlan(
         status=STATUS_QUEUED,
         reason=reason,
@@ -134,6 +156,65 @@ def plan_for_outcome(
         retry_after_seconds=backoff_seconds(
             attempt, CRM_DISPATCH_RETRY_BASE_SECONDS, RETRY_MAX_SECONDS
         ),
+    )
+
+
+async def _gate(message: QueuedMessage) -> Optional[str]:
+    """Returns a refusal reason, or None to allow. may_contact() (B5)
+    replaces this body; the call site never changes.
+
+    The thin slice that exists today is the one check a person who said
+    STOP is protected by: platform's suppression probe, which itself fails
+    closed (a DB error inside it reads as suppressed). Consent, purpose and
+    quiet hours arrive with the full gate.
+    """
+    # TODO(permission): the full gate must ALSO call may_contact() (B5) —
+    # consent from the consent table, purpose authorisation, quiet hours.
+    # Suppression stays as check #1; may_contact() joins it here, and its
+    # decision_id flows into mint_send_token below.
+    kind = gate_handle_kind_for(message.channel)
+    if kind is None:
+        # A channel the gate cannot check must not slip through unchecked.
+        return REASON_GATE_UNAVAILABLE
+    try:
+        # Same deadline law as send(): the probe reads the same pool, and a
+        # hung probe stalls the serial batch past the claim lease exactly
+        # like a hung provider — same reassigned tail, same double send. The
+        # lease-pin test bounds BATCH × timeout × 2, which covers this
+        # deadline plus send()'s.
+        if await asyncio.wait_for(
+            is_suppressed({kind: message.sent_to_address}),
+            timeout=CRM_MESSAGE_SEND_TIMEOUT_SECONDS,
+        ):
+            return REASON_SUPPRESSED
+    except asyncio.TimeoutError:
+        # Fail closed, not retry-later-by-word: nothing was sent, so this is
+        # OUR refusal, same as a probe that raised.
+        logger.error(
+            f"gate probe timed out after {CRM_MESSAGE_SEND_TIMEOUT_SECONDS}s "
+            f"for {message.id}"
+        )
+        return REASON_GATE_UNAVAILABLE
+    except Exception as e:
+        # is_suppressed is total by contract; this catches an escape from
+        # OUR plumbing around it. Unknown gate input → NO (ADR 0018).
+        logger.opt(exception=e).error(f"gate probe raised for {message.id}")
+        return REASON_GATE_UNAVAILABLE
+    return None
+
+
+def mint_send_token(message: QueuedMessage) -> SendToken:
+    """The token that names the one message _gate() just allowed.
+
+    Policy lives in _gate(); this mints identity, and send() refuses a token
+    that does not name this exact message — so no adapter was ever wired
+    without one. When may_contact() (B5) replaces _gate's body, its
+    decision_id lands here, tracing a send back to the grant.
+    """
+    return SendToken(
+        message_id=message.id,
+        purpose_key=message.purpose_key,
+        granted=True,
     )
 
 
@@ -148,24 +229,35 @@ def _jittered(seconds: Optional[int]) -> Optional[int]:
 async def claim_sends(batch: int) -> List[QueuedMessage]:
     """The scaffold's claim: sweep stale leases, then claim up to ``batch``.
 
-    Lease-style, not txn-style — the claim commits before any send happens
-    (holding a transaction across a provider call would pin a pooled
-    connection for as long as the network takes), and the stale sweep is
-    what expires a dead worker's lease.
+    Lease-style, not txn-style: the claim commits before any send happens,
+    because holding a transaction across a provider call would pin a pooled
+    connection for as long as the network takes. The stale sweep is what
+    expires a dead worker's lease.
     """
     # Reset per pass, so the previous message's ids can't leak into this
     # pass's claim and sweep lines.
     set_log_context(component=LOG_COMPONENT)
 
-    # Reclaim first so rows abandoned by a dead worker rejoin this batch
-    # instead of waiting another tick.
-    reclaimed = await accessor.requeue_stale_claims(CRM_DISPATCH_STALE_MINUTES)
+    # Reclaim first, so rows abandoned by a dead worker rejoin this batch
+    # instead of waiting a tick. The sweep KILLS rather than requeues a row
+    # out of attempts — every lap through it was a claim that really sent, so
+    # an unbounded sweep would be an unbounded sender.
+    reclaimed, exhausted = await accessor.requeue_stale_claims(
+        CRM_DISPATCH_STALE_MINUTES, CRM_DISPATCH_MAX_ATTEMPTS
+    )
     if reclaimed:
         # Named, not counted: these are the rows a double-send investigation
         # starts from.
         logger.warning(
             f"crm dispatch reclaimed {len(reclaimed)} stale claim(s): "
             f"{sample_ids(reclaimed)}"
+        )
+    if exhausted:
+        # Louder than a reclaim: each of these was attempted max times and
+        # never once recorded an outcome — the customer may have every copy.
+        logger.error(
+            f"crm dispatch killed {len(exhausted)} stale claim(s) out of "
+            f"attempts: {sample_ids(exhausted)}"
         )
 
     messages = await accessor.claim_queued_messages(batch)
@@ -175,9 +267,9 @@ async def claim_sends(batch: int) -> List[QueuedMessage]:
 
 def _log_queue_lag(messages: Sequence[QueuedMessage], limit: int) -> None:
     """How long the oldest claimed row sat past due — the alert that rises
-    whatever the cause. Measured from next_attempt_at (timestamptz NOT NULL,
-    so always aware), not created_at: a retry serving out its backoff is
-    waiting on purpose, and on-purpose waiting is not lag."""
+    whatever the cause. Measured from next_attempt_at, not created_at: a
+    retry serving out its backoff is waiting on purpose, and on-purpose
+    waiting is not lag."""
     if not messages:
         return
     oldest = min(m.next_attempt_at for m in messages)
@@ -198,11 +290,9 @@ async def _dispatch_one(message: QueuedMessage, max_attempts: int) -> None:
     """Work one claimed message.
 
     Never raises: the rest of the batch is already claimed, so an escaping
-    exception would strand it until those claims expire.
-
-    Nothing is wrapped in a transaction. Holding one across the provider call
-    would pin a pooled connection for as long as the network takes, and one
-    slow provider could then starve the app behind the connection pooler.
+    exception would strand it until those claims expire. Nothing is wrapped
+    in a transaction either — one held across a provider call would pin a
+    pooled connection for as long as the network takes.
     """
     # Structured, so a log search can filter by message or merchant instead of
     # substring-matching the text. Every line below inherits these fields.
@@ -215,15 +305,25 @@ async def _dispatch_one(message: QueuedMessage, max_attempts: int) -> None:
         channel=message.channel,
         attempt=message.attempt,
     )
-    try:
-        outcome = await send(message)
-    except Exception as e:
-        # Retryable, not rejected: we don't know whether the provider saw it.
-        # opt(exception=) not exc_info=True — loguru drops the latter's stack.
-        logger.opt(exception=e).error(f"send raised for message {message.id}")
-        outcome = SendOutcome(
-            status=STATUS_FAILED, reason=REASON_SEND_ERROR, retryable=True
-        )
+    refusal = await _gate(message)
+    if refusal is not None:
+        # Blocked before the adapter is ever touched — the row records OUR
+        # refusal with its reason, and nothing reaches the provider.
+        # gate_unavailable is louder: it means misconfig (a channel the gate
+        # cannot probe), not policy — the one refusal an operator must notice.
+        log = logger.error if refusal == REASON_GATE_UNAVAILABLE else logger.warning
+        log(f"message {message.id} blocked by gate — {refusal}")
+        outcome = SendOutcome(status=STATUS_BLOCKED, reason=refusal)
+    else:
+        try:
+            outcome = await send(mint_send_token(message), message)
+        except Exception as e:
+            # Retryable, not rejected: we don't know whether the provider
+            # saw it. opt(exception=) — loguru drops exc_info's stack.
+            logger.opt(exception=e).error(f"send raised for message {message.id}")
+            outcome = SendOutcome(
+                status=STATUS_FAILED, reason=REASON_SEND_ERROR, retryable=True
+            )
 
     # message.attempt already counts this try — the claim incremented it.
     plan = plan_for_outcome(outcome, message.attempt, max_attempts)
@@ -235,6 +335,9 @@ async def _dispatch_one(message: QueuedMessage, max_attempts: int) -> None:
             plan.reason,
             plan.provider_message_id,
             plan.mark_sent,
+            # The claim's generation: if the sweep reassigned this row and a
+            # newer claim bumped attempt, our late outcome must miss.
+            message.attempt,
             _jittered(plan.retry_after_seconds),
         )
     except Exception as e:

--- a/app/crm/connectivity/providers/__init__.py
+++ b/app/crm/connectivity/providers/__init__.py
@@ -1,0 +1,46 @@
+"""The adapter registry — the channel vocabulary, in code.
+
+This dict is what the tables deliberately refuse to hold: migration 027
+taught that a CHECK constraint turns "support a new channel" into a
+migration, a deploy window and a rollback plan. Here a new channel is
+providers/<name>.py plus one line below. Nothing else.
+
+Imported ONLY by send.py — the point of putting adapters behind one door:
+
+    grep -rn "connectivity.providers" app/ | grep -v "^app/crm/connectivity/providers/"
+"""
+
+from typing import Dict, Optional
+
+from app.crm.connectivity.providers.base import ChannelAdapter
+from app.crm.connectivity.providers.whatsapp import MetaWhatsAppAdapter
+
+# Instantiated once: adapters are stateless request builders.
+#
+# One entry on purpose — no stand-in adapter. A local run points
+# META_WHATSAPP_GRAPH_BASE_URL at a stub and exercises the REAL adapter,
+# testing the request we actually send rather than one that resembles it.
+ADAPTERS: Dict[str, ChannelAdapter] = {
+    MetaWhatsAppAdapter.channel: MetaWhatsAppAdapter(),
+    # "sms": SmsAdapter(),
+    # "email": EmailAdapter(),
+    # "instagram": InstagramAdapter(),
+}
+
+
+def adapter_for(channel: str) -> Optional[ChannelAdapter]:
+    """The adapter serving ``channel``, or None.
+
+    None rather than a raise: an unroutable channel is a terminal fact about
+    that row, which the caller records as its reason — not an exception the
+    worker should wear.
+    """
+    return ADAPTERS.get(channel)
+
+
+__all__ = [
+    "ADAPTERS",
+    "ChannelAdapter",
+    "MetaWhatsAppAdapter",
+    "adapter_for",
+]

--- a/app/crm/connectivity/providers/base.py
+++ b/app/crm/connectivity/providers/base.py
@@ -1,0 +1,105 @@
+"""The parent every channel adapter inherits.
+
+A child implements two things — build the request, read the answer — and
+inherits what must never vary between channels: transport-failure
+classification, address masking, and the fact that policy is not its job.
+
+The split that matters: an adapter CLASSIFIES, it never DECIDES. It reports
+what the provider did (accepted; failed, plausibly-retryable or not);
+dispatch.plan_for_outcome alone turns that into queued / failed / dead.
+An adapter reaching for the retry ladder would give each channel its own
+private policy, and "why was this retried" would stop having one answer.
+"""
+
+from abc import ABC, abstractmethod
+from typing import Any, ClassVar, Dict, Optional
+
+import httpx
+
+from app.core.logger import logger
+from app.crm.connectivity.reasons import REASON_TRANSPORT
+from app.crm.connectivity.schemas import (
+    ChannelBinding,
+    CredentialBundle,
+    QueuedMessage,
+    SendOutcome,
+)
+from app.crm.shared.redact import mask_address
+
+# All REASON_* words live in reasons.py — one file, one name per failure
+# mode.
+
+
+class ChannelAdapter(ABC):
+    """One provider, behind one method.
+
+    Subclasses set ``channel`` and implement ``deliver``. They receive
+    everything already resolved — endpoint, decrypted secrets — so no adapter
+    touches the database, which is what makes them testable without one.
+    """
+
+    #: The channel word this adapter serves, e.g. "whatsapp". The registry
+    #: keys on it; it is the vocabulary the tables deliberately do not store.
+    channel: ClassVar[str] = ""
+
+    @abstractmethod
+    async def deliver(
+        self,
+        message: QueuedMessage,
+        route_bundle: CredentialBundle,
+        binding: ChannelBinding,
+    ) -> SendOutcome:
+        """Hand ``message`` to the provider and report what happened.
+
+        Must not raise for anything the provider does — a rejection is a
+        SendOutcome, not an exception. Raising is reserved for genuine bugs,
+        which send() catches as retryable since it cannot know whether the
+        message got out.
+        """
+
+    # ---- shared plumbing children inherit --------------------------------
+
+    def transport_failure(self, error: Exception, address: str) -> SendOutcome:
+        """Classify a request that never produced a response.
+
+        Always retryable: this covers "no answer", and no answer is not the
+        same as no — the customer may already have the message.
+        """
+        logger.warning(
+            f"{self.channel} transport failure to "
+            f"{mask_address(address, self.channel)}: "
+            f"{type(error).__name__}"
+        )
+        return SendOutcome(status="failed", reason=REASON_TRANSPORT, retryable=True)
+
+    @staticmethod
+    def json_body(response: httpx.Response) -> Dict[str, Any]:
+        """The response as an object, or an empty one.
+
+        A provider having a bad day returns HTML from a load balancer, and a
+        JSONDecodeError here would read as a code bug rather than the upstream
+        failure it is. The status code still carries the verdict, so an empty
+        body degrades to "failed, no detail" instead of taking the worker down.
+        """
+        try:
+            body = response.json()
+        except ValueError:
+            return {}
+        return body if isinstance(body, dict) else {}
+
+
+class AdapterRegistryError(LookupError):
+    """No adapter serves this channel — raised only by the registry lookup."""
+
+
+def require_secret(bundle: CredentialBundle, key: str, channel: str) -> Optional[str]:
+    """A secret the adapter cannot work without, or None with a log line.
+
+    Split out so every adapter reports a missing key the same way: terminal,
+    never retryable — retrying a bundle that lacks the key it needs just
+    spends attempts.
+    """
+    value = bundle.secret(key)
+    if value is None:
+        logger.error(f"{channel}: credential bundle is missing '{key}'")
+    return value

--- a/app/crm/connectivity/providers/whatsapp.py
+++ b/app/crm/connectivity/providers/whatsapp.py
@@ -1,0 +1,355 @@
+"""WhatsApp, straight at Meta's Cloud API — no aggregator in between.
+
+The first child of ChannelAdapter, and the shape every later one copies:
+build a request from the manifest row, read the answer, classify it. Nothing
+here decides whether to retry, only whether retrying could plausibly differ.
+
+Sends are template-only by design, not by omission: the manifest stores
+template_id + variables and never a rendered string, because Meta renders the
+final text and our own copy would be a guess at what the customer saw.
+Free-form text needs an open conversation, which is the conversations
+module's job.
+
+Credential bundle (written by onboarding, read here):
+    system_user_token   the bearer for every call        [required]
+    app_secret          verifies inbound webhooks        [phase 3]
+    verify_token        the webhook handshake secret     [phase 3]
+"""
+
+import re
+from typing import Any, Dict, List, Optional, Union
+from urllib.parse import quote
+
+import httpx
+
+from app.core.config.static import (
+    CRM_MESSAGE_SEND_TIMEOUT_SECONDS,
+    META_WHATSAPP_GRAPH_BASE_URL,
+    META_WHATSAPP_GRAPH_VERSION,
+)
+from app.core.logger import logger
+from app.core.transport.http_client import create_http_client
+from app.crm.connectivity.providers.base import ChannelAdapter, require_secret
+from app.crm.connectivity.reasons import (
+    REASON_BAD_ADDRESS,
+    REASON_BAD_VARIABLES,
+    REASON_NO_CREDENTIAL,
+    REASON_NO_TEMPLATE,
+    REASON_UNREADABLE,
+)
+from app.crm.connectivity.schemas import (
+    ChannelBinding,
+    CredentialBundle,
+    QueuedMessage,
+    SendOutcome,
+)
+from app.crm.shared.redact import mask_address, mask_digit_runs
+
+TOKEN_KEY = "system_user_token"
+
+# Meta's error codes, split by the only question an adapter may ask: could
+# the same request plausibly succeed later?
+#
+# Retryable — the provider is busy or pacing us, not refusing on the merits.
+# The first three are Graph/app/WABA throttles that arrive as HTTP 400, which
+# the unknown-4xx default below would read as terminal — permanently failing
+# every message queued during a throttle window instead of backing off.
+RETRYABLE_CODES = {
+    "4",  # app-level "API Too Many Calls"
+    "613",  # Graph rate limit exceeded
+    "80007",  # WABA rate limit
+    "130429",  # Cloud API throughput limit
+    "131048",  # spam rate limit
+    "131049",  # per-user engagement limit ("healthy ecosystem")
+    "131056",  # business/consumer pair rate limit
+}
+
+# Terminal — waiting changes nothing; retrying just collects the identical
+# refusal three times.
+TERMINAL_CODES = {
+    "100",  # invalid parameter
+    "131008",  # required parameter missing
+    "131009",  # parameter value invalid
+    "131026",  # undeliverable: recipient cannot receive WhatsApp messages
+    "131047",  # 24-hour window closed — a template is the fix, not a retry
+    "132000",  # template param count mismatch
+    "132001",  # template does not exist
+    "132005",  # rendered template too long
+    "132007",  # template content policy violation
+    "132012",  # template parameter format mismatch
+    "132015",  # template paused
+    "132016",  # template disabled
+}
+
+# Terminal, and a statement about the CONNECTION rather than this message:
+# every queued message for that merchant is about to fail the same way. The
+# send path does not act on them (that is channel-lifecycle work, not built
+# yet) — they are named so that module has an exact signal to watch for on
+# crm_message.reason instead of guessing which codes mean "re-authenticate".
+CREDENTIAL_CODES = {
+    "10",  # permission denied
+    "190",  # invalid or expired access token
+    "200",  # permissions error
+    "133010",  # phone number not registered for Cloud API
+}
+
+_NON_DIGITS = re.compile(r"\D")
+
+
+def to_meta_recipient(address: str) -> Optional[str]:
+    """E.164 in, Meta's digits-only form out.
+
+    Stripping happens HERE and the stripped form is never persisted: one
+    representation in the database, whatever each provider prefers at its
+    own edge.
+    """
+    digits = _NON_DIGITS.sub("", address or "")
+    # Deliberate parity with shared/normalize.py's ^\+[1-9][0-9]{6,14}$ (and
+    # the platform_identity CHECK), so a number this system was willing to
+    # store is never rejected here as an "invalid address". 15 is E.164's
+    # ceiling; 7 is the real short end (Saint Helena, +290 plus 4 digits);
+    # no country code starts with 0.
+    if not 7 <= len(digits) <= 15 or digits.startswith("0"):
+        return None
+    return digits
+
+
+# The value types str() renders faithfully. bool is refused below despite
+# being an int subclass: str(True) is 'True', which no customer message
+# means to say.
+_TEXTABLE_TYPES = (str, int, float)
+
+
+def build_parameters(variables: Dict[str, Any]) -> Union[List[Dict[str, Any]], str]:
+    """Manifest variables -> Meta template body parameters, or the defect.
+
+    Meta accepts two forms and the producer chooses by how it writes the keys:
+
+      {"1": "Priya", "2": "ORD-42"}         -> positional, in numeric order
+      {"customer_name": "Priya", ...}       -> named (parameter_name)
+
+    A str return means the dict cannot be sent and says why — the caller
+    logs it and refuses terminally with REASON_BAD_VARIABLES. Two defects
+    earn that:
+
+      · A value that is not text or a number. str() rendered a JSON null as
+        the literal word 'None' inside a customer's message — corruption
+        that LOOKS delivered. The defect names the key and type, never the
+        value, which may be personal data.
+      · Positional and named keys mixed. Meta takes one style per request,
+        so no rendering is correct; guessing one only buys a round trip to
+        the refusal this string already states.
+
+    ASCII digits decide positional vs named, not str.isdigit(), which also
+    accepts digit-CATEGORY characters like '²' that int() then refuses —
+    turning a bad key into a mid-send exception instead of an outcome.
+    """
+    if not variables:
+        return []
+    items = [(str(key), value) for key, value in variables.items()]
+    for key, value in items:
+        if isinstance(value, bool) or not isinstance(value, _TEXTABLE_TYPES):
+            return f"variable '{key}' is {type(value).__name__}, not text"
+    positional = [key for key, _ in items if key.isascii() and key.isdigit()]
+    if len(positional) == len(items):
+        # Sorting as strings would put "10" before "2" and silently swap two
+        # values in a customer's message.
+        ordered = sorted(items, key=lambda item: int(item[0]))
+        return [{"type": "text", "text": str(value)} for _, value in ordered]
+    if positional:
+        return "mixes positional and named template variables"
+    return [
+        {"type": "text", "parameter_name": key, "text": str(value)}
+        for key, value in items
+    ]
+
+
+class MetaWhatsAppAdapter(ChannelAdapter):
+    """Meta Cloud API, one merchant's phone number at a time."""
+
+    channel = "whatsapp"
+
+    def __init__(
+        self,
+        base_url: str = META_WHATSAPP_GRAPH_BASE_URL,
+        api_version: str = META_WHATSAPP_GRAPH_VERSION,
+    ) -> None:
+        """Both are dials so a local run can point at a stub and exercise
+        the whole dispatcher without sending anything to Meta."""
+        self._base_url = base_url.rstrip("/")
+        self._api_version = api_version.strip("/")
+
+    def endpoint(self, phone_number_id: str) -> str:
+        """The per-number /messages URL — one endpoint per binding address."""
+        # quote(..., safe="") pins the address inside one path segment. The
+        # column has no format CHECK and no writer validates it: a '/' in a
+        # bad row must not become URL structure carrying the bearer token to
+        # another Graph path, and a control character must not raise
+        # httpx.InvalidURL — not an HTTPError, so it sails past the catch.
+        return (
+            f"{self._base_url}/{self._api_version}/"
+            f"{quote(phone_number_id, safe='')}/messages"
+        )
+
+    async def deliver(
+        self,
+        message: QueuedMessage,
+        route_bundle: CredentialBundle,
+        binding: ChannelBinding,
+    ) -> SendOutcome:
+        """Build the request, post it, classify the answer.
+
+        Every refusal before the network is 'blocked', never 'failed':
+        nothing was posted, so these are OUR refusals — 'failed' is the word
+        the manifest reserves for the provider's no (T16 col 12). Terminal
+        either way: a missing token, template or usable address does not
+        change by retrying.
+        """
+        token = require_secret(route_bundle, TOKEN_KEY, self.channel)
+        if token is None:
+            # This reason must carry the same status here as it does from
+            # resolve_send_route — one word, one meaning on the manifest.
+            return SendOutcome(status="blocked", reason=REASON_NO_CREDENTIAL)
+
+        if not message.template_id:
+            # Not a retry: this row can never be sent as it stands.
+            logger.error(f"whatsapp: message {message.id} has no template_id")
+            return SendOutcome(status="blocked", reason=REASON_NO_TEMPLATE)
+
+        recipient = to_meta_recipient(message.sent_to_address)
+        if recipient is None:
+            logger.error(
+                f"whatsapp: message {message.id} address "
+                f"{mask_address(message.sent_to_address, self.channel)} "
+                f"is not a usable number"
+            )
+            return SendOutcome(status="blocked", reason=REASON_BAD_ADDRESS)
+
+        parameters = build_parameters(message.variables)
+        if isinstance(parameters, str):
+            # No rendering of these variables is the right one; refuse here
+            # instead of shipping a guess or letting Meta refuse one.
+            logger.error(
+                f"whatsapp: message {message.id} has unsendable variables — "
+                f"{parameters}"
+            )
+            return SendOutcome(status="blocked", reason=REASON_BAD_VARIABLES)
+
+        payload = self.build_payload(message, recipient, binding, parameters)
+        url = self.endpoint(binding.address)
+
+        try:
+            async with create_http_client(
+                timeout=CRM_MESSAGE_SEND_TIMEOUT_SECONDS
+            ) as client:
+                response = await client.post(
+                    url,
+                    json=payload,
+                    headers={"Authorization": f"Bearer {token}"},
+                )
+        except httpx.HTTPError as e:
+            return self.transport_failure(e, message.sent_to_address)
+
+        return self.read_response(response, message)
+
+    def build_payload(
+        self,
+        message: QueuedMessage,
+        recipient: str,
+        binding: ChannelBinding,
+        parameters: List[Dict[str, Any]],
+    ) -> Dict[str, Any]:
+        """The Cloud API send body. Assembly only — ``parameters`` arrive
+        already built and judged sendable by deliver().
+
+        Language comes from the binding: which locale a merchant's template
+        is approved in is a per-endpoint fact, not a global setting. INTERIM
+        until T23's registry keys templates by (merchant, channel, name,
+        language) — then the registry decides and this read goes away.
+        """
+        language = str(binding.capabilities.get("template_language") or "en_US")
+        components: List[Dict[str, Any]] = []
+        if parameters:
+            components.append({"type": "body", "parameters": parameters})
+        return {
+            "messaging_product": "whatsapp",
+            "recipient_type": "individual",
+            "to": recipient,
+            "type": "template",
+            "template": {
+                "name": message.template_id,
+                "language": {"code": language},
+                "components": components,
+            },
+        }
+
+    def read_response(
+        self, response: httpx.Response, message: QueuedMessage
+    ) -> SendOutcome:
+        """Meta's answer -> SendOutcome. Classification only."""
+        body = self.json_body(response)
+
+        if response.is_success:
+            provider_message_id = self.message_id_of(body)
+            if provider_message_id is None:
+                # Still 'accepted': Meta took it, and calling this a failure
+                # would retry a message the customer may already have.
+                logger.warning(
+                    f"whatsapp: message {message.id} accepted without a wamid"
+                )
+            return SendOutcome(
+                status="accepted", provider_message_id=provider_message_id
+            )
+
+        code, detail = self.error_of(body)
+        # detail is Meta's text, not ours: their catalog strings carry no
+        # values today, but a string we don't control could someday echo the
+        # recipient — masking beats trusting the contract to hold.
+        logger.warning(
+            f"whatsapp: message {message.id} refused — "
+            f"http={response.status_code} code={code or 'none'} "
+            f"{mask_digit_runs(detail)}"
+        )
+
+        # Both classes are terminal for THIS row and behave identically here;
+        # they stay separate sets because they differ in what they say about
+        # the CONNECTION, which channel-lifecycle code reads off `reason`.
+        if code in TERMINAL_CODES or code in CREDENTIAL_CODES:
+            return SendOutcome(status="failed", reason=code)
+        if code in RETRYABLE_CODES or response.status_code == 429:
+            return SendOutcome(status="failed", reason=code or "429", retryable=True)
+
+        # Unknown code: 5xx is Meta's problem and may pass, 4xx is ours and
+        # will not — retrying an unknown 4xx spends attempts learning nothing.
+        retryable = response.status_code >= 500
+        return SendOutcome(
+            status="failed",
+            reason=code or f"http_{response.status_code}",
+            retryable=retryable,
+        )
+
+    @staticmethod
+    def message_id_of(body: Dict[str, Any]) -> Optional[str]:
+        """The wamid, which every delivery receipt will be keyed by."""
+        messages = body.get("messages")
+        if isinstance(messages, list) and messages:
+            first = messages[0]
+            if isinstance(first, dict) and first.get("id"):
+                return str(first["id"])
+        return None
+
+    @staticmethod
+    def error_of(body: Dict[str, Any]) -> tuple:
+        """(code, human detail) from Meta's error envelope.
+
+        The code lands in `reason` verbatim — the provider's own word, not
+        our paraphrase, so "why?" has an answer matching Meta's docs.
+        """
+        error = body.get("error")
+        if not isinstance(error, dict):
+            return None, REASON_UNREADABLE
+        code = error.get("code")
+        return (
+            str(code) if code is not None else None,
+            str(error.get("message") or ""),
+        )

--- a/app/crm/connectivity/reasons.py
+++ b/app/crm/connectivity/reasons.py
@@ -1,0 +1,57 @@
+"""Every reason a crm_message row can carry — one file, one name each.
+
+`reason` is this module's public vocabulary: merchants read it off the
+manifest, channel-lifecycle code watches for specific words, support greps
+for them. Definitions scattered across files is how one failure mode drifts
+into two spellings, so every constant is declared here and imported by the
+file that raises it.
+
+Only the WORDS live here. What each one means for the row — terminal or
+retryable, which status it rides with — is decided where it always was:
+adapters classify, plan_for_outcome decides.
+"""
+
+# --- the send door's refusals (send.py) — all terminal: none of these
+# changes by waiting, so a retry would spend the row's attempts
+# rediscovering the same missing thing.
+REASON_GATE_REFUSED = "gate_refused"
+REASON_NO_ADAPTER = "channel_not_supported"
+REASON_NO_BINDING = "no_active_binding"
+REASON_NO_INSTALLATION = "connector_not_installed"
+REASON_INSTALLATION_UNHEALTHY = "connector_unhealthy"
+
+# Retryable, unlike the refusals above — both mean "no answer", and no
+# answer is not "no": the provider may have taken the message. The timeout
+# is the deadline firing; send_error is the default case, naming anything
+# that escapes classification, one name shared by send()'s catch-all and
+# dispatch's outer one.
+REASON_TIMEOUT = "send_timeout"
+REASON_SEND_ERROR = "send_error"
+
+# --- provider classification (providers/) ---
+# A refused connection, a DNS failure and a read timeout all mean the same
+# thing everywhere: we don't know whether the provider saw the message.
+REASON_TRANSPORT = "transport_error"
+# Terminal, and one word for two reporters: require_secret in an adapter
+# and send.py's route resolution surface the same broken-credential fact,
+# and it is the word channel-lifecycle code watches for on crm_message.
+REASON_NO_CREDENTIAL = "connector_credential_missing"
+REASON_NO_TEMPLATE = "template_missing"
+REASON_BAD_ADDRESS = "recipient_address_invalid"
+REASON_BAD_VARIABLES = "template_variables_invalid"
+REASON_UNREADABLE = "provider_response_unreadable"
+
+# --- dispatch policy (dispatch.py) ---
+# Must match the literal the stale sweep writes in SQL
+# (db/queries.py::requeue_stale_claims_query) — dead-by-sweep and
+# dead-by-retry are one fact and must carry one word.
+REASON_ATTEMPTS_EXHAUSTED = "max_attempts_exhausted"
+# Must match its SQL literal in the same sweep: what a reclaimed row carries
+# while it waits for its retry. Written only by that UPDATE, but the word is
+# merchant-visible on the manifest, so it is declared with the rest of the
+# vocabulary rather than living in SQL alone.
+REASON_RECLAIMED_STALE_CLAIM = "reclaimed_stale_claim"
+# A row with no reason is a support ticket nobody can answer.
+REASON_PROVIDER_REJECTED = "provider_rejected"
+REASON_SUPPRESSED = "suppressed"
+REASON_GATE_UNAVAILABLE = "gate_unavailable"

--- a/app/crm/connectivity/schemas.py
+++ b/app/crm/connectivity/schemas.py
@@ -3,7 +3,7 @@
 from datetime import datetime
 from typing import Any, Dict, Literal, Optional
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 class QueuedMessage(BaseModel):
@@ -30,14 +30,94 @@ class QueuedMessage(BaseModel):
 
 
 class SendOutcome(BaseModel):
-    """What a connector reports back.
+    """What a connector reports back: what the provider DID, never what the
+    row should become — that decision stays in dispatch.py. ``reason`` is
+    shown to merchants, so "error" is not a reason.
 
-    Deliberately says what the provider did, not what the row should become —
-    that decision stays in dispatch.py. ``reason`` is shown to merchants, so
-    "error" is not a reason.
+    'blocked' is OUR refusal (gate, no route); 'failed' is the provider's
+    (T16 col 12) — a row is refused by us or by them, never both.
     """
 
-    status: Literal["accepted", "failed"]
+    status: Literal["accepted", "failed", "blocked"]
     provider_message_id: Optional[str] = None
     reason: Optional[str] = None
     retryable: bool = False
+
+
+class SendToken(BaseModel):
+    """The gate's grant for ONE message. Presented to send(), consumed there.
+
+    dispatch.py mints one only after _gate() allows the message — today the
+    suppression slice (fail closed), until the full may_contact() (consent,
+    purpose, quiet hours — the permission module's B5) replaces the gate's
+    body. send() refuses a token that does not name this exact message, so
+    one grant can never authorise a batch.
+    """
+
+    message_id: str
+    purpose_key: str
+    granted: bool = False
+    # Points at the permission decision that authorised the send; stamped onto
+    # the manifest row once the diary exists.
+    decision_id: Optional[int] = None
+
+
+class ConnectorInstallation(BaseModel):
+    """A merchant's account on one connector — the door.
+
+    Holds no secret: ``credential_id`` says where the bundle lives.
+    """
+
+    id: str
+    merchant_id: str
+    connector_key: str
+    external_account_id: str
+    display_label: Optional[str] = None
+    credential_id: Optional[str] = None
+    status: str
+    token_expires_at: Optional[datetime] = None
+
+
+class ChannelBinding(BaseModel):
+    """One real endpoint under an installation — the pipe.
+
+    ``address`` is the provider's identifier for it (a Meta phone_number_id,
+    a sender id, a from-address); what it means is the channel's business.
+    """
+
+    id: str
+    merchant_id: str
+    channel: str
+    installation_id: str
+    address: str
+    capabilities: Dict[str, Any] = {}
+    is_primary: bool = False
+    status: str
+
+
+class CredentialBundle(BaseModel):
+    """One installation's whole key bundle, decrypted.
+
+    A bag, not a schema: what keys a connector needs is the adapter's
+    business. ``repr=False`` means an accidental f-string prints
+    CredentialBundle(), not a live token — the cheapest guard against
+    leaking a secret into a log aggregator.
+    """
+
+    values: Dict[str, Any] = Field(default_factory=dict, repr=False)
+
+    def secret(self, key: str) -> Optional[str]:
+        """The named secret, or None. Callers fail closed on None; a bundle
+        missing the key it needs is a broken connection, not a retry."""
+        value = self.values.get(key)
+        return value if isinstance(value, str) and value else None
+
+
+class SendRoute(BaseModel):
+    """Everything a sender needs, resolved in one call — so no adapter ever
+    asks the database anything, which is what keeps them testable without
+    one."""
+
+    installation: ConnectorInstallation
+    binding: ChannelBinding
+    bundle: CredentialBundle

--- a/app/crm/connectivity/send.py
+++ b/app/crm/connectivity/send.py
@@ -1,40 +1,219 @@
-"""The provider seam — a dummy for now.
+"""The provider seam — the module's only path to the outside world.
 
-By convention the module's only provider call site: keeping real channel
-adapters behind this file is what lets the manifest answer "did we contact
-this person?" without auditing the whole module.
+Everything that must be true before a message reaches a person is checked
+here, once, for every channel: the gate granted it, the channel has an
+adapter, the merchant has a live pipe, the account behind it is healthy, its
+credentials decrypt. Any of those missing REFUSES the send — nothing falls
+through to a default, because every plausible default (another number,
+another account) contacts somebody in a way they did not agree to.
 
-A real adapter maps the provider's response onto SendOutcome:
-accepted with the provider's message id, or failed with its error code and
-whether retrying could plausibly differ (429 and 5xx yes, bad template no).
+The route is assembled here and handed to the adapter whole, which is what
+lets an adapter be tested without a database. Adapters live behind
+providers/ and are imported nowhere else — boundary rule 11 fails CI on any
+other import, because a stray one reaches a provider without passing the
+checks above. The same fact, greppable:
 
-TODO before the first real adapter: wrap this call in asyncio.wait_for at the
-dispatcher's call site — one timeout no adapter can forget — well under
-CRM_DISPATCH_STALE_MINUTES, and treat a timeout as a retryable failure. A send
-that outlives its lease gets claimed by a second worker while the first is
-still sending, and the customer receives the message twice. A dummy send
-cannot exceed the lease, which is the only reason nothing enforces this yet.
+    grep -rn "connectivity.providers" app/ | grep -v "^app/crm/connectivity/providers/"
+
+Two things this file deliberately does NOT do:
+
+  · Decide what a failure means. It reports; dispatch.py's retry ladder
+    decides. Two deciders would mean two answers to "why was this retried".
+  · Write to the route tables — only READ them. Acting on a credential
+    rejection (marking degraded, alerting, re-auth) belongs to channel
+    lifecycle code; two owners for one lifecycle is how a status flaps.
 """
 
-from uuid import uuid4
+import asyncio
+from typing import Optional, Union
 
+from app.core.config.static import CRM_MESSAGE_SEND_TIMEOUT_SECONDS
 from app.core.logger import logger
-from app.crm.connectivity.schemas import QueuedMessage, SendOutcome
+from app.crm.connectivity.db import accessor
+from app.crm.connectivity.providers import adapter_for
+from app.crm.connectivity.providers.base import ChannelAdapter
+from app.crm.connectivity.reasons import (
+    REASON_GATE_REFUSED,
+    REASON_INSTALLATION_UNHEALTHY,
+    REASON_NO_ADAPTER,
+    REASON_NO_BINDING,
+    REASON_NO_CREDENTIAL,
+    REASON_NO_INSTALLATION,
+    REASON_SEND_ERROR,
+    REASON_TIMEOUT,
+)
+from app.crm.connectivity.schemas import (
+    CredentialBundle,
+    QueuedMessage,
+    SendOutcome,
+    SendRoute,
+    SendToken,
+)
+from app.crm.shared.redact import mask_address
+from app.database.accessor.breeze_buddy.credentials import get_credential_by_id
+
+# All REASON_* words live in reasons.py — one file, one name per failure
+# mode. This door only raises them.
+
+# The only installation state a send may leave through — fail closed on
+# everything else, 'connecting' included. Onboarding (#1038) verifies the
+# token and number against the Graph API and writes the row as 'healthy'
+# directly, so 'connecting' is an unproven connection with no first-send
+# deadlock to earn it an exception.
+SENDABLE_INSTALLATION_STATES = frozenset({"healthy"})
 
 
-async def send(message: QueuedMessage) -> SendOutcome:
-    """Pretend to hand ``message`` to its provider.
+def _refused(reason: str) -> SendOutcome:
+    """OUR refusal — 'blocked', never 'failed'.
 
-    Change the return value by hand to exercise the retry and give-up paths.
+    The manifest distinguishes "we would not" (blocked: no route, no
+    adapter, gate said no) from "they would not" (failed: the provider's
+    code). A merchant with a paused number must not read the word reserved
+    for "Meta said no". Terminal either way.
     """
-    provider_message_id = f"dummy-{uuid4().hex[:16]}"
-    # Address masked and variable values omitted — no PII in logs.
-    logger.info(
-        f"[dummy send] channel={message.channel} "
-        f"to=***{message.sent_to_address[-4:]} "
-        f"purpose={message.purpose_key} template={message.template_id} "
-        f"variables={sorted(message.variables)} "
-        f"merchant={message.merchant_id} message={message.id} "
-        f"-> {provider_message_id}"
+    return SendOutcome(status="blocked", reason=reason)
+
+
+def token_grants(token: SendToken, message: QueuedMessage) -> bool:
+    """Whether this token authorises THIS message.
+
+    The identity check is the point: a token granting some other message is
+    not a weaker grant, it is a bug — one grant reused across a batch would
+    authorise customers it never named. Checking it while the gate is still a
+    stub means the check is in place and tested before real grants arrive.
+    """
+    return (
+        token.granted
+        and token.message_id == message.id
+        and token.purpose_key == message.purpose_key
     )
-    return SendOutcome(status="accepted", provider_message_id=provider_message_id)
+
+
+async def resolve_send_route(
+    merchant_id: str, channel: str, binding_id: Optional[str] = None
+) -> Union[SendRoute, str]:
+    """Find the pipe, the account and the secrets — or the reason there is none.
+
+    Returns a SendRoute, or a refusal reason as a string. Not an exception:
+    "this merchant has not connected WhatsApp" is an ordinary answer that
+    belongs on the manifest row.
+
+    Order matters — the binding comes first because it is the merchant-scoped
+    anchor, and everything after is reached THROUGH it, so no lookup here can
+    wander into another tenant's rows.
+    """
+    # TODO(T23, #1038): once crm_template lands, look the template up here by
+    # (merchant_id, channel, name, language) and refuse with
+    # blocked/template_not_approved unless status='approved' — taking language
+    # from the registry instead of binding.capabilities.template_language
+    # (ADR 0011: a non-approved template is refused BEFORE the provider call).
+    # Owned by whichever of #1037/#1038 merges second.
+    binding = await accessor.get_binding(merchant_id, channel, binding_id)
+    if binding is None:
+        # Never connected, paused, retired, or another merchant's row: from
+        # the sender's side those are one fact, so they get one reason.
+        return REASON_NO_BINDING
+
+    installation = await accessor.get_installation(merchant_id, binding.installation_id)
+    if installation is None:
+        return REASON_NO_INSTALLATION
+    if installation.status not in SENDABLE_INSTALLATION_STATES:
+        logger.warning(
+            f"connectivity: installation {installation.id} is "
+            f"'{installation.status}' — no route for {merchant_id}/{channel}"
+        )
+        return REASON_INSTALLATION_UNHEALTHY
+
+    if not installation.credential_id:
+        return REASON_NO_CREDENTIAL
+    # The vault (`credentials`) belongs to app/database, so it is read through
+    # ITS accessor, never raw SQL from here (table-ownership law). mask=False:
+    # the adapter needs the real secret, not the API's ****. raise_errors=True:
+    # None must mean "row gone/dead" (terminal below) — a pool blip on this
+    # read has to raise and ride send()'s catch into a retryable send_error,
+    # like the same blip on any other read in this resolver.
+    credential = await get_credential_by_id(
+        installation.credential_id, mask=False, raise_errors=True
+    )
+    if credential is None or not credential.is_active or not credential.value:
+        # Vault row gone, deactivated, or it would not decrypt (an
+        # undecryptable value decodes as {}) — same thing to this message,
+        # and none of it is worth a retry.
+        return REASON_NO_CREDENTIAL
+    # Ownership cannot be compared HERE: the vault's scope column is
+    # reseller_id — one level above merchant (022) — and this module by law
+    # knows no reseller. The guard is the merchant-scoped installation fetch
+    # above; the onboarding sync that WRITES credential_id owns refusing a
+    # foreign reseller's bundle (NULL = global stays legal).
+    bundle = CredentialBundle(values=credential.value)
+
+    return SendRoute(installation=installation, binding=binding, bundle=bundle)
+
+
+async def _resolve_and_deliver(
+    adapter: ChannelAdapter, message: QueuedMessage
+) -> SendOutcome:
+    """The part of a send that must finish inside the claim lease.
+
+    Split out so ONE wait_for in send() covers the route's DB reads as well
+    as the provider call: a stalled pool outlives the lease exactly like a
+    hung provider — same reassigned row, same double send.
+    """
+    route = await resolve_send_route(
+        message.merchant_id, message.channel, message.binding_id
+    )
+    if not isinstance(route, SendRoute):
+        # No route, and the resolver said why. Its reason is the honest one.
+        logger.warning(f"connectivity: message {message.id} refused — {route}")
+        return _refused(route)
+
+    logger.info(
+        f"connectivity: sending {message.id} via {message.channel} "
+        f"to {mask_address(message.sent_to_address, message.channel)} "
+        f"from binding {route.binding.id}"
+    )
+    return await adapter.deliver(message, route.bundle, route.binding)
+
+
+async def send(send_token: SendToken, message: QueuedMessage) -> SendOutcome:
+    """Hand ``message`` to its channel's adapter, if everything permits it."""
+    if not token_grants(send_token, message):
+        logger.error(
+            f"connectivity: send token does not authorise message {message.id}"
+        )
+        return _refused(REASON_GATE_REFUSED)
+
+    adapter = adapter_for(message.channel)
+    if adapter is None:
+        # The registry IS the channel vocabulary, so a row naming a channel
+        # nothing serves cannot become sendable by waiting.
+        logger.error(
+            f"connectivity: no adapter for channel '{message.channel}' "
+            f"(message {message.id})"
+        )
+        return _refused(REASON_NO_ADAPTER)
+
+    try:
+        return await asyncio.wait_for(
+            _resolve_and_deliver(adapter, message),
+            timeout=CRM_MESSAGE_SEND_TIMEOUT_SECONDS,
+        )
+    except asyncio.TimeoutError:
+        # Retryable: "no answer" is not "no", the provider may have taken it.
+        # The timeout exists so a hung send cannot outlive the claim lease and
+        # hand the row to a second worker mid-send — the one double-send the
+        # dedupe key cannot prevent.
+        logger.warning(
+            f"connectivity: message {message.id} timed out after "
+            f"{CRM_MESSAGE_SEND_TIMEOUT_SECONDS}s"
+        )
+        return SendOutcome(status="failed", reason=REASON_TIMEOUT, retryable=True)
+    except Exception as e:
+        # The default case. Adapters classify their own failures, so anything
+        # landing here escaped classification — it becomes an outcome rather
+        # than a raise the caller must guess about, retryable for the same
+        # reason as the timeout: we cannot know whether the provider saw it.
+        logger.opt(exception=e).error(
+            f"connectivity: send raised for message {message.id}"
+        )
+        return SendOutcome(status="failed", reason=REASON_SEND_ERROR, retryable=True)

--- a/app/crm/shared/decode.py
+++ b/app/crm/shared/decode.py
@@ -1,0 +1,36 @@
+"""Row-decoding primitives every module's db/decoder.py needs.
+
+Both TOTAL: they answer for any input the driver can hand them and never
+raise. That is why they live here rather than being reimplemented per
+module — a decoder that raises on one malformed row strands the whole
+claimed batch, which is then reclaimed, decoded, and raises again forever.
+
+Imported directly (shared/ is exempt from the contracts-only rule).
+"""
+
+import json
+from typing import Any, Dict, Optional
+
+
+def jsonb_object(value: Any) -> Dict[str, Any]:
+    """A jsonb column as a dict. Anything else becomes an empty dict.
+
+    Plain jsonb accepts scalars and arrays too, so 42 and [1, 2] are legal
+    stored values. Non-objects are DROPPED, not converted: dict() would turn
+    [["a", 1]] into {"a": 1} and invent a template variable nobody wrote.
+
+    The driver returns jsonb as a string today; the non-string branch covers
+    a codec being registered later.
+    """
+    if isinstance(value, str):
+        try:
+            value = json.loads(value)
+        except (TypeError, ValueError):
+            return {}
+    return dict(value) if isinstance(value, dict) else {}
+
+
+def uuid_or_none(value: Any) -> Optional[str]:
+    """A uuid column as a string, preserving NULL as None — asyncpg hands
+    back UUID objects, schemas type these as Optional[str]."""
+    return str(value) if value is not None else None

--- a/app/crm/shared/redact.py
+++ b/app/crm/shared/redact.py
@@ -1,0 +1,55 @@
+"""How a customer's contact details may appear in a log — defined ONCE.
+
+The mirror of normalize.py: that file fixes the form a handle is STORED in,
+this one the form it may be WRITTEN OUT in. One module logging a full phone
+number undoes the discipline of every module that doesn't.
+
+Imported directly (shared/ is exempt from the contracts-only rule).
+"""
+
+import re
+
+FULL_MASK = "****"
+
+# 7 digits = E.164's floor, so shorter runs (error codes, dates, counts)
+# survive — a log stripped of every number stops being useful.
+_LONG_DIGIT_RUN = re.compile(r"\d{7,}")
+
+
+def _mask_phone(phone: str) -> str:
+    """Last four digits of the national number, everything else starred.
+
+    Self-contained on purpose: the previous import came from a legacy
+    queries file, which is not a home this module may depend on. The
+    rendering matches the voice path's mask_phone exactly (digits only,
+    last 10 kept, ≤4 digits fully masked) so one number reads the same
+    in every log.
+    """
+    digits = re.sub(r"\D", "", phone or "")[-10:]
+    if len(digits) <= 4:
+        return FULL_MASK
+    return "*" * (len(digits) - 4) + digits[-4:]
+
+
+def mask_digit_runs(text: str) -> str:
+    """Mask any digit run long enough to be a contact number.
+
+    For text WE did not write — a provider's error message may echo back the
+    value it rejected ("Invalid parameter: to=9198…"). mask_address covers
+    what we log on purpose; this covers what somebody else smuggles in.
+    """
+    return _LONG_DIGIT_RUN.sub(FULL_MASK, text or "")
+
+
+def mask_address(address: str, channel: str) -> str:
+    """``address`` as it may appear in a log, masked by ``channel``'s rule.
+
+    The channel picks the rule, never the value's shape: sniffing would make
+    the mask depend on the data being well-formed, which is exactly when
+    masking matters most. A channel with no branch masks EVERYTHING — new
+    channels opt in to revealing anything. Total: empty input masks rather
+    than raising, because a log line is never worth an exception.
+    """
+    if channel == "whatsapp":
+        return _mask_phone(address or "")
+    return FULL_MASK

--- a/app/crm/worker_main.py
+++ b/app/crm/worker_main.py
@@ -6,6 +6,7 @@ import asyncio
 from typing import Any, Callable, Coroutine, Dict, Optional
 
 from app.core.config.static import (
+    CRM_DISPATCH_BATCH,
     CRM_WORKER_BATCH,
     CRM_WORKER_INTERVAL,
     POSTGRES_MAX_OVERFLOW,
@@ -29,7 +30,10 @@ ROLES: Dict[str, Callable[[asyncio.Event], Coroutine[Any, Any, None]]] = {
         claim_sends,
         dispatch_send,
         interval=CRM_WORKER_INTERVAL,
-        batch=CRM_WORKER_BATCH,
+        # Its own dial, not CRM_WORKER_BATCH: a claimed batch must finish
+        # inside the claim lease (batch × send timeout < lease), or another
+        # pod's sweep re-sends the unworked tail — a real duplicate message.
+        batch=CRM_DISPATCH_BATCH,
         stop_event=stop_event,
         name="dispatcher",
     ),

--- a/app/database/accessor/__init__.py
+++ b/app/database/accessor/__init__.py
@@ -22,6 +22,7 @@ from .breeze_buddy.call_execution_config import (
     update_call_execution_config,
 )
 from .breeze_buddy.credentials import (
+    CredentialInUseError,
     create_credential,
     delete_credential,
     get_all_credentials,
@@ -131,4 +132,5 @@ __all__ = [
     "get_credentials_as_template_vars",
     "update_credential",
     "delete_credential",
+    "CredentialInUseError",
 ]

--- a/app/database/accessor/breeze_buddy/credentials.py
+++ b/app/database/accessor/breeze_buddy/credentials.py
@@ -5,6 +5,8 @@ Database accessor functions for the credentials table.
 from typing import Any, Dict, List, Optional
 from uuid import uuid4
 
+import asyncpg
+
 from app.core.logger import logger
 from app.database.decoder.breeze_buddy.credentials import (
     CREDENTIAL_MASK,
@@ -23,6 +25,12 @@ from app.database.queries.breeze_buddy.credentials import (
 )
 from app.schemas import Credential, CredentialType
 from app.services.encryption import encrypt_credential
+
+
+class CredentialInUseError(Exception):
+    """RESTRICT refused the DELETE: a connector installation still holds
+    this bundle. The domain word for the FK violation, so callers can
+    answer 409 without knowing which driver said no."""
 
 
 def _merge_credential_value(
@@ -134,14 +142,22 @@ async def create_credential(
 async def get_credential_by_id(
     credential_id: str,
     mask: bool = True,
+    raise_errors: bool = False,
 ) -> Optional[Credential]:
-    """Get a credential by ID."""
+    """Get a credential by ID.
+
+    With raise_errors=True, a query failure re-raises instead of folding into
+    None — for callers that treat None as terminal ("row gone") and must not
+    read a transient outage as that. None still means "no such row" either way.
+    """
     try:
         query_text, values = get_credential_by_id_query(credential_id)
         result = await run_parameterized_query(query_text, values)
         return decode_single_credential(result, mask=mask)
     except Exception as e:
         logger.error(f"Error getting credential by ID: {e}")
+        if raise_errors:
+            raise
         return None
 
 
@@ -258,20 +274,34 @@ async def update_credential(
 
 
 async def delete_credential(credential_id: str) -> bool:
-    """Delete a credential by ID."""
-    logger.info(f"Deleting credential {credential_id}")
+    """Delete a credential by ID. False means only "no row matched".
+
+    Errors re-raise rather than fold into False, so the handler can answer
+    honestly: a connector installation still holding the bundle raises
+    CredentialInUseError (the handler's 409), anything else re-raises as
+    itself (the handler's 500) — never a 404 for a row that still exists.
+    The driver's exception is translated HERE, at the accessor boundary,
+    so no layer above needs to import asyncpg.
+    """
+    # bind() rather than interpolation: credential_id lands as a structured
+    # field a log search can filter on.
+    log = logger.bind(credential_id=credential_id)
+    log.info("Deleting credential")
 
     try:
         query_text, values = delete_credential_query(credential_id)
         result = await run_parameterized_query(query_text, values)
 
         if result and len(result) > 0:
-            logger.info(f"Credential {credential_id} deleted successfully")
+            log.info("Credential deleted successfully")
             return True
 
-        logger.warning(f"Credential {credential_id} not found for deletion")
+        log.warning("Credential not found for deletion")
         return False
 
+    except asyncpg.ForeignKeyViolationError as exc:
+        log.warning("Credential is still in use and was not deleted")
+        raise CredentialInUseError(credential_id) from exc
     except Exception as e:
-        logger.error(f"Error deleting credential {credential_id}: {e}")
-        return False
+        log.opt(exception=e).error("Error deleting credential")
+        raise

--- a/app/database/migrations/060_create_crm_connector_tables.sql
+++ b/app/database/migrations/060_create_crm_connector_tables.sql
@@ -1,0 +1,243 @@
+-- 060: the connector layer — crm_connector_installation + crm_channel_binding.
+--
+-- Two tables in one migration because they are meaningless apart: a binding
+-- carries a foreign key into an installation, and an installation with no
+-- binding is an account nothing can send from. Splitting them would only
+-- create a numbered window in which the schema is half-built.
+--
+--   crm_connector_installation   the DOOR — a merchant's account on one
+--                                connector (a WhatsApp Business Account).
+--   crm_channel_binding          the PIPE — one real endpoint under that
+--                                account (a phone number, a sender id, a
+--                                from-address).
+--
+-- A message resolves pipe -> door -> secret, in that order, and every step is
+-- merchant-scoped so no lookup can wander into another tenant's rows.
+--
+-- Deliberate choices, each with the reason it beat the obvious alternative:
+--
+-- 1. No CHECK on connector_key or on channel. Those columns are vocabulary,
+--    and the migration-027 scar says vocabulary lives in code: a CHECK is
+--    exactly what once made adding a channel a migration instead of a deploy.
+--    The adapter registry (app/crm/connectivity/providers/__init__.py) is the
+--    one place the list is enforced, and adding email means adding a file
+--    there — no schema change at all.
+--
+-- 2. status IS a CHECK on both tables, and that is not a contradiction.
+--    connector_key names WHICH provider (open set, grows with the product);
+--    status names WHERE IN ITS LIFECYCLE a row is (closed set, changes only
+--    when the lifecycle itself changes). Same split as crm_message.status.
+--
+-- 3. No 'expired' status. Expiry is a predicate — token_expires_at < now() —
+--    and a stored copy of a predicate is a lie waiting to happen: it is
+--    correct only until the clock passes it and something remembers to run.
+--    NULL means the token does not expire (some providers issue permanent
+--    ones); Meta system-user tokens run ~60 days, so a refresh job later
+--    watches the non-NULL rows.
+--
+-- 4. credential_id is a real foreign key, ON DELETE RESTRICT. The vault is a
+--    legacy table and pointing at it couples us to its shape, which is a cost
+--    worth paying: without the constraint, deleting a credential through the
+--    existing credentials API silently breaks every send for that merchant,
+--    and the only symptom is messages failing with "credential missing" long
+--    after the delete. RESTRICT turns that into an immediate, explicit
+--    refusal at the moment somebody tries.
+--
+--    RESTRICT and never CASCADE: deleting a secret must not quietly delete
+--    the record that a merchant ever connected. Disconnecting is a status
+--    change ('revoked'), not a DELETE — history is the point of this table.
+--
+--    Nullable, so an installation may exist before its bundle does (a
+--    half-finished onboarding is 'connecting' with no credential yet); NULL
+--    is exempt from the constraint, and send() refuses such a row anyway.
+--
+-- 5. health_detail and capabilities are jsonb blobs rather than columns. The
+--    health probe ladder (configured -> authenticated -> subscribed ->
+--    heartbeat -> healthy) will grow reasons we cannot name yet, and read
+--    receipts / session windows / throughput budgets differ per channel and
+--    per provider tier. Code asks the blob instead of hardcoding "WhatsApp
+--    has read receipts" — which is how the second channel stays cheap.
+--    INTERIM: template language rides capabilities.template_language until
+--    T23's template registry lands; then the registry decides per template.
+--
+-- 6. No format CHECK on `address`. It means whatever its channel says it
+--    means: a Meta phone_number_id here, a sender id or a from-address
+--    elsewhere. Any check would have to branch on channel and so re-introduce
+--    the vocabulary this table refuses to store. Same reasoning as
+--    crm_message.sent_to_address; writers normalise instead.
+--
+-- 7. EVERY index below is a UNIQUE one — a correctness rule, not a read
+--    optimisation. These tables are configuration: one row per merchant per
+--    account, one per endpoint, so tens of thousands of rows at the very top
+--    end. At that size a sequential scan is sub-millisecond, and a plain index
+--    would only add write cost and a page to keep warm for a scan Postgres was
+--    never going to struggle with.
+--
+--    Three candidates were considered and dropped on purpose, so nobody has to
+--    rediscover the reasoning:
+--      · (merchant_id, connector_key) — a PREFIX of the account unique index,
+--        which already serves it. Redundant at any table size.
+--      · (credential_id) — the FK's referencing side. Postgres scans here on
+--        every credentials DELETE, but that is a rare admin action against a
+--        tiny table.
+--      · (token_expires_at) — for a refresh job that does not exist yet. An
+--        index ships with the query that needs it, never before.
+--    If one of these tables ever stops being configuration-sized, add the
+--    index THEN, with the plan that proves it.
+
+-- ---------------------------------------------------------------------------
+-- The door
+-- ---------------------------------------------------------------------------
+
+CREATE TABLE crm_connector_installation (
+    id                  uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    merchant_id         text NOT NULL,
+    -- Which provider this account is on: whatsapp, sms, instagram, email…
+    -- Validated by the adapter registry, never by this table (see 1).
+    connector_key       text NOT NULL,
+    -- The provider's own id for the account — a WhatsApp Business Account id
+    -- today. Composite-unique with merchant so one merchant can hold two
+    -- accounts on the same connector (two shops, two WABAs).
+    external_account_id text NOT NULL,
+    -- What the merchant calls it in the console. Cosmetic, never matched on.
+    display_label       text,
+    -- Where the secret bundle lives, not the secret (see 4). One vault row
+    -- holds a whole bundle, so rotation is a new row plus a pointer flip
+    -- here — reversible in one statement. RESTRICT: a credential in use by a
+    -- live connection cannot be deleted out from under it.
+    credential_id       uuid REFERENCES credentials (id) ON DELETE RESTRICT,
+    status              text NOT NULL DEFAULT 'connecting'
+                        CHECK (status IN ('connecting', 'healthy', 'degraded',
+                                          'revoked', 'disabled')),
+    -- NULL means permanent (see 3).
+    token_expires_at    timestamptz,
+    -- Stamped by arriving provider events. Catches the failure mode a token
+    -- check cannot see: credentials still valid, webhook subscription quietly
+    -- dropped, and nothing inbound for days.
+    last_event_at       timestamptz,
+    health_detail       jsonb NOT NULL DEFAULT '{}'::jsonb,
+    installed_at        timestamptz NOT NULL DEFAULT now(),
+    created_at          timestamptz NOT NULL DEFAULT now(),
+    updated_at          timestamptz NOT NULL DEFAULT now()
+);
+
+-- One installation per merchant per provider account. merchant_id leads, as
+-- every unique index on a crm_ table must: the ids after it are only unique
+-- inside a tenant.
+--
+-- It also serves the send path's lookup (merchant_id, connector_key), which is
+-- a prefix of these columns — so a separate index on that pair would be pure
+-- write cost for a scan Postgres can already do here.
+CREATE UNIQUE INDEX crm_connector_installation_account_uq
+    ON crm_connector_installation (merchant_id, connector_key, external_account_id);
+
+-- Not a read path: this exists so crm_channel_binding can carry a COMPOSITE
+-- foreign key and be structurally unable to point at another tenant's
+-- installation. Postgres requires a unique index to reference. It happens to
+-- serve the "this merchant's installation by id" fetch too.
+CREATE UNIQUE INDEX crm_connector_installation_merchant_id_uq
+    ON crm_connector_installation (merchant_id, id);
+
+CREATE TRIGGER crm_connector_installation_touch
+    BEFORE UPDATE ON crm_connector_installation
+    FOR EACH ROW EXECUTE FUNCTION crm_touch_updated_at();
+
+-- ---------------------------------------------------------------------------
+-- The pipe
+-- ---------------------------------------------------------------------------
+--
+-- Two more choices that belong to this table alone:
+--
+-- 8. 'paused' fails sends CLOSED. A paused pipe is not a slow pipe: the
+--    resolver refuses rather than picking another route, because silently
+--    sending from a different number is worse than not sending.
+--
+-- 9. 'retired' rows are NEVER deleted. crm_message.binding_id points here,
+--    and "which number did this August send leave on" must stay answerable
+--    long after a provider recycles that number to somebody else.
+
+CREATE TABLE crm_channel_binding (
+    id              uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    merchant_id     text NOT NULL,
+    -- whatsapp, sms, email, instagram… validated in code (see 1).
+    channel         text NOT NULL,
+    installation_id uuid NOT NULL,
+    -- The provider's identifier for this endpoint (see 6).
+    address         text NOT NULL,
+    capabilities    jsonb NOT NULL DEFAULT '{}'::jsonb,
+    -- Which pipe an unrouted message takes. Partial-unique below, so a
+    -- merchant can never have two primaries on one channel.
+    is_primary      boolean NOT NULL DEFAULT false,
+    status          text NOT NULL DEFAULT 'active'
+                    CHECK (status IN ('active', 'paused', 'retired')),
+    created_at      timestamptz NOT NULL DEFAULT now(),
+    updated_at      timestamptz NOT NULL DEFAULT now(),
+    -- Composite, so a binding is structurally unable to hang off another
+    -- tenant's installation. A plain installation_id reference would accept
+    -- any uuid, and the merchant scope would rest on the writer being right.
+    FOREIGN KEY (merchant_id, installation_id)
+        REFERENCES crm_connector_installation (merchant_id, id)
+);
+
+-- One row per real endpoint per merchant.
+CREATE UNIQUE INDEX crm_channel_binding_merchant_address_uq
+    ON crm_channel_binding (merchant_id, channel, address);
+
+-- Exactly one default pipe per channel. Partial, so the non-primary rows are
+-- unconstrained — a merchant may hold many numbers, but only one answers
+-- "send this WhatsApp message" when nothing named a route.
+CREATE UNIQUE INDEX crm_channel_binding_primary_uq
+    ON crm_channel_binding (merchant_id, channel)
+    WHERE is_primary;
+
+-- One live endpoint belongs to ONE merchant, platform-wide.
+--
+-- The SECOND deliberate exception to "merchant_id first in every unique
+-- index", and it earns it the same way crm_message_provider_id_uq does: that
+-- law protects OUR identifiers, which are unique only inside a tenant. An
+-- address is the PROVIDER's identifier. Inbound routing works backwards
+-- through this index — a delivery receipt or a customer reply names only the
+-- receiving number, and that number is how we learn whose message it was — so
+-- two merchants registering one number would make the sender unknowable.
+--
+-- Scoped to non-retired rows on purpose: providers recycle numbers, and a
+-- retired row must be able to coexist with the same address live under
+-- whoever holds it now (see 9).
+CREATE UNIQUE INDEX crm_channel_binding_address_uq
+    ON crm_channel_binding (channel, address)
+    WHERE status <> 'retired';
+
+CREATE TRIGGER crm_channel_binding_touch
+    BEFORE UPDATE ON crm_channel_binding
+    FOR EACH ROW EXECUTE FUNCTION crm_touch_updated_at();
+
+-- ---------------------------------------------------------------------------
+-- crm_message trigger amendment — rides this migration because merged
+-- migrations are never edited (056 shipped with #1031).
+--
+-- binding_id becomes SET-ONCE: NULL until a route is picked, stamped when
+-- the message leaves, never rewritten after — a rewrite would forge which
+-- endpoint a message left on, while full immutability would forbid the
+-- stamp itself (T16 col 6). Everything else is unchanged from 056.
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION crm_message_immutable() RETURNS trigger AS $$
+BEGIN
+    IF NEW.id              IS DISTINCT FROM OLD.id
+       OR NEW.merchant_id     IS DISTINCT FROM OLD.merchant_id
+       OR NEW.customer_id     IS DISTINCT FROM OLD.customer_id
+       OR NEW.sent_to_address IS DISTINCT FROM OLD.sent_to_address
+       OR NEW.channel         IS DISTINCT FROM OLD.channel
+       OR (OLD.binding_id IS NOT NULL
+           AND NEW.binding_id IS DISTINCT FROM OLD.binding_id)
+       OR NEW.source_kind     IS DISTINCT FROM OLD.source_kind
+       OR NEW.source_id       IS DISTINCT FROM OLD.source_id
+       OR NEW.purpose_key     IS DISTINCT FROM OLD.purpose_key
+       OR NEW.template_id     IS DISTINCT FROM OLD.template_id
+       OR NEW.variables       IS DISTINCT FROM OLD.variables
+       OR NEW.dedupe_key      IS DISTINCT FROM OLD.dedupe_key
+       OR NEW.created_at      IS DISTINCT FROM OLD.created_at THEN
+        RAISE EXCEPTION 'crm_message: these fields are immutable and one of them changed — id, merchant_id, customer_id, sent_to_address, channel, source_kind, source_id, purpose_key, template_id, variables, dedupe_key, created_at (and binding_id may be set once, never changed)';
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;

--- a/scripts/check_crm_boundaries.py
+++ b/scripts/check_crm_boundaries.py
@@ -29,6 +29,9 @@ PR time — earlier than a grant would fail:
   10. HANDLES STAY DOWN — connection()/crm_connection never appears in
      logic; accessors self-scope single statements and batch loops. A
      logic file touches a handle ONLY as an _in_txn body's txn param.
+  11. ADAPTER CONFINEMENT — app.crm.connectivity.providers is imported
+     only by app/crm/connectivity/send.py and inside providers/ itself;
+     any other import reaches a provider around the send() door's checks.
 
 New table? Add it to TABLE_OWNERS with its owning module. New violation
 class? This script is the place — the boundary is code, so the check is
@@ -52,6 +55,8 @@ TABLE_OWNERS = {
     "crm_message": "connectivity",
     "crm_workflow": "outreach",
     "crm_workflow_enrollment": "outreach",
+    "crm_connector_installation": "connectivity",
+    "crm_channel_binding": "connectivity",
 }
 
 # Pre-existing legacy inversions, allowlisted and CLOSED to additions
@@ -86,6 +91,7 @@ def crm_module_of(rp: str) -> str | None:
 
 
 def check(root: Path = ROOT) -> list[str]:
+    """Scan the tree and return every boundary violation as a message."""
     errors: list[str] = []
     py_files = [
         p
@@ -166,6 +172,15 @@ def check(root: Path = ROOT) -> list[str]:
                         f"{rp}: the data layer imports neither app.ai nor "
                         f"app.crm ({target}) — use the hook-registry pattern"
                     )
+            # 11. adapter confinement — providers/ sits behind the send() door
+            if target.startswith("app.crm.connectivity.providers"):
+                if rp != "app/crm/connectivity/send.py" and not rp.startswith(
+                    "app/crm/connectivity/providers/"
+                ):
+                    errors.append(
+                        f"{rp}: adapter import outside send.py ({target}) — "
+                        f"providers/ is reached only through the send() door"
+                    )
 
         # 7-9. the atomic grammar
         if in_crm and not is_shared_db:
@@ -214,12 +229,16 @@ def check(root: Path = ROOT) -> list[str]:
 
 
 def main() -> int:
+    """CLI entry: print violations and exit nonzero when any exist."""
     errors = check()
     for error in errors:
         print(f"error: {error}", file=sys.stderr)
     if errors:
         return 1
-    print("OK: crm boundaries clean (ownership, SQL, driver, imports, handles).")
+    print(
+        "OK: crm boundaries clean "
+        "(ownership, SQL, driver, imports, handles, adapters)."
+    )
     return 0
 
 

--- a/tests/breeze_buddy/test_credentials_delete.py
+++ b/tests/breeze_buddy/test_credentials_delete.py
@@ -1,0 +1,88 @@
+"""delete_credential: three outcomes, three honest answers.
+
+The bool can carry exactly one fact — "the DELETE ran and matched no row",
+which the handler reports as 404. The other two outcomes must leave by their
+own doors: in-use raises CredentialInUseError (the handler's 409), and an
+infrastructure error re-raises (the handler's 500). Folding the last one into
+False reported a DB outage as "not found" for a credential the same handler
+had fetched two lines earlier.
+"""
+
+import asyncpg
+import pytest
+
+from app.database.accessor.breeze_buddy import credentials as credentials_module
+from app.database.accessor.breeze_buddy.credentials import (
+    CredentialInUseError,
+    delete_credential,
+)
+
+
+def _query_runs(monkeypatch, runner) -> None:
+    """Patch the accessor's query runner with a stand-in."""
+    monkeypatch.setattr(credentials_module, "run_parameterized_query", runner)
+
+
+async def test_a_deleted_row_returns_true(monkeypatch) -> None:
+    """A deleted row returns true."""
+
+    async def runner(query, values):
+        """Test double: stands in for run_parameterized_query."""
+        return [{"id": "cred-1"}]
+
+    _query_runs(monkeypatch, runner)
+    assert await delete_credential("cred-1") is True
+
+
+async def test_false_means_only_that_no_row_matched(monkeypatch) -> None:
+    """False means only that no row matched."""
+
+    async def runner(query, values):
+        """Test double: stands in for run_parameterized_query."""
+        return []
+
+    _query_runs(monkeypatch, runner)
+    assert await delete_credential("cred-1") is False
+
+
+async def test_in_use_raises_the_domain_error_for_the_handlers_409(
+    monkeypatch,
+) -> None:
+    """In use raises the domain error for the handlers 409.
+
+    RESTRICT refused the DELETE: the row exists and is wired to a connector
+    installation. "Not found" would send the operator after the wrong
+    problem, so this must not travel through the bool — and it leaves as
+    CredentialInUseError, not the driver's class: the accessor boundary is
+    where asyncpg is translated, so the handler answers 409 without
+    importing the driver.
+    """
+
+    async def runner(query, values):
+        """Test double: stands in for run_parameterized_query."""
+        raise asyncpg.ForeignKeyViolationError("violates foreign key constraint")
+
+    _query_runs(monkeypatch, runner)
+    with pytest.raises(CredentialInUseError) as excinfo:
+        await delete_credential("cred-1")
+    # The driver's detail is chained, not discarded — a 409 investigation
+    # can still see which constraint refused.
+    assert isinstance(excinfo.value.__cause__, asyncpg.ForeignKeyViolationError)
+
+
+async def test_an_infrastructure_error_is_not_reported_as_not_found(
+    monkeypatch,
+) -> None:
+    """An infrastructure error is not reported as not found."""
+
+    # The half-fixed case the review caught: the FK path re-raised, but a
+    # pool timeout still returned False — which the handler translated into
+    # 404 for a credential that plainly existed. An outage must surface as
+    # an incident, not as a phantom deletion.
+    async def runner(query, values):
+        """Test double: stands in for run_parameterized_query."""
+        raise ConnectionError("pool down")
+
+    _query_runs(monkeypatch, runner)
+    with pytest.raises(ConnectionError):
+        await delete_credential("cred-1")

--- a/tests/crm/test_check_boundaries.py
+++ b/tests/crm/test_check_boundaries.py
@@ -152,3 +152,30 @@ def test_connection_handle_in_logic_fails(tmp_path: Path) -> None:
         },
     )
     assert any("connection handle in logic" in e for e in check(root))
+
+
+def test_adapter_import_outside_send_fails(tmp_path: Path) -> None:
+    root = _tree(
+        tmp_path,
+        {
+            "app/crm/connectivity/dispatch.py": (
+                "from app.crm.connectivity.providers import adapter_for\n"
+            )
+        },
+    )
+    assert any("adapter import outside send.py" in e for e in check(root))
+
+
+def test_send_and_providers_themselves_may_import_adapters(tmp_path: Path) -> None:
+    root = _tree(
+        tmp_path,
+        {
+            "app/crm/connectivity/send.py": (
+                "from app.crm.connectivity.providers import adapter_for\n"
+            ),
+            "app/crm/connectivity/providers/whatsapp.py": (
+                "from app.crm.connectivity.providers.base import ChannelAdapter\n"
+            ),
+        },
+    )
+    assert check(root) == []

--- a/tests/crm/test_connectivity_adapters.py
+++ b/tests/crm/test_connectivity_adapters.py
@@ -1,0 +1,745 @@
+"""The send door: the token, the registry, the route, and the timeout.
+
+Every test here is about a refusal. That is deliberate — the accepted path is
+one line, and everything that makes this seam worth having is what it declines
+to do when something is missing.
+"""
+
+import asyncio
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from app.crm.connectivity import send as send_module
+from app.crm.connectivity.db.queries import (
+    binding_by_id_query,
+    primary_binding_query,
+)
+from app.crm.connectivity.providers import ADAPTERS, adapter_for
+from app.crm.connectivity.providers.base import ChannelAdapter
+from app.crm.connectivity.providers.whatsapp import MetaWhatsAppAdapter
+from app.crm.connectivity.schemas import (
+    ChannelBinding,
+    ConnectorInstallation,
+    CredentialBundle,
+    QueuedMessage,
+    SendOutcome,
+    SendRoute,
+    SendToken,
+)
+from app.crm.connectivity.send import (
+    REASON_GATE_REFUSED,
+    REASON_INSTALLATION_UNHEALTHY,
+    REASON_NO_ADAPTER,
+    REASON_NO_BINDING,
+    REASON_NO_CREDENTIAL,
+    REASON_NO_INSTALLATION,
+    REASON_SEND_ERROR,
+    REASON_TIMEOUT,
+    resolve_send_route,
+    send,
+    token_grants,
+)
+from app.crm.shared.redact import mask_address, mask_digit_runs
+from app.schemas import Credential, CredentialType
+from scripts.check_crm_boundaries import TABLE_OWNERS
+
+# One file: the door and the pipe are meaningless apart, so they are created
+# together rather than leaving a numbered window with half a schema.
+CONNECTOR_MIGRATION = Path(
+    "app/database/migrations/060_create_crm_connector_tables.sql"
+)
+
+
+def _ddl(path: Path = CONNECTOR_MIGRATION) -> str:
+    """The migration with comment prose stripped: a structural assertion that
+    passes on the paragraph explaining an absence proves nothing."""
+    return "\n".join(
+        line
+        for line in path.read_text().splitlines()
+        if not line.lstrip().startswith("--")
+    )
+
+
+def _table_ddl(table: str) -> str:
+    """Just one table's slice of the shared migration.
+
+    Without this, an assertion meant for the binding would pass on the
+    installation's DDL sitting in the same file — which is the one thing
+    merging two tables into one migration could quietly cost us.
+    """
+    body = _ddl()
+    start = body.index(f"CREATE TABLE {table} (")
+    nxt = body.find("CREATE TABLE ", start + 1)
+    return body[start:] if nxt == -1 else body[start:nxt]
+
+
+def _message(**overrides) -> QueuedMessage:
+    """A queued message for tests; keyword overrides replace any field."""
+    fields = dict(
+        id="m-1",
+        merchant_id="shop",
+        customer_id="c-1",
+        channel="whatsapp",
+        sent_to_address="+919876543210",
+        source_kind="transactional",
+        purpose_key="order_update",
+        template_id="order_update_v1",
+        variables={"1": "Priya"},
+        dedupe_key="evt-1",
+        attempt=1,
+        next_attempt_at=datetime.now(timezone.utc),
+    )
+    fields.update(overrides)
+    return QueuedMessage(**fields)
+
+
+def _token(message: QueuedMessage) -> SendToken:
+    """A granted send token naming exactly this message."""
+    return SendToken(
+        message_id=message.id, purpose_key=message.purpose_key, granted=True
+    )
+
+
+def _binding(**overrides) -> ChannelBinding:
+    """An active channel binding for tests; overrides replace any field."""
+    fields = dict(
+        id="b-1",
+        merchant_id="shop",
+        channel="whatsapp",
+        installation_id="i-1",
+        address="1234567890",
+        capabilities={},
+        is_primary=True,
+        status="active",
+    )
+    fields.update(overrides)
+    return ChannelBinding(**fields)
+
+
+def _installation(**overrides) -> ConnectorInstallation:
+    """A healthy connector installation for tests."""
+    fields = dict(
+        id="i-1",
+        merchant_id="shop",
+        connector_key="whatsapp",
+        external_account_id="waba-1",
+        credential_id="cred-1",
+        status="healthy",
+    )
+    fields.update(overrides)
+    return ConnectorInstallation(**fields)
+
+
+def _credential(**overrides) -> Credential:
+    """A live vault row as get_credential_by_id(mask=False) returns it."""
+    fields = dict(
+        id="cred-1",
+        reseller_id=None,
+        name="wa-bundle",
+        credential_type=CredentialType.CUSTOM,
+        value={"system_user_token": "tok"},
+        is_active=True,
+    )
+    fields.update(overrides)
+    return Credential(**fields)
+
+
+def _patch_credential(monkeypatch, credential) -> None:
+    """Route resolution's vault read, without a database."""
+
+    async def _get(credential_id, mask=True, raise_errors=False):
+        """Test double: the seeded vault credential."""
+        # Pinned: the adapter needs the real secret, never the API's mask —
+        # and the send path must ask for errors raised, or an outage on this
+        # one read folds into None and terminally blocks the message.
+        assert mask is False
+        assert raise_errors is True
+        return credential
+
+    monkeypatch.setattr(send_module, "get_credential_by_id", _get)
+
+
+def _route(**overrides) -> SendRoute:
+    """A fully resolved SendRoute for tests."""
+    fields = dict(
+        installation=_installation(),
+        binding=_binding(),
+        bundle=CredentialBundle(values={"system_user_token": "tok"}),
+    )
+    fields.update(overrides)
+    return SendRoute(**fields)
+
+
+class _FakeAccessor:
+    """Stands in for db/accessor so the door is testable without a database —
+    which is the whole reason routes are resolved in one place."""
+
+    def __init__(self, binding=None, installation=None):
+        """Test double."""
+        self._binding = binding
+        self._installation = installation
+        self.writes: list = []
+
+    async def get_binding(self, merchant_id, channel, binding_id):
+        """Test double: the seeded binding, or a hang/None per scenario."""
+        return self._binding
+
+    async def get_installation(self, merchant_id, installation_id):
+        """Test double: the seeded installation."""
+        return self._installation
+
+    def __getattr__(self, name):
+        """Anything beyond the reads above is recorded, not raised.
+
+        Only reached when normal lookup fails, so the reads keep working. This
+        turns "the send path called something else" into a readable assertion
+        about WHAT it called, rather than an AttributeError that a reader has
+        to decode.
+        """
+
+        async def _record(*args, **kwargs):
+            """Record any non-read accessor call as a write."""
+            self.writes.append(name)
+            return True
+
+        return _record
+
+
+@pytest.fixture
+def happy_accessor(monkeypatch) -> _FakeAccessor:
+    """Test double."""
+    fake = _FakeAccessor(binding=_binding(), installation=_installation())
+    monkeypatch.setattr(send_module, "accessor", fake)
+    _patch_credential(monkeypatch, _credential())
+    return fake
+
+
+# --- the registry is the channel vocabulary ---------------------------------
+
+
+def test_every_registered_adapter_answers_to_its_own_key() -> None:
+    """Every registered adapter answers to its own key."""
+    # The registry key and the adapter's channel must agree, or send() would
+    # look up "whatsapp" and hand the message to something else entirely.
+    for key, adapter in ADAPTERS.items():
+        assert adapter.channel == key
+        assert isinstance(adapter, ChannelAdapter)
+
+
+def test_whatsapp_is_the_only_shipped_channel() -> None:
+    """Whatsapp is the only shipped channel."""
+    # Not a tautology: it fails the day someone registers a half-built
+    # adapter, which is exactly when a review should notice. It also pins the
+    # decision that there is no stand-in adapter — local runs point the Graph
+    # base URL at a stub and exercise the real one.
+    assert set(ADAPTERS) == {"whatsapp"}
+    assert isinstance(adapter_for("whatsapp"), MetaWhatsAppAdapter)
+
+
+def test_an_unknown_channel_returns_none_rather_than_raising() -> None:
+    """An unknown channel returns none rather than raising."""
+    # The caller must be able to record a terminal reason on the row; an
+    # exception here would take the whole worker pass instead.
+    assert adapter_for("sms") is None
+    assert adapter_for("") is None
+
+
+def test_masking_is_channel_keyed_and_reveals_the_last_four_at_most() -> None:
+    """Masking is channel keyed and reveals the last four at most."""
+    # The channel picks the rule — an address is only maskable by knowing
+    # what kind of thing it is. WhatsApp uses the pre-existing mask_phone,
+    # so these are the exact renderings connectivity's log lines carry.
+    assert mask_address("+919876543210", "whatsapp") == "******3210"
+    assert mask_address("", "whatsapp") == "****"
+    # A short value is fully masked, never revealed whole behind a prefix.
+    assert mask_address("12", "whatsapp") == "****"
+    assert mask_address("9198", "whatsapp") == "****"
+
+
+def test_a_channel_without_a_masking_rule_reveals_nothing() -> None:
+    """A channel without a masking rule reveals nothing."""
+    # Fail closed: a new channel must opt in to showing ANY part of its
+    # addresses. Revealing by default would leak until somebody remembered
+    # redact.py exists.
+    assert mask_address("+919876543210", "carrier_pigeon") == "****"
+    assert mask_address("someone@example.com", "email") == "****"
+
+
+def test_digit_runs_long_enough_to_be_a_number_are_masked() -> None:
+    """Digit runs long enough to be a number are masked."""
+    # For text WE did not write: a provider's error message may echo the
+    # value it rejected. Short runs — error codes, dates, counts — survive,
+    # because a log stripped of every number stops being useful.
+    assert (
+        mask_digit_runs("Invalid parameter: to=919812345670")
+        == "Invalid parameter: to=****"
+    )
+    assert mask_digit_runs("(#131049) rate limit hit") == "(#131049) rate limit hit"
+    assert mask_digit_runs("") == ""
+
+
+# --- the token: a grant names one message -----------------------------------
+
+
+def test_a_token_for_another_message_grants_nothing() -> None:
+    """A token for another message grants nothing."""
+    # The failure this prevents: one grant reused across a claimed batch,
+    # authorising customers it never named.
+    message = _message()
+    assert token_grants(_token(message), message) is True
+    assert token_grants(_token(message), _message(id="m-2")) is False
+
+
+def test_a_token_for_another_purpose_grants_nothing() -> None:
+    """A token for another purpose grants nothing."""
+    # Consent is granted per purpose, so a marketing send may not ride an
+    # order-update grant.
+    message = _message()
+    assert token_grants(_token(message), _message(purpose_key="promotions")) is False
+
+
+def test_an_ungranted_token_is_refused() -> None:
+    """An ungranted token is refused."""
+    message = _message()
+    ungranted = SendToken(
+        message_id=message.id, purpose_key=message.purpose_key, granted=False
+    )
+    assert token_grants(ungranted, message) is False
+
+
+def test_send_refuses_before_touching_an_adapter(monkeypatch) -> None:
+    """Send refuses before touching an adapter."""
+    # No accessor is patched in: reaching the route lookup would hit the real
+    # database layer and come back as 'send_error', so the reason asserted
+    # here also proves the token check runs FIRST.
+    message = _message()
+    stranger = SendToken(message_id="m-2", purpose_key="order_update", granted=True)
+    outcome = asyncio.run(send(stranger, message))
+    # 'blocked', not 'failed': this is OUR refusal, not the provider's.
+    assert outcome.status == "blocked"
+    assert outcome.reason == REASON_GATE_REFUSED
+    assert outcome.retryable is False
+
+
+# --- fail closed: every missing piece refuses, none retry --------------------
+
+
+async def test_an_unserved_channel_is_terminal() -> None:
+    """An unserved channel is terminal."""
+    message = _message(channel="carrier_pigeon")
+    outcome = await send(_token(message), message)
+    assert outcome.reason == REASON_NO_ADAPTER
+    assert outcome.retryable is False
+
+
+@pytest.mark.parametrize(
+    "accessor_kwargs,credential,expected",
+    [
+        # Never connected, paused, retired, or another tenant's row: the
+        # accessor returns nothing for all of them, and one reason covers it.
+        (dict(binding=None), None, REASON_NO_BINDING),
+        (dict(binding=_binding(), installation=None), None, REASON_NO_INSTALLATION),
+        (
+            dict(binding=_binding(), installation=_installation(credential_id=None)),
+            None,
+            REASON_NO_CREDENTIAL,
+        ),
+        # Vault row gone, deactivated via the credentials API, or its value
+        # would not decrypt ({}): all the same "broken connection" answer.
+        (
+            dict(binding=_binding(), installation=_installation()),
+            None,
+            REASON_NO_CREDENTIAL,
+        ),
+        (
+            dict(binding=_binding(), installation=_installation()),
+            _credential(is_active=False),
+            REASON_NO_CREDENTIAL,
+        ),
+        (
+            dict(binding=_binding(), installation=_installation()),
+            _credential(value={}),
+            REASON_NO_CREDENTIAL,
+        ),
+    ],
+)
+async def test_a_broken_route_refuses_and_never_retries(
+    monkeypatch, accessor_kwargs, credential, expected
+) -> None:
+    """A broken route refuses and never retries."""
+    monkeypatch.setattr(send_module, "accessor", _FakeAccessor(**accessor_kwargs))
+    _patch_credential(monkeypatch, credential)
+    message = _message()
+    outcome = await send(_token(message), message)
+    # 'blocked', not 'failed': a missing route is US refusing (T16 col 12).
+    assert outcome.status == "blocked"
+    assert outcome.reason == expected
+    # Retrying cannot conjure a connection the merchant never made.
+    assert outcome.retryable is False
+
+
+async def test_a_vault_outage_retries_instead_of_blocking(monkeypatch) -> None:
+    """A vault outage retries instead of blocking."""
+    # None from the vault means "row gone/dead" and is rightly terminal above;
+    # a raising read is the pool blipping, and the same blip one line earlier
+    # (on get_binding) already retries. One transient failure, one answer.
+    monkeypatch.setattr(
+        send_module,
+        "accessor",
+        _FakeAccessor(binding=_binding(), installation=_installation()),
+    )
+
+    async def _outage(credential_id, mask=True, raise_errors=False):
+        """Test double: the pool dies mid-read."""
+        raise ConnectionError("pool exhausted")
+
+    monkeypatch.setattr(send_module, "get_credential_by_id", _outage)
+    message = _message()
+    outcome = await send(_token(message), message)
+    assert outcome.status == "failed"
+    assert outcome.reason == REASON_SEND_ERROR
+    assert outcome.retryable is True
+
+
+@pytest.mark.parametrize("status", ["degraded", "revoked", "disabled"])
+async def test_an_unhealthy_installation_refuses(monkeypatch, status) -> None:
+    """An unhealthy installation refuses."""
+    # Each of these states was chosen by somebody or by a prior failure; a
+    # send must not quietly ignore it.
+    monkeypatch.setattr(
+        send_module,
+        "accessor",
+        _FakeAccessor(binding=_binding(), installation=_installation(status=status)),
+    )
+    _patch_credential(monkeypatch, _credential())
+    message = _message()
+    outcome = await send(_token(message), message)
+    assert outcome.reason == REASON_INSTALLATION_UNHEALTHY
+
+
+async def test_a_connecting_installation_refuses(happy_accessor) -> None:
+    """A connecting installation refuses — fail closed, no exceptions."""
+    # Onboarding (#1038) verifies against the Graph API and writes rows as
+    # 'healthy' directly, so 'connecting' is an unproven connection and
+    # there is no first-send bootstrap to earn it a fail-open.
+    happy_accessor._installation = _installation(status="connecting")
+    route = await resolve_send_route("shop", "whatsapp", None)
+    assert route == REASON_INSTALLATION_UNHEALTHY
+
+
+async def test_a_resolved_route_carries_the_whole_context(happy_accessor) -> None:
+    """A resolved route carries the whole context."""
+    route = await resolve_send_route("shop", "whatsapp", None)
+    assert isinstance(route, SendRoute)
+    assert route.binding.address == "1234567890"
+    assert route.bundle.secret("system_user_token") == "tok"
+
+
+def test_both_binding_lookups_are_pinned_to_their_channel() -> None:
+    """Both binding lookups are pinned to their channel."""
+    # binding_id on a message is a bare uuid with no FK, so a row could name
+    # a binding of a DIFFERENT channel — and without the filter that
+    # binding's address would reach the message's adapter as if it were its
+    # own kind of endpoint. A mismatch must be 'no route', exactly like
+    # naming another tenant's row, never a wrong-endpoint send.
+    named_sql, named_values = binding_by_id_query("shop", "b-1", "whatsapp")
+    assert "channel = $3" in named_sql
+    assert named_values == ["shop", "b-1", "whatsapp"]
+    primary_sql, primary_values = primary_binding_query("shop", "whatsapp")
+    assert "channel = $2" in primary_sql
+    assert primary_values == ["shop", "whatsapp"]
+
+
+# --- the timeout no adapter can forget --------------------------------------
+
+
+class _HangingAdapter(ChannelAdapter):
+    channel = "whatsapp"
+
+    async def deliver(self, message, route_bundle, binding):
+        """Test double: adapter deliver with a scripted behaviour."""
+        await asyncio.sleep(3600)
+        raise AssertionError("unreachable")
+
+
+async def test_a_hung_provider_becomes_a_retryable_failure(
+    monkeypatch, happy_accessor
+) -> None:
+    """A hung provider becomes a retryable failure."""
+    # The lease, not politeness, is why this exists: a send that outlives its
+    # claim gets the row reassigned mid-flight and the customer gets two.
+    monkeypatch.setattr(send_module, "adapter_for", lambda channel: _HangingAdapter())
+    monkeypatch.setattr(send_module, "CRM_MESSAGE_SEND_TIMEOUT_SECONDS", 0.05)
+    message = _message()
+    outcome = await send(_token(message), message)
+    assert outcome.status == "failed"
+    assert outcome.reason == REASON_TIMEOUT
+    assert outcome.retryable is True
+
+
+async def test_a_hung_route_lookup_is_bounded_by_the_same_deadline(
+    monkeypatch,
+) -> None:
+    """A hung route lookup is bounded by the same deadline."""
+
+    # The lease does not care WHERE a send hangs: a stalled connection pool
+    # during the route's reads outlives the claim exactly like a hung
+    # provider, with the same reassigned row and the same double send. One
+    # deadline covers both.
+    class _HangingAccessor:
+        async def get_binding(self, merchant_id, channel, binding_id):
+            """Test double: the seeded binding, or a hang/None per scenario."""
+            await asyncio.sleep(3600)
+
+    monkeypatch.setattr(send_module, "accessor", _HangingAccessor())
+    monkeypatch.setattr(send_module, "CRM_MESSAGE_SEND_TIMEOUT_SECONDS", 0.05)
+    message = _message()
+    outcome = await send(_token(message), message)
+    assert outcome.status == "failed"
+    assert outcome.reason == REASON_TIMEOUT
+    assert outcome.retryable is True
+
+
+async def test_an_escaping_exception_becomes_the_default_outcome(
+    monkeypatch, happy_accessor
+) -> None:
+    """An escaping exception becomes the default outcome."""
+
+    # The default case. Adapters classify their own failures, so anything
+    # raising out of one is an escape from classification — it must land as
+    # an outcome on the row rather than as an exception the worker has to
+    # guess about, and it retries because we cannot know whether the
+    # provider saw it.
+    class _Raises(ChannelAdapter):
+        channel = "whatsapp"
+
+        async def deliver(self, message, route_bundle, binding):
+            """Test double: adapter deliver with a scripted behaviour."""
+            raise ValueError("classification escape")
+
+    monkeypatch.setattr(send_module, "adapter_for", lambda channel: _Raises())
+    message = _message()
+    outcome = await send(_token(message), message)
+    assert outcome.status == "failed"
+    assert outcome.reason == REASON_SEND_ERROR
+    assert outcome.retryable is True
+
+
+def test_a_whole_batch_of_worst_case_sends_fits_inside_the_claim_lease() -> None:
+    """A whole batch of worst case sends fits inside the claim lease."""
+    # Two inequalities, one law. A timeout above the lease would be no
+    # timeout at all — and a BATCH that outlasts the lease is worse: sends
+    # are serial, so rows claimed at the head of a pass sit in 'sending'
+    # while the tail is worked, and another pod's sweep re-sends the tail
+    # a first pod still holds. That duplicate is a real message to a real
+    # person; no outcome guard can undo it.
+    from app.core.config.static import (
+        CRM_DISPATCH_BATCH,
+        CRM_DISPATCH_STALE_MINUTES,
+        CRM_MESSAGE_SEND_TIMEOUT_SECONDS,
+    )
+
+    lease_seconds = CRM_DISPATCH_STALE_MINUTES * 60
+    assert CRM_MESSAGE_SEND_TIMEOUT_SECONDS < lease_seconds
+    # The whole-batch bound. The 2× is no longer just margin: each message
+    # may burn one full timeout in the gate probe (its own wait_for in
+    # dispatch._gate) and another in send(), so 2× IS the worst case — at
+    # the defaults 20 × 20s × 2 = 800s against 900s, leaving 100s for pass
+    # overhead (DB reads, backoff writes). Nudge one dial and the others
+    # must follow.
+    assert CRM_DISPATCH_BATCH * CRM_MESSAGE_SEND_TIMEOUT_SECONDS * 2 <= lease_seconds
+
+
+# --- the send path reads the route tables, it never writes them -------------
+
+
+async def test_a_credential_refusal_does_not_touch_connection_state(
+    monkeypatch, happy_accessor
+) -> None:
+    """An expired token fails the row with the provider's code and stops there.
+
+    Marking the connection degraded belongs to the channel module. Two owners
+    for one lifecycle is how a status ends up flapping between a health probe
+    that says 'healthy' and a send path that says 'degraded'.
+    """
+
+    class _RejectsCredentials(ChannelAdapter):
+        channel = "whatsapp"
+
+        async def deliver(self, message, route_bundle, binding):
+            """Test double: adapter deliver with a scripted behaviour."""
+            return SendOutcome(status="failed", reason="190")
+
+    monkeypatch.setattr(
+        send_module, "adapter_for", lambda channel: _RejectsCredentials()
+    )
+    message = _message()
+    outcome = await send(_token(message), message)
+    assert outcome.reason == "190"
+    assert outcome.retryable is False
+    # The reason on the row is the whole signal the channel module needs.
+    assert happy_accessor.writes == []
+
+
+# --- the credential bundle keeps secrets out of logs ------------------------
+
+
+def test_a_bundle_does_not_print_its_secrets() -> None:
+    """A bundle does not print its secrets."""
+    # The cheapest guard against the mistake that ships a token to a log
+    # aggregator: an f-string of the bundle must reveal nothing.
+    bundle = CredentialBundle(values={"system_user_token": "SUPER_SECRET"})
+    assert "SUPER_SECRET" not in repr(bundle)
+    assert "SUPER_SECRET" not in f"{bundle}"
+
+
+def test_a_missing_or_blank_secret_reads_as_absent() -> None:
+    """A missing or blank secret reads as absent."""
+    bundle = CredentialBundle(values={"system_user_token": "", "app_secret": None})
+    assert bundle.secret("system_user_token") is None
+    assert bundle.secret("app_secret") is None
+    assert bundle.secret("nope") is None
+
+
+# --- the route tables --------------------------------------------------------
+
+
+def test_the_route_tables_are_owned_by_connectivity() -> None:
+    """The route tables are owned by connectivity."""
+    assert TABLE_OWNERS["crm_connector_installation"] == "connectivity"
+    assert TABLE_OWNERS["crm_channel_binding"] == "connectivity"
+    assert TABLE_OWNERS["crm_message"] == "connectivity"
+
+
+def test_the_vault_is_read_through_its_own_accessor() -> None:
+    """The vault is read through its own accessor."""
+    # Table-ownership law: `credentials` belongs to app/database, so the one
+    # sanctioned seam is its accessor — no vault SQL in connectivity's
+    # builders, and send.py's read really is app/database's function.
+    queries_source = Path("app/crm/connectivity/db/queries.py").read_text()
+    assert "credentials" not in queries_source
+    assert (
+        send_module.get_credential_by_id.__module__
+        == "app.database.accessor.breeze_buddy.credentials"
+    )
+
+
+def test_both_tables_are_created_together() -> None:
+    """Both tables are created together."""
+    # They are meaningless apart — a binding has a foreign key into an
+    # installation — so splitting them would leave a numbered window in which
+    # the schema is half-built.
+    sql = _ddl()
+    assert "CREATE TABLE crm_connector_installation (" in sql
+    assert "CREATE TABLE crm_channel_binding (" in sql
+    # And the door must come first, or the pipe's FK has nothing to reference.
+    assert sql.index("CREATE TABLE crm_connector_installation (") < sql.index(
+        "CREATE TABLE crm_channel_binding ("
+    )
+
+
+def test_a_credential_in_use_cannot_be_deleted() -> None:
+    """A credential in use cannot be deleted."""
+    # Without this, deleting a secret through the credentials API silently
+    # breaks every send for that merchant, and the only symptom arrives much
+    # later as "credential missing" on failed rows.
+    sql = _table_ddl("crm_connector_installation")
+    assert "REFERENCES credentials (id) ON DELETE RESTRICT" in sql
+    # Never CASCADE: deleting a secret must not delete the record that a
+    # merchant ever connected. Disconnecting is a status change.
+    assert "ON DELETE CASCADE" not in _ddl()
+
+
+def test_an_installation_never_stores_a_secret() -> None:
+    """An installation never stores a secret."""
+    # The whole point of the credential_id pointer. A column named for a token
+    # here would mean secrets in every backup of this table.
+    sql = _table_ddl("crm_connector_installation")
+    for forbidden in ("access_token", "system_user_token", "secret", "password"):
+        assert forbidden not in sql, forbidden
+    assert "credential_id       uuid" in sql
+
+
+def test_connector_key_and_channel_have_no_check() -> None:
+    """Connector key and channel have no check."""
+    # The migration-027 scar: vocabulary in a CHECK made a new channel a
+    # migration. Both columns must stay plain text.
+    assert "CHECK (connector_key" not in _ddl()
+    assert "CHECK (channel" not in _ddl()
+
+
+def test_lifecycle_states_are_closed_enums() -> None:
+    """Lifecycle states are closed enums."""
+    # Status is not vocabulary: it changes only when the lifecycle does.
+    installation = _table_ddl("crm_connector_installation")
+    assert "CHECK (status IN (" in installation
+    for state in ("connecting", "healthy", "degraded", "revoked", "disabled"):
+        assert f"'{state}'" in installation, state
+    binding = _table_ddl("crm_channel_binding")
+    assert "CHECK (status IN (" in binding
+    for state in ("active", "paused", "retired"):
+        assert f"'{state}'" in binding, state
+    # Sliced per table on purpose: without it, the binding's states would be
+    # "found" in the installation's CHECK sitting in the same file.
+    assert "'connecting'" not in binding
+
+
+def test_there_is_no_stored_expired_state() -> None:
+    """There is no stored expired state."""
+    # Expiry is the predicate token_expires_at < now(). A stored copy is
+    # correct only until the clock passes it.
+    assert "'expired'" not in _ddl()
+
+
+def test_these_tables_carry_no_read_only_indexes() -> None:
+    """These tables carry no read only indexes."""
+    # Configuration tables: one row per merchant per account, one per endpoint.
+    # At that size a sequential scan is sub-millisecond, so every index here
+    # has to earn its write cost by being a CORRECTNESS rule. The send path is
+    # served entirely by the unique ones — (merchant_id, connector_key) is a
+    # prefix of the account index, and the primary-pipe lookup IS the partial
+    # unique. A plain CREATE INDEX appearing here means someone added a read
+    # optimisation these tables do not need.
+    plain = re.findall(r"CREATE INDEX (\w+)", _ddl())
+    assert plain == [], plain
+
+
+def test_every_merchant_scoped_unique_index_leads_with_merchant() -> None:
+    """Every merchant scoped unique index leads with merchant."""
+    # One exception, named here rather than skipped silently: a law with an
+    # anonymous exception is not a law. It is asserted on its own below.
+    EXCEPTION = "crm_channel_binding_address_uq"
+    found = re.findall(r"CREATE UNIQUE INDEX (\w+)\s+ON \w+ \(([^)]+)\)", _ddl())
+    assert len(found) >= 4, found
+    for name, columns in found:
+        if name == EXCEPTION:
+            continue
+        assert columns.strip().startswith("merchant_id"), name
+
+
+def test_one_live_address_belongs_to_one_merchant() -> None:
+    """One live address belongs to one merchant."""
+    # The deliberate exception to merchant-first, and the reason phase 3 can
+    # resolve a merchant from an inbound receipt at all.
+    sql = _table_ddl("crm_channel_binding")
+    assert "crm_channel_binding (channel, address)" in sql
+    # Retired rows are excluded so a recycled number can live again elsewhere.
+    assert "WHERE status <> 'retired'" in sql
+
+
+def test_a_merchant_has_at_most_one_primary_pipe_per_channel() -> None:
+    """A merchant has at most one primary pipe per channel."""
+    sql = _table_ddl("crm_channel_binding")
+    assert "crm_channel_binding (merchant_id, channel)" in sql
+    assert "WHERE is_primary" in sql
+
+
+def test_a_binding_cannot_hang_off_another_tenants_installation() -> None:
+    """A binding cannot hang off another tenants installation."""
+    # Composite FK, same protection crm_message gives its customer link.
+    sql = _table_ddl("crm_channel_binding")
+    assert "FOREIGN KEY (merchant_id, installation_id)" in sql
+    assert "REFERENCES crm_connector_installation (merchant_id, id)" in sql

--- a/tests/crm/test_dispatch.py
+++ b/tests/crm/test_dispatch.py
@@ -1,15 +1,13 @@
 """The dispatcher's retry policy, its plumbing, its SQL builders, and the DDL."""
 
+import asyncio
 import re
 from datetime import datetime, timezone
 from pathlib import Path
 
 from app.core.config.static import _positive_float, _positive_int
 from app.crm.connectivity import dispatch
-from app.crm.connectivity.db.decoder import (
-    _load_variables,
-    decode_queued_message,
-)
+from app.crm.connectivity.channels import CHANNELS, gate_handle_kind_for
 from app.crm.connectivity.db.queries import (
     CLAIMED_COLUMNS,
     apply_outcome_query,
@@ -18,10 +16,13 @@ from app.crm.connectivity.db.queries import (
 )
 from app.crm.connectivity.dispatch import (
     REASON_ATTEMPTS_EXHAUSTED,
+    REASON_GATE_UNAVAILABLE,
     REASON_PROVIDER_REJECTED,
     REASON_SEND_ERROR,
+    REASON_SUPPRESSED,
     RETRY_MAX_SECONDS,
     STATUS_ACCEPTED,
+    STATUS_BLOCKED,
     STATUS_DEAD,
     STATUS_FAILED,
     STATUS_QUEUED,
@@ -30,7 +31,10 @@ from app.crm.connectivity.dispatch import (
     plan_for_outcome,
     sample_ids,
 )
+from app.crm.connectivity.providers import ADAPTERS
+from app.crm.connectivity.reasons import REASON_RECLAIMED_STALE_CLAIM
 from app.crm.connectivity.schemas import QueuedMessage, SendOutcome
+from app.crm.shared.decode import jsonb_object
 from scripts.check_crm_boundaries import TABLE_OWNERS
 
 MIGRATION = Path("app/database/migrations/056_create_crm_message.sql")
@@ -50,6 +54,7 @@ def _ddl() -> str:
 
 
 def test_accepted_records_the_provider_id_and_stamps_sent() -> None:
+    """Accepted records the provider id and stamps sent."""
     plan = plan_for_outcome(
         SendOutcome(status="accepted", provider_message_id="wamid.X"), 1, 3
     )
@@ -60,6 +65,7 @@ def test_accepted_records_the_provider_id_and_stamps_sent() -> None:
 
 
 def test_retryable_failure_goes_back_on_the_queue() -> None:
+    """Retryable failure goes back on the queue."""
     plan = plan_for_outcome(
         SendOutcome(status="failed", reason="rate_limited", retryable=True), 1, 3
     )
@@ -69,6 +75,7 @@ def test_retryable_failure_goes_back_on_the_queue() -> None:
 
 
 def test_retryable_failure_goes_dead_on_the_last_attempt() -> None:
+    """Retryable failure goes dead on the last attempt."""
     plan = plan_for_outcome(
         SendOutcome(status="failed", reason="rate_limited", retryable=True), 3, 3
     )
@@ -78,6 +85,7 @@ def test_retryable_failure_goes_dead_on_the_last_attempt() -> None:
 
 
 def test_permanent_failure_never_retries_however_many_attempts_remain() -> None:
+    """Permanent failure never retries however many attempts remain."""
     plan = plan_for_outcome(
         SendOutcome(status="failed", reason="template_not_approved"), 1, 99
     )
@@ -86,16 +94,35 @@ def test_permanent_failure_never_retries_however_many_attempts_remain() -> None:
 
 
 def test_failure_without_a_reason_still_records_one() -> None:
+    """Failure without a reason still records one."""
     plan = plan_for_outcome(SendOutcome(status="failed"), 1, 3)
     assert plan.reason == REASON_PROVIDER_REJECTED
 
 
 def test_a_send_that_never_reports_cannot_be_marked_sent() -> None:
+    """A send that never reports cannot be marked sent."""
     for outcome in (
         SendOutcome(status="failed", reason="boom", retryable=True),
         SendOutcome(status="failed", reason="boom"),
     ):
         assert plan_for_outcome(outcome, 1, 3).mark_sent is False
+
+
+def test_our_refusal_lands_as_blocked_terminal_and_unsent() -> None:
+    """Our refusal lands as blocked, terminal and unsent.
+
+    T16 col 12: 'failed' is the provider refusing, 'blocked' is us. A
+    merchant with a paused number must not read the word reserved for
+    "Meta said no" — and OUR decision does not change by retrying.
+    """
+    plan = plan_for_outcome(
+        SendOutcome(status="blocked", reason=REASON_SUPPRESSED), 1, 3
+    )
+    assert plan.status == STATUS_BLOCKED
+    assert plan.reason == REASON_SUPPRESSED
+    assert plan.mark_sent is False
+    assert plan.retry_after_seconds is None
+    assert plan.provider_message_id is None
 
 
 # --- the plumbing never raises -----------------------------------------------
@@ -104,6 +131,7 @@ def test_a_send_that_never_reports_cannot_be_marked_sent() -> None:
 
 
 def _message(attempt: int = 1) -> QueuedMessage:
+    """A queued message for tests; keyword overrides replace any field."""
     return QueuedMessage(
         id="m-1",
         merchant_id="m-1000",
@@ -118,35 +146,59 @@ def _message(attempt: int = 1) -> QueuedMessage:
     )
 
 
+async def _gate_open(handles):
+    """Test double: the suppression probe finds nothing."""
+    return False
+
+
 async def test_an_accepted_send_records_the_outcome(monkeypatch) -> None:
+    """An accepted send records the outcome."""
     written = {}
 
-    async def fake_send(message):
+    async def fake_send(send_token, message):
+        """Test double: a send with a scripted outcome."""
+        # The dispatcher mints a token for every send — the fake carries the
+        # real signature so a signature drift fails here, not in production.
         written["sent"] = message.id
+        written["token_names_message"] = send_token.message_id == message.id
         return SendOutcome(status="accepted", provider_message_id="wamid.T")
 
-    async def record_outcome(message_id, status, reason, pmid, mark_sent, retry):
-        written.update(status=status, mark_sent=mark_sent)
+    async def record_outcome(
+        message_id, status, reason, pmid, mark_sent, attempt, retry
+    ):
+        """Test double: records what the dispatcher tried to write."""
+        written.update(status=status, mark_sent=mark_sent, attempt=attempt)
         return True
 
+    monkeypatch.setattr(dispatch, "is_suppressed", _gate_open)
     monkeypatch.setattr(dispatch, "send", fake_send)
     monkeypatch.setattr(dispatch.accessor, "apply_outcome", record_outcome)
     await dispatch._dispatch_one(_message(), 3)
     assert written["sent"] == "m-1"
+    assert written["token_names_message"] is True
     assert written["status"] == STATUS_ACCEPTED
     assert written["mark_sent"] is True
+    # The write carries the claim's generation, so a stale claim's late
+    # outcome cannot land on a row a newer claim now owns.
+    assert written["attempt"] == 1
 
 
 async def test_a_raising_send_becomes_a_retryable_send_error(monkeypatch) -> None:
+    """A raising send becomes a retryable send error."""
     written = {}
 
-    async def broken_send(message):
+    async def broken_send(send_token, message):
+        """Test double: a send that raises."""
         raise RuntimeError("wire fell over")
 
-    async def record_outcome(message_id, status, reason, pmid, mark_sent, retry):
+    async def record_outcome(
+        message_id, status, reason, pmid, mark_sent, attempt, retry
+    ):
+        """Test double: records what the dispatcher tried to write."""
         written.update(status=status, reason=reason, retry=retry)
         return True
 
+    monkeypatch.setattr(dispatch, "is_suppressed", _gate_open)
     monkeypatch.setattr(dispatch, "send", broken_send)
     monkeypatch.setattr(dispatch.accessor, "apply_outcome", record_outcome)
     await dispatch._dispatch_one(_message(attempt=1), 3)
@@ -156,16 +208,134 @@ async def test_a_raising_send_becomes_a_retryable_send_error(monkeypatch) -> Non
     assert written["retry"] is not None and written["retry"] >= 1
 
 
+async def test_a_suppressed_address_is_blocked_and_the_adapter_never_called(
+    monkeypatch,
+) -> None:
+    """A suppressed address is blocked and the adapter never called.
+
+    The one check a person who said STOP is protected by. The send spy
+    RAISES, so reaching the adapter at all fails the test — blocked means
+    nothing left the building.
+    """
+    written = {}
+
+    async def suppressed(handles):
+        """Test double: this handle carries a live suppression."""
+        assert handles == {"phone": "+919812345678"}
+        return True
+
+    async def exploding_send(send_token, message):
+        """Test double: the adapter must never be reached."""
+        raise AssertionError("adapter reached past a refusing gate")
+
+    async def record_outcome(
+        message_id, status, reason, pmid, mark_sent, attempt, retry
+    ):
+        """Test double: records what the dispatcher tried to write."""
+        written.update(status=status, reason=reason, mark_sent=mark_sent)
+        return True
+
+    monkeypatch.setattr(dispatch, "is_suppressed", suppressed)
+    monkeypatch.setattr(dispatch, "send", exploding_send)
+    monkeypatch.setattr(dispatch.accessor, "apply_outcome", record_outcome)
+    await dispatch._dispatch_one(_message(), 3)
+    assert written["status"] == STATUS_BLOCKED
+    assert written["reason"] == REASON_SUPPRESSED
+    assert written["mark_sent"] is False
+
+
+async def test_a_channel_the_gate_cannot_check_fails_closed(monkeypatch) -> None:
+    """A channel the gate cannot check fails closed.
+
+    ADR 0018: unknown gate input means NO. A channel with no handle-kind
+    mapping must block, not slip past the gate unchecked.
+    """
+    written = {}
+
+    async def exploding_send(send_token, message):
+        """Test double: the adapter must never be reached."""
+        raise AssertionError("adapter reached past a refusing gate")
+
+    async def record_outcome(
+        message_id, status, reason, pmid, mark_sent, attempt, retry
+    ):
+        """Test double: records what the dispatcher tried to write."""
+        written.update(status=status, reason=reason)
+        return True
+
+    monkeypatch.setattr(dispatch, "send", exploding_send)
+    monkeypatch.setattr(dispatch.accessor, "apply_outcome", record_outcome)
+    message = _message()
+    message = message.model_copy(update={"channel": "carrier_pigeon"})
+    await dispatch._dispatch_one(message, 3)
+    assert written["status"] == STATUS_BLOCKED
+    assert written["reason"] == REASON_GATE_UNAVAILABLE
+
+
+async def test_a_hung_gate_probe_is_bounded_and_fails_closed(monkeypatch) -> None:
+    """A hung gate probe is bounded and fails closed.
+
+    The probe reads the same pool send() guards with its deadline; unbounded,
+    a hung probe stalls the serial batch past the claim lease and reproduces
+    the double send the lease inequality pins against. Bounded, it is OUR
+    refusal — blocked/gate_unavailable — and nothing reaches the provider.
+    """
+    written = {}
+
+    async def hanging_probe(handles):
+        """Test double: the suppression probe never answers."""
+        await asyncio.sleep(3600)
+
+    async def exploding_send(send_token, message):
+        """Test double: the adapter must never be reached."""
+        raise AssertionError("adapter reached past a refusing gate")
+
+    async def record_outcome(
+        message_id, status, reason, pmid, mark_sent, attempt, retry
+    ):
+        """Test double: records what the dispatcher tried to write."""
+        written.update(status=status, reason=reason, mark_sent=mark_sent)
+        return True
+
+    monkeypatch.setattr(dispatch, "is_suppressed", hanging_probe)
+    monkeypatch.setattr(dispatch, "send", exploding_send)
+    monkeypatch.setattr(dispatch, "CRM_MESSAGE_SEND_TIMEOUT_SECONDS", 0.05)
+    monkeypatch.setattr(dispatch.accessor, "apply_outcome", record_outcome)
+    await dispatch._dispatch_one(_message(), 3)
+    assert written["status"] == STATUS_BLOCKED
+    assert written["reason"] == REASON_GATE_UNAVAILABLE
+    assert written["mark_sent"] is False
+
+
+def test_every_adapter_channel_is_registered_in_channels() -> None:
+    """Every adapter channel is registered in channels.py (ADAPTERS ⊆ CHANNELS).
+
+    The fail-closed default above means an unregistered channel blocks every
+    send — safe but useless. Registering an adapter without an entry in the
+    channel registry fails here, in CI. The pin lives in the tests because
+    channels.py itself may not import providers/ (rule 11 confines them
+    behind the send door — the reason the registry is a separate file).
+    """
+    assert set(ADAPTERS) <= set(CHANNELS)
+    # Every entry carries a probe-able handle kind, not just a key.
+    for channel in ADAPTERS:
+        assert gate_handle_kind_for(channel)
+
+
 async def test_a_reclaimed_row_discards_the_late_outcome(monkeypatch) -> None:
+    """A reclaimed row discards the late outcome."""
     calls = []
 
-    async def fake_send(message):
+    async def fake_send(send_token, message):
+        """Test double: a send with a scripted outcome."""
         return SendOutcome(status="accepted", provider_message_id="wamid.L")
 
-    async def reclaimed(message_id, status, reason, pmid, mark_sent, retry):
+    async def reclaimed(message_id, status, reason, pmid, mark_sent, attempt, retry):
+        """Test double: the row already belongs to another worker."""
         calls.append(status)
         return False  # the sweep already handed this row to another worker
 
+    monkeypatch.setattr(dispatch, "is_suppressed", _gate_open)
     monkeypatch.setattr(dispatch, "send", fake_send)
     monkeypatch.setattr(dispatch.accessor, "apply_outcome", reclaimed)
     await dispatch._dispatch_one(_message(), 3)
@@ -174,6 +344,7 @@ async def test_a_reclaimed_row_discards_the_late_outcome(monkeypatch) -> None:
 
 
 def test_jitter_stays_in_bounds_and_never_reaches_zero() -> None:
+    """Jitter stays in bounds and never reaches zero."""
     assert _jittered(None) is None
     for _ in range(500):
         spread = _jittered(30)
@@ -187,6 +358,7 @@ def test_jitter_stays_in_bounds_and_never_reaches_zero() -> None:
 
 
 def test_claim_is_race_safe_across_pods() -> None:
+    """Claim is race safe across pods."""
     query, values = claim_queued_messages_query(25)
     assert "FOR UPDATE SKIP LOCKED" in query
     assert "status = 'queued'" in query
@@ -198,11 +370,13 @@ def test_claim_is_race_safe_across_pods() -> None:
 
 
 def test_sample_ids_lists_everything_when_it_fits() -> None:
+    """Sample ids lists everything when it fits."""
     assert sample_ids(["a", "b"], limit=10) == "a, b"
     assert sample_ids([], limit=10) == ""
 
 
 def test_sample_ids_truncates_and_says_how_many_it_hid() -> None:
+    """Sample ids truncates and says how many it hid."""
     # Batch size is operator-tunable and the stale sweep is unbounded, so an
     # uncapped join could emit a multi-megabyte log record.
     out = sample_ids([f"id-{n}" for n in range(1000)], limit=3)
@@ -217,6 +391,7 @@ def test_sample_ids_truncates_and_says_how_many_it_hid() -> None:
 
 
 def test_dispatcher_is_a_registered_worker_role() -> None:
+    """Dispatcher is a registered worker role."""
     # start_worker_role raises on an unregistered role, so without this entry
     # a CRM_ROLE=dispatcher pod crashes at boot.
     from app.crm.worker_main import ROLES
@@ -225,6 +400,7 @@ def test_dispatcher_is_a_registered_worker_role() -> None:
 
 
 def test_contracts_export_the_scaffold_pair() -> None:
+    """Contracts export the scaffold pair."""
     # worker_main may import only the module's contracts — the claim/handle
     # pair must be reachable there, not by deep import.
     from app.crm.connectivity import contracts
@@ -237,6 +413,7 @@ def test_contracts_export_the_scaffold_pair() -> None:
 
 
 def test_a_bad_dial_falls_back_instead_of_stopping_the_pod(monkeypatch) -> None:
+    """A bad dial falls back instead of stopping the pod."""
     # Lenient by choice: raising here would fail the pod at import, and a
     # mistyped retry dial should not be able to do that.
     for bad in ("", "fast", "1.5", "0", "-1"):
@@ -249,6 +426,7 @@ def test_a_bad_dial_falls_back_instead_of_stopping_the_pod(monkeypatch) -> None:
 
 
 def test_a_bad_float_dial_falls_back_too(monkeypatch) -> None:
+    """A bad float dial falls back too."""
     # Guards CRM_WORKER_INTERVAL/HEARTBEAT. 'inf' is the dangerous one: it
     # parses, it compares > 0, and an infinite poll interval is a worker that
     # sleeps forever after its first empty poll.
@@ -262,6 +440,7 @@ def test_a_bad_float_dial_falls_back_too(monkeypatch) -> None:
 
 
 def test_retry_waits_longer_each_attempt_then_caps() -> None:
+    """Retry waits longer each attempt then caps."""
     # Retrying a rate-limited send instantly is the one response guaranteed
     # to make it fail again.
     assert backoff_seconds(1, 30, RETRY_MAX_SECONDS) == 30
@@ -272,6 +451,7 @@ def test_retry_waits_longer_each_attempt_then_caps() -> None:
 
 
 def test_requeue_carries_a_delay_and_terminal_outcomes_do_not() -> None:
+    """Requeue carries a delay and terminal outcomes do not."""
     requeued = plan_for_outcome(
         SendOutcome(status="failed", reason="131049", retryable=True), 1, 3
     )
@@ -289,12 +469,14 @@ def test_requeue_carries_a_delay_and_terminal_outcomes_do_not() -> None:
 
 
 def test_claim_returns_when_rows_came_due_for_the_lag_metric() -> None:
+    """Claim returns when rows came due for the lag metric."""
     # The lag log line reads next_attempt_at off the claimed row; dropping it
     # from CLAIMED_COLUMNS would fail the decoder on every claimed batch.
     assert "next_attempt_at" in CLAIMED_COLUMNS
 
 
 def test_queue_filters_and_orders_by_when_a_row_is_due() -> None:
+    """Queue filters and orders by when a row is due."""
     # Ordering by created_at would send a requeued row to the FRONT on its
     # original timestamp, retrying it ahead of every fresh message.
     query, _ = claim_queued_messages_query(25)
@@ -304,42 +486,75 @@ def test_queue_filters_and_orders_by_when_a_row_is_due() -> None:
 
 
 def test_only_a_requeue_moves_the_next_attempt_time() -> None:
+    """Only a requeue moves the next attempt time."""
     query, values = apply_outcome_query(
-        "m-1", "queued", "rate_limited", None, False, 30
+        "m-1", "queued", "rate_limited", None, False, 1, 30
     )
     assert "make_interval(secs => $6::int)" in query
     assert values[5] == 30
 
 
 def test_claim_burns_an_attempt_so_a_dead_worker_cannot_loop_forever() -> None:
+    """Claim burns an attempt so a dead worker cannot loop forever."""
     query, _ = claim_queued_messages_query(10)
     assert "attempt = attempt + 1" in query
 
 
 def test_outcome_write_is_guarded_by_the_claim() -> None:
-    query, values = apply_outcome_query("m-1", "accepted", None, "wamid.X", True, None)
+    """Outcome write is guarded by the claim."""
+    # Two guards, one question — "is this still MY claim?": the status stops
+    # a write after a terminal outcome landed, and the attempt stops one
+    # after the sweep reassigned the row to a NEWER claim (which put it back
+    # in 'sending', so status alone would let the stale write through).
+    query, values = apply_outcome_query(
+        "m-1", "accepted", None, "wamid.X", True, 2, None
+    )
     assert "status = 'sending'" in query
-    assert values == ["m-1", "accepted", None, "wamid.X", True, None]
+    assert "attempt = $7::int" in query
+    assert values == ["m-1", "accepted", None, "wamid.X", True, None, 2]
 
 
 def test_outcome_write_never_erases_a_known_provider_id() -> None:
-    query, _ = apply_outcome_query("m-1", "queued", "rate_limited", None, False, 30)
+    """Outcome write never erases a known provider id."""
+    query, _ = apply_outcome_query("m-1", "queued", "rate_limited", None, False, 1, 30)
     assert "COALESCE($4, provider_message_id)" in query
 
 
 def test_stale_sweep_targets_only_expired_claims() -> None:
-    query, values = requeue_stale_claims_query(5)
+    """Stale sweep targets only expired claims."""
+    query, values = requeue_stale_claims_query(5, 3)
     assert "status = 'sending'" in query
     assert "make_interval(mins => $1::int)" in query
-    assert values == [5]
+    # The reclaim reason the sweep writes is manifest vocabulary, so the
+    # word must be the one reasons.py declares — not a SQL-only spelling.
+    assert f"'{REASON_RECLAIMED_STALE_CLAIM}'" in query
+    assert values == [5, 3]
+
+
+def test_stale_sweep_kills_rows_that_are_out_of_attempts() -> None:
+    """Stale sweep kills rows that are out of attempts."""
+    # The loop this closes: a row whose outcome can never be RECORDED (e.g. a
+    # duplicate provider_message_id makes apply_outcome raise every time) is
+    # claimed, really sent, left in 'sending', reclaimed — and really sent
+    # again on every lap. Each lap's claim spends an attempt, so the sweep
+    # applying the same ceiling as the retry ladder bounds it at max_attempts
+    # copies instead of one per stale window, forever.
+    query, values = requeue_stale_claims_query(5, 3)
+    assert "attempt >= $2::int" in query
+    assert "'dead'" in query
+    # Same word as plan_for_outcome's dead: we stopped, the provider didn't.
+    assert f"'{REASON_ATTEMPTS_EXHAUSTED}'" in query
+    assert "RETURNING id, status" in query
+    assert values == [5, 3]
 
 
 def test_builders_parameterize_every_value() -> None:
+    """Builders parameterize every value."""
     # A mismatch is an unbound $n or, worse, a value that got interpolated.
     for query, values in (
         claim_queued_messages_query(25),
-        requeue_stale_claims_query(5),
-        apply_outcome_query("m-1", "failed", "nope", None, False, None),
+        requeue_stale_claims_query(5, 3),
+        apply_outcome_query("m-1", "failed", "nope", None, False, 1, None),
     ):
         placeholders = set(re.findall(r"\$(\d+)", query))
         assert placeholders == {str(n) for n in range(1, len(values) + 1)}
@@ -348,7 +563,8 @@ def test_builders_parameterize_every_value() -> None:
 # --- the decoder can never stop the queue -----------------------------------
 
 
-def test_load_variables_is_total() -> None:
+def test_jsonb_object_is_total() -> None:
+    """Jsonb object is total."""
     # A raise here would strand a whole claimed batch in 'sending', forever.
     cases = [
         ('{"name":"Priya"}', {"name": "Priya"}),  # the live path
@@ -368,18 +584,20 @@ def test_load_variables_is_total() -> None:
         (["a", "b"], {}),
     ]
     for value, expected in cases:
-        assert _load_variables(value) == expected, value
+        assert jsonb_object(value) == expected, value
 
 
-def test_load_variables_refuses_to_invent_variables() -> None:
+def test_jsonb_object_refuses_to_invent_keys() -> None:
+    """Jsonb object refuses to invent keys."""
     # dict([["a", 1]]) == {"a": 1} would post a variable nobody wrote.
-    assert _load_variables([["a", 1]]) == {}
-    assert _load_variables([("a", 1)]) == {}
+    assert jsonb_object([["a", 1]]) == {}
+    assert jsonb_object([("a", 1)]) == {}
 
 
 def test_decoded_variables_do_not_alias_the_row() -> None:
+    """Decoded variables do not alias the row."""
     row = {"a": 1}
-    decoded = _load_variables(row)
+    decoded = jsonb_object(row)
     decoded["b"] = 2
     assert row == {"a": 1}
 
@@ -388,10 +606,12 @@ def test_decoded_variables_do_not_alias_the_row() -> None:
 
 
 def test_manifest_is_owned_by_connectivity() -> None:
+    """Manifest is owned by connectivity."""
     assert TABLE_OWNERS["crm_message"] == "connectivity"
 
 
 def test_dedupe_key_is_mandatory_and_unique_per_merchant() -> None:
+    """Dedupe key is mandatory and unique per merchant."""
     # The only thing between a crash-retry and a duplicate send, so it covers
     # every row: NOT NULL with no default, and a total (not partial) unique.
     sql = _ddl()
@@ -401,6 +621,7 @@ def test_dedupe_key_is_mandatory_and_unique_per_merchant() -> None:
 
 
 def test_expected_columns_are_all_present() -> None:
+    """Expected columns are all present."""
     sql = _ddl()
     for column in (
         "binding_id",
@@ -418,25 +639,29 @@ def test_expected_columns_are_all_present() -> None:
 
 
 def test_decision_id_matches_the_diary_pages() -> None:
+    """Decision id matches the diary pages."""
     # The permission decision table keys on a bigserial; a uuid would not join.
     sql = _ddl()
     assert "decision_id         bigint" in sql
 
 
 def test_variables_shape_is_enforced_in_code_not_in_the_table() -> None:
-    # Any JSON value is a legal row; _load_variables neutralises the rest.
+    """Variables shape is enforced in code not in the table."""
+    # Any JSON value is a legal row; jsonb_object neutralises the rest.
     sql = _ddl()
     assert "variables           jsonb NOT NULL" in sql
     assert "jsonb_typeof" not in sql
 
 
 def test_purpose_key_cannot_be_null() -> None:
+    """Purpose key cannot be null."""
     # A mandatory gate input, and missing inputs must fail closed.
     sql = _ddl()
     assert "purpose_key         text NOT NULL" in sql
 
 
 def test_proposal_fields_are_immutable_by_trigger() -> None:
+    """Proposal fields are immutable by trigger."""
     sql = _ddl()
     assert "crm_message_immutable_guard" in sql
     for frozen in ("sent_to_address", "purpose_key", "variables", "dedupe_key"):
@@ -446,7 +671,27 @@ def test_proposal_fields_are_immutable_by_trigger() -> None:
         assert f"NEW.{mutable} " not in sql, mutable
 
 
+def test_binding_id_is_set_once_never_rewritten() -> None:
+    """Binding id is set once never rewritten.
+
+    NULL on refused rows, stamped when a route is picked — so it may be SET
+    once but never changed: a rewrite would forge which endpoint a message
+    left on, while full immutability would forbid the stamp itself. Lives in
+    060 as a CREATE OR REPLACE of 056's function, because merged migrations
+    are never edited.
+    """
+    sql = Path(
+        "app/database/migrations/060_create_crm_connector_tables.sql"
+    ).read_text()
+    assert "CREATE OR REPLACE FUNCTION crm_message_immutable()" in sql
+    assert "OLD.binding_id IS NOT NULL" in sql
+    assert "NEW.binding_id IS DISTINCT FROM OLD.binding_id" in sql
+    # And 056 itself carries no set-once clause — it must stay as merged.
+    assert "OLD.binding_id" not in _ddl()
+
+
 def test_the_work_queue_is_a_partial_index() -> None:
+    """The work queue is a partial index."""
     sql = _ddl()
     assert "crm_message_queued_ix" in sql
     assert "WHERE status = 'queued'" in sql
@@ -454,6 +699,7 @@ def test_the_work_queue_is_a_partial_index() -> None:
 
 
 def test_index_set_is_exactly_what_is_read() -> None:
+    """Index set is exactly what is read."""
     # Three for the loop, two for analytics. The delivery-receipt index ships
     # with the walker that queries it — an unused index is a write cost.
     sql = _ddl()
@@ -469,6 +715,7 @@ def test_index_set_is_exactly_what_is_read() -> None:
 
 
 def test_one_provider_message_is_one_row() -> None:
+    """One provider message is one row."""
     # A write rule, not a read index: recording the same provider id twice
     # must be impossible. Not merchant-scoped on purpose — a provider id is
     # globally unique, so scoping it per tenant would let two merchants each
@@ -479,6 +726,7 @@ def test_one_provider_message_is_one_row() -> None:
 
 
 def test_analytics_indexes_are_merchant_first_and_time_ordered() -> None:
+    """Analytics indexes are merchant first and time ordered."""
     # merchant-first makes a tenant's slice a range scan, not a filter over
     # everyone; created_at DESC matches how every report reads.
     sql = _ddl()
@@ -487,6 +735,7 @@ def test_analytics_indexes_are_merchant_first_and_time_ordered() -> None:
 
 
 def test_no_touch_trigger_because_there_is_no_updated_at() -> None:
+    """No touch trigger because there is no updated at."""
     # Every state stamps its own clock; same choice as crm_event_raw (051).
     sql = _ddl()
     assert "updated_at" not in sql
@@ -495,6 +744,7 @@ def test_no_touch_trigger_because_there_is_no_updated_at() -> None:
 
 
 def test_status_is_a_closed_enum_but_channel_is_not() -> None:
+    """Status is a closed enum but channel is not."""
     # Format CHECKs are required; vocabulary CHECKs are the 027 scar.
     sql = _ddl()
     assert "CHECK (status IN (" in sql
@@ -506,6 +756,7 @@ def test_status_is_a_closed_enum_but_channel_is_not() -> None:
 
 
 def test_customer_fk_is_composite_so_a_message_cannot_cross_tenants() -> None:
+    """Customer fk is composite so a message cannot cross tenants."""
     sql = _ddl()
     assert "FOREIGN KEY (merchant_id, customer_id)" in sql
     assert "REFERENCES crm_customer (merchant_id, id)" in sql

--- a/tests/crm/test_whatsapp_adapter.py
+++ b/tests/crm/test_whatsapp_adapter.py
@@ -1,0 +1,541 @@
+"""The WhatsApp adapter: what it posts, and what it makes of the answer.
+
+No network anywhere. httpx.MockTransport stands in for Meta, so the entire
+error matrix — including the ones that are painful to provoke for real, like
+an expired token — is exercised on every test run.
+"""
+
+from datetime import datetime, timezone
+from typing import Any, Dict, Optional
+
+import httpx
+import pytest
+
+from app.crm.connectivity.providers import whatsapp as whatsapp_module
+from app.crm.connectivity.providers.whatsapp import (
+    CREDENTIAL_CODES,
+    RETRYABLE_CODES,
+    TERMINAL_CODES,
+    MetaWhatsAppAdapter,
+    build_parameters,
+    to_meta_recipient,
+)
+from app.crm.connectivity.schemas import (
+    ChannelBinding,
+    CredentialBundle,
+    QueuedMessage,
+)
+
+ACCEPTED_BODY = {
+    "messaging_product": "whatsapp",
+    "contacts": [{"input": "919876543210", "wa_id": "919876543210"}],
+    "messages": [{"id": "wamid.HBgMOTE5ODc2NTQzMjEw"}],
+}
+
+
+def _message(**overrides) -> QueuedMessage:
+    """A queued message for tests; keyword overrides replace any field."""
+    fields = dict(
+        id="m-1",
+        merchant_id="shop",
+        customer_id="c-1",
+        channel="whatsapp",
+        sent_to_address="+919876543210",
+        source_kind="transactional",
+        purpose_key="order_update",
+        template_id="order_update_v1",
+        variables={"1": "Priya", "2": "ORD-42"},
+        dedupe_key="evt-1",
+        attempt=1,
+        next_attempt_at=datetime.now(timezone.utc),
+    )
+    fields.update(overrides)
+    return QueuedMessage(**fields)
+
+
+def _binding(**overrides) -> ChannelBinding:
+    """An active channel binding for tests; overrides replace any field."""
+    fields = dict(
+        id="b-1",
+        merchant_id="shop",
+        channel="whatsapp",
+        installation_id="i-1",
+        address="PHONE_NUMBER_ID",
+        capabilities={},
+        is_primary=True,
+        status="active",
+    )
+    fields.update(overrides)
+    return ChannelBinding(**fields)
+
+
+def _bundle(**values) -> CredentialBundle:
+    """A credential bundle holding a usable token."""
+    return CredentialBundle(values={"system_user_token": "tok", **values})
+
+
+def _mocked(monkeypatch, handler) -> Dict[str, Any]:
+    """Point the adapter's HTTP client at a canned responder and capture the
+    request it made."""
+    seen: Dict[str, Any] = {}
+
+    def _capture(request: httpx.Request) -> httpx.Response:
+        """Record the outgoing request, then delegate to the handler."""
+        seen["url"] = str(request.url)
+        seen["headers"] = dict(request.headers)
+        seen["body"] = request.read().decode()
+        return handler(request)
+
+    monkeypatch.setattr(
+        whatsapp_module,
+        "create_http_client",
+        lambda **_: httpx.AsyncClient(transport=httpx.MockTransport(_capture)),
+    )
+    return seen
+
+
+def _responds(status: int, body: Optional[dict] = None, text: Optional[str] = None):
+    """A canned HTTP responder with the given status and body."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        """Test double: canned provider response."""
+        if text is not None:
+            return httpx.Response(status, text=text)
+        return httpx.Response(status, json=body or {})
+
+    return handler
+
+
+async def _deliver(monkeypatch, handler, message=None, binding=None, bundle=None):
+    """Run deliver() against a mocked transport; return (outcome, request seen)."""
+    seen = _mocked(monkeypatch, handler)
+    outcome = await MetaWhatsAppAdapter().deliver(
+        message or _message(), bundle or _bundle(), binding or _binding()
+    )
+    return outcome, seen
+
+
+# --- the request ------------------------------------------------------------
+
+
+async def test_the_send_goes_to_this_bindings_number(monkeypatch) -> None:
+    """The send goes to this bindings number."""
+    # The endpoint is per-endpoint, not per-merchant: two numbers under one
+    # account must not share a URL.
+    _, seen = await _deliver(monkeypatch, _responds(200, ACCEPTED_BODY))
+    assert seen["url"].endswith("/PHONE_NUMBER_ID/messages")
+    assert seen["headers"]["authorization"] == "Bearer tok"
+
+
+async def test_the_recipient_is_sent_without_its_plus(monkeypatch) -> None:
+    """The recipient is sent without its plus."""
+    # Stored E.164, posted Meta-style. The stripped form is never persisted.
+    _, seen = await _deliver(monkeypatch, _responds(200, ACCEPTED_BODY))
+    assert '"to":"919876543210"' in seen["body"].replace(" ", "")
+
+
+async def test_the_body_names_a_template_and_never_a_rendered_string(
+    monkeypatch,
+) -> None:
+    """The body names a template and never a rendered string."""
+    _, seen = await _deliver(monkeypatch, _responds(200, ACCEPTED_BODY))
+    body = seen["body"].replace(" ", "")
+    assert '"type":"template"' in body
+    assert '"name":"order_update_v1"' in body
+    # Values are posted as parameters; we never assemble the sentence.
+    assert '"text":"Priya"' in body
+
+
+def test_numeric_keys_become_positional_parameters_in_numeric_order() -> None:
+    """Numeric keys become positional parameters in numeric order."""
+    # Sorting as strings would put "10" before "2" and silently swap two
+    # values in a customer's message.
+    params = build_parameters({"2": "second", "10": "tenth", "1": "first"})
+    assert isinstance(params, list)
+    assert [p["text"] for p in params] == ["first", "second", "tenth"]
+    assert all("parameter_name" not in p for p in params)
+
+
+def test_named_keys_become_named_parameters() -> None:
+    """Named keys become named parameters."""
+    params = build_parameters({"customer_name": "Priya"})
+    assert params == [
+        {"type": "text", "parameter_name": "customer_name", "text": "Priya"}
+    ]
+
+
+def test_no_variables_means_no_components() -> None:
+    """No variables means no components."""
+    assert build_parameters({}) == []
+
+
+def test_mixed_key_styles_are_refused_not_guessed() -> None:
+    """Mixed key styles are refused not guessed."""
+    # Meta takes positional OR named per request, never both. The old
+    # behaviour guessed named — emitting parameter_name='1' — and spent a
+    # network round trip to receive the refusal this defect already states.
+    defect = build_parameters({"1": "x", "otp": "y"})
+    assert isinstance(defect, str)
+    assert "mixes" in defect
+
+
+def test_untextable_values_are_refused_not_coerced() -> None:
+    """Untextable values are refused not coerced."""
+    # str() rendered a JSON null as the literal word 'None' inside the
+    # customer's message — corruption that LOOKS delivered. Numbers keep
+    # their one obvious text form; everything else is a producer bug this
+    # refusal surfaces.
+    ok = build_parameters({"1": "Priya", "2": 42, "3": 9.5})
+    assert ok == [
+        {"type": "text", "text": "Priya"},
+        {"type": "text", "text": "42"},
+        {"type": "text", "text": "9.5"},
+    ]
+    for bad in (None, True, ["a"], {"a": 1}):
+        defect = build_parameters({"1": "Priya", "2": bad})
+        assert isinstance(defect, str), bad
+        assert "'2'" in defect
+
+
+def test_a_variable_defect_names_the_key_and_type_never_the_value() -> None:
+    """A variable defect names the key and type never the value."""
+    # Variable values can be personal data, and the defect string is
+    # destined for a log line.
+    defect = build_parameters({"otp": ["123456"]})
+    assert isinstance(defect, str)
+    assert "otp" in defect and "list" in defect
+    assert "123456" not in defect
+
+
+def test_a_unicode_digit_key_is_a_name_not_a_crash() -> None:
+    """A unicode digit key is a name not a crash."""
+    # '²'.isdigit() is True but int('²') raises: sorting by int() turned this
+    # legal jsonb key into a mid-send exception that burned every attempt as
+    # 'send_error'. As a (doomed) NAME, Meta's refusal is a classified,
+    # terminal answer instead.
+    assert build_parameters({"²": "x"}) == [
+        {"type": "text", "parameter_name": "²", "text": "x"}
+    ]
+
+
+async def test_mixed_variables_are_blocked_before_posting(monkeypatch) -> None:
+    """Mixed variables are blocked before posting — OUR refusal, not Meta's."""
+    seen = _mocked(monkeypatch, _responds(200, ACCEPTED_BODY))
+    outcome = await MetaWhatsAppAdapter().deliver(
+        _message(variables={"1": "x", "otp": "y"}), _bundle(), _binding()
+    )
+    assert outcome.status == "blocked"
+    assert outcome.reason == "template_variables_invalid"
+    assert outcome.retryable is False
+    # Nothing was posted: no rendering of a mixed dict is the right one.
+    assert seen == {}
+
+
+async def test_a_null_variable_is_blocked_before_posting(monkeypatch) -> None:
+    """A null variable is blocked before posting — OUR refusal, not Meta's."""
+    seen = _mocked(monkeypatch, _responds(200, ACCEPTED_BODY))
+    outcome = await MetaWhatsAppAdapter().deliver(
+        _message(variables={"1": "Priya", "2": None}), _bundle(), _binding()
+    )
+    assert outcome.status == "blocked"
+    assert outcome.reason == "template_variables_invalid"
+    assert outcome.retryable is False
+    # Nothing was posted: 'Hi Priya, your order None…' must never exist.
+    assert seen == {}
+
+
+def test_the_language_comes_from_the_binding(monkeypatch) -> None:
+    """The language comes from the binding."""
+    # A per-endpoint fact: one merchant's templates may be approved in a
+    # different locale from another's.
+    adapter = MetaWhatsAppAdapter()
+    parameters = build_parameters(_message().variables)
+    assert isinstance(parameters, list)
+    payload = adapter.build_payload(
+        _message(),
+        "919876543210",
+        _binding(capabilities={"template_language": "hi"}),
+        parameters,
+    )
+    assert payload["template"]["language"]["code"] == "hi"
+    default = adapter.build_payload(_message(), "919876543210", _binding(), parameters)
+    assert default["template"]["language"]["code"] == "en_US"
+
+
+# --- refusals that never reach the network ----------------------------------
+
+
+async def test_a_bundle_without_a_token_is_blocked(monkeypatch) -> None:
+    """A missing bundle key is OUR refusal — 'blocked', the same status this
+    reason carries from resolve_send_route, never Meta's word 'failed'."""
+    seen = _mocked(monkeypatch, _responds(200, ACCEPTED_BODY))
+    outcome = await MetaWhatsAppAdapter().deliver(
+        _message(), CredentialBundle(values={"app_secret": "x"}), _binding()
+    )
+    assert outcome.status == "blocked"
+    assert outcome.reason == "connector_credential_missing"
+    assert outcome.retryable is False
+    # Nothing was posted: a bundle missing its key cannot be fixed by asking
+    # Meta about it.
+    assert seen == {}
+
+
+async def test_a_message_without_a_template_is_blocked(monkeypatch) -> None:
+    """A message without a template is blocked — terminally, before posting."""
+    seen = _mocked(monkeypatch, _responds(200, ACCEPTED_BODY))
+    outcome = await MetaWhatsAppAdapter().deliver(
+        _message(template_id=None), _bundle(), _binding()
+    )
+    assert outcome.status == "blocked"
+    assert outcome.reason == "template_missing"
+    assert outcome.retryable is False
+    assert seen == {}
+
+
+@pytest.mark.parametrize(
+    "address", ["", "+1234", "not-a-number", "+" + "9" * 20, "+0123456789"]
+)
+async def test_an_unusable_address_is_blocked_before_posting(
+    monkeypatch, address
+) -> None:
+    """An unusable address is blocked before posting — WE refused, Meta never
+    saw it, so the manifest must not show the word reserved for Meta's no."""
+    seen = _mocked(monkeypatch, _responds(200, ACCEPTED_BODY))
+    outcome = await MetaWhatsAppAdapter().deliver(
+        _message(sent_to_address=address), _bundle(), _binding()
+    )
+    assert outcome.status == "blocked"
+    assert outcome.reason == "recipient_address_invalid"
+    assert seen == {}
+
+
+def test_recipient_normalisation_accepts_only_plausible_numbers() -> None:
+    """Recipient normalisation accepts only plausible numbers."""
+    # An Indian mobile is 12 digits in E.164: +91 plus the 10 national ones.
+    assert to_meta_recipient("+91 98765-43210") == "919876543210"
+    assert to_meta_recipient("9" * 16) is None  # past E.164's 15-digit ceiling
+    assert to_meta_recipient("+12345") is None  # 5 digits, below any country
+    assert to_meta_recipient("") is None
+
+
+def test_the_accepted_length_window_matches_what_this_system_stores() -> None:
+    """The accepted length window matches what this system stores."""
+    # normalize.py and the platform_identity CHECK both allow +[1-9][0-9]{6,14}
+    # — 7 to 15 digits. A tighter bound here would reject a number the system
+    # was happy to store, and report it as an invalid address rather than as
+    # the mismatch it is.
+    from app.crm.shared.normalize import _E164
+
+    for length in range(4, 18):
+        stored = "+" + "9" * length
+        assert (_E164.match(stored) is not None) == (
+            to_meta_recipient(stored) is not None
+        ), length
+    # The [1-9] half of the same parity: no country code starts with 0, and
+    # normalize.py refuses to store one — so accepting it here would post a
+    # number the system would never have stored, and report Meta's code
+    # instead of our recipient_address_invalid.
+    assert _E164.match("+0123456789") is None
+    assert to_meta_recipient("+0123456789") is None
+    assert to_meta_recipient("0123456789") is None
+
+
+# --- reading Meta's answer ---------------------------------------------------
+
+
+async def test_an_accepted_send_records_the_wamid(monkeypatch) -> None:
+    """An accepted send records the wamid."""
+    outcome, _ = await _deliver(monkeypatch, _responds(200, ACCEPTED_BODY))
+    assert outcome.status == "accepted"
+    assert outcome.provider_message_id == "wamid.HBgMOTE5ODc2NTQzMjEw"
+
+
+async def test_a_2xx_without_a_wamid_is_still_accepted(monkeypatch) -> None:
+    """A 2xx without a wamid is still accepted."""
+    # Meta took it. Calling this a failure would retry a message the customer
+    # may already have — losing the receipt link is the smaller harm.
+    outcome, _ = await _deliver(monkeypatch, _responds(200, {"messages": []}))
+    assert outcome.status == "accepted"
+    assert outcome.provider_message_id is None
+
+
+@pytest.mark.parametrize("code", sorted(RETRYABLE_CODES))
+async def test_pacing_errors_are_retryable(monkeypatch, code) -> None:
+    """Pacing errors are retryable."""
+    outcome, _ = await _deliver(
+        monkeypatch, _responds(400, {"error": {"code": int(code), "message": "slow"}})
+    )
+    assert outcome.status == "failed"
+    assert outcome.reason == code
+    assert outcome.retryable is True
+    # Pacing is not a verdict on the connection.
+
+
+@pytest.mark.parametrize("code", sorted(TERMINAL_CODES))
+async def test_message_level_refusals_never_retry(monkeypatch, code) -> None:
+    """Message level refusals never retry."""
+    outcome, _ = await _deliver(
+        monkeypatch, _responds(400, {"error": {"code": int(code), "message": "no"}})
+    )
+    assert outcome.status == "failed"
+    # The provider's own code, verbatim: a merchant asking "why" gets an
+    # answer that matches Meta's documentation.
+    assert outcome.reason == code
+    assert outcome.retryable is False
+
+
+@pytest.mark.parametrize("code", sorted(CREDENTIAL_CODES))
+async def test_credential_refusals_flag_the_connection(monkeypatch, code) -> None:
+    """Credential refusals flag the connection."""
+    outcome, _ = await _deliver(
+        monkeypatch,
+        _responds(401, {"error": {"code": int(code), "message": "bad token"}}),
+    )
+    assert outcome.status == "failed"
+    assert outcome.retryable is False
+    # The provider's code lands on the row verbatim. That IS the signal the
+    # channel module watches to decide the connection needs re-authenticating
+    # — the send path deliberately does not act on it itself.
+    assert outcome.reason == code
+
+
+async def test_a_429_without_a_code_is_still_retryable(monkeypatch) -> None:
+    """A 429 without a code is still retryable."""
+    outcome, _ = await _deliver(monkeypatch, _responds(429, {}))
+    assert outcome.retryable is True
+
+
+async def test_an_unknown_5xx_is_retryable_and_an_unknown_4xx_is_not(
+    monkeypatch,
+) -> None:
+    """An unknown 5xx is retryable and an unknown 4xx is not."""
+    # Meta's problem may pass; ours will not, and three attempts would learn
+    # nothing.
+    server, _ = await _deliver(monkeypatch, _responds(503, {}))
+    assert server.retryable is True
+    assert server.reason == "http_503"
+
+    client, _ = await _deliver(
+        monkeypatch, _responds(400, {"error": {"code": 999999, "message": "?"}})
+    )
+    assert client.retryable is False
+    assert client.reason == "999999"
+
+
+async def test_a_provider_error_echoing_the_recipient_never_reaches_the_log(
+    monkeypatch,
+) -> None:
+    """A provider error echoing the recipient never reaches the log."""
+    # Meta's catalog strings carry no values today. This pins that even if
+    # that contract breaks — or a proxy rewrites the body — the echoed
+    # number dies at the log boundary, while the code survives for
+    # classification and support.
+    lines = []
+
+    class _Recorder:
+        def warning(self, msg):
+            """Collect the log line."""
+            lines.append(msg)
+
+        def error(self, msg):
+            """Collect the log line."""
+            lines.append(msg)
+
+        def info(self, msg):
+            """Collect the log line."""
+            lines.append(msg)
+
+    monkeypatch.setattr(whatsapp_module, "logger", _Recorder())
+    outcome, _ = await _deliver(
+        monkeypatch,
+        _responds(
+            400,
+            {"error": {"code": 100, "message": "Invalid parameter: to=919876543210"}},
+        ),
+    )
+    assert outcome.reason == "100"
+    joined = " ".join(lines)
+    assert "919876543210" not in joined
+    assert "code=100" in joined
+
+
+async def test_a_non_json_response_does_not_crash_the_worker(monkeypatch) -> None:
+    """A non json response does not crash the worker."""
+    # A load balancer returning HTML must degrade to "failed, no detail",
+    # not raise a JSONDecodeError that reads like a code bug.
+    outcome, _ = await _deliver(
+        monkeypatch, _responds(502, text="<html>bad gateway</html>")
+    )
+    assert outcome.status == "failed"
+    assert outcome.retryable is True
+
+
+@pytest.mark.parametrize(
+    "error",
+    [httpx.ConnectError("refused"), httpx.ReadTimeout("slow"), httpx.PoolTimeout("x")],
+)
+async def test_a_transport_failure_is_retryable(monkeypatch, error) -> None:
+    """A transport failure is retryable."""
+
+    # "No answer" is not "no": the provider may have taken it.
+    def handler(request: httpx.Request) -> httpx.Response:
+        """Test double: canned provider response."""
+        raise error
+
+    outcome, _ = await _deliver(monkeypatch, handler)
+    assert outcome.status == "failed"
+    assert outcome.reason == "transport_error"
+    assert outcome.retryable is True
+
+
+# --- the classification table itself ----------------------------------------
+
+
+def test_no_error_code_is_claimed_by_two_classes() -> None:
+    """No error code is claimed by two classes."""
+    # An overlap would make the outcome depend on the order of the branches
+    # in read_response, which is exactly the kind of bug that shows up as
+    # "sometimes it retries".
+    assert RETRYABLE_CODES & TERMINAL_CODES == set()
+    assert RETRYABLE_CODES & CREDENTIAL_CODES == set()
+    assert TERMINAL_CODES & CREDENTIAL_CODES == set()
+
+
+def test_the_endpoint_is_built_from_the_configured_dials() -> None:
+    """The endpoint is built from the configured dials."""
+    adapter = MetaWhatsAppAdapter(
+        base_url="http://localhost:9999/", api_version="v99.0"
+    )
+    assert adapter.endpoint("PN1") == "http://localhost:9999/v99.0/PN1/messages"
+
+
+def test_a_malformed_address_cannot_become_url_structure() -> None:
+    """A malformed address cannot become url structure."""
+    # The address column has no format CHECK and no writer validates it. A
+    # '/' or '?' in a bad row must stay inside its one path segment — the
+    # alternative posts the merchant's bearer token to whatever Graph path
+    # the junk spells out.
+    adapter = MetaWhatsAppAdapter(base_url="http://stub", api_version="v23.0")
+    assert (
+        adapter.endpoint("123/other?x=")
+        == "http://stub/v23.0/123%2Fother%3Fx%3D/messages"
+    )
+
+
+async def test_a_control_character_address_does_not_escape_deliver(
+    monkeypatch,
+) -> None:
+    """A control character address does not escape deliver."""
+    # Unquoted, a '\n' in the address raised httpx.InvalidURL — which is not
+    # an httpx.HTTPError — straight past the transport catch, and the row
+    # burned every attempt as 'send_error'. Quoted, the request is made and
+    # Meta's refusal comes back as a classified, terminal outcome.
+    outcome, seen = await _deliver(
+        monkeypatch,
+        _responds(400, {"error": {"code": 100, "message": "no"}}),
+        binding=_binding(address="PN\n1"),
+    )
+    assert outcome.status == "failed"
+    assert outcome.reason == "100"
+    assert outcome.retryable is False
+    assert "/PN%0A1/messages" in seen["url"]


### PR DESCRIPTION
- send() is the module's one seam to the outside world: verify the send
  token, resolve the route (binding -> installation -> credential bundle),
  hand to the channel's adapter.
- The vault is read through app/database's own accessor
  (get_credential_by_id, mask=False, raise_errors=True) — no raw SQL against
  credentials from app/crm. Inactive or undecryptable bundles refuse the
  send terminally; a DB outage on the read raises and retries as send_error
  instead of terminally blocking the row.
- The gate is a real slice, not a stub: _gate() probes platform suppression
  (fail closed) before every send — suppressed -> blocked/suppressed, a
  channel it cannot check -> blocked/gate_unavailable — and the probe runs
  under its own CRM_MESSAGE_SEND_TIMEOUT_SECONDS deadline, so a hung probe
  cannot stall the batch past the claim lease. may_contact() (B5) replaces
  the gate's body later; the call site never changes.
- OUR refusals land as 'blocked', never 'failed' (T16 col 12): no route, no
  adapter, gate refusal, and every adapter refusal that never reaches Meta
  (missing bundle key, missing template, unusable address, unsendable
  variables). 'failed' is the provider's no; 'dead' is us out of retries.
- One constant (CRM_MESSAGE_SEND_TIMEOUT_SECONDS) bounds the gate probe AND
  the route's DB reads + provider call; test-pinned so a whole worst-case
  batch fits inside the claim lease (CRM_DISPATCH_BATCH x timeout x 2 <=
  lease — the 2 is the real worst case: one timeout in the gate, one in
  send()).
- Channel-agnostic: ChannelAdapter is the parent, the ADAPTERS registry is
  the channel vocabulary in code — a new channel is a file plus a registry
  line, never a migration. Adapter-independent channel metadata (the gate's
  handle kind today; W8 pacing later) lives in one connectivity/channels.py,
  test-pinned ADAPTERS ⊆ CHANNELS. Boundary rule 11 (CI + red test) confines
  providers/ imports to send.py. All REASON_* words live in one reasons.py —
  including the sweep's reclaimed_stale_claim, declared beside its SQL
  literal.
- Adapters only CLASSIFY outcomes; plan_for_outcome in dispatch remains the
  sole retry policy.
- Migration 060: crm_connector_installation (the door) and
  crm_channel_binding (the pipe). credential_id is a FK ON DELETE RESTRICT
  into the vault; partial uniques enforce one primary pipe per (merchant,
  channel) and one live address per channel. The crm_message immutability
  trigger is re-created here to add the binding_id set-once rule (056 is
  merged and never edited).
- Only 'healthy' installations send — fail closed on 'connecting' too:
  onboarding (#1038) verifies against the Graph API and writes rows as
  'healthy' directly, so no first-send bootstrap earns an exception.
- MetaWhatsAppAdapter, straight at the Cloud API: template-only sends,
  E.164 stripped only at Meta's edge, endpoint address URL-quoted.
  Template language rides binding capabilities until T23's registry lands.
- Explicit error-code table: retryable throttles (incl. 4/613/80007, which
  arrive as HTTP 400), terminal refusals, and CREDENTIAL_CODES named
  separately as the signal the future channel-lifecycle module watches on
  crm_message.reason.
- Unexpected escapes become a retryable send_error outcome instead of a
  raise; outcome writes are pinned to the claim's attempt, so a reclaimed
  row's late outcome misses instead of overwriting the new claim's.
- Stale-claim sweep applies the attempt ceiling: a row whose outcome can
  never be recorded dies as max_attempts_exhausted instead of being re-sent
  on every sweep window forever.
- credentials: deleting a vault row a connector uses is refused — the
  accessor translates the FK violation into a domain CredentialInUseError
  and the handler answers 409 without importing asyncpg; DB outages on
  delete re-raise instead of reporting 404; delete logs bind credential_id
  as a structured field.
- Logged addresses pass through one channel-keyed mask, self-contained in
  crm/shared/redact.py (rendering identical to the voice path's
  mask_phone); a channel without a rule masks everything.
- New env dials: META_WHATSAPP_GRAPH_BASE_URL / _VERSION (point at a local
  stub to run the pipeline offline), CRM_MESSAGE_SEND_TIMEOUT_SECONDS,
  CRM_DISPATCH_BATCH, CRM_DISPATCH_STALE_MINUTES.
- New tests: adapter response matrix over a mocked transport, DDL
  assertions, token/registry/route/timeout refusals, gate/blocked behaviour
  (incl. a hung suppression probe and a vault outage), sweep and
  credential-delete behaviour, boundary red tests.
- Cloud API payload shape cherry-picked from Moni's #860/#881, rewritten
  onto create_http_client and this module's outcome classification.


dev proof:
### Note: tested using mocked meta apis
<img width="1027" height="681" alt="Screenshot 2026-08-30 at 10 16 54 PM" src="https://github.com/user-attachments/assets/4aaad9fb-20d9-4cde-a96f-cb25d1d30c19" />
<img width="2773" height="965" alt="Screenshot 2026-08-30 at 10 14 29 PM" src="https://github.com/user-attachments/assets/c73d499a-0767-4982-8194-06a089e67c78" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added outbound WhatsApp message delivery through Meta’s WhatsApp Cloud API.
  * Added connector and channel configuration for provider accounts, endpoints, templates, credentials, and delivery status.
  * Added configurable sending timeouts, batching, retries, and maximum delivery attempts.

* **Bug Fixes**
  * Prevented stale workers from overwriting newer delivery results.
  * Messages exceeding retry limits are now marked failed instead of retried indefinitely.
  * Credential deletion now clearly reports when a credential is still in use.

* **Security**
  * Sensitive credentials and contact details are protected from appearing in logs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->