### PR TITLE
feat(crm): list transformation in decoder and orders/updated shopify event

### DIFF
--- a/app/core/config/dynamic.py
+++ b/app/core/config/dynamic.py
@@ -1,4 +1,6 @@
 import json
+import time
+from typing import Optional, Tuple
 
 from app.core.logger import logger
 from app.services.live_config.store import get_config
@@ -81,6 +83,73 @@ async def BB_DISPATCH_ENABLED() -> bool:
     overriding ``BB_DISPATCH_ENABLED`` in the Redis feature-flag blob.
     """
     return await get_config("BB_DISPATCH_ENABLED", True, bool)
+
+
+#: The engine's own join budget, extractors/engine.py VARIABLE_MAX_CHARS.
+#: DUPLICATED here, not imported: app/core imports nothing from app.crm, and
+#: inverting that for one integer would put the base layer under a module
+#: that sits on top of it. tests/crm/test_context_ceiling.py pins the two
+#: equal — the executable inequality the house rule asks for, written where
+#: both sides are visible, since neither file may see the other.
+_CONTEXT_VALUE_FLOOR = 256
+#: How long a process trusts its own copy. The dial changes about once a
+#: year and is read once per consumed letter, so a fresh Redis GET per row
+#: buys nothing and costs thousands a second on the busiest worker in the
+#: system. Sixty seconds keeps the reason this is live at all — "raising it
+#: for one noisy producer should not need a deploy" — entirely intact.
+_CONTEXT_VALUE_CACHE_SECONDS = 60
+_context_value_cache: Optional[Tuple[float, int]] = None
+
+
+async def CRM_CONTEXT_VALUE_MAX_CHARS() -> int:
+    """How long one scalar fact may be to ride in a run's context.
+
+    Canon T20 col 12 keeps a run to pointers plus small facts, and this is
+    where "small" is decided. Read live rather than bound at import: the
+    right ceiling is a property of the merchants on the box, not of the
+    build, and raising it for one noisy producer should not need a deploy.
+    A value over it is DROPPED, so a send that maps it parks — raise it
+    when a real letter is being cut off, never as a matter of course.
+
+    FLOORED at the engine's join budget, and that is not defensiveness. The
+    two numbers are mutually constrained: join_list truncates a cart TO the
+    budget precisely so the scalar gate below cannot drop it whole ("the
+    send would then park on a blank whose cause is two modules away"). Set
+    this dial to 200 and every full-length joined cart is silently dropped —
+    exactly the failure the truncation exists to prevent — and set it to 0
+    and every run is born with an empty context. One side of the pair is
+    bound at import and cannot move at runtime, so the pin has to be a
+    clamp: an operator may raise this ceiling, never lower it below what the
+    build already promised.
+
+    Cached in process for _CONTEXT_VALUE_CACHE_SECONDS: this is the spine's
+    per-row path, and it was the only live-config read on it."""
+    global _context_value_cache
+    now = time.monotonic()
+    if _context_value_cache is not None and _context_value_cache[0] > now:
+        return _context_value_cache[1]
+
+    raw = await get_config("CRM_CONTEXT_VALUE_MAX_CHARS", _CONTEXT_VALUE_FLOOR, int)
+    try:
+        ceiling = int(raw)
+    except (TypeError, ValueError):
+        logger.warning(
+            f"Invalid CRM_CONTEXT_VALUE_MAX_CHARS value {raw!r}; "
+            f"using {_CONTEXT_VALUE_FLOOR}"
+        )
+        ceiling = _CONTEXT_VALUE_FLOOR
+    if ceiling < _CONTEXT_VALUE_FLOOR:
+        logger.warning(
+            f"CRM_CONTEXT_VALUE_MAX_CHARS={ceiling} is below the engine's join "
+            f"budget ({_CONTEXT_VALUE_FLOOR}); a joined list truncated TO that "
+            f"budget would be dropped from every run's context. Clamped to "
+            f"{_CONTEXT_VALUE_FLOOR} — lower the engine's budget in the build "
+            f"if this ceiling is really meant to fall."
+        )
+        ceiling = _CONTEXT_VALUE_FLOOR
+
+    _context_value_cache = (now + _CONTEXT_VALUE_CACHE_SECONDS, ceiling)
+    return ceiling
 
 
 async def BB_SCHEDULE_DEPTH_ALERT_THRESHOLD() -> int:

--- a/app/crm/outreach/entry.py
+++ b/app/crm/outreach/entry.py
@@ -25,6 +25,7 @@ source-event check and the open-run unique — not by that rollback.
 
 from typing import Any, Dict, Optional, Sequence, Tuple
 
+from app.core.config.dynamic import CRM_CONTEXT_VALUE_MAX_CHARS
 from app.core.logger import logger
 from app.crm.outreach.db.accessors import (
     enrollment as enrollment_accessor,
@@ -64,11 +65,6 @@ _PHONE_PATHS = ("customer_mobile_number", "phone")
 # (G7): an order placed between the founding checkout and a later cart
 # update must keep counting as after.
 _FOUNDING_KEYS = ("source_event_id", "entered_event_at")
-
-# Small-facts cap (canon: context carries pointers "plus the few small
-# facts the sends will need" — never payload photocopies): scalars only,
-# short values only; the full letter already lives on the event row.
-_CONTEXT_VALUE_MAX_CHARS = 256
 
 
 def _phone_from_payload(payload: dict) -> str | None:
@@ -205,7 +201,7 @@ async def _wake_on_reply(
     square (context.facts.<square>), so a later call can say what this
     stage's letter said; the same bridge enrol uses, so bookkeeping names
     and nested payload never reach the run."""
-    facts = _context_from_payload(event.payload)
+    facts = _context_from_payload(event.payload, await CRM_CONTEXT_VALUE_MAX_CHARS())
     for node in definition.nodes:
         if node.type != "wait_event" or event.topic not in node.topics:
             continue
@@ -342,7 +338,7 @@ def _where_matches(door: WorkflowEntry, event: RawEvent) -> bool:
     )
 
 
