### PR TITLE
refactor(crm): structure 2 — one tenancy door and translator, one home for the manifest's words, templates split, outreach db/ per table

### DIFF
--- a/app/crm/auth.py
+++ b/app/crm/auth.py
@@ -26,7 +26,7 @@ use any of these — it is signature-verified per source in record/api.py (A9).
 """
 
 import hmac
-from typing import Optional
+from typing import Awaitable, Callable, Optional
 
 from fastapi import Depends, HTTPException, Request, status
 
@@ -35,6 +35,7 @@ from app.api.security.breeze_buddy.rbac_token import (
     rbac_token_manager,
 )
 from app.core.logger import logger
+from app.core.logger.context import set_log_context
 from app.core.security.authorization import require_admin
 from app.database.accessor.breeze_buddy.merchants import (
     check_merchant_identifier_exists,
@@ -93,6 +94,57 @@ def assert_merchant_access(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Access denied to this merchant",
         )
+
+
+#: The attribute the route-walk test looks for — a dependency produced by
+#: merchant_scope() carries it, so "every route declares the tenancy door"
+#: is a structural fact CI can read off the router, not a convention.
+MERCHANT_SCOPE_MARK = "is_merchant_scope"
+
+
+def merchant_scope(operation: str, component: str) -> Callable[..., Awaitable[str]]:
+    """The tenancy door as a route's DECLARED dependency (ADR 0007 amendment).
+
+    One dependency does what every merchant-facing route used to spell by
+    hand in three lines: find the merchant the request is about (the
+    ``merchant_id`` query param on a GET, the ``merchant_id`` body field on
+    a POST/PATCH/PUT — the TenantScoped base every request model inherits),
+    run the tenancy check, set the log context, and hand the merchant to the
+    handler. Declared, not called, for the reason the ingest door gives: a
+    route without its auth dependency is a BLOCKER, and a declaration is
+    what a test can walk the router for.
+
+    ``operation`` is the audit word ("retire a template"); ``component`` is
+    the log context's. Fail closed: no merchant in the request is a 400
+    before anything reads or writes.
+    """
+
+    async def _scope(
+        request: Request,
+        current_user: UserInfo = Depends(get_current_user_with_rbac),
+    ) -> str:
+        merchant_id: Optional[str] = request.query_params.get("merchant_id")
+        if not merchant_id and request.method in ("POST", "PUT", "PATCH"):
+            # Starlette caches the body, so the handler's own model parse
+            # reads the same bytes afterwards — one read, two readers.
+            try:
+                body = await request.json()
+            except Exception:
+                body = None
+            if isinstance(body, dict):
+                candidate = body.get("merchant_id")
+                merchant_id = candidate if isinstance(candidate, str) else None
+        if not merchant_id:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="merchant_id is required",
+            )
+        assert_merchant_access(current_user, merchant_id, operation)
+        set_log_context(component=component, merchant_id=merchant_id)
+        return merchant_id
+
+    setattr(_scope, MERCHANT_SCOPE_MARK, True)
+    return _scope
 
 
 def _extract_token(request: Request) -> Optional[str]:

--- a/app/crm/connectivity/api.py
+++ b/app/crm/connectivity/api.py
@@ -1,10 +1,10 @@
-"""The connectors surface — thin routes (module rules §1): auth, tenancy
-check, delegate to contracts.py.
+"""The connectors surface — thin routes (module rules §1): the tenancy door as
+each route's DECLARED dependency, delegate to contracts.py, one translator.
 
 Mounted at ``/connectors``. The paths carry no internal word (ADR 0022): a
 merchant connecting WhatsApp is connecting a CONNECTOR, which is the noun the
 console, the docs and the corpus all use. The provider webhook bays are NOT
-here — their routes are record's (/ingest/webhooks/{provider}); webhooks.py
+here — their routes are record's (/ingest/webhooks/{provider}); ingress.py
 registers this module's mechanics into them.
 
 **The routes are connector-agnostic.** ``POST /{connector_key}/onboard``
@@ -20,28 +20,29 @@ own onboarding. This is a deliberate early move to merchant-facing access
 (ADR 0007 rules phase 1 admin/S2S-only); admins still pass, so the pilot is
 unaffected.
 
-``merchant_id`` rides in the request — body for a POST, query for a GET — and
-is checked before anything else runs. A caller may hold several merchant_ids,
-so there is no single "current" one to infer from the token.
+**Two structural guarantees, both pinned by tests** (structure PR, 3 Sep
+2026): every route declares ``merchant_scope(...)`` — the dependency finds
+the merchant (query on a GET, the TenantScoped body on a POST/PATCH), runs
+the tenancy check, sets the log context and hands the merchant over, so a
+route cannot forget the check by omitting three lines; and ONE route class
+translates this module's exceptions into status codes, so a new route
+cannot map the same family to a different code than its neighbour.
 """
 
-from typing import Any, Dict, List, Optional
+from typing import Any, Callable, Coroutine, Dict, List, Optional
 
-from fastapi import (
-    APIRouter,
-    Body,
-    Depends,
-    HTTPException,
-    Query,
-    status,
-)
+from fastapi import APIRouter, Body, Depends, HTTPException, Query, Request, status
+from fastapi.responses import Response
+from fastapi.routing import APIRoute
 from pydantic import ValidationError
 
-from app.api.security.breeze_buddy.rbac_token import get_current_user_with_rbac
-from app.core.logger.context import set_log_context
-from app.crm.auth import assert_merchant_access
+from app.crm.auth import merchant_scope
 from app.crm.connectivity import contracts
-from app.crm.connectivity.onboarding import OnboardingError, UnknownConnectorError
+from app.crm.connectivity.onboarding import (
+    OnboardingError,
+    ResubscribeRefused,
+    UnknownConnectorError,
+)
 from app.crm.connectivity.schemas.connector import (
     InstallationRead,
     SubscriptionResult,
@@ -58,19 +59,55 @@ from app.crm.connectivity.templates import (
     TemplateInUseError,
     TemplateNotFoundError,
 )
-from app.schemas import UserInfo
-
-router = APIRouter()
 
 
-def _bad_request(error: Exception) -> HTTPException:
-    """The caller's mistake, with the reason."""
-    return HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(error))
+def translate(error: Exception) -> Optional[HTTPException]:
+    """PURE: this module's exception families -> the one status code each
+    earns. None for anything that is not ours (FastAPI keeps its own).
+
+    404 for an absence the caller named (an unknown connector, a template
+    that is not theirs); 409 for a request understood and deliberately
+    declined (a template still in use, a recovery the provider refused);
+    422 for a body the registry's own model rejects — ``include_input=False``
+    because pydantic v2 puts each error's INPUT in the detail, and a bad
+    onboard body would echo the one-shot signup code straight back; 400 for
+    every other refusal, with the reason.
+    """
+    if isinstance(error, (UnknownConnectorError, TemplateNotFoundError)):
+        return HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(error))
+    if isinstance(error, (TemplateInUseError, ResubscribeRefused)):
+        return HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(error))
+    if isinstance(error, ValidationError):
+        return HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=error.errors(include_input=False),
+        )
+    if isinstance(error, (OnboardingError, TemplateError)):
+        return HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(error))
+    return None
 
 
-def _not_found(error: Exception) -> HTTPException:
-    """An absence, with the reason."""
-    return HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(error))
+class TranslatingRoute(APIRoute):
+    """The one place this module's exceptions become status codes."""
+
+    def get_route_handler(self) -> Callable[[Request], Coroutine[Any, Any, Response]]:
+        handler = super().get_route_handler()
+
+        async def _translated(request: Request) -> Response:
+            try:
+                return await handler(request)
+            except Exception as error:  # noqa: BLE001 — re-raised unless ours
+                translated = translate(error)
+                if translated is None:
+                    raise
+                raise translated from error
+
+        return _translated
+
+
+router = APIRouter(route_class=TranslatingRoute)
+
+_NOT_FOUND = "Connection not found"
 
 
 # ---------------------------------------------------------------------------
@@ -82,7 +119,9 @@ def _not_found(error: Exception) -> HTTPException:
 async def onboard_route(
     connector_key: str,
     payload: Dict[str, Any] = Body(...),
-    current_user: UserInfo = Depends(get_current_user_with_rbac),
+    merchant_id: str = Depends(
+        merchant_scope("onboard a connector", "crm.connectivity.onboard")
+    ),
 ) -> InstallationRead:
     """Connect a merchant to one connector account.
 
@@ -90,55 +129,30 @@ async def onboard_route(
     is what keeps this route from growing a branch per connector. FastAPI's
     own validation still runs — just against the model the spec names.
     """
-    merchant_id = str(payload.get("merchant_id") or "")
-    if not merchant_id:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="merchant_id is required",
-        )
-    assert_merchant_access(current_user, merchant_id, "onboard a connector")
-    set_log_context(component="crm.connectivity.onboard", merchant_id=merchant_id)
-    try:
-        return await contracts.onboard(merchant_id, connector_key, payload)
-    except UnknownConnectorError as e:
-        raise _not_found(e) from e
-    except ValidationError as e:
-        # include_input=False: pydantic v2 puts each error's INPUT in the
-        # detail, so a bad body would echo the one-shot signup code straight
-        # back to the caller. Field names and messages are all they need.
-        raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-            detail=e.errors(include_input=False),
-        ) from e
-    except OnboardingError as e:
-        raise _bad_request(e) from e
+    return await contracts.onboard(merchant_id, connector_key, payload)
 
 
 @router.get("/installations", response_model=List[InstallationRead])
 async def list_installations_route(
-    merchant_id: str = Query(..., description="Tenant scope — required"),
-    current_user: UserInfo = Depends(get_current_user_with_rbac),
+    merchant_id: str = Depends(
+        merchant_scope("list connections", "crm.connectivity.installations")
+    ),
 ) -> List[InstallationRead]:
     """Every connected account this merchant holds."""
-    assert_merchant_access(current_user, merchant_id, "list connections")
-    set_log_context(component="crm.connectivity.installations", merchant_id=merchant_id)
     return await contracts.list_installations(merchant_id)
 
 
 @router.get("/installations/{installation_id}", response_model=InstallationRead)
 async def get_installation_route(
     installation_id: str,
-    merchant_id: str = Query(..., description="Tenant scope — required"),
-    current_user: UserInfo = Depends(get_current_user_with_rbac),
+    merchant_id: str = Depends(
+        merchant_scope("read a connection", "crm.connectivity.installations")
+    ),
 ) -> InstallationRead:
     """One connected account, merchant-scoped."""
-    assert_merchant_access(current_user, merchant_id, "read a connection")
-    set_log_context(component="crm.connectivity.installations", merchant_id=merchant_id)
     installation = await contracts.get_installation(merchant_id, installation_id)
     if installation is None:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND, detail="Connection not found"
-        )
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=_NOT_FOUND)
     return installation
 
 
@@ -147,20 +161,46 @@ async def get_installation_route(
 )
 async def disconnect_route(
     installation_id: str,
-    merchant_id: str = Query(..., description="Tenant scope — required"),
-    current_user: UserInfo = Depends(get_current_user_with_rbac),
+    merchant_id: str = Depends(
+        merchant_scope("disconnect a connection", "crm.connectivity.disconnect")
+    ),
 ) -> InstallationRead:
     """Revoke a connected account; its pipes pause with it."""
-    assert_merchant_access(current_user, merchant_id, "disconnect a connection")
-    set_log_context(component="crm.connectivity.disconnect", merchant_id=merchant_id)
     installation = await contracts.disconnect(merchant_id, installation_id)
     if installation is None:
         # Unknown id and another tenant's id are one answer — the second must
         # not be distinguishable, or the endpoint enumerates installations.
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND, detail="Connection not found"
-        )
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=_NOT_FOUND)
     return installation
