### PR TITLE
feat(crm): template registry and the T23 send-time lookup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -201,9 +201,9 @@ AWS_ACCESS_KEY_ID=""
 AWS_SECRET_ACCESS_KEY=""
 
 # Meta (WhatsApp Embedded Signup + Graph API)
-# Used by app/crm/connectivity to onboard a WhatsApp Business Account.
-# META_APP_SECRET is also the key that will verify inbound Meta webhooks, so
-# it is named once here for both directions.
+# Used by app/crm/connectivity to onboard a WhatsApp Business Account and
+# register message templates. META_APP_SECRET is also the key that will
+# verify inbound Meta webhooks, so it is named once here for both.
 #
 # Empty is a legal boot: a deployment that never connects WhatsApp needs
 # neither, and a Graph call without them fails loudly at the call rather

--- a/app/core/config/dynamic.py
+++ b/app/core/config/dynamic.py
@@ -783,7 +783,7 @@ async def PLIVO_INR_CONVERSION_RATE() -> float:
 
 # ----------------------------------------------------------------------------
 # CRM connectivity — the ceiling on ONE non-send Graph call (the Embedded
-# Signup handshake today; template registration next).
+# Signup handshake, and registering a message template).
 #
 # Dynamic rather than static by this file's own rule: it is awaited on every
 # call and nothing binds it at startup, so a Redis change takes effect on the

--- a/app/core/config/static.py
+++ b/app/core/config/static.py
@@ -541,9 +541,9 @@ META_WHATSAPP_GRAPH_BASE_URL = os.environ.get(
 )
 META_WHATSAPP_GRAPH_VERSION = os.environ.get("META_WHATSAPP_GRAPH_VERSION", "v23.0")
 
-# The app identity behind Embedded Signup and every non-send Graph call.
-# APP_SECRET is also what will verify inbound Meta webhooks — the same secret
-# proves both directions — so it is named here once, for both.
+# The app identity behind Embedded Signup and every non-send Graph call
+# (code exchange, template registration). APP_SECRET is also what will verify
+# inbound Meta webhooks — the same secret proves both directions.
 # Empty is a legal boot: a deployment that never connects WhatsApp needs
 # neither, and a Graph call without them fails loudly at the call, not at
 # import (there is no get_required_env() in this repo to lean on).

--- a/app/crm/auth.py
+++ b/app/crm/auth.py
@@ -80,13 +80,18 @@ def assert_merchant_access(
         merchant_id not in current_user.merchant_ids
         and "*" not in current_user.merchant_ids
     ):
-        logger.warning(
-            f"User {current_user.username} attempted to {operation} for "
-            f"unauthorized merchant: {merchant_id}"
-        )
+        # merchant_id arrives in the request body and username off a token,
+        # so neither belongs inside the message: a newline in either forges a
+        # log line, and a log a reader cannot trust is worse than no log.
+        # Structured fields keep the audit detail without the interpolation.
+        logger.bind(
+            merchant_id=merchant_id,
+            username=current_user.username,
+            operation=operation,
+        ).warning("crm auth: denied access to a merchant outside the caller's scope")
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
-            detail=f"Access denied to merchant {merchant_id}",
+            detail="Access denied to this merchant",
         )
 
 

--- a/app/crm/connectivity/accounts.py
+++ b/app/crm/connectivity/accounts.py
@@ -1,0 +1,99 @@
+"""The door behind a provider account — which installation, and what it unlocks.
+
+Three callers ask the same two questions: send.py once per message,
+templates.py once per lifecycle transition, onboarding.py once on disconnect.
+Before this file each asked them in its own words — three copies of the
+credential sequence, and two definitions of "usable installation" (a bare
+``!= "healthy"`` in one file, a named set in another). Two definitions of one
+policy is a policy that changes in one place and not the other: the day a
+degraded door may register templates but not send, the miss is silent.
+
+So the policy lives here, once, and the answers come back as FACTS or as ONE
+domain error. Each caller keeps its own word for the refusal — send.py turns
+it into a ``REASON_*`` on the manifest row, templates.py into a
+``TemplateError`` behind a 400, disconnect swallows it. That split is the
+point rather than an oversight: "no usable credential" is a refusal reason, an
+API error and a shrug depending on who asked, and a helper that picked one of
+those would be wrong for the other two.
+
+What deliberately does NOT become an AccountError: a database failure. The
+vault is read with ``raise_errors=True`` so a pool blip RAISES instead of
+reading as "no credential" — the difference between a send that retries and
+one that is refused forever. Only a genuine answer (no row, deactivated, would
+not decrypt) is a refusal.
+"""
+
+from app.crm.connectivity.db.accessors import installation as installation_accessor
+from app.crm.connectivity.schemas import ConnectorInstallation, CredentialBundle
+from app.database.accessor.breeze_buddy.credentials import get_credential_by_id
+
+#: The only installation state anything may act through — fail closed on
+#: everything else, 'connecting' included. Onboarding verifies the token and
+#: the endpoint against the provider and writes the row 'healthy' directly, so
+#: 'connecting' is an unproven connection with no first-use deadlock to earn it
+#: an exception.
+USABLE_INSTALLATION_STATES = frozenset({"healthy"})
+
+
+class AccountError(Exception):
+    """No usable door, or no usable credential behind one.
+
+    Messages on this type are written FOR the merchant — each names something
+    they can act on (reconnect the account, finish the connection) — so a
+    caller that surfaces the text is not leaking an internal detail.
+    """
+
+
+def is_usable(installation: ConnectorInstallation) -> bool:
+    """Whether this door may be acted through at all."""
+    return installation.status in USABLE_INSTALLATION_STATES
+
+
+async def healthy_installation(
+    merchant_id: str, connector_key: str, provider_account_ref: str
+) -> ConnectorInstallation:
+    """The door this provider account hangs off, or a refusal.
+
+    Merchant-scoped by the lookup itself, which is what keeps every step
+    reached THROUGH it inside one tenant.
+    """
+    installation = await installation_accessor.get_installation_by_account(
+        merchant_id, connector_key, provider_account_ref
+    )
+    if installation is None:
+        raise AccountError(
+            f"no connected account '{provider_account_ref}' on this channel"
+        )
+    if not is_usable(installation):
+        raise AccountError(
+            f"the account '{provider_account_ref}' is '{installation.status}' — "
+            f"reconnect it before using it"
+        )
+    return installation
+
+
+async def bundle_for(installation: ConnectorInstallation) -> CredentialBundle:
+    """The installation's decrypted secrets, handed over whole.
+
+    Whole, not one key: which secret a face needs is the face's business, and
+    generic code picking a key would have to know every provider's bundle.
+
+    Ownership cannot be compared here: the vault's scope column is
+    ``reseller_id`` — one level above merchant (migration 022) — and this
+    module by law knows no reseller. The guard is the merchant-scoped
+    installation the caller arrived with; the onboarding sync that WRITES
+    ``credential_id`` owns refusing a foreign reseller's bundle.
+    """
+    if not installation.credential_id:
+        raise AccountError("this connection has no stored credential")
+    # mask=False: callers need the real secret, not the API's ****.
+    # raise_errors=True: see the module docstring — a blip must raise, not
+    # quietly become a permanent refusal.
+    credential = await get_credential_by_id(
+        installation.credential_id, mask=False, raise_errors=True
+    )
+    if credential is None or not credential.is_active or not credential.value:
+        # Vault row gone, deactivated, or it would not decrypt (an
+        # undecryptable value decodes as {}) — one fact to every caller.
+        raise AccountError("this connection's credential is missing or unreadable")
+    return CredentialBundle(values=credential.value)

--- a/app/crm/connectivity/api.py
+++ b/app/crm/connectivity/api.py
@@ -18,14 +18,12 @@ own onboarding. This is a deliberate early move to merchant-facing access
 (ADR 0007 rules phase 1 admin/S2S-only); admins still pass, so the pilot is
 unaffected.
 
-The template routes join this router with the template registry.
-
 ``merchant_id`` rides in the request — body for a POST, query for a GET — and
 is checked before anything else runs. A caller may hold several merchant_ids,
 so there is no single "current" one to infer from the token.
 """
 
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 from fastapi import APIRouter, Body, Depends, HTTPException, Query, status
 from pydantic import ValidationError
@@ -35,7 +33,15 @@ from app.core.logger.context import set_log_context
 from app.crm.auth import assert_merchant_access
 from app.crm.connectivity import contracts
 from app.crm.connectivity.onboarding import OnboardingError, UnknownConnectorError
-from app.crm.connectivity.schemas import InstallationRead
+from app.crm.connectivity.schemas import (
+    CreateTemplateDraftRequest,
+    EditTemplateRequest,
+    InstallationRead,
+    RetireTemplateRequest,
+    SubmitTemplateRequest,
+    TemplateRead,
+)
+from app.crm.connectivity.templates import TemplateError, TemplateNotFoundError
 from app.schemas import UserInfo
 
 router = APIRouter()
@@ -134,3 +140,111 @@ async def disconnect_route(
             status_code=status.HTTP_404_NOT_FOUND, detail="Connection not found"
         )
     return installation
+
+
+# ---------------------------------------------------------------------------
+# Templates
+# ---------------------------------------------------------------------------
+#
+# No connector in these paths: the row's `channel` decides which provider
+# serves it, and the route never needs to know.
+
+
+@router.post("/templates", response_model=TemplateRead)
+async def create_template_route(
+    req: CreateTemplateDraftRequest,
+    current_user: UserInfo = Depends(get_current_user_with_rbac),
+) -> TemplateRead:
+    assert_merchant_access(current_user, req.merchant_id, "create a template")
+    set_log_context(component="crm.connectivity.templates", merchant_id=req.merchant_id)
+    try:
+        return await contracts.create_template_draft(
+            req.merchant_id,
+            req.channel,
+            req.provider_account_ref,
+            req.name,
+            req.language,
+            req.components,
+        )
+    except TemplateError as e:
+        raise _bad_request(e) from e
+
+
+@router.get("/templates", response_model=List[TemplateRead])
+async def list_templates_route(
+    merchant_id: str = Query(..., description="Tenant scope — required"),
+    channel: Optional[str] = Query(None),
+    status_filter: Optional[str] = Query(None, alias="status"),
+    current_user: UserInfo = Depends(get_current_user_with_rbac),
+) -> List[TemplateRead]:
+    assert_merchant_access(current_user, merchant_id, "list templates")
+    set_log_context(component="crm.connectivity.templates", merchant_id=merchant_id)
+    return await contracts.list_templates(merchant_id, channel, status_filter)
+
+
+@router.get("/templates/{template_id}", response_model=TemplateRead)
+async def get_template_route(
+    template_id: str,
+    merchant_id: str = Query(..., description="Tenant scope — required"),
+    current_user: UserInfo = Depends(get_current_user_with_rbac),
+) -> TemplateRead:
+    assert_merchant_access(current_user, merchant_id, "read a template")
+    set_log_context(component="crm.connectivity.templates", merchant_id=merchant_id)
+    template = await contracts.get_template(merchant_id, template_id)
+    if template is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Template not found"
+        )
+    return template
+
+
+@router.post("/templates/{template_id}/submit", response_model=TemplateRead)
+async def submit_template_route(
+    template_id: str,
+    req: SubmitTemplateRequest,
+    current_user: UserInfo = Depends(get_current_user_with_rbac),
+) -> TemplateRead:
+    assert_merchant_access(current_user, req.merchant_id, "submit a template")
+    set_log_context(component="crm.connectivity.templates", merchant_id=req.merchant_id)
+    try:
+        return await contracts.submit_template(
+            req.merchant_id, template_id, req.category
+        )
+    except TemplateNotFoundError as e:
+        raise _not_found(e) from e
+    except TemplateError as e:
+        raise _bad_request(e) from e
+
+
+@router.patch("/templates/{template_id}", response_model=TemplateRead)
+async def edit_template_route(
+    template_id: str,
+    req: EditTemplateRequest,
+    current_user: UserInfo = Depends(get_current_user_with_rbac),
+) -> TemplateRead:
+    assert_merchant_access(current_user, req.merchant_id, "edit a template")
+    set_log_context(component="crm.connectivity.templates", merchant_id=req.merchant_id)
+    try:
+        return await contracts.edit_template(
+            req.merchant_id, template_id, req.components
+        )
+    except TemplateNotFoundError as e:
+        raise _not_found(e) from e
+    except TemplateError as e:
+        raise _bad_request(e) from e
+
+
+@router.post("/templates/{template_id}/retire", response_model=TemplateRead)
+async def retire_template_route(
+    template_id: str,
+    req: RetireTemplateRequest,
+    current_user: UserInfo = Depends(get_current_user_with_rbac),
+) -> TemplateRead:
+    assert_merchant_access(current_user, req.merchant_id, "retire a template")
+    set_log_context(component="crm.connectivity.templates", merchant_id=req.merchant_id)
+    try:
+        return await contracts.retire_template(req.merchant_id, template_id)
+    except TemplateNotFoundError as e:
+        raise _not_found(e) from e
+    except TemplateError as e:
+        raise _bad_request(e) from e

--- a/app/crm/connectivity/connectors.py
+++ b/app/crm/connectivity/connectors.py
@@ -25,9 +25,15 @@ from pydantic import BaseModel
 from app.crm.connectivity.providers.base import (
     ConnectorHandshakeError,
     ConnectorOnboarder,
+    ProviderError,
+    TemplateProvider,
+    TemplateProviderError,
 )
-from app.crm.connectivity.providers.whatsapp.onboard import WhatsappOnboarder
-from app.crm.connectivity.schemas import OnboardWhatsappRequest
+from app.crm.connectivity.providers.whatsapp.onboard import (
+    OnboardWhatsappRequest,
+    WhatsappOnboarder,
+)
+from app.crm.connectivity.providers.whatsapp.templates import WhatsappTemplates
 
 #: Re-exported so onboarding.py can name the error every onboarder raises.
 #: It cannot import providers/base itself — boundary rule 11 gives that file
@@ -36,13 +42,20 @@ __all__ = [
     "CONNECTORS",
     "ConnectorHandshakeError",
     "ConnectorSpec",
+    "ProviderError",
+    "TemplateProviderError",
     "connector_for",
+    "connector_for_channel",
+    "sending_connectors",
 ]
 
 
 @dataclass(frozen=True)
 class ConnectorSpec:
     """Everything the generic code needs to serve one connector."""
+
+    #: The registry key this spec is filed under.
+    key: str
 
     #: The channel its bindings carry, or None for a connector that does not
     #: SEND. Canon T11's vocabulary is shopify · whatsapp · instagram ·
@@ -55,6 +68,7 @@ class ConnectorSpec:
     #: Instagram and Messenger are two connectors on one Meta app.
     channel: Optional[str]
     onboarder: ConnectorOnboarder
+    templates: TemplateProvider
     #: The request model the onboard route validates its body against, so the
     #: route itself stays connector-agnostic.
     request_model: Type[BaseModel]
@@ -64,8 +78,10 @@ class ConnectorSpec:
 # the adapters.
 CONNECTORS: Dict[str, ConnectorSpec] = {
     "whatsapp": ConnectorSpec(
+        key="whatsapp",
         channel="whatsapp",
         onboarder=WhatsappOnboarder(),
+        templates=WhatsappTemplates(),
         request_model=OnboardWhatsappRequest,
     ),
 }
@@ -89,3 +105,24 @@ def sending_connectors() -> Dict[str, ConnectorSpec]:
     would make adding one fail two tests that are about sending.
     """
     return {key: spec for key, spec in CONNECTORS.items() if spec.channel is not None}
+
+
+def connector_for_channel(channel: str) -> Optional[ConnectorSpec]:
+    """The spec serving ``channel``, or None.
+
+    A template row carries a channel, not a connector key, so the template
+    lifecycle resolves its provider this way. Linear over a dict of a handful
+    of entries: a second index would be state to keep consistent for a lookup
+    that is never hot.
+
+    The falsy guard matters now that a spec's channel may be None: without it
+    a lookup for "no channel" would match a data connector — a door with no
+    pipe — and the template lifecycle would try to register a message shape
+    against something that cannot send one.
+    """
+    if not channel:
+        return None
+    for spec in CONNECTORS.values():
+        if spec.channel == channel:
+            return spec
+    return None

--- a/app/crm/connectivity/contracts.py
+++ b/app/crm/connectivity/contracts.py
@@ -3,10 +3,10 @@
 The only file other modules and app/crm/worker_main.py may import.
 
 This module owns everything between "we want to send something" and "the
-provider took it": connector accounts, the endpoints under them, the message
-table, send() and the dispatch pass. It is channel-agnostic — WhatsApp,
-Instagram and email are adapters and faces behind a registry, not packages
-other modules know about.
+provider took it": connector accounts, the endpoints under them, the template
+registry, the message table, send() and the dispatch pass. It is
+channel-agnostic — WhatsApp, Instagram and email are adapters and faces
+behind a registry, not packages other modules know about.
 
 What is here, and why each thing is on the surface:
 
@@ -19,6 +19,12 @@ What is here, and why each thing is on the surface:
   — connector accounts and the pipes under them. Connector-agnostic:
   ``onboard`` takes a connector_key and a payload, and the CONNECTORS
   registry decides what that payload means.
+- the ``*_template`` family — the T23 registry that ``send.py`` resolves
+  against before any provider call.
+
+Provider-decided template state (approved, rejected, a re-categorisation)
+arrives as webhooks, and the consumer that applies them joins this surface
+with the ingress bay that receives them. There is deliberately no timer.
 
 ``send()`` stays OFF this surface so that nothing outside the module can
 reach a provider without passing the checks in front of it. So does the
@@ -33,6 +39,14 @@ from app.crm.connectivity.onboarding import (
     onboard,
 )
 from app.crm.connectivity.queue import queue_message
