### PR TITLE
feat(crm): events carry facts into the run; current node rides to templates; parked runs move; any node can re-arm on a repeat (rollout 16)

### DIFF
--- a/app/crm/outreach/db/accessor.py
+++ b/app/crm/outreach/db/accessor.py
@@ -385,11 +385,17 @@ async def open_runs_for_customer(
 
 
 async def resume_run_by_id(
-    merchant_id: str, run_id: str, node_id: str, context_patch: Dict[str, Any]
+    merchant_id: str,
+    run_id: str,
+    node_id: str,
+    context_patch: Dict[str, Any],
+    facts: Optional[Dict[str, Any]] = None,
 ) -> bool:
-    """True when the run was standing on the listening square and took
-    the answer."""
-    query, values = resume_run_by_id_query(merchant_id, run_id, node_id, context_patch)
+    """True when the run was standing on the listening square (waiting or
+    parked) and took the answer and the letter's facts."""
+    query, values = resume_run_by_id_query(
+        merchant_id, run_id, node_id, context_patch, facts
+    )
     async with crm_connection() as conn:
         row = await conn.fetchrow(query, *values)
     return row is not None
@@ -424,8 +430,10 @@ async def patch_open_run(
     max_field: Optional[str],
     max_value: Optional[float],
     debounce_minutes: float,
+    anywhere: bool = False,
 ) -> bool:
-    """True when an open run on the entry square took the repeat."""
+    """True when an open run on the door's start square (or, with
+    ``anywhere``, on any square) took the repeat."""
     query, values = patch_open_run_query(
         merchant_id,
         workflow_id,
@@ -437,6 +445,7 @@ async def patch_open_run(
         max_field,
         max_value,
         debounce_minutes,
+        anywhere,
     )
     async with crm_connection() as conn:
         row = await conn.fetchrow(query, *values)

--- a/app/crm/outreach/db/queries.py
+++ b/app/crm/outreach/db/queries.py
@@ -487,7 +487,11 @@ def open_runs_for_customer_query(
 
 
 def resume_run_by_id_query(
-    merchant_id: str, run_id: str, node_id: str, context_patch: Dict[str, Any]
+    merchant_id: str,
+    run_id: str,
+    node_id: str,
+    context_patch: Dict[str, Any],
+    facts: Optional[Dict[str, Any]] = None,
 ) -> Tuple[str, List[Any]]:
     """W5: the reply reaches the token — by run id (phase 13), because
     the listening square is the RUN'S version's, and a sibling run on
@@ -496,15 +500,39 @@ def resume_run_by_id_query(
     repeated reply changes nothing. The answer is recorded on the run
     BEFORE anything fires (canon T20), and wake_at = now() hands it to
     the walker. Event-side: unconditional (the walker's writes defer to
-    it, phase 03)."""
+    it, phase 03).
+
+    Phase 16: the letter's scalar facts land under context.facts.<square>
+    — namespaced, so two stages' payloads never collide; a second letter
+    on the same square replaces that square's facts (anything that is not
+    an object under `facts` — a legacy scalar a producer once sent — is
+    replaced, never concatenated into an array). And a PARKED run
+    hears its square too: an event is evidence the customer moved, so a
+    parked run that hears it is no longer stuck on the thing that parked
+    it — it becomes waiting with its failure counter forgiven (the human
+    resume's semantics, now event-driven) and, as for any reply, its
+    last_error cleared: the letter IS the step that unstuck it."""
     query = f"""
         UPDATE {ENROLLMENT_TABLE}
-        SET context = context || $4::jsonb, wake_at = now(), last_error = NULL
+        SET context = context || $4::jsonb
+                || jsonb_build_object('facts',
+                       CASE WHEN jsonb_typeof(context->'facts') = 'object' THEN context->'facts' ELSE '{{}}'::jsonb END
+                       || jsonb_build_object($3::text, $5::jsonb)),
+            wake_at = now(),
+            last_error = NULL,
+            status = 'waiting',
+            attempts = CASE WHEN status = 'parked' THEN 0 ELSE attempts END
         WHERE merchant_id = $1 AND id = $2
-          AND status = 'waiting' AND current_node = $3
+          AND status IN ('waiting', 'parked') AND current_node = $3
         RETURNING id
     """
-    return query, [merchant_id, run_id, node_id, json.dumps(context_patch)]
+    return query, [
+        merchant_id,
+        run_id,
+        node_id,
+        json.dumps(context_patch),
+        json.dumps(facts or {}),
+    ]
 
 
 def cancel_run_query(
@@ -592,12 +620,16 @@ def patch_open_run_query(
     max_field: Optional[str],
     max_value: Optional[float],
     debounce_minutes: float,
+    anywhere: bool = False,
 ) -> Tuple[str, List[Any]]:
     """Repeat entries (modules/05 §Repeat entries): ONE idempotent UPDATE
-    in the reply's shape (resume_run_by_id_query). Touches only a run still standing on
-    its first square (status waiting, current_node = the entry node) — a
-    run past it is never patched. Found by enrollment_key so a keyed plan's
-    order edit patches ITS order's run. The event marks itself used in
+    in the reply's shape (resume_run_by_id_query). Touches only a run still
+    standing on the door's start square (status waiting, current_node =
+    the start) — a run past it is never patched — unless the door says
+    restart_on_repeat (phase 16, G8: ``anywhere``): then a repeat of the
+    door's topic re-arms whichever square the run stands on, "KYC retried,
+    the timer restarts". Found by enrollment_key so a keyed plan's order
+    edit patches ITS order's run. The event marks itself used in
     context.repeat_event_ids, so a redelivered repeat matches zero rows and
     the alarm cannot slide twice for one letter.
 
@@ -644,7 +676,7 @@ def patch_open_run_query(
                            ELSE wake_at END,
             last_error = NULL
         WHERE merchant_id = $1 AND workflow_id = $2::uuid AND enrollment_key = $3
-          AND status = 'waiting' AND current_node = $4
+          AND status = 'waiting' AND ($11::boolean OR current_node = $4)
           AND NOT (COALESCE(context->'repeat_event_ids', '[]'::jsonb) ? $5::text)
           AND context->>'source_event_id' IS DISTINCT FROM $5::text
         RETURNING id
@@ -660,6 +692,7 @@ def patch_open_run_query(
         max_field,
         max_value,
         debounce_minutes,
+        anywhere,
     ]
 
 

--- a/app/crm/outreach/entry.py
+++ b/app/crm/outreach/entry.py
@@ -173,7 +173,12 @@ async def _wake_on_reply(
     """A wait_event square of ITS document listening on this topic wakes
     the run with the answer — the statement decides whether the token is
     standing there (a reply to a square it has left, or not yet reached,
-    changes nothing)."""
+    changes nothing), waiting or parked (phase 16: an event is evidence
+    the customer moved). The letter's scalar facts ride along under the
+    square (context.facts.<square>), so a later call can say what this
+    stage's letter said; the same bridge enrol uses, so bookkeeping names
+    and nested payload never reach the run."""
+    facts = _context_from_payload(event.payload)
     for node in definition.nodes:
         if node.type != "wait_event" or event.topic not in node.topics:
             continue
@@ -194,7 +199,11 @@ async def _wake_on_reply(
             )
             continue
         await accessor.resume_run_by_id(
-            run.merchant_id, str(run.id), node.id, {reply_key(node.id): str(answer)}
+            run.merchant_id,
+            str(run.id),
+            node.id,
+            {reply_key(node.id): str(answer)},
+            facts,
         )
 
 

--- a/app/crm/outreach/nodes.py
+++ b/app/crm/outreach/nodes.py
@@ -57,6 +57,9 @@ _BOOKKEEPING_KEYS = (
     "customer_mobile_number",
     "repeat_event_ids",  # repeat.py: which letters already patched this run
     "repeat_items",  # repeat.py: accumulate's list — never a template variable
+    "facts",  # entry.py: each square's letter, by square (phase 16) — flattened below
+    "current_node",  # run_facts: computed from the square, never a producer's
+    "current_stage",
 )
 _BOOKKEEPING_PREFIXES = ("lead_", "message_", "reply_")
 
@@ -204,7 +207,7 @@ async def execute_call(
     # payload — {placeholder}s in the template resolve from these keys.
     # reporting_webhook_url rides too: the lead machine reads it from the
     # lead payload to report the call's outcome back to the merchant.
-    payload: Dict[str, Any] = run_facts(run.context)
+    payload: Dict[str, Any] = run_facts(run.context, node)
     payload["customer_mobile_number"] = phone
 
     try:
@@ -263,7 +266,7 @@ async def execute_send(
             source_id=str(run.id),
             purpose_key=definition.purpose_key,
             template_id=node.template,
-            variables=send_variables(run.context),
+            variables=send_variables(run.context, node),
             dedupe_key=dedupe_key,
         )
     except ValueError as e:
@@ -290,24 +293,57 @@ def lead_request_id(context: Dict[str, Any], run_id: str) -> str:
     return f"wf-{run_id}"
 
 
-def run_facts(context: Dict[str, Any]) -> Dict[str, Any]:
+def run_facts(
+    context: Dict[str, Any], node: Optional[WorkflowNode] = None
+) -> Dict[str, Any]:
     """PURE: the run's small facts = context minus the walker's own
     bookkeeping. The ONE filter both the call payload and the send
-    variables derive from, so they can never disagree on what is ours."""
-    return {
+    variables derive from, so they can never disagree on what is ours.
+
+    Phase 16: each square's letter lives under context.facts.<square>
+    (entry.py writes it on resume). Flattened here for templates: the
+    top-level facts first, then the CURRENT square's override them (the
+    most recent stage wins the call), and every square's stay reachable as
+    facts_<square>_<key>. With the square given, current_node (and
+    current_stage when the square is labelled) ride along, so one call
+    template can say "you stopped at {current_stage}"."""
+    facts = {
         key: value
         for key, value in context.items()
         if key not in _BOOKKEEPING_KEYS and not key.startswith(_BOOKKEEPING_PREFIXES)
     }
+    by_square = context.get("facts")
+    by_square = by_square if isinstance(by_square, dict) else {}
+    for square, letter in by_square.items():
+        if isinstance(letter, dict):
+            for key, value in letter.items():
+                facts[f"facts_{square}_{key}"] = value
+    if node is not None:
+        current = by_square.get(node.id)
+        if isinstance(current, dict):
+            facts.update(current)
+        facts["current_node"] = node.id
+        if node.stage:
+            facts["current_stage"] = node.stage
+    return facts
 
 
-def send_variables(context: Dict[str, Any]) -> Dict[str, Any]:
+def send_variables(
+    context: Dict[str, Any], node: Optional[WorkflowNode] = None
+) -> Dict[str, Any]:
     """PURE: the template's fill-ins = the run's facts minus what only
-    the lead machine reads."""
+    the lead machine reads, and only what a provider can render: text and
+    numbers. A bool or a None among the variables makes the WhatsApp face
+    refuse the whole message terminally (connectivity renders nothing it
+    cannot spell — "True" or "None" inside a customer's message is
+    corruption that looks delivered), and with every listened letter's
+    facts riding along (phase 16) such values are ordinary, not rare."""
     return {
         key: value
-        for key, value in run_facts(context).items()
+        for key, value in run_facts(context, node).items()
         if key not in _LEAD_ONLY_KEYS
+        and isinstance(value, (str, int, float))
+        and not isinstance(value, bool)
     }
 
 

--- a/app/crm/outreach/plans.py
+++ b/app/crm/outreach/plans.py
@@ -81,6 +81,11 @@ def validate_definition(
                 f"entry {door.topic!r}: debounce_minutes needs a wait as its start "
                 "node — there is no entry alarm to slide otherwise"
             )
+        if door.restart_on_repeat and door.debounce_minutes <= 0:
+            problems.append(
+                f"entry {door.topic!r}: restart_on_repeat needs debounce_minutes > 0 "
+                "— there is nothing to re-arm otherwise"
+            )
 
     # Goal tiers (phase 06): the reason is vocabulary, and one tier per
     # reason — two tiers claiming goal_met could never be told apart.

--- a/app/crm/outreach/repeat.py
+++ b/app/crm/outreach/repeat.py
@@ -147,8 +147,9 @@ async def apply_repeat(
     facts: Dict[str, Any],
 ) -> bool:
     """A refused enrol may be a repeat of an open run standing on the
-    door's start square. Returns True when a run was patched. Zero rows
-    is the normal answer for "not a repeat" (nothing open, or the run
+    door's start square — or, when the door says restart_on_repeat (phase
+    16), on any square. Returns True when a run was patched. Zero rows is
+    the normal answer for "not a repeat" (nothing open, or the run
     already moved on) and for a redelivered event (it marked itself used
     the first time)."""
     plan = repeat_plan(door, facts)
@@ -165,6 +166,7 @@ async def apply_repeat(
         plan.max_field,
         plan.max_value,
         plan.debounce_minutes,
+        door.restart_on_repeat,
     )
     if patched:
         logger.info(

--- a/app/crm/outreach/schemas.py
+++ b/app/crm/outreach/schemas.py
@@ -39,6 +39,11 @@ class WorkflowEntry(BaseModel):
     on_repeat: str = "ignore"
     # Every matching repeat slides the entry wait's alarm to now + this.
     debounce_minutes: float = Field(0, ge=0)
+    # Phase 16 (G8): a repeat of this door's topic re-arms the run's CURRENT
+    # square, not only the start square — "KYC retried, the timer restarts"
+    # — sliding its alarm by debounce_minutes and merging the facts. Needs
+    # debounce_minutes > 0 (validated), or there is nothing to re-arm.
+    restart_on_repeat: bool = False
 
 
 class WorkflowEntryAt(WorkflowEntry):
@@ -60,6 +65,7 @@ _SHARED_ENTRY_WORDS = (
     "key",
     "on_repeat",
     "debounce_minutes",
+    "restart_on_repeat",
 )
 
 
@@ -119,6 +125,11 @@ class WorkflowNode(BaseModel):
     template_id: Optional[str] = None
     topics: List[str] = Field(default_factory=list)
     key: Optional[str] = None
+    # Phase 16: an optional stage label the square belongs to. It rides to
+    # templates as current_stage ("you stopped at {current_stage}") — one
+    # call template for a whole board. The stages ladder (phase 17) sets it
+    # for every square it expands.
+    stage: Optional[str] = Field(None, min_length=1)
 
 
 # An arrow: [from, to] or [from, to, on]. `on` labels a branch out of a

--- a/docs/crm/runbooks/cart-recovery.md
+++ b/docs/crm/runbooks/cart-recovery.md
@@ -130,7 +130,11 @@ curl -sS -X POST "$BASE/workflows/<wf>/runs/<run>/resume?merchant_id=$M" -H "$H"
 
 `resume` puts the run back to `waiting` with `wake_at = now` and the
 failure counter forgiven; the walker retries the same node on its next
-tick. `last_error` stays visible until the next successful step.
+tick. `last_error` stays visible until the next successful step. An
+event the parked run's square listens for also resumes it by itself —
+the customer moved, so the run is no longer stuck on what parked it —
+but that path clears `last_error` at once (the letter is the step that
+unstuck it), so the breadcrumb is only kept on a manual resume.
 
 ## Exit reasons
 

--- a/docs/crm/runbooks/loan-dropoff.md
+++ b/docs/crm/runbooks/loan-dropoff.md
@@ -79,7 +79,9 @@ Order does not matter — each clock only listens for its own stage topic.
 - **Parked runs:** `GET /workflows/<wf>/runs?merchant_id=$M&status=parked`.
   Almost always `no phone in run context` (the lender omitted the
   number) or a call template problem — fix, then
-  `POST /workflows/<wf>/runs/<run>/resume?merchant_id=$M`.
+  `POST /workflows/<wf>/runs/<run>/resume?merchant_id=$M`. A stage event
+  the parked run's square listens for resumes it by itself (and clears
+  `last_error`, unlike the manual resume).
 - **A customer's journey** = their runs across the five plans in stage
   order: `GET /customers/<customer_id>/runs?merchant_id=$M` (see "How to
   read the funnel").

--- a/tests/crm/test_worker_runtime.py
+++ b/tests/crm/test_worker_runtime.py
@@ -327,7 +327,13 @@ def test_reply_wakes_the_run_standing_on_the_listening_node(
     )
     ((kind, args),) = calls
     assert kind == "resume"
-    assert args == ("m1", str(run.id), "ask", {"reply_ask": "YES"})
+    assert args == (
+        "m1",
+        str(run.id),
+        "ask",
+        {"reply_ask": "YES"},
+        {"button_id": "YES"},
+    )
 
 
 def test_pick_next_takes_the_answer_edge_or_timeout() -> None:

--- a/tests/crm/test_workflow_entry.py
+++ b/tests/crm/test_workflow_entry.py
@@ -139,6 +139,7 @@ class _Spine:
         self.definition_reads: List[Tuple[str, int]] = []
         self.cancels: List[Tuple[str, str, Optional[Tuple[str, str]], Any]] = []
         self.resumes: List[Tuple[str, str, Dict[str, Any]]] = []
+        self.facts: List[Tuple[str, str, Any]] = []
         self.exited: set = set()
 
     async def live_workflows(self, merchant_id: str) -> List[Workflow]:
@@ -171,9 +172,15 @@ class _Spine:
         return True
 
     async def resume_run_by_id(
-        self, merchant_id: str, run_id: str, node_id: str, patch: Dict[str, Any]
+        self,
+        merchant_id: str,
+        run_id: str,
+        node_id: str,
+        patch: Dict[str, Any],
+        facts: Optional[Dict[str, Any]] = None,
     ) -> bool:
         self.resumes.append((run_id, node_id, patch))
+        self.facts.append((run_id, node_id, facts))
         return True
 
 
@@ -576,3 +583,30 @@ def test_each_door_starts_the_run_on_its_own_square(
         ("loan.kyc_completed", "at-kyc"),
         ("loan.profile_created", "at-profile"),
     ]
+
+
+# --- rollout phase 16: the letter's facts ride with the reply; a parked run
+# hears its square ---
+
+
+def test_a_reply_carries_the_letters_scalar_facts_for_its_square(
+    listening: _Spine,
+) -> None:
+    """The scalar facts of the letter (never nested objects, never the
+    walker's bookkeeping names) are offered under the square that heard
+    it, so a later call template can say what this stage's letter said."""
+    (run,) = listening.runs
+    run.status = "parked"  # an event moves a parked run too (the statement decides)
+    _consume(
+        _event(
+            "button.reply",
+            {
+                "button_id": "YES",
+                "amount": 5,
+                "nested": {"a": 1},
+                "reply_ask": "forged",
+            },
+        )
+    )
+    assert listening.resumes == [(str(run.id), "ask", {"reply_ask": "YES"})]
+    assert listening.facts == [(str(run.id), "ask", {"button_id": "YES", "amount": 5})]

--- a/tests/crm/test_workflow_plans.py
+++ b/tests/crm/test_workflow_plans.py
@@ -672,3 +672,21 @@ def test_the_migrate_guard_compares_doors_as_a_list() -> None:
     }
     problems = validate_definition(moved, occupied_nodes=["at-kyc"], live_entry=live)
     assert any("entry rule changed" in p for p in problems)
+
+
+# --- rollout phase 16: a square may carry a stage label; a door the restart word ---
+
+
+def test_a_square_may_carry_a_stage_label_and_a_door_the_restart_word() -> None:
+    doc = {
+        **_LADDER,
+        "restart_on_repeat": True,
+        "debounce_minutes": 10,
+        "nodes": [{**_LADDER["nodes"][0], "stage": "profile"}] + _LADDER["nodes"][1:],
+    }
+    assert validate_definition(doc) == []
+    definition = WorkflowDefinition.model_validate(doc)
+    assert definition.nodes[0].stage == "profile" and definition.nodes[1].stage is None
+    assert all(
+        d.restart_on_repeat and d.debounce_minutes == 10 for d in definition.entries
+    )

--- a/tests/crm/test_workflow_queries.py
+++ b/tests/crm/test_workflow_queries.py
@@ -57,9 +57,9 @@ def test_goal_cancel_and_reply_name_the_run_they_are_about() -> None:
     assert params[:2] == ["m1", "run-1"]
     sql, params = resume_run_by_id_query("m1", "run-1", "ask", {"reply_ask": "YES"})
     assert "WHERE merchant_id = $1 AND id = $2" in sql
-    assert "status = 'waiting' AND current_node = $3" in sql
+    assert "status IN ('waiting', 'parked') AND current_node = $3" in sql
     assert "RETURNING id" in sql
-    assert params == ["m1", "run-1", "ask", json.dumps({"reply_ask": "YES"})]
+    assert params[:4] == ["m1", "run-1", "ask", json.dumps({"reply_ask": "YES"})]
 
 
 def test_open_runs_for_customer_is_merchant_first_and_open_only() -> None:
@@ -204,3 +204,35 @@ def test_goal_recheck_survives_a_null_occurred_at() -> None:
     sql, params = customer_has_event_query("m1", "c-1", ["order.placed"], NOW)
     assert "COALESCE(occurred_at, received_at) > $4" in sql
     assert params == ["m1", "c-1", ["order.placed"], NOW]
+
+
+# --- rollout phase 16: a letter carries its facts into the run, and moves a
+# parked one ---
+
+
+def test_a_reply_carries_the_letters_facts_under_its_square() -> None:
+    """Facts land under facts.<square> — namespaced, so two stages'
+    payloads never collide — beside the answer."""
+    sql, params = resume_run_by_id_query(
+        "m1", "run-1", "ask", {"reply_ask": "YES"}, {"button_id": "YES", "amount": 5}
+    )
+    assert "jsonb_build_object('facts'," in sql
+    assert (
+        "CASE WHEN jsonb_typeof(context->'facts') = 'object' "
+        "THEN context->'facts' ELSE '{}'::jsonb END" in sql
+    )
+    assert "|| jsonb_build_object($3::text, $5::jsonb)" in sql
+    assert params[4] == json.dumps({"button_id": "YES", "amount": 5})
+    _, params = resume_run_by_id_query("m1", "run-1", "ask", {"reply_ask": "YES"})
+    assert params[4] == "{}"  # no facts offered: the square's entry stays empty
+
+
+def test_an_event_moves_a_parked_run_too() -> None:
+    """An event is evidence the customer moved; a parked run that hears it
+    is no longer stuck on the thing that parked it — it becomes waiting
+    with its failure counter forgiven, the human resume's semantics."""
+    sql, _ = resume_run_by_id_query("m1", "run-1", "ask", {"reply_ask": "YES"})
+    set_clause, where_clause = sql.split("WHERE")
+    assert "status IN ('waiting', 'parked')" in where_clause
+    assert "status = 'waiting'" in set_clause
+    assert "CASE WHEN status = 'parked' THEN 0 ELSE attempts END" in set_clause

--- a/tests/crm/test_workflow_repeat.py
+++ b/tests/crm/test_workflow_repeat.py
@@ -117,7 +117,8 @@ def test_patch_touches_only_an_open_run_on_the_entry_square_by_key() -> None:
         4500.0,
         10.0,
     )
-    assert "status = 'waiting' AND current_node = $4" in sql
+    assert "status = 'waiting' AND ($11::boolean OR current_node = $4)" in sql
+    assert params[10] is False  # pinned to the start square unless restart_on_repeat
     assert "enrollment_key = $3" in sql and "customer_id" not in sql
     assert "NOT (COALESCE(context->'repeat_event_ids', '[]'::jsonb) ? $5::text)" in sql
     assert "make_interval(secs => $10::float8 * 60)" in sql
@@ -302,6 +303,9 @@ def test_a_payload_can_never_plant_bookkeeping_keys_in_context() -> None:
             "lead_call": "l-1",
             "message_wa": "m-1",
             "reply_ask": "YES",
+            "facts": "junk",  # phase 16: the per-square store is ours
+            "current_node": "forged",
+            "current_stage": "forged",
         }
     )
     assert context == {"item": "tv"}
