### PR TITLE
fix(voice): make VAD enable/disable template-overridable

### DIFF
--- a/app/ai/voice/agents/breeze_buddy/handlers/internal/stt.py
+++ b/app/ai/voice/agents/breeze_buddy/handlers/internal/stt.py
@@ -7,14 +7,18 @@ async def mute_stt(context: TemplateContext, args, transition_to=None):
     """
     Mute STT input.
 
-    Routes to the appropriate mute mechanism:
-    - VAD enabled: delegates to mute_vad (duration arg is ignored)
-    - VAD disabled: engages TranscriptionGateProcessor hard mute
+    Engages both mechanisms when available:
+    - VAD enabled: also mutes VAD
+    - TranscriptionGateProcessor: hard-drops all transcripts at the source
 
-    Accepts an optional ``duration`` (seconds) in *args*. When provided and
-    the TranscriptionGate path is active, the mute is automatically released
-    after that many seconds. Without it the mute is indefinite until an
-    explicit ``unmute_stt`` call. The duration arg is ignored on the VAD path.
+    VAD mute alone doesn't stop a turn from starting — Soniox keeps
+    transcribing regardless, and TranscriptionUserTurnStartStrategy reacts
+    to those transcripts independently of VAD state. The gate is what
+    actually stops a transcript from reaching the aggregator.
+
+    Accepts an optional ``duration`` (seconds) in *args*. When provided, the
+    mute is automatically released after that many seconds. Without it the
+    mute is indefinite until an explicit ``unmute_stt`` call.
 
     Example JSON action with duration::
 
@@ -30,21 +34,19 @@ async def mute_stt(context: TemplateContext, args, transition_to=None):
     )
 
     if context.vad_analyzer:
-        if duration is not None:
-            logger.debug(
-                f"duration arg ignored for VAD path on call {context.call_sid}"
-            )
-        mute_vad(context)
-    elif context.speech_gate:
+        mute_vad(context, float(duration) if duration is not None else None)
+
+    if context.speech_gate:
         if duration is not None:
             context.speech_gate.mute_for(float(duration))
         else:
             context.speech_gate.mute()
         logger.info(
             f"STT muted via TranscriptionGate for call {context.call_sid} "
-            f"(VAD disabled, duration={duration})"
+            f"(duration={duration})"
         )
-    else:
+
+    if not context.vad_analyzer and not context.speech_gate:
         logger.warning(
             f"No VAD analyzer or speech gate found for call {context.call_sid}, cannot mute STT"
         )
@@ -54,22 +56,23 @@ async def unmute_stt(context: TemplateContext, args, transition_to=None):
     """
     Unmute STT input.
 
-    Routes to the appropriate unmute mechanism:
-    - VAD enabled: delegates to unmute_vad (restores stored/default params)
-    - VAD disabled: releases TranscriptionGateProcessor hard mute
+    Releases both mechanisms when available, mirroring mute_stt:
+    - VAD enabled: unmute_vad (restores stored/default params)
+    - TranscriptionGateProcessor: releases hard mute
 
-    Also cancels any pending timed-unmute task so that an explicit unmute
-    takes precedence over a previously scheduled auto-unmute.
+    Also cancels any pending timed-unmute task on either side, so an
+    explicit unmute always takes precedence over a scheduled one.
     """
     logger.debug(f"unmute_stt called for call {context.call_sid}")
+
     if context.vad_analyzer:
         unmute_vad(context)
-    elif context.speech_gate:
+
+    if context.speech_gate:
         context.speech_gate.unmute()
-        logger.info(
-            f"STT unmuted via TranscriptionGate for call {context.call_sid} (VAD disabled)"
-        )
-    else:
+        logger.info(f"STT unmuted via TranscriptionGate for call {context.call_sid}")
+
+    if not context.vad_analyzer and not context.speech_gate:
         logger.warning(
             f"No VAD analyzer or speech gate found for call {context.call_sid}, cannot unmute STT"
         )

--- a/app/ai/voice/agents/breeze_buddy/template/types.py
+++ b/app/ai/voice/agents/breeze_buddy/template/types.py
@@ -33,6 +33,10 @@ class ActionType(str, Enum):
 class VadConfig(BaseModel):
     """VAD configuration for template or node-level customization."""
 
+    enabled: Optional[bool] = Field(
+        None,
+        description="Whether VAD runs for this template. Overrides env default if set.",
+    )
     confidence: Optional[float] = Field(
         None, ge=0.0, le=1.0, description="VAD confidence threshold (0.0-1.0)"
     )

--- a/app/ai/voice/agents/breeze_buddy/template/vad.py
+++ b/app/ai/voice/agents/breeze_buddy/template/vad.py
@@ -12,6 +12,7 @@ For the full mute_stt/unmute_stt routing (VAD → TranscriptionGate fallback),
 see handlers/internal/stt.py.
 """
 
