### PR TITLE
fix(crm): admission guards scope to the enrollment key on keyed plans (rollout 02)

### DIFF
--- a/app/crm/outreach/db/accessor.py
+++ b/app/crm/outreach/db/accessor.py
@@ -123,9 +123,15 @@ async def live_workflows(merchant_id: str) -> List[Workflow]:
 
 
 async def admission_facts(
-    conn: asyncpg.Connection, merchant_id: str, workflow_id: str, customer_id: str
+    conn: asyncpg.Connection,
+    merchant_id: str,
+    workflow_id: str,
+    customer_id: str,
+    enrollment_key: Optional[str] = None,
 ) -> Dict[str, Any]:
-    query, values = admission_facts_query(merchant_id, workflow_id, customer_id)
+    query, values = admission_facts_query(
+        merchant_id, workflow_id, customer_id, enrollment_key
+    )
     row = await conn.fetchrow(query, *values)
     return {
         "runs": row["runs"] if row else 0,

--- a/app/crm/outreach/db/queries.py
+++ b/app/crm/outreach/db/queries.py
@@ -157,10 +157,28 @@ def insert_enrollment_query(
 
 
 def admission_facts_query(
-    merchant_id: str, workflow_id: str, customer_id: str
+    merchant_id: str,
+    workflow_id: str,
+    customer_id: str,
+    enrollment_key: Optional[str] = None,
 ) -> Tuple[str, List[Any]]:
     """Everything the admission guards need in one read: has she EVER run
-    this flow (reenter), when did her latest run begin (cooldown)."""
+    this flow (reenter), when did her latest run begin (cooldown).
+
+    On a keyed plan (entry.key, canon T20 col 13: "one run per <field>")
+    the history judged is that KEY's, not the customer's — "has this
+    ORDER ever run" is what the author declared, so her second order has
+    no history and is admitted (B2, rollout phase 02). The customer
+    predicate stays beside the key for tenancy paranoia. Unkeyed plans
+    keep the customer-wide read."""
+    if enrollment_key is not None:
+        query = f"""
+            SELECT count(*) AS runs, max(entered_at) AS latest_entered_at
+            FROM {ENROLLMENT_TABLE}
+            WHERE merchant_id = $1 AND workflow_id = $2
+              AND enrollment_key = $3 AND customer_id = $4
+        """
+        return query, [merchant_id, workflow_id, enrollment_key, customer_id]
     query = f"""
         SELECT count(*) AS runs, max(entered_at) AS latest_entered_at
         FROM {ENROLLMENT_TABLE}

--- a/app/crm/outreach/enrol.py
+++ b/app/crm/outreach/enrol.py
@@ -102,8 +102,15 @@ async def _enrol_in_txn(
     ):
         return None  # this event already made its run (at-least-once scan)
 
+    # Keyed plan: the guards judge THIS key's history (B2 — "one run per
+    # <field>" means reenter/cooldown are about the order, not the
+    # customer). Unkeyed: the key is the customer id and the read is hers.
     facts = await accessor.admission_facts(
-        txn, merchant_id, str(workflow.id), customer_id
+        txn,
+        merchant_id,
+        str(workflow.id),
+        customer_id,
+        enrollment_key=enrollment_key if definition.entry.key else None,
     )
     now = datetime.now(timezone.utc)
     admit, reason = _admission(

--- a/tests/crm/test_workflow_admission.py
+++ b/tests/crm/test_workflow_admission.py
@@ -1,12 +1,20 @@
 """W2 admission guards (canon: entry carries reenter + cooldown, enforced
 for both doors) and arrival scheduling — pure decide functions."""
 
+import asyncio
 from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, List, Optional, cast
+from uuid import UUID, uuid4
 
+import pytest
+
+import app.crm.outreach.enrol as enrol_mod
+from app.crm.outreach.db import DbTxn
 from app.crm.outreach.enrol import _admission, _first_wake
-from app.crm.outreach.schemas import WorkflowDefinition
+from app.crm.outreach.schemas import EnrollmentRun, Workflow, WorkflowDefinition
 
 NOW = datetime(2026, 8, 26, 14, 0, tzinfo=timezone.utc)
+CUSTOMER = str(uuid4())
 
 
 def _definition(reenter: bool = True, cooldown_hours: float = 0.0, first_node=None):
@@ -122,3 +130,128 @@ def test_context_phone_is_normalized_for_the_send_path() -> None:
     # a clear reason, which beats losing the number at this seam.
     assert _phone_from_payload({"phone": "n/a"}) == "n/a"
     assert _phone_from_payload({}) is None
+
+
+# --- rollout phase 02 (B2): keyed plans judge admission per key, not per customer ---
+
+
+def _workflow(key: Optional[str], reenter: bool = False) -> Workflow:
+    entry: Dict[str, Any] = {"topic": "orders/create", "reenter": reenter}
+    if key:
+        entry["key"] = key
+    return Workflow(
+        id=uuid4(),
+        merchant_id="m1",
+        name="wismo",
+        status="live",
+        version=1,
+        created_by=None,
+        created_at=NOW,
+        updated_at=NOW,
+        definition={
+            "entry": entry,
+            "nodes": [{"id": "wait-30m", "type": "wait", "minutes": 30}],
+            "edges": [],
+            "goal": {"topics": ["order.delivered"]},
+        },
+        draft=None,
+    )
+
+
+class _History:
+    """The accessor slice _enrol_in_txn touches. The customer has ONE run
+    on this plan, five minutes old, keyed ORD-1; ORD-2 has never run."""
+
+    def __init__(self) -> None:
+        self.judged: List[Optional[str]] = []
+        self.inserted: List[str] = []
+
+    async def source_event_used(self, conn: Any, *args: Any) -> bool:
+        return False
+
+    async def admission_facts(
+        self,
+        conn: Any,
+        merchant_id: str,
+        workflow_id: str,
+        customer_id: str,
+        enrollment_key: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        self.judged.append(enrollment_key)
+        if enrollment_key in (None, "ORD-1"):
+            return {"runs": 1, "latest_entered_at": NOW - timedelta(minutes=5)}
+        return {"runs": 0, "latest_entered_at": None}
+
+    async def insert_enrollment(
+        self,
+        conn: Any,
+        merchant_id: str,
+        workflow_id: str,
+        workflow_version: int,
+        customer_id: str,
+        current_node: str,
+        wake_at: datetime,
+        context: Dict[str, Any],
+        enrollment_key: str,
+    ) -> EnrollmentRun:
+        self.inserted.append(enrollment_key)
+        return EnrollmentRun(
+            id=uuid4(),
+            merchant_id=merchant_id,
+            workflow_id=UUID(workflow_id),
+            workflow_version=workflow_version,
+            customer_id=UUID(customer_id),
+            status="waiting",
+            current_node=current_node,
+            wake_at=wake_at,
+            entered_at=NOW,
+            exited_at=None,
+            exit_reason=None,
+            context=context,
+            enrollment_key=enrollment_key,
+            attempts=0,
+            last_error=None,
+        )
+
+
+def _enrol(history: _History, workflow: Workflow, key: str) -> Optional[EnrollmentRun]:
+    definition = WorkflowDefinition.model_validate(workflow.definition)
+    return asyncio.run(
+        enrol_mod._enrol_in_txn(
+            cast(DbTxn, object()), "m1", workflow, definition, CUSTOMER, {}, key
+        )
+    )
+
+
+def test_a_keyed_plan_admits_a_new_key_despite_the_customers_history(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """B2: with the defaults (reenter False, cooldown 24h) the customer's
+    second order was refused as reenter_disabled, because admission
+    counted ALL her runs on the plan. "Has this ORDER ever run" is what
+    entry.key declared — a new order id has no history, so it is admitted."""
+    history = _History()
+    monkeypatch.setattr(enrol_mod, "accessor", history)
+    run = _enrol(history, _workflow(key="order_id"), "ORD-2")
+    assert run is not None and history.inserted == ["ORD-2"]
+    assert history.judged == ["ORD-2"]  # judged per key, never per customer
+
+
+def test_a_keyed_plan_still_refuses_a_key_that_already_ran(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    history = _History()
+    monkeypatch.setattr(enrol_mod, "accessor", history)
+    assert _enrol(history, _workflow(key="order_id"), "ORD-1") is None
+    assert history.inserted == [] and history.judged == ["ORD-1"]
+
+
+def test_an_unkeyed_plan_keeps_judging_the_customer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No entry.key: the key IS the customer id and the guards read her
+    whole history on the plan, exactly as before."""
+    history = _History()
+    monkeypatch.setattr(enrol_mod, "accessor", history)
+    assert _enrol(history, _workflow(key=None), CUSTOMER) is None
+    assert history.inserted == [] and history.judged == [None]

--- a/tests/crm/test_workflow_queries.py
+++ b/tests/crm/test_workflow_queries.py
@@ -92,6 +92,20 @@ def test_admission_and_source_reads_are_merchant_first() -> None:
         assert params[0] == "m1"
 
 
+def test_admission_facts_scope_to_the_key_on_keyed_plans() -> None:
+    """B2 (rollout phase 02): entry.key says runs are per <field>, so the
+    history the reenter/cooldown guards judge is that KEY's, not the
+    customer's whole history — otherwise her second order is refused as a
+    re-entry. The customer predicate stays, for tenancy paranoia."""
+    sql, params = admission_facts_query("m1", "wf-1", "c-1", enrollment_key="ORD-2")
+    assert "enrollment_key = $3" in sql and "customer_id = $4" in sql
+    assert params == ["m1", "wf-1", "ORD-2", "c-1"]
+    # the unkeyed form is untouched
+    sql, params = admission_facts_query("m1", "wf-1", "c-1")
+    assert "enrollment_key" not in sql and "customer_id = $3" in sql
+    assert params == ["m1", "wf-1", "c-1"]
+
+
 def test_claim_skips_paused_plans_and_counts_the_claim() -> None:
     sql, values = claim_due_runs_query(50, 300)
     assert "w.status = 'paused'" in sql and "NOT EXISTS" in sql


### PR DESCRIPTION
**Rollout phase 02** — `docs/crm/workflow-rollout/02-keyed-admission.md` (notes §4 W-4, §11 B2, §12 on why keyed flows exist).

## Why

`entry.key` (canon T20 col 13) says "one run per `<field>`", but the admission guards in `enrol.py` read history per **customer**: `admission_facts` counted every run she ever had on the plan. With the defaults (`reenter: false`, `cooldown_hours: 24`) her second order was refused as `reenter_disabled`, so the documented WISMO case (two parcels, two threads) could never open its second thread. Reproduced in the notes: `_admission(keyed plan, runs=1, latest=now-5m)` → `(False, "reenter_disabled")`.

## What changed

**Semantics (the phase's decision):** on a keyed plan, `reenter` and `cooldown` are judged per `(workflow, enrollment_key)`. "Has this ORDER ever run" is what the author declared. Customer-level spam control across keys belongs to the permission gate (phase 19), not to admission.

| Layer | Change |
|---|---|
| `db/queries.py::admission_facts_query` | Gains `enrollment_key=None`. With a key: `WHERE merchant_id = $1 AND workflow_id = $2 AND enrollment_key = $3 AND customer_id = $4` (the key implies the customer on a keyed plan; the customer predicate stays for tenancy paranoia). The unkeyed builder is untouched. |
| `db/accessor.py::admission_facts` | Same optional parameter, threaded through. |
| `enrol.py::_enrol_in_txn` | Passes the key only when `definition.entry.key` is set. Unkeyed plans still pass the customer id as the key and take the unkeyed builder. |
| Validator | No warning added, per the phase: the semantics change makes the defaults correct for keyed plans (a new order id has no history → admitted). |

No migration, no vocabulary change, no new index (the open-run unique on `(merchant_id, workflow_id, enrollment_key)` already covers the keyed read for open rows; exited rows are a small per-key count).

## Red tests (fail on `release`, pass here)

- `tests/crm/test_workflow_queries.py::test_admission_facts_scope_to_the_key_on_keyed_plans` — **red on release** (`TypeError: unexpected keyword argument 'enrollment_key'`); also pins the unkeyed form unchanged.
- `tests/crm/test_workflow_admission.py::test_a_keyed_plan_admits_a_new_key_despite_the_customers_history` — **red on release** (the atom judged the customer, refused, never reached `insert_enrollment`).
- `tests/crm/test_workflow_admission.py::test_a_keyed_plan_still_refuses_a_key_that_already_ran` — **red on release** (judged with no key).
- `tests/crm/test_workflow_admission.py::test_an_unkeyed_plan_keeps_judging_the_customer` — guard, passes both sides.

The atom is exercised directly (`_enrol_in_txn` with a fake handle and a fake accessor slice), the same shape `test_event_worker.py` uses for `_pass_in_txn`.

## Checks (unpiped before push)

`black` · `isort` · `autoflake` · `pyrefly check` (0 errors) · `pytest tests/crm` (**532 passed** = 528 on release + 4 new) · `check_crm_boundaries.py` (clean) · `check_migrations.py --base origin/release` (clean). One commit.

## Decisions already made — disagreements

None. Implemented as written: per-key semantics, no validator warning, `customer_id` kept in the keyed WHERE.

## Not done on purpose

- The acceptance line's edits to `context/reading-notes.md` (§11 B2, §13 keyed caveat). Left untouched per the rollout rule; the PR list is the ledger.

## Adjacent observations, left alone

- **Staples and keys.** The keyed WHERE keeps `customer_id`, so a key whose earlier run was filed under a customer that has since been merged away is judged as "never ran" for the survivor. Acceptable today (the open-run unique still prevents two open runs per key); a design point for identity's staple semantics (P3, backlog).
- **`source_event_used`** is unchanged and still per customer, which is right: it is per-letter idempotency, not admission.
- **P1** (phase 03) is next: walker writes are still unconditional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014UNZ4z7zb87HnNHjTXoFpW
