### PR TITLE
feat(chameleon): ui_component registry - custom components as data

### DIFF
--- a/app/ai/voice/agents/breeze_buddy/chat/ui/custom_defs.py
+++ b/app/ai/voice/agents/breeze_buddy/chat/ui/custom_defs.py
@@ -1,0 +1,432 @@
+"""Custom-component registry: write-time guards + session-scoped hydration.
+
+CHAMELEON — merchant-specific components as DATA (``ui_component`` rows,
+migration 070). Two halves, both pure (no DB, no agent state):
+
+- **Registration guards** (:func:`validate_registration`): name shape and
+  built-in collision, JSON-Schema well-formedness, flag rules (v1:
+  data-bound only, no literal fields), and the ``render_def`` grammar lint.
+  The registry API calls this before any write; rejected defs never reach
+  a session.
+- **Hydration** (:func:`resolve_custom_show_op`): mirrors
+  ``binding.resolve_show_op`` for defs that live outside ``UI_CATALOG`` —
+  same BindingStore pointer-walk (THIS turn only), single-object→list
+  lift, ``items[]`` selection, caps — but validates the hydrated props
+  against the def's **JSON Schema** instead of a Pydantic class. Every
+  RFC-001 trust invariant survives: values come only from this turn's
+  validated tool results; the model authors selectors, never values.
+
+Isolation: nothing here is process-global. Defs arrive per-session on the
+``ChatAgent`` (``custom_components`` constructor arg) — two merchants on
+the same worker never see each other's definitions.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Dict, List, Optional
+
+from jsonschema import Draft202012Validator
+from jsonschema.exceptions import SchemaError
+
+from app.ai.voice.agents.breeze_buddy.chat.ui.binding import (
+    parse_bind_ref,
+    resolve_json_pointer,
+)
+from app.ai.voice.agents.breeze_buddy.chat.ui.stream import OpResult
+from app.ai.voice.agents.breeze_buddy.template.types import CustomComponentDef
+from app.ai.voice.agents.breeze_buddy.template.ui_catalog import (
+    LAZY_GROUPS,
+    UI_CATALOG,
+    ensure_group_loaded,
+)
+
+# ---------------------------------------------------------------------------
+# render_def grammar v1 (shared contract with the widget's declarative
+# interpreter — packages/breeze-buddy-assist-widget declarative module)
+# ---------------------------------------------------------------------------
+
+# Structural node vocabulary. The interpreter drops unknown types at render
+# time (never heals); the lint rejects them at write time so authors find
+# out immediately.
+RENDER_DEF_NODE_TYPES = frozenset(
+    {
+        "box",  # container; props.direction: row|col, gap, wrap, align
+        "row",  # sugar: box direction=row
+        "col",  # sugar: box direction=col
+        "text",  # props.value (interpolatable), props.variant
+        "badge",  # small emphasized text chip; props.value, props.tone
+        "chip",  # alias of badge with pill styling
+        "image",  # props.src (interpolatable), props.alt
+        "button",  # props.label, props.variant, props.action
+        "divider",
+    }
+)
+
+RENDER_DEF_MAX_DEPTH = 8
+RENDER_DEF_MAX_NODES = 400
+
+_NAME_RE = re.compile(r"^[A-Z][A-Za-z0-9]{1,63}$")
+_BINDING_RE = re.compile(r"^\$[A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z0-9_]+)*$")
+_ACTION_TYPES = frozenset({"to_assistant", "open_url", "open_detail"})
+
+
+def _lint_action(action: Any, path: str, errors: List[str]) -> None:
+    if not isinstance(action, dict):
+        errors.append(f"{path}: action must be an object")
+        return
+    a_type = action.get("type")
+    if a_type not in _ACTION_TYPES:
+        errors.append(f"{path}: action.type must be one of {sorted(_ACTION_TYPES)}")
+        return
+    if a_type == "to_assistant":
+        if not isinstance(action.get("msg"), str) or not action["msg"].strip():
+            errors.append(f"{path}: to_assistant action needs a non-empty msg")
+    if a_type == "open_url":
+        url = action.get("url")
+        if not isinstance(url, str) or not url:
+            errors.append(f"{path}: open_url action needs a url")
+        # A static URL must be https; a bound/interpolated URL resolves to
+        # tool data at render time (the interpreter re-checks scheme).
+        elif "{" not in url and not url.startswith("$"):
+            if not url.startswith("https://"):
+                errors.append(f"{path}: static open_url urls must be https")
+    if a_type == "open_detail":
+        # Opens the widget's detail overlay rendering ANOTHER registry
+        # component with props hydrated CLIENT-side from the current
+        # scope. The component name must be a static PascalCase name —
+        # never a binding — so data can't choose which def paints
+        # full-page; the widget additionally drops names not in the
+        # session's def registry.
+        component = action.get("component")
+        if not isinstance(component, str) or not _NAME_RE.match(component):
+            errors.append(
+                f"{path}: open_detail action needs a static PascalCase component"
+            )
+        props = action.get("props")
+        if props is not None and not isinstance(props, dict):
+            errors.append(f"{path}: open_detail action props must be an object")
+        title = action.get("title")
+        if title is not None and not isinstance(title, str):
+            errors.append(f"{path}: open_detail action title must be a string")
+
+
+def _lint_node(
+    node: Any, depth: int, path: str, counter: List[int], errors: List[str]
+) -> None:
+    if counter[0] > RENDER_DEF_MAX_NODES:
+        return  # already reported
+    if depth > RENDER_DEF_MAX_DEPTH:
+        errors.append(f"{path}: exceeds max depth {RENDER_DEF_MAX_DEPTH}")
+        return
+    if not isinstance(node, dict):
+        errors.append(f"{path}: node must be an object")
+        return
+    counter[0] += 1
+    if counter[0] > RENDER_DEF_MAX_NODES:
+        errors.append(f"render_def exceeds {RENDER_DEF_MAX_NODES} nodes")
+        return
+    n_type = node.get("type")
+    if n_type not in RENDER_DEF_NODE_TYPES:
+        errors.append(
+            f"{path}: unknown node type {n_type!r} "
+            f"(allowed: {sorted(RENDER_DEF_NODE_TYPES)})"
+        )
+    repeat = node.get("repeat")
+    if repeat is not None:
+        if not isinstance(repeat, dict):
+            errors.append(f"{path}: repeat must be an object")
+        else:
+            src = repeat.get("in")
+            if not (isinstance(src, str) and _BINDING_RE.match(src)):
+                errors.append(
+                    f"{path}: repeat.in must be a binding like '$props.journeys'"
+                )
+            as_name = repeat.get("as")
+            if not (
+                isinstance(as_name, str) and re.match(r"^[a-z][A-Za-z0-9_]*$", as_name)
+            ):
+                errors.append(f"{path}: repeat.as must be a lowercase identifier")
+    cond = node.get("if")
+    if cond is not None and not (isinstance(cond, str) and _BINDING_RE.match(cond)):
+        errors.append(f"{path}: 'if' must be a binding like '$item.route'")
+    cls = node.get("class")
+    if cls is not None and not isinstance(cls, str):
+        errors.append(f"{path}: class must be a string")
+    props = node.get("props")
+    if props is not None and not isinstance(props, dict):
+        errors.append(f"{path}: props must be an object")
+    if isinstance(props, dict) and "action" in props:
+        _lint_action(props["action"], f"{path}.props.action", errors)
+    children = node.get("children")
+    if children is not None:
+        if not isinstance(children, list):
+            errors.append(f"{path}: children must be an array")
+        else:
+            for i, child in enumerate(children):
+                _lint_node(child, depth + 1, f"{path}.children[{i}]", counter, errors)
+
+
+def lint_render_def(render_def: Any) -> List[str]:
+    """Lint a render_def tree. Empty list = clean.
+
+    Grammar v1: whitelisted node types, ``repeat``/``if`` binding syntax,
+    depth ≤ {depth}, ≤ {nodes} nodes, actions restricted to
+    ``to_assistant``/``open_url``/``open_detail`` (static
+    open_url URLs https-only; open_detail components static
+    PascalCase). No
+    merchant JavaScript, no arbitrary expressions — ever.
+    """.format(depth=RENDER_DEF_MAX_DEPTH, nodes=RENDER_DEF_MAX_NODES)
+    errors: List[str] = []
+    _lint_node(render_def, 1, "$", [0], errors)
+    return errors
+
+
+# ---------------------------------------------------------------------------
+# Registration guards (write path)
+# ---------------------------------------------------------------------------
+
+
+def builtin_component_names() -> set:
+    """Every name a custom component may NOT take: the full built-in
+    catalog including every lazy flavor group — each group is loaded at
+    check time, so the check can't pass just because commerce hasn't been
+    imported yet in this process."""
+    for group in LAZY_GROUPS:
+
+        ensure_group_loaded(group)
+    return set(UI_CATALOG.keys())
+
+
+def validate_registration(
+    *,
+    name: str,
+    props_schema: Dict[str, Any],
+    flags: Dict[str, Any],
+    render_def: Optional[Dict[str, Any]],
+) -> List[str]:
+    """All write-time guard errors for one registration. Empty = accept."""
+    errors: List[str] = []
+    if not _NAME_RE.match(name or ""):
+        errors.append(
+            "name must be PascalCase (letters/digits, starting uppercase, "
+            "2-64 chars)"
+        )
+    elif name in builtin_component_names():
+        errors.append(f"name {name!r} collides with a built-in component")
+
+    try:
+        Draft202012Validator.check_schema(props_schema)
+    except SchemaError as exc:
+        errors.append(f"props_schema is not valid JSON Schema: {exc.message}")
+
+    if flags.get("data_bound") is False:
+        errors.append("flags.data_bound must be true in v1 (data-bound only)")
+    if flags.get("literal_fields"):
+        # v1: no literal fields — the engine's fail-closed gate would drop
+        # them anyway (no flavor verifier exists for custom components).
+        errors.append("flags.literal_fields is not supported for custom components")
+    sel = flags.get("selection_field")
+    if sel is not None and not isinstance(sel, str):
+        errors.append("flags.selection_field must be a string prop name")
+    list_props = flags.get("list_props")
+    if list_props is not None and not (
+        isinstance(list_props, list) and all(isinstance(p, str) for p in list_props)
+    ):
+        errors.append("flags.list_props must be a list of prop names")
+    for cap in ("max_items_default", "max_items_limit"):
+        value = flags.get(cap)
+        if value is not None and not (isinstance(value, int) and value > 0):
+            errors.append(f"flags.{cap} must be a positive integer")
+    if flags.get("overlay_only") and render_def is None:
+        # overlay_only removes the def from the model's vocabulary, so a
+        # render_def is its ONLY way to ever paint — without one the row
+        # is dead weight on every session surface.
+        errors.append("flags.overlay_only requires a render_def")
+
+    if render_def is not None:
+        errors.extend(lint_render_def(render_def))
+    return errors
+
+
+# ---------------------------------------------------------------------------
+# Hydration (render path) — mirrors binding.resolve_show_op
+# ---------------------------------------------------------------------------
+
+
+def _schema_expects_list(props_schema: Dict[str, Any], prop: str) -> bool:
+    """True when the def's schema types ``prop`` as an array (drives the
+    single-object→list lift, mirroring the Pydantic-annotation check)."""
+    spec = (props_schema.get("properties") or {}).get(prop)
+    if not isinstance(spec, dict):
+        return False
+    s_type = spec.get("type")
+    if s_type == "array":
+        return True
+    if isinstance(s_type, list) and "array" in s_type:
+        return True
+    return any(
+        isinstance(variant, dict) and variant.get("type") == "array"
+        for variant in (spec.get("anyOf") or []) + (spec.get("oneOf") or [])
+    )
+
+
+def _apply_selection(
+    hydrated: Dict[str, Any],
+    def_: CustomComponentDef,
+) -> None:
+    """Model-directed ``items[]`` selection over the def's list props —
+    id-matching only, selection order, fail-open on zero matches (the
+    full tool list beats an empty render on a model-mangled id).
+    Runs before capping; the selection directive itself is popped from
+    the output by the caller."""
+    sel_field = def_.flags.selection_field
+    if not sel_field:
+        return
+    raw = hydrated.get(sel_field)
+    if not isinstance(raw, list):
+        return
+    ids: List[str] = []
+    for entry in raw:
+        if isinstance(entry, str) and entry:
+            ids.append(entry)
+        elif (
+            isinstance(entry, dict) and isinstance(entry.get("id"), str) and entry["id"]
+        ):
+            ids.append(entry["id"])
+    if not ids:
+        return
+    for key in def_.flags.list_props:
+        value = hydrated.get(key)
+        if not isinstance(value, list):
+            continue
+        by_id: Dict[str, Any] = {}
+        for entry in value:
+            if isinstance(entry, dict) and isinstance(entry.get("id"), str):
+                by_id.setdefault(entry["id"], entry)
+        selected = [by_id[i] for i in ids if i in by_id]
+        if selected:
+            hydrated[key] = selected
+
+
+def _apply_caps(hydrated: Dict[str, Any], def_: CustomComponentDef) -> None:
+    """Cap bound list props: op-level ``max_items`` (or the def default),
+    hard-bounded by ``max_items_limit``."""
+    flags = def_.flags
+    raw = hydrated.get("max_items", flags.max_items_default)
+    cap = raw if isinstance(raw, int) and raw > 0 else None
+    if flags.max_items_limit is not None:
+        cap = min(cap, flags.max_items_limit) if cap else flags.max_items_limit
+    if cap is None:
+        return
+    for key in flags.list_props:
+        value = hydrated.get(key)
+        if isinstance(value, list) and len(value) > cap:
+            hydrated[key] = value[:cap]
+
+
+def resolve_custom_show_op(
+    op: Dict[str, Any],
+    store: Any,
+    def_: CustomComponentDef,
+) -> OpResult:
+    """Hydrate one custom-component ``show`` op against this turn's
+    binding store, validated by the def's JSON Schema.
+
+    Same shape and invariants as ``binding.resolve_show_op``; error
+    strings are structural-only (paths + validator names, never values).
+    """
+    bind = op.get("bind") or {}
+    props = op.get("props") or {}
+    hydrated: Dict[str, Any] = dict(props)
+    for prop, ref in bind.items():
+        parsed = parse_bind_ref(ref)
+        if parsed is None:
+            return OpResult(error=f"bad_bind_ref:{prop}")
+        payload = store.resolve(parsed.tool_name, parsed.tool_use_id)
+        if payload is None:
+            return OpResult(
+                error=f"bind_unresolved:{parsed.tool_name}:{parsed.pointer}"
+            )
+        value, found = resolve_json_pointer(payload, parsed.pointer)
+        if not found or value is None:
+            return OpResult(
+                error=f"bind_unresolved:{parsed.tool_name}:{parsed.pointer}"
+            )
+        if isinstance(value, dict) and (
+            prop in def_.flags.list_props
+            or _schema_expects_list(def_.props_schema, prop)
+        ):
+            value = [value]
+        hydrated[prop] = value
+
+    _apply_selection(hydrated, def_)
+    _apply_caps(hydrated, def_)
+
+    # Directives, not render props — keep them out of validation and off
+    # the wire (mirrors resolve_show_op's selection_field pop).
+    sel_field = def_.flags.selection_field
+    if sel_field:
+        hydrated.pop(sel_field, None)
+    hydrated.pop("max_items", None)
+
+    validator = Draft202012Validator(def_.props_schema)
+    schema_errors = sorted(validator.iter_errors(hydrated), key=lambda e: e.json_path)
+    if schema_errors:
+        details = ";".join(
+            f"{err.json_path}:{err.validator}" for err in schema_errors[:5]
+        )
+        return OpResult(error=f"bind_validation_failed:{def_.name}:{details}")
+
+    hydrated_op: Dict[str, Any] = {
+        "op": "add",
+        "id": op.get("id"),
+        "type": def_.name,
+        "props": hydrated,
+        "v": 2,
+    }
+    parent = op.get("parent")
+    if isinstance(parent, str) and parent:
+        hydrated_op["parent"] = parent
+    return OpResult(op=hydrated_op)
+
+
+def summarize_custom_render(
+    def_: CustomComponentDef, hydrated_props: Dict[str, Any]
+) -> Dict[str, Any]:
+    """Function-response summary for a custom render — the model's UI
+    memory. Echoes id/title-ish referents from the def's list props
+    (capped) so cross-turn references ("the second option") keep working,
+    mirroring the commerce summarizer's shape."""
+    result: Dict[str, Any] = {"status": "ok", "rendered": def_.name}
+    for key in def_.flags.list_props:
+        value = hydrated_props.get(key)
+        if not isinstance(value, list):
+            continue
+        result["count"] = len(value)
+        referents: List[Dict[str, Any]] = []
+        for entry in value[:8]:
+            if not isinstance(entry, dict):
+                continue
+            ref: Dict[str, Any] = {}
+            for field in ("id", "title", "name", "summary", "label"):
+                if isinstance(entry.get(field), (str, int, float)):
+                    ref[field] = entry[field]
+            if ref:
+                referents.append(ref)
+        if referents:
+            result[key] = referents
+        break
+    return result
+
+
+__all__ = [
+    "RENDER_DEF_MAX_DEPTH",
+    "RENDER_DEF_MAX_NODES",
+    "RENDER_DEF_NODE_TYPES",
+    "builtin_component_names",
+    "lint_render_def",
+    "resolve_custom_show_op",
+    "summarize_custom_render",
+    "validate_registration",
+]

