### PR TITLE
feat(crm): publish refuses a send node whose template the registry does not know (rollout 08)

### DIFF
--- a/app/crm/connectivity/contracts.py
+++ b/app/crm/connectivity/contracts.py
@@ -21,6 +21,9 @@ What is here, and why each thing is on the surface:
   registry decides what that payload means.
 - the ``*_template`` family — the T23 registry that ``send.py`` resolves
   against before any provider call.
+- ``template_status`` / ``registers_templates_for`` — what outreach's
+  publish asks so a send node naming an unknown or unapproved template
+  is refused at publish, not blocked at dispatch hours later (phase 08).
 
 Provider-decided template state (approved, rejected, a re-categorisation)
 arrives as webhooks, and the consumer that applies them joins this surface
@@ -31,6 +34,7 @@ reach a provider without passing the checks in front of it. So does the
 route resolver, and so do the provider packages.
 """
 
+from app.crm.connectivity.channels import registers_templates_for
 from app.crm.connectivity.dispatch import claim_sends, dispatch_send
 from app.crm.connectivity.onboarding import (
     disconnect,
@@ -46,6 +50,7 @@ from app.crm.connectivity.templates import (
     list_templates,
     retire as retire_template,
     submit as submit_template,
+    template_status,
 )
 
 __all__ = [
@@ -66,4 +71,7 @@ __all__ = [
     "retire_template",
     "get_template",
     "list_templates",
+    # the publish-time check (outreach asks)
+    "template_status",
+    "registers_templates_for",
 ]

--- a/app/crm/connectivity/db/accessors/template.py
+++ b/app/crm/connectivity/db/accessors/template.py
@@ -24,6 +24,7 @@ from app.crm.connectivity.db.queries.template import (
     retire_template_query,
     template_by_id_query,
     template_by_natural_key_query,
+    templates_by_name_query,
     update_draft_components_query,
 )
 from app.crm.connectivity.schemas.template import ApprovedTemplate, TemplateRead
@@ -60,6 +61,15 @@ async def list_templates(
     merchant_id: str, channel: Optional[str] = None, status: Optional[str] = None
 ) -> List[TemplateRead]:
     query, values = list_templates_query(merchant_id, channel, status)
+    async with crm_connection() as conn:
+        rows = await conn.fetch(query, *values)
+    return [decode_template(row) for row in rows]
+
+
+async def templates_by_name(
+    merchant_id: str, channel: str, name: str
+) -> List[TemplateRead]:
+    query, values = templates_by_name_query(merchant_id, channel, name)
     async with crm_connection() as conn:
         rows = await conn.fetch(query, *values)
     return [decode_template(row) for row in rows]

--- a/app/crm/connectivity/db/queries/template.py
+++ b/app/crm/connectivity/db/queries/template.py
@@ -92,6 +92,25 @@ def list_templates_query(
     return query, [merchant_id, channel, status]
 
 
+def templates_by_name_query(
+    merchant_id: str, channel: str, name: str
+) -> Tuple[str, List[Any]]:
+    """The publish-time read (rollout phase 08, G12): every row registered
+    under this NAME on this channel for this merchant, across provider
+    accounts and languages, newest status first. The send door resolves an
+    account before it looks a name up; publish cannot know the account yet,
+    so it reads them all and templates.template_status judges."""
+    query = f"""
+        SELECT {TEMPLATE_COLUMNS}
+          FROM {TEMPLATE_TABLE}
+         WHERE merchant_id = $1
+           AND channel = $2
+           AND name = $3
+         ORDER BY status_updated_at DESC, created_at DESC
+    """
+    return query, [merchant_id, channel, name]
+
+
 def approved_template_for_send_query(
     merchant_id: str, channel: str, provider_account_ref: str, name: str
 ) -> Tuple[str, List[Any]]:

--- a/app/crm/connectivity/templates.py
+++ b/app/crm/connectivity/templates.py
@@ -47,6 +47,7 @@ from app.crm.connectivity.schemas.template import (
     TemplateRead,
 )
 from app.crm.connectivity.status import (
+    TEMPLATE_APPROVED,
     TEMPLATE_DRAFT,
     TEMPLATE_IN_PLACE_EDIT,
     TEMPLATE_LOCAL_EDIT,
@@ -500,6 +501,42 @@ async def list_templates(
     merchant_id: str, channel: Optional[str] = None, status: Optional[str] = None
 ) -> List[TemplateRead]:
     return await template_accessor.list_templates(merchant_id, channel, status)
+
+
+async def template_status(merchant_id: str, channel: str, name: str) -> Optional[str]:
+    """Is this template NAME publishable on this channel — the registry's
+    one publish-time read (rollout phase 08, G12), beside approved_template
+    (the send-time read) so every read of the table stays in this file.
+
+    A workflow's send node names a template and a channel, never the
+    provider account that will serve it (the route picks that at send
+    time), so the question is asked across the merchant's accounts:
+
+      * None — no row under that name: never registered here;
+      * "approved" — every account holding the name holds exactly ONE
+        approved row (the send door will find its one row whichever
+        account the route picks);
+      * "approved in N languages" — some account holds several approved
+        rows: the ambiguity approved_template refuses at send time,
+        refused here first — same rule, earlier;
+      * otherwise the newest row's status (pending, rejected, deleted…),
+        so the refusal can say why.
+    """
+    rows = await template_accessor.templates_by_name(merchant_id, channel, name)
+    if not rows:
+        return None
+    approved_per_account: Dict[str, int] = {}
+    for row in rows:
+        if row.status == TEMPLATE_APPROVED:
+            approved_per_account[row.provider_account_ref] = (
+                approved_per_account.get(row.provider_account_ref, 0) + 1
+            )
+    if approved_per_account:
+        crowded = max(approved_per_account.values())
+        if crowded > 1:
+            return f"approved in {crowded} languages"
+        return TEMPLATE_APPROVED
+    return rows[0].status
 
 
 async def approved_template(

--- a/app/crm/outreach/plans.py
+++ b/app/crm/outreach/plans.py
@@ -9,6 +9,7 @@ gather -> decide (PURE, returns the problems) -> apply.
 from typing import Any, Dict, List, Optional
 
 from app.core.logger import logger
+from app.crm.connectivity.contracts import registers_templates_for, template_status
 from app.crm.outreach.db import DbTxn, accessor, atomically
 from app.crm.outreach.nodes import NODE_TYPES, is_wait
 from app.crm.outreach.repeat import parse_repeat_policy
@@ -175,6 +176,11 @@ async def _publish_in_txn(txn: DbTxn, merchant_id: str, workflow_id: str) -> Wor
     )
     if problems:
         raise WorkflowValidationError(problems)
+    problems = await _template_problems(
+        merchant_id, WorkflowDefinition.model_validate(workflow.draft)
+    )
+    if problems:
+        raise WorkflowValidationError(problems)
     published = await accessor.apply_publish(txn, merchant_id, workflow_id)
     if published is None:  # a racing publish consumed the draft first
         raise WorkflowValidationError(["draft already published"])
@@ -183,6 +189,37 @@ async def _publish_in_txn(txn: DbTxn, merchant_id: str, workflow_id: str) -> Wor
         f"(merchant {merchant_id})"
     )
     return published
+
+
+async def _template_problems(
+    merchant_id: str, definition: WorkflowDefinition
+) -> List[str]:
+    """GATHER for the publish atom (rollout phase 08, G12): every send node
+    on a channel that registers templates must name one the registry knows
+    AND has approved — otherwise the first sign of a wrong name is a
+    blocked send at dispatch, hours after publish. A lookup, so it lives
+    here beside the atom and validate_definition stays PURE. Drafts are
+    not checked (create/update): a draft may precede approval. The
+    contract takes its own pooled connection beside the atom's — the
+    resolve()-inside-the-pass precedent."""
+    problems: List[str] = []
+    for node in definition.nodes:
+        if node.type != "send" or not node.channel or not node.template:
+            continue  # the validator already demands both on a send node
+        if not registers_templates_for(node.channel):
+            continue  # a channel with no registry (email) has nothing to ask
+        status = await template_status(merchant_id, node.channel, node.template)
+        if status is None:
+            problems.append(
+                f"send node {node.id}: template '{node.template}' is not "
+                f"registered on {node.channel} for this merchant"
+            )
+        elif status != "approved":
+            problems.append(
+                f"send node {node.id}: template '{node.template}' is "
+                f"'{status}', not approved"
+            )
+    return problems
 
 
 async def set_status(

--- a/tests/crm/test_templates.py
+++ b/tests/crm/test_templates.py
@@ -665,3 +665,90 @@ def test_the_in_place_edit_is_conditional_on_the_status_it_read() -> None:
     sql, values = record_in_place_edit_query("shop", "t-1", "[]", "pending", "approved")
     assert "AND status = $5" in sql
     assert values[-1] == "approved"
+
+
+# --- rollout phase 08: the registry's publish-time read ----------------------
+
+from app.crm.connectivity import channels as channels_module, contracts
+from app.crm.connectivity.db.queries.template import templates_by_name_query
+from app.crm.connectivity.templates import template_status
+
+
+def test_templates_by_name_read_is_merchant_first_and_parameterised() -> None:
+    sql, params = templates_by_name_query("m1", "whatsapp", "cart_recovery_1")
+    assert "merchant_id = $1" in sql and "channel = $2" in sql and "name = $3" in sql
+    assert "ORDER BY status_updated_at DESC" in sql
+    assert params == ["m1", "whatsapp", "cart_recovery_1"]
+    assert "cart_recovery_1" not in sql  # a value never reaches SQL as text
+
+
+def _registry_row(
+    status: str, language: str = "en", account: str = "waba-1"
+) -> TemplateRead:
+    now = datetime(2026, 9, 3, 10, 0, tzinfo=timezone.utc)
+    return TemplateRead(
+        id=f"t-{status}-{language}-{account}",
+        merchant_id="m1",
+        channel="whatsapp",
+        provider_account_ref=account,
+        name="cart_recovery_1",
+        language=language,
+        status=status,
+        status_updated_at=now,
+        quality="UNKNOWN",
+        created_at=now,
+        updated_at=now,
+    )
+
+
+class _ByNameAccessor:
+    def __init__(self, rows: List[TemplateRead]) -> None:
+        self.rows = rows
+
+    async def templates_by_name(
+        self, merchant_id: str, channel: str, name: str
+    ) -> List[TemplateRead]:
+        return self.rows
+
+
+@pytest.mark.parametrize(
+    ("rows", "verdict"),
+    [
+        ([], None),
+        ([_registry_row("approved")], "approved"),
+        ([_registry_row("pending"), _registry_row("deleted")], "pending"),
+        (
+            [_registry_row("approved", "en"), _registry_row("approved", "hi")],
+            "approved in 2 languages",
+        ),
+        (
+            [
+                _registry_row("approved", "en", "waba-1"),
+                _registry_row("approved", "en", "waba-2"),
+            ],
+            "approved",
+        ),
+    ],
+    ids=[
+        "no-row",
+        "one-approved",
+        "newest-status",
+        "two-languages-one-account",
+        "one-per-account",
+    ],
+)
+async def test_template_status_answers_for_the_publish_check(
+    monkeypatch, rows: List[TemplateRead], verdict: Optional[str]
+) -> None:
+    """None: never registered. "approved": every account holding the name
+    holds exactly one approved row. Two approved languages on one account
+    is the ambiguity the send door refuses — same rule, earlier. Otherwise
+    the newest row's status, so the publish message can say why."""
+    monkeypatch.setattr(templates_module, "template_accessor", _ByNameAccessor(rows))
+    assert await template_status("m1", "whatsapp", "cart_recovery_1") == verdict
+
+
+def test_the_publish_check_is_on_the_contract_surface() -> None:
+    assert "template_status" in contracts.__all__
+    assert "registers_templates_for" in contracts.__all__
+    assert contracts.registers_templates_for is channels_module.registers_templates_for

