### PR TITLE
feat(assist): admin-only fleet inventory endpoint for the console

### DIFF
--- a/app/ai/voice/agents/breeze_buddy/assist/fleet.py
+++ b/app/ai/voice/agents/breeze_buddy/assist/fleet.py
@@ -1,0 +1,861 @@
+"""Buddy Assist fleet model — pure functions, no I/O.
+
+``build_fleet`` turns the raw rows the ``assist_fleet`` accessors return into
+the ``AssistFleetResponse`` the admin console renders. Everything an operator
+sees on the fleet page (agent type, generation, health flags, cleanup plan,
+shared-block variants, findings) is decided here so it can be unit-tested
+without a database.
+
+Vocabulary decisions this module encodes:
+
+* **Agent type** follows the console rule (loom ``agent-type.ts``, user
+  decision 2026-07-13): ``'chat'`` in ``supported_channels`` → chat agent (with
+  widget voice mode if ``'voice'`` is also present); otherwise a telephony voice
+  agent. There is no separate column.
+* **Shared block** = the ``## Operating principles`` section of the system
+  prompt — the fleet SOP keeps it byte-identical across merchants, so its hash
+  is the drift detector. The reference hash comes from the reseller's
+  ``buddy-assist-default`` blueprint when it exists, else from an explicitly
+  named template, else from the majority of live chat agents.
+* **Cleanup** is only ever proposed for chat templates under the assist
+  resellers that no widget binds. ``chat_session.template_id`` is
+  ``ON DELETE RESTRICT`` (migration 027), so anything with sessions can only be
+  deactivated; a hard delete is proposed only at zero sessions.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from collections import Counter, defaultdict
+from dataclasses import dataclass, field
+from datetime import date, datetime, timedelta, timezone
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple
+from zoneinfo import ZoneInfo
+
+from app.ai.voice.agents.breeze_buddy.assist.commerce.assist_onboarding import (
+    DEFAULT_ASSIST_TEMPLATE_NAME,
+)
+from app.schemas.breeze_buddy.admin.assist_fleet import (
+    AgentType,
+    AssistFleetResponse,
+    FleetCleanup,
+    FleetFlag,
+    FleetIssue,
+    FleetMerchant,
+    FleetMerchantRow,
+    FleetMerchantUsage,
+    FleetReference,
+    FleetTemplate,
+    FleetTotals,
+    FleetUsage,
+    FleetVariant,
+    FleetWidget,
+    Generation,
+    HostApp,
+    Platform,
+)
+
+ASSIST_RESELLERS: Tuple[str, ...] = ("BB_SHOPIFY", "BB_ASSIST")
+_STANDALONE_PREFIX = "assist-"  # mirrors tenancy._ASSIST_MERCHANT_PREFIX
+SHARED_BLOCK_HEADING = "## Operating principles"
+_BARE_PROMPT_CHARS = 1300
+_SILENT_AFTER_DAYS = 14
+_SILENT_CRITICAL_WINDOW_SESSIONS = 100
+_SHALLOW_SHARE = 0.5
+_IST = ZoneInfo("Asia/Kolkata")
+
+# Origins that never identify a merchant's storefront brand.
+_NOISE_ORIGIN_MARKERS = (
+    "myshopify.com",
+    "localhost",
+    "127.0.0.1",
+    "breezelabs.app",
+    "breezebuddy.ai",
+    "breeze.in",
+    "juspay.in",
+)
+
+_SECTION_RE = re.compile(r"^##\s+(.+?)\s*$", re.M)
+_SHARED_BLOCK_RE = re.compile(
+    re.escape(SHARED_BLOCK_HEADING) + r".*?(?=^##\s|\Z)", re.S | re.M
+)
+_BRAND_PATTERNS = (
+    re.compile(r"\*\*Brand:\*\*\s*([^\n|]+)"),
+    re.compile(r"You are ([^,\n]+?) Assist\b"),
+    re.compile(r"\*\*Assistant name:\*\*\s*([^\n]+)"),
+)
+_BRAND_SPLIT_RE = re.compile(r"\s+[—–-]\s+|\s\(|[.;:,]\s")
+
+
+@dataclass
+class FleetInputs:
+    """Raw rows from the ``assist_fleet`` accessors (see handlers.py)."""
+
+    widgets: List[Dict[str, Any]]
+    templates: List[Dict[str, Any]]
+    merchants: Dict[str, Dict[str, Any]]  # "reseller|merchant" -> row
+    voice_counts: Dict[str, int]  # "reseller|merchant" -> count
+    blueprints: List[Dict[str, Any]]
+    template_stats: Dict[str, Dict[str, Any]]  # template_id -> row
+    template_depth: Dict[str, Dict[str, Any]]  # template_id -> row
+    template_daily: Dict[str, Dict[str, int]]  # template_id -> {day: n}
+    merchant_stats: Dict[str, Dict[str, Any]]  # "reseller|merchant" -> row
+    reference_template_id: Optional[str] = None
+    extra: Dict[str, Any] = field(default_factory=dict)
+
+
+# --------------------------------------------------------------------------- #
+# Small pure helpers (each unit-tested)
+# --------------------------------------------------------------------------- #
+
+
+def normalize_channels(raw: Optional[Iterable[Any]]) -> List[str]:
+    """Console rule: unknown/empty channel lists are voice-era templates."""
+    seen: List[str] = []
+    for c in raw or []:
+        s = str(c).strip().lower()
+        if s in ("voice", "chat") and s not in seen:
+            seen.append(s)
+    return seen or ["voice"]
+
+
+def agent_type_of(channels: Sequence[str]) -> AgentType:
+    return "chat" if "chat" in channels else "voice"
+
+
+def widget_voice_of(channels: Sequence[str]) -> bool:
+    return "chat" in channels and "voice" in channels
+
+
+def prompt_sections(prompt: str) -> List[str]:
+    return _SECTION_RE.findall(prompt or "")
+
+
+def shared_block(prompt: str) -> str:
+    m = _SHARED_BLOCK_RE.search(prompt or "")
+    return m.group(0).strip() if m else ""
+
+
+def block_hash(block: str) -> Optional[str]:
+    """Stable content hash of a prompt block (``hashlib``, never ``hash()``)."""
+    if not block:
+        return None
+    h = hashlib.sha256()
+    h.update(b"breeze-buddy.assist-fleet.shared-block.v1\0")
+    h.update(block.encode("utf-8"))
+    return h.hexdigest()[:12]
+
+
+def brand_from_prompt(prompt: str) -> Optional[str]:
+    for pat in _BRAND_PATTERNS:
+        m = pat.search(prompt or "")
+        if not m:
+            continue
+        b = _BRAND_SPLIT_RE.split(m.group(1).strip().strip("`*"))[0]
+        b = b.strip().strip('"“”')
+        if b and b.lower() not in ("assist", "the", "a") and len(b) <= 48:
+            return b
+    return None
+
+
+def brand_domain(origins: Iterable[str]) -> Optional[str]:
+    for o in origins:
+        host = re.sub(r"^https?://", "", o).rstrip("/")
+        if host and not any(n in host for n in _NOISE_ORIGIN_MARKERS):
+            return re.sub(r"^www\.", "", host)
+    return None
+
+
+def merchant_domain(reseller_id: str, merchant_id: str) -> str:
+    if reseller_id == "BB_ASSIST" and merchant_id.startswith(_STANDALONE_PREFIX):
+        return merchant_id[len(_STANDALONE_PREFIX) :]
+    return merchant_id
+
+
+def host_app_of(reseller_id: str) -> HostApp:
+    if reseller_id == "BB_SHOPIFY":
+        return "breeze-buddy"
+    if reseller_id == "BB_ASSIST":
+        return "buddy-assist"
+    return "direct"
+
+
+def platform_of(
+    reseller_id: str, merchant_id: str, mcp_servers: Sequence[str]
+) -> Platform:
+    if reseller_id == "woocommerce":
+        return "woocommerce"
+    if reseller_id == "acme":
+        return "demo"
+    if reseller_id == "breeze":
+        return "internal"
+    if merchant_id.endswith(".myshopify.com") or any(
+        "/api/ucp/mcp" in (u or "") for u in mcp_servers
+    ):
+        return "shopify"
+    return "shopify" if reseller_id in ASSIST_RESELLERS else "custom"
+
+
+def ist_days(now: datetime, window_days: int) -> List[date]:
+    """``window_days + 1`` IST calendar days ending today (both ends partial)."""
+    today = now.astimezone(_IST).date()
+    return [today - timedelta(days=window_days - i) for i in range(window_days + 1)]
+
+
+# --------------------------------------------------------------------------- #
+# Template summaries
+# --------------------------------------------------------------------------- #
+
+
+def summarize_template(
+    row: Dict[str, Any],
+    *,
+    reference_hashes: Sequence[str],
+    bound: Optional[Dict[str, Any]] = None,
+) -> FleetTemplate:
+    flow = row.get("flow") or {}
+    conf = row.get("configurations") or {}
+    prompt = flow.get("system_prompt") if isinstance(flow, dict) else ""
+    prompt = prompt if isinstance(prompt, str) else ""
+    llm = conf.get("llm_configurations") if isinstance(conf, dict) else None
+    llm = llm if isinstance(llm, dict) else {}
+    channels = normalize_channels(row.get("supported_channels"))
+    agent_type = agent_type_of(channels)
+    sections = prompt_sections(prompt)
+    sb_hash = block_hash(shared_block(prompt))
+    functions = [
+        f.get("name")
+        for f in (flow.get("functions") or [])
+        if isinstance(f, dict) and f.get("name")
+    ]
+    mcp_cfg = conf.get("mcp") if isinstance(conf, dict) else None
+    mcp_servers = [
+        s.get("url")
+        for s in ((mcp_cfg or {}).get("servers") or [])
+        if isinstance(s, dict) and s.get("url")
+    ]
+    flavor = conf.get("flavor") if isinstance(conf, dict) else None
+    flavor = flavor if isinstance(flavor, dict) else {}
+    connectors = sorted(
+        {
+            c
+            for v in flavor.values()
+            if isinstance(v, dict)
+            for c in (v.get("connectors") or [])
+        }
+    )
+    quick = conf.get("quick_replies") if isinstance(conf, dict) else None
+    reseller_id = row.get("reseller_id")
+    matches = bool(sb_hash) and sb_hash in reference_hashes
+
+    generation: Generation
+    if reseller_id not in ASSIST_RESELLERS:
+        generation = "other-tenant"
+    elif agent_type == "voice":
+        generation = "voice-agent"
+    elif sb_hash and matches:
+        generation = "standard"
+    elif sb_hash:
+        generation = "variant"
+    elif len(prompt) < _BARE_PROMPT_CHARS:
+        generation = "bare"
+    else:
+        generation = "legacy-personalized"
+
+    return FleetTemplate(
+        id=str(row["id"]),
+        name=row.get("name") or "",
+        reseller_id=reseller_id,
+        merchant_id=row.get("merchant_id"),
+        is_active=bool(row.get("is_active", True)),
+        created_at=row.get("created_at"),
+        updated_at=row.get("updated_at"),
+        agent_type=agent_type,
+        widget_voice=widget_voice_of(channels),
+        channels=channels,
+        generation=generation,
+        matches_reference=matches,
+        prompt_chars=len(prompt),
+        sections=sections,
+        shared_block_hash=sb_hash,
+        model=llm.get("model"),
+        provider=llm.get("provider"),
+        wismo="get_order_status" in functions
+        or any("wismo" in s.lower() for s in sections),
+        functions=functions,
+        mcp_servers=mcp_servers,
+        flavors=sorted(flavor.keys()),
+        connectors=connectors,
+        quick_replies=len(quick) if isinstance(quick, list) else 0,
+        has_greeting=(
+            bool(conf.get("initial_greeting")) if isinstance(conf, dict) else False
+        ),
+        brand_name=brand_from_prompt(prompt),
+        bound_widget_config_id=bound["id"] if bound else None,
+        bound_merchant_key=(
+            f"{bound['reseller_id']}|{bound['merchant_id']}" if bound else None
+        ),
+    )
+
+
+def usage_for(
+    template_id: str,
+    stats: Dict[str, Dict[str, Any]],
+    depth: Dict[str, Dict[str, Any]],
+    daily: Dict[str, Dict[str, int]],
+    days: Sequence[date],
+) -> FleetUsage:
+    s = stats.get(template_id) or {}
+    d = depth.get(template_id) or {}
+    per_day = daily.get(template_id) or {}
+    sessions = int(d.get("sessions") or 0)
+    zero = int(d.get("zero_message_sessions") or 0)
+    return FleetUsage(
+        total=int(s.get("total") or 0),
+        total_window=int(s.get("total_window") or 0),
+        total_7d=int(s.get("total_7d") or 0),
+        active_now=int(s.get("active_now") or 0),
+        last_activity_at=s.get("last_activity_at"),
+        first_seen_at=s.get("first_seen_at"),
+        avg_messages=(
+            round(float(d["avg_messages"]), 1)
+            if d.get("avg_messages") is not None
+            else None
+        ),
+        zero_message_share=round(zero / sessions, 2) if sessions else None,
+        daily=[int(per_day.get(day.isoformat(), 0)) for day in days],
+    )
+
+
+def cleanup_for(
+    template: FleetTemplate, usage: FleetUsage, reference_ids: Sequence[str]
+) -> FleetCleanup:
+    if template.id in reference_ids:
+        return FleetCleanup(
+            action="keep",
+            reason="This is the fleet reference template; the standard is measured against it.",
+        )
+    if not template.is_active:
+        return FleetCleanup(action="none", reason="Already inactive.")
+    if usage.total == 0:
+        return FleetCleanup(
+            action="delete",
+            reason="No chat session references it, so a hard delete is safe.",
+        )
+    last = usage.last_activity_at.date().isoformat() if usage.last_activity_at else "?"
+    return FleetCleanup(
+        action="deactivate",
+        reason=(
+            f"{usage.total:,} chat sessions reference it (last {last}); the "
+            "session foreign key blocks a delete, so deactivate to keep transcripts."
+        ),
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Health flags
+# --------------------------------------------------------------------------- #
+
+
+def flags_for(
+    *,
+    reseller_id: str,
+    origins: Sequence[str],
+    widget_active: bool,
+    appearance_set: bool,
+    merchant_exists: bool,
+    template: FleetTemplate,
+    usage: FleetUsage,
+    now: datetime,
+) -> List[FleetFlag]:
+    flags: List[FleetFlag] = []
+    assist = reseller_id in ASSIST_RESELLERS
+    if template.agent_type == "voice":
+        flags.append(
+            FleetFlag(
+                level="critical",
+                code="voice-only-template",
+                text="Widget is bound to a voice agent (no 'chat' channel); the widget cannot serve it.",
+            )
+        )
+    if not template.is_active:
+        flags.append(
+            FleetFlag(
+                level="critical",
+                code="template-inactive",
+                text="Bound template is inactive; the widget will fail to start sessions.",
+            )
+        )
+    if not widget_active:
+        flags.append(
+            FleetFlag(level="info", code="widget-disabled", text="Widget is disabled.")
+        )
+    if usage.total == 0:
+        flags.append(
+            FleetFlag(
+                level="warning",
+                code="never-used",
+                text="No chat sessions ever; the widget is provisioned but nobody has opened it.",
+            )
+        )
+    elif usage.last_activity_at and usage.last_activity_at < now - timedelta(
+        days=_SILENT_AFTER_DAYS
+    ):
+        level = (
+            "critical"
+            if usage.total_window > _SILENT_CRITICAL_WINDOW_SESSIONS
+            else "warning"
+        )
+        since = usage.last_activity_at.date().isoformat()
+        text = (
+            f"Silent since {since}: {usage.total_window:,} sessions in the window, none in the last 7 days."
+            if usage.total_window
+            else f"Silent since {since}."
+        )
+        flags.append(FleetFlag(level=level, code="silent", text=text))
+    if assist and not brand_domain(origins):
+        flags.append(
+            FleetFlag(
+                level="warning",
+                code="no-custom-domain",
+                text="Only the .myshopify.com origin is allowed; shoppers on a custom storefront domain get 403.",
+            )
+        )
+    if template.generation == "bare":
+        flags.append(
+            FleetFlag(
+                level="warning",
+                code="bare-template",
+                text=f"Live on the {template.prompt_chars}-char default prompt; never personalized.",
+            )
+        )
+    if (
+        usage.zero_message_share is not None
+        and usage.zero_message_share > _SHALLOW_SHARE
+    ):
+        flags.append(
+            FleetFlag(
+                level="info",
+                code="shallow-sessions",
+                text=f"{usage.zero_message_share:.0%} of window sessions have zero messages.",
+            )
+        )
+    if assist and not merchant_exists:
+        flags.append(
+            FleetFlag(
+                level="critical",
+                code="no-merchant-row",
+                text="Widget config exists but there is no merchants row for this reseller/merchant.",
+            )
+        )
+    if not appearance_set:
+        flags.append(
+            FleetFlag(
+                level="info",
+                code="appearance-default",
+                text="Appearance is empty; the widget renders defaults.",
+            )
+        )
+    if template.widget_voice:
+        flags.append(
+            FleetFlag(
+                level="info",
+                code="voice-mode",
+                text="Chat agent with widget voice mode (WebRTC call inside the widget).",
+            )
+        )
+    return flags
+
+
+# --------------------------------------------------------------------------- #
+# Reference resolution
+# --------------------------------------------------------------------------- #
+
+
+def resolve_reference(
+    blueprints: Sequence[Dict[str, Any]],
+    templates_by_id: Dict[str, Dict[str, Any]],
+    bound_ids: Sequence[str],
+    reference_template_id: Optional[str],
+) -> FleetReference:
+    """Which shared-block hash counts as "standard".
+
+    Blueprint rows (one per reseller) win; an explicitly named template is
+    added to them; with neither, the most common shared block among *live*
+    chat templates is the reference so the page still shows drift.
+    """
+    ids: List[str] = []
+    hashes: List[str] = []
+    for bp in blueprints:
+        flow = bp.get("flow") or {}
+        prompt = flow.get("system_prompt") if isinstance(flow, dict) else ""
+        h = block_hash(shared_block(prompt if isinstance(prompt, str) else ""))
+        if h:
+            ids.append(str(bp["id"]))
+            if h not in hashes:
+                hashes.append(h)
+    source = "blueprint" if hashes else "none"
+    if reference_template_id and reference_template_id in templates_by_id:
+        row = templates_by_id[reference_template_id]
+        flow = row.get("flow") or {}
+        prompt = flow.get("system_prompt") if isinstance(flow, dict) else ""
+        h = block_hash(shared_block(prompt if isinstance(prompt, str) else ""))
+        if h:
+            ids.append(reference_template_id)
+            if h not in hashes:
+                hashes.append(h)
+            source = "blueprint" if source == "blueprint" else "template"
+    if not hashes:
+        counts: Counter = Counter()
+        for tid in bound_ids:
+            row = templates_by_id.get(tid)
+            if not row or row.get("reseller_id") not in ASSIST_RESELLERS:
+                continue
+            flow = row.get("flow") or {}
+            prompt = flow.get("system_prompt") if isinstance(flow, dict) else ""
+            h = block_hash(shared_block(prompt if isinstance(prompt, str) else ""))
+            if h:
+                counts[h] += 1
+        if counts:
+            top, _ = counts.most_common(1)[0]
+            hashes = [top]
+            source = "majority"
+    return FleetReference(source=source, template_ids=ids, hashes=hashes)
+
+
+# --------------------------------------------------------------------------- #
+# The builder
+# --------------------------------------------------------------------------- #
+
+
+def build_fleet(
+    inputs: FleetInputs, *, now: Optional[datetime] = None, window_days: int = 30
+) -> AssistFleetResponse:
+    now = now or datetime.now(timezone.utc)
+    days = ist_days(now, window_days)
+    templates_by_id = {str(t["id"]): t for t in inputs.templates}
+    widgets_by_tid = {str(w["template_id"]): w for w in inputs.widgets}
+    bound_ids = list(widgets_by_tid.keys())
+
+    reference = resolve_reference(
+        inputs.blueprints, templates_by_id, bound_ids, inputs.reference_template_id
+    )
+
+    summaries: Dict[str, FleetTemplate] = {}
+    for row in inputs.templates:
+        tid = str(row["id"])
+        summaries[tid] = summarize_template(
+            row, reference_hashes=reference.hashes, bound=widgets_by_tid.get(tid)
+        )
+
+    # ---- merchants (one per widget) --------------------------------------
+    merchants: List[FleetMerchant] = []
+    for w in inputs.widgets:
+        key = f"{w['reseller_id']}|{w['merchant_id']}"
+        tid = str(w["template_id"])
+        tsum = summaries.get(tid)
+        if tsum is None:
+            # Bound template vanished between the two reads; describe it minimally.
+            tsum = summarize_template(
+                {
+                    "id": tid,
+                    "name": "(missing template)",
+                    "reseller_id": w["reseller_id"],
+                },
+                reference_hashes=reference.hashes,
+                bound=w,
+            )
+            tsum.is_active = False
+        usage = usage_for(
+            tid,
+            inputs.template_stats,
+            inputs.template_depth,
+            inputs.template_daily,
+            days,
+        )
+        mrow = inputs.merchants.get(key)
+        mstats = inputs.merchant_stats.get(key) or {}
+        origins = list(w.get("allowed_origins") or [])
+        appearance_set = bool(w.get("appearance"))
+        flags = flags_for(
+            reseller_id=w["reseller_id"],
+            origins=origins,
+            widget_active=bool(w.get("active", True)),
+            appearance_set=appearance_set,
+            merchant_exists=mrow is not None,
+            template=tsum,
+            usage=usage,
+            now=now,
+        )
+        domain = merchant_domain(w["reseller_id"], w["merchant_id"])
+        bdomain = brand_domain(origins)
+        merchants.append(
+            FleetMerchant(
+                key=key,
+                reseller_id=w["reseller_id"],
+                merchant_id=w["merchant_id"],
+                merchant_domain=domain,
+                host_app=host_app_of(w["reseller_id"]),
+                platform=platform_of(
+                    w["reseller_id"], w["merchant_id"], tsum.mcp_servers
+                ),
+                brand=bdomain or tsum.brand_name or domain.split(".")[0],
+                brand_domain=bdomain,
+                origins=origins,
+                widget=FleetWidget(
+                    id=str(w["id"]),
+                    active=bool(w.get("active", True)),
+                    created_at=w.get("created_at"),
+                    updated_at=w.get("updated_at"),
+                    appearance_set=appearance_set,
+                    max_sessions_per_ip_hour=w.get("max_sessions_per_ip_hour"),
+                    max_messages_per_ip_hour=w.get("max_messages_per_ip_hour"),
+                    max_concurrent_per_ip=w.get("max_concurrent_per_ip"),
+                    max_voice_sessions_per_ip_hour=w.get(
+                        "max_voice_sessions_per_ip_hour"
+                    ),
+                ),
+                merchant_row=(
+                    FleetMerchantRow(
+                        exists=True,
+                        name=mrow.get("name"),
+                        is_active=mrow.get("is_active"),
+                        created_at=mrow.get("created_at"),
+                    )
+                    if mrow
+                    else FleetMerchantRow(exists=False)
+                ),
+                template=tsum,
+                usage=usage,
+                merchant_usage=FleetMerchantUsage(
+                    total=int(mstats.get("total") or 0),
+                    total_window=int(mstats.get("total_window") or 0),
+                    total_7d=int(mstats.get("total_7d") or 0),
+                    last_activity_at=mstats.get("last_activity_at"),
+                ),
+                voice_templates=int(inputs.voice_counts.get(key, 0)),
+                flags=flags,
+            )
+        )
+    merchants.sort(
+        key=lambda m: (
+            m.reseller_id not in ASSIST_RESELLERS,
+            -m.usage.total_window,
+            -m.usage.total,
+        )
+    )
+
+    # ---- templates: usage + cleanup for orphans ---------------------------
+    templates: List[FleetTemplate] = []
+    for tid, tsum in summaries.items():
+        tsum.usage = usage_for(
+            tid,
+            inputs.template_stats,
+            inputs.template_depth,
+            inputs.template_daily,
+            days,
+        )
+        orphan = (
+            tsum.bound_widget_config_id is None
+            and tsum.agent_type == "chat"
+            and tsum.reseller_id in ASSIST_RESELLERS
+        )
+        if orphan:
+            tsum.cleanup = cleanup_for(tsum, tsum.usage, reference.template_ids)
+        templates.append(tsum)
+    templates.sort(
+        key=lambda t: (
+            t.generation in ("voice-agent", "other-tenant"),
+            t.bound_widget_config_id is None,
+            t.name.lower(),
+        )
+    )
+
+    # ---- variants ---------------------------------------------------------
+    by_hash: Dict[str, List[FleetTemplate]] = defaultdict(list)
+    for t in templates:
+        if t.shared_block_hash and t.generation not in ("voice-agent", "other-tenant"):
+            by_hash[t.shared_block_hash].append(t)
+    variants = [
+        FleetVariant(
+            hash=h,
+            is_reference=h in reference.hashes,
+            template_ids=[t.id for t in ts],
+            live_count=sum(1 for t in ts if t.bound_widget_config_id),
+        )
+        for h, ts in by_hash.items()
+    ]
+    variants.sort(key=lambda v: (not v.is_reference, -len(v.template_ids)))
+
+    # ---- totals -----------------------------------------------------------
+    assist_merchants = [m for m in merchants if m.reseller_id in ASSIST_RESELLERS]
+    orphans = [t for t in templates if t.cleanup is not None]
+    totals = FleetTotals(
+        merchants=len(merchants),
+        active_7d=sum(1 for m in merchants if m.usage.total_7d > 0),
+        sessions_total=sum(m.usage.total for m in merchants),
+        sessions_window=sum(m.usage.total_window for m in merchants),
+        sessions_7d=sum(m.usage.total_7d for m in merchants),
+        silent=sum(
+            1
+            for m in merchants
+            if any(f.code in ("silent", "never-used") for f in m.flags)
+        ),
+        orphans=len(orphans),
+        orphans_deletable=sum(
+            1 for t in orphans if t.cleanup and t.cleanup.action == "delete"
+        ),
+        standard=sum(1 for m in merchants if m.template.generation == "standard"),
+        bare=sum(1 for m in merchants if m.template.generation == "bare"),
+        wismo=sum(1 for m in merchants if m.template.wismo),
+        voice_templates=sum(m.voice_templates for m in merchants),
+        by_reseller=dict(Counter(m.reseller_id for m in merchants)),
+    )
+
+    issues = _issues(
+        merchants=merchants,
+        assist_merchants=assist_merchants,
+        orphans=orphans,
+        variants=variants,
+        blueprints=inputs.blueprints,
+        reference=reference,
+    )
+
+    return AssistFleetResponse(
+        generated_at=now,
+        window_days=window_days,
+        days=[d.isoformat() for d in days],
+        assist_resellers=list(ASSIST_RESELLERS),
+        reference=reference,
+        merchants=merchants,
+        templates=templates,
+        variants=variants,
+        issues=issues,
+        totals=totals,
+    )
+
+
+def _issues(
+    *,
+    merchants: List[FleetMerchant],
+    assist_merchants: List[FleetMerchant],
+    orphans: List[FleetTemplate],
+    variants: List[FleetVariant],
+    blueprints: Sequence[Dict[str, Any]],
+    reference: FleetReference,
+) -> List[FleetIssue]:
+    issues: List[FleetIssue] = []
+    have_bp = {bp.get("reseller_id") for bp in blueprints}
+    for r in ASSIST_RESELLERS:
+        if r not in have_bp:
+            issues.append(
+                FleetIssue(
+                    level="critical",
+                    title=f"Blueprint template '{DEFAULT_ASSIST_TEMPLATE_NAME}' is missing under {r}",
+                    detail=(
+                        "The bare onboard path loads this reseller-level template on first "
+                        "create, so every fresh install through that reseller fails with "
+                        "DEFAULT_TEMPLATE_NOT_FOUND until it exists."
+                    ),
+                    fix=f"Create a reseller-level (merchant_id null) template named "
+                    f"'{DEFAULT_ASSIST_TEMPLATE_NAME}' under {r}.",
+                )
+            )
+    for m in assist_merchants:
+        if any(f.code == "silent" and f.level == "critical" for f in m.flags):
+            since = (
+                m.usage.last_activity_at.date().isoformat()
+                if m.usage.last_activity_at
+                else "?"
+            )
+            issues.append(
+                FleetIssue(
+                    level="critical",
+                    title=f"{m.brand} went silent on {since}",
+                    detail=(
+                        f"{m.usage.total:,} sessions lifetime, {m.usage.total_window:,} in the "
+                        "window, none in the last 7 days."
+                    ),
+                    fix="Check the theme app-embed on the storefront and that the storefront-config resolve returns 200 for its domain.",
+                )
+            )
+    misbound = [
+        m for m in merchants if any(f.code == "voice-only-template" for f in m.flags)
+    ]
+    if misbound:
+        issues.append(
+            FleetIssue(
+                level="critical",
+                title=f"{len(misbound)} widget(s) bound to voice-only templates",
+                detail=", ".join(m.brand for m in misbound[:8]),
+                fix="Add the 'chat' channel to the template or bind the widget to a chat agent.",
+            )
+        )
+    if orphans:
+        deletable = sum(
+            1 for t in orphans if t.cleanup and t.cleanup.action == "delete"
+        )
+        issues.append(
+            FleetIssue(
+                level="warning",
+                title=f"{len(orphans)} orphan chat templates under the assist resellers",
+                detail=(
+                    f"{deletable} have no sessions and can be deleted; the rest should be "
+                    "deactivated (session foreign key blocks a delete)."
+                ),
+                fix="Use the cleanup plan.",
+            )
+        )
+    missing_rows = [m for m in assist_merchants if not m.merchant_row.exists]
+    if missing_rows:
+        issues.append(
+            FleetIssue(
+                level="warning",
+                title=f"{len(missing_rows)} assist widget(s) have no merchants row",
+                detail=", ".join(m.merchant_id for m in missing_rows[:8]),
+                fix="Create the merchants row so scoped users can be granted access.",
+            )
+        )
+    if assist_merchants:
+        standard = sum(
+            1 for m in assist_merchants if m.template.generation == "standard"
+        )
+        bare = sum(1 for m in assist_merchants if m.template.generation == "bare")
+        live_variants = sum(1 for v in variants if v.live_count and not v.is_reference)
+        issues.append(
+            FleetIssue(
+                level="info",
+                title=f"{standard} of {len(assist_merchants)} live assist agents match the reference prompt",
+                detail=(
+                    f"{live_variants} other shared-block variants are live; {bare} agents still "
+                    f"run the bare default prompt. Reference source: {reference.source}."
+                ),
+                fix="Pick the canonical shared block, then roll it out with the fleet SOP.",
+            )
+        )
+    return issues
+
+
+__all__ = [
+    "ASSIST_RESELLERS",
+    "FleetInputs",
+    "agent_type_of",
+    "block_hash",
+    "brand_domain",
+    "brand_from_prompt",
+    "build_fleet",
+    "cleanup_for",
+    "flags_for",
+    "host_app_of",
+    "ist_days",
+    "merchant_domain",
+    "normalize_channels",
+    "platform_of",
+    "prompt_sections",
+    "resolve_reference",
+    "shared_block",
+    "summarize_template",
+    "usage_for",
+    "widget_voice_of",
+]

--- a/app/api/routers/breeze_buddy/__init__.py
+++ b/app/api/routers/breeze_buddy/__init__.py
@@ -1,5 +1,7 @@
 from fastapi import APIRouter
 
+from app.api.routers.breeze_buddy.admin import router as admin_router
+
 # Pod health probes (1-pod-1-call isolation architecture)
 from app.api.routers.breeze_buddy.agent_router.health import router as pod_router
 
@@ -160,6 +162,9 @@ router.include_router(chat_router, prefix="", tags=["chat"])
 # - widget_config: per-merchant config (admin/reseller-scoped CRUD)
 # - widget: unified /widget/session/* conversation router (chat ↔ voice)
 router.include_router(widget_config_router, prefix="", tags=["widget-config"])
+# Admin-only surfaces (/admin/*): assist fleet inventory, and any future
+# platform-wide read or action — see routers/breeze_buddy/admin/__init__.py
+router.include_router(admin_router, prefix="", tags=["admin"])
 # - ui_components: CHAMELEON custom-component registry (migration 070)
 router.include_router(ui_components_router, prefix="", tags=["ui-components"])
 router.include_router(widget_router, prefix="", tags=["widget-session"])

--- a/app/api/routers/breeze_buddy/admin/__init__.py
+++ b/app/api/routers/breeze_buddy/admin/__init__.py
@@ -1,0 +1,23 @@
+"""Admin-only surfaces, mounted under ``/admin/*``.
+
+Everything that only a platform admin may call lives in this package, one
+sub-package per surface, and every route in here gates with
+``require_admin``. Cross-tenant reads (fleet inventories, platform health)
+and platform-wide actions belong here, never in a tenant-scoped router.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter
+
+from app.api.routers.breeze_buddy.admin.assist_fleet import (
+    router as assist_fleet_router,
+)
+
+router = APIRouter()
+
+# Buddy Assist fleet inventory: every assist agent, usage, health, orphaned
+# templates, shared-prompt variants — behind the console's Admin page.
+router.include_router(assist_fleet_router, prefix="", tags=["admin-assist-fleet"])
+
+__all__ = ["router"]

--- a/app/api/routers/breeze_buddy/admin/assist_fleet/__init__.py
+++ b/app/api/routers/breeze_buddy/admin/assist_fleet/__init__.py
@@ -1,0 +1,55 @@
+"""Admin-only Buddy Assist fleet inventory.
+
+``GET /admin/assist-fleet`` — every widget_config (an assist agent's public
+surface) with its merchant, bound template, chat-session usage and health
+flags; every chat-agent template under the assist resellers with its
+generation and, for orphans, a cleanup recommendation; the shared-prompt-block
+variants; and fleet-level findings. Read-only. Actions (deactivate / delete a
+template, disable a widget) go through the existing template and
+widget-config endpoints.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from fastapi import APIRouter, Depends, Query
+
+from app.api.routers.breeze_buddy.admin.assist_fleet.handlers import (
+    get_assist_fleet_handler,
+)
+from app.api.security.breeze_buddy.rbac_token import get_current_user_with_rbac
+from app.core.security.authorization import require_admin
+from app.schemas import UserInfo
+from app.schemas.breeze_buddy.admin.assist_fleet import AssistFleetResponse
+
+router = APIRouter()
+
+
+@router.get("/admin/assist-fleet", response_model=AssistFleetResponse)
+async def get_assist_fleet(
+    window_days: int = Query(
+        default=30, ge=7, le=90, description="Usage window in days (7-90)."
+    ),
+    reference_template_id: Optional[str] = Query(
+        default=None,
+        description=(
+            "Template whose '## Operating principles' block counts as the fleet "
+            "standard, in addition to the reseller blueprints."
+        ),
+    ),
+    current_user: UserInfo = Depends(get_current_user_with_rbac),
+) -> AssistFleetResponse:
+    """Fleet-wide inventory of assist agents.
+
+    **RBAC rules:** admin only; a reseller or merchant token gets 403.
+    """
+    require_admin(current_user)
+    return await get_assist_fleet_handler(
+        current_user,
+        window_days=window_days,
+        reference_template_id=reference_template_id,
+    )
+
+
+__all__ = ["router"]

--- a/app/api/routers/breeze_buddy/admin/assist_fleet/handlers.py
+++ b/app/api/routers/breeze_buddy/admin/assist_fleet/handlers.py
@@ -1,0 +1,105 @@
+"""Handler for ``GET /admin/assist-fleet``.
+
+Loads the raw rows (nine read-only queries, the independent ones in parallel;
+two gathers because typeshed's ``gather`` overloads stop at six positionals),
+then hands everything to the pure ``build_fleet``. The route module owns auth;
+this module owns orchestration; ``assist/fleet.py`` owns every decision.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+
+from fastapi import HTTPException, status
+
+from app.ai.voice.agents.breeze_buddy.assist.commerce.assist_onboarding import (
+    DEFAULT_ASSIST_TEMPLATE_NAME,
+)
+from app.ai.voice.agents.breeze_buddy.assist.fleet import (
+    ASSIST_RESELLERS,
+    FleetInputs,
+    build_fleet,
+)
+from app.core.logger import logger
+from app.database.accessor.breeze_buddy.admin.assist_fleet import (
+    fetch_all_widget_configs,
+    fetch_blueprint_templates,
+    fetch_chat_templates,
+    fetch_merchant_session_stats,
+    fetch_merchants_by_ids,
+    fetch_template_daily_sessions,
+    fetch_template_session_depth,
+    fetch_template_session_stats,
+    fetch_voice_template_counts,
+)
+from app.schemas import UserInfo
+from app.schemas.breeze_buddy.admin.assist_fleet import AssistFleetResponse
+
+
+async def get_assist_fleet_handler(
+    current_user: UserInfo,
+    *,
+    window_days: int = 30,
+    reference_template_id: Optional[str] = None,
+) -> AssistFleetResponse:
+    now = datetime.now(timezone.utc)
+    since_window = now - timedelta(days=window_days)
+    since_7d = now - timedelta(days=7)
+    logger.info(
+        f"assist-fleet: {current_user.username} requested the fleet "
+        f"(window_days={window_days}, reference={reference_template_id})"
+    )
+    try:
+        widgets = await fetch_all_widget_configs()
+        bound_ids = sorted({w["template_id"] for w in widgets})
+        extra_ids = list(bound_ids)
+        if reference_template_id and reference_template_id not in extra_ids:
+            extra_ids.append(reference_template_id)
+        templates = await fetch_chat_templates(ASSIST_RESELLERS, extra_ids)
+        template_ids = [t["id"] for t in templates]
+        merchant_ids = sorted({w["merchant_id"] for w in widgets})
+        reseller_ids = sorted({w["reseller_id"] for w in widgets})
+
+        merchants, voice_counts, blueprints = await asyncio.gather(
+            fetch_merchants_by_ids(merchant_ids),
+            fetch_voice_template_counts(ASSIST_RESELLERS),
+            fetch_blueprint_templates(ASSIST_RESELLERS, DEFAULT_ASSIST_TEMPLATE_NAME),
+        )
+        (
+            template_stats,
+            template_depth,
+            template_daily,
+            merchant_stats,
+        ) = await asyncio.gather(
+            fetch_template_session_stats(template_ids, since_window, since_7d),
+            fetch_template_session_depth(template_ids, since_window),
+            fetch_template_daily_sessions(template_ids, since_window),
+            fetch_merchant_session_stats(
+                reseller_ids, merchant_ids, since_window, since_7d
+            ),
+        )
+    except Exception as e:  # accessors already logged the SQL failure
+        logger.error(f"assist-fleet: failed to load fleet rows: {e}", exc_info=True)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Could not load the assist fleet.",
+        ) from e
+
+    inputs = FleetInputs(
+        widgets=widgets,
+        templates=templates,
+        merchants=merchants,
+        voice_counts=voice_counts,
+        blueprints=blueprints,
+        template_stats=template_stats,
+        template_depth=template_depth,
+        template_daily=template_daily,
+        merchant_stats=merchant_stats,
+        reference_template_id=reference_template_id,
+    )
+    return build_fleet(inputs, now=now, window_days=window_days)
+
+
+__all__ = ["get_assist_fleet_handler"]

--- a/app/database/accessor/breeze_buddy/admin/__init__.py
+++ b/app/database/accessor/breeze_buddy/admin/__init__.py
@@ -1,0 +1,1 @@
+"""Accessors behind the admin surfaces (``/admin/*``)."""

--- a/app/database/accessor/breeze_buddy/admin/assist_fleet.py
+++ b/app/database/accessor/breeze_buddy/admin/assist_fleet.py
@@ -1,0 +1,201 @@
+"""Async accessors for the assist-fleet read model.
+
+Rows come back as plain dicts (the ``chat_analytics`` accessor idiom) — the
+fleet builder in ``assist/fleet.py`` is the layer that shapes them. jsonb
+columns are decoded here because asyncpg returns them as ``str`` unless a
+codec is registered.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from typing import Any, Dict, List, Sequence
+
+from app.core.logger import logger
+from app.database.queries import run_parameterized_query
+from app.database.queries.breeze_buddy.admin.assist_fleet import (
+    all_widget_configs_query,
+    blueprint_templates_query,
+    chat_templates_query,
+    merchant_session_stats_query,
+    merchants_by_ids_query,
+    template_daily_sessions_query,
+    template_session_depth_query,
+    template_session_stats_query,
+    voice_template_counts_query,
+)
+
+
+def _jsonb(value: Any, default: Any) -> Any:
+    if value is None:
+        return default
+    if isinstance(value, str):
+        try:
+            return json.loads(value)
+        except ValueError:
+            return default
+    return value
+
+
+def _rows(result) -> List[Dict[str, Any]]:
+    return [dict(r) for r in result] if result else []
+
+
+async def fetch_all_widget_configs() -> List[Dict[str, Any]]:
+    try:
+        query, values = all_widget_configs_query()
+        rows = _rows(await run_parameterized_query(query, values))
+        for r in rows:
+            r["id"] = str(r["id"])
+            r["template_id"] = str(r["template_id"])
+            r["allowed_origins"] = list(r.get("allowed_origins") or [])
+            r["appearance"] = _jsonb(r.get("appearance"), {})
+        return rows
+    except Exception as e:
+        logger.error(f"assist-fleet: error listing widget configs: {e}")
+        raise
+
+
+async def fetch_chat_templates(
+    reseller_ids: Sequence[str], template_ids: Sequence[str]
+) -> List[Dict[str, Any]]:
+    try:
+        query, values = chat_templates_query(reseller_ids, template_ids)
+        rows = _rows(await run_parameterized_query(query, values))
+        for r in rows:
+            r["id"] = str(r["id"])
+            r["supported_channels"] = list(r.get("supported_channels") or [])
+            r["flow"] = _jsonb(r.get("flow"), {})
+            r["configurations"] = _jsonb(r.get("configurations"), {})
+        return rows
+    except Exception as e:
+        logger.error(f"assist-fleet: error listing chat templates: {e}")
+        raise
+
+
+async def fetch_voice_template_counts(
+    reseller_ids: Sequence[str],
+) -> Dict[str, int]:
+    """``"reseller|merchant" -> active voice-only template count``."""
+    try:
+        query, values = voice_template_counts_query(reseller_ids)
+        rows = _rows(await run_parameterized_query(query, values))
+        return {
+            f"{r['reseller_id']}|{r['merchant_id']}": int(r["voice_templates"])
+            for r in rows
+            if r.get("merchant_id")
+        }
+    except Exception as e:
+        logger.error(f"assist-fleet: error counting voice templates: {e}")
+        raise
+
+
+async def fetch_blueprint_templates(
+    reseller_ids: Sequence[str], name: str
+) -> List[Dict[str, Any]]:
+    try:
+        query, values = blueprint_templates_query(reseller_ids, name)
+        rows = _rows(await run_parameterized_query(query, values))
+        for r in rows:
+            r["id"] = str(r["id"])
+            r["flow"] = _jsonb(r.get("flow"), {})
+        return rows
+    except Exception as e:
+        logger.error(f"assist-fleet: error loading blueprint templates: {e}")
+        raise
+
+
+async def fetch_merchants_by_ids(
+    merchant_ids: Sequence[str],
+) -> Dict[str, Dict[str, Any]]:
+    """``"reseller|merchant" -> merchants row`` for the given merchant ids."""
+    if not merchant_ids:
+        return {}
+    try:
+        query, values = merchants_by_ids_query(merchant_ids)
+        rows = _rows(await run_parameterized_query(query, values))
+        return {f"{r['reseller_id']}|{r['merchant_id']}": r for r in rows}
+    except Exception as e:
+        logger.error(f"assist-fleet: error loading merchants: {e}")
+        raise
+
+
+async def fetch_template_session_stats(
+    template_ids: Sequence[str], since_window: datetime, since_7d: datetime
+) -> Dict[str, Dict[str, Any]]:
+    if not template_ids:
+        return {}
+    try:
+        query, values = template_session_stats_query(
+            template_ids, since_window, since_7d
+        )
+        rows = _rows(await run_parameterized_query(query, values))
+        return {r["template_id"]: r for r in rows}
+    except Exception as e:
+        logger.error(f"assist-fleet: error aggregating template sessions: {e}")
+        raise
+
+
+async def fetch_template_session_depth(
+    template_ids: Sequence[str], since_window: datetime
+) -> Dict[str, Dict[str, Any]]:
+    if not template_ids:
+        return {}
+    try:
+        query, values = template_session_depth_query(template_ids, since_window)
+        rows = _rows(await run_parameterized_query(query, values))
+        return {r["template_id"]: r for r in rows}
+    except Exception as e:
+        logger.error(f"assist-fleet: error aggregating session depth: {e}")
+        raise
+
+
+async def fetch_template_daily_sessions(
+    template_ids: Sequence[str], since_window: datetime
+) -> Dict[str, Dict[str, int]]:
+    """``template_id -> {"YYYY-MM-DD": sessions}``."""
+    if not template_ids:
+        return {}
+    try:
+        query, values = template_daily_sessions_query(template_ids, since_window)
+        rows = _rows(await run_parameterized_query(query, values))
+        out: Dict[str, Dict[str, int]] = {}
+        for r in rows:
+            out.setdefault(r["template_id"], {})[r["day"]] = int(r["sessions"])
+        return out
+    except Exception as e:
+        logger.error(f"assist-fleet: error bucketing daily sessions: {e}")
+        raise
+
+
+async def fetch_merchant_session_stats(
+    reseller_ids: Sequence[str],
+    merchant_ids: Sequence[str],
+    since_window: datetime,
+    since_7d: datetime,
+) -> Dict[str, Dict[str, Any]]:
+    if not merchant_ids:
+        return {}
+    try:
+        query, values = merchant_session_stats_query(
+            reseller_ids, merchant_ids, since_window, since_7d
+        )
+        rows = _rows(await run_parameterized_query(query, values))
+        return {f"{r['reseller_id']}|{r['merchant_id']}": r for r in rows}
+    except Exception as e:
+        logger.error(f"assist-fleet: error aggregating merchant sessions: {e}")
+        raise
+
+
+__all__ = [
+    "fetch_all_widget_configs",
+    "fetch_blueprint_templates",
+    "fetch_chat_templates",
+    "fetch_merchant_session_stats",
+    "fetch_merchants_by_ids",
+    "fetch_template_daily_sessions",
+    "fetch_template_session_depth",
+    "fetch_template_session_stats",
+    "fetch_voice_template_counts",
+]

--- a/app/database/queries/breeze_buddy/admin/__init__.py
+++ b/app/database/queries/breeze_buddy/admin/__init__.py
@@ -1,0 +1,1 @@
+"""Read-only cross-table queries behind the admin surfaces (``/admin/*``)."""

--- a/app/database/queries/breeze_buddy/admin/assist_fleet.py
+++ b/app/database/queries/breeze_buddy/admin/assist_fleet.py
@@ -1,0 +1,198 @@
+"""Read-only cross-table queries behind ``GET /admin/assist-fleet``.
+
+The fleet view joins four tables that each keep their writes in their own
+query module (``widget_config.py``, ``template.py``, ``chat_session.py``,
+``merchants.py``). Everything here is a SELECT, and every aggregate follows
+the ``chat_analytics.py`` rule: per-session message counts come from a
+scalar subquery so a LEFT JOIN can never fan a session out by its message
+count and skew an average.
+
+``$N::uuid[]`` / ``$N::text[]`` casts are deliberate — asyncpg infers array
+element codecs from the cast, so callers pass plain Python lists of ``str``.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, List, Sequence, Tuple
+
+WIDGET_CONFIG_TABLE = "widget_config"
+TEMPLATE_TABLE = "template"
+MERCHANTS_TABLE = "merchants"
+CHAT_SESSION_TABLE = "chat_session"
+CHAT_MESSAGE_TABLE = "chat_message"
+
+# Day buckets follow the console's analytics convention (IST), not UTC.
+_DAY_BUCKET = "(cs.created_at AT TIME ZONE 'Asia/Kolkata')::date::text"
+
+
+def all_widget_configs_query() -> Tuple[str, List[Any]]:
+    """Every widget_config row, active or not — the fleet's one-row-per-agent spine.
+
+    ``public_widget_key`` is intentionally not selected: the fleet payload is an
+    inventory, and the key has no business in it.
+    """
+    query = f"""
+        SELECT id, reseller_id, merchant_id, template_id, allowed_origins,
+               max_sessions_per_ip_hour, max_messages_per_ip_hour,
+               max_concurrent_per_ip, max_voice_sessions_per_ip_hour,
+               active, appearance, created_at, updated_at
+        FROM {WIDGET_CONFIG_TABLE}
+        ORDER BY created_at DESC
+    """
+    return query, []
+
+
+def chat_templates_query(
+    reseller_ids: Sequence[str], template_ids: Sequence[str]
+) -> Tuple[str, List[Any]]:
+    """Chat-agent templates under the assist resellers, plus any explicit ids.
+
+    "Chat agent" is the console rule (loom ``agent-type.ts``): ``'chat'`` in
+    ``supported_channels``. The explicit id list carries the widget-bound
+    templates of *other* resellers (demo / internal tenants) so a widget can
+    always be described, even when its template is not an assist template.
+    Full ``flow`` + ``configurations`` are selected because generation
+    classification needs the prompt and the LLM/tool config.
+    """
+    query = f"""
+        SELECT id, reseller_id, merchant_id, name, is_active, supported_channels,
+               flow, configurations, created_at, updated_at
+        FROM {TEMPLATE_TABLE}
+        WHERE (reseller_id = ANY($1::text[]) AND 'chat' = ANY(supported_channels))
+           OR id = ANY($2::uuid[])
+        ORDER BY name
+    """
+    return query, [list(reseller_ids), list(template_ids)]
+
+
+def voice_template_counts_query(reseller_ids: Sequence[str]) -> Tuple[str, List[Any]]:
+    """Active telephony (voice-only) templates per merchant under the assist resellers."""
+    query = f"""
+        SELECT reseller_id, merchant_id, COUNT(*) AS voice_templates
+        FROM {TEMPLATE_TABLE}
+        WHERE reseller_id = ANY($1::text[])
+          AND NOT ('chat' = ANY(supported_channels))
+          AND is_active = TRUE
+        GROUP BY reseller_id, merchant_id
+    """
+    return query, [list(reseller_ids)]
+
+
+def blueprint_templates_query(
+    reseller_ids: Sequence[str], name: str
+) -> Tuple[str, List[Any]]:
+    """Reseller-level blueprint rows (``merchant_id IS NULL``) by exact name."""
+    query = f"""
+        SELECT id, reseller_id, flow
+        FROM {TEMPLATE_TABLE}
+        WHERE reseller_id = ANY($1::text[])
+          AND merchant_id IS NULL
+          AND name = $2
+    """
+    return query, [list(reseller_ids), name]
+
+
+def merchants_by_ids_query(merchant_ids: Sequence[str]) -> Tuple[str, List[Any]]:
+    query = f"""
+        SELECT merchant_id, name, is_active, reseller_id, created_at
+        FROM {MERCHANTS_TABLE}
+        WHERE merchant_id = ANY($1::text[])
+    """
+    return query, [list(merchant_ids)]
+
+
+def template_session_stats_query(
+    template_ids: Sequence[str], since_window: datetime, since_7d: datetime
+) -> Tuple[str, List[Any]]:
+    """Lifetime / window / 7-day session counts and activity bounds per template."""
+    query = f"""
+        SELECT cs.template_id::text AS template_id,
+               COUNT(*) AS total,
+               COUNT(*) FILTER (WHERE cs.created_at >= $2::timestamptz) AS total_window,
+               COUNT(*) FILTER (WHERE cs.created_at >= $3::timestamptz) AS total_7d,
+               COUNT(*) FILTER (WHERE cs.status = 'ACTIVE') AS active_now,
+               MAX(cs.last_activity_at) AS last_activity_at,
+               MIN(cs.created_at) AS first_seen_at
+        FROM {CHAT_SESSION_TABLE} cs
+        WHERE cs.template_id = ANY($1::uuid[])
+        GROUP BY cs.template_id
+    """
+    return query, [list(template_ids), since_window, since_7d]
+
+
+def template_session_depth_query(
+    template_ids: Sequence[str], since_window: datetime
+) -> Tuple[str, List[Any]]:
+    """Average messages per session and zero-message sessions inside the window.
+
+    Message counts are a scalar subquery per session (see module docstring).
+    """
+    query = f"""
+        WITH s AS (
+            SELECT cs.template_id,
+                   (SELECT COUNT(*) FROM {CHAT_MESSAGE_TABLE} m
+                     WHERE m.session_id = cs.id) AS msgs
+            FROM {CHAT_SESSION_TABLE} cs
+            WHERE cs.template_id = ANY($1::uuid[])
+              AND cs.created_at >= $2::timestamptz
+        )
+        SELECT template_id::text AS template_id,
+               COUNT(*) AS sessions,
+               AVG(msgs)::float AS avg_messages,
+               COUNT(*) FILTER (WHERE msgs = 0) AS zero_message_sessions
+        FROM s
+        GROUP BY template_id
+    """
+    return query, [list(template_ids), since_window]
+
+
+def template_daily_sessions_query(
+    template_ids: Sequence[str], since_window: datetime
+) -> Tuple[str, List[Any]]:
+    """Sessions per IST calendar day per template inside the window."""
+    query = f"""
+        SELECT cs.template_id::text AS template_id,
+               {_DAY_BUCKET} AS day,
+               COUNT(*) AS sessions
+        FROM {CHAT_SESSION_TABLE} cs
+        WHERE cs.template_id = ANY($1::uuid[])
+          AND cs.created_at >= $2::timestamptz
+        GROUP BY 1, 2
+    """
+    return query, [list(template_ids), since_window]
+
+
+def merchant_session_stats_query(
+    reseller_ids: Sequence[str],
+    merchant_ids: Sequence[str],
+    since_window: datetime,
+    since_7d: datetime,
+) -> Tuple[str, List[Any]]:
+    """Session counts per (reseller, merchant) across every template the merchant
+    ever used — survives template swaps, which the per-template stats do not."""
+    query = f"""
+        SELECT cs.reseller_id, cs.merchant_id,
+               COUNT(*) AS total,
+               COUNT(*) FILTER (WHERE cs.created_at >= $3::timestamptz) AS total_window,
+               COUNT(*) FILTER (WHERE cs.created_at >= $4::timestamptz) AS total_7d,
+               MAX(cs.last_activity_at) AS last_activity_at
+        FROM {CHAT_SESSION_TABLE} cs
+        WHERE cs.reseller_id = ANY($1::text[])
+          AND cs.merchant_id = ANY($2::text[])
+        GROUP BY cs.reseller_id, cs.merchant_id
+    """
+    return query, [list(reseller_ids), list(merchant_ids), since_window, since_7d]
+
+
+__all__ = [
+    "all_widget_configs_query",
+    "blueprint_templates_query",
+    "chat_templates_query",
+    "merchant_session_stats_query",
+    "merchants_by_ids_query",
+    "template_daily_sessions_query",
+    "template_session_depth_query",
+    "template_session_stats_query",
+    "voice_template_counts_query",
+]

--- a/app/schemas/breeze_buddy/admin/__init__.py
+++ b/app/schemas/breeze_buddy/admin/__init__.py
@@ -1,0 +1,1 @@
+"""Admin-only response models (``/admin/*``)."""

--- a/app/schemas/breeze_buddy/admin/assist_fleet.py
+++ b/app/schemas/breeze_buddy/admin/assist_fleet.py
@@ -1,0 +1,231 @@
+"""Response models for ``GET /admin/assist-fleet``.
+
+One payload describes the whole Buddy Assist fleet: one row per widget_config
+(the agent's public surface) with its merchant, bound template and usage;
+every chat-agent template under the assist resellers (bound or orphaned);
+the shared-prompt-block variants; and the findings an operator should act on.
+Bodies (``flow`` / ``configurations``) are never included — a diff view fetches
+the two templates it compares through ``GET /templates/{id}``.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Dict, List, Literal, Optional
+
+from pydantic import BaseModel, Field
+
+AgentType = Literal["chat", "voice"]
+Generation = Literal[
+    "standard",  # shared block matches the reference (blueprint / configured)
+    "variant",  # sectioned prompt, shared block differs from the reference
+    "legacy-personalized",  # no sections, long prompt (old nautilus personalization)
+    "bare",  # no sections, short default prompt
+    "voice-agent",  # no 'chat' channel — telephony template, not graded
+    "other-tenant",  # widget tenant outside the assist resellers, not graded
+]
+FlagLevel = Literal["critical", "warning", "info"]
+HostApp = Literal["breeze-buddy", "buddy-assist", "direct"]
+Platform = Literal["shopify", "woocommerce", "demo", "internal", "custom"]
+CleanupAction = Literal["delete", "deactivate", "keep", "none"]
+
+
+class FleetUsage(BaseModel):
+    """Chat-session usage for one template (the widget's bound template)."""
+
+    total: int = 0
+    total_window: int = 0
+    total_7d: int = 0
+    active_now: int = 0
+    last_activity_at: Optional[datetime] = None
+    first_seen_at: Optional[datetime] = None
+    avg_messages: Optional[float] = Field(
+        default=None, description="Mean messages per session inside the window."
+    )
+    zero_message_share: Optional[float] = Field(
+        default=None,
+        description="Share of window sessions with no messages (widget opened, nothing typed).",
+    )
+    daily: List[int] = Field(
+        default_factory=list,
+        description="Sessions per IST day, aligned with AssistFleetResponse.days.",
+    )
+
+
+class FleetMerchantUsage(BaseModel):
+    """Sessions for the merchant across every template it ever used."""
+
+    total: int = 0
+    total_window: int = 0
+    total_7d: int = 0
+    last_activity_at: Optional[datetime] = None
+
+
+class FleetFlag(BaseModel):
+    level: FlagLevel
+    code: str
+    text: str
+
+
+class FleetCleanup(BaseModel):
+    action: CleanupAction
+    reason: str
+
+
+class FleetTemplate(BaseModel):
+    """Summary of one template — enough to classify, never the body."""
+
+    id: str
+    name: str
+    reseller_id: Optional[str] = None
+    merchant_id: Optional[str] = None
+    is_active: bool = True
+    created_at: Optional[datetime] = None
+    updated_at: Optional[datetime] = None
+    agent_type: AgentType
+    widget_voice: bool = Field(
+        description="Chat agent whose widget may escalate to a WebRTC voice call."
+    )
+    channels: List[str] = Field(default_factory=list)
+    generation: Generation
+    matches_reference: bool = False
+    prompt_chars: int = 0
+    sections: List[str] = Field(default_factory=list)
+    shared_block_hash: Optional[str] = None
+    model: Optional[str] = None
+    provider: Optional[str] = None
+    wismo: bool = False
+    functions: List[str] = Field(default_factory=list)
+    mcp_servers: List[str] = Field(default_factory=list)
+    flavors: List[str] = Field(default_factory=list)
+    connectors: List[str] = Field(default_factory=list)
+    quick_replies: int = 0
+    has_greeting: bool = False
+    brand_name: Optional[str] = None
+    bound_widget_config_id: Optional[str] = None
+    bound_merchant_key: Optional[str] = None
+    usage: Optional[FleetUsage] = None
+    cleanup: Optional[FleetCleanup] = Field(
+        default=None,
+        description="Set only for orphaned chat templates under the assist resellers.",
+    )
+
+
+class FleetWidget(BaseModel):
+    id: str
+    active: bool = True
+    created_at: Optional[datetime] = None
+    updated_at: Optional[datetime] = None
+    appearance_set: bool = False
+    max_sessions_per_ip_hour: Optional[int] = None
+    max_messages_per_ip_hour: Optional[int] = None
+    max_concurrent_per_ip: Optional[int] = None
+    max_voice_sessions_per_ip_hour: Optional[int] = None
+
+
+class FleetMerchantRow(BaseModel):
+    exists: bool
+    name: Optional[str] = None
+    is_active: Optional[bool] = None
+    created_at: Optional[datetime] = None
+
+
+class FleetMerchant(BaseModel):
+    """One assist agent: a widget_config with everything hanging off it."""
+
+    key: str = Field(description="``reseller_id|merchant_id``.")
+    reseller_id: str
+    merchant_id: str
+    merchant_domain: str = Field(
+        description="merchant_id with the standalone-app ``assist-`` prefix removed."
+    )
+    host_app: HostApp
+    platform: Platform
+    brand: str
+    brand_domain: Optional[str] = None
+    origins: List[str] = Field(default_factory=list)
+    widget: FleetWidget
+    merchant_row: FleetMerchantRow
+    template: FleetTemplate
+    usage: FleetUsage
+    merchant_usage: FleetMerchantUsage
+    voice_templates: int = 0
+    flags: List[FleetFlag] = Field(default_factory=list)
+
+
+class FleetVariant(BaseModel):
+    """One distinct ``## Operating principles`` block, by content hash."""
+
+    hash: str
+    is_reference: bool = False
+    template_ids: List[str] = Field(default_factory=list)
+    live_count: int = 0
+
+
+class FleetIssue(BaseModel):
+    level: FlagLevel
+    title: str
+    detail: str
+    fix: Optional[str] = None
+
+
+class FleetReference(BaseModel):
+    source: Literal["blueprint", "template", "majority", "none"]
+    template_ids: List[str] = Field(default_factory=list)
+    hashes: List[str] = Field(default_factory=list)
+
+
+class FleetTotals(BaseModel):
+    merchants: int = 0
+    active_7d: int = 0
+    sessions_total: int = 0
+    sessions_window: int = 0
+    sessions_7d: int = 0
+    silent: int = 0
+    orphans: int = 0
+    orphans_deletable: int = 0
+    standard: int = 0
+    bare: int = 0
+    wismo: int = 0
+    voice_templates: int = 0
+    by_reseller: Dict[str, int] = Field(default_factory=dict)
+
+
+class AssistFleetResponse(BaseModel):
+    """Body of ``GET /admin/assist-fleet``."""
+
+    generated_at: datetime
+    window_days: int
+    days: List[str] = Field(
+        description="IST calendar days covered by every ``daily`` series, oldest first."
+    )
+    assist_resellers: List[str]
+    reference: FleetReference
+    merchants: List[FleetMerchant]
+    templates: List[FleetTemplate]
+    variants: List[FleetVariant]
+    issues: List[FleetIssue]
+    totals: FleetTotals
+
+
+__all__ = [
+    "AgentType",
+    "AssistFleetResponse",
+    "CleanupAction",
+    "FlagLevel",
+    "FleetCleanup",
+    "FleetFlag",
+    "FleetIssue",
+    "FleetMerchant",
+    "FleetMerchantRow",
+    "FleetMerchantUsage",
+    "FleetReference",
+    "FleetTemplate",
+    "FleetTotals",
+    "FleetUsage",
+    "FleetVariant",
+    "FleetWidget",
+    "Generation",
+    "HostApp",
+    "Platform",
+]

--- a/tests/test_admin_assist_fleet.py
+++ b/tests/test_admin_assist_fleet.py
@@ -1,0 +1,581 @@
+"""``GET /admin/assist-fleet``: query builders, the pure fleet model, and the route gate."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, List, Optional, Sequence
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.ai.voice.agents.breeze_buddy.assist import fleet
+from app.api.routers.breeze_buddy.admin.assist_fleet import handlers, router
+from app.api.security.breeze_buddy.rbac_token import get_current_user_with_rbac
+from app.database.queries.breeze_buddy.admin import assist_fleet as q
+from app.schemas import UserInfo, UserRole
+
+NOW = datetime(2026, 9, 8, 10, 0, tzinfo=timezone.utc)
+CANON = "## Operating principles\n\nWarm, precise, never pushy.\n"
+OTHER_BLOCK = "## Operating principles\n\nSomething else entirely.\n"
+WISMO = "## Order tracking (WISMO)\n\nAsk for the order number.\n"
+
+
+def _prompt(brand: str = "Acme", block: str = CANON, tail: str = "") -> str:
+    return f"## Brand identity\n\n- **Brand:** {brand} (est. 1966)\n\n{block}{tail}"
+
+
+def _template(
+    tid: str,
+    *,
+    reseller: str = "BB_SHOPIFY",
+    merchant: Optional[str] = "m1.myshopify.com",
+    channels: Sequence[str] = ("chat", "voice"),
+    prompt: str = "",
+    model: str = "gemini-2.5-flash",
+    functions: Sequence[str] = (),
+    mcp: Sequence[str] = ("https://{shop_url}/api/ucp/mcp",),
+    active: bool = True,
+    name: Optional[str] = None,
+) -> Dict[str, Any]:
+    return {
+        "id": tid,
+        "reseller_id": reseller,
+        "merchant_id": merchant,
+        "name": name or f"{tid}-assist",
+        "is_active": active,
+        "supported_channels": list(channels),
+        "flow": {
+            "system_prompt": prompt,
+            "functions": [{"name": f} for f in functions],
+        },
+        "configurations": {
+            "llm_configurations": {"model": model, "provider": "google_vertex"},
+            "mcp": {"servers": [{"url": u} for u in mcp]},
+            "quick_replies": ["a", "b"],
+            "initial_greeting": "Hi",
+        },
+        "created_at": NOW - timedelta(days=40),
+        "updated_at": NOW - timedelta(days=1),
+    }
+
+
+def _widget(
+    wid: str,
+    tid: str,
+    *,
+    reseller: str = "BB_SHOPIFY",
+    merchant: str = "m1.myshopify.com",
+    origins: Optional[List[str]] = None,
+    active: bool = True,
+    appearance: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    return {
+        "id": wid,
+        "reseller_id": reseller,
+        "merchant_id": merchant,
+        "template_id": tid,
+        "allowed_origins": origins if origins is not None else [f"https://{merchant}"],
+        "max_sessions_per_ip_hour": 60,
+        "max_messages_per_ip_hour": 600,
+        "max_concurrent_per_ip": 4,
+        "max_voice_sessions_per_ip_hour": 10,
+        "active": active,
+        "appearance": appearance or {},
+        "created_at": NOW - timedelta(days=30),
+        "updated_at": NOW - timedelta(days=30),
+    }
+
+
+def _stats(total: int, window: int = 0, d7: int = 0, last_days_ago: float = 0.5):
+    return {
+        "total": total,
+        "total_window": window,
+        "total_7d": d7,
+        "active_now": 0,
+        "last_activity_at": NOW - timedelta(days=last_days_ago),
+        "first_seen_at": NOW - timedelta(days=60),
+    }
+
+
+def _inputs(**over: Any) -> fleet.FleetInputs:
+    base: Dict[str, Any] = dict(
+        widgets=[],
+        templates=[],
+        merchants={},
+        voice_counts={},
+        blueprints=[],
+        template_stats={},
+        template_depth={},
+        template_daily={},
+        merchant_stats={},
+        reference_template_id=None,
+    )
+    base.update(over)
+    return fleet.FleetInputs(**base)
+
+
+def _blueprint(reseller: str, block: str = CANON) -> Dict[str, Any]:
+    return {
+        "id": f"bp-{reseller}",
+        "reseller_id": reseller,
+        "flow": {"system_prompt": "{{brand_identity_section}}\n\n" + block},
+    }
+
+
+# --------------------------------------------------------------------------- #
+# helpers
+# --------------------------------------------------------------------------- #
+
+
+def test_agent_type_follows_the_console_rule():
+    assert fleet.normalize_channels(None) == ["voice"]
+    assert fleet.normalize_channels(["CHAT", " voice ", "chat", "sms"]) == [
+        "chat",
+        "voice",
+    ]
+    assert fleet.agent_type_of(["voice"]) == "voice"
+    assert fleet.agent_type_of(["chat"]) == "chat"
+    assert fleet.agent_type_of(["chat", "voice"]) == "chat"
+    assert fleet.widget_voice_of(["chat", "voice"]) is True
+    assert fleet.widget_voice_of(["chat"]) is False
+    assert fleet.widget_voice_of(["voice"]) is False
+
+
+def test_shared_block_extraction_and_hash():
+    prompt = _prompt(block=CANON, tail=WISMO)
+    assert fleet.shared_block(prompt) == CANON.strip()
+    assert fleet.prompt_sections(prompt) == [
+        "Brand identity",
+        "Operating principles",
+        "Order tracking (WISMO)",
+    ]
+    h1 = fleet.block_hash(fleet.shared_block(prompt))
+    h2 = fleet.block_hash(fleet.shared_block(_prompt(brand="Other", block=CANON)))
+    assert h1 is not None and h1 == h2 and len(h1) == 12
+    assert fleet.block_hash(fleet.shared_block(_prompt(block=OTHER_BLOCK))) != h1
+    assert fleet.block_hash("") is None
+    assert fleet.shared_block("no headings here") == ""
+
+
+def test_brand_and_domain_helpers():
+    assert fleet.brand_from_prompt(_prompt(brand="Amir & Sons")) == "Amir & Sons"
+    assert fleet.brand_from_prompt("You are zuvio Assist, a helper.") == "zuvio"
+    assert fleet.brand_from_prompt("You are Assist, a helper.") is None
+    assert (
+        fleet.brand_domain(
+            ["https://x.myshopify.com", "http://localhost:5173", "https://www.shop.in"]
+        )
+        == "shop.in"
+    )
+    assert fleet.brand_domain(["https://x.myshopify.com"]) is None
+    assert fleet.merchant_domain("BB_ASSIST", "assist-shop.in") == "shop.in"
+    assert fleet.merchant_domain("BB_SHOPIFY", "assist-shop.in") == "assist-shop.in"
+    assert fleet.host_app_of("BB_SHOPIFY") == "breeze-buddy"
+    assert fleet.host_app_of("BB_ASSIST") == "buddy-assist"
+    assert fleet.host_app_of("breeze") == "direct"
+    assert fleet.platform_of("acme", "showcase_x", []) == "demo"
+    assert fleet.platform_of("breeze", "lohono", []) == "internal"
+    assert fleet.platform_of("woocommerce", "shopyvision", []) == "woocommerce"
+    assert fleet.platform_of("BB_ASSIST", "assist-shop.in", []) == "shopify"
+    assert fleet.platform_of("other", "x", ["https://a/api/ucp/mcp"]) == "shopify"
+    assert fleet.platform_of("other", "x", []) == "custom"
+
+
+def test_ist_days_cover_window_plus_today():
+    days = fleet.ist_days(NOW, 30)
+    assert len(days) == 31
+    assert days[-1].isoformat() == "2026-09-08"
+    assert days[0].isoformat() == "2026-08-09"
+
+
+# --------------------------------------------------------------------------- #
+# classification
+# --------------------------------------------------------------------------- #
+
+
+def test_generation_classification_against_blueprint_reference():
+    templates = [
+        _template("std", prompt=_prompt(block=CANON)),
+        _template("var", prompt=_prompt(block=OTHER_BLOCK), model="gemini-3.6-flash"),
+        _template("bare", prompt="You are X Assist. Be brief."),
+        _template("legacy", prompt="You are X Assist. " + "Long text. " * 200),
+        _template("voice", channels=("voice",), prompt=""),
+        _template("demo", reseller="acme", merchant="showcase_x", prompt=_prompt()),
+    ]
+    widgets = [
+        _widget(
+            f"w-{t['id']}",
+            t["id"],
+            reseller=t["reseller_id"],
+            merchant=t["merchant_id"],
+        )
+        for t in templates
+    ]
+    out = fleet.build_fleet(
+        _inputs(
+            widgets=widgets,
+            templates=templates,
+            blueprints=[_blueprint("BB_SHOPIFY"), _blueprint("BB_ASSIST")],
+        ),
+        now=NOW,
+    )
+    gen = {t.id: t.generation for t in out.templates}
+    assert gen == {
+        "std": "standard",
+        "var": "variant",
+        "bare": "bare",
+        "legacy": "legacy-personalized",
+        "voice": "voice-agent",
+        "demo": "other-tenant",
+    }
+    assert out.reference.source == "blueprint"
+    assert out.reference.template_ids == ["bp-BB_SHOPIFY", "bp-BB_ASSIST"]
+    assert len(out.reference.hashes) == 1
+    by_id = {t.id: t for t in out.templates}
+    assert by_id["std"].matches_reference is True
+    assert by_id["var"].matches_reference is False
+    # Variants: canon (reference, 1 live) + the drifted block (1 live).
+    assert [(v.is_reference, v.live_count) for v in out.variants] == [
+        (True, 1),
+        (False, 1),
+    ]
+    # Nothing outside the assist resellers is graded or clustered.
+    assert all(
+        "demo" not in v.template_ids and "voice" not in v.template_ids
+        for v in out.variants
+    )
+
+
+def test_reference_falls_back_to_majority_of_live_agents():
+    templates = [
+        _template("a", merchant="a.myshopify.com", prompt=_prompt(block=OTHER_BLOCK)),
+        _template("b", merchant="b.myshopify.com", prompt=_prompt(block=OTHER_BLOCK)),
+        _template("c", merchant="c.myshopify.com", prompt=_prompt(block=CANON)),
+        _template("orphan", merchant="d.myshopify.com", prompt=_prompt(block=CANON)),
+    ]
+    widgets = [
+        _widget(f"w-{t['id']}", t["id"], merchant=t["merchant_id"])
+        for t in templates
+        if t["id"] != "orphan"
+    ]
+    out = fleet.build_fleet(_inputs(widgets=widgets, templates=templates), now=NOW)
+    assert out.reference.source == "majority"
+    gen = {t.id: t.generation for t in out.templates}
+    assert gen["a"] == gen["b"] == "standard"
+    assert gen["c"] == "variant"
+    assert gen["orphan"] == "variant"
+
+
+def test_explicit_reference_template_wins_over_majority():
+    templates = [
+        _template("a", merchant="a.myshopify.com", prompt=_prompt(block=OTHER_BLOCK)),
+        _template("b", merchant="b.myshopify.com", prompt=_prompt(block=OTHER_BLOCK)),
+        _template("ref", merchant="c.myshopify.com", prompt=_prompt(block=CANON)),
+    ]
+    widgets = [
+        _widget(f"w-{t['id']}", t["id"], merchant=t["merchant_id"]) for t in templates
+    ]
+    out = fleet.build_fleet(
+        _inputs(widgets=widgets, templates=templates, reference_template_id="ref"),
+        now=NOW,
+    )
+    assert out.reference.source == "template"
+    assert out.reference.template_ids == ["ref"]
+    gen = {t.id: t.generation for t in out.templates}
+    assert gen == {"a": "variant", "b": "variant", "ref": "standard"}
+
+
+# --------------------------------------------------------------------------- #
+# orphans + cleanup
+# --------------------------------------------------------------------------- #
+
+
+def test_orphan_cleanup_plan():
+    templates = [
+        _template("live", prompt=_prompt()),
+        _template("dead", prompt=_prompt(), name="old-1"),
+        _template("used", prompt=_prompt(), name="old-2"),
+        _template("off", prompt=_prompt(), active=False, name="old-3"),
+        _template("voice", channels=("voice",), name="order-confirmation"),
+        _template("ref", prompt=_prompt(), name="reference"),
+        _template("demo", reseller="acme", merchant="showcase_x", prompt=_prompt()),
+    ]
+    widgets = [_widget("w-live", "live")]
+    out = fleet.build_fleet(
+        _inputs(
+            widgets=widgets,
+            templates=templates,
+            template_stats={"used": _stats(12, last_days_ago=30)},
+            reference_template_id="ref",
+        ),
+        now=NOW,
+    )
+    plan = {t.id: (t.cleanup.action if t.cleanup else None) for t in out.templates}
+    assert plan == {
+        "live": None,  # bound: never in the cleanup plan
+        "dead": "delete",  # zero sessions
+        "used": "deactivate",  # sessions reference it
+        "off": "none",  # already inactive
+        "voice": None,  # telephony template, not a chat orphan
+        "ref": "keep",  # the reference
+        "demo": None,  # outside the assist resellers
+    }
+    used = next(t for t in out.templates if t.id == "used")
+    assert used.cleanup is not None
+    assert "12" in used.cleanup.reason and "deactivate" in used.cleanup.reason
+    assert out.totals.orphans == 4  # dead, used, off, ref
+    assert out.totals.orphans_deletable == 1
+
+
+# --------------------------------------------------------------------------- #
+# flags + usage + issues
+# --------------------------------------------------------------------------- #
+
+
+def test_merchant_flags_and_usage():
+    templates = [
+        _template("silent", merchant="s.myshopify.com", prompt=_prompt()),
+        _template("fresh", merchant="f.myshopify.com", prompt=_prompt()),
+        _template("bare", merchant="b.myshopify.com", prompt="You are B Assist."),
+        _template("voice", merchant="v.myshopify.com", channels=("voice",)),
+        _template("demo", reseller="acme", merchant="showcase_x", prompt=_prompt()),
+    ]
+    widgets = [
+        _widget(
+            "w-silent",
+            "silent",
+            merchant="s.myshopify.com",
+            origins=["https://s.myshopify.com", "https://silent.in"],
+        ),
+        _widget("w-fresh", "fresh", merchant="f.myshopify.com"),
+        _widget(
+            "w-bare",
+            "bare",
+            merchant="b.myshopify.com",
+            appearance={"primary_color": "#000"},
+        ),
+        _widget("w-voice", "voice", merchant="v.myshopify.com"),
+        _widget("w-demo", "demo", reseller="acme", merchant="showcase_x", origins=[]),
+    ]
+    days = fleet.ist_days(NOW, 30)
+    out = fleet.build_fleet(
+        _inputs(
+            widgets=widgets,
+            templates=templates,
+            merchants={
+                "BB_SHOPIFY|s.myshopify.com": {"name": "S", "is_active": True},
+                "BB_SHOPIFY|f.myshopify.com": {"name": "F", "is_active": True},
+                "BB_SHOPIFY|b.myshopify.com": {"name": "B", "is_active": True},
+                "BB_SHOPIFY|v.myshopify.com": {"name": "V", "is_active": True},
+            },
+            template_stats={
+                "silent": _stats(24_000, window=7_000, d7=0, last_days_ago=15),
+                "bare": _stats(50, window=50, d7=10),
+            },
+            template_depth={
+                "bare": {
+                    "sessions": 50,
+                    "avg_messages": 0.8,
+                    "zero_message_sessions": 40,
+                }
+            },
+            template_daily={"bare": {days[-1].isoformat(): 7, days[-2].isoformat(): 3}},
+            voice_counts={"BB_SHOPIFY|s.myshopify.com": 2},
+            blueprints=[_blueprint("BB_SHOPIFY"), _blueprint("BB_ASSIST")],
+        ),
+        now=NOW,
+    )
+    by = {m.merchant_id: m for m in out.merchants}
+    codes = lambda m: {f.code: f.level for f in m.flags}  # noqa: E731
+
+    silent = by["s.myshopify.com"]
+    assert codes(silent)["silent"] == "critical"
+    assert silent.brand == "silent.in" and silent.brand_domain == "silent.in"
+    assert silent.voice_templates == 2
+    assert silent.template.generation == "standard"
+
+    fresh = by["f.myshopify.com"]
+    assert codes(fresh)["never-used"] == "warning"
+    assert codes(fresh)["no-custom-domain"] == "warning"
+    assert fresh.brand == "Acme"  # from the prompt when no custom origin exists
+
+    bare = by["b.myshopify.com"]
+    assert codes(bare)["bare-template"] == "warning"
+    assert codes(bare)["shallow-sessions"] == "info"
+    assert "appearance-default" not in codes(bare)
+    assert bare.usage.avg_messages == 0.8 and bare.usage.zero_message_share == 0.8
+    assert len(bare.usage.daily) == 31 and bare.usage.daily[-1] == 7
+    assert bare.usage.daily[-2] == 3 and sum(bare.usage.daily) == 10
+
+    voice = by["v.myshopify.com"]
+    assert codes(voice)["voice-only-template"] == "critical"
+
+    demo = by["showcase_x"]
+    assert demo.platform == "demo" and demo.host_app == "direct"
+    assert "no-merchant-row" not in codes(demo)  # only enforced for assist resellers
+    assert "no-custom-domain" not in codes(demo)
+
+    titles = [i.title for i in out.issues]
+    assert any("went silent" in t for t in titles)
+    assert any("voice-only" in t for t in titles)
+    assert not any("Blueprint" in t for t in titles)
+    assert (
+        out.totals.merchants == 5 and out.totals.silent == 4
+    )  # 1 silent + 3 never-used
+    assert out.totals.by_reseller == {"BB_SHOPIFY": 4, "acme": 1}
+    # Assist merchants sort first, then by window volume.
+    assert [m.merchant_id for m in out.merchants][:2] == [
+        "s.myshopify.com",
+        "b.myshopify.com",
+    ]
+
+
+def test_missing_blueprints_and_missing_merchant_rows_are_findings():
+    templates = [_template("t", prompt=_prompt())]
+    out = fleet.build_fleet(
+        _inputs(widgets=[_widget("w", "t")], templates=templates), now=NOW
+    )
+    crit = [i.title for i in out.issues if i.level == "critical"]
+    assert any("missing under BB_SHOPIFY" in t for t in crit)
+    assert any("missing under BB_ASSIST" in t for t in crit)
+    m = out.merchants[0]
+    assert {f.code for f in m.flags} >= {"no-merchant-row", "never-used"}
+    assert any("no merchants row" in i.title for i in out.issues)
+
+
+def test_bound_template_missing_from_read_is_described_not_fatal():
+    out = fleet.build_fleet(_inputs(widgets=[_widget("w", "gone")]), now=NOW)
+    m = out.merchants[0]
+    assert m.template.name == "(missing template)"
+    assert m.template.is_active is False
+    assert {f.code for f in m.flags} >= {"template-inactive"}
+
+
+# --------------------------------------------------------------------------- #
+# query builders
+# --------------------------------------------------------------------------- #
+
+
+def test_query_builders_bind_in_order():
+    since = NOW - timedelta(days=30)
+    since7 = NOW - timedelta(days=7)
+    query, values = q.chat_templates_query(["BB_SHOPIFY"], ["t1", "t2"])
+    assert "'chat' = ANY(supported_channels)" in query
+    assert "id = ANY($2::uuid[])" in query
+    assert values == [["BB_SHOPIFY"], ["t1", "t2"]]
+
+    query, values = q.template_session_stats_query(["t1"], since, since7)
+    assert "cs.template_id = ANY($1::uuid[])" in query
+    assert "created_at >= $2::timestamptz" in query
+    assert "created_at >= $3::timestamptz" in query
+    assert values == [["t1"], since, since7]
+
+    query, values = q.template_session_depth_query(["t1"], since)
+    assert "FROM chat_message m" in query and "msgs = 0" in query
+    assert values == [["t1"], since]
+
+    query, values = q.template_daily_sessions_query(["t1"], since)
+    assert "AT TIME ZONE 'Asia/Kolkata'" in query
+    assert values == [["t1"], since]
+
+    query, values = q.merchant_session_stats_query(["r"], ["m"], since, since7)
+    assert "cs.reseller_id = ANY($1::text[])" in query
+    assert "cs.merchant_id = ANY($2::text[])" in query
+    assert values == [["r"], ["m"], since, since7]
+
+    query, values = q.voice_template_counts_query(["BB_SHOPIFY", "BB_ASSIST"])
+    assert "NOT ('chat' = ANY(supported_channels))" in query
+    assert values == [["BB_SHOPIFY", "BB_ASSIST"]]
+
+    query, values = q.blueprint_templates_query(["BB_SHOPIFY"], "buddy-assist-default")
+    assert "merchant_id IS NULL" in query and "name = $2" in query
+    assert values == [["BB_SHOPIFY"], "buddy-assist-default"]
+
+    query, values = q.all_widget_configs_query()
+    assert "public_widget_key" not in query
+    assert values == []
+
+
+# --------------------------------------------------------------------------- #
+# route
+# --------------------------------------------------------------------------- #
+
+ADMIN = UserInfo(id="admin-1", username="admin", role=UserRole.ADMIN)
+RESELLER = UserInfo(
+    id="r-1", username="partner", role=UserRole.RESELLER, reseller_ids=["BB_SHOPIFY"]
+)
+
+
+@pytest.fixture()
+def fleet_mocks(monkeypatch) -> Dict[str, AsyncMock]:
+    """Patch every accessor *as imported into the handler module* (repo idiom)."""
+    templates = [_template("t", prompt=_prompt())]
+    mocks: Dict[str, AsyncMock] = {
+        "fetch_all_widget_configs": AsyncMock(return_value=[_widget("w", "t")]),
+        "fetch_chat_templates": AsyncMock(return_value=templates),
+        "fetch_merchants_by_ids": AsyncMock(return_value={}),
+        "fetch_voice_template_counts": AsyncMock(return_value={}),
+        "fetch_blueprint_templates": AsyncMock(
+            return_value=[_blueprint("BB_SHOPIFY"), _blueprint("BB_ASSIST")]
+        ),
+        "fetch_template_session_stats": AsyncMock(
+            return_value={"t": _stats(3, window=3, d7=1)}
+        ),
+        "fetch_template_session_depth": AsyncMock(return_value={}),
+        "fetch_template_daily_sessions": AsyncMock(return_value={}),
+        "fetch_merchant_session_stats": AsyncMock(return_value={}),
+    }
+    for name, mock in mocks.items():
+        monkeypatch.setattr(handlers, name, mock)
+    return mocks
+
+
+@pytest.fixture()
+def fleet_app(fleet_mocks):
+    def make(user: UserInfo) -> TestClient:
+        app = FastAPI()
+        app.include_router(router)
+        app.dependency_overrides[get_current_user_with_rbac] = lambda: user
+        return TestClient(app)
+
+    return make
+
+
+def test_admin_gets_the_fleet(fleet_app, fleet_mocks):
+    res = fleet_app(ADMIN).get("/admin/assist-fleet?window_days=14")
+    assert res.status_code == 200, res.text
+    body = res.json()
+    assert body["window_days"] == 14 and len(body["days"]) == 15
+    assert body["assist_resellers"] == ["BB_SHOPIFY", "BB_ASSIST"]
+    assert body["reference"]["source"] == "blueprint"
+    assert (
+        len(body["merchants"]) == 1
+        and body["merchants"][0]["template"]["generation"] == "standard"
+    )
+    assert body["merchants"][0]["usage"]["total"] == 3
+    assert body["totals"]["merchants"] == 1 and body["totals"]["active_7d"] == 1
+    # The reference template ids are forwarded to the template read so an explicit
+    # reference outside the bound set is still loaded.
+    fleet_mocks["fetch_chat_templates"].assert_awaited_once()
+    assert fleet_mocks["fetch_chat_templates"].await_args.args[1] == ["t"]
+
+
+def test_reference_template_id_is_loaded_with_the_bound_set(fleet_app, fleet_mocks):
+    res = fleet_app(ADMIN).get("/admin/assist-fleet?reference_template_id=ref-x")
+    assert res.status_code == 200
+    assert fleet_mocks["fetch_chat_templates"].await_args.args[1] == ["t", "ref-x"]
+
+
+def test_non_admin_is_refused(fleet_app, fleet_mocks):
+    res = fleet_app(RESELLER).get("/admin/assist-fleet")
+    assert res.status_code == 403
+    fleet_mocks["fetch_all_widget_configs"].assert_not_awaited()
+
+
+def test_window_days_is_bounded(fleet_app):
+    assert fleet_app(ADMIN).get("/admin/assist-fleet?window_days=3").status_code == 422
+    assert (
+        fleet_app(ADMIN).get("/admin/assist-fleet?window_days=400").status_code == 422
+    )


### PR DESCRIPTION
## What

`GET /agent/voice/breeze-buddy/admin/assist-fleet` (admin only) — the read model behind the new **Console → Admin → Assist fleet** page (loom PR to follow).

One call returns:
- **merchants**: one row per `widget_config`, joined to its `merchants` row, bound template summary and chat-session usage (lifetime / window / 7-day counts, IST daily series, average messages, zero-message share), plus health flags (`silent`, `never-used`, `no-custom-domain`, `bare-template`, `voice-only-template`, `no-merchant-row`, …).
- **templates**: every chat-agent template under `BB_SHOPIFY` / `BB_ASSIST` (bound or orphaned) with a generation grade (`standard` / `variant` / `legacy-personalized` / `bare`), and for orphans a cleanup recommendation.
- **variants**: distinct `## Operating principles` blocks by content hash, with the reference marked.
- **issues**: fleet-level findings (missing blueprint per reseller, silent high-volume merchants, misbound widgets, orphan summary, standard share).

## How

- Agent type follows the console's rule (`loom/src/lib/console/agent-type.ts`): `chat` in `supported_channels` → chat agent (with widget voice mode when `voice` is also present); otherwise a telephony voice agent. No new column.
- Reference shared block: the reseller's `buddy-assist-default` blueprint → an explicit `?reference_template_id` → the majority block among live agents.
- Cleanup never proposes a hard delete when chat sessions reference the template (`chat_session.template_id` is `ON DELETE RESTRICT`); it proposes deactivation instead.
- Read-only. Nine SELECTs in `queries/breeze_buddy/admin/assist_fleet.py` (scalar-subquery message counts, no fan-out), accessors in `accessor/breeze_buddy/admin/assist_fleet.py`, every decision in `assist/fleet.py` (pure, unit-tested). Route: `routers/breeze_buddy/admin/assist_fleet/` (everything admin lives under `admin/` on every layer). No migration.
- Actions the console takes (deactivate / delete a template, disable a widget) use the existing `PUT/DELETE /templates/{id}` and `PUT /widget-config/{id}` endpoints. Hard-deleting a template that has chat history is a separate admin endpoint (`DELETE /admin/templates/{id}/purge`, its own PR).

## Tests

`tests/test_admin_assist_fleet.py` (16): agent-type rule, shared-block hashing, generation grading against blueprint / explicit / majority references, orphan cleanup plan, health flags and usage alignment, findings, query-builder placeholder order, and the route gate (admin 200, reseller 403, `window_days` bounds). Full suite: 1,507 + 1,019 crm passing; pyrefly clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DNdffo648u5Qg9Q5Ctftub

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an admin fleet inventory endpoint for Assist agents.
  * Provides widget configurations, templates, variants, usage metrics, health flags, cleanup recommendations, and fleet-level findings.
  * Supports configurable analysis windows and optional reference templates.
  * Restricts access to administrators and validates analysis-window settings.
* **Tests**
  * Added coverage for fleet summaries, classifications, issue detection, query behavior, authorization, and parameter validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
