### PR TITLE
fix(chameleon): keep backend-only registry defs renderable by the model

### DIFF
--- a/app/ai/voice/agents/breeze_buddy/chat/custom_components.py
+++ b/app/ai/voice/agents/breeze_buddy/chat/custom_components.py
@@ -30,18 +30,19 @@ def model_renderable(
 ) -> Dict[str, CustomComponentDef]:
     """The subset the MODEL may render in-thread via render_ui.
 
-    Two exclusions, both mirroring what the widget wire can paint:
+    One exclusion:
 
     - ``overlay_only`` defs are client-side render targets (opened by an
       ``open_detail`` / intent action in the widget's detail overlay): they
       ship on the session surface wire but never join the render_ui enum,
       coaching, or allowlist — the model cannot paint them in-thread.
     - defs with NO ``render_def`` (registered for a merchant frontend that
-      renders them itself): ``_custom_components_wire`` never ships them,
-      so offering them to the model would let it persist a ui_op our
-      widget cannot interpret.
+      renders them itself) STAY renderable: the model may paint them and
+      the op persists; ``_custom_components_wire`` still never ships them,
+      so the generic widget is unaffected — only the merchant's own page,
+      which draws them by name, ever paints the op.
     """
-    return {k: v for k, v in defs.items() if v.render_def and not v.flags.overlay_only}
+    return {k: v for k, v in defs.items() if not v.flags.overlay_only}
 
 
 async def resolve_custom_components(

--- a/tests/test_custom_defs.py
+++ b/tests/test_custom_defs.py
@@ -133,7 +133,7 @@ class TestRegistrationGuards:
         }
         assert set(model_renderable(defs)) == {"JourneyOptions"}
 
-    def test_model_renderable_filters_render_def_less(self):
+    def test_model_renderable_keeps_render_def_less(self):
         """A def without a render_def never ships on the widget wire, so it
         must not be offered to the model either — or the model can persist
         a ui_op the widget cannot paint."""
@@ -150,7 +150,8 @@ class TestRegistrationGuards:
             ),
             "BackendOnly": CustomComponentDef(name="BackendOnly", props_schema={}),
         }
-        assert set(model_renderable(defs)) == {"Renderable"}
+        # Backend-only defs (merchant page draws them) stay renderable.
+        assert set(model_renderable(defs)) == {"Renderable", "BackendOnly"}
 
     @pytest.mark.parametrize("bad", ["journeyOptions", "J", "Has Spaces", "x" * 70])
     def test_name_must_be_pascal_case(self, bad):


### PR DESCRIPTION
## What

One line in `model_renderable` (`app/ai/voice/agents/breeze_buddy/chat/custom_components.py`): registry defs **without** a `render_def` stay in the render_ui enum; only `overlay_only` defs are excluded. This is the `chameleon-local` behaviour before 4762ad2e.

## Why

Chennai One's assist page draws its own `JourneyOptions` / `JourneyDetail` / `TicketCard`, so their `ui_component` rows carry no `render_def`. Since 4762ad2e the model is never offered them, so every journey turn ends in prose (prod and local, verified 2026-09-08). Restoring the line brings the card back — same local turn, same template:

- before: `search_journeys → render_ui(no_ui)`, prose only
- after: `search_journeys → render_ui` → `ui_op JourneyOptions` with the journeys bound, one line under it

## Safety

- `_custom_components_wire` is unchanged: backend-only defs still never ship to the generic widget.
- The persisted op is only ever painted by the merchant page that registered the def, by name.
- Tests: `test_model_renderable_keeps_render_def_less` (renamed from `_filters_`) asserts the new expectation; `test_custom_defs`, `test_widget_surface_block`, `test_render_ui_*`, `test_turn_core`, `test_ui_stream_show` — 120 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018zuEdoHfiy7mKW5otXuxbK


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Model-rendered custom components without a widget rendering definition now remain available for model painting.
  * Components intended only for backend rendering continue to be excluded from generic widget delivery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->