### PR TITLE
fix(crm): wait_event reply without key, entry compare, draft→live 422 (rollout 01)

### DIFF
--- a/app/crm/outreach/api.py
+++ b/app/crm/outreach/api.py
@@ -119,7 +119,12 @@ async def set_workflow_status_route(
     current_user: UserInfo = Depends(crm_admin_user),
 ) -> Workflow:
     set_log_context(component="crm.workflows.status", merchant_id=merchant_id)
-    workflow = await plans.set_status(merchant_id, workflow_id, body.status)
+    try:
+        workflow = await plans.set_status(merchant_id, workflow_id, body.status)
+    except plans.WorkflowValidationError as e:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=e.problems
+        )
     if workflow is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,

--- a/app/crm/outreach/entry.py
+++ b/app/crm/outreach/entry.py
@@ -100,12 +100,24 @@ async def consume_attributed_event(
         )
     for flow, node in listening:
         answer = event.payload.get(node.key or "")
+        if answer is None:
+            # B1 (rollout phase 01): no key, no answer to branch on. Waking
+            # the run with {reply_<node>: None} made pick_next read "the
+            # alarm fired" and take the timeout edge at once — any letter
+            # on the listened topic without the key ended the listening
+            # window early. The window simply continues; only the alarm
+            # may time it out.
+            logger.info(
+                f"wait_event reply ignored: key {node.key!r} missing "
+                f"(workflow {flow.id}, event {event.id})"
+            )
+            continue
         await accessor.resume_run_on_event(
             event.merchant_id,
             str(flow.id),
             customer_id,
             node.id,
-            {reply_key(node.id): None if answer is None else str(answer)},
+            {reply_key(node.id): str(answer)},
         )
     for flow, definition in entry_matches:
         await _try_enrol(flow, definition, event, customer_id, handles)

--- a/app/crm/outreach/plans.py
+++ b/app/crm/outreach/plans.py
@@ -12,7 +12,12 @@ from app.core.logger import logger
 from app.crm.outreach.db import DbTxn, accessor, atomically
 from app.crm.outreach.nodes import NODE_TYPES, is_wait
 from app.crm.outreach.repeat import parse_repeat_policy
-from app.crm.outreach.schemas import Workflow, WorkflowDefinition, WorkflowSummary
+from app.crm.outreach.schemas import (
+    Workflow,
+    WorkflowDefinition,
+    WorkflowEntry,
+    WorkflowSummary,
+)
 
 TIMEOUT = "timeout"
 
