### PR TITLE
feat(uap): send gateway_reference_id as order metadata; env override

### DIFF
--- a/app/api/routers/breeze_buddy/preview/uap/handlers.py
+++ b/app/api/routers/breeze_buddy/preview/uap/handlers.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, List, Literal, Optional, Tuple
 from fastapi import APIRouter, HTTPException, Query, Request, status
 from pydantic import BaseModel, Field
 
-from app.core.config.static import APP_BASE_URL
+from app.core.config.static import APP_BASE_URL, UAP_GATEWAY_REFERENCE_ID
 from app.core.logger import logger
 from app.crm.identity.contracts import get_customer, resolve
 from app.crm.preview.uap.contracts import (
@@ -946,7 +946,9 @@ async def draw_against_agent(payload: DrawRequest) -> Dict[str, Any]:
     # (``metadata.webhook_url``): /txns creates the order inline, so this is
     # the only way NY ever hears it was paid and issues the tickets.
     order_fields = uap_api.confirm_order_fields(confirm)
-    gateway_reference_id = uap_api.confirm_gateway_reference_id(confirm)
+    gateway_reference_id = (
+        UAP_GATEWAY_REFERENCE_ID or uap_api.confirm_gateway_reference_id(confirm)
+    )
 
     # The draw must match NY's confirmed amount exactly (the LLM's figure is
     # the card's "from ₹x"), and the cart is built from that same amount so

--- a/app/core/config/static.py
+++ b/app/core/config/static.py
@@ -920,3 +920,6 @@ UAP_VALIDITY_DAYS = os.environ.get("UAP_VALIDITY_DAYS", "90")
 UAP_LIMIT_CHOICES = os.environ.get("UAP_LIMIT_CHOICES", "200.00,500.00,1000.00")
 UAP_SELLER_NAME = os.environ.get("UAP_SELLER_NAME", "Chennai Metro Rail Limited")
 UAP_SELLER_MIC = os.environ.get("UAP_SELLER_MIC", "CMRL")
+# Juspay routing label for agentic /txns (order.metadata.JUSPAY:gateway_reference_id);
+# unset = use the value NY returns on confirm, if any.
+UAP_GATEWAY_REFERENCE_ID = os.environ.get("UAP_GATEWAY_REFERENCE_ID", "").strip()

--- a/app/services/preview/uap/api.py
+++ b/app/services/preview/uap/api.py
@@ -745,7 +745,7 @@ async def create_txn(
             continue
         body[f"order.{key}"] = value
     if gateway_reference_id:
-        body["gateway_reference_id"] = gateway_reference_id
+        body["order.metadata.JUSPAY:gateway_reference_id"] = gateway_reference_id
 
     logger.info(
         f"uap txns: draw order_id={order_id} amount={amount} action_id={action_id}"


### PR DESCRIPTION
## What

Juspay reads the agentic routing label from `order.metadata.JUSPAY:gateway_reference_id`. The draw sent it as a top-level `gateway_reference_id` field, which the gateway ignores, so the reference never reached it.

- `UAP_GATEWAY_REFERENCE_ID` (new env, default empty). When set, it is the value sent.
- Otherwise the draw keeps using the `gatewayReferenceId` NY returns on confirm.
- With neither, the key is not sent.

## Files

- `app/core/config/static.py` — the env, next to the other UAP settings.
- `app/api/routers/breeze_buddy/preview/uap/handlers.py` — env wins, else NY confirm.
- `app/services/preview/uap/api.py` — the key moves into order metadata.

## Verified

- `tests/test_uap_*` pass (12).
- Body replayed against `api.juspay.in` `/txns` through `create_txn`: the new key is accepted (request reaches Juspay's partner check, no decode error).

## Prod env

`UAP_GATEWAY_REFERENCE_ID=MULTIMODALCUMTAUAP`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018zuEdoHfiy7mKW5otXuxbK


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated transaction routing to use a configurable gateway reference when available.
  * Added fallback behavior to derive the gateway reference from the confirmation response.
  * Adjusted transaction requests to include gateway routing metadata in the expected location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->