### PR TITLE
docs(crm): cart-recovery and loan-dropoff plan templates, validated in CI (rollout 07)

### DIFF
--- a/docs/crm/plans/README.md
+++ b/docs/crm/plans/README.md
@@ -1,0 +1,25 @@
+# Plan templates — the two target flows as documents CI validates
+
+Each `*.json` here is the `definition` body of `POST /workflows`
+(wrap it as `{"name": "...", "definition": <file>}`; the runbooks in
+`../runbooks/` show the exact calls). `tests/crm/test_plan_templates.py`
+validates every file on every CI run and pins the shape the notes
+decided, so a vocabulary change that would break a published flow fails
+the PR that makes it.
+
+| File | Flow | Shape |
+|---|---|---|
+| `cart-recovery.json` | Cart abandonment (`context/reading-notes.md` §16.1) | one board: wait 30m → WhatsApp → wait 30m → rescue call → wait 1d |
+| `loan-dropoff/0N-*.json` | Loan-onboarding drop-off (§13 Option A) | one **clock** per stage: wait 30m → call; see that folder's README |
+
+Placeholders: every `template_id` is the string `TEMPLATE_ID_PLACEHOLDER`
+so the document validates as-is — replace it with the merchant's Breeze
+Buddy template id before publishing (the walker parks a run whose call
+node names a template that does not exist). The WhatsApp `template` is a
+NAME (`cart_recovery_1`) resolved against the merchant's approved
+templates at send time; phase 08 makes publish refuse an unknown one.
+
+Not in the documents yet, on purpose: `on_publish` (`pin` | `migrate`)
+is phase 11's word — the cart board will declare `migrate` then (runs are
+a day long; fixing a template name should reach every waiting run), the
+loan board `pin`.

--- a/docs/crm/plans/cart-recovery.json
+++ b/docs/crm/plans/cart-recovery.json
@@ -1,0 +1,79 @@
+{
+  "entry": {
+    "topic": "checkouts/update",
+    "reenter": true,
+    "cooldown_hours": 24,
+    "on_repeat": "refresh_latest",
+    "debounce_minutes": 30
+  },
+  "goals": [
+    {
+      "topics": [
+        "orders/create",
+        "orders/paid"
+      ],
+      "key": {
+        "event": "cart_token",
+        "run": "cart_token"
+      },
+      "exit_reason": "goal_met"
+    },
+    {
+      "topics": [
+        "orders/create",
+        "orders/paid"
+      ],
+      "exit_reason": "converted_elsewhere"
+    }
+  ],
+  "exits": {
+    "max_age_days": 7
+  },
+  "purpose_key": "marketing.cart.recovery",
+  "nodes": [
+    {
+      "id": "wait-30m",
+      "type": "wait",
+      "minutes": 30
+    },
+    {
+      "id": "wa-nudge",
+      "type": "send",
+      "channel": "whatsapp",
+      "template": "cart_recovery_1"
+    },
+    {
+      "id": "wait-30m-2",
+      "type": "wait",
+      "minutes": 30
+    },
+    {
+      "id": "rescue-call",
+      "type": "call",
+      "template_id": "TEMPLATE_ID_PLACEHOLDER"
+    },
+    {
+      "id": "wait-1d",
+      "type": "wait",
+      "minutes": 1440
+    }
+  ],
+  "edges": [
+    [
+      "wait-30m",
+      "wa-nudge"
+    ],
+    [
+      "wa-nudge",
+      "wait-30m-2"
+    ],
+    [
+      "wait-30m-2",
+      "rescue-call"
+    ],
+    [
+      "rescue-call",
+      "wait-1d"
+    ]
+  ]
+}

--- a/docs/crm/plans/loan-dropoff/01-profile.json
+++ b/docs/crm/plans/loan-dropoff/01-profile.json
@@ -1,0 +1,50 @@
+{
+  "entry": {
+    "topic": "loan.profile_created",
+    "key": "application_id",
+    "reenter": true,
+    "cooldown_hours": 1,
+    "on_repeat": "refresh_latest",
+    "debounce_minutes": 30
+  },
+  "goals": [
+    {
+      "topics": [
+        "loan.kyc_completed",
+        "loan.bank_linked",
+        "loan.offer_accepted",
+        "loan.agreement_signed",
+        "loan.disbursed"
+      ],
+      "exit_reason": "goal_met"
+    },
+    {
+      "topics": [
+        "loan.rejected",
+        "loan.withdrawn"
+      ],
+      "exit_reason": "withdrawn"
+    }
+  ],
+  "exits": {
+    "max_age_days": 1
+  },
+  "nodes": [
+    {
+      "id": "wait-30m",
+      "type": "wait",
+      "minutes": 30
+    },
+    {
+      "id": "dropoff-call",
+      "type": "call",
+      "template_id": "TEMPLATE_ID_PLACEHOLDER"
+    }
+  ],
+  "edges": [
+    [
+      "wait-30m",
+      "dropoff-call"
+    ]
+  ]
+}

