### PR TITLE
feat(crm): event catalog — schema-driven flows (T24, where-grammar, seen-vs-matched)

### DIFF
--- a/app/core/config/static.py
+++ b/app/core/config/static.py
@@ -496,6 +496,10 @@ CRM_WORKER_HEARTBEAT = _positive_float("CRM_WORKER_HEARTBEAT", 60.0)
 # forever. Replay (clear processed_at/quarantine_reason) re-drives it.
 CRM_EVENT_MAX_ATTEMPTS = _positive_int("CRM_EVENT_MAX_ATTEMPTS", 5)
 
+# How long the event worker trusts its in-process copy of a vendor's registered
+# identity mapping (T24 is cold by design; the hot path reads the cache).
+CRM_SCHEMA_CACHE_SECONDS = _positive_float("CRM_SCHEMA_CACHE_SECONDS", 60.0)
+
 # CRM outbound dispatcher (runs only when CRM_ROLE=dispatcher; pacing rides
 # CRM_WORKER_INTERVAL, but the batch is its own dial below). send() reaches
 # real providers behind a thin permission slice: dispatch._gate probes

--- a/app/crm/api.py
+++ b/app/crm/api.py
@@ -36,6 +36,7 @@ router.include_router(
 # writes for consumers, and the inversion that keeps rule 12 whole: record
 # owns the slot, this root fills it, and record never imports back.
 record_ingress.register_ingress("meta", connectivity_contracts.META_INGRESS)
+router.include_router(record_api.catalog_router, tags=["Catalog"])
 router.include_router(outreach_api.router, prefix="/workflows", tags=["Workflows"])
 router.include_router(
     outreach_api.customer_router, prefix="/customers", tags=["Workflows"]

--- a/app/crm/connectivity/db/accessors/message.py
+++ b/app/crm/connectivity/db/accessors/message.py
@@ -80,6 +80,7 @@ async def apply_outcome(
     mark_sent: bool,
     attempt: int,
     retry_after_seconds: Optional[int] = None,
+    binding_id: Optional[str] = None,
 ) -> bool:
     """False means the row was no longer ours — another worker reclaimed it
     (``attempt`` is the claim's generation; a stale claim's write misses)."""
@@ -91,6 +92,7 @@ async def apply_outcome(
         mark_sent,
         attempt,
         retry_after_seconds,
+        binding_id,
     )
     async with crm_connection() as conn:
         row = await conn.fetchrow(query, *values)

--- a/app/crm/connectivity/db/queries/message.py
+++ b/app/crm/connectivity/db/queries/message.py
@@ -145,6 +145,7 @@ def apply_outcome_query(
     mark_sent: bool,
     attempt: int,
     retry_after_seconds: Optional[int],
+    binding_id: Optional[str] = None,
 ) -> Tuple[str, List[Any]]:
     """Record what happened to a claimed message.
 
@@ -158,12 +159,19 @@ def apply_outcome_query(
     COALESCE stops a later failure erasing an id an earlier attempt earned.
     ``retry_after_seconds`` is set only when requeuing; NULL leaves
     next_attempt_at alone, since a terminal outcome has no next attempt.
+
+    ``binding_id`` is which pipe the message LEFT on (T16 col 6): stamped
+    once, on the accepted outcome, and never rewritten — migration 060's
+    trigger permits exactly that one write. NULL on blocked rows, where no
+    pipe was ever used, is the honest answer, so a NULL here leaves the
+    column alone.
     """
     query = f"""
         UPDATE {MESSAGE_TABLE}
            SET status = $2,
                reason = $3,
                provider_message_id = COALESCE($4, provider_message_id),
+               binding_id = COALESCE(binding_id, $9::uuid),
                claimed_at = NULL,
                sent_at = CASE WHEN $5 THEN now() ELSE sent_at END,
                next_attempt_at = CASE
@@ -184,4 +192,5 @@ def apply_outcome_query(
         retry_after_seconds,
         attempt,
         MESSAGE_SENDING,
+        binding_id,
     ]

--- a/app/crm/connectivity/dispatch.py
+++ b/app/crm/connectivity/dispatch.py
@@ -342,6 +342,7 @@ async def _dispatch_one(message: QueuedMessage, max_attempts: int) -> None:
             # newer claim bumped attempt, our late outcome must miss.
             message.attempt,
             _jittered(plan.retry_after_seconds),
+            binding_id=outcome.binding_id,
         )
     except Exception as e:
         # Leave it claimed; the sweep will hand it to another worker.

--- a/app/crm/connectivity/schemas/message.py
+++ b/app/crm/connectivity/schemas/message.py
@@ -44,6 +44,10 @@ class SendOutcome(BaseModel):
 
     status: Literal["accepted", "failed", "blocked"]
     provider_message_id: Optional[str] = None
+    # Which pipe it LEFT on (T16 col 6; set-once on the row, migration 060):
+    # stamped by send() on an accepted outcome, None otherwise — a blocked or
+    # failed message never left, and a retry may leave on another pipe.
+    binding_id: Optional[str] = None
     reason: Optional[str] = None
     retryable: bool = False
 

--- a/app/crm/connectivity/send.py
+++ b/app/crm/connectivity/send.py
@@ -192,7 +192,10 @@ async def _resolve_and_deliver(
         f"to {mask_address(message.sent_to_address, message.channel)} "
         f"from binding {route.binding.id}"
     )
-    return await adapter.deliver(message, route)
+    outcome = await adapter.deliver(message, route)
+    if outcome.status != "accepted":
+        return outcome
+    return outcome.model_copy(update={"binding_id": str(route.binding.id)})
 
 
 async def send(send_token: SendToken, message: QueuedMessage) -> SendOutcome:

--- a/app/crm/outreach/catalog_laws.py
+++ b/app/crm/outreach/catalog_laws.py
@@ -1,0 +1,187 @@
+"""The catalog laws of a plan (design/event-catalog.md §Ownership; canon
+T24): conditions, entry.key and a send node's template variables come
+ONLY from declared fields, an op only from the field's type, a deprecated
+field is a warning. One pure concern, kept apart from the plan lifecycle
+(plans.py: gather -> validate -> apply) so each file stays one thing.
+
+gather_catalogs is the cold read; everything else is pure and takes what
+it gathered as an argument.
+"""
+
+from typing import Any, Dict, List, Optional
+
+from app.core.logger import logger
+from app.crm.outreach.ladder import expand_stages
+from app.crm.outreach.schemas import WorkflowDefinition
+from app.crm.record.contracts import (
+    AmbiguousTopic,
+    CatalogField,
+    canonical_path,
+    catalog_fields,
+    variable_name,
+)
+from app.crm.shared.predicate import Condition, as_number
+
+# The catalog handed to validate_definition: topic -> (path -> field, both
+# layers), with None for a topic no layer knows — every door's topic and
+# every listened topic. None altogether = the caller gathered nothing
+# (unit callers): shape laws only.
+Catalogs = Optional[Dict[str, Optional[Dict[str, CatalogField]]]]
+
+
+class WorkflowValidationError(Exception):
+    def __init__(self, problems: List[str]):
+        self.problems = problems
+        super().__init__("; ".join(problems))
+
+
+def entry_against_catalog(
+    definition: WorkflowDefinition, catalogs: Catalogs
+) -> List[str]:
+    """The catalog laws (event-catalog.md §Ownership): conditions,
+    entry.key and the send nodes' template variables come ONLY from
+    declared fields; an op only from the field's type; a deprecated field
+    is a warning, not a refusal. One pass per door (phase 15): each door's
+    topic is the catalog its words are checked against — a send node's
+    mapped facts must be declared on EVERY door's topic, since a run may
+    enter through any of them."""
+    if catalogs is None:
+        return []  # nothing gathered (pure-unit callers): shape laws only
+    problems: List[str] = []
+    mapped = [
+        (node.id, blank, fact)
+        for node in definition.nodes
+        if node.type == "send"
+        for blank, fact in node.variables.items()
+    ]
+    listened = listened_facts(definition, catalogs)
+    for entry in definition.entries:
+        topic = entry.topic
+        fields = catalogs.get(topic)
+        if fields is None:
+            if entry.where or entry.key or mapped:
+                problems.append(
+                    f"topic {topic!r} is not in the catalog — register its "
+                    "schema (or declare it in code) before filtering, keying "
+                    "or templating on it"
+                )
+            continue
+        declared = {variable_name(f.path) for f in fields.values() if f.variable}
+        allowed = declared | _WALKER_FACTS | listened
+        for node_id, blank, fact in mapped:
+            if fact not in allowed:
+                problems.append(
+                    f"send node {node_id}: variable {blank!r} <- {fact!r} is not "
+                    f"a declared variable field (topic {topic!r}; declared: "
+                    f"{', '.join(sorted(declared)) or 'none'})"
+                )
+        for condition in entry.where:
+            problems.extend(
+                f"{p} (topic {topic!r})"
+                for p in condition_against_catalog(condition, fields)
+            )
+        if entry.key:
+            key_path = canonical_path(entry.key)
+            field = fields.get(key_path)
+            if field is None:
+                problems.append(
+                    f"entry.key {entry.key!r} is not a declared field (topic {topic!r})"
+                )
+            elif not field.keyable:
+                problems.append(
+                    f"entry.key {entry.key!r} is not keyable (topic {topic!r})"
+                )
+    return problems
+
+
+# Facts the walker computes for a template at the square (nodes.run_facts,
+# phase 16) — never a producer's, so no catalog declares them.
+_WALKER_FACTS = frozenset({"current_node", "current_stage"})
+
+
+def listened_facts(definition: WorkflowDefinition, catalogs: Catalogs) -> set:
+    """PURE: every facts_<square>_<key> a send may name — a wait_event
+    square's letter (phase 16: kept under context.facts.<square>) exposes
+    the variable fields declared for ANY topic that square listens on."""
+    names: set = set()
+    if catalogs is None:
+        return names
+    for node in definition.nodes:
+        if node.type != "wait_event":
+            continue
+        for topic in node.topics:
+            for field in (catalogs.get(topic) or {}).values():
+                if field.variable:
+                    names.add(f"facts_{node.id}_{variable_name(field.path)}")
+    return names
+
+
+def condition_against_catalog(
+    condition: Condition, fields: Dict[str, CatalogField]
+) -> List[str]:
+    field = fields.get(condition.field)
+    if field is None:
+        return [f"where: {condition.field!r} is not a declared field"]
+    if condition.op not in field.ops:
+        return [
+            f"where: {condition.op!r} is not an op for {condition.field!r} "
+            f"({field.type}; allowed: {', '.join(field.ops) or 'none'})"
+        ]
+    if field.deprecated:
+        logger.warning(f"where: {condition.field!r} is deprecated in the catalog")
+    values = condition.value if condition.op == "in" else [condition.value]
+    if condition.op == "exists":
+        return []
+    if field.type == "choice" and field.values:
+        bad = [v for v in values if str(v) not in field.values]
+        if bad:
+            return [f"where: {condition.field!r} has no value {bad[0]!r}"]
+    if field.type == "number" and any(as_number(v) is None for v in values):
+        return [f"where: {condition.field!r} is a number"]
+    if field.type == "boolean" and any(not isinstance(v, bool) for v in values):
+        return [f"where: {condition.field!r} is a yes/no"]
+    return []
+
+
+async def gather_catalogs(merchant_id: str, raw: Dict[str, Any]) -> Catalogs:
+    """topic -> merged field map (None = unknown topic) for every door's
+    topic and every listened topic — the cold read the pure validator
+    receives as an argument. Read off the EXPANDED document (phase 17): a
+    ladder has no doors or squares until expand_stages mints them; a
+    ladder that will not expand gathers nothing and the validator says why.
+
+    A topic TWO sources declare for the merchant has no honest field map
+    while a door names topic alone (canon T19; `entry.source` is a ruling
+    owed): the gather refuses with a WorkflowValidationError naming both
+    sources rather than hand the validator a silent union."""
+    if isinstance(raw, dict) and raw.get("stages") is not None:
+        try:
+            raw = expand_stages(raw)
+        except Exception:  # LadderProblem / pydantic — validate_definition reports it
+            return {}
+    entry = raw.get("entry") if isinstance(raw, dict) else None
+    doors = entry if isinstance(entry, list) else [entry]
+    topics = {
+        str(door["topic"])
+        for door in doors
+        if isinstance(door, dict) and door.get("topic")
+    }
+    # …and every topic a wait_event square listens on: its letter's facts
+    # (phase 16) are what a send may name as facts_<square>_<key>.
+    for node in raw.get("nodes") or [] if isinstance(raw, dict) else []:
+        if isinstance(node, dict) and node.get("type") == "wait_event":
+            topics.update(str(t) for t in node.get("topics") or [] if t)
+    catalogs: Dict[str, Optional[Dict[str, CatalogField]]] = {}
+    problems: List[str] = []
+    for topic in sorted(topics):
+        try:
+            catalogs[topic] = await catalog_fields(merchant_id, topic)
+        except AmbiguousTopic as e:
+            problems.append(
+                f"topic {topic!r} is declared by more than one source "
+                f"({', '.join(e.sources)}) — a door names the topic alone, so "
+                "the plan cannot say which letter it means"
+            )
+    if problems:
+        raise WorkflowValidationError(problems)
+    return catalogs

--- a/app/crm/outreach/db/accessors/enrollment.py
+++ b/app/crm/outreach/db/accessors/enrollment.py
@@ -20,6 +20,7 @@ from app.crm.outreach.db.queries.enrollment import (
     cancel_run_query,
     claim_due_runs_query,
     customer_runs_query,
+    enrollment_counts_query,
     exit_run_query,
     insert_enrollment_query,
     list_runs_query,
@@ -336,3 +337,12 @@ async def customer_runs(
     async with crm_connection() as conn:
         rows = await conn.fetch(query, *values)
     return [decode_customer_run(row) for row in rows]
+
+
+async def enrollment_counts(merchant_id: str, days: int) -> Dict[str, int]:
+    """The "matched" side of seen-vs-matched: runs started per plan in the
+    window, computed on read — no counter column, nothing to drift."""
+    query, values = enrollment_counts_query(merchant_id, days)
+    async with crm_connection() as conn:
+        rows = await conn.fetch(query, *values)
+    return {row["workflow_id"]: row["started"] for row in rows}

--- a/app/crm/outreach/db/decoders/workflow.py
+++ b/app/crm/outreach/db/decoders/workflow.py
@@ -22,6 +22,7 @@ def decode_workflow_summary(row: Mapping[str, Any]) -> WorkflowSummary:
         created_by=row["created_by"],
         created_at=row["created_at"],
         updated_at=row["updated_at"],
+        entry_topic=row["entry_topic"] if "entry_topic" in row.keys() else None,
     )
 
 

--- a/app/crm/outreach/db/queries/enrollment.py
+++ b/app/crm/outreach/db/queries/enrollment.py
@@ -624,3 +624,16 @@ def sweep_exited_runs_query(cutoff: datetime, batch: int) -> Tuple[str, List[Any
         RETURNING id
     """
     return query, [cutoff, batch]
+
+
+def enrollment_counts_query(merchant_id: str, days: int) -> Tuple[str, List[Any]]:
+    """The "matched" side of seen-vs-matched: runs started per plan in the
+    window, computed on read — no counter column, nothing to drift."""
+    query = f"""
+        SELECT workflow_id::text AS workflow_id, count(*)::int AS started
+        FROM {ENROLLMENT_TABLE}
+        WHERE merchant_id = $1
+          AND entered_at > now() - make_interval(days => $2)
+        GROUP BY workflow_id
+    """
+    return query, [merchant_id, days]

--- a/app/crm/outreach/db/queries/workflow.py
+++ b/app/crm/outreach/db/queries/workflow.py
@@ -55,8 +55,15 @@ def get_workflow_query(merchant_id: str, workflow_id: str) -> Tuple[str, List[An
 def list_workflows_query(
     merchant_id: str, limit: int, offset: int
 ) -> Tuple[str, List[Any]]:
+    """entry_topic is the FIRST door's topic (a single-object entry, or
+    door 0 of a list): the summary's seen-this-week count is the first
+    door's; a multi-door plan's other doors are not summed here."""
     query = f"""
-        SELECT {_WORKFLOW_SUMMARY_COLUMNS}
+        SELECT {_WORKFLOW_SUMMARY_COLUMNS},
+               COALESCE(
+                   COALESCE(definition, draft) -> 'entry' ->> 'topic',
+                   COALESCE(definition, draft) -> 'entry' -> 0 ->> 'topic'
+               ) AS entry_topic
         FROM {WORKFLOW_TABLE}
         WHERE merchant_id = $1
         ORDER BY created_at DESC, id DESC

--- a/app/crm/outreach/entry.py
+++ b/app/crm/outreach/entry.py
@@ -23,7 +23,7 @@ stays pending and returns next poll. Our writes commit on their own
 source-event check and the open-run unique — not by that rollback.
 """
 
-from typing import Optional, Sequence, Tuple
+from typing import Any, Dict, Optional, Sequence, Tuple
 
 from app.core.logger import logger
 from app.crm.outreach.db.accessors import (
@@ -48,8 +48,9 @@ from app.crm.outreach.schemas import (
     WorkflowEntryAt,
     WorkflowNode,
 )
-from app.crm.record.contracts import RawEvent
+from app.crm.record.contracts import RawEvent, canonical_path, derive_for, field_value
 from app.crm.shared.normalize import normalize_phone
+from app.crm.shared.predicate import matches
 
 # Fallback only: where a phone hides in a payload when no extractor
 # handles were passed in (the voice mirrors, which send the flat shape).
@@ -92,7 +93,10 @@ def _phone_from_payload(payload: dict) -> str | None:
 
 
 async def consume_attributed_event(
-    event: RawEvent, customer_id: Optional[str], handles: Optional[dict] = None
+    event: RawEvent,
+    customer_id: Optional[str],
+    handles: Optional[dict] = None,
+    variables: Optional[Dict[str, Any]] = None,
 ) -> None:
     """Match one just-attributed event against her open runs (each by its
     own version) and every live plan's entry (latest). customer_id
@@ -112,7 +116,12 @@ async def consume_attributed_event(
     the system: the number the sends dial is then the same number identity
     resolved on, so suppression matches by construction and a new source
     needs no teaching here. The payload search stays as the fallback for
-    the voice mirrors, which resolve before this consumer exists."""
+    the voice mirrors, which resolve before this consumer exists.
+
+    ``variables`` are the template fill-ins the catalog declared for this
+    (source, topic), resolved by the same engine — nested paths and derived
+    names (Shopify's customer_name) that the top-level scalar copy below
+    can never see."""
     if customer_id is None:
         return  # not about a person: nothing to admit, end or wake
     open_runs = await enrollment_accessor.open_runs_for_customer(
@@ -137,9 +146,16 @@ async def consume_attributed_event(
     for flow in flows:
         definition = WorkflowDefinition.model_validate(flow.definition)
         for door in definition.entries:
-            if door.topic == event.topic and _where_matches(door.where, event.payload):
+            if door.topic == event.topic and _where_matches(door, event):
                 await _try_enrol(
-                    flow, definition, door, event, customer_id, handles, open_runs
+                    flow,
+                    definition,
+                    door,
+                    event,
+                    customer_id,
+                    handles,
+                    open_runs,
+                    variables,
                 )
                 break  # topics are unique across a plan's doors
 
@@ -301,8 +317,16 @@ def _goal_patch(event: RawEvent) -> dict:
     return {"goal": goal}
 
 
-def _where_matches(where: dict, payload: dict) -> bool:
-    return all(payload.get(key) == value for key, value in where.items())
+def _where_matches(door: WorkflowEntry, event: RawEvent) -> bool:
+    """One door's typed where-grammar against the payload
+    (shared/predicate.py); fields resolve through record's catalog paths —
+    dot-walks and the code layer's derived fields. No table read: the
+    validator guaranteed op-type fit at publish."""
+    derive = derive_for(event.source, event.topic)
+    return matches(
+        door.where,
+        lambda path: field_value(event.payload, path, derive),
+    )
 
 
 def _context_from_payload(payload: dict) -> dict:
@@ -336,11 +360,16 @@ async def _try_enrol(
     customer_id: str,
     handles: Optional[dict] = None,
     open_runs: Sequence[EnrollmentRun] = (),
+    variables: Optional[Dict[str, Any]] = None,
 ) -> None:
     admit, enrollment_key = _enrollment_key(door, event, str(flow.id))
     if not admit:
         return  # a keyed plan without its key: a refusal, not an error
     context = _context_from_payload(event.payload)
+    # The catalog's declared variables win over the scalar copy: the engine
+    # resolved them through the declared paths (customer_name from
+    # customer.first_name + last_name), and a bookkeeping name is still ours.
+    context.update(_context_from_payload(variables or {}))
     context["source_event_id"] = str(event.id)
     # When the founding letter HAPPENED (its own claim, else the envelope's
     # receipt): goals compare against this, not the row's insert time (G7).
@@ -426,7 +455,9 @@ def _enrollment_key(
     field = door.key
     if not field:
         return True, None
-    value = event.payload.get(field)
+    value = field_value(
+        event.payload, canonical_path(field), derive_for(event.source, event.topic)
+    )
     if value in (None, ""):
         logger.info(
             f"enrol skipped: entry.key {field!r} missing in payload "

--- a/app/crm/outreach/nodes.py
+++ b/app/crm/outreach/nodes.py
@@ -97,14 +97,12 @@ def without_reply(context: Dict[str, Any], node_id: str) -> Dict[str, Any]:
     return {key: value for key, value in context.items() if key != reply_key(node_id)}
 
 
-# Facts the lead machine consumes itself, not the template: kept in the
-# call payload, dropped from send variables.
-_LEAD_ONLY_KEYS = ("reporting_webhook_url",)
-
 # The merchant's own id for the thing this call is about. Buddy's reporter
 # echoes lead.request_id back to the merchant as orderId on every outcome
 # webhook — nautilus matches it to the Shopify order, so it must be THEIR
-# id, not ours. The run id is the fallback for a plan with no order.
+# id, not ours. On a KEYED plan that is the enrollment key itself (entry.key
+# names the order field — Shopify's `id`, a platform-wide unique); the flat
+# keys below serve unkeyed plans, and the run id is the last fallback.
 _REQUEST_ID_KEYS = ("order_id", "request_id")
 
 Validate = Callable[[WorkflowNode, WorkflowDefinition], List[str]]
@@ -156,6 +154,29 @@ def _validate_send(node: WorkflowNode, definition: WorkflowDefinition) -> List[s
         problems.append(
             f"send node {node.id}: the plan needs a purpose_key "
             "(what its sends are for, e.g. utility.order.cod_confirm)"
+        )
+    problems.extend(_variable_map_problems(node))
+    return problems
+
+
+def _variable_map_problems(node: WorkflowNode) -> List[str]:
+    """PURE: the shape laws of a send node's {blank: fact} map — names on
+    both sides, and one parameter style per template (a provider takes
+    positional "1","2" OR named, never a mix; refusing here beats a
+    refusal at dispatch). Whether each fact is DECLARED is the catalog
+    law, checked at publish (plans.py) where the catalog is at hand."""
+    problems = []
+    for blank, fact in node.variables.items():
+        if not blank.strip() or not fact.strip():
+            problems.append(
+                f"send node {node.id}: variables map needs a template blank on "
+                f"the left and a run fact on the right (got {blank!r}: {fact!r})"
+            )
+    positional = [b for b in node.variables if b.isascii() and b.isdigit()]
+    if positional and len(positional) != len(node.variables):
+        problems.append(
+            f'send node {node.id}: variables mix positional ("1", "2") and '
+            "named blanks — a template takes one style"
         )
     return problems
 
@@ -240,7 +261,15 @@ async def execute_call(
                 "workflow_id": str(run.workflow_id),
                 "enrollment_id": str(run.id),
             },
-            request_id=lead_request_id(run.context, str(run.id)),
+            request_id=lead_request_id(
+                run.context,
+                str(run.id),
+                (
+                    run.enrollment_key
+                    if any(door.key for door in definition.entries)
+                    else None
+                ),
+            ),
             execution_mode=ExecutionMode.TELEPHONY,
             status=LeadCallStatus.BACKLOG,
         )
@@ -271,6 +300,16 @@ async def execute_send(
     if not definition.purpose_key:
         raise NodeParked(f"send node {node.id}: plan has no purpose_key")
 
+    try:
+        variables = send_variables(node.variables, run.context, node)
+    except KeyError as e:
+        raise NodeParked(
+            f"send node {node.id}: mapped fact {e.args[0]!r} is not in the run "
+            "context — the entry event did not carry it"
+        ) from e
+    except ValueError as e:
+        raise NodeParked(f"send node {node.id}: {e}") from e
+
     dedupe_key = f"{run.id}:{node.id}"
     try:
         message_id = await queue_message(
@@ -282,7 +321,7 @@ async def execute_send(
             source_id=str(run.id),
             purpose_key=definition.purpose_key,
             template_id=node.template,
-            variables=send_variables(run.context, node),
+            variables=variables,
             dedupe_key=dedupe_key,
         )
     except ValueError as e:
@@ -299,9 +338,15 @@ async def execute_send(
 # --- the small pure helpers the actions share ---
 
 
-def lead_request_id(context: Dict[str, Any], run_id: str) -> str:
-    """PURE: the merchant's order/request id from the run's facts, else
-    a traceable wf-<run id>."""
+def lead_request_id(
+    context: Dict[str, Any], run_id: str, enrollment_key: Optional[str] = None
+) -> str:
+    """PURE: what this run is ABOUT, for the merchant — the enrollment key
+    when the plan is keyed (the order id the author named), else the
+    merchant's order/request id from the run's facts, else a traceable
+    wf-<run id>."""
+    if enrollment_key:
+        return str(enrollment_key)
     for key in _REQUEST_ID_KEYS:
         value = context.get(key)
         if value not in (None, ""):
@@ -350,25 +395,33 @@ def run_facts(
 
 
 def send_variables(
-    context: Dict[str, Any], node: Optional[WorkflowNode] = None
+    mapping: Dict[str, str],
+    context: Dict[str, Any],
+    node: Optional[WorkflowNode] = None,
 ) -> Dict[str, Any]:
-    """PURE: the template's fill-ins = the run's facts minus what only
-    the lead machine reads, and only what a provider can render: text and
-    numbers. A bool or a None among the variables makes the WhatsApp face
-    refuse the whole message terminally (connectivity renders nothing it
-    cannot spell — "True" or "None" inside a customer's message is
-    corruption that looks delivered), and with every listened letter's
-    facts riding along (phase 16) such values are ordinary, not rare."""
-    return {
-        key: value
-        for key, value in run_facts(context, node).items()
-        if key not in _LEAD_ONLY_KEYS
-        and isinstance(value, (str, int, float))
-        and not isinstance(value, bool)
-    }
+    """PURE: the template's fill-ins = EXACTLY the facts the send node
+    mapped, {blank: facts[fact]} over run_facts (so a blank may name a
+    stage's letter, facts_<square>_<key>, or current_node/current_stage)
+    — no map, no parameters. Bookkeeping is never mapped: the validator
+    only admits declared names on the right-hand side.
 
+    Two honest refusals, both parking the run rather than posting a
+    half-filled or misspelled message: a mapped fact absent from the run
+    (KeyError(fact)), and a mapped value a provider cannot render — a
+    bool, a None, a list (ValueError naming the fact): "True" or "None"
+    inside a customer's message is corruption that looks delivered."""
+    facts = run_facts(context, node)
+    variables: Dict[str, Any] = {}
+    for blank, fact in mapping.items():
+        value = facts[fact]
+        if isinstance(value, bool) or not isinstance(value, (str, int, float)):
+            raise ValueError(
+                f"mapped fact {fact!r} is {type(value).__name__}, not text — "
+                "a template blank needs text or a number"
+            )
+        variables[blank] = value
+    return variables
 
-# --- THE registry: the vocabulary, one entry per word ---
 
 NODE_TYPES: Dict[str, NodeSpec] = {
     "wait": NodeSpec(validate=_validate_wait, execute=None, is_wait=True),

--- a/app/crm/outreach/plans.py
+++ b/app/crm/outreach/plans.py
@@ -10,6 +10,12 @@ from typing import Any, Dict, List, Optional
 
 from app.core.logger import logger
 from app.crm.connectivity.contracts import registers_templates_for, template_status
+from app.crm.outreach.catalog_laws import (
+    Catalogs,
+    WorkflowValidationError,
+    entry_against_catalog,
+    gather_catalogs as _gather_catalogs,
+)
 from app.crm.outreach.db import DbTxn, atomically
 from app.crm.outreach.db.accessors import (
     enrollment as enrollment_accessor,
@@ -27,18 +33,27 @@ from app.crm.outreach.schemas import (
     WorkflowEntryAt,
     WorkflowSummary,
 )
+from app.crm.record.contracts import (
+    topic_counts,
+)
+
+SEEN_WINDOW_DAYS = 7
 
 
 def validate_definition(
     raw: Dict[str, Any],
     occupied_nodes: Optional[List[str]] = None,
     live_entry: Optional[Dict[str, Any]] = None,
+    catalogs: Catalogs = None,
 ) -> List[str]:
     """PURE decide: every law the document must satisfy, as a list of
     human-readable problems (empty = valid). occupied_nodes are the
     squares open tokens stand on — publish must not delete one, and while
     any exist the entry rule (live_entry) must not change under them
-    (canon T19: no changing entry semantics mid-flight).
+    (canon T19: no changing entry semantics mid-flight). catalogs maps each
+    topic to its merged field map (gathered by the caller — this function
+    never reads); a topic mapped to None is one no layer declares, so
+    nothing may be filtered, keyed or templated on it.
 
     A ladder (phase 17) is expanded first, so every law below judges the
     board it means — and the stored form, the ladder beside its own
@@ -56,6 +71,19 @@ def validate_definition(
         return [f"definition shape invalid: {e}"]
 
     problems: List[str] = []
+    raw_entry = raw.get("entry")
+    raw_doors = raw_entry if isinstance(raw_entry, list) else [raw_entry]
+    if any(
+        isinstance(door, dict) and isinstance(door.get("where"), dict) and door["where"]
+        for door in raw_doors
+    ):
+        # The model reads a map for the immutable rows 069 could not rewrite;
+        # a document being WRITTEN today must speak the typed grammar.
+        problems.append(
+            "entry.where is a list of conditions [{field, op, value}] — the "
+            "equality map is retired (migration 069)"
+        )
+    problems.extend(entry_against_catalog(definition, catalogs))
     node_ids = [node.id for node in definition.nodes]
     seen = set()
     for node_id in node_ids:
@@ -242,7 +270,8 @@ async def create_workflow(
     never in ways that break the editor. A ladder (phase 17) is stored
     with the board it expands to: the author's intent beside what the
     walker reads."""
-    problems = validate_definition(definition)
+    catalogs = await _gather_catalogs(merchant_id, definition)
+    problems = validate_definition(definition, catalogs=catalogs)
     if problems:
         raise WorkflowValidationError(problems)
     return await workflow_accessor.insert_workflow(
@@ -253,7 +282,8 @@ async def create_workflow(
 async def update_draft(
     merchant_id: str, workflow_id: str, definition: Dict[str, Any]
 ) -> Optional[Workflow]:
-    problems = validate_definition(definition)
+    catalogs = await _gather_catalogs(merchant_id, definition)
+    problems = validate_definition(definition, catalogs=catalogs)
     if problems:
         raise WorkflowValidationError(problems)
     return await workflow_accessor.update_draft(
@@ -264,11 +294,21 @@ async def update_draft(
 async def publish_workflow(
     merchant_id: str, workflow_id: str, published_by: Optional[str] = None
 ) -> Workflow:
-    return await atomically(_publish_in_txn, merchant_id, workflow_id, published_by)
+    draft = await workflow_accessor.get_workflow(merchant_id, workflow_id)
+    catalogs = await _gather_catalogs(
+        merchant_id, (draft.draft if draft else None) or {}
+    )
+    return await atomically(
+        _publish_in_txn, merchant_id, workflow_id, published_by, catalogs
+    )
 
 
 async def _publish_in_txn(
-    txn: DbTxn, merchant_id: str, workflow_id: str, published_by: Optional[str]
+    txn: DbTxn,
+    merchant_id: str,
+    workflow_id: str,
+    published_by: Optional[str],
+    catalogs: Catalogs = None,
 ) -> Workflow:
     """ATOMIC: the validate, the copy, the version row and (migrate) the
     re-pin share one fate — the document the validator approved must be
@@ -292,7 +332,10 @@ async def _publish_in_txn(
     occupied = await enrollment_accessor.occupied_nodes(txn, merchant_id, workflow_id)
     live_entry = (workflow.definition or {}).get("entry")
     problems = validate_definition(
-        draft, occupied_nodes=occupied, live_entry=live_entry
+        draft,
+        occupied_nodes=occupied,
+        live_entry=live_entry,
+        catalogs=catalogs,
     )
     if problems:
         raise WorkflowValidationError(problems)
@@ -400,13 +443,25 @@ async def get_workflow(merchant_id: str, workflow_id: str) -> Optional[Workflow]
 async def list_workflows(
     merchant_id: str, limit: int, offset: int
 ) -> List[WorkflowSummary]:
-    return await workflow_accessor.list_workflows(merchant_id, limit, offset)
-
-
-class WorkflowValidationError(Exception):
-    def __init__(self, problems: List[str]):
-        self.problems = problems
-        super().__init__("; ".join(problems))
+    """The list, decorated with seen-vs-matched for the window: events on
+    each plan's entry topic (record's count, any source) against runs it
+    started — "saw 240 · matched 3" is a dashboard fact, never a stored one."""
+    summaries = await workflow_accessor.list_workflows(merchant_id, limit, offset)
+    if not summaries:
+        return summaries
+    seen: Dict[str, int] = {}
+    for count in await topic_counts(merchant_id, SEEN_WINDOW_DAYS):
+        seen[count.topic] = seen.get(count.topic, 0) + count.seen
+    started = await enrollment_accessor.enrollment_counts(merchant_id, SEEN_WINDOW_DAYS)
+    return [
+        s.model_copy(
+            update={
+                "seen_7d": seen.get(s.entry_topic or "", 0),
+                "matched_7d": started.get(str(s.id), 0),
+            }
+        )
+        for s in summaries
+    ]
 
 
 class WorkflowNotFound(Exception):

--- a/app/crm/outreach/schemas.py
+++ b/app/crm/outreach/schemas.py
@@ -14,15 +14,23 @@ from uuid import UUID
 
 from pydantic import BaseModel, Field, model_validator
 
+from app.crm.shared.predicate import Condition, from_equality_map
+
 
 class WorkflowEntry(BaseModel):
     """Which event admits a customer, and the admission guards enforced
     for both doors (canon: entry carries reenter + cooldown)."""
 
     topic: str = Field(min_length=1)
-    # Optional payload condition: every key must equal (orders/create AND
-    # payload.gateway = COD). Empty = topic alone admits.
-    where: Dict[str, Any] = Field(default_factory=dict)
+    # Typed conditions, ANDed (design/event-catalog.md §The where-grammar):
+    # [{field: "payload.gateway", op: "is", value: "COD"}]. Every field must
+    # be declared in the catalog (code or registered layer) — the publish
+    # validator refuses the rest. Empty = topic alone admits. The pre-catalog
+    # equality map is retired: migration 069 rewrote every stored plan, and a
+    # map that still reaches this model (a crm_workflow_version row is
+    # immutable, so 069 could not touch it) is read as the conditions it
+    # meant — the publish validator refuses a NEW document that writes one.
+    where: List[Condition] = Field(default_factory=list)
     reenter: bool = False
     cooldown_hours: float = Field(24.0, ge=0)
     # What a run is ABOUT (canon T20 col 13, ruled 31 Aug 2026): the payload
@@ -44,6 +52,14 @@ class WorkflowEntry(BaseModel):
     # — sliding its alarm by debounce_minutes and merging the facts. Needs
     # debounce_minutes > 0 (validated), or there is nothing to re-arm.
     restart_on_repeat: bool = False
+
+    @model_validator(mode="before")
+    @classmethod
+    def _legacy_where_map(cls, data: Any) -> Any:
+        """The pre-catalog equality map, read as the conditions it meant."""
+        if isinstance(data, dict) and isinstance(data.get("where"), dict):
+            data = {**data, "where": from_equality_map(data["where"])}
+        return data
 
 
 class WorkflowEntryAt(WorkflowEntry):
@@ -146,6 +162,17 @@ class WorkflowNode(BaseModel):
     stage: Optional[str] = Field(None, min_length=1)
     # Phase 18: only the letter about THIS run wakes the square.
     match: Optional[WorkflowMatch] = None
+    # send only: which run fact fills which template blank, {blank: fact}.
+    # Left = the parameter the provider's registered template declares
+    # ({{customer_name}} named, or "1"/"2" positional); right = the key in
+    # the run's context — a variable field the catalog declares for the
+    # entry topic (design/event-catalog.md: template variables ONLY from
+    # declared fields; the publish validator refuses the rest). Absent or
+    # empty = the template has no blanks and ZERO parameters are posted.
+    # Never the whole context: crm_message.variables is what we actually
+    # posted (canon T16 col 11), and a template with two blanks handed 27
+    # facts is refused by every provider.
+    variables: Dict[str, str] = Field(default_factory=dict)
 
 
 # An arrow: [from, to] or [from, to, on]. `on` labels a branch out of a
@@ -319,6 +346,11 @@ class WorkflowSummary(BaseModel):
     created_by: Optional[str]
     created_at: datetime
     updated_at: datetime
+    # Drift observability (event-catalog.md §Seen vs matched): events on
+    # the entry topic vs runs started, last 7 days — computed on read.
+    entry_topic: Optional[str] = None
+    seen_7d: int = 0
+    matched_7d: int = 0
 
 
 class Workflow(WorkflowSummary):

--- a/app/crm/record/api.py
+++ b/app/crm/record/api.py
@@ -1,5 +1,6 @@
 """The record module's doors: the per-customer journey view (A12), the event
-ingest push door (A9), and the provider webhook bays (A9).
+ingest push door (A9), the provider webhook bays (A9), and the event catalog
+(design/event-catalog.md).
 
 Thin routes per module rules §1. ``journey_router`` auths via
 Depends(crm_admin_user) and delegates to timeline.py; ``ingest_router``
@@ -23,20 +24,29 @@ from datetime import datetime
 from typing import List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response, status
-from fastapi.responses import PlainTextResponse
+from fastapi.responses import JSONResponse, PlainTextResponse
 
 from app.core.logger import logger
 from app.core.logger.context import set_log_context
 from app.crm.auth import crm_admin_user, verify_s2s_caller
-from app.crm.record import ingress
+from app.crm.record import catalog, ingress
 from app.crm.record.ingest import ingest_event
-from app.crm.record.schemas import EventIn, EventReceipt, JourneyCard
+from app.crm.record.schemas import (
+    CatalogEntry,
+    EventIn,
+    EventReceipt,
+    EventSchema,
+    JourneyCard,
+    SampledField,
+    SchemaRegistration,
+)
 from app.crm.record.timeline import get_customer_journey
 from app.schemas import UserInfo
 
 journey_router = APIRouter()
 ingest_router = APIRouter()
 webhook_router = APIRouter()
+catalog_router = APIRouter()
 
 
 @journey_router.get("/{customer_id}/journey", response_model=List[JourneyCard])
@@ -91,6 +101,19 @@ async def verified_caller(event: EventIn, request: Request) -> str:
     handler.
     """
     return await verify_s2s_caller(event.merchant_id, request)
+
+
+async def verified_merchant_caller(
+    request: Request,
+    merchant_id: str = Query(..., description="Tenant scope — required"),
+) -> str:
+    """The sibling of verified_caller for a door whose merchant is in the
+    QUERY, not the body (the S2S schema registration): the same
+    verify_s2s_caller, declared as the route's dependency for the same
+    reason — the door-walk test (test_ingress_door) can then prove every
+    ingest route carries its auth, instead of trusting a handler's first
+    line."""
+    return await verify_s2s_caller(merchant_id, request)
 
 
 @ingest_router.post("/events", response_model=EventReceipt)
@@ -218,3 +241,93 @@ async def provider_webhook_route(provider: str, request: Request) -> Response:
             filed += 1
     logger.info(f"ingress: {provider} webhook filed {filed}/{len(letters)} letters")
     return Response(status_code=status.HTTP_200_OK)
+
+
+# --- The event catalog (design/event-catalog.md; canon T24) -----------------
+
+
+@catalog_router.get("/catalog", response_model=List[CatalogEntry])
+async def get_catalog_route(
+    request: Request,
+    merchant_id: str = Query(..., description="Tenant scope — required"),
+    current_user: UserInfo = Depends(crm_admin_user),
+) -> Response:
+    """The merged catalog (code layer + this merchant's registrations),
+    content-addressed: send If-None-Match and get 304 until a deploy or a
+    re-registration changes it."""
+    set_log_context(component="crm.record.catalog", merchant_id=merchant_id)
+    # entries -> etag -> 304, and only a body that is sent pays the
+    # seen-this-week GROUP BY (the ETag excludes seen_7d by design).
+    entries = await catalog.merged_entries(merchant_id)
+    etag = catalog.etag_for(entries)
+    if request.headers.get("if-none-match") == etag:
+        return Response(
+            status_code=status.HTTP_304_NOT_MODIFIED, headers={"ETag": etag}
+        )
+    entries = await catalog.with_seen_counts(merchant_id, entries)
+    return JSONResponse(
+        content=[e.model_dump(mode="json") for e in entries], headers={"ETag": etag}
+    )
+
+
+@catalog_router.get("/catalog/samples", response_model=List[SampledField])
+async def sample_fields_route(
+    merchant_id: str = Query(..., description="Tenant scope — required"),
+    source: str = Query(..., min_length=1),
+    topic: str = Query(..., min_length=1),
+    current_user: UserInfo = Depends(crm_admin_user),
+) -> List[SampledField]:
+    """The registration wizard's pre-fill from the vendor's real traffic."""
+    set_log_context(component="crm.record.catalog.samples", merchant_id=merchant_id)
+    return await catalog.sample_fields(merchant_id, source, topic)
+
+
+@catalog_router.get("/schemas", response_model=List[EventSchema])
+async def list_schemas_route(
+    merchant_id: str = Query(..., description="Tenant scope — required"),
+    current_user: UserInfo = Depends(crm_admin_user),
+) -> List[EventSchema]:
+    set_log_context(component="crm.record.schemas.list", merchant_id=merchant_id)
+    return await catalog.list_schemas(merchant_id)
+
+
+@catalog_router.post(
+    "/schemas", response_model=EventSchema, status_code=status.HTTP_201_CREATED
+)
+async def register_schema_admin_route(
+    body: SchemaRegistration,
+    merchant_id: str = Query(..., description="Tenant scope — required"),
+    current_user: UserInfo = Depends(crm_admin_user),
+) -> EventSchema:
+    """The console wizard's door — our ops registering on a vendor's behalf."""
+    set_log_context(component="crm.record.schemas.register", merchant_id=merchant_id)
+    return await _register(
+        merchant_id, body, current_user.email or current_user.username
+    )
+
+
+@ingest_router.post(
+    "/schemas", response_model=EventSchema, status_code=status.HTTP_201_CREATED
+)
+async def register_schema_s2s_route(
+    body: SchemaRegistration,
+    merchant_id: str = Query(..., description="Tenant scope — required"),
+    _caller: str = Depends(verified_merchant_caller),
+) -> EventSchema:
+    """The vendor's own door at enrollment, beside the envelope door and
+    under its exact auth (verify_s2s_caller, declared): the credential
+    says who may speak; this registration says what their words mean
+    (canon T24)."""
+    set_log_context(component="crm.record.schemas.register", merchant_id=merchant_id)
+    return await _register(merchant_id, body, f"s2s:{merchant_id}")
+
+
+async def _register(
+    merchant_id: str, body: SchemaRegistration, registered_by: str
+) -> EventSchema:
+    try:
+        return await catalog.register_schema(merchant_id, body, registered_by)
+    except catalog.SchemaValidationError as e:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=e.problems
+        )

--- a/app/crm/record/catalog.py
+++ b/app/crm/record/catalog.py
@@ -1,0 +1,441 @@
+"""The event catalog (design/event-catalog.md; canon T24) — record's fourth
+house registry, beside EXTRACTORS: (source, topic) -> what this event is
+called and what's inside it. Two layers, one shape:
+
+  CODE layer      — CATALOG below. Grows in the same PR as the decoder
+                    (extractor + fixtures + catalog entry: the four-part
+                    ritual; tests/crm/test_catalog.py pins the square).
+  REGISTERED layer — crm_event_schema rows a push vendor signs at
+                    enrollment (POST /ingest/schemas or the console wizard).
+
+The catalog API merges them; the editor, the publish validator and the
+where-grammar are layer-blind. gather (accessor reads) -> decide (pure:
+merge, validate a registration, resolve a field) -> apply (register).
+
+Hot-path law (canon T24 wiring): the FLOW runtime never reads the table;
+the DECODE step reads only the cached spec (decode_spec — one engine, two
+spec sources: a code CatalogEntry or a registered row, same shape),
+and discovery costs one INSERT per new topic EVER (is_known/mark_known).
+"""
+
+import hashlib
+import json
+import re
+import time
+from datetime import datetime
+from typing import Any, Dict, List, Optional, Set, Tuple
+
+from app.core.config.static import CRM_SCHEMA_CACHE_SECONDS
+from app.crm.record.db import accessor
+from app.crm.record.extractors import SPEC_MODULES
+from app.crm.record.extractors.engine import (
+    EMPTY_SPEC,
+    PAYLOAD_PREFIX,
+    DecodeSpec,
+    Deriver,
+    spec_for_entry,
+)
+from app.crm.record.schemas import (
+    CatalogEntry,
+    CatalogField,
+    EventSchema,
+    SampledField,
+    SchemaRegistration,
+)
+from app.crm.shared.predicate import EQUALS_OP, EXISTS_OP, ORDER_OPS, TEXT_OPS
+
+# Type -> the ops the where-grammar implements for it. Spelled from the
+# evaluator's own families (shared/predicate.py), so the UI shows exactly
+# what the engine runs — parity is structural, not a convention. phone is
+# identity — never filterable.
+OPS_BY_TYPE: Dict[str, List[str]] = {
+    "text": [*TEXT_OPS, EXISTS_OP],
+    "choice": [*TEXT_OPS, EXISTS_OP],
+    "number": [*ORDER_OPS, EQUALS_OP, EXISTS_OP],
+    "boolean": ["is", "is_not", EXISTS_OP],
+    "datetime": [*ORDER_OPS, EXISTS_OP],
+    "phone": [],
+}
+KEYABLE_TYPES = ("text", "number")
+MAX_REGISTERED_FIELDS = 200
+SAMPLE_WINDOW_EVENTS = 200
+SEEN_WINDOW_DAYS = 7
+
+_PAYLOAD_PATH = re.compile(
+    r"^payload\.[A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_]*)*$"
+)
+_DERIVED_PATH = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+VENDOR_ROLES = ("phone", "name")  # canon T24: identity is phone | name
+_PHONE_LIKE = re.compile(r"^\+?\d[\d\s-]{8,}$")
+
+SchemaKey = Tuple[str, str, str]  # (merchant_id, source, topic)
+# Computed on read (ops) or code-layer only (fallbacks, derived): never
+# stored in a T24 row — canon's field list is what the row carries.
+_CODE_ONLY_KEYS = {"ops", "fallbacks", "derived"}
+
+
+# --- The CODE layer ---------------------------------------------------------
+#
+# One entry per (source, topic), DECLARED beside its derivers in the source's
+# spec module (one source, one file) and assembled through
+# extractors.SPEC_MODULES — this file never names a source. Adding an event
+# = one entry + a recorded fixture, same PR, pinned by tests/crm/test_catalog.py;
+# adding a source = one import + one registry line in extractors/__init__.py.
+# The engine (extractors/engine.py) executes these exactly as it executes a
+# registered vendor row: one decode engine, two spec sources.
+
+CATALOG: Dict[Tuple[str, str], CatalogEntry] = {
+    (entry.source, entry.topic): entry
+    for module in SPEC_MODULES
+    for entry in module.ENTRIES
+}
+
+# (source, topic) -> derived field -> derive(payload). A spec module exports
+# its derivers once; every entry of that source that declares a derived field
+# gets it from here (pinned: declared == provided, per entry).
+DERIVE: Dict[Tuple[str, str], Dict[str, Deriver]] = {
+    (entry.source, entry.topic): {
+        f.path: module.DERIVERS[f.path]
+        for f in entry.fields
+        if f.derived and f.path in module.DERIVERS
+    }
+    for module in SPEC_MODULES
+    for entry in module.ENTRIES
+}
+
+
+# --- Pure helpers -----------------------------------------------------------
+
+
+def with_ops(field: CatalogField) -> CatalogField:
+    """The ops a field admits are a function of its type, never authored."""
+    return field.model_copy(update={"ops": list(OPS_BY_TYPE[field.type])})
+
+
+def code_entries() -> List[CatalogEntry]:
+    return [
+        entry.model_copy(update={"fields": [with_ops(f) for f in entry.fields]})
+        for entry in CATALOG.values()
+    ]
+
+
+def canonical_path(path: str) -> str:
+    """entry.key was authored bare ("order_id") before the catalog; the
+    catalog's identity for the same thing is "payload.order_id"."""
+    if path.startswith(PAYLOAD_PREFIX) or path in _all_derived_names():
+        return path
+    return PAYLOAD_PREFIX + path
+
+
+def _all_derived_names() -> Set[str]:
+    return {name for table in DERIVE.values() for name in table}
+
+
+def derive_for(source: str, topic: str) -> Dict[str, Deriver]:
+    return DERIVE.get((source, topic), {})
+
+
+def validate_registration(registration: SchemaRegistration) -> List[str]:
+    """PURE decide: every law a signed schema must satisfy, as problems.
+    Unknown types are rejected HERE, never discovered at flow-publish."""
+    problems: List[str] = []
+    if (registration.source, registration.topic) in CATALOG:
+        # The code layer is authoritative for its own events: a shadow row
+        # would be gathered by the validator (same source, so the ambiguity
+        # guard is silent), hidden by the console and ignored by decode —
+        # a plan could then template on a field no send can ever fill.
+        # Discovery writes no nudge for a code-layer topic; registration
+        # keeps the same rule. A merchant's own vendor picks its own source.
+        problems.append(
+            f"{registration.source}/{registration.topic} is declared in code — "
+            "nothing to register"
+        )
+    fields = registration.fields
+    if len(fields) > MAX_REGISTERED_FIELDS:
+        problems.append(f"too many fields ({len(fields)} > {MAX_REGISTERED_FIELDS})")
+    seen: Set[str] = set()
+    roles: Dict[str, str] = {}
+    for field in fields:
+        if field.derived:
+            problems.append(f"{field.path}: derived fields are code-layer only")
+        if field.fallbacks:
+            problems.append(f"{field.path}: fallbacks are code-layer only")
+        if field.identity is not None and field.identity not in VENDOR_ROLES:
+            problems.append(
+                f"{field.path}: identity role must be one of {' | '.join(VENDOR_ROLES)}"
+            )
+        if not _PAYLOAD_PATH.match(field.path):
+            problems.append(
+                f"{field.path}: path must be payload.<key>[.<key>...] "
+                "(letters, digits, underscore)"
+            )
+        if field.path in seen:
+            problems.append(f"{field.path}: declared twice")
+        seen.add(field.path)
+        if field.type == "choice" and not field.values:
+            problems.append(f"{field.path}: choice needs its values")
+        if field.type != "choice" and field.values:
+            problems.append(f"{field.path}: only choice carries values")
+        if field.keyable and field.type not in KEYABLE_TYPES:
+            problems.append(f"{field.path}: keyable needs text or number")
+        if field.identity is not None:
+            if field.identity in roles:
+                problems.append(
+                    f"{field.path}: identity role {field.identity!r} already "
+                    f"taken by {roles[field.identity]}"
+                )
+            roles[field.identity] = field.path
+            if field.identity == "phone" and field.type != "phone":
+                problems.append(f"{field.path}: identity:phone must be type phone")
+            if field.keyable:
+                problems.append(f"{field.path}: an identity field cannot be keyable")
+        if field.type == "phone" and field.identity != "phone":
+            problems.append(f"{field.path}: type phone is identity:phone or nothing")
+    return problems
+
+
+def dropped_paths(previous: EventSchema, registration: SchemaRegistration) -> List[str]:
+    """PURE decide: additive-or-deprecate (design/event-catalog.md §Laws —
+    "fields are deprecated, never deleted"). A re-registration that drops
+    a path a live flow may filter or template on is refused; the vendor
+    keeps the path and marks it `deprecated: true` instead."""
+    kept = {f.path for f in registration.fields}
+    return [
+        f"{f.path}: declared in v{previous.version} and missing now — "
+        "a field is deprecated, never deleted (keep it with deprecated: true)"
+        for f in previous.fields
+        if f.path not in kept
+    ]
+
+
+def etag_for(entries: List[CatalogEntry]) -> str:
+    """Version stamp of one merged catalog: content-addressed, so a
+    re-registration or a code deploy changes it and nothing else does."""
+    body = json.dumps(
+        [e.model_dump(mode="json", exclude={"seen_7d"}) for e in entries],
+        sort_keys=True,
+    )
+    return '"' + hashlib.sha256(body.encode()).hexdigest()[:32] + '"'
+
+
+def _guess_type(jtype: str, samples: List[Any]) -> str:
+    if jtype == "number":
+        return "number"
+    if jtype == "boolean":
+        return "boolean"
+    texts = [s for s in samples if isinstance(s, str)]
+    if texts and all(_PHONE_LIKE.match(t) for t in texts):
+        return "phone"
+    if texts and all(_parses_datetime(t) for t in texts):
+        return "datetime"
+    return "text"
+
+
+def _parses_datetime(text: str) -> bool:
+    try:
+        datetime.fromisoformat(text.replace("Z", "+00:00"))
+        return True
+    except ValueError:
+        return False
+
+
+def _entry_from_row(row: EventSchema, seen: int) -> CatalogEntry:
+    return CatalogEntry(
+        source=row.source,
+        topic=row.topic,
+        label=row.label or row.topic,
+        group=row.source,
+        layer="registered",
+        status="registered" if row.status == "registered" else "detected",
+        version=row.version,
+        fields=[with_ops(f) for f in row.fields],
+        seen_7d=seen,
+    )
+
+
+# --- Reads the API and the validator gather -------------------------------
+
+
+async def merged_entries(merchant_id: str) -> List[CatalogEntry]:
+    """Code layer + this merchant's registered layer, one shape, counts
+    NOT filled (seen_7d = 0): everything the ETag hashes, and nothing it
+    excludes — so a 304 costs one schema read and no GROUP BY."""
+    rows = await accessor.list_schemas(merchant_id)
+    entries = list(code_entries())
+    code_keys = set(CATALOG)
+    for row in rows:
+        if (row.source, row.topic) in code_keys:
+            continue  # the code layer is authoritative for its own events
+        entries.append(_entry_from_row(row, 0))
+    return entries
+
+
+async def with_seen_counts(
+    merchant_id: str, entries: List[CatalogEntry]
+) -> List[CatalogEntry]:
+    """The seen-this-week count, computed on read (T24 stays cold) —
+    after the ETag check, only for a body that is actually sent."""
+    counts = {
+        (c.source, c.topic): c.seen
+        for c in await accessor.topic_counts(merchant_id, SEEN_WINDOW_DAYS)
+    }
+    return [
+        e.model_copy(update={"seen_7d": counts.get((e.source, e.topic), 0)})
+        for e in entries
+    ]
+
+
+async def merged_catalog(merchant_id: str) -> List[CatalogEntry]:
+    """Code layer + this merchant's registered layer, with the seen-this-week
+    count filled: what a caller with no ETag to offer reads."""
+    return await with_seen_counts(merchant_id, await merged_entries(merchant_id))
+
+
+async def topic_counts(merchant_id: str, days: int = SEEN_WINDOW_DAYS):
+    """Events seen per (source, topic) in the window — the flow list's
+    "saw 240" side, computed on read (the timeline.py seam: cross-module
+    callers never depend on an accessor signature)."""
+    return await accessor.topic_counts(merchant_id, days)
+
+
+async def catalog_fields(
+    merchant_id: str, topic: str
+) -> Optional[Dict[str, CatalogField]]:
+    """The validator's gather: every declared field for a topic (both
+    layers), by path. None = no layer knows this topic.
+
+    Catalog identity is (source, topic) and a door carries topic only
+    (canon T19 — `entry.source` is a ruling owed), so a topic that TWO
+    sources declare for this merchant cannot be honestly gathered: a
+    union would let a condition on a path only one source has match
+    nothing for the other, silently. It raises AmbiguousTopic naming
+    both; the validator turns that into a problem."""
+    found: Dict[str, CatalogField] = {}
+    sources: List[str] = []
+    for entry in code_entries():
+        if entry.topic == topic:
+            sources.append(entry.source)
+            found.update({f.path: f for f in entry.fields})
+    for row in await accessor.list_schemas(merchant_id):
+        if row.topic == topic and row.status == "registered":
+            if row.source not in sources:
+                sources.append(row.source)
+            found.update({f.path: with_ops(f) for f in row.fields})
+    if len(sources) > 1:
+        raise AmbiguousTopic(topic, sources)
+    return found if sources else None
+
+
+async def register_schema(
+    merchant_id: str, registration: SchemaRegistration, registered_by: str
+) -> EventSchema:
+    """gather (the previous version) -> decide (the laws, incl. the
+    additive-or-deprecate law against it) -> apply (the row)."""
+    problems = validate_registration(registration)
+    previous = await accessor.get_schema(
+        merchant_id, registration.source, registration.topic
+    )
+    if previous is not None and previous.status == "registered":
+        problems.extend(dropped_paths(previous, registration))
+    if problems:
+        raise SchemaValidationError(problems)
+    row = await accessor.register_schema(
+        merchant_id,
+        registration.source,
+        registration.topic,
+        registration.label,
+        json.dumps(
+            [f.model_dump(exclude=_CODE_ONLY_KEYS) for f in registration.fields]
+        ),
+        registered_by,
+    )
+    _SPEC_CACHE.pop((merchant_id, registration.source, registration.topic), None)
+    return row
+
+
+async def list_schemas(merchant_id: str) -> List[EventSchema]:
+    return await accessor.list_schemas(merchant_id)
+
+
+async def sample_fields(
+    merchant_id: str, source: str, topic: str
+) -> List[SampledField]:
+    """The wizard's pre-fill: keys seen in the vendor's recent traffic with a
+    guessed type — compute-on-read over crm_event_raw, nothing stored."""
+    rows = await accessor.sample_fields(
+        merchant_id, source, topic, SAMPLE_WINDOW_EVENTS
+    )
+    return [
+        SampledField(
+            path=PAYLOAD_PREFIX + r["path"],
+            type_guess=_guess_type(r["jtype"], r["samples"]),  # type: ignore[arg-type]
+            seen=r["seen"],
+            samples=r["samples"],
+        )
+        for r in rows
+    ]
+
+
+# --- Hot-path helpers for the event worker ----------------------------------
+
+_KNOWN: Set[SchemaKey] = set()
+_SPEC_CACHE: Dict[SchemaKey, Tuple[float, DecodeSpec]] = {}
+
+
+def is_known(key: SchemaKey) -> bool:
+    return key in _KNOWN
+
+
+def mark_known(key: SchemaKey) -> None:
+    _KNOWN.add(key)
+
+
+def code_spec(source: str, topic: str) -> Optional[DecodeSpec]:
+    """The code layer's spec for a topic, or None when no entry declares
+    it. Pure and free: no table, no cache."""
+    entry = CATALOG.get((source, topic))
+    if entry is None:
+        return None
+    return spec_for_entry(entry, derive_for(source, topic))
+
+
+async def decode_spec(merchant_id: str, source: str, topic: str) -> DecodeSpec:
+    """What the engine reads for one letter — the code layer when it
+    declares the topic (authoritative, no I/O), else the vendor's
+    registration, cached in process for CRM_SCHEMA_CACHE_SECONDS (T24 stays
+    cold; the hot path reads the cache). EMPTY_SPEC when nothing declares
+    the topic: the flat shape alone applies."""
+    spec = code_spec(source, topic)
+    if spec is not None:
+        return spec
+    key = (merchant_id, source, topic)
+    cached = _SPEC_CACHE.get(key)
+    now = time.monotonic()
+    if cached and cached[0] > now:
+        return cached[1]
+    row = await accessor.get_schema(merchant_id, source, topic)
+    spec = EMPTY_SPEC
+    if row is not None and row.status == "registered":
+        entry = _entry_from_row(row, 0)
+        spec = spec_for_entry(entry, {})
+    _SPEC_CACHE[key] = (now + CRM_SCHEMA_CACHE_SECONDS, spec)
+    return spec
+
+
+class SchemaValidationError(Exception):
+    def __init__(self, problems: List[str]):
+        self.problems = problems
+        super().__init__("; ".join(problems))
+
+
+class AmbiguousTopic(Exception):
+    """A topic two sources declare for one merchant: no honest field map
+    exists for a door that names the topic alone."""
+
+    def __init__(self, topic: str, sources: List[str]):
+        self.topic = topic
+        self.sources = sources
+        super().__init__(
+            f"topic {topic!r} is declared by more than one source "
+            f"({', '.join(sources)})"
+        )

--- a/app/crm/record/consumers.py
+++ b/app/crm/record/consumers.py
@@ -16,12 +16,13 @@ segments and the transactional-send consumer (A13) join as one
 ``register_consumer`` line in worker_main each — zero edits in the pass.
 """
 
-from typing import Awaitable, Callable, Dict, List, Optional
+from typing import Any, Awaitable, Callable, Dict, List, Optional
 
 from app.crm.record.schemas import RawEvent
 
-# One processed event in: (event, customer_id, handles). ``handles`` is
-# what the source's extractor found — a consumer never re-hunts the
+# One processed event in: (event, customer_id, handles, variables).
+# ``handles`` is what the engine found the person by and ``variables`` the
+# template fill-ins the catalog declared — a consumer never re-hunts the
 # payload (two searches drift; the parked-Shopify-run scar is the proof).
 # ``customer_id`` is None for a MERCHANT-LEVEL letter (Extracted.about ==
 # "merchant": a template review, an account notice): a consumer that is
@@ -29,7 +30,8 @@ from app.crm.record.schemas import RawEvent
 # things — template status, account health — is exactly who those letters
 # are for. Every consumer hears every letter; none is filtered here.
 Consumer = Callable[
-    [RawEvent, Optional[str], Optional[Dict[str, str]]], Awaitable[None]
+    [RawEvent, Optional[str], Optional[Dict[str, str]], Optional[Dict[str, Any]]],
+    Awaitable[None],
 ]
 
 _CONSUMERS: List[Consumer] = []

--- a/app/crm/record/contracts.py
+++ b/app/crm/record/contracts.py
@@ -6,12 +6,26 @@ deliberately NOT exported here. workers.py calls outreach's entry-rules
 consumer, and outreach imports this file — exporting the pass here would
 close an import cycle. app/crm/worker_main.py, the one composition root,
 takes the pass from workers.py directly.
+
+Catalog exports (design/event-catalog.md): the publish validator gathers
+`catalog_fields` (both layers, cold read) before its pure validate; the
+entry evaluator resolves conditions with `field_value` + `derive_for`
+(code layer only — the flow runtime never reads T24); `topic_counts` is
+the seen-side of the flow list's "saw 240 · matched 3".
 """
 
+from app.crm.record.catalog import (
+    AmbiguousTopic,
+    canonical_path,
+    catalog_fields,
+    derive_for,
+    topic_counts,
+)
 from app.crm.record.events import customer_has_event
+from app.crm.record.extractors.engine import field_value, variable_name
 from app.crm.record.ingest import record_event
 from app.crm.record.ingress import IngressSpec, register_ingress
-from app.crm.record.schemas import EventIn, RawEvent
+from app.crm.record.schemas import CatalogField, EventIn, RawEvent, TopicCount
 from app.crm.record.timeline import get_customer_journey
 
 __all__ = [
@@ -27,4 +41,13 @@ __all__ = [
     "IngressSpec",
     "register_ingress",
     "EventIn",
+    "CatalogField",
+    "TopicCount",
+    "AmbiguousTopic",
+    "canonical_path",
+    "catalog_fields",
+    "derive_for",
+    "field_value",
+    "topic_counts",
+    "variable_name",
 ]

--- a/app/crm/record/db/accessor.py
+++ b/app/crm/record/db/accessor.py
@@ -6,20 +6,31 @@ fail postures and serialization decisions live in the logic files
 ``txn`` is reserved for the _in_txn bodies that own a boundary.
 """
 
+import json
 from datetime import datetime
-from typing import List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 from app.crm.record.db import DbTxn
-from app.crm.record.db.decoder import decode_journey_card, decode_raw_event
+from app.crm.record.db.decoder import (
+    decode_event_schema,
+    decode_journey_card,
+    decode_raw_event,
+)
 from app.crm.record.db.queries import (
     claim_pending_events_query,
     customer_has_event_query,
     get_customer_journey_query,
+    get_schema_query,
+    insert_detected_schema_query,
     insert_event_query,
+    list_schemas_query,
     quarantine_event_query,
+    register_schema_query,
+    sample_fields_query,
     stamp_event_query,
+    topic_counts_query,
 )
-from app.crm.record.schemas import JourneyCard, RawEvent
+from app.crm.record.schemas import EventSchema, JourneyCard, RawEvent, TopicCount
 from app.crm.shared.db import crm_connection
 
 
@@ -95,3 +106,84 @@ async def customer_has_event(
     async with crm_connection() as conn:
         row = await conn.fetchrow(query, *values)
     return bool(row["found"]) if row else False
+
+
+# --- crm_event_schema (T24) ---------------------------------------------------
+
+
+async def insert_detected_schema(
+    conn: DbTxn, merchant_id: str, source: str, topic: str
+) -> None:
+    """Inside the pass's row savepoint — the nudge row shares fate with the
+    row that revealed the topic."""
+    query, values = insert_detected_schema_query(merchant_id, source, topic)
+    await conn.execute(query, *values)
+
+
+async def register_schema(
+    merchant_id: str,
+    source: str,
+    topic: str,
+    label: str,
+    fields_json: str,
+    registered_by: str,
+) -> EventSchema:
+    query, values = register_schema_query(
+        merchant_id, source, topic, label, fields_json, registered_by
+    )
+    async with crm_connection() as conn:
+        row = await conn.fetchrow(query, *values)
+    if row is None:
+        raise RuntimeError("schema registration returned no row")
+    return decode_event_schema(row)
+
+
+async def list_schemas(merchant_id: str) -> List[EventSchema]:
+    query, values = list_schemas_query(merchant_id)
+    async with crm_connection() as conn:
+        rows = await conn.fetch(query, *values)
+    return [decode_event_schema(row) for row in rows]
+
+
+async def get_schema(
+    merchant_id: str, source: str, topic: str
+) -> Optional[EventSchema]:
+    query, values = get_schema_query(merchant_id, source, topic)
+    async with crm_connection() as conn:
+        row = await conn.fetchrow(query, *values)
+    return decode_event_schema(row) if row is not None else None
+
+
+async def topic_counts(merchant_id: str, days: int) -> List[TopicCount]:
+    query, values = topic_counts_query(merchant_id, days)
+    async with crm_connection() as conn:
+        rows = await conn.fetch(query, *values)
+    return [
+        TopicCount(source=r["source"], topic=r["topic"], seen=r["seen"]) for r in rows
+    ]
+
+
+async def sample_fields(
+    merchant_id: str, source: str, topic: str, limit: int
+) -> List[Dict[str, Any]]:
+    """Raw {path, jtype, seen, samples} rows; catalog.py guesses the type."""
+    query, values = sample_fields_query(merchant_id, source, topic, limit)
+    async with crm_connection() as conn:
+        rows = await conn.fetch(query, *values)
+    out: List[Dict[str, Any]] = []
+    for r in rows:
+        samples = []
+        for text in r["samples"] or []:
+            try:
+                samples.append(json.loads(text))
+            except (TypeError, ValueError):
+                samples.append(text)
+        out.append(
+            {
+                "path": r["path"],
+                "jtype": r["jtype"],
+                "seen": r["seen"],
+                "samples": samples,
+            }
+        )
+    return out

--- a/app/crm/record/db/decoder.py
+++ b/app/crm/record/db/decoder.py
@@ -9,7 +9,7 @@ becomes a switch on source_kind — not before.
 import json
 from typing import Any, Mapping
 
-from app.crm.record.schemas import JourneyCard, RawEvent
+from app.crm.record.schemas import CatalogField, EventSchema, JourneyCard, RawEvent
 
 
 def decode_raw_event(row: Mapping[str, Any]) -> RawEvent:
@@ -45,4 +45,24 @@ def decode_journey_card(row: Mapping[str, Any]) -> JourneyCard:
         recording_ref=row["recording_ref"],
         transcript_ref=row["transcript_ref"],
         source_kind=row["source_kind"],
+    )
+
+
+def decode_event_schema(row: Mapping[str, Any]) -> EventSchema:
+    fields = row["fields"]
+    if isinstance(fields, str):
+        fields = json.loads(fields)
+    return EventSchema(
+        id=str(row["id"]),
+        merchant_id=row["merchant_id"],
+        source=row["source"],
+        topic=row["topic"],
+        label=row["label"],
+        fields=[CatalogField.model_validate(f) for f in (fields or [])],
+        status=row["status"],
+        version=row["version"],
+        registered_by=row["registered_by"],
+        first_seen_at=row["first_seen_at"],
+        created_at=row["created_at"],
+        updated_at=row["updated_at"],
     )

--- a/app/crm/record/db/queries.py
+++ b/app/crm/record/db/queries.py
@@ -157,3 +157,106 @@ def customer_has_event_query(
     if where:
         params.extend([where[0], where[1]])
     return query, params
+
+
+# --- crm_event_schema (T24) + the catalog's compute-on-read queries ---------
+
+EVENT_SCHEMA_TABLE = "crm_event_schema"
+
+
+def insert_detected_schema_query(
+    merchant_id: str, source: str, topic: str
+) -> Tuple[str, List[Any]]:
+    """Discovery: the nudge row, written ONCE per topic ever (the in-process
+    known-set in catalog.py keeps the hot path from even probing). A
+    registered row is never touched — DO NOTHING."""
+    query = f"""
+        INSERT INTO {EVENT_SCHEMA_TABLE}
+            (merchant_id, source, topic, status, first_seen_at)
+        VALUES ($1, $2, $3, 'detected', now())
+        ON CONFLICT (merchant_id, source, topic) DO NOTHING
+    """
+    return query, [merchant_id, source, topic]
+
+
+def register_schema_query(
+    merchant_id: str,
+    source: str,
+    topic: str,
+    label: str,
+    fields_json: str,
+    registered_by: str,
+) -> Tuple[str, List[Any]]:
+    """Registration upgrades the same row: detected -> registered, and every
+    re-registration bumps version (the audit stamp). first_seen_at stays
+    whatever discovery wrote."""
+    query = f"""
+        INSERT INTO {EVENT_SCHEMA_TABLE}
+            (merchant_id, source, topic, label, fields, status, version, registered_by)
+        VALUES ($1, $2, $3, $4, $5::jsonb, 'registered', 1, $6)
+        ON CONFLICT (merchant_id, source, topic) DO UPDATE SET
+            label = EXCLUDED.label,
+            fields = EXCLUDED.fields,
+            status = 'registered',
+            version = {EVENT_SCHEMA_TABLE}.version + 1,
+            registered_by = EXCLUDED.registered_by
+        RETURNING *
+    """
+    return query, [merchant_id, source, topic, label, fields_json, registered_by]
+
+
+def list_schemas_query(merchant_id: str) -> Tuple[str, List[Any]]:
+    query = f"""
+        SELECT * FROM {EVENT_SCHEMA_TABLE}
+        WHERE merchant_id = $1
+        ORDER BY source, topic
+    """
+    return query, [merchant_id]
+
+
+def get_schema_query(
+    merchant_id: str, source: str, topic: str
+) -> Tuple[str, List[Any]]:
+    query = f"""
+        SELECT * FROM {EVENT_SCHEMA_TABLE}
+        WHERE merchant_id = $1 AND source = $2 AND topic = $3
+    """
+    return query, [merchant_id, source, topic]
+
+
+def topic_counts_query(merchant_id: str, days: int) -> Tuple[str, List[Any]]:
+    """ "312 this week" — computed on read from the spine, never stored."""
+    query = f"""
+        SELECT source, topic, count(*)::int AS seen
+        FROM {EVENT_RAW_TABLE}
+        WHERE merchant_id = $1
+          AND received_at > now() - make_interval(days => $2)
+        GROUP BY source, topic
+    """
+    return query, [merchant_id, days]
+
+
+def sample_fields_query(
+    merchant_id: str, source: str, topic: str, limit: int
+) -> Tuple[str, List[Any]]:
+    """The registration wizard's pre-fill: top-level scalar keys seen in the
+    vendor's most recent letters, with up to three distinct sample values.
+    Nested objects and arrays are skipped — the catalog addresses those
+    only through code-layer derived fields."""
+    query = f"""
+        WITH recent AS (
+            SELECT payload FROM {EVENT_RAW_TABLE}
+            WHERE merchant_id = $1 AND source = $2 AND topic = $3
+            ORDER BY received_at DESC
+            LIMIT $4
+        )
+        SELECT e.key AS path,
+               jsonb_typeof(e.value) AS jtype,
+               count(*)::int AS seen,
+               (array_agg(DISTINCT e.value::text))[1:3] AS samples
+        FROM recent, jsonb_each(recent.payload) AS e
+        WHERE jsonb_typeof(e.value) IN ('string', 'number', 'boolean')
+        GROUP BY e.key, jsonb_typeof(e.value)
+        ORDER BY seen DESC, path
+    """
+    return query, [merchant_id, source, topic, limit]

--- a/app/crm/record/extractors/__init__.py
+++ b/app/crm/record/extractors/__init__.py
@@ -1,26 +1,37 @@
-"""source -> extractor: the single assembly point.
+"""The assembly point of record's decoders — both kinds, one file.
 
-One provider per file; this module is the only place that knows which
-source maps to which. A new channel is one import and one registry line —
-an unregistered source falls back to the flat shape, so a producer that
-speaks the house payload needs nothing here at all.
+SPEC_MODULES: the ruled path (event-catalog.md §One decode engine). Each
+module declares its (source, topic) CatalogEntries as ``ENTRIES`` and its
+derive() functions as ``DERIVERS``; record/catalog.py builds the code
+layer by iterating this tuple and never spells a source. Adding a source
+= one import + one entry here, beside its fixtures and tests.
+
+EXTRACTORS: source -> IMPERATIVE extractor, for the few sources that
+still decode by hand — the flat shape for the buddy mirrors. A source is
+in ONE of the two, never both (tests/crm/test_catalog.py fails CI on the
+overlap: two readers of one payload drift). An unregistered source falls
+back to the flat shape, so a producer that speaks the house payload needs
+nothing here at all.
 
 Mirrors connectivity's ``providers/__init__.py`` holding ADAPTERS: same
 anatomy on both sides of the house.
 """
 
-from typing import Any, Callable, Dict
+from typing import Any, Callable, Dict, Tuple
 
 from app.crm.record.extractors import flat, shopify
 from app.crm.record.schemas import Extracted
 
 Extractor = Callable[[Dict[str, Any]], Extracted]
 
+# Declared specs: modules exporting ENTRIES (List[CatalogEntry]) and
+# DERIVERS (derived field name -> derive(payload)).
+SPEC_MODULES: Tuple[Any, ...] = (shopify,)
+
 EXTRACTORS: Dict[str, Extractor] = {
     "lead-api": flat.extract,
     "telephony": flat.extract,
-    "shopify": shopify.extract,
 }
 DEFAULT_EXTRACTOR: Extractor = flat.extract
 
-__all__ = ["EXTRACTORS", "DEFAULT_EXTRACTOR", "Extractor"]
+__all__ = ["EXTRACTORS", "DEFAULT_EXTRACTOR", "Extractor", "SPEC_MODULES"]

--- a/app/crm/record/extractors/engine.py
+++ b/app/crm/record/extractors/engine.py
@@ -1,0 +1,157 @@
+"""The ONE decode engine (design/event-catalog.md §One decode engine, two
+spec sources — ruled 1 Sep 2026).
+
+A payload is decoded by a SPEC, never by hand-written code: which paths
+hold the person (identity roles, in precedence order), which paths ride
+into templates (variables), and which names are computed (derive — the
+code escape hatch for the ~10% that is genuinely logic). Two spec sources
+feed this one function:
+
+  registered  — a push vendor's crm_event_schema row (T24), read through
+                the cached mapping in record/catalog.py;
+  code        — a connector's CatalogEntry (extractors/shopify.py), the
+                SAME vocabulary written in code, with fallbacks and derive().
+
+One engine cannot drift from itself: the path the editor shows for "the
+phone" IS the path this function reads. (Two hand-written readers did
+drift — #1025's extractor found the phone in four places while outreach's
+entry context searched three, and the flagship run parked at its first
+call node.)
+
+The flat shape (customer_mobile_number / customer_name at the top level)
+is the standing fallback beneath every spec: a conventional producer never
+thinks about registration. Path resolution lives here too — catalog.py and
+outreach's entry evaluator resolve fields through these same helpers.
+"""
+
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, List, Literal, Optional
+
+from app.crm.record.extractors import flat
+from app.crm.record.schemas import ABOUT_CUSTOMER, CatalogEntry, Extracted
+from app.crm.shared.normalize import normalize_email, normalize_phone
+
+Deriver = Callable[[Dict[str, Any]], Any]
+
+PAYLOAD_PREFIX = "payload."
+# Small-facts cap, the same ceiling outreach applies to run context: a
+# variable is a template fill-in, never a payload photocopy.
+VARIABLE_MAX_CHARS = 256
+# Roles that are handles resolve() probes on — everything but the name.
+_NORMALIZE: Dict[str, Callable[[str], Optional[str]]] = {
+    "phone": normalize_phone,
+    "email": normalize_email,
+}
+_SCALARS = (str, int, float, bool)
+
+
+@dataclass(frozen=True)
+class DecodeSpec:
+    """What one (source, topic) means to the engine. Built from a code
+    CatalogEntry or a registered row — the engine never knows which."""
+
+    # role -> paths in precedence order (first non-empty wins)
+    identity: Dict[str, List[str]] = field(default_factory=dict)
+    # template placeholder -> path (a bare name is a derived field)
+    variables: Dict[str, str] = field(default_factory=dict)
+    derive: Dict[str, Deriver] = field(default_factory=dict)
+    # who the letter is about — the entry's word, passed through to
+    # Extracted.about so the pass knows a NULL customer is by design
+    about: Literal["customer", "merchant"] = ABOUT_CUSTOMER
+
+
+EMPTY_SPEC = DecodeSpec()
+
+
+def field_value(
+    payload: Dict[str, Any],
+    path: str,
+    derive: Optional[Dict[str, Deriver]] = None,
+) -> Any:
+    """Resolve one catalog path against one payload: payload.a.b walks the
+    dots (a missing step -> None, never a raise); a bare name is a derived
+    field when the caller's derive table knows it, else a top-level key."""
+    if path.startswith(PAYLOAD_PREFIX):
+        node: Any = payload
+        for step in path[len(PAYLOAD_PREFIX) :].split("."):
+            if not isinstance(node, dict):
+                return None
+            node = node.get(step)
+        return node
+    if derive and path in derive:
+        try:
+            return derive[path](payload)
+        except Exception:
+            return None
+    return payload.get(path)
+
+
+def variable_name(path: str) -> str:
+    """The {placeholder} a variable field fills: a derived field's own
+    name, else the path's last segment (payload.customer.first_name ->
+    first_name). Pinned unique per entry by tests/crm/test_catalog.py."""
+    if path.startswith(PAYLOAD_PREFIX):
+        return path.rsplit(".", 1)[-1]
+    return path
+
+
+def spec_for_entry(entry: CatalogEntry, derive: Dict[str, Deriver]) -> DecodeSpec:
+    """PURE: a catalog entry (either layer) -> what the engine reads.
+    Deprecated fields keep their place in the catalog but stop feeding
+    decode; a field's fallbacks follow its own path in order."""
+    identity: Dict[str, List[str]] = {}
+    variables: Dict[str, str] = {}
+    for f in entry.fields:
+        if f.deprecated:
+            continue
+        if f.identity:
+            identity.setdefault(f.identity, []).extend([f.path, *f.fallbacks])
+        if f.variable:
+            variables[variable_name(f.path)] = f.path
+    return DecodeSpec(
+        identity=identity, variables=variables, derive=dict(derive), about=entry.about
+    )
+
+
+def extract(payload: Dict[str, Any], spec: DecodeSpec) -> Extracted:
+    """One letter in; handles, facts and template variables out. The flat
+    shape first (standard keys), then the spec — a declared path wins over
+    a standard key, so a vendor's rider_phone beats an absent
+    customer_mobile_number and a present one is still honoured."""
+    base = flat.extract(payload)
+    handles: Dict[str, str] = dict(base.handles)
+    facts: Dict[str, Any] = dict(base.facts)
+
+    for role, paths in spec.identity.items():
+        raw = _first_present(payload, paths, spec.derive)
+        if raw is None:
+            continue
+        if role == "name":
+            name = str(raw).strip()
+            if name:
+                facts["name"] = name
+            continue
+        normalize = _NORMALIZE.get(role)
+        value = normalize(str(raw)) if normalize else str(raw).strip()
+        if value:
+            handles[role] = value
+
+    variables: Dict[str, Any] = {}
+    for name, path in spec.variables.items():
+        value = field_value(payload, path, spec.derive)
+        if isinstance(value, _SCALARS) and len(str(value)) <= VARIABLE_MAX_CHARS:
+            variables[name] = value
+
+    return Extracted(
+        handles=handles, facts=facts, variables=variables, about=spec.about
+    )
+
+
+def _first_present(
+    payload: Dict[str, Any], paths: List[str], derive: Dict[str, Deriver]
+) -> Any:
+    for path in paths:
+        value = field_value(payload, path, derive)
+        if value not in (None, ""):
+            return value
+    return None

--- a/app/crm/record/extractors/shopify.py
+++ b/app/crm/record/extractors/shopify.py
@@ -1,72 +1,222 @@
-"""Shopify's own order/checkout body, as the relay forwards it.
+"""Shopify, as a code-layer SPEC — the engine's first (event-catalog.md
+§One decode engine, ruled 1 Sep 2026).
 
-The relay is a pipe: it carries Shopify's words unopened, so the nesting
-arrives intact and this is where it gets read. Shopify puts a phone in up
-to four places and the top-level one is usually null — ``default_address``
-is the common home for a returning shopper — while a guest checkout
-carries no customer object at all, which is why the shipping address is
-the last fallback for both handle and name.
+Nothing here reads a payload by hand. Each topic the relay forwards
+(nautilus#195: orders/create · orders/cancelled · checkouts/create ·
+checkouts/update, plus orders/paid as the cart board's goal) is ONE
+CatalogEntry in the same vocabulary a push vendor registers in T24 —
+paths, identity roles, keyable/variable flags — extended by two things
+only code may say:
 
-Three handle kinds, matching the corpus's example for this extractor
-(shopify/checkouts.create -> phone, email, shopify_customer_id): the id is
-what lets a signed-in shopper's early checkout frames resolve before she
-has typed a number.
+  fallbacks   Shopify puts a phone in up to four places and the top-level
+              one is usually null; a guest checkout carries no customer
+              object at all. The precedence list is DECLARED, so the editor
+              and the engine cannot disagree about where the phone lives.
+  derive()    the ~10% that is genuinely logic: a full name from two
+              fields with their own fallbacks, a count over line_items.
+              The matcher never learns array semantics — arrays are
+              reachable only through these.
 
-The name is never defaulted. A placeholder like "Customer" would reach
-assert_facts as a genuine name claim and overwrite what we actually know
-about this person — absent is absent.
+The name is never defaulted: a placeholder like "Customer" would reach
+assert_facts as a genuine claim and overwrite what we actually know.
+Fixtures under tests/crm/fixtures/shopify/ pin every path and fallback.
 """
 
-from typing import Any, Dict
+from typing import Any, Dict, List, Optional
 
-from app.crm.record.schemas import Extracted
-from app.crm.shared.normalize import normalize_email, normalize_phone
+from app.crm.record.schemas import CatalogEntry, CatalogField
+
+SOURCE = "shopify"
+GROUP = "Shopify"
+
+# Where Shopify puts the person, most specific first. The customer record
+# beats the shipping contact; a returning shopper's number usually sits on
+# default_address; a guest has only the addresses.
+PHONE_PATHS = [
+    "payload.customer.phone",
+    "payload.customer.default_address.phone",
+    "payload.phone",
+    "payload.shipping_address.phone",
+    "payload.billing_address.phone",
+]
+EMAIL_PATHS = ["payload.customer.email", "payload.email"]
+_NAME_HOMES = ("customer", "billing_address", "shipping_address")
+
+FINANCIAL_STATUSES = [
+    "pending",
+    "authorized",
+    "paid",
+    "partially_paid",
+    "refunded",
+    "voided",
+    "partially_refunded",
+]
+CANCEL_REASONS = ["customer", "fraud", "inventory", "declined", "other"]
 
 
-def extract(payload: Dict[str, Any]) -> Extracted:
-    customer = payload.get("customer") or {}
-    address = payload.get("shipping_address") or payload.get("billing_address") or {}
-    default_address = customer.get("default_address") or {}
+# --- derive(): the code escape hatch ----------------------------------------
 
-    # Most specific first: the customer record beats the shipping contact.
-    raw_phone = (
-        customer.get("phone")
-        or default_address.get("phone")
-        or payload.get("phone")
-        or address.get("phone")
+
+def customer_name(payload: Dict[str, Any]) -> Optional[str]:
+    """First + last, from the customer record, else the billing contact,
+    else the shipping contact — each half found where it lives. Billing
+    before shipping is deliberate (the pre-catalog extractor read shipping
+    first): the billing contact is the person who pays, the one a
+    recovery message should address; the fixtures pin the order."""
+    first = _name_part(payload, "first_name")
+    last = _name_part(payload, "last_name")
+    name = " ".join(part for part in (first, last) if part).strip()
+    return name or None
+
+
+def _name_part(payload: Dict[str, Any], key: str) -> str:
+    customer = payload.get("customer")
+    homes: List[Any] = [
+        customer,
+        (customer or {}).get("default_address") if isinstance(customer, dict) else None,
+        payload.get("billing_address"),
+        payload.get("shipping_address"),
+    ]
+    for home in homes:
+        if isinstance(home, dict) and home.get(key):
+            return str(home[key]).strip()
+    return ""
+
+
+def items_count(payload: Dict[str, Any]) -> Optional[int]:
+    items = payload.get("line_items")
+    return len(items) if isinstance(items, list) else None
+
+
+def first_item_name(payload: Dict[str, Any]) -> Optional[str]:
+    items = payload.get("line_items")
+    if isinstance(items, list) and items and isinstance(items[0], dict):
+        title = items[0].get("title")
+        return str(title) if title is not None else None
+    return None
+
+
+DERIVERS = {
+    "customer_name": customer_name,
+    "items_count": items_count,
+    "first_item_name": first_item_name,
+}
+
+
+# --- the specs -------------------------------------------------------------
+
+
+def _f(path: str, type: str, label: str, **flags: Any) -> CatalogField:
+    return CatalogField(path=path, type=type, label=label, **flags)  # type: ignore[arg-type]
+
+
+def _person_fields() -> List[CatalogField]:
+    """The customer, the same on every Shopify topic."""
+    return [
+        _f(
+            PHONE_PATHS[0],
+            "phone",
+            "Customer phone",
+            identity="phone",
+            fallbacks=PHONE_PATHS[1:],
+        ),
+        _f(
+            EMAIL_PATHS[0],
+            "text",
+            "Customer email",
+            identity="email",
+            fallbacks=EMAIL_PATHS[1:],
+        ),
+        # Shopify's own customer id, when the shopper is signed in: the early
+        # checkout frames carry no phone yet (she types it later) but they
+        # carry this, so they resolve to the person instead of quarantining.
+        _f(
+            "payload.customer.id",
+            "text",
+            "Shopify customer id",
+            identity="shopify_customer_id",
+        ),
+        _f(
+            "customer_name",
+            "text",
+            "Customer name",
+            identity="name",
+            variable=True,
+            derived=True,
+        ),
+        _f("payload.customer.first_name", "text", "Customer first name", variable=True),
+    ]
+
+
+def _money_fields() -> List[CatalogField]:
+    return [
+        _f("payload.total_price", "number", "Order total", variable=True),
+        _f("payload.currency", "text", "Currency", variable=True),
+        _f("items_count", "number", "Items", derived=True, variable=True),
+        _f("first_item_name", "text", "First item", derived=True, variable=True),
+    ]
+
+
+def _order_fields() -> List[CatalogField]:
+    return [
+        _f("payload.id", "text", "Order ID", keyable=True, variable=True),
+        _f("payload.name", "text", "Order number", variable=True),
+        _f("payload.order_number", "number", "Order sequence", variable=True),
+        # The cart this order came from — what a cart-recovery run is ABOUT,
+        # so the order can end the right run (goal key cart_token).
+        _f("payload.cart_token", "text", "Cart token", keyable=True, variable=True),
+        _f(
+            "payload.financial_status",
+            "choice",
+            "Payment status",
+            values=FINANCIAL_STATUSES,
+        ),
+        _f("payload.gateway", "text", "Payment method"),
+        *_money_fields(),
+        *_person_fields(),
+    ]
+
+
+def _checkout_fields() -> List[CatalogField]:
+    return [
+        _f("payload.token", "text", "Checkout token", keyable=True, variable=True),
+        _f("payload.cart_token", "text", "Cart token", keyable=True, variable=True),
+        _f("payload.abandoned_checkout_url", "text", "Resume link", variable=True),
+        _f("payload.gateway", "text", "Payment method"),
+        _f("payload.updated_at", "datetime", "Last edited"),
+        *_money_fields(),
+        *_person_fields(),
+    ]
+
+
+def _entry(topic: str, label: str, fields: List[CatalogField]) -> CatalogEntry:
+    return CatalogEntry(
+        source=SOURCE,
+        topic=topic,
+        label=label,
+        group=GROUP,
+        layer="code",
+        fields=fields,
     )
-    raw_email = customer.get("email") or payload.get("email")
 
-    handles: Dict[str, str] = {}
-    if raw_phone:
-        phone = normalize_phone(str(raw_phone))
-        if phone:
-            handles["phone"] = phone
-    if raw_email:
-        email = normalize_email(str(raw_email))
-        if email:
-            handles["email"] = email
 
-    # Shopify's own customer id, when the shopper is signed in. It earns
-    # its line on the checkouts/update stream: the early frames carry no
-    # phone yet (she types it later) but they do carry this, so they
-    # resolve to the person instead of quarantining no_handle.
-    raw_customer_id = customer.get("id")
-    if raw_customer_id is not None:
-        handles["shopify_customer_id"] = str(raw_customer_id)
-
-    first = (
-        customer.get("first_name")
-        or default_address.get("first_name")
-        or address.get("first_name")
-        or ""
-    )
-    last = (
-        customer.get("last_name")
-        or default_address.get("last_name")
-        or address.get("last_name")
-        or ""
-    )
-    name = " ".join(part for part in (str(first), str(last)) if part).strip()
-
-    return Extracted(handles=handles, facts={"name": name} if name else {})
+ENTRIES: List[CatalogEntry] = [
+    _entry("orders/create", "Order placed", _order_fields()),
+    _entry("orders/paid", "Order paid", _order_fields()),
+    _entry(
+        "orders/cancelled",
+        "Order cancelled",
+        [
+            *_order_fields(),
+            _f(
+                "payload.cancel_reason",
+                "choice",
+                "Cancel reason",
+                values=CANCEL_REASONS,
+            ),
+            _f("payload.cancelled_at", "datetime", "Cancelled at"),
+        ],
+    ),
+    _entry("checkouts/create", "Checkout started", _checkout_fields()),
+    _entry("checkouts/update", "Checkout updated", _checkout_fields()),
+]

--- a/app/crm/record/schemas.py
+++ b/app/crm/record/schemas.py
@@ -9,7 +9,7 @@ commerce) populate the same shape instead of the schema growing per arm.
 """
 
 from datetime import datetime
-from typing import Any, Dict, Literal, Optional
+from typing import Any, Dict, List, Literal, Optional
 from uuid import UUID
 
 from pydantic import AwareDatetime, BaseModel, ConfigDict, Field
@@ -53,6 +53,9 @@ class Extracted(BaseModel):
     handles: Dict[str, str] = {}
     facts: Dict[str, Any] = {}
     about: Literal["customer", "merchant"] = ABOUT_CUSTOMER
+    # Declared template fill-ins (catalog fields flagged variable), resolved
+    # by the engine at decode so no consumer re-reads the payload.
+    variables: Dict[str, Any] = {}
 
 
 class RawEvent(BaseModel):
@@ -116,3 +119,99 @@ class EventReceipt(BaseModel):
 
     id: Optional[UUID] = None
     duplicate: bool = False
+
+
+# --- The event catalog (design/event-catalog.md, canon T24) ------------------
+
+# The closed type set a registration may use — each maps one-to-one onto the
+# where-grammar's operators (record/catalog.py OPS_BY_TYPE). Unknown types
+# are rejected at registration, never discovered at flow-publish.
+FieldType = Literal["text", "number", "choice", "boolean", "datetime", "phone"]
+IdentityRole = Literal["phone", "name", "email", "shopify_customer_id"]
+
+
+class CatalogField(BaseModel):
+    """One field of one event. `path` is identity (payload.gateway, or a bare
+    derived name like items_count); `label` is presentation and renames
+    freely. `ops` is filled by the catalog from the type — never authored."""
+
+    path: str
+    type: FieldType
+    label: str
+    keyable: bool = False
+    variable: bool = False
+    values: List[str] = Field(default_factory=list)
+    identity: Optional[IdentityRole] = None
+    derived: bool = False
+    deprecated: bool = False
+    # Code layer only: alternate paths tried in order after `path` (Shopify
+    # keeps a phone in four places). A registration may not carry them —
+    # precedence chains in jsonb are the DSL the ruling forbids.
+    fallbacks: List[str] = Field(default_factory=list)
+    ops: List[str] = Field(default_factory=list)
+
+
+class CatalogEntry(BaseModel):
+    """(source, topic) -> what this event is and what's inside it. `layer`
+    says who declared it: our code, or the vendor's registration (T24 row).
+    The editor is layer-blind."""
+
+    source: str
+    topic: str
+    label: str
+    group: str
+    layer: Literal["code", "registered"]
+    # WHO the letters of this topic are about (Extracted.about): a person
+    # (the default — no handle is a quarantine) or the MERCHANT (a template
+    # review, an account notice: no person by design, NULL customer, every
+    # consumer still hears it). The engine's vocabulary, so a source whose
+    # letters are merchant-level (WhatsApp's template/account topics) is a
+    # declared spec like any other — never a hand-written extractor.
+    about: Literal["customer", "merchant"] = ABOUT_CUSTOMER
+    goalable: bool = True
+    status: Literal["registered", "detected"] = "registered"
+    version: int = 1
+    fields: List[CatalogField] = Field(default_factory=list)
+    seen_7d: int = 0
+
+
+class SchemaRegistration(BaseModel):
+    """What a push vendor (or our ops, via the wizard) signs: the whole
+    field list for one topic, in OUR language."""
+
+    source: str = Field(min_length=1, max_length=64)
+    topic: str = Field(min_length=1, max_length=128)
+    label: str = Field(min_length=1, max_length=120)
+    fields: List[CatalogField] = Field(min_length=1)
+
+
+class EventSchema(BaseModel):
+    """One crm_event_schema row (T24)."""
+
+    id: str
+    merchant_id: str
+    source: str
+    topic: str
+    label: Optional[str]
+    fields: List[CatalogField]
+    status: str
+    version: int
+    registered_by: Optional[str]
+    first_seen_at: Optional[datetime]
+    created_at: datetime
+    updated_at: datetime
+
+
+class TopicCount(BaseModel):
+    source: str
+    topic: str
+    seen: int
+
+
+class SampledField(BaseModel):
+    """The wizard's pre-fill: one key seen in a vendor's recent traffic."""
+
+    path: str
+    type_guess: FieldType
+    seen: int
+    samples: List[Any]

--- a/app/crm/record/workers.py
+++ b/app/crm/record/workers.py
@@ -2,41 +2,62 @@
 claim a batch, then per row extract -> resolve() -> assert_facts() -> entry
 rules -> stamp, one commit.
 
-The pass knows no source by name: which extractor reads a payload is the
-registry's business (record/extractors), and this file only asks it."""
+The pass knows no source by name: which spec reads a payload is the
+catalog's business (record/catalog, record/extractors), and this file only
+asks it."""
 
 from datetime import datetime, timezone
-from typing import Dict, List, NamedTuple, Optional
+from typing import Any, Dict, List, NamedTuple, Optional
 
 from app.core.config.static import CRM_EVENT_MAX_ATTEMPTS
 from app.core.logger import logger
 from app.crm.identity.contracts import assert_facts, resolve as crm_resolve
+from app.crm.record import catalog
 from app.crm.record.consumers import consumers
 from app.crm.record.db import DbTxn, accessor, atomically, savepoint
-from app.crm.record.extractors import DEFAULT_EXTRACTOR, EXTRACTORS
-from app.crm.record.schemas import ABOUT_MERCHANT, RawEvent
+from app.crm.record.extractors import EXTRACTORS, engine
+from app.crm.record.extractors.engine import EMPTY_SPEC, DecodeSpec
+from app.crm.record.schemas import ABOUT_MERCHANT, Extracted, RawEvent
 
 
 async def run_pass(limit: int) -> List[RawEvent]:
     """One whole pass, claim through commit. Returns the rows it CLAIMED, so a
-    fully quarantined batch still reads as work rather than as an empty queue."""
-    return await atomically(_pass_in_txn, limit)
+    fully quarantined batch still reads as work rather than as an empty queue.
+
+    Discovered topics are marked known only HERE, after the commit: a
+    nudge row written inside a row's savepoint and rolled back by a later
+    raise in that row must not be remembered as written, or the process
+    never retries it (only a restart would)."""
+    discovered: List[catalog.SchemaKey] = []
+    events = await atomically(_pass_in_txn, limit, discovered)
+    for key in discovered:
+        catalog.mark_known(key)
+    return events
 
 
-async def _pass_in_txn(txn: DbTxn, limit: int) -> List[RawEvent]:
+async def _pass_in_txn(
+    txn: DbTxn, limit: int, discovered: Optional[List[catalog.SchemaKey]] = None
+) -> List[RawEvent]:
     """ATOMIC: the claim and every stamp it authorises share one commit — the
     FOR UPDATE SKIP LOCKED lock lives exactly as long as this transaction, so
     a stamp can never outlive its claim. resolve(), assert_facts() and the
     entry-rules call are NOT in this atom: each commits independently, so a
-    replay is made safe by their idempotency, not by this rollback."""
+    replay is made safe by their idempotency, not by this rollback.
+
+    ``discovered`` collects the nudge rows that SURVIVED their savepoint;
+    run_pass marks them once the commit is real."""
+    discovered = [] if discovered is None else discovered
     events = await accessor.claim_pending_events(txn, limit)
     _log_queue_lag(events, limit)
     for event in events:
         try:
             async with savepoint(txn):
-                await _process_one(txn, event)
+                key = await _process_one(txn, event, discovered)
         except Exception as e:
             await _after_failed_row(txn, event, e)
+            continue
+        if key is not None and key not in discovered:
+            discovered.append(key)
     return events
 
 
@@ -79,29 +100,46 @@ async def _after_failed_row(txn: DbTxn, event: RawEvent, error: Exception) -> No
 class _Processed(NamedTuple):
     """What the processor made of one row: the customer it is about (None
     for a merchant-level letter — canon T13 col 14's "processed but not
-    about a person"), the handles the extractor found, and whether the row
-    quarantined itself (then nothing else may touch it)."""
+    about a person"), the handles the spec found the person by, the
+    template fill-ins the catalog declared for this (source, topic) —
+    resolved by the engine at decode so no consumer re-reads the payload —
+    and whether the row quarantined itself (then nothing else may touch
+    it)."""
 
     customer_id: Optional[str]
     handles: Dict[str, str]
+    variables: Dict[str, Any]
     quarantined: bool
 
 
-async def _process_one(txn: DbTxn, event: RawEvent) -> None:
+async def _process_one(
+    txn: DbTxn, event: RawEvent, discovered: Optional[List[catalog.SchemaKey]] = None
+) -> Optional[catalog.SchemaKey]:
     """One row, inside the caller's savepoint. A quarantine stamped itself
     already and names no customer, so it returns early. A merchant-level
     letter (``Extracted.about == "merchant"``) is processed with a NULL
     customer: every consumer still hears it, and the stamp writes
-    processed_at with customer_id NULL — forever, correctly."""
+    processed_at with customer_id NULL — forever, correctly.
+
+    Returns the (merchant, source, topic) whose nudge row this row wrote,
+    for run_pass to mark known after the commit — None when nothing was
+    written."""
+    key = await _discover_topic(txn, event, discovered or [])
     outcome = await _run_processor(txn, event)
     if outcome.quarantined:
-        return
-    await _consume_attributed_event(event, outcome.customer_id, outcome.handles)
+        return key
+    await _consume_attributed_event(
+        event, outcome.customer_id, outcome.handles, outcome.variables
+    )
     await accessor.stamp_event(txn, str(event.id), outcome.customer_id)
+    return key
 
 
 async def _consume_attributed_event(
-    event: RawEvent, customer_id: Optional[str], handles: Dict[str, str]
+    event: RawEvent,
+    customer_id: Optional[str],
+    handles: Dict[str, str],
+    variables: Optional[Dict[str, Any]] = None,
 ) -> None:
     """Consumer slot: per row, inside its savepoint, before its stamp, so a
     poison consumer costs one row per poll. A raise here leaves the row
@@ -113,38 +151,80 @@ async def _consume_attributed_event(
     an account notice): the letter still reaches every consumer, and each
     decides whether a letter with no person is its business.
 
-    The extractor's handles ride along so no consumer re-hunts what this
-    pass already found. Two searches would drift — and did: a Shopify
-    order with its phone only in customer.default_address resolved here and
-    then parked at the first call node, because the payload re-search did
-    not know that path."""
+    The spec's handles and variables ride along so no consumer re-hunts
+    what this pass already found. Two searches would drift — and did: a
+    Shopify order with its phone only in customer.default_address resolved
+    here and then parked at the first call node, because the payload
+    re-search did not know that path."""
     for consume in consumers():
-        await consume(event, customer_id, handles)
+        await consume(event, customer_id, handles, variables or {})
+
+
+async def _discover_topic(
+    txn: DbTxn, event: RawEvent, discovered: List[catalog.SchemaKey]
+) -> Optional[catalog.SchemaKey]:
+    """The unregistered-topic nudge (canon T24): one INSERT per new
+    (merchant, source, topic) EVER; the in-process known-set means the hot
+    path never probes. Inside the row's savepoint — a failure here fails
+    the row, so the nudge can never be lost silently. The key is marked
+    known by run_pass AFTER the commit (a rolled-back row's nudge is not a
+    written nudge); within one pass, ``discovered`` (the rows that already
+    wrote it and survived) spares the repeat INSERT."""
+    key = (event.merchant_id, event.source, event.topic)
+    if catalog.is_known(key) or key in discovered:
+        return None
+    if catalog.code_spec(event.source, event.topic) is not None:
+        # The code layer already declares this event: there is nothing to
+        # nudge anyone to register, and a detected row here would be noise
+        # the merge has to ignore. Nothing written, so mark at once.
+        catalog.mark_known(key)
+        return None
+    await accessor.insert_detected_schema(
+        txn, event.merchant_id, event.source, event.topic
+    )
+    return key
+
+
+def _extract(event: RawEvent, spec: DecodeSpec) -> Extracted:
+    """The decode step (pure). One engine, two spec sources: the letter is
+    read by its spec — a code CatalogEntry or the vendor's registration —
+    over the flat shape. The few sources still decoding by hand (EXTRACTORS)
+    keep their function until they become specs; a code-catalog source is
+    never in both (pinned)."""
+    extract = EXTRACTORS.get(event.source)
+    if extract is not None:
+        return extract(event.payload)
+    return engine.extract(event.payload, spec)
 
 
 async def _run_processor(txn: DbTxn, event: RawEvent) -> _Processed:
     """extract -> resolve() (or pass through a set customer_id) -> assert_facts().
     Quarantines what it cannot attribute; a failed assert_facts never fails the row.
 
-    Returns the customer AND the handles the extractor found, so the one
-    source-aware discovery in the system is this one. A letter the
-    extractor declares ABOUT THE MERCHANT skips resolve() and facts — there
-    is no person to find or describe — and comes back with no customer and
-    no quarantine: processed, NULL, correctly (canon T13 col 14)."""
-    extract = EXTRACTORS.get(event.source, DEFAULT_EXTRACTOR)
+    Returns the customer, the handles the engine found the person by, and
+    the template variables the catalog declared — so the one source-aware
+    read of the payload in the system is this one. A letter the spec
+    declares ABOUT THE MERCHANT skips resolve() and facts — there is no
+    person to find or describe — and comes back with no customer and no
+    quarantine: processed, NULL, correctly (canon T13 col 14)."""
+    spec = EMPTY_SPEC
+    if event.source not in EXTRACTORS:
+        # Code layer: pure. Registered layer: a cached read (T24 stays cold).
+        # A failure here raises: the row stays pending and returns next poll
+        # — never a terminal quarantine.
+        spec = await catalog.decode_spec(event.merchant_id, event.source, event.topic)
     try:
-        extracted = extract(event.payload)
+        extracted = _extract(event, spec)
     except Exception as e:
         await accessor.quarantine_event(txn, str(event.id), f"extractor_error: {e}")
-        return _Processed(None, {}, quarantined=True)
-
+        return _Processed(None, {}, {}, quarantined=True)
     customer_id = event.customer_id
     if not customer_id and extracted.about == ABOUT_MERCHANT:
-        return _Processed(None, {}, quarantined=False)
+        return _Processed(None, {}, extracted.variables, quarantined=False)
     if not customer_id:
         if not extracted.handles:
             await accessor.quarantine_event(txn, str(event.id), "no_handle")
-            return _Processed(None, {}, quarantined=True)
+            return _Processed(None, {}, {}, quarantined=True)
         try:
             customer_id = str(
                 await crm_resolve(
@@ -156,8 +236,7 @@ async def _run_processor(txn: DbTxn, event: RawEvent) -> _Processed:
             )
         except ValueError as e:
             await accessor.quarantine_event(txn, str(event.id), f"unresolvable: {e}")
-            return _Processed(None, {}, quarantined=True)
-
+            return _Processed(None, {}, {}, quarantined=True)
     if extracted.facts:
         try:
             await assert_facts(
@@ -169,7 +248,9 @@ async def _run_processor(txn: DbTxn, event: RawEvent) -> _Processed:
             )
         except Exception as e:
             logger.warning(f"event {event.id}: assert_facts failed, dropping: {e}")
-    return _Processed(customer_id, extracted.handles, quarantined=False)
+    return _Processed(
+        customer_id, extracted.handles, extracted.variables, quarantined=False
+    )
 
 
 def _log_queue_lag(events: List[RawEvent], limit: int) -> None:

--- a/app/crm/shared/predicate.py
+++ b/app/crm/shared/predicate.py
@@ -1,0 +1,143 @@
+"""The where-grammar (design/event-catalog.md §The where-grammar, sealed
+1 Sep 2026): ONE closed op set and ONE evaluator, shared by the publish
+validator (outreach/plans.py) and the entry processor (outreach/entry.py).
+The same predicate shape compiles to SQL for phase-2 segments — an op lands
+here + the catalog's OPS_BY_TYPE + the SQL compiler together, or not at all.
+
+Leaf by law: imports nothing internal.
+
+Evaluation is deliberately conservative: a field that is MISSING from the
+payload satisfies no op except nothing — not even `is_not` — so a filter
+gone stale never quietly widens who gets contacted; and the `is` family
+compares text exactly (no numeric coercion — that is `=`'s job).
+"""
+
+import re
+from datetime import datetime
+from typing import Any, Callable, Iterable, List, Literal, Optional
+
+from pydantic import BaseModel, Field, model_validator
+
+Op = Literal["is", "is_not", "in", ">", ">=", "<", "<=", "=", "exists"]
+# The op FAMILIES, by what they compare. The catalog's OPS_BY_TYPE (record/
+# catalog.py) is built from these, so a type's allowed ops and the evaluator
+# that runs them cannot drift apart.
+TEXT_OPS = ("is", "is_not", "in")  # exact text, never coerced
+ORDER_OPS = (">", ">=", "<", "<=")  # numbers or datetimes
+EQUALS_OP = "="  # numbers only
+EXISTS_OP = "exists"
+_NUMBER = re.compile(r"^-?\d+(\.\d+)?$")
+
+
+class Condition(BaseModel):
+    """One typed condition: `field` is a catalog path (payload.gateway or a
+    derived name), `op` one of the closed set, `value` shaped by the op."""
+
+    field: str = Field(min_length=1)
+    op: Op
+    value: Any = None
+
+    @model_validator(mode="after")
+    def _value_matches_op(self) -> "Condition":
+        if self.op == "in":
+            if not isinstance(self.value, list) or not self.value:
+                raise ValueError("'in' needs a non-empty list value")
+            if any(isinstance(v, (list, dict)) or v is None for v in self.value):
+                raise ValueError("'in' values must be scalars")
+        elif self.op == "exists":
+            if self.value is not None:
+                raise ValueError("'exists' takes no value")
+        elif self.value is None or isinstance(self.value, (list, dict)):
+            raise ValueError(f"{self.op!r} needs a scalar value")
+        return self
+
+
+def as_number(value: Any) -> Optional[float]:
+    """Numbers, and numeric strings (Shopify posts money as "1850.00") —
+    never booleans, never anything else."""
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str) and _NUMBER.match(value.strip()):
+        return float(value.strip())
+    return None
+
+
+def _as_datetime(value: Any) -> Optional[datetime]:
+    if isinstance(value, datetime):
+        return value
+    if isinstance(value, str):
+        try:
+            return datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError:
+            return None
+    return None
+
+
+def _same(a: Any, b: Any) -> bool:
+    """The `is` family compares like with like, strictly: text with text,
+    a boolean with a boolean, a number with a number — never across. The
+    catalog puts numbers under `=` and the ordering ops, so `is` needs no
+    coercion; with it, "007" matched "7", 1.0 matched "1" and True matched
+    "true" on a text field, which widens who gets contacted."""
+    if isinstance(a, bool) or isinstance(b, bool):
+        return isinstance(a, bool) and isinstance(b, bool) and a == b
+    if isinstance(a, str) or isinstance(b, str):
+        return isinstance(a, str) and isinstance(b, str) and a == b
+    if isinstance(a, (int, float)) and isinstance(b, (int, float)):
+        return a == b
+    return False
+
+
+def _ordered(op: str, actual: Any, expected: Any) -> bool:
+    a, b = as_number(actual), as_number(expected)
+    if a is None or b is None:
+        da, db = _as_datetime(actual), _as_datetime(expected)
+        if da is None or db is None:
+            return False
+        if (da.tzinfo is None) != (db.tzinfo is None):
+            return False
+        a, b = da.timestamp(), db.timestamp()
+    if op == ">":
+        return a > b
+    if op == ">=":
+        return a >= b
+    if op == "<":
+        return a < b
+    return a <= b
+
+
+def evaluate(condition: Condition, actual: Any) -> bool:
+    """One condition against the value the payload holds at its field.
+    None = the field is absent: only `exists` has an opinion (no)."""
+    if actual is None:
+        return False
+    op = condition.op
+    if op == "exists":
+        return True
+    if op == "is":
+        return _same(actual, condition.value)
+    if op == "is_not":
+        return not _same(actual, condition.value)
+    if op == "in":
+        return any(_same(actual, v) for v in condition.value)
+    if op == "=":
+        a, b = as_number(actual), as_number(condition.value)
+        return a is not None and b is not None and a == b
+    return _ordered(op, actual, condition.value)
+
+
+def matches(conditions: Iterable[Condition], lookup: Callable[[str], Any]) -> bool:
+    """ANDed. `lookup(path)` is the caller's field resolver (record's
+    field_value: payload dot-paths + derived fields)."""
+    return all(evaluate(c, lookup(c.field)) for c in conditions)
+
+
+def from_equality_map(mapping: dict) -> List[Condition]:
+    """The pre-catalog `where` shape ({"gateway": "COD"}) as conditions —
+    what migration 069 does in SQL, for tests and tooling."""
+    return [
+        Condition(field=f"payload.{key}", op="is", value=value)
+        for key, value in mapping.items()
+    ]

--- a/app/database/migrations/068_create_crm_event_schema.sql
+++ b/app/database/migrations/068_create_crm_event_schema.sql
@@ -1,0 +1,53 @@
+-- 068: crm_event_schema (canon T24, sealed 1 Sep 2026) — the REGISTERED
+-- contract for a push vendor's events (design/event-catalog.md §Vendor
+-- events). One row per (merchant, source, topic); the fields document is
+-- the whole registration; the row is cold by design.
+--
+-- Numbering trail: sealed as 060 on 1 Sep; #1037 took 060, #1050 took 061
+-- (crm_channel_template) and the workflow rollout took 062-064, so this is
+-- 068 — the next free number at implementation time (docs/crm/migrations.md).
+--
+-- Deliberate shape (canon T24 notes):
+--   * fields jsonb is ONE document [{path, type, label, keyable, variable,
+--     values[], identity, deprecated}], never per-field rows. The type
+--     vocabulary lives in the REGISTRATION VALIDATOR (record/catalog.py),
+--     never a CHECK — the 027 scar. `identity` is a ROLE (phone | name), at
+--     most one field per role: the vendor keeps THEIR names (rider_phone)
+--     and the mapping tells decode where the handle lives.
+--   * status IS a CHECK (closed lifecycle, like T19/T20): detected = the
+--     event worker's discovery upsert saw an unregistered topic (fields
+--     empty — the nudge row); registered = a human/vendor signed the
+--     schema. Registration upgrades the same row.
+--   * version bumps on every re-registration — the audit stamp (T19's
+--     precedent); removals are deprecations inside `fields`, never deletes.
+--   * first_seen_at is written ONCE by discovery. No per-event counters
+--     here — "312 this week" is computed on read from crm_event_raw.
+--   * UNIQUE (merchant_id, source, topic): merchant-first per tenancy law.
+--
+-- Readers: the catalog API merges these rows with the code CATALOG; the
+-- publish validator receives the merged catalog as an argument. The FLOW
+-- runtime (entry evaluator, walker) never reads this table; the DECODE
+-- step reads only the cached identity mapping.
+
+CREATE TABLE crm_event_schema (
+    id            uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    merchant_id   text NOT NULL,
+    source        text NOT NULL,
+    topic         text NOT NULL,
+    label         text,
+    fields        jsonb NOT NULL DEFAULT '[]'::jsonb,
+    status        text NOT NULL DEFAULT 'detected'
+                  CHECK (status IN ('detected', 'registered')),
+    version       integer NOT NULL DEFAULT 0,
+    registered_by text,
+    first_seen_at timestamptz,
+    created_at    timestamptz NOT NULL DEFAULT now(),
+    updated_at    timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX crm_event_schema_topic_uq
+    ON crm_event_schema (merchant_id, source, topic);
+
+CREATE TRIGGER crm_event_schema_touch
+    BEFORE UPDATE ON crm_event_schema
+    FOR EACH ROW EXECUTE FUNCTION crm_touch_updated_at();

--- a/app/database/migrations/069_migrate_workflow_where_to_conditions.sql
+++ b/app/database/migrations/069_migrate_workflow_where_to_conditions.sql
@@ -1,0 +1,82 @@
+-- 069: entry.where graduates from an equality map to typed conditions
+-- (design/event-catalog.md §The where-grammar; companion ruling 1 Sep 2026:
+-- "legacy entry.where equality maps -> ONE migration to the typed condition
+-- list (definition + draft), validator accepts lists only").
+--
+--   {"gateway": "COD"}  ->  [{"field": "payload.gateway", "op": "is", "value": "COD"}]
+--
+-- Data-only; touches crm_workflow (outreach) and nothing else. Idempotent:
+-- only documents (or doors) whose where is still an object are rewritten,
+-- so a re-run is a no-op. Both entry shapes: the single object and the
+-- list of doors (phase 15). The touch trigger stamps updated_at; version
+-- is NOT bumped (no publish happened — the plan's meaning is unchanged).
+
+UPDATE crm_workflow
+SET definition = jsonb_set(
+    definition,
+    '{entry,where}',
+    COALESCE(
+        (SELECT jsonb_agg(jsonb_build_object(
+                    'field', 'payload.' || e.key, 'op', 'is', 'value', e.value))
+         FROM jsonb_each(definition -> 'entry' -> 'where') AS e),
+        '[]'::jsonb)
+)
+WHERE jsonb_typeof(definition -> 'entry' -> 'where') = 'object';
+
+UPDATE crm_workflow
+SET draft = jsonb_set(
+    draft,
+    '{entry,where}',
+    COALESCE(
+        (SELECT jsonb_agg(jsonb_build_object(
+                    'field', 'payload.' || e.key, 'op', 'is', 'value', e.value))
+         FROM jsonb_each(draft -> 'entry' -> 'where') AS e),
+        '[]'::jsonb)
+)
+WHERE jsonb_typeof(draft -> 'entry' -> 'where') = 'object';
+
+-- The list shape (rollout phase 15): a plan's entry may be a LIST of doors,
+-- each with its own where. The object-shape UPDATEs above see NULL at
+-- entry->where for those, so every door is rebuilt here — only the doors
+-- still holding a map change, order kept, and a list with no map is not
+-- touched at all (idempotent, same as above).
+
+UPDATE crm_workflow
+SET definition = jsonb_set(
+    definition,
+    '{entry}',
+    (SELECT jsonb_agg(
+                CASE WHEN jsonb_typeof(d -> 'where') = 'object'
+                     THEN jsonb_set(d, '{where}', COALESCE(
+                              (SELECT jsonb_agg(jsonb_build_object(
+                                          'field', 'payload.' || e.key,
+                                          'op', 'is', 'value', e.value))
+                               FROM jsonb_each(d -> 'where') AS e),
+                              '[]'::jsonb))
+                     ELSE d
+                END ORDER BY ord)
+     FROM jsonb_array_elements(definition -> 'entry') WITH ORDINALITY AS t(d, ord))
+)
+WHERE jsonb_typeof(definition -> 'entry') = 'array'
+  AND EXISTS (SELECT 1 FROM jsonb_array_elements(definition -> 'entry') AS d
+              WHERE jsonb_typeof(d -> 'where') = 'object');
+
+UPDATE crm_workflow
+SET draft = jsonb_set(
+    draft,
+    '{entry}',
+    (SELECT jsonb_agg(
+                CASE WHEN jsonb_typeof(d -> 'where') = 'object'
+                     THEN jsonb_set(d, '{where}', COALESCE(
+                              (SELECT jsonb_agg(jsonb_build_object(
+                                          'field', 'payload.' || e.key,
+                                          'op', 'is', 'value', e.value))
+                               FROM jsonb_each(d -> 'where') AS e),
+                              '[]'::jsonb))
+                     ELSE d
+                END ORDER BY ord)
+     FROM jsonb_array_elements(draft -> 'entry') WITH ORDINALITY AS t(d, ord))
+)
+WHERE jsonb_typeof(draft -> 'entry') = 'array'
+  AND EXISTS (SELECT 1 FROM jsonb_array_elements(draft -> 'entry') AS d
+              WHERE jsonb_typeof(d -> 'where') = 'object');

--- a/docs/crm/migrations.md
+++ b/docs/crm/migrations.md
@@ -64,7 +64,9 @@ Rules the template encodes:
   the writes (identity → crm_customer; platform → platform_identity, Permission
   squad owns it; permission →
   crm_consent_*, crm_decision_log; connectivity → installations, bindings,
-  templates, crm_message; record → crm_event_raw; outreach →
+  templates, crm_message; record → crm_event_raw and `crm_event_schema`
+  (068, canon T24 — a push vendor's registered event schema, one row per
+  (merchant, source, topic); `status` is a closed enum in a CHECK); outreach →
   segments/workflows/broadcasts — note the P2 outreach table must be
   `crm_campaign` to avoid colliding with buddy's existing `campaign`;
   `crm_workflow_version` (064, ADR 0023) is outreach's too — the
@@ -93,3 +95,7 @@ Rules the template encodes:
   the run's own cart can say "recovered" while any other order still ends
   the run, distinguishably). A new reason is a migration that re-creates
   the constraint under its explicit name, never an edit to 058/063.
+- `crm_workflow.definition/draft -> entry.where` is a typed condition list
+  (069 rewrote the pre-catalog equality maps in place; data-only). Rows in
+  `crm_workflow_version` are immutable and were NOT rewritten — the entry
+  model converts a legacy map on read, so a pinned document still parses.

--- a/docs/crm/plans/README.md
+++ b/docs/crm/plans/README.md
@@ -22,6 +22,18 @@ in `stages.on_idle`; a stage may name its own under
 (`cart_recovery_1`) resolved against the merchant's approved templates;
 publish refuses an unknown or unapproved one (phase 08).
 
+A send node's `variables` map (`{"1": "customer_name"}`) is the ONLY
+thing posted to the provider as template fill-ins — one entry per blank,
+the fact a declared `variable` field of the entry topic (or
+`current_node` / `current_stage`, or a listened square's
+`facts_<square>_<key>`). The cart boards map `{{1}}` ← `customer_name`;
+edit the map to the merchant's approved template before publishing (the
+runbook's step 3). `test_plan_templates` validates every board against the
+CODE catalog (Shopify's declared fields); the loan board's `loan.*` topics
+are a vendor's, so the test supplies the registration the vendor signs at
+enrollment (`payload.application_id`, keyable) — publish on a real
+merchant needs that same `POST /ingest/schemas` first.
+
 `on_publish` (ADR 0023): the loan board declares `pin` — a journey lives
 for weeks and finishes on the document it entered under; a fix reaches
 the runs in flight only through the migrate-forward route. The cart

--- a/docs/crm/plans/cart-recovery-fallback.json
+++ b/docs/crm/plans/cart-recovery-fallback.json
@@ -41,7 +41,10 @@
       "id": "wa-nudge",
       "type": "send",
       "channel": "whatsapp",
-      "template": "cart_recovery_1"
+      "template": "cart_recovery_1",
+      "variables": {
+        "1": "customer_name"
+      }
     },
     {
       "id": "wait-30m-2",
@@ -70,7 +73,10 @@
       "id": "wa-fallback",
       "type": "send",
       "channel": "whatsapp",
-      "template": "cart_recovery_2"
+      "template": "cart_recovery_2",
+      "variables": {
+        "1": "customer_name"
+      }
     },
     {
       "id": "wait-1d",

--- a/docs/crm/plans/cart-recovery.json
+++ b/docs/crm/plans/cart-recovery.json
@@ -41,7 +41,10 @@
       "id": "wa-nudge",
       "type": "send",
       "channel": "whatsapp",
-      "template": "cart_recovery_1"
+      "template": "cart_recovery_1",
+      "variables": {
+        "1": "customer_name"
+      }
     },
     {
       "id": "wait-30m-2",

--- a/docs/crm/runbooks/cart-recovery.md
+++ b/docs/crm/runbooks/cart-recovery.md
@@ -31,6 +31,15 @@ Paths below carry no `crm` segment on purpose: the CRM routers mount at the app 
    automatically: check with the connectivity owner. A send against an
    unapproved template is `blocked / template_not_approved`; the run
    still continues to the call.
+   **Map the template's blanks.** A send node posts EXACTLY the facts its
+   `variables` map names — `{"1": "customer_name"}` fills positional
+   `{{1}}`; a named template maps `{"name": "customer_name"}` — and
+   nothing when the map is empty. The plans ship with `{{1}}` ←
+   `customer_name`; if your approved `cart_recovery_1` has more blanks
+   (or none), edit the map to match before publishing: a count mismatch
+   is a terminal provider refusal on every send. Every fact must be a
+   declared `variable` field of the entry topic (`GET /catalog`), or
+   `current_node` / `current_stage`.
 4. **A Breeze Buddy call template** for the rescue call, belonging to the
    merchant (or global), with a `call_execution_config`. Its id replaces
    `TEMPLATE_ID_PLACEHOLDER`. Calls obey buddy's own calling hours,

--- a/scripts/check_crm_boundaries.py
+++ b/scripts/check_crm_boundaries.py
@@ -59,6 +59,7 @@ TABLE_OWNERS = {
     "crm_customer": "identity",
     "platform_identity": "platform",
     "crm_event_raw": "record",
+    "crm_event_schema": "record",
     "crm_journey_event": "record",
     "crm_message": "connectivity",
     "crm_workflow": "outreach",

--- a/tests/crm/fixtures/shopify/checkouts_create.json
+++ b/tests/crm/fixtures/shopify/checkouts_create.json
@@ -1,0 +1,39 @@
+{
+  "id": 36201000011,
+  "token": "ck-77aa2b3c4d5e",
+  "cart_token": "c1-3f9a2b8e7d6c5b4a",
+  "email": "priya.sharma@example.com",
+  "phone": null,
+  "gateway": null,
+  "buyer_accepts_marketing": false,
+  "created_at": "2026-09-02T10:05:11+05:30",
+  "updated_at": "2026-09-02T10:05:11+05:30",
+  "completed_at": null,
+  "abandoned_checkout_url": "https://demo-store.myshopify.com/12345/checkouts/ck-77aa2b3c4d5e/recover?key=abc",
+  "currency": "INR",
+  "subtotal_price": "2499.00",
+  "total_tax": "0.00",
+  "total_price": "2499.00",
+  "presentment_currency": "INR",
+  "source_name": "web",
+  "customer": {
+    "id": 7011200034,
+    "email": "priya.sharma@example.com",
+    "first_name": "Priya",
+    "last_name": "Sharma",
+    "phone": null,
+    "default_address": null
+  },
+  "billing_address": null,
+  "shipping_address": null,
+  "line_items": [
+    {
+      "id": 1301,
+      "title": "Air Runner Sneakers",
+      "quantity": 1,
+      "price": "2499.00",
+      "sku": "AR-42",
+      "variant_title": "42 / White"
+    }
+  ]
+}

--- a/tests/crm/fixtures/shopify/checkouts_create_returning.json
+++ b/tests/crm/fixtures/shopify/checkouts_create_returning.json
@@ -1,0 +1,39 @@
+{
+  "id": 36201000012,
+  "token": "ck-88bb3c4d5e6f",
+  "cart_token": "c1-returning-33cc",
+  "email": "priya.sharma@example.com",
+  "phone": "+919876543210",
+  "gateway": "Cash on Delivery (COD)",
+  "buyer_accepts_marketing": false,
+  "created_at": "2026-09-02T10:05:11+05:30",
+  "updated_at": "2026-09-02T10:05:11+05:30",
+  "completed_at": null,
+  "abandoned_checkout_url": "https://demo-store.myshopify.com/12345/checkouts/ck-77aa2b3c4d5e/recover?key=abc",
+  "currency": "INR",
+  "subtotal_price": "2499.00",
+  "total_tax": "0.00",
+  "total_price": "2499.00",
+  "presentment_currency": "INR",
+  "source_name": "web",
+  "customer": {
+    "id": 7011200034,
+    "email": "priya.sharma@example.com",
+    "first_name": "Priya",
+    "last_name": "Sharma",
+    "phone": "+91 98765 43210",
+    "default_address": null
+  },
+  "billing_address": null,
+  "shipping_address": null,
+  "line_items": [
+    {
+      "id": 1301,
+      "title": "Air Runner Sneakers",
+      "quantity": 1,
+      "price": "2499.00",
+      "sku": "AR-42",
+      "variant_title": "42 / White"
+    }
+  ]
+}

--- a/tests/crm/fixtures/shopify/checkouts_update.json
+++ b/tests/crm/fixtures/shopify/checkouts_update.json
@@ -1,0 +1,71 @@
+{
+  "id": 36201000011,
+  "token": "ck-77aa2b3c4d5e",
+  "cart_token": "c1-3f9a2b8e7d6c5b4a",
+  "email": "priya.sharma@example.com",
+  "phone": "+919876543210",
+  "gateway": "Cash on Delivery (COD)",
+  "buyer_accepts_marketing": false,
+  "created_at": "2026-09-02T10:05:11+05:30",
+  "updated_at": "2026-09-02T10:09:48+05:30",
+  "completed_at": null,
+  "abandoned_checkout_url": "https://demo-store.myshopify.com/12345/checkouts/ck-77aa2b3c4d5e/recover?key=abc",
+  "currency": "INR",
+  "subtotal_price": "3097.00",
+  "total_tax": "0.00",
+  "total_price": "3097.00",
+  "presentment_currency": "INR",
+  "source_name": "web",
+  "customer": {
+    "id": 7011200034,
+    "email": "priya.sharma@example.com",
+    "first_name": "Priya",
+    "last_name": "Sharma",
+    "phone": "+91 98765 43210",
+    "default_address": {
+      "first_name": "Priya",
+      "last_name": "Sharma",
+      "city": "Bengaluru",
+      "country_code": "IN",
+      "phone": "+91 98765 43210"
+    }
+  },
+  "billing_address": {
+    "first_name": "Priya",
+    "last_name": "Sharma",
+    "address1": "12 MG Road",
+    "city": "Bengaluru",
+    "province": "Karnataka",
+    "country_code": "IN",
+    "zip": "560001",
+    "phone": "+91 98765 43210"
+  },
+  "shipping_address": {
+    "first_name": "Priya",
+    "last_name": "Sharma",
+    "address1": "12 MG Road",
+    "city": "Bengaluru",
+    "province": "Karnataka",
+    "country_code": "IN",
+    "zip": "560001",
+    "phone": "+91 98765 43210"
+  },
+  "line_items": [
+    {
+      "id": 1301,
+      "title": "Air Runner Sneakers",
+      "quantity": 1,
+      "price": "2499.00",
+      "sku": "AR-42",
+      "variant_title": "42 / White"
+    },
+    {
+      "id": 1302,
+      "title": "Ankle Socks (3 pack)",
+      "quantity": 2,
+      "price": "299.00",
+      "sku": "SK-3",
+      "variant_title": null
+    }
+  ]
+}

--- a/tests/crm/fixtures/shopify/orders_cancelled.json
+++ b/tests/crm/fixtures/shopify/orders_cancelled.json
@@ -1,0 +1,89 @@
+{
+  "id": 5201000001,
+  "admin_graphql_api_id": "gid://shopify/Order/5201000001",
+  "name": "#1001",
+  "order_number": 1001,
+  "email": "priya.sharma@example.com",
+  "phone": null,
+  "cart_token": "c1-3f9a2b8e7d6c5b4a",
+  "checkout_token": "ck-77aa",
+  "token": "ord-tok-1",
+  "created_at": "2026-09-02T10:14:07+05:30",
+  "updated_at": "2026-09-02T11:02:40+05:30",
+  "processed_at": "2026-09-02T10:14:07+05:30",
+  "financial_status": "voided",
+  "fulfillment_status": null,
+  "gateway": "Cash on Delivery (COD)",
+  "payment_gateway_names": [
+    "Cash on Delivery (COD)"
+  ],
+  "currency": "INR",
+  "subtotal_price": "3097.00",
+  "total_discounts": "0.00",
+  "total_tax": "0.00",
+  "total_price": "3097.00",
+  "confirmed": true,
+  "test": false,
+  "buyer_accepts_marketing": false,
+  "taxes_included": true,
+  "source_name": "web",
+  "tags": "",
+  "customer": {
+    "id": 7011200034,
+    "email": "priya.sharma@example.com",
+    "first_name": "Priya",
+    "last_name": "Sharma",
+    "phone": "+91 98765 43210",
+    "state": "enabled",
+    "default_address": {
+      "first_name": "Priya",
+      "last_name": "Sharma",
+      "address1": "12 MG Road",
+      "city": "Bengaluru",
+      "province": "Karnataka",
+      "country_code": "IN",
+      "zip": "560001",
+      "phone": "+91 98765 43210"
+    }
+  },
+  "billing_address": {
+    "first_name": "Priya",
+    "last_name": "Sharma",
+    "address1": "12 MG Road",
+    "city": "Bengaluru",
+    "province": "Karnataka",
+    "country_code": "IN",
+    "zip": "560001",
+    "phone": "+91 98765 43210"
+  },
+  "shipping_address": {
+    "first_name": "Priya",
+    "last_name": "Sharma",
+    "address1": "12 MG Road",
+    "city": "Bengaluru",
+    "province": "Karnataka",
+    "country_code": "IN",
+    "zip": "560001",
+    "phone": "+91 98765 43210"
+  },
+  "line_items": [
+    {
+      "id": 1301,
+      "title": "Air Runner Sneakers",
+      "quantity": 1,
+      "price": "2499.00",
+      "sku": "AR-42",
+      "variant_title": "42 / White"
+    },
+    {
+      "id": 1302,
+      "title": "Ankle Socks (3 pack)",
+      "quantity": 2,
+      "price": "299.00",
+      "sku": "SK-3",
+      "variant_title": null
+    }
+  ],
+  "cancelled_at": "2026-09-02T11:02:40+05:30",
+  "cancel_reason": "customer"
+}

--- a/tests/crm/fixtures/shopify/orders_create.json
+++ b/tests/crm/fixtures/shopify/orders_create.json
@@ -1,0 +1,87 @@
+{
+  "id": 5201000001,
+  "admin_graphql_api_id": "gid://shopify/Order/5201000001",
+  "name": "#1001",
+  "order_number": 1001,
+  "email": "priya.sharma@example.com",
+  "phone": null,
+  "cart_token": "c1-3f9a2b8e7d6c5b4a",
+  "checkout_token": "ck-77aa",
+  "token": "ord-tok-1",
+  "created_at": "2026-09-02T10:14:07+05:30",
+  "updated_at": "2026-09-02T10:14:07+05:30",
+  "processed_at": "2026-09-02T10:14:07+05:30",
+  "financial_status": "pending",
+  "fulfillment_status": null,
+  "gateway": "Cash on Delivery (COD)",
+  "payment_gateway_names": [
+    "Cash on Delivery (COD)"
+  ],
+  "currency": "INR",
+  "subtotal_price": "3097.00",
+  "total_discounts": "0.00",
+  "total_tax": "0.00",
+  "total_price": "3097.00",
+  "confirmed": true,
+  "test": false,
+  "buyer_accepts_marketing": false,
+  "taxes_included": true,
+  "source_name": "web",
+  "tags": "",
+  "customer": {
+    "id": 7011200034,
+    "email": "priya.sharma@example.com",
+    "first_name": "Priya",
+    "last_name": "Sharma",
+    "phone": null,
+    "state": "enabled",
+    "default_address": {
+      "first_name": "Priya",
+      "last_name": "Sharma",
+      "address1": "12 MG Road",
+      "city": "Bengaluru",
+      "province": "Karnataka",
+      "country_code": "IN",
+      "zip": "560001",
+      "phone": "+91 98765 43210"
+    }
+  },
+  "billing_address": {
+    "first_name": "Priya",
+    "last_name": "Sharma",
+    "address1": "12 MG Road",
+    "city": "Bengaluru",
+    "province": "Karnataka",
+    "country_code": "IN",
+    "zip": "560001",
+    "phone": "+91 98765 43210"
+  },
+  "shipping_address": {
+    "first_name": "Priya",
+    "last_name": "Sharma",
+    "address1": "12 MG Road",
+    "city": "Bengaluru",
+    "province": "Karnataka",
+    "country_code": "IN",
+    "zip": "560001",
+    "phone": "+91 98765 43210"
+  },
+  "line_items": [
+    {
+      "id": 1301,
+      "title": "Air Runner Sneakers",
+      "quantity": 1,
+      "price": "2499.00",
+      "sku": "AR-42",
+      "variant_title": "42 / White"
+    },
+    {
+      "id": 1302,
+      "title": "Ankle Socks (3 pack)",
+      "quantity": 2,
+      "price": "299.00",
+      "sku": "SK-3",
+      "variant_title": null
+    }
+  ]
+}

--- a/tests/crm/fixtures/shopify/orders_create_guest.json
+++ b/tests/crm/fixtures/shopify/orders_create_guest.json
@@ -1,0 +1,69 @@
+{
+  "id": 5201000002,
+  "admin_graphql_api_id": "gid://shopify/Order/5201000001",
+  "name": "#1002",
+  "order_number": 1002,
+  "email": "rohan.mehta@example.com",
+  "phone": null,
+  "cart_token": "c1-guest-11aa",
+  "checkout_token": "ck-77aa",
+  "token": "ord-tok-2",
+  "created_at": "2026-09-02T10:14:07+05:30",
+  "updated_at": "2026-09-02T10:14:07+05:30",
+  "processed_at": "2026-09-02T10:14:07+05:30",
+  "financial_status": "pending",
+  "fulfillment_status": null,
+  "gateway": "Cash on Delivery (COD)",
+  "payment_gateway_names": [
+    "Cash on Delivery (COD)"
+  ],
+  "currency": "INR",
+  "subtotal_price": "3097.00",
+  "total_discounts": "0.00",
+  "total_tax": "0.00",
+  "total_price": "3097.00",
+  "confirmed": true,
+  "test": false,
+  "buyer_accepts_marketing": false,
+  "taxes_included": true,
+  "source_name": "web",
+  "tags": "",
+  "billing_address": {
+    "first_name": "Rohan",
+    "last_name": "Mehta",
+    "address1": "12 MG Road",
+    "city": "Bengaluru",
+    "province": "Karnataka",
+    "country_code": "IN",
+    "zip": "560001",
+    "phone": null
+  },
+  "shipping_address": {
+    "first_name": "Rohan",
+    "last_name": "Mehta",
+    "address1": "12 MG Road",
+    "city": "Bengaluru",
+    "province": "Karnataka",
+    "country_code": "IN",
+    "zip": "560001",
+    "phone": "9876543211"
+  },
+  "line_items": [
+    {
+      "id": 1301,
+      "title": "Air Runner Sneakers",
+      "quantity": 1,
+      "price": "2499.00",
+      "sku": "AR-42",
+      "variant_title": "42 / White"
+    },
+    {
+      "id": 1302,
+      "title": "Ankle Socks (3 pack)",
+      "quantity": 2,
+      "price": "299.00",
+      "sku": "SK-3",
+      "variant_title": null
+    }
+  ]
+}

--- a/tests/crm/fixtures/shopify/orders_create_signed_in.json
+++ b/tests/crm/fixtures/shopify/orders_create_signed_in.json
@@ -1,0 +1,87 @@
+{
+  "id": 5201000003,
+  "admin_graphql_api_id": "gid://shopify/Order/5201000001",
+  "name": "#1003",
+  "order_number": 1003,
+  "email": "priya.sharma@example.com",
+  "phone": "+919876543210",
+  "cart_token": "c1-signed-22bb",
+  "checkout_token": "ck-77aa",
+  "token": "ord-tok-3",
+  "created_at": "2026-09-02T10:14:07+05:30",
+  "updated_at": "2026-09-02T10:14:07+05:30",
+  "processed_at": "2026-09-02T10:14:07+05:30",
+  "financial_status": "pending",
+  "fulfillment_status": null,
+  "gateway": "Cash on Delivery (COD)",
+  "payment_gateway_names": [
+    "Cash on Delivery (COD)"
+  ],
+  "currency": "INR",
+  "subtotal_price": "3097.00",
+  "total_discounts": "0.00",
+  "total_tax": "0.00",
+  "total_price": "3097.00",
+  "confirmed": true,
+  "test": false,
+  "buyer_accepts_marketing": false,
+  "taxes_included": true,
+  "source_name": "web",
+  "tags": "",
+  "customer": {
+    "id": 7011200034,
+    "email": "priya.sharma@example.com",
+    "first_name": "Priya",
+    "last_name": "Sharma",
+    "phone": "+91 98765 43210",
+    "state": "enabled",
+    "default_address": {
+      "first_name": "Priya",
+      "last_name": "Sharma",
+      "address1": "12 MG Road",
+      "city": "Bengaluru",
+      "province": "Karnataka",
+      "country_code": "IN",
+      "zip": "560001",
+      "phone": null
+    }
+  },
+  "billing_address": {
+    "first_name": "Priya",
+    "last_name": "Sharma",
+    "address1": "12 MG Road",
+    "city": "Bengaluru",
+    "province": "Karnataka",
+    "country_code": "IN",
+    "zip": "560001",
+    "phone": "+91 98765 43210"
+  },
+  "shipping_address": {
+    "first_name": "Priya",
+    "last_name": "Sharma",
+    "address1": "12 MG Road",
+    "city": "Bengaluru",
+    "province": "Karnataka",
+    "country_code": "IN",
+    "zip": "560001",
+    "phone": "+91 98765 43210"
+  },
+  "line_items": [
+    {
+      "id": 1301,
+      "title": "Air Runner Sneakers",
+      "quantity": 1,
+      "price": "2499.00",
+      "sku": "AR-42",
+      "variant_title": "42 / White"
+    },
+    {
+      "id": 1302,
+      "title": "Ankle Socks (3 pack)",
+      "quantity": 2,
+      "price": "299.00",
+      "sku": "SK-3",
+      "variant_title": null
+    }
+  ]
+}

--- a/tests/crm/fixtures/shopify/orders_paid.json
+++ b/tests/crm/fixtures/shopify/orders_paid.json
@@ -1,0 +1,87 @@
+{
+  "id": 5201000001,
+  "admin_graphql_api_id": "gid://shopify/Order/5201000001",
+  "name": "#1001",
+  "order_number": 1001,
+  "email": "priya.sharma@example.com",
+  "phone": null,
+  "cart_token": "c1-3f9a2b8e7d6c5b4a",
+  "checkout_token": "ck-77aa",
+  "token": "ord-tok-1",
+  "created_at": "2026-09-02T10:14:07+05:30",
+  "updated_at": "2026-09-02T10:20:00+05:30",
+  "processed_at": "2026-09-02T10:14:07+05:30",
+  "financial_status": "paid",
+  "fulfillment_status": null,
+  "gateway": "razorpay",
+  "payment_gateway_names": [
+    "razorpay"
+  ],
+  "currency": "INR",
+  "subtotal_price": "3097.00",
+  "total_discounts": "0.00",
+  "total_tax": "0.00",
+  "total_price": "3097.00",
+  "confirmed": true,
+  "test": false,
+  "buyer_accepts_marketing": false,
+  "taxes_included": true,
+  "source_name": "web",
+  "tags": "",
+  "customer": {
+    "id": 7011200034,
+    "email": "priya.sharma@example.com",
+    "first_name": "Priya",
+    "last_name": "Sharma",
+    "phone": "+91 98765 43210",
+    "state": "enabled",
+    "default_address": {
+      "first_name": "Priya",
+      "last_name": "Sharma",
+      "address1": "12 MG Road",
+      "city": "Bengaluru",
+      "province": "Karnataka",
+      "country_code": "IN",
+      "zip": "560001",
+      "phone": "+91 98765 43210"
+    }
+  },
+  "billing_address": {
+    "first_name": "Priya",
+    "last_name": "Sharma",
+    "address1": "12 MG Road",
+    "city": "Bengaluru",
+    "province": "Karnataka",
+    "country_code": "IN",
+    "zip": "560001",
+    "phone": "+91 98765 43210"
+  },
+  "shipping_address": {
+    "first_name": "Priya",
+    "last_name": "Sharma",
+    "address1": "12 MG Road",
+    "city": "Bengaluru",
+    "province": "Karnataka",
+    "country_code": "IN",
+    "zip": "560001",
+    "phone": "+91 98765 43210"
+  },
+  "line_items": [
+    {
+      "id": 1301,
+      "title": "Air Runner Sneakers",
+      "quantity": 1,
+      "price": "2499.00",
+      "sku": "AR-42",
+      "variant_title": "42 / White"
+    },
+    {
+      "id": 1302,
+      "title": "Ankle Socks (3 pack)",
+      "quantity": 2,
+      "price": "299.00",
+      "sku": "SK-3",
+      "variant_title": null
+    }
+  ]
+}

--- a/tests/crm/test_catalog.py
+++ b/tests/crm/test_catalog.py
@@ -1,0 +1,494 @@
+"""The event catalog's pin tests (design/event-catalog.md §Ownership): the
+four-part square a new source/topic must ship — spec (the engine
+decodes it) · fixtures · catalog entry (· ingress) — enforced so a
+half-added entry fails CI.
+
+Fixtures under tests/crm/fixtures/<source>/<topic>.json are recorded
+payloads (the Shopify one is document-shaped until nautilus#195's shadow
+records a real letter; the pin holds either way). They double as the
+catalog's conformance test: every declared non-derived field must resolve
+against at least one fixture, so provider drift fails HERE, not in prod.
+"""
+
+import asyncio
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional, get_args
+
+import pytest
+
+from app.crm.record import catalog
+from app.crm.record.extractors import engine
+from app.crm.record.schemas import (
+    CatalogField,
+    EventSchema,
+    SchemaRegistration,
+    TopicCount,
+)
+from app.crm.shared import predicate
+from app.crm.shared.predicate import Condition, matches
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def _fixtures_for(source: str, topic: str) -> List[Dict[str, Any]]:
+    folder = FIXTURES / source
+    name = topic.replace("/", "_").replace(".", "_")
+    # sorted: glob order is the filesystem's (Linux CI once handed the
+    # signed-in variant first), and callers index into this list.
+    return [
+        json.loads(p.read_text())
+        for p in sorted(folder.glob("*.json"))
+        if p.stem.startswith(name)
+    ]
+
+
+# --- The square -------------------------------------------------------------
+
+
+def test_every_code_entry_has_fixtures_and_every_field_appears_in_one() -> None:
+    """Every declared path resolves against a recorded letter of its topic;
+    every FALLBACK path against a recorded letter of its source (Shopify
+    keeps a phone in four homes — each must be seen in the wild once)."""
+    by_source: Dict[str, List[Dict[str, Any]]] = {}
+    for (source, topic), entry in catalog.CATALOG.items():
+        payloads = _fixtures_for(source, topic)
+        assert payloads, f"{source}/{topic}: no fixture under tests/crm/fixtures"
+        by_source.setdefault(source, []).extend(payloads)
+        derive = catalog.derive_for(source, topic)
+        for field in entry.fields:
+            assert any(
+                engine.field_value(p, field.path, derive) is not None for p in payloads
+            ), f"{source}/{topic}: declared field {field.path} appears in no fixture"
+    for (source, topic), entry in catalog.CATALOG.items():
+        for field in entry.fields:
+            for path in field.fallbacks:
+                assert any(
+                    engine.field_value(p, path) not in (None, "")
+                    for p in by_source[source]
+                ), f"{source}: fallback {path} appears in no recorded letter"
+
+
+def test_the_engine_finds_the_person_in_every_recorded_letter() -> None:
+    """The extractor half of the square: a code entry whose spec cannot
+    attribute its own fixtures would quarantine every real letter."""
+    for (source, topic), entry in catalog.CATALOG.items():
+        spec = catalog.code_spec(source, topic)
+        assert spec is not None
+        for payload in _fixtures_for(source, topic):
+            extracted = engine.extract(payload, spec)
+            assert extracted.handles, f"{source}/{topic}: a fixture yields no handle"
+
+
+def test_variable_names_are_unique_within_an_entry() -> None:
+    # {placeholder} is the last path segment (or the derived name): two
+    # declared variables ending in the same word would fill one slot.
+    for key, entry in catalog.CATALOG.items():
+        names = [engine.variable_name(f.path) for f in entry.fields if f.variable]
+        assert len(names) == len(set(names)), (key, names)
+
+
+def test_every_derived_field_has_its_deriver_and_vice_versa() -> None:
+    for key, entry in catalog.CATALOG.items():
+        declared = {f.path for f in entry.fields if f.derived}
+        assert declared == set(catalog.DERIVE.get(key, {})), key
+
+
+def test_ops_come_from_type_and_phone_is_never_filterable() -> None:
+    for entry in catalog.code_entries():
+        for field in entry.fields:
+            assert field.ops == catalog.OPS_BY_TYPE[field.type]
+            if field.type == "phone":
+                assert field.ops == []
+    assert set(catalog.OPS_BY_TYPE) == {
+        "text",
+        "number",
+        "choice",
+        "boolean",
+        "datetime",
+        "phone",
+    }
+
+
+# --- Shopify orders/create through the grammar ----------------------------
+
+
+def test_shopify_fixture_answers_the_worked_example() -> None:
+    # the recorded COD order by name — its variants (guest, signed-in)
+    # answer differently and are pinned by the coverage tests above
+    payload = json.loads((FIXTURES / "shopify" / "orders_create.json").read_text())
+    derive = catalog.derive_for("shopify", "orders/create")
+    lookup = lambda path: engine.field_value(payload, path, derive)  # noqa: E731
+    assert matches(
+        [
+            Condition(field="payload.financial_status", op="is", value="pending"),
+            Condition(field="payload.gateway", op="is", value="Cash on Delivery (COD)"),
+            Condition(field="payload.total_price", op=">", value=1000),
+            Condition(field="items_count", op="=", value=2),
+        ],
+        lookup,
+    )
+    assert lookup("first_item_name") == "Air Runner Sneakers"
+    assert lookup("customer_name") == "Priya Sharma"
+    # Shopify's top-level customer.phone is null on this recorded order —
+    # the DECLARED fallback (default_address) is where the engine finds it.
+    assert lookup("payload.customer.phone") is None
+    spec = catalog.code_spec("shopify", "orders/create")
+    assert spec is not None
+    assert engine.extract(payload, spec).handles["phone"] == "+919876543210"
+    assert lookup("payload.customer.missing") is None
+    assert lookup("payload.customer.phone.deeper") is None
+
+
+def test_canonical_path_keeps_bare_entry_keys_working() -> None:
+    assert catalog.canonical_path("order_id") == "payload.order_id"
+    assert catalog.canonical_path("payload.order_id") == "payload.order_id"
+    assert catalog.canonical_path("items_count") == "items_count"
+
+
+# --- Registration validator (T24) --------------------------------------------
+
+
+def _reg(fields: List[Dict[str, Any]]) -> SchemaRegistration:
+    return SchemaRegistration(
+        source="flipkart",
+        topic="order.created",
+        label="Order placed",
+        fields=[CatalogField.model_validate(f) for f in fields],
+    )
+
+
+def test_registration_accepts_the_nammayatri_shape() -> None:
+    problems = catalog.validate_registration(
+        _reg(
+            [
+                {
+                    "path": "payload.ride_id",
+                    "type": "text",
+                    "label": "Ride ID",
+                    "keyable": True,
+                },
+                {
+                    "path": "payload.rider_phone",
+                    "type": "phone",
+                    "label": "Phone",
+                    "identity": "phone",
+                },
+                {
+                    "path": "payload.fare",
+                    "type": "number",
+                    "label": "Fare",
+                    "variable": True,
+                },
+                {
+                    "path": "payload.cancelled_by",
+                    "type": "choice",
+                    "label": "Cancelled by",
+                    "values": ["driver", "customer", "system"],
+                },
+            ]
+        )
+    )
+    assert problems == []
+
+
+@pytest.mark.parametrize(
+    "field, fragment",
+    [
+        ({"path": "ride_id", "type": "text", "label": "x"}, "path must be payload."),
+        (
+            {"path": "payload.a-b", "type": "text", "label": "x"},
+            "path must be payload.",
+        ),
+        (
+            {"path": "payload.x", "type": "choice", "label": "x"},
+            "choice needs its values",
+        ),
+        (
+            {"path": "payload.x", "type": "text", "label": "x", "values": ["a"]},
+            "only choice",
+        ),
+        (
+            {"path": "payload.x", "type": "boolean", "label": "x", "keyable": True},
+            "keyable needs",
+        ),
+        (
+            {"path": "payload.x", "type": "text", "label": "x", "identity": "phone"},
+            "must be type phone",
+        ),
+        (
+            {"path": "payload.x", "type": "phone", "label": "x"},
+            "identity:phone or nothing",
+        ),
+        (
+            {"path": "payload.x", "type": "text", "label": "x", "derived": True},
+            "code-layer only",
+        ),
+        (
+            {
+                "path": "payload.x",
+                "type": "phone",
+                "label": "x",
+                "identity": "phone",
+                "fallbacks": ["payload.y"],
+            },
+            "fallbacks are code-layer only",
+        ),
+        (
+            {"path": "payload.x", "type": "text", "label": "x", "identity": "email"},
+            "identity role must be one of phone | name",
+        ),
+    ],
+)
+def test_registration_refuses_each_law_break(
+    field: Dict[str, Any], fragment: str
+) -> None:
+    problems = catalog.validate_registration(_reg([field]))
+    assert any(fragment in p for p in problems), problems
+
+
+def test_a_registration_may_not_shadow_a_code_entry() -> None:
+    """The code layer is authoritative for its events: a vendor row under
+    shopify/orders/create would be gathered by the validator, hidden by the
+    console and ignored by decode — a plan templating on it parks every
+    send. Refused at the door, like discovery writes no nudge for it."""
+    shadow = SchemaRegistration(
+        source="shopify",
+        topic="orders/create",
+        label="Orders",
+        fields=[
+            CatalogField(
+                path="payload.loyalty_tier", type="text", label="Tier", variable=True
+            )
+        ],
+    )
+    problems = catalog.validate_registration(shadow)
+    assert problems == [
+        "shopify/orders/create is declared in code — nothing to register"
+    ]
+    # the same topic word under the merchant's own source is theirs to declare
+    own = shadow.model_copy(update={"source": "flipkart"})
+    assert catalog.validate_registration(own) == []
+
+
+def test_the_catalog_is_assembled_from_the_spec_modules_only() -> None:
+    """Adding a source is one registry line in extractors/__init__.py; the
+    catalog's logic file spells no source. Every code entry belongs to a
+    listed module, and every listed module's entries are in the catalog."""
+    from app.crm.record.extractors import SPEC_MODULES
+
+    listed = {(e.source, e.topic) for module in SPEC_MODULES for e in module.ENTRIES}
+    assert set(catalog.CATALOG) == listed
+    source_words = [
+        line
+        for line in Path(catalog.__file__).read_text().splitlines()
+        if "shopify" in line.lower() and not line.lstrip().startswith("#")
+    ]
+    assert source_words == [], source_words
+
+
+def test_registration_refuses_unknown_type_at_the_shape() -> None:
+    with pytest.raises(Exception):
+        CatalogField.model_validate(
+            {"path": "payload.x", "type": "money", "label": "x"}
+        )
+
+
+def test_registration_refuses_two_fields_for_one_identity_role() -> None:
+    problems = catalog.validate_registration(
+        _reg(
+            [
+                {
+                    "path": "payload.a",
+                    "type": "phone",
+                    "label": "a",
+                    "identity": "phone",
+                },
+                {
+                    "path": "payload.b",
+                    "type": "phone",
+                    "label": "b",
+                    "identity": "phone",
+                },
+            ]
+        )
+    )
+    assert any("already taken" in p for p in problems)
+
+
+def test_etag_changes_with_content_not_with_counts() -> None:
+    entries = catalog.code_entries()
+    a = catalog.etag_for(entries)
+    assert a == catalog.etag_for(
+        [e.model_copy(update={"seen_7d": 99}) for e in entries]
+    )
+    changed = [e.model_copy(update={"label": "renamed"}) for e in entries]
+    assert a != catalog.etag_for(changed)
+
+
+def test_type_guess_from_samples() -> None:
+    assert catalog._guess_type("number", [1, 2]) == "number"
+    assert catalog._guess_type("boolean", [True]) == "boolean"
+    assert catalog._guess_type("string", ["+919876543210", "9876543210"]) == "phone"
+    assert catalog._guess_type("string", ["2026-09-01T10:00:00Z"]) == "datetime"
+    assert catalog._guess_type("string", ["COD", "UPI"]) == "text"
+
+
+# ---------------------------------------------------------------------------
+# Review round (4 Sep 2026): op parity, additive-or-deprecate, one source per
+# topic, the stored row's keys, and the ETag before the counts query.
+# ---------------------------------------------------------------------------
+
+
+def test_every_catalog_op_is_an_op_the_evaluator_speaks() -> None:
+    """Parity is structural (OPS_BY_TYPE is spelled from predicate's
+    families); this pins it against a hand-typed word sneaking back in."""
+    spoken = set(get_args(predicate.Op))
+    for field_type, ops in catalog.OPS_BY_TYPE.items():
+        assert set(ops) <= spoken, (field_type, set(ops) - spoken)
+    assert catalog.OPS_BY_TYPE["text"] == [*predicate.TEXT_OPS, predicate.EXISTS_OP]
+    assert catalog.OPS_BY_TYPE["number"] == [
+        *predicate.ORDER_OPS,
+        predicate.EQUALS_OP,
+        predicate.EXISTS_OP,
+    ]
+
+
+def _row(
+    source: str,
+    topic: str,
+    fields: List[Dict[str, Any]],
+    status: str = "registered",
+    version: int = 1,
+) -> EventSchema:
+    now = datetime.now(timezone.utc)
+    return EventSchema(
+        id="row-1",
+        merchant_id="m1",
+        source=source,
+        topic=topic,
+        label=None,
+        fields=[CatalogField.model_validate(f) for f in fields],
+        status=status,
+        version=version,
+        registered_by="s2s:m1",
+        first_seen_at=None,
+        created_at=now,
+        updated_at=now,
+    )
+
+
+class _SchemaAccessor:
+    """The accessor slots the catalog reads, as recording fakes."""
+
+    def __init__(self, rows: Optional[List[EventSchema]] = None) -> None:
+        self.rows = rows or []
+        self.registered: List[Any] = []
+        self.count_calls = 0
+
+    async def list_schemas(self, merchant_id: str) -> List[EventSchema]:
+        return list(self.rows)
+
+    async def get_schema(self, merchant_id: str, source: str, topic: str) -> Any:
+        for row in self.rows:
+            if (row.source, row.topic) == (source, topic):
+                return row
+        return None
+
+    async def register_schema(self, *args: Any) -> EventSchema:
+        self.registered.append(args)
+        return self.rows[0] if self.rows else _row(args[1], args[2], [])
+
+    async def topic_counts(self, merchant_id: str, days: int) -> List[TopicCount]:
+        self.count_calls += 1
+        return [TopicCount(source="shopify", topic="orders/create", seen=3)]
+
+
+RIDE = {"path": "payload.ride_id", "type": "text", "label": "Ride", "keyable": True}
+FARE = {"path": "payload.fare", "type": "number", "label": "Fare", "variable": True}
+
+
+def test_a_re_registration_may_deprecate_a_path_but_never_drop_it(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """design/event-catalog.md: fields are deprecated, never deleted — a
+    live flow may filter or template on the path a vendor just dropped."""
+    fake = _SchemaAccessor([_row("flipkart", "order.created", [RIDE, FARE])])
+    monkeypatch.setattr(catalog, "accessor", fake)
+
+    dropped = _reg([RIDE])
+    with pytest.raises(catalog.SchemaValidationError) as refused:
+        asyncio.run(catalog.register_schema("m1", dropped, "s2s:m1"))
+    assert "payload.fare: declared in v1 and missing now" in str(refused.value)
+    assert fake.registered == []
+
+    deprecated = _reg([RIDE, {**FARE, "deprecated": True}])
+    asyncio.run(catalog.register_schema("m1", deprecated, "s2s:m1"))
+    assert len(fake.registered) == 1
+
+    tip = {"path": "payload.tip", "type": "number", "label": "Tip"}
+    asyncio.run(catalog.register_schema("m1", _reg([RIDE, FARE, tip]), "s2s:m1"))
+    assert len(fake.registered) == 2, "additive lands"
+
+
+def test_the_stored_row_carries_canons_field_list_only(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """ops are computed on read; fallbacks/derived are code-layer words —
+    none of them is written into a T24 row."""
+    fake = _SchemaAccessor()
+    monkeypatch.setattr(catalog, "accessor", fake)
+    asyncio.run(catalog.register_schema("m1", _reg([RIDE]), "s2s:m1"))
+    stored = json.loads(fake.registered[0][4])
+    assert stored == [
+        {
+            "path": "payload.ride_id",
+            "type": "text",
+            "label": "Ride",
+            "keyable": True,
+            "variable": False,
+            "values": [],
+            "identity": None,
+            "deprecated": False,
+        }
+    ]
+
+
+def test_a_topic_two_sources_declare_cannot_be_gathered(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A door carries topic only (canon T19; entry.source is a ruling owed):
+    a union of two sources' fields would let a condition on a path only one
+    has silently match nothing for the other. Refuse, naming both."""
+    vendor_orders = _row("flipkart", "orders/create", [RIDE])
+    monkeypatch.setattr(catalog, "accessor", _SchemaAccessor([vendor_orders]))
+    with pytest.raises(catalog.AmbiguousTopic) as e:
+        asyncio.run(catalog.catalog_fields("m1", "orders/create"))
+    assert e.value.sources == ["shopify", "flipkart"]
+
+    # one source, either layer: the field map as before
+    monkeypatch.setattr(catalog, "accessor", _SchemaAccessor([]))
+    fields = asyncio.run(catalog.catalog_fields("m1", "orders/create"))
+    assert fields is not None and "payload.id" in fields
+    only_vendor = _row("nammayatri", "ride.completed", [RIDE])
+    monkeypatch.setattr(catalog, "accessor", _SchemaAccessor([only_vendor]))
+    fields = asyncio.run(catalog.catalog_fields("m1", "ride.completed"))
+    assert fields is not None and list(fields) == ["payload.ride_id"]
+    assert asyncio.run(catalog.catalog_fields("m1", "nobody/knows")) is None
+
+
+def test_the_etag_is_computed_before_the_counts_query(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A 304 costs one schema read: merged_entries never runs the 7-day
+    GROUP BY, and its ETag equals the filled catalog's (seen_7d excluded)."""
+    fake = _SchemaAccessor()
+    monkeypatch.setattr(catalog, "accessor", fake)
+    entries = asyncio.run(catalog.merged_entries("m1"))
+    assert fake.count_calls == 0
+    filled = asyncio.run(catalog.with_seen_counts("m1", entries))
+    assert fake.count_calls == 1
+    assert catalog.etag_for(entries) == catalog.etag_for(filled)
+    by_key = {(e.source, e.topic): e.seen_7d for e in filled}
+    assert by_key[("shopify", "orders/create")] == 3

--- a/tests/crm/test_connectivity_adapters.py
+++ b/tests/crm/test_connectivity_adapters.py
@@ -979,3 +979,36 @@ def test_the_lookup_is_scoped_to_the_merchants_own_account() -> None:
     # the filter is still there, now bound rather than spelled in SQL text
     assert "status = $5" in sql
     assert values == ["shop", "whatsapp", "waba-1", "n", TEMPLATE_APPROVED]
+
+
+class _ScriptedAdapter(ChannelAdapter):
+    channel = "whatsapp"
+
+    def __init__(self, outcome: SendOutcome) -> None:
+        self._outcome = outcome
+
+    async def deliver(self, message, route):
+        """Test double: returns the scripted outcome, route untouched."""
+        return self._outcome
+
+
+async def test_an_accepted_send_names_the_pipe_it_left_on_and_a_refusal_does_not(
+    monkeypatch, happy_accessor
+) -> None:
+    """T16 col 6: the outcome carries the binding the route resolved, so
+    the dispatcher can stamp crm_message.binding_id once; a blocked outcome
+    carries none — no pipe was used, and NULL is the honest row."""
+    message = _message()
+    accepted = SendOutcome(status="accepted", provider_message_id="wamid.T")
+    monkeypatch.setattr(
+        send_module, "adapter_for", lambda channel: _ScriptedAdapter(accepted)
+    )
+    outcome = await send(_token(message), message)
+    assert outcome.status == "accepted" and outcome.binding_id == "b-1"
+
+    blocked = SendOutcome(status="blocked", reason=REASON_GATE_REFUSED)
+    monkeypatch.setattr(
+        send_module, "adapter_for", lambda channel: _ScriptedAdapter(blocked)
+    )
+    outcome = await send(_token(message), message)
+    assert outcome.status == "blocked" and outcome.binding_id is None

--- a/tests/crm/test_consumer_registry.py
+++ b/tests/crm/test_consumer_registry.py
@@ -14,7 +14,7 @@ from app.crm.record.schemas import RawEvent
 
 
 async def _consumer_a(
-    event: RawEvent, customer_id: Optional[str], handles: Any
+    event: RawEvent, customer_id: Optional[str], handles: Any, variables: Any = None
 ) -> None:
     return None
 
@@ -48,10 +48,14 @@ def test_the_pass_runs_every_registered_consumer_in_order(
     # with zero edits in the pass.
     ran: List[str] = []
 
-    async def first(event: RawEvent, customer_id: Optional[str], handles: Any) -> None:
+    async def first(
+        event: RawEvent, customer_id: Optional[str], handles: Any, variables: Any = None
+    ) -> None:
         ran.append(f"first:{customer_id}:{(handles or {}).get('phone')}")
 
-    async def second(event: RawEvent, customer_id: Optional[str], handles: Any) -> None:
+    async def second(
+        event: RawEvent, customer_id: Optional[str], handles: Any, variables: Any = None
+    ) -> None:
         ran.append(f"second:{customer_id}")
 
     monkeypatch.setattr(record_consumers, "_CONSUMERS", [first, second])

--- a/tests/crm/test_decode_engine.py
+++ b/tests/crm/test_decode_engine.py
@@ -1,0 +1,263 @@
+"""The one decode engine (event-catalog.md §One decode engine, two spec
+sources): a spec in, handles + facts + variables out — the same function
+for a code CatalogEntry and a registered vendor row.
+
+The Shopify cases carried over from the imperative extractor it replaced:
+same letters, same answers, now read by declared paths.
+"""
+
+from typing import Any, Dict
+
+from app.crm.record import catalog
+from app.crm.record.extractors import EXTRACTORS, engine, shopify
+from app.crm.record.extractors.engine import EMPTY_SPEC, DecodeSpec, spec_for_entry
+from app.crm.record.schemas import CatalogEntry, CatalogField
+
+
+def _shopify(topic: str) -> DecodeSpec:
+    spec = catalog.code_spec("shopify", topic)
+    assert spec is not None, topic
+    return spec
+
+
+ORDER = _shopify("orders/create")
+CHECKOUT = _shopify("checkouts/update")
+
+
+def _entry(*fields: CatalogField) -> CatalogEntry:
+    return CatalogEntry(
+        source="x", topic="t", label="T", group="X", layer="code", fields=list(fields)
+    )
+
+
+# --- the spec, built from either layer ----------------------------------------
+
+
+def test_an_entry_says_who_its_letters_are_about() -> None:
+    """The engine's vocabulary (Extracted.about) is the entry's word: a
+    merchant-level topic (a template review, an account notice) decodes
+    with about="merchant" — no handle, no quarantine, NULL customer by
+    design — and the default stays "customer" for every existing entry."""
+    review = CatalogEntry(
+        source="whatsapp",
+        topic="template.status",
+        label="Template review",
+        group="WhatsApp",
+        layer="code",
+        about="merchant",
+        fields=[
+            CatalogField(path="payload.event", type="text", label="E", variable=True)
+        ],
+    )
+    spec = spec_for_entry(review, {})
+    assert spec.about == "merchant"
+    out = engine.extract({"event": "APPROVED"}, spec)
+    assert out.about == "merchant" and out.handles == {}
+    assert out.variables == {"event": "APPROVED"}
+
+    assert spec_for_entry(_entry(), {}).about == "customer"
+    assert EMPTY_SPEC.about == "customer"
+    assert (
+        engine.extract({"customer_mobile_number": "+919999999999"}, EMPTY_SPEC).about
+        == "customer"
+    )
+
+
+def test_a_spec_is_the_same_shape_from_code_and_from_a_registration() -> None:
+    registered = _entry(
+        CatalogField(
+            path="payload.rider.phone", type="phone", label="P", identity="phone"
+        ),
+        CatalogField(
+            path="payload.rider.name", type="text", label="N", identity="name"
+        ),
+        CatalogField(path="payload.fare", type="number", label="F", variable=True),
+    )
+    spec = spec_for_entry(registered, {})
+    assert spec.identity == {
+        "phone": ["payload.rider.phone"],
+        "name": ["payload.rider.name"],
+    }
+    assert spec.variables == {"fare": "payload.fare"}
+    # The code layer's spec is built by the same function.
+    assert ORDER.identity["phone"] == shopify.PHONE_PATHS
+
+
+def test_fallbacks_follow_the_field_in_order_and_deprecated_fields_drop_out() -> None:
+    entry = _entry(
+        CatalogField(
+            path="payload.a",
+            type="phone",
+            label="P",
+            identity="phone",
+            fallbacks=["payload.b", "payload.c"],
+        ),
+        CatalogField(
+            path="payload.old", type="text", label="O", variable=True, deprecated=True
+        ),
+    )
+    spec = spec_for_entry(entry, {})
+    assert spec.identity["phone"] == ["payload.a", "payload.b", "payload.c"]
+    assert spec.variables == {}
+
+
+def test_variable_names_are_the_last_path_segment_or_the_derived_name() -> None:
+    assert engine.variable_name("payload.customer.first_name") == "first_name"
+    assert engine.variable_name("payload.total_price") == "total_price"
+    assert engine.variable_name("customer_name") == "customer_name"
+
+
+# --- decoding Shopify by its declared spec -------------------------------------
+
+
+def test_the_nested_customer_phone_beats_the_shipping_contact() -> None:
+    # The relay forwards Shopify's body unopened: the phone arrives nested
+    # and the top-level one is usually null.
+    extracted = engine.extract(
+        {
+            "phone": None,
+            "customer": {
+                "first_name": "Priya",
+                "last_name": "Sharma",
+                "phone": "+91 98765 43210",
+            },
+            "shipping_address": {"phone": "9999999999"},
+        },
+        ORDER,
+    )
+    assert extracted.handles["phone"] == "+919876543210"  # normalized
+    assert extracted.facts == {"name": "Priya Sharma"}
+
+
+def test_a_guest_checkout_falls_back_to_the_shipping_contact() -> None:
+    # No customer object at all — the last fallback in the declared list.
+    extracted = engine.extract(
+        {
+            "shipping_address": {
+                "first_name": "Rohan",
+                "last_name": "Mehta",
+                "phone": "9876543210",
+            }
+        },
+        ORDER,
+    )
+    assert extracted.handles["phone"] == "+919876543210"
+    assert extracted.facts == {"name": "Rohan Mehta"}
+    assert "shopify_customer_id" not in extracted.handles
+
+
+def test_the_default_address_is_the_returning_shoppers_phone_home() -> None:
+    extracted = engine.extract(
+        {"customer": {"phone": None, "default_address": {"phone": "98765 43210"}}},
+        ORDER,
+    )
+    assert extracted.handles["phone"] == "+919876543210"
+
+
+def test_a_name_is_never_invented() -> None:
+    # A placeholder would reach assert_facts as a real claim and overwrite
+    # what we actually know. Absent is absent.
+    extracted = engine.extract({"customer": {"phone": "9876543210"}}, ORDER)
+    assert extracted.facts == {}
+    assert "customer_name" not in extracted.variables
+
+
+def test_an_unusable_phone_is_skipped_not_written() -> None:
+    extracted = engine.extract({"customer": {"phone": "n/a"}}, ORDER)
+    assert "phone" not in extracted.handles
+
+
+def test_email_and_customer_id_are_handles_too() -> None:
+    extracted = engine.extract(
+        {
+            "customer": {
+                "id": 77,
+                "email": "  Priya@Example.COM  ",
+                "phone": "9876543210",
+            }
+        },
+        ORDER,
+    )
+    assert extracted.handles["email"] == "priya@example.com"
+    assert extracted.handles["shopify_customer_id"] == "77"
+
+
+def test_a_phoneless_checkout_frame_resolves_by_the_customer_id() -> None:
+    # The early checkouts/update frames carry no phone yet — she types it
+    # later — but they carry Shopify's customer id.
+    extracted = engine.extract({"customer": {"id": 77}, "token": "ck-1"}, CHECKOUT)
+    assert extracted.handles == {"shopify_customer_id": "77"}
+    assert extracted.variables["token"] == "ck-1"
+
+
+def test_declared_variables_come_out_named_for_templates() -> None:
+    extracted = engine.extract(
+        {
+            "id": 881,
+            "name": "#881",
+            "cart_token": "c1-abc",
+            "total_price": "2499.00",
+            "customer": {
+                "first_name": "Priya",
+                "last_name": "Sharma",
+                "phone": "9876543210",
+            },
+            "line_items": [{"title": "Sneakers"}, {"title": "Socks"}],
+            "confirmed": True,
+        },
+        ORDER,
+    )
+    v = extracted.variables
+    assert v["customer_name"] == "Priya Sharma"  # derived, nested, template-ready
+    assert v["first_name"] == "Priya"
+    assert v["total_price"] == "2499.00" and v["cart_token"] == "c1-abc"
+    assert v["items_count"] == 2 and v["first_item_name"] == "Sneakers"
+    assert "confirmed" not in v  # undeclared scalars never become variables
+
+
+# --- the flat shape beneath every spec ------------------------------------------
+
+
+def test_the_flat_shape_applies_with_no_spec_at_all() -> None:
+    extracted = engine.extract(
+        {"customer_mobile_number": "+919999999999", "customer_name": "Asha"}, EMPTY_SPEC
+    )
+    assert extracted.handles == {"phone": "+919999999999"}
+    assert extracted.facts == {"name": "Asha"}
+    assert extracted.variables == {}
+
+
+def test_a_declared_path_wins_over_the_standard_key() -> None:
+    spec = DecodeSpec(identity={"phone": ["payload.rider.phone"]})
+    extracted = engine.extract(
+        {"customer_mobile_number": "+911111111111", "rider": {"phone": "9876543210"}},
+        spec,
+    )
+    assert extracted.handles["phone"] == "+919876543210"
+
+
+def test_a_missing_declared_path_leaves_the_standard_key_standing() -> None:
+    spec = DecodeSpec(identity={"phone": ["payload.rider.phone"]})
+    extracted = engine.extract({"customer_mobile_number": "+911111111111"}, spec)
+    assert extracted.handles["phone"] == "+911111111111"
+
+
+# --- one engine: a code-catalog source never also decodes by hand -------------
+
+
+def test_shopify_is_a_spec_not_an_imperative_extractor() -> None:
+    assert "shopify" not in EXTRACTORS
+    for source, _ in catalog.CATALOG:
+        assert source not in EXTRACTORS, f"{source} has two readers of one payload"
+
+
+def test_every_catalog_derived_field_is_provided_by_its_spec_module() -> None:
+    for key, entry in catalog.CATALOG.items():
+        declared = {f.path for f in entry.fields if f.derived}
+        assert declared == set(catalog.DERIVE[key]), key
+        for name in declared:
+            assert catalog.DERIVE[key][name] is shopify.DERIVERS[name]
+
+
+def _spec_dict(spec: DecodeSpec) -> Dict[str, Any]:
+    return {"identity": spec.identity, "variables": spec.variables}

--- a/tests/crm/test_dispatch.py
+++ b/tests/crm/test_dispatch.py
@@ -167,7 +167,7 @@ async def test_an_accepted_send_records_the_outcome(monkeypatch) -> None:
         return SendOutcome(status="accepted", provider_message_id="wamid.T")
 
     async def record_outcome(
-        message_id, status, reason, pmid, mark_sent, attempt, retry
+        message_id, status, reason, pmid, mark_sent, attempt, retry, binding_id=None
     ):
         """Test double: records what the dispatcher tried to write."""
         written.update(status=status, mark_sent=mark_sent, attempt=attempt)
@@ -195,7 +195,7 @@ async def test_a_raising_send_becomes_a_retryable_send_error(monkeypatch) -> Non
         raise RuntimeError("wire fell over")
 
     async def record_outcome(
-        message_id, status, reason, pmid, mark_sent, attempt, retry
+        message_id, status, reason, pmid, mark_sent, attempt, retry, binding_id=None
     ):
         """Test double: records what the dispatcher tried to write."""
         written.update(status=status, reason=reason, retry=retry)
@@ -232,7 +232,7 @@ async def test_a_suppressed_address_is_blocked_and_the_adapter_never_called(
         raise AssertionError("adapter reached past a refusing gate")
 
     async def record_outcome(
-        message_id, status, reason, pmid, mark_sent, attempt, retry
+        message_id, status, reason, pmid, mark_sent, attempt, retry, binding_id=None
     ):
         """Test double: records what the dispatcher tried to write."""
         written.update(status=status, reason=reason, mark_sent=mark_sent)
@@ -260,7 +260,7 @@ async def test_a_channel_the_gate_cannot_check_fails_closed(monkeypatch) -> None
         raise AssertionError("adapter reached past a refusing gate")
 
     async def record_outcome(
-        message_id, status, reason, pmid, mark_sent, attempt, retry
+        message_id, status, reason, pmid, mark_sent, attempt, retry, binding_id=None
     ):
         """Test double: records what the dispatcher tried to write."""
         written.update(status=status, reason=reason)
@@ -294,7 +294,7 @@ async def test_a_hung_gate_probe_is_bounded_and_fails_closed(monkeypatch) -> Non
         raise AssertionError("adapter reached past a refusing gate")
 
     async def record_outcome(
-        message_id, status, reason, pmid, mark_sent, attempt, retry
+        message_id, status, reason, pmid, mark_sent, attempt, retry, binding_id=None
     ):
         """Test double: records what the dispatcher tried to write."""
         written.update(status=status, reason=reason, mark_sent=mark_sent)
@@ -333,7 +333,9 @@ async def test_a_reclaimed_row_discards_the_late_outcome(monkeypatch) -> None:
         """Test double: a send with a scripted outcome."""
         return SendOutcome(status="accepted", provider_message_id="wamid.L")
 
-    async def reclaimed(message_id, status, reason, pmid, mark_sent, attempt, retry):
+    async def reclaimed(
+        message_id, status, reason, pmid, mark_sent, attempt, retry, binding_id=None
+    ):
         """Test double: the row already belongs to another worker."""
         calls.append(status)
         return False  # the sweep already handed this row to another worker
@@ -523,6 +525,7 @@ def test_outcome_write_is_guarded_by_the_claim() -> None:
         None,
         2,
         MESSAGE_SENDING,
+        None,
     ]
 
 
@@ -788,3 +791,25 @@ def test_customer_fk_is_composite_so_a_message_cannot_cross_tenants() -> None:
     sql = _ddl()
     assert "FOREIGN KEY (merchant_id, customer_id)" in sql
     assert "REFERENCES crm_customer (merchant_id, id)" in sql
+
+
+def test_the_accepted_outcome_stamps_the_pipe_it_left_on_once() -> None:
+    """T16 col 6: binding_id is which pipe the message LEFT on — stamped
+    with the accepted outcome, COALESCEd so it is written once, and left
+    NULL when no pipe was used (blocked)."""
+    query, values = apply_outcome_query(
+        "m-1",
+        "accepted",
+        None,
+        "wamid.T",
+        True,
+        1,
+        None,
+        "7bfe7079-6a19-4116-8f72-e1bde415eb6c",
+    )
+    assert "binding_id = COALESCE(binding_id, $9::uuid)" in query
+    assert values[8] == "7bfe7079-6a19-4116-8f72-e1bde415eb6c"
+    _, values = apply_outcome_query(
+        "m-1", "blocked", "no_binding", None, False, 1, None
+    )
+    assert values[8] is None

--- a/tests/crm/test_event_worker.py
+++ b/tests/crm/test_event_worker.py
@@ -27,13 +27,15 @@ from typing import Any, Dict, List, Optional, Tuple, cast
 import pytest
 
 import app.crm.record.consumers as record_consumers
-import app.crm.record.extractors.shopify as shopify_extractor
+import app.crm.record.extractors.flat as flat_extractor
 import app.crm.record.workers as workers
 import app.crm.shared.worker as worker_mod
+from app.crm.record import catalog
 from app.crm.record.db import DbTxn
 from app.crm.record.db.decoder import decode_raw_event
 from app.crm.record.db.queries import claim_pending_events_query
 from app.crm.record.extractors import EXTRACTORS
+from app.crm.record.extractors.engine import DecodeSpec
 from app.crm.record.schemas import Extracted, RawEvent
 from app.crm.shared.worker import run_drain_loop
 
@@ -43,7 +45,7 @@ from app.crm.shared.worker import run_drain_loop
 
 
 async def _no_plans_live(
-    event: RawEvent, customer_id: str, handles: Dict[str, str]
+    event: RawEvent, customer_id: str, handles: Dict[str, str], variables: Any = None
 ) -> None:
     """The entry-rules consumer with no plans live: the pass must run the
     same with or without outreach reacting."""
@@ -56,6 +58,20 @@ def _no_outreach(monkeypatch: pytest.MonkeyPatch) -> None:
     # subscriber by name (rule 12) — tests wire the slot the same way
     # worker_main does.
     monkeypatch.setattr(record_consumers, "_CONSUMERS", [_no_plans_live])
+
+
+class _NoSchemas:
+    async def get_schema(self, merchant_id: str, source: str, topic: str) -> Any:
+        return None
+
+
+@pytest.fixture(autouse=True)
+def _fresh_catalog_caches(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Discovery's known-set and the identity-mapping cache are process
+    state; each test starts cold, with no registration on file."""
+    catalog._KNOWN.clear()
+    catalog._SPEC_CACHE.clear()
+    monkeypatch.setattr(catalog, "accessor", _NoSchemas())
 
 
 class _FakeSavepoint:
@@ -79,6 +95,7 @@ class _FakeAccessor:
     def __init__(self) -> None:
         self.stamped: List[Tuple[str, Optional[str]]] = []
         self.quarantined: List[Tuple[str, str]] = []
+        self.detected: List[Tuple[str, str, str]] = []
 
     async def stamp_event(
         self, conn: Any, event_id: str, customer_id: Optional[str]
@@ -87,6 +104,14 @@ class _FakeAccessor:
 
     async def quarantine_event(self, conn: Any, event_id: str, reason: str) -> None:
         self.quarantined.append((event_id, reason))
+
+    async def insert_detected_schema(
+        self, conn: Any, merchant_id: str, source: str, topic: str
+    ) -> None:
+        self.detected.append((merchant_id, source, topic))
+
+    async def get_schema(self, merchant_id: str, source: str, topic: str) -> Any:
+        return None
 
 
 def _event(
@@ -159,7 +184,7 @@ def test_a_merchant_level_letter_is_processed_with_no_customer(
     heard: List[Tuple[Optional[str], Any]] = []
 
     async def consumer(
-        event: RawEvent, customer_id: Optional[str], handles: Any
+        event: RawEvent, customer_id: Optional[str], handles: Any, variables: Any = None
     ) -> None:
         heard.append((customer_id, handles))
 
@@ -455,7 +480,7 @@ def test_entry_rules_run_per_row_before_that_row_is_stamped(
     seen: List[Tuple[str, str]] = []
 
     async def fake_consume(
-        event: RawEvent, customer_id: str, handles: Dict[str, str]
+        event: RawEvent, customer_id: str, handles: Dict[str, str], variables: Any
     ) -> None:
         order.append("consume")
         seen.append((event.id, customer_id))
@@ -482,7 +507,10 @@ def test_entry_rules_never_run_for_a_quarantined_row(
     monkeypatch.setattr(workers, "accessor", fake_accessor)
 
     async def fail_consume(
-        event: RawEvent, customer_id: str, handles: Dict[str, str]
+        event: RawEvent,
+        customer_id: str,
+        handles: Dict[str, str],
+        variables: Any = None,
     ) -> None:
         raise AssertionError("entry rules must not see an unattributed row")
 
@@ -509,7 +537,10 @@ def test_a_failing_entry_rule_costs_its_own_row_only(
         return events
 
     async def poison_first(
-        event: RawEvent, customer_id: str, handles: Dict[str, str]
+        event: RawEvent,
+        customer_id: str,
+        handles: Dict[str, str],
+        variables: Any = None,
     ) -> None:
         if event.id == "evt-1":
             raise RuntimeError("workflow rule blew up")
@@ -574,7 +605,10 @@ def _poison_pass(
         return [event]
 
     async def poison(
-        event: RawEvent, customer_id: str, handles: Dict[str, str]
+        event: RawEvent,
+        customer_id: str,
+        handles: Dict[str, str],
+        variables: Any = None,
     ) -> None:
         raise RuntimeError("bad live definition")
 
@@ -621,7 +655,7 @@ def test_pass_returns_claimed_rows_even_when_every_row_failed(
     async def fake_claim(conn: Any, limit: int) -> List[RawEvent]:
         return events
 
-    async def fake_process_one(conn: Any, event: RawEvent) -> None:
+    async def fake_process_one(conn: Any, event: RawEvent, *rest: Any) -> None:
         raise RuntimeError("boom")
 
     monkeypatch.setattr(workers.accessor, "claim_pending_events", fake_claim)
@@ -645,7 +679,7 @@ def test_one_failing_row_does_not_stop_the_rest_of_the_batch(
 
     processed: List[str] = []
 
-    async def fake_process_one(conn: Any, event: RawEvent) -> None:
+    async def fake_process_one(conn: Any, event: RawEvent, *rest: Any) -> None:
         if event.id == "evt-1":
             raise RuntimeError("boom")
         processed.append(event.id)
@@ -980,131 +1014,6 @@ def test_heartbeat_counts_rows_since_the_last_beat(
     assert any(n == 3 for _, n in counted)
 
 
-# --- the Shopify extractor: a pipe's letter, read at the belt ---
-
-
-def test_shopify_extractor_reads_the_nested_customer_phone() -> None:
-    # The relay forwards Shopify's body unopened, so the phone arrives
-    # nested and the top-level one is usually null.
-    extracted = shopify_extractor.extract(
-        {
-            "phone": None,
-            "customer": {
-                "first_name": "Priya",
-                "last_name": "Sharma",
-                "phone": "+91 98765 43210",
-            },
-            "shipping_address": {"phone": "9999999999"},
-        }
-    )
-    assert extracted.handles["phone"] == "+919876543210"  # normalized
-    assert extracted.facts == {"name": "Priya Sharma"}
-
-
-def test_shopify_extractor_falls_back_to_the_shipping_contact() -> None:
-    # A guest checkout carries no customer object at all.
-    extracted = shopify_extractor.extract(
-        {
-            "shipping_address": {
-                "first_name": "Rohan",
-                "last_name": "Mehta",
-                "phone": "9876543210",
-            }
-        }
-    )
-    assert extracted.handles["phone"] == "+919876543210"
-    assert extracted.facts == {"name": "Rohan Mehta"}
-
-
-def test_shopify_extractor_never_invents_a_name() -> None:
-    # A placeholder would reach assert_facts as a real name claim and
-    # overwrite what we actually know. Absent is absent.
-    extracted = shopify_extractor.extract({"customer": {"phone": "9876543210"}})
-    assert extracted.facts == {}
-
-
-def test_shopify_extractor_skips_an_unusable_phone() -> None:
-    # normalize_phone returns None rather than writing a bad handle; with
-    # nothing usable the row quarantines no_handle and stays replayable.
-    extracted = shopify_extractor.extract({"customer": {"phone": "n/a"}})
-    assert "phone" not in extracted.handles
-
-
-def test_shopify_extractor_takes_the_email_too() -> None:
-    extracted = shopify_extractor.extract(
-        {"customer": {"email": "  Priya@Example.COM  ", "phone": "9876543210"}}
-    )
-    assert extracted.handles["email"] == "priya@example.com"
-
-
-def test_shopify_source_is_registered() -> None:
-    # Without the registration a raw Shopify body falls to _extract_flat,
-    # which looks for a top-level customer_mobile_number that is not
-    # there — every order would quarantine no_handle.
-    assert EXTRACTORS["shopify"] is shopify_extractor.extract
-
-
-def test_shopify_extractor_takes_the_customer_id_handle() -> None:
-    # The corpus's own example for this extractor is
-    # shopify/checkouts.create -> {phone, email, shopify_customer_id}.
-    extracted = shopify_extractor.extract(
-        {"customer": {"id": 77, "phone": "9876543210"}}
-    )
-    assert extracted.handles["shopify_customer_id"] == "77"
-
-
-def test_shopify_extractor_resolves_a_phoneless_checkout_frame() -> None:
-    # The checkouts/update stream's early frames carry no phone — she
-    # types it later — but a signed-in shopper's customer id is there
-    # from the first frame. Without this handle those frames quarantine
-    # no_handle; with it they attribute to the person.
-    extracted = shopify_extractor.extract(
-        {"token": "chk-88412", "phone": None, "customer": {"id": 77}}
-    )
-    assert extracted.handles == {"shopify_customer_id": "77"}
-    assert extracted.facts == {}
-
-
-def test_shopify_extractor_omits_the_id_handle_for_a_guest() -> None:
-    # A guest checkout carries no customer object at all.
-    extracted = shopify_extractor.extract({"shipping_address": {"phone": "9876543210"}})
-    assert "shopify_customer_id" not in extracted.handles
-
-
-def test_shopify_extractor_reads_the_default_address() -> None:
-    # design/ingest-doors names customer.default_address.phone as this
-    # extractor's mapping: a returning shopper's number often lives only
-    # there, with the customer object itself carrying none.
-    extracted = shopify_extractor.extract(
-        {
-            "customer": {
-                "id": 77,
-                "phone": None,
-                "default_address": {
-                    "phone": "9876543210",
-                    "first_name": "Priya",
-                    "last_name": "Sharma",
-                },
-            }
-        }
-    )
-    assert extracted.handles["phone"] == "+919876543210"
-    assert extracted.facts == {"name": "Priya Sharma"}
-
-
-def test_shopify_extractor_prefers_the_customer_phone_over_default_address() -> None:
-    # Probe order is the law: most specific first.
-    extracted = shopify_extractor.extract(
-        {
-            "customer": {
-                "phone": "+919999999999",
-                "default_address": {"phone": "9876543210"},
-            }
-        }
-    )
-    assert extracted.handles["phone"] == "+919999999999"
-
-
 def test_pass_hands_the_extractors_handles_to_the_consumer() -> None:
     # THE divergence this closes: the extractor searches four places for a
     # phone, the consumer's own payload reader searches three — and the
@@ -1121,7 +1030,7 @@ def test_pass_hands_the_extractors_handles_to_the_consumer() -> None:
     async def fake_facts(*a: Any, **k: Any) -> None:
         return None
 
-    async def fake_consume(event, customer_id, handles):  # type: ignore[no-untyped-def]
+    async def fake_consume(event, customer_id, handles, variables):  # type: ignore[no-untyped-def]
         seen["handles"] = handles
 
     workers.crm_resolve = fake_resolve  # type: ignore[assignment]
@@ -1132,6 +1041,8 @@ def test_pass_hands_the_extractors_handles_to_the_consumer() -> None:
         return None
 
     workers.accessor.stamp_event = fake_stamp  # type: ignore[assignment]
+    # the discovery nudge writes through the same accessor on a real txn
+    workers.accessor.insert_detected_schema = fake_stamp  # type: ignore[assignment]
 
     event = RawEvent(
         id="e1",
@@ -1150,3 +1061,187 @@ def test_pass_hands_the_extractors_handles_to_the_consumer() -> None:
 
     # the number the sends will dial is the number identity resolved on
     assert seen["handles"]["phone"] == "+919876543210"
+
+
+# ---------------------------------------------------------------------------
+# The catalog's hot-path pieces (canon T24 wiring)
+# ---------------------------------------------------------------------------
+
+
+def test_discovery_never_nudges_for_a_code_layer_topic(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Shopify's orders/create is declared in code: nobody has to register
+    it, so no detected row is written for it — the nudge is for vendors."""
+    fake_accessor = _FakeAccessor()
+    monkeypatch.setattr(workers, "accessor", fake_accessor)
+
+    async def fake_resolve(merchant_id: str, handles: Dict[str, str], **kw: Any) -> str:
+        return "cust-1"
+
+    monkeypatch.setattr(workers, "crm_resolve", fake_resolve)
+    event = _event(
+        source="shopify",
+        topic="orders/create",
+        payload={"customer": {"phone": "9876543210"}},
+    )
+    _run(workers._process_one(_fake_txn(), event))
+    assert fake_accessor.detected == []
+    assert fake_accessor.stamped == [("evt-1", "cust-1")]
+
+
+def _pass_over(
+    monkeypatch: pytest.MonkeyPatch,
+    fake_accessor: _FakeAccessor,
+    events: List[RawEvent],
+) -> None:
+    """run_pass with the atom faked: the body runs over a fake txn, and
+    run_pass's after-commit step (marking discovered topics) is real."""
+
+    async def fake_claim(conn: Any, limit: int) -> List[RawEvent]:
+        return list(events)
+
+    async def fake_atomically(fn: Any, *args: Any) -> Any:
+        return await fn(_fake_txn(), *args)
+
+    monkeypatch.setattr(
+        fake_accessor, "claim_pending_events", fake_claim, raising=False
+    )
+    monkeypatch.setattr(workers, "atomically", fake_atomically)
+    _run(workers.run_pass(10))
+
+
+def test_discovery_writes_the_nudge_row_once_per_topic_ever(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_accessor = _FakeAccessor()
+    monkeypatch.setattr(workers, "accessor", fake_accessor)
+
+    async def fake_resolve(merchant_id: str, handles: Dict[str, str], **kw: Any) -> str:
+        return "cust-1"
+
+    monkeypatch.setattr(workers, "crm_resolve", fake_resolve)
+
+    # three of one topic and one of another in one pass; then a second pass
+    _pass_over(
+        monkeypatch,
+        fake_accessor,
+        [_event(event_id=f"evt-{i}") for i in range(3)]
+        + [_event(event_id="evt-x", topic="lead.updated")],
+    )
+    _pass_over(monkeypatch, fake_accessor, [_event(event_id="evt-later")])
+
+    assert fake_accessor.detected == [
+        ("m1", "lead-api", "lead.pushed"),
+        ("m1", "lead-api", "lead.updated"),
+    ]
+    assert catalog.is_known(("m1", "lead-api", "lead.pushed"))
+    assert catalog.is_known(("m1", "lead-api", "lead.updated"))
+
+
+def test_a_rolled_back_nudge_is_not_remembered_as_written(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The nudge INSERT shares the row's savepoint: a consumer raise rolls
+    it back. Marking the topic known at INSERT time would then hide the
+    loss until a restart; marking after the commit — and only rows that
+    survived — means the next pass writes it again."""
+    fake_accessor = _FakeAccessor()
+    monkeypatch.setattr(workers, "accessor", fake_accessor)
+
+    async def fake_resolve(merchant_id: str, handles: Dict[str, str], **kw: Any) -> str:
+        return "cust-1"
+
+    monkeypatch.setattr(workers, "crm_resolve", fake_resolve)
+    blow_up = {"on": True}
+
+    async def poison(event: RawEvent, *rest: Any) -> None:
+        if blow_up["on"]:
+            raise RuntimeError("workflow rule blew up")
+
+    monkeypatch.setattr(workers, "_consume_attributed_event", poison)
+
+    _pass_over(monkeypatch, fake_accessor, [_event(event_id="evt-1")])
+    key = ("m1", "lead-api", "lead.pushed")
+    assert fake_accessor.detected == [key], "the INSERT ran (and rolled back)"
+    assert not catalog.is_known(key), "...so it must not be remembered"
+
+    blow_up["on"] = False
+    _pass_over(monkeypatch, fake_accessor, [_event(event_id="evt-1", attempts=2)])
+    assert fake_accessor.detected == [key, key], "the next pass writes it again"
+    assert catalog.is_known(key)
+
+
+def test_the_processor_alone_never_marks_a_topic_known(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """_process_one returns the key it nudged; only run_pass, after the
+    commit, marks it. (A code-layer topic writes nothing and is marked at
+    once — test_discovery_never_nudges_for_a_code_layer_topic.)"""
+    fake_accessor = _FakeAccessor()
+    monkeypatch.setattr(workers, "accessor", fake_accessor)
+
+    async def fake_resolve(merchant_id: str, handles: Dict[str, str], **kw: Any) -> str:
+        return "cust-1"
+
+    monkeypatch.setattr(workers, "crm_resolve", fake_resolve)
+    key = _run(workers._process_one(_fake_txn(), _event()))
+    assert key == ("m1", "lead-api", "lead.pushed")
+    assert not catalog.is_known(key)
+
+
+def test_a_registered_identity_mapping_decodes_the_vendors_own_names(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """NammaYatri marks rider_phone as identity:phone and never renames a
+    thing: the generic extractor reads the mapping, normalizes, resolves —
+    and the handles ride to the consumers like any extractor's would."""
+    fake_accessor = _FakeAccessor()
+    monkeypatch.setattr(workers, "accessor", fake_accessor)
+
+    async def spec(merchant_id: str, source: str, topic: str) -> DecodeSpec:
+        return DecodeSpec(
+            identity={"phone": ["payload.rider.phone"], "name": ["payload.rider.name"]},
+            variables={"ride_id": "payload.ride_id"},
+        )
+
+    monkeypatch.setattr(catalog, "decode_spec", spec)
+
+    seen: Dict[str, Any] = {}
+
+    async def fake_resolve(merchant_id: str, handles: Dict[str, str], **kw: Any) -> str:
+        seen["handles"] = handles
+        return "cust-9"
+
+    facts_calls: List[Dict[str, Any]] = []
+
+    async def fake_assert_facts(
+        merchant_id: str, customer_id: str, facts: Dict[str, Any], **kw: Any
+    ) -> None:
+        facts_calls.append(facts)
+
+    monkeypatch.setattr(workers, "crm_resolve", fake_resolve)
+    monkeypatch.setattr(workers, "assert_facts", fake_assert_facts)
+
+    event = _event(
+        source="nammayatri",
+        topic="ride.cancelled",
+        payload={"ride_id": "R1", "rider": {"phone": "9876543210", "name": "Asha"}},
+    )
+    _run(workers._process_one(_fake_txn(), event))
+
+    assert seen["handles"] == {"phone": "+919876543210"}
+    assert facts_calls == [{"name": "Asha"}]
+    assert fake_accessor.stamped == [("evt-1", "cust-9")]
+
+
+def test_no_mapping_and_no_standard_keys_still_quarantines(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_accessor = _FakeAccessor()
+    monkeypatch.setattr(workers, "accessor", fake_accessor)
+    event = _event(
+        source="nammayatri", topic="ride.cancelled", payload={"ride_id": "R1"}
+    )
+    _run(workers._process_one(_fake_txn(), event))
+    assert fake_accessor.quarantined == [("evt-1", "no_handle")]

--- a/tests/crm/test_ingress_door.py
+++ b/tests/crm/test_ingress_door.py
@@ -189,8 +189,10 @@ def test_only_the_webhook_router_is_unauthenticated() -> None:
 
     Both directions matter: auth appearing on the provider bays locks the
     provider out and silently stops every event, and auth going missing
-    from any /connectors route would expose connector administration to
-    anyone.
+    from any /connectors, /ingest or /catalog route would expose the door
+    to anyone. The walk reads DECLARED dependencies — a check awaited on a
+    handler's first line is invisible to it, which is the point: a route
+    without its auth dependency is a BLOCKER (design/ingest-doors).
     """
 
     def dependency_names(route) -> list:
@@ -225,6 +227,19 @@ def test_only_the_webhook_router_is_unauthenticated() -> None:
         assert carries(route, "get_current_user_with_rbac"), getattr(
             route, "path", route
         )
+    # Every /ingest door (the envelope and the S2S schema registration)
+    # declares the s2s verifier — by body or by query, one of the two
+    # dependencies that call verify_s2s_caller.
+    assert record_api.ingest_router.routes, "the ingest router has doors"
+    for route in record_api.ingest_router.routes:
+        assert carries(route, "verified_caller") or carries(
+            route, "verified_merchant_caller"
+        ), getattr(route, "path", route)
+    # Every /catalog and /schemas console route is the admin's (ADR 0007
+    # phase 1); merchant users take merchant_scope when "Your events" ships.
+    assert record_api.catalog_router.routes, "the catalog router has routes"
+    for route in record_api.catalog_router.routes:
+        assert carries(route, "crm_admin_user"), getattr(route, "path", route)
 
 
 def test_a_callback_carrying_no_letters_is_still_200(client, spec, spine) -> None:

--- a/tests/crm/test_migration_069.py
+++ b/tests/crm/test_migration_069.py
@@ -1,0 +1,103 @@
+"""Migration 069 over BOTH entry shapes: the single door object and the
+list of doors (rollout phase 15). Runs the migration's own SQL, verbatim,
+against a temp table that shadows crm_workflow for the session — so the
+statements under test are the statements that ship, not a copy.
+
+  CRM_WEBHOOK_TEST_DSN=postgresql:///crm_webhook_test uv run pytest \\
+      tests/crm/test_migration_069.py
+
+Unset, the DB-backed tests skip (tests/crm/conftest.py)."""
+
+import asyncio
+import json
+from pathlib import Path
+from typing import Any, Dict, List
+
+import asyncpg
+import pytest
+
+from tests.crm.conftest import CRM_WEBHOOK_TEST_DSN as DSN
+
+pytestmark = pytest.mark.skipif(
+    not DSN, reason="set CRM_WEBHOOK_TEST_DSN to run the DB-backed migration test"
+)
+
+SQL = Path("app/database/migrations/069_migrate_workflow_where_to_conditions.sql")
+
+OBJECT_SHAPE = {
+    "entry": {"topic": "orders/create", "where": {"gateway": "COD"}},
+    "nodes": [],
+}
+LIST_SHAPE = {
+    "entry": [
+        {"topic": "orders/create", "start": "a", "where": {"gateway": "COD"}},
+        {"topic": "orders/paid", "start": "b"},
+        {"topic": "checkouts/update", "start": "c", "where": {"currency": "INR"}},
+    ],
+    "nodes": [],
+}
+ALREADY_TYPED = {
+    "entry": [
+        {
+            "topic": "orders/create",
+            "start": "a",
+            "where": [{"field": "payload.gateway", "op": "is", "value": "UPI"}],
+        }
+    ],
+    "nodes": [],
+}
+COD = [{"field": "payload.gateway", "op": "is", "value": "COD"}]
+INR = [{"field": "payload.currency", "op": "is", "value": "INR"}]
+
+
+async def _migrate(rows: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    conn = await asyncpg.connect(DSN)
+    try:
+        await conn.execute(
+            "CREATE TEMP TABLE crm_workflow (n int, definition jsonb, draft jsonb)"
+        )
+        for i, row in enumerate(rows):
+            await conn.execute(
+                "INSERT INTO crm_workflow VALUES ($1, $2::jsonb, $3::jsonb)",
+                i,
+                json.dumps(row["definition"]) if row.get("definition") else None,
+                json.dumps(row["draft"]) if row.get("draft") else None,
+            )
+        await conn.execute(SQL.read_text())
+        await conn.execute(SQL.read_text())  # idempotent: a re-run is a no-op
+        out = await conn.fetch("SELECT definition, draft FROM crm_workflow ORDER BY n")
+        return [
+            {
+                "definition": json.loads(r["definition"]) if r["definition"] else None,
+                "draft": json.loads(r["draft"]) if r["draft"] else None,
+            }
+            for r in out
+        ]
+    finally:
+        await conn.close()
+
+
+def test_069_rewrites_the_object_shape_and_every_door_of_the_list_shape() -> None:
+    rows = asyncio.run(
+        _migrate(
+            [
+                {"definition": OBJECT_SHAPE, "draft": OBJECT_SHAPE},
+                {"definition": LIST_SHAPE, "draft": LIST_SHAPE},
+                {"definition": ALREADY_TYPED, "draft": None},
+            ]
+        )
+    )
+    for column in ("definition", "draft"):
+        assert rows[0][column]["entry"]["where"] == COD
+        doors = rows[1][column]["entry"]
+        assert [d["topic"] for d in doors] == [
+            "orders/create",
+            "orders/paid",
+            "checkouts/update",
+        ], "door order is kept"
+        assert doors[0]["where"] == COD
+        assert "where" not in doors[1], "a door with no map is untouched"
+        assert doors[2]["where"] == INR
+        assert doors[0]["start"] == "a", "the door's other words survive"
+    assert rows[2]["definition"] == ALREADY_TYPED, "typed already: not touched"
+    assert rows[2]["draft"] is None

--- a/tests/crm/test_plan_templates.py
+++ b/tests/crm/test_plan_templates.py
@@ -14,8 +14,10 @@ from typing import Any, Dict, List, Optional, Set, Tuple
 import pytest
 
 from app.crm.outreach.ladder import expand_stages
-from app.crm.outreach.plans import validate_definition
+from app.crm.outreach.plans import Catalogs, validate_definition
 from app.crm.outreach.schemas import WorkflowDefinition
+from app.crm.record.catalog import code_entries
+from app.crm.record.contracts import CatalogField
 
 PLANS = Path(__file__).resolve().parents[2] / "docs" / "crm" / "plans"
 CART = PLANS / "cart-recovery.json"
@@ -47,6 +49,32 @@ def _slug(topic: str) -> str:
     return topic.split(".")[-1].replace("_", "-")
 
 
+def _loan_registration() -> Dict[str, CatalogField]:
+    """What the loan vendor signs at enrollment (POST /ingest/schemas): the
+    one field every loan.* door keys on. The board cannot validate without
+    it — which is the point: a keyed door needs its topic in the catalog."""
+    field = CatalogField(
+        path="payload.application_id",
+        type="text",
+        label="Application",
+        keyable=True,
+        ops=["is", "is_not", "in", "exists"],
+    )
+    return {field.path: field}
+
+
+def _catalogs() -> Catalogs:
+    """The CODE catalog (Shopify's declared fields, by topic) plus the loan
+    vendor's registration — so every catalog law runs over the shipped
+    boards on every CI run, never `catalogs=None` (which skips them all)."""
+    catalogs: Dict[str, Optional[Dict[str, CatalogField]]] = {
+        entry.topic: {f.path: f for f in entry.fields} for entry in code_entries()
+    }
+    for topic in [*LOAN_STAGES, LOAN_DONE, *LOAN_OUT]:
+        catalogs[topic] = _loan_registration()
+    return catalogs
+
+
 def test_the_expected_documents_exist() -> None:
     assert CART.is_file(), CART
     assert LOAN.is_file(), LOAN
@@ -56,7 +84,27 @@ def test_the_expected_documents_exist() -> None:
 
 @pytest.mark.parametrize("path", _every_plan(), ids=lambda p: p.stem)
 def test_every_plan_template_validates(path: Path) -> None:
-    assert validate_definition(_load(path)) == [], path
+    assert validate_definition(_load(path), catalogs=_catalogs()) == [], path
+
+
+def test_the_catalog_laws_actually_run_over_the_boards() -> None:
+    """The guard on the guard: with the catalog in hand, a send mapping a
+    fact Shopify never declares is refused — so a passing suite means the
+    boards' maps and keys were judged, not skipped."""
+    doc = _load(CART)
+    send = next(n for n in doc["nodes"] if n["type"] == "send")
+    send["variables"] = {"1": "loyalty_tier"}
+    problems = validate_definition(doc, catalogs=_catalogs())
+    assert any("loyalty_tier" in p and "not a declared variable" in p for p in problems)
+
+
+def test_every_cart_send_maps_its_blanks() -> None:
+    """send_variables posts EXACTLY the map, nothing when it is empty — a
+    shipped board with an unmapped send would refuse on every send."""
+    for path in (CART, CART_FALLBACK):
+        for node in _load(path)["nodes"]:
+            if node["type"] == "send":
+                assert node.get("variables") == {"1": "customer_name"}, (path, node)
 
 
 def test_cart_recovery_is_the_final_shape_from_the_notes() -> None:

--- a/tests/crm/test_predicate.py
+++ b/tests/crm/test_predicate.py
@@ -1,0 +1,99 @@
+"""The where-grammar (app/crm/shared/predicate.py): the closed op set, the
+value shapes each op accepts, and the conservative evaluator — a missing
+field satisfies nothing, the `is` family compares text exactly, and only
+`=` and the ordering ops read numeric strings as numbers."""
+
+import pytest
+
+from app.crm.shared.predicate import Condition, evaluate, from_equality_map, matches
+
+
+@pytest.mark.parametrize(
+    "op, value, actual, expected",
+    [
+        ("is", "COD", "COD", True),
+        ("is", "COD", "cod", False),
+        ("is", "5", "5", True),
+        ("is", True, True, True),
+        # text-strict: no numeric coercion inside the is family, so a stale
+        # filter on a TEXT field cannot quietly widen who gets contacted
+        ("is", "7", "007", False),
+        ("is", "1", 1.0, False),
+        ("is", 5, "5", False),
+        ("is", 5, 5, True),
+        ("is", "true", True, False),
+        ("is", True, "true", False),
+        ("is_not", "7", "007", True),
+        ("in", ["7"], "007", False),
+        ("in", [5], "5", False),
+        # ...and `=` is where numbers meet
+        ("=", 7, "007", True),
+        ("is_not", "COD", "UPI", True),
+        ("is_not", "COD", "COD", False),
+        ("in", ["COD", "UPI"], "UPI", True),
+        ("in", ["COD"], "UPI", False),
+        (">", 1000, "1850.00", True),
+        (">", 1000, 999.5, False),
+        (">=", 1000, 1000, True),
+        ("<", 1000, "abc", False),
+        ("<=", "2026-09-01T00:00:00+00:00", "2026-08-31T10:00:00Z", True),
+        ("=", 2, 2.0, True),
+        ("=", 2, "two", False),
+        ("exists", None, "", True),
+        ("exists", None, 0, True),
+    ],
+)
+def test_evaluate(op, value, actual, expected) -> None:
+    assert (
+        evaluate(Condition(field="payload.x", op=op, value=value), actual) is expected
+    )
+
+
+@pytest.mark.parametrize(
+    "op, value",
+    [("is", "COD"), ("is_not", "COD"), ("in", ["COD"]), (">", 1), ("exists", None)],
+)
+def test_missing_field_satisfies_nothing(op, value) -> None:
+    assert evaluate(Condition(field="payload.x", op=op, value=value), None) is False
+
+
+@pytest.mark.parametrize(
+    "op, value",
+    [
+        ("in", "COD"),
+        ("in", []),
+        ("in", [None]),
+        ("exists", 1),
+        ("is", None),
+        ("is", [1]),
+        (">", {"a": 1}),
+    ],
+)
+def test_value_shape_is_checked_at_the_shape(op, value) -> None:
+    with pytest.raises(ValueError):
+        Condition(field="payload.x", op=op, value=value)
+
+
+def test_unknown_op_is_refused() -> None:
+    with pytest.raises(ValueError):
+        Condition(field="payload.x", op="contains", value="x")  # type: ignore[arg-type]
+
+
+def test_matches_is_and() -> None:
+    payload = {"gateway": "COD", "total": "1850.00"}
+    lookup = lambda p: payload.get(p.removeprefix("payload."))  # noqa: E731
+    both = [
+        Condition(field="payload.gateway", op="is", value="COD"),
+        Condition(field="payload.total", op=">", value=1000),
+    ]
+    assert matches(both, lookup)
+    assert not matches(
+        both + [Condition(field="payload.total", op="<", value=1000)], lookup
+    )
+    assert matches([], lookup)
+
+
+def test_from_equality_map_is_what_migration_069_writes() -> None:
+    assert from_equality_map({"gateway": "COD"}) == [
+        Condition(field="payload.gateway", op="is", value="COD")
+    ]

--- a/tests/crm/test_worker_runtime.py
+++ b/tests/crm/test_worker_runtime.py
@@ -160,6 +160,33 @@ def _wire(
     return run
 
 
+def test_declared_variables_ride_into_the_run_context_and_win(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The engine resolved the catalog's variable fields (nested paths,
+    derived names) — they land in context beside the scalar copy and
+    override it; a bookkeeping name in the variables is still ours."""
+    calls: List[Any] = []
+    _wire(monkeypatch, _flow(), calls)
+    event = _event("checkout.initiated")
+    asyncio.run(
+        entry.consume_attributed_event(
+            event,
+            "cust-1",
+            variables={
+                "customer_name": "Priya Sharma",
+                "cart_value": 2999,
+                "source_event_id": "forged",
+            },
+        )
+    )
+    ((kind, kwargs),) = calls
+    assert kind == "enrol"
+    assert kwargs["context"]["customer_name"] == "Priya Sharma"
+    assert kwargs["context"]["cart_value"] == 2999  # declared beats the scalar copy
+    assert kwargs["context"]["source_event_id"] == event.id
+
+
 def test_entry_topic_enrols_with_phone_and_small_facts(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -271,7 +298,10 @@ def test_a_failure_propagates_to_the_row_savepoint(
 # --- W5: entry.where and wait_event ---
 
 _COD_DEFINITION = {
-    "entry": {"topic": "orders/create", "where": {"gateway": "COD"}},
+    "entry": {
+        "topic": "orders/create",
+        "where": [{"field": "payload.gateway", "op": "is", "value": "COD"}],
+    },
     "nodes": [
         {
             "id": "ask",
@@ -350,18 +380,26 @@ def test_pick_next_takes_the_answer_edge_or_timeout() -> None:
 # --- the send node proposes one manifest row ---
 
 
-def test_send_variables_are_the_small_facts_only() -> None:
+def test_send_variables_are_only_the_mapped_facts() -> None:
+    """A template with two blanks handed 27 facts is refused by every
+    provider (the COD demo: 'confirmed' is bool) — the send node names
+    which fact fills which blank, and an unmapped template posts none."""
     context = {
         "phone": "+91…",
         "customer_mobile_number": "98450 12345",
         "source_event_id": "e1",
-        "name": "Priya",
+        "customer_name": "Priya",
+        "name": "#1001",
         "cart_value": 1999,
+        "confirmed": True,
         "lead_call": "L1",
         "message_ask": "M1",
         "reply_reply": "YES",
     }
-    assert send_variables(context) == {"name": "Priya", "cart_value": 1999}
+    assert send_variables(
+        {"customer_name": "customer_name", "order_no": "name"}, context
+    ) == {"customer_name": "Priya", "order_no": "#1001"}
+    assert send_variables({}, context) == {}  # hello_world: zero parameters
 
 
 # --- entry.key: what a run is about (canon T20 col 13, ruled 31 Aug 2026) ---

--- a/tests/crm/test_workflow_ladder.py
+++ b/tests/crm/test_workflow_ladder.py
@@ -348,6 +348,11 @@ async def test_create_and_draft_store_the_ladder_and_its_board(
 
     monkeypatch.setattr(plans.workflow_accessor, "insert_workflow", insert_workflow)
     monkeypatch.setattr(plans.workflow_accessor, "update_draft", update_draft)
+
+    async def no_catalogs(merchant_id: str, raw: Dict[str, Any]) -> plans.Catalogs:
+        return None  # nothing gathered (a DB read): shape laws are the point here
+
+    monkeypatch.setattr(plans, "_gather_catalogs", no_catalogs)
     await plans.create_workflow("m1", "loan-dropoff", _ladder(), "ops@x")
     await plans.update_draft("m1", "wf-1", _ladder())
     assert stored == [expand_stages(_ladder())] * 2

--- a/tests/crm/test_workflow_plans.py
+++ b/tests/crm/test_workflow_plans.py
@@ -15,6 +15,8 @@ from app.crm.outreach.schemas import (
     Workflow,
     WorkflowDefinition,
 )
+from app.crm.record.catalog import code_entries
+from app.crm.record.schemas import CatalogField
 from tests.crm.doubles import patch_accessors
 
 NOW = datetime(2026, 9, 3, 10, 0, tzinfo=timezone.utc)
@@ -22,7 +24,11 @@ NOW = datetime(2026, 9, 3, 10, 0, tzinfo=timezone.utc)
 
 def _definition(**overrides):
     base = {
-        "entry": {"topic": "checkout.initiated", "reenter": True, "cooldown_hours": 0},
+        "entry": {
+            "topic": "checkout.initiated",
+            "reenter": True,
+            "cooldown_hours": 0,
+        },
         "nodes": [
             {"id": "wait-30m", "type": "wait", "minutes": 30},
             {"id": "rescue-call", "type": "call", "template_id": "tpl-1"},
@@ -152,7 +158,10 @@ def test_publish_refuses_an_entry_change_while_runs_are_open_in_migrate_mode() -
 
 
 _COD = {
-    "entry": {"topic": "orders/create", "where": {"gateway": "COD"}},
+    "entry": {
+        "topic": "orders/create",
+        "where": [{"field": "payload.gateway", "op": "is", "value": "COD"}],
+    },
     "nodes": [
         {
             "id": "ask",
@@ -787,3 +796,128 @@ def test_else_is_one_catch_all_arrow_out_of_a_listening_square() -> None:
     plain = [["call", "after-call"], ["again", "done", "else"]]
     problems = validate_definition(_definition(nodes=_CALL_THEN_LISTEN, edges=plain))
     assert any("only a wait_event" in p and "again" in p for p in problems)
+
+
+def _orders_create_catalog() -> Dict[str, CatalogField]:
+    entry = next(e for e in code_entries() if e.topic == "orders/create")
+    return {f.path: f for f in entry.fields}
+
+
+def test_each_door_is_checked_against_its_own_topics_catalog() -> None:
+    """Phase 15 x the catalog: the laws run once per door. A declared
+    field on the orders/create door passes; a where on a door whose topic
+    no layer knows is refused; a door-list still refuses the legacy map."""
+    doors = {
+        **_LADDER,
+        "entry": [
+            {
+                "topic": "orders/create",
+                "start": "at-profile",
+                "where": [{"field": "payload.gateway", "op": "is", "value": "COD"}],
+            },
+            {
+                "topic": "loan.kyc_completed",
+                "start": "at-kyc",
+                "where": [{"field": "payload.stage", "op": "is", "value": "kyc"}],
+            },
+        ],
+    }
+    del doors["key"]  # application_id is not a declared field on orders/create
+    catalogs: plans.Catalogs = {
+        "orders/create": _orders_create_catalog(),
+        "loan.kyc_completed": None,
+    }
+    problems = validate_definition(doors, catalogs=catalogs)
+    assert problems == [
+        "topic 'loan.kyc_completed' is not in the catalog — register its schema "
+        "(or declare it in code) before filtering, keying or templating on it"
+    ]
+    legacy = {
+        **doors,
+        "entry": [doors["entry"][0], {**doors["entry"][1], "where": {"stage": "kyc"}}],
+    }
+    assert any("equality map is retired" in p for p in validate_definition(legacy))
+
+
+def _send(**words) -> Dict[str, Any]:
+    node = {"id": "confirm", "type": "send", "channel": "whatsapp", "template": "t"}
+    node.update(words)
+    return {
+        **_COD,
+        "nodes": [node],
+        "edges": [],
+        "purpose_key": "utility.order.confirm",
+    }
+
+
+def test_send_variables_map_shape_laws() -> None:
+    assert validate_definition(_send()) == []  # no blanks: zero parameters
+    assert validate_definition(_send(variables={"1": "customer_name"})) == []
+    problems = validate_definition(_send(variables={"1": "name", "order_no": "name"}))
+    assert any("mix positional" in p for p in problems)
+    problems = validate_definition(_send(variables={"": "name"}))
+    assert any("template blank on the left" in p for p in problems)
+
+
+def test_send_variables_must_be_declared_variable_fields_on_the_entry_topic() -> None:
+    """event-catalog.md: template variables ONLY from declared fields —
+    the derived customer_name and Shopify's own order name pass; a typo,
+    a bool field, and an identity (phone) do not."""
+    catalogs: plans.Catalogs = {"orders/create": _orders_create_catalog()}
+    ok = _send(variables={"customer_name": "customer_name", "order_no": "name"})
+    assert validate_definition(ok, catalogs=catalogs) == []
+    for fact in ("customer_nmae", "confirmed", "phone"):
+        problems = validate_definition(_send(variables={"1": fact}), catalogs=catalogs)
+        assert any(
+            f"<- {fact!r} is not a declared variable field" in p for p in problems
+        ), fact
+    # an unknown topic may trigger a plan, but its facts cannot fill a template
+    unknown = {**_send(variables={"1": "name"}), "entry": {"topic": "ride.done"}}
+    problems = validate_definition(unknown, catalogs={"ride.done": None})
+    assert any("before filtering, keying or templating" in p for p in problems)
+
+
+def test_send_variables_may_name_a_stage_letters_fact_and_the_square() -> None:
+    """Phase 16 x the map: a wait_event square's letter is reachable as
+    facts_<square>_<key> for the variable fields its topics declare, and
+    the walker's own current_node / current_stage are always allowed."""
+    orders = _orders_create_catalog()
+    doc: Dict[str, Any] = {
+        **_COD,
+        "nodes": [
+            {
+                "id": "ask",
+                "type": "wait_event",
+                "topics": ["orders/paid"],
+                "key": "$topic",
+                "minutes": 60,
+                "stage": "paid",
+            },
+            {
+                "id": "thanks",
+                "type": "send",
+                "channel": "whatsapp",
+                "template": "t",
+                "variables": {
+                    "1": "facts_ask_name",
+                    "2": "current_stage",
+                    "3": "customer_name",
+                },
+            },
+        ],
+        "edges": [["ask", "thanks", "orders/paid"]],
+        "purpose_key": "utility.order.thanks",
+    }
+    catalogs: plans.Catalogs = {"orders/create": orders, "orders/paid": orders}
+    assert validate_definition(doc, catalogs=catalogs) == []
+    bad = {
+        **doc,
+        "nodes": [
+            doc["nodes"][0],
+            {**doc["nodes"][1], "variables": {"1": "facts_ask_confirmed"}},
+        ],
+    }
+    problems = validate_definition(bad, catalogs=catalogs)
+    assert any(
+        "'facts_ask_confirmed' is not a declared variable field" in p for p in problems
+    )

--- a/tests/crm/test_workflow_repeat.py
+++ b/tests/crm/test_workflow_repeat.py
@@ -199,6 +199,8 @@ def test_a_refused_enrol_hands_the_repeat_to_apply_repeat(
         {
             "id": "ev-9",
             "merchant_id": "m1",
+            "source": "lead-api",
+            "topic": "checkout.initiated",
             "received_at": _NOW,
             "occurred_at": None,
             "payload": {
@@ -236,6 +238,8 @@ def test_a_successful_enrol_never_calls_apply_repeat(
         {
             "id": "ev-1",
             "merchant_id": "m1",
+            "source": "lead-api",
+            "topic": "checkout.initiated",
             "received_at": _NOW,
             "occurred_at": None,
             "payload": {},
@@ -335,6 +339,8 @@ def test_the_repeat_carries_the_refreshed_phone_but_never_the_founding_id(
         {
             "id": "ev-9",
             "merchant_id": "m1",
+            "source": "lead-api",
+            "topic": "checkout.initiated",
             "received_at": _NOW,
             "occurred_at": None,
             "payload": {"customer_mobile_number": "9876543210", "cart_value": 900},

--- a/tests/crm/test_workflow_runs.py
+++ b/tests/crm/test_workflow_runs.py
@@ -76,7 +76,15 @@ def test_call_payload_and_send_variables_share_one_bookkeeping_filter() -> None:
         "cart_value": 1999,
         "repeat_count": 3,
     }
-    assert send_variables(context) == {"cart_value": 1999, "repeat_count": 3}
+    # The send posts EXACTLY what the node mapped, {blank: fact} — nothing
+    # rides along, whatever else the context holds.
+    assert send_variables({"1": "cart_value", "n": "repeat_count"}, context) == {
+        "1": 1999,
+        "n": 3,
+    }
+    assert send_variables({}, context) == {}
+    with pytest.raises(KeyError):
+        send_variables({"1": "cart_value", "2": "coupon"}, context)
 
 
 def test_lead_request_id_is_the_merchants_order_id_else_the_run() -> None:
@@ -85,6 +93,10 @@ def test_lead_request_id_is_the_merchants_order_id_else_the_run() -> None:
     assert lead_request_id({"request_id": "req-9"}, "r-1") == "req-9"
     assert lead_request_id({"order_id": ""}, "r-1") == "wf-r-1"
     assert lead_request_id({}, "r-1") == "wf-r-1"
+    # A keyed plan: the enrollment key IS the order id (Shopify's `id`) —
+    # it beats every payload key, so nautilus matches the outcome to the order.
+    assert lead_request_id({"order_id": "o-1001"}, "r-1", "5306070030") == "5306070030"
+    assert lead_request_id({}, "r-1", None) == "wf-r-1"
 
 
 def test_the_current_squares_facts_win_and_every_squares_stay_reachable() -> None:
@@ -121,15 +133,28 @@ def test_the_current_squares_facts_win_and_every_squares_stay_reachable() -> Non
     assert plain["facts_at-bank_bank"] == "hdfc"
     unlabelled = WorkflowNode(id="w", type="wait", minutes=1)
     assert "current_stage" not in run_facts(context, unlabelled)
-    assert send_variables(context, node)["current_node"] == "at-kyc"
+    # a send blank may name the square, its stage, or a stage letter's fact
+    assert send_variables(
+        {"1": "current_node", "2": "current_stage", "3": "facts_at-bank_bank"},
+        context,
+        node,
+    ) == {"1": "at-kyc", "2": "kyc", "3": "hdfc"}
 
 
-def test_send_variables_carry_only_what_a_provider_can_render() -> None:
-    """A bool or a None among the variables makes the WhatsApp face refuse
-    the message terminally; the producer keeps text and numbers only. The
-    call payload is not narrowed — the lead machine spells its own."""
+def test_send_variables_refuse_what_a_provider_cannot_render() -> None:
+    """A bool or a None posted as a variable makes the WhatsApp face refuse
+    the message terminally — so a MAPPED one parks the run here, by name,
+    instead of posting it. The call payload is not narrowed — the lead
+    machine spells its own."""
     context = {"name": "Priya", "amount": 1999, "vip": True, "note": None, "score": 4.5}
-    assert send_variables(context) == {"name": "Priya", "amount": 1999, "score": 4.5}
+    assert send_variables({"1": "name", "2": "amount", "3": "score"}, context) == {
+        "1": "Priya",
+        "2": 1999,
+        "3": 4.5,
+    }
+    for fact in ("vip", "note"):
+        with pytest.raises(ValueError, match=fact):
+            send_variables({"1": fact}, context)
     assert run_facts(context)["vip"] is True
 
 
@@ -159,4 +184,5 @@ def test_the_latest_letters_facts_win_when_the_square_that_heard_it_is_behind() 
     assert run_facts(context, act)["stage"] == "kyc_completed"
     # a pointer at a square with no letter changes nothing
     assert run_facts({**context, "latest_letter": "gone"})["amount"] == 100
-    assert "latest_letter" not in send_variables(context, act)
+    assert "latest_letter" not in run_facts(context, act)
+    assert send_variables({"1": "amount"}, context, act) == {"1": 999}


### PR DESCRIPTION
## Event catalog — schema-driven flows (T24, where-grammar, seen-vs-matched)

Canon T24 as built: the catalog's two layers (code specs beside their extractors; `crm_event_schema` rows a push vendor signs at enrollment), one decode engine over both, the typed `entry.where` grammar, the send node's `variables` map, and the flows list's seen-vs-matched.

**Migrations: 068 (`crm_event_schema`), 069 (entry.where equality map → typed conditions, both entry shapes).** Next free after this PR = 070.

### What lands
- **Code layer** — `extractors/shopify.py` is the engine's first declared spec (`fallbacks`, `derive()`); every code entry has a recorded fixture and `test_catalog` pins the four-part square (ingress · extractor · fixture · entry). Name precedence is billing before shipping, deliberately (docstring).
- **Registered layer** — `POST /ingest/schemas` (S2S, `verified_merchant_caller`) and `POST /schemas` (console, admin); `GET /catalog` (ETag, 304 before the counts query), `GET /catalog/samples`. A re-registration is additive-or-deprecate: dropping a declared path is refused. The stored row carries canon's field list only.
- **Discovery** — one `detected` INSERT per new (merchant, source, topic) ever; marked known after the pass commits, so a rolled-back nudge is retried.
- **Where-grammar** — `shared/predicate.py`: one closed op set, one evaluator; the `is` family is text-strict (`=` and ordering ops are where numbers meet). `record/catalog.py` spells `OPS_BY_TYPE` from predicate's families (parity pinned).
- **Publish validator** — `outreach/catalog_laws.py`: conditions, `entry.key` and send `variables` only from declared fields; a topic two sources declare is refused by name (`entry.source` on the door is the ruling owed).
- **Send `variables`** — a send node posts EXACTLY its map (`{"1": "customer_name"}`); the shipped cart plans carry the map, the runbook says how to write it, and `test_plan_templates` validates every board against the CODE catalog.
- **Seen-vs-matched** — `list_workflows` decorates `seen_7d` (first door's topic) / `matched_7d`.
- **`binding_id` stamp** (connectivity, rides here) — `crm_message.binding_id` is set once, on an accepted send, from the route the send resolved (T16 col 6; migration 060 made the column set-once). Found while proving the catalog's send path end to end; kept in this PR rather than a 40-line sibling.

### Not in this PR
- `entry.source` on the door (canon T19) — ruling owed.
- The repeat-entry stale guard (`refresh_latest` comparing `occurred_at`) — rides #1058.
- The consumer tuple as a named object — on its next change.

### Verified
`tests/crm` 856 passed (DB-backed 069 test run locally against Postgres over both entry shapes) · pyrefly 0 errors · boundary guard OK · migration guard OK · black/isort/autoflake clean · route dependency trees and consumer registry import-smoked at runtime.
