### PR TITLE
feat(crm): goal tiers with a payload key — recovered vs converted elsewhere, time-aware on the entry event (rollout 06)

### DIFF
--- a/app/crm/outreach/db/accessor.py
+++ b/app/crm/outreach/db/accessor.py
@@ -8,7 +8,7 @@ transaction; standalone single statements self-scope their own connection
 """
 
 from datetime import datetime
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 import asyncpg
 
@@ -290,9 +290,10 @@ async def cancel_open_runs(
     customer_id: str,
     exit_reason: str,
     occurred_at: Optional[datetime] = None,
+    key: Optional[Tuple[str, str]] = None,
 ) -> int:
     query, values = cancel_open_runs_query(
-        merchant_id, workflow_id, customer_id, exit_reason, occurred_at
+        merchant_id, workflow_id, customer_id, exit_reason, occurred_at, key
     )
     async with crm_connection() as conn:
         rows = await conn.fetch(query, *values)

--- a/app/crm/outreach/db/queries.py
+++ b/app/crm/outreach/db/queries.py
@@ -444,24 +444,47 @@ def cancel_open_runs_query(
     customer_id: str,
     exit_reason: str,
     occurred_at: Optional[datetime] = None,
+    key: Optional[Tuple[str, str]] = None,
 ) -> Tuple[str, List[Any]]:
     """Goal-cancel (canon: the goal event resolves OPEN enrolments — open
     is waiting or parked; a parked run she has already satisfied must not
     keep holding the open-run unique) — and the same shape ejects runs
-    when a flow is archived. Time-aware: only runs that began before the
-    goal event count, so a stale goal event redelivered later cannot end
-    a newer run; an unstamped event (occurred_at NULL) keeps today's
-    behaviour and ends every open run."""
+    when a flow is archived. Event-side: unconditional (the walker's
+    writes defer to it, phase 03).
+
+    Time-aware on the ENTRY EVENT (G7, phase 06): only runs whose
+    founding letter happened before the goal event count — the run's
+    context carries that moment (entered_event_at), with the row's
+    insert time as the fallback for runs written before the stamp — so a
+    late-delivered earlier-stage letter cannot keep a run alive past a
+    goal that truly happened after it, and a stale goal redelivered
+    later cannot end a newer run. An unstamped goal (occurred_at NULL)
+    keeps today's behaviour and ends every open run.
+
+    Keyed (phase 06): ``key = (run field, value)`` ends only the run the
+    letter is about (context cart_token = the order's cart_token); the
+    unkeyed form is byte-identical to before."""
+    keyed = "AND context->>$6 = $7" if key else ""
     query = f"""
         UPDATE {ENROLLMENT_TABLE}
         SET status = 'exited', exit_reason = $4, exited_at = now(),
             wake_at = NULL
         WHERE merchant_id = $1 AND workflow_id = $2 AND customer_id = $3
           AND status <> 'exited'
-          AND ($5::timestamptz IS NULL OR entered_at < $5::timestamptz)
+          AND ($5::timestamptz IS NULL OR COALESCE((context->>'entered_event_at')::timestamptz, entered_at) < $5::timestamptz)
+          {keyed}
         RETURNING id
     """
