### PR TITLE
feat(crm): WhatsApp webhooks — verify, resolve the merchant, file to the spine

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -161,6 +161,23 @@ META_WHATSAPP_GRAPH_VERSION=v23.0
 # one dial and the others must follow.
 CRM_MESSAGE_SEND_TIMEOUT_SECONDS=20
 
+# Inbound webhooks: Meta posts delivery receipts and customer replies to one
+# callback URL for the whole app. Both secrets are PLATFORM-level (one Meta
+# app): the payload naming the merchant cannot be trusted until the signature
+# is verified, and verifying it needs the secret. Empty means every callback
+# is refused — the /ingest/webhooks/{provider} bays are the unauthenticated
+# routes in the service, and the signature is their only authentication.
+#
+# Register the callback URL (https://<host>/ingest/webhooks/meta) once per
+# environment in the Meta app dashboard (App -> WhatsApp -> Configuration ->
+# Webhook), subscribing the fields: messages,
+# message_template_status_update, template_category_update,
+# message_template_quality_update, account_update. Onboarding subscribes
+# each account; if that failed or Meta unsubscribed one later,
+# POST /connectors/installations/{id}/subscribe turns it back on.
+META_APP_SECRET=""
+META_WEBHOOK_VERIFY_TOKEN=""
+
 # Webhook Authentication
 ORDER_CONFIRMATION_WEBHOOK_SECRET_KEY=""
 ORDER_CONFIRMATION_TOKEN=""
@@ -202,14 +219,14 @@ AWS_SECRET_ACCESS_KEY=""
 
 # Meta (WhatsApp Embedded Signup + Graph API)
 # Used by app/crm/connectivity to onboard a WhatsApp Business Account and
-# register message templates. META_APP_SECRET is also the key that will
-# verify inbound Meta webhooks, so it is named once here for both.
+# register message templates. META_APP_SECRET lives in the inbound-webhooks
+# block above — ONE definition; the same secret signs the Graph calls here
+# and verifies inbound webhooks there.
 #
 # Empty is a legal boot: a deployment that never connects WhatsApp needs
 # neither, and a Graph call without them fails loudly at the call rather
 # than at import.
 META_APP_ID=
-META_APP_SECRET=
 # Ceiling on ONE non-send Graph call (onboarding, template registration).
 # Live-tunable: resolved Redis -> env -> 15, awaited per call, so this env
 # value is the floor a deployment starts from, not the last word.

--- a/app/core/config/static.py
+++ b/app/core/config/static.py
@@ -547,13 +547,19 @@ META_WHATSAPP_GRAPH_BASE_URL = os.environ.get(
 META_WHATSAPP_GRAPH_VERSION = os.environ.get("META_WHATSAPP_GRAPH_VERSION", "v23.0")
 
 # The app identity behind Embedded Signup and every non-send Graph call
-# (code exchange, template registration). APP_SECRET is also what will verify
-# inbound Meta webhooks — the same secret proves both directions.
-# Empty is a legal boot: a deployment that never connects WhatsApp needs
-# neither, and a Graph call without them fails loudly at the call, not at
-# import (there is no get_required_env() in this repo to lean on).
+# (code exchange, template registration). APP_SECRET also verifies inbound
+# Meta webhooks — one secret proves both directions — and both are
+# PLATFORM-level by necessity: the payload naming the merchant cannot be
+# trusted until the signature is verified, and verifying it needs the
+# secret. Empty is a legal boot (a deployment that never connects WhatsApp
+# needs neither): a Graph call without them fails loudly at the call, and an
+# inbound webhook is REFUSED — fail closed, or anyone can write delivery
+# receipts to us.
 META_APP_ID = os.environ.get("META_APP_ID", "")
 META_APP_SECRET = os.environ.get("META_APP_SECRET", "")
+
+# Echoed back once, when the callback URL is registered in the Meta app.
+META_WEBHOOK_VERIFY_TOKEN = os.environ.get("META_WEBHOOK_VERIFY_TOKEN", "")
 
 
 # Announcement Banner Configuration

--- a/app/crm/api.py
+++ b/app/crm/api.py
@@ -13,15 +13,29 @@ because webhook ingress must stay reachable without a bearer token.
 
 from fastapi import APIRouter
 
-from app.crm.connectivity import api as connectivity_api
+from app.crm.connectivity import (
+    api as connectivity_api,
+    contracts as connectivity_contracts,
+)
 from app.crm.identity import api as identity_api
 from app.crm.outreach import api as outreach_api
-from app.crm.record import api as record_api
+from app.crm.record import api as record_api, ingress as record_ingress
 
 router = APIRouter()
 router.include_router(identity_api.router, prefix="/customers", tags=["Customers"])
 router.include_router(record_api.journey_router, prefix="/customers", tags=["Journey"])
 router.include_router(record_api.ingest_router, prefix="/ingest", tags=["Ingest"])
+# The provider bays beside the envelope door above (design/ingest-doors: one
+# mailroom, two entrance kinds). These routes carry NO bearer auth — each
+# provider authenticates by its own signature ritual inside its registered
+# bay, so /ingest/webhooks/{provider} must stay reachable without a token.
+router.include_router(
+    record_api.webhook_router, prefix="/ingest/webhooks", tags=["Ingest"]
+)
+# The one registration line per provider bay — the same line worker_main
+# writes for consumers, and the inversion that keeps rule 12 whole: record
+# owns the slot, this root fills it, and record never imports back.
+record_ingress.register_ingress("meta", connectivity_contracts.META_INGRESS)
 router.include_router(outreach_api.router, prefix="/workflows", tags=["Workflows"])
 router.include_router(
     outreach_api.customer_router, prefix="/customers", tags=["Workflows"]

--- a/app/crm/connectivity/api.py
+++ b/app/crm/connectivity/api.py
@@ -3,7 +3,9 @@ check, delegate to contracts.py.
 
 Mounted at ``/connectors``. The paths carry no internal word (ADR 0022): a
 merchant connecting WhatsApp is connecting a CONNECTOR, which is the noun the
-console, the docs and the corpus all use.
+console, the docs and the corpus all use. The provider webhook bays are NOT
+here — their routes are record's (/ingest/webhooks/{provider}); webhooks.py
+registers this module's mechanics into them.
 
 **The routes are connector-agnostic.** ``POST /{connector_key}/onboard``
 takes a plain body and asks the CONNECTORS registry which model validates it.
@@ -25,7 +27,14 @@ so there is no single "current" one to infer from the token.
 
 from typing import Any, Dict, List, Optional
 
-from fastapi import APIRouter, Body, Depends, HTTPException, Query, status
+from fastapi import (
+    APIRouter,
+    Body,
+    Depends,
+    HTTPException,
+    Query,
+    status,
+)
 from pydantic import ValidationError
 
 from app.api.security.breeze_buddy.rbac_token import get_current_user_with_rbac
@@ -33,7 +42,10 @@ from app.core.logger.context import set_log_context
 from app.crm.auth import assert_merchant_access
 from app.crm.connectivity import contracts
 from app.crm.connectivity.onboarding import OnboardingError, UnknownConnectorError
-from app.crm.connectivity.schemas.connector import InstallationRead
+from app.crm.connectivity.schemas.connector import (
+    InstallationRead,
+    SubscriptionResult,
+)
 from app.crm.connectivity.schemas.template import (
     CreateTemplateDraftRequest,
     EditTemplateRequest,
@@ -52,10 +64,12 @@ router = APIRouter()
 
 
 def _bad_request(error: Exception) -> HTTPException:
+    """The caller's mistake, with the reason."""
     return HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(error))
 
 
 def _not_found(error: Exception) -> HTTPException:
+    """An absence, with the reason."""
     return HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(error))
 
 
@@ -105,6 +119,7 @@ async def list_installations_route(
     merchant_id: str = Query(..., description="Tenant scope — required"),
     current_user: UserInfo = Depends(get_current_user_with_rbac),
 ) -> List[InstallationRead]:
+    """Every connected account this merchant holds."""
     assert_merchant_access(current_user, merchant_id, "list connections")
     set_log_context(component="crm.connectivity.installations", merchant_id=merchant_id)
     return await contracts.list_installations(merchant_id)
@@ -116,6 +131,7 @@ async def get_installation_route(
     merchant_id: str = Query(..., description="Tenant scope — required"),
     current_user: UserInfo = Depends(get_current_user_with_rbac),
 ) -> InstallationRead:
+    """One connected account, merchant-scoped."""
     assert_merchant_access(current_user, merchant_id, "read a connection")
     set_log_context(component="crm.connectivity.installations", merchant_id=merchant_id)
     installation = await contracts.get_installation(merchant_id, installation_id)
@@ -134,6 +150,7 @@ async def disconnect_route(
     merchant_id: str = Query(..., description="Tenant scope — required"),
     current_user: UserInfo = Depends(get_current_user_with_rbac),
 ) -> InstallationRead:
+    """Revoke a connected account; its pipes pause with it."""
     assert_merchant_access(current_user, merchant_id, "disconnect a connection")
     set_log_context(component="crm.connectivity.disconnect", merchant_id=merchant_id)
     installation = await contracts.disconnect(merchant_id, installation_id)
@@ -254,3 +271,37 @@ async def retire_template_route(
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(e)) from e
     except TemplateError as e:
         raise _bad_request(e) from e
+
+
+@router.post(
+    "/installations/{installation_id}/subscribe",
+    response_model=SubscriptionResult,
+)
+async def subscribe_installation_route(
+    installation_id: str,
+    merchant_id: str = Query(..., description="Tenant scope — required"),
+    current_user: UserInfo = Depends(get_current_user_with_rbac),
+) -> SubscriptionResult:
+    """(Re)subscribe this connected account to our app's webhooks.
+
+    Onboarding subscribes on its happy path; this is the RECOVERY door — a
+    handshake that could not subscribe, or an account the provider quietly
+    unsubscribed — and it spends no fresh signup code, which re-onboarding
+    would require. 409 on refusal: understood and deliberately declined,
+    with a message the caller can act on. Success re-stamps the door's
+    health in the same act, so sends resolve again without a second button.
+    """
+    assert_merchant_access(current_user, merchant_id, "subscribe a connection")
+    set_log_context(component="crm.connectivity.subscribe", merchant_id=merchant_id)
+    try:
+        installation = await contracts.resubscribe(merchant_id, installation_id)
+    except OnboardingError as e:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(e)) from e
+    if installation is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Connection not found"
+        )
+    return SubscriptionResult(
+        installation_id=installation_id,
+        external_account_id=installation.external_account_id or "",
+    )

--- a/app/crm/connectivity/contracts.py
+++ b/app/crm/connectivity/contracts.py
@@ -28,6 +28,16 @@ What is here, and why each thing is on the surface:
   count of open runs naming a template, so retire can refuse to pull a
   template from under a run in flight without this module importing
   outreach (phase 14; the record/consumers.py inversion).
+- ``META_INGRESS`` — the Meta bay for record's /ingest/webhooks/{provider}
+  door (ingress.py builds it; app/crm/api.py registers it into record's
+  INGRESS slot — the same line worker_main writes for consumers, and the
+  inversion that keeps rule 12 whole). A generic surface names the vendor
+  exactly once, for that one line. Consumers of the filed letters are a
+  separate concern.
+- ``resubscribe`` — turn a connected account's webhooks (back) on without
+  spending a fresh signup code; onboarding subscribes on the happy path,
+  this is the recovery door (disconnect's opposite verb, health re-stamped
+  by its atom).
 
 Provider-decided template state (approved, rejected, a re-categorisation)
 arrives as webhooks, and the consumer that applies them joins this surface
@@ -40,11 +50,13 @@ route resolver, and so do the provider packages.
 
 from app.crm.connectivity.channels import registers_templates_for
 from app.crm.connectivity.dispatch import claim_sends, dispatch_send
