### PR TITLE
fix(crm): crm_event_raw counts attempts and quarantines poison rows (rollout 04)

### DIFF
--- a/app/core/config/static.py
+++ b/app/core/config/static.py
@@ -490,6 +490,11 @@ CRM_ROLE = os.environ.get("CRM_ROLE", "api").lower()
 CRM_WORKER_INTERVAL = _positive_float("CRM_WORKER_INTERVAL", 1.0)
 CRM_WORKER_BATCH = _positive_int("CRM_WORKER_BATCH", 100)
 CRM_WORKER_HEARTBEAT = _positive_float("CRM_WORKER_HEARTBEAT", 60.0)
+# Event worker: every claim spends one attempt on the row (migration 062,
+# the enrollment.attempts shape); a row whose consumer still raises at
+# this count is quarantined instead of sitting at the head of the queue
+# forever. Replay (clear processed_at/quarantine_reason) re-drives it.
+CRM_EVENT_MAX_ATTEMPTS = _positive_int("CRM_EVENT_MAX_ATTEMPTS", 5)
 
 # CRM outbound dispatcher (runs only when CRM_ROLE=dispatcher; pacing rides
 # CRM_WORKER_INTERVAL, but the batch is its own dial below). send() reaches

--- a/app/crm/record/db/decoder.py
+++ b/app/crm/record/db/decoder.py
@@ -27,6 +27,7 @@ def decode_raw_event(row: Mapping[str, Any]) -> RawEvent:
         received_at=row["received_at"],
         occurred_at=row["occurred_at"],
         customer_id=str(row["customer_id"]) if row["customer_id"] else None,
+        attempts=int(row["attempts"]),
     )
 
 

