### PR TITLE
feat(crm): shopify extractor + normalize the phone the sends actually dial

### DIFF
--- a/app/crm/outreach/entry.py
+++ b/app/crm/outreach/entry.py
@@ -19,6 +19,7 @@ from app.crm.outreach.db import accessor
 from app.crm.outreach.enrol import enrol
 from app.crm.outreach.schemas import Workflow, WorkflowDefinition, WorkflowNode
 from app.crm.record.contracts import RawEvent
+from app.crm.shared.normalize import normalize_phone
 
 # Where a phone hides in an event payload, tried in order — the voice
 # mirrors use customer_mobile_number; external doors normalize to
@@ -32,13 +33,23 @@ _CONTEXT_VALUE_MAX_CHARS = 256
 
 
 def _phone_from_payload(payload: dict) -> str | None:
+    """The number the sends will actually dial or message — normalized to
+    E.164 here, because resolve() normalizes only what it probes on and
+    context is a separate copy. Unnormalized, a bare "9876543210" would
+    resolve to +919876543210 for identity while the call node dialled the
+    bare form, and a suppression stored in E.164 would not match it."""
+    raw: str | None = None
     for key in _PHONE_PATHS:
         if payload.get(key):
-            return str(payload[key])
-    customer = payload.get("customer")
-    if isinstance(customer, dict) and customer.get("phone"):
-        return str(customer["phone"])
-    return None
+            raw = str(payload[key])
+            break
+    if raw is None:
+        customer = payload.get("customer")
+        if isinstance(customer, dict) and customer.get("phone"):
+            raw = str(customer["phone"])
+    if raw is None:
+        return None
+    return normalize_phone(raw) or raw
 
 
 async def consume_attributed_event(event: RawEvent, customer_id: str) -> None:

--- a/app/crm/record/workers.py
+++ b/app/crm/record/workers.py
@@ -10,6 +10,7 @@ from app.crm.identity.contracts import assert_facts, resolve as crm_resolve
 from app.crm.outreach.contracts import consume_attributed_event
 from app.crm.record.db import DbTxn, accessor, atomically, savepoint
 from app.crm.record.schemas import Extracted, RawEvent
+from app.crm.shared.normalize import normalize_email, normalize_phone
 
 # Producer's payload key -> canon attribute name (T05). A producer with a
 # different shape brings its own map.
@@ -35,12 +36,50 @@ def _extract_flat(payload: Dict[str, Any]) -> Extracted:
     )
 
 
+def _extract_shopify(payload: Dict[str, Any]) -> Extracted:
+    """Shopify's own order/checkout body, as the relay forwards it.
+
+    The relay is a pipe: it carries Shopify's words unopened, so the
+    nesting arrives intact and this is where it gets read. Shopify puts a
+    phone in up to three places and the top-level one is usually null; a
+    guest checkout carries no customer object at all, which is why the
+    shipping address is the fallback for both handle and name.
+
+    The name is never defaulted. A placeholder like "Customer" would
+    reach assert_facts as a genuine name claim and overwrite what we
+    actually know about this person — absent is absent.
+    """
+    customer = payload.get("customer") or {}
+    address = payload.get("shipping_address") or payload.get("billing_address") or {}
+
+    # Most specific first: the customer record beats the shipping contact.
+    raw_phone = customer.get("phone") or payload.get("phone") or address.get("phone")
+    raw_email = customer.get("email") or payload.get("email")
+
+    handles: Dict[str, str] = {}
+    if raw_phone:
+        phone = normalize_phone(str(raw_phone))
+        if phone:
+            handles["phone"] = phone
+    if raw_email:
+        email = normalize_email(str(raw_email))
+        if email:
+            handles["email"] = email
+
+    first = customer.get("first_name") or address.get("first_name") or ""
+    last = customer.get("last_name") or address.get("last_name") or ""
+    name = " ".join(part for part in (str(first), str(last)) if part).strip()
+
+    return Extracted(handles=handles, facts={"name": name} if name else {})
+
+
 # source -> extractor. A new channel is one registration here; an
 # unregistered source falls back to the flat shape.
 Extractor = Callable[[Dict[str, Any]], Extracted]
 EXTRACTORS: Dict[str, Extractor] = {
     "lead-api": _extract_flat,
     "telephony": _extract_flat,
+    "shopify": _extract_shopify,
 }
 DEFAULT_EXTRACTOR: Extractor = _extract_flat
 

