### PR TITLE
feat(chameleon): merchant custom components + template-defined direct intents

### DIFF
--- a/app/ai/voice/agents/breeze_buddy/chat/agent/core.py
+++ b/app/ai/voice/agents/breeze_buddy/chat/agent/core.py
@@ -51,7 +51,10 @@ from app.ai.voice.agents.breeze_buddy.mcp import (
     close_mcp_pool,
 )
 from app.ai.voice.agents.breeze_buddy.template.approval import build_approval_map
-from app.ai.voice.agents.breeze_buddy.template.types import TemplateModel
+from app.ai.voice.agents.breeze_buddy.template.types import (
+    CustomComponentDef,
+    TemplateModel,
+)
 from app.ai.voice.agents.breeze_buddy.template.ui_catalog import (
     CATALOG_VERSION_V2,
     data_bound_names,
@@ -143,6 +146,7 @@ class ChatAgent(
         context_placement: Optional[str] = None,
         catalog_version: Optional[str] = None,
         merchant_id: Optional[str] = None,
+        custom_components: Optional[Dict[str, "CustomComponentDef"]] = None,
     ) -> None:
         self.session_id = session_id
         self.template = template
@@ -253,6 +257,17 @@ class ChatAgent(
         self._catalog_v2 = catalog_version == CATALOG_VERSION_V2
         if not self._catalog_v2:
             self._ui_allowlist -= data_bound_names()
+        # CHAMELEON session overlay: this template's resolved registry
+        # component defs (ui_component rows named in
+        # ``ui_catalog.custom_components``). Session DATA, never a catalog
+        # mutation — two merchants on one worker never see each other's
+        # defs. v2/render_ui-only, so the overlay joins the allowlist
+        # AFTER the catalog-version prune above (v1/voice sessions carry
+        # no custom defs at all).
+        self._custom_defs: Dict[str, "CustomComponentDef"] = (
+            dict(custom_components) if (custom_components and self._catalog_v2) else {}
+        )
+        self._ui_allowlist |= set(self._custom_defs)
         # Per-turn record of successful post-pipeline tool results, keyed
         # (tool_name, tool_use_id) — what `show`-op bindings resolve
         # against. Populated in _cycle_loop after each ungated dispatch;

--- a/app/ai/voice/agents/breeze_buddy/chat/agent/render_ui.py
+++ b/app/ai/voice/agents/breeze_buddy/chat/agent/render_ui.py
@@ -152,7 +152,11 @@ class RenderUiHandlerMixin:
             # Componentless chips call is the canonical chips-cycle shape
             # now that QuickReplies left the schema enum.
             raw_args["component"] = "QuickReplies"
-        components = render_ui_components(self._ui_allowlist, self._catalog_v2)
+        components = render_ui_components(
+            self._ui_allowlist,
+            self._catalog_v2,
+            custom_components=set(self._custom_defs),
+        )
         if self._quick_replies_mode == "off":
             components = [c for c in components if c != "QuickReplies"]
         if chips_cycle:
@@ -183,6 +187,7 @@ class RenderUiHandlerMixin:
             template=self.template,
             state_values=self.agent_state,
             flavor_groups=self._ui_flavor_groups,
+            custom_defs=self._custom_defs,
         )
         if outcome.decision == "rendered" and outcome.component and outcome.ops:
             # Repeat-render merge is FLAVOR policy (commerce: a second

--- a/app/ai/voice/agents/breeze_buddy/chat/agent/runtime.py
+++ b/app/ai/voice/agents/breeze_buddy/chat/agent/runtime.py
@@ -3,6 +3,7 @@ pure helpers, and the small per-turn dataclasses. No agent state —
 everything here is importable by every sibling mixin module without
 cycles."""
 
+import re
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -52,19 +53,34 @@ _ANSWER_NUDGE = (
 )
 
 
+_IDENTIFIER_CHIP_RE = re.compile(
+    r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+    r"|\b[0-9a-f]{16,}\b",
+    re.IGNORECASE,
+)
+
+
 def _chip_labels(raw: Any) -> List[str]:
     """Lift a `quick_replies` arg (strings canonical; {'label': …} dicts
     tolerated) into clean labels — same tolerance as execute_render_ui's
-    extraction, kept tiny here for the rider-harvest path."""
+    extraction, kept tiny here for the rider-harvest path.
+
+    Labels carrying raw identifiers (UUIDs / long hex ids) are DROPPED —
+    a chip is user-facing copy, and an id in one is always a model
+    mistake (live-observed: "Select <journey uuid>" chips); ids belong in
+    UI actions' `msg`, never on a pill."""
     if not isinstance(raw, list):
         return []
     labels: List[str] = []
     for entry in raw:
+        label = None
         if isinstance(entry, str) and entry.strip():
-            labels.append(entry.strip())
+            label = entry.strip()
         elif isinstance(entry, dict) and isinstance(entry.get("label"), str):
             if entry["label"].strip():
-                labels.append(entry["label"].strip())
+                label = entry["label"].strip()
+        if label and not _IDENTIFIER_CHIP_RE.search(label):
+            labels.append(label)
     return labels[:5]
 
 

--- a/app/ai/voice/agents/breeze_buddy/chat/agent/tooling.py
+++ b/app/ai/voice/agents/breeze_buddy/chat/agent/tooling.py
@@ -152,7 +152,11 @@ class ToolDispatchMixin:
         # approval-gated; neither is read_only (so they never fan out —
         # ordering with sibling calls is meaningful).
         if self._render_ui_enabled:
-            rui_components = render_ui_components(self._ui_allowlist, self._catalog_v2)
+            rui_components = render_ui_components(
+                self._ui_allowlist,
+                self._catalog_v2,
+                custom_components=set(self._custom_defs),
+            )
             if self._quick_replies_mode == "off":
                 # quick_replies='off': the component vanishes from the
                 # schema enum and docs; execute rejects it as unknown.
@@ -165,6 +169,11 @@ class ToolDispatchMixin:
                         trusted_urls=sorted(self._trusted_link_urls),
                         quick_replies_mode=self._quick_replies_mode,
                         flavor_groups=self._ui_flavor_groups,
+                        custom_coaching={
+                            name: d.prompt_hint
+                            for name, d in self._custom_defs.items()
+                            if d.prompt_hint
+                        },
                     )
                 )
         if self._plan_enforcement:

--- a/app/ai/voice/agents/breeze_buddy/chat/custom_components.py
+++ b/app/ai/voice/agents/breeze_buddy/chat/custom_components.py
@@ -1,0 +1,97 @@
+"""Session-start resolution of a template's custom-component defs.
+
+Reads ``configurations.ui_catalog.custom_components`` (opt-in names) and
+fetches the matching active ``ui_component`` rows scoped to the template's
+reseller/merchant. Missing or inactive names are skipped with a warning —
+a stale template narrows its catalog, it never fails the turn.
+
+One indexed SELECT per turn; rows are immutable per version so a cache can
+be added later without changing callers. Best-effort: any DB error resolves
+to an empty overlay (the session degrades to built-ins, never breaks).
+"""
+
+from typing import Dict
+
+from pydantic import ValidationError
+
+from app.ai.voice.agents.breeze_buddy.template.types import (
+    CustomComponentDef,
+    CustomComponentFlags,
+    TemplateModel,
+)
+from app.core.logger import logger
+from app.database.accessor.breeze_buddy.ui_component import (
+    get_ui_components_by_names,
+)
+
+
+def model_renderable(
+    defs: Dict[str, CustomComponentDef],
+) -> Dict[str, CustomComponentDef]:
+    """The subset the MODEL may render in-thread via render_ui.
+
+    Two exclusions, both mirroring what the widget wire can paint:
+
+    - ``overlay_only`` defs are client-side render targets (opened by an
+      ``open_detail`` / intent action in the widget's detail overlay): they
+      ship on the session surface wire but never join the render_ui enum,
+      coaching, or allowlist — the model cannot paint them in-thread.
+    - defs with NO ``render_def`` (registered for a merchant frontend that
+      renders them itself): ``_custom_components_wire`` never ships them,
+      so offering them to the model would let it persist a ui_op our
+      widget cannot interpret.
+    """
+    return {k: v for k, v in defs.items() if v.render_def and not v.flags.overlay_only}
+
+
+async def resolve_custom_components(
+    template: TemplateModel,
+) -> Dict[str, CustomComponentDef]:
+    """The CHAMELEON overlay for one session: name → resolved def.
+
+    Attribute-tolerant on purpose: the turn path hands this whatever it
+    holds as the template (test doubles included), and a template that
+    never opted in must cost nothing — no DB round-trip, empty overlay.
+    """
+    configurations = getattr(template, "configurations", None)
+    ui_cat = getattr(configurations, "ui_catalog", None)
+    names = list(getattr(ui_cat, "custom_components", None) or [])
+
+    if not names:
+        return {}
+    try:
+        rows = await get_ui_components_by_names(
+            reseller_id=template.reseller_id,
+            merchant_id=template.merchant_id,
+            names=names,
+        )
+    except Exception:
+        logger.opt(exception=True).error(
+            f"custom_components fetch failed for template {template.name!r}; "
+            "session proceeds with built-ins only"
+        )
+        return {}
+    defs: Dict[str, CustomComponentDef] = {}
+    for row in rows:
+        try:
+            defs[row.name] = CustomComponentDef(
+                name=row.name,
+                version=row.version,
+                props_schema=row.props_schema,
+                flags=CustomComponentFlags.model_validate(row.flags or {}),
+                render_def=row.render_def,
+                prompt_hint=row.prompt_hint,
+            )
+        except ValidationError:
+            logger.opt(exception=True).error(
+                f"ui_component {row.name!r} (v{row.version}) has invalid "
+                "flags; skipping"
+            )
+
+    missing = set(names) - set(defs)
+    if missing:
+        logger.warning(
+            f"template {template.name!r} opts into unknown/inactive "
+            f"ui_components {sorted(missing)}; they are skipped"
+        )
+    return defs

--- a/app/ai/voice/agents/breeze_buddy/chat/intents/router.py
+++ b/app/ai/voice/agents/breeze_buddy/chat/intents/router.py
@@ -58,6 +58,9 @@ from pydantic import BaseModel, ConfigDict, Field, ValidationError
 from app.ai.voice.agents.breeze_buddy.chat.agent import ChatAgent
 from app.ai.voice.agents.breeze_buddy.chat.agent.runtime import is_approval_gated
 from app.ai.voice.agents.breeze_buddy.chat.client_context import diff_state_patch