--- a/docs/crm/plans/loan-dropoff/02-kyc.json
+++ b/docs/crm/plans/loan-dropoff/02-kyc.json
@@ -1,0 +1,49 @@
+{
+  "entry": {
+    "topic": "loan.kyc_completed",
+    "key": "application_id",
+    "reenter": true,
+    "cooldown_hours": 1,
+    "on_repeat": "refresh_latest",
+    "debounce_minutes": 30
+  },
+  "goals": [
+    {
+      "topics": [
+        "loan.bank_linked",
+        "loan.offer_accepted",
+        "loan.agreement_signed",
+        "loan.disbursed"
+      ],
+      "exit_reason": "goal_met"
+    },
+    {
+      "topics": [
+        "loan.rejected",
+        "loan.withdrawn"
+      ],
+      "exit_reason": "withdrawn"
+    }
+  ],
+  "exits": {
+    "max_age_days": 1
+  },
+  "nodes": [
+    {
+      "id": "wait-30m",
+      "type": "wait",
+      "minutes": 30
+    },
+    {
+      "id": "dropoff-call",
+      "type": "call",
+      "template_id": "TEMPLATE_ID_PLACEHOLDER"
+    }
+  ],
+  "edges": [
+    [
+      "wait-30m",
+      "dropoff-call"
+    ]
+  ]
+}

--- a/docs/crm/plans/loan-dropoff/03-bank.json
+++ b/docs/crm/plans/loan-dropoff/03-bank.json
@@ -1,0 +1,48 @@
+{
+  "entry": {
+    "topic": "loan.bank_linked",
+    "key": "application_id",
+    "reenter": true,
+    "cooldown_hours": 1,
+    "on_repeat": "refresh_latest",
+    "debounce_minutes": 30
+  },
+  "goals": [
+    {
+      "topics": [
+        "loan.offer_accepted",
+        "loan.agreement_signed",
+        "loan.disbursed"
+      ],
+      "exit_reason": "goal_met"
+    },
+    {
+      "topics": [
+        "loan.rejected",
+        "loan.withdrawn"
+      ],
+      "exit_reason": "withdrawn"
+    }
+  ],
+  "exits": {
+    "max_age_days": 1
+  },
+  "nodes": [
+    {
+      "id": "wait-30m",
+      "type": "wait",
+      "minutes": 30
+    },
+    {
+      "id": "dropoff-call",
+      "type": "call",
+      "template_id": "TEMPLATE_ID_PLACEHOLDER"
+    }
+  ],
+  "edges": [
+    [
+      "wait-30m",
+      "dropoff-call"
+    ]
+  ]
+}

--- a/docs/crm/plans/loan-dropoff/04-offer.json
+++ b/docs/crm/plans/loan-dropoff/04-offer.json
@@ -1,0 +1,47 @@
+{
+  "entry": {
+    "topic": "loan.offer_accepted",
+    "key": "application_id",
+    "reenter": true,
+    "cooldown_hours": 1,
+    "on_repeat": "refresh_latest",
+    "debounce_minutes": 30
+  },
+  "goals": [
+    {
+      "topics": [
+        "loan.agreement_signed",
+        "loan.disbursed"
+      ],
+      "exit_reason": "goal_met"
+    },
+    {
+      "topics": [
+        "loan.rejected",
+        "loan.withdrawn"
+      ],
+      "exit_reason": "withdrawn"
+    }
+  ],
+  "exits": {
+    "max_age_days": 1
+  },
+  "nodes": [
+    {
+      "id": "wait-30m",
+      "type": "wait",
+      "minutes": 30
+    },
+    {
+      "id": "dropoff-call",
+      "type": "call",
+      "template_id": "TEMPLATE_ID_PLACEHOLDER"
+    }
+  ],
+  "edges": [
+    [
+      "wait-30m",
+      "dropoff-call"
+    ]
+  ]
+}