--- a/app/ai/voice/agents/breeze_buddy/template/types.py
+++ b/app/ai/voice/agents/breeze_buddy/template/types.py
@@ -1247,6 +1247,64 @@ class McpConfig(BaseModel):
     )
 
 
+class CustomComponentFlags(BaseModel):
+    """Engine-read behavior flags of one registry component (the ``flags``
+    JSONB of a ``ui_component`` row, migration 070).
+
+    v1 keeps the surface deliberately small: custom components are
+    data-bound render_ui components only — no literal fields (the engine's
+    fail-closed gate would drop them anyway), no DIRECT intents.
+    """
+
+    data_bound: bool = Field(
+        True,
+        description="Must be true in v1 — custom components hydrate from "
+        "this turn's tool results, never from model-authored values.",
+    )
+    selection_field: Optional[str] = Field(
+        None,
+        description="Prop name that carries the model's items[] selection "
+        "(id-matching over bound list entries), e.g. 'journeys'.",
+    )
+    list_props: List[str] = Field(
+        default_factory=list,
+        description="Props that hydrate as lists (selection + caps apply; "
+        "a single bound object lifts to a one-element list).",
+    )
+    max_items_default: Optional[int] = Field(
+        None,
+        description="Default cap on bound list length when the op "
+        "carries no max_items.",
+    )
+    max_items_limit: Optional[int] = Field(
+        None,
+        description="Hard ceiling on bound list length regardless of "
+        "the op's max_items.",
+    )
+    overlay_only: bool = Field(
+        False,
+        description=(
+            "True = the component is a CLIENT-side render target only "
+            "(opened by another component's open_detail action in the "
+            "widget's detail overlay). It ships to the widget with the "
+            "session surface but is EXCLUDED from the model's render_ui "
+            "vocabulary — the model can never paint it in-thread."
+        ),
+    )
+
+
+class CustomComponentDef(BaseModel):
+    """One resolved registry component as the session overlay carries it
+    (decoded off a ``ui_component`` row; immutable per version)."""
+
+    name: str
+    version: int = 1
+    props_schema: Dict[str, Any]
+    flags: CustomComponentFlags = Field(default_factory=CustomComponentFlags)
+    render_def: Optional[Dict[str, Any]] = None
+    prompt_hint: Optional[str] = None
+
+
 class UiCatalogConfig(BaseModel):
     """Per-template selection of which generative-UI primitives the LLM
     may emit and the widget will render.

--- a/app/api/routers/breeze_buddy/__init__.py
+++ b/app/api/routers/breeze_buddy/__init__.py
@@ -49,6 +49,7 @@ from app.api.routers.breeze_buddy.template_generator import (
 from app.api.routers.breeze_buddy.templates import router as templates_router
 from app.api.routers.breeze_buddy.topics import router as topics_router
 from app.api.routers.breeze_buddy.tts_catalog import router as tts_catalog_router
+from app.api.routers.breeze_buddy.ui_components import router as ui_components_router
 from app.api.routers.breeze_buddy.users import router as users_router
 from app.api.routers.breeze_buddy.wallet import router as wallet_router
 from app.api.routers.breeze_buddy.webhooks import router as webhooks_router
@@ -157,4 +158,6 @@ router.include_router(chat_router, prefix="", tags=["chat"])
 # - widget_config: per-merchant config (admin/reseller-scoped CRUD)
 # - widget: unified /widget/session/* conversation router (chat ↔ voice)
 router.include_router(widget_config_router, prefix="", tags=["widget-config"])
+# - ui_components: CHAMELEON custom-component registry (migration 070)
+router.include_router(ui_components_router, prefix="", tags=["ui-components"])
 router.include_router(widget_router, prefix="", tags=["widget-session"])

--- a/app/api/routers/breeze_buddy/ui_components/__init__.py
+++ b/app/api/routers/breeze_buddy/ui_components/__init__.py
@@ -1,0 +1,109 @@
+"""RBAC-gated CRUD for ui_component rows (migration 070, CHAMELEON).
+
+Five endpoints under ``/agent/voice/breeze-buddy/ui-components``:
+
+- ``POST   /ui-components``            — register (admin / scoped reseller)
+- ``GET    /ui-components/list``       — list (RBAC-filtered)
+- ``GET    /ui-components/{id}``       — get by id
+- ``PUT    /ui-components/{id}``       — partial update (bumps version)
+- ``DELETE /ui-components/{id}``       — delete (admin only)
+
+Mirrors the widget_config router — thin routes that validate auth + RBAC,
+then delegate to handlers. Every write runs the registration guards
+(``chat/ui/custom_defs.validate_registration``): name shape + built-in
+collision, JSON-Schema well-formedness, v1 flag rules, render_def lint.
+"""
+
+from typing import Optional
+
+from fastapi import APIRouter, Depends, Query, status
+
+from app.api.security.breeze_buddy.rbac_token import get_current_user_with_rbac
+from app.core.security.authorization import require_admin
+from app.schemas import UserInfo
+from app.schemas.breeze_buddy.ui_component import (
+    UiComponentCreate,
+    UiComponentListResponse,
+    UiComponentResponse,
+    UiComponentUpdate,
+)
+
+from .handlers import (
+    DeleteUiComponentResponse,
+    create_ui_component_handler,
+    delete_ui_component_handler,
+    get_ui_component_by_id_handler,
+    list_ui_components_handler,
+    update_ui_component_handler,
+)
+
+router = APIRouter()
+
+
+@router.post(
+    "/ui-components",
+    status_code=status.HTTP_201_CREATED,
+    response_model=UiComponentResponse,
+)
+async def create_ui_component(
+    body: UiComponentCreate,
+    current_user: UserInfo = Depends(get_current_user_with_rbac),
+) -> UiComponentResponse:
+    """Register a custom component. 400 with the full guard-error list on
+    any registration violation."""
+    return await create_ui_component_handler(body, current_user)
+
+
+@router.get("/ui-components/list", response_model=UiComponentListResponse)
+async def list_ui_components(
+    reseller_id: Optional[str] = Query(None),
+    merchant_id: Optional[str] = Query(None),
+    include_inactive: bool = Query(False),
+    page: int = Query(1, ge=1),
+    limit: int = Query(50, ge=1, le=200),
+    current_user: UserInfo = Depends(get_current_user_with_rbac),
+) -> UiComponentListResponse:
+    """List ui_components visible to the caller (RBAC-filtered)."""
+    return await list_ui_components_handler(
+        reseller_id=reseller_id,
+        merchant_id=merchant_id,
+        include_inactive=include_inactive,
+        page=page,
+        limit=limit,
+        current_user=current_user,
+    )
+
+
+@router.get("/ui-components/{ui_component_id}", response_model=UiComponentResponse)
+async def get_ui_component(
+    ui_component_id: str,
+    current_user: UserInfo = Depends(get_current_user_with_rbac),
+) -> UiComponentResponse:
+    """Get a ui_component by id (403 outside the caller's scope)."""
+    return await get_ui_component_by_id_handler(ui_component_id, current_user)
+
+
+@router.put("/ui-components/{ui_component_id}", response_model=UiComponentResponse)
+async def update_ui_component(
+    ui_component_id: str,
+    body: UiComponentUpdate,
+    current_user: UserInfo = Depends(get_current_user_with_rbac),
+) -> UiComponentResponse:
+    """Partial update; every real change bumps ``version``. Guards re-run
+    on the merged row."""
+    return await update_ui_component_handler(ui_component_id, body, current_user)
+
+
+@router.delete(
+    "/ui-components/{ui_component_id}", response_model=DeleteUiComponentResponse
+)
+async def delete_ui_component(
+    ui_component_id: str,
+    current_user: UserInfo = Depends(get_current_user_with_rbac),
+) -> DeleteUiComponentResponse:
+    """Delete a ui_component row. Admin only (matches templates DELETE)."""
+    require_admin(current_user)
+    return await delete_ui_component_handler(ui_component_id, current_user)
+
+
+__all__ = ["router"]

--- a/app/api/routers/breeze_buddy/ui_components/handlers.py
+++ b/app/api/routers/breeze_buddy/ui_components/handlers.py
@@ -1,0 +1,215 @@
+"""Business logic for ui_component CRUD (migration 070, CHAMELEON).
+
+All handlers run after the route layer has validated the user's RBAC
+token. Reseller/merchant scoping is enforced via
+``validate_template_access`` (same predicate semantics as templates and
+widget_config). Every write runs the registration guards from
+``chat/ui/custom_defs.py`` — a def that fails them never reaches a
+session.
+"""
+
+from typing import List, Optional
+
+from fastapi import HTTPException, status
+from pydantic import BaseModel
+
+from app.ai.voice.agents.breeze_buddy.chat.ui.custom_defs import (
+    validate_registration,
+)
+from app.api.routers.breeze_buddy.templates.rbac import validate_template_access
+from app.core.logger import logger
+from app.database.accessor.breeze_buddy.ui_component import (
+    create_ui_component,
+    delete_ui_component,
+    get_ui_component_by_id,
+    list_ui_components,
+    update_ui_component,
+)
+from app.schemas import UserInfo
+from app.schemas.breeze_buddy.ui_component import (
+    UiComponentCreate,
+    UiComponentListResponse,
+    UiComponentResponse,
+    UiComponentUpdate,
+)
+
+
+class DeleteUiComponentResponse(BaseModel):
+    deleted: bool
+    id: str
+
+
+# Update fields backed by NOT NULL columns — an explicit null is a 400.
+_NON_NULLABLE_FIELDS = ("props_schema", "flags", "is_active")
+
+
+async def create_ui_component_handler(
+    body: UiComponentCreate, current_user: UserInfo
+) -> UiComponentResponse:
+    logger.info(
+        f"User {current_user.username} (role: {current_user.role}) registering "
+        f"ui_component {body.name!r} for reseller={body.reseller_id} "
+        f"merchant={body.merchant_id}"
+    )
+    validate_template_access(
+        current_user,
+        body.reseller_id,
+        body.merchant_id,
+        operation="create ui_component",
+    )
+    errors = validate_registration(
+        name=body.name,
+        props_schema=body.props_schema,
+        flags=body.flags,
+        render_def=body.render_def,
+    )
+    if errors:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={"registration_errors": errors},
+        )
+    try:
+        created = await create_ui_component(
+            reseller_id=body.reseller_id,
+            merchant_id=body.merchant_id,
+            name=body.name,
+            props_schema=body.props_schema,
+            flags=body.flags,
+            render_def=body.render_def,
+            prompt_hint=body.prompt_hint,
+            is_active=body.is_active,
+        )
+    except Exception as exc:
+        if "ui_component_scope_name_unique" in str(exc):
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail=(
+                    f"ui_component {body.name!r} already exists in this "
+                    "scope. Update the existing row instead."
+                ),
+            )
+        raise
+    if not created:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to create ui_component",
+        )
+    return created
+
+
+async def _fetch_scoped(
+    ui_component_id: str, current_user: UserInfo, operation: str
+) -> UiComponentResponse:
+    row = await get_ui_component_by_id(ui_component_id)
+    if not row:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"ui_component '{ui_component_id}' not found",
+        )
+    validate_template_access(
+        current_user, row.reseller_id, row.merchant_id, operation=operation
+    )
+    return row
+
+
+async def get_ui_component_by_id_handler(
+    ui_component_id: str, current_user: UserInfo
+) -> UiComponentResponse:
+    return await _fetch_scoped(ui_component_id, current_user, "read ui_component")
+
+
+async def list_ui_components_handler(
+    *,
+    reseller_id: Optional[str],
+    merchant_id: Optional[str],
+    include_inactive: bool,
+    page: int,
+    limit: int,
+    current_user: UserInfo,
+) -> UiComponentListResponse:
+    """RBAC-aware listing, same shape as ``list_widget_configs_handler``.
+
+    Admins see everything. Non-admins are scoped to their accessible
+    resellers AND merchants — both allowlists reach the query, which
+    filters BEFORE pagination and the total. Reseller-wide rows
+    (``merchant_id IS NULL``) stay visible to anyone with reseller access,
+    matching ``filter_templates_by_rbac``. Asking for a specific
+    reseller_id / merchant_id outside the caller's scope is a 403.
+    """
+    accessible_reseller_ids: Optional[List[str]] = None
+    accessible_merchant_ids: Optional[List[str]] = None
+    if current_user.role != "admin":
+        if "*" not in current_user.reseller_ids:
+            accessible_reseller_ids = current_user.reseller_ids
+            if reseller_id and reseller_id not in current_user.reseller_ids:
+                raise HTTPException(
+                    status_code=status.HTTP_403_FORBIDDEN,
+                    detail=f"Access denied to reseller {reseller_id}",
+                )
+        if "*" not in current_user.merchant_ids:
+            accessible_merchant_ids = current_user.merchant_ids
+            if merchant_id and merchant_id not in current_user.merchant_ids:
+                raise HTTPException(
+                    status_code=status.HTTP_403_FORBIDDEN,
+                    detail=f"Access denied to merchant {merchant_id}",
+                )
+    items, total = await list_ui_components(
+        page=page,
+        limit=limit,
+        reseller_id=reseller_id,
+        merchant_id=merchant_id,
+        reseller_ids=accessible_reseller_ids,
+        merchant_ids=accessible_merchant_ids,
+        include_inactive=include_inactive,
+    )
+    return UiComponentListResponse(ui_components=items, total=total, page=page)
+
+
+async def update_ui_component_handler(
+    ui_component_id: str, body: UiComponentUpdate, current_user: UserInfo
+) -> UiComponentResponse:
+    row = await _fetch_scoped(ui_component_id, current_user, "update ui_component")
+    # Presence decides what changes, not None-ness: a field omitted from
+    # the body is untouched; a field sent as null clears it. Only the
+    # nullable columns may be cleared.
+    patch = body.model_dump(exclude_unset=True)
+    nulled = [k for k in _NON_NULLABLE_FIELDS if k in patch and patch[k] is None]
+    if nulled:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"{', '.join(nulled)} cannot be null",
+        )
+    # Guards re-run on the MERGED row — a partial update cannot sneak an
+    # invalid schema or def past registration (clearing render_def on an
+    # overlay_only def fails here exactly as it would at create time).
+    errors = validate_registration(
+        name=row.name,
+        props_schema=patch.get("props_schema", row.props_schema),
+        flags=patch.get("flags", row.flags),
+        render_def=patch.get("render_def", row.render_def),
+    )
+    # The stored name already passed the collision check at create time;
+    # re-running it against the (now-registered) built-ins can only
+    # re-flag a legitimate name if a flavor later ships the same one —
+    # in that case the update is the right place to hear about it.
+    if errors:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={"registration_errors": errors},
+        )
+    updated = await update_ui_component(ui_component_id, patch)
+
+    if not updated:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to update ui_component",
+        )
+    return updated
+
+
+async def delete_ui_component_handler(
+    ui_component_id: str, current_user: UserInfo
+) -> DeleteUiComponentResponse:
+    await _fetch_scoped(ui_component_id, current_user, "delete ui_component")
+    deleted = await delete_ui_component(ui_component_id)
+    return DeleteUiComponentResponse(deleted=deleted, id=ui_component_id)

