### PR TITLE
feat(chameleon): template-defined DIRECT ui_intents

### DIFF
--- a/app/ai/voice/agents/breeze_buddy/chat/intents/router.py
+++ b/app/ai/voice/agents/breeze_buddy/chat/intents/router.py
@@ -58,6 +58,9 @@ from pydantic import BaseModel, ConfigDict, Field, ValidationError
 from app.ai.voice.agents.breeze_buddy.chat.agent import ChatAgent
 from app.ai.voice.agents.breeze_buddy.chat.agent.runtime import is_approval_gated
 from app.ai.voice.agents.breeze_buddy.chat.client_context import diff_state_patch
+from app.ai.voice.agents.breeze_buddy.chat.custom_components import (
+    resolve_custom_components,
+)
 from app.ai.voice.agents.breeze_buddy.chat.history.block_codec import (
     assistant_turn_to_blocks,
     internal_text_block,
@@ -70,7 +73,11 @@ from app.ai.voice.agents.breeze_buddy.chat.turn_core import (
     resolve_session_catalog_version,
 )
 from app.ai.voice.agents.breeze_buddy.chat.ui.binding import resolve_show_op
+from app.ai.voice.agents.breeze_buddy.chat.ui.custom_defs import (
+    resolve_custom_show_op,
+)
 from app.ai.voice.agents.breeze_buddy.chat.ui.stream import (
+    OpResult,
     summarize_ui_ops,
     ui_op_dropped_event,
     ui_op_event,
@@ -330,7 +337,10 @@ def _structural_errors(exc: ValidationError) -> List[Dict[str, Any]]:
 
 
 def parse_ui_intent(
-    raw: Dict[str, Any], *, enabled_flavors: Optional[Set[str]] = None
+    raw: Dict[str, Any],
+    *,
+    enabled_flavors: Optional[Set[str]] = None,
+    extra_policies: Optional[Dict[str, IntentPolicy]] = None,
 ) -> ParsedIntent:
     """Validate one raw ``ui_intent`` body against the wire model + the
     per-intent payload schema. Raises :class:`IntentValidationError` (422
@@ -342,6 +352,11 @@ def parse_ui_intent(
     :func:`ensure_flavor_intents` on it first so an enabled flavor's
     intents are actually registered. ``None`` skips the flavor gate
     (trusted/internal callers only).
+
+    ``extra_policies`` — template-defined policies (see
+    ``template_intents.template_intent_policies``). Checked FIRST and
+    exempt from the flavor gate: they exist only for the one template that
+    configured them, which is a stricter scope than any flavor's.
     """
     try:
         wire = UiIntent.model_validate(raw)
@@ -349,6 +364,18 @@ def parse_ui_intent(
         raise IntentValidationError(
             "invalid_intent", "Malformed ui_intent body", _structural_errors(exc)
         ) from exc
+
+    template_policy = (extra_policies or {}).get(wire.intent)
+    if template_policy is not None:
+        try:
+            payload = template_policy.payload_model.model_validate(wire.payload)
+        except ValidationError as exc:
+            raise IntentValidationError(
+                "invalid_intent_payload",
+                f"Invalid payload for intent {wire.intent!r}",
+                _structural_errors(exc),
+            ) from exc
+        return ParsedIntent(intent=wire, policy=template_policy, payload=payload)
 
     policy = INTENT_POLICY.get(wire.intent)
     if policy is None:
@@ -665,12 +692,31 @@ async def run_direct_intent(
         ui_events: List[SSEEvent] = []
         if parsed.policy.show_op is not None:
             show_op = parsed.policy.show_op(final_tool, final_result, agent)
-            resolved = resolve_show_op(
-                show_op,
-                agent.binding_store,
-                agent.ui_allowlist,
-                agent.ui_flavor_groups,
+            # CHAMELEON: a template intent may target a REGISTRY custom
+            # component. Gated on the template's own opt-in list, so no DB
+            # fetch (and no behaviour change) for every flavor intent.
+            component = show_op.get("component")
+            ui_cat = (
+                template.configurations.ui_catalog if template.configurations else None
             )
+            custom_names = set(getattr(ui_cat, "custom_components", None) or [])
+            if isinstance(component, str) and component in custom_names:
+                custom_defs = await resolve_custom_components(template)
+
+                def_ = custom_defs.get(component)
+                if def_ is not None:
+                    resolved = resolve_custom_show_op(
+                        show_op, agent.binding_store, def_
+                    )
+                else:
+                    resolved = OpResult(error=f"custom_def_missing:{component}")
+            else:
+                resolved = resolve_show_op(
+                    show_op,
+                    agent.binding_store,
+                    agent.ui_allowlist,
+                    agent.ui_flavor_groups,
+                )
             if resolved.op is not None:
                 hydrated_ops.append(resolved.op)
                 ui_events.append(ui_op_event(resolved.op))

--- a/app/ai/voice/agents/breeze_buddy/chat/intents/template_intents.py
+++ b/app/ai/voice/agents/breeze_buddy/chat/intents/template_intents.py
@@ -1,0 +1,208 @@
+"""Template-DEFINED direct intents (CHAMELEON).
+
+Flavor packages register compiled-in :class:`IntentPolicy` rows; this module
+builds the config-authored equivalent from
+``configurations.ui_intents.custom`` — each entry becomes an ephemeral
+DIRECT policy whose ``drive`` runs the configured template tools through the
+same persisted pipeline (``inject_tool_args`` → dispatch → result pipeline →
+reducers) and whose ``show_op`` hydrates a REGISTRY custom component against
+this turn's binding store.
+
+Nothing here is transport- or merchant-specific: which tools run, which
+payload keys feed which args, and which component renders are all template
+config. Policies are built per request (cheap — closures over parsed
+config) and passed to ``parse_ui_intent`` as ``extra_policies``; they are
+never written into the process-global flavor registry, so two templates can
+define the same intent name without colliding.
+"""
+
+from typing import Any, AsyncIterator, Dict, Optional, Tuple
+
+from pydantic import BaseModel, ConfigDict
+
+from app.ai.voice.agents.breeze_buddy.chat.intents.router import (
+    IntentPolicy,
+    IntentRoute,
+    ParsedIntent,
+    error_events,
+    run_persisted_tool,
+)
+from app.ai.voice.agents.breeze_buddy.chat.sse import SSEEvent
+from app.ai.voice.agents.breeze_buddy.chat.ui.binding import (
+    parse_bind_ref,
+    resolve_json_pointer,
+)
+from app.ai.voice.agents.breeze_buddy.template.session_state import (
+    _is_tool_success,
+)
+from app.ai.voice.agents.breeze_buddy.template.types import CustomUiIntent
+from app.core.logger import logger
+
+
+class TemplateIntentPayload(BaseModel):
+    """Permissive payload shell for template intents: structural validation
+    is the step config's job (``args_from_payload`` fails closed on any
+    missing key), so the wire gate only enforces object shape."""
+
+    model_config = ConfigDict(extra="allow")
+
+
+def _dig(payload: Dict[str, Any], path: str) -> Any:
+    """Resolve one dot-path into the raw intent payload; None on any miss."""
+    cur: Any = payload
+    for part in path.split("."):
+        if not isinstance(cur, dict) or part not in cur:
+            return None
+        cur = cur[part]
+    return cur
+
+
+def _apply_enrich(agent: Any, cfg: CustomUiIntent) -> None:
+    """Run the config's cross-tool list-marking rules against this turn's
+    binding store, mutating the recorded payloads in place (the store hands
+    back the recorded object, so the show-op resolver sees the marks).
+    Fail-open by contract — enrichment is presentation, never allowed to
+    fail the intent."""
+    for rule in cfg.enrich:
+        try:
+            list_ref = parse_bind_ref(rule.list_ref)
+            equals_ref = parse_bind_ref(rule.equals_ref)
+            if list_ref is None or equals_ref is None:
+                logger.warning(
+                    f"template_intent {cfg.name!r}: enrich rule has a bad "
+                    f"bind ref; skipping"
+                )
+                continue
+            list_payload = agent.binding_store.resolve(
+                list_ref.tool_name, list_ref.tool_use_id
+            )
+            equals_payload = agent.binding_store.resolve(
+                equals_ref.tool_name, equals_ref.tool_use_id
+            )
+            if list_payload is None or equals_payload is None:
+                continue
+            items, found = resolve_json_pointer(list_payload, list_ref.pointer)
+            target, t_found = resolve_json_pointer(equals_payload, equals_ref.pointer)
+            # A null target (the API omitted the selected value) means
+            # "nothing to mark": leave the payload untouched rather than
+            # letting str(None) == str(None) mark every item that lacks
+            # the match field as selected.
+            if not found or not t_found or target is None:
+                continue
+            if not isinstance(items, list):
+                continue
+            marked = 0
+            for item in items:
+                if not isinstance(item, dict):
+                    continue
+                candidate = item.get(rule.match_field)
+                if candidate is not None and str(candidate) == str(target):
+                    item.update(rule.set)
+                    marked += 1
+                else:
+                    item.update(rule.else_set)
+
+            logger.info(
+                f"template_intent {cfg.name!r}: enrich matched {marked}/"
+                f"{len(items)} items on {rule.match_field!r}"
+            )
+        except Exception:  # noqa: BLE001 — decoration, never fatal
+            logger.exception(
+                f"template_intent {cfg.name!r}: enrich rule failed; skipping"
+            )
+
+
+def _make_drive(cfg: CustomUiIntent):
+    async def drive(
+        agent: Any,
+        prep: Any,
+        node: Dict[str, Any],
+        parsed: ParsedIntent,
+        turn_id: str,
+    ) -> AsyncIterator[Tuple[Optional[SSEEvent], Optional[str], Any]]:
+        payload = parsed.intent.payload or {}
+        final_tool: Optional[str] = None
+        final_result: Any = None
+        for step in cfg.steps:
+            args: Dict[str, Any] = dict(step.args)
+            missing = None
+            for arg, key in step.args_from_payload.items():
+                value = _dig(payload, key)
+                if value is None:
+                    missing = key
+                    break
+                args[arg] = value
+            if missing is not None:
+                logger.warning(
+                    f"template_intent {cfg.name!r}: payload key {missing!r} "
+                    f"missing for step {step.tool!r}"
+                )
+                for ev in error_events(
+                    "invalid_intent_payload",
+                    "This action is missing required details. Please try "
+                    "again from a fresh card.",
+                ):
+                    yield ev, None, None
+                return
+            events, result = await run_persisted_tool(
+                agent,
+                tool_name=step.tool,
+                args=args,
+                node=node,
+                prep=prep,
+                turn_id=turn_id,
+            )
+            for ev in events:
+                yield ev, None, None
+            final_tool, final_result = step.tool, result
+            if not _is_tool_success(result):
+                # Surface the failing step as the final pair — the engine
+                # shell renders the typed intent_tool_failed copy.
+                break
+        else:
+            # Every step succeeded — apply the cross-tool marks BEFORE the
+            # engine shell resolves the show op against the store.
+            if cfg.enrich:
+                _apply_enrich(agent, cfg)
+        yield None, final_tool, final_result
+
+    return drive
+
+
+def _make_show_op(cfg: CustomUiIntent):
+    def show_op(tool_name: str, result: Any, agent: Any) -> Dict[str, Any]:
+        # id 'root' — the widget's detail-overlay tree anchors on it.
+        op: Dict[str, Any] = {
+            "op": "show",
+            "id": "root",
+            "component": cfg.component,
+            "bind": dict(cfg.bind),
+        }
+        if cfg.props:
+            op["props"] = dict(cfg.props)
+        return op
+
+    return show_op
+
+
+def template_intent_policies(template: Any) -> Dict[str, IntentPolicy]:
+    """Build the per-request policy map off the template's
+    ``ui_intents.custom`` config. Empty config → empty map (zero cost on
+    every template that never opts in)."""
+    configurations = getattr(template, "configurations", None)
+    ui_intents = getattr(configurations, "ui_intents", None) if configurations else None
+    custom = list(getattr(ui_intents, "custom", None) or [])
+    policies: Dict[str, IntentPolicy] = {}
+    for cfg in custom:
+        policies[cfg.name] = IntentPolicy(
+            route=IntentRoute.DIRECT,
+            payload_model=TemplateIntentPayload,
+            default_display=cfg.display,
+            drive=_make_drive(cfg),
+            show_op=_make_show_op(cfg) if cfg.component else None,
+            silent=cfg.silent,
+        )
+    return policies
+
+
+__all__ = ["TemplateIntentPayload", "template_intent_policies"]

--- a/app/ai/voice/agents/breeze_buddy/chat/ui/custom_defs.py
+++ b/app/ai/voice/agents/breeze_buddy/chat/ui/custom_defs.py
@@ -68,7 +68,7 @@ RENDER_DEF_MAX_NODES = 400
 
 _NAME_RE = re.compile(r"^[A-Z][A-Za-z0-9]{1,63}$")
 _BINDING_RE = re.compile(r"^\$[A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z0-9_]+)*$")
-_ACTION_TYPES = frozenset({"to_assistant", "open_url", "open_detail"})
+_ACTION_TYPES = frozenset({"to_assistant", "open_url", "open_detail", "intent"})
 
 
 def _lint_action(action: Any, path: str, errors: List[str]) -> None:
@@ -109,6 +109,28 @@ def _lint_action(action: Any, path: str, errors: List[str]) -> None:
         title = action.get("title")
         if title is not None and not isinstance(title, str):
             errors.append(f"{path}: open_detail action title must be a string")
+    if a_type == "intent":
+        # Fires a template-defined DIRECT ui_intent (see
+        # UiIntentsConfig.custom) and — when `component` is present —
+        # opens the detail overlay armed to hydrate with that component.
+        # Same static-PascalCase rule as open_detail: data must never
+        # choose which def paints full-page.
+        name = action.get("name")
+        if not isinstance(name, str) or not name.strip():
+            errors.append(f"{path}: intent action needs a non-empty name")
+        component = action.get("component")
+        if component is not None and (
+            not isinstance(component, str) or not _NAME_RE.match(component)
+        ):
+            errors.append(
+                f"{path}: intent action component must be a static " "PascalCase name"
+            )
+        payload = action.get("payload")
+        if payload is not None and not isinstance(payload, dict):
+            errors.append(f"{path}: intent action payload must be an object")
+        title = action.get("title")
+        if title is not None and not isinstance(title, str):
+            errors.append(f"{path}: intent action title must be a string")
 
 
 def _lint_node(
@@ -172,8 +194,8 @@ def lint_render_def(render_def: Any) -> List[str]:
 
     Grammar v1: whitelisted node types, ``repeat``/``if`` binding syntax,
     depth ≤ {depth}, ≤ {nodes} nodes, actions restricted to
-    ``to_assistant``/``open_url``/``open_detail`` (static
-    open_url URLs https-only; open_detail components static
+    ``to_assistant``/``open_url``/``open_detail``/``intent`` (static
+    open_url URLs https-only; open_detail/intent components static
     PascalCase). No
     merchant JavaScript, no arbitrary expressions — ever.
     """.format(depth=RENDER_DEF_MAX_DEPTH, nodes=RENDER_DEF_MAX_NODES)

--- a/app/ai/voice/agents/breeze_buddy/template/field_reference.json
+++ b/app/ai/voice/agents/breeze_buddy/template/field_reference.json
@@ -561,6 +561,48 @@
       "example": {
         "checkout_page": "https://www.thebeyondbound.com/cart"
       }
+    },
+    "custom": {
+      "description": "Template-DEFINED direct intents (CHAMELEON): each entry runs the named template tools with NO LLM call and hydrates a registry custom component bound to their results — the config-authored counterpart of a flavor's compiled-in IntentPolicy. steps[] run in order (args = static `args` + `args_from_payload` dot-paths into the widget's intent payload, fail-closed on a missing key); `bind` maps component props to `$tool:<tool>#/<json-pointer>` refs over this turn's results; `enrich` rules mark list items across tools (e.g. the selected fare class); `silent` intents leave no visible thread trace. Names share the global intent namespace on the wire; a name that collides with a flavor intent shadows it for this template only.",
+      "example": [
+        {
+          "name": "journey_detail",
+          "steps": [
+            {
+              "tool": "get_journey_details",
+              "args_from_payload": {
+                "journey_id": "journey_id"
+              }
+            },
+            {
+              "tool": "get_tier_options",
+              "args_from_payload": {
+                "journey_id": "journey_id",
+                "leg_order": "leg_order"
+              }
+            }
+          ],
+          "component": "JourneyDetail",
+          "bind": {
+            "journey": "$tool:get_journey_details#/journey",
+            "tiers": "$tool:get_tier_options#/tiers"
+          },
+          "enrich": [
+            {
+              "list_ref": "$tool:get_tier_options#/tiers",
+              "match_field": "quote_id",
+              "equals_ref": "$tool:get_journey_details#/selected_quote_id",
+              "set": {
+                "selected": true
+              },
+              "else_set": {
+                "unselected": true
+              }
+            }
+          ],
+          "silent": true
+        }
+      ]
     }
   },
   "FlowNodeModel": {

--- a/app/ai/voice/agents/breeze_buddy/template/types.py
+++ b/app/ai/voice/agents/breeze_buddy/template/types.py
@@ -1479,6 +1479,106 @@ class UiIntentsConfig(BaseModel):
         "storefront /cart page) instead of the cart tool's checkout-bound "
         "continue_url; unset keeps continue_url.",
     )
+    custom: List["CustomUiIntent"] = Field(
+        default_factory=list,
+        description=(
+            "Template-DEFINED direct intents (CHAMELEON): each entry runs "
+            "the named template tools with NO LLM call and hydrates a "
+            "registry custom component bound to their results — the "
+            "config-authored counterpart of a flavor's compiled-in "
+            "IntentPolicy. Names share the global intent namespace on the "
+            "wire; a name that collides with a flavor intent shadows it "
+            "for this template only."
+        ),
+    )
+
+
+class CustomUiIntentStep(BaseModel):
+    """One tool dispatch inside a :class:`CustomUiIntent` — the tool must
+    exist on this template's function surface; args flow through the same
+    ``inject_tool_args`` pipeline an LLM call would use."""
+
+    tool: str = Field(..., min_length=1, max_length=128)
+    args: Dict[str, Any] = Field(
+        default_factory=dict,
+        description="Literal args merged under any payload-sourced ones.",
+    )
+    args_from_payload: Dict[str, str] = Field(
+        default_factory=dict,
+        description=(
+            "Tool arg name → dot-path into the intent payload. A missing "
+            "payload key fails the intent closed (typed intent_failed) — "
+            "never a tool call with a hole in its args."
+        ),
+    )
+
+
+class UiIntentEnrichRule(BaseModel):
+    """Cross-tool list marking, applied after a custom intent's steps
+    succeed: find the element of ``list_ref`` whose ``match_field`` equals
+    the scalar at ``equals_ref`` and merge ``set`` onto it (``else_set``
+    onto every other element). The generic answer to "mark the SELECTED
+    option" when one tool returns the options and another names the
+    current choice — per-tool response transforms can't see across tools.
+    Fail-open: unresolvable refs / non-list targets leave data untouched.
+    """
+
+    list_ref: str = Field(
+        ..., description="'$tool:<tool>#/<ptr>' bind ref to a LIST result."
+    )
+    match_field: str = Field(..., min_length=1)
+    equals_ref: str = Field(
+        ..., description="'$tool:<tool>#/<ptr>' bind ref to the scalar to match."
+    )
+    set: Dict[str, Any] = Field(
+        default_factory=dict, description="Merged onto the matching element(s)."
+    )
+    else_set: Dict[str, Any] = Field(
+        default_factory=dict, description="Merged onto non-matching elements."
+    )
+
+
+class CustomUiIntent(BaseModel):
+    """One template-defined DIRECT ui_intent (see ``UiIntentsConfig.custom``).
+
+    ``steps`` run in order through the persisted-tool pipeline; the LAST
+    step's success gates the show op. ``bind`` refs may point at ANY step's
+    result (``"<tool>#/<pointer>"`` — same grammar as render_ui binds).
+    """
+
+    name: str = Field(..., min_length=1, max_length=64)
+    steps: List[CustomUiIntentStep] = Field(..., min_length=1, max_length=4)
+    enrich: List[UiIntentEnrichRule] = Field(
+        default_factory=list,
+        description=(
+            "Cross-tool list-marking rules applied after the steps succeed "
+            "and before the component hydrates (e.g. stamp selected=true on "
+            "the tier whose quote_id the journey currently uses)."
+        ),
+    )
+    component: Optional[str] = Field(
+        None,
+        description=(
+            "Registry custom-component name to hydrate and stream after "
+            "the steps succeed (must be opted into via "
+            "ui_catalog.custom_components). None = tools only, no render."
+        ),
+    )
+    bind: Dict[str, str] = Field(
+        default_factory=dict,
+        description="Component prop → '<tool>#/<pointer>' bind ref.",
+    )
+    props: Dict[str, Any] = Field(
+        default_factory=dict, description="Literal component props."
+    )
+    silent: bool = Field(
+        True,
+        description=(
+            "Silent intents leave no visible thread trace (detail-overlay "
+            "hydration); non-silent ones post the display bubble."
+        ),
+    )
+    display: Optional[str] = Field(None, max_length=200)
 
 
 class RenderUiConfig(BaseModel):

--- a/app/api/routers/breeze_buddy/chat/handlers.py
+++ b/app/api/routers/breeze_buddy/chat/handlers.py
@@ -35,6 +35,9 @@ from app.ai.voice.agents.breeze_buddy.chat.intents.router import (
     run_direct_intent,
     template_enabled_flavors,
 )
+from app.ai.voice.agents.breeze_buddy.chat.intents.template_intents import (
+    template_intent_policies,
+)
 from app.ai.voice.agents.breeze_buddy.chat.metrics import TurnMetrics
 from app.ai.voice.agents.breeze_buddy.chat.sse import SSEEvent, format_sse
 from app.ai.voice.agents.breeze_buddy.chat.turn_core import (
@@ -620,7 +623,11 @@ async def serve_session_intent(
     flavors = template_enabled_flavors(template)
     ensure_flavor_intents(flavors)
     try:
-        parsed = parse_ui_intent(raw_intent, enabled_flavors=flavors)
+        parsed = parse_ui_intent(
+            raw_intent,
+            enabled_flavors=flavors,
+            extra_policies=template_intent_policies(template),
+        )
     except IntentValidationError as exc:
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,

--- a/tests/test_custom_defs.py
+++ b/tests/test_custom_defs.py
@@ -436,3 +436,62 @@ class TestRenderUiSurface:
         )
         assert outcome.fn_result["status"] == "error"
         assert "unknown component" in outcome.fn_result["error"]
+
+
+# ---------------------------------------------------------------------------
+# `intent` action — fires a template-defined DIRECT ui_intent
+# ---------------------------------------------------------------------------
+
+
+class TestIntentActionLint:
+    """The ``intent`` action fires a template-defined DIRECT ui_intent
+    (``UiIntentsConfig.custom``). Its name and overlay component are STATIC:
+    data never chooses which intent fires or which def paints full-page."""
+
+    @staticmethod
+    def _button(action: Dict[str, Any]) -> Dict[str, Any]:
+        return {"type": "button", "props": {"label": "Select", "action": action}}
+
+    def test_name_required_component_static_payload_object(self):
+        assert any(
+            "non-empty name" in e
+            for e in lint_render_def(self._button({"type": "intent", "name": " "}))
+        )
+        assert any(
+            "PascalCase" in e
+            for e in lint_render_def(
+                self._button(
+                    {
+                        "type": "intent",
+                        "name": "select_tier",
+                        "component": "journeyDetail",
+                    }
+                )
+            )
+        )
+        assert any(
+            "payload must be an object" in e
+            for e in lint_render_def(
+                self._button(
+                    {"type": "intent", "name": "select_tier", "payload": ["x"]}
+                )
+            )
+        )
+        assert any(
+            "title must be a string" in e
+            for e in lint_render_def(
+                self._button({"type": "intent", "name": "select_tier", "title": 3})
+            )
+        )
+
+    def test_clean_intent_action_passes(self):
+        good = self._button(
+            {
+                "type": "intent",
+                "name": "select_tier",
+                "component": "JourneyDetail",
+                "title": "Your journey",
+                "payload": {"journey_id": "$j.id", "quote_id": "{$t.quote_id}"},
+            }
+        )
+        assert lint_render_def(good) == []

--- a/tests/test_direct_intent_engine.py
+++ b/tests/test_direct_intent_engine.py
@@ -265,3 +265,268 @@ def _install_direct_intent_stubs(monkeypatch, capture_merge):
     monkeypatch.setattr(router, "create_aiohttp_session", lambda: None)
     monkeypatch.setattr(router, "upsert_agent_session_state_merge", capture_merge)
     monkeypatch.setattr(router, "ChatAgent", _Agent)
+
+
+# ---------------------------------------------------------------------------
+# Template-intent enrich rules — cross-tool selected-marking
+# ---------------------------------------------------------------------------
+
+
+def test_template_intent_enrich_marks_selected_tier():
+    from app.ai.voice.agents.breeze_buddy.chat.intents.template_intents import (
+        _apply_enrich,
+    )
+    from app.ai.voice.agents.breeze_buddy.chat.ui.binding import BindingStore
+    from app.ai.voice.agents.breeze_buddy.template.types import (
+        CustomUiIntent,
+        CustomUiIntentStep,
+        UiIntentEnrichRule,
+    )
+
+    store = BindingStore()
+    store.record(
+        "get_journey_details",
+        None,
+        {"status": "success", "selected_quote_id": "q2"},
+    )
+    store.record(
+        "get_tier_options",
+        None,
+        {
+            "status": "success",
+            "tiers": [
+                {"quote_id": "q1", "name": "First Class"},
+                {"quote_id": "q2", "name": "Second Class"},
+            ],
+        },
+    )
+
+    class _Agent:
+        binding_store = store
+
+    cfg = CustomUiIntent(
+        name="journey_detail",
+        steps=[CustomUiIntentStep(tool="get_journey_details")],
+        enrich=[
+            UiIntentEnrichRule(
+                list_ref="$tool:get_tier_options#/tiers",
+                match_field="quote_id",
+                equals_ref="$tool:get_journey_details#/selected_quote_id",
+                set={"selected": True, "state_label": "Selected"},
+                else_set={"unselected": True},
+            )
+        ],
+    )
+    _apply_enrich(_Agent(), cfg)
+    tiers = store.resolve("get_tier_options")["tiers"]
+    assert tiers[1]["selected"] is True and tiers[1]["state_label"] == "Selected"
+    assert "selected" not in tiers[0] and tiers[0]["unselected"] is True
+
+
+def test_template_intent_enrich_null_target_marks_nothing():
+    """A null match target (the API omitted the selected value) must leave
+    the list untouched — the earlier str() compare marked every item that
+    lacked the match field as selected (str(None) == str(None))."""
+    from app.ai.voice.agents.breeze_buddy.chat.intents.template_intents import (
+        _apply_enrich,
+    )
+    from app.ai.voice.agents.breeze_buddy.chat.ui.binding import BindingStore
+    from app.ai.voice.agents.breeze_buddy.template.types import (
+        CustomUiIntent,
+        CustomUiIntentStep,
+        UiIntentEnrichRule,
+    )
+
+    store = BindingStore()
+    store.record("gjd", None, {"status": "success", "selected_quote_id": None})
+    store.record(
+        "tiers",
+        None,
+        {"status": "success", "tiers": [{"name": "no quote id"}, {"quote_id": "q1"}]},
+    )
+
+    class _Agent:
+        binding_store = store
+
+    rule = UiIntentEnrichRule(
+        list_ref="$tool:tiers#/tiers",
+        match_field="quote_id",
+        equals_ref="$tool:gjd#/selected_quote_id",
+        set={"selected": True},
+        else_set={"unselected": True},
+    )
+    cfg = CustomUiIntent(
+        name="n", steps=[CustomUiIntentStep(tool="gjd")], enrich=[rule]
+    )
+    _apply_enrich(_Agent(), cfg)
+    assert store.resolve("tiers")["tiers"] == [
+        {"name": "no quote id"},
+        {"quote_id": "q1"},
+    ]
+
+    # a real target still never matches an item that lacks the field
+    store.record("gjd", None, {"status": "success", "selected_quote_id": "q1"})
+    _apply_enrich(_Agent(), cfg)
+    tiers = store.resolve("tiers")["tiers"]
+    assert tiers[0] == {"name": "no quote id", "unselected": True}
+    assert tiers[1]["selected"] is True
+
+
+def test_template_intent_enrich_fail_open():
+
+    from app.ai.voice.agents.breeze_buddy.chat.intents.template_intents import (
+        _apply_enrich,
+    )
+    from app.ai.voice.agents.breeze_buddy.chat.ui.binding import BindingStore
+    from app.ai.voice.agents.breeze_buddy.template.types import (
+        CustomUiIntent,
+        CustomUiIntentStep,
+        UiIntentEnrichRule,
+    )
+
+    store = BindingStore()
+    store.record("t", None, {"status": "success", "xs": [{"id": "a"}]})
+
+    class _Agent:
+        binding_store = store
+
+    # bad ref + missing tool + non-list target: all silently skipped
+    cfg = CustomUiIntent(
+        name="n",
+        steps=[CustomUiIntentStep(tool="t")],
+        enrich=[
+            UiIntentEnrichRule(
+                list_ref="no-prefix#/xs",
+                match_field="id",
+                equals_ref="$tool:t#/missing",
+                set={"s": 1},
+            ),
+            UiIntentEnrichRule(
+                list_ref="$tool:absent#/xs",
+                match_field="id",
+                equals_ref="$tool:t#/xs",
+                set={"s": 1},
+            ),
+        ],
+    )
+    _apply_enrich(_Agent(), cfg)
+    assert store.resolve("t")["xs"] == [{"id": "a"}]
+
+
+@pytest.mark.asyncio
+async def test_template_intent_drive_runs_steps_in_order_and_fails_closed(monkeypatch):
+    """The config-authored drive: steps dispatch IN ORDER through the shared
+    persisted-tool path (static args merged with payload dot-paths), a
+    missing payload key fails CLOSED before any dispatch, and a failing
+    step ends the run as the final (tool, result) pair the engine shell
+    reports. The show op it hands back anchors on id 'root'."""
+    from types import SimpleNamespace
+
+    from app.ai.voice.agents.breeze_buddy.chat.intents.template_intents import (
+        TemplateIntentPayload,
+        template_intent_policies,
+    )
+    from app.ai.voice.agents.breeze_buddy.template.types import (
+        CustomUiIntent,
+        CustomUiIntentStep,
+    )
+
+    async def _noop_persist(*_a, **_k):
+        return None
+
+    monkeypatch.setattr(router, "_persist_tool_step", _noop_persist)
+
+    cfg = CustomUiIntent(
+        name="journey_detail",
+        steps=[
+            CustomUiIntentStep(
+                tool="get_journey_details",
+                args_from_payload={"journey_id": "journey.id"},
+            ),
+            CustomUiIntentStep(
+                tool="get_tier_options",
+                args={"leg_order": 0},
+                args_from_payload={"journey_id": "journey.id"},
+            ),
+        ],
+        component="JourneyDetail",
+        bind={"legs": "$tool:get_journey_details#/legs"},
+    )
+    template = SimpleNamespace(
+        configurations=SimpleNamespace(ui_intents=SimpleNamespace(custom=[cfg]))
+    )
+    policy = template_intent_policies(template)["journey_detail"]
+    assert policy.route is IntentRoute.DIRECT and policy.silent is True
+    assert template_intent_policies(SimpleNamespace(configurations=None)) == {}
+
+    def _parsed(payload):
+        return ParsedIntent(
+            intent=UiIntent(
+                intent="journey_detail", component_id="card-1", payload=payload
+            ),
+            policy=policy,
+            payload=TemplateIntentPayload(),
+        )
+
+    drive = policy.drive
+    assert drive is not None
+
+    async def _run(agent, payload):
+        return [
+            item
+            async for item in drive(  # pyrefly: ignore[not-callable] (narrowed above)
+                agent,  # pyrefly: ignore[bad-argument-type]
+                None,
+                {},
+                _parsed(payload),
+                "t1",
+            )
+        ]
+
+    # happy path: both steps, in order, static args merged with payload paths
+    agent = _StubAgent()
+    out = await _run(agent, {"journey": {"id": "J1"}})
+    assert agent.dispatched == [
+        ("get_journey_details", {"journey_id": "J1"}),
+        ("get_tier_options", {"leg_order": 0, "journey_id": "J1"}),
+    ]
+    assert out[-1] == (None, "get_tier_options", {"ok": True})
+    show_op = policy.show_op
+    assert show_op is not None
+    rendered = show_op(
+        "get_tier_options",
+        {"ok": True},
+        agent,  # pyrefly: ignore[bad-argument-type]
+    )
+    assert rendered == {
+        "op": "show",
+        "id": "root",
+        "component": "JourneyDetail",
+        "bind": {"legs": "$tool:get_journey_details#/legs"},
+    }
+
+    # missing payload key: fails closed BEFORE any dispatch, typed notice
+    agent = _StubAgent()
+    out = await _run(agent, {"journey": {}})
+    assert agent.dispatched == []
+    assert [ev.event for ev, _, _ in out if ev is not None] == [
+        "intent_failed",
+        "turn_end",
+    ]
+
+    # a failing step stops the run and is reported as the final pair
+    class _FailsFirst(_StubAgent):
+        async def run_direct_tool(  # pyrefly: ignore[bad-override]
+            self, *, tool_name, args, node, prep, turn_id
+        ):
+            self.dispatched.append((tool_name, dict(args)))
+            return _Call("call-1", dict(args)), {"status": "error", "error": "boom"}
+
+    agent = _FailsFirst()
+    out = await _run(agent, {"journey": {"id": "J1"}})
+    assert [t for t, _ in agent.dispatched] == ["get_journey_details"]
+    assert out[-1] == (
+        None,
+        "get_journey_details",
+        {"status": "error", "error": "boom"},
+    )


### PR DESCRIPTION
Config-authored IntentPolicies on the existing /intent engine
(ui_intents.custom): each entry runs the named template tools with NO LLM
call (args = static values + payload dot-paths, fail-closed on a missing
key) through the persisted pipeline, applies cross-tool enrich rules that
mark list items (e.g. the selected fare tier - a null target marks
nothing), and hydrates a registry custom component as the show op.
parse_ui_intent gains extra_policies (checked first, template-scoped,
exempt from the flavor gate); run_direct_intent resolves registry
components via resolve_custom_show_op. The render_def grammar gains the
`intent` action (static name and PascalCase component; payload
interpolates) so a card button can fire one.

**Part 7 of 7** of the split of #1039 — the review feedback from there is already incorporated. Parts 1–5 are independent of each other and of the CHAMELEON stack (5 → 6 → 7).

### Validation (this branch alone)
- `uv run pytest tests/`: 2315 passed · `pyrefly` 0 errors · black / isort / autoflake clean · migration-numbering and CRM-boundary guards OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MExhDfX8SUSdPpA8ruW4sG
