### PR TITLE
refactor(crm): the nodes package __init__ exports the registry and nothing else

### DIFF
--- a/app/crm/outreach/entry.py
+++ b/app/crm/outreach/entry.py
@@ -32,13 +32,12 @@ from app.crm.outreach.db.accessors import (
 )
 from app.crm.outreach.definitions import definition_for
 from app.crm.outreach.enrol import enrol
-from app.crm.outreach.nodes import (
-    _BOOKKEEPING_KEYS,
-    _BOOKKEEPING_PREFIXES,
+from app.crm.outreach.nodes.context import (
     LATEST_LETTER_KEY,
-    TOPIC_KEY,
+    is_bookkeeping,
     reply_key,
 )
+from app.crm.outreach.nodes.wait_event import TOPIC_KEY
 from app.crm.outreach.repeat import _as_number, apply_repeat
 from app.crm.outreach.schemas import (
     EnrollmentRun,
@@ -356,7 +355,7 @@ def _context_from_payload(payload: dict) -> dict:
     re-added below, normalized, from what identity resolved on."""
     context = {}
     for key, value in payload.items():
-        if key in _BOOKKEEPING_KEYS or key.startswith(_BOOKKEEPING_PREFIXES):
+        if is_bookkeeping(key):
             continue  # ours to write, never a producer's
         if not isinstance(value, (str, int, float, bool)):
             continue  # nested objects/lists stay on the event row

--- a/app/crm/outreach/ladder.py
+++ b/app/crm/outreach/ladder.py
@@ -41,7 +41,7 @@ for one would otherwise move both.
 import re
 from typing import Any, Dict, List, Optional, Tuple
 
-from app.crm.outreach.nodes import TIMEOUT, TOPIC_KEY
+from app.crm.outreach.nodes.wait_event import TIMEOUT, TOPIC_KEY
 from app.crm.outreach.schemas import StageAction, Stages
 
 # What the ladder produces. A document carrying a ladder may not draw

--- a/app/crm/outreach/nodes/__init__.py
+++ b/app/crm/outreach/nodes/__init__.py
@@ -11,12 +11,14 @@ accepted.
 
 ONE WORD PER FILE, and the registry ASSEMBLED here from them — the
 record/extractors/__init__.py (SPEC_MODULES) precedent, which is the
-sanctioned shape for a non-empty __init__. It replaced a single module
-that reached 596 lines carrying five validators, three executors, the
-placeholder helpers, the run-context filters and the registry, at which
-point "where does a call decide it cannot proceed?" needed a search rather
-than a filename (modules/00 §1: the split lands in the PR that crosses
-the line, and the fifth word is what crossed it).
+sanctioned shape for a non-empty __init__: the registry and its type are
+the package's public surface, so they are built where the package is
+imported. That is ALL this file exports. Every other name is imported by
+full path — the run-context filters from ``nodes.context``, ``NodeParked``
+from ``nodes.spec``, the listening square's words from ``nodes.wait_event``
+— because an ``__init__`` that re-exports its siblings is the 132-line
+accessor hub scar (modules/00 §1), and a test pins ``__all__`` to the
+registry so it cannot grow back into one.
 
   wait.py        time passes; the alarm was set on arrival.
   wait_event.py  the alarm OR an event, whichever first (W5).
@@ -27,30 +29,12 @@ the line, and the fifth word is what crossed it).
                  payload and the send variables both derive from.
   spec.py        NodeSpec and NodeParked: what a word must answer, and how
                  it says it cannot.
-
-Every name the twelve importers used from the old module is re-exported
-below, so the split is a move and not a migration.
 """
 
 from typing import Dict
 
 from app.crm.outreach.nodes import action, call, send, wait, wait_event
-from app.crm.outreach.nodes.action import execute as execute_action
-from app.crm.outreach.nodes.call import execute as execute_call
-from app.crm.outreach.nodes.context import (
-    _BOOKKEEPING_KEYS,
-    _BOOKKEEPING_PREFIXES,
-    _REQUEST_ID_KEYS,
-    LATEST_LETTER_KEY,
-    lead_request_id,
-    reply_key,
-    run_facts,
-    send_variables,
-    without_reply,
-)
-from app.crm.outreach.nodes.send import execute as execute_send
-from app.crm.outreach.nodes.spec import Execute, NodeParked, NodeSpec, Validate
-from app.crm.outreach.nodes.wait_event import ELSE, TIMEOUT, TOPIC_KEY
+from app.crm.outreach.nodes.spec import NodeSpec
 from app.crm.outreach.schemas import WorkflowNode
 
 NODE_TYPES: Dict[str, NodeSpec] = {
@@ -69,26 +53,4 @@ def is_wait(node: WorkflowNode) -> bool:
     return NODE_TYPES[node.type].is_wait
 
 
-__all__ = [
-    "ELSE",
-    "Execute",
-    "LATEST_LETTER_KEY",
-    "NODE_TYPES",
-    "NodeParked",
-    "NodeSpec",
-    "TIMEOUT",
-    "TOPIC_KEY",
-    "Validate",
-    "_BOOKKEEPING_KEYS",
-    "_BOOKKEEPING_PREFIXES",
-    "_REQUEST_ID_KEYS",
-    "execute_action",
-    "execute_call",
-    "execute_send",
-    "is_wait",
-    "lead_request_id",
-    "reply_key",
-    "run_facts",
-    "send_variables",
-    "without_reply",
-]
+__all__ = ["NODE_TYPES", "NodeSpec", "is_wait"]

--- a/app/crm/outreach/nodes/context.py
+++ b/app/crm/outreach/nodes/context.py
@@ -48,6 +48,16 @@ _BOOKKEEPING_PREFIXES = ("lead_", "message_", "reply_", "action_")
 _REQUEST_ID_KEYS = ("order_id", "request_id")
 
 
+def is_bookkeeping(key: str) -> bool:
+    """PURE: whether a context key is the walker's own — never a template
+    variable, never a producer's fact. The ONE definition: run_facts drops
+    these, and entry.py refuses a producer who spells one (a payload key
+    named `repeat_items` or `source_event_id` would corrupt the accumulate
+    branch or the founding-event dedupe). Two lists would let a walker key
+    reach a customer's message the day they diverged."""
+    return key in _BOOKKEEPING_KEYS or key.startswith(_BOOKKEEPING_PREFIXES)
+
+
 def reply_key(node_id: str) -> str:
     """Where a wait_event square's answer lives in the run's context."""
     return f"reply_{node_id}"
@@ -93,11 +103,7 @@ def run_facts(
     given, current_node (and current_stage when the square is labelled)
     ride along, so one call template can say "you stopped at
     {current_stage}"."""
-    facts = {
-        key: value
-        for key, value in context.items()
-        if key not in _BOOKKEEPING_KEYS and not key.startswith(_BOOKKEEPING_PREFIXES)
-    }
+    facts = {key: value for key, value in context.items() if not is_bookkeeping(key)}
     by_square = context.get("facts")
     by_square = by_square if isinstance(by_square, dict) else {}
     for square, letter in by_square.items():

--- a/app/crm/outreach/walker.py
+++ b/app/crm/outreach/walker.py
@@ -36,15 +36,10 @@ from app.crm.outreach.db.accessors import (
     workflow as workflow_accessor,
 )
 from app.crm.outreach.definitions import definition_for
-from app.crm.outreach.nodes import (
-    ELSE,
-    NODE_TYPES,
-    TIMEOUT,
-    NodeParked,
-    is_wait,
-    reply_key,
-    without_reply,
-)
+from app.crm.outreach.nodes import NODE_TYPES, is_wait
+from app.crm.outreach.nodes.context import reply_key, without_reply
+from app.crm.outreach.nodes.spec import NodeParked
+from app.crm.outreach.nodes.wait_event import ELSE, TIMEOUT
 from app.crm.outreach.schemas import EnrollmentRun, WorkflowDefinition, WorkflowNode
 from app.crm.record.contracts import customer_has_event
 

--- a/docs/crm/building-modules.md
+++ b/docs/crm/building-modules.md
@@ -72,11 +72,15 @@ cannot proceed?" needed a search rather than a filename.
 
 This is the one sanctioned non-empty `__init__` (the `record/extractors/`
 SPEC_MODULES precedent): the registry is the module's public surface, so it
-is assembled where the package is imported, and every name the old flat
-module exported is re-exported beside it so the split is a move rather than
-a migration. `spec.py` is separate from `__init__` so a word can import the
-type it implements without importing the registry that lists it. Outreach
-took the shape 7 Sep 2026, in the PR that added the fifth word.
+is assembled where the package is imported — and that is ALL the `__init__`
+exports (`NODE_TYPES`, `NodeSpec`, `is_wait`; a test pins `__all__`). Every
+other name is imported by full path — `nodes.context` for the run-context
+filters, `nodes.spec` for `NodeParked`, `nodes.wait_event` for the listening
+square's words — because an `__init__` that re-exports its siblings is the
+re-export-hub scar (L192) in a new coat. `spec.py` is separate from
+`__init__` so a word can import the type it implements without importing the
+registry that lists it. Outreach took the shape 7 Sep 2026, in the PR that
+added the fifth word; the hub it shipped with was trimmed the same day.
 
 **Vocabulary files, one word each, one home each**: `reasons.py` (why a send
 was refused — T16 col 13), `topics.py` (what a letter is CALLED on the spine —

--- a/tests/crm/test_worker_runtime.py
+++ b/tests/crm/test_worker_runtime.py
@@ -14,7 +14,7 @@ import app.crm.outreach.definitions as definitions
 import app.crm.outreach.entry as entry
 import app.crm.outreach.workers as outreach_workers
 from app.crm.outreach.db.accessors import version as version_accessor
-from app.crm.outreach.nodes import send_variables
+from app.crm.outreach.nodes.context import send_variables
 from app.crm.outreach.schemas import EnrollmentRun, Workflow, WorkflowDefinition
 from app.crm.outreach.walker import pick_next
 from app.crm.record.contracts import RawEvent

--- a/tests/crm/test_workflow_action.py
+++ b/tests/crm/test_workflow_action.py
@@ -13,11 +13,14 @@ from uuid import uuid4
 
 import pytest
 
-import app.crm.outreach.nodes as nodes
 import app.crm.outreach.nodes.action as action_node
 from app.crm.connectivity.contracts import ActionError
-from app.crm.outreach.nodes import NodeParked, execute_action
-from app.crm.outreach.nodes.action import validate as _validate_action
+from app.crm.outreach.nodes.action import (
+    execute as execute_action,
+    validate as _validate_action,
+)
+from app.crm.outreach.nodes.context import run_facts
+from app.crm.outreach.nodes.spec import NodeParked
 from app.crm.outreach.schemas import EnrollmentRun, WorkflowDefinition, WorkflowNode
 
 NOW = datetime(2026, 9, 3, 12, 0, tzinfo=timezone.utc)
@@ -188,8 +191,8 @@ async def test_the_marker_is_bookkeeping_and_never_a_template_variable(
     patch = await execute_action(run, _node(), _DEFINITION)
 
     merged = {**run.context, **patch}
-    assert "action_tag-vip" not in nodes.run_facts(merged)
-    assert nodes.run_facts(merged)["cart_value"] == 900
+    assert "action_tag-vip" not in run_facts(merged)
+    assert run_facts(merged)["cart_value"] == 900
 
 
 async def test_a_missing_fact_for_a_placeholder_parks(

--- a/tests/crm/test_workflow_entry.py
+++ b/tests/crm/test_workflow_entry.py
@@ -22,7 +22,7 @@ import app.crm.outreach.definitions as definitions
 import app.crm.outreach.entry as entry
 from app.crm.outreach.entry import consume_attributed_event
 from app.crm.outreach.ladder import expand_stages
-from app.crm.outreach.nodes import TIMEOUT
+from app.crm.outreach.nodes.wait_event import TIMEOUT
 from app.crm.outreach.schemas import (
     EnrollmentRun,
     Workflow,

--- a/tests/crm/test_workflow_ladder.py
+++ b/tests/crm/test_workflow_ladder.py
@@ -14,7 +14,7 @@ import pytest
 import app.crm.outreach.plans as plans
 from app.crm.outreach.db import DbTxn
 from app.crm.outreach.ladder import LadderProblem, expand_stages
-from app.crm.outreach.nodes import run_facts
+from app.crm.outreach.nodes.context import run_facts
 from app.crm.outreach.plans import validate_definition
 from app.crm.outreach.schemas import Workflow, WorkflowDefinition
 from tests.crm.doubles import patch_accessors

--- a/tests/crm/test_workflow_nodes.py
+++ b/tests/crm/test_workflow_nodes.py
@@ -36,3 +36,29 @@ def test_is_wait_answers_for_every_word() -> None:
         "call": False,
         "action": False,
     }
+
+
+def test_the_package_init_exports_the_registry_and_nothing_else() -> None:
+    """The one sanctioned non-empty __init__ (record/extractors precedent)
+    assembles the registry; it does not re-export its siblings. The split
+    of 7 Sep 2026 shipped a 21-name hub (three of them private) so twelve
+    importers could stay unchanged — the accessor/__init__ scar in a new
+    coat. Importers name the file they mean: nodes.context, nodes.spec,
+    nodes.wait_event, nodes.<word>."""
+    import app.crm.outreach.nodes as package
+
+    assert set(package.__all__) == {"NODE_TYPES", "NodeSpec", "is_wait"}
+    exported = {
+        name
+        for name in dir(package)
+        if not name.startswith("__")
+        and not name.startswith("_")
+        and name not in package.__all__
+        # the word modules and the siblings are attributes of any package
+        # once imported; only NAMES the init defines or re-exports count
+        and name
+        not in {"action", "call", "send", "wait", "wait_event", "context", "spec"}
+        and name not in {"Dict", "WorkflowNode"}
+    }
+    assert exported == set(), f"__init__ grew a re-export: {sorted(exported)}"
+    assert not [n for n in dir(package) if n.startswith("_") and not n.startswith("__")]

--- a/tests/crm/test_workflow_reporting.py
+++ b/tests/crm/test_workflow_reporting.py
@@ -26,7 +26,7 @@ from app.crm.outreach.db.queries.enrollment import (
     customer_runs_query,
     workflow_summary_query,
 )
-from app.crm.outreach.nodes import run_facts
+from app.crm.outreach.nodes.context import run_facts
 
 NOW = datetime(2026, 9, 3, 12, 0, tzinfo=timezone.utc)
 SINCE, UNTIL = NOW - timedelta(days=7), NOW

--- a/tests/crm/test_workflow_runs.py
+++ b/tests/crm/test_workflow_runs.py
@@ -10,7 +10,11 @@ from app.crm.outreach.db.queries.enrollment import (
     resume_run_query,
     sweep_exited_runs_query,
 )
-from app.crm.outreach.nodes import lead_request_id, run_facts, send_variables
+from app.crm.outreach.nodes.context import (
+    lead_request_id,
+    run_facts,
+    send_variables,
+)
 from app.crm.outreach.runs import list_runs
 from app.crm.outreach.schemas import WorkflowNode
 from app.crm.outreach.walker import retry_delay_seconds

--- a/tests/crm/test_workflow_walker.py
+++ b/tests/crm/test_workflow_walker.py
@@ -23,7 +23,7 @@ import pytest
 
 import app.crm.outreach.definitions as definitions
 import app.crm.outreach.walker as walker
-from app.crm.outreach.nodes import NodeParked
+from app.crm.outreach.nodes.spec import NodeParked
 from app.crm.outreach.schemas import EnrollmentRun, Workflow, WorkflowDefinition
 from tests.crm.doubles import patch_accessors
 


### PR DESCRIPTION
## What

#1057 split `outreach/nodes.py` into the `nodes/` package and, so its twelve importers could stay unchanged, had the package `__init__` re-export **twenty-one names — three of them private** (`_BOOKKEEPING_KEYS`, `_BOOKKEEPING_PREFIXES`, `_REQUEST_ID_KEYS`). That is the `accessor/__init__` re-export-hub scar in a new coat (modules/00 §1: an `__init__` exports nothing; the one sanctioned exception — `record/extractors`, `SPEC_MODULES` — assembles the registry and re-exports nothing beside it).

This PR trims it to the ideal shape:

- **`nodes/__init__.py` exports `NODE_TYPES`, `NodeSpec` and `is_wait`** — the registry and its type — and a test pins `__all__` so it cannot grow back into a hub. The pin was proven red with an injected re-export before the fix.
- **`nodes/context.py` gains `is_bookkeeping(key)`**: the ONE definition of "this key is the walker's own", used by `run_facts` and by `entry.py`'s producer filter — so no private name crosses a module boundary any more (entry.py was importing two underscore names to re-spell the same predicate).
- **`entry.py`, `walker.py`, `ladder.py` and seven tests import by full path**: `nodes.context` (run-context filters), `nodes.spec` (`NodeParked`), `nodes.wait_event` (`TIMEOUT`, `TOPIC_KEY`, `ELSE`), `nodes.action` (`execute`).
- `docs/crm/building-modules.md` says so.

## Why now

Raised on Swaroop's ask at #1057's merge: the hub was the one item left open in that review, mechanical, and cheapest the day it landed. No behaviour change.

## Gates

On the rebased tree (`release` = `f98b7ae1`, the #1057 merge): black · isort · pyrefly 0 · `check_crm_boundaries` clean · 71 migrations no gaps · `pytest tests/crm` green (+1 pin test). One commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01APYhsMRBdKLz74A6NRuWy5


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified the workflow node package’s public interface to expose only the registry and core node helpers.
  * Node-specific utilities and constants are now accessed through their dedicated modules.
  * Centralized identification of internal bookkeeping context keys.

* **Documentation**
  * Updated module-building guidance to reflect the streamlined package interface.

* **Tests**
  * Added coverage ensuring only the intended workflow node APIs are publicly exported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->