### PR TITLE
fix(voice): Daily initial greeting — wrong pipeline entry point and timing

### DIFF
--- a/app/ai/voice/agents/breeze_buddy/agent/__init__.py
+++ b/app/ai/voice/agents/breeze_buddy/agent/__init__.py
@@ -50,8 +50,8 @@ from app.ai.voice.agents.breeze_buddy.agent.transport import (
 )
 from app.ai.voice.agents.breeze_buddy.agent.utils import (
     end_call_with_errors,
+    prepare_initial_greeting_daily,
     send_initial_greeting,
-    send_initial_greeting_daily,
 )
 from app.ai.voice.agents.breeze_buddy.chat.voice_bridge import WidgetVoiceBridge
 from app.ai.voice.agents.breeze_buddy.handlers.internal.end_conversation import (
@@ -1100,15 +1100,19 @@ class Agent:
         # respond_immediately=False — same downstream behavior as telephony.
         # (Stream mode returned above — its greeting is spoken by the voice
         # bridge, not injected into an LLM context.)
-        if self.is_daily_mode and not self.is_stream_mode and self.task:
-            greeting_result = await send_initial_greeting_daily(
-                task=self.task,
+        # The audio itself is only queued after flow init below
+        daily_greeting_audio = None
+        daily_greeting_commit = None
+        if self.is_daily_mode and not self.is_stream_mode and self.transport:
+            greeting_result = await prepare_initial_greeting_daily(
                 lead=self.lead,
                 template=self.template,
                 errors=self.errors,
             )
             self.greeting_source = greeting_result.source
             self.greeting_text = greeting_result.text
+            daily_greeting_audio = greeting_result.audio
+            daily_greeting_commit = greeting_result.commit
 
             # Gemini Live + played greeting (Daily variant): the service was
             # built before the client connected, so apply the no-initial-
@@ -1188,6 +1192,18 @@ class Agent:
 
         await self.flow_manager.initialize(initial_node_config)
         logger.info(f"FlowManager initialized at node: {initial_node_name}")
+
+        # Daily greeting playback, strictly after flow init: initialize() only
+        # returns once the initial node's "function" pre-actions (mute_stt) have
+        # reached the end of the pipeline, so the mute window now starts when the
+        # greeting starts — as it does on telephony — instead of when it ends.
+        if daily_greeting_audio is not None and self.transport:
+            await self.transport.output().queue_frame(daily_greeting_audio)
+            logger.info(
+                f"Queued Daily initial greeting (source={self.greeting_source})"
+            )
+            if daily_greeting_commit is not None:
+                await daily_greeting_commit()
 
     # ══════════════════════════════════════════════════════════════════════
     # Run loop & pipeline generation

--- a/app/ai/voice/agents/breeze_buddy/agent/utils.py
+++ b/app/ai/voice/agents/breeze_buddy/agent/utils.py
@@ -5,11 +5,10 @@ import base64
 import json
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from typing import Any, Callable, Dict, List, Optional
+from typing import Any, Awaitable, Callable, Dict, List, Optional
 
 from fastapi import WebSocket
 from pipecat.frames.frames import OutputAudioRawFrame
-from pipecat.pipeline.task import PipelineTask
 
 from app.ai.voice.agents.breeze_buddy.template.types import TemplateModel
 from app.ai.voice.agents.breeze_buddy.utils.common import (
@@ -34,6 +33,9 @@ class GreetingResult:
 
     source: Optional[str]  # "template_static", "lead_dynamic", or None
     text: Optional[str]  # The resolved greeting text for LLM context
+    # Daily only: greeting audio, queued by the caller AFTER flow init.
+    audio: Optional[OutputAudioRawFrame] = None
+    commit: Optional[Callable[[], Awaitable[None]]] = None
 
 
 async def send_initial_greeting(
@@ -141,17 +143,17 @@ def _transcode_mulaw_to_daily_pcm(mulaw_bytes: bytes) -> bytes:
     return pcm_daily
 
 
-async def send_initial_greeting_daily(
-    task: PipelineTask,
+async def prepare_initial_greeting_daily(
     lead: LeadCallTracker,
     template: TemplateModel,
     errors: Optional[List[Dict[str, Any]]] = None,
 ) -> GreetingResult:
-    """Send initial greeting audio for Daily-mode calls.
+    """Prepare initial greeting audio for Daily-mode calls.
 
     Reuses the telephony Redis greeting cache (mulaw 8 kHz), transcodes to PCM
-    24 kHz to match the Daily transport's output sample rate, and queues an
-    ``OutputAudioRawFrame`` through the pipeline for playback.
+    24 kHz to match the Daily transport's output sample rate. The frame is
+    returned, not queued: the caller must play it on ``transport.output()``
+    (past STT) and only after ``flow_manager.initialize()``.
 
     The cache keys are identical to telephony, so the dispatch worker's
     pre-synthesis (which runs for outbound) populates the cache for both
@@ -160,14 +162,14 @@ async def send_initial_greeting_daily(
     in the agent setup, same pattern as inbound telephony.
 
     Args:
-        task: Pipeline task to queue the audio frame on
         lead: Lead data
         template: Template model
         errors: Optional errors list to track failures
 
     Returns:
-        GreetingResult with source and resolved greeting text. ``source`` is
-        ``None`` when no cached audio is available (falls through to LLM-speaks-first).
+        GreetingResult with source, resolved greeting text and the audio frame
+        to play. ``source`` is ``None`` when no cached audio is available
+        (falls through to LLM-speaks-first).
     """
     try:
         redis = await get_redis_service()
@@ -187,7 +189,8 @@ async def send_initial_greeting_daily(
             if template.configurations and template.configurations.initial_greeting:
                 greeting_text = template.configurations.initial_greeting
 
-        # 2. Dynamic greeting (per-lead cache, deleted after retrieval)
+        # 2. Dynamic greeting (per-lead cache, deleted once played).
+        commit: Optional[Callable[[], Awaitable[None]]] = None
         if not mulaw_data:
             lead_greeting_key = f"greeting:{lead.id}"
             lead_greeting_data = await redis.get(lead_greeting_key)
@@ -200,8 +203,14 @@ async def send_initial_greeting_daily(
                 except (json.JSONDecodeError, KeyError):
                     # Legacy format: raw base64 mulaw, no JSON wrapper
                     mulaw_data = base64.b64decode(lead_greeting_data)
-                await redis.delete(lead_greeting_key)
-                logger.info(f"Deleted dynamic greeting from Redis for lead {lead.id}")
+
+                async def delete_lead_greeting() -> None:
+                    await redis.delete(lead_greeting_key)
+                    logger.info(
+                        f"Deleted dynamic greeting from Redis for lead {lead.id}"
+                    )
+
+                commit = delete_lead_greeting
 
         if not mulaw_data:
             logger.info("No greeting audio cached for Daily call; LLM will speak first")
@@ -209,22 +218,24 @@ async def send_initial_greeting_daily(
 
         pcm_daily = _transcode_mulaw_to_daily_pcm(mulaw_data)
 
-        await task.queue_frame(
-            OutputAudioRawFrame(
+        logger.info(
+            f"Prepared Daily initial greeting (source={greeting_source}, "
+            f"{len(pcm_daily)} bytes PCM at {DAILY_OUTPUT_SAMPLE_RATE} Hz)"
+        )
+        return GreetingResult(
+            source=greeting_source,
+            text=greeting_text,
+            audio=OutputAudioRawFrame(
                 audio=pcm_daily,
                 sample_rate=DAILY_OUTPUT_SAMPLE_RATE,
                 num_channels=1,
-            )
+            ),
+            commit=commit,
         )
-        logger.info(
-            f"Queued Daily initial greeting (source={greeting_source}, "
-            f"{len(pcm_daily)} bytes PCM at {DAILY_OUTPUT_SAMPLE_RATE} Hz)"
-        )
-        return GreetingResult(source=greeting_source, text=greeting_text)
 
     except Exception as e:
-        logger.error(f"Failed to send Daily initial greeting: {e}", exc_info=True)
-        track_error(errors, f"Failed to send Daily initial greeting: {e}")
+        logger.error(f"Failed to prepare Daily initial greeting: {e}", exc_info=True)
+        track_error(errors, f"Failed to prepare Daily initial greeting: {e}")
         return GreetingResult(source=None, text=None)
 
 


### PR DESCRIPTION
**Old behavior**: the greeting was queued via task.queue_frame() before flow_manager.initialize(), so it entered at the top of the pipeline and could start playing before the initial node's mute_stt pre-action ran — the mute window started when the greeting ended (or never covered it). 

**New behavior:** audio is prepared only, then queued on transport.output() strictly after initialize() returns (pre-actions executed), so the mute covers the greeting playback — matching telephony. The ordering claim holds: the mute frame is processed during init, and the greeting enters at the output transport afterward.
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the timing of the initial Daily greeting so audio begins after conversation setup is complete.
  * Mute timing now starts when the greeting begins, preventing premature or extended muting.
  * Preserved prepared greeting audio until it is ready to play.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->