-def _context_from_payload(payload: dict) -> dict:
+def _context_from_payload(payload: dict, max_chars: int) -> dict:
     """The template-variable bridge: merchants send standard identity keys
     (customer_mobile_number, customer_name) plus whatever scalar keys
     their call template references ({item}, {cart_value}); those small
@@ -359,7 +355,7 @@ def _context_from_payload(payload: dict) -> dict:
             continue  # ours to write, never a producer's
         if not isinstance(value, (str, int, float, bool)):
             continue  # nested objects/lists stay on the event row
-        if len(str(value)) > _CONTEXT_VALUE_MAX_CHARS:
+        if len(str(value)) > max_chars:
             continue
         context[key] = value
     return context
@@ -378,11 +374,12 @@ async def _try_enrol(
     admit, enrollment_key = _enrollment_key(door, event, str(flow.id))
     if not admit:
         return  # a keyed plan without its key: a refusal, not an error
-    context = _context_from_payload(event.payload)
+    max_chars = await CRM_CONTEXT_VALUE_MAX_CHARS()
+    context = _context_from_payload(event.payload, max_chars)
     # The catalog's declared variables win over the scalar copy: the engine
     # resolved them through the declared paths (customer_name from
     # customer.first_name + last_name), and a bookkeeping name is still ours.
-    context.update(_context_from_payload(variables or {}))
+    context.update(_context_from_payload(variables or {}, max_chars))
     context["source_event_id"] = str(event.id)
     # When the founding letter HAPPENED (its own claim, else the envelope's
     # receipt): goals compare against this, not the row's insert time (G7).

--- a/app/crm/record/catalog.py
+++ b/app/crm/record/catalog.py
@@ -30,10 +30,13 @@ from app.crm.record.db import accessor
 from app.crm.record.extractors import SPEC_MODULES
 from app.crm.record.extractors.engine import (
     EMPTY_SPEC,
+    LIST_TYPE,
     PAYLOAD_PREFIX,
     DecodeSpec,
     Deriver,
+    format_faults,
     spec_for_entry,
+    variable_name,
 )
 from app.crm.record.schemas import (
     CatalogEntry,
@@ -55,6 +58,11 @@ OPS_BY_TYPE: Dict[str, List[str]] = {
     "boolean": ["is", "is_not", EXISTS_OP],
     "datetime": [*ORDER_OPS, EXISTS_OP],
     "phone": [],
+    # A list is a template variable and nothing else. No ops, so the
+    # where-grammar never receives an array and the matcher never learns
+    # array semantics (design/event-catalog.md, sealed) — a condition on a
+    # list field is refused at publish, naming the empty set.
+    "list": [],
 }
 KEYABLE_TYPES = ("text", "number")
 MAX_REGISTERED_FIELDS = 200
@@ -107,6 +115,19 @@ DERIVE: Dict[Tuple[str, str], Dict[str, Deriver]] = {
 # --- Pure helpers -----------------------------------------------------------
 
 
+def stored_field(field: CatalogField) -> Dict[str, Any]:
+    """PURE: one field as the T24 row carries it. `ops` are computed on read
+    and `fallbacks`/`derived` are code-layer words, so none is written.
+    `item_format` rides only on a field that HAS one, so every type canon
+    already describes is stored exactly as it was before the list type
+    existed — the field list is extended for the new type, not for every
+    row."""
+    doc = field.model_dump(exclude=_CODE_ONLY_KEYS)
+    if doc.get("item_format") is None:
+        doc.pop("item_format", None)
+    return doc
+
+
 def with_ops(field: CatalogField) -> CatalogField:
     """The ops a field admits are a function of its type, never authored."""
     return field.model_copy(update={"ops": list(OPS_BY_TYPE[field.type])})
@@ -155,6 +176,7 @@ def validate_registration(registration: SchemaRegistration) -> List[str]:
         problems.append(f"too many fields ({len(fields)} > {MAX_REGISTERED_FIELDS})")
     seen: Set[str] = set()
     roles: Dict[str, str] = {}
+    blanks: Dict[str, str] = {}
     for field in fields:
         if field.derived:
             problems.append(f"{field.path}: derived fields are code-layer only")
@@ -172,6 +194,42 @@ def validate_registration(registration: SchemaRegistration) -> List[str]:
         if field.path in seen:
             problems.append(f"{field.path}: declared twice")
         seen.add(field.path)
+        if field.item_format is not None:
+            if field.type != LIST_TYPE:
+                problems.append(f"{field.path}: item_format belongs to type list")
+            else:
+                problems.extend(
+                    f"{field.path}: {p}" for p in format_faults(field.item_format)
+                )
+        if field.type == LIST_TYPE:
+            # No ops and never a handle, so a list that is not a variable can
+            # be neither filtered, keyed nor templated — a field nothing can
+            # read is a mistake, not a declaration. (keyable is refused below:
+            # KEYABLE_TYPES is text | number.)
+            if not field.variable:
+                problems.append(
+                    f"{field.path}: type list is a template variable or nothing "
+                    "(set variable: true)"
+                )
+            if field.identity is not None:
+                problems.append(f"{field.path}: a list cannot be an identity field")
+        if field.variable and not field.deprecated:
+            blank = variable_name(field.path)
+            if blank in blanks:
+                problems.append(
+                    f"{field.path}: fills {{{blank}}}, already filled by "
+                    f"{blanks[blank]} — a blank is the path's last segment, so "
+                    "two variables ending in the same word collide (rename one, "
+                    "or drop variable)"
+                )
+            else:
+                blanks[blank] = field.path
+        if field.type == "boolean" and field.variable:
+            problems.append(
+                f"{field.path}: a yes/no is a filter, never a blank — "
+                '"true" in a customer\'s message is corruption that looks '
+                "delivered (drop variable, or declare it type choice)"
+            )
         if field.type == "choice" and not field.values:
             problems.append(f"{field.path}: choice needs its values")
         if field.type != "choice" and field.values:
@@ -344,9 +402,7 @@ async def register_schema(
         registration.source,
         registration.topic,
         registration.label,
-        json.dumps(
-            [f.model_dump(exclude=_CODE_ONLY_KEYS) for f in registration.fields]
-        ),
+        json.dumps([stored_field(f) for f in registration.fields]),
         registered_by,
     )
     _SPEC_CACHE.pop((merchant_id, registration.source, registration.topic), None)

--- a/app/crm/record/extractors/engine.py
+++ b/app/crm/record/extractors/engine.py
@@ -24,6 +24,7 @@ thinks about registration. Path resolution lives here too — catalog.py and
 outreach's entry evaluator resolve fields through these same helpers.
 """
 
+import re
 from dataclasses import dataclass, field
 from typing import Any, Callable, Dict, List, Literal, Optional
 
@@ -43,6 +44,19 @@ _NORMALIZE: Dict[str, Callable[[str], Optional[str]]] = {
     "email": normalize_email,
 }
 _SCALARS = (str, int, float, bool)
+# The declared type whose value is an ARRAY. It is a template variable and
+# nothing else: OPS_BY_TYPE gives it no ops, so the where-grammar never
+# receives a list and the matcher never learns array semantics
+# (design/event-catalog.md, sealed). The engine turns it into ONE scalar at
+# decode, because that is what a template blank and a lead payload can carry.
+LIST_TYPE = "list"
+LIST_JOIN = ", "
+# One blank inside an item_format — an element's own key, dot-walked.
+ITEM_BLANK = re.compile(r"\{([A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*)*)\}")
+# Any brace group at all: what the validator measures a format against, so a
+# misspelled blank is refused at registration instead of reaching a customer
+# as the literal "{na-me}".
+ANY_BLANK = re.compile(r"\{[^{}]*\}")
 
 
 @dataclass(frozen=True)
@@ -54,6 +68,10 @@ class DecodeSpec:
     identity: Dict[str, List[str]] = field(default_factory=dict)
     # template placeholder -> path (a bare name is a derived field)
     variables: Dict[str, str] = field(default_factory=dict)
+    # placeholder -> how one element reads, for the variables whose declared
+    # type is `list` (None = the path already named one field). A name here
+    # is ALSO in `variables`: one loop reads both.
+    lists: Dict[str, Optional[str]] = field(default_factory=dict)
     derive: Dict[str, Deriver] = field(default_factory=dict)
     # who the letter is about — the entry's word, passed through to
     # Extracted.about so the pass knows a NULL customer is by design
@@ -61,6 +79,161 @@ class DecodeSpec:
 
 
 EMPTY_SPEC = DecodeSpec()
