### PR TITLE
feat(crm): entries match the latest version; goals and listening match each open run's version (rollout 13)

### DIFF
--- a/app/crm/outreach/db/accessor.py
+++ b/app/crm/outreach/db/accessor.py
@@ -23,7 +23,7 @@ from app.crm.outreach.db.decoder import (
 from app.crm.outreach.db.queries import (
     admission_facts_query,
     advance_run_query,
-    cancel_open_runs_query,
+    cancel_run_query,
     claim_due_runs_query,
     customer_runs_query,
     exit_run_query,
@@ -36,12 +36,13 @@ from app.crm.outreach.db.queries import (
     list_workflows_query,
     live_workflows_query,
     occupied_nodes_query,
+    open_runs_for_customer_query,
     park_run_query,
     patch_open_run_query,
     publish_workflow_query,
     record_run_error_query,
     repin_open_runs_query,
-    resume_run_on_event_query,
+    resume_run_by_id_query,
     resume_run_query,
     set_workflow_status_query,
     source_event_used_query,
@@ -294,18 +295,42 @@ async def record_run_error(
     return row is not None
 
 
-async def resume_run_on_event(
+async def open_runs_for_customer(
+    merchant_id: str, customer_id: str
+) -> List[EnrollmentRun]:
+    query, values = open_runs_for_customer_query(merchant_id, customer_id)
+    async with crm_connection() as conn:
+        rows = await conn.fetch(query, *values)
+    return [decode_run(row) for row in rows]
+
+
+async def resume_run_by_id(
+    merchant_id: str, run_id: str, node_id: str, context_patch: Dict[str, Any]
+) -> bool:
+    """True when the run was standing on the listening square and took
+    the answer."""
+    query, values = resume_run_by_id_query(merchant_id, run_id, node_id, context_patch)
+    async with crm_connection() as conn:
+        row = await conn.fetchrow(query, *values)
+    return row is not None
+
+
+async def cancel_run(
     merchant_id: str,
-    workflow_id: str,
-    customer_id: str,
-    node_id: str,
-    context_patch: Dict[str, Any],
-) -> None:
-    query, values = resume_run_on_event_query(
-        merchant_id, workflow_id, customer_id, node_id, context_patch
+    run_id: str,
+    exit_reason: str,
+    occurred_at: Optional[datetime] = None,
+    key: Optional[Tuple[str, str]] = None,
+    context_patch: Optional[Dict[str, Any]] = None,
+) -> bool:
+    """True when the run was open (and, keyed, still the one the letter
+    is about) and ended."""
+    query, values = cancel_run_query(
+        merchant_id, run_id, exit_reason, occurred_at, key, context_patch
     )
     async with crm_connection() as conn:
-        await conn.execute(query, *values)
+        row = await conn.fetchrow(query, *values)
+    return row is not None
 
 
 async def patch_open_run(
@@ -336,29 +361,6 @@ async def patch_open_run(
     async with crm_connection() as conn:
         row = await conn.fetchrow(query, *values)
     return row is not None
-
-
-async def cancel_open_runs(
-    merchant_id: str,
-    workflow_id: str,
-    customer_id: str,
-    exit_reason: str,
-    occurred_at: Optional[datetime] = None,
-    key: Optional[Tuple[str, str]] = None,
-    context_patch: Optional[Dict[str, Any]] = None,
-) -> int:
-    query, values = cancel_open_runs_query(
-        merchant_id,
-        workflow_id,
-        customer_id,
-        exit_reason,
-        occurred_at,
-        key,
-        context_patch,
-    )
-    async with crm_connection() as conn:
-        rows = await conn.fetch(query, *values)
-    return len(rows)
 
 
 async def list_runs(

--- a/app/crm/outreach/db/queries.py
+++ b/app/crm/outreach/db/queries.py
@@ -335,7 +335,7 @@ def exit_run_query(
     at-least-once redelivery enrol a second run from a stale checkout.
 
     The lease is the generation: a write under a stale lease is a no-op
-    (P1). The event side's exit is cancel_open_runs_query, unconditional."""
+    (P1). The event side's exit is cancel_run_query, unconditional."""
     query = f"""
         UPDATE {ENROLLMENT_TABLE}
         SET status = 'exited', exit_reason = $2, exited_at = now(),
@@ -387,30 +387,94 @@ def record_run_error_query(
     return query, [run_id, last_error, retry_in_seconds, leased_wake_at]
 
 
-def resume_run_on_event_query(
-    merchant_id: str,
-    workflow_id: str,
-    customer_id: str,
-    node_id: str,
-    context_patch: Dict[str, Any],
+def open_runs_for_customer_query(
+    merchant_id: str, customer_id: str
 ) -> Tuple[str, List[Any]]:
-    """W5: the reply reaches the token. Only a run still standing on the
-    listening square is touched — a late or repeated reply changes
-    nothing. The answer is recorded on the run BEFORE anything fires
-    (canon T20), and wake_at = now() hands it to the walker."""
+    """The consumer's per-run read (rollout phase 13): this customer's
+    open runs across every plan, so goals and listening are judged
+    against each run's PINNED version. The customer index carries it; a
+    customer with nothing open costs one empty indexed read."""
+    query = f"""
+        SELECT {_RUN_COLUMNS}
+        FROM {ENROLLMENT_TABLE}
+        WHERE merchant_id = $1 AND customer_id = $2 AND status <> 'exited'
+        ORDER BY entered_at, id
+    """
+    return query, [merchant_id, customer_id]
+
+
+def resume_run_by_id_query(
+    merchant_id: str, run_id: str, node_id: str, context_patch: Dict[str, Any]
+) -> Tuple[str, List[Any]]:
+    """W5: the reply reaches the token — by run id (phase 13), because
+    the listening square is the RUN'S version's, and a sibling run on
+    another version must never be woken by a square it does not have.
+    Only a run still standing on that square is touched — a late or
+    repeated reply changes nothing. The answer is recorded on the run
+    BEFORE anything fires (canon T20), and wake_at = now() hands it to
+    the walker. Event-side: unconditional (the walker's writes defer to
+    it, phase 03)."""
     query = f"""
         UPDATE {ENROLLMENT_TABLE}
-        SET context = context || $5::jsonb, wake_at = now(), last_error = NULL
-        WHERE merchant_id = $1 AND workflow_id = $2 AND customer_id = $3
-          AND status = 'waiting' AND current_node = $4
+        SET context = context || $4::jsonb, wake_at = now(), last_error = NULL
+        WHERE merchant_id = $1 AND id = $2
+          AND status = 'waiting' AND current_node = $3
+        RETURNING id
     """
-    return query, [
-        merchant_id,
-        workflow_id,
-        customer_id,
-        node_id,
-        json.dumps(context_patch),
-    ]
+    return query, [merchant_id, run_id, node_id, json.dumps(context_patch)]
+
+
+def cancel_run_query(
+    merchant_id: str,
+    run_id: str,
+    exit_reason: str,
+    occurred_at: Optional[datetime] = None,
+    key: Optional[Tuple[str, str]] = None,
+    context_patch: Optional[Dict[str, Any]] = None,
+) -> Tuple[str, List[Any]]:
+    """Goal-cancel, by run id (phase 13): the tier that matched is the
+    RUN'S version's, so the write names the run — a v3 goal never touches
+    a sibling run on v5. Open is waiting or parked (canon: the goal event
+    resolves OPEN enrolments; a parked run she has already satisfied must
+    not keep holding the open-run unique). Event-side: unconditional (the
+    walker's writes defer to it, phase 03).
+
+    Time-aware on the ENTRY EVENT (G7, phase 06): only a run whose
+    founding letter happened before the goal event ends — its context
+    carries that moment (entered_event_at), with the row's insert time as
+    the fallback for runs written before the stamp — so a late-delivered
+    earlier-stage letter cannot keep a run alive past a goal that truly
+    happened after it, and a stale goal redelivered later cannot end a
+    newer run. An unstamped goal (occurred_at NULL) ends the run.
+
+    Keyed (phase 06): ``key = (run field, value)`` re-asserts in the
+    statement what the consumer judged from the row it read — the run is
+    still the one the letter is about.
+
+    ``context_patch`` (phase 09) rides the same UPDATE — context ||
+    $n::jsonb — so the run remembers which letter ended it and what it
+    was worth (context.goal), for the summary's recovered revenue. Its
+    placeholder follows the optional key."""
+    params: List[Any] = [merchant_id, run_id, exit_reason, occurred_at]
+    keyed = ""
+    if key:
+        keyed = "AND context->>$5 = $6"
+        params.extend([key[0], key[1]])
+    patched = ""
+    if context_patch is not None:
+        patched = f", context = context || ${len(params) + 1}::jsonb"
+        params.append(json.dumps(context_patch))
+    query = f"""
+        UPDATE {ENROLLMENT_TABLE}
+        SET status = 'exited', exit_reason = $3, exited_at = now(),
+            wake_at = NULL{patched}
+        WHERE merchant_id = $1 AND id = $2
+          AND status <> 'exited'
+          AND ($4::timestamptz IS NULL OR COALESCE((context->>'entered_event_at')::timestamptz, entered_at) < $4::timestamptz)
+          {keyed}
+        RETURNING id
+    """
+    return query, params
 
 
 def patch_open_run_query(
@@ -426,7 +490,7 @@ def patch_open_run_query(
     debounce_minutes: float,
 ) -> Tuple[str, List[Any]]:
     """Repeat entries (modules/05 §Repeat entries): ONE idempotent UPDATE
-    in the resume_run_on_event shape. Touches only a run still standing on
+    in the reply's shape (resume_run_by_id_query). Touches only a run still standing on
     its first square (status waiting, current_node = the entry node) — a
     run past it is never patched. Found by enrollment_key so a keyed plan's
     order edit patches ITS order's run. The event marks itself used in
@@ -493,66 +557,6 @@ def patch_open_run_query(
         max_value,
         debounce_minutes,
     ]
-
-
-def cancel_open_runs_query(
-    merchant_id: str,
-    workflow_id: str,
-    customer_id: str,
-    exit_reason: str,
-    occurred_at: Optional[datetime] = None,
-    key: Optional[Tuple[str, str]] = None,
-    context_patch: Optional[Dict[str, Any]] = None,
-) -> Tuple[str, List[Any]]:
-    """Goal-cancel (canon: the goal event resolves OPEN enrolments — open
-    is waiting or parked; a parked run she has already satisfied must not
-    keep holding the open-run unique) — and the same shape ejects runs
-    when a flow is archived. Event-side: unconditional (the walker's
-    writes defer to it, phase 03).
-
-    Time-aware on the ENTRY EVENT (G7, phase 06): only runs whose
-    founding letter happened before the goal event count — the run's
-    context carries that moment (entered_event_at), with the row's
-    insert time as the fallback for runs written before the stamp — so a
-    late-delivered earlier-stage letter cannot keep a run alive past a
-    goal that truly happened after it, and a stale goal redelivered
-    later cannot end a newer run. An unstamped goal (occurred_at NULL)
-    keeps today's behaviour and ends every open run.
-
-    Keyed (phase 06): ``key = (run field, value)`` ends only the run the
-    letter is about (context cart_token = the order's cart_token); the
-    unkeyed form is byte-identical to before.
-
-    ``context_patch`` (phase 09) rides the same UPDATE — context ||
-    $n::jsonb — so the run remembers which letter ended it and what it
-    was worth (context.goal), for the summary's recovered revenue. Its
-    placeholder follows the optional key."""
-    params: List[Any] = [
-        merchant_id,
-        workflow_id,
-        customer_id,
-        exit_reason,
-        occurred_at,
-    ]
-    keyed = ""
-    if key:
-        keyed = "AND context->>$6 = $7"
-        params.extend([key[0], key[1]])
-    patched = ""
-    if context_patch is not None:
-        patched = f", context = context || ${len(params) + 1}::jsonb"
-        params.append(json.dumps(context_patch))
-    query = f"""
-        UPDATE {ENROLLMENT_TABLE}
-        SET status = 'exited', exit_reason = $4, exited_at = now(),
-            wake_at = NULL{patched}
-        WHERE merchant_id = $1 AND workflow_id = $2 AND customer_id = $3
-          AND status <> 'exited'
-          AND ($5::timestamptz IS NULL OR COALESCE((context->>'entered_event_at')::timestamptz, entered_at) < $5::timestamptz)
-          {keyed}
-        RETURNING id
-    """
-    return query, params
 
 
 def list_runs_query(

--- a/app/crm/outreach/definitions.py
+++ b/app/crm/outreach/definitions.py
@@ -1,0 +1,48 @@
+"""Which document a run executes (ADR 0023) — ONE answer for the two
+readers that need it: the walker (rollout phase 12) and the entry
+consumer's per-run pass (phase 13).
+
+A run's pin — crm_workflow_enrollment.workflow_version — names the
+crm_workflow_version row it executes. Rows there are immutable (064's
+trigger refuses every UPDATE; phase 14's sweep deletes only versions no
+run references), so a document read once is true for as long as the
+process lives: the cache below never invalidates, it only evicts — least
+recently used first, past the bound. A migrate publish re-pins open runs
+by changing the run's version NUMBER, so the next read of that run lands
+on a different key with nothing to invalidate.
+
+Logic, not db: the only db-world import is the module's accessor door.
+"""
+
+from collections import OrderedDict
+from typing import Optional, Tuple
+
+from app.crm.outreach.db import accessor
+from app.crm.outreach.schemas import EnrollmentRun, WorkflowDefinition
+
+# Sized for one merchant fleet's live versions many times over; §14.7's
+# cost of pinning is otherwise one indexed point read per claim or event.
+_DEFINITION_CACHE_SIZE = 512
+_definitions: OrderedDict[Tuple[str, int], WorkflowDefinition] = OrderedDict()
+
+
+async def definition_for(run: EnrollmentRun) -> Optional[WorkflowDefinition]:
+    """The document this run executes: its pin, by (workflow, version),
+    from the cache or one indexed point read. None when no such version
+    row exists — the caller says what that means (the walker parks the
+    run honestly; the consumer leaves it for the walker), never a
+    fallback to the live document, which would judge a run by a plan it
+    did not enter under."""
+    key = (str(run.workflow_id), run.workflow_version)
+    cached = _definitions.get(key)
+    if cached is not None:
+        _definitions.move_to_end(key)
+        return cached
+    document = await accessor.get_definition(run.merchant_id, key[0], key[1])
+    if document is None:
+        return None
+    definition = WorkflowDefinition.model_validate(document)
+    _definitions[key] = definition
+    while len(_definitions) > _DEFINITION_CACHE_SIZE:
+        _definitions.popitem(last=False)
+    return definition

--- a/app/crm/outreach/entry.py
+++ b/app/crm/outreach/entry.py
@@ -1,8 +1,17 @@
 """The entry-rules consumer (W4 + W5) — outreach's subscription on the
-event spine: an attributed event whose topic matches a LIVE plan's entry
-starts a run (enrol()); one matching a plan's goal ends open runs
-(goal-cancel); one a wait_event node listens for wakes the run standing
-on that node with the answer written in its context (W5).
+event spine. One consumer, two reads (ADR 0023 §4; the sentence in
+docs/crm/workflow-rollout/context/reading-notes.md §15.3):
+
+  1. HER OPEN RUNS, each judged by the version it entered under
+     (definitions.py): a goal tier of THAT document ends the run
+     (goal-cancel); a wait_event square of THAT document wakes it with
+     the answer written in its context (W5). A v3 run is ended by v3's
+     goals and woken by v3's listening even after v5 changed them, and
+     every write names the run it is about. A migrate plan is the
+     degenerate case — every open run pinned to the latest — same path,
+     no branch.
+  2. THE LIVE PLANS, latest document: an entry match starts a run
+     (enrol()) — a new run always begins on the newest version.
 
 A consumer is a function, not a loop (worker-runtime.md): the event
 worker's pass calls consume_attributed_event() per row, inside that row's
@@ -12,14 +21,19 @@ stays pending and returns next poll. Our writes commit on their own
 source-event check and the open-run unique — not by that rollback.
 """
 
-from typing import List, Optional, Tuple
+from typing import Optional, Sequence, Tuple
 
 from app.core.logger import logger
 from app.crm.outreach.db import accessor
+from app.crm.outreach.definitions import definition_for
 from app.crm.outreach.enrol import enrol
 from app.crm.outreach.nodes import _BOOKKEEPING_KEYS, _BOOKKEEPING_PREFIXES
 from app.crm.outreach.repeat import _as_number, apply_repeat
-from app.crm.outreach.schemas import Workflow, WorkflowDefinition, WorkflowNode
+from app.crm.outreach.schemas import (
+    EnrollmentRun,
+    Workflow,
+    WorkflowDefinition,
+)
 from app.crm.record.contracts import RawEvent
 from app.crm.shared.normalize import normalize_phone
 
@@ -66,9 +80,15 @@ def _phone_from_payload(payload: dict) -> str | None:
 async def consume_attributed_event(
     event: RawEvent, customer_id: str, handles: Optional[dict] = None
 ) -> None:
-    """Match one just-attributed event against every live plan's entry and
-    goal topics. customer_id arrives separately: the row object still
-    carries the pre-stamp value.
+    """Match one just-attributed event against her open runs (each by its
+    own version) and every live plan's entry (latest). customer_id
+    arrives separately: the row object still carries the pre-stamp
+    value.
+
+    Order: every open run first — its goal, then its reply — and entries
+    last. An order arriving right behind its checkout must not cancel the
+    run that checkout is about to start; and a run a goal just ended is
+    not woken by the same letter.
 
     ``handles`` is what the source's extractor already found. Taking it
     rather than re-reading the payload keeps ONE source-aware discovery in
@@ -76,54 +96,76 @@ async def consume_attributed_event(
     resolved on, so suppression matches by construction and a new source
     needs no teaching here. The payload search stays as the fallback for
     the voice mirrors, which resolve before this consumer exists."""
+    open_runs = await accessor.open_runs_for_customer(event.merchant_id, customer_id)
+    goal_patch = _goal_patch(event) if open_runs else None
+    for run in open_runs:
+        definition = await definition_for(run)
+        if definition is None:
+            # No version row for the pin: nothing honest can be judged for
+            # this run here; the walker parks it at its next claim.
+            logger.warning(
+                f"run {run.id}: definition v{run.workflow_version} missing — "
+                f"goals and listening not judged (event {event.id})"
+            )
+            continue
+        if await _end_on_goal(run, definition, event, goal_patch):
+            continue  # exited: there is nothing left to wake
+        await _wake_on_reply(run, definition, event)
+
     flows = await accessor.live_workflows(event.merchant_id)
-    entry_matches: List[Tuple[Workflow, WorkflowDefinition]] = []
-    goal_matches: List[Tuple[Workflow, WorkflowDefinition]] = []
-    listening: List[Tuple[Workflow, WorkflowNode]] = []
     for flow in flows:
         definition = WorkflowDefinition.model_validate(flow.definition)
         if definition.entry.topic == event.topic and _where_matches(
             definition.entry.where, event.payload
         ):
-            entry_matches.append((flow, definition))
-        if definition.goal_tiers(event.topic):
-            goal_matches.append((flow, definition))
-        for node in definition.nodes:
-            if node.type == "wait_event" and event.topic in node.topics:
-                listening.append((flow, node))
+            await _try_enrol(flow, definition, event, customer_id, handles, open_runs)
 
-    # Goal first: an order arriving right behind its checkout must not
-    # cancel the run that checkout is about to start. Then replies, then
-    # entries. Time-aware on the entry event: only runs whose founding
-    # letter happened before the goal event end (G7) — a stale goal
-    # redelivered by the spine cannot end a run born after it.
-    #
-    # Tiers are judged keyed-first (goal_tiers): the keyed tier ends the
-    # run the letter is ABOUT (context cart_token = payload cart_token) as
-    # goal_met; the unkeyed tier then sweeps whatever is still open as
-    # converted_elsewhere — the recovered run is already exited, so the
-    # UPDATE's status <> 'exited' keeps the two verdicts apart. A keyed
-    # tier whose payload field is missing cannot say which run it is
-    # about and is skipped; the unkeyed tier still applies.
-    goal_patch = _goal_patch(event) if goal_matches else None
-    for flow, definition in goal_matches:
-        for tier in definition.goal_tiers(event.topic):
-            key: Optional[Tuple[str, str]] = None
-            if tier.key:
-                value = event.payload.get(tier.key.event)
-                if value in (None, ""):
-                    continue
-                key = (tier.key.run, str(value))
-            await accessor.cancel_open_runs(
-                event.merchant_id,
-                str(flow.id),
-                customer_id,
-                tier.exit_reason,
-                event.occurred_at,
-                key,
-                goal_patch,
-            )
-    for flow, node in listening:
+
+async def _end_on_goal(
+    run: EnrollmentRun,
+    definition: WorkflowDefinition,
+    event: RawEvent,
+    goal_patch: Optional[dict],
+) -> bool:
+    """Judge this run against ITS document's goal tiers, keyed-first
+    (goal_tiers, phase 06): "THIS cart recovered" (goal_met) beats "she
+    bought something" (converted_elsewhere), and the first tier that ends
+    the run is its verdict — no second tier sweeps an exited run. A keyed
+    tier whose payload field is missing cannot say which run it is about
+    and is skipped; one naming another run of hers is not this run's.
+    Time-aware on the founding letter (G7) in the statement. Returns True
+    when the run ended."""
+    for tier in definition.goal_tiers(event.topic):
+        key: Optional[Tuple[str, str]] = None
+        if tier.key:
+            value = event.payload.get(tier.key.event)
+            if value in (None, ""):
+                continue
+            if str(run.context.get(tier.key.run, "")) != str(value):
+                continue  # about another run of hers
+            key = (tier.key.run, str(value))
+        if await accessor.cancel_run(
+            run.merchant_id,
+            str(run.id),
+            tier.exit_reason,
+            event.occurred_at,
+            key,
+            goal_patch,
+        ):
+            return True
+    return False
+
+
+async def _wake_on_reply(
+    run: EnrollmentRun, definition: WorkflowDefinition, event: RawEvent
+) -> None:
+    """A wait_event square of ITS document listening on this topic wakes
+    the run with the answer — the statement decides whether the token is
+    standing there (a reply to a square it has left, or not yet reached,
+    changes nothing)."""
+    for node in definition.nodes:
+        if node.type != "wait_event" or event.topic not in node.topics:
+            continue
         answer = event.payload.get(node.key or "")
         if answer is None:
             # B1 (rollout phase 01): no key, no answer to branch on. Waking
@@ -134,18 +176,12 @@ async def consume_attributed_event(
             # may time it out.
             logger.info(
                 f"wait_event reply ignored: key {node.key!r} missing "
-                f"(workflow {flow.id}, event {event.id})"
+                f"(run {run.id}, event {event.id})"
             )
             continue
-        await accessor.resume_run_on_event(
-            event.merchant_id,
-            str(flow.id),
-            customer_id,
-            node.id,
-            {reply_key(node.id): str(answer)},
+        await accessor.resume_run_by_id(
+            run.merchant_id, str(run.id), node.id, {reply_key(node.id): str(answer)}
         )
-    for flow, definition in entry_matches:
-        await _try_enrol(flow, definition, event, customer_id, handles)
 
 
 # Where an order's amount lives in a payload, most specific first —
@@ -206,6 +242,7 @@ async def _try_enrol(
     event: RawEvent,
     customer_id: str,
     handles: Optional[dict] = None,
+    open_runs: Sequence[EnrollmentRun] = (),
 ) -> None:
     admit, enrollment_key = _enrollment_key(definition, event, str(flow.id))
     if not admit:
@@ -227,23 +264,49 @@ async def _try_enrol(
     )
     if run is None:
         # Refused — most often because a run for this key is already open.
-        # The plan's repeat words decide what that open run does with the
-        # repeat (repeat.py); the UPDATE's WHERE makes every other refusal
-        # a no-op, so no second signal from enrol() is needed. The repeat
-        # is offered the SAME small facts enrol() was — the normalized
-        # phone included, so a corrected number reaches the run — minus
-        # the founding pointers (_FOUNDING_KEYS): the id is what
-        # patch_open_run_query refuses the founding event by, the time is
-        # what goals are measured from.
+        # THAT run's repeat words decide what it does with the repeat
+        # (repeat.py; its own version's, phase 13); the UPDATE's WHERE
+        # makes every other refusal a no-op, so no second signal from
+        # enrol() is needed. The repeat is offered the SAME small facts
+        # enrol() was — the normalized phone included, so a corrected
+        # number reaches the run — minus the founding pointers
+        # (_FOUNDING_KEYS): the id is what patch_open_run_query refuses
+        # the founding event by, the time is what goals are measured from.
+        key = enrollment_key or customer_id
         repeat_facts = {k: v for k, v in context.items() if k not in _FOUNDING_KEYS}
         await apply_repeat(
             event.merchant_id,
             str(flow.id),
-            enrollment_key or customer_id,
-            definition,
+            key,
+            await _repeat_definition(open_runs, flow, key, definition),
             str(event.id),
             repeat_facts,
         )
+
+
+async def _repeat_definition(
+    open_runs: Sequence[EnrollmentRun],
+    flow: Workflow,
+    enrollment_key: str,
+    latest: WorkflowDefinition,
+) -> WorkflowDefinition:
+    """The repeat's words are the OPEN RUN'S version's: its on_repeat and
+    debounce, and its first square's id — v5 may have renamed the entry
+    node, and the patch's `current_node = entry node` guard would then
+    never find a v3 run. The run was read at the top of this pass; when
+    it is not among her open runs (a keyed run that resolved to another
+    customer, or a sibling tick opened it after the read) the latest
+    document stands in — exactly the pre-pinning behaviour."""
+    for run in open_runs:
+        if (
+            str(run.workflow_id) == str(flow.id)
+            and run.enrollment_key == enrollment_key
+        ):
+            pinned = await definition_for(run)
+            if pinned is not None:
+                return pinned
+            break
+    return latest
 
 
 def _enrollment_key(

--- a/app/crm/outreach/repeat.py
+++ b/app/crm/outreach/repeat.py
@@ -18,13 +18,16 @@ and at 10:19 she gets ONE message, about the biggest cart, after she has
 actually gone quiet.
 
 Mechanics: gather (the repeat's small facts) -> decide (PURE: what to write)
--> apply (ONE idempotent UPDATE, the resume_run_on_event shape):
+-> apply (ONE idempotent UPDATE, the reply's shape):
 `WHERE status='waiting' AND current_node = <entry node>` — a run past its
 first square is NEVER patched; what it already said was true when it said
 it. Each event marks itself used (context.repeat_event_ids), so the spine's
 at-least-once redelivery cannot slide the alarm twice for one event. The
 row is found by enrollment_key, not customer_id: with entry.key an order
-edit must patch ITS order's run, never a sibling's.
+edit must patch ITS order's run, never a sibling's. The words judged are
+the OPEN RUN'S version's (phase 13): the consumer hands over the pinned
+definition of the run it found, so a v3 run keeps v3's on_repeat and its
+first square's id even after v5 renamed both.
 
 Plan vocabulary, never walker behaviour: WISMO (keyed) and transactional
 flows leave on_repeat at ignore and debounce at 0.

--- a/app/crm/outreach/walker.py
+++ b/app/crm/outreach/walker.py
@@ -6,11 +6,12 @@ writes, never worker uniqueness — scale is replicas.
 
 Which document (ADR 0023, rollout phase 12): the run's own pin —
 crm_workflow_enrollment.workflow_version names the crm_workflow_version
-row it executes, so a run finishes on the version it entered under while
-new entrants take the newest; `on_publish: migrate` re-pins open runs
-inside the publish atom instead. The live row is still read, for its
-STATUS only (archived ejects, paused snoozes); its definition column is
-never what a run executes.
+row it executes (definitions.py resolves and caches it), so a run
+finishes on the version it entered under while new entrants take the
+newest; `on_publish: migrate` re-pins open runs inside the publish atom
+instead. The live row is still read, for its STATUS only (archived
+ejects, paused snoozes); its definition column is never what a run
+executes.
 
 The node vocabulary — what each square does when the token lands, and
 whether landing means waiting — lives in nodes.py (NODE_TYPES); the walker
@@ -22,7 +23,6 @@ goal-cancel is the fast path; this is the belt-and-suspenders.
 """
 
 import random
-from collections import OrderedDict
 from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -32,6 +32,7 @@ from app.core.config.static import (
 )
 from app.core.logger import logger
 from app.crm.outreach.db import accessor
+from app.crm.outreach.definitions import definition_for
 from app.crm.outreach.entry import reply_key
 from app.crm.outreach.nodes import NODE_TYPES, NodeParked, is_wait
 from app.crm.outreach.plans import TIMEOUT
@@ -45,17 +46,6 @@ _MAX_STEPS_PER_VISIT = 10
 # Transient-failure retry: exponential from the lease, capped, ±20% jitter
 # (canon T20: "backoff with jitter written into wake_at").
 _RETRY_CAP_SECONDS = 3600
-
-# The pinned documents this process has already read, by (workflow_id,
-# version). A version row is immutable (064's trigger refuses every
-# UPDATE; phase 14's sweep deletes only versions no run references), so a
-# cached document is true for as long as the process lives: the cache
-# never invalidates, it only evicts — least recently used first, once it
-# holds more than the bound. Sized for one merchant fleet's live versions
-# many times over; §14.7's cost of pinning is otherwise one indexed point
-# read per claim.
-_DEFINITION_CACHE_SIZE = 512
-_definitions: OrderedDict[Tuple[str, int], WorkflowDefinition] = OrderedDict()
 
 
 def retry_delay_seconds(attempts: int, base: int) -> int:
@@ -101,7 +91,13 @@ async def walk_run(run: EnrollmentRun) -> None:
             return
         if workflow.status == "paused":
             return  # the lease push IS the snooze; re-checked next wake
-        definition = await _definition_for(run)
+        definition = await definition_for(run)
+        if definition is None:
+            # No version row for the pin: an honest park — never a fallback
+            # to the live document, which would execute a plan the run did
+            # not enter under (phase 14's retention keeps every version an
+            # open run references, so this is drift, not life).
+            raise NodeParked(f"definition v{run.workflow_version} missing")
         await _advance(run, definition, lease)
     except NodeParked as e:
         if await accessor.park_run(str(run.id), str(e), lease):
@@ -120,27 +116,6 @@ async def walk_run(run: EnrollmentRun) -> None:
                 logger.warning(f"walker: run {run.id} retries in {retry_in}s — {e}")
             else:
                 _deferred(run, "retry")
-
-
-async def _definition_for(run: EnrollmentRun) -> WorkflowDefinition:
-    """The document this run executes: its pin, by (workflow, version),
-    from the cache or one point read. No such version row is an honest
-    park — never a fallback to the live document, which would execute a
-    plan the run did not enter under (phase 14's retention must keep
-    every version an open run references, so this is drift, not life)."""
-    key = (str(run.workflow_id), run.workflow_version)
-    cached = _definitions.get(key)
-    if cached is not None:
-        _definitions.move_to_end(key)
-        return cached
-    document = await accessor.get_definition(run.merchant_id, key[0], key[1])
-    if document is None:
-        raise NodeParked(f"definition v{run.workflow_version} missing")
-    definition = WorkflowDefinition.model_validate(document)
-    _definitions[key] = definition
-    while len(_definitions) > _DEFINITION_CACHE_SIZE:
-        _definitions.popitem(last=False)
-    return definition
 
 
 def _deferred(run: EnrollmentRun, write: str) -> None:

--- a/tests/crm/test_worker_runtime.py
+++ b/tests/crm/test_worker_runtime.py
@@ -5,15 +5,16 @@ goal before entry, unmatched topics ignored, and a failure that propagates
 
 import asyncio
 import uuid
-from datetime import datetime, timezone
-from typing import Any, List
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, List, Optional
 
 import pytest
 
+import app.crm.outreach.definitions as definitions
 import app.crm.outreach.entry as entry
 import app.crm.outreach.workers as outreach_workers
 from app.crm.outreach.nodes import send_variables
-from app.crm.outreach.schemas import Workflow, WorkflowDefinition
+from app.crm.outreach.schemas import EnrollmentRun, Workflow, WorkflowDefinition
 from app.crm.outreach.walker import pick_next
 from app.crm.record.contracts import RawEvent
 from app.crm.worker_main import ROLES
@@ -87,27 +88,75 @@ def _event(topic: str, merchant_id: str = "m1") -> RawEvent:
     )
 
 
-def _wire(monkeypatch: pytest.MonkeyPatch, flow: Workflow, calls: List[Any]) -> None:
+def _open_run(flow: Workflow) -> EnrollmentRun:
+    """One open run of hers on the plan's first square, pinned to the
+    version the live row carries (phase 13: goals and listening are judged
+    per open run, by its own version)."""
+    first_node = (flow.definition or {})["nodes"][0]["id"]
+    return EnrollmentRun(
+        id=uuid.uuid4(),
+        merchant_id=flow.merchant_id,
+        workflow_id=flow.id,
+        workflow_version=flow.version,
+        customer_id=uuid.uuid4(),
+        status="waiting",
+        current_node=first_node,
+        wake_at=NOW + timedelta(minutes=30),
+        entered_at=NOW - timedelta(hours=1),
+        exited_at=None,
+        exit_reason=None,
+        context={"phone": "+919845012345"},
+        enrollment_key="cust-1",
+        attempts=0,
+        last_error=None,
+    )
+
+
+def _wire(
+    monkeypatch: pytest.MonkeyPatch, flow: Workflow, calls: List[Any]
+) -> EnrollmentRun:
+    run = _open_run(flow)
+    definitions._definitions.clear()
+
     async def live_workflows(merchant_id: str) -> List[Workflow]:
         # The read is tenant-scoped in SQL: another merchant sees no plans.
         return [flow] if merchant_id == flow.merchant_id else []
 
-    async def cancel_open_runs(*args: Any) -> int:
+    async def open_runs_for_customer(
+        merchant_id: str, customer_id: str
+    ) -> List[EnrollmentRun]:
+        return [run] if merchant_id == flow.merchant_id else []
+
+    async def get_definition(
+        merchant_id: str, workflow_id: str, version: int
+    ) -> Optional[Dict[str, Any]]:
+        return (
+            flow.definition
+            if (workflow_id, version) == (str(flow.id), flow.version)
+            else None
+        )
+
+    async def cancel_run(*args: Any) -> bool:
         calls.append(("cancel", args))
-        return 1
+        return True
 
-    async def resume_run_on_event(*args: Any) -> None:
+    async def resume_run_by_id(*args: Any) -> bool:
         calls.append(("resume", args))
-
-    monkeypatch.setattr(entry.accessor, "resume_run_on_event", resume_run_on_event)
+        return True
 
     async def fake_enrol(**kwargs: Any) -> object:
         calls.append(("enrol", kwargs))
         return object()
 
     monkeypatch.setattr(entry.accessor, "live_workflows", live_workflows)
-    monkeypatch.setattr(entry.accessor, "cancel_open_runs", cancel_open_runs)
+    monkeypatch.setattr(
+        entry.accessor, "open_runs_for_customer", open_runs_for_customer
+    )
+    monkeypatch.setattr(entry.accessor, "get_definition", get_definition)
+    monkeypatch.setattr(entry.accessor, "cancel_run", cancel_run)
+    monkeypatch.setattr(entry.accessor, "resume_run_by_id", resume_run_by_id)
     monkeypatch.setattr(entry, "enrol", fake_enrol)
+    return run
 
 
 def test_entry_topic_enrols_with_phone_and_small_facts(
@@ -179,10 +228,10 @@ def test_extractor_handles_beat_the_payload_fallback(
 
 def test_goal_topic_cancels_open_runs(monkeypatch: pytest.MonkeyPatch) -> None:
     calls: List[Any] = []
-    _wire(monkeypatch, _flow(), calls)
+    run = _wire(monkeypatch, _flow(), calls)
     asyncio.run(entry.consume_attributed_event(_event("order.placed"), "cust-1"))
-    assert calls[0][0] == "cancel" and calls[0][1][2] == "cust-1"
-    assert calls[0][1][4] == NOW  # the goal's occurred_at bounds the cancel
+    assert calls[0][0] == "cancel" and calls[0][1][1] == str(run.id)
+    assert calls[0][1][3] == NOW  # the goal's occurred_at bounds the cancel
 
 
 def test_goal_runs_before_entry_when_a_topic_is_both(
@@ -270,8 +319,7 @@ def test_reply_wakes_the_run_standing_on_the_listening_node(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     calls: List[Any] = []
-    flow = _cod_flow()
-    _wire(monkeypatch, flow, calls)
+    run = _wire(monkeypatch, _cod_flow(), calls)
     asyncio.run(
         entry.consume_attributed_event(
             _event_with("button.reply", {"button_id": "YES"}), "cust-1"
@@ -279,7 +327,7 @@ def test_reply_wakes_the_run_standing_on_the_listening_node(
     )
     ((kind, args),) = calls
     assert kind == "resume"
-    assert args == ("m1", str(flow.id), "cust-1", "ask", {"reply_ask": "YES"})
+    assert args == ("m1", str(run.id), "ask", {"reply_ask": "YES"})
 
 
 def test_pick_next_takes_the_answer_edge_or_timeout() -> None:

--- a/tests/crm/test_workflow_entry.py
+++ b/tests/crm/test_workflow_entry.py
@@ -1,24 +1,33 @@
-"""The entry-rules consumer's listening path (W5) — rollout phase 01, B1.
+"""The entry-rules consumer — one consumer, two reads (ADR 0023 §4;
+context/reading-notes.md §15.3; rollout phase 13).
 
-A wait_event reply whose payload lacks the node's key must NOT wake the
-run. Written as {reply_<node>: None} with wake_at = now, the walker's
-pick_next read None as "the alarm fired" and took the timeout edge at
-once: any letter on the listened topic without the key ended the
-listening window early and mis-routed. The fix is at the consumer — no
-resume without an answer — while pick_next keeps its alarm semantics,
-pinned here so the two halves cannot drift apart."""
+Read one: HER OPEN RUNS, each judged by the version it entered under —
+a v3 run is ended by v3's goals and woken by v3's wait_event squares even
+after v5 changed them, and every goal-cancel and reply names the run it
+is about, never a sibling on another version. Read two: THE LIVE PLANS,
+latest document — a new run always starts on the newest version.
+
+Carried forward from earlier phases, now per run: B1 (phase 01 — no
+resume without an answer), goal tiers keyed-first with the entry event's
+time (phase 06), the goal stash (phase 09)."""
 
 import asyncio
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, List, Optional, Tuple
-from uuid import uuid4
+from uuid import UUID, uuid4
 
 import pytest
 
+import app.crm.outreach.definitions as definitions
 import app.crm.outreach.entry as entry
 from app.crm.outreach.entry import consume_attributed_event
 from app.crm.outreach.plans import TIMEOUT
-from app.crm.outreach.schemas import Workflow, WorkflowDefinition, WorkflowNode
+from app.crm.outreach.schemas import (
+    EnrollmentRun,
+    Workflow,
+    WorkflowDefinition,
+    WorkflowNode,
+)
 from app.crm.outreach.walker import pick_next
 from app.crm.record.schemas import RawEvent
 
@@ -42,79 +51,6 @@ _LISTENING_PLAN = {
     "goal": {"topics": ["order.confirmed"]},
 }
 
-
-def _flow() -> Workflow:
-    return Workflow(
-        id=uuid4(),
-        merchant_id="m1",
-        name="cod-confirm",
-        status="live",
-        version=1,
-        created_by=None,
-        created_at=NOW,
-        updated_at=NOW,
-        definition=_LISTENING_PLAN,
-        draft=None,
-    )
-
-
-def _reply(payload: Dict[str, Any]) -> RawEvent:
-    return RawEvent(
-        id="ev-1",
-        merchant_id="m1",
-        source="whatsapp",
-        topic="button.reply",
-        schema_version="1",
-        external_id="wamid-1",
-        payload=payload,
-        received_at=NOW,
-        occurred_at=NOW,
-    )
-
-
-@pytest.fixture
-def resumes(monkeypatch: pytest.MonkeyPatch) -> List[Tuple[Any, ...]]:
-    """One live listening plan; every resume the consumer asks for is
-    recorded. Goal-cancel must never be reached (no goal topic matches)."""
-    calls: List[Tuple[Any, ...]] = []
-
-    async def live_workflows(merchant_id: str) -> List[Workflow]:
-        return [_flow()]
-
-    async def resume_run_on_event(*args: Any) -> None:
-        calls.append(args)
-
-    async def cancel_open_runs(*args: Any, **kwargs: Any) -> int:
-        raise AssertionError("a button reply is not a goal event")
-
-    monkeypatch.setattr(entry.accessor, "live_workflows", live_workflows)
-    monkeypatch.setattr(entry.accessor, "resume_run_on_event", resume_run_on_event)
-    monkeypatch.setattr(entry.accessor, "cancel_open_runs", cancel_open_runs)
-    return calls
-
-
-def test_a_reply_carrying_the_key_wakes_the_listening_run(
-    resumes: List[Tuple[Any, ...]],
-) -> None:
-    asyncio.run(consume_attributed_event(_reply({"button_id": "YES"}), "c-1", {}))
-    ((merchant, _workflow_id, customer, node, patch),) = resumes
-    assert (merchant, customer, node) == ("m1", "c-1", "ask")
-    assert patch == {"reply_ask": "YES"}
-
-
-def test_a_reply_without_the_key_never_wakes_the_run(
-    resumes: List[Tuple[Any, ...]],
-) -> None:
-    """B1: with no answer there is nothing to branch on. Resuming with
-    None made the walker take the timeout edge immediately — the listening
-    window ended early on an unrelated letter. The window continues; only
-    the alarm may time it out."""
-    asyncio.run(consume_attributed_event(_reply({"text": "hello"}), "c-1", {}))
-    assert resumes == []
-
-
-# --- rollout phase 06: goal tiers with a key, and the entry event's time ---
-
 _CART_PLAN = {
     "entry": {"topic": "checkouts/update", "reenter": True, "cooldown_hours": 0},
     "nodes": [{"id": "wait-30m", "type": "wait", "minutes": 30}],
@@ -130,101 +66,386 @@ _CART_PLAN = {
 }
 
 
-def _order(payload: Dict[str, Any]) -> RawEvent:
+def _flow(definition: Dict[str, Any] = _LISTENING_PLAN, version: int = 1) -> Workflow:
+    return Workflow(
+        id=uuid4(),
+        merchant_id="m1",
+        name="plan",
+        status="live",
+        version=version,
+        created_by=None,
+        created_at=NOW,
+        updated_at=NOW,
+        definition=definition,
+        draft=None,
+    )
+
+
+def _run(
+    flow: Workflow,
+    version: int,
+    node: str,
+    context: Optional[Dict[str, Any]] = None,
+    key: str = "c-1",
+) -> EnrollmentRun:
+    return EnrollmentRun(
+        id=uuid4(),
+        merchant_id="m1",
+        workflow_id=flow.id,
+        workflow_version=version,
+        customer_id=uuid4(),
+        status="waiting",
+        current_node=node,
+        wake_at=NOW + timedelta(minutes=30),
+        entered_at=NOW - timedelta(hours=1),
+        exited_at=None,
+        exit_reason=None,
+        context={"phone": "+919876543210", **(context or {})},
+        enrollment_key=key,
+        attempts=0,
+        last_error=None,
+    )
+
+
+def _event(topic: str, payload: Dict[str, Any], event_id: str = "ev-1") -> RawEvent:
     return RawEvent(
-        id="ev-order",
+        id=event_id,
         merchant_id="m1",
         source="shopify",
-        topic="orders/create",
+        topic=topic,
         schema_version="1",
-        external_id="orders/create:1",
+        external_id=f"{topic}:{event_id}",
         payload=payload,
         received_at=NOW,
         occurred_at=NOW,
     )
 
 
+class _Spine:
+    """The accessor slice the consumer reads and writes through: the live
+    plans, her open runs and the version rows are seeded; every write is
+    recorded by the run it named. A run ends once — a second cancel of
+    the same run answers False, as the UPDATE's status guard would."""
+
+    def __init__(
+        self,
+        flows: List[Workflow],
+        runs: List[EnrollmentRun],
+        versions: Dict[Tuple[UUID, int], Dict[str, Any]],
+    ) -> None:
+        self.flows = flows
+        self.runs = runs
+        self.versions = {(str(wf), v): d for (wf, v), d in versions.items()}
+        self.definition_reads: List[Tuple[str, int]] = []
+        self.cancels: List[Tuple[str, str, Optional[Tuple[str, str]], Any]] = []
+        self.resumes: List[Tuple[str, str, Dict[str, Any]]] = []
+        self.exited: set = set()
+
+    async def live_workflows(self, merchant_id: str) -> List[Workflow]:
+        return list(self.flows)
+
+    async def open_runs_for_customer(
+        self, merchant_id: str, customer_id: str
+    ) -> List[EnrollmentRun]:
+        return list(self.runs)
+
+    async def get_definition(
+        self, merchant_id: str, workflow_id: str, version: int
+    ) -> Optional[Dict[str, Any]]:
+        self.definition_reads.append((workflow_id, version))
+        return self.versions.get((workflow_id, version))
+
+    async def cancel_run(
+        self,
+        merchant_id: str,
+        run_id: str,
+        exit_reason: str,
+        occurred_at: Optional[datetime] = None,
+        key: Optional[Tuple[str, str]] = None,
+        context_patch: Optional[Dict[str, Any]] = None,
+    ) -> bool:
+        self.cancels.append((run_id, exit_reason, key, context_patch))
+        if run_id in self.exited:
+            return False
+        self.exited.add(run_id)
+        return True
+
+    async def resume_run_by_id(
+        self, merchant_id: str, run_id: str, node_id: str, patch: Dict[str, Any]
+    ) -> bool:
+        self.resumes.append((run_id, node_id, patch))
+        return True
+
+
+def _install(monkeypatch: pytest.MonkeyPatch, spine: _Spine) -> None:
+    definitions._definitions.clear()
+    for name in (
+        "live_workflows",
+        "open_runs_for_customer",
+        "get_definition",
+        "cancel_run",
+        "resume_run_by_id",
+    ):
+        monkeypatch.setattr(entry.accessor, name, getattr(spine, name))
+
+
+def _consume(event: RawEvent) -> None:
+    asyncio.run(consume_attributed_event(event, "c-1", {}))
+
+
+# --- phase 01, B1: no resume without an answer ---
+
+
 @pytest.fixture
-def cancels(monkeypatch: pytest.MonkeyPatch) -> List[Tuple[Any, ...]]:
-    calls: List[Tuple[Any, ...]] = []
-
-    async def live_workflows(merchant_id: str) -> List[Workflow]:
-        flow = _flow()
-        flow.definition = _CART_PLAN
-        return [flow]
-
-    async def cancel_open_runs(*args: Any) -> int:
-        calls.append((args[3], args[5] if len(args) > 5 else None))
-        return 1
-
-    async def resume_run_on_event(*args: Any) -> None:
-        raise AssertionError("an order is not a reply")
-
-    monkeypatch.setattr(entry.accessor, "live_workflows", live_workflows)
-    monkeypatch.setattr(entry.accessor, "cancel_open_runs", cancel_open_runs)
-    monkeypatch.setattr(entry.accessor, "resume_run_on_event", resume_run_on_event)
-    return calls
+def listening(monkeypatch: pytest.MonkeyPatch) -> _Spine:
+    flow = _flow()
+    run = _run(flow, 1, "ask")
+    spine = _Spine([flow], [run], {(flow.id, 1): _LISTENING_PLAN})
+    _install(monkeypatch, spine)
+    return spine
 
 
-def test_the_goal_cancel_stashes_the_goal_event_with_its_amount(
-    cancels: List[Tuple[Any, ...]], monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """Phase 09: the run remembers which letter ended it — and how much it
-    was worth, when the payload says so as a number — so the summary can
-    sum recovered revenue without re-reading the spine."""
-    patches: List[Any] = []
-
-    async def cancel_open_runs(*args: Any) -> int:
-        patches.append(args[6] if len(args) > 6 else None)
-        return 1
-
-    monkeypatch.setattr(entry.accessor, "cancel_open_runs", cancel_open_runs)
-    asyncio.run(
-        consume_attributed_event(
-            _order({"cart_token": "chk-1", "total_price": "1850.00"}), "c-1", {}
-        )
-    )
-    assert (
-        patches
-        == [
-            {
-                "goal": {
-                    "topic": "orders/create",
-                    "event_id": "ev-order",
-                    "amount": "1850.00",
-                }
-            }
-        ]
-        * 2
-    )  # both tiers' cancels carry it; only goal_met rows are summed
-    patches.clear()
-    asyncio.run(
-        consume_attributed_event(
-            _order({"cart_token": "chk-1", "total_price": "n/a"}), "c-1", {}
-        )
-    )
-    assert patches[0] == {"goal": {"topic": "orders/create", "event_id": "ev-order"}}
+def test_a_reply_carrying_the_key_wakes_the_listening_run(listening: _Spine) -> None:
+    _consume(_event("button.reply", {"button_id": "YES"}))
+    (run,) = listening.runs
+    assert listening.resumes == [(str(run.id), "ask", {"reply_ask": "YES"})]
+    assert listening.cancels == []  # a button reply is not a goal event
 
 
-def test_an_order_carrying_the_cart_token_is_judged_keyed_first(
-    cancels: List[Tuple[Any, ...]],
-) -> None:
-    """THIS cart recovered -> goal_met on the run keyed to it; any other
-    open run of hers still ends, as converted_elsewhere (never nudge
-    someone who just bought). The keyed tier runs first so the recovered
-    run is already exited when the unkeyed tier sweeps."""
-    asyncio.run(consume_attributed_event(_order({"cart_token": "chk-1"}), "c-1", {}))
-    assert cancels == [
-        ("goal_met", ("cart_token", "chk-1")),
-        ("converted_elsewhere", None),
+def test_a_reply_without_the_key_never_wakes_the_run(listening: _Spine) -> None:
+    """B1: with no answer there is nothing to branch on. Resuming with
+    None made the walker take the timeout edge immediately — the listening
+    window ended early on an unrelated letter. The window continues; only
+    the alarm may time it out."""
+    _consume(_event("button.reply", {"text": "hello"}))
+    assert listening.resumes == []
+
+
+# --- phase 06 + 09: goal tiers keyed-first, per run; the goal stash ---
+
+
+@pytest.fixture
+def carts(monkeypatch: pytest.MonkeyPatch) -> _Spine:
+    """Two open cart runs of hers on one keyed plan: chk-1 and chk-2."""
+    flow = _flow(_CART_PLAN)
+    runs = [
+        _run(flow, 1, "wait-30m", {"cart_token": "chk-1"}, key="chk-1"),
+        _run(flow, 1, "wait-30m", {"cart_token": "chk-2"}, key="chk-2"),
+    ]
+    spine = _Spine([flow], runs, {(flow.id, 1): _CART_PLAN})
+    _install(monkeypatch, spine)
+    return spine
+
+
+def test_an_order_carrying_the_cart_token_is_judged_keyed_first(carts: _Spine) -> None:
+    """THIS cart recovered -> goal_met on the run keyed to it, and that
+    run is ended once (the keyed tier's verdict stands; the unkeyed tier
+    never sweeps it). Any other open run of hers still ends, as
+    converted_elsewhere (never nudge someone who just bought)."""
+    _consume(_event("orders/create", {"cart_token": "chk-1"}))
+    first, second = carts.runs
+    assert [(r, reason, key) for r, reason, key, _ in carts.cancels] == [
+        (str(first.id), "goal_met", ("cart_token", "chk-1")),
+        (str(second.id), "converted_elsewhere", None),
     ]
 
 
-def test_an_order_without_the_key_can_only_end_runs_elsewhere(
-    cancels: List[Tuple[Any, ...]],
+def test_an_order_without_the_key_can_only_end_runs_elsewhere(carts: _Spine) -> None:
+    _consume(_event("orders/create", {"total_price": "1850.00"}))
+    assert [reason for _, reason, _, _ in carts.cancels] == ["converted_elsewhere"] * 2
+
+
+def test_the_goal_cancel_stashes_the_goal_event_with_its_amount(carts: _Spine) -> None:
+    """Phase 09: the run remembers which letter ended it — and how much it
+    was worth, when the payload says so as a number — so the summary can
+    sum recovered revenue without re-reading the spine."""
+    _consume(
+        _event(
+            "orders/create",
+            {"cart_token": "chk-1", "total_price": "1850.00"},
+            "ev-order",
+        )
+    )
+    stash = {
+        "goal": {"topic": "orders/create", "event_id": "ev-order", "amount": "1850.00"}
+    }
+    assert [patch for _, _, _, patch in carts.cancels] == [stash, stash]
+    carts.cancels.clear()
+    _consume(
+        _event(
+            "orders/create", {"cart_token": "chk-1", "total_price": "n/a"}, "ev-order"
+        )
+    )
+    assert carts.cancels[0][3] == {
+        "goal": {"topic": "orders/create", "event_id": "ev-order"}
+    }
+
+
+# --- phase 13: each open run is judged by the version it entered under ---
+
+# One keyed order plan, three versions apart: v3's goal is the payment, v5
+# moved the goal to fulfilment, renamed the listening topic AND the entry
+# topic. Order A entered under v3, order B under v5; both are open.
+_V3 = {
+    "entry": {
+        "topic": "orders/create",
+        "key": "order_id",
+        "on_repeat": "refresh_latest",
+    },
+    "nodes": [
+        {"id": "wait-30m", "type": "wait", "minutes": 30},
+        {
+            "id": "ask",
+            "type": "wait_event",
+            "topics": ["button.reply"],
+            "key": "button_id",
+            "minutes": 60,
+        },
+    ],
+    "edges": [["wait-30m", "ask"]],
+    "goals": [
+        {
+            "topics": ["orders/paid"],
+            "key": {"event": "order_id", "run": "order_id"},
+            "exit_reason": "goal_met",
+        }
+    ],
+}
+_V5 = {
+    "entry": {"topic": "orders/confirmed", "key": "order_id", "on_repeat": "ignore"},
+    "nodes": [
+        {"id": "hold-30m", "type": "wait", "minutes": 30},
+        {
+            "id": "ask",
+            "type": "wait_event",
+            "topics": ["list.reply"],
+            "key": "button_id",
+            "minutes": 60,
+        },
+    ],
+    "edges": [["hold-30m", "ask"]],
+    "goals": [
+        {
+            "topics": ["orders/fulfilled"],
+            "key": {"event": "order_id", "run": "order_id"},
+            "exit_reason": "goal_met",
+        }
+    ],
+}
+
+
+@pytest.fixture
+def two_versions(monkeypatch: pytest.MonkeyPatch) -> _Spine:
+    flow = _flow(_V5, version=5)
+    runs = [
+        _run(flow, 3, "ask", {"order_id": "A"}, key="A"),
+        _run(flow, 5, "ask", {"order_id": "B"}, key="B"),
+    ]
+    spine = _Spine([flow], runs, {(flow.id, 3): _V3, (flow.id, 5): _V5})
+    _install(monkeypatch, spine)
+    return spine
+
+
+def test_a_goal_ends_only_the_runs_whose_own_version_names_it(
+    two_versions: _Spine,
 ) -> None:
-    asyncio.run(consume_attributed_event(_order({"total_price": "1850.00"}), "c-1", {}))
-    assert cancels == [("converted_elsewhere", None)]
+    """orders/paid is v3's goal, not v5's: order A's run ends, order B's
+    is untouched — even though the live plan (v5) has no such goal."""
+    a, b = two_versions.runs
+    _consume(_event("orders/paid", {"order_id": "A"}))
+    assert [(r, reason) for r, reason, _, _ in two_versions.cancels] == [
+        (str(a.id), "goal_met")
+    ]
+    two_versions.cancels.clear()
+    _consume(_event("orders/fulfilled", {"order_id": "B"}))
+    assert [(r, reason) for r, reason, _, _ in two_versions.cancels] == [
+        (str(b.id), "goal_met")
+    ]
+
+
+def test_a_reply_wakes_only_the_runs_whose_own_version_listens_for_it(
+    two_versions: _Spine,
+) -> None:
+    a, b = two_versions.runs
+    _consume(_event("button.reply", {"button_id": "YES"}))
+    assert two_versions.resumes == [(str(a.id), "ask", {"reply_ask": "YES"})]
+    two_versions.resumes.clear()
+    _consume(_event("list.reply", {"button_id": "NO"}))
+    assert two_versions.resumes == [(str(b.id), "ask", {"reply_ask": "NO"})]
+
+
+def test_entries_still_match_the_latest_version(
+    two_versions: _Spine, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A new run always starts on the newest document: v5's entry topic
+    enrols, v3's old one no longer does."""
+    enrolled: List[Any] = []
+
+    async def enrol(**kwargs: Any) -> object:
+        enrolled.append(kwargs["workflow"].version)
+        return object()
+
+    monkeypatch.setattr(entry, "enrol", enrol)
+    _consume(_event("orders/confirmed", {"order_id": "C"}))
+    assert enrolled == [5]
+    _consume(_event("orders/create", {"order_id": "D"}))
+    assert enrolled == [5]
+
+
+def test_a_repeat_is_judged_by_the_open_runs_own_version(
+    two_versions: _Spine, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The refused enrol is a repeat of order A's run, which entered under
+    v3: its repeat words (refresh_latest) and its first square (wait-30m)
+    are v3's — the live v5 says ignore and renamed the square, and with
+    v5's words the patch would never find the run."""
+    repeats: List[Any] = []
+
+    async def refused(**kwargs: Any) -> None:
+        return None
+
+    async def apply_repeat(*args: Any) -> bool:
+        repeats.append(args)
+        return True
+
+    monkeypatch.setattr(entry, "enrol", refused)
+    monkeypatch.setattr(entry, "apply_repeat", apply_repeat)
+    # v5's entry topic, but the order is A's -> the open run on v3
+    _consume(_event("orders/confirmed", {"order_id": "A"}))
+    ((_, _, key, definition, _, _),) = repeats
+    assert key == "A"
+    assert definition.entry.on_repeat == "refresh_latest"
+    assert definition.nodes[0].id == "wait-30m"
+
+
+def test_a_run_whose_version_is_missing_is_skipped_not_fatal(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No version row for a pin: that run is neither ended nor woken (the
+    walker parks it honestly at its next claim); her other runs are still
+    judged, and the row is never left pending by a raise."""
+    flow = _flow(_V5, version=5)
+    orphan = _run(flow, 2, "ask", {"order_id": "A"}, key="A")
+    fine = _run(flow, 5, "ask", {"order_id": "B"}, key="B")
+    spine = _Spine([flow], [orphan, fine], {(flow.id, 5): _V5})
+    _install(monkeypatch, spine)
+    _consume(_event("orders/fulfilled", {"order_id": "B"}))
+    assert [r for r, _, _, _ in spine.cancels] == [str(fine.id)]
+
+
+def test_each_pinned_version_is_read_once_across_her_runs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    flow = _flow(_V5, version=5)
+    runs = [_run(flow, 5, "ask", {"order_id": k}, key=k) for k in ("A", "B", "C")]
+    spine = _Spine([flow], runs, {(flow.id, 5): _V5})
+    _install(monkeypatch, spine)
+    _consume(_event("list.reply", {"button_id": "YES"}))
+    assert len(spine.resumes) == 3
+    assert spine.definition_reads == [(str(flow.id), 5)]
+
+
+# --- carried: the founding stamp, and pick_next's alarm law ---
 
 
 def test_enrol_stamps_the_entry_events_time_and_repeats_never_move_it(

--- a/tests/crm/test_workflow_queries.py
+++ b/tests/crm/test_workflow_queries.py
@@ -7,15 +7,16 @@ from datetime import datetime, timezone
 from app.crm.outreach.db.queries import (
     admission_facts_query,
     advance_run_query,
-    cancel_open_runs_query,
+    cancel_run_query,
     claim_due_runs_query,
     exit_run_query,
     insert_enrollment_query,
     live_workflows_query,
+    open_runs_for_customer_query,
     park_run_query,
     publish_workflow_query,
     record_run_error_query,
-    resume_run_on_event_query,
+    resume_run_by_id_query,
     source_event_used_query,
 )
 from app.crm.record.db.queries import customer_has_event_query
@@ -42,9 +43,30 @@ def test_enrollment_insert_binds_everything_positionally() -> None:
 
 
 def test_goal_cancel_ends_every_open_run_including_parked() -> None:
-    sql, params = cancel_open_runs_query("m1", "wf-1", "c-1", "goal_met")
+    sql, params = cancel_run_query("m1", "run-1", "goal_met")
     assert "status <> 'exited'" in sql and "status = 'waiting'" not in sql
     assert params[0] == "m1"
+
+
+def test_goal_cancel_and_reply_name_the_run_they_are_about() -> None:
+    """Phase 13: the tier or listening node that matched is the RUN'S
+    version's, so the write names the run — merchant first, then id — and
+    a sibling run on another version is never touched."""
+    sql, params = cancel_run_query("m1", "run-1", "goal_met")
+    assert "WHERE merchant_id = $1 AND id = $2" in sql
+    assert params[:2] == ["m1", "run-1"]
+    sql, params = resume_run_by_id_query("m1", "run-1", "ask", {"reply_ask": "YES"})
+    assert "WHERE merchant_id = $1 AND id = $2" in sql
+    assert "status = 'waiting' AND current_node = $3" in sql
+    assert "RETURNING id" in sql
+    assert params == ["m1", "run-1", "ask", json.dumps({"reply_ask": "YES"})]
+
+
+def test_open_runs_for_customer_is_merchant_first_and_open_only() -> None:
+    sql, params = open_runs_for_customer_query("m1", "c-1")
+    assert "WHERE merchant_id = $1 AND customer_id = $2" in sql
+    assert "status <> 'exited'" in sql
+    assert params == ["m1", "c-1"]
 
 
 def test_goal_cancel_is_time_aware_on_the_entry_event_and_null_safe() -> None:
@@ -52,28 +74,28 @@ def test_goal_cancel_is_time_aware_on_the_entry_event_and_null_safe() -> None:
     EVENT happened, not after the row was inserted — a late-delivered
     earlier-stage letter must not keep a run alive past a goal that truly
     happened after it. entered_at stays the fallback for older rows."""
-    sql, params = cancel_open_runs_query("m1", "wf-1", "c-1", "goal_met", NOW)
+    sql, params = cancel_run_query("m1", "run-1", "goal_met", NOW)
     assert (
         "COALESCE((context->>'entered_event_at')::timestamptz, entered_at) "
-        "< $5::timestamptz" in sql
+        "< $4::timestamptz" in sql
     )
-    assert "$5::timestamptz IS NULL OR" in sql
-    assert params[4] == NOW
-    _, params = cancel_open_runs_query("m1", "wf-1", "c-1", "goal_met")
-    assert params[4] is None  # unstamped goal keeps today's behaviour
+    assert "$4::timestamptz IS NULL OR" in sql
+    assert params[3] == NOW
+    _, params = cancel_run_query("m1", "run-1", "goal_met")
+    assert params[3] is None  # unstamped goal keeps today's behaviour
 
 
 def test_goal_cancel_can_be_keyed_to_the_run_it_is_about() -> None:
     """A keyed tier ends only the run whose context field equals the
     letter's payload field (cart_token = cart_token); the unkeyed form is
     byte-identical to before."""
-    sql, params = cancel_open_runs_query(
-        "m1", "wf-1", "c-1", "goal_met", NOW, key=("cart_token", "chk-88412")
+    sql, params = cancel_run_query(
+        "m1", "run-1", "goal_met", NOW, key=("cart_token", "chk-88412")
     )
-    assert "AND context->>$6 = $7" in sql
-    assert params[5:] == ["cart_token", "chk-88412"]
-    sql, params = cancel_open_runs_query("m1", "wf-1", "c-1", "converted_elsewhere")
-    assert "$6" not in sql and len(params) == 5
+    assert "AND context->>$5 = $6" in sql
+    assert params[4:] == ["cart_token", "chk-88412"]
+    sql, params = cancel_run_query("m1", "run-1", "converted_elsewhere")
+    assert "$5" not in sql and len(params) == 4
 
 
 def test_goal_recheck_can_be_keyed_to_the_run_it_is_about() -> None:
@@ -136,9 +158,9 @@ def test_walker_writes_are_conditional_on_the_leased_wake_at() -> None:
 def test_event_side_writes_stay_unconditional() -> None:
     """The reply and the goal-cancel are the event side: they always win
     over a walker mid-visit (the walker defers on its CAS miss)."""
-    sql, _ = cancel_open_runs_query("m1", "wf-1", "c-1", "goal_met")
+    sql, _ = cancel_run_query("m1", "run-1", "goal_met")
     assert "AND wake_at =" not in sql
-    sql, _ = resume_run_on_event_query("m1", "wf-1", "c-1", "ask", {"reply_ask": "YES"})
+    sql, _ = resume_run_by_id_query("m1", "run-1", "ask", {"reply_ask": "YES"})
     assert "AND wake_at =" not in sql
 
 

--- a/tests/crm/test_workflow_reporting.py
+++ b/tests/crm/test_workflow_reporting.py
@@ -19,7 +19,7 @@ import app.crm.outreach.api as outreach_api
 from app.crm.auth import crm_admin_user
 from app.crm.outreach.db.decoder import decode_customer_run, decode_run_summary
 from app.crm.outreach.db.queries import (
-    cancel_open_runs_query,
+    cancel_run_query,
     customer_runs_query,
     workflow_summary_query,
 )
@@ -63,24 +63,18 @@ def test_goal_cancel_can_stash_the_goal_on_the_runs_it_ends() -> None:
     patch = {
         "goal": {"topic": "orders/create", "event_id": "ev-1", "amount": "1850.00"}
     }
-    sql, params = cancel_open_runs_query(
-        "m1",
-        "wf-1",
-        "c-1",
-        "goal_met",
-        NOW,
-        key=("cart_token", "chk-1"),
-        context_patch=patch,
+    sql, params = cancel_run_query(
+        "m1", "run-1", "goal_met", NOW, key=("cart_token", "chk-1"), context_patch=patch
     )
-    assert "context = context || $8::jsonb" in sql and "AND context->>$6 = $7" in sql
-    assert len(params) == 8 and '"1850.00"' in params[7]
-    sql, params = cancel_open_runs_query(
-        "m1", "wf-1", "c-1", "converted_elsewhere", NOW, context_patch=patch
+    assert "context = context || $7::jsonb" in sql and "AND context->>$5 = $6" in sql
+    assert len(params) == 7 and '"1850.00"' in params[6]
+    sql, params = cancel_run_query(
+        "m1", "run-1", "converted_elsewhere", NOW, context_patch=patch
     )
-    assert "context = context || $6::jsonb" in sql and "$7" not in sql
-    assert len(params) == 6
-    sql, params = cancel_open_runs_query("m1", "wf-1", "c-1", "goal_met", NOW)
-    assert "context = context ||" not in sql and len(params) == 5
+    assert "context = context || $5::jsonb" in sql and "$6" not in sql
+    assert len(params) == 5
+    sql, params = cancel_run_query("m1", "run-1", "goal_met", NOW)
+    assert "context = context ||" not in sql and len(params) == 4
 
 
 def test_the_goal_stash_is_bookkeeping_not_a_template_variable() -> None:

--- a/tests/crm/test_workflow_walker.py
+++ b/tests/crm/test_workflow_walker.py
@@ -21,6 +21,7 @@ from uuid import uuid4
 
 import pytest
 
+import app.crm.outreach.definitions as definitions
 import app.crm.outreach.walker as walker
 from app.crm.outreach.nodes import NodeParked
 from app.crm.outreach.schemas import EnrollmentRun, Workflow, WorkflowDefinition
@@ -115,6 +116,13 @@ class _Writes:
         return self.matched
 
 
+def _install(monkeypatch: pytest.MonkeyPatch, writes: _Writes) -> None:
+    """The walker writes through its accessor; the pinned document comes
+    through definitions.py's (phase 13) — one fake serves both doors."""
+    monkeypatch.setattr(walker, "accessor", writes)
+    monkeypatch.setattr(definitions, "accessor", writes)
+
+
 @pytest.fixture
 def no_goal(monkeypatch: pytest.MonkeyPatch) -> None:
     async def never(*args: Any, **kwargs: Any) -> bool:
@@ -132,7 +140,7 @@ def test_advance_carries_the_lease_it_was_claimed_under(
     monkeypatch: pytest.MonkeyPatch, no_goal: None
 ) -> None:
     writes = _Writes(matched=True, definition=_TWO_WAITS)
-    monkeypatch.setattr(walker, "accessor", writes)
+    _install(monkeypatch, writes)
     run = _run()
     _advance(writes, run)
     ((verb, args),) = writes.calls
@@ -154,7 +162,7 @@ def test_a_missed_cas_on_advance_defers_without_raising_or_exiting(
     walker neither raises nor writes anything else — the next claim
     re-reads the run with the reply in it."""
     writes = _Writes(matched=False, definition=_TWO_WAITS)
-    monkeypatch.setattr(walker, "accessor", writes)
+    _install(monkeypatch, writes)
     _advance(writes, _run())
     assert [verb for verb, _ in writes.calls] == ["advance"]
 
@@ -163,7 +171,7 @@ def test_a_missed_cas_on_exit_defers_too(
     monkeypatch: pytest.MonkeyPatch, no_goal: None
 ) -> None:
     writes = _Writes(matched=False, definition=_ONE_WAIT)
-    monkeypatch.setattr(walker, "accessor", writes)
+    _install(monkeypatch, writes)
     run = _run()
     _advance(writes, run)
     ((verb, args),) = writes.calls
@@ -175,7 +183,7 @@ def test_a_park_under_a_stale_lease_is_a_no_op(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     writes = _Writes(matched=False, definition=_TWO_WAITS)
-    monkeypatch.setattr(walker, "accessor", writes)
+    _install(monkeypatch, writes)
 
     async def parked(*args: Any) -> None:
         raise NodeParked("template gone")
@@ -190,7 +198,7 @@ def test_a_retry_under_a_stale_lease_is_a_no_op(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     writes = _Writes(matched=False, definition=_TWO_WAITS)
-    monkeypatch.setattr(walker, "accessor", writes)
+    _install(monkeypatch, writes)
 
     async def flaky(*args: Any) -> None:
         raise RuntimeError("provider hiccup")
@@ -249,7 +257,7 @@ def _goal_recheck(
 
 def test_this_cart_recovered_exits_goal_met(monkeypatch: pytest.MonkeyPatch) -> None:
     writes = _Writes(matched=True, definition=_TIERED)
-    monkeypatch.setattr(walker, "accessor", writes)
+    _install(monkeypatch, writes)
     asked = _goal_recheck(monkeypatch, {("cart_token", "chk-1"): True})
     _advance(writes, _tiered_run())
     ((verb, args),) = writes.calls
@@ -262,7 +270,7 @@ def test_another_order_exits_converted_elsewhere(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     writes = _Writes(matched=True, definition=_TIERED)
-    monkeypatch.setattr(walker, "accessor", writes)
+    _install(monkeypatch, writes)
     asked = _goal_recheck(monkeypatch, {None: True})
     _advance(writes, _tiered_run())
     ((verb, args),) = writes.calls
@@ -276,7 +284,7 @@ def test_a_run_without_the_key_falls_back_to_the_row_time_and_the_unkeyed_tier(
     """An older row (no entered_event_at) compares against entered_at, and
     a run whose context lacks the key field cannot match a keyed tier."""
     writes = _Writes(matched=True, definition=_TIERED)
-    monkeypatch.setattr(walker, "accessor", writes)
+    _install(monkeypatch, writes)
     asked = _goal_recheck(monkeypatch, {})
     run = _run()
     _advance(writes, run)
@@ -291,7 +299,7 @@ def test_walk_run_never_writes_without_a_lease(
     rows have wake_at NOT NULL). Without one there is no token to write
     under, and a blind overwrite is exactly the bug this phase closes."""
     writes = _Writes(matched=True, definition=_TWO_WAITS)
-    monkeypatch.setattr(walker, "accessor", writes)
+    _install(monkeypatch, writes)
     asyncio.run(walker.walk_run(_run(wake_at=None)))
     assert writes.calls == []
 
@@ -321,7 +329,7 @@ def _pinned_run(version: int) -> EnrollmentRun:
 def cold_cache() -> None:
     """The definition cache is process-wide and never invalidates
     (versions are immutable) — each test starts it empty."""
-    walker._definitions.clear()
+    definitions._definitions.clear()
 
 
 def test_the_walker_executes_the_version_the_run_entered_under(
@@ -331,7 +339,7 @@ def test_the_walker_executes_the_version_the_run_entered_under(
     entered under v3 (wait-30m -> wait-1d) and finishes on v3. The pin is
     read by (merchant, workflow, version), never from crm_workflow."""
     writes = _Writes(matched=True, definition=_V4, versions={3: _V3, 4: _V4})
-    monkeypatch.setattr(walker, "accessor", writes)
+    _install(monkeypatch, writes)
     run = _pinned_run(3)
     asyncio.run(walker.walk_run(run))
     ((verb, args),) = writes.calls
@@ -346,7 +354,7 @@ def test_a_missing_version_parks_the_run_honestly(
     a silent fallback to the live document (which would execute a plan
     the run did not enter under)."""
     writes = _Writes(matched=True, definition=_V4, versions={4: _V4})
-    monkeypatch.setattr(walker, "accessor", writes)
+    _install(monkeypatch, writes)
     run = _pinned_run(3)
     asyncio.run(walker.walk_run(run))
     ((verb, args),) = writes.calls
@@ -362,7 +370,7 @@ def test_a_pinned_version_is_read_once_per_process(
     run on the same (workflow, version) is served from the walker's cache
     without a read."""
     writes = _Writes(matched=True, definition=_V3, versions={3: _V3})
-    monkeypatch.setattr(walker, "accessor", writes)
+    _install(monkeypatch, writes)
     first = _pinned_run(3)
     second = _pinned_run(3)
     second.workflow_id = first.workflow_id
@@ -375,19 +383,19 @@ def test_a_pinned_version_is_read_once_per_process(
 def test_the_cache_is_bounded_and_evicts_the_least_recently_used(
     monkeypatch: pytest.MonkeyPatch, cold_cache: None
 ) -> None:
-    monkeypatch.setattr(walker, "_DEFINITION_CACHE_SIZE", 2)
+    monkeypatch.setattr(definitions, "_DEFINITION_CACHE_SIZE", 2)
     writes = _Writes(matched=True, definition=_V3, versions={1: _V3, 2: _V3, 3: _V3})
-    monkeypatch.setattr(walker, "accessor", writes)
+    _install(monkeypatch, writes)
     runs = [_pinned_run(version) for version in (1, 2, 3)]
     for run in runs[1:]:
         run.workflow_id = runs[0].workflow_id
 
     async def read_in_order() -> None:
-        await walker._definition_for(runs[0])  # v1: miss
-        await walker._definition_for(runs[1])  # v2: miss
-        await walker._definition_for(runs[0])  # v1: hit, now most recent
-        await walker._definition_for(runs[2])  # v3: miss, evicts v2
-        await walker._definition_for(runs[1])  # v2: miss again
+        await definitions.definition_for(runs[0])  # v1: miss
+        await definitions.definition_for(runs[1])  # v2: miss
+        await definitions.definition_for(runs[0])  # v1: hit, now most recent
+        await definitions.definition_for(runs[2])  # v3: miss, evicts v2
+        await definitions.definition_for(runs[1])  # v2: miss again
 
     asyncio.run(read_in_order())
     assert [version for _, _, version in writes.definition_reads] == [1, 2, 3, 2]


### PR DESCRIPTION
## Rollout phase 13 — `docs/crm/workflow-rollout/13-consumer-per-run-versions.md`

Depends on 12 (#1069, merged). ADR 0023 §4: "one consumer, two reads" (`context/reading-notes.md` §15.3) is now what the code does — `app/crm/outreach/entry.py` cites the file.

### What changed

| File | Change |
|---|---|
| `app/crm/outreach/definitions.py` (new) | `definition_for(run) -> Optional[WorkflowDefinition]`: the pin resolved by `(workflow_id, version)` through a 512-entry LRU that never invalidates (versions are immutable). Logic, imports only the module's db door. Shared by walker and consumer. |
| `app/crm/outreach/entry.py` | `consume_attributed_event` reads `open_runs_for_customer`, then per run: `_end_on_goal` (its version's tiers, keyed-first; the first tier that ends the run is its verdict) → `_wake_on_reply` (its version's `wait_event` squares; the statement decides whether the token stands there). Then `live_workflows` for entries, latest, unchanged. `_try_enrol` passes the open runs so `_repeat_definition` hands `apply_repeat` the open run's pinned words (on_repeat, debounce, first square's id). |
| `app/crm/outreach/walker.py` | Uses `definitions.definition_for`; `None` → `NodeParked("definition vN missing")` as in phase 12. Cache code removed. |
| `db/queries.py`, `db/accessor.py` | New: `open_runs_for_customer_query` (`merchant_id, customer_id, status <> 'exited'`, customer index), `resume_run_by_id_query`, `cancel_run_query` (merchant first, `id = $2`, same G7 time predicate, same keyed re-assertion, same context patch; `RETURNING id` → accessors return bool). Retired: `resume_run_on_event(_query)`, `cancel_open_runs(_query)` — their only caller was this consumer. |
| `app/crm/outreach/repeat.py` | Docstring: the words judged are the open run's version's. |
| Tests | `test_workflow_entry.py` rewritten around a `_Spine` fake (seeded open runs + version rows, writes recorded by run id); `test_workflow_queries.py` and `test_workflow_reporting.py` re-pointed to the by-id builders; `test_workflow_walker.py` cache references moved to `definitions`; `test_worker_runtime.py` seeds one open run per plan. |

No migration.

### Red tests (fail on release, pass here)

All of `tests/crm/test_workflow_entry.py`, `test_workflow_queries.py` and `test_workflow_walker.py` fail to import on release (`No module named app.crm.outreach.definitions`, `cannot import name cancel_run_query`). The phase's own assertions:

- `test_a_goal_ends_only_the_runs_whose_own_version_names_it` — one keyed plan, order A on v3 (goal `orders/paid`), order B on v5 (goal `orders/fulfilled`); `orders/paid` cancels A only, `orders/fulfilled` cancels B only, though the live plan is v5.
- `test_a_reply_wakes_only_the_runs_whose_own_version_listens_for_it` — v3 listens on `button.reply`, v5 on `list.reply`; each wakes only its run, by id.
- `test_entries_still_match_the_latest_version` — v5's entry topic enrols, v3's no longer does.
- `test_a_repeat_is_judged_by_the_open_runs_own_version` — a refused enrol for order A hands `apply_repeat` v3's definition (`refresh_latest`, first square `wait-30m`) while v5 says `ignore` and renamed the square.
- `test_a_run_whose_version_is_missing_is_skipped_not_fatal`, `test_each_pinned_version_is_read_once_across_her_runs`.
- Builders: `cancel_run_query`/`resume_run_by_id_query` carry `WHERE merchant_id = $1 AND id = $2`; `open_runs_for_customer_query` is merchant-first and open-only.

### Checks (strictly `&&`-chained, pytest to a log)

black, isort, autoflake clean · pyrefly 0 errors · **`pytest tests/crm`: 614 passed** (606 on release + 8 net) · `check_crm_boundaries.py` clean · `check_migrations.py --base origin/release`: 64, no duplicates, no gaps.

### Decisions already made that I disagree with

None.

### Judgment calls (overrule if you want)

- **Keyed tiers are judged in Python from the run row, and re-asserted in the statement.** With the row in hand the consumer knows which run a keyed letter is about, so a customer with three open carts costs one UPDATE for the matching run instead of three; the `context->>$5 = $6` predicate still guards the write. A run's keyed tier that matched ends the loop for that run — the unkeyed tier no longer issues a second, always-zero-row UPDATE against an exited run.
- **Listening is NOT pre-filtered on `current_node`** — the statement decides, exactly as before, so a reply that lands as the token arrives on the square is not dropped. Cost is one UPDATE per (open run, listening square on that topic), the same order as before.
- **Open runs of paused plans are now judged too.** The old consumer read only LIVE plans, so a paused plan's runs were neither goal-cancelled nor woken. Now a goal ends them (the walker's fire-time re-check would have on resume anyway, so the outcome is unchanged, only earlier) and a reply is recorded in context while the walker keeps snoozing them. If you want the old blind spot back, it is a status join in `open_runs_for_customer_query`.
- **Repeat fallback:** when the refused enrol's run is not among her open runs (a keyed run that resolved to another customer, or a sibling tick opened it after the read), `apply_repeat` gets the latest definition — the pre-pinning behaviour, never a dropped repeat.
- **The retired writers were deleted, not kept as unused variants.** Their only caller was this consumer.

### Not done on purpose

- Drain tooling, retention, migrate-forward, the retirement guard (phase 14).
- The reading-notes sentence is cited from the code; the notes file itself is not edited (rollout rule).

### Adjacent observations (not touched)

- Same as #1069: `docs/crm/plans/README.md` still promises `on_publish: migrate` on the cart board from phase 11, and no plan document declares it. The notes still describe routes as `/crm/...`; phase files 10/11 say "ADR 0022" (it is 0023).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014UNZ4z7zb87HnNHjTXoFpW
