### PR TITLE
feat(widget): response_reveal surface field

### DIFF
--- a/app/ai/voice/agents/breeze_buddy/template/field_reference.json
+++ b/app/ai/voice/agents/breeze_buddy/template/field_reference.json
@@ -431,6 +431,10 @@
       "description": "Whether the free-text composer is visible to the user. Default true. Set false to restrict input to quick-reply buttons only (bot-driven or menu-style flows).",
       "example": true
     },
+    "response_reveal": {
+      "description": "How the widget reveals assistant prose. 'stream' (default) = paced typewriter as tokens arrive. 'complete' = a typing indicator while the reply is in flight, then the full message at once (Messenger style). Presentation-only: the SSE transport streams either way.",
+      "example": "complete"
+    },
     "wake_phrase": {
       "description": "Require the user to say a trigger phrase before the bot responds. Useful for IVR-style consent flows. phrases: list of accepted trigger words. single_activation: if true, phrase required only once per session.",
       "example": {

--- a/app/ai/voice/agents/breeze_buddy/template/types.py
+++ b/app/ai/voice/agents/breeze_buddy/template/types.py
@@ -1999,6 +1999,16 @@ class ConfigurationModel(BaseModel):
             "agent-driven input is possible."
         ),
     )
+    response_reveal: Literal["stream", "complete"] = Field(
+        "stream",
+        description=(
+            "How the widget reveals assistant prose. 'stream' (default) = "
+            "paced typewriter as tokens arrive. 'complete' = a typing "
+            "indicator while the reply is in flight, then the full message "
+            "at once (Messenger style). Presentation-only: the SSE "
+            "transport streams either way."
+        ),
+    )
     ivr_configuration: Optional[IvrConfig] = None  # IVR-specific configuration
     # DEPRECATED: Use ivr_configuration.greeting / ivr_configuration.goodbye / ivr_configuration.priority
     ivr_greeting: Optional[str] = None

--- a/app/api/routers/breeze_buddy/widget/handlers.py
+++ b/app/api/routers/breeze_buddy/widget/handlers.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 
 import uuid
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Literal, Optional
 
 from fastapi import HTTPException, Request, UploadFile, status
 
@@ -181,6 +181,7 @@ class _WidgetSurface:
     quick_replies: List[QuickReplyWire] = field(default_factory=list)
     enable_text_input: bool = True
     greeting_tiles: List[GreetingTileWire] = field(default_factory=list)
+    response_reveal: Literal["stream", "complete"] = "stream"
 
 
 def _extract_widget_config(template: object) -> _WidgetSurface:
@@ -215,6 +216,7 @@ def _extract_widget_config(template: object) -> _WidgetSurface:
             GreetingTileWire(label=t.label, prompt=t.prompt, image_url=t.image_url)
             for t in (getattr(configurations, "greeting_tiles", None) or [])
         ],
+        response_reveal=getattr(configurations, "response_reveal", "stream"),
     )
 
 
@@ -234,6 +236,7 @@ def _surface_wire(
         quick_replies=surface.quick_replies,
         greeting_tiles=surface.greeting_tiles,
         enable_text_input=surface.enable_text_input,
+        response_reveal=surface.response_reveal,
         voice_enabled=_template_voice_enabled(template),
         catalog_active=catalog_active,
         ui_flavors=ui_flavors,

--- a/app/schemas/breeze_buddy/chat.py
+++ b/app/schemas/breeze_buddy/chat.py
@@ -7,7 +7,7 @@ analytics over voice + chat use the same field semantics.
 
 from datetime import datetime
 from enum import Enum
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Literal, Optional
 
 from pydantic import BaseModel, Field, model_validator
 
@@ -541,6 +541,14 @@ class WidgetSurfaceWire(BaseModel):
     )
     enable_text_input: bool = Field(
         True, description="False hides the composer (pills/tiles only)."
+    )
+    response_reveal: Literal["stream", "complete"] = Field(
+        "stream",
+        description=(
+            "'stream' (default) = typewriter reveal as tokens arrive; "
+            "'complete' = typing indicator until the reply finalizes, then "
+            "the full message at once. Presentation-only — SSE still streams."
+        ),
     )
     voice_enabled: bool = Field(
         False,

--- a/tests/test_response_reveal.py
+++ b/tests/test_response_reveal.py
@@ -1,0 +1,43 @@
+"""``response_reveal``: template field → widget surface block, presentation-only."""
+
+from __future__ import annotations
+
+import inspect
+from types import SimpleNamespace
+
+import pytest
+from pydantic import ValidationError
+
+from app.ai.voice.agents.breeze_buddy.template.types import ConfigurationModel
+from app.api.routers.breeze_buddy.widget.handlers import (
+    _extract_widget_config,
+    _surface_wire,
+)
+from app.schemas.breeze_buddy.chat import WidgetSurfaceWire
+
+
+def test_template_field_defaults_to_stream_and_is_closed():
+    assert ConfigurationModel().response_reveal == "stream"
+    assert ConfigurationModel(response_reveal="complete").response_reveal == "complete"
+    with pytest.raises(ValidationError):
+        ConfigurationModel.model_validate({"response_reveal": "instant"})
+
+
+async def test_surface_block_carries_the_template_value():
+    template = SimpleNamespace(
+        configurations=ConfigurationModel(response_reveal="complete"),
+        supported_channels=["chat"],
+    )
+    surface = _extract_widget_config(template)
+    assert surface.response_reveal == "complete"
+    # The builder is sync today and becomes async once the session overlay
+    # lands (it fetches registry defs); this test must pass on both sides
+    # of that merge, whichever order the two PRs land in.
+    block = _surface_wire(surface, template, catalog_active="v1", ui_flavors=[])
+    if inspect.isawaitable(block):
+        block = await block
+    assert block.response_reveal == "complete"
+    # absent configurations → the wire default, never a missing key
+    bare = _extract_widget_config(SimpleNamespace(configurations=None))
+    assert bare.response_reveal == "stream"
+    assert WidgetSurfaceWire().response_reveal == "stream"


### PR DESCRIPTION
ConfigurationModel.response_reveal ('stream' | 'complete', default
'stream') tells the embed how to reveal assistant prose: paced typewriter
as tokens arrive, or a typing indicator until the reply finalizes and then
the full message at once (Messenger style). Presentation-only - the SSE
transport streams either way. Rides on the one widget surface block so
create, resume and demo responses all carry it.

**Part 4 of 7** of the split of #1039 — the review feedback from there is already incorporated. Parts 1–5 are independent of each other and of the CHAMELEON stack (5 → 6 → 7).

### Validation (this branch alone)
- `uv run pytest tests/`: 2269 passed · `pyrefly` 0 errors · black / isort / autoflake clean · migration-numbering and CRM-boundary guards OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MExhDfX8SUSdPpA8ruW4sG