@@ -80,7 +85,7 @@ def validate_definition(
                 problems.append(f"node {src} has {len(arrows)} outgoing edges")
 
     if occupied_nodes and live_entry is not None:
-        if raw.get("entry") != live_entry:
+        if _entry_changed(raw.get("entry"), live_entry):
             problems.append(
                 "entry rule changed while runs are open — pause the plan and "
                 "let them finish, or publish the entry change as a new plan"
@@ -94,6 +99,22 @@ def validate_definition(
             )
 
     return problems
+
+
+def _entry_changed(raw_entry: Any, live_entry: Dict[str, Any]) -> bool:
+    """PURE: does the draft's entry MEAN something different from the live
+    one? Compared as validated models, so a draft that omits the defaults
+    and a live entry that spells them out read equal (B3, rollout phase
+    01) — a raw-dict compare refused every re-publish that changed nothing
+    about admission. A live entry that no longer parses (a legacy row from
+    before a word was added) cannot be normalised: then the raw dicts are
+    compared, exactly as before."""
+    try:
+        draft = WorkflowEntry.model_validate(raw_entry).model_dump()
+        live = WorkflowEntry.model_validate(live_entry).model_dump()
+    except Exception:
+        return raw_entry != live_entry
+    return draft != live
 
 
 async def create_workflow(
@@ -152,9 +173,27 @@ async def set_status(
 ) -> Optional[Workflow]:
     """live <-> paused, or archived (terminal). Archiving force-exits open
     runs as 'ejected' at the walker's next claim — the paused/archived
-    check happens there, so no sweep is needed here."""
+    check happens there, so no sweep is needed here.
+
+    Returns None for an unknown, foreign or archived plan (the door's
+    404, as before). Leaving 'draft' needs a published document: migration
+    057's CHECK (status = 'draft' OR definition IS NOT NULL) admits a NULL
+    definition only while the plan is a draft, so live, paused and
+    archived on a never-published draft all used to surface as a driver
+    error — a 500. The pre-read decides it here as one validation miss
+    (B4, rollout phase 01); a driver exception is never caught in logic."""
     if status not in ("live", "paused", "archived"):
         raise WorkflowValidationError([f"unknown status: {status}"])
+    workflow = await accessor.get_workflow(merchant_id, workflow_id)
+    if workflow is None or workflow.status == "archived":
+        return None
+    if not workflow.definition:
+        verb = {
+            "live": "going live",
+            "paused": "pausing it",
+            "archived": "archiving it",
+        }
+        raise WorkflowValidationError([f"publish a draft before {verb[status]}"])
     return await accessor.set_workflow_status(merchant_id, workflow_id, status)
 
 

--- a/tests/crm/test_workflow_entry.py
+++ b/tests/crm/test_workflow_entry.py
@@ -1,0 +1,128 @@
+"""The entry-rules consumer's listening path (W5) — rollout phase 01, B1.
+
+A wait_event reply whose payload lacks the node's key must NOT wake the
+run. Written as {reply_<node>: None} with wake_at = now, the walker's
+pick_next read None as "the alarm fired" and took the timeout edge at
+once: any letter on the listened topic without the key ended the
+listening window early and mis-routed. The fix is at the consumer — no
+resume without an answer — while pick_next keeps its alarm semantics,
+pinned here so the two halves cannot drift apart."""
+
+import asyncio
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional, Tuple
+from uuid import uuid4
+
+import pytest
+
+import app.crm.outreach.entry as entry
+from app.crm.outreach.entry import consume_attributed_event
+from app.crm.outreach.plans import TIMEOUT
+from app.crm.outreach.schemas import Workflow, WorkflowNode
+from app.crm.outreach.walker import pick_next
+from app.crm.record.schemas import RawEvent
+
+NOW = datetime(2026, 9, 3, 10, 0, tzinfo=timezone.utc)
+
+# A COD-confirmation board: the first square listens for a button reply.
+_LISTENING_PLAN = {
+    "entry": {"topic": "orders/create"},
+    "nodes": [
+        {
+            "id": "ask",
+            "type": "wait_event",
+            "topics": ["button.reply"],
+            "key": "button_id",
+            "minutes": 60,
+        },
+        {"id": "confirm", "type": "wait", "minutes": 1},
+        {"id": "call", "type": "call", "template_id": "tpl-1"},
+    ],
+    "edges": [["ask", "confirm", "YES"], ["ask", "call", TIMEOUT]],
+    "goal": {"topics": ["order.confirmed"]},
+}
+
+
+def _flow() -> Workflow:
+    return Workflow(
+        id=uuid4(),
+        merchant_id="m1",
+        name="cod-confirm",
+        status="live",
+        version=1,
+        created_by=None,
+        created_at=NOW,
+        updated_at=NOW,
+        definition=_LISTENING_PLAN,
+        draft=None,
+    )
+
+
+def _reply(payload: Dict[str, Any]) -> RawEvent:
+    return RawEvent(
+        id="ev-1",
+        merchant_id="m1",
+        source="whatsapp",
+        topic="button.reply",
+        schema_version="1",
+        external_id="wamid-1",
+        payload=payload,
+        received_at=NOW,
+        occurred_at=NOW,
+    )
+
+
+@pytest.fixture
+def resumes(monkeypatch: pytest.MonkeyPatch) -> List[Tuple[Any, ...]]:
+    """One live listening plan; every resume the consumer asks for is
+    recorded. Goal-cancel must never be reached (no goal topic matches)."""
+    calls: List[Tuple[Any, ...]] = []
+
+    async def live_workflows(merchant_id: str) -> List[Workflow]:
+        return [_flow()]
+
+    async def resume_run_on_event(*args: Any) -> None:
+        calls.append(args)
+
+    async def cancel_open_runs(*args: Any, **kwargs: Any) -> int:
+        raise AssertionError("a button reply is not a goal event")
+
+    monkeypatch.setattr(entry.accessor, "live_workflows", live_workflows)
+    monkeypatch.setattr(entry.accessor, "resume_run_on_event", resume_run_on_event)
+    monkeypatch.setattr(entry.accessor, "cancel_open_runs", cancel_open_runs)
+    return calls
+
+
+def test_a_reply_carrying_the_key_wakes_the_listening_run(
+    resumes: List[Tuple[Any, ...]],
+) -> None:
+    asyncio.run(consume_attributed_event(_reply({"button_id": "YES"}), "c-1", {}))
+    ((merchant, _workflow_id, customer, node, patch),) = resumes
+    assert (merchant, customer, node) == ("m1", "c-1", "ask")
+    assert patch == {"reply_ask": "YES"}
+
+
+def test_a_reply_without_the_key_never_wakes_the_run(
+    resumes: List[Tuple[Any, ...]],
+) -> None:
+    """B1: with no answer there is nothing to branch on. Resuming with
+    None made the walker take the timeout edge immediately — the listening
+    window ended early on an unrelated letter. The window continues; only
+    the alarm may time it out."""
+    asyncio.run(consume_attributed_event(_reply({"text": "hello"}), "c-1", {}))
+    assert resumes == []
+
+
+def test_the_alarm_path_still_times_a_listening_node_out() -> None:
+    """pick_next keeps its law: no answer in context = the alarm fired ->
+    the timeout edge. B1 is fixed at the consumer, never here."""
+    node = WorkflowNode(
+        id="ask",
+        type="wait_event",
+        topics=["button.reply"],
+        key="button_id",
+        minutes=60,
+    )
+    arrows: List[Tuple[str, Optional[str]]] = [("confirm", "YES"), ("call", TIMEOUT)]
+    assert pick_next(node, arrows, {}) == "call"
+    assert pick_next(node, arrows, {"reply_ask": "YES"}) == "confirm"

--- a/tests/crm/test_workflow_plans.py
+++ b/tests/crm/test_workflow_plans.py
@@ -1,7 +1,16 @@
 """W1 publish-validator laws: the exact edit classes canon T19 says the
 validator must block, each as a red test."""
 
+from datetime import datetime, timezone
+from uuid import uuid4
+
+import pytest
+
+import app.crm.outreach.plans as plans
 from app.crm.outreach.plans import validate_definition
+from app.crm.outreach.schemas import Workflow
+
+NOW = datetime(2026, 9, 3, 10, 0, tzinfo=timezone.utc)
 
 
 def _definition(**overrides):
@@ -203,3 +212,152 @@ def test_changing_entry_key_mid_flight_is_blocked() -> None:
         _definition(entry=keyed), occupied_nodes=["wait-30m"], live_entry=live_entry
     )
     assert any("entry rule changed" in p for p in problems)
+
+
+# --- rollout phase 01: B3 (entry compared by meaning) and B4 (draft -> live) ---
+
+_TERSE_DRAFT = {
+    "entry": {"topic": "checkout.initiated"},
+    "nodes": [{"id": "w", "type": "wait", "minutes": 30}],
+    "edges": [],
+    "goal": {"topics": ["order.placed"]},
+}
+_SPELLED_OUT_ENTRY = {
+    "topic": "checkout.initiated",
+    "where": {},
+    "reenter": False,
+    "cooldown_hours": 24.0,
+    "key": None,
+}
+
+
+def test_publish_compares_the_live_entry_by_meaning_not_spelling() -> None:
+    """B3: the live entry is whatever dict the last publish stored. A draft
+    that omits the defaults compared unequal to a live entry that spelled
+    them out (or the reverse) — a spurious "entry rule changed" refusal on
+    a re-publish that changed nothing about admission."""
+    assert (
+        validate_definition(
+            _TERSE_DRAFT, occupied_nodes=["w"], live_entry=_SPELLED_OUT_ENTRY
+        )
+        == []
+    )
+    explicit = {**_TERSE_DRAFT, "entry": _SPELLED_OUT_ENTRY}
+    assert (
+        validate_definition(
+            explicit, occupied_nodes=["w"], live_entry={"topic": "checkout.initiated"}
+        )
+        == []
+    )
+
+
+def test_a_live_entry_that_no_longer_parses_is_compared_raw() -> None:
+    """A legacy row whose entry fails today's shape cannot be normalised;
+    the raw dicts are compared as before, so a real change is still caught."""
+    problems = validate_definition(
+        _TERSE_DRAFT, occupied_nodes=["w"], live_entry={"topic": ""}
+    )
+    assert any("entry rule changed" in p for p in problems)
+
+
+def _workflow(status: str, definition) -> Workflow:
+    return Workflow(
+        id=uuid4(),
+        merchant_id="m1",
+        name="plan",
+        status=status,
+        version=0 if definition is None else 1,
+        created_by=None,
+        created_at=NOW,
+        updated_at=NOW,
+        definition=definition,
+        draft=_TERSE_DRAFT,
+    )
+
+
+@pytest.mark.asyncio
+async def test_going_live_on_a_never_published_draft_is_refused_before_the_db(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """B4: migration 057's CHECK (status = 'draft' OR definition IS NOT
+    NULL) used to fire as an asyncpg error -> HTTP 500. The pre-read
+    refuses in logic (a 422), and the UPDATE is never issued — no driver
+    exception is raised, let alone caught outside db/."""
+
+    async def get_workflow(merchant_id: str, workflow_id: str) -> Workflow:
+        return _workflow("draft", None)
+
+    async def set_workflow_status(*args: object) -> None:
+        raise AssertionError("must not reach the UPDATE")
+
+    monkeypatch.setattr(plans.accessor, "get_workflow", get_workflow)
+    monkeypatch.setattr(plans.accessor, "set_workflow_status", set_workflow_status)
+    with pytest.raises(plans.WorkflowValidationError) as refused:
+        await plans.set_status("m1", "wf-1", "live")
+    assert "publish" in refused.value.problems[0]
+
+
+@pytest.mark.asyncio
+async def test_pausing_or_archiving_a_never_published_draft_is_refused_too(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """057 admits a NULL definition only while status = 'draft', so paused
+    and archived hit the same CHECK as live — one pre-read covers all."""
+
+    async def get_workflow(merchant_id: str, workflow_id: str) -> Workflow:
+        return _workflow("draft", None)
+
+    async def set_workflow_status(*args: object) -> None:
+        raise AssertionError("must not reach the UPDATE")
+
+    monkeypatch.setattr(plans.accessor, "get_workflow", get_workflow)
+    monkeypatch.setattr(plans.accessor, "set_workflow_status", set_workflow_status)
+    for wanted in ("paused", "archived"):
+        with pytest.raises(plans.WorkflowValidationError) as refused:
+            await plans.set_status("m1", "wf-1", wanted)
+        assert "publish a draft" in refused.value.problems[0], wanted
+
+
+@pytest.mark.asyncio
+async def test_a_published_plan_still_pauses_and_resumes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    published = _workflow("live", _TERSE_DRAFT)
+    writes: list = []
+
+    async def get_workflow(merchant_id: str, workflow_id: str) -> Workflow:
+        return published
+
+    async def set_workflow_status(
+        merchant_id: str, workflow_id: str, status: str
+    ) -> Workflow:
+        writes.append(status)
+        return published
+
+    monkeypatch.setattr(plans.accessor, "get_workflow", get_workflow)
+    monkeypatch.setattr(plans.accessor, "set_workflow_status", set_workflow_status)
+    assert await plans.set_status("m1", "wf-1", "paused") is published
+    assert await plans.set_status("m1", "wf-1", "live") is published
+    assert writes == ["paused", "live"]
+
+
+@pytest.mark.asyncio
+async def test_unknown_or_archived_plans_answer_none_for_the_404(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def set_workflow_status(*args: object) -> None:
+        raise AssertionError("must not reach the UPDATE")
+
+    monkeypatch.setattr(plans.accessor, "set_workflow_status", set_workflow_status)
+
+    async def missing(merchant_id: str, workflow_id: str) -> None:
+        return None
+
+    monkeypatch.setattr(plans.accessor, "get_workflow", missing)
+    assert await plans.set_status("m1", "wf-1", "live") is None
+
+    async def archived(merchant_id: str, workflow_id: str) -> Workflow:
+        return _workflow("archived", None)
+
+    monkeypatch.setattr(plans.accessor, "get_workflow", archived)
+    assert await plans.set_status("m1", "wf-1", "live") is None


### PR DESCRIPTION
**Rollout phase 01** — `docs/crm/workflow-rollout/01-outreach-correctness.md` (notes §4 W-1/W-3/W-5, §11 B1/B3/B4).

Three reproduced bugs in `app/crm/outreach`, each a pure-function or single-read fix with a red test. No migration, no vocabulary change. Branched from `release` after #1058 merged, so no rebase was needed.

## What changed

| Bug | Before | After | Where |
|---|---|---|---|
| **B1** | A `wait_event` reply whose payload lacks `node.key` was written as `{reply_<node>: None}` with `wake_at = now`; `pick_next` read `None` as "the alarm fired" and took the **timeout** edge at once, so any letter on the listened topic without the key ended the listening window early and mis-routed. | No answer, no resume (logged at info with the key, workflow and event id — never a payload value). The window continues; only the alarm may time it out. `pick_next` unchanged; its alarm semantics are now pinned by a test. | `entry.py` listening loop |
| **B3** | Publish compared the live entry as a raw dict: a draft that omitted `reenter`/`cooldown_hours`/`where`/`key` refused with a spurious "entry rule changed while runs are open" against a live entry that spelled them out, and vice versa. | Both sides go through `WorkflowEntry.model_validate(...).model_dump()` in a pure `_entry_changed` helper. A live entry that no longer parses (legacy row) falls back to the raw compare, so a real change is still refused. | `plans.py::validate_definition` |
| **B4** | `POST /{id}/status {live}` on a never-published draft violated migration 057's `CHECK (status = 'draft' OR definition IS NOT NULL)`, surfaced as an asyncpg error → **500**. The CHECK admits a NULL definition only while status is `draft`, so `paused` and `archived` on such a draft failed the same way. | `set_status` pre-reads the plan: unknown/foreign/archived → `None` (404 as today); any move off `draft` without a definition → `WorkflowValidationError(["publish a draft before going live" / "pausing it" / "archiving it"])` → **422**. No driver exception is handled in logic (boundary law); the CHECK stays the backstop for the read→update gap. | `plans.py::set_status`, `api.py` status route |

Two deviations from the phase file's text, not its intent. (1) It scopes B4 to `live`; the same CHECK fires for `paused` and `archived` on a never-published draft, so the pre-read refuses all three (one line, one extra test). (2) It says `api.py` "already maps that to 422". The status route was the one route without the `except WorkflowValidationError` clause (create, draft and publish have it), so the clause is added there. Without it B4 would have moved from a 500 to a different 500.

## Red tests (fail on `release`, pass here)

`tests/crm/test_workflow_entry.py` (new):
- `test_a_reply_without_the_key_never_wakes_the_run` — **red on release** (resume was called with `{"reply_ask": None}`)
- `test_a_reply_carrying_the_key_wakes_the_listening_run` — guard, passes both sides
- `test_the_alarm_path_still_times_a_listening_node_out` — pins `pick_next` (`{}` → timeout edge, answer → its edge)

`tests/crm/test_workflow_plans.py`:
- `test_publish_compares_the_live_entry_by_meaning_not_spelling` — **red on release** (spurious "entry rule changed")
- `test_a_live_entry_that_no_longer_parses_is_compared_raw` — guard for the legacy fallback
- `test_going_live_on_a_never_published_draft_is_refused_before_the_db` — **red on release** (reached the UPDATE)
- `test_pausing_or_archiving_a_never_published_draft_is_refused_too` — **red on release** (same CHECK, same 500; found on self-review and folded in)
- `test_unknown_or_archived_plans_answer_none_for_the_404` — **red on release** (reached the UPDATE)
- `test_a_published_plan_still_pauses_and_resumes` — guard

The existing refusals are kept and still pass: a real topic change and a `key` added mid-flight are refused; phase 00's "changing repeat words mid-flight is blocked" test still holds under the model compare.

## Checks (unpiped before push)

`black` · `isort` · `autoflake` · `pyrefly check` (0 errors) · `pytest tests/crm` (**528 passed** = 519 on release + 9 new) · `check_crm_boundaries.py` (clean) · `check_migrations.py --base origin/release` (clean) · import-smoke of the outreach router (8 routes mount). One commit.

## Decisions already made — disagreements

None. B1 fixed by not resuming (no sentinel answer, no new edge vocabulary). B4 stays a logic-side pre-read; no DB constraint change, no driver types in logic.

## Not done on purpose

- The phase file's acceptance line offers updating `context/reading-notes.md` §11 rows B1/B3/B4 "in the same commit". Left untouched per the rollout rule that context notes are never edited in a rollout PR; the PR list is the ledger.

## Adjacent observations, left alone

- **N1 / W-7**: `entry.py` and `pick_next` still match `node.type == "wait_event"` as a string rather than asking the registry. Out of scope here (backlog).
- **B2** (phase 02): keyed plans are still refused on the second key by the per-customer admission guard. **P1** (phase 03): walker writes remain unconditional, so a reply that lands mid-visit can still be clobbered by the timeout path.
- `set_status` now costs one extra SELECT per status change (admin operation, negligible); the walker's paused/archived checks are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014UNZ4z7zb87HnNHjTXoFpW