+from app.crm.connectivity.ingress import META_INGRESS
 from app.crm.connectivity.onboarding import (
     disconnect,
     get_installation,
     list_installations,
     onboard,
+    resubscribe,
 )
 from app.crm.connectivity.queue import queue_message
 from app.crm.connectivity.templates import (
@@ -81,4 +93,8 @@ __all__ = [
     "registers_templates_for",
     # the retire guard slot (worker_main fills)
     "register_retire_guard",
+    # webhook subscription recovery
+    "resubscribe",
+    # the inbound bay, for app/crm/api.py's one registration line
+    "META_INGRESS",
 ]

--- a/app/crm/connectivity/db/accessors/binding.py
+++ b/app/crm/connectivity/db/accessors/binding.py
@@ -12,6 +12,7 @@ from app.crm.connectivity.db.queries.binding import (
     binding_by_address_query,
     binding_by_id_query,
     has_active_primary_binding_query,
+    inbound_binding_query,
     pause_bindings_for_installation_query,
     primary_binding_query,
     upsert_binding_query,
@@ -107,3 +108,15 @@ async def pause_bindings_for_installation(
     query, values = pause_bindings_for_installation_query(merchant_id, installation_id)
     rows = await conn.fetch(query, *values)
     return [decode_binding(row) for row in rows]
+
+
+async def get_binding_for_inbound(
+    channel: str, address: str
+) -> Optional[ChannelBinding]:
+    """Whose endpoint an inbound fact arrived on — the merchant is the ANSWER
+    here, not a parameter, so this is the one lookup that cannot be scoped by
+    it (see inbound_binding_query for the index that keeps it unambiguous)."""
+    query, values = inbound_binding_query(channel, address)
+    async with crm_connection() as conn:
+        row = await conn.fetchrow(query, *values)
+    return decode_binding(row) if row is not None else None

--- a/app/crm/connectivity/db/accessors/installation.py
+++ b/app/crm/connectivity/db/accessors/installation.py
@@ -10,9 +10,11 @@ from app.crm.connectivity.db.decoders.installation import (
 from app.crm.connectivity.db.queries.installation import (
     installation_by_account_query,
     installation_by_id_query,
+    installation_for_inbound_query,
     installation_read_by_id_query,
     list_installations_query,
     revoke_installation_query,
+    update_installation_health_query,
     upsert_installation_query,
 )
 from app.crm.connectivity.schemas.connector import (
@@ -95,5 +97,34 @@ async def revoke_installation(
 ) -> Optional[InstallationRead]:
     """None = not this merchant's installation (fail closed on tenancy)."""
     query, values = revoke_installation_query(merchant_id, installation_id)
+    row = await conn.fetchrow(query, *values)
+    return decode_installation_read(row) if row is not None else None
+
+
+async def get_installation_for_inbound(
+    connector_key: str, external_account_id: str
+) -> Optional[ConnectorInstallation]:
+    """Whose account a provider-level fact arrived about — the merchant is
+    the ANSWER, not a parameter (installation_for_inbound_query says why it
+    has no merchant)."""
+    query, values = installation_for_inbound_query(connector_key, external_account_id)
+    async with crm_connection() as conn:
+        row = await conn.fetchrow(query, *values)
+    return decode_installation(row) if row is not None else None
+
+
+async def update_installation_health(
+    conn: DbTxn,
+    merchant_id: str,
+    installation_id: str,
+    *,
+    status: str,
+    health_detail: str,
+) -> Optional[InstallationRead]:
+    """Re-stamp status + health_detail together. None = not this merchant's
+    installation, or a revoked one (fail closed on both)."""
+    query, values = update_installation_health_query(
+        merchant_id, installation_id, status, health_detail
+    )
     row = await conn.fetchrow(query, *values)
     return decode_installation_read(row) if row is not None else None

--- a/app/crm/connectivity/db/queries/binding.py
+++ b/app/crm/connectivity/db/queries/binding.py
@@ -2,7 +2,11 @@
 
 from typing import Any, List, Tuple
 
-from app.crm.connectivity.status import BINDING_ACTIVE, BINDING_PAUSED
+from app.crm.connectivity.status import (
+    BINDING_ACTIVE,
+    BINDING_PAUSED,
+    BINDING_RETIRED,
+)
 
 BINDING_TABLE = "crm_channel_binding"
 
@@ -158,3 +162,26 @@ def pause_bindings_for_installation_query(
         RETURNING {BINDING_COLUMNS}
     """
     return query, [merchant_id, installation_id, BINDING_PAUSED, BINDING_ACTIVE]
+
+
+def inbound_binding_query(channel: str, address: str) -> Tuple[str, List[Any]]:
+    """The pipe an inbound fact ARRIVED on — the one lookup with no merchant.
+
+    NOT the merchant-scoped binding_by_address_query above: a delivery
+    receipt or a reply names only the receiving endpoint, so this row is HOW
+    the merchant is learned. The WHERE matches 057's
+    crm_channel_binding_address_uq predicate exactly — (channel, address)
+    WHERE status <> 'retired' — so at most one row can come back; widened,
+    a recycled number could match a retired row too, and filing under the
+    wrong merchant is a cross-tenant leak. 'paused' is included where the
+    send path takes 'active' only: pausing stops SENDING, not facts about
+    already-sent messages from arriving.
+    """
+    query = f"""
+        SELECT {BINDING_COLUMNS}
+          FROM {BINDING_TABLE}
+         WHERE channel = $1
+           AND address = $2
+           AND status <> $3
+    """
+    return query, [channel, address, BINDING_RETIRED]

--- a/app/crm/connectivity/db/queries/installation.py
+++ b/app/crm/connectivity/db/queries/installation.py
@@ -155,3 +155,54 @@ def revoke_installation_query(
         RETURNING {INSTALLATION_READ_COLUMNS}
     """
     return query, [merchant_id, installation_id, INSTALLATION_REVOKED]
+
+
+def installation_for_inbound_query(
+    connector_key: str, external_account_id: str
+) -> Tuple[str, List[Any]]:
+    """The account a provider-level fact ARRIVED about — no merchant param.
+
+    NOT the merchant-scoped installation_by_account_query above: a template
+    or account notification names only the provider's account id (the WABA),
+    so this row is HOW the merchant is learned — the same posture, and the
+    same cross-tenant stakes, as inbound_binding_query in binding.py.
+    'revoked' rows are excluded: a disconnected account's facts have no
+    merchant that wants them, and a re-onboarded account gets a fresh row.
+    """
+    query = f"""
+        SELECT {INSTALLATION_COLUMNS}
+          FROM {INSTALLATION_TABLE}
+         WHERE connector_key = $1
+           AND external_account_id = $2
+           AND status <> $3
+         ORDER BY created_at DESC
+         LIMIT 1
+    """
+    return query, [connector_key, external_account_id, INSTALLATION_REVOKED]
+
+
+def update_installation_health_query(
+    merchant_id: str, installation_id: str, status: str, health_detail: str
+) -> Tuple[str, List[Any]]:
+    """Re-stamp the traffic light and the sentence under it, together.
+
+    One writer's one statement (canon T11): the resubscribe atom today, the
+    health probe when it lands. Never on a revoked row — recovery does not
+    resurrect a disconnected account.
+    """
+    query = f"""
+        UPDATE {INSTALLATION_TABLE}
+           SET status = $3,
+               health_detail = $4::jsonb
+         WHERE merchant_id = $1
+           AND id = $2::uuid
+           AND status <> $5
+        RETURNING {INSTALLATION_READ_COLUMNS}
+    """
+    return query, [
+        merchant_id,
+        installation_id,
+        status,
+        health_detail,
+        INSTALLATION_REVOKED,
+    ]

--- a/app/crm/connectivity/ingress.py
+++ b/app/crm/connectivity/ingress.py
@@ -1,0 +1,114 @@
+"""The ingress root — provider bays assembled for record's webhook door.
+
+GENERIC on purpose: every inbound face yields the same neutral shape
+(schemas.ProviderLetter), so the owner-to-merchant resolution below works
+for any provider unchanged. The ONLY provider names in this file are the
+spec assemblies at the bottom — one registry-style entry per provider,
+exactly like ADAPTERS and CONNECTORS. Everything provider-specific (wire
+shape, signature, topics, versions) lives in that provider's face under
+providers/.
+
+Why the resolution lives here and not in the face: provider files talk to
+the provider and never to our tables (the base.py port contract — a face
+"returns FACTS; it writes nothing"). Deciding WHOSE letter something is
+means reading crm_channel_binding / crm_connector_installation, and that
+one permission-adjacent lookup belongs in one auditable place.
+
+Why record does not do it instead: record may import no other module
+(boundary rule 12), so app/crm/api.py registers each spec into record's
+INGRESS slot — the same line worker_main writes for consumers — and record
+dispatches knowing no provider by name. Rule 11 makes this file the one
+reader of every ``providers/<x>/inbound.py`` face.
+"""
+
+from typing import Awaitable, Callable, Dict, List, Mapping, Optional
+
+import app.crm.connectivity.providers.meta.inbound as meta
+from app.core.logger import logger
+from app.crm.connectivity.db.accessors import (
+    binding as binding_accessor,
+    installation as installation_accessor,
+)
+from app.crm.connectivity.schemas.ingress import OWNER_PHONE_NUMBER, ProviderLetter
+from app.crm.record.contracts import EventIn, IngressSpec
+
+
+async def _merchant_for(letter: ProviderLetter) -> Optional[str]:
+    """Whose letter this is — the one permission-adjacent lookup, one place.
+
+    A receiving endpoint resolves through its binding; a provider account
+    resolves through its installation. None means nobody owns it, and the
+    caller drops the letter (filing it under any merchant would be a
+    cross-tenant leak).
+    """
+    if letter.owner_kind == OWNER_PHONE_NUMBER:
+        binding = await binding_accessor.get_binding_for_inbound(
+            letter.source, letter.owner_id
+        )
+        return binding.merchant_id if binding else None
+    installation = await installation_accessor.get_installation_for_inbound(
+        letter.source, letter.owner_id
+    )
+    return installation.merchant_id if installation else None
+
+
+async def resolve_letters(letters: List[ProviderLetter]) -> List[EventIn]:
+    """Provider letters -> record's letters, owners resolved to merchants.
+
+    Grouped by owner first: one callback may legitimately carry facts for
+    several merchants, so each owner costs one lookup — and an owner nobody
+    holds must not cost the letters beside it, which belong to someone else
+    entirely.
+    """
+    merchants: Dict[tuple, Optional[str]] = {}
+    for letter in letters:
+        key = (letter.owner_kind, letter.source, letter.owner_id)
+        if key not in merchants:
+            merchants[key] = await _merchant_for(letter)
+
+    out: List[EventIn] = []
+    for letter in letters:
+        merchant_id = merchants[(letter.owner_kind, letter.source, letter.owner_id)]
+        if merchant_id is None:
+            logger.warning(
+                f"ingress: {letter.source} webhook for a "
+                f"{letter.owner_kind} no merchant owns"
+            )
+            continue
+        out.append(
+            EventIn(
+                merchant_id=merchant_id,
+                source=letter.source,
+                topic=letter.topic,
+                external_id=letter.external_id,
+                payload=letter.payload,
+                occurred_at=letter.occurred_at,
+                schema_version=letter.schema_version,
+            )
+        )
+    return out
+
+
+def envelope_over(
+    letters_of: Callable[[Dict], List[ProviderLetter]],
+) -> Callable[[Mapping[str, str], Dict], Awaitable[List[EventIn]]]:
+    """An IngressSpec envelope from a face's ``letters`` verb — the generic
+    half applied to any provider's parse."""
+
+    async def _envelope(headers: Mapping[str, str], body: Dict) -> List[EventIn]:
+        """The registered envelope: parse (the face's), resolve (ours)."""
+        return await resolve_letters(letters_of(body))
+
+    return _envelope
+
+
+# --- the bays: one assembly per provider (the only provider names here) ------
+
+#: Registered by app/crm/api.py under the key "meta" — the PROVIDER, not a
+#: channel: one Meta app serves WhatsApp, Instagram and Messenger through
+#: one callback, and each letter carries its own source.
+META_INGRESS = IngressSpec(
+    verify=meta.verify_signature,
+    envelope=envelope_over(meta.letters),
+    challenge=meta.handshake_challenge,
+)

--- a/app/crm/connectivity/onboarding.py
+++ b/app/crm/connectivity/onboarding.py
@@ -411,3 +411,84 @@ async def _disconnect_in_txn(
         f"{len(paused)} binding(s) paused"
     )
     return installation
+
+
+async def resubscribe(
+    merchant_id: str, installation_id: str
+) -> Optional[InstallationRead]:
+    """Turn a connected account's webhooks (back) on — the recovery door.
+
+    Onboarding subscribes on its happy path but cannot run again: its
+    Embedded Signup code is one-shot. So a handshake that authenticated but
+    could not subscribe, or an account the provider quietly unsubscribed,
+    gets just the subscription step re-run from stored credentials —
+    ``disconnect`` with the opposite verb, same gather, then an atom that
+    re-stamps health.
+
+    Returns None when the installation is not this merchant's (fail closed
+    on tenancy, exactly like disconnect). Raises OnboardingError with a
+    sentence a merchant can act on for every other refusal — a silently
+    failed subscription looks healthy until somebody wonders why no events
+    ever arrive.
+    """
+    installation = await installation_accessor.get_installation(
+        merchant_id, installation_id
+    )
+    if installation is None:
+        return None
+
+    spec = connector_for(installation.connector_key)
+    if spec is None:
+        # Refusing beats guessing: running Meta's call against a connector
+        # that has no subscription step would send a request nothing there
+        # understands.
+        raise OnboardingError(
+            f"This account is a '{installation.connector_key}' connector, "
+            f"which has no webhook subscription to turn on."
+        )
+    if not installation.external_account_id:
+        raise OnboardingError("This account has no provider account id to subscribe.")
+
+    try:
+        bundle = await accounts.bundle_for(installation)
+    except accounts.AccountError:
+        # Vault row gone, deactivated, or undecryptable — one fact from
+        # here: no usable secret to subscribe with. (A vault OUTAGE raises
+        # past this except and surfaces as the route's 500, never as
+        # "reconnect your account" advice for a healthy credential.)
+        raise OnboardingError(
+            "This account's credentials are missing or unreadable. "
+            "Reconnect it first."
+        )
+
+    try:
+        await spec.onboarder.resubscribe(bundle, installation.external_account_id)
+    except ConnectorHandshakeError as e:
+        # The provider's own refusal, passed through: the merchant's "why"
+        # gets the provider's words, not our paraphrase.
+        logger.error(f"resubscribe: {installation.connector_key} refused — {e}")
+        raise OnboardingError(str(e)) from e
+
+    return await atomically(_resubscribe_in_txn, merchant_id, installation_id)
+
+
+async def _resubscribe_in_txn(
+    txn: DbTxn, merchant_id: str, installation_id: str
+) -> Optional[InstallationRead]:
+    """ATOMIC: the provider confirmed the subscription and the door's light
+    must say so in the same breath — a successful recovery that left the row
+    'degraded' would keep every send refusing (send fails closed on anything
+    but 'healthy'), and a health_detail whose why is now false contradicts
+    canon T11 (the light never contradicts the sentence)."""
+    detail = {
+        "level": "subscribed",
+        "checked_at": datetime.now(timezone.utc).isoformat(),
+        "why": None,
+    }
+    return await installation_accessor.update_installation_health(
+        txn,
+        merchant_id,
+        installation_id,
+        status=_STATUS_FOR_HEALTH["subscribed"],
+        health_detail=json.dumps(detail),
+    )

--- a/app/crm/connectivity/providers/base.py
+++ b/app/crm/connectivity/providers/base.py
@@ -172,6 +172,19 @@ class ConnectorOnboarder(Protocol):
         is unreachable would trap the merchant.
         """
 
+    async def resubscribe(
+        self, bundle: CredentialBundle, external_account_id: str
+    ) -> None:
+        """Turn this account's webhooks (back) on — revoke's opposite verb,
+        same signature. The recovery door: onboarding subscribes on its
+        happy path but cannot run again (its signup code is one-shot), so
+        this re-runs just the subscription step from stored credentials.
+
+        NOT best-effort: raises the module's own error type on a provider
+        refusal, because the caller re-stamps health on success and must
+        not on failure.
+        """
+
 
 class TemplateProviderError(ProviderError):
     """A provider refused a template operation.

--- a/app/crm/connectivity/providers/meta/__init__.py
+++ b/app/crm/connectivity/providers/meta/__init__.py
@@ -1,6 +1,8 @@
 """Meta's shared vendor layer. WhatsApp, Instagram and Messenger are three
 products on ONE Graph API, so the transport lives here and each product's
-package holds only what differs.
+package holds only what differs. inbound.py is the vendor's inbound face —
+one callback, one signature scheme for all three products — answering to
+connectivity/ingress.py (boundary rule 11).
 
 Exports nothing: import graph.py by its full path (the re-export-hub scar).
 """

--- a/app/crm/connectivity/providers/meta/inbound.py
+++ b/app/crm/connectivity/providers/meta/inbound.py
@@ -1,0 +1,289 @@
+"""Meta's inbound face: callbacks verified and unwrapped, vendor-level.
+
+This lives beside graph.py rather than in a product package because the
+callback is per APP, not per product: one Meta app serves WhatsApp,
+Instagram and Messenger through one URL, one signature scheme, one
+handshake. Which product a notification concerns is a fact INSIDE the body
+(its ``object``), so the letters this face yields carry their own source.
+
+Public surface: three verbs — ``verify_signature``, ``handshake_challenge``,
+``letters``. The walk helpers underneath are private: a face exports verbs,
+not its walk (the pattern onboard.py and templates.py follow).
+
+Composition root: connectivity/ingress.py (boundary rule 11) — the one file
+outside providers/ that may import this. Nothing here touches the database;
+a letter names its OWNER (a receiving phone number, or the WABA itself) and
+the root resolves who that is.
+
+Signing is platform-level by necessity, not choice: the payload naming the
+merchant cannot be trusted until its signature is verified, and verifying
+needs the secret.
+"""
+
+import hashlib
+import hmac
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Mapping, Optional
+
+from app.core.config.static import (
+    META_APP_SECRET,
+    META_WEBHOOK_VERIFY_TOKEN,
+    META_WHATSAPP_GRAPH_VERSION,
+)
+from app.core.logger import logger
+from app.crm.connectivity.schemas.ingress import (
+    OWNER_ACCOUNT,
+    OWNER_PHONE_NUMBER,
+    ProviderLetter,
+)
+from app.crm.connectivity.topics import (
+    TOPIC_ACCOUNT,
+    TOPIC_INBOUND,
+    TOPIC_STATUS,
+    TOPIC_TEMPLATE_CATEGORY,
+    TOPIC_TEMPLATE_QUALITY,
+    TOPIC_TEMPLATE_STATUS,
+)
+
+SIGNATURE_HEADER = "x-hub-signature-256"
+_SIGNATURE_PREFIX = "sha256="
+
+# The body's ``object`` -> the source word its letters carry on the spine.
+# A closed map: an object we do not serve yields no letters (and the root
+# logs it), never a guessed source.
+_SOURCE_FOR_OBJECT = {"whatsapp_business_account": "whatsapp"}
+
+# Meta's change fields for template/account facts -> our spine topics
+# (topics.py owns the vocabulary; Meta's field names stay in this file).
+_TOPIC_FOR_FIELD = {
+    "message_template_status_update": TOPIC_TEMPLATE_STATUS,
+    "template_category_update": TOPIC_TEMPLATE_CATEGORY,
+    "message_template_quality_update": TOPIC_TEMPLATE_QUALITY,
+    "account_update": TOPIC_ACCOUNT,
+}
+# The short word inside the composed external_id, per field — the event
+# name for status updates comes from the value itself.
+_EVENT_WORD_FOR_FIELD = {
+    "template_category_update": "category",
+    "message_template_quality_update": "quality",
+}
+
+
+def verify_signature(raw_body: bytes, headers: Mapping[str, str]) -> bool:
+    """Whether this callback really came from Meta.
+
+    HMAC-SHA256 over the RAW bytes, keyed by the app secret — Meta cannot
+    hold a bearer token, so this IS the callback route's authentication.
+    Fails closed on every uncertainty (no secret configured, no header, an
+    unexpected shape): an endpoint that accepts unverifiable bodies is one
+    anyone can write events into.
+
+    Two details are load-bearing: the MAC covers the bytes BEFORE any parse
+    (re-serialising changes whitespace and key order, and the signature
+    would never match again), and compare_digest replaces == because an
+    early-exit comparison leaks enough timing to discover a valid signature
+    byte by byte.
+    """
+    if not META_APP_SECRET:
+        # Loud, because this is the difference between "authenticated" and
+        # "open to the internet", and the symptom otherwise is silence.
+        logger.error("meta: no app secret configured — refusing every inbound webhook")
+        return False
+    # Header names are case-insensitive on the wire; a plain dict of them is
+    # not, so look the value up without assuming the sender's casing.
+    header = next(
+        (v for k, v in headers.items() if k.lower() == SIGNATURE_HEADER), None
+    )
+    if not header or not header.startswith(_SIGNATURE_PREFIX):
+        return False
+    expected = hmac.new(META_APP_SECRET.encode(), raw_body, hashlib.sha256).hexdigest()
+    return hmac.compare_digest(expected, header[len(_SIGNATURE_PREFIX) :])
+
+
+def handshake_challenge(params: Mapping[str, str]) -> Optional[str]:
+    """Meta's subscription challenge, echoed back when the token matches.
+
+    Called once, when the callback URL is saved in the app dashboard, to
+    prove we own the endpoint. Same fail-closed posture and constant-time
+    compare as the signature — leaking the shared verify token through
+    timing would let someone else claim our callback URL.
+    """
+    if not META_WEBHOOK_VERIFY_TOKEN:
+        logger.error(
+            "meta: no webhook verify token configured — refusing the "
+            "subscription handshake"
+        )
+        return None
+    token = params.get("hub.verify_token")
+    challenge = params.get("hub.challenge")
+    if params.get("hub.mode") != "subscribe" or not token or challenge is None:
+        return None
+    if not hmac.compare_digest(token, META_WEBHOOK_VERIFY_TOKEN):
+        logger.warning("meta: webhook handshake presented a wrong token")
+        return None
+    return challenge
+
+
+def letters(body: Dict[str, Any]) -> List[ProviderLetter]:
+    """Meta's envelope -> letters, each still naming its provider owner.
+
+    Total on purpose: an unreadable fragment yields no letters rather than
+    raising — Meta is owed a 200 either way, and a malformed entry must not
+    discard the good ones beside it. An ``object`` we do not serve yields
+    nothing at all: a guessed source would file letters no consumer reads.
+    """
+    source = _SOURCE_FOR_OBJECT.get(str(body.get("object") or ""))
+    if source is None:
+        return []
+
+    out: List[ProviderLetter] = []
+    entries = body.get("entry")
+    if not isinstance(entries, list):
+        return out
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        waba_id = str(entry.get("id") or "")
+        entry_time = _provider_timestamp(entry.get("time"))
+        changes = entry.get("changes")
+        if not isinstance(changes, list):
+            continue
+        for change in changes:
+            if not isinstance(change, dict):
+                continue
+            value = change.get("value")
+            if not isinstance(value, dict):
+                continue
+            field = str(change.get("field") or "")
+            if field in _TOPIC_FOR_FIELD:
+                letter = _account_letter(source, waba_id, field, value, entry_time)
+                if letter is not None:
+                    out.append(letter)
+            else:
+                # The "messages" field — and, totally, anything unknown that
+                # still carries a receiving number and message items.
+                out.extend(_message_letters(source, value))
+    return out
+
+
+# --- the walk (private: the face exports verbs, not its steps) ---------------
+
+
+def _provider_timestamp(value: Any) -> Optional[datetime]:
+    """Meta's unix seconds -> an aware datetime, or None if unusable.
+
+    Their clock, not ours: when it happened is the provider's fact. Total —
+    a letter with a broken timestamp is still worth filing.
+    """
+    try:
+        return datetime.fromtimestamp(int(value), tz=timezone.utc)
+    except (TypeError, ValueError, OSError, OverflowError):
+        return None
+
+
+def _narrowed(value: Dict[str, Any], key: str, item: Dict[str, Any]) -> Dict[str, Any]:
+    """Meta's value with the batched array narrowed to ONE item.
+
+    Everything else — messaging_product, metadata, contacts — rides along
+    verbatim, so the stored payload is Meta's documented shape and a
+    recorded callback works as a fixture unchanged (canon T13 col 7).
+    """
+    narrowed = {k: v for k, v in value.items() if k not in ("statuses", "messages")}
+    narrowed[key] = [item]
+    return narrowed
+
+
+def _message_letters(source: str, value: Dict[str, Any]) -> List[ProviderLetter]:
+    """One "messages" value -> a letter per status and per inbound message.
+
+    statuses[] — what became of a message WE sent; Meta sends one per
+    transition on the same id, so the external_id pairs it with the status
+    to keep four letters four. messages[] — what a customer sent US; its
+    own id is already unique. Both are owned by the receiving number
+    (metadata.phone_number_id); a value without one cannot be owned and
+    yields nothing.
+    """
+    metadata = value.get("metadata")
+    number = ""
+    if isinstance(metadata, dict):
+        number = str(metadata.get("phone_number_id") or "")
+    if not number:
+        return []
+
+    out: List[ProviderLetter] = []
+    statuses = value.get("statuses")
+    if isinstance(statuses, list):
+        for status in statuses:
+            if not isinstance(status, dict):
+                continue
+            message_id, state = status.get("id"), status.get("status")
+            if not message_id or not state:
+                continue
+            out.append(
+                ProviderLetter(
+                    owner_kind=OWNER_PHONE_NUMBER,
+                    owner_id=number,
+                    source=source,
+                    topic=TOPIC_STATUS,
+                    external_id=f"{message_id}:{state}",
+                    payload=_narrowed(value, "statuses", status),
+                    occurred_at=_provider_timestamp(status.get("timestamp")),
+                    schema_version=META_WHATSAPP_GRAPH_VERSION,
+                )
+            )
+
+    messages = value.get("messages")
+    if isinstance(messages, list):
+        for message in messages:
+            if not isinstance(message, dict):
+                continue
+            message_id = message.get("id")
+            if not message_id:
+                continue
+            out.append(
+                ProviderLetter(
+                    owner_kind=OWNER_PHONE_NUMBER,
+                    owner_id=number,
+                    source=source,
+                    topic=TOPIC_INBOUND,
+                    external_id=str(message_id),
+                    payload=_narrowed(value, "messages", message),
+                    occurred_at=_provider_timestamp(message.get("timestamp")),
+                    schema_version=META_WHATSAPP_GRAPH_VERSION,
+                )
+            )
+    return out
+
+
+def _account_letter(
+    source: str,
+    waba_id: str,
+    field: str,
+    value: Dict[str, Any],
+    entry_time: Optional[datetime],
+) -> Optional[ProviderLetter]:
+    """A template or account notification -> one letter owned by the WABA.
+
+    Meta gives these no id of their own, so the external_id is COMPOSED
+    (canon T13 col 6 — losing idempotency here poisons every consumer):
+    ``{waba}:{template_id}:{event}:{timestamp}`` for a status update,
+    ``…:category:…`` / ``…:quality:…`` for the others, ``{waba}:account:…``
+    when no template is named. The timestamp is the entry's — these values
+    carry none of their own.
+    """
+    if not waba_id:
+        return None
+    template_id = str(value.get("message_template_id") or "")
+    event = _EVENT_WORD_FOR_FIELD.get(field) or str(value.get("event") or field)
+    ts = int(entry_time.timestamp()) if entry_time else 0
+    subject = template_id or "account"
+    return ProviderLetter(
+        owner_kind=OWNER_ACCOUNT,
+        owner_id=waba_id,
+        source=source,
+        topic=_TOPIC_FOR_FIELD[field],
+        external_id=f"{waba_id}:{subject}:{event}:{ts}",
+        payload=value,
+        occurred_at=entry_time,
+        schema_version=META_WHATSAPP_GRAPH_VERSION,
+    )

--- a/app/crm/connectivity/providers/whatsapp/__init__.py
+++ b/app/crm/connectivity/providers/whatsapp/__init__.py
@@ -1,12 +1,15 @@
 """WhatsApp, straight at Meta's Cloud API — no aggregator in between.
 
-Four faces, one package:
+One package, its faces:
 
     adapter.py    the send door's child of ChannelAdapter
     classify.py   Meta's error codes, split by "could this succeed later?"
     payload.py    E.164 -> Meta's digits, variables -> template parameters
     onboard.py    Embedded Signup: code -> token -> number -> subscription
     templates.py  the WABA template registry face
+
+The inbound direction is NOT here: Meta's callbacks arrive per APP, not per
+product, so that face is vendor-level — providers/meta/inbound.py.
 
 Only the bundle keys live here, because both the send face and the onboarding
 face need them and neither may own them: onboarding WRITES the bundle,

--- a/app/crm/connectivity/providers/whatsapp/onboard.py
+++ b/app/crm/connectivity/providers/whatsapp/onboard.py
@@ -244,6 +244,27 @@ class WhatsappOnboarder:
             health_why=health_why,
         )
 
+    async def resubscribe(
+        self, bundle: CredentialBundle, external_account_id: str
+    ) -> None:
+        """Turn this WABA's webhooks (back) on — revoke's opposite verb.
+
+        Vendor errors leave as WhatsappOnboardingError (the port family):
+        GraphError never crosses the package boundary, though its detail
+        does — Meta's own words are what the merchant's refusal should
+        carry.
+        """
+        token = bundle.secret(TOKEN_KEY)
+        if not token:
+            raise WhatsappOnboardingError(
+                "This account's credentials hold no usable access token. "
+                "Reconnect it first."
+            )
+        try:
+            await subscribe(external_account_id, token)
+        except GraphError as e:
+            raise WhatsappOnboardingError(e.detail) from e
+
     async def revoke(self, bundle: CredentialBundle, external_account_id: str) -> None:
         """Tell Meta to stop sending this account's events.
 

--- a/app/crm/connectivity/schemas/connector.py
+++ b/app/crm/connectivity/schemas/connector.py
@@ -122,3 +122,13 @@ class InstallationRead(BaseModel):
     installed_at: datetime
     created_at: datetime
     updated_at: datetime
+
+
+class SubscriptionResult(BaseModel):
+    """What was resubscribed. The provider's account id is echoed so an
+    operator running the recovery across several accounts can see which one
+    answered."""
+
+    installation_id: str
+    external_account_id: str
+    subscribed: bool = True

--- a/app/crm/connectivity/schemas/ingress.py
+++ b/app/crm/connectivity/schemas/ingress.py
@@ -1,0 +1,35 @@
+"""The shapes crossing the ingress seam — no table family, one port.
+
+ProviderLetter is what every provider's inbound face yields: a fact with
+its owner still a provider identifier. Neutral by design, so the ingress
+root's owner resolution stays generic and no provider name leaks out of
+its package.
+"""
+
+from datetime import datetime
+from typing import Any, Dict, NamedTuple, Optional
+
+#: How an inbound letter names its owner: the receiving endpoint (a phone
+#: number id) or the provider account itself (a WABA). These are the two
+#: lookups the ingress root knows how to resolve — and the ONLY thing it
+#: needs to know about any provider.
+OWNER_PHONE_NUMBER = "phone_number"
+OWNER_ACCOUNT = "account"
+
+
+class ProviderLetter(NamedTuple):
+    """One fact a provider told us, its owner still a provider identifier.
+
+    ``payload`` is the provider's own object, narrowed to the one item where
+    they batch (canon T13 col 7); ``schema_version`` is the provider's API
+    version, stamped by the face that knows it.
+    """
+
+    owner_kind: str
+    owner_id: str
+    source: str
+    topic: str
+    external_id: str
+    payload: Dict[str, Any]
+    occurred_at: Optional[datetime]
+    schema_version: str

--- a/app/crm/connectivity/send.py
+++ b/app/crm/connectivity/send.py
@@ -17,6 +17,10 @@ checks above. The same fact, greppable:
 
     grep -rn "connectivity.providers" app/ | grep -v "^app/crm/connectivity/providers/"
 
+The other roots (connectors.py, ingress.py) are allowed because neither
+sends a message — the law protects the path to a customer, not every call
+to a vendor.
+
 Two things this file deliberately does NOT do:
 
   · Decide what a failure means. It reports; dispatch.py's retry ladder

--- a/app/crm/connectivity/topics.py
+++ b/app/crm/connectivity/topics.py
@@ -32,3 +32,14 @@ TEMPLATE_TOPICS = (
     TOPIC_TEMPLATE_CATEGORY,
     TOPIC_TEMPLATE_QUALITY,
 )
+
+#: What became of a message WE sent — one letter per transition, whatever
+#: channel carried it (the channel rides in the event's source and payload).
+TOPIC_STATUS = "message.status"
+
+#: A customer wrote back to us.
+TOPIC_INBOUND = "message.inbound"
+
+#: A provider said something about the connected account itself (a review
+#: decision, a ban, a tier change) — the letters the health probe will read.
+TOPIC_ACCOUNT = "account.update"

--- a/app/crm/record/api.py
+++ b/app/crm/record/api.py
@@ -1,26 +1,34 @@
-"""The record module's two doors (/customers and /ingest): the per-customer journey view (A12) and the
-event ingest push door (A9).
+"""The record module's doors: the per-customer journey view (A12), the event
+ingest push door (A9), and the provider webhook bays (A9).
 
 Thin routes per module rules §1. ``journey_router`` auths via
 Depends(crm_admin_user) and delegates to timeline.py; ``ingest_router``
 verifies the s2s caller and delegates to ingest.py — store first, 200
-fast, understand later, and nothing here parses the payload. Two routers,
-not one, because the two doors mount under different prefixes with
+fast, understand later, and nothing here parses the payload;
+``webhook_router`` (GET·POST /{provider}, mounted at /ingest/webhooks)
+carries NO Depends at all — a provider cannot hold a bearer token, so each
+request authenticates by its own ritual inside the registered bay
+(ingress.py records the inversion that keeps rule 12 whole). Separate
+routers, not one, because the doors mount under different prefixes with
 different auth; the root router includes each exactly once.
 
-Tenancy law holds on both: merchant_id is a required query param on the
-journey read, and on ingest the merchant in the envelope IS the merchant
-the token was verified against.
+Tenancy law holds on all: merchant_id is a required query param on the
+journey read; on ingest the merchant in the envelope IS the merchant the
+token was verified against; on a webhook the merchant is the ANSWER,
+resolved per letter from the receiving endpoint by the bay.
 """
 
+import json
 from datetime import datetime
 from typing import List, Optional
 
-from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response, status
+from fastapi.responses import PlainTextResponse
 
 from app.core.logger import logger
 from app.core.logger.context import set_log_context
 from app.crm.auth import crm_admin_user, verify_s2s_caller
+from app.crm.record import ingress
 from app.crm.record.ingest import ingest_event
 from app.crm.record.schemas import EventIn, EventReceipt, JourneyCard
 from app.crm.record.timeline import get_customer_journey
@@ -28,6 +36,7 @@ from app.schemas import UserInfo
 
 journey_router = APIRouter()
 ingest_router = APIRouter()
+webhook_router = APIRouter()
 
 
 @journey_router.get("/{customer_id}/journey", response_model=List[JourneyCard])
@@ -114,3 +123,98 @@ async def push_event_route(
             detail="Event store unavailable — retry with the same external_id",
         )
     return EventReceipt(id=event_id, duplicate=event_id is None)
+
+
+# --- the provider bays (design/ingest-doors) ----------------------------------
+#
+# One cap, one door: a letter is stored verbatim and forever whichever
+# entrance it came through, so the bays share the envelope door's constant.
+# Here the read ITSELF is bounded (streamed) rather than a declared
+# Content-Length — a chunked body has no header to check, and these are the
+# routes that buffer bytes from callers they have not authenticated yet.
+
+
+@webhook_router.get("/{provider}", response_class=PlainTextResponse)
+async def webhook_challenge_route(provider: str, request: Request) -> Response:
+    """A provider's subscription challenge, echoed back once at registration.
+
+    Meta calls this GET when the callback URL is saved in its dashboard.
+    404, not 403, on refusal — and the same 404 for an unknown provider as
+    for a wrong token: a different answer would tell an unauthenticated
+    caller they found something worth guessing at.
+    """
+    set_log_context(component="crm.ingest.webhooks")
+    spec = ingress.INGRESS.get(provider)
+    challenge = spec.challenge(request.query_params) if spec else None
+    if challenge is None:
+        return PlainTextResponse("", status_code=status.HTTP_404_NOT_FOUND)
+    logger.info(f"ingress: {provider} webhook subscription verified")
+    # Echoed raw: Meta compares the body, so quoting or JSON-wrapping it
+    # fails the handshake.
+    return PlainTextResponse(challenge)
+
+
+@webhook_router.post("/{provider}")
+async def provider_webhook_route(provider: str, request: Request) -> Response:
+    """Verify a provider callback and file its letters in the event spine.
+
+    The raw bytes are read untouched — the bay's signature covers exactly
+    what was sent, and parse-then-reserialise would break it forever. 200
+    means RECEIVED, never UNDERSTOOD — but a STORE failure is 503, exactly
+    as on the envelope door: the provider retries with the same ids and
+    dedupe makes the retry safe, where a 200 on a dropped letter would lose
+    it forever.
+    """
+    set_log_context(component="crm.ingest.webhooks")
+    spec = ingress.INGRESS.get(provider)
+    if spec is None:
+        # No such bay — hidden exactly like a wrong handshake token, and
+        # refused before a single body byte is read.
+        return Response(status_code=status.HTTP_404_NOT_FOUND)
+
+    body = bytearray()
+    async for chunk in request.stream():
+        body.extend(chunk)
+        if len(body) > MAX_LETTER_BYTES:
+            return Response(status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE)
+
+    if not spec.verify(bytes(body), request.headers):
+        # No detail: a caller who cannot sign has not earned an explanation.
+        return Response(status_code=status.HTTP_403_FORBIDDEN)
+
+    try:
+        parsed = json.loads(bytes(body).decode("utf-8"))
+    except (ValueError, UnicodeDecodeError):
+        parsed = None
+    if not isinstance(parsed, dict):
+        # Signed by the provider, but not shaped like anything they
+        # document. Worth a 400 and a log line rather than a silent 200.
+        logger.error(f"ingress: a signed {provider} body was not a JSON object")
+        return Response(status_code=status.HTTP_400_BAD_REQUEST)
+
+    letters = await spec.envelope(request.headers, parsed)
+    filed = 0
+    for letter in letters:
+        try:
+            event_id = await ingest_event(
+                merchant_id=letter.merchant_id,
+                source=letter.source,
+                topic=letter.topic,
+                external_id=letter.external_id,
+                payload=letter.payload,
+                occurred_at=letter.occurred_at,
+                schema_version=letter.schema_version,
+            )
+        except Exception as e:
+            # Front door fails CLOSED, same as the push door above: a 200
+            # here would silently drop the provider's letter; 503 tells
+            # them to retry, and dedupe makes the retry safe.
+            logger.error(
+                f"ingress: store failed for {letter.source}/{letter.topic} "
+                f"external_id={letter.external_id}: {e}"
+            )
+            return Response(status_code=status.HTTP_503_SERVICE_UNAVAILABLE)
+        if event_id is not None:
+            filed += 1
+    logger.info(f"ingress: {provider} webhook filed {filed}/{len(letters)} letters")
+    return Response(status_code=status.HTTP_200_OK)

--- a/app/crm/record/contracts.py
+++ b/app/crm/record/contracts.py
@@ -10,7 +10,21 @@ takes the pass from workers.py directly.
 
 from app.crm.record.events import customer_has_event
 from app.crm.record.ingest import record_event
-from app.crm.record.schemas import RawEvent
+from app.crm.record.ingress import IngressSpec, register_ingress
+from app.crm.record.schemas import EventIn, RawEvent
 from app.crm.record.timeline import get_customer_journey
 
-__all__ = ["RawEvent", "record_event", "get_customer_journey", "customer_has_event"]
+__all__ = [
+    "RawEvent",
+    "record_event",
+    "get_customer_journey",
+    "customer_has_event",
+    # The provider bays' seam (ingress.py): the module that owns a
+    # provider's webhook mechanics builds an IngressSpec, and app/crm/api.py
+    # registers it — record never imports the registrant back (rule 12).
+    # EventIn is the letter shape a spec's envelope returns: one shape for
+    # both doors is "one mailroom" made literal.
+    "IngressSpec",
+    "register_ingress",
+    "EventIn",
+]

--- a/app/crm/record/ingress.py
+++ b/app/crm/record/ingress.py
@@ -1,0 +1,50 @@
+"""The INGRESS slot — provider webhook bays record OWNS but never fills.
+
+design/ingest-doors (amended 2 Sep 2026): every ingest door is record's,
+and the provider bays are one registry — GET·POST /ingest/webhooks/
+{provider} in record/api.py dispatches through the specs registered here.
+But record may import no other module (boundary rule 12), and a provider's
+mechanics — its signature ritual, its envelope walk, the owner lookups that
+name the merchant — live behind another module's contracts. So the
+dependency INVERTS, exactly as it does for spine consumers
+(record/consumers.py): the owning module builds an IngressSpec and
+app/crm/api.py registers it here, one line, the same line worker_main
+writes for consumers. Record knows no provider by name, and
+record -> registrant never happens, so the cycle rule 12 exists to kill
+cannot form.
+"""
+
+from typing import Awaitable, Callable, Dict, List, Mapping, NamedTuple, Optional
+
+from app.crm.record.schemas import EventIn
+
+
+class IngressSpec(NamedTuple):
+    """One provider's bay: how they prove themselves, how their body becomes
+    letters, and (only where the provider demands one) how their
+    subscription challenge is answered.
+
+    ``verify`` runs over the RAW bytes before any parse. ``envelope``
+    receives the parsed body and returns record's letters with the merchant
+    already resolved — envelope fields only, never a reading of the
+    payload's contents (a semantic problem is quarantine's job, not the
+    door's).
+    """
+
+    verify: Callable[[bytes, Mapping[str, str]], bool]
+    envelope: Callable[[Mapping[str, str], Dict], Awaitable[List[EventIn]]]
+    challenge: Callable[[Mapping[str, str]], Optional[str]]
+
+
+#: The slot. Empty until app/crm/api.py fills it at wiring time — a closed
+#: map nobody extends by accident, and an unknown {provider} is a 404.
+INGRESS: Dict[str, IngressSpec] = {}
+
+
+def register_ingress(provider: str, spec: IngressSpec) -> None:
+    """Called from the composition root (app/crm/api.py), never from record.
+
+    Last registration wins, which lets a test stand in a fake spec without
+    a teardown ritual.
+    """
+    INGRESS[provider] = spec

--- a/app/crm/worker_main.py
+++ b/app/crm/worker_main.py
@@ -53,7 +53,7 @@ ROLES: Dict[str, Callable[[asyncio.Event], Coroutine[Any, Any, None]]] = {
         dispatch_send,
         interval=CRM_WORKER_INTERVAL,
         # Its own dial, not CRM_WORKER_BATCH: a claimed batch must finish
-        # inside the claim lease (batch × send timeout < lease), or another
+        # inside the claim lease (batch x send timeout < lease), or another
         # pod's sweep re-sends the unworked tail — a real duplicate message.
         batch=CRM_DISPATCH_BATCH,
         stop_event=stop_event,

--- a/scripts/check_crm_boundaries.py
+++ b/scripts/check_crm_boundaries.py
@@ -30,11 +30,11 @@ PR time — earlier than a grant would fail:
   10. HANDLES STAY DOWN — connection()/crm_connection never appears in
      logic; accessors self-scope single statements and batch loops. A
      logic file touches a handle ONLY as an _in_txn body's txn param.
-  11. PROVIDER FACE CONFINEMENT — a provider package has more than one
-     face, and each face has exactly ONE composition root outside
-     providers/: the send door (the ADAPTERS assembly and <x>/adapter.py)
-     answers to send.py, the non-send faces (<x>/onboard.py,
-     <x>/templates.py) answer to connectors.py, and vendor transport
+  11. PROVIDER FACE CONFINEMENT — each provider face has exactly ONE
+     composition root outside providers/: the send door (the ADAPTERS
+     assembly and <x>/adapter.py) answers to send.py; <x>/onboard.py and
+     <x>/templates.py to connectors.py; <x>/inbound.py to ingress.py
+     (record's webhook bays, built here); and vendor transport
      (providers/meta/graph.py) never leaves providers/ at all.
   12. RECORD HEARS, NEVER CALLS — app/crm/record imports no subscriber
      module (identity + shared only): consumers register through
@@ -83,6 +83,9 @@ TABLE_OWNERS = {
 PROVIDER_ROOTS = {
     "send": "app/crm/connectivity/send.py",
     "connectors": "app/crm/connectivity/connectors.py",
+    # The inbound direction: ingress.py builds the spec record's webhook
+    # bays dispatch to, and is the one reader of a vendor's inbound face.
+    "ingress": "app/crm/connectivity/ingress.py",
 }
 PROVIDER_FACES = (
     # the ADAPTERS assembly itself, and every adapter behind it
@@ -97,8 +100,16 @@ PROVIDER_FACES = (
         re.compile(r"^app\.crm\.connectivity\.providers\.\w+\.templates\b"),
         ("connectors",),
     ),
-    # the ports both roots must name to type what they assemble
-    (re.compile(r"^app\.crm\.connectivity\.providers\.base\b"), ("send", "connectors")),
+    # the inbound face: signature, handshake, envelope -> letters
+    (
+        re.compile(r"^app\.crm\.connectivity\.providers\.\w+\.inbound\b"),
+        ("ingress",),
+    ),
+    # the ports every root must name to type what they assemble
+    (
+        re.compile(r"^app\.crm\.connectivity\.providers\.base\b"),
+        ("send", "connectors"),
+    ),
 )
 
 # Pre-existing legacy inversions, allowlisted and CLOSED to additions

--- a/tests/crm/conftest.py
+++ b/tests/crm/conftest.py
@@ -1,0 +1,10 @@
+"""Shared test dials for tests/crm.
+
+CRM_WEBHOOK_TEST_DSN lives here, not in app config: it is a test dial, and
+the app's static config surface is for the app (review ruling, 2 Sep 2026).
+Unset means the DB-backed integration tests skip.
+"""
+
+import os
+
+CRM_WEBHOOK_TEST_DSN = os.environ.get("CRM_WEBHOOK_TEST_DSN") or None

--- a/tests/crm/test_check_boundaries.py
+++ b/tests/crm/test_check_boundaries.py
@@ -7,6 +7,7 @@ from scripts.check_crm_boundaries import check
 
 
 def _tree(tmp_path: Path, files: Dict[str, str]) -> Path:
+    """Materialise the given files under a temp root."""
     for name, content in files.items():
         p = tmp_path / name
         p.parent.mkdir(parents=True, exist_ok=True)
@@ -15,6 +16,7 @@ def _tree(tmp_path: Path, files: Dict[str, str]) -> Path:
 
 
 def test_clean_tree_passes(tmp_path: Path) -> None:
+    """Clean tree passes."""
     root = _tree(
         tmp_path,
         {
@@ -26,6 +28,7 @@ def test_clean_tree_passes(tmp_path: Path) -> None:
 
 
 def test_table_literal_outside_owner_fails(tmp_path: Path) -> None:
+    """Table literal outside owner fails."""
     root = _tree(
         tmp_path,
         {"app/crm/record/ingest.py": 'q = "crm_customer"'},
@@ -34,6 +37,7 @@ def test_table_literal_outside_owner_fails(tmp_path: Path) -> None:
 
 
 def test_buddy_touching_crm_table_fails(tmp_path: Path) -> None:
+    """Buddy touching crm table fails."""
     root = _tree(
         tmp_path,
         {"app/ai/voice/thing.py": 'q = "platform_identity"'},
@@ -42,6 +46,7 @@ def test_buddy_touching_crm_table_fails(tmp_path: Path) -> None:
 
 
 def test_sql_outside_queries_fails(tmp_path: Path) -> None:
+    """Sql outside queries fails."""
     root = _tree(
         tmp_path,
         {"app/crm/identity/resolve.py": 'q = "SELECT x FROM t WHERE y=$1"'},
@@ -50,6 +55,7 @@ def test_sql_outside_queries_fails(tmp_path: Path) -> None:
 
 
 def test_asyncpg_in_logic_fails(tmp_path: Path) -> None:
+    """Asyncpg in logic fails."""
     root = _tree(
         tmp_path,
         {"app/crm/identity/resolve.py": "import asyncpg\n"},
@@ -58,6 +64,7 @@ def test_asyncpg_in_logic_fails(tmp_path: Path) -> None:
 
 
 def test_crm_importing_ai_fails(tmp_path: Path) -> None:
+    """Crm importing ai fails."""
     root = _tree(
         tmp_path,
         {"app/crm/identity/resolve.py": "from app.ai.voice import x\n"},
@@ -66,6 +73,7 @@ def test_crm_importing_ai_fails(tmp_path: Path) -> None:
 
 
 def test_cross_module_bypass_fails(tmp_path: Path) -> None:
+    """Cross module bypass fails."""
     root = _tree(
         tmp_path,
         {"app/crm/identity/resolve.py": "from app.crm.platform.suppression import x\n"},
@@ -74,6 +82,7 @@ def test_cross_module_bypass_fails(tmp_path: Path) -> None:
 
 
 def test_buddy_deep_import_fails(tmp_path: Path) -> None:
+    """Buddy deep import fails."""
     root = _tree(
         tmp_path,
         {"app/ai/mirror.py": "from app.crm.identity.resolve import resolve\n"},
@@ -82,6 +91,7 @@ def test_buddy_deep_import_fails(tmp_path: Path) -> None:
 
 
 def test_data_layer_importing_crm_fails(tmp_path: Path) -> None:
+    """Data layer importing crm fails."""
     root = _tree(
         tmp_path,
         {"app/database/accessor/foo.py": "from app.crm.identity.contracts import x\n"},
@@ -90,6 +100,7 @@ def test_data_layer_importing_crm_fails(tmp_path: Path) -> None:
 
 
 def test_handle_call_in_logic_fails(tmp_path: Path) -> None:
+    """Handle call in logic fails."""
     root = _tree(
         tmp_path,
         {"app/crm/identity/resolve.py": "row = await txn.fetchrow(q)\n"},
@@ -109,6 +120,7 @@ def test_nesting_via_driver_transaction_in_logic_fails(tmp_path: Path) -> None:
 
 
 def test_unowned_table_in_migration_fails(tmp_path: Path) -> None:
+    """Unowned table in migration fails."""
     root = _tree(
         tmp_path,
         {"app/database/migrations/099_x.sql": "CREATE TABLE crm_mystery (id int);"},
@@ -117,6 +129,7 @@ def test_unowned_table_in_migration_fails(tmp_path: Path) -> None:
 
 
 def test_raw_transaction_in_logic_fails(tmp_path: Path) -> None:
+    """Raw transaction in logic fails."""
     root = _tree(
         tmp_path,
         {"app/crm/identity/resolve.py": "async with transaction() as txn:\n    pass\n"},
@@ -125,6 +138,7 @@ def test_raw_transaction_in_logic_fails(tmp_path: Path) -> None:
 
 
 def test_atomically_callee_must_be_in_txn(tmp_path: Path) -> None:
+    """Atomically callee must be in txn."""
     root = _tree(
         tmp_path,
         {"app/crm/identity/resolve.py": "x = await atomically(do_stuff, 1)\n"},
@@ -133,6 +147,7 @@ def test_atomically_callee_must_be_in_txn(tmp_path: Path) -> None:
 
 
 def test_in_txn_body_needs_atomic_docstring(tmp_path: Path) -> None:
+    """In txn body needs atomic docstring."""
     root = _tree(
         tmp_path,
         {
@@ -145,6 +160,7 @@ def test_in_txn_body_needs_atomic_docstring(tmp_path: Path) -> None:
 
 
 def test_connection_handle_in_logic_fails(tmp_path: Path) -> None:
+    """Connection handle in logic fails."""
     root = _tree(
         tmp_path,
         {
@@ -154,7 +170,11 @@ def test_connection_handle_in_logic_fails(tmp_path: Path) -> None:
     assert any("connection handle in logic" in e for e in check(root))
 
 
-def test_adapter_import_outside_send_fails(tmp_path: Path) -> None:
+def test_adapter_import_outside_the_doors_fails(tmp_path: Path) -> None:
+    # Any file that is not a named door, however innocent it looks: dispatch
+    # reaching an adapter directly would send around send()'s route
+    # resolution and suppression gate.
+    """Adapter import outside the doors fails."""
     root = _tree(
         tmp_path,
         {
@@ -166,7 +186,26 @@ def test_adapter_import_outside_send_fails(tmp_path: Path) -> None:
     assert any("provider face imported outside its door" in e for e in check(root))
 
 
-def test_send_and_providers_themselves_may_import_adapters(tmp_path: Path) -> None:
+def test_a_new_root_file_is_not_a_door_by_being_next_to_them(tmp_path: Path) -> None:
+    # The map is closed, not "anything at the module root". A file added
+    # beside the doors has to be registered in PROVIDER_ROOTS/PROVIDER_FACES
+    # deliberately, which is the moment somebody has to name its direction.
+    """A new root file is not a door by being next to them."""
+    root = _tree(
+        tmp_path,
+        {
+            "app/crm/connectivity/refresh.py": (
+                "from app.crm.connectivity.providers.whatsapp.onboard import x\n"
+            )
+        },
+    )
+    assert any("provider face imported outside its door" in e for e in check(root))
+
+
+def test_each_direction_has_its_door(tmp_path: Path) -> None:
+    # One root per face of provider traffic — send, onboard/administer,
+    # receive — plus providers/ importing itself.
+    """Each direction has its door."""
     root = _tree(
         tmp_path,
         {
@@ -174,6 +213,13 @@ def test_send_and_providers_themselves_may_import_adapters(tmp_path: Path) -> No
                 "from app.crm.connectivity.providers import adapter_for\n"
                 "from app.crm.connectivity.providers.base import ChannelAdapter\n"
                 "from app.crm.connectivity.providers.whatsapp.adapter import A\n"
+            ),
+            "app/crm/connectivity/ingress.py": (
+                "import app.crm.connectivity.providers.meta.inbound as meta\n"
+            ),
+            "app/crm/connectivity/connectors.py": (
+                "from app.crm.connectivity.providers.base import Err\n"
+                "from app.crm.connectivity.providers.whatsapp.onboard import W\n"
             ),
             "app/crm/connectivity/providers/whatsapp/adapter.py": (
                 "from app.crm.connectivity.providers.base import ChannelAdapter\n"
@@ -184,9 +230,25 @@ def test_send_and_providers_themselves_may_import_adapters(tmp_path: Path) -> No
     assert check(root) == []
 
 
+def test_the_inbound_face_outside_ingress_fails(tmp_path: Path) -> None:
+    """The inbound face answers to ingress.py alone: a route or worker that
+    read it directly would receive letters without the owner resolution in
+    front of them."""
+    root = _tree(
+        tmp_path,
+        {
+            "app/crm/record/api.py": (
+                "import app.crm.connectivity.providers.meta.inbound as meta\n"
+            )
+        },
+    )
+    assert any("provider face imported outside its door" in e for e in check(root))
+
+
 def test_record_importing_a_subscriber_fails(tmp_path: Path) -> None:
     # Rule 12: not even the subscriber's contracts — worker_main registers
     # consumers through record/consumers.py; record never reaches back.
+    """Record importing a subscriber fails."""
     root = _tree(
         tmp_path,
         {"app/crm/record/workers.py": "from app.crm.outreach.contracts import x\n"},
@@ -195,6 +257,7 @@ def test_record_importing_a_subscriber_fails(tmp_path: Path) -> None:
 
 
 def test_record_may_import_identity_and_shared(tmp_path: Path) -> None:
+    """Record may import identity and shared."""
     root = _tree(
         tmp_path,
         {
@@ -239,6 +302,7 @@ def test_adapter_face_in_connectors_fails(tmp_path: Path) -> None:
 
 
 def test_connectors_may_import_the_non_send_faces(tmp_path: Path) -> None:
+    """Connectors may import the non send faces."""
     root = _tree(
         tmp_path,
         {
@@ -270,6 +334,7 @@ def test_vendor_transport_never_leaves_providers(tmp_path: Path) -> None:
 
 
 def test_sql_in_split_queries_folder_passes(tmp_path: Path) -> None:
+    """Sql in split queries folder passes."""
     root = _tree(
         tmp_path,
         {

--- a/tests/crm/test_connectivity_ingress.py
+++ b/tests/crm/test_connectivity_ingress.py
@@ -1,0 +1,225 @@
+"""connectivity/ingress.py: owners resolved, letters shaped for the spine.
+
+The envelope's own half, over fake accessors: which merchant owns each
+letter's owner, what a letter no merchant owns costs, and the stamps the
+corpus requires (schema_version from the app's API version, source from the
+body). Meta's wire shape itself is test_meta_inbound.py's; the record door
+that calls this spec is test_ingress_door.py's.
+"""
+
+from typing import Optional
+
+import pytest
+
+from app.core.config.static import META_WHATSAPP_GRAPH_VERSION
+from app.crm.connectivity import ingress as ingress_module
+from app.crm.connectivity.schemas.connector import (
+    ChannelBinding,
+    ConnectorInstallation,
+)
+from app.crm.connectivity.topics import TOPIC_STATUS, TOPIC_TEMPLATE_STATUS
+
+OUR_NUMBER = "812345678901234"
+OTHER_NUMBER = "812999999999999"
+WABA = "waba-77"
+TS = 1788177600
+
+
+def _binding(merchant="shop", address=OUR_NUMBER) -> ChannelBinding:
+    """An active binding for one of our numbers."""
+    return ChannelBinding(
+        id="b-1",
+        merchant_id=merchant,
+        channel="whatsapp",
+        installation_id="i-1",
+        address=address,
+        status="active",
+    )
+
+
+def _installation(merchant="shop") -> ConnectorInstallation:
+    """A connected account holding the WABA."""
+    return ConnectorInstallation(
+        id="i-1",
+        merchant_id=merchant,
+        connector_key="whatsapp",
+        external_account_id=WABA,
+        status="healthy",
+    )
+
+
+class _Fakes:
+    """Fake accessors that record every lookup."""
+
+    def __init__(self, bindings=None, installations=None):
+        """Test double."""
+        self.bindings = bindings if bindings is not None else {OUR_NUMBER: _binding()}
+        self.installations = (
+            installations if installations is not None else {WABA: _installation()}
+        )
+        self.binding_lookups: list = []
+        self.installation_lookups: list = []
+
+    async def get_binding_for_inbound(
+        self, channel, address
+    ) -> Optional[ChannelBinding]:
+        """Test double."""
+        self.binding_lookups.append((channel, address))
+        return self.bindings.get(address)
+
+    async def get_installation_for_inbound(
+        self, connector_key, external_account_id
+    ) -> Optional[ConnectorInstallation]:
+        """Test double."""
+        self.installation_lookups.append((connector_key, external_account_id))
+        return self.installations.get(external_account_id)
+
+
+@pytest.fixture
+def fakes(monkeypatch) -> _Fakes:
+    """The envelope over fake accessors."""
+    doubles = _Fakes()
+    monkeypatch.setattr(ingress_module, "binding_accessor", doubles)
+    monkeypatch.setattr(ingress_module, "installation_accessor", doubles)
+    return doubles
+
+
+def _status(wamid="wamid.OUT", state="delivered") -> dict:
+    """A delivery receipt item."""
+    return {"id": wamid, "status": state, "timestamp": str(TS)}
+
+
+def _value(number=OUR_NUMBER, **overrides) -> dict:
+    """One "messages" value."""
+    fields = {"messaging_product": "whatsapp", "metadata": {"phone_number_id": number}}
+    fields.update(overrides)
+    return fields
+
+
+def _body(*changes, waba=WABA) -> dict:
+    """Meta's envelope; each change is (field, value)."""
+    return {
+        "object": "whatsapp_business_account",
+        "entry": [
+            {
+                "id": waba,
+                "time": TS,
+                "changes": [{"field": f, "value": v} for f, v in changes],
+            }
+        ],
+    }
+
+
+async def test_a_receipt_is_filed_under_whoever_owns_the_number(fakes) -> None:
+    """A receipt is filed under whoever owns the number."""
+    letters = await ingress_module.META_INGRESS.envelope(
+        {}, _body(("messages", _value(statuses=[_status()])))
+    )
+    assert len(letters) == 1
+    letter = letters[0]
+    assert letter.merchant_id == "shop"
+    assert letter.source == "whatsapp"
+    assert letter.topic == TOPIC_STATUS
+    assert letter.external_id == "wamid.OUT:delivered"
+
+
+async def test_schema_version_is_the_apps_webhook_api_version(fakes) -> None:
+    # Canon T13 col 5: stamped at ingest from the source's own version,
+    # never inferred later — what makes replay survivable.
+    """Schema version is the app's webhook API version."""
+    letters = await ingress_module.META_INGRESS.envelope(
+        {}, _body(("messages", _value(statuses=[_status()])))
+    )
+    assert letters[0].schema_version == META_WHATSAPP_GRAPH_VERSION
+
+
+async def test_a_template_letter_is_owned_through_the_waba(fakes) -> None:
+    # Finding 2: no phone_number_id on these — the WABA's installation names
+    # the merchant.
+    """A template letter is owned through the WABA."""
+    letters = await ingress_module.META_INGRESS.envelope(
+        {},
+        _body(
+            (
+                "message_template_status_update",
+                {"event": "APPROVED", "message_template_id": "t-1"},
+            )
+        ),
+    )
+    assert len(letters) == 1
+    assert letters[0].merchant_id == "shop"
+    assert letters[0].topic == TOPIC_TEMPLATE_STATUS
+    assert fakes.installation_lookups == [("whatsapp", WABA)]
+
+
+async def test_an_owner_costs_one_lookup_however_many_letters(fakes) -> None:
+    """An owner costs one lookup however many letters."""
+    letters = await ingress_module.META_INGRESS.envelope(
+        {},
+        _body(
+            ("messages", _value(statuses=[_status(wamid=f"w{n}") for n in range(5)]))
+        ),
+    )
+    assert len(letters) == 5
+    assert fakes.binding_lookups == [("whatsapp", OUR_NUMBER)]
+
+
+async def test_one_callback_can_carry_two_merchants(monkeypatch) -> None:
+    # Meta batches across accounts, so tenancy is per owner, never per
+    # request.
+    """One callback can carry two merchants."""
+    doubles = _Fakes(
+        bindings={
+            OUR_NUMBER: _binding(),
+            OTHER_NUMBER: _binding(merchant="other", address=OTHER_NUMBER),
+        }
+    )
+    monkeypatch.setattr(ingress_module, "binding_accessor", doubles)
+    monkeypatch.setattr(ingress_module, "installation_accessor", doubles)
+    letters = await ingress_module.META_INGRESS.envelope(
+        {},
+        _body(
+            ("messages", _value(statuses=[_status()])),
+            ("messages", _value(number=OTHER_NUMBER, statuses=[_status(wamid="w2")])),
+        ),
+    )
+    assert {letter.merchant_id for letter in letters} == {"shop", "other"}
+
+
+async def test_an_unowned_number_files_nothing_and_spares_its_neighbours(
+    fakes,
+) -> None:
+    # Filing it under any merchant would be a cross-tenant leak — and it
+    # must not cost the letters beside it, which belong to someone else.
+    """An unowned number files nothing and spares its neighbours."""
+    letters = await ingress_module.META_INGRESS.envelope(
+        {},
+        _body(
+            ("messages", _value(number="nobodys", statuses=[_status(wamid="wX")])),
+            ("messages", _value(statuses=[_status()])),
+        ),
+    )
+    assert [letter.external_id for letter in letters] == ["wamid.OUT:delivered"]
+
+
+async def test_an_unowned_waba_drops_only_its_own_letters(monkeypatch) -> None:
+    """An unowned WABA drops only its own letters."""
+    doubles = _Fakes(installations={})
+    monkeypatch.setattr(ingress_module, "binding_accessor", doubles)
+    monkeypatch.setattr(ingress_module, "installation_accessor", doubles)
+    letters = await ingress_module.META_INGRESS.envelope(
+        {},
+        _body(
+            ("messages", _value(statuses=[_status()])),
+            ("message_template_status_update", {"event": "APPROVED"}),
+        ),
+    )
+    assert [letter.topic for letter in letters] == [TOPIC_STATUS]
+
+
+async def test_the_spec_is_assembled_from_the_meta_face() -> None:
+    """The spec is assembled from the meta face."""
+    from app.crm.connectivity.providers.meta import inbound
+
+    assert ingress_module.META_INGRESS.verify is inbound.verify_signature
+    assert ingress_module.META_INGRESS.challenge is inbound.handshake_challenge

--- a/tests/crm/test_connectors_onboarding.py
+++ b/tests/crm/test_connectors_onboarding.py
@@ -346,6 +346,9 @@ class _StubOnboarder:
         self.gathered += 1
         return self.result
 
+    async def resubscribe(self, bundle, external_account_id):
+        """Test double: the port verb exists; these tests never call it."""
+
     async def revoke(self, bundle, external_account_id):
         """Test double: record that the provider was told."""
         self.revoked.append(external_account_id)
@@ -913,3 +916,348 @@ def test_route_answers_422_for_a_body_the_connector_cannot_validate(
     assert res.status_code == 422
     assert "waba_id" in res.text
     assert "super-secret-code" not in res.text
+
+
+# --- resubscribe: the recovery door (disconnect's opposite verb) -------------
+
+
+def _patch_resubscribe(
+    monkeypatch,
+    *,
+    installation="default",
+    bundle="default",
+    onboarder=None,
+    spec="default",
+):
+    """Wire onboarding.resubscribe to doubles; returns the recorders."""
+    provider_calls: List[tuple] = []
+    health_stamps: List[dict] = []
+
+    class _ResubOnboarder:
+        """Test double: records the provider call instead of making it."""
+
+        def identify(self, request):
+            """Test double: unused here."""
+            return (None, None)
+
+        async def gather(self, request):
+            """Test double: unused here."""
+            raise NotImplementedError
+
+        async def revoke(self, bundle, external_account_id):
+            """Test double: unused here."""
+
+        async def resubscribe(self, bundle, external_account_id):
+            """Test double."""
+            provider_calls.append((bundle, external_account_id))
+
+    row = (
+        _healthy_route(status="degraded") if installation == "default" else installation
+    )
+
+    async def _get_installation(merchant_id, installation_id):
+        """Test double: the seeded installation, tenancy applied upstream."""
+        return row
+
+    monkeypatch.setattr(
+        onboarding_module.installation_accessor,
+        "get_installation",
+        _get_installation,
+    )
+
+    async def _bundle_for(installation):
+        """Test double: the vault read."""
+        if bundle == "default":
+            from app.crm.connectivity.schemas.message import CredentialBundle
+
+            return CredentialBundle(values={"system_user_token": "tok"})
+        if isinstance(bundle, Exception):
+            raise bundle
+        return bundle
+
+    monkeypatch.setattr(onboarding_module.accounts, "bundle_for", _bundle_for)
+
+    if spec == "default":
+        built = ConnectorSpec(
+            key="whatsapp",
+            channel="whatsapp",
+            onboarder=onboarder or _ResubOnboarder(),
+            templates=CONNECTORS["whatsapp"].templates,
+            request_model=OnboardWhatsappRequest,
+        )
+    else:
+        built = spec
+    monkeypatch.setattr(onboarding_module, "connector_for", lambda key: built)
+
+    async def _atomically(fn, *args):
+        """Test double: run the atom body with a dummy handle."""
+        return await fn(None, *args)
+
+    monkeypatch.setattr(onboarding_module, "atomically", _atomically)
+
+    async def _update_health(
+        txn, merchant_id, installation_id, *, status, health_detail
+    ):
+        """Test double: record the re-stamp and answer like the accessor."""
+        health_stamps.append(
+            {
+                "merchant_id": merchant_id,
+                "installation_id": installation_id,
+                "status": status,
+                "health_detail": health_detail,
+            }
+        )
+        return _installation_read(status=status)
+
+    monkeypatch.setattr(
+        onboarding_module.installation_accessor,
+        "update_installation_health",
+        _update_health,
+    )
+    return provider_calls, health_stamps
+
+
+async def test_resubscribe_calls_the_provider_with_the_stored_bundle(
+    monkeypatch,
+) -> None:
+    """Resubscribe calls the provider with the stored bundle."""
+    provider_calls, _ = _patch_resubscribe(monkeypatch)
+    result = await onboarding_module.resubscribe("m-1", "i-1")
+    assert result is not None
+    assert len(provider_calls) == 1
+    bundle, account_id = provider_calls[0]
+    assert bundle.secret("system_user_token") == "tok"
+    assert account_id == _healthy_route().external_account_id
+
+
+async def test_a_successful_resubscribe_restamps_health(monkeypatch) -> None:
+    # Finding 5: a recovery that leaves the row 'degraded' keeps every send
+    # refusing, and a why that is now false contradicts canon T11.
+    """A successful resubscribe restamps health."""
+    import json as _json
+
+    _, health_stamps = _patch_resubscribe(monkeypatch)
+    result = await onboarding_module.resubscribe("m-1", "i-1")
+    assert result is not None and result.status == "healthy"
+    assert len(health_stamps) == 1
+    stamp = health_stamps[0]
+    assert stamp["status"] == "healthy"
+    detail = _json.loads(stamp["health_detail"])
+    assert detail["level"] == "subscribed" and detail["why"] is None
+    assert detail["checked_at"]
+
+
+async def test_a_foreign_tenants_installation_is_simply_not_found(
+    monkeypatch,
+) -> None:
+    """A foreign tenant's installation is simply not found."""
+    _patch_resubscribe(monkeypatch, installation=None)
+
+    async def _none(merchant_id, installation_id):
+        """Test double: not this merchant's row."""
+        return None
+
+    monkeypatch.setattr(
+        onboarding_module.installation_accessor, "get_installation", _none
+    )
+    assert await onboarding_module.resubscribe("m-1", "i-1") is None
+
+
+async def test_a_connector_without_the_verb_is_refused_before_the_vault(
+    monkeypatch,
+) -> None:
+    """A connector without the verb is refused before the vault."""
+    vault_reads: List[str] = []
+    _patch_resubscribe(monkeypatch, spec=None)
+    monkeypatch.setattr(onboarding_module, "connector_for", lambda key: None)
+
+    async def _recording_bundle(installation):
+        """Test double: must never be reached."""
+        vault_reads.append(installation.id)
+
+    monkeypatch.setattr(onboarding_module.accounts, "bundle_for", _recording_bundle)
+    with pytest.raises(OnboardingError) as caught:
+        await onboarding_module.resubscribe("m-1", "i-1")
+    assert "no webhook subscription" in str(caught.value)
+    assert vault_reads == []
+
+
+async def test_unusable_credentials_are_a_refusal_not_a_crash(monkeypatch) -> None:
+    """Unusable credentials are a refusal, not a crash."""
+    _patch_resubscribe(monkeypatch, bundle=accounts_module.AccountError("gone"))
+    with pytest.raises(OnboardingError) as caught:
+        await onboarding_module.resubscribe("m-1", "i-1")
+    assert "credentials" in str(caught.value)
+
+
+async def test_a_vault_outage_is_not_reported_as_a_refusal(monkeypatch) -> None:
+    # An outage must surface as an incident (the route's 500), never as
+    # "reconnect your account" advice for an account whose credentials are
+    # fine.
+    """A vault outage is not reported as a refusal."""
+    _patch_resubscribe(monkeypatch, bundle=ConnectionError("pool down"))
+    with pytest.raises(ConnectionError):
+        await onboarding_module.resubscribe("m-1", "i-1")
+
+
+async def test_a_provider_refusal_passes_through_in_its_own_words(
+    monkeypatch,
+) -> None:
+    """A provider refusal passes through in its own words."""
+
+    class _Refusing:
+        """Test double: the provider said no, in its own words."""
+
+        def identify(self, request):
+            """Test double: unused here."""
+            return (None, None)
+
+        async def gather(self, request):
+            """Test double: unused here."""
+            raise NotImplementedError
+
+        async def revoke(self, bundle, external_account_id):
+            """Test double: unused here."""
+
+        async def resubscribe(self, bundle, external_account_id):
+            """Test double."""
+            raise WhatsappOnboardingError("that number is not on this account")
+
+    _, health_stamps = _patch_resubscribe(monkeypatch, onboarder=_Refusing())
+    with pytest.raises(OnboardingError) as caught:
+        await onboarding_module.resubscribe("m-1", "i-1")
+    assert "that number is not on this account" in str(caught.value)
+    # And no re-stamp: a refused recovery must not turn the light green.
+    assert health_stamps == []
+
+
+async def test_the_whatsapp_face_translates_graph_errors(monkeypatch) -> None:
+    # Rule 11: GraphError never leaves the package; its detail does.
+    """The whatsapp face translates graph errors."""
+    from app.crm.connectivity.providers.meta.graph import GraphError
+    from app.crm.connectivity.providers.whatsapp import onboard as onboard_module
+    from app.crm.connectivity.schemas.message import CredentialBundle
+
+    async def _graph_refuses(waba_id, token):
+        """Test double: Meta refused at the wire."""
+        raise GraphError("(#200) permissions error", code="200")
+
+    monkeypatch.setattr(onboard_module, "subscribe", _graph_refuses)
+    with pytest.raises(WhatsappOnboardingError) as caught:
+        await WhatsappOnboarder().resubscribe(
+            CredentialBundle(values={"system_user_token": "tok"}), "waba-1"
+        )
+    assert "(#200) permissions error" in str(caught.value)
+    assert isinstance(caught.value.__cause__, GraphError)
+
+
+async def test_the_whatsapp_face_refuses_a_bundle_without_a_token(
+    monkeypatch,
+) -> None:
+    """The whatsapp face refuses a bundle without a token."""
+    from app.crm.connectivity.providers.whatsapp import onboard as onboard_module
+    from app.crm.connectivity.schemas.message import CredentialBundle
+
+    calls: List[tuple] = []
+
+    async def _record(waba_id, token):
+        """Test double: must never be reached."""
+        calls.append((waba_id, token))
+
+    monkeypatch.setattr(onboard_module, "subscribe", _record)
+    with pytest.raises(WhatsappOnboardingError) as caught:
+        await WhatsappOnboarder().resubscribe(CredentialBundle(values={}), "waba-1")
+    assert "access token" in str(caught.value)
+    assert calls == []
+
+
+# --- the subscribe route ------------------------------------------------------
+
+
+def _client(monkeypatch, user_merchants=("shop",)):
+    """A TestClient with auth overridden — tenancy and error mapping run for
+    real."""
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    from app.api.security.breeze_buddy.rbac_token import get_current_user_with_rbac
+    from app.crm.connectivity import api as connectivity_api
+
+    app = FastAPI()
+    app.include_router(connectivity_api.router, prefix="/connectors")
+    app.dependency_overrides[get_current_user_with_rbac] = lambda: SimpleNamespace(
+        role="user", merchant_ids=list(user_merchants), username="tester"
+    )
+    return TestClient(app)
+
+
+def test_the_subscribe_route_reports_a_refusal_as_409(monkeypatch) -> None:
+    # Understood and deliberately declined — with a sentence the merchant
+    # can act on, not a 400's "you asked wrong".
+    """The subscribe route reports a refusal as 409."""
+    from app.crm.connectivity import contracts
+
+    async def refuses(merchant_id, installation_id):
+        """Test double: the door refused."""
+        raise OnboardingError("This account's credentials are missing or unreadable.")
+
+    monkeypatch.setattr(contracts, "resubscribe", refuses)
+    response = _client(monkeypatch).post(
+        "/connectors/installations/i-1/subscribe", params={"merchant_id": "shop"}
+    )
+    assert response.status_code == 409
+    assert "credentials" in response.json()["detail"]
+
+
+def test_the_subscribe_route_hides_a_foreign_installation_as_404(
+    monkeypatch,
+) -> None:
+    """The subscribe route hides a foreign installation as 404."""
+    from app.crm.connectivity import contracts
+
+    async def not_found(merchant_id, installation_id):
+        """Test double: not this merchant's row."""
+        return None
+
+    monkeypatch.setattr(contracts, "resubscribe", not_found)
+    response = _client(monkeypatch).post(
+        "/connectors/installations/i-1/subscribe", params={"merchant_id": "shop"}
+    )
+    assert response.status_code == 404
+
+
+def test_the_subscribe_route_echoes_what_was_subscribed(monkeypatch) -> None:
+    """The subscribe route echoes what was subscribed."""
+    from app.crm.connectivity import contracts
+
+    async def succeeds(merchant_id, installation_id):
+        """Test double: the door subscribed and re-stamped health."""
+        return _installation_read(status="healthy")
+
+    monkeypatch.setattr(contracts, "resubscribe", succeeds)
+    response = _client(monkeypatch).post(
+        "/connectors/installations/i-1/subscribe", params={"merchant_id": "shop"}
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["subscribed"] is True and body["installation_id"] == "i-1"
+
+
+def test_the_subscribe_route_refuses_a_foreign_merchant_before_the_door(
+    monkeypatch,
+) -> None:
+    """The subscribe route refuses a foreign merchant before the door."""
+    from app.crm.connectivity import contracts
+
+    reached: List[str] = []
+
+    async def records(merchant_id, installation_id):
+        """Test double: must never be reached."""
+        reached.append(merchant_id)
+
+    monkeypatch.setattr(contracts, "resubscribe", records)
+    response = _client(monkeypatch, user_merchants=("someone-else",)).post(
+        "/connectors/installations/i-1/subscribe", params={"merchant_id": "shop"}
+    )
+    assert response.status_code == 403
+    assert reached == []

--- a/tests/crm/test_ingress_door.py
+++ b/tests/crm/test_ingress_door.py
@@ -1,0 +1,221 @@
+"""Record's provider bays: dispatch through the slot, and the door's replies.
+
+Everything here runs over a FAKE spec registered in the INGRESS slot — the
+door must know no provider by name, so its tests don't either. The Meta
+spec's own halves are tested in test_meta_inbound.py (wire shape) and
+test_connectivity_ingress.py (owner resolution); the URL Meta is actually
+given is proven in test_ingress_integration.py.
+
+Two promises carry the file: the bays are the only unauthenticated routes
+in the service, so most tests refuse something; and a STORE failure is 503
+— the one answer that doesn't lose the provider's letter forever.
+"""
+
+from typing import List, Optional
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.crm.connectivity import api as connectivity_api
+from app.crm.record import api as record_api, ingress
+from app.crm.record.schemas import EventIn
+
+RAW = b'{"any": "body"}'
+
+
+class _FakeSpec:
+    """A controllable IngressSpec stand-in registered under "fake"."""
+
+    def __init__(self):
+        """Test double."""
+        self.verify_ok = True
+        self.challenge_answer: Optional[str] = "echo-me"
+        self.letters: List[EventIn] = [_letter()]
+        self.verified: list = []
+        self.enveloped: list = []
+
+    def verify(self, raw, headers) -> bool:
+        """Test double."""
+        self.verified.append(raw)
+        return self.verify_ok
+
+    async def envelope(self, headers, body) -> List[EventIn]:
+        """Test double."""
+        self.enveloped.append(body)
+        return self.letters
+
+    def challenge(self, params) -> Optional[str]:
+        """Test double."""
+        return self.challenge_answer
+
+
+def _letter(external_id="x-1") -> EventIn:
+    """One resolved letter as a spec's envelope returns it."""
+    return EventIn(
+        merchant_id="shop",
+        source="fake",
+        topic="message.status",
+        external_id=external_id,
+        payload={"k": "v"},
+    )
+
+
+@pytest.fixture
+def spec(monkeypatch) -> _FakeSpec:
+    """A fake bay in the slot, and the spine patched to record filings."""
+    fake = _FakeSpec()
+    monkeypatch.setitem(ingress.INGRESS, "fake", fake)
+    return fake
+
+
+@pytest.fixture
+def spine(monkeypatch) -> list:
+    """Captures every letter the door files."""
+    filed: list = []
+
+    async def _ingest(**kwargs):
+        """Test double: the store accepts."""
+        filed.append(kwargs)
+        return f"ev-{len(filed)}"
+
+    monkeypatch.setattr(record_api, "ingest_event", _ingest)
+    return filed
+
+
+@pytest.fixture
+def client(spec, spine) -> TestClient:
+    """The webhook router over the fake bay."""
+    app = FastAPI()
+    app.include_router(record_api.webhook_router, prefix="/ingest/webhooks")
+    return TestClient(app)
+
+
+URL = "/ingest/webhooks/fake"
+
+
+def test_a_verified_body_is_filed_and_answered_200(client, spec, spine) -> None:
+    """A verified body is filed and answered 200."""
+    assert client.post(URL, content=RAW).status_code == 200
+    assert spec.verified == [RAW]
+    assert len(spine) == 1
+    assert spine[0]["external_id"] == "x-1" and spine[0]["merchant_id"] == "shop"
+
+
+def test_an_unknown_provider_is_a_404_before_the_body_is_read(
+    client, spec, spine
+) -> None:
+    # The slot is a closed map: no bay, no bytes buffered, nothing learned.
+    """An unknown provider is a 404 before the body is read."""
+    assert client.post("/ingest/webhooks/nobody", content=RAW).status_code == 404
+    assert spec.verified == [] and spine == []
+
+
+def test_a_failed_verification_is_403_and_files_nothing(client, spec, spine) -> None:
+    """A failed verification is 403 and files nothing."""
+    spec.verify_ok = False
+    response = client.post(URL, content=RAW)
+    assert response.status_code == 403
+    # No detail: a caller who cannot sign has not earned an explanation.
+    assert response.content == b""
+    assert spine == []
+
+
+def test_a_verified_non_object_body_is_400(client, spec, spine) -> None:
+    """A verified non-object body is 400."""
+    assert client.post(URL, content=b"[1,2,3]").status_code == 400
+    assert spec.enveloped == [] and spine == []
+
+
+def test_a_store_failure_is_503_never_a_silent_200(client, spec, monkeypatch) -> None:
+    # Finding 3: the provider retries a 503 with the same ids and dedupe
+    # makes that safe; a 200 on a dropped letter loses it forever.
+    """A store failure is 503, never a silent 200."""
+
+    async def _down(**kwargs):
+        """Test double: the store raised."""
+        raise RuntimeError("pool down")
+
+    monkeypatch.setattr(record_api, "ingest_event", _down)
+    assert client.post(URL, content=RAW).status_code == 503
+
+
+def test_a_duplicate_is_still_200(client, spec, monkeypatch) -> None:
+    # None = the dedupe UNIQUE already holds it; asking for a resend would
+    # not help.
+    """A duplicate is still 200."""
+
+    async def _duplicate(**kwargs):
+        """Test double: the spine already holds it."""
+        return None
+
+    monkeypatch.setattr(record_api, "ingest_event", _duplicate)
+    assert client.post(URL, content=RAW).status_code == 200
+
+
+def test_an_oversized_body_is_refused_while_streaming(
+    client, spec, spine, monkeypatch
+) -> None:
+    """An oversized body is refused while streaming.
+
+    Even a VALID signature does not buy an unbounded read: the cap fires
+    during the read, before verification — buffering an arbitrary body for
+    an unauthenticated caller is the cost the route must not pay.
+    """
+    monkeypatch.setattr(record_api, "MAX_LETTER_BYTES", 64)
+    assert client.post(URL, content=b"x" * 65).status_code == 413
+    assert spec.verified == [] and spine == []
+
+
+def test_the_handshake_echoes_in_plain_text(client, spec) -> None:
+    """The handshake echoes in plain text."""
+    response = client.get(URL)
+    assert response.status_code == 200
+    # Echoed raw — the provider compares the body, so quotes would fail it.
+    assert response.text == "echo-me"
+
+
+def test_a_refused_handshake_hides_the_route(client, spec) -> None:
+    # 404, not 403: a different answer for a wrong token than for a missing
+    # bay tells an unauthenticated caller they found something to guess at.
+    """A refused handshake hides the route."""
+    spec.challenge_answer = None
+    assert client.get(URL).status_code == 404
+    assert client.get("/ingest/webhooks/nobody").status_code == 404
+
+
+def test_only_the_webhook_router_is_unauthenticated() -> None:
+    """The carve-out is the webhook router and nothing else.
+
+    Both directions matter: auth appearing on the provider bays locks the
+    provider out and silently stops every event, and auth going missing
+    from any /connectors route would expose connector administration to
+    anyone.
+    """
+
+    def dependency_names(route) -> list:
+        """The route's declared dependencies, by function name."""
+        dependant = getattr(route, "dependant", None)
+        return [
+            d.call.__name__
+            for d in (dependant.dependencies if dependant else [])
+            if getattr(d, "call", None) is not None
+        ]
+
+    for route in record_api.webhook_router.routes:
+        assert dependency_names(route) == [], getattr(route, "path", route)
+    # Every /connectors route carries the merchant-facing RBAC dependency —
+    # the tenancy check itself runs inside the handler via
+    # assert_merchant_access.
+    for route in connectivity_api.router.routes:
+        names = dependency_names(route)
+        assert "get_current_user_with_rbac" in names, getattr(route, "path", route)
+
+
+def test_a_callback_carrying_no_letters_is_still_200(client, spec, spine) -> None:
+    # Account-review noise and unknown objects ride the same webhook; a 200
+    # with nothing filed is the right answer, not an error.
+    """A callback carrying no letters is still 200."""
+    spec.letters = []
+    assert client.post(URL, content=RAW).status_code == 200
+    assert spine == []

--- a/tests/crm/test_ingress_integration.py
+++ b/tests/crm/test_ingress_integration.py
@@ -1,0 +1,480 @@
+"""The provider bay against a real Postgres and the real router.
+
+Skipped unless a database is offered:
+
+    createdb crm_webhook_test
+    for f in app/database/migrations/*.sql; do psql -q -d crm_webhook_test -f $f; done
+    CRM_WEBHOOK_TEST_DSN=postgresql:///crm_webhook_test uv run pytest \\
+        tests/crm/test_ingress_integration.py -v
+
+Mocks in test_ingress_door.py, test_connectivity_ingress.py and
+test_meta_inbound.py cover everything else; they cannot answer the four
+questions this file asks:
+
+  1. Is the route mounted at the URL we tell Meta about? A unit test builds
+     its own app; a typo in app/crm/api.py cannot fail it.
+  2. Does the signature verify over the bytes FASTAPI hands us, rather than
+     the bytes a test constructed?
+  3. Is the SQL real SQL, against the index these migrations actually build?
+  4. Does the spine's UNIQUE constraint really dedupe a replayed callback —
+     the one part no mock can stand in for.
+
+Meta itself is still faked (its bytes are signed here): a test that needed a
+real WhatsApp Business Account would never run.
+"""
+
+import hashlib
+import hmac
+import json
+import uuid
+from typing import Any, AsyncIterator, Dict, List
+
+import asyncpg
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from tests.crm.conftest import CRM_WEBHOOK_TEST_DSN as DSN
+
+pytestmark = pytest.mark.skipif(
+    not DSN, reason="set CRM_WEBHOOK_TEST_DSN to run the DB-backed webhook tests"
+)
+
+SECRET = "integration-app-secret"
+TOKEN = "integration-verify-token"
+MERCHANT = "itest-shop"
+OTHER_MERCHANT = "itest-other"
+# Reserved for this file. An address is unique per channel PLATFORM-wide
+# (crm_channel_binding_address_uq), so seeding a number another row already
+# holds fails the insert — which is the index doing its job, and the reason
+# these are namespaced rather than plausible-looking.
+OUR_NUMBER = "999000000000001"
+OTHER_NUMBER = "999000000000002"
+UNOWNED_NUMBER = "999000000000003"
+SENT_WAMID = "wamid.ITEST-SENT"
+URL = "/ingest/webhooks/meta"
+
+
+def _signed(body: bytes, secret: str = SECRET) -> Dict[str, str]:
+    """Headers Meta would send with these exact bytes."""
+    mac = hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+    return {"X-Hub-Signature-256": f"sha256={mac}", "Content-Type": "application/json"}
+
+
+def _envelope(*values: Dict[str, Any]) -> bytes:
+    """Meta's entry/changes/value envelope, serialised once — the same bytes
+    that get signed and posted, because re-serialising would invalidate the
+    signature and quietly turn every test into a 403."""
+    return json.dumps(
+        {
+            "object": "whatsapp_business_account",
+            "entry": [
+                {
+                    "id": "waba-itest",
+                    "changes": [{"field": "messages", "value": v} for v in values],
+                }
+            ],
+        }
+    ).encode()
+
+
+def _status(number: str, wamid: str, status: str) -> Dict[str, Any]:
+    """A Meta status entry for test payloads."""
+    return {
+        "metadata": {"phone_number_id": number},
+        "statuses": [
+            {
+                "id": wamid,
+                "status": status,
+                "timestamp": "1788177600",
+                "recipient_id": "919876543210",
+                "pricing": {"billable": True, "category": "utility"},
+            }
+        ],
+    }
+
+
+def _inbound(number: str, wamid: str, text: str = "yes") -> Dict[str, Any]:
+    """A Meta inbound-message entry for test payloads."""
+    return {
+        "metadata": {"phone_number_id": number},
+        "messages": [
+            {
+                "from": "919876543210",
+                "id": wamid,
+                "timestamp": "1788177601",
+                "type": "text",
+                "text": {"body": text},
+                "context": {"id": SENT_WAMID},
+            }
+        ],
+    }
+
+
+@pytest.fixture
+async def db() -> AsyncIterator[asyncpg.Connection]:
+    """A connection for seeding and asserting, plus the app's own pool.
+
+    The pool is assigned to app.database.pool directly: it must live on the
+    loop this test runs on (asyncpg pools are loop-bound), and going through
+    init_db_pool() would read the five POSTGRES_* variables that static config
+    froze at import instead of the DSN this file was given.
+    """
+    import app.database as database
+
+    pool = await asyncpg.create_pool(dsn=DSN, min_size=1, max_size=2)
+    # The ignore is because the module declares `pool = None` and only ever
+    # reassigns it from inside itself.
+    previous, database.pool = database.pool, pool  # type: ignore[assignment]
+    conn = await asyncpg.connect(DSN)
+    try:
+        await _seed(conn)
+        yield conn
+    finally:
+        await _purge(conn)
+        await conn.close()
+        database.pool = previous
+        await pool.close()
+
+
+async def _purge(conn: asyncpg.Connection) -> None:
+    """Only this test's own rows — the DSN may point at a shared dev box.
+
+    Bindings are also cleared by ADDRESS, because those three numbers are
+    reserved above and a crashed run can leave one behind under a merchant
+    name this function would otherwise not look at. Credentials are cleared
+    by NAME for the same reason — and they must go LAST: the installation's
+    FK is ON DELETE RESTRICT, so a vault row is only deletable once the
+    installations above have released it. Skipping this delete leaks the
+    rows, and the NEXT run's seed dies on the unique credential-name index.
+    """
+    await conn.execute(
+        "DELETE FROM crm_channel_binding WHERE address = ANY($1::text[])",
+        [OUR_NUMBER, OTHER_NUMBER, UNOWNED_NUMBER],
+    )
+    for merchant in (MERCHANT, OTHER_MERCHANT):
+        await conn.execute("DELETE FROM crm_event_raw WHERE merchant_id = $1", merchant)
+        await conn.execute("DELETE FROM crm_message WHERE merchant_id = $1", merchant)
+        await conn.execute(
+            "DELETE FROM crm_channel_binding WHERE merchant_id = $1", merchant
+        )
+        await conn.execute(
+            "DELETE FROM crm_connector_installation WHERE merchant_id = $1", merchant
+        )
+        await conn.execute("DELETE FROM crm_customer WHERE merchant_id = $1", merchant)
+    await conn.execute(
+        "DELETE FROM credentials WHERE name = ANY($1::text[])",
+        [f"{MERCHANT}-wa", f"{OTHER_MERCHANT}-wa"],
+    )
+
+
+async def _seed(conn: asyncpg.Connection) -> None:
+    """Two merchants, one number each, and one message already sent.
+
+    Two of them because tenancy is the property most worth testing here: with
+    a single merchant, filing everything under "the" merchant would pass.
+    """
+    await _purge(conn)
+    for merchant, number in ((MERCHANT, OUR_NUMBER), (OTHER_MERCHANT, OTHER_NUMBER)):
+        credential_id, installation_id = uuid.uuid4(), uuid.uuid4()
+        await conn.execute(
+            "INSERT INTO credentials (id, name, credential_type, value)"
+            " VALUES ($1, $2, 'custom', $3)",
+            credential_id,
+            f"{merchant}-wa",
+            json.dumps({"system_user_token": "itest-token"}),
+        )
+        await conn.execute(
+            "INSERT INTO crm_connector_installation (id, merchant_id, connector_key,"
+            " external_account_id, credential_id, status)"
+            " VALUES ($1, $2, 'whatsapp', $3, $4, 'healthy')",
+            installation_id,
+            merchant,
+            f"waba-{merchant}",
+            credential_id,
+        )
+        await conn.execute(
+            "INSERT INTO crm_channel_binding (id, merchant_id, channel,"
+            " installation_id, address, is_primary, status)"
+            " VALUES (gen_random_uuid(), $1, 'whatsapp', $2, $3, TRUE, 'active')",
+            merchant,
+            installation_id,
+            number,
+        )
+    customer_id = uuid.uuid4()
+    await conn.execute(
+        "INSERT INTO crm_customer (id, merchant_id) VALUES ($1, $2)",
+        customer_id,
+        MERCHANT,
+    )
+    await conn.execute(
+        "INSERT INTO crm_message (merchant_id, customer_id, sent_to_address, channel,"
+        " source_kind, purpose_key, dedupe_key, status, provider_message_id)"
+        " VALUES ($1, $2, '+919876543210', 'whatsapp', 'transactional',"
+        " 'order_update', 'itest-1', 'accepted', $3)",
+        MERCHANT,
+        customer_id,
+        SENT_WAMID,
+    )
+
+
+@pytest.fixture
+async def client(monkeypatch, db) -> AsyncIterator[AsyncClient]:
+    """The real CRM router, in this loop, with the platform secrets set.
+
+    Mounted with prefix "" exactly as app/main.py mounts it (ADR 0022: no
+    internal words on the outside surface), so the URL under test here is the
+    URL Meta is actually given."""
+    from app.crm import api as crm_api
+    from app.crm.connectivity.providers.meta import inbound as meta_module
+
+    monkeypatch.setattr(meta_module, "META_APP_SECRET", SECRET)
+    monkeypatch.setattr(meta_module, "META_WEBHOOK_VERIFY_TOKEN", TOKEN)
+
+    app = FastAPI()
+    app.include_router(crm_api.router, prefix="")
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://itest"
+    ) as http:
+        yield http
+
+
+async def _letters(conn: asyncpg.Connection, merchant: str = MERCHANT) -> List[dict]:
+    """Read back what the door filed in the spine."""
+    rows = await conn.fetch(
+        "SELECT source, topic, external_id, customer_id, occurred_at, payload,"
+        "       schema_version"
+        "  FROM crm_event_raw WHERE merchant_id = $1 ORDER BY external_id",
+        merchant,
+    )
+    return [dict(row) for row in rows]
+
+
+# --- the route exists, and only the signature opens it ------------------------
+
+
+async def test_the_url_we_give_meta_is_really_mounted(client) -> None:
+    # The whole point of testing through app.crm.api: a unit test builds its
+    # own router and cannot notice a missing include_router.
+    """The url we give meta is really mounted."""
+    body = _envelope(_status(OUR_NUMBER, SENT_WAMID, "delivered"))
+    response = await client.post(URL, content=body, headers=_signed(body))
+    assert response.status_code == 200
+
+
+async def test_the_signature_is_verified_over_the_bytes_fastapi_delivers(
+    client, db
+) -> None:
+    # Signed with the wrong secret: identical bytes, so only the HMAC differs.
+    """The signature is verified over the bytes fastapi delivers."""
+    body = _envelope(_status(OUR_NUMBER, SENT_WAMID, "read"))
+    response = await client.post(URL, content=body, headers=_signed(body, "wrong"))
+    assert response.status_code == 403
+    assert await _letters(db) == []
+
+
+async def test_a_body_rewritten_under_a_real_signature_is_refused(client, db) -> None:
+    """A body rewritten under a real signature is refused."""
+    real = _envelope(_status(OUR_NUMBER, SENT_WAMID, "sent"))
+    forged = _envelope(_status(OUR_NUMBER, SENT_WAMID, "read"))
+    response = await client.post(URL, content=forged, headers=_signed(real))
+    assert response.status_code == 403
+    assert await _letters(db) == []
+
+
+async def test_the_handshake_answers_over_http(client) -> None:
+    """The handshake answers over http."""
+    response = await client.get(
+        URL,
+        params={
+            "hub.mode": "subscribe",
+            "hub.verify_token": TOKEN,
+            "hub.challenge": "31415",
+        },
+    )
+    # Meta compares the raw body, so the content type matters as much as the
+    # text: JSON quoting would fail the handshake at registration time.
+    assert response.status_code == 200
+    assert response.text == "31415"
+
+
+# --- what lands in the spine --------------------------------------------------
+
+
+async def test_a_receipt_lands_under_the_merchant_that_owns_the_number(
+    client, db
+) -> None:
+    """A receipt lands under the merchant that owns the number."""
+    body = _envelope(_status(OUR_NUMBER, SENT_WAMID, "delivered"))
+    assert (
+        await client.post(URL, content=body, headers=_signed(body))
+    ).status_code == 200
+
+    filed = await _letters(db)
+    assert len(filed) == 1
+    assert filed[0]["source"] == "whatsapp"
+    assert filed[0]["topic"] == "message.status"
+    assert filed[0]["external_id"] == f"{SENT_WAMID}:delivered"
+    # Meta's clock, through a real timestamptz column.
+    assert filed[0]["occurred_at"].timestamp() == 1788177600.0
+    # Meta's value, narrowed to the one item: a consumer reads Meta's
+    # documented shape, and a recorded callback is a valid fixture unchanged.
+    payload = json.loads(filed[0]["payload"])
+    assert payload["statuses"][0]["pricing"]["category"] == "utility"
+    assert payload["metadata"]["phone_number_id"] == OUR_NUMBER
+    # Canon T13 col 5: the version stamped at ingest is the app's webhook
+    # API version, never an inferred "1".
+    from app.core.config.static import META_WHATSAPP_GRAPH_VERSION
+
+    assert filed[0]["schema_version"] == META_WHATSAPP_GRAPH_VERSION
+
+
+async def test_the_door_stamps_no_customer(client, db) -> None:
+    """The door stamps no customer."""
+    body = _envelope(_inbound(OUR_NUMBER, "wamid.ITEST-IN"))
+    await client.post(URL, content=body, headers=_signed(body))
+    filed = await _letters(db)
+    assert [row["customer_id"] for row in filed] == [None]
+
+
+async def test_meta_replaying_a_callback_files_nothing_new(client, db) -> None:
+    # THE test a mock cannot run: dedupe is a UNIQUE index doing the work.
+    """Meta replaying a callback files nothing new."""
+    body = _envelope(_status(OUR_NUMBER, SENT_WAMID, "delivered"))
+    for _ in range(3):
+        response = await client.post(URL, content=body, headers=_signed(body))
+        # 200 every time: asking Meta to re-send would not help.
+        assert response.status_code == 200
+    assert len(await _letters(db)) == 1
+
+
+async def test_each_transition_is_its_own_letter(client, db) -> None:
+    # One wamid, four states. Keyed by id alone they would collapse into one.
+    """Each transition is its own letter."""
+    for state in ("sent", "delivered", "read", "failed"):
+        body = _envelope(_status(OUR_NUMBER, SENT_WAMID, state))
+        await client.post(URL, content=body, headers=_signed(body))
+    assert len(await _letters(db)) == 4
+
+
+async def test_one_callback_carrying_two_merchants_is_split(client, db) -> None:
+    # Meta batches across accounts. Tenancy resolved once per REQUEST would
+    # file one merchant's events under the other.
+    """One callback carrying two merchants is split."""
+    body = _envelope(
+        _status(OUR_NUMBER, SENT_WAMID, "delivered"),
+        _status(OTHER_NUMBER, "wamid.ITEST-THEIRS", "read"),
+    )
+    assert (
+        await client.post(URL, content=body, headers=_signed(body))
+    ).status_code == 200
+
+    ours = await _letters(db, MERCHANT)
+    theirs = await _letters(db, OTHER_MERCHANT)
+    assert [row["external_id"] for row in ours] == [f"{SENT_WAMID}:delivered"]
+    assert [row["external_id"] for row in theirs] == ["wamid.ITEST-THEIRS:read"]
+
+
+async def test_an_unowned_number_is_accepted_and_filed_nowhere(client, db) -> None:
+    """An unowned number is accepted and filed nowhere."""
+    body = _envelope(_status(UNOWNED_NUMBER, "wamid.ITEST-NOBODY", "read"))
+    response = await client.post(URL, content=body, headers=_signed(body))
+    # 200: it is a real Meta callback, just not about anything of ours.
+    assert response.status_code == 200
+    assert await _letters(db) == []
+    assert await _letters(db, OTHER_MERCHANT) == []
+
+
+async def test_a_retired_number_no_longer_files(client, db) -> None:
+    # A number handed back to Meta and recycled: after retirement its events
+    # must stop being filed under the merchant that used to hold it.
+    """A retired number no longer files."""
+    await db.execute(
+        "UPDATE crm_channel_binding SET status = 'retired' WHERE merchant_id = $1",
+        MERCHANT,
+    )
+    body = _envelope(_status(OUR_NUMBER, SENT_WAMID, "read"))
+    assert (
+        await client.post(URL, content=body, headers=_signed(body))
+    ).status_code == 200
+    assert await _letters(db) == []
+
+
+async def test_a_paused_number_still_files(client, db) -> None:
+    # Pausing stops us SENDING from a number. Receipts for messages already
+    # sent keep arriving, and dropping them would lose real events.
+    """A paused number still files."""
+    await db.execute(
+        "UPDATE crm_channel_binding SET status = 'paused' WHERE merchant_id = $1",
+        MERCHANT,
+    )
+    body = _envelope(_status(OUR_NUMBER, SENT_WAMID, "delivered"))
+    await client.post(URL, content=body, headers=_signed(body))
+    assert len(await _letters(db)) == 1
+
+
+# --- the promise: filing, and nothing else ------------------------------------
+
+
+async def test_the_door_writes_no_other_crm_table(client, db) -> None:
+    """The door writes no other crm table."""
+    body = _envelope(
+        _status(OUR_NUMBER, SENT_WAMID, "delivered"),
+        _inbound(OUR_NUMBER, "wamid.ITEST-REPLY"),
+    )
+    await client.post(URL, content=body, headers=_signed(body))
+
+    # The manifest row the receipt is about: still exactly as it was sent.
+    message = dict(
+        await db.fetchrow(
+            "SELECT status, reason, delivered_at, read_at, cost_micros"
+            "  FROM crm_message WHERE merchant_id = $1",
+            MERCHANT,
+        )
+    )
+    assert message == {
+        "status": "accepted",
+        "reason": None,
+        "delivered_at": None,
+        "read_at": None,
+        "cost_micros": None,
+    }
+    # And the customer who replied was NOT resolved into existence.
+    assert (
+        await db.fetchval(
+            "SELECT count(*) FROM crm_customer WHERE merchant_id = $1", MERCHANT
+        )
+        == 1
+    )
+    assert len(await _letters(db)) == 2
+
+
+async def test_a_template_letter_is_owned_through_the_waba(client, db) -> None:
+    # The WABA lookup against real SQL: installation_for_inbound_query and
+    # the composed external_id, end to end.
+    """A template letter is owned through the WABA."""
+    body = json.dumps(
+        {
+            "object": "whatsapp_business_account",
+            "entry": [
+                {
+                    "id": f"waba-{MERCHANT}",
+                    "time": 1788177600,
+                    "changes": [
+                        {
+                            "field": "message_template_status_update",
+                            "value": {
+                                "event": "APPROVED",
+                                "message_template_id": "tmpl-1",
+                            },
+                        }
+                    ],
+                }
+            ],
+        }
+    ).encode()
+    response = await client.post(URL, content=body, headers=_signed(body))
+    assert response.status_code == 200
+    filed = await _letters(db)
+    assert [row["topic"] for row in filed] == ["template.status"]
+    assert filed[0]["external_id"] == f"waba-{MERCHANT}:tmpl-1:APPROVED:1788177600"

--- a/tests/crm/test_meta_inbound.py
+++ b/tests/crm/test_meta_inbound.py
@@ -1,0 +1,328 @@
+"""Meta's inbound face: their signature, their handshake, their envelope.
+
+The face's own half only — verify, challenge, and the walk from Meta's
+entry[]/changes[]/value to letters that still name a provider OWNER. Who
+that owner belongs to is connectivity/ingress.py's business, tested in
+test_connectivity_ingress.py; the record door that mounts it is tested in
+test_ingress_door.py.
+"""
+
+import hashlib
+import hmac
+
+import pytest
+
+from app.crm.connectivity.providers.meta import inbound
+from app.crm.connectivity.topics import (
+    TOPIC_ACCOUNT,
+    TOPIC_INBOUND,
+    TOPIC_STATUS,
+    TOPIC_TEMPLATE_CATEGORY,
+    TOPIC_TEMPLATE_QUALITY,
+    TOPIC_TEMPLATE_STATUS,
+)
+
+SECRET = "meta-app-secret-for-tests"
+TOKEN = "meta-verify-token-for-tests"
+NUMBER = "812345678901234"
+WABA = "waba-77"
+OUT_WAMID = "wamid.OUT"
+IN_WAMID = "wamid.IN"
+TS = "1788177600"
+
+
+@pytest.fixture
+def secrets(monkeypatch):
+    """Both platform secrets present — the normal running state."""
+    monkeypatch.setattr(inbound, "META_APP_SECRET", SECRET)
+    monkeypatch.setattr(inbound, "META_WEBHOOK_VERIFY_TOKEN", TOKEN)
+
+
+def _sig(raw: bytes, secret: str = SECRET) -> str:
+    """A valid X-Hub-Signature-256 over these exact bytes."""
+    return "sha256=" + hmac.new(secret.encode(), raw, hashlib.sha256).hexdigest()
+
+
+def _status(**overrides) -> dict:
+    """A delivery receipt item as Meta sends one."""
+    fields = {"id": OUT_WAMID, "status": "delivered", "timestamp": TS}
+    fields.update(overrides)
+    return fields
+
+
+def _message(**overrides) -> dict:
+    """An inbound customer message as Meta sends one."""
+    fields = {
+        "from": "919876543210",
+        "id": IN_WAMID,
+        "timestamp": TS,
+        "type": "text",
+        "text": {"body": "yes"},
+    }
+    fields.update(overrides)
+    return fields
+
+
+def _value(number=NUMBER, **overrides) -> dict:
+    """One "messages" value, addressed to one of our numbers."""
+    fields = {"messaging_product": "whatsapp", "metadata": {"phone_number_id": number}}
+    fields.update(overrides)
+    return fields
+
+
+def _body(*changes, obj="whatsapp_business_account", waba=WABA) -> dict:
+    """Meta's envelope. Each change is (field, value)."""
+    return {
+        "object": obj,
+        "entry": [
+            {
+                "id": waba,
+                "time": int(TS),
+                "changes": [{"field": f, "value": v} for f, v in changes],
+            }
+        ],
+    }
+
+
+# --- their signature ----------------------------------------------------------
+
+
+def test_a_correct_signature_over_these_exact_bytes_passes(secrets) -> None:
+    """A correct signature over these exact bytes passes."""
+    raw = b'{"object": "whatsapp_business_account"}'
+    assert inbound.verify_signature(raw, {"X-Hub-Signature-256": _sig(raw)})
+
+
+def test_the_header_is_matched_whatever_its_casing(secrets) -> None:
+    """The header is matched whatever its casing."""
+    raw = b"{}"
+    assert inbound.verify_signature(raw, {"x-hub-signature-256": _sig(raw)})
+
+
+def test_a_signature_for_different_bytes_is_refused(secrets) -> None:
+    """A signature for different bytes is refused."""
+    assert not inbound.verify_signature(
+        b"tampered", {"X-Hub-Signature-256": _sig(b"real")}
+    )
+
+
+def test_a_signature_from_a_different_secret_is_refused(secrets) -> None:
+    """A signature from a different secret is refused."""
+    raw = b"{}"
+    header = {"X-Hub-Signature-256": _sig(raw, "not-the-secret")}
+    assert not inbound.verify_signature(raw, header)
+
+
+@pytest.mark.parametrize(
+    "header", [{}, {"X-Hub-Signature-256": ""}, {"X-Hub-Signature-256": "md5=abc"}]
+)
+def test_a_missing_or_misshapen_signature_is_refused(secrets, header) -> None:
+    """A missing or misshapen signature is refused."""
+    assert not inbound.verify_signature(b"{}", header)
+
+
+def test_without_a_configured_secret_everything_is_refused(monkeypatch) -> None:
+    """Without a configured secret everything is refused."""
+    monkeypatch.setattr(inbound, "META_APP_SECRET", "")
+    raw = b"{}"
+    assert not inbound.verify_signature(raw, {"X-Hub-Signature-256": _sig(raw)})
+
+
+# --- their handshake ----------------------------------------------------------
+
+
+def test_the_handshake_echoes_the_challenge_for_our_token(secrets) -> None:
+    """The handshake echoes the challenge for our token."""
+    params = {"hub.mode": "subscribe", "hub.verify_token": TOKEN, "hub.challenge": "9"}
+    assert inbound.handshake_challenge(params) == "9"
+
+
+@pytest.mark.parametrize(
+    "params",
+    [
+        {"hub.mode": "subscribe", "hub.verify_token": "guess", "hub.challenge": "9"},
+        {"hub.mode": "unsubscribe", "hub.verify_token": TOKEN, "hub.challenge": "9"},
+        {"hub.mode": "subscribe", "hub.challenge": "9"},
+        {},
+    ],
+)
+def test_the_handshake_refuses_anything_else(secrets, params) -> None:
+    """The handshake refuses anything else."""
+    assert inbound.handshake_challenge(params) is None
+
+
+def test_without_a_configured_token_no_handshake_succeeds(monkeypatch) -> None:
+    """Without a configured token no handshake succeeds."""
+    monkeypatch.setattr(inbound, "META_WEBHOOK_VERIFY_TOKEN", "")
+    params = {"hub.mode": "subscribe", "hub.verify_token": "", "hub.challenge": "9"}
+    assert inbound.handshake_challenge(params) is None
+
+
+# --- their envelope -> letters ------------------------------------------------
+
+
+def test_a_status_becomes_one_letter_per_transition() -> None:
+    """A status becomes one letter per transition."""
+    body = _body(
+        ("messages", _value(statuses=[_status(), _status(status="read")])),
+    )
+    out = inbound.letters(body)
+    assert [(l.topic, l.external_id) for l in out] == [
+        (TOPIC_STATUS, f"{OUT_WAMID}:delivered"),
+        (TOPIC_STATUS, f"{OUT_WAMID}:read"),
+    ]
+    assert all(
+        l.owner_kind == inbound.OWNER_PHONE_NUMBER and l.owner_id == NUMBER for l in out
+    )
+
+
+def test_an_inbound_message_is_keyed_by_its_own_id() -> None:
+    """An inbound message is keyed by its own id."""
+    out = inbound.letters(_body(("messages", _value(messages=[_message()]))))
+    assert [(l.topic, l.external_id) for l in out] == [(TOPIC_INBOUND, IN_WAMID)]
+
+
+def test_every_letter_carries_its_source_from_the_body_object() -> None:
+    """Every letter carries its source from the body's object."""
+    out = inbound.letters(_body(("messages", _value(statuses=[_status()]))))
+    assert out[0].source == "whatsapp"
+
+
+def test_an_object_we_do_not_serve_yields_nothing() -> None:
+    # A guessed source would file letters no consumer reads.
+    """An object we do not serve yields nothing."""
+    body = _body(("messages", _value(statuses=[_status()])), obj="page_mystery")
+    assert inbound.letters(body) == []
+
+
+def test_the_payload_is_metas_value_narrowed_to_one_item() -> None:
+    # Canon T13 col 7: the letter they sent, never our understanding of it —
+    # a recorded callback is a valid fixture unchanged.
+    """The payload is Meta's value narrowed to one item."""
+    contacts = [{"wa_id": "919876543210", "profile": {"name": "Priya"}}]
+    value = _value(messages=[_message()], contacts=contacts)
+    out = inbound.letters(_body(("messages", value)))
+    payload = out[0].payload
+    assert payload["messages"] == [_message()]
+    assert payload["contacts"] == contacts
+    assert payload["metadata"] == {"phone_number_id": NUMBER}
+    assert payload["messaging_product"] == "whatsapp"
+    assert "statuses" not in payload
+
+
+def test_a_value_with_no_receiving_number_yields_no_message_letters() -> None:
+    """A value with no receiving number yields no message letters."""
+    value = {"statuses": [_status()]}
+    assert inbound.letters(_body(("messages", value))) == []
+
+
+def test_a_template_status_update_is_owned_by_the_waba() -> None:
+    # Finding 2: these carry no phone_number_id — the WABA in entry.id is
+    # the owner, and the external_id is COMPOSED (Meta sends none).
+    """A template status update is owned by the WABA."""
+    value = {
+        "event": "APPROVED",
+        "message_template_id": "tmpl-9",
+        "message_template_name": "order_update",
+        "message_template_language": "en",
+    }
+    out = inbound.letters(_body(("message_template_status_update", value)))
+    assert len(out) == 1
+    letter = out[0]
+    assert letter.topic == TOPIC_TEMPLATE_STATUS
+    assert letter.owner_kind == inbound.OWNER_ACCOUNT and letter.owner_id == WABA
+    assert letter.external_id == f"{WABA}:tmpl-9:APPROVED:{TS}"
+    assert letter.payload == value
+
+
+def test_a_category_update_composes_its_own_event_word() -> None:
+    """A category update composes its own event word."""
+    value = {"message_template_id": "tmpl-9", "new_category": "MARKETING"}
+    out = inbound.letters(_body(("template_category_update", value)))
+    assert out[0].topic == TOPIC_TEMPLATE_CATEGORY
+    assert out[0].external_id == f"{WABA}:tmpl-9:category:{TS}"
+
+
+def test_a_quality_update_composes_its_own_event_word() -> None:
+    """A quality update composes its own event word."""
+    value = {"message_template_id": "tmpl-9", "new_quality_score": "GREEN"}
+    out = inbound.letters(_body(("message_template_quality_update", value)))
+    assert out[0].topic == TOPIC_TEMPLATE_QUALITY
+    assert out[0].external_id == f"{WABA}:tmpl-9:quality:{TS}"
+
+
+def test_an_account_update_is_a_letter_too() -> None:
+    """An account update is a letter too."""
+    value = {"event": "DISABLED_UPDATE"}
+    out = inbound.letters(_body(("account_update", value)))
+    assert out[0].topic == TOPIC_ACCOUNT
+    assert out[0].external_id == f"{WABA}:account:DISABLED_UPDATE:{TS}"
+
+
+def test_both_kinds_ride_one_callback() -> None:
+    """Both kinds ride one callback."""
+    out = inbound.letters(
+        _body(
+            ("messages", _value(statuses=[_status()])),
+            (
+                "message_template_status_update",
+                {"event": "REJECTED", "message_template_id": "t"},
+            ),
+        )
+    )
+    assert {l.owner_kind for l in out} == {
+        inbound.OWNER_PHONE_NUMBER,
+        inbound.OWNER_ACCOUNT,
+    }
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        {},
+        {"object": "whatsapp_business_account"},
+        {"object": "whatsapp_business_account", "entry": "nope"},
+        {"object": "whatsapp_business_account", "entry": [{"changes": [{"value": 3}]}]},
+    ],
+)
+def test_an_unreadable_envelope_yields_nothing_and_raises_nothing(body) -> None:
+    """An unreadable envelope yields nothing and raises nothing."""
+    assert inbound.letters(body) == []
+
+
+def test_a_malformed_entry_does_not_hide_a_good_one() -> None:
+    """A malformed entry does not hide a good one."""
+    body = _body(("messages", _value(statuses=[_status()])))
+    body["entry"].insert(0, "garbage")
+    assert len(inbound.letters(body)) == 1
+
+
+def test_letters_carry_the_providers_clock() -> None:
+    """Letters carry the provider's clock."""
+    out = inbound.letters(_body(("messages", _value(statuses=[_status()]))))
+    assert out[0].occurred_at is not None
+    assert int(out[0].occurred_at.timestamp()) == int(TS)
+
+
+def test_an_unusable_timestamp_never_raises() -> None:
+    """An unusable timestamp never raises."""
+    out = inbound.letters(
+        _body(("messages", _value(statuses=[_status(timestamp="soon")])))
+    )
+    assert out[0].occurred_at is None
+
+
+def test_a_button_tap_survives_the_narrowing_intact() -> None:
+    # The workflow's Yes/No branching (#1047's derived `reply` field) reads
+    # messages[0].button.payload and messages[0].context.id — pin that the
+    # narrowed letter still carries both exactly as Meta sent them.
+    """A button tap survives the narrowing intact."""
+    tap = _message(
+        type="button",
+        button={"payload": "YES", "text": "Yes"},
+        context={"id": "wamid.OUT1"},
+    )
+    out = inbound.letters(_body(("messages", _value(messages=[tap]))))
+    message = out[0].payload["messages"][0]
+    assert message["button"] == {"payload": "YES", "text": "Yes"}
+    assert message["context"]["id"] == "wamid.OUT1"


### PR DESCRIPTION
feat(crm): WhatsApp webhooks — verify, resolve the merchant, file to the spine
- The provider bays land where the corpus puts every ingest door — record:
  GET·POST /ingest/webhooks/{provider} on record/api.py's webhook_router,
  beside the s2s envelope door POST /ingest/events, dispatched through the
  INGRESS slot in record/ingress.py (IngressSpec: verify / envelope /
  challenge). Record knows no provider by name; rule 12 holds by INVERSION —
  connectivity builds META_INGRESS and app/crm/api.py registers it
  ("meta", one line, exactly as worker_main registers consumers). Unknown
  {provider} = 404 before a body byte is read.
- The bay key is the PROVIDER, meta: one Meta app serves WhatsApp,
  Instagram and Messenger through one callback and one signature scheme.
  The face is vendor-level — providers/meta/inbound.py (verify_signature,
  handshake_challenge, letters; the walk is private) — and its ONE rule-11
  composition root is connectivity/ingress.py. That root is fully GENERIC:
  every face yields one neutral shape (schemas.ProviderLetter — owner kind,
  source from the body's `object`, its own schema_version), and the root's
  owner->merchant resolution works for any provider unchanged. Meta is
  named there exactly once, in the META_INGRESS spec assembly — adding a
  provider is one face + one assembly + one registration line.
- The door FILES ONLY, and fails CLOSED like the envelope door: verify ->
  403; unparseable -> 400; ingest_event per letter with a STORE failure
  answered 503 (Meta retries, dedupe makes the retry safe) — a 200 on a
  dropped letter would lose it forever. A duplicate stays 200. No
  crm_message update, no customer resolution — consumers read the spine.
- Two owner kinds, so template and account letters are no longer dropped:
  a receiving phone_number_id resolves through inbound_binding_query (the
  one binding lookup with no merchant — the merchant is the ANSWER; WHERE
  matches 057's partial unique exactly), and a WABA resolves through the
  new installation_for_inbound_query (status <> 'revoked', same no-merchant
  discipline). message_template_status_update / template_category_update /
  message_template_quality_update / account_update file under topics.py's
  TOPIC_TEMPLATE_* / TOPIC_ACCOUNT with COMPOSED external_ids
  ({waba}:{template_id}:{event}:{ts} — Meta sends none; canon T13 col 6).
- Letters are record's EventIn — one shape for both doors ("one mailroom"
  made literal). Payloads are Meta's value NARROWED to the one item where
  they batch (canon T13 col 7: their letter, never our reading — a recorded
  callback is a valid fixture unchanged), and schema_version is stamped by
  the face from META_WHATSAPP_GRAPH_VERSION — the provider's own version,
  never an inferred "1" (canon T13 col 5).
- Message topics join topics.py (TOPIC_STATUS message.status, TOPIC_INBOUND
  message.inbound, one file one name); external_id is {wamid}:{status} /
  {wamid}, so Meta's retries dedupe in the spine and no consumer implements
  dedupe. One body cap: the bays stream against record's MAX_LETTER_BYTES
  (chunked bodies carry no Content-Length) -> 413.
- The recovery door dissolves into onboarding: ConnectorOnboarder gains
  resubscribe(bundle, external_account_id) beside revoke (the WhatsApp face
  implements it; GraphError never leaves the package), and
  onboarding.resubscribe(merchant_id, installation_id) mirrors disconnect —
  installation -> accounts.bundle_for -> the port -> an atom that RE-STAMPS
  health (status healthy, level subscribed, why null) through the new
  update_installation_health accessor the future probe reuses: a recovered
  door must not keep refusing sends. Route stays
  POST /connectors/installations/{id}/subscribe (RBAC + tenancy; 409 on a
  refusal in the provider's own words; errors are the OnboardingError
  family).
- Auth carve-out: the webhook_router carries NO Depends at all (a provider
  cannot hold a bearer token; the bay's signature is the auth) and every
  /connectors route carries the merchant-facing RBAC dependency — a test
  audits both directions. Fail closed: no app secret -> every callback
  refused; 403 carries no detail; a wrong handshake token gets 404, not 403.
- Boundary rule 11: the "ingress" root replaces the webhooks/subscribe
  roots; providers/<x>/inbound.py answers to it alone; onboard/templates
  return to connectors.py only, as https://github.com/juspay/clairvoyance/pull/1049 sealed. Red tests moved with it.
- Config: META_WEBHOOK_VERIFY_TOKEN beside META_APP_SECRET (one Meta app,
  one secret, both directions). CRM_WEBHOOK_TEST_DSN moved out of app
  config into tests/crm/conftest.py — a test dial is not the app's surface.
  .env.example names the real callback URL (/ingest/webhooks/meta), ALL
  the fields to subscribe (template updates included), and defines
  META_APP_SECRET exactly once.
- Tests split by module: test_meta_inbound.py (the face: signature,
  handshake, envelope walk, narrowing, composed ids),
  test_connectivity_ingress.py (owner resolution over fake accessors),
  test_ingress_door.py (record's door over a FAKE registered spec: 404 /
  403 / 400 / 503 / 200 / handshake / cap / the unauthenticated-routes
  walk), resubscribe cases beside disconnect's in
  test_connectors_onboarding.py (logic + the route: 409 refusal in the
  provider's words, 404 hidden, 403 foreign merchant, echo), and
  test_ingress_integration.py (DB-backed, seeds and purges its own rows)
  proving the URL Meta is actually given AND the WABA lookup + composed
  external_id against real SQL.

Recorded triggers, deliberately not in this PR:
- catalog entry + recorded-fixtures folder for message.status /
  message.inbound / the template topics — blocked on the CATALOG registry
  (https://github.com/juspay/clairvoyance/pull/1047, migration 062); the "no extractor without a catalog entry" pin
  test will force them when it lands.
- https://github.com/juspay/clairvoyance/pull/1052 (the whatsapp extractor) restacks onto this branch once merged and
  reads Meta's documented `value` shape (its contacts-copy workaround is
  superseded by the narrowed payloads here).
- lifecycle.py split (disconnect / resubscribe / refresh) when the
  token-refresh PR pushes onboarding.py past 500 lines.
  
  dev proof:
  
<img width="867" height="186" alt="Screenshot 2026-08-31 at 7 50 25 PM" src="https://github.com/user-attachments/assets/7f7e3c9a-8b2d-4866-91e8-aa57c356de35" />
<img width="1741" height="522" alt="Screenshot 2026-08-31 at 7 38 53 PM" src="https://github.com/user-attachments/assets/1cf99340-9b2f-4762-aaf5-fe1707dc0736" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added CRM connectivity for WhatsApp outbound messaging through Meta’s Graph API.
  - Added guarded message delivery with credential, route, installation, timeout, retry, and suppression checks.
  - Added WhatsApp webhook handshake and signed inbound event processing.
  - Added installation subscription support for connected accounts.
  - Added connector and channel-binding configuration.

- **Bug Fixes**
  - Credential deletion now reports conflicts when credentials remain in use.
  - Improved stale-send recovery and protection against late delivery results.
  - Added fail-closed handling for invalid or missing webhook credentials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->