--- a/docs/crm/plans/loan-dropoff/05-agreement.json
+++ b/docs/crm/plans/loan-dropoff/05-agreement.json
@@ -1,0 +1,46 @@
+{
+  "entry": {
+    "topic": "loan.agreement_signed",
+    "key": "application_id",
+    "reenter": true,
+    "cooldown_hours": 1,
+    "on_repeat": "refresh_latest",
+    "debounce_minutes": 30
+  },
+  "goals": [
+    {
+      "topics": [
+        "loan.disbursed"
+      ],
+      "exit_reason": "goal_met"
+    },
+    {
+      "topics": [
+        "loan.rejected",
+        "loan.withdrawn"
+      ],
+      "exit_reason": "withdrawn"
+    }
+  ],
+  "exits": {
+    "max_age_days": 1
+  },
+  "nodes": [
+    {
+      "id": "wait-30m",
+      "type": "wait",
+      "minutes": 30
+    },
+    {
+      "id": "dropoff-call",
+      "type": "call",
+      "template_id": "TEMPLATE_ID_PLACEHOLDER"
+    }
+  ],
+  "edges": [
+    [
+      "wait-30m",
+      "dropoff-call"
+    ]
+  ]
+}

--- a/docs/crm/plans/loan-dropoff/README.md
+++ b/docs/crm/plans/loan-dropoff/README.md
@@ -1,0 +1,37 @@
+# Loan drop-off as clocks — one small plan per stage
+
+The funnel (`loan.profile_created` → `kyc_completed` → `bank_linked` →
+`offer_accepted` → `agreement_signed` → `disbursed`) ships as **five
+clocks**, not one board (notes §13 Option A, §14.7 sequencing): each
+clock is a plan whose entry is one stage topic and whose only work is
+"wait 30 minutes, then call".
+
+How five clocks behave as one funnel:
+
+- **Progress closes the clock.** Clock *k*'s goals list **every stage
+  after k** plus `loan.disbursed`. The goal-cancel runs before entry in
+  the consumer, so one stage letter ends clock *k* (`goal_met` — read it
+  as "progressed", not "converted") and opens clock *k+1*.
+- **Skipped stages are harmless.** Because every downstream topic is a
+  goal, a customer who jumps from KYC straight to an offer closes the KYC
+  clock all the same. `tests/crm/test_plan_templates.py` computes each
+  clock's goal list from the ordered funnel and fails CI if one topic is
+  missing — one missing topic is one wrong phone call.
+- **Retries re-arm the clock.** `on_repeat: refresh_latest` +
+  `debounce_minutes: 30`: a repeated stage letter (a KYC retry) slides
+  the alarm and carries the newest facts to the call.
+- **One application, one thread.** `key: application_id` — two
+  concurrent applications by one customer run two clocks; admission
+  (`reenter`, the 1-hour `cooldown`) is judged per application.
+- **Leaving the funnel.** `loan.rejected` / `loan.withdrawn` end any open
+  clock as `withdrawn`.
+- **Unrelated letters are ignored.** An order or a refund matches no
+  entry and no goal.
+
+Cost of the pattern: a journey is up to five short runs, each exiting
+`goal_met`; "where do customers drop" is a join of a customer's runs
+across the five plans (phase 09 adds that read). **Phase 17 replaces
+this folder with one `loan-dropoff.json` board** (`stages` ladder, pinned
+versions): publish the board, pause the five clocks, let their open
+runs finish (they live 30 minutes), archive them. The stage topics, call
+templates and goal lists carry over one-to-one.

