### PR TITLE
feat(crm): the walker executes the version a run entered under (rollout 12)

### DIFF
--- a/app/crm/outreach/walker.py
+++ b/app/crm/outreach/walker.py
@@ -1,8 +1,16 @@
 """The walker (W3) — the clock that moves tokens. NOT an engine (canon:
-"wake_at + the live document IS the engine"): claim due runs off the
-partial index, read the plan LIVE, execute the current node, write the
-next alarm. Correctness rides the wake_at lease + idempotent writes,
-never worker uniqueness — scale is replicas.
+"wake_at + the document IS the engine"): claim due runs off the partial
+index, read the plan the run ENTERED UNDER, execute the current node,
+write the next alarm. Correctness rides the wake_at lease + idempotent
+writes, never worker uniqueness — scale is replicas.
+
+Which document (ADR 0023, rollout phase 12): the run's own pin —
+crm_workflow_enrollment.workflow_version names the crm_workflow_version
+row it executes, so a run finishes on the version it entered under while
+new entrants take the newest; `on_publish: migrate` re-pins open runs
+inside the publish atom instead. The live row is still read, for its
+STATUS only (archived ejects, paused snoozes); its definition column is
+never what a run executes.
 
 The node vocabulary — what each square does when the token lands, and
 whether landing means waiting — lives in nodes.py (NODE_TYPES); the walker
@@ -14,6 +22,7 @@ goal-cancel is the fast path; this is the belt-and-suspenders.
 """
 
 import random
+from collections import OrderedDict
 from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -36,6 +45,17 @@ _MAX_STEPS_PER_VISIT = 10
 # Transient-failure retry: exponential from the lease, capped, ±20% jitter
 # (canon T20: "backoff with jitter written into wake_at").
 _RETRY_CAP_SECONDS = 3600
+
+# The pinned documents this process has already read, by (workflow_id,
+# version). A version row is immutable (064's trigger refuses every
+# UPDATE; phase 14's sweep deletes only versions no run references), so a
+# cached document is true for as long as the process lives: the cache
+# never invalidates, it only evicts — least recently used first, once it
+# holds more than the bound. Sized for one merchant fleet's live versions
+# many times over; §14.7's cost of pinning is otherwise one indexed point
+# read per claim.
+_DEFINITION_CACHE_SIZE = 512
+_definitions: OrderedDict[Tuple[str, int], WorkflowDefinition] = OrderedDict()
 
 
 def retry_delay_seconds(attempts: int, base: int) -> int:
@@ -79,9 +99,9 @@ async def walk_run(run: EnrollmentRun) -> None:
             if not await accessor.exit_run(str(run.id), "ejected", lease):
                 _deferred(run, "eject")
             return
-        if workflow.status == "paused" or not workflow.definition:
+        if workflow.status == "paused":
             return  # the lease push IS the snooze; re-checked next wake
-        definition = WorkflowDefinition.model_validate(workflow.definition)
+        definition = await _definition_for(run)
         await _advance(run, definition, lease)
     except NodeParked as e:
         if await accessor.park_run(str(run.id), str(e), lease):
@@ -100,6 +120,27 @@ async def walk_run(run: EnrollmentRun) -> None:
                 logger.warning(f"walker: run {run.id} retries in {retry_in}s — {e}")
             else:
                 _deferred(run, "retry")
+
+
+async def _definition_for(run: EnrollmentRun) -> WorkflowDefinition:
+    """The document this run executes: its pin, by (workflow, version),
+    from the cache or one point read. No such version row is an honest
+    park — never a fallback to the live document, which would execute a
+    plan the run did not enter under (phase 14's retention must keep
+    every version an open run references, so this is drift, not life)."""
+    key = (str(run.workflow_id), run.workflow_version)
+    cached = _definitions.get(key)
+    if cached is not None:
+        _definitions.move_to_end(key)
+        return cached
+    document = await accessor.get_definition(run.merchant_id, key[0], key[1])
+    if document is None:
+        raise NodeParked(f"definition v{run.workflow_version} missing")
+    definition = WorkflowDefinition.model_validate(document)
+    _definitions[key] = definition
+    while len(_definitions) > _DEFINITION_CACHE_SIZE:
+        _definitions.popitem(last=False)
+    return definition
 
 
 def _deferred(run: EnrollmentRun, write: str) -> None:
@@ -152,9 +193,12 @@ async def _advance(
     for _ in range(_MAX_STEPS_PER_VISIT):
         node = nodes.get(current_id)
         if node is None:
-            # The publish validator forbids stranding, so this is drift
-            # (e.g. a run parked across an archive/re-create) — honest park.
-            raise NodeParked(f"node {current_id} not in live definition")
+            # A pinned version never loses a node under a run (pin), and
+            # the migrate validator forbids stranding — so this is drift
+            # (e.g. a run parked across an archive/re-create): honest park.
+            raise NodeParked(
+                f"node {current_id} not in definition v{run.workflow_version}"
+            )
 
         execute = NODE_TYPES[node.type].execute
         if execute is not None:  # a wait's action IS the alarm

--- a/docs/crm/runbooks/cart-recovery.md
+++ b/docs/crm/runbooks/cart-recovery.md
@@ -74,8 +74,14 @@ curl -sS -X POST "$BASE/workflows/<wf>/status?merchant_id=$M" -H "$H" -H "$J" \
 ```
 
 Publishing again later: put the new document in `draft`, then `publish`.
-While runs are open the validator refuses removing a node they stand on
-and changing the `entry` words; pause the plan and let them finish, or
+**Runs finish on the version they entered under** (ADR 0023): a publish
+makes version N+1 for new checkouts, and every run already in flight
+keeps executing the version N it started on — the walker reads each
+run's pinned document, never the live one. To reach the runs in flight
+too (a template name fixed, a delay shortened), declare
+`"on_publish": "migrate"` in the document: then the publish re-pins every
+open run to N+1, and the validator refuses removing a node they stand on
+or changing the `entry` words — pause the plan and let them finish, or
 publish the change as a new plan.
 
 ## Watch it run
@@ -102,7 +108,8 @@ wait for a human; `last_error` says why:
 | `… no phone in run context` | the checkout had no phone we could read (email-only checkout); nothing to fix — archive or ignore |
 | `call node …: template … not found` / `no call_execution_config` | replace the placeholder / configure the buddy template |
 | `send node …: <reason>` | the channel/address was refused at queue time (bad number) |
-| `node X not in live definition` | drift across an archive/re-create; re-publish with the node or archive the plan |
+| `node X not in definition vN` | drift across an archive/re-create; re-publish with the node or archive the plan |
+| `definition vN missing` | the run's pinned version row is gone (should never happen — versions a run references are retained); archive the plan or re-create it |
 | `attempts exhausted: …` | a transient error kept failing (provider, DB); check the cause |
 
 ```bash

--- a/docs/crm/runbooks/loan-dropoff.md
+++ b/docs/crm/runbooks/loan-dropoff.md
@@ -70,9 +70,12 @@ Order does not matter — each clock only listens for its own stage topic.
   `POST /workflows/<wf>/status {"status": "paused"}` — its open runs
   snooze (the walker skips them) and no new runs start; `live` resumes.
 - **Change a stage's timing or template:** put the new document in
-  `draft`, `publish`. Clocks are empty most of the time (runs live ~30
-  minutes), so the stranding guard rarely bites; if it does, pause, wait
-  half an hour, publish.
+  `draft`, `publish`. Runs finish on the version they entered under (ADR
+  0023): the ~30-minute runs already open keep the old timing and the new
+  ones take the new document, so nothing is stranded and nothing needs
+  pausing. Declare `"on_publish": "migrate"` only when the change must
+  reach the open runs too — then the stranding guard applies (pause, wait
+  half an hour, publish).
 - **Parked runs:** `GET /workflows/<wf>/runs?merchant_id=$M&status=parked`.
   Almost always `no phone in run context` (the lender omitted the
   number) or a call template problem — fix, then

--- a/tests/crm/test_workflow_walker.py
+++ b/tests/crm/test_workflow_walker.py
@@ -64,9 +64,18 @@ class _Writes:
     """The accessor slice the walker writes through. ``matched`` is the
     CAS answer every write returns; ``calls`` records what was asked."""
 
-    def __init__(self, matched: bool, definition: Dict[str, Any]) -> None:
+    def __init__(
+        self,
+        matched: bool,
+        definition: Dict[str, Any],
+        versions: Optional[Dict[int, Dict[str, Any]]] = None,
+    ) -> None:
         self.matched = matched
         self.definition = definition
+        # The version rows (phase 12): what get_definition answers by pin.
+        # Default: the live document IS v1, the version _run() enters under.
+        self.versions = versions if versions is not None else {1: definition}
+        self.definition_reads: List[Tuple[str, str, int]] = []
         self.calls: List[Tuple[str, Tuple[Any, ...]]] = []
 
     async def get_workflow(self, merchant_id: str, workflow_id: str) -> Workflow:
@@ -82,6 +91,12 @@ class _Writes:
             definition=self.definition,
             draft=None,
         )
+
+    async def get_definition(
+        self, merchant_id: str, workflow_id: str, version: int
+    ) -> Optional[Dict[str, Any]]:
+        self.definition_reads.append((merchant_id, workflow_id, version))
+        return self.versions.get(version)
 
     async def advance_run(self, *args: Any) -> bool:
         self.calls.append(("advance", args))