+
+
+@router.post(
+    "/installations/{installation_id}/subscribe",
+    response_model=SubscriptionResult,
+)
+async def subscribe_installation_route(
+    installation_id: str,
+    merchant_id: str = Depends(
+        merchant_scope("subscribe a connection", "crm.connectivity.subscribe")
+    ),
+) -> SubscriptionResult:
+    """(Re)subscribe this connected account to our app's webhooks.
+
+    Onboarding subscribes on its happy path; this is the RECOVERY door — a
+    handshake that could not subscribe, or an account the provider quietly
+    unsubscribed — and it spends no fresh signup code, which re-onboarding
+    would require. A refusal is a 409 (ResubscribeRefused: understood and
+    deliberately declined, with a message the caller can act on). Success
+    re-stamps the door's health in the same act, so sends resolve again
+    without a second button.
+    """
+    installation = await contracts.resubscribe(merchant_id, installation_id)
+    if installation is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=_NOT_FOUND)
+    return SubscriptionResult(
+        installation_id=installation_id,
+        external_account_id=installation.external_account_id or "",
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -174,43 +214,38 @@ async def disconnect_route(
 @router.post("/templates", response_model=TemplateRead)
 async def create_template_route(
     req: CreateTemplateDraftRequest,
-    current_user: UserInfo = Depends(get_current_user_with_rbac),
+    merchant_id: str = Depends(
+        merchant_scope("create a template", "crm.connectivity.templates")
+    ),
 ) -> TemplateRead:
-    assert_merchant_access(current_user, req.merchant_id, "create a template")
-    set_log_context(component="crm.connectivity.templates", merchant_id=req.merchant_id)
-    try:
-        return await contracts.create_template_draft(
-            req.merchant_id,
-            req.channel,
-            req.provider_account_ref,
-            req.name,
-            req.language,
-            req.components,
-        )
-    except TemplateError as e:
-        raise _bad_request(e) from e
+    return await contracts.create_template_draft(
+        merchant_id,
+        req.channel,
+        req.provider_account_ref,
+        req.name,
+        req.language,
+        req.components,
+    )
 
 
 @router.get("/templates", response_model=List[TemplateRead])
 async def list_templates_route(
-    merchant_id: str = Query(..., description="Tenant scope — required"),
     channel: Optional[str] = Query(None),
     status_filter: Optional[str] = Query(None, alias="status"),
-    current_user: UserInfo = Depends(get_current_user_with_rbac),
+    merchant_id: str = Depends(
+        merchant_scope("list templates", "crm.connectivity.templates")
+    ),
 ) -> List[TemplateRead]:
-    assert_merchant_access(current_user, merchant_id, "list templates")
-    set_log_context(component="crm.connectivity.templates", merchant_id=merchant_id)
     return await contracts.list_templates(merchant_id, channel, status_filter)
 
 
 @router.get("/templates/{template_id}", response_model=TemplateRead)
 async def get_template_route(
     template_id: str,
-    merchant_id: str = Query(..., description="Tenant scope — required"),
-    current_user: UserInfo = Depends(get_current_user_with_rbac),
+    merchant_id: str = Depends(
+        merchant_scope("read a template", "crm.connectivity.templates")
+    ),
 ) -> TemplateRead:
-    assert_merchant_access(current_user, merchant_id, "read a template")
-    set_log_context(component="crm.connectivity.templates", merchant_id=merchant_id)
     template = await contracts.get_template(merchant_id, template_id)
     if template is None:
         raise HTTPException(
@@ -223,85 +258,30 @@ async def get_template_route(
 async def submit_template_route(
     template_id: str,
     req: SubmitTemplateRequest,
-    current_user: UserInfo = Depends(get_current_user_with_rbac),
+    merchant_id: str = Depends(
+        merchant_scope("submit a template", "crm.connectivity.templates")
+    ),
 ) -> TemplateRead:
-    assert_merchant_access(current_user, req.merchant_id, "submit a template")
-    set_log_context(component="crm.connectivity.templates", merchant_id=req.merchant_id)
-    try:
-        return await contracts.submit_template(
-            req.merchant_id, template_id, req.category
-        )
-    except TemplateNotFoundError as e:
-        raise _not_found(e) from e
-    except TemplateError as e:
-        raise _bad_request(e) from e
+    return await contracts.submit_template(merchant_id, template_id, req.category)
 
 
 @router.patch("/templates/{template_id}", response_model=TemplateRead)
 async def edit_template_route(
     template_id: str,
     req: EditTemplateRequest,
-    current_user: UserInfo = Depends(get_current_user_with_rbac),
+    merchant_id: str = Depends(
+        merchant_scope("edit a template", "crm.connectivity.templates")
+    ),
 ) -> TemplateRead:
-    assert_merchant_access(current_user, req.merchant_id, "edit a template")
-    set_log_context(component="crm.connectivity.templates", merchant_id=req.merchant_id)
-    try:
-        return await contracts.edit_template(
-            req.merchant_id, template_id, req.components
-        )
-    except TemplateNotFoundError as e:
-        raise _not_found(e) from e
-    except TemplateError as e:
-        raise _bad_request(e) from e
+    return await contracts.edit_template(merchant_id, template_id, req.components)
 
 
 @router.post("/templates/{template_id}/retire", response_model=TemplateRead)
 async def retire_template_route(
     template_id: str,
     req: RetireTemplateRequest,
-    current_user: UserInfo = Depends(get_current_user_with_rbac),
+    merchant_id: str = Depends(
+        merchant_scope("retire a template", "crm.connectivity.templates")
+    ),
 ) -> TemplateRead:
-    assert_merchant_access(current_user, req.merchant_id, "retire a template")
-    set_log_context(component="crm.connectivity.templates", merchant_id=req.merchant_id)
-    try:
-        return await contracts.retire_template(req.merchant_id, template_id)
-    except TemplateNotFoundError as e:
-        raise _not_found(e) from e
-    except TemplateInUseError as e:
-        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(e)) from e
-    except TemplateError as e:
-        raise _bad_request(e) from e
-
-
-@router.post(
-    "/installations/{installation_id}/subscribe",
-    response_model=SubscriptionResult,
-)
-async def subscribe_installation_route(
-    installation_id: str,
-    merchant_id: str = Query(..., description="Tenant scope — required"),
-    current_user: UserInfo = Depends(get_current_user_with_rbac),
-) -> SubscriptionResult:
-    """(Re)subscribe this connected account to our app's webhooks.
-
-    Onboarding subscribes on its happy path; this is the RECOVERY door — a
-    handshake that could not subscribe, or an account the provider quietly
-    unsubscribed — and it spends no fresh signup code, which re-onboarding
-    would require. 409 on refusal: understood and deliberately declined,
-    with a message the caller can act on. Success re-stamps the door's
-    health in the same act, so sends resolve again without a second button.
-    """
-    assert_merchant_access(current_user, merchant_id, "subscribe a connection")
-    set_log_context(component="crm.connectivity.subscribe", merchant_id=merchant_id)
-    try:
-        installation = await contracts.resubscribe(merchant_id, installation_id)
-    except OnboardingError as e:
-        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(e)) from e
-    if installation is None:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND, detail="Connection not found"
-        )
-    return SubscriptionResult(
-        installation_id=installation_id,
-        external_account_id=installation.external_account_id or "",
-    )
+    return await contracts.retire_template(merchant_id, template_id)

--- a/app/crm/connectivity/contracts.py
+++ b/app/crm/connectivity/contracts.py
@@ -59,15 +59,17 @@ from app.crm.connectivity.onboarding import (
     resubscribe,
 )
 from app.crm.connectivity.queue import queue_message
+from app.crm.connectivity.retire_guard import register_retire_guard
+from app.crm.connectivity.template_reads import (
+    get as get_template,
+    list_templates,
+    template_status,
+)
 from app.crm.connectivity.templates import (
     create_draft as create_template_draft,
     edit as edit_template,
-    get as get_template,
-    list_templates,
-    register_retire_guard,
     retire as retire_template,
     submit as submit_template,
-    template_status,
 )
 
 __all__ = [

--- a/app/crm/connectivity/db/accessors/message.py
+++ b/app/crm/connectivity/db/accessors/message.py
@@ -15,6 +15,7 @@ from app.crm.connectivity.db.queries.message import (
     requeue_stale_claims_query,
 )
 from app.crm.connectivity.schemas.message import QueuedMessage
+from app.crm.connectivity.status import MESSAGE_QUEUED
 from app.crm.shared.db import crm_connection
 
 
@@ -66,8 +67,8 @@ async def requeue_stale_claims(
     query, values = requeue_stale_claims_query(stale_minutes, max_attempts)
     async with crm_connection() as conn:
         rows = await conn.fetch(query, *values)
-    requeued = [str(row["id"]) for row in rows if row["status"] == "queued"]
-    dead = [str(row["id"]) for row in rows if row["status"] != "queued"]
+    requeued = [str(row["id"]) for row in rows if row["status"] == MESSAGE_QUEUED]
+    dead = [str(row["id"]) for row in rows if row["status"] != MESSAGE_QUEUED]
     return requeued, dead
 
 

--- a/app/crm/connectivity/db/queries/message.py
+++ b/app/crm/connectivity/db/queries/message.py
@@ -12,6 +12,16 @@ reads it through that layer's accessor, never SQL from here.
 import json
 from typing import Any, Dict, List, Optional, Tuple
 
+from app.crm.connectivity.reasons import (
+    REASON_ATTEMPTS_EXHAUSTED,
+    REASON_RECLAIMED_STALE_CLAIM,
+)
+from app.crm.connectivity.status import (
+    MESSAGE_DEAD,
+    MESSAGE_QUEUED,
+    MESSAGE_SENDING,
+)
+
 MESSAGE_TABLE = "crm_message"
 
 # Named once so the claim's RETURNING and the decoder cannot drift apart.
@@ -72,13 +82,13 @@ def claim_queued_messages_query(batch_size: int) -> Tuple[str, List[Any]]:
     """
     query = f"""
         UPDATE {MESSAGE_TABLE}
-           SET status = 'sending',
+           SET status = $2,
                claimed_at = now(),
                attempt = attempt + 1
          WHERE id IN (
                SELECT id
                  FROM {MESSAGE_TABLE}
-                WHERE status = 'queued'
+                WHERE status = $3
                   AND next_attempt_at <= now()
                 ORDER BY next_attempt_at
                 LIMIT $1
@@ -86,7 +96,7 @@ def claim_queued_messages_query(batch_size: int) -> Tuple[str, List[Any]]:
          )
         RETURNING {CLAIMED_COLUMNS}
     """
-    return query, [batch_size]
+    return query, [batch_size, MESSAGE_SENDING, MESSAGE_QUEUED]
 
 
 def requeue_stale_claims_query(
@@ -108,16 +118,23 @@ def requeue_stale_claims_query(
     query = f"""
         UPDATE {MESSAGE_TABLE}
            SET status = CASE WHEN attempt >= $2::int
-                             THEN 'dead' ELSE 'queued' END,
+                             THEN $3::text ELSE $4::text END,
                reason = CASE WHEN attempt >= $2::int
-                             THEN 'max_attempts_exhausted'
-                             ELSE 'reclaimed_stale_claim' END,
+                             THEN $5::text ELSE $6::text END,
                claimed_at = NULL
-         WHERE status = 'sending'
+         WHERE status = $7
            AND claimed_at < now() - make_interval(mins => $1::int)
         RETURNING id, status
     """
-    return query, [stale_minutes, max_attempts]
+    return query, [
+        stale_minutes,
+        max_attempts,
+        MESSAGE_DEAD,
+        MESSAGE_QUEUED,
+        REASON_ATTEMPTS_EXHAUSTED,
+        REASON_RECLAIMED_STALE_CLAIM,
+        MESSAGE_SENDING,
+    ]
 
 
 def apply_outcome_query(
@@ -154,7 +171,7 @@ def apply_outcome_query(
                    ELSE now() + make_interval(secs => $6::int)
                END
          WHERE id = $1
-           AND status = 'sending'
+           AND status = $8
            AND attempt = $7::int
         RETURNING id
     """
@@ -166,4 +183,5 @@ def apply_outcome_query(
         mark_sent,
         retry_after_seconds,
         attempt,
+        MESSAGE_SENDING,
     ]

--- a/app/crm/connectivity/db/queries/template.py
+++ b/app/crm/connectivity/db/queries/template.py
@@ -326,7 +326,8 @@ def lock_template_exclusive_query(key: int) -> Tuple[str, List[Any]]:
     EXCLUSIVE for the rest of the transaction — waits for every in-flight
     pinner of this template to commit, and makes later pinners wait for
     the verdict."""
-    return "SELECT pg_advisory_xact_lock($1::bigint)", [key]
+    query = "SELECT pg_advisory_xact_lock($1::bigint)"
+    return query, [key]
 
 
 def retire_template_query(merchant_id: str, template_id: str) -> Tuple[str, List[Any]]:

--- a/app/crm/connectivity/dispatch.py
+++ b/app/crm/connectivity/dispatch.py
@@ -39,6 +39,13 @@ from app.crm.connectivity.reasons import (
 )
 from app.crm.connectivity.schemas.message import QueuedMessage, SendOutcome, SendToken
 from app.crm.connectivity.send import send
+from app.crm.connectivity.status import (
+    MESSAGE_ACCEPTED,
+    MESSAGE_BLOCKED,
+    MESSAGE_DEAD,
+    MESSAGE_FAILED,
+    MESSAGE_QUEUED,
+)
 from app.crm.platform.contracts import is_suppressed
 
 LOG_COMPONENT = "crm.connectivity.dispatch"
@@ -53,14 +60,10 @@ LOG_ID_SAMPLE = 100
 # CRM_DISPATCH_MAX_ATTEMPTS cannot silently park a message for hours.
 RETRY_MAX_SECONDS = 300
 
+# The manifest's words live in status.py (one home, four vocabularies):
 # 'failed' is the provider refusing for good; 'blocked' is US refusing
 # (gate, no route); 'dead' is us running out of retries. A merchant asking
 # why nothing arrived needs to know which (T16 col 12).
-STATUS_QUEUED = "queued"
-STATUS_ACCEPTED = "accepted"
-STATUS_FAILED = "failed"
-STATUS_BLOCKED = "blocked"
-STATUS_DEAD = "dead"
 
 # All REASON_* words live in reasons.py — one file, one name per failure
 # mode. Channel metadata (which handle kind the gate probes) lives in
@@ -103,19 +106,19 @@ def plan_for_outcome(
     Pure, so the whole retry policy is testable without a database.
     ``attempt`` already counts this try — the claim increments it.
     """
-    if outcome.status == STATUS_ACCEPTED:
+    if outcome.status == MESSAGE_ACCEPTED:
         return DispatchPlan(
-            status=STATUS_ACCEPTED,
+            status=MESSAGE_ACCEPTED,
             reason=None,
             provider_message_id=outcome.provider_message_id,
             mark_sent=True,
         )
 
-    if outcome.status == STATUS_BLOCKED:
+    if outcome.status == MESSAGE_BLOCKED:
         # OUR refusal: terminal, nothing was sent, and retrying cannot
         # change what WE decided (T16: blocked vs failed vs dead).
         return DispatchPlan(
-            status=STATUS_BLOCKED,
+            status=MESSAGE_BLOCKED,
             reason=outcome.reason or REASON_GATE_UNAVAILABLE,
             provider_message_id=None,
             mark_sent=False,
@@ -126,7 +129,7 @@ def plan_for_outcome(
 
     if not outcome.retryable:
         return DispatchPlan(
-            status=STATUS_FAILED,
+            status=MESSAGE_FAILED,
             reason=reason,
             provider_message_id=outcome.provider_message_id,
             mark_sent=False,
@@ -135,7 +138,7 @@ def plan_for_outcome(
     if attempt >= max_attempts:
         # Our reason, not the provider's last error — we stopped, they didn't.
         return DispatchPlan(
-            status=STATUS_DEAD,
+            status=MESSAGE_DEAD,
             reason=REASON_ATTEMPTS_EXHAUSTED,
             provider_message_id=outcome.provider_message_id,
             mark_sent=False,
@@ -149,7 +152,7 @@ def plan_for_outcome(
     # response we lost, the retry sends again. Bounded by the claim lease,
     # not eliminated.
     return DispatchPlan(
-        status=STATUS_QUEUED,
+        status=MESSAGE_QUEUED,
         reason=reason,
         provider_message_id=outcome.provider_message_id,
         mark_sent=False,
@@ -313,7 +316,7 @@ async def _dispatch_one(message: QueuedMessage, max_attempts: int) -> None:
         # cannot probe), not policy — the one refusal an operator must notice.
         log = logger.error if refusal == REASON_GATE_UNAVAILABLE else logger.warning
         log(f"message {message.id} blocked by gate — {refusal}")
-        outcome = SendOutcome(status=STATUS_BLOCKED, reason=refusal)
+        outcome = SendOutcome(status=MESSAGE_BLOCKED, reason=refusal)
     else:
         try:
             outcome = await send(mint_send_token(message), message)
@@ -322,7 +325,7 @@ async def _dispatch_one(message: QueuedMessage, max_attempts: int) -> None:
             # saw it. opt(exception=) — loguru drops exc_info's stack.
             logger.opt(exception=e).error(f"send raised for message {message.id}")
             outcome = SendOutcome(
-                status=STATUS_FAILED, reason=REASON_SEND_ERROR, retryable=True
+                status=MESSAGE_FAILED, reason=REASON_SEND_ERROR, retryable=True
             )
 
     # message.attempt already counts this try — the claim incremented it.

--- a/app/crm/connectivity/onboarding.py
+++ b/app/crm/connectivity/onboarding.py
@@ -77,6 +77,12 @@ class OnboardingError(Exception):
     """Onboarding refused before, or instead of, writing a connection."""
 
 
+class ResubscribeRefused(OnboardingError):
+    """The recovery door understood the request and deliberately declined —
+    a 409, not a 400: the account is not this connector's to subscribe, holds
+    no usable credentials, or the provider refused in its own words."""
+
+
 class UnknownConnectorError(OnboardingError):
     """No such connector_key — the registry IS the vocabulary, so this is a
     404 rather than a bad request."""
@@ -442,12 +448,14 @@ async def resubscribe(
         # Refusing beats guessing: running Meta's call against a connector
         # that has no subscription step would send a request nothing there
         # understands.
-        raise OnboardingError(
+        raise ResubscribeRefused(
             f"This account is a '{installation.connector_key}' connector, "
             f"which has no webhook subscription to turn on."
         )
     if not installation.external_account_id:
-        raise OnboardingError("This account has no provider account id to subscribe.")
+        raise ResubscribeRefused(
+            "This account has no provider account id to subscribe."
+        )
 
     try:
         bundle = await accounts.bundle_for(installation)
@@ -456,7 +464,7 @@ async def resubscribe(
         # here: no usable secret to subscribe with. (A vault OUTAGE raises
         # past this except and surfaces as the route's 500, never as
         # "reconnect your account" advice for a healthy credential.)
-        raise OnboardingError(
+        raise ResubscribeRefused(
             "This account's credentials are missing or unreadable. "
             "Reconnect it first."
         )
@@ -467,7 +475,7 @@ async def resubscribe(
         # The provider's own refusal, passed through: the merchant's "why"
         # gets the provider's words, not our paraphrase.
         logger.error(f"resubscribe: {installation.connector_key} refused — {e}")
-        raise OnboardingError(str(e)) from e
+        raise ResubscribeRefused(str(e)) from e
 
     return await atomically(_resubscribe_in_txn, merchant_id, installation_id)
 

--- a/app/crm/connectivity/retire_guard.py
+++ b/app/crm/connectivity/retire_guard.py
@@ -1,0 +1,42 @@
+"""The retire guard slot (rollout phase 14, ADR 0023 §6) — outreach's answer
+to "who would still send this template?", filled at the composition root.
+
+(merchant_id, channel, name) -> (open runs whose PINNED document names it,
+live or paused plans whose LATEST document names it). Connectivity may not
+import outreach (outreach already reads this module's contracts; the reverse
+arrow would close an import cycle), so the slot is filled by
+app/crm/worker_main.py — the record/consumers.py inversion (checker rule 12;
+modules/00 §11). Empty until then, and templates.retire() fails CLOSED on
+empty: a missing registration is a wiring bug, never permission to delete
+what a run is about to send.
+
+Its own file so templates.py holds the four lifecycle transitions and nothing
+else; the guard is plumbing the transitions call, not a transition.
+"""
+
+from typing import Awaitable, Callable, Optional, Tuple
+
+RetireGuard = Callable[[str, str, str], Awaitable[Tuple[int, int]]]
+_retire_guard: Optional[RetireGuard] = None
+
+
+def register_retire_guard(guard: RetireGuard) -> None:
+    """Idempotent: imports can run more than once (tests, reload)."""
+    global _retire_guard
+    _retire_guard = guard
+
+
+def registered() -> bool:
+    """Whether the composition root has filled the slot."""
+    return _retire_guard is not None
+
+
+async def workflows_naming(
+    merchant_id: str, channel: str, name: str
+) -> Optional[Tuple[int, int]]:
+    """GATHER for retire: (open runs whose pinned document sends this
+    template, live or paused plans whose latest document does) — or None
+    when nothing is registered, which the caller treats as a refusal."""
+    if _retire_guard is None:
+        return None
+    return await _retire_guard(merchant_id, channel, name)

--- a/app/crm/connectivity/schemas/template.py
+++ b/app/crm/connectivity/schemas/template.py
@@ -6,6 +6,8 @@ from typing import Any, Dict, List, Optional
 
 from pydantic import BaseModel, Field
 
+from app.crm.connectivity.schemas.tenancy import TenantScoped
+
 
 class TemplateDraft(BaseModel):
     """What a provider needs to register a template. The local row's id and
@@ -63,13 +65,12 @@ class ProviderTemplateState(BaseModel):
 # ---------------------------------------------------------------------------
 
 
-class CreateTemplateDraftRequest(BaseModel):
+class CreateTemplateDraftRequest(TenantScoped):
     """Body for POST /connectors/templates. ``components`` is stored verbatim — the
     provider's own registered structure — and is never validated against
     their schema here: that is the provider's job at submission time, and a
     second validator would refuse shapes they accept."""
 
-    merchant_id: str = Field(..., description="Tenant scope — required")
     channel: str = Field(..., description="Must name a registered connector")
     provider_account_ref: str = Field(
         ..., description="The account that owns this template (a WABA id)"
@@ -83,8 +84,7 @@ class CreateTemplateDraftRequest(BaseModel):
     )
 
 
-class SubmitTemplateRequest(BaseModel):
-    merchant_id: str = Field(..., description="Tenant scope — required")
+class SubmitTemplateRequest(TenantScoped):
     category: str = Field(
         ...,
         description=(
@@ -94,15 +94,27 @@ class SubmitTemplateRequest(BaseModel):
     )
 
 
-class EditTemplateRequest(BaseModel):
-    merchant_id: str = Field(..., description="Tenant scope — required")
+class EditTemplateRequest(TenantScoped):
     components: List[Dict[str, Any]] = Field(
         ..., description="Replacement components, verbatim"
     )
 
 
-class RetireTemplateRequest(BaseModel):
-    merchant_id: str = Field(..., description="Tenant scope — required")
+class RetireTemplateRequest(TenantScoped):
+    """Body for POST /connectors/templates/{id}/retire — the tenant, nothing
+    else; the id rides in the path."""
+
+
+class TemplateVerdict(BaseModel):
+    """The publish-time answer for one template NAME on one channel (rollout
+    phase 08, G12), verdict-shaped so the words stay inside connectivity:
+    outreach reads ``publishable`` and quotes ``reason`` — it never compares a
+    status word across the module seam. ``reason`` is the clause after the
+    template's name in a refusal ("is 'pending', not approved"); None when
+    publishable."""
+
+    publishable: bool
+    reason: Optional[str] = None
 
 
 class TemplateRead(BaseModel):

--- a/app/crm/connectivity/schemas/tenancy.py
+++ b/app/crm/connectivity/schemas/tenancy.py
@@ -1,0 +1,17 @@
+"""The one field every request body that names a merchant declares.
+
+``merchant_scope`` (app/crm/auth.py) reads it from the body of a POST or
+PATCH exactly as it reads ``merchant_id`` from a GET's query — so a route
+never spells the tenancy check itself, and a request model that forgets
+to inherit this base is a body the dependency cannot scope (a 400, never a
+silent pass).
+"""
+
+from pydantic import BaseModel, Field
+
+
+class TenantScoped(BaseModel):
+    """Base for request bodies: the merchant the caller must be allowed to
+    touch. Checked BEFORE the handler runs, by the route's dependency."""
+
+    merchant_id: str = Field(..., description="Tenant scope — required")

--- a/app/crm/connectivity/send.py
+++ b/app/crm/connectivity/send.py
@@ -35,7 +35,7 @@ from typing import Optional, Union
 
 from app.core.config.static import CRM_MESSAGE_SEND_TIMEOUT_SECONDS
 from app.core.logger import logger
-from app.crm.connectivity import accounts, templates
+from app.crm.connectivity import accounts, template_reads
 from app.crm.connectivity.channels import registers_templates_for
 from app.crm.connectivity.db.accessors import (
     binding as binding_accessor,
@@ -142,7 +142,7 @@ async def resolve_send_route(
             # The adapter refuses this too, but refusing here keeps the
             # reason on the near side of the wire for every such channel.
             return REASON_NO_TEMPLATE
-        template = await templates.approved_template(
+        template = await template_reads.approved_template(
             merchant_id, channel, installation.external_account_id, template_name
         )
         if template is None:

--- a/app/crm/connectivity/status.py
+++ b/app/crm/connectivity/status.py
@@ -1,12 +1,15 @@
-"""The three status vocabularies this module writes, and the transition sets
+"""The four status vocabularies this module writes, and the transition sets
 that read them.
 
-ONE file, three sections, rather than three files: the vocabularies are small
-(7 · 5 · 3 words) and two of them are read TOGETHER at the only place that
-moves both — onboarding, where a door's status and its pipes' statuses change
-in one atom. Three modules would make that file import three names to state
-one transition, and would suggest the three lists change independently. They
-do not.
+ONE file, four sections, rather than four files: the vocabularies are small
+(7 · 5 · 3 · 9 words) and two of them are read TOGETHER at the only place
+that moves both — onboarding, where a door's status and its pipes' statuses
+change in one atom. Separate modules would make that file import several
+names to state one transition, and would suggest the lists change
+independently. They do not. The manifest's words (T16) joined 3 Sep 2026 —
+they had a second home in dispatch.py and were spelled as literals inside
+the claim and the sweep, which is exactly the two-definitions scar this file
+exists to close; the vocabulary test walks every builder for every word here.
 
 **These words are OPEN sets, not closed ones.** Migration 061 ships no CHECK
 on ``crm_channel_template.status`` and says why: the status vocabulary is the
@@ -91,3 +94,24 @@ BINDING_PAUSED = "paused"
 #: may have recycled it to someone else, so re-onboarding must RAISE rather
 #: than resurrect it.
 BINDING_RETIRED = "retired"
+
+# ---------------------------------------------------------------------------
+# crm_message (T16) — the manifest. Canon T16 col 12: one stamped word.
+# ---------------------------------------------------------------------------
+
+#: Migration 056's column default: proposed, gate not yet asked.
+MESSAGE_QUEUED = "queued"
+#: The in-flight word a claim stamps (T16 col 12, 29 Aug 2026): the claim
+#: must COMMIT before the provider call, so "claimed" is visible in the row.
+MESSAGE_SENDING = "sending"
+#: US refusing — the gate, no route (T16 col 13 carries the reason).
+MESSAGE_BLOCKED = "blocked"
+#: The provider took it; the receipt walker moves it on from here.
+MESSAGE_ACCEPTED = "accepted"
+MESSAGE_SENT = "sent"
+MESSAGE_DELIVERED = "delivered"
+MESSAGE_READ = "read"
+#: The provider refused for good.
+MESSAGE_FAILED = "failed"
+#: We ran out of retries — the provider never said no, we stopped asking.
+MESSAGE_DEAD = "dead"

--- a/app/crm/connectivity/template_reads.py
+++ b/app/crm/connectivity/template_reads.py
@@ -1,0 +1,121 @@
+"""The template registry's READS (T23) — every read of the table, in one file.
+
+templates.py owns the four lifecycle transitions (create · submit · edit ·
+retire); this file owns what the rest of the system ASKS the registry:
+
+  get / list_templates   the console's reads
+  template_status        the publish-time question (rollout phase 08, G12),
+                         verdict-shaped so the words never leave this module
+  approved_template      the send-time question — the ROW, not a field
+
+Two logic files owning reads on one table is how two answers to "is this
+approved" appear; that is why the send door and the publish check both ask
+here, and why the transitions file reads nothing itself.
+"""
+
+from typing import Dict, List, Optional
+
+from app.core.logger import logger
+from app.crm.connectivity.db.accessors import template as template_accessor
+from app.crm.connectivity.schemas.template import (
+    ApprovedTemplate,
+    TemplateRead,
+    TemplateVerdict,
+)
+from app.crm.connectivity.status import TEMPLATE_APPROVED
+
+
+async def get(merchant_id: str, template_id: str) -> Optional[TemplateRead]:
+    return await template_accessor.get_template(merchant_id, template_id)
+
+
+async def list_templates(
+    merchant_id: str, channel: Optional[str] = None, status: Optional[str] = None
+) -> List[TemplateRead]:
+    return await template_accessor.list_templates(merchant_id, channel, status)
+
+
+async def template_status(merchant_id: str, channel: str, name: str) -> TemplateVerdict:
+    """Is this template NAME publishable on this channel — the registry's
+    one publish-time read (rollout phase 08, G12).
+
+    A workflow's send node names a template and a channel, never the
+    provider account that will serve it (the route picks that at send
+    time), so the question is asked across the merchant's accounts:
+
+      * no row under that name — never registered here;
+      * every account holding the name holds exactly ONE approved row —
+        publishable (the send door will find its one row whichever account
+        the route picks);
+      * some account holds several approved rows — the ambiguity
+        approved_template refuses at send time, refused here first;
+      * otherwise the newest row's status, so the refusal can say why.
+
+    Verdict-shaped (3 Sep 2026 audit): outreach reads ``publishable`` and
+    quotes ``reason``; it never compares a status word of this module's
+    across the seam. ``reason`` is the clause after the template's name.
+    """
+    rows = await template_accessor.templates_by_name(merchant_id, channel, name)
+    if not rows:
+        return TemplateVerdict(
+            publishable=False,
+            reason=f"is not registered on {channel} for this merchant",
+        )
+    approved_per_account: Dict[str, int] = {}
+    for row in rows:
+        if row.status == TEMPLATE_APPROVED:
+            approved_per_account[row.provider_account_ref] = (
+                approved_per_account.get(row.provider_account_ref, 0) + 1
+            )
+    if approved_per_account:
+        crowded = max(approved_per_account.values())
+        if crowded > 1:
+            return TemplateVerdict(
+                publishable=False,
+                reason=f"is approved in {crowded} languages on one account — "
+                "exactly one is required to send",
+            )
+        return TemplateVerdict(publishable=True)
+    return TemplateVerdict(
+        publishable=False, reason=f"is '{rows[0].status}', not approved"
+    )
+
+
+async def approved_template(
+    merchant_id: str, channel: str, provider_account_ref: str, name: str
+) -> Optional[ApprovedTemplate]:
+    """Is this template name approved on this account — and if so, the row.
+
+    The registry's one public read for the send path. It states a FACT and
+    nothing else — the caller owns the word for "no", exactly as the binding
+    and installation steps already separate the fact from the refusal.
+
+    The answer is the ROW, not one of its fields: which field a send needs is
+    the adapter's business (WhatsApp renders by language, SMS-DLT sends the
+    provider's id), and a registry that answered "the language" would be
+    answering WhatsApp's question for every channel.
+
+    None has three causes, and from the sender's side they are one fact:
+
+      * the name was never registered here;
+      * it is registered but pending / rejected / paused / deleted;
+      * it is approved in MORE THAN ONE language.
+
+    The last deserves the same None as the others rather than a default:
+    crm_message carries the template NAME and no language column, so picking a
+    locale would be guessing which language a customer reads, and a wrong
+    guess is an unreadable message sent under a merchant's name. When T16
+    grows a language column this becomes a lookup on the full natural key and
+    the ambiguity disappears — noted as the trail, not worked around here.
+    """
+    approved = await template_accessor.approved_templates_for_send(
+        merchant_id, channel, provider_account_ref, name
+    )
+    if len(approved) != 1:
+        logger.warning(
+            f"connectivity: template '{name}' on {provider_account_ref} has "
+            f"{len(approved)} approved rows for {merchant_id}/{channel} — "
+            f"exactly one is required to send"
+        )
+        return None
+    return approved[0]

--- a/app/crm/connectivity/templates.py
+++ b/app/crm/connectivity/templates.py
@@ -14,6 +14,10 @@ The lifecycle, and where each rule lives:
     retire   local (guarded), then       -> deleted
              provider best-effort
 
+The registry's READS live in template_reads.py (get · list · the publish
+verdict · the send-time row) and the retire guard's slot in retire_guard.py;
+this file holds the transitions and nothing else.
+
 Two things this file deliberately does NOT do.
 
 **It does not decide what "editable" means for a provider.** Meta re-reviews
@@ -27,10 +31,10 @@ twenty-three hours out of twenty-four for zero information, and the one it
 would catch arrives as a webhook anyway.
 """
 
-from typing import Any, Awaitable, Callable, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional
 
 from app.core.logger import logger
-from app.crm.connectivity import accounts
+from app.crm.connectivity import accounts, retire_guard
 from app.crm.connectivity.connectors import (
     ConnectorSpec,
     ProviderError,
@@ -42,13 +46,8 @@ from app.crm.connectivity.db.accessors import (
 )
 from app.crm.connectivity.schemas.connector import ConnectorInstallation
 from app.crm.connectivity.schemas.message import CredentialBundle
-from app.crm.connectivity.schemas.template import (
-    ApprovedTemplate,
-    TemplateDraft,
-    TemplateRead,
-)
+from app.crm.connectivity.schemas.template import TemplateDraft, TemplateRead
 from app.crm.connectivity.status import (
-    TEMPLATE_APPROVED,
     TEMPLATE_DRAFT,
     TEMPLATE_IN_PLACE_EDIT,
     TEMPLATE_LOCAL_EDIT,
@@ -71,24 +70,6 @@ class TemplateInUseError(TemplateError):
     document, or live/paused plans by their latest — a 409, not a 400:
     let the runs finish or migrate them, and republish the plans without
     it."""
-
-
-# The retire guard (rollout phase 14): outreach's answer to "who would
-# still send this template?" — (merchant_id, channel, name) ->
-# (open runs whose PINNED document names it, live or paused plans whose
-# LATEST document names it). Connectivity may not import outreach
-# (outreach already reads this module's contracts; the reverse arrow would
-# close an import cycle), so the slot is filled by the composition root,
-# app/crm/worker_main.py — the record/consumers.py inversion (checker rule
-# 12), applied here. Empty until then, and retire() fails CLOSED on empty.
-RetireGuard = Callable[[str, str, str], Awaitable[Tuple[int, int]]]
-_retire_guard: Optional[RetireGuard] = None
-
-
-def register_retire_guard(guard: RetireGuard) -> None:
-    """Idempotent: imports can run more than once (tests, reload)."""
-    global _retire_guard
-    _retire_guard = guard
 
 
 def _as_template_error(error: Exception) -> TemplateError:
@@ -537,14 +518,16 @@ async def _retire_in_txn(
     return await template_accessor.retire_template(txn, merchant_id, template.id)
 
 
-async def _workflows_naming(
-    merchant_id: str, template: TemplateRead
-) -> Tuple[int, int]:
+async def _workflows_naming(merchant_id: str, template: TemplateRead) -> tuple:
     """GATHER for retire: (open runs whose pinned document sends this
-    template, live or paused plans whose latest document does). Fails
-    CLOSED without a registered guard — a missing registration is a
-    wiring bug, never permission to delete what a run is about to send."""
-    if _retire_guard is None:
+    template, live or paused plans whose latest document does) through the
+    slot worker_main fills (retire_guard.py). Fails CLOSED without a
+    registered guard — a missing registration is a wiring bug, never
+    permission to delete what a run is about to send."""
+    counts = await retire_guard.workflows_naming(
+        merchant_id, template.channel, template.name
+    )
+    if counts is None:
         logger.error(
             "template retire guard is not registered — refusing to retire; "
             "app/crm/worker_main.py must register outreach's template_references"
@@ -552,97 +535,4 @@ async def _workflows_naming(
         raise TemplateError(
             "template retirement is not wired: the workflow guard is not registered"
         )
-    return await _retire_guard(merchant_id, template.channel, template.name)
-
-
-# ---------------------------------------------------------------------------
-# reads
-# ---------------------------------------------------------------------------
-
-
-async def get(merchant_id: str, template_id: str) -> Optional[TemplateRead]:
-    return await template_accessor.get_template(merchant_id, template_id)
-
-
-async def list_templates(
-    merchant_id: str, channel: Optional[str] = None, status: Optional[str] = None
-) -> List[TemplateRead]:
-    return await template_accessor.list_templates(merchant_id, channel, status)
-
-
-async def template_status(merchant_id: str, channel: str, name: str) -> Optional[str]:
-    """Is this template NAME publishable on this channel — the registry's
-    one publish-time read (rollout phase 08, G12), beside approved_template
-    (the send-time read) so every read of the table stays in this file.
-
-    A workflow's send node names a template and a channel, never the
-    provider account that will serve it (the route picks that at send
-    time), so the question is asked across the merchant's accounts:
-
-      * None — no row under that name: never registered here;
-      * "approved" — every account holding the name holds exactly ONE
-        approved row (the send door will find its one row whichever
-        account the route picks);
-      * "approved in N languages" — some account holds several approved
-        rows: the ambiguity approved_template refuses at send time,
-        refused here first — same rule, earlier;
-      * otherwise the newest row's status (pending, rejected, deleted…),
-        so the refusal can say why.
-    """
-    rows = await template_accessor.templates_by_name(merchant_id, channel, name)
-    if not rows:
-        return None
-    approved_per_account: Dict[str, int] = {}
-    for row in rows:
-        if row.status == TEMPLATE_APPROVED:
-            approved_per_account[row.provider_account_ref] = (
-                approved_per_account.get(row.provider_account_ref, 0) + 1
-            )
-    if approved_per_account:
-        crowded = max(approved_per_account.values())
-        if crowded > 1:
-            return f"approved in {crowded} languages"
-        return TEMPLATE_APPROVED
-    return rows[0].status
-
-
-async def approved_template(
-    merchant_id: str, channel: str, provider_account_ref: str, name: str
-) -> Optional[ApprovedTemplate]:
-    """Is this template name approved on this account — and if so, the row.
-
-    The registry's one public read for the send path. It states a FACT and
-    nothing else — the caller owns the word for "no", exactly as the binding
-    and installation steps already separate the fact from the refusal. It also
-    keeps every read of the registry table in this file: two logic files
-    owning reads on one table is how two answers to "is this approved" appear.
-
-    The answer is the ROW, not one of its fields: which field a send needs is
-    the adapter's business (WhatsApp renders by language, SMS-DLT sends the
-    provider's id), and a registry that answered "the language" would be
-    answering WhatsApp's question for every channel.
-
-    None has three causes, and from the sender's side they are one fact:
-
-      * the name was never registered here;
-      * it is registered but pending / rejected / paused / deleted;
-      * it is approved in MORE THAN ONE language.
-
-    The last deserves the same None as the others rather than a default:
-    crm_message carries the template NAME and no language column, so picking a
-    locale would be guessing which language a customer reads, and a wrong
-    guess is an unreadable message sent under a merchant's name. When T16
-    grows a language column this becomes a lookup on the full natural key and
-    the ambiguity disappears — noted as the trail, not worked around here.
-    """
-    approved = await template_accessor.approved_templates_for_send(
-        merchant_id, channel, provider_account_ref, name
-    )
-    if len(approved) != 1:
-        logger.warning(
-            f"connectivity: template '{name}' on {provider_account_ref} has "
-            f"{len(approved)} approved rows for {merchant_id}/{channel} — "
-            f"exactly one is required to send"
-        )
-        return None
-    return approved[0]
+    return counts

--- a/app/crm/outreach/db/accessors/__init__.py
+++ b/app/crm/outreach/db/accessors/__init__.py
@@ -1,0 +1,1 @@
+"""Mechanical DB access, one module per table. Exports nothing."""

--- a/app/crm/outreach/db/accessors/enrollment.py
+++ b/app/crm/outreach/db/accessors/enrollment.py
@@ -1,10 +1,7 @@
-"""Outreach accessor — mechanical DB access ONLY (module rules §1).
-
-Executes exactly one query builder per function. Admission guards, node
-execution and publish laws live in the logic files (plans.py, enrol.py,
-walker.py, entry.py). Functions taking a ``conn`` run inside the caller's
-transaction; standalone single statements self-scope their own connection
-— the same shape as every other module's accessor.
+"""Mechanical DB access for crm_workflow_enrollment (T20) — one table, one file (module rules §1 at scale;
+outreach took the shape 3 Sep 2026, structure PR 2). Two shapes, by signature:
+a ``conn`` parameter runs inside the caller's atom; no parameter self-scopes
+one statement (module rules §1).
 """
 
 from datetime import datetime
@@ -12,106 +9,41 @@ from typing import Any, Dict, List, Optional, Tuple
 
 import asyncpg
 
-from app.crm.outreach.db.decoder import (
-    _jsonb as decode_jsonb,
+from app.crm.outreach.db.decoders.enrollment import (
     decode_customer_run,
     decode_run,
     decode_run_summary,
-    decode_version,
-    decode_workflow,
-    decode_workflow_summary,
 )
-from app.crm.outreach.db.queries import (
+from app.crm.outreach.db.queries.enrollment import (
     admission_facts_query,
     advance_run_query,
     cancel_run_query,
     claim_due_runs_query,
     customer_runs_query,
     exit_run_query,
-    get_definition_query,
-    get_workflow_query,
     insert_enrollment_query,
-    insert_version_query,
-    insert_workflow_query,
     list_runs_query,
-    list_versions_query,
-    list_workflows_query,
-    live_plans_naming_template_query,
-    live_workflows_query,
-    lock_template_shared_query,
     occupied_nodes_on_version_query,
     occupied_nodes_query,
     open_runs_for_customer_query,
     park_run_query,
     patch_open_run_query,
-    publish_workflow_query,
     record_run_error_query,
     repin_open_runs_query,
     repin_runs_on_version_query,
     resume_run_by_id_query,
     resume_run_query,
     runs_referencing_template_query,
-    set_workflow_status_query,
     source_event_used_query,
     sweep_exited_runs_query,
-    update_draft_query,
     workflow_summary_query,
 )
 from app.crm.outreach.schemas import (
     CustomerRun,
     EnrollmentRun,
-    Workflow,
     WorkflowRunSummary,
-    WorkflowSummary,
-    WorkflowVersion,
 )
 from app.crm.shared.db import crm_connection
-from app.crm.shared.locks import template_lock_key
-
-
-async def insert_workflow(
-    merchant_id: str, name: str, draft: Dict[str, Any], created_by: Optional[str]
-) -> Workflow:
-    query, values = insert_workflow_query(merchant_id, name, draft, created_by)
-    async with crm_connection() as conn:
-        row = await conn.fetchrow(query, *values)
-    assert row is not None  # INSERT ... RETURNING always yields the row
-    return decode_workflow(row)
-
-
-async def update_draft(
-    merchant_id: str, workflow_id: str, draft: Dict[str, Any]
-) -> Optional[Workflow]:
-    query, values = update_draft_query(merchant_id, workflow_id, draft)
-    async with crm_connection() as conn:
-        row = await conn.fetchrow(query, *values)
-    return decode_workflow(row) if row else None
-
-
-async def get_workflow(merchant_id: str, workflow_id: str) -> Optional[Workflow]:
-    query, values = get_workflow_query(merchant_id, workflow_id)
-    async with crm_connection() as conn:
-        row = await conn.fetchrow(query, *values)
-    return decode_workflow(row) if row else None
-
-
-async def list_workflows(
-    merchant_id: str, limit: int, offset: int
-) -> List[WorkflowSummary]:
-    query, values = list_workflows_query(merchant_id, limit, offset)
-    async with crm_connection() as conn:
-        rows = await conn.fetch(query, *values)
-    return [decode_workflow_summary(row) for row in rows]
-
-
-async def workflow_for_publish(
-    conn: asyncpg.Connection, merchant_id: str, workflow_id: str
-) -> Optional[Workflow]:
-    """Runs inside the caller's publish atom (conn param) — the
-    validate-then-copy decision must read the same draft it publishes."""
-    query, values = get_workflow_query(merchant_id, workflow_id)
-    row = await conn.fetchrow(query, *values)
-    return decode_workflow(row) if row else None
 
 
 async def occupied_nodes(
@@ -122,31 +54,6 @@ async def occupied_nodes(
     return [row["current_node"] for row in rows]
 
 
-async def apply_publish(
-    conn: asyncpg.Connection, merchant_id: str, workflow_id: str
-) -> Optional[Workflow]:
-    query, values = publish_workflow_query(merchant_id, workflow_id)
-    row = await conn.fetchrow(query, *values)
-    return decode_workflow(row) if row else None
-
-
-async def insert_version(
-    conn: asyncpg.Connection,
-    merchant_id: str,
-    workflow_id: str,
-    version: int,
-    definition: Dict[str, Any],
-    on_publish: str,
-    published_by: Optional[str],
-) -> None:
-    """Runs inside the publish atom (conn param): the row shares the
-    publish's fate."""
-    query, values = insert_version_query(
-        merchant_id, workflow_id, version, definition, on_publish, published_by
-    )
-    await conn.execute(query, *values)
-
-
 async def repin_open_runs(
     conn: asyncpg.Connection, merchant_id: str, workflow_id: str, version: int
 ) -> int:
@@ -155,47 +62,6 @@ async def repin_open_runs(
     query, values = repin_open_runs_query(merchant_id, workflow_id, version)
     rows = await conn.fetch(query, *values)
     return len(rows)
-
-
-async def get_definition(
-    merchant_id: str, workflow_id: str, version: int
-) -> Optional[Dict[str, Any]]:
-    """The pinned document, or None when no such version row exists."""
-    query, values = get_definition_query(merchant_id, workflow_id, version)
-    async with crm_connection() as conn:
-        row = await conn.fetchrow(query, *values)
-    if row is None:
-        return None
-    definition = decode_jsonb(row["definition"])
-    return definition if isinstance(definition, dict) else None
-
-
-async def lock_templates_shared(
-    conn: asyncpg.Connection, merchant_id: str, templates: List[Tuple[str, str]]
-) -> None:
-    """Inside the caller's atom: take the template lock SHARED for every
-    (channel, name) the document being pinned sends. In a stable order,
-    so two pinners of the same document never wait on each other's second
-    key (they never do anyway — shared locks do not conflict — but a
-    stable order is free)."""
-    for channel, name in sorted(set(templates)):
-        query, values = lock_template_shared_query(
-            template_lock_key(merchant_id, channel, name)
-        )
-        await conn.execute(query, *values)
-
-
-async def pinned_definition(
-    conn: asyncpg.Connection, merchant_id: str, workflow_id: str, version: int
-) -> Optional[Dict[str, Any]]:
-    """The pinned document inside the caller's atom (conn param) —
-    migrate-forward validates the exact documents it moves runs between."""
-    query, values = get_definition_query(merchant_id, workflow_id, version)
-    row = await conn.fetchrow(query, *values)
-    if row is None:
-        return None
-    definition = decode_jsonb(row["definition"])
-    return definition if isinstance(definition, dict) else None
 
 
 async def occupied_nodes_on_version(
@@ -220,41 +86,11 @@ async def repin_runs_on_version(
     return len(rows)
 
 
-async def list_versions(merchant_id: str, workflow_id: str) -> List[WorkflowVersion]:
-    query, values = list_versions_query(merchant_id, workflow_id)
-    async with crm_connection() as conn:
-        rows = await conn.fetch(query, *values)
-    return [decode_version(row) for row in rows]
-
-
 async def runs_referencing_template(merchant_id: str, channel: str, name: str) -> int:
     query, values = runs_referencing_template_query(merchant_id, channel, name)
     async with crm_connection() as conn:
         row = await conn.fetchrow(query, *values)
     return int(row["runs"]) if row is not None else 0
-
-
-async def live_plans_naming_template(merchant_id: str, channel: str, name: str) -> int:
-    query, values = live_plans_naming_template_query(merchant_id, channel, name)
-    async with crm_connection() as conn:
-        row = await conn.fetchrow(query, *values)
-    return int(row["plans"]) if row is not None else 0
-
-
-async def set_workflow_status(
-    merchant_id: str, workflow_id: str, status: str
-) -> Optional[Workflow]:
-    query, values = set_workflow_status_query(merchant_id, workflow_id, status)
-    async with crm_connection() as conn:
-        row = await conn.fetchrow(query, *values)
-    return decode_workflow(row) if row else None
-
-
-async def live_workflows(merchant_id: str) -> List[Workflow]:
-    query, values = live_workflows_query(merchant_id)
-    async with crm_connection() as conn:
-        rows = await conn.fetch(query, *values)
-    return [decode_workflow(row) for row in rows]
 
 
 async def admission_facts(

--- a/app/crm/outreach/db/accessors/version.py
+++ b/app/crm/outreach/db/accessors/version.py
@@ -1,0 +1,90 @@
+"""Mechanical DB access for crm_workflow_version (T25, ADR 0023) — one table, one file (module rules §1 at scale;
+outreach took the shape 3 Sep 2026, structure PR 2). Two shapes, by signature:
+a ``conn`` parameter runs inside the caller's atom; no parameter self-scopes
+one statement (module rules §1).
+"""
+
+from typing import Any, Dict, List, Optional, Tuple
+
+import asyncpg
+
+from app.crm.outreach.db.decoders.version import (
+    decode_version,
+)
+from app.crm.outreach.db.queries.version import (
+    get_definition_query,
+    insert_version_query,
+    list_versions_query,
+    lock_template_shared_query,
+)
+from app.crm.outreach.schemas import (
+    WorkflowVersion,
+)
+from app.crm.shared.db import crm_connection
+from app.crm.shared.decode import jsonb_value as decode_jsonb
+from app.crm.shared.locks import template_lock_key
+
+
+async def insert_version(
+    conn: asyncpg.Connection,
+    merchant_id: str,
+    workflow_id: str,
+    version: int,
+    definition: Dict[str, Any],
+    on_publish: str,
+    published_by: Optional[str],
+) -> None:
+    """Runs inside the publish atom (conn param): the row shares the
+    publish's fate."""
+    query, values = insert_version_query(
+        merchant_id, workflow_id, version, definition, on_publish, published_by
+    )
+    await conn.execute(query, *values)
+
+
+async def get_definition(
+    merchant_id: str, workflow_id: str, version: int
+) -> Optional[Dict[str, Any]]:
+    """The pinned document, or None when no such version row exists."""
+    query, values = get_definition_query(merchant_id, workflow_id, version)
+    async with crm_connection() as conn:
+        row = await conn.fetchrow(query, *values)
+    if row is None:
+        return None
+    definition = decode_jsonb(row["definition"])
+    return definition if isinstance(definition, dict) else None
+
+
+async def lock_templates_shared(
+    conn: asyncpg.Connection, merchant_id: str, templates: List[Tuple[str, str]]
+) -> None:
+    """Inside the caller's atom: take the template lock SHARED for every
+    (channel, name) the document being pinned sends. In a stable order,
+    so two pinners of the same document never wait on each other's second
+    key (they never do anyway — shared locks do not conflict — but a
+    stable order is free)."""
+    for channel, name in sorted(set(templates)):
+        query, values = lock_template_shared_query(
+            template_lock_key(merchant_id, channel, name)
+        )
+        await conn.execute(query, *values)
+
+
+async def pinned_definition(
+    conn: asyncpg.Connection, merchant_id: str, workflow_id: str, version: int
+) -> Optional[Dict[str, Any]]:
+    """The pinned document inside the caller's atom (conn param) —
+    migrate-forward validates the exact documents it moves runs between."""
+    query, values = get_definition_query(merchant_id, workflow_id, version)
+    row = await conn.fetchrow(query, *values)
+    if row is None:
+        return None
+    definition = decode_jsonb(row["definition"])
+    return definition if isinstance(definition, dict) else None
+
+
+async def list_versions(merchant_id: str, workflow_id: str) -> List[WorkflowVersion]:
+    query, values = list_versions_query(merchant_id, workflow_id)
+    async with crm_connection() as conn:
+        rows = await conn.fetch(query, *values)
+    return [decode_version(row) for row in rows]

--- a/app/crm/outreach/db/accessors/workflow.py
+++ b/app/crm/outreach/db/accessors/workflow.py
@@ -1,0 +1,105 @@
+"""Mechanical DB access for crm_workflow (T19) — one table, one file (module rules §1 at scale;
+outreach took the shape 3 Sep 2026, structure PR 2). Two shapes, by signature:
+a ``conn`` parameter runs inside the caller's atom; no parameter self-scopes
+one statement (module rules §1).
+"""
+
+from typing import Any, Dict, List, Optional
+
+import asyncpg
+
+from app.crm.outreach.db.decoders.workflow import (
+    decode_workflow,
+    decode_workflow_summary,
+)
+from app.crm.outreach.db.queries.workflow import (
+    get_workflow_query,
+    insert_workflow_query,
+    list_workflows_query,
+    live_plans_naming_template_query,
+    live_workflows_query,
+    publish_workflow_query,
+    set_workflow_status_query,
+    update_draft_query,
+)
+from app.crm.outreach.schemas import (
+    Workflow,
+    WorkflowSummary,
+)
+from app.crm.shared.db import crm_connection
+
+
+async def insert_workflow(
+    merchant_id: str, name: str, draft: Dict[str, Any], created_by: Optional[str]
+) -> Workflow:
+    query, values = insert_workflow_query(merchant_id, name, draft, created_by)
+    async with crm_connection() as conn:
+        row = await conn.fetchrow(query, *values)
+    assert row is not None  # INSERT ... RETURNING always yields the row
+    return decode_workflow(row)
+
+
+async def update_draft(
+    merchant_id: str, workflow_id: str, draft: Dict[str, Any]
+) -> Optional[Workflow]:
+    query, values = update_draft_query(merchant_id, workflow_id, draft)
+    async with crm_connection() as conn:
+        row = await conn.fetchrow(query, *values)
+    return decode_workflow(row) if row else None
+
+
+async def get_workflow(merchant_id: str, workflow_id: str) -> Optional[Workflow]:
+    query, values = get_workflow_query(merchant_id, workflow_id)
+    async with crm_connection() as conn:
+        row = await conn.fetchrow(query, *values)
+    return decode_workflow(row) if row else None
+
+
+async def list_workflows(
+    merchant_id: str, limit: int, offset: int
+) -> List[WorkflowSummary]:
+    query, values = list_workflows_query(merchant_id, limit, offset)
+    async with crm_connection() as conn:
+        rows = await conn.fetch(query, *values)
+    return [decode_workflow_summary(row) for row in rows]
+
+
+async def workflow_for_publish(
+    conn: asyncpg.Connection, merchant_id: str, workflow_id: str
+) -> Optional[Workflow]:
+    """Runs inside the caller's publish atom (conn param) — the
+    validate-then-copy decision must read the same draft it publishes."""
+    query, values = get_workflow_query(merchant_id, workflow_id)
+    row = await conn.fetchrow(query, *values)
+    return decode_workflow(row) if row else None
+
+
+async def apply_publish(
+    conn: asyncpg.Connection, merchant_id: str, workflow_id: str
+) -> Optional[Workflow]:
+    query, values = publish_workflow_query(merchant_id, workflow_id)
+    row = await conn.fetchrow(query, *values)
+    return decode_workflow(row) if row else None
+
+
+async def set_workflow_status(
+    merchant_id: str, workflow_id: str, status: str
+) -> Optional[Workflow]:
+    query, values = set_workflow_status_query(merchant_id, workflow_id, status)
+    async with crm_connection() as conn:
+        row = await conn.fetchrow(query, *values)
+    return decode_workflow(row) if row else None
+
+
+async def live_workflows(merchant_id: str) -> List[Workflow]:
+    query, values = live_workflows_query(merchant_id)
+    async with crm_connection() as conn:
+        rows = await conn.fetch(query, *values)
+    return [decode_workflow(row) for row in rows]
+
+
+async def live_plans_naming_template(merchant_id: str, channel: str, name: str) -> int:
+    query, values = live_plans_naming_template_query(merchant_id, channel, name)
+    async with crm_connection() as conn:
+        row = await conn.fetchrow(query, *values)
+    return int(row["plans"]) if row is not None else 0

--- a/app/crm/outreach/db/decoders/__init__.py
+++ b/app/crm/outreach/db/decoders/__init__.py
@@ -1,0 +1,1 @@
+"""row -> schemas, one module per table. Exports nothing."""

--- a/app/crm/outreach/db/decoders/enrollment.py
+++ b/app/crm/outreach/db/decoders/enrollment.py
@@ -1,56 +1,16 @@
-"""Row -> domain shapes for the outreach module (module rules §1).
-DB-side translation only — never imported outside db/."""
+"""row -> schema translation for crm_workflow_enrollment (T20) — one table, one file (module rules §1 at scale;
+outreach took the shape 3 Sep 2026, structure PR 2). DB-side translation only — never
+imported outside db/.
+"""
 
-import json
 from typing import Any, Dict, Iterable, Mapping, Optional
 
 from app.crm.outreach.schemas import (
     CustomerRun,
     EnrollmentRun,
-    Workflow,
     WorkflowRunSummary,
-    WorkflowSummary,
-    WorkflowVersion,
 )
-
-
-def _jsonb(value: Any) -> Any:
-    """asyncpg hands jsonb back as text unless a codec is registered —
-    decode defensively, the record-module precedent."""
-    if isinstance(value, str):
-        return json.loads(value)
-    return value
-
-
-def decode_workflow_summary(row: Mapping[str, Any]) -> WorkflowSummary:
-    return WorkflowSummary(
-        id=row["id"],
-        merchant_id=row["merchant_id"],
-        name=row["name"],
-        status=row["status"],
-        version=row["version"],
-        created_by=row["created_by"],
-        created_at=row["created_at"],
-        updated_at=row["updated_at"],
-    )
-
-
-def decode_workflow(row: Mapping[str, Any]) -> Workflow:
-    return Workflow(
-        **decode_workflow_summary(row).model_dump(),
-        definition=_jsonb(row["definition"]),
-        draft=_jsonb(row["draft"]),
-    )
-
-
-def decode_version(row: Mapping[str, Any]) -> WorkflowVersion:
-    return WorkflowVersion(
-        version=row["version"],
-        on_publish=row["on_publish"],
-        published_by=row["published_by"],
-        published_at=row["published_at"],
-        open_runs=int(row["open_runs"] or 0),
-    )
+from app.crm.shared.decode import jsonb_value as _jsonb
 
 
 def decode_run(row: Mapping[str, Any]) -> EnrollmentRun:

--- a/app/crm/outreach/db/decoders/version.py
+++ b/app/crm/outreach/db/decoders/version.py
@@ -1,0 +1,20 @@
+"""row -> schema translation for crm_workflow_version (T25, ADR 0023) — one table, one file (module rules §1 at scale;
+outreach took the shape 3 Sep 2026, structure PR 2). DB-side translation only — never
+imported outside db/.
+"""
+
+from typing import Any, Mapping
+
+from app.crm.outreach.schemas import (
+    WorkflowVersion,
+)
+
+
+def decode_version(row: Mapping[str, Any]) -> WorkflowVersion:
+    return WorkflowVersion(
+        version=row["version"],
+        on_publish=row["on_publish"],
+        published_by=row["published_by"],
+        published_at=row["published_at"],
+        open_runs=int(row["open_runs"] or 0),
+    )

--- a/app/crm/outreach/db/decoders/workflow.py
+++ b/app/crm/outreach/db/decoders/workflow.py
@@ -1,0 +1,33 @@
+"""row -> schema translation for crm_workflow (T19) — one table, one file (module rules §1 at scale;
+outreach took the shape 3 Sep 2026, structure PR 2). DB-side translation only — never
+imported outside db/.
+"""
+
+from typing import Any, Mapping
+
+from app.crm.outreach.schemas import (
+    Workflow,
+    WorkflowSummary,
+)
+from app.crm.shared.decode import jsonb_value as _jsonb
+
+
+def decode_workflow_summary(row: Mapping[str, Any]) -> WorkflowSummary:
+    return WorkflowSummary(
+        id=row["id"],
+        merchant_id=row["merchant_id"],
+        name=row["name"],
+        status=row["status"],
+        version=row["version"],
+        created_by=row["created_by"],
+        created_at=row["created_at"],
+        updated_at=row["updated_at"],
+    )
+
+
+def decode_workflow(row: Mapping[str, Any]) -> Workflow:
+    return Workflow(
+        **decode_workflow_summary(row).model_dump(),
+        definition=_jsonb(row["definition"]),
+        draft=_jsonb(row["draft"]),
+    )

--- a/app/crm/outreach/db/queries/__init__.py
+++ b/app/crm/outreach/db/queries/__init__.py
@@ -1,0 +1,3 @@
+"""SQL builders, one module per table. Exports nothing — import the table
+you mean by its full path.
+"""

--- a/app/crm/outreach/db/queries/enrollment.py
+++ b/app/crm/outreach/db/queries/enrollment.py
@@ -1,128 +1,23 @@
-"""SQL builders for crm_workflow (T19) and crm_workflow_enrollment (T20).
-$1 placeholders only — every value parameterized.
-
-Two kinds of writer touch a run, and the law between them (P1, rollout
-phase 03): WALKER writes (advance, exit, park, record error) are
-compare-and-set on the leased wake_at — the claim pushed wake_at one
-lease window and returned it, so that value is the generation the visit
-holds; a write carrying a stale lease matches zero rows. EVENT-SIDE writes
-(goal-cancel, a wait_event reply, a repeat patch) are unconditional and
-always move wake_at — the event wins, the walker defers to its next wake.
+"""SQL builders for crm_workflow_enrollment (T20) — one table, one file (module rules §1 at scale;
+outreach took the shape 3 Sep 2026, structure PR 2). $1 placeholders only — every value
+parameterized.
 """
 
 import json
 from datetime import datetime
 from typing import Any, Dict, List, Optional, Tuple
 
-WORKFLOW_TABLE = "crm_workflow"
-ENROLLMENT_TABLE = "crm_workflow_enrollment"
-VERSION_TABLE = "crm_workflow_version"
-_WORKFLOW_SUMMARY_COLUMNS = """
-    id, merchant_id, name, status, version, created_by,
-    created_at, updated_at
-"""
-
-# Detail adds the two documents — the list never fetches them.
-_WORKFLOW_COLUMNS = _WORKFLOW_SUMMARY_COLUMNS + ", definition, draft"
+from app.crm.outreach.db.queries.tables import (
+    ENROLLMENT_TABLE,
+    VERSION_TABLE,
+    WORKFLOW_TABLE,
+)
 
 _RUN_COLUMNS = """
     id, merchant_id, workflow_id, workflow_version, customer_id, status,
     current_node, wake_at, entered_at, exited_at, exit_reason, context,
     enrollment_key, attempts, last_error
 """
-
-
-def insert_workflow_query(
-    merchant_id: str, name: str, draft: Dict[str, Any], created_by: Optional[str]
-) -> Tuple[str, List[Any]]:
-    """A new plan is born as a draft — the walker cannot see it until
-    publish copies draft -> definition."""
-    query = f"""
-        INSERT INTO {WORKFLOW_TABLE} (merchant_id, name, draft, created_by)
-        VALUES ($1, $2, $3::jsonb, $4)
-        RETURNING {_WORKFLOW_COLUMNS}
-    """
-    return query, [merchant_id, name, json.dumps(draft), created_by]
-
-
-def update_draft_query(
-    merchant_id: str, workflow_id: str, draft: Dict[str, Any]
-) -> Tuple[str, List[Any]]:
-    query = f"""
-        UPDATE {WORKFLOW_TABLE}
-        SET draft = $3::jsonb, updated_at = now()
-        WHERE merchant_id = $1 AND id = $2
-        RETURNING {_WORKFLOW_COLUMNS}
-    """
-    return query, [merchant_id, workflow_id, json.dumps(draft)]
-
-
-def get_workflow_query(merchant_id: str, workflow_id: str) -> Tuple[str, List[Any]]:
-    query = f"""
-        SELECT {_WORKFLOW_COLUMNS}
-        FROM {WORKFLOW_TABLE}
-        WHERE merchant_id = $1 AND id = $2
-    """
-    return query, [merchant_id, workflow_id]
-
-
-def list_workflows_query(
-    merchant_id: str, limit: int, offset: int
-) -> Tuple[str, List[Any]]:
-    query = f"""
-        SELECT {_WORKFLOW_SUMMARY_COLUMNS}
-        FROM {WORKFLOW_TABLE}
-        WHERE merchant_id = $1
-        ORDER BY created_at DESC, id DESC
-        LIMIT $2 OFFSET $3
-    """
-    return query, [merchant_id, limit, offset]
-
-
-def publish_workflow_query(merchant_id: str, workflow_id: str) -> Tuple[str, List[Any]]:
-    """Publish = copy draft -> definition, bump version (the audit stamp),
-    go/stay live. Runs inside the publish atom AFTER the validator said
-    yes — the WHERE re-checks a draft still exists so a racing publish
-    cannot double-bump."""
-    query = f"""
-        UPDATE {WORKFLOW_TABLE}
-        SET definition = draft,
-            draft = NULL,
-            version = version + 1,
-            status = CASE WHEN status = 'draft' THEN 'live' ELSE status END,
-            updated_at = now()
-        WHERE merchant_id = $1 AND id = $2 AND draft IS NOT NULL
-        RETURNING {_WORKFLOW_COLUMNS}
-    """
-    return query, [merchant_id, workflow_id]
-
-
-def insert_version_query(
-    merchant_id: str,
-    workflow_id: str,
-    version: int,
-    definition: Dict[str, Any],
-    on_publish: str,
-    published_by: Optional[str],
-) -> Tuple[str, List[Any]]:
-    """One immutable row per publish (ADR 0023, phase 11): the document
-    that became live, under the mode it declared. No ON CONFLICT — a
-    second row for the same version is a bug the unique index must
-    surface, never a merge."""
-    query = f"""
-        INSERT INTO {VERSION_TABLE}
-            (merchant_id, workflow_id, version, definition, on_publish, published_by)
-        VALUES ($1, $2, $3, $4::jsonb, $5, $6)
-        RETURNING id
-    """
-    return query, [
-        merchant_id,
-        workflow_id,
-        version,
-        json.dumps(definition),
-        on_publish,
-        published_by,
-    ]
 
 
 def repin_open_runs_query(
@@ -139,25 +34,6 @@ def repin_open_runs_query(
         RETURNING id
     """
     return query, [merchant_id, workflow_id, version]
-
-
-def get_definition_query(
-    merchant_id: str, workflow_id: str, version: int
-) -> Tuple[str, List[Any]]:
-    """The pinned document, by the pin (phase 12's read)."""
-    query = f"""
-        SELECT definition
-        FROM {VERSION_TABLE}
-        WHERE merchant_id = $1 AND workflow_id = $2 AND version = $3
-    """
-    return query, [merchant_id, workflow_id, version]
-
-
-def lock_template_shared_query(key: int) -> Tuple[str, List[Any]]:
-    """The pinning side of the template lock (shared/locks.py): held
-    SHARED for the rest of the transaction, so pinners never block one
-    another and a retirement (EXCLUSIVE) waits for them to commit."""
-    return "SELECT pg_advisory_xact_lock_shared($1::bigint)", [key]
 
 
 def occupied_nodes_on_version_query(
@@ -192,24 +68,6 @@ def repin_runs_on_version_query(
     return query, [merchant_id, workflow_id, from_version, to_version]
 
 
-def list_versions_query(merchant_id: str, workflow_id: str) -> Tuple[str, List[Any]]:
-    """The versions list (rollout phase 14): every published document,
-    newest first, with the open runs still pinned to it — what to migrate
-    from. Both tables are outreach's."""
-    query = f"""
-        SELECT v.version, v.on_publish, v.published_by, v.published_at,
-               (SELECT count(*) FROM {ENROLLMENT_TABLE} e
-                 WHERE e.merchant_id = v.merchant_id
-                   AND e.workflow_id = v.workflow_id
-                   AND e.workflow_version = v.version
-                   AND e.status <> 'exited') AS open_runs
-        FROM {VERSION_TABLE} v
-        WHERE v.merchant_id = $1 AND v.workflow_id = $2
-        ORDER BY v.version DESC
-    """
-    return query, [merchant_id, workflow_id]
-
-
 def runs_referencing_template_query(
     merchant_id: str, channel: str, name: str
 ) -> Tuple[str, List[Any]]:
@@ -234,31 +92,6 @@ def runs_referencing_template_query(
           )
     """
     return query, [merchant_id, channel, name]
-
-
-def set_workflow_status_query(
-    merchant_id: str, workflow_id: str, status: str
-) -> Tuple[str, List[Any]]:
-    query = f"""
-        UPDATE {WORKFLOW_TABLE}
-        SET status = $3, updated_at = now()
-        WHERE merchant_id = $1 AND id = $2 AND status <> 'archived'
-        RETURNING {_WORKFLOW_COLUMNS}
-    """
-    return query, [merchant_id, workflow_id, status]
-
-
-def live_workflows_query(merchant_id: str) -> Tuple[str, List[Any]]:
-    """The entry-rule processor's read: this merchant's live plans, on
-    the (merchant_id, status) index — the read runs once per attributed
-    event inside the event worker's pass, so it must never scan other
-    tenants' plans (nor validate them in Python)."""
-    query = f"""
-        SELECT {_WORKFLOW_COLUMNS}
-        FROM {WORKFLOW_TABLE}
-        WHERE merchant_id = $1 AND status = 'live'
-    """
-    return query, [merchant_id]
 
 
 def occupied_nodes_query(merchant_id: str, workflow_id: str) -> Tuple[str, List[Any]]:
@@ -586,27 +419,6 @@ def cancel_run_query(
         RETURNING id
     """
     return query, params
-
-
-def live_plans_naming_template_query(
-    merchant_id: str, channel: str, name: str
-) -> Tuple[str, List[Any]]:
-    """The retirement guard's second count (rollout phase 14): plans that
-    are live, or paused and able to go live, whose LATEST document has a
-    send node on this channel naming this template — their next entrant
-    would be pinned to a withdrawn template just as an open run is."""
-    query = f"""
-        SELECT count(*) AS plans
-        FROM {WORKFLOW_TABLE} w
-        WHERE w.merchant_id = $1 AND w.status IN ('live', 'paused')
-          AND EXISTS (
-              SELECT 1 FROM jsonb_array_elements(w.definition->'nodes') AS node
-              WHERE node->>'type' = 'send'
-                AND node->>'channel' = $2
-                AND node->>'template' = $3
-          )
-    """
-    return query, [merchant_id, channel, name]
 
 
 def patch_open_run_query(

--- a/app/crm/outreach/db/queries/tables.py
+++ b/app/crm/outreach/db/queries/tables.py
@@ -1,0 +1,9 @@
+"""The three physical table names outreach owns, in one leaf — so a builder
+file that joins across tables imports the name it touches instead of the
+sibling module that owns it (which is how two per-table files would import
+each other). A reader sees a cross-table join by this file's import list.
+"""
+
+WORKFLOW_TABLE = "crm_workflow"
+ENROLLMENT_TABLE = "crm_workflow_enrollment"
+VERSION_TABLE = "crm_workflow_version"

--- a/app/crm/outreach/db/queries/version.py
+++ b/app/crm/outreach/db/queries/version.py
@@ -1,0 +1,74 @@
+"""SQL builders for crm_workflow_version (T25, ADR 0023) — one table, one file (module rules §1 at scale;
+outreach took the shape 3 Sep 2026, structure PR 2). $1 placeholders only — every value
+parameterized.
+"""
+
+import json
+from typing import Any, Dict, List, Optional, Tuple
+
+from app.crm.outreach.db.queries.tables import ENROLLMENT_TABLE, VERSION_TABLE
+
+
+def insert_version_query(
+    merchant_id: str,
+    workflow_id: str,
+    version: int,
+    definition: Dict[str, Any],
+    on_publish: str,
+    published_by: Optional[str],
+) -> Tuple[str, List[Any]]:
+    """One immutable row per publish (ADR 0023, phase 11): the document
+    that became live, under the mode it declared. No ON CONFLICT — a
+    second row for the same version is a bug the unique index must
+    surface, never a merge."""
+    query = f"""
+        INSERT INTO {VERSION_TABLE}
+            (merchant_id, workflow_id, version, definition, on_publish, published_by)
+        VALUES ($1, $2, $3, $4::jsonb, $5, $6)
+        RETURNING id
+    """
+    return query, [
+        merchant_id,
+        workflow_id,
+        version,
+        json.dumps(definition),
+        on_publish,
+        published_by,
+    ]
+
+
+def get_definition_query(
+    merchant_id: str, workflow_id: str, version: int
+) -> Tuple[str, List[Any]]:
+    """The pinned document, by the pin (phase 12's read)."""
+    query = f"""
+        SELECT definition
+        FROM {VERSION_TABLE}
+        WHERE merchant_id = $1 AND workflow_id = $2 AND version = $3
+    """
+    return query, [merchant_id, workflow_id, version]
+
+
+def lock_template_shared_query(key: int) -> Tuple[str, List[Any]]:
+    """The pinning side of the template lock (shared/locks.py): held
+    SHARED for the rest of the transaction, so pinners never block one
+    another and a retirement (EXCLUSIVE) waits for them to commit."""
+    return "SELECT pg_advisory_xact_lock_shared($1::bigint)", [key]
+
+
+def list_versions_query(merchant_id: str, workflow_id: str) -> Tuple[str, List[Any]]:
+    """The versions list (rollout phase 14): every published document,
+    newest first, with the open runs still pinned to it — what to migrate
+    from. Both tables are outreach's."""
+    query = f"""
+        SELECT v.version, v.on_publish, v.published_by, v.published_at,
+               (SELECT count(*) FROM {ENROLLMENT_TABLE} e
+                 WHERE e.merchant_id = v.merchant_id
+                   AND e.workflow_id = v.workflow_id
+                   AND e.workflow_version = v.version
+                   AND e.status <> 'exited') AS open_runs
+        FROM {VERSION_TABLE} v
+        WHERE v.merchant_id = $1 AND v.workflow_id = $2
+        ORDER BY v.version DESC
+    """
+    return query, [merchant_id, workflow_id]

--- a/app/crm/outreach/db/queries/workflow.py
+++ b/app/crm/outreach/db/queries/workflow.py
@@ -1,0 +1,129 @@
+"""SQL builders for crm_workflow (T19) — one table, one file (module rules §1 at scale;
+outreach took the shape 3 Sep 2026, structure PR 2). $1 placeholders only — every value
+parameterized.
+"""
+
+import json
+from typing import Any, Dict, List, Optional, Tuple
+
+from app.crm.outreach.db.queries.tables import WORKFLOW_TABLE
+
+_WORKFLOW_SUMMARY_COLUMNS = """
+    id, merchant_id, name, status, version, created_by,
+    created_at, updated_at
+"""
+
+
+# Detail adds the two documents — the list never fetches them.
+_WORKFLOW_COLUMNS = _WORKFLOW_SUMMARY_COLUMNS + ", definition, draft"
+
+
+def insert_workflow_query(
+    merchant_id: str, name: str, draft: Dict[str, Any], created_by: Optional[str]
+) -> Tuple[str, List[Any]]:
+    """A new plan is born as a draft — the walker cannot see it until
+    publish copies draft -> definition."""
+    query = f"""
+        INSERT INTO {WORKFLOW_TABLE} (merchant_id, name, draft, created_by)
+        VALUES ($1, $2, $3::jsonb, $4)
+        RETURNING {_WORKFLOW_COLUMNS}
+    """
+    return query, [merchant_id, name, json.dumps(draft), created_by]
+
+
+def update_draft_query(
+    merchant_id: str, workflow_id: str, draft: Dict[str, Any]
+) -> Tuple[str, List[Any]]:
+    query = f"""
+        UPDATE {WORKFLOW_TABLE}
+        SET draft = $3::jsonb, updated_at = now()
+        WHERE merchant_id = $1 AND id = $2
+        RETURNING {_WORKFLOW_COLUMNS}
+    """
+    return query, [merchant_id, workflow_id, json.dumps(draft)]
+
+
+def get_workflow_query(merchant_id: str, workflow_id: str) -> Tuple[str, List[Any]]:
+    query = f"""
+        SELECT {_WORKFLOW_COLUMNS}
+        FROM {WORKFLOW_TABLE}
+        WHERE merchant_id = $1 AND id = $2
+    """
+    return query, [merchant_id, workflow_id]
+
+
+def list_workflows_query(
+    merchant_id: str, limit: int, offset: int
+) -> Tuple[str, List[Any]]:
+    query = f"""
+        SELECT {_WORKFLOW_SUMMARY_COLUMNS}
+        FROM {WORKFLOW_TABLE}
+        WHERE merchant_id = $1
+        ORDER BY created_at DESC, id DESC
+        LIMIT $2 OFFSET $3
+    """
+    return query, [merchant_id, limit, offset]
+
+
+def publish_workflow_query(merchant_id: str, workflow_id: str) -> Tuple[str, List[Any]]:
+    """Publish = copy draft -> definition, bump version (the audit stamp),
+    go/stay live. Runs inside the publish atom AFTER the validator said
+    yes — the WHERE re-checks a draft still exists so a racing publish
+    cannot double-bump."""
+    query = f"""
+        UPDATE {WORKFLOW_TABLE}
+        SET definition = draft,
+            draft = NULL,
+            version = version + 1,
+            status = CASE WHEN status = 'draft' THEN 'live' ELSE status END,
+            updated_at = now()
+        WHERE merchant_id = $1 AND id = $2 AND draft IS NOT NULL
+        RETURNING {_WORKFLOW_COLUMNS}
+    """
+    return query, [merchant_id, workflow_id]
+
+
+def set_workflow_status_query(
+    merchant_id: str, workflow_id: str, status: str
+) -> Tuple[str, List[Any]]:
+    query = f"""
+        UPDATE {WORKFLOW_TABLE}
+        SET status = $3, updated_at = now()
+        WHERE merchant_id = $1 AND id = $2 AND status <> 'archived'
+        RETURNING {_WORKFLOW_COLUMNS}
+    """
+    return query, [merchant_id, workflow_id, status]
+
+
+def live_workflows_query(merchant_id: str) -> Tuple[str, List[Any]]:
+    """The entry-rule processor's read: this merchant's live plans, on
+    the (merchant_id, status) index — the read runs once per attributed
+    event inside the event worker's pass, so it must never scan other
+    tenants' plans (nor validate them in Python)."""
+    query = f"""
+        SELECT {_WORKFLOW_COLUMNS}
+        FROM {WORKFLOW_TABLE}
+        WHERE merchant_id = $1 AND status = 'live'
+    """
+    return query, [merchant_id]
+
+
+def live_plans_naming_template_query(
+    merchant_id: str, channel: str, name: str
+) -> Tuple[str, List[Any]]:
+    """The retirement guard's second count (rollout phase 14): plans that
+    are live, or paused and able to go live, whose LATEST document has a
+    send node on this channel naming this template — their next entrant
+    would be pinned to a withdrawn template just as an open run is."""
+    query = f"""
+        SELECT count(*) AS plans
+        FROM {WORKFLOW_TABLE} w
+        WHERE w.merchant_id = $1 AND w.status IN ('live', 'paused')
+          AND EXISTS (
+              SELECT 1 FROM jsonb_array_elements(w.definition->'nodes') AS node
+              WHERE node->>'type' = 'send'
+                AND node->>'channel' = $2
+                AND node->>'template' = $3
+          )
+    """
+    return query, [merchant_id, channel, name]

--- a/app/crm/outreach/definitions.py
+++ b/app/crm/outreach/definitions.py
@@ -17,7 +17,9 @@ Logic, not db: the only db-world import is the module's accessor door.
 from collections import OrderedDict
 from typing import Optional, Tuple
 
-from app.crm.outreach.db import accessor
+from app.crm.outreach.db.accessors import (
+    version as version_accessor,
+)
 from app.crm.outreach.schemas import EnrollmentRun, WorkflowDefinition
 
 # Sized for one merchant fleet's live versions many times over; §14.7's
@@ -38,7 +40,7 @@ async def definition_for(run: EnrollmentRun) -> Optional[WorkflowDefinition]:
     if cached is not None:
         _definitions.move_to_end(key)
         return cached
-    document = await accessor.get_definition(run.merchant_id, key[0], key[1])
+    document = await version_accessor.get_definition(run.merchant_id, key[0], key[1])
     if document is None:
         return None
     definition = WorkflowDefinition.model_validate(document)

--- a/app/crm/outreach/enrol.py
+++ b/app/crm/outreach/enrol.py
@@ -10,7 +10,11 @@ from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, Optional, Tuple
 
 from app.core.logger import logger
-from app.crm.outreach.db import DbTxn, UniqueViolation, accessor, atomically
+from app.crm.outreach.db import DbTxn, UniqueViolation, atomically
+from app.crm.outreach.db.accessors import (
+    enrollment as enrollment_accessor,
+    version as version_accessor,
+)
 from app.crm.outreach.nodes import is_wait
 from app.crm.outreach.schemas import (
     EnrollmentRun,
@@ -111,7 +115,7 @@ async def _enrol_in_txn(
     templates this document sends are held SHARED (shared/locks.py) so a
     retirement cannot commit between its count and this insert."""
     source_event_id = context.get("source_event_id")
-    if source_event_id and await accessor.source_event_used(
+    if source_event_id and await enrollment_accessor.source_event_used(
         txn, merchant_id, str(workflow.id), customer_id, str(source_event_id)
     ):
         return None  # this event already made its run (at-least-once scan)
@@ -119,7 +123,7 @@ async def _enrol_in_txn(
     # Keyed plan: the guards judge THIS key's history (B2 — "one run per
     # <field>" means reenter/cooldown are about the order, not the
     # customer). Unkeyed: the key is the customer id and the read is hers.
-    facts = await accessor.admission_facts(
+    facts = await enrollment_accessor.admission_facts(
         txn,
         merchant_id,
         str(workflow.id),
@@ -138,8 +142,10 @@ async def _enrol_in_txn(
     start = next((node for node in definition.nodes if node.id == door.start), None)
     if start is None:  # the validator forbids this; drift is an error, not a run
         raise ValueError(f"door {door.topic!r} starts on unknown node {door.start!r}")
-    await accessor.lock_templates_shared(txn, merchant_id, definition.send_templates())
-    run = await accessor.insert_enrollment(
+    await version_accessor.lock_templates_shared(
+        txn, merchant_id, definition.send_templates()
+    )
+    run = await enrollment_accessor.insert_enrollment(
         txn,
         merchant_id,
         str(workflow.id),

--- a/app/crm/outreach/entry.py
+++ b/app/crm/outreach/entry.py
@@ -26,7 +26,10 @@ source-event check and the open-run unique — not by that rollback.
 from typing import Optional, Sequence, Tuple
 
 from app.core.logger import logger
-from app.crm.outreach.db import accessor
+from app.crm.outreach.db.accessors import (
+    enrollment as enrollment_accessor,
+    workflow as workflow_accessor,
+)
 from app.crm.outreach.definitions import definition_for
 from app.crm.outreach.enrol import enrol
 from app.crm.outreach.nodes import (
@@ -112,7 +115,9 @@ async def consume_attributed_event(
     the voice mirrors, which resolve before this consumer exists."""
     if customer_id is None:
         return  # not about a person: nothing to admit, end or wake
-    open_runs = await accessor.open_runs_for_customer(event.merchant_id, customer_id)
+    open_runs = await enrollment_accessor.open_runs_for_customer(
+        event.merchant_id, customer_id
+    )
     goal_patch = _goal_patch(event) if open_runs else None
     for run in open_runs:
         definition = await definition_for(run)
@@ -128,7 +133,7 @@ async def consume_attributed_event(
             continue  # exited: there is nothing left to wake
         await _wake_on_reply(run, definition, event)
 
-    flows = await accessor.live_workflows(event.merchant_id)
+    flows = await workflow_accessor.live_workflows(event.merchant_id)
     for flow in flows:
         definition = WorkflowDefinition.model_validate(flow.definition)
         for door in definition.entries:
@@ -162,7 +167,7 @@ async def _end_on_goal(
             if str(run.context.get(tier.key.run, "")) != str(value):
                 continue  # about another run of hers
             key = (tier.key.run, str(value))
-        if await accessor.cancel_run(
+        if await enrollment_accessor.cancel_run(
             run.merchant_id,
             str(run.id),
             tier.exit_reason,
@@ -208,7 +213,7 @@ async def _wake_on_reply(
         # facts of THIS letter win the next call even after the run has
         # moved on (nodes.run_facts; a ladder hears a stage's letter on
         # the square it leaves).
-        await accessor.resume_run_by_id(
+        await enrollment_accessor.resume_run_by_id(
             run.merchant_id,
             str(run.id),
             node.id,

--- a/app/crm/outreach/plans.py
+++ b/app/crm/outreach/plans.py
@@ -10,7 +10,12 @@ from typing import Any, Dict, List, Optional
 
 from app.core.logger import logger
 from app.crm.connectivity.contracts import registers_templates_for, template_status
-from app.crm.outreach.db import DbTxn, accessor, atomically
+from app.crm.outreach.db import DbTxn, atomically
+from app.crm.outreach.db.accessors import (
+    enrollment as enrollment_accessor,
+    version as version_accessor,
+    workflow as workflow_accessor,
+)
 from app.crm.outreach.ladder import LadderProblem, expand_stages
 from app.crm.outreach.nodes import NODE_TYPES, is_wait
 from app.crm.outreach.repeat import parse_repeat_policy
@@ -240,7 +245,7 @@ async def create_workflow(
     problems = validate_definition(definition)
     if problems:
         raise WorkflowValidationError(problems)
-    return await accessor.insert_workflow(
+    return await workflow_accessor.insert_workflow(
         merchant_id, name, expand_stages(definition), created_by
     )
 
@@ -251,7 +256,7 @@ async def update_draft(
     problems = validate_definition(definition)
     if problems:
         raise WorkflowValidationError(problems)
-    return await accessor.update_draft(
+    return await workflow_accessor.update_draft(
         merchant_id, workflow_id, expand_stages(definition)
     )
 
@@ -276,13 +281,15 @@ async def _publish_in_txn(
     ladder draft must already carry its board (phase 17): the copy is
     verbatim, so a ladder saved without one would go live without
     squares."""
-    workflow = await accessor.workflow_for_publish(txn, merchant_id, workflow_id)
+    workflow = await workflow_accessor.workflow_for_publish(
+        txn, merchant_id, workflow_id
+    )
     if workflow is None:
         raise WorkflowNotFound(workflow_id)
     draft = workflow.draft
     if not draft:
         raise WorkflowValidationError(["nothing to publish — draft is empty"])
-    occupied = await accessor.occupied_nodes(txn, merchant_id, workflow_id)
+    occupied = await enrollment_accessor.occupied_nodes(txn, merchant_id, workflow_id)
     live_entry = (workflow.definition or {}).get("entry")
     problems = validate_definition(
         draft, occupied_nodes=occupied, live_entry=live_entry
@@ -297,16 +304,18 @@ async def _publish_in_txn(
             ]
         )
     definition = WorkflowDefinition.model_validate(draft)
-    await accessor.lock_templates_shared(txn, merchant_id, definition.send_templates())
+    await version_accessor.lock_templates_shared(
+        txn, merchant_id, definition.send_templates()
+    )
     problems = await _template_problems(merchant_id, definition)
     if problems:
         raise WorkflowValidationError(problems)
-    published = await accessor.apply_publish(txn, merchant_id, workflow_id)
+    published = await workflow_accessor.apply_publish(txn, merchant_id, workflow_id)
     if published is None:  # a racing publish consumed the draft first
         raise WorkflowValidationError(["draft already published"])
     # The version row holds the document that just became live — the draft
     # apply_publish copied verbatim — under the mode it declared.
-    await accessor.insert_version(
+    await version_accessor.insert_version(
         txn,
         merchant_id,
         workflow_id,
@@ -317,7 +326,7 @@ async def _publish_in_txn(
     )
     repinned = 0
     if definition.on_publish == "migrate":
-        repinned = await accessor.repin_open_runs(
+        repinned = await enrollment_accessor.repin_open_runs(
             txn, merchant_id, workflow_id, published.version
         )
     logger.info(
@@ -345,16 +354,12 @@ async def _template_problems(
             continue  # the validator already demands both on a send node
         if not registers_templates_for(node.channel):
             continue  # a channel with no registry (email) has nothing to ask
-        status = await template_status(merchant_id, node.channel, node.template)
-        if status is None:
+        verdict = await template_status(merchant_id, node.channel, node.template)
+        if not verdict.publishable:
+            # The registry's own words for why (its reason clause); outreach
+            # never compares a status word across the seam.
             problems.append(
-                f"send node {node.id}: template '{node.template}' is not "
-                f"registered on {node.channel} for this merchant"
-            )
-        elif status != "approved":
-            problems.append(
-                f"send node {node.id}: template '{node.template}' is "
-                f"'{status}', not approved"
+                f"send node {node.id}: template '{node.template}' {verdict.reason}"
             )
     return problems
 
@@ -375,7 +380,7 @@ async def set_status(
     (B4, rollout phase 01); a driver exception is never caught in logic."""
     if status not in ("live", "paused", "archived"):
         raise WorkflowValidationError([f"unknown status: {status}"])
-    workflow = await accessor.get_workflow(merchant_id, workflow_id)
+    workflow = await workflow_accessor.get_workflow(merchant_id, workflow_id)
     if workflow is None or workflow.status == "archived":
         return None
     if not workflow.definition:
@@ -385,17 +390,17 @@ async def set_status(
             "archived": "archiving it",
         }
         raise WorkflowValidationError([f"publish a draft before {verb[status]}"])
-    return await accessor.set_workflow_status(merchant_id, workflow_id, status)
+    return await workflow_accessor.set_workflow_status(merchant_id, workflow_id, status)
 
 
 async def get_workflow(merchant_id: str, workflow_id: str) -> Optional[Workflow]:
-    return await accessor.get_workflow(merchant_id, workflow_id)
+    return await workflow_accessor.get_workflow(merchant_id, workflow_id)
 
 
 async def list_workflows(
     merchant_id: str, limit: int, offset: int
 ) -> List[WorkflowSummary]:
-    return await accessor.list_workflows(merchant_id, limit, offset)
+    return await workflow_accessor.list_workflows(merchant_id, limit, offset)
 
 
 class WorkflowValidationError(Exception):

--- a/app/crm/outreach/repeat.py
+++ b/app/crm/outreach/repeat.py
@@ -39,7 +39,9 @@ from dataclasses import dataclass
 from typing import Any, Dict, Optional, Tuple
 
 from app.core.logger import logger
-from app.crm.outreach.db import accessor
+from app.crm.outreach.db.accessors import (
+    enrollment as enrollment_accessor,
+)
 from app.crm.outreach.schemas import WorkflowEntry, WorkflowEntryAt
 
 # The words, exactly as the corpus writes them. refresh_max carries its
@@ -155,7 +157,7 @@ async def apply_repeat(
     plan = repeat_plan(door, facts)
     if plan.is_noop:
         return False  # ignore + no debounce: exactly today's behaviour
-    patched = await accessor.patch_open_run(
+    patched = await enrollment_accessor.patch_open_run(
         merchant_id,
         workflow_id,
         enrollment_key,

--- a/app/crm/outreach/runs.py
+++ b/app/crm/outreach/runs.py
@@ -18,7 +18,9 @@ from app.core.config.static import (
     CRM_RUN_SWEEP_BATCH_SIZE,
 )
 from app.core.logger import logger
-from app.crm.outreach.db import accessor
+from app.crm.outreach.db.accessors import (
+    enrollment as enrollment_accessor,
+)
 from app.crm.outreach.schemas import CustomerRun, EnrollmentRun, WorkflowRunSummary
 
 _LISTABLE_STATUSES = ("waiting", "parked", "exited")
@@ -33,7 +35,9 @@ async def list_runs(
 ) -> List[EnrollmentRun]:
     if status is not None and status not in _LISTABLE_STATUSES:
         raise ValueError(f"unknown run status: {status}")
-    return await accessor.list_runs(merchant_id, workflow_id, status, limit, offset)
+    return await enrollment_accessor.list_runs(
+        merchant_id, workflow_id, status, limit, offset
+    )
 
 
 async def resume_run(
@@ -42,7 +46,7 @@ async def resume_run(
     """Revive one parked run: wake now, failure counter forgiven. Returns
     None when the run isn't parked (or isn't this merchant's) — the
     walker claims it on its next tick."""
-    run = await accessor.resume_run(merchant_id, workflow_id, run_id)
+    run = await enrollment_accessor.resume_run(merchant_id, workflow_id, run_id)
     if run:
         logger.info(f"run resumed by operator: {run_id} (merchant {merchant_id})")
     return run
@@ -55,7 +59,9 @@ async def workflow_summary(
     until: Optional[datetime],
 ) -> WorkflowRunSummary:
     """The plan's report over a window of entered_at (rollout phase 09)."""
-    return await accessor.workflow_summary(merchant_id, workflow_id, since, until)
+    return await enrollment_accessor.workflow_summary(
+        merchant_id, workflow_id, since, until
+    )
 
 
 async def customer_runs(
@@ -63,7 +69,7 @@ async def customer_runs(
 ) -> List[CustomerRun]:
     """The customer's journey: her runs across every plan, in the order
     they began (rollout phase 09)."""
-    return await accessor.customer_runs(merchant_id, customer_id, limit)
+    return await enrollment_accessor.customer_runs(merchant_id, customer_id, limit)
 
 
 async def run_retention_sweep_tick() -> None:
@@ -74,7 +80,9 @@ async def run_retention_sweep_tick() -> None:
     leftovers go next pass."""
     try:
         cutoff = datetime.now(timezone.utc) - timedelta(days=CRM_RUN_RETENTION_DAYS)
-        swept = await accessor.sweep_exited_runs(cutoff, CRM_RUN_SWEEP_BATCH_SIZE)
+        swept = await enrollment_accessor.sweep_exited_runs(
+            cutoff, CRM_RUN_SWEEP_BATCH_SIZE
+        )
         if swept:
             logger.info(
                 f"run retention sweep: removed {swept} exited runs "

--- a/app/crm/outreach/versions.py
+++ b/app/crm/outreach/versions.py
@@ -30,7 +30,12 @@ from typing import List, Tuple
 
 from app.core.logger import logger
 from app.crm.outreach import plans
-from app.crm.outreach.db import DbTxn, accessor, atomically
+from app.crm.outreach.db import DbTxn, atomically
+from app.crm.outreach.db.accessors import (
+    enrollment as enrollment_accessor,
+    version as version_accessor,
+    workflow as workflow_accessor,
+)
 from app.crm.outreach.plans import WorkflowValidationError, validate_migration
 from app.crm.outreach.schemas import WorkflowDefinition, WorkflowVersion
 
@@ -66,15 +71,17 @@ async def _migrate_forward_in_txn(
         raise WorkflowValidationError(
             [f"version {from_version} is already the version those runs execute"]
         )
-    source = await accessor.pinned_definition(
+    source = await version_accessor.pinned_definition(
         txn, merchant_id, workflow_id, from_version
     )
     if source is None:
         raise VersionNotFound(f"version {from_version}")
-    target = await accessor.pinned_definition(txn, merchant_id, workflow_id, to_version)
+    target = await version_accessor.pinned_definition(
+        txn, merchant_id, workflow_id, to_version
+    )
     if target is None:
         raise VersionNotFound(f"version {to_version}")
-    occupied = await accessor.occupied_nodes_on_version(
+    occupied = await enrollment_accessor.occupied_nodes_on_version(
         txn, merchant_id, workflow_id, from_version
     )
     problems = validate_migration(source, target, occupied)
@@ -84,13 +91,13 @@ async def _migrate_forward_in_txn(
     # have been retired since. The same check publish makes, under the
     # same lock — a run must never be moved onto a template it cannot send.
     target_definition = WorkflowDefinition.model_validate(target)
-    await accessor.lock_templates_shared(
+    await version_accessor.lock_templates_shared(
         txn, merchant_id, target_definition.send_templates()
     )
     problems = await plans._template_problems(merchant_id, target_definition)
     if problems:
         raise WorkflowValidationError(problems)
-    moved = await accessor.repin_runs_on_version(
+    moved = await enrollment_accessor.repin_runs_on_version(
         txn, merchant_id, workflow_id, from_version, to_version
     )
     logger.info(
@@ -103,7 +110,7 @@ async def _migrate_forward_in_txn(
 async def list_versions(merchant_id: str, workflow_id: str) -> List[WorkflowVersion]:
     """Every published document of the plan, newest first, each with the
     open runs still executing it."""
-    return await accessor.list_versions(merchant_id, workflow_id)
+    return await version_accessor.list_versions(merchant_id, workflow_id)
 
 
 async def template_references(
@@ -114,6 +121,10 @@ async def template_references(
     paused plans, by their LATEST document — the one their next entrant
     is pinned to). Connectivity's retire asks this inside its withdrawal
     atom, through the hook worker_main registers."""
-    open_runs = await accessor.runs_referencing_template(merchant_id, channel, name)
-    plans = await accessor.live_plans_naming_template(merchant_id, channel, name)
+    open_runs = await enrollment_accessor.runs_referencing_template(
+        merchant_id, channel, name
+    )
+    plans = await workflow_accessor.live_plans_naming_template(
+        merchant_id, channel, name
+    )
     return open_runs, plans

--- a/app/crm/outreach/walker.py
+++ b/app/crm/outreach/walker.py
@@ -31,7 +31,10 @@ from app.core.config.static import (
     CRM_WALKER_MAX_ATTEMPTS,
 )
 from app.core.logger import logger
-from app.crm.outreach.db import accessor
+from app.crm.outreach.db.accessors import (
+    enrollment as enrollment_accessor,
+    workflow as workflow_accessor,
+)
 from app.crm.outreach.definitions import definition_for
 from app.crm.outreach.nodes import (
     ELSE,
@@ -66,7 +69,7 @@ async def claim_due_runs(batch: int) -> List[EnrollmentRun]:
     wake_at lease push — one UPDATE that moves the alarm one lease window
     forward IS the lock, so replicas never collide and a crashed claim
     self-heals when the pushed alarm comes due again."""
-    return await accessor.claim_due_runs(batch, CRM_WALKER_LEASE_SECONDS)
+    return await enrollment_accessor.claim_due_runs(batch, CRM_WALKER_LEASE_SECONDS)
 
 
 async def walk_run(run: EnrollmentRun) -> None:
@@ -90,9 +93,11 @@ async def walk_run(run: EnrollmentRun) -> None:
         logger.error(f"walker: run {run.id} claimed without a lease — skipping")
         return
     try:
-        workflow = await accessor.get_workflow(run.merchant_id, str(run.workflow_id))
+        workflow = await workflow_accessor.get_workflow(
+            run.merchant_id, str(run.workflow_id)
+        )
         if workflow is None or workflow.status == "archived":
-            if not await accessor.exit_run(str(run.id), "ejected", lease):
+            if not await enrollment_accessor.exit_run(str(run.id), "ejected", lease):
                 _deferred(run, "eject")
             return
         if workflow.status == "paused":
@@ -106,19 +111,23 @@ async def walk_run(run: EnrollmentRun) -> None:
             raise NodeParked(f"definition v{run.workflow_version} missing")
         await _advance(run, definition, lease)
     except NodeParked as e:
-        if await accessor.park_run(str(run.id), str(e), lease):
+        if await enrollment_accessor.park_run(str(run.id), str(e), lease):
             logger.warning(f"walker: run {run.id} parked — {e}")
         else:
             _deferred(run, "park")
     except Exception as e:
         if run.attempts >= CRM_WALKER_MAX_ATTEMPTS:
-            if await accessor.park_run(str(run.id), f"attempts exhausted: {e}", lease):
+            if await enrollment_accessor.park_run(
+                str(run.id), f"attempts exhausted: {e}", lease
+            ):
                 logger.error(f"walker: run {run.id} parked after retries — {e}")
             else:
                 _deferred(run, "park")
         else:
             retry_in = retry_delay_seconds(run.attempts, CRM_WALKER_LEASE_SECONDS)
-            if await accessor.record_run_error(str(run.id), str(e), retry_in, lease):
+            if await enrollment_accessor.record_run_error(
+                str(run.id), str(e), retry_in, lease
+            ):
                 logger.warning(f"walker: run {run.id} retries in {retry_in}s — {e}")
             else:
                 _deferred(run, "retry")
@@ -145,7 +154,7 @@ async def _advance(
     # timed_out no matter which square it stands on.
     max_age = timedelta(days=definition.exits.max_age_days)
     if now - run.entered_at > max_age:
-        if not await accessor.exit_run(str(run.id), "timed_out", lease):
+        if not await enrollment_accessor.exit_run(str(run.id), "timed_out", lease):
             _deferred(run, "timed_out")
         return
 
@@ -165,7 +174,9 @@ async def _advance(
         if await customer_has_event(
             run.merchant_id, str(run.customer_id), tier.topics, since, where
         ):
-            if not await accessor.exit_run(str(run.id), tier.exit_reason, lease):
+            if not await enrollment_accessor.exit_run(
+                str(run.id), tier.exit_reason, lease
+            ):
                 _deferred(run, tier.exit_reason)
             return
 
@@ -192,7 +203,7 @@ async def _advance(
             # revisited — a stale reply would resolve the revisit at once.
             context = without_reply(context, node.id)
         if next_id is None:
-            if not await accessor.exit_run(
+            if not await enrollment_accessor.exit_run(
                 str(run.id),
                 "completed",
                 lease,
@@ -207,7 +218,7 @@ async def _advance(
             raise NodeParked(f"edge points at unknown node {next_id}")
         if is_wait(next_node) and next_node.minutes:
             # Arrival scheduling: the wait's alarm starts now.
-            if not await accessor.advance_run(
+            if not await enrollment_accessor.advance_run(
                 str(run.id),
                 next_id,
                 datetime.now(timezone.utc) + timedelta(minutes=next_node.minutes),

--- a/app/crm/shared/decode.py
+++ b/app/crm/shared/decode.py
@@ -53,3 +53,11 @@ def uuid_or_none(value: Any) -> Optional[str]:
     """A uuid column as a string, preserving NULL as None — asyncpg hands
     back UUID objects, schemas type these as Optional[str]."""
     return str(value) if value is not None else None
+
+
+def jsonb_value(value: Any) -> Any:
+    """asyncpg hands jsonb back as text unless a codec is registered —
+    decode defensively, the record-module precedent."""
+    if isinstance(value, str):
+        return json.loads(value)
+    return value

--- a/docs/crm/building-modules.md
+++ b/docs/crm/building-modules.md
@@ -44,7 +44,39 @@ Shared column lists move with their table. Import the table you mean by its
 full path (`from ...db.accessors import binding as binding_accessor`) — the
 sub-packages export nothing, so an accessor's imports say which table it
 touches without opening a second file. CI rule 2 admits both shapes; a file
-under `db/accessors/` or `db/decoders/` still may not carry SQL.
+under `db/accessors/` or `db/decoders/` still may not carry SQL. Outreach
+took the shape 3 Sep 2026 (three tables: workflow · enrollment · version).
+
+**`schemas.py` becomes `schemas/` the same way** — one file per table family
+(connectivity: `connector.py` · `message.py` · `template.py`), plus a port
+file where a seam needs a neutral shape (`ingress.py`) and `tenancy.py` for
+the `TenantScoped` request base. `__init__` exports nothing; import the
+family you mean.
+
+**Vocabulary files, one word each, one home each**: `reasons.py` (why a send
+was refused — T16 col 13), `topics.py` (what a letter is CALLED on the spine —
+T13 col 4), `status.py` (every status word this module BRANCHES on, one
+section per table — the manifest's included). SQL never spells a status:
+builders bind them as `$n` (importing the constant is fine; interpolating it
+into the statement is the blocker `tests/crm/test_vocabulary.py` walks the
+builders for). A table whose words live in a logic file is the two-definitions
+scar — `dispatch.py` held the manifest's for three days.
+
+**The tenancy door is ONE dependency**: `merchant_scope(operation, component)`
+in `app/crm/auth.py` finds the merchant (query on a GET, the `TenantScoped`
+body on a POST/PATCH), runs the check, sets the log context and hands the
+merchant to the handler. Every merchant-facing route DECLARES it; a test walks
+the router and fails on one that does not (`test_connectivity_routes.py`).
+Status codes come from ONE route class (`TranslatingRoute`) that maps the
+module's exception families — a route never writes `try/except HTTPException`.
+
+**Slots are filled at the composition root** (corpus modules/00 §11): when A
+needs B's answer but B already imports A's contracts, A owns `register_*` with
+a FAIL-CLOSED default and `app/crm/worker_main.py` fills it — consumers
+(record), INGRESS entries (record), the template retire guard (connectivity,
+`retire_guard.py`). `shared/locks.py` is the legal leaf both sides derive an
+advisory-lock key from; each module executes the lock through its own
+`db/queries`.
 
 **The layer law:** `api -> logic -> db/accessor -> db/queries`.
 **The boundary law:** logic owns transaction scope (atomicity is business

--- a/tests/crm/conftest.py
+++ b/tests/crm/conftest.py
@@ -8,3 +8,19 @@ Unset means the DB-backed integration tests skip.
 import os
 
 CRM_WEBHOOK_TEST_DSN = os.environ.get("CRM_WEBHOOK_TEST_DSN") or None
+
+
+import pytest  # noqa: E402  (the DSN above is a plain constant, not a fixture)
+
+from tests.crm import doubles  # noqa: E402
+
+
+@pytest.fixture
+def graph_stub(monkeypatch: pytest.MonkeyPatch):
+    """The shared Meta Graph transport, canned: ``graph_stub(handler)`` returns
+    the list of requests the code made."""
+
+    def _install(handler):
+        return doubles.stub_graph(monkeypatch, handler)
+
+    return _install

--- a/tests/crm/doubles.py
+++ b/tests/crm/doubles.py
@@ -1,0 +1,99 @@
+"""Test doubles shared across the connectivity and outreach suites — one
+implementation each, so a fake that grows a method grows it everywhere.
+
+Rules the doubles keep: a fake accessor records writes BY FIELD NAME (the
+strict-zip trick — an accessor whose signature grows a column turns the
+assertions red instead of silently reading the wrong one); an HTTP stub
+captures the exact request the code made and delegates to a canned handler.
+"""
+
+from typing import Any, Callable, Dict, List, Optional
+
+import httpx
+import pytest
+
+# --- HTTP transports -----------------------------------------------------------
+
+
+def stub_http(
+    monkeypatch: pytest.MonkeyPatch, module: Any, handler: Callable
+) -> List[httpx.Request]:
+    """Point ``module.create_http_client`` at a canned responder; return the
+    list every outgoing request is appended to, in order."""
+    seen: List[httpx.Request] = []
+
+    def _capture(request: httpx.Request) -> httpx.Response:
+        seen.append(request)
+        return handler(request)
+
+    monkeypatch.setattr(
+        module,
+        "create_http_client",
+        lambda **_: httpx.AsyncClient(transport=httpx.MockTransport(_capture)),
+    )
+    return seen
+
+
+def stub_graph(
+    monkeypatch: pytest.MonkeyPatch, handler: Callable
+) -> List[httpx.Request]:
+    """The shared Meta Graph transport, canned."""
+    from app.crm.connectivity.providers.meta import graph as graph_module
+
+    return stub_http(monkeypatch, graph_module, handler)
+
+
+# --- accessors -----------------------------------------------------------------
+
+#: db/accessors/installation.upsert_installation's positional signature after
+#: ``txn``, named once so assertions read as facts about the row.
+UPSERT_INSTALLATION_FIELDS = (
+    "merchant_id",
+    "connector_key",
+    "external_account_id",
+    "display_label",
+    "credential_id",
+    "status",
+    "token_expires_at",
+    "health_detail_json",
+)
+
+
+class FakeInstallationAccessor:
+    """Stands in for db/accessors/installation.
+
+    ``installation`` / ``existing_account``: what the door read answers
+    (``get_installation_by_account``) — two names because the templates suite
+    seeds "the door behind this template" and the onboarding suite seeds
+    "what is already connected"; ``upsert_returns``: what the write answers.
+    """
+
+    def __init__(
+        self,
+        installation: Any = None,
+        *,
+        existing_account: Any = None,
+        upsert_returns: Any = None,
+    ) -> None:
+        self.installation = installation
+        self.existing_account = existing_account
+        self.upsert_returns = upsert_returns
+        self.written: Optional[Dict[str, Any]] = None
+
+    async def get_installation_by_account(self, merchant_id, key, account_ref):
+        if self.existing_account is not None:
+            return self.existing_account
+        return self.installation
+
+    async def upsert_installation(self, txn, *args):
+        self.written = dict(zip(UPSERT_INSTALLATION_FIELDS, args, strict=True))
+        return self.upsert_returns
+
+
+def patch_accessors(monkeypatch: pytest.MonkeyPatch, module: Any, fake: Any) -> None:
+    """Point every ``*_accessor`` name a logic module imports at one fake —
+    the outreach suites seed one object that answers for all three tables."""
+    names = [n for n in vars(module) if n.endswith("_accessor") or n == "accessor"]
+    assert names, f"{module.__name__} imports no accessor to patch"
+    for name in names:
+        monkeypatch.setattr(module, name, fake)

--- a/tests/crm/test_connectivity_adapters.py
+++ b/tests/crm/test_connectivity_adapters.py
@@ -15,7 +15,7 @@ import pytest
 from app.crm.connectivity import (
     accounts as accounts_module,
     send as send_module,
-    templates as templates_module,
+    template_reads as template_reads_module,
 )
 from app.crm.connectivity.db.queries.binding import (
     binding_by_id_query,
@@ -240,7 +240,7 @@ def _patch_accessors(monkeypatch, fake) -> None:
     """
     for name in ("binding_accessor", "installation_accessor"):
         monkeypatch.setattr(send_module, name, fake)
-    monkeypatch.setattr(templates_module, "template_accessor", fake)
+    monkeypatch.setattr(template_reads_module, "template_accessor", fake)
 
 
 @pytest.fixture

--- a/tests/crm/test_connectivity_routes.py
+++ b/tests/crm/test_connectivity_routes.py
@@ -1,0 +1,124 @@
+"""The two structural guarantees of the connectors surface (structure PR,
+3 Sep 2026): every route declares the tenancy door, and one route class
+translates this module's exceptions — so a route cannot forget the check
+and two routes cannot map one family to two codes.
+"""
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from fastapi import FastAPI
+from fastapi.routing import APIRoute
+from fastapi.testclient import TestClient
+
+from app.api.security.breeze_buddy.rbac_token import get_current_user_with_rbac
+from app.crm.auth import MERCHANT_SCOPE_MARK
+from app.crm.connectivity import api as connectivity_api
+from app.crm.connectivity.onboarding import (
+    OnboardingError,
+    ResubscribeRefused,
+    UnknownConnectorError,
+)
+from app.crm.connectivity.templates import (
+    TemplateError,
+    TemplateInUseError,
+    TemplateNotFoundError,
+)
+
+
+def _declares_merchant_scope(route: APIRoute) -> bool:
+    return any(
+        getattr(dep.call, MERCHANT_SCOPE_MARK, False)
+        for dep in route.dependant.dependencies
+    )
+
+
+def test_every_connectors_route_declares_the_tenancy_door() -> None:
+    """The structural guarantee: walk the router, not the handlers."""
+    routes = [r for r in connectivity_api.router.routes if isinstance(r, APIRoute)]
+    assert len(routes) >= 11, "the router lost routes — the walk found too few"
+    missing = [r.path for r in routes if not _declares_merchant_scope(r)]
+    assert missing == [], f"routes without merchant_scope: {missing}"
+
+
+def test_every_connectors_route_uses_the_translating_route_class() -> None:
+    routes = [r for r in connectivity_api.router.routes if isinstance(r, APIRoute)]
+    assert all(isinstance(r, connectivity_api.TranslatingRoute) for r in routes)
+
+
+@pytest.mark.parametrize(
+    ("error", "code"),
+    [
+        (UnknownConnectorError("telegram"), 404),
+        (TemplateNotFoundError("no such template"), 404),
+        (TemplateInUseError("still named by 2 runs"), 409),
+        (ResubscribeRefused("the provider declined"), 409),
+        (OnboardingError("bad code"), 400),
+        (TemplateError("not from draft"), 400),
+        (RuntimeError("not ours"), None),
+    ],
+)
+def test_the_translator_maps_each_family_once(error: Exception, code: Any) -> None:
+    translated = connectivity_api.translate(error)
+    if code is None:
+        assert translated is None
+    else:
+        assert translated is not None and translated.status_code == code
+
+
+def _client(monkeypatch: pytest.MonkeyPatch, merchants=("shop",)) -> TestClient:
+    app = FastAPI()
+    app.include_router(connectivity_api.router, prefix="/connectors")
+    app.dependency_overrides[get_current_user_with_rbac] = lambda: SimpleNamespace(
+        role="user", username="u", merchant_ids=list(merchants), reseller_ids=[]
+    )
+    return TestClient(app)
+
+
+def test_the_door_reads_the_merchant_from_a_post_body(monkeypatch) -> None:
+    """merchant_scope reads the TenantScoped body on a POST and the handler
+    still gets its parsed model — one read, two readers."""
+    seen = {}
+
+    async def fake_create(merchant_id, *args):
+        seen["merchant"] = merchant_id
+        raise TemplateError("stop here")
+
+    monkeypatch.setattr(
+        connectivity_api.contracts, "create_template_draft", fake_create
+    )
+    response = _client(monkeypatch).post(
+        "/connectors/templates",
+        json={
+            "merchant_id": "shop",
+            "channel": "whatsapp",
+            "provider_account_ref": "waba-1",
+            "name": "n",
+            "language": "en",
+            "components": [],
+        },
+    )
+    assert response.status_code == 400 and seen["merchant"] == "shop"
+
+
+def test_a_foreign_merchant_is_refused_before_the_handler_runs(monkeypatch) -> None:
+    async def never(*args):
+        raise AssertionError("the handler must not run for a foreign merchant")
+
+    monkeypatch.setattr(connectivity_api.contracts, "list_templates", never)
+    response = _client(monkeypatch).get(
+        "/connectors/templates", params={"merchant_id": "someone-else"}
+    )
+    assert response.status_code == 403
+
+
+def test_a_body_without_a_merchant_is_a_400_not_a_pass(monkeypatch) -> None:
+    async def never(*args):
+        raise AssertionError("no merchant, no handler")
+
+    monkeypatch.setattr(connectivity_api.contracts, "onboard", never)
+    response = _client(monkeypatch).post(
+        "/connectors/whatsapp/onboard", json={"code": "x"}
+    )
+    assert response.status_code == 400

--- a/tests/crm/test_connectors_onboarding.py
+++ b/tests/crm/test_connectors_onboarding.py
@@ -28,12 +28,12 @@ from app.crm.connectivity.connectors import (
 from app.crm.connectivity.db import UniqueViolation
 from app.crm.connectivity.onboarding import (
     OnboardingError,
+    ResubscribeRefused,
     UnknownConnectorError,
     disconnect,
     onboard,
 )
 from app.crm.connectivity.providers import ADAPTERS
-from app.crm.connectivity.providers.meta import graph as graph_module
 from app.crm.connectivity.providers.whatsapp.onboard import (
     OnboardWhatsappRequest,
     WhatsappOnboarder,
@@ -44,6 +44,10 @@ from app.crm.connectivity.schemas.connector import (
     ConnectorInstallation,
     InstallationRead,
     OnboardResult,
+)
+from tests.crm.doubles import (
+    FakeInstallationAccessor,
+    stub_graph,
 )
 
 # --- the registry -----------------------------------------------------------
@@ -89,23 +93,6 @@ async def test_an_unknown_connector_is_refused_by_name() -> None:
 
 
 # --- the WhatsApp handshake -------------------------------------------------
-
-
-def _graph(monkeypatch, handler) -> List[httpx.Request]:
-    """Point the shared Graph transport at a canned responder."""
-    seen: List[httpx.Request] = []
-
-    def _capture(request: httpx.Request) -> httpx.Response:
-        """Record the outgoing request, then delegate to the handler."""
-        seen.append(request)
-        return handler(request)
-
-    monkeypatch.setattr(
-        graph_module,
-        "create_http_client",
-        lambda **_: httpx.AsyncClient(transport=httpx.MockTransport(_capture)),
-    )
-    return seen
 
 
 def _meta_stub(
@@ -174,7 +161,7 @@ async def test_an_expiry_becomes_a_real_deadline(monkeypatch) -> None:
     non-NULL rows, so a discarded expiry is a door that claims to hold a
     permanent credential and goes dark on day sixty with a green light.
     """
-    _graph(monkeypatch, _meta_stub(expires_in=5184000))
+    stub_graph(monkeypatch, _meta_stub(expires_in=5184000))
     result = await WhatsappOnboarder().gather(_request())
     assert result.token_expires_at is not None
     expected = datetime.now(timezone.utc) + timedelta(seconds=5184000)
@@ -184,14 +171,14 @@ async def test_an_expiry_becomes_a_real_deadline(monkeypatch) -> None:
 async def test_no_expiry_stays_an_honest_null(monkeypatch) -> None:
     """Some tokens genuinely never expire, and NULL has to keep meaning that
     rather than 'we forgot to look'."""
-    _graph(monkeypatch, _meta_stub(expires_in=None))
+    stub_graph(monkeypatch, _meta_stub(expires_in=None))
     result = await WhatsappOnboarder().gather(_request())
     assert result.token_expires_at is None
 
 
 async def test_the_token_never_rides_the_query_string(monkeypatch) -> None:
     """A bearer token in a URL reaches proxy logs and browser history."""
-    seen = _graph(monkeypatch, _meta_stub())
+    seen = stub_graph(monkeypatch, _meta_stub())
     await WhatsappOnboarder().gather(_request())
     for request in seen:
         assert "access_token=" not in str(request.url)
@@ -202,7 +189,7 @@ async def test_the_token_never_rides_the_query_string(monkeypatch) -> None:
 async def test_a_number_not_on_the_account_is_refused(monkeypatch) -> None:
     """Both ids arrive from a page we do not control; binding a number that
     is not on the account would build a door onto someone else's endpoint."""
-    _graph(monkeypatch, _meta_stub())
+    stub_graph(monkeypatch, _meta_stub())
     with pytest.raises(WhatsappOnboardingError):
         await WhatsappOnboarder().gather(_request(phone_number_id="PN-OTHER"))
 
@@ -211,49 +198,13 @@ async def test_a_failed_subscription_reports_a_lower_rung(monkeypatch) -> None:
     """Not a refusal: the account is real and the token works. What is
     missing is the event stream, which is a DEGRADED door with a why — and
     refusing outright would leave the merchant with a spent signup code."""
-    _graph(monkeypatch, _meta_stub(subscribe_ok=False))
+    stub_graph(monkeypatch, _meta_stub(subscribe_ok=False))
     result = await WhatsappOnboarder().gather(_request())
     assert result.health_level == "authenticated"
     assert result.health_why
 
 
 # --- onboarding's four steps ------------------------------------------------
-
-
-#: The accessor's positional signature after ``txn``, named once so the
-#: assertions read as facts about the row rather than about tuple indices.
-_UPSERT_FIELDS = (
-    "merchant_id",
-    "connector_key",
-    "external_account_id",
-    "display_label",
-    "credential_id",
-    "status",
-    "token_expires_at",
-    "health_detail_json",
-)
-
-
-class _FakeInstallationAccessor:
-    """Stands in for db/accessors/installation."""
-
-    def __init__(self, upsert_returns=None, existing_account=None):
-        """Test double."""
-        self.upsert_returns = upsert_returns
-        self.existing_account = existing_account
-        self.written: Optional[Dict[str, Any]] = None
-
-    async def get_installation_by_account(self, merchant_id, key, account_id):
-        """Test double: the pre-check's read — nothing connected by default."""
-        return self.existing_account
-
-    async def upsert_installation(self, txn, *args):
-        """Test double: record the write by field name, return the seeded row."""
-        # strict: the double records the write BY FIELD NAME, so if the
-        # accessor's signature grows a column the assertions would silently
-        # start reading the wrong one. This makes that a failure instead.
-        self.written = dict(zip(_UPSERT_FIELDS, args, strict=True))
-        return self.upsert_returns
 
 
 class _FakeBindingAccessor:
@@ -426,7 +377,7 @@ def _patch_onboarding(
     monkeypatch.setattr(
         onboarding_module,
         "installation_accessor",
-        installations or _FakeInstallationAccessor(_installation_read()),
+        installations or FakeInstallationAccessor(upsert_returns=_installation_read()),
     )
     monkeypatch.setattr(
         onboarding_module, "binding_accessor", bindings or _FakeBindingAccessor()
@@ -481,7 +432,7 @@ async def test_the_status_is_derived_from_the_health_rung(
     on a door whose subscription failed means receipts and inbound STOPs
     never arrive while the screen says everything is fine.
     """
-    installations = _FakeInstallationAccessor(_installation_read())
+    installations = FakeInstallationAccessor(upsert_returns=_installation_read())
     _patch_onboarding(
         monkeypatch,
         result=_result(health_level=level, health_why="because"),
@@ -496,7 +447,7 @@ async def test_the_expiry_reaches_the_row(monkeypatch) -> None:
     """What the handshake learned about the token's life has to be written,
     or the refresh job never sees this door."""
     expires = datetime.now(timezone.utc) + timedelta(days=60)
-    installations = _FakeInstallationAccessor(_installation_read())
+    installations = FakeInstallationAccessor(upsert_returns=_installation_read())
     _patch_onboarding(
         monkeypatch,
         result=_result(token_expires_at=expires),
@@ -512,7 +463,7 @@ async def test_a_disabled_connection_is_not_resurrected(monkeypatch) -> None:
     undo it. The upsert's WHERE declines and returns nothing; the refusal
     names what to do about it."""
     _patch_onboarding(
-        monkeypatch, installations=_FakeInstallationAccessor(upsert_returns=None)
+        monkeypatch, installations=FakeInstallationAccessor(upsert_returns=None)
     )
     with pytest.raises(OnboardingError, match="disabled"):
         await onboard("shop", "whatsapp", _request().model_dump())
@@ -709,7 +660,7 @@ async def test_an_unconfirmed_subscription_degrades_rather_than_aborting(
     abort onboarding — leaving the merchant with a spent one-time code and no
     connection. The account is real and its token works; only the event
     stream is missing, which is a degraded door with a why."""
-    _graph(monkeypatch, _meta_stub(subscribe_silent=True))
+    stub_graph(monkeypatch, _meta_stub(subscribe_silent=True))
     result = await WhatsappOnboarder().gather(_request())
     assert result.health_level == "authenticated"
     assert result.health_why
@@ -719,7 +670,7 @@ async def test_a_number_on_a_later_page_is_still_found(monkeypatch) -> None:
     """Meta returns 25 numbers a page. Without following the cursor, a
     business with more than one page has a legitimate number refused as "not
     on this account" — a wrong answer, not a slow one."""
-    _graph(monkeypatch, _meta_stub(phone_pages=3))
+    stub_graph(monkeypatch, _meta_stub(phone_pages=3))
     result = await WhatsappOnboarder().gather(_request())
     assert result.external_account_id == "waba-1"
 
@@ -735,7 +686,7 @@ async def test_the_app_secret_never_rides_the_query_string(monkeypatch) -> None:
     Both OAuth exchanges POST it in the body — a query string reaches proxy
     access logs, browser history and every intermediary's request log.
     """
-    seen = _graph(monkeypatch, _meta_stub())
+    seen = stub_graph(monkeypatch, _meta_stub())
     await WhatsappOnboarder().gather(_request())
     for request in seen:
         assert "client_secret=" not in str(request.url)
@@ -757,7 +708,7 @@ async def test_a_disabled_connection_refuses_before_the_code_is_spent(
     the cheap answer."""
     onboarder = _patch_onboarding(
         monkeypatch,
-        installations=_FakeInstallationAccessor(
+        installations=FakeInstallationAccessor(
             _installation_read(), existing_account=_healthy_route("disabled")
         ),
     )
@@ -1198,8 +1149,12 @@ def test_the_subscribe_route_reports_a_refusal_as_409(monkeypatch) -> None:
     from app.crm.connectivity import contracts
 
     async def refuses(merchant_id, installation_id):
-        """Test double: the door refused."""
-        raise OnboardingError("This account's credentials are missing or unreadable.")
+        """Test double: the door refused — the declared type, so the one
+        translator answers 409 (a plain OnboardingError is the caller's
+        mistake, 400)."""
+        raise ResubscribeRefused(
+            "This account's credentials are missing or unreadable."
+        )
 
     monkeypatch.setattr(contracts, "resubscribe", refuses)
     response = _client(monkeypatch).post(

--- a/tests/crm/test_consumer_registry.py
+++ b/tests/crm/test_consumer_registry.py
@@ -102,10 +102,10 @@ def test_worker_main_registers_the_template_retire_guard() -> None:
     # contracts; the reverse arrow would close a cycle), so worker_main
     # hands outreach's count into connectivity's slot.
     import app.crm.worker_main  # noqa: F401  (registration is an import effect)
-    from app.crm.connectivity import templates as connectivity_templates
+    from app.crm.connectivity import retire_guard as connectivity_retire_guard
     from app.crm.outreach.contracts import template_references
 
-    assert connectivity_templates._retire_guard is template_references
+    assert connectivity_retire_guard._retire_guard is template_references
 
 
 def test_the_api_process_wires_the_guard_through_worker_main() -> None:

--- a/tests/crm/test_dispatch.py
+++ b/tests/crm/test_dispatch.py
@@ -21,11 +21,6 @@ from app.crm.connectivity.dispatch import (
     REASON_SEND_ERROR,
     REASON_SUPPRESSED,
     RETRY_MAX_SECONDS,
-    STATUS_ACCEPTED,
-    STATUS_BLOCKED,
-    STATUS_DEAD,
-    STATUS_FAILED,
-    STATUS_QUEUED,
     _jittered,
     backoff_seconds,
     plan_for_outcome,
@@ -34,6 +29,14 @@ from app.crm.connectivity.dispatch import (
 from app.crm.connectivity.providers import ADAPTERS
 from app.crm.connectivity.reasons import REASON_RECLAIMED_STALE_CLAIM
 from app.crm.connectivity.schemas.message import QueuedMessage, SendOutcome
+from app.crm.connectivity.status import (
+    MESSAGE_ACCEPTED,
+    MESSAGE_BLOCKED,
+    MESSAGE_DEAD,
+    MESSAGE_FAILED,
+    MESSAGE_QUEUED,
+    MESSAGE_SENDING,
+)
 from app.crm.shared.decode import jsonb_object
 from scripts.check_crm_boundaries import TABLE_OWNERS
 
@@ -58,7 +61,7 @@ def test_accepted_records_the_provider_id_and_stamps_sent() -> None:
     plan = plan_for_outcome(
         SendOutcome(status="accepted", provider_message_id="wamid.X"), 1, 3
     )
-    assert plan.status == STATUS_ACCEPTED
+    assert plan.status == MESSAGE_ACCEPTED
     assert plan.provider_message_id == "wamid.X"
     assert plan.mark_sent is True
     assert plan.reason is None
@@ -69,7 +72,7 @@ def test_retryable_failure_goes_back_on_the_queue() -> None:
     plan = plan_for_outcome(
         SendOutcome(status="failed", reason="rate_limited", retryable=True), 1, 3
     )
-    assert plan.status == STATUS_QUEUED
+    assert plan.status == MESSAGE_QUEUED
     assert plan.reason == "rate_limited"
     assert plan.mark_sent is False
 
@@ -80,7 +83,7 @@ def test_retryable_failure_goes_dead_on_the_last_attempt() -> None:
         SendOutcome(status="failed", reason="rate_limited", retryable=True), 3, 3
     )
     # 'dead' (we stopped trying), not 'failed' (the wire said no).
-    assert plan.status == STATUS_DEAD
+    assert plan.status == MESSAGE_DEAD
     assert plan.reason == REASON_ATTEMPTS_EXHAUSTED
 
 
@@ -89,7 +92,7 @@ def test_permanent_failure_never_retries_however_many_attempts_remain() -> None:
     plan = plan_for_outcome(
         SendOutcome(status="failed", reason="template_not_approved"), 1, 99
     )
-    assert plan.status == STATUS_FAILED
+    assert plan.status == MESSAGE_FAILED
     assert plan.reason == "template_not_approved"
 
 
@@ -118,7 +121,7 @@ def test_our_refusal_lands_as_blocked_terminal_and_unsent() -> None:
     plan = plan_for_outcome(
         SendOutcome(status="blocked", reason=REASON_SUPPRESSED), 1, 3
     )
-    assert plan.status == STATUS_BLOCKED
+    assert plan.status == MESSAGE_BLOCKED
     assert plan.reason == REASON_SUPPRESSED
     assert plan.mark_sent is False
     assert plan.retry_after_seconds is None
@@ -176,7 +179,7 @@ async def test_an_accepted_send_records_the_outcome(monkeypatch) -> None:
     await dispatch._dispatch_one(_message(), 3)
     assert written["sent"] == "m-1"
     assert written["token_names_message"] is True
-    assert written["status"] == STATUS_ACCEPTED
+    assert written["status"] == MESSAGE_ACCEPTED
     assert written["mark_sent"] is True
     # The write carries the claim's generation, so a stale claim's late
     # outcome cannot land on a row a newer claim now owns.
@@ -203,7 +206,7 @@ async def test_a_raising_send_becomes_a_retryable_send_error(monkeypatch) -> Non
     monkeypatch.setattr(dispatch.message_accessor, "apply_outcome", record_outcome)
     await dispatch._dispatch_one(_message(attempt=1), 3)
     # We don't know whether the provider saw it, so it requeues with a delay.
-    assert written["status"] == STATUS_QUEUED
+    assert written["status"] == MESSAGE_QUEUED
     assert written["reason"] == REASON_SEND_ERROR
     assert written["retry"] is not None and written["retry"] >= 1
 
@@ -239,7 +242,7 @@ async def test_a_suppressed_address_is_blocked_and_the_adapter_never_called(
     monkeypatch.setattr(dispatch, "send", exploding_send)
     monkeypatch.setattr(dispatch.message_accessor, "apply_outcome", record_outcome)
     await dispatch._dispatch_one(_message(), 3)
-    assert written["status"] == STATUS_BLOCKED
+    assert written["status"] == MESSAGE_BLOCKED
     assert written["reason"] == REASON_SUPPRESSED
     assert written["mark_sent"] is False
 
@@ -268,7 +271,7 @@ async def test_a_channel_the_gate_cannot_check_fails_closed(monkeypatch) -> None
     message = _message()
     message = message.model_copy(update={"channel": "carrier_pigeon"})
     await dispatch._dispatch_one(message, 3)
-    assert written["status"] == STATUS_BLOCKED
+    assert written["status"] == MESSAGE_BLOCKED
     assert written["reason"] == REASON_GATE_UNAVAILABLE
 
 
@@ -302,7 +305,7 @@ async def test_a_hung_gate_probe_is_bounded_and_fails_closed(monkeypatch) -> Non
     monkeypatch.setattr(dispatch, "CRM_MESSAGE_SEND_TIMEOUT_SECONDS", 0.05)
     monkeypatch.setattr(dispatch.message_accessor, "apply_outcome", record_outcome)
     await dispatch._dispatch_one(_message(), 3)
-    assert written["status"] == STATUS_BLOCKED
+    assert written["status"] == MESSAGE_BLOCKED
     assert written["reason"] == REASON_GATE_UNAVAILABLE
     assert written["mark_sent"] is False
 
@@ -340,7 +343,7 @@ async def test_a_reclaimed_row_discards_the_late_outcome(monkeypatch) -> None:
     monkeypatch.setattr(dispatch.message_accessor, "apply_outcome", reclaimed)
     await dispatch._dispatch_one(_message(), 3)
     # Discarded means one write attempt, no retry, no raise — their row now.
-    assert calls == [STATUS_ACCEPTED]
+    assert calls == [MESSAGE_ACCEPTED]
 
 
 def test_jitter_stays_in_bounds_and_never_reaches_zero() -> None:
@@ -361,9 +364,9 @@ def test_claim_is_race_safe_across_pods() -> None:
     """Claim is race safe across pods."""
     query, values = claim_queued_messages_query(25)
     assert "FOR UPDATE SKIP LOCKED" in query
-    assert "status = 'queued'" in query
+    assert "WHERE status = $3" in query
     assert "LIMIT $1" in query
-    assert values == [25]
+    assert values == [25, MESSAGE_SENDING, MESSAGE_QUEUED]
 
 
 # --- log lines stay bounded --------------------------------------------------
@@ -455,7 +458,7 @@ def test_requeue_carries_a_delay_and_terminal_outcomes_do_not() -> None:
     requeued = plan_for_outcome(
         SendOutcome(status="failed", reason="131049", retryable=True), 1, 3
     )
-    assert requeued.status == STATUS_QUEUED
+    assert requeued.status == MESSAGE_QUEUED
     assert requeued.retry_after_seconds and requeued.retry_after_seconds > 0
 
     for terminal in (
@@ -509,9 +512,18 @@ def test_outcome_write_is_guarded_by_the_claim() -> None:
     query, values = apply_outcome_query(
         "m-1", "accepted", None, "wamid.X", True, 2, None
     )
-    assert "status = 'sending'" in query
+    assert "AND status = $8" in query
     assert "attempt = $7::int" in query
-    assert values == ["m-1", "accepted", None, "wamid.X", True, None, 2]
+    assert values == [
+        "m-1",
+        "accepted",
+        None,
+        "wamid.X",
+        True,
+        None,
+        2,
+        MESSAGE_SENDING,
+    ]
 
 
 def test_outcome_write_never_erases_a_known_provider_id() -> None:
@@ -523,12 +535,20 @@ def test_outcome_write_never_erases_a_known_provider_id() -> None:
 def test_stale_sweep_targets_only_expired_claims() -> None:
     """Stale sweep targets only expired claims."""
     query, values = requeue_stale_claims_query(5, 3)
-    assert "status = 'sending'" in query
+    assert "WHERE status = $7" in query
     assert "make_interval(mins => $1::int)" in query
     # The reclaim reason the sweep writes is manifest vocabulary, so the
     # word must be the one reasons.py declares — not a SQL-only spelling.
-    assert f"'{REASON_RECLAIMED_STALE_CLAIM}'" in query
-    assert values == [5, 3]
+    assert REASON_RECLAIMED_STALE_CLAIM in values  # bound as $6, never SQL text
+    assert values == [
+        5,
+        3,
+        MESSAGE_DEAD,
+        MESSAGE_QUEUED,
+        REASON_ATTEMPTS_EXHAUSTED,
+        REASON_RECLAIMED_STALE_CLAIM,
+        MESSAGE_SENDING,
+    ]
 
 
 def test_stale_sweep_kills_rows_that_are_out_of_attempts() -> None:
@@ -541,11 +561,19 @@ def test_stale_sweep_kills_rows_that_are_out_of_attempts() -> None:
     # copies instead of one per stale window, forever.
     query, values = requeue_stale_claims_query(5, 3)
     assert "attempt >= $2::int" in query
-    assert "'dead'" in query
+    assert MESSAGE_DEAD in values and "THEN $3::text ELSE $4::text" in query
     # Same word as plan_for_outcome's dead: we stopped, the provider didn't.
-    assert f"'{REASON_ATTEMPTS_EXHAUSTED}'" in query
+    assert REASON_ATTEMPTS_EXHAUSTED in values  # bound as $5, never SQL text
     assert "RETURNING id, status" in query
-    assert values == [5, 3]
+    assert values == [
+        5,
+        3,
+        MESSAGE_DEAD,
+        MESSAGE_QUEUED,
+        REASON_ATTEMPTS_EXHAUSTED,
+        REASON_RECLAIMED_STALE_CLAIM,
+        MESSAGE_SENDING,
+    ]
 
 
 def test_builders_parameterize_every_value() -> None:
@@ -694,7 +722,7 @@ def test_the_work_queue_is_a_partial_index() -> None:
     """The work queue is a partial index."""
     sql = _ddl()
     assert "crm_message_queued_ix" in sql
-    assert "WHERE status = 'queued'" in sql
+    assert "WHERE status = 'queued'" in sql  # DDL: the partial index's predicate
     assert "crm_message_claimed_ix" in sql
 
 

--- a/tests/crm/test_event_worker.py
+++ b/tests/crm/test_event_worker.py
@@ -27,7 +27,6 @@ from typing import Any, Dict, List, Optional, Tuple, cast
 import pytest
 
 import app.crm.record.consumers as record_consumers
-import app.crm.record.extractors.flat as flat_extractor
 import app.crm.record.extractors.shopify as shopify_extractor
 import app.crm.record.workers as workers
 import app.crm.shared.worker as worker_mod

--- a/tests/crm/test_ingress_door.py
+++ b/tests/crm/test_ingress_door.py
@@ -202,14 +202,29 @@ def test_only_the_webhook_router_is_unauthenticated() -> None:
             if getattr(d, "call", None) is not None
         ]
 
+    def carries(route, name: str) -> bool:
+        """Whether the dependency tree declares ``name`` at any depth."""
+
+        def walk(dependant) -> bool:
+            for d in dependant.dependencies:
+                call = getattr(d, "call", None)
+                if call is not None and call.__name__ == name:
+                    return True
+                if walk(d):
+                    return True
+            return False
+
+        return walk(route.dependant)
+
     for route in record_api.webhook_router.routes:
         assert dependency_names(route) == [], getattr(route, "path", route)
-    # Every /connectors route carries the merchant-facing RBAC dependency —
-    # the tenancy check itself runs inside the handler via
-    # assert_merchant_access.
+    # Every /connectors route declares the tenancy door (merchant_scope),
+    # which itself depends on the merchant-facing RBAC dependency — so the
+    # walk looks one level in: the door, and the auth inside it.
     for route in connectivity_api.router.routes:
-        names = dependency_names(route)
-        assert "get_current_user_with_rbac" in names, getattr(route, "path", route)
+        assert carries(route, "get_current_user_with_rbac"), getattr(
+            route, "path", route
+        )
 
 
 def test_a_callback_carrying_no_letters_is_still_200(client, spec, spine) -> None:

--- a/tests/crm/test_templates.py
+++ b/tests/crm/test_templates.py
@@ -9,16 +9,17 @@ every language variant with it.
 
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import List, Optional
 
 import httpx
 import pytest
 
 from app.crm.connectivity import (
     accounts as accounts_module,
+    retire_guard as retire_guard_module,
+    template_reads as template_reads_module,
     templates as templates_module,
 )
-from app.crm.connectivity.providers.meta import graph as graph_module
 from app.crm.connectivity.providers.whatsapp.templates import (
     WhatsappTemplateError,
     WhatsappTemplates,
@@ -27,6 +28,7 @@ from app.crm.connectivity.providers.whatsapp.templates import (
 from app.crm.connectivity.schemas.connector import ConnectorInstallation
 from app.crm.connectivity.schemas.message import CredentialBundle
 from app.crm.connectivity.schemas.template import TemplateDraft, TemplateRead
+from app.crm.connectivity.template_reads import template_status
 from app.crm.connectivity.templates import (
     TemplateError,
     TemplateInUseError,
@@ -37,6 +39,7 @@ from app.crm.connectivity.templates import (
     submit,
 )
 from scripts.check_crm_boundaries import TABLE_OWNERS
+from tests.crm.doubles import FakeInstallationAccessor, stub_graph
 
 # --- the provider face ------------------------------------------------------
 
@@ -55,23 +58,6 @@ def test_meta_shouting_becomes_the_canon_dictionary() -> None:
     assert _from_meta("  ") is None
 
 
-def _graph(monkeypatch, handler) -> List[httpx.Request]:
-    """Point the shared Graph transport at a canned responder."""
-    seen: List[httpx.Request] = []
-
-    def _capture(request: httpx.Request) -> httpx.Response:
-        """Record the outgoing request, then delegate to the handler."""
-        seen.append(request)
-        return handler(request)
-
-    monkeypatch.setattr(
-        graph_module,
-        "create_http_client",
-        lambda **_: httpx.AsyncClient(transport=httpx.MockTransport(_capture)),
-    )
-    return seen
-
-
 def _bundle() -> CredentialBundle:
     return CredentialBundle(values={"system_user_token": "tok"})
 
@@ -82,7 +68,7 @@ async def test_a_submitted_template_keeps_metas_own_verdict(monkeypatch) -> None
     The category especially: a provider may assign a different one from the
     one requested, and theirs is what the merchant is billed at.
     """
-    _graph(
+    stub_graph(
         monkeypatch,
         lambda _r: httpx.Response(
             200, json={"id": "T-1", "status": "PENDING", "category": "UTILITY"}
@@ -103,7 +89,7 @@ async def test_a_submitted_template_keeps_metas_own_verdict(monkeypatch) -> None
 async def test_a_submission_without_an_id_is_a_failure(monkeypatch) -> None:
     """Without the provider's id no webhook can ever be matched to this row,
     so a 200 that omits it is not a success."""
-    _graph(monkeypatch, lambda _r: httpx.Response(200, json={"status": "PENDING"}))
+    stub_graph(monkeypatch, lambda _r: httpx.Response(200, json={"status": "PENDING"}))
     with pytest.raises(Exception):
         await WhatsappTemplates().submit(
             _bundle(),
@@ -119,7 +105,9 @@ async def test_retiring_one_language_carries_the_provider_id(monkeypatch) -> Non
     variant of it. Retiring order_update/en_US would silently delete
     order_update/hi_IN on Meta while our hi_IN row still read 'approved' —
     and the first send on it would fail at Meta with 132001."""
-    seen = _graph(monkeypatch, lambda _r: httpx.Response(200, json={"success": True}))
+    seen = stub_graph(
+        monkeypatch, lambda _r: httpx.Response(200, json={"success": True})
+    )
     await WhatsappTemplates().retire(
         _bundle(), "waba-1", "T-1", "order_update", "en_US"
     )
@@ -260,18 +248,6 @@ class _FakeTemplateAccessor:
         return _template(status="deleted")
 
 
-class _FakeInstallationAccessor:
-    """Stands in for db/accessors/installation."""
-
-    def __init__(self, installation=None):
-        """Test double."""
-        self.installation = installation
-
-    async def get_installation_by_account(self, merchant_id, key, account_ref):
-        """Test double: the seeded door for that provider account."""
-        return self.installation
-
-
 class _StubTemplates:
     """A TemplateProvider with scripted behaviour."""
 
@@ -325,7 +301,7 @@ def _healthy(**overrides) -> ConnectorInstallation:
 def _patch(monkeypatch, *, templates=None, installation=None, provider=None):
     """Wire templates.py to doubles."""
     accessor = templates or _FakeTemplateAccessor()
-    installations = _FakeInstallationAccessor(
+    installations = FakeInstallationAccessor(
         _healthy() if installation is None else installation
     )
     face = provider or _StubTemplates()
@@ -354,7 +330,7 @@ def _patch(monkeypatch, *, templates=None, installation=None, provider=None):
     monkeypatch.setattr(templates_module, "atomically", _atomically)
     monkeypatch.setattr(accounts_module, "get_credential_by_id", _credential)
     monkeypatch.setattr(templates_module, "connector_for_channel", lambda c: spec)
-    monkeypatch.setattr(templates_module, "_retire_guard", _no_open_runs)
+    monkeypatch.setattr(retire_guard_module, "_retire_guard", _no_open_runs)
     return accessor, face
 
 
@@ -372,7 +348,7 @@ async def test_a_draft_on_an_unconnected_account_is_refused(monkeypatch) -> None
     to submit with, so it is refused here rather than at submit."""
     _patch(monkeypatch, installation=None)
     monkeypatch.setattr(
-        accounts_module, "installation_accessor", _FakeInstallationAccessor(None)
+        accounts_module, "installation_accessor", FakeInstallationAccessor(None)
     )
     with pytest.raises(TemplateError, match="no connected account"):
         await create_draft("shop", "whatsapp", "waba-9", "n", "en_US", [])
@@ -528,7 +504,7 @@ async def test_retire_is_refused_while_open_runs_name_the_template(
         asked.append((merchant_id, channel, name))
         return (2, 0)
 
-    monkeypatch.setattr(templates_module, "_retire_guard", two_runs)
+    monkeypatch.setattr(retire_guard_module, "_retire_guard", two_runs)
     with pytest.raises(TemplateInUseError, match="2 open workflow run"):
         await retire("shop", "t-1")
     template = accessor.template
@@ -548,7 +524,7 @@ async def test_retire_is_refused_while_a_live_plan_names_the_template(
     async def one_plan(merchant_id: str, channel: str, name: str) -> tuple:
         return (0, 1)
 
-    monkeypatch.setattr(templates_module, "_retire_guard", one_plan)
+    monkeypatch.setattr(retire_guard_module, "_retire_guard", one_plan)
     with pytest.raises(TemplateInUseError, match="1 live or paused plan"):
         await retire("shop", "t-1")
     assert "retire" not in accessor.calls and face.retired == []
@@ -601,7 +577,7 @@ async def test_retire_withdraws_locally_with_the_check_before_the_provider(
         templates=_Recording(_template(status="approved", provider_template_id="T-1")),
         provider=_Face(),
     )
-    monkeypatch.setattr(templates_module, "_retire_guard", checked)
+    monkeypatch.setattr(retire_guard_module, "_retire_guard", checked)
     updated = await retire("shop", "t-1")
     assert updated.status == "deleted"
     assert order == ["lock", "check", "local", "provider"]
@@ -611,7 +587,7 @@ async def test_retire_fails_closed_when_no_guard_is_registered(monkeypatch) -> N
     """A missing registration is a wiring bug, not permission to delete:
     refuse, and say so in the log."""
     accessor, face = _patch(monkeypatch, templates=_approved())
-    monkeypatch.setattr(templates_module, "_retire_guard", None)
+    monkeypatch.setattr(retire_guard_module, "_retire_guard", None)
     with pytest.raises(TemplateError, match="not wired"):
         await retire("shop", "t-1")
     assert "retire" not in accessor.calls and face.retired == []
@@ -795,7 +771,8 @@ def test_the_in_place_edit_is_conditional_on_the_status_it_read() -> None:
 
 from app.crm.connectivity import channels as channels_module, contracts
 from app.crm.connectivity.db.queries.template import templates_by_name_query
-from app.crm.connectivity.templates import template_status
+from app.crm.connectivity.schemas.template import TemplateVerdict
+from app.crm.connectivity.templates import TemplateInUseError as _InUse  # noqa: F401
 
 
 def test_templates_by_name_read_is_merchant_first_and_parameterised() -> None:
@@ -838,19 +815,32 @@ class _ByNameAccessor:
 @pytest.mark.parametrize(
     ("rows", "verdict"),
     [
-        ([], None),
-        ([_registry_row("approved")], "approved"),
-        ([_registry_row("pending"), _registry_row("deleted")], "pending"),
+        (
+            [],
+            TemplateVerdict(
+                publishable=False,
+                reason="is not registered on whatsapp for this merchant",
+            ),
+        ),
+        ([_registry_row("approved")], TemplateVerdict(publishable=True)),
+        (
+            [_registry_row("pending"), _registry_row("deleted")],
+            TemplateVerdict(publishable=False, reason="is 'pending', not approved"),
+        ),
         (
             [_registry_row("approved", "en"), _registry_row("approved", "hi")],
-            "approved in 2 languages",
+            TemplateVerdict(
+                publishable=False,
+                reason="is approved in 2 languages on one account — exactly one "
+                "is required to send",
+            ),
         ),
         (
             [
                 _registry_row("approved", "en", "waba-1"),
                 _registry_row("approved", "en", "waba-2"),
             ],
-            "approved",
+            TemplateVerdict(publishable=True),
         ),
     ],
     ids=[
@@ -862,13 +852,16 @@ class _ByNameAccessor:
     ],
 )
 async def test_template_status_answers_for_the_publish_check(
-    monkeypatch, rows: List[TemplateRead], verdict: Optional[str]
+    monkeypatch, rows: List[TemplateRead], verdict: TemplateVerdict
 ) -> None:
-    """None: never registered. "approved": every account holding the name
-    holds exactly one approved row. Two approved languages on one account
-    is the ambiguity the send door refuses — same rule, earlier. Otherwise
-    the newest row's status, so the publish message can say why."""
-    monkeypatch.setattr(templates_module, "template_accessor", _ByNameAccessor(rows))
+    """Never registered; every account holding the name holds exactly one
+    approved row (publishable); two approved languages on one account — the
+    ambiguity the send door refuses, refused here first; otherwise the
+    newest row's status, so the publish message can say why. Verdict-shaped:
+    outreach quotes the reason and never compares a status word."""
+    monkeypatch.setattr(
+        template_reads_module, "template_accessor", _ByNameAccessor(rows)
+    )
     assert await template_status("m1", "whatsapp", "cart_recovery_1") == verdict
 
 

--- a/tests/crm/test_vocabulary.py
+++ b/tests/crm/test_vocabulary.py
@@ -20,12 +20,18 @@ from app.crm.connectivity import accounts, status
 
 QUERIES_DIR = Path(__file__).resolve().parents[2] / "app/crm/connectivity/db/queries"
 
-#: Every word of all three vocabularies, as SQL would spell it.
+#: Every word of all four vocabularies, as SQL would spell it.
 STATUS_WORDS = sorted(
     v
     for k, v in vars(status).items()
     if not k.startswith("_") and isinstance(v, str) and k.isupper()
 )
+
+#: The tables this module writes a status on — a FIXED list, so a fifth
+#: table whose words never reach status.py cannot hide from this test the
+#: way crm_message's did (its words lived in dispatch.py and its SQL spelled
+#: 'sending' while every check here passed — the 3 Sep 2026 audit).
+STATUS_FAMILIES = ("TEMPLATE_", "INSTALLATION_", "BINDING_", "MESSAGE_")
 
 
 #: Names in status.py, so an interpolated constant is recognised by NAME as
@@ -100,6 +106,24 @@ def test_no_status_word_is_spelled_inside_a_sql_string() -> None:
                         f"a status is a VALUE and binds as $n, never as f-string text"
                     )
     assert not offences, "\n".join(offences)
+
+
+def test_every_table_family_has_its_words_in_status_py() -> None:
+    """Each family must export at least its column default; a table whose
+    vocabulary lives elsewhere is invisible to the SQL walk above."""
+    for family in STATUS_FAMILIES:
+        words = [k for k in vars(status) if k.startswith(family) and k.isupper()]
+        assert words, f"{family} words are not in status.py"
+    # the manifest's ladder, as canon T16 col 12 spells it
+    assert status.MESSAGE_QUEUED == "queued" and status.MESSAGE_SENDING == "sending"
+    assert status.MESSAGE_DEAD == "dead"
+
+
+def test_no_second_home_for_the_manifest_words() -> None:
+    """dispatch.py once defined STATUS_QUEUED… beside status.py's words."""
+    from app.crm.connectivity import dispatch
+
+    assert not [n for n in vars(dispatch) if n.startswith("STATUS_")]
 
 
 def test_the_builders_were_actually_read() -> None:

--- a/tests/crm/test_whatsapp_adapter.py
+++ b/tests/crm/test_whatsapp_adapter.py
@@ -29,6 +29,7 @@ from app.crm.connectivity.schemas.message import (
     SendRoute,
 )
 from app.crm.connectivity.schemas.template import ApprovedTemplate
+from tests.crm.doubles import stub_http
 
 ACCEPTED_BODY = {
     "messaging_product": "whatsapp",
@@ -115,22 +116,18 @@ def _route(**overrides) -> SendRoute:
 
 
 def _mocked(monkeypatch, handler) -> Dict[str, Any]:
-    """Point the adapter's HTTP client at a canned responder and capture the
-    request it made."""
+    """Point the adapter's HTTP client at a canned responder (the shared
+    stub, tests/crm/doubles.py) and keep the LAST request as the dict this
+    suite reads: url, headers, body."""
     seen: Dict[str, Any] = {}
 
-    def _capture(request: httpx.Request) -> httpx.Response:
-        """Record the outgoing request, then delegate to the handler."""
+    def _record(request: httpx.Request) -> httpx.Response:
         seen["url"] = str(request.url)
         seen["headers"] = dict(request.headers)
         seen["body"] = request.read().decode()
         return handler(request)
 
-    monkeypatch.setattr(
-        whatsapp_module,
-        "create_http_client",
-        lambda **_: httpx.AsyncClient(transport=httpx.MockTransport(_capture)),
-    )
+    stub_http(monkeypatch, whatsapp_module, _record)
     return seen
 
 

--- a/tests/crm/test_worker_runtime.py
+++ b/tests/crm/test_worker_runtime.py
@@ -13,6 +13,7 @@ import pytest
 import app.crm.outreach.definitions as definitions
 import app.crm.outreach.entry as entry
 import app.crm.outreach.workers as outreach_workers
+from app.crm.outreach.db.accessors import version as version_accessor
 from app.crm.outreach.nodes import send_variables
 from app.crm.outreach.schemas import EnrollmentRun, Workflow, WorkflowDefinition
 from app.crm.outreach.walker import pick_next
@@ -148,13 +149,13 @@ def _wire(
         calls.append(("enrol", kwargs))
         return object()
 
-    monkeypatch.setattr(entry.accessor, "live_workflows", live_workflows)
+    monkeypatch.setattr(entry.workflow_accessor, "live_workflows", live_workflows)
     monkeypatch.setattr(
-        entry.accessor, "open_runs_for_customer", open_runs_for_customer
+        entry.enrollment_accessor, "open_runs_for_customer", open_runs_for_customer
     )
-    monkeypatch.setattr(entry.accessor, "get_definition", get_definition)
-    monkeypatch.setattr(entry.accessor, "cancel_run", cancel_run)
-    monkeypatch.setattr(entry.accessor, "resume_run_by_id", resume_run_by_id)
+    monkeypatch.setattr(version_accessor, "get_definition", get_definition)
+    monkeypatch.setattr(entry.enrollment_accessor, "cancel_run", cancel_run)
+    monkeypatch.setattr(entry.enrollment_accessor, "resume_run_by_id", resume_run_by_id)
     monkeypatch.setattr(entry, "enrol", fake_enrol)
     return run
 

--- a/tests/crm/test_workflow_admission.py
+++ b/tests/crm/test_workflow_admission.py
@@ -12,6 +12,7 @@ import app.crm.outreach.enrol as enrol_mod
 from app.crm.outreach.db import DbTxn
 from app.crm.outreach.enrol import _admission, _first_wake
 from app.crm.outreach.schemas import EnrollmentRun, Workflow, WorkflowDefinition
+from tests.crm.doubles import patch_accessors
 
 NOW = datetime(2026, 8, 26, 14, 0, tzinfo=timezone.utc)
 CUSTOMER = str(uuid4())
@@ -158,7 +159,7 @@ def _workflow(key: Optional[str], reenter: bool = False) -> Workflow:
     )
 
 
-_REAL_ACCESSOR = enrol_mod.accessor
+_REAL_ACCESSORS = (enrol_mod.enrollment_accessor, enrol_mod.version_accessor)
 
 
 class _History:
@@ -250,7 +251,7 @@ def test_a_keyed_plan_admits_a_new_key_despite_the_customers_history(
     counted ALL her runs on the plan. "Has this ORDER ever run" is what
     entry.key declared — a new order id has no history, so it is admitted."""
     history = _History()
-    monkeypatch.setattr(enrol_mod, "accessor", history)
+    patch_accessors(monkeypatch, enrol_mod, history)
     run = _enrol(history, _workflow(key="order_id"), "ORD-2")
     assert run is not None and history.inserted == ["ORD-2"]
     assert history.judged == ["ORD-2"]  # judged per key, never per customer
@@ -260,7 +261,7 @@ def test_a_keyed_plan_still_refuses_a_key_that_already_ran(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     history = _History()
-    monkeypatch.setattr(enrol_mod, "accessor", history)
+    patch_accessors(monkeypatch, enrol_mod, history)
     assert _enrol(history, _workflow(key="order_id"), "ORD-1") is None
     assert history.inserted == [] and history.judged == ["ORD-1"]
 
@@ -271,7 +272,7 @@ def test_an_unkeyed_plan_keeps_judging_the_customer(
     """No entry.key: the key IS the customer id and the guards read her
     whole history on the plan, exactly as before."""
     history = _History()
-    monkeypatch.setattr(enrol_mod, "accessor", history)
+    patch_accessors(monkeypatch, enrol_mod, history)
     assert _enrol(history, _workflow(key=None), CUSTOMER) is None
     assert history.inserted == [] and history.judged == [None]
 
@@ -282,7 +283,8 @@ def test_enrol_holds_the_templates_the_document_sends_before_the_insert() -> Non
     before its insert — a retirement's EXCLUSIVE lock then waits for this
     row to commit and counts it, instead of racing past it."""
     history = _History()
-    enrol_mod.accessor = history  # type: ignore[assignment]
+    enrol_mod.enrollment_accessor = history  # type: ignore[assignment]
+    enrol_mod.version_accessor = history  # type: ignore[assignment]
     try:
         workflow = Workflow(
             id=uuid4(),
@@ -312,7 +314,7 @@ def test_enrol_holds_the_templates_the_document_sends_before_the_insert() -> Non
         )
         run = _enrol(history, workflow, "ORD-2")
     finally:
-        enrol_mod.accessor = _REAL_ACCESSOR  # type: ignore[assignment]
+        enrol_mod.enrollment_accessor, enrol_mod.version_accessor = _REAL_ACCESSORS  # type: ignore[assignment]
     assert run is not None
     assert history.locked == [[("whatsapp", "cart_recovery_1")]]
     assert history.order == ["lock", "insert"]

--- a/tests/crm/test_workflow_decoder.py
+++ b/tests/crm/test_workflow_decoder.py
@@ -5,7 +5,8 @@ import json
 from datetime import datetime, timezone
 from uuid import uuid4
 
-from app.crm.outreach.db.decoder import decode_run, decode_workflow
+from app.crm.outreach.db.decoders.enrollment import decode_run
+from app.crm.outreach.db.decoders.workflow import decode_workflow
 
 NOW = datetime(2026, 8, 26, 14, 0, tzinfo=timezone.utc)
 

--- a/tests/crm/test_workflow_entry.py
+++ b/tests/crm/test_workflow_entry.py
@@ -31,6 +31,7 @@ from app.crm.outreach.schemas import (
 )
 from app.crm.outreach.walker import pick_next
 from app.crm.record.schemas import RawEvent
+from tests.crm.doubles import patch_accessors
 
 NOW = datetime(2026, 9, 3, 10, 0, tzinfo=timezone.utc)
 
@@ -186,15 +187,18 @@ class _Spine:
 
 
 def _install(monkeypatch: pytest.MonkeyPatch, spine: _Spine) -> None:
+    """Seed the spine on the per-table accessor each read lives in — the
+    workflow read, the run reads, and the pinned-definition read (which
+    definitions.py owns, on the version table)."""
     definitions._definitions.clear()
-    for name in (
-        "live_workflows",
-        "open_runs_for_customer",
-        "get_definition",
-        "cancel_run",
-        "resume_run_by_id",
+    for module, name in (
+        (entry.workflow_accessor, "live_workflows"),
+        (entry.enrollment_accessor, "open_runs_for_customer"),
+        (definitions.version_accessor, "get_definition"),
+        (entry.enrollment_accessor, "cancel_run"),
+        (entry.enrollment_accessor, "resume_run_by_id"),
     ):
-        monkeypatch.setattr(entry.accessor, name, getattr(spine, name))
+        monkeypatch.setattr(module, name, getattr(spine, name))
 
 
 def _consume(event: RawEvent) -> None:
@@ -851,7 +855,7 @@ def test_a_merchant_level_letter_starts_ends_and_wakes_nothing(
     # once — no open-run read, no entry match.
     import app.crm.outreach.entry as entry_module
 
-    monkeypatch.setattr(entry_module, "accessor", _UntouchableAccessor())
+    patch_accessors(monkeypatch, entry_module, _UntouchableAccessor())
     event = RawEvent(
         id="e-tpl",
         merchant_id="m1",

--- a/tests/crm/test_workflow_ladder.py
+++ b/tests/crm/test_workflow_ladder.py
@@ -17,6 +17,7 @@ from app.crm.outreach.ladder import LadderProblem, expand_stages
 from app.crm.outreach.nodes import run_facts
 from app.crm.outreach.plans import validate_definition
 from app.crm.outreach.schemas import Workflow, WorkflowDefinition
+from tests.crm.doubles import patch_accessors
 
 NOW = datetime(2026, 9, 3, 10, 0, tzinfo=timezone.utc)
 THREE = ["loan.profile_created", "loan.kyc_completed", "loan.bank_linked"]
@@ -345,8 +346,8 @@ async def test_create_and_draft_store_the_ladder_and_its_board(
         stored.append(draft)
         return _workflow("draft", None, draft)
 
-    monkeypatch.setattr(plans.accessor, "insert_workflow", insert_workflow)
-    monkeypatch.setattr(plans.accessor, "update_draft", update_draft)
+    monkeypatch.setattr(plans.workflow_accessor, "insert_workflow", insert_workflow)
+    monkeypatch.setattr(plans.workflow_accessor, "update_draft", update_draft)
     await plans.create_workflow("m1", "loan-dropoff", _ladder(), "ops@x")
     await plans.update_draft("m1", "wf-1", _ladder())
     assert stored == [expand_stages(_ladder())] * 2
@@ -398,7 +399,7 @@ async def test_publish_takes_the_stored_ladder_and_refuses_a_drifted_board(
     never published half-and-half."""
     stored = expand_stages(_ladder())
     accessor = _PublishAccessor(stored)
-    monkeypatch.setattr(plans, "accessor", accessor)
+    patch_accessors(monkeypatch, plans, accessor)
     published = await plans._publish_in_txn(cast(DbTxn, object()), "m1", "wf-1", None)
     assert published.definition == stored
     assert accessor.versions == [(1, stored)]
@@ -410,7 +411,7 @@ async def test_publish_takes_the_stored_ladder_and_refuses_a_drifted_board(
             for n in stored["nodes"]
         ],
     }
-    monkeypatch.setattr(plans, "accessor", _PublishAccessor(drifted))
+    patch_accessors(monkeypatch, plans, _PublishAccessor(drifted))
     with pytest.raises(plans.WorkflowValidationError) as refused:
         await plans._publish_in_txn(cast(DbTxn, object()), "m1", "wf-1", None)
     assert any("stages" in p and "nodes" in p for p in refused.value.problems)
@@ -418,7 +419,7 @@ async def test_publish_takes_the_stored_ladder_and_refuses_a_drifted_board(
     # a ladder saved WITHOUT its board (never by create/draft — a direct
     # write) is refused as well: apply_publish copies the draft verbatim,
     # and a live document without squares would park every run
-    monkeypatch.setattr(plans, "accessor", _PublishAccessor(_ladder()))
+    patch_accessors(monkeypatch, plans, _PublishAccessor(_ladder()))
     with pytest.raises(plans.WorkflowValidationError) as refused:
         await plans._publish_in_txn(cast(DbTxn, object()), "m1", "wf-1", None)
     assert any("without its board" in p for p in refused.value.problems)

--- a/tests/crm/test_workflow_plans.py
+++ b/tests/crm/test_workflow_plans.py
@@ -8,12 +8,14 @@ from uuid import uuid4
 import pytest
 
 import app.crm.outreach.plans as plans
+from app.crm.connectivity.schemas.template import TemplateVerdict
 from app.crm.outreach.db import DbTxn
 from app.crm.outreach.plans import validate_definition
 from app.crm.outreach.schemas import (
     Workflow,
     WorkflowDefinition,
 )
+from tests.crm.doubles import patch_accessors
 
 NOW = datetime(2026, 9, 3, 10, 0, tzinfo=timezone.utc)
 
@@ -316,8 +318,10 @@ async def test_going_live_on_a_never_published_draft_is_refused_before_the_db(
     async def set_workflow_status(*args: object) -> None:
         raise AssertionError("must not reach the UPDATE")
 
-    monkeypatch.setattr(plans.accessor, "get_workflow", get_workflow)
-    monkeypatch.setattr(plans.accessor, "set_workflow_status", set_workflow_status)
+    monkeypatch.setattr(plans.workflow_accessor, "get_workflow", get_workflow)
+    monkeypatch.setattr(
+        plans.workflow_accessor, "set_workflow_status", set_workflow_status
+    )
     with pytest.raises(plans.WorkflowValidationError) as refused:
         await plans.set_status("m1", "wf-1", "live")
     assert "publish" in refused.value.problems[0]
@@ -336,8 +340,10 @@ async def test_pausing_or_archiving_a_never_published_draft_is_refused_too(
     async def set_workflow_status(*args: object) -> None:
         raise AssertionError("must not reach the UPDATE")
 
-    monkeypatch.setattr(plans.accessor, "get_workflow", get_workflow)
-    monkeypatch.setattr(plans.accessor, "set_workflow_status", set_workflow_status)
+    monkeypatch.setattr(plans.workflow_accessor, "get_workflow", get_workflow)
+    monkeypatch.setattr(
+        plans.workflow_accessor, "set_workflow_status", set_workflow_status
+    )
     for wanted in ("paused", "archived"):
         with pytest.raises(plans.WorkflowValidationError) as refused:
             await plans.set_status("m1", "wf-1", wanted)
@@ -360,8 +366,10 @@ async def test_a_published_plan_still_pauses_and_resumes(
         writes.append(status)
         return published
 
-    monkeypatch.setattr(plans.accessor, "get_workflow", get_workflow)
-    monkeypatch.setattr(plans.accessor, "set_workflow_status", set_workflow_status)
+    monkeypatch.setattr(plans.workflow_accessor, "get_workflow", get_workflow)
+    monkeypatch.setattr(
+        plans.workflow_accessor, "set_workflow_status", set_workflow_status
+    )
     assert await plans.set_status("m1", "wf-1", "paused") is published
     assert await plans.set_status("m1", "wf-1", "live") is published
     assert writes == ["paused", "live"]
@@ -374,18 +382,20 @@ async def test_unknown_or_archived_plans_answer_none_for_the_404(
     async def set_workflow_status(*args: object) -> None:
         raise AssertionError("must not reach the UPDATE")
 
-    monkeypatch.setattr(plans.accessor, "set_workflow_status", set_workflow_status)
+    monkeypatch.setattr(
+        plans.workflow_accessor, "set_workflow_status", set_workflow_status
+    )
 
     async def missing(merchant_id: str, workflow_id: str) -> None:
         return None
 
-    monkeypatch.setattr(plans.accessor, "get_workflow", missing)
+    monkeypatch.setattr(plans.workflow_accessor, "get_workflow", missing)
     assert await plans.set_status("m1", "wf-1", "live") is None
 
     async def archived(merchant_id: str, workflow_id: str) -> Workflow:
         return _workflow("archived", None)
 
-    monkeypatch.setattr(plans.accessor, "get_workflow", archived)
+    monkeypatch.setattr(plans.workflow_accessor, "get_workflow", archived)
     assert await plans.set_status("m1", "wf-1", "live") is None
 
 
@@ -443,6 +453,18 @@ class _PublishAccessor:
         return 0
 
 
+def _verdict(status: Optional[str]) -> TemplateVerdict:
+    """The registry's verdict for a test's shorthand: None = never
+    registered, "approved" = publishable, any other word = that status."""
+    if status is None:
+        return TemplateVerdict(
+            publishable=False, reason="is not registered on whatsapp for this merchant"
+        )
+    if status == "approved":
+        return TemplateVerdict(publishable=True)
+    return TemplateVerdict(publishable=False, reason=f"is '{status}', not approved")
+
+
 def _registry(
     monkeypatch: pytest.MonkeyPatch, status: Optional[str], registers: bool = True
 ) -> List[Tuple[str, str, str]]:
@@ -450,9 +472,9 @@ def _registry(
 
     async def template_status(
         merchant_id: str, channel: str, name: str
-    ) -> Optional[str]:
+    ) -> TemplateVerdict:
         asked.append((merchant_id, channel, name))
-        return status
+        return _verdict(status)
 
     monkeypatch.setattr(plans, "template_status", template_status)
     monkeypatch.setattr(plans, "registers_templates_for", lambda channel: registers)
@@ -470,7 +492,7 @@ async def test_publish_refuses_a_send_node_whose_template_is_unknown(
     """G12: today the first sign of a wrong template name is a blocked
     send hours later. The registry can answer at publish."""
     accessor = _PublishAccessor(_SEND_PLAN)
-    monkeypatch.setattr(plans, "accessor", accessor)
+    patch_accessors(monkeypatch, plans, accessor)
     asked = _registry(monkeypatch, status=None)
     with pytest.raises(plans.WorkflowValidationError) as refused:
         await _publish(accessor)
@@ -487,7 +509,7 @@ async def test_publish_refuses_a_send_node_whose_template_is_not_approved(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     accessor = _PublishAccessor(_SEND_PLAN)
-    monkeypatch.setattr(plans, "accessor", accessor)
+    patch_accessors(monkeypatch, plans, accessor)
     _registry(monkeypatch, status="pending")
     with pytest.raises(plans.WorkflowValidationError) as refused:
         await _publish(accessor)
@@ -502,7 +524,7 @@ async def test_publish_proceeds_when_the_template_is_approved(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     accessor = _PublishAccessor(_SEND_PLAN)
-    monkeypatch.setattr(plans, "accessor", accessor)
+    patch_accessors(monkeypatch, plans, accessor)
     _registry(monkeypatch, status="approved")
     published = await _publish(accessor)
     assert accessor.published is True and published.status == "live"
@@ -513,7 +535,7 @@ async def test_a_plan_without_send_nodes_never_asks_the_registry(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     accessor = _PublishAccessor(_TERSE_DRAFT)
-    monkeypatch.setattr(plans, "accessor", accessor)
+    patch_accessors(monkeypatch, plans, accessor)
     asked = _registry(monkeypatch, status=None)
     await _publish(accessor)
     assert asked == [] and accessor.published is True
@@ -524,7 +546,7 @@ async def test_a_channel_that_does_not_register_templates_is_not_asked(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     accessor = _PublishAccessor(_SEND_PLAN)
-    monkeypatch.setattr(plans, "accessor", accessor)
+    patch_accessors(monkeypatch, plans, accessor)
     asked = _registry(monkeypatch, status=None, registers=False)
     await _publish(accessor)
     assert asked == [] and accessor.published is True
@@ -538,11 +560,13 @@ async def test_publish_holds_the_templates_it_sends_before_asking_the_registry(
     every template the draft sends BEFORE the approval check, so a
     retirement cannot commit between "approved" and the version row."""
     accessor = _PublishAccessor(_SEND_PLAN)
-    monkeypatch.setattr(plans, "accessor", accessor)
+    patch_accessors(monkeypatch, plans, accessor)
 
-    async def template_status(merchant_id: str, channel: str, name: str) -> str:
+    async def template_status(
+        merchant_id: str, channel: str, name: str
+    ) -> TemplateVerdict:
         accessor.order.append("ask")
-        return "approved"
+        return TemplateVerdict(publishable=True)
 
     monkeypatch.setattr(plans, "template_status", template_status)
     monkeypatch.setattr(plans, "registers_templates_for", lambda channel: True)

--- a/tests/crm/test_workflow_queries.py
+++ b/tests/crm/test_workflow_queries.py
@@ -4,20 +4,22 @@ predicates present, the claim's lease semantics, idempotent stamps."""
 import json
 from datetime import datetime, timezone
 
-from app.crm.outreach.db.queries import (
+from app.crm.outreach.db.queries.enrollment import (
     admission_facts_query,
     advance_run_query,
     cancel_run_query,
     claim_due_runs_query,
     exit_run_query,
     insert_enrollment_query,
-    live_workflows_query,
     open_runs_for_customer_query,
     park_run_query,
-    publish_workflow_query,
     record_run_error_query,
     resume_run_by_id_query,
     source_event_used_query,
+)
+from app.crm.outreach.db.queries.workflow import (
+    live_workflows_query,
+    publish_workflow_query,
 )
 from app.crm.record.db.queries import customer_has_event_query
 

--- a/tests/crm/test_workflow_repeat.py
+++ b/tests/crm/test_workflow_repeat.py
@@ -11,7 +11,7 @@ import pytest
 
 import app.crm.outreach.entry as entry
 from app.crm.outreach import repeat
-from app.crm.outreach.db.queries import patch_open_run_query
+from app.crm.outreach.db.queries.enrollment import patch_open_run_query
 from app.crm.outreach.plans import validate_definition
 from app.crm.outreach.repeat import parse_repeat_policy, repeat_plan
 from app.crm.outreach.schemas import WorkflowDefinition, WorkflowEntryAt
@@ -391,7 +391,7 @@ def test_apply_repeat_hands_the_restart_word_to_the_patch(
         seen.append(args)
         return True
 
-    monkeypatch.setattr(repeat.accessor, "patch_open_run", patch_open_run)
+    monkeypatch.setattr(repeat.enrollment_accessor, "patch_open_run", patch_open_run)
     door = _door(
         on_repeat="refresh_latest", debounce_minutes=10, restart_on_repeat=True
     )

--- a/tests/crm/test_workflow_reporting.py
+++ b/tests/crm/test_workflow_reporting.py
@@ -9,7 +9,7 @@ route that lost its admin dependency or its mount fails here."""
 
 import inspect
 from datetime import datetime, timedelta, timezone
-from typing import Any, Dict, List
+from typing import Any, Dict
 from uuid import uuid4
 
 from fastapi.routing import APIRoute
@@ -17,8 +17,11 @@ from fastapi.routing import APIRoute
 import app.crm.api as crm_api
 import app.crm.outreach.api as outreach_api
 from app.crm.auth import crm_admin_user
-from app.crm.outreach.db.decoder import decode_customer_run, decode_run_summary
-from app.crm.outreach.db.queries import (
+from app.crm.outreach.db.decoders.enrollment import (
+    decode_customer_run,
+    decode_run_summary,
+)
+from app.crm.outreach.db.queries.enrollment import (
     cancel_run_query,
     customer_runs_query,
     workflow_summary_query,

--- a/tests/crm/test_workflow_runs.py
+++ b/tests/crm/test_workflow_runs.py
@@ -5,7 +5,7 @@ from datetime import datetime, timezone
 
 import pytest
 
-from app.crm.outreach.db.queries import (
+from app.crm.outreach.db.queries.enrollment import (
     list_runs_query,
     resume_run_query,
     sweep_exited_runs_query,

--- a/tests/crm/test_workflow_versions.py
+++ b/tests/crm/test_workflow_versions.py
@@ -18,19 +18,22 @@ import app.crm.outreach.api as outreach_api
 import app.crm.outreach.plans as plans
 import app.crm.outreach.versions as versions
 from app.crm.outreach.db import DbTxn
-from app.crm.outreach.db.queries import (
-    get_definition_query,
-    insert_version_query,
-    list_versions_query,
-    live_plans_naming_template_query,
+from app.crm.outreach.db.queries.enrollment import (
     occupied_nodes_on_version_query,
     repin_open_runs_query,
     repin_runs_on_version_query,
     runs_referencing_template_query,
 )
+from app.crm.outreach.db.queries.version import (
+    get_definition_query,
+    insert_version_query,
+    list_versions_query,
+)
+from app.crm.outreach.db.queries.workflow import live_plans_naming_template_query
 from app.crm.outreach.plans import validate_definition, validate_migration
 from app.crm.outreach.schemas import Workflow, WorkflowDefinition
 from scripts.check_crm_boundaries import TABLE_OWNERS
+from tests.crm.doubles import patch_accessors
 
 NOW = datetime(2026, 9, 3, 12, 0, tzinfo=timezone.utc)
 
@@ -148,7 +151,7 @@ async def _publish(
     monkeypatch: pytest.MonkeyPatch, draft: Dict[str, Any], occupied: List[str]
 ) -> _PublishAccessor:
     accessor = _PublishAccessor(draft, occupied)
-    monkeypatch.setattr(plans, "accessor", accessor)
+    patch_accessors(monkeypatch, plans, accessor)
 
     async def no_templates(
         merchant_id: str, definition: WorkflowDefinition
@@ -202,7 +205,7 @@ async def test_a_migrating_publish_that_would_strand_is_refused_before_any_write
         "nodes": [{"id": "wait-1h", "type": "wait", "minutes": 60}],
     }
     accessor = _PublishAccessor(draft, occupied=["wait-30m"])
-    monkeypatch.setattr(plans, "accessor", accessor)
+    patch_accessors(monkeypatch, plans, accessor)
     with pytest.raises(plans.WorkflowValidationError) as refused:
         await plans._publish_in_txn(cast(DbTxn, object()), "m1", "wf-1", None)
     assert any("waiting runs standing on it" in p for p in refused.value.problems)
@@ -301,11 +304,22 @@ def test_migration_reads_and_repins_only_runs_on_the_from_version() -> None:
 def test_versions_are_never_deleted() -> None:
     """ADR 0023 §5 as amended: no sweep, no dial, no DELETE builder — an
     exited run's workflow_version must keep answering what it executed."""
-    import app.crm.outreach.db.queries as queries
+    import importlib
+    import pkgutil
 
-    assert not [name for name in dir(queries) if "sweep" in name and "version" in name]
+    import app.crm.outreach.db.queries as queries_pkg
+
+    builders = [
+        name
+        for _, module, _ in pkgutil.iter_modules(queries_pkg.__path__)
+        for name in dir(importlib.import_module(f"{queries_pkg.__name__}.{module}"))
+    ]
+    assert not [name for name in builders if "sweep" in name and "version" in name]
     assert not hasattr(versions, "sweep_unreferenced_versions_tick")
-    assert "DELETE FROM crm_workflow_version" not in Path(queries.__file__).read_text()
+    assert all(
+        "DELETE FROM crm_workflow_version" not in p.read_text()
+        for p in Path(queries_pkg.__file__).parent.glob("*.py")
+    )
 
 
 def test_runs_referencing_a_template_are_counted_by_their_pinned_document() -> None:
@@ -351,7 +365,7 @@ async def test_template_references_answers_both_counts(
         async def live_plans_naming_template(self, m: str, c: str, n: str) -> int:
             return 1
 
-    monkeypatch.setattr(versions, "accessor", _Counts())
+    patch_accessors(monkeypatch, versions, _Counts())
     assert await versions.template_references("m1", "whatsapp", "x") == (2, 1)
 
 
@@ -399,7 +413,7 @@ async def _migrate(
     from_version: int = 3,
     to_version: int = 4,
 ) -> int:
-    monkeypatch.setattr(versions, "accessor", accessor)
+    patch_accessors(monkeypatch, versions, accessor)
     return await versions._migrate_forward_in_txn(
         cast(DbTxn, object()), "m1", "wf-1", from_version, to_version
     )
@@ -501,7 +515,7 @@ def test_the_template_lock_key_is_stable_and_bigint_sized() -> None:
 
 def test_pinners_lock_shared_and_retirement_locks_exclusive() -> None:
     from app.crm.connectivity.db.queries.template import lock_template_exclusive_query
-    from app.crm.outreach.db.queries import lock_template_shared_query
+    from app.crm.outreach.db.queries.version import lock_template_shared_query
 
     sql, params = lock_template_shared_query(42)
     assert "pg_advisory_xact_lock_shared($1::bigint)" in sql and params == [42]

--- a/tests/crm/test_workflow_walker.py
+++ b/tests/crm/test_workflow_walker.py
@@ -25,6 +25,7 @@ import app.crm.outreach.definitions as definitions
 import app.crm.outreach.walker as walker
 from app.crm.outreach.nodes import NodeParked
 from app.crm.outreach.schemas import EnrollmentRun, Workflow, WorkflowDefinition
+from tests.crm.doubles import patch_accessors
 
 NOW = datetime(2026, 9, 3, 12, 0, tzinfo=timezone.utc)
 LEASE = NOW + timedelta(seconds=300)
@@ -119,8 +120,8 @@ class _Writes:
 def _install(monkeypatch: pytest.MonkeyPatch, writes: _Writes) -> None:
     """The walker writes through its accessor; the pinned document comes
     through definitions.py's (phase 13) — one fake serves both doors."""
-    monkeypatch.setattr(walker, "accessor", writes)
-    monkeypatch.setattr(definitions, "accessor", writes)
+    patch_accessors(monkeypatch, walker, writes)
+    patch_accessors(monkeypatch, definitions, writes)
 
 
 @pytest.fixture


### PR DESCRIPTION
Structure PR 2 — the hygiene the 3 Sep audit found owed, as ONE commit (CI's one-commit rule) whose message keeps two parts apart so each is reviewable for what it is: part 1 is connectivity's plumbing and vocabulary (small behaviour reconciliations, each named); part 2 is a pure move of outreach's `db/` into the per-table shape.

### Part 1 — connectivity: one tenancy door, one translator, one home for the manifest's words, the registry's reads apart

- **`merchant_scope(operation, component)`** in `app/crm/auth.py` — the tenancy check as every route's DECLARED dependency: finds the merchant (query on a GET, the `TenantScoped` body on a POST/PATCH), runs `assert_merchant_access`, sets the log context, hands the merchant to the handler. Every `/connectors` route declares it; **`tests/crm/test_connectivity_routes.py` walks the router** and fails on one that does not. The door's auth walk in `test_ingress_door.py` now looks one level in (the door, and the RBAC dependency inside it).
- **One route class (`TranslatingRoute`)** maps the module's exception families to codes: unknown connector / template not found → 404; template in use / **`ResubscribeRefused`** → 409; the registry's request-model `ValidationError` → 422 (input never echoed); every other `OnboardingError` / `TemplateError` → 400. The one behaviour reconciliation the audit asked for: the subscribe route's refusal keeps its 409 under a declared type instead of mapping the whole `OnboardingError` family differently from the onboard route. No route writes `try/except` any more.
- **`schemas/tenancy.py`: `TenantScoped`**, the base of the four template request models.
- **Message statuses have one home**: `status.py` gains the manifest's nine words; `dispatch.py` imports them (its `STATUS_*` second home is gone; `test_dispatch` imports from `status`); `db/queries/message.py` binds every status AND both sweep reasons as `$n`; `accessors/message.py` compares by name. **`test_vocabulary.py` checks a FIXED list of four table families** so a fifth table whose words never reach `status.py` cannot hide the way `crm_message` did, and pins that `dispatch.py` defines no `STATUS_` word. `lock_template_exclusive_query` is in the `query = …` shape the walk reads.
- **`template_status` is verdict-shaped** (`TemplateVerdict {publishable, reason}`): outreach's publish check quotes the reason and never compares a status word across the seam.
- **`templates.py` 648 → 538**: the registry's READS move to `template_reads.py` (`get` · `list_templates` · `template_status` · `approved_template` — `send.py` and `contracts.py` read there), the retire-guard slot to `retire_guard.py` (`register_retire_guard`, fail-closed `workflows_naming`). What stays is the four transitions.
- **Shared test doubles** — `tests/crm/doubles.py`: `stub_http` / `stub_graph` (the two `_graph` copies are gone; the adapter's request capture rides the same stub), one `FakeInstallationAccessor` for both suites (strict-zip field names kept), `patch_accessors`; a `graph_stub` fixture in conftest. Left local on purpose: `_FakeTemplateAccessor` and `_FakeBindingAccessor` are bound to their file's row factories.
- **`docs/crm/building-modules.md`**: `schemas/` at scale, the three vocabulary files, the tenancy door, the composition-root slots.

### Part 2 — outreach `db/` takes the per-table shape (pure move)

The ruled trigger fired at #1068 (`db/queries.py` held a third table at 814 lines) and did not land. Now: `db/queries/{workflow,enrollment,version}.py` (+ `tables.py`, the three physical names in one leaf so a cross-table join imports a name, never a sibling module — the cycle `list_versions` ↔ `runs_referencing_template` would otherwise form), `db/accessors/…`, `db/decoders/…`. The eight logic files import the accessors they use by table (`enrollment_accessor.claim_due_runs` says which table a call touches); the tests are rewired through `patch_accessors`. `shared/decode.jsonb_value` replaces the decoder's private reader. **No builder, accessor or decoder body was edited** — the move is AST-driven and the diff shows it.

### Gates
760 passed (+0 net across both parts; 12 new, the rest moved) · `check_crm_boundaries.py` clean · black · isort · pyrefly 0 errors · db/ handle-name greps empty.

### Merge order and who rebases
After #1079 (the audit gap closures). Then #1047 (touches `outreach/db/queries.py`, now split), #1052 and #1021 rebase onto this. #1079's one appended test in `test_workflow_entry.py` patches `entry.accessor`; on rebase it becomes `patch_accessors(monkeypatch, entry, …)` — one line.

Sizes after: `templates.py` 538 (the four transitions; the next seam is per-transition files, not yet), `queries/enrollment.py` 626 (one table, 23 builders — a split by concern lands with the receipt walker's builders).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01APYhsMRBdKLz74A6NRuWy5



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added consistent merchant scoping and access checks across connectivity operations.
  * Added connector resubscription support with clearer refusal responses.
  * Added template publishability results, including explanations for approval or registration issues.
  * Improved workflow and version management capabilities, including publishing, version history, and template safety checks.

* **Bug Fixes**
  * Standardized API error responses for missing, invalid, conflicting, and unavailable resources.
  * Improved handling of stale message claims and message status reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->