### PR TITLE
fix(transport): read HTTP response bodies to EOF

### DIFF
--- a/app/ai/voice/agents/breeze_buddy/handlers/transport/http_requester.py
+++ b/app/ai/voice/agents/breeze_buddy/handlers/transport/http_requester.py
@@ -196,11 +196,23 @@ class HttpRequestExecutor:
                             except ValueError:
                                 pass  # Invalid Content-Length, will check actual size below
 
-                        # Read response with size limit
-                        response_bytes = await response.content.read(
-                            HTTP_REQUEST_MAX_RESPONSE_BYTES + 1
-                        )
-                        if len(response_bytes) > HTTP_REQUEST_MAX_RESPONSE_BYTES:
+                        # Read response to EOF with a size limit. NB: a single
+                        # StreamReader.read(n) can return a PARTIAL body on
+                        # slow/chunked upstreams (observed: 3KB of a 20KB
+                        # long-poll response, truncating the JSON) — so
+                        # accumulate chunks until EOF.
+                        body_chunks = []
+                        bytes_read = 0
+                        while True:
+                            chunk = await response.content.read(65536)
+                            if not chunk:
+                                break
+                            bytes_read += len(chunk)
+                            if bytes_read > HTTP_REQUEST_MAX_RESPONSE_BYTES:
+                                break
+                            body_chunks.append(chunk)
+                        response_bytes = b"".join(body_chunks)
+                        if bytes_read > HTTP_REQUEST_MAX_RESPONSE_BYTES:
                             error_msg = (
                                 f"Response exceeded max size of "
                                 f"{HTTP_REQUEST_MAX_RESPONSE_BYTES} bytes"

--- a/tests/test_http_requester_read.py
+++ b/tests/test_http_requester_read.py
@@ -1,0 +1,92 @@
+"""``HttpRequestExecutor`` reads the whole response body, not one chunk.
+
+A single ``StreamReader.read(n)`` can return a PARTIAL body on slow or
+chunked upstreams (observed: 3KB of a 20KB long-poll response, which
+truncated the JSON the LLM then saw). The executor must accumulate until
+EOF while still enforcing ``HTTP_REQUEST_MAX_RESPONSE_BYTES``.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import List
+
+# isort: off
+# template.types must load before the transport modules (reversing the
+# order trips a circular import — see test_response_transform.py).
+from app.ai.voice.agents.breeze_buddy.template.types import HttpRequestConfig
+
+import app.ai.voice.agents.breeze_buddy.handlers.transport.http_requester as hr
+
+# isort: on
+
+
+class _Content:
+    """Hands back one queued chunk per read(), then EOF — the shape of a
+    chunked upstream where read(n) never returns the full body."""
+
+    def __init__(self, chunks: List[bytes]) -> None:
+        self._chunks = list(chunks)
+        self.reads = 0
+
+    async def read(self, n: int) -> bytes:
+        self.reads += 1
+        return self._chunks.pop(0) if self._chunks else b""
+
+
+class _Response:
+    def __init__(self, chunks: List[bytes], status: int = 200) -> None:
+        self.status = status
+        self.headers = {"Content-Type": "application/json"}
+        self.content = _Content(chunks)
+
+    async def __aenter__(self) -> "_Response":
+        return self
+
+    async def __aexit__(self, *exc) -> bool:
+        return False
+
+
+class _Session:
+    def __init__(self, chunks: List[bytes]) -> None:
+        self.response = _Response(chunks)
+
+    def request(self, **kwargs) -> _Response:
+        return self.response
+
+
+_CFG = HttpRequestConfig(
+    url="https://api.example.com/v1/journeys", method="GET", max_retries=1
+)
+
+
+async def test_body_is_accumulated_until_eof():
+    session = _Session([b'{"journeys": [', b'{"id": 1}, ', b'{"id": 2}]}'])
+    executor = hr.HttpRequestExecutor(session)  # pyrefly: ignore[bad-argument-type]
+
+    result = await executor.execute(
+        config=_CFG, resolved_fields={}, fire_and_forget=False
+    )
+    assert result is not None
+    status, body = result
+
+    assert status == 200
+    assert json.loads(body) == {"journeys": [{"id": 1}, {"id": 2}]}
+    assert session.response.content.reads == 4  # three chunks + EOF
+
+
+async def test_size_cap_counts_every_chunk(monkeypatch):
+    monkeypatch.setattr(hr, "HTTP_REQUEST_MAX_RESPONSE_BYTES", 10)
+    session = _Session([b"x" * 8, b"y" * 8, b"z" * 8])
+    executor = hr.HttpRequestExecutor(session)  # pyrefly: ignore[bad-argument-type]
+
+    result = await executor.execute(
+        config=_CFG, resolved_fields={}, fire_and_forget=False
+    )
+    assert result is not None
+    status, body = result
+
+    assert status == 0
+    assert "exceeded max size of 10 bytes" in body
+    # stops reading once the cap is crossed — never buffers the whole body
+    assert session.response.content.reads == 2


### PR DESCRIPTION
A single StreamReader.read(n) can return a PARTIAL body on slow or chunked
upstreams - observed as 3KB of a 20KB long-poll response, which truncated
the JSON the LLM then saw. The executor now accumulates chunks until EOF,
still enforcing HTTP_REQUEST_MAX_RESPONSE_BYTES (counted per chunk, so an
oversized body is refused without buffering it). Regression test drives
the executor with a chunked fake response.

**Part 1 of 7** of the split of #1039 — the review feedback from there is already incorporated. Parts 1–5 are independent of each other and of the CHAMELEON stack (5 → 6 → 7).

### Validation (this branch alone)
- `uv run pytest tests/`: 2269 passed · `pyrefly` 0 errors · black / isort / autoflake clean · migration-numbering and CRM-boundary guards OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MExhDfX8SUSdPpA8ruW4sG


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of responses delivered in multiple chunks, ensuring complete response bodies are processed correctly.
  - Enforced response-size limits across the entire response, including data received after the initial chunk.

- **Tests**
  - Added coverage for multi-chunk response processing and response-size limit enforcement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->