--- a/docs/crm/runbooks/cart-recovery.md
+++ b/docs/crm/runbooks/cart-recovery.md
@@ -1,0 +1,146 @@
+# Runbook — cart recovery (the board in `docs/crm/plans/cart-recovery.json`)
+
+What it does: a Shopify checkout update starts a run; 30 minutes of
+silence → WhatsApp nudge; 30 more → rescue call; one more day → the run
+completes. An order for **that cart** ends the run as `goal_met` at any
+point; any other order by the customer ends it as `converted_elsewhere`.
+Every repeated checkout update inside the window restarts the 30-minute
+timer and refreshes the facts the nudge will carry.
+
+Paths below carry no `crm` segment on purpose: the CRM routers mount at the app root (ADR 0022 keeps the internal name off every external surface; `app/crm` and the `crm_*` tables keep it inside).
+
+## Before publishing
+
+1. **Worker pods are running** — three `CRM_ROLE`s, or nothing moves:
+   `event-worker` (attributes letters, starts/ends runs), `walker` (fires
+   waits, queues sends, creates calls), `dispatcher` (delivers queued
+   WhatsApp rows). Each needs a DB pool ceiling ≥ 2.
+2. **WhatsApp connector onboarded** for the merchant and `healthy`:
+   `POST /connectors/whatsapp/onboard?merchant_id=<m>` with the
+   Embedded Signup `code` and `waba_id`; check
+   `GET /connectors/installations?merchant_id=<m>`. A `degraded`
+   door (webhook subscribe failed) cannot send.
+3. **The WhatsApp template exists and is approved** under the name the
+   plan uses (`cart_recovery_1`):
+   `POST /connectors/templates` (body: `merchant_id`, `channel:
+   "whatsapp"`, `provider_account_ref`, `name`, `language`, `components`)
+   then `POST /connectors/templates/{id}/submit`. Confirm with
+   `GET /connectors/templates?merchant_id=<m>&channel=whatsapp` —
+   status must be `approved`, in exactly ONE language. Until the Meta
+   status webhook (PR #1040) lands, approval is not recorded
+   automatically: check with the connectivity owner. A send against an
+   unapproved template is `blocked / template_not_approved`; the run
+   still continues to the call.
+4. **A Breeze Buddy call template** for the rescue call, belonging to the
+   merchant (or global), with a `call_execution_config`. Its id replaces
+   `TEMPLATE_ID_PLACEHOLDER`. Calls obey buddy's own calling hours,
+   DND and blacklist — the walker only creates the lead.
+5. **The relay pushes the three topics with these exact strings** —
+   `checkouts/update`, `orders/create`, `orders/paid` — as
+   `source: "shopify"` to `POST /ingest/events`, Shopify's body
+   unopened, with `occurred_at` (Shopify's `updated_at`/`created_at`)
+   and an `external_id` that is unique **per delivery**, e.g.
+   `checkouts/update:<checkout id>:<updated_at>`. An `external_id` that
+   repeats across updates dedupes them at the door and the repeat/debounce
+   words never see them.
+6. **Auth in hand:** an admin JWT for the `/workflows` routes; the
+   relay's wildcard RBAC JWT (Nautilus's `CLAIRVOYANCE_JWT_TOKEN`) or the
+   merchant's `s2s_token` for the ingest door.
+7. **The goal key is `cart_token`.** Shopify's checkout and order bodies
+   both carry it. On the first real payload confirm it is present; if the
+   relay ever strips it, switch both `key.event` and `key.run` to `token`.
+
+## Publish
+
+```bash
+export BASE=https://<clairvoyance>; export M=<merchant_id>
+export H="Authorization: Bearer $ADMIN_JWT"; export J="Content-Type: application/json"
+
+# 1. create (born as a draft; validated at the door -> 422 lists every problem)
+jq -n --arg name cart-recovery --slurpfile d docs/crm/plans/cart-recovery.json \
+  '{name: $name, definition: $d[0]}' \
+  | curl -sS -X POST "$BASE/workflows?merchant_id=$M" -H "$H" -H "$J" -d @-
+# -> 201 {"id": "<wf>", "status": "draft", "version": 0, ...}
+
+# 2. (edit the draft again if needed — same body, replaces the draft)
+curl -sS -X PUT "$BASE/workflows/<wf>/draft?merchant_id=$M" -H "$H" -H "$J" -d @body.json
+
+# 3. publish: draft -> definition, version 1, status live
+curl -sS -X POST "$BASE/workflows/<wf>/publish?merchant_id=$M" -H "$H"
+
+# 4. status (live <-> paused; archived is terminal and ejects open runs)
+curl -sS -X POST "$BASE/workflows/<wf>/status?merchant_id=$M" -H "$H" -H "$J" \
+  -d '{"status": "paused"}'
+```
+
+Publishing again later: put the new document in `draft`, then `publish`.
+While runs are open the validator refuses removing a node they stand on
+and changing the `entry` words; pause the plan and let them finish, or
+publish the change as a new plan.
+
+## Watch it run
+
+```bash
+curl -sS "$BASE/workflows/<wf>/runs?merchant_id=$M&status=waiting" -H "$H"
+curl -sS "$BASE/workflows/<wf>/runs?merchant_id=$M&status=parked" -H "$H"   # the triage view
+curl -sS "$BASE/workflows/<wf>/runs?merchant_id=$M&status=exited" -H "$H"
+```
+
+A run shows `current_node`, `wake_at` (the next alarm — also the walker's
+lease while a visit is in progress), `attempts`, `last_error`, and
+`context`: the customer's small facts (`cart_token`, `total_price`, …),
+the founding letter's id and time (`source_event_id`,
+`entered_event_at`), the normalized `phone`, and per-node results
+(`message_wa-nudge`, `lead_rescue-call`). `repeat_event_ids` lists the
+checkout updates that refreshed the run.
+
+**Parked runs** (`status=parked`) stopped on a deterministic failure and
+wait for a human; `last_error` says why:
+
+| `last_error` | Fix, then resume |
+|---|---|
+| `… no phone in run context` | the checkout had no phone we could read (email-only checkout); nothing to fix — archive or ignore |
+| `call node …: template … not found` / `no call_execution_config` | replace the placeholder / configure the buddy template |
+| `send node …: <reason>` | the channel/address was refused at queue time (bad number) |
+| `node X not in live definition` | drift across an archive/re-create; re-publish with the node or archive the plan |
+| `attempts exhausted: …` | a transient error kept failing (provider, DB); check the cause |
+
+```bash
+curl -sS -X POST "$BASE/workflows/<wf>/runs/<run>/resume?merchant_id=$M" -H "$H"
+```
+
+`resume` puts the run back to `waiting` with `wake_at = now` and the
+failure counter forgiven; the walker retries the same node on its next
+tick. `last_error` stays visible until the next successful step.
+
+## Exit reasons
+
+| `exit_reason` | Meaning |
+|---|---|
+| `goal_met` | an order carrying the run's `cart_token` — **this cart recovered** |
+| `converted_elsewhere` | the customer ordered something else; the nudge stopped, the cart was not recovered |
+| `completed` | the whole board ran (nudge, call, one day) with no order |
+| `timed_out` | the run outlived `exits.max_age_days` (7) — normally only a parked-then-resumed run |
+| `ejected` | the plan was archived while the run was open |
+| `withdrawn` | not used by this board (the loan clocks use it) |
+
+Goal comparisons are against the moment the **checkout update happened**
+(`entered_event_at`), not when we stored the run — an order that arrived
+late but happened after the abandonment still ends the run.
+
+## Settings to change per merchant
+
+| Where | Word | Default in the document | Change when |
+|---|---|---|---|
+| `entry` | `cooldown_hours` | 24 | how soon after an exited run the same customer may be nudged again |
+| `entry` | `debounce_minutes` | 30 | how long the customer must go quiet before the timer fires (only extends, never shortens) |
+| `entry` | `on_repeat` | `refresh_latest` | `refresh_max(total_price)` to nudge about the biggest of several carts |
+| `nodes` | `minutes` on the three waits | 30 / 30 / 1440 | the merchant's cadence |
+| `nodes` | `template` on `wa-nudge`, `template_id` on `rescue-call` | `cart_recovery_1` / placeholder | per merchant |
+| root | `purpose_key` | `marketing.cart.recovery` | must be a `marketing.*` purpose — the permission gate (phase 19) will require consent for it |
+| `exits` | `max_age_days` | 7 | rarely |
+
+Operator knobs (env, all pods): `CRM_WALKER_LEASE_SECONDS` (300),
+`CRM_WALKER_MAX_ATTEMPTS` (3), `CRM_RUN_RETENTION_DAYS` (90, exited runs
+are deleted after), `CRM_EVENT_MAX_ATTEMPTS` (5, letters whose consumer
+keeps failing are quarantined on the spine, not lost).

