### PR TITLE
fix(chat): release the session lock before turn_end is written

### DIFF
--- a/app/api/routers/breeze_buddy/chat/handlers.py
+++ b/app/api/routers/breeze_buddy/chat/handlers.py
@@ -788,6 +788,14 @@ async def _turn_sse_stream(
                 yield format_sse(pre)
             async for event in events:
                 turn_metrics.observe(event)
+                if event.event == "turn_end":
+                    # Release before the terminal frame: every DB write is
+                    # done, and the widget POSTs its next turn the instant
+                    # it reads turn_end. Releasing only in the ``finally``
+                    # left that request racing the lock for a spurious 409.
+                    # Idempotent, so the finally's call is a no-op; shielded
+                    # so a client disconnect can't skip the Redis DEL.
+                    await asyncio.shield(lock.release())
                 yield format_sse(event)
         except asyncio.CancelledError:
             # User clicked Stop. Emit a clean turn_end so the client
@@ -816,6 +824,10 @@ async def _turn_sse_stream(
                     pass
             logger.info(f"chat turn stream for session {session_id} cancelled by user")
             turn_metrics.status = "CANCELED"
+            # Same contract as the ACTIVE path above: the lock is free by
+            # the time the client reads turn_end, so a client that drains
+            # the stream to EOS can start its next turn without racing.
+            await asyncio.shield(lock.release())
             yield format_sse(
                 SSEEvent(event="turn_end", data={"session_status": "CANCELED"})
             )


### PR DESCRIPTION
## Problem

Add to cart from the product overlay intermittently failed with `409 turn_in_flight` and the button stayed dead.

The per-session Redis lock was released only in the stream's `finally`, after the terminal `turn_end` frame had been written. The widget starts its next turn the instant it reads `turn_end` (overlay enrichment after `view_product`, `add_to_cart` after cancelling the overlay's blurb turn), so it raced the release.

## Change (one file, 12 lines, 3 of code)

`app/api/routers/breeze_buddy/chat/handlers.py`: release the lock just before the terminal frame, on both the `ACTIVE` and `CANCELED` paths.

```python
if event.event == "turn_end":
    await asyncio.shield(lock.release())
```
```python
await asyncio.shield(lock.release())   # before the CANCELED turn_end
```

Every DB write of the turn is already done at that point (the agent's own cleanup only closes connections). The `finally` release stays and becomes a no-op. Shielded so a client disconnect at that moment cannot skip the Redis DEL.

Contract for clients: **when you read `turn_end`, the lock is free.** The `/cancel` route is unchanged.

Companion SDK change: juspay/loom#326 (cancel() drains to that frame instead of aborting locally). Both halves are needed.

## Latency

One Redis DEL moves from after the final frame to before it, ~1ms per turn. Nothing else changes.

## Verification

- Full suite: 2267 passed, 15 skipped, 1 xfailed. `black --check` clean.
- Live against local clairvoyance + the assist widget with #326: the exact failing sequence (`view_product` → blurb turn → size → add to cart) now returns `intent:200, intent:200, cancel:202, intent:200`; add_to_cart left 11ms after the click and the cart holds the item.
- Stop button mid-stream: turn ends on the server's `CANCELED` frame, next message succeeds.
