### PR TITLE
feat(crm): repeat entries — on_repeat + debounce_minutes entry vocabulary

### DIFF
--- a/app/crm/outreach/db/accessor.py
+++ b/app/crm/outreach/db/accessor.py
@@ -31,6 +31,7 @@ from app.crm.outreach.db.queries import (
     live_workflows_query,
     occupied_nodes_query,
     park_run_query,
+    patch_open_run_query,
     publish_workflow_query,
     record_run_error_query,
     resume_run_on_event_query,
@@ -224,6 +225,36 @@ async def resume_run_on_event(
     )
     async with crm_connection() as conn:
         await conn.execute(query, *values)
+
+
+async def patch_open_run(
+    merchant_id: str,
+    workflow_id: str,
+    enrollment_key: str,
+    entry_node: str,
+    event_id: str,
+    patch: Dict[str, Any],
+    accumulate: bool,
+    max_field: Optional[str],
+    max_value: Optional[float],
+    debounce_minutes: float,
+) -> bool:
+    """True when an open run on the entry square took the repeat."""
+    query, values = patch_open_run_query(
+        merchant_id,
+        workflow_id,
+        enrollment_key,
+        entry_node,
+        event_id,
+        patch,
+        accumulate,
+        max_field,
+        max_value,
+        debounce_minutes,
+    )
+    async with crm_connection() as conn:
+        row = await conn.fetchrow(query, *values)
+    return row is not None
 
 
 async def cancel_open_runs(

--- a/app/crm/outreach/db/queries.py
+++ b/app/crm/outreach/db/queries.py
@@ -305,6 +305,78 @@ def resume_run_on_event_query(
     ]
 
 
+def patch_open_run_query(
+    merchant_id: str,
+    workflow_id: str,
+    enrollment_key: str,
+    entry_node: str,
+    event_id: str,
+    patch: Dict[str, Any],
+    accumulate: bool,
+    max_field: Optional[str],
+    max_value: Optional[float],
+    debounce_minutes: float,
+) -> Tuple[str, List[Any]]:
+    """Repeat entries (modules/05 §Repeat entries): ONE idempotent UPDATE
+    in the resume_run_on_event shape. Touches only a run still standing on
+    its first square (status waiting, current_node = the entry node) — a
+    run past it is never patched. Found by enrollment_key so a keyed plan's
+    order edit patches ITS order's run. The event marks itself used in
+    context.repeat_event_ids, so a redelivered repeat matches zero rows and
+    the alarm cannot slide twice for one letter.
+
+    The facts win unconditionally (refresh_latest), only when the new value
+    beats the stored one (refresh_max — compared here, in the statement, a
+    non-numeric stored value never blocks a numeric win), or are appended
+    under repeat_items (accumulate). debounce > 0 slides wake_at."""
+    query = f"""
+        UPDATE {ENROLLMENT_TABLE}
+        SET context = (
+                CASE
+                    WHEN $7::boolean THEN
+                        context || jsonb_build_object(
+                            'repeat_items',
+                            COALESCE(context->'repeat_items', '[]'::jsonb)
+                                || jsonb_build_array($6::jsonb),
+                            'repeat_count',
+                            COALESCE(jsonb_array_length(context->'repeat_items'), 0) + 2
+                        )
+                    WHEN $8::text IS NULL THEN context || $6::jsonb
+                    WHEN $9::float8 > COALESCE(
+                        CASE WHEN (context->>$8::text) ~ '^-?[0-9]+(\\.[0-9]+)?$'
+                             THEN (context->>$8::text)::float8 END,
+                        '-Infinity'::float8)
+                        THEN context || $6::jsonb
+                    ELSE context
+                END
+            ) || jsonb_build_object(
+                'repeat_event_ids',
+                COALESCE(context->'repeat_event_ids', '[]'::jsonb)
+                    || jsonb_build_array(to_jsonb($5::text))
+            ),
+            wake_at = CASE WHEN $10::float8 > 0
+                           THEN now() + make_interval(secs => $10::float8 * 60)
+                           ELSE wake_at END,
+            last_error = NULL
+        WHERE merchant_id = $1 AND workflow_id = $2::uuid AND enrollment_key = $3
+          AND status = 'waiting' AND current_node = $4
+          AND NOT (COALESCE(context->'repeat_event_ids', '[]'::jsonb) ? $5::text)
+        RETURNING id
+    """
+    return query, [
+        merchant_id,
+        workflow_id,
+        enrollment_key,
+        entry_node,
+        event_id,
+        json.dumps(patch),
+        accumulate,
+        max_field,
+        max_value,
+        debounce_minutes,
+    ]
+
+
 def cancel_open_runs_query(
     merchant_id: str,
     workflow_id: str,

--- a/app/crm/outreach/entry.py
+++ b/app/crm/outreach/entry.py
@@ -17,6 +17,7 @@ from typing import List, Optional, Tuple
 from app.core.logger import logger
 from app.crm.outreach.db import accessor
 from app.crm.outreach.enrol import enrol
+from app.crm.outreach.repeat import apply_repeat
 from app.crm.outreach.schemas import Workflow, WorkflowDefinition, WorkflowNode
 from app.crm.record.contracts import RawEvent
 
@@ -122,13 +123,26 @@ async def _try_enrol(
     phone = _phone_from_payload(event.payload)
     if phone:
         context["phone"] = phone
-    await enrol(
+    run = await enrol(
         merchant_id=event.merchant_id,
         workflow=flow,
         customer_id=customer_id,
         context=context,
         enrollment_key=enrollment_key,
     )
+    if run is None:
+        # Refused — most often because a run for this key is already open.
+        # The plan's repeat words decide what that open run does with the
+        # repeat (repeat.py); the UPDATE's WHERE makes every other refusal
+        # a no-op, so no second signal from enrol() is needed.
+        await apply_repeat(
+            event.merchant_id,
+            str(flow.id),
+            enrollment_key or customer_id,
+            definition,
+            str(event.id),
+            _context_from_payload(event.payload),
+        )
 
 
 def _enrollment_key(

--- a/app/crm/outreach/nodes.py
+++ b/app/crm/outreach/nodes.py
@@ -49,7 +49,13 @@ from app.schemas.breeze_buddy.core import ExecutionMode, LeadCallStatus
 # The walker's own bookkeeping in a run's context — never a template
 # variable, never a lead payload key: pointers, the phone (re-added under
 # its canonical key by the call node), per-node results and answers.
-_BOOKKEEPING_KEYS = ("source_event_id", "phone", "customer_mobile_number")
+_BOOKKEEPING_KEYS = (
+    "source_event_id",
+    "phone",
+    "customer_mobile_number",
+    "repeat_event_ids",  # repeat.py: which letters already patched this run
+    "repeat_items",  # repeat.py: accumulate's list — never a template variable
+)
 _BOOKKEEPING_PREFIXES = ("lead_", "message_", "reply_")
 
 # Facts the lead machine consumes itself, not the template: kept in the

--- a/app/crm/outreach/plans.py
+++ b/app/crm/outreach/plans.py
@@ -10,7 +10,8 @@ from typing import Any, Dict, List, Optional
 
 from app.core.logger import logger
 from app.crm.outreach.db import DbTxn, accessor, atomically
-from app.crm.outreach.nodes import NODE_TYPES
+from app.crm.outreach.nodes import NODE_TYPES, is_wait
+from app.crm.outreach.repeat import parse_repeat_policy
 from app.crm.outreach.schemas import Workflow, WorkflowDefinition, WorkflowSummary
 
 TIMEOUT = "timeout"
@@ -44,6 +45,20 @@ def validate_definition(
     # walker executes from, so validator and walker cannot disagree.
     for node in definition.nodes:
         problems.extend(NODE_TYPES[node.type].validate(node, definition))
+
+    # Repeat-entry words (repeat.py owns the vocabulary). debounce slides
+    # "the entry wait's alarm" — a plan whose first square is an action has
+    # no alarm to slide.
+    if parse_repeat_policy(definition.entry.on_repeat) is None:
+        problems.append(
+            f"entry.on_repeat {definition.entry.on_repeat!r} is not a policy "
+            "(ignore · refresh_latest · refresh_max(<field>) · accumulate)"
+        )
+    if definition.entry.debounce_minutes > 0 and not is_wait(definition.nodes[0]):
+        problems.append(
+            "entry.debounce_minutes needs a wait as the first node — there is "
+            "no entry alarm to slide otherwise"
+        )
 
     node_types = {node.id: node.type for node in definition.nodes}
     for src, dst in ((edge[0], edge[1]) for edge in definition.edges):

--- a/app/crm/outreach/repeat.py
+++ b/app/crm/outreach/repeat.py
@@ -1,0 +1,164 @@
+"""Repeat entries — debounce and refresh (modules/05-outreach §Repeat entries,
+sealed 31 Aug 2026). Humans act in sessions; event streams arrive in bursts.
+When a second entry event arrives for a run that is still standing on its
+first square, the open-run unique refuses a second run (dedupe, built) — and
+this file decides what the FIRST run does with the repeat, per the plan's
+own words:
+
+  on_repeat        ignore (default — today's behaviour) · refresh_latest ·
+                   refresh_max(<payload field>) · accumulate
+  debounce_minutes every matching repeat slides the entry wait's alarm
+
+Priya abandons six carts between 10:00 and 10:09; the plan says "message 10
+minutes after abandonment". Without this, the run born at 10:00 holds cart
+#1 (Rs 800) and fires at 10:10 while she is still shopping. With
+refresh_max(cart_value) + debounce_minutes 10, each repeat patches the
+unfired run — context keeps the Rs 4,500 cart, the alarm slides to now+10 —
+and at 10:19 she gets ONE message, about the biggest cart, after she has
+actually gone quiet.
+
+Mechanics: gather (the repeat's small facts) -> decide (PURE: what to write)
+-> apply (ONE idempotent UPDATE, the resume_run_on_event shape):
+`WHERE status='waiting' AND current_node = <entry node>` — a run past its
+first square is NEVER patched; what it already said was true when it said
+it. Each event marks itself used (context.repeat_event_ids), so the spine's
+at-least-once redelivery cannot slide the alarm twice for one event. The
+row is found by enrollment_key, not customer_id: with entry.key an order
+edit must patch ITS order's run, never a sibling's.
+
+Plan vocabulary, never walker behaviour: WISMO (keyed) and transactional
+flows leave on_repeat at ignore and debounce at 0.
+"""
+
+import re
+from dataclasses import dataclass
+from typing import Any, Dict, Optional, Tuple
+
+from app.core.logger import logger
+from app.crm.outreach.db import accessor
+from app.crm.outreach.schemas import WorkflowDefinition
+
+# The words, exactly as the corpus writes them. refresh_max carries its
+# field in parentheses: refresh_max(cart_value).
+POLICY_IGNORE = "ignore"
+POLICY_REFRESH_LATEST = "refresh_latest"
+POLICY_REFRESH_MAX = "refresh_max"
+POLICY_ACCUMULATE = "accumulate"
+REPEAT_POLICIES = (
+    POLICY_IGNORE,
+    POLICY_REFRESH_LATEST,
+    POLICY_REFRESH_MAX,
+    POLICY_ACCUMULATE,
+)
+_REFRESH_MAX = re.compile(r"^refresh_max\(\s*([A-Za-z_][A-Za-z0-9_]*)\s*\)$")
+
+# Where the repeats live in a run's context. repeat_event_ids and
+# repeat_items are walker bookkeeping (nodes.run_facts drops them — a list
+# can never be a template variable); repeat_count is a fact a template may
+# read ("{repeat_count} orders").
+REPEAT_EVENTS_KEY = "repeat_event_ids"
+REPEATS_KEY = "repeat_items"
+REPEAT_COUNT_KEY = "repeat_count"
+
+
+def parse_repeat_policy(word: str) -> Optional[Tuple[str, Optional[str]]]:
+    """PURE: the document's word -> (policy, field) or None when it is not
+    in the vocabulary. refresh_max needs its field; the others carry none."""
+    if word in (POLICY_IGNORE, POLICY_REFRESH_LATEST, POLICY_ACCUMULATE):
+        return word, None
+    match = _REFRESH_MAX.match(word or "")
+    if match:
+        return POLICY_REFRESH_MAX, match.group(1)
+    return None
+
+
+@dataclass(frozen=True)
+class RepeatPlan:
+    """What the one UPDATE will write. patch merges into context (or is
+    appended under repeat_items when accumulate); max_field/max_value make
+    the merge conditional on the new value winning; debounce_minutes > 0
+    slides the alarm."""
+
+    patch: Dict[str, Any]
+    accumulate: bool
+    max_field: Optional[str]
+    max_value: Optional[float]
+    debounce_minutes: float
+
+    @property
+    def is_noop(self) -> bool:
+        return not self.patch and not self.accumulate and self.debounce_minutes <= 0
+
+
+def _as_number(value: Any) -> Optional[float]:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        try:
+            return float(value)
+        except ValueError:
+            return None
+    return None
+
+
+def repeat_plan(definition: WorkflowDefinition, facts: Dict[str, Any]) -> RepeatPlan:
+    """PURE decide: given the plan's entry words and the repeat's small
+    facts, what does the open run get?
+
+      ignore          -> nothing in context (the alarm may still slide)
+      refresh_latest  -> the newest facts win, always
+      refresh_max(f)  -> the newest facts win only if facts[f] beats the
+                         run's f (compared in the statement; a non-numeric
+                         new value never wins)
+      accumulate      -> the facts are appended under repeat_items
+    """
+    parsed = parse_repeat_policy(definition.entry.on_repeat)
+    policy, field = parsed if parsed else (POLICY_IGNORE, None)
+    debounce = float(definition.entry.debounce_minutes or 0)
+    if policy == POLICY_REFRESH_LATEST:
+        return RepeatPlan(dict(facts), False, None, None, debounce)
+    if policy == POLICY_REFRESH_MAX:
+        value = _as_number(facts.get(field or ""))
+        if value is None:
+            return RepeatPlan({}, False, None, None, debounce)
+        return RepeatPlan(dict(facts), False, field, value, debounce)
+    if policy == POLICY_ACCUMULATE:
+        return RepeatPlan(dict(facts), True, None, None, debounce)
+    return RepeatPlan({}, False, None, None, debounce)
+
+
+async def apply_repeat(
+    merchant_id: str,
+    workflow_id: str,
+    enrollment_key: str,
+    definition: WorkflowDefinition,
+    event_id: str,
+    facts: Dict[str, Any],
+) -> bool:
+    """A refused enrol may be a repeat of an open run on the entry square.
+    Returns True when a run was patched. Zero rows is the normal answer
+    for "not a repeat" (nothing open, or the run already moved on) and
+    for a redelivered event (it marked itself used the first time)."""
+    plan = repeat_plan(definition, facts)
+    if plan.is_noop:
+        return False  # ignore + no debounce: exactly today's behaviour
+    patched = await accessor.patch_open_run(
+        merchant_id,
+        workflow_id,
+        enrollment_key,
+        definition.nodes[0].id,
+        event_id,
+        plan.patch,
+        plan.accumulate,
+        plan.max_field,
+        plan.max_value,
+        plan.debounce_minutes,
+    )
+    if patched:
+        logger.info(
+            f"repeat entry applied: workflow {workflow_id} key {enrollment_key} "
+            f"policy {definition.entry.on_repeat} debounce {plan.debounce_minutes}m"
+        )
+    return patched

--- a/app/crm/outreach/schemas.py
+++ b/app/crm/outreach/schemas.py
@@ -30,6 +30,15 @@ class WorkflowEntry(BaseModel):
     # (bursts coalesce: one abandonment conversation); "order_id" = one run
     # per order (WISMO: two parcels, two parallel threads).
     key: Optional[str] = Field(None, min_length=1)
+    # Repeat entries (modules/05-outreach §Repeat entries, sealed 31 Aug
+    # 2026): what an OPEN run still on its first square does when another
+    # entry event for the same key arrives. Words: ignore (default — the
+    # unique absorbs it, today's behaviour) · refresh_latest ·
+    # refresh_max(<payload field>) · accumulate. Vocabulary in code
+    # (repeat.py), validated at publish.
+    on_repeat: str = "ignore"
+    # Every matching repeat slides the entry wait's alarm to now + this.
+    debounce_minutes: float = Field(0, ge=0)
 
 
 class WorkflowGoal(BaseModel):

--- a/tests/crm/test_workflow_repeat.py
+++ b/tests/crm/test_workflow_repeat.py
@@ -1,0 +1,214 @@
+"""Repeat entries — debounce + refresh (modules/05-outreach §Repeat entries,
+sealed 31 Aug 2026): the vocabulary, the pure decide, the one UPDATE's
+laws, and the validator's two entry rules."""
+
+import asyncio
+import json
+from typing import Any, Dict, List
+
+import pytest
+
+import app.crm.outreach.entry as entry
+from app.crm.outreach import repeat
+from app.crm.outreach.db.queries import patch_open_run_query
+from app.crm.outreach.plans import validate_definition
+from app.crm.outreach.repeat import parse_repeat_policy, repeat_plan
+from app.crm.outreach.schemas import WorkflowDefinition
+
+
+def _definition(**entry_words: Any) -> WorkflowDefinition:
+    return WorkflowDefinition.model_validate(
+        {
+            "entry": {"topic": "checkouts/create", "reenter": True, **entry_words},
+            "nodes": [
+                {"id": "wait_10m", "type": "wait", "minutes": 10},
+                {"id": "call", "type": "call", "template_id": "tpl-1"},
+            ],
+            "edges": [["wait_10m", "call"]],
+            "goal": {"topics": ["orders/create"]},
+        }
+    )
+
+
+# --- the words ---
+
+
+def test_vocabulary_is_the_corpus_four() -> None:
+    assert parse_repeat_policy("ignore") == ("ignore", None)
+    assert parse_repeat_policy("refresh_latest") == ("refresh_latest", None)
+    assert parse_repeat_policy("accumulate") == ("accumulate", None)
+    assert parse_repeat_policy("refresh_max(cart_value)") == (
+        "refresh_max",
+        "cart_value",
+    )
+    assert parse_repeat_policy("refresh_max( total )") == ("refresh_max", "total")
+    for bad in ("refresh_max", "refresh_max()", "latest", "", "refresh_max(a b)"):
+        assert parse_repeat_policy(bad) is None, bad
+
+
+def test_defaults_are_todays_behaviour() -> None:
+    plan = repeat_plan(_definition(), {"cart_value": 800})
+    assert plan.is_noop  # ignore + debounce 0 -> no statement at all
+
+
+# --- the pure decide ---
+
+
+def test_refresh_latest_always_takes_the_new_facts() -> None:
+    plan = repeat_plan(_definition(on_repeat="refresh_latest"), {"cart_value": 300})
+    assert plan.patch == {"cart_value": 300} and plan.max_field is None
+    assert not plan.accumulate and not plan.is_noop
+
+
+def test_refresh_max_names_the_field_and_the_number() -> None:
+    plan = repeat_plan(
+        _definition(on_repeat="refresh_max(cart_value)"), {"cart_value": "4500"}
+    )
+    assert plan.max_field == "cart_value" and plan.max_value == 4500.0
+    assert plan.patch == {"cart_value": "4500"}
+
+
+def test_refresh_max_with_a_non_numeric_value_never_wins() -> None:
+    plan = repeat_plan(
+        _definition(on_repeat="refresh_max(cart_value)", debounce_minutes=10),
+        {"cart_value": "n/a"},
+    )
+    assert plan.patch == {} and plan.max_field is None
+    assert plan.debounce_minutes == 10 and not plan.is_noop  # alarm still slides
+
+
+def test_accumulate_appends() -> None:
+    plan = repeat_plan(_definition(on_repeat="accumulate"), {"order_id": "B"})
+    assert plan.accumulate and plan.patch == {"order_id": "B"}
+
+
+def test_ignore_with_debounce_slides_without_touching_facts() -> None:
+    plan = repeat_plan(_definition(debounce_minutes=5), {"cart_value": 1})
+    assert plan.patch == {} and plan.debounce_minutes == 5 and not plan.is_noop
+
+
+# --- the one UPDATE ---
+
+
+def test_patch_touches_only_an_open_run_on_the_entry_square_by_key() -> None:
+    sql, params = patch_open_run_query(
+        "m1",
+        "wf-1",
+        "ORD-1",
+        "wait_10m",
+        "ev-1",
+        {"cart_value": 4500},
+        False,
+        "cart_value",
+        4500.0,
+        10.0,
+    )
+    assert "status = 'waiting' AND current_node = $4" in sql
+    assert "enrollment_key = $3" in sql and "customer_id" not in sql
+    assert "NOT (COALESCE(context->'repeat_event_ids', '[]'::jsonb) ? $5::text)" in sql
+    assert "make_interval(secs => $10::float8 * 60)" in sql
+    assert params[0] == "m1" and json.loads(params[5]) == {"cart_value": 4500}
+    assert params[4] == "ev-1" and params[7] == "cart_value" and params[9] == 10.0
+
+
+def test_patch_marks_the_event_used_and_compares_in_the_statement() -> None:
+    sql, _ = patch_open_run_query(
+        "m1", "wf-1", "c-1", "w", "ev-1", {}, False, "cart_value", 1.0, 0.0
+    )
+    assert (
+        "'repeat_event_ids'" in sql and "jsonb_build_array(to_jsonb($5::text))" in sql
+    )
+    assert "$9::float8 > COALESCE(" in sql and "'-Infinity'::float8" in sql
+    assert "WHEN $7::boolean THEN" in sql and "'repeat_items'" in sql
+
+
+# --- the validator ---
+
+
+def _raw(**entry_words: Any) -> Dict[str, Any]:
+    return _definition(**entry_words).model_dump()
+
+
+def test_validator_refuses_a_word_outside_the_vocabulary() -> None:
+    problems = validate_definition(_raw(on_repeat="latest"))
+    assert problems and "not a policy" in problems[0]
+
+
+def test_validator_accepts_every_corpus_word() -> None:
+    for word in ("ignore", "refresh_latest", "refresh_max(cart_value)", "accumulate"):
+        assert validate_definition(_raw(on_repeat=word)) == [], word
+
+
+def test_debounce_needs_a_wait_as_the_first_node() -> None:
+    raw = _raw(debounce_minutes=10)
+    raw["nodes"] = [raw["nodes"][1], raw["nodes"][0]]
+    raw["edges"] = [["call", "wait_10m"]]
+    problems = validate_definition(raw)
+    assert any("entry alarm to slide" in p for p in problems)
+    assert validate_definition(_raw(debounce_minutes=10)) == []
+
+
+def test_changing_repeat_words_mid_flight_is_blocked_by_the_entry_guard() -> None:
+    live = _raw()["entry"]
+    problems = validate_definition(
+        _raw(on_repeat="refresh_latest"), occupied_nodes=["wait_10m"], live_entry=live
+    )
+    assert any("entry rule changed" in p for p in problems)
+
+
+# --- the processor hook ---
+
+
+def test_a_refused_enrol_hands_the_repeat_to_apply_repeat(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: List[Any] = []
+
+    async def refused_enrol(**kwargs: Any) -> None:
+        return None
+
+    async def fake_apply(*args: Any) -> bool:
+        calls.append(args)
+        return True
+
+    monkeypatch.setattr(entry, "enrol", refused_enrol)
+    monkeypatch.setattr(entry, "apply_repeat", fake_apply)
+    flow = type("F", (), {"id": "wf-1"})()
+    definition = _definition(on_repeat="refresh_latest", key="order_id")
+    event = type(
+        "E",
+        (),
+        {
+            "id": "ev-9",
+            "merchant_id": "m1",
+            "payload": {
+                "order_id": "ORD-1",
+                "cart_value": 900,
+                "customer_mobile_number": "+91",
+            },
+        },
+    )()
+    asyncio.run(entry._try_enrol(flow, definition, event, "cust-1"))
+    ((merchant, wf, key, defn, event_id, facts),) = calls
+    assert (merchant, wf, key, event_id) == ("m1", "wf-1", "ORD-1", "ev-9")
+    assert facts["cart_value"] == 900 and defn is definition
+
+
+def test_a_successful_enrol_never_calls_apply_repeat(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: List[Any] = []
+
+    async def new_run(**kwargs: Any) -> object:
+        return object()
+
+    async def fake_apply(*args: Any) -> bool:
+        calls.append(args)
+        return True
+
+    monkeypatch.setattr(entry, "enrol", new_run)
+    monkeypatch.setattr(entry, "apply_repeat", fake_apply)
+    flow = type("F", (), {"id": "wf-1"})()
+    event = type("E", (), {"id": "ev-1", "merchant_id": "m1", "payload": {}})()
+    asyncio.run(entry._try_enrol(flow, _definition(on_repeat="accumulate"), event, "c"))
+    assert calls == []

--- a/tests/crm/test_workflow_runs.py
+++ b/tests/crm/test_workflow_runs.py
@@ -65,13 +65,17 @@ def test_call_payload_and_send_variables_share_one_bookkeeping_filter() -> None:
         "reply_ask": "YES",
         "reporting_webhook_url": "https://merchant/report",
         "cart_value": 1999,
+        "repeat_event_ids": ["e-2", "e-3"],
+        "repeat_items": [{"order_id": "B"}],
+        "repeat_count": 3,
     }
     facts = run_facts(context)
     assert facts == {
         "reporting_webhook_url": "https://merchant/report",
         "cart_value": 1999,
+        "repeat_count": 3,
     }
-    assert send_variables(context) == {"cart_value": 1999}
+    assert send_variables(context) == {"cart_value": 1999, "repeat_count": 3}
 
 
 def test_lead_request_id_is_the_merchants_order_id_else_the_run() -> None:


### PR DESCRIPTION
The sealed follow-up to #1029 (modules/05-outreach §Repeat entries, 31 Aug 2026): humans act in sessions, event streams arrive in bursts. Today a repeat entry event for an open run is silently absorbed by the open-run unique — right for "one message per burst", wrong for WHICH message and WHEN. Priya abandons six carts between 10:00 and 10:09 on a "message 10 minutes after abandonment" plan: as built she gets the Rs 800 cart at 10:10, mid-shopping. With refresh_max(cart_value) + debounce_minutes 10 she gets ONE message at 10:19, about the Rs 4,500 cart, after going quiet.

Two new words on entry, beside reenter/cooldown/key (plan vocabulary, never walker behaviour — WISMO and transactional flows keep the defaults):

- on_repeat: ignore (default, today's behaviour) · refresh_latest · refresh_max(<payload field>) · accumulate
- debounce_minutes: every matching repeat slides the alarm to now + N. Independent of the entry wait's minutes: the wait sets the FIRST alarm once at enrol; only debounce moves it afterwards.

Mechanics, per the sealed position:

- repeat.py (new concern file): the vocabulary in code, the PURE decide (repeat_plan), the apply. A refused enrol() hands the event here.
- ONE idempotent UPDATE (patch_open_run_query), the resume_run_on_event shape: WHERE status='waiting' AND current_node = <entry node> — a run past its first square is NEVER patched; found by enrollment_key so a keyed plan's order edit patches ITS order's run, never a sibling's; refresh_max compared in the statement (a non-numeric stored value never blocks a numeric win); accumulate appends under context.repeat_items with repeat_count. Each event marks itself used (repeat_event_ids), so the spine's at-least-once redelivery cannot slide the alarm twice for one letter. Source-event idempotency unchanged.
- Publish validator: on_repeat must be in the vocabulary; debounce > 0 requires a wait (is_wait — wait_event included) as the first node. Changing either word mid-flight is blocked by the existing entry guard.
- nodes.run_facts: repeat_event_ids/repeat_items are walker bookkeeping (a list can never be a template variable); repeat_count stays a fact.

No migration, no API change; both words ride the definition jsonb.

16 new tests (vocabulary, decide per policy, the UPDATE's laws, validator, processor hook); 249 tests/crm green, pyrefly 0, boundary checker clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable repeat-event handling for outreach workflow entries.
  * Supports ignoring repeats, refreshing values, keeping maximum values, or accumulating repeated items.
  * Added optional debounce timing to delay entry processing after repeated events.
  * Prevented duplicate repeat events from being applied.

* **Bug Fixes**
  * Repeat events are now applied when enrollment is declined but an open run remains available.

* **Validation**
  * Added checks for valid repeat policies and compatible debounce settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->