--- a/docs/crm/runbooks/loan-dropoff.md
+++ b/docs/crm/runbooks/loan-dropoff.md
@@ -1,0 +1,108 @@
+# Runbook — loan drop-off as clocks (`docs/crm/plans/loan-dropoff/`)
+
+What it does: a customer who reaches a stage and then goes quiet for 30
+minutes gets a call. One plan ("clock") per stage; the next stage event
+closes the current clock and starts the next; skipped stages are fine;
+`loan.rejected` / `loan.withdrawn` end everything. Read that folder's
+README for why five clocks and not one board (phase 17 changes that).
+
+Paths below carry no `crm` segment on purpose: the CRM routers mount at the app root (ADR 0022 keeps the internal name off every external surface; `app/crm` and the `crm_*` tables keep it inside).
+
+## Before publishing
+
+1. **Worker pods are running** — `event-worker` and `walker` at least
+   (no WhatsApp in these plans, so the `dispatcher` is not required).
+2. **The lender pushes stage events** to `POST /ingest/events` with
+   the relay JWT or the merchant's `s2s_token`:
+
+   ```json
+   {
+     "merchant_id": "<m>",
+     "source": "lender-api",
+     "topic": "loan.kyc_completed",
+     "external_id": "kyc:APP-1001:2026-09-03T10:15:00Z",
+     "occurred_at": "2026-09-03T10:15:00Z",
+     "payload": {
+       "application_id": "APP-1001",
+       "customer_mobile_number": "+919876543210",
+       "customer_name": "Ravi",
+       "stage": "kyc_completed"
+     }
+   }
+   ```
+
+   Rules that matter: **topic strings must match the plans exactly**
+   (`loan.profile_created`, `loan.kyc_completed`, `loan.bank_linked`,
+   `loan.offer_accepted`, `loan.agreement_signed`, `loan.disbursed`,
+   `loan.rejected`, `loan.withdrawn`); `payload.application_id` is the
+   run key (an event without it is refused, not re-keyed);
+   `customer_mobile_number` is how the customer is resolved and the
+   number the call dials (the default extractor reads the flat shape);
+   `occurred_at` is what "went quiet" and "progressed after" are measured
+   from — send the lender's own timestamp; `external_id` unique per
+   delivery so retries of the same stage still reach the debounce.
+3. **A Breeze Buddy call template per stage** (or one stage-aware
+   template): replace `TEMPLATE_ID_PLACEHOLDER` in each file. The call
+   payload carries the run's facts (`application_id`, `stage`, whatever
+   scalars the lender sends) as `{placeholder}` variables.
+4. **Auth:** an admin JWT for `/workflows`.
+
+## Publish the five clocks
+
+```bash
+export BASE=https://<clairvoyance>; export M=<merchant_id>
+export H="Authorization: Bearer $ADMIN_JWT"; export J="Content-Type: application/json"
+for f in docs/crm/plans/loan-dropoff/0*.json; do
+  name="loan-dropoff-$(basename "$f" .json)"
+  jq -n --arg name "$name" --slurpfile d "$f" '{name: $name, definition: $d[0]}' \
+    | curl -sS -X POST "$BASE/workflows?merchant_id=$M" -H "$H" -H "$J" -d @-
+done
+# then, per returned id:
+curl -sS -X POST "$BASE/workflows/<wf>/publish?merchant_id=$M" -H "$H"
+```
+
+Order does not matter — each clock only listens for its own stage topic.
+`GET /workflows?merchant_id=$M` lists them with status and version.
+
+## Operate
+
+- **Pause one stage** without touching the others:
+  `POST /workflows/<wf>/status {"status": "paused"}` — its open runs
+  snooze (the walker skips them) and no new runs start; `live` resumes.
+- **Change a stage's timing or template:** put the new document in
+  `draft`, `publish`. Clocks are empty most of the time (runs live ~30
+  minutes), so the stranding guard rarely bites; if it does, pause, wait
+  half an hour, publish.
+- **Parked runs:** `GET /workflows/<wf>/runs?merchant_id=$M&status=parked`.
+  Almost always `no phone in run context` (the lender omitted the
+  number) or a call template problem — fix, then
+  `POST /workflows/<wf>/runs/<run>/resume?merchant_id=$M`.
+- **A customer's journey** = their runs across the five plans in stage
+  order; until phase 09 adds the read, query each plan's runs and match
+  `context.application_id`.
+
+## Exit reasons
+
+| `exit_reason` | Meaning for a clock |
+|---|---|
+| `goal_met` | **progressed** — a later stage (or `loan.disbursed`) arrived before the alarm; not a conversion by itself |
+| `withdrawn` | `loan.rejected` or `loan.withdrawn` arrived |
+| `completed` | the alarm fired and the call was placed — the drop-off record |
+| `timed_out` | outlived `exits.max_age_days` (1) — a parked run left alone for a day |
+| `ejected` | the plan was archived while the run was open |
+| `converted_elsewhere` | not used by the clocks |
+
+Progress is judged against the moment the **stage event happened**
+(`entered_event_at`): a later stage delivered late still counts if it
+happened after; an earlier stage delivered late cannot resurrect a clock.
+
+## Settings to change per merchant
+
+| Word | Default | Change when |
+|---|---|---|
+| `entry.cooldown_hours` | 1 | how soon the same application may be called again after a clock exits |
+| `entry.debounce_minutes` | 30 | the "went quiet" window (a retried stage event re-arms it) |
+| `nodes[wait-30m].minutes` | 30 | the idle threshold per stage (the offer stage may deserve longer) |
+| `nodes[dropoff-call].template_id` | placeholder | per stage, per merchant |
+| `goals[0].topics` | every downstream stage + disbursed | only when the funnel gains a stage — add it to every earlier clock (CI checks the list) |
+| `exits.max_age_days` | 1 | rarely |

