### PR TITLE
feat(assist): GET /assist/blueprint — read the reseller blueprint directly

### DIFF
--- a/app/api/routers/breeze_buddy/__init__.py
+++ b/app/api/routers/breeze_buddy/__init__.py
@@ -7,6 +7,9 @@ from app.api.routers.breeze_buddy.agent_router.health import router as pod_route
 
 # Modern RESTful routers
 from app.api.routers.breeze_buddy.analytics import router as analytics_router
+from app.api.routers.breeze_buddy.assist.blueprint import (
+    router as assist_blueprint_router,
+)
 from app.api.routers.breeze_buddy.assist.onboarding import (
     router as assist_onboarding_router,
 )
@@ -110,6 +113,8 @@ router.include_router(website_scraping_router, prefix="", tags=["website-scrapin
 
 # Idempotent merchant onboarding for the Buddy Assist widget.
 router.include_router(assist_onboarding_router, prefix="", tags=["assist-onboarding"])
+# The reseller blueprint the merchant templates are built from (read-only).
+router.include_router(assist_blueprint_router, prefix="", tags=["assist-onboarding"])
 
 # Playground (configuration exploration)
 router.include_router(playground_router, prefix="", tags=["playground"])

--- a/app/api/routers/breeze_buddy/assist/__init__.py
+++ b/app/api/routers/breeze_buddy/assist/__init__.py
@@ -1,6 +1,7 @@
-"""Buddy Assist HTTP surface: onboarding (install + stream) and research."""
+"""Buddy Assist HTTP surface: onboarding (install + stream), the blueprint, and research."""
 
+from app.api.routers.breeze_buddy.assist.blueprint import router as blueprint_router
 from app.api.routers.breeze_buddy.assist.onboarding import router as onboarding_router
 from app.api.routers.breeze_buddy.assist.research import router as research_router
 
-__all__ = ["onboarding_router", "research_router"]
+__all__ = ["blueprint_router", "onboarding_router", "research_router"]

--- a/app/api/routers/breeze_buddy/assist/blueprint.py
+++ b/app/api/routers/breeze_buddy/assist/blueprint.py
@@ -1,0 +1,60 @@
+"""``GET /assist/blueprint`` — the reseller-level Assist blueprint, read-only.
+
+The console's Template Studio compares an agent's operating core against
+the blueprint the reseller's merchant templates are built from ("standard"
+vs "drifted"); until now the row was reachable only by paging the whole
+templates list without a merchant filter.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+
+from app.ai.voice.agents.breeze_buddy.assist.verticals import registry as verticals
+from app.ai.voice.agents.breeze_buddy.template.types import TemplateModel
+from app.ai.voice.agents.breeze_buddy.utils.secrets import mask_template_secrets
+from app.api.security.breeze_buddy.authorization import validate_reseller_access
+from app.api.security.breeze_buddy.rbac_token import get_current_user_with_rbac
+from app.core.security.authorization import require_role
+from app.database.accessor import get_template_in_scope
+from app.schemas import UserInfo, UserRole
+
+router = APIRouter()
+
+# Read-only and secrets-masked, so every scoped role may see it: a merchant
+# editing their own agent in the console needs the core to diff against.
+_BLUEPRINT_ROLES = [UserRole.ADMIN, UserRole.RESELLER, UserRole.MERCHANT]
+
+
+@router.get("/assist/blueprint", response_model=TemplateModel)
+async def get_assist_blueprint(
+    reseller_id: str = Query(..., min_length=1, max_length=255),
+    vertical: Optional[str] = Query(
+        None,
+        description="The vertical whose blueprint to read; the default when absent.",
+    ),
+    current_user: UserInfo = Depends(get_current_user_with_rbac),
+) -> TemplateModel:
+    """The reseller-level blueprint the vertical's agents are built from,
+    secrets masked exactly like ``GET /templates/{id}``. 404 when the
+    reseller has none; 400 for an unknown vertical."""
+    require_role(current_user, _BLUEPRINT_ROLES)
+    validate_reseller_access(current_user, reseller_id=reseller_id)
+    try:
+        blueprint_name = verticals.for_request(vertical).blueprint_name
+    except KeyError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)
+        ) from exc
+    template = await get_template_in_scope(reseller_id.strip(), None, blueprint_name)
+    if template is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="The default Assist template is not configured for this reseller.",
+        )
+    return mask_template_secrets(template)
+
+
+__all__ = ["router"]

--- a/tests/assist/onboarding/test_blueprint_endpoint.py
+++ b/tests/assist/onboarding/test_blueprint_endpoint.py
@@ -1,0 +1,108 @@
+"""``GET /assist/blueprint``: scoped read of the reseller blueprint, secrets masked."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.ai.voice.agents.breeze_buddy.assist.commerce.vertical import (
+    DEFAULT_ASSIST_TEMPLATE_NAME,
+)
+from app.ai.voice.agents.breeze_buddy.template.types import TemplateModel
+from app.api.routers.breeze_buddy.assist import blueprint
+from app.api.security.breeze_buddy.rbac_token import get_current_user_with_rbac
+from app.schemas import UserInfo, UserRole
+
+ADMIN = UserInfo(
+    id="admin-1", username="admin", role=UserRole.ADMIN, reseller_ids=["*"]
+)
+PARTNER = UserInfo(
+    id="r-1", username="partner", role=UserRole.RESELLER, reseller_ids=["BB_SHOPIFY"]
+)
+MERCHANT = UserInfo(
+    id="merchant:9b1086-18.myshopify.com",
+    username="merchant-9b1086-18.myshopify.com",
+    role=UserRole.MERCHANT,
+    reseller_ids=["BB_SHOPIFY"],
+    merchant_ids=["9b1086-18.myshopify.com"],
+)
+
+
+def _blueprint() -> TemplateModel:
+    return TemplateModel(
+        id="00000000-0000-0000-0000-00000000b1e0",
+        reseller_id="BB_SHOPIFY",
+        merchant_id=None,
+        name=DEFAULT_ASSIST_TEMPLATE_NAME,
+        flow={
+            "mode": "direct",
+            "functions": [],
+            "system_prompt": "{{brand_identity_section}}",
+        },
+        expected_payload_schema={},
+        expected_callback_response_schema={},
+        configurations=None,
+        secrets={"wismo_secret": "super-secret-value"},
+        is_active=True,
+        supported_channels=["chat"],
+    )
+
+
+LOOKUP = AsyncMock()
+
+
+def _client(user: UserInfo, monkeypatch, found: bool = True) -> TestClient:
+    app = FastAPI()
+    app.include_router(blueprint.router)
+    app.dependency_overrides[get_current_user_with_rbac] = lambda: user
+    LOOKUP.reset_mock()
+    LOOKUP.return_value = _blueprint() if found else None
+    monkeypatch.setattr(blueprint, "get_template_in_scope", LOOKUP)
+    return TestClient(app)
+
+
+def test_admin_reads_the_blueprint_with_secrets_masked(monkeypatch) -> None:
+    res = _client(ADMIN, monkeypatch).get(
+        "/assist/blueprint", params={"reseller_id": "BB_SHOPIFY"}
+    )
+    assert res.status_code == 200
+    body = res.json()
+    assert body["name"] == DEFAULT_ASSIST_TEMPLATE_NAME and body["merchant_id"] is None
+    assert "super-secret-value" not in res.text
+    LOOKUP.assert_awaited_once_with("BB_SHOPIFY", None, DEFAULT_ASSIST_TEMPLATE_NAME)
+
+
+def test_partner_and_merchant_read_their_own_reseller(monkeypatch) -> None:
+    for user in (PARTNER, MERCHANT):
+        res = _client(user, monkeypatch).get(
+            "/assist/blueprint", params={"reseller_id": "BB_SHOPIFY"}
+        )
+        assert res.status_code == 200, user.role
+
+
+def test_other_reseller_is_forbidden(monkeypatch) -> None:
+    res = _client(PARTNER, monkeypatch).get(
+        "/assist/blueprint", params={"reseller_id": "BB_ASSIST"}
+    )
+    assert res.status_code == 403
+
+
+def test_missing_blueprint_is_404(monkeypatch) -> None:
+    res = _client(ADMIN, monkeypatch, found=False).get(
+        "/assist/blueprint", params={"reseller_id": "BB_ASSIST"}
+    )
+    assert res.status_code == 404
+
+
+def test_reseller_id_is_required(monkeypatch) -> None:
+    assert _client(ADMIN, monkeypatch).get("/assist/blueprint").status_code == 422
+
+
+def test_unknown_vertical_is_400(monkeypatch) -> None:
+    res = _client(ADMIN, monkeypatch).get(
+        "/assist/blueprint", params={"reseller_id": "BB_SHOPIFY", "vertical": "booking"}
+    )
+    assert res.status_code == 400


### PR DESCRIPTION
## Why

The console's Template Studio (plan §29.4, roadmap P1-3 / CV-4) diffs an agent's operating core against the reseller blueprint its merchant templates are built from. Until now that row was reachable only by paging the whole templates list without a merchant filter.

## What

`GET /assist/blueprint?reseller_id=…` returns the reseller-level `buddy-assist-default` template with secrets masked exactly like `GET /templates/{id}`; 404 when the reseller has none. Any scoped role may read it (admin / reseller / merchant, gated by `validate_reseller_access`): it is read-only, and a merchant editing their own agent needs the core to diff against. Mounted next to the onboarding routes under `routers/breeze_buddy/assist/blueprint.py`.

Independent of #1115 (branches from `release`).

## Checks

Route tests (masked secrets, own-reseller reads for partner and merchant, 403 for another reseller, 404 unconfigured, 422 without `reseller_id`); the assist suite passes; `pyrefly` clean; `black`/`isort`; boundary guard; router mount import-smoked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DNdffo648u5Qg9Q5Ctftub
