### PR TITLE
feat(crm): crm_workflow_version — publish writes an immutable version row; on_publish pin|migrate (rollout 11)

### DIFF
--- a/app/crm/outreach/api.py
+++ b/app/crm/outreach/api.py
@@ -110,7 +110,9 @@ async def publish_workflow_route(
 ) -> Workflow:
     set_log_context(component="crm.workflows.publish", merchant_id=merchant_id)
     try:
-        return await plans.publish_workflow(merchant_id, workflow_id)
+        return await plans.publish_workflow(
+            merchant_id, workflow_id, current_user.email
+        )
     except plans.WorkflowNotFound:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="Workflow not found"

--- a/app/crm/outreach/db/accessor.py
+++ b/app/crm/outreach/db/accessor.py
@@ -13,6 +13,7 @@ from typing import Any, Dict, List, Optional, Tuple
 import asyncpg
 
 from app.crm.outreach.db.decoder import (
+    _jsonb as decode_jsonb,
     decode_customer_run,
     decode_run,
     decode_run_summary,
@@ -26,8 +27,10 @@ from app.crm.outreach.db.queries import (
     claim_due_runs_query,
     customer_runs_query,
     exit_run_query,
+    get_definition_query,
     get_workflow_query,
     insert_enrollment_query,
+    insert_version_query,
     insert_workflow_query,
     list_runs_query,
     list_workflows_query,
@@ -37,6 +40,7 @@ from app.crm.outreach.db.queries import (
     patch_open_run_query,
     publish_workflow_query,
     record_run_error_query,
+    repin_open_runs_query,
     resume_run_on_event_query,
     resume_run_query,
     set_workflow_status_query,
@@ -114,6 +118,46 @@ async def apply_publish(
     query, values = publish_workflow_query(merchant_id, workflow_id)
     row = await conn.fetchrow(query, *values)
     return decode_workflow(row) if row else None
+
+
+async def insert_version(
+    conn: asyncpg.Connection,
+    merchant_id: str,
+    workflow_id: str,
+    version: int,
+    definition: Dict[str, Any],
+    on_publish: str,
+    published_by: Optional[str],
+) -> None:
+    """Runs inside the publish atom (conn param): the row shares the
+    publish's fate."""
+    query, values = insert_version_query(
+        merchant_id, workflow_id, version, definition, on_publish, published_by
+    )
+    await conn.execute(query, *values)
+
+
+async def repin_open_runs(
+    conn: asyncpg.Connection, merchant_id: str, workflow_id: str, version: int
+) -> int:
+    """Runs inside the publish atom (conn param). Returns how many runs
+    now execute the new version."""
+    query, values = repin_open_runs_query(merchant_id, workflow_id, version)
+    rows = await conn.fetch(query, *values)
+    return len(rows)
+
+
+async def get_definition(
+    merchant_id: str, workflow_id: str, version: int
+) -> Optional[Dict[str, Any]]:
+    """The pinned document, or None when no such version row exists."""
+    query, values = get_definition_query(merchant_id, workflow_id, version)
+    async with crm_connection() as conn:
+        row = await conn.fetchrow(query, *values)
+    if row is None:
+        return None
+    definition = decode_jsonb(row["definition"])
+    return definition if isinstance(definition, dict) else None
 
 
 async def set_workflow_status(

--- a/app/crm/outreach/db/queries.py
+++ b/app/crm/outreach/db/queries.py
@@ -16,6 +16,7 @@ from typing import Any, Dict, List, Optional, Tuple
 
 WORKFLOW_TABLE = "crm_workflow"
 ENROLLMENT_TABLE = "crm_workflow_enrollment"
+VERSION_TABLE = "crm_workflow_version"
 _WORKFLOW_SUMMARY_COLUMNS = """
     id, merchant_id, name, status, version, created_by,
     created_at, updated_at
@@ -94,6 +95,62 @@ def publish_workflow_query(merchant_id: str, workflow_id: str) -> Tuple[str, Lis
         RETURNING {_WORKFLOW_COLUMNS}
     """
     return query, [merchant_id, workflow_id]
+
+
+def insert_version_query(
+    merchant_id: str,
+    workflow_id: str,
+    version: int,
+    definition: Dict[str, Any],
+    on_publish: str,
+    published_by: Optional[str],
+) -> Tuple[str, List[Any]]:
+    """One immutable row per publish (ADR 0023, phase 11): the document
+    that became live, under the mode it declared. No ON CONFLICT — a
+    second row for the same version is a bug the unique index must
+    surface, never a merge."""
+    query = f"""
+        INSERT INTO {VERSION_TABLE}
+            (merchant_id, workflow_id, version, definition, on_publish, published_by)
+        VALUES ($1, $2, $3, $4::jsonb, $5, $6)
+        RETURNING id
+    """
+    return query, [
+        merchant_id,
+        workflow_id,
+        version,
+        json.dumps(definition),
+        on_publish,
+        published_by,
+    ]
+
+
+def repin_open_runs_query(
+    merchant_id: str, workflow_id: str, version: int
+) -> Tuple[str, List[Any]]:
+    """migrate mode (ADR 0023): every open run of the plan now executes the
+    version just published — inside the publish atom, after the stranding
+    validator said the document keeps every occupied square. Exited runs
+    keep the version they finished under: the audit fact."""
+    query = f"""
+        UPDATE {ENROLLMENT_TABLE}
+        SET workflow_version = $3
+        WHERE merchant_id = $1 AND workflow_id = $2 AND status <> 'exited'
+        RETURNING id
+    """
+    return query, [merchant_id, workflow_id, version]
+
+
+def get_definition_query(
+    merchant_id: str, workflow_id: str, version: int
+) -> Tuple[str, List[Any]]:
+    """The pinned document, by the pin (phase 12's read)."""
+    query = f"""
+        SELECT definition
+        FROM {VERSION_TABLE}
+        WHERE merchant_id = $1 AND workflow_id = $2 AND version = $3
+    """
+    return query, [merchant_id, workflow_id, version]
 
 
 def set_workflow_status_query(

--- a/app/crm/outreach/plans.py
+++ b/app/crm/outreach/plans.py
@@ -102,19 +102,25 @@ def validate_definition(
             if len(arrows) > 1:
                 problems.append(f"node {src} has {len(arrows)} outgoing edges")
 
-    if occupied_nodes and live_entry is not None:
-        if _entry_changed(raw.get("entry"), live_entry):
-            problems.append(
-                "entry rule changed while runs are open — pause the plan and "
-                "let them finish, or publish the entry change as a new plan"
-            )
+    # The stranding laws are migrate-mode preconditions (ADR 0023): only a
+    # document that will be pushed UNDER the open runs can strand them.
+    # Under pin they keep their own version, and the new one is theirs to
+    # ignore — the checks below do not apply.
+    if definition.on_publish == "migrate":
+        if occupied_nodes and live_entry is not None:
+            if _entry_changed(raw.get("entry"), live_entry):
+                problems.append(
+                    "entry rule changed while runs are open — pause the plan "
+                    "and let them finish, publish the entry change as a new "
+                    "plan, or publish with on_publish: pin"
+                )
 
-    for occupied in occupied_nodes or []:
-        if occupied not in seen:
-            problems.append(
-                f"node {occupied} has waiting runs standing on it — "
-                "publishing a document without it strands every one"
-            )
+        for occupied in occupied_nodes or []:
+            if occupied not in seen:
+                problems.append(
+                    f"node {occupied} has waiting runs standing on it — "
+                    "migrating a document without it strands every one"
+                )
 
     return problems
 
@@ -156,37 +162,61 @@ async def update_draft(
     return await accessor.update_draft(merchant_id, workflow_id, definition)
 
 
-async def publish_workflow(merchant_id: str, workflow_id: str) -> Workflow:
-    return await atomically(_publish_in_txn, merchant_id, workflow_id)
+async def publish_workflow(
+    merchant_id: str, workflow_id: str, published_by: Optional[str] = None
+) -> Workflow:
+    return await atomically(_publish_in_txn, merchant_id, workflow_id, published_by)
 
 
-async def _publish_in_txn(txn: DbTxn, merchant_id: str, workflow_id: str) -> Workflow:
-    """ATOMIC: the validate and the copy share one fate — the document the
-    validator approved must be the exact document that becomes live, and
-    the occupied-squares read must not race a walker moving tokens."""
+async def _publish_in_txn(
+    txn: DbTxn, merchant_id: str, workflow_id: str, published_by: Optional[str]
+) -> Workflow:
+    """ATOMIC: the validate, the copy, the version row and (migrate) the
+    re-pin share one fate — the document the validator approved must be
+    the exact document that becomes live AND the one the new version row
+    holds, the occupied-squares read must not race a walker moving tokens,
+    and a migrate must never leave a run pointing at a version that did
+    not get written (ADR 0023)."""
     workflow = await accessor.workflow_for_publish(txn, merchant_id, workflow_id)
     if workflow is None:
         raise WorkflowNotFound(workflow_id)
-    if not workflow.draft:
+    draft = workflow.draft
+    if not draft:
         raise WorkflowValidationError(["nothing to publish — draft is empty"])
     occupied = await accessor.occupied_nodes(txn, merchant_id, workflow_id)
     live_entry = (workflow.definition or {}).get("entry")
     problems = validate_definition(
-        workflow.draft, occupied_nodes=occupied, live_entry=live_entry
+        draft, occupied_nodes=occupied, live_entry=live_entry
     )
     if problems:
         raise WorkflowValidationError(problems)
-    problems = await _template_problems(
-        merchant_id, WorkflowDefinition.model_validate(workflow.draft)
-    )
+    definition = WorkflowDefinition.model_validate(draft)
+    problems = await _template_problems(merchant_id, definition)
     if problems:
         raise WorkflowValidationError(problems)
     published = await accessor.apply_publish(txn, merchant_id, workflow_id)
     if published is None:  # a racing publish consumed the draft first
         raise WorkflowValidationError(["draft already published"])
+    # The version row holds the document that just became live — the draft
+    # apply_publish copied verbatim — under the mode it declared.
+    await accessor.insert_version(
+        txn,
+        merchant_id,
+        workflow_id,
+        published.version,
+        draft,
+        definition.on_publish,
+        published_by,
+    )
+    repinned = 0
+    if definition.on_publish == "migrate":
+        repinned = await accessor.repin_open_runs(
+            txn, merchant_id, workflow_id, published.version
+        )
     logger.info(
         f"workflow published: {workflow_id} v{published.version} "
-        f"(merchant {merchant_id})"
+        f"({definition.on_publish}; {repinned} open runs re-pinned; "
+        f"merchant {merchant_id})"
     )
     return published
 

--- a/app/crm/outreach/schemas.py
+++ b/app/crm/outreach/schemas.py
@@ -112,6 +112,13 @@ class WorkflowDefinition(BaseModel):
     edges: List[WorkflowEdge] = Field(default_factory=list)
     goals: List[WorkflowGoal] = Field(min_length=1)
     exits: WorkflowExits = Field(default_factory=WorkflowExits)
+    # ADR 0023: what a publish does to runs in flight. pin (default) — new
+    # entrants take the new version, runs in flight finish the one they
+    # entered under; migrate — every open run is re-pinned to the new
+    # version inside the publish atom, allowed only when the stranding
+    # validator passes (057's semantics as an opt-in mode). Vocabulary in
+    # code; the 064 CHECK on the stored column is the closed superset.
+    on_publish: Literal["pin", "migrate"] = "pin"
     # What the plan's sends are for (canon T16 col 9, NOT NULL on the
     # manifest; the gate checks it against the grant). Required once the
     # plan has a send node; the send node copies it onto every row.

--- a/app/database/migrations/064_create_crm_workflow_version.sql
+++ b/app/database/migrations/064_create_crm_workflow_version.sql
@@ -1,0 +1,82 @@
+-- 064: outreach — crm_workflow_version (ADR 0023, rollout phase 11): the
+-- immutable per-publish document a run is pinned to.
+--
+-- 057 keeps ONE live definition per plan and calls `version` an audit
+-- stamp. ADR 0023 reverses that: every enrollment executes the version it
+-- entered under (crm_workflow_enrollment.workflow_version becomes the
+-- execution pin), so each publish must leave a document that never
+-- changes again. crm_workflow.definition stays the LATEST version's
+-- document — the entry consumer and the console read it; the walker
+-- (phase 12) reads this table by (workflow_id, version).
+--
+-- on_publish is a closed status enum -> CHECK required (law 11):
+--   pin      new entrants take this version, runs in flight finish theirs;
+--   migrate  every open run is re-pinned to this version inside the
+--            publish atom, allowed only when the stranding validator
+--            passes — 057's semantics as an opt-in mode.
+--
+-- merchant_id first in the unique index (tenancy law); the FK pins the
+-- tenant (the 057 tenant_pin precedent). No partitioning: a plan publishes
+-- tens of versions, not millions of rows.
+
+CREATE TABLE crm_workflow_version (
+    id           uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    merchant_id  text NOT NULL,
+    workflow_id  uuid NOT NULL,
+    version      integer NOT NULL,
+    definition   jsonb NOT NULL,
+    on_publish   text NOT NULL DEFAULT 'pin'
+                 CHECK (on_publish IN ('pin', 'migrate')),
+    published_by text,
+    published_at timestamptz NOT NULL DEFAULT now(),
+    CONSTRAINT crm_workflow_version_workflow_fk
+        FOREIGN KEY (merchant_id, workflow_id)
+        REFERENCES crm_workflow (merchant_id, id)
+);
+
+CREATE UNIQUE INDEX crm_workflow_version_uq
+    ON crm_workflow_version (merchant_id, workflow_id, version);
+
+-- A version a run references is never mutated — by trigger, not by
+-- intention (the 051 pattern). Only rows, never edits; the retention
+-- sweep (phase 14) deletes unreferenced old versions, so no DELETE guard.
+CREATE OR REPLACE FUNCTION crm_workflow_version_immutable() RETURNS trigger AS $$
+BEGIN
+    IF NEW.merchant_id  IS DISTINCT FROM OLD.merchant_id
+       OR NEW.workflow_id  IS DISTINCT FROM OLD.workflow_id
+       OR NEW.version      IS DISTINCT FROM OLD.version
+       OR NEW.definition   IS DISTINCT FROM OLD.definition
+       OR NEW.on_publish   IS DISTINCT FROM OLD.on_publish
+       OR NEW.published_by IS DISTINCT FROM OLD.published_by
+       OR NEW.published_at IS DISTINCT FROM OLD.published_at THEN
+        RAISE EXCEPTION 'crm_workflow_version rows are immutable — publish writes a new version, never edits one';
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER crm_workflow_version_immutable_guard
+    BEFORE UPDATE ON crm_workflow_version
+    FOR EACH ROW EXECUTE FUNCTION crm_workflow_version_immutable();
+
+-- Backfill 1: every plan with a published document gets its current
+-- version row, so the pin resolves for runs entered under it. Older
+-- versions were overwritten in place by 057 and cannot be recovered.
+INSERT INTO crm_workflow_version (merchant_id, workflow_id, version, definition)
+SELECT merchant_id, id, version, definition
+  FROM crm_workflow
+ WHERE definition IS NOT NULL;
+
+-- Backfill 2: open runs entered under an OLDER, unrecoverable version are
+-- re-pinned to the current one. That is exactly what they execute today
+-- (057: the live document), so nothing changes for them — and when the
+-- walker starts honouring the pin (phase 12) none of them parks on a
+-- version that no longer exists.
+UPDATE crm_workflow_enrollment e
+   SET workflow_version = w.version
+  FROM crm_workflow w
+ WHERE w.merchant_id = e.merchant_id
+   AND w.id = e.workflow_id
+   AND w.definition IS NOT NULL
+   AND e.status <> 'exited'
+   AND e.workflow_version <> w.version;

--- a/docs/crm/migrations.md
+++ b/docs/crm/migrations.md
@@ -67,8 +67,9 @@ Rules the template encodes:
   templates, crm_message; record → crm_event_raw; outreach →
   segments/workflows/broadcasts — note the P2 outreach table must be
   `crm_campaign` to avoid colliding with buddy's existing `campaign`;
-  planned: `crm_workflow_version`, owner outreach, rollout phase 11 per
-  ADR 0023 — the immutable per-publish document runs are pinned to).
+  `crm_workflow_version` (064, ADR 0023) is outreach's too — the
+  immutable per-publish document runs are pinned to, rows only, never
+  edits; its `on_publish` is a closed enum in a CHECK).
 - Append-only tables (crm_consent_event) additionally REVOKE UPDATE,
   DELETE and add the refusal trigger in the same migration.
 - Partitioned tables (crm_event_raw, crm_message, crm_decision_log)

--- a/scripts/check_crm_boundaries.py
+++ b/scripts/check_crm_boundaries.py
@@ -63,6 +63,7 @@ TABLE_OWNERS = {
     "crm_message": "connectivity",
     "crm_workflow": "outreach",
     "crm_workflow_enrollment": "outreach",
+    "crm_workflow_version": "outreach",
     "crm_connector_installation": "connectivity",
     "crm_channel_binding": "connectivity",
     "crm_channel_template": "connectivity",

--- a/tests/crm/test_workflow_plans.py
+++ b/tests/crm/test_workflow_plans.py
@@ -106,28 +106,44 @@ def test_cooldown_cannot_be_negative() -> None:
     assert problems and "shape invalid" in problems[0]
 
 
-def test_occupied_node_deletion_fails() -> None:
-    """The stranding law: a document that removes a square waiting tokens
-    stand on must not publish."""
-    problems = validate_definition(_definition(), occupied_nodes=["old-node"])
+def test_occupied_node_deletion_fails_in_migrate_mode() -> None:
+    """The stranding law, now a migrate-mode precondition (ADR 0023): a
+    document that removes a square waiting tokens stand on must not be
+    migrated onto them."""
+    problems = validate_definition(
+        _definition(on_publish="migrate"), occupied_nodes=["old-node"]
+    )
     assert any("waiting runs standing on it" in p for p in problems)
+
+
+def test_occupied_node_deletion_is_fine_under_pin() -> None:
+    """pin (the default): runs in flight keep their version, so a new
+    document cannot strand anyone — the refusal does not apply."""
+    assert validate_definition(_definition(), occupied_nodes=["old-node"]) == []
+    assert (
+        validate_definition(_definition(on_publish="pin"), occupied_nodes=["old-node"])
+        == []
+    )
 
 
 def test_occupied_node_kept_passes() -> None:
     assert validate_definition(_definition(), occupied_nodes=["wait-30m"]) == []
 
 
-def test_publish_refuses_an_entry_change_while_runs_are_open() -> None:
+def test_publish_refuses_an_entry_change_while_runs_are_open_in_migrate_mode() -> None:
     draft = {
         "entry": {"topic": "cart.abandoned"},
         "nodes": [{"id": "w", "type": "wait", "minutes": 30}],
         "edges": [],
         "goal": {"topics": ["order.placed"]},
+        "on_publish": "migrate",
     }
     live_entry = {"topic": "checkout.initiated"}
     assert validate_definition(draft, occupied_nodes=["w"], live_entry=live_entry)
     assert not validate_definition(draft, occupied_nodes=[], live_entry=live_entry)
     assert not validate_definition(draft, occupied_nodes=["w"], live_entry=None)
+    pinned = {**draft, "on_publish": "pin"}
+    assert not validate_definition(pinned, occupied_nodes=["w"], live_entry=live_entry)
 
 
 _COD = {
@@ -207,11 +223,13 @@ def test_entry_key_is_document_vocabulary() -> None:
     assert problems and "shape invalid" in problems[0]
 
 
-def test_changing_entry_key_mid_flight_is_blocked() -> None:
+def test_changing_entry_key_mid_flight_is_blocked_in_migrate_mode() -> None:
     live_entry = {"topic": "checkout.initiated", "reenter": True, "cooldown_hours": 0}
     keyed = {**live_entry, "key": "order_id"}
     problems = validate_definition(
-        _definition(entry=keyed), occupied_nodes=["wait-30m"], live_entry=live_entry
+        _definition(entry=keyed, on_publish="migrate"),
+        occupied_nodes=["wait-30m"],
+        live_entry=live_entry,
     )
     assert any("entry rule changed" in p for p in problems)
 
@@ -238,13 +256,14 @@ def test_publish_compares_the_live_entry_by_meaning_not_spelling() -> None:
     that omits the defaults compared unequal to a live entry that spelled
     them out (or the reverse) — a spurious "entry rule changed" refusal on
     a re-publish that changed nothing about admission."""
+    migrating = {**_TERSE_DRAFT, "on_publish": "migrate"}
     assert (
         validate_definition(
-            _TERSE_DRAFT, occupied_nodes=["w"], live_entry=_SPELLED_OUT_ENTRY
+            migrating, occupied_nodes=["w"], live_entry=_SPELLED_OUT_ENTRY
         )
         == []
     )
-    explicit = {**_TERSE_DRAFT, "entry": _SPELLED_OUT_ENTRY}
+    explicit = {**migrating, "entry": _SPELLED_OUT_ENTRY}
     assert (
         validate_definition(
             explicit, occupied_nodes=["w"], live_entry={"topic": "checkout.initiated"}
@@ -257,7 +276,9 @@ def test_a_live_entry_that_no_longer_parses_is_compared_raw() -> None:
     """A legacy row whose entry fails today's shape cannot be normalised;
     the raw dicts are compared as before, so a real change is still caught."""
     problems = validate_definition(
-        _TERSE_DRAFT, occupied_nodes=["w"], live_entry={"topic": ""}
+        {**_TERSE_DRAFT, "on_publish": "migrate"},
+        occupied_nodes=["w"],
+        live_entry={"topic": ""},
     )
     assert any("entry rule changed" in p for p in problems)
 
@@ -403,6 +424,12 @@ class _PublishAccessor:
         self.published = True
         return _workflow("live", self.draft)
 
+    async def insert_version(self, conn: Any, *args: Any) -> None:
+        return None  # phase 11's row; pinned by test_workflow_versions.py
+
+    async def repin_open_runs(self, conn: Any, *args: Any) -> int:
+        return 0
+
 
 def _registry(
     monkeypatch: pytest.MonkeyPatch, status: Optional[str], registers: bool = True
@@ -421,7 +448,7 @@ def _registry(
 
 
 async def _publish(accessor: _PublishAccessor) -> Workflow:
-    return await plans._publish_in_txn(cast(DbTxn, object()), "m1", "wf-1")
+    return await plans._publish_in_txn(cast(DbTxn, object()), "m1", "wf-1", None)
 
 
 @pytest.mark.asyncio

--- a/tests/crm/test_workflow_repeat.py
+++ b/tests/crm/test_workflow_repeat.py
@@ -152,9 +152,12 @@ def test_debounce_needs_a_wait_as_the_first_node() -> None:
 
 
 def test_changing_repeat_words_mid_flight_is_blocked_by_the_entry_guard() -> None:
+    """In migrate mode (ADR 0023): under pin the open runs keep their own
+    entry words and the guard does not apply."""
     live = _raw()["entry"]
+    migrating = {**_raw(on_repeat="refresh_latest"), "on_publish": "migrate"}
     problems = validate_definition(
-        _raw(on_repeat="refresh_latest"), occupied_nodes=["wait_10m"], live_entry=live
+        migrating, occupied_nodes=["wait_10m"], live_entry=live
     )
     assert any("entry rule changed" in p for p in problems)
 

--- a/tests/crm/test_workflow_versions.py
+++ b/tests/crm/test_workflow_versions.py
@@ -1,0 +1,219 @@
+"""Version storage + the on_publish word (rollout phase 11, ADR 0023).
+
+Publish writes an immutable crm_workflow_version row; a plan declares
+on_publish: pin (default — new entrants take vN+1, runs in flight finish
+vN) or migrate (every open run is re-pinned inside the publish atom, and
+only when the stranding validator passes — today's semantics as a mode).
+Nothing reads the pin yet (phase 12); this phase makes the rows exist."""
+
+import json
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional, Tuple, cast
+from uuid import uuid4
+
+import pytest
+
+import app.crm.outreach.api as outreach_api
+import app.crm.outreach.plans as plans
+from app.crm.outreach.db import DbTxn
+from app.crm.outreach.db.queries import (
+    get_definition_query,
+    insert_version_query,
+    repin_open_runs_query,
+)
+from app.crm.outreach.plans import validate_definition
+from app.crm.outreach.schemas import Workflow, WorkflowDefinition
+from scripts.check_crm_boundaries import TABLE_OWNERS
+
+NOW = datetime(2026, 9, 3, 12, 0, tzinfo=timezone.utc)
+
+_PLAN: Dict[str, Any] = {
+    "entry": {"topic": "checkout.initiated", "reenter": True, "cooldown_hours": 0},
+    "nodes": [{"id": "wait-30m", "type": "wait", "minutes": 30}],
+    "edges": [],
+    "goal": {"topics": ["order.placed"]},
+}
+
+
+# --- the word ---
+
+
+def test_on_publish_defaults_to_pin_and_is_closed_vocabulary() -> None:
+    assert WorkflowDefinition.model_validate(_PLAN).on_publish == "pin"
+    assert (
+        WorkflowDefinition.model_validate({**_PLAN, "on_publish": "migrate"}).on_publish
+        == "migrate"
+    )
+    problems = validate_definition({**_PLAN, "on_publish": "rollback"})
+    assert problems and "shape invalid" in problems[0]
+
+
+# --- the table's owner ---
+
+
+def test_the_version_table_has_an_owner() -> None:
+    assert TABLE_OWNERS["crm_workflow_version"] == "outreach"
+
+
+# --- the builders ---
+
+
+def test_insert_version_is_merchant_first_and_immutable_by_shape() -> None:
+    sql, params = insert_version_query(
+        "m1", "wf-1", 3, {"entry": {"topic": "t"}}, "pin", "ops@x"
+    )
+    assert "INSERT INTO crm_workflow_version" in sql
+    assert (
+        "(merchant_id, workflow_id, version, definition, on_publish, published_by)"
+        in sql
+    )
+    assert (
+        "$4::jsonb" in sql and "ON CONFLICT" not in sql
+    )  # a duplicate version is a bug, not a merge
+    assert params[0] == "m1" and params[2] == 3
+    assert json.loads(params[3]) == {"entry": {"topic": "t"}}
+    assert params[4:] == ["pin", "ops@x"]
+
+
+def test_repin_moves_only_open_runs_of_this_plan() -> None:
+    sql, params = repin_open_runs_query("m1", "wf-1", 4)
+    assert "SET workflow_version = $3" in sql
+    assert "merchant_id = $1 AND workflow_id = $2" in sql
+    assert "status <> 'exited'" in sql and "RETURNING id" in sql
+    assert params == ["m1", "wf-1", 4]
+
+
+def test_get_definition_reads_one_pinned_document() -> None:
+    sql, params = get_definition_query("m1", "wf-1", 2)
+    assert "FROM crm_workflow_version" in sql
+    assert "merchant_id = $1 AND workflow_id = $2 AND version = $3" in sql
+    assert params == ["m1", "wf-1", 2]
+
+
+# --- the publish atom writes the row, and re-pins only for migrate ---
+
+
+def _workflow(draft: Dict[str, Any], definition: Optional[Dict[str, Any]]) -> Workflow:
+    return Workflow(
+        id=uuid4(),
+        merchant_id="m1",
+        name="plan",
+        status="live" if definition else "draft",
+        version=1 if definition else 0,
+        created_by=None,
+        created_at=NOW,
+        updated_at=NOW,
+        definition=definition,
+        draft=draft,
+    )
+
+
+class _PublishAccessor:
+    def __init__(self, draft: Dict[str, Any], occupied: List[str]) -> None:
+        self.draft = draft
+        self.occupied = occupied
+        self.versions: List[Tuple[Any, ...]] = []
+        self.repins: List[Tuple[Any, ...]] = []
+
+    async def workflow_for_publish(self, conn: Any, m: str, w: str) -> Workflow:
+        return _workflow(self.draft, _PLAN)
+
+    async def occupied_nodes(self, conn: Any, m: str, w: str) -> List[str]:
+        return self.occupied
+
+    async def apply_publish(self, conn: Any, m: str, w: str) -> Workflow:
+        published = _workflow({}, self.draft)
+        published.version = 2
+        return published
+
+    async def insert_version(self, conn: Any, *args: Any) -> None:
+        self.versions.append(args)
+
+    async def repin_open_runs(self, conn: Any, *args: Any) -> int:
+        self.repins.append(args)
+        return 3
+
+
+async def _publish(
+    monkeypatch: pytest.MonkeyPatch, draft: Dict[str, Any], occupied: List[str]
+) -> _PublishAccessor:
+    accessor = _PublishAccessor(draft, occupied)
+    monkeypatch.setattr(plans, "accessor", accessor)
+
+    async def no_templates(
+        merchant_id: str, definition: WorkflowDefinition
+    ) -> List[str]:
+        return []
+
+    monkeypatch.setattr(plans, "_template_problems", no_templates)
+    await plans._publish_in_txn(cast(DbTxn, object()), "m1", "wf-1", "ops@x")
+    return accessor
+
+
+@pytest.mark.asyncio
+async def test_a_pinned_publish_writes_the_version_row_and_touches_no_run(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    draft = {**_PLAN, "nodes": [{"id": "wait-1h", "type": "wait", "minutes": 60}]}
+    accessor = await _publish(
+        monkeypatch, draft, occupied=["wait-30m"]
+    )  # a removed node — fine under pin
+    ((merchant, workflow_id, version, definition, on_publish, published_by),) = (
+        accessor.versions
+    )
+    assert (merchant, workflow_id, version, on_publish, published_by) == (
+        "m1",
+        "wf-1",
+        2,
+        "pin",
+        "ops@x",
+    )
+    assert definition == draft
+    assert accessor.repins == []
+
+
+@pytest.mark.asyncio
+async def test_a_migrating_publish_repins_every_open_run_in_the_same_atom(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    draft = {**_PLAN, "on_publish": "migrate"}
+    accessor = await _publish(monkeypatch, draft, occupied=["wait-30m"])
+    assert accessor.versions[0][4] == "migrate"
+    assert accessor.repins == [("m1", "wf-1", 2)]
+
+
+@pytest.mark.asyncio
+async def test_a_migrating_publish_that_would_strand_is_refused_before_any_write(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    draft = {
+        **_PLAN,
+        "on_publish": "migrate",
+        "nodes": [{"id": "wait-1h", "type": "wait", "minutes": 60}],
+    }
+    accessor = _PublishAccessor(draft, occupied=["wait-30m"])
+    monkeypatch.setattr(plans, "accessor", accessor)
+    with pytest.raises(plans.WorkflowValidationError) as refused:
+        await plans._publish_in_txn(cast(DbTxn, object()), "m1", "wf-1", None)
+    assert any("waiting runs standing on it" in p for p in refused.value.problems)
+    assert accessor.versions == [] and accessor.repins == []
+
+
+@pytest.mark.asyncio
+async def test_the_publish_route_threads_the_publisher(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    seen: List[Tuple[Any, ...]] = []
+
+    async def publish_workflow(
+        merchant_id: str, workflow_id: str, published_by: Optional[str] = None
+    ) -> Workflow:
+        seen.append((merchant_id, workflow_id, published_by))
+        return _workflow({}, _PLAN)
+
+    monkeypatch.setattr(plans, "publish_workflow", publish_workflow)
+    user = cast(Any, type("U", (), {"email": "ops@x"})())
+    await outreach_api.publish_workflow_route(
+        "wf-1", merchant_id="m1", current_user=user
+    )
+    assert seen == [("m1", "wf-1", "ops@x")]


### PR DESCRIPTION
**Rollout phase 11** — `docs/crm/workflow-rollout/11-version-storage-and-on-publish.md`, implementing **ADR 0023** (`docs/crm/adr/0023-version-pinning.md`, signed off in #1067; the phase file's "0022" is the corpus's never-words record). **Carries migration 064.** Storage and the word only: nothing reads the pin yet (phase 12), so behaviour is unchanged except that every publish now leaves a version row.

## What changed

| Piece | Change |
|---|---|
| **Migration 064** `crm_workflow_version` | `(merchant_id, workflow_id, version, definition, on_publish CHECK (pin\|migrate), published_by, published_at)`; tenant-pinned FK to `crm_workflow`; unique `(merchant_id, workflow_id, version)`; immutability trigger (the 051 pattern) — a version row is never edited. `TABLE_OWNERS` and `docs/crm/migrations.md` name it (outreach). |
| **Backfill 1** | every plan with a published document gets its current version row, so runs entered under it resolve. |
| **Backfill 2** (a judgment call, see below) | open runs entered under an **older** version are re-pinned to the current one. 057 overwrote old versions in place, so they cannot be recovered — and those runs execute the live document today anyway, so nothing changes for them; without this, phase 12 would park every one of them on a missing version. |
| **The word** | `WorkflowDefinition.on_publish: Literal["pin", "migrate"] = "pin"`. |
| **Validator** | the two stranding refusals (occupied node removed, entry changed while runs are open) apply in **migrate** mode only: under pin the new version cannot strand anyone. The messages now suggest `on_publish: pin` as the third way out. |
| **Publish atom** | after validate and the template check: `apply_publish` (unchanged) → `insert_version(version, the published document, on_publish, published_by)` → for migrate, `repin_open_runs` (`UPDATE … SET workflow_version = $3 … AND status <> 'exited'`). One atom: `ATOMIC: the copy, the version row and the re-pin share the publish's fate`. |
| **Publisher** | the publish route threads `current_user.email` into `published_by`. |
| **Read for phase 12** | `accessor.get_definition(merchant, workflow_id, version) -> Optional[Dict]` (self-scoped single statement). Unused here. |

## Migration verified on a scratch database

057 → 058 → 063, seeded with a live plan at v3, a definition-less draft, two open runs on v2 and an exited run on v1, then 064: exactly one version row is backfilled (v3, pin); the two open runs are re-pinned to v3 and the exited run keeps v1; an UPDATE of a definition is refused by the trigger; an unknown `on_publish`, a duplicate version and a version for an unknown plan are each refused; a real publish's row (v4, migrate, ops@x) is accepted. Transcript in the comment below. `check_migrations.py --base origin/release` clean; 064 is the next free number.

## Red tests (fail on `release`, pass here)

`tests/crm/test_workflow_versions.py` (new, 9): the word's default and closed vocabulary; the table's owner; the three builders; a pinned publish writes the row and touches no run; a migrating publish re-pins in the same atom; a migrating publish that would strand is refused before any write; the route threads the publisher.

`tests/crm/test_workflow_plans.py` / `test_workflow_repeat.py`: the tests that pinned the stranding refusals now declare `on_publish: migrate` (they still assert the refusal there); new pin counterparts assert the refusals are skipped, and these are **red on release**.

## Checks (unpiped before push)

`black` · `isort` · `autoflake` · `pyrefly check` (0 errors) · `pytest tests/crm` (**602 passed** = 592 on release + 10 new) · `check_crm_boundaries.py` (clean, incl. rule 6 for the new table) · `check_migrations.py --base origin/release` (clean). One commit.

## Decisions already made — disagreements

None. `pin` default; migrate opt-in and validator-gated; version rows immutable.

## Judgment calls, stated so you can overrule

- **Backfill 2 (re-pin open runs to the current version).** The phase lists only backfill 1. Without backfill 2, any run that entered under an earlier version and is still open when phase 12 lands would park as "definition vN missing", because 057 never kept those documents. Re-pinning them to the current version records exactly what they execute today. One statement, only non-exited rows, only where the version differs.
- **Backfill rows carry no `published_by`** (the column is nullable): 057 never recorded a publisher, so none is invented.

## Not done on purpose

- The walker still reads `crm_workflow.definition` (phase 12). The consumer still evaluates everything against the latest version (phase 13). No retention, no migrate-forward, no template guard (phase 14).

## Adjacent observations, left alone

- Phase 00's `apply_repeat` patches the run standing on `nodes[0]` of the **latest** definition; under pin that node may differ from the run's own version's first node. Phase 13 scopes repeats to the run's version, per its file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014UNZ4z7zb87HnNHjTXoFpW