--- a/app/database/accessor/breeze_buddy/ui_component.py
+++ b/app/database/accessor/breeze_buddy/ui_component.py
@@ -1,0 +1,179 @@
+"""Async accessor functions for ui_component (migration 070).
+
+Thin wrappers around ``run_parameterized_query`` + ``decode_ui_component``.
+Returns Pydantic models, never raw rows. Errors are logged + re-raised so
+route handlers can convert them into the appropriate HTTP status.
+"""
+
+import json
+from typing import Any, Dict, List, Optional, Tuple
+
+from app.core.logger import logger
+from app.database.decoder.breeze_buddy.ui_component import decode_ui_component
+from app.database.queries import run_parameterized_query
+from app.database.queries.breeze_buddy.ui_component import (
+    create_ui_component_query,
+    delete_ui_component_query,
+    get_ui_component_by_id_query,
+    get_ui_components_by_names_query,
+    list_ui_components_query,
+    update_ui_component_query,
+)
+from app.schemas.breeze_buddy.ui_component import UiComponentResponse
+
+# Columns stored as JSONB — serialised on the way in; NULL passes through.
+_JSONB_COLUMNS = frozenset({"props_schema", "flags", "render_def"})
+
+
+async def create_ui_component(
+    *,
+    reseller_id: str,
+    merchant_id: Optional[str],
+    name: str,
+    props_schema: Dict[str, Any],
+    flags: Dict[str, Any],
+    render_def: Optional[Dict[str, Any]],
+    prompt_hint: Optional[str],
+    is_active: bool = True,
+) -> Optional[UiComponentResponse]:
+    query, values = create_ui_component_query(
+        reseller_id=reseller_id,
+        merchant_id=merchant_id,
+        name=name,
+        props_schema=json.dumps(props_schema),
+        flags=json.dumps(flags),
+        render_def=json.dumps(render_def) if render_def is not None else None,
+        prompt_hint=prompt_hint,
+        is_active=is_active,
+    )
+    try:
+        result = await run_parameterized_query(query, values)
+        row = result[0] if result else None
+        if row:
+            logger.info(
+                f"Created ui_component: reseller={reseller_id} "
+                f"merchant={merchant_id} name={name} id={row['id']}"
+            )
+            return decode_ui_component(row)
+        return None
+    except Exception as e:
+        logger.error(
+            f"Error creating ui_component {name!r} for reseller={reseller_id} "
+            f"merchant={merchant_id}: {e}"
+        )
+        raise
+
+
+async def get_ui_component_by_id(
+    ui_component_id: str,
+) -> Optional[UiComponentResponse]:
+    query, values = get_ui_component_by_id_query(ui_component_id)
+    try:
+        result = await run_parameterized_query(query, values)
+        row = result[0] if result else None
+        return decode_ui_component(row) if row else None
+    except Exception as e:
+        logger.error(f"Error fetching ui_component {ui_component_id}: {e}")
+        raise
+
+
+async def get_ui_components_by_names(
+    *,
+    reseller_id: str,
+    merchant_id: Optional[str],
+    names: List[str],
+) -> List[UiComponentResponse]:
+    """Session-start def fetch: active rows for the template's opt-in names
+    (merchant-specific rows shadow reseller-wide ones). Missing names are
+    simply absent from the result — the caller decides whether that's an
+    error or a silently-narrower catalog."""
+    if not names:
+        return []
+    query, values = get_ui_components_by_names_query(
+        reseller_id=reseller_id, merchant_id=merchant_id, names=names
+    )
+    try:
+        rows = await run_parameterized_query(query, values)
+        return [decode_ui_component(r) for r in rows] if rows else []
+    except Exception as e:
+        logger.error(
+            f"Error fetching ui_components {names} for reseller={reseller_id} "
+            f"merchant={merchant_id}: {e}"
+        )
+        raise
+
+
+async def list_ui_components(
+    *,
+    page: int = 1,
+    limit: int = 50,
+    reseller_id: Optional[str] = None,
+    merchant_id: Optional[str] = None,
+    reseller_ids: Optional[List[str]] = None,
+    merchant_ids: Optional[List[str]] = None,
+    include_inactive: bool = False,
+) -> Tuple[List[UiComponentResponse], int]:
+    query, count_query, values = list_ui_components_query(
+        page=page,
+        limit=limit,
+        reseller_id=reseller_id,
+        merchant_id=merchant_id,
+        reseller_ids=reseller_ids,
+        merchant_ids=merchant_ids,
+        include_inactive=include_inactive,
+    )
+    try:
+        rows = await run_parameterized_query(query, values)
+        count_result = await run_parameterized_query(count_query, values[:-2])
+        count_row = count_result[0] if count_result else None
+        items = [decode_ui_component(r) for r in rows] if rows else []
+        total = count_row["total"] if count_row else 0
+        return items, total
+    except Exception as e:
+        logger.error(f"Error listing ui_components: {e}")
+        raise
+
+
+async def update_ui_component(
+    ui_component_id: str,
+    patch: Dict[str, Any],
+) -> Optional[UiComponentResponse]:
+    """``patch`` holds ONLY the columns the caller supplied (Pydantic
+    ``exclude_unset``); a key present with ``None`` writes SQL NULL."""
+    query, values = update_ui_component_query(
+        ui_component_id=ui_component_id,
+        patch={
+            column: (
+                json.dumps(new_value)
+                if column in _JSONB_COLUMNS and new_value is not None
+                else new_value
+            )
+            for column, new_value in patch.items()
+        },
+    )
+    if not values:
+
+        return await get_ui_component_by_id(ui_component_id)
+    try:
+        result = await run_parameterized_query(query, values)
+        row = result[0] if result else None
+        if row:
+            logger.info(f"Updated ui_component: {ui_component_id}")
+            return decode_ui_component(row)
+        return None
+    except Exception as e:
+        logger.error(f"Error updating ui_component {ui_component_id}: {e}")
+        raise
+
+
+async def delete_ui_component(ui_component_id: str) -> bool:
+    query, values = delete_ui_component_query(ui_component_id)
+    try:
+        result = await run_parameterized_query(query, values)
+        deleted = bool(result)
+        if deleted:
+            logger.info(f"Deleted ui_component: {ui_component_id}")
+        return deleted
+    except Exception as e:
+        logger.error(f"Error deleting ui_component {ui_component_id}: {e}")
+        raise

