### PR TITLE
refactor(crm): channel-neutral send route — registry gate and address kind become CHANNELS facts

### DIFF
--- a/app/crm/connectivity/channels.py
+++ b/app/crm/connectivity/channels.py
@@ -1,9 +1,16 @@
 """What the platform knows about each channel, adapter-independent.
 
 One registry, one entry per channel the CRM can speak. The metadata here is
-everything OUTSIDE the send door that varies by channel — today only which
-handle kind the permission gate probes; W8's pacing and quality-tier
-defaults join as fields on Channel, not as new dicts scattered per file.
+everything OUTSIDE the send door that varies by channel — which handle kind
+the permission gate probes, and whether the channel pre-registers message
+templates; W8's pacing and quality-tier defaults join as fields on Channel,
+not as new dicts scattered per file.
+
+Every per-channel question generic code asks is answered HERE, and only
+here. The scar: queue.py once carried its own tuple of "phone channels" and
+send.py assumed every channel registers templates — two parallel answers to
+questions this registry already owned, each one a channel added in one place
+and forgotten in the other.
 
 Why this file and not providers/__init__: rule 11 confines providers/
 behind send.py, so anything dispatch (or later, pacing) needs per channel
@@ -26,12 +33,19 @@ class Channel:
     """One channel's adapter-independent metadata."""
 
     # The platform_identity handle kind the gate probes for suppression —
-    # a suppressed value on this kind of handle is what "STOP" wrote.
+    # a suppressed value on this kind of handle is what "STOP" wrote. It is
+    # also the address kind the manifest stores for this channel, which is why
+    # queue.py normalizes by it.
     gate_handle_kind: str
+    # Whether sends on this channel must name a template APPROVED in the T23
+    # registry (ADR 0011). WhatsApp and SMS-DLT do; email does not — for a
+    # channel that does not, the send door skips the registry and the route
+    # carries no template row.
+    registers_templates: bool
 
 
 CHANNELS: Dict[str, Channel] = {
-    "whatsapp": Channel(gate_handle_kind="phone"),
+    "whatsapp": Channel(gate_handle_kind="phone", registers_templates=True),
 }
 
 
@@ -44,3 +58,14 @@ def gate_handle_kind_for(channel: str) -> Optional[str]:
     """
     entry = CHANNELS.get(channel)
     return entry.gate_handle_kind if entry else None
+
+
+def registers_templates_for(channel: str) -> bool:
+    """Whether sends on ``channel`` must name an approved registry template.
+
+    An unregistered channel answers True: the send door then looks the
+    template up and refuses — fail CLOSED, the same posture the gate takes on
+    a channel this registry cannot describe.
+    """
+    entry = CHANNELS.get(channel)
+    return entry.registers_templates if entry else True

--- a/app/crm/connectivity/db/decoders/template.py
+++ b/app/crm/connectivity/db/decoders/template.py
@@ -40,9 +40,15 @@ def decode_template(row: Mapping[str, Any]) -> TemplateRead:
 
 
 def decode_approved_template(row: Mapping[str, Any]) -> ApprovedTemplate:
-    """The send path's narrow read: which locale this approved name is in.
+    """The send path's narrow read: the facts an adapter needs to send.
 
     Deliberately not TemplateRead — the send path runs per message and has no
     use for a components blob it will never render.
     """
-    return ApprovedTemplate(id=str(row["id"]), language=row["language"])
+    return ApprovedTemplate(
+        id=str(row["id"]),
+        name=row["name"],
+        language=row["language"],
+        provider_template_id=row["provider_template_id"],
+        category=row["category"],
+    )

