### PR TITLE
fix(crm): walker writes are conditional on the lease they were claimed under (rollout 03)

### DIFF
--- a/app/crm/outreach/db/accessor.py
+++ b/app/crm/outreach/db/accessor.py
@@ -189,34 +189,55 @@ async def claim_due_runs(limit: int, lease_seconds: int) -> List[EnrollmentRun]:
 
 
 async def advance_run(
-    run_id: str, current_node: str, wake_at: datetime, context: Dict[str, Any]
-) -> None:
-    query, values = advance_run_query(run_id, current_node, wake_at, context)
+    run_id: str,
+    current_node: str,
+    wake_at: datetime,
+    context: Dict[str, Any],
+    leased_wake_at: datetime,
+) -> bool:
+    """True when the row still carried the lease (the write landed)."""
+    query, values = advance_run_query(
+        run_id, current_node, wake_at, context, leased_wake_at
+    )
     async with crm_connection() as conn:
-        await conn.execute(query, *values)
+        row = await conn.fetchrow(query, *values)
+    return row is not None
 
 
 async def exit_run(
     run_id: str,
     exit_reason: str,
+    leased_wake_at: datetime,
     current_node: Optional[str] = None,
     context: Optional[Dict[str, Any]] = None,
-) -> None:
-    query, values = exit_run_query(run_id, exit_reason, current_node, context)
+) -> bool:
+    """True when the row still carried the lease (the write landed)."""
+    query, values = exit_run_query(
+        run_id, exit_reason, current_node, context, leased_wake_at
+    )
     async with crm_connection() as conn:
-        await conn.execute(query, *values)
+        row = await conn.fetchrow(query, *values)
+    return row is not None
 
 
-async def park_run(run_id: str, last_error: str) -> None:
-    query, values = park_run_query(run_id, last_error)
+async def park_run(run_id: str, last_error: str, leased_wake_at: datetime) -> bool:
+    """True when the row still carried the lease (the write landed)."""
+    query, values = park_run_query(run_id, last_error, leased_wake_at)
     async with crm_connection() as conn:
-        await conn.execute(query, *values)
+        row = await conn.fetchrow(query, *values)
+    return row is not None
 
 
-async def record_run_error(run_id: str, last_error: str, retry_in_seconds: int) -> None:
-    query, values = record_run_error_query(run_id, last_error, retry_in_seconds)
+async def record_run_error(
+    run_id: str, last_error: str, retry_in_seconds: int, leased_wake_at: datetime
+) -> bool:
+    """True when the row still carried the lease (the write landed)."""
+    query, values = record_run_error_query(
+        run_id, last_error, retry_in_seconds, leased_wake_at
+    )
     async with crm_connection() as conn:
