### PR TITLE
fix(leads): validate reporting_webhook_url at ingest

### DIFF
--- a/app/ai/voice/agents/breeze_buddy/types/models.py
+++ b/app/ai/voice/agents/breeze_buddy/types/models.py
@@ -1,5 +1,6 @@
 from io import BytesIO
 from typing import Any, Dict, List, NamedTuple, Optional
+from urllib.parse import urlparse
 from uuid import UUID
 
 from pydantic import BaseModel, Field, field_validator, model_validator
@@ -15,6 +16,15 @@ _LEGACY_TEMPLATE_NAME_ALIASES: Dict[str, str] = {
     "loan_reminder_dpd_0": "1079319f-7c90-4197-94fc-6d8fb4af24c7",
     "loan_collections_dpd_0_7_demo": "6742efc7-9385-4f25-94c2-1a8386797e3d",
 }
+
+
+# Reporting-webhook URL limits. FORMAT only, and deliberately so: no DNS
+# resolution and no address checks here. Those belong at delivery time —
+# the answer can change in the minutes between a push and the call ending,
+# and a lookup on this endpoint would put DNS on the push latency budget
+# and fail pushes whenever a merchant's DNS blips.
+_WEBHOOK_URL_SCHEMES = ("http", "https")
+_WEBHOOK_URL_MAX_LEN = 2048
 
 
 class CallRecordingResult(NamedTuple):
@@ -52,6 +62,49 @@ class PushLeadRequest(BaseModel):
         except ValueError as e:
             raise ValueError("template_id must be a valid UUID") from e
         return v
+
+    @field_validator("reporting_webhook_url")
+    @classmethod
+    def validate_reporting_webhook_url(cls, v: str | None) -> str | None:
+        """Reject a malformed webhook URL while the caller can still fix it.
+
+        This value is dereferenced by a background task minutes or hours after
+        the push, when the sender is long gone and a failure reaches nobody but
+        our own logs. Checking it here — at the writer — is the only point where
+        a rejection lands in front of someone who can act on it.
+
+        Messages never echo the URL back: a webhook URL routinely authenticates
+        the receiver with a shared secret in the query string.
+        """
+        if v is None:
+            return None
+        url = v.strip()
+        if not url:
+            # Empty means "no webhook", which is already how an empty value
+            # behaves downstream (the handler drops it on a falsy check).
+            # Turning that into a 422 would break pushes that work today.
+            return None
+        if len(url) > _WEBHOOK_URL_MAX_LEN:
+            raise ValueError(
+                f"reporting_webhook_url exceeds {_WEBHOOK_URL_MAX_LEN} characters"
+            )
+        try:
+            parsed = urlparse(url)
+            parsed.port  # noqa: B018 — raises on a non-numeric port
+        except ValueError as e:
+            raise ValueError(f"reporting_webhook_url is not a valid URL: {e}") from e
+        if parsed.scheme.lower() not in _WEBHOOK_URL_SCHEMES:
+            raise ValueError(
+                "reporting_webhook_url must start with http:// or https://"
+            )
+        if not parsed.hostname:
+            raise ValueError("reporting_webhook_url has no host")
+        if parsed.username or parsed.password:
+            raise ValueError(
+                "reporting_webhook_url must not embed credentials "
+                "(user:pass@host); use a header or a query token instead"
+            )
+        return url
 
     reseller_id: str
     merchant_id: Optional[str] = None

