### PR TITLE
feat(transport): retry_until on HttpRequestConfig

### DIFF
--- a/app/ai/voice/agents/breeze_buddy/handlers/transport/http_handler.py
+++ b/app/ai/voice/agents/breeze_buddy/handlers/transport/http_handler.py
@@ -19,6 +19,7 @@ Uses the same resolution pattern as hooks:
 - {placeholder} resolution in http_request config
 """
 
+import asyncio
 import json
 from typing import Any, Dict, Optional, Tuple
 
@@ -36,9 +37,69 @@ from app.ai.voice.agents.breeze_buddy.template.context import TemplateContext
 from app.ai.voice.agents.breeze_buddy.template.types import (
     FieldSource,
     GlobalHttpFunction,
+    HttpRequestConfig,
+    RetryUntilConfig,
     SseResponseMode,
 )
 from app.core.logger import logger
+
+
+def _is_ready(body: str, cfg: RetryUntilConfig) -> bool:
+    """True when polling should STOP: ``cfg.field`` equals ``cfg.equals``, or
+    the body cannot be judged (unparseable, non-dict, field missing)."""
+    try:
+        current: Any = json.loads(body)
+    except (json.JSONDecodeError, TypeError):
+        return True
+    for key in cfg.field.split("."):
+        if not isinstance(current, dict) or key not in current:
+            return True
+        current = current[key]
+    return bool(current == cfg.equals)
+
+
+async def _poll_until_ready(
+    executor: HttpRequestExecutor,
+    http_request: HttpRequestConfig,
+    resolved_fields: Dict[str, Any],
+    sse_forwarder: Any,
+    first: Optional[Tuple[int, str]],
+    function_name: str,
+) -> Optional[Tuple[int, str]]:
+    """Re-issue a poll-until-ready request until ``retry_until`` holds.
+
+    Polls run without the executor's inner transport retries; a failed poll
+    ends the loop and the last successful body is returned. Non-SSE 2xx only.
+    """
+    cfg = http_request.retry_until
+    result = first
+    if cfg is None or sse_forwarder.chunks:
+        return result
+    poll = http_request.model_copy(update={"max_retries": 1})
+    for attempt in range(2, cfg.max_attempts + 1):
+        if not result or result == (0, "") or not 200 <= result[0] < 300:
+            break
+        if _is_ready(result[1], cfg):
+            break
+        logger.info(
+            f"[{function_name}] retry_until: {cfg.field!r} not ready - attempt "
+            f"{attempt}/{cfg.max_attempts} after {cfg.delay_ms}ms"
+        )
+        await asyncio.sleep(cfg.delay_ms / 1000)
+        polled = await executor.execute(
+            config=poll,
+            resolved_fields=resolved_fields,
+            fire_and_forget=False,
+            on_sse_event=sse_forwarder,
+        )
+        if not polled or polled == (0, "") or not 200 <= polled[0] < 300:
+            logger.warning(
+                f"[{function_name}] retry_until: poll attempt {attempt} failed; "
+                "keeping the last successful response"
+            )
+            break
+        result = polled
+    return result
 
 
 async def http_function_handler(
@@ -142,6 +203,18 @@ async def http_function_handler(
             fire_and_forget=False,
             on_sse_event=sse_forwarder,
         )
+
+        # Step 4b: poll-until-ready re-request (RetryUntilConfig) - only the
+        # final body continues down the pipeline.
+        if config.http_request.retry_until is not None:
+            result = await _poll_until_ready(
+                executor,
+                config.http_request,
+                resolved_fields,
+                sse_forwarder,
+                result,
+                function_name,
+            )
 
         # Step 5: Handle response
         if result is None or result == (0, ""):

--- a/app/ai/voice/agents/breeze_buddy/template/types.py
+++ b/app/ai/voice/agents/breeze_buddy/template/types.py
@@ -2485,6 +2485,32 @@ class HttpAuthConfig(BaseModel):
         return "**********"
 
 
+class RetryUntilConfig(BaseModel):
+    """Re-request a poll-until-ready endpoint until a body field is ready.
+
+    Some APIs answer 2xx immediately with "not finished yet" (async planners,
+    order status, report generation). The SAME request is re-issued until
+    ``field`` in the parsed JSON body equals ``equals`` - bounded, and
+    invisible to the LLM, which only sees the final body. GET only (the
+    request is re-issued verbatim); polls run with no transport retries, so
+    the added latency is at most ``(max_attempts - 1) * (timeout + delay_ms /
+    1000)`` seconds. Non-SSE 2xx JSON only; a failed poll keeps the last
+    successful body.
+    """
+
+    field: str = Field(
+        ...,
+        description="Dotted path into the parsed JSON body, e.g. 'allJourneysLoaded'.",
+    )
+    equals: Union[bool, int, float, str, None] = Field(
+        True, description="JSON scalar at `field` that means ready (default true)."
+    )
+    max_attempts: int = Field(
+        3, ge=2, le=5, description="TOTAL attempts including the first."
+    )
+    delay_ms: int = Field(1200, ge=100, le=10000, description="Pause between attempts.")
+
+
 class HttpRequestConfig(BaseModel):
     """Complete HTTP request configuration for hooks and global functions.
 
