### PR TITLE
fix(chat): drop quick-reply chips that carry raw identifiers

### DIFF
--- a/app/ai/voice/agents/breeze_buddy/chat/agent/runtime.py
+++ b/app/ai/voice/agents/breeze_buddy/chat/agent/runtime.py
@@ -9,6 +9,8 @@ from typing import Any, Dict, List, Optional, Tuple
 from pipecat.adapters.schemas.tools_schema import ToolsSchema
 from pipecat_flows import FlowsFunctionSchema
 
+from app.ai.voice.agents.breeze_buddy.chat.ui.chips import carries_identifier
+
 # Each tool-call → handler → re-invoke counts as one cycle. The guard stops a
 # pathological template (handler always returns a transition that loops back)
 # from burning unbounded LLM calls. Set to 20 (was 8): legitimate multi-item
@@ -55,16 +57,24 @@ _ANSWER_NUDGE = (
 def _chip_labels(raw: Any) -> List[str]:
     """Lift a `quick_replies` arg (strings canonical; {'label': …} dicts
     tolerated) into clean labels — same tolerance as execute_render_ui's
-    extraction, kept tiny here for the rider-harvest path."""
+    extraction, kept tiny here for the rider-harvest path.
+
+    Labels carrying raw identifiers (UUIDs / long hex ids) are DROPPED —
+    a chip is user-facing copy, and an id in one is always a model
+    mistake (live-observed: "Select <journey uuid>" chips); ids belong in
+    UI actions' `msg`, never on a pill."""
     if not isinstance(raw, list):
         return []
     labels: List[str] = []
     for entry in raw:
+        label = None
         if isinstance(entry, str) and entry.strip():
-            labels.append(entry.strip())
+            label = entry.strip()
         elif isinstance(entry, dict) and isinstance(entry.get("label"), str):
             if entry["label"].strip():
-                labels.append(entry["label"].strip())
+                label = entry["label"].strip()
+        if label and not carries_identifier(label):
+            labels.append(label)
     return labels[:5]
 
 

--- a/app/ai/voice/agents/breeze_buddy/chat/ui/chips.py
+++ b/app/ai/voice/agents/breeze_buddy/chat/ui/chips.py
@@ -1,0 +1,28 @@
+"""Quick-reply chip hygiene, shared by BOTH harvest paths — render_ui's
+QuickReplies extraction (chat/ui/render_ui_tool.py) and the rider harvest
+(chat/agent/runtime.py) — so the rule lives in exactly one place."""
+
+import re
+
+_IDENTIFIER_RE = re.compile(
+    r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+    # A 16+ hex run that contains at least one letter: no word boundary (ids
+    # hide behind "_" or "0x"), and pure digit runs are NOT ids — a 16-digit
+    # order or tracking number is legitimate chip copy.
+    r"|(?=[0-9]*[a-f])[0-9a-f]{16,}",
+    re.IGNORECASE,
+)
+
+
+def carries_identifier(label: str) -> bool:
+    """True when a chip label contains a UUID or a 16+ char hex id.
+
+    A chip is user-facing copy, so an id in one is always a model mistake
+    (live-observed: "Select <journey uuid>" pills); ids belong in a UI
+    action's ``msg``, never on a pill. Ordinary labels ("Bus 5C",
+    "Platform 2", "Track order 1234567890123456") never match: no real word
+    carries sixteen consecutive hex characters, so the hex run needs no word
+    boundary ("Order_0123456789abcdef01", "0xdeadbeefcafebabe" match), and a
+    run without a single a-f letter is a number, not an id.
+    """
+    return bool(_IDENTIFIER_RE.search(label))

--- a/app/ai/voice/agents/breeze_buddy/chat/ui/render_ui_tool.py
+++ b/app/ai/voice/agents/breeze_buddy/chat/ui/render_ui_tool.py
@@ -41,6 +41,7 @@ from app.ai.voice.agents.breeze_buddy.chat.ui.binding import (
     resolve_show_op,
     selector_extension_keys,
 )
+from app.ai.voice.agents.breeze_buddy.chat.ui.chips import carries_identifier
 from app.ai.voice.agents.breeze_buddy.chat.ui.custom_defs import (
     resolve_custom_show_op,
     summarize_custom_render,
@@ -655,7 +656,26 @@ def execute_render_ui(
                 chip_items.append(
                     {k: v for k, v in entry.items() if k in ("label", "value") and v}
                 )
-        props["items"] = chip_items
+        # Chips are user-facing copy: drop any carrying a raw identifier —
+        # the same guard the rider-harvest path applies (chat/ui/chips.py).
+        kept = [
+            item for item in chip_items if not carries_identifier(item.get("label", ""))
+        ]
+        if chip_items and not kept:
+            # Every chip was an id: say WHY, so the model re-emits real
+            # labels instead of reading a generic schema error.
+            return RenderUiOutcome(
+                fn_result={
+                    "status": "error",
+                    "error": (
+                        "QuickReplies chips are user-facing copy: every chip "
+                        "carried a raw identifier. Re-emit short labels and "
+                        "keep ids in the action msg."
+                    ),
+                },
+                component=component,
+            )
+        props["items"] = kept
     if component == "LinkButton":
         link = args.get("link")
         if not (isinstance(link, dict) and isinstance(link.get("url"), str)):

--- a/tests/test_chip_labels.py
+++ b/tests/test_chip_labels.py
@@ -1,0 +1,73 @@
+"""Quick-reply chips are user-facing copy: a raw identifier in one is always
+a model mistake (live-observed "Select <journey uuid>" pills), so the
+harvest path drops such labels instead of showing them."""
+
+from __future__ import annotations
+
+from app.ai.voice.agents.breeze_buddy.chat.agent.runtime import _chip_labels
+
+
+def test_chip_labels_drop_raw_identifiers():
+    raw = [
+        "Book now",
+        "Select 3f2a1b4c-5d6e-4f70-8a9b-0c1d2e3f4a5b",
+        {"label": "Ticket 0123456789abcdef01"},
+        {"label": "Show other routes"},
+        "",
+        {"label": "   "},
+        42,
+    ]
+    assert _chip_labels(raw) == ["Book now", "Show other routes"]
+
+
+def test_chip_labels_keep_ordinary_labels_and_cap_at_five():
+    labels = ["Bus 5C", "Platform 2", "Metro", "Train", "Walk", "Auto"]
+    assert _chip_labels(labels) == labels[:5]
+    assert _chip_labels("not a list") == []
+
+
+def test_render_ui_quick_replies_extraction_uses_the_same_guard():
+    from app.ai.voice.agents.breeze_buddy.chat.ui.chips import carries_identifier
+
+    assert carries_identifier("Select 3f2a1b4c-5d6e-4f70-8a9b-0c1d2e3f4a5b")
+    assert carries_identifier("order 0123456789ABCDEF")
+    # prefixed / embedded ids (no word boundary before the hex run)
+    assert carries_identifier("Order_0123456789abcdef01")
+    assert carries_identifier("Pay 0xdeadbeefcafebabe now")
+    assert not carries_identifier("Deadline 2026-09-07 at 15:30")
+    # pure digit runs are numbers people read, not ids
+    assert not carries_identifier("Track order 1234567890123456")
+    assert not carries_identifier("Card ending 4242")
+    assert not carries_identifier("Bus 5C") and not carries_identifier("Platform 2")
+
+
+def test_render_ui_quick_replies_drop_ids_and_explain_when_none_survive():
+    from app.ai.voice.agents.breeze_buddy.chat.ui.binding import BindingStore
+    from app.ai.voice.agents.breeze_buddy.chat.ui.render_ui_tool import (
+        execute_render_ui,
+        render_ui_components,
+    )
+    from app.ai.voice.agents.breeze_buddy.template.ui_catalog import resolve_allowlist
+
+    allow = resolve_allowlist(enabled_groups=["core", "commerce"])
+    comps = render_ui_components(allow, True)
+
+    def run(chips):
+        return execute_render_ui(
+            {"component": "QuickReplies", "quick_replies": chips},
+            store=BindingStore(),
+            allowlist=allow,
+            components=comps,
+            op_id="rui1",
+        )
+
+    mixed = run(["Book now", "Select 3f2a1b4c-5d6e-4f70-8a9b-0c1d2e3f4a5b", "Help"])
+    assert mixed.decision == "rendered"
+    assert [i["label"] for i in mixed.ops[0]["props"]["items"]] == ["Book now", "Help"]
+
+    none_left = run(["Select 3f2a1b4c-5d6e-4f70-8a9b-0c1d2e3f4a5b"])
+    assert none_left.decision != "rendered" and none_left.ops == []
+    assert "raw identifier" in none_left.fn_result["error"]
+
+    numeric = run(["Track order 1234567890123456"])
+    assert numeric.decision == "rendered"


### PR DESCRIPTION
The rider-harvest path lifts a turn's `quick_replies` into pills. A chip is user-facing copy, and an id in one is always a model mistake (live-observed "Select <journey uuid>" chips). Labels containing a UUID or a 16+ hex id are dropped; ids belong in a UI action's `msg`, never on a pill.

**Part 8** of the split of #1039 — found bundled into #1094 during review and pulled out: it is a standalone behaviour fix for every template, not part of the session overlay. Independent of everything else.

### Validation (this branch alone)
- `uv run pytest tests/`: 2397 passed · `pyrefly` 0 errors · black / isort / autoflake clean · guards OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MExhDfX8SUSdPpA8ruW4sG


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented quick-reply chips containing raw UUIDs or long hexadecimal identifiers from appearing to users.
  * Applied consistent identifier filtering across chat suggestions and rendered quick replies.
  * Preserved ordinary labels while limiting displayed suggestions to five entries.

* **Tests**
  * Added coverage for identifier filtering, valid labels, entry limits, invalid input, and UI extraction behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->