### PR TITLE
feat(chameleon): session overlay - registry components join the session catalog

### DIFF
--- a/app/ai/voice/agents/breeze_buddy/chat/agent/core.py
+++ b/app/ai/voice/agents/breeze_buddy/chat/agent/core.py
@@ -51,7 +51,10 @@ from app.ai.voice.agents.breeze_buddy.mcp import (
     close_mcp_pool,
 )
 from app.ai.voice.agents.breeze_buddy.template.approval import build_approval_map
-from app.ai.voice.agents.breeze_buddy.template.types import TemplateModel
+from app.ai.voice.agents.breeze_buddy.template.types import (
+    CustomComponentDef,
+    TemplateModel,
+)
 from app.ai.voice.agents.breeze_buddy.template.ui_catalog import (
     CATALOG_VERSION_V2,
     data_bound_names,
@@ -143,6 +146,7 @@ class ChatAgent(
         context_placement: Optional[str] = None,
         catalog_version: Optional[str] = None,
         merchant_id: Optional[str] = None,
+        custom_components: Optional[Dict[str, "CustomComponentDef"]] = None,
     ) -> None:
         self.session_id = session_id
         self.template = template
@@ -253,6 +257,17 @@ class ChatAgent(
         self._catalog_v2 = catalog_version == CATALOG_VERSION_V2
         if not self._catalog_v2:
             self._ui_allowlist -= data_bound_names()
+        # CHAMELEON session overlay: this template's resolved registry
+        # component defs (ui_component rows named in
+        # ``ui_catalog.custom_components``). Session DATA, never a catalog
+        # mutation — two merchants on one worker never see each other's
+        # defs. v2/render_ui-only, so the overlay joins the allowlist
+        # AFTER the catalog-version prune above (v1/voice sessions carry
+        # no custom defs at all).
+        self._custom_defs: Dict[str, "CustomComponentDef"] = (
+            dict(custom_components) if (custom_components and self._catalog_v2) else {}
+        )
+        self._ui_allowlist |= set(self._custom_defs)
         # Per-turn record of successful post-pipeline tool results, keyed
         # (tool_name, tool_use_id) — what `show`-op bindings resolve
         # against. Populated in _cycle_loop after each ungated dispatch;

--- a/app/ai/voice/agents/breeze_buddy/chat/agent/render_ui.py
+++ b/app/ai/voice/agents/breeze_buddy/chat/agent/render_ui.py
@@ -152,7 +152,11 @@ class RenderUiHandlerMixin:
             # Componentless chips call is the canonical chips-cycle shape
             # now that QuickReplies left the schema enum.
             raw_args["component"] = "QuickReplies"
-        components = render_ui_components(self._ui_allowlist, self._catalog_v2)
+        components = render_ui_components(
+            self._ui_allowlist,
+            self._catalog_v2,
+            custom_components=set(self._custom_defs),
+        )
         if self._quick_replies_mode == "off":
             components = [c for c in components if c != "QuickReplies"]
         if chips_cycle:
@@ -183,6 +187,7 @@ class RenderUiHandlerMixin:
             template=self.template,
             state_values=self.agent_state,
             flavor_groups=self._ui_flavor_groups,
+            custom_defs=self._custom_defs,
         )
         if outcome.decision == "rendered" and outcome.component and outcome.ops:
             # Repeat-render merge is FLAVOR policy (commerce: a second

--- a/app/ai/voice/agents/breeze_buddy/chat/agent/tooling.py
+++ b/app/ai/voice/agents/breeze_buddy/chat/agent/tooling.py
@@ -152,7 +152,11 @@ class ToolDispatchMixin:
         # approval-gated; neither is read_only (so they never fan out —
         # ordering with sibling calls is meaningful).
         if self._render_ui_enabled:
-            rui_components = render_ui_components(self._ui_allowlist, self._catalog_v2)
+            rui_components = render_ui_components(
+                self._ui_allowlist,
+                self._catalog_v2,
+                custom_components=set(self._custom_defs),
+            )
             if self._quick_replies_mode == "off":
                 # quick_replies='off': the component vanishes from the
                 # schema enum and docs; execute rejects it as unknown.
@@ -165,6 +169,11 @@ class ToolDispatchMixin:
                         trusted_urls=sorted(self._trusted_link_urls),
                         quick_replies_mode=self._quick_replies_mode,
                         flavor_groups=self._ui_flavor_groups,
+                        custom_coaching={
+                            name: d.prompt_hint
+                            for name, d in self._custom_defs.items()
+                            if d.prompt_hint
+                        },
                     )
                 )
         if self._plan_enforcement:

--- a/app/ai/voice/agents/breeze_buddy/chat/custom_components.py
+++ b/app/ai/voice/agents/breeze_buddy/chat/custom_components.py
@@ -1,0 +1,97 @@
+"""Session-start resolution of a template's custom-component defs.
+
+Reads ``configurations.ui_catalog.custom_components`` (opt-in names) and
+fetches the matching active ``ui_component`` rows scoped to the template's
+reseller/merchant. Missing or inactive names are skipped with a warning —
+a stale template narrows its catalog, it never fails the turn.
+
+One indexed SELECT per turn; rows are immutable per version so a cache can
+be added later without changing callers. Best-effort: any DB error resolves
+to an empty overlay (the session degrades to built-ins, never breaks).
+"""
+
+from typing import Dict
+
+from pydantic import ValidationError
+
+from app.ai.voice.agents.breeze_buddy.template.types import (
+    CustomComponentDef,
+    CustomComponentFlags,
+    TemplateModel,
+)
+from app.core.logger import logger
+from app.database.accessor.breeze_buddy.ui_component import (
+    get_ui_components_by_names,
+)
+
+
+def model_renderable(
+    defs: Dict[str, CustomComponentDef],
+) -> Dict[str, CustomComponentDef]:
+    """The subset the MODEL may render in-thread via render_ui.
+
+    Two exclusions, both mirroring what the widget wire can paint:
+
+    - ``overlay_only`` defs are client-side render targets (opened by an
+      ``open_detail`` / intent action in the widget's detail overlay): they
+      ship on the session surface wire but never join the render_ui enum,
+      coaching, or allowlist — the model cannot paint them in-thread.
+    - defs with NO ``render_def`` (registered for a merchant frontend that
+      renders them itself): ``_custom_components_wire`` never ships them,
+      so offering them to the model would let it persist a ui_op our
+      widget cannot interpret.
+    """
+    return {k: v for k, v in defs.items() if v.render_def and not v.flags.overlay_only}
+
+
+async def resolve_custom_components(
+    template: TemplateModel,
+) -> Dict[str, CustomComponentDef]:
+    """The CHAMELEON overlay for one session: name → resolved def.
+
+    Attribute-tolerant on purpose: the turn path hands this whatever it
+    holds as the template (test doubles included), and a template that
+    never opted in must cost nothing — no DB round-trip, empty overlay.
+    """
+    configurations = getattr(template, "configurations", None)
+    ui_cat = getattr(configurations, "ui_catalog", None)
+    names = list(getattr(ui_cat, "custom_components", None) or [])
+
+    if not names:
+        return {}
+    try:
+        rows = await get_ui_components_by_names(
+            reseller_id=template.reseller_id,
+            merchant_id=template.merchant_id,
+            names=names,
+        )
+    except Exception:
+        logger.opt(exception=True).error(
+            f"custom_components fetch failed for template {template.name!r}; "
+            "session proceeds with built-ins only"
+        )
+        return {}
+    defs: Dict[str, CustomComponentDef] = {}
+    for row in rows:
+        try:
+            defs[row.name] = CustomComponentDef(
+                name=row.name,
+                version=row.version,
+                props_schema=row.props_schema,
+                flags=CustomComponentFlags.model_validate(row.flags or {}),
+                render_def=row.render_def,
+                prompt_hint=row.prompt_hint,
+            )
+        except ValidationError:
+            logger.opt(exception=True).error(
+                f"ui_component {row.name!r} (v{row.version}) has invalid "
+                "flags; skipping"
+            )
+
+    missing = set(names) - set(defs)
+    if missing:
+        logger.warning(
+            f"template {template.name!r} opts into unknown/inactive "
+            f"ui_components {sorted(missing)}; they are skipped"
+        )
+    return defs