+import asyncio
 from typing import Optional
 
 from pipecat.audio.vad.silero import SileroVADAnalyzer
@@ -114,8 +115,9 @@ async def create_vad_analyzer(
 ) -> tuple[Optional[SileroVADAnalyzer], Optional[VADParams]]:
     """Create VAD analyzer with appropriate parameters.
 
-    VAD is gated behind BREEZE_BUDDY_ENABLE_VAD (default False).
-    When disabled, returns (None, None) and all VAD-related functionality is skipped.
+    VAD is gated behind BREEZE_BUDDY_ENABLE_VAD (default False), overridable
+    per template via `configurations.vad_config.enabled`. When disabled,
+    returns (None, None) and all VAD-related functionality is skipped.
 
     Both Daily and telephony modes honor template-level `vad_config` with per-field
     fallback to mode-specific Redis defaults (`BB_DAILY_VAD_*` / `BB_TELEPHONY_VAD_*`).
@@ -129,8 +131,28 @@ async def create_vad_analyzer(
         The default_vad_params is returned so node-level VAD overrides can reset
         back to the call-level default (see `reset_vad_to_default` below).
     """
-    if not await BREEZE_BUDDY_ENABLE_VAD():
-        logger.info("VAD disabled (BREEZE_BUDDY_ENABLE_VAD=false)")
+    template_vad = (
+        template.configurations.vad_config
+        if template and template.configurations
+        else None
+    )
+    template_enabled = template_vad.enabled if template_vad else None
+
+    if template_enabled is not None:
+        logger.info(
+            "Using template-specific VAD enabled override: {}", template_enabled
+        )
+        effective_enabled = template_enabled
+    else:
+        effective_enabled = await BREEZE_BUDDY_ENABLE_VAD()
+
+    if not effective_enabled:
+        reason = (
+            "template override"
+            if template_enabled is not None
+            else "BREEZE_BUDDY_ENABLE_VAD=false"
+        )
+        logger.info(f"VAD disabled ({reason})")
         return None, None
 
     if is_daily_mode:
@@ -239,12 +261,19 @@ def _apply_vad_config_to_analyzer(vad_analyzer, vad_config, call_sid: str):
     )
 
 
-def mute_vad(context: TemplateContext):
+def mute_vad(context: TemplateContext, duration: Optional[float] = None):
     """Mute STT by setting VAD confidence to 1.0 (impossible to trigger).
 
-    Stores previous params so they can be restored on unmute.
-    Only call this when context.vad_analyzer is available.
+    Stores previous params so they can be restored on unmute. Only call this
+    when context.vad_analyzer is available.
+
+    Args:
+        duration: If given, auto-unmutes after this many seconds. Any
+            previously pending auto-unmute is cancelled first; an explicit
+            unmute_vad() call also cancels it, so an explicit unmute always
+            takes precedence over a scheduled one.
     """
+    _cancel_vad_timed_unmute(context)
     context.bot._pre_mute_vad_params = {
         "confidence": context.vad_analyzer.params.confidence,
         "start_secs": context.vad_analyzer.params.start_secs,
@@ -260,9 +289,37 @@ def mute_vad(context: TemplateContext):
             min_volume=context.vad_analyzer.params.min_volume,
         )
     )
+    if duration is not None:
+        context.bot._vad_timed_unmute_task = asyncio.create_task(
+            _auto_unmute_vad(context, duration)
+        )
     logger.info(
         f"STT muted via VAD for call {context.call_sid} "
-        f"(confidence: {old_confidence} -> 1.0, stored pre-mute params)"
+        f"(confidence: {old_confidence} -> 1.0, stored pre-mute params"
+        + (f", duration={duration}s)" if duration is not None else ")")
+    )
+
+
+def _cancel_vad_timed_unmute(context: TemplateContext):
+    """Cancel any pending VAD timed-unmute task, if one is scheduled."""
+    bot = context.bot
+    task = getattr(bot, "_vad_timed_unmute_task", None)
+    if task and not task.done():
+        task.cancel()
+        logger.debug(f"Cancelled pending VAD timed-unmute for call {context.call_sid}")
+    bot._vad_timed_unmute_task = None
+
+
+async def _auto_unmute_vad(context: TemplateContext, duration: float):
+    """Sleep for *duration* seconds then release the VAD mute."""
+    try:
+        await asyncio.sleep(duration)
+    except asyncio.CancelledError:
+        return
+    context.bot._vad_timed_unmute_task = None
+    unmute_vad(context)
+    logger.info(
+        f"STT auto-unmuted via VAD for call {context.call_sid} after {duration}s"
     )
 
 
