### PR TITLE
fix(crm): publish-time template check asks the account the route will send from

### DIFF
--- a/app/crm/connectivity/template_reads.py
+++ b/app/crm/connectivity/template_reads.py
@@ -13,10 +13,14 @@ approved" appear; that is why the send door and the publish check both ask
 here, and why the transitions file reads nothing itself.
 """
 
-from typing import Dict, List, Optional
+from typing import List, Optional
 
 from app.core.logger import logger
-from app.crm.connectivity.db.accessors import template as template_accessor
+from app.crm.connectivity.db.accessors import (
+    binding as binding_accessor,
+    installation as installation_accessor,
+    template as template_accessor,
+)
 from app.crm.connectivity.schemas.template import (
     ApprovedTemplate,
     TemplateRead,
@@ -37,48 +41,72 @@ async def list_templates(
 
 async def template_status(merchant_id: str, channel: str, name: str) -> TemplateVerdict:
     """Is this template NAME publishable on this channel — the registry's
-    one publish-time read (rollout phase 08, G12).
+    one publish-time read (rollout phase 08, G12), asked of the ACCOUNT the
+    route will send from.
 
-    A workflow's send node names a template and a channel, never the
-    provider account that will serve it (the route picks that at send
-    time), so the question is asked across the merchant's accounts:
+    A workflow's send node names a template and a channel, never a provider
+    account; the route picks the account at send time — and it always picks
+    the same one: the merchant's primary active pipe on the channel
+    (partial-unique, primary_binding_query) and that pipe's installation.
+    So this is the send door's question asked early, of that one account.
+    Not "approved somewhere" (an approval on a second account the route
+    never uses passed publish and then blocked every send — the #1080
+    review), and not "clean on every account" (a pending copy on a second
+    account would refuse a board that only ever sends from the first):
 
-      * no row under that name — never registered here;
-      * every account holding the name holds exactly ONE approved row —
-        publishable (the send door will find its one row whichever account
-        the route picks);
-      * some account holds several approved rows — the ambiguity
+      * no active primary pipe on the channel — nothing can send; say so;
+      * no row under that name on the sending account — never registered
+        there (a row on another account does not count);
+      * more than one approved row there — the language ambiguity
         approved_template refuses at send time, refused here first;
-      * otherwise the newest row's status, so the refusal can say why.
+      * no approved row — the newest row's status, so the refusal says why;
+      * exactly one approved row — publishable.
 
-    Verdict-shaped (3 Sep 2026 audit): outreach reads ``publishable`` and
-    quotes ``reason``; it never compares a status word of this module's
-    across the seam. ``reason`` is the clause after the template's name.
+    Verdict-shaped: outreach reads ``publishable`` and quotes ``reason``
+    (the clause after the template's name); it never compares a status word
+    across the seam. A send node that names its own pipe
+    (Message.binding_id — nothing sets it today) is the trigger for this
+    read to take that binding instead of the primary: the same lookup, one
+    parameter earlier.
     """
-    rows = await template_accessor.templates_by_name(merchant_id, channel, name)
+    binding = await binding_accessor.get_binding(merchant_id, channel, None)
+    installation = (
+        await installation_accessor.get_installation(
+            merchant_id, binding.installation_id
+        )
+        if binding is not None
+        else None
+    )
+    if installation is None:
+        return TemplateVerdict(
+            publishable=False,
+            reason=f"cannot be sent: no active primary {channel} pipe is connected",
+        )
+    account = installation.external_account_id
+    rows = [
+        row
+        for row in await template_accessor.templates_by_name(merchant_id, channel, name)
+        if row.provider_account_ref == account
+    ]
     if not rows:
         return TemplateVerdict(
             publishable=False,
-            reason=f"is not registered on {channel} for this merchant",
+            reason=f"is not registered on the sending {channel} account ({account})",
         )
-    approved_per_account: Dict[str, int] = {}
-    for row in rows:
-        if row.status == TEMPLATE_APPROVED:
-            approved_per_account[row.provider_account_ref] = (
-                approved_per_account.get(row.provider_account_ref, 0) + 1
-            )
-    if approved_per_account:
-        crowded = max(approved_per_account.values())
-        if crowded > 1:
-            return TemplateVerdict(
-                publishable=False,
-                reason=f"is approved in {crowded} languages on one account — "
-                "exactly one is required to send",
-            )
-        return TemplateVerdict(publishable=True)
-    return TemplateVerdict(
-        publishable=False, reason=f"is '{rows[0].status}', not approved"
-    )
+    approved = [row for row in rows if row.status == TEMPLATE_APPROVED]
+    if len(approved) > 1:
+        return TemplateVerdict(
+            publishable=False,
+            reason=f"is approved in {len(approved)} languages on the sending "
+            f"{channel} account — exactly one is required to send",
+        )
+    if not approved:
+        return TemplateVerdict(
+            publishable=False,
+            reason=f"is '{rows[0].status}', not approved, on the sending "
+            f"{channel} account",
+        )
+    return TemplateVerdict(publishable=True)
 
 
 async def approved_template(

--- a/docs/crm/workflow-rollout/08-publish-template-check.md
+++ b/docs/crm/workflow-rollout/08-publish-template-check.md
@@ -21,6 +21,7 @@ A `send` node names a `template` by NAME; today the first sign it is wrong is a 
 ## Decisions already made
 - Refuse, don't warn: an unapproved template on a LIVE plan is a guaranteed blocked send.
 - Language ambiguity (approved in two languages) is refused here exactly as `approved_template` refuses it at send time — same rule, earlier.
+- *(Amended 2026-09-04: `template_status` is verdict-shaped since #1080 — `{publishable, reason}` — and asks the question of the ACCOUNT the route will send from: the merchant's primary active pipe on the channel and its installation, exactly as `resolve_send_route` picks it. "Approved on some account" passed publish and then blocked every send when the approval sat on an account the route never uses; "clean on every account" would refuse a board for a pending copy on an account it never sends from. Same rule, earlier, on the same account.)*
 
 ## Out of scope
 - Variable-shape validation against `components` (backlog).

--- a/tests/crm/doubles.py
+++ b/tests/crm/doubles.py
@@ -80,6 +80,9 @@ class FakeInstallationAccessor:
         self.upsert_returns = upsert_returns
         self.written: Optional[Dict[str, Any]] = None
 
+    async def get_installation(self, merchant_id, installation_id):
+        return self.installation
+
     async def get_installation_by_account(self, merchant_id, key, account_ref):
         if self.existing_account is not None:
             return self.existing_account

--- a/tests/crm/test_templates.py
+++ b/tests/crm/test_templates.py
@@ -25,7 +25,7 @@ from app.crm.connectivity.providers.whatsapp.templates import (
     WhatsappTemplates,
     _from_meta,
 )
-from app.crm.connectivity.schemas.connector import ConnectorInstallation
+from app.crm.connectivity.schemas.connector import ChannelBinding, ConnectorInstallation
 from app.crm.connectivity.schemas.message import CredentialBundle
 from app.crm.connectivity.schemas.template import TemplateDraft, TemplateRead
 from app.crm.connectivity.template_reads import template_status
@@ -812,6 +812,50 @@ class _ByNameAccessor:
         return self.rows
 
 
+class _PrimaryPipe:
+    """The route's first read: the merchant's primary pipe on the channel."""
+
+    def __init__(self, binding: Optional[ChannelBinding]) -> None:
+        self.binding = binding
+
+    async def get_binding(
+        self, merchant_id: str, channel: str, binding_id: Optional[str]
+    ) -> Optional[ChannelBinding]:
+        assert binding_id is None, "the publish check asks for the PRIMARY pipe"
+        return self.binding
+
+
+def _sends_from(account: str, monkeypatch, rows: List[TemplateRead]) -> None:
+    """Wire the publish check so the route would send from ``account``."""
+    installation = ConnectorInstallation(
+        id="inst-1",
+        merchant_id="m1",
+        connector_key="whatsapp",
+        external_account_id=account,
+        status="healthy",
+    )
+    binding = ChannelBinding(
+        id="b-1",
+        merchant_id="m1",
+        channel="whatsapp",
+        installation_id="inst-1",
+        address="15550001",
+        is_primary=True,
+        status="active",
+    )
+    monkeypatch.setattr(
+        template_reads_module, "binding_accessor", _PrimaryPipe(binding)
+    )
+    monkeypatch.setattr(
+        template_reads_module,
+        "installation_accessor",
+        FakeInstallationAccessor(installation),
+    )
+    monkeypatch.setattr(
+        template_reads_module, "template_accessor", _ByNameAccessor(rows)
+    )
+
+
 @pytest.mark.parametrize(
     ("rows", "verdict"),
     [
@@ -819,50 +863,100 @@ class _ByNameAccessor:
             [],
             TemplateVerdict(
                 publishable=False,
-                reason="is not registered on whatsapp for this merchant",
+                reason="is not registered on the sending whatsapp account (waba-1)",
             ),
         ),
-        ([_registry_row("approved")], TemplateVerdict(publishable=True)),
         (
-            [_registry_row("pending"), _registry_row("deleted")],
-            TemplateVerdict(publishable=False, reason="is 'pending', not approved"),
+            [_registry_row("approved", "en", "waba-1")],
+            TemplateVerdict(publishable=True),
         ),
         (
-            [_registry_row("approved", "en"), _registry_row("approved", "hi")],
+            [
+                _registry_row("pending", "en", "waba-1"),
+                _registry_row("deleted", "en", "waba-1"),
+            ],
             TemplateVerdict(
                 publishable=False,
-                reason="is approved in 2 languages on one account — exactly one "
-                "is required to send",
+                reason="is 'pending', not approved, on the sending whatsapp account",
             ),
         ),
         (
             [
                 _registry_row("approved", "en", "waba-1"),
+                _registry_row("approved", "hi", "waba-1"),
+            ],
+            TemplateVerdict(
+                publishable=False,
+                reason="is approved in 2 languages on the sending whatsapp account — "
+                "exactly one is required to send",
+            ),
+        ),
+        (
+            # Approved only on an account the route never uses: the #1080
+            # review's case — publish used to pass, every send then blocked.
+            [_registry_row("approved", "en", "waba-2")],
+            TemplateVerdict(
+                publishable=False,
+                reason="is not registered on the sending whatsapp account (waba-1)",
+            ),
+        ),
+        (
+            # A pending copy on a second account is not the sending
+            # account's problem: refusing here would block a board that only
+            # ever sends from waba-1.
+            [
+                _registry_row("approved", "en", "waba-1"),
+                _registry_row("pending", "en", "waba-2"),
+            ],
+            TemplateVerdict(publishable=True),
+        ),
+        (
+            # Two languages on the OTHER account do not crowd this one.
+            [
+                _registry_row("approved", "en", "waba-1"),
                 _registry_row("approved", "en", "waba-2"),
+                _registry_row("approved", "hi", "waba-2"),
             ],
             TemplateVerdict(publishable=True),
         ),
     ],
     ids=[
         "no-row",
-        "one-approved",
-        "newest-status",
-        "two-languages-one-account",
-        "one-per-account",
+        "one-approved-on-the-sending-account",
+        "newest-status-on-the-sending-account",
+        "two-languages-on-the-sending-account",
+        "approved-only-elsewhere",
+        "pending-elsewhere-is-not-our-problem",
+        "crowded-elsewhere-is-not-our-problem",
     ],
 )
-async def test_template_status_answers_for_the_publish_check(
+async def test_template_status_answers_for_the_sending_account(
     monkeypatch, rows: List[TemplateRead], verdict: TemplateVerdict
 ) -> None:
-    """Never registered; every account holding the name holds exactly one
-    approved row (publishable); two approved languages on one account — the
-    ambiguity the send door refuses, refused here first; otherwise the
-    newest row's status, so the publish message can say why. Verdict-shaped:
+    """The publish check is the send door's question asked early, of the
+    account the route will pick — the primary pipe's installation — so a
+    row on any other account neither helps nor hurts. Verdict-shaped:
     outreach quotes the reason and never compares a status word."""
-    monkeypatch.setattr(
-        template_reads_module, "template_accessor", _ByNameAccessor(rows)
-    )
+    _sends_from("waba-1", monkeypatch, rows)
     assert await template_status("m1", "whatsapp", "cart_recovery_1") == verdict
+
+
+async def test_template_status_with_no_primary_pipe_says_so(monkeypatch) -> None:
+    """No active primary pipe on the channel: nothing can send, and the
+    registry is not even consulted — the refusal names the real problem."""
+
+    class _Untouched:
+        async def templates_by_name(self, *args):
+            raise AssertionError("no pipe, no registry read")
+
+    monkeypatch.setattr(template_reads_module, "binding_accessor", _PrimaryPipe(None))
+    monkeypatch.setattr(template_reads_module, "template_accessor", _Untouched())
+    assert await template_status(
+        "m1", "whatsapp", "cart_recovery_1"
+    ) == TemplateVerdict(
+        publishable=False,
+        reason="cannot be sent: no active primary whatsapp pipe is connected",
+    )
 
 
 def test_the_publish_check_is_on_the_contract_surface() -> None:


### PR DESCRIPTION
Closes the finding CodeRabbit raised on #1080's `template_reads.py` — with a different resolution than it proposed, because the send path does not fan out across accounts.

### The gap
`template_status` answered "is this name approved on **some** account" (its docstring promised "on every account"). The send door asks a third question: **exactly one approved row on the account the route picks** — and the route always picks the same one, the merchant's primary active pipe on the channel (partial-unique) and that pipe's installation.

- Approval only on a second account the route never uses → publish passed, every send then blocked. (The finding.)
- CodeRabbit's "refuse if any account is unclean" → a pending copy on an account the board never sends from would block publishing. (Over-refusal.)

The gap predates #1080: it came in with #1065's publish check, and #1080 moved it verbatim into the new file.

### The fix
`template_status` resolves the primary pipe and its installation (the same two reads `resolve_send_route` makes), filters the name's rows to that account, and applies the send door's exactly-one rule there. Same rule, earlier, on the same account. No new SQL — the existing `templates_by_name` accessor, filtered.

Verdicts, as the publish refusal quotes them after the template's name:

| Case | Verdict |
|---|---|
| no active primary pipe on the channel | `cannot be sent: no active primary whatsapp pipe is connected` (registry not read) |
| no row on the sending account | `is not registered on the sending whatsapp account (waba-1)` |
| newest row not approved there | `is 'pending', not approved, on the sending whatsapp account` |
| several approved languages there | `is approved in 2 languages on the sending whatsapp account — exactly one is required to send` |
| exactly one approved row there | publishable |

Rows on any other account neither help nor hurt.

**Trigger written beside it:** a send node that names its own pipe (`Message.binding_id` — nothing sets it today) moves this read to that binding: the same lookup, one parameter earlier.

### Files
- `app/crm/connectivity/template_reads.py` — the read; docstring carries the reasoning and the trigger.
- `tests/crm/test_templates.py` — seven verdicts incl. approved-only-elsewhere (refused), pending-elsewhere (publishable), crowded-elsewhere (publishable); a no-primary-pipe test asserting the registry is not read.
- `tests/crm/doubles.py` — `FakeInstallationAccessor.get_installation`.
- `docs/crm/workflow-rollout/08-publish-template-check.md` — amendment line.

770 passed · boundaries · numbering · black · isort · autoflake · pyrefly 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01APYhsMRBdKLz74A6NRuWy5
