### PR TITLE
fix(widget): size the storefront probe cap for the revalidating loader

### DIFF
--- a/app/api/routers/breeze_buddy/widget/storefront.py
+++ b/app/api/routers/breeze_buddy/widget/storefront.py
@@ -48,9 +48,14 @@ _CACHE_TTL_SECONDS = 60
 # Pre-lookup probe cap. The merchant-scoped limiter below can only run AFTER
 # a config resolves (it is keyed by widget_config_id), which would leave
 # unknown-domain probes as unbounded free DB lookups for an anonymous
-# caller. This fixed per-IP cap bounds them. Generous on purpose: a real
-# shopper hits this endpoint only on loader cache-miss (~4/shop/hour).
-_PROBE_LIMIT_PER_IP_HOUR = 600
+# caller. This fixed per-IP cap bounds them.
+#
+# Sized for the revalidating loader: it asks once a minute per shop, so a
+# single browser costs up to 60 calls an hour and most of them are 304s that
+# never reach the database. The cap is per IP across every store, so it has
+# to hold a whole office or a carrier NAT pool behind one address — hence
+# the headroom. It is a denial-of-service bound, not a fair-use quota.
+_PROBE_LIMIT_PER_IP_HOUR = 3000
 _PROBE_WINDOW_SECONDS = 3600
 
 

--- a/tests/test_storefront_widget_config.py
+++ b/tests/test_storefront_widget_config.py
@@ -256,6 +256,30 @@ def test_stale_or_weak_if_none_match_is_a_full_200(client: TestClient) -> None:
     assert _get(client, **{"If-None-Match": "*"}).status_code == 304
 
 
+def test_a_valid_etag_from_a_foreign_origin_is_still_403(client: TestClient) -> None:
+    # The ETag is not a credential. Revalidation is answered only after the
+    # origin allowlist has run, so a tag lifted from a real storefront buys
+    # a foreign page nothing.
+    etag = _get(client).headers["ETag"]
+    response = client.get(
+        "/widget/storefront-config",
+        params={"merchant_domain": MERCHANT_DOMAIN},
+        headers={"Origin": "https://evil.example", "If-None-Match": etag},
+    )
+    assert response.status_code == 403
+
+
+def test_the_probe_cap_still_bounds_revalidation(
+    client: TestClient, monkeypatch
+) -> None:
+    # The per-IP probe cap is the only limiter a 304 passes through, so it
+    # has to run before the revalidation shortcut — otherwise conditional
+    # requests would be free and unbounded.
+    etag = _get(client).headers["ETag"]
+    monkeypatch.setattr(storefront, "check_rate_limit", AsyncMock(return_value=_deny()))
+    assert _get(client, **{"If-None-Match": etag}).status_code == 429
+
+
 def test_etag_changes_when_the_appearance_changes(
     client: TestClient, lookup: AsyncMock
 ) -> None:


### PR DESCRIPTION
## Why

Follow-up to #1120, flagged in its review. The per-IP cap on `GET /widget/storefront-config` was sized when the loader slept 900 s between fetches — its comment still claims a shopper costs "~4/shop/hour". With the 60 s TTL the loader revalidates once a minute per shop, so a single browser is now up to 60 calls an hour.

The cap is per IP **across every store**, so one shared address — an office, a carrier NAT pool — reaches 600 with a handful of active shoppers, and the storefront starts answering 429. The new loader keeps its cached copy on a 429, so nothing breaks visibly, but propagation stops for the rest of the hour.

## What

- `_PROBE_LIMIT_PER_IP_HOUR` 600 → 3000, and the comment now says what the number is: a denial-of-service bound on unknown-domain probes, not a fair-use quota. Most traffic behind it is conditional and answers 304 without a DB read.
- Two tests for invariants #1120 introduced but did not pin:
  - an ETag lifted from a real storefront is **still 403** from a foreign origin — the ETag is not a credential, and the origin allowlist runs before the revalidation shortcut;
  - the probe cap **still bounds a revalidation** — it is the one limiter a 304 passes through, so it must run first or conditional requests would be free and unbounded.

No behaviour change for a caller under the cap. Nothing else touched.

## Checks

`tests/test_storefront_widget_config.py` 15 passed; `black` / `isort` / `autoflake` clean; `pyrefly` 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DNdffo648u5Qg9Q5Ctftub

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Enforced origin authorization and probe rate limits during ETag revalidation.
  - Unauthorized requests now return the appropriate access error, while rate-limited requests return a rate-limit response instead of a cached success.

- **Capacity**
  - Increased the hourly limit for anonymous storefront probes per IP to better support normal revalidation traffic and shared networks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->