### PR TITLE
feat(admin): purge a template together with its chat history

### DIFF
--- a/app/api/routers/breeze_buddy/__init__.py
+++ b/app/api/routers/breeze_buddy/__init__.py
@@ -1,5 +1,7 @@
 from fastapi import APIRouter
 
+from app.api.routers.breeze_buddy.admin import router as admin_router
+
 # Pod health probes (1-pod-1-call isolation architecture)
 from app.api.routers.breeze_buddy.agent_router.health import router as pod_router
 
@@ -163,3 +165,7 @@ router.include_router(widget_config_router, prefix="", tags=["widget-config"])
 # - ui_components: CHAMELEON custom-component registry (migration 070)
 router.include_router(ui_components_router, prefix="", tags=["ui-components"])
 router.include_router(widget_router, prefix="", tags=["widget-session"])
+
+# Admin-only surfaces (/admin/*): template purge today, any future
+# platform-wide read or action — see routers/breeze_buddy/admin/__init__.py
+router.include_router(admin_router, prefix="", tags=["admin"])

--- a/app/api/routers/breeze_buddy/admin/__init__.py
+++ b/app/api/routers/breeze_buddy/admin/__init__.py
@@ -1,0 +1,23 @@
+"""Admin-only surfaces, mounted under ``/admin/*``.
+
+Everything that only a platform admin may call lives in this package, one
+sub-package per surface, and every route in here gates with
+``require_admin``. Cross-tenant reads (fleet inventories, platform health)
+and platform-wide actions belong here, never in a tenant-scoped router.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter
+
+from app.api.routers.breeze_buddy.admin.templates import (
+    router as admin_templates_router,
+)
+
+router = APIRouter()
+
+# Template maintenance that the tenant endpoints cannot do: purge a template
+# together with its chat history.
+router.include_router(admin_templates_router, prefix="", tags=["admin-templates"])
+
+__all__ = ["router"]

--- a/app/api/routers/breeze_buddy/admin/templates/__init__.py
+++ b/app/api/routers/breeze_buddy/admin/templates/__init__.py
@@ -1,0 +1,48 @@
+"""Admin-only template maintenance.
+
+``DELETE /admin/templates/{id}/purge`` — delete a template *and* its chat
+history in one transaction. The tenant ``DELETE /templates/{id}`` cannot
+remove a template that ever served a chat session (``chat_session.template_id``
+is ``ON DELETE RESTRICT``), so orphaned or duplicated agent templates could
+only be deactivated. This is the admin's answer when the transcripts are not
+worth keeping. ``?dry_run=true`` reports what would go without touching
+anything.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, Query
+
+from app.api.routers.breeze_buddy.admin.templates.handlers import (
+    purge_template_handler,
+)
+from app.api.security.breeze_buddy.rbac_token import get_current_user_with_rbac
+from app.core.security.authorization import require_admin
+from app.schemas import UserInfo
+from app.schemas.breeze_buddy.admin.template_purge import TemplatePurgeResponse
+
+router = APIRouter()
+
+
+@router.delete(
+    "/admin/templates/{template_id}/purge", response_model=TemplatePurgeResponse
+)
+async def purge_template(
+    template_id: str,
+    dry_run: bool = Query(
+        default=False,
+        description="Report what the purge would delete without deleting anything.",
+    ),
+    current_user: UserInfo = Depends(get_current_user_with_rbac),
+) -> TemplatePurgeResponse:
+    """Delete a template together with every chat session that used it.
+
+    **RBAC rules:** admin only; a reseller or merchant token gets 403.
+    Refuses with 409 while a widget config, call execution config or
+    in-flight lead still references the template.
+    """
+    require_admin(current_user)
+    return await purge_template_handler(template_id, current_user, dry_run=dry_run)
+
+
+__all__ = ["router"]