@@ -279,3 +294,100 @@ def test_walk_run_never_writes_without_a_lease(
     monkeypatch.setattr(walker, "accessor", writes)
     asyncio.run(walker.walk_run(_run(wake_at=None)))
     assert writes.calls == []
+
+
+# --- rollout phase 12: the walker executes the version a run entered under ---
+
+# v3: wait-30m -> wait-1d (the document above). v4 re-routes the second
+# square: a run standing on wait-30m must go where ITS version says.
+_V3 = _TWO_WAITS
+_V4 = {
+    **_TWO_WAITS,
+    "nodes": [
+        {"id": "wait-30m", "type": "wait", "minutes": 30},
+        {"id": "wait-2h", "type": "wait", "minutes": 120},
+    ],
+    "edges": [["wait-30m", "wait-2h"]],
+}
+
+
+def _pinned_run(version: int) -> EnrollmentRun:
+    run = _run()
+    run.workflow_version = version
+    return run
+
+
+@pytest.fixture
+def cold_cache() -> None:
+    """The definition cache is process-wide and never invalidates
+    (versions are immutable) — each test starts it empty."""
+    walker._definitions.clear()
+
+
+def test_the_walker_executes_the_version_the_run_entered_under(
+    monkeypatch: pytest.MonkeyPatch, no_goal: None, cold_cache: None
+) -> None:
+    """The live row already carries v4 (wait-30m -> wait-2h); the run
+    entered under v3 (wait-30m -> wait-1d) and finishes on v3. The pin is
+    read by (merchant, workflow, version), never from crm_workflow."""
+    writes = _Writes(matched=True, definition=_V4, versions={3: _V3, 4: _V4})
+    monkeypatch.setattr(walker, "accessor", writes)
+    run = _pinned_run(3)
+    asyncio.run(walker.walk_run(run))
+    ((verb, args),) = writes.calls
+    assert verb == "advance" and args[1] == "wait-1d"
+    assert writes.definition_reads == [("m1", str(run.workflow_id), 3)]
+
+
+def test_a_missing_version_parks_the_run_honestly(
+    monkeypatch: pytest.MonkeyPatch, no_goal: None, cold_cache: None
+) -> None:
+    """No version row for the pin: an honest park under the lease, never
+    a silent fallback to the live document (which would execute a plan
+    the run did not enter under)."""
+    writes = _Writes(matched=True, definition=_V4, versions={4: _V4})
+    monkeypatch.setattr(walker, "accessor", writes)
+    run = _pinned_run(3)
+    asyncio.run(walker.walk_run(run))
+    ((verb, args),) = writes.calls
+    assert verb == "park"
+    assert args[0] == str(run.id) and args[-1] == LEASE
+    assert "definition v3 missing" in args[1]
+
+
+def test_a_pinned_version_is_read_once_per_process(
+    monkeypatch: pytest.MonkeyPatch, no_goal: None, cold_cache: None
+) -> None:
+    """Versions are immutable (064's trigger), so the second claim of any
+    run on the same (workflow, version) is served from the walker's cache
+    without a read."""
+    writes = _Writes(matched=True, definition=_V3, versions={3: _V3})
+    monkeypatch.setattr(walker, "accessor", writes)
+    first = _pinned_run(3)
+    second = _pinned_run(3)
+    second.workflow_id = first.workflow_id
+    asyncio.run(walker.walk_run(first))
+    asyncio.run(walker.walk_run(second))
+    assert [verb for verb, _ in writes.calls] == ["advance", "advance"]
+    assert len(writes.definition_reads) == 1
+
+
+def test_the_cache_is_bounded_and_evicts_the_least_recently_used(
+    monkeypatch: pytest.MonkeyPatch, cold_cache: None
+) -> None:
+    monkeypatch.setattr(walker, "_DEFINITION_CACHE_SIZE", 2)
+    writes = _Writes(matched=True, definition=_V3, versions={1: _V3, 2: _V3, 3: _V3})
+    monkeypatch.setattr(walker, "accessor", writes)
+    runs = [_pinned_run(version) for version in (1, 2, 3)]
+    for run in runs[1:]:
+        run.workflow_id = runs[0].workflow_id
+
+    async def read_in_order() -> None:
+        await walker._definition_for(runs[0])  # v1: miss
+        await walker._definition_for(runs[1])  # v2: miss
+        await walker._definition_for(runs[0])  # v1: hit, now most recent
+        await walker._definition_for(runs[2])  # v3: miss, evicts v2
+        await walker._definition_for(runs[1])  # v2: miss again
+
+    asyncio.run(read_in_order())
+    assert [version for _, _, version in writes.definition_reads] == [1, 2, 3, 2]


### PR DESCRIPTION
## Rollout phase 12 — `docs/crm/workflow-rollout/12-walker-pinned-definition.md`

Depends on 11 (#1068, merged). ADR 0023 (`docs/crm/adr/0023-version-pinning.md`). This is the **first behaviour change** of the pinning series: from this PR on, a run executes the document version it entered under, not the live one.

### What changed

| File | Change |
|---|---|
| `app/crm/outreach/walker.py` | `walk_run` still reads the live row for **status** (archived → eject, paused → snooze) but takes the definition from `_definition_for(run)` → `accessor.get_definition(merchant, workflow_id, run.workflow_version)`. `None` → `NodeParked("definition vN missing")` — an honest park under the lease, never a fallback to the live document. In-process LRU cache keyed `(workflow_id, version)`, `OrderedDict`, bound 512, no new dependency; versions are immutable (064 trigger) so it never invalidates, only evicts. The drift park now reads `node X not in definition vN`. Module docstring updated (canon's "read the plan LIVE" is no longer what the walker does). |
| `tests/crm/test_workflow_walker.py` | `_Writes` gains `get_definition` (answers from a `versions` dict, records reads). Four new tests, all red on release. |
| `docs/crm/runbooks/cart-recovery.md`, `loan-dropoff.md` | "Runs finish on the version they entered under"; when to declare `on_publish: migrate`; the two new park reasons in the triage table. |

No migration in this phase (064 already ships the table and the backfill that pins every open run).

### Red tests (fail on release, pass here)

- `test_the_walker_executes_the_version_the_run_entered_under` — the live row carries v4 (`wait-30m → wait-2h`), the run is pinned to v3 (`wait-30m → wait-1d`): the walker advances to `wait-1d` and the only definition read is `("m1", workflow_id, 3)`.
- `test_a_missing_version_parks_the_run_honestly` — no v3 row → `park_run(run, "definition v3 missing", lease)`, nothing else written.
- `test_a_pinned_version_is_read_once_per_process` — two claims on the same `(workflow, version)` → two advances, one accessor read.
- `test_the_cache_is_bounded_and_evicts_the_least_recently_used` — bound 2, reads 1,2,1,3,2 → accessor hit for 1,2,3,2 (the touched v1 survives, v2 is evicted).

On release all four error (`module 'app.crm.outreach.walker' has no attribute '_definitions'`); without the cache fixture the first two would still fail on the node/verb assertions.

### Checks (strictly `&&`-chained, pytest to a log)

black, isort, autoflake clean · pyrefly 0 errors · **`pytest tests/crm`: 606 passed** (602 on release + 4) · `check_crm_boundaries.py` clean · `check_migrations.py --base origin/release`: 64 migrations, no duplicates, no gaps.

### Decisions already made that I disagree with

None.

### Judgment calls (overrule if you want)

- **Dropped the `or not workflow.definition` snooze.** Under pinning a run executes its version row regardless of the live column; and post-B4 a live plan cannot have an empty definition anyway. A missing *version* row parks (visible), rather than snoozing silently forever.
- **The cache stores the parsed `WorkflowDefinition`, not the raw dict**, so a claim costs neither the read nor the Pydantic validation. `_advance` and the node executors only read the definition (checked: `nodes.py` touches `purpose_key` only), so sharing one instance across visits is safe.
- **Cache key is `(workflow_id, version)` as the phase file says**, without `merchant_id`. The first read is merchant-scoped by the query; a workflow id is a uuid PK and a run's workflow_id comes from a merchant-scoped read at enrol, so a cross-tenant hit is not constructible.
- **Cache lives in `walker.py`** as phase 12 says; phase 13 moves it to `outreach/definitions.py` when the entry consumer needs it too.

### Not done on purpose

- Goals and `wait_event` listening per open run's version (phase 13). `apply_repeat` still uses the latest definition's `nodes[0]` (phase 13 too).
- Retention / migrate-forward / retirement guard (phase 14).

### Adjacent observations (not touched)

- `docs/crm/plans/README.md` still says `on_publish` is "not in the documents yet, on purpose — phase 11's word; the cart board will declare `migrate` then". Phase 11 landed the word but neither plan document declares it, so `cart-recovery.json` now runs under the default `pin`: a template-name fix no longer reaches waiting cart runs unless the board declares `migrate`. Worth a one-line docs/plan PR; not phase 12's scope.
- Still pending from earlier phases: the context notes describe routes as `/crm/...` (they mount at app root, ADR 0022), and phase files 10/11 say "ADR 0022" (it is 0023).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014UNZ4z7zb87HnNHjTXoFpW


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Workflow runs now continue using the version active when they started, while new runs use the latest published version.
  - Publishing can optionally migrate open runs to the new version with `"on_publish": "migrate"`.

- **Bug Fixes**
  - Runs with missing or incompatible workflow versions are parked with clearer error details.

- **Documentation**
  - Updated recovery and loan runbooks explain versioned execution, publishing, migration, and safeguards against stranding active runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->