-    return query, [merchant_id, workflow_id, customer_id, exit_reason, occurred_at]
+    params: List[Any] = [
+        merchant_id,
+        workflow_id,
+        customer_id,
+        exit_reason,
+        occurred_at,
+    ]
+    if key:
+        params.extend([key[0], key[1]])
+    return query, params
 
 
 def list_runs_query(

--- a/app/crm/outreach/entry.py
+++ b/app/crm/outreach/entry.py
@@ -30,6 +30,13 @@ from app.crm.shared.normalize import normalize_phone
 # extractor's business, not this file's.
 _PHONE_PATHS = ("customer_mobile_number", "phone")
 
+# The founding letter's own pointers: written once at enrol, never moved
+# by a repeat (phase 00) — the id is what source_event_used dedupes on,
+# the time is what "did she buy AFTER the run began" is measured from
+# (G7): an order placed between the founding checkout and a later cart
+# update must keep counting as after.
+_FOUNDING_KEYS = ("source_event_id", "entered_event_at")
+
 # Small-facts cap (canon: context carries pointers "plus the few small
 # facts the sends will need" — never payload photocopies): scalars only,
 # short values only; the full letter already lives on the event row.
@@ -71,7 +78,7 @@ async def consume_attributed_event(
     the voice mirrors, which resolve before this consumer exists."""
     flows = await accessor.live_workflows(event.merchant_id)
     entry_matches: List[Tuple[Workflow, WorkflowDefinition]] = []
-    goal_matches: List[Workflow] = []
+    goal_matches: List[Tuple[Workflow, WorkflowDefinition]] = []
     listening: List[Tuple[Workflow, WorkflowNode]] = []
     for flow in flows:
         definition = WorkflowDefinition.model_validate(flow.definition)
@@ -79,25 +86,41 @@ async def consume_attributed_event(
             definition.entry.where, event.payload
         ):
             entry_matches.append((flow, definition))
-        if event.topic in definition.goal.topics:
-            goal_matches.append(flow)
+        if definition.goal_tiers(event.topic):
+            goal_matches.append((flow, definition))
         for node in definition.nodes:
             if node.type == "wait_event" and event.topic in node.topics:
                 listening.append((flow, node))
 
     # Goal first: an order arriving right behind its checkout must not
     # cancel the run that checkout is about to start. Then replies, then
-    # entries. Time-aware: only runs that began before the goal event end
-    # (decisions §5) — a stale goal redelivered by the spine cannot end a
-    # run born after it.
-    for flow in goal_matches:
-        await accessor.cancel_open_runs(
-            event.merchant_id,
-            str(flow.id),
-            customer_id,
-            "goal_met",
-            event.occurred_at,
-        )
+    # entries. Time-aware on the entry event: only runs whose founding
+    # letter happened before the goal event end (G7) — a stale goal
+    # redelivered by the spine cannot end a run born after it.
+    #
+    # Tiers are judged keyed-first (goal_tiers): the keyed tier ends the
+    # run the letter is ABOUT (context cart_token = payload cart_token) as
+    # goal_met; the unkeyed tier then sweeps whatever is still open as
+    # converted_elsewhere — the recovered run is already exited, so the
+    # UPDATE's status <> 'exited' keeps the two verdicts apart. A keyed
+    # tier whose payload field is missing cannot say which run it is
+    # about and is skipped; the unkeyed tier still applies.
+    for flow, definition in goal_matches:
+        for tier in definition.goal_tiers(event.topic):
+            key: Optional[Tuple[str, str]] = None
+            if tier.key:
+                value = event.payload.get(tier.key.event)
+                if value in (None, ""):
+                    continue
+                key = (tier.key.run, str(value))
+            await accessor.cancel_open_runs(
+                event.merchant_id,
+                str(flow.id),
+                customer_id,
+                tier.exit_reason,
+                event.occurred_at,
+                key,
+            )
     for flow, node in listening:
         answer = event.payload.get(node.key or "")
         if answer is None:
@@ -167,6 +190,9 @@ async def _try_enrol(
         return  # a keyed plan without its key: a refusal, not an error
     context = _context_from_payload(event.payload)
     context["source_event_id"] = str(event.id)
+    # When the founding letter HAPPENED (its own claim, else the envelope's
+    # receipt): goals compare against this, not the row's insert time (G7).
+    context["entered_event_at"] = (event.occurred_at or event.received_at).isoformat()
     phone = (handles or {}).get("phone") or _phone_from_payload(event.payload)
     if phone:
         context["phone"] = phone
@@ -184,9 +210,10 @@ async def _try_enrol(
         # a no-op, so no second signal from enrol() is needed. The repeat
         # is offered the SAME small facts enrol() was — the normalized
         # phone included, so a corrected number reaches the run — minus
-        # source_event_id: that pointer stays the founding event's, and
-        # patch_open_run_query refuses the founding event by it.
-        repeat_facts = {k: v for k, v in context.items() if k != "source_event_id"}
+        # the founding pointers (_FOUNDING_KEYS): the id is what
+        # patch_open_run_query refuses the founding event by, the time is
+        # what goals are measured from.
+        repeat_facts = {k: v for k, v in context.items() if k not in _FOUNDING_KEYS}
         await apply_repeat(
             event.merchant_id,
             str(flow.id),

--- a/app/crm/outreach/nodes.py
+++ b/app/crm/outreach/nodes.py
@@ -51,6 +51,7 @@ from app.schemas.breeze_buddy.core import ExecutionMode, LeadCallStatus
 # its canonical key by the call node), per-node results and answers.
 _BOOKKEEPING_KEYS = (
     "source_event_id",
+    "entered_event_at",  # entry.py: when the founding letter happened (G7)
     "phone",
     "customer_mobile_number",
     "repeat_event_ids",  # repeat.py: which letters already patched this run

--- a/app/crm/outreach/plans.py
+++ b/app/crm/outreach/plans.py
@@ -13,6 +13,7 @@ from app.crm.outreach.db import DbTxn, accessor, atomically
 from app.crm.outreach.nodes import NODE_TYPES, is_wait
 from app.crm.outreach.repeat import parse_repeat_policy
 from app.crm.outreach.schemas import (
+    GOAL_EXIT_REASONS,
     Workflow,
     WorkflowDefinition,
     WorkflowEntry,
@@ -64,6 +65,22 @@ def validate_definition(
             "entry.debounce_minutes needs a wait as the first node — there is "
             "no entry alarm to slide otherwise"
         )
+
+    # Goal tiers (phase 06): the reason is vocabulary, and one tier per
+    # reason — two tiers claiming goal_met could never be told apart.
+    reasons_seen = set()
+    for index, tier in enumerate(definition.goals):
+        if tier.exit_reason not in GOAL_EXIT_REASONS:
+            problems.append(
+                f"goal tier {index}: exit_reason {tier.exit_reason!r} is not one "
+                f"of {' · '.join(GOAL_EXIT_REASONS)}"
+            )
+        elif tier.exit_reason in reasons_seen:
+            problems.append(
+                f"goal tier {index}: exit_reason {tier.exit_reason!r} is already "
+                "used by an earlier tier — one tier per reason"
+            )
+        reasons_seen.add(tier.exit_reason)
 
     node_types = {node.id: node.type for node in definition.nodes}
     for src, dst in ((edge[0], edge[1]) for edge in definition.edges):

--- a/app/crm/outreach/schemas.py
+++ b/app/crm/outreach/schemas.py
@@ -12,7 +12,7 @@ from datetime import datetime
 from typing import Any, Dict, List, Literal, Optional, Tuple, Union
 from uuid import UUID
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 
 class WorkflowEntry(BaseModel):
@@ -41,12 +41,33 @@ class WorkflowEntry(BaseModel):
     debounce_minutes: float = Field(0, ge=0)
 
 
+class WorkflowGoalKey(BaseModel):
+    """What ties a goal letter to ONE run: the letter's payload field must
+    equal the run's context field (cart_token = cart_token). Compared as
+    text — keys are ids and tokens, never amounts."""
+
+    event: str = Field(min_length=1)
+    run: str = Field(min_length=1)
+
+
+# The reasons a goal TIER may end a run with (vocabulary in code; the 063
+# CHECK on the column is the closed superset). timed_out, ejected and
+# completed are the walker's own verdicts, never a tier's.
+GOAL_EXIT_REASONS = ("goal_met", "converted_elsewhere", "withdrawn")
+
+
 class WorkflowGoal(BaseModel):
-    """The 'she did the thing' topics: any one of them ends every open
-    run for the customer (match=customer; keyed matching lands with the
-    WISMO-style flows)."""
+    """One goal TIER (rollout phase 06): the 'she did the thing' topics,
+    optionally keyed to the run they are about, and the reason the run
+    exits with. Tiers are judged keyed-first (goal_tiers()): the keyed
+    tier says "THIS cart recovered" (goal_met); the unkeyed one says "she
+    bought something" and still ends every other open run — never nudge
+    someone who just bought — but as converted_elsewhere, so the funnel
+    can tell the two apart. A single unkeyed tier is today's behaviour."""
 
     topics: List[str] = Field(min_length=1)
+    key: Optional[WorkflowGoalKey] = None
+    exit_reason: str = "goal_met"
 
 
 class WorkflowExits(BaseModel):
@@ -89,12 +110,32 @@ class WorkflowDefinition(BaseModel):
     entry: WorkflowEntry
     nodes: List[WorkflowNode] = Field(min_length=1)
     edges: List[WorkflowEdge] = Field(default_factory=list)
-    goal: WorkflowGoal
+    goals: List[WorkflowGoal] = Field(min_length=1)
     exits: WorkflowExits = Field(default_factory=WorkflowExits)
     # What the plan's sends are for (canon T16 col 9, NOT NULL on the
     # manifest; the gate checks it against the grant). Required once the
     # plan has a send node; the send node copies it onto every row.
     purpose_key: Optional[str] = None
+
+    @model_validator(mode="before")
+    @classmethod
+    def _goal_becomes_one_tier(cls, data: Any) -> Any:
+        """The singular `goal` (every document published before phase 06)
+        is one tier; `goals` is the list. Both at once is ambiguous."""
+        if isinstance(data, dict) and "goal" in data:
+            if "goals" in data:
+                raise ValueError("give goal or goals, not both")
+            data = dict(data)
+            data["goals"] = [data.pop("goal")]
+        return data
+
+    def goal_tiers(self, topic: Optional[str] = None) -> List[WorkflowGoal]:
+        """The tiers to judge, in judging order: keyed first (the more
+        specific claim — a run it ends is no longer open for the unkeyed
+        sweep), then unkeyed; document order within each. With a topic,
+        only the tiers listening for it."""
+        tiers = [t for t in self.goals if topic is None or topic in t.topics]
+        return [t for t in tiers if t.key] + [t for t in tiers if not t.key]
 
     def outgoing(self) -> Dict[str, List[Tuple[str, Optional[str]]]]:
         """node id -> [(next node id, on)], in document order."""

--- a/app/crm/outreach/walker.py
+++ b/app/crm/outreach/walker.py
@@ -127,17 +127,25 @@ async def _advance(
             _deferred(run, "timed_out")
         return
 
-    # Goal re-check at fire time — one indexed EXISTS via record's
-    # contract, never a foreign SELECT.
-    if await customer_has_event(
-        run.merchant_id,
-        str(run.customer_id),
-        definition.goal.topics,
-        run.entered_at,
-    ):
-        if not await accessor.exit_run(str(run.id), "goal_met", lease):
-            _deferred(run, "goal_met")
-        return
+    # Goal re-check at fire time — one indexed EXISTS per tier via
+    # record's contract, never a foreign SELECT. Tiers are judged
+    # keyed-first (goal_tiers, phase 06): "THIS cart recovered" beats
+    # "she bought something", and the run exits with the tier's reason.
+    # Measured from the founding letter's own time (G7), not the row's.
+    since = goal_since(run)
+    for tier in definition.goal_tiers():
+        where: Optional[Tuple[str, str]] = None
+        if tier.key:
+            value = run.context.get(tier.key.run)
+            if value in (None, ""):
+                continue  # this run cannot match a keyed tier
+            where = (tier.key.event, str(value))
+        if await customer_has_event(
+            run.merchant_id, str(run.customer_id), tier.topics, since, where
+        ):
+            if not await accessor.exit_run(str(run.id), tier.exit_reason, lease):
+                _deferred(run, tier.exit_reason)
+            return
 
     current_id = run.current_node
     context = dict(run.context)
@@ -183,6 +191,23 @@ async def _advance(
     raise NodeParked(
         f"{_MAX_STEPS_PER_VISIT} immediate nodes in one visit — runaway document"
     )
+
+
+def goal_since(run: EnrollmentRun) -> datetime:
+    """PURE: the moment "after the run began" is measured from — the
+    founding letter's own time (entered_event_at, stamped by entry.py:
+    G7), else the row's insert time for runs written before the stamp
+    existed. Total: an unreadable stamp falls back rather than failing
+    the visit."""
+    stamp = run.context.get("entered_event_at")
+    if isinstance(stamp, str):
+        try:
+            parsed = datetime.fromisoformat(stamp)
+        except ValueError:
+            return run.entered_at
+        if parsed.tzinfo is not None:
+            return parsed
+    return run.entered_at
 
 
 def pick_next(

--- a/app/crm/record/db/accessor.py
+++ b/app/crm/record/db/accessor.py
@@ -7,7 +7,7 @@ fail postures and serialization decisions live in the logic files
 """
 
 from datetime import datetime
-from typing import List, Optional
+from typing import List, Optional, Tuple
 
 from app.crm.record.db import DbTxn
 from app.crm.record.db.decoder import decode_journey_card, decode_raw_event
@@ -83,9 +83,15 @@ async def get_customer_journey(
 
 
 async def customer_has_event(
-    merchant_id: str, customer_id: str, topics: List[str], since: datetime
+    merchant_id: str,
+    customer_id: str,
+    topics: List[str],
+    since: datetime,
+    where: Optional[Tuple[str, str]] = None,
 ) -> bool:
-    query, values = customer_has_event_query(merchant_id, customer_id, topics, since)
+    query, values = customer_has_event_query(
+        merchant_id, customer_id, topics, since, where
+    )
     async with crm_connection() as conn:
         row = await conn.fetchrow(query, *values)
     return bool(row["found"]) if row else False

--- a/app/crm/record/db/queries.py
+++ b/app/crm/record/db/queries.py
@@ -128,12 +128,21 @@ def get_customer_journey_query(
 
 
 def customer_has_event_query(
-    merchant_id: str, customer_id: str, topics: List[str], since: datetime
+    merchant_id: str,
+    customer_id: str,
+    topics: List[str],
+    since: datetime,
+    where: Optional[Tuple[str, str]] = None,
 ) -> Tuple[str, List[Any]]:
     """The walker's goal re-check at fire time: did she do the thing after
     the run began? One EXISTS on the stamped customer index. A producer
     that omits occurred_at must not defeat the check (NULL > x is NULL,
-    never true) — the envelope's received_at stands in."""
+    never true) — the envelope's received_at stands in.
+
+    ``where = (payload field, value)`` narrows it to the letters about
+    ONE thing (the order carrying this run's cart_token — outreach's goal
+    key, phase 06), compared as text: keys are ids and tokens."""
+    keyed = "AND payload->>$5 = $6" if where else ""
     query = f"""
         SELECT EXISTS (
             SELECT 1 FROM {EVENT_RAW_TABLE}
@@ -141,6 +150,10 @@ def customer_has_event_query(
               AND customer_id = $2
               AND topic = ANY($3)
               AND COALESCE(occurred_at, received_at) > $4
+              {keyed}
         ) AS found
     """
-    return query, [merchant_id, customer_id, topics, since]
+    params: List[Any] = [merchant_id, customer_id, topics, since]
+    if where:
+        params.extend([where[0], where[1]])
+    return query, params

--- a/app/crm/record/events.py
+++ b/app/crm/record/events.py
@@ -8,12 +8,20 @@ signature.
 """
 
 from datetime import datetime
-from typing import List
+from typing import List, Optional, Tuple
 
 from app.crm.record.db import accessor
 
 
 async def customer_has_event(
-    merchant_id: str, customer_id: str, topics: List[str], since: datetime
+    merchant_id: str,
+    customer_id: str,
+    topics: List[str],
+    since: datetime,
+    where: Optional[Tuple[str, str]] = None,
 ) -> bool:
-    return await accessor.customer_has_event(merchant_id, customer_id, topics, since)
+    """Did she do one of ``topics`` after ``since``? ``where`` narrows it
+    to the letters whose payload field equals a value (the goal key)."""
+    return await accessor.customer_has_event(
+        merchant_id, customer_id, topics, since, where
+    )

--- a/app/database/migrations/063_extend_crm_workflow_enrollment_exit_reasons.sql
+++ b/app/database/migrations/063_extend_crm_workflow_enrollment_exit_reasons.sql
@@ -1,0 +1,24 @@
+-- 063: crm_workflow_enrollment.exit_reason gains 'converted_elsewhere'
+-- (canon T20 col exit_reason; rollout phase 06 — goal tiers with a key).
+--
+-- A goal is now a list of TIERS, each {topics, key?, exit_reason}. For
+-- cart recovery: an order carrying the run's own cart token ends the run
+-- as goal_met ("THIS cart recovered"); any other order by the customer
+-- still ends it — never nudge someone who just bought — but as
+-- converted_elsewhere, so the funnel can tell the two apart. The reason
+-- vocabulary is a closed status enum, so the CHECK is required (law 11)
+-- and amended here rather than dropped.
+--
+-- 058 declared the CHECK inline on the column; Postgres named it
+-- crm_workflow_enrollment_exit_reason_check (verified on 16.10). The
+-- replacement carries an explicit name so the next amendment never has
+-- to guess. Canon amendment (the sixth value) proposed to Swaroop with
+-- this phase, beside 058's 'completed'.
+
+ALTER TABLE crm_workflow_enrollment
+    DROP CONSTRAINT crm_workflow_enrollment_exit_reason_check;
+
+ALTER TABLE crm_workflow_enrollment
+    ADD CONSTRAINT crm_workflow_enrollment_exit_reason_ck
+    CHECK (exit_reason IN ('goal_met', 'timed_out', 'withdrawn',
+                           'ejected', 'completed', 'converted_elsewhere'));

--- a/docs/crm/migrations.md
+++ b/docs/crm/migrations.md
@@ -81,3 +81,9 @@ Rules the template encodes:
   ones — the 051 immutability trigger (amended in 062) refuses every
   ingestion field, and `attempts` is spent by the claim so a poison row
   quarantines after `CRM_EVENT_MAX_ATTEMPTS` instead of looping forever.
+- `crm_workflow_enrollment.exit_reason` is a closed enum in a CHECK
+  (`goal_met`, `timed_out`, `withdrawn`, `ejected`, `completed`,
+  `converted_elsewhere` — the last added by 063 so a goal tier keyed to
+  the run's own cart can say "recovered" while any other order still ends
+  the run, distinguishably). A new reason is a migration that re-creates
+  the constraint under its explicit name, never an edit to 058/063.

--- a/tests/crm/test_workflow_entry.py
+++ b/tests/crm/test_workflow_entry.py
@@ -18,7 +18,7 @@ import pytest
 import app.crm.outreach.entry as entry
 from app.crm.outreach.entry import consume_attributed_event
 from app.crm.outreach.plans import TIMEOUT
-from app.crm.outreach.schemas import Workflow, WorkflowNode
+from app.crm.outreach.schemas import Workflow, WorkflowDefinition, WorkflowNode
 from app.crm.outreach.walker import pick_next
 from app.crm.record.schemas import RawEvent
 
@@ -111,6 +111,122 @@ def test_a_reply_without_the_key_never_wakes_the_run(
     the alarm may time it out."""
     asyncio.run(consume_attributed_event(_reply({"text": "hello"}), "c-1", {}))
     assert resumes == []
+
+
+# --- rollout phase 06: goal tiers with a key, and the entry event's time ---
+
+_CART_PLAN = {
+    "entry": {"topic": "checkouts/update", "reenter": True, "cooldown_hours": 0},
+    "nodes": [{"id": "wait-30m", "type": "wait", "minutes": 30}],
+    "edges": [],
+    "goals": [
+        {
+            "topics": ["orders/create"],
+            "key": {"event": "cart_token", "run": "cart_token"},
+            "exit_reason": "goal_met",
+        },
+        {"topics": ["orders/create"], "exit_reason": "converted_elsewhere"},
+    ],
+}
+
+
+def _order(payload: Dict[str, Any]) -> RawEvent:
+    return RawEvent(
+        id="ev-order",
+        merchant_id="m1",
+        source="shopify",
+        topic="orders/create",
+        schema_version="1",
+        external_id="orders/create:1",
+        payload=payload,
+        received_at=NOW,
+        occurred_at=NOW,
+    )
+
+
+@pytest.fixture
+def cancels(monkeypatch: pytest.MonkeyPatch) -> List[Tuple[Any, ...]]:
+    calls: List[Tuple[Any, ...]] = []
+
+    async def live_workflows(merchant_id: str) -> List[Workflow]:
+        flow = _flow()
+        flow.definition = _CART_PLAN
+        return [flow]
+
+    async def cancel_open_runs(*args: Any) -> int:
+        calls.append((args[3], args[5] if len(args) > 5 else None))
+        return 1
+
+    async def resume_run_on_event(*args: Any) -> None:
+        raise AssertionError("an order is not a reply")
+
+    monkeypatch.setattr(entry.accessor, "live_workflows", live_workflows)
+    monkeypatch.setattr(entry.accessor, "cancel_open_runs", cancel_open_runs)
+    monkeypatch.setattr(entry.accessor, "resume_run_on_event", resume_run_on_event)
+    return calls
+
+
+def test_an_order_carrying_the_cart_token_is_judged_keyed_first(
+    cancels: List[Tuple[Any, ...]],
+) -> None:
+    """THIS cart recovered -> goal_met on the run keyed to it; any other
+    open run of hers still ends, as converted_elsewhere (never nudge
+    someone who just bought). The keyed tier runs first so the recovered
+    run is already exited when the unkeyed tier sweeps."""
+    asyncio.run(consume_attributed_event(_order({"cart_token": "chk-1"}), "c-1", {}))
+    assert cancels == [
+        ("goal_met", ("cart_token", "chk-1")),
+        ("converted_elsewhere", None),
+    ]
+
+
+def test_an_order_without_the_key_can_only_end_runs_elsewhere(
+    cancels: List[Tuple[Any, ...]],
+) -> None:
+    asyncio.run(consume_attributed_event(_order({"total_price": "1850.00"}), "c-1", {}))
+    assert cancels == [("converted_elsewhere", None)]
+
+
+def test_enrol_stamps_the_entry_events_time_and_repeats_never_move_it(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """G7: the run remembers WHEN its founding letter happened (occurred_at,
+    else received_at) under a bookkeeping key, so goals compare against the
+    event's time rather than the row's insert time. A repeat (phase 00)
+    refreshes facts, never the founding time — or an order placed between
+    the founding checkout and a later cart update would stop counting."""
+    seen: Dict[str, Any] = {}
+
+    async def enrol(**kwargs: Any) -> None:
+        seen["enrol"] = dict(kwargs["context"])
+        return None
+
+    async def apply_repeat(*args: Any) -> bool:
+        seen["repeat"] = dict(args[5])
+        return True
+
+    monkeypatch.setattr(entry, "enrol", enrol)
+    monkeypatch.setattr(entry, "apply_repeat", apply_repeat)
+    definition = WorkflowDefinition.model_validate(
+        {**_CART_PLAN, "entry": {**_CART_PLAN["entry"], "on_repeat": "refresh_latest"}}
+    )
+    happened = datetime(2026, 9, 3, 9, 30, tzinfo=timezone.utc)
+    event = RawEvent(
+        id="ev-1",
+        merchant_id="m1",
+        source="shopify",
+        topic="checkouts/update",
+        schema_version="1",
+        external_id="x",
+        payload={"cart_token": "chk-1", "entered_event_at": "forged"},
+        received_at=NOW,
+        occurred_at=happened,
+    )
+    asyncio.run(entry._try_enrol(_flow(), definition, event, "c-1", {}))
+    assert seen["enrol"]["entered_event_at"] == happened.isoformat()
+    assert "entered_event_at" not in seen["repeat"]
+    assert "source_event_id" not in seen["repeat"]
+    assert seen["repeat"]["cart_token"] == "chk-1"
 
 
 def test_the_alarm_path_still_times_a_listening_node_out() -> None:

--- a/tests/crm/test_workflow_goals.py
+++ b/tests/crm/test_workflow_goals.py
@@ -1,0 +1,97 @@
+"""Goal tiers (rollout phase 06): a goal is a list of tiers, each
+{topics, key?, exit_reason}. Tiers are judged keyed-first — the tier that
+can say "THIS cart was recovered" beats the customer-level one that only
+says "she bought something" — and the first tier that matches a run ends
+it with that tier's reason. The singular `goal` is still accepted and
+becomes one tier, so every published document keeps validating."""
+
+from typing import Any, Dict
+
+from app.crm.outreach.plans import validate_definition
+from app.crm.outreach.schemas import WorkflowDefinition
+
+_BASE: Dict[str, Any] = {
+    "entry": {"topic": "checkouts/update", "reenter": True, "cooldown_hours": 0},
+    "nodes": [{"id": "wait-30m", "type": "wait", "minutes": 30}],
+    "edges": [],
+}
+RECOVERED = {
+    "topics": ["orders/create", "orders/paid"],
+    "key": {"event": "cart_token", "run": "cart_token"},
+    "exit_reason": "goal_met",
+}
+ELSEWHERE = {
+    "topics": ["orders/create", "orders/paid"],
+    "exit_reason": "converted_elsewhere",
+}
+
+
+def test_the_singular_goal_still_validates_as_one_tier() -> None:
+    definition = WorkflowDefinition.model_validate(
+        {**_BASE, "goal": {"topics": ["orders/create"]}}
+    )
+    (tier,) = definition.goals
+    assert tier.topics == ["orders/create"]
+    assert tier.key is None and tier.exit_reason == "goal_met"
+    assert validate_definition({**_BASE, "goal": {"topics": ["orders/create"]}}) == []
+
+
+def test_two_tiers_recovered_then_converted_elsewhere() -> None:
+    raw = {**_BASE, "goals": [RECOVERED, ELSEWHERE]}
+    assert validate_definition(raw) == []
+    definition = WorkflowDefinition.model_validate(raw)
+    assert [t.exit_reason for t in definition.goals] == [
+        "goal_met",
+        "converted_elsewhere",
+    ]
+    assert definition.goals[0].key is not None
+    assert definition.goals[0].key.event == "cart_token"
+
+
+def test_goal_and_goals_together_is_a_shape_error() -> None:
+    problems = validate_definition(
+        {**_BASE, "goal": {"topics": ["a"]}, "goals": [{"topics": ["b"]}]}
+    )
+    assert problems and "shape invalid" in problems[0]
+
+
+def test_two_tiers_with_the_same_exit_reason_are_refused() -> None:
+    problems = validate_definition(
+        {**_BASE, "goals": [{"topics": ["a"]}, {"topics": ["b"]}]}
+    )
+    assert any("exit_reason" in p and "goal_met" in p for p in problems)
+
+
+def test_an_exit_reason_outside_the_goal_vocabulary_is_refused() -> None:
+    for bad in ("recovered", "completed", "timed_out", "ejected"):
+        problems = validate_definition(
+            {**_BASE, "goals": [{"topics": ["a"], "exit_reason": bad}]}
+        )
+        assert any("exit_reason" in p for p in problems), bad
+    assert (
+        validate_definition(
+            {
+                **_BASE,
+                "goals": [{"topics": ["loan.rejected"], "exit_reason": "withdrawn"}],
+            }
+        )
+        == []
+    )
+
+
+def test_tiers_are_judged_keyed_first_in_document_order() -> None:
+    """The document lists the customer-level tier FIRST here; the keyed
+    tier must still be judged first — it is the more specific claim, and a
+    run it ends is no longer open for the unkeyed tier to catch."""
+    definition = WorkflowDefinition.model_validate(
+        {**_BASE, "goals": [ELSEWHERE, RECOVERED]}
+    )
+    assert [t.exit_reason for t in definition.goal_tiers()] == [
+        "goal_met",
+        "converted_elsewhere",
+    ]
+    assert [t.exit_reason for t in definition.goal_tiers("orders/paid")] == [
+        "goal_met",
+        "converted_elsewhere",
+    ]
+    assert definition.goal_tiers("orders/refunded") == []

--- a/tests/crm/test_workflow_queries.py
+++ b/tests/crm/test_workflow_queries.py
@@ -47,12 +47,43 @@ def test_goal_cancel_ends_every_open_run_including_parked() -> None:
     assert params[0] == "m1"
 
 
-def test_goal_cancel_is_time_aware_and_null_safe() -> None:
+def test_goal_cancel_is_time_aware_on_the_entry_event_and_null_safe() -> None:
+    """G7 (rollout phase 06): 'after the run began' means after the ENTRY
+    EVENT happened, not after the row was inserted — a late-delivered
+    earlier-stage letter must not keep a run alive past a goal that truly
+    happened after it. entered_at stays the fallback for older rows."""
     sql, params = cancel_open_runs_query("m1", "wf-1", "c-1", "goal_met", NOW)
-    assert "$5::timestamptz IS NULL OR entered_at < $5::timestamptz" in sql
+    assert (
+        "COALESCE((context->>'entered_event_at')::timestamptz, entered_at) "
+        "< $5::timestamptz" in sql
+    )
+    assert "$5::timestamptz IS NULL OR" in sql
     assert params[4] == NOW
     _, params = cancel_open_runs_query("m1", "wf-1", "c-1", "goal_met")
     assert params[4] is None  # unstamped goal keeps today's behaviour
+
+
+def test_goal_cancel_can_be_keyed_to_the_run_it_is_about() -> None:
+    """A keyed tier ends only the run whose context field equals the
+    letter's payload field (cart_token = cart_token); the unkeyed form is
+    byte-identical to before."""
+    sql, params = cancel_open_runs_query(
+        "m1", "wf-1", "c-1", "goal_met", NOW, key=("cart_token", "chk-88412")
+    )
+    assert "AND context->>$6 = $7" in sql
+    assert params[5:] == ["cart_token", "chk-88412"]
+    sql, params = cancel_open_runs_query("m1", "wf-1", "c-1", "converted_elsewhere")
+    assert "$6" not in sql and len(params) == 5
+
+
+def test_goal_recheck_can_be_keyed_to_the_run_it_is_about() -> None:
+    sql, params = customer_has_event_query(
+        "m1", "c-1", ["orders/create"], NOW, where=("cart_token", "chk-88412")
+    )
+    assert "AND payload->>$5 = $6" in sql
+    assert params == ["m1", "c-1", ["orders/create"], NOW, "cart_token", "chk-88412"]
+    sql, params = customer_has_event_query("m1", "c-1", ["orders/create"], NOW)
+    assert "$5" not in sql and len(params) == 4
 
 
 def test_live_workflows_read_is_merchant_scoped() -> None:

--- a/tests/crm/test_workflow_repeat.py
+++ b/tests/crm/test_workflow_repeat.py
@@ -4,6 +4,7 @@ laws, and the validator's two entry rules."""
 
 import asyncio
 import json
+from datetime import datetime, timezone
 from typing import Any, Dict, List
 
 import pytest
@@ -14,6 +15,8 @@ from app.crm.outreach.db.queries import patch_open_run_query
 from app.crm.outreach.plans import validate_definition
 from app.crm.outreach.repeat import parse_repeat_policy, repeat_plan
 from app.crm.outreach.schemas import WorkflowDefinition
+
+_NOW = datetime(2026, 9, 3, 10, 0, tzinfo=timezone.utc)
 
 
 def _definition(**entry_words: Any) -> WorkflowDefinition:
@@ -181,6 +184,8 @@ def test_a_refused_enrol_hands_the_repeat_to_apply_repeat(
         {
             "id": "ev-9",
             "merchant_id": "m1",
+            "received_at": _NOW,
+            "occurred_at": None,
             "payload": {
                 "order_id": "ORD-1",
                 "cart_value": 900,
@@ -209,7 +214,17 @@ def test_a_successful_enrol_never_calls_apply_repeat(
     monkeypatch.setattr(entry, "enrol", new_run)
     monkeypatch.setattr(entry, "apply_repeat", fake_apply)
     flow = type("F", (), {"id": "wf-1"})()
-    event = type("E", (), {"id": "ev-1", "merchant_id": "m1", "payload": {}})()
+    event = type(
+        "E",
+        (),
+        {
+            "id": "ev-1",
+            "merchant_id": "m1",
+            "received_at": _NOW,
+            "occurred_at": None,
+            "payload": {},
+        },
+    )()
     asyncio.run(entry._try_enrol(flow, _definition(on_repeat="accumulate"), event, "c"))
     assert calls == []
 
@@ -297,6 +312,8 @@ def test_the_repeat_carries_the_refreshed_phone_but_never_the_founding_id(
         {
             "id": "ev-9",
             "merchant_id": "m1",
+            "received_at": _NOW,
+            "occurred_at": None,
             "payload": {"customer_mobile_number": "9876543210", "cart_value": 900},
         },
     )()

--- a/tests/crm/test_workflow_walker.py
+++ b/tests/crm/test_workflow_walker.py
@@ -186,6 +186,89 @@ def test_a_retry_under_a_stale_lease_is_a_no_op(
     assert verb == "retry" and args[-1] == LEASE
 
 
+# --- rollout phase 06: the fire-time goal re-check judges tiers keyed-first ---
+
+_TIERED = {
+    **_TWO_WAITS,
+    "goals": [
+        {
+            "topics": ["orders/create"],
+            "key": {"event": "cart_token", "run": "cart_token"},
+            "exit_reason": "goal_met",
+        },
+        {"topics": ["orders/create"], "exit_reason": "converted_elsewhere"},
+    ],
+}
+del _TIERED["goal"]
+ENTERED_EVENT_AT = NOW - timedelta(hours=2)
+
+
+def _tiered_run() -> EnrollmentRun:
+    run = _run()
+    run.context = {
+        "phone": "+919876543210",
+        "cart_token": "chk-1",
+        "entered_event_at": ENTERED_EVENT_AT.isoformat(),
+    }
+    return run
+
+
+def _goal_recheck(
+    monkeypatch: pytest.MonkeyPatch, answers: Dict[Optional[Tuple[str, str]], bool]
+) -> List[Tuple[Any, ...]]:
+    asked: List[Tuple[Any, ...]] = []
+
+    async def customer_has_event(
+        merchant_id: str,
+        customer_id: str,
+        topics: List[str],
+        since: datetime,
+        where: Optional[Tuple[str, str]] = None,
+    ) -> bool:
+        asked.append((tuple(topics), since, where))
+        return answers.get(where, False)
+
+    monkeypatch.setattr(walker, "customer_has_event", customer_has_event)
+    return asked
+
+
+def test_this_cart_recovered_exits_goal_met(monkeypatch: pytest.MonkeyPatch) -> None:
+    writes = _Writes(matched=True, definition=_TIERED)
+    monkeypatch.setattr(walker, "accessor", writes)
+    asked = _goal_recheck(monkeypatch, {("cart_token", "chk-1"): True})
+    _advance(writes, _tiered_run())
+    ((verb, args),) = writes.calls
+    assert verb == "exit" and args[1] == "goal_met"
+    # keyed tier asked first, against the ENTRY EVENT's time (G7)
+    assert asked[0] == (("orders/create",), ENTERED_EVENT_AT, ("cart_token", "chk-1"))
+
+
+def test_another_order_exits_converted_elsewhere(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    writes = _Writes(matched=True, definition=_TIERED)
+    monkeypatch.setattr(walker, "accessor", writes)
+    asked = _goal_recheck(monkeypatch, {None: True})
+    _advance(writes, _tiered_run())
+    ((verb, args),) = writes.calls
+    assert verb == "exit" and args[1] == "converted_elsewhere"
+    assert [where for _, _, where in asked] == [("cart_token", "chk-1"), None]
+
+
+def test_a_run_without_the_key_falls_back_to_the_row_time_and_the_unkeyed_tier(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An older row (no entered_event_at) compares against entered_at, and
+    a run whose context lacks the key field cannot match a keyed tier."""
+    writes = _Writes(matched=True, definition=_TIERED)
+    monkeypatch.setattr(walker, "accessor", writes)
+    asked = _goal_recheck(monkeypatch, {})
+    run = _run()
+    _advance(writes, run)
+    assert asked == [(("orders/create",), run.entered_at, None)]
+    assert [verb for verb, _ in writes.calls] == ["advance"]  # no goal -> moved on
+
+
 def test_walk_run_never_writes_without_a_lease(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
**Rollout phase 06** — `docs/crm/workflow-rollout/06-goal-tiers-and-key.md` (notes §12 Q2/Q3, §16.1, §16.3 G7). **Carries migration 063.** Read #1047 first as the pipeline asks: it retypes `entry.where` into a `conditions` grammar and touches neither goals nor `cancel_open_runs`, so the goal `key` (one payload field equal to one run field) does not contradict it.

## Why

`goal.topics` was customer-level: ANY order by the customer ended every open run as `goal_met`. That is the right safety default (never nudge someone who just bought) but it cannot say whether **this** cart was recovered. The funnel needs: an order carrying the run's cart → `goal_met`; any other order → still exit, but distinguishably.

## What changed

| Layer | Change |
|---|---|
| **Vocabulary** (`schemas.py`) | `WorkflowGoal` is a tier `{topics, key?: {event, run}, exit_reason = "goal_met"}`; `WorkflowDefinition.goals` is a list (≥ 1). The singular `goal` is still accepted and rewritten to one tier by a before-validator; `goal` and `goals` together is a shape error. `goal_tiers(topic?)` returns the judging order: keyed tiers first, then unkeyed, document order within each. |
| **Validator** (`plans.py`) | `exit_reason` must be one of `goal_met · converted_elsewhere · withdrawn` (the goal vocabulary; `timed_out`/`ejected`/`completed` stay the walker's own verdicts). At most one tier per reason. |
| **Migration 063** | Drops 058's inline CHECK (`crm_workflow_enrollment_exit_reason_check`, name verified on Postgres 16.10, so no `DO` block was needed) and re-creates it under an explicit name with `converted_elsewhere` added. Closed status enum → CHECK required (law 11). `TABLE_OWNERS` unchanged. |
| **Record contract** | `customer_has_event(..., where=(payload_field, value))` → `AND payload->>$5 = $6`, compared as text (keys are ids and tokens). Threaded through `events.py` and the accessor. |
| **Outreach queries** | `cancel_open_runs_query(..., key=(run_field, value))` → `AND context->>$6 = $7`; the unkeyed form is byte-identical. |
| **Entry consumer** | For each tier listening for the letter's topic, keyed-first: a keyed tier whose payload field is missing cannot say which run it is about and is skipped; otherwise cancel with the tier's reason and key. The keyed cancel runs first, so the recovered run is already exited when the unkeyed sweep (`status <> 'exited'`) runs. |
| **Walker re-check** | Iterates the same tiers in the same order, keyed with the run's context value, and exits with the tier's reason. A run whose context lacks the key field cannot match a keyed tier. |
| **G7, time-aware on the entry event** | `entry.py` stamps `context["entered_event_at"]` = the founding letter's `occurred_at` (else `received_at`), a bookkeeping key (never a template variable, never plantable by a producer). `cancel_open_runs_query` compares `COALESCE((context->>'entered_event_at')::timestamptz, entered_at) < goal occurred_at`; the walker passes the same value as `since` (`goal_since`, total: an unreadable stamp falls back to `entered_at`). Rows written before this phase keep comparing on `entered_at`. |

## Migration verified on a scratch database

057 → 058 → 063 on a local Postgres 16, then dropped: the constraint is replaced under its explicit name, `converted_elsewhere` is accepted, an unknown reason is refused, and the keyed, entry-event-aware predicate matches an order at 10:00 carrying the run's cart, matches nothing for an order at 09:00 (before the founding letter), and matches nothing for a different cart. Transcript in the comment below. `check_migrations.py --base origin/release` is clean; 063 is the next free number (#1047 still carries a 062 that already clashed with the merged 062 and will need renumbering regardless).

## Red tests (15, all fail on `release`, pass here)

- `tests/crm/test_workflow_goals.py` (new, 6): singular `goal` → one tier; two tiers; `goal`+`goals` refused; same reason twice refused; reason vocabulary (incl. `withdrawn` accepted, `completed` refused); keyed-first ordering regardless of document order.
- `tests/crm/test_workflow_queries.py` (3): the cancel compares on the entry event's time; keyed cancel and keyed re-check builders; unkeyed forms unchanged.
- `tests/crm/test_workflow_entry.py` (3): an order with the cart token is judged keyed-first then `converted_elsewhere`; an order without the token only `converted_elsewhere`; enrol stamps the entry event's time and a repeat never moves it (nor the founding id).
- `tests/crm/test_workflow_walker.py` (3): this cart recovered → `goal_met`, asked against the entry event's time; another order → `converted_elsewhere`; an older row without the stamp falls back to `entered_at` and only the unkeyed tier.

Two carried tests from #1041 gained `received_at` on their stub events (a real `RawEvent` always has it); no assertion changed.

## Checks (unpiped before push)

`black` · `isort` · `autoflake` · `pyrefly check` (0 errors) · `pytest tests/crm` (**558 passed** = 544 on release + 14 new, plus one existing query test rewritten for the entry-event time) · `check_crm_boundaries.py` (clean) · `check_migrations.py --base origin/release` (clean). One commit.

## Decisions already made — disagreements

None. Two tiers, not item-overlap logic; closed set in a CHECK; cart key `cart_token` is phase 07's to confirm against the relay payload.

## Two judgment calls, stated so you can overrule

- **Goal tiers may only use `goal_met`, `converted_elsewhere`, `withdrawn`.** The phase says "the closed set (see migration)"; the CHECK's set also contains the walker's own verdicts (`timed_out`, `ejected`, `completed`). A tier claiming `completed` would misreport the funnel, so the validator refuses those three for tiers. Widening is one tuple.
- **A repeat never refreshes `entered_event_at`.** The phase adds the stamp; it does not say what a phase-00 repeat does with it. If a repeat moved it, an order placed between the founding checkout and a later cart update would stop counting as "after the run began" and the customer would be nudged after buying. The stamp stays the founding letter's, beside `source_event_id`.

## Not done on purpose

- Recovered-revenue capture at goal time (phase 09). Plan documents using `goals` (phase 07). The notes-file update the acceptance line offers (rollout rule).

## Adjacent observations, left alone

- **#1047 follow-up:** once `entry.key`/conditions come from the declared catalog, `goal.key.event` should too. Not mine to add here.
- `_where_matches` / `entry.where` untouched; #1047 replaces them and will rebase over this file's goal loop (a few lines apart).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014UNZ4z7zb87HnNHjTXoFpW


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tiered workflow goals with optional event-to-run key matching.
  * Added distinct exit reasons, including “converted elsewhere.”
  * Improved goal evaluation using the workflow’s founding event timestamp.
  * Preserved support for existing single-goal workflow definitions.

* **Bug Fixes**
  * Improved matching for keyed events and fallback goal tiers.
  * Ensured repeated events do not change a workflow’s original start time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->