--- a/app/api/routers/breeze_buddy/admin/templates/handlers.py
+++ b/app/api/routers/breeze_buddy/admin/templates/handlers.py
@@ -1,0 +1,135 @@
+"""Handler for ``DELETE /admin/templates/{id}/purge``."""
+
+from __future__ import annotations
+
+from fastapi import HTTPException, status
+
+from app.ai.voice.agents.breeze_buddy.template.cache import invalidate_template
+from app.core.logger import logger
+from app.database.accessor.breeze_buddy.admin.template_purge import (
+    fetch_template_purge_blockers,
+    purge_template,
+)
+from app.database.accessor.breeze_buddy.template import get_template_by_id
+from app.schemas import UserInfo
+from app.schemas.breeze_buddy.admin.template_purge import (
+    TemplatePurgeBlockers,
+    TemplatePurgeResponse,
+    TemplatePurgeTemplate,
+)
+
+
+def _blocker_reasons(blockers: TemplatePurgeBlockers) -> list[str]:
+    reasons: list[str] = []
+    if blockers.widget_configs:
+        reasons.append(
+            f"{blockers.widget_configs} widget config(s) still bind this template; "
+            "rebind or delete the widget first"
+        )
+    if blockers.call_configs:
+        reasons.append(
+            f"{blockers.call_configs} call execution config(s) reference this template"
+        )
+    if blockers.inflight_leads:
+        reasons.append(
+            f"{blockers.inflight_leads} in-flight lead(s) (BACKLOG/RETRY/PROCESSING) "
+            "use this template"
+        )
+    return reasons
+
+
+async def purge_template_handler(
+    template_id: str, current_user: UserInfo, *, dry_run: bool
+) -> TemplatePurgeResponse:
+    """Delete a template together with its chat history.
+
+    Refuses (409) while a widget config, a call execution config or an
+    in-flight lead still points at the template; those references are live
+    behaviour, not history. Chat sessions are history and go with the
+    template, which is the whole point of this endpoint over the tenant
+    ``DELETE /templates/{id}``.
+    """
+    existing = await get_template_by_id(template_id)
+    if not existing:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Template not found: {template_id}",
+        )
+
+    try:
+        counts = await fetch_template_purge_blockers(template_id)
+    except Exception as exc:  # pragma: no cover - surfaced as 500
+        logger.error(f"Purge pre-check failed for {template_id}: {exc}", exc_info=True)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Could not inspect the template's references",
+        ) from exc
+
+    blockers = TemplatePurgeBlockers(
+        widget_configs=counts["widget_configs"],
+        call_configs=counts["call_configs"],
+        inflight_leads=counts["inflight_leads"],
+    )
+    reasons = _blocker_reasons(blockers)
+    if reasons:
+        detail = (
+            f"Template '{existing.name}' cannot be purged. "
+            f"Reasons: {'; '.join(reasons)}."
+        )
+        logger.warning(f"Template {template_id} purge blocked: {detail}")
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=detail)
+
+    template = TemplatePurgeTemplate(
+        id=template_id,
+        name=existing.name,
+        reseller_id=existing.reseller_id,
+        merchant_id=existing.merchant_id,
+        is_active=existing.is_active,
+    )
+    if dry_run:
+        return TemplatePurgeResponse(
+            purged=False,
+            template=template,
+            chat_sessions=counts["chat_sessions"],
+            chat_messages=counts["chat_messages"],
+            active_sessions=counts["active_sessions"],
+            blockers=blockers,
+        )
+
+    logger.info(
+        f"Admin {current_user.username} purging template {template_id} "
+        f"('{existing.name}') with {counts['chat_sessions']} chat session(s) / "
+        f"{counts['chat_messages']} message(s)"
+    )
+    try:
+        result = await purge_template(template_id)
+    except Exception as exc:
+        logger.error(f"Template purge failed for {template_id}: {exc}", exc_info=True)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Purge failed and was rolled back: {exc}",
+        ) from exc
+    if result is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Template not found: {template_id}",
+        )
+
+    try:
+        await invalidate_template(template_id)
+    except Exception as cache_exc:  # pragma: no cover - best effort
+        logger.warning(
+            f"Template cache invalidation failed for {template_id}: {cache_exc}"
+        )
+
+    return TemplatePurgeResponse(
+        purged=True,
+        template=template,
+        chat_sessions=result["chat_sessions_deleted"],
+        chat_messages=counts["chat_messages"],
+        active_sessions=counts["active_sessions"],
+        blockers=blockers,
+    )
+
+
+__all__ = ["purge_template_handler"]

--- a/app/database/accessor/breeze_buddy/admin/__init__.py
+++ b/app/database/accessor/breeze_buddy/admin/__init__.py
@@ -1,0 +1,1 @@
+"""Accessors behind the admin surfaces (``/admin/*``)."""