--- a/tests/crm/test_entry_rules.py
+++ b/tests/crm/test_entry_rules.py
@@ -1,0 +1,18 @@
+def test_context_phone_is_normalized_for_the_send_path() -> None:
+    # resolve() normalizes what it PROBES on; context is a separate copy,
+    # and it is what the call and send nodes actually dial. Unnormalized,
+    # identity would resolve to +919876543210 while the node dialled the
+    # bare form — and a suppression stored in E.164 would not match it.
+    from app.crm.outreach.entry import _phone_from_payload
+
+    assert (
+        _phone_from_payload({"customer_mobile_number": "9876543210"}) == "+919876543210"
+    )
+    assert _phone_from_payload({"phone": "+91 98765 43210"}) == "+919876543210"
+    assert (
+        _phone_from_payload({"customer": {"phone": "09876543210"}}) == "+919876543210"
+    )
+    # Unparseable is handed through rather than dropped: a node that cannot
+    # use it parks with a clear reason, which beats losing the number here.
+    assert _phone_from_payload({"phone": "n/a"}) == "n/a"
+    assert _phone_from_payload({}) is None

--- a/tests/crm/test_event_worker.py
+++ b/tests/crm/test_event_worker.py
@@ -812,3 +812,67 @@ def test_heartbeat_counts_rows_since_the_last_beat(
     assert counted, "expected at least one heartbeat"
     # first beat precedes any work; a later one reports the batch just done
     assert any(n == 3 for _, n in counted)
+
+
+# --- the Shopify extractor: a pipe's letter, read at the belt ---
+
+
+def test_shopify_extractor_reads_the_nested_customer_phone() -> None:
+    # The relay forwards Shopify's body unopened, so the phone arrives
+    # nested and the top-level one is usually null.
+    extracted = workers._extract_shopify(
+        {
+            "phone": None,
+            "customer": {
+                "first_name": "Priya",
+                "last_name": "Sharma",
+                "phone": "+91 98765 43210",
+            },
+            "shipping_address": {"phone": "9999999999"},
+        }
+    )
+    assert extracted.handles["phone"] == "+919876543210"  # normalized
+    assert extracted.facts == {"name": "Priya Sharma"}
+
+
+def test_shopify_extractor_falls_back_to_the_shipping_contact() -> None:
+    # A guest checkout carries no customer object at all.
+    extracted = workers._extract_shopify(
+        {
+            "shipping_address": {
+                "first_name": "Rohan",
+                "last_name": "Mehta",
+                "phone": "9876543210",
+            }
+        }
+    )
+    assert extracted.handles["phone"] == "+919876543210"
+    assert extracted.facts == {"name": "Rohan Mehta"}
+
+
+def test_shopify_extractor_never_invents_a_name() -> None:
+    # A placeholder would reach assert_facts as a real name claim and
+    # overwrite what we actually know. Absent is absent.
+    extracted = workers._extract_shopify({"customer": {"phone": "9876543210"}})
+    assert extracted.facts == {}
+
+
+def test_shopify_extractor_skips_an_unusable_phone() -> None:
+    # normalize_phone returns None rather than writing a bad handle; with
+    # nothing usable the row quarantines no_handle and stays replayable.
+    extracted = workers._extract_shopify({"customer": {"phone": "n/a"}})
+    assert "phone" not in extracted.handles
+
+
+def test_shopify_extractor_takes_the_email_too() -> None:
+    extracted = workers._extract_shopify(
+        {"customer": {"email": "  Priya@Example.COM  ", "phone": "9876543210"}}
+    )
+    assert extracted.handles["email"] == "priya@example.com"
+
+
+def test_shopify_source_is_registered() -> None:
+    # Without the registration a raw Shopify body falls to _extract_flat,
+    # which looks for a top-level customer_mobile_number that is not
+    # there — every order would quarantine no_handle.
+    assert workers.EXTRACTORS["shopify"] is workers._extract_shopify


### PR DESCRIPTION
Closes the two gaps between a relayed Shopify letter and a customer it can be attributed to. Raised on the X1 thread: *"there is no shopify extractor which maps the raw payload of shopify to our clairvoyance norms — without that no consumers will work (resolve and entry rule)."* Correct, and this is the Phase B item Swaroop's bridge plan lists as *"Shopify extractor registered in A10."*

## 1 · No extractor for `source=shopify`

The relay is a pipe — it carries Shopify's body unopened — so the phone arrives **nested**:

```
Shopify webhook → nautilus relays raw body (source=shopify) → /ingest/events → crm_event_raw  ✓
  → event worker → EXTRACTORS.get("shopify") → not registered → _extract_flat
  → payload has no top-level "customer_mobile_number"  (it is at customer.phone)
  → handles = {} → quarantine "no_handle"
  → resolve ✗   entry rule ✗   journey ✗
```

`_extract_shopify` reads what Shopify actually sends:

| | where it looks, in order |
|---|---|
| phone | `customer.phone` → `phone` → `shipping_address.phone` |
| email | `customer.email` → `email` |
| name | `customer.first/last_name` → `shipping_address.first/last_name` |

Three details that matter:

- **The top-level `phone` is usually `null`** on a real order, and a **guest checkout has no `customer` object at all** — hence the shipping-address fallback for both handle and name.
- **The name is never defaulted.** A placeholder like `"Customer"` would reach `assert_facts` as a genuine name claim and overwrite what we actually know about the person. Absent is absent.
- **An unusable number is skipped, not written.** `normalize_phone` returns `None` on garbage, so the row quarantines and stays replayable rather than resolving onto a malformed handle.

**Nothing already stored is stranded.** `payload` is verbatim and `replay()` re-runs the *current* extractor, so events that quarantined under the flat fallback attribute correctly once this lands. That is why Phase A's exit criterion is *"lands on the spine; quarantined rows replayable"* rather than *"attributed"*.

## 2 · The number the sends dial was never normalized

Found while tracing the above:

```
entry.py   phone = _phone_from_payload(event.payload)   ← raw
entry.py   context["phone"] = phone
nodes.py   phone = run.context.get("phone")             ← the call node dials this
nodes.py   address=str(phone)                           ← the send node messages this
```

`resolve()` normalizes what it **probes on** (`_normalize(handles)`), but run context is a separate copy taken straight from the payload. So a producer sending `"9876543210"`:

- identity resolves to `+919876543210` ✅
- the call node dials `9876543210` ❌
- the WhatsApp send addresses `9876543210` ❌

A suppression stored in E.164 would not match that — the exact failure the *normalize at every writer* law exists to prevent (*"a format mismatch on a suppressed value CONTACTS someone who said stop"*).

`_phone_from_payload` now normalizes. An unparseable value is handed through unchanged so the node parks with a clear reason, rather than the number being lost here.

## Unchanged

The **default extractor is untouched**. Any producer that sends a top-level `customer_mobile_number` still needs no registration — that stays the zero-code path for new partners, and it is what `lead-api` and `telephony` use.

## Tests

7 new: nested phone with normalization · guest-checkout fallback · name never invented · unusable phone skipped · email lowercased · registry wired · context phone normalized across all three payload shapes.

**1590 pass** · pyrefly 0 errors · black/isort/autoflake · boundary + migration checks clean.

## Scope

Deliberately **not** folded into #1025 — that PR is approved and mergeable, and this touches `record/workers.py` (A10), not the door (A9). The two are independent and can merge in either order.

⚠️ `entry.py` is also touched by #1041 (repeat entries). Different function, but worth merging in a considered order.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Shopify event support for extracting customer contact details, including names, email addresses, and phone numbers.
  * Added improved phone number normalization to a consistent international format.
  * Preserved unrecognized phone values when they cannot be normalized.

* **Bug Fixes**
  * Improved contact extraction from nested customer, shipping, billing, and address data.
  * Omitted unusable phone numbers and unavailable names instead of using placeholders.

* **Tests**
  * Added coverage for phone normalization and Shopify contact extraction scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->