+from app.crm.connectivity.templates import (
+    create_draft as create_template_draft,
+    edit as edit_template,
+    get as get_template,
+    list_templates,
+    retire as retire_template,
+    submit as submit_template,
+)
 
 __all__ = [
     # the dispatcher role
@@ -45,4 +59,11 @@ __all__ = [
     "get_installation",
     "list_installations",
     "disconnect",
+    # the template registry
+    "create_template_draft",
+    "submit_template",
+    "edit_template",
+    "retire_template",
+    "get_template",
+    "list_templates",
 ]

--- a/app/crm/connectivity/db/accessors/template.py
+++ b/app/crm/connectivity/db/accessors/template.py
@@ -1,0 +1,185 @@
+"""Mechanical DB access for crm_channel_template.
+
+Reads and the webhook writes self-scope (each is one statement, which
+Postgres runs atomically). The lifecycle writes take a ``conn`` because
+templates.py owns their fate: a claim and the read that justified it share
+one commit, or two callers both believe they hold it.
+"""
+
+import json
+from typing import Any, Dict, List, Optional
+
+from app.crm.connectivity.db.decoders.template import (
+    decode_approved_template,
+    decode_template,
+)
+from app.crm.connectivity.db.queries.template import (
+    approved_template_for_send_query,
+    claim_for_submit_query,
+    insert_template_draft_query,
+    list_templates_query,
+    record_in_place_edit_query,
+    record_submission_query,
+    release_submit_claim_query,
+    retire_template_query,
+    template_by_id_query,
+    template_by_natural_key_query,
+    update_draft_components_query,
+)
+from app.crm.connectivity.schemas import ApprovedTemplate, TemplateRead
+from app.crm.shared.db import DbTxn, crm_connection
+
+# ---------------------------------------------------------------------------
+# Reads
+# ---------------------------------------------------------------------------
+
+
+async def get_template(merchant_id: str, template_id: str) -> Optional[TemplateRead]:
+    query, values = template_by_id_query(merchant_id, template_id)
+    async with crm_connection() as conn:
+        row = await conn.fetchrow(query, *values)
+    return decode_template(row) if row is not None else None
+
+
+async def get_template_by_natural_key(
+    conn: DbTxn,
+    merchant_id: str,
+    channel: str,
+    provider_account_ref: str,
+    name: str,
+    language: str,
+) -> Optional[TemplateRead]:
+    query, values = template_by_natural_key_query(
+        merchant_id, channel, provider_account_ref, name, language
+    )
+    row = await conn.fetchrow(query, *values)
+    return decode_template(row) if row is not None else None
+
+
+async def list_templates(
+    merchant_id: str, channel: Optional[str] = None, status: Optional[str] = None
+) -> List[TemplateRead]:
+    query, values = list_templates_query(merchant_id, channel, status)
+    async with crm_connection() as conn:
+        rows = await conn.fetch(query, *values)
+    return [decode_template(row) for row in rows]
+
+
+async def approved_templates_for_send(
+    merchant_id: str, channel: str, provider_account_ref: str, name: str
+) -> List[ApprovedTemplate]:
+    """At most two rows: the caller only needs one-or-many, never the count."""
+    query, values = approved_template_for_send_query(
+        merchant_id, channel, provider_account_ref, name
+    )
+    async with crm_connection() as conn:
+        rows = await conn.fetch(query, *values)
+    return [decode_approved_template(row) for row in rows]
+
+
+# ---------------------------------------------------------------------------
+# The local lifecycle
+# ---------------------------------------------------------------------------
+
+
+async def insert_template_draft(
+    conn: DbTxn,
+    merchant_id: str,
+    channel: str,
+    provider_account_ref: str,
+    name: str,
+    language: str,
+    components: List[Dict[str, Any]],
+) -> TemplateRead:
+    query, values = insert_template_draft_query(
+        merchant_id,
+        channel,
+        provider_account_ref,
+        name,
+        language,
+        json.dumps(components),
+    )
+    row = await conn.fetchrow(query, *values)
+    if row is None:
+        # A plain INSERT ... RETURNING; no row means the statement did not do
+        # what it says, and returning None would make the caller report a
+        # draft it never created.
+        raise RuntimeError("crm_channel_template insert returned no row")
+    return decode_template(row)
+
+
+async def update_draft_components(
+    conn: DbTxn, merchant_id: str, template_id: str, components: List[Dict[str, Any]]
+) -> Optional[TemplateRead]:
+    """None = the row is no longer a draft (raced, or already submitted)."""
+    query, values = update_draft_components_query(
+        merchant_id, template_id, json.dumps(components)
+    )
+    row = await conn.fetchrow(query, *values)
+    return decode_template(row) if row is not None else None
+
+
+async def claim_for_submit(
+    conn: DbTxn, merchant_id: str, template_id: str
+) -> Optional[TemplateRead]:
+    """None = somebody else holds the claim, or the row is not a draft."""
+    query, values = claim_for_submit_query(merchant_id, template_id)
+    row = await conn.fetchrow(query, *values)
+    return decode_template(row) if row is not None else None
+
+
+async def release_submit_claim(
+    merchant_id: str, template_id: str
+) -> Optional[TemplateRead]:
+    """Self-scoped on purpose: this runs in an exception path, where the
+    caller's own transaction may be exactly what failed."""
+    query, values = release_submit_claim_query(merchant_id, template_id)
+    async with crm_connection() as conn:
+        row = await conn.fetchrow(query, *values)
+    return decode_template(row) if row is not None else None
+
+
+async def record_submission(
+    conn: DbTxn,
+    merchant_id: str,
+    template_id: str,
+    provider_template_id: str,
+    category: Optional[str],
+    submitted_category: str,
+    status: str,
+) -> Optional[TemplateRead]:
+    query, values = record_submission_query(
+        merchant_id,
+        template_id,
+        provider_template_id,
+        category,
+        submitted_category,
+        status,
+    )
+    row = await conn.fetchrow(query, *values)
+    return decode_template(row) if row is not None else None
+
+
+async def record_in_place_edit(
+    conn: DbTxn,
+    merchant_id: str,
+    template_id: str,
+    components: List[Dict[str, Any]],
+    status: str,
+    expected_status: str,
+) -> Optional[TemplateRead]:
+    """None = the row no longer carries ``expected_status`` — something moved
+    it while the provider call was in flight."""
+    query, values = record_in_place_edit_query(
+        merchant_id, template_id, json.dumps(components), status, expected_status
+    )
+    row = await conn.fetchrow(query, *values)
+    return decode_template(row) if row is not None else None
+
+
+async def retire_template(
+    conn: DbTxn, merchant_id: str, template_id: str
+) -> Optional[TemplateRead]:
+    query, values = retire_template_query(merchant_id, template_id)
+    row = await conn.fetchrow(query, *values)
+    return decode_template(row) if row is not None else None

--- a/app/crm/connectivity/db/decoders/template.py
+++ b/app/crm/connectivity/db/decoders/template.py
@@ -1,0 +1,48 @@
+"""crm_channel_template rows -> domain shapes."""
+
+from typing import Any, Mapping
+
+from app.crm.connectivity.schemas import ApprovedTemplate, TemplateRead
+from app.crm.shared.decode import jsonb_list
+
+
+def decode_template(row: Mapping[str, Any]) -> TemplateRead:
+    """One crm_channel_template row -> TemplateRead."""
+    return TemplateRead(
+        id=str(row["id"]),
+        merchant_id=row["merchant_id"],
+        channel=row["channel"],
+        provider_account_ref=row["provider_account_ref"],
+        name=row["name"],
+        language=row["language"],
+        provider_template_id=row["provider_template_id"],
+        category=row["category"],
+        submitted_category=row["submitted_category"],
+        category_updated_at=row["category_updated_at"],
+        # Total for the same reason every jsonb read here is: the webhook
+        # consumer decodes rows inside a batch, and one raise would strand
+        # every letter beside it. jsonb_list makes the COLUMN total; the dict
+        # filter finishes the job for this caller, because TemplateRead types
+        # components as objects and a stored [1, 2] would raise in pydantic
+        # one line later — defeating the guarantee at the layer above it.
+        # The filter lives here, not in the shared helper: another module may
+        # legitimately want a list of scalars out of a jsonb column.
+        components=[c for c in jsonb_list(row["components"]) if isinstance(c, dict)],
+        status=row["status"],
+        status_updated_at=row["status_updated_at"],
+        rejection_reason=row["rejection_reason"],
+        quality=row["quality"],
+        quality_updated_at=row["quality_updated_at"],
+        last_synced_at=row["last_synced_at"],
+        created_at=row["created_at"],
+        updated_at=row["updated_at"],
+    )
+
+
+def decode_approved_template(row: Mapping[str, Any]) -> ApprovedTemplate:
+    """The send path's narrow read: which locale this approved name is in.
+
+    Deliberately not TemplateRead — the send path runs per message and has no
+    use for a components blob it will never render.
+    """
+    return ApprovedTemplate(id=str(row["id"]), language=row["language"])

--- a/app/crm/connectivity/db/queries/template.py
+++ b/app/crm/connectivity/db/queries/template.py
@@ -1,0 +1,317 @@
+"""SQL builders for crm_channel_template (T23, the template registry).
+
+Two rules run through every builder here.
+
+**Tenancy plus account.** Every write carries ``provider_account_ref`` as
+well as ``merchant_id``, including the ones that could match on the
+provider's globally-unique id alone. It costs nothing and makes it
+structurally impossible for one account's webhook to touch another
+account's row on a surprising payload.
+
+**Status moves stamp their clock.** ``status_updated_at`` is exposed to
+merchants and read by the out-of-order guard, so any statement that changes
+``status`` sets it in the same breath. A transition with a stale timestamp
+is worse than no timestamp: it looks answered.
+"""
+
+from typing import Any, List, Optional, Tuple
+
+TEMPLATE_TABLE = "crm_channel_template"
+
+TEMPLATE_COLUMNS = """
+    id, merchant_id, channel, provider_account_ref, name, language,
+    provider_template_id, category, submitted_category, category_updated_at,
+    components, status, status_updated_at, rejection_reason, quality,
+    quality_updated_at, last_synced_at, created_at, updated_at
+"""
+
+
+# ---------------------------------------------------------------------------
+# Reads
+# ---------------------------------------------------------------------------
+
+
+def template_by_id_query(merchant_id: str, template_id: str) -> Tuple[str, List[Any]]:
+    query = f"""
+        SELECT {TEMPLATE_COLUMNS}
+          FROM {TEMPLATE_TABLE}
+         WHERE merchant_id = $1
+           AND id = $2::uuid
+    """
+    return query, [merchant_id, template_id]
+
+
+def template_by_natural_key_query(
+    merchant_id: str,
+    channel: str,
+    provider_account_ref: str,
+    name: str,
+    language: str,
+) -> Tuple[str, List[Any]]:
+    """The registry's natural key.
+
+    ``provider_account_ref`` is IN the key, one column beyond canon T23's
+    four: a merchant may hold two accounts on one channel (two WABAs), and
+    the same name+language registered in both are two different templates
+    with two different provider ids. Without it the second one collides with
+    the first and the merchant simply cannot register it.
+    """
+    query = f"""
+        SELECT {TEMPLATE_COLUMNS}
+          FROM {TEMPLATE_TABLE}
+         WHERE merchant_id = $1
+           AND channel = $2
+           AND provider_account_ref = $3
+           AND name = $4
+           AND language = $5
+    """
+    return query, [merchant_id, channel, provider_account_ref, name, language]
+
+
+def list_templates_query(
+    merchant_id: str, channel: Optional[str], status: Optional[str]
+) -> Tuple[str, List[Any]]:
+    """The console's list. Filters are optional and applied in SQL rather
+    than in Python — an IS NULL OR test keeps one statement and one plan
+    instead of four hand-built variants."""
+    query = f"""
+        SELECT {TEMPLATE_COLUMNS}
+          FROM {TEMPLATE_TABLE}
+         WHERE merchant_id = $1
+           AND ($2::text IS NULL OR channel = $2)
+           AND ($3::text IS NULL OR status = $3)
+         ORDER BY created_at DESC
+    """
+    return query, [merchant_id, channel, status]
+
+
+def approved_template_for_send_query(
+    merchant_id: str, channel: str, provider_account_ref: str, name: str
+) -> Tuple[str, List[Any]]:
+    """The send-time lookup (ADR 0011): is this name APPROVED, and in which
+    language?
+
+    Filtered to 'approved' in SQL so the caller's two refusals fall out of
+    the row count: zero rows means never registered, still pending, rejected
+    or deleted — one fact from the sender's side; more than one means the
+    name is approved in several languages and crm_message carries no language
+    column to choose with. Both refuse, because guessing which locale a
+    customer should receive is not a guess anyone may make.
+
+    LIMIT 2 because the caller only needs to distinguish one from many.
+    """
+    query = f"""
+        SELECT id, language
+          FROM {TEMPLATE_TABLE}
+         WHERE merchant_id = $1
+           AND channel = $2
+           AND provider_account_ref = $3
+           AND name = $4
+           AND status = 'approved'
+         LIMIT 2
+    """
+    return query, [merchant_id, channel, provider_account_ref, name]
+
+
+# ---------------------------------------------------------------------------
+# The local lifecycle
+# ---------------------------------------------------------------------------
+
+
+def insert_template_draft_query(
+    merchant_id: str,
+    channel: str,
+    provider_account_ref: str,
+    name: str,
+    language: str,
+    components_json: str,
+) -> Tuple[str, List[Any]]:
+    query = f"""
+        INSERT INTO {TEMPLATE_TABLE}
+            (merchant_id, channel, provider_account_ref, name, language,
+             components)
+        VALUES ($1, $2, $3, $4, $5, $6::jsonb)
+        RETURNING {TEMPLATE_COLUMNS}
+    """
+    return query, [
+        merchant_id,
+        channel,
+        provider_account_ref,
+        name,
+        language,
+        components_json,
+    ]
+
+
+def update_draft_components_query(
+    merchant_id: str, template_id: str, components_json: str
+) -> Tuple[str, List[Any]]:
+    """Only ever touches a row that is still 'draft'.
+
+    Re-running "create this draft" must never overwrite a template already
+    sent for review: the components on file are the ones the provider is
+    looking at, and replacing them locally would make the registry lie about
+    what is under review. The status filter is the guard; a caller seeing no
+    row raises.
+    """
+    query = f"""
+        UPDATE {TEMPLATE_TABLE}
+           SET components = $3::jsonb
+         WHERE merchant_id = $1
+           AND id = $2::uuid
+           AND status = 'draft'
+        RETURNING {TEMPLATE_COLUMNS}
+    """
+    return query, [merchant_id, template_id, components_json]
+
+
+def claim_for_submit_query(merchant_id: str, template_id: str) -> Tuple[str, List[Any]]:
+    """draft -> submitting, exclusively.
+
+    The claim is the whole defence against submitting one template twice.
+    Two requests that both read 'draft' would both POST to the provider; the
+    provider refuses the second by name, but only AFTER we fired it, and the
+    local row then records whichever answer landed last.
+
+    'submitting' is deliberately NOT claimable. It looks like it should be —
+    "a crashed submit should be retryable" — but a crash after the provider
+    accepted leaves a template registered under that name, so the retry
+    cannot succeed either; it can only fail differently. Recovery is the
+    webhook's resume path below, which matches on the natural key and stamps
+    the id the provider already assigned.
+    """
+    query = f"""
+        UPDATE {TEMPLATE_TABLE}
+           SET status = 'submitting',
+               status_updated_at = now()
+         WHERE merchant_id = $1
+           AND id = $2::uuid
+           AND status = 'draft'
+        RETURNING {TEMPLATE_COLUMNS}
+    """
+    return query, [merchant_id, template_id]
+
+
+def release_submit_claim_query(
+    merchant_id: str, template_id: str
+) -> Tuple[str, List[Any]]:
+    """submitting -> draft, but only while no provider id was ever stamped.
+
+    Everything between the claim and the provider's acceptance can fail: the
+    credential may not resolve, the components may be refused, the process
+    may die. Without this the row sits 'submitting' forever — unclaimable by
+    the exclusive claim above, and unreachable by the resume path because the
+    provider never received it. That template would be dead permanently.
+
+    The ``provider_template_id IS NULL`` guard is what keeps the release
+    safe: once an id exists the submission really happened, and only the
+    webhook may move the row on.
+    """
+    query = f"""
+        UPDATE {TEMPLATE_TABLE}
+           SET status = 'draft',
+               status_updated_at = now()
+         WHERE merchant_id = $1
+           AND id = $2::uuid
+           AND status = 'submitting'
+           AND provider_template_id IS NULL
+        RETURNING {TEMPLATE_COLUMNS}
+    """
+    return query, [merchant_id, template_id]
+
+
+def record_submission_query(
+    merchant_id: str,
+    template_id: str,
+    provider_template_id: str,
+    category: Optional[str],
+    submitted_category: str,
+    status: str,
+) -> Tuple[str, List[Any]]:
+    """The provider accepted it: their id, their category, their status.
+
+    ``submitted_category`` is OURS and is kept beside theirs on purpose — a
+    provider that re-categorises MARKETING as UTILITY has changed what the
+    merchant pays, and a single column would erase the evidence.
+    """
+    query = f"""
+        UPDATE {TEMPLATE_TABLE}
+           SET provider_template_id = $3,
+               category = $4,
+               submitted_category = $5,
+               category_updated_at = now(),
+               status = $6,
+               status_updated_at = now(),
+               rejection_reason = NULL
+         WHERE merchant_id = $1
+           AND id = $2::uuid
+           AND status = 'submitting'
+        RETURNING {TEMPLATE_COLUMNS}
+    """
+    return query, [
+        merchant_id,
+        template_id,
+        provider_template_id,
+        category,
+        submitted_category,
+        status,
+    ]
+
+
+def record_in_place_edit_query(
+    merchant_id: str,
+    template_id: str,
+    components_json: str,
+    status: str,
+    expected_status: str,
+) -> Tuple[str, List[Any]]:
+    """New components on the SAME row, back to whatever the provider says
+    the edit put it in (canon T23's one explicit transition rule: editing an
+    approved template re-reviews it in place rather than making a new row).
+
+    ``rejection_reason`` is cleared: the reason described the components that
+    were just replaced, and leaving it would attach an old refusal to new
+    content.
+
+    ``expected_status`` is the status the caller read before it went to the
+    provider, and the write only lands if the row still carries it. Without
+    that guard the sequence is: edit() reads 'approved', calls the provider,
+    a concurrent retire() sets 'deleted', and this UPDATE puts 'pending' and
+    fresh components over the retired row — resurrecting a template the
+    merchant withdrew. Same CAS shape as update_draft_components_query.
+    """
+    query = f"""
+        UPDATE {TEMPLATE_TABLE}
+           SET components = $3::jsonb,
+               status = $4,
+               status_updated_at = now(),
+               rejection_reason = NULL
+         WHERE merchant_id = $1
+           AND id = $2::uuid
+           AND status = $5
+        RETURNING {TEMPLATE_COLUMNS}
+    """
+    return query, [merchant_id, template_id, components_json, status, expected_status]
+
+
+def retire_template_query(merchant_id: str, template_id: str) -> Tuple[str, List[Any]]:
+    """status -> deleted. Never a DELETE: crm_message rows name this template
+    by name, and "what did we send in August" must stay answerable."""
+    query = f"""
+        UPDATE {TEMPLATE_TABLE}
+           SET status = 'deleted',
+               status_updated_at = now()
+         WHERE merchant_id = $1
+           AND id = $2::uuid
+        RETURNING {TEMPLATE_COLUMNS}
+    """
+    return query, [merchant_id, template_id]
+
+
+# The webhook path — apply_status_event / apply_category_event /
+# apply_quality_event and the crashed-submit resume — is deliberately NOT
+# here. Those builders have exactly one caller, the spine consumer that
+# turns a provider's template webhook into a status change, and that
+# consumer is the next PR. Shipping the SQL ahead of it would leave four
+# statements nothing calls, which is the thing a reader cannot tell from a
+# statement that is merely unused today.

--- a/app/crm/connectivity/onboarding.py
+++ b/app/crm/connectivity/onboarding.py
@@ -29,6 +29,7 @@ from typing import Any, Dict, List, Optional
 
 from app.core.logger import logger
 from app.core.logger.context import update_log_context
+from app.crm.connectivity import accounts
 from app.crm.connectivity.connectors import (
     ConnectorHandshakeError,
     ConnectorSpec,
@@ -41,13 +42,11 @@ from app.crm.connectivity.db.accessors import (
 )
 from app.crm.connectivity.schemas import (
     ConnectorInstallation,
-    CredentialBundle,
     InstallationRead,
     OnboardResult,
 )
 from app.database.accessor.breeze_buddy.credentials import (
     create_credential,
-    get_credential_by_id,
     get_credential_by_name,
     update_credential,
 )
@@ -366,19 +365,16 @@ async def _revoke_at_provider(
     if spec is None or not installation.credential_id:
         return
     try:
-        credential = await get_credential_by_id(
-            installation.credential_id, mask=False, raise_errors=True
-        )
-        if credential is None or not credential.value:
-            return
-        await spec.onboarder.revoke(
-            CredentialBundle(values=credential.value),
-            installation.external_account_id,
-        )
+        bundle = await accounts.bundle_for(installation)
+        await spec.onboarder.revoke(bundle, installation.external_account_id)
+    except accounts.AccountError:
+        # No usable credential to revoke WITH. Nothing to tell the provider,
+        # and nothing to warn about — the local disconnect proceeds.
+        return
     except Exception as e:
-        logger.warning(
+        logger.opt(exception=e).warning(
             f"disconnect: could not revoke {connector_key} subscription for "
-            f"installation {installation.id}: {e}"
+            f"installation {installation.id}"
         )
 
 

--- a/app/crm/connectivity/providers/base.py
+++ b/app/crm/connectivity/providers/base.py
@@ -1,27 +1,28 @@
 """The ports a provider package implements — one per face.
 
-A connector is not one thing. WhatsApp is a send adapter and an onboarding
-handshake, and the two answer to different callers: send.py drives the
-first, connectors.py the second. Naming them as separate ports is what lets
-`onboarding.py` stay generic — the vocabulary dispatches through a registry
-instead of branching on `if connector == "whatsapp"`.
+A connector is not one thing. WhatsApp is a send adapter, an onboarding
+handshake and a template registry, and those three answer to different
+callers: send.py drives the first, connectors.py the other two. Naming them
+as separate ports is what lets `onboarding.py` and `templates.py` stay
+generic — the vocabulary dispatches through a registry instead of branching
+on `if connector == "whatsapp"`.
 
     ChannelAdapter       build the request, read the answer      -> send.py
     ConnectorOnboarder   turn a signup payload into a door       -> connectors.py
+    TemplateProvider     register and track a message shape      -> connectors.py
 
-A third face — registering the message shapes a provider pre-approves —
-joins them with the template registry.
-
-The split that matters for both: a provider CLASSIFIES or NORMALISES, it
-never DECIDES. An adapter reports what the provider did and
+The split that matters for all three: a provider CLASSIFIES or NORMALISES,
+it never DECIDES. An adapter reports what the provider did and
 dispatch.plan_for_outcome turns that into queued / failed / dead; an
 onboarder reports how far up the health ladder it got and onboarding.py
-turns that into a status. A provider reaching for policy would give each
-channel its own private answer to "why", and there would stop being one.
+turns that into a status; a template face returns Meta's words in the
+canon's lowercase vocabulary and templates.py decides which transition that
+allows. A provider reaching for policy would give each channel its own
+private answer to "why", and there would stop being one.
 """
 
 from abc import ABC, abstractmethod
-from typing import Any, ClassVar, Dict, Optional, Protocol
+from typing import Any, ClassVar, Dict, List, Mapping, Optional, Protocol
 
 import httpx
 
@@ -30,9 +31,11 @@ from app.crm.connectivity.reasons import REASON_TRANSPORT
 from app.crm.connectivity.schemas import (
     CredentialBundle,
     OnboardResult,
+    ProviderTemplateState,
     QueuedMessage,
     SendOutcome,
     SendRoute,
+    TemplateDraft,
 )
 from app.crm.shared.redact import mask_address
 
@@ -100,15 +103,30 @@ class ChannelAdapter(ABC):
         return body if isinstance(body, dict) else {}
 
 
-class ConnectorHandshakeError(Exception):
+class ProviderError(Exception):
+    """A provider DECLARED a refusal — the base every face raises under.
+
+    The one distinction generic code needs: a refusal it may repeat to the
+    merchant, versus a bug it must not. Messages on this type are written FOR
+    the merchant ("that number is not on this account", "component BODY has
+    too many variables") and the logic file passes them through verbatim;
+    anything else becomes a fixed sentence, because an arbitrary exception's
+    text is an internal detail and an API response is not the place to learn
+    it.
+
+    It is a base rather than two unrelated types so the contract is stated
+    once: the next face — an SMS-DLT registry, a Zendesk handshake — declares
+    its refusals by subclassing, and the pass-through rule already covers it.
+    Each face still gets its own leaf so a caller CAN narrow when it has a
+    reason to.
+    """
+
+
+class ConnectorHandshakeError(ProviderError):
     """A provider refused a step of its onboarding handshake.
 
-    The type every ConnectorOnboarder raises, so generic code can tell a
-    refusal it may repeat to the merchant from a bug it must not. Messages
-    on this type are written FOR the merchant — "that number is not on this
-    account" — and onboarding.py passes them through; anything else becomes
-    a fixed sentence, because an arbitrary exception's text is an internal
-    detail and the API response is not the place to learn it.
+    The type every ConnectorOnboarder raises; onboarding.py passes its
+    message through.
     """
 
 
@@ -154,6 +172,60 @@ class ConnectorOnboarder(Protocol):
         proceeds, because refusing to disconnect locally when the provider
         is unreachable would trap the merchant.
         """
+
+
+class TemplateProviderError(ProviderError):
+    """A provider refused a template operation.
+
+    The twin of ConnectorHandshakeError: a provider describing why it
+    rejected components is describing the merchant's OWN template, so
+    templates.py passes the message through.
+    """
+
+
+class TemplateProvider(Protocol):
+    """One provider's template-registry face.
+
+    Every method returns a NORMALISED ProviderTemplateState: uppercase-vs-
+    lowercase is Meta's quirk, not the registry's, so it is spent here and
+    never crosses into templates.py.
+    """
+
+    #: Whether an already-registered template can be edited in place.
+    #: Meta re-reviews the SAME row (approved/rejected/paused -> pending);
+    #: SMS-DLT cannot, and must be retired and re-registered under a new id.
+    #: templates.py branches on this instead of on a provider name.
+    edits_in_place: bool
+
+    async def submit(
+        self, bundle: CredentialBundle, account_ref: str, draft: TemplateDraft
+    ) -> ProviderTemplateState:
+        """Register a draft for review and report what the provider assigned."""
+
+    async def edit(
+        self,
+        bundle: CredentialBundle,
+        account_ref: str,
+        provider_template_id: str,
+        components: List[Dict[str, Any]],
+    ) -> ProviderTemplateState:
+        """Replace a registered template's components in place."""
+
+    async def retire(
+        self,
+        bundle: CredentialBundle,
+        account_ref: str,
+        provider_template_id: str,
+        name: str,
+        language: str,
+    ) -> None:
+        """Withdraw ONE registered template — this name in this language."""
+
+    def normalize_event(
+        self, topic: str, value: Mapping[str, Any]
+    ) -> Optional[ProviderTemplateState]:
+        """One webhook payload -> the registry's vocabulary, or None if this
+        letter says nothing about a template."""
 
 
 class AdapterRegistryError(LookupError):

--- a/app/crm/connectivity/providers/whatsapp/adapter.py
+++ b/app/crm/connectivity/providers/whatsapp/adapter.py
@@ -42,19 +42,10 @@ from app.crm.connectivity.reasons import (
 from app.crm.connectivity.schemas import QueuedMessage, SendOutcome, SendRoute
 from app.crm.shared.redact import mask_address, mask_digit_runs
 
-# The Cloud API's own default when a binding declares no locale.
-#
-# INTERIM, and named so it is easy to find: which locale a merchant's
-# template was APPROVED in is a fact about the TEMPLATE, and the binding's
-# capabilities blob can disagree with what Meta actually approved. The
-# template registry (T23) is what will answer this, and this read goes away
-# when it does.
+# The Cloud API's own default, used only when the route resolved no language
+# — which the T23 lookup makes impossible for an approved template. It exists
+# so a future channel that does not pre-register templates cannot crash here.
 DEFAULT_LANGUAGE = "en_US"
-
-
-def _language_of(route: SendRoute) -> str:
-    """The locale to render this template in — from the binding, for now."""
-    return str(route.binding.capabilities.get("template_language") or DEFAULT_LANGUAGE)
 
 
 class MetaWhatsAppAdapter(ChannelAdapter):
@@ -134,7 +125,10 @@ class MetaWhatsAppAdapter(ChannelAdapter):
             return SendOutcome(status="blocked", reason=REASON_BAD_VARIABLES)
 
         payload = build_send_body(
-            message.template_id, _language_of(route), recipient, parameters
+            message.template_id,
+            route.template_language or DEFAULT_LANGUAGE,
+            recipient,
+            parameters,
         )
         url = self.endpoint(route.binding.address)
 
@@ -159,9 +153,17 @@ class MetaWhatsAppAdapter(ChannelAdapter):
         route: SendRoute,
         parameters: List[Dict[str, Any]],
     ) -> Dict[str, Any]:
-        """The Cloud API send body for this message on this route."""
+        """The Cloud API send body for this message on this route.
+
+        Language comes from the route, which resolve_send_route() took from
+        the approved template registry row (T23) — the one place that knows
+        which locale a merchant's template was actually approved in.
+        """
         return build_send_body(
-            message.template_id or "", _language_of(route), recipient, parameters
+            message.template_id or "",
+            route.template_language or DEFAULT_LANGUAGE,
+            recipient,
+            parameters,
         )
 
     def read_response(

--- a/app/crm/connectivity/providers/whatsapp/onboard.py
+++ b/app/crm/connectivity/providers/whatsapp/onboard.py
@@ -14,6 +14,8 @@ once the ingress bay is live.
 from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, List, Optional, Tuple
 
+from pydantic import BaseModel, Field
+
 from app.core.config.static import META_APP_ID, META_APP_SECRET
 from app.core.logger import logger
 from app.crm.connectivity.providers.base import ConnectorHandshakeError
@@ -37,6 +39,26 @@ _NO_RECEIVER_WHY = (
     "subscribed to the WABA; nothing consumes its events yet — delivery "
     "receipts, inbound replies and template status updates are not processed"
 )
+
+
+class OnboardWhatsappRequest(BaseModel):
+    """Body for POST /connectors/whatsapp/onboard.
+
+    Lives with the face, not in the module's generic schemas: the route
+    takes a plain dict and asks the registry which model validates it, so
+    this model's only consumer is this package's ConnectorSpec entry. Left
+    in schemas.py, Instagram's and Messenger's would land beside it and the
+    generic file would become a provider dump — the exact scatter the
+    package split exists to prevent.
+    """
+
+    merchant_id: str = Field(..., description="Tenant scope — required")
+    code: str = Field(..., description="Embedded Signup authorization code")
+    waba_id: str = Field(..., description="WhatsApp Business Account id")
+    phone_number_id: str = Field(..., description="Meta phone_number_id")
+    display_label: Optional[str] = Field(
+        None, description="What the merchant calls this account in the console"
+    )
 
 
 class WhatsappOnboardingError(ConnectorHandshakeError):

--- a/app/crm/connectivity/providers/whatsapp/templates.py
+++ b/app/crm/connectivity/providers/whatsapp/templates.py
@@ -1,0 +1,214 @@
+"""WhatsApp's template-registry face — Meta's message_templates endpoints,
+and the one place Meta's SHOUTING becomes the canon's lowercase.
+
+Reached only through connectivity/connectors.py (boundary rule 11).
+
+Why the normaliser lives here and nowhere else: Meta answers `APPROVED`,
+canon T23 spells the dictionary `approved`, and every rule in templates.py
+compares lowercase. A registry that stored both had `APPROVED`, `PENDING`,
+`submitting` and `deleted` sitting side by side; `?status=approved` returned
+zero rows while the row was plainly approved, and editing it was refused
+with "is 'APPROVED' — edit not supported from this status". Spending the
+quirk at the boundary is the only place it cannot leak.
+"""
+
+from typing import Any, Dict, List, Mapping, Optional
+
+from app.core.logger import logger
+from app.crm.connectivity.providers.base import TemplateProviderError
+from app.crm.connectivity.providers.meta.graph import GraphError, call, segment
+from app.crm.connectivity.providers.whatsapp import TOKEN_KEY
+from app.crm.connectivity.schemas import (
+    CredentialBundle,
+    ProviderTemplateState,
+    TemplateDraft,
+)
+from app.crm.connectivity.topics import (
+    TOPIC_TEMPLATE_CATEGORY,
+    TOPIC_TEMPLATE_QUALITY,
+    TOPIC_TEMPLATE_STATUS,
+)
+
+
+class WhatsappTemplateError(TemplateProviderError):
+    """Meta refused a template operation.
+
+    Subclasses the port's declared type so templates.py can tell this — a
+    refusal describing the merchant's own components — from an unexpected
+    exception whose text must not reach the API response.
+    """
+
+
+def _from_meta(word: Optional[str]) -> Optional[str]:
+    """Meta's vocabulary -> canon's.
+
+    Lowercasing, not a lookup table. Canon T23 names seven words "+ whatever
+    Meta adds", so an unrecognised one (PENDING_DELETION, FLAGGED) passes
+    through as itself rather than being dropped or mapped to a guess: an
+    unknown status is not 'approved', which is the only judgement anything
+    downstream actually makes.
+    """
+    if word is None:
+        return None
+    normalised = str(word).strip().lower()
+    return normalised or None
+
+
+async def _graph(method: str, path: str, **kwargs) -> Dict[str, Any]:
+    """One Graph call, with the transport error translated at this boundary.
+
+    GraphError is meta/graph.py's type and stays inside providers/ (rule 11),
+    so templates.py could not catch it even if it wanted to. Converting here
+    keeps its detail — which for a template operation is Meta describing the
+    merchant's own components, the actionable half of the refusal — while
+    letting the generic code catch exactly one declared type.
+    """
+    try:
+        return await call(method, path, **kwargs)
+    except GraphError as e:
+        raise WhatsappTemplateError(
+            e.detail or "Meta refused this template operation"
+        ) from e
+
+
+def _token(bundle: CredentialBundle) -> str:
+    token = bundle.secret(TOKEN_KEY)
+    if not token:
+        raise WhatsappTemplateError("the stored credential has no usable token")
+    return token
+
+
+class WhatsappTemplates:
+    """The TemplateProvider for WhatsApp."""
+
+    #: Meta re-reviews an edited template on the SAME row (approved, rejected
+    #: or paused -> pending). SMS-DLT cannot, and would have to re-register
+    #: under a new id — which is why templates.py asks the provider instead
+    #: of assuming Meta's behaviour is universal.
+    edits_in_place = True
+
+    async def submit(
+        self, bundle: CredentialBundle, account_ref: str, draft: TemplateDraft
+    ) -> ProviderTemplateState:
+        """POST /{waba}/message_templates — register a draft for review."""
+        body = await _graph(
+            "POST",
+            f"{segment(account_ref)}/message_templates",
+            access_token=_token(bundle),
+            json_body={
+                "name": draft.name,
+                "language": draft.language,
+                "category": draft.category,
+                "components": draft.components,
+            },
+        )
+        provider_template_id = body.get("id")
+        if not provider_template_id:
+            # Without an id we cannot ever match this template to a webhook,
+            # so a 200 without one is a failure, not a success.
+            raise WhatsappTemplateError("Meta accepted the template but returned no id")
+        return ProviderTemplateState(
+            provider_template_id=str(provider_template_id),
+            name=draft.name,
+            language=draft.language,
+            # Meta may assign a DIFFERENT category from the one requested.
+            # Theirs is what the merchant is billed at, so theirs is stored.
+            category=body.get("category") or draft.category,
+            status=_from_meta(body.get("status")) or "pending",
+        )
+
+    async def edit(
+        self,
+        bundle: CredentialBundle,
+        account_ref: str,
+        provider_template_id: str,
+        components: List[Dict[str, Any]],
+    ) -> ProviderTemplateState:
+        """POST /{template_id} — Meta addresses an edit by the template's own
+        id, not nested under the account.
+
+        The answer carries no status, so the transition is stated rather than
+        read: an edit sends the template back for review. The webhook that
+        follows is what confirms it.
+        """
+        await _graph(
+            "POST",
+            segment(provider_template_id),
+            access_token=_token(bundle),
+            json_body={"components": components},
+        )
+        return ProviderTemplateState(
+            provider_template_id=provider_template_id, status="pending"
+        )
+
+    async def retire(
+        self,
+        bundle: CredentialBundle,
+        account_ref: str,
+        provider_template_id: str,
+        name: str,
+        language: str,
+    ) -> None:
+        """DELETE /{waba}/message_templates — withdraw ONE template.
+
+        ``hsm_id`` is the load-bearing parameter. Meta's delete takes a name,
+        and a name alone deletes EVERY LANGUAGE VARIANT of it: retiring
+        order_update/en_US would silently delete order_update/hi_IN on Meta
+        while our hi_IN row still reads 'approved', and the first send on it
+        would fail at Meta with 132001. Passing the provider's id alongside
+        the name is Meta's documented single-language form.
+        """
+        await _graph(
+            "DELETE",
+            f"{segment(account_ref)}/message_templates",
+            access_token=_token(bundle),
+            params={"name": name, "hsm_id": provider_template_id},
+        )
+
+    def normalize_event(
+        self, topic: str, value: Mapping[str, Any]
+    ) -> Optional[ProviderTemplateState]:
+        """One Meta webhook `value` object -> the registry's vocabulary.
+
+        Returns None when the letter carries nothing this registry stores —
+        which is an ordinary outcome, not an error: the same bay delivers
+        fields we do not consume yet.
+        """
+        provider_template_id = value.get("message_template_id")
+        state = ProviderTemplateState(
+            provider_template_id=(
+                str(provider_template_id) if provider_template_id else None
+            ),
+            name=value.get("message_template_name"),
+            language=value.get("message_template_language"),
+        )
+
+        if topic == TOPIC_TEMPLATE_STATUS:
+            status = _from_meta(value.get("event"))
+            if status is None:
+                return None
+            state.status = status
+            # Meta spells it 'reason' and sends the literal string "NONE"
+            # when there is none — storing that would show a merchant the
+            # word NONE as their rejection reason.
+            reason = value.get("reason")
+            if reason and str(reason).upper() != "NONE":
+                state.rejection_reason = str(reason)
+            return state
+
+        if topic == TOPIC_TEMPLATE_CATEGORY:
+            category = value.get("new_category")
+            if not category:
+                return None
+            state.category = str(category)
+            return state
+
+        if topic == TOPIC_TEMPLATE_QUALITY:
+            quality = value.get("new_quality_score")
+            if not quality:
+                return None
+            state.quality = str(quality)
+            return state
+
+        logger.debug(f"whatsapp templates: nothing to apply for topic '{topic}'")
+        return None

--- a/app/crm/connectivity/reasons.py
+++ b/app/crm/connectivity/reasons.py
@@ -19,6 +19,11 @@ REASON_NO_ADAPTER = "channel_not_supported"
 REASON_NO_BINDING = "no_active_binding"
 REASON_NO_INSTALLATION = "connector_not_installed"
 REASON_INSTALLATION_UNHEALTHY = "connector_unhealthy"
+# The T23 registry says this name is not approved for this account — never
+# registered, still pending, rejected, deleted, or approved in more than one
+# language with nothing on the row to choose between them. ADR 0011: refused
+# on OUR side of the wire, so the provider never sees it.
+REASON_TEMPLATE_NOT_APPROVED = "template_not_approved"
 
 # Retryable, unlike the refusals above — both mean "no answer", and no
 # answer is not "no": the provider may have taken the message. The timeout

--- a/app/crm/connectivity/schemas.py
+++ b/app/crm/connectivity/schemas.py
@@ -3,7 +3,7 @@ nothing internal — api.py, contracts.py, the provider ports and the tests
 all read their vocabulary from here."""
 
 from datetime import datetime
-from typing import Any, Dict, Literal, Optional
+from typing import Any, Dict, List, Literal, Optional
 
 from pydantic import BaseModel, Field, model_validator
 
@@ -123,6 +123,11 @@ class SendRoute(BaseModel):
     installation: ConnectorInstallation
     binding: ChannelBinding
     bundle: CredentialBundle
+    # The locale the template registry says this merchant's template was
+    # APPROVED in (T23). Optional only so a future channel that does not
+    # pre-register templates can leave it unset — for a channel that does,
+    # resolve_send_route refuses before the adapter rather than passing None.
+    template_language: Optional[str] = None
 
 
 # ---------------------------------------------------------------------------
@@ -185,6 +190,56 @@ class OnboardResult(BaseModel):
 
 
 # ---------------------------------------------------------------------------
+# Template registry — the shapes crossing the TemplateProvider port
+# ---------------------------------------------------------------------------
+
+
+class TemplateDraft(BaseModel):
+    """What a provider needs to register a template. The local row's id and
+    status are deliberately absent: the provider has no business knowing
+    them, and passing them invites a face to make a lifecycle decision."""
+
+    name: str
+    language: str
+    category: str
+    components: List[Dict[str, Any]]
+
+
+class ApprovedTemplate(BaseModel):
+    """The send path's answer from the registry: this name is approved, and
+    this is the locale it was approved in.
+
+    Narrow on purpose. resolve_send_route runs once per message, and the row
+    it needs an answer from carries a components blob the send path will
+    never render — the provider does the rendering.
+    """
+
+    id: str
+    language: str
+
+
+class ProviderTemplateState(BaseModel):
+    """A provider's answer about one template, in the CANON's vocabulary.
+
+    Normalisation happens in the provider face, never here and never in
+    templates.py: Meta shouting APPROVED while canon T23 spells it
+    'approved' is Meta's quirk, and a registry that stored both would have
+    every status filter silently return the wrong half of its rows. That is
+    not hypothetical — it shipped once and was found by running it.
+    """
+
+    provider_template_id: Optional[str] = None
+    name: Optional[str] = None
+    language: Optional[str] = None
+    status: Optional[str] = None
+    #: The category the provider ASSIGNED, which may differ from the one we
+    #: requested — the difference is a price change, so it is kept visible.
+    category: Optional[str] = None
+    quality: Optional[str] = None
+    rejection_reason: Optional[str] = None
+
+
+# ---------------------------------------------------------------------------
 # The API surface — request bodies and read models
 # ---------------------------------------------------------------------------
 #
@@ -193,23 +248,6 @@ class OnboardResult(BaseModel):
 # no single "current" one to infer, and inferring the wrong one is a
 # cross-tenant write. api.py validates it against the caller's RBAC scope
 # before anything else runs (fail closed on tenancy).
-
-
-class OnboardWhatsappRequest(BaseModel):
-    """Body for POST /connectors/whatsapp/onboard.
-
-    Named by the whatsapp ConnectorSpec, not by the route — the route takes
-    a dict and asks the registry which model validates it, so adding a
-    connector adds no branch here.
-    """
-
-    merchant_id: str = Field(..., description="Tenant scope — required")
-    code: str = Field(..., description="Embedded Signup authorization code")
-    waba_id: str = Field(..., description="WhatsApp Business Account id")
-    phone_number_id: str = Field(..., description="Meta phone_number_id")
-    display_label: Optional[str] = Field(
-        None, description="What the merchant calls this account in the console"
-    )
 
 
 class InstallationRead(BaseModel):
@@ -229,5 +267,67 @@ class InstallationRead(BaseModel):
     last_event_at: Optional[datetime] = None
     health_detail: Dict[str, Any] = Field(default_factory=dict)
     installed_at: datetime
+    created_at: datetime
+    updated_at: datetime
+
+
+class CreateTemplateDraftRequest(BaseModel):
+    """Body for POST /connectors/templates. ``components`` is stored verbatim — the
+    provider's own registered structure — and is never validated against
+    their schema here: that is the provider's job at submission time, and a
+    second validator would refuse shapes they accept."""
+
+    merchant_id: str = Field(..., description="Tenant scope — required")
+    channel: str = Field(..., description="Must name a registered connector")
+    provider_account_ref: str = Field(
+        ..., description="The account that owns this template (a WABA id)"
+    )
+    name: str = Field(..., description="What crm_message.template_id will store")
+    language: str = Field(
+        ..., description="The provider's key is (account, name, language)"
+    )
+    components: List[Dict[str, Any]] = Field(
+        ..., description="The registered structure, verbatim"
+    )
+
+
+class SubmitTemplateRequest(BaseModel):
+    merchant_id: str = Field(..., description="Tenant scope — required")
+    category: str = Field(..., description="MARKETING · UTILITY · AUTHENTICATION")
+
+
+class EditTemplateRequest(BaseModel):
+    merchant_id: str = Field(..., description="Tenant scope — required")
+    components: List[Dict[str, Any]] = Field(
+        ..., description="Replacement components, verbatim"
+    )
+
+
+class RetireTemplateRequest(BaseModel):
+    merchant_id: str = Field(..., description="Tenant scope — required")
+
+
+class TemplateRead(BaseModel):
+    """One registry row (T23). ``category`` is what the provider ASSIGNED and
+    ``submitted_category`` what we asked for — the difference is a price
+    change, so both stay visible rather than one overwriting the other."""
+
+    id: str
+    merchant_id: str
+    channel: str
+    provider_account_ref: str
+    name: str
+    language: str
+    provider_template_id: Optional[str] = None
+    category: Optional[str] = None
+    submitted_category: Optional[str] = None
+    category_updated_at: Optional[datetime] = None
+    components: List[Dict[str, Any]] = Field(default_factory=list)
+    status: str
+    status_updated_at: datetime
+    rejection_reason: Optional[str] = None
+    quality: str
+    quality_updated_at: Optional[datetime] = None
+    last_synced_at: Optional[datetime] = None
     created_at: datetime
     updated_at: datetime

--- a/app/crm/connectivity/send.py
+++ b/app/crm/connectivity/send.py
@@ -3,9 +3,11 @@
 Everything that must be true before a message reaches a person is checked
 here, once, for every channel: the gate granted it, the channel has an
 adapter, the merchant has a live pipe, the account behind it is healthy, its
-credentials decrypt. Any of those missing REFUSES the send — nothing falls
+credentials decrypt, and the template it names is APPROVED on that account
+(ADR 0011). Any of those missing REFUSES the send — nothing falls
 through to a default, because every plausible default (another number,
-another account) contacts somebody in a way they did not agree to.
+another account, another locale) contacts somebody in a way they did not
+agree to.
 
 The route is assembled here and handed to the adapter whole, which is what
 lets an adapter be tested without a database. Adapters live behind
@@ -29,6 +31,7 @@ from typing import Optional, Union
 
 from app.core.config.static import CRM_MESSAGE_SEND_TIMEOUT_SECONDS
 from app.core.logger import logger
+from app.crm.connectivity import accounts, templates
 from app.crm.connectivity.db.accessors import (
     binding as binding_accessor,
     installation as installation_accessor,
@@ -42,28 +45,21 @@ from app.crm.connectivity.reasons import (
     REASON_NO_BINDING,
     REASON_NO_CREDENTIAL,
     REASON_NO_INSTALLATION,
+    REASON_NO_TEMPLATE,
     REASON_SEND_ERROR,
+    REASON_TEMPLATE_NOT_APPROVED,
     REASON_TIMEOUT,
 )
 from app.crm.connectivity.schemas import (
-    CredentialBundle,
     QueuedMessage,
     SendOutcome,
     SendRoute,
     SendToken,
 )
 from app.crm.shared.redact import mask_address
-from app.database.accessor.breeze_buddy.credentials import get_credential_by_id
 
 # All REASON_* words live in reasons.py — one file, one name per failure
 # mode. This door only raises them.
-
-# The only installation state a send may leave through — fail closed on
-# everything else, 'connecting' included. Onboarding (#1038) verifies the
-# token and number against the Graph API and writes the row as 'healthy'
-# directly, so 'connecting' is an unproven connection with no first-send
-# deadlock to earn it an exception.
-SENDABLE_INSTALLATION_STATES = frozenset({"healthy"})
 
 
 def _refused(reason: str) -> SendOutcome:
@@ -93,9 +89,13 @@ def token_grants(token: SendToken, message: QueuedMessage) -> bool:
 
 
 async def resolve_send_route(
-    merchant_id: str, channel: str, binding_id: Optional[str] = None
+    merchant_id: str,
+    channel: str,
+    binding_id: Optional[str] = None,
+    template_name: Optional[str] = None,
 ) -> Union[SendRoute, str]:
-    """Find the pipe, the account and the secrets — or the reason there is none.
+    """Find the pipe, the account, the secrets and the approved template — or
+    the reason there is none.
 
     Returns a SendRoute, or a refusal reason as a string. Not an exception:
     "this merchant has not connected WhatsApp" is an ordinary answer that
@@ -103,13 +103,10 @@ async def resolve_send_route(
 
     Order matters — the binding comes first because it is the merchant-scoped
     anchor, and everything after is reached THROUGH it, so no lookup here can
-    wander into another tenant's rows.
-
-    TODO(T23): once the template registry lands, look the template up here
-    and refuse with blocked/template_not_approved unless it is approved on
-    this account — taking the language from the registry row instead of
-    binding.capabilities (ADR 0011: a non-approved template is refused
-    BEFORE the provider call).
+    wander into another tenant's rows. The template is keyed by the
+    installation's provider account, so it comes after those two — but before
+    the vault, because it is a plain read and the vault read is a KMS
+    decrypt: the cheapest refusal should never pay for the dearest step.
     """
     binding = await binding_accessor.get_binding(merchant_id, channel, binding_id)
     if binding is None:
@@ -122,37 +119,42 @@ async def resolve_send_route(
     )
     if installation is None:
         return REASON_NO_INSTALLATION
-    if installation.status not in SENDABLE_INSTALLATION_STATES:
+    if not accounts.is_usable(installation):
         logger.warning(
             f"connectivity: installation {installation.id} is "
             f"'{installation.status}' — no route for {merchant_id}/{channel}"
         )
         return REASON_INSTALLATION_UNHEALTHY
 
-    if not installation.credential_id:
-        return REASON_NO_CREDENTIAL
-    # The vault (`credentials`) belongs to app/database, so it is read through
-    # ITS accessor, never raw SQL from here (table-ownership law). mask=False:
-    # the adapter needs the real secret, not the API's ****. raise_errors=True:
-    # None must mean "row gone/dead" (terminal below) — a pool blip on this
-    # read has to raise and ride send()'s catch into a retryable send_error,
-    # like the same blip on any other read in this resolver.
-    credential = await get_credential_by_id(
-        installation.credential_id, mask=False, raise_errors=True
+    if not template_name:
+        # The adapter refuses this too, but refusing here keeps the reason on
+        # the near side of the wire for every channel, not just WhatsApp's.
+        return REASON_NO_TEMPLATE
+    # ADR 0011: a non-approved template is refused BEFORE the provider call.
+    # The registry states the fact; the word for "no" is this door's.
+    language = await templates.approved_language(
+        merchant_id, channel, installation.external_account_id, template_name
     )
-    if credential is None or not credential.is_active or not credential.value:
-        # Vault row gone, deactivated, or it would not decrypt (an
-        # undecryptable value decodes as {}) — same thing to this message,
-        # and none of it is worth a retry.
-        return REASON_NO_CREDENTIAL
-    # Ownership cannot be compared HERE: the vault's scope column is
-    # reseller_id — one level above merchant (022) — and this module by law
-    # knows no reseller. The guard is the merchant-scoped installation fetch
-    # above; the onboarding sync that WRITES credential_id owns refusing a
-    # foreign reseller's bundle (NULL = global stays legal).
-    bundle = CredentialBundle(values=credential.value)
+    if language is None:
+        return REASON_TEMPLATE_NOT_APPROVED
 
-    return SendRoute(installation=installation, binding=binding, bundle=bundle)
+    try:
+        # The vault read is a KMS decrypt, so it comes last: the cheapest
+        # refusal should never pay for the dearest step. A DB failure here
+        # RAISES rather than answering "no credential" — it rides send()'s
+        # catch into a retryable send_error, like a blip on any other read.
+        bundle = await accounts.bundle_for(installation)
+    except accounts.AccountError:
+        # Vault row gone, deactivated, or it would not decrypt — none of it
+        # worth a retry.
+        return REASON_NO_CREDENTIAL
+
+    return SendRoute(
+        installation=installation,
+        binding=binding,
+        bundle=bundle,
+        template_language=language,
+    )
 
 
 async def _resolve_and_deliver(
@@ -165,7 +167,10 @@ async def _resolve_and_deliver(
     hung provider — same reassigned row, same double send.
     """
     route = await resolve_send_route(
-        message.merchant_id, message.channel, message.binding_id
+        message.merchant_id,
+        message.channel,
+        message.binding_id,
+        message.template_id,
     )
     if not isinstance(route, SendRoute):
         # No route, and the resolver said why. Its reason is the honest one.

--- a/app/crm/connectivity/templates.py
+++ b/app/crm/connectivity/templates.py
@@ -1,0 +1,542 @@
+"""The template registry (T23) — generic, dispatching through CONNECTORS.
+
+canon T23 calls this registry multi-channel: WhatsApp first, SMS-DLT second,
+email later. So nothing here names a provider. A template row carries a
+`channel`; the registry asks which connector serves that channel and hands
+the work to its face, which returns a NORMALISED ProviderTemplateState.
+
+The lifecycle, and where each rule lives:
+
+    create   local only                  draft
+    submit   claim -> provider -> record  draft -> submitting -> pending
+    edit     draft: local; otherwise      approved/rejected/paused -> pending
+             in place at the provider     (only if the provider supports it)
+    retire   provider, then local         -> deleted
+
+Two things this file deliberately does NOT do.
+
+**It does not decide what "editable" means for a provider.** Meta re-reviews
+an edited template on the same row; SMS-DLT has to re-register under a new
+id. The branch reads `provider.edits_in_place`, not a provider's name.
+
+**It does not learn status on a clock.** Providers push status, category and
+quality as events, and the webhook consumer (PR C) will be the only writer of
+them. A timed full sync across every merchant rewrites the same rows
+twenty-three hours out of twenty-four for zero information, and the one it
+would catch arrives as a webhook anyway.
+"""
+
+from typing import Any, Dict, List, Optional
+
+from app.core.logger import logger
+from app.crm.connectivity import accounts
+from app.crm.connectivity.connectors import (
+    ConnectorSpec,
+    ProviderError,
+    connector_for_channel,
+)
+from app.crm.connectivity.db import DbTxn, atomically
+from app.crm.connectivity.db.accessors import (
+    template as template_accessor,
+)
+from app.crm.connectivity.schemas import (
+    ConnectorInstallation,
+    CredentialBundle,
+    TemplateDraft,
+    TemplateRead,
+)
+
+#: The only status a local draft edit applies to. Everything else has been
+#: shown to a provider and has to go back through one.
+_LOCAL_EDIT_STATUSES = {"draft"}
+
+#: Statuses a provider that edits in place will re-review from. 'rejected' is
+#: in this set and NOT in the submittable set, which is the whole fix for a
+#: dead end that existed both ways: re-submitting a rejected template POSTs a
+#: create for a name the provider already holds ("name already exists"), and
+#: refusing to edit it left no way to correct the components either.
+_IN_PLACE_EDIT_STATUSES = {"approved", "rejected", "paused"}
+
+
+class TemplateError(Exception):
+    """A transition is not available from this template's current status, or
+    the account behind it cannot be resolved."""
+
+
+class TemplateNotFoundError(TemplateError):
+    """No such template for this merchant — a 404, not a 400."""
+
+
+def _as_template_error(error: Exception) -> TemplateError:
+    """A provider's exception, translated at this module's edge.
+
+    api.py cannot catch a provider's own type — boundary rule 11 forbids it
+    from importing a provider package at all — so every failure leaves here
+    wearing this module's word for it.
+
+    A DECLARED refusal is passed through verbatim: for a template operation
+    the provider's message is the actionable part ("component BODY has too
+    many variables"), and what it describes is the merchant's own template.
+    Anything else is a bug, and its text is an internal detail — a
+    KeyError('id') must not become a 400 whose body reads 'id'. Same split
+    onboarding makes with ConnectorHandshakeError.
+    """
+    if isinstance(error, TemplateError):
+        return error
+    if isinstance(error, ProviderError):
+        # The base, not the template leaf: every face declares its refusals
+        # under one type, so a face added later is covered without editing
+        # this line — which is the whole reason the base exists.
+        return TemplateError(str(error) or "the provider refused this template")
+    logger.opt(exception=error).error(
+        "templates: a template operation raised unexpectedly"
+    )
+    return TemplateError("could not complete the template operation")
+
+
+# ---------------------------------------------------------------------------
+# Resolving the provider behind a row
+# ---------------------------------------------------------------------------
+
+
+def _spec_for(channel: str) -> ConnectorSpec:
+    spec = connector_for_channel(channel)
+    if spec is None:
+        raise TemplateError(f"no connector serves channel '{channel}'")
+    return spec
+
+
+async def _healthy_installation(
+    merchant_id: str, connector_key: str, provider_account_ref: str
+) -> ConnectorInstallation:
+    """accounts.py's answer, wearing this module's word for a refusal.
+
+    The policy — which statuses are usable — lives in accounts.py alone, so
+    the send door and this one cannot drift apart on it. All that is left here
+    is the translation every caller does in its own vocabulary.
+    """
+    try:
+        return await accounts.healthy_installation(
+            merchant_id, connector_key, provider_account_ref
+        )
+    except accounts.AccountError as e:
+        raise TemplateError(str(e)) from e
+
+
+async def _bundle_for(installation: ConnectorInstallation) -> CredentialBundle:
+    """The same translation for the credential step."""
+    try:
+        return await accounts.bundle_for(installation)
+    except accounts.AccountError as e:
+        raise TemplateError(str(e)) from e
+
+
+# ---------------------------------------------------------------------------
+# create
+# ---------------------------------------------------------------------------
+
+
+async def create_draft(
+    merchant_id: str,
+    channel: str,
+    provider_account_ref: str,
+    name: str,
+    language: str,
+    components: List[Dict[str, Any]],
+) -> TemplateRead:
+    """A local draft. Nothing is sent to the provider until submit().
+
+    Both inputs are validated CLOSED here rather than at submit, because a
+    draft that cannot ever be submitted is worse than a refusal: it looks
+    like progress. An unregistered channel has no provider to submit to, and
+    an account with no healthy connection has no credential to submit with.
+
+    Idempotent on the natural key, but only while the row is still a draft —
+    law #4's "safely callable twice" does not extend to overwriting the
+    components a provider is currently reviewing.
+    """
+    # Refuses an unregistered channel. The spec's own channel is this one by
+    # construction — connector_for_channel matches on equality — so the
+    # validated parameter is what gets stored, and it is already a str. A
+    # spec's channel is Optional now that a connector may be a door with no
+    # pipe, and such a connector can never be resolved from a channel here.
+    spec = _spec_for(channel)
+    await _healthy_installation(merchant_id, spec.key, provider_account_ref)
+    return await atomically(
+        _create_draft_in_txn,
+        merchant_id,
+        channel,
+        provider_account_ref,
+        name,
+        language,
+        components,
+    )
+
+
+async def _create_draft_in_txn(
+    txn: DbTxn,
+    merchant_id: str,
+    channel: str,
+    provider_account_ref: str,
+    name: str,
+    language: str,
+    components: List[Dict[str, Any]],
+) -> TemplateRead:
+    """ATOMIC: the natural-key probe and the write share one fate — two
+    concurrent create calls for one key must not both pass the probe and
+    then meet as a unique violation the caller cannot explain."""
+    existing = await template_accessor.get_template_by_natural_key(
+        txn, merchant_id, channel, provider_account_ref, name, language
+    )
+    if existing is None:
+        return await template_accessor.insert_template_draft(
+            txn, merchant_id, channel, provider_account_ref, name, language, components
+        )
+    if existing.status != "draft":
+        raise TemplateError(
+            f"a template named '{name}' ({language}) already exists on this "
+            f"account and is '{existing.status}' — edit it instead of recreating it"
+        )
+    updated = await template_accessor.update_draft_components(
+        txn, merchant_id, existing.id, components
+    )
+    if updated is None:
+        raise TemplateError("the draft changed while it was being updated")
+    return updated
+
+
+# ---------------------------------------------------------------------------
+# submit
+# ---------------------------------------------------------------------------
+
+
+async def submit(merchant_id: str, template_id: str, category: str) -> TemplateRead:
+    """Register a draft with its provider.
+
+    The shape is claim -> call -> record, and the claim is what stops one
+    template being registered twice: two requests that both read 'draft'
+    would both POST, and the provider refuses the second by name only AFTER
+    we have fired it.
+
+    Everything between the claim and the provider's acceptance is wrapped,
+    because all of it can fail — the credential may not resolve, the
+    components may be refused, the process may die. A claim left standing
+    after a failure is permanent: 'submitting' is not re-claimable (by
+    design), and the resume path cannot help because the provider never
+    received it. Releasing it is the difference between "try again" and "this
+    template is dead".
+    """
+    template = await template_accessor.get_template(merchant_id, template_id)
+    if template is None:
+        raise TemplateNotFoundError("no such template")
+    if template.status != "draft":
+        raise TemplateError(
+            f"this template is '{template.status}' — only a draft can be "
+            f"submitted"
+            + (
+                "; edit it to send the corrected version for review"
+                if template.status == "rejected"
+                else ""
+            )
+        )
+
+    claimed = await atomically(_claim_for_submit_in_txn, merchant_id, template_id)
+    if claimed is None:
+        raise TemplateError("this template is already being submitted")
+
+    try:
+        spec = _spec_for(claimed.channel)
+        installation = await _healthy_installation(
+            merchant_id,
+            spec.key,
+            claimed.provider_account_ref,
+        )
+        bundle = await _bundle_for(installation)
+        state = await spec.templates.submit(
+            bundle,
+            claimed.provider_account_ref,
+            TemplateDraft(
+                name=claimed.name,
+                language=claimed.language,
+                category=category,
+                components=claimed.components,
+            ),
+        )
+    except Exception as e:
+        # The provider never accepted it, so the row goes back to being a
+        # draft the merchant can fix and retry. Re-raised: the caller still
+        # needs to see what went wrong.
+        released = await template_accessor.release_submit_claim(
+            merchant_id, template_id
+        )
+        if released is None:
+            logger.error(
+                f"template {template_id}: submit failed and the claim could not "
+                f"be released — the row may be stuck in 'submitting'"
+            )
+        raise _as_template_error(e) from e
+
+    updated = await atomically(
+        _record_submission_in_txn,
+        merchant_id,
+        template_id,
+        state.provider_template_id or "",
+        state.category,
+        category,
+        state.status or "pending",
+    )
+    return updated
+
+
+async def _claim_for_submit_in_txn(
+    txn: DbTxn, merchant_id: str, template_id: str
+) -> Optional[TemplateRead]:
+    """ATOMIC: the status test and the swap to 'submitting' share one fate —
+    two concurrent submits must not both believe they hold the claim, because
+    each of them would then register the same template with the provider."""
+    return await template_accessor.claim_for_submit(txn, merchant_id, template_id)
+
+
+async def _record_submission_in_txn(
+    txn: DbTxn,
+    merchant_id: str,
+    template_id: str,
+    provider_template_id: str,
+    category: Optional[str],
+    submitted_category: str,
+    status: str,
+) -> TemplateRead:
+    """ATOMIC: the provider's id, category and status land together — a
+    reader must never see a template carrying the provider's id beside our
+    stale status, which is exactly the state the webhook consumer's resume
+    path is written to repair."""
+    updated = await template_accessor.record_submission(
+        txn,
+        merchant_id,
+        template_id,
+        provider_template_id,
+        category,
+        submitted_category,
+        status,
+    )
+    if updated is None:
+        raise TemplateError("the template changed while its submission was recorded")
+    return updated
+
+
+# ---------------------------------------------------------------------------
+# edit
+# ---------------------------------------------------------------------------
+
+
+async def edit(
+    merchant_id: str, template_id: str, components: List[Dict[str, Any]]
+) -> TemplateRead:
+    """Replace a template's components.
+
+    A draft is edited locally. Anything the provider has already seen is
+    edited AT the provider — and for a provider that re-reviews in place,
+    that edit IS the way to resubmit a rejected template.
+    """
+    template = await template_accessor.get_template(merchant_id, template_id)
+    if template is None:
+        raise TemplateNotFoundError("no such template")
+
+    if template.status in _LOCAL_EDIT_STATUSES:
+        return await atomically(
+            _edit_draft_in_txn, merchant_id, template_id, components
+        )
+
+    spec = _spec_for(template.channel)
+    if template.status not in _IN_PLACE_EDIT_STATUSES:
+        raise TemplateError(
+            f"this template is '{template.status}' — it cannot be edited from "
+            f"that state"
+        )
+    if not spec.templates.edits_in_place:
+        # Honest rather than a 400 carrying another provider's rule: this
+        # provider genuinely cannot re-review a registered template.
+        raise TemplateError(
+            f"templates on '{template.channel}' cannot be edited once "
+            f"registered — retire this one and register a new one"
+        )
+    if template.provider_template_id is None:
+        raise TemplateError(
+            "this template has no provider id yet — its submission has not "
+            "been confirmed"
+        )
+
+    installation = await _healthy_installation(
+        merchant_id, spec.key, template.provider_account_ref
+    )
+    bundle = await _bundle_for(installation)
+    try:
+        state = await spec.templates.edit(
+            bundle,
+            template.provider_account_ref,
+            template.provider_template_id,
+            components,
+        )
+    except Exception as e:
+        # Nothing local has changed yet, so there is no claim to release —
+        # only the provider's word to translate into ours.
+        raise _as_template_error(e) from e
+    return await atomically(
+        _edit_registered_in_txn,
+        merchant_id,
+        template_id,
+        components,
+        state.status or "pending",
+        template.status,
+    )
+
+
+async def _edit_draft_in_txn(
+    txn: DbTxn, merchant_id: str, template_id: str, components: List[Dict[str, Any]]
+) -> TemplateRead:
+    """ATOMIC: one statement — this exists so a draft edit enters the
+    database through the same door every other transition does, rather than
+    growing a second way in the first time it needs a second statement."""
+    updated = await template_accessor.update_draft_components(
+        txn, merchant_id, template_id, components
+    )
+    if updated is None:
+        raise TemplateError("this template is no longer a draft")
+    return updated
+
+
+async def _edit_registered_in_txn(
+    txn: DbTxn,
+    merchant_id: str,
+    template_id: str,
+    components: List[Dict[str, Any]],
+    status: str,
+    expected_status: str,
+) -> TemplateRead:
+    """ATOMIC: the new components and the status they put the row back into
+    share one fate (canon T23: editing an approved template returns the SAME
+    row to pending) — a reader must never see new components still labelled
+    'approved', because the send path would take that as permission.
+
+    Conditional on the status this edit was authorised against. The provider
+    call happens outside any transaction, so a concurrent retire() can land
+    in between; without the guard this write would put fresh components and
+    'pending' over a row the merchant just deleted."""
+    updated = await template_accessor.record_in_place_edit(
+        txn, merchant_id, template_id, components, status, expected_status
+    )
+    if updated is None:
+        raise TemplateError(
+            "the template changed while it was being edited — reload it and "
+            "try again"
+        )
+    return updated
+
+
+# ---------------------------------------------------------------------------
+# retire
+# ---------------------------------------------------------------------------
+
+
+async def retire(merchant_id: str, template_id: str) -> TemplateRead:
+    """Withdraw a template, at the provider and here.
+
+    The provider call is best-effort: a provider outage must not leave a
+    merchant unable to stop using a template locally. Local retirement is
+    what the send path reads, so it is the one that has to happen.
+
+    A 'submitting' row can be retired mid-flight, and the submit that is
+    still in the air then finds no claim to record against and fails. That
+    is acceptable rather than guarded: the merchant asked for this template
+    to be gone, the provider's own status webhook still arrives, and the
+    resume path matches by natural key rather than by our claim.
+    """
+    template = await template_accessor.get_template(merchant_id, template_id)
+    if template is None:
+        raise TemplateNotFoundError("no such template")
+
+    if template.provider_template_id is not None:
+        try:
+            spec = _spec_for(template.channel)
+            installation = await _healthy_installation(
+                merchant_id,
+                spec.key,
+                template.provider_account_ref,
+            )
+            bundle = await _bundle_for(installation)
+            await spec.templates.retire(
+                bundle,
+                template.provider_account_ref,
+                template.provider_template_id,
+                template.name,
+                template.language,
+            )
+        except Exception as e:
+            logger.opt(exception=e).warning(
+                f"template {template_id}: could not withdraw it at the provider, "
+                f"retiring locally anyway"
+            )
+
+    updated = await atomically(_retire_in_txn, merchant_id, template_id)
+    if updated is None:
+        raise TemplateNotFoundError("no such template")
+    return updated
+
+
+async def _retire_in_txn(
+    txn: DbTxn, merchant_id: str, template_id: str
+) -> Optional[TemplateRead]:
+    """ATOMIC: one statement — the same single door every transition uses."""
+    return await template_accessor.retire_template(txn, merchant_id, template_id)
+
+
+# ---------------------------------------------------------------------------
+# reads
+# ---------------------------------------------------------------------------
+
+
+async def get(merchant_id: str, template_id: str) -> Optional[TemplateRead]:
+    return await template_accessor.get_template(merchant_id, template_id)
+
+
+async def list_templates(
+    merchant_id: str, channel: Optional[str] = None, status: Optional[str] = None
+) -> List[TemplateRead]:
+    return await template_accessor.list_templates(merchant_id, channel, status)
+
+
+async def approved_language(
+    merchant_id: str, channel: str, provider_account_ref: str, name: str
+) -> Optional[str]:
+    """Is this template name approved on this account, and in which language?
+
+    The registry's one public read for the send path. It states a FACT and
+    nothing else — the caller owns the word for "no", exactly as the binding
+    and installation steps already separate the fact from the refusal. It also
+    keeps every read of the registry table in this file: two logic files
+    owning reads on one table is how two answers to "is this approved" appear.
+
+    None has three causes, and from the sender's side they are one fact:
+
+      * the name was never registered here;
+      * it is registered but pending / rejected / paused / deleted;
+      * it is approved in MORE THAN ONE language.
+
+    The last deserves the same None as the others rather than a default:
+    crm_message carries the template NAME and no language column, so picking a
+    locale would be guessing which language a customer reads, and a wrong
+    guess is an unreadable message sent under a merchant's name. When T16
+    grows a language column this becomes a lookup on the full natural key and
+    the ambiguity disappears — noted as the trail, not worked around here.
+    """
+    approved = await template_accessor.approved_templates_for_send(
+        merchant_id, channel, provider_account_ref, name
+    )
+    if len(approved) != 1:
+        logger.warning(
+            f"connectivity: template '{name}' on {provider_account_ref} has "
+            f"{len(approved)} approved rows for {merchant_id}/{channel} — "
+            f"exactly one is required to send"
+        )
+        return None
+    return approved[0].language

--- a/app/crm/connectivity/topics.py
+++ b/app/crm/connectivity/topics.py
@@ -1,0 +1,34 @@
+"""The spine topics this module publishes and consumes — one file, one name
+each.
+
+These are canon T13 vocabulary, not any provider's: `template.status` is what
+a letter about a template's approval is CALLED on the event spine, whatever
+sent it. Meta's own word for the same thing is
+`message_template_status_update`, and that mapping belongs in the bay that
+receives it.
+
+They live here rather than in providers/whatsapp/templates.py for a boundary
+reason, not a tidiness one: the consumer that reads these letters is generic
+(it dispatches through CONNECTORS), and rule 11 forbids it from importing a
+provider package. A shared constant in a provider file is a boundary
+violation waiting for its second caller. Same shape, and the same reason, as
+reasons.py.
+"""
+
+#: A provider decided a template's fate — approved, rejected, paused, deleted.
+TOPIC_TEMPLATE_STATUS = "template.status"
+
+#: A provider re-categorised a template. The money one: the category is what
+#: the merchant is billed at, and providers change it on their own.
+TOPIC_TEMPLATE_CATEGORY = "template.category"
+
+#: A provider's quality read on a template — the early warning before it
+#: pauses one itself.
+TOPIC_TEMPLATE_QUALITY = "template.quality"
+
+#: Every template topic, for a consumer registering itself against all three.
+TEMPLATE_TOPICS = (
+    TOPIC_TEMPLATE_STATUS,
+    TOPIC_TEMPLATE_CATEGORY,
+    TOPIC_TEMPLATE_QUALITY,
+)

--- a/app/crm/shared/decode.py
+++ b/app/crm/shared/decode.py
@@ -9,7 +9,7 @@ Imported directly (shared/ is exempt from the contracts-only rule).
 """
 
 import json
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 
 def jsonb_object(value: Any) -> Dict[str, Any]:
@@ -28,6 +28,25 @@ def jsonb_object(value: Any) -> Dict[str, Any]:
         except (TypeError, ValueError):
             return {}
     return dict(value) if isinstance(value, dict) else {}
+
+
+def jsonb_list(value: Any) -> List[Any]:
+    """A jsonb column as a list. Anything else becomes an empty list.
+
+    Same totality contract as ``jsonb_object`` and the same reason for it: a
+    template's components are decoded inside a batch, where one raise would
+    strand every row beside it.
+
+    A stored object or scalar is DROPPED rather than wrapped — [42] is not
+    what "42" meant, and every caller reading a components list has already
+    handled the empty case.
+    """
+    if isinstance(value, str):
+        try:
+            value = json.loads(value)
+        except (TypeError, ValueError):
+            return []
+    return list(value) if isinstance(value, list) else []
 
 
 def uuid_or_none(value: Any) -> Optional[str]:

--- a/app/database/migrations/061_create_crm_channel_template.sql
+++ b/app/database/migrations/061_create_crm_channel_template.sql
@@ -1,0 +1,124 @@
+-- 061: crm_channel_template (canon T23, C7) — the channel template registry.
+--
+-- One table for every channel that pre-registers message shapes: WhatsApp
+-- (WABA templates) first, SMS-DLT second, email later. crm_message.template_id
+-- (T16, migration 056) stores the `name` this table registers — plain text, no
+-- FK, because crm_message carries a name and no language, and a composite FK
+-- would need both.
+--
+-- Named crm_channel_TEMPLATE, singular and channel-qualified, because "template"
+-- alone already means something else in this repo: buddy's agent templates are
+-- JSON conversation graphs, and two things called template in one schema is a
+-- question every future reader has to re-answer.
+--
+-- Deliberate choices, each with the reason it beat the obvious alternative:
+--
+-- 1. The natural key carries provider_account_ref, one column beyond canon
+--    T23's (merchant_id, channel, name, language). The provider's own key is
+--    (account, name, language) — for WhatsApp, (WABA, name, language) — and a
+--    merchant may hold TWO accounts on one channel (two shops, two WABAs).
+--    Without the account in the key, the same name+language registered in the
+--    second account collides with the first and simply cannot be created,
+--    though they are two different templates with two different provider ids.
+--    merchant_id still leads, as every unique index on a crm_ table must.
+--
+-- 2. provider_template_id gets a partial unique index ALONE — the same
+--    exception crm_message_provider_id_uq earns. That law protects OUR
+--    identifiers, which are unique only inside a tenant; this is the
+--    PROVIDER's, globally unique by construction, and webhooks arrive naming
+--    it and nothing else. Partial because a draft has no provider id yet.
+--
+-- 3. No CHECK on status, category, quality or channel. All four are provider
+--    vocabulary, and the 027 scar says vocabulary lives in code: Meta has
+--    renamed categories before and will add statuses we have not seen. The
+--    lowercase dictionary (draft · submitting · pending · approved · rejected ·
+--    paused · deleted) is enforced by the one place that writes it — the
+--    provider face normalises there, so an unknown word arrives lowercased
+--    rather than rejected.
+--
+--    'submitting' is ours, not canon's: it is the exclusive claim a submit
+--    holds while the provider call is in flight, so two callers cannot both
+--    register one template. Vocabulary lives in code, so adding it costs
+--    nothing here.
+--
+-- 4. category and submitted_category are two columns on purpose. Providers
+--    re-categorise templates on their own, and MARKETING becoming UTILITY
+--    changes what the merchant is billed. One column would overwrite the
+--    evidence that it ever happened; two make the difference visible, which
+--    is the whole reason canon T23 keeps both.
+--
+-- 5. Editing an approved template puts the SAME row back to pending — Meta
+--    re-reviews in place. History lives as template.status events in the
+--    spine, replayable, not as extra rows here.
+--
+-- 6. Every timestamp column is a stamp, not a derived value: status_updated_at
+--    is also the out-of-order guard for webhooks (a provider promises no
+--    ordering, and a status LADDER would be wrong here — see choice 5, where
+--    approved -> pending is a legitimate move backwards, so time is the only
+--    honest ordering key).
+--
+-- 7. last_synced_at ships with NO WRITER, and that is canon's own position:
+--    freshness comes from webhooks, one write per actual change, and there is
+--    deliberately no timer walking every merchant's templates on a clock. The
+--    column exists for a future explicit "import this account's existing
+--    templates" action, which is a human pressing a button, never a schedule.
+--    Every other column is written by either the lifecycle routes or the
+--    webhook consumer.
+
+CREATE TABLE crm_channel_template (
+    id                   uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    merchant_id          text NOT NULL,
+    -- whatsapp, sms, email… validated against the CONNECTORS registry in
+    -- code at create time, never by this table (see 3).
+    channel              text NOT NULL,
+    -- The provider account that owns this template — a WABA id today. Plain
+    -- text rather than an FK to crm_connector_installation: the template is
+    -- namespaced by the PROVIDER's account, which outlives any particular
+    -- installation row (re-onboarding writes a new row for the same WABA).
+    provider_account_ref text NOT NULL,
+    -- What crm_message.template_id stores.
+    name                 text NOT NULL,
+    language             text NOT NULL,
+    -- NULL until the provider accepts a submission (see 2).
+    provider_template_id text,
+    -- THEIRS (see 4).
+    category             text,
+    -- OURS: what we asked for.
+    submitted_category   text,
+    category_updated_at  timestamptz,
+    -- The provider's registered structure, verbatim. Never validated against
+    -- their schema here: a second validator refuses shapes they accept.
+    components           jsonb NOT NULL,
+    status               text NOT NULL DEFAULT 'draft',
+    status_updated_at    timestamptz NOT NULL DEFAULT now(),
+    -- The provider's own words, kept unparaphrased — it is what the merchant
+    -- has to act on to get an approval.
+    rejection_reason     text,
+    quality              text NOT NULL DEFAULT 'UNKNOWN',
+    quality_updated_at   timestamptz,
+    -- See 7: no writer today.
+    last_synced_at       timestamptz,
+    created_at           timestamptz NOT NULL DEFAULT now(),
+    updated_at           timestamptz NOT NULL DEFAULT now()
+);
+
+-- The natural key (see 1).
+CREATE UNIQUE INDEX crm_channel_template_natural_uq
+    ON crm_channel_template (merchant_id, channel, provider_account_ref, name,
+                             language);
+
+-- The provider-id exception (see 2). Webhooks arrive naming this and nothing
+-- else, so it has to be findable without a tenant.
+CREATE UNIQUE INDEX crm_channel_template_provider_id_uq
+    ON crm_channel_template (provider_template_id)
+    WHERE provider_template_id IS NOT NULL;
+
+-- The console's list is (merchant, channel, status); the send-time lookup is
+-- (merchant, channel, account, name) and is served by the natural-key index's
+-- prefix, so it needs nothing of its own.
+CREATE INDEX crm_channel_template_merchant_status_ix
+    ON crm_channel_template (merchant_id, channel, status);
+
+CREATE TRIGGER crm_channel_template_touch
+    BEFORE UPDATE ON crm_channel_template
+    FOR EACH ROW EXECUTE FUNCTION crm_touch_updated_at();

--- a/docs/crm/building-modules.md
+++ b/docs/crm/building-modules.md
@@ -8,7 +8,7 @@ corpus wins. Migration conventions: [migrations.md](./migrations.md).
 
 ## The module skeleton (sealed — every `app/crm/<module>/` looks like this)
 
-```
+```text
 app/crm/<module>/
   __init__.py    # empty — exports NOTHING
   contracts.py   # THE public surface — re-exports from the logic files;
@@ -32,12 +32,12 @@ app/crm/<module>/
 form connectivity carries today, and the one a module takes on its next `db/`
 touch once one file would hold four tables or cross the ~500-line line:
 
-```
+```text
   db/
     __init__.py                  the door, unchanged
-    queries/    installation.py · binding.py · message.py
-    accessors/  installation.py · binding.py · message.py
-    decoders/   installation.py · binding.py · message.py
+    queries/    installation.py · binding.py · template.py · message.py
+    accessors/  installation.py · binding.py · template.py · message.py
+    decoders/   installation.py · binding.py · template.py · message.py
 ```
 
 Shared column lists move with their table. Import the table you mean by its

--- a/scripts/check_crm_boundaries.py
+++ b/scripts/check_crm_boundaries.py
@@ -65,6 +65,7 @@ TABLE_OWNERS = {
     "crm_workflow_enrollment": "outreach",
     "crm_connector_installation": "connectivity",
     "crm_channel_binding": "connectivity",
+    "crm_channel_template": "connectivity",
 }
 
 # ---- rule 11's map: one composition root per provider face ----------------

--- a/tests/crm/test_connectivity_adapters.py
+++ b/tests/crm/test_connectivity_adapters.py
@@ -12,7 +12,11 @@ from pathlib import Path
 
 import pytest
 
-from app.crm.connectivity import send as send_module
+from app.crm.connectivity import (
+    accounts as accounts_module,
+    send as send_module,
+    templates as templates_module,
+)
 from app.crm.connectivity.db.queries.binding import (
     binding_by_id_query,
     primary_binding_query,
@@ -21,6 +25,7 @@ from app.crm.connectivity.providers import ADAPTERS, adapter_for
 from app.crm.connectivity.providers.base import ChannelAdapter
 from app.crm.connectivity.providers.whatsapp.adapter import MetaWhatsAppAdapter
 from app.crm.connectivity.schemas import (
+    ApprovedTemplate,
     ChannelBinding,
     ConnectorInstallation,
     CredentialBundle,
@@ -159,7 +164,7 @@ def _patch_credential(monkeypatch, credential) -> None:
         assert raise_errors is True
         return credential
 
-    monkeypatch.setattr(send_module, "get_credential_by_id", _get)
+    monkeypatch.setattr(accounts_module, "get_credential_by_id", _get)
 
 
 def _route(**overrides) -> SendRoute:
@@ -173,20 +178,26 @@ def _route(**overrides) -> SendRoute:
     return SendRoute(**fields)
 
 
+#: What the registry answers for an approved template, unless a test seeds
+#: something else. One row = one language = sendable.
+_APPROVED = [ApprovedTemplate(id="t-1", language="en_US")]
+
+
 class _FakeAccessor:
-    """Stands in for the db/accessors modules send.py reads, so the door is
+    """Stands in for every db/accessors module send.py reads, so the door is
     testable without a database — which is the whole reason routes are
     resolved in one place.
 
-    One double for both modules on purpose: the point under test is the
+    One double for three modules on purpose: the point under test is the
     ORDER of the resolver's reads and what it refuses on, and splitting it
-    would only make each test say which of them to seed.
+    into three doubles would only make each test say which of them to seed.
     """
 
-    def __init__(self, binding=None, installation=None):
+    def __init__(self, binding=None, installation=None, approved=None):
         """Test double."""
         self._binding = binding
         self._installation = installation
+        self._approved = _APPROVED if approved is None else approved
         self.writes: list = []
 
     async def get_binding(self, merchant_id, channel, binding_id):
@@ -196,6 +207,12 @@ class _FakeAccessor:
     async def get_installation(self, merchant_id, installation_id):
         """Test double: the seeded installation."""
         return self._installation
+
+    async def approved_templates_for_send(
+        self, merchant_id, channel, provider_account_ref, name
+    ):
+        """Test double: the seeded registry answer for this template name."""
+        return self._approved
 
     def __getattr__(self, name):
         """Anything beyond the reads above is recorded, not raised.
@@ -215,9 +232,15 @@ class _FakeAccessor:
 
 
 def _patch_accessors(monkeypatch, fake) -> None:
-    """Point send.py's accessor modules at one double."""
+    """Point every accessor the send path reaches at one double.
+
+    The registry read moved to templates.py (it owns crm_channel_template's
+    reads), so the double is installed there rather than on send.py — the
+    resolver's behaviour under test is unchanged either way.
+    """
     for name in ("binding_accessor", "installation_accessor"):
         monkeypatch.setattr(send_module, name, fake)
+    monkeypatch.setattr(templates_module, "template_accessor", fake)
 
 
 @pytest.fixture
@@ -406,7 +429,7 @@ async def test_a_vault_outage_retries_instead_of_blocking(monkeypatch) -> None:
         """Test double: the pool dies mid-read."""
         raise ConnectionError("pool exhausted")
 
-    monkeypatch.setattr(send_module, "get_credential_by_id", _outage)
+    monkeypatch.setattr(accounts_module, "get_credential_by_id", _outage)
     message = _message()
     outcome = await send(_token(message), message)
     assert outcome.status == "failed"
@@ -441,10 +464,13 @@ async def test_a_connecting_installation_refuses(happy_accessor) -> None:
 
 async def test_a_resolved_route_carries_the_whole_context(happy_accessor) -> None:
     """A resolved route carries the whole context."""
-    route = await resolve_send_route("shop", "whatsapp", None)
+    route = await resolve_send_route("shop", "whatsapp", None, "order_update_v1")
     assert isinstance(route, SendRoute)
     assert route.binding.address == "1234567890"
     assert route.bundle.secret("system_user_token") == "tok"
+    # And the language the registry approved, which is the whole reason the
+    # adapter no longer reads it off the binding.
+    assert route.template_language == "en_US"
 
 
 def test_both_binding_lookups_are_pinned_to_their_channel() -> None:
@@ -639,9 +665,27 @@ def test_the_vault_is_read_through_its_own_accessor() -> None:
     for builder in Path("app/crm/connectivity/db/queries").glob("*.py"):
         assert not vault_in_sql.search(builder.read_text()), builder
     assert (
-        send_module.get_credential_by_id.__module__
+        accounts_module.get_credential_by_id.__module__
         == "app.database.accessor.breeze_buddy.credentials"
     )
+
+
+def test_one_home_for_the_account_policy() -> None:
+    """The usable-states set and the vault sequence live in accounts.py only.
+
+    Two definitions of one policy is a policy that changes in one place and
+    not the other — the day a degraded door may register templates but not
+    send, the miss would be silent. Same reason the registry read belongs to
+    templates.py: send.py owning a second read on crm_channel_template would
+    be a second answer to "is this approved".
+    """
+    send_src = Path("app/crm/connectivity/send.py").read_text()
+    templates_src = Path("app/crm/connectivity/templates.py").read_text()
+    for src in (send_src, templates_src):
+        assert "get_credential_by_id" not in src
+        assert '!= "healthy"' not in src and 'frozenset({"healthy"})' not in src
+    assert "template_accessor" not in send_src
+    assert accounts_module.USABLE_INSTALLATION_STATES == frozenset({"healthy"})
 
 
 def test_both_tables_are_created_together() -> None:
@@ -760,3 +804,132 @@ def test_a_binding_cannot_hang_off_another_tenants_installation() -> None:
     sql = _table_ddl("crm_channel_binding")
     assert "FOREIGN KEY (merchant_id, installation_id)" in sql
     assert "REFERENCES crm_connector_installation (merchant_id, id)" in sql
+
+
+# --- the T23 send-time template lookup (ADR 0011) ---------------------------
+#
+# A non-approved template must be refused BEFORE the provider call. Without
+# this, a pending or rejected name goes to Meta and fails there — the wrong
+# side of the wire, where it costs an attempt, a rate-limit budget and a
+# support ticket instead of a manifest row with an honest reason.
+
+
+class _CountingAdapter(ChannelAdapter):
+    """Records whether the send path ever reached a provider."""
+
+    channel = "whatsapp"
+
+    def __init__(self):
+        """Test double."""
+        self.calls = 0
+
+    async def deliver(self, message, route):
+        """Test double: count the call that should never happen."""
+        self.calls += 1
+        return SendOutcome(status="accepted", provider_message_id="wamid.1")
+
+
+@pytest.fixture
+def counting_adapter(monkeypatch) -> _CountingAdapter:
+    """Test double."""
+    adapter = _CountingAdapter()
+    monkeypatch.setattr(send_module, "adapter_for", lambda channel: adapter)
+    return adapter
+
+
+async def test_an_approved_template_passes_to_the_adapter(
+    monkeypatch, happy_accessor, counting_adapter
+) -> None:
+    """One approved row, so exactly one language — the send may proceed."""
+    message = _message()
+    outcome = await send(_token(message), message)
+    assert outcome.status == "accepted"
+    assert counting_adapter.calls == 1
+
+
+@pytest.mark.parametrize(
+    "approved,why",
+    [
+        ([], "never registered, pending, rejected or deleted"),
+        (
+            [
+                ApprovedTemplate(id="t-1", language="en_US"),
+                ApprovedTemplate(id="t-2", language="hi_IN"),
+            ],
+            "approved in more than one language",
+        ),
+    ],
+)
+async def test_a_template_that_is_not_one_approved_row_is_refused(
+    monkeypatch, counting_adapter, approved, why
+) -> None:
+    """Zero rows and many rows are one fact from the sender's side.
+
+    The ambiguous case earns the same refusal rather than a default: a
+    manifest row carries the template NAME and no language, so picking one
+    locale would be guessing which language a customer reads — and the wrong
+    guess sends an unreadable message under a merchant's name.
+    """
+    _patch_accessors(
+        monkeypatch,
+        _FakeAccessor(
+            binding=_binding(), installation=_installation(), approved=approved
+        ),
+    )
+    _patch_credential(monkeypatch, _credential())
+    message = _message()
+    outcome = await send(_token(message), message)
+    assert outcome.status == "blocked", why
+    assert outcome.reason == "template_not_approved"
+    assert outcome.retryable is False
+    # The provider never saw it, which is the whole point.
+    assert counting_adapter.calls == 0
+
+
+async def test_a_message_naming_no_template_never_reaches_a_provider(
+    monkeypatch, happy_accessor, counting_adapter
+) -> None:
+    """Refused in the resolver rather than in the adapter, so the reason is
+    the same for every channel instead of one per adapter."""
+    message = _message(template_id=None)
+    outcome = await send(_token(message), message)
+    assert outcome.status == "blocked"
+    assert outcome.reason == "template_missing"
+    assert counting_adapter.calls == 0
+
+
+async def test_the_route_carries_the_registrys_language_not_the_bindings(
+    monkeypatch,
+) -> None:
+    """Which locale a template was APPROVED in is a fact about the template.
+
+    The binding's capabilities blob used to answer this, and could disagree
+    with what the provider actually approved — the interim the manifest
+    adapter's own docstring named.
+    """
+    _patch_accessors(
+        monkeypatch,
+        _FakeAccessor(
+            binding=_binding(capabilities={"template_language": "de_DE"}),
+            installation=_installation(),
+            approved=[ApprovedTemplate(id="t-1", language="hi_IN")],
+        ),
+    )
+    _patch_credential(monkeypatch, _credential())
+    route = await resolve_send_route("shop", "whatsapp", None, "order_update_v1")
+    assert isinstance(route, SendRoute)
+    assert route.template_language == "hi_IN"
+
+
+def test_the_lookup_is_scoped_to_the_merchants_own_account() -> None:
+    """The registry's natural key includes the provider account, so one
+    merchant's approved template can never be resolved for another's."""
+    from app.crm.connectivity.db.queries.template import (
+        approved_template_for_send_query,
+    )
+
+    sql, values = approved_template_for_send_query("shop", "whatsapp", "waba-1", "n")
+    assert "merchant_id = $1" in sql
+    assert "provider_account_ref = $3" in sql
+    assert "status = 'approved'" in sql
+    assert values == ["shop", "whatsapp", "waba-1", "n"]

--- a/tests/crm/test_connectors_onboarding.py
+++ b/tests/crm/test_connectors_onboarding.py
@@ -13,12 +13,16 @@ import httpx
 import pytest
 from pydantic import ValidationError
 
-from app.crm.connectivity import onboarding as onboarding_module
+from app.crm.connectivity import (
+    accounts as accounts_module,
+    onboarding as onboarding_module,
+)
 from app.crm.connectivity.channels import CHANNELS
 from app.crm.connectivity.connectors import (
     CONNECTORS,
     ConnectorSpec,
     connector_for,
+    connector_for_channel,
     sending_connectors,
 )
 from app.crm.connectivity.db import UniqueViolation
@@ -31,6 +35,7 @@ from app.crm.connectivity.onboarding import (
 from app.crm.connectivity.providers import ADAPTERS
 from app.crm.connectivity.providers.meta import graph as graph_module
 from app.crm.connectivity.providers.whatsapp.onboard import (
+    OnboardWhatsappRequest,
     WhatsappOnboarder,
     WhatsappOnboardingError,
 )
@@ -39,7 +44,6 @@ from app.crm.connectivity.schemas import (
     ConnectorInstallation,
     InstallationRead,
     OnboardResult,
-    OnboardWhatsappRequest,
 )
 
 # --- the registry -----------------------------------------------------------
@@ -61,12 +65,21 @@ def test_every_connector_channel_has_an_adapter() -> None:
     assert {s.channel for s in sending_connectors().values()} <= set(ADAPTERS)
 
 
+def test_every_spec_knows_the_key_it_is_filed_under() -> None:
+    """The spec carries its own key so one lookup answers both "which
+    provider" and "what is it called" — an installation row is keyed by
+    connector_key, and without this the caller scans the registry a second
+    time to re-derive what it just found."""
+    assert all(key == spec.key for key, spec in CONNECTORS.items())
+
+
 def test_the_registry_is_the_vocabulary() -> None:
     """An unknown key resolves to nothing — the dict IS the list of
     connectors, so asking for one that is not in it is asking for something
     that does not exist."""
     assert connector_for("whatsapp") is not None
     assert connector_for("telegram") is None
+    assert connector_for_channel("whatsapp") is not None
 
 
 async def test_an_unknown_connector_is_refused_by_name() -> None:
@@ -362,13 +375,27 @@ class _Credential:
 
 
 def _patch_onboarding(
-    monkeypatch, *, result=None, installations=None, bindings=None, onboarder=None
+    monkeypatch,
+    *,
+    result=None,
+    installations=None,
+    bindings=None,
+    onboarder=None,
+    channel="whatsapp",
 ):
-    """Wire onboarding.py to doubles: merchant, vault, accessors, atom."""
+    """Wire onboarding.py to doubles: merchant, vault, accessors, atom.
+
+    The ONE place a ConnectorSpec is built. A test that needs a different
+    onboarder passes one in rather than assembling its own spec — otherwise
+    every field the registry grows has to be added to every test body, and
+    the type checker is the only thing that notices when it isn't.
+    """
     onboarder = onboarder or _StubOnboarder(result or _result())
     spec = ConnectorSpec(
-        channel="whatsapp",
+        key="whatsapp",
+        channel=channel,
         onboarder=onboarder,
+        templates=CONNECTORS["whatsapp"].templates,
         request_model=OnboardWhatsappRequest,
     )
     monkeypatch.setattr(onboarding_module, "connector_for", lambda key: spec)
@@ -580,7 +607,7 @@ async def test_disconnect_tells_the_provider_before_it_touches_the_rows(
         """Test double: the vault read behind the revoke."""
         return _Credential()
 
-    monkeypatch.setattr(onboarding_module, "get_credential_by_id", _credential)
+    monkeypatch.setattr(accounts_module, "get_credential_by_id", _credential)
 
     result = await disconnect("shop", "i-1")
     assert result is not None and result.status == "revoked"
@@ -614,16 +641,7 @@ async def test_a_providers_own_refusal_reaches_the_merchant(monkeypatch) -> None
                 "phone number PN9 is not on this WhatsApp Business Account"
             )
 
-    _patch_onboarding(monkeypatch)
-    monkeypatch.setattr(
-        onboarding_module,
-        "connector_for",
-        lambda key: ConnectorSpec(
-            channel="whatsapp",
-            onboarder=_Refuses(_result()),
-            request_model=OnboardWhatsappRequest,
-        ),
-    )
+    _patch_onboarding(monkeypatch, onboarder=_Refuses(_result()))
     with pytest.raises(OnboardingError, match="not on this WhatsApp Business Account"):
         await onboard("shop", "whatsapp", _request().model_dump())
 
@@ -640,16 +658,7 @@ async def test_an_unexpected_exception_does_not_reach_the_caller(
             """Test double: a bug, not a refusal."""
             raise KeyError("internal_pool_handle_7f3a")
 
-    _patch_onboarding(monkeypatch)
-    monkeypatch.setattr(
-        onboarding_module,
-        "connector_for",
-        lambda key: ConnectorSpec(
-            channel="whatsapp",
-            onboarder=_Explodes(_result()),
-            request_model=OnboardWhatsappRequest,
-        ),
-    )
+    _patch_onboarding(monkeypatch, onboarder=_Explodes(_result()))
     with pytest.raises(OnboardingError) as caught:
         await onboard("shop", "whatsapp", _request().model_dump())
     assert "internal_pool_handle_7f3a" not in str(caught.value)
@@ -775,13 +784,7 @@ async def test_a_door_with_no_channel_onboards_without_a_binding(
     with no pipe. A Shopify OAuth install is a COMPLETE onboarding with
     nothing to bind, so the atom must not try."""
     bindings = _FakeBindingAccessor()
-    _patch_onboarding(monkeypatch, bindings=bindings)
-    spec = ConnectorSpec(
-        channel=None,
-        onboarder=_StubOnboarder(_result()),
-        request_model=OnboardWhatsappRequest,
-    )
-    monkeypatch.setattr(onboarding_module, "connector_for", lambda key: spec)
+    _patch_onboarding(monkeypatch, bindings=bindings, channel=None)
     installation = await onboard("shop", "shopify", _request().model_dump())
     assert installation is not None
     assert bindings.upserts == [], "a door with no channel writes no pipe"

--- a/tests/crm/test_templates.py
+++ b/tests/crm/test_templates.py
@@ -1,0 +1,670 @@
+"""The template registry's lifecycle, and the provider face under it.
+
+Every test here pins a transition, because transitions are where this
+registry has been wrong: a rejected template that could neither be
+resubmitted nor edited, a claim that was never released, a provider's
+UPPERCASE status stored beside our lowercase rules, and a delete that took
+every language variant with it.
+"""
+
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import httpx
+import pytest
+
+from app.crm.connectivity import (
+    accounts as accounts_module,
+    templates as templates_module,
+)
+from app.crm.connectivity.providers.meta import graph as graph_module
+from app.crm.connectivity.providers.whatsapp.templates import (
+    WhatsappTemplateError,
+    WhatsappTemplates,
+    _from_meta,
+)
+from app.crm.connectivity.schemas import (
+    ConnectorInstallation,
+    CredentialBundle,
+    TemplateDraft,
+    TemplateRead,
+)
+from app.crm.connectivity.templates import (
+    TemplateError,
+    TemplateNotFoundError,
+    create_draft,
+    edit,
+    retire,
+    submit,
+)
+from scripts.check_crm_boundaries import TABLE_OWNERS
+
+# --- the provider face ------------------------------------------------------
+
+
+def test_meta_shouting_becomes_the_canon_dictionary() -> None:
+    """Meta answers APPROVED; every rule in templates.py compares 'approved'.
+
+    Storing their casing verbatim once meant a registry holding 'APPROVED',
+    'PENDING', 'submitting' and 'deleted' side by side, ?status=approved
+    returning nothing for an approved template, and edits refused with "is
+    'APPROVED' — edit not supported from this status".
+    """
+    assert _from_meta("APPROVED") == "approved"
+    assert _from_meta("PENDING_DELETION") == "pending_deletion"
+    assert _from_meta(None) is None
+    assert _from_meta("  ") is None
+
+
+def _graph(monkeypatch, handler) -> List[httpx.Request]:
+    """Point the shared Graph transport at a canned responder."""
+    seen: List[httpx.Request] = []
+
+    def _capture(request: httpx.Request) -> httpx.Response:
+        """Record the outgoing request, then delegate to the handler."""
+        seen.append(request)
+        return handler(request)
+
+    monkeypatch.setattr(
+        graph_module,
+        "create_http_client",
+        lambda **_: httpx.AsyncClient(transport=httpx.MockTransport(_capture)),
+    )
+    return seen
+
+
+def _bundle() -> CredentialBundle:
+    return CredentialBundle(values={"system_user_token": "tok"})
+
+
+async def test_a_submitted_template_keeps_metas_own_verdict(monkeypatch) -> None:
+    """Their id, their category, their status — normalised, not reinterpreted.
+
+    The category especially: a provider may assign a different one from the
+    one requested, and theirs is what the merchant is billed at.
+    """
+    _graph(
+        monkeypatch,
+        lambda _r: httpx.Response(
+            200, json={"id": "T-1", "status": "PENDING", "category": "UTILITY"}
+        ),
+    )
+    state = await WhatsappTemplates().submit(
+        _bundle(),
+        "waba-1",
+        TemplateDraft(
+            name="order_update", language="en_US", category="MARKETING", components=[]
+        ),
+    )
+    assert state.provider_template_id == "T-1"
+    assert state.status == "pending"
+    assert state.category == "UTILITY"
+
+
+async def test_a_submission_without_an_id_is_a_failure(monkeypatch) -> None:
+    """Without the provider's id no webhook can ever be matched to this row,
+    so a 200 that omits it is not a success."""
+    _graph(monkeypatch, lambda _r: httpx.Response(200, json={"status": "PENDING"}))
+    with pytest.raises(Exception):
+        await WhatsappTemplates().submit(
+            _bundle(),
+            "waba-1",
+            TemplateDraft(
+                name="n", language="en_US", category="UTILITY", components=[]
+            ),
+        )
+
+
+async def test_retiring_one_language_carries_the_provider_id(monkeypatch) -> None:
+    """Meta's delete takes a NAME, and a name alone deletes every language
+    variant of it. Retiring order_update/en_US would silently delete
+    order_update/hi_IN on Meta while our hi_IN row still read 'approved' —
+    and the first send on it would fail at Meta with 132001."""
+    seen = _graph(monkeypatch, lambda _r: httpx.Response(200, json={"success": True}))
+    await WhatsappTemplates().retire(
+        _bundle(), "waba-1", "T-1", "order_update", "en_US"
+    )
+    url = str(seen[0].url)
+    assert "hsm_id=T-1" in url
+    assert "name=order_update" in url
+
+
+def test_a_status_webhook_normalises_into_the_registry() -> None:
+    face = WhatsappTemplates()
+    state = face.normalize_event(
+        "template.status",
+        {
+            "message_template_id": "T-1",
+            "message_template_name": "order_update",
+            "message_template_language": "en_US",
+            "event": "APPROVED",
+            "reason": "NONE",
+        },
+    )
+    assert state is not None
+    assert state.status == "approved"
+    # Meta sends the literal string "NONE" when there is no reason; storing
+    # it would show a merchant the word NONE as their rejection reason.
+    assert state.rejection_reason is None
+
+
+def test_a_rejection_keeps_the_providers_own_words() -> None:
+    state = WhatsappTemplates().normalize_event(
+        "template.status",
+        {
+            "message_template_id": "T-1",
+            "event": "REJECTED",
+            "reason": "INVALID_FORMAT",
+        },
+    )
+    assert state is not None and state.rejection_reason == "INVALID_FORMAT"
+
+
+def test_a_category_webhook_carries_the_new_category() -> None:
+    state = WhatsappTemplates().normalize_event(
+        "template.category",
+        {
+            "message_template_id": "T-1",
+            "previous_category": "MARKETING",
+            "new_category": "UTILITY",
+        },
+    )
+    assert state is not None and state.category == "UTILITY"
+
+
+def test_a_letter_with_nothing_to_apply_is_none() -> None:
+    assert WhatsappTemplates().normalize_event("template.status", {}) is None
+    assert WhatsappTemplates().normalize_event("something.else", {}) is None
+
+
+# --- the lifecycle ----------------------------------------------------------
+
+
+def _template(**overrides) -> TemplateRead:
+    fields = dict(
+        id="t-1",
+        merchant_id="shop",
+        channel="whatsapp",
+        provider_account_ref="waba-1",
+        name="order_update",
+        language="en_US",
+        components=[{"type": "BODY", "text": "hi"}],
+        status="draft",
+        status_updated_at=datetime.now(timezone.utc),
+        quality="UNKNOWN",
+        created_at=datetime.now(timezone.utc),
+        updated_at=datetime.now(timezone.utc),
+    )
+    fields.update(overrides)
+    return TemplateRead(**fields)
+
+
+class _FakeTemplateAccessor:
+    """Stands in for db/accessors/template."""
+
+    def __init__(self, template: Optional[TemplateRead] = None, claim=True):
+        """Test double."""
+        self.template = template
+        self.claim = claim
+        self.calls: List[str] = []
+        self.released = False
+
+    async def get_template(self, merchant_id, template_id):
+        """Test double: the seeded row."""
+        return self.template
+
+    async def get_template_by_natural_key(self, txn, *args):
+        """Test double: no existing row unless one was seeded."""
+        return self.template
+
+    async def insert_template_draft(self, txn, *args):
+        """Test double: record the insert."""
+        self.calls.append("insert")
+        return _template()
+
+    async def update_draft_components(self, txn, merchant_id, template_id, components):
+        """Test double: record the draft edit."""
+        self.calls.append("update_draft")
+        return _template(components=components)
+
+    async def claim_for_submit(self, txn, merchant_id, template_id):
+        """Test double: the exclusive claim, or nothing."""
+        self.calls.append("claim")
+        return _template(status="submitting") if self.claim else None
+
+    async def release_submit_claim(self, merchant_id, template_id):
+        """Test double: record that the claim was handed back."""
+        self.released = True
+        return _template(status="draft")
+
+    async def record_submission(self, txn, *args):
+        """Test double: record the provider's verdict."""
+        self.calls.append("record_submission")
+        return _template(status="pending", provider_template_id="T-1")
+
+    async def record_in_place_edit(
+        self, conn, merchant_id, template_id, comps, status, expected_status
+    ):
+        """Test double: the conditional write — records what it was
+        authorised against as well as what it sets."""
+        self.calls.append("record_in_place_edit")
+        self.edited_from = expected_status
+        return _template(status=status, components=comps)
+
+    async def retire_template(self, txn, merchant_id, template_id):
+        """Test double: record the retirement."""
+        self.calls.append("retire")
+        return _template(status="deleted")
+
+
+class _FakeInstallationAccessor:
+    """Stands in for db/accessors/installation."""
+
+    def __init__(self, installation=None):
+        """Test double."""
+        self.installation = installation
+
+    async def get_installation_by_account(self, merchant_id, key, account_ref):
+        """Test double: the seeded door for that provider account."""
+        return self.installation
+
+
+class _StubTemplates:
+    """A TemplateProvider with scripted behaviour."""
+
+    def __init__(self, edits_in_place=True, submit_error=None):
+        """Test double."""
+        self.edits_in_place = edits_in_place
+        self.submit_error = submit_error
+        self.retired: List[tuple] = []
+
+    async def submit(self, bundle, account_ref, draft):
+        """Test double: the provider's answer, or its refusal."""
+        if self.submit_error:
+            raise self.submit_error
+        from app.crm.connectivity.schemas import ProviderTemplateState
+
+        return ProviderTemplateState(
+            provider_template_id="T-1", status="pending", category=draft.category
+        )
+
+    async def edit(self, bundle, account_ref, provider_template_id, components):
+        """Test double: an in-place edit sends it back for review."""
+        from app.crm.connectivity.schemas import ProviderTemplateState
+
+        return ProviderTemplateState(
+            provider_template_id=provider_template_id, status="pending"
+        )
+
+    async def retire(self, bundle, account_ref, provider_template_id, name, language):
+        """Test double: record the withdrawal."""
+        self.retired.append((provider_template_id, name, language))
+
+
+class _Credential:
+    is_active = True
+    value = {"system_user_token": "tok"}
+
+
+def _healthy(**overrides) -> ConnectorInstallation:
+    fields = dict(
+        id="i-1",
+        merchant_id="shop",
+        connector_key="whatsapp",
+        external_account_id="waba-1",
+        credential_id="cred-1",
+        status="healthy",
+    )
+    fields.update(overrides)
+    return ConnectorInstallation(**fields)
+
+
+def _patch(monkeypatch, *, templates=None, installation=None, provider=None):
+    """Wire templates.py to doubles."""
+    accessor = templates or _FakeTemplateAccessor()
+    installations = _FakeInstallationAccessor(
+        _healthy() if installation is None else installation
+    )
+    face = provider or _StubTemplates()
+
+    class _Spec:
+        key = "whatsapp"
+        channel = "whatsapp"
+
+    spec = _Spec()
+    spec.templates = face  # type: ignore[attr-defined]
+
+    async def _atomically(fn, *args):
+        """Test double: run the atom body against a None handle."""
+        return await fn(None, *args)
+
+    async def _credential(credential_id, mask=True, raise_errors=False):
+        """Test double: the vault read."""
+        return _Credential()
+
+    monkeypatch.setattr(templates_module, "template_accessor", accessor)
+    monkeypatch.setattr(accounts_module, "installation_accessor", installations)
+    monkeypatch.setattr(templates_module, "atomically", _atomically)
+    monkeypatch.setattr(accounts_module, "get_credential_by_id", _credential)
+    monkeypatch.setattr(templates_module, "connector_for_channel", lambda c: spec)
+    return accessor, face
+
+
+async def test_a_draft_on_an_unregistered_channel_is_refused(monkeypatch) -> None:
+    """Fail closed at create. A draft nothing can ever submit is worse than a
+    refusal — it looks like progress."""
+    _patch(monkeypatch)
+    monkeypatch.setattr(templates_module, "connector_for_channel", lambda c: None)
+    with pytest.raises(TemplateError, match="no connector"):
+        await create_draft("shop", "telegram", "acct", "n", "en_US", [])
+
+
+async def test_a_draft_on_an_unconnected_account_is_refused(monkeypatch) -> None:
+    """A provider_account_ref naming no healthy connection has no credential
+    to submit with, so it is refused here rather than at submit."""
+    _patch(monkeypatch, installation=None)
+    monkeypatch.setattr(
+        accounts_module, "installation_accessor", _FakeInstallationAccessor(None)
+    )
+    with pytest.raises(TemplateError, match="no connected account"):
+        await create_draft("shop", "whatsapp", "waba-9", "n", "en_US", [])
+
+
+async def test_a_draft_on_a_degraded_connection_is_refused(monkeypatch) -> None:
+    _patch(monkeypatch, installation=_healthy(status="degraded"))
+    with pytest.raises(TemplateError, match="degraded"):
+        await create_draft("shop", "whatsapp", "waba-1", "n", "en_US", [])
+
+
+async def test_recreating_a_submitted_draft_does_not_overwrite_it(
+    monkeypatch,
+) -> None:
+    """Idempotency does not extend to replacing the components a provider is
+    currently reviewing."""
+    _patch(monkeypatch, templates=_FakeTemplateAccessor(_template(status="pending")))
+    with pytest.raises(TemplateError, match="already exists"):
+        await create_draft("shop", "whatsapp", "waba-1", "order_update", "en_US", [])
+
+
+async def test_a_rejected_template_cannot_be_resubmitted(monkeypatch) -> None:
+    """The provider still holds that name, so a re-create answers "name
+    already exists" — the refusal names the way out instead."""
+    _patch(monkeypatch, templates=_FakeTemplateAccessor(_template(status="rejected")))
+    with pytest.raises(TemplateError, match="edit it"):
+        await submit("shop", "t-1", "UTILITY")
+
+
+async def test_a_rejected_template_is_corrected_by_editing_it(monkeypatch) -> None:
+    """The edit IS the resubmission: same row, back to pending."""
+    accessor, _ = _patch(
+        monkeypatch,
+        templates=_FakeTemplateAccessor(
+            _template(status="rejected", provider_template_id="T-1")
+        ),
+    )
+    updated = await edit("shop", "t-1", [{"type": "BODY", "text": "fixed"}])
+    assert updated.status == "pending"
+    assert "record_in_place_edit" in accessor.calls
+
+
+async def test_an_approved_template_edited_goes_back_to_pending(monkeypatch) -> None:
+    """canon T23's one explicit transition rule."""
+    accessor, _ = _patch(
+        monkeypatch,
+        templates=_FakeTemplateAccessor(
+            _template(status="approved", provider_template_id="T-1")
+        ),
+    )
+    updated = await edit("shop", "t-1", [{"type": "BODY", "text": "new"}])
+    assert updated.status == "pending"
+
+
+async def test_a_provider_without_in_place_edits_says_so(monkeypatch) -> None:
+    """Meta's behaviour is not universal: SMS-DLT re-registers under a new
+    id. The refusal is honest rather than repeating Meta's rule."""
+    _patch(
+        monkeypatch,
+        templates=_FakeTemplateAccessor(
+            _template(status="approved", provider_template_id="T-1")
+        ),
+        provider=_StubTemplates(edits_in_place=False),
+    )
+    with pytest.raises(TemplateError, match="retire"):
+        await edit("shop", "t-1", [])
+
+
+async def test_a_refused_submission_gives_the_draft_back(monkeypatch) -> None:
+    """The claim is exclusive and 'submitting' is not re-claimable, so a
+    claim left standing after a failure is permanent: that template could
+    never be submitted or edited again."""
+    accessor, _ = _patch(
+        monkeypatch,
+        templates=_FakeTemplateAccessor(_template(status="draft")),
+        provider=_StubTemplates(submit_error=WhatsappTemplateError("bad components")),
+    )
+    with pytest.raises(TemplateError, match="bad components"):
+        await submit("shop", "t-1", "UTILITY")
+    assert accessor.released is True
+
+
+async def test_a_concurrent_submit_loses_the_claim(monkeypatch) -> None:
+    """Two requests that both read 'draft' must not both reach the provider:
+    it refuses the second by name, but only after we have fired it."""
+    _patch(
+        monkeypatch,
+        templates=_FakeTemplateAccessor(_template(status="draft"), claim=False),
+    )
+    with pytest.raises(TemplateError, match="already being submitted"):
+        await submit("shop", "t-1", "UTILITY")
+
+
+async def test_a_successful_submit_records_the_providers_verdict(
+    monkeypatch,
+) -> None:
+    accessor, _ = _patch(
+        monkeypatch, templates=_FakeTemplateAccessor(_template(status="draft"))
+    )
+    updated = await submit("shop", "t-1", "UTILITY")
+    assert updated.status == "pending"
+    assert updated.provider_template_id == "T-1"
+    assert accessor.calls == ["claim", "record_submission"]
+
+
+async def test_retiring_still_happens_when_the_provider_is_down(
+    monkeypatch,
+) -> None:
+    """Local retirement is what the send path reads, so it is the one that
+    has to happen — a provider outage must not leave a merchant unable to
+    stop using a template."""
+
+    class _Broken(_StubTemplates):
+        async def retire(
+            self, bundle, account_ref, provider_template_id, name, language
+        ):
+            """Test double: the provider is unreachable."""
+            raise RuntimeError("meta down")
+
+    accessor, _ = _patch(
+        monkeypatch,
+        templates=_FakeTemplateAccessor(
+            _template(status="approved", provider_template_id="T-1")
+        ),
+        provider=_Broken(),
+    )
+    updated = await retire("shop", "t-1")
+    assert updated.status == "deleted"
+
+
+async def test_an_unknown_template_is_a_not_found(monkeypatch) -> None:
+    """Its own exception type, so routes answer 404 rather than 400."""
+    _patch(monkeypatch, templates=_FakeTemplateAccessor(None))
+    with pytest.raises(TemplateNotFoundError):
+        await submit("shop", "t-999", "UTILITY")
+    with pytest.raises(TemplateNotFoundError):
+        await edit("shop", "t-999", [])
+    with pytest.raises(TemplateNotFoundError):
+        await retire("shop", "t-999")
+
+
+# --- the table itself -------------------------------------------------------
+
+TEMPLATE_MIGRATION = Path("app/database/migrations/061_create_crm_channel_template.sql")
+
+
+def _template_ddl() -> str:
+    """The migration with comment prose stripped: a structural assertion that
+    passes on the paragraph explaining a choice proves nothing."""
+    return "\n".join(
+        line
+        for line in TEMPLATE_MIGRATION.read_text().splitlines()
+        if not line.lstrip().startswith("--")
+    )
+
+
+def test_the_table_is_owned_by_connectivity() -> None:
+    assert TABLE_OWNERS["crm_channel_template"] == "connectivity"
+
+
+def _index_columns(index_name: str) -> str:
+    """The parenthesised column list of one index, and nothing else.
+
+    Sliced rather than matched on the whole statement, because the index NAME
+    contains the word 'channel' and would satisfy an assertion meant for the
+    columns.
+    """
+    ddl = _template_ddl()
+    body = ddl[ddl.index(index_name) :]
+    return body[body.index("(") + 1 : body.index(")")]
+
+
+def test_the_natural_key_includes_the_provider_account() -> None:
+    """canon T23 seals four columns; this index carries a fifth.
+
+    A merchant may hold two accounts on one channel, and the same
+    name+language registered in both are two different templates with two
+    different provider ids. Without the account in the key the second one
+    collides with the first and simply cannot be created.
+    """
+    columns = [
+        c.strip() for c in _index_columns("crm_channel_template_natural_uq").split(",")
+    ]
+    assert columns == [
+        "merchant_id",
+        "channel",
+        "provider_account_ref",
+        "name",
+        "language",
+    ]
+    # merchant_id leads, as every unique index on a crm_ table must.
+    assert columns[0] == "merchant_id"
+
+
+def test_the_provider_id_is_unique_alone_and_partial() -> None:
+    """The same exception crm_message_provider_id_uq earns: the tenancy law
+    protects OUR identifiers, and this one is the PROVIDER's — globally
+    unique, and the only thing a webhook names."""
+    assert _index_columns("crm_channel_template_provider_id_uq").strip() == (
+        "provider_template_id"
+    )
+    ddl = _template_ddl()
+    index = ddl[ddl.index("crm_channel_template_provider_id_uq") :]
+    assert "WHERE provider_template_id IS NOT NULL" in index[: index.index(";")]
+
+
+def test_no_check_constrains_provider_vocabulary() -> None:
+    """The 027 scar: a CHECK turns "support a new status" into a migration.
+    Providers rename categories and add statuses we have not seen."""
+    ddl = _template_ddl()
+    assert "CHECK" not in ddl.upper()
+
+
+def test_the_touch_trigger_is_present() -> None:
+    assert "crm_channel_template_touch" in _template_ddl()
+
+
+def test_a_malformed_components_blob_decodes_to_empty_rather_than_raising() -> None:
+    """The totality promise has to hold at the layer that needs objects.
+
+    jsonb_list makes the COLUMN total — a scalar or an object becomes []. But
+    TemplateRead types components as objects, so a stored `[1, 2]` would sail
+    through the helper and raise in pydantic one line later, stranding every
+    row decoded beside it in the same batch. The decoder filters, so the
+    guarantee survives the layer above it.
+    """
+    from app.crm.connectivity.db.decoders.template import decode_template
+
+    row = {
+        "id": "t-1",
+        "merchant_id": "shop",
+        "channel": "whatsapp",
+        "provider_account_ref": "waba-1",
+        "name": "n",
+        "language": "en_US",
+        "provider_template_id": None,
+        "category": None,
+        "submitted_category": None,
+        "category_updated_at": None,
+        "components": '[1, 2, {"type": "BODY"}]',
+        "status": "draft",
+        "status_updated_at": datetime.now(timezone.utc),
+        "rejection_reason": None,
+        "quality": "UNKNOWN",
+        "quality_updated_at": None,
+        "last_synced_at": None,
+        "created_at": datetime.now(timezone.utc),
+        "updated_at": datetime.now(timezone.utc),
+    }
+    decoded = decode_template(row)
+    assert decoded.components == [{"type": "BODY"}], "non-objects must be dropped"
+
+
+async def test_a_bug_in_the_face_does_not_reach_the_caller(monkeypatch) -> None:
+    """A declared refusal is the merchant's own template being described, so
+    it passes through. Anything else is a bug, and a bug's text is an
+    internal detail — a KeyError('provider_row_id') must not become a 400
+    whose body reads 'provider_row_id'. Same split onboarding makes with
+    ConnectorHandshakeError."""
+    accessor, _ = _patch(
+        monkeypatch,
+        templates=_FakeTemplateAccessor(_template(status="draft")),
+        provider=_StubTemplates(submit_error=KeyError("provider_row_id")),
+    )
+    with pytest.raises(TemplateError) as caught:
+        await submit("shop", "t-1", "UTILITY")
+    assert "provider_row_id" not in str(caught.value)
+    assert str(caught.value) == "could not complete the template operation"
+    # and the claim is still released, so the draft is retryable
+    assert accessor.released is True
+
+
+async def test_an_edit_refuses_when_the_row_moved_underneath_it(
+    monkeypatch,
+) -> None:
+    """The provider call happens outside any transaction, so a concurrent
+    retire() can land between the pre-read and the write. Without the CAS
+    this update would put fresh components and 'pending' over a row the
+    merchant just deleted — resurrecting a withdrawn template."""
+
+    accessor = _FakeTemplateAccessor(
+        _template(status="approved", provider_template_id="T-1")
+    )
+
+    async def _row_moved(*args, **kwargs):
+        """Test double: the CAS matched nothing — something else moved the
+        row while the provider call was in flight."""
+        return None
+
+    accessor.record_in_place_edit = _row_moved  # type: ignore[method-assign]
+    _patch(monkeypatch, templates=accessor)
+    with pytest.raises(TemplateError, match="changed while it was being edited"):
+        await edit("shop", "t-1", [{"type": "BODY", "text": "new"}])
+
+
+def test_the_in_place_edit_is_conditional_on_the_status_it_read() -> None:
+    """The guard lives in SQL, where two callers cannot interleave around it."""
+    from app.crm.connectivity.db.queries.template import record_in_place_edit_query
+
+    sql, values = record_in_place_edit_query("shop", "t-1", "[]", "pending", "approved")
+    assert "AND status = $5" in sql
+    assert values[-1] == "approved"

--- a/tests/crm/test_whatsapp_adapter.py
+++ b/tests/crm/test_whatsapp_adapter.py
@@ -93,8 +93,17 @@ def _installation(**overrides) -> ConnectorInstallation:
 
 
 def _route(**overrides) -> SendRoute:
-    """Everything send() resolves, handed to the adapter as one object."""
-    fields = dict(installation=_installation(), binding=_binding(), bundle=_bundle())
+    """Everything send() resolves, handed to the adapter as one object.
+
+    template_language defaults to what the registry would have supplied for
+    an approved template — the adapter never reads it from the binding.
+    """
+    fields = dict(
+        installation=_installation(),
+        binding=_binding(),
+        bundle=_bundle(),
+        template_language="en_US",
+    )
     fields.update(overrides)
     return SendRoute(**fields)
 
@@ -296,22 +305,30 @@ async def test_a_null_variable_is_blocked_before_posting(monkeypatch) -> None:
     assert seen == {}
 
 
-def test_the_language_comes_from_the_binding_for_now() -> None:
-    """INTERIM: which locale a template was APPROVED in is a fact about the
-    TEMPLATE, and the binding's capabilities blob can disagree with what Meta
-    actually approved. The template registry (T23) is what will answer this;
-    until it lands the binding does, exactly as it did before."""
+def test_the_language_comes_from_the_template_registry() -> None:
+    """The language comes from the route, which took it from the registry."""
+    # Which locale a template was APPROVED in is a fact about the template,
+    # not about the endpoint — the binding's capabilities blob used to answer
+    # this, and could disagree with what Meta actually approved.
     adapter = MetaWhatsAppAdapter()
     parameters = build_parameters(_message().variables)
     assert isinstance(parameters, list)
     payload = adapter.build_payload(
-        _message(),
-        "919876543210",
-        _route(binding=_binding(capabilities={"template_language": "hi"})),
-        parameters,
+        _message(), "919876543210", _route(template_language="hi"), parameters
     )
     assert payload["template"]["language"]["code"] == "hi"
-    default = adapter.build_payload(_message(), "919876543210", _route(), parameters)
+
+
+def test_a_route_without_a_language_falls_back_rather_than_crashing() -> None:
+    """A route with no language still renders — the T23 lookup makes this
+    unreachable for WhatsApp, so it exists so a channel that does not
+    pre-register templates cannot take the worker down."""
+    adapter = MetaWhatsAppAdapter()
+    parameters = build_parameters(_message().variables)
+    assert isinstance(parameters, list)
+    default = adapter.build_payload(
+        _message(), "919876543210", _route(template_language=None), parameters
+    )
     assert default["template"]["language"]["code"] == "en_US"
 
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added WhatsApp Business onboarding through Meta Embedded Signup.
  - Added connector management, including installation listing, details, and disconnection.
  - Added message template management: drafts, submission, editing, retirement, filtering, and status updates.
  - Added Meta Graph API support for WhatsApp messaging and template operations.
- **Bug Fixes**
  - Messages now require an approved template before sending.
  - Improved handling of provider errors, throttling, invalid recipients, and malformed template variables.
  - Strengthened merchant-level access controls for connector routes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->