### PR TITLE
feat(crm): wait_event branches on $topic; entry as a list of {topic, start}; replies cleared on advance (rollout 15)

### DIFF
--- a/app/crm/outreach/enrol.py
+++ b/app/crm/outreach/enrol.py
@@ -12,36 +12,43 @@ from typing import Any, Dict, Optional, Tuple
 from app.core.logger import logger
 from app.crm.outreach.db import DbTxn, UniqueViolation, accessor, atomically
 from app.crm.outreach.nodes import is_wait
-from app.crm.outreach.schemas import EnrollmentRun, Workflow, WorkflowDefinition
+from app.crm.outreach.schemas import (
+    EnrollmentRun,
+    Workflow,
+    WorkflowDefinition,
+    WorkflowEntry,
+    WorkflowEntryAt,
+    WorkflowNode,
+)
 
 
 def _admission(
-    definition: WorkflowDefinition,
+    door: WorkflowEntry,
     runs: int,
     latest_entered_at: Optional[datetime],
     now: datetime,
 ) -> Tuple[bool, str]:
-    """PURE decide: may this customer start a run? Returns (admit, reason)
-    — the reason is logged, never stored (skips-with-rows are the
-    broadcast door's T18 concern, phase 2)."""
-    if runs and not definition.entry.reenter:
+    """PURE decide: may this customer start a run through this door?
+    Returns (admit, reason) — the reason is logged, never stored
+    (skips-with-rows are the broadcast door's T18 concern, phase 2)."""
+    if runs and not door.reenter:
         return False, "reenter_disabled"
-    if latest_entered_at is not None and definition.entry.cooldown_hours > 0:
-        cooled_at = latest_entered_at + timedelta(hours=definition.entry.cooldown_hours)
+    if latest_entered_at is not None and door.cooldown_hours > 0:
+        cooled_at = latest_entered_at + timedelta(hours=door.cooldown_hours)
         if now < cooled_at:
             return False, "cooldown_active"
     return True, "admitted"
 
 
-def _first_wake(definition: WorkflowDefinition, now: datetime) -> datetime:
-    """Arrival scheduling: the token arrives on nodes[0]; a wait node's
-    alarm is arrival + delay, an action node's alarm is now (the canon
-    'enrolled = waiting with an immediate wake'). "Is it a wait?" is the
-    registry's answer, never a type string — a wait_event first node used
-    to fall through here and enrol with a zero listening window."""
-    first = definition.nodes[0]
-    if is_wait(first) and first.minutes:
-        return now + timedelta(minutes=first.minutes)
+def _first_wake(start: WorkflowNode, now: datetime) -> datetime:
+    """Arrival scheduling: the token arrives on the door's start square; a
+    wait node's alarm is arrival + delay, an action node's alarm is now
+    (the canon 'enrolled = waiting with an immediate wake'). "Is it a
+    wait?" is the registry's answer, never a type string — a wait_event
+    first node used to fall through here and enrol with a zero listening
+    window."""
+    if is_wait(start) and start.minutes:
+        return now + timedelta(minutes=start.minutes)
     return now
 
 
@@ -52,11 +59,14 @@ async def enrol(
     customer_id: str,
     context: Dict[str, Any],
     enrollment_key: Optional[str] = None,
+    door: Optional[WorkflowEntryAt] = None,
 ) -> Optional[EnrollmentRun]:
-    """Admit one customer into one live plan. Returns the run, or None
-    when a guard (or the open-run unique) said no — a refusal is a normal
-    outcome, never an error. context carries pointers + the small facts
-    the sends need ({source_event_id, phone, ...}), never payloads."""
+    """Admit one customer into one live plan through one door (phase 15:
+    the door names the square the run starts on; None = the plan's first
+    door). Returns the run, or None when a guard (or the open-run unique)
+    said no — a refusal is a normal outcome, never an error. context
+    carries pointers + the small facts the sends need ({source_event_id,
+    phone, ...}), never payloads."""
     if workflow.status != "live" or not workflow.definition:
         logger.info(
             f"enrol skipped: workflow {workflow.id} not live "
@@ -70,6 +80,7 @@ async def enrol(
             merchant_id,
             workflow,
             definition,
+            door or definition.entries[0],
             customer_id,
             context,
             enrollment_key or customer_id,
@@ -89,6 +100,7 @@ async def _enrol_in_txn(
     merchant_id: str,
     workflow: Workflow,
     definition: WorkflowDefinition,
+    door: WorkflowEntryAt,
     customer_id: str,
     context: Dict[str, Any],
     enrollment_key: str,
@@ -112,12 +124,10 @@ async def _enrol_in_txn(
         merchant_id,
         str(workflow.id),
         customer_id,
-        enrollment_key=enrollment_key if definition.entry.key else None,
+        enrollment_key=enrollment_key if door.key else None,
     )
     now = datetime.now(timezone.utc)
-    admit, reason = _admission(
-        definition, facts["runs"], facts["latest_entered_at"], now
-    )
+    admit, reason = _admission(door, facts["runs"], facts["latest_entered_at"], now)
     if not admit:
         logger.info(
             f"enrol skipped: {reason} (workflow {workflow.id}, "
@@ -125,6 +135,9 @@ async def _enrol_in_txn(
         )
         return None
 
+    start = next((node for node in definition.nodes if node.id == door.start), None)
+    if start is None:  # the validator forbids this; drift is an error, not a run
+        raise ValueError(f"door {door.topic!r} starts on unknown node {door.start!r}")
     await accessor.lock_templates_shared(txn, merchant_id, definition.send_templates())
     run = await accessor.insert_enrollment(
         txn,
@@ -132,8 +145,8 @@ async def _enrol_in_txn(
         str(workflow.id),
         workflow.version,
         customer_id,
-        definition.nodes[0].id,
-        _first_wake(definition, now),
+        door.start,
+        _first_wake(start, now),
         context,
         enrollment_key,
     )

--- a/app/crm/outreach/entry.py
+++ b/app/crm/outreach/entry.py
@@ -10,8 +10,10 @@ docs/crm/workflow-rollout/context/reading-notes.md §15.3):
      every write names the run it is about. A migrate plan is the
      degenerate case — every open run pinned to the latest — same path,
      no branch.
-  2. THE LIVE PLANS, latest document: an entry match starts a run
-     (enrol()) — a new run always begins on the newest version.
+  2. THE LIVE PLANS, latest document: a door match (phase 15: a plan
+     lists its doors, one per topic, each naming the square its run
+     starts on) starts a run (enrol()) — a new run always begins on the
+     newest version.
 
 A consumer is a function, not a loop (worker-runtime.md): the event
 worker's pass calls consume_attributed_event() per row, inside that row's
@@ -27,12 +29,19 @@ from app.core.logger import logger
 from app.crm.outreach.db import accessor
 from app.crm.outreach.definitions import definition_for
 from app.crm.outreach.enrol import enrol
-from app.crm.outreach.nodes import _BOOKKEEPING_KEYS, _BOOKKEEPING_PREFIXES
+from app.crm.outreach.nodes import (
+    _BOOKKEEPING_KEYS,
+    _BOOKKEEPING_PREFIXES,
+    TOPIC_KEY,
+    reply_key,
+)
 from app.crm.outreach.repeat import _as_number, apply_repeat
 from app.crm.outreach.schemas import (
     EnrollmentRun,
     Workflow,
     WorkflowDefinition,
+    WorkflowEntry,
+    WorkflowEntryAt,
 )
 from app.crm.record.contracts import RawEvent
 from app.crm.shared.normalize import normalize_phone
@@ -115,10 +124,12 @@ async def consume_attributed_event(
     flows = await accessor.live_workflows(event.merchant_id)
     for flow in flows:
         definition = WorkflowDefinition.model_validate(flow.definition)
-        if definition.entry.topic == event.topic and _where_matches(
-            definition.entry.where, event.payload
-        ):
-            await _try_enrol(flow, definition, event, customer_id, handles, open_runs)
+        for door in definition.entries:
+            if door.topic == event.topic and _where_matches(door.where, event.payload):
+                await _try_enrol(
+                    flow, definition, door, event, customer_id, handles, open_runs
+                )
+                break  # topics are unique across a plan's doors
 
 
 async def _end_on_goal(
@@ -166,7 +177,10 @@ async def _wake_on_reply(
     for node in definition.nodes:
         if node.type != "wait_event" or event.topic not in node.topics:
             continue
-        answer = event.payload.get(node.key or "")
+        # $topic (phase 15): the branch is the letter's NAME, not a field.
+        answer = (
+            event.topic if node.key == TOPIC_KEY else event.payload.get(node.key or "")
+        )
         if answer is None:
             # B1 (rollout phase 01): no key, no answer to branch on. Waking
             # the run with {reply_<node>: None} made pick_next read "the
@@ -204,11 +218,6 @@ def _goal_patch(event: RawEvent) -> dict:
     return {"goal": goal}
 
 
-def reply_key(node_id: str) -> str:
-    """Where a wait_event node's answer lives in the run's context."""
-    return f"reply_{node_id}"
-
-
 def _where_matches(where: dict, payload: dict) -> bool:
     return all(payload.get(key) == value for key, value in where.items())
 
@@ -239,12 +248,13 @@ def _context_from_payload(payload: dict) -> dict:
 async def _try_enrol(
     flow: Workflow,
     definition: WorkflowDefinition,
+    door: WorkflowEntryAt,
     event: RawEvent,
     customer_id: str,
     handles: Optional[dict] = None,
     open_runs: Sequence[EnrollmentRun] = (),
 ) -> None:
-    admit, enrollment_key = _enrollment_key(definition, event, str(flow.id))
+    admit, enrollment_key = _enrollment_key(door, event, str(flow.id))
     if not admit:
         return  # a keyed plan without its key: a refusal, not an error
     context = _context_from_payload(event.payload)
@@ -261,6 +271,7 @@ async def _try_enrol(
         customer_id=customer_id,
         context=context,
         enrollment_key=enrollment_key,
+        door=door,
     )
     if run is None:
         # Refused — most often because a run for this key is already open.
@@ -278,25 +289,29 @@ async def _try_enrol(
             event.merchant_id,
             str(flow.id),
             key,
-            await _repeat_definition(open_runs, flow, key, definition),
+            await _repeat_door(open_runs, flow, key, door.topic, door),
             str(event.id),
             repeat_facts,
         )
 
 
-async def _repeat_definition(
+async def _repeat_door(
     open_runs: Sequence[EnrollmentRun],
     flow: Workflow,
     enrollment_key: str,
-    latest: WorkflowDefinition,
-) -> WorkflowDefinition:
-    """The repeat's words are the OPEN RUN'S version's: its on_repeat and
-    debounce, and its first square's id — v5 may have renamed the entry
-    node, and the patch's `current_node = entry node` guard would then
-    never find a v3 run. The run was read at the top of this pass; when
-    it is not among her open runs (a keyed run that resolved to another
-    customer, or a sibling tick opened it after the read) the latest
-    document stands in — exactly the pre-pinning behaviour."""
+    topic: str,
+    latest: WorkflowEntryAt,
+) -> WorkflowEntryAt:
+    """The repeat's words are the OPEN RUN'S version's door: its on_repeat
+    and debounce, and the square it starts on — v5 may have renamed the
+    start square, and the patch's `current_node = start` guard would then
+    never find a v3 run. That version's door for this topic; if it has
+    none (the door is newer than the run), its first door — the patch's
+    guard makes a wrong square a no-op, never a wrong write. The run was
+    read at the top of this pass; when it is not among her open runs (a
+    keyed run that resolved to another customer, or a sibling tick opened
+    it after the read) the latest door stands in — exactly the
+    pre-pinning behaviour."""
     for run in open_runs:
         if (
             str(run.workflow_id) == str(flow.id)
@@ -304,21 +319,22 @@ async def _repeat_definition(
         ):
             pinned = await definition_for(run)
             if pinned is not None:
-                return pinned
+                doors = pinned.entries
+                return next((d for d in doors if d.topic == topic), doors[0])
             break
     return latest
 
 
 def _enrollment_key(
-    definition: WorkflowDefinition, event: RawEvent, workflow_id: str
+    door: WorkflowEntry, event: RawEvent, workflow_id: str
 ) -> Tuple[bool, Optional[str]]:
-    """PURE decide: (admit, key). No entry.key -> (True, None): enrol()
-    falls back to the customer id, canon's default. entry.key set -> the
+    """PURE decide: (admit, key). No door.key -> (True, None): enrol()
+    falls back to the customer id, canon's default. door.key set -> the
     payload's value for it. The author declared runs are per <field>; an
     event without that field cannot honestly start one, so it is refused
     like any other admission miss — never silently re-keyed to the
     customer, which would coalesce what the author said to keep apart."""
-    field = definition.entry.key
+    field = door.key
     if not field:
         return True, None
     value = event.payload.get(field)

--- a/app/crm/outreach/nodes.py
+++ b/app/crm/outreach/nodes.py
@@ -60,6 +60,24 @@ _BOOKKEEPING_KEYS = (
 )
 _BOOKKEEPING_PREFIXES = ("lead_", "message_", "reply_")
 
+# The one $-word a wait_event may branch on (rollout phase 15): the
+# event's TOPIC rather than a payload field.
+TOPIC_KEY = "$topic"
+
+
+def reply_key(node_id: str) -> str:
+    """Where a wait_event square's answer lives in the run's context."""
+    return f"reply_{node_id}"
+
+
+def without_reply(context: Dict[str, Any], node_id: str) -> Dict[str, Any]:
+    """PURE: the context with this square's answer cleared — written when
+    the token leaves the square (phase 15). A door may start a run on any
+    square, so a square can be revisited; a stale answer left behind
+    would resolve the revisit at once, on the old reply."""
+    return {key: value for key, value in context.items() if key != reply_key(node_id)}
+
+
 # Facts the lead machine consumes itself, not the template: kept in the
 # call payload, dropped from send variables.
 _LEAD_ONLY_KEYS = ("reporting_webhook_url",)
@@ -139,6 +157,11 @@ def _validate_wait_event(
         problems.append(f"wait_event node {node.id} needs topics")
     if not node.key:
         problems.append(f"wait_event node {node.id} needs a payload key")
+    elif node.key.startswith("$") and node.key != TOPIC_KEY:
+        problems.append(
+            f"wait_event node {node.id}: key {node.key!r} — the only $-word is "
+            f"{TOPIC_KEY} (branch on the event's topic)"
+        )
     return problems
 
 

--- a/app/crm/outreach/plans.py
+++ b/app/crm/outreach/plans.py
@@ -18,6 +18,7 @@ from app.crm.outreach.schemas import (
     Workflow,
     WorkflowDefinition,
     WorkflowEntry,
+    WorkflowEntryAt,
     WorkflowSummary,
 )
 
@@ -53,19 +54,33 @@ def validate_definition(
     for node in definition.nodes:
         problems.extend(NODE_TYPES[node.type].validate(node, definition))
 
-    # Repeat-entry words (repeat.py owns the vocabulary). debounce slides
-    # "the entry wait's alarm" — a plan whose first square is an action has
+    # The doors (phase 15): one per topic, each starting on a real square.
+    # Repeat-entry words per door (repeat.py owns the vocabulary); debounce
+    # slides "the entry wait's alarm" — a door whose start is an action has
     # no alarm to slide.
-    if parse_repeat_policy(definition.entry.on_repeat) is None:
-        problems.append(
-            f"entry.on_repeat {definition.entry.on_repeat!r} is not a policy "
-            "(ignore · refresh_latest · refresh_max(<field>) · accumulate)"
-        )
-    if definition.entry.debounce_minutes > 0 and not is_wait(definition.nodes[0]):
-        problems.append(
-            "entry.debounce_minutes needs a wait as the first node — there is "
-            "no entry alarm to slide otherwise"
-        )
+    by_id = {node.id: node for node in definition.nodes}
+    if not definition.entries:
+        problems.append("entry: a plan needs at least one door (a topic and a start)")
+    topics_seen = set()
+    for door in definition.entries:
+        if door.topic in topics_seen:
+            problems.append(
+                f"entry topic {door.topic!r} appears twice — one door per topic"
+            )
+        topics_seen.add(door.topic)
+        start = by_id.get(door.start)
+        if start is None:
+            problems.append(f"entry {door.topic!r}: start {door.start!r} is not a node")
+        if parse_repeat_policy(door.on_repeat) is None:
+            problems.append(
+                f"entry {door.topic!r}: on_repeat {door.on_repeat!r} is not a policy "
+                "(ignore · refresh_latest · refresh_max(<field>) · accumulate)"
+            )
+        if door.debounce_minutes > 0 and (start is None or not is_wait(start)):
+            problems.append(
+                f"entry {door.topic!r}: debounce_minutes needs a wait as its start "
+                "node — there is no entry alarm to slide otherwise"
+            )
 
     # Goal tiers (phase 06): the reason is vocabulary, and one tier per
     # reason — two tiers claiming goal_met could never be told apart.
@@ -125,20 +140,36 @@ def validate_definition(
     return problems
 
 
-def _entry_changed(raw_entry: Any, live_entry: Dict[str, Any]) -> bool:
+def _entry_changed(raw_entry: Any, live_entry: Any) -> bool:
     """PURE: does the draft's entry MEAN something different from the live
     one? Compared as validated models, so a draft that omits the defaults
     and a live entry that spells them out read equal (B3, rollout phase
     01) — a raw-dict compare refused every re-publish that changed nothing
-    about admission. A live entry that no longer parses (a legacy row from
-    before a word was added) cannot be normalised: then the raw dicts are
+    about admission. Doors (phase 15) compare as a list, order-free; a
+    single object compares as one door with no explicit start, so the
+    object and list spellings of the same topic read as different doors
+    (conservative: under migrate that is a refusal, and pin is the way
+    out). A live entry that no longer parses (a legacy row from before a
+    word was added) cannot be normalised: then the raw values are
     compared, exactly as before."""
     try:
-        draft = WorkflowEntry.model_validate(raw_entry).model_dump()
-        live = WorkflowEntry.model_validate(live_entry).model_dump()
+        return _doors_by_meaning(raw_entry) != _doors_by_meaning(live_entry)
     except Exception:
         return raw_entry != live_entry
-    return draft != live
+
+
+def _doors_by_meaning(entry: Any) -> List[Dict[str, Any]]:
+    """PURE: an entry object or door list as sorted, fully-spelled doors."""
+    items = entry if isinstance(entry, list) else [entry]
+    doors: List[Dict[str, Any]] = []
+    for item in items:
+        if isinstance(item, dict) and "start" in item:
+            doors.append(WorkflowEntryAt.model_validate(item).model_dump())
+        else:
+            doors.append(
+                {**WorkflowEntry.model_validate(item).model_dump(), "start": None}
+            )
+    return sorted(doors, key=lambda door: door["topic"])
 
 
 def validate_migration(

--- a/app/crm/outreach/repeat.py
+++ b/app/crm/outreach/repeat.py
@@ -40,7 +40,7 @@ from typing import Any, Dict, Optional, Tuple
 
 from app.core.logger import logger
 from app.crm.outreach.db import accessor
-from app.crm.outreach.schemas import WorkflowDefinition
+from app.crm.outreach.schemas import WorkflowEntry, WorkflowEntryAt
 
 # The words, exactly as the corpus writes them. refresh_max carries its
 # field in parentheses: refresh_max(cart_value).
@@ -112,8 +112,8 @@ def _as_number(value: Any) -> Optional[float]:
     return number if math.isfinite(number) else None
 
 
-def repeat_plan(definition: WorkflowDefinition, facts: Dict[str, Any]) -> RepeatPlan:
-    """PURE decide: given the plan's entry words and the repeat's small
+def repeat_plan(door: WorkflowEntry, facts: Dict[str, Any]) -> RepeatPlan:
+    """PURE decide: given the door's entry words and the repeat's small
     facts, what does the open run get?
 
       ignore          -> nothing in context (the alarm may still slide)
@@ -123,9 +123,9 @@ def repeat_plan(definition: WorkflowDefinition, facts: Dict[str, Any]) -> Repeat
                          new value never wins)
       accumulate      -> the facts are appended under repeat_items
     """
-    parsed = parse_repeat_policy(definition.entry.on_repeat)
+    parsed = parse_repeat_policy(door.on_repeat)
     policy, field = parsed if parsed else (POLICY_IGNORE, None)
-    debounce = float(definition.entry.debounce_minutes or 0)
+    debounce = float(door.debounce_minutes or 0)
     if policy == POLICY_REFRESH_LATEST:
         return RepeatPlan(dict(facts), False, None, None, debounce)
     if policy == POLICY_REFRESH_MAX:
@@ -142,22 +142,23 @@ async def apply_repeat(
     merchant_id: str,
     workflow_id: str,
     enrollment_key: str,
-    definition: WorkflowDefinition,
+    door: WorkflowEntryAt,
     event_id: str,
     facts: Dict[str, Any],
 ) -> bool:
-    """A refused enrol may be a repeat of an open run on the entry square.
-    Returns True when a run was patched. Zero rows is the normal answer
-    for "not a repeat" (nothing open, or the run already moved on) and
-    for a redelivered event (it marked itself used the first time)."""
-    plan = repeat_plan(definition, facts)
+    """A refused enrol may be a repeat of an open run standing on the
+    door's start square. Returns True when a run was patched. Zero rows
+    is the normal answer for "not a repeat" (nothing open, or the run
+    already moved on) and for a redelivered event (it marked itself used
+    the first time)."""
+    plan = repeat_plan(door, facts)
     if plan.is_noop:
         return False  # ignore + no debounce: exactly today's behaviour
     patched = await accessor.patch_open_run(
         merchant_id,
         workflow_id,
         enrollment_key,
-        definition.nodes[0].id,
+        door.start,
         event_id,
         plan.patch,
         plan.accumulate,
@@ -168,6 +169,6 @@ async def apply_repeat(
     if patched:
         logger.info(
             f"repeat entry applied: workflow {workflow_id} key {enrollment_key} "
-            f"policy {definition.entry.on_repeat} debounce {plan.debounce_minutes}m"
+            f"policy {door.on_repeat} debounce {plan.debounce_minutes}m"
         )
     return patched

--- a/app/crm/outreach/schemas.py
+++ b/app/crm/outreach/schemas.py
@@ -41,6 +41,28 @@ class WorkflowEntry(BaseModel):
     debounce_minutes: float = Field(0, ge=0)
 
 
+class WorkflowEntryAt(WorkflowEntry):
+    """One DOOR of a plan (rollout phase 15): the entry words plus the
+    square a run admitted through it starts on. A plan lists its doors
+    when a journey may first be seen at any stage — a customer who
+    appears at KYC starts on the KYC square, not on nodes[0]. The single
+    `entry` object is one door starting on nodes[0]."""
+
+    start: str = Field(min_length=1)
+
+
+# The admission words a plan may state ONCE at the top level for every
+# door (reenter, cooldown_hours, key, on_repeat, debounce_minutes); a door
+# may still say its own. Folded into each door before validation.
+_SHARED_ENTRY_WORDS = (
+    "reenter",
+    "cooldown_hours",
+    "key",
+    "on_repeat",
+    "debounce_minutes",
+)
+
+
 class WorkflowGoalKey(BaseModel):
     """What ties a goal letter to ONE run: the letter's payload field must
     equal the run's context field (cart_token = cart_token). Compared as
@@ -84,7 +106,10 @@ class WorkflowNode(BaseModel):
     call (template_id, via buddy's lead machine — ADR 0010) ·
     wait_event (topics + key + minutes: waits for an event OR the timer,
     whichever first; the branch taken is the edge whose `on` equals the
-    event's payload[key], or "timeout")."""
+    event's payload[key], or "timeout"). key: "$topic" (rollout phase 15)
+    branches on the event's TOPIC instead — the edge's `on` is the topic
+    string — so a stage board reads "she went to KYC" from the letter's
+    name; $topic is the only $-word."""
 
     id: str = Field(min_length=1)
     type: Literal["wait", "send", "call", "wait_event"]
@@ -103,11 +128,15 @@ WorkflowEdge = Union[Tuple[str, str], Tuple[str, str, str]]
 
 
 class WorkflowDefinition(BaseModel):
-    """THE plan, whole (canon T19). nodes[0] is the start square —
-    explicit convention, stated here once. Node ids are minted by the
-    author and never regenerated (the publish validator's first law)."""
+    """THE plan, whole (canon T19). Node ids are minted by the author and
+    never regenerated (the publish validator's first law).
 
-    entry: WorkflowEntry
+    `entry` is one door (an object — its run starts on nodes[0], the
+    explicit convention stated here once) or a LIST of doors (phase 15),
+    each naming its topic and the square its run starts on; `entries`
+    is always the list."""
+
+    entry: Union[WorkflowEntry, List[WorkflowEntryAt]]
     nodes: List[WorkflowNode] = Field(min_length=1)
     edges: List[WorkflowEdge] = Field(default_factory=list)
     goals: List[WorkflowGoal] = Field(min_length=1)
@@ -134,6 +163,32 @@ class WorkflowDefinition(BaseModel):
     # manifest; the gate checks it against the grant). Required once the
     # plan has a send node; the send node copies it onto every row.
     purpose_key: Optional[str] = None
+
+    @model_validator(mode="before")
+    @classmethod
+    def _doors_take_the_shared_words(cls, data: Any) -> Any:
+        """The admission words stated once at the top level reach every
+        door; a door's own word wins (phase 15)."""
+        if isinstance(data, dict) and any(w in data for w in _SHARED_ENTRY_WORDS):
+            data = dict(data)
+            shared = {w: data.pop(w) for w in _SHARED_ENTRY_WORDS if w in data}
+            entry = data.get("entry")
+            if isinstance(entry, list):
+                data["entry"] = [
+                    {**shared, **door} if isinstance(door, dict) else door
+                    for door in entry
+                ]
+            elif isinstance(entry, dict):
+                data["entry"] = {**shared, **entry}
+        return data
+
+    @property
+    def entries(self) -> List[WorkflowEntryAt]:
+        """The doors, in document order, one per topic. A single `entry`
+        is one door starting on nodes[0]."""
+        if isinstance(self.entry, list):
+            return list(self.entry)
+        return [WorkflowEntryAt(**self.entry.model_dump(), start=self.nodes[0].id)]
 
     @model_validator(mode="before")
     @classmethod

--- a/app/crm/outreach/walker.py
+++ b/app/crm/outreach/walker.py
@@ -33,8 +33,13 @@ from app.core.config.static import (
 from app.core.logger import logger
 from app.crm.outreach.db import accessor
 from app.crm.outreach.definitions import definition_for
-from app.crm.outreach.entry import reply_key
-from app.crm.outreach.nodes import NODE_TYPES, NodeParked, is_wait
+from app.crm.outreach.nodes import (
+    NODE_TYPES,
+    NodeParked,
+    is_wait,
+    reply_key,
+    without_reply,
+)
 from app.crm.outreach.plans import TIMEOUT
 from app.crm.outreach.schemas import EnrollmentRun, WorkflowDefinition, WorkflowNode
 from app.crm.record.contracts import customer_has_event
@@ -180,6 +185,11 @@ async def _advance(
             context.update(await execute(run, node, definition))
 
         next_id = pick_next(node, outgoing.get(current_id, []), context)
+        if node.type == "wait_event":
+            # Leaving a listening square: its answer is spent (phase 15).
+            # A door may start a run on any square, so this one can be
+            # revisited — a stale reply would resolve the revisit at once.
+            context = without_reply(context, node.id)
         if next_id is None:
             if not await accessor.exit_run(
                 str(run.id),

--- a/tests/crm/test_workflow_admission.py
+++ b/tests/crm/test_workflow_admission.py
@@ -35,33 +35,33 @@ def _definition(reenter: bool = True, cooldown_hours: float = 0.0, first_node=No
 
 
 def test_first_run_admits() -> None:
-    admit, reason = _admission(_definition(), 0, None, NOW)
+    admit, reason = _admission(_definition().entries[0], 0, None, NOW)
     assert admit and reason == "admitted"
 
 
 def test_reenter_disabled_blocks_second_run() -> None:
     admit, reason = _admission(
-        _definition(reenter=False), 1, NOW - timedelta(days=2), NOW
+        _definition(reenter=False).entries[0], 1, NOW - timedelta(days=2), NOW
     )
     assert not admit and reason == "reenter_disabled"
 
 
 def test_cooldown_blocks_inside_window() -> None:
     admit, reason = _admission(
-        _definition(cooldown_hours=24), 1, NOW - timedelta(hours=5), NOW
+        _definition(cooldown_hours=24).entries[0], 1, NOW - timedelta(hours=5), NOW
     )
     assert not admit and reason == "cooldown_active"
 
 
 def test_cooldown_admits_after_window() -> None:
     admit, reason = _admission(
-        _definition(cooldown_hours=24), 1, NOW - timedelta(hours=25), NOW
+        _definition(cooldown_hours=24).entries[0], 1, NOW - timedelta(hours=25), NOW
     )
     assert admit
 
 
 def test_first_wake_of_wait_node_is_arrival_plus_delay() -> None:
-    assert _first_wake(_definition(), NOW) == NOW + timedelta(minutes=30)
+    assert _first_wake(_definition().nodes[0], NOW) == NOW + timedelta(minutes=30)
 
 
 def test_first_wake_of_wait_event_node_is_arrival_plus_delay() -> None:
@@ -78,14 +78,14 @@ def test_first_wake_of_wait_event_node_is_arrival_plus_delay() -> None:
             "minutes": 30,
         }
     )
-    assert _first_wake(definition, NOW) == NOW + timedelta(minutes=30)
+    assert _first_wake(definition.nodes[0], NOW) == NOW + timedelta(minutes=30)
 
 
 def test_first_wake_of_action_node_is_immediate() -> None:
     definition = _definition(
         first_node={"id": "call-now", "type": "call", "template_id": "t"}
     )
-    assert _first_wake(definition, NOW) == NOW
+    assert _first_wake(definition.nodes[0], NOW) == NOW
 
 
 def test_context_passthrough_keeps_scalars_drops_structures() -> None:
@@ -230,7 +230,14 @@ def _enrol(history: _History, workflow: Workflow, key: str) -> Optional[Enrollme
     definition = WorkflowDefinition.model_validate(workflow.definition)
     return asyncio.run(
         enrol_mod._enrol_in_txn(
-            cast(DbTxn, object()), "m1", workflow, definition, CUSTOMER, {}, key
+            cast(DbTxn, object()),
+            "m1",
+            workflow,
+            definition,
+            definition.entries[0],
+            CUSTOMER,
+            {},
+            key,
         )
     )
 

--- a/tests/crm/test_workflow_entry.py
+++ b/tests/crm/test_workflow_entry.py
@@ -412,10 +412,10 @@ def test_a_repeat_is_judged_by_the_open_runs_own_version(
     monkeypatch.setattr(entry, "apply_repeat", apply_repeat)
     # v5's entry topic, but the order is A's -> the open run on v3
     _consume(_event("orders/confirmed", {"order_id": "A"}))
-    ((_, _, key, definition, _, _),) = repeats
+    ((_, _, key, door, _, _),) = repeats
     assert key == "A"
-    assert definition.entry.on_repeat == "refresh_latest"
-    assert definition.nodes[0].id == "wait-30m"
+    assert door.on_repeat == "refresh_latest"
+    assert door.start == "wait-30m"
 
 
 def test_a_run_whose_version_is_missing_is_skipped_not_fatal(
@@ -483,7 +483,9 @@ def test_enrol_stamps_the_entry_events_time_and_repeats_never_move_it(
         received_at=NOW,
         occurred_at=happened,
     )
-    asyncio.run(entry._try_enrol(_flow(), definition, event, "c-1", {}))
+    asyncio.run(
+        entry._try_enrol(_flow(), definition, definition.entries[0], event, "c-1", {})
+    )
     assert seen["enrol"]["entered_event_at"] == happened.isoformat()
     assert "entered_event_at" not in seen["repeat"]
     assert "source_event_id" not in seen["repeat"]
@@ -503,3 +505,74 @@ def test_the_alarm_path_still_times_a_listening_node_out() -> None:
     arrows: List[Tuple[str, Optional[str]]] = [("confirm", "YES"), ("call", TIMEOUT)]
     assert pick_next(node, arrows, {}) == "call"
     assert pick_next(node, arrows, {"reply_ask": "YES"}) == "confirm"
+
+
+# --- rollout phase 15: $topic branching, and a door per topic ---
+
+_LADDER: Dict[str, Any] = {
+    "entry": [
+        {"topic": "loan.profile_created", "start": "at-profile"},
+        {"topic": "loan.kyc_completed", "start": "at-kyc"},
+    ],
+    "key": "application_id",
+    "reenter": True,
+    "cooldown_hours": 0,
+    "nodes": [
+        {
+            "id": "at-profile",
+            "type": "wait_event",
+            "key": "$topic",
+            "minutes": 30,
+            "topics": ["loan.kyc_completed", "loan.bank_linked"],
+        },
+        {"id": "call-profile", "type": "call", "template_id": "tpl-p"},
+        {"id": "at-kyc", "type": "wait", "minutes": 30},
+    ],
+    "edges": [
+        ["at-profile", "at-kyc", "loan.kyc_completed"],
+        ["at-profile", "call-profile", "timeout"],
+    ],
+    "goal": {"topics": ["loan.disbursed"]},
+}
+
+
+def test_a_topic_keyed_square_wakes_with_the_topic_as_its_answer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """key: "$topic" — the branch is the event's TOPIC, not a payload
+    field, so a stage board can say "she went to KYC" from the letter's
+    name alone (§14.1 prerequisite 1)."""
+    flow = _flow(_LADDER, version=1)
+    run = _run(flow, 1, "at-profile", {"application_id": "L-1"}, key="L-1")
+    spine = _Spine([flow], [run], {(flow.id, 1): _LADDER})
+    _install(monkeypatch, spine)
+    # bank_linked is listened for at-profile but is not a door of this
+    # plan, so the letter wakes the run and starts nothing.
+    _consume(_event("loan.bank_linked", {"application_id": "L-1"}))
+    assert spine.resumes == [
+        (str(run.id), "at-profile", {"reply_at-profile": "loan.bank_linked"})
+    ]
+
+
+def test_each_door_starts_the_run_on_its_own_square(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A journey first seen at KYC enrols on the KYC square, not on
+    nodes[0] (§14.1 prerequisite 2)."""
+    flow = _flow(_LADDER, version=1)
+    spine = _Spine([flow], [], {(flow.id, 1): _LADDER})
+    _install(monkeypatch, spine)
+    doors: List[Tuple[str, str]] = []
+
+    async def enrol(**kwargs: Any) -> object:
+        doors.append((kwargs["door"].topic, kwargs["door"].start))
+        return object()
+
+    monkeypatch.setattr(entry, "enrol", enrol)
+    _consume(_event("loan.kyc_completed", {"application_id": "L-2"}))
+    _consume(_event("loan.profile_created", {"application_id": "L-3"}))
+    _consume(_event("loan.bank_linked", {"application_id": "L-4"}))  # no door
+    assert doors == [
+        ("loan.kyc_completed", "at-kyc"),
+        ("loan.profile_created", "at-profile"),
+    ]

--- a/tests/crm/test_workflow_plans.py
+++ b/tests/crm/test_workflow_plans.py
@@ -550,3 +550,125 @@ async def test_publish_holds_the_templates_it_sends_before_asking_the_registry(
     expected = WorkflowDefinition.model_validate(_SEND_PLAN).send_templates()
     assert expected and accessor.locked == [expected]
     assert accessor.order == ["lock", "ask", "publish"]
+
+
+# --- rollout phase 15: entry as a list of doors, and $topic on wait_event ---
+
+_LADDER: Dict[str, Any] = {
+    "entry": [
+        {"topic": "loan.profile_created", "start": "at-profile"},
+        {"topic": "loan.kyc_completed", "start": "at-kyc"},
+    ],
+    "reenter": True,
+    "cooldown_hours": 0,
+    "key": "application_id",
+    "nodes": [
+        {
+            "id": "at-profile",
+            "type": "wait_event",
+            "key": "$topic",
+            "minutes": 30,
+            "topics": ["loan.kyc_completed"],
+        },
+        {"id": "call-profile", "type": "call", "template_id": "tpl-p"},
+        {"id": "at-kyc", "type": "wait", "minutes": 30},
+        {"id": "call-kyc", "type": "call", "template_id": "tpl-k"},
+    ],
+    "edges": [
+        ["at-profile", "at-kyc", "loan.kyc_completed"],
+        ["at-profile", "call-profile", "timeout"],
+        ["at-kyc", "call-kyc"],
+    ],
+    "goal": {"topics": ["loan.disbursed"]},
+}
+
+
+def test_entry_as_a_list_of_doors_validates_and_a_single_entry_still_does() -> None:
+    assert validate_definition(_LADDER) == []
+    doors = WorkflowDefinition.model_validate(_LADDER).entries
+    assert [(d.topic, d.start) for d in doors] == [
+        ("loan.profile_created", "at-profile"),
+        ("loan.kyc_completed", "at-kyc"),
+    ]
+    # the shared words at the top level reach every door
+    assert all(
+        d.reenter and d.cooldown_hours == 0 and d.key == "application_id" for d in doors
+    )
+    # a door may override them
+    overridden = {
+        **_LADDER,
+        "entry": [{**_LADDER["entry"][0], "cooldown_hours": 2}, _LADDER["entry"][1]],
+    }
+    d0, d1 = WorkflowDefinition.model_validate(overridden).entries
+    assert (d0.cooldown_hours, d1.cooldown_hours) == (2, 0)
+    # a single-entry plan is one door starting on nodes[0]
+    (door,) = WorkflowDefinition.model_validate(_definition()).entries
+    assert (door.topic, door.start) == ("checkout.initiated", "wait-30m")
+    assert validate_definition(_definition()) == []
+
+
+def test_a_plan_needs_at_least_one_door() -> None:
+    """An empty door list would parse, publish, and never start a run —
+    and enrol() has no first door to fall back on."""
+    problems = validate_definition({**_LADDER, "entry": []})
+    assert any("at least one door" in p for p in problems)
+
+
+def test_a_door_must_start_on_a_real_square_and_topics_must_be_unique() -> None:
+    bad_start = {
+        **_LADDER,
+        "entry": [{"topic": "loan.profile_created", "start": "nowhere"}],
+    }
+    problems = validate_definition(bad_start)
+    assert any("nowhere" in p and "start" in p for p in problems)
+    twice = {
+        **_LADDER,
+        "entry": [
+            {"topic": "loan.profile_created", "start": "at-profile"},
+            {"topic": "loan.profile_created", "start": "at-kyc"},
+        ],
+    }
+    problems = validate_definition(twice)
+    assert any("loan.profile_created" in p and "twice" in p for p in problems)
+
+
+def test_topic_is_the_only_dollar_word_a_wait_event_may_branch_on() -> None:
+    assert validate_definition(_LADDER) == []
+    other = {
+        **_LADDER,
+        "nodes": [{**_LADDER["nodes"][0], "key": "$payload"}] + _LADDER["nodes"][1:],
+    }
+    problems = validate_definition(other)
+    assert any("$payload" in p and "$topic" in p for p in problems)
+
+
+def test_debounce_needs_a_wait_at_each_doors_own_start() -> None:
+    bouncing = {
+        **_LADDER,
+        "entry": [
+            {
+                "topic": "loan.profile_created",
+                "start": "call-profile",
+                "debounce_minutes": 10,
+            },
+            {"topic": "loan.kyc_completed", "start": "at-kyc", "debounce_minutes": 10},
+        ],
+    }
+    problems = validate_definition(bouncing)
+    assert any("loan.profile_created" in p and "alarm" in p for p in problems)
+    assert not any("loan.kyc_completed" in p for p in problems)
+
+
+def test_the_migrate_guard_compares_doors_as_a_list() -> None:
+    live = _LADDER["entry"]
+    same = {**_LADDER, "on_publish": "migrate"}
+    assert validate_definition(same, occupied_nodes=["at-kyc"], live_entry=live) == []
+    moved = {
+        **same,
+        "entry": [
+            _LADDER["entry"][0],
+            {"topic": "loan.kyc_completed", "start": "call-kyc"},
+        ],
+    }
+    problems = validate_definition(moved, occupied_nodes=["at-kyc"], live_entry=live)
+    assert any("entry rule changed" in p for p in problems)

--- a/tests/crm/test_workflow_repeat.py
+++ b/tests/crm/test_workflow_repeat.py
@@ -5,7 +5,7 @@ laws, and the validator's two entry rules."""
 import asyncio
 import json
 from datetime import datetime, timezone
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Tuple
 
 import pytest
 
@@ -14,9 +14,20 @@ from app.crm.outreach import repeat
 from app.crm.outreach.db.queries import patch_open_run_query
 from app.crm.outreach.plans import validate_definition
 from app.crm.outreach.repeat import parse_repeat_policy, repeat_plan
-from app.crm.outreach.schemas import WorkflowDefinition
+from app.crm.outreach.schemas import WorkflowDefinition, WorkflowEntryAt
 
 _NOW = datetime(2026, 9, 3, 10, 0, tzinfo=timezone.utc)
+
+
+def _door(**entry_words: Any) -> Any:
+    """The plan's one door (phase 15): its entry words + start square."""
+    return _definition(**entry_words).entries[0]
+
+
+def _with_door(
+    definition: WorkflowDefinition,
+) -> Tuple[WorkflowDefinition, WorkflowEntryAt]:
+    return definition, definition.entries[0]
 
 
 def _definition(**entry_words: Any) -> WorkflowDefinition:
@@ -50,7 +61,7 @@ def test_vocabulary_is_the_corpus_four() -> None:
 
 
 def test_defaults_are_todays_behaviour() -> None:
-    plan = repeat_plan(_definition(), {"cart_value": 800})
+    plan = repeat_plan(_door(), {"cart_value": 800})
     assert plan.is_noop  # ignore + debounce 0 -> no statement at all
 
 
@@ -58,14 +69,14 @@ def test_defaults_are_todays_behaviour() -> None:
 
 
 def test_refresh_latest_always_takes_the_new_facts() -> None:
-    plan = repeat_plan(_definition(on_repeat="refresh_latest"), {"cart_value": 300})
+    plan = repeat_plan(_door(on_repeat="refresh_latest"), {"cart_value": 300})
     assert plan.patch == {"cart_value": 300} and plan.max_field is None
     assert not plan.accumulate and not plan.is_noop
 
 
 def test_refresh_max_names_the_field_and_the_number() -> None:
     plan = repeat_plan(
-        _definition(on_repeat="refresh_max(cart_value)"), {"cart_value": "4500"}
+        _door(on_repeat="refresh_max(cart_value)"), {"cart_value": "4500"}
     )
     assert plan.max_field == "cart_value" and plan.max_value == 4500.0
     assert plan.patch == {"cart_value": "4500"}
@@ -73,7 +84,7 @@ def test_refresh_max_names_the_field_and_the_number() -> None:
 
 def test_refresh_max_with_a_non_numeric_value_never_wins() -> None:
     plan = repeat_plan(
-        _definition(on_repeat="refresh_max(cart_value)", debounce_minutes=10),
+        _door(on_repeat="refresh_max(cart_value)", debounce_minutes=10),
         {"cart_value": "n/a"},
     )
     assert plan.patch == {} and plan.max_field is None
@@ -81,12 +92,12 @@ def test_refresh_max_with_a_non_numeric_value_never_wins() -> None:
 
 
 def test_accumulate_appends() -> None:
-    plan = repeat_plan(_definition(on_repeat="accumulate"), {"order_id": "B"})
+    plan = repeat_plan(_door(on_repeat="accumulate"), {"order_id": "B"})
     assert plan.accumulate and plan.patch == {"order_id": "B"}
 
 
 def test_ignore_with_debounce_slides_without_touching_facts() -> None:
-    plan = repeat_plan(_definition(debounce_minutes=5), {"cart_value": 1})
+    plan = repeat_plan(_door(debounce_minutes=5), {"cart_value": 1})
     assert plan.patch == {} and plan.debounce_minutes == 5 and not plan.is_noop
 
 
@@ -196,10 +207,11 @@ def test_a_refused_enrol_hands_the_repeat_to_apply_repeat(
             },
         },
     )()
-    asyncio.run(entry._try_enrol(flow, definition, event, "cust-1"))
-    ((merchant, wf, key, defn, event_id, facts),) = calls
+    asyncio.run(entry._try_enrol(flow, *_with_door(definition), event, "cust-1"))
+    ((merchant, wf, key, door, event_id, facts),) = calls
     assert (merchant, wf, key, event_id) == ("m1", "wf-1", "ORD-1", "ev-9")
-    assert facts["cart_value"] == 900 and defn is definition
+    assert facts["cart_value"] == 900
+    assert (door.on_repeat, door.start) == ("refresh_latest", "wait_10m")
 
 
 def test_a_successful_enrol_never_calls_apply_repeat(
@@ -228,7 +240,11 @@ def test_a_successful_enrol_never_calls_apply_repeat(
             "payload": {},
         },
     )()
-    asyncio.run(entry._try_enrol(flow, _definition(on_repeat="accumulate"), event, "c"))
+    asyncio.run(
+        entry._try_enrol(
+            flow, *_with_door(_definition(on_repeat="accumulate")), event, "c"
+        )
+    )
     assert calls == []
 
 
@@ -267,7 +283,7 @@ def test_refresh_max_ignores_non_finite_numbers() -> None:
         assert repeat._as_number(junk) is None, junk
     assert repeat._as_number("4500") == 4500.0 and repeat._as_number(12) == 12.0
     plan = repeat_plan(
-        _definition(on_repeat="refresh_max(cart_value)"), {"cart_value": "inf"}
+        _door(on_repeat="refresh_max(cart_value)"), {"cart_value": "inf"}
     )
     assert plan.patch == {} and plan.max_field is None
 
@@ -321,7 +337,9 @@ def test_the_repeat_carries_the_refreshed_phone_but_never_the_founding_id(
         },
     )()
     asyncio.run(
-        entry._try_enrol(flow, _definition(on_repeat="refresh_latest"), event, "c")
+        entry._try_enrol(
+            flow, *_with_door(_definition(on_repeat="refresh_latest")), event, "c"
+        )
     )
     ((_, _, _, _, _, facts),) = calls
     assert facts["phone"] == "+919876543210"

--- a/tests/crm/test_workflow_walker.py
+++ b/tests/crm/test_workflow_walker.py
@@ -399,3 +399,40 @@ def test_the_cache_is_bounded_and_evicts_the_least_recently_used(
 
     asyncio.run(read_in_order())
     assert [version for _, _, version in writes.definition_reads] == [1, 2, 3, 2]
+
+
+# --- rollout phase 15: a reply is cleared when the token leaves the square ---
+
+_ASK_TWICE = {
+    "entry": {"topic": "orders/create"},
+    "nodes": [
+        {
+            "id": "ask",
+            "type": "wait_event",
+            "topics": ["button.reply"],
+            "key": "button_id",
+            "minutes": 60,
+        },
+        {"id": "wait-1d", "type": "wait", "minutes": 1440},
+    ],
+    "edges": [["ask", "wait-1d", "YES"], ["ask", "wait-1d", "timeout"]],
+    "goal": {"topics": ["order.confirmed"]},
+}
+
+
+def test_advancing_off_a_listening_square_clears_its_reply(
+    monkeypatch: pytest.MonkeyPatch, no_goal: None
+) -> None:
+    """Once a door may start a run anywhere, a square can be revisited;
+    a stale reply_<node> left in context would resolve the revisit at
+    once on an old answer (§14.1 prerequisite 4)."""
+    writes = _Writes(matched=True, definition=_ASK_TWICE)
+    _install(monkeypatch, writes)
+    run = _run()
+    run.current_node = "ask"
+    run.context = {"phone": "+919876543210", "reply_ask": "YES", "order_id": "O-1"}
+    _advance(writes, run)
+    ((verb, args),) = writes.calls
+    assert verb == "advance" and args[1] == "wait-1d"
+    written = args[3]
+    assert "reply_ask" not in written and written["order_id"] == "O-1"


### PR DESCRIPTION
## Rollout phase 15 — `docs/crm/workflow-rollout/15-topic-branching-and-multi-entry.md`

Depends on 01 and 13 (both merged). Notes §14.1 prerequisites (1), (2), (4). No migration.

### What changed

| Piece | Files | Change |
|---|---|---|
| **1. `key: "$topic"`** | `nodes.py`, `entry.py`, `schemas.py` | `_wake_on_reply` records `event.topic` as the answer when the square's key is `$topic`; `pick_next` is unchanged (the edge's `on` is the topic string). `_validate_wait_event` refuses any other `$`-word. `TOPIC_KEY` and the docstring on `WorkflowNode` say so. |
| **2. Doors** | `schemas.py`, `plans.py`, `enrol.py`, `entry.py`, `repeat.py` | `WorkflowEntryAt = WorkflowEntry + start`; `WorkflowDefinition.entry: Union[WorkflowEntry, List[WorkflowEntryAt]]`; `entries` is always the list (a single object → one door starting on `nodes[0]`). A before-validator folds the top-level shared words into every door (a door's own word wins). Validator: every `start` is a node, topics unique across doors, `on_repeat` vocabulary and the debounce-needs-a-wait law judged per door at its own start. `enrol(..., door=)` takes the door: admission words from it, `current_node = door.start`, first alarm from that square. The consumer matches doors (one per topic, so it breaks on the first). `_enrollment_key(door, …)`. `apply_repeat` takes the door (`on_repeat`, `debounce`, and patches the run standing on `door.start`); `_repeat_door` resolves it in the open run's own version (that version's door for the topic, else its first door — the patch's `current_node = start` guard makes a wrong square a no-op). `_entry_changed` compares doors as a sorted list; a single object compares as a door with no explicit start. |
| **3. Reply clearing** | `nodes.py`, `walker.py` | `reply_key` moved from `entry.py` to `nodes.py` (both entry and walker import it from there — no more walker→entry import); `without_reply(context, node_id)` beside `run_facts`. `_advance` clears the square's reply the moment the token leaves a `wait_event` node, so the advance/exit write carries no stale answer. |

### Red tests (fail on release, pass here)

- Schema/validator (`test_workflow_plans.py`): an empty door list is refused (it would parse, publish and never start a run); a door list validates and a single entry still does (and is one door on `nodes[0]`); shared words reach every door and a door may override; a bad `start` and a duplicate topic are refused; `$payload` refused, `$topic` accepted; debounce judged at each door's own start; the migrate guard compares doors as a list (same list passes, a moved start refuses).
- Consumer (`test_workflow_entry.py`): a `$topic` square wakes with the topic as its answer; each door enrols on its own square (and a listened-for topic that is not a door starts nothing).
- Walker (`test_workflow_walker.py`): advancing off `ask` writes a context without `reply_ask`, other facts intact.

On release: 8 failed, 59 passed in those three files.

### Checks (strictly `&&`-chained, pytest to a log)

black, isort, autoflake clean · pyrefly 0 errors · **`pytest tests/crm`: 651 passed** (642 on release + 9) · `check_crm_boundaries.py` clean · `check_migrations.py --base origin/release`: 64, no duplicates, no gaps. `docs/crm/plans/*.json` still validate (phase 07's test, in the suite).

### Decisions already made that I disagree with

None.

### Judgment calls (overrule if you want)

- **Object vs list spelling of the same topic reads as a different door** in the migrate-mode entry guard (a single object has no explicit start). Conservative: under migrate with open runs that is a refusal, and pin is the way out. Comparing them equal would need the live document's nodes, which the guard is not handed.
- **A repeat whose topic the open run's version has no door for** uses that version's first door. The patch's `current_node = start` guard turns a wrong square into a no-op, so this can never patch the wrong run.
- **The shared words are folded into the doors at parse time and not kept as top-level fields**, so the model has one place for admission words. The stored document keeps whatever spelling the author wrote.
- **`_first_wake` and `_admission` now take the door/start node rather than the definition.** The existing tests were updated to pass `.entries[0]` / `.nodes[0]`; the semantics are unchanged for single-entry plans.

### Not done on purpose

- Facts on resume, `current_stage`, parked runs movable, restart-on-repeat anywhere (phase 16). The `stages` ladder sugar (phase 17).
- No runbook or plan document changes: today's documents are single-entry and keep validating; the loan board gets its doors in phase 17.

### Adjacent observations (not touched)

- Same as before: `docs/crm/plans/README.md` still promises `on_publish: migrate` on the cart board; the notes still say `/crm/...`; phase files 10/11 say "ADR 0022".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014UNZ4z7zb87HnNHjTXoFpW