--- a/tests/crm/test_plan_templates.py
+++ b/tests/crm/test_plan_templates.py
@@ -1,0 +1,105 @@
+"""The plan templates under docs/crm/plans/ are real documents, validated
+on every CI run (rollout phase 07): the cart-recovery board (§16.1) and
+the loan-dropoff funnel as per-stage clocks (§13 Option A) — the shape
+the funnel ships in until phase 17 folds it into one pinned board.
+
+A document that stops validating fails CI; a loan stage plan whose goal
+list is not exactly "every downstream stage, plus disbursed" fails CI —
+one missing topic is one wrong phone call (§14.3 objection 5)."""
+
+import json
+from pathlib import Path
+from typing import Any, Dict, List
+
+import pytest
+
+from app.crm.outreach.plans import validate_definition
+
+PLANS = Path(__file__).resolve().parents[2] / "docs" / "crm" / "plans"
+CART = PLANS / "cart-recovery.json"
+LOAN = PLANS / "loan-dropoff"
+
+# The funnel, in order (§16.2). The goal of stage i is every stage after
+# it plus the terminal topic; rejected/withdrawn is the second tier.
+LOAN_STAGES = [
+    ("01-profile", "loan.profile_created"),
+    ("02-kyc", "loan.kyc_completed"),
+    ("03-bank", "loan.bank_linked"),
+    ("04-offer", "loan.offer_accepted"),
+    ("05-agreement", "loan.agreement_signed"),
+]
+LOAN_DONE = "loan.disbursed"
+LOAN_OUT = ["loan.rejected", "loan.withdrawn"]
+
+
+def _load(path: Path) -> Dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _every_plan() -> List[Path]:
+    return sorted(PLANS.rglob("*.json"))
+
+
+def test_the_expected_documents_exist() -> None:
+    assert CART.is_file(), CART
+    for stem, _ in LOAN_STAGES:
+        assert (LOAN / f"{stem}.json").is_file(), stem
+    assert len(_every_plan()) == 1 + len(LOAN_STAGES)
+
+
+@pytest.mark.parametrize("path", _every_plan(), ids=lambda p: p.stem)
+def test_every_plan_template_validates(path: Path) -> None:
+    assert validate_definition(_load(path)) == [], path
+
+
+def test_cart_recovery_is_the_final_shape_from_the_notes() -> None:
+    doc = _load(CART)
+    entry = doc["entry"]
+    assert entry["topic"] == "checkouts/update"
+    assert entry["reenter"] is True and entry["cooldown_hours"] == 24
+    assert entry["on_repeat"] == "refresh_latest" and entry["debounce_minutes"] == 30
+    assert doc["purpose_key"] == "marketing.cart.recovery"
+    assert doc["exits"] == {"max_age_days": 7}
+    # two tiers: THIS cart recovered, then anything else she bought
+    recovered, elsewhere = doc["goals"]
+    assert recovered["key"] == {"event": "cart_token", "run": "cart_token"}
+    assert recovered["exit_reason"] == "goal_met"
+    assert "key" not in elsewhere and elsewhere["exit_reason"] == "converted_elsewhere"
+    assert (
+        recovered["topics"] == elsewhere["topics"] == ["orders/create", "orders/paid"]
+    )
+    # wait 30 -> WhatsApp -> wait 30 -> call -> wait 1d -> completed
+    assert [(n["type"], n.get("minutes")) for n in doc["nodes"]] == [
+        ("wait", 30),
+        ("send", None),
+        ("wait", 30),
+        ("call", None),
+        ("wait", 1440),
+    ]
+    send = doc["nodes"][1]
+    assert send["channel"] == "whatsapp" and send["template"] == "cart_recovery_1"
+    assert doc["nodes"][3]["template_id"] == "TEMPLATE_ID_PLACEHOLDER"
+    ids = [n["id"] for n in doc["nodes"]]
+    assert doc["edges"] == [[a, b] for a, b in zip(ids, ids[1:])]
+
+
+@pytest.mark.parametrize(
+    "index", range(len(LOAN_STAGES)), ids=lambda i: LOAN_STAGES[i][0]
+)
+def test_each_loan_clock_listens_for_every_downstream_stage(index: int) -> None:
+    stem, topic = LOAN_STAGES[index]
+    doc = _load(LOAN / f"{stem}.json")
+    downstream = [t for _, t in LOAN_STAGES[index + 1 :]] + [LOAN_DONE]
+    entry = doc["entry"]
+    assert entry["topic"] == topic and entry["key"] == "application_id"
+    assert entry["reenter"] is True and entry["cooldown_hours"] == 1
+    assert entry["on_repeat"] == "refresh_latest" and entry["debounce_minutes"] == 30
+    progressed, withdrawn = doc["goals"]
+    assert progressed["topics"] == downstream, stem  # exactly, in funnel order
+    assert progressed["exit_reason"] == "goal_met" and "key" not in progressed
+    assert withdrawn == {"topics": LOAN_OUT, "exit_reason": "withdrawn"}
+    assert [(n["type"], n.get("minutes")) for n in doc["nodes"]] == [
+        ("wait", 30),
+        ("call", None),
+    ]
+    assert doc["nodes"][1]["template_id"] == "TEMPLATE_ID_PLACEHOLDER"