--- a/app/database/accessor/breeze_buddy/admin/template_purge.py
+++ b/app/database/accessor/breeze_buddy/admin/template_purge.py
@@ -1,0 +1,76 @@
+"""Accessors behind ``DELETE /admin/templates/{id}/purge``."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+from app.core.logger import logger
+from app.database import get_db_connection
+from app.database.queries import run_parameterized_query
+from app.database.queries.breeze_buddy.admin.template_purge import (
+    delete_template_row_query,
+    delete_template_sessions_query,
+    template_purge_blockers_query,
+)
+
+BLOCKER_FIELDS = (
+    "widget_configs",
+    "call_configs",
+    "inflight_leads",
+    "chat_sessions",
+    "active_sessions",
+    "chat_messages",
+)
+
+
+class _TemplateGone(Exception):
+    """Raised inside the transaction so the session deletes roll back."""
+
+
+async def fetch_template_purge_blockers(template_id: str) -> Dict[str, int]:
+    """Counts of references and of history the purge would remove."""
+    query, values = template_purge_blockers_query(template_id)
+    result = await run_parameterized_query(query, values)
+    row = result[0] if result else {}
+    return {field: int(row.get(field) or 0) for field in BLOCKER_FIELDS}
+
+
+async def purge_template_with_sessions(template_id: str) -> Optional[Dict[str, Any]]:
+    """Delete the template's chat sessions and then the template, atomically.
+
+    Returns ``None`` when the template no longer exists (nothing is deleted in
+    that case either — the transaction rolls back). A foreign-key violation
+    from a reference that appeared after the pre-check also rolls everything
+    back and is re-raised.
+    """
+    sessions_query, sessions_values = delete_template_sessions_query(template_id)
+    row_query, row_values = delete_template_row_query(template_id)
+    async for conn in get_db_connection():
+        async with conn.transaction():
+            sessions = await conn.fetch(sessions_query, *sessions_values)
+            row = await conn.fetchrow(row_query, *row_values)
+            if row is None:
+                # Template vanished between pre-check and purge: keep the sessions.
+                raise _TemplateGone()
+            logger.info(
+                f"Purged template {template_id} ({row['name']}) with "
+                f"{len(sessions)} chat session(s)"
+            )
+            return {"template": dict(row), "chat_sessions_deleted": len(sessions)}
+    return None
+
+
+async def purge_template(template_id: str) -> Optional[Dict[str, Any]]:
+    """``purge_template_with_sessions`` with the vanished-template case as ``None``."""
+    try:
+        return await purge_template_with_sessions(template_id)
+    except _TemplateGone:
+        return None
+
+
+__all__ = [
+    "BLOCKER_FIELDS",
+    "fetch_template_purge_blockers",
+    "purge_template",
+    "purge_template_with_sessions",
+]

--- a/app/database/queries/breeze_buddy/admin/__init__.py
+++ b/app/database/queries/breeze_buddy/admin/__init__.py
@@ -1,0 +1,1 @@
+"""Cross-table queries behind the admin surfaces (``/admin/*``)."""

--- a/app/database/queries/breeze_buddy/admin/template_purge.py
+++ b/app/database/queries/breeze_buddy/admin/template_purge.py
@@ -1,0 +1,73 @@
+"""Queries behind ``DELETE /admin/templates/{id}/purge``.
+
+A template with chat history cannot be deleted through the tenant endpoint:
+``chat_session.template_id`` is ``ON DELETE RESTRICT`` and nothing deletes
+sessions. The purge removes the sessions first (``chat_message``,
+``agent_session_state``, ``chat_turn_metrics`` and ``tool_approvals`` cascade
+from the session) and then the template, in one transaction. Anything that
+would still point at the template afterwards — a widget_config, a call
+execution config, an in-flight lead — blocks the purge instead.
+"""
+
+from __future__ import annotations
+
+from typing import Any, List, Tuple
+
+TEMPLATE_TABLE = "template"
+WIDGET_CONFIG_TABLE = "widget_config"
+CALL_CONFIG_TABLE = "call_execution_config"
+LEAD_TABLE = "lead_call_tracker"
+CHAT_SESSION_TABLE = "chat_session"
+CHAT_MESSAGE_TABLE = "chat_message"
+
+INFLIGHT_LEAD_STATUSES = ("BACKLOG", "RETRY", "PROCESSING")
+
+
+def template_purge_blockers_query(template_id: str) -> Tuple[str, List[Any]]:
+    """One row of counts: what blocks the purge and what it would remove."""
+    statuses = ", ".join(f"'{s}'" for s in INFLIGHT_LEAD_STATUSES)
+    query = f"""
+        SELECT
+            (SELECT COUNT(*) FROM {WIDGET_CONFIG_TABLE}
+              WHERE template_id = $1::uuid)                          AS widget_configs,
+            (SELECT COUNT(*) FROM {CALL_CONFIG_TABLE}
+              WHERE template_id = $1::uuid)                          AS call_configs,
+            (SELECT COUNT(*) FROM {LEAD_TABLE}
+              WHERE template_id = $1::uuid AND status IN ({statuses})) AS inflight_leads,
+            (SELECT COUNT(*) FROM {CHAT_SESSION_TABLE}
+              WHERE template_id = $1::uuid)                          AS chat_sessions,
+            (SELECT COUNT(*) FROM {CHAT_SESSION_TABLE}
+              WHERE template_id = $1::uuid AND status = 'ACTIVE')     AS active_sessions,
+            (SELECT COUNT(*) FROM {CHAT_MESSAGE_TABLE} m
+              JOIN {CHAT_SESSION_TABLE} s ON s.id = m.session_id
+              WHERE s.template_id = $1::uuid)                        AS chat_messages
+    """
+    return query, [template_id]
+
+
+def delete_template_sessions_query(template_id: str) -> Tuple[str, List[Any]]:
+    """Delete every chat session of the template; dependents cascade."""
+    query = f"""
+        DELETE FROM {CHAT_SESSION_TABLE}
+        WHERE template_id = $1::uuid
+        RETURNING id
+    """
+    return query, [template_id]
+
+
+def delete_template_row_query(template_id: str) -> Tuple[str, List[Any]]:
+    """Delete the template row itself (run after the sessions, same transaction)."""
+    query = f"""
+        DELETE FROM {TEMPLATE_TABLE}
+        WHERE id = $1::uuid
+        RETURNING id, reseller_id, merchant_id, name, is_active, created_at, updated_at
+    """
+    return query, [template_id]
+
+
+__all__ = [
+    "INFLIGHT_LEAD_STATUSES",
+    "delete_template_row_query",
+    "delete_template_sessions_query",
+    "template_purge_blockers_query",
+]

--- a/app/schemas/breeze_buddy/admin/__init__.py
+++ b/app/schemas/breeze_buddy/admin/__init__.py
@@ -1,0 +1,1 @@
+"""Admin-only response models (``/admin/*``)."""

--- a/app/schemas/breeze_buddy/admin/template_purge.py
+++ b/app/schemas/breeze_buddy/admin/template_purge.py
@@ -1,0 +1,44 @@
+"""Response model for ``DELETE /admin/templates/{id}/purge``."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+
+class TemplatePurgeBlockers(BaseModel):
+    """Live references that make a purge refuse (all must be zero)."""
+
+    widget_configs: int = 0
+    call_configs: int = 0
+    inflight_leads: int = 0
+
+
+class TemplatePurgeTemplate(BaseModel):
+    id: str
+    name: str
+    reseller_id: Optional[str] = None
+    merchant_id: Optional[str] = None
+    is_active: bool = True
+
+
+class TemplatePurgeResponse(BaseModel):
+    """What a purge removed, or with ``dry_run`` what it would remove."""
+
+    purged: bool = Field(description="False on a dry run; nothing was deleted.")
+    template: TemplatePurgeTemplate
+    chat_sessions: int = Field(
+        description="Chat sessions removed (dry run: that would be removed)."
+    )
+    chat_messages: int = Field(
+        description="Messages under those sessions (cascade from the session)."
+    )
+    active_sessions: int = Field(
+        default=0,
+        description="Sessions still marked ACTIVE among those; stale on an unbound template.",
+    )
+    blockers: TemplatePurgeBlockers = Field(default_factory=TemplatePurgeBlockers)
+
+
+__all__ = ["TemplatePurgeBlockers", "TemplatePurgeResponse", "TemplatePurgeTemplate"]

--- a/tests/test_admin_template_purge.py
+++ b/tests/test_admin_template_purge.py
@@ -1,0 +1,178 @@
+"""``DELETE /admin/templates/{id}/purge``: query builders and the route."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Dict
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.api.routers.breeze_buddy.admin.templates import handlers, router
+from app.api.security.breeze_buddy.rbac_token import get_current_user_with_rbac
+from app.database.queries.breeze_buddy.admin import template_purge as q
+from app.schemas import UserInfo, UserRole
+
+ADMIN = UserInfo(id="admin-1", username="admin", role=UserRole.ADMIN)
+RESELLER = UserInfo(
+    id="r-1", username="partner", role=UserRole.RESELLER, reseller_ids=["BB_SHOPIFY"]
+)
+TID = "9c6e7f0c-db4a-469c-a693-d8c5fc98f499"
+
+
+def _counts(**over: int) -> Dict[str, int]:
+    base = {
+        "widget_configs": 0,
+        "call_configs": 0,
+        "inflight_leads": 0,
+        "chat_sessions": 268,
+        "active_sessions": 3,
+        "chat_messages": 1402,
+    }
+    base.update(over)
+    return base
+
+
+# --- query builders ---------------------------------------------------------
+
+
+def test_blockers_query_counts_every_reference_and_the_history():
+    sql, values = q.template_purge_blockers_query(TID)
+    assert values == [TID]
+    for table in (
+        "widget_config",
+        "call_execution_config",
+        "lead_call_tracker",
+        "chat_session",
+        "chat_message",
+    ):
+        assert table in sql
+    assert "'BACKLOG', 'RETRY', 'PROCESSING'" in sql
+    assert "status = 'ACTIVE'" in sql
+
+
+def test_delete_queries_target_sessions_then_the_template_row():
+    s_sql, s_values = q.delete_template_sessions_query(TID)
+    t_sql, t_values = q.delete_template_row_query(TID)
+    assert s_values == t_values == [TID]
+    assert "DELETE FROM chat_session" in s_sql and "RETURNING id" in s_sql
+    assert "DELETE FROM template" in t_sql and "RETURNING id, reseller_id" in t_sql
+
+
+# --- route ------------------------------------------------------------------
+
+
+@pytest.fixture()
+def purge_mocks(monkeypatch) -> Dict[str, AsyncMock]:
+    """Patch every accessor *as imported into the handler module* (repo idiom)."""
+    existing = SimpleNamespace(
+        id=TID,
+        name="thebeyondbound-buddy-assist",
+        reseller_id="BB_SHOPIFY",
+        merchant_id="beyond-bound.myshopify.com",
+        is_active=False,
+    )
+    mocks: Dict[str, AsyncMock] = {
+        "get_template_by_id": AsyncMock(return_value=existing),
+        "fetch_template_purge_blockers": AsyncMock(return_value=_counts()),
+        "purge_template": AsyncMock(
+            return_value={
+                "template": {"id": TID, "name": existing.name},
+                "chat_sessions_deleted": 268,
+            }
+        ),
+        "invalidate_template": AsyncMock(return_value=None),
+    }
+    for name, mock in mocks.items():
+        monkeypatch.setattr(handlers, name, mock)
+    return mocks
+
+
+@pytest.fixture()
+def purge_app(purge_mocks):
+    def make(user: UserInfo) -> TestClient:
+        app = FastAPI()
+        app.include_router(router)
+        app.dependency_overrides[get_current_user_with_rbac] = lambda: user
+        return TestClient(app)
+
+    return make
+
+
+def test_admin_purges_sessions_and_template(purge_app, purge_mocks):
+    res = purge_app(ADMIN).delete(f"/admin/templates/{TID}/purge")
+    assert res.status_code == 200, res.text
+    body = res.json()
+    assert body["purged"] is True
+    assert body["template"]["name"] == "thebeyondbound-buddy-assist"
+    assert body["chat_sessions"] == 268 and body["chat_messages"] == 1402
+    assert body["active_sessions"] == 3
+    assert body["blockers"] == {
+        "widget_configs": 0,
+        "call_configs": 0,
+        "inflight_leads": 0,
+    }
+    purge_mocks["purge_template"].assert_awaited_once_with(TID)
+    purge_mocks["invalidate_template"].assert_awaited_once_with(TID)
+
+
+def test_dry_run_reports_without_deleting(purge_app, purge_mocks):
+    res = purge_app(ADMIN).delete(f"/admin/templates/{TID}/purge?dry_run=true")
+    assert res.status_code == 200, res.text
+    body = res.json()
+    assert body["purged"] is False and body["chat_sessions"] == 268
+    purge_mocks["purge_template"].assert_not_awaited()
+    purge_mocks["invalidate_template"].assert_not_awaited()
+
+
+@pytest.mark.parametrize(
+    "field, phrase",
+    [
+        ("widget_configs", "widget config(s) still bind"),
+        ("call_configs", "call execution config(s)"),
+        ("inflight_leads", "in-flight lead(s)"),
+    ],
+)
+def test_live_references_block_the_purge(purge_app, purge_mocks, field, phrase):
+    purge_mocks["fetch_template_purge_blockers"].return_value = _counts(**{field: 2})
+    res = purge_app(ADMIN).delete(f"/admin/templates/{TID}/purge")
+    assert res.status_code == 409, res.text
+    assert phrase in res.json()["detail"]
+    purge_mocks["purge_template"].assert_not_awaited()
+
+
+def test_chat_history_alone_never_blocks(purge_app, purge_mocks):
+    purge_mocks["fetch_template_purge_blockers"].return_value = _counts(
+        chat_sessions=766, active_sessions=766, chat_messages=9000
+    )
+    res = purge_app(ADMIN).delete(f"/admin/templates/{TID}/purge")
+    assert res.status_code == 200, res.text
+
+
+def test_missing_template_is_404(purge_app, purge_mocks):
+    purge_mocks["get_template_by_id"].return_value = None
+    res = purge_app(ADMIN).delete(f"/admin/templates/{TID}/purge")
+    assert res.status_code == 404
+    purge_mocks["fetch_template_purge_blockers"].assert_not_awaited()
+
+
+def test_template_vanishing_mid_purge_is_404_and_rolls_back(purge_app, purge_mocks):
+    purge_mocks["purge_template"].return_value = None
+    res = purge_app(ADMIN).delete(f"/admin/templates/{TID}/purge")
+    assert res.status_code == 404
+    purge_mocks["invalidate_template"].assert_not_awaited()
+
+
+def test_purge_failure_is_500_with_rollback_note(purge_app, purge_mocks):
+    purge_mocks["purge_template"].side_effect = RuntimeError("fk violation")
+    res = purge_app(ADMIN).delete(f"/admin/templates/{TID}/purge")
+    assert res.status_code == 500
+    assert "rolled back" in res.json()["detail"]
+
+
+def test_reseller_is_forbidden(purge_app, purge_mocks):
+    res = purge_app(RESELLER).delete(f"/admin/templates/{TID}/purge")
+    assert res.status_code == 403
+    purge_mocks["get_template_by_id"].assert_not_awaited()


### PR DESCRIPTION
## What

`DELETE /agent/voice/breeze-buddy/admin/templates/{id}/purge` (admin only; `?dry_run=true` to preview) — delete a template **together with its chat history** in one transaction.

The tenant `DELETE /templates/{id}` cannot remove any template that ever served a chat session: `chat_session.template_id` is `ON DELETE RESTRICT` and nothing in the codebase deletes sessions. So duplicated or orphaned agent templates could only be deactivated. On 2026-09-08 the BB_SHOPIFY duplicate cleanup left 13 such templates behind (≈1,300 sessions of throw-away transcripts); this is the admin's answer when the transcripts are not worth keeping.

## How

- **Refuses with 409** while a `widget_config`, a `call_execution_config` or an in-flight `lead_call_tracker` row (BACKLOG/RETRY/PROCESSING) still references the template — those are live behaviour, not history. Chat sessions alone never block.
- **One transaction** (`conn.transaction()`): `DELETE FROM chat_session WHERE template_id = $1` (messages, `agent_session_state`, `chat_turn_metrics`, `tool_approvals` cascade from the session), then `DELETE FROM template WHERE id = $1 RETURNING …`. A template that vanishes between pre-check and purge, or a late FK violation, rolls everything back (404 / 500 with a rollback note). Template cache is invalidated after.
- **Dry run** returns the same payload (`chat_sessions`, `chat_messages`, `active_sessions`, `blockers`) with `purged: false` and touches nothing — the console can show it in a confirm dialog.
- **Admin package.** Introduces `routers/breeze_buddy/admin/` (aggregator mounted from `routers/breeze_buddy/__init__.py`) plus `queries/`, `accessor/` and `schemas/breeze_buddy/admin/` so every admin-only surface lives under `admin/` on every layer. #1107 (fleet inventory) adds its sub-package to the same aggregator; whichever lands second gets a one-line rebase.
- No migration.

## Tests

`tests/test_admin_template_purge.py` (12): query builders (every reference table and the in-flight statuses named; sessions deleted before the row), admin purge 200 with accessor and cache invalidation awaited, dry run deletes nothing, each live reference → 409, chat history alone never blocks, 404 on missing / vanished template, 500 with rollback note on failure, reseller 403. Full suite passing; pyrefly clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DNdffo648u5Qg9Q5Ctftub


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an admin-only template purge capability.
  - Administrators can preview purge results with a dry run before deleting a template and its chat history.
  - Purges are blocked when active references or in-flight leads remain.
  - Results report deleted sessions, messages, active sessions, and any blockers.

- **Bug Fixes**
  - Added transactional safeguards to prevent partial template purges and preserve data consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->