### PR TITLE
test(crm): pin the ingest door's handles seam and size gate

### DIFF
--- a/tests/crm/test_event_ingest_api.py
+++ b/tests/crm/test_event_ingest_api.py
@@ -302,3 +302,45 @@ def test_record_event_stays_fail_open_on_store_failure(
         )
     )
     assert result is None
+
+
+# --- the size gate: "store first" is not "store anything of any size" ---
+
+
+def _request_with_content_length(value: str) -> Request:
+    return Request(
+        scope={
+            "type": "http",
+            "method": "POST",
+            "headers": [(b"content-length", value.encode())],
+        }
+    )
+
+
+def test_an_oversized_letter_is_413_before_the_row_exists() -> None:
+    too_big = str(record_api.MAX_LETTER_BYTES + 1)
+    with pytest.raises(HTTPException) as e:
+        asyncio.run(record_api.within_size_limit(_request_with_content_length(too_big)))
+    assert e.value.status_code == 413
+
+
+def test_a_normal_letter_passes_the_size_gate() -> None:
+    ok = str(record_api.MAX_LETTER_BYTES)
+    assert (
+        asyncio.run(record_api.within_size_limit(_request_with_content_length(ok)))
+        is None
+    )
+
+
+def test_size_gate_is_declared_on_the_route() -> None:
+    # Same structure as the auth pin: a door's limit is a declared
+    # dependency, so the next route added beside this one cannot quietly
+    # ship without it.
+    route = next(
+        r
+        for r in record_api.ingest_router.routes
+        if isinstance(r, APIRoute) and r.path == "/events"
+    )
+    assert record_api.within_size_limit in [
+        d.call for d in route.dependant.dependencies
+    ]

--- a/tests/crm/test_worker_runtime.py
+++ b/tests/crm/test_worker_runtime.py
@@ -125,6 +125,58 @@ def test_entry_topic_enrols_with_phone_and_small_facts(
     assert kwargs["context"]["source_event_id"] == event.id
 
 
+def test_extractor_handles_reach_context_when_the_payload_hides_the_phone(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # The parked-run regression: a verbatim Shopify letter carries its
+    # phone ONLY in customer.default_address — none of this file's
+    # fallback paths. Before handles were passed through, this order
+    # resolved, enrolled, and parked at its first call/send node
+    # ("no phone in run context"). The extractor's discovery must win.
+    calls: List[Any] = []
+    _wire(monkeypatch, _flow(), calls)
+    event = _event("checkout.initiated")
+    event = event.model_copy(
+        update={
+            "source": "shopify",
+            "payload": {
+                "customer": {
+                    "phone": None,
+                    "default_address": {"phone": "+91 98450 12345"},
+                },
+                "cart_value": 1999,
+            },
+        }
+    )
+    asyncio.run(
+        entry.consume_attributed_event(
+            event, "cust-1", handles={"phone": "+919845012345"}
+        )
+    )
+    ((kind, kwargs),) = calls
+    assert kind == "enrol"
+    assert kwargs["context"]["phone"] == "+919845012345"
+
+
+def test_extractor_handles_beat_the_payload_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Precedence pin: when both exist, the extractor's handle wins — the
+    # number the sends dial must be the number identity resolved on, or
+    # suppression stops matching what we contact.
+    calls: List[Any] = []
+    _wire(monkeypatch, _flow(), calls)
+    event = _event("checkout.initiated")  # payload carries +919845012345
+    asyncio.run(
+        entry.consume_attributed_event(
+            event, "cust-1", handles={"phone": "+918888877777"}
+        )
+    )
+    ((kind, kwargs),) = calls
+    assert kind == "enrol"
+    assert kwargs["context"]["phone"] == "+918888877777"
+
+
 def test_goal_topic_cancels_open_runs(monkeypatch: pytest.MonkeyPatch) -> None:
     calls: List[Any] = []
     _wire(monkeypatch, _flow(), calls)


### PR DESCRIPTION
Stacked on #1025 — merge that first; this diff then collapses to one test commit (5 tests, no production code).

Closes the two coverage gaps from the #1025 review sweep:

**The parked-run regression, at the layer that broke.** The extractor and the pass were already pinned, but not the entry side of the handles seam — the exact line that used to park runs. New tests:
- a verbatim Shopify letter whose phone lives only in `customer.default_address` (none of entry's fallback paths) reaches run context through the extractor's handles — the input that previously enrolled and then parked at the first call/send node with "no phone in run context"
- when handles and payload both carry a phone, the extractor's wins: the number the sends dial is the number identity resolved on, so suppression matches what we contact

**The size gate, both behaviorally and structurally.**
- oversized `content-length` → 413 before the row exists; boundary-sized passes
- `within_size_limit` is asserted to be a DECLARED dependency on the route — the same structural pin the auth check has, so the next route added beside this one cannot quietly ship without the limit

286 passed locally · boundary checker clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)