### PR TITLE
feat(crm/identity): read and update one key of crm_customer.attributes

### DIFF
--- a/app/crm/identity/attributes.py
+++ b/app/crm/identity/attributes.py
@@ -1,0 +1,96 @@
+"""Per-customer state kept by OTHER modules under one key of
+``crm_customer.attributes`` (agentic keeps its onboarding attempts under
+``"agents"``). Identity owns the row, so identity owns the atom: a caller
+hands in a pure function over the current value and gets the result back;
+the read + write happen under the row lock, so two concurrent patches (a
+poll tick and the SDK callback) never lose each other's fields.
+
+Values under a key are opaque JSON to identity — it never inspects them.
+"""
+
+import json
+from typing import Any, Callable, Optional, Tuple
+
+from app.crm.identity.db import accessor
+from app.crm.shared.db import DbTxn, atomically
+
+# (customer_id, merchant_id, value-under-key)
+AttributeHit = Tuple[str, str, Any]
+
+# (new value to store, result handed back to the caller)
+Mutation = Callable[[Any], Tuple[Any, Any]]
+
+
+def _attributes(raw: Any) -> dict:
+    if isinstance(raw, str):
+        try:
+            raw = json.loads(raw)
+        except json.JSONDecodeError:
+            return {}
+    return raw if isinstance(raw, dict) else {}
+
+
+async def read_customer_attribute(customer_id: str, key: str) -> Optional[AttributeHit]:
+    """The value under ``key`` for one customer; None when the customer does
+    not exist. A missing key reads as None inside the hit."""
+    row = await accessor.fetch_attributes_by_id(customer_id)
+    if row is None:
+        return None
+    return str(row["id"]), row["merchant_id"], _attributes(row["attributes"]).get(key)
+
+
+async def find_customer_by_attribute(key: str, fragment: Any) -> Optional[AttributeHit]:
+    """The customer whose value under ``key`` contains ``fragment`` (jsonb
+    containment). For a list value pass ``[{...}]`` to mean "an element
+    with these fields"."""
+    row = await accessor.find_customer_by_attribute(key, json.dumps(fragment))
+    if row is None:
+        return None
+    return str(row["id"]), row["merchant_id"], _attributes(row["attributes"]).get(key)
+
+
+async def mutate_customer_attribute(
+    customer_id: str,
+    key: str,
+    mutation: Mutation,
+    *,
+    merchant_id: Optional[str] = None,
+) -> Optional[Tuple[str, Any]]:
+    """Replace the value under ``key`` with ``mutation(current)[0]`` and
+    return ``(merchant_id, mutation(current)[1])``; None when the customer
+    does not exist (nothing written). ``mutation`` must be pure.
+
+    ``merchant_id``, when given, is the tenant the caller believes owns the
+    customer: a customer of another merchant is refused under the lock,
+    BEFORE anything is written (also None). Callers that only hold a
+    customer id (webhook and poll paths, whose refs embed it) omit it."""
+    return await atomically(
+        _mutate_customer_attribute_in_txn, customer_id, key, mutation, merchant_id
+    )
+
+
+async def _mutate_customer_attribute_in_txn(
+    txn: DbTxn,
+    customer_id: str,
+    key: str,
+    mutation: Mutation,
+    expected_merchant: Optional[str],
+) -> Optional[Tuple[str, Any]]:
+    """ATOMIC: read-under-lock + write of one attributes key — a concurrent
+    writer of the same customer (another key, or the same one) must never
+    overwrite this change with a stale copy of the document."""
+    row = await accessor.fetch_attributes_for_update_by_id(txn, customer_id)
+    if row is None:
+        return None
+    merchant_id = row["merchant_id"]
+    if expected_merchant is not None and merchant_id != expected_merchant:
+        # tenant-pinned: the door never lets one merchant write onto
+        # another merchant's customer, whatever id the caller was handed
+        return None
+    attributes = _attributes(row["attributes"])
+    new_value, result = mutation(attributes.get(key))
+    attributes[key] = new_value
+    await accessor.update_attributes(
+        txn, merchant_id, customer_id, json.dumps(attributes, default=str), {}
+    )
+    return merchant_id, result

