### PR TITLE
docs(crm): defer rollout phase 19 until #1021 merges (rollout status)

### DIFF
--- a/docs/crm/workflow-rollout/19-gate-wiring.md
+++ b/docs/crm/workflow-rollout/19-gate-wiring.md
@@ -2,6 +2,8 @@
 
 **Kind**: feat · **PR title**: `feat(crm): dispatch gate calls may_contact — consent, purpose, quiet hours, frequency` · **Depends on**: **PR #1021 merged** (`feat(crm): consent ledger, resolved state, and decision log`, rab1prasad) — the permission module and its `may_contact()` contract. If #1021 is not merged, stop; this phase is the call-site wiring, not the module. · **Notes**: §6 dispatch `_gate` TODO, §16.3 G1, design/gate-mechanics in the corpus
 
+
+**Status (2026-09-03): deferred — revisit after #1021 merges.** #1021 is open and conflicting, its migrations are numbered 055/056 (taken; next free is 066), and its contracts expose `record_consent` and `log_decision` only — no `may_contact`. This phase is the call-site wiring of that decision, so nothing here can start until the module exposes it.
 ## Design
 - `app/crm/connectivity/dispatch.py::_gate`: keep suppression as check #1 (fail closed, unchanged); then `decision = await may_contact(merchant_id, customer_id, channel, purpose_key, address)` from `app.crm.permission.contracts` (name per #1021). Decision shape (per canon): allow | refuse(reason) | defer(next_allowed_at). Refuse → `blocked` with the permission reason (add the words to `reasons.py`: `REASON_NO_CONSENT`, `REASON_PURPOSE_NOT_GRANTED`, `REASON_FREQUENCY_CAP`); defer → **requeue** with `next_attempt_at = next_allowed_at` (new `apply_outcome` path: status `queued`, reason `quiet_hours`, `retry_after_seconds` computed from the deadline; T16 col 22 says the gate's deferral writes `next_attempt_at`). `mint_send_token` carries `decision_id` onto the row (`crm_message.decision_id` exists, unused).
 - Same wait_for deadline as the suppression probe; timeout/raise → `gate_unavailable` (fail closed).

--- a/docs/crm/workflow-rollout/README.md
+++ b/docs/crm/workflow-rollout/README.md
@@ -83,12 +83,25 @@ PR has not merged yet.
 | 15 | Topic branching + multi-topic entry + reply clearing | feat | 01, 13 |
 | 16 | Facts on resume, stage facts, parked runs movable, restart-on-repeat anywhere | feat | 00, 15 |
 | 17 | `stages` ladder sugar + loan funnel migration to a board | feat + docs | 14, 15, 16 |
-| 18 | Outcome feedback into runs (G2, G3) | feat | PRs #1040/#1052 merged; 15 |
-| 19 | Permission-gate wiring (G1) | feat | PR #1021 merged |
+| 18 | Outcome feedback into runs (G2, G3) — **call half landed (#1076)**; the message half (receipts, STOP) waits | feat | PRs #1040/#1052 merged; 15 |
+| 19 | Permission-gate wiring (G1) — **deferred (2026-09-03): revisit after #1021 merges** | feat | PR #1021 merged |
 | 99 | Backlog (G4, G5, G6, G10, G11, remaining nits) | — | — |
 
 Phases 00–09 need no canon change. Phase 10 is the canon decision; 11–17
-build on it. 18 and 19 are gated on other people's PRs and can slide. Phase
+build on it. 18 and 19 are gated on other people's PRs and can slide.
+
+**Status (2026-09-03):** phases 00–17 and the call half of 18 are merged
+(release `015231e`). What remains is gated on other people's PRs:
+
+- **18, message half** — delivery receipts (`message_for_provider_id`, the
+  receipt-topic injection) and STOP → suppression: after #1040 (WhatsApp
+  webhooks) and #1052 (extractor) merge. A second PR under the same file.
+- **19** — deferred, by decision, until #1021 merges. Today #1021 conflicts
+  with release, carries migrations numbered 055/056 (both long taken; the
+  next free number is 066), and exposes `record_consent` / `log_decision`
+  only — no `may_contact`. Phase 19 is the call-site wiring of that
+  decision, so it needs the PR rebased, renumbered and extended (or a phase
+  file defining the decision contract) before it can start. Phase
 05 does not exist (its content became phase 00 when we decided to land
 #1041 ourselves); numbering was kept so cross-references stay stable.
 


### PR DESCRIPTION
Docs only — no code.

- `docs/crm/workflow-rollout/README.md`: queue rows 18 and 19 updated; a **Status (2026-09-03)** paragraph says what is merged (00–17 + the call half of 18, release `015231e`) and what is gated: the 18 message half on #1040/#1052, and **19 deferred by decision until #1021 merges** — #1021 conflicts with release, its migrations are numbered 055/056 (taken; next free is 066), and it exposes no `may_contact`.
- `docs/crm/workflow-rollout/19-gate-wiring.md`: a status line at the top saying the same.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014UNZ4z7zb87HnNHjTXoFpW