@@ -273,7 +330,11 @@ def unmute_vad(context: TemplateContext):
     at agent startup (template layered over Redis). Only call this when
     context.vad_analyzer is available — which also guarantees
     bot.default_vad_params is set (see create_vad_analyzer).
+
+    Cancels any pending timed-unmute task first, so an explicit unmute
+    always takes precedence over a scheduled auto-unmute.
     """
+    _cancel_vad_timed_unmute(context)
     old_confidence = context.vad_analyzer.params.confidence
     bot = context.bot
 

--- a/docs/INPUT_COLLECTION_MODE.md
+++ b/docs/INPUT_COLLECTION_MODE.md
@@ -48,7 +48,7 @@ User: "9 8 7"  [pause]  "6 5 4"  [pause]  "3 2 1 0"
 - **LLM-driven intelligence** — the LLM handles classification, completion detection, and conversational responses. No regex/if-else classification in custom code.
 - **Minimal framework code** — configure the pipeline environment so the LLM can work effectively.
 - **Node-level configuration** — collection mode is per-node, not template-wide.
-- **No VAD dependency** — VAD is disabled in production. Solution must work purely with transcription-based turn detection.
+- **No VAD dependency** — VAD is disabled by default (`BREEZE_BUDDY_ENABLE_VAD=false`), so the solution must work purely with transcription-based turn detection without assuming VAD is present. This is a default, not an architectural guarantee: `configurations.vad_config.enabled` lets a template opt into VAD per-call (`template/vad.py::create_vad_analyzer`) — see [VAD Compatibility](#vad-compatibility) in §4.
 
 ---
 
@@ -446,6 +446,12 @@ LLM receives aggregated: "9 8 7 6 5 4 3 2 1 0" (single user message)
 - **Works with existing pipeline** — just changing a single parameter value
 - **Runtime configurable** — strategy can be rebuilt on node transitions (already supported)
 - **Follows existing patterns** — same reset-then-apply as VAD/interruption
+
+### VAD Compatibility
+
+`configurations.vad_config.enabled` (added alongside the global `BREEZE_BUDDY_ENABLE_VAD` flag) lets a template opt into VAD independently of the fallback mode above.
+
+With VAD present, `SpeechTimeoutUserTurnStopStrategy` runs its VAD-anchored branch instead of the fallback branch: the timer starts on `VADUserStoppedSpeakingFrame` rather than on each transcript. A `VADUserStartedSpeakingFrame` — fired the instant the user resumes speaking, ahead of STT round-trip latency — cancels any pending timer outright. A resumed segment therefore reopens the turn before the prior segment's timer can expire, independent of whether Soniox has finalized a transcript yet.
 
 ---
 


### PR DESCRIPTION
**Root cause**: 

Turn-stop relies solely on Soniox's own endpoint guess; with VAD disabled (the global default), one premature transcript ends the turn immediately, with no independent signal to catch it.

VAD is now template-overridable (`configurations.vad_config.enabled`), falling back to the existing global/env default when unset. With VAD on for a template, the turn only ends once VAD independently confirms the user actually went quiet — a premature Soniox transcript can no longer end the turn by itself. Soniox can still split a sentence into multiple transcripts at its own endpoint boundary, but VAD's interruption signal kills the premature LLM response before it's ever spoken, and the next turn's context naturally picks up the accumulated fragments as one complete question — verified end-to-end on real calls.

Also fixes `mute_stt(duration=...)`: once VAD is enabled for a template, the duration arg was silently ignored on the VAD path — `mute_vad()` had no timed-unmute, so a mute only ever cleared on an explicit `unmute_stt` call or a node transition. A real prod template mutes for 5s at call start as a fire-and-forget action with no paired `unmute_stt`, and VAD stayed permanently muted for the rest of the call once the gate's own timer released — caught live on a test call. `mute_vad()` now mirrors `TranscriptionGateProcessor`'s existing `mute_for()` behavior and auto-unmutes after the given duration.