--- a/app/database/decoder/breeze_buddy/ui_component.py
+++ b/app/database/decoder/breeze_buddy/ui_component.py
@@ -1,0 +1,33 @@
+"""Row → Pydantic decoder for ui_component (migration 070)."""
+
+import json
+from typing import Any, Dict, Optional
+
+from app.schemas.breeze_buddy.ui_component import UiComponentResponse
+
+
+def _jsonb(value: Any) -> Optional[Dict[str, Any]]:
+    """asyncpg returns JSONB as str without a codec — accept both."""
+    if value is None:
+        return None
+    if isinstance(value, str):
+        return json.loads(value)
+    return value
+
+
+def decode_ui_component(row) -> UiComponentResponse:
+    """Build UiComponentResponse from a ui_component asyncpg Record."""
+    return UiComponentResponse(
+        id=str(row["id"]),
+        reseller_id=row["reseller_id"],
+        merchant_id=row["merchant_id"],
+        name=row["name"],
+        version=row["version"],
+        props_schema=_jsonb(row["props_schema"]) or {},
+        flags=_jsonb(row["flags"]) or {},
+        render_def=_jsonb(row["render_def"]),
+        prompt_hint=row["prompt_hint"],
+        is_active=row.get("is_active", True),
+        created_at=row.get("created_at"),
+        updated_at=row.get("updated_at"),
+    )