@@ -345,3 +349,52 @@ def test_the_repeat_carries_the_refreshed_phone_but_never_the_founding_id(
     assert facts["phone"] == "+919876543210"
     assert facts["cart_value"] == 900
     assert "source_event_id" not in facts
+
+
+# --- rollout phase 16: restart_on_repeat — any square re-arms on its own
+# stage's repeat (G8; the #1041 patch generalised) ---
+
+
+def test_the_patch_leaves_the_start_square_only_with_restart_on_repeat() -> None:
+    _, params = patch_open_run_query(
+        "m1", "wf-1", "ORD-1", "wait_10m", "ev-1", {}, False, None, None, 10.0
+    )
+    assert params[10] is False
+    _, params = patch_open_run_query(
+        "m1",
+        "wf-1",
+        "ORD-1",
+        "wait_10m",
+        "ev-1",
+        {},
+        False,
+        None,
+        None,
+        10.0,
+        anywhere=True,
+    )
+    assert params[10] is True
+
+
+def test_restart_on_repeat_needs_a_debounce_to_re_arm() -> None:
+    problems = validate_definition(_raw(restart_on_repeat=True))
+    assert any("restart_on_repeat" in p and "debounce" in p for p in problems)
+    assert validate_definition(_raw(restart_on_repeat=True, debounce_minutes=10)) == []
+
+
+def test_apply_repeat_hands_the_restart_word_to_the_patch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    seen: List[Any] = []
+
+    async def patch_open_run(*args: Any) -> bool:
+        seen.append(args)
+        return True
+
+    monkeypatch.setattr(repeat.accessor, "patch_open_run", patch_open_run)
+    door = _door(
+        on_repeat="refresh_latest", debounce_minutes=10, restart_on_repeat=True
+    )
+    asyncio.run(repeat.apply_repeat("m1", "wf-1", "ORD-1", door, "ev-1", {"cart": 1}))
+    ((*_, anywhere),) = seen
+    assert anywhere is True

--- a/tests/crm/test_workflow_runs.py
+++ b/tests/crm/test_workflow_runs.py
@@ -12,6 +12,7 @@ from app.crm.outreach.db.queries import (
 )
 from app.crm.outreach.nodes import lead_request_id, run_facts, send_variables
 from app.crm.outreach.runs import list_runs
+from app.crm.outreach.schemas import WorkflowNode
 from app.crm.outreach.walker import retry_delay_seconds
 
 NOW = datetime(2026, 8, 26, 14, 0, tzinfo=timezone.utc)
@@ -84,3 +85,49 @@ def test_lead_request_id_is_the_merchants_order_id_else_the_run() -> None:
     assert lead_request_id({"request_id": "req-9"}, "r-1") == "req-9"
     assert lead_request_id({"order_id": ""}, "r-1") == "wf-r-1"
     assert lead_request_id({}, "r-1") == "wf-r-1"
+
+
+def test_the_current_squares_facts_win_and_every_squares_stay_reachable() -> None:
+    """Phase 16: a letter's facts land under facts.<square>. For the
+    template the current square's facts override the top-level ones (the
+    most recent stage wins), every square's stay reachable as
+    facts_<square>_<key>, the square itself rides as current_node (and
+    current_stage when labelled), and `facts` is bookkeeping."""
+    context = {
+        "phone": "+91",
+        "amount": 100,
+        "facts": {
+            "at-kyc": {"amount": 250, "doc": "pan"},
+            "at-bank": {"bank": "hdfc"},
+        },
+    }
+    node = WorkflowNode(
+        id="at-kyc",
+        type="wait_event",
+        topics=["loan.bank_linked"],
+        key="$topic",
+        minutes=30,
+        stage="kyc",
+    )
+    facts = run_facts(context, node)
+    assert facts["amount"] == 250 and facts["doc"] == "pan"
+    assert facts["facts_at-kyc_amount"] == 250 and facts["facts_at-bank_bank"] == "hdfc"
+    assert facts["current_node"] == "at-kyc" and facts["current_stage"] == "kyc"
+    assert "facts" not in facts and "phone" not in facts
+    plain = run_facts(context)
+    assert (
+        plain["amount"] == 100 and "current_node" not in plain and "facts" not in plain
+    )
+    assert plain["facts_at-bank_bank"] == "hdfc"
+    unlabelled = WorkflowNode(id="w", type="wait", minutes=1)
+    assert "current_stage" not in run_facts(context, unlabelled)
+    assert send_variables(context, node)["current_node"] == "at-kyc"
+
+
+def test_send_variables_carry_only_what_a_provider_can_render() -> None:
+    """A bool or a None among the variables makes the WhatsApp face refuse
+    the message terminally; the producer keeps text and numbers only. The
+    call payload is not narrowed — the lead machine spells its own."""
+    context = {"name": "Priya", "amount": 1999, "vip": True, "note": None, "score": 4.5}
+    assert send_variables(context) == {"name": "Priya", "amount": 1999, "score": 4.5}
+    assert run_facts(context)["vip"] is True


### PR DESCRIPTION
## Rollout phase 16 — `docs/crm/workflow-rollout/16-facts-on-resume-and-stage-facts.md`

Depends on 00 and 15 (both merged). Notes §14.1 prerequisite (3), §14.7 objections #2/#3, §16.2, §16.3 G8. No migration.

### What changed

| Piece | Files | Change |
|---|---|---|
| **1. Facts on resume** | `db/queries.py`, `db/accessor.py`, `entry.py`, `nodes.py` | `resume_run_by_id_query(..., facts)` merges `jsonb_build_object('facts', <context.facts if it is an object, else {}> \|\| jsonb_build_object($3::text, $5::jsonb))` beside the reply — namespaced per square; a second letter on the same square replaces that square's facts and leaves the others. A legacy non-object under `facts` (a scalar a producer once sent, before the key was bookkeeping) is replaced, never concatenated into an array. The consumer offers `_context_from_payload(event.payload)`: scalars only, bookkeeping names filtered, the same bridge enrol uses. `run_facts(context, node=None)` flattens: top-level facts, then the current square's override, every square's as `facts_<square>_<key>`; `facts`, `current_node` and `current_stage` join `_BOOKKEEPING_KEYS`, so a producer can never plant them (the N19 lesson). |
| **2. `current_node` / `current_stage`** | `schemas.py`, `nodes.py` | `WorkflowNode.stage: Optional[str]`. With the square given, `run_facts` adds `current_node` and, when labelled, `current_stage`; `execute_call` and `execute_send` pass their node, so the lead payload and the send variables carry them. **`send_variables` now keeps only text and numbers** (no bool, no None): connectivity's WhatsApp payload builder refuses a message terminally on any other value, and with every listened letter's facts riding along such values become ordinary. The call payload is not narrowed. |
| **3. Parked runs movable** | `db/queries.py` | The reply UPDATE's WHERE is `status IN ('waiting', 'parked')`; SET makes it `waiting` with `attempts = CASE WHEN status = 'parked' THEN 0 ELSE attempts END`. Goal-cancel already took parked runs (`status <> 'exited'`). **Why this reaches the common parks:** action squares execute inside the visit and the row's `current_node` is only written by the next wait's `advance_run`, so a run parked because its call or send failed still stands, in the row, on the listening square before it — exactly the square whose event now resumes it, and the walker then takes the reply branch instead of retrying the failed action. A run parked behind a plain `wait` (today's cart board) listens for nothing and still needs the button, or the goal. |
| **4. `restart_on_repeat`** | `schemas.py`, `plans.py`, `repeat.py`, `db/queries.py`, `db/accessor.py` | New door word (also a top-level shared word). `patch_open_run_query(..., anywhere)` guards with `($11::boolean OR current_node = $4)` — one prepared statement, the flag bound. `apply_repeat` passes `door.restart_on_repeat`. Validator: needs `debounce_minutes > 0`. |
| Docs | `runbooks/cart-recovery.md`, `runbooks/loan-dropoff.md` | One sentence each: a stage event the parked run's square listens for resumes it by itself. |