--- a/app/crm/record/db/queries.py
+++ b/app/crm/record/db/queries.py
@@ -44,16 +44,33 @@ def insert_event_query(
 
 def claim_pending_events_query(limit: int) -> Tuple[str, List[Any]]:
     """The lock IS the claim: FOR UPDATE SKIP LOCKED means concurrent
-    event-worker replicas never fight over the same row. Ordered by
-    received_at to match crm_event_raw_pending_ix (T13)."""
+    event-worker replicas never fight over the same row, and the lock is
+    held by the enclosing transaction (_pass_in_txn) until its commit.
+    Ordered by received_at to match crm_event_raw_pending_ix (T13) — the
+    CTE keeps that order on the rows handed back, which an UPDATE's
+    RETURNING alone does not promise.
+
+    The claim SPENDS an attempt (migration 062; the enrollment claim's
+    shape, 058): counted by the claim, not by the failure, so a crash
+    mid-row counts against the row and a poison row can no longer hide
+    at the head of the queue — the worker quarantines it once attempts
+    reach CRM_EVENT_MAX_ATTEMPTS."""
     query = f"""
-        SELECT id, merchant_id, source, topic, schema_version, external_id,
-               payload, received_at, occurred_at, customer_id
-        FROM {EVENT_RAW_TABLE}
-        WHERE processed_at IS NULL
-        ORDER BY received_at
-        LIMIT $1
-        FOR UPDATE SKIP LOCKED
+        WITH claimed AS (
+            UPDATE {EVENT_RAW_TABLE}
+            SET attempts = attempts + 1
+            WHERE id IN (
+                SELECT id FROM {EVENT_RAW_TABLE}
+                WHERE processed_at IS NULL
+                ORDER BY received_at
+                LIMIT $1
+                FOR UPDATE SKIP LOCKED
+            )
+            RETURNING id, merchant_id, source, topic, schema_version,
+                      external_id, payload, received_at, occurred_at,
+                      customer_id, attempts
+        )
+        SELECT * FROM claimed ORDER BY received_at
     """
     return query, [limit]
 

--- a/app/crm/record/schemas.py
+++ b/app/crm/record/schemas.py
@@ -40,7 +40,8 @@ class Extracted(BaseModel):
 
 class RawEvent(BaseModel):
     """One claimed crm_event_raw row (T13). processed_at/quarantine_reason
-    aren't modeled: a claimed row is always still pending."""
+    aren't modeled: a claimed row is always still pending. ``attempts``
+    already counts the claim that handed the row over (062)."""
 
     id: str
     merchant_id: str
@@ -52,6 +53,7 @@ class RawEvent(BaseModel):
     received_at: datetime
     occurred_at: Optional[datetime] = None
     customer_id: Optional[str] = None
+    attempts: int = 0
 
 
 class EventIn(BaseModel):

--- a/app/crm/record/workers.py
+++ b/app/crm/record/workers.py
@@ -8,6 +8,7 @@ registry's business (record/extractors), and this file only asks it."""
 from datetime import datetime, timezone
 from typing import Dict, List, Optional, Tuple
 
+from app.core.config.static import CRM_EVENT_MAX_ATTEMPTS
 from app.core.logger import logger
 from app.crm.identity.contracts import assert_facts, resolve as crm_resolve
 from app.crm.record.consumers import consumers
@@ -35,8 +36,44 @@ async def _pass_in_txn(txn: DbTxn, limit: int) -> List[RawEvent]:
             async with savepoint(txn):
                 await _process_one(txn, event)
         except Exception as e:
-            logger.error(f"event {event.id} pass failed, will retry next poll: {e}")
+            await _after_failed_row(txn, event, e)
     return events
+
+
+async def _after_failed_row(txn: DbTxn, event: RawEvent, error: Exception) -> None:
+    """The row's savepoint has rolled back; ``txn`` is still valid. The
+    claim already spent this attempt (062), so a row at the ceiling is
+    quarantined here as its own statement, inside its own savepoint — a
+    consumer that raises deterministically used to sit at the head of the
+    queue forever, re-running resolve()/assert_facts() every poll. Below
+    the ceiling the row stays pending and returns next poll, as before.
+    Quarantine, never delete: replay is the recovery. The log names the
+    letter, never its payload."""
+    if event.attempts < CRM_EVENT_MAX_ATTEMPTS:
+        logger.error(
+            f"event {event.id} ({event.source}/{event.topic}) pass failed on "
+            f"attempt {event.attempts}, will retry next poll: {error}"
+        )
+        return
+    reason = f"consumer_error after {event.attempts} attempts: {error}"
+    try:
+        # Its own savepoint: a failed statement on the bare transaction
+        # would abort it, and every later row's stamp would be lost at
+        # commit. Inside a savepoint only this write rolls back.
+        async with savepoint(txn):
+            await accessor.quarantine_event(txn, str(event.id), reason)
+    except Exception as quarantine_error:
+        # The batch must not die for one row's bookkeeping; the row stays
+        # pending and the next claim tries the quarantine again.
+        logger.error(
+            f"event {event.id} ({event.source}/{event.topic}) could not be "
+            f"quarantined, stays pending: {quarantine_error}"
+        )
+        return
+    logger.error(
+        f"event {event.id} ({event.source}/{event.topic}) quarantined after "
+        f"{event.attempts} attempts: {error}"
+    )
 
 
 async def _process_one(txn: DbTxn, event: RawEvent) -> None:

--- a/app/database/migrations/062_add_attempts_to_crm_event_raw.sql
+++ b/app/database/migrations/062_add_attempts_to_crm_event_raw.sql
@@ -1,0 +1,38 @@
+-- 062: crm_event_raw.attempts (canon T13; rollout phase 04, P2) — the
+-- claim spends an attempt, so a poison row can be quarantined.
+--
+-- A row whose consumer raised deterministically (a bad live definition,
+-- a DB error on one merchant) stayed processed_at IS NULL forever:
+-- re-claimed every poll at the head of the queue (ORDER BY received_at),
+-- re-running resolve()/assert_facts() each time, never quarantining.
+-- Compare crm_workflow_enrollment.attempts (058): counted BY the claim,
+-- so a crash mid-row counts against the row too. The event worker
+-- quarantines the row once attempts reach CRM_EVENT_MAX_ATTEMPTS.
+-- Quarantine, not delete — replay is the recovery mechanism: clear
+-- processed_at/quarantine_reason by hand to re-drive the letter.
+--
+-- attempts is ENVELOPE, like processed_at, quarantine_reason and
+-- customer_id. 051's immutability trigger denies changes to the
+-- ingestion fields only, so it already admits this column; the function
+-- is re-created here (CREATE OR REPLACE — the 060 amendment precedent,
+-- never an edit to 051) only so its message names every mutable envelope
+-- column truthfully. The trigger binding is unchanged.
+
+ALTER TABLE crm_event_raw
+    ADD COLUMN attempts smallint NOT NULL DEFAULT 0;
+
+CREATE OR REPLACE FUNCTION crm_event_raw_immutable() RETURNS trigger AS $$
+BEGIN
+    IF NEW.merchant_id     IS DISTINCT FROM OLD.merchant_id
+       OR NEW.source          IS DISTINCT FROM OLD.source
+       OR NEW.topic           IS DISTINCT FROM OLD.topic
+       OR NEW.schema_version  IS DISTINCT FROM OLD.schema_version
+       OR NEW.external_id     IS DISTINCT FROM OLD.external_id
+       OR NEW.payload         IS DISTINCT FROM OLD.payload
+       OR NEW.received_at     IS DISTINCT FROM OLD.received_at
+       OR NEW.occurred_at     IS DISTINCT FROM OLD.occurred_at THEN
+        RAISE EXCEPTION 'crm_event_raw ingestion fields are immutable — only processed_at, quarantine_reason, customer_id and attempts may change';
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;

--- a/docs/crm/migrations.md
+++ b/docs/crm/migrations.md
@@ -76,3 +76,8 @@ Rules the template encodes:
   a deploy, never a migration.
 - Accessors reach these tables only through
   `app.crm.shared.db.crm_transaction()`.
+- On `crm_event_raw` the envelope columns (`processed_at`,
+  `quarantine_reason`, `customer_id`, `attempts`) are the only mutable
+  ones — the 051 immutability trigger (amended in 062) refuses every
+  ingestion field, and `attempts` is spent by the claim so a poison row
+  quarantines after `CRM_EVENT_MAX_ATTEMPTS` instead of looping forever.

--- a/tests/crm/test_event_worker.py
+++ b/tests/crm/test_event_worker.py
@@ -32,6 +32,8 @@ import app.crm.record.extractors.shopify as shopify_extractor
 import app.crm.record.workers as workers
 import app.crm.shared.worker as worker_mod
 from app.crm.record.db import DbTxn
+from app.crm.record.db.decoder import decode_raw_event
+from app.crm.record.db.queries import claim_pending_events_query
 from app.crm.record.extractors import EXTRACTORS
 from app.crm.record.schemas import Extracted, RawEvent
 from app.crm.shared.worker import run_drain_loop
@@ -94,6 +96,7 @@ def _event(
     topic: str = "lead.pushed",
     customer_id: Optional[str] = None,
     payload: Optional[Dict[str, Any]] = None,
+    attempts: int = 1,
 ) -> RawEvent:
     return RawEvent(
         id=event_id,
@@ -109,6 +112,7 @@ def _event(
         ),
         received_at=datetime.now(timezone.utc),
         customer_id=customer_id,
+        attempts=attempts,
     )
 
 
@@ -456,6 +460,88 @@ def test_a_failing_entry_rule_costs_its_own_row_only(
     assert fake_accessor.stamped == [("evt-2", "c2")]
     # ...and the claim still reports both rows as work found.
     assert [e.id for e in result] == ["evt-1", "evt-2"]
+
+
+# --- rollout phase 04 (P2): the claim spends an attempt; poison rows quarantine ---
+
+
+def test_the_claim_spends_an_attempt_and_returns_it() -> None:
+    """The lock is still the claim (FOR UPDATE SKIP LOCKED inside the
+    pass's transaction), but the claim now counts against the row — the
+    crm_workflow_enrollment shape (058): a crash mid-row counts too, so a
+    poison row cannot hide behind never reaching its except."""
+    sql, params = claim_pending_events_query(10)
+    assert "attempts = attempts + 1" in sql
+    assert "FOR UPDATE SKIP LOCKED" in sql and "processed_at IS NULL" in sql
+    returning = sql.split("RETURNING", 1)[1]
+    assert "attempts" in returning and "payload" in returning
+    assert "ORDER BY received_at" in sql  # the pending index's order, kept
+    assert params == [10]
+
+
+def test_decoder_carries_attempts() -> None:
+    row = {
+        "id": "e1",
+        "merchant_id": "m1",
+        "source": "shopify",
+        "topic": "orders/create",
+        "schema_version": "1",
+        "external_id": "x",
+        "payload": '{"a": 1}',
+        "received_at": datetime.now(timezone.utc),
+        "occurred_at": None,
+        "customer_id": None,
+        "attempts": 3,
+    }
+    assert decode_raw_event(row).attempts == 3
+
+
+def _poison_pass(
+    monkeypatch: pytest.MonkeyPatch, attempts: int, max_attempts: int
+) -> _FakeAccessor:
+    """One claimed row whose consumer raises deterministically."""
+    fake_accessor = _FakeAccessor()
+    monkeypatch.setattr(workers, "accessor", fake_accessor)
+    monkeypatch.setattr(workers, "CRM_EVENT_MAX_ATTEMPTS", max_attempts)
+    event = _event("evt-1", customer_id="c1", attempts=attempts)
+
+    async def fake_claim(conn: Any, limit: int) -> List[RawEvent]:
+        return [event]
+
+    async def poison(
+        event: RawEvent, customer_id: str, handles: Dict[str, str]
+    ) -> None:
+        raise RuntimeError("bad live definition")
+
+    monkeypatch.setattr(
+        fake_accessor, "claim_pending_events", fake_claim, raising=False
+    )
+    monkeypatch.setattr(workers, "_consume_attributed_event", poison)
+    _run(workers._pass_in_txn(_fake_txn(), 10))
+    return fake_accessor
+
+
+def test_a_row_that_exhausted_its_attempts_is_quarantined_not_retried_forever(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Before: a deterministically failing consumer left the row pending
+    forever, re-claimed at the head of the queue every poll and re-running
+    resolve()/assert_facts() each time. Now the claim that reaches
+    CRM_EVENT_MAX_ATTEMPTS quarantines it — outside the rolled-back
+    savepoint, as its own statement on the still-valid transaction."""
+    fake_accessor = _poison_pass(monkeypatch, attempts=5, max_attempts=5)
+    assert len(fake_accessor.quarantined) == 1
+    event_id, reason = fake_accessor.quarantined[0]
+    assert event_id == "evt-1"
+    assert reason.startswith("consumer_error after 5 attempts")
+    assert fake_accessor.stamped == []  # quarantine is the terminal stamp
+
+
+def test_a_row_with_attempts_to_spare_stays_pending(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_accessor = _poison_pass(monkeypatch, attempts=1, max_attempts=5)
+    assert fake_accessor.quarantined == [] and fake_accessor.stamped == []
 
 
 def test_pass_returns_claimed_rows_even_when_every_row_failed(


### PR DESCRIPTION
**Rollout phase 04** — `docs/crm/workflow-rollout/04-event-attempts-quarantine.md` (notes §3 record observation, §11 P2). **Carries a migration (062).**

## Why

`record/workers.py::_pass_in_txn` claims pending rows `FOR UPDATE SKIP LOCKED` ordered by `received_at`. A row whose consumer raises deterministically (a bad live definition, a DB error on one merchant) stays `processed_at IS NULL` forever: it is re-claimed every poll at the head of the queue and re-runs `resolve()`/`assert_facts()` each time, and it never quarantines. `crm_workflow_enrollment.attempts` (058) already solves this for runs by letting the claim count.

## What changed

| Layer | Change |
|---|---|
| **Migration `062_add_attempts_to_crm_event_raw.sql`** | `attempts smallint NOT NULL DEFAULT 0` on `crm_event_raw`. The 051 immutability function is re-created with `CREATE OR REPLACE` (the 060 precedent; 051 itself untouched). Note: 051's trigger denies the *ingestion* fields only, so it already admitted the new column; the replace exists so the error message names every mutable envelope column truthfully. No new table, so `TABLE_OWNERS` is unchanged. |
| `record/db/queries.py::claim_pending_events_query` | The claim **spends** an attempt: `UPDATE … SET attempts = attempts + 1 WHERE id IN (SELECT … FOR UPDATE SKIP LOCKED) RETURNING …` (the 058/056 claim shape). Wrapped in a CTE with `ORDER BY received_at` so the batch keeps the pending index's order, which a bare `RETURNING` does not promise. The lock is still held by the enclosing transaction. |
| `record/schemas.py`, `record/db/decoder.py` | `RawEvent.attempts` (default 0), mapped by the decoder. |
| `record/workers.py` | In the per-row except (savepoint already rolled back, `txn` still valid): `attempts >= CRM_EVENT_MAX_ATTEMPTS` → `quarantine_event(txn, id, "consumer_error after N attempts: <error>")` as its own statement inside its own savepoint; otherwise the row stays pending exactly as today. A quarantine that itself fails rolls back only that savepoint, is logged, and the row stays pending, so the batch never dies for one row's bookkeeping (a failed statement on the bare transaction would have aborted it and lost every later stamp at commit). Logs carry the event id and source/topic, never the payload. |
| `app/core/config/static.py` | `CRM_EVENT_MAX_ATTEMPTS` (default 5) beside the `CRM_WORKER_*` knobs. |
| `docs/crm/migrations.md` | One line: the envelope columns are the only mutable ones on `crm_event_raw`. |

## Migration verified on a scratch database

Applied on a local Postgres 16 scratch database (051 then 062, then dropped): the column lands with its default; `attempts`, `processed_at`, `quarantine_reason` and `customer_id` stay writable; an UPDATE of `payload` is refused with the amended message; the new claim statement runs, locks, increments and returns `attempts` in `received_at` order. Output is in the PR comment below the description. `check_migrations.py --base origin/release` is clean (062 is the next free number; if #1021 or #1053 lands a 062 first I will renumber).

## Red tests (fail on `release`, pass here) — `tests/crm/test_event_worker.py`

- `test_the_claim_spends_an_attempt_and_returns_it` — **red** (the claim was a plain SELECT)
- `test_decoder_carries_attempts` — **red** (`RawEvent` had no `attempts`)
- `test_a_row_that_exhausted_its_attempts_is_quarantined_not_retried_forever` — **red** (no ceiling existed); asserts the reason starts `consumer_error after 5 attempts` and that the row is never stamped
- `test_a_row_with_attempts_to_spare_stays_pending` — **red** (the config name did not exist)

Every existing worker test still passes: a failing consumer below the ceiling still costs only its own row and the batch commits the rest.

## Checks (unpiped before push)

`black` · `isort` · `autoflake` · `pyrefly check` (0 errors) · `pytest tests/crm` (**544 passed** = 540 on release + 4 new) · `check_crm_boundaries.py` (clean) · `check_migrations.py --base origin/release` (clean). One commit.

## Decisions already made — disagreements

None. Quarantine, not delete; attempts counted by the claim. Both implemented as written.

## Not done on purpose

- The operator endpoint to re-drive quarantined rows (backlog, per the phase). Replay today is clearing `processed_at`/`quarantine_reason` by hand.

## Adjacent observations, left alone

- `quarantine_event`'s reason column receives the consumer's exception text, which is the same text the worker already logged before this PR. If a consumer ever embeds payload values in its message, both places would carry them; none does today.
- The size guard on the ingest door (P8, backlog) and the poison-extractor path are unchanged: extractor errors still quarantine on the first attempt, as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014UNZ4z7zb87HnNHjTXoFpW