### PR DESCRIPTION
**Rollout phase 07** — `docs/crm/workflow-rollout/07-plan-templates-and-runbooks.md` (notes §12, §13 Option A, §16.1, §15.1 Phase 1). **Docs + one test; no application code.**

## What this delivers

| Deliverable | Where |
|---|---|
| The cart-recovery board as a document — §16.1's final shape: `checkouts/update` entry with `reenter`, 24h cooldown, `on_repeat: refresh_latest`, 30-minute debounce; two goal tiers keyed on `cart_token` (`goal_met`) then anything else she bought (`converted_elsewhere`); wait 30 → WhatsApp `cart_recovery_1` → wait 30 → call → wait 1d; `purpose_key: marketing.cart.recovery`; 7-day ceiling. | `docs/crm/plans/cart-recovery.json` |
| The loan funnel as five per-stage **clocks** (§13 Option A, the shape it ships in until phase 17): entry = the stage topic, `key: application_id`, `reenter` + 1h cooldown, `refresh_latest` + 30-minute debounce; wait 30 → call; goals = every downstream stage + `loan.disbursed` (`goal_met`) and `loan.rejected`/`loan.withdrawn` (`withdrawn`). Generated from the ordered funnel so the goal lists cannot drift. | `docs/crm/plans/loan-dropoff/01-profile.json` … `05-agreement.json` |
| Why clocks, how five clocks act as one funnel, and the phase 17 replacement | `docs/crm/plans/loan-dropoff/README.md`, `docs/crm/plans/README.md` |
| The CI test: every `docs/crm/plans/**/*.json` validates; the cart document is the notes' shape; each loan clock's goal list is **exactly** its downstream stages, computed from the ordered funnel in the test (one missing topic = one wrong phone call, §14.3) | `tests/crm/test_plan_templates.py` |
| Runbooks: prerequisites (worker pods per `CRM_ROLE`, connector `healthy`, template `approved`, buddy call template, relay topics and `external_id` discipline, auth doors), the create → draft → publish → status sequence with curl against the real routes, reading `GET /runs?status=parked`, what `resume` does, every exit reason, and the per-merchant settings | `docs/crm/runbooks/cart-recovery.md`, `docs/crm/runbooks/loan-dropoff.md` |