+
+
+def dig(node: Any, path: str) -> Any:
+    """PURE: walk dots from here (a missing step -> None, never a raise).
+    The ONE dot-walker: field_value walks a payload with it and the list
+    reader walks each element with it, so `customer.phone` and an item's
+    `variant.title` can never mean two different things."""
+    for step in path.split("."):
+        if not isinstance(node, dict):
+            return None
+        node = node.get(step)
+    return node
+
+
+def list_values(payload: Dict[str, Any], path: str) -> Optional[List[Any]]:
+    """PURE: what a declared `list` field addresses. Its path walks THROUGH
+    every array it crosses, and what it finds is flattened:
+
+        payload.tags                            the tags themselves
+        payload.line_items                      every line, whole
+        payload.line_items.title                the title of every line
+        payload.loanApplications.offers         every offer of every
+                                                application
+        payload.loanApplications.offers.rate    …and one field of each
+
+    Nesting is not a special case, it is the same step again: real letters
+    put a list inside a list (an order's applications, their offers), and a
+    path that stopped at the first array could name the application but
+    never the offer.
+
+    Flattening is the honest answer for a template blank, which is ONE
+    string: "every offer" reads as a sentence, and which application each
+    came from is a distinction a blank cannot carry anyway. A plan that
+    needs that distinction wants the application's own field beside it.
+
+    None when nothing on the path is a list — the caller then writes no
+    variable at all, rather than a half-answer."""
+    if not path.startswith(PAYLOAD_PREFIX):
+        return None
+    found = _walk(payload, path[len(PAYLOAD_PREFIX) :].split("."))
+    return found if isinstance(found, list) else None
+
+
+def _walk(node: Any, steps: List[str]) -> Any:
+    """PURE: the value at these steps, with every array crossed on the way
+    mapped over and flattened into one list. A missing step is None, never
+    a raise — a letter is not obliged to carry what a plan hopes for."""
+    for index, step in enumerate(steps):
+        if isinstance(node, list):
+            found: List[Any] = []
+            for element in node:
+                below = _walk(element, steps[index:])
+                if isinstance(below, list):
+                    found.extend(below)
+                else:
+                    found.append(below)
+            return found
+        if not isinstance(node, dict):
+            return None
+        node = node.get(step)
+    return node
+
+
+def render_item(element: Any, item_format: str) -> Optional[str]:
+    """PURE: one element through its declared format — "{title} x{quantity}"
+    over {"title": "Socks", "quantity": 2} is "Socks x2".
+
+    Every blank must answer, or the element is SKIPPED WHOLE. A line reading
+    " x2" because the title was missing is the half-formed value a provider
+    renders as corruption; better to name three items than four badly."""
+    missing = False
+
+    def one(match: "re.Match[str]") -> str:
+        nonlocal missing
+        found = dig(element, match.group(1))
+        if isinstance(found, bool) or not isinstance(found, (str, int, float)):
+            missing = True
+            return ""
+        text = str(found).strip()
+        if not text:
+            missing = True
+        return text
+
+    rendered = ITEM_BLANK.sub(one, item_format).strip()
+    return None if missing or not rendered else rendered
+
+
+def join_list(
+    values: Optional[List[Any]],
+    item_format: Optional[str] = None,
+    budget: int = VARIABLE_MAX_CHARS,
+) -> Optional[str]:
+    """PURE: the array as ONE scalar a template blank can carry.
+
+    With a format each element is rendered through it; without one the
+    values are already what the path named. Anything unrenderable is
+    skipped, never printed as an object.
+
+    Truncated HERE, with the overflow COUNTED — a list that came out over
+    the ceiling would be dropped by the scalar gate below, and the send
+    would then park on a blank whose cause is two modules away."""
+    if not values:
+        return None
+    parts: List[str] = []
+    for value in values:
+        text = (
+            render_item(value, item_format)
+            if item_format
+            else (
+                None
+                if isinstance(value, bool) or not isinstance(value, (str, int, float))
+                else str(value).strip() or None
+            )
+        )
+        if text:
+            parts.append(text)
+    return _joined_within(parts, budget) if parts else None
+
+
+def _joined_within(parts: List[str], budget: int) -> str:
+    """PURE: as many parts as fit, then "+N more". Every part is measured,
+    the first one included — guarding that on "we kept something" let one
+    long title through to a slice that cut it mid-word and took the count
+    with it, which is the one thing this promises never to do."""
+    kept: List[str] = []
+    for part in parts:
+        left = len(parts) - len(kept) - 1
+        tail = f" +{left} more" if left else ""
+        if len(LIST_JOIN.join([*kept, part])) + len(tail) > budget:
+            break
+        kept.append(part)
+    text = LIST_JOIN.join(kept)
+    remaining = len(parts) - len(kept)
+    if not remaining:
+        return text[:budget]
+    counted = f"{text} +{remaining} more" if text else f"+{remaining} more"
+    return counted if len(counted) <= budget else text[:budget]
+
+
+def format_faults(item_format: str) -> List[str]:
+    """PURE: where one item_format breaks its laws. Balance FIRST —
+    ANY_BLANK sees only CLOSED groups, so "{title} x{quantity" would look
+    like one well-formed blank and pass, and the engine would leave the
+    literal "{quantity" in a customer's message."""
+    leftover = ANY_BLANK.sub("", item_format)
+    if "{" in leftover or "}" in leftover:
+        return [f"item_format {item_format!r} has an unmatched brace"]
+    blanks = ANY_BLANK.findall(item_format)
+    if not blanks:
+        return [f"item_format {item_format!r} names no key of an element"]
+    return [
+        f"item_format blank {bad!r} is not a key (letters, digits, underscore, dots)"
+        for bad in blanks
+        if not ITEM_BLANK.fullmatch(bad)
+    ]
 
 
 def field_value(
@@ -72,12 +245,7 @@ def field_value(
     dots (a missing step -> None, never a raise); a bare name is a derived
     field when the caller's derive table knows it, else a top-level key."""
     if path.startswith(PAYLOAD_PREFIX):
-        node: Any = payload
-        for step in path[len(PAYLOAD_PREFIX) :].split("."):
-            if not isinstance(node, dict):
-                return None
-            node = node.get(step)
-        return node
+        return dig(payload, path[len(PAYLOAD_PREFIX) :])
     if derive and path in derive:
         try:
             return derive[path](payload)
@@ -101,15 +269,25 @@ def spec_for_entry(entry: CatalogEntry, derive: Dict[str, Deriver]) -> DecodeSpe
     decode; a field's fallbacks follow its own path in order."""
     identity: Dict[str, List[str]] = {}
     variables: Dict[str, str] = {}
+    lists: Dict[str, Optional[str]] = {}
     for f in entry.fields:
         if f.deprecated:
             continue
         if f.identity:
             identity.setdefault(f.identity, []).extend([f.path, *f.fallbacks])
         if f.variable:
-            variables[variable_name(f.path)] = f.path
+            name = variable_name(f.path)
+            variables[name] = f.path
+            if f.type == LIST_TYPE:
+                lists[name] = f.item_format
+            else:
+                lists.pop(name, None)
     return DecodeSpec(
-        identity=identity, variables=variables, derive=dict(derive), about=entry.about
+        identity=identity,
+        variables=variables,
+        lists=lists,
+        derive=dict(derive),
+        about=entry.about,
     )
 
 
@@ -138,6 +316,11 @@ def extract(payload: Dict[str, Any], spec: DecodeSpec) -> Extracted:
 
     variables: Dict[str, Any] = {}
     for name, path in spec.variables.items():
+        if name in spec.lists:
+            joined = join_list(list_values(payload, path), spec.lists[name])
+            if joined:
+                variables[name] = joined
+            continue
         value = field_value(payload, path, spec.derive)
         if isinstance(value, _SCALARS) and len(str(value)) <= VARIABLE_MAX_CHARS:
             variables[name] = value

--- a/app/crm/record/extractors/shopify.py
+++ b/app/crm/record/extractors/shopify.py
@@ -22,8 +22,10 @@ assert_facts as a genuine claim and overwrite what we actually know.
 Fixtures under tests/crm/fixtures/shopify/ pin every path and fallback.
 """
 
-from typing import Any, Dict, List, Optional
+from decimal import ROUND_HALF_UP, Decimal, InvalidOperation
+from typing import Any, Dict, List, Optional, Tuple
 
+from app.crm.record.extractors.engine import Deriver, join_list
 from app.crm.record.schemas import CatalogEntry, CatalogField
 
 SOURCE = "shopify"
@@ -41,6 +43,23 @@ PHONE_PATHS = [
 ]
 EMAIL_PATHS = ["payload.customer.email", "payload.email"]
 _NAME_HOMES = ("customer", "billing_address", "shipping_address")
+_ADDRESS_PARTS = ("address1", "address2", "city", "province", "zip")
+# Shopify sends NULL for an order nobody has shipped yet — "unfulfilled"
+# is a line-item word and a GraphQL enum, never the order field. A null is
+# the one value the where-grammar cannot ask about: `is`, `is_not`, `in`
+# and even `exists` all answer False for a missing field, by law
+# (shared/predicate: a stale filter must never quietly widen). So "not yet
+# fulfilled" — the commonest thing an author wants to say — is
+# inexpressible against the raw field, three different ways.
+#
+# The derived field below says it instead: null becomes "unfulfilled", and
+# the vocabulary is then honest about being OURS rather than Shopify's.
+FULFILLMENT_STATES = ["unfulfilled", "partial", "fulfilled", "restocked"]
+LINE_ITEM_FORMATS: Dict[str, Tuple[str, str]] = {
+    "items": ("Items", "{title}"),
+    "items_qty": ("Items with quantity", "{title} x{quantity}"),
+    "items_priced": ("Items with unit price", "{title} = {unit_price} x{quantity}"),
+}
 
 FINANCIAL_STATUSES = [
     "pending",
@@ -88,6 +107,133 @@ def items_count(payload: Dict[str, Any]) -> Optional[int]:
     return len(items) if isinstance(items, list) else None
 
 
+def line_total(line: Dict[str, Any]) -> Optional[str]:
+    """PURE: price x quantity, spelled the way Shopify spells money.
+
+    None when either half is missing or not a number — a line whose total
+    cannot be computed is dropped by the renderer rather than shown with a
+    hole in it. Decimal, never float: a bill is not a place to discover
+    binary rounding."""
+    try:
+        amount = Decimal(str(line["price"])) * Decimal(str(line["quantity"]))
+        # NaN and the infinities are Decimals too, and they survive the
+        # multiply: "nan" would render as "=₹NaN" in a customer's message,
+        # and an overflow raises out of quantize. Both are the same answer —
+        # this line has no total, so the renderer drops it — and quantize
+        # sits INSIDE the try so the raise cannot escape into field_value's
+        # blanket except, where one odd line would delete the whole cart.
+        if not amount.is_finite():
+            return None
+        return f"{amount.quantize(Decimal('0.01'), rounding=ROUND_HALF_UP):f}"
+    except (KeyError, TypeError, ArithmeticError, InvalidOperation):
+        return None
+
+
+def order_currency(payload: Dict[str, Any]) -> str:
+    """PURE: the ISO code the line PRICES are spelled in, "" when the letter
+    says nothing.
+
+    The shop's own `currency` is preferred, and the order is the whole
+    point. On a multi-currency store REST still spells `line_items[].price`
+    and `total_price` in the SHOP's currency; what the shopper was actually
+    charged lives under `*_set.presentment_money`, which nothing here reads.
+    So labelling `price` with `presentment_currency` would put a USD code on
+    an INR number in a customer's message — the exact failure this function
+    exists to prevent, and the reason not to "improve" the order below.
+
+    `presentment_currency` is read ONLY when the letter carries no
+    `currency` at all: there, a plausible code beats none."""
+    for key in ("currency", "presentment_currency"):
+        value = payload.get(key)
+        if value:
+            return str(value).strip().upper()
+    return ""
+
+
+def money(amount: Optional[str], currency: str) -> Optional[str]:
+    """PURE: an amount with its currency, or the bare amount when the letter
+    named no currency — never None for want of a currency alone. A missing
+    AMOUNT is still None: that is the line having no price, which is a
+    different fact from the store having no ISO code."""
+    if amount is None:
+        return None
+    return f"{amount} {currency}" if currency else amount
+
+
+def _priced(line: Any, currency: str) -> Any:
+    """One line with `unit_price` and `line_total` beside its own keys, so an
+    item_format may name them exactly like a key the producer sent.
+
+    `unit_price` rather than overwriting `price`: `price` is the producer's
+    own word for a bare number, and a format that says `{price}` — a
+    vendor's registered row included — must keep getting one."""
+    if not isinstance(line, dict):
+        return line
+    raw = line.get("price")
+    extra: Dict[str, Any] = {}
+    unit = money(str(raw) if raw is not None else None, currency)
+    if unit is not None:
+        extra["unit_price"] = unit
+    total = money(line_total(line), currency)
+    if total is not None:
+        extra["line_total"] = total
+    return {**line, **extra} if extra else line
+
+
+def fulfillment_state(payload: Dict[str, Any]) -> Optional[str]:
+    """Shopify's fulfillment_status, with its null spelled out.
+
+    An order nobody has shipped carries null, and a null satisfies no
+    operator — so a plan could not ask for one. Here it is "unfulfilled",
+    which is what the merchant calls it and what the console offers."""
+    state = payload.get("fulfillment_status")
+    return str(state) if state else "unfulfilled"
+
+
+def _line_items_as(item_format: str) -> Deriver:
+    """One deriver per declared phrasing: every line of the cart through the
+    format, joined and truncated by the engine — the same renderer a vendor
+    row gets from its `item_format`, so the two layers cannot phrase a cart
+    differently."""
+
+    def derive(payload: Dict[str, Any]) -> Optional[str]:
+        lines = payload.get("line_items")
+        if not isinstance(lines, list):
+            return None
+        currency = order_currency(payload)
+        return join_list([_priced(line, currency) for line in lines], item_format)
+
+    return derive
+
+
+def shipping_address(payload: Dict[str, Any]) -> Optional[str]:
+    """Where the order is going, as ONE comma-separated line.
+
+    A blank per part would be six blanks a template author has to place in
+    the right order, in a message that says the address once — and any of
+    them may be absent (``address2`` usually is), which reads as a hole or a
+    doubled comma. One field, assembled here, where the ABSENCE is handled:
+    a missing part is dropped, never rendered empty.
+
+    None when the letter carries no shipping address at all (a digital order,
+    an early checkout frame) — a send that maps it then simply has nothing to
+    say, rather than saying ", , ".
+    """
+    home = payload.get("shipping_address")
+    if not isinstance(home, dict):
+        return None
+    name = home.get("name") or " ".join(
+        str(home[half]).strip()
+        for half in ("first_name", "last_name")
+        if home.get(half)
+    )
+    parts = [
+        str(name).strip(),
+        *(str(home.get(k) or "").strip() for k in _ADDRESS_PARTS),
+    ]
+    return ", ".join(part for part in parts if part) or None
+
+
 def first_item_name(payload: Dict[str, Any]) -> Optional[str]:
     items = payload.get("line_items")
     if isinstance(items, list) and items and isinstance(items[0], dict):
@@ -96,10 +242,13 @@ def first_item_name(payload: Dict[str, Any]) -> Optional[str]:
     return None
 
 
-DERIVERS = {
+DERIVERS: Dict[str, Deriver] = {
     "customer_name": customer_name,
+    "fulfillment_state": fulfillment_state,
     "items_count": items_count,
     "first_item_name": first_item_name,
+    "shipping_address": shipping_address,
+    **{name: _line_items_as(fmt) for name, (_, fmt) in LINE_ITEM_FORMATS.items()},
 }
 
 
@@ -152,8 +301,17 @@ def _money_fields() -> List[CatalogField]:
     return [
         _f("payload.total_price", "number", "Order total", variable=True),
         _f("payload.currency", "text", "Currency", variable=True),
-        _f("items_count", "number", "Items", derived=True, variable=True),
+        _f("items_count", "number", "Item count", derived=True, variable=True),
         _f("first_item_name", "text", "First item", derived=True, variable=True),
+        _f("payload.subtotal_price", "number", "Subtotal", variable=True),
+        _f("payload.total_tax", "number", "Tax", variable=True),
+        _f("payload.total_discounts", "number", "Discount", variable=True),
+        # The cart, in every phrasing a message has asked for — one blank
+        # each, so a plan picks the one its template needs.
+        *[
+            _f(name, "text", label, derived=True, variable=True)
+            for name, (label, _) in LINE_ITEM_FORMATS.items()
+        ],
     ]
 
 
@@ -172,6 +330,49 @@ def _order_fields() -> List[CatalogField]:
             values=FINANCIAL_STATUSES,
         ),
         _f("payload.gateway", "text", "Payment method"),
+        # ── what a message or an agent actually says ──────────────────────
+        # Shopify's own hosted status page: no login, no lookup — the one
+        # link an order message is really for.
+        _f("payload.order_status_url", "text", "Track order link", variable=True),
+        _f("payload.confirmation_number", "text", "Confirmation no.", variable=True),
+        _f("payload.email", "text", "Order email", variable=True),
+        _f("payload.note", "text", "Order note", variable=True),
+        _f("payload.tags", "text", "Tags", variable=True),
+        _f("payload.total_outstanding", "number", "Amount due", variable=True),
+        # Where it is going. The parts stay declared beside the whole: a
+        # call confirms the city and never the street, while a shipped-out
+        # message says the address once, in full.
+        _f("shipping_address", "text", "Ship to address", derived=True, variable=True),
+        _f("payload.shipping_address.city", "text", "Ship to city", variable=True),
+        _f("payload.shipping_address.province", "text", "Ship to state", variable=True),
+        _f("payload.shipping_address.zip", "text", "Ship to PIN", variable=True),
+        # How it was paid, in Shopify's own words — a list, because an order
+        # can be split across two methods.
+        _f(
+            "payload.payment_gateway_names",
+            "list",
+            "Payment methods",
+            variable=True,
+        ),
+        # ── what a plan FILTERS on, and never says out loud ───────────────
+        _f(
+            "fulfillment_state",
+            "choice",
+            "Fulfilment status",
+            values=FULFILLMENT_STATES,
+            derived=True,
+        ),
+        _f("payload.checkout_token", "text", "Checkout token", keyable=True),
+        _f("payload.source_name", "text", "Order source"),
+        _f("payload.created_at", "datetime", "Placed at"),
+        _f("payload.processed_at", "datetime", "Processed at"),
+        _f("payload.updated_at", "datetime", "Last updated"),
+        # A yes/no is a filter, never a blank: "true" in a customer's message
+        # is corruption that looks delivered, so none of these is a variable.
+        _f("payload.confirmed", "boolean", "Confirmed"),
+        _f("payload.test", "boolean", "Test order"),
+        _f("payload.taxes_included", "boolean", "Taxes included"),
+        _f("payload.buyer_accepts_marketing", "boolean", "Accepts marketing"),
         *_money_fields(),
         *_person_fields(),
     ]
@@ -203,6 +404,11 @@ def _entry(topic: str, label: str, fields: List[CatalogField]) -> CatalogEntry:
 ENTRIES: List[CatalogEntry] = [
     _entry("orders/create", "Order placed", _order_fields()),
     _entry("orders/paid", "Order paid", _order_fields()),
+    # An EDIT is a fact of its own — a fulfilment, a tag, a note, a refund.
+    # Shopify fires it on every order mutation, so a door on this topic is a
+    # busy one: the relay keys each edit by its own updated_at, or the spine
+    # dedupes every edit after the first into it.
+    _entry("orders/updated", "Order updated", _order_fields()),
     _entry(
         "orders/cancelled",
         "Order cancelled",

--- a/app/crm/record/schemas.py
+++ b/app/crm/record/schemas.py
@@ -126,7 +126,7 @@ class EventReceipt(BaseModel):
 # The closed type set a registration may use — each maps one-to-one onto the
 # where-grammar's operators (record/catalog.py OPS_BY_TYPE). Unknown types
 # are rejected at registration, never discovered at flow-publish.
-FieldType = Literal["text", "number", "choice", "boolean", "datetime", "phone"]
+FieldType = Literal["text", "number", "choice", "boolean", "datetime", "phone", "list"]
 IdentityRole = Literal["phone", "name", "email", "shopify_customer_id"]
 
 
@@ -149,6 +149,7 @@ class CatalogField(BaseModel):
     # precedence chains in jsonb are the DSL the ruling forbids.
     fallbacks: List[str] = Field(default_factory=list)
     ops: List[str] = Field(default_factory=list)
+    item_format: Optional[str] = Field(None, min_length=1, max_length=160)
 
 
 class CatalogEntry(BaseModel):

--- a/tests/crm/fixtures/shopify/checkouts_create.json
+++ b/tests/crm/fixtures/shopify/checkouts_create.json
@@ -35,5 +35,6 @@
       "sku": "AR-42",
       "variant_title": "42 / White"
     }
-  ]
+  ],
+  "total_discounts": "0.00"
 }

