### PR TITLE
feat(assist): clairvoyance-owned widget config — appearance, storefront resolve, bare S2S onboard

### DIFF
--- a/app/ai/voice/agents/breeze_buddy/assist/commerce/assist_onboarding.py
+++ b/app/ai/voice/agents/breeze_buddy/assist/commerce/assist_onboarding.py
@@ -14,10 +14,18 @@ from uuid import uuid4
 
 from pydantic import ValidationError
 
+from app.ai.voice.agents.breeze_buddy.assist.commerce.tenancy import (
+    assist_tenant,
+    normalize_merchant_domain,
+)
 from app.ai.voice.agents.breeze_buddy.chat.sse import SSEEvent
 from app.ai.voice.agents.breeze_buddy.template.cache import invalidate_template
 from app.ai.voice.agents.breeze_buddy.template.types import TemplateModel
 from app.core.logger import logger
+from app.database.accessor.breeze_buddy.merchants import (
+    create_merchant,
+    get_merchant_by_merchant_identifier,
+)
 from app.database.accessor.breeze_buddy.template import (
     create_template,
     delete_template_if_not_referenced,
@@ -34,6 +42,8 @@ from app.schemas.breeze_buddy.assist_onboarding import (
     AssistOnboardingCompletion,
     AssistOnboardingError,
     AssistOnboardingStreamRequest,
+    AssistOnboardRequest,
+    AssistOnboardResponse,
 )
 from app.schemas.breeze_buddy.widget_config import WidgetConfigResponse
 from app.services.scraper.website.exceptions import (
@@ -308,7 +318,9 @@ async def _update_template(template: TemplateModel) -> TemplateModel:
 
 
 async def _create_widget(
-    body: AssistOnboardingStreamRequest, template_id: str
+    body: AssistOnboardingStreamRequest,
+    template_id: str,
+    appearance: Optional[Dict[str, Any]] = None,
 ) -> WidgetConfigResponse:
     created = await create_widget_config(
         reseller_id=body.reseller_id,
@@ -321,6 +333,7 @@ async def _create_widget(
         max_concurrent_per_ip=4,
         max_voice_sessions_per_ip_hour=10,
         active=body.is_active,
+        appearance=appearance,
     )
     if created is None:
         raise OnboardingFailure(
@@ -333,13 +346,17 @@ async def _create_widget(
 
 
 async def _update_widget(
-    widget: WidgetConfigResponse, body: AssistOnboardingStreamRequest, template_id: str
+    widget: WidgetConfigResponse,
+    body: AssistOnboardingStreamRequest,
+    template_id: str,
+    appearance: Optional[Dict[str, Any]] = None,
 ) -> WidgetConfigResponse:
     updated = await update_widget_config(
         widget.id,
         template_id=template_id,
         allowed_origins=body.allowed_origins,
         active=body.is_active,
+        appearance=appearance,
     )
     if updated is None:
         raise OnboardingFailure(
@@ -364,7 +381,191 @@ def _widget_payload(widget: WidgetConfigResponse) -> Dict[str, Any]:
         "max_concurrent_per_ip": widget.max_concurrent_per_ip,
         "max_voice_sessions_per_ip_hour": widget.max_voice_sessions_per_ip_hour,
         "active": widget.active,
+        "appearance": widget.appearance,
     }
+
+
+# What the brand-identity marker resolves to when the merchant has not
+# personalized yet. Honest with the model: no invented brand facts; the
+# live commerce tools are the only ground truth until the dashboard run.
+_BARE_WEBSITE_CONTEXT = (
+    "(No verified website context yet — this assistant has not been "
+    "personalized. Ground every catalog, price, and policy claim in live "
+    "commerce tool results; do not invent brand facts. The merchant can "
+    "personalize this assistant from the Buddy dashboard.)"
+)
+
+
+async def _ensure_assist_merchant(
+    reseller_id: str, merchant_id: str, merchant_domain: str, merchant_name: str
+) -> bool:
+    """Create the Assist merchant row if missing. Returns True when created.
+
+    Races with a concurrent install are settled by the PK: on a create
+    failure we re-check existence and treat "someone else won" as success.
+    """
+    existing = await get_merchant_by_merchant_identifier(merchant_id)
+    if existing is not None:
+        return False
+    try:
+        created = await create_merchant(
+            merchant_id=merchant_id,
+            reseller_id=reseller_id,
+            name=merchant_name,
+            description=f"Buddy Assist merchant - {merchant_domain}",
+            is_active=True,
+        )
+        if created is not None:
+            return True
+    except Exception:
+        pass
+    if await get_merchant_by_merchant_identifier(merchant_id) is not None:
+        return False
+    raise OnboardingFailure(
+        "ensuring_merchant",
+        "ONBOARDING_PERSISTENCE_FAILED",
+        "Could not create the Assist merchant.",
+        True,
+    )
+
+
+async def onboard_assist_bare(body: AssistOnboardRequest) -> AssistOnboardResponse:
+    """Bare-metal install-time onboarding: merchant + blueprint template +
+    widget config, idempotently — and NO website scraping.
+
+    Same state machine as ``stream_assist_onboarding`` (widget row is the
+    source of truth; created / updated / recovered; template rollback on
+    widget-create failure) minus the personalization step: the brand
+    marker resolves to a placeholder that points the model at live tool
+    results, and the merchant personalizes later from the Buddy dashboard.
+    Raises ``OnboardingFailure``; the route maps it to HTTP.
+    """
+    merchant_domain = normalize_merchant_domain(body.merchant_domain)
+    reseller_id, merchant_id = assist_tenant(body.host_app, merchant_domain)
+    merchant_name = body.merchant_name or merchant_domain.removesuffix(".myshopify.com")
+    origins = [f"https://{merchant_domain}"] + [
+        origin
+        for origin in body.allowed_origins
+        if origin != f"https://{merchant_domain}"
+    ]
+    appearance = (
+        body.appearance.model_dump(exclude_none=True)
+        if body.appearance is not None
+        else None
+    )
+
+    internal = AssistOnboardingStreamRequest(
+        reseller_id=reseller_id,
+        merchant_id=merchant_id,
+        merchant_name=merchant_name,
+        website_url=f"https://{merchant_domain}",
+        is_shopify=True,
+        allowed_origins=origins,
+        bot_brand_name=body.bot_brand_name,
+        is_active=body.is_active,
+    )
+
+    merchant_created = await _ensure_assist_merchant(
+        reseller_id, merchant_id, merchant_domain, merchant_name
+    )
+
+    widget = await get_widget_config_by_reseller_merchant(
+        internal.reseller_id, internal.merchant_id
+    )
+    template_name = _template_name(internal.merchant_name)
+    existing_template: Optional[TemplateModel] = None
+    operation: Literal["created", "updated", "recovered"]
+
+    if widget is not None:
+        operation = "updated"
+        existing_template = await get_template_by_id(widget.template_id)
+        if existing_template is None:
+            raise OnboardingFailure(
+                "checking_widget",
+                "ONBOARDING_STATE_INVALID",
+                "The widget references a missing template.",
+            )
+        if (
+            existing_template.reseller_id != internal.reseller_id
+            or existing_template.merchant_id != internal.merchant_id
+        ):
+            raise OnboardingFailure(
+                "checking_widget",
+                "ONBOARDING_STATE_INVALID",
+                "The widget references a template outside its tenant scope.",
+            )
+    else:
+        existing_template = await get_template_in_scope(
+            internal.reseller_id, internal.merchant_id, template_name
+        )
+        operation = "recovered" if existing_template else "created"
+
+    # An existing template is NEVER rebuilt here: it may carry dashboard
+    # customization or a personalized prompt, and a reinstall must not wipe
+    # that back to bare-metal. The blueprint is consulted only when a
+    # template has to be created — so already-provisioned tenants keep
+    # working even before the blueprint row exists for this reseller.
+    created_template_id: Optional[str] = None
+    if existing_template is None:
+        default_template = await get_template_in_scope(
+            internal.reseller_id, None, DEFAULT_ASSIST_TEMPLATE_NAME
+        )
+        if default_template is None:
+            raise OnboardingFailure(
+                "loading_default_template",
+                "DEFAULT_TEMPLATE_NOT_FOUND",
+                "The default Assist template is not configured for this reseller.",
+            )
+        _validate_default_template(default_template)
+
+        candidate = build_merchant_template(
+            default_template=default_template,
+            body=internal,
+            website_context=_BARE_WEBSITE_CONTEXT,
+            template_id=str(uuid4()),
+            existing_template=None,
+        )
+        persisted_template = await _create_template(candidate)
+        created_template_id = persisted_template.id
+    else:
+        persisted_template = existing_template
+
+    if widget is None:
+        try:
+            persisted_widget = await _create_widget(
+                internal, persisted_template.id, appearance=appearance
+            )
+        except Exception:
+            if created_template_id:
+                try:
+                    await delete_template_if_not_referenced(created_template_id)
+                except Exception as cleanup_error:
+                    logger.warning(
+                        f"Assist onboarding cleanup failed for template "
+                        f"{created_template_id}: {cleanup_error}"
+                    )
+            raise
+    else:
+        persisted_widget = await _update_widget(
+            widget, internal, persisted_template.id, appearance=appearance
+        )
+
+    if created_template_id:
+        try:
+            await invalidate_template(persisted_template.id)
+        except Exception as cache_error:
+            logger.warning(
+                f"Assist template cache invalidation failed for "
+                f"{persisted_template.id}: {cache_error}"
+            )
+
+    return AssistOnboardResponse(
+        operation=operation,
+        merchant_created=merchant_created,
+        template_id=persisted_template.id,
+        template_name=persisted_template.name,
+        widget_config=_widget_payload(persisted_widget),
+    )
 
 
 async def stream_assist_onboarding(
@@ -560,6 +761,8 @@ __all__ = [
     "DEFAULT_ASSIST_TEMPLATE_NAME",
     "SHOPIFY_OPERATING_END_MARKER",
     "SHOPIFY_OPERATING_START_MARKER",
+    "OnboardingFailure",
     "build_merchant_template",
+    "onboard_assist_bare",
     "stream_assist_onboarding",
 ]

--- a/app/ai/voice/agents/breeze_buddy/assist/commerce/tenancy.py
+++ b/app/ai/voice/agents/breeze_buddy/assist/commerce/tenancy.py
@@ -1,0 +1,70 @@
+"""Assist tenancy convention: how a merchant's storefront domain maps to a tenant.
+
+The RESELLER is decided by which host Shopify app installed Assist:
+
+- ``breeze-buddy`` (the voice app's Assist tab) → reseller ``BB_SHOPIFY``
+  with the PLAIN domain as merchant id — the same merchant row as the
+  voice registration. Every pre-existing live Assist tenant has this
+  shape.
+- ``buddy-assist`` (the standalone Assist app) → reseller ``BB_ASSIST``
+  with an ``assist-`` prefixed merchant id. The prefix is required:
+  ``merchants.merchant_identifier`` is a GLOBAL primary key, so a plain
+  domain under BB_ASSIST would collide with the shop's voice row.
+
+The storefront loader knows only the domain, not the host app, so
+domain-only lookups (the public storefront-config resolve) probe both
+namespaces via ``assist_tenant_candidates`` — the standalone app's
+tenant wins when both exist.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Literal, Tuple
+
+AssistHostApp = Literal["buddy-assist", "breeze-buddy"]
+
+_ASSIST_MERCHANT_PREFIX = "assist-"
+
+# Hostname labels: letters/digits/hyphens separated by dots. Deliberately
+# mechanical — this is input hygiene for a public query param, not domain
+# ontology.
+_MERCHANT_DOMAIN_RE = re.compile(
+    r"^(?=.{4,253}$)[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)+$"
+)
+
+
+def normalize_merchant_domain(merchant_domain: str) -> str:
+    """Lowercased bare hostname, or ``ValueError`` for anything else."""
+    candidate = (merchant_domain or "").strip().lower().rstrip(".")
+    if candidate.startswith("https://"):
+        candidate = candidate[len("https://") :]
+    candidate = candidate.split("/", 1)[0]
+    if not _MERCHANT_DOMAIN_RE.match(candidate):
+        raise ValueError(
+            "merchant_domain must be a bare domain, e.g. acme.myshopify.com"
+        )
+    return candidate
+
+
+def assist_tenant(host_app: AssistHostApp, merchant_domain: str) -> Tuple[str, str]:
+    """(reseller_id, merchant_id) for a host app's Assist tenant."""
+    if host_app == "breeze-buddy":
+        return "BB_SHOPIFY", merchant_domain
+    return "BB_ASSIST", f"{_ASSIST_MERCHANT_PREFIX}{merchant_domain}"
+
+
+def assist_tenant_candidates(merchant_domain: str) -> Tuple[Tuple[str, str], ...]:
+    """Lookup order for domain-only resolution: standalone app first."""
+    return (
+        assist_tenant("buddy-assist", merchant_domain),
+        assist_tenant("breeze-buddy", merchant_domain),
+    )
+
+
+__all__ = [
+    "AssistHostApp",
+    "assist_tenant",
+    "assist_tenant_candidates",
+    "normalize_merchant_domain",
+]

--- a/app/api/routers/breeze_buddy/assist_onboarding/__init__.py
+++ b/app/api/routers/breeze_buddy/assist_onboarding/__init__.py
@@ -4,11 +4,17 @@ from __future__ import annotations
 
 from typing import AsyncIterator
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException, status
 from fastapi.responses import StreamingResponse
 
 from app.ai.voice.agents.breeze_buddy.assist.commerce.assist_onboarding import (
+    OnboardingFailure,
+    onboard_assist_bare,
     stream_assist_onboarding,
+)
+from app.ai.voice.agents.breeze_buddy.assist.commerce.tenancy import (
+    assist_tenant,
+    normalize_merchant_domain,
 )
 from app.ai.voice.agents.breeze_buddy.chat.sse import format_sse
 from app.api.security.breeze_buddy.authorization import (
@@ -18,7 +24,11 @@ from app.api.security.breeze_buddy.authorization import (
 from app.api.security.breeze_buddy.rbac_token import get_current_user_with_rbac
 from app.core.security.authorization import require_role
 from app.schemas import UserInfo, UserRole
-from app.schemas.breeze_buddy.assist_onboarding import AssistOnboardingStreamRequest
+from app.schemas.breeze_buddy.assist_onboarding import (
+    AssistOnboardingStreamRequest,
+    AssistOnboardRequest,
+    AssistOnboardResponse,
+)
 
 router = APIRouter()
 
@@ -47,6 +57,44 @@ async def onboard_assist_stream(
             "Connection": "keep-alive",
         },
     )
+
+
+@router.post("/assist/onboard", response_model=AssistOnboardResponse)
+async def onboard_assist(
+    body: AssistOnboardRequest,
+    current_user: UserInfo = Depends(get_current_user_with_rbac),
+) -> AssistOnboardResponse:
+    """Bare-metal install-time onboarding (S2S, no personalization).
+
+    Same RBAC posture as the stream route; tenancy is derived
+    server-side from ``host_app`` + ``merchant_domain`` (breeze-buddy →
+    BB_SHOPIFY/plain domain; buddy-assist → BB_ASSIST/assist-prefixed),
+    so access is validated against the DERIVED ids — a caller cannot
+    smuggle a different namespace in.
+    """
+    require_role(current_user, [UserRole.ADMIN, UserRole.RESELLER])
+    try:
+        merchant_domain = normalize_merchant_domain(body.merchant_domain)
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)
+        ) from exc
+    reseller_id, merchant_id = assist_tenant(body.host_app, merchant_domain)
+    validate_reseller_access(current_user, reseller_id=reseller_id)
+    validate_merchant_access(current_user, merchant_id=merchant_id)
+
+    try:
+        return await onboard_assist_bare(body)
+    except OnboardingFailure as exc:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail={
+                "step": exc.step,
+                "code": exc.code,
+                "message": exc.message,
+                "retryable": exc.retryable,
+            },
+        ) from exc
 
 
 __all__ = ["router"]

--- a/app/api/routers/breeze_buddy/widget/__init__.py
+++ b/app/api/routers/breeze_buddy/widget/__init__.py
@@ -2,6 +2,7 @@
 
 Routes under ``/agent/voice/breeze-buddy/widget``:
 
+- ``GET  /widget/storefront-config``                    resolve merchant domain → config
 - ``POST /widget/session``                              create
 - ``POST /widget/session/{id}/message``                 chat turn (SSE)
 - ``POST /widget/session/{id}/intent``                  typed UI intent (SSE)
@@ -43,6 +44,7 @@ from app.schemas.breeze_buddy.chat import (
     WidgetVoiceConnectResponse,
     WidgetVoiceEndResponse,
 )
+from app.schemas.breeze_buddy.widget_config import StorefrontWidgetConfigResponse
 
 from .handlers import (
     approve_widget_tool_handler,
@@ -57,6 +59,7 @@ from .handlers import (
     voice_connect_handler,
     voice_end_handler,
 )
+from .storefront import storefront_widget_config_handler
 
 router = APIRouter(prefix="/widget", tags=["widget-session"])
 
@@ -64,6 +67,11 @@ router = APIRouter(prefix="/widget", tags=["widget-session"])
 # ---------------------------------------------------------------------------
 # CORS preflight (transport layer — application allowlist runs in handlers)
 # ---------------------------------------------------------------------------
+
+
+@router.options("/storefront-config")
+async def widget_storefront_config_preflight() -> Response:
+    return options_cors_response()
 
 
 @router.options("/session")
@@ -124,6 +132,17 @@ async def widget_end_preflight(session_id: str) -> Response:
 # ---------------------------------------------------------------------------
 # Public — auth via public_widget_key + Origin + per-IP rate limit
 # ---------------------------------------------------------------------------
+
+
+@router.get(
+    "/storefront-config",
+    response_model=StorefrontWidgetConfigResponse,
+    summary="Resolve a merchant's storefront domain to its Assist widget config + appearance",
+)
+async def get_storefront_widget_config(
+    request: Request, merchant_domain: str
+) -> StorefrontWidgetConfigResponse:
+    return await storefront_widget_config_handler(request, merchant_domain)
 
 
 @router.post(

--- a/app/api/routers/breeze_buddy/widget/storefront.py
+++ b/app/api/routers/breeze_buddy/widget/storefront.py
@@ -1,0 +1,127 @@
+"""Public storefront-config resolve for the Assist widget.
+
+The theme-extension loader on a merchant's storefront calls this on page
+view to learn whether the widget is enabled for the merchant and how to dress
+it. It is the only widget endpoint keyed by the MERCHANT'S STOREFRONT
+DOMAIN rather than by ``public_widget_key`` — the loader knows nothing
+but the domain it runs on; the key is part of this endpoint's ANSWER,
+not its input.
+
+Trust model mirrors ``POST /widget/session``: anonymous, but the caller's
+Origin must be in the row's ``allowed_origins`` and per-IP rate limits
+apply. Unknown merchant, inactive row and origin mismatch are indistinguishable
+to the caller (404/403 with no detail) so the door isn't enumerable.
+"""
+
+from __future__ import annotations
+
+from fastapi import HTTPException, Request, status
+
+from app.ai.voice.agents.breeze_buddy.assist.commerce.tenancy import (
+    assist_tenant_candidates,
+    normalize_merchant_domain,
+)
+from app.api.routers.breeze_buddy.widget_common import (
+    client_ip,
+    enforce_widget_ip_limit,
+    enforce_widget_origin,
+)
+from app.core.logger import logger
+from app.database.accessor.breeze_buddy.widget_config import (
+    get_widget_config_by_reseller_merchant,
+)
+from app.schemas.breeze_buddy.widget_config import StorefrontWidgetConfigResponse
+from app.services.redis.rate_limit import check_rate_limit
+
+_CACHE_TTL_SECONDS = 900
+
+# Pre-lookup probe cap. The merchant-scoped limiter below can only run AFTER
+# a config resolves (it is keyed by widget_config_id), which would leave
+# unknown-domain probes as unbounded free DB lookups for an anonymous
+# caller. This fixed per-IP cap bounds them. Generous on purpose: a real
+# shopper hits this endpoint only on loader cache-miss (~4/shop/hour).
+_PROBE_LIMIT_PER_IP_HOUR = 600
+_PROBE_WINDOW_SECONDS = 3600
+
+
+async def _enforce_probe_ip_limit(request: Request) -> None:
+    decision = await check_rate_limit(
+        bucket="storefront_probe",
+        identifier=client_ip(request),
+        limit=_PROBE_LIMIT_PER_IP_HOUR,
+        window_seconds=_PROBE_WINDOW_SECONDS,
+        prefix="widget",
+        fail_closed=True,
+    )
+    if decision.allowed:
+        return
+    raise HTTPException(
+        status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+        detail=(
+            f"Widget rate limit hit ({decision.count}/{decision.limit} per hour). "
+            "Try again later."
+        ),
+        headers={"Retry-After": str(decision.retry_after_seconds)},
+    )
+
+
+async def storefront_widget_config_handler(
+    request: Request, merchant_domain: str
+) -> StorefrontWidgetConfigResponse:
+    try:
+        normalized_domain = normalize_merchant_domain(merchant_domain)
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)
+        ) from exc
+
+    # Before any DB read — see _PROBE_LIMIT_PER_IP_HOUR.
+    await _enforce_probe_ip_limit(request)
+
+    # The loader knows only the domain, not which host app installed
+    # Assist, so probe both namespaces (standalone buddy-assist app first,
+    # then the breeze-buddy tab's BB_SHOPIFY tenant). First ACTIVE config
+    # wins — an inactive standalone tenant never shadows a live one.
+    cfg = None
+    for reseller_id, merchant_id in assist_tenant_candidates(normalized_domain):
+        candidate = await get_widget_config_by_reseller_merchant(
+            reseller_id, merchant_id
+        )
+        if candidate is not None and candidate.active:
+            cfg = candidate
+            break
+    if cfg is None:
+        # Unknown and inactive are indistinguishable — same posture as the
+        # public-key path in widget_common.resolve_widget_config_for_request.
+        logger.info(
+            f"widget: no active storefront config for merchant_domain={normalized_domain}"
+        )
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Widget configuration not found",
+        )
+
+    enforce_widget_origin(request=request, cfg=cfg)
+
+    # Separate bucket from "session_create": a page view must never burn a
+    # real session slot. Same per-hour cap, its own counter.
+    await enforce_widget_ip_limit(
+        request=request,
+        bucket="storefront_config",
+        limit=cfg.max_sessions_per_ip_hour,
+        widget_config_id=cfg.id,
+    )
+
+    return StorefrontWidgetConfigResponse(
+        enabled=True,
+        tenant=cfg.public_widget_key,
+        merchant_domain=normalized_domain,
+        appearance=cfg.appearance,
+        settings_revision=(
+            cfg.updated_at.isoformat() if cfg.updated_at is not None else None
+        ),
+        cache_ttl_seconds=_CACHE_TTL_SECONDS,
+    )
+
+
+__all__ = ["storefront_widget_config_handler"]

--- a/app/api/routers/breeze_buddy/widget_common.py
+++ b/app/api/routers/breeze_buddy/widget_common.py
@@ -137,6 +137,29 @@ async def _enforce_widget_ip_limit(
     )
 
 
+def enforce_widget_origin(*, request: Request, cfg: WidgetConfigResponse) -> None:
+    """403 unless the caller's Origin (or Referer-derived origin) is in the
+    row's ``allowed_origins``. Empty list = deny-all. Shared by the
+    key-resolved session path and the shop-resolved storefront-config path
+    so the two doors can never drift on origin policy.
+    """
+    origin = _caller_origin(request)
+    if origin is None:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Origin required for widget routes",
+        )
+    if not cfg.allowed_origins or origin not in cfg.allowed_origins:
+        logger.warning(
+            f"widget: origin {origin!r} not in allowed_origins for "
+            f"widget_config={cfg.id}"
+        )
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Origin not permitted for this widget",
+        )
+
+
 async def resolve_widget_config_for_request(
     *,
     request: Request,
@@ -180,21 +203,7 @@ async def resolve_widget_config_for_request(
             detail="Widget configuration not found",
         )
 
-    origin = _caller_origin(request)
-    if origin is None:
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="Origin required for widget routes",
-        )
-    if not cfg.allowed_origins or origin not in cfg.allowed_origins:
-        logger.warning(
-            f"widget: origin {origin!r} not in allowed_origins for "
-            f"widget_config={cfg.id}"
-        )
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="Origin not permitted for this widget",
-        )
+    enforce_widget_origin(request=request, cfg=cfg)
 
     effective_limit = (
         rate_limit if rate_limit is not None else cfg.max_sessions_per_ip_hour
@@ -263,6 +272,7 @@ def options_cors_response() -> Response:
 __all__ = [
     "client_ip",
     "enforce_widget_ip_limit",
+    "enforce_widget_origin",
     "options_cors_response",
     "resolve_widget_config_for_request",
 ]

--- a/app/api/routers/breeze_buddy/widget_config/handlers.py
+++ b/app/api/routers/breeze_buddy/widget_config/handlers.py
@@ -112,6 +112,11 @@ async def create_widget_config_handler(
         max_concurrent_per_ip=body.max_concurrent_per_ip,
         max_voice_sessions_per_ip_hour=body.max_voice_sessions_per_ip_hour,
         active=body.active,
+        appearance=(
+            body.appearance.model_dump(exclude_none=True)
+            if body.appearance is not None
+            else None
+        ),
     )
     if not created:
         raise HTTPException(
@@ -240,6 +245,11 @@ async def update_widget_config_handler(
         max_concurrent_per_ip=body.max_concurrent_per_ip,
         max_voice_sessions_per_ip_hour=body.max_voice_sessions_per_ip_hour,
         active=body.active,
+        appearance=(
+            body.appearance.model_dump(exclude_none=True)
+            if body.appearance is not None
+            else None
+        ),
     )
     if updated is None:
         raise HTTPException(

--- a/app/database/accessor/breeze_buddy/widget_config.py
+++ b/app/database/accessor/breeze_buddy/widget_config.py
@@ -5,7 +5,8 @@ Returns Pydantic models, never raw rows. Errors are logged + re-raised
 so route handlers can convert them into the appropriate HTTP status.
 """
 
-from typing import List, Optional, Tuple
+import json
+from typing import Any, Dict, List, Optional, Tuple
 
 from app.core.logger import logger
 from app.database.decoder.breeze_buddy.widget_config import decode_widget_config
@@ -34,6 +35,7 @@ async def create_widget_config(
     max_concurrent_per_ip: int,
     max_voice_sessions_per_ip_hour: int,
     active: bool,
+    appearance: Optional[Dict[str, Any]] = None,
 ) -> Optional[WidgetConfigResponse]:
     query, values = create_widget_config_query(
         reseller_id=reseller_id,
@@ -46,6 +48,7 @@ async def create_widget_config(
         max_concurrent_per_ip=max_concurrent_per_ip,
         max_voice_sessions_per_ip_hour=max_voice_sessions_per_ip_hour,
         active=active,
+        appearance_json=json.dumps(appearance) if appearance is not None else None,
     )
     try:
         result = await run_parameterized_query(query, values)
@@ -161,6 +164,7 @@ async def update_widget_config(
     max_concurrent_per_ip: Optional[int] = None,
     max_voice_sessions_per_ip_hour: Optional[int] = None,
     active: Optional[bool] = None,
+    appearance: Optional[Dict[str, Any]] = None,
 ) -> Optional[WidgetConfigResponse]:
     query, values = update_widget_config_query(
         widget_config_id=widget_config_id,
@@ -171,6 +175,7 @@ async def update_widget_config(
         max_concurrent_per_ip=max_concurrent_per_ip,
         max_voice_sessions_per_ip_hour=max_voice_sessions_per_ip_hour,
         active=active,
+        appearance_json=json.dumps(appearance) if appearance is not None else None,
     )
     if not values:
         # Caller passed no fields — return current row so PUT semantics

--- a/app/database/decoder/breeze_buddy/widget_config.py
+++ b/app/database/decoder/breeze_buddy/widget_config.py
@@ -1,6 +1,22 @@
 """Row → Pydantic decoder for widget_config (migration 030)."""
 
+import json
+
 from app.schemas.breeze_buddy.widget_config import WidgetConfigResponse
+
+
+def _decode_appearance(value) -> dict:
+    # asyncpg returns jsonb as str unless a codec is registered; rows
+    # predating migration 065 come back without the key at all.
+    if value is None:
+        return {}
+    if isinstance(value, str):
+        try:
+            parsed = json.loads(value)
+        except ValueError:
+            return {}
+        return parsed if isinstance(parsed, dict) else {}
+    return value if isinstance(value, dict) else {}
 
 
 def decode_widget_config(row) -> WidgetConfigResponse:
@@ -17,6 +33,7 @@ def decode_widget_config(row) -> WidgetConfigResponse:
         max_concurrent_per_ip=row["max_concurrent_per_ip"],
         max_voice_sessions_per_ip_hour=row["max_voice_sessions_per_ip_hour"],
         active=row.get("active", True),
+        appearance=_decode_appearance(row.get("appearance")),
         created_at=row.get("created_at"),
         updated_at=row.get("updated_at"),
     )

--- a/app/database/migrations/066_add_appearance_to_widget_config.sql
+++ b/app/database/migrations/066_add_appearance_to_widget_config.sql
@@ -1,0 +1,23 @@
+-- 066_add_appearance_to_widget_config.sql
+--
+-- Widget appearance moves onto the widget_config row.
+--
+-- Until now the storefront look of the Assist widget (colors, header title,
+-- launcher label, logos, offsets, modes) lived in the Shopify-app layer
+-- (nautilus `buddy_assist_settings`), which made nautilus a mandatory hop in
+-- the storefront runtime path just to dress the widget. The widget_config row
+-- already owns everything else the loader needs (public key, origins, active),
+-- so appearance belongs here too — one row, one owner, and the public
+-- storefront-config endpoint can serve the whole mount payload.
+--
+-- JSONB rather than columns: the appearance vocabulary is display-only,
+-- validated at the API boundary (schemas/breeze_buddy/widget_config.py), and
+-- expected to grow with the widget SDK; none of it is ever queried by key.
+
+ALTER TABLE widget_config
+    ADD COLUMN IF NOT EXISTS appearance jsonb NOT NULL DEFAULT '{}'::jsonb;
+
+COMMENT ON COLUMN widget_config.appearance IS
+    'Display-only widget appearance (primary_color, header_title, launcher_label, '
+    'header_logo_url, launcher_logo_url, offset_x, offset_y, modes, default_mode). '
+    'Validated at the API boundary; served verbatim to the storefront loader.';

--- a/app/database/queries/breeze_buddy/widget_config.py
+++ b/app/database/queries/breeze_buddy/widget_config.py
@@ -14,7 +14,7 @@ _COLUMNS = (
     "id, reseller_id, merchant_id, public_widget_key, template_id, "
     "allowed_origins, max_sessions_per_ip_hour, max_messages_per_ip_hour, "
     "max_concurrent_per_ip, max_voice_sessions_per_ip_hour, active, "
-    "created_at, updated_at"
+    "appearance, created_at, updated_at"
 )
 
 
@@ -30,15 +30,17 @@ def create_widget_config_query(
     max_concurrent_per_ip: int,
     max_voice_sessions_per_ip_hour: int,
     active: bool,
+    appearance_json: Optional[str] = None,
 ) -> Tuple[str, List[Any]]:
     query = f"""
         INSERT INTO {WIDGET_CONFIG_TABLE} (
             reseller_id, merchant_id, public_widget_key, template_id,
             allowed_origins, max_sessions_per_ip_hour, max_messages_per_ip_hour,
             max_concurrent_per_ip, max_voice_sessions_per_ip_hour,
-            active, created_at, updated_at
+            active, appearance, created_at, updated_at
         ) VALUES (
-            $1, $2, $3, $4::uuid, $5, $6, $7, $8, $9, $10, $11, $12
+            $1, $2, $3, $4::uuid, $5, $6, $7, $8, $9, $10,
+            COALESCE($11::jsonb, '{{}}'::jsonb), $12, $13
         )
         RETURNING {_COLUMNS}
     """
@@ -54,6 +56,7 @@ def create_widget_config_query(
         int(max_concurrent_per_ip),
         int(max_voice_sessions_per_ip_hour),
         bool(active),
+        appearance_json,
         now,
         now,
     ]
@@ -157,9 +160,13 @@ def update_widget_config_query(
     max_concurrent_per_ip: Optional[int] = None,
     max_voice_sessions_per_ip_hour: Optional[int] = None,
     active: Optional[bool] = None,
+    appearance_json: Optional[str] = None,
 ) -> Tuple[str, List[Any]]:
     """Returns ("", []) if no fields were provided — callers should treat
-    that as a no-op and return the current row."""
+    that as a no-op and return the current row.
+
+    ``appearance_json`` replaces the whole appearance object (the dashboard
+    always saves the full form); ``None`` leaves it untouched."""
     set_clauses: List[str] = []
     params: List[Any] = []
     idx = 1
@@ -197,6 +204,11 @@ def update_widget_config_query(
     if active is not None:
         set_clauses.append(f"active = ${idx}")
         params.append(bool(active))
+        idx += 1
+
+    if appearance_json is not None:
+        set_clauses.append(f"appearance = ${idx}::jsonb")
+        params.append(appearance_json)
         idx += 1
 
     if not set_clauses:

--- a/app/schemas/breeze_buddy/assist_onboarding.py
+++ b/app/schemas/breeze_buddy/assist_onboarding.py
@@ -8,6 +8,8 @@ from urllib.parse import urlsplit, urlunsplit
 
 from pydantic import BaseModel, Field, field_validator
 
+from app.schemas.breeze_buddy.widget_config import WidgetAppearance
+
 
 def _public_https_url(value: str, *, origin_only: bool) -> str:
     raw = value.strip()
@@ -88,6 +90,68 @@ class AssistOnboardingStreamRequest(BaseModel):
         return normalized
 
 
+class AssistOnboardRequest(BaseModel):
+    """Body of the non-streaming ``POST /assist/onboard`` (S2S).
+
+    The bare-metal install path: called by the Shopify-app layer at app
+    install. Creates only the un-personalized default — merchant row,
+    blueprint-derived template, widget config — and NEVER scrapes the
+    storefront; personalization is a later, dashboard-triggered action.
+
+    Tenancy is derived server-side from ``host_app`` + ``merchant_domain``
+    (see assist/commerce/tenancy.py): the breeze-buddy host app lands on
+    reseller ``BB_SHOPIFY`` with the plain domain; the standalone
+    buddy-assist app on ``BB_ASSIST`` with an ``assist-`` prefixed
+    merchant id. Callers cannot pick a namespace directly.
+    """
+
+    merchant_domain: str = Field(..., min_length=4, max_length=253)
+    host_app: Literal["buddy-assist", "breeze-buddy"] = "buddy-assist"
+    merchant_name: Optional[str] = Field(None, min_length=1, max_length=255)
+    bot_brand_name: Optional[str] = Field(None, min_length=1, max_length=255)
+    allowed_origins: List[str] = Field(
+        default_factory=list,
+        max_length=20,
+        description="Extra allowed origins (e.g. the merchant's primary domain). "
+        "https://<merchant_domain> is always included.",
+    )
+    appearance: Optional[WidgetAppearance] = None
+    is_active: bool = True
+
+    @field_validator("merchant_name", "bot_brand_name")
+    @classmethod
+    def _strip_optional_text(cls, value: Optional[str]) -> Optional[str]:
+        if value is None:
+            return value
+        stripped = value.strip()
+        if not stripped:
+            raise ValueError("must not be blank")
+        return stripped
+
+    @field_validator("allowed_origins")
+    @classmethod
+    def _validate_extra_origins(cls, values: List[str]) -> List[str]:
+        normalized: List[str] = []
+        for value in values:
+            if len(value) > 2048:
+                raise ValueError("allowed origin is too long")
+            origin = _public_https_url(value, origin_only=True)
+            if origin not in normalized:
+                normalized.append(origin)
+        return normalized
+
+
+class AssistOnboardResponse(BaseModel):
+    """Body of ``POST /assist/onboard``."""
+
+    success: Literal[True] = True
+    operation: Literal["created", "updated", "recovered"]
+    merchant_created: bool
+    template_id: str
+    template_name: str
+    widget_config: Dict[str, Any]
+
+
 class AssistOnboardingProgress(BaseModel):
     step: str
     status: Literal["running", "done"]
@@ -112,6 +176,8 @@ class AssistOnboardingCompletion(BaseModel):
 
 
 __all__ = [
+    "AssistOnboardRequest",
+    "AssistOnboardResponse",
     "AssistOnboardingCompletion",
     "AssistOnboardingError",
     "AssistOnboardingProgress",

--- a/app/schemas/breeze_buddy/widget_config.py
+++ b/app/schemas/breeze_buddy/widget_config.py
@@ -11,9 +11,60 @@ a dedicated rotate endpoint later; this PR keeps the surface minimal.
 """
 
 from datetime import datetime
-from typing import List, Optional
+from typing import Any, Dict, List, Optional
+from urllib.parse import urlsplit
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
+
+
+class WidgetAppearance(BaseModel):
+    """Display-only widget appearance, stored verbatim on the row.
+
+    Every field optional — absent means "widget default". Validation is
+    deliberately mechanical (length caps + https on logo URLs); what the
+    values look like on screen is the widget SDK's business, not the
+    server's. ``launcher_label`` may be an empty string: that is a real
+    setting (hide the launcher text), not an absence.
+    """
+
+    primary_color: Optional[str] = Field(None, max_length=64)
+    header_title: Optional[str] = Field(None, max_length=120)
+    launcher_label: Optional[str] = Field(None, max_length=60)
+    header_logo_url: Optional[str] = Field(None, max_length=2048)
+    launcher_logo_url: Optional[str] = Field(None, max_length=2048)
+    offset_x: Optional[str] = Field(None, max_length=16)
+    offset_y: Optional[str] = Field(None, max_length=16)
+    # Which corner the launcher/panel anchors to (widget SDK vocabulary:
+    # "bottom-right" | "bottom-left"); unknown values fall back SDK-side.
+    position: Optional[str] = Field(None, max_length=16)
+    launcher_height: Optional[str] = Field(None, max_length=16)
+    # String, not bool: the SDK parses the literal attribute string
+    # ("false" pins the launcher; presence-semantics would break that).
+    draggable: Optional[str] = Field(None, max_length=8)
+    modes: Optional[str] = Field(None, max_length=32)
+    default_mode: Optional[str] = Field(None, max_length=16)
+    # Hosted skin (full custom UI in a sandboxed iframe) and hosted
+    # theme.css for the default UI. Both are widget-SDK contracts
+    # (custom-skin-url / custom-style-url); the server only insists on
+    # https. Skins must live on a DEDICATED origin — never the merchant's
+    # own page origin (the SDK docs carry the full warning).
+    custom_skin_url: Optional[str] = Field(None, max_length=2048)
+    custom_style_url: Optional[str] = Field(None, max_length=2048)
+
+    @field_validator(
+        "header_logo_url", "launcher_logo_url", "custom_skin_url", "custom_style_url"
+    )
+    @classmethod
+    def _https_only(cls, value: Optional[str]) -> Optional[str]:
+        if value is None:
+            return value
+        stripped = value.strip()
+        if not stripped:
+            return None
+        parsed = urlsplit(stripped)
+        if parsed.scheme.lower() != "https" or not parsed.hostname:
+            raise ValueError("appearance URLs must be HTTPS")
+        return stripped
 
 
 class WidgetConfigCreate(BaseModel):
@@ -36,6 +87,9 @@ class WidgetConfigCreate(BaseModel):
     max_concurrent_per_ip: int = Field(4, ge=0)
     max_voice_sessions_per_ip_hour: int = Field(10, ge=0)
     active: bool = Field(True, description="Inactive rows behave like 404.")
+    appearance: Optional[WidgetAppearance] = Field(
+        None, description="Display-only widget appearance; omitted = defaults."
+    )
 
 
 class WidgetConfigUpdate(BaseModel):
@@ -52,6 +106,11 @@ class WidgetConfigUpdate(BaseModel):
     max_concurrent_per_ip: Optional[int] = Field(None, ge=0)
     max_voice_sessions_per_ip_hour: Optional[int] = Field(None, ge=0)
     active: Optional[bool] = None
+    appearance: Optional[WidgetAppearance] = Field(
+        None,
+        description="Replaces the WHOLE appearance object (send the full "
+        "form); omitted = leave appearance untouched.",
+    )
 
 
 class WidgetConfigResponse(BaseModel):
@@ -68,8 +127,32 @@ class WidgetConfigResponse(BaseModel):
     max_concurrent_per_ip: int = 4
     max_voice_sessions_per_ip_hour: int = 10
     active: bool = True
+    # Served verbatim as stored (a Dict, not WidgetAppearance, so rows
+    # written by a newer deploy never fail validation on an older one).
+    appearance: Dict[str, Any] = Field(default_factory=dict)
     created_at: Optional[datetime] = None
     updated_at: Optional[datetime] = None
+
+
+class StorefrontWidgetConfigResponse(BaseModel):
+    """Body of the public ``GET /widget/storefront-config`` resolve.
+
+    Everything the storefront loader needs to mount the widget, nothing
+    more. ``tenant`` is the public widget key — public by design (it is
+    embedded in every storefront page). Disabled/unknown/blocked merchants
+    never reach this shape; they get 404/403 with no body detail.
+    """
+
+    enabled: bool = True
+    tenant: str
+    merchant_domain: str
+    appearance: Dict[str, Any] = Field(default_factory=dict)
+    settings_revision: Optional[str] = Field(
+        None,
+        description="Opaque change fingerprint (row updated_at). The loader "
+        "refetches when this differs from its cached copy.",
+    )
+    cache_ttl_seconds: int = 900
 
 
 class WidgetConfigListResponse(BaseModel):
@@ -90,6 +173,8 @@ class DeleteWidgetConfigResponse(BaseModel):
 
 
 __all__ = [
+    "StorefrontWidgetConfigResponse",
+    "WidgetAppearance",
     "WidgetConfigCreate",
     "WidgetConfigUpdate",
     "WidgetConfigResponse",

--- a/tests/test_assist_bare_onboarding.py
+++ b/tests/test_assist_bare_onboarding.py
@@ -1,0 +1,354 @@
+"""Bare-metal (non-streaming, no-scrape) Assist onboarding.
+
+Mirrors tests/test_assist_onboarding.py's fixture style: service-level,
+every accessor AsyncMock'ed, no DB. The property under test throughout:
+``onboard_assist_bare`` NEVER touches the scraper, derives tenancy from
+the merchant domain server-side, and otherwise keeps the stream path's
+idempotency contract (created / updated / recovered, rollback on widget
+failure).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock
+
+import pytest
+from pydantic import ValidationError
+
+from app.ai.voice.agents.breeze_buddy.assist.commerce import (
+    assist_onboarding as service,
+)
+from app.ai.voice.agents.breeze_buddy.assist.commerce.tenancy import (
+    assist_tenant,
+    assist_tenant_candidates,
+    normalize_merchant_domain,
+)
+from app.ai.voice.agents.breeze_buddy.template.types import TemplateModel
+from app.schemas.breeze_buddy.assist_onboarding import AssistOnboardRequest
+from app.schemas.breeze_buddy.widget_config import WidgetConfigResponse
+
+MERCHANT_DOMAIN = "yuqe0m-xr.myshopify.com"
+# Default host app is the standalone buddy-assist app → BB_ASSIST namespace.
+RESELLER_ID, MERCHANT_ID = assist_tenant("buddy-assist", MERCHANT_DOMAIN)
+
+
+def _request(**overrides) -> AssistOnboardRequest:
+    body = {
+        "merchant_domain": MERCHANT_DOMAIN,
+        "merchant_name": "Zodiac",
+        "allowed_origins": ["https://zodiaconline.com"],
+        "appearance": {"header_title": "Zodiac Assist", "launcher_label": ""},
+    }
+    body.update(overrides)
+    return AssistOnboardRequest.model_validate(body)
+
+
+def _default_template() -> TemplateModel:
+    return TemplateModel(
+        id="00000000-0000-0000-0000-000000000001",
+        reseller_id=RESELLER_ID,
+        merchant_id=None,
+        name=service.DEFAULT_ASSIST_TEMPLATE_NAME,
+        flow={
+            "mode": "direct",
+            "functions": [],
+            "system_prompt": (
+                f"{service.BRAND_IDENTITY_MARKER}\n\n"
+                "## Operating principles\n"
+                f"{service.SHOPIFY_OPERATING_START_MARKER}\n"
+                "### Shopify commerce tools\n"
+                "Use Shopify tools for live commerce facts.\n"
+                f"{service.SHOPIFY_OPERATING_END_MARKER}\n"
+            ),
+        },
+        expected_payload_schema={
+            "shop_url": {"type": "string"},
+            "shopify_customer_token": {"type": "string"},
+        },
+        expected_callback_response_schema={},
+        configurations={
+            "mcp": {
+                "servers": [
+                    {
+                        "name": service.SHOPIFY_MCP_SERVER_NAME,
+                        "url": "https://{shop_url}/api/mcp",
+                        "auth": {"type": "none"},
+                    }
+                ]
+            },
+            "state_reducers": [
+                {"tool_name": tool, "set_paths": {"cart_id": "id"}}
+                for tool in ("create_cart", "update_cart", "get_cart")
+            ],
+            "tool_arg_injection": [
+                {"tool_name": tool, "set_paths": {"id": "state.data.cart_id"}}
+                for tool in ("create_cart", "update_cart", "get_cart")
+            ],
+        },
+        secrets={},
+        is_active=True,
+        supported_channels=["chat"],
+    )
+
+
+def _widget(template_id: str, **overrides) -> WidgetConfigResponse:
+    fields = {
+        "id": "00000000-0000-0000-0000-000000000020",
+        "reseller_id": RESELLER_ID,
+        "merchant_id": MERCHANT_ID,
+        "public_widget_key": "public-key-123",
+        "template_id": template_id,
+        "allowed_origins": [f"https://{MERCHANT_DOMAIN}", "https://zodiaconline.com"],
+        "active": True,
+        "appearance": {"header_title": "Zodiac Assist"},
+    }
+    fields.update(overrides)
+    return WidgetConfigResponse(**fields)
+
+
+@pytest.fixture()
+def wired(monkeypatch):
+    """Patch every accessor; return the mock bundle for assertions."""
+    mocks = {
+        "get_merchant": AsyncMock(return_value=None),
+        "create_merchant": AsyncMock(return_value=object()),
+        "get_widget": AsyncMock(return_value=None),
+        "get_template_by_id": AsyncMock(return_value=None),
+        "get_template_in_scope": AsyncMock(),
+        "create_template": AsyncMock(),
+        "replace_template": AsyncMock(),
+        "create_widget_config": AsyncMock(),
+        "update_widget_config": AsyncMock(),
+        "delete_template": AsyncMock(),
+        "invalidate": AsyncMock(),
+        "scrape": AsyncMock(
+            side_effect=AssertionError("bare onboarding must never scrape")
+        ),
+    }
+    monkeypatch.setattr(
+        service, "get_merchant_by_merchant_identifier", mocks["get_merchant"]
+    )
+    monkeypatch.setattr(service, "create_merchant", mocks["create_merchant"])
+    monkeypatch.setattr(
+        service, "get_widget_config_by_reseller_merchant", mocks["get_widget"]
+    )
+    monkeypatch.setattr(service, "get_template_by_id", mocks["get_template_by_id"])
+    monkeypatch.setattr(
+        service, "get_template_in_scope", mocks["get_template_in_scope"]
+    )
+    monkeypatch.setattr(service, "create_template", mocks["create_template"])
+    monkeypatch.setattr(service, "replace_template", mocks["replace_template"])
+    monkeypatch.setattr(service, "create_widget_config", mocks["create_widget_config"])
+    monkeypatch.setattr(service, "update_widget_config", mocks["update_widget_config"])
+    monkeypatch.setattr(
+        service, "delete_template_if_not_referenced", mocks["delete_template"]
+    )
+    monkeypatch.setattr(service, "invalidate_template", mocks["invalidate"])
+    monkeypatch.setattr(service, "scrape_website", mocks["scrape"])
+    return mocks
+
+
+def _scope_lookup(existing_merchant_template, default):
+    """get_template_in_scope: merchant-scoped call first, blueprint second."""
+
+    async def lookup(reseller_id, merchant_id, name):
+        if merchant_id is None:
+            assert name == service.DEFAULT_ASSIST_TEMPLATE_NAME
+            return default
+        return existing_merchant_template
+
+    return lookup
+
+
+def test_tenancy_helpers() -> None:
+    assert normalize_merchant_domain("HTTPS://Zodiaconline.COM/") == "zodiaconline.com"
+    # Host app decides the reseller: standalone app gets its own namespace
+    # (prefixed — the merchants PK is global, plain would collide with the
+    # voice row); the breeze-buddy tab shares the voice tenant.
+    assert assist_tenant("buddy-assist", MERCHANT_DOMAIN) == (
+        "BB_ASSIST",
+        f"assist-{MERCHANT_DOMAIN}",
+    )
+    assert assist_tenant("breeze-buddy", MERCHANT_DOMAIN) == (
+        "BB_SHOPIFY",
+        MERCHANT_DOMAIN,
+    )
+    # Domain-only resolution probes the standalone namespace first.
+    assert assist_tenant_candidates(MERCHANT_DOMAIN) == (
+        ("BB_ASSIST", f"assist-{MERCHANT_DOMAIN}"),
+        ("BB_SHOPIFY", MERCHANT_DOMAIN),
+    )
+    with pytest.raises(ValueError):
+        normalize_merchant_domain("not a domain")
+
+
+def test_breeze_buddy_host_app_lands_on_shared_voice_tenant(wired) -> None:
+    default = _default_template()
+    default.reseller_id = "BB_SHOPIFY"
+    wired["get_template_in_scope"].side_effect = _scope_lookup(None, default)
+    wired["create_template"].side_effect = lambda **kwargs: _echo_template(kwargs)
+    wired["create_widget_config"].return_value = _widget(
+        "00000000-0000-0000-0000-000000000002",
+        reseller_id="BB_SHOPIFY",
+        merchant_id=MERCHANT_DOMAIN,
+    )
+
+    asyncio.run(service.onboard_assist_bare(_request(host_app="breeze-buddy")))
+
+    merchant_kwargs = wired["create_merchant"].call_args.kwargs
+    assert merchant_kwargs["reseller_id"] == "BB_SHOPIFY"
+    assert merchant_kwargs["merchant_id"] == MERCHANT_DOMAIN
+    widget_kwargs = wired["create_widget_config"].call_args.kwargs
+    assert widget_kwargs["reseller_id"] == "BB_SHOPIFY"
+    assert widget_kwargs["merchant_id"] == MERCHANT_DOMAIN
+
+
+def test_appearance_urls_must_be_https() -> None:
+    with pytest.raises(ValidationError):
+        _request(
+            appearance={"custom_skin_url": "http://cdn.example.com/skin/index.html"}
+        )
+    body = _request(
+        appearance={
+            "custom_skin_url": "https://cdn.example.com/skin/index.html",
+            "custom_style_url": "https://cdn.example.com/skin/theme.css",
+            "position": "bottom-left",
+            "draggable": "false",
+        }
+    )
+    assert body.appearance is not None
+    assert body.appearance.custom_skin_url == "https://cdn.example.com/skin/index.html"
+
+
+def test_request_rejects_path_origins() -> None:
+    with pytest.raises(ValidationError):
+        _request(allowed_origins=["https://zodiaconline.com/pages/contact"])
+
+
+def test_created_path_never_scrapes_and_derives_tenancy(wired) -> None:
+    default = _default_template()
+    wired["get_template_in_scope"].side_effect = _scope_lookup(None, default)
+    wired["create_template"].side_effect = lambda **kwargs: _echo_template(kwargs)
+    created_widget = _widget("00000000-0000-0000-0000-000000000002")
+    wired["create_widget_config"].return_value = created_widget
+
+    result = asyncio.run(service.onboard_assist_bare(_request()))
+
+    assert result.operation == "created"
+    assert result.merchant_created is True
+    wired["scrape"].assert_not_called()
+
+    merchant_kwargs = wired["create_merchant"].call_args.kwargs
+    assert merchant_kwargs["merchant_id"] == MERCHANT_ID
+    assert merchant_kwargs["reseller_id"] == RESELLER_ID
+
+    template_kwargs = wired["create_template"].call_args.kwargs
+    assert template_kwargs["reseller_id"] == RESELLER_ID
+    assert template_kwargs["merchant_id"] == MERCHANT_ID
+    prompt = template_kwargs["flow"]["system_prompt"]
+    assert service.BRAND_IDENTITY_MARKER not in prompt
+    assert "has not been personalized" in prompt
+    assert "### Shopify commerce tools" in prompt
+
+    widget_kwargs = wired["create_widget_config"].call_args.kwargs
+    # Exact list: merchant domain origin always first, extras preserved.
+    assert widget_kwargs["allowed_origins"] == [
+        f"https://{MERCHANT_DOMAIN}",
+        "https://zodiaconline.com",
+    ]
+    assert widget_kwargs["appearance"] == {
+        "header_title": "Zodiac Assist",
+        "launcher_label": "",
+    }
+    assert result.widget_config["appearance"] == {"header_title": "Zodiac Assist"}
+
+
+def test_updated_path_keeps_existing_widget_and_merchant(wired) -> None:
+    default = _default_template()
+    existing_template = _echo_template(
+        {
+            "template_id": "00000000-0000-0000-0000-000000000009",
+            "reseller_id": RESELLER_ID,
+            "merchant_id": MERCHANT_ID,
+            "flow": default.flow,
+        }
+    )
+    widget = _widget(existing_template.id)
+    wired["get_merchant"].return_value = object()
+    wired["get_widget"].return_value = widget
+    wired["get_template_by_id"].return_value = existing_template
+    wired["update_widget_config"].return_value = widget
+
+    result = asyncio.run(service.onboard_assist_bare(_request()))
+
+    assert result.operation == "updated"
+    assert result.merchant_created is False
+    wired["create_merchant"].assert_not_called()
+    # Existing templates are NEVER rebuilt — a reinstall must not wipe a
+    # personalized prompt back to bare-metal, and no blueprint is needed.
+    wired["create_template"].assert_not_called()
+    wired["replace_template"].assert_not_called()
+    assert result.template_id == existing_template.id
+    update_kwargs = wired["update_widget_config"].call_args.kwargs
+    assert update_kwargs["appearance"] == {
+        "header_title": "Zodiac Assist",
+        "launcher_label": "",
+    }
+
+
+def test_widget_create_failure_rolls_back_new_template(wired) -> None:
+    default = _default_template()
+    wired["get_template_in_scope"].side_effect = _scope_lookup(None, default)
+    wired["create_template"].side_effect = lambda **kwargs: _echo_template(kwargs)
+    wired["create_widget_config"].side_effect = RuntimeError("insert failed")
+
+    with pytest.raises(RuntimeError):
+        asyncio.run(service.onboard_assist_bare(_request()))
+
+    wired["delete_template"].assert_awaited_once()
+
+
+def test_merchant_create_race_settles_as_existing(wired) -> None:
+    default = _default_template()
+    # First existence check misses; create blows up (unique violation);
+    # re-check finds the row the concurrent install wrote.
+    wired["get_merchant"].side_effect = [None, object()]
+    wired["create_merchant"].side_effect = RuntimeError("duplicate key")
+    wired["get_template_in_scope"].side_effect = _scope_lookup(None, default)
+    wired["create_template"].side_effect = lambda **kwargs: _echo_template(kwargs)
+    wired["create_widget_config"].return_value = _widget(
+        "00000000-0000-0000-0000-000000000002"
+    )
+
+    result = asyncio.run(service.onboard_assist_bare(_request()))
+    assert result.merchant_created is False
+
+
+def test_missing_blueprint_fails_closed(wired) -> None:
+    wired["get_template_in_scope"].side_effect = _scope_lookup(None, None)
+
+    with pytest.raises(service.OnboardingFailure) as exc:
+        asyncio.run(service.onboard_assist_bare(_request()))
+    assert exc.value.code == "DEFAULT_TEMPLATE_NOT_FOUND"
+    wired["create_widget_config"].assert_not_called()
+
+
+def _echo_template(kwargs) -> TemplateModel:
+    """Build a TemplateModel from create/replace kwargs (the accessors echo
+    the persisted row back)."""
+    return TemplateModel(
+        id=kwargs.get("template_id", "00000000-0000-0000-0000-000000000002"),
+        reseller_id=kwargs.get("reseller_id", RESELLER_ID),
+        merchant_id=kwargs.get("merchant_id", MERCHANT_ID),
+        name=kwargs.get("name", "zodiac-buddy-assist"),
+        flow=kwargs.get("flow", {"mode": "direct", "system_prompt": "x"}),
+        expected_payload_schema=kwargs.get("expected_payload_schema", {}),
+        expected_callback_response_schema=kwargs.get(
+            "expected_callback_response_schema", {}
+        ),
+        configurations=kwargs.get("configurations"),
+        secrets=kwargs.get("secrets", {}),
+        is_active=kwargs.get("is_active", True),
+        supported_channels=list(kwargs.get("supported_channels", ["chat"])),
+    )

--- a/tests/test_storefront_widget_config.py
+++ b/tests/test_storefront_widget_config.py
@@ -1,0 +1,219 @@
+"""Public ``GET /widget/storefront-config`` — merchant-domain resolve.
+
+Route-level via TestClient on a bare app (pattern:
+tests/test_tts_catalog_endpoint.py). The DB accessor and the Redis rate
+limiter are monkeypatched on the handler module; the origin allowlist and
+domain normalization run for real — they ARE the subject.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.ai.voice.agents.breeze_buddy.assist.commerce.tenancy import assist_tenant
+from app.api.routers.breeze_buddy.widget import router, storefront
+from app.schemas.breeze_buddy.widget_config import WidgetConfigResponse
+from app.services.redis.rate_limit import RateLimitDecision
+
+MERCHANT_DOMAIN = "yuqe0m-xr.myshopify.com"
+STANDALONE = assist_tenant("buddy-assist", MERCHANT_DOMAIN)
+SHARED = assist_tenant("breeze-buddy", MERCHANT_DOMAIN)
+STOREFRONT_ORIGIN = "https://zodiaconline.com"
+UPDATED_AT = datetime(2026, 9, 3, 10, 0, 0, tzinfo=timezone.utc)
+
+
+def _cfg(**overrides) -> WidgetConfigResponse:
+    fields = {
+        "id": "00000000-0000-0000-0000-000000000020",
+        "reseller_id": STANDALONE[0],
+        "merchant_id": STANDALONE[1],
+        "public_widget_key": "public-key-123",
+        "template_id": "00000000-0000-0000-0000-000000000002",
+        "allowed_origins": [f"https://{MERCHANT_DOMAIN}", STOREFRONT_ORIGIN],
+        "active": True,
+        "appearance": {"header_title": "Zodiac Assist", "primary_color": "#111"},
+        "updated_at": UPDATED_AT,
+    }
+    fields.update(overrides)
+    return WidgetConfigResponse(**fields)
+
+
+def _allow(limit: int = 600) -> RateLimitDecision:
+    return RateLimitDecision(allowed=True, count=1, limit=limit, retry_after_seconds=0)
+
+
+def _deny(limit: int = 600) -> RateLimitDecision:
+    return RateLimitDecision(
+        allowed=False, count=limit, limit=limit, retry_after_seconds=42
+    )
+
+
+@pytest.fixture()
+def lookup(monkeypatch) -> AsyncMock:
+    mock = AsyncMock(return_value=_cfg())
+    monkeypatch.setattr(storefront, "get_widget_config_by_reseller_merchant", mock)
+    monkeypatch.setattr(storefront, "enforce_widget_ip_limit", AsyncMock())
+    monkeypatch.setattr(
+        storefront, "check_rate_limit", AsyncMock(return_value=_allow())
+    )
+    return mock
+
+
+@pytest.fixture()
+def client(lookup) -> TestClient:
+    app = FastAPI()
+    app.include_router(router)
+    return TestClient(app)
+
+
+def test_resolves_shop_to_config(client: TestClient, lookup: AsyncMock) -> None:
+    response = client.get(
+        "/widget/storefront-config",
+        params={"merchant_domain": MERCHANT_DOMAIN},
+        headers={"Origin": STOREFRONT_ORIGIN},
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["enabled"] is True
+    assert body["tenant"] == "public-key-123"
+    assert body["merchant_domain"] == MERCHANT_DOMAIN
+    assert body["appearance"] == {
+        "header_title": "Zodiac Assist",
+        "primary_color": "#111",
+    }
+    assert body["settings_revision"] == UPDATED_AT.isoformat()
+    assert body["cache_ttl_seconds"] == 900
+    lookup.assert_awaited_once_with(*STANDALONE)
+
+
+def test_normalizes_shop_before_lookup(client: TestClient, lookup: AsyncMock) -> None:
+    response = client.get(
+        "/widget/storefront-config",
+        params={"merchant_domain": f"HTTPS://{MERCHANT_DOMAIN.upper()}/"},
+        headers={"Origin": STOREFRONT_ORIGIN},
+    )
+    assert response.status_code == 200
+    lookup.assert_awaited_once_with(*STANDALONE)
+
+
+def test_unknown_and_inactive_are_the_same_404(
+    client: TestClient, lookup: AsyncMock
+) -> None:
+    lookup.return_value = None
+    unknown = client.get(
+        "/widget/storefront-config",
+        params={"merchant_domain": MERCHANT_DOMAIN},
+        headers={"Origin": STOREFRONT_ORIGIN},
+    )
+    lookup.return_value = _cfg(active=False)
+    inactive = client.get(
+        "/widget/storefront-config",
+        params={"merchant_domain": MERCHANT_DOMAIN},
+        headers={"Origin": STOREFRONT_ORIGIN},
+    )
+    assert unknown.status_code == inactive.status_code == 404
+    assert unknown.json() == inactive.json()
+
+
+def test_origin_missing_or_foreign_is_403(client: TestClient) -> None:
+    missing = client.get(
+        "/widget/storefront-config", params={"merchant_domain": MERCHANT_DOMAIN}
+    )
+    foreign = client.get(
+        "/widget/storefront-config",
+        params={"merchant_domain": MERCHANT_DOMAIN},
+        headers={"Origin": "https://evil.example"},
+    )
+    assert missing.status_code == 403
+    assert foreign.status_code == 403
+
+
+def test_falls_back_to_shared_voice_tenant(
+    client: TestClient, lookup: AsyncMock
+) -> None:
+    # No standalone (BB_ASSIST) tenant → the breeze-buddy tab's BB_SHOPIFY
+    # tenant serves the storefront. This is every pre-existing live tenant.
+    shared_cfg = _cfg(reseller_id=SHARED[0], merchant_id=SHARED[1])
+
+    async def by_namespace(reseller_id, merchant_id):
+        return shared_cfg if (reseller_id, merchant_id) == SHARED else None
+
+    lookup.side_effect = by_namespace
+    response = client.get(
+        "/widget/storefront-config",
+        params={"merchant_domain": MERCHANT_DOMAIN},
+        headers={"Origin": STOREFRONT_ORIGIN},
+    )
+    assert response.status_code == 200
+    assert response.json()["tenant"] == "public-key-123"
+
+
+def test_inactive_standalone_never_shadows_live_shared_tenant(
+    client: TestClient, lookup: AsyncMock
+) -> None:
+    inactive_standalone = _cfg(active=False)
+    live_shared = _cfg(reseller_id=SHARED[0], merchant_id=SHARED[1])
+
+    async def by_namespace(reseller_id, merchant_id):
+        return (
+            inactive_standalone
+            if (reseller_id, merchant_id) == STANDALONE
+            else live_shared
+        )
+
+    lookup.side_effect = by_namespace
+    response = client.get(
+        "/widget/storefront-config",
+        params={"merchant_domain": MERCHANT_DOMAIN},
+        headers={"Origin": STOREFRONT_ORIGIN},
+    )
+    assert response.status_code == 200
+
+
+def test_referer_fallback_matches_allowlist(client: TestClient) -> None:
+    response = client.get(
+        "/widget/storefront-config",
+        params={"merchant_domain": MERCHANT_DOMAIN},
+        headers={"Referer": f"{STOREFRONT_ORIGIN}/products/blue-shirt"},
+    )
+    assert response.status_code == 200
+
+
+def test_malformed_shop_is_400_and_never_hits_db(
+    client: TestClient, lookup: AsyncMock
+) -> None:
+    response = client.get(
+        "/widget/storefront-config",
+        params={"merchant_domain": "javascript:alert(1)"},
+        headers={"Origin": STOREFRONT_ORIGIN},
+    )
+    assert response.status_code == 400
+    lookup.assert_not_awaited()
+
+
+def test_probe_limit_runs_before_any_db_lookup(
+    client: TestClient, lookup: AsyncMock, monkeypatch
+) -> None:
+    # An anonymous caller spraying unknown-but-valid domains must be
+    # bounded BEFORE the database is consulted — the merchant-scoped
+    # limiter can never cover this case (it needs a resolved config).
+    monkeypatch.setattr(storefront, "check_rate_limit", AsyncMock(return_value=_deny()))
+    response = client.get(
+        "/widget/storefront-config",
+        params={"merchant_domain": "sprayed-domain.example.com"},
+        headers={"Origin": STOREFRONT_ORIGIN},
+    )
+    assert response.status_code == 429
+    assert response.headers["retry-after"] == "42"
+    lookup.assert_not_awaited()
+
+
+def test_preflight_is_open(client: TestClient) -> None:
+    response = client.options("/widget/storefront-config")
+    assert response.status_code == 204
+    assert response.headers["access-control-allow-origin"] == "*"


### PR DESCRIPTION
## What

Phase 1 of moving ALL Assist configuration off nautilus and into clairvoyance. After this lands, the storefront loader can mount the widget without any nautilus hop, and app install can provision a working (bare-metal) Assist with one S2S call.

### 1. `widget_config.appearance` (migration 065)
Display-only appearance (primary_color, header_title, launcher_label, logos, offsets, modes, default_mode) as a jsonb column — the fields nautilus's `buddy_assist_settings` holds today. Validated at the API boundary (`WidgetAppearance`: length caps + https-only logos; `launcher_label: ""` is a real value = hide label), served verbatim, threaded through widget-config create/update/get/list.

### 2. `GET /widget/storefront-config?shop=<domain>` (public)
Shop-domain → `{enabled, tenant, shop, appearance, settings_revision, cache_ttl_seconds}`.
- Same trust model as `POST /widget/session`: Origin/Referer must be in `allowed_origins`, per-IP rate limit (own `storefront_config` bucket so page views never burn session quota), unknown/inactive collapse to one 404.
- Mounted under `/widget/` so it inherits the CORS bypass; OPTIONS preflight added.
- `settings_revision` = row `updated_at` — the loader's cache-refresh fingerprint.
- Tenancy convention (reseller `BB_ASSIST`, merchant `assist-<shop>`) now lives server-side in `assist/commerce/tenancy.py`.

### 3. `POST /assist/onboard` (S2S, non-streaming)
The install-time path nautilus will call. **Bare-metal by design: never scrapes.** Ensures the merchant row (idempotent, race-settled by PK), stamps the reseller blueprint (`buddy-assist-default`) with a "not personalized yet — ground claims in live tools" placeholder, creates/updates the widget config with appearance. Reuses the SSE path's idempotency contract (created/updated/recovered, template rollback on widget-create failure, cache invalidation). RBAC mirrors the stream route and validates the ids DERIVED from `shop_domain` — callers cannot pick their namespace. The SSE personalization flow is untouched (it becomes the dashboard "personalize" action later).

## Tests
- `tests/test_storefront_widget_config.py` — route-level: resolve happy path, normalization, 404-indistinguishability, 403 origin posture, Referer fallback, 400 malformed shop never hits DB, open preflight.
- `tests/test_assist_bare_onboarding.py` — service-level: never-scrapes guard, tenancy derivation, created/updated paths, appearance passthrough, merchant-create race, template rollback, missing-blueprint fail-closed.
- Full suite: **1981 passed** (was 1967); pyrefly 0 errors; migration + CRM boundary guards clean.

## Deploy notes
- Migration 065 is additive (`DEFAULT '{}'`).
- **Ops prerequisite for the onboard endpoint**: a `buddy-assist-default` blueprint template row under reseller `BB_ASSIST` (endpoint 500s with `DEFAULT_TEMPLATE_NOT_FOUND` until it exists).
- Nautilus-side PR (loader swap + gutting + backfill) follows; nothing here breaks existing flows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DNdffo648u5Qg9Q5Ctftub

---
## Updates (same commit, amended)
- **Vocabulary**: clairvoyance never says "shop" — the resolve param and all new fields/identifiers are `merchant_domain` (`GET /widget/storefront-config?merchant_domain=<domain>`, `AssistOnboardRequest.merchant_domain`, `normalize_merchant_domain`). Pre-existing `shop_url` template-engine variable untouched.
- **Appearance now covers the widget SDK's full attribute contract**, closing the skin loop: added `custom_skin_url` (hosted full custom UI, sandboxed iframe + postMessage bridge) and `custom_style_url` (hosted theme.css for the default UI) — https-enforced — plus `position` (bottom-right|bottom-left), `launcher_height`, `draggable`. A merchant-built skin becomes just a widget-config field.
- Suite now 1982 passed.


## Update 2: prod-namespace correction + no-rebuild guarantee
- **Tenancy corrected to prod reality**: `ASSIST_RESELLER_ID = "BB_SHOPIFY"`, `assist_merchant_id` = identity (plain domain, shared with the voice registration) — matching all 22 live Assist widget configs; the planned `BB_ASSIST`/`assist-` namespace had zero tenants. Every live tenant now resolves through the new endpoint with no migration. The seam function stays so a future split is one module.
- **Bare onboard never rebuilds an existing template**: blueprint is consulted only on CREATE; a reinstall/re-onboard of a personalized tenant leaves its template untouched (just reactivates the widget config and updates origins/appearance). Also means already-provisioned tenants work before the blueprint row exists.
- Suite: 1982 passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added streamlined Assist onboarding using a merchant’s storefront domain, without requiring website scraping.
  * Added configurable widget appearance settings, including branding, colors, labels, positioning, and hosted styles.
  * Added a storefront endpoint to retrieve widget configuration and appearance settings.
* **Security & Validation**
  * Added domain, HTTPS URL, origin allowlist, access-control, and rate-limit protections.
  * Added clear handling for invalid, missing, inactive, or unauthorized configurations.
* **Bug Fixes**
  * Improved onboarding reliability with idempotent setup, rollback handling, and race-condition recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Update 3: per-host-app resellers
- Tenancy is now decided by the installing host app (`host_app` on the onboard request; namespace still derived server-side): `breeze-buddy` → `BB_SHOPIFY`/plain domain (the shared voice tenant — matches every live Assist tenant); `buddy-assist` → `BB_ASSIST`/`assist-<domain>` (prefixed because `merchants.merchant_identifier` is a global PK).
- The storefront resolve probes both namespaces (standalone app first; an inactive standalone tenant never shadows a live shared one) since the loader only knows the domain.
- **Ops note:** the `buddy-assist-default` blueprint row is needed under EACH reseller that will onboard new tenants (BB_SHOPIFY and BB_ASSIST — same artifact, two creates).
- Suite: 1985 passed.