Both runbooks were written against `app/crm/outreach/api.py` as it stands (`merchant_id` is a query param on every workflow route, admin JWT via `crm_admin_user`), the connectivity routes, and `verify_s2s_caller`'s two token kinds for the ingest door.

## Red test

`tests/crm/test_plan_templates.py` fails on `release` (the documents do not exist there: `test_the_expected_documents_exist` asserts on the files, and the parametrised validation collects nothing) and passes here.

## Checks (unpiped before push)

`black` · `isort` · `autoflake` · `pyrefly check` (0 errors) · `pytest tests/crm` (**571 passed** = 558 on release + 13 new) · `check_crm_boundaries.py` (clean) · `check_migrations.py --base origin/release` (clean, no migration). One commit.

## Decisions already made — disagreements

None. Cart goal key is `cart_token`; loan clocks trigger on stage events.

**On `cart_token`:** the relay forwards Shopify's body unopened, and Shopify's checkout and order bodies both carry `cart_token` (nautilus types the order with it). The runbook says to confirm on the first real payload and switch both sides of the key to `token` if the relay ever strips it, exactly as the phase allows.

## Two small choices the phase left open

- `exits.max_age_days` for the clocks is **1** (the phase file names none; runs live ~30 minutes, so the ceiling only matters for a parked run left alone).
- The documents are the `definition` body only (what the runbooks wrap as `{"name", "definition"}`), so `validate_definition(doc) == []` holds exactly as the phase's test wants. `on_publish` is deliberately absent until phase 11 adds the word (the README says so); including it now would validate but be silently ignored.

## Not done on purpose

- No code change to the walker or validator; reporting (phase 09); the publish-time template check that would catch a wrong `cart_recovery_1` (phase 08).

## Adjacent observations, left alone

- Until the Meta status webhook (PR #1040) lands, a template's `approved` status is not recorded automatically; the cart runbook says to check with the connectivity owner, and notes that a blocked send does not stop the run (the call still happens).
- The relay's `external_id` must be unique per delivery or repeated checkout updates dedupe at the door and never reach the repeat/debounce words. Stated in the runbook; worth a line in nautilus's relay when it is wired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014UNZ4z7zb87HnNHjTXoFpW