--- a/tests/crm/fixtures/shopify/checkouts_create_returning.json
+++ b/tests/crm/fixtures/shopify/checkouts_create_returning.json
@@ -35,5 +35,6 @@
       "sku": "AR-42",
       "variant_title": "42 / White"
     }
-  ]
+  ],
+  "total_discounts": "0.00"
 }

--- a/tests/crm/fixtures/shopify/checkouts_update.json
+++ b/tests/crm/fixtures/shopify/checkouts_update.json
@@ -67,5 +67,6 @@
       "sku": "SK-3",
       "variant_title": null
     }
-  ]
+  ],
+  "total_discounts": "0.00"
 }

--- a/tests/crm/fixtures/shopify/orders_cancelled.json
+++ b/tests/crm/fixtures/shopify/orders_cancelled.json
@@ -27,7 +27,7 @@
   "buyer_accepts_marketing": false,
   "taxes_included": true,
   "source_name": "web",
-  "tags": "",
+  "tags": "cod, cancelled",
   "customer": {
     "id": 7011200034,
     "email": "priya.sharma@example.com",
@@ -85,5 +85,9 @@
     }
   ],
   "cancelled_at": "2026-09-02T11:02:40+05:30",
-  "cancel_reason": "customer"
+  "cancel_reason": "customer",
+  "confirmation_number": "ZAQXSWCDE",
+  "note": "Customer changed their mind",
+  "total_outstanding": "0.00",
+  "order_status_url": "https://urban-thread.myshopify.com/61234567890/orders/ord-tok-1/authenticate?key=8f2c1a"
 }