--- a/tests/test_push_lead_webhook_url.py
+++ b/tests/test_push_lead_webhook_url.py
@@ -1,0 +1,117 @@
+"""Lead push — reporting_webhook_url is validated at ingest.
+
+The URL arrives on ``POST /push/lead/v2`` and is not dereferenced until the
+call ends, by a background task, minutes or hours later. A bad value used to
+be accepted silently there and only fail at delivery time, where the failure
+reaches our logs and nobody else — the merchant's push returned 201 long ago.
+
+The check is FORMAT only. Scheme, host, credentials, length. It deliberately
+does not resolve the host or judge the address: DNS answers change between the
+push and the call, and the egress guard on the sending side owns that question.
+
+http:// stays allowed on purpose. Tenants post to plaintext endpoints today and
+rejecting them here would break working integrations; the sender warns instead.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from app.ai.voice.agents.breeze_buddy.types.models import PushLeadRequest
+
+TEMPLATE_ID = "6b1f0d3c-8a2e-4f5b-9c7d-1e2a3b4c5d6e"
+
+
+def _req(url: str | None) -> PushLeadRequest:
+    return PushLeadRequest(
+        request_id="order-1",
+        payload={"customer_mobile_number": "+919999999999"},
+        template_id=TEMPLATE_ID,
+        reseller_id="RESELLER",
+        reporting_webhook_url=url,
+    )
+
+
+# --- accepted -------------------------------------------------------------
+
+
+def test_https_url_is_kept():
+    assert _req("https://myshop.com/hooks/calls").reporting_webhook_url == (
+        "https://myshop.com/hooks/calls"
+    )
+
+
+def test_http_url_is_still_accepted():
+    # Tenants on plaintext endpoints must keep working — the delivery path
+    # warns about the scheme, it does not refuse it.
+    assert _req("http://myshop.com/hooks/calls").reporting_webhook_url == (
+        "http://myshop.com/hooks/calls"
+    )
+
+
+def test_url_with_port_and_query_is_kept():
+    url = "https://myshop.com:8443/hooks/calls?token=abc123"
+    assert _req(url).reporting_webhook_url == url
+
+
+def test_surrounding_whitespace_is_stripped():
+    assert _req("  https://myshop.com/hook  ").reporting_webhook_url == (
+        "https://myshop.com/hook"
+    )
+
+
+@pytest.mark.parametrize("value", [None, "", "   "])
+def test_absent_or_blank_means_no_webhook(value):
+    # Blank already behaved as "no webhook" downstream (the handler drops it
+    # on a falsy check). Turning it into a 422 would break working pushes.
+    assert _req(value).reporting_webhook_url is None
+
+
+# --- rejected -------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "file:///etc/passwd",
+        "gopher://myshop.com:6379/_SET%20key",
+        "javascript:alert(1)",
+        "ftp://myshop.com/hook",
+        "myshop.com/hook",  # no scheme at all
+    ],
+)
+def test_non_http_schemes_are_rejected(value):
+    with pytest.raises(ValidationError, match="http:// or https://"):
+        _req(value)
+
+
+def test_url_without_a_host_is_rejected():
+    with pytest.raises(ValidationError, match="no host"):
+        _req("https:///hooks/calls")
+
+
+def test_embedded_credentials_are_rejected():
+    # userinfo is a credential that would be replayed on every outcome and
+    # written to every log line that names the destination.
+    with pytest.raises(ValidationError, match="must not embed credentials"):
+        _req("https://user:s3cret@myshop.com/hook")
+
+
+def test_invalid_port_is_rejected():
+    with pytest.raises(ValidationError, match="not a valid URL"):
+        _req("https://myshop.com:notaport/hook")
+
+
+def test_overlong_url_is_rejected():
+    with pytest.raises(ValidationError, match="exceeds 2048 characters"):
+        _req("https://myshop.com/" + "a" * 2100)
+
+
+def test_rejection_never_echoes_the_url():
+    # A webhook URL routinely carries a shared secret in the query string.
+    # The message must describe the problem without repeating the value.
+    secret = "s3cret-token-do-not-log"
+    with pytest.raises(ValidationError) as exc:
+        _req(f"ftp://myshop.com/hook?token={secret}")
+    assert secret not in str(exc.value.errors()[0]["msg"])


### PR DESCRIPTION
reporting_webhook_url arrives on POST /push/lead/v2 as a bare `str` with no validation of any kind, is stored in the lead payload, and is not dereferenced until the call ends — minutes or hours later, inside a background task. A bad value is therefore accepted with a 201 and fails at delivery time, where the failure reaches our logs and nobody else: the merchant who could fix it got a success response long ago and never learns their outcomes are not arriving.

The check belongs at the writer, which is the one moment the sender is still on the request. Scheme (http/https only, so file:/gopher:/javascript: cannot be registered at all), a host must be present, no embedded user:pass credentials, and a 2048-character cap.

Three deliberate limits:

- FORMAT only. No DNS resolution, no address checks. The answer changes between a push and the call ending, so a check here proves nothing about where the request will actually go — that question belongs to the sending path. It would also put a DNS round-trip on this endpoint's latency budget and fail pushes whenever a merchant's resolver blips.
- http:// stays accepted. Tenants post to plaintext endpoints today; refusing them here would break working integrations for a scheme the sender already warns about.
- Blank stays "no webhook". An empty or whitespace-only value is already dropped downstream on a falsy check, so rejecting it would turn pushes that work today into a 422 for no gain.

Messages never echo the URL: these routinely authenticate the receiver with a shared secret in the query string, and a validation error is a logged object.

The three internal callers (breeze + woocommerce webhook bridges, campaigns) never set the field, so nothing but the public push path changes behaviour.

Not covered here: app/crm/outreach/nodes/call.py is a second writer of the same lead-payload key, taking it from workflow facts rather than this model. Covering it needs the check in a place app/crm may import — app/crm never imports app.ai — which is a design call, not a drive-by.

Tests: 17 cases — accepted shapes, every rejected shape, blank/None handling, whitespace stripping, and that a rejection does not repeat a query-string token.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validation for reporting webhook URLs.
  * Accepts HTTP and HTTPS URLs, trims surrounding whitespace, and permits blank values.
  * Rejects unsupported schemes, missing hosts, embedded credentials, invalid URLs, and URLs exceeding 2,048 characters.

* **Tests**
  * Added coverage for valid, normalized, blank, malformed, oversized, and sensitive webhook URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->