### PR TITLE
refactor(assist): onboarding is platform-blind and the engine is vertical-blind

### DIFF
--- a/app/ai/voice/agents/breeze_buddy/assist/commerce/models.py
+++ b/app/ai/voice/agents/breeze_buddy/assist/commerce/models.py
@@ -1,0 +1,60 @@
+"""The commerce vertical's research and slot shapes.
+
+The engine's ``SiteResearch`` is what any website yields; a shop adds its
+catalogue. ``CommerceSlots`` is the only merchant-specific content a
+commerce template carries (plan §3.2).
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, Field
+
+from app.ai.voice.agents.breeze_buddy.assist.engine.models import SiteResearch
+
+
+class ResearchProduct(BaseModel):
+    title: str
+    url: Optional[str] = None
+    product_type: Optional[str] = None
+    tags: List[str] = Field(default_factory=list)
+    options: List[Dict[str, Any]] = Field(default_factory=list)
+    price_min: Optional[float] = None
+    price_max: Optional[float] = None
+    currency: Optional[str] = None
+    image_url: Optional[str] = None
+    available: Optional[bool] = None
+    source: Optional[str] = None
+
+
+class ResearchCollection(BaseModel):
+    title: str
+    url: Optional[str] = None
+    image_url: Optional[str] = None
+    product_count: Optional[int] = None
+
+
+class CommerceResearch(SiteResearch):
+    categories: List[str] = Field(default_factory=list)
+    products: List[ResearchProduct] = Field(default_factory=list)
+    collections: List[ResearchCollection] = Field(default_factory=list)
+
+
+class CommerceSlots(BaseModel):
+    brand_block: str
+    sizing_section: str
+    link_label: str
+    link_url: str
+    link_noun: Optional[str] = None
+    guided: Dict[str, str] = Field(default_factory=dict)
+    greeting: str
+    quick_replies: List[Dict[str, Any]] = Field(default_factory=list)
+    tiles: List[Dict[str, Any]] = Field(default_factory=list)
+    trusted_urls: List[str] = Field(default_factory=list)
+    checkout_url: Optional[str] = None
+    example_product: Optional[str] = None
+    sources: Dict[str, str] = Field(default_factory=dict)
+
+
+__all__ = ["CommerceResearch", "CommerceSlots", "ResearchCollection", "ResearchProduct"]

--- a/app/ai/voice/agents/breeze_buddy/assist/commerce/skeleton.py
+++ b/app/ai/voice/agents/breeze_buddy/assist/commerce/skeleton.py
@@ -1,0 +1,44 @@
+"""The commerce vertical's prompt skeleton (Beyond Bound v2).
+
+Merchant slots inside the shared operating block: the contact LinkButton
+example and phrase, the guided-shopping example phrases, and the sizing /
+selection help section (heading varies per merchant). Kept in lockstep
+with the ops rollout script that standardised the fleet.
+"""
+
+from __future__ import annotations
+
+import re
+
+from app.ai.voice.agents.breeze_buddy.assist.engine.skeleton import SkeletonSpec
+
+COMMERCE_V2 = SkeletonSpec(
+    id="commerce-v2",
+    vertical_section_end="\n### UI emission",
+    slot_patterns=(
+        (
+            re.compile(r'`link=\{"label": "[^"]+", "url": "https://[^"]+"\}`\.'),
+            "<LINK>",
+        ),
+        (re.compile(r'\("I\'ve added an? [^"]+ button below"\)'), "<LINKPHRASE>"),
+        (
+            re.compile(r"- \*\*Named product or line\*\* \([^)]*\)"),
+            "- **Named product or line** <NAMED>",
+        ),
+        (re.compile(r"- \*\*Broad ask\*\* \([^)]*\)"), "- **Broad ask** <BROAD>"),
+        (
+            re.compile(r"ONE grounded question \([^)]*\)"),
+            "ONE grounded question <AXES>",
+        ),
+        (
+            re.compile(r"\(checkout, or the one category that [^)]*\)"),
+            "(checkout, or the one category that <COMPLETES>)",
+        ),
+        (
+            re.compile(r"narrowing filters right after a category \([^)]*\)"),
+            "narrowing filters right after a category <CHIPS>",
+        ),
+    ),
+)
+
+__all__ = ["COMMERCE_V2"]

--- a/app/ai/voice/agents/breeze_buddy/assist/engine/models.py
+++ b/app/ai/voice/agents/breeze_buddy/assist/engine/models.py
@@ -1,4 +1,4 @@
-"""Versioned artefacts that flow between engine stages (ASSIST-ENGINE-DESIGN.md §2).
+"""Versioned, vertical-agnostic artefacts that flow between engine stages (ASSIST-ENGINE-DESIGN.md §2).
 
 Every artefact carries provenance (``sources`` / ``fetched_at``) so a slot,
 a tile or a policy fact can always be traced to the page it came from.
@@ -51,40 +51,20 @@ class TenantIdentity(BaseModel):
     merchant_id: Optional[str] = None
 
 
-class ResearchProduct(BaseModel):
-    title: str
-    url: Optional[str] = None
-    product_type: Optional[str] = None
-    tags: List[str] = Field(default_factory=list)
-    options: List[Dict[str, Any]] = Field(default_factory=list)
-    price_min: Optional[float] = None
-    price_max: Optional[float] = None
-    currency: Optional[str] = None
-    image_url: Optional[str] = None
-    available: Optional[bool] = None
-    source: Optional[str] = None
+class SiteResearch(BaseModel):
+    """Stage 3 output — the vertical-agnostic part; missing = null, never invented.
 