--- a/tests/crm/test_workflow_plans.py
+++ b/tests/crm/test_workflow_plans.py
@@ -2,11 +2,13 @@
 validator must block, each as a red test."""
 
 from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional, Tuple, cast
 from uuid import uuid4
 
 import pytest
 
 import app.crm.outreach.plans as plans
+from app.crm.outreach.db import DbTxn
 from app.crm.outreach.plans import validate_definition
 from app.crm.outreach.schemas import Workflow
 
@@ -361,3 +363,129 @@ async def test_unknown_or_archived_plans_answer_none_for_the_404(
 
     monkeypatch.setattr(plans.accessor, "get_workflow", archived)
     assert await plans.set_status("m1", "wf-1", "live") is None
+
+
+# --- rollout phase 08 (G12): publish asks the template registry about every send node ---
+
+_SEND_PLAN: Dict[str, Any] = {
+    "entry": {"topic": "checkouts/update", "reenter": True, "cooldown_hours": 0},
+    "nodes": [
+        {"id": "wait-30m", "type": "wait", "minutes": 30},
+        {
+            "id": "wa-nudge",
+            "type": "send",
+            "channel": "whatsapp",
+            "template": "cart_recovery_1",
+        },
+    ],
+    "edges": [["wait-30m", "wa-nudge"]],
+    "goal": {"topics": ["orders/create"]},
+    "purpose_key": "marketing.cart.recovery",
+}
+
+
+class _PublishAccessor:
+    """The accessor slice _publish_in_txn touches: a live plan with a draft
+    waiting, no occupied squares, and apply_publish recording whether the
+    copy happened."""
+
+    def __init__(self, draft: Dict[str, Any]) -> None:
+        self.draft = draft
+        self.published = False
+
+    async def workflow_for_publish(self, conn: Any, m: str, w: str) -> Workflow:
+        return _workflow("live", _TERSE_DRAFT).model_copy(update={"draft": self.draft})
+
+    async def occupied_nodes(self, conn: Any, m: str, w: str) -> List[str]:
+        return []
+
+    async def apply_publish(self, conn: Any, m: str, w: str) -> Workflow:
+        self.published = True
+        return _workflow("live", self.draft)
+
+
+def _registry(
+    monkeypatch: pytest.MonkeyPatch, status: Optional[str], registers: bool = True
+) -> List[Tuple[str, str, str]]:
+    asked: List[Tuple[str, str, str]] = []
+
+    async def template_status(
+        merchant_id: str, channel: str, name: str
+    ) -> Optional[str]:
+        asked.append((merchant_id, channel, name))
+        return status
+
+    monkeypatch.setattr(plans, "template_status", template_status)
+    monkeypatch.setattr(plans, "registers_templates_for", lambda channel: registers)
+    return asked
+
+
+async def _publish(accessor: _PublishAccessor) -> Workflow:
+    return await plans._publish_in_txn(cast(DbTxn, object()), "m1", "wf-1")
+
+
+@pytest.mark.asyncio
+async def test_publish_refuses_a_send_node_whose_template_is_unknown(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """G12: today the first sign of a wrong template name is a blocked
+    send hours later. The registry can answer at publish."""
+    accessor = _PublishAccessor(_SEND_PLAN)
+    monkeypatch.setattr(plans, "accessor", accessor)
+    asked = _registry(monkeypatch, status=None)
+    with pytest.raises(plans.WorkflowValidationError) as refused:
+        await _publish(accessor)
+    assert refused.value.problems == [
+        "send node wa-nudge: template 'cart_recovery_1' is not registered on "
+        "whatsapp for this merchant"
+    ]
+    assert asked == [("m1", "whatsapp", "cart_recovery_1")]
+    assert accessor.published is False
+
+
+@pytest.mark.asyncio
+async def test_publish_refuses_a_send_node_whose_template_is_not_approved(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    accessor = _PublishAccessor(_SEND_PLAN)
+    monkeypatch.setattr(plans, "accessor", accessor)
+    _registry(monkeypatch, status="pending")
+    with pytest.raises(plans.WorkflowValidationError) as refused:
+        await _publish(accessor)
+    assert refused.value.problems == [
+        "send node wa-nudge: template 'cart_recovery_1' is 'pending', not approved"
+    ]
+    assert accessor.published is False
+
+
+@pytest.mark.asyncio
+async def test_publish_proceeds_when_the_template_is_approved(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    accessor = _PublishAccessor(_SEND_PLAN)
+    monkeypatch.setattr(plans, "accessor", accessor)
+    _registry(monkeypatch, status="approved")
+    published = await _publish(accessor)
+    assert accessor.published is True and published.status == "live"
+
+
+@pytest.mark.asyncio
+async def test_a_plan_without_send_nodes_never_asks_the_registry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    accessor = _PublishAccessor(_TERSE_DRAFT)
+    monkeypatch.setattr(plans, "accessor", accessor)
+    asked = _registry(monkeypatch, status=None)
+    await _publish(accessor)
+    assert asked == [] and accessor.published is True
+
+
+@pytest.mark.asyncio
+async def test_a_channel_that_does_not_register_templates_is_not_asked(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    accessor = _PublishAccessor(_SEND_PLAN)
+    monkeypatch.setattr(plans, "accessor", accessor)
+    asked = _registry(monkeypatch, status=None, registers=False)
+    await _publish(accessor)
+    assert asked == [] and accessor.published is True


### PR DESCRIPTION
**Rollout phase 08** — `docs/crm/workflow-rollout/08-publish-template-check.md` (notes §16.3 G12, §6 connectivity templates). No migration.

## Why

A `send` node names a template by NAME. Today the first sign it is wrong is a `blocked / template_not_approved` row at dispatch time, hours after publish (the runbook from phase 07 has to warn about exactly this). The T23 registry can answer at publish.

## What changed

| Layer | Change |
|---|---|
| **Connectivity, query + accessor** | `templates_by_name_query(merchant, channel, name)`: every row under that name on that channel for this merchant, newest status first; `templates_by_name` executes it. Merchant-first, `$1` params. |
| **Connectivity, logic** | `templates.py::template_status(merchant, channel, name) -> Optional[str]`, beside `approved_template` (the send-time read) so every read of the registry table stays in one file. `None` = never registered. `"approved"` = every provider account holding the name holds exactly **one** approved row. `"approved in N languages"` = one account holds several (the send door refuses that too — same rule, earlier). Otherwise the newest row's status, so the message can say why. |
| **Connectivity, surface** | `contracts.py` exports `template_status` and `channels.registers_templates_for`. |
| **Outreach, publish atom** | `_publish_in_txn`: after `validate_definition` passes, a GATHER step (`_template_problems`) asks the registry for every send node on a channel that registers templates. Unknown name → `send node X: template 'T' is not registered on C for this merchant`; other status → `… is 'pending', not approved`. Refused as `WorkflowValidationError` (422); nothing is published. `validate_definition` stays pure; `create_workflow`/`update_draft` do not check (drafts may precede approval). |

Boundary: outreach → `app.crm.connectivity.contracts` only (the import `nodes.py` already makes for `queue_message`). The contract call takes its own pooled connection beside the atom's, the same shape as `resolve()` inside the event pass; the pool-ceiling ≥ 2 rule the worker already enforces covers it.

## Red tests (fail on `release`, pass here)

`tests/crm/test_workflow_plans.py` (5): unknown template refused with the exact message; pending refused; approved publishes; a plan without send nodes never asks; a channel that does not register templates is not asked. The atom is driven directly with a fake accessor slice and a fake registry.

`tests/crm/test_templates.py` (7): the by-name builder is merchant-first and parameterised; `template_status` verdicts for no rows, one approved, newest-status, two languages on one account (ambiguous), one approved row per account (fine); the two contract exports exist and `registers_templates_for` is the channel registry's own function.

## Checks (unpiped before push)

`black` · `isort` · `autoflake` · `pyrefly check` (0 errors) · `pytest tests/crm` (**583 passed** = 571 on release + 12 new) · `check_crm_boundaries.py` (clean) · `check_migrations.py --base origin/release` (clean, no migration). One commit.

## Decisions already made — disagreements

None. Refuse, don't warn. Language ambiguity refused at publish exactly as at send.

## One judgment call

The phase describes the verdict as "the most recent row's status" for the non-approved case. Two approved rows on **different** provider accounts are not ambiguous for the send door (it resolves one account first, then looks the name up there), so `template_status` says `approved` for that shape and reserves the ambiguity verdict for several approved languages on **one** account. Mirrors `approved_template` exactly.

## Not done on purpose

- Variable-shape validation against `components` (backlog). Publish still cannot know which account will serve a send; it checks that every account holding the name is unambiguous.

## Adjacent observations, left alone

- Until the Meta status webhook (PR #1040) lands, `approved` is never written automatically, so this check will refuse every WhatsApp send node in practice. That is the honest state: the runbook already says approval must be recorded before publishing. Nothing to do here; it resolves when #1040 merges.
- `entry.py` and now `plans.py` match node type strings (`"wait_event"`, `"send"`); N1 in the backlog proposes registry flags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014UNZ4z7zb87HnNHjTXoFpW