--- a/app/crm/identity/contracts.py
+++ b/app/crm/identity/contracts.py
@@ -4,7 +4,20 @@ The ONLY file other modules (and buddy's sync-door callers) may import
 from app/crm/identity.
 """
 
+from app.crm.identity.attributes import (
+    find_customer_by_attribute,
+    mutate_customer_attribute,
+    read_customer_attribute,
+)
+from app.crm.identity.db.accessor import get_customer
 from app.crm.identity.facts import assert_facts
 from app.crm.identity.resolve import resolve
 
-__all__ = ["resolve", "assert_facts"]
+__all__ = [
+    "resolve",
+    "assert_facts",
+    "get_customer",
+    "read_customer_attribute",
+    "find_customer_by_attribute",
+    "mutate_customer_attribute",
+]

--- a/app/crm/identity/db/accessor.py
+++ b/app/crm/identity/db/accessor.py
@@ -18,11 +18,14 @@ from app.crm.identity.db.decoder import (
 )
 from app.crm.identity.db.queries import (
     apply_handles_query,
+    find_customer_by_attribute_query,
     get_customer_query,
     insert_customer_query,
     list_customers_query,
     merge_customer_query,
     probe_customer_query,
+    select_attributes_by_id_query,
+    select_attributes_for_update_by_id_query,
     select_attributes_for_update_query,
     update_attributes_query,
 )
@@ -107,3 +110,24 @@ async def update_attributes(
         merchant_id, customer_id, attributes_json, materialized
     )
     await conn.execute(query, *values)
+
+
+async def fetch_attributes_by_id(customer_id: str) -> Optional[asyncpg.Record]:
+    query, values = select_attributes_by_id_query(customer_id)
+    async with crm_connection() as conn:
+        return await conn.fetchrow(query, *values)
+
+
+async def fetch_attributes_for_update_by_id(
+    conn: asyncpg.Connection, customer_id: str
+) -> Optional[asyncpg.Record]:
+    query, values = select_attributes_for_update_by_id_query(customer_id)
+    return await conn.fetchrow(query, *values)
+
+
+async def find_customer_by_attribute(
+    key: str, fragment: str
+) -> Optional[asyncpg.Record]:
+    query, values = find_customer_by_attribute_query(key, fragment)
+    async with crm_connection() as conn:
+        return await conn.fetchrow(query, *values)

--- a/app/crm/identity/db/queries.py
+++ b/app/crm/identity/db/queries.py
@@ -154,3 +154,47 @@ def update_attributes_query(
         WHERE merchant_id = $1 AND id = $2
     """
     return query, values
+
+
+# ---- attributes as a keyed store (used by other modules via contracts) ----
+# Other modules may keep per-customer state under ONE key of ``attributes``
+# (agentic keeps its onboarding attempts under "agents"). They never touch
+# crm_customer themselves: these builders + identity.attributes are the door.
+
+
+def select_attributes_by_id_query(customer_id: str) -> Tuple[str, List[Any]]:
+    """Merchant-less read: callers holding only a customer id (the poll and
+    webhook paths carry our per-attempt refs, which embed it)."""
+    query = f"""
+        SELECT id, merchant_id, attributes FROM {CRM_CUSTOMER_TABLE}
+        WHERE id = $1::uuid
+    """
+    return query, [customer_id]
+
+
+def select_attributes_for_update_by_id_query(
+    customer_id: str,
+) -> Tuple[str, List[Any]]:
+    query = f"""
+        SELECT id, merchant_id, attributes FROM {CRM_CUSTOMER_TABLE}
+        WHERE id = $1::uuid
+        FOR UPDATE
+    """
+    return query, [customer_id]
+
+
+def find_customer_by_attribute_query(key: str, fragment: str) -> Tuple[str, List[Any]]:
+    """The customer whose ``attributes -> key`` contains ``fragment`` (jsonb
+    ``@>``; for an array key, "an element with these fields"). For the rare
+    lookups that carry no customer id (a Juspay agent_id).
+
+    Written as containment on the WHOLE document — ``attributes @>
+    {key: fragment}`` — so the jsonb_path_ops GIN index on attributes (added with the agentic module)
+    serves it; ``attributes -> key @> fragment`` would be a table scan."""
+    query = f"""
+        SELECT id, merchant_id, attributes FROM {CRM_CUSTOMER_TABLE}
+        WHERE attributes @> jsonb_build_object($1::text, $2::jsonb)
+        ORDER BY updated_at DESC
+        LIMIT 1
+    """
+    return query, [key, fragment]

--- a/tests/crm/test_identity_attributes.py
+++ b/tests/crm/test_identity_attributes.py
@@ -1,0 +1,109 @@
+"""identity.attributes — the keyed store other modules use on crm_customer.
+
+The DB is faked at the accessor seam: what is tested is the door's own
+rules (tenant guard before any write, the document handed back, the SQL
+shape the GIN index needs)."""
+
+from typing import Any, Dict, List, Optional
+
+import pytest
+
+import app.crm.identity.attributes as attributes
+from app.crm.identity.db.queries import (
+    find_customer_by_attribute_query,
+    select_attributes_by_id_query,
+    select_attributes_for_update_by_id_query,
+)
+
+# ---- query shapes ----
+
+
+def test_find_by_attribute_is_whole_document_containment() -> None:
+    sql, values = find_customer_by_attribute_query("agents", '[{"agent_id": "x"}]')
+    assert "attributes @> jsonb_build_object($1::text, $2::jsonb)" in sql
+    assert "attributes -> $1" not in sql  # that form cannot use the GIN index
+    assert values == ["agents", '[{"agent_id": "x"}]']
+
+
+def test_by_id_reads_are_merchantless_and_the_mutating_one_locks() -> None:
+    plain, _ = select_attributes_by_id_query("c1")
+    locked, values = select_attributes_for_update_by_id_query("c1")
+    assert "FOR UPDATE" not in plain and "FOR UPDATE" in locked
+    assert "merchant_id =" not in locked and values == ["c1"]
+
+
+# ---- the door, over a faked accessor ----
+
+
+class _Fake:
+    """One customer row; records every write."""
+
+    def __init__(self, merchant_id: str, attrs: Any) -> None:
+        self.row: Optional[Dict[str, Any]] = {
+            "id": "c1",
+            "merchant_id": merchant_id,
+            "attributes": attrs,
+        }
+        self.writes: List[Any] = []
+
+    async def fetch_attributes_for_update_by_id(self, _txn, customer_id):
+        return self.row if customer_id == "c1" else None
+
+    async def update_attributes(self, _txn, merchant_id, customer_id, doc, mat):
+        self.writes.append((merchant_id, customer_id, doc, mat))
+
+
+@pytest.fixture
+def fake(monkeypatch: pytest.MonkeyPatch):
+    fake = _Fake("m1", '{"agents": [1], "other": true}')
+    monkeypatch.setattr(attributes, "accessor", fake)
+
+    async def run_inline(fn, *args):
+        return await fn(None, *args)
+
+    monkeypatch.setattr(attributes, "atomically", run_inline)
+    return fake
+
+
+async def test_mutation_sees_current_value_and_writes_the_whole_document(
+    fake: _Fake,
+) -> None:
+    def mutation(current):
+        return (current or []) + [2], "done"
+
+    result = await attributes.mutate_customer_attribute("c1", "agents", mutation)
+    assert result == ("m1", "done")
+    ((merchant, customer, doc, materialized),) = fake.writes
+    assert (merchant, customer, materialized) == ("m1", "c1", {})
+    assert '"agents": [1, 2]' in doc and '"other": true' in doc  # other keys kept
+
+
+async def test_wrong_merchant_is_refused_before_any_write(fake: _Fake) -> None:
+    calls = []
+
+    def mutation(current):
+        calls.append(current)
+        return [], None
+
+    result = await attributes.mutate_customer_attribute(
+        "c1", "agents", mutation, merchant_id="someone_else"
+    )
+    assert result is None and fake.writes == [] and calls == []
+
+
+async def test_right_merchant_and_unknown_customer(fake: _Fake) -> None:
+    ok = await attributes.mutate_customer_attribute(
+        "c1", "agents", lambda cur: ([], None), merchant_id="m1"
+    )
+    assert ok == ("m1", None) and len(fake.writes) == 1
+    missing = await attributes.mutate_customer_attribute(
+        "nope", "agents", lambda cur: ([], None)
+    )
+    assert missing is None and len(fake.writes) == 1
+
+
+def test_attributes_parser_tolerates_strings_and_garbage() -> None:
+    assert attributes._attributes('{"a": 1}') == {"a": 1}
+    assert attributes._attributes({"a": 1}) == {"a": 1}
+    assert attributes._attributes("not json") == {}
+    assert attributes._attributes(None) == {}


### PR DESCRIPTION
Other CRM modules can keep per-customer data under one key of crm_customer.attributes (agentic will store UPI agents under "agents"). Adds three functions on the identity contract:

- read_customer_attribute(customer_id, key)
- find_customer_by_attribute(key, fragment)  (jsonb containment)
- mutate_customer_attribute(customer_id, key, fn, merchant_id=None) reads and writes under the row lock; if merchant_id is given and the customer belongs to another merchant nothing is written.


Claude-Session: https://claude.ai/code/session_01F6a4he4QRTTJXD39cAFDUz