### PR TITLE
feat(crm): spine consumer registry — record hears, never calls

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ uv run autoflake --in-place --remove-all-unused-imports --remove-unused-variable
 uv run pyrefly check                # Type check
 uv run pytest tests/                # Tests
 uv run python scripts/check_migrations.py       # Migration numbering guard
-uv run python scripts/check_crm_boundaries.py   # CRM boundary guard (11 rules)
+uv run python scripts/check_crm_boundaries.py   # CRM boundary guard (12 rules)
 ```
 
 ## Building modules & making code changes — READ THIS FIRST

--- a/app/crm/record/consumers.py
+++ b/app/crm/record/consumers.py
@@ -1,0 +1,42 @@
+"""Who hears an attributed event — the slot record OWNS but never fills.
+
+Record decides WHEN consumers run (per row, inside the row's savepoint,
+before its stamp — a poison consumer costs one row per poll, never the
+batch). It must not know WHO runs: a subscriber import here points the
+arrow record -> subscriber while every subscriber already reads record's
+contracts, which is the import cycle the #1029 round hit. So the WHO lives
+with worker_main — the one leaf allowed to see every module side by side —
+which registers subscribers at import through this file. The boundary
+checker (rule 12) fails CI on any record import of a subscriber module, so
+the inversion cannot quietly regress.
+
+A LIST, not a dict: consumers carry no names to collide on, and
+registration order is execution order. Entry rules are the first entry;
+segments and the transactional-send consumer (A13) join as one
+``register_consumer`` line in worker_main each — zero edits in the pass.
+"""
+
+from typing import Awaitable, Callable, Dict, List, Optional
+
+from app.crm.record.schemas import RawEvent
+
+# One attributed event in: (event, customer_id, handles). ``handles`` is
+# what the source's extractor found — a consumer never re-hunts the
+# payload (two searches drift; the parked-Shopify-run scar is the proof).
+Consumer = Callable[[RawEvent, str, Optional[Dict[str, str]]], Awaitable[None]]
+
+_CONSUMERS: List[Consumer] = []
+
+
+def register_consumer(consumer: Consumer) -> None:
+    """Idempotent: worker imports can run more than once (tests, reload);
+    the same function registering again must be a no-op, never a second
+    delivery of every event."""
+    if consumer not in _CONSUMERS:
+        _CONSUMERS.append(consumer)
+
+
+def consumers() -> List[Consumer]:
+    """A copy, so the pass iterates a stable list and no caller can mutate
+    the registry through the return value."""
+    return list(_CONSUMERS)

--- a/app/crm/record/workers.py
+++ b/app/crm/record/workers.py
@@ -10,7 +10,7 @@ from typing import Dict, List, Optional, Tuple
 
 from app.core.logger import logger
 from app.crm.identity.contracts import assert_facts, resolve as crm_resolve
-from app.crm.outreach.contracts import consume_attributed_event
+from app.crm.record.consumers import consumers
 from app.crm.record.db import DbTxn, accessor, atomically, savepoint
 from app.crm.record.extractors import DEFAULT_EXTRACTOR, EXTRACTORS
 from app.crm.record.schemas import RawEvent
@@ -52,15 +52,19 @@ async def _process_one(txn: DbTxn, event: RawEvent) -> None:
 async def _consume_attributed_event(
     event: RawEvent, customer_id: str, handles: Dict[str, str]
 ) -> None:
-    """Entry-rules slot: per row, inside its savepoint, before its stamp, so a
-    poison rule costs one row per poll. A raise here leaves the row pending.
+    """Consumer slot: per row, inside its savepoint, before its stamp, so a
+    poison consumer costs one row per poll. A raise here leaves the row
+    pending. WHO runs is the registry's business (record/consumers.py,
+    filled by worker_main) — this file imports no subscriber, so a
+    subscriber may read record's contracts without ever forming a cycle.
 
-    The extractor's handles ride along so the consumer never re-hunts what
-    this pass already found. Two searches would drift — and did: a Shopify
+    The extractor's handles ride along so no consumer re-hunts what this
+    pass already found. Two searches would drift — and did: a Shopify
     order with its phone only in customer.default_address resolved here and
     then parked at the first call node, because the payload re-search did
     not know that path."""
-    await consume_attributed_event(event, customer_id, handles)
+    for consume in consumers():
+        await consume(event, customer_id, handles)
 
 
 async def _run_processor(

--- a/app/crm/worker_main.py
+++ b/app/crm/worker_main.py
@@ -13,9 +13,20 @@ from app.core.config.static import (
     POSTGRES_POOL_SIZE,
 )
 from app.crm.connectivity.contracts import claim_sends, dispatch_send
-from app.crm.outreach.contracts import claim_due_runs, walk_run
+from app.crm.outreach.contracts import (
+    claim_due_runs,
+    consume_attributed_event,
+    walk_run,
+)
+from app.crm.record.consumers import register_consumer
 from app.crm.record.workers import observe_processed_event, run_pass
 from app.crm.shared.worker import run_drain_loop
+
+# The composition root fills record's consumer slot: record owns the WHEN
+# (per row, inside the row's savepoint), this file owns the WHO — so the
+# import always runs subscriber -> record, never back (checker rule 12).
+# Segments and the transactional-send consumer (A13) each add one line here.
+register_consumer(consume_attributed_event)
 
 ROLES: Dict[str, Callable[[asyncio.Event], Coroutine[Any, Any, None]]] = {
     "event-worker": lambda stop_event: run_drain_loop(

--- a/scripts/check_crm_boundaries.py
+++ b/scripts/check_crm_boundaries.py
@@ -32,6 +32,10 @@ PR time — earlier than a grant would fail:
   11. ADAPTER CONFINEMENT — app.crm.connectivity.providers is imported
      only by app/crm/connectivity/send.py and inside providers/ itself;
      any other import reaches a provider around the send() door's checks.
+  12. RECORD HEARS, NEVER CALLS — app/crm/record imports no subscriber
+     module (identity + shared only): consumers register through
+     record/consumers.py from worker_main, so subscriber -> record is the
+     only direction the import cycle can never form in.
 
 New table? Add it to TABLE_OWNERS with its owning module. New violation
 class? This script is the place — the boundary is code, so the check is
@@ -181,6 +185,28 @@ def check(root: Path = ROOT) -> list[str]:
                         f"{rp}: adapter import outside send.py ({target}) — "
                         f"providers/ is reached only through the send() door"
                     )
+            # 12. record hears, never calls — the spine's owner imports no
+            # subscriber (not even its contracts; worker_main registers them
+            # through record/consumers.py). record -> subscriber is the
+            # import cycle the registry exists to kill: every subscriber
+            # already reads record's contracts.
+            if rp.startswith("app/crm/record/") and target.startswith("app.crm."):
+                t_parts = target.split(".")
+                t_mod = t_parts[2] if len(t_parts) > 2 else None
+                # auth/api are crm-ROOT surfaces (same allowlist as the
+                # generic cross-module rule), not subscriber modules.
+                if t_mod and t_mod not in (
+                    "record",
+                    "identity",
+                    "shared",
+                    "auth",
+                    "api",
+                ):
+                    errors.append(
+                        f"{rp}: record imports a subscriber ({target}) — "
+                        f"consumers register through record/consumers.py "
+                        f"from worker_main, never the reverse"
+                    )
 
         # 7-9. the atomic grammar
         if in_crm and not is_shared_db:
@@ -237,7 +263,7 @@ def main() -> int:
         return 1
     print(
         "OK: crm boundaries clean "
-        "(ownership, SQL, driver, imports, handles, adapters)."
+        "(ownership, SQL, driver, imports, handles, adapters, subscribers)."
     )
     return 0
 

--- a/tests/crm/test_check_boundaries.py
+++ b/tests/crm/test_check_boundaries.py
@@ -179,3 +179,26 @@ def test_send_and_providers_themselves_may_import_adapters(tmp_path: Path) -> No
         },
     )
     assert check(root) == []
+
+
+def test_record_importing_a_subscriber_fails(tmp_path: Path) -> None:
+    # Rule 12: not even the subscriber's contracts — worker_main registers
+    # consumers through record/consumers.py; record never reaches back.
+    root = _tree(
+        tmp_path,
+        {"app/crm/record/workers.py": "from app.crm.outreach.contracts import x\n"},
+    )
+    assert any("record imports a subscriber" in e for e in check(root))
+
+
+def test_record_may_import_identity_and_shared(tmp_path: Path) -> None:
+    root = _tree(
+        tmp_path,
+        {
+            "app/crm/record/workers.py": (
+                "from app.crm.identity.contracts import resolve\n"
+                "from app.crm.shared.db import crm_connection\n"
+            )
+        },
+    )
+    assert not any("record imports a subscriber" in e for e in check(root))

--- a/tests/crm/test_consumer_registry.py
+++ b/tests/crm/test_consumer_registry.py
@@ -1,0 +1,94 @@
+"""The spine consumer registry: record owns the WHEN, worker_main owns the
+WHO, and the import arrow only ever points subscriber -> record."""
+
+import asyncio
+from datetime import datetime, timezone
+from typing import Any, Dict, List
+
+import pytest
+
+import app.crm.record.consumers as record_consumers
+import app.crm.record.workers as workers
+from app.crm.record.consumers import consumers, register_consumer
+from app.crm.record.schemas import RawEvent
+
+
+async def _consumer_a(event: RawEvent, customer_id: str, handles: Any) -> None:
+    return None
+
+
+def test_register_is_idempotent() -> None:
+    # Worker imports can run twice (tests, reload); the same function must
+    # never end up delivering every event twice.
+    before = consumers()
+    register_consumer(_consumer_a)
+    register_consumer(_consumer_a)
+    added = [c for c in consumers() if c is _consumer_a]
+    assert len(added) == 1
+    record_consumers._CONSUMERS = [
+        c for c in record_consumers._CONSUMERS if c is not _consumer_a
+    ]
+    assert consumers() == before
+
+
+def test_consumers_returns_a_copy() -> None:
+    # Mutating the returned list must not edit the registry.
+    snapshot = consumers()
+    snapshot.append(_consumer_a)
+    assert _consumer_a not in consumers()
+
+
+def test_the_pass_runs_every_registered_consumer_in_order(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Registration order is execution order: entry rules first today;
+    # segments and the A13 transactional-send consumer join behind them
+    # with zero edits in the pass.
+    ran: List[str] = []
+
+    async def first(event: RawEvent, customer_id: str, handles: Any) -> None:
+        ran.append(f"first:{customer_id}:{(handles or {}).get('phone')}")
+
+    async def second(event: RawEvent, customer_id: str, handles: Any) -> None:
+        ran.append(f"second:{customer_id}")
+
+    monkeypatch.setattr(record_consumers, "_CONSUMERS", [first, second])
+    event = RawEvent(
+        id="e1",
+        merchant_id="m1",
+        source="lead-api",
+        topic="t",
+        schema_version="1",
+        external_id="x",
+        payload={},
+        received_at=datetime.now(timezone.utc),
+    )
+    asyncio.run(
+        workers._consume_attributed_event(event, "cust-1", {"phone": "+911234567890"})
+    )
+    assert ran == ["first:cust-1:+911234567890", "second:cust-1"]
+
+
+def test_worker_main_registers_the_entry_consumer() -> None:
+    # The composition root fills the slot: importing worker_main is what
+    # wires outreach's entry rules onto the spine.
+    import app.crm.worker_main  # noqa: F401  (registration is an import effect)
+    from app.crm.outreach.contracts import consume_attributed_event
+
+    assert consume_attributed_event in consumers()
+
+
+def test_record_imports_no_subscriber() -> None:
+    # The structural inversion itself, greppable: nothing under record/
+    # imports outreach (or any other subscriber module). Rule 12 enforces
+    # this in CI over the real tree; this pins it from the test suite too.
+    import pathlib
+
+    record_dir = pathlib.Path(workers.__file__).parent
+    offenders: Dict[str, str] = {}
+    for py in record_dir.rglob("*.py"):
+        text = py.read_text()
+        for needle in ("app.crm.outreach", "app.crm.connectivity"):
+            if needle in text:
+                offenders[str(py)] = needle
+    assert offenders == {}

--- a/tests/crm/test_event_worker.py
+++ b/tests/crm/test_event_worker.py
@@ -26,6 +26,7 @@ from typing import Any, Dict, List, Optional, Tuple, cast
 
 import pytest
 
+import app.crm.record.consumers as record_consumers
 import app.crm.record.extractors.flat as flat_extractor
 import app.crm.record.extractors.shopify as shopify_extractor
 import app.crm.record.workers as workers
@@ -50,7 +51,10 @@ async def _no_plans_live(
 
 @pytest.fixture(autouse=True)
 def _no_outreach(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(workers, "consume_attributed_event", _no_plans_live)
+    # The registry, not the import: workers.py no longer knows any
+    # subscriber by name (rule 12) — tests wire the slot the same way
+    # worker_main does.
+    monkeypatch.setattr(record_consumers, "_CONSUMERS", [_no_plans_live])
 
 
 class _FakeSavepoint:
@@ -971,7 +975,7 @@ def test_pass_hands_the_extractors_handles_to_the_consumer() -> None:
 
     workers.crm_resolve = fake_resolve  # type: ignore[assignment]
     workers.assert_facts = fake_facts  # type: ignore[assignment]
-    workers.consume_attributed_event = fake_consume  # type: ignore[assignment]
+    record_consumers._CONSUMERS = [fake_consume]
 
     async def fake_stamp(*a: Any, **k: Any) -> None:
         return None


### PR DESCRIPTION
The committed inversion from the ledger ("spine consumer registry — next record-touching PR: record imports no subscriber; worker_main registers"), overdue since #1025 touched the consumer call site.

**Why now:** every future spine consumer — segments, the A13 transactional-send consumer — would otherwise mean record importing one more subscriber module, which is the #1029 import-cycle class waiting to recur (subscribers already read record's contracts; record reading back closes the loop).

**The shape:**
- `record/consumers.py` — the slot record OWNS but never fills: `Consumer` type `(event, customer_id, handles)`, idempotent `register_consumer`, `consumers()` returns a copy. Registration order = execution order.
- `record/workers.py` — the outreach import is gone; the per-row savepoint slot iterates registered consumers. Poison semantics unchanged: a raise still parks one row, never the batch.
- `worker_main.py` — the composition root (already "the one leaf that may import every module's contracts side by side") registers outreach's entry consumer. Record owns the WHEN, worker_main owns the WHO. A new consumer is one line here, zero edits in the pass.
- **Boundary rule 12** + red tests both directions: record imports no subscriber module, not even its contracts (identity / shared / root auth allowlisted, same list as the generic cross-module rule) — so the inversion cannot quietly regress.
- Tests: registry semantics (idempotent, ordered, copy-not-reference), worker_main wiring, a record-tree grep pin, and the event-worker harness rewired through the registry — tests now wire the slot the same way production does.

404 passed locally · boundary checker clean (12 rules).

🤖 Generated with [Claude Code](https://claude.com/claude-code)