--- a/app/crm/connectivity/db/queries/template.py
+++ b/app/crm/connectivity/db/queries/template.py
@@ -101,7 +101,7 @@ def approved_template_for_send_query(
     LIMIT 2 because the caller only needs to distinguish one from many.
     """
     query = f"""
-        SELECT id, language
+        SELECT id, name, language, provider_template_id, category
           FROM {TEMPLATE_TABLE}
          WHERE merchant_id = $1
            AND channel = $2

--- a/app/crm/connectivity/providers/whatsapp/adapter.py
+++ b/app/crm/connectivity/providers/whatsapp/adapter.py
@@ -42,10 +42,17 @@ from app.crm.connectivity.reasons import (
 from app.crm.connectivity.schemas import QueuedMessage, SendOutcome, SendRoute
 from app.crm.shared.redact import mask_address, mask_digit_runs
 
-# The Cloud API's own default, used only when the route resolved no language
-# — which the T23 lookup makes impossible for an approved template. It exists
-# so a future channel that does not pre-register templates cannot crash here.
+# The Cloud API's own default, used only when the route carries no registry
+# row — which the T23 lookup makes impossible on this channel, since WhatsApp
+# registers templates and the send door refuses before reaching here without
+# an approved one. Kept as the honest fallback rather than an assertion.
 DEFAULT_LANGUAGE = "en_US"
+
+
+def _language_of(route: SendRoute) -> str:
+    """The locale the registry approved this template in — WhatsApp's field
+    on the channel-neutral route."""
+    return route.template.language if route.template else DEFAULT_LANGUAGE
 
 
 class MetaWhatsAppAdapter(ChannelAdapter):
@@ -125,10 +132,7 @@ class MetaWhatsAppAdapter(ChannelAdapter):
             return SendOutcome(status="blocked", reason=REASON_BAD_VARIABLES)
 
         payload = build_send_body(
-            message.template_id,
-            route.template_language or DEFAULT_LANGUAGE,
-            recipient,
-            parameters,
+            message.template_id, _language_of(route), recipient, parameters
         )
         url = self.endpoint(route.binding.address)
 
@@ -160,10 +164,7 @@ class MetaWhatsAppAdapter(ChannelAdapter):
         which locale a merchant's template was actually approved in.
         """
         return build_send_body(
-            message.template_id or "",
-            route.template_language or DEFAULT_LANGUAGE,
-            recipient,
-            parameters,
+            message.template_id or "", _language_of(route), recipient, parameters
         )
 
     def read_response(

--- a/app/crm/connectivity/queue.py
+++ b/app/crm/connectivity/queue.py
@@ -12,14 +12,12 @@ producer as the owner of the validating dictionary.
 
 from typing import Any, Dict, Optional
 
+from app.crm.connectivity.channels import gate_handle_kind_for
 from app.crm.connectivity.db.accessors import message as message_accessor
 from app.crm.shared.normalize import normalize_email, normalize_phone
 
 # T16 col 7. What caused the send; every funnel groups on this.
 SOURCE_KINDS = ("broadcast", "workflow", "agent", "transactional")
-
-# Channels whose address is a phone number; everything else is an email.
-_PHONE_CHANNELS = ("whatsapp", "sms", "voice", "rcs")
 
 # Purpose roots the gate's caps are set per (design/gate-mechanics.md §3);
 # the full dotted list is permission's (canon T14 CK), not ours.
@@ -29,10 +27,20 @@ PURPOSE_ROOTS = ("marketing", "utility", "transactional", "authentication")
 def normalize_address(channel: str, address: str) -> Optional[str]:
     """PURE: the writer normalizes (E.164 / lowercased email). A format
     mismatch on a suppressed value is how someone who said stop gets
-    contacted, so an unparseable address is refused, never stored."""
-    if channel in _PHONE_CHANNELS:
+    contacted, so an unparseable address is refused, never stored.
+
+    Which normalizer applies is the CHANNELS registry's answer — the same
+    handle kind the gate probes — not a second list kept here. A channel the
+    registry does not know is refused outright: the gate would fail closed on
+    it at dispatch anyway, and a manifest row that can never send is not
+    worth writing.
+    """
+    kind = gate_handle_kind_for(channel)
+    if kind == "phone":
         return normalize_phone(address)
-    return normalize_email(address)
+    if kind == "email":
+        return normalize_email(address)
+    return None
 
 
 def validate_proposal(source_kind: str, purpose_key: str) -> None:

--- a/app/crm/connectivity/schemas.py
+++ b/app/crm/connectivity/schemas.py
@@ -123,11 +123,16 @@ class SendRoute(BaseModel):
     installation: ConnectorInstallation
     binding: ChannelBinding
     bundle: CredentialBundle
-    # The locale the template registry says this merchant's template was
-    # APPROVED in (T23). Optional only so a future channel that does not
-    # pre-register templates can leave it unset — for a channel that does,
-    # resolve_send_route refuses before the adapter rather than passing None.
-    template_language: Optional[str] = None
+    # The approved registry row (T23) this send renders — or None on a
+    # channel that does not pre-register templates (channels.py decides
+    # which do). Channel-neutral on purpose: the WhatsApp adapter reads its
+    # language, an SMS-DLT adapter will read its provider_template_id, an
+    # email adapter reads nothing. The route carries the ROW and each adapter
+    # takes the field it needs; a field named for one provider's need would
+    # be the first thing the second adapter has to work around. For a channel
+    # that registers, resolve_send_route refuses before the adapter rather
+    # than passing None.
+    template: Optional["ApprovedTemplate"] = None
 
 
 # ---------------------------------------------------------------------------
@@ -207,15 +212,21 @@ class TemplateDraft(BaseModel):
 
 class ApprovedTemplate(BaseModel):
     """The send path's answer from the registry: this name is approved, and
-    this is the locale it was approved in.
+    these are the facts about it an adapter may need to send.
 
-    Narrow on purpose. resolve_send_route runs once per message, and the row
-    it needs an answer from carries a components blob the send path will
-    never render — the provider does the rendering.
+    Narrow on purpose — resolve_send_route runs once per message, and the row
+    carries a components blob the send path never renders (the provider does)
+    — but not narrower than the CHANNELS it serves: language is what WhatsApp
+    renders by, provider_template_id is what an SMS-DLT header carries, and
+    category is what the gate will map a purpose against. One shape, every
+    adapter reads its own field.
     """
 
     id: str
+    name: str
     language: str
+    provider_template_id: Optional[str] = None
+    category: Optional[str] = None
 
 
 class ProviderTemplateState(BaseModel):
@@ -293,7 +304,13 @@ class CreateTemplateDraftRequest(BaseModel):
 
 class SubmitTemplateRequest(BaseModel):
     merchant_id: str = Field(..., description="Tenant scope — required")
-    category: str = Field(..., description="MARKETING · UTILITY · AUTHENTICATION")
+    category: str = Field(
+        ...,
+        description=(
+            "The provider's own category vocabulary, stored as theirs "
+            "(Meta: MARKETING · UTILITY · AUTHENTICATION)"
+        ),
+    )
 
 
 class EditTemplateRequest(BaseModel):
@@ -331,3 +348,8 @@ class TemplateRead(BaseModel):
     last_synced_at: Optional[datetime] = None
     created_at: datetime
     updated_at: datetime
+
+
+# SendRoute names ApprovedTemplate before it is defined; resolve the forward
+# reference now rather than on first validation.
+SendRoute.model_rebuild()

--- a/app/crm/connectivity/send.py
+++ b/app/crm/connectivity/send.py
@@ -32,6 +32,7 @@ from typing import Optional, Union
 from app.core.config.static import CRM_MESSAGE_SEND_TIMEOUT_SECONDS
 from app.core.logger import logger
 from app.crm.connectivity import accounts, templates
+from app.crm.connectivity.channels import registers_templates_for
 from app.crm.connectivity.db.accessors import (
     binding as binding_accessor,
     installation as installation_accessor,
@@ -126,17 +127,22 @@ async def resolve_send_route(
         )
         return REASON_INSTALLATION_UNHEALTHY
 
-    if not template_name:
-        # The adapter refuses this too, but refusing here keeps the reason on
-        # the near side of the wire for every channel, not just WhatsApp's.
-        return REASON_NO_TEMPLATE
-    # ADR 0011: a non-approved template is refused BEFORE the provider call.
+    # ADR 0011: on a channel that pre-registers templates, a non-approved
+    # template is refused BEFORE the provider call. Whether a channel does is
+    # the CHANNELS registry's answer, not an assumption made here — an email
+    # send names no registry row and must not be refused for lacking one.
     # The registry states the fact; the word for "no" is this door's.
-    language = await templates.approved_language(
-        merchant_id, channel, installation.external_account_id, template_name
-    )
-    if language is None:
-        return REASON_TEMPLATE_NOT_APPROVED
+    template = None
+    if registers_templates_for(channel):
+        if not template_name:
+            # The adapter refuses this too, but refusing here keeps the
+            # reason on the near side of the wire for every such channel.
+            return REASON_NO_TEMPLATE
+        template = await templates.approved_template(
+            merchant_id, channel, installation.external_account_id, template_name
+        )
+        if template is None:
+            return REASON_TEMPLATE_NOT_APPROVED
 
     try:
         # The vault read is a KMS decrypt, so it comes last: the cheapest
@@ -153,7 +159,7 @@ async def resolve_send_route(
         installation=installation,
         binding=binding,
         bundle=bundle,
-        template_language=language,
+        template=template,
     )
 
 

--- a/app/crm/connectivity/templates.py
+++ b/app/crm/connectivity/templates.py
@@ -40,6 +40,7 @@ from app.crm.connectivity.db.accessors import (
     template as template_accessor,
 )
 from app.crm.connectivity.schemas import (
+    ApprovedTemplate,
     ConnectorInstallation,
     CredentialBundle,
     TemplateDraft,
@@ -505,16 +506,21 @@ async def list_templates(
     return await template_accessor.list_templates(merchant_id, channel, status)
 
 
-async def approved_language(
+async def approved_template(
     merchant_id: str, channel: str, provider_account_ref: str, name: str
-) -> Optional[str]:
-    """Is this template name approved on this account, and in which language?
+) -> Optional[ApprovedTemplate]:
+    """Is this template name approved on this account — and if so, the row.
 
     The registry's one public read for the send path. It states a FACT and
     nothing else — the caller owns the word for "no", exactly as the binding
     and installation steps already separate the fact from the refusal. It also
     keeps every read of the registry table in this file: two logic files
     owning reads on one table is how two answers to "is this approved" appear.
+
+    The answer is the ROW, not one of its fields: which field a send needs is
+    the adapter's business (WhatsApp renders by language, SMS-DLT sends the
+    provider's id), and a registry that answered "the language" would be
+    answering WhatsApp's question for every channel.
 
     None has three causes, and from the sender's side they are one fact:
 
@@ -539,4 +545,4 @@ async def approved_language(
             f"exactly one is required to send"
         )
         return None
-    return approved[0].language
+    return approved[0]

--- a/tests/crm/test_connectivity_adapters.py
+++ b/tests/crm/test_connectivity_adapters.py
@@ -180,7 +180,7 @@ def _route(**overrides) -> SendRoute:
 
 #: What the registry answers for an approved template, unless a test seeds
 #: something else. One row = one language = sendable.
-_APPROVED = [ApprovedTemplate(id="t-1", language="en_US")]
+_APPROVED = [ApprovedTemplate(id="t-1", name="order_update_v1", language="en_US")]
 
 
 class _FakeAccessor:
@@ -468,9 +468,10 @@ async def test_a_resolved_route_carries_the_whole_context(happy_accessor) -> Non
     assert isinstance(route, SendRoute)
     assert route.binding.address == "1234567890"
     assert route.bundle.secret("system_user_token") == "tok"
-    # And the language the registry approved, which is the whole reason the
-    # adapter no longer reads it off the binding.
-    assert route.template_language == "en_US"
+    # And the registry row it was approved as, which is the whole reason the
+    # adapter no longer reads a language off the binding.
+    assert route.template is not None
+    assert route.template.language == "en_US"
 
 
 def test_both_binding_lookups_are_pinned_to_their_channel() -> None:
@@ -853,8 +854,8 @@ async def test_an_approved_template_passes_to_the_adapter(
         ([], "never registered, pending, rejected or deleted"),
         (
             [
-                ApprovedTemplate(id="t-1", language="en_US"),
-                ApprovedTemplate(id="t-2", language="hi_IN"),
+                ApprovedTemplate(id="t-1", name="order_update_v1", language="en_US"),
+                ApprovedTemplate(id="t-2", name="order_update_v1", language="hi_IN"),
             ],
             "approved in more than one language",
         ),
@@ -912,13 +913,57 @@ async def test_the_route_carries_the_registrys_language_not_the_bindings(
         _FakeAccessor(
             binding=_binding(capabilities={"template_language": "de_DE"}),
             installation=_installation(),
-            approved=[ApprovedTemplate(id="t-1", language="hi_IN")],
+            approved=[
+                ApprovedTemplate(id="t-1", name="order_update_v1", language="hi_IN")
+            ],
         ),
     )
     _patch_credential(monkeypatch, _credential())
     route = await resolve_send_route("shop", "whatsapp", None, "order_update_v1")
     assert isinstance(route, SendRoute)
-    assert route.template_language == "hi_IN"
+    assert route.template is not None
+    assert route.template.language == "hi_IN"
+
+
+# --- the registry gate is a CHANNELS fact, not a send.py assumption ---------
+
+
+def test_whether_a_channel_registers_templates_is_the_registrys_answer() -> None:
+    """WhatsApp does; an unregistered channel answers True so the door fails
+    CLOSED on it — the same posture the gate takes on a channel CHANNELS
+    cannot describe."""
+    from app.crm.connectivity.channels import registers_templates_for
+
+    assert registers_templates_for("whatsapp") is True
+    assert registers_templates_for("carrier_pigeon") is True
+
+
+async def test_a_channel_that_does_not_register_templates_skips_the_registry(
+    monkeypatch, counting_adapter
+) -> None:
+    """An email send names no registry row and must not be refused for
+    lacking one. Before this the resolver assumed every channel pre-registers
+    and would have blocked every such send with template_not_approved — the
+    adapter's own "channel that does not pre-register" fallback was
+    unreachable because the door refused first."""
+
+    class _NeverAsked(_FakeAccessor):
+        async def approved_templates_for_send(self, *args, **kwargs):
+            """Test double: the registry must not be consulted at all."""
+            raise AssertionError("registry read on a non-registering channel")
+
+    _patch_accessors(
+        monkeypatch, _NeverAsked(binding=_binding(), installation=_installation())
+    )
+    _patch_credential(monkeypatch, _credential())
+    monkeypatch.setattr(send_module, "registers_templates_for", lambda channel: False)
+    message = _message(template_id=None)
+    outcome = await send(_token(message), message)
+    assert outcome.status == "accepted"
+    assert counting_adapter.calls == 1
+    route = await resolve_send_route("shop", "whatsapp", None, None)
+    assert isinstance(route, SendRoute)
+    assert route.template is None
 
 
 def test_the_lookup_is_scoped_to_the_merchants_own_account() -> None:

--- a/tests/crm/test_queue_message.py
+++ b/tests/crm/test_queue_message.py
@@ -39,7 +39,18 @@ def test_purpose_must_start_with_a_known_root() -> None:
     queue.validate_proposal("workflow", "utility.order.cod_confirm")
 
 
-def test_writer_normalizes_the_address() -> None:
+def test_writer_normalizes_the_address(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The kind of normalization is the CHANNELS registry's answer. "email"
+    is seeded here because no email channel is registered yet — the point is
+    that an email-kind channel lowercases and a phone-kind one parses E.164,
+    and that the writer never guesses which from the channel's name."""
+    from app.crm.connectivity import channels
+
+    monkeypatch.setitem(
+        channels.CHANNELS,
+        "email",
+        channels.Channel(gate_handle_kind="email", registers_templates=False),
+    )
     assert queue.normalize_address("whatsapp", "98450 12345") == "+919845012345"
     assert queue.normalize_address("email", " Priya@Shop.IN ") == "priya@shop.in"
     assert queue.normalize_address("whatsapp", "hello") is None
@@ -88,3 +99,40 @@ def test_unusable_address_is_refused_before_any_write(
     monkeypatch.setattr(queue.message_accessor, "insert_message", never)
     with pytest.raises(ValueError):
         asyncio.run(queue.queue_message(**_proposal(address="hello")))
+
+
+def test_the_address_kind_is_the_channel_registrys_answer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """queue.py once kept its own tuple of "phone channels" beside the
+    CHANNELS registry that already knew each channel's handle kind — two
+    answers to one question. The registry is the only answer now: a channel
+    it describes as email-kind is lowercased, not parsed as a phone."""
+    from app.crm.connectivity import channels
+
+    monkeypatch.setitem(
+        channels.CHANNELS,
+        "mail",
+        channels.Channel(gate_handle_kind="email", registers_templates=False),
+    )
+    assert (
+        queue.normalize_address("mail", "  Priya@Example.COM ") == "priya@example.com"
+    )
+    assert queue.normalize_address("whatsapp", "+91 98765 43210") == "+919876543210"
+
+
+def test_an_unregistered_channel_is_refused_before_any_write(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A channel CHANNELS cannot describe has no address kind, so nothing is
+    normalized and nothing is stored: the gate would fail closed on the row
+    at dispatch anyway, and a manifest row that can never send is not worth
+    writing."""
+
+    async def never(*args: Any) -> Optional[str]:
+        raise AssertionError("must not write")
+
+    monkeypatch.setattr(queue.message_accessor, "insert_message", never)
+    assert queue.normalize_address("carrier_pigeon", "+919876543210") is None
+    with pytest.raises(ValueError):
+        asyncio.run(queue.queue_message(**_proposal(channel="carrier_pigeon")))

--- a/tests/crm/test_whatsapp_adapter.py
+++ b/tests/crm/test_whatsapp_adapter.py
@@ -23,6 +23,7 @@ from app.crm.connectivity.providers.whatsapp.payload import (
     to_meta_recipient,
 )
 from app.crm.connectivity.schemas import (
+    ApprovedTemplate,
     ChannelBinding,
     ConnectorInstallation,
     CredentialBundle,
@@ -92,17 +93,23 @@ def _installation(**overrides) -> ConnectorInstallation:
     return ConnectorInstallation(**fields)
 
 
+def _approved(language: str) -> ApprovedTemplate:
+    """The registry row the send path resolved, in ``language``."""
+    return ApprovedTemplate(id="t-1", name="order_update_v1", language=language)
+
+
 def _route(**overrides) -> SendRoute:
     """Everything send() resolves, handed to the adapter as one object.
 
-    template_language defaults to what the registry would have supplied for
-    an approved template — the adapter never reads it from the binding.
+    ``template`` defaults to the registry row an approved template would have
+    supplied — the adapter reads its language from there, never from the
+    binding.
     """
     fields = dict(
         installation=_installation(),
         binding=_binding(),
         bundle=_bundle(),
-        template_language="en_US",
+        template=_approved("en_US"),
     )
     fields.update(overrides)
     return SendRoute(**fields)
@@ -314,20 +321,20 @@ def test_the_language_comes_from_the_template_registry() -> None:
     parameters = build_parameters(_message().variables)
     assert isinstance(parameters, list)
     payload = adapter.build_payload(
-        _message(), "919876543210", _route(template_language="hi"), parameters
+        _message(), "919876543210", _route(template=_approved("hi")), parameters
     )
     assert payload["template"]["language"]["code"] == "hi"
 
 
-def test_a_route_without_a_language_falls_back_rather_than_crashing() -> None:
-    """A route with no language still renders — the T23 lookup makes this
-    unreachable for WhatsApp, so it exists so a channel that does not
-    pre-register templates cannot take the worker down."""
+def test_a_route_without_a_registry_row_falls_back_rather_than_crashing() -> None:
+    """A route carrying no template row still renders — the T23 lookup makes
+    this unreachable on WhatsApp (the door refuses first), so it exists only
+    so a misrouted call cannot take the worker down."""
     adapter = MetaWhatsAppAdapter()
     parameters = build_parameters(_message().variables)
     assert isinstance(parameters, list)
     default = adapter.build_payload(
-        _message(), "919876543210", _route(template_language=None), parameters
+        _message(), "919876543210", _route(template=None), parameters
     )
     assert default["template"]["language"]["code"] == "en_US"
 


### PR DESCRIPTION
## Why

After #1050 merged, a sweep for WhatsApp assumptions sitting in GENERIC connectivity code found three. Each would have bitten the next channel, not this one. All three become facts of the `CHANNELS` registry — the one place per-channel questions are answered — and WhatsApp's behaviour is byte-for-byte unchanged.

## What

**1. The registry gate applied to every channel.** `send.py` refused any send whose template name had no approved registry row. A channel that does not pre-register templates (email) would have been blocked with `template_not_approved` before its adapter ran — and the WhatsApp adapter's own "channel that does not pre-register" fallback was unreachable because the door refused first. Now `Channel.registers_templates` decides whether the lookup runs. WhatsApp: `True`. A channel the registry cannot describe answers `True` (fail closed, the gate's posture).

**2. The route carried one provider's field.** `SendRoute.template_language` was Meta's need on a channel-neutral shape. The route now carries the approved registry ROW — `ApprovedTemplate(id, name, language, provider_template_id, category)` — and each adapter reads the field it needs: WhatsApp its language, an SMS-DLT adapter its provider id, email nothing. `templates.approved_language` becomes `templates.approved_template` (still the registry's one public read for the send path).

**3. `queue.py` kept a second channel list.** `_PHONE_CHANNELS = ("whatsapp", "sms", "voice", "rcs")` sat beside the registry that already knew each channel's handle kind. `normalize_address` now asks `CHANNELS` (phone → E.164, email → lowercase) instead of guessing from the name.

Plus one docstring: `SubmitTemplateRequest.category` no longer presents Meta's category words as the registry's vocabulary.

## The one observable difference (for a channel that does not exist)

`queue_message(channel=<not in CHANNELS>, ...)` now raises `ValueError` at proposal time instead of writing a manifest row that the gate would block at dispatch with `gate_unavailable`. No producer sends on such a channel today; the walker already parks a run on `ValueError` from `queue_message`. Called out so it is a decision, not a surprise. For `whatsapp` — the only registered channel — nothing changes: same reads, same order, same refusals, same payload.

## Not in this PR

The structure follow-up (schemas/ package, status vocabularies, route dependency, shared test doubles) — separate, as ruled. `shared/redact.py`'s `whatsapp` mask branch stays: `channels.py` documents why (shared/ may not import connectivity; its default is mask-everything, so an unregistered channel already fails safe).

## Verified

- `pytest tests/crm`: 493 passed (4 new: registry-answers-registration, non-registering channel skips the registry and reaches the adapter with `route.template is None`, address kind from the registry, unregistered channel refused before any write)
- `scripts/check_crm_boundaries.py` clean · black · isort · pyrefly 0 errors · no `txn` under db/
- `grep -rn "template_language\|approved_language\|_PHONE_CHANNELS" app tests` → only Meta's webhook field name and a test binding blob that proves the adapter no longer reads it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01APYhsMRBdKLz74A6NRuWy5


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added channel-specific handling for template registration, allowing non-registering channels to send without template approval checks.
  * Send routes now retain approved template details, including name, language, provider ID, and category.
  * WhatsApp messages use the approved template language, with a default fallback when unavailable.
* **Bug Fixes**
  * Address normalization now follows each channel’s registered type and refuses unknown channels instead of applying incorrect email handling.
  * Improved template approval data retrieval for more accurate message delivery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->