### Proof on Postgres (scratch DB, all 64 migrations applied, the PR's builders)

```
seeded: parked run on 'ask', attempts=3
resume (parked): matched | status waiting | attempts 0 | last_error None
  context.reply_ask = YES | context.facts = {'ask': {'amount': 250, 'button_id': 'YES'}} | top-level amount still 100
resume (again): facts = {'ask': {'button_id': 'NO'}, 'other': {'x': 1}}
patch pinned to start: missed (expected) | patch anywhere: matched | amount 300 | alarm slid ~10m: True
SQL PROOF OK
```

### Red tests (fail on release, pass here)

- Queries: facts nested under `facts` per square (and `{}` when none offered); parked included in the WHERE, `waiting` + forgiven attempts in the SET; the patch carries the anywhere flag (False by default, True with `restart_on_repeat`).
- `run_facts`: the current square's facts override top-level, every square's reachable under its prefix, `facts` and bookkeeping excluded, `current_node` present and `current_stage` only when labelled; `send_variables` carries `current_node`.
- Consumer: a **parked** run on the listening square is offered the reply and the letter's scalar facts (nested objects and bookkeeping names dropped).
- `send_variables` drops a bool and a None, keeps text and numbers; the call payload keeps the bool.
- Validator: `restart_on_repeat` without a debounce is refused; `apply_repeat` hands the flag to the patch; a square accepts a `stage` label and the top-level `restart_on_repeat` reaches every door.

