### PR TITLE
docs(crm): workflow rollout queue — 20 ordered PR-sized phases, pipeline and full context

### DIFF
--- a/docs/crm/workflow-rollout/00-land-repeat-entries.md
+++ b/docs/crm/workflow-rollout/00-land-repeat-entries.md
@@ -1,0 +1,32 @@
+# Phase 00 — Land repeat entries ourselves (supersede PR #1041 with its fixes folded in)
+
+**Kind**: feat (carried) + fix · **PR title**: `feat(crm): repeat entries — on_repeat + debounce_minutes, with founding-event and debounce guards` · **Depends on**: nothing · **Notes**: §12 "PR #1041", §11 P9/P10, `context/nits.md` N18–N21 · **Wave 0 — first thing in the queue**
+
+## Why this is a phase and not "wait for manas"
+We run the whole rollout ourselves. #1041 (`manas-narra:feat/crm-repeat-entries`, one commit `0c45714`, base `75594cb`) is reviewed, CI-green, and merges cleanly onto today's `release`, but it lives on a fork branch we cannot push to, carries three unresolved CodeRabbit nits, and needs two one-line guards (P9, P10) before the cart flow can rely on it. So we land it: cherry-pick the commit onto a branch of ours, apply the five fixes in the same single commit, open our PR crediting manas, and ask for #1041 to be closed as superseded. Phases 07 and 16 depend on this being merged.
+
+## What #1041 adds (so the reviewer of our PR knows what is carried vs new)
+`entry.on_repeat` ∈ {ignore, refresh_latest, refresh_max(<field>), accumulate} and `entry.debounce_minutes`; new `app/crm/outreach/repeat.py` (`parse_repeat_policy`, `repeat_plan`, `apply_repeat`); `db/queries.py::patch_open_run_query` — one idempotent UPDATE on the run standing on `nodes[0]`, found by `enrollment_key`, marking the event in `context.repeat_event_ids`, sliding `wake_at`; hooked from `entry._try_enrol` when `enrol()` returns None; validator rules (policy word; debounce needs a wait first); `repeat_event_ids`/`repeat_items` as bookkeeping; 16 tests in `tests/crm/test_workflow_repeat.py`. 9 files, +533/−4.
+
+## Steps
+1. `git fetch origin pull/1041/head:pr-1041 && git checkout -b claude/crm-phase-00-land-repeat-entries origin/release && git cherry-pick 0c45714` (clean today; if it conflicts later in `entry.py`, the intent is: after `enrol()` returns None, call `apply_repeat` with the same args as the PR).
+2. Apply the five fixes, all inside the cherry-picked commit (`git commit --amend`):
+   - **P9 — founding-event redelivery**: in `patch_open_run_query` WHERE add `AND context->>'source_event_id' IS DISTINCT FROM $5::text`. A redelivered copy of the run's own founding event is refused by `source_event_used`, falls into `apply_repeat`, is not in `repeat_event_ids`, and would overwrite newer facts with the first snapshot and restart the timer.
+   - **P10 — debounce only extends**: `wake_at = CASE WHEN $10::float8 > 0 THEN GREATEST(wake_at, now() + make_interval(secs => $10::float8 * 60)) ELSE wake_at END`. With `now()+N` a debounce shorter than the remaining entry wait pulls the alarm EARLIER (manas flagged it himself in the PR comment; the answer is GREATEST).
+   - **N18 — non-finite refresh_max**: `repeat.py::_as_number` returns None unless `math.isfinite(value)` ("nan"/"inf" otherwise always win in Postgres ordering).
+   - **N19 — accumulate on a scalar `repeat_items`**: `entry.py::_context_from_payload` skips keys in `nodes._BOOKKEEPING_KEYS` and with `nodes._BOOKKEEPING_PREFIXES` (import both; they are the one definition), so a producer payload can never plant `repeat_items`/`source_event_id`/`lead_*` in context.
+   - **N20 — refreshed phone**: `_try_enrol` passes `apply_repeat` the same `context` dict it built for `enrol()` **minus `source_event_id`** (P9 needs the founding id to stay put), so a changed phone reaches the run.
+3. Add the tests (N21): SQL contains the P9 predicate and `GREATEST(wake_at`; `_as_number("nan"/"inf"/"-inf")` → None; bookkeeping keys never enter context; monkeypatched `apply_repeat` receives `phone` and not `source_event_id`. Keep all 16 of manas's tests.
+4. Commit message keeps manas's original body, adds a "Carried from #1041 by @manas-narra; adds P9/P10/N18–N20" paragraph and `Co-authored-by: manas-narra <…>` (take the email from `git log pr-1041 -1 --format=%ae`).
+5. Full check list from `README.md`; open the PR; in the description link #1041 and ask a maintainer to close it as superseded. Do not comment on #1041 yourself beyond that link.
+
+## Acceptance
+- `pytest tests/crm` green with the 16 carried + 5 new tests; boundary checker clean; pyrefly 0; one commit.
+- After merge: `context/reading-notes.md` §12 "Two asks on the PR" and §11 P9/P10 are done (no edit needed; the PR list is the ledger).
+
+## Decisions already made
+- Supersede, do not wait. Attribution stays with manas in the commit and PR body.
+- `GREATEST` semantics for debounce. `pin`-vs-`migrate` is irrelevant here (phase 11).
+
+## Out of scope
+- Generalising repeats beyond the entry node (phase 16). Manas's open questions on list-shaped facts / `accumulate(<field>)` (backlog G4).

--- a/docs/crm/workflow-rollout/01-outreach-correctness.md
+++ b/docs/crm/workflow-rollout/01-outreach-correctness.md
@@ -1,0 +1,34 @@
+# Phase 01 — Outreach correctness fixes (B1, B3, B4)
+
+**Kind**: fix · **PR title**: `fix(crm): wait_event reply without key, entry compare, draft→live 422` · **Depends on**: nothing · **Notes**: `context/reading-notes.md` §4 (W-1, W-3, W-5), §11 (B1, B3, B4)
+
+## Why
+Three reproduced bugs in `app/crm/outreach` that any plan using `wait_event`, any re-publish, or any status change can hit. All three are pure-function or single-statement fixes with red tests; no migration, no vocabulary change.
+
+## B1 — a `wait_event` reply whose payload lacks `node.key` routes to "timeout"
+- **Where**: `app/crm/outreach/entry.py::consume_attributed_event` (the `listening` loop) writes `{reply_<node>: None}` via `accessor.resume_run_on_event(...)` when `event.payload.get(node.key)` is None. `app/crm/outreach/walker.py::pick_next` then reads `None` and takes the `"timeout"` edge.
+- **Repro (pure)**: `pick_next(WorkflowNode(id="ask", type="wait_event", topics=["button.reply"], key="button_id", minutes=60), [("confirm","YES"),("call","timeout")], {"reply_ask": None})` → `"call"`.
+- **Fix**: in `entry.py`, when the answer is `None` do **not** call `resume_run_on_event`; log at info (`"wait_event reply ignored: key {node.key!r} missing (workflow …, event …)"`). The listening window continues; only the alarm can time it out. Keep `pick_next` unchanged (None still means timeout for the alarm path).
+- **Red tests** (`tests/crm/test_workflow_entry.py`, new file): monkeypatch `accessor.resume_run_on_event`; (a) payload with the key → called with `{reply_ask: "YES"}`; (b) payload without the key → NOT called; (c) `pick_next` with `{}` still returns the timeout edge (pins the alarm semantics).
+
+## B3 — publish compares the live entry as a raw dict
+- **Where**: `app/crm/outreach/plans.py::validate_definition`: `if raw.get("entry") != live_entry`. `live_entry` is whatever dict was stored at the last publish; a draft that omits defaults (`reenter`, `cooldown_hours`, `where`, `key`) compares unequal to a live entry that spelled them out (or vice versa) → spurious "entry rule changed while runs are open".
+- **Fix**: compare `WorkflowEntry.model_validate(raw["entry"]).model_dump()` with `WorkflowEntry.model_validate(live_entry).model_dump()`. Guard: if `live_entry` fails to validate (legacy row), fall back to raw compare.
+- **Red test** (`tests/crm/test_workflow_plans.py`): draft `{"topic": "checkout.initiated"}` vs live `{"topic": "checkout.initiated", "where": {}, "reenter": false, "cooldown_hours": 24.0, "key": null}` with `occupied_nodes=["w"]` → `[]`. Keep the existing test that a REAL change (`key` added) is still refused.
+
+## B4 — `POST /{id}/status {live}` on a never-published draft is a 500
+- **Where**: `plans.py::set_status` → `accessor.set_workflow_status` → migration 057 `CHECK (status = 'draft' OR definition IS NOT NULL)` → `asyncpg.CheckViolationError` → 500 from `api.py::set_workflow_status_route`.
+- **Fix** (logic, not DB): `set_status` reads the workflow first (`accessor.get_workflow`), and if `status == "live"` and `workflow.definition is None` raises `WorkflowValidationError(["publish a draft before going live"])`; `api.py` already maps that to 422. Also map `None` from the accessor (archived) to 404 as today. Do not catch the driver error in logic — the boundary rules forbid driver types outside `db/`; the pre-read is the fix.
+- **Red test**: monkeypatch `accessor.get_workflow` to return a `Workflow` with `definition=None, status="draft"`; `await plans.set_status("m1","wf","live")` raises `WorkflowValidationError`. Also assert `set_status` never calls `set_workflow_status` in that case.
+
+## Acceptance
+- The three red tests fail on `origin/release` and pass on the branch.
+- `pytest tests/crm` green, boundary checker clean, pyrefly 0.
+- Update `context/reading-notes.md` §11 rows B1/B3/B4 with "fixed in phase 01" (docs in the same commit is fine).
+
+## Decisions already made
+- B1 is fixed by NOT resuming, not by a sentinel answer. A sentinel would need a new edge label vocabulary.
+- B4 stays a logic-side check; no new DB constraint, no driver exception handling in logic.
+
+## Out of scope
+- B2 (phase 02), P1 (phase 03). N1 (type-string matching) — leave.

--- a/docs/crm/workflow-rollout/02-keyed-admission.md
+++ b/docs/crm/workflow-rollout/02-keyed-admission.md
@@ -1,0 +1,24 @@
+# Phase 02 — Keyed-plan admission (B2)
+
+**Kind**: fix · **PR title**: `fix(crm): admission guards scope to the enrollment key on keyed plans` · **Depends on**: 01 · **Notes**: §4 (W-4), §11 (B2), §12 (why keyed flows exist: WISMO, two parcels)
+
+## Why
+`entry.key` (canon T20 col 13, ruled 31 Aug 2026) says "one run per <field>", but the admission guards in `app/crm/outreach/enrol.py` read history per **customer**: `accessor.admission_facts(txn, merchant, workflow, customer)` counts ALL of the customer's runs. With the default `reenter: false` / `cooldown_hours: 24`, the second order of the same customer is refused with `reenter_disabled`. Reproduced: `_admission(keyed_definition, runs=1, latest=now-5m, now)` → `(False, "reenter_disabled")`.
+
+## Design
+- **Semantics** (decision): on a keyed plan, `reenter` and `cooldown` are judged per `(workflow, enrollment_key)`, not per customer. "Has this ORDER ever run" is what the author declared. Customer-level spam control across keys is the permission gate's job (phase 19), not admission's.
+- `db/queries.py::admission_facts_query` gains an optional `enrollment_key` predicate: when given, `WHERE merchant_id=$1 AND workflow_id=$2 AND enrollment_key=$3` (drop the customer predicate — the key already implies the customer for keyed plans; keep `customer_id` in the WHERE too for tenancy paranoia: `AND customer_id=$4`). Keep the unkeyed builder path byte-identical for existing tests.
+- `db/accessor.py::admission_facts(conn, merchant, workflow, customer, enrollment_key=None)`.
+- `enrol.py::_enrol_in_txn`: pass `enrollment_key` when `definition.entry.key` is set (the key passed in is the payload value; unkeyed plans pass `customer_id` today — keep that but call the unkeyed builder).
+- `plans.py::validate_definition`: no refusal, but when `entry.key` is set and `reenter` is false, append a **warning**? The validator returns problems only. Decision: do NOT warn; the semantics change makes the default correct for keyed plans (a new order id has no history → admitted).
+
+## Red tests
+- `tests/crm/test_workflow_queries.py`: `admission_facts_query("m1","wf","c1", enrollment_key="ORD-2")` contains `enrollment_key = $3`; unkeyed form unchanged.
+- `tests/crm/test_workflow_admission.py`: monkeypatch `accessor.admission_facts` to return `{runs: 0, latest_entered_at: None}` when called with a key and `{runs: 1, ...}` without; assert `_enrol_in_txn` on a keyed definition with a fresh key inserts (reaches `insert_enrollment`) even with `reenter=False`.
+
+## Acceptance
+- Red tests fail on release, pass on branch; suite green; boundary clean.
+- `context/reading-notes.md` §11 B2 → "fixed in phase 02"; §13 caveat about keyed plans removed.
+
+## Out of scope
+- Cross-key frequency caps (phase 19). Changing `reenter` defaults.