--- a/app/database/migrations/070_create_ui_component.sql
+++ b/app/database/migrations/070_create_ui_component.sql
@@ -1,0 +1,56 @@
+-- ===========================================================================
+-- 070: ui_component — merchant-scoped custom UI component registry
+-- ---------------------------------------------------------------------------
+-- CHAMELEON: custom components as DATA. A row defines one merchant-specific
+-- component (e.g. Chennai One's JourneyOptions): a JSON-Schema contract for
+-- its hydrated props, behavioral flags the engine reads (selection field,
+-- list caps), and an OPTIONAL declarative render_def our widget interprets.
+-- Backend-only merchants (own frontend) leave render_def NULL.
+--
+-- Visibility is per-session data: a template opts in via
+-- configurations.ui_catalog.custom_components = ["JourneyOptions", ...];
+-- the chat agent overlays the named rows onto its session-scoped catalog.
+-- Nothing process-global changes — two merchants on the same worker never
+-- see each other's definitions.
+-- ===========================================================================
+
+CREATE TABLE IF NOT EXISTS ui_component (
+    id            uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    reseller_id   varchar(255) NOT NULL,
+    -- NULL = reseller-wide component (usable by any of the reseller's
+    -- templates that opt in by name).
+    merchant_id   varchar(255),
+    -- PascalCase component type, unique per scope (see index below). The
+    -- write path additionally rejects collisions with built-in catalog and
+    -- flavor component names.
+    name          varchar(128) NOT NULL,
+    -- Bumped on every update; hydrated ops and def caches key on it.
+    version       integer NOT NULL DEFAULT 1,
+    -- JSON Schema (draft 2020-12) for the component's hydrated props.
+    props_schema  jsonb NOT NULL,
+    -- Engine-read behavior: {"data_bound": true, "selection_field": "...",
+    -- "list_props": [...], "max_items_default": n, "max_items_limit": n}.
+    flags         jsonb NOT NULL DEFAULT '{}'::jsonb,
+    -- Declarative render tree for OUR widget/skins. NULL for merchants
+    -- rendering with their own frontend.
+    render_def    jsonb,
+    -- One or two sentences spliced into render_ui's bind coaching when the
+    -- component is offered ("Use JourneyOptions after search_journeys ...").
+    prompt_hint   text,
+    is_active     boolean NOT NULL DEFAULT TRUE,
+    created_at    timestamptz NOT NULL DEFAULT now(),
+    updated_at    timestamptz NOT NULL DEFAULT now(),
+    CONSTRAINT ui_component_version_positive CHECK (version > 0)
+);
+
+-- Uniqueness per (reseller, merchant, name) with NULL merchant folded to ''
+-- so a reseller-wide name can't be re-registered as a merchant row twice.
+CREATE UNIQUE INDEX IF NOT EXISTS ui_component_scope_name_unique
+    ON ui_component (reseller_id, COALESCE(merchant_id, ''), name);
+
+-- Session-start lookup (get_ui_components_by_names_query): reseller + name on
+-- ACTIVE rows only, so the is_active filter is answered by the index instead
+-- of a post-scan filter step.
+CREATE INDEX IF NOT EXISTS ui_component_active_lookup
+    ON ui_component (reseller_id, name)
+    WHERE is_active = TRUE;

--- a/app/database/queries/breeze_buddy/ui_component.py
+++ b/app/database/queries/breeze_buddy/ui_component.py
@@ -1,0 +1,195 @@
+"""SQL builders for ui_component (migration 070).
+
+Pure functions; no DB I/O. Returns ``Tuple[str, List[Any]]`` for
+``run_parameterized_query``. JSONB values arrive as JSON strings and are
+cast with ``::jsonb`` (same convention as the template queries).
+"""
+
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional, Tuple
+
+UI_COMPONENT_TABLE = "ui_component"
+
+_COLUMNS = (
+    "id, reseller_id, merchant_id, name, version, props_schema, flags, "
+    "render_def, prompt_hint, is_active, created_at, updated_at"
+)
+
+
+def create_ui_component_query(
+    *,
+    reseller_id: str,
+    merchant_id: Optional[str],
+    name: str,
+    props_schema: str,
+    flags: str,
+    render_def: Optional[str],
+    prompt_hint: Optional[str],
+    is_active: bool,
+) -> Tuple[str, List[Any]]:
+    query = f"""
+        INSERT INTO {UI_COMPONENT_TABLE} (
+            reseller_id, merchant_id, name, props_schema, flags,
+            render_def, prompt_hint, is_active, created_at, updated_at
+        ) VALUES (
+            $1, $2, $3, $4::jsonb, $5::jsonb, $6::jsonb, $7, $8, $9, $10
+        )
+        RETURNING {_COLUMNS}
+    """
+    now = datetime.now(timezone.utc)
+    return query, [
+        reseller_id,
+        merchant_id,
+        name,
+        props_schema,
+        flags,
+        render_def,
+        prompt_hint,
+        bool(is_active),
+        now,
+        now,
+    ]
+
+
+def get_ui_component_by_id_query(ui_component_id: str) -> Tuple[str, List[Any]]:
+    query = f"""
+        SELECT {_COLUMNS}
+        FROM {UI_COMPONENT_TABLE}
+        WHERE id = $1::uuid
+    """
+    return query, [ui_component_id]
+
+
+def get_ui_components_by_names_query(
+    *,
+    reseller_id: str,
+    merchant_id: Optional[str],
+    names: List[str],
+) -> Tuple[str, List[Any]]:
+    """Session-start def fetch: active rows matching the template's opt-in
+    names, scoped to the template's reseller — merchant rows win over
+    reseller-wide rows of the same name (ORDER + DISTINCT ON)."""
+    query = f"""
+        SELECT DISTINCT ON (name) {_COLUMNS}
+        FROM {UI_COMPONENT_TABLE}
+        WHERE reseller_id = $1
+          AND name = ANY($2)
+          AND is_active = TRUE
+          AND (merchant_id IS NULL OR merchant_id = $3)
+        ORDER BY name, merchant_id NULLS LAST
+    """
+    return query, [reseller_id, list(names), merchant_id or ""]
+
+
+def list_ui_components_query(
+    *,
+    page: int = 1,
+    limit: int = 50,
+    reseller_id: Optional[str] = None,
+    merchant_id: Optional[str] = None,
+    reseller_ids: Optional[List[str]] = None,
+    merchant_ids: Optional[List[str]] = None,
+    include_inactive: bool = False,
+) -> Tuple[str, str, List[Any]]:
+    """Returns (query, count_query, values) — same composition rules as
+    ``list_widget_configs_query``, except that the ``merchant_ids``
+    allowlist also admits reseller-wide rows (NULL merchant)."""
+    where: List[str] = []
+    params: List[Any] = []
+    idx = 1
+
+    if reseller_id:
+        where.append(f"reseller_id = ${idx}")
+        params.append(reseller_id)
+        idx += 1
+    elif reseller_ids is not None:
+        where.append(f"reseller_id = ANY(${idx})")
+        params.append(reseller_ids)
+        idx += 1
+
+    if merchant_id:
+        where.append(f"merchant_id = ${idx}")
+        params.append(merchant_id)
+        idx += 1
+    elif merchant_ids is not None:
+        # Reseller-wide rows are visible to anyone with reseller access —
+        # the same rule filter_templates_by_rbac applies to templates.
+        where.append(f"(merchant_id IS NULL OR merchant_id = ANY(${idx}))")
+        params.append(merchant_ids)
+        idx += 1
+
+    if not include_inactive:
+        where.append("is_active = TRUE")
+
+    where_clause = f"WHERE {' AND '.join(where)}" if where else ""
+    offset = max(page - 1, 0) * limit
+
+    query = f"""
+        SELECT {_COLUMNS}
+        FROM {UI_COMPONENT_TABLE}
+        {where_clause}
+        ORDER BY created_at DESC
+        LIMIT ${idx} OFFSET ${idx + 1}
+    """
+    count_query = f"SELECT COUNT(*) AS total FROM {UI_COMPONENT_TABLE} {where_clause}"
+    params.extend([limit, offset])
+    return query, count_query, params
+
+
+# Column → parameter cast for UPDATE. This allowlist is what keeps ``patch``
+# keys out of the SQL text: unknown keys are ignored, values are always $N.
+_UPDATABLE_COLUMNS = {
+    "props_schema": "::jsonb",
+    "flags": "::jsonb",
+    "render_def": "::jsonb",
+    "prompt_hint": "",
+    "is_active": "",
+}
+
+
+def update_ui_component_query(
+    *,
+    ui_component_id: str,
+    patch: Dict[str, Any],
+) -> Tuple[str, List[Any]]:
+    """``patch`` maps column → new value for ONLY the columns the caller
+    supplied; a ``None`` value writes NULL (the handler has already
+    refused null for NOT NULL columns). Returns ("", []) when nothing
+    updatable was supplied. Every real update bumps ``version`` —
+    hydrated ops and def caches key on it."""
+    set_clauses: List[str] = []
+    params: List[Any] = []
+    idx = 1
+
+    for column, cast in _UPDATABLE_COLUMNS.items():
+        if column not in patch:
+            continue
+        set_clauses.append(f"{column} = ${idx}{cast}")
+        params.append(patch[column])
+        idx += 1
+
+    if not set_clauses:
+        return "", []
+
+    set_clauses.append("version = version + 1")
+    set_clauses.append(f"updated_at = ${idx}")
+    params.append(datetime.now(timezone.utc))
+    idx += 1
+
+    params.append(ui_component_id)
+    query = f"""
+        UPDATE {UI_COMPONENT_TABLE}
+        SET {', '.join(set_clauses)}
+        WHERE id = ${idx}::uuid
+        RETURNING {_COLUMNS}
+    """
+    return query, params
+
+
+def delete_ui_component_query(ui_component_id: str) -> Tuple[str, List[Any]]:
+    query = f"""
+        DELETE FROM {UI_COMPONENT_TABLE}
+        WHERE id = $1::uuid
+        RETURNING id
+    """
+    return query, [ui_component_id]

--- a/app/schemas/breeze_buddy/ui_component.py
+++ b/app/schemas/breeze_buddy/ui_component.py
@@ -1,0 +1,86 @@
+"""Pydantic models for ui_component rows (migration 070).
+
+The custom-component registry: merchant-specific UI components stored as
+DATA — a JSON-Schema props contract, engine-read flags, and an optional
+declarative ``render_def`` the widget interprets. See
+``ai/voice/agents/breeze_buddy/chat/ui/custom_defs.py`` for the write-time
+guards and the hydration path.
+"""
+
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, Field
+
+
+class UiComponentCreate(BaseModel):
+    """Body of ``POST /ui-components``."""
+
+    reseller_id: str = Field(..., min_length=1, max_length=255)
+    merchant_id: Optional[str] = Field(
+        None,
+        max_length=255,
+        description="NULL/omitted = reseller-wide component.",
+    )
+    name: str = Field(..., min_length=1, max_length=128)
+    props_schema: Dict[str, Any] = Field(
+        ..., description="JSON Schema (draft 2020-12) for the hydrated props."
+    )
+    flags: Dict[str, Any] = Field(
+        default_factory=dict,
+        description=(
+            "Engine flags: data_bound (must be true), selection_field, "
+            "list_props, max_items_default, max_items_limit."
+        ),
+    )
+    render_def: Optional[Dict[str, Any]] = Field(
+        None,
+        description=(
+            "Declarative render tree for our widget/skins. A row without one "
+            "is registered but never offered to the model or shipped to the "
+            "widget (reserved for merchants rendering with their own frontend)."
+        ),
+    )
+    prompt_hint: Optional[str] = Field(None, max_length=2000)
+    is_active: bool = True
+
+
+class UiComponentUpdate(BaseModel):
+    """Body of ``PUT /ui-components/{id}``.
+
+    Presence semantics (PATCH-style): a field omitted from the body is left
+    untouched; a field sent as ``null`` clears it — allowed for the nullable
+    columns (``render_def``, ``prompt_hint``), a 400 for the rest. Every
+    real update bumps ``version``.
+    """
+
+    props_schema: Optional[Dict[str, Any]] = None
+    flags: Optional[Dict[str, Any]] = None
+    render_def: Optional[Dict[str, Any]] = None
+    prompt_hint: Optional[str] = Field(None, max_length=2000)
+    is_active: Optional[bool] = None
+
+
+class UiComponentResponse(BaseModel):
+    """One ui_component row."""
+
+    id: str
+    reseller_id: str
+    merchant_id: Optional[str] = None
+    name: str
+    version: int = 1
+    props_schema: Dict[str, Any]
+    flags: Dict[str, Any] = Field(default_factory=dict)
+    render_def: Optional[Dict[str, Any]] = None
+    prompt_hint: Optional[str] = None
+    is_active: bool = True
+    created_at: Optional[datetime] = None
+    updated_at: Optional[datetime] = None
+
+
+class UiComponentListResponse(BaseModel):
+    """Body of ``GET /ui-components``."""
+
+    ui_components: List[UiComponentResponse]
+    total: int
+    page: int = 1

--- a/tests/test_custom_defs.py
+++ b/tests/test_custom_defs.py
@@ -1,0 +1,324 @@
+"""CHAMELEON custom-component registry: guards + hydration + LLM surface.
+
+Covers the pure halves of the feature (no DB, no agent):
+- registration guards (name, schema, flags, render_def lint)
+- resolve_custom_show_op (pointer walk, object lift, selection, caps,
+  JSON-Schema validation with structural-only errors)
+- render_ui enum joining + execute routing (two-merchant isolation lives
+  here too: a def not passed in is simply unknown)
+"""
+
+from typing import Any, Dict
+
+import pytest
+
+from app.ai.voice.agents.breeze_buddy.chat.ui.binding import BindingStore
+from app.ai.voice.agents.breeze_buddy.chat.ui.custom_defs import (
+    lint_render_def,
+    resolve_custom_show_op,
+    summarize_custom_render,
+    validate_registration,
+)
+from app.ai.voice.agents.breeze_buddy.template.types import (
+    CustomComponentDef,
+    CustomComponentFlags,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+JOURNEY_SCHEMA: Dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "journeys": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "id": {"type": "string"},
+                    "summary": {"type": "string"},
+                    "duration_label": {"type": "string"},
+                    "min_fare_label": {"type": "string"},
+                },
+                "required": ["id"],
+            },
+        },
+    },
+    "required": ["journeys"],
+}
+
+
+def journey_def(**flag_overrides) -> CustomComponentDef:
+    flags = {
+        "data_bound": True,
+        "selection_field": "items",
+        "list_props": ["journeys"],
+        "max_items_default": 4,
+        "max_items_limit": 8,
+        **flag_overrides,
+    }
+    return CustomComponentDef(
+        name="JourneyOptions",
+        version=1,
+        props_schema=JOURNEY_SCHEMA,
+        flags=CustomComponentFlags.model_validate(flags),
+        render_def={"type": "col", "children": []},
+        prompt_hint="Bind journeys to $tool:search_journeys#/journeys",
+    )
+
+
+def store_with(tool: str, payload: Any) -> BindingStore:
+    store = BindingStore()
+    assert store.record(tool, "t1", payload)
+    return store
+
+
+JOURNEYS = [
+    {"id": "j1", "summary": "Metro via Alandur", "duration_label": "51 min"},
+    {"id": "j2", "summary": "Bus 570", "duration_label": "64 min"},
+    {"id": "j3", "summary": "Metro + walk", "duration_label": "58 min"},
+]
+
+
+# ---------------------------------------------------------------------------
+# Registration guards
+# ---------------------------------------------------------------------------
+
+
+class TestRegistrationGuards:
+    def test_clean_registration_passes(self):
+        assert (
+            validate_registration(
+                name="JourneyOptions",
+                props_schema=JOURNEY_SCHEMA,
+                flags={"data_bound": True},
+                render_def={"type": "col", "children": [{"type": "text"}]},
+            )
+            == []
+        )
+
+    def test_overlay_only_requires_render_def(self):
+        errors = validate_registration(
+            name="JourneyDetail",
+            props_schema=JOURNEY_SCHEMA,
+            flags={"data_bound": True, "overlay_only": True},
+            render_def=None,
+        )
+        assert any("overlay_only requires a render_def" in e for e in errors)
+
+    @pytest.mark.parametrize("bad", ["journeyOptions", "J", "Has Spaces", "x" * 70])
+    def test_name_must_be_pascal_case(self, bad):
+        errors = validate_registration(
+            name=bad, props_schema={}, flags={}, render_def=None
+        )
+        assert any("PascalCase" in e for e in errors)
+
+    def test_builtin_collision_rejected(self):
+        for taken in ("Card", "ProductGrid", "QuickReplies"):
+            errors = validate_registration(
+                name=taken, props_schema={}, flags={}, render_def=None
+            )
+            assert any("collides" in e for e in errors), taken
+
+    def test_invalid_json_schema_rejected(self):
+        errors = validate_registration(
+            name="GoodName",
+            props_schema={"type": "not-a-type"},
+            flags={},
+            render_def=None,
+        )
+        assert any("JSON Schema" in e for e in errors)
+
+    def test_literal_fields_rejected(self):
+        errors = validate_registration(
+            name="GoodName",
+            props_schema={},
+            flags={"literal_fields": ["eta"]},
+            render_def=None,
+        )
+        assert any("literal_fields" in e for e in errors)
+
+    def test_data_bound_false_rejected(self):
+        errors = validate_registration(
+            name="GoodName",
+            props_schema={},
+            flags={"data_bound": False},
+            render_def=None,
+        )
+        assert any("data_bound" in e for e in errors)
+
+
+class TestRenderDefLint:
+    def test_unknown_node_type(self):
+        assert any(
+            "unknown node type" in e
+            for e in lint_render_def({"type": "script", "children": []})
+        )
+
+    def test_depth_cap(self):
+        node: Dict[str, Any] = {"type": "text"}
+        for _ in range(10):
+            node = {"type": "box", "children": [node]}
+        assert any("depth" in e for e in lint_render_def(node))
+
+    def test_static_open_url_must_be_https(self):
+        bad = {
+            "type": "button",
+            "props": {
+                "label": "Go",
+                "action": {"type": "open_url", "url": "http://x.example/y"},
+            },
+        }
+        assert any("https" in e for e in lint_render_def(bad))
+        good = dict(
+            bad,
+            props={
+                "label": "Go",
+                "action": {"type": "open_url", "url": "https://x.example/y"},
+            },
+        )
+        assert lint_render_def(good) == []
+
+    def test_bound_open_url_allowed(self):
+        node = {
+            "type": "button",
+            "props": {
+                "label": "Ticket",
+                "action": {"type": "open_url", "url": "{$props.ticket_url}"},
+            },
+        }
+        assert lint_render_def(node) == []
+
+    def test_open_detail_component_must_be_static_pascal(self):
+        bad = {
+            "type": "button",
+            "props": {
+                "label": "View details",
+                "action": {"type": "open_detail", "component": "{$props.c}"},
+            },
+        }
+        assert any("PascalCase" in e for e in lint_render_def(bad))
+        good = {
+            "type": "button",
+            "props": {
+                "label": "View details",
+                "action": {
+                    "type": "open_detail",
+                    "component": "JourneyDetail",
+                    "title": "Your journey",
+                    "props": {"journey_id": "{$j.id}", "legs": "$j.legs"},
+                },
+            },
+        }
+        assert lint_render_def(good) == []
+
+    def test_open_detail_props_must_be_object(self):
+        bad = {
+            "type": "button",
+            "props": {
+                "label": "x",
+                "action": {
+                    "type": "open_detail",
+                    "component": "JourneyDetail",
+                    "props": ["not", "an", "object"],
+                },
+            },
+        }
+        assert any("props must be an object" in e for e in lint_render_def(bad))
+
+    def test_repeat_binding_syntax(self):
+        bad = {"type": "box", "repeat": {"in": "journeys", "as": "j"}}
+        assert any("repeat.in" in e for e in lint_render_def(bad))
+        good = {"type": "box", "repeat": {"in": "$props.journeys", "as": "j"}}
+        assert lint_render_def(good) == []
+
+    def test_to_assistant_needs_msg(self):
+        node = {
+            "type": "button",
+            "props": {"label": "Pick", "action": {"type": "to_assistant"}},
+        }
+        assert any("msg" in e for e in lint_render_def(node))
+
+
+# ---------------------------------------------------------------------------
+# Hydration
+# ---------------------------------------------------------------------------
+
+
+def _ok(result) -> Dict[str, Any]:
+    assert result.error is None, result.error
+    assert result.op is not None
+    return result.op
+
+
+def _err(result) -> str:
+    assert result.op is None
+    assert result.error is not None
+    return result.error
+
+
+class TestResolveCustomShowOp:
+    def _op(self, **overrides) -> Dict[str, Any]:
+        op = {
+            "op": "show",
+            "id": "root",
+            "component": "JourneyOptions",
+            "bind": {"journeys": "$tool:search_journeys#/journeys"},
+            "props": {},
+        }
+        op.update(overrides)
+        return op
+
+    def test_happy_path_hydrates(self):
+        store = store_with("search_journeys", {"journeys": JOURNEYS})
+        op = _ok(resolve_custom_show_op(self._op(), store, journey_def()))
+        assert op["type"] == "JourneyOptions"
+        assert op["v"] == 2
+        assert [j["id"] for j in op["props"]["journeys"]] == ["j1", "j2", "j3"]
+
+    def test_missing_tool_drops(self):
+        error = _err(resolve_custom_show_op(self._op(), BindingStore(), journey_def()))
+        assert error.startswith("bind_unresolved:")
+
+    def test_selection_order_respected(self):
+        store = store_with("search_journeys", {"journeys": JOURNEYS})
+        show = self._op(props={"items": [{"id": "j3"}, {"id": "j1"}]})
+        op = _ok(resolve_custom_show_op(show, store, journey_def()))
+        assert [j["id"] for j in op["props"]["journeys"]] == ["j3", "j1"]
+        assert "items" not in op["props"]
+
+    def test_mangled_selection_fails_open(self):
+        store = store_with("search_journeys", {"journeys": JOURNEYS})
+        show = self._op(props={"items": [{"id": "nope"}]})
+        op = _ok(resolve_custom_show_op(show, store, journey_def()))
+        assert len(op["props"]["journeys"]) == 3
+
+    def test_caps_apply(self):
+        many = [{"id": f"j{i}", "summary": "s"} for i in range(12)]
+        store = store_with("search_journeys", {"journeys": many})
+        op = _ok(resolve_custom_show_op(self._op(), store, journey_def()))
+        assert len(op["props"]["journeys"]) == 4  # max_items_default
+        show = self._op(props={"max_items": 20})
+        op = _ok(resolve_custom_show_op(show, store, journey_def()))
+        assert len(op["props"]["journeys"]) == 8  # max_items_limit
+        assert "max_items" not in op["props"]
+
+    def test_single_object_lifts_to_list(self):
+        store = store_with("search_journeys", {"journeys": JOURNEYS[0]})
+        op = _ok(resolve_custom_show_op(self._op(), store, journey_def()))
+        assert [j["id"] for j in op["props"]["journeys"]] == ["j1"]
+
+    def test_schema_validation_structural_only(self):
+        store = store_with("search_journeys", {"journeys": [{"summary": 42}]})
+        error = _err(resolve_custom_show_op(self._op(), store, journey_def()))
+        assert error.startswith("bind_validation_failed:JourneyOptions:")
+        assert "42" not in error  # never echo values
+
+    def test_summary_echoes_referents(self):
+        store = store_with("search_journeys", {"journeys": JOURNEYS})
+        op = _ok(resolve_custom_show_op(self._op(), store, journey_def()))
+        summary = summarize_custom_render(journey_def(), op["props"])
+        assert summary["rendered"] == "JourneyOptions"
+        assert summary["count"] == 3
+        assert summary["journeys"][0]["id"] == "j1"

