### PR TITLE
feat(credentials): add merchant_id to credentials

### DIFF
--- a/app/api/routers/breeze_buddy/credentials/__init__.py
+++ b/app/api/routers/breeze_buddy/credentials/__init__.py
@@ -17,6 +17,9 @@ from typing import List, Optional
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 
 from app.api.security.breeze_buddy.rbac_token import get_current_user_with_rbac
+from app.database.accessor.breeze_buddy.merchants import (
+    get_merchant_by_merchant_identifier,
+)
 from app.schemas import (
     CreateCredentialRequest,
     Credential,
@@ -48,7 +51,9 @@ async def create_credential_endpoint(
     Create a new credential.
 
     - Global credentials (reseller_id=null): available to all merchants as {name} placeholder
-    - Merchant credentials (reseller_id set): available only to that merchant's templates
+    - Reseller credentials (reseller_id set): available to every merchant of that reseller
+    - Merchant credentials (reseller_id + merchant_id): only that merchant; wins over the
+      reseller row of the same name
 
     Values are encrypted at rest when CREDENTIAL_ENCRYPTION_KEY is configured.
     """
@@ -67,7 +72,37 @@ async def create_credential_endpoint(
         ):
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,
-                detail=f"Access denied to merchant {req.reseller_id}",
+                detail=f"Access denied to reseller {req.reseller_id}",
+            )
+
+    if req.merchant_id:
+        # A merchant row always sits under its reseller (DB CHECK says the same).
+        if not req.reseller_id:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="merchant_id requires reseller_id",
+            )
+        if current_user.role != "admin" and (
+            req.merchant_id not in current_user.merchant_ids
+            and "*" not in current_user.merchant_ids
+        ):
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail=f"Access denied to merchant {req.merchant_id}",
+            )
+        # The merchant must actually belong to this reseller: a user may hold
+        # access to both ids independently, and a row scoped to the wrong
+        # reseller would never resolve for the merchant's real one.
+        merchant = await get_merchant_by_merchant_identifier(req.merchant_id)
+        if merchant is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Merchant {req.merchant_id} not found",
+            )
+        if merchant.reseller_id != req.reseller_id:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"Merchant {req.merchant_id} does not belong to reseller {req.reseller_id}",
             )
 
     return await create_credential_handler(req, current_user)
@@ -78,10 +113,14 @@ async def list_credentials_endpoint(
     reseller_id: Optional[str] = Query(
         None, description="Filter by reseller ID. Omit to list all (admin only)."
     ),
+    merchant_id: Optional[str] = Query(
+        None,
+        description="With reseller_id: also include that merchant's own rows.",
+    ),
     current_user: UserInfo = Depends(get_current_user_with_rbac),
 ):
     """
-    List credentials with optional merchant filter.
+    List credentials with optional reseller / merchant filter.
 
     - Admin: sees all credentials or filtered by merchant
     - Merchant: must provide reseller_id, sees merchant + global credentials
@@ -92,6 +131,14 @@ async def list_credentials_endpoint(
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Non-admin users must provide a reseller_id filter",
+        )
+
+    # A merchant filter only means something under a reseller; without one
+    # the request would fall through to the unfiltered admin listing.
+    if merchant_id and not reseller_id:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="merchant_id requires reseller_id",
         )
 
     # Validate merchant access
@@ -105,7 +152,20 @@ async def list_credentials_endpoint(
                 detail=f"Access denied to reseller {reseller_id}",
             )
 
-    return await list_credentials_handler(reseller_id, current_user)
+    if (
+        merchant_id
+        and current_user.role != "admin"
+        and (
+            merchant_id not in current_user.merchant_ids
+            and "*" not in current_user.merchant_ids
+        )
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=f"Access denied to merchant {merchant_id}",
+        )
+
+    return await list_credentials_handler(reseller_id, current_user, merchant_id)
 
 
 @router.get("/credentials/{credential_id}", response_model=Credential)

--- a/app/api/routers/breeze_buddy/credentials/handlers.py
+++ b/app/api/routers/breeze_buddy/credentials/handlers.py
@@ -36,6 +36,7 @@ async def create_credential_handler(
     try:
         credential = await create_credential(
             reseller_id=req.reseller_id,
+            merchant_id=req.merchant_id,
             name=req.name,
             credential_type=req.credential_type,
             value=req.value,
@@ -64,16 +65,19 @@ async def create_credential_handler(
 async def list_credentials_handler(
     reseller_id: Optional[str],
     current_user: UserInfo,
+    merchant_id: Optional[str] = None,
 ) -> List[Credential]:
-    """List credentials with optional merchant filter."""
+    """List credentials with optional reseller / merchant filter."""
     logger.info(
         f"User {current_user.username} listing credentials "
-        f"(reseller={reseller_id or 'all'})"
+        f"(reseller={reseller_id or 'all'} merchant={merchant_id or '-'})"
     )
 
     try:
         if reseller_id:
-            return await get_credentials_by_merchant(reseller_id, mask=True)
+            return await get_credentials_by_merchant(
+                reseller_id, mask=True, merchant_id=merchant_id
+            )
         else:
             return await get_all_credentials(mask=True)
 

--- a/app/database/accessor/breeze_buddy/credentials.py
+++ b/app/database/accessor/breeze_buddy/credentials.py
@@ -104,9 +104,13 @@ async def create_credential(
     credential_type: CredentialType,
     value: Dict[str, Any],
     description: Optional[str] = None,
+    merchant_id: Optional[str] = None,
 ) -> Optional[Credential]:
     """Create a new credential with optional KMS encryption."""
-    logger.info(f"Creating credential '{name}' for merchant: {reseller_id or 'GLOBAL'}")
+    logger.info(
+        f"Creating credential '{name}' for reseller: {reseller_id or 'GLOBAL'}"
+        + (f" merchant: {merchant_id}" if merchant_id else "")
+    )
 
     try:
         # Validate value structure matches credential_type
@@ -122,6 +126,7 @@ async def create_credential(
             value=stored_value,
             is_encrypted=is_encrypted,
             description=description,
+            merchant_id=merchant_id,
         )
 
         result = await run_parameterized_query(query_text, values)
@@ -187,13 +192,15 @@ async def get_credential_by_name(
 async def get_credentials_by_merchant(
     reseller_id: Optional[str],
     mask: bool = True,
+    merchant_id: Optional[str] = None,
 ) -> List[Credential]:
     """
-    Get credentials for a merchant (includes global credentials).
-    Results ordered: global first, then merchant-specific.
+    Get the credentials a tenant can see: global, the reseller's, and —
+    when ``merchant_id`` is given — that merchant's own rows.
+    Results ordered least-specific first (global, reseller, merchant).
     """
     try:
-        query_text, values = get_credentials_by_merchant_query(reseller_id)
+        query_text, values = get_credentials_by_merchant_query(reseller_id, merchant_id)
         result = await run_parameterized_query(query_text, values)
         return decode_credential_list(result, mask=mask)
     except Exception as e:
@@ -214,13 +221,14 @@ async def get_all_credentials(mask: bool = True) -> List[Credential]:
 
 async def get_credentials_as_template_vars(
     reseller_id: str,
+    merchant_id: Optional[str] = None,
 ) -> Dict[str, Any]:
     """
     Get credentials as a flat dict for template_vars resolution.
-    Merges global + merchant-specific credentials (merchant overrides global).
+    Merges global + reseller (+ merchant when given); most specific wins.
     """
     try:
-        query_text, values = get_credentials_by_merchant_query(reseller_id)
+        query_text, values = get_credentials_by_merchant_query(reseller_id, merchant_id)
         result = await run_parameterized_query(query_text, values)
         return decode_credentials_as_dict(result)
     except Exception as e:

--- a/app/database/decoder/breeze_buddy/credentials.py
+++ b/app/database/decoder/breeze_buddy/credentials.py
@@ -48,6 +48,7 @@ def decode_credential(
     return Credential(
         id=str(row["id"]),
         reseller_id=row["reseller_id"],
+        merchant_id=row["merchant_id"] if "merchant_id" in row.keys() else None,
         name=row["name"],
         credential_type=CredentialType(row["credential_type"]),
         value=_mask_credential_value(real_value) if mask else real_value,
@@ -91,8 +92,9 @@ def decode_credentials_as_dict(
     For basic_auth: {"api_username": "user", "api_password": "pass"}
     For custom: all key-value pairs are flattened
 
-    If multiple credentials share the same key, reseller-specific overrides global
-    (query must ORDER BY reseller_id NULLS FIRST).
+    If multiple credentials share the same key, the most specific wins:
+    merchant over reseller over global (query must ORDER BY reseller_id
+    NULLS FIRST, merchant_id NULLS FIRST).
     """
     if not result:
         return {}

--- a/app/database/migrations/071_credentials_merchant_id.sql
+++ b/app/database/migrations/071_credentials_merchant_id.sql
@@ -1,0 +1,22 @@
+-- 071: merchant-scoped credentials.
+--
+-- A credential row was reseller-wide (reseller_id) or global (NULL). Some
+-- integrations are per merchant — the agentic "uap" row holds one Juspay
+-- merchant and one NammaYatri host — so a row may now name a merchant too.
+-- Resolution is most-specific-wins: merchant row, else the reseller row,
+-- else the global row. Existing rows have merchant_id NULL and behave
+-- exactly as before.
+ALTER TABLE credentials
+    ADD COLUMN IF NOT EXISTS merchant_id varchar NULL;
+
+-- A merchant row always sits under its reseller (tenancy law): no
+-- merchant-scoped global credentials.
+ALTER TABLE credentials
+    DROP CONSTRAINT IF EXISTS credentials_merchant_needs_reseller;
+ALTER TABLE credentials
+    ADD CONSTRAINT credentials_merchant_needs_reseller
+    CHECK (merchant_id IS NULL OR reseller_id IS NOT NULL);
+
+CREATE INDEX IF NOT EXISTS credentials_scope_ix
+    ON credentials (reseller_id, merchant_id, name)
+    WHERE is_active;

--- a/app/database/queries/breeze_buddy/credentials.py
+++ b/app/database/queries/breeze_buddy/credentials.py
@@ -16,18 +16,20 @@ def insert_credential_query(
     value: str,
     is_encrypted: bool,
     description: Optional[str],
+    merchant_id: Optional[str] = None,
 ) -> Tuple[str, List[Any]]:
     """Generate query to insert a credential record."""
     text = f"""
         INSERT INTO "{CREDENTIALS_TABLE}"
-        ("id", "reseller_id", "name", "credential_type", "value",
+        ("id", "reseller_id", "merchant_id", "name", "credential_type", "value",
          "is_encrypted", "description", "is_active", "created_at", "updated_at")
-        VALUES ($1, $2, $3, $4, $5, $6, $7, TRUE, $8, $9)
+        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, TRUE, $9, $10)
         RETURNING *;
     """
     values = [
         id,
         reseller_id,
+        merchant_id,
         name,
         credential_type,
         value,
@@ -47,16 +49,33 @@ def get_credential_by_id_query(credential_id: str) -> Tuple[str, List[Any]]:
 
 def get_credentials_by_merchant_query(
     reseller_id: Optional[str],
+    merchant_id: Optional[str] = None,
 ) -> Tuple[str, List[Any]]:
     """
-    Generate query to get credentials for a merchant.
-    If reseller is provided, returns reseller-specific + global credentials.
-    If reseller is None, returns only global credentials.
+    Generate query to get the credentials a tenant can see.
+
+    reseller given            -> global + that reseller's reseller-wide rows
+    reseller + merchant given -> the above + that merchant's rows
+    neither                   -> only global rows
+
+    Ordered least-specific first (global, reseller, merchant) so a caller
+    that merges by name ends up with the most specific row winning.
     """
+    if reseller_id and merchant_id:
+        text = f"""
+            SELECT * FROM "{CREDENTIALS_TABLE}"
+            WHERE ("reseller_id" IS NULL
+                   OR ("reseller_id" = $1
+                       AND ("merchant_id" IS NULL OR "merchant_id" = $2)))
+            AND "is_active" = TRUE
+            ORDER BY "reseller_id" NULLS FIRST, "merchant_id" NULLS FIRST, "name" ASC;
+        """
+        return text, [reseller_id, merchant_id]
     if reseller_id:
         text = f"""
             SELECT * FROM "{CREDENTIALS_TABLE}"
             WHERE ("reseller_id" = $1 OR "reseller_id" IS NULL)
+            AND "merchant_id" IS NULL
             AND "is_active" = TRUE
             ORDER BY "reseller_id" NULLS FIRST, "name" ASC;
         """
@@ -104,7 +123,7 @@ def get_credential_by_name_query(
 
 def get_all_credentials_query() -> Tuple[str, List[Any]]:
     """Generate query to get all credentials."""
-    text = f'SELECT * FROM "{CREDENTIALS_TABLE}" where "is_active" = TRUE ORDER BY "reseller_id" NULLS FIRST, "name" ASC;'
+    text = f'SELECT * FROM "{CREDENTIALS_TABLE}" where "is_active" = TRUE ORDER BY "reseller_id" NULLS FIRST, "merchant_id" NULLS FIRST, "name" ASC;'
     return text, []
 
 

--- a/app/schemas/breeze_buddy/credentials.py
+++ b/app/schemas/breeze_buddy/credentials.py
@@ -23,6 +23,12 @@ class CreateCredentialRequest(BaseModel):
         default=None,
         description="Reseller ID. NULL for global credentials available to all resellers.",
     )
+    merchant_id: Optional[str] = Field(
+        default=None,
+        description="Merchant ID for a merchant-scoped credential (requires "
+        "reseller_id). NULL = reseller-wide. Resolution: merchant row, else "
+        "reseller row, else global.",
+    )
     name: str = Field(
         description="Unique name used as the placeholder key (e.g., 'shopify_api_key')"
     )
@@ -51,6 +57,7 @@ class Credential(BaseModel):
 
     id: str
     reseller_id: Optional[str] = None
+    merchant_id: Optional[str] = None
     name: str
     credential_type: CredentialType
     value: Optional[Dict[str, Any]] = Field(

--- a/tests/test_credentials_scope.py
+++ b/tests/test_credentials_scope.py
@@ -1,0 +1,39 @@
+"""Credential visibility: global < reseller < merchant, scoped only when asked."""
+
+from app.database.queries.breeze_buddy.credentials import (
+    get_all_credentials_query,
+    get_credentials_by_merchant_query,
+    insert_credential_query,
+)
+
+
+def test_query_scopes_merchant_rows_only_when_asked() -> None:
+    sql, values = get_credentials_by_merchant_query("breeze", "chennai_one")
+    assert values == ["breeze", "chennai_one"] and '"merchant_id" = $2' in sql
+    assert '"merchant_id" NULLS FIRST' in sql  # least specific first
+
+    sql, values = get_credentials_by_merchant_query("breeze")
+    assert values == ["breeze"] and '"merchant_id" IS NULL' in sql
+
+    sql, values = get_credentials_by_merchant_query(None)
+    assert values == [] and '"reseller_id" IS NULL' in sql
+
+
+def test_all_credentials_orders_most_specific_last() -> None:
+    sql, _ = get_all_credentials_query()
+    assert '"reseller_id" NULLS FIRST, "merchant_id" NULLS FIRST' in sql
+
+
+def test_insert_carries_merchant_id_in_position() -> None:
+    sql, values = insert_credential_query(
+        id="cred_1",
+        reseller_id="breeze",
+        name="uap",
+        credential_type="custom",
+        value="{}",
+        is_encrypted=False,
+        description=None,
+        merchant_id="chennai_one",
+    )
+    assert '"reseller_id", "merchant_id", "name"' in sql
+    assert values[1:4] == ["breeze", "chennai_one", "uap"]


### PR DESCRIPTION
A credential row was global (reseller_id NULL) or reseller-wide. It can now also be scoped to one merchant of that reseller.

- migration 071: nullable merchant_id, CHECK that it needs reseller_id, index on (reseller_id, merchant_id, name) for active rows
- create/list endpoints accept merchant_id (non-admin must have access to that merchant)
- lookup order: merchant row, else reseller row, else global row. Merchant rows are returned only when merchant_id is passed, so existing callers see no change.


Claude-Session: https://claude.ai/code/session_01F6a4he4QRTTJXD39cAFDUz

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added merchant-scoped credentials alongside global and reseller-wide credentials.
  - Credentials now resolve from the most specific available scope: merchant, reseller, then global.
  - Credential creation and listing support selecting a merchant.
  - Added access validation for merchant-specific credential operations.
  - Credential responses now include merchant information when applicable.

- **Tests**
  - Added coverage for credential visibility, scope fallback, ordering, and merchant association.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->