### PR TITLE
feat(transforms): generic in-place response transforms

### DIFF
--- a/app/ai/voice/agents/breeze_buddy/handlers/transport/utils/response_transform.py
+++ b/app/ai/voice/agents/breeze_buddy/handlers/transport/utils/response_transform.py
@@ -52,7 +52,9 @@ spec narrowly scoped to the in-place-mutation idiom.
 
 from __future__ import annotations
 
+import math
 import re
+from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple
 
 from app.core.logger import logger
@@ -245,6 +247,193 @@ def scale_by_exponent(value: Any, args: Dict[str, Any]) -> Any:
     return value
 
 
+@register_transform("format_number")
+def format_number(value: Any, args: Dict[str, Any]) -> Any:
+    """Derive a display string from a numeric field on the same dict.
+
+    The label-derivation workhorse behind "display values are
+    pre-formatted — never build your own": templates derive
+    ``duration_label`` ("51 min"), ``distance_label`` ("13.1 km") and fare
+    labels ("₹30") server-side so the LLM (and data-bound UI) only ever
+    shows ready-made strings.
+
+    Args:
+        field     — source numeric field name (required).
+        to        — destination field name (required). Overwritten.
+        divide_by — divide the source value first (e.g. 60 s→min, 1000 m→km).
+        decimals  — decimal places for the result (default 0 → rounded int).
+        skip_zero — when true, a zero source value derives nothing (walk
+                    legs must not grow a "₹0" fare label).
+        prefix    — literal prefix (e.g. "₹").
+        suffix    — literal suffix (e.g. " min").
+
+    Non-dict values, missing/non-numeric sources: pass-through no-op.
+    """
+    if not isinstance(value, dict):
+        return value
+    src_field = args.get("field")
+    dst_field = args.get("to")
+    if not src_field or not dst_field:
+        return value
+    raw = value.get(src_field)
+    try:
+        number = float(raw)  # pyrefly: ignore[bad-argument-type]
+    except (TypeError, ValueError):
+        return value
+    if not math.isfinite(number):
+        # "nan" / "inf" parse, but round() below would raise and abort the
+        # whole transform pass.
+        return value
+    if args.get("skip_zero") and number == 0:
+        return value
+    divide_by = args.get("divide_by")
+    if isinstance(divide_by, (int, float)) and divide_by:
+        number = number / divide_by
+    decimals = args.get("decimals", 0)
+    if not isinstance(decimals, int) or decimals < 0:
+        decimals = 0
+    if decimals == 0:
+        body = str(int(round(number)))
+    else:
+        body = f"{number:.{decimals}f}"
+    prefix = args.get("prefix") or ""
+    suffix = args.get("suffix") or ""
+    value[dst_field] = f"{prefix}{body}{suffix}"
+    return value
+
+
+@register_transform("coalesce")
+def coalesce(value: Any, args: Dict[str, Any]) -> Any:
+    """Write the first non-empty of several (dotted) source fields to a
+    destination field on the same dict — the display-layer if/else that
+    the declarative render grammar deliberately lacks (e.g. a transit
+    leg's title is its route code when it has one, else its mode; its
+    value line is the fare when priced, else the walking distance).
+
+    Args:
+        fields  — ordered list of source paths on this dict; a path may be
+                  dotted to reach nested dicts ("route.code").
+        to      — destination field name (required). Overwritten.
+        default — literal written when NO field resolves (optional). Lets
+                  a downstream hard bind (top-level component prop) rely
+                  on the field existing — e.g. selected_tier_type "" on
+                  modes whose API omits a selected tier.
+
+    Non-dict values / no field resolving to a non-empty scalar (and no
+    default): no-op.
+    """
+    if not isinstance(value, dict):
+        return value
+    fields = args.get("fields")
+    dst_field = args.get("to")
+    if not isinstance(fields, list) or not dst_field:
+        return value
+    if "default" in args:
+        value.setdefault(dst_field, args["default"])
+        # A present-but-None value still needs replacing — None fails the
+        # bind resolver's `is None` check, which is what `default` exists
+        # to prevent.
+        if value[dst_field] is None:
+            value[dst_field] = args["default"]
+    for path in fields:
+        if not isinstance(path, str) or not path:
+            continue
+        current: Any = value
+        for key in path.split("."):
+            if not isinstance(current, dict):
+                current = None
+                break
+            current = current.get(key)
+        if current is not None and not isinstance(current, (dict, list)):
+            text = str(current)
+            if text.strip():
+                value[dst_field] = current
+                return value
+    return value
+
+
+def _utc_now() -> datetime:
+    """Wall clock for the time-relative transforms — module-level so tests
+    can pin it."""
+    return datetime.now(timezone.utc)
+
+
+@register_transform("format_time")
+def format_time(value: Any, args: Dict[str, Any]) -> Any:
+    """Derive a short clock label ("11:18") from an ISO-8601 field on the
+    same dict — the display counterpart of format_number for timestamps
+    (departure/arrival chips and the like).
+
+    Args:
+        field     — source ISO-8601 string field name (required).
+        to        — destination field name (required). Overwritten.
+        tz_offset — minutes to shift a UTC/naive timestamp into the
+                    display zone (e.g. 330 for IST). Timestamps that
+                    already carry an offset are converted, not shifted twice.
+        fmt       — strftime format (default "%H:%M").
+
+    Non-dict values, missing/unparseable sources: pass-through no-op.
+    """
+    if not isinstance(value, dict):
+        return value
+    src_field = args.get("field")
+    dst_field = args.get("to")
+    if not src_field or not dst_field:
+        return value
+    raw = value.get(src_field)
+    if not isinstance(raw, str) or not raw:
+        return value
+    try:
+        parsed = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+    except ValueError:
+        return value
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    tz_offset = args.get("tz_offset")
+    # 0 is a valid offset (display in UTC): test the type, not truthiness.
+    if isinstance(tz_offset, (int, float)) and not isinstance(tz_offset, bool):
+        parsed = parsed.astimezone(timezone(timedelta(minutes=tz_offset)))
+    fmt = args.get("fmt")
+    if not isinstance(fmt, str) or not fmt:
+        fmt = "%H:%M"
+    try:
+        value[dst_field] = parsed.strftime(fmt)
+    except ValueError:
+        return value
+    return value
+
+
+@register_transform("join_list")
+def join_list(value: Any, args: Dict[str, Any]) -> Any:
+    """Join a list-of-strings field into one display string on the same dict.
+
+    E.g. ``modes: ["Walk", "Metro", "Walk"]`` →
+    ``modes_label: "Walk → Metro → Walk"``.
+
+    Args:
+        field     — source list field name (required).
+        to        — destination field name (required). Overwritten.
+        separator — joiner (default " → ").
+
+    Non-dict values, missing/non-list sources: pass-through no-op.
+    Non-string entries are stringified.
+    """
+    if not isinstance(value, dict):
+        return value
+    src_field = args.get("field")
+    dst_field = args.get("to")
+    if not src_field or not dst_field:
+        return value
+    raw = value.get(src_field)
+    if not isinstance(raw, list):
+        return value
+    separator = args.get("separator")
+    if not isinstance(separator, str):
+        separator = " → "
+    value[dst_field] = separator.join(str(item) for item in raw)
+    return value
+
+
 @register_transform("pick_fields")
 def pick_fields(value: Any, args: Dict[str, Any]) -> Any:
     """Keep only the listed top-level keys in a dict; drop everything else.
@@ -413,14 +602,352 @@ def derive_field(value: Any, args: Dict[str, Any]) -> Any:
     return value
 
 
+@register_transform("map_values")
+def map_values(value: Any, args: Dict[str, Any]) -> Any:
+    """Map a field's value(s) through a lookup table onto a destination
+    field on the same dict — the display-layer rename the render grammar
+    deliberately lacks (e.g. a transit wire mode "Subway" reads as
+    "Train" to commuters).
+
+    Args:
+        field   — source field name (required). Scalar or list of scalars.
+        to      — destination field name (required). Overwritten.
+        map     — {source value (as string) → replacement} (required).
+        default — value for unmapped entries; omitted = keep the original.
+
+    A LIST source maps each element (writing a new list). Non-dict
+    values, missing source, or a non-dict ``map``: pass-through no-op.
+    """
+    if not isinstance(value, dict):
+        return value
+    src_field = args.get("field")
+    dst_field = args.get("to")
+    table = args.get("map")
+    if not src_field or not dst_field or not isinstance(table, dict):
+        return value
+    raw = value.get(src_field)
+    if raw is None:
+        return value
+    mapping: Dict[str, Any] = table
+
+    def _one(item: Any) -> Any:
+        key = str(item)
+        if key in mapping:
+            return mapping[key]
+        return args.get("default", item)
+
+    if isinstance(raw, list):
+        value[dst_field] = [_one(item) for item in raw]
+    else:
+        value[dst_field] = _one(raw)
+    return value
+
+
+@register_transform("format_range")
+def format_range(value: Any, args: Dict[str, Any]) -> Any:
+    """Derive a display label from a min/max pair on the same dict:
+    "₹30" when they agree, "₹10–55" when they span (a fare across
+    service classes). The two-field counterpart of format_number.
+
+    Args:
+        min_field — source field for the lower bound (required).
+        max_field — source field for the upper bound (required).
+        to        — destination field name (required). Overwritten.
+        prefix    — prepended once (default "").
+        suffix    — appended once (default "").
+        decimals  — round to N decimals; default 0 drops any ".0".
+        skip_zero — True: both bounds zero → no label written.
+        style     — "span" (default): "₹10–55"; "from": "from ₹10" — the
+                    consumer-friendly form when the spread is a class
+                    ladder, not price uncertainty. Equal bounds always
+                    render plain ("₹30") in either style.
+
+    Non-dict values or non-numeric bounds: pass-through no-op. A missing
+    max falls back to min (and vice versa) so a single-priced row still
+    labels.
+    """
+    if not isinstance(value, dict):
+        return value
+    min_field = args.get("min_field")
+    max_field = args.get("max_field")
+    dst_field = args.get("to")
+    if not min_field or not max_field or not dst_field:
+        return value
+    lo_raw = value.get(min_field)
+    hi_raw = value.get(max_field)
+    if lo_raw is None and hi_raw is None:
+        return value
+    try:
+        lo = float(lo_raw if lo_raw is not None else hi_raw)  # type: ignore[arg-type]
+        hi = float(hi_raw if hi_raw is not None else lo_raw)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return value
+    if args.get("skip_zero") and lo == 0 and hi == 0:
+        return value
+    decimals = args.get("decimals", 0)
+    if not isinstance(decimals, int) or decimals < 0:
+        decimals = 0
+
+    def _fmt(number: float) -> str:
+        text = f"{number:.{decimals}f}"
+        if decimals == 0 and text.endswith(".0"):
+            text = text[:-2]
+        return text
+
+    prefix = args.get("prefix") or ""
+    suffix = args.get("suffix") or ""
+    if lo == hi:
+        label = f"{prefix}{_fmt(lo)}{suffix}"
+    elif args.get("style") == "from":
+        label = f"from {prefix}{_fmt(min(lo, hi))}{suffix}"
+    else:
+        label = f"{prefix}{_fmt(min(lo, hi))}–{_fmt(max(lo, hi))}{suffix}"
+    value[dst_field] = label
+    return value
+
+
+@register_transform("mark_extremum")
+def mark_extremum(value: Any, args: Dict[str, Any]) -> Any:
+    """Tag the min/max element of a list field — the cross-item ranking a
+    per-item transform cannot express (e.g. label the fastest / cheapest
+    journey of a result set). Apply at the path of the dict HOLDING the
+    list (root for a top-level list).
+
+    Args:
+        list_field  — field on this dict holding the list (required).
+        field       — numeric field ranked on each element (required).
+        mode        — "min" (default) or "max".
+        to          — destination field on the WINNING element (required).
+        label       — value written to `to` (required).
+        skip_if_set — True (default): elements whose `to` is already set
+                      are not overwritten AND are skipped when ranking, so
+                      a second rule ("Cheapest" after "Fastest") tags the
+                      best of the REMAINING elements.
+
+    Elements without a numeric `field` are ignored. No qualifying
+    element / bad args: no-op.
+    """
+    if not isinstance(value, dict):
+        return value
+    list_field = args.get("list_field")
+    field = args.get("field")
+    dst_field = args.get("to")
+    label = args.get("label")
+    if not list_field or not field or not dst_field or label is None:
+        return value
+    items = value.get(list_field)
+    if not isinstance(items, list):
+        return value
+    skip_if_set = args.get("skip_if_set", True)
+    best: Optional[Dict[str, Any]] = None
+    best_num: Optional[float] = None
+    use_max = args.get("mode") == "max"
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        if skip_if_set and item.get(dst_field) is not None:
+            continue
+        raw = item.get(field)
+        try:
+            num = float(raw)  # type: ignore[arg-type]
+        except (TypeError, ValueError):
+            continue
+        if best_num is None or (num > best_num if use_max else num < best_num):
+            best_num = num
+            best = item
+    if best is not None:
+        best[dst_field] = label
+    return value
+
+
+@register_transform("count_where")
+def count_where(value: Any, args: Dict[str, Any]) -> Any:
+    """Count a list field's elements by a member-field predicate and write
+    the (offset, clamped) count — e.g. transfers = transit legs minus one.
+
+    Args:
+        list_field — field on this dict holding the list (required).
+        field      — member field inspected on each element (required).
+        in         — count only elements whose field (as string) is in
+                     this list.
+        not_in     — count only elements whose field is NOT in this list.
+        offset     — added to the count (default 0), e.g. -1 for
+                     transfers.
+        min        — lower clamp after offset (default 0).
+        to         — destination field on this dict (required).
+
+    Missing/non-list source or bad args: no-op.
+    """
+    if not isinstance(value, dict):
+        return value
+    list_field = args.get("list_field")
+    field = args.get("field")
+    dst_field = args.get("to")
+    if not list_field or not field or not dst_field:
+        return value
+    items = value.get(list_field)
+    if not isinstance(items, list):
+        return value
+    include = args.get("in")
+    exclude = args.get("not_in")
+    count = 0
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        member = str(item.get(field))
+        if isinstance(include, list) and member not in [str(x) for x in include]:
+            continue
+        if isinstance(exclude, list) and member in [str(x) for x in exclude]:
+            continue
+        count += 1
+    offset = args.get("offset", 0)
+    floor = args.get("min", 0)
+    if not isinstance(offset, int):
+        offset = 0
+    if not isinstance(floor, int):
+        floor = 0
+    value[dst_field] = max(floor, count + offset)
+    return value
+
+
+@register_transform("find_where")
+def find_where(value: Any, args: Dict[str, Any]) -> Any:
+    """Find the FIRST element of a list field matching a member-field
+    predicate and lift chosen member fields onto this dict — e.g. surface
+    the transit leg's order as a journey-level field a card action can
+    pass into an intent payload.
+
+    Args:
+        list_field — field on this dict holding the list (required).
+        field      — member field inspected on each element (required).
+        in         — match only elements whose field (as string) is in
+                     this list.
+        not_in     — match only elements whose field is NOT in this list.
+        set        — {destination field on this dict: source field on the
+                     matched element} (required, non-empty).
+
+    Source fields missing on the match copy as absent (not None-stomped).
+    No match / missing list / bad args: no-op.
+    """
+    if not isinstance(value, dict):
+        return value
+    list_field = args.get("list_field")
+    field = args.get("field")
+    mapping = args.get("set")
+    if not list_field or not field or not isinstance(mapping, dict) or not mapping:
+        return value
+    items = value.get(list_field)
+    if not isinstance(items, list):
+        return value
+    include = args.get("in")
+    exclude = args.get("not_in")
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        member = str(item.get(field))
+        if isinstance(include, list) and member not in [str(x) for x in include]:
+            continue
+        if isinstance(exclude, list) and member in [str(x) for x in exclude]:
+            continue
+        for dst, src in mapping.items():
+            if not isinstance(dst, str) or not isinstance(src, str):
+                continue
+            if src in item:
+                value[dst] = item[src]
+        break
+    return value
+
+
+@register_transform("upcoming_times")
+def upcoming_times(value: Any, args: Dict[str, Any]) -> Any:
+    """Reduce a service-day timetable to the next departures after "now" —
+    e.g. a transit feed's ``nextAvailableTimings`` (a full-day list of
+    "HH:MM:SS" strings or ``[arrival, departure]`` pairs) into
+    "5:23 PM, 5:53 PM". Times are local clock strings in the zone given by
+    ``tz_offset``; "now" is computed in that zone at transform time.
+
+    Args:
+        field     — source list field on this dict (required). Elements:
+                    "HH:MM[:SS]" strings, or lists/tuples of them (the
+                    LAST element of a pair is used — the departure).
+        to        — destination field (required). Written ONLY when at
+                    least one upcoming time exists — bind-guards and `if`
+                    gates can rely on absence meaning "no more today".
+        count     — how many to keep (default 2).
+        tz_offset — minutes from UTC for "now" (default 0; IST = 330).
+        separator — join string (default ", ").
+        fmt       — strftime for the label (default "%-I:%M %p" — "5:23 PM").
+
+    Non-dict values / missing list / bad args: no-op.
+    """
+    if not isinstance(value, dict):
+        return value
+    src_field = args.get("field")
+    dst_field = args.get("to")
+    if not src_field or not dst_field:
+        return value
+    raw = value.get(src_field)
+    if not isinstance(raw, list):
+        return value
+    count = args.get("count", 2)
+    if not isinstance(count, int) or count < 1:
+        count = 2
+    offset = args.get("tz_offset", 0)
+    if not isinstance(offset, (int, float)):
+        offset = 0
+    fmt = args.get("fmt")
+    if not isinstance(fmt, str) or not fmt:
+        fmt = "%-I:%M %p"
+    separator = args.get("separator")
+    if not isinstance(separator, str):
+        separator = ", "
+    now_local = _utc_now() + timedelta(minutes=offset)
+    now_secs = now_local.hour * 3600 + now_local.minute * 60 + now_local.second
+
+    labels: List[str] = []
+    for entry in raw:
+        if isinstance(entry, (list, tuple)) and entry:
+            entry = entry[-1]  # [arrival, departure] → departure
+        if not isinstance(entry, str):
+            continue
+        parts = entry.split(":")
+        try:
+            h, m = int(parts[0]), int(parts[1])
+            s = int(parts[2]) if len(parts) > 2 else 0
+        except (ValueError, IndexError):
+            continue
+        if h * 3600 + m * 60 + s <= now_secs:
+            continue
+        try:
+            label = now_local.replace(hour=h % 24, minute=m, second=0).strftime(fmt)
+        except ValueError:
+            continue
+        labels.append(label)
+        if len(labels) >= count:
+            break
+    if labels:
+        value[dst_field] = separator.join(labels)
+    return value
+
+
 __all__ = [
     "TRANSFORM_REGISTRY",
     "TransformFn",
     "apply_response_transforms",
+    "coalesce",
+    "count_where",
     "derive_field",
+    "find_where",
+    "format_number",
+    "format_range",
+    "format_time",
+    "join_list",
+    "map_values",
+    "mark_extremum",
     "omit_fields",
     "pick_fields",
     "register_transform",
     "scale_by_exponent",
     "strip_html",
+    "upcoming_times",
 ]

--- a/tests/test_response_transform.py
+++ b/tests/test_response_transform.py
@@ -21,7 +21,12 @@ from app.ai.voice.agents.breeze_buddy.template.types import ResponseTransform
 
 from app.ai.voice.agents.breeze_buddy.handlers.transport.utils.response_transform import (
     apply_response_transforms,
+    count_where,
+    find_where,
+    mark_extremum,
     derive_field,
+    format_range,
+    map_values,
     omit_fields,
     pick_fields,
     scale_by_exponent,
@@ -777,3 +782,447 @@ def test_derive_field_malformed_template_is_noop():
     )
     # Original values preserved, no "out" field added.
     assert data["products"] == [{"id": "ok-1"}, {"id": "ok-2"}]
+
+
+# ---------------------------------------------------------------------------
+# map_values — display-layer value rename (scalar + list)
+# ---------------------------------------------------------------------------
+
+
+def test_map_values_scalar_and_list():
+    leg = {"mode": "Subway"}
+    map_values(
+        leg,
+        {"field": "mode", "to": "mode_display", "map": {"Subway": "Train"}},
+    )
+    assert leg["mode_display"] == "Train"
+    assert leg["mode"] == "Subway"  # source untouched
+
+    journey = {"modes": ["Walk", "Subway", "Walk"]}
+    map_values(
+        journey,
+        {"field": "modes", "to": "modes_display", "map": {"Subway": "Train"}},
+    )
+    assert journey["modes_display"] == ["Walk", "Train", "Walk"]
+
+
+def test_map_values_unmapped_keeps_original_unless_default():
+    leg = {"mode": "Metro"}
+    map_values(leg, {"field": "mode", "to": "d", "map": {"Subway": "Train"}})
+    assert leg["d"] == "Metro"
+    map_values(
+        leg,
+        {"field": "mode", "to": "d2", "map": {"Subway": "Train"}, "default": "?"},
+    )
+    assert leg["d2"] == "?"
+
+
+def test_map_values_bad_args_noop():
+    leg = {"mode": "Bus"}
+    map_values(leg, {"field": "mode", "to": "x", "map": "not-a-dict"})
+    assert "x" not in leg
+    map_values(leg, {"field": "missing", "to": "x", "map": {}})
+    assert "x" not in leg
+
+
+# ---------------------------------------------------------------------------
+# format_range — min/max display label
+# ---------------------------------------------------------------------------
+
+
+def test_format_range_equal_and_span():
+    j = {"min_fare": 30, "max_fare": 30}
+    format_range(
+        j,
+        {"min_field": "min_fare", "max_field": "max_fare", "to": "fare", "prefix": "₹"},
+    )
+    assert j["fare"] == "₹30"
+    j2 = {"min_fare": 10, "max_fare": 55}
+    format_range(
+        j2,
+        {"min_field": "min_fare", "max_field": "max_fare", "to": "fare", "prefix": "₹"},
+    )
+    assert j2["fare"] == "₹10–55"
+
+
+def test_format_range_missing_side_and_skip_zero():
+    j = {"min_fare": 15}
+    format_range(
+        j,
+        {"min_field": "min_fare", "max_field": "max_fare", "to": "fare", "prefix": "₹"},
+    )
+    assert j["fare"] == "₹15"
+    z = {"min_fare": 0, "max_fare": 0}
+    format_range(
+        z,
+        {
+            "min_field": "min_fare",
+            "max_field": "max_fare",
+            "to": "fare",
+            "prefix": "₹",
+            "skip_zero": True,
+        },
+    )
+    assert "fare" not in z
+
+
+def test_format_range_non_numeric_noop():
+    j = {"min_fare": "abc", "max_fare": 5}
+    format_range(j, {"min_field": "min_fare", "max_field": "max_fare", "to": "fare"})
+    assert "fare" not in j
+
+
+def test_format_range_from_style():
+    j = {"min_fare": 5, "max_fare": 35}
+    format_range(
+        j,
+        {
+            "min_field": "min_fare",
+            "max_field": "max_fare",
+            "to": "fare",
+            "prefix": "₹",
+            "style": "from",
+        },
+    )
+    assert j["fare"] == "from ₹5"
+    # equal bounds stay plain regardless of style
+    e = {"min_fare": 30, "max_fare": 30}
+    format_range(
+        e,
+        {
+            "min_field": "min_fare",
+            "max_field": "max_fare",
+            "to": "fare",
+            "prefix": "₹",
+            "style": "from",
+        },
+    )
+    assert e["fare"] == "₹30"
+
+
+# ---------------------------------------------------------------------------
+# mark_extremum — cross-item ranking tags (Fastest / Cheapest)
+# ---------------------------------------------------------------------------
+
+
+def test_mark_extremum_min_and_second_pass_skips_tagged():
+    data = {
+        "journeys": [
+            {"id": "a", "duration": 900, "min_fare": 40},
+            {"id": "b", "duration": 1700, "min_fare": 5},
+            {"id": "c", "duration": 2000, "min_fare": 30},
+        ]
+    }
+    mark_extremum(
+        data,
+        {
+            "list_field": "journeys",
+            "field": "duration",
+            "to": "tag",
+            "label": "Fastest",
+        },
+    )
+    mark_extremum(
+        data,
+        {
+            "list_field": "journeys",
+            "field": "min_fare",
+            "to": "tag",
+            "label": "Cheapest",
+        },
+    )
+    tags = [j.get("tag") for j in data["journeys"]]
+    assert tags == ["Fastest", "Cheapest", None]
+
+
+def test_mark_extremum_fastest_also_cheapest_stays_fastest():
+    data = {
+        "journeys": [
+            {"id": "a", "duration": 900, "min_fare": 5},
+            {"id": "b", "duration": 1700, "min_fare": 30},
+        ]
+    }
+    mark_extremum(
+        data,
+        {
+            "list_field": "journeys",
+            "field": "duration",
+            "to": "tag",
+            "label": "Fastest",
+        },
+    )
+    mark_extremum(
+        data,
+        {
+            "list_field": "journeys",
+            "field": "min_fare",
+            "to": "tag",
+            "label": "Cheapest",
+        },
+    )
+    # a took Fastest; Cheapest then goes to the best REMAINING (b)
+    assert [j.get("tag") for j in data["journeys"]] == ["Fastest", "Cheapest"]
+
+
+def test_mark_extremum_max_and_bad_values():
+    data = {"items": [{"v": "x"}, {"v": 2}, {"v": 9}]}
+    mark_extremum(
+        data,
+        {"list_field": "items", "field": "v", "mode": "max", "to": "t", "label": "Top"},
+    )
+    assert data["items"][2]["t"] == "Top"
+    # no numeric values at all → no-op
+    empty = {"items": [{"v": None}]}
+    mark_extremum(
+        empty, {"list_field": "items", "field": "v", "to": "t", "label": "Top"}
+    )
+    assert "t" not in empty["items"][0]
+
+
+# ---------------------------------------------------------------------------
+# count_where — predicate counting (transfers)
+# ---------------------------------------------------------------------------
+
+
+def test_count_where_transfers():
+    j = {
+        "legs": [{"mode": "Walk"}, {"mode": "Bus"}, {"mode": "Metro"}, {"mode": "Walk"}]
+    }
+    count_where(
+        j,
+        {
+            "list_field": "legs",
+            "field": "mode",
+            "not_in": ["Walk"],
+            "offset": -1,
+            "min": 0,
+            "to": "transfers",
+        },
+    )
+    assert j["transfers"] == 1
+    direct = {"legs": [{"mode": "Walk"}, {"mode": "Metro"}]}
+    count_where(
+        direct,
+        {
+            "list_field": "legs",
+            "field": "mode",
+            "not_in": ["Walk"],
+            "offset": -1,
+            "min": 0,
+            "to": "transfers",
+        },
+    )
+    assert direct["transfers"] == 0
+
+
+def test_count_where_in_filter_and_noop():
+    j = {"legs": [{"mode": "Bus"}, {"mode": "Bus"}, {"mode": "Walk"}]}
+    count_where(
+        j, {"list_field": "legs", "field": "mode", "in": ["Bus"], "to": "buses"}
+    )
+    assert j["buses"] == 2
+    bad = {"legs": "not-a-list"}
+    count_where(bad, {"list_field": "legs", "field": "mode", "to": "n"})
+    assert "n" not in bad
+
+
+# ---------------------------------------------------------------------------
+# find_where — first-match field lifting (transit leg order for intents)
+# ---------------------------------------------------------------------------
+
+
+def test_find_where_lifts_first_transit_leg():
+    j = {
+        "legs": [
+            {"mode": "Walk", "order": 0},
+            {"mode": "Subway", "order": 1},
+            {"mode": "Metro", "order": 2},
+        ]
+    }
+    find_where(
+        j,
+        {
+            "list_field": "legs",
+            "field": "mode",
+            "not_in": ["Walk", "Taxi"],
+            "set": {"tier_leg_order": "order", "tier_leg_found": "mode"},
+        },
+    )
+    assert j["tier_leg_order"] == 1
+    assert j["tier_leg_found"] == "Subway"
+
+
+def test_find_where_in_filter_no_match_and_noop():
+    j = {"legs": [{"mode": "Walk", "order": 0}, {"mode": "Taxi", "order": 1}]}
+    find_where(
+        j,
+        {
+            "list_field": "legs",
+            "field": "mode",
+            "in": ["Subway", "Metro", "Bus"],
+            "set": {"tier_leg_order": "order"},
+        },
+    )
+    assert "tier_leg_order" not in j
+    # zero order copies verbatim (falsy values are data, not misses)
+    z = {"legs": [{"mode": "Metro", "order": 0}]}
+    find_where(
+        z,
+        {
+            "list_field": "legs",
+            "field": "mode",
+            "not_in": ["Walk"],
+            "set": {"tier_leg_order": "order"},
+        },
+    )
+    assert z["tier_leg_order"] == 0
+    bad = {"legs": "nope"}
+    find_where(bad, {"list_field": "legs", "field": "mode", "set": {"x": "order"}})
+    assert "x" not in bad
+    # missing source field on the match: destination stays absent
+    m = {"legs": [{"mode": "Bus"}]}
+    find_where(
+        m,
+        {
+            "list_field": "legs",
+            "field": "mode",
+            "not_in": ["Walk"],
+            "set": {"tier_leg_order": "order"},
+        },
+    )
+    assert "tier_leg_order" not in m
+
+
+def test_coalesce_default_guarantees_field():
+    from app.ai.voice.agents.breeze_buddy.handlers.transport.utils.response_transform import (
+        coalesce,
+    )
+
+    absent = {}
+    coalesce(absent, {"fields": ["tier"], "to": "tier", "default": ""})
+    assert absent["tier"] == ""
+    none_val = {"tier": None}
+    coalesce(none_val, {"fields": ["tier"], "to": "tier", "default": ""})
+    assert none_val["tier"] == ""
+    present = {"tier": "FIRST_CLASS"}
+    coalesce(present, {"fields": ["tier"], "to": "tier", "default": ""})
+    assert present["tier"] == "FIRST_CLASS"
+    zero = {"n": 0}
+    coalesce(zero, {"fields": ["n"], "to": "n", "default": -1})
+    assert zero["n"] == 0
+    # no default: legacy no-op on miss
+    legacy = {}
+    coalesce(legacy, {"fields": ["missing"], "to": "out"})
+    assert "out" not in legacy
+
+
+# ---------------------------------------------------------------------------
+# upcoming_times — next departures after "now" from a service-day timetable
+# ---------------------------------------------------------------------------
+
+
+def _pin_clock(monkeypatch, hour: int, minute: int = 0):
+    """Freeze the transform module's wall clock at HH:MM UTC on a fixed
+    date so the timetable fixtures below are deterministic — the earlier
+    now()-relative version wrapped past midnight near 23:20 UTC."""
+    from datetime import datetime, timezone
+
+    import app.ai.voice.agents.breeze_buddy.handlers.transport.utils.response_transform as rt
+
+    fixed = datetime(2026, 9, 7, hour, minute, 0, tzinfo=timezone.utc)
+    monkeypatch.setattr(rt, "_utc_now", lambda: fixed)
+    return rt
+
+
+def test_upcoming_times_filters_and_formats(monkeypatch):
+    rt = _pin_clock(monkeypatch, 10, 0)  # 10:00 UTC
+
+    # pair-shaped entries: last element (departure) is used
+    d = {
+        "times": [
+            ["08:55:00", "09:00:00"],
+            ["09:55:00", "10:10:00"],
+            ["10:40:00", "10:40:00"],
+            ["11:10:00", "11:10:00"],
+        ]
+    }
+    rt.upcoming_times(d, {"field": "times", "to": "next_label", "count": 2})
+    assert d["next_label"] == "10:10 AM, 10:40 AM"
+
+    # exactly-now is not upcoming; bare strings work; count caps
+    edge = {"times": ["10:00:00", "10:05", "10:06:00", "10:07:00"]}
+    rt.upcoming_times(edge, {"field": "times", "to": "next_label", "count": 1})
+    assert edge["next_label"] == "10:05 AM"
+
+    # all in the past → field NOT written (absence = no more today)
+    gone = {"times": ["07:00:00", "09:59:59"]}
+    rt.upcoming_times(gone, {"field": "times", "to": "next_label"})
+    assert "next_label" not in gone
+
+    # malformed entries skipped; non-list no-op
+    junk = {"times": ["nope", None, 42, "10:30:00"]}
+    rt.upcoming_times(junk, {"field": "times", "to": "next_label", "count": 1})
+    assert junk["next_label"] == "10:30 AM"
+    bad = {"times": "x"}
+    rt.upcoming_times(bad, {"field": "times", "to": "n"})
+    assert "n" not in bad
+
+
+def test_upcoming_times_tz_offset_and_arg_guards(monkeypatch):
+    rt = _pin_clock(monkeypatch, 10, 0)  # 10:00 UTC == 15:30 IST
+
+    # timetable strings are local to tz_offset; "now" is computed there
+    ist = {"times": ["15:15:00", "15:45:00", "16:00:00"]}
+    rt.upcoming_times(ist, {"field": "times", "to": "n", "tz_offset": 330})
+    assert ist["n"] == "3:45 PM, 4:00 PM"
+
+    # non-string fmt / separator fall back to the documented defaults
+    # instead of raising inside strftime / join and aborting the pass
+    guarded = {"times": ["10:30:00", "10:45:00"]}
+    rt.upcoming_times(
+        guarded, {"field": "times", "to": "n", "fmt": 7, "separator": ["x"]}
+    )
+    assert guarded["n"] == "10:30 AM, 10:45 AM"
+    custom = {"times": ["10:30:00", "10:45:00"]}
+    rt.upcoming_times(
+        custom, {"field": "times", "to": "n", "fmt": "%H:%M", "separator": " / "}
+    )
+    assert custom["n"] == "10:30 / 10:45"
+
+
+# ---------------------------------------------------------------------------
+# format_number / format_time — review-found edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_format_number_ignores_non_finite_values():
+    from app.ai.voice.agents.breeze_buddy.handlers.transport.utils.response_transform import (
+        format_number,
+    )
+
+    for raw in ("nan", "inf", "-inf", float("nan"), float("inf")):
+        d = {"amount": raw}
+        assert format_number(d, {"field": "amount", "to": "label"}) is d
+        assert "label" not in d
+    ok = {"amount": "12.5"}
+    format_number(ok, {"field": "amount", "to": "label", "prefix": "₹"})
+    assert ok["label"] == "₹12"
+
+
+def test_format_time_honours_zero_offset():
+    from app.ai.voice.agents.breeze_buddy.handlers.transport.utils.response_transform import (
+        format_time,
+    )
+
+    # +05:30 source displayed in UTC: 0 is a real offset, not "unset"
+    utc = {"at": "2026-09-07T15:30:00+05:30"}
+    format_time(utc, {"field": "at", "to": "label", "tz_offset": 0})
+    assert utc["label"] == "10:00"
+    # unset offset leaves the source zone alone
+    same = {"at": "2026-09-07T15:30:00+05:30"}
+    format_time(same, {"field": "at", "to": "label"})
+    assert same["label"] == "15:30"
+    # bool is not an offset
+    boolean = {"at": "2026-09-07T15:30:00+05:30"}
+    format_time(boolean, {"field": "at", "to": "label", "tz_offset": True})
+    assert boolean["label"] == "15:30"


### PR DESCRIPTION
Registers format_number coalesce format_time join_list map_values format_range mark_extremum count_where find_where upcoming_times- all shape-level and vertical-agnostic, declared per
template in response_transforms like scale_by_exponent. They exist so a
tool result reaches the LLM (and data-bound UI) with ready-made labels
and derived fields instead of the model doing arithmetic and formatting.

Edge cases pinned by tests: format_number ignores non-finite input,
format_time honours tz_offset=0, upcoming_times coerces bad fmt/separator
and reads a pinnable clock (_utc_now) so the tests are day-boundary safe;
__all__ lists every registered transform.

**Part 2 of 7** of the split of #1039 — the review feedback from there is already incorporated. Parts 1–5 are independent of each other and of the CHAMELEON stack (5 → 6 → 7).

### Validation (this branch alone)
- `uv run pytest tests/`: 2286 passed · `pyrefly` 0 errors · black / isort / autoflake clean · migration-numbering and CRM-boundary guards OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MExhDfX8SUSdPpA8ruW4sG