--- a/tests/crm/fixtures/shopify/orders_create.json
+++ b/tests/crm/fixtures/shopify/orders_create.json
@@ -27,7 +27,7 @@
   "buyer_accepts_marketing": false,
   "taxes_included": true,
   "source_name": "web",
-  "tags": "",
+  "tags": "cod, first-order",
   "customer": {
     "id": 7011200034,
     "email": "priya.sharma@example.com",
@@ -83,5 +83,9 @@
       "sku": "SK-3",
       "variant_title": null
     }
-  ]
+  ],
+  "confirmation_number": "UFEACMFQN",
+  "note": "Ring the bell twice",
+  "total_outstanding": "3097.00",
+  "order_status_url": "https://urban-thread.myshopify.com/61234567890/orders/ord-tok-1/authenticate?key=8f2c1a"
 }

--- a/tests/crm/fixtures/shopify/orders_create_guest.json
+++ b/tests/crm/fixtures/shopify/orders_create_guest.json
@@ -27,7 +27,7 @@
   "buyer_accepts_marketing": false,
   "taxes_included": true,
   "source_name": "web",
-  "tags": "",
+  "tags": "cod, guest",
   "billing_address": {
     "first_name": "Rohan",
     "last_name": "Mehta",
@@ -65,5 +65,9 @@
       "sku": "SK-3",
       "variant_title": null
     }
-  ]
+  ],
+  "confirmation_number": "KQWERTZUI",
+  "note": "Leave with the guard",
+  "total_outstanding": "3097.00",
+  "order_status_url": "https://urban-thread.myshopify.com/61234567890/orders/ord-tok-2/authenticate?key=8f2c1a"
 }

--- a/tests/crm/fixtures/shopify/orders_create_signed_in.json
+++ b/tests/crm/fixtures/shopify/orders_create_signed_in.json
@@ -27,7 +27,7 @@
   "buyer_accepts_marketing": false,
   "taxes_included": true,
   "source_name": "web",
-  "tags": "",
+  "tags": "cod, returning",
   "customer": {
     "id": 7011200034,
     "email": "priya.sharma@example.com",
@@ -83,5 +83,9 @@
       "sku": "SK-3",
       "variant_title": null
     }
-  ]
+  ],
+  "confirmation_number": "MNBVCXZAS",
+  "note": "Call before delivery",
+  "total_outstanding": "3097.00",
+  "order_status_url": "https://urban-thread.myshopify.com/61234567890/orders/ord-tok-3/authenticate?key=8f2c1a"
 }

--- a/tests/crm/fixtures/shopify/orders_updated.json
+++ b/tests/crm/fixtures/shopify/orders_updated.json
@@ -1,21 +1,21 @@
 {
-  "id": 5201000001,
+  "id": 5201000003,
   "admin_graphql_api_id": "gid://shopify/Order/5201000001",
-  "name": "#1001",
-  "order_number": 1001,
+  "name": "#1003",
+  "order_number": 1003,
   "email": "priya.sharma@example.com",
-  "phone": null,
-  "cart_token": "c1-3f9a2b8e7d6c5b4a",
+  "phone": "+919876543210",
+  "cart_token": "c1-signed-22bb",
   "checkout_token": "ck-77aa",
-  "token": "ord-tok-1",
+  "token": "ord-tok-3",
   "created_at": "2026-09-02T10:14:07+05:30",
-  "updated_at": "2026-09-02T10:20:00+05:30",
+  "updated_at": "2026-09-02T13:41:22+05:30",
   "processed_at": "2026-09-02T10:14:07+05:30",
-  "financial_status": "paid",
-  "fulfillment_status": null,
-  "gateway": "razorpay",
+  "financial_status": "pending",
+  "fulfillment_status": "fulfilled",
+  "gateway": "Cash on Delivery (COD)",
   "payment_gateway_names": [
-    "razorpay"
+    "Cash on Delivery (COD)"
   ],
   "currency": "INR",
   "subtotal_price": "3097.00",
@@ -27,7 +27,7 @@
   "buyer_accepts_marketing": false,
   "taxes_included": true,
   "source_name": "web",
-  "tags": "prepaid",
+  "tags": "cod, returning, dispatched",
   "customer": {
     "id": 7011200034,
     "email": "priya.sharma@example.com",
@@ -43,7 +43,7 @@
       "province": "Karnataka",
       "country_code": "IN",
       "zip": "560001",
-      "phone": "+91 98765 43210"
+      "phone": null
     }
   },
   "billing_address": {
@@ -84,8 +84,8 @@
       "variant_title": null
     }
   ],
-  "confirmation_number": "PLMOKNIJB",
-  "note": "Gift wrap",
-  "total_outstanding": "0.00",
-  "order_status_url": "https://urban-thread.myshopify.com/61234567890/orders/ord-tok-1/authenticate?key=8f2c1a"
+  "confirmation_number": "MNBVCXZAS",
+  "note": "Call before delivery — dispatched via BlueDart",
+  "total_outstanding": "3097.00",
+  "order_status_url": "https://urban-thread.myshopify.com/61234567890/orders/ord-tok-3/authenticate?key=8f2c1a"
 }

--- a/tests/crm/test_catalog.py
+++ b/tests/crm/test_catalog.py
@@ -18,6 +18,7 @@ from typing import Any, Dict, List, Optional, get_args
 
 import pytest
 
+from app.crm.outreach.catalog_laws import condition_against_catalog
 from app.crm.record import catalog
 from app.crm.record.extractors import engine
 from app.crm.record.schemas import (
@@ -119,6 +120,7 @@ def test_ops_come_from_type_and_phone_is_never_filterable() -> None:
         "boolean",
         "datetime",
         "phone",
+        "list",
     }
 
 