--- a/docs/crm/workflow-rollout/03-enrollment-cas.md
+++ b/docs/crm/workflow-rollout/03-enrollment-cas.md
@@ -1,0 +1,27 @@
+# Phase 03 — Compare-and-set on enrollment writes (P1)
+
+**Kind**: fix · **PR title**: `fix(crm): walker writes are conditional on the lease they were claimed under` · **Depends on**: 01 · **Notes**: §4 (W-2), §11 (P1), §12 (#1041 adds a second writer), §14.7
+
+## Why
+`db/queries.py::advance_run_query` (and `exit_run_query`, `park_run_query`, `record_run_error_query`) update `context`/`wake_at` unconditionally (`WHERE id=$1 AND status='waiting'`). Meanwhile `resume_run_on_event_query` (W5 replies) and PR #1041's `patch_open_run_query` (repeats) also write `context` + `wake_at` from the event worker. If a reply lands while the walker is mid-visit on that node's timeout path, the walker's `advance_run` overwrites the reply and the timeout branch wins. Same for a repeat patch. No migration needed.
+
+## Design — the leased `wake_at` is the generation token
+- `claim_due_runs_query` already sets `wake_at = now() + lease` and RETURNS the row; the decoded `EnrollmentRun.wake_at` is therefore the claim's token. Every event-side writer sets `wake_at` to something else (`now()` for replies, `now()+debounce` for repeats), and the claim itself moves it. So `AND wake_at = $leased` on the walker's writes is a correct CAS without a new column.
+- Change the four walker-side builders to take `leased_wake_at: datetime` and add `AND wake_at = $n`. `exit_run` from the ENTRY consumer (`cancel_open_runs`) stays unconditional (it is the event side; goals win).
+- `walker.py`: thread `run.wake_at` into `accessor.advance_run/exit_run/park_run/record_run_error`. On a CAS miss (`UPDATE … RETURNING id` → None): log info `"walker: run {id} changed under the lease — deferring to the next wake"` and return. The lease already re-arms the run; on the next claim the walker re-reads the run WITH the reply/patch and takes the right branch. Action nodes are idempotent (dedupe `run:node`, uuid5 lead), so a re-executed visit is safe (the same guarantee the lease relies on today).
+- Accessors return `bool` (row matched) for these four.
+- Docstrings: state the law in each builder ("the lease is the generation; a write under a stale lease is a no-op").
+
+## Red tests
+- `tests/crm/test_workflow_queries.py`: each of the four builders contains `wake_at = $` and carries the leased value in params.
+- `tests/crm/test_workflow_walker.py` (new): monkeypatch accessor; `advance_run` returns False → `_advance` returns without raising and without calling `exit_run`; with True → behaves as today.
+
+## Acceptance
+- Suite green; boundary clean (no driver types in logic).
+- §11 P1 → "fixed in phase 03". Note in `db/queries.py` module docstring: "walker writes are CAS on the leased wake_at; event-side writes are not".
+
+## Decisions already made
+- No `revision` column. The leased `wake_at` is sufficient and avoids a migration. Revisit only if a writer ever needs to leave `wake_at` untouched (none does).
+
+## Out of scope
+- #1041's patch query (it is event-side; unchanged). Phase 16 generalises repeats.

--- a/docs/crm/workflow-rollout/04-event-attempts-quarantine.md
+++ b/docs/crm/workflow-rollout/04-event-attempts-quarantine.md
@@ -1,0 +1,28 @@
+# Phase 04 — Event attempts + quarantine after N (P2)
+
+**Kind**: fix + migration · **PR title**: `fix(crm): crm_event_raw counts attempts and quarantines poison rows` · **Depends on**: nothing · **Notes**: §3 (record OBSERVATION), §11 (P2)
+
+## Why
+`app/crm/record/workers.py::_pass_in_txn` claims pending rows FOR UPDATE SKIP LOCKED ordered by `received_at`; a row whose consumer raises deterministically (a bad live definition, a DB error on one merchant) stays `processed_at IS NULL` forever, is re-claimed every poll at the head of the queue, and re-runs `resolve()`/`assert_facts()` each time. Compare `crm_workflow_enrollment.attempts` (058), which the claim increments.
+
+## Design
+- **Migration `NNN_add_attempts_to_crm_event_raw.sql`** (next free number): `ALTER TABLE crm_event_raw ADD COLUMN attempts smallint NOT NULL DEFAULT 0;` and `CREATE OR REPLACE FUNCTION crm_event_raw_immutable()` so `attempts` is an allowed change (copy 051's function body; the immutability list is the ingestion fields only — `attempts` is envelope, like `processed_at`). Header comment cites T13 and this phase. Register nothing new in `TABLE_OWNERS` (no new table).
+- `db/queries.py::claim_pending_events_query`: becomes `UPDATE crm_event_raw SET attempts = attempts + 1 WHERE id IN (SELECT … FOR UPDATE SKIP LOCKED) RETURNING <columns incl. attempts>` — the claim spends an attempt (the same shape as `claim_due_runs_query` and `claim_queued_messages_query`). The lock is still held by the enclosing transaction (`_pass_in_txn`).
+- `schemas.py::RawEvent` gains `attempts: int = 0`; `decoder.py` maps it.
+- `workers.py::_pass_in_txn`: in the per-row `except`, if `event.attempts >= CRM_EVENT_MAX_ATTEMPTS` (new static config, default 5, `app/core/config/static.py` beside `CRM_WORKER_*`) → `accessor.quarantine_event(txn, id, f"consumer_error after {n} attempts: {e}")` **outside the failed savepoint** (the savepoint rolled back; the quarantine must be its own statement on `txn`, which is still valid). Otherwise log and leave pending as today. Log at error with the event id and source/topic (never payload).
+- `observe_processed_event` unchanged.
+
+## Red tests
+- `tests/crm/test_event_worker.py`: (a) claim SQL contains `attempts = attempts + 1` and RETURNING `attempts`; (b) with `attempts=5` and a raising consumer, `quarantine_event` is called with a reason starting `consumer_error`; with `attempts=1` it is not.
+- `tests/crm/test_check_migrations.py` untouched (numbering guard runs in CI).
+
+## Acceptance
+- Migration applies on a fresh DB (`uv run python scripts/migrate.py up` locally if a Postgres is available; otherwise state in the PR that it was not run) and `check_migrations.py --base origin/release` passes.
+- Docs: `docs/crm/migrations.md` ownership table unchanged (same owner); add one line under the CRM table template notes: "envelope columns (processed_at, quarantine_reason, customer_id, attempts) are the only mutable ones".
+
+## Decisions already made
+- Quarantine, not delete. Replay is the recovery mechanism; a quarantined row is re-processable by clearing `processed_at`/`quarantine_reason` by hand.
+- Attempts counted by the claim, not by the failure, so a crash mid-row counts.
+
+## Out of scope
+- An operator endpoint to re-drive quarantined rows (backlog).

--- a/docs/crm/workflow-rollout/06-goal-tiers-and-key.md
+++ b/docs/crm/workflow-rollout/06-goal-tiers-and-key.md
@@ -1,0 +1,42 @@
+# Phase 06 — Goal tiers, goal key, occurred_at guard (cart→order attribution, G7)
+
+**Kind**: feat + migration · **PR title**: `feat(crm): goal tiers with a payload key — recovered vs converted elsewhere, time-aware on the entry event` · **Depends on**: 01, 03 · **Notes**: §12 Q2/Q3, §16.1, §16.3 G7
+
+## Why
+Today `goal.topics` is customer-level: ANY order by the customer ends every open run as `goal_met` (`entry.py` goal loop → `cancel_open_runs`; `walker._advance` → `record.contracts.customer_has_event`). For cart recovery that is the right SAFETY default (never nudge someone who just bought) but it cannot say whether THIS cart was recovered. The funnel needs: order carrying the run's cart → `goal_met`; any other order → still exit, different reason.
+
+## Design
+### Vocabulary (schemas.py)
+- `WorkflowGoal` becomes a tier: `{topics: [...], key: Optional[{event: str, run: str}], exit_reason: str = "goal_met"}`.
+- `WorkflowDefinition.goals: List[WorkflowGoal]` (min 1). Keep `goal` (singular) accepted for backward compatibility: a `model_validator(mode="before")` rewrites `{"goal": X}` → `{"goals": [X]}`. Validator: at most one tier per exit_reason; `exit_reason` ∈ the closed set (see migration); `key.run` must be a context field name (string), `key.event` a payload field.
+- Matching order: tiers are evaluated **in document order**; the first tier whose topic matches AND whose key matches (or has no key) wins. So `[{recovered, key}, {converted_elsewhere}]` gives the two-tier cart semantics; a single tier without a key is today's behaviour.
+### Migration `NNN_extend_crm_workflow_enrollment_exit_reasons.sql`
+- `ALTER TABLE crm_workflow_enrollment DROP CONSTRAINT crm_workflow_enrollment_exit_reason_check` (058 declared the CHECK inline on the column; Postgres names it `<table>_<column>_check` — verify with `\d crm_workflow_enrollment` and fall back to a `DO` block over `pg_constraint` if the name differs), then `ADD CONSTRAINT crm_workflow_enrollment_exit_reason_ck CHECK (exit_reason IN ('goal_met','timed_out','withdrawn','ejected','completed','converted_elsewhere'))`. Closed status enum → CHECK is REQUIRED (law 11). Header cites T20 and this phase; canon amendment proposed to Swaroop.
+### Record contract
+- `record/contracts.py::customer_has_event(merchant, customer, topics, since, where: Optional[Tuple[str, str]] = None)` → `db/queries.py::customer_has_event_query` adds `AND payload->>$5 = $6` when given. `record/events.py` threads it. This is a read on record's own table through its own contract — no boundary issue.
+### Outreach
+- `db/queries.py::cancel_open_runs_query` gains optional `(run_field, event_value)` → `AND context->>$6 = $7`. `exit_reason` already parameterised.
+- `entry.py`: build `goal_matches` as `(flow, tier)` pairs; for each open-run-relevant tier call `cancel_open_runs(..., tier.exit_reason, event.occurred_at, key=(tier.key.run, payload[tier.key.event]) if tier.key else None)`. Tier order = document order; stop at the first tier that cancelled ≥1 run **per run** — simplest correct implementation: evaluate keyed tiers first (they are more specific) then unkeyed; a run already exited by tier 1 is not matched by tier 2 because the WHERE has `status <> 'exited'`. Document this in the loop.
+- `walker._advance`: iterate tiers; call `customer_has_event(..., since, where=(tier.key.event, run.context.get(tier.key.run)) if tier.key else None)`; exit with the tier's reason.
+### G7 — time-aware on the entry event, not `entered_at`
+- `enrol.py::_enrol_in_txn`: store `context["entered_event_at"] = <source event occurred_at or received_at ISO>` (entry.py passes it in context; it is bookkeeping → add to `nodes._BOOKKEEPING_KEYS`).
+- Goal comparisons use `COALESCE((context->>'entered_event_at')::timestamptz, entered_at)` in `cancel_open_runs_query` and pass the same value as `since` in the walker. A late-delivered earlier-stage event can no longer keep a run alive past a goal that truly happened after it.
+
+## Red tests
+- Schema: `{"goal": {...}}` still validates and yields one tier; two tiers with the same exit_reason refused; unknown exit_reason refused.
+- Queries: `cancel_open_runs_query` with key contains `context->>$6 = $7`; `customer_has_event_query` with where contains `payload->>$5 = $6`; both contain the `entered_event_at` COALESCE.
+- Entry (monkeypatched accessor): order with matching `cart_token` → cancel called with `goal_met` and the key; non-matching → `converted_elsewhere` without key.
+- Walker: two-tier definition, `customer_has_event` returns True only for the keyed where → exits `goal_met`; False/True → `converted_elsewhere`.
+
+## Acceptance
+- Suite green; boundary clean; `check_migrations --base` clean; `TABLE_OWNERS` unchanged.
+- `docs/crm/migrations.md`: note the exit_reason set now includes `converted_elsewhere` and why.
+- §16.1 cart definition in the notes is now valid as written (`goals` list).
+
+## Decisions already made
+- Two tiers, not item-overlap logic (not expressible; §12 Q3).
+- Exit reason is a closed set in a CHECK (law 11), so a migration is required.
+- Cart key defaults in the plan template (phase 07) to `cart_token`; confirm the relay payload carries it.
+
+## Out of scope
+- Recovered-revenue capture at goal time (phase 09).

--- a/docs/crm/workflow-rollout/07-plan-templates-and-runbooks.md
+++ b/docs/crm/workflow-rollout/07-plan-templates-and-runbooks.md
@@ -1,0 +1,23 @@
+# Phase 07 — Plan templates + runbooks (cart board; loan funnel as clocks)
+
+**Kind**: docs + tests · **PR title**: `docs(crm): cart-recovery and loan-dropoff plan templates, validated in CI` · **Depends on**: 00, 01, 02, 06 · **Notes**: §12, §13 Option A, §16.1, §15.1 Phase 1
+
+## Why
+The two target flows become concrete, versioned JSON documents that a test validates on every CI run, plus a runbook per flow so ops can publish them without reading code. This is also how the loan funnel ships NOW (per-stage clocks) before versioning exists.
+
+## Deliverables
+1. `docs/crm/plans/cart-recovery.json` — §16.1 exactly (entry `checkouts/update`, `reenter: true`, `cooldown_hours: 24`, `on_repeat: refresh_latest`, `debounce_minutes: 30`; `goals` two tiers keyed on `cart_token`; `wait 30 → send whatsapp cart_recovery_1 → wait 30 → call <template> → wait 1440`; `purpose_key: marketing.cart.recovery`; `exits.max_age_days: 7`). Placeholders (`<template_id>`) as `"TEMPLATE_ID_PLACEHOLDER"` strings so the document validates.
+2. `docs/crm/plans/loan-dropoff/` — one JSON per stage (`01-profile.json` … `05-agreement.json`): entry = stage topic, `reenter: true`, `cooldown_hours: 1`, `on_repeat: refresh_latest`, `debounce_minutes: 30`; nodes `wait 30 → call <stage template>`; `goals` = `[{topics: <every downstream stage + loan.disbursed>, exit_reason: goal_met}, {topics: [loan.rejected, loan.withdrawn], exit_reason: withdrawn}]`; `key: application_id`. A `README.md` in the folder explains the clock pattern (§13 A) and that phase 17 replaces it with one board.
+3. `tests/crm/test_plan_templates.py`: loads every `docs/crm/plans/**/*.json` and asserts `validate_definition(doc) == []`; asserts the loan stage plans' goal lists are exactly "all downstream stages" (compute from an ordered list in the test so a missing topic fails CI).
+4. `docs/crm/runbooks/cart-recovery.md` and `docs/crm/runbooks/loan-dropoff.md`: prerequisites (connector onboarded, template approved, s2s token, relay topic names), the `POST /crm/workflows` → `PUT draft` → `POST publish` → `POST status` sequence with curl, how to read `GET /runs?status=parked`, how `resume` works, what each exit reason means, the settings to change per merchant.
+
+## Acceptance
+- CI validates the documents. No app code changes except possibly a `tests/` helper.
+- Both runbooks reviewed against `app/crm/outreach/api.py` route signatures (merchant_id is a query param on every route; admin JWT).
+
+## Decisions already made
+- Goal key for cart is `cart_token`; if the relay's checkout payload lacks it, switch to `token` and note it.
+- Loan clocks trigger on stage EVENTS (not a stage attribute) because the source system is an API integrator sending events today; §15.1 mentions the attribute variant as a later option.
+
+## Out of scope
+- Any code change to the walker or validator. Reporting (phase 09).

--- a/docs/crm/workflow-rollout/08-publish-template-check.md
+++ b/docs/crm/workflow-rollout/08-publish-template-check.md
@@ -1,0 +1,26 @@
+# Phase 08 — Publish-time template check (G12)
+
+**Kind**: feat · **PR title**: `feat(crm): publish refuses a send node whose template the registry does not know` · **Depends on**: 06 · **Notes**: §16.3 G12, §6 (connectivity templates, `approved_template`)
+
+## Why
+A `send` node names a `template` by NAME; today the first sign it is wrong is a `blocked / template_not_approved` row at dispatch time, hours after publish. The T23 registry (`crm_channel_template`, `app/crm/connectivity/templates.py`) can answer at publish.
+
+## Design
+- New connectivity contract `template_status(merchant_id, channel, name) -> Optional[str]`: the status of the registry row(s) with that name for this merchant+channel — `None` if no row, `"approved"` if exactly one approved row, else the most recent row's status (for the message). Implement in `connectivity/templates.py` (the one file owning registry reads), export from `contracts.py`. Accessor: a new query `templates_by_name_query(merchant, channel, name)` ordered by `status_updated_at DESC`.
+- `plans.py::_publish_in_txn` (outreach): after `validate_definition` passes, for each `send` node whose channel `registers_templates_for(channel)` (connectivity `channels.py` — expose `registers_templates_for` via contracts too) call `template_status`; `None` → problem `"send node {id}: template '{name}' is not registered on {channel} for this merchant"`; not approved → problem `"... is '{status}', not approved"`. Refuse publish with `WorkflowValidationError`. Keep `validate_definition` PURE — the lookup is a gather step in the atom, not in the validator.
+- `create_workflow`/`update_draft` do NOT check (drafts may precede approval).
+- Boundary: outreach → `app.crm.connectivity.contracts` only (already imported for `queue_message`).
+
+## Red tests
+- `tests/crm/test_workflow_plans.py`: monkeypatch `template_status` → None / "pending" / "approved"; `_publish_in_txn` (with monkeypatched accessor) raises with the right message for the first two and publishes for the third; a plan with no send nodes never calls it.
+- Connectivity: `templates_by_name_query` is merchant-first and parameterised.
+
+## Acceptance
+- Suite green; boundary clean (contract import only).
+
+## Decisions already made
+- Refuse, don't warn: an unapproved template on a LIVE plan is a guaranteed blocked send.
+- Language ambiguity (approved in two languages) is refused here exactly as `approved_template` refuses it at send time — same rule, earlier.
+
+## Out of scope
+- Variable-shape validation against `components` (backlog).

--- a/docs/crm/workflow-rollout/09-runs-reporting.md
+++ b/docs/crm/workflow-rollout/09-runs-reporting.md
@@ -1,0 +1,23 @@
+# Phase 09 — Runs reporting (G9)
+
+**Kind**: feat · **PR title**: `feat(crm): workflow run summary and journey read — counts by exit reason, time per node` · **Depends on**: 06; **coordinate with PR #1053** (`feat(crm): per-workflow run counts, trigger and updated_by column`, sharifajahanshaik) — if merged, extend its counts rather than duplicating; if open, build on `release` and note the overlap in the PR. · **Notes**: §13 verdict (A + reporting view), §16.3 G9
+
+## Why
+With the loan funnel running as per-stage clocks, "where do customers drop" is a join across plans. Boards (later) answer it from one run. Either way the read belongs to outreach and is missing.
+
+## Design
+- `GET /crm/workflows/{id}/summary?merchant_id&since&until` → `{runs: n, by_exit_reason: {...}, open: {waiting: n, parked: n}, median_minutes_to_exit}`. One query builder (`workflow_summary_query`) with `GROUP BY exit_reason`; merchant-first; window on `entered_at`.
+- `GET /crm/customers/{customer_id}/runs?merchant_id` → the customer's runs across ALL plans ordered by `entered_at` (`customer_runs_query`; index `crm_workflow_enrollment_customer_ix` exists). This is the loan funnel's journey view under Option A.
+- Recovered revenue: at goal-cancel time (phase 06 `cancel_open_runs`), stash `context.goal = {topic, event_id, amount}` where `amount` is `payload.total_price` / `payload.amount` if scalar — done in `entry.py` before calling cancel (pass a `context_patch` to `cancel_open_runs_query`: `context = context || $8::jsonb`). Summary adds `recovered_amount = sum((context->'goal'->>'amount')::numeric)` for `goal_met` rows.
+- Schemas: `WorkflowSummary` name is taken (list shape) — call it `WorkflowRunSummary`; add `CustomerRun` (a thin `EnrollmentRun` with `workflow_name`).
+
+## Red tests
+- Query builders: merchant-first, `$1` params, window predicates present, GROUP BY exit_reason.
+- `entry.py`: goal cancel passes a `goal` patch with the amount when present, none when absent (monkeypatched accessor).
+
+## Acceptance
+- Routes admin-only (`crm_admin_user`), `set_log_context` on each. Suite green; boundary clean.
+- Runbooks (phase 07) gain a "how to read the summary" section.
+
+## Out of scope
+- Console UI. Cross-merchant/platform totals.

--- a/docs/crm/workflow-rollout/10-adr-version-pinning.md
+++ b/docs/crm/workflow-rollout/10-adr-version-pinning.md
@@ -1,0 +1,22 @@
+# Phase 10 — ADR: version pinning for in-flight runs
+
+**Kind**: docs · **PR title**: `docs(crm): ADR — runs execute the definition version they entered under` · **Depends on**: nothing; **blocks 11–17** · **Notes**: §14.4, §14.5, §14.7, §15.3
+
+## Why
+Canon T19 / migration 057 says: one live `definition`; publish replaces it in place; every run not yet past the change follows the new document; `version` is "an AUDIT stamp, never an execution pin"; safety = the publish validator blocks stranding edits. That fits runs of minutes. For runs of weeks (loan onboarding) there is always someone on nearly every node, so most meaningful edits are refused and the only exits are archive-and-eject or a second plan. Every enterprise journey engine (Braze Canvas, SFMC Journey Builder, Temporal for code) pins in-flight runs to the version they entered under and lets new entrants take the new one. This ADR reverses the 057 sentence and makes "edits reach everyone" an opt-in mode.
+
+## Deliverable
+`docs/crm/adr/0022-version-pinning.md` (the corpus numbers ADRs 0001–0021; 0022 is the next; Swaroop mirrors it into the corpus site). Sections:
+1. **Context** — the T19 choice, why it was right for 30-minute runs, the loan-funnel failure (cite §14.5).
+2. **Decision** — (a) every enrollment executes the definition version recorded in `workflow_version` at entry; (b) publish creates a new immutable version row, never mutates a version a run references; (c) a plan declares `on_publish: "pin"` (default) or `"migrate"`; `migrate` re-pins every open run to the new version inside the publish atom and is allowed only when the existing stranding validator passes (occupied nodes kept, entry unchanged) — i.e. today's semantics become a mode; (d) the entry consumer evaluates ENTRIES against the latest version and GOALS/LISTENING against each open run's pinned version; (e) old versions are retained while any non-exited run references them, then swept; (f) a template (call or channel) named by a retained version may not be retired while runs reference it — refuse with the count.
+3. **Consequences** — storage (`crm_workflow_version`), walker read path + cache, entry consumer redesign (iterate open runs), drain/migrate-forward tooling, the occupied-node/entry guards demoted to `migrate`-mode preconditions, canon text changes: 057's comment (cannot edit a merged migration — the ADR supersedes it), T19 §edits, T20 col `workflow_version` becomes "execution pin".
+4. **Alternatives rejected** — keep blocking (loan board impossible); per-node versioning (too fine); copy-on-publish into each run's context (bloats every row, breaks "one document").
+5. **Rollout** — phases 11–14 in this folder; no behaviour change until 12 lands; existing plans get `on_publish: migrate` semantics? **Decision: existing plans default to `pin`** — there are no long-running production plans yet; state it.
+
+## Acceptance
+- ADR merged; `docs/crm/building-modules.md` law list gains one line under law 10/11 area: "Runs execute their pinned version (ADR 0022); `migrate` is the opt-in". `docs/crm/migrations.md` ownership table gains the planned `crm_workflow_version` (owner outreach) marked "phase 11".
+- No code.
+
+## Decisions already made
+- Default is `pin`. Migrate is opt-in and validator-gated.
+- Version rows are immutable; a "fix a typo for everyone" on a pinned plan is a new version + migrate-forward (phase 14), never an in-place edit.

--- a/docs/crm/workflow-rollout/11-version-storage-and-on-publish.md
+++ b/docs/crm/workflow-rollout/11-version-storage-and-on-publish.md
@@ -1,0 +1,41 @@
+# Phase 11 — Version storage + `on_publish` word
+
+**Kind**: feat + migration · **PR title**: `feat(crm): crm_workflow_version — publish writes an immutable version row; on_publish pin|migrate` · **Depends on**: 10 · **Notes**: §15.1 Phase 2, §15.3
+
+## Design
+### Migration `NNN_create_crm_workflow_version.sql`
+```sql
+CREATE TABLE crm_workflow_version (
+    id           uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    merchant_id  text NOT NULL,
+    workflow_id  uuid NOT NULL,
+    version      integer NOT NULL,
+    definition   jsonb NOT NULL,
+    on_publish   text NOT NULL DEFAULT 'pin' CHECK (on_publish IN ('pin','migrate')),
+    published_by text,
+    published_at timestamptz NOT NULL DEFAULT now(),
+    FOREIGN KEY (merchant_id, workflow_id) REFERENCES crm_workflow (merchant_id, id)
+);
+CREATE UNIQUE INDEX crm_workflow_version_uq ON crm_workflow_version (merchant_id, workflow_id, version);
+```
+- Immutability trigger: refuse UPDATE of `definition`/`version` (copy the 051 pattern). No DELETE grant changes (one role) — the retention sweep (phase 14) deletes only unreferenced versions.
+- Backfill in the same migration: `INSERT … SELECT merchant_id, id, version, definition FROM crm_workflow WHERE definition IS NOT NULL` so every existing live plan has its current version row.
+- `TABLE_OWNERS["crm_workflow_version"] = "outreach"`; `docs/crm/migrations.md` entry.
+### Vocabulary
+- `WorkflowDefinition.on_publish: Literal["pin","migrate"] = "pin"` (schemas.py). Validator: when `migrate`, the existing stranding checks apply (they already run when `occupied_nodes`/`live_entry` are passed); when `pin`, **skip** the occupied-node and entry-change refusals (the new version cannot strand anyone).
+### Publish atom (`plans.py::_publish_in_txn`)
+- After validation: `apply_publish` (copies draft→definition, bumps version — unchanged) then `accessor.insert_version(txn, merchant, workflow_id, published.version, published.definition, on_publish, created_by)`; if `migrate`, `accessor.repin_open_runs(txn, merchant, workflow_id, published.version)` → `UPDATE crm_workflow_enrollment SET workflow_version=$3 WHERE merchant_id=$1 AND workflow_id=$2 AND status<>'exited'`. All in the one atom (docstring `ATOMIC: version row + repin share the publish's fate`).
+- `published_by`: thread `current_user.email` from `api.py` into `publish_workflow(merchant, id, published_by)`.
+### Reads
+- `accessor.get_definition(merchant, workflow_id, version) -> Optional[Dict]` (single statement, self-scoped) — used by phase 12. Not wired to the walker yet.
+
+## Red tests
+- Migration numbering guard; `TABLE_OWNERS` completeness (rule 6 test exists: `tests/crm/test_check_boundaries.py`).
+- Queries: `insert_version_query` merchant-first; `repin_open_runs_query` has `status <> 'exited'`.
+- Plans: `pin` + occupied node removed → publishes; `migrate` + occupied node removed → refused; monkeypatched accessor asserts `repin_open_runs` called only for `migrate`.
+
+## Acceptance
+- Suite green; boundary clean; migration applies; existing behaviour for `migrate` plans identical to today except the version row.
+
+## Out of scope
+- Walker reading versions (12). Consumer (13). Ops (14).

--- a/docs/crm/workflow-rollout/12-walker-pinned-definition.md
+++ b/docs/crm/workflow-rollout/12-walker-pinned-definition.md
@@ -1,0 +1,19 @@
+# Phase 12 — Walker reads the pinned definition
+
+**Kind**: feat · **PR title**: `feat(crm): the walker executes the version a run entered under` · **Depends on**: 11 · **Notes**: §14.7 costs, §15.3
+
+## Design
+- `walker.py::walk_run`: replace `accessor.get_workflow(...)` + `workflow.definition` with: `workflow = accessor.get_workflow(...)` (still needed for `status` archived/paused) and `definition_doc = await _definition_for(run)` → `accessor.get_definition(run.merchant_id, str(run.workflow_id), run.workflow_version)`; `None` → `NodeParked(f"definition v{run.workflow_version} missing")` (honest park; phase 14's retention must never delete a referenced version).
+- Cache: a small in-process LRU keyed `(workflow_id, version)` in `walker.py` (versions are immutable, so the cache never invalidates; bound it, e.g. 512 entries). Pure dict + OrderedDict; no new dependency.
+- `enrol.py`: `workflow.version` already stamped into `workflow_version` at insert — verify it is the version whose `definition` was validated (it is: `enrol` reads `workflow.definition` of the row it was handed; after phase 11 the live row's `version` == latest version row).
+- `plans.set_status("archived")` behaviour unchanged (walker ejects on next claim).
+
+## Red tests
+- `tests/crm/test_workflow_walker.py`: monkeypatch `get_definition` to return v3 for a run with `workflow_version=3` while `get_workflow` returns a row whose `definition` is v4 with a different node set → the walker acts on v3 (asserts the node executed is from v3); missing version → `park_run` called with "missing".
+- Cache: second call with the same key does not hit the accessor.
+
+## Acceptance
+- Suite green; boundary clean; the runbooks note "runs finish on the version they entered under".
+
+## Out of scope
+- Goals/listening per version (13).

--- a/docs/crm/workflow-rollout/13-consumer-per-run-version.md
+++ b/docs/crm/workflow-rollout/13-consumer-per-run-version.md
@@ -1,0 +1,25 @@
+# Phase 13 — Entry consumer evaluates per-run versions
+
+**Kind**: feat · **PR title**: `feat(crm): entries match the latest version; goals and listening match each open run's version` · **Depends on**: 12 · **Notes**: §14.7 (entry consumer redesign), §15.3
+
+## Why
+`entry.py::consume_attributed_event` loads the merchant's LIVE plans once and evaluates entry, goal and listening from the same (latest) document. With pinning, a run on v3 must be cancelled by v3's goals and woken by v3's `wait_event` topics, even after v5 changed them.
+
+## Design
+- New accessor `open_runs_for_customer(merchant, customer) -> List[EnrollmentRun]` (index `crm_workflow_enrollment_customer_ix`; `status <> 'exited'`).
+- Consumer shape becomes two passes:
+  1. **Per open run** (goals + listening): for each open run, `definition = get_definition(run.workflow_id, run.workflow_version)` (reuse the walker's cache — move the cache into a small `outreach/definitions.py` concern used by both walker and entry; it is logic, not db); evaluate goal tiers (phase 06) and `wait_event` listening against THAT definition; `cancel_open_runs`/`resume_run_on_event` are already scoped by `(merchant, workflow, customer[, node])` — add `AND id = $n` variants or pass the run id so a v3 goal never touches a sibling run on v5 (`cancel_run_query(run_id, reason, occurred_at, key)`; `resume_run_query` by run id).
+  2. **Entries**: latest live plans as today (`live_workflows`), unchanged; keyed by the latest `entry`.
+- Ordering law kept: goals first, then replies, then entries (docstring explains why).
+- `apply_repeat` (#1041) also needs the run's version's `entry` words, not the latest: pass the run's definition.
+
+## Red tests
+- `tests/crm/test_workflow_entry.py`: two open runs on v3 and v5 with different goal topics; an event matching only v3's goal cancels only the v3 run (monkeypatched accessors record ids); listening likewise; entries still use v5.
+- Query builders: `cancel_run_query`/`resume_run_by_id_query` carry `id = $` and merchant-first.
+
+## Acceptance
+- Suite green; boundary clean (`definitions.py` imports only the module's db door).
+- `context/reading-notes.md` §15.3 sentence "one consumer with two reads" now true in code — cite the file.
+
+## Out of scope
+- Drain tooling (14).

--- a/docs/crm/workflow-rollout/14-version-ops.md
+++ b/docs/crm/workflow-rollout/14-version-ops.md
@@ -1,0 +1,20 @@
+# Phase 14 — Version operations: migrate-forward, retention, template guard
+
+**Kind**: feat · **PR title**: `feat(crm): version drain — migrate-forward endpoint, unreferenced-version sweep, template retirement guard` · **Depends on**: 13 · **Notes**: §14.7, §15.1 Phase 2 tooling
+
+## Design
+1. **Migrate-forward**: `POST /crm/workflows/{id}/versions/{from}/migrate?merchant_id&to=<version>` (admin). Atom `_migrate_forward_in_txn`: load both definitions; refuse unless every node occupied by runs on `from` exists in `to` AND `to.entry` equals `from.entry` (model_dump compare; phase 01) — the stranding validator reused as a pure function `validate_migration(from_doc, to_doc, occupied_nodes) -> problems`; then `UPDATE … SET workflow_version=$to WHERE workflow_id AND workflow_version=$from AND status<>'exited' RETURNING id`. Returns the count. This is how a typo fix reaches pinned runs.
+2. **Retention**: on the walker pod's hourly housekeeping (`outreach/workers.py` beside `run_retention_sweep_tick`) add `sweep_unreferenced_versions_tick`: `DELETE FROM crm_workflow_version v WHERE v.version < (SELECT version FROM crm_workflow w WHERE w.id=v.workflow_id) AND NOT EXISTS (SELECT 1 FROM crm_workflow_enrollment e WHERE e.workflow_id=v.workflow_id AND e.workflow_version=v.version AND e.status<>'exited') AND v.published_at < now() - CRM_VERSION_RETENTION_DAYS` (new static config, default 30). Never the latest version. Batched.
+3. **Template retirement guard**: connectivity `templates.retire(...)` must refuse when a non-exited run's pinned definition names the template on a send node. Boundary: connectivity may not read outreach tables; add outreach contract `runs_referencing_template(merchant, channel, name) -> int` (query joins enrollment → version → `definition->'nodes'` with `jsonb_path_exists`; index later if hot) and call it from `templates.retire` via `app.crm.outreach.contracts`. **Cycle check**: outreach already imports connectivity contracts (`queue_message`); connectivity importing outreach contracts closes a cycle at import time. Resolution (decision): register the guard through a small hook in connectivity (`templates.register_retire_guard(fn)`) filled by `app/crm/worker_main.py`/`app/main.py` composition root — the same inversion as `record/consumers.py` (rule 12 precedent). The same for buddy call templates is out of scope (buddy's template deletion path is legacy).
+4. `GET /crm/workflows/{id}/versions?merchant_id` → list `{version, on_publish, published_by, published_at, open_runs}` (coordinate with #1053's counts).
+
+## Red tests
+- `validate_migration` pure cases (node missing → refused; entry changed → refused; ok → []).
+- Sweep SQL never deletes the latest version and only unreferenced ones (string assertions on both predicates).
+- Retire guard: hook registered and count ≥1 → retire refused with the count; hook registered and count 0 → retire proceeds; **no hook registered → retire refuses and logs an error** (fail closed: a missing registration is a wiring bug, not permission to delete). `app/main.py` and `worker_main.py` must register it. Test all three.
+
+## Acceptance
+- Suite green; boundary clean (hook registration, no direct cross import); config documented in `app/core/config/static.py` beside `CRM_RUN_RETENTION_DAYS`.
+
+## Out of scope
+- UI for versions. Buddy template deletion guard (backlog).

--- a/docs/crm/workflow-rollout/15-topic-branching-and-multi-entry.md
+++ b/docs/crm/workflow-rollout/15-topic-branching-and-multi-entry.md
@@ -1,0 +1,23 @@
+# Phase 15 — Topic branching, multi-topic entry, reply clearing
+
+**Kind**: feat · **PR title**: `feat(crm): wait_event branches on $topic; entry as a list of {topic, start}; replies cleared on advance` · **Depends on**: 01, 13 · **Notes**: §13 Option B blockers, §14.1 prerequisites (1), (2), (4), §16.2
+
+## Design
+1. **`key: "$topic"`** on a `wait_event` node: in `entry.py`'s listening loop, `answer = event.topic if node.key == "$topic" else event.payload.get(node.key)`. Validator: `$topic` is the only `$`-word; any other `$…` is refused. `pick_next` unchanged (the edge `on` equals the topic string). Docs in `schemas.WorkflowNode`.
+2. **Entry as a list**: `WorkflowDefinition.entry: Union[WorkflowEntry, List[WorkflowEntryAt]]` where `WorkflowEntryAt = WorkflowEntry + start: str`. Normalise in a `model_validator(mode="before")` to a list internally (`entries`), keeping `entry` accepted; single-entry plans get `start = nodes[0].id`. Validator: every `start` names a node; topics unique across entries; the shared words (`reenter`, `cooldown_hours`, `key`, `on_repeat`, `debounce_minutes`) may be given at the definition top level as defaults and overridden per entry.
+   - `enrol.py`: `enrol(..., start_node)`; `_first_wake` uses the start node; `insert_enrollment` with `current_node=start`.
+   - `entry.py`: `entry_matches` becomes `(flow, definition, entry_at)`; `_enrollment_key` reads `entry_at.key`.
+   - `apply_repeat` (#1041) uses the matched entry's words and patches the run standing on **that entry's start node** (today hard-coded `nodes[0].id`).
+   - Publish guard (`migrate` mode only, phase 11): "entry unchanged" compares the list.
+3. **Clear reply keys on advance**: `walker._advance` — when moving OFF a `wait_event` node, delete `reply_<node.id>` from the context written by `advance_run`/`exit_run` so a later revisit of the same node (allowed once entries can start anywhere) cannot resolve on a stale answer. Pure helper `without_reply(context, node_id)` in `nodes.py` beside `run_facts`.
+
+## Red tests
+- Schema: `entry` object and list both validate; list with a bad `start` refused; `key: "$other"` refused; `$topic` accepted.
+- Entry: `$topic` node → `resume_run_on_event` receives `{reply_x: "<topic>"}`; list entry → enrol called with the right `start` per topic.
+- Walker: after advancing past `ask`, the written context has no `reply_ask`.
+
+## Acceptance
+- Suite green; boundary clean; `docs/crm/plans/` examples still validate (phase 07 test).
+
+## Out of scope
+- Facts on resume (16). Ladder sugar (17).

--- a/docs/crm/workflow-rollout/16-facts-on-resume-and-stage-facts.md
+++ b/docs/crm/workflow-rollout/16-facts-on-resume-and-stage-facts.md
@@ -1,0 +1,20 @@
+# Phase 16 — Facts on resume, stage facts, parked runs movable, restart-on-repeat anywhere
+
+**Kind**: feat · **PR title**: `feat(crm): events carry facts into the run; current node rides to templates; parked runs move; any node can re-arm on a repeat` · **Depends on**: 00, 15 · **Notes**: §14.1 prerequisite (3), §14.7 objections #2/#3, §16.2 (`current_stage`, `restart_on_repeat`), §16.3 G8
+
+## Design
+1. **Facts on resume, namespaced**: `resume_run_on_event_query` merges `{reply_<node>: answer, "facts": {"<node>": <scalar payload facts>}}` — nested under `facts.<node>` (`context || jsonb_build_object('facts', COALESCE(context->'facts','{}') || $x)`) so stage payloads never collide. `nodes.run_facts` flattens for templates: top-level facts first, then `facts.<current_node>`'s keys override (the most recent stage wins for the call), and exposes `facts_<node>_<key>` for explicit access. `facts` is bookkeeping (`_BOOKKEEPING_KEYS`).
+2. **`current_node` / `current_stage`**: `run_facts` adds `current_node` (the run's node id) and, when the definition came from a `stages` ladder (phase 17) or the node carries a `stage` label (new optional `WorkflowNode.stage: Optional[str]`), `current_stage`. The call node passes it in the lead payload so one template can say "you stopped at {current_stage}". Test pins both keys.
+3. **Parked runs movable by events**: `resume_run_on_event_query` and `cancel_open_runs_query` accept `status IN ('waiting','parked')` (cancel already does); a resumed parked run becomes `waiting` with `attempts=0` (the human's "resume" semantics, now event-driven). Docstring: "an event is evidence the customer moved; a parked run that hears it is no longer stuck on the thing that parked it".
+4. **Restart-on-repeat anywhere** (#1041 generalised): `patch_open_run_query` drops the `current_node = <entry start>` restriction when the definition sets `restart_on_repeat: true` on the entry (new word) — then a repeat of the current node's OWN stage topic (the entry topic that started the run, or for ladder nodes the stage's topic) re-arms `wake_at = GREATEST(wake_at, now()+debounce)` and merges facts. Validator: `restart_on_repeat` requires `debounce_minutes > 0`.
+
+## Red tests
+- Queries: facts nested under `facts`; parked included in resume; patch query has/hasn't the node restriction per flag.
+- `run_facts`: precedence (facts of current node override top-level), bookkeeping excluded, `current_node` present.
+- Walker/entry (monkeypatched): a parked run receiving a listened event is resumed.
+
+## Acceptance
+- Suite green; boundary clean; §16.3 G8 → done.
+
+## Out of scope
+- Ladder expansion (17). List-shaped facts (G4, backlog).

--- a/docs/crm/workflow-rollout/17-stages-ladder-and-funnel-migration.md
+++ b/docs/crm/workflow-rollout/17-stages-ladder-and-funnel-migration.md
@@ -1,0 +1,19 @@
+# Phase 17 — `stages` ladder sugar + loan funnel migration to one board
+
+**Kind**: feat + docs · **PR title**: `feat(crm): stages ladder — an ordered funnel expands into the wait_event board; loan-dropoff becomes one pinned plan` · **Depends on**: 14, 15, 16 · **Notes**: §14.1, §16.2, §15.1 Phase 3
+
+## Design
+1. **Sugar**: `WorkflowDefinition.stages: Optional[Stages]` with `Stages = {order: [topic…] (≥2), idle_minutes, on_idle: {type: call|send, …}, after_action_minutes, restart_on_repeat: bool, overrides: {topic: {idle_minutes?, on_idle?, after_action_minutes?}}}`. A document with `stages` MUST NOT also carry `nodes`/`edges`/`entry` (validator refuses); the expander produces them.
+2. **Expander** (`outreach/ladder.py`, PURE: `expand_stages(definition) -> WorkflowDefinition`): for stage i with topic T_i: node `at-<slug>` = `wait_event(key="$topic", topics=[T_{i+1}…T_n], minutes=idle, stage=T_i)`; `act-<slug>` = the `on_idle` node; `after-<slug>` = `wait_event(same downstream, minutes=after_action_minutes, stage=T_i)`; edges: `at→at-j` labelled `T_j` for every j>i, `at→act` labelled `timeout`, `act→after`, `after→at-j` labelled `T_j`, no edge out of `after` on timeout (→ `completed`). The LAST stage's `at-` is a plain `wait` (nothing downstream to listen for) → `act` → end. `entry` = `[{topic: T_i, start: at-<slug>} …]` with the definition's shared words. Goals untouched (the author writes them).
+3. **Where expansion runs**: at `create_workflow`/`update_draft`/`publish` — store BOTH: `definition.stages` (the author's intent) and the expanded `nodes/edges/entry` (what the walker reads). Decision: expand on validate and store the expanded document with `stages` retained alongside, so the walker never learns about ladders and the console can re-edit the ladder. Re-expansion on every draft save is idempotent (node ids derive from topics).
+4. **Loan funnel migration**: replace `docs/crm/plans/loan-dropoff/*.json` with one `loan-dropoff.json` (§16.2, `on_publish: pin`, `key: application_id`); runbook: publish the board, pause the five clocks, let their open runs finish (≤ 1 day), archive them. The phase-07 CI test validates the new document and asserts the expansion's edge set equals the computed downstream set (the "one missing arrow = a wrong call" guard).
+
+## Red tests
+- Expander: for 3 stages, exact node ids, edge labels, and that every `at-`/`after-` node lists ALL downstream topics; overrides apply; last stage is a plain wait; `stages` + `nodes` together refused.
+- Idempotence: expanding twice yields the same document.
+
+## Acceptance
+- Suite green; boundary clean; runbook updated; §13/§14 "verdict" rows updated to "loan funnel is a board as of phase 17".
+
+## Out of scope
+- Console. Outcome branches after the call (18).

--- a/docs/crm/workflow-rollout/18-outcome-feedback.md
+++ b/docs/crm/workflow-rollout/18-outcome-feedback.md
@@ -1,0 +1,20 @@
+# Phase 18 — Outcome feedback into runs (G2, G3)
+
+**Kind**: feat · **PR title**: `feat(crm): message and call outcomes reach the run — fallback branches and STOP handling` · **Depends on**: 15; **PRs #1040 (WhatsApp webhooks → spine) and #1052 (WhatsApp extractor) merged** — if not, build the call half only and note it. · **Notes**: §16.3 G2/G3, §3 (record consumers), `app/ai/voice/agents/breeze_buddy/crm_mirror.py` (call.attempted/completed already mirrored with `customer_id`)
+
+## Design
+1. **Call outcomes**: `call.completed` letters already carry `customer_id` and the lead's `outcome`; the lead carries `enrollment_id` (059). Make the outcome addressable by the run: the mirror payload (buddy side, `crm_mirror.py` MIRRORS row for `call.completed`) includes `enrollment_id` and `outcome`; a `wait_event(topics=["call.completed"], key="outcome")` after a `call` node branches on it (`on: "no_answer" → retry`, `on: "connected" → …`). Because the consumer resolves listening per customer (phase 13), add an optional `WorkflowNode.match: {"payload": "enrollment_id", "run": "id"}` so only THIS run's call resumes it (a customer can have two runs). Generic: `match` compares a payload field with a run field, reusing the goal-key predicate from phase 06.
+2. **Message outcomes**: delivery receipts arrive via #1040 as spine letters (align the topic name to `connectivity/topics.py`; they carry `provider_message_id`). The dispatcher stamped `provider_message_id` on `crm_message`, and `crm_message.source_id` is the run id for workflow sends, so the mapping wamid → (run id, message id) exists. Add a connectivity contract `message_for_provider_id(merchant, provider_message_id) -> Optional[(source_id, message_id)]`. In the outreach consumer's listening loop, when a listened topic is a receipt topic, resolve the pair through that contract and inject `message_id` as a synthetic payload field before matching. Then a node such as `wait_event(topics=["message.status"], key="status", match={"payload": "message_id", "run": "message_<node>"})` resumes only the run that queued that message.
+3. **STOP → suppression (G3)**: inbound WhatsApp letters (#1052 extractor) with body matching a STOP vocabulary (`app/crm/platform/stop_words.py`, in code) → a new record consumer in platform: `record_suppression(kind=phone, value, channel="whatsapp", reason="user_request", source="whatsapp_inbound", evidence_ref=event.id)`; registered in `worker_main.py` (rule 12). Fail closed on unparseable phone (skip with error log). Also cancel the customer's open runs with `exit_reason: withdrawn` (outreach consumer, listening on the same topic).
+
+## Red tests
+- Buddy mirror payload includes `enrollment_id`/`outcome` (tests/crm/test_crm_mirror.py).
+- `match` predicate in `resume_run_on_event_query` and in the entry loop; a run without a matching field is not resumed.
+- STOP consumer: "STOP", "stop ", "unsubscribe" → `record_suppression` called with E.164; garbage → not called.
+
+## Acceptance
+- Suite green; boundary clean (platform imports record contracts; outreach → connectivity contracts; buddy → crm contracts only).
+- Cart runbook gains the fallback pattern (`call.completed` no_answer → send WA).
+
+## Out of scope
+- Email/SMS channels. Retry ladders as sugar.

--- a/docs/crm/workflow-rollout/19-gate-wiring.md
+++ b/docs/crm/workflow-rollout/19-gate-wiring.md
@@ -1,0 +1,19 @@
+# Phase 19 — Permission-gate wiring (G1)
+
+**Kind**: feat · **PR title**: `feat(crm): dispatch gate calls may_contact — consent, purpose, quiet hours, frequency` · **Depends on**: **PR #1021 merged** (`feat(crm): consent ledger, resolved state, and decision log`, rab1prasad) — the permission module and its `may_contact()` contract. If #1021 is not merged, stop; this phase is the call-site wiring, not the module. · **Notes**: §6 dispatch `_gate` TODO, §16.3 G1, design/gate-mechanics in the corpus
+
+## Design
+- `app/crm/connectivity/dispatch.py::_gate`: keep suppression as check #1 (fail closed, unchanged); then `decision = await may_contact(merchant_id, customer_id, channel, purpose_key, address)` from `app.crm.permission.contracts` (name per #1021). Decision shape (per canon): allow | refuse(reason) | defer(next_allowed_at). Refuse → `blocked` with the permission reason (add the words to `reasons.py`: `REASON_NO_CONSENT`, `REASON_PURPOSE_NOT_GRANTED`, `REASON_FREQUENCY_CAP`); defer → **requeue** with `next_attempt_at = next_allowed_at` (new `apply_outcome` path: status `queued`, reason `quiet_hours`, `retry_after_seconds` computed from the deadline; T16 col 22 says the gate's deferral writes `next_attempt_at`). `mint_send_token` carries `decision_id` onto the row (`crm_message.decision_id` exists, unused).
+- Same wait_for deadline as the suppression probe; timeout/raise → `gate_unavailable` (fail closed).
+- Frequency caps across plans: whatever #1021 exposes; if it does not, add a connectivity-side count (`messages_sent_since(merchant, customer, channel, since)`) and a per-merchant cap config as the interim — decision: implement the interim only if #1021 lacks it, and say so.
+
+## Red tests
+- `plan_for_outcome`/dispatch: deferred decision → queued row with `next_attempt_at` from the deadline and `reason=quiet_hours`; refused → blocked with the permission word; `decision_id` stamped.
+- Gate still fails closed on unknown channel and on probe timeout (existing tests kept).
+
+## Acceptance
+- Suite green; boundary clean (connectivity → permission contracts only).
+- Cart runbook: consent prerequisites for `marketing.*` purposes.
+
+## Out of scope
+- The consent ledger itself. Send-time optimisation.

--- a/docs/crm/workflow-rollout/99-backlog.md
+++ b/docs/crm/workflow-rollout/99-backlog.md
@@ -1,0 +1,24 @@
+# 99 — Backlog (not scheduled; each needs its own phase file before work starts)
+
+From `context/reading-notes.md` §16.3 and `context/nits.md`.
+
+| Item | What | Why deferred |
+|---|---|---|
+| G4 | List-shaped facts (`line_items`) never reach templates — producer scalar summary vs fire-time letter read vs per-plan extractor (manas's open question on #1041) | Needs a ruling from Swaroop on the direction |
+| G5 | Generic nodes: `http` action (coupons, lender APIs), `condition` on a customer attribute / context fact, `split` (percentage) | Product scope; each is a NODE_TYPES entry + validator + walker test |
+| G6 | Human handoff / task node | Depends on where tasks live (assist data layer, PR #963) |
+| G10 | Dry-run / simulate a plan against a sample event | Validator + a `simulate` endpoint that walks without writing |
+| G11 | Send pacing per merchant/channel (W8 in `channels.py`) | Needed at promo-day scale, not for pilot |
+| — | Operator endpoint to re-drive quarantined events (phase 04 follow-up) | Ops convenience |
+| — | Buddy call-template deletion guard against pinned versions (phase 14 covers channel templates only) | Legacy path |
+| N1 | Type-string matching in `entry.py`/`pick_next` → NodeSpec flags | Cosmetic |
+| N2 | Global (merchant NULL) templates allowed on call nodes — confirm intent | Needs a ruling |
+| N3 | Two definitions of "goal after entry" — phase 06 unifies on `entered_event_at`; verify | Verify after 06 |
+| N5/N6/N7 | Onboarding credential-before-atom; degraded doors cannot send; template webhook consumer (#1040 lands it) | Connectivity, other owners |
+| N8–N17 | See `context/nits.md` | Hygiene |
+| P3 | Identity staple: loser's handles not present in the payload stay unreachable — check ADR 0021 intent | Identity module, needs a ruling |
+| P4 | `crm_workflow_enrollment.customer_id` has no composite FK to `crm_customer` | Migration; check canon T20 |
+| P6 | Suppression gate ignores channel (any suppression blocks all channels) | Design question once channels multiply |
+| P7 | Run context exposes every scalar payload key via GET runs | Console/privacy review |
+| P8 | Ingest size cap reads only Content-Length | Minor |
+| — | In-call WhatsApp (`send_whatsapp` builtin) | **Dropped by decision 2026-09-02; do not re-add without a new decision** |

--- a/docs/crm/workflow-rollout/PIPELINE.md
+++ b/docs/crm/workflow-rollout/PIPELINE.md
@@ -1,0 +1,152 @@
+# The pipeline — how the 20 phases get merged, in what order, by one agent
+
+This is the operating document for the queue in `README.md`. It answers: what
+merges first, what runs in parallel, how status is tracked, and the exact
+prompts to give the agent. The person dispatching (Swaroop) merges every PR;
+the agent opens them. Update the *External PRs* table as those PRs move;
+nothing else here should need editing until a phase changes shape.
+
+## External PRs (state as of 2026-09-02)
+
+| PR | Author | What | State | Gates |
+|---|---|---|---|---|
+| #1041 `feat/crm-repeat-entries` | manas-narra | `on_repeat` + `debounce_minutes` | open, CI green; **we land it ourselves as phase 00** (cherry-pick + 5 fixes) and ask for #1041 to be closed as superseded | 00 → 07, 16 |
+| #1040 `feat/send-whatsapp-webhooks` | rab1prasad | WhatsApp webhooks → spine | open | 18 |
+| #1052 `feat/whatsapp-extractor` | rab1prasad | WhatsApp inbound extractor | open | 18 |
+| #1021 `feat/crm-permission-b1` | rab1prasad | consent ledger, decision log, `may_contact` | open | 19 |
+| #1053 `feat/crm-workflow-list-counts` | sharifajahanshaik | per-workflow run counts, updated_by | open | 09, 14 coordinate |
+| #1047 `feat/crm-event-catalog` | manas-narra | event catalog, where-grammar | open | none hard; 06/15 must not contradict its `where` grammar — read it before 06 |
+
+## Phase 00 first — we land #1041 ourselves
+
+Rather than wait for a fork branch we cannot push to, phase 00 cherry-picks
+#1041's single commit onto our branch, folds in the two guards (P9: a
+redelivered founding event never re-patches; P10: debounce only extends the
+window via `GREATEST`) and the three CodeRabbit nits, keeps manas's
+attribution in the commit, and opens our PR with a note asking a maintainer
+to close #1041 as superseded. Everything downstream that needs repeat
+entries (07's cart plan, 16) depends on phase 00 being merged, not on #1041.
+
+## One agent, resumable, merge-driven
+
+Use **one agent, one long-lived session**, not several. Reasons: waves 3 and
+4 are strictly sequential; waves 1 and 2 share `outreach/db/queries.py`,
+`entry.py`, `plans.py`, so parallel agents mostly buy rebases; decisions must
+stay consistent across twenty PRs; and you are the only merger, so the
+merge queue is the real bottleneck either way. Parallelism inside the agent
+comes from it opening every PR whose dependencies are already merged before
+it has to wait.
+
+The loop is:
+1. You paste the **kick-off prompt** (below). The agent reads the corpus,
+   then works every phase that is startable now (00, 01, 04, 10), one branch
+   and one PR each, and stops with a report listing the open PRs and what
+   they unblock.
+2. You review and merge. Then paste the **continue prompt**. The agent
+   re-checks which phases are now unblocked, works them, stops, reports.
+3. Repeat until phase 19 is merged.
+
+A phase is DONE only when its PR is merged AND `pytest tests/crm` is green on
+`release` afterwards. The PR list is the ledger — every rollout PR carries
+`(rollout NN)` in its title; `is:pr "(rollout"` in the repo search shows the
+queue's state. Phase files are never edited to say "done".
+
+## Waves (what becomes startable when)
+
+| Wave | Phases | Startable when | Shared files (the agent merges its own PRs' order, you merge serially) |
+|---|---|---|---|
+| 0 | 00 · 01 · 04 · 10 | now | 00 and 01 both touch `entry.py` — the agent opens 00 first, branches 01 from `release`, and rebases 01 after 00 merges |
+| 1 | 02 · 03 | 01 merged (02, 03); | `outreach/db/queries.py` (02, 03) |
+| 2 | 06 → then 07 · 08 · 09 | 06 after 01 and 03; 07 after 00, 02, 06; 08 and 09 after 06 | `plans.py` (06, 08), `entry.py` (06, 09) |
+| 3 | 11 → 12 → 13 → 14 | 11 after 10 merged (needs your sign-off on the ADR); each after the previous | sequential by design |
+| 4 | 15 → 16 → 17 | 15 after 13; 16 after 00 and 15; 17 after 14, 15, 16 | `schemas.py`, `entry.py`, `walker.py`, `nodes.py` — sequential |
+| 5 | 18 · 19 | 18 after 15 and #1040/#1052 merged; 19 after #1021 merged | independent |
+
+Milestones: **M1/M2** cart board publishable + loan clocks live after wave 2
+(phase 07); **M3** versioning after wave 3; **M4** loan funnel is one pinned
+board after wave 4; **M5** feedback loops + compliance after wave 5.
+
+Merge order within a wave when several PRs are open: lowest phase number
+first; ask the agent to rebase the rest (the continue prompt does that).
+
+## Review gates
+
+- Waves 0–2: a CRM maintainer review; the red tests and the boundary
+  checker are the substance. Migrations (04, 06) get a second look at the
+  `CREATE OR REPLACE` trigger amendment and the constraint name.
+- Wave 3: phase 10 (the ADR) needs Swaroop's explicit sign-off before 11
+  starts — it reverses a canon sentence (057: "never an execution pin").
+- Wave 4: phase 17's expander test ("every node lists all downstream
+  topics") is the gate.
+- Wave 5: 19 is compliance — review with #1021's author.
+
+## The kick-off prompt (paste once, at the start)
+
+> You are running the CRM workflow rollout in juspay/clairvoyance, end to
+> end, as the single implementing agent. I (Swaroop) merge every PR; you open
+> them. Work from `docs/crm/workflow-rollout/` on `origin/release`.
+>
+> First, read in this order and do not skip: `CLAUDE.md`;
+> `docs/crm/building-modules.md`; `docs/crm/migrations.md`;
+> `docs/crm/workflow-rollout/README.md`; `docs/crm/workflow-rollout/PIPELINE.md`;
+> `docs/crm/workflow-rollout/context/README.md`; then
+> `docs/crm/workflow-rollout/context/reading-notes.md` in full (it is the
+> source of truth for intent) and `context/nits.md`. Then read every phase
+> file `00`–`19` and `99-backlog.md` once, so you know the whole queue before
+> touching the first phase. Then read the current code of `app/crm/outreach`,
+> `app/crm/record`, `app/crm/shared` and `scripts/check_crm_boundaries.py`
+> against the notes and tell me in one paragraph anything that has drifted
+> since the notes were written (commits after `719d88f` on `release`).
+>
+> Then work the queue. A phase is startable when every PR in its *Depends
+> on* line is MERGED into `origin/release` (verify with the GitHub tools; an
+> open PR does not count). Work every startable phase, lowest number first,
+> each on its own branch `claude/crm-phase-NN-<slug>` from `origin/release`,
+> one commit per branch (amend as you iterate), red tests written first and
+> shown failing on `release`, the full check list from the README run unpiped
+> before pushing (`uv sync --extra dev` first; export `JWT_SECRET_KEY`,
+> `JWT_ALGORITHM`, `SKIP_KMS_DECRYPT=true`). Open a PR to `release` titled
+> exactly as the phase file's *PR title* with ` (rollout NN)` appended. The
+> body states: phase number and file, what changed, the red tests and that
+> they fail on release, anything in *Decisions already made* you disagreed
+> with (implement as written regardless), and adjacent bugs you noticed but
+> left alone. Subscribe to each PR and drive it green; address review
+> comments; never widen a phase; never edit a phase file or the context
+> notes in a rollout PR (a `docs(crm)` PR of its own if a decision must
+> change — and tell me).
+>
+> Phase 00 is special: it carries PR #1041 by cherry-pick with five fixes
+> folded in; keep manas-narra's attribution exactly as the phase file says.
+> Phase 01 touches the same file — open 00 first, then 01, and expect to
+> rebase 01 after 00 merges.
+>
+> When no phase is startable, stop and report: the open rollout PRs with
+> links, what each unblocks, and which external PRs (#1040, #1052, #1021)
+> are still gating 18/19. Do not wait or poll for merges; I will tell you to
+> continue.
+
+## The continue prompt (paste after each merge round)
+
+> Continue the CRM workflow rollout. Re-read `docs/crm/workflow-rollout/PIPELINE.md`
+> and check `origin/release` for which rollout PRs merged since your last
+> report (search PRs for "(rollout"). For every open rollout PR of yours,
+> rebase onto the new `origin/release` (`git rebase`, keep one commit,
+> `--force-with-lease`), re-run the check list, and make sure CI is green.
+> Then work every newly startable phase exactly as in the kick-off prompt,
+> lowest number first. Before starting phase 11, confirm with me that the
+> phase 10 ADR is signed off — ask, do not assume. Stop and report as before.
+
+## If something slips
+
+- A phase's design turns out wrong mid-implementation: the agent stops,
+  reports, and the phase file is corrected by you in a separate docs PR
+  before any code is pushed. Drift is what this folder exists to prevent.
+- #1021 stalls: phase 19 waits; everything else proceeds. Sends stay
+  suppression-gated only — do not put `marketing.*` purposes in front of
+  real customers without it.
+- #1040/#1052 stall: phase 18 ships the call-outcome half only (its file
+  says how).
+- #1053 merges before 09/14: the agent extends its counts instead of
+  duplicating (both phase files say so).
+- Someone else lands a migration number you planned: `check_migrations.py
+  --base origin/release` fails in CI; renumber, amend, push.

--- a/docs/crm/workflow-rollout/README.md
+++ b/docs/crm/workflow-rollout/README.md
@@ -1,0 +1,97 @@
+# CRM workflow rollout — the ordered implementation queue (20 phases 00–19 + backlog)
+
+This folder is the ordered, PR-sized backlog for taking the CRM workflow layer
+(`app/crm/outreach`, with touches in `record`, `connectivity`, `app/ai`) from
+where it is on `release` today to the two target flows:
+
+1. **Cart abandonment** (short board): checkout update → 30m → WhatsApp → 30m →
+   rescue call → 1d → close; recovered at any point ends the run.
+2. **Loan-onboarding drop-off** (long board): a customer stalls on any stage for
+   30 minutes → call; stages may be skipped; runs live for weeks; ships as
+   per-stage "clocks" first, becomes one pinned board once versioning exists.
+
+Every phase is **one PR with one commit** (CI-enforced). Phases are ordered;
+a later phase may assume every earlier phase is merged. Where a phase depends
+on someone else's open PR it says so in *Dependencies* and what to do if that
+PR has not merged yet.
+
+## Read this before picking up any phase
+
+0. `PIPELINE.md` — when #1041 merges, the waves, what runs in parallel, the
+   handoff prompt, and how status is tracked. Read it if you are the person
+   dispatching agents; agents read it too, once.
+
+1. `CLAUDE.md` and `docs/crm/building-modules.md` — the module skeleton, the
+   layer law, the atomic grammar, the twelve boundary rules. CI enforces them
+   (`scripts/check_crm_boundaries.py`); do not fight the rule, fix the code.
+2. `context/reading-notes.md` — the full read of every CRM module (sections
+   0–8), the bug/issue tally (10–11), the two flows and PR #1041 (12), the loan
+   funnel and the clocks-vs-boards decision (13–15), and the final flow shapes
+   with the remaining functional gaps G1–G12 (16). Phase files cite these
+   sections by number; **the notes are the source of truth for intent**.
+3. `context/nits.md` — N1–N21, the small things; some phases pick them up.
+4. The phase file itself, end to end, including *Out of scope* and *Decisions
+   already made*. Do not re-open a decision the file marks as made; if you
+   believe it is wrong, say so in the PR description and implement as written.
+
+## Conventions every phase follows
+
+- Branch: `claude/crm-phase-<NN>-<slug>` from `origin/release`. Target:
+  `release`. Title/commit prefix as the phase file says (`feat(crm):`,
+  `fix(crm):`, `docs(crm):`).
+- One commit. Iterate with `git commit --amend` + `git push --force-with-lease`.
+- Before pushing, unpiped so the exit code is real:
+  `uv run black . && uv run isort . --profile black && uv run autoflake --in-place --remove-all-unused-imports --remove-unused-variables --exclude "app/__init__.py,.venv/*,venv/*" -r app/ && uv run pyrefly check && uv run pytest tests/crm && uv run python scripts/check_crm_boundaries.py && uv run python scripts/check_migrations.py --base origin/release`
+  (`uv sync --extra dev` first; tests need `JWT_SECRET_KEY`, `JWT_ALGORITHM`,
+  `SKIP_KMS_DECRYPT=true` in the environment.)
+- **Every law change is a triple in one commit**: docs text + CI rule + a red
+  test proving the rule fires. Every bug fix carries a regression test that
+  fails on `release`.
+- Migrations: take the **next free number at implementation time** (other open
+  PRs — #1021 consent ledger, #1053 run counts — may take numbers first; run
+  `check_migrations.py --base`). Never edit a merged migration; amend triggers
+  with `CREATE OR REPLACE` in the new file (migration 060 is the precedent).
+  New tables need a `TABLE_OWNERS` entry in `scripts/check_crm_boundaries.py`
+  and an ownership-map entry in `docs/crm/migrations.md`.
+- Vocabulary (channels, topics, node types, policy words) lives in code dicts,
+  never in CHECKs. CHECKs on FORMAT and on closed status enums are required.
+- Fail CLOSED anywhere permission-adjacent; buddy-side mirrors fail OPEN.
+- Logs never carry a phone/email; use `app/crm/shared/redact.py`.
+- Do not widen a phase. If you find an adjacent bug, note it in the PR
+  description and leave it for its own phase (or `99-backlog.md`).
+- The PR description states: the phase number, what changed, the red test(s),
+  and any *Decisions already made* you disagreed with.
+
+## The queue
+
+| # | Phase | Kind | Depends on |
+|---|---|---|---|
+| 00 | Land repeat entries ourselves (carry #1041 + P9, P10, N18–N20) | feat + fix | — |
+| 01 | Outreach correctness fixes (B1, B3, B4) | fix | — |
+| 02 | Keyed-plan admission (B2) | fix | 01 |
+| 03 | Compare-and-set on enrollment writes (P1) | fix | 01 |
+| 04 | Event attempts + quarantine (P2) | fix + migration | — |
+| 06 | Goal tiers, goal key, occurred_at guard (G7, cart→order attribution) | feat + migration | 01, 03 |
+| 07 | Plan templates + runbooks (cart board; loan funnel as clocks) | docs + tests | 00, 01, 02, 06 |
+| 08 | Publish-time template check (G12) | feat | 06 |
+| 09 | Runs reporting (G9) | feat | 06; coordinate PR #1053 |
+| 10 | ADR: version pinning | docs | — (blocks 11) |
+| 11 | Version storage + `on_publish` word | feat + migration | 10 |
+| 12 | Walker reads the pinned definition; migrate mode | feat | 11 |
+| 13 | Entry consumer evaluates per-run versions | feat | 12 |
+| 14 | Version operations (drain/migrate-forward, retention, template guard) | feat | 13 |
+| 15 | Topic branching + multi-topic entry + reply clearing | feat | 01, 13 |
+| 16 | Facts on resume, stage facts, parked runs movable, restart-on-repeat anywhere | feat | 00, 15 |
+| 17 | `stages` ladder sugar + loan funnel migration to a board | feat + docs | 14, 15, 16 |
+| 18 | Outcome feedback into runs (G2, G3) | feat | PRs #1040/#1052 merged; 15 |
+| 19 | Permission-gate wiring (G1) | feat | PR #1021 merged |
+| 99 | Backlog (G4, G5, G6, G10, G11, remaining nits) | — | — |
+
+Phases 00–09 need no canon change. Phase 10 is the canon decision; 11–17
+build on it. 18 and 19 are gated on other people's PRs and can slide. Phase
+05 does not exist (its content became phase 00 when we decided to land
+#1041 ourselves); numbering was kept so cross-references stay stable.
+
+Deliberately NOT in the queue (decision, 2026-09-02): a `send_whatsapp`
+builtin for WhatsApp from inside a buddy call. The cart flow's WhatsApp is
+the workflow's `send` node only. Do not add it back without a new decision.

--- a/docs/crm/workflow-rollout/context/README.md
+++ b/docs/crm/workflow-rollout/context/README.md
@@ -1,0 +1,19 @@
+# context/ — everything an agent needs to know before touching a phase
+
+| File | What it is | Read when |
+|---|---|---|
+| `reading-notes.md` | The complete read-through of `app/crm` (shared, platform, identity, record, connectivity, outreach), migrations 048–061, the CI boundary guard and the workflow tests (§0–8); verification results (§9); the one-page model of the event → run → send path (§10); the tally of 4 bugs / 10 probable issues (§11); the abandoned-cart flow, the three follow-up questions and the PR #1041 review (§12); the loan-onboarding funnel and Option A (clocks) vs Option B (one board) (§13); Option B written out, the plain-language reasoning, industry practice, the version-pinning canon decision, the recommendation (§14); the end-to-end plan and what "one system" means (§15); both flows in the final vocabulary and the functional gaps G1–G12 (§16). | Always, in full, before phase 00. Then the sections each phase cites. |
+| `nits.md` | N1–N21: consistency, hygiene and doc points. Several are picked up by phases (N18–N20 in 00); the rest sit in `99-backlog.md`. | Before phase 00; skim later. |
+
+How the notes map to the queue:
+- §11 bugs B1–B4 → phases 01, 02; P1 → 03; P2 → 04; P9/P10 → 00.
+- §12 cart flow + Q2 (cart→order attribution) → 06, 07; Q1 (debounce) → 00.
+- §13/§14 loan funnel: Option A → 07 (clocks now); Option B prerequisites → 15, 16, 17; version pinning → 10–14.
+- §16.3 gaps: G1 → 19; G2/G3 → 18; G7 → 06; G8 → 16; G9 → 09; G12 → 08; G4, G5, G6, G10, G11 → 99-backlog.
+
+Vocabulary the notes use:
+- **Clock** = a small plan (one wait + one action) with runs of minutes; **board** = a multi-node journey plan with runs of days–weeks. Same engine (`crm_workflow`); the difference is document size and run length.
+- **Pin vs migrate** = whether in-flight runs keep the definition version they entered under (pin, ADR in phase 10) or follow the newest publish (migrate, today's behaviour, validator-gated).
+- **Spine** = `crm_event_raw`; **letter** = one event row; **token** = a `crm_workflow_enrollment` row; **walker** = the outreach worker that moves tokens; **gate** = the dispatcher's send-time permission check.
+
+Decisions recorded here that later agents must not reopen: the in-call WhatsApp builtin is dropped; goals have tiers with a payload key (06); `pin` is the default publish mode (10/11); the loan funnel ships as clocks first and becomes a board at phase 17.

--- a/docs/crm/workflow-rollout/context/nits.md
+++ b/docs/crm/workflow-rollout/context/nits.md
@@ -1,0 +1,31 @@
+> Nits from the app/crm + workflow read-through. Companion to crm-workflow-notes.md (bugs B1–B4, probable issues P1–P8 live there). A nit here is a consistency, hygiene, doc or ergonomics point — none changes behaviour a merchant or customer would notice on its own.
+
+## Nits (17)
+
+| # | Where | What | Suggested touch |
+|---|---|---|---|
+| N1 (W-7) | outreach/entry.py, outreach/walker.py `pick_next` | nodes.py says nothing matches a type string, but entry.py (`node.type == "wait_event"`) and pick_next (`node.type != "wait_event"`) do. | Add `listens`/`branches` flags to `NodeSpec` and ask the registry. |
+| N2 (W-10) | outreach/nodes.py `execute_call` | Templates with `merchant_id IS NULL` (global) are accepted for any merchant's call node. Probably intended for shared templates. | Confirm and state it in the docstring. |
+| N3 (W-11) | outreach/entry.py vs walker.py | Two definitions of "goal happened after entry": entry uses `entered_at < occurred_at` (NULL → cancel all), walker uses `COALESCE(occurred_at, received_at) > entered_at`. | Pick one predicate and reuse it. |
+| N4 (C-2) | migration 056 comment | Says "NOTHING validates source_kind" — queue.py's `SOURCE_KINDS` now does. Merged migrations are immutable, so this is a doc drift only. | Note it in the corpus trail / building-modules.md. |
+| N5 (C-3) | connectivity/onboarding.py | The credential is stored/rotated BEFORE the atom that may refuse (disabled door). A merchant re-running signup on a disabled door still rotates the vault row. | Move the disabled check ahead of `_store_credential` (it is already cheap via `identify()`), or accept and document. |
+| N6 (C-4) | connectivity/onboarding.py `_STATUS_FOR_HEALTH` | `authenticated` → `degraded`, and only `healthy` may send, so a WABA whose subscribe call failed cannot send at all until re-onboarded. Deliberate, but ops-visible. | Surface a "re-run subscribe" action rather than full re-onboard later. |
+| N7 (C-5) | connectivity/db/queries/template.py tail comment | Template webhook consumer (status/category/quality + crashed-submit resume) not built; templates stay `pending` and sends refuse `template_not_approved`. Documented gap. | Tracked in the corpus; nothing to do here. |
+| N8 | platform/suppression.py `_load_dict`/`_load_list` | Not total (raise on a malformed jsonb) unlike shared/decode. Fine inside a single-row atom, but inconsistent with the house rule. | Use `jsonb_object`/`jsonb_list` from shared/decode. |
+| N9 | platform/suppression.py `entry_is_live` | Only referenced from tests; the trigger is the authority. Executable documentation, but reads like dead code. | Comment says so already; optionally call it from `is_suppressed` logging or drop. |
+| N10 | identity/facts.py `_assert_facts_in_txn` | Customer not found → logs error and returns silently. Callers (event worker) cannot distinguish "wrote facts" from "no such customer". | Return a bool or raise a domain error the worker logs. |
+| N11 | identity/db/queries.py `list_customers_query` | `display_name ILIKE '%q%'` is a seq scan; docstring acknowledges pg_trgm as the follow-up. | Add the expression/trgm index when the list gets hot. |
+| N12 | outreach/nodes.py `execute_send` | On a lease-retry dedupe (queue_message returns None) it returns `{}`, so `message_<node>` is never written to context for that run. Bookkeeping only. | Look up the existing row id by dedupe_key, or accept the gap. |
+| N13 | record/api.py `within_size_limit` | Declared as a dependency AFTER `verified_caller`; since both depend on the parsed body, the order does not matter today, but the 413 fires after auth rather than before. | Put the size dep first if the intent is "cheapest refusal first". |
+| N14 | record/extractors/flat.py vs entry.py `_phone_from_payload` | Two phone-discovery paths (extractor handles + entry fallback). The fallback exists for voice mirrors that resolve before the consumer; the docstring explains it, but it is the "two searches drift" pattern the file itself warns about. | Remove the fallback once voice mirrors pass handles too. |
+| N15 | outreach/schemas.py `WorkflowEdge` | `Union[Tuple[str,str], Tuple[str,str,str]]` accepts any string as `on`; no vocabulary for labels beyond "timeout". | Fine while labels are merchant-defined; note it in the plan docs. |
+| N16 | outreach/plans.py `validate_definition` | No reachability check (orphan nodes), cycles allowed, and a wait_event without a "timeout" edge exits `completed` on timeout rather than failing validation. | Add warnings (not refusals) or document the semantics. |
+| N17 | app/crm/worker_main.py | Pool-ceiling guard is `>= 2`, but a walker visit can hold three connections transiently (claim conn released, then execute_call → lead accessor + update_lead_enrollment_id, plus queue_message). Not a hang risk since none nest, but the docstring's "two" is walker-inaccurate. | Reword the guard message per role, or leave as-is. |
+
+## Added after reviewing PR #1041 (repeat entries)
+| # | Where | What | Suggested touch |
+|---|---|---|---|
+| N18 | PR #1041 `repeat.py` `_as_number` | Accepts "nan"/"inf" strings; Postgres orders NaN above everything so a junk value always wins `refresh_max`. | `math.isfinite` guard (CodeRabbit finding, valid). |
+| N19 | PR #1041 `patch_open_run_query` accumulate branch | `jsonb_array_length(context->'repeat_items')` errors if a producer payload carried a scalar `repeat_items` key (copied by `_context_from_payload`). | Filter bookkeeping keys in `_context_from_payload`, or `CASE jsonb_typeof(...) = 'array'`. |
+| N20 | PR #1041 `entry._try_enrol` repeat call | Passes `_context_from_payload(event.payload)`, so a refreshed `phone` is not applied. Passing the full `context` would also overwrite `source_event_id`, which breaks the founding-event dedupe (P9). | Pass payload scalars + normalized `phone`, never `source_event_id`. |
+| N21 | PR #1041 tests | SQL-shape and monkeypatch tests only; the founding-event redelivery case (P9) and the earlier-alarm case (P10) are not pinned. | Add red tests for both with the fixes. |

--- a/docs/crm/workflow-rollout/context/reading-notes.md
+++ b/docs/crm/workflow-rollout/context/reading-notes.md
@@ -1,0 +1,435 @@
+> **Status note (2026-09-02)**: these notes are the discussion record behind `docs/crm/workflow-rollout/`. One item discussed here was later DROPPED by decision and is not in the queue: the in-call WhatsApp `send_whatsapp` builtin (mentioned in §12, §14.6, §16.1). Treat every mention of it as historical.
+
+> Reading notes for app/crm (all six modules) + the workflow layer (app/crm/outreach), migrations 048–061, the CI boundary guard and the workflow tests. Sections: 0 plumbing · 1 platform · 2 identity · 3 record · 4 outreach/workflow (with W-1..W-11 findings) · 5 migrations · 6 connectivity · 7 CI guard · 8 tests · 9 verification · 10 one-page model.
+
+# CRM + workflow reading notes (branch claude/crm-workflow-review-k2gko2, HEAD 719d88f)
+
+## 0. Layout / plumbing
+- `app/crm/` modules: shared, platform, identity, record, connectivity, outreach (== the workflow layer; mounted at `/crm/workflows`).
+- `app/crm/api.py` root router: identity→/customers, record.journey→/customers, record.ingest→/ingest, outreach→/workflows, connectivity→/connectors. Auth per-router, never blanket (webhook ingress needs no bearer).
+- `app/crm/auth.py`: 4 doors. `crm_admin_user` (RBAC JWT + admin), `assert_merchant_access(user, merchant_id, op)` (admin passes; "*" wildcard; merchant_id from REQUEST not token; fail closed 403), `verify_s2s_merchant` (constant-time compare vs merchants.s2s_token then JWT verify; 404 on unknown merchant so non-enumerable), `verify_s2s_caller` (branch on what the token CLAIMS: wildcard/admin → check merchant exists (404), else defer to per-merchant token compare). Load-bearing: never "try relay, fall back", since rotated per-merchant tokens still have valid sigs.
+- `app/crm/worker_main.py`: closed ROLES dict: event-worker (record.run_pass), dispatcher (connectivity claim_sends/dispatch_send, own batch dial CRM_DISPATCH_BATCH because batch×send-timeout < lease), walker (outreach claim_due_runs/walk_run). Registers `consume_attributed_event` as record consumer here (composition root; subscriber→record import direction). Refuses to start with pool ceiling < 2 (claim txn holds conn #1 for whole batch; contracts open conn #2).
+- `shared/db.py`: `DbTxn = asyncpg.Connection`, `UniqueViolation`; `crm_connection()` (no txn, single statements), `crm_transaction()`, `atomically(fn,*a)` (ParamSpec-typed; the ONLY logic entry), `savepoint(txn)` for per-row isolation in batch atoms.
+- `shared/decode.py`: TOTAL decoders `jsonb_object`, `jsonb_list`, `uuid_or_none` (never raise — a raising decoder strands a claimed batch forever). Note: driver returns jsonb as string today.
+- `shared/normalize.py`: `normalize_phone` (E.164; bare 10-digit → +91 default; 0-prefixed 11 → +91; returns None if unparseable), `normalize_email` (lower/strip; needs "@").
+- `shared/redact.py`: `mask_address(address, channel)` — channel picks the rule, unknown channel masks everything; `mask_digit_runs` for foreign text (≥7 digits).
+- `shared/worker.py`: `run_drain_loop(claim, handle, interval, batch, stop_event, name)` — claim commits already; handle is per-row post-commit hook; per-row error isolation (log+skip); jittered exp backoff capped 5s; heartbeat; full batch → no sleep.
+
+## 1. platform (platform_identity, T02) — the cross-merchant handles book
+- contracts: `ensure_identities(handles)` (best-effort upsert, never raises), `is_suppressed(handles) -> bool` (FAIL CLOSED: error → True; no channel arg — probe is `bool_or(is_suppressed)` across (kind,value) pairs, so ANY live suppression on any channel blocks), `record_suppression(kind, value, channel, reason, source, evidence_ref, until)`.
+- HANDLE_KINDS = phone/email only (igsid, shopify ids never enter the book). Normalizes before touching table; 048 CHECKs are backstop.
+- `record_suppression` atom: ensure_identity → SELECT ... FOR UPDATE → pure `_merge_entry` (suppressions[channel] = entry; log.append) → UPDATE suppressions+log. `is_suppressed` column is derived by the 048 liveness trigger, never written here.
+- `entry_is_live()` mirrors the trigger (until None/unparseable → live). NOTE: `_load_dict/_load_list` here are NOT total (raise on garbage) unlike shared/decode — acceptable since inside a single-row atom, not a batch.
+- queries: `ensure_identity_query` ON CONFLICT (kind,value) DO UPDATE last_seen_at at most once/day.
+- OBSERVATION: the resolved map is keyed by channel, but the gate probe ignores channel (is_suppressed is a single bool). A whatsapp-only STOP also blocks email/voice by construction (conservative — fine for now, flag for when channels multiply).
+
+## 2. identity (crm_customer, T05)
+- contracts: `resolve(merchant_id, handles, *, evidence="observed", source)` → customer_id; `assert_facts(merchant_id, customer_id, facts, evidence, source, confidence)`.
+- HANDLE_COLUMNS probe order (the law): phone, email, igsid, shopify_customer_id, external_ref. Partial uniques `WHERE status='active'` per (merchant_id, handle).
+- resolve: normalize (drop unparseable phone/email with len-only log; strip others) → `atomically(_resolve_in_txn)`: GATHER owners by probing each handle → DECIDE `plan_resolution` (0 owners → create; 1 → `plan_handle_writes` ladder; N → staple: survivor = oldest first_seen_at, tie lower uuid; losers → merged_away) → APPLY. UniqueViolation → retry once (index is the referee). Then `ensure_identities` best-effort.
+- Evidence: RESOLVE_EVIDENCE = declared/observed/imported; `inferred` refused. Overwrite of occupied slot only for declared/observed; imported keeps existing; 049 trigger keeps replaced value in history.
+- OBSERVATION (merge semantics): on a staple, only the INCOMING handles are written onto the survivor. A loser's other handles (e.g. its igsid) stay on the merged_away row and are no longer probe-able (probe filters status='active'). A later payload with just that igsid mints a NEW customer. The docstring says "their freed handles attach to the survivor" — code only attaches those present in the payload. Worth checking against ADR 0021 / canon.
+- OBSERVATION: `_apply_resolution` logs the loser/survivor ids (uuids, not PII) — fine.
+- facts.py: ladder declared(1.0) > observed(0.9) > imported(0.7) > inferred(0.4, cap 0.5). Claims appended to `attributes[attr]` list `{v,e,k,src,at}` only on drift vs LATEST claim. Winner = max(rank, at); materialized to display_name/primary_locale/timezone unless winner is inferred. Atom: SELECT attributes FOR UPDATE → append → UPDATE. Customer not found → logs error and returns (silent no-op, not raise).
+- api: GET /crm/customers?merchant_id&q&limit&offset (admin), GET /crm/customers/{id}?merchant_id. `q` normalized to stored form for exact match (phone/email) + ILIKE on display_name (seq scan; pg_trgm later).
+- db: only `apply_handles_query` writes handle columns (ADR 0021 lock #3). Column names come from HANDLE_COLUMNS only (asserted) so f-string is safe. `merge_customer_query` has `AND status='active'` so racing staplers converge.
+
+## 3. record (crm_event_raw T13 + crm_journey_event view V01) — the spine
+- contracts: `RawEvent`, `record_event` (buddy mirrors; fire-and-forget, returns None on failure), `get_customer_journey`, `customer_has_event(merchant, customer, topics, since)`.
+- NOT exported: `workers.run_pass/observe_processed_event` (would form cycle with outreach) — worker_main takes them directly. `consumers.py` = registry LIST filled by worker_main (`register_consumer`, idempotent).
+- api: `GET /crm/customers/{id}/journey?merchant_id&limit&before_started_at&before_id` (admin, keyset cursor on (started_at,id)); `POST /crm/ingest/events` (s2s via `verify_s2s_caller`, 1MB cap on Content-Length only, 503 on store failure = fail closed, 200 `duplicate=true` on dedupe).
+- `EventIn`: extra=forbid (smuggled customer_id → 422), str_strip_whitespace, occurred_at must be tz-aware. Dedupe UNIQUE (merchant_id, source, external_id). occurred_at clamped LEAST($7, now()).
+- Worker pass (`_pass_in_txn`): claim FOR UPDATE SKIP LOCKED (ORDER BY received_at) → per row `savepoint` → extractor (EXTRACTORS: lead-api/telephony → flat, shopify → shopify, default flat) → resolve(evidence=observed) → assert_facts (failure logged, never fails row) → consumers (entry rules) → stamp. Quarantine reasons: extractor_error, no_handle, unresolvable. resolve/assert_facts/consumers each commit on their own connection (why pool ceiling ≥ 2).
+- OBSERVATION (poison row): crm_event_raw has NO attempt counter. A consumer that raises deterministically for one row leaves it pending forever; it is re-claimed every poll (it sits at the head, ORDER BY received_at) and re-runs resolve/assert_facts each time. "Costs one row per poll" is true but it never quarantines. Compare with enrollment.attempts. Candidate improvement: attempts column or quarantine after N.
+- OBSERVATION: size guard checks only the Content-Length header; body is already parsed by FastAPI before the dep runs (EventIn is a dependency of verified_caller). Chunked bodies bypass. Minor.
+- shopify extractor: phone from customer.phone → default_address.phone → payload.phone → shipping/billing.phone; email; shopify_customer_id; name never defaulted. Normalizes itself (resolve re-normalizes — harmless).
+- `customer_has_event_query`: `COALESCE(occurred_at, received_at) > $4` on topic ANY($3) — index crm_event_raw_customer_ix (merchant, customer, occurred_at).
+- Journey view 055 reads lead_call_tracker (call arm only), direction lowercased, WHERE customer_id IS NOT NULL. Registered in TABLE_OWNERS as record.
+- Migration 051: deliberate NO partitioning (dedupe unique needs it); immutability trigger allows only processed_at/quarantine_reason/customer_id to change.
+
+## 4. outreach == THE WORKFLOW LAYER (crm_workflow T19, crm_workflow_enrollment T20; /crm/workflows)
+### Files
+- `schemas.py`: `WorkflowDefinition{entry{topic, where{}, reenter=False, cooldown_hours=24, key?}, nodes[≥1], edges[[from,to] | [from,to,on]], goal{topics[≥1]}, exits{max_age_days=7 >0}, purpose_key?}`. Node types (Literal): wait(minutes) · send(channel, template) · call(template_id) · wait_event(topics, key, minutes). nodes[0] is the start. `outgoing()` = adjacency in doc order.
+- `nodes.py`: NODE_TYPES registry {validate, execute, is_wait}. wait/wait_event: execute None, is_wait True. send → `queue_message` (connectivity contract; dedupe_key=`run:node`, source_kind="workflow", source_id=run.id, purpose_key from plan, variables=send_variables(context)). call → `create_lead_call_tracker` with deterministic lead id uuid5(`crm-workflow-lead:{run}:{node}`), status BACKLOG, TELEPHONY, meta {workflow_id, enrollment_id}, request_id = context.order_id|request_id|`wf-<run>`, then `update_lead_enrollment_id`. NodeParked = deterministic failure (park); anything else = transient (retry on lease). Context bookkeeping keys: source_event_id, phone, customer_mobile_number, lead_*/message_*/reply_* prefixes; `reporting_webhook_url` rides to lead only.
+- `plans.py`: `validate_definition(raw, occupied_nodes, live_entry)` PURE: shape (pydantic) → dup node ids → per-type validate → edge endpoints exist → wait_event edges all labelled & unique labels; other nodes ≤1 unlabelled edge → entry unchanged while runs open → no occupied node removed. Lifecycle: create (draft; validated) → update_draft (validated) → publish (`_publish_in_txn`: read, occupied_nodes, validate, `apply_publish` = definition:=draft, draft:=NULL, version+1, draft→live) → set_status(live|paused|archived; archived terminal).
+- `enrol.py`: ONLY creator of runs. `enrol(merchant, workflow, customer, context, enrollment_key)`: skip if not live; atom: source_event_used? → admission_facts (count runs, max entered_at per customer+workflow) → `_admission` PURE (runs>0 && !reenter → refuse; cooldown) → insert with current_node=nodes[0].id, wake_at=`_first_wake` (wait → now+minutes else now). UniqueViolation on open-run unique → None (normal).
+- `entry.py`: the CONSUMER `consume_attributed_event(event, customer_id, handles)`: load live flows for merchant; classify: entry match (topic + where equality), goal match, listening wait_event nodes (topic in node.topics). Order: goal-cancel (time-aware: entered_at < occurred_at; NULL occurred_at ends all) → replies (`resume_run_on_event` writes context[reply_<node>] and wake_at=now for runs standing on that node) → enrol (context = scalar payload keys ≤256 chars + source_event_id + phone from extractor handles or payload fallback; enrollment_key from entry.key payload field, refused if missing).
+- `walker.py`: `claim_due_runs` = one UPDATE (wake_at += lease, attempts+1, status waiting & due & workflow not paused, SKIP LOCKED). `walk_run`: archived/missing → exit ejected; paused/no def → snooze; `_advance`: max_age → timed_out; goal re-check via `customer_has_event(since=entered_at)` → goal_met; loop ≤10 steps: execute action node (context.update), `pick_next` (wait_event: edge `on == reply` else "timeout"; plain: first edge), None → exit completed (writes context); next is wait → `advance_run` (wake=now+minutes, attempts=0, last_error=NULL) and return; else continue. NodeParked → park; other exception → attempts ≥ CRM_WALKER_MAX_ATTEMPTS ? park : `record_run_error` with jittered exp backoff (cap 3600s).
+- `runs.py`: list_runs, resume_run (parked → waiting, wake now, attempts 0), `run_retention_sweep_tick` (DELETE exited older than CRM_RUN_RETENTION_DAYS, batched). `workers.py`: claim callable also runs the sweep every CRM_RUN_SWEEP_INTERVAL_SECONDS.
+- `api.py` (admin only, merchant_id query): POST "" create · GET "" list · GET /{id} · PUT /{id}/draft · POST /{id}/publish · POST /{id}/status · GET /{id}/runs?status · POST /{id}/runs/{run}/resume.
+- db: 21 query builders. Notables: `exit_run_query` keeps context unless given (source_event_id must survive for replay idempotency); `cancel_open_runs` hits waiting+parked; `resume_run_on_event` only `status='waiting' AND current_node=$4`; `occupied_nodes` = status<>'exited'.
+- Config knobs: CRM_WALKER_LEASE_SECONDS, CRM_WALKER_MAX_ATTEMPTS, CRM_RUN_RETENTION_DAYS, CRM_RUN_SWEEP_BATCH_SIZE, CRM_RUN_SWEEP_INTERVAL_SECONDS, CRM_WORKER_BATCH/INTERVAL/HEARTBEAT, CRM_DISPATCH_BATCH.
+
+### Workflow observations / candidate findings
+- W-1 (semantic bug, medium): a wait_event reply whose payload LACKS `node.key` is written as `{reply_<node>: None}` and wake_at=now. `pick_next` reads None → takes the "timeout" branch immediately. An event on the listened topic without the key thus ends the listening window early and mis-routes as timeout. Fix: skip the resume when answer is None (or write a sentinel and treat it as no-match).
+- W-2 (lost update race, low-medium): `advance_run` overwrites `context` and `wake_at` unconditionally. If a reply (`resume_run_on_event`) lands while the walker is mid-visit on that wait_event node's timeout path, the walker's `advance_run` clobbers the reply and the timeout branch wins. Guard: `AND context = <as-claimed>`/version column, or `WHERE wake_at = <leased value>`.
+- W-3 (500 instead of 422): `POST /{id}/status {live}` on a never-published draft violates CHECK (status='draft' OR definition NOT NULL) → asyncpg CheckViolation → 500. plans.set_status should refuse "live" without a definition (or catch and 422).
+- W-4 (footgun): admission facts are per (workflow, customer), not per enrollment_key. A keyed plan (entry.key="order_id", the WISMO case) with default `reenter=False`/`cooldown_hours=24` refuses the second order. Keyed flows silently need reenter=True + cooldown 0; validator could enforce/warn, or admission could scope to the key.
+- W-5 (validator gap): no check that a wait_event has a "timeout" edge, no reachability check (orphan nodes), cycles allowed (a stale `reply_<node>` in context makes a re-entered wait_event resolve instantly — see W-1 family). Also `live_entry` comparison is raw-dict equality: omitted defaults vs explicit defaults compare unequal → spurious "entry rule changed" on publish.
+- W-6 (docstring overclaims): `_publish_in_txn` says the occupied read "must not race a walker" but READ COMMITTED + no lock on the workflow row does not prevent a token moving onto a removed node between the read and apply_publish. Consequence is an honest park ("node X not in live definition"), so low risk.
+- W-7 (consistency nit): nodes.py says nobody matches type strings, but entry.py (`node.type == "wait_event"`) and walker.pick_next (`node.type != "wait_event"`) do. Could be a NodeSpec flag (`is_listener`/`branches`).
+- W-8 (schema): crm_workflow_enrollment.customer_id has NO composite FK to crm_customer (crm_message and crm_workflow do pin tenancy via composite FK). A wrong merchant_id could file a run against another tenant's customer. Check canon T20.
+- W-9 (context PII): `_context_from_payload` copies every scalar payload key ≤256 chars (email, name, addresses…) into `context` jsonb, which is then listed via GET runs and forwarded as send variables / lead payload. By design (template-variable bridge) but the run listing exposes it to any admin; note for the console.
+- W-10: `execute_call` allows templates with merchant_id NULL (global). Confirm intended.
+- W-11: goal-cancel in entry uses `entered_at < occurred_at`, walker re-check uses `COALESCE(occurred_at, received_at) > entered_at` — consistent for stamped events; for NULL occurred_at entry cancels ALL open runs while walker uses received_at. Fine but two definitions.
+- Idempotency story is sound: source_event_used (context->>'source_event_id', kept on exit), open-run partial unique, dedupe_key run:node on manifest, uuid5 lead id, lease via wake_at, attempts++ by claim.
+
+## 5. migrations (CRM era 048+)
+- 048 platform_identity: kind CHECK (phone,email,device), E.164/lowercase CHECKs, `is_suppressed` recomputed by BEFORE INSERT/UPDATE trigger from suppressions jsonb (until NULL or future), suppression_log append-only trigger (prefix check).
+- 049 crm_customer: partial uniques per handle WHERE status='active'; composite FK (merchant_id, merged_into_id) → same tenant; handle-history trigger appends `_handle_history` into attributes on replaced non-NULL handle. status ∈ active/merged_away/erased.
+- 051 crm_event_raw (no partition; immutability trigger). 055 journey view. 056 crm_message (status ladder CHECK; dedupe (merchant, dedupe_key) total unique; provider_message_id global unique; immutability trigger, amended in 060 so binding_id is set-once). 057 crm_workflow. 058 crm_workflow_enrollment (exit_reason adds 'completed'; open-run unique (merchant, workflow, key) WHERE status<>'exited'; due index (wake_at,id) WHERE waiting; CHECK waiting→wake_at NOT NULL, exited→exit_reason NOT NULL). 059 lead_call_tracker.enrollment_id. 060 crm_connector_installation + crm_channel_binding (composite FKs; credential_id FK RESTRICT to legacy `credentials`; binding (channel,address) global unique WHERE not retired; one primary per (merchant, channel)). 061 crm_channel_template (natural key incl. provider_account_ref; provider_template_id global partial unique; no vocab CHECKs).
+
+## 6. connectivity (crm_message T16, crm_connector_installation T11, crm_channel_binding T12, crm_channel_template T23; /crm/connectors)
+- contracts: `claim_sends/dispatch_send` (dispatcher role), `queue_message(...)` (the producer door; the walker's send node uses it), `onboard/get_installation/list_installations/disconnect`, template family `create_template_draft/submit/edit/retire/get/list_templates`. `send()` and route resolution are deliberately OFF the surface.
+- Registries (vocabulary in code): `channels.CHANNELS` {whatsapp: gate_handle_kind=phone, registers_templates=True} (unknown channel → gate fails CLOSED, registers_templates defaults True → refuse); `connectors.CONNECTORS` {whatsapp: ConnectorSpec(channel, onboarder, templates, request_model)}; `providers.ADAPTERS` (behind send.py only; rule 11). `reasons.py` one name per REASON_*; `status.py` open-set words + transition sets (INSTALLATION_USABLE = {healthy} only); `topics.py` template.* spine topics.
+- queue.py: SOURCE_KINDS (broadcast, workflow, agent, transactional), PURPOSE_ROOTS (marketing, utility, transactional, authentication); `normalize_address` by channel's gate handle kind (unparseable → ValueError, never stored); insert ON CONFLICT (merchant_id, dedupe_key) DO NOTHING → None.
+- dispatch.py: `claim_sends` = requeue stale 'sending' rows (claimed_at older than CRM_DISPATCH_STALE_MINUTES; dead if attempt ≥ max) then claim queued due rows (status→sending, attempt+1, SKIP LOCKED). `_dispatch_one`: `_gate` (suppression probe via platform `is_suppressed({kind: address})`, wait_for'd; unknown channel/timeout/raise → gate_unavailable, fail closed) → `send(mint_send_token(msg), msg)` → `plan_for_outcome` PURE (accepted / blocked terminal / failed non-retryable / dead at max / requeue with capped exp backoff + ±20% jitter) → `apply_outcome` CAS on (status='sending' AND attempt=claim generation). At-least-once by design.
+- send.py: `token_grants` identity check; `resolve_send_route` binding (named or primary, active only) → installation (usable=healthy) → approved template on channel that registers (exactly ONE approved row by name; >1 language → refuse) → vault bundle (KMS decrypt last; DB error raises → retryable, AccountError → no_credential terminal). `send()` wraps resolve+deliver in ONE wait_for(CRM_MESSAGE_SEND_TIMEOUT_SECONDS) so a stalled pool can't outlive the lease; timeout/raise → failed retryable.
+- accounts.py: single door policy (`healthy_installation`, `bundle_for`, AccountError) shared by send/templates/disconnect. Vault is legacy `credentials` table scoped by reseller_id (no merchant column) → credential NAME carries tenancy `connector:merchant:account`.
+- onboarding.py: merchant exists → `_refuse_before_spending` (disabled door / retired endpoint, via `identify()` PURE) → `spec.onboarder.gather()` (provider calls, outside any txn) → store credential (rotate by name) → atom `_onboard_in_txn`: upsert installation (WHERE status<>'disabled'), refuse retired binding, upsert binding (first pipe becomes primary; is_primary only ever raised; status→active on conflict). UniqueViolation on primary race → 400 "try again". `disconnect`: best-effort provider revoke, then atom revoke installation + pause bindings (clearing is_primary — load-bearing for the partial unique).
+- templates.py: create_draft (validated closed: channel registered + healthy installation; idempotent while draft), submit (claim draft→submitting atom → provider → record atom; failure releases claim only if provider_template_id IS NULL), edit (draft local; approved/rejected/paused → provider edit in place if `edits_in_place`, CAS on expected_status), retire (best-effort provider delete by name+hsm_id, then local 'deleted'). `approved_template()` = the send-time read. Webhook consumer (status/category/quality + crashed-submit resume) is NOT yet built (comment in db/queries/template.py).
+- providers/base.py: ports ChannelAdapter (deliver; never raises for provider answers), ConnectorOnboarder (gather/identify/revoke), TemplateProvider (submit/edit/retire/normalize_event, edits_in_place); ProviderError base → messages pass through to merchants; anything else → fixed sentence.
+- providers/meta/graph.py: single `call()` (status read first, body parsed second, throttle codes retryable, secrets never in query string, `segment()` URL-pins ids). whatsapp/: adapter (template-only sends; digits recipient; positional vs named params; refusals before the wire are 'blocked'), classify (RETRYABLE/TERMINAL/CREDENTIAL code sets), onboard (Embedded Signup: code → short token → long-lived (+expires_in → token_expires_at) → verify phone on WABA (paged) → subscribe; subscribe failure = degraded door, not refusal), templates (Meta SHOUTING → lowercase at this boundary; delete with hsm_id to avoid deleting all languages).
+- api.py: merchant-facing via `get_current_user_with_rbac` + `assert_merchant_access` (NOT crm_admin_user). Routes: POST /{connector_key}/onboard, GET /installations, GET /installations/{id}, POST /installations/{id}/disconnect, POST/GET /templates, GET/PATCH /templates/{id}, POST /templates/{id}/submit|retire. pydantic errors returned with include_input=False (signup code never echoed).
+- db: split per table (queries/accessors/decoders). All decoders TOTAL via shared/decode.
+
+### Connectivity observations
+- C-1: `_gate` probes suppression by the message's address only (not the customer's other handles) — fine, matches "STOP wrote this kind".
+- C-2: T16 comment says nothing validates source_kind — now queue.py does (SOURCE_KINDS). Migration note is stale but harmless.
+- C-3: onboarding stores credential BEFORE the atom; if the atom fails (e.g., disabled door discovered inside), the rotated credential persists — acceptable (idempotent by name), but a disabled door's token gets rotated by a merchant re-running signup. Minor.
+- C-4: `INSTALLATION_USABLE = {healthy}`; `_STATUS_FOR_HEALTH['authenticated'] = degraded`. So a WABA whose subscribe call failed cannot send at all until re-onboarded. Deliberate (docstring), but note for ops.
+- C-5: Template webhook consumer not built → templates stay 'pending' forever until it lands; sends refuse with template_not_approved. Known gap (documented).
+
+## 7. CI guard `scripts/check_crm_boundaries.py` (12 rules)
+1 table literal only in owner's db/; 2 SQL only in db/queries*; 3 asyncpg only in shared/db + db/; 4 import direction (crm↛app.ai; buddy → contracts only; app/database ↛ ai/crm; cross-module → contracts only; shared/auth/api exempt); 5 no driver calls on txn/conn in logic; 6 every crm_/platform_ CREATE TABLE in TABLE_OWNERS; 7 crm_transaction only in shared/db; 8 atomically callee named *_in_txn; 9 ATOMIC: docstring within 400 chars; 10 crm_connection never in logic; 11 provider faces: adapters/ADAPTERS ← send.py only, onboard/templates ← connectors.py only, base ← both, graph ← nowhere outside providers/; 12 record imports no subscriber module.
+- NOTE: rule 4 lets outreach import `app.database.accessor` (crm → data layer is allowed; only the reverse is banned).
+
+## 8. Workflow tests (tests/crm/test_workflow_*.py) — what's pinned
+- plans: validator laws (dup ids, unknown edge nodes, >1 plain edge, per-type needs, shape errors, exits>0, cooldown≥0, occupied node deletion, entry change with open runs, wait_event labelled/distinct edges, only wait_event labels, send needs channel + purpose_key, entry.key vocabulary).
+- nodes: Literal == NODE_TYPES keys; is_wait ⇔ execute None.
+- admission: reenter/cooldown, first wake for wait/wait_event/action, context scalar filter, phone normalization in context.
+- runs: resume SQL shape, sweep SQL, list SQL, unknown status, retry delay, bookkeeping filter, lead_request_id.
+- queries: claim lease/attempts/skip paused, insert positional, goal-cancel shape + time-aware, live read merchant-scoped, publish requires draft, park/exit guards, exit keeps context, merchant-first reads, record error, goal recheck COALESCE.
+- decoder: string jsonb.
+- NOT pinned (gaps): `pick_next` semantics (W-1), `resume_run_on_event` with missing key, `_advance` loop, `walk_run` error ladder, `consume_attributed_event` ordering, `set_status('live')` on a draft (W-3), keyed-plan admission (W-4).
+
+## 9. Verification done during the read
+- `uv run python scripts/check_crm_boundaries.py` → OK (12 rules clean).
+- `uv run pytest tests/crm` → 499 passed after `uv sync --extra dev` (pytest-asyncio was missing in the fresh container; the 121 "failures" before that were all "async def functions are not natively supported").
+- Branch `claude/crm-workflow-review-k2gko2` == `origin/release` (no diff); working tree clean. Nothing committed.
+- Repro'd with pure functions (no DB):
+  - W-1 CONFIRMED: `pick_next(wait_event, [(confirm,YES),(call,timeout)], {"reply_ask": None})` → `call` (timeout branch). entry.py writes exactly `{reply_<node>: None}` when the payload lacks `node.key`, with wake_at=now → early, wrong branch.
+  - W-4 CONFIRMED: keyed plan (`entry.key="order_id"`) with default reenter/cooldown, second order 5 min later → `(False, "reenter_disabled")`.
+  - W-5 CONFIRMED: draft `{"topic": ...}` vs live entry with explicit defaults → "entry rule changed while runs are open" although semantically identical (raw-dict comparison).
+- Not repro'd (need DB): W-2 (advance_run lost-update race), W-3 (CHECK violation → 500 on `status=live` for a never-published draft — read from 057 DDL + set_workflow_status_query), record poison-row loop.
+
+## 10. One-page mental model of the workflow layer
+```
+producer (Shopify relay / buddy mirror / POST /crm/ingest/events)
+   └─ crm_event_raw (store first, dedupe by (merchant, source, external_id))
+        └─ event-worker pass: claim → extract → resolve() → assert_facts() → CONSUMERS → stamp
+              └─ outreach.consume_attributed_event (per live plan of the merchant)
+                    ├─ goal topic  → cancel_open_runs(goal_met, time-aware)
+                    ├─ wait_event  → resume_run_on_event(context[reply_<node>], wake now)
+                    └─ entry topic → enrol(): source_event_used? admission(reenter/cooldown) → INSERT run
+                                       (open-run unique (merchant, workflow, key) WHERE not exited)
+walker pod: claim_due_runs (wake_at lease push + attempts++) → walk_run
+   ├─ archived → ejected · paused → snooze
+   ├─ max_age → timed_out · customer_has_event(goal, since entered_at) → goal_met
+   └─ loop ≤10: execute(node) [send → queue_message dedupe run:node | call → lead uuid5(run:node)]
+                 pick_next (wait_event: on==reply else "timeout") → wait? advance_run(wake=now+min) : continue
+                 no edge → exited completed ; NodeParked → parked (operator resume) ; other → backoff/park
+dispatcher pod: requeue stale → claim queued → _gate(suppression, fail closed) → send() [route: binding→installation→approved template→vault] → adapter.deliver → plan_for_outcome → apply_outcome (CAS on attempt)
+```
+
+## 11. Tally — bugs vs probable issues vs nits
+
+### Bugs (4) — wrong behaviour, reproduced or unambiguous from code + DDL
+| # | Where | What |
+|---|---|---|
+| B1 (W-1) | outreach/entry.py + walker.pick_next | wait_event reply without `node.key` writes `{reply_<node>: None}` + wake now → walker takes the "timeout" edge early. Repro'd. |
+| B2 (W-4) | outreach/enrol.py `_admission` | Keyed plans (entry.key, the documented WISMO case) are refused on the second key by the per-customer reenter/cooldown guard with default settings. Repro'd. |
+| B3 (W-5) | outreach/plans.py `validate_definition` | Live-entry comparison is raw-dict equality; omitted vs explicit defaults → spurious "entry rule changed" publish refusal. Repro'd. |
+| B4 (W-3) | outreach/plans.py `set_status` + 057 CHECK | `status=live` on a never-published draft violates `CHECK (status='draft' OR definition IS NOT NULL)` → asyncpg error → HTTP 500 instead of 422. From DDL + query; not run against a DB. |
+
+### Probable issues (8) — plausible defects or design gaps that need a DB run or a canon/ADR check to confirm
+| # | Where | What |
+|---|---|---|
+| P1 (W-2) | outreach/db advance_run vs resume_run_on_event | Unconditional overwrite of context/wake_at; a reply landing mid-visit can be clobbered by the timeout path. Race, needs a DB to demonstrate. |
+| P2 | record/workers.py | No attempt counter on crm_event_raw: a deterministically failing consumer keeps the row pending forever and re-runs resolve/assert_facts every poll. |
+| P3 | identity/resolve.py staple | Only incoming handles attach to the survivor; a loser's other handles are unreachable (probe filters status='active') and a later event re-mints a customer. Check ADR 0021 intent. |
+| P4 (W-8) | migration 058 | crm_workflow_enrollment.customer_id has no composite FK to crm_customer, unlike crm_message/crm_workflow. Check canon T20. |
+| P5 (W-6) | outreach/plans.py `_publish_in_txn` | Docstring claims the occupied-node read cannot race the walker; READ COMMITTED with no lock does not guarantee it. Consequence is an honest park, so low risk. |
+| P6 | platform/suppression.py `is_suppressed` | Gate ignores channel; any live suppression on any channel blocks all channels. Conservative today, a design question once channels multiply. |
+| P7 (W-9) | outreach/entry.py `_context_from_payload` | Every scalar payload key (email, name, address…) lands in run context, listed by GET runs and forwarded as send variables. By design as the template bridge; privacy exposure to review. |
+| P8 | record/api.py `within_size_limit` | Cap checks Content-Length only, after FastAPI has already parsed the body; chunked bodies bypass. |
+
+### Nits / known gaps (not counted): W-7 type-string matching in entry.py & pick_next; W-10 global (merchant NULL) templates allowed for call nodes; W-11 two definitions of "goal after entry" (entry vs walker); C-2 stale 056 comment about source_kind validation; C-3 credential rotated before the atom can refuse; C-4 authenticated→degraded cannot send (deliberate); C-5 template webhook consumer not built (documented).
+
+## 12. The abandoned-cart flow and PR #1041 (repeat entries)
+
+### The flow as asked (checkout abandonment → 30m → WhatsApp → 30m → call (+WhatsApp from the call) → 1d → close)
+| Step | Construct | Status |
+|---|---|---|
+| Shopify abandonment event | `entry.topic` = the checkout topic the relay pushes; bursts coalesce via open-run unique + `source_event_used` | Works |
+| Wait 30m; recovered by any means → nothing | `wait` node; `goal.topics` = order topics; entry consumer cancels open runs on the goal event, walker re-checks goal before every action | Works |
+| Send WhatsApp | `send` node (channel, template) + plan `purpose_key` | Works (given connectors + approved template) |
+| Wait 30m; recovered → `goal_met` | second `wait` | Works |
+| Trigger call | `call` node (`template_id`) → BACKLOG lead | Works |
+| WhatsApp **from inside the call** via functions | **Gap** — buddy has only tts_say / end_conversation / function(HTTP, builtin) / alert; no send-WhatsApp builtin and no `/crm/messages` route; `queue_message` is a Python contract only | Needs a `send_whatsapp` builtin (buddy → connectivity contracts, `source_kind: agent`, dedupe `lead:<id>:<fn>`) or a POST route |
+| Wait 1d; recovered → `goal_met` else close | third `wait` with no outgoing edge → `completed` | Works |
+- Plan settings to set deliberately: `reenter: true` + a `cooldown_hours`; phone must be extractable (email-only checkout parks at the send node); goal topic must match the relay string exactly; timers start at queue/push time, not delivery/call time; `exits.max_age_days` default 7 covers the flow.
+- `entry.reenter` is fully implemented (schemas → `_admission` → atom → tests). Per customer, exited runs count; guard is per customer not per key (B2).
+
+### The three follow-up questions
+1. **All events for the customer into one run**: already true by refusal (unique + guard). Before #1041 later events were dropped, not applied: timer started at the FIRST update and the nudge carried the first snapshot → nudges a customer still on the checkout page. `wait_event` is not the fix (stale `reply_<node>` in context would loop a self-edge forever).
+2. **Same-cart order mapping**: sending the cart link works today — `abandoned_checkout_url`, `token`, `cart_token` are scalars → context → template variables. Matching the order back is NOT built: goal matching is customer+topic only (`cancel_open_runs`, `customer_has_event`). Needs a `goal.key` (order `checkout_token` vs run's `token`) and a distinct exit reason.
+3. **Different order with overlapping items**: already handled conservatively — ANY order by the customer ends every open run (`goal_met`, time-aware). Item-overlap logic is not expressible (`where` is equality on top-level keys; goal has no filter). If cart-keyed goals are added later, keep two tiers (exact match → recovered; any other order → still exit, different reason) or this case regresses into spam. Cross-run spam control = `reenter` + `cooldown_hours`; per-purpose frequency caps belong to the unbuilt permission gate (B5).
+
+### PR #1041 — feat(crm): repeat entries (on_repeat + debounce_minutes), manas-narra, branch feat/crm-repeat-entries, base 75594cb
+- Adds `entry.on_repeat` ∈ {ignore (default), refresh_latest, refresh_max(<field>), accumulate} and `entry.debounce_minutes`. New `repeat.py` (vocabulary, PURE `repeat_plan`, `apply_repeat`); `patch_open_run_query` = ONE idempotent UPDATE: `WHERE status='waiting' AND current_node = nodes[0].id AND enrollment_key=$3 AND NOT (repeat_event_ids ? event_id)`; merges/appends facts per policy, `wake_at = now() + debounce`, appends event id to `context.repeat_event_ids`. Hooked in `entry._try_enrol` when `enrol()` returns None. Validator: policy word must parse; debounce>0 needs `is_wait(nodes[0])`. `repeat_event_ids`/`repeat_items` are bookkeeping (dropped from run_facts); `repeat_count` is a fact. No migration, no API change. 16 tests (SQL shape + pure + monkeypatched hook; no DB).
+- State (2026-09-02): open, 1 commit, CI green (build, Yama, SentinelOne), merges cleanly onto today's release (merge-base 9 commits behind; `git merge-tree` clean). CodeRabbit: 3 unresolved minor comments — (a) `accumulate` errors on `jsonb_array_length` if a payload carries a scalar `repeat_items` key; (b) `_as_number` accepts NaN/inf → always "wins" refresh_max; (c) repeat path passes `_context_from_payload(payload)` so refreshed `phone` is not carried (do NOT pass `source_event_id` though — see below).
+- **Supersedes my `entry.refresh` sketch** — same shape (first node only, one UPDATE, per-event dedupe) with a richer vocabulary. Do not build a second version.
+- **What it solves for the flow**: `on_repeat: refresh_latest` + `debounce_minutes: 30` (first node `wait 30`) = timer restarts on every checkout update and the nudge carries the latest cart. Use `refresh_max(cart_value)` only for several distinct carts.
+- **What it does NOT solve**: in-call WhatsApp send; cart→order attribution (goal.key); bugs B1–B4; races P1/P2. It adds a second concurrent writer of `wake_at`/`context` beside the walker, so P1 (unconditional `advance_run` overwrite) gets slightly more likely.
+- **Two asks on the PR before relying on it** (both one-liners in `patch_open_run_query`):
+  - P9: exclude the founding event — a redelivered copy of the run's own `source_event_id` is refused by `source_event_used`, falls into `apply_repeat`, is NOT in `repeat_event_ids`, and so overwrites newer facts with the first snapshot and restarts the timer. Add `AND context->>'source_event_id' IS DISTINCT FROM $5` (or seed `repeat_event_ids` with the founding id at insert).
+  - P10: `wake_at = now() + N` can pull the alarm EARLIER when debounce < remaining wait (author flagged it). Use `GREATEST(wake_at, now() + make_interval(...))` — a debounce may only extend the window.
+- Author's open questions addressed to Swaroop in the PR comment: (1) list-shaped facts (`line_items`) never reach templates — producers owe a scalar summary, or a fire-time letter re-read, or a per-plan extractor? (2) `accumulate(<field>)` joining values into one scalar at fire time? (3) GREATEST vs now()+N for debounce (answer: GREATEST).
+
+## 13. Loan-onboarding funnel (stage drop-off → call after 30m)
+Requirements: customer-level; ~10 stage events (profile_created → kyc → bank_linked → offer → agreement → disbursed) plus unrelated events (order placed, refund); usually top-down but a stage event may be missing; drop-off at ANY stage → call after 30m.
+
+### Option A — one small plan per stage (works today, + #1041)
+- Plan k: `entry.topic = stage_k`, `reenter: true` + cooldown, `on_repeat: refresh_latest`, `debounce_minutes: 30`; nodes `wait 30 → call`; `goal.topics = every stage downstream of k`.
+- Mechanics: goal-cancel runs before entry in the consumer, so one stage event closes run k (`goal_met`) and opens run k+1; walker re-checks goal before acting; skipped stages are harmless because goals list ALL downstream topics; unrelated topics are ignored; retries covered by reenter + debounce.
+- Cost: N-1 plans; a journey = up to N-1 short runs each exiting `goal_met` ("progressed", not "converted"); funnel reporting = join runs across plans per customer.
+### Option B — one plan, a chain of `wait_event` nodes (one run per journey)
+- Each stage node listens for all downstream stage topics (30m), a labelled edge per stage jumps to the right node, `timeout → call_k → listen_k_after_call (1d) → timeout → completed`. Distinct node ids after the call (no cycles).
+- **Blocked today by**: B1 (event lacking the key → timeout → false call); `wait_event` branches on `payload[key]`, not the topic (needs `key: "$topic"` resolved from `event.topic` in entry.py); single-topic entry (a journey first seen at KYC never enrols — needs `entry` as a list of `{topic, start}`); the reply written by `resume_run_on_event` carries only `reply_<node>`, no event facts (later stages' facts never reach call templates — needs a merge of scalars on resume, the refresh_latest shape); stale `reply_<node>` on any cycle (clear reply keys on advance); `exits.max_age_days` must cover the whole onboarding; O(n²) edges (console-generated).
+- Same for both: out-of-order delivery (goal cancel compares goal `occurred_at` vs run `entered_at`, so a late-delivered earlier stage can still get a call — compare vs the entry event's `occurred_at` instead); a phone must be extractable; the call obeys buddy calling hours/DND; two concurrent applications → key by application id (B2).
+### Verdict
+Start with A (no code changes beyond #1041). B earns its keep only when per-journey funnel analytics or a single editable document matters, and it needs five small features plus the B1 fix first. A hybrid — A for behaviour + a reporting view joining a customer's runs across the stage plans in workflow order — gives most of B's analytics with none of its risk (one big plan's state machine parks every journey on a bug; entry edits are blocked while any run is open, and B's runs live for days).
+
+## 14. Option B written out, why not B (plain-language version), industry practice, and the canon decision underneath
+
+### 14.1 Option B, once B1 + four features exist (four stages shown; ten stages ≈ 30 nodes / 80 edges — console-generated only)
+Prerequisites beyond the B1 fix: (1) `key: "$topic"` on wait_event → branch on `event.topic`; (2) `entry` as a list of `{topic, start}` so a journey first seen at KYC enrols on the KYC node; (3) `resume_run_on_event` merges the event's scalars (refresh_latest shape) so later stages' facts reach call templates; (4) clear `reply_<node>` keys on advance so a revisited node cannot resolve on a stale answer.
+```json
+{
+  "entry": [
+    {"topic": "loan.profile_created", "start": "at-profile"},
+    {"topic": "loan.kyc_completed",   "start": "at-kyc"},
+    {"topic": "loan.bank_linked",     "start": "at-bank"},
+    {"topic": "loan.offer_accepted",  "start": "at-offer"}
+  ],
+  "reenter": true, "cooldown_hours": 0,
+  "goal": {"topics": ["loan.disbursed"]},
+  "exits": {"max_age_days": 30},
+  "nodes": [
+    {"id": "at-profile", "type": "wait_event", "key": "$topic", "minutes": 30,
+     "topics": ["loan.kyc_completed", "loan.bank_linked", "loan.offer_accepted"]},
+    {"id": "call-profile", "type": "call", "template_id": "<profile dropoff>"},
+    {"id": "after-call-profile", "type": "wait_event", "key": "$topic", "minutes": 1440,
+     "topics": ["loan.kyc_completed", "loan.bank_linked", "loan.offer_accepted"]},
+    {"id": "at-kyc", "type": "wait_event", "key": "$topic", "minutes": 30,
+     "topics": ["loan.bank_linked", "loan.offer_accepted"]},
+    {"id": "call-kyc", "type": "call", "template_id": "<kyc dropoff>"},
+    {"id": "after-call-kyc", "type": "wait_event", "key": "$topic", "minutes": 1440,
+     "topics": ["loan.bank_linked", "loan.offer_accepted"]},
+    {"id": "at-bank", "type": "wait_event", "key": "$topic", "minutes": 30,
+     "topics": ["loan.offer_accepted"]},
+    {"id": "call-bank", "type": "call", "template_id": "<bank dropoff>"},
+    {"id": "after-call-bank", "type": "wait_event", "key": "$topic", "minutes": 1440,
+     "topics": ["loan.offer_accepted"]},
+    {"id": "at-offer", "type": "wait", "minutes": 30},
+    {"id": "call-offer", "type": "call", "template_id": "<offer dropoff>"}
+  ],
+  "edges": [
+    ["at-profile", "at-kyc", "loan.kyc_completed"], ["at-profile", "at-bank", "loan.bank_linked"],
+    ["at-profile", "at-offer", "loan.offer_accepted"], ["at-profile", "call-profile", "timeout"],
+    ["call-profile", "after-call-profile"],
+    ["after-call-profile", "at-kyc", "loan.kyc_completed"], ["after-call-profile", "at-bank", "loan.bank_linked"],
+    ["after-call-profile", "at-offer", "loan.offer_accepted"],
+    ["at-kyc", "at-bank", "loan.bank_linked"], ["at-kyc", "at-offer", "loan.offer_accepted"],
+    ["at-kyc", "call-kyc", "timeout"], ["call-kyc", "after-call-kyc"],
+    ["after-call-kyc", "at-bank", "loan.bank_linked"], ["after-call-kyc", "at-offer", "loan.offer_accepted"],
+    ["at-bank", "at-offer", "loan.offer_accepted"], ["at-bank", "call-bank", "timeout"],
+    ["call-bank", "after-call-bank"], ["after-call-bank", "at-offer", "loan.offer_accepted"],
+    ["at-offer", "call-offer"]
+  ]
+}
+```
+Walk-through: profile event enrols on `at-profile` (30m alarm). KYC event within the window → labelled edge → `at-kyc`, alarm restarts. Skipped stage = longer jump on another labelled edge. Silence → `timeout` → call → 1-day listening window → silence → `completed` (the drop-off record). `loan.disbursed` ends the run anywhere as `goal_met`. Post-call nodes have distinct ids so the graph stays acyclic.
+
+### 14.2 A vs B comparison
+| | A: plan per stage | B: one journey plan |
+|---|---|---|
+| Works today | Yes (+ #1041) | No — B1 + four features |
+| Runs per journey | up to N-1 short runs | one |
+| Funnel analytics | join runs across plans per customer | read one run (current node, exit reason, time per stage) |
+| Call template variables | that stage's event facts | only with feature 3; risk of cross-stage key collisions |
+| Editing while live | pause one stage plan | entry edits blocked while any run is open; runs live for weeks |
+| Blast radius of a bug | one stage's 30-minute run | every journey in flight (a parked run stops being covered) |
+| Write contention | short-lived rows, rarely concurrent | one hot row per customer → P1 race more likely |
+| Document | N tiny plans | one large generated document; one missing edge = a wrong call |
+| New vocabulary | none | five words, each an ADR + validator rule + test, forever |
+Both call the same customer at the same minute. B wins only on reporting/product surface.
+
+### 14.3 Why not B even after the fixes (the kid version — Ravi's loan)
+Ravi climbs five steps: profile → KYC → bank → offer → money. Stop 30 minutes on any step and we phone him.
+- **A = five small alarm clocks, one per step.** Finish profile → profile clock starts. Finish KYC in time → profile clock thrown away, KYC clock starts. Go quiet → the clock rings, we call. Each clock only knows "did he move past my step?"
+- **B = one board game, Ravi is the token.** One board with all five squares; the token moves when he does a step; sit still 30 minutes and the square rings.
+Both ring at the same moment. Why still the clocks:
+1. **You cannot redraw a board while people stand on it.** Rules: entry can't change and occupied squares can't be removed while tokens are on the board. B's tokens sit for weeks, so someone is on nearly every square; adding "upload salary slip" means wiping every token (archive → ejected) or running two boards. Clocks run 30 minutes, so they are almost always empty and free to change; adding a step = one more clock.
+2. **One broken square parks the whole token.** Bank square's call template deleted → Ravi parked and invisible until a human resumes him; even finishing the bank step later isn't watched. With clocks only the bank clock is broken; the offer clock still starts when he accepts.
+3. **One backpack collects everybody's stuff.** B's single context gets every stage's payload; `status`/`amount`/`reason` mean different things at KYC and offer, the last writer wins, the stage-five call reads the wrong one. Clocks: one small bag per step.
+4. **Everyone scribbles on the same page.** In B every stage event, repeat patch and walker visit write Ravi's one row → the P1 lost-update race gets likelier. Clocks: separate pages, rarely written together.
+5. **Lots of arrows; one missing arrow = a wrong phone call.** Ten steps ≈ 30 squares / 80 arrows; the validator checks shape, not "every square lists all downstream steps". Machine-drawn only.
+6. **New rules kept forever.** Five vocabulary words vs. none.
+Where the board is nicer: one token shows where Ravi is, time per step, where he gave up. That is a report, not a behaviour — buildable from the clocks with one query.
+What would change the verdict: the console generates boards; per-journey state becomes a merchant-facing feature; or clocks sprawl (10 plans × many lenders) becomes the maintenance problem.
+
+### 14.4 What the industry does (from training knowledge, not checked against current docs)
+- **The product merchants buy is a board**: Braze Canvas, SFMC Journey Builder, Iterable, Customer.io, Klaviyo Flows, MoEngage, CleverTap, WebEngage, HubSpot workflows, Dittofeed (cited in migration 057). Visual journey, customer as token: trigger · wait · wait-for-event with branches · action · exit.
+- **Two things keep their boards safe**: (a) **version pinning** — an edit creates vN+1; people already inside finish vN; new entrants take vN+1 (Braze, Journey Builder; Temporal/Step Functions do the same for code); (b) **exit criteria re-checked at every step** — Klaviyo abandoned-cart: trigger Started Checkout, every step re-checks "has not Placed Order since entering" (= the walker's goal re-check, already built here).
+- **For funnels, enterprises mostly run clocks**: the source system writes a profile attribute/segment (`onboarding_stage = kyc_pending`); one small campaign per stage fires on segment entry and exits on segment exit (= Option A keyed on STATE, not events). Reasons: different teams own different stages and A/B test independently; ten-stage canvases with skip-ahead arrows become spaghetti; audit ("why did we call him") is simpler. Boards are used for short linear journeys (cart recovery, post-purchase, welcome series).
+
+### 14.5 The canon decision underneath ("not what the repo's canon chose")
+- **Repo (T19, migration 057, plans.py)**: ONE live `definition`; publish replaces it in place and every run not yet past the change follows the new document; `version` is an audit stamp ("she entered under v3"), explicitly "never an execution pin"; safety = the publish validator BLOCKS stranding edits (occupied node removed, entry changed while runs open). Edits reach everyone — a feature for 30-minute runs (fix a template name, every waiting run benefits).
+- **Enterprise engines**: PIN instead of block — keep every version that still has someone on it, answer "which version is this run on" at every claim, tool for draining/migrating old versions. Nothing is blocked because nobody in flight sees the change.
+- **Consequence**: the repo's choice fits short runs; a three-week loan board hits the validator on most meaningful edits (only exits: archive → eject all, or a second plan). Making long boards enterprise-grade is therefore not the five vocabulary features — it is an ADR-level decision on pinning in-flight runs to the definition they entered under (multiple live definitions, per-run version resolution, drain tooling). Neither choice is wrong; they fit different run lengths.
+
+### 14.6 What we should do (recommendation)
+1. **Abandoned cart**: build the board — short, fits the current design; `on_repeat: refresh_latest` + `debounce_minutes: 30` from #1041; still needs the in-call WhatsApp send and cart→order `goal.key`.
+2. **Loan funnel**: clocks (Option A) now — no canon change, no new vocabulary. Borrow the industry twist: trigger on a stage attribute/segment from the source system rather than raw stage events, which also removes skipped-event and out-of-order worries. Add a reporting view joining a customer's runs across stage plans in stage order for funnel analytics.
+3. **Long boards as a product later**: put version pinning in front of Swaroop as the prerequisite; once decided, the five B features are small. Keep the B vocabulary on the roadmap, not in the corpus, until then.
+4. Regardless: fix B1 (missing key → timeout), B2 (keyed plans vs reenter), B3 (entry dict compare), B4 (500 on draft→live), P1 (CAS on advance_run), P2 (event attempt counter); land P9/P10 on #1041.
+
+### 14.7 Decision: build the board + version pinning ("runs complete on the version they entered under") — does the loan funnel become a board?
+- **What pinning changes**: removes the biggest structural objection (#1 — edits blocked while runs are open). The occupied-node and entry-change guards become unnecessary for in-flight safety (they only protect the CURRENT version's new entrants).
+- **What pinning costs** (beyond storing old definitions): the walker resolves the run's pinned definition on every claim (a `crm_workflow_version` table or a jsonb history on crm_workflow); the entry consumer changes shape — today it iterates the merchant's LIVE flows once per event; with pinning, goal topics and wait_event listening must be evaluated per OPEN RUN against that run's pinned version, while entries use the latest version → iterate the customer's open runs + latest definitions, not flows; drain/migrate-forward tooling; retention of old versions while any run references them; template references in old versions must stay resolvable (retiring a call/WA template a pinned run still names = park).
+- **The other objections and what closes each**: #2 parked journey stops being watched → let stage events move a PARKED run too (resume_run_on_event currently touches `waiting` only) or park the action, not the listening; #3 context pollution → namespace facts per node (`facts.<node>`) in feature 3; #4 one hot row → the P1 CAS fix (generation/attempt guard on advance_run and every patch); #5 O(n²) edges → authoring sugar: an ordered `stages` list expanded into the wait_event ladder (validator-owned expansion), or `on: "$topic"` edges implied by node naming; #6 vocabulary → accepted cost once boards are the product.
+- **Verdict with pinning + those five**: yes, the loan funnel can be a board, and one operating model (boards) beats two (boards + clocks). The remaining preference for clocks in enterprises is organisational (per-stage ownership, A/B), not technical — for a lender integrating via API, one pinned board is fine.
+- **Sequencing**: pinning touches storage, walker, entry consumer and canon — weeks, not days. Ship the loan funnel as clocks NOW (five tiny plans, disposable), build pinning + the five items, then migrate the funnel to one board. Nothing is wasted: the stage topics, call templates and goal lists carry over one-to-one.
+
+## 15. End-to-end plan (agreed direction) and the "boards everywhere?" answer
+
+### 15.1 The plan, in order
+**Phase 0 — hygiene (any time, small, independent)**
+- Fix B1 (missing reply key → skip resume, never route to timeout), B2 (admission per enrollment_key when the plan is keyed, or validator warns), B3 (compare entries via model_dump, not raw dicts), B4 (refuse `live` without a definition → 422).
+- P1: compare-and-set on every enrollment write (advance_run, resume_run_on_event, #1041 patch, record_run_error) — a `revision` column or the leased `wake_at` as the guard.
+- P2: attempt counter / quarantine after N for crm_event_raw.
+- Land #1041 with P9 (exclude founding `source_event_id`) and P10 (`GREATEST(wake_at, now()+N)`), plus the three CodeRabbit nits.
+
+**Phase 1 — the abandoned-cart board (short journey; current live-document semantics are right for it)**
+- Plan: entry `checkouts/update` + `reenter: true` + cooldown + `on_repeat: refresh_latest` + `debounce_minutes: 30`; `wait 30 → send WA → wait 30 → call → wait 1d`; goal = order topics; `abandoned_checkout_url` as a template variable.
+- Build: `send_whatsapp` builtin in buddy (buddy → connectivity contracts, `source_kind: agent`, dedupe `lead:<id>:<fn>`) for the in-call send. `goal.key` (order `checkout_token` vs run `token`) with a distinct exit reason ("recovered" vs "converted elsewhere"); keep the customer-level goal as the second tier so an unrelated order still stops the nudge.
+- Ship the loan funnel as CLOCKS in parallel (five/nine tiny stage plans; ideally triggered on a stage attribute/segment from the source system). Disposable; nothing wasted.
+
+**Phase 2 — version pinning (ADR-level; touches storage, walker, entry consumer, canon)**
+- Storage: `crm_workflow_version` (merchant_id, workflow_id, version, definition, published_at, published_by) or a jsonb history; runs already carry `workflow_version` — it becomes the execution pin. Old versions retained while any non-exited run references them; retirement guard on templates a pinned version names.
+- Walker: resolve the run's pinned definition on every claim (cache by (workflow_id, version)).
+- Entry consumer redesign: entries evaluate the LATEST version; goal topics and wait_event listening evaluate per OPEN RUN against that run's pinned version → iterate the customer's open runs + the merchant's latest definitions, not flows alone.
+- Publish semantics per plan: `on_publish: pin` (default; new entrants take vN+1, in-flight finish vN) or `on_publish: migrate` (today's "edits reach everyone", allowed only when the stranding validator passes — keeps the short-board benefit of fixing a template name for every waiting run). Braze offers the same choice.
+- Tooling: drain/migrate-forward (move waiting runs from vN to vN+1 when their current node still exists), per-version run counts on the list endpoint (#1053 is adding run counts — align).
+
+**Phase 3 — long-board vocabulary (small once pinning exists)**
+- `key: "$topic"` (branch on topic); `entry` as a list of `{topic, start}`; facts merged on resume, namespaced per node (`facts.<node>`); clear `reply_<node>` on advance; events may move a PARKED run (or park the action, keep listening); `stages` authoring sugar expanded into the wait_event ladder by the validator.
+- Then migrate the loan funnel to one pinned board; retire the stage clocks.
+
+### 15.2 Once all of it is built: boards everywhere, or do clocks survive?
+- **There is only one engine.** A "clock" is a board with one wait and one action: same `crm_workflow` row, same walker, same enrol(). Clocks are a PATTERN (small plan, short run), not a second mechanism. After Phase 2/3 nothing is "clock code" that could be deleted.
+- **Long boards become the default for journeys with state that matters**: cart recovery, onboarding funnels, WISMO, post-purchase sequences — anything where "where is this customer in the journey" is a product fact or a report.
+- **Small boards (clocks) remain the right shape for**:
+  1. One-shot / transactional flows — order confirmation → send; OTP; a single reminder. A one-node board.
+  2. Cross-cutting nudges that fire regardless of where the customer is in another journey — "payment failed → retry call", "refund initiated → WA update". These must be separate plans anyway: the open-run unique is per workflow, and one customer can legitimately be in the cart board and the loan board at once.
+  3. State/segment-triggered nudges from the source system ("stage attribute changed to X") when the source owns the funnel position and we only react.
+  4. Independently owned or A/B-tested steps, where teams want to pause/edit one step without touching the journey.
+  5. Very high-churn plans where "edits reach everyone" (`on_publish: migrate`) is the point and runs are minutes long.
+- **The decision rule per plan**: run length × edit frequency. Runs of minutes-to-hours → small board, migrate-on-publish. Runs of days-to-weeks with position that matters → one pinned board. Never a long board on live-document semantics (the loan-funnel objection), never ten clocks for one journey once pinning exists (the reporting-join tax).
+- **Merchant-facing framing**: the console shows one concept ("workflow"), with a template gallery: "Cart recovery" (a board), "Order confirmation" (a one-step board), "Onboarding funnel" (a stages ladder). Nobody outside engineering should hear the words clock or board.
+
+### 15.3 "Once versioning is done, there is only one system" — yes, with the precise meaning
+- **One engine, always**: one table pair (crm_workflow + crm_workflow_enrollment, plus the version table), one walker, one enrol(), one entry consumer, one validator, one API. This is already true today — clocks and boards are the same `crm_workflow` mechanism differing only in document size and run length. Versioning does not merge two systems; it removes the reason to keep long journeys OUT of the one system.
+- **What varies per plan, not per system**: document size (one node or thirty); `on_publish: pin | migrate`; entry words (reenter, cooldown, key, on_repeat, debounce); goal tiers; exits. All are words in the definition jsonb, read by the same code.
+- **The one place the code must know about both**: the entry consumer evaluates entries against the LATEST version and goals/listening against each open run's PINNED version. That is one consumer with two reads, not two consumers. A `migrate`-mode plan simply has every open run pinned to the latest version, so the same code path serves it with no branch.
+- **What disappears once pinning exists**: the occupied-node and entry-change publish guards as blockers (they survive only as the precondition for `migrate` mode); the need to archive-and-eject to change a long plan; the reporting join across stage clocks for one journey; the "clock vs board" vocabulary itself outside engineering.
+- **What never disappears**: small plans as a pattern (one-shot sends, cross-cutting nudges, source-owned stage triggers) — they are boards too, just short ones, and they run through pinning like everything else (a one-node board pinned to v3 is trivially fine).
+- **Sanity check for the corpus**: after Phase 2 the canon sentence "version is an audit stamp, never an execution pin" (057) is reversed and needs an ADR; T19's "edits reach everyone not yet past them" becomes the definition of `migrate` mode, not the law.
+
+## 16. Both flows in the final vocabulary (after Phases 0–3), and what would still be missing
+
+Assumed vocabulary after the plan: entry as object or list of `{topic, start}`; `on_publish: pin | migrate`; `goals` as a list of tiers `{topics, key?, exit_reason}` (key = `{event: <payload field>, run: <context field>}`); nodes wait · send · call · wait_event (`key: "$topic"` allowed); `stages` ladder sugar expanded by the validator; facts merged on resume, namespaced per node; `current_stage` exposed in run_facts.
+
+### 16.1 Cart abandonment — final shape
+```json
+{
+  "name": "cart-recovery",
+  "on_publish": "migrate",
+  "purpose_key": "marketing.cart.recovery",
+  "entry": {"topic": "checkouts/update", "reenter": true, "cooldown_hours": 24,
+            "on_repeat": "refresh_latest", "debounce_minutes": 30},
+  "goals": [
+    {"topics": ["orders/create", "orders/paid"],
+     "key": {"event": "cart_token", "run": "cart_token"}, "exit_reason": "goal_met"},
+    {"topics": ["orders/create", "orders/paid"], "exit_reason": "converted_elsewhere"}
+  ],
+  "exits": {"max_age_days": 7},
+  "nodes": [
+    {"id": "wait-30m",   "type": "wait", "minutes": 30},
+    {"id": "wa-nudge",   "type": "send", "channel": "whatsapp", "template": "cart_recovery_1"},
+    {"id": "wait-30m-2", "type": "wait", "minutes": 30},
+    {"id": "rescue-call","type": "call", "template_id": "<cart rescue template — uses the send_whatsapp builtin mid-call>"},
+    {"id": "wait-1d",    "type": "wait", "minutes": 1440}
+  ],
+  "edges": [["wait-30m","wa-nudge"],["wa-nudge","wait-30m-2"],["wait-30m-2","rescue-call"],["rescue-call","wait-1d"]]
+}
+```
+- `migrate` on publish: runs are ≤ 1 day, fixing a template name should reach every waiting run; the stranding validator still guards it.
+- `cart_token` rather than checkout `token` for the goal key: Shopify mints a new checkout token when a customer re-enters checkout, the cart token is stabler. Confirm against the relay's payload.
+- The mid-call WhatsApp is a buddy template function (`send_whatsapp` builtin → `queue_message`, `source_kind: agent`), not a workflow node — the workflow only sees the call.
+
+### 16.2 Loan onboarding — final shape (stages ladder)
+```json
+{
+  "name": "loan-onboarding-dropoff",
+  "on_publish": "pin",
+  "key": "application_id",
+  "reenter": true, "cooldown_hours": 0,
+  "exits": {"max_age_days": 30},
+  "goals": [
+    {"topics": ["loan.disbursed"], "exit_reason": "goal_met"},
+    {"topics": ["loan.rejected", "loan.withdrawn"], "exit_reason": "withdrawn"}
+  ],
+  "stages": {
+    "order": ["loan.profile_created", "loan.kyc_completed", "loan.bank_linked",
+              "loan.offer_accepted", "loan.agreement_signed"],
+    "idle_minutes": 30,
+    "on_idle": {"type": "call", "template_id": "<stage-aware dropoff template>"},
+    "after_action_minutes": 1440,
+    "restart_on_repeat": true,
+    "overrides": {
+      "loan.offer_accepted": {"idle_minutes": 120}
+    }
+  }
+}
+```
+Expansion (validator-owned): entry = every stage topic → its `at-<stage>` node; per stage `at-<stage>` wait_event(`$topic`, downstream topics, idle_minutes) → timeout → `<on_idle>-<stage>` → `after-<stage>` wait_event(downstream, after_action_minutes) → timeout → completed; labelled edges to every downstream `at-*`; `restart_on_repeat` = the stage's own topic re-arms the current node's alarm (the #1041 debounce generalised to any node). `current_stage` rides run_facts so one call template can say "you stopped at KYC".
+
+### 16.3 Will they be perfect? No. What still needs building (functionality, not bugs)
+| Gap | Affects | Why it matters | Where it lives |
+|---|---|---|---|
+| G1 Permission gate B5 (consent, purpose caps, quiet hours, cross-plan frequency caps) | both | Today the dispatcher only checks suppression; a marketing WA send has no consent check; a 30-min wait ending at 2am sends at 2am | dispatch `_gate` body + permission module (PR #1021 is the ledger) |
+| G2 Send/call OUTCOME back into the run (delivered / failed / no-answer / busy) | both | No fallback channel, no "call didn't connect → WA", no retry ladder; `send` and `call` nodes have no outcome edges | receipts + inbound via #1040/#1052 onto the spine; then `wait_event` on `message.status` / `call.completed` with `key: outcome` (call.completed is already mirrored by crm_mirror, so the call half is nearly expressible) |
+| G3 Inbound reply handling (STOP → suppression; "not interested" → skip the call; button replies) | cart mainly | Compliance and spam; the `wait_event` branch exists, the inbound letters do not yet | #1040 webhooks + #1052 extractor + a STOP → `record_suppression` consumer |
+| G4 List-shaped facts (`line_items`) never reach templates | cart | The nudge cannot name the items (manas's open question on #1041) | producer scalar summary, or fire-time letter read via a record contract, or per-plan extractor |
+| G5 Generic action nodes: `http` (create a discount code, hit the lender's API), `condition` (branch on a customer attribute / context fact), `split` (percentage / A-B) | both | Coupons, tiering ("KYC tier A gets a call, B gets WA"), experiments | new NODE_TYPES entries |
+| G6 Human handoff / task node (assign to an agent, open a ticket) | loan | Escalation after two failed calls | new node type + wherever tasks live (assist data layer PR #963?) |
+| G7 Out-of-order delivery guard (compare goal/listen against the entry event's `occurred_at`, not `entered_at`) | loan | Late-delivered earlier stage still gets a call | entry.py + walker re-check |
+| G8 Same-stage repeat re-arms mid-board nodes (`restart_on_repeat`) | loan | KYC retried → timer should restart; #1041 covers the entry node only | generalise the #1041 patch to `current_node` |
+| G9 Funnel/journey reporting (time per stage, drop-off by stage, recovered revenue with order amount captured at goal) | both | The reason boards were chosen; runs carry the data, no read yet | reporting view / endpoint (#1053 adds run counts — extend) |
+| G10 Dry-run / simulate a plan against a sample event; plan-level test mode | both | Merchants publish blind today | validator + a `simulate` endpoint that walks the document without writing |
+| G11 Send pacing / throughput budgets per merchant and channel (W8, named in channels.py) | cart at scale | A promo day queues 50k rows; Meta throttles | dispatcher + Channel fields |
+| G12 Template-variable contract validation at publish (does `cart_recovery_1` exist, approved, and take these variables?) | both | Today failures surface at send time as `template_not_approved` / bad variables | publish validator consults the T23 registry via connectivity contracts |
+Verdict: with Phases 0–3 the two flows RUN correctly end to end. G1–G3 are what make them shippable to real customers (compliance + feedback loops); G4–G6 and G9–G12 are what make them a product rather than a pipeline.


### PR DESCRIPTION
## What this adds

`docs/crm/workflow-rollout/` — the ordered implementation queue for taking the CRM workflow layer (`app/crm/outreach`, with touches in `record`, `connectivity`, `platform`) from `release` today to the two target flows:

1. **Cart abandonment** as a short board: `checkouts/update` → 30m → WhatsApp → 30m → rescue call → 1d → close; recovered at any point ends the run, with cart→order attribution.
2. **Loan-onboarding drop-off** as per-stage clocks first (no canon change), then one pinned board once version pinning exists.

Docs only. No code, no migration.

## Layout

- `README.md` — how to read the folder, conventions every phase follows (one commit per PR, the unpiped check list, the law triple, migration numbering, fail postures), and the queue table with dependencies.
- `PIPELINE.md` — the operating document: the external PRs and what they gate (#1040, #1052, #1021, #1053, #1047), the waves and what becomes startable when, single-agent merge-driven operation, the kick-off and continue prompts, review gates, and what to do when something slips.
- `00-…19-*.md` — one file per phase: why, current code pointers, design, red tests, acceptance, decisions already made, out of scope, dependencies. Phase 00 lands PR #1041 (repeat entries, @manas-narra) by cherry-pick with its two guards (founding-event redelivery; debounce only extends via `GREATEST`) and the three CodeRabbit nits folded in, keeping the author's attribution. Phase 05 intentionally does not exist (it became 00). Phase 10 is the one canon decision (ADR: runs execute the version they entered under).
- `99-backlog.md` — deferred items and the one dropped decision (in-call WhatsApp builtin).
- `context/` — the full read-through notes of every CRM module, migrations 048–061, the CI boundary guard and the workflow tests; the bug/issue tally (4 bugs reproduced, 10 probable issues, 21 nits); both flows; the #1041 review; the clocks-vs-boards analysis and industry practice; the version-pinning rationale; and a README mapping notes sections to phases.

## Why a folder and not a ticket list

Each phase is written so an agent (or a person) can pick it up cold without re-deriving intent, which is what the context notes are for. Decisions are recorded as made so they are not re-litigated per PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E6dTj6NvxeVys7f52m2o7K

---
_Generated by [Claude Code](https://claude.ai/code/session_01E6dTj6NvxeVys7f52m2o7K)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive CRM workflow rollout documentation covering 20 implementation phases, operational procedures, acceptance criteria, testing plans, and deferred backlog items.
  * Documented workflow improvements including version pinning, keyed enrollment, event handling, goal tracking, template validation, run reporting, branching, stages, outcome feedback, and permission-aware dispatch.
  * Added context guides, reading notes, implementation conventions, and rollout pipeline guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->