On release: 10 failed (8 new + 2 updated assertions), 99 passed in those files.

### Checks (strictly `&&`-chained, pytest to a log)

black, isort, autoflake clean · pyrefly 0 errors · **`pytest tests/crm`: 660 passed** (651 on release + 9) · `check_crm_boundaries.py` clean · `check_migrations.py --base origin/release`: 64, no duplicates, no gaps.

### Decisions already made that I disagree with

None.

### Review round (CodeRabbit, 1 thread — answered and resolved)

- Runbook wording said the event-driven resume keeps `last_error` like the manual one; it clears it. Both runbooks corrected.

### Judgment calls (overrule if you want)

- **Send variables are narrowed to text and numbers at the producer.** Read from `providers/whatsapp/payload.py::build_parameters`: a bool or None among the variables is a terminal refusal (`REASON_BAD_VARIABLES`) that would surface as a failed message after the run had already moved on. Entry-payload booleans could already do this; per-square facts make it common. Filtering at the producer keeps every proposed send renderable.

- **The event-driven resume clears `last_error`** (as the reply resume always did) rather than keeping it readable like the human resume. The letter is the step that unstuck the run; the docstring says so. Easy to flip if you would rather keep the operator's breadcrumb.
- **Repeats still touch only `waiting` runs.** Parked runs are moved by letters their square listens for (piece 3), not by repeats of the door's topic; a parked run is stuck on an action, and re-arming its alarm would not unstick it.
- **`facts_<square>_<key>` uses the square id verbatim** (`facts_at-kyc_amount`); the phase names this shape. If the buddy template placeholder grammar rejects hyphens, the ladder in phase 17 can mint hyphen-free ids.
- **`run_facts`/`send_variables` keep their one-argument form** (`node=None`): the reporting and journey reads keep calling them without a square.

### Known ambiguity (not a bug, noted)

- Flattened names `facts_<square>_<key>` can collide when a square id itself contains an underscore (`a` + `b_c` vs `a_b` + `c`). The current square's own facts are also exposed unprefixed, which is what a template normally reads; phase 17's ladder can mint square ids without underscores.

### Not done on purpose

- The `stages` ladder and the funnel migration (phase 17). List-shaped facts (G4, backlog).

### Adjacent observations (not touched)

- Same as before: `docs/crm/plans/README.md` still promises `on_publish: migrate` on the cart board; the notes still say `/crm/...`; phase files 10/11 say "ADR 0022".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014UNZ4z7zb87HnNHjTXoFpW


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Workflow stages can now have labels available in workflow context and messages.
  * Reply events preserve relevant letter facts for use in later workflow steps.
  * Matching events can automatically resume parked runs.
  * Repeated entry events can restart an active run from its current workflow stage.

* **Bug Fixes**
  * Resuming a parked run resets it for a fresh retry.

* **Validation**
  * Repeat-based restarts now require a debounce period to be configured.

* **Documentation**
  * Updated runbooks to explain automatic resumption of parked runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