@@ -2507,6 +2533,18 @@ class HttpRequestConfig(BaseModel):
     auth: Optional[HttpAuthConfig] = None
     timeout: int = 10
     max_retries: int = 3
+    retry_until: Optional[RetryUntilConfig] = None
+
+    @model_validator(mode="after")
+    def _retry_until_only_on_get(self) -> "HttpRequestConfig":
+        # retry_until re-issues the request verbatim; on a mutating method
+        # that repeats the mutation, so it is refused when the config loads.
+        if self.retry_until is not None and self.method != HttpMethod.GET:
+            raise ValueError(
+                "retry_until is only allowed with method GET (the request is "
+                f"re-issued verbatim); got {self.method.value}"
+            )
+        return self
 
 
 class FieldConfig(BaseModel):

--- a/tests/test_transport_guards.py
+++ b/tests/test_transport_guards.py
@@ -1,0 +1,190 @@
+"""Guards on the template HTTP transport that a review found missing.
+
+1. SSRF: the URL validator has NO environment-dependent carve-out. Plain
+   http is refused everywhere, and a loopback target stays blocked even
+   over https — in dev exactly as in production. (An earlier draft of this
+   branch admitted plain-http loopback outside production; review removed
+   it, and this test pins the unconditional posture.)
+2. ``retry_until`` re-issues a request verbatim, so ``HttpRequestConfig``
+   refuses it on any mutating method at load time; polls run with no
+   transport retries and a failed poll keeps the last good body.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+# isort: off
+# template.types must load before the transport modules (see the note in
+# test_response_transform.py — reversing the order trips a circular import).
+from app.ai.voice.agents.breeze_buddy.template.types import (
+    HttpRequestConfig,
+    RetryUntilConfig,
+)
+
+import app.ai.voice.agents.breeze_buddy.handlers.transport.http_requester as hr
+from app.ai.voice.agents.breeze_buddy.handlers.transport.http_handler import (
+    _poll_until_ready,
+)
+
+# isort: on
+
+_validate = hr.HttpRequestExecutor._validate_resolved_url
+
+
+# ---------------------------------------------------------------------------
+# SSRF: no environment carve-out
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("env", ["dev", "development", "staging", "production"])
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://127.0.0.1:8787/pay",
+        "http://localhost/pay",
+        "http://[::1]:8787/pay",
+        "http://example.com/x",
+    ],
+)
+def test_plain_http_is_refused_in_every_environment(monkeypatch, env, url):
+    monkeypatch.setattr(hr, "ENVIRONMENT", env)
+    with pytest.raises(ValueError, match="Only HTTPS"):
+        _validate(url)
+
+
+@pytest.mark.parametrize("env", ["dev", "production"])
+def test_loopback_and_private_targets_blocked_over_https_too(monkeypatch, env):
+    monkeypatch.setattr(hr, "ENVIRONMENT", env)
+    # production refuses by hostname first ("localhost ... not allowed"),
+    # dev by address class ("loopback") — refused either way.
+    with pytest.raises(ValueError, match="not allowed"):
+        _validate("https://127.0.0.1/x")
+    with pytest.raises(ValueError, match="not allowed"):
+        _validate("https://[::1]/x")
+
+    with pytest.raises(ValueError, match="private"):
+        _validate("https://192.168.1.1/x")
+    with pytest.raises(ValueError):
+        _validate("https://169.254.169.254/latest/meta-data")
+    _validate("https://api.example.com/v1")  # public https is always fine
+
+
+# ---------------------------------------------------------------------------
+# retry_until is GET-only
+# ---------------------------------------------------------------------------
+
+
+def test_retry_until_allowed_on_get():
+    cfg = HttpRequestConfig(
+        url="https://api.example.com/journeys/{id}",
+        method="GET",
+        retry_until=RetryUntilConfig(field="allJourneysLoaded"),
+    )
+    assert cfg.retry_until is not None
+
+
+@pytest.mark.parametrize("method", ["POST", "PUT", "PATCH", "DELETE"])
+def test_retry_until_refused_on_mutating_methods(method):
+    with pytest.raises(
+        ValidationError, match="retry_until is only allowed with method GET"
+    ):
+        HttpRequestConfig(
+            url="https://api.example.com/orders",
+            method=method,
+            retry_until=RetryUntilConfig(field="ready"),
+        )
+
+
+def test_retry_until_default_method_is_post_so_it_must_be_explicit():
+    with pytest.raises(ValidationError):
+        HttpRequestConfig(
+            url="https://api.example.com/orders",
+            retry_until=RetryUntilConfig(field="ready"),
+        )
+
+
+# ---------------------------------------------------------------------------
+# retry_until: bounded polling
+# ---------------------------------------------------------------------------
+
+
+class _Executor:
+    def __init__(self, responses):
+        self.responses = list(responses)
+        self.calls: list = []
+
+    async def execute(self, *, config, resolved_fields, fire_and_forget, on_sse_event):
+        self.calls.append(config)
+        return self.responses.pop(0)
+
+
+class _Forwarder:
+    def __init__(self, chunks=None):
+        self.chunks = chunks or []
+
+
+NOT_READY = (200, '{"allJourneysLoaded": false}')
+READY = (200, '{"allJourneysLoaded": true}')
+
+
+def _cfg(**kw) -> RetryUntilConfig:
+    base = dict(field="allJourneysLoaded", delay_ms=100, max_attempts=3)
+    base.update(kw)
+    return RetryUntilConfig(**base)
+
+
+async def _poll(executor, retry_until, first, chunks=None):
+    request = HttpRequestConfig(
+        url="https://api.example.com/journeys/1",
+        method="GET",
+        timeout=10,
+        max_retries=3,
+        retry_until=retry_until,
+    )
+    return await _poll_until_ready(
+        executor,  # pyrefly: ignore[bad-argument-type]
+        request,
+        {},
+        _Forwarder(chunks),
+        first,
+        "get_journeys",
+    )
+
+
+async def test_poll_stops_when_ready_and_never_inherits_transport_retries():
+    ex = _Executor([READY])
+    assert await _poll(ex, _cfg(), NOT_READY) == READY
+    assert len(ex.calls) == 1
+    poll_request = ex.calls[0]
+    assert poll_request.max_retries == 1 and poll_request.timeout == 10
+    assert (
+        poll_request.url.endswith("/journeys/1") and poll_request.method.value == "GET"
+    )
+
+
+async def test_failed_poll_keeps_last_good_body_and_stops():
+    ex = _Executor([(0, ""), READY])
+    assert await _poll(ex, _cfg(), NOT_READY) == NOT_READY  # never a failed poll
+    assert len(ex.calls) == 1  # a failed poll ends the loop
+    ex = _Executor([(503, "upstream")])
+    assert await _poll(ex, _cfg(), NOT_READY) == NOT_READY
+
+
+async def test_no_poll_when_first_response_is_ready_failed_or_sse():
+    ex = _Executor([])
+    assert await _poll(ex, _cfg(), READY) == READY
+    assert await _poll(ex, _cfg(), (500, "boom")) == (500, "boom")
+    assert await _poll(ex, _cfg(), (0, "")) == (0, "")
+    assert await _poll(ex, _cfg(), NOT_READY, chunks=["event"]) == NOT_READY
+    assert ex.calls == []
+
+
+def test_retry_until_equals_is_a_json_scalar():
+    for ok in (True, 0, 1.5, "done", None):
+        assert RetryUntilConfig(field="f", equals=ok).equals == ok
+    with pytest.raises(ValidationError):
+        RetryUntilConfig.model_validate({"field": "f", "equals": ["ready"]})
+    with pytest.raises(ValidationError):
+        RetryUntilConfig.model_validate({"field": "f", "equals": {"ready": True}})


### PR DESCRIPTION
Content-conditional re-request for poll-until-ready endpoints (a 2xx that says "not finished yet", e.g. a journey planner's `allJourneysLoaded: false`): the same **GET** is re-issued until a body field reaches its ready value. Bounded by `max_attempts` / `delay_ms`, invisible to the LLM (only the final body continues down the pipeline), non-SSE only. Refused at load time on mutating methods; polls run without the executor's inner transport retries, and a failed poll keeps the last successful body.

Why: without it the model has to notice "not loaded yet" and call the tool again itself — an extra LLM round trip per poll, and unreliable.

**What this PR no longer contains.** An earlier revision also added `FieldSource.TOOL_RESULT` (bind a tool arg to a previous tool's result by JSON pointer). Dropped: the existing `state_reducers` + `tool_arg_injection` pair already carries a tool result into the next tool's args (the commerce `cart_id` pattern), and does so across turns. The template now uses those.

**Part 3** of the split of #1039. Independent of everything else; 3 files.

### Validation (this branch alone)
- `uv run pytest tests/`: 2436 passed · `pyrefly` 0 errors · black / isort / autoflake clean · guards OK.
- `tests/test_transport_guards.py` pins: GET-only validation, `equals` is a JSON scalar, the poll loop (stops when ready, no inner retries on polls, failed poll keeps the last good body, no polling on SSE / non-2xx), and the URL validator's HTTPS-only / loopback-blocked posture in every environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MExhDfX8SUSdPpA8ruW4sG