@@ -250,6 +252,58 @@ def test_registration_accepts_the_nammayatri_shape() -> None:
             {"path": "payload.x", "type": "text", "label": "x", "identity": "email"},
             "identity role must be one of phone | name",
         ),
+        # A list is a template variable and nothing else.
+        (
+            {"path": "payload.x", "type": "list", "label": "x"},
+            "type list is a template variable or nothing",
+        ),
+        (
+            {
+                "path": "payload.x",
+                "type": "list",
+                "label": "x",
+                "variable": True,
+                "identity": "name",
+            },
+            "a list cannot be an identity field",
+        ),
+        # item_format is the list's own word, and every blank in it must be a
+        # key — the engine leaves an unmatched group in place, and a customer
+        # would read the literal "{na-me}".
+        (
+            {"path": "payload.x", "type": "text", "label": "x", "item_format": "{a}"},
+            "item_format belongs to type list",
+        ),
+        (
+            {
+                "path": "payload.x",
+                "type": "list",
+                "label": "x",
+                "variable": True,
+                "item_format": "{title} x{quantity",
+            },
+            "unmatched brace",
+        ),
+        (
+            {
+                "path": "payload.x",
+                "type": "list",
+                "label": "x",
+                "variable": True,
+                "item_format": "{na-me}",
+            },
+            "is not a key",
+        ),
+        (
+            {
+                "path": "payload.x",
+                "type": "list",
+                "label": "x",
+                "variable": True,
+                "item_format": "just words",
+            },
+            "names no key",
+        ),
     ],
 )
 def test_registration_refuses_each_law_break(
@@ -257,6 +311,108 @@ def test_registration_refuses_each_law_break(
 ) -> None:
     problems = catalog.validate_registration(_reg([field]))
     assert any(fragment in p for p in problems), problems
+
+
+def test_two_variable_fields_may_not_fill_one_blank() -> None:
+    """The registered layer's half of test_variable_names_are_unique_within
+    _an_entry. A blank is the path's LAST SEGMENT, so payload.items.name and
+    payload.customer.name are both {name}: spec_for_entry writes one key,
+    the later declaration wins, and the earlier field vanishes from every
+    template that named it — silently, and in an order the vendor never
+    sees. Refused where it is still a typo."""
+    problems = catalog.validate_registration(
+        _reg(
+            [
+                {
+                    "path": "payload.items.name",
+                    "type": "text",
+                    "label": "Item",
+                    "variable": True,
+                },
+                {
+                    "path": "payload.customer.name",
+                    "type": "text",
+                    "label": "Customer",
+                    "variable": True,
+                },
+            ]
+        )
+    )
+    assert any("already filled by payload.items.name" in p for p in problems), problems
+
+    # Not a variable, not a blank: the same last segment is fine when only
+    # one of the two is templated on.
+    filter_only = catalog.validate_registration(
+        _reg(
+            [
+                {
+                    "path": "payload.items.name",
+                    "type": "text",
+                    "label": "Item",
+                    "variable": True,
+                },
+                {"path": "payload.customer.name", "type": "text", "label": "Customer"},
+            ]
+        )
+    )
+    assert filter_only == [], filter_only
+
+
+def test_a_deprecated_predecessor_may_share_its_successors_blank() -> None:
+    """The exemption the two laws need to coexist. dropped_paths FORCES a
+    renamed path to stay in the registration as deprecated (a field is
+    deprecated, never deleted), and decode already skips deprecated fields —
+    so refusing the old path its successor's blank would make
+    additive-or-deprecate and the collision law unsatisfiable together."""
+    problems = catalog.validate_registration(
+        _reg(
+            [
+                {
+                    "path": "payload.buyer.name",
+                    "type": "text",
+                    "label": "Buyer (old)",
+                    "variable": True,
+                    "deprecated": True,
+                },
+                {
+                    "path": "payload.customer.name",
+                    "type": "text",
+                    "label": "Customer",
+                    "variable": True,
+                },
+            ]
+        )
+    )
+    assert problems == [], problems
+
+
+def test_a_registered_yes_no_may_not_be_a_variable() -> None:
+    """ "A yes/no is a filter, never a blank" is a law, not a house style.
+    A boolean extracts as a Python True and send_variables refuses a bool at
+    fire time, so the first run that maps it PARKS — hours later, naming a
+    variable rather than this row. The code layer keeps the rule by hand;
+    the vendor layer gets it enforced."""
+    problems = catalog.validate_registration(
+        _reg(
+            [
+                {
+                    "path": "payload.cod",
+                    "type": "boolean",
+                    "label": "COD",
+                    "variable": True,
+                }
+            ]
+        )
+    )
+    assert any("a yes/no is a filter, never a blank" in p for p in problems), problems
+
+    # As a filter it is exactly what booleans are for.
+    assert (
+        catalog.validate_registration(
+            _reg([{"path": "payload.cod", "type": "boolean", "label": "COD"}])
+        )
+        == []
+    )
 
 
 def test_a_registration_may_not_shadow_a_code_entry() -> None:
@@ -503,3 +659,63 @@ def test_the_etag_is_computed_before_the_counts_query(
     assert catalog.etag_for(entries) == catalog.etag_for(filled)
     by_key = {(e.source, e.topic): e.seen_7d for e in filled}
     assert by_key[("shopify", "orders/create")] == 3
+
+
+def test_a_registration_may_declare_a_formatted_list() -> None:
+    """The registered layer's door to an array — a T24 row carries no
+    derive(), so the format IS how a vendor shapes a cart."""
+    assert (
+        catalog.validate_registration(
+            _reg(
+                [
+                    {
+                        "path": "payload.items",
+                        "type": "list",
+                        "label": "Items",
+                        "variable": True,
+                        "item_format": "{name} x{qty}",
+                    },
+                    {
+                        "path": "payload.tags",
+                        "type": "list",
+                        "label": "Tags",
+                        "variable": True,
+                    },
+                ]
+            )
+        )
+        == []
+    )
+
+
+def test_a_list_field_is_never_filterable() -> None:
+    """No ops, exactly like phone: the where-grammar never receives an array,
+    so the matcher never learns array semantics (event-catalog.md, sealed)."""
+    assert catalog.OPS_BY_TYPE["list"] == []
+    field = catalog.with_ops(
+        CatalogField(path="payload.items", type="list", label="Items", variable=True)
+    )
+    assert field.ops == []
+    # …and the refusal itself, through the function that does it
+    for op, value in (("is", "x"), ("in", ["x"]), ("exists", None), (">", 1)):
+        problems = condition_against_catalog(
+            Condition(field="payload.items", op=op, value=value),
+            {"payload.items": field},
+        )
+        assert problems and "allowed: none" in problems[0], (op, problems)
+
+
+def test_the_stored_row_keeps_item_format_only_where_it_means_something() -> None:
+    """canon's field list is extended for the new type, not for every row."""
+    plain = catalog.stored_field(CatalogField(path="payload.a", type="text", label="A"))
+    assert "item_format" not in plain
+    listed = catalog.stored_field(
+        CatalogField(
+            path="payload.b",
+            type="list",
+            label="B",
+            variable=True,
+            item_format="{n}",
+        )
+    )
+    assert listed["item_format"] == "{n}"

--- a/tests/crm/test_context_ceiling.py
+++ b/tests/crm/test_context_ceiling.py
@@ -1,0 +1,89 @@
+"""The run-context ceiling and the engine's join budget are ONE dial in two
+files, and neither file may import the other (app/core sits under app/crm).
+This is where that inequality is executable.
+
+The pair matters because join_list truncates a joined list TO the engine's
+budget precisely so the scalar gate cannot drop it whole — "the send would
+then park on a blank whose cause is two modules away". A ceiling below the
+budget re-opens exactly that failure, silently, for every full-length cart.
+"""
+
+import pytest
+
+from app.core.config import dynamic
+from app.crm.record.extractors import engine
+
+
+@pytest.fixture(autouse=True)
+def _cold_cache():
+    """Each case starts with no process-local copy, and leaves none behind —
+    the cache is a module global and would otherwise leak across tests."""
+    dynamic._context_value_cache = None
+    yield
+    dynamic._context_value_cache = None
+
+
+def _stored(monkeypatch, value, calls=None):
+    async def fake_get_config(key, default_value, return_type=str):
+        assert key == "CRM_CONTEXT_VALUE_MAX_CHARS"
+        if calls is not None:
+            calls.append(key)
+        return value
+
+    monkeypatch.setattr(dynamic, "get_config", fake_get_config)
+
+
+def test_the_floor_is_the_engine_s_join_budget() -> None:
+    """The pin. app/core imports nothing from app.crm, so the constant is
+    duplicated rather than imported — and duplicated constants drift unless
+    something fails when they do. This is that something."""
+    assert dynamic._CONTEXT_VALUE_FLOOR == engine.VARIABLE_MAX_CHARS
+
+
+@pytest.mark.asyncio
+async def test_an_operator_may_raise_the_ceiling(monkeypatch) -> None:
+    """The whole reason the dial is live: one noisy producer needs more room
+    and should not need a deploy to get it."""
+    _stored(monkeypatch, 1024)
+    assert await dynamic.CRM_CONTEXT_VALUE_MAX_CHARS() == 1024
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("stored", [200, 0, -1])
+async def test_a_ceiling_below_the_join_budget_is_clamped(monkeypatch, stored) -> None:
+    """Lowering it is the one move that breaks the pair. At 200 every
+    full-length joined cart is dropped from context; at 0 every run is born
+    empty. The operator gets the floor and a log line, not the failure."""
+    _stored(monkeypatch, stored)
+    assert await dynamic.CRM_CONTEXT_VALUE_MAX_CHARS() == engine.VARIABLE_MAX_CHARS
+
+
+@pytest.mark.asyncio
+async def test_an_unreadable_value_falls_back_to_the_floor(monkeypatch) -> None:
+    """A dial set to "wide" in Redis must not raise out of the consumer
+    pass: the letter is not at fault for the operator's typo."""
+    _stored(monkeypatch, "wide")
+    assert await dynamic.CRM_CONTEXT_VALUE_MAX_CHARS() == engine.VARIABLE_MAX_CHARS
+
+
+@pytest.mark.asyncio
+async def test_the_ceiling_is_read_once_per_window_not_once_per_letter(
+    monkeypatch,
+) -> None:
+    """This is the spine's per-row path — entry.py reads it for every
+    consumed letter, in both enrol and the wait-event branch. Uncached that
+    is a Redis GET per event on the busiest worker in the system, for a
+    value that changes about once a year."""
+    calls: list = []
+    _stored(monkeypatch, 512, calls)
+
+    for _ in range(50):
+        assert await dynamic.CRM_CONTEXT_VALUE_MAX_CHARS() == 512
+    assert len(calls) == 1, calls
+
+    # The window is what makes it live rather than static: when it lapses,
+    # the next letter sees the operator's new value.
+    dynamic._context_value_cache = None
+    _stored(monkeypatch, 900, calls)
+    assert await dynamic.CRM_CONTEXT_VALUE_MAX_CHARS() == 900
+    assert len(calls) == 2, calls

--- a/tests/crm/test_decode_engine.py
+++ b/tests/crm/test_decode_engine.py
@@ -6,6 +6,8 @@ The Shopify cases carried over from the imperative extractor it replaced:
 same letters, same answers, now read by declared paths.
 """
 
+import json
+from pathlib import Path
 from typing import Any, Dict
 
 from app.crm.record import catalog
@@ -21,6 +23,15 @@ def _shopify(topic: str) -> DecodeSpec:
 
 
 ORDER = _shopify("orders/create")
+
+
+def _fixture(name: str) -> Dict[str, Any]:
+    """One recorded Shopify letter — the fixture IS the payload."""
+    return json.loads(
+        (Path(__file__).parent / "fixtures" / "shopify" / f"{name}.json").read_text()
+    )
+
+
 CHECKOUT = _shopify("checkouts/update")
 
 
@@ -262,3 +273,279 @@ def test_every_catalog_derived_field_is_provided_by_its_spec_module() -> None:
 
 def _spec_dict(spec: DecodeSpec) -> Dict[str, Any]:
     return {"identity": spec.identity, "variables": spec.variables}
+
+
+# --- a declared list becomes one sentence ------------------------------------
+
+
+def _listed(path: str, fmt: Any = None) -> CatalogEntry:
+    return _entry(
+        CatalogField(
+            path=path, type="list", label="Items", variable=True, item_format=fmt
+        )
+    )
+
+
+def test_a_declared_list_is_joined_into_one_scalar() -> None:
+    """The letter keeps every key on the event row; the run carries the
+    sentence a template can actually render."""
+    spec = spec_for_entry(_listed("payload.line_items.title"), {})
+    assert spec.lists == {"title": None}
+    payload = {"line_items": [{"title": "Kurta"}, {"title": "Dupatta"}]}
+    assert engine.extract(payload, spec).variables == {"title": "Kurta, Dupatta"}
+
+
+def test_an_item_format_pairs_the_keys_of_one_line() -> None:
+    """The thing a path alone cannot say: `line_items.title` and
+    `line_items.quantity` are two parallel lists ("Kurta, Cap" beside
+    "1, 2"), never "Kurta x1, Cap x2"."""
+    spec = spec_for_entry(
+        _listed("payload.line_items", "{title} x{quantity} -\u20b9{price}"), {}
+    )
+    payload = {
+        "line_items": [
+            {"title": "Kurta", "quantity": 1, "price": "1199.00", "sku": "K-1"},
+            {"title": "Cap", "quantity": 2, "price": "150.00", "sku": "C-2"},
+        ]
+    }
+    assert engine.extract(payload, spec).variables == {
+        "line_items": "Kurta x1 -\u20b91199.00, Cap x2 -\u20b9150.00"
+    }
+
+
+def test_a_list_of_bare_scalars_needs_no_format() -> None:
+    spec = spec_for_entry(_listed("payload.tags"), {})
+    assert engine.extract({"tags": ["vip", "new"]}, spec).variables == {
+        "tags": "vip, new"
+    }
+
+
+def test_a_line_missing_a_blank_is_skipped_whole() -> None:
+    """Not " x2". A half-formed line is corruption that looks delivered;
+    better to name three items than four badly."""
+    spec = spec_for_entry(_listed("payload.xs", "{title} x{quantity}"), {})
+    payload = {
+        "xs": [{"title": "Kurta"}, {"quantity": 3}, {"title": "Cap", "quantity": 1}]
+    }
+    assert engine.extract(payload, spec).variables == {"xs": "Cap x1"}
+
+
+def test_nothing_renderable_is_no_variable_at_all() -> None:
+    """None, not "" — a template mapping it parks by name, which is honest,
+    where an empty blank sends a message with a hole in it."""
+    spec = spec_for_entry(_listed("payload.xs", "{title}"), {})
+    for payload in ({"xs": []}, {"xs": [{}]}, {"xs": "not a list"}, {}):
+        assert engine.extract(payload, spec).variables == {}
+
+
+def test_a_long_cart_is_truncated_with_the_overflow_counted() -> None:
+    """Truncating at the join is the point: over the ceiling the value would
+    be dropped by the scalar gate and the send would park on a blank whose
+    cause is two modules away."""
+    spec = spec_for_entry(_listed("payload.xs", "{title}"), {})
+    payload = {"xs": [{"title": f"Item number {i}"} for i in range(200)]}
+    rendered = engine.extract(payload, spec).variables["xs"]
+    assert len(rendered) <= engine.VARIABLE_MAX_CHARS
+    assert rendered.startswith("Item number 0, Item number 1, ")
+    assert rendered.endswith(" more")
+    # one oversized line is omitted, and still counted
+    assert engine.join_list(["a" * 300, "b"]) == "+2 more"
+
+
+def test_shopify_offers_every_phrasing_of_the_cart() -> None:
+    """Three declared blanks over one array, so a plan picks the phrasing
+    its template needs — and they are DERIVED rather than three `list` fields
+    on payload.line_items, because a variable is named for its path\'s last
+    segment and three of those would all be called `line_items`."""
+    variables = engine.extract(_fixture("orders_create"), ORDER).variables
+    assert variables["items"] == "Air Runner Sneakers, Ankle Socks (3 pack)"
+    assert variables["items_qty"] == ("Air Runner Sneakers x1, Ankle Socks (3 pack) x2")
+    # The money carries the ORDER's currency, never a hard-coded symbol.
+    assert variables["items_priced"] == (
+        "Air Runner Sneakers = 2499.00 INR x1, Ankle Socks (3 pack) = 299.00 INR x2"
+    )
+    # every phrasing is a distinct blank — the collision this shape avoids
+    assert len({variables[k] for k in ("items", "items_qty", "items_priced")}) == 3
+    assert variables["payment_gateway_names"] == "Cash on Delivery (COD)"
+    assert variables["order_status_url"].startswith("https://")
+    assert variables["city"] == "Bengaluru"
+    # the derived pair stays beside it — live plans template on them
+    assert variables["items_count"] == 2
+    assert variables["first_item_name"] == "Air Runner Sneakers"
+
+
+def test_the_cart_is_priced_in_the_order_s_own_currency() -> None:
+    """The symbol is a fact of the LETTER, not of the format: a hard-coded ₹
+    renders a USD store's cart at the wrong price. Same cart, three stores —
+    the phrasing is identical and only the code moves."""
+    payload = _fixture("orders_create")
+    payload["line_items"] = [{"title": "Kurta", "quantity": 2, "price": "100.00"}]
+
+    payload["currency"] = "USD"
+    assert (
+        engine.extract(payload, ORDER).variables["items_priced"]
+        == "Kurta = 100.00 USD x2"
+    )
+
+    # A multi-currency store sends BOTH, and the shop's code wins: REST
+    # spells line_items[].price in the shop's currency, so labelling it
+    # "USD" would price an INR number in dollars.
+    payload["currency"] = "INR"
+    payload["presentment_currency"] = "USD"
+    assert (
+        engine.extract(payload, ORDER).variables["items_priced"]
+        == "Kurta = 100.00 INR x2"
+    )
+
+    # `presentment_currency` is read only when the shop's own is absent.
+    del payload["currency"]
+    payload["presentment_currency"] = "aed"
+    assert (
+        engine.extract(payload, ORDER).variables["items_priced"]
+        == "Kurta = 100.00 AED x2"
+    )
+
+    # Neither: the bare number. The currency rides in the derived VALUE, not
+    # in a {currency} blank of its own — render_item skips a line WHOLE when
+    # a blank is missing, so a blank would have emptied the cart instead.
+    del payload["presentment_currency"]
+    assert (
+        engine.extract(payload, ORDER).variables["items_priced"] == "Kurta = 100.00 x2"
+    )
+
+
+def test_the_shipping_address_is_one_sentence_with_no_holes_in_it() -> None:
+    """Six parts a template author would otherwise place by hand, in the
+    order a label is read, with the absent ones DROPPED — never ", , "."""
+    assert (
+        engine.extract(_fixture("orders_create"), ORDER).variables["shipping_address"]
+        == "Priya Sharma, 12 MG Road, Bengaluru, Karnataka, 560001"
+    )
+
+    # Shopify's newer shape sends a joined `name` and an explicit null
+    # address2. Both are read, and the null simply does not appear.
+    payload = _fixture("orders_create")
+    payload["shipping_address"] = {
+        "zip": "560095",
+        "city": "Bangalore",
+        "name": "Swaroop Varma",
+        "company": None,
+        "country": "India",
+        "address1": "A32",
+        "address2": None,
+        "latitude": 12.938781,
+        "province": "Karnataka",
+        "last_name": "Varma",
+        "longitude": 77.62067689999999,
+        "first_name": "Swaroop",
+        "country_code": "IN",
+        "province_code": "KA",
+    }
+    assert (
+        engine.extract(payload, ORDER).variables["shipping_address"]
+        == "Swaroop Varma, A32, Bangalore, Karnataka, 560095"
+    )
+
+    # A letter with no address at all says nothing, rather than saying ", ".
+    payload.pop("shipping_address")
+    assert "shipping_address" not in engine.extract(payload, ORDER).variables
+
+
+def test_a_yes_no_is_declared_for_filtering_and_never_as_a_blank() -> None:
+    """send_variables refuses a bool, so a boolean that were a variable
+    would park the run at fire time. No code-layer boolean is one."""
+    for module in SPEC_MODULES:
+        for entry in module.ENTRIES:
+            for f in entry.fields:
+                if f.type == "boolean":
+                    assert not f.variable, f"{entry.topic}: {f.path}"
+
+
+def test_a_line_with_no_price_is_left_out_of_the_sentence() -> None:
+    """The missing-blank law reaching the computed key too: `unit_price` is
+    assembled by the deriver, not sent by Shopify, and a line the format
+    cannot complete is skipped whole rather than rendered half."""
+    entry = _entry(
+        CatalogField(
+            path="line_items", type="text", label="x", derived=True, variable=True
+        )
+    )
+    derive = {
+        "line_items": catalog.derive_for("shopify", "orders/create")["items_priced"]
+    }
+    spec = spec_for_entry(entry, derive)
+    payload = {
+        "line_items": [
+            {"title": "Kurta", "quantity": 2, "price": "100.00"},
+            {"title": "Broken", "quantity": 1},
+        ]
+    }
+    # "Broken" carries no price, so it has no `unit_price` and drops out.
+    # This letter also names no `currency`, so the money degrades to the bare
+    # number — a cart WITHOUT a currency code, never an EMPTY cart.
+    assert engine.extract(payload, spec).variables == {
+        "line_items": "Kurta = 100.00 x2"
+    }
+
+
+def test_a_list_inside_a_list_is_just_another_step() -> None:
+    """Real letters nest: an order's applications, each with its own offers.
+    A path that stopped at the first array could name the application but
+    never the offer, so every array crossed is mapped over and flattened —
+    which is the honest answer for a blank, since a blank is ONE string and
+    cannot carry which application an offer came from anyway."""
+    payload = {
+        "loanApplications": [
+            {
+                "lenderName": "FINNABLE",
+                "offers": [
+                    {
+                        "sanctionedAmount": "9000.00",
+                        "duration": "6",
+                        "emiType": "NO_COST_EMI_WITH_DISCOUNT",
+                    },
+                    {
+                        "sanctionedAmount": "8500.00",
+                        "duration": "9",
+                        "emiType": "STANDARD",
+                    },
+                ],
+            },
+            {
+                "lenderName": "DMI",
+                "offers": [
+                    {
+                        "sanctionedAmount": "7000.00",
+                        "duration": "12",
+                        "emiType": "STANDARD",
+                    }
+                ],
+            },
+        ]
+    }
+
+    def one(path: str, fmt: Any = None) -> Any:
+        entry = _entry(
+            CatalogField(
+                path=path, type="list", label="X", variable=True, item_format=fmt
+            )
+        )
+        return engine.extract(payload, spec_for_entry(entry, {})).variables
+
+    # one level down
+    assert one("payload.loanApplications.lenderName") == {"lenderName": "FINNABLE, DMI"}
+    # two levels down, flattened across both applications
+    assert one("payload.loanApplications.offers.sanctionedAmount") == {
+        "sanctionedAmount": "9000.00, 8500.00, 7000.00"
+    }
+    # …and the nested elements are what an item_format reads
+    assert one(
+        "payload.loanApplications.offers",
+        "{duration} - {emiType} - {sanctionedAmount}",
+    ) == {
+        "offers": (
+            "6 - NO_COST_EMI_WITH_DISCOUNT - 9000.00, "
+            "9 - STANDARD - 8500.00, "
+            "12 - STANDARD - 7000.00"
+        )
+    }

--- a/tests/crm/test_workflow_admission.py
+++ b/tests/crm/test_workflow_admission.py
@@ -104,7 +104,8 @@ def test_context_passthrough_keeps_scalars_drops_structures() -> None:
             "gift_wrap": True,
             "line_items": [{"sku": "WM-1"}],  # nested -> dropped
             "huge": "x" * 500,  # oversized -> dropped
-        }
+        },
+        256,  # the ceiling the caller reads from live config
     )
     assert context["item"] == "washing machine"
     assert context["cart_value"] == 3499

--- a/tests/crm/test_workflow_repeat.py
+++ b/tests/crm/test_workflow_repeat.py
@@ -310,7 +310,8 @@ def test_a_payload_can_never_plant_bookkeeping_keys_in_context() -> None:
             "facts": "junk",  # phase 16: the per-square store is ours
             "current_node": "forged",
             "current_stage": "forged",
-        }
+        },
+        256,
     )
     assert context == {"item": "tv"}
 


### PR DESCRIPTION
- type: "list" in the event catalog — an array becomes one rendered scalar at decode
- item_format shapes each element: {title} x{quantity} =₹{line_total}
- Shopify: 11 → 42 fields, four cart phrasings, new orders/updated topic
- fulfillment_state derives null → "unfulfilled" (a null matches no operator)
- Context ceiling → CRM_CONTEXT_VALUE_MAX_CHARS in live config
- list has zero operators, so the where-grammar never sees an array

As discussed the letter facts approach will be dropped and the lists will be decoded based on event_schema and converted to scalar with support for formats.

Goes with: https://github.com/juspay/nautilus/pull/205

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for list-type catalog fields, including nested extraction, item formatting, joining, and length limits.
  - Expanded Shopify order data with fulfillment status, line-item details, totals, discounts, customer information, payment details, and order metadata.
  - Added support for updated Shopify order events.
  - Made CRM context value limits configurable at runtime.

- **Bug Fixes**
  - Improved handling of missing, invalid, and empty list items during data extraction.
  - Shopify orders with missing fulfillment status now display as unfulfilled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->