### PR TITLE
fix(docker): precompile bytecode so bots stop recompiling on every call

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,10 @@ COPY pyproject.toml uv.lock ./
 # Install Python dependencies using uv
 # Use --no-install-project to avoid installing the app/ package at this stage
 # This allows optimal Docker layer caching - dependencies layer is cached separately
-RUN uv sync --frozen --no-dev --no-install-project && \
+# --compile-bytecode: write .pyc at BUILD time. Without it every bot subprocess
+# recompiles ~12k source files on each call (PYTHONDONTWRITEBYTECODE=1 means the
+# result is never cached). Measured 1.4-1.8x faster bot startup under CPU pressure.
+RUN uv sync --frozen --no-dev --no-install-project --compile-bytecode && \
     uv pip show pipecat-ai
 
 # Download AIC assets from GCP Storage using authenticated context
@@ -69,6 +72,9 @@ RUN mkdir -p /usr/local/nltk_data && \
 
 # Copy application code
 COPY . .
+
+# Precompile the app's own bytecode too (same reason as --compile-bytecode above).
+RUN /app/.venv/bin/python -m compileall -q -j 0 /app/app || true
 
 # Set proper permissions
 RUN chmod +x run.py


### PR DESCRIPTION
The image shipped 11,959 .py files and exactly 1 .pyc. Combined with PYTHONDONTWRITEBYTECODE=1, every Daily bot subprocess compiled source to bytecode from scratch on every call and could never cache the result.

That cost is invisible on a developer machine and severe in production: bot startup is pure CPU, and the voice pod requests 1 core on a 2-vCPU node that is already running telephony pipelines in the API process. Measured in a container with a cgroup CPU cap (the same mechanism Kubernetes uses), median of 3 runs:

    --cpus     before    after    speedup
       1       3.36s     1.85s     1.82x
     0.5       7.35s     3.90s     1.89x
    0.25      31.30s    19.56s     1.60x

0.25 cores is roughly what a bot gets while telephony is live, so this is ~11.7s off every voice call at production CPU levels.

PYTHONDONTWRITEBYTECODE=1 is deliberately kept: with every .pyc present at build time there is nothing left to write, and keeping it guarantees no runtime writes against the pod's 2Gi ephemeral-storage limit, keeps behaviour identical on call #1 and call #1000, and survives readOnlyRootFilesystem.

Relying on runtime .pyc writes instead would leave the first call after every deploy slow and make concurrent bots race to compile the same modules -- burning the CPU that is already the scarce resource.


Claude-Session: https://claude.ai/code/session_01MhfHcSTBu79o6uBNTCcata

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Application bytecode is now compiled during image creation, reducing repeated compilation work when bot processes start.
  - Dependency bytecode is also compiled during installation, helping improve startup efficiency in deployed environments.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->