### PR TITLE
feat(crm): whatsapp catalog spec + reply-aware squares + readable sen…

### DIFF
--- a/app/crm/connectivity/contracts.py
+++ b/app/crm/connectivity/contracts.py
@@ -38,6 +38,11 @@ What is here, and why each thing is on the surface:
   spending a fresh signup code; onboarding subscribes on the happy path,
   this is the recovery door (disconnect's opposite verb, health re-stamped
   by its atom).
+- ``reason_label`` — the human word for a message row's stored reason,
+  pure. The row keeps the provider's code (canon T16 col 13); any surface
+  that SHOWS a row — the coming message read / "why didn't it send" view —
+  translates through this at read, so the stored evidence is never
+  rewritten.
 
 Provider-decided template state (approved, rejected, a re-categorisation)
 arrives as webhooks, and the consumer that applies them joins this surface
@@ -59,6 +64,7 @@ from app.crm.connectivity.onboarding import (
     resubscribe,
 )
 from app.crm.connectivity.queue import queue_message
+from app.crm.connectivity.reasons import reason_label
 from app.crm.connectivity.retire_guard import register_retire_guard
 from app.crm.connectivity.template_reads import (
     get as get_template,
@@ -97,6 +103,8 @@ __all__ = [
     "register_retire_guard",
     # webhook subscription recovery
     "resubscribe",
+    # the read-side word for a stored reason (the row keeps the code)
+    "reason_label",
     # the inbound bay, for app/crm/api.py's one registration line
     "META_INGRESS",
 ]

--- a/app/crm/connectivity/dispatch.py
+++ b/app/crm/connectivity/dispatch.py
@@ -335,6 +335,10 @@ async def _dispatch_one(message: QueuedMessage, max_attempts: int) -> None:
         applied = await message_accessor.apply_outcome(
             message.id,
             plan.status,
+            # Verbatim: on a provider refusal the row keeps the provider's
+            # CODE (canon T16 col 13) — what support greps and what matches
+            # the provider's documentation. The human word is a read-side
+            # concern (reasons.reason_label, on the contracts surface).
             plan.reason,
             plan.provider_message_id,
             plan.mark_sent,

--- a/app/crm/connectivity/providers/meta/inbound.py
+++ b/app/crm/connectivity/providers/meta/inbound.py
@@ -112,7 +112,12 @@ def verify_signature(raw_body: bytes, headers: Mapping[str, str]) -> bool:
     if not header or not header.startswith(_SIGNATURE_PREFIX):
         return False
     expected = hmac.new(META_APP_SECRET.encode(), raw_body, hashlib.sha256).hexdigest()
-    return hmac.compare_digest(expected, header[len(_SIGNATURE_PREFIX) :])
+    # Compared as BYTES: compare_digest over str raises TypeError the moment
+    # either side is non-ASCII, and the header is attacker-controlled — one
+    # crafted byte would turn "refused" into an unhandled 500.
+    return hmac.compare_digest(
+        expected.encode(), header[len(_SIGNATURE_PREFIX) :].encode()
+    )
 
 
 def handshake_challenge(params: Mapping[str, str]) -> Optional[str]:
@@ -133,7 +138,9 @@ def handshake_challenge(params: Mapping[str, str]) -> Optional[str]:
     challenge = params.get("hub.challenge")
     if params.get("hub.mode") != "subscribe" or not token or challenge is None:
         return None
-    if not hmac.compare_digest(token, META_WEBHOOK_VERIFY_TOKEN):
+    # BYTES for the same reason as the signature compare: a non-ASCII guess
+    # must be a wrong token, not a TypeError.
+    if not hmac.compare_digest(token.encode(), META_WEBHOOK_VERIFY_TOKEN.encode()):
         logger.warning("meta: webhook handshake presented a wrong token")
         return None
     return challenge

--- a/app/crm/connectivity/providers/whatsapp/classify.py
+++ b/app/crm/connectivity/providers/whatsapp/classify.py
@@ -31,6 +31,7 @@ TERMINAL_CODES = {
     "131008",  # required parameter missing
     "131009",  # parameter value invalid
     "131026",  # undeliverable: recipient cannot receive WhatsApp messages
+    "131030",  # recipient not in the allowed list (a test number's own limit)
     "131047",  # 24-hour window closed — a template is the fix, not a retry
     "132000",  # template param count mismatch
     "132001",  # template does not exist
@@ -50,6 +51,11 @@ CREDENTIAL_CODES = {
     "10",  # permission denied
     "190",  # invalid or expired access token
     "200",  # permissions error
+    # Access denied on the ASSET: the token is valid and scoped, but this
+    # app/business may not use this number. Left unnamed it fell to the
+    # unknown-4xx default, which is right about not retrying and silent
+    # about why — and this is the class an operator must act on.
+    "131005",
     "133010",  # phone number not registered for Cloud API
 }
 

--- a/app/crm/connectivity/reasons.py
+++ b/app/crm/connectivity/reasons.py
@@ -60,3 +60,66 @@ REASON_RECLAIMED_STALE_CLAIM = "reclaimed_stale_claim"
 REASON_PROVIDER_REJECTED = "provider_rejected"
 REASON_SUPPRESSED = "suppressed"
 REASON_GATE_UNAVAILABLE = "gate_unavailable"
+
+
+# --- what a provider's error code MEANS, for the reader ----------------------
+#
+# Adapters classify on the provider's code and hand it up untouched, and the
+# ROW keeps that code verbatim (canon T16 col 13: "failed | dead — the
+# provider's code") — the code is what support greps and what matches the
+# provider's documentation. But the people READING the row off the manifest
+# do not have that documentation open: a merchant on the "why didn't it
+# send" view, an operator at 2am. "190" is a lookup task; "token_expired"
+# is the answer.
+#
+# So the translation lives on the READ side — reason_label(), exported
+# through contracts.py for any surface that shows a message row — and never
+# rewrites what the row stores. Only codes we have named become words;
+# everything else — every word above, and any code not in this table —
+# passes through unchanged, so nothing is ever lost or invented.
+PROVIDER_CODE_REASONS = {
+    # The connection is broken: every queued message for this merchant is
+    # about to fail the same way.
+    "10": "permission_denied",
+    "190": "token_expired",
+    "200": "permission_denied",
+    "131005": "access_denied",
+    "133010": "number_not_registered",
+    # This message was wrong; the connection is fine.
+    "100": "invalid_parameter",
+    "131008": "required_parameter_missing",
+    "131009": "parameter_value_invalid",
+    "131026": "recipient_cannot_receive_whatsapp",
+    "131030": "recipient_not_in_allowed_list",
+    "131047": "outside_24h_window",
+    "132000": "template_variable_count_mismatch",
+    "132001": "template_not_found",
+    "132005": "template_too_long",
+    "132007": "template_policy_violation",
+    "132012": "template_variable_format_invalid",
+    "132015": "template_paused",
+    "132016": "template_disabled",
+    # Pacing, not a verdict: these ride status=failed with a retry.
+    "4": "provider_rate_limited",
+    "613": "provider_rate_limited",
+    "80007": "account_rate_limited",
+    "131056": "pair_rate_limited",
+    "130429": "throughput_limit_reached",
+    "131048": "spam_rate_limit_reached",
+    "131049": "engagement_limit_reached",
+    "429": "provider_rate_limited",
+}
+
+
+def reason_label(reason):
+    """The human word for a stored reason, at READ time — the row itself
+    keeps what dispatch wrote (canon T16 col 13: the provider's code).
+
+    Total and lossless: a provider code we have named becomes its meaning, a
+    code we have not stays exactly as stored (so a new code is still
+    greppable and still matches the provider's docs), and one of this
+    file's own words is already the answer and passes through.
+    """
+    if reason is None:
+        return None
+    return PROVIDER_CODE_REASONS.get(reason, reason)

--- a/app/crm/outreach/entry.py
+++ b/app/crm/outreach/entry.py
@@ -246,7 +246,11 @@ def _is_about(node: WorkflowNode, event: RawEvent, run: EnrollmentRun) -> bool:
     nobody, so it is not hers either."""
     if node.match is None:
         return True
-    claimed = event.payload.get(node.match.payload)
+    claimed = field_value(
+        event.payload,
+        canonical_path(node.match.payload),
+        derive_for(event.source, event.topic),
+    )
     if claimed is None:
         return False
     mine = str(run.id) if node.match.run == "id" else run.context.get(node.match.run)
@@ -256,13 +260,23 @@ def _is_about(node: WorkflowNode, event: RawEvent, run: EnrollmentRun) -> bool:
 def _answer_for(node: WorkflowNode, event: RawEvent) -> Optional[str]:
     """PURE: what this letter answers on this square — the topic itself
     for a $topic square (phase 15: the branch is the letter's NAME), else
-    the payload field the square branches on; None when the square is not
-    listening for the topic, or the field is missing (B1). The ONE
-    definition of "this letter is this square's answer": the wake and
-    the repeat refusal below both ask it."""
+    the payload field the square branches on — resolved through the
+    catalog like entry.where and entry.key, so a derived field (whatsapp's
+    reply, read from messages[0].button) answers too, not only top-level
+    keys; None when the square is not listening for the topic, or the
+    field is missing (B1). The ONE definition of "this letter is this
+    square's answer": the wake and the repeat refusal below both ask it."""
     if node.type != "wait_event" or event.topic not in node.topics:
         return None
-    answer = event.topic if node.key == TOPIC_KEY else event.payload.get(node.key or "")
+    answer = (
+        event.topic
+        if node.key == TOPIC_KEY
+        else field_value(
+            event.payload,
+            canonical_path(node.key or ""),
+            derive_for(event.source, event.topic),
+        )
+    )
     return None if answer is None else str(answer)
 
 

--- a/app/crm/record/extractors/__init__.py
+++ b/app/crm/record/extractors/__init__.py
@@ -19,14 +19,14 @@ anatomy on both sides of the house.
 
 from typing import Any, Callable, Dict, Tuple
 
-from app.crm.record.extractors import flat, shopify
+from app.crm.record.extractors import flat, shopify, whatsapp
 from app.crm.record.schemas import Extracted
 
 Extractor = Callable[[Dict[str, Any]], Extracted]
 
 # Declared specs: modules exporting ENTRIES (List[CatalogEntry]) and
 # DERIVERS (derived field name -> derive(payload)).
-SPEC_MODULES: Tuple[Any, ...] = (shopify,)
+SPEC_MODULES: Tuple[Any, ...] = (shopify, whatsapp)
 
 EXTRACTORS: Dict[str, Extractor] = {
     "lead-api": flat.extract,

--- a/app/crm/record/extractors/whatsapp.py
+++ b/app/crm/record/extractors/whatsapp.py
@@ -1,0 +1,386 @@
+"""WhatsApp, as a code-layer SPEC — Meta's letters through the one decode
+engine (event-catalog.md §One decode engine).
+
+Nothing here reads a payload by hand at decode time. The ingress door files
+Meta's documented value with the batched array narrowed to ONE item
+(providers/meta/inbound.py::_narrowed) — statuses=[item] on a receipt,
+messages=[item] on an inbound — and metadata and contacts ride along
+verbatim. The engine's path grammar deliberately never indexes arrays, so
+almost everything about the person is a derive(): the legitimate use of the
+escape hatch, because Meta ships the person inside lists.
+
+message.inbound is the one topic about the CUSTOMER. The rest say
+about="merchant" (canon T13 col 14): a receipt (message.status) is about
+the MESSAGE we sent — the manifest row already carries the customer —
+and template/account letters concern the WABA. No identity fields on any
+of them: decoded with no handles, processed with customer NULL, never
+quarantined. Template/account values arrive flat (the door files Meta's
+value verbatim, no batched arrays), so they are plain payload.* paths —
+except the ban state, which Meta ships as a one-element list inside
+ban_info.
+
+The sender's name is matched from the value's contacts roster by wa_id —
+never by position, because the lists ride in parallel and a batch can carry
+several senders. A type="contacts" message keeps the CARDS the customer
+shared inside the message item itself, so the roster match can never read a
+shared card as the sender. The name is never defaulted: a placeholder would
+reach assert_facts as a genuine claim.
+
+Meta's wa_id IS the phone (digits with country code, no "+"), so the
+engine's role normalization is the whole translation and no new handle kind
+is needed.
+"""
+
+from typing import Any, Dict, List, Literal, Optional
+
+from app.crm.record.extractors.engine import Deriver
+from app.crm.record.schemas import CatalogEntry, CatalogField
+
+SOURCE = "whatsapp"
+GROUP = "WhatsApp"
+
+# Meta's own message.type vocabulary — what a flow may filter on.
+MESSAGE_TYPES = [
+    "text",
+    "image",
+    "audio",
+    "video",
+    "document",
+    "sticker",
+    "location",
+    "contacts",
+    "interactive",
+    "button",
+    "reaction",
+    "order",
+    "system",
+    "unknown",
+]
+STATUS_STATES = ["sent", "delivered", "read", "failed"]
+
+# Meta's template-review vocabulary (message_template_status_update.event),
+# and the category/quality words the other template letters carry.
+TEMPLATE_EVENTS = [
+    "APPROVED",
+    "IN_APPEAL",
+    "PENDING",
+    "REJECTED",
+    "PENDING_DELETION",
+    "DELETED",
+    "DISABLED",
+    "PAUSED",
+    "LIMIT_EXCEEDED",
+    "FLAGGED",
+]
+TEMPLATE_CATEGORIES = ["AUTHENTICATION", "MARKETING", "UTILITY"]
+QUALITY_SCORES = ["GREEN", "YELLOW", "RED", "UNKNOWN"]
+
+
+# --- derive(): the code escape hatch ----------------------------------------
+#
+# Every one of these exists because the item lives inside a one-element list
+# the door narrowed — payload.messages[0].* is not a path the grammar walks.
+
+
+def _item(payload: Dict[str, Any], key: str) -> Dict[str, Any]:
+    """The letter's single narrowed item under ``key``, or {}."""
+    items = payload.get(key)
+    if isinstance(items, list) and items and isinstance(items[0], dict):
+        return items[0]
+    return {}
+
+
+def sender_phone(payload: Dict[str, Any]) -> Optional[Any]:
+    """Who wrote to us: the inbound message's ``from`` (their wa_id)."""
+    return _item(payload, "messages").get("from")
+
+
+def sender_name(payload: Dict[str, Any]) -> Optional[str]:
+    """The sender's display name from the contacts roster, matched by
+    wa_id; None when Meta sent no roster or no entry matches."""
+    sender = sender_phone(payload)
+    contacts = payload.get("contacts")
+    if sender is None or not isinstance(contacts, list):
+        return None
+    for contact in contacts:
+        if not isinstance(contact, dict) or str(contact.get("wa_id")) != str(sender):
+            continue
+        profile = contact.get("profile")
+        if isinstance(profile, dict) and profile.get("name"):
+            return str(profile["name"])
+        return None
+    return None
+
+
+def message_type(payload: Dict[str, Any]) -> Optional[Any]:
+    """Meta's message.type — text, image, button, and the rest."""
+    return _item(payload, "messages").get("type")
+
+
+def message_text(payload: Dict[str, Any]) -> Optional[Any]:
+    """The body of a text message; None for every other type."""
+    text = _item(payload, "messages").get("text")
+    return text.get("body") if isinstance(text, dict) else None
+
+
+def replied_to(payload: Dict[str, Any]) -> Optional[Any]:
+    """The wamid this message replies to (context.id) — the join key that
+    says WHICH of our sends the customer answered."""
+    context = _item(payload, "messages").get("context")
+    return context.get("id") if isinstance(context, dict) else None
+
+
+def reply(payload: Dict[str, Any]) -> Optional[Any]:
+    """What the customer answered, whatever shape Meta used: a template
+    quick-reply's payload, an interactive button's or list row's id, else
+    the text body. One field, so a wait_event square branches on the
+    answer without knowing which widget the template put in front of
+    her — a tap and a typed reply land on the same key."""
+    item = _item(payload, "messages")
+    button = item.get("button")
+    if isinstance(button, dict) and button.get("payload") is not None:
+        return button["payload"]
+    interactive = item.get("interactive")
+    if isinstance(interactive, dict):
+        for kind in ("button_reply", "list_reply"):
+            chosen = interactive.get(kind)
+            if isinstance(chosen, dict) and chosen.get("id") is not None:
+                return chosen["id"]
+    return message_text(payload)
+
+
+def recipient_phone(payload: Dict[str, Any]) -> Optional[Any]:
+    """Who the receipt is about: the status's recipient_id (their wa_id)."""
+    return _item(payload, "statuses").get("recipient_id")
+
+
+def status(payload: Dict[str, Any]) -> Optional[Any]:
+    """What became of the message — sent, delivered, read, failed."""
+    return _item(payload, "statuses").get("status")
+
+
+def status_message_id(payload: Dict[str, Any]) -> Optional[Any]:
+    """The wamid of OUR message this receipt is about — the key a goal
+    matches on when a run waits for its own send to be delivered or read."""
+    return _item(payload, "statuses").get("id")
+
+
+def ban_state(payload: Dict[str, Any]) -> Optional[Any]:
+    """The WABA's ban state on an account notice — Meta ships it as a
+    one-element list inside ban_info; absent when the letter is no ban."""
+    ban = payload.get("ban_info")
+    if not isinstance(ban, dict):
+        return None
+    state = ban.get("waba_ban_state")
+    if isinstance(state, list):
+        return state[0] if state else None
+    return state
+
+
+DERIVERS: Dict[str, Deriver] = {
+    "sender_phone": sender_phone,
+    "sender_name": sender_name,
+    "message_type": message_type,
+    "message_text": message_text,
+    "replied_to": replied_to,
+    "reply": reply,
+    "recipient_phone": recipient_phone,
+    "status": status,
+    "status_message_id": status_message_id,
+    "ban_state": ban_state,
+}
+
+
+# --- the specs -------------------------------------------------------------
+
+
+def _f(path: str, type: str, label: str, **flags: Any) -> CatalogField:
+    """One declared field; flags mirror CatalogField's keywords."""
+    return CatalogField(path=path, type=type, label=label, **flags)  # type: ignore[arg-type]
+
+
+def _inbound_fields() -> List[CatalogField]:
+    """A customer's message: who wrote, what kind, what it said."""
+    return [
+        _f("sender_phone", "phone", "Sender phone", identity="phone", derived=True),
+        _f(
+            "sender_name",
+            "text",
+            "Sender name",
+            identity="name",
+            variable=True,
+            derived=True,
+        ),
+        _f(
+            "message_type",
+            "choice",
+            "Message type",
+            values=MESSAGE_TYPES,
+            derived=True,
+        ),
+        _f("message_text", "text", "Message text", variable=True, derived=True),
+        # The answer itself, whichever widget carried it — what a
+        # wait_event square branches on (key: "reply").
+        _f("reply", "text", "Reply", variable=True, derived=True),
+        # The reply join: which of OUR sends this message answers. A Meta
+        # wamid, while a run records OUR message id (crm_message.id) — so
+        # no square can key on this until the accepted outcome stamps the
+        # wamid into the run context, or a consumer joins through the
+        # manifest's provider_message_id. Declared now so the join key is
+        # in the catalog the day that trigger lands.
+        _f("replied_to", "text", "Replied-to message id", keyable=True, derived=True),
+    ]
+
+
+def _status_fields() -> List[CatalogField]:
+    """A receipt for our own outbound: which send, and what became of it.
+
+    No identity fields: a receipt is about the MESSAGE, not a person —
+    canon T13 col 14 lists receipts beside template letters, customer
+    NULL forever. The join to WHO we messaged lives on the manifest row
+    (crm_message is born with customer_id), so resolving the recipient
+    here would run resolve() three times per send — sent, delivered,
+    read — to duplicate a fact the manifest already owns."""
+    return [
+        _f("recipient_phone", "phone", "Recipient phone", derived=True),
+        _f("status", "choice", "Delivery status", values=STATUS_STATES, derived=True),
+        # A Meta wamid, like replied_to: joinable to a run only through
+        # the manifest's provider_message_id, or once the accepted
+        # outcome stamps the wamid into the run context.
+        _f(
+            "status_message_id",
+            "text",
+            "Message id",
+            keyable=True,
+            derived=True,
+        ),
+    ]
+
+
+def _template_fields() -> List[CatalogField]:
+    """The template a review letter is about: Meta's id, name, language."""
+    return [
+        _f(
+            "payload.message_template_id",
+            "number",
+            "Template id",
+            keyable=True,
+            variable=True,
+        ),
+        _f("payload.message_template_name", "text", "Template name", variable=True),
+        _f(
+            "payload.message_template_language",
+            "text",
+            "Template language",
+            variable=True,
+        ),
+    ]
+
+
+def _template_status_fields() -> List[CatalogField]:
+    """Meta's verdict on a submitted template, with the reason when refused."""
+    return [
+        *_template_fields(),
+        _f(
+            "payload.event",
+            "choice",
+            "Review event",
+            values=TEMPLATE_EVENTS,
+            variable=True,
+        ),
+        _f("payload.reason", "text", "Rejection reason", variable=True),
+    ]
+
+
+def _template_category_fields() -> List[CatalogField]:
+    """Meta recategorized a template: what it was, what it is now."""
+    return [
+        *_template_fields(),
+        _f(
+            "payload.previous_category",
+            "choice",
+            "Previous category",
+            values=TEMPLATE_CATEGORIES,
+            variable=True,
+        ),
+        _f(
+            "payload.new_category",
+            "choice",
+            "New category",
+            values=TEMPLATE_CATEGORIES,
+            variable=True,
+        ),
+    ]
+
+
+def _template_quality_fields() -> List[CatalogField]:
+    """A template's quality score moved — the early warning before a pause."""
+    return [
+        *_template_fields(),
+        _f(
+            "payload.previous_quality_score",
+            "choice",
+            "Previous quality",
+            values=QUALITY_SCORES,
+            variable=True,
+        ),
+        _f(
+            "payload.new_quality_score",
+            "choice",
+            "New quality",
+            values=QUALITY_SCORES,
+            variable=True,
+        ),
+    ]
+
+
+def _account_fields() -> List[CatalogField]:
+    """A notice about the WABA itself — verification, restriction, a ban."""
+    return [
+        _f("payload.event", "text", "Account event", variable=True),
+        _f("ban_state", "text", "Ban state", variable=True, derived=True),
+        _f("payload.ban_info.waba_ban_date", "text", "Ban date", variable=True),
+    ]
+
+
+def _entry(
+    topic: str,
+    label: str,
+    fields: List[CatalogField],
+    about: Literal["customer", "merchant"] = "customer",
+) -> CatalogEntry:
+    """One (source, topic) declaration in the code layer."""
+    return CatalogEntry(
+        source=SOURCE,
+        topic=topic,
+        label=label,
+        group=GROUP,
+        layer="code",
+        about=about,
+        fields=fields,
+    )
+
+
+ENTRIES: List[CatalogEntry] = [
+    _entry("message.inbound", "Message received", _inbound_fields()),
+    _entry("message.status", "Message status", _status_fields(), about="merchant"),
+    _entry(
+        "template.status",
+        "Template review",
+        _template_status_fields(),
+        about="merchant",
+    ),
+    _entry(
+        "template.category",
+        "Template recategorized",
+        _template_category_fields(),
+        about="merchant",
+    ),
+    _entry(
+        "template.quality",
+        "Template quality",
+        _template_quality_fields(),
+        about="merchant",
+    ),
+    _entry("account.update", "Account notice", _account_fields(), about="merchant"),
+]

--- a/tests/crm/fixtures/whatsapp/account_update.json
+++ b/tests/crm/fixtures/whatsapp/account_update.json
@@ -1,0 +1,8 @@
+{
+  "phone_number": "15556744876",
+  "event": "DISABLED_UPDATE",
+  "ban_info": {
+    "waba_ban_state": ["SCHEDULE_FOR_DISABLE"],
+    "waba_ban_date": "January 31, 2027"
+  }
+}

--- a/tests/crm/fixtures/whatsapp/message_inbound.json
+++ b/tests/crm/fixtures/whatsapp/message_inbound.json
@@ -1,0 +1,22 @@
+{
+  "messaging_product": "whatsapp",
+  "metadata": {
+    "display_phone_number": "918067451234",
+    "phone_number_id": "812345678901234"
+  },
+  "contacts": [
+    {
+      "profile": { "name": "Priya Sharma" },
+      "wa_id": "919876543210"
+    }
+  ],
+  "messages": [
+    {
+      "from": "919876543210",
+      "id": "wamid.HBgMOTE5ODc2NTQzMjEwFQIAEhggNzY5RkYzQkI3Qzc4",
+      "timestamp": "1788177601",
+      "type": "text",
+      "text": { "body": "yes, confirm my order" }
+    }
+  ]
+}

--- a/tests/crm/fixtures/whatsapp/message_inbound_reply.json
+++ b/tests/crm/fixtures/whatsapp/message_inbound_reply.json
@@ -1,0 +1,26 @@
+{
+  "messaging_product": "whatsapp",
+  "metadata": {
+    "display_phone_number": "918067451234",
+    "phone_number_id": "812345678901234"
+  },
+  "contacts": [
+    {
+      "profile": { "name": "Rohan Mehta" },
+      "wa_id": "918887776665"
+    }
+  ],
+  "messages": [
+    {
+      "from": "918887776665",
+      "id": "wamid.HBgMOTE4ODg3Nzc2NjY1FQIAEhggQTIzNEI1NkM3RDg5",
+      "timestamp": "1788177650",
+      "type": "button",
+      "context": {
+        "from": "918067451234",
+        "id": "wamid.HBgMOTE4ODg3Nzc2NjY1FQIAERgSMEYwRkI3NkYyQzE1NUFCRDMx"
+      },
+      "button": { "payload": "CONFIRM_ORDER", "text": "Confirm order" }
+    }
+  ]
+}

--- a/tests/crm/fixtures/whatsapp/message_status.json
+++ b/tests/crm/fixtures/whatsapp/message_status.json
@@ -1,0 +1,24 @@
+{
+  "messaging_product": "whatsapp",
+  "metadata": {
+    "display_phone_number": "918067451234",
+    "phone_number_id": "812345678901234"
+  },
+  "statuses": [
+    {
+      "id": "wamid.HBgMOTE5ODc2NTQzMjEwFQIAERgSRjMwMEQ3QjA5NEE1NkQ2QUYx",
+      "status": "delivered",
+      "timestamp": "1788177700",
+      "recipient_id": "919876543210",
+      "conversation": {
+        "id": "f2b8a1c9d0e34567",
+        "origin": { "type": "utility" }
+      },
+      "pricing": {
+        "billable": true,
+        "pricing_model": "PMP",
+        "category": "utility"
+      }
+    }
+  ]
+}

--- a/tests/crm/fixtures/whatsapp/template_category.json
+++ b/tests/crm/fixtures/whatsapp/template_category.json
@@ -1,0 +1,8 @@
+{
+  "message_template_id": 1953621872,
+  "message_template_name": "cod_order_confirmation",
+  "message_template_language": "en_US",
+  "previous_category": "MARKETING",
+  "new_category": "UTILITY",
+  "correct_category": "UTILITY"
+}

--- a/tests/crm/fixtures/whatsapp/template_quality.json
+++ b/tests/crm/fixtures/whatsapp/template_quality.json
@@ -1,0 +1,7 @@
+{
+  "previous_quality_score": "GREEN",
+  "new_quality_score": "RED",
+  "message_template_id": 1953621872,
+  "message_template_name": "cod_order_confirmation",
+  "message_template_language": "en_US"
+}

--- a/tests/crm/fixtures/whatsapp/template_status.json
+++ b/tests/crm/fixtures/whatsapp/template_status.json
@@ -1,0 +1,7 @@
+{
+  "event": "APPROVED",
+  "message_template_id": 1953621872,
+  "message_template_name": "cod_order_confirmation",
+  "message_template_language": "en_US",
+  "reason": null
+}

--- a/tests/crm/fixtures/whatsapp/template_status_rejected.json
+++ b/tests/crm/fixtures/whatsapp/template_status_rejected.json
@@ -1,0 +1,7 @@
+{
+  "event": "REJECTED",
+  "message_template_id": 1953621873,
+  "message_template_name": "diwali_blowout_sale",
+  "message_template_language": "en_US",
+  "reason": "INCORRECT_CATEGORY"
+}

--- a/tests/crm/test_catalog.py
+++ b/tests/crm/test_catalog.py
@@ -72,13 +72,24 @@ def test_every_code_entry_has_fixtures_and_every_field_appears_in_one() -> None:
 
 def test_the_engine_finds_the_person_in_every_recorded_letter() -> None:
     """The extractor half of the square: a code entry whose spec cannot
-    attribute its own fixtures would quarantine every real letter."""
+    attribute its own fixtures would quarantine every real letter. A
+    merchant-level entry is the ruled opposite (canon T13 col 14): its
+    letters name no person, so they decode about="merchant" with no
+    handles — processed with customer NULL, never quarantined."""
     for (source, topic), entry in catalog.CATALOG.items():
         spec = catalog.code_spec(source, topic)
         assert spec is not None
         for payload in _fixtures_for(source, topic):
             extracted = engine.extract(payload, spec)
-            assert extracted.handles, f"{source}/{topic}: a fixture yields no handle"
+            if entry.about == "merchant":
+                assert extracted.about == "merchant"
+                assert (
+                    not extracted.handles
+                ), f"{source}/{topic}: a merchant letter grew a handle"
+            else:
+                assert (
+                    extracted.handles
+                ), f"{source}/{topic}: a fixture yields no handle"
 
 
 def test_variable_names_are_unique_within_an_entry() -> None:

--- a/tests/crm/test_decode_engine.py
+++ b/tests/crm/test_decode_engine.py
@@ -9,7 +9,7 @@ same letters, same answers, now read by declared paths.
 from typing import Any, Dict
 
 from app.crm.record import catalog
-from app.crm.record.extractors import EXTRACTORS, engine, shopify
+from app.crm.record.extractors import EXTRACTORS, SPEC_MODULES, engine, shopify
 from app.crm.record.extractors.engine import EMPTY_SPEC, DecodeSpec, spec_for_entry
 from app.crm.record.schemas import CatalogEntry, CatalogField
 
@@ -252,11 +252,12 @@ def test_shopify_is_a_spec_not_an_imperative_extractor() -> None:
 
 
 def test_every_catalog_derived_field_is_provided_by_its_spec_module() -> None:
+    modules = {module.SOURCE: module for module in SPEC_MODULES}
     for key, entry in catalog.CATALOG.items():
         declared = {f.path for f in entry.fields if f.derived}
         assert declared == set(catalog.DERIVE[key]), key
         for name in declared:
-            assert catalog.DERIVE[key][name] is shopify.DERIVERS[name]
+            assert catalog.DERIVE[key][name] is modules[key[0]].DERIVERS[name]
 
 
 def _spec_dict(spec: DecodeSpec) -> Dict[str, Any]:

--- a/tests/crm/test_dispatch.py
+++ b/tests/crm/test_dispatch.py
@@ -27,7 +27,10 @@ from app.crm.connectivity.dispatch import (
     sample_ids,
 )
 from app.crm.connectivity.providers import ADAPTERS
-from app.crm.connectivity.reasons import REASON_RECLAIMED_STALE_CLAIM
+from app.crm.connectivity.reasons import (
+    PROVIDER_CODE_REASONS,
+    REASON_RECLAIMED_STALE_CLAIM,
+)
 from app.crm.connectivity.schemas.message import QueuedMessage, SendOutcome
 from app.crm.connectivity.status import (
     MESSAGE_ACCEPTED,
@@ -813,3 +816,96 @@ def test_the_accepted_outcome_stamps_the_pipe_it_left_on_once() -> None:
         "m-1", "blocked", "no_binding", None, False, 1, None
     )
     assert values[8] is None
+
+
+# --- the row keeps the code; the word lives at read (canon T16 col 13) -------
+
+
+async def test_a_provider_code_lands_on_the_row_verbatim(monkeypatch) -> None:
+    """A provider code lands on the row verbatim."""
+    # The adapter classifies on Meta's code and hands it up untouched, and
+    # the row KEEPS it (canon T16 col 13: "failed | dead — the provider's
+    # code"): one vocabulary in the column, greppable by the code the
+    # provider's own documentation uses. The human word is a read-side
+    # concern (reason_label, on the contracts surface).
+    written = {}
+
+    async def refuses_credentials(send_token, message):
+        """Test double: the provider refuses with an expired token."""
+        return SendOutcome(status="failed", reason="190")
+
+    async def record_outcome(
+        message_id, status, reason, pmid, mark_sent, attempt, retry, binding_id=None
+    ):
+        """Test double: records what the dispatcher tried to write."""
+        written.update(status=status, reason=reason)
+        return True
+
+    monkeypatch.setattr(dispatch, "is_suppressed", _gate_open)
+    monkeypatch.setattr(dispatch, "send", refuses_credentials)
+    monkeypatch.setattr(dispatch.message_accessor, "apply_outcome", record_outcome)
+    await dispatch._dispatch_one(_message(), 3)
+    assert written["reason"] == "190"
+
+
+async def test_an_unnamed_code_is_written_exactly_as_reported(monkeypatch) -> None:
+    """An unnamed code is written exactly as reported."""
+    # Lossless: a code we have not named yet must stay greppable and must
+    # still match the provider's documentation. Inventing a word for it, or
+    # dropping it for a generic one, would cost the only clue there is.
+    written = {}
+
+    async def refuses_unknown(send_token, message):
+        """Test double: the provider refuses with a code we do not name."""
+        return SendOutcome(status="failed", reason="999999")
+
+    async def record_outcome(
+        message_id, status, reason, pmid, mark_sent, attempt, retry, binding_id=None
+    ):
+        """Test double: records what the dispatcher tried to write."""
+        written.update(reason=reason)
+        return True
+
+    monkeypatch.setattr(dispatch, "is_suppressed", _gate_open)
+    monkeypatch.setattr(dispatch, "send", refuses_unknown)
+    monkeypatch.setattr(dispatch.message_accessor, "apply_outcome", record_outcome)
+    await dispatch._dispatch_one(_message(), 3)
+    assert written["reason"] == "999999"
+
+
+def test_every_classified_provider_code_has_a_word() -> None:
+    """Every classified provider code has a word."""
+    # The pairing that keeps the read side readable: a code the adapter
+    # classifies but the table does not name would be SHOWN as digits on
+    # the "why didn't it send" view, which is the whole thing the label
+    # exists to prevent. 131005 arrived exactly that way — classified as
+    # nothing, surfaced as provider_rejected.
+    from app.crm.connectivity.providers.whatsapp.classify import (
+        CREDENTIAL_CODES,
+        RETRYABLE_CODES,
+        TERMINAL_CODES,
+    )
+
+    for code in CREDENTIAL_CODES | TERMINAL_CODES | RETRYABLE_CODES:
+        assert code in PROVIDER_CODE_REASONS, f"code {code} has no word"
+
+
+def test_the_read_side_turns_a_stored_code_into_its_meaning() -> None:
+    """The read side turns a stored code into its meaning."""
+    # The merchant on the "why didn't it send" view gets the word; the row
+    # keeps the code. Imported off the contracts surface, because that is
+    # where a message-read view gets it.
+    from app.crm.connectivity.contracts import reason_label
+
+    assert reason_label("190") == "token_expired"
+    assert reason_label("131030") == "recipient_not_in_allowed_list"
+    # Lossless and total: an unnamed code stays exactly as stored — still
+    # greppable, still matching the provider's docs — and a word this
+    # module already chose (gate_refused, send_timeout) is the answer and
+    # must not be rewritten.
+    assert reason_label("999999") == "999999"
+    assert reason_label(REASON_SEND_ERROR) == REASON_SEND_ERROR
+    assert reason_label(None) is None
+    # And no entry may map to a digit string, which would defeat the point.
+    for code, word in PROVIDER_CODE_REASONS.items():
+        assert not word.isdigit(), code

--- a/tests/crm/test_meta_inbound.py
+++ b/tests/crm/test_meta_inbound.py
@@ -121,6 +121,14 @@ def test_a_missing_or_misshapen_signature_is_refused(secrets, header) -> None:
     assert not inbound.verify_signature(b"{}", header)
 
 
+def test_a_non_ascii_signature_is_refused_not_a_crash(secrets) -> None:
+    """A non-ascii signature is refused, not a crash."""
+    # compare_digest over str raises TypeError on non-ASCII, and the header
+    # is attacker-controlled: one crafted byte was a remote 500 where the
+    # route owes a 403. Bytes make it just another wrong signature.
+    assert not inbound.verify_signature(b"{}", {"X-Hub-Signature-256": "sha256=café"})
+
+
 def test_without_a_configured_secret_everything_is_refused(monkeypatch) -> None:
     """Without a configured secret everything is refused."""
     monkeypatch.setattr(inbound, "META_APP_SECRET", "")
@@ -148,6 +156,19 @@ def test_the_handshake_echoes_the_challenge_for_our_token(secrets) -> None:
 )
 def test_the_handshake_refuses_anything_else(secrets, params) -> None:
     """The handshake refuses anything else."""
+    assert inbound.handshake_challenge(params) is None
+
+
+def test_a_non_ascii_token_is_a_wrong_token_not_a_crash(secrets) -> None:
+    """A non-ascii token is a wrong token, not a crash."""
+    # Same scar as the signature: the token arrives in a query string
+    # anyone can send, and a str compare_digest turned it into a 500
+    # where the route owes a 404.
+    params = {
+        "hub.mode": "subscribe",
+        "hub.verify_token": "tökén",
+        "hub.challenge": "9",
+    }
     assert inbound.handshake_challenge(params) is None
 
 

--- a/tests/crm/test_whatsapp_extractor.py
+++ b/tests/crm/test_whatsapp_extractor.py
@@ -1,0 +1,414 @@
+"""WhatsApp through the one decode engine: the code-layer spec attributes
+Meta's letters to a person.
+
+The chain this pins: the ingress door files source="whatsapp" letters with
+customer_id NULL, and the event worker reads each by its catalog spec.
+Undeclared, whatsapp fell to the flat shape — which reads a top-level
+customer_mobile_number Meta never sends — so every letter quarantined
+no_handle: no resolve, no journey, no workflow entry.
+
+The generic four-part square (fixtures exist, every field resolves, the
+engine finds the person in every recorded letter, derivers match) is pinned
+for ALL code entries by test_catalog.py; what lives here is whatsapp's own
+behaviour — the wa_id match, the refusals, and the worker handing the
+normalized phone onward.
+
+Payloads are shaped exactly as the door files them
+(providers/meta/inbound.py::_narrowed): Meta's value with the batched array
+narrowed to one item, metadata and contacts riding along verbatim.
+"""
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict
+
+import pytest
+
+import app.crm.record.workers as workers
+from app.crm.record import catalog
+from app.crm.record.extractors import EXTRACTORS, engine, whatsapp as whatsapp_spec
+from app.crm.record.schemas import Extracted, RawEvent
+
+WA_FROM = "919876543210"
+OUR_NUMBER_ID = "812345678901234"
+
+INBOUND_SPEC = catalog.code_spec("whatsapp", "message.inbound")
+STATUS_SPEC = catalog.code_spec("whatsapp", "message.status")
+
+
+def _message(**overrides) -> Dict[str, Any]:
+    """One inbound message item, as Meta shapes it."""
+    fields: Dict[str, Any] = {
+        "from": WA_FROM,
+        "id": "wamid.INBOUND",
+        "timestamp": "1788177600",
+        "type": "text",
+        "text": {"body": "yes, confirm it"},
+    }
+    fields.update(overrides)
+    return fields
+
+
+def _inbound(message: Dict[str, Any] | None = None, **overrides) -> Dict[str, Any]:
+    """An inbound letter's payload: the value narrowed to one message."""
+    payload: Dict[str, Any] = {
+        "messaging_product": "whatsapp",
+        "metadata": {"phone_number_id": OUR_NUMBER_ID},
+        "contacts": [{"wa_id": WA_FROM, "profile": {"name": "Priya Sharma"}}],
+        "messages": [_message() if message is None else message],
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _status(**overrides) -> Dict[str, Any]:
+    """A status letter's payload: the value narrowed to one status."""
+    item: Dict[str, Any] = {
+        "id": "wamid.OUTBOUND",
+        "status": "delivered",
+        "timestamp": "1788177600",
+        "recipient_id": WA_FROM,
+        "pricing": {"billable": True, "category": "utility"},
+    }
+    item.update(overrides)
+    return {
+        "messaging_product": "whatsapp",
+        "metadata": {"phone_number_id": OUR_NUMBER_ID},
+        "statuses": [item],
+    }
+
+
+def _extract_inbound(payload: Dict[str, Any]) -> Extracted:
+    """The engine over whatsapp's inbound spec — the worker's exact read."""
+    assert INBOUND_SPEC is not None
+    return engine.extract(payload, INBOUND_SPEC)
+
+
+def _extract_status(payload: Dict[str, Any]) -> Extracted:
+    """The engine over whatsapp's status spec — the worker's exact read."""
+    assert STATUS_SPEC is not None
+    return engine.extract(payload, STATUS_SPEC)
+
+
+# --- inbound: the customer wrote to us ----------------------------------------
+
+
+def test_an_inbound_message_yields_the_senders_phone_in_e164() -> None:
+    # Meta's `from` is the wa_id: country code, no "+". The stored form is
+    # the probed form, so the handle must leave here already normalized.
+    """An inbound message yields the sender's phone in E.164."""
+    extracted = _extract_inbound(_inbound())
+    assert extracted.handles["phone"] == "+919876543210"
+
+
+def test_the_senders_name_is_matched_from_contacts_by_wa_id() -> None:
+    # contacts[] rides parallel to messages[]; a positional read would pin
+    # one person's name on another when a batch carries several senders.
+    """The sender's name is matched from contacts by wa_id."""
+    extracted = _extract_inbound(
+        _inbound(
+            contacts=[
+                {"wa_id": "918888888888", "profile": {"name": "Somebody Else"}},
+                {"wa_id": WA_FROM, "profile": {"name": "Priya Sharma"}},
+            ]
+        )
+    )
+    assert extracted.facts == {"name": "Priya Sharma"}
+
+
+@pytest.mark.parametrize("contacts", [None, [], [{"wa_id": "918888888888"}]])
+def test_a_letter_without_the_senders_contact_still_attributes(contacts) -> None:
+    # Meta may omit contacts, and a contact for someone else lends no name.
+    # Attribution must not hinge on the name: absent is absent, the phone
+    # is what resolves.
+    """A letter without the sender's contact still attributes."""
+    extracted = _extract_inbound(_inbound(contacts=contacts))
+    assert extracted.handles["phone"] == "+919876543210"
+    assert "name" not in extracted.facts
+
+
+def test_a_blank_profile_name_is_not_a_fact() -> None:
+    # Never defaulted, never padded: a blank reaching assert_facts would be
+    # a genuine claim overwriting what we actually know about the person.
+    """A blank profile name is not a fact."""
+    extracted = _extract_inbound(
+        _inbound(contacts=[{"wa_id": WA_FROM, "profile": {"name": "   "}}])
+    )
+    assert "name" not in extracted.facts
+
+
+def test_a_shared_contact_card_is_not_read_as_the_sender() -> None:
+    # On a type="contacts" message the CARDS the customer shared live inside
+    # the message item; the sender roster stays at the value level. Only the
+    # roster is read: the plumber's card must never become anyone's name.
+    """A shared contact card is not read as the sender."""
+    cards = [{"name": {"formatted_name": "My Plumber"}, "phones": [{"phone": "+1555"}]}]
+    extracted = _extract_inbound(
+        _inbound(message=_message(type="contacts", contacts=cards), contacts=[])
+    )
+    assert extracted.handles["phone"] == "+919876543210"
+    assert "name" not in extracted.facts
+
+
+def test_the_declared_variables_ride_out_for_templates() -> None:
+    # What the catalog marks variable=True is what a template may fill.
+    """The declared variables ride out for templates."""
+    extracted = _extract_inbound(_inbound())
+    assert extracted.variables["message_text"] == "yes, confirm it"
+    assert extracted.variables["sender_name"] == "Priya Sharma"
+
+
+# --- reply: what the customer answered, whichever widget carried it -----------
+
+
+def test_a_button_tap_answers_with_the_registered_payload() -> None:
+    """A button tap answers with the registered payload."""
+    # A template quick-reply carries no text.body; the answer is the
+    # button's payload — stable across languages, unlike its label.
+    extracted = _extract_inbound(
+        _inbound(
+            _message(
+                type="button",
+                text=None,
+                button={"payload": "CONFIRM_ORDER", "text": "Confirm order"},
+            )
+        )
+    )
+    assert extracted.variables["reply"] == "CONFIRM_ORDER"
+    assert "message_text" not in extracted.variables
+
+
+def test_an_interactive_choice_answers_with_its_id() -> None:
+    """An interactive choice answers with its id."""
+    extracted = _extract_inbound(
+        _inbound(
+            _message(
+                type="interactive",
+                text=None,
+                interactive={
+                    "type": "button_reply",
+                    "button_reply": {"id": "CANCEL_ORDER", "title": "Cancel"},
+                },
+            )
+        )
+    )
+    assert extracted.variables["reply"] == "CANCEL_ORDER"
+
+
+def test_a_typed_answer_falls_back_to_the_text_body() -> None:
+    """A typed answer falls back to the text body."""
+    # She ignored the buttons and wrote instead: still an answer, on the
+    # same key a wait_event square branches on.
+    extracted = _extract_inbound(_inbound())
+    assert extracted.variables["reply"] == "yes, confirm it"
+
+
+def test_the_recorded_fixtures_pin_both_reply_shapes() -> None:
+    """The recorded fixtures pin both reply shapes."""
+    # The same pin Meta's docs cannot drift past: the recorded button
+    # letter answers with its payload, the recorded text letter with its
+    # body (tests/crm/fixtures/whatsapp/).
+    folder = Path(__file__).parent / "fixtures" / "whatsapp"
+    button = json.loads((folder / "message_inbound_reply.json").read_text())
+    text = json.loads((folder / "message_inbound.json").read_text())
+    assert whatsapp_spec.reply(button) == "CONFIRM_ORDER"
+    assert whatsapp_spec.reply(text) == "yes, confirm my order"
+
+
+# --- statuses: what became of a message we sent -------------------------------
+
+
+def test_a_receipt_is_about_the_message_not_a_person() -> None:
+    # Canon T13 col 14 lists receipts beside template letters: processed
+    # but not about a person, customer NULL forever. The join to WHO we
+    # messaged lives on the manifest row (crm_message is born with
+    # customer_id); resolving the recipient here would run resolve()
+    # three times per send — sent, delivered, read — to duplicate it.
+    """A receipt is about the message, not a person."""
+    assert STATUS_SPEC is not None
+    assert STATUS_SPEC.about == "merchant" and STATUS_SPEC.identity == {}
+    extracted = _extract_status(_status())
+    assert extracted.about == "merchant"
+    assert extracted.handles == {} and extracted.facts == {}
+
+
+# --- merchant letters: the WABA's news, no person in them ---------------------
+
+
+@pytest.mark.parametrize(
+    "topic",
+    ["template.status", "template.category", "template.quality", "account.update"],
+)
+def test_letters_about_the_waba_are_declared_merchant_level(topic) -> None:
+    # Template and account letters ride the same source but concern the
+    # WABA, not a customer. Declared about="merchant" with no identity
+    # fields, they decode with no handles and the worker stamps them
+    # processed with customer NULL — no resolve, no quarantine (canon T13
+    # col 14). Undeclared, they fell to the flat shape, quarantined
+    # no_handle, and the template-status consumer never heard a letter.
+    """Letters about the WABA are declared merchant-level."""
+    spec = catalog.code_spec("whatsapp", topic)
+    assert spec is not None and spec.about == "merchant"
+    assert spec.identity == {}
+
+
+def test_a_template_review_decodes_with_its_facts_and_no_handles() -> None:
+    """A template review decodes with its facts and no handles."""
+    payload = {
+        "event": "REJECTED",
+        "message_template_id": 1953621873,
+        "message_template_name": "diwali_blowout_sale",
+        "message_template_language": "en_US",
+        "reason": "INCORRECT_CATEGORY",
+    }
+    spec = catalog.code_spec("whatsapp", "template.status")
+    assert spec is not None
+    extracted = engine.extract(payload, spec)
+    assert extracted.about == "merchant"
+    assert extracted.handles == {} and extracted.facts == {}
+    assert extracted.variables["event"] == "REJECTED"
+    assert extracted.variables["reason"] == "INCORRECT_CATEGORY"
+    assert extracted.variables["message_template_name"] == "diwali_blowout_sale"
+
+
+def test_a_ban_notice_reads_the_state_meta_ships_in_a_list() -> None:
+    # ban_info.waba_ban_state is a one-element LIST in Meta's value — the
+    # deriver unwraps it; a letter that is no ban derives nothing.
+    """A ban notice reads the state Meta ships in a list."""
+    folder = Path(__file__).parent / "fixtures" / "whatsapp"
+    ban = json.loads((folder / "account_update.json").read_text())
+    assert whatsapp_spec.ban_state(ban) == "SCHEDULE_FOR_DISABLE"
+    assert whatsapp_spec.ban_state({"event": "VERIFIED_ACCOUNT"}) is None
+
+
+# --- refusals: skipped, not written -------------------------------------------
+
+
+def test_an_unusable_number_is_skipped_not_written() -> None:
+    # normalize_phone returns None rather than writing a malformed handle;
+    # a bad handle would poison every later probe on it.
+    """An unusable number is skipped, not written."""
+    bad_inbound = _inbound(message=_message(**{"from": "n/a"}))
+    assert _extract_inbound(bad_inbound).handles == {}
+
+
+# --- the catalog placement and the pass ---------------------------------------
+
+
+def test_whatsapp_is_a_code_catalog_source_not_an_imperative_extractor() -> None:
+    # The ruled path (event-catalog.md §One decode engine): a connector
+    # source is a SPEC. Listed in EXTRACTORS too, two readers of one
+    # payload would drift — the disease the engine exists to end.
+    """Whatsapp is a code-catalog source, not an imperative extractor."""
+    topics = (
+        "message.inbound",
+        "message.status",
+        "template.status",
+        "template.category",
+        "template.quality",
+        "account.update",
+    )
+    for topic in topics:
+        assert ("whatsapp", topic) in catalog.CATALOG
+        assert set(catalog.derive_for("whatsapp", topic)) <= set(whatsapp_spec.DERIVERS)
+    assert "whatsapp" not in EXTRACTORS
+
+
+async def test_the_pass_hands_the_normalized_phone_to_the_consumers(
+    monkeypatch,
+) -> None:
+    # End of the chain: the number the consumers see is the number identity
+    # resolved on, so suppression matches by construction — and the
+    # catalog's variables ride beside it.
+    """The pass hands the normalized phone to the consumers."""
+    seen: Dict[str, Any] = {}
+
+    async def fake_resolve(merchant_id, handles, evidence, source):
+        """Test double: resolve without a database."""
+        seen["resolved_on"] = handles
+        return "cus-1"
+
+    async def fake_facts(*args: Any, **kwargs: Any) -> None:
+        """Test double: swallow the name claim."""
+        return None
+
+    async def fake_consume(event, customer_id, handles, variables) -> None:
+        """Test double: record what the consumer slot receives."""
+        seen["handles"] = handles
+        seen["variables"] = variables
+
+    async def fake_stamp(*args: Any, **kwargs: Any) -> None:
+        """Test double: swallow the stamp."""
+        return None
+
+    monkeypatch.setattr(workers, "crm_resolve", fake_resolve)
+    monkeypatch.setattr(workers, "assert_facts", fake_facts)
+    monkeypatch.setattr(workers, "consumers", lambda: [fake_consume])
+    monkeypatch.setattr(workers.accessor, "stamp_event", fake_stamp)
+
+    event = RawEvent(
+        id="e1",
+        merchant_id="m1",
+        source="whatsapp",
+        topic="message.inbound",
+        schema_version="1",
+        external_id="wamid.INBOUND",
+        payload=_inbound(),
+        received_at=datetime.now(timezone.utc),
+    )
+    await workers._process_one(None, event)  # type: ignore[arg-type]
+
+    assert seen["resolved_on"]["phone"] == "+919876543210"
+    assert seen["handles"] == seen["resolved_on"]
+    assert seen["variables"]["message_text"] == "yes, confirm it"
+
+
+async def test_the_pass_stamps_a_merchant_letter_with_no_customer(
+    monkeypatch,
+) -> None:
+    # The merchant end of the chain: a template review reaches every
+    # consumer with customer_id None and stamps processed — no resolve, no
+    # quarantine. Before the entries existed, this exact letter quarantined
+    # no_handle and the template-status consumer heard nothing.
+    """The pass stamps a merchant letter with no customer."""
+    seen: Dict[str, Any] = {}
+
+    async def never_resolve(*args: Any, **kwargs: Any) -> str:
+        """Test double: a merchant letter must never resolve()."""
+        raise AssertionError("a merchant letter must never resolve()")
+
+    async def never_quarantine(*args: Any, **kwargs: Any) -> None:
+        """Test double: a merchant letter must never quarantine."""
+        raise AssertionError("a merchant letter must never quarantine")
+
+    async def fake_consume(event, customer_id, handles, variables) -> None:
+        """Test double: record what the consumer slot receives."""
+        seen["customer_id"] = customer_id
+        seen["variables"] = variables
+
+    async def fake_stamp(txn, event_id, customer_id) -> None:
+        """Test double: record the stamp."""
+        seen["stamped"] = (event_id, customer_id)
+
+    monkeypatch.setattr(workers, "crm_resolve", never_resolve)
+    monkeypatch.setattr(workers, "consumers", lambda: [fake_consume])
+    monkeypatch.setattr(workers.accessor, "stamp_event", fake_stamp)
+    monkeypatch.setattr(workers.accessor, "quarantine_event", never_quarantine)
+
+    folder = Path(__file__).parent / "fixtures" / "whatsapp"
+    event = RawEvent(
+        id="e2",
+        merchant_id="m1",
+        source="whatsapp",
+        topic="template.status",
+        schema_version="v23.0",
+        external_id="waba:1953621873:REJECTED:1",
+        payload=json.loads((folder / "template_status_rejected.json").read_text()),
+        received_at=datetime.now(timezone.utc),
+    )
+    await workers._process_one(None, event)  # type: ignore[arg-type]
+
+    assert seen["customer_id"] is None
+    assert seen["stamped"] == ("e2", None)
+    assert seen["variables"]["reason"] == "INCORRECT_CATEGORY"

--- a/tests/crm/test_workflow_entry.py
+++ b/tests/crm/test_workflow_entry.py
@@ -109,11 +109,16 @@ def _run(
     )
 
 
-def _event(topic: str, payload: Dict[str, Any], event_id: str = "ev-1") -> RawEvent:
+def _event(
+    topic: str,
+    payload: Dict[str, Any],
+    event_id: str = "ev-1",
+    source: str = "shopify",
+) -> RawEvent:
     return RawEvent(
         id=event_id,
         merchant_id="m1",
-        source="shopify",
+        source=source,
         topic=topic,
         schema_version="1",
         external_id=f"{topic}:{event_id}",
@@ -233,6 +238,69 @@ def test_a_reply_without_the_key_never_wakes_the_run(listening: _Spine) -> None:
     the alarm may time it out."""
     _consume(_event("button.reply", {"text": "hello"}))
     assert listening.resumes == []
+
+
+# --- the answer resolves through the catalog, derived fields included ---
+
+
+def _tap_plan(key: str) -> Dict[str, Any]:
+    return {
+        "entry": {"topic": "orders/create"},
+        "nodes": [
+            {
+                "id": "ask",
+                "type": "wait_event",
+                "topics": ["message.inbound"],
+                "key": key,
+                "minutes": 30,
+            }
+        ],
+        "edges": [],
+        "goal": {"topics": ["order.confirmed"]},
+    }
+
+
+# A WhatsApp button tap as the door files it: the answer lives at
+# messages[0].button.payload — nothing at the top level.
+_TAP = {
+    "messages": [
+        {"type": "button", "button": {"payload": "CONFIRM_ORDER", "text": "Confirm"}}
+    ]
+}
+
+
+def test_a_button_tap_wakes_the_square_through_the_catalog(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A button tap wakes the square through the catalog."""
+    # The square's key resolves like entry.where already does: whatsapp's
+    # reply is a DERIVED field (the answer sits inside a list the path
+    # grammar never indexes), so a top-level read finds nothing and the
+    # tap is indistinguishable from silence — the run times out CALLED.
+    plan = _tap_plan("reply")
+    flow = _flow(plan)
+    run = _run(flow, 1, "ask")
+    spine = _Spine([flow], [run], {(flow.id, 1): plan})
+    _install(monkeypatch, spine)
+    _consume(_event("message.inbound", _TAP, source="whatsapp"))
+    assert spine.resumes == [
+        (str(run.id), "ask", {"reply_ask": "CONFIRM_ORDER", "latest_letter": "ask"})
+    ]
+
+
+def test_the_same_tap_without_its_key_is_still_ignored(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The same tap without its key is still ignored."""
+    # B1 holds through the catalog read: a key naming nothing — derived
+    # or top-level — is no answer, and only the alarm may end the window.
+    plan = _tap_plan("nonexistent")
+    flow = _flow(plan)
+    run = _run(flow, 1, "ask")
+    spine = _Spine([flow], [run], {(flow.id, 1): plan})
+    _install(monkeypatch, spine)
+    _consume(_event("message.inbound", _TAP, source="whatsapp"))
+    assert spine.resumes == []
 
 
 # --- phase 06 + 09: goal tiers keyed-first, per run; the goal stash ---


### PR DESCRIPTION
THIS IS RE-RAISED PR: https://github.com/juspay/clairvoyance/pull/1052(old pr link)


- WhatsApp declared in the code-layer catalog (extractors/whatsapp.py), all six
  topics via SPEC_MODULES. Undeclared, every letter fell to the flat extractor
  and quarantined no_handle.
- message.inbound is the one customer topic: sender matched from contacts[] by
  wa_id (never positional, never defaulted); wa_id IS the phone, E.164 out.
- New reply field: button.payload -> interactive id -> text body — one key for
  whatever widget carried the answer.
- outreach/entry.py: _answer_for/_is_about resolve through the catalog, so a
  wait_event keyed "reply" hears a button tap; top-level keys unchanged, B1
  holds (no key -> ignored, only the alarm ends the window).
- template.status/category/quality + account.update declared about="merchant":
  no identity, recorded fixtures each, processed with customer NULL (canon T13
  col 14) — the template consumer (https://github.com/juspay/clairvoyance/pull/1084) hears every letter; exclusion pin
  flipped. ban_state deriver unwraps Meta's one-element ban_info list.
- Receipts (message.status) merchant-level too: no resolve() per receipt — the
  customer join lives on the manifest row (crm_message born with customer_id).
- crm_message.reason keeps the provider's code verbatim (canon T16 col 13);
  the words moved to the read side — reason_label() on connectivity's
  contracts (same PROVIDER_CODE_REASONS map), for the message-read view when
  it lands. Named 131005 (credential) and 131030 (terminal), both hit live.
- providers/meta/inbound.py: compare_digest over BYTES — non-ASCII input was
  an unhandled 500 where the route owes 403/404 (CodeRabbit r3913648045).
- replied_to/status_message_id: wamid-vs-our-id join trigger named in code.
- Tests: 8 recorded fixtures under test_catalog's square (merchant branch:
  no handles, no quarantine), worker-level NULL-stamp test, reply shapes
  pinned, dispatcher writes "190" verbatim + read-side label pinned through
  contracts, webhook tests proven red pre-fix.

Live-proven on a real WABA: COD order -> template accepted with a wamid ->
sent/delivered/read -> CONFIRM tap attributed, zero quarantined.

testing:
<img width="1899" height="659" alt="Screenshot 2026-09-04 at 6 11 30 PM" src="https://github.com/user-attachments/assets/c54c45f9-696f-46e2-9a4f-2183efe307c3" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added WhatsApp webhook support, including inbound messages, replies, delivery statuses, sender details, and catalog fields.
  - WhatsApp button and interactive replies can now resume matching workflows with their response values.
- **Bug Fixes**
  - Provider error codes are now stored with readable reasons where available.
  - Invalid non-ASCII webhook signatures and handshake tokens are safely rejected instead of causing server errors.
  - Added clearer handling for additional Meta permission and recipient errors.
- **Improvements**
  - Workflow event matching now supports derived and nested record fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->