--- a/app/ai/voice/agents/breeze_buddy/chat/turn_core.py
+++ b/app/ai/voice/agents/breeze_buddy/chat/turn_core.py
@@ -29,6 +29,10 @@ from app.ai.voice.agents.breeze_buddy.chat.approvals import (
     claim_tool_approval,
     resolve_dangling_approvals,
 )
+from app.ai.voice.agents.breeze_buddy.chat.custom_components import (
+    model_renderable,
+    resolve_custom_components,
+)
 from app.ai.voice.agents.breeze_buddy.chat.history.block_codec import (
     blocks_to_llm_context_messages,
     repair_dangling_tool_uses,
@@ -122,7 +126,13 @@ def negotiate_catalog(
             list(ui_cat.disabled_primitives or []) if ui_cat is not None else None
         ),
     )
-    if not any(is_data_bound(name) for name in allowlist):
+    # A template is v2-capable when its allowlist carries a data-bound
+    # component OR it opts into registry custom components (CHAMELEON) —
+    # those are data-bound by definition (v1 rejects anything else at
+    # registration) but live outside the process-global catalog, so the
+    # is_data_bound scan can't see them.
+    custom_names = list(getattr(ui_cat, "custom_components", None) or [])
+    if not any(is_data_bound(name) for name in allowlist) and not custom_names:
         return CATALOG_VERSION, []
     flavors = [g for g in (enabled_groups or []) if g in LAZY_GROUPS]
     return CATALOG_VERSION_V2, flavors
@@ -280,6 +290,7 @@ async def run_chat_turn(
         context_placement=context_placement,
         catalog_version=resolve_session_catalog_version(session.metadata),
         merchant_id=session.merchant_id,
+        custom_components=model_renderable(await resolve_custom_components(template)),
     )
     async for event in agent.run_turn(
         user_content=user_content,
@@ -372,6 +383,7 @@ async def run_chat_approval_continuation(
         agent_state=agent_state,
         catalog_version=resolve_session_catalog_version(session.metadata),
         merchant_id=session.merchant_id,
+        custom_components=model_renderable(await resolve_custom_components(template)),
     )
     async for event in agent.run_approval_turn(
         approval=claimed,

--- a/app/ai/voice/agents/breeze_buddy/chat/ui/render_ui_tool.py
+++ b/app/ai/voice/agents/breeze_buddy/chat/ui/render_ui_tool.py
@@ -41,6 +41,10 @@ from app.ai.voice.agents.breeze_buddy.chat.ui.binding import (
     resolve_show_op,
     selector_extension_keys,
 )
+from app.ai.voice.agents.breeze_buddy.chat.ui.custom_defs import (
+    resolve_custom_show_op,
+    summarize_custom_render,
+)
 from app.ai.voice.agents.breeze_buddy.template.ui_catalog import (
     UI_CATALOG,
     is_data_bound,
@@ -48,6 +52,7 @@ from app.ai.voice.agents.breeze_buddy.template.ui_catalog import (
 )
 
 RENDER_UI_TOOL_NAME = "render_ui"
+
 REVISE_PLAN_TOOL_NAME = "revise_plan"
 
 
@@ -155,14 +160,25 @@ class RenderUiOutcome:
     reason: Optional[str] = None
 
 
-def render_ui_components(ui_allowlist: Set[str], catalog_v2: bool) -> List[str]:
+def render_ui_components(
+    ui_allowlist: Set[str],
+    catalog_v2: bool,
+    custom_components: Optional[Set[str]] = None,
+) -> List[str]:
     """The component names ``render_ui`` offers on this session: data-bound,
     allowlisted, not server-only — plus the literal-content components the
     engine keeps model-authored (QuickReplies; LinkButton, whose url is
-    server-verified against trusted/tool-sourced links)."""
+    server-verified against trusted/tool-sourced links).
+
+    ``custom_components`` are this session's registry defs (CHAMELEON
+    overlay) — session data, never catalog entries, so they join the enum
+    here explicitly. v2-only, same as every data-bound component."""
     names: List[str] = []
     if catalog_v2:
         for name in sorted(ui_allowlist):
+            if custom_components and name in custom_components:
+                names.append(name)
+                continue
             schema = UI_CATALOG.get(name)
             if schema is None or not is_data_bound(name):
                 continue
@@ -228,6 +244,7 @@ def build_render_ui_schema(
     trusted_urls: Optional[List[str]] = None,
     quick_replies_mode: Optional[str] = None,
     flavor_groups: Optional[List[str]] = None,
+    custom_coaching: Optional[Dict[str, str]] = None,
 ) -> FlowsFunctionSchema:
     """The ``render_ui`` function schema (Vertex-safe subset: no
     additionalProperties — ``bind`` is an array of {prop, ref} pairs).
@@ -272,6 +289,12 @@ def build_render_ui_schema(
     ).items():
         if comp_name in components:
             bind_desc += sentence
+    # Custom registry defs coach the same way (prompt_hint per offered
+    # component) — a def a template didn't opt into leaves no trace.
+    for comp_name, sentence in (custom_coaching or {}).items():
+        if comp_name in components and sentence:
+            hint = sentence.strip()
+            bind_desc += " " + hint if hint.endswith(".") else " " + hint + "."
     # `fields` is advertised only when an offered component actually
     # declares literal fields — every other session keeps today's schema
     # byte-identical (no arg for the model to misuse).
@@ -526,6 +549,7 @@ def execute_render_ui(
     template: Any = None,
     state_values: Optional[Dict[str, Any]] = None,
     flavor_groups: Optional[List[str]] = None,
+    custom_defs: Optional[Dict[str, Any]] = None,
 ) -> RenderUiOutcome:
     """Run one ``render_ui`` call: validate → hydrate → finalize → summarize.
 
@@ -684,6 +708,55 @@ def execute_render_ui(
             for k, v in bind_raw.items()
             if isinstance(k, str) and isinstance(v, str)
         }
+
+    if custom_defs and component in custom_defs:
+        # CHAMELEON: session-scoped registry component. Same trust path
+        # (this turn's BindingStore only), hydrated + validated against
+        # the def's JSON Schema instead of a catalog Pydantic class. No
+        # flavor finalize, no literal fields (v1 rejects them at write).
+        def_ = custom_defs[component]
+
+        if not bind:
+            return RenderUiOutcome(
+                fn_result={
+                    "status": "error",
+                    "error": (
+                        f"{component} is data-bound: pass bind, e.g. "
+                        f"{_BIND_EXAMPLE_GENERIC}"
+                    ),
+                },
+                component=component,
+            )
+        show_op: Dict[str, Any] = {
+            "op": "show",
+            "id": op_id,
+            "component": component,
+            "bind": bind,
+            "props": props,
+        }
+        if parent:
+            show_op["parent"] = parent
+        custom_result = resolve_custom_show_op(show_op, store, def_)
+        if custom_result.op is None:
+            return RenderUiOutcome(
+                fn_result={
+                    "status": "error",
+                    "error": (
+                        f"render failed: {custom_result.error}. Bind refs "
+                        "must point into a tool result from THIS turn."
+                    ),
+                },
+                component=component,
+                reason=custom_result.error,
+            )
+        return RenderUiOutcome(
+            fn_result=summarize_custom_render(
+                def_, custom_result.op.get("props") or {}
+            ),
+            ops=[custom_result.op],
+            decision="rendered",
+            component=component,
+        )
 
     if is_data_bound(component):
         if not bind:

--- a/app/ai/voice/agents/breeze_buddy/template/types.py
+++ b/app/ai/voice/agents/breeze_buddy/template/types.py
@@ -1362,6 +1362,17 @@ class UiCatalogConfig(BaseModel):
             "in the 'core' group."
         ),
     )
+    custom_components: List[str] = Field(
+        default_factory=list,
+        description=(
+            "Registry (ui_component, migration 070) component names this "
+            "template opts into, e.g. ['JourneyOptions']. Resolved at turn "
+            "start into a session-scoped overlay: the names join the "
+            "render_ui enum and hydrate via their JSON-Schema defs. "
+            "catalog-v2 render_ui sessions only — pruned everywhere else. "
+            "Unknown/inactive names are skipped with a warning."
+        ),
+    )
 
 
 class FlavorProtocolConfig(BaseModel):

--- a/app/api/routers/breeze_buddy/chat/demo.py
+++ b/app/api/routers/breeze_buddy/chat/demo.py
@@ -260,7 +260,7 @@ async def create_demo_session(
         # ui_flavors, so a demo page structurally could not render quick
         # replies or greeting tiles its template defined — the asymmetry
         # the one-block shape exists to prevent.
-        widget=_surface_wire(
+        widget=await _surface_wire(
             _extract_widget_config(template),
             template,
             catalog_active=catalog_active,

--- a/app/api/routers/breeze_buddy/widget/handlers.py
+++ b/app/api/routers/breeze_buddy/widget/handlers.py
@@ -30,6 +30,9 @@ from app.ai.voice.agents.breeze_buddy.chat.client_context import (
     ClientContextTooLarge,
     compute_context_patch,
 )
+from app.ai.voice.agents.breeze_buddy.chat.custom_components import (
+    resolve_custom_components,
+)
 from app.ai.voice.agents.breeze_buddy.chat.turn_core import (
     negotiate_catalog,
     resolve_session_catalog_version,
@@ -103,6 +106,7 @@ from app.schemas.breeze_buddy.chat import (
     CreateChatSessionRequest,
     CreateWidgetSessionRequest,
     CreateWidgetSessionResponse,
+    CustomComponentWire,
     GreetingTileWire,
     QuickReplyWire,
     SendChatMessageRequest,
@@ -220,7 +224,7 @@ def _extract_widget_config(template: object) -> _WidgetSurface:
     )
 
 
-def _surface_wire(
+async def _surface_wire(
     surface: _WidgetSurface,
     template: object,
     *,
@@ -230,7 +234,11 @@ def _surface_wire(
     """The one-block form of the session's presentation surface.
 
     Built from exactly the same values the flat response fields carry, so
-    the two can never disagree while both are on the wire.
+    the two can never disagree while both are on the wire. The registry
+    defs are fetched HERE, not by the callers — the block exists so a
+    surface field is filled in one place and every response (create,
+    resume, demo) gets it; a per-call keyword is how the demo response
+    lost it once already.
     """
     return WidgetSurfaceWire(
         quick_replies=surface.quick_replies,
@@ -240,7 +248,25 @@ def _surface_wire(
         voice_enabled=_template_voice_enabled(template),
         catalog_active=catalog_active,
         ui_flavors=ui_flavors,
+        custom_components=await _custom_components_wire(template, catalog_active),
     )
+
+
+async def _custom_components_wire(
+    template: object, catalog_active: str
+) -> List[CustomComponentWire]:
+    """CHAMELEON: the render_def-bearing registry defs this session may
+    render, in wire form. Backend-only defs (render_def NULL) never ship —
+    the widget can't paint them and the props would leak schema detail the
+    merchant's own frontend owns. Empty on v1 sessions."""
+    if catalog_active != CATALOG_VERSION_V2:
+        return []
+    defs = await resolve_custom_components(template)  # type: ignore[arg-type]
+    return [
+        CustomComponentWire(name=d.name, version=d.version, render_def=d.render_def)
+        for d in defs.values()
+        if d.render_def
+    ]
 
 
 def _template_voice_enabled(template: object) -> bool:
@@ -348,8 +374,11 @@ async def create_widget_session_handler(
         voice_enabled=_template_voice_enabled(template),
         catalog_active=catalog_active,
         ui_flavors=ui_flavors,
-        widget=_surface_wire(
-            surface, template, catalog_active=catalog_active, ui_flavors=ui_flavors
+        widget=await _surface_wire(
+            surface,
+            template,
+            catalog_active=catalog_active,
+            ui_flavors=ui_flavors,
         ),
     )
 
@@ -1231,8 +1260,11 @@ async def get_widget_session_state_handler(
         voice_enabled=_template_voice_enabled(template),
         catalog_active=catalog_active,
         ui_flavors=ui_flavors,
-        widget=_surface_wire(
-            surface, template, catalog_active=catalog_active, ui_flavors=ui_flavors
+        widget=await _surface_wire(
+            surface,
+            template,
+            catalog_active=catalog_active,
+            ui_flavors=ui_flavors,
         ),
         template_vars=template_vars,
         metadata=session.metadata or {},

--- a/app/schemas/breeze_buddy/chat.py
+++ b/app/schemas/breeze_buddy/chat.py
@@ -516,6 +516,18 @@ class GreetingTileWire(BaseModel):
     image_url: str = Field(..., description="Tile image URL (merchant CDN).")
 
 
+class CustomComponentWire(BaseModel):
+    """One CHAMELEON registry component in wire form: the declarative
+    ``render_def`` the widget's interpreter paints, keyed by (name, version)
+    so a client may cache it — a def never changes under a version."""
+
+    name: str = Field(..., description="PascalCase component type.")
+    version: int = Field(..., ge=1, description="Bumped on every registry update.")
+    render_def: Dict[str, Any] = Field(
+        ..., description="Declarative render tree (grammar v1)."
+    )
+
+
 class WidgetSurfaceWire(BaseModel):
     """Everything the embed needs to paint its chrome for one session.
 
@@ -569,6 +581,15 @@ class WidgetSurfaceWire(BaseModel):
         description=(
             "Lazy UI flavor groups the template enables — preload these "
             "code-split chunks. Empty when catalog_active is 'v1'."
+        ),
+    )
+    custom_components: List[CustomComponentWire] = Field(
+        default_factory=list,
+        description=(
+            "CHAMELEON registry components this session may render — "
+            "render_def-bearing defs only (backend-only defs never ship). "
+            "The widget's declarative interpreter renders these; empty when "
+            "catalog_active is 'v1'."
         ),
     )
 

--- a/tests/test_custom_defs.py
+++ b/tests/test_custom_defs.py
@@ -19,6 +19,10 @@ from app.ai.voice.agents.breeze_buddy.chat.ui.custom_defs import (
     summarize_custom_render,
     validate_registration,
 )
+from app.ai.voice.agents.breeze_buddy.chat.ui.render_ui_tool import (
+    execute_render_ui,
+    render_ui_components,
+)
 from app.ai.voice.agents.breeze_buddy.template.types import (
     CustomComponentDef,
     CustomComponentFlags,
@@ -106,6 +110,47 @@ class TestRegistrationGuards:
             render_def=None,
         )
         assert any("overlay_only requires a render_def" in e for e in errors)
+
+    def test_model_renderable_filters_overlay_only(self):
+        from app.ai.voice.agents.breeze_buddy.chat.custom_components import (
+            model_renderable,
+        )
+        from app.ai.voice.agents.breeze_buddy.template.types import (
+            CustomComponentDef,
+            CustomComponentFlags,
+        )
+
+        defs = {
+            "JourneyOptions": CustomComponentDef(
+                name="JourneyOptions", props_schema={}, render_def={"type": "col"}
+            ),
+            "JourneyDetail": CustomComponentDef(
+                name="JourneyDetail",
+                props_schema={},
+                render_def={"type": "col"},
+                flags=CustomComponentFlags(overlay_only=True),
+            ),
+        }
+        assert set(model_renderable(defs)) == {"JourneyOptions"}
+
+    def test_model_renderable_filters_render_def_less(self):
+        """A def without a render_def never ships on the widget wire, so it
+        must not be offered to the model either — or the model can persist
+        a ui_op the widget cannot paint."""
+        from app.ai.voice.agents.breeze_buddy.chat.custom_components import (
+            model_renderable,
+        )
+        from app.ai.voice.agents.breeze_buddy.template.types import (
+            CustomComponentDef,
+        )
+
+        defs = {
+            "Renderable": CustomComponentDef(
+                name="Renderable", props_schema={}, render_def={"type": "col"}
+            ),
+            "BackendOnly": CustomComponentDef(name="BackendOnly", props_schema={}),
+        }
+        assert set(model_renderable(defs)) == {"Renderable"}
 
     @pytest.mark.parametrize("bad", ["journeyOptions", "J", "Has Spaces", "x" * 70])
     def test_name_must_be_pascal_case(self, bad):
@@ -322,3 +367,72 @@ class TestResolveCustomShowOp:
         assert summary["rendered"] == "JourneyOptions"
         assert summary["count"] == 3
         assert summary["journeys"][0]["id"] == "j1"
+
+
+# ---------------------------------------------------------------------------
+# LLM surface: enum joining + execute routing + isolation
+# ---------------------------------------------------------------------------
+
+
+class TestRenderUiSurface:
+    def test_custom_names_join_enum_v2_only(self):
+        allow = {"QuickReplies", "JourneyOptions"}
+        assert "JourneyOptions" in render_ui_components(
+            allow, True, custom_components={"JourneyOptions"}
+        )
+        # v1 session: customs pruned along with every data-bound component
+        assert "JourneyOptions" not in render_ui_components(
+            allow, False, custom_components={"JourneyOptions"}
+        )
+
+    def test_execute_routes_custom(self):
+        store = store_with("search_journeys", {"journeys": JOURNEYS})
+        defs = {"JourneyOptions": journey_def()}
+        outcome = execute_render_ui(
+            {
+                "component": "JourneyOptions",
+                "bind": [
+                    {"prop": "journeys", "ref": "$tool:search_journeys#/journeys"}
+                ],
+            },
+            store=store,
+            allowlist={"JourneyOptions"},
+            components=["JourneyOptions"],
+            op_id="root",
+            custom_defs=defs,
+        )
+        assert outcome.decision == "rendered"
+        assert outcome.ops[0]["type"] == "JourneyOptions"
+        assert outcome.fn_result["count"] == 3
+
+    def test_execute_requires_bind_for_custom(self):
+        outcome = execute_render_ui(
+            {"component": "JourneyOptions"},
+            store=BindingStore(),
+            allowlist={"JourneyOptions"},
+            components=["JourneyOptions"],
+            op_id="root",
+            custom_defs={"JourneyOptions": journey_def()},
+        )
+        assert outcome.fn_result["status"] == "error"
+        assert "data-bound" in outcome.fn_result["error"]
+
+    def test_two_merchant_isolation(self):
+        """A session without the def treats the component as unknown even
+        when another session on the same worker carries it."""
+        store = store_with("search_journeys", {"journeys": JOURNEYS})
+        outcome = execute_render_ui(
+            {
+                "component": "JourneyOptions",
+                "bind": [
+                    {"prop": "journeys", "ref": "$tool:search_journeys#/journeys"}
+                ],
+            },
+            store=store,
+            allowlist={"QuickReplies"},
+            components=["QuickReplies"],  # other merchant's enum
+            op_id="root",
+            custom_defs={},  # no overlay on THIS session
+        )
+        assert outcome.fn_result["status"] == "error"
+        assert "unknown component" in outcome.fn_result["error"]

--- a/tests/test_widget_surface_block.py
+++ b/tests/test_widget_surface_block.py
@@ -48,10 +48,10 @@ def _template(voice: bool = False) -> SimpleNamespace:
     )
 
 
-def test_block_carries_the_same_values_as_the_flat_fields():
+async def test_block_carries_the_same_values_as_the_flat_fields():
     surface = _surface()
     template = _template(voice=True)
-    block = _surface_wire(
+    block = await _surface_wire(
         surface, template, catalog_active="v2", ui_flavors=["commerce"]
     )
     # Field-for-field against the SAME sources the flat response fields are
@@ -76,17 +76,54 @@ def test_every_session_response_exposes_the_block():
         assert "widget" in model.model_fields, model.__name__
 
 
-def test_block_defaults_are_safe_for_a_bare_template():
+async def test_block_defaults_are_safe_for_a_bare_template():
+
     # A template with no widget config at all still produces a legal block:
     # empty pills/tiles, composer ON, voice OFF, v1 catalog. A default that
     # hid the composer would lock a shopper out of a working session.
-    block = _surface_wire(
+    block = await _surface_wire(
         _WidgetSurface(quick_replies=[], greeting_tiles=[], enable_text_input=True),
         _template(),
         catalog_active="v1",
         ui_flavors=[],
     )
     assert block == WidgetSurfaceWire()
+
+
+async def test_custom_components_ride_the_block_from_one_place(monkeypatch):
+    """The registry defs are fetched INSIDE ``_surface_wire`` — every
+    response that builds the block (create, resume, demo) gets them without
+    a per-call keyword to forget. Typed entries, render_def-bearing defs
+    only, and nothing at all on a v1 catalog."""
+    from app.ai.voice.agents.breeze_buddy.template.types import CustomComponentDef
+    from app.api.routers.breeze_buddy.widget import handlers as widget_handlers
+    from app.schemas.breeze_buddy.chat import CustomComponentWire
+
+    async def fake_resolve(template):
+        return {
+            "JourneyOptions": CustomComponentDef(
+                name="JourneyOptions",
+                version=28,
+                props_schema={},
+                render_def={"type": "col"},
+            ),
+            "BackendOnly": CustomComponentDef(name="BackendOnly", props_schema={}),
+        }
+
+    monkeypatch.setattr(widget_handlers, "resolve_custom_components", fake_resolve)
+
+    v2 = await _surface_wire(
+        _surface(), _template(), catalog_active="v2", ui_flavors=[]
+    )
+    assert v2.custom_components == [
+        CustomComponentWire(
+            name="JourneyOptions", version=28, render_def={"type": "col"}
+        )
+    ]
+    v1 = await _surface_wire(
+        _surface(), _template(), catalog_active="v1", ui_flavors=[]
+    )
+    assert v1.custom_components == []
 
 
 def test_demo_response_defaults_the_block_when_unset():


### PR DESCRIPTION
A template opts into registry defs by name (ui_catalog.custom_components);
at session start they overlay the built-in catalog for that session only
(two merchants on one worker never see each other's defs). Overlaid defs
join the render_ui enum, coaching and allowlist; render_ui hydrates them
through resolve_custom_show_op against this turn's BindingStore, the same
trust path as built-ins. model_renderable() keeps overlay_only defs and
defs without a render_def out of the model's vocabulary, mirroring what
the widget wire can paint.

The widget surface block gains typed CustomComponentWire entries (name,
version, render_def - render_def-bearing defs only), fetched inside
_surface_wire so create, resume AND demo responses all carry them.
resolve_custom_components is attribute-tolerant and costs nothing on a
template that never opted in.

**Part 6 of 7** of the split of #1039 — the review feedback from there is already incorporated. Parts 1–5 are independent of each other and of the CHAMELEON stack (5 → 6 → 7).

### Validation (this branch alone)
- `uv run pytest tests/`: 2310 passed · `pyrefly` 0 errors · black / isort / autoflake clean · migration-numbering and CRM-boundary guards OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MExhDfX8SUSdPpA8ruW4sG
