### PR TITLE
feat(crm): workflow run summary and journey read — counts by exit reason, time per node (rollout 09)

### DIFF
--- a/app/crm/api.py
+++ b/app/crm/api.py
@@ -24,5 +24,8 @@ router.include_router(record_api.journey_router, prefix="/customers", tags=["Jou
 router.include_router(record_api.ingest_router, prefix="/ingest", tags=["Ingest"])
 router.include_router(outreach_api.router, prefix="/workflows", tags=["Workflows"])
 router.include_router(
+    outreach_api.customer_router, prefix="/customers", tags=["Workflows"]
+)
+router.include_router(
     connectivity_api.router, prefix="/connectors", tags=["Connectors"]
 )

--- a/app/crm/outreach/api.py
+++ b/app/crm/outreach/api.py
@@ -5,6 +5,7 @@ Thin routes per module rules §1: auth via Depends, delegate to plans.py.
 Tenancy law: merchant_id is a required query param on every route.
 """
 
+from datetime import datetime
 from typing import Any, Dict, List, Literal, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
@@ -13,10 +14,19 @@ from pydantic import BaseModel, Field
 from app.core.logger.context import set_log_context
 from app.crm.auth import crm_admin_user
 from app.crm.outreach import plans, runs
-from app.crm.outreach.schemas import EnrollmentRun, Workflow, WorkflowSummary
+from app.crm.outreach.schemas import (
+    CustomerRun,
+    EnrollmentRun,
+    Workflow,
+    WorkflowRunSummary,
+    WorkflowSummary,
+)
 from app.schemas import UserInfo
 
 router = APIRouter()
+# The customer-facing door (/customers/{id}/runs) mounts under a different
+# prefix than the plans' router — the record module's two-router precedent.
+customer_router = APIRouter()
 
 
 class WorkflowCreate(BaseModel):
@@ -163,3 +173,26 @@ async def resume_run_route(
             detail="Run not found, not parked, or not this merchant's",
         )
     return run
+
+
+@router.get("/{workflow_id}/summary", response_model=WorkflowRunSummary)
+async def workflow_summary_route(
+    workflow_id: str,
+    merchant_id: str = Query(..., description="Tenant scope — required"),
+    since: Optional[datetime] = Query(None, description="Window start on entered_at"),
+    until: Optional[datetime] = Query(None, description="Window end on entered_at"),
+    current_user: UserInfo = Depends(crm_admin_user),
+) -> WorkflowRunSummary:
+    set_log_context(component="crm.workflows.summary", merchant_id=merchant_id)
+    return await runs.workflow_summary(merchant_id, workflow_id, since, until)
+
+
+@customer_router.get("/{customer_id}/runs", response_model=List[CustomerRun])
+async def customer_runs_route(
+    customer_id: str,
+    merchant_id: str = Query(..., description="Tenant scope — required"),
+    limit: int = Query(100, ge=1, le=500),
+    current_user: UserInfo = Depends(crm_admin_user),
+) -> List[CustomerRun]:
+    set_log_context(component="crm.workflows.journey", merchant_id=merchant_id)
+    return await runs.customer_runs(merchant_id, customer_id, limit)

--- a/app/crm/outreach/db/accessor.py
+++ b/app/crm/outreach/db/accessor.py
@@ -13,7 +13,9 @@ from typing import Any, Dict, List, Optional, Tuple
 import asyncpg
 
 from app.crm.outreach.db.decoder import (
+    decode_customer_run,
     decode_run,
+    decode_run_summary,
     decode_workflow,
     decode_workflow_summary,
 )
@@ -22,6 +24,7 @@ from app.crm.outreach.db.queries import (
     advance_run_query,
     cancel_open_runs_query,
     claim_due_runs_query,
+    customer_runs_query,
     exit_run_query,
     get_workflow_query,
     insert_enrollment_query,
@@ -40,8 +43,15 @@ from app.crm.outreach.db.queries import (
     source_event_used_query,
     sweep_exited_runs_query,
     update_draft_query,
+    workflow_summary_query,
 )
-from app.crm.outreach.schemas import EnrollmentRun, Workflow, WorkflowSummary
+from app.crm.outreach.schemas import (
+    CustomerRun,
+    EnrollmentRun,
+    Workflow,
+    WorkflowRunSummary,
+    WorkflowSummary,
+)
 from app.crm.shared.db import crm_connection
 
 
@@ -291,9 +301,16 @@ async def cancel_open_runs(
     exit_reason: str,
     occurred_at: Optional[datetime] = None,
     key: Optional[Tuple[str, str]] = None,
+    context_patch: Optional[Dict[str, Any]] = None,
 ) -> int:
     query, values = cancel_open_runs_query(
-        merchant_id, workflow_id, customer_id, exit_reason, occurred_at, key
+        merchant_id,
+        workflow_id,
+        customer_id,
+        exit_reason,
+        occurred_at,
+        key,
+        context_patch,
     )
     async with crm_connection() as conn:
         rows = await conn.fetch(query, *values)
@@ -327,3 +344,24 @@ async def sweep_exited_runs(cutoff: datetime, batch: int) -> int:
     async with crm_connection() as conn:
         rows = await conn.fetch(query, *values)
     return len(rows)
+
+
+async def workflow_summary(
+    merchant_id: str,
+    workflow_id: str,
+    since: Optional[datetime],
+    until: Optional[datetime],
+) -> WorkflowRunSummary:
+    query, values = workflow_summary_query(merchant_id, workflow_id, since, until)
+    async with crm_connection() as conn:
+        rows = await conn.fetch(query, *values)
+    return decode_run_summary(rows)
+
+
+async def customer_runs(
+    merchant_id: str, customer_id: str, limit: int
+) -> List[CustomerRun]:
+    query, values = customer_runs_query(merchant_id, customer_id, limit)
+    async with crm_connection() as conn:
+        rows = await conn.fetch(query, *values)
+    return [decode_customer_run(row) for row in rows]

--- a/app/crm/outreach/db/decoder.py
+++ b/app/crm/outreach/db/decoder.py
@@ -2,9 +2,15 @@
 DB-side translation only — never imported outside db/."""
 
 import json
-from typing import Any, Mapping
+from typing import Any, Dict, Iterable, Mapping, Optional
 
-from app.crm.outreach.schemas import EnrollmentRun, Workflow, WorkflowSummary
+from app.crm.outreach.schemas import (
+    CustomerRun,
+    EnrollmentRun,
+    Workflow,
+    WorkflowRunSummary,
+    WorkflowSummary,
+)
 
 
 def _jsonb(value: Any) -> Any:
@@ -53,4 +59,52 @@ def decode_run(row: Mapping[str, Any]) -> EnrollmentRun:
         enrollment_key=row["enrollment_key"],
         attempts=row["attempts"],
         last_error=row["last_error"],
+    )
+
+
+def decode_customer_run(row: Mapping[str, Any]) -> CustomerRun:
+    return CustomerRun(
+        **decode_run(row).model_dump(), workflow_name=row["workflow_name"]
+    )
+
+
+def _number(value: Any) -> Optional[float]:
+    """Total: a numeric/Decimal aggregate as a float, NULL as None."""
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def decode_run_summary(rows: Iterable[Mapping[str, Any]]) -> WorkflowRunSummary:
+    """Fold workflow_summary_query's grouping-set rows into one summary.
+    grouping_level 0 rows are one (status, exit_reason) each; the level-3
+    row (both columns grouped away) is the whole window. Total: an empty
+    window is a zero summary, never a raise."""
+    runs = 0
+    by_exit_reason: Dict[str, int] = {}
+    open_runs = {"waiting": 0, "parked": 0}
+    median: Optional[float] = None
+    recovered: Optional[float] = None
+    for row in rows:
+        if int(row["grouping_level"] or 0) == 3:
+            runs = int(row["runs"] or 0)
+            median = _number(row["median_minutes_to_exit"])
+            recovered = _number(row["recovered_amount"])
+            continue
+        status, reason = row["status"], row["exit_reason"]
+        if status in open_runs:
+            open_runs[status] += int(row["runs"] or 0)
+        elif reason:
+            by_exit_reason[reason] = by_exit_reason.get(reason, 0) + int(
+                row["runs"] or 0
+            )
+    return WorkflowRunSummary(
+        runs=runs,
+        by_exit_reason=by_exit_reason,
+        open=open_runs,
+        median_minutes_to_exit=median,
+        recovered_amount=recovered,
     )

--- a/app/crm/outreach/db/queries.py
+++ b/app/crm/outreach/db/queries.py
@@ -445,6 +445,7 @@ def cancel_open_runs_query(
     exit_reason: str,
     occurred_at: Optional[datetime] = None,
     key: Optional[Tuple[str, str]] = None,
+    context_patch: Optional[Dict[str, Any]] = None,
 ) -> Tuple[str, List[Any]]:
     """Goal-cancel (canon: the goal event resolves OPEN enrolments — open
     is waiting or parked; a parked run she has already satisfied must not
@@ -463,18 +464,12 @@ def cancel_open_runs_query(
 
     Keyed (phase 06): ``key = (run field, value)`` ends only the run the
     letter is about (context cart_token = the order's cart_token); the
-    unkeyed form is byte-identical to before."""
-    keyed = "AND context->>$6 = $7" if key else ""
-    query = f"""
-        UPDATE {ENROLLMENT_TABLE}
-        SET status = 'exited', exit_reason = $4, exited_at = now(),
-            wake_at = NULL
-        WHERE merchant_id = $1 AND workflow_id = $2 AND customer_id = $3
-          AND status <> 'exited'
-          AND ($5::timestamptz IS NULL OR COALESCE((context->>'entered_event_at')::timestamptz, entered_at) < $5::timestamptz)
-          {keyed}
-        RETURNING id
-    """
+    unkeyed form is byte-identical to before.
+
+    ``context_patch`` (phase 09) rides the same UPDATE — context ||
+    $n::jsonb — so the run remembers which letter ended it and what it
+    was worth (context.goal), for the summary's recovered revenue. Its
+    placeholder follows the optional key."""
     params: List[Any] = [
         merchant_id,
         workflow_id,
@@ -482,8 +477,24 @@ def cancel_open_runs_query(
         exit_reason,
         occurred_at,
     ]
+    keyed = ""
     if key:
+        keyed = "AND context->>$6 = $7"
         params.extend([key[0], key[1]])
+    patched = ""
+    if context_patch is not None:
+        patched = f", context = context || ${len(params) + 1}::jsonb"
+        params.append(json.dumps(context_patch))
+    query = f"""
+        UPDATE {ENROLLMENT_TABLE}
+        SET status = 'exited', exit_reason = $4, exited_at = now(),
+            wake_at = NULL{patched}
+        WHERE merchant_id = $1 AND workflow_id = $2 AND customer_id = $3
+          AND status <> 'exited'
+          AND ($5::timestamptz IS NULL OR COALESCE((context->>'entered_event_at')::timestamptz, entered_at) < $5::timestamptz)
+          {keyed}
+        RETURNING id
+    """
     return query, params
 
 
@@ -529,6 +540,61 @@ def resume_run_query(
         RETURNING {_RUN_COLUMNS}
     """
     return query, [merchant_id, workflow_id, run_id]
+
+
+def workflow_summary_query(
+    merchant_id: str,
+    workflow_id: str,
+    since: Optional[datetime],
+    until: Optional[datetime],
+) -> Tuple[str, List[Any]]:
+    """The plan's report (rollout phase 09, G9) in ONE statement. Grouping
+    sets give two kinds of row at once: one per (status, exit_reason) —
+    the open counts and the exits by reason — and the () row for the whole
+    window: total runs, the median minutes from entry to exit over the
+    finished ones, and the recovered amount (context.goal.amount summed
+    over goal_met rows, behind a numeric regex so a stray value can never
+    break the read). GROUPING() tells the decoder which row is which. The
+    window bounds entered_at; NULL bounds mean all time."""
+    query = f"""
+        SELECT status, exit_reason,
+               GROUPING(status, exit_reason) AS grouping_level,
+               count(*) AS runs,
+               percentile_cont(0.5) WITHIN GROUP (
+                   ORDER BY EXTRACT(EPOCH FROM (exited_at - entered_at)) / 60.0
+               ) FILTER (WHERE status = 'exited') AS median_minutes_to_exit,
+               sum(CASE WHEN exit_reason = 'goal_met'
+                         AND (context->'goal'->>'amount') ~ '^-?[0-9]+(\\.[0-9]+)?$'
+                        THEN (context->'goal'->>'amount')::numeric END) AS recovered_amount
+        FROM {ENROLLMENT_TABLE}
+        WHERE merchant_id = $1 AND workflow_id = $2
+          AND ($3::timestamptz IS NULL OR entered_at >= $3::timestamptz)
+          AND ($4::timestamptz IS NULL OR entered_at < $4::timestamptz)
+        GROUP BY GROUPING SETS ((status, exit_reason), ())
+    """
+    return query, [merchant_id, workflow_id, since, until]
+
+
+_RUN_COLUMNS_OF_E = ", ".join(f"e.{c.strip()}" for c in _RUN_COLUMNS.split(","))
+
+
+def customer_runs_query(
+    merchant_id: str, customer_id: str, limit: int
+) -> Tuple[str, List[Any]]:
+    """The customer's journey (rollout phase 09): her runs across EVERY
+    plan in the order they began, each naming its plan — the loan funnel's
+    journey view while it runs as clocks. Both tables are outreach's; the
+    customer index carries the read."""
+    query = f"""
+        SELECT {_RUN_COLUMNS_OF_E}, w.name AS workflow_name
+        FROM {ENROLLMENT_TABLE} e
+        JOIN {WORKFLOW_TABLE} w
+          ON w.merchant_id = e.merchant_id AND w.id = e.workflow_id
+        WHERE e.merchant_id = $1 AND e.customer_id = $2
+        ORDER BY e.entered_at, e.id
+        LIMIT $3
+    """
+    return query, [merchant_id, customer_id, limit]
 
 
 def sweep_exited_runs_query(cutoff: datetime, batch: int) -> Tuple[str, List[Any]]:

--- a/app/crm/outreach/entry.py
+++ b/app/crm/outreach/entry.py
@@ -18,7 +18,7 @@ from app.core.logger import logger
 from app.crm.outreach.db import accessor
 from app.crm.outreach.enrol import enrol
 from app.crm.outreach.nodes import _BOOKKEEPING_KEYS, _BOOKKEEPING_PREFIXES
-from app.crm.outreach.repeat import apply_repeat
+from app.crm.outreach.repeat import _as_number, apply_repeat
 from app.crm.outreach.schemas import Workflow, WorkflowDefinition, WorkflowNode
 from app.crm.record.contracts import RawEvent
 from app.crm.shared.normalize import normalize_phone
@@ -105,6 +105,7 @@ async def consume_attributed_event(
     # UPDATE's status <> 'exited' keeps the two verdicts apart. A keyed
     # tier whose payload field is missing cannot say which run it is
     # about and is skipped; the unkeyed tier still applies.
+    goal_patch = _goal_patch(event) if goal_matches else None
     for flow, definition in goal_matches:
         for tier in definition.goal_tiers(event.topic):
             key: Optional[Tuple[str, str]] = None
@@ -120,6 +121,7 @@ async def consume_attributed_event(
                 tier.exit_reason,
                 event.occurred_at,
                 key,
+                goal_patch,
             )
     for flow, node in listening:
         answer = event.payload.get(node.key or "")
@@ -144,6 +146,26 @@ async def consume_attributed_event(
         )
     for flow, definition in entry_matches:
         await _try_enrol(flow, definition, event, customer_id, handles)
+
+
+# Where an order's amount lives in a payload, most specific first —
+# Shopify's total_price, the generic amount.
+_AMOUNT_KEYS = ("total_price", "amount")
+
+
+def _goal_patch(event: RawEvent) -> dict:
+    """PURE: what a run keeps about the letter that ended it (phase 09):
+    the topic, the letter's id, and — when the payload says so as a
+    number — the amount, as the payload gave it (Shopify posts money as
+    "1850.00"; a float here would lose that spelling). The summary sums
+    it over goal_met rows; a non-numeric value is simply absent."""
+    goal: dict = {"topic": event.topic, "event_id": str(event.id)}
+    for key in _AMOUNT_KEYS:
+        value = event.payload.get(key)
+        if _as_number(value) is not None:
+            goal["amount"] = value
+            break
+    return {"goal": goal}
 
 
 def reply_key(node_id: str) -> str:

--- a/app/crm/outreach/nodes.py
+++ b/app/crm/outreach/nodes.py
@@ -52,6 +52,7 @@ from app.schemas.breeze_buddy.core import ExecutionMode, LeadCallStatus
 _BOOKKEEPING_KEYS = (
     "source_event_id",
     "entered_event_at",  # entry.py: when the founding letter happened (G7)
+    "goal",  # entry.py: the letter that ended the run, and its amount (phase 09)
     "phone",
     "customer_mobile_number",
     "repeat_event_ids",  # repeat.py: which letters already patched this run

--- a/app/crm/outreach/runs.py
+++ b/app/crm/outreach/runs.py
@@ -19,7 +19,7 @@ from app.core.config.static import (
 )
 from app.core.logger import logger
 from app.crm.outreach.db import accessor
-from app.crm.outreach.schemas import EnrollmentRun
+from app.crm.outreach.schemas import CustomerRun, EnrollmentRun, WorkflowRunSummary
 
 _LISTABLE_STATUSES = ("waiting", "parked", "exited")
 
@@ -46,6 +46,24 @@ async def resume_run(
     if run:
         logger.info(f"run resumed by operator: {run_id} (merchant {merchant_id})")
     return run
+
+
+async def workflow_summary(
+    merchant_id: str,
+    workflow_id: str,
+    since: Optional[datetime],
+    until: Optional[datetime],
+) -> WorkflowRunSummary:
+    """The plan's report over a window of entered_at (rollout phase 09)."""
+    return await accessor.workflow_summary(merchant_id, workflow_id, since, until)
+
+
+async def customer_runs(
+    merchant_id: str, customer_id: str, limit: int
+) -> List[CustomerRun]:
+    """The customer's journey: her runs across every plan, in the order
+    they began (rollout phase 09)."""
+    return await accessor.customer_runs(merchant_id, customer_id, limit)
 
 
 async def run_retention_sweep_tick() -> None:

--- a/app/crm/outreach/schemas.py
+++ b/app/crm/outreach/schemas.py
@@ -168,6 +168,19 @@ class Workflow(WorkflowSummary):
     draft: Optional[Dict[str, Any]]
 
 
+class WorkflowRunSummary(BaseModel):
+    """One plan's runs over a window (rollout phase 09, G9): how many
+    started, how they ended, what is still in flight, how long they took,
+    and what the recovered ones were worth. ``WorkflowSummary`` is the
+    list shape, hence the name."""
+
+    runs: int
+    by_exit_reason: Dict[str, int]
+    open: Dict[str, int]
+    median_minutes_to_exit: Optional[float]
+    recovered_amount: Optional[float]
+
+
 class EnrollmentRun(BaseModel):
     """One person's run — the token (canon T20)."""
 
@@ -186,3 +199,10 @@ class EnrollmentRun(BaseModel):
     enrollment_key: str
     attempts: int
     last_error: Optional[str]
+
+
+class CustomerRun(EnrollmentRun):
+    """A run as the customer's journey lists it — across every plan, so
+    each row says which plan it belongs to (rollout phase 09)."""
+
+    workflow_name: str

--- a/docs/crm/runbooks/cart-recovery.md
+++ b/docs/crm/runbooks/cart-recovery.md
@@ -128,6 +128,32 @@ Goal comparisons are against the moment the **checkout update happened**
 (`entered_event_at`), not when we stored the run — an order that arrived
 late but happened after the abandonment still ends the run.
 
+## How to read the summary
+
+```bash
+curl -sS "$BASE/workflows/<wf>/summary?merchant_id=$M&since=2026-09-01T00:00:00Z&until=2026-09-08T00:00:00Z" -H "$H"
+```
+
+One object for the window (`since`/`until` bound `entered_at`; omit both
+for all time):
+
+| Field | Meaning |
+|---|---|
+| `runs` | runs that started in the window |
+| `open.waiting` / `open.parked` | still in flight / stuck for a human |
+| `by_exit_reason` | how the finished ones ended (`goal_met` = this cart recovered, `converted_elsewhere`, `completed`, `timed_out`, `ejected`) |
+| `median_minutes_to_exit` | median time from the checkout update to the exit, over finished runs |
+| `recovered_amount` | sum of the order amount on `goal_met` runs — the order's `total_price` as the relay delivered it, stored on the run when the goal ended it |
+
+Recovery rate = `goal_met / runs` once the window is old enough for every
+run to have finished (a day after `until`, for this board).
+
+A customer's runs across every plan, in the order they started:
+
+```bash
+curl -sS "$BASE/customers/<customer_id>/runs?merchant_id=$M" -H "$H"
+```
+
 ## Settings to change per merchant
 
 | Where | Word | Default in the document | Change when |

--- a/docs/crm/runbooks/loan-dropoff.md
+++ b/docs/crm/runbooks/loan-dropoff.md
@@ -78,8 +78,37 @@ Order does not matter — each clock only listens for its own stage topic.
   number) or a call template problem — fix, then
   `POST /workflows/<wf>/runs/<run>/resume?merchant_id=$M`.
 - **A customer's journey** = their runs across the five plans in stage
-  order; until phase 09 adds the read, query each plan's runs and match
-  `context.application_id`.
+  order: `GET /customers/<customer_id>/runs?merchant_id=$M` (see "How to
+  read the funnel").
+
+## How to read the funnel
+
+Per clock, the summary says how many customers reached that stage in the
+window and what happened next:
+
+```bash
+curl -sS "$BASE/workflows/<wf-for-a-stage>/summary?merchant_id=$M&since=<iso>&until=<iso>" -H "$H"
+```
+
+| Field | Meaning for a clock |
+|---|---|
+| `runs` | applications that reached this stage in the window |
+| `by_exit_reason.goal_met` | progressed to a later stage before the alarm |
+| `by_exit_reason.completed` | went quiet for 30 minutes and were called — the drop-offs at this stage |
+| `by_exit_reason.withdrawn` | rejected or withdrawn while on this stage |
+| `open.waiting` | still inside the 30-minute window |
+| `median_minutes_to_exit` | median time on this stage (progress or call) |
+
+Drop-off rate at a stage = `completed / runs`; the funnel is the five
+summaries side by side. `recovered_amount` is empty for the clocks (loan
+events carry no order amount).
+
+One application's journey — its runs across the five clocks, in the
+order the stages happened, each row naming its plan:
+
+```bash
+curl -sS "$BASE/customers/<customer_id>/runs?merchant_id=$M" -H "$H"
+```
 
 ## Exit reasons
 

--- a/tests/crm/test_workflow_entry.py
+++ b/tests/crm/test_workflow_entry.py
@@ -166,6 +166,46 @@ def cancels(monkeypatch: pytest.MonkeyPatch) -> List[Tuple[Any, ...]]:
     return calls
 
 
+def test_the_goal_cancel_stashes_the_goal_event_with_its_amount(
+    cancels: List[Tuple[Any, ...]], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Phase 09: the run remembers which letter ended it — and how much it
+    was worth, when the payload says so as a number — so the summary can
+    sum recovered revenue without re-reading the spine."""
+    patches: List[Any] = []
+
+    async def cancel_open_runs(*args: Any) -> int:
+        patches.append(args[6] if len(args) > 6 else None)
+        return 1
+
+    monkeypatch.setattr(entry.accessor, "cancel_open_runs", cancel_open_runs)
+    asyncio.run(
+        consume_attributed_event(
+            _order({"cart_token": "chk-1", "total_price": "1850.00"}), "c-1", {}
+        )
+    )
+    assert (
+        patches
+        == [
+            {
+                "goal": {
+                    "topic": "orders/create",
+                    "event_id": "ev-order",
+                    "amount": "1850.00",
+                }
+            }
+        ]
+        * 2
+    )  # both tiers' cancels carry it; only goal_met rows are summed
+    patches.clear()
+    asyncio.run(
+        consume_attributed_event(
+            _order({"cart_token": "chk-1", "total_price": "n/a"}), "c-1", {}
+        )
+    )
+    assert patches[0] == {"goal": {"topic": "orders/create", "event_id": "ev-order"}}
+
+
 def test_an_order_carrying_the_cart_token_is_judged_keyed_first(
     cancels: List[Tuple[Any, ...]],
 ) -> None:

--- a/tests/crm/test_workflow_reporting.py
+++ b/tests/crm/test_workflow_reporting.py
@@ -1,0 +1,184 @@
+"""Runs reporting (rollout phase 09, G9): the per-plan summary and the
+customer's journey across plans — the read the clocks pattern (§13) owed.
+
+The summary is ONE statement (grouping sets) folded by a pure decoder;
+the journey read joins the plan's name onto the customer's runs; the
+goal-cancel stashes the goal event on the run so recovered revenue can be
+summed later. Route wiring is checked by inspecting the routers, so a
+route that lost its admin dependency or its mount fails here."""
+
+import inspect
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, List
+from uuid import uuid4
+
+from fastapi.routing import APIRoute
+
+import app.crm.api as crm_api
+import app.crm.outreach.api as outreach_api
+from app.crm.auth import crm_admin_user
+from app.crm.outreach.db.decoder import decode_customer_run, decode_run_summary
+from app.crm.outreach.db.queries import (
+    cancel_open_runs_query,
+    customer_runs_query,
+    workflow_summary_query,
+)
+from app.crm.outreach.nodes import run_facts
+
+NOW = datetime(2026, 9, 3, 12, 0, tzinfo=timezone.utc)
+SINCE, UNTIL = NOW - timedelta(days=7), NOW
+
+
+# --- the builders ---
+
+
+def test_summary_is_one_merchant_first_statement_with_a_window() -> None:
+    sql, params = workflow_summary_query("m1", "wf-1", SINCE, UNTIL)
+    assert "merchant_id = $1 AND workflow_id = $2" in sql
+    assert (
+        "entered_at >= $3::timestamptz" in sql and "entered_at < $4::timestamptz" in sql
+    )
+    assert "$3::timestamptz IS NULL OR" in sql and "$4::timestamptz IS NULL OR" in sql
+    assert "GROUP BY GROUPING SETS ((status, exit_reason), ())" in sql
+    assert "GROUPING(status, exit_reason)" in sql
+    assert "percentile_cont(0.5)" in sql and "exited_at - entered_at" in sql
+    assert "context->'goal'->>'amount'" in sql and "exit_reason = 'goal_met'" in sql
+    assert params == ["m1", "wf-1", SINCE, UNTIL]
+    _, params = workflow_summary_query("m1", "wf-1", None, None)
+    assert params == ["m1", "wf-1", None, None]  # no window = all time
+
+
+def test_customer_runs_join_the_plan_name_in_entry_order() -> None:
+    sql, params = customer_runs_query("m1", "c-1", 100)
+    assert "e.merchant_id = $1 AND e.customer_id = $2" in sql
+    assert "JOIN crm_workflow w" in sql and "w.name AS workflow_name" in sql
+    assert "w.merchant_id = e.merchant_id AND w.id = e.workflow_id" in sql
+    assert "ORDER BY e.entered_at, e.id" in sql and "LIMIT $3" in sql
+    assert params == ["m1", "c-1", 100]
+
+
+def test_goal_cancel_can_stash_the_goal_on_the_runs_it_ends() -> None:
+    """The patch rides the same UPDATE: context = context || $n::jsonb.
+    Its placeholder follows the optional key, so both shapes are pinned."""
+    patch = {
+        "goal": {"topic": "orders/create", "event_id": "ev-1", "amount": "1850.00"}
+    }
+    sql, params = cancel_open_runs_query(
+        "m1",
+        "wf-1",
+        "c-1",
+        "goal_met",
+        NOW,
+        key=("cart_token", "chk-1"),
+        context_patch=patch,
+    )
+    assert "context = context || $8::jsonb" in sql and "AND context->>$6 = $7" in sql
+    assert len(params) == 8 and '"1850.00"' in params[7]
+    sql, params = cancel_open_runs_query(
+        "m1", "wf-1", "c-1", "converted_elsewhere", NOW, context_patch=patch
+    )
+    assert "context = context || $6::jsonb" in sql and "$7" not in sql
+    assert len(params) == 6
+    sql, params = cancel_open_runs_query("m1", "wf-1", "c-1", "goal_met", NOW)
+    assert "context = context ||" not in sql and len(params) == 5
+
+
+def test_the_goal_stash_is_bookkeeping_not_a_template_variable() -> None:
+    facts = run_facts({"cart_token": "chk-1", "goal": {"topic": "orders/create"}})
+    assert facts == {"cart_token": "chk-1"}
+
+
+# --- the decoder folds grouping-set rows into one summary ---
+
+
+def _row(
+    status: Any,
+    reason: Any,
+    level: int,
+    runs: int,
+    median: Any = None,
+    amount: Any = None,
+) -> Dict[str, Any]:
+    return {
+        "status": status,
+        "exit_reason": reason,
+        "grouping_level": level,
+        "runs": runs,
+        "median_minutes_to_exit": median,
+        "recovered_amount": amount,
+    }
+
+
+def test_decoder_folds_the_grouping_rows() -> None:
+    rows = [
+        _row("waiting", None, 0, 4),
+        _row("parked", None, 0, 1),
+        _row("exited", "goal_met", 0, 6, 42.0, 5400),
+        _row("exited", "converted_elsewhere", 0, 2, 30.0, None),
+        _row("exited", "completed", 0, 3, 1500.0, None),
+        _row(None, None, 3, 16, 61.5, 5400),  # the () set: the whole window
+    ]
+    summary = decode_run_summary(rows)
+    assert summary.runs == 16
+    assert summary.open == {"waiting": 4, "parked": 1}
+    assert summary.by_exit_reason == {
+        "goal_met": 6,
+        "converted_elsewhere": 2,
+        "completed": 3,
+    }
+    assert summary.median_minutes_to_exit == 61.5
+    assert summary.recovered_amount == 5400.0
+
+
+def test_decoder_is_total_on_an_empty_window() -> None:
+    summary = decode_run_summary([])
+    assert summary.runs == 0 and summary.open == {"waiting": 0, "parked": 0}
+    assert summary.by_exit_reason == {} and summary.median_minutes_to_exit is None
+    assert summary.recovered_amount is None
+
+
+def test_decoder_carries_the_plan_name_on_a_customer_run() -> None:
+    run_id, wf_id, cust_id = uuid4(), uuid4(), uuid4()
+    row = {
+        "id": run_id,
+        "merchant_id": "m1",
+        "workflow_id": wf_id,
+        "workflow_version": 1,
+        "customer_id": cust_id,
+        "status": "exited",
+        "current_node": "wait-30m",
+        "wake_at": None,
+        "entered_at": NOW,
+        "exited_at": NOW,
+        "exit_reason": "goal_met",
+        "context": '{"application_id": "APP-1"}',
+        "enrollment_key": "APP-1",
+        "attempts": 1,
+        "last_error": None,
+        "workflow_name": "loan-dropoff-02-kyc",
+    }
+    run = decode_customer_run(row)
+    assert run.workflow_name == "loan-dropoff-02-kyc" and run.context == {
+        "application_id": "APP-1"
+    }
+
+
+# --- the doors ---
+
+
+def _route(router: Any, path: str) -> APIRoute:
+    matches = [r for r in router.routes if isinstance(r, APIRoute) and r.path == path]
+    assert len(matches) == 1, path
+    return matches[0]
+
+
+def test_summary_and_journey_routes_are_admin_only_and_mounted() -> None:
+    summary = _route(outreach_api.router, "/{workflow_id}/summary")
+    journey = _route(outreach_api.customer_router, "/{customer_id}/runs")
+    for route in (summary, journey):
+        assert route.methods == {"GET"}
+        guard = inspect.signature(route.endpoint).parameters["current_user"].default
+        assert guard.dependency is crm_admin_user
+    mounted = [r.path for r in crm_api.router.routes if isinstance(r, APIRoute)]
+    assert "/workflows/{workflow_id}/summary" in mounted
+    assert "/customers/{customer_id}/runs" in mounted


### PR DESCRIPTION
**Rollout phase 09** — `docs/crm/workflow-rollout/09-runs-reporting.md` (notes §13 verdict, §16.3 G9). No migration.

## Why

With the loan funnel running as per-stage clocks, "where do customers drop" is a join across plans; boards (later) answer it from one run. Either way the read belongs to outreach and was missing (G9).

## What changed

| Piece | Where |
|---|---|
| `GET /workflows/{id}/summary?merchant_id&since&until` → `{runs, by_exit_reason, open: {waiting, parked}, median_minutes_to_exit, recovered_amount}`. **One** statement: merchant-first, window on `entered_at`, `GROUP BY GROUPING SETS ((status, exit_reason), ())` so the per-reason rows and the overall row (total, median minutes from `entered_at` to `exited_at`, recovered amount) arrive together; a pure, total decoder folds them. | `db/queries.py::workflow_summary_query`, `db/decoder.py::decode_run_summary`, `runs.py`, `api.py` |
| `GET /customers/{customer_id}/runs?merchant_id&limit` → the customer's runs across **all** plans in `entered_at` order, each carrying `workflow_name` (a join of outreach's two tables on the customer index). Outreach's second router, mounted at `/customers` beside identity's and record's — the record precedent of two doors under two prefixes. This is the loan funnel's journey view under Option A. | `db/queries.py::customer_runs_query`, `schemas.py::CustomerRun`, `api.py::customer_router`, `app/crm/api.py` |
| **Recovered revenue.** At goal-cancel time the entry consumer stashes `context.goal = {topic, event_id, amount}` on every run the goal ends — `amount` only when `payload.total_price` / `payload.amount` is a finite number (Shopify posts money as `"1850.00"`). `cancel_open_runs_query` takes the patch as `context = context || $n::jsonb` (the placeholder follows the optional key, both shapes tested). The summary sums it for `goal_met` rows behind a numeric regex, so a stray value can never break the read. `goal` is a bookkeeping key: never a template variable. | `entry.py`, `db/queries.py`, `nodes.py` |
| Schemas: `WorkflowRunSummary` (the list shape already owns the name `WorkflowSummary`), `CustomerRun`. Routes admin-only (`crm_admin_user`), `set_log_context` on each. | `schemas.py`, `api.py` |
| Runbooks: "How to read the summary" (cart) and "How to read the funnel" (loan), including the journey read; the loan runbook's "until phase 09" line replaced. | `docs/crm/runbooks/*` |

## Summary SQL executed on a scratch database

057 → 058 → 063 on a local Postgres 16 with seeded runs (waiting, parked, exited by three reasons, one with a stored goal amount): the grouping-set rows fold to the expected totals, median and revenue. Transcript in the comment below.

## Coordination with #1053 (still open)

Per the phase: built on `release`, overlap noted. #1053 adds `GET /workflows/runs/counts` and `GET /workflows/{id}/runs/counts` (`RunCounts` per status/reason, no window). This PR's summary overlaps with it on the counts only, not on the window, the median, the revenue or the journey read. Whichever lands second should fold the counts into one read; nothing here blocks #1053 (its migration is numbered 061 and will need renumbering regardless).

## Red tests (fail on `release`, pass here)

`tests/crm/test_workflow_reporting.py` (new, 8): both builders merchant-first with `$1` params, the window predicates, the grouping sets, the join and ordering; the cancel patch placeholder with and without a key; `goal` excluded from template facts; the decoder folds grouping rows and is total on an empty window; the customer-run decoder; both routes exist, are `GET`, depend on `crm_admin_user`, and are mounted at the right prefixes.

`tests/crm/test_workflow_entry.py` (1): the goal cancel carries the goal patch with the amount when the payload has a numeric one, without it otherwise, on both tiers' cancels.

## Checks (unpiped before push)

`black` · `isort` · `autoflake` · `pyrefly check` (0 errors) · `pytest tests/crm` (**592 passed** = 583 on release + 9 new) · `check_crm_boundaries.py` (clean) · `check_migrations.py --base origin/release` (clean). One commit.

## Decisions already made — disagreements

None.

## Judgment calls

- The PR title (from the phase file) says "time per node"; the phase's design section specifies `median_minutes_to_exit`, which is what is built. Per-node timing needs per-node timestamps the run does not keep; noted for the board era (phase 12+).
- The goal patch is stored on **every** run a goal ends (both tiers), so `converted_elsewhere` runs also remember the order that ended them; only `goal_met` rows are summed.
- `amount` is stored as the payload gave it (string or number) once it parses as a finite number, and cast in SQL; float conversion in Python would lose the "1850.00" the merchant sent.

## Not done on purpose

- Console UI; cross-merchant totals (out of scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014UNZ4z7zb87HnNHjTXoFpW