-        await conn.execute(query, *values)
+        row = await conn.fetchrow(query, *values)
+    return row is not None
 
 
 async def resume_run_on_event(

--- a/app/crm/outreach/db/queries.py
+++ b/app/crm/outreach/db/queries.py
@@ -1,5 +1,13 @@
 """SQL builders for crm_workflow (T19) and crm_workflow_enrollment (T20).
 $1 placeholders only — every value parameterized.
+
+Two kinds of writer touch a run, and the law between them (P1, rollout
+phase 03): WALKER writes (advance, exit, park, record error) are
+compare-and-set on the leased wake_at — the claim pushed wake_at one
+lease window and returned it, so that value is the generation the visit
+holds; a write carrying a stale lease matches zero rows. EVENT-SIDE writes
+(goal-cancel, a wait_event reply, a repeat patch) are unconditional and
+always move wake_at — the event wins, the walker defers to its next wake.
 """
 
 import json
@@ -233,17 +241,27 @@ def claim_due_runs_query(limit: int, lease_seconds: int) -> Tuple[str, List[Any]
 
 
 def advance_run_query(
-    run_id: str, current_node: str, wake_at: datetime, context: Dict[str, Any]
+    run_id: str,
+    current_node: str,
+    wake_at: datetime,
+    context: Dict[str, Any],
+    leased_wake_at: datetime,
 ) -> Tuple[str, List[Any]]:
     """A successful step: move the token, set its next alarm, reset the
-    failure counter (only CONSECUTIVE failures park a run)."""
+    failure counter (only CONSECUTIVE failures park a run).
+
+    The lease is the generation: a write under a stale lease is a no-op.
+    A reply or a repeat that landed mid-visit moved wake_at, so this
+    UPDATE matches nothing and the walker defers instead of clobbering
+    the answer with the timeout path (P1)."""
     query = f"""
         UPDATE {ENROLLMENT_TABLE}
         SET current_node = $2, wake_at = $3, context = $4::jsonb,
             attempts = 0, last_error = NULL
-        WHERE id = $1 AND status = 'waiting'
+        WHERE id = $1 AND status = 'waiting' AND wake_at = $5
+        RETURNING id
     """
-    return query, [run_id, current_node, wake_at, json.dumps(context)]
+    return query, [run_id, current_node, wake_at, json.dumps(context), leased_wake_at]
 
 
 def exit_run_query(
@@ -251,50 +269,65 @@ def exit_run_query(
     exit_reason: str,
     current_node: Optional[str],
     context: Optional[Dict[str, Any]],
+    leased_wake_at: datetime,
 ) -> Tuple[str, List[Any]]:
-    """An exit without a context KEEPS the row's context: the exited row's
-    pointers (source_event_id above all) are what source_event_used reads
-    to refuse a replayed entry event — wiping them would let the spine's
-    at-least-once redelivery enrol a second run from a stale checkout."""
+    """The WALKER's exit (timed_out, goal_met, completed, ejected). An exit
+    without a context KEEPS the row's context: the exited row's pointers
+    (source_event_id above all) are what source_event_used reads to
+    refuse a replayed entry event — wiping them would let the spine's
+    at-least-once redelivery enrol a second run from a stale checkout.
+
+    The lease is the generation: a write under a stale lease is a no-op
+    (P1). The event side's exit is cancel_open_runs_query, unconditional."""
     query = f"""
         UPDATE {ENROLLMENT_TABLE}
         SET status = 'exited', exit_reason = $2, exited_at = now(),
             wake_at = NULL,
             current_node = COALESCE($3, current_node),
             context = COALESCE($4::jsonb, context)
-        WHERE id = $1 AND status <> 'exited'
+        WHERE id = $1 AND status <> 'exited' AND wake_at = $5
+        RETURNING id
     """
     return query, [
         run_id,
         exit_reason,
         current_node,
         None if context is None else json.dumps(context),
+        leased_wake_at,
     ]
 
 
-def park_run_query(run_id: str, last_error: str) -> Tuple[str, List[Any]]:
+def park_run_query(
+    run_id: str, last_error: str, leased_wake_at: datetime
+) -> Tuple[str, List[Any]]:
     """Errors park, never exit (canon) — held visible for the merchant,
-    resumable by a human."""
+    resumable by a human. The lease is the generation: a park under a
+    stale lease is a no-op (P1) — the run that moved on will be judged
+    again on its next claim."""
     query = f"""
         UPDATE {ENROLLMENT_TABLE}
         SET status = 'parked', wake_at = NULL, last_error = $2
-        WHERE id = $1 AND status = 'waiting'
+        WHERE id = $1 AND status = 'waiting' AND wake_at = $3
+        RETURNING id
     """
-    return query, [run_id, last_error]
+    return query, [run_id, last_error, leased_wake_at]
 
 
 def record_run_error_query(
-    run_id: str, last_error: str, retry_in_seconds: int
+    run_id: str, last_error: str, retry_in_seconds: int, leased_wake_at: datetime
 ) -> Tuple[str, List[Any]]:
     """A transient failure: the retry timer is written into wake_at (canon
-    T20: backoff with jitter), and the reason is kept for the screen."""
+    T20: backoff with jitter), and the reason is kept for the screen. The
+    lease is the generation: under a stale lease this is a no-op (P1) —
+    the reply that moved the run already set its own, earlier alarm."""
     query = f"""
         UPDATE {ENROLLMENT_TABLE}
         SET last_error = $2,
             wake_at = now() + make_interval(secs => $3)
-        WHERE id = $1 AND status = 'waiting'
+        WHERE id = $1 AND status = 'waiting' AND wake_at = $4
+        RETURNING id
     """
-    return query, [run_id, last_error, retry_in_seconds]
+    return query, [run_id, last_error, retry_in_seconds, leased_wake_at]
 
 
 def resume_run_on_event_query(

--- a/app/crm/outreach/walker.py
+++ b/app/crm/outreach/walker.py
@@ -56,30 +56,65 @@ async def claim_due_runs(batch: int) -> List[EnrollmentRun]:
 async def walk_run(run: EnrollmentRun) -> None:
     """Move one claimed token as far as it can go this visit. The claim
     already pushed wake_at one lease window, so every failure path below
-    retries by simply doing nothing — the clock brings the run back."""
+    retries by simply doing nothing — the clock brings the run back.
+
+    Every write this visit makes is conditional on that lease (P1,
+    rollout phase 03): the claim's wake_at is the generation token, and
+    every event-side writer (a reply, a repeat patch, a goal-cancel)
+    moves it. A miss means the run changed under us — defer: the lease
+    already re-arms the run, and the next claim re-reads it WITH the
+    reply and takes the right branch. Action nodes are idempotent
+    (dedupe run:node, uuid5 lead), so a re-executed visit is exactly as
+    safe as the lease retry this file already relied on."""
+    lease = run.wake_at
+    if lease is None:
+        # A claimed run always carries its lease (the claim wrote it, and
+        # waiting rows have wake_at NOT NULL). Anything else is a caller
+        # bug — and a write without a token would be a blind overwrite.
+        logger.error(f"walker: run {run.id} claimed without a lease — skipping")
+        return
     try:
         workflow = await accessor.get_workflow(run.merchant_id, str(run.workflow_id))
         if workflow is None or workflow.status == "archived":
-            await accessor.exit_run(str(run.id), "ejected")
+            if not await accessor.exit_run(str(run.id), "ejected", lease):
+                _deferred(run, "eject")
             return
         if workflow.status == "paused" or not workflow.definition:
             return  # the lease push IS the snooze; re-checked next wake
         definition = WorkflowDefinition.model_validate(workflow.definition)
-        await _advance(run, definition)
+        await _advance(run, definition, lease)
     except NodeParked as e:
-        await accessor.park_run(str(run.id), str(e))
-        logger.warning(f"walker: run {run.id} parked — {e}")
+        if await accessor.park_run(str(run.id), str(e), lease):
+            logger.warning(f"walker: run {run.id} parked — {e}")
+        else:
+            _deferred(run, "park")
     except Exception as e:
         if run.attempts >= CRM_WALKER_MAX_ATTEMPTS:
-            await accessor.park_run(str(run.id), f"attempts exhausted: {e}")
-            logger.error(f"walker: run {run.id} parked after retries — {e}")
+            if await accessor.park_run(str(run.id), f"attempts exhausted: {e}", lease):
+                logger.error(f"walker: run {run.id} parked after retries — {e}")
+            else:
+                _deferred(run, "park")
         else:
             retry_in = retry_delay_seconds(run.attempts, CRM_WALKER_LEASE_SECONDS)
-            await accessor.record_run_error(str(run.id), str(e), retry_in)
-            logger.warning(f"walker: run {run.id} retries in {retry_in}s — {e}")
+            if await accessor.record_run_error(str(run.id), str(e), retry_in, lease):
+                logger.warning(f"walker: run {run.id} retries in {retry_in}s — {e}")
+            else:
+                _deferred(run, "retry")
 
 
-async def _advance(run: EnrollmentRun, definition: WorkflowDefinition) -> None:
+def _deferred(run: EnrollmentRun, write: str) -> None:
+    """A CAS miss: the run moved under the lease (a reply or repeat landed
+    mid-visit). Nothing to undo — the event side's alarm stands and the
+    next claim re-reads the run as it now is."""
+    logger.info(
+        f"walker: run {run.id} changed under the lease ({write} skipped) — "
+        f"deferring to the next wake"
+    )
+
+
+async def _advance(
+    run: EnrollmentRun, definition: WorkflowDefinition, lease: datetime
+) -> None:
     nodes = {node.id: node for node in definition.nodes}
     outgoing = definition.outgoing()
     now = datetime.now(timezone.utc)
@@ -88,7 +123,8 @@ async def _advance(run: EnrollmentRun, definition: WorkflowDefinition) -> None:
     # timed_out no matter which square it stands on.
     max_age = timedelta(days=definition.exits.max_age_days)
     if now - run.entered_at > max_age:
-        await accessor.exit_run(str(run.id), "timed_out")
+        if not await accessor.exit_run(str(run.id), "timed_out", lease):
+            _deferred(run, "timed_out")
         return
 
     # Goal re-check at fire time — one indexed EXISTS via record's
@@ -99,7 +135,8 @@ async def _advance(run: EnrollmentRun, definition: WorkflowDefinition) -> None:
         definition.goal.topics,
         run.entered_at,
     ):
-        await accessor.exit_run(str(run.id), "goal_met")
+        if not await accessor.exit_run(str(run.id), "goal_met", lease):
+            _deferred(run, "goal_met")
         return
 
     current_id = run.current_node
@@ -117,9 +154,14 @@ async def _advance(run: EnrollmentRun, definition: WorkflowDefinition) -> None:
 
         next_id = pick_next(node, outgoing.get(current_id, []), context)
         if next_id is None:
-            await accessor.exit_run(
-                str(run.id), "completed", current_node=current_id, context=context
-            )
+            if not await accessor.exit_run(
+                str(run.id),
+                "completed",
+                lease,
+                current_node=current_id,
+                context=context,
+            ):
+                _deferred(run, "completed")
             return
 
         next_node = nodes.get(next_id)
@@ -127,12 +169,14 @@ async def _advance(run: EnrollmentRun, definition: WorkflowDefinition) -> None:
             raise NodeParked(f"edge points at unknown node {next_id}")
         if is_wait(next_node) and next_node.minutes:
             # Arrival scheduling: the wait's alarm starts now.
-            await accessor.advance_run(
+            if not await accessor.advance_run(
                 str(run.id),
                 next_id,
                 datetime.now(timezone.utc) + timedelta(minutes=next_node.minutes),
                 context,
-            )
+                lease,
+            ):
+                _deferred(run, f"advance to {next_id}")
             return
         current_id = next_id  # action node: execute in this same visit
 

--- a/tests/crm/test_workflow_queries.py
+++ b/tests/crm/test_workflow_queries.py
@@ -6,6 +6,7 @@ from datetime import datetime, timezone
 
 from app.crm.outreach.db.queries import (
     admission_facts_query,
+    advance_run_query,
     cancel_open_runs_query,
     claim_due_runs_query,
     exit_run_query,
@@ -14,6 +15,7 @@ from app.crm.outreach.db.queries import (
     park_run_query,
     publish_workflow_query,
     record_run_error_query,
+    resume_run_on_event_query,
     source_event_used_query,
 )
 from app.crm.record.db.queries import customer_has_event_query
@@ -66,21 +68,47 @@ def test_publish_requires_a_draft_to_exist() -> None:
 
 
 def test_park_only_moves_waiting_runs() -> None:
-    sql, _ = park_run_query("en-1", "boom")
+    sql, _ = park_run_query("en-1", "boom", NOW)
     assert "status = 'waiting'" in sql and "'parked'" in sql
 
 
 def test_exit_never_reexits() -> None:
-    sql, _ = exit_run_query("en-1", "completed", None, {})
+    sql, _ = exit_run_query("en-1", "completed", None, {}, NOW)
     assert "status <> 'exited'" in sql
 
 
 def test_exit_without_context_keeps_the_rows_pointers() -> None:
-    sql, params = exit_run_query("en-1", "goal_met", None, None)
+    sql, params = exit_run_query("en-1", "goal_met", None, None, NOW)
     assert "context = COALESCE($4::jsonb, context)" in sql
     assert params[3] is None  # NULL -> COALESCE keeps source_event_id
-    _, params = exit_run_query("en-1", "completed", "n1", {"reply_x": "YES"})
+    _, params = exit_run_query("en-1", "completed", "n1", {"reply_x": "YES"}, NOW)
     assert json.loads(params[3]) == {"reply_x": "YES"}
+
+
+def test_walker_writes_are_conditional_on_the_leased_wake_at() -> None:
+    """P1 (rollout phase 03): the claim's wake_at is the generation token.
+    Every event-side writer (a reply, a repeat patch) moves wake_at, so a
+    walker write under a stale lease matches zero rows instead of
+    clobbering the reply — and RETURNING id is how the walker learns it."""
+    leased = NOW
+    for sql, params, placeholder in (
+        (*advance_run_query("r-1", "wait-1d", NOW, {"k": 1}, leased), "$5"),
+        (*exit_run_query("r-1", "completed", None, None, leased), "$5"),
+        (*park_run_query("r-1", "boom", leased), "$3"),
+        (*record_run_error_query("r-1", "boom", 600, leased), "$4"),
+    ):
+        assert f"AND wake_at = {placeholder}" in sql, sql
+        assert "RETURNING id" in sql, sql
+        assert params[-1] is leased
+
+
+def test_event_side_writes_stay_unconditional() -> None:
+    """The reply and the goal-cancel are the event side: they always win
+    over a walker mid-visit (the walker defers on its CAS miss)."""
+    sql, _ = cancel_open_runs_query("m1", "wf-1", "c-1", "goal_met")
+    assert "AND wake_at =" not in sql
+    sql, _ = resume_run_on_event_query("m1", "wf-1", "c-1", "ask", {"reply_ask": "YES"})
+    assert "AND wake_at =" not in sql
 
 
 def test_admission_and_source_reads_are_merchant_first() -> None:
@@ -114,9 +142,9 @@ def test_claim_skips_paused_plans_and_counts_the_claim() -> None:
 
 
 def test_transient_error_writes_the_retry_into_wake_at() -> None:
-    sql, values = record_run_error_query("r-1", "boom", 600)
+    sql, values = record_run_error_query("r-1", "boom", 600, NOW)
     assert "wake_at = now() + make_interval(secs => $3)" in sql
-    assert values == ["r-1", "boom", 600]
+    assert values == ["r-1", "boom", 600, NOW]
 
 
 def test_goal_recheck_survives_a_null_occurred_at() -> None:

--- a/tests/crm/test_workflow_walker.py
+++ b/tests/crm/test_workflow_walker.py
@@ -1,0 +1,198 @@
+"""The walker's writes are conditional on the lease they were claimed
+under (P1, rollout phase 03).
+
+claim_due_runs pushes wake_at one lease window and RETURNS the row, so the
+decoded run's wake_at IS the claim's token. Every event-side writer moves
+wake_at (a reply sets now(), a repeat patch slides it), so a walker write
+that still carries the leased value is a write nobody raced; one that does
+not match zero rows. On that miss the walker defers — the lease already
+re-arms the run, and the next claim re-reads it WITH the reply and takes
+the right branch. Before this, advance_run overwrote context and wake_at
+unconditionally and the timeout path could clobber a reply that landed
+mid-visit.
+
+Exercised against the private _advance/walk_run with a fake accessor slice,
+the same shape test_event_worker.py uses for the pass."""
+
+import asyncio
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, List, Optional, Tuple
+from uuid import uuid4
+
+import pytest
+
+import app.crm.outreach.walker as walker
+from app.crm.outreach.nodes import NodeParked
+from app.crm.outreach.schemas import EnrollmentRun, Workflow, WorkflowDefinition
+
+NOW = datetime(2026, 9, 3, 12, 0, tzinfo=timezone.utc)
+LEASE = NOW + timedelta(seconds=300)
+
+_TWO_WAITS = {
+    "entry": {"topic": "checkout.initiated"},
+    "nodes": [
+        {"id": "wait-30m", "type": "wait", "minutes": 30},
+        {"id": "wait-1d", "type": "wait", "minutes": 1440},
+    ],
+    "edges": [["wait-30m", "wait-1d"]],
+    "goal": {"topics": ["order.placed"]},
+}
+_ONE_WAIT = {**_TWO_WAITS, "nodes": _TWO_WAITS["nodes"][:1], "edges": []}
+
+
+def _run(wake_at: Optional[datetime] = LEASE, attempts: int = 1) -> EnrollmentRun:
+    return EnrollmentRun(
+        id=uuid4(),
+        merchant_id="m1",
+        workflow_id=uuid4(),
+        workflow_version=1,
+        customer_id=uuid4(),
+        status="waiting",
+        current_node="wait-30m",
+        wake_at=wake_at,
+        entered_at=NOW - timedelta(minutes=31),
+        exited_at=None,
+        exit_reason=None,
+        context={"phone": "+919876543210"},
+        enrollment_key="c-1",
+        attempts=attempts,
+        last_error=None,
+    )
+
+
+class _Writes:
+    """The accessor slice the walker writes through. ``matched`` is the
+    CAS answer every write returns; ``calls`` records what was asked."""
+
+    def __init__(self, matched: bool, definition: Dict[str, Any]) -> None:
+        self.matched = matched
+        self.definition = definition
+        self.calls: List[Tuple[str, Tuple[Any, ...]]] = []
+
+    async def get_workflow(self, merchant_id: str, workflow_id: str) -> Workflow:
+        return Workflow(
+            id=uuid4(),
+            merchant_id=merchant_id,
+            name="plan",
+            status="live",
+            version=1,
+            created_by=None,
+            created_at=NOW,
+            updated_at=NOW,
+            definition=self.definition,
+            draft=None,
+        )
+
+    async def advance_run(self, *args: Any) -> bool:
+        self.calls.append(("advance", args))
+        return self.matched
+
+    async def exit_run(self, *args: Any, **kwargs: Any) -> bool:
+        self.calls.append(("exit", args + tuple(kwargs.values())))
+        return self.matched
+
+    async def park_run(self, *args: Any) -> bool:
+        self.calls.append(("park", args))
+        return self.matched
+
+    async def record_run_error(self, *args: Any) -> bool:
+        self.calls.append(("retry", args))
+        return self.matched
+
+
+@pytest.fixture
+def no_goal(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def never(*args: Any, **kwargs: Any) -> bool:
+        return False
+
+    monkeypatch.setattr(walker, "customer_has_event", never)
+
+
+def _advance(writes: _Writes, run: EnrollmentRun) -> None:
+    definition = WorkflowDefinition.model_validate(writes.definition)
+    asyncio.run(walker._advance(run, definition, LEASE))
+
+
+def test_advance_carries_the_lease_it_was_claimed_under(
+    monkeypatch: pytest.MonkeyPatch, no_goal: None
+) -> None:
+    writes = _Writes(matched=True, definition=_TWO_WAITS)
+    monkeypatch.setattr(walker, "accessor", writes)
+    run = _run()
+    _advance(writes, run)
+    ((verb, args),) = writes.calls
+    assert verb == "advance"
+    run_id, node, wake, context, lease = args
+    assert (run_id, node, lease) == (str(run.id), "wait-1d", LEASE)
+    assert context == run.context
+    assert (
+        timedelta(minutes=1439)
+        < wake - datetime.now(timezone.utc)
+        < timedelta(minutes=1441)
+    )
+
+
+def test_a_missed_cas_on_advance_defers_without_raising_or_exiting(
+    monkeypatch: pytest.MonkeyPatch, no_goal: None
+) -> None:
+    """The run changed under the lease (a reply landed mid-visit). The
+    walker neither raises nor writes anything else — the next claim
+    re-reads the run with the reply in it."""
+    writes = _Writes(matched=False, definition=_TWO_WAITS)
+    monkeypatch.setattr(walker, "accessor", writes)
+    _advance(writes, _run())
+    assert [verb for verb, _ in writes.calls] == ["advance"]
+
+
+def test_a_missed_cas_on_exit_defers_too(
+    monkeypatch: pytest.MonkeyPatch, no_goal: None
+) -> None:
+    writes = _Writes(matched=False, definition=_ONE_WAIT)
+    monkeypatch.setattr(walker, "accessor", writes)
+    run = _run()
+    _advance(writes, run)
+    ((verb, args),) = writes.calls
+    assert verb == "exit"
+    assert args[0] == str(run.id) and args[1] == "completed" and LEASE in args
+
+
+def test_a_park_under_a_stale_lease_is_a_no_op(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    writes = _Writes(matched=False, definition=_TWO_WAITS)
+    monkeypatch.setattr(walker, "accessor", writes)
+
+    async def parked(*args: Any) -> None:
+        raise NodeParked("template gone")
+
+    monkeypatch.setattr(walker, "_advance", parked)
+    asyncio.run(walker.walk_run(_run()))  # must not raise
+    ((verb, args),) = writes.calls
+    assert verb == "park" and args[-1] == LEASE
+
+
+def test_a_retry_under_a_stale_lease_is_a_no_op(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    writes = _Writes(matched=False, definition=_TWO_WAITS)
+    monkeypatch.setattr(walker, "accessor", writes)
+
+    async def flaky(*args: Any) -> None:
+        raise RuntimeError("provider hiccup")
+
+    monkeypatch.setattr(walker, "_advance", flaky)
+    asyncio.run(walker.walk_run(_run(attempts=1)))
+    ((verb, args),) = writes.calls
+    assert verb == "retry" and args[-1] == LEASE
+
+
+def test_walk_run_never_writes_without_a_lease(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A claimed run always carries its lease (the claim wrote it; waiting
+    rows have wake_at NOT NULL). Without one there is no token to write
+    under, and a blind overwrite is exactly the bug this phase closes."""
+    writes = _Writes(matched=True, definition=_TWO_WAITS)
+    monkeypatch.setattr(walker, "accessor", writes)
+    asyncio.run(walker.walk_run(_run(wake_at=None)))
+    assert writes.calls == []


### PR DESCRIPTION
**Rollout phase 03** — `docs/crm/workflow-rollout/03-enrollment-cas.md` (notes §4 W-2, §11 P1, §12 "#1041 adds a second writer", §14.7).

## Why

`advance_run_query`, `exit_run_query`, `park_run_query` and `record_run_error_query` updated `context`/`wake_at` unconditionally (`WHERE id = $1 AND status = 'waiting'`). The event worker also writes both columns: `resume_run_on_event_query` for a `wait_event` reply, and `patch_open_run_query` (#1041, phase 00) for a repeat. A reply landing while the walker was mid-visit on that node's timeout path was overwritten by the walker's `advance_run`, and the timeout branch won. No migration needed.

## Design — the leased `wake_at` is the generation token

`claim_due_runs_query` already sets `wake_at = now() + lease` and RETURNS the row, so the decoded run's `wake_at` is the claim's token. Every event-side writer moves `wake_at` (a reply sets `now()`, a repeat slides it), and the claim itself moves it. So `AND wake_at = $leased` on the walker's writes is a correct compare-and-set without a new column.

| Layer | Change |
|---|---|
| `db/queries.py` | The four walker-side builders take `leased_wake_at`, add `AND wake_at = $n`, and `RETURNING id`. Each docstring states the law; the module docstring records "walker writes are CAS on the leased `wake_at`; event-side writes are not". `cancel_open_runs` (goal-cancel from the entry consumer), `resume_run_on_event` and `patch_open_run` are untouched — the event side always wins. |
| `db/accessor.py` | The four return `bool` (a row matched). |
| `walker.py` | `walk_run` takes the lease from `run.wake_at` and threads it into every write. On a miss: one info line, "changed under the lease — deferring to the next wake", and return. The lease already re-arms the run; the next claim re-reads it with the reply/patch and takes the right branch. Action nodes are idempotent (dedupe `run:node`, uuid5 lead id), so a re-executed visit is exactly as safe as the lease retry the walker already relied on. A run handed in without a lease (`wake_at` None) is refused with an error log rather than written blind. |

## Red tests (fail on `release`, pass here)

`tests/crm/test_workflow_queries.py`:
- `test_walker_writes_are_conditional_on_the_leased_wake_at` — **red on release** (the builders did not take a lease); each of the four carries `AND wake_at = $n` and `RETURNING id`, with the leased value last.
- `test_event_side_writes_stay_unconditional` — guard: `cancel_open_runs` and `resume_run_on_event` carry no lease predicate.
- The four existing builder tests updated to the new signatures.

`tests/crm/test_workflow_walker.py` (new):
- `test_advance_carries_the_lease_it_was_claimed_under` — **red on release**
- `test_a_missed_cas_on_advance_defers_without_raising_or_exiting` — **red on release** (nothing else written, no raise)
- `test_a_missed_cas_on_exit_defers_too`, `test_a_park_under_a_stale_lease_is_a_no_op`, `test_a_retry_under_a_stale_lease_is_a_no_op` — **red on release**
- `test_walk_run_never_writes_without_a_lease` — **red on release**

## Checks (unpiped before push)

`black` · `isort` · `autoflake` · `pyrefly check` (0 errors) · `pytest tests/crm` (**540 passed** = 532 on release + 8 new) · `check_crm_boundaries.py` (clean) · `check_migrations.py --base origin/release` (clean). One commit.

## Decisions already made — disagreements

None. No `revision` column; the leased `wake_at` is the token, exactly as written.

## One residual worth knowing (the phase's own revisit clause)

The phase says "revisit only if a writer ever needs to leave `wake_at` untouched (none does)". Since phase 00 one can: the repeat patch is `GREATEST(wake_at, now() + debounce)`, so a repeat that lands mid-visit with a debounce shorter than the lease still remaining leaves `wake_at` at the leased value and is invisible to this CAS. Consequence is bounded: those facts arrive after the alarm already fired, the walker moves the run off the entry node in the same visit, and nothing duplicates or mis-routes. If that ever matters, a `revision` column is the answer. Not done here (would widen the phase).

## Not done on purpose

- The acceptance line's edit to `context/reading-notes.md` §11 P1. Left untouched per the rollout rule; the PR list is the ledger.

## Adjacent observations, left alone

- `resume_run` (the operator's parked → waiting) and `cancel_open_runs` remain unconditional by design; parked rows carry `wake_at` NULL, so they can never collide with a lease.
- The SQL was not executed against a Postgres in this session; the added predicate compares the stored `timestamptz` with the exact value the claim's RETURNING handed back (microsecond precision on both sides).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014UNZ4z7zb87HnNHjTXoFpW