+from app.ai.voice.agents.breeze_buddy.chat.custom_components import (
+    resolve_custom_components,
+)
 from app.ai.voice.agents.breeze_buddy.chat.history.block_codec import (
     assistant_turn_to_blocks,
     internal_text_block,
@@ -70,7 +73,11 @@ from app.ai.voice.agents.breeze_buddy.chat.turn_core import (
     resolve_session_catalog_version,
 )
 from app.ai.voice.agents.breeze_buddy.chat.ui.binding import resolve_show_op
+from app.ai.voice.agents.breeze_buddy.chat.ui.custom_defs import (
+    resolve_custom_show_op,
+)
 from app.ai.voice.agents.breeze_buddy.chat.ui.stream import (
+    OpResult,
     summarize_ui_ops,
     ui_op_dropped_event,
     ui_op_event,
@@ -330,7 +337,10 @@ def _structural_errors(exc: ValidationError) -> List[Dict[str, Any]]:
 
 
 def parse_ui_intent(
-    raw: Dict[str, Any], *, enabled_flavors: Optional[Set[str]] = None
+    raw: Dict[str, Any],
+    *,
+    enabled_flavors: Optional[Set[str]] = None,
+    extra_policies: Optional[Dict[str, IntentPolicy]] = None,
 ) -> ParsedIntent:
     """Validate one raw ``ui_intent`` body against the wire model + the
     per-intent payload schema. Raises :class:`IntentValidationError` (422
@@ -342,6 +352,11 @@ def parse_ui_intent(
     :func:`ensure_flavor_intents` on it first so an enabled flavor's
     intents are actually registered. ``None`` skips the flavor gate
     (trusted/internal callers only).
+
+    ``extra_policies`` — template-defined policies (see
+    ``template_intents.template_intent_policies``). Checked FIRST and
+    exempt from the flavor gate: they exist only for the one template that
+    configured them, which is a stricter scope than any flavor's.
     """
     try:
         wire = UiIntent.model_validate(raw)
@@ -349,6 +364,18 @@ def parse_ui_intent(
         raise IntentValidationError(
             "invalid_intent", "Malformed ui_intent body", _structural_errors(exc)
         ) from exc
+
+    template_policy = (extra_policies or {}).get(wire.intent)
+    if template_policy is not None:
+        try:
+            payload = template_policy.payload_model.model_validate(wire.payload)
+        except ValidationError as exc:
+            raise IntentValidationError(
+                "invalid_intent_payload",
+                f"Invalid payload for intent {wire.intent!r}",
+                _structural_errors(exc),
+            ) from exc
+        return ParsedIntent(intent=wire, policy=template_policy, payload=payload)
 
     policy = INTENT_POLICY.get(wire.intent)
     if policy is None:
@@ -665,12 +692,31 @@ async def run_direct_intent(
         ui_events: List[SSEEvent] = []
         if parsed.policy.show_op is not None:
             show_op = parsed.policy.show_op(final_tool, final_result, agent)
-            resolved = resolve_show_op(
-                show_op,
-                agent.binding_store,
-                agent.ui_allowlist,
-                agent.ui_flavor_groups,
+            # CHAMELEON: a template intent may target a REGISTRY custom
+            # component. Gated on the template's own opt-in list, so no DB
+            # fetch (and no behaviour change) for every flavor intent.
+            component = show_op.get("component")
+            ui_cat = (
+                template.configurations.ui_catalog if template.configurations else None
             )
+            custom_names = set(getattr(ui_cat, "custom_components", None) or [])
+            if isinstance(component, str) and component in custom_names:
+                custom_defs = await resolve_custom_components(template)
+
+                def_ = custom_defs.get(component)
+                if def_ is not None:
+                    resolved = resolve_custom_show_op(
+                        show_op, agent.binding_store, def_
+                    )
+                else:
+                    resolved = OpResult(error=f"custom_def_missing:{component}")
+            else:
+                resolved = resolve_show_op(
+                    show_op,
+                    agent.binding_store,
+                    agent.ui_allowlist,
+                    agent.ui_flavor_groups,
+                )
             if resolved.op is not None:
                 hydrated_ops.append(resolved.op)
                 ui_events.append(ui_op_event(resolved.op))

--- a/app/ai/voice/agents/breeze_buddy/chat/intents/template_intents.py
+++ b/app/ai/voice/agents/breeze_buddy/chat/intents/template_intents.py
@@ -1,0 +1,208 @@
+"""Template-DEFINED direct intents (CHAMELEON).
+
+Flavor packages register compiled-in :class:`IntentPolicy` rows; this module
+builds the config-authored equivalent from
+``configurations.ui_intents.custom`` — each entry becomes an ephemeral
+DIRECT policy whose ``drive`` runs the configured template tools through the
+same persisted pipeline (``inject_tool_args`` → dispatch → result pipeline →
+reducers) and whose ``show_op`` hydrates a REGISTRY custom component against
+this turn's binding store.
+
+Nothing here is transport- or merchant-specific: which tools run, which
+payload keys feed which args, and which component renders are all template
+config. Policies are built per request (cheap — closures over parsed
+config) and passed to ``parse_ui_intent`` as ``extra_policies``; they are
+never written into the process-global flavor registry, so two templates can
+define the same intent name without colliding.
+"""
+
+from typing import Any, AsyncIterator, Dict, Optional, Tuple
+
+from pydantic import BaseModel, ConfigDict
+
+from app.ai.voice.agents.breeze_buddy.chat.intents.router import (
+    IntentPolicy,
+    IntentRoute,
+    ParsedIntent,
+    error_events,
+    run_persisted_tool,
+)
+from app.ai.voice.agents.breeze_buddy.chat.sse import SSEEvent
+from app.ai.voice.agents.breeze_buddy.chat.ui.binding import (
+    parse_bind_ref,
+    resolve_json_pointer,
+)
+from app.ai.voice.agents.breeze_buddy.template.session_state import (
+    _is_tool_success,
+)
+from app.ai.voice.agents.breeze_buddy.template.types import CustomUiIntent
+from app.core.logger import logger
+
+
+class TemplateIntentPayload(BaseModel):
+    """Permissive payload shell for template intents: structural validation
+    is the step config's job (``args_from_payload`` fails closed on any
+    missing key), so the wire gate only enforces object shape."""
+
+    model_config = ConfigDict(extra="allow")
+
+
+def _dig(payload: Dict[str, Any], path: str) -> Any:
+    """Resolve one dot-path into the raw intent payload; None on any miss."""
+    cur: Any = payload
+    for part in path.split("."):
+        if not isinstance(cur, dict) or part not in cur:
+            return None
+        cur = cur[part]
+    return cur
+
+
+def _apply_enrich(agent: Any, cfg: CustomUiIntent) -> None:
+    """Run the config's cross-tool list-marking rules against this turn's
+    binding store, mutating the recorded payloads in place (the store hands
+    back the recorded object, so the show-op resolver sees the marks).
+    Fail-open by contract — enrichment is presentation, never allowed to
+    fail the intent."""
+    for rule in cfg.enrich:
+        try:
+            list_ref = parse_bind_ref(rule.list_ref)
+            equals_ref = parse_bind_ref(rule.equals_ref)
+            if list_ref is None or equals_ref is None:
+                logger.warning(
+                    f"template_intent {cfg.name!r}: enrich rule has a bad "
+                    f"bind ref; skipping"
+                )
+                continue
+            list_payload = agent.binding_store.resolve(
+                list_ref.tool_name, list_ref.tool_use_id
+            )
+            equals_payload = agent.binding_store.resolve(
+                equals_ref.tool_name, equals_ref.tool_use_id
+            )
+            if list_payload is None or equals_payload is None:
+                continue
+            items, found = resolve_json_pointer(list_payload, list_ref.pointer)
+            target, t_found = resolve_json_pointer(equals_payload, equals_ref.pointer)
+            # A null target (the API omitted the selected value) means
+            # "nothing to mark": leave the payload untouched rather than
+            # letting str(None) == str(None) mark every item that lacks
+            # the match field as selected.
+            if not found or not t_found or target is None:
+                continue
+            if not isinstance(items, list):
+                continue
+            marked = 0
+            for item in items:
+                if not isinstance(item, dict):
+                    continue
+                candidate = item.get(rule.match_field)
+                if candidate is not None and str(candidate) == str(target):
+                    item.update(rule.set)
+                    marked += 1
+                else:
+                    item.update(rule.else_set)
+
+            logger.info(
+                f"template_intent {cfg.name!r}: enrich matched {marked}/"
+                f"{len(items)} items on {rule.match_field!r}"
+            )
+        except Exception:  # noqa: BLE001 — decoration, never fatal
+            logger.exception(
+                f"template_intent {cfg.name!r}: enrich rule failed; skipping"
+            )
+
+
+def _make_drive(cfg: CustomUiIntent):
+    async def drive(
+        agent: Any,
+        prep: Any,
+        node: Dict[str, Any],
+        parsed: ParsedIntent,
+        turn_id: str,
+    ) -> AsyncIterator[Tuple[Optional[SSEEvent], Optional[str], Any]]:
+        payload = parsed.intent.payload or {}
+        final_tool: Optional[str] = None
+        final_result: Any = None
+        for step in cfg.steps:
+            args: Dict[str, Any] = dict(step.args)
+            missing = None
+            for arg, key in step.args_from_payload.items():
+                value = _dig(payload, key)
+                if value is None:
+                    missing = key
+                    break
+                args[arg] = value
+            if missing is not None:
+                logger.warning(
+                    f"template_intent {cfg.name!r}: payload key {missing!r} "
+                    f"missing for step {step.tool!r}"
+                )
+                for ev in error_events(
+                    "invalid_intent_payload",
+                    "This action is missing required details. Please try "
+                    "again from a fresh card.",
+                ):
+                    yield ev, None, None
+                return
+            events, result = await run_persisted_tool(
+                agent,
+                tool_name=step.tool,
+                args=args,
+                node=node,
+                prep=prep,
+                turn_id=turn_id,
+            )
+            for ev in events:
+                yield ev, None, None
+            final_tool, final_result = step.tool, result
+            if not _is_tool_success(result):
+                # Surface the failing step as the final pair — the engine
+                # shell renders the typed intent_tool_failed copy.
+                break
+        else:
+            # Every step succeeded — apply the cross-tool marks BEFORE the
+            # engine shell resolves the show op against the store.
+            if cfg.enrich:
+                _apply_enrich(agent, cfg)
+        yield None, final_tool, final_result
+
+    return drive
+
+
+def _make_show_op(cfg: CustomUiIntent):
+    def show_op(tool_name: str, result: Any, agent: Any) -> Dict[str, Any]:
+        # id 'root' — the widget's detail-overlay tree anchors on it.
+        op: Dict[str, Any] = {
+            "op": "show",
+            "id": "root",
+            "component": cfg.component,
+            "bind": dict(cfg.bind),
+        }
+        if cfg.props:
+            op["props"] = dict(cfg.props)
+        return op
+
+    return show_op
+
+
+def template_intent_policies(template: Any) -> Dict[str, IntentPolicy]:
+    """Build the per-request policy map off the template's
+    ``ui_intents.custom`` config. Empty config → empty map (zero cost on
+    every template that never opts in)."""
+    configurations = getattr(template, "configurations", None)
+    ui_intents = getattr(configurations, "ui_intents", None) if configurations else None
+    custom = list(getattr(ui_intents, "custom", None) or [])
+    policies: Dict[str, IntentPolicy] = {}
+    for cfg in custom:
+        policies[cfg.name] = IntentPolicy(
+            route=IntentRoute.DIRECT,
+            payload_model=TemplateIntentPayload,
+            default_display=cfg.display,
+            drive=_make_drive(cfg),
+            show_op=_make_show_op(cfg) if cfg.component else None,
+            silent=cfg.silent,
+        )
+    return policies
+
+
+__all__ = ["TemplateIntentPayload", "template_intent_policies"]

--- a/app/ai/voice/agents/breeze_buddy/chat/turn_core.py
+++ b/app/ai/voice/agents/breeze_buddy/chat/turn_core.py
@@ -29,6 +29,10 @@ from app.ai.voice.agents.breeze_buddy.chat.approvals import (
     claim_tool_approval,
     resolve_dangling_approvals,
 )
+from app.ai.voice.agents.breeze_buddy.chat.custom_components import (
+    model_renderable,
+    resolve_custom_components,
+)
 from app.ai.voice.agents.breeze_buddy.chat.history.block_codec import (
     blocks_to_llm_context_messages,
     repair_dangling_tool_uses,
@@ -122,7 +126,13 @@ def negotiate_catalog(
             list(ui_cat.disabled_primitives or []) if ui_cat is not None else None
         ),
     )
-    if not any(is_data_bound(name) for name in allowlist):
+    # A template is v2-capable when its allowlist carries a data-bound
+    # component OR it opts into registry custom components (CHAMELEON) —
+    # those are data-bound by definition (v1 rejects anything else at
+    # registration) but live outside the process-global catalog, so the
+    # is_data_bound scan can't see them.
+    custom_names = list(getattr(ui_cat, "custom_components", None) or [])
+    if not any(is_data_bound(name) for name in allowlist) and not custom_names:
         return CATALOG_VERSION, []
     flavors = [g for g in (enabled_groups or []) if g in LAZY_GROUPS]
     return CATALOG_VERSION_V2, flavors
@@ -280,6 +290,7 @@ async def run_chat_turn(
         context_placement=context_placement,
         catalog_version=resolve_session_catalog_version(session.metadata),
         merchant_id=session.merchant_id,
+        custom_components=model_renderable(await resolve_custom_components(template)),
     )
     async for event in agent.run_turn(
         user_content=user_content,
@@ -372,6 +383,7 @@ async def run_chat_approval_continuation(
         agent_state=agent_state,
         catalog_version=resolve_session_catalog_version(session.metadata),
         merchant_id=session.merchant_id,
+        custom_components=model_renderable(await resolve_custom_components(template)),
     )
     async for event in agent.run_approval_turn(
         approval=claimed,

--- a/app/ai/voice/agents/breeze_buddy/chat/ui/custom_defs.py
+++ b/app/ai/voice/agents/breeze_buddy/chat/ui/custom_defs.py
@@ -1,0 +1,454 @@
+"""Custom-component registry: write-time guards + session-scoped hydration.
+
+CHAMELEON — merchant-specific components as DATA (``ui_component`` rows,
+migration 070). Two halves, both pure (no DB, no agent state):
+
+- **Registration guards** (:func:`validate_registration`): name shape and
+  built-in collision, JSON-Schema well-formedness, flag rules (v1:
+  data-bound only, no literal fields), and the ``render_def`` grammar lint.
+  The registry API calls this before any write; rejected defs never reach
+  a session.
+- **Hydration** (:func:`resolve_custom_show_op`): mirrors
+  ``binding.resolve_show_op`` for defs that live outside ``UI_CATALOG`` —
+  same BindingStore pointer-walk (THIS turn only), single-object→list
+  lift, ``items[]`` selection, caps — but validates the hydrated props
+  against the def's **JSON Schema** instead of a Pydantic class. Every
+  RFC-001 trust invariant survives: values come only from this turn's
+  validated tool results; the model authors selectors, never values.
+
+Isolation: nothing here is process-global. Defs arrive per-session on the
+``ChatAgent`` (``custom_components`` constructor arg) — two merchants on
+the same worker never see each other's definitions.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Dict, List, Optional
+
+from jsonschema import Draft202012Validator
+from jsonschema.exceptions import SchemaError
+
+from app.ai.voice.agents.breeze_buddy.chat.ui.binding import (
+    parse_bind_ref,
+    resolve_json_pointer,
+)
+from app.ai.voice.agents.breeze_buddy.chat.ui.stream import OpResult
+from app.ai.voice.agents.breeze_buddy.template.types import CustomComponentDef
+from app.ai.voice.agents.breeze_buddy.template.ui_catalog import (
+    LAZY_GROUPS,
+    UI_CATALOG,
+    ensure_group_loaded,
+)
+
+# ---------------------------------------------------------------------------
+# render_def grammar v1 (shared contract with the widget's declarative
+# interpreter — packages/breeze-buddy-assist-widget declarative module)
+# ---------------------------------------------------------------------------
+
+# Structural node vocabulary. The interpreter drops unknown types at render
+# time (never heals); the lint rejects them at write time so authors find
+# out immediately.
+RENDER_DEF_NODE_TYPES = frozenset(
+    {
+        "box",  # container; props.direction: row|col, gap, wrap, align
+        "row",  # sugar: box direction=row
+        "col",  # sugar: box direction=col
+        "text",  # props.value (interpolatable), props.variant
+        "badge",  # small emphasized text chip; props.value, props.tone
+        "chip",  # alias of badge with pill styling
+        "image",  # props.src (interpolatable), props.alt
+        "button",  # props.label, props.variant, props.action
+        "divider",
+    }
+)
+
+RENDER_DEF_MAX_DEPTH = 8
+RENDER_DEF_MAX_NODES = 400
+
+_NAME_RE = re.compile(r"^[A-Z][A-Za-z0-9]{1,63}$")
+_BINDING_RE = re.compile(r"^\$[A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z0-9_]+)*$")
+_ACTION_TYPES = frozenset({"to_assistant", "open_url", "open_detail", "intent"})
+
+
+def _lint_action(action: Any, path: str, errors: List[str]) -> None:
+    if not isinstance(action, dict):
+        errors.append(f"{path}: action must be an object")
+        return
+    a_type = action.get("type")
+    if a_type not in _ACTION_TYPES:
+        errors.append(f"{path}: action.type must be one of {sorted(_ACTION_TYPES)}")
+        return
+    if a_type == "to_assistant":
+        if not isinstance(action.get("msg"), str) or not action["msg"].strip():
+            errors.append(f"{path}: to_assistant action needs a non-empty msg")
+    if a_type == "open_url":
+        url = action.get("url")
+        if not isinstance(url, str) or not url:
+            errors.append(f"{path}: open_url action needs a url")
+        # A static URL must be https; a bound/interpolated URL resolves to
+        # tool data at render time (the interpreter re-checks scheme).
+        elif "{" not in url and not url.startswith("$"):
+            if not url.startswith("https://"):
+                errors.append(f"{path}: static open_url urls must be https")
+    if a_type == "open_detail":
+        # Opens the widget's detail overlay rendering ANOTHER registry
+        # component with props hydrated CLIENT-side from the current
+        # scope. The component name must be a static PascalCase name —
+        # never a binding — so data can't choose which def paints
+        # full-page; the widget additionally drops names not in the
+        # session's def registry.
+        component = action.get("component")
+        if not isinstance(component, str) or not _NAME_RE.match(component):
+            errors.append(
+                f"{path}: open_detail action needs a static PascalCase component"
+            )
+        props = action.get("props")
+        if props is not None and not isinstance(props, dict):
+            errors.append(f"{path}: open_detail action props must be an object")
+        title = action.get("title")
+        if title is not None and not isinstance(title, str):
+            errors.append(f"{path}: open_detail action title must be a string")
+    if a_type == "intent":
+        # Fires a template-defined DIRECT ui_intent (see
+        # UiIntentsConfig.custom) and — when `component` is present —
+        # opens the detail overlay armed to hydrate with that component.
+        # Same static-PascalCase rule as open_detail: data must never
+        # choose which def paints full-page.
+        name = action.get("name")
+        if not isinstance(name, str) or not name.strip():
+            errors.append(f"{path}: intent action needs a non-empty name")
+        component = action.get("component")
+        if component is not None and (
+            not isinstance(component, str) or not _NAME_RE.match(component)
+        ):
+            errors.append(
+                f"{path}: intent action component must be a static " "PascalCase name"
+            )
+        payload = action.get("payload")
+        if payload is not None and not isinstance(payload, dict):
+            errors.append(f"{path}: intent action payload must be an object")
+        title = action.get("title")
+        if title is not None and not isinstance(title, str):
+            errors.append(f"{path}: intent action title must be a string")
+
+
+def _lint_node(
+    node: Any, depth: int, path: str, counter: List[int], errors: List[str]
+) -> None:
+    if counter[0] > RENDER_DEF_MAX_NODES:
+        return  # already reported
+    if depth > RENDER_DEF_MAX_DEPTH:
+        errors.append(f"{path}: exceeds max depth {RENDER_DEF_MAX_DEPTH}")
+        return
+    if not isinstance(node, dict):
+        errors.append(f"{path}: node must be an object")
+        return
+    counter[0] += 1
+    if counter[0] > RENDER_DEF_MAX_NODES:
+        errors.append(f"render_def exceeds {RENDER_DEF_MAX_NODES} nodes")
+        return
+    n_type = node.get("type")
+    if n_type not in RENDER_DEF_NODE_TYPES:
+        errors.append(
+            f"{path}: unknown node type {n_type!r} "
+            f"(allowed: {sorted(RENDER_DEF_NODE_TYPES)})"
+        )
+    repeat = node.get("repeat")
+    if repeat is not None:
+        if not isinstance(repeat, dict):
+            errors.append(f"{path}: repeat must be an object")
+        else:
+            src = repeat.get("in")
+            if not (isinstance(src, str) and _BINDING_RE.match(src)):
+                errors.append(
+                    f"{path}: repeat.in must be a binding like '$props.journeys'"
+                )
+            as_name = repeat.get("as")
+            if not (
+                isinstance(as_name, str) and re.match(r"^[a-z][A-Za-z0-9_]*$", as_name)
+            ):
+                errors.append(f"{path}: repeat.as must be a lowercase identifier")
+    cond = node.get("if")
+    if cond is not None and not (isinstance(cond, str) and _BINDING_RE.match(cond)):
+        errors.append(f"{path}: 'if' must be a binding like '$item.route'")
+    cls = node.get("class")
+    if cls is not None and not isinstance(cls, str):
+        errors.append(f"{path}: class must be a string")
+    props = node.get("props")
+    if props is not None and not isinstance(props, dict):
+        errors.append(f"{path}: props must be an object")
+    if isinstance(props, dict) and "action" in props:
+        _lint_action(props["action"], f"{path}.props.action", errors)
+    children = node.get("children")
+    if children is not None:
+        if not isinstance(children, list):
+            errors.append(f"{path}: children must be an array")
+        else:
+            for i, child in enumerate(children):
+                _lint_node(child, depth + 1, f"{path}.children[{i}]", counter, errors)
+
+
+def lint_render_def(render_def: Any) -> List[str]:
+    """Lint a render_def tree. Empty list = clean.
+
+    Grammar v1: whitelisted node types, ``repeat``/``if`` binding syntax,
+    depth ≤ {depth}, ≤ {nodes} nodes, actions restricted to
+    ``to_assistant``/``open_url``/``open_detail``/``intent`` (static
+    open_url URLs https-only; open_detail/intent components static
+    PascalCase). No
+    merchant JavaScript, no arbitrary expressions — ever.
+    """.format(depth=RENDER_DEF_MAX_DEPTH, nodes=RENDER_DEF_MAX_NODES)
+    errors: List[str] = []
+    _lint_node(render_def, 1, "$", [0], errors)
+    return errors
+
+
+# ---------------------------------------------------------------------------
+# Registration guards (write path)
+# ---------------------------------------------------------------------------
+
+
+def builtin_component_names() -> set:
+    """Every name a custom component may NOT take: the full built-in
+    catalog including every lazy flavor group — each group is loaded at
+    check time, so the check can't pass just because commerce hasn't been
+    imported yet in this process."""
+    for group in LAZY_GROUPS:
+
+        ensure_group_loaded(group)
+    return set(UI_CATALOG.keys())
+
+
+def validate_registration(
+    *,
+    name: str,
+    props_schema: Dict[str, Any],
+    flags: Dict[str, Any],
+    render_def: Optional[Dict[str, Any]],
+) -> List[str]:
+    """All write-time guard errors for one registration. Empty = accept."""
+    errors: List[str] = []
+    if not _NAME_RE.match(name or ""):
+        errors.append(
+            "name must be PascalCase (letters/digits, starting uppercase, "
+            "2-64 chars)"
+        )
+    elif name in builtin_component_names():
+        errors.append(f"name {name!r} collides with a built-in component")
+
+    try:
+        Draft202012Validator.check_schema(props_schema)
+    except SchemaError as exc:
+        errors.append(f"props_schema is not valid JSON Schema: {exc.message}")
+
+    if flags.get("data_bound") is False:
+        errors.append("flags.data_bound must be true in v1 (data-bound only)")
+    if flags.get("literal_fields"):
+        # v1: no literal fields — the engine's fail-closed gate would drop
+        # them anyway (no flavor verifier exists for custom components).
+        errors.append("flags.literal_fields is not supported for custom components")
+    sel = flags.get("selection_field")
+    if sel is not None and not isinstance(sel, str):
+        errors.append("flags.selection_field must be a string prop name")
+    list_props = flags.get("list_props")
+    if list_props is not None and not (
+        isinstance(list_props, list) and all(isinstance(p, str) for p in list_props)
+    ):
+        errors.append("flags.list_props must be a list of prop names")
+    for cap in ("max_items_default", "max_items_limit"):
+        value = flags.get(cap)
+        if value is not None and not (isinstance(value, int) and value > 0):
+            errors.append(f"flags.{cap} must be a positive integer")
+    if flags.get("overlay_only") and render_def is None:
+        # overlay_only removes the def from the model's vocabulary, so a
+        # render_def is its ONLY way to ever paint — without one the row
+        # is dead weight on every session surface.
+        errors.append("flags.overlay_only requires a render_def")
+
+    if render_def is not None:
+        errors.extend(lint_render_def(render_def))
+    return errors
+
+
+# ---------------------------------------------------------------------------
+# Hydration (render path) — mirrors binding.resolve_show_op
+# ---------------------------------------------------------------------------
+
+
+def _schema_expects_list(props_schema: Dict[str, Any], prop: str) -> bool:
+    """True when the def's schema types ``prop`` as an array (drives the
+    single-object→list lift, mirroring the Pydantic-annotation check)."""
+    spec = (props_schema.get("properties") or {}).get(prop)
+    if not isinstance(spec, dict):
+        return False
+    s_type = spec.get("type")
+    if s_type == "array":
+        return True
+    if isinstance(s_type, list) and "array" in s_type:
+        return True
+    return any(
+        isinstance(variant, dict) and variant.get("type") == "array"
+        for variant in (spec.get("anyOf") or []) + (spec.get("oneOf") or [])
+    )
+
+
+def _apply_selection(
+    hydrated: Dict[str, Any],
+    def_: CustomComponentDef,
+) -> None:
+    """Model-directed ``items[]`` selection over the def's list props —
+    id-matching only, selection order, fail-open on zero matches (the
+    full tool list beats an empty render on a model-mangled id).
+    Runs before capping; the selection directive itself is popped from
+    the output by the caller."""
+    sel_field = def_.flags.selection_field
+    if not sel_field:
+        return
+    raw = hydrated.get(sel_field)
+    if not isinstance(raw, list):
+        return
+    ids: List[str] = []
+    for entry in raw:
+        if isinstance(entry, str) and entry:
+            ids.append(entry)
+        elif (
+            isinstance(entry, dict) and isinstance(entry.get("id"), str) and entry["id"]
+        ):
+            ids.append(entry["id"])
+    if not ids:
+        return
+    for key in def_.flags.list_props:
+        value = hydrated.get(key)
+        if not isinstance(value, list):
+            continue
+        by_id: Dict[str, Any] = {}
+        for entry in value:
+            if isinstance(entry, dict) and isinstance(entry.get("id"), str):
+                by_id.setdefault(entry["id"], entry)
+        selected = [by_id[i] for i in ids if i in by_id]
+        if selected:
+            hydrated[key] = selected
+
+
+def _apply_caps(hydrated: Dict[str, Any], def_: CustomComponentDef) -> None:
+    """Cap bound list props: op-level ``max_items`` (or the def default),
+    hard-bounded by ``max_items_limit``."""
+    flags = def_.flags
+    raw = hydrated.get("max_items", flags.max_items_default)
+    cap = raw if isinstance(raw, int) and raw > 0 else None
+    if flags.max_items_limit is not None:
+        cap = min(cap, flags.max_items_limit) if cap else flags.max_items_limit
+    if cap is None:
+        return
+    for key in flags.list_props:
+        value = hydrated.get(key)
+        if isinstance(value, list) and len(value) > cap:
+            hydrated[key] = value[:cap]
+
+
+def resolve_custom_show_op(
+    op: Dict[str, Any],
+    store: Any,
+    def_: CustomComponentDef,
+) -> OpResult:
+    """Hydrate one custom-component ``show`` op against this turn's
+    binding store, validated by the def's JSON Schema.
+
+    Same shape and invariants as ``binding.resolve_show_op``; error
+    strings are structural-only (paths + validator names, never values).
+    """
+    bind = op.get("bind") or {}
+    props = op.get("props") or {}
+    hydrated: Dict[str, Any] = dict(props)
+    for prop, ref in bind.items():
+        parsed = parse_bind_ref(ref)
+        if parsed is None:
+            return OpResult(error=f"bad_bind_ref:{prop}")
+        payload = store.resolve(parsed.tool_name, parsed.tool_use_id)
+        if payload is None:
+            return OpResult(
+                error=f"bind_unresolved:{parsed.tool_name}:{parsed.pointer}"
+            )
+        value, found = resolve_json_pointer(payload, parsed.pointer)
+        if not found or value is None:
+            return OpResult(
+                error=f"bind_unresolved:{parsed.tool_name}:{parsed.pointer}"
+            )
+        if isinstance(value, dict) and (
+            prop in def_.flags.list_props
+            or _schema_expects_list(def_.props_schema, prop)
+        ):
+            value = [value]
+        hydrated[prop] = value
+
+    _apply_selection(hydrated, def_)
+    _apply_caps(hydrated, def_)
+
+    # Directives, not render props — keep them out of validation and off
+    # the wire (mirrors resolve_show_op's selection_field pop).
+    sel_field = def_.flags.selection_field
+    if sel_field:
+        hydrated.pop(sel_field, None)
+    hydrated.pop("max_items", None)
+
+    validator = Draft202012Validator(def_.props_schema)
+    schema_errors = sorted(validator.iter_errors(hydrated), key=lambda e: e.json_path)
+    if schema_errors:
+        details = ";".join(
+            f"{err.json_path}:{err.validator}" for err in schema_errors[:5]
+        )
+        return OpResult(error=f"bind_validation_failed:{def_.name}:{details}")
+
+    hydrated_op: Dict[str, Any] = {
+        "op": "add",
+        "id": op.get("id"),
+        "type": def_.name,
+        "props": hydrated,
+        "v": 2,
+    }
+    parent = op.get("parent")
+    if isinstance(parent, str) and parent:
+        hydrated_op["parent"] = parent
+    return OpResult(op=hydrated_op)
+
+
+def summarize_custom_render(
+    def_: CustomComponentDef, hydrated_props: Dict[str, Any]
+) -> Dict[str, Any]:
+    """Function-response summary for a custom render — the model's UI
+    memory. Echoes id/title-ish referents from the def's list props
+    (capped) so cross-turn references ("the second option") keep working,
+    mirroring the commerce summarizer's shape."""
+    result: Dict[str, Any] = {"status": "ok", "rendered": def_.name}
+    for key in def_.flags.list_props:
+        value = hydrated_props.get(key)
+        if not isinstance(value, list):
+            continue
+        result["count"] = len(value)
+        referents: List[Dict[str, Any]] = []
+        for entry in value[:8]:
+            if not isinstance(entry, dict):
+                continue
+            ref: Dict[str, Any] = {}
+            for field in ("id", "title", "name", "summary", "label"):
+                if isinstance(entry.get(field), (str, int, float)):
+                    ref[field] = entry[field]
+            if ref:
+                referents.append(ref)
+        if referents:
+            result[key] = referents
+        break
+    return result
+
+
+__all__ = [
+    "RENDER_DEF_MAX_DEPTH",
+    "RENDER_DEF_MAX_NODES",
+    "RENDER_DEF_NODE_TYPES",
+    "builtin_component_names",
+    "lint_render_def",
+    "resolve_custom_show_op",
+    "summarize_custom_render",
+    "validate_registration",
+]

--- a/app/ai/voice/agents/breeze_buddy/chat/ui/render_ui_tool.py
+++ b/app/ai/voice/agents/breeze_buddy/chat/ui/render_ui_tool.py
@@ -27,6 +27,7 @@ assignment (first rendered op of a turn anchors the widget tree as
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass, field
 from typing import Any, Callable, Dict, List, Optional, Set
 
@@ -41,6 +42,10 @@ from app.ai.voice.agents.breeze_buddy.chat.ui.binding import (
     resolve_show_op,
     selector_extension_keys,
 )
+from app.ai.voice.agents.breeze_buddy.chat.ui.custom_defs import (
+    resolve_custom_show_op,
+    summarize_custom_render,
+)
 from app.ai.voice.agents.breeze_buddy.template.ui_catalog import (
     UI_CATALOG,
     is_data_bound,
@@ -48,6 +53,15 @@ from app.ai.voice.agents.breeze_buddy.template.ui_catalog import (
 )
 
 RENDER_UI_TOOL_NAME = "render_ui"
+
+# Chips carrying raw identifiers are always a model mistake (ids belong
+# in actions' msg, never on a user-facing pill). Shared shape with the
+# rider-harvest guard in agent/runtime.py.
+_IDENTIFIER_CHIP_RE = re.compile(
+    r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+    r"|\b[0-9a-f]{16,}\b",
+    re.IGNORECASE,
+)
 REVISE_PLAN_TOOL_NAME = "revise_plan"
 
 
@@ -155,14 +169,25 @@ class RenderUiOutcome:
     reason: Optional[str] = None
 
 
-def render_ui_components(ui_allowlist: Set[str], catalog_v2: bool) -> List[str]:
+def render_ui_components(
+    ui_allowlist: Set[str],
+    catalog_v2: bool,
+    custom_components: Optional[Set[str]] = None,
+) -> List[str]:
     """The component names ``render_ui`` offers on this session: data-bound,
     allowlisted, not server-only — plus the literal-content components the
     engine keeps model-authored (QuickReplies; LinkButton, whose url is
-    server-verified against trusted/tool-sourced links)."""
+    server-verified against trusted/tool-sourced links).
+
+    ``custom_components`` are this session's registry defs (CHAMELEON
+    overlay) — session data, never catalog entries, so they join the enum
+    here explicitly. v2-only, same as every data-bound component."""
     names: List[str] = []
     if catalog_v2:
         for name in sorted(ui_allowlist):
+            if custom_components and name in custom_components:
+                names.append(name)
+                continue
             schema = UI_CATALOG.get(name)
             if schema is None or not is_data_bound(name):
                 continue
@@ -228,6 +253,7 @@ def build_render_ui_schema(
     trusted_urls: Optional[List[str]] = None,
     quick_replies_mode: Optional[str] = None,
     flavor_groups: Optional[List[str]] = None,
+    custom_coaching: Optional[Dict[str, str]] = None,
 ) -> FlowsFunctionSchema:
     """The ``render_ui`` function schema (Vertex-safe subset: no
     additionalProperties — ``bind`` is an array of {prop, ref} pairs).
@@ -272,6 +298,12 @@ def build_render_ui_schema(
     ).items():
         if comp_name in components:
             bind_desc += sentence
+    # Custom registry defs coach the same way (prompt_hint per offered
+    # component) — a def a template didn't opt into leaves no trace.
+    for comp_name, sentence in (custom_coaching or {}).items():
+        if comp_name in components and sentence:
+            hint = sentence.strip()
+            bind_desc += " " + hint if hint.endswith(".") else " " + hint + "."
     # `fields` is advertised only when an offered component actually
     # declares literal fields — every other session keeps today's schema
     # byte-identical (no arg for the model to misuse).
@@ -526,6 +558,7 @@ def execute_render_ui(
     template: Any = None,
     state_values: Optional[Dict[str, Any]] = None,
     flavor_groups: Optional[List[str]] = None,
+    custom_defs: Optional[Dict[str, Any]] = None,
 ) -> RenderUiOutcome:
     """Run one ``render_ui`` call: validate → hydrate → finalize → summarize.
 
@@ -631,6 +664,13 @@ def execute_render_ui(
                 chip_items.append(
                     {k: v for k, v in entry.items() if k in ("label", "value") and v}
                 )
+        # Chips are user-facing copy: drop any carrying a raw identifier
+        # (UUID / long hex) — same guard as the rider-harvest path.
+        chip_items = [
+            item
+            for item in chip_items
+            if not _IDENTIFIER_CHIP_RE.search(item.get("label", ""))
+        ]
         props["items"] = chip_items
     if component == "LinkButton":
         link = args.get("link")
@@ -684,6 +724,55 @@ def execute_render_ui(
             for k, v in bind_raw.items()
             if isinstance(k, str) and isinstance(v, str)
         }
+
+    if custom_defs and component in custom_defs:
+        # CHAMELEON: session-scoped registry component. Same trust path
+        # (this turn's BindingStore only), hydrated + validated against
+        # the def's JSON Schema instead of a catalog Pydantic class. No
+        # flavor finalize, no literal fields (v1 rejects them at write).
+        def_ = custom_defs[component]
+
+        if not bind:
+            return RenderUiOutcome(
+                fn_result={
+                    "status": "error",
+                    "error": (
+                        f"{component} is data-bound: pass bind, e.g. "
+                        f"{_BIND_EXAMPLE_GENERIC}"
+                    ),
+                },
+                component=component,
+            )
+        show_op: Dict[str, Any] = {
+            "op": "show",
+            "id": op_id,
+            "component": component,
+            "bind": bind,
+            "props": props,
+        }
+        if parent:
+            show_op["parent"] = parent
+        custom_result = resolve_custom_show_op(show_op, store, def_)
+        if custom_result.op is None:
+            return RenderUiOutcome(
+                fn_result={
+                    "status": "error",
+                    "error": (
+                        f"render failed: {custom_result.error}. Bind refs "
+                        "must point into a tool result from THIS turn."
+                    ),
+                },
+                component=component,
+                reason=custom_result.error,
+            )
+        return RenderUiOutcome(
+            fn_result=summarize_custom_render(
+                def_, custom_result.op.get("props") or {}
+            ),
+            ops=[custom_result.op],
+            decision="rendered",
+            component=component,
+        )
 
     if is_data_bound(component):
         if not bind:

--- a/app/ai/voice/agents/breeze_buddy/handlers/transport/http_handler.py
+++ b/app/ai/voice/agents/breeze_buddy/handlers/transport/http_handler.py
@@ -19,6 +19,7 @@ Uses the same resolution pattern as hooks:
 - {placeholder} resolution in http_request config
 """
 
+import asyncio
 import json
 from typing import Any, Dict, Optional, Tuple
 
@@ -39,6 +40,23 @@ from app.ai.voice.agents.breeze_buddy.template.types import (
     SseResponseMode,
 )
 from app.core.logger import logger
+
+
+def _retry_condition_met(response_body: str, cfg: Any) -> bool:
+    """True when the parsed body's `cfg.field` (dotted) equals `cfg.equals`.
+
+    Unparseable / non-dict bodies and missing fields return True — never
+    keep re-requesting something we cannot evaluate.
+    """
+    try:
+        current: Any = json.loads(response_body)
+    except (json.JSONDecodeError, TypeError):
+        return True
+    for key in cfg.field.split("."):
+        if not isinstance(current, dict) or key not in current:
+            return True
+        current = current[key]
+    return bool(current == cfg.equals)
 
 
 async def http_function_handler(
@@ -142,6 +160,38 @@ async def http_function_handler(
             fire_and_forget=False,
             on_sse_event=sse_forwarder,
         )
+
+        # Step 4b: content-conditional re-request (poll-until-ready APIs —
+        # see RetryUntilConfig). Bounded and invisible to the LLM: only the
+        # final response continues down the pipeline. Non-SSE 2xx only, and
+        # GET only — HttpRequestConfig refuses retry_until on mutating
+        # methods at load time, so no re-issue here can repeat a mutation.
+
+        retry_until = config.http_request.retry_until
+        if retry_until is not None:
+            attempt = 1
+            while (
+                attempt < retry_until.max_attempts
+                and result is not None
+                and result != (0, "")
+                and not sse_forwarder.chunks
+                and 200 <= result[0] < 300
+                and not _retry_condition_met(result[1], retry_until)
+            ):
+                logger.info(
+                    f"[{function_name}] retry_until: {retry_until.field!r} not "
+                    f"{retry_until.equals!r} yet — attempt "
+                    f"{attempt + 1}/{retry_until.max_attempts} after "
+                    f"{retry_until.delay_ms}ms"
+                )
+                await asyncio.sleep(retry_until.delay_ms / 1000)
+                result = await executor.execute(
+                    config=config.http_request,
+                    resolved_fields=resolved_fields,
+                    fire_and_forget=False,
+                    on_sse_event=sse_forwarder,
+                )
+                attempt += 1
 
         # Step 5: Handle response
         if result is None or result == (0, ""):

--- a/app/ai/voice/agents/breeze_buddy/handlers/transport/http_requester.py
+++ b/app/ai/voice/agents/breeze_buddy/handlers/transport/http_requester.py
@@ -196,11 +196,23 @@ class HttpRequestExecutor:
                             except ValueError:
                                 pass  # Invalid Content-Length, will check actual size below
 
-                        # Read response with size limit
-                        response_bytes = await response.content.read(
-                            HTTP_REQUEST_MAX_RESPONSE_BYTES + 1
-                        )
-                        if len(response_bytes) > HTTP_REQUEST_MAX_RESPONSE_BYTES:
+                        # Read response to EOF with a size limit. NB: a single
+                        # StreamReader.read(n) can return a PARTIAL body on
+                        # slow/chunked upstreams (observed: 3KB of a 20KB
+                        # long-poll response, truncating the JSON) — so
+                        # accumulate chunks until EOF.
+                        body_chunks = []
+                        bytes_read = 0
+                        while True:
+                            chunk = await response.content.read(65536)
+                            if not chunk:
+                                break
+                            bytes_read += len(chunk)
+                            if bytes_read > HTTP_REQUEST_MAX_RESPONSE_BYTES:
+                                break
+                            body_chunks.append(chunk)
+                        response_bytes = b"".join(body_chunks)
+                        if bytes_read > HTTP_REQUEST_MAX_RESPONSE_BYTES:
                             error_msg = (
                                 f"Response exceeded max size of "
                                 f"{HTTP_REQUEST_MAX_RESPONSE_BYTES} bytes"

--- a/app/ai/voice/agents/breeze_buddy/handlers/transport/utils/field_resolver.py
+++ b/app/ai/voice/agents/breeze_buddy/handlers/transport/utils/field_resolver.py
@@ -142,6 +142,8 @@ class FieldResolver:
             return self._resolve_llm(config, field_name=field_name)
         elif config.source == FieldSource.COMPUTED:
             return self._resolve_computed(config)
+        elif config.source == FieldSource.TOOL_RESULT:
+            return self._resolve_tool_result(config, field_name)
         else:
             raise ValueError(
                 f"Unsupported field source: {config.source}. "
@@ -255,6 +257,56 @@ class FieldResolver:
             logger.debug(f"Resolved LLM field '{arg_name}' successfully")
 
         return value
+
+    def _resolve_tool_result(
+        self, config: FieldConfig, field_name: Optional[str] = None
+    ) -> Optional[Any]:
+        """Resolve "<tool_name>#/<json-pointer>" against THIS turn's
+        recorded tool results (the chat agent's BindingStore — the same
+        store render_ui show-ops hydrate from).
+
+        Databinding for tool ARGS: an identifier produced by one tool and
+        consumed by the next hops server-side instead of being retyped by
+        the LLM, which mistranscribes UUIDs often enough to break flows.
+        Fail-soft: no store on this surface (voice), unknown tool, or a
+        pointer miss all resolve to None with a log line.
+        """
+        expr = config.value
+        if not isinstance(expr, str) or "#/" not in expr:
+            logger.error(
+                f"TOOL_RESULT value must be '<tool>#/<pointer>', got {expr!r} "
+                f"(field {field_name!r})"
+            )
+            return None
+        tool_name, pointer = expr.split("#/", 1)
+        store = getattr(getattr(self.context, "bot", None), "binding_store", None)
+        if store is None:
+            logger.warning(
+                f"TOOL_RESULT source unavailable on this surface for "
+                f"field {field_name!r} ({expr!r})"
+            )
+            return None
+        data = store.resolve(tool_name)
+        for segment in [s for s in pointer.split("/") if s]:
+            # RFC 6901 escapes, decoded in this order: "~1" → "/", "~0" → "~".
+            segment = segment.replace("~1", "/").replace("~0", "~")
+            if isinstance(data, list):
+
+                try:
+                    data = data[int(segment)]
+                except (ValueError, IndexError):
+                    data = None
+            elif isinstance(data, dict):
+                data = data.get(segment)
+            else:
+                data = None
+            if data is None:
+                logger.warning(
+                    f"TOOL_RESULT {expr!r} unresolved at segment "
+                    f"{segment!r} (field {field_name!r})"
+                )
+                return None
+        return data
 
     def _resolve_computed(self, config: FieldConfig) -> str:
         """

--- a/app/ai/voice/agents/breeze_buddy/handlers/transport/utils/response_transform.py
+++ b/app/ai/voice/agents/breeze_buddy/handlers/transport/utils/response_transform.py
@@ -52,7 +52,9 @@ spec narrowly scoped to the in-place-mutation idiom.
 
 from __future__ import annotations
 
+import math
 import re
+from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple
 
 from app.core.logger import logger
@@ -245,6 +247,193 @@ def scale_by_exponent(value: Any, args: Dict[str, Any]) -> Any:
     return value
 
 
+@register_transform("format_number")
+def format_number(value: Any, args: Dict[str, Any]) -> Any:
+    """Derive a display string from a numeric field on the same dict.
+
+    The label-derivation workhorse behind "display values are
+    pre-formatted — never build your own": templates derive
+    ``duration_label`` ("51 min"), ``distance_label`` ("13.1 km") and fare
+    labels ("₹30") server-side so the LLM (and data-bound UI) only ever
+    shows ready-made strings.
+
+    Args:
+        field     — source numeric field name (required).
+        to        — destination field name (required). Overwritten.
+        divide_by — divide the source value first (e.g. 60 s→min, 1000 m→km).
+        decimals  — decimal places for the result (default 0 → rounded int).
+        skip_zero — when true, a zero source value derives nothing (walk
+                    legs must not grow a "₹0" fare label).
+        prefix    — literal prefix (e.g. "₹").
+        suffix    — literal suffix (e.g. " min").
+
+    Non-dict values, missing/non-numeric sources: pass-through no-op.
+    """
+    if not isinstance(value, dict):
+        return value
+    src_field = args.get("field")
+    dst_field = args.get("to")
+    if not src_field or not dst_field:
+        return value
+    raw = value.get(src_field)
+    try:
+        number = float(raw)  # pyrefly: ignore[bad-argument-type]
+    except (TypeError, ValueError):
+        return value
+    if not math.isfinite(number):
+        # "nan" / "inf" parse, but round() below would raise and abort the
+        # whole transform pass.
+        return value
+    if args.get("skip_zero") and number == 0:
+        return value
+    divide_by = args.get("divide_by")
+    if isinstance(divide_by, (int, float)) and divide_by:
+        number = number / divide_by
+    decimals = args.get("decimals", 0)
+    if not isinstance(decimals, int) or decimals < 0:
+        decimals = 0
+    if decimals == 0:
+        body = str(int(round(number)))
+    else:
+        body = f"{number:.{decimals}f}"
+    prefix = args.get("prefix") or ""
+    suffix = args.get("suffix") or ""
+    value[dst_field] = f"{prefix}{body}{suffix}"
+    return value
+
+
+@register_transform("coalesce")
+def coalesce(value: Any, args: Dict[str, Any]) -> Any:
+    """Write the first non-empty of several (dotted) source fields to a
+    destination field on the same dict — the display-layer if/else that
+    the declarative render grammar deliberately lacks (e.g. a transit
+    leg's title is its route code when it has one, else its mode; its
+    value line is the fare when priced, else the walking distance).
+
+    Args:
+        fields  — ordered list of source paths on this dict; a path may be
+                  dotted to reach nested dicts ("route.code").
+        to      — destination field name (required). Overwritten.
+        default — literal written when NO field resolves (optional). Lets
+                  a downstream hard bind (top-level component prop) rely
+                  on the field existing — e.g. selected_tier_type "" on
+                  modes whose API omits a selected tier.
+
+    Non-dict values / no field resolving to a non-empty scalar (and no
+    default): no-op.
+    """
+    if not isinstance(value, dict):
+        return value
+    fields = args.get("fields")
+    dst_field = args.get("to")
+    if not isinstance(fields, list) or not dst_field:
+        return value
+    if "default" in args:
+        value.setdefault(dst_field, args["default"])
+        # A present-but-None value still needs replacing — None fails the
+        # bind resolver's `is None` check, which is what `default` exists
+        # to prevent.
+        if value[dst_field] is None:
+            value[dst_field] = args["default"]
+    for path in fields:
+        if not isinstance(path, str) or not path:
+            continue
+        current: Any = value
+        for key in path.split("."):
+            if not isinstance(current, dict):
+                current = None
+                break
+            current = current.get(key)
+        if current is not None and not isinstance(current, (dict, list)):
+            text = str(current)
+            if text.strip():
+                value[dst_field] = current
+                return value
+    return value
+
+
+def _utc_now() -> datetime:
+    """Wall clock for the time-relative transforms — module-level so tests
+    can pin it."""
+    return datetime.now(timezone.utc)
+
+
+@register_transform("format_time")
+def format_time(value: Any, args: Dict[str, Any]) -> Any:
+    """Derive a short clock label ("11:18") from an ISO-8601 field on the
+    same dict — the display counterpart of format_number for timestamps
+    (departure/arrival chips and the like).
+
+    Args:
+        field     — source ISO-8601 string field name (required).
+        to        — destination field name (required). Overwritten.
+        tz_offset — minutes to shift a UTC/naive timestamp into the
+                    display zone (e.g. 330 for IST). Timestamps that
+                    already carry an offset are converted, not shifted twice.
+        fmt       — strftime format (default "%H:%M").
+
+    Non-dict values, missing/unparseable sources: pass-through no-op.
+    """
+    if not isinstance(value, dict):
+        return value
+    src_field = args.get("field")
+    dst_field = args.get("to")
+    if not src_field or not dst_field:
+        return value
+    raw = value.get(src_field)
+    if not isinstance(raw, str) or not raw:
+        return value
+    try:
+        parsed = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+    except ValueError:
+        return value
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    tz_offset = args.get("tz_offset")
+    # 0 is a valid offset (display in UTC): test the type, not truthiness.
+    if isinstance(tz_offset, (int, float)) and not isinstance(tz_offset, bool):
+        parsed = parsed.astimezone(timezone(timedelta(minutes=tz_offset)))
+    fmt = args.get("fmt")
+    if not isinstance(fmt, str) or not fmt:
+        fmt = "%H:%M"
+    try:
+        value[dst_field] = parsed.strftime(fmt)
+    except ValueError:
+        return value
+    return value
+
+
+@register_transform("join_list")
+def join_list(value: Any, args: Dict[str, Any]) -> Any:
+    """Join a list-of-strings field into one display string on the same dict.
+
+    E.g. ``modes: ["Walk", "Metro", "Walk"]`` →
+    ``modes_label: "Walk → Metro → Walk"``.
+
+    Args:
+        field     — source list field name (required).
+        to        — destination field name (required). Overwritten.
+        separator — joiner (default " → ").
+
+    Non-dict values, missing/non-list sources: pass-through no-op.
+    Non-string entries are stringified.
+    """
+    if not isinstance(value, dict):
+        return value
+    src_field = args.get("field")
+    dst_field = args.get("to")
+    if not src_field or not dst_field:
+        return value
+    raw = value.get(src_field)
+    if not isinstance(raw, list):
+        return value
+    separator = args.get("separator")
+    if not isinstance(separator, str):
+        separator = " → "
+    value[dst_field] = separator.join(str(item) for item in raw)
+    return value
+
+
 @register_transform("pick_fields")
 def pick_fields(value: Any, args: Dict[str, Any]) -> Any:
     """Keep only the listed top-level keys in a dict; drop everything else.
@@ -413,14 +602,352 @@ def derive_field(value: Any, args: Dict[str, Any]) -> Any:
     return value
 
 
+@register_transform("map_values")
+def map_values(value: Any, args: Dict[str, Any]) -> Any:
+    """Map a field's value(s) through a lookup table onto a destination
+    field on the same dict — the display-layer rename the render grammar
+    deliberately lacks (e.g. a transit wire mode "Subway" reads as
+    "Train" to commuters).
+
+    Args:
+        field   — source field name (required). Scalar or list of scalars.
+        to      — destination field name (required). Overwritten.
+        map     — {source value (as string) → replacement} (required).
+        default — value for unmapped entries; omitted = keep the original.
+
+    A LIST source maps each element (writing a new list). Non-dict
+    values, missing source, or a non-dict ``map``: pass-through no-op.
+    """
+    if not isinstance(value, dict):
+        return value
+    src_field = args.get("field")
+    dst_field = args.get("to")
+    table = args.get("map")
+    if not src_field or not dst_field or not isinstance(table, dict):
+        return value
+    raw = value.get(src_field)
+    if raw is None:
+        return value
+    mapping: Dict[str, Any] = table
+
+    def _one(item: Any) -> Any:
+        key = str(item)
+        if key in mapping:
+            return mapping[key]
+        return args.get("default", item)
+
+    if isinstance(raw, list):
+        value[dst_field] = [_one(item) for item in raw]
+    else:
+        value[dst_field] = _one(raw)
+    return value
+
+
+@register_transform("format_range")
+def format_range(value: Any, args: Dict[str, Any]) -> Any:
+    """Derive a display label from a min/max pair on the same dict:
+    "₹30" when they agree, "₹10–55" when they span (a fare across
+    service classes). The two-field counterpart of format_number.
+
+    Args:
+        min_field — source field for the lower bound (required).
+        max_field — source field for the upper bound (required).
+        to        — destination field name (required). Overwritten.
+        prefix    — prepended once (default "").
+        suffix    — appended once (default "").
+        decimals  — round to N decimals; default 0 drops any ".0".
+        skip_zero — True: both bounds zero → no label written.
+        style     — "span" (default): "₹10–55"; "from": "from ₹10" — the
+                    consumer-friendly form when the spread is a class
+                    ladder, not price uncertainty. Equal bounds always
+                    render plain ("₹30") in either style.
+
+    Non-dict values or non-numeric bounds: pass-through no-op. A missing
+    max falls back to min (and vice versa) so a single-priced row still
+    labels.
+    """
+    if not isinstance(value, dict):
+        return value
+    min_field = args.get("min_field")
+    max_field = args.get("max_field")
+    dst_field = args.get("to")
+    if not min_field or not max_field or not dst_field:
+        return value
+    lo_raw = value.get(min_field)
+    hi_raw = value.get(max_field)
+    if lo_raw is None and hi_raw is None:
+        return value
+    try:
+        lo = float(lo_raw if lo_raw is not None else hi_raw)  # type: ignore[arg-type]
+        hi = float(hi_raw if hi_raw is not None else lo_raw)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return value
+    if args.get("skip_zero") and lo == 0 and hi == 0:
+        return value
+    decimals = args.get("decimals", 0)
+    if not isinstance(decimals, int) or decimals < 0:
+        decimals = 0
+
+    def _fmt(number: float) -> str:
+        text = f"{number:.{decimals}f}"
+        if decimals == 0 and text.endswith(".0"):
+            text = text[:-2]
+        return text
+
+    prefix = args.get("prefix") or ""
+    suffix = args.get("suffix") or ""
+    if lo == hi:
+        label = f"{prefix}{_fmt(lo)}{suffix}"
+    elif args.get("style") == "from":
+        label = f"from {prefix}{_fmt(min(lo, hi))}{suffix}"
+    else:
+        label = f"{prefix}{_fmt(min(lo, hi))}–{_fmt(max(lo, hi))}{suffix}"
+    value[dst_field] = label
+    return value
+
+
+@register_transform("mark_extremum")
+def mark_extremum(value: Any, args: Dict[str, Any]) -> Any:
+    """Tag the min/max element of a list field — the cross-item ranking a
+    per-item transform cannot express (e.g. label the fastest / cheapest
+    journey of a result set). Apply at the path of the dict HOLDING the
+    list (root for a top-level list).
+
+    Args:
+        list_field  — field on this dict holding the list (required).
+        field       — numeric field ranked on each element (required).
+        mode        — "min" (default) or "max".
+        to          — destination field on the WINNING element (required).
+        label       — value written to `to` (required).
+        skip_if_set — True (default): elements whose `to` is already set
+                      are not overwritten AND are skipped when ranking, so
+                      a second rule ("Cheapest" after "Fastest") tags the
+                      best of the REMAINING elements.
+
+    Elements without a numeric `field` are ignored. No qualifying
+    element / bad args: no-op.
+    """
+    if not isinstance(value, dict):
+        return value
+    list_field = args.get("list_field")
+    field = args.get("field")
+    dst_field = args.get("to")
+    label = args.get("label")
+    if not list_field or not field or not dst_field or label is None:
+        return value
+    items = value.get(list_field)
+    if not isinstance(items, list):
+        return value
+    skip_if_set = args.get("skip_if_set", True)
+    best: Optional[Dict[str, Any]] = None
+    best_num: Optional[float] = None
+    use_max = args.get("mode") == "max"
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        if skip_if_set and item.get(dst_field) is not None:
+            continue
+        raw = item.get(field)
+        try:
+            num = float(raw)  # type: ignore[arg-type]
+        except (TypeError, ValueError):
+            continue
+        if best_num is None or (num > best_num if use_max else num < best_num):
+            best_num = num
+            best = item
+    if best is not None:
+        best[dst_field] = label
+    return value
+
+
+@register_transform("count_where")
+def count_where(value: Any, args: Dict[str, Any]) -> Any:
+    """Count a list field's elements by a member-field predicate and write
+    the (offset, clamped) count — e.g. transfers = transit legs minus one.
+
+    Args:
+        list_field — field on this dict holding the list (required).
+        field      — member field inspected on each element (required).
+        in         — count only elements whose field (as string) is in
+                     this list.
+        not_in     — count only elements whose field is NOT in this list.
+        offset     — added to the count (default 0), e.g. -1 for
+                     transfers.
+        min        — lower clamp after offset (default 0).
+        to         — destination field on this dict (required).
+
+    Missing/non-list source or bad args: no-op.
+    """
+    if not isinstance(value, dict):
+        return value
+    list_field = args.get("list_field")
+    field = args.get("field")
+    dst_field = args.get("to")
+    if not list_field or not field or not dst_field:
+        return value
+    items = value.get(list_field)
+    if not isinstance(items, list):
+        return value
+    include = args.get("in")
+    exclude = args.get("not_in")
+    count = 0
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        member = str(item.get(field))
+        if isinstance(include, list) and member not in [str(x) for x in include]:
+            continue
+        if isinstance(exclude, list) and member in [str(x) for x in exclude]:
+            continue
+        count += 1
+    offset = args.get("offset", 0)
+    floor = args.get("min", 0)
+    if not isinstance(offset, int):
+        offset = 0
+    if not isinstance(floor, int):
+        floor = 0
+    value[dst_field] = max(floor, count + offset)
+    return value
+
+
+@register_transform("find_where")
+def find_where(value: Any, args: Dict[str, Any]) -> Any:
+    """Find the FIRST element of a list field matching a member-field
+    predicate and lift chosen member fields onto this dict — e.g. surface
+    the transit leg's order as a journey-level field a card action can
+    pass into an intent payload.
+
+    Args:
+        list_field — field on this dict holding the list (required).
+        field      — member field inspected on each element (required).
+        in         — match only elements whose field (as string) is in
+                     this list.
+        not_in     — match only elements whose field is NOT in this list.
+        set        — {destination field on this dict: source field on the
+                     matched element} (required, non-empty).
+
+    Source fields missing on the match copy as absent (not None-stomped).
+    No match / missing list / bad args: no-op.
+    """
+    if not isinstance(value, dict):
+        return value
+    list_field = args.get("list_field")
+    field = args.get("field")
+    mapping = args.get("set")
+    if not list_field or not field or not isinstance(mapping, dict) or not mapping:
+        return value
+    items = value.get(list_field)
+    if not isinstance(items, list):
+        return value
+    include = args.get("in")
+    exclude = args.get("not_in")
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        member = str(item.get(field))
+        if isinstance(include, list) and member not in [str(x) for x in include]:
+            continue
+        if isinstance(exclude, list) and member in [str(x) for x in exclude]:
+            continue
+        for dst, src in mapping.items():
+            if not isinstance(dst, str) or not isinstance(src, str):
+                continue
+            if src in item:
+                value[dst] = item[src]
+        break
+    return value
+
+
+@register_transform("upcoming_times")
+def upcoming_times(value: Any, args: Dict[str, Any]) -> Any:
+    """Reduce a service-day timetable to the next departures after "now" —
+    e.g. a transit feed's ``nextAvailableTimings`` (a full-day list of
+    "HH:MM:SS" strings or ``[arrival, departure]`` pairs) into
+    "5:23 PM, 5:53 PM". Times are local clock strings in the zone given by
+    ``tz_offset``; "now" is computed in that zone at transform time.
+
+    Args:
+        field     — source list field on this dict (required). Elements:
+                    "HH:MM[:SS]" strings, or lists/tuples of them (the
+                    LAST element of a pair is used — the departure).
+        to        — destination field (required). Written ONLY when at
+                    least one upcoming time exists — bind-guards and `if`
+                    gates can rely on absence meaning "no more today".
+        count     — how many to keep (default 2).
+        tz_offset — minutes from UTC for "now" (default 0; IST = 330).
+        separator — join string (default ", ").
+        fmt       — strftime for the label (default "%-I:%M %p" — "5:23 PM").
+
+    Non-dict values / missing list / bad args: no-op.
+    """
+    if not isinstance(value, dict):
+        return value
+    src_field = args.get("field")
+    dst_field = args.get("to")
+    if not src_field or not dst_field:
+        return value
+    raw = value.get(src_field)
+    if not isinstance(raw, list):
+        return value
+    count = args.get("count", 2)
+    if not isinstance(count, int) or count < 1:
+        count = 2
+    offset = args.get("tz_offset", 0)
+    if not isinstance(offset, (int, float)):
+        offset = 0
+    fmt = args.get("fmt")
+    if not isinstance(fmt, str) or not fmt:
+        fmt = "%-I:%M %p"
+    separator = args.get("separator")
+    if not isinstance(separator, str):
+        separator = ", "
+    now_local = _utc_now() + timedelta(minutes=offset)
+    now_secs = now_local.hour * 3600 + now_local.minute * 60 + now_local.second
+
+    labels: List[str] = []
+    for entry in raw:
+        if isinstance(entry, (list, tuple)) and entry:
+            entry = entry[-1]  # [arrival, departure] → departure
+        if not isinstance(entry, str):
+            continue
+        parts = entry.split(":")
+        try:
+            h, m = int(parts[0]), int(parts[1])
+            s = int(parts[2]) if len(parts) > 2 else 0
+        except (ValueError, IndexError):
+            continue
+        if h * 3600 + m * 60 + s <= now_secs:
+            continue
+        try:
+            label = now_local.replace(hour=h % 24, minute=m, second=0).strftime(fmt)
+        except ValueError:
+            continue
+        labels.append(label)
+        if len(labels) >= count:
+            break
+    if labels:
+        value[dst_field] = separator.join(labels)
+    return value
+
+
 __all__ = [
     "TRANSFORM_REGISTRY",
     "TransformFn",
     "apply_response_transforms",
+    "coalesce",
+    "count_where",
     "derive_field",
+    "find_where",
+    "format_number",
+    "format_range",
+    "format_time",
+    "join_list",
+    "map_values",
+    "mark_extremum",
     "omit_fields",
     "pick_fields",
     "register_transform",
     "scale_by_exponent",
     "strip_html",
+    "upcoming_times",
 ]

--- a/app/ai/voice/agents/breeze_buddy/template/field_reference.json
+++ b/app/ai/voice/agents/breeze_buddy/template/field_reference.json
@@ -431,6 +431,10 @@
       "description": "Whether the free-text composer is visible to the user. Default true. Set false to restrict input to quick-reply buttons only (bot-driven or menu-style flows).",
       "example": true
     },
+    "response_reveal": {
+      "description": "How the widget reveals assistant prose. 'stream' (default) = paced typewriter as tokens arrive. 'complete' = a typing indicator while the reply is in flight, then the full message at once (Messenger style). Presentation-only: the SSE transport streams either way.",
+      "example": "complete"
+    },
     "wake_phrase": {
       "description": "Require the user to say a trigger phrase before the bot responds. Useful for IVR-style consent flows. phrases: list of accepted trigger words. single_activation: if true, phrase required only once per session.",
       "example": {
@@ -557,6 +561,48 @@
       "example": {
         "checkout_page": "https://www.thebeyondbound.com/cart"
       }
+    },
+    "custom": {
+      "description": "Template-DEFINED direct intents (CHAMELEON): each entry runs the named template tools with NO LLM call and hydrates a registry custom component bound to their results — the config-authored counterpart of a flavor's compiled-in IntentPolicy. steps[] run in order (args = static `args` + `args_from_payload` dot-paths into the widget's intent payload, fail-closed on a missing key); `bind` maps component props to `$tool:<tool>#/<json-pointer>` refs over this turn's results; `enrich` rules mark list items across tools (e.g. the selected fare class); `silent` intents leave no visible thread trace. Names share the global intent namespace on the wire; a name that collides with a flavor intent shadows it for this template only.",
+      "example": [
+        {
+          "name": "journey_detail",
+          "steps": [
+            {
+              "tool": "get_journey_details",
+              "args_from_payload": {
+                "journey_id": "journey_id"
+              }
+            },
+            {
+              "tool": "get_tier_options",
+              "args_from_payload": {
+                "journey_id": "journey_id",
+                "leg_order": "leg_order"
+              }
+            }
+          ],
+          "component": "JourneyDetail",
+          "bind": {
+            "journey": "$tool:get_journey_details#/journey",
+            "tiers": "$tool:get_tier_options#/tiers"
+          },
+          "enrich": [
+            {
+              "list_ref": "$tool:get_tier_options#/tiers",
+              "match_field": "quote_id",
+              "equals_ref": "$tool:get_journey_details#/selected_quote_id",
+              "set": {
+                "selected": true
+              },
+              "else_set": {
+                "unselected": true
+              }
+            }
+          ],
+          "silent": true
+        }
+      ]
     }
   },
   "FlowNodeModel": {

--- a/app/ai/voice/agents/breeze_buddy/template/types.py
+++ b/app/ai/voice/agents/breeze_buddy/template/types.py
@@ -1247,6 +1247,64 @@ class McpConfig(BaseModel):
     )
 
 
+class CustomComponentFlags(BaseModel):
+    """Engine-read behavior flags of one registry component (the ``flags``
+    JSONB of a ``ui_component`` row, migration 070).
+
+    v1 keeps the surface deliberately small: custom components are
+    data-bound render_ui components only — no literal fields (the engine's
+    fail-closed gate would drop them anyway), no DIRECT intents.
+    """
+
+    data_bound: bool = Field(
+        True,
+        description="Must be true in v1 — custom components hydrate from "
+        "this turn's tool results, never from model-authored values.",
+    )
+    selection_field: Optional[str] = Field(
+        None,
+        description="Prop name that carries the model's items[] selection "
+        "(id-matching over bound list entries), e.g. 'journeys'.",
+    )
+    list_props: List[str] = Field(
+        default_factory=list,
+        description="Props that hydrate as lists (selection + caps apply; "
+        "a single bound object lifts to a one-element list).",
+    )
+    max_items_default: Optional[int] = Field(
+        None,
+        description="Default cap on bound list length when the op "
+        "carries no max_items.",
+    )
+    max_items_limit: Optional[int] = Field(
+        None,
+        description="Hard ceiling on bound list length regardless of "
+        "the op's max_items.",
+    )
+    overlay_only: bool = Field(
+        False,
+        description=(
+            "True = the component is a CLIENT-side render target only "
+            "(opened by another component's open_detail action in the "
+            "widget's detail overlay). It ships to the widget with the "
+            "session surface but is EXCLUDED from the model's render_ui "
+            "vocabulary — the model can never paint it in-thread."
+        ),
+    )
+
+
+class CustomComponentDef(BaseModel):
+    """One resolved registry component as the session overlay carries it
+    (decoded off a ``ui_component`` row; immutable per version)."""
+
+    name: str
+    version: int = 1
+    props_schema: Dict[str, Any]
+    flags: CustomComponentFlags = Field(default_factory=CustomComponentFlags)
+    render_def: Optional[Dict[str, Any]] = None
+    prompt_hint: Optional[str] = None
+
+
 class UiCatalogConfig(BaseModel):
     """Per-template selection of which generative-UI primitives the LLM
     may emit and the widget will render.
@@ -1302,6 +1360,17 @@ class UiCatalogConfig(BaseModel):
             "Explicit overrides to remove from the resolved set, e.g. "
             "disable 'Table' on a voice-first template even though it's "
             "in the 'core' group."
+        ),
+    )
+    custom_components: List[str] = Field(
+        default_factory=list,
+        description=(
+            "Registry (ui_component, migration 070) component names this "
+            "template opts into, e.g. ['JourneyOptions']. Resolved at turn "
+            "start into a session-scoped overlay: the names join the "
+            "render_ui enum and hydrate via their JSON-Schema defs. "
+            "catalog-v2 render_ui sessions only — pruned everywhere else. "
+            "Unknown/inactive names are skipped with a warning."
         ),
     )
 
@@ -1410,6 +1479,106 @@ class UiIntentsConfig(BaseModel):
         "storefront /cart page) instead of the cart tool's checkout-bound "
         "continue_url; unset keeps continue_url.",
     )
+    custom: List["CustomUiIntent"] = Field(
+        default_factory=list,
+        description=(
+            "Template-DEFINED direct intents (CHAMELEON): each entry runs "
+            "the named template tools with NO LLM call and hydrates a "
+            "registry custom component bound to their results — the "
+            "config-authored counterpart of a flavor's compiled-in "
+            "IntentPolicy. Names share the global intent namespace on the "
+            "wire; a name that collides with a flavor intent shadows it "
+            "for this template only."
+        ),
+    )
+
+
+class CustomUiIntentStep(BaseModel):
+    """One tool dispatch inside a :class:`CustomUiIntent` — the tool must
+    exist on this template's function surface; args flow through the same
+    ``inject_tool_args`` pipeline an LLM call would use."""
+
+    tool: str = Field(..., min_length=1, max_length=128)
+    args: Dict[str, Any] = Field(
+        default_factory=dict,
+        description="Literal args merged under any payload-sourced ones.",
+    )
+    args_from_payload: Dict[str, str] = Field(
+        default_factory=dict,
+        description=(
+            "Tool arg name → dot-path into the intent payload. A missing "
+            "payload key fails the intent closed (typed intent_failed) — "
+            "never a tool call with a hole in its args."
+        ),
+    )
+
+
+class UiIntentEnrichRule(BaseModel):
+    """Cross-tool list marking, applied after a custom intent's steps
+    succeed: find the element of ``list_ref`` whose ``match_field`` equals
+    the scalar at ``equals_ref`` and merge ``set`` onto it (``else_set``
+    onto every other element). The generic answer to "mark the SELECTED
+    option" when one tool returns the options and another names the
+    current choice — per-tool response transforms can't see across tools.
+    Fail-open: unresolvable refs / non-list targets leave data untouched.
+    """
+
+    list_ref: str = Field(
+        ..., description="'$tool:<tool>#/<ptr>' bind ref to a LIST result."
+    )
+    match_field: str = Field(..., min_length=1)
+    equals_ref: str = Field(
+        ..., description="'$tool:<tool>#/<ptr>' bind ref to the scalar to match."
+    )
+    set: Dict[str, Any] = Field(
+        default_factory=dict, description="Merged onto the matching element(s)."
+    )
+    else_set: Dict[str, Any] = Field(
+        default_factory=dict, description="Merged onto non-matching elements."
+    )
+
+
+class CustomUiIntent(BaseModel):
+    """One template-defined DIRECT ui_intent (see ``UiIntentsConfig.custom``).
+
+    ``steps`` run in order through the persisted-tool pipeline; the LAST
+    step's success gates the show op. ``bind`` refs may point at ANY step's
+    result (``"<tool>#/<pointer>"`` — same grammar as render_ui binds).
+    """
+
+    name: str = Field(..., min_length=1, max_length=64)
+    steps: List[CustomUiIntentStep] = Field(..., min_length=1, max_length=4)
+    enrich: List[UiIntentEnrichRule] = Field(
+        default_factory=list,
+        description=(
+            "Cross-tool list-marking rules applied after the steps succeed "
+            "and before the component hydrates (e.g. stamp selected=true on "
+            "the tier whose quote_id the journey currently uses)."
+        ),
+    )
+    component: Optional[str] = Field(
+        None,
+        description=(
+            "Registry custom-component name to hydrate and stream after "
+            "the steps succeed (must be opted into via "
+            "ui_catalog.custom_components). None = tools only, no render."
+        ),
+    )
+    bind: Dict[str, str] = Field(
+        default_factory=dict,
+        description="Component prop → '<tool>#/<pointer>' bind ref.",
+    )
+    props: Dict[str, Any] = Field(
+        default_factory=dict, description="Literal component props."
+    )
+    silent: bool = Field(
+        True,
+        description=(
+            "Silent intents leave no visible thread trace (detail-overlay "
+            "hydration); non-silent ones post the display bubble."
+        ),
+    )
+    display: Optional[str] = Field(None, max_length=200)
 
 
 class RenderUiConfig(BaseModel):
@@ -1999,6 +2168,16 @@ class ConfigurationModel(BaseModel):
             "agent-driven input is possible."
         ),
     )
+    response_reveal: Literal["stream", "complete"] = Field(
+        "stream",
+        description=(
+            "How the widget reveals assistant prose. 'stream' (default) = "
+            "paced typewriter as tokens arrive. 'complete' = a typing "
+            "indicator while the reply is in flight, then the full message "
+            "at once (Messenger style). Presentation-only: the SSE "
+            "transport streams either way."
+        ),
+    )
     ivr_configuration: Optional[IvrConfig] = None  # IVR-specific configuration
     # DEPRECATED: Use ivr_configuration.greeting / ivr_configuration.goodbye / ivr_configuration.priority
     ivr_greeting: Optional[str] = None
@@ -2207,11 +2386,17 @@ class FieldSource(str, Enum):
     - STATIC: Value is a literal or contains {template_var} placeholders
     - LLM: Value comes from LLM function arguments
     - COMPUTED: Value is dynamically computed at invocation time (e.g., timestamps)
+    - TOOL_RESULT: Value binds to a field of a PRIOR tool result from the
+      same turn ("<tool_name>#/<json-pointer>") — databinding for tool
+      args: identifiers hop server-side instead of being retyped by the
+      LLM (which mistranscribes UUIDs). Chat sessions only (needs the
+      turn's binding store); resolves to None elsewhere.
     """
 
     STATIC = "static"
     LLM = "llm"
     COMPUTED = "computed"
+    TOOL_RESULT = "tool_result"
 
 
 class HttpMethod(str, Enum):
@@ -2306,6 +2491,34 @@ class HttpAuthConfig(BaseModel):
         return "**********"
 
 
+class RetryUntilConfig(BaseModel):
+    """Content-conditional re-request for poll-until-ready endpoints.
+
+    Some APIs answer 2xx immediately with "not finished yet" (async
+    planners, order-status, report generation). This re-issues the SAME
+    request until a field in the parsed JSON body reaches the ready
+    value — bounded, config-driven, and invisible to the LLM, which only
+    ever sees the final response. Applies to non-SSE 2xx JSON responses;
+    transport errors keep the executor's own retry logic.
+
+    Only legal with ``method: GET``: the request is re-issued verbatim, so
+    on a mutating method it would repeat the mutation. ``HttpRequestConfig``
+    refuses that combination at load time.
+    """
+
+    field: str = Field(
+        ...,
+        description="Dotted path into the parsed JSON body, e.g. 'allJourneysLoaded'.",
+    )
+    equals: Any = Field(
+        True, description="Value at `field` that means ready (default true)."
+    )
+    max_attempts: int = Field(
+        3, ge=2, le=5, description="TOTAL attempts including the first."
+    )
+    delay_ms: int = Field(1200, ge=100, le=10000, description="Pause between attempts.")
+
+
 class HttpRequestConfig(BaseModel):
     """Complete HTTP request configuration for hooks and global functions.
 
@@ -2328,6 +2541,18 @@ class HttpRequestConfig(BaseModel):
     auth: Optional[HttpAuthConfig] = None
     timeout: int = 10
     max_retries: int = 3
+    retry_until: Optional[RetryUntilConfig] = None
+
+    @model_validator(mode="after")
+    def _retry_until_only_on_get(self) -> "HttpRequestConfig":
+        # retry_until re-issues the request verbatim; on a mutating method
+        # that repeats the mutation, so it is refused when the config loads.
+        if self.retry_until is not None and self.method != HttpMethod.GET:
+            raise ValueError(
+                "retry_until is only allowed with method GET (the request is "
+                f"re-issued verbatim); got {self.method.value}"
+            )
+        return self
 
 
 class FieldConfig(BaseModel):

--- a/app/api/routers/breeze_buddy/__init__.py
+++ b/app/api/routers/breeze_buddy/__init__.py
@@ -49,6 +49,7 @@ from app.api.routers.breeze_buddy.template_generator import (
 from app.api.routers.breeze_buddy.templates import router as templates_router
 from app.api.routers.breeze_buddy.topics import router as topics_router
 from app.api.routers.breeze_buddy.tts_catalog import router as tts_catalog_router
+from app.api.routers.breeze_buddy.ui_components import router as ui_components_router
 from app.api.routers.breeze_buddy.users import router as users_router
 from app.api.routers.breeze_buddy.wallet import router as wallet_router
 from app.api.routers.breeze_buddy.webhooks import router as webhooks_router
@@ -157,4 +158,6 @@ router.include_router(chat_router, prefix="", tags=["chat"])
 # - widget_config: per-merchant config (admin/reseller-scoped CRUD)
 # - widget: unified /widget/session/* conversation router (chat ↔ voice)
 router.include_router(widget_config_router, prefix="", tags=["widget-config"])
+# - ui_components: CHAMELEON custom-component registry (migration 070)
+router.include_router(ui_components_router, prefix="", tags=["ui-components"])
 router.include_router(widget_router, prefix="", tags=["widget-session"])

--- a/app/api/routers/breeze_buddy/chat/demo.py
+++ b/app/api/routers/breeze_buddy/chat/demo.py
@@ -260,7 +260,7 @@ async def create_demo_session(
         # ui_flavors, so a demo page structurally could not render quick
         # replies or greeting tiles its template defined — the asymmetry
         # the one-block shape exists to prevent.
-        widget=_surface_wire(
+        widget=await _surface_wire(
             _extract_widget_config(template),
             template,
             catalog_active=catalog_active,

--- a/app/api/routers/breeze_buddy/chat/handlers.py
+++ b/app/api/routers/breeze_buddy/chat/handlers.py
@@ -35,6 +35,9 @@ from app.ai.voice.agents.breeze_buddy.chat.intents.router import (
     run_direct_intent,
     template_enabled_flavors,
 )
+from app.ai.voice.agents.breeze_buddy.chat.intents.template_intents import (
+    template_intent_policies,
+)
 from app.ai.voice.agents.breeze_buddy.chat.metrics import TurnMetrics
 from app.ai.voice.agents.breeze_buddy.chat.sse import SSEEvent, format_sse
 from app.ai.voice.agents.breeze_buddy.chat.turn_core import (
@@ -620,7 +623,11 @@ async def serve_session_intent(
     flavors = template_enabled_flavors(template)
     ensure_flavor_intents(flavors)
     try:
-        parsed = parse_ui_intent(raw_intent, enabled_flavors=flavors)
+        parsed = parse_ui_intent(
+            raw_intent,
+            enabled_flavors=flavors,
+            extra_policies=template_intent_policies(template),
+        )
     except IntentValidationError as exc:
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,

--- a/app/api/routers/breeze_buddy/ui_components/__init__.py
+++ b/app/api/routers/breeze_buddy/ui_components/__init__.py
@@ -1,0 +1,109 @@
+"""RBAC-gated CRUD for ui_component rows (migration 070, CHAMELEON).
+
+Five endpoints under ``/agent/voice/breeze-buddy/ui-components``:
+
+- ``POST   /ui-components``            — register (admin / scoped reseller)
+- ``GET    /ui-components/list``       — list (RBAC-filtered)
+- ``GET    /ui-components/{id}``       — get by id
+- ``PUT    /ui-components/{id}``       — partial update (bumps version)
+- ``DELETE /ui-components/{id}``       — delete (admin only)
+
+Mirrors the widget_config router — thin routes that validate auth + RBAC,
+then delegate to handlers. Every write runs the registration guards
+(``chat/ui/custom_defs.validate_registration``): name shape + built-in
+collision, JSON-Schema well-formedness, v1 flag rules, render_def lint.
+"""
+
+from typing import Optional
+
+from fastapi import APIRouter, Depends, Query, status
+
+from app.api.security.breeze_buddy.rbac_token import get_current_user_with_rbac
+from app.core.security.authorization import require_admin
+from app.schemas import UserInfo
+from app.schemas.breeze_buddy.ui_component import (
+    UiComponentCreate,
+    UiComponentListResponse,
+    UiComponentResponse,
+    UiComponentUpdate,
+)
+
+from .handlers import (
+    DeleteUiComponentResponse,
+    create_ui_component_handler,
+    delete_ui_component_handler,
+    get_ui_component_by_id_handler,
+    list_ui_components_handler,
+    update_ui_component_handler,
+)
+
+router = APIRouter()
+
+
+@router.post(
+    "/ui-components",
+    status_code=status.HTTP_201_CREATED,
+    response_model=UiComponentResponse,
+)
+async def create_ui_component(
+    body: UiComponentCreate,
+    current_user: UserInfo = Depends(get_current_user_with_rbac),
+) -> UiComponentResponse:
+    """Register a custom component. 400 with the full guard-error list on
+    any registration violation."""
+    return await create_ui_component_handler(body, current_user)
+
+
+@router.get("/ui-components/list", response_model=UiComponentListResponse)
+async def list_ui_components(
+    reseller_id: Optional[str] = Query(None),
+    merchant_id: Optional[str] = Query(None),
+    include_inactive: bool = Query(False),
+    page: int = Query(1, ge=1),
+    limit: int = Query(50, ge=1, le=200),
+    current_user: UserInfo = Depends(get_current_user_with_rbac),
+) -> UiComponentListResponse:
+    """List ui_components visible to the caller (RBAC-filtered)."""
+    return await list_ui_components_handler(
+        reseller_id=reseller_id,
+        merchant_id=merchant_id,
+        include_inactive=include_inactive,
+        page=page,
+        limit=limit,
+        current_user=current_user,
+    )
+
+
+@router.get("/ui-components/{ui_component_id}", response_model=UiComponentResponse)
+async def get_ui_component(
+    ui_component_id: str,
+    current_user: UserInfo = Depends(get_current_user_with_rbac),
+) -> UiComponentResponse:
+    """Get a ui_component by id (403 outside the caller's scope)."""
+    return await get_ui_component_by_id_handler(ui_component_id, current_user)
+
+
+@router.put("/ui-components/{ui_component_id}", response_model=UiComponentResponse)
+async def update_ui_component(
+    ui_component_id: str,
+    body: UiComponentUpdate,
+    current_user: UserInfo = Depends(get_current_user_with_rbac),
+) -> UiComponentResponse:
+    """Partial update; every real change bumps ``version``. Guards re-run
+    on the merged row."""
+    return await update_ui_component_handler(ui_component_id, body, current_user)
+
+
+@router.delete(
+    "/ui-components/{ui_component_id}", response_model=DeleteUiComponentResponse
+)
+async def delete_ui_component(
+    ui_component_id: str,
+    current_user: UserInfo = Depends(get_current_user_with_rbac),
+) -> DeleteUiComponentResponse:
+    """Delete a ui_component row. Admin only (matches templates DELETE)."""
+    require_admin(current_user)
+    return await delete_ui_component_handler(ui_component_id, current_user)
+
+
+__all__ = ["router"]

--- a/app/api/routers/breeze_buddy/ui_components/handlers.py
+++ b/app/api/routers/breeze_buddy/ui_components/handlers.py
@@ -1,0 +1,215 @@
+"""Business logic for ui_component CRUD (migration 070, CHAMELEON).
+
+All handlers run after the route layer has validated the user's RBAC
+token. Reseller/merchant scoping is enforced via
+``validate_template_access`` (same predicate semantics as templates and
+widget_config). Every write runs the registration guards from
+``chat/ui/custom_defs.py`` — a def that fails them never reaches a
+session.
+"""
+
+from typing import List, Optional
+
+from fastapi import HTTPException, status
+from pydantic import BaseModel
+
+from app.ai.voice.agents.breeze_buddy.chat.ui.custom_defs import (
+    validate_registration,
+)
+from app.api.routers.breeze_buddy.templates.rbac import validate_template_access
+from app.core.logger import logger
+from app.database.accessor.breeze_buddy.ui_component import (
+    create_ui_component,
+    delete_ui_component,
+    get_ui_component_by_id,
+    list_ui_components,
+    update_ui_component,
+)
+from app.schemas import UserInfo
+from app.schemas.breeze_buddy.ui_component import (
+    UiComponentCreate,
+    UiComponentListResponse,
+    UiComponentResponse,
+    UiComponentUpdate,
+)
+
+
+class DeleteUiComponentResponse(BaseModel):
+    deleted: bool
+    id: str
+
+
+# Update fields backed by NOT NULL columns — an explicit null is a 400.
+_NON_NULLABLE_FIELDS = ("props_schema", "flags", "is_active")
+
+
+async def create_ui_component_handler(
+    body: UiComponentCreate, current_user: UserInfo
+) -> UiComponentResponse:
+    logger.info(
+        f"User {current_user.username} (role: {current_user.role}) registering "
+        f"ui_component {body.name!r} for reseller={body.reseller_id} "
+        f"merchant={body.merchant_id}"
+    )
+    validate_template_access(
+        current_user,
+        body.reseller_id,
+        body.merchant_id,
+        operation="create ui_component",
+    )
+    errors = validate_registration(
+        name=body.name,
+        props_schema=body.props_schema,
+        flags=body.flags,
+        render_def=body.render_def,
+    )
+    if errors:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={"registration_errors": errors},
+        )
+    try:
+        created = await create_ui_component(
+            reseller_id=body.reseller_id,
+            merchant_id=body.merchant_id,
+            name=body.name,
+            props_schema=body.props_schema,
+            flags=body.flags,
+            render_def=body.render_def,
+            prompt_hint=body.prompt_hint,
+            is_active=body.is_active,
+        )
+    except Exception as exc:
+        if "ui_component_scope_name_unique" in str(exc):
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail=(
+                    f"ui_component {body.name!r} already exists in this "
+                    "scope. Update the existing row instead."
+                ),
+            )
+        raise
+    if not created:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to create ui_component",
+        )
+    return created
+
+
+async def _fetch_scoped(
+    ui_component_id: str, current_user: UserInfo, operation: str
+) -> UiComponentResponse:
+    row = await get_ui_component_by_id(ui_component_id)
+    if not row:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"ui_component '{ui_component_id}' not found",
+        )
+    validate_template_access(
+        current_user, row.reseller_id, row.merchant_id, operation=operation
+    )
+    return row
+
+
+async def get_ui_component_by_id_handler(
+    ui_component_id: str, current_user: UserInfo
+) -> UiComponentResponse:
+    return await _fetch_scoped(ui_component_id, current_user, "read ui_component")
+
+
+async def list_ui_components_handler(
+    *,
+    reseller_id: Optional[str],
+    merchant_id: Optional[str],
+    include_inactive: bool,
+    page: int,
+    limit: int,
+    current_user: UserInfo,
+) -> UiComponentListResponse:
+    """RBAC-aware listing, same shape as ``list_widget_configs_handler``.
+
+    Admins see everything. Non-admins are scoped to their accessible
+    resellers AND merchants — both allowlists reach the query, which
+    filters BEFORE pagination and the total. Reseller-wide rows
+    (``merchant_id IS NULL``) stay visible to anyone with reseller access,
+    matching ``filter_templates_by_rbac``. Asking for a specific
+    reseller_id / merchant_id outside the caller's scope is a 403.
+    """
+    accessible_reseller_ids: Optional[List[str]] = None
+    accessible_merchant_ids: Optional[List[str]] = None
+    if current_user.role != "admin":
+        if "*" not in current_user.reseller_ids:
+            accessible_reseller_ids = current_user.reseller_ids
+            if reseller_id and reseller_id not in current_user.reseller_ids:
+                raise HTTPException(
+                    status_code=status.HTTP_403_FORBIDDEN,
+                    detail=f"Access denied to reseller {reseller_id}",
+                )
+        if "*" not in current_user.merchant_ids:
+            accessible_merchant_ids = current_user.merchant_ids
+            if merchant_id and merchant_id not in current_user.merchant_ids:
+                raise HTTPException(
+                    status_code=status.HTTP_403_FORBIDDEN,
+                    detail=f"Access denied to merchant {merchant_id}",
+                )
+    items, total = await list_ui_components(
+        page=page,
+        limit=limit,
+        reseller_id=reseller_id,
+        merchant_id=merchant_id,
+        reseller_ids=accessible_reseller_ids,
+        merchant_ids=accessible_merchant_ids,
+        include_inactive=include_inactive,
+    )
+    return UiComponentListResponse(ui_components=items, total=total, page=page)
+
+
+async def update_ui_component_handler(
+    ui_component_id: str, body: UiComponentUpdate, current_user: UserInfo
+) -> UiComponentResponse:
+    row = await _fetch_scoped(ui_component_id, current_user, "update ui_component")
+    # Presence decides what changes, not None-ness: a field omitted from
+    # the body is untouched; a field sent as null clears it. Only the
+    # nullable columns may be cleared.
+    patch = body.model_dump(exclude_unset=True)
+    nulled = [k for k in _NON_NULLABLE_FIELDS if k in patch and patch[k] is None]
+    if nulled:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"{', '.join(nulled)} cannot be null",
+        )
+    # Guards re-run on the MERGED row — a partial update cannot sneak an
+    # invalid schema or def past registration (clearing render_def on an
+    # overlay_only def fails here exactly as it would at create time).
+    errors = validate_registration(
+        name=row.name,
+        props_schema=patch.get("props_schema", row.props_schema),
+        flags=patch.get("flags", row.flags),
+        render_def=patch.get("render_def", row.render_def),
+    )
+    # The stored name already passed the collision check at create time;
+    # re-running it against the (now-registered) built-ins can only
+    # re-flag a legitimate name if a flavor later ships the same one —
+    # in that case the update is the right place to hear about it.
+    if errors:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={"registration_errors": errors},
+        )
+    updated = await update_ui_component(ui_component_id, patch)
+
+    if not updated:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to update ui_component",
+        )
+    return updated
+
+
+async def delete_ui_component_handler(
+    ui_component_id: str, current_user: UserInfo
+) -> DeleteUiComponentResponse:
+    await _fetch_scoped(ui_component_id, current_user, "delete ui_component")
+    deleted = await delete_ui_component(ui_component_id)
+    return DeleteUiComponentResponse(deleted=deleted, id=ui_component_id)

--- a/app/api/routers/breeze_buddy/widget/handlers.py
+++ b/app/api/routers/breeze_buddy/widget/handlers.py
@@ -30,6 +30,9 @@ from app.ai.voice.agents.breeze_buddy.chat.client_context import (
     ClientContextTooLarge,
     compute_context_patch,
 )
+from app.ai.voice.agents.breeze_buddy.chat.custom_components import (
+    resolve_custom_components,
+)
 from app.ai.voice.agents.breeze_buddy.chat.turn_core import (
     negotiate_catalog,
     resolve_session_catalog_version,
@@ -103,6 +106,7 @@ from app.schemas.breeze_buddy.chat import (
     CreateChatSessionRequest,
     CreateWidgetSessionRequest,
     CreateWidgetSessionResponse,
+    CustomComponentWire,
     GreetingTileWire,
     QuickReplyWire,
     SendChatMessageRequest,
@@ -181,6 +185,7 @@ class _WidgetSurface:
     quick_replies: List[QuickReplyWire] = field(default_factory=list)
     enable_text_input: bool = True
     greeting_tiles: List[GreetingTileWire] = field(default_factory=list)
+    response_reveal: str = "stream"
 
 
 def _extract_widget_config(template: object) -> _WidgetSurface:
@@ -215,10 +220,11 @@ def _extract_widget_config(template: object) -> _WidgetSurface:
             GreetingTileWire(label=t.label, prompt=t.prompt, image_url=t.image_url)
             for t in (getattr(configurations, "greeting_tiles", None) or [])
         ],
+        response_reveal=getattr(configurations, "response_reveal", "stream"),
     )
 
 
-def _surface_wire(
+async def _surface_wire(
     surface: _WidgetSurface,
     template: object,
     *,
@@ -228,16 +234,39 @@ def _surface_wire(
     """The one-block form of the session's presentation surface.
 
     Built from exactly the same values the flat response fields carry, so
-    the two can never disagree while both are on the wire.
+    the two can never disagree while both are on the wire. The registry
+    defs are fetched HERE, not by the callers — the block exists so a
+    surface field is filled in one place and every response (create,
+    resume, demo) gets it; a per-call keyword is how the demo response
+    lost it once already.
     """
     return WidgetSurfaceWire(
         quick_replies=surface.quick_replies,
         greeting_tiles=surface.greeting_tiles,
         enable_text_input=surface.enable_text_input,
+        response_reveal=surface.response_reveal,
         voice_enabled=_template_voice_enabled(template),
         catalog_active=catalog_active,
         ui_flavors=ui_flavors,
+        custom_components=await _custom_components_wire(template, catalog_active),
     )
+
+
+async def _custom_components_wire(
+    template: object, catalog_active: str
+) -> List[CustomComponentWire]:
+    """CHAMELEON: the render_def-bearing registry defs this session may
+    render, in wire form. Backend-only defs (render_def NULL) never ship —
+    the widget can't paint them and the props would leak schema detail the
+    merchant's own frontend owns. Empty on v1 sessions."""
+    if catalog_active != CATALOG_VERSION_V2:
+        return []
+    defs = await resolve_custom_components(template)  # type: ignore[arg-type]
+    return [
+        CustomComponentWire(name=d.name, version=d.version, render_def=d.render_def)
+        for d in defs.values()
+        if d.render_def
+    ]
 
 
 def _template_voice_enabled(template: object) -> bool:
@@ -345,8 +374,11 @@ async def create_widget_session_handler(
         voice_enabled=_template_voice_enabled(template),
         catalog_active=catalog_active,
         ui_flavors=ui_flavors,
-        widget=_surface_wire(
-            surface, template, catalog_active=catalog_active, ui_flavors=ui_flavors
+        widget=await _surface_wire(
+            surface,
+            template,
+            catalog_active=catalog_active,
+            ui_flavors=ui_flavors,
         ),
     )
 
@@ -1228,8 +1260,11 @@ async def get_widget_session_state_handler(
         voice_enabled=_template_voice_enabled(template),
         catalog_active=catalog_active,
         ui_flavors=ui_flavors,
-        widget=_surface_wire(
-            surface, template, catalog_active=catalog_active, ui_flavors=ui_flavors
+        widget=await _surface_wire(
+            surface,
+            template,
+            catalog_active=catalog_active,
+            ui_flavors=ui_flavors,
         ),
         template_vars=template_vars,
         metadata=session.metadata or {},

--- a/app/database/accessor/breeze_buddy/ui_component.py
+++ b/app/database/accessor/breeze_buddy/ui_component.py
@@ -1,0 +1,179 @@
+"""Async accessor functions for ui_component (migration 070).
+
+Thin wrappers around ``run_parameterized_query`` + ``decode_ui_component``.
+Returns Pydantic models, never raw rows. Errors are logged + re-raised so
+route handlers can convert them into the appropriate HTTP status.
+"""
+
+import json
+from typing import Any, Dict, List, Optional, Tuple
+
+from app.core.logger import logger
+from app.database.decoder.breeze_buddy.ui_component import decode_ui_component
+from app.database.queries import run_parameterized_query
+from app.database.queries.breeze_buddy.ui_component import (
+    create_ui_component_query,
+    delete_ui_component_query,
+    get_ui_component_by_id_query,
+    get_ui_components_by_names_query,
+    list_ui_components_query,
+    update_ui_component_query,
+)
+from app.schemas.breeze_buddy.ui_component import UiComponentResponse
+
+# Columns stored as JSONB — serialised on the way in; NULL passes through.
+_JSONB_COLUMNS = frozenset({"props_schema", "flags", "render_def"})
+
+
+async def create_ui_component(
+    *,
+    reseller_id: str,
+    merchant_id: Optional[str],
+    name: str,
+    props_schema: Dict[str, Any],
+    flags: Dict[str, Any],
+    render_def: Optional[Dict[str, Any]],
+    prompt_hint: Optional[str],
+    is_active: bool = True,
+) -> Optional[UiComponentResponse]:
+    query, values = create_ui_component_query(
+        reseller_id=reseller_id,
+        merchant_id=merchant_id,
+        name=name,
+        props_schema=json.dumps(props_schema),
+        flags=json.dumps(flags),
+        render_def=json.dumps(render_def) if render_def is not None else None,
+        prompt_hint=prompt_hint,
+        is_active=is_active,
+    )
+    try:
+        result = await run_parameterized_query(query, values)
+        row = result[0] if result else None
+        if row:
+            logger.info(
+                f"Created ui_component: reseller={reseller_id} "
+                f"merchant={merchant_id} name={name} id={row['id']}"
+            )
+            return decode_ui_component(row)
+        return None
+    except Exception as e:
+        logger.error(
+            f"Error creating ui_component {name!r} for reseller={reseller_id} "
+            f"merchant={merchant_id}: {e}"
+        )
+        raise
+
+
+async def get_ui_component_by_id(
+    ui_component_id: str,
+) -> Optional[UiComponentResponse]:
+    query, values = get_ui_component_by_id_query(ui_component_id)
+    try:
+        result = await run_parameterized_query(query, values)
+        row = result[0] if result else None
+        return decode_ui_component(row) if row else None
+    except Exception as e:
+        logger.error(f"Error fetching ui_component {ui_component_id}: {e}")
+        raise
+
+
+async def get_ui_components_by_names(
+    *,
+    reseller_id: str,
+    merchant_id: Optional[str],
+    names: List[str],
+) -> List[UiComponentResponse]:
+    """Session-start def fetch: active rows for the template's opt-in names
+    (merchant-specific rows shadow reseller-wide ones). Missing names are
+    simply absent from the result — the caller decides whether that's an
+    error or a silently-narrower catalog."""
+    if not names:
+        return []
+    query, values = get_ui_components_by_names_query(
+        reseller_id=reseller_id, merchant_id=merchant_id, names=names
+    )
+    try:
+        rows = await run_parameterized_query(query, values)
+        return [decode_ui_component(r) for r in rows] if rows else []
+    except Exception as e:
+        logger.error(
+            f"Error fetching ui_components {names} for reseller={reseller_id} "
+            f"merchant={merchant_id}: {e}"
+        )
+        raise
+
+
+async def list_ui_components(
+    *,
+    page: int = 1,
+    limit: int = 50,
+    reseller_id: Optional[str] = None,
+    merchant_id: Optional[str] = None,
+    reseller_ids: Optional[List[str]] = None,
+    merchant_ids: Optional[List[str]] = None,
+    include_inactive: bool = False,
+) -> Tuple[List[UiComponentResponse], int]:
+    query, count_query, values = list_ui_components_query(
+        page=page,
+        limit=limit,
+        reseller_id=reseller_id,
+        merchant_id=merchant_id,
+        reseller_ids=reseller_ids,
+        merchant_ids=merchant_ids,
+        include_inactive=include_inactive,
+    )
+    try:
+        rows = await run_parameterized_query(query, values)
+        count_result = await run_parameterized_query(count_query, values[:-2])
+        count_row = count_result[0] if count_result else None
+        items = [decode_ui_component(r) for r in rows] if rows else []
+        total = count_row["total"] if count_row else 0
+        return items, total
+    except Exception as e:
+        logger.error(f"Error listing ui_components: {e}")
+        raise
+
+
+async def update_ui_component(
+    ui_component_id: str,
+    patch: Dict[str, Any],
+) -> Optional[UiComponentResponse]:
+    """``patch`` holds ONLY the columns the caller supplied (Pydantic
+    ``exclude_unset``); a key present with ``None`` writes SQL NULL."""
+    query, values = update_ui_component_query(
+        ui_component_id=ui_component_id,
+        patch={
+            column: (
+                json.dumps(new_value)
+                if column in _JSONB_COLUMNS and new_value is not None
+                else new_value
+            )
+            for column, new_value in patch.items()
+        },
+    )
+    if not values:
+
+        return await get_ui_component_by_id(ui_component_id)
+    try:
+        result = await run_parameterized_query(query, values)
+        row = result[0] if result else None
+        if row:
+            logger.info(f"Updated ui_component: {ui_component_id}")
+            return decode_ui_component(row)
+        return None
+    except Exception as e:
+        logger.error(f"Error updating ui_component {ui_component_id}: {e}")
+        raise
+
+
+async def delete_ui_component(ui_component_id: str) -> bool:
+    query, values = delete_ui_component_query(ui_component_id)
+    try:
+        result = await run_parameterized_query(query, values)
+        deleted = bool(result)
+        if deleted:
+            logger.info(f"Deleted ui_component: {ui_component_id}")
+        return deleted
+    except Exception as e:
+        logger.error(f"Error deleting ui_component {ui_component_id}: {e}")
+        raise

--- a/app/database/decoder/breeze_buddy/ui_component.py
+++ b/app/database/decoder/breeze_buddy/ui_component.py
@@ -1,0 +1,33 @@
+"""Row → Pydantic decoder for ui_component (migration 070)."""
+
+import json
+from typing import Any, Dict, Optional
+
+from app.schemas.breeze_buddy.ui_component import UiComponentResponse
+
+
+def _jsonb(value: Any) -> Optional[Dict[str, Any]]:
+    """asyncpg returns JSONB as str without a codec — accept both."""
+    if value is None:
+        return None
+    if isinstance(value, str):
+        return json.loads(value)
+    return value
+
+
+def decode_ui_component(row) -> UiComponentResponse:
+    """Build UiComponentResponse from a ui_component asyncpg Record."""
+    return UiComponentResponse(
+        id=str(row["id"]),
+        reseller_id=row["reseller_id"],
+        merchant_id=row["merchant_id"],
+        name=row["name"],
+        version=row["version"],
+        props_schema=_jsonb(row["props_schema"]) or {},
+        flags=_jsonb(row["flags"]) or {},
+        render_def=_jsonb(row["render_def"]),
+        prompt_hint=row["prompt_hint"],
+        is_active=row.get("is_active", True),
+        created_at=row.get("created_at"),
+        updated_at=row.get("updated_at"),
+    )

--- a/app/database/migrations/070_create_ui_component.sql
+++ b/app/database/migrations/070_create_ui_component.sql
@@ -1,0 +1,56 @@
+-- ===========================================================================
+-- 070: ui_component — merchant-scoped custom UI component registry
+-- ---------------------------------------------------------------------------
+-- CHAMELEON: custom components as DATA. A row defines one merchant-specific
+-- component (e.g. Chennai One's JourneyOptions): a JSON-Schema contract for
+-- its hydrated props, behavioral flags the engine reads (selection field,
+-- list caps), and an OPTIONAL declarative render_def our widget interprets.
+-- Backend-only merchants (own frontend) leave render_def NULL.
+--
+-- Visibility is per-session data: a template opts in via
+-- configurations.ui_catalog.custom_components = ["JourneyOptions", ...];
+-- the chat agent overlays the named rows onto its session-scoped catalog.
+-- Nothing process-global changes — two merchants on the same worker never
+-- see each other's definitions.
+-- ===========================================================================
+
+CREATE TABLE IF NOT EXISTS ui_component (
+    id            uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    reseller_id   varchar(255) NOT NULL,
+    -- NULL = reseller-wide component (usable by any of the reseller's
+    -- templates that opt in by name).
+    merchant_id   varchar(255),
+    -- PascalCase component type, unique per scope (see index below). The
+    -- write path additionally rejects collisions with built-in catalog and
+    -- flavor component names.
+    name          varchar(128) NOT NULL,
+    -- Bumped on every update; hydrated ops and def caches key on it.
+    version       integer NOT NULL DEFAULT 1,
+    -- JSON Schema (draft 2020-12) for the component's hydrated props.
+    props_schema  jsonb NOT NULL,
+    -- Engine-read behavior: {"data_bound": true, "selection_field": "...",
+    -- "list_props": [...], "max_items_default": n, "max_items_limit": n}.
+    flags         jsonb NOT NULL DEFAULT '{}'::jsonb,
+    -- Declarative render tree for OUR widget/skins. NULL for merchants
+    -- rendering with their own frontend.
+    render_def    jsonb,
+    -- One or two sentences spliced into render_ui's bind coaching when the
+    -- component is offered ("Use JourneyOptions after search_journeys ...").
+    prompt_hint   text,
+    is_active     boolean NOT NULL DEFAULT TRUE,
+    created_at    timestamptz NOT NULL DEFAULT now(),
+    updated_at    timestamptz NOT NULL DEFAULT now(),
+    CONSTRAINT ui_component_version_positive CHECK (version > 0)
+);
+
+-- Uniqueness per (reseller, merchant, name) with NULL merchant folded to ''
+-- so a reseller-wide name can't be re-registered as a merchant row twice.
+CREATE UNIQUE INDEX IF NOT EXISTS ui_component_scope_name_unique
+    ON ui_component (reseller_id, COALESCE(merchant_id, ''), name);
+
+-- Session-start lookup (get_ui_components_by_names_query): reseller + name on
+-- ACTIVE rows only, so the is_active filter is answered by the index instead
+-- of a post-scan filter step.
+CREATE INDEX IF NOT EXISTS ui_component_active_lookup
+    ON ui_component (reseller_id, name)
+    WHERE is_active = TRUE;

--- a/app/database/queries/breeze_buddy/ui_component.py
+++ b/app/database/queries/breeze_buddy/ui_component.py
@@ -1,0 +1,195 @@
+"""SQL builders for ui_component (migration 070).
+
+Pure functions; no DB I/O. Returns ``Tuple[str, List[Any]]`` for
+``run_parameterized_query``. JSONB values arrive as JSON strings and are
+cast with ``::jsonb`` (same convention as the template queries).
+"""
+
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional, Tuple
+
+UI_COMPONENT_TABLE = "ui_component"
+
+_COLUMNS = (
+    "id, reseller_id, merchant_id, name, version, props_schema, flags, "
+    "render_def, prompt_hint, is_active, created_at, updated_at"
+)
+
+
+def create_ui_component_query(
+    *,
+    reseller_id: str,
+    merchant_id: Optional[str],
+    name: str,
+    props_schema: str,
+    flags: str,
+    render_def: Optional[str],
+    prompt_hint: Optional[str],
+    is_active: bool,
+) -> Tuple[str, List[Any]]:
+    query = f"""
+        INSERT INTO {UI_COMPONENT_TABLE} (
+            reseller_id, merchant_id, name, props_schema, flags,
+            render_def, prompt_hint, is_active, created_at, updated_at
+        ) VALUES (
+            $1, $2, $3, $4::jsonb, $5::jsonb, $6::jsonb, $7, $8, $9, $10
+        )
+        RETURNING {_COLUMNS}
+    """
+    now = datetime.now(timezone.utc)
+    return query, [
+        reseller_id,
+        merchant_id,
+        name,
+        props_schema,
+        flags,
+        render_def,
+        prompt_hint,
+        bool(is_active),
+        now,
+        now,
+    ]
+
+
+def get_ui_component_by_id_query(ui_component_id: str) -> Tuple[str, List[Any]]:
+    query = f"""
+        SELECT {_COLUMNS}
+        FROM {UI_COMPONENT_TABLE}
+        WHERE id = $1::uuid
+    """
+    return query, [ui_component_id]
+
+
+def get_ui_components_by_names_query(
+    *,
+    reseller_id: str,
+    merchant_id: Optional[str],
+    names: List[str],
+) -> Tuple[str, List[Any]]:
+    """Session-start def fetch: active rows matching the template's opt-in
+    names, scoped to the template's reseller — merchant rows win over
+    reseller-wide rows of the same name (ORDER + DISTINCT ON)."""
+    query = f"""
+        SELECT DISTINCT ON (name) {_COLUMNS}
+        FROM {UI_COMPONENT_TABLE}
+        WHERE reseller_id = $1
+          AND name = ANY($2)
+          AND is_active = TRUE
+          AND (merchant_id IS NULL OR merchant_id = $3)
+        ORDER BY name, merchant_id NULLS LAST
+    """
+    return query, [reseller_id, list(names), merchant_id or ""]
+
+
+def list_ui_components_query(
+    *,
+    page: int = 1,
+    limit: int = 50,
+    reseller_id: Optional[str] = None,
+    merchant_id: Optional[str] = None,
+    reseller_ids: Optional[List[str]] = None,
+    merchant_ids: Optional[List[str]] = None,
+    include_inactive: bool = False,
+) -> Tuple[str, str, List[Any]]:
+    """Returns (query, count_query, values) — same composition rules as
+    ``list_widget_configs_query``, except that the ``merchant_ids``
+    allowlist also admits reseller-wide rows (NULL merchant)."""
+    where: List[str] = []
+    params: List[Any] = []
+    idx = 1
+
+    if reseller_id:
+        where.append(f"reseller_id = ${idx}")
+        params.append(reseller_id)
+        idx += 1
+    elif reseller_ids is not None:
+        where.append(f"reseller_id = ANY(${idx})")
+        params.append(reseller_ids)
+        idx += 1
+
+    if merchant_id:
+        where.append(f"merchant_id = ${idx}")
+        params.append(merchant_id)
+        idx += 1
+    elif merchant_ids is not None:
+        # Reseller-wide rows are visible to anyone with reseller access —
+        # the same rule filter_templates_by_rbac applies to templates.
+        where.append(f"(merchant_id IS NULL OR merchant_id = ANY(${idx}))")
+        params.append(merchant_ids)
+        idx += 1
+
+    if not include_inactive:
+        where.append("is_active = TRUE")
+
+    where_clause = f"WHERE {' AND '.join(where)}" if where else ""
+    offset = max(page - 1, 0) * limit
+
+    query = f"""
+        SELECT {_COLUMNS}
+        FROM {UI_COMPONENT_TABLE}
+        {where_clause}
+        ORDER BY created_at DESC
+        LIMIT ${idx} OFFSET ${idx + 1}
+    """
+    count_query = f"SELECT COUNT(*) AS total FROM {UI_COMPONENT_TABLE} {where_clause}"
+    params.extend([limit, offset])
+    return query, count_query, params
+
+
+# Column → parameter cast for UPDATE. This allowlist is what keeps ``patch``
+# keys out of the SQL text: unknown keys are ignored, values are always $N.
+_UPDATABLE_COLUMNS = {
+    "props_schema": "::jsonb",
+    "flags": "::jsonb",
+    "render_def": "::jsonb",
+    "prompt_hint": "",
+    "is_active": "",
+}
+
+
+def update_ui_component_query(
+    *,
+    ui_component_id: str,
+    patch: Dict[str, Any],
+) -> Tuple[str, List[Any]]:
+    """``patch`` maps column → new value for ONLY the columns the caller
+    supplied; a ``None`` value writes NULL (the handler has already
+    refused null for NOT NULL columns). Returns ("", []) when nothing
+    updatable was supplied. Every real update bumps ``version`` —
+    hydrated ops and def caches key on it."""
+    set_clauses: List[str] = []
+    params: List[Any] = []
+    idx = 1
+
+    for column, cast in _UPDATABLE_COLUMNS.items():
+        if column not in patch:
+            continue
+        set_clauses.append(f"{column} = ${idx}{cast}")
+        params.append(patch[column])
+        idx += 1
+
+    if not set_clauses:
+        return "", []
+
+    set_clauses.append("version = version + 1")
+    set_clauses.append(f"updated_at = ${idx}")
+    params.append(datetime.now(timezone.utc))
+    idx += 1
+
+    params.append(ui_component_id)
+    query = f"""
+        UPDATE {UI_COMPONENT_TABLE}
+        SET {', '.join(set_clauses)}
+        WHERE id = ${idx}::uuid
+        RETURNING {_COLUMNS}
+    """
+    return query, params
+
+
+def delete_ui_component_query(ui_component_id: str) -> Tuple[str, List[Any]]:
+    query = f"""
+        DELETE FROM {UI_COMPONENT_TABLE}
+        WHERE id = $1::uuid
+        RETURNING id
+    """
+    return query, [ui_component_id]

--- a/app/schemas/breeze_buddy/chat.py
+++ b/app/schemas/breeze_buddy/chat.py
@@ -516,6 +516,18 @@ class GreetingTileWire(BaseModel):
     image_url: str = Field(..., description="Tile image URL (merchant CDN).")
 
 
+class CustomComponentWire(BaseModel):
+    """One CHAMELEON registry component in wire form: the declarative
+    ``render_def`` the widget's interpreter paints, keyed by (name, version)
+    so a client may cache it — a def never changes under a version."""
+
+    name: str = Field(..., description="PascalCase component type.")
+    version: int = Field(..., ge=1, description="Bumped on every registry update.")
+    render_def: Dict[str, Any] = Field(
+        ..., description="Declarative render tree (grammar v1)."
+    )
+
+
 class WidgetSurfaceWire(BaseModel):
     """Everything the embed needs to paint its chrome for one session.
 
@@ -542,6 +554,14 @@ class WidgetSurfaceWire(BaseModel):
     enable_text_input: bool = Field(
         True, description="False hides the composer (pills/tiles only)."
     )
+    response_reveal: str = Field(
+        "stream",
+        description=(
+            "'stream' (default) = typewriter reveal as tokens arrive; "
+            "'complete' = typing indicator until the reply finalizes, then "
+            "the full message at once. Presentation-only — SSE still streams."
+        ),
+    )
     voice_enabled: bool = Field(
         False,
         description=(
@@ -561,6 +581,15 @@ class WidgetSurfaceWire(BaseModel):
         description=(
             "Lazy UI flavor groups the template enables — preload these "
             "code-split chunks. Empty when catalog_active is 'v1'."
+        ),
+    )
+    custom_components: List[CustomComponentWire] = Field(
+        default_factory=list,
+        description=(
+            "CHAMELEON registry components this session may render — "
+            "render_def-bearing defs only (backend-only defs never ship). "
+            "The widget's declarative interpreter renders these; empty when "
+            "catalog_active is 'v1'."
         ),
     )
 

--- a/app/schemas/breeze_buddy/ui_component.py
+++ b/app/schemas/breeze_buddy/ui_component.py
@@ -1,0 +1,86 @@
+"""Pydantic models for ui_component rows (migration 070).
+
+The custom-component registry: merchant-specific UI components stored as
+DATA — a JSON-Schema props contract, engine-read flags, and an optional
+declarative ``render_def`` the widget interprets. See
+``ai/voice/agents/breeze_buddy/chat/ui/custom_defs.py`` for the write-time
+guards and the hydration path.
+"""
+
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, Field
+
+
+class UiComponentCreate(BaseModel):
+    """Body of ``POST /ui-components``."""
+
+    reseller_id: str = Field(..., min_length=1, max_length=255)
+    merchant_id: Optional[str] = Field(
+        None,
+        max_length=255,
+        description="NULL/omitted = reseller-wide component.",
+    )
+    name: str = Field(..., min_length=1, max_length=128)
+    props_schema: Dict[str, Any] = Field(
+        ..., description="JSON Schema (draft 2020-12) for the hydrated props."
+    )
+    flags: Dict[str, Any] = Field(
+        default_factory=dict,
+        description=(
+            "Engine flags: data_bound (must be true), selection_field, "
+            "list_props, max_items_default, max_items_limit."
+        ),
+    )
+    render_def: Optional[Dict[str, Any]] = Field(
+        None,
+        description=(
+            "Declarative render tree for our widget/skins. A row without one "
+            "is registered but never offered to the model or shipped to the "
+            "widget (reserved for merchants rendering with their own frontend)."
+        ),
+    )
+    prompt_hint: Optional[str] = Field(None, max_length=2000)
+    is_active: bool = True
+
+
+class UiComponentUpdate(BaseModel):
+    """Body of ``PUT /ui-components/{id}``.
+
+    Presence semantics (PATCH-style): a field omitted from the body is left
+    untouched; a field sent as ``null`` clears it — allowed for the nullable
+    columns (``render_def``, ``prompt_hint``), a 400 for the rest. Every
+    real update bumps ``version``.
+    """
+
+    props_schema: Optional[Dict[str, Any]] = None
+    flags: Optional[Dict[str, Any]] = None
+    render_def: Optional[Dict[str, Any]] = None
+    prompt_hint: Optional[str] = Field(None, max_length=2000)
+    is_active: Optional[bool] = None
+
+
+class UiComponentResponse(BaseModel):
+    """One ui_component row."""
+
+    id: str
+    reseller_id: str
+    merchant_id: Optional[str] = None
+    name: str
+    version: int = 1
+    props_schema: Dict[str, Any]
+    flags: Dict[str, Any] = Field(default_factory=dict)
+    render_def: Optional[Dict[str, Any]] = None
+    prompt_hint: Optional[str] = None
+    is_active: bool = True
+    created_at: Optional[datetime] = None
+    updated_at: Optional[datetime] = None
+
+
+class UiComponentListResponse(BaseModel):
+    """Body of ``GET /ui-components``."""
+
+    ui_components: List[UiComponentResponse]
+    total: int
+    page: int = 1

--- a/tests/test_custom_defs.py
+++ b/tests/test_custom_defs.py
@@ -1,0 +1,438 @@
+"""CHAMELEON custom-component registry: guards + hydration + LLM surface.
+
+Covers the pure halves of the feature (no DB, no agent):
+- registration guards (name, schema, flags, render_def lint)
+- resolve_custom_show_op (pointer walk, object lift, selection, caps,
+  JSON-Schema validation with structural-only errors)
+- render_ui enum joining + execute routing (two-merchant isolation lives
+  here too: a def not passed in is simply unknown)
+"""
+
+from typing import Any, Dict
+
+import pytest
+
+from app.ai.voice.agents.breeze_buddy.chat.ui.binding import BindingStore
+from app.ai.voice.agents.breeze_buddy.chat.ui.custom_defs import (
+    lint_render_def,
+    resolve_custom_show_op,
+    summarize_custom_render,
+    validate_registration,
+)
+from app.ai.voice.agents.breeze_buddy.chat.ui.render_ui_tool import (
+    execute_render_ui,
+    render_ui_components,
+)
+from app.ai.voice.agents.breeze_buddy.template.types import (
+    CustomComponentDef,
+    CustomComponentFlags,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+JOURNEY_SCHEMA: Dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "journeys": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "id": {"type": "string"},
+                    "summary": {"type": "string"},
+                    "duration_label": {"type": "string"},
+                    "min_fare_label": {"type": "string"},
+                },
+                "required": ["id"],
+            },
+        },
+    },
+    "required": ["journeys"],
+}
+
+
+def journey_def(**flag_overrides) -> CustomComponentDef:
+    flags = {
+        "data_bound": True,
+        "selection_field": "items",
+        "list_props": ["journeys"],
+        "max_items_default": 4,
+        "max_items_limit": 8,
+        **flag_overrides,
+    }
+    return CustomComponentDef(
+        name="JourneyOptions",
+        version=1,
+        props_schema=JOURNEY_SCHEMA,
+        flags=CustomComponentFlags.model_validate(flags),
+        render_def={"type": "col", "children": []},
+        prompt_hint="Bind journeys to $tool:search_journeys#/journeys",
+    )
+
+
+def store_with(tool: str, payload: Any) -> BindingStore:
+    store = BindingStore()
+    assert store.record(tool, "t1", payload)
+    return store
+
+
+JOURNEYS = [
+    {"id": "j1", "summary": "Metro via Alandur", "duration_label": "51 min"},
+    {"id": "j2", "summary": "Bus 570", "duration_label": "64 min"},
+    {"id": "j3", "summary": "Metro + walk", "duration_label": "58 min"},
+]
+
+
+# ---------------------------------------------------------------------------
+# Registration guards
+# ---------------------------------------------------------------------------
+
+
+class TestRegistrationGuards:
+    def test_clean_registration_passes(self):
+        assert (
+            validate_registration(
+                name="JourneyOptions",
+                props_schema=JOURNEY_SCHEMA,
+                flags={"data_bound": True},
+                render_def={"type": "col", "children": [{"type": "text"}]},
+            )
+            == []
+        )
+
+    def test_overlay_only_requires_render_def(self):
+        errors = validate_registration(
+            name="JourneyDetail",
+            props_schema=JOURNEY_SCHEMA,
+            flags={"data_bound": True, "overlay_only": True},
+            render_def=None,
+        )
+        assert any("overlay_only requires a render_def" in e for e in errors)
+
+    def test_model_renderable_filters_overlay_only(self):
+        from app.ai.voice.agents.breeze_buddy.chat.custom_components import (
+            model_renderable,
+        )
+        from app.ai.voice.agents.breeze_buddy.template.types import (
+            CustomComponentDef,
+            CustomComponentFlags,
+        )
+
+        defs = {
+            "JourneyOptions": CustomComponentDef(
+                name="JourneyOptions", props_schema={}, render_def={"type": "col"}
+            ),
+            "JourneyDetail": CustomComponentDef(
+                name="JourneyDetail",
+                props_schema={},
+                render_def={"type": "col"},
+                flags=CustomComponentFlags(overlay_only=True),
+            ),
+        }
+        assert set(model_renderable(defs)) == {"JourneyOptions"}
+
+    def test_model_renderable_filters_render_def_less(self):
+        """A def without a render_def never ships on the widget wire, so it
+        must not be offered to the model either — or the model can persist
+        a ui_op the widget cannot paint."""
+        from app.ai.voice.agents.breeze_buddy.chat.custom_components import (
+            model_renderable,
+        )
+        from app.ai.voice.agents.breeze_buddy.template.types import (
+            CustomComponentDef,
+        )
+
+        defs = {
+            "Renderable": CustomComponentDef(
+                name="Renderable", props_schema={}, render_def={"type": "col"}
+            ),
+            "BackendOnly": CustomComponentDef(name="BackendOnly", props_schema={}),
+        }
+        assert set(model_renderable(defs)) == {"Renderable"}
+
+    @pytest.mark.parametrize("bad", ["journeyOptions", "J", "Has Spaces", "x" * 70])
+    def test_name_must_be_pascal_case(self, bad):
+        errors = validate_registration(
+            name=bad, props_schema={}, flags={}, render_def=None
+        )
+        assert any("PascalCase" in e for e in errors)
+
+    def test_builtin_collision_rejected(self):
+        for taken in ("Card", "ProductGrid", "QuickReplies"):
+            errors = validate_registration(
+                name=taken, props_schema={}, flags={}, render_def=None
+            )
+            assert any("collides" in e for e in errors), taken
+
+    def test_invalid_json_schema_rejected(self):
+        errors = validate_registration(
+            name="GoodName",
+            props_schema={"type": "not-a-type"},
+            flags={},
+            render_def=None,
+        )
+        assert any("JSON Schema" in e for e in errors)
+
+    def test_literal_fields_rejected(self):
+        errors = validate_registration(
+            name="GoodName",
+            props_schema={},
+            flags={"literal_fields": ["eta"]},
+            render_def=None,
+        )
+        assert any("literal_fields" in e for e in errors)
+
+    def test_data_bound_false_rejected(self):
+        errors = validate_registration(
+            name="GoodName",
+            props_schema={},
+            flags={"data_bound": False},
+            render_def=None,
+        )
+        assert any("data_bound" in e for e in errors)
+
+
+class TestRenderDefLint:
+    def test_unknown_node_type(self):
+        assert any(
+            "unknown node type" in e
+            for e in lint_render_def({"type": "script", "children": []})
+        )
+
+    def test_depth_cap(self):
+        node: Dict[str, Any] = {"type": "text"}
+        for _ in range(10):
+            node = {"type": "box", "children": [node]}
+        assert any("depth" in e for e in lint_render_def(node))
+
+    def test_static_open_url_must_be_https(self):
+        bad = {
+            "type": "button",
+            "props": {
+                "label": "Go",
+                "action": {"type": "open_url", "url": "http://x.example/y"},
+            },
+        }
+        assert any("https" in e for e in lint_render_def(bad))
+        good = dict(
+            bad,
+            props={
+                "label": "Go",
+                "action": {"type": "open_url", "url": "https://x.example/y"},
+            },
+        )
+        assert lint_render_def(good) == []
+
+    def test_bound_open_url_allowed(self):
+        node = {
+            "type": "button",
+            "props": {
+                "label": "Ticket",
+                "action": {"type": "open_url", "url": "{$props.ticket_url}"},
+            },
+        }
+        assert lint_render_def(node) == []
+
+    def test_open_detail_component_must_be_static_pascal(self):
+        bad = {
+            "type": "button",
+            "props": {
+                "label": "View details",
+                "action": {"type": "open_detail", "component": "{$props.c}"},
+            },
+        }
+        assert any("PascalCase" in e for e in lint_render_def(bad))
+        good = {
+            "type": "button",
+            "props": {
+                "label": "View details",
+                "action": {
+                    "type": "open_detail",
+                    "component": "JourneyDetail",
+                    "title": "Your journey",
+                    "props": {"journey_id": "{$j.id}", "legs": "$j.legs"},
+                },
+            },
+        }
+        assert lint_render_def(good) == []
+
+    def test_open_detail_props_must_be_object(self):
+        bad = {
+            "type": "button",
+            "props": {
+                "label": "x",
+                "action": {
+                    "type": "open_detail",
+                    "component": "JourneyDetail",
+                    "props": ["not", "an", "object"],
+                },
+            },
+        }
+        assert any("props must be an object" in e for e in lint_render_def(bad))
+
+    def test_repeat_binding_syntax(self):
+        bad = {"type": "box", "repeat": {"in": "journeys", "as": "j"}}
+        assert any("repeat.in" in e for e in lint_render_def(bad))
+        good = {"type": "box", "repeat": {"in": "$props.journeys", "as": "j"}}
+        assert lint_render_def(good) == []
+
+    def test_to_assistant_needs_msg(self):
+        node = {
+            "type": "button",
+            "props": {"label": "Pick", "action": {"type": "to_assistant"}},
+        }
+        assert any("msg" in e for e in lint_render_def(node))
+
+
+# ---------------------------------------------------------------------------
+# Hydration
+# ---------------------------------------------------------------------------
+
+
+def _ok(result) -> Dict[str, Any]:
+    assert result.error is None, result.error
+    assert result.op is not None
+    return result.op
+
+
+def _err(result) -> str:
+    assert result.op is None
+    assert result.error is not None
+    return result.error
+
+
+class TestResolveCustomShowOp:
+    def _op(self, **overrides) -> Dict[str, Any]:
+        op = {
+            "op": "show",
+            "id": "root",
+            "component": "JourneyOptions",
+            "bind": {"journeys": "$tool:search_journeys#/journeys"},
+            "props": {},
+        }
+        op.update(overrides)
+        return op
+
+    def test_happy_path_hydrates(self):
+        store = store_with("search_journeys", {"journeys": JOURNEYS})
+        op = _ok(resolve_custom_show_op(self._op(), store, journey_def()))
+        assert op["type"] == "JourneyOptions"
+        assert op["v"] == 2
+        assert [j["id"] for j in op["props"]["journeys"]] == ["j1", "j2", "j3"]
+
+    def test_missing_tool_drops(self):
+        error = _err(resolve_custom_show_op(self._op(), BindingStore(), journey_def()))
+        assert error.startswith("bind_unresolved:")
+
+    def test_selection_order_respected(self):
+        store = store_with("search_journeys", {"journeys": JOURNEYS})
+        show = self._op(props={"items": [{"id": "j3"}, {"id": "j1"}]})
+        op = _ok(resolve_custom_show_op(show, store, journey_def()))
+        assert [j["id"] for j in op["props"]["journeys"]] == ["j3", "j1"]
+        assert "items" not in op["props"]
+
+    def test_mangled_selection_fails_open(self):
+        store = store_with("search_journeys", {"journeys": JOURNEYS})
+        show = self._op(props={"items": [{"id": "nope"}]})
+        op = _ok(resolve_custom_show_op(show, store, journey_def()))
+        assert len(op["props"]["journeys"]) == 3
+
+    def test_caps_apply(self):
+        many = [{"id": f"j{i}", "summary": "s"} for i in range(12)]
+        store = store_with("search_journeys", {"journeys": many})
+        op = _ok(resolve_custom_show_op(self._op(), store, journey_def()))
+        assert len(op["props"]["journeys"]) == 4  # max_items_default
+        show = self._op(props={"max_items": 20})
+        op = _ok(resolve_custom_show_op(show, store, journey_def()))
+        assert len(op["props"]["journeys"]) == 8  # max_items_limit
+        assert "max_items" not in op["props"]
+
+    def test_single_object_lifts_to_list(self):
+        store = store_with("search_journeys", {"journeys": JOURNEYS[0]})
+        op = _ok(resolve_custom_show_op(self._op(), store, journey_def()))
+        assert [j["id"] for j in op["props"]["journeys"]] == ["j1"]
+
+    def test_schema_validation_structural_only(self):
+        store = store_with("search_journeys", {"journeys": [{"summary": 42}]})
+        error = _err(resolve_custom_show_op(self._op(), store, journey_def()))
+        assert error.startswith("bind_validation_failed:JourneyOptions:")
+        assert "42" not in error  # never echo values
+
+    def test_summary_echoes_referents(self):
+        store = store_with("search_journeys", {"journeys": JOURNEYS})
+        op = _ok(resolve_custom_show_op(self._op(), store, journey_def()))
+        summary = summarize_custom_render(journey_def(), op["props"])
+        assert summary["rendered"] == "JourneyOptions"
+        assert summary["count"] == 3
+        assert summary["journeys"][0]["id"] == "j1"
+
+
+# ---------------------------------------------------------------------------
+# LLM surface: enum joining + execute routing + isolation
+# ---------------------------------------------------------------------------
+
+
+class TestRenderUiSurface:
+    def test_custom_names_join_enum_v2_only(self):
+        allow = {"QuickReplies", "JourneyOptions"}
+        assert "JourneyOptions" in render_ui_components(
+            allow, True, custom_components={"JourneyOptions"}
+        )
+        # v1 session: customs pruned along with every data-bound component
+        assert "JourneyOptions" not in render_ui_components(
+            allow, False, custom_components={"JourneyOptions"}
+        )
+
+    def test_execute_routes_custom(self):
+        store = store_with("search_journeys", {"journeys": JOURNEYS})
+        defs = {"JourneyOptions": journey_def()}
+        outcome = execute_render_ui(
+            {
+                "component": "JourneyOptions",
+                "bind": [
+                    {"prop": "journeys", "ref": "$tool:search_journeys#/journeys"}
+                ],
+            },
+            store=store,
+            allowlist={"JourneyOptions"},
+            components=["JourneyOptions"],
+            op_id="root",
+            custom_defs=defs,
+        )
+        assert outcome.decision == "rendered"
+        assert outcome.ops[0]["type"] == "JourneyOptions"
+        assert outcome.fn_result["count"] == 3
+
+    def test_execute_requires_bind_for_custom(self):
+        outcome = execute_render_ui(
+            {"component": "JourneyOptions"},
+            store=BindingStore(),
+            allowlist={"JourneyOptions"},
+            components=["JourneyOptions"],
+            op_id="root",
+            custom_defs={"JourneyOptions": journey_def()},
+        )
+        assert outcome.fn_result["status"] == "error"
+        assert "data-bound" in outcome.fn_result["error"]
+
+    def test_two_merchant_isolation(self):
+        """A session without the def treats the component as unknown even
+        when another session on the same worker carries it."""
+        store = store_with("search_journeys", {"journeys": JOURNEYS})
+        outcome = execute_render_ui(
+            {
+                "component": "JourneyOptions",
+                "bind": [
+                    {"prop": "journeys", "ref": "$tool:search_journeys#/journeys"}
+                ],
+            },
+            store=store,
+            allowlist={"QuickReplies"},
+            components=["QuickReplies"],  # other merchant's enum
+            op_id="root",
+            custom_defs={},  # no overlay on THIS session
+        )
+        assert outcome.fn_result["status"] == "error"
+        assert "unknown component" in outcome.fn_result["error"]

--- a/tests/test_direct_intent_engine.py
+++ b/tests/test_direct_intent_engine.py
@@ -265,3 +265,149 @@ def _install_direct_intent_stubs(monkeypatch, capture_merge):
     monkeypatch.setattr(router, "create_aiohttp_session", lambda: None)
     monkeypatch.setattr(router, "upsert_agent_session_state_merge", capture_merge)
     monkeypatch.setattr(router, "ChatAgent", _Agent)
+
+
+# ---------------------------------------------------------------------------
+# Template-intent enrich rules — cross-tool selected-marking
+# ---------------------------------------------------------------------------
+
+
+def test_template_intent_enrich_marks_selected_tier():
+    from app.ai.voice.agents.breeze_buddy.chat.intents.template_intents import (
+        _apply_enrich,
+    )
+    from app.ai.voice.agents.breeze_buddy.chat.ui.binding import BindingStore
+    from app.ai.voice.agents.breeze_buddy.template.types import (
+        CustomUiIntent,
+        CustomUiIntentStep,
+        UiIntentEnrichRule,
+    )
+
+    store = BindingStore()
+    store.record(
+        "get_journey_details",
+        None,
+        {"status": "success", "selected_quote_id": "q2"},
+    )
+    store.record(
+        "get_tier_options",
+        None,
+        {
+            "status": "success",
+            "tiers": [
+                {"quote_id": "q1", "name": "First Class"},
+                {"quote_id": "q2", "name": "Second Class"},
+            ],
+        },
+    )
+
+    class _Agent:
+        binding_store = store
+
+    cfg = CustomUiIntent(
+        name="journey_detail",
+        steps=[CustomUiIntentStep(tool="get_journey_details")],
+        enrich=[
+            UiIntentEnrichRule(
+                list_ref="$tool:get_tier_options#/tiers",
+                match_field="quote_id",
+                equals_ref="$tool:get_journey_details#/selected_quote_id",
+                set={"selected": True, "state_label": "Selected"},
+                else_set={"unselected": True},
+            )
+        ],
+    )
+    _apply_enrich(_Agent(), cfg)
+    tiers = store.resolve("get_tier_options")["tiers"]
+    assert tiers[1]["selected"] is True and tiers[1]["state_label"] == "Selected"
+    assert "selected" not in tiers[0] and tiers[0]["unselected"] is True
+
+
+def test_template_intent_enrich_null_target_marks_nothing():
+    """A null match target (the API omitted the selected value) must leave
+    the list untouched — the earlier str() compare marked every item that
+    lacked the match field as selected (str(None) == str(None))."""
+    from app.ai.voice.agents.breeze_buddy.chat.intents.template_intents import (
+        _apply_enrich,
+    )
+    from app.ai.voice.agents.breeze_buddy.chat.ui.binding import BindingStore
+    from app.ai.voice.agents.breeze_buddy.template.types import (
+        CustomUiIntent,
+        CustomUiIntentStep,
+        UiIntentEnrichRule,
+    )
+
+    store = BindingStore()
+    store.record("gjd", None, {"status": "success", "selected_quote_id": None})
+    store.record(
+        "tiers",
+        None,
+        {"status": "success", "tiers": [{"name": "no quote id"}, {"quote_id": "q1"}]},
+    )
+
+    class _Agent:
+        binding_store = store
+
+    rule = UiIntentEnrichRule(
+        list_ref="$tool:tiers#/tiers",
+        match_field="quote_id",
+        equals_ref="$tool:gjd#/selected_quote_id",
+        set={"selected": True},
+        else_set={"unselected": True},
+    )
+    cfg = CustomUiIntent(
+        name="n", steps=[CustomUiIntentStep(tool="gjd")], enrich=[rule]
+    )
+    _apply_enrich(_Agent(), cfg)
+    assert store.resolve("tiers")["tiers"] == [
+        {"name": "no quote id"},
+        {"quote_id": "q1"},
+    ]
+
+    # a real target still never matches an item that lacks the field
+    store.record("gjd", None, {"status": "success", "selected_quote_id": "q1"})
+    _apply_enrich(_Agent(), cfg)
+    tiers = store.resolve("tiers")["tiers"]
+    assert tiers[0] == {"name": "no quote id", "unselected": True}
+    assert tiers[1]["selected"] is True
+
+
+def test_template_intent_enrich_fail_open():
+
+    from app.ai.voice.agents.breeze_buddy.chat.intents.template_intents import (
+        _apply_enrich,
+    )
+    from app.ai.voice.agents.breeze_buddy.chat.ui.binding import BindingStore
+    from app.ai.voice.agents.breeze_buddy.template.types import (
+        CustomUiIntent,
+        CustomUiIntentStep,
+        UiIntentEnrichRule,
+    )
+
+    store = BindingStore()
+    store.record("t", None, {"status": "success", "xs": [{"id": "a"}]})
+
+    class _Agent:
+        binding_store = store
+
+    # bad ref + missing tool + non-list target: all silently skipped
+    cfg = CustomUiIntent(
+        name="n",
+        steps=[CustomUiIntentStep(tool="t")],
+        enrich=[
+            UiIntentEnrichRule(
+                list_ref="no-prefix#/xs",
+                match_field="id",
+                equals_ref="$tool:t#/missing",
+                set={"s": 1},
+            ),
+            UiIntentEnrichRule(
+                list_ref="$tool:absent#/xs",
+                match_field="id",
+                equals_ref="$tool:t#/xs",
+                set={"s": 1},
+            ),
+        ],
+    )
+    _apply_enrich(_Agent(), cfg)
+    assert store.resolve("t")["xs"] == [{"id": "a"}]

--- a/tests/test_response_transform.py
+++ b/tests/test_response_transform.py
@@ -21,7 +21,12 @@ from app.ai.voice.agents.breeze_buddy.template.types import ResponseTransform
 
 from app.ai.voice.agents.breeze_buddy.handlers.transport.utils.response_transform import (
     apply_response_transforms,
+    count_where,
+    find_where,
+    mark_extremum,
     derive_field,
+    format_range,
+    map_values,
     omit_fields,
     pick_fields,
     scale_by_exponent,
@@ -777,3 +782,447 @@ def test_derive_field_malformed_template_is_noop():
     )
     # Original values preserved, no "out" field added.
     assert data["products"] == [{"id": "ok-1"}, {"id": "ok-2"}]
+
+
+# ---------------------------------------------------------------------------
+# map_values — display-layer value rename (scalar + list)
+# ---------------------------------------------------------------------------
+
+
+def test_map_values_scalar_and_list():
+    leg = {"mode": "Subway"}
+    map_values(
+        leg,
+        {"field": "mode", "to": "mode_display", "map": {"Subway": "Train"}},
+    )
+    assert leg["mode_display"] == "Train"
+    assert leg["mode"] == "Subway"  # source untouched
+
+    journey = {"modes": ["Walk", "Subway", "Walk"]}
+    map_values(
+        journey,
+        {"field": "modes", "to": "modes_display", "map": {"Subway": "Train"}},
+    )
+    assert journey["modes_display"] == ["Walk", "Train", "Walk"]
+
+
+def test_map_values_unmapped_keeps_original_unless_default():
+    leg = {"mode": "Metro"}
+    map_values(leg, {"field": "mode", "to": "d", "map": {"Subway": "Train"}})
+    assert leg["d"] == "Metro"
+    map_values(
+        leg,
+        {"field": "mode", "to": "d2", "map": {"Subway": "Train"}, "default": "?"},
+    )
+    assert leg["d2"] == "?"
+
+
+def test_map_values_bad_args_noop():
+    leg = {"mode": "Bus"}
+    map_values(leg, {"field": "mode", "to": "x", "map": "not-a-dict"})
+    assert "x" not in leg
+    map_values(leg, {"field": "missing", "to": "x", "map": {}})
+    assert "x" not in leg
+
+
+# ---------------------------------------------------------------------------
+# format_range — min/max display label
+# ---------------------------------------------------------------------------
+
+
+def test_format_range_equal_and_span():
+    j = {"min_fare": 30, "max_fare": 30}
+    format_range(
+        j,
+        {"min_field": "min_fare", "max_field": "max_fare", "to": "fare", "prefix": "₹"},
+    )
+    assert j["fare"] == "₹30"
+    j2 = {"min_fare": 10, "max_fare": 55}
+    format_range(
+        j2,
+        {"min_field": "min_fare", "max_field": "max_fare", "to": "fare", "prefix": "₹"},
+    )
+    assert j2["fare"] == "₹10–55"
+
+
+def test_format_range_missing_side_and_skip_zero():
+    j = {"min_fare": 15}
+    format_range(
+        j,
+        {"min_field": "min_fare", "max_field": "max_fare", "to": "fare", "prefix": "₹"},
+    )
+    assert j["fare"] == "₹15"
+    z = {"min_fare": 0, "max_fare": 0}
+    format_range(
+        z,
+        {
+            "min_field": "min_fare",
+            "max_field": "max_fare",
+            "to": "fare",
+            "prefix": "₹",
+            "skip_zero": True,
+        },
+    )
+    assert "fare" not in z
+
+
+def test_format_range_non_numeric_noop():
+    j = {"min_fare": "abc", "max_fare": 5}
+    format_range(j, {"min_field": "min_fare", "max_field": "max_fare", "to": "fare"})
+    assert "fare" not in j
+
+
+def test_format_range_from_style():
+    j = {"min_fare": 5, "max_fare": 35}
+    format_range(
+        j,
+        {
+            "min_field": "min_fare",
+            "max_field": "max_fare",
+            "to": "fare",
+            "prefix": "₹",
+            "style": "from",
+        },
+    )
+    assert j["fare"] == "from ₹5"
+    # equal bounds stay plain regardless of style
+    e = {"min_fare": 30, "max_fare": 30}
+    format_range(
+        e,
+        {
+            "min_field": "min_fare",
+            "max_field": "max_fare",
+            "to": "fare",
+            "prefix": "₹",
+            "style": "from",
+        },
+    )
+    assert e["fare"] == "₹30"
+
+
+# ---------------------------------------------------------------------------
+# mark_extremum — cross-item ranking tags (Fastest / Cheapest)
+# ---------------------------------------------------------------------------
+
+
+def test_mark_extremum_min_and_second_pass_skips_tagged():
+    data = {
+        "journeys": [
+            {"id": "a", "duration": 900, "min_fare": 40},
+            {"id": "b", "duration": 1700, "min_fare": 5},
+            {"id": "c", "duration": 2000, "min_fare": 30},
+        ]
+    }
+    mark_extremum(
+        data,
+        {
+            "list_field": "journeys",
+            "field": "duration",
+            "to": "tag",
+            "label": "Fastest",
+        },
+    )
+    mark_extremum(
+        data,
+        {
+            "list_field": "journeys",
+            "field": "min_fare",
+            "to": "tag",
+            "label": "Cheapest",
+        },
+    )
+    tags = [j.get("tag") for j in data["journeys"]]
+    assert tags == ["Fastest", "Cheapest", None]
+
+
+def test_mark_extremum_fastest_also_cheapest_stays_fastest():
+    data = {
+        "journeys": [
+            {"id": "a", "duration": 900, "min_fare": 5},
+            {"id": "b", "duration": 1700, "min_fare": 30},
+        ]
+    }
+    mark_extremum(
+        data,
+        {
+            "list_field": "journeys",
+            "field": "duration",
+            "to": "tag",
+            "label": "Fastest",
+        },
+    )
+    mark_extremum(
+        data,
+        {
+            "list_field": "journeys",
+            "field": "min_fare",
+            "to": "tag",
+            "label": "Cheapest",
+        },
+    )
+    # a took Fastest; Cheapest then goes to the best REMAINING (b)
+    assert [j.get("tag") for j in data["journeys"]] == ["Fastest", "Cheapest"]
+
+
+def test_mark_extremum_max_and_bad_values():
+    data = {"items": [{"v": "x"}, {"v": 2}, {"v": 9}]}
+    mark_extremum(
+        data,
+        {"list_field": "items", "field": "v", "mode": "max", "to": "t", "label": "Top"},
+    )
+    assert data["items"][2]["t"] == "Top"
+    # no numeric values at all → no-op
+    empty = {"items": [{"v": None}]}
+    mark_extremum(
+        empty, {"list_field": "items", "field": "v", "to": "t", "label": "Top"}
+    )
+    assert "t" not in empty["items"][0]
+
+
+# ---------------------------------------------------------------------------
+# count_where — predicate counting (transfers)
+# ---------------------------------------------------------------------------
+
+
+def test_count_where_transfers():
+    j = {
+        "legs": [{"mode": "Walk"}, {"mode": "Bus"}, {"mode": "Metro"}, {"mode": "Walk"}]
+    }
+    count_where(
+        j,
+        {
+            "list_field": "legs",
+            "field": "mode",
+            "not_in": ["Walk"],
+            "offset": -1,
+            "min": 0,
+            "to": "transfers",
+        },
+    )
+    assert j["transfers"] == 1
+    direct = {"legs": [{"mode": "Walk"}, {"mode": "Metro"}]}
+    count_where(
+        direct,
+        {
+            "list_field": "legs",
+            "field": "mode",
+            "not_in": ["Walk"],
+            "offset": -1,
+            "min": 0,
+            "to": "transfers",
+        },
+    )
+    assert direct["transfers"] == 0
+
+
+def test_count_where_in_filter_and_noop():
+    j = {"legs": [{"mode": "Bus"}, {"mode": "Bus"}, {"mode": "Walk"}]}
+    count_where(
+        j, {"list_field": "legs", "field": "mode", "in": ["Bus"], "to": "buses"}
+    )
+    assert j["buses"] == 2
+    bad = {"legs": "not-a-list"}
+    count_where(bad, {"list_field": "legs", "field": "mode", "to": "n"})
+    assert "n" not in bad
+
+
+# ---------------------------------------------------------------------------
+# find_where — first-match field lifting (transit leg order for intents)
+# ---------------------------------------------------------------------------
+
+
+def test_find_where_lifts_first_transit_leg():
+    j = {
+        "legs": [
+            {"mode": "Walk", "order": 0},
+            {"mode": "Subway", "order": 1},
+            {"mode": "Metro", "order": 2},
+        ]
+    }
+    find_where(
+        j,
+        {
+            "list_field": "legs",
+            "field": "mode",
+            "not_in": ["Walk", "Taxi"],
+            "set": {"tier_leg_order": "order", "tier_leg_found": "mode"},
+        },
+    )
+    assert j["tier_leg_order"] == 1
+    assert j["tier_leg_found"] == "Subway"
+
+
+def test_find_where_in_filter_no_match_and_noop():
+    j = {"legs": [{"mode": "Walk", "order": 0}, {"mode": "Taxi", "order": 1}]}
+    find_where(
+        j,
+        {
+            "list_field": "legs",
+            "field": "mode",
+            "in": ["Subway", "Metro", "Bus"],
+            "set": {"tier_leg_order": "order"},
+        },
+    )
+    assert "tier_leg_order" not in j
+    # zero order copies verbatim (falsy values are data, not misses)
+    z = {"legs": [{"mode": "Metro", "order": 0}]}
+    find_where(
+        z,
+        {
+            "list_field": "legs",
+            "field": "mode",
+            "not_in": ["Walk"],
+            "set": {"tier_leg_order": "order"},
+        },
+    )
+    assert z["tier_leg_order"] == 0
+    bad = {"legs": "nope"}
+    find_where(bad, {"list_field": "legs", "field": "mode", "set": {"x": "order"}})
+    assert "x" not in bad
+    # missing source field on the match: destination stays absent
+    m = {"legs": [{"mode": "Bus"}]}
+    find_where(
+        m,
+        {
+            "list_field": "legs",
+            "field": "mode",
+            "not_in": ["Walk"],
+            "set": {"tier_leg_order": "order"},
+        },
+    )
+    assert "tier_leg_order" not in m
+
+
+def test_coalesce_default_guarantees_field():
+    from app.ai.voice.agents.breeze_buddy.handlers.transport.utils.response_transform import (
+        coalesce,
+    )
+
+    absent = {}
+    coalesce(absent, {"fields": ["tier"], "to": "tier", "default": ""})
+    assert absent["tier"] == ""
+    none_val = {"tier": None}
+    coalesce(none_val, {"fields": ["tier"], "to": "tier", "default": ""})
+    assert none_val["tier"] == ""
+    present = {"tier": "FIRST_CLASS"}
+    coalesce(present, {"fields": ["tier"], "to": "tier", "default": ""})
+    assert present["tier"] == "FIRST_CLASS"
+    zero = {"n": 0}
+    coalesce(zero, {"fields": ["n"], "to": "n", "default": -1})
+    assert zero["n"] == 0
+    # no default: legacy no-op on miss
+    legacy = {}
+    coalesce(legacy, {"fields": ["missing"], "to": "out"})
+    assert "out" not in legacy
+
+
+# ---------------------------------------------------------------------------
+# upcoming_times — next departures after "now" from a service-day timetable
+# ---------------------------------------------------------------------------
+
+
+def _pin_clock(monkeypatch, hour: int, minute: int = 0):
+    """Freeze the transform module's wall clock at HH:MM UTC on a fixed
+    date so the timetable fixtures below are deterministic — the earlier
+    now()-relative version wrapped past midnight near 23:20 UTC."""
+    from datetime import datetime, timezone
+
+    import app.ai.voice.agents.breeze_buddy.handlers.transport.utils.response_transform as rt
+
+    fixed = datetime(2026, 9, 7, hour, minute, 0, tzinfo=timezone.utc)
+    monkeypatch.setattr(rt, "_utc_now", lambda: fixed)
+    return rt
+
+
+def test_upcoming_times_filters_and_formats(monkeypatch):
+    rt = _pin_clock(monkeypatch, 10, 0)  # 10:00 UTC
+
+    # pair-shaped entries: last element (departure) is used
+    d = {
+        "times": [
+            ["08:55:00", "09:00:00"],
+            ["09:55:00", "10:10:00"],
+            ["10:40:00", "10:40:00"],
+            ["11:10:00", "11:10:00"],
+        ]
+    }
+    rt.upcoming_times(d, {"field": "times", "to": "next_label", "count": 2})
+    assert d["next_label"] == "10:10 AM, 10:40 AM"
+
+    # exactly-now is not upcoming; bare strings work; count caps
+    edge = {"times": ["10:00:00", "10:05", "10:06:00", "10:07:00"]}
+    rt.upcoming_times(edge, {"field": "times", "to": "next_label", "count": 1})
+    assert edge["next_label"] == "10:05 AM"
+
+    # all in the past → field NOT written (absence = no more today)
+    gone = {"times": ["07:00:00", "09:59:59"]}
+    rt.upcoming_times(gone, {"field": "times", "to": "next_label"})
+    assert "next_label" not in gone
+
+    # malformed entries skipped; non-list no-op
+    junk = {"times": ["nope", None, 42, "10:30:00"]}
+    rt.upcoming_times(junk, {"field": "times", "to": "next_label", "count": 1})
+    assert junk["next_label"] == "10:30 AM"
+    bad = {"times": "x"}
+    rt.upcoming_times(bad, {"field": "times", "to": "n"})
+    assert "n" not in bad
+
+
+def test_upcoming_times_tz_offset_and_arg_guards(monkeypatch):
+    rt = _pin_clock(monkeypatch, 10, 0)  # 10:00 UTC == 15:30 IST
+
+    # timetable strings are local to tz_offset; "now" is computed there
+    ist = {"times": ["15:15:00", "15:45:00", "16:00:00"]}
+    rt.upcoming_times(ist, {"field": "times", "to": "n", "tz_offset": 330})
+    assert ist["n"] == "3:45 PM, 4:00 PM"
+
+    # non-string fmt / separator fall back to the documented defaults
+    # instead of raising inside strftime / join and aborting the pass
+    guarded = {"times": ["10:30:00", "10:45:00"]}
+    rt.upcoming_times(
+        guarded, {"field": "times", "to": "n", "fmt": 7, "separator": ["x"]}
+    )
+    assert guarded["n"] == "10:30 AM, 10:45 AM"
+    custom = {"times": ["10:30:00", "10:45:00"]}
+    rt.upcoming_times(
+        custom, {"field": "times", "to": "n", "fmt": "%H:%M", "separator": " / "}
+    )
+    assert custom["n"] == "10:30 / 10:45"
+
+
+# ---------------------------------------------------------------------------
+# format_number / format_time — review-found edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_format_number_ignores_non_finite_values():
+    from app.ai.voice.agents.breeze_buddy.handlers.transport.utils.response_transform import (
+        format_number,
+    )
+
+    for raw in ("nan", "inf", "-inf", float("nan"), float("inf")):
+        d = {"amount": raw}
+        assert format_number(d, {"field": "amount", "to": "label"}) is d
+        assert "label" not in d
+    ok = {"amount": "12.5"}
+    format_number(ok, {"field": "amount", "to": "label", "prefix": "₹"})
+    assert ok["label"] == "₹12"
+
+
+def test_format_time_honours_zero_offset():
+    from app.ai.voice.agents.breeze_buddy.handlers.transport.utils.response_transform import (
+        format_time,
+    )
+
+    # +05:30 source displayed in UTC: 0 is a real offset, not "unset"
+    utc = {"at": "2026-09-07T15:30:00+05:30"}
+    format_time(utc, {"field": "at", "to": "label", "tz_offset": 0})
+    assert utc["label"] == "10:00"
+    # unset offset leaves the source zone alone
+    same = {"at": "2026-09-07T15:30:00+05:30"}
+    format_time(same, {"field": "at", "to": "label"})
+    assert same["label"] == "15:30"
+    # bool is not an offset
+    boolean = {"at": "2026-09-07T15:30:00+05:30"}
+    format_time(boolean, {"field": "at", "to": "label", "tz_offset": True})
+    assert boolean["label"] == "15:30"

--- a/tests/test_transport_guards.py
+++ b/tests/test_transport_guards.py
@@ -1,0 +1,150 @@
+"""Guards on the template HTTP transport that a review found missing.
+
+1. SSRF: the URL validator has NO environment-dependent carve-out. Plain
+   http is refused everywhere, and a loopback target stays blocked even
+   over https — in dev exactly as in production. (An earlier draft of this
+   branch admitted plain-http loopback outside production; review removed
+   it, and this test pins the unconditional posture.)
+2. ``retry_until`` re-issues a request verbatim, so ``HttpRequestConfig``
+   refuses it on any mutating method at load time.
+3. ``TOOL_RESULT`` pointers decode RFC 6901 escapes (``~1`` → ``/``,
+   ``~0`` → ``~``) before each lookup.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+# isort: off
+# template.types must load before the transport modules (see the note in
+# test_response_transform.py — reversing the order trips a circular import).
+from app.ai.voice.agents.breeze_buddy.template.types import (
+    FieldConfig,
+    FieldSource,
+    HttpRequestConfig,
+    RetryUntilConfig,
+)
+
+import app.ai.voice.agents.breeze_buddy.handlers.transport.http_requester as hr
+from app.ai.voice.agents.breeze_buddy.handlers.transport.utils.field_resolver import (
+    FieldResolver,
+)
+
+# isort: on
+
+_validate = hr.HttpRequestExecutor._validate_resolved_url
+
+
+# ---------------------------------------------------------------------------
+# SSRF: no environment carve-out
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("env", ["dev", "development", "staging", "production"])
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://127.0.0.1:8787/pay",
+        "http://localhost/pay",
+        "http://[::1]:8787/pay",
+        "http://example.com/x",
+    ],
+)
+def test_plain_http_is_refused_in_every_environment(monkeypatch, env, url):
+    monkeypatch.setattr(hr, "ENVIRONMENT", env)
+    with pytest.raises(ValueError, match="Only HTTPS"):
+        _validate(url)
+
+
+@pytest.mark.parametrize("env", ["dev", "production"])
+def test_loopback_and_private_targets_blocked_over_https_too(monkeypatch, env):
+    monkeypatch.setattr(hr, "ENVIRONMENT", env)
+    # production refuses by hostname first ("localhost ... not allowed"),
+    # dev by address class ("loopback") — refused either way.
+    with pytest.raises(ValueError, match="not allowed"):
+        _validate("https://127.0.0.1/x")
+    with pytest.raises(ValueError, match="not allowed"):
+        _validate("https://[::1]/x")
+
+    with pytest.raises(ValueError, match="private"):
+        _validate("https://192.168.1.1/x")
+    with pytest.raises(ValueError):
+        _validate("https://169.254.169.254/latest/meta-data")
+    _validate("https://api.example.com/v1")  # public https is always fine
+
+
+# ---------------------------------------------------------------------------
+# retry_until is GET-only
+# ---------------------------------------------------------------------------
+
+
+def test_retry_until_allowed_on_get():
+    cfg = HttpRequestConfig(
+        url="https://api.example.com/journeys/{id}",
+        method="GET",
+        retry_until=RetryUntilConfig(field="allJourneysLoaded"),
+    )
+    assert cfg.retry_until is not None
+
+
+@pytest.mark.parametrize("method", ["POST", "PUT", "PATCH", "DELETE"])
+def test_retry_until_refused_on_mutating_methods(method):
+    with pytest.raises(
+        ValidationError, match="retry_until is only allowed with method GET"
+    ):
+        HttpRequestConfig(
+            url="https://api.example.com/orders",
+            method=method,
+            retry_until=RetryUntilConfig(field="ready"),
+        )
+
+
+def test_retry_until_default_method_is_post_so_it_must_be_explicit():
+    with pytest.raises(ValidationError):
+        HttpRequestConfig(
+            url="https://api.example.com/orders",
+            retry_until=RetryUntilConfig(field="ready"),
+        )
+
+
+# ---------------------------------------------------------------------------
+# TOOL_RESULT pointer decoding
+# ---------------------------------------------------------------------------
+
+
+class _Store:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def resolve(self, tool_name, tool_use_id=None):
+        return self._payload if tool_name == "t" else None
+
+
+class _Bot:
+    def __init__(self, payload):
+        self.binding_store = _Store(payload)
+
+
+class _Ctx:
+    def __init__(self, payload):
+        self.bot = _Bot(payload)
+
+
+def _resolve(payload, expr):
+    resolver = FieldResolver(
+        context=_Ctx(payload),  # pyrefly: ignore[bad-argument-type]
+        args={},
+    )
+
+    return resolver._resolve_tool_result(
+        FieldConfig(source=FieldSource.TOOL_RESULT, value=expr), "f"
+    )
+
+
+def test_tool_result_pointer_decodes_rfc6901_escapes():
+    payload = {"a/b": {"m~n": ["x", "y"]}, "plain": 1}
+    assert _resolve(payload, "t#/a~1b/m~0n/1") == "y"
+    assert _resolve(payload, "t#/plain") == 1
+    # the undecoded literal is not a key
+    assert _resolve({"a~1b": 1}, "t#/a~1b") is None

--- a/tests/test_ui_components_rbac.py
+++ b/tests/test_ui_components_rbac.py
@@ -1,0 +1,208 @@
+"""ui_component CRUD: merchant-scoped listing and PATCH-style update.
+
+Two review findings, both about the boundary between the route handler
+and the query builder:
+
+1. Listing must scope by the caller's MERCHANTS as well as resellers —
+   both allowlists reach the SQL, which filters before pagination and
+   the total. Reseller-wide rows (NULL merchant) remain visible to any
+   user with reseller access, as templates do.
+2. Update distinguishes "field omitted" (untouched) from "field sent as
+   null" (cleared) via Pydantic field presence. NOT NULL columns refuse an
+   explicit null with a 400.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+import pytest
+from fastapi import HTTPException
+
+import app.api.routers.breeze_buddy.ui_components.handlers as handlers
+from app.database.queries.breeze_buddy.ui_component import (
+    list_ui_components_query,
+    update_ui_component_query,
+)
+from app.schemas import UserInfo
+from app.schemas.breeze_buddy.ui_component import (
+    UiComponentResponse,
+    UiComponentUpdate,
+)
+
+SCHEMA = {"type": "object", "properties": {"items": {"type": "array"}}}
+
+
+def _user(role="reseller", resellers=("r1",), merchants=("m1",)) -> UserInfo:
+    return UserInfo(
+        id="u1",
+        username="u1",
+        role=role,
+        reseller_ids=list(resellers),
+        merchant_ids=list(merchants),
+    )
+
+
+# ---------------------------------------------------------------------------
+# list: merchant allowlist reaches the query
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def captured_list(monkeypatch) -> Dict[str, Any]:
+    seen: Dict[str, Any] = {}
+
+    async def fake_list(**kwargs):
+        seen.update(kwargs)
+        return [], 0
+
+    monkeypatch.setattr(handlers, "list_ui_components", fake_list)
+    return seen
+
+
+async def _list(user: UserInfo, **overrides):
+    kwargs = dict(
+        reseller_id=None,
+        merchant_id=None,
+        include_inactive=False,
+        page=1,
+        limit=50,
+        current_user=user,
+    )
+    kwargs.update(overrides)
+    return await handlers.list_ui_components_handler(**kwargs)
+
+
+@pytest.mark.asyncio
+async def test_list_scopes_non_admin_to_their_merchants(captured_list):
+    await _list(_user())
+    assert captured_list["reseller_ids"] == ["r1"]
+    assert captured_list["merchant_ids"] == ["m1"]
+
+
+@pytest.mark.asyncio
+async def test_list_refuses_merchant_outside_scope(captured_list):
+    with pytest.raises(HTTPException) as exc:
+        await _list(_user(), merchant_id="m2")
+    assert exc.value.status_code == 403
+    assert captured_list == {}  # never reached the accessor
+
+
+@pytest.mark.asyncio
+async def test_list_passes_explicit_merchant_inside_scope(captured_list):
+    await _list(_user(merchants=("m1", "m2")), merchant_id="m2")
+    assert captured_list["merchant_id"] == "m2"
+    assert captured_list["merchant_ids"] == ["m1", "m2"]
+
+
+@pytest.mark.asyncio
+async def test_list_wildcard_and_admin_skip_merchant_filter(captured_list):
+    await _list(_user(merchants=("*",)))
+    assert captured_list["merchant_ids"] is None
+    assert captured_list["reseller_ids"] == ["r1"]
+    captured_list.clear()
+    await _list(_user(role="admin", resellers=(), merchants=()))
+    assert captured_list["merchant_ids"] is None
+    assert captured_list["reseller_ids"] is None
+
+
+def test_list_query_admits_reseller_wide_rows_for_merchant_allowlist():
+    query, count_query, params = list_ui_components_query(
+        reseller_ids=["r1"], merchant_ids=["m1"]
+    )
+    clause = "(merchant_id IS NULL OR merchant_id = ANY($2))"
+    assert clause in query and clause in count_query
+    assert params[:2] == [["r1"], ["m1"]]
+    # an explicit merchant_id wins over the allowlist
+    query, _, params = list_ui_components_query(merchant_id="m1", merchant_ids=["m1"])
+    assert "merchant_id = $1" in query and "ANY" not in query
+
+
+# ---------------------------------------------------------------------------
+# update: presence semantics
+# ---------------------------------------------------------------------------
+
+
+def _row(**overrides) -> UiComponentResponse:
+    base: Dict[str, Any] = dict(
+        id="11111111-1111-1111-1111-111111111111",
+        reseller_id="r1",
+        merchant_id="m1",
+        name="JourneyOptions",
+        version=3,
+        props_schema=SCHEMA,
+        flags={"data_bound": True},
+        render_def={"type": "col", "children": [{"type": "text"}]},
+        prompt_hint="hint",
+    )
+    base.update(overrides)
+    return UiComponentResponse(**base)
+
+
+@pytest.fixture
+def captured_update(monkeypatch) -> List[Any]:
+    calls: List[Any] = []
+
+    async def fake_get(ui_component_id):
+        return _row()
+
+    async def fake_update(ui_component_id, patch):
+        calls.append(patch)
+        return _row(**{k: v for k, v in patch.items()})
+
+    monkeypatch.setattr(handlers, "get_ui_component_by_id", fake_get)
+    monkeypatch.setattr(handlers, "update_ui_component", fake_update)
+    return calls
+
+
+@pytest.mark.asyncio
+async def test_update_forwards_only_supplied_fields(captured_update):
+    body = UiComponentUpdate.model_validate({"prompt_hint": "new"})
+    await handlers.update_ui_component_handler(_row().id, body, _user())
+    assert captured_update == [{"prompt_hint": "new"}]
+
+
+@pytest.mark.asyncio
+async def test_update_explicit_null_clears_nullable_fields(captured_update):
+    body = UiComponentUpdate.model_validate({"render_def": None, "prompt_hint": None})
+    await handlers.update_ui_component_handler(_row().id, body, _user())
+    assert captured_update == [{"render_def": None, "prompt_hint": None}]
+
+
+@pytest.mark.asyncio
+async def test_update_explicit_null_refused_on_not_null_columns(captured_update):
+    body = UiComponentUpdate.model_validate({"props_schema": None, "is_active": None})
+    with pytest.raises(HTTPException) as exc:
+        await handlers.update_ui_component_handler(_row().id, body, _user())
+    assert exc.value.status_code == 400
+    assert "props_schema" in exc.value.detail and "is_active" in exc.value.detail
+    assert captured_update == []
+
+
+@pytest.mark.asyncio
+async def test_update_reruns_guards_on_merged_row(captured_update, monkeypatch):
+    # clearing render_def on an overlay_only def is refused, as at create
+    async def fake_get(ui_component_id):
+        return _row(flags={"data_bound": True, "overlay_only": True})
+
+    monkeypatch.setattr(handlers, "get_ui_component_by_id", fake_get)
+    body = UiComponentUpdate.model_validate({"render_def": None})
+    with pytest.raises(HTTPException) as exc:
+        await handlers.update_ui_component_handler(_row().id, body, _user())
+    assert exc.value.status_code == 400
+    assert captured_update == []
+
+
+def test_update_query_writes_null_and_ignores_unknown_keys():
+    query, params = update_ui_component_query(
+        ui_component_id="id-1",
+        patch={"render_def": None, "prompt_hint": "p", "not_a_column": "x"},
+    )
+    assert "render_def = $1::jsonb" in query and "prompt_hint = $2" in query
+    assert "not_a_column" not in query
+    assert "version = version + 1" in query
+    assert params[:2] == [None, "p"] and params[-1] == "id-1"
+    assert update_ui_component_query(ui_component_id="id-1", patch={}) == ("", [])
+    assert update_ui_component_query(
+        ui_component_id="id-1", patch={"not_a_column": 1}
+    ) == ("", [])

--- a/tests/test_widget_surface_block.py
+++ b/tests/test_widget_surface_block.py
@@ -48,10 +48,10 @@ def _template(voice: bool = False) -> SimpleNamespace:
     )
 
 
-def test_block_carries_the_same_values_as_the_flat_fields():
+async def test_block_carries_the_same_values_as_the_flat_fields():
     surface = _surface()
     template = _template(voice=True)
-    block = _surface_wire(
+    block = await _surface_wire(
         surface, template, catalog_active="v2", ui_flavors=["commerce"]
     )
     # Field-for-field against the SAME sources the flat response fields are
@@ -76,17 +76,54 @@ def test_every_session_response_exposes_the_block():
         assert "widget" in model.model_fields, model.__name__
 
 
-def test_block_defaults_are_safe_for_a_bare_template():
+async def test_block_defaults_are_safe_for_a_bare_template():
+
     # A template with no widget config at all still produces a legal block:
     # empty pills/tiles, composer ON, voice OFF, v1 catalog. A default that
     # hid the composer would lock a shopper out of a working session.
-    block = _surface_wire(
+    block = await _surface_wire(
         _WidgetSurface(quick_replies=[], greeting_tiles=[], enable_text_input=True),
         _template(),
         catalog_active="v1",
         ui_flavors=[],
     )
     assert block == WidgetSurfaceWire()
+
+
+async def test_custom_components_ride_the_block_from_one_place(monkeypatch):
+    """The registry defs are fetched INSIDE ``_surface_wire`` — every
+    response that builds the block (create, resume, demo) gets them without
+    a per-call keyword to forget. Typed entries, render_def-bearing defs
+    only, and nothing at all on a v1 catalog."""
+    from app.ai.voice.agents.breeze_buddy.template.types import CustomComponentDef
+    from app.api.routers.breeze_buddy.widget import handlers as widget_handlers
+    from app.schemas.breeze_buddy.chat import CustomComponentWire
+
+    async def fake_resolve(template):
+        return {
+            "JourneyOptions": CustomComponentDef(
+                name="JourneyOptions",
+                version=28,
+                props_schema={},
+                render_def={"type": "col"},
+            ),
+            "BackendOnly": CustomComponentDef(name="BackendOnly", props_schema={}),
+        }
+
+    monkeypatch.setattr(widget_handlers, "resolve_custom_components", fake_resolve)
+
+    v2 = await _surface_wire(
+        _surface(), _template(), catalog_active="v2", ui_flavors=[]
+    )
+    assert v2.custom_components == [
+        CustomComponentWire(
+            name="JourneyOptions", version=28, render_def={"type": "col"}
+        )
+    ]
+    v1 = await _surface_wire(
+        _surface(), _template(), catalog_active="v1", ui_flavors=[]
+    )
+    assert v1.custom_components == []
 
 
 def test_demo_response_defaults_the_block_when_unset():


### PR DESCRIPTION
## CHAMELEON — merchant custom components + template-defined direct intents

Per-merchant UI for Buddy Assist driven entirely by **template config + a DB registry** — no per-merchant code ships in this diff.

### What's in here (one commit, per repo convention)

**Registry** — migration 070 `ui_component` (+ three-layer DB access, RBAC CRUD under `/breeze-buddy/ui-components`): JSON-Schema props, declarative `render_def` (linted grammar v1: whitelisted node types, depth/node caps, `to_assistant`/`open_url`/`open_detail`/`intent` actions only), `overlay_only` flag, reseller **and merchant** scoping on list (reseller-wide rows stay visible to anyone with reseller access), PATCH-style update (omitted field = untouched; explicit `null` clears `render_def`/`prompt_hint`, 400 on NOT NULL columns), partial index `(reseller_id, name) WHERE is_active` for the session-start lookup.

**Session overlay** — a template opts into defs via `ui_catalog.custom_components`; they join the render_ui enum/coaching/allowlist per session and hydrate through `resolve_custom_show_op` against the turn's BindingStore (same trust path as built-ins). `model_renderable()` keeps overlay-only **and render_def-less** defs out of the model vocabulary (mirrors the widget wire filter). The widget surface block ships the render_def-bearing defs as typed `CustomComponentWire` entries, fetched inside `_surface_wire` so create, resume **and demo** responses all carry them.

**Template-defined DIRECT intents** (`ui_intents.custom`) — config-authored `IntentPolicy` rows on the existing `/intent` engine: tool steps run through the persisted pipeline with **no LLM call**, cross-tool `enrich` rules mark list items (e.g. the currently selected fare tier; a null match target marks nothing), and a registry component hydrates as the show op. `parse_ui_intent` gains `extra_policies` (checked first, template-scoped, exempt from the flavor gate).

**Generic engine additions** — `FieldSource.TOOL_RESULT` arg binding (RFC 6901 `~1`/`~0` decoded), `retry_until` on `HttpRequestConfig` (**GET-only — refused at load time on mutating methods**), http_requester read-to-EOF fix (chunked long-poll responses were truncated), `response_reveal` surface field, response transforms `map_values` / `format_range` / `mark_extremum` / `count_where` / `find_where` / `upcoming_times` / `coalesce default` (+ non-finite, zero-offset and bad-argument guards).

**SSRF posture** — unchanged: `_validate_resolved_url` is byte-identical to `release` (HTTPS only, loopback / private / link-local blocked, in every environment). The dev-only loopback carve-out from the first revision is removed outright, and `tests/test_transport_guards.py` pins the unconditional posture. The only http_requester change left is the read-to-EOF fix.

### Validation
- `uv run pytest tests/` — 2357 passed, 15 skipped, 1 xfailed (full suite on the rebased commit); `pyrefly` 0 errors; black / isort / autoflake clean; `scripts/check_migrations.py` and `scripts/check_crm_boundaries.py` OK.
- Proven E2E against the Chennai One demo at round 0 (local widget → this backend → real NY sandbox): journey cards, class selection (`getLegTierOptions`/`switchFRFSTier`), server-hydrated detail overlay, booking with HITL approval. Round 1 changes are unit-tested; the Chennai One template re-validates against the new load-time checks.

### Review round 1 (7 Sep 2026) — every thread addressed

| Finding | Fix |
|---|---|
| 🔒 SSRF dev carve-out (Tara) | removed outright — the validator is back to the `release` version (no env-var gate either); `tests/test_transport_guards.py` pins plain-http refused and loopback blocked in every environment |
| 🔒 cross-merchant list read (Tara + CodeRabbit) | handler passes the caller's merchant allowlist; query filters before pagination and the total, `*` preserved — `tests/test_ui_components_rbac.py` |
| nullable update semantics | `model_fields_set`-driven patch through handler → accessor → query; explicit `null` clears nullable columns, 400 for the rest |
| `model_renderable` render_def filter | also drops render_def-less defs, matching `_custom_components_wire` |
| enrich null target | `target is None` / missing match field → no-op |
| JSON Pointer `~1`/`~0` | decoded per RFC 6901 before each lookup |
| `format_number` non-finite · `format_time` tz_offset=0 · `upcoming_times` fmt/separator | guarded, tested |
| `retry_until` idempotency | GET-only, enforced by a `model_validator` on `HttpRequestConfig` |
| `__all__` complete + sorted · Loguru `opt(exception=True)` · day-boundary test flake (clock pinned via `_utc_now`) | done |
| index suggestion on the registry table | partial index `(reseller_id, name) WHERE is_active = TRUE` |
| (self-review) demo response lacked `custom_components` | the registry fetch moved inside `_surface_wire`, so no call site can omit it; entries typed as `CustomComponentWire(name, version, render_def)` — `tests/test_widget_surface_block.py` |

Also in this round: rebased onto `release` (39 commits) — the migration is renumbered **057 → 070** (release took 057); `resolve_custom_components` made attribute-tolerant so release's `test_turn_core` template stubs pass; `response_reveal` and `ui_intents.custom` documented in `field_reference.json`.

### Notes for reviewers
- No secrets in the diff (audited): no tokens, keys, or merchant credentials — merchant provisioning (templates/defs) stays in the DB via the admin API.
- Known follow-ups: prod already ships `format_number` + `uap_pay`/`uap_order_status` builtins — reconcile with this branch's local variants; def cache per (component_id, version) instead of per-turn fetch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MExhDfX8SUSdPpA8ruW4sG