--- a/tests/test_ui_components_rbac.py
+++ b/tests/test_ui_components_rbac.py
@@ -1,0 +1,208 @@
+"""ui_component CRUD: merchant-scoped listing and PATCH-style update.
+
+Two review findings, both about the boundary between the route handler
+and the query builder:
+
+1. Listing must scope by the caller's MERCHANTS as well as resellers —
+   both allowlists reach the SQL, which filters before pagination and
+   the total. Reseller-wide rows (NULL merchant) remain visible to any
+   user with reseller access, as templates do.
+2. Update distinguishes "field omitted" (untouched) from "field sent as
+   null" (cleared) via Pydantic field presence. NOT NULL columns refuse an
+   explicit null with a 400.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+import pytest
+from fastapi import HTTPException
+
+import app.api.routers.breeze_buddy.ui_components.handlers as handlers
+from app.database.queries.breeze_buddy.ui_component import (
+    list_ui_components_query,
+    update_ui_component_query,
+)
+from app.schemas import UserInfo
+from app.schemas.breeze_buddy.ui_component import (
+    UiComponentResponse,
+    UiComponentUpdate,
+)
+
+SCHEMA = {"type": "object", "properties": {"items": {"type": "array"}}}
+
+
+def _user(role="reseller", resellers=("r1",), merchants=("m1",)) -> UserInfo:
+    return UserInfo(
+        id="u1",
+        username="u1",
+        role=role,
+        reseller_ids=list(resellers),
+        merchant_ids=list(merchants),
+    )
+
+
+# ---------------------------------------------------------------------------
+# list: merchant allowlist reaches the query
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def captured_list(monkeypatch) -> Dict[str, Any]:
+    seen: Dict[str, Any] = {}
+
+    async def fake_list(**kwargs):
+        seen.update(kwargs)
+        return [], 0
+
+    monkeypatch.setattr(handlers, "list_ui_components", fake_list)
+    return seen
+
+
+async def _list(user: UserInfo, **overrides):
+    kwargs = dict(
+        reseller_id=None,
+        merchant_id=None,
+        include_inactive=False,
+        page=1,
+        limit=50,
+        current_user=user,
+    )
+    kwargs.update(overrides)
+    return await handlers.list_ui_components_handler(**kwargs)
+
+
+@pytest.mark.asyncio
+async def test_list_scopes_non_admin_to_their_merchants(captured_list):
+    await _list(_user())
+    assert captured_list["reseller_ids"] == ["r1"]
+    assert captured_list["merchant_ids"] == ["m1"]
+
+
+@pytest.mark.asyncio
+async def test_list_refuses_merchant_outside_scope(captured_list):
+    with pytest.raises(HTTPException) as exc:
+        await _list(_user(), merchant_id="m2")
+    assert exc.value.status_code == 403
+    assert captured_list == {}  # never reached the accessor
+
+
+@pytest.mark.asyncio
+async def test_list_passes_explicit_merchant_inside_scope(captured_list):
+    await _list(_user(merchants=("m1", "m2")), merchant_id="m2")
+    assert captured_list["merchant_id"] == "m2"
+    assert captured_list["merchant_ids"] == ["m1", "m2"]
+
+
+@pytest.mark.asyncio
+async def test_list_wildcard_and_admin_skip_merchant_filter(captured_list):
+    await _list(_user(merchants=("*",)))
+    assert captured_list["merchant_ids"] is None
+    assert captured_list["reseller_ids"] == ["r1"]
+    captured_list.clear()
+    await _list(_user(role="admin", resellers=(), merchants=()))
+    assert captured_list["merchant_ids"] is None
+    assert captured_list["reseller_ids"] is None
+
+
+def test_list_query_admits_reseller_wide_rows_for_merchant_allowlist():
+    query, count_query, params = list_ui_components_query(
+        reseller_ids=["r1"], merchant_ids=["m1"]
+    )
+    clause = "(merchant_id IS NULL OR merchant_id = ANY($2))"
+    assert clause in query and clause in count_query
+    assert params[:2] == [["r1"], ["m1"]]
+    # an explicit merchant_id wins over the allowlist
+    query, _, params = list_ui_components_query(merchant_id="m1", merchant_ids=["m1"])
+    assert "merchant_id = $1" in query and "ANY" not in query
+
+
+# ---------------------------------------------------------------------------
+# update: presence semantics
+# ---------------------------------------------------------------------------
+
+
+def _row(**overrides) -> UiComponentResponse:
+    base: Dict[str, Any] = dict(
+        id="11111111-1111-1111-1111-111111111111",
+        reseller_id="r1",
+        merchant_id="m1",
+        name="JourneyOptions",
+        version=3,
+        props_schema=SCHEMA,
+        flags={"data_bound": True},
+        render_def={"type": "col", "children": [{"type": "text"}]},
+        prompt_hint="hint",
+    )
+    base.update(overrides)
+    return UiComponentResponse(**base)
+
+
+@pytest.fixture
+def captured_update(monkeypatch) -> List[Any]:
+    calls: List[Any] = []
+
+    async def fake_get(ui_component_id):
+        return _row()
+
+    async def fake_update(ui_component_id, patch):
+        calls.append(patch)
+        return _row(**{k: v for k, v in patch.items()})
+
+    monkeypatch.setattr(handlers, "get_ui_component_by_id", fake_get)
+    monkeypatch.setattr(handlers, "update_ui_component", fake_update)
+    return calls
+
+
+@pytest.mark.asyncio
+async def test_update_forwards_only_supplied_fields(captured_update):
+    body = UiComponentUpdate.model_validate({"prompt_hint": "new"})
+    await handlers.update_ui_component_handler(_row().id, body, _user())
+    assert captured_update == [{"prompt_hint": "new"}]
+
+
+@pytest.mark.asyncio
+async def test_update_explicit_null_clears_nullable_fields(captured_update):
+    body = UiComponentUpdate.model_validate({"render_def": None, "prompt_hint": None})
+    await handlers.update_ui_component_handler(_row().id, body, _user())
+    assert captured_update == [{"render_def": None, "prompt_hint": None}]
+
+
+@pytest.mark.asyncio
+async def test_update_explicit_null_refused_on_not_null_columns(captured_update):
+    body = UiComponentUpdate.model_validate({"props_schema": None, "is_active": None})
+    with pytest.raises(HTTPException) as exc:
+        await handlers.update_ui_component_handler(_row().id, body, _user())
+    assert exc.value.status_code == 400
+    assert "props_schema" in exc.value.detail and "is_active" in exc.value.detail
+    assert captured_update == []
+
+
+@pytest.mark.asyncio
+async def test_update_reruns_guards_on_merged_row(captured_update, monkeypatch):
+    # clearing render_def on an overlay_only def is refused, as at create
+    async def fake_get(ui_component_id):
+        return _row(flags={"data_bound": True, "overlay_only": True})
+
+    monkeypatch.setattr(handlers, "get_ui_component_by_id", fake_get)
+    body = UiComponentUpdate.model_validate({"render_def": None})
+    with pytest.raises(HTTPException) as exc:
+        await handlers.update_ui_component_handler(_row().id, body, _user())
+    assert exc.value.status_code == 400
+    assert captured_update == []
+
+
+def test_update_query_writes_null_and_ignores_unknown_keys():
+    query, params = update_ui_component_query(
+        ui_component_id="id-1",
+        patch={"render_def": None, "prompt_hint": "p", "not_a_column": "x"},
+    )
+    assert "render_def = $1::jsonb" in query and "prompt_hint = $2" in query
+    assert "not_a_column" not in query
+    assert "version = version + 1" in query
+    assert params[:2] == [None, "p"] and params[-1] == "id-1"
+    assert update_ui_component_query(ui_component_id="id-1", patch={}) == ("", [])
+    assert update_ui_component_query(
+        ui_component_id="id-1", patch={"not_a_column": 1}
+    ) == ("", [])


### PR DESCRIPTION
Merchant-specific UI components stored as DATA, not code: migration 070
`ui_component` (reseller/merchant-scoped, unique name per scope, partial
index for the session-start lookup) with three-layer DB access, and RBAC
CRUD under /breeze-buddy/ui-components (list scoped by reseller AND
merchant with reseller-wide rows visible; PATCH-style update where an
omitted field is untouched and an explicit null clears a nullable column).

A row is a JSON-Schema props contract, engine flags (data_bound,
selection_field, list caps, overlay_only) and an optional declarative
render_def. chat/ui/custom_defs.py holds the write-time guards every
registration passes (PascalCase name, no collision with built-in or
flavor components, well-formed schema, v1 flag rules, render_def lint:
whitelisted nodes, depth/node caps, to_assistant/open_url/open_detail
actions only) and the read-time hydration (resolve_custom_show_op:
this turn's BindingStore only, selection + caps, structural schema
validation). Nothing consumes the rows yet - the session overlay lands
in the next part.

**Part 5 of 7** of the split of #1039 — the review feedback from there is already incorporated. Parts 1–5 are independent of each other and of the CHAMELEON stack (5 → 6 → 7).

### Validation (this branch alone)
- `uv run pytest tests/`: 2303 passed · `pyrefly` 0 errors · black / isort / autoflake clean · migration-numbering and CRM-boundary guards OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MExhDfX8SUSdPpA8ruW4sG