-
-class ResearchCollection(BaseModel):
-    title: str
-    url: Optional[str] = None
-    image_url: Optional[str] = None
-    product_count: Optional[int] = None
-
-
-class StoreResearch(BaseModel):
-    """Stage 3 output — the same shape for every platform; missing = null, never invented."""
+    A vertical extends this with its own inventory shapes (see the commerce
+    vertical's ``assist/commerce/models.py``).
+    """
 
     platform: str
     canonical_origin: str
     extra_origins: List[str] = Field(default_factory=list)
-    store_name: Optional[str] = None
+    name: Optional[str] = None
     brand_story: Optional[str] = None
     tone_hints: List[str] = Field(default_factory=list)
     audience: Optional[str] = None
-    categories: List[str] = Field(default_factory=list)
-    products: List[ResearchProduct] = Field(default_factory=list)
-    collections: List[ResearchCollection] = Field(default_factory=list)
     policies: Dict[str, str] = Field(default_factory=dict)
     contacts: Dict[str, str] = Field(default_factory=dict)
     offers: List[str] = Field(default_factory=list)
@@ -96,35 +76,18 @@ class StoreResearch(BaseModel):
 
 
 class ResearchDelta(BaseModel):
-    """What a platform adapter adds to the generic research; merged field by field, adapter wins."""
+    """What a platform adapter adds to the generic research; merged field by
+    field, adapter wins. Vertical-specific payloads travel in ``vertical``
+    for that vertical's merge step."""
 
-    store_name: Optional[str] = None
+    name: Optional[str] = None
     permanent_host: Optional[str] = None
-    products: Optional[List[ResearchProduct]] = None
-    collections: Optional[List[ResearchCollection]] = None
     policies: Dict[str, str] = Field(default_factory=dict)
     contacts: Dict[str, str] = Field(default_factory=dict)
     brand: Dict[str, Any] = Field(default_factory=dict)
     extra_origins: List[str] = Field(default_factory=list)
+    vertical: Dict[str, Any] = Field(default_factory=dict)
     sources: List[str] = Field(default_factory=list)
-
-
-class Slots(BaseModel):
-    """Stage 4 output: the ONLY merchant-specific content in a template."""
-
-    brand_block: str
-    sizing_section: str
-    link_label: str
-    link_url: str
-    link_noun: Optional[str] = None
-    guided: Dict[str, str] = Field(default_factory=dict)
-    greeting: str
-    quick_replies: List[Dict[str, Any]] = Field(default_factory=list)
-    tiles: List[Dict[str, Any]] = Field(default_factory=list)
-    trusted_urls: List[str] = Field(default_factory=list)
-    checkout_url: Optional[str] = None
-    example_product: Optional[str] = None
-    sources: Dict[str, str] = Field(default_factory=dict)
 
 
 class ToolBinding(BaseModel):
@@ -155,26 +118,28 @@ class WidgetBinding(BaseModel):
 
 
 class MirrorPolicy(BaseModel):
-    """What the preview mirror may proxy for this platform."""
+    """What the preview mirror may proxy for this platform.
+
+    ``handoff`` is how a blocked transactional path sends the visitor to the
+    real site: ``permalink`` rebuilds their in-progress state on the real
+    domain, ``link`` opens the real URL, ``none`` shows only the notice.
+    """
 
     blocked_paths: List[str] = Field(default_factory=list)
     allowed_xhr: List[str] = Field(default_factory=list)
     cdn_hosts: List[str] = Field(default_factory=list)
     script_policy: Literal["drop_third_party", "pass_through"] = "drop_third_party"
-    cart_handoff: Literal["permalink", "link", "none"] = "link"
+    handoff: Literal["permalink", "link", "none"] = "link"
     section_probe: bool = False
 
 
 __all__ = [
     "InstallMethod",
     "MirrorPolicy",
-    "ResearchCollection",
     "ResearchDelta",
-    "ResearchProduct",
     "Signal",
     "SiteProfile",
-    "Slots",
-    "StoreResearch",
+    "SiteResearch",
     "TemplateCandidate",
     "TenantIdentity",
     "ToolBinding",

--- a/app/ai/voice/agents/breeze_buddy/assist/engine/prompt_core.py
+++ b/app/ai/voice/agents/breeze_buddy/assist/engine/prompt_core.py
@@ -1,65 +1,47 @@
-"""The shared operating core of a Buddy Assist v2 prompt.
+"""The shared operating core of a prompt, for any vertical's skeleton.
 
-Every production Assist template is the same skeleton with a handful of
-merchant "slots" swapped: the ``## Brand identity`` block, the sizing /
-selection section, the contact LinkButton example, and the guided-shopping
-example phrases. ``shared_core`` strips those slots so two prompts built from
-the same skeleton hash identically — the consistency guarantee the fleet,
-the onboarding gate and the future re-sync all rely on.
-
-Kept in lockstep with the ops workspace's rollout script (the script that rolled the fleet out); change both or neither.
+Every production Assist template of one vertical is the same skeleton with
+a handful of merchant slots swapped. ``shared_core`` strips those slots
+(as the vertical's ``SkeletonSpec`` describes them) so two prompts built
+from the same skeleton hash identically — the consistency guarantee the
+fleet, the onboarding gate and re-sync rely on. Nothing here knows what a
+slot says; the commerce vertical's patterns live in
+``assist/commerce/skeleton.py``.
 """
 
 from __future__ import annotations
 
 import hashlib
-import re
 from typing import Tuple
 
-OPERATING_HEAD = "## Operating principles"
-SIZING_END = "\n### UI emission"
-
-_LINK_EXAMPLE = re.compile(r'`link=\{"label": "[^"]+", "url": "https://[^"]+"\}`\.')
-_LINK_PHRASE = re.compile(r'\("I\'ve added an? [^"]+ button below"\)')
-_NAMED = re.compile(r"- \*\*Named product or line\*\* \([^)]*\)")
-_BROAD = re.compile(r"- \*\*Broad ask\*\* \([^)]*\)")
-_AXES = re.compile(r"ONE grounded question \([^)]*\)")
-_COMPLETES = re.compile(r"\(checkout, or the one category that [^)]*\)")
-_CHIPS = re.compile(r"narrowing filters right after a category \([^)]*\)")
+from app.ai.voice.agents.breeze_buddy.assist.engine.skeleton import SkeletonSpec
 
 
-def split_prompt(prompt: str) -> Tuple[str, str]:
-    """(brand block, operating block) of a v2 prompt.
-
-    Raises ``ValueError`` when the prompt is not a v2 skeleton.
-    """
-    index = prompt.find(OPERATING_HEAD)
+def split_prompt(prompt: str, skeleton: SkeletonSpec) -> Tuple[str, str]:
+    """(brand block, operating block); ``ValueError`` when not this skeleton."""
+    index = prompt.find(skeleton.operating_head)
     if index < 0:
         raise ValueError("prompt has no operating block")
     return prompt[:index], prompt[index:]
 
 
-def shared_core(prompt: str) -> str:
+def shared_core(prompt: str, skeleton: SkeletonSpec) -> str:
     """The operating block with every merchant slot normalized."""
-    _, op = split_prompt(prompt)
-    sizing_end = op.find(SIZING_END)
-    if sizing_end >= 0:
-        sizing_start = op.rfind("\n### ", 0, sizing_end)
-        if sizing_start >= 0:
-            op = op[:sizing_start] + "\n<SIZING>" + op[sizing_end:]
-    op = _LINK_EXAMPLE.sub("<LINK>", op)
-    op = _LINK_PHRASE.sub("<LINKPHRASE>", op)
-    op = _NAMED.sub("- **Named product or line** <NAMED>", op)
-    op = _BROAD.sub("- **Broad ask** <BROAD>", op)
-    op = _AXES.sub("ONE grounded question <AXES>", op)
-    op = _COMPLETES.sub("(checkout, or the one category that <COMPLETES>)", op)
-    op = _CHIPS.sub("narrowing filters right after a category <CHIPS>", op)
+    _, op = split_prompt(prompt, skeleton)
+    if skeleton.vertical_section_end:
+        section_end = op.find(skeleton.vertical_section_end)
+        if section_end >= 0:
+            section_start = op.rfind("\n### ", 0, section_end)
+            if section_start >= 0:
+                op = op[:section_start] + "\n<VERTICAL>" + op[section_end:]
+    for pattern, replacement in skeleton.slot_patterns:
+        op = pattern.sub(replacement, op)
     return op
 
 
-def core_hash(prompt: str) -> str:
+def core_hash(prompt: str, skeleton: SkeletonSpec) -> str:
     """Short, stable fingerprint of ``shared_core`` (what the fleet table shows)."""
-    return hashlib.sha256(shared_core(prompt).encode()).hexdigest()[:12]
+    return hashlib.sha256(shared_core(prompt, skeleton).encode()).hexdigest()[:12]
 
 
-__all__ = ["OPERATING_HEAD", "core_hash", "shared_core", "split_prompt"]
+__all__ = ["core_hash", "shared_core", "split_prompt"]

--- a/app/ai/voice/agents/breeze_buddy/assist/engine/research/providers/gemini.py
+++ b/app/ai/voice/agents/breeze_buddy/assist/engine/research/providers/gemini.py
@@ -22,10 +22,10 @@ from app.core.logger import logger
 DEFAULT_GEMINI_SCRAPER_PROMPT = (
     "You have access to internet search, URL context, and related online sources. "
     "Visit and analyze the provided website URL. Extract concise factual website "
-    "context for building an assistant. Include what the business sells or does, "
-    "key categories, important products or services, offers, shipping or delivery "
-    "information, returns or refunds, payment information, support or contact "
-    "details, trust claims, brand tone, and target audience when available. Use "
+    "context for building an assistant. Include what the business offers or does, "
+    "its main categories, notable offerings, current offers, delivery or fulfilment "
+    "information, cancellation or refund terms, payment information, support or "
+    "contact details, trust claims, brand tone, and target audience when available. Use "
     "only information found on the website or related online sources. Do not "
     "invent missing details."
 )

--- a/app/ai/voice/agents/breeze_buddy/assist/engine/skeleton.py
+++ b/app/ai/voice/agents/breeze_buddy/assist/engine/skeleton.py
@@ -1,0 +1,147 @@
+"""The prompt skeleton mechanism — markers, platform sections, slot normalization.
+
+What a skeleton CONTAINS is a vertical's business: the commerce vertical
+ships ``assist/commerce/skeleton.py`` (its slot phrases, its vertical-help
+section); a booking or transit vertical ships its own. The engine only
+knows the shape: a brand marker, an operating head, platform sections,
+and a table of slot patterns to normalize when comparing cores.
+
+A blueprint prompt is ``{{brand_identity_section}}`` followed by the shared
+operating block. Runs of platform-only text are wrapped INLINE in
+``{{#platform_section:<platform>}}…{{/platform_section}}`` so a build for
+that platform is byte-identical to the block without markers, and a build
+for any other platform drops the run. Adapters may also register the
+legacy marker pair they shipped before this syntax existed; the engine
+treats those exactly like the generic form.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Any, List, Mapping, Pattern, Set, Tuple
+
+BRAND_MARKER = "{{brand_identity_section}}"
+OPERATING_HEAD = "## Operating principles"
+SHOP_DOMAIN_PLACEHOLDER = "{{shop_domain}}"
+
+
+@dataclass(frozen=True)
+class SkeletonSpec:
+    """A vertical's prompt skeleton: what varies per merchant inside a shared core.
+
+    ``slot_patterns`` are (regex, replacement) pairs applied to the operating
+    block before hashing, so two prompts built from the same skeleton with
+    different merchant slots compare equal. ``vertical_section_end`` is the
+    heading that closes the merchant-specific help section (its heading text
+    varies per merchant, so the whole section is normalized away).
+    """
+
+    id: str
+    brand_marker: str = BRAND_MARKER
+    operating_head: str = OPERATING_HEAD
+    vertical_section_end: str | None = None
+    slot_patterns: Tuple[Tuple[Pattern[str], str], ...] = field(default_factory=tuple)
+
+
+SECTION_END = "{{/platform_section}}"
+_SECTION_START = re.compile(r"\{\{#platform_section:([a-z0-9_-]+)\}\}")
+
+# start marker -> (platform id, end marker); adapters contribute their legacy pairs
+LegacyMarkers = Mapping[str, Tuple[str, str]]
+
+
+@dataclass(frozen=True)
+class PlatformSection:
+    platform: str
+    start: int  # index of the start marker
+    body_start: int  # first char after the start marker
+    body_end: int  # index of the end marker
+    end: int  # first char after the end marker
+
+
+def platform_sections(
+    prompt: str, legacy: LegacyMarkers | None = None
+) -> List[PlatformSection]:
+    """Every platform section in order; ``ValueError`` when malformed.
+
+    Each start must be closed by its own end marker before the next start;
+    an end marker without a start is a stray. Zero sections is legal — a
+    blueprint for a platform without tools has nothing to wrap.
+    """
+    legacy = dict(legacy or {})
+    starts: List[Tuple[int, int, str, str]] = []  # (index, len, platform, end marker)
+    for match in _SECTION_START.finditer(prompt):
+        starts.append((match.start(), len(match.group(0)), match.group(1), SECTION_END))
+    for marker, (platform, end_marker) in legacy.items():
+        position = 0
+        while True:
+            index = prompt.find(marker, position)
+            if index < 0:
+                break
+            starts.append((index, len(marker), platform, end_marker))
+            position = index + len(marker)
+    starts.sort()
+
+    sections: List[PlatformSection] = []
+    cursor = 0
+    for index, length, platform, end_marker in starts:
+        if index < cursor:
+            raise ValueError(f"nested platform section at {index}")
+        body_start = index + length
+        body_end = prompt.find(end_marker, body_start)
+        if body_end < 0:
+            raise ValueError(f"unterminated platform section {platform!r}")
+        end = body_end + len(end_marker)
+        sections.append(PlatformSection(platform, index, body_start, body_end, end))
+        cursor = end
+
+    expected_ends = len(sections)
+    end_markers = {SECTION_END} | {end for _, end in legacy.values()}
+    actual_ends = sum(prompt.count(marker) for marker in end_markers)
+    if actual_ends != expected_ends:
+        raise ValueError("stray platform section end marker")
+    return sections
+
+
+def resolve_platform_sections(
+    prompt: str, keep: Set[str], legacy: LegacyMarkers | None = None
+) -> str:
+    """Strip the markers of kept platforms' sections; remove every other section."""
+    resolved = prompt
+    for section in reversed(platform_sections(prompt, legacy)):
+        if section.platform in keep:
+            resolved = (
+                resolved[: section.start]
+                + resolved[section.body_start : section.body_end]
+                + resolved[section.end :]
+            )
+        else:
+            resolved = resolved[: section.start] + resolved[section.end :]
+    return resolved
+
+
+def fill_placeholders(value: Any, mapping: Mapping[str, str]) -> Any:
+    """Substitute every placeholder in every string of a blueprint value."""
+    if isinstance(value, str):
+        for placeholder, replacement in mapping.items():
+            value = value.replace(placeholder, replacement)
+        return value
+    if isinstance(value, list):
+        return [fill_placeholders(item, mapping) for item in value]
+    if isinstance(value, dict):
+        return {key: fill_placeholders(item, mapping) for key, item in value.items()}
+    return value
+
+
+__all__ = [
+    "BRAND_MARKER",
+    "OPERATING_HEAD",
+    "PlatformSection",
+    "SECTION_END",
+    "SHOP_DOMAIN_PLACEHOLDER",
+    "SkeletonSpec",
+    "fill_placeholders",
+    "platform_sections",
+    "resolve_platform_sections",
+]

--- a/app/ai/voice/agents/breeze_buddy/assist/onboarding/service.py
+++ b/app/ai/voice/agents/breeze_buddy/assist/onboarding/service.py
@@ -8,12 +8,15 @@ import re
 import secrets
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from typing import Any, AsyncIterator, Dict, List, Literal, Optional, Tuple
+from typing import Any, AsyncIterator, Dict, List, Literal, Optional, cast
 from urllib.parse import urlsplit
 from uuid import uuid4
 
 from pydantic import ValidationError
 
+from app.ai.voice.agents.breeze_buddy.assist.engine.identity import (
+    normalize_merchant_domain,
+)
 from app.ai.voice.agents.breeze_buddy.assist.engine.research.exceptions import (
     WebsiteScrapingConfigurationError,
     WebsiteScrapingUpstreamError,
@@ -21,10 +24,15 @@ from app.ai.voice.agents.breeze_buddy.assist.engine.research.exceptions import (
 from app.ai.voice.agents.breeze_buddy.assist.engine.research.website import (
     scrape_website,
 )
-from app.ai.voice.agents.breeze_buddy.assist.platforms.shopify.tenancy import (
-    assist_tenant,
-    normalize_merchant_domain,
+from app.ai.voice.agents.breeze_buddy.assist.engine.skeleton import (
+    BRAND_MARKER,
+    SHOP_DOMAIN_PLACEHOLDER,
+    fill_placeholders,
+    platform_sections,
+    resolve_platform_sections,
 )
+from app.ai.voice.agents.breeze_buddy.assist.platforms import registry
+from app.ai.voice.agents.breeze_buddy.assist.platforms.base import PlatformAdapter
 from app.ai.voice.agents.breeze_buddy.chat.sse import SSEEvent
 from app.ai.voice.agents.breeze_buddy.template.cache import invalidate_template
 from app.ai.voice.agents.breeze_buddy.template.types import TemplateModel
@@ -51,24 +59,12 @@ from app.schemas.breeze_buddy.assist.onboarding import (
     AssistOnboardingStreamRequest,
     AssistOnboardRequest,
     AssistOnboardResponse,
+    OnboardingPlatform,
 )
 from app.schemas.breeze_buddy.widget_config import WidgetConfigResponse
 
 DEFAULT_ASSIST_TEMPLATE_NAME = "buddy-assist-default"
-BRAND_IDENTITY_MARKER = "{{brand_identity_section}}"
-SHOPIFY_OPERATING_START_MARKER = "{{#shopify_operating_section}}"
-SHOPIFY_OPERATING_END_MARKER = "{{/shopify_operating_section}}"
-SHOPIFY_MCP_SERVER_NAME = "shopify-storefront"
-# The fleet's live templates name the storefront MCP server
-# ``shopify-storefront-ucp``; the first blueprint used the short form. Both
-# point at ``https://{shop_url}/api/ucp/mcp`` and are treated as the same.
-SHOPIFY_MCP_SERVER_NAMES = frozenset(
-    {SHOPIFY_MCP_SERVER_NAME, "shopify-storefront-ucp"}
-)
-# Substituted with the storefront host everywhere a blueprint string carries
-# it (checkout / cart URLs, trusted links, tool UI hints, the LinkButton
-# example in the prompt).
-SHOP_DOMAIN_PLACEHOLDER = "{{shop_domain}}"
+BRAND_IDENTITY_MARKER = BRAND_MARKER
 # The skeleton every live Assist template runs on (plan §3.1); drift from it
 # is logged, not fatal — see ``blueprint_shape_warnings``.
 EXPECTED_BLUEPRINT_MODEL = "gemini-3.6-flash"
@@ -137,7 +133,9 @@ def _configuration_dict(template: TemplateModel) -> Dict[str, Any]:
     )
 
 
-def _validate_default_template(template: TemplateModel) -> None:
+def _validate_default_template(
+    template: TemplateModel, adapter: PlatformAdapter
+) -> None:
     prompt = template.flow.get("system_prompt")
     if not isinstance(prompt, str):
         raise OnboardingFailure(
@@ -152,51 +150,22 @@ def _validate_default_template(template: TemplateModel) -> None:
             "Default Assist template has an invalid brand marker.",
         )
     try:
-        _shopify_sections(prompt)
+        platform_sections(prompt, registry.legacy_section_markers())
     except ValueError as exc:
         raise OnboardingFailure(
             "loading_default_template",
             "DEFAULT_TEMPLATE_INVALID",
-            f"Default Assist template has an invalid Shopify section ({exc}).",
+            f"Default Assist template has an invalid platform section ({exc}).",
         ) from exc
+    problems = adapter.validate_blueprint(prompt, _configuration_dict(template))
+    if problems:
+        raise OnboardingFailure(
+            "loading_default_template",
+            "DEFAULT_TEMPLATE_INVALID",
+            f"Default Assist template is not usable for {adapter.id}: {problems[0]}.",
+        )
     for warning in blueprint_shape_warnings(template):
         logger.warning(f"Assist blueprint {template.id} shape drift: {warning}")
-
-
-def _shopify_sections(prompt: str) -> List[Tuple[int, int]]:
-    """Spans of every ``{{#shopify_operating_section}}…{{/…}}`` pair, in order.
-
-    A blueprint may wrap more than one run of Shopify-only sections: the
-    fleet's operating block interleaves them with generic ones, and a
-    Shopify build has to stay byte-identical to that block, so the markers
-    sit inline around each run rather than around one reordered chunk.
-    Each start must be closed before the next one opens; at least one pair.
-    """
-    spans: List[Tuple[int, int]] = []
-    position = 0
-    while True:
-        start = prompt.find(SHOPIFY_OPERATING_START_MARKER, position)
-        if start < 0:
-            break
-        end = prompt.find(SHOPIFY_OPERATING_END_MARKER, start)
-        if end < 0:
-            raise ValueError("unterminated Shopify section")
-        if (
-            prompt.find(
-                SHOPIFY_OPERATING_START_MARKER,
-                start + len(SHOPIFY_OPERATING_START_MARKER),
-                end,
-            )
-            >= 0
-        ):
-            raise ValueError("nested Shopify section")
-        spans.append((start, end + len(SHOPIFY_OPERATING_END_MARKER)))
-        position = spans[-1][1]
-    if not spans:
-        raise ValueError("no Shopify section")
-    if prompt.count(SHOPIFY_OPERATING_END_MARKER) != len(spans):
-        raise ValueError("stray Shopify section end marker")
-    return spans
 
 
 def blueprint_shape_warnings(template: TemplateModel) -> List[str]:
@@ -227,29 +196,6 @@ def blueprint_shape_warnings(template: TemplateModel) -> List[str]:
     return warnings
 
 
-def _resolve_shopify_prompt_section(prompt: str, is_shopify: bool) -> str:
-    """Keep or remove every Shopify block authored in the DB blueprint."""
-    if is_shopify:
-        return prompt.replace(SHOPIFY_OPERATING_START_MARKER, "").replace(
-            SHOPIFY_OPERATING_END_MARKER, ""
-        )
-    resolved = prompt
-    for start, end in reversed(_shopify_sections(prompt)):
-        resolved = resolved[:start] + resolved[end:]
-    return resolved
-
-
-def _fill_placeholders(value: Any, shop_host: str) -> Any:
-    """Substitute ``{{shop_domain}}`` in every string of a blueprint value."""
-    if isinstance(value, str):
-        return value.replace(SHOP_DOMAIN_PLACEHOLDER, shop_host)
-    if isinstance(value, list):
-        return [_fill_placeholders(item, shop_host) for item in value]
-    if isinstance(value, dict):
-        return {key: _fill_placeholders(item, shop_host) for key, item in value.items()}
-    return value
-
-
 def build_merchant_template(
     *,
     default_template: TemplateModel,
@@ -257,56 +203,42 @@ def build_merchant_template(
     website_context: str,
     template_id: str,
     existing_template: Optional[TemplateModel],
+    adapter: PlatformAdapter,
 ) -> TemplateModel:
-    """Build a merchant template from the DB blueprint without mutating it."""
+    """Build a merchant template from the DB blueprint without mutating it.
+
+    Platform-blind: the adapter decides which prompt sections, MCP servers,
+    config entries and payload keys survive; everything another platform
+    owns is dropped.
+    """
     flow = copy.deepcopy(default_template.flow)
     prompt = flow.get("system_prompt")
-    _validate_default_template(default_template)
+    _validate_default_template(default_template, adapter)
     assert isinstance(prompt, str)
 
     prompt = prompt.replace(
         BRAND_IDENTITY_MARKER, _brand_identity(body, website_context), 1
     )
-    prompt = _resolve_shopify_prompt_section(prompt, body.is_shopify)
+    prompt = resolve_platform_sections(
+        prompt, {adapter.id}, registry.legacy_section_markers()
+    )
     flow["system_prompt"] = prompt
 
     configurations = _configuration_dict(default_template)
     mcp = copy.deepcopy(configurations.get("mcp") or {})
+    foreign_servers = registry.foreign_mcp_server_names(adapter)
     servers = [
         server
         for server in list(mcp.get("servers") or [])
-        if server.get("name") not in SHOPIFY_MCP_SERVER_NAMES
+        if server.get("name") not in foreign_servers
     ]
-    if body.is_shopify:
-        shopify_servers = [
-            server
-            for server in list(mcp.get("servers") or [])
-            if server.get("name") in SHOPIFY_MCP_SERVER_NAMES
-        ]
-        if len(shopify_servers) != 1:
-            raise OnboardingFailure(
-                "building_template",
-                "DEFAULT_TEMPLATE_INVALID",
-                "Default Assist template must contain one Shopify MCP server.",
-            )
-        if not configurations.get("state_reducers") or not configurations.get(
-            "tool_arg_injection"
-        ):
-            raise OnboardingFailure(
-                "building_template",
-                "DEFAULT_TEMPLATE_INVALID",
-                "Default Assist template is missing Shopify cart state configuration.",
-            )
-        servers.append(shopify_servers[0])
     if servers:
         mcp["servers"] = servers
         configurations["mcp"] = mcp
     else:
         configurations.pop("mcp", None)
-    if not body.is_shopify:
-        configurations.pop("state_reducers", None)
-        configurations.pop("tool_arg_injection", None)
-        configurations.pop("client_context", None)
+    for key in registry.foreign_tool_config_keys(adapter):
+        configurations.pop(key, None)
 
     expected_payload_schema = copy.deepcopy(
         default_template.expected_payload_schema or {}
@@ -316,8 +248,8 @@ def build_merchant_template(
         "example": _shop_host(body.website_url),
         "description": "Storefront domain used by the assistant's commerce tools.",
     }
-    if not body.is_shopify:
-        expected_payload_schema.pop("shopify_customer_token", None)
+    for key in registry.foreign_payload_keys(adapter):
+        expected_payload_schema.pop(key, None)
 
     persisted_secrets = (
         copy.deepcopy(
@@ -328,9 +260,9 @@ def build_merchant_template(
     # Provides a server-owned fallback; a widget session payload may override it.
     persisted_secrets["shop_url"] = _shop_host(body.website_url)
 
-    shop_host = _shop_host(body.website_url)
-    flow["system_prompt"] = _fill_placeholders(flow["system_prompt"], shop_host)
-    configurations = _fill_placeholders(configurations, shop_host)
+    placeholders = {SHOP_DOMAIN_PLACEHOLDER: _shop_host(body.website_url)}
+    flow["system_prompt"] = fill_placeholders(flow["system_prompt"], placeholders)
+    configurations = fill_placeholders(configurations, placeholders)
 
     candidate = TemplateModel(
         id=template_id,
@@ -537,9 +469,10 @@ async def onboard_assist_bare(body: AssistOnboardRequest) -> AssistOnboardRespon
     results, and the merchant personalizes later from the Buddy dashboard.
     Raises ``OnboardingFailure``; the route maps it to HTTP.
     """
+    adapter = registry.for_host_app(body.host_app)
     merchant_domain = normalize_merchant_domain(body.merchant_domain)
-    reseller_id, merchant_id = assist_tenant(body.host_app, merchant_domain)
-    merchant_name = body.merchant_name or merchant_domain.removesuffix(".myshopify.com")
+    reseller_id, merchant_id = adapter.tenant(body.host_app, merchant_domain)
+    merchant_name = body.merchant_name or adapter.store_name(merchant_domain)
     origins = [f"https://{merchant_domain}"] + [
         origin
         for origin in body.allowed_origins
@@ -556,7 +489,7 @@ async def onboard_assist_bare(body: AssistOnboardRequest) -> AssistOnboardRespon
         merchant_id=merchant_id,
         merchant_name=merchant_name,
         website_url=f"https://{merchant_domain}",
-        is_shopify=True,
+        platform=cast(OnboardingPlatform, adapter.request_platform),
         allowed_origins=origins,
         bot_brand_name=body.bot_brand_name,
         is_active=body.is_active,
@@ -613,7 +546,7 @@ async def onboard_assist_bare(body: AssistOnboardRequest) -> AssistOnboardRespon
                 "DEFAULT_TEMPLATE_NOT_FOUND",
                 "The default Assist template is not configured for this reseller.",
             )
-        _validate_default_template(default_template)
+        _validate_default_template(default_template, adapter)
 
         candidate = build_merchant_template(
             default_template=default_template,
@@ -621,6 +554,7 @@ async def onboard_assist_bare(body: AssistOnboardRequest) -> AssistOnboardRespon
             website_context=_BARE_WEBSITE_CONTEXT,
             template_id=str(uuid4()),
             existing_template=None,
+            adapter=adapter,
         )
         persisted_template = await _create_template(candidate)
         created_template_id = persisted_template.id
@@ -669,6 +603,7 @@ async def stream_assist_onboarding(
     body: AssistOnboardingStreamRequest,
 ) -> AsyncIterator[SSEEvent]:
     """Run onboarding and emit structured progress until complete or error."""
+    adapter = registry.for_request(body.platform)
     created_template_id: Optional[str] = None
     step = "checking_widget"
     try:
@@ -718,8 +653,8 @@ async def stream_assist_onboarding(
                 "DEFAULT_TEMPLATE_NOT_FOUND",
                 "The default Assist template is not configured for this reseller.",
             )
-        _validate_default_template(default_template)
-        yield _progress(step, "done")
+        _validate_default_template(default_template, adapter)
+        yield _progress(step, "done", platform=adapter.id)
 
         step = "scraping_website"
         yield _progress(step, "running", provider=body.provider)
@@ -774,8 +709,9 @@ async def stream_assist_onboarding(
             website_context=website_context,
             template_id=template_id,
             existing_template=existing_template,
+            adapter=adapter,
         )
-        yield _progress(step, "done", shopify_enabled=body.is_shopify)
+        yield _progress(step, "done", platform=adapter.id)
 
         step = "saving_configuration"
         yield _progress(step, "running")
@@ -878,12 +814,8 @@ async def stream_assist_onboarding(
 __all__ = [
     "BRAND_IDENTITY_MARKER",
     "DEFAULT_ASSIST_TEMPLATE_NAME",
-    "SHOPIFY_OPERATING_END_MARKER",
-    "SHOPIFY_OPERATING_START_MARKER",
     "EXPECTED_BLUEPRINT_MODEL",
     "OnboardingFailure",
-    "SHOPIFY_MCP_SERVER_NAME",
-    "SHOPIFY_MCP_SERVER_NAMES",
     "SHOP_DOMAIN_PLACEHOLDER",
     "blueprint_shape_warnings",
     "build_merchant_template",

--- a/app/ai/voice/agents/breeze_buddy/assist/platforms/base.py
+++ b/app/ai/voice/agents/breeze_buddy/assist/platforms/base.py
@@ -2,12 +2,15 @@
 
 Rule (ASSIST-ENGINE-DESIGN.md §1): the engine works on any public website
 with ZERO adapters — ``GenericAdapter`` is that behaviour. A platform adds
-by overriding hooks, never by forking a stage.
+by overriding hooks, never by forking a stage. Everything a build stage
+used to branch on is a hook here: which prompt sections to keep, which MCP
+servers and config entries belong to the platform, which payload keys it
+needs, how a host app maps to a tenant, how a blueprint must look.
 """
 
 from __future__ import annotations
 
-from typing import List, Protocol, Sequence
+from typing import FrozenSet, List, Mapping, Protocol, Sequence, Tuple
 from urllib.parse import urlsplit
 
 from app.ai.voice.agents.breeze_buddy.assist.engine.models import (
@@ -16,31 +19,48 @@ from app.ai.voice.agents.breeze_buddy.assist.engine.models import (
     ResearchDelta,
     Signal,
     SiteProfile,
-    StoreResearch,
+    SiteResearch,
     TenantIdentity,
     ToolBinding,
 )
+from app.ai.voice.agents.breeze_buddy.assist.engine.skeleton import LegacyMarkers
 
 
 class PlatformAdapter(Protocol):
     id: str
+    request_platform: str
+    host_apps: Tuple[str, ...]
 
     def classify(self, signals: Sequence[Signal]) -> float: ...
 
     def identity(self, profile: SiteProfile) -> TenantIdentity: ...
 
+    def tenant(self, host_app: str, merchant_domain: str) -> Tuple[str, str]: ...
+
+    def store_name(self, merchant_domain: str) -> str: ...
+
     async def research(
         self, profile: SiteProfile, budget_seconds: float
     ) -> ResearchDelta: ...
 
-    def operating_sections(self) -> List[str]: ...
+    def legacy_section_markers(self) -> LegacyMarkers: ...
+
+    def validate_blueprint(
+        self, prompt: str, configurations: Mapping[str, object]
+    ) -> List[str]: ...
+
+    def mcp_server_names(self) -> FrozenSet[str]: ...
+
+    def tool_config_keys(self) -> Tuple[str, ...]: ...
+
+    def payload_keys(self) -> Tuple[str, ...]: ...
 
     def tools(
-        self, identity: TenantIdentity, research: StoreResearch
+        self, identity: TenantIdentity, research: SiteResearch
     ) -> List[ToolBinding]: ...
 
     def extra_origins(
-        self, identity: TenantIdentity, research: StoreResearch
+        self, identity: TenantIdentity, research: SiteResearch
     ) -> List[str]: ...
 
     def mirror_policy(self) -> MirrorPolicy: ...
@@ -68,6 +88,10 @@ class GenericAdapter:
     """Any public website: no platform facts, catalogue from research only."""
 
     id = "generic"
+    # The value the onboarding API uses for this adapter (``platform`` field).
+    request_platform = "web"
+    # Host apps (install-time callers) that land on this adapter: none.
+    host_apps: Tuple[str, ...] = ()
 
     def classify(self, signals: Sequence[Signal]) -> float:
         return 0.0
@@ -76,26 +100,46 @@ class GenericAdapter:
         host = (urlsplit(profile.final_url or profile.url).hostname or "").lower()
         return TenantIdentity(platform=self.id, canonical_host=host)
 
+    def tenant(self, host_app: str, merchant_domain: str) -> Tuple[str, str]:
+        raise ValueError(f"host app {host_app!r} has no tenant namespace on {self.id}")
+
+    def store_name(self, merchant_domain: str) -> str:
+        return merchant_domain
+
     async def research(
         self, profile: SiteProfile, budget_seconds: float
     ) -> ResearchDelta:
         return ResearchDelta()
 
-    def operating_sections(self) -> List[str]:
+    def legacy_section_markers(self) -> LegacyMarkers:
+        return {}
+
+    def validate_blueprint(
+        self, prompt: str, configurations: Mapping[str, object]
+    ) -> List[str]:
         return []
 
+    def mcp_server_names(self) -> FrozenSet[str]:
+        return frozenset()
+
+    def tool_config_keys(self) -> Tuple[str, ...]:
+        return ()
+
+    def payload_keys(self) -> Tuple[str, ...]:
+        return ()
+
     def tools(
-        self, identity: TenantIdentity, research: StoreResearch
+        self, identity: TenantIdentity, research: SiteResearch
     ) -> List[ToolBinding]:
         return []
 
     def extra_origins(
-        self, identity: TenantIdentity, research: StoreResearch
+        self, identity: TenantIdentity, research: SiteResearch
     ) -> List[str]:
         return list(research.extra_origins)
 
     def mirror_policy(self) -> MirrorPolicy:
-        return MirrorPolicy(blocked_paths=list(_GENERIC_BLOCKED), cart_handoff="link")
+        return MirrorPolicy(blocked_paths=list(_GENERIC_BLOCKED), handoff="link")
 
     def install(self) -> InstallMethod:
         return "snippet"

--- a/app/ai/voice/agents/breeze_buddy/assist/platforms/registry.py
+++ b/app/ai/voice/agents/breeze_buddy/assist/platforms/registry.py
@@ -1,14 +1,16 @@
 """The platform registry — the engine's only door to a platform.
 
 Adding a platform is a package under ``platforms/`` plus one entry here.
-Stages call ``resolve`` / ``classify``; they never import an adapter module.
+Stages call ``resolve`` / ``classify`` / ``for_request`` / ``for_host_app``;
+they never import an adapter module, and they never name a platform.
 """
 
 from __future__ import annotations
 
-from typing import Sequence, Tuple
+from typing import Dict, FrozenSet, Optional, Sequence, Tuple
 
 from app.ai.voice.agents.breeze_buddy.assist.engine.models import Signal
+from app.ai.voice.agents.breeze_buddy.assist.engine.skeleton import LegacyMarkers
 from app.ai.voice.agents.breeze_buddy.assist.platforms.base import PlatformAdapter
 from app.ai.voice.agents.breeze_buddy.assist.platforms.generic.adapter import (
     adapter as generic,
@@ -30,6 +32,22 @@ def resolve(adapter_id: str) -> PlatformAdapter:
     raise KeyError(f"unknown platform adapter: {adapter_id!r}")
 
 
+def for_request(platform: Optional[str]) -> PlatformAdapter:
+    """The adapter behind an onboarding request's ``platform`` value."""
+    for adapter in PLATFORMS:
+        if adapter.request_platform == platform:
+            return adapter
+    return generic
+
+
+def for_host_app(host_app: str) -> PlatformAdapter:
+    """The adapter an install-time caller (a host app) lands on."""
+    for adapter in PLATFORMS:
+        if host_app in adapter.host_apps:
+            return adapter
+    raise KeyError(f"no platform adapter for host app {host_app!r}")
+
+
 def classify(signals: Sequence[Signal]) -> Tuple[PlatformAdapter, float]:
     """(adapter, confidence) for a probe's signals; ``generic`` below threshold."""
     best, best_score = generic, 0.0
@@ -42,4 +60,49 @@ def classify(signals: Sequence[Signal]) -> Tuple[PlatformAdapter, float]:
     return best, best_score
 
 
-__all__ = ["CLASSIFY_THRESHOLD", "PLATFORMS", "classify", "resolve"]
+def legacy_section_markers() -> LegacyMarkers:
+    """Every legacy marker pair any platform still ships in its blueprints."""
+    merged: Dict[str, Tuple[str, str]] = {}
+    for adapter in PLATFORMS:
+        merged.update(adapter.legacy_section_markers())
+    return merged
+
+
+def foreign_mcp_server_names(adapter: PlatformAdapter) -> FrozenSet[str]:
+    """MCP server names owned by OTHER platforms — a build drops those."""
+    names: set[str] = set()
+    for other in PLATFORMS:
+        if other.id != adapter.id:
+            names |= set(other.mcp_server_names())
+    return frozenset(names - set(adapter.mcp_server_names()))
+
+
+def foreign_tool_config_keys(adapter: PlatformAdapter) -> Tuple[str, ...]:
+    keys = [
+        k
+        for other in PLATFORMS
+        if other.id != adapter.id
+        for k in other.tool_config_keys()
+    ]
+    return tuple(dict.fromkeys(k for k in keys if k not in adapter.tool_config_keys()))
+
+
+def foreign_payload_keys(adapter: PlatformAdapter) -> Tuple[str, ...]:
+    keys = [
+        k for other in PLATFORMS if other.id != adapter.id for k in other.payload_keys()
+    ]
+    return tuple(dict.fromkeys(k for k in keys if k not in adapter.payload_keys()))
+
+
+__all__ = [
+    "CLASSIFY_THRESHOLD",
+    "PLATFORMS",
+    "classify",
+    "for_host_app",
+    "for_request",
+    "foreign_mcp_server_names",
+    "foreign_payload_keys",
+    "foreign_tool_config_keys",
+    "legacy_section_markers",
+    "resolve",
+]

--- a/app/ai/voice/agents/breeze_buddy/assist/platforms/shopify/adapter.py
+++ b/app/ai/voice/agents/breeze_buddy/assist/platforms/shopify/adapter.py
@@ -1,14 +1,15 @@
 """ShopifyAdapter — every build-time Shopify fact, in one place.
 
-Signals, the permanent-domain identity rule, the prompt sections that only
-make sense with the storefront MCP, the tool binding, the mirror policy
-and the install method. Research fetchers (``sources.py``) arrive with the
-engine's research stage.
+Signals, the permanent-domain identity rule, the host-app tenancy table,
+the prompt sections that only make sense with the storefront MCP, the MCP
+server names, the cart-state config entries, the customer-token payload
+key, the blueprint requirements, the mirror policy and the install method.
+Research fetchers (``sources.py``) arrive with the engine's research stage.
 """
 
 from __future__ import annotations
 
-from typing import List, Sequence
+from typing import FrozenSet, List, Mapping, Sequence, Tuple
 from urllib.parse import urlsplit
 
 from app.ai.voice.agents.breeze_buddy.assist.engine.models import (
@@ -16,11 +17,18 @@ from app.ai.voice.agents.breeze_buddy.assist.engine.models import (
     MirrorPolicy,
     Signal,
     SiteProfile,
-    StoreResearch,
+    SiteResearch,
     TenantIdentity,
     ToolBinding,
 )
+from app.ai.voice.agents.breeze_buddy.assist.engine.skeleton import (
+    LegacyMarkers,
+    platform_sections,
+)
 from app.ai.voice.agents.breeze_buddy.assist.platforms.base import GenericAdapter
+from app.ai.voice.agents.breeze_buddy.assist.platforms.shopify.tenancy import (
+    assist_tenant,
+)
 
 # (kind, pattern, weight) — verified live on hustleculture.co.in 2026-09-08.
 SIGNALS = (
@@ -34,13 +42,34 @@ SIGNALS = (
     ("meta", "shopify-digital-wallet", 3.0),
 )
 CONFIDENCE_DENOMINATOR = 10.0
+
+# The fleet's live templates name the storefront MCP server
+# ``shopify-storefront-ucp``; the first blueprint used the short form. Both
+# point at ``https://{shop_url}/api/ucp/mcp`` and are treated as the same.
 MCP_SERVER_NAME = "shopify-storefront-ucp"
+MCP_SERVER_NAMES: FrozenSet[str] = frozenset({"shopify-storefront", MCP_SERVER_NAME})
 MCP_URL = "https://{shop_url}/api/ucp/mcp"
 OPERATING_SECTION = "shopify_operating_section"
+# The marker pair the first blueprints shipped with; the engine reads it as
+# ``{{#platform_section:shopify}}…{{/platform_section}}``.
+LEGACY_SECTION_START = "{{#shopify_operating_section}}"
+LEGACY_SECTION_END = "{{/shopify_operating_section}}"
+# Cart state plumbing that only means something next to the UCP tools.
+TOOL_CONFIG_KEYS: Tuple[str, ...] = (
+    "state_reducers",
+    "tool_arg_injection",
+    "client_context",
+)
+# Payload keys the storefront session may carry beyond the generic ``shop_url``.
+PAYLOAD_KEYS: Tuple[str, ...] = ("shopify_customer_token",)
+PERMANENT_DOMAIN_SUFFIX = ".myshopify.com"
 
 
 class ShopifyAdapter(GenericAdapter):
     id = "shopify"
+    request_platform = "shopify"
+    # The two Shopify apps that install Assist (see tenancy.py for the namespaces).
+    host_apps: Tuple[str, ...] = ("breeze-buddy", "buddy-assist")
 
     def classify(self, signals: Sequence[Signal]) -> float:
         score = 0.0
@@ -63,16 +92,58 @@ class ShopifyAdapter(GenericAdapter):
             platform=self.id, canonical_host=host, permanent_host=permanent
         )
 
-    def operating_sections(self) -> List[str]:
-        return [OPERATING_SECTION]
+    def tenant(self, host_app: str, merchant_domain: str) -> Tuple[str, str]:
+        if host_app not in self.host_apps:
+            raise ValueError(f"host app {host_app!r} is not a Shopify app")
+        return assist_tenant(host_app, merchant_domain)  # type: ignore[arg-type]
+
+    def store_name(self, merchant_domain: str) -> str:
+        return merchant_domain.removesuffix(PERMANENT_DOMAIN_SUFFIX)
+
+    def legacy_section_markers(self) -> LegacyMarkers:
+        return {LEGACY_SECTION_START: (self.id, LEGACY_SECTION_END)}
+
+    def validate_blueprint(
+        self, prompt: str, configurations: Mapping[str, object]
+    ) -> List[str]:
+        problems: List[str] = []
+        try:
+            sections = platform_sections(prompt, self.legacy_section_markers())
+        except ValueError as exc:
+            return [f"invalid platform section: {exc}"]
+        if not any(section.platform == self.id for section in sections):
+            problems.append("no Shopify section in the operating block")
+        mcp = configurations.get("mcp") or {}
+        servers = list((mcp.get("servers") if isinstance(mcp, Mapping) else None) or [])
+        named = [
+            s
+            for s in servers
+            if isinstance(s, Mapping) and s.get("name") in MCP_SERVER_NAMES
+        ]
+        if len(named) != 1:
+            problems.append("must contain exactly one Shopify storefront MCP server")
+        if not configurations.get("state_reducers") or not configurations.get(
+            "tool_arg_injection"
+        ):
+            problems.append("missing Shopify cart state configuration")
+        return problems
+
+    def mcp_server_names(self) -> FrozenSet[str]:
+        return MCP_SERVER_NAMES
+
+    def tool_config_keys(self) -> Tuple[str, ...]:
+        return TOOL_CONFIG_KEYS
+
+    def payload_keys(self) -> Tuple[str, ...]:
+        return PAYLOAD_KEYS
 
     def tools(
-        self, identity: TenantIdentity, research: StoreResearch
+        self, identity: TenantIdentity, research: SiteResearch
     ) -> List[ToolBinding]:
         return [ToolBinding(kind="mcp", name=MCP_SERVER_NAME, url=MCP_URL)]
 
     def extra_origins(
-        self, identity: TenantIdentity, research: StoreResearch
+        self, identity: TenantIdentity, research: SiteResearch
     ) -> List[str]:
         origins = list(research.extra_origins)
         if identity.permanent_host:
@@ -100,7 +171,7 @@ class ShopifyAdapter(GenericAdapter):
                 "/?section_id=",
             ],
             cdn_hosts=["cdn.shopify.com", "fonts.shopifycdn.com"],
-            cart_handoff="permalink",
+            handoff="permalink",
             section_probe=True,
         )
 
@@ -111,10 +182,15 @@ class ShopifyAdapter(GenericAdapter):
 adapter = ShopifyAdapter()
 
 __all__ = [
+    "LEGACY_SECTION_END",
+    "LEGACY_SECTION_START",
     "MCP_SERVER_NAME",
+    "MCP_SERVER_NAMES",
     "MCP_URL",
     "OPERATING_SECTION",
+    "PAYLOAD_KEYS",
     "SIGNALS",
+    "TOOL_CONFIG_KEYS",
     "ShopifyAdapter",
     "adapter",
 ]

--- a/app/api/routers/breeze_buddy/assist/onboarding.py
+++ b/app/api/routers/breeze_buddy/assist/onboarding.py
@@ -7,15 +7,15 @@ from typing import AsyncIterator
 from fastapi import APIRouter, Depends, HTTPException, status
 from fastapi.responses import StreamingResponse
 
+from app.ai.voice.agents.breeze_buddy.assist.engine.identity import (
+    normalize_merchant_domain,
+)
 from app.ai.voice.agents.breeze_buddy.assist.onboarding.service import (
     OnboardingFailure,
     onboard_assist_bare,
     stream_assist_onboarding,
 )
-from app.ai.voice.agents.breeze_buddy.assist.platforms.shopify.tenancy import (
-    assist_tenant,
-    normalize_merchant_domain,
-)
+from app.ai.voice.agents.breeze_buddy.assist.platforms import registry
 from app.ai.voice.agents.breeze_buddy.chat.sse import format_sse
 from app.api.security.breeze_buddy.authorization import (
     validate_merchant_access,
@@ -72,11 +72,10 @@ async def onboard_assist(
 ) -> AssistOnboardResponse:
     """Bare-metal install-time onboarding (S2S, no personalization).
 
-    Same RBAC posture as the stream route; tenancy is derived
-    server-side from ``host_app`` + ``merchant_domain`` (breeze-buddy →
-    BB_SHOPIFY/plain domain; buddy-assist → BB_ASSIST/assist-prefixed),
-    so access is validated against the DERIVED ids — a caller cannot
-    smuggle a different namespace in.
+    Same RBAC posture as the stream route; tenancy is derived server-side
+    from ``host_app`` + ``merchant_domain`` by the platform adapter that
+    host app lands on, so access is validated against the DERIVED ids — a
+    caller cannot smuggle a different namespace in.
     """
     require_role(current_user, [UserRole.ADMIN, UserRole.RESELLER])
     try:
@@ -85,7 +84,13 @@ async def onboard_assist(
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)
         ) from exc
-    reseller_id, merchant_id = assist_tenant(body.host_app, merchant_domain)
+    try:
+        adapter = registry.for_host_app(body.host_app)
+        reseller_id, merchant_id = adapter.tenant(body.host_app, merchant_domain)
+    except (KeyError, ValueError) as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)
+        ) from exc
     validate_reseller_access(current_user, reseller_id=reseller_id)
     validate_merchant_access(current_user, merchant_id=merchant_id)
 

--- a/app/schemas/breeze_buddy/assist/onboarding.py
+++ b/app/schemas/breeze_buddy/assist/onboarding.py
@@ -49,6 +49,9 @@ def _public_https_url(value: str, *, origin_only: bool) -> str:
     )
 
 
+OnboardingPlatform = Literal["shopify", "web"]
+
+
 class AssistOnboardingStreamRequest(BaseModel):
     """Request body for the Buddy Assist onboarding stream."""
 
@@ -56,12 +59,15 @@ class AssistOnboardingStreamRequest(BaseModel):
     merchant_id: str = Field(..., min_length=1, max_length=255)
     merchant_name: str = Field(..., min_length=1, max_length=255)
     website_url: str = Field(..., max_length=2048)
-    is_shopify: bool
+    is_shopify: Optional[bool] = Field(
+        None,
+        description="Legacy alias of ``platform`` (true = shopify, false = web).",
+    )
     allowed_origins: List[str] = Field(..., max_length=20)
     provider: Literal["google"] = "google"
     bot_brand_name: Optional[str] = Field(None, min_length=1, max_length=255)
     is_active: bool = True
-    platform: Optional[Literal["shopify", "web"]] = Field(
+    platform: Optional[OnboardingPlatform] = Field(
         None,
         description=(
             "Storefront platform. Optional alias of ``is_shopify`` for callers "
@@ -81,10 +87,17 @@ class AssistOnboardingStreamRequest(BaseModel):
 
     @model_validator(mode="after")
     def _platform_agrees_with_is_shopify(self) -> "AssistOnboardingStreamRequest":
-        if (
-            self.platform is not None
-            and (self.platform == "shopify") != self.is_shopify
-        ):
+        """One of ``platform`` / ``is_shopify`` is required; both must agree.
+
+        After validation both are set, so callers may read either.
+        """
+        if self.platform is None and self.is_shopify is None:
+            raise ValueError("platform is required")
+        if self.platform is None:
+            self.platform = "shopify" if self.is_shopify else "web"
+        elif self.is_shopify is None:
+            self.is_shopify = self.platform == "shopify"
+        elif (self.platform == "shopify") != self.is_shopify:
             raise ValueError("platform and is_shopify disagree")
         return self
 
@@ -202,6 +215,7 @@ class AssistOnboardingCompletion(BaseModel):
 
 
 __all__ = [
+    "OnboardingPlatform",
     "AssistOnboardRequest",
     "AssistOnboardResponse",
     "AssistOnboardingCompletion",

--- a/tests/assist/engine/test_no_platform_forks.py
+++ b/tests/assist/engine/test_no_platform_forks.py
@@ -1,19 +1,44 @@
-"""The engine never names a platform (ASSIST-ENGINE-DESIGN.md §1 rule 2)."""
+"""The engine never names a platform, and never speaks a vertical's vocabulary.
+
+ASSIST-ENGINE-DESIGN.md §1: platform facts live in ``assist/platforms/<name>/``
+only; the engine, the onboarding surface and the assist HTTP surface are
+platform-blind. The engine is also vertical-blind — a booking or transit
+assistant must run on it unchanged — so commerce words belong to
+``assist/commerce/``, never to ``assist/engine/``.
+"""
 
 import pathlib
 import re
 
-ENGINE = (
-    pathlib.Path(__file__).resolve().parents[3]
-    / "app/ai/voice/agents/breeze_buddy/assist/engine"
+ROOT = pathlib.Path(__file__).resolve().parents[3]
+ENGINE = ROOT / "app/ai/voice/agents/breeze_buddy/assist/engine"
+PLATFORM_BLIND = (
+    ENGINE,
+    ROOT / "app/ai/voice/agents/breeze_buddy/assist/onboarding",
+    ROOT / "app/api/routers/breeze_buddy/assist",
 )
-FORBIDDEN = re.compile(r"shopify|woocommerce|magento|bigcommerce", re.IGNORECASE)
+PLATFORM_WORDS = re.compile(r"shopify|woocommerce|magento|bigcommerce", re.IGNORECASE)
+VERTICAL_WORDS = re.compile(
+    r"\b(checkout|cart|product|products|collection|collections|sizing|catalog|catalogue)\b",
+    re.IGNORECASE,
+)
 
 
-def test_engine_has_no_platform_branches():
-    offenders = []
-    for path in ENGINE.rglob("*.py"):
-        for number, line in enumerate(path.read_text().splitlines(), 1):
-            if FORBIDDEN.search(line):
-                offenders.append(f"{path.relative_to(ENGINE)}:{number}: {line.strip()}")
-    assert not offenders, "platform names inside engine/:\n" + "\n".join(offenders)
+def _offenders(scopes, pattern):
+    found = []
+    for scope in scopes:
+        for path in scope.rglob("*.py"):
+            for number, line in enumerate(path.read_text().splitlines(), 1):
+                if pattern.search(line):
+                    found.append(f"{path.relative_to(ROOT)}:{number}: {line.strip()}")
+    return found
+
+
+def test_engine_onboarding_and_routes_name_no_platform():
+    offenders = _offenders(PLATFORM_BLIND, PLATFORM_WORDS)
+    assert not offenders, "platform names outside platforms/:\n" + "\n".join(offenders)
+
+
+def test_engine_has_no_vertical_vocabulary():
+    offenders = _offenders((ENGINE,), VERTICAL_WORDS)
+    assert not offenders, "vertical vocabulary inside engine/:\n" + "\n".join(offenders)

--- a/tests/assist/onboarding/test_bare.py
+++ b/tests/assist/onboarding/test_bare.py
@@ -17,6 +17,9 @@ import pytest
 from pydantic import ValidationError
 
 from app.ai.voice.agents.breeze_buddy.assist.onboarding import service
+from app.ai.voice.agents.breeze_buddy.assist.platforms.shopify import (
+    adapter as shopify_adapter,
+)
 from app.ai.voice.agents.breeze_buddy.assist.platforms.shopify.tenancy import (
     assist_tenant,
     assist_tenant_candidates,
@@ -54,10 +57,10 @@ def _default_template() -> TemplateModel:
             "system_prompt": (
                 f"{service.BRAND_IDENTITY_MARKER}\n\n"
                 "## Operating principles\n"
-                f"{service.SHOPIFY_OPERATING_START_MARKER}\n"
+                f"{shopify_adapter.LEGACY_SECTION_START}\n"
                 "### Shopify commerce tools\n"
                 "Use Shopify tools for live commerce facts.\n"
-                f"{service.SHOPIFY_OPERATING_END_MARKER}\n"
+                f"{shopify_adapter.LEGACY_SECTION_END}\n"
             ),
         },
         expected_payload_schema={
@@ -69,7 +72,7 @@ def _default_template() -> TemplateModel:
             "mcp": {
                 "servers": [
                     {
-                        "name": service.SHOPIFY_MCP_SERVER_NAME,
+                        "name": shopify_adapter.MCP_SERVER_NAME,
                         "url": "https://{shop_url}/api/mcp",
                         "auth": {"type": "none"},
                     }

--- a/tests/assist/onboarding/test_blueprint_v2.py
+++ b/tests/assist/onboarding/test_blueprint_v2.py
@@ -19,6 +19,8 @@ from unittest.mock import AsyncMock
 import pytest
 from pydantic import ValidationError
 
+from app.ai.voice.agents.breeze_buddy.assist.commerce.skeleton import COMMERCE_V2
+from app.ai.voice.agents.breeze_buddy.assist.engine import skeleton
 from app.ai.voice.agents.breeze_buddy.assist.engine.prompt_core import (
     core_hash,
     shared_core,
@@ -28,6 +30,10 @@ from app.ai.voice.agents.breeze_buddy.assist.engine.research.exceptions import (
     WebsiteScrapingUpstreamError,
 )
 from app.ai.voice.agents.breeze_buddy.assist.onboarding import service
+from app.ai.voice.agents.breeze_buddy.assist.platforms import registry
+from app.ai.voice.agents.breeze_buddy.assist.platforms.shopify import (
+    adapter as shopify_adapter,
+)
 from app.ai.voice.agents.breeze_buddy.template.types import TemplateModel
 from app.api.routers.breeze_buddy.assist.onboarding import _ONBOARDING_ROLES
 from app.schemas import UserRole
@@ -95,18 +101,21 @@ def _build(is_shopify: bool = True) -> TemplateModel:
         website_context="Sells premium sneakers.",
         template_id="00000000-0000-0000-0000-000000000002",
         existing_template=None,
+        adapter=registry.resolve("shopify" if is_shopify else "generic"),
     )
 
 
 def test_fixture_is_the_fleet_skeleton() -> None:
     blueprint = _blueprint()
-    service._validate_default_template(blueprint)
+    service._validate_default_template(blueprint, registry.resolve("shopify"))
     assert service.blueprint_shape_warnings(blueprint) == []
     prompt = blueprint.flow["system_prompt"]
     assert prompt.count(service.BRAND_IDENTITY_MARKER) == 1
-    assert len(service._shopify_sections(prompt)) == 2
+    assert (
+        len(skeleton.platform_sections(prompt, registry.legacy_section_markers())) == 2
+    )
     assert blueprint.configurations is not None
-    assert service.SHOP_DOMAIN_PLACEHOLDER in json.dumps(
+    assert skeleton.SHOP_DOMAIN_PLACEHOLDER in json.dumps(
         blueprint.configurations.model_dump()
     )
 
@@ -119,29 +128,29 @@ def test_shopify_build_lands_on_the_fleet_core() -> None:
     # markers gone, brand block filled, Shopify sections kept in place
     for marker in (
         service.BRAND_IDENTITY_MARKER,
-        service.SHOPIFY_OPERATING_START_MARKER,
-        service.SHOPIFY_OPERATING_END_MARKER,
-        service.SHOP_DOMAIN_PLACEHOLDER,
+        shopify_adapter.LEGACY_SECTION_START,
+        shopify_adapter.LEGACY_SECTION_END,
+        skeleton.SHOP_DOMAIN_PLACEHOLDER,
     ):
         assert marker not in prompt
-    brand, _ = split_prompt(prompt)
+    brand, _ = split_prompt(prompt, COMMERCE_V2)
     assert "{shop_url}" in brand and "Hustle Culture" in brand
     assert "### Tools — Universal Commerce Protocol" in prompt
     assert "### Cart-cookie sync (Shopify storefront)" in prompt
 
     # the operating core is byte-for-byte the blueprint's (slots normalized)
-    skeleton = blueprint.flow["system_prompt"]
-    skeleton = skeleton.replace(service.SHOPIFY_OPERATING_START_MARKER, "").replace(
-        service.SHOPIFY_OPERATING_END_MARKER, ""
+    reference = blueprint.flow["system_prompt"]
+    reference = reference.replace(shopify_adapter.LEGACY_SECTION_START, "").replace(
+        shopify_adapter.LEGACY_SECTION_END, ""
     )
-    assert shared_core(prompt) == shared_core(skeleton)
-    assert core_hash(prompt) == core_hash(skeleton)
+    assert shared_core(prompt, COMMERCE_V2) == shared_core(reference, COMMERCE_V2)
+    assert core_hash(prompt, COMMERCE_V2) == core_hash(reference, COMMERCE_V2)
 
     # {{shop_domain}} resolved everywhere in the config
     assert built.configurations is not None
     config = built.configurations.model_dump(mode="json", exclude_none=True)
     blob = json.dumps(config)
-    assert service.SHOP_DOMAIN_PLACEHOLDER not in blob
+    assert skeleton.SHOP_DOMAIN_PLACEHOLDER not in blob
     assert (
         config["ui_intents"]["urls"]["checkout_page"]
         == "https://hustleculture.co.in/cart"
@@ -151,7 +160,7 @@ def test_shopify_build_lands_on_the_fleet_core() -> None:
         in config["render_ui"]["trusted_link_urls"]
     )
     servers = config["mcp"]["servers"]
-    assert len(servers) == 1 and servers[0]["name"] in service.SHOPIFY_MCP_SERVER_NAMES
+    assert len(servers) == 1 and servers[0]["name"] in shopify_adapter.MCP_SERVER_NAMES
     assert (
         "https://hustleculture.co.in/cart"
         in servers[0]["tool_ui_instructions"]["get_cart"]["instructions"]
@@ -175,8 +184,8 @@ def test_generic_build_drops_every_shopify_section() -> None:
         "### Cart-cookie sync (Shopify storefront)",
         "### Review-and-checkout flow",
         "### Store policy / refunds / shipping / FAQ",
-        service.SHOPIFY_OPERATING_START_MARKER,
-        service.SHOPIFY_OPERATING_END_MARKER,
+        shopify_adapter.LEGACY_SECTION_START,
+        shopify_adapter.LEGACY_SECTION_END,
     ):
         assert gone not in prompt
     for kept in (
@@ -206,7 +215,7 @@ def test_marker_validation_rejects_bad_shapes(prompt: str) -> None:
     blueprint = _blueprint()
     blueprint.flow["system_prompt"] = prompt
     with pytest.raises(service.OnboardingFailure) as failure:
-        service._validate_default_template(blueprint)
+        service._validate_default_template(blueprint, registry.resolve("shopify"))
     assert failure.value.code == "DEFAULT_TEMPLATE_INVALID"
 
 
@@ -222,7 +231,9 @@ def test_old_shape_blueprint_only_warns() -> None:
     assert any("functions" in w for w in warnings)
     assert any("supported_channels" in w for w in warnings)
     assert any("gemini-2.5-flash" in w for w in warnings)
-    service._validate_default_template(old)  # tolerated until the data rows are v2
+    service._validate_default_template(
+        old, registry.resolve("shopify")
+    )  # tolerated until the data rows are v2
 
 
 def test_template_name_is_store_assist() -> None:

--- a/tests/assist/onboarding/test_stream.py
+++ b/tests/assist/onboarding/test_stream.py
@@ -11,6 +11,10 @@ from app.ai.voice.agents.breeze_buddy.assist.engine.research.website import (
     WebsiteScrapingResult,
 )
 from app.ai.voice.agents.breeze_buddy.assist.onboarding import service
+from app.ai.voice.agents.breeze_buddy.assist.platforms import registry
+from app.ai.voice.agents.breeze_buddy.assist.platforms.shopify import (
+    adapter as shopify_adapter,
+)
 from app.ai.voice.agents.breeze_buddy.template.types import TemplateModel
 from app.schemas.breeze_buddy.assist.onboarding import AssistOnboardingStreamRequest
 from app.schemas.breeze_buddy.widget_config import WidgetConfigResponse
@@ -44,10 +48,10 @@ def _default_template() -> TemplateModel:
             "system_prompt": (
                 f"{service.BRAND_IDENTITY_MARKER}\n\n"
                 "## Operating principles\n"
-                f"{service.SHOPIFY_OPERATING_START_MARKER}\n"
+                f"{shopify_adapter.LEGACY_SECTION_START}\n"
                 "### Shopify commerce tools\n"
                 "Use Shopify tools for live commerce facts.\n"
-                f"{service.SHOPIFY_OPERATING_END_MARKER}\n"
+                f"{shopify_adapter.LEGACY_SECTION_END}\n"
                 "{{ui_primitives_section}}"
             ),
         },
@@ -61,7 +65,7 @@ def _default_template() -> TemplateModel:
             "mcp": {
                 "servers": [
                     {
-                        "name": service.SHOPIFY_MCP_SERVER_NAME,
+                        "name": shopify_adapter.MCP_SERVER_NAME,
                         "url": "https://{shop_url}/api/mcp",
                         "auth": {"type": "none"},
                     }
@@ -117,18 +121,19 @@ def test_template_builder_adds_and_removes_shopify_mcp() -> None:
         website_context="Sells premium sneakers.",
         template_id="00000000-0000-0000-0000-000000000002",
         existing_template=None,
+        adapter=registry.resolve("shopify"),
     )
 
     assert shopify.name == "hustle-culture-assist"
     assert "Sells premium sneakers." in shopify.flow["system_prompt"]
     assert service.BRAND_IDENTITY_MARKER not in shopify.flow["system_prompt"]
     assert "### Shopify commerce tools" in shopify.flow["system_prompt"]
-    assert service.SHOPIFY_OPERATING_START_MARKER not in shopify.flow["system_prompt"]
-    assert service.SHOPIFY_OPERATING_END_MARKER not in shopify.flow["system_prompt"]
+    assert shopify_adapter.LEGACY_SECTION_START not in shopify.flow["system_prompt"]
+    assert shopify_adapter.LEGACY_SECTION_END not in shopify.flow["system_prompt"]
     assert shopify.configurations is not None
     assert shopify.configurations.mcp is not None
     assert [server.name for server in shopify.configurations.mcp.servers] == [
-        service.SHOPIFY_MCP_SERVER_NAME
+        shopify_adapter.MCP_SERVER_NAME
     ]
     assert len(shopify.configurations.state_reducers) == 3
     assert len(shopify.configurations.tool_arg_injection) == 3
@@ -140,6 +145,7 @@ def test_template_builder_adds_and_removes_shopify_mcp() -> None:
         website_context="Provides consulting.",
         template_id="00000000-0000-0000-0000-000000000003",
         existing_template=None,
+        adapter=registry.resolve("generic"),
     )
     assert non_shopify.configurations is not None
     assert "### Shopify commerce tools" not in non_shopify.flow["system_prompt"]
@@ -225,6 +231,7 @@ def test_existing_widget_updates_its_referenced_template(monkeypatch) -> None:
         website_context="Old context",
         template_id="00000000-0000-0000-0000-000000000010",
         existing_template=None,
+        adapter=registry.resolve("shopify"),
     )
     widget = _widget(existing.id)
 
@@ -291,6 +298,7 @@ def test_orphan_template_is_recovered_when_widget_is_missing(monkeypatch) -> Non
         website_context="Old context",
         template_id="00000000-0000-0000-0000-000000000030",
         existing_template=None,
+        adapter=registry.resolve("shopify"),
     )
 
     async def template_in_scope(reseller_id, merchant_id, name):

--- a/tests/assist/platforms/test_registry.py
+++ b/tests/assist/platforms/test_registry.py
@@ -1,7 +1,7 @@
 from app.ai.voice.agents.breeze_buddy.assist.engine.models import (
     Signal,
     SiteProfile,
-    StoreResearch,
+    SiteResearch,
 )
 from app.ai.voice.agents.breeze_buddy.assist.platforms import registry
 
@@ -49,7 +49,7 @@ def test_shopify_identity_uses_the_permanent_domain():
     assert identity.permanent_host == "9b1086-18.myshopify.com"
     origins = registry.resolve("shopify").extra_origins(
         identity,
-        StoreResearch(
+        SiteResearch(
             platform="shopify", canonical_origin="https://hustleculture.co.in"
         ),
     )
@@ -59,15 +59,41 @@ def test_shopify_identity_uses_the_permanent_domain():
 def test_generic_adapter_is_the_zero_adapter_path():
     generic = registry.resolve("generic")
     identity = generic.identity(_profile())
-    research = StoreResearch(
+    research = SiteResearch(
         platform="generic", canonical_origin="https://hustleculture.co.in"
     )
-    assert (
-        generic.operating_sections() == [] and generic.tools(identity, research) == []
-    )
-    assert (
-        generic.install() == "snippet"
-        and generic.mirror_policy().cart_handoff == "link"
-    )
+    assert generic.tools(identity, research) == []
+    assert generic.install() == "snippet" and generic.mirror_policy().handoff == "link"
     assert registry.resolve("shopify").install() == "theme_embed"
-    assert registry.resolve("shopify").mirror_policy().cart_handoff == "permalink"
+    assert registry.resolve("shopify").mirror_policy().handoff == "permalink"
+
+
+def test_host_apps_and_request_platform_resolve_through_the_registry():
+    for host_app in ("breeze-buddy", "buddy-assist"):
+        adapter = registry.for_host_app(host_app)
+        assert adapter.id == "shopify"
+        reseller, merchant = adapter.tenant(host_app, "acme.myshopify.com")
+        assert reseller in ("BB_SHOPIFY", "BB_ASSIST") and merchant.endswith(
+            "acme.myshopify.com"
+        )
+    try:
+        registry.for_host_app("some-other-app")
+    except KeyError:
+        pass
+    else:
+        raise AssertionError("unknown host app resolved")
+    assert registry.for_request("shopify").id == "shopify"
+    assert registry.for_request("web").id == "generic"
+    assert registry.for_request(None).id == "generic"
+
+
+def test_foreign_ownership_is_symmetric():
+    shopify, generic = registry.resolve("shopify"), registry.resolve("generic")
+    assert "shopify-storefront-ucp" in registry.foreign_mcp_server_names(generic)
+    assert registry.foreign_mcp_server_names(shopify) == frozenset()
+    assert "state_reducers" in registry.foreign_tool_config_keys(generic)
+    assert registry.foreign_tool_config_keys(shopify) == ()
+    assert registry.foreign_payload_keys(generic) == ("shopify_customer_token",)
+    assert "{{#shopify_operating_section}}" in registry.legacy_section_markers()
+    assert shopify.store_name("acme.myshopify.com") == "acme"
+    assert generic.store_name("acme.example.com") == "acme.example.com"


### PR DESCRIPTION
## Why

Two axes the engine must not know (ASSIST-ENGINE-DESIGN.md §1). **Platform**: `onboarding/service.py` still branched on `is_shopify` forty times after the relocation, and the bare route imported the Shopify tenancy table. **Vertical**: `engine/prompt_core.py` hardcoded the commerce skeleton's slot regexes, so a metro or hotel booking assistant could not run on the same engine.

## Platform-blind onboarding

- Every branch became an adapter hook: `legacy_section_markers`, `validate_blueprint`, `mcp_server_names`, `tool_config_keys`, `payload_keys`, `tenant(host_app, domain)`, `store_name`, `request_platform`, `host_apps`. `ShopifyAdapter` owns every Shopify fact; `GenericAdapter` is the zero-adapter path.
- `registry.for_request(platform)` / `for_host_app(host_app)` resolve the adapter; `foreign_*` helpers tell a build which servers, config keys and payload keys *other* platforms own, so it drops them symmetrically.
- `engine/skeleton.py`: platform sections with a generic `{{#platform_section:<id>}}…{{/platform_section}}` syntax; adapters register the legacy pair they shipped (`shopify_operating_section`), so existing blueprints keep working unchanged.
- The stream resolves the adapter from `platform` (`is_shopify` stays as a legacy alias, one of the two required); the bare route from the host app. Progress events carry `platform` instead of `shopify_enabled`.

## Vertical-blind engine

- `SkeletonSpec` describes a vertical's skeleton (brand marker, operating head, merchant help section, slot patterns); `shared_core` / `core_hash` take it as a parameter. The commerce patterns live in `assist/commerce/skeleton.py` (`COMMERCE_V2`).
- `engine/models.py` keeps only vertical-agnostic artefacts (`SiteResearch`, `ResearchDelta` with a `vertical` payload, `MirrorPolicy.handoff`); the shopping shapes moved to `assist/commerce/models.py`.
- The guard test now checks `onboarding/` and `routers/breeze_buddy/assist` for platform names and `engine/` for commerce vocabulary. It caught two phrases in this change.

## Checks

No API path changes. 1527 tests pass (CRM suite excluded locally), `pyrefly` 0 errors, `black`/`isort`/`autoflake`, boundary guard, router mount and flavor registration import-smoked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DNdffo648u5Qg9Q5Ctftub


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added commerce support for the Breeze Buddy voice assistant, including product, collection, sizing, checkout, and guided-shopping content.
  * Expanded onboarding to support multiple platforms through platform-aware configuration.
  * Added flexible prompt and template handling for platform-specific content.

* **Improvements**
  * Broadened website research to capture business offerings, categories, fulfillment, and refund information.
  * Improved compatibility for existing onboarding requests using legacy platform fields.

* **Bug Fixes**
  * Improved validation and handling of platform-specific onboarding templates and configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->