### PR TITLE
feat(crm): conditions on a goal tier

### DIFF
--- a/app/crm/outreach/catalog_laws.py
+++ b/app/crm/outreach/catalog_laws.py
@@ -115,6 +115,46 @@ def entry_against_catalog(
     return problems
 
 
+def goals_against_catalog(
+    definition: WorkflowDefinition, catalogs: Catalogs
+) -> List[str]:
+    """The ownership laws, applied to a GOAL tier's conditions (phase 20).
+
+    A tier WITHOUT a `where` is unchanged — it may name any topic, declared
+    or not. Only one that asks a question about a payload has to prove the
+    payload is one we can read.
+    """
+    if catalogs is None:
+        return []  # nothing gathered (pure-unit callers): shape laws only
+    problems: List[str] = []
+    for index, tier in enumerate(definition.goals):
+        if tier.key and "." in tier.key.event:
+            # The walker compares this in SQL as payload->>$5 — one key,
+            # nothing deeper. A nested path would work at the live consumer
+            # and silently match nothing at the next claim.
+            problems.append(
+                f"goal tier {index}: key.event {tier.key.event!r} must be a "
+                "top-level payload field (it is compared in SQL at fire time)"
+            )
+        if not tier.where:
+            continue
+        for topic in tier.topics:
+            fields = catalogs.get(topic)
+            if fields is None:
+                problems.append(
+                    f"goal tier {index}: topic {topic!r} is not in the catalog "
+                    "— register its schema (or declare it in code) before "
+                    "filtering on it"
+                )
+                continue
+            for condition in tier.where:
+                problems.extend(
+                    f"goal tier {index}: {p} (topic {topic!r})"
+                    for p in condition_against_catalog(condition, fields)
+                )
+    return problems
+
+
 # Facts the walker computes for a template at the square (nodes.run_facts,
 # phase 16) — never a producer's, so no catalog declares them.
 _WALKER_FACTS = frozenset({"current_node", "current_stage"})
@@ -218,6 +258,14 @@ async def gather_catalogs(merchant_id: str, raw: Dict[str, Any]) -> Catalogs:
     for node in raw.get("nodes") or [] if isinstance(raw, dict) else []:
         if isinstance(node, dict) and node.get("type") == "wait_event":
             topics.update(str(t) for t in node.get("topics") or [] if t)
+    if isinstance(raw, dict):
+        # `goal` (singular) is the pre-phase-06 spelling. The MODEL rewrites
+        # it to `goals` (_goal_becomes_one_tier), but this gather runs on the
+        # RAW document — before any model has touched it — so it has to read
+        # both. Version rows are immutable, so those documents never go away.
+        for tier in raw.get("goals") or ([raw["goal"]] if raw.get("goal") else []):
+            if isinstance(tier, dict):
+                topics.update(str(t) for t in tier.get("topics") or [] if t)
     catalogs: Dict[str, Optional[Dict[str, CatalogField]]] = {}
     problems: List[str] = []
     for topic in sorted(topics):

--- a/app/crm/outreach/conditions.py
+++ b/app/crm/outreach/conditions.py
@@ -1,0 +1,20 @@
+"""One typed where-grammar, judged against one letter.
+
+Three surfaces mean the same thing by a condition: a door's admission, a
+goal tier's verdict, and the walker's re-check of that goal. One wrapper so
+a fix cannot land in one of them and not the others.
+"""
+
+from typing import Sequence
+
+from app.crm.record.contracts import RawEvent, derive_for, field_value
+from app.crm.shared.predicate import Condition, matches
+
+
+def conditions_match(conditions: Sequence[Condition], event: RawEvent) -> bool:
+    """ANDed. Empty = True: no `where` admits, or ends, on the topic alone."""
+    derive = derive_for(event.source, event.topic)
+    return matches(
+        conditions,
+        lambda path: field_value(event.payload, path, derive),
+    )

--- a/app/crm/outreach/entry.py
+++ b/app/crm/outreach/entry.py
@@ -27,6 +27,7 @@ from typing import Any, Dict, Optional, Sequence, Tuple
 
 from app.core.config.dynamic import CRM_CONTEXT_VALUE_MAX_CHARS
 from app.core.logger import logger
+from app.crm.outreach.conditions import conditions_match
 from app.crm.outreach.db.accessors import (
     enrollment as enrollment_accessor,
     workflow as workflow_accessor,
@@ -50,7 +51,6 @@ from app.crm.outreach.schemas import (
 )
 from app.crm.record.contracts import RawEvent, canonical_path, derive_for, field_value
 from app.crm.shared.normalize import normalize_phone
-from app.crm.shared.predicate import matches
 
 # Fallback only: where a phone hides in a payload when no extractor
 # handles were passed in (the voice mirrors, which send the flat shape).
@@ -178,6 +178,8 @@ async def _end_on_goal(
             if str(run.context.get(tier.key.run, "")) != str(value):
                 continue  # about another run of hers
             key = (tier.key.run, str(value))
+        if not conditions_match(tier.where, event):
+            continue
         if await enrollment_accessor.cancel_run(
             run.merchant_id,
             str(run.id),
@@ -327,15 +329,8 @@ def _goal_patch(event: RawEvent) -> dict:
 
 
 def _where_matches(door: WorkflowEntry, event: RawEvent) -> bool:
-    """One door's typed where-grammar against the payload
-    (shared/predicate.py); fields resolve through record's catalog paths —
-    dot-walks and the code layer's derived fields. No table read: the
-    validator guaranteed op-type fit at publish."""
-    derive = derive_for(event.source, event.topic)
-    return matches(
-        door.where,
-        lambda path: field_value(event.payload, path, derive),
-    )
+    """One door's admission conditions (conditions.py: the one evaluator)."""
+    return conditions_match(door.where, event)
 
 
 def _context_from_payload(payload: dict, max_chars: int) -> dict:

--- a/app/crm/outreach/plans.py
+++ b/app/crm/outreach/plans.py
@@ -15,6 +15,7 @@ from app.crm.outreach.catalog_laws import (
     WorkflowValidationError,
     entry_against_catalog,
     gather_catalogs as _gather_catalogs,
+    goals_against_catalog,
 )
 from app.crm.outreach.db import DbTxn, atomically
 from app.crm.outreach.db.accessors import (
@@ -84,6 +85,7 @@ def validate_definition(
             "equality map is retired (migration 069)"
         )
     problems.extend(entry_against_catalog(definition, catalogs))
+    problems.extend(goals_against_catalog(definition, catalogs))
     node_ids = [node.id for node in definition.nodes]
     seen = set()
     for node_id in node_ids:

--- a/app/crm/outreach/schemas.py
+++ b/app/crm/outreach/schemas.py
@@ -111,6 +111,7 @@ class WorkflowGoal(BaseModel):
 
     topics: List[str] = Field(min_length=1)
     key: Optional[WorkflowGoalKey] = None
+    where: List[Condition] = Field(default_factory=list)
     exit_reason: str = "goal_met"
 
 

--- a/app/crm/outreach/walker.py
+++ b/app/crm/outreach/walker.py
@@ -31,6 +31,7 @@ from app.core.config.static import (
     CRM_WALKER_MAX_ATTEMPTS,
 )
 from app.core.logger import logger
+from app.crm.outreach.conditions import conditions_match
 from app.crm.outreach.db.accessors import (
     enrollment as enrollment_accessor,
     workflow as workflow_accessor,
@@ -40,8 +41,15 @@ from app.crm.outreach.nodes import NODE_TYPES, is_wait
 from app.crm.outreach.nodes.context import reply_key, without_reply
 from app.crm.outreach.nodes.spec import NodeParked
 from app.crm.outreach.nodes.wait_event import ELSE, TIMEOUT
-from app.crm.outreach.schemas import EnrollmentRun, WorkflowDefinition, WorkflowNode
-from app.crm.record.contracts import customer_has_event
+from app.crm.outreach.schemas import (
+    EnrollmentRun,
+    WorkflowDefinition,
+    WorkflowGoal,
+    WorkflowNode,
+)
+from app.crm.record.contracts import customer_goal_events, customer_has_event
+
+GOAL_LETTER_SCAN = 50
 
 # One claim executes consecutive immediate nodes (call -> next wait) in a
 # single visit; the bound is a runaway-document guard, not a feature.
@@ -166,9 +174,7 @@ async def _advance(
             if value in (None, ""):
                 continue  # this run cannot match a keyed tier
             where = (tier.key.event, str(value))
-        if await customer_has_event(
-            run.merchant_id, str(run.customer_id), tier.topics, since, where
-        ):
+        if await _tier_happened(run, tier, since, where):
             if not await enrollment_accessor.exit_run(
                 str(run.id), tier.exit_reason, lease
             ):
@@ -227,6 +233,38 @@ async def _advance(
     raise NodeParked(
         f"{_MAX_STEPS_PER_VISIT} immediate nodes in one visit — runaway document"
     )
+
+
+async def _tier_happened(
+    run: EnrollmentRun,
+    tier: WorkflowGoal,
+    since: datetime,
+    where: Optional[Tuple[str, str]],
+) -> bool:
+    """Did a letter this tier accepts arrive after the run began?
+
+    A tier with no `where` is the indexed EXISTS it has always been —
+    untouched, so every plan published before phase 20 costs exactly what
+    it did.
+
+    A tier WITH one cannot: the SQL knows the topic and the key, so it would
+    say yes to any orders/updated about this order — a fulfilment, an address
+    fix — and end the run at the next claim. So SQL narrows and the letters
+    come back to the SAME evaluator that judged them live.
+    """
+    if not tier.where:
+        return await customer_has_event(
+            run.merchant_id, str(run.customer_id), tier.topics, since, where
+        )
+    letters = await customer_goal_events(
+        run.merchant_id,
+        str(run.customer_id),
+        tier.topics,
+        since,
+        where,
+        GOAL_LETTER_SCAN,
+    )
+    return any(conditions_match(tier.where, letter) for letter in letters)
 
 
 def goal_since(run: EnrollmentRun) -> datetime:

--- a/app/crm/record/catalog.py
+++ b/app/crm/record/catalog.py
@@ -45,7 +45,13 @@ from app.crm.record.schemas import (
     SampledField,
     SchemaRegistration,
 )
-from app.crm.shared.predicate import EQUALS_OP, EXISTS_OP, ORDER_OPS, TEXT_OPS
+from app.crm.shared.predicate import (
+    EQUALS_OP,
+    EXISTS_OP,
+    LIST_OPS,
+    ORDER_OPS,
+    TEXT_OPS,
+)
 
 # Type -> the ops the where-grammar implements for it. Spelled from the
 # evaluator's own families (shared/predicate.py), so the UI shows exactly
@@ -63,6 +69,7 @@ OPS_BY_TYPE: Dict[str, List[str]] = {
     # array semantics (design/event-catalog.md, sealed) — a condition on a
     # list field is refused at publish, naming the empty set.
     "list": [],
+    "tags": [*LIST_OPS, EXISTS_OP],
 }
 KEYABLE_TYPES = ("text", "number")
 MAX_REGISTERED_FIELDS = 200

--- a/app/crm/record/contracts.py
+++ b/app/crm/record/contracts.py
@@ -21,7 +21,7 @@ from app.crm.record.catalog import (
     derive_for,
     topic_counts,
 )
-from app.crm.record.events import customer_has_event
+from app.crm.record.events import customer_goal_events, customer_has_event
 from app.crm.record.extractors.engine import field_value, variable_name
 from app.crm.record.ingest import record_event
 from app.crm.record.ingress import IngressSpec, register_ingress
@@ -33,6 +33,7 @@ __all__ = [
     "record_event",
     "get_customer_journey",
     "customer_has_event",
+    "customer_goal_events",
     # The provider bays' seam (ingress.py): the module that owns a
     # provider's webhook mechanics builds an IngressSpec, and app/crm/api.py
     # registers it — record never imports the registrant back (rule 12).

--- a/app/crm/record/db/accessor.py
+++ b/app/crm/record/db/accessor.py
@@ -18,6 +18,7 @@ from app.crm.record.db.decoder import (
 )
 from app.crm.record.db.queries import (
     claim_pending_events_query,
+    customer_goal_events_query,
     customer_has_event_query,
     get_customer_journey_query,
     get_schema_query,
@@ -106,6 +107,24 @@ async def customer_has_event(
     async with crm_connection() as conn:
         row = await conn.fetchrow(query, *values)
     return bool(row["found"]) if row else False
+
+
+async def customer_goal_events(
+    merchant_id: str,
+    customer_id: str,
+    topics: List[str],
+    since: datetime,
+    where: Optional[Tuple[str, str]] = None,
+    limit: int = 50,
+) -> List[RawEvent]:
+    """The letters behind the EXISTS, newest first and capped — for a goal
+    tier whose `where` the SQL cannot answer."""
+    query, values = customer_goal_events_query(
+        merchant_id, customer_id, topics, since, where, limit
+    )
+    async with crm_connection() as conn:
+        rows = await conn.fetch(query, *values)
+    return [decode_raw_event(row) for row in rows]
 
 
 # --- crm_event_schema (T24) ---------------------------------------------------

--- a/app/crm/record/db/queries.py
+++ b/app/crm/record/db/queries.py
@@ -159,6 +159,51 @@ def customer_has_event_query(
     return query, params
 
 
+def customer_goal_events_query(
+    merchant_id: str,
+    customer_id: str,
+    topics: List[str],
+    since: datetime,
+    where: Optional[Tuple[str, str]] = None,
+    limit: int = 50,
+) -> Tuple[str, List[Any]]:
+    """The letters themselves, for a goal tier the EXISTS above cannot
+    answer — one carrying a `where` (outreach phase 20).
+
+    Same index, same narrowing, one clause more: newest first and capped,
+    so the caller can run the SAME pure evaluator over the payloads that
+    judged them live at arrival. The alternative was compiling the
+    where-grammar to SQL here, which needs each field's catalog TYPE (a
+    numeric cast over a text column raises on the first non-numeric row)
+    and would put a SECOND evaluator in the system — the drift
+    extractors/engine.py was written to end. The grammar still owes a
+    compiler to phase-2 segments; it is not owed to this read.
+
+    Deliberately NOT the whole window: a goal is judged live by the entry
+    consumer against the full payload, and this is the walker's
+    belt-and-suspenders re-check. The cap bounds what a claim may fetch;
+    the caller names it and says why."""
+    keyed = "AND payload->>$5 = $6" if where else ""
+    params: List[Any] = [merchant_id, customer_id, topics, since]
+    if where:
+        params.extend([where[0], where[1]])
+    params.append(limit)
+    query = f"""
+        SELECT id, merchant_id, source, topic, schema_version,
+               external_id, payload, received_at, occurred_at,
+               customer_id, attempts
+        FROM {EVENT_RAW_TABLE}
+        WHERE merchant_id = $1
+          AND customer_id = $2
+          AND topic = ANY($3)
+          AND COALESCE(occurred_at, received_at) > $4
+          {keyed}
+        ORDER BY COALESCE(occurred_at, received_at) DESC
+        LIMIT ${len(params)}
+    """
+    return query, params
+
+
 # --- crm_event_schema (T24) + the catalog's compute-on-read queries ---------
 
 EVENT_SCHEMA_TABLE = "crm_event_schema"

--- a/app/crm/record/events.py
+++ b/app/crm/record/events.py
@@ -11,6 +11,7 @@ from datetime import datetime
 from typing import List, Optional, Tuple
 
 from app.crm.record.db import accessor
+from app.crm.record.schemas import RawEvent
 
 
 async def customer_has_event(
@@ -24,4 +25,20 @@ async def customer_has_event(
     to the letters whose payload field equals a value (the goal key)."""
     return await accessor.customer_has_event(
         merchant_id, customer_id, topics, since, where
+    )
+
+
+async def customer_goal_events(
+    merchant_id: str,
+    customer_id: str,
+    topics: List[str],
+    since: datetime,
+    where: Optional[Tuple[str, str]] = None,
+    limit: int = 50,
+) -> List[RawEvent]:
+    """The letters that EXISTS would have answered for, newest first and
+    capped — so a caller whose question SQL cannot express (a goal tier's
+    `where`) asks it of the payloads with its own evaluator."""
+    return await accessor.customer_goal_events(
+        merchant_id, customer_id, topics, since, where, limit
     )

--- a/app/crm/record/extractors/shopify.py
+++ b/app/crm/record/extractors/shopify.py
@@ -329,6 +329,7 @@ def _order_fields() -> List[CatalogField]:
             "Payment status",
             values=FINANCIAL_STATUSES,
         ),
+        _f("payload.tags", "tags", "Order tags", variable=True),
         _f("payload.gateway", "text", "Payment method"),
         # ── what a message or an agent actually says ──────────────────────
         # Shopify's own hosted status page: no login, no lookup — the one
@@ -337,7 +338,6 @@ def _order_fields() -> List[CatalogField]:
         _f("payload.confirmation_number", "text", "Confirmation no.", variable=True),
         _f("payload.email", "text", "Order email", variable=True),
         _f("payload.note", "text", "Order note", variable=True),
-        _f("payload.tags", "text", "Tags", variable=True),
         _f("payload.total_outstanding", "number", "Amount due", variable=True),
         # Where it is going. The parts stay declared beside the whole: a
         # call confirms the city and never the street, while a shipped-out

--- a/app/crm/record/schemas.py
+++ b/app/crm/record/schemas.py
@@ -126,7 +126,12 @@ class EventReceipt(BaseModel):
 # The closed type set a registration may use — each maps one-to-one onto the
 # where-grammar's operators (record/catalog.py OPS_BY_TYPE). Unknown types
 # are rejected at registration, never discovered at flow-publish.
-FieldType = Literal["text", "number", "choice", "boolean", "datetime", "phone", "list"]
+# `tags` is the LIST-shaped type: a Shopify order's comma string or a
+# vendor's array, read as one set by shared/predicate.as_tag_set. It is the
+# only type whose ops ask about containment rather than equality.
+FieldType = Literal[
+    "text", "number", "choice", "boolean", "datetime", "phone", "list", "tags"
+]
 IdentityRole = Literal["phone", "name", "email", "shopify_customer_id"]
 
 

--- a/app/crm/shared/predicate.py
+++ b/app/crm/shared/predicate.py
@@ -14,11 +14,24 @@ compares text exactly (no numeric coercion — that is `=`'s job).
 
 import re
 from datetime import datetime
-from typing import Any, Callable, Iterable, List, Literal, Optional
+from typing import Any, Callable, FrozenSet, Iterable, List, Literal, Optional
 
 from pydantic import BaseModel, Field, model_validator
 
-Op = Literal["is", "is_not", "in", ">", ">=", "<", "<=", "=", "exists"]
+Op = Literal[
+    "is",
+    "is_not",
+    "in",
+    ">",
+    ">=",
+    "<",
+    "<=",
+    "=",
+    "exists",
+    "has_all",
+    "has_any",
+    "has_none",
+]
 # The op FAMILIES, by what they compare. The catalog's OPS_BY_TYPE (record/
 # catalog.py) is built from these, so a type's allowed ops and the evaluator
 # that runs them cannot drift apart.
@@ -26,6 +39,8 @@ TEXT_OPS = ("is", "is_not", "in")  # exact text, never coerced
 ORDER_OPS = (">", ">=", "<", "<=")  # numbers or datetimes
 EQUALS_OP = "="  # numbers only
 EXISTS_OP = "exists"
+LIST_OPS = ("has_all", "has_any", "has_none")
+_LIST_VALUE_OPS = ("in", *LIST_OPS)
 _NUMBER = re.compile(r"^-?\d+(\.\d+)?$")
 
 
@@ -39,11 +54,11 @@ class Condition(BaseModel):
 
     @model_validator(mode="after")
     def _value_matches_op(self) -> "Condition":
-        if self.op == "in":
+        if self.op in _LIST_VALUE_OPS:
             if not isinstance(self.value, list) or not self.value:
-                raise ValueError("'in' needs a non-empty list value")
+                raise ValueError(f"{self.op!r} needs a non-empty list value")
             if any(isinstance(v, (list, dict)) or v is None for v in self.value):
-                raise ValueError("'in' values must be scalars")
+                raise ValueError(f"{self.op!r} values must be scalars")
         elif self.op == "exists":
             if self.value is not None:
                 raise ValueError("'exists' takes no value")
@@ -62,6 +77,50 @@ def as_number(value: Any) -> Optional[float]:
     if isinstance(value, str) and _NUMBER.match(value.strip()):
         return float(value.strip())
     return None
+
+
+def as_tag_set(value: Any) -> Optional[FrozenSet[str]]:
+    """A list-shaped value as a set, or None when it is not list-shaped.
+
+    Reads both Shopify shapes — a REST comma string and a GraphQL array — and
+    casefolds both sides, since Shopify matches tags case-insensitively and an
+    exact compare would give a rule that silently never fires.
+    """
+    if isinstance(value, bool):
+        return None  # a boolean is not a one-item list
+    if isinstance(value, str):
+        items: Iterable[Any] = value.split(",")
+    elif isinstance(value, (list, tuple)):
+        items = value
+    else:
+        return None
+    return frozenset(
+        text
+        for item in items
+        if isinstance(item, (str, int, float)) and not isinstance(item, bool)
+        for text in (str(item).strip().casefold(),)
+        if text
+    )
+
+
+def _contains(op: str, actual: Any, wanted: Any) -> bool:
+    """One list op, both sides through as_tag_set.
+
+    `has_none` means "present and holds none of these", never "not has_any":
+    an absent field is not evidence of absence, and the caller already
+    returned False for it.
+    """
+    have = as_tag_set(actual)
+    if have is None:
+        return False
+    want: FrozenSet[str] = frozenset(
+        tag for value in wanted for tag in (as_tag_set(value) or frozenset())
+    )
+    if op == "has_all":
+        return want <= have
+    if op == "has_any":
+        return bool(want & have)
+    return not (want & have)  # has_none
 
 
 def _as_datetime(value: Any) -> Optional[datetime]:
@@ -116,6 +175,8 @@ def evaluate(condition: Condition, actual: Any) -> bool:
     op = condition.op
     if op == "exists":
         return True
+    if op in LIST_OPS:
+        return _contains(op, actual, condition.value)
     if op == "is":
         return _same(actual, condition.value)
     if op == "is_not":

--- a/docs/crm/workflow-rollout/20-goal-conditions-and-tags.md
+++ b/docs/crm/workflow-rollout/20-goal-conditions-and-tags.md
@@ -1,0 +1,540 @@
+# Phase 20 — Goal conditions (`goal.where`), the `tags` field type, and `shopify/orders/updated`
+
+**Kind**: feat (no migration) · **PR title**: `feat(crm): conditions on a goal tier, a tags field type, and the shopify orders/updated spec` · **Depends on**: 06 (goal tiers + key), 15 (doors), 18 (match) — all merged · **Touches**: `app/crm/shared/predicate.py`, `app/crm/record/{schemas,catalog,contracts,db}`, `app/crm/record/extractors/shopify.py`, `app/crm/outreach/{schemas,entry,walker,catalog_laws}.py`
+
+---
+
+## Why
+
+A goal tier says *which topics* end a run and, since phase 06, *which run* a
+letter is about (`goal.key`). It cannot say **what the letter has to contain**.
+
+That was fine while every goal topic was a once-per-order fact —
+`orders/paid`, `orders/cancelled`. It breaks the moment the goal topic is
+`orders/updated`, which Shopify fires for a fulfilment, a shipping edit, a
+note, an address correction, a refund, a tag write, a metafield change. A
+tier listening on `orders/updated` today ends the run on the *first edit of
+any kind*, which is not a goal — it is noise wearing a goal's costume.
+
+The concrete ask: a plan calls a COD customer, an `action` square tags the
+order (`update_order` → `tags: ["Buddy Confirmed"]`), and the run should end
+`goal_met` **only when Shopify's order data actually carries that tag** —
+not when the parcel ships.
+
+Two facts found while reading, both blocking, both worth stating plainly:
+
+1. **`("shopify", "orders/updated")` is not in the code catalog at all.**
+   `decode_spec` finds no entry and no registered row, returns `EMPTY_SPEC`,
+   and `_extract` falls through to `flat.extract`, which looks only for a
+   top-level `customer_mobile_number`. A Shopify order payload has none.
+   So `_run_processor` takes the `if not extracted.handles` branch and
+   writes `quarantine_event(..., "no_handle")`. **Every relayed
+   `orders/updated` is quarantined today**, `customer_id` is never set, and
+   `consume_attributed_event` returns on its first line. A goal on that
+   topic currently fires for nobody — and any shop already inside
+   `CRM_EVENT_RELAY_MERCHANTS` is accumulating quarantine rows for it.
+2. **Nautilus needs no change.** `handleBreezeBuddyOrder` already relays
+   `orders/updated` verbatim (`relayOrderFact`, gated per-shop), stamped
+   with the edit's own `updated_at` both as `occurred_at` and as the
+   `externalId` revision suffix, so each edit is a distinct spine row rather
+   than a duplicate of the create. The payload it relays is
+   `savedOrder.orderData`, and `upsertOrder` does `order_data =
+   EXCLUDED.order_data ... RETURNING *` **before** the app handler is
+   dispatched — so the relayed body is the *fresh* webhook payload with the
+   new tags, not the stored create-time one. `orders/updated` is subscribed
+   declaratively in `shopify-apps/breeze-buddy/shopify.app.toml`.
+
+## The shape of the answer
+
+Not a Shopify branch, and not a tag-matching feature. Three separable pieces,
+each of which is the generic version of what was asked:
+
+| # | Piece | Generic statement |
+|---|---|---|
+| 1 | `goal.where` | A goal tier carries the **same typed `where` grammar a door carries**. Any field, any op, any source. |
+| 2 | `tags` type + `has_all` / `has_any` / `has_none` | The grammar learns **list-shaped fields** once, in one evaluator. Shopify's comma string and a vendor's JSON array are the same value to it. |
+| 3 | the `orders/updated` spec | One `CatalogEntry` + one fixture. The four-part ritual, no new machinery. |
+
+Everything else in this file is the consequence of those three.
+
+---
+
+## Design
+
+### Part 1 — `where` on a goal tier
+
+**`app/crm/outreach/schemas.py`**
+
+```python
+class WorkflowGoal(BaseModel):
+    topics: List[str] = Field(min_length=1)
+    key: Optional[WorkflowGoalKey] = None
+    # Phase 20: what the letter must CONTAIN, in the door's own grammar
+    # (shared/predicate.py). ANDed, and ANDed with `key`. Empty = the topic
+    # alone ends the run, which is every document published before this.
+    where: List[Condition] = Field(default_factory=list)
+    exit_reason: str = "goal_met"
+```
+
+`goal_tiers()` orders by **specificity**, refining the phase-06 rule rather
+than replacing it — keyed tiers still come before unkeyed ones, and within
+each half a tier that carries a `where` is judged before one that does not:
+
+```python
+def goal_tiers(self, topic=None):
+    tiers = [t for t in self.goals if topic is None or topic in t.topics]
+    return sorted(tiers, key=lambda t: (t.key is None, not t.where))  # stable
+```
+
+No document published before this phase carries a `where`, so no existing
+plan's judging order changes. That is the reason for refining rather than
+re-sorting.
+
+**`entry.py::_end_on_goal`** — the live path. Generalise the existing door
+helper to take conditions instead of a door and use it in both places:
+
+```python
+def _conditions_match(conditions: List[Condition], event: RawEvent) -> bool:
+    derive = derive_for(event.source, event.topic)
+    return matches(conditions, lambda path: field_value(event.payload, path, derive))
+
+def _where_matches(door: WorkflowEntry, event: RawEvent) -> bool:   # unchanged callers
+    return _conditions_match(door.where, event)
+```
+
+and in the tier loop, after the key check and before `cancel_run`:
+
+```python
+if tier.where and not _conditions_match(tier.where, event):
+    continue  # this letter is not the thing the tier is waiting for
+```
+
+One evaluator, two surfaces. A door and a goal that both say
+`payload.gateway is COD` cannot disagree about what that means.
+
+**`goal.key.event` — the wart, fixed here because the example plan walks
+straight into it.** `_end_on_goal` reads `event.payload.get(tier.key.event)`,
+a bare top-level lookup, while `entry.key` goes through
+`field_value(canonical_path(...), derive_for(...))`. An author who writes
+`key: {event: "payload.id", run: "id"}` — the spelling the catalog and the
+console show them — gets silence. But the walker compiles the same key to
+`payload->>$5 = $6`, which is top-level-only by construction, so widening
+the reader would make the two judging sites disagree.
+
+Resolution, in this phase, as a law rather than a widening:
+
+- `entry.py` accepts the `payload.` prefix on a single-segment path and
+  strips it (`payload.id` → `id`), so both spellings read alike;
+- `validate_definition` **refuses** a `goal.key.event` naming a nested or
+  derived path: *"goal key must be a top-level payload field (it is compared
+  in SQL at fire time); `payload.customer.id` is not one."*
+
+### Part 2 — list-shaped fields, in one evaluator
+
+**`app/crm/shared/predicate.py`** (still leaf — imports nothing internal).
+
+```python
+Op = Literal["is", "is_not", "in", ">", ">=", "<", "<=", "=", "exists",
+             "has_all", "has_any", "has_none"]
+LIST_OPS = ("has_all", "has_any", "has_none")
+```
+
+`Condition._value_matches_op`: the list ops take a non-empty list of scalars,
+exactly as `in` does — reuse that branch.
+
+The normaliser, and the one place either side of a comparison is spelled:
+
+```python
+def as_tag_set(value: Any) -> Optional[FrozenSet[str]]:
+    """PURE: a list-shaped value as a comparable set, or None when the value
+    is not list-shaped at all (so no op has an opinion — the file's standing
+    rule for a field that isn't there).
+
+    A LIST is its scalar items. A STRING is split on commas: that is
+    Shopify's REST shape ("Buddy Confirmed, VIP"), and a vendor's GraphQL
+    shape is the array — one op has to read both or an author would have to
+    know which transport carried their order.
+
+    Every item is stripped and CASEFOLDED, on both sides. Shopify treats
+    tags case-insensitively and collapses whitespace; a merchant types
+    "Buddy Confirmed" into the console and Shopify stores whatever the
+    write sent. Comparing exactly would mean a goal that silently never
+    fires — the same class of harm as an unnormalised phone matching no
+    suppression (shared/normalize.py's law, applied to a filter)."""
+```
+
+`evaluate()`:
+
+```python
+if op in LIST_OPS:
+    have = as_tag_set(actual)
+    if have is None:
+        return False
+    want = set().union(*(as_tag_set(v) or set() for v in condition.value))
+    if op == "has_all":  return want <= have
+    if op == "has_any":  return bool(want & have)
+    return not (want & have)          # has_none
+```
+
+**`has_none` is "present and contains none of these", never "not
+`has_any`".** A missing `tags` key returns False for all three, because a
+field that is absent is not evidence of absence — the file's existing
+conservatism, stated for the new ops so nobody has to infer it. An empty
+string or empty array *is* present and empty: `has_none` true, `has_all`
+false. Pin both in a test.
+
+### Part 3 — the `tags` field type
+
+- `record/schemas.py`: `FieldType = Literal[..., "tags"]`.
+- `record/catalog.py`: `OPS_BY_TYPE["tags"] = [*LIST_OPS, EXISTS_OP]`.
+  `KEYABLE_TYPES` is unchanged, so a tags field is not keyable and the
+  existing law says so for free.
+- `validate_registration` (the vendor layer): `tags` carries no `values`
+  (already covered by the choice-only rule) and **may not be `variable`** —
+  a list is not a scalar, `engine.extract` drops it, and declaring it would
+  be a template promise with no reader. Refused at registration with that
+  sentence, so a vendor learns it while they are still registering.
+
+### Part 4 — Shopify: the tags field and the `orders/updated` entry
+
+**`record/extractors/shopify.py`** — one field and one entry:
+
+```python
+def _order_fields() -> List[CatalogField]:
+    return [
+        ...,
+        _f("payload.tags", "tags", "Order tags"),   # NEW — create/paid/cancelled/updated
+        ...
+    ]
+
+ENTRIES = [
+    ...,
+    _entry("orders/updated", "Order updated", _order_fields()),   # NEW
+]
+```
+
+Putting `payload.tags` on `_order_fields()` rather than only on the new entry
+gives every order topic the same field for free — "goal when an order is
+*placed* already carrying tag X" is the same author sentence with a different
+topic. `_checkout_fields()` is untouched: a checkout has no tags.
+
+The new entry inherits the full person block, which is what fixes finding
+(1): `orders/updated` starts resolving to a customer through
+`PHONE_PATHS`/`EMAIL_PATHS`/`payload.customer.id` exactly as `orders/create`
+does, instead of quarantining as `no_handle`.
+
+**Fixture** `tests/crm/fixtures/shopify/orders_updated.json` — a real
+captured body with a populated `"tags": "Buddy Confirmed, COD"`, an
+`updated_at` later than `created_at`, and the phone only under
+`customer.default_address` (so the fallback chain is exercised on this topic
+too). `tests/crm/test_catalog.py` pins every declared path against it, as it
+does for the other five.
+
+### Part 5 — the walker's re-check, without a SQL compiler
+
+The walker re-checks goals at every claim (`_advance`), through
+`customer_has_event`, which is one `EXISTS` with an optional
+`payload->>$5 = $6`. It cannot express `has_all`.
+
+**Decision: do not compile the predicate to SQL in this phase.** Compiling
+`is_not`, `=`, the ordering ops and the list ops correctly needs the field's
+catalog *type* at the query (numeric casts must be `CASE`-guarded or a
+non-numeric row raises), and it produces a second evaluator that can drift
+from `predicate.evaluate` — the exact failure `engine.py` was written to
+end ("two hand-written readers of one payload drift"). `event-catalog.md`
+owes a SQL compiler to **segments**; that phase can land it with the type
+information it needs, and this phase must not half-land it.
+
+Instead the walker uses the **same pure evaluator**, over a bounded read:
+
+- `record/db/queries.py` gains `customer_goal_events_query(merchant, customer,
+  topics, since, where, limit)` — the existing `EXISTS` body as a
+  `SELECT ... ORDER BY COALESCE(occurred_at, received_at) DESC LIMIT $n`,
+  on the same index, with the same optional top-level key narrowing.
+  `$1` params only; no new predicate reaches SQL.
+- `record/contracts.py` re-exports `customer_goal_events(...) -> List[RawEvent]`
+  through `events.py` (the `customer_has_event` seam, one function over).
+  No new leaf shape: the existing decoder already returns `RawEvent`.
+- `walker._advance`:
+
+```python
+for tier in definition.goal_tiers():
+    where = ...                       # unchanged: the top-level key pair
+    if not tier.where:
+        hit = await customer_has_event(...)          # unchanged fast path
+    else:
+        hit = any(
+            _conditions_match_payload(tier.where, letter)
+            for letter in await customer_goal_events(
+                run.merchant_id, str(run.customer_id), tier.topics,
+                since, where, GOAL_LETTER_SCAN)
+        )
+```
+
+`GOAL_LETTER_SCAN = 50`, a module constant in `walker.py` with its reason in
+the docstring. **Every plan without a `where` keeps the indexed `EXISTS`
+exactly as it is** — zero regression on the existing path, and the row read
+happens only for the tiers that asked for it.
+
+The bound is honest and is stated as a limitation, not hidden: if a run
+somehow accumulates more than 50 matching letters inside its own window and
+the qualifying one is not among the newest 50, the walker misses it. It is
+the *belt-and-suspenders* check — `entry.py` already judged that letter live
+at arrival, against the full payload, with no bound.
+
+### Part 6 — the catalog laws for a goal (this is what makes it safe)
+
+Today `gather_catalogs` collects **door topics and `wait_event` topics only**.
+Goal topics are validated against nothing, so
+`where: [{field: "payload.tags", op: "has_all", ...}]` on a topic that
+declares no tags field would publish cleanly and silently never fire — the
+precise failure the catalog law exists to prevent.
+
+- `catalog_laws.gather_catalogs`: add every `goals[].topics` entry to the
+  topic set it gathers.
+- `catalog_laws.goals_against_catalog(definition, catalogs)` — new pure
+  function beside `entry_against_catalog`, called from `validate_definition`:
+  - a tier with a `where` on a topic no layer declares →
+    *"topic 'X' is not in the catalog — register its schema (or declare it in
+    code) before filtering on it"*, the door's own sentence;
+  - each condition through the existing `condition_against_catalog`, which
+    already checks declared-field, op-fits-type, choice values, deprecation;
+  - the `goal.key.event` top-level law from Part 1.
+- `validate_definition` keeps its `catalogs is None → shape laws only`
+  contract, so every pure unit caller is unaffected.
+
+### Part 7 (optional, same grammar) — `where` on a `wait_event` square
+
+`wait_event` branches on `key` equality and nothing else. The identical
+`where: List[Condition]` on a listening square — "a letter only answers this
+square if it also satisfies these conditions" — is the same three lines in
+`entry.py::_answer_for` / `_is_about`, entirely in memory, with **no walker
+or SQL involvement at all**. It is arguably the better modelling for "wait
+until the order carries the tag" (a square you stand on, with a timeout edge)
+than a goal.
+
+Land it in this PR only if the diff stays reviewable; otherwise it is phase
+21 and this file says so. Do not land it half-way.
+
+---
+
+## What this does *not* need
+
+- **No migration.** The goal document lives in `crm_workflow.definition` /
+  `crm_workflow_version.definition` jsonb; no new `exit_reason`, so migration
+  063's CHECK is untouched; no new table, so `TABLE_OWNERS` and
+  `docs/crm/migrations.md` are unchanged.
+- **No nautilus change.** Verified above, end to end. What to *check* before
+  relying on it is in Rollout below.
+- **No change to pinned runs.** A run pinned to a pre-20 version keeps its
+  own goals, judged by its own document (`definitions.py`) — the ADR 0023
+  path, working as designed.
+
+---
+
+## The two traps, stated so an author meets them in the doc and not in prod
+
+**1. The plan's own tag write echoes back.** If the plan's `action` square
+writes `Buddy Confirmed` and the goal fires on `has_all: ["Buddy Confirmed"]`,
+then Shopify's `orders/updated` for *our own write* ends the run. Whether
+that is right depends on which sentence the author means:
+
+- *"the run ends when the confirmation is durably recorded in Shopify"* —
+  correct, and the echo **is** the acknowledgement. This is the normal case.
+- *"the run ends when somebody else confirms the order"* — wrong, and the
+  goal must name a tag the plan does not itself write (an ops tag, a
+  fulfilment tag), or the check belongs on a `wait_event` square (Part 7)
+  rather than on a goal.
+
+We cannot distinguish the two from the payload: Shopify's webhook carries no
+trace of the `_run_ref` idempotency key the action sent. So this is an
+author's decision, and the console copy for a tags condition should say so
+in one line.
+
+**2. `orders/updated` is a high-volume topic.** Every fulfilment, edit,
+refund and tag write on every order of every relayed shop now becomes a spine
+row (correctly: the `externalId` revision suffix makes each edit distinct, so
+they do not collapse). Two consequences to watch, neither blocking: the
+`crm_event_raw` growth rate for pilot shops, and the entry-rules consumer
+now running per edit — it is `O(open runs for that customer)` and already
+bounded, but the pass rate is what to look at first if the worker lags.
+
+---
+
+## The authored plan, end to end
+
+```json
+{
+  "purpose_key": "order_confirmation",
+  "entry": [{ "topic": "orders/create", "start": "hold", "key": "id",
+              "where": [{ "field": "payload.gateway", "op": "is", "value": "COD" }] }],
+  "nodes": [
+    { "id": "hold",   "type": "wait", "minutes": 30 },
+    { "id": "call",   "type": "call", "template_id": "…" },
+    { "id": "tag_it", "type": "action", "connector": "shopify", "action": "update_order",
+      "args": { "order_id": "{id}", "tags": ["Buddy Confirmed"],
+                "note": "Confirmed on a Buddy call" } }
+  ],
+  "edges": [["hold", "call"], ["call", "tag_it"]],
+  "goals": [
+    { "topics": ["orders/updated"],
+      "key":   { "event": "id", "run": "id" },
+      "where": [{ "field": "payload.tags", "op": "has_all",
+                  "value": ["Buddy Confirmed"] }],
+      "exit_reason": "goal_met" },
+    { "topics": ["orders/cancelled"], "exit_reason": "withdrawn" }
+  ],
+  "exits": { "max_age_days": 3 }
+}
+```
+
+`key` ties the letter to **this** order (`entry.key: "id"` makes the order id
+the enrollment key, and `_context_from_payload` copies the top-level `id`
+into the run's context, so `run: "id"` resolves). `where` says which edit
+counts. Both must hold. The second tier needs neither — a cancellation is
+unambiguous — and that asymmetry is the point of the feature.
+
+---
+
+## Red tests
+
+Every one fails on `release`.
+
+**predicate** — `as_tag_set` over `"A, B"`, `["A","B"]`, `""`, `[]`, `None`,
+`{"a":1}`, `"  a ,, B  "`; casefold on both sides (`"buddy confirmed"` in the
+payload satisfies `has_all: ["Buddy Confirmed"]`); `has_all` / `has_any` /
+`has_none` truth tables; **`has_none` on a missing field is False**; the list
+ops refuse a scalar value and an empty list at model_validate.
+
+**catalog** — `OPS_BY_TYPE["tags"]` is exactly the list ops plus `exists`;
+`with_ops` fills them; a registration declaring `type: "tags"` with
+`variable: true` is refused, one declaring it plain is accepted;
+`("shopify","orders/updated")` is in `CATALOG`; every path it declares
+resolves against `orders_updated.json`; `payload.tags` resolves on
+`orders_create.json` too.
+
+**record decode** — `orders/updated` through `_run_processor` resolves a
+customer (the finding-(1) regression: on `release` the same fixture
+quarantines `no_handle`).
+
+**queries** — `customer_goal_events_query` contains `LIMIT`, `ORDER BY
+COALESCE(occurred_at, received_at) DESC`, the same key clause, and `$1`
+placeholders only.
+
+**outreach schema** — a tier with `where` validates; `goal_tiers()` order is
+`keyed+where, keyed, where, plain`; a pre-20 document (`goal` singular, no
+`where`) is unchanged.
+
+**catalog laws** — a goal `where` on an undeclared topic is refused with the
+register-the-schema sentence; `has_all` on a `text` field is refused as a
+wrong op; `goal.key.event: "payload.customer.id"` is refused; `"payload.id"`
+and `"id"` both accepted and read alike.
+
+**entry** (monkeypatched accessor) — an `orders/updated` with the tag ends
+the run `goal_met`; one *without* it (a shipping edit on the same order)
+ends nothing; one with the tag but **another order's id** ends nothing.
+
+**walker** — a tier with `where`: `customer_goal_events` returns a
+non-matching letter → the run does not exit; returns a matching one → exits
+with the tier's reason; a tier **without** `where` still calls
+`customer_has_event` and never `customer_goal_events` (pins the fast path).
+
+---
+
+## Acceptance
+
+- `uv run black . && uv run isort . --profile black && uv run autoflake … &&
+  uv run pyrefly check && uv run pytest tests/ && uv run python
+  scripts/check_crm_boundaries.py` — all unpiped, all green.
+- `check_migrations.py --base origin/release` clean and reporting **no new
+  migration** (a migration in this PR means the design drifted).
+- `predicate.py` still imports nothing internal.
+- Import-smoke, not just pyrefly: the catalog registry actually carries
+  `orders/updated`, and `outreach.plans.validate_definition` actually refuses
+  the four new problems, run from a REPL.
+- One commit.
+
+## Rollout
+
+1. Merge; nothing changes for an existing plan (no document has a `where`).
+2. Confirm the pilot shop is in `CRM_EVENT_RELAY_MERCHANTS` and that
+   `orders/updated` rows are landing **processed with a `customer_id`**, not
+   quarantined `no_handle` — that flip is the observable proof Part 4 worked.
+3. Re-publish the pilot plan with the goal `where`. It takes effect for new
+   runs; runs in flight keep their pinned version (`on_publish: "pin"`), or
+   `migrate` them deliberately.
+4. Watch `crm_event_raw` growth and the event worker's pass rate for the
+   first day of `orders/updated` volume.
+
+## Decisions already made
+
+- The check is a **condition list on the goal tier**, not a tags feature and
+  not a Shopify branch. Anything a door can say, a goal can now say.
+- The tier's `where` and its `key` are **ANDed**. A tier is one sentence.
+- **Case-insensitive, whitespace-trimmed tag comparison, both sides.** The
+  alternative silently never fires.
+- **`has_none` requires the field to be present.** Absence is not evidence.
+- **No SQL predicate compiler in this phase.** One evaluator or none; the
+  compiler is owed to segments, with the field types it needs.
+- The tags condition's *value* is a **literal list** the author writes. It is
+  not automatically read from the `action` node's `args.tags` — the tag a
+  goal waits for is very often not one this plan writes.
+- The echo (Part 6 trap 1) is an **author's decision**, surfaced in console
+  copy, never a silent filter.
+
+## Out of scope
+
+- **A goal condition whose value references a run fact** (`{"run":
+  "action_tag_it_tagged"}`, generalising `WorkflowGoalKey` to the whole
+  grammar). This is what "the tags this run actually wrote" would need when
+  the action's tags are `{placeholder}`-resolved rather than literal. Real,
+  clearly scoped, and its own phase.
+- **The SQL compiler** for the predicate — segments' phase.
+- **`goalable`.** `CatalogEntry.goalable` has been declared since the catalog
+  landed and has **no reader anywhere**. The natural one is right here ("this
+  topic may not be a goal"), but it needs `Catalogs` to carry entry-level
+  flags, not just a field map — a contract shape change. Note it in
+  `99-backlog.md` with this file as the reason it was noticed.
+- **`variable: true` on a tags field** (list-shaped facts in templates) —
+  that is backlog item G4, which needs a ruling.
+- **Part 7** if it does not fit this PR.
+
+---
+
+## As built (9 Sep 2026)
+
+Landed as specified above, with four deviations worth recording:
+
+1. **`conditions.py` is a new file.** The plan said generalise
+   `entry._where_matches` into `_conditions_match` and call it from the
+   walker. The walker importing the entry consumer is the wrong edge, so
+   the evaluator became its own concern file —
+   `app/crm/outreach/conditions.py::conditions_match` — which both judging
+   sites import. Same one-evaluator guarantee, no cycle.
+2. **The goal key's two spellings live on the model.**
+   `WorkflowGoalKey.event_field` (a property in `schemas.py`) strips a
+   `payload.` prefix, so `entry.py` and `walker.py` read one key by
+   construction; the nested-path refusal is in `goals_against_catalog`.
+3. **Two fixtures, not one.** `orders_updated.json` (carrying the tag) and
+   `orders_updated_shipping.json` (a fulfilment on the same order). The
+   pair *is* the feature: every test that matters asserts against both.
+   `test_catalog.py`'s `OPS_BY_TYPE` pin was extended with `tags` — that
+   test is the closed-set law, so extending the set edits it deliberately.
+4. **Part 7 (`where` on a `wait_event` square) was NOT landed.** The PR was
+   already wide. It is phase 21; the grammar and the evaluator it needs are
+   both in place, so it is a small file.
+
+Verified: `pytest tests/` 2544 passed / 15 skipped / 1 xfailed · pyrefly 0
+errors · `check_crm_boundaries.py` clean · `check_migrations.py --base
+origin/release` reports **no new migration**, as the design requires.
+
+Both regression tests were confirmed RED against the unfixed code by
+temporarily reverting each judging site in turn — the walker bypass fails
+`test_the_walker_does_not_end_a_run_on_an_edit_the_where_declines` and
+`..._accepts`; the live-path bypass fails
+`test_a_shipping_edit_on_the_same_order_ends_nothing`.
+
+**Still blocked on nautilus.** None of this fires until nautilus #205
+(`feat(crm-relay): relay orders/updated, keyed by the edit's own
+timestamp`) merges. It is currently applied to the working tree as a
+patch, not on `release`.

--- a/tests/crm/test_catalog.py
+++ b/tests/crm/test_catalog.py
@@ -121,6 +121,8 @@ def test_ops_come_from_type_and_phone_is_never_filterable() -> None:
         "datetime",
         "phone",
         "list",
+        # LIST-shaped: containment, never equality (predicate.LIST_OPS).
+        "tags",
     }
 
 

--- a/tests/crm/test_predicate.py
+++ b/tests/crm/test_predicate.py
@@ -5,7 +5,14 @@ field satisfies nothing, the `is` family compares text exactly, and only
 
 import pytest
 
-from app.crm.shared.predicate import Condition, evaluate, from_equality_map, matches
+from app.crm.shared.predicate import (
+    Condition,
+    Op,
+    as_tag_set,
+    evaluate,
+    from_equality_map,
+    matches,
+)
 
 
 @pytest.mark.parametrize(
@@ -97,3 +104,66 @@ def test_from_equality_map_is_what_migration_069_writes() -> None:
     assert from_equality_map({"gateway": "COD"}) == [
         Condition(field="payload.gateway", op="is", value="COD")
     ]
+
+
+# --- LIST-shaped fields: has_all · has_any · has_none (phase 20) -------------
+
+
+def test_a_tag_set_reads_both_shopify_shapes_and_nothing_else() -> None:
+    # REST posts one comma string, GraphQL an array: one op reads both, or
+    # a rule would depend on which transport carried the order.
+    assert as_tag_set("Buddy Confirmed, COD") == frozenset({"buddy confirmed", "cod"})
+    assert as_tag_set(["Buddy Confirmed", "COD"]) == frozenset(
+        {"buddy confirmed", "cod"}
+    )
+    # Present and empty is a SET, not an absence.
+    assert as_tag_set("") == frozenset()
+    assert as_tag_set([]) == frozenset()
+    # Blank members and stray whitespace never become tags.
+    assert as_tag_set("  a ,, B  ") == frozenset({"a", "b"})
+    # Not list-shaped at all: no op has an opinion.
+    for value in (None, {"a": 1}, True, 7):
+        assert as_tag_set(value) is None, value
+
+
+def test_the_list_ops_are_case_and_whitespace_insensitive_on_both_sides() -> None:
+    # Shopify matches tags case-insensitively; comparing exactly would give
+    # a goal that silently never fires.
+    tagged = Condition(field="payload.tags", op="has_all", value=["Buddy Confirmed"])
+    assert evaluate(tagged, "buddy confirmed, cod")
+    assert evaluate(tagged, ["  BUDDY CONFIRMED  "])
+
+
+def test_has_all_has_any_has_none_truth_table() -> None:
+    tags = "Buddy Confirmed, COD"
+
+    def check(op: Op, value: list) -> bool:
+        return evaluate(Condition(field="payload.tags", op=op, value=value), tags)
+
+    assert check("has_all", ["cod", "buddy confirmed"])
+    assert not check("has_all", ["cod", "refunded"])
+    assert check("has_any", ["refunded", "cod"])
+    assert not check("has_any", ["refunded"])
+    assert check("has_none", ["refunded"])
+    assert not check("has_none", ["refunded", "cod"])
+
+
+def test_a_missing_field_answers_no_to_every_list_op_including_has_none() -> None:
+    """`has_none` is "present and holds none of these", never "not
+    has_any": an absent field is not evidence of absence, and this file's
+    standing rule is that a missing field satisfies no op."""
+    ops: tuple[Op, ...] = ("has_all", "has_any", "has_none")
+    for op in ops:
+        assert not evaluate(
+            Condition(field="payload.tags", op=op, value=["x"]), None
+        ), op
+    # …but present-and-empty DOES answer has_none.
+    assert evaluate(Condition(field="payload.tags", op="has_none", value=["x"]), "")
+
+
+def test_the_list_ops_need_a_non_empty_list_of_scalars() -> None:
+    ops: tuple[Op, ...] = ("has_all", "has_any", "has_none")
+    for op in ops:
+        for bad in ("a-scalar", [], [None], [["nested"]]):
+            with pytest.raises(ValueError):
+                Condition(field="payload.tags", op=op, value=bad)

--- a/tests/crm/test_workflow_goal_conditions.py
+++ b/tests/crm/test_workflow_goal_conditions.py
@@ -1,0 +1,511 @@
+"""Conditions on a goal tier (rollout phase 20).
+
+A goal tier said WHICH topics end a run and, since phase 06, which RUN a
+letter is about. It could not say what the letter had to CONTAIN — fine
+while every goal topic was a once-per-order fact, wrong the moment the
+topic is a many-reasons one. Shopify fires orders/updated for a
+fulfilment, a note, an address fix and a tag write alike, so "the topic
+arrived" is not the goal.
+
+`goal.where` is the door's own typed grammar on the verdict side, and the
+tests below pin the three things that make it safe rather than merely
+present: the live consumer declines the wrong edit; the WALKER's
+re-check declines it too (the bypass that would otherwise undo the filter
+at the next claim); and the publish validator refuses a condition the
+catalog cannot answer, instead of letting it publish and never fire.
+"""
+
+import asyncio
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, List, Optional, Tuple
+from uuid import UUID, uuid4
+
+import pytest
+
+import app.crm.outreach.definitions as definitions
+import app.crm.outreach.entry as entry
+import app.crm.outreach.walker as walker
+from app.crm.outreach.catalog_laws import goals_against_catalog
+from app.crm.outreach.entry import consume_attributed_event
+from app.crm.outreach.plans import validate_definition
+from app.crm.outreach.schemas import (
+    EnrollmentRun,
+    Workflow,
+    WorkflowDefinition,
+)
+from app.crm.record.catalog import code_entries
+from app.crm.record.db.queries import customer_goal_events_query
+from app.crm.record.schemas import RawEvent
+
+NOW = datetime(2026, 9, 3, 10, 0, tzinfo=timezone.utc)
+
+
+class _Frozen(datetime):
+    """`datetime` with `now()` pinned to NOW — a subclass, so the walker's
+    arithmetic against entered_at still behaves."""
+
+    @classmethod
+    def now(cls, tz: Optional[timezone] = None) -> datetime:  # type: ignore[override]
+        return NOW
+
+
+@pytest.fixture(autouse=True)
+def frozen_clock(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The fixtures are dated; walk_run asks the REAL clock for
+    `now - entered_at > max_age_days` (default 7), so they expire on a date."""
+    monkeypatch.setattr(walker, "datetime", _Frozen)
+
+
+LEASE = NOW + timedelta(seconds=300)
+
+CONFIRMED = "Buddy Confirmed"
+
+# The board the WhatsApp confirmation flow actually publishes: admitted on
+# a COD order, tagged by an action square, and ended by Shopify's echo of
+# THAT tag — never by the fulfilment that follows it.
+_TAG_GOAL: Dict[str, Any] = {
+    "topics": ["orders/updated"],
+    "key": {"event": "id", "run": "id"},
+    "where": [{"field": "payload.tags", "op": "has_all", "value": [CONFIRMED]}],
+    "exit_reason": "goal_met",
+}
+_PLAN: Dict[str, Any] = {
+    "entry": {"topic": "orders/create", "key": "id"},
+    "nodes": [{"id": "hold", "type": "wait", "minutes": 30}],
+    "edges": [],
+    "goals": [_TAG_GOAL],
+}
+
+
+def _catalogs() -> Dict[str, Optional[Dict[str, Any]]]:
+    """The real code-layer field maps, keyed the way gather_catalogs keys
+    them — so these laws are checked against the catalog we actually ship,
+    not a hand-written stand-in that could drift from it."""
+    by_topic: Dict[str, Optional[Dict[str, Any]]] = {}
+    for entry_ in code_entries():
+        if entry_.source == "shopify":
+            by_topic[entry_.topic] = {f.path: f for f in entry_.fields}
+    return by_topic
+
+
+# --- the vocabulary ---------------------------------------------------------
+
+
+def test_a_goal_tier_carries_conditions_and_an_empty_where_is_the_old_behaviour() -> (
+    None
+):
+    definition = WorkflowDefinition.model_validate(_PLAN)
+    (tier,) = definition.goals
+    assert [c.op for c in tier.where] == ["has_all"]
+    plain = WorkflowDefinition.model_validate(
+        {**_PLAN, "goals": [{"topics": ["orders/paid"]}]}
+    )
+    assert plain.goals[0].where == []
+
+
+def test_tiers_are_judged_keyed_first() -> None:
+    """The phase-06 rule, unchanged: the keyed tier says "THIS order" and a
+    run it ends is no longer open for the unkeyed sweep. A `where` narrows a
+    tier but does not reorder it — tiers are filtered by TOPIC first, so two
+    tiers of one plan rarely compete at all."""
+    unkeyed = {"topics": ["orders/updated"], "exit_reason": "converted_elsewhere"}
+    definition = WorkflowDefinition.model_validate(
+        {**_PLAN, "goals": [unkeyed, _TAG_GOAL]}  # least specific first
+    )
+    assert [t.exit_reason for t in definition.goal_tiers()] == [
+        "goal_met",  # keyed
+        "converted_elsewhere",  # unkeyed
+    ]
+
+
+def test_a_goal_key_must_be_a_top_level_payload_field() -> None:
+    """The walker compares this key in SQL as payload->>$5 — one key,
+    nothing deeper. Anything with a dot would work at the live consumer and
+    silently match nothing at the next claim, so it is refused instead."""
+    for bad in ("payload.id", "customer.id"):
+        problems = goals_against_catalog(
+            WorkflowDefinition.model_validate(
+                {**_PLAN, "goals": [{**_TAG_GOAL, "key": {"event": bad, "run": "id"}}]}
+            ),
+            _catalogs(),
+        )
+        assert any("top-level payload field" in p for p in problems), (bad, problems)
+    # the bare key is what the letter carries, and what the SQL can compare
+    assert (
+        goals_against_catalog(WorkflowDefinition.model_validate(_PLAN), _catalogs())
+        == []
+    )
+
+
+# --- the publish laws -------------------------------------------------------
+
+
+def test_a_condition_on_an_undeclared_goal_topic_is_refused() -> None:
+    """Without this the plan publishes cleanly and silently never fires —
+    the failure the door-side catalog law exists to prevent, one surface
+    over."""
+    problems = goals_against_catalog(
+        WorkflowDefinition.model_validate(
+            {**_PLAN, "goals": [{**_TAG_GOAL, "topics": ["orders/nobody-declares"]}]}
+        ),
+        _catalogs(),
+    )
+    assert any("not in the catalog" in p for p in problems), problems
+
+
+def test_a_tier_without_conditions_may_still_name_any_topic() -> None:
+    """Only a tier that asks a question about a payload has to prove the
+    payload is one we can read."""
+    assert (
+        goals_against_catalog(
+            WorkflowDefinition.model_validate(
+                {**_PLAN, "goals": [{"topics": ["orders/nobody-declares"]}]}
+            ),
+            _catalogs(),
+        )
+        == []
+    )
+
+
+def test_a_list_op_on_a_text_field_is_refused() -> None:
+    problems = goals_against_catalog(
+        WorkflowDefinition.model_validate(
+            {
+                **_PLAN,
+                "goals": [
+                    {
+                        **_TAG_GOAL,
+                        "where": [
+                            {"field": "payload.name", "op": "has_all", "value": ["x"]}
+                        ],
+                    }
+                ],
+            }
+        ),
+        _catalogs(),
+    )
+    assert any("is not an op" in p for p in problems), problems
+
+
+def test_the_shipped_confirmation_plan_passes_every_law() -> None:
+    assert validate_definition(_PLAN, catalogs=_catalogs()) == []
+
+
+def test_a_nested_goal_key_is_refused_because_the_walker_compares_it_in_sql() -> None:
+    """A nested path would work at the live consumer and silently match
+    nothing at the walker — the two judging sites must agree."""
+    problems = goals_against_catalog(
+        WorkflowDefinition.model_validate(
+            {
+                **_PLAN,
+                "goals": [{**_TAG_GOAL, "key": {"event": "customer.id", "run": "id"}}],
+            }
+        ),
+        _catalogs(),
+    )
+    assert any("top-level payload field" in p for p in problems), problems
+
+
+# --- the live consumer ------------------------------------------------------
+
+
+def _flow() -> Workflow:
+    return Workflow(
+        id=uuid4(),
+        merchant_id="m1",
+        name="cod-confirmation",
+        status="live",
+        version=1,
+        created_by=None,
+        created_at=NOW,
+        updated_at=NOW,
+        definition=_PLAN,
+        draft=None,
+    )
+
+
+def _run(flow: Workflow, order_id: str = "5201000001") -> EnrollmentRun:
+    return EnrollmentRun(
+        id=uuid4(),
+        merchant_id="m1",
+        workflow_id=flow.id,
+        workflow_version=1,
+        customer_id=uuid4(),
+        status="waiting",
+        current_node="hold",
+        wake_at=NOW + timedelta(minutes=30),
+        entered_at=NOW - timedelta(hours=1),
+        exited_at=None,
+        exit_reason=None,
+        context={
+            "id": order_id,
+            "entered_event_at": (NOW - timedelta(hours=1)).isoformat(),
+        },
+        enrollment_key=order_id,
+        attempts=0,
+        last_error=None,
+    )
+
+
+def _event(payload: Dict[str, Any]) -> RawEvent:
+    return RawEvent(
+        id="ev-1",
+        merchant_id="m1",
+        source="shopify",
+        topic="orders/updated",
+        schema_version="1",
+        external_id="orders/updated:1",
+        payload=payload,
+        received_at=NOW,
+        occurred_at=NOW,
+    )
+
+
+class _Spine:
+    def __init__(self, flow: Workflow, run: EnrollmentRun) -> None:
+        self.flows = [flow]
+        self.runs = [run]
+        self.versions = {(str(flow.id), 1): _PLAN}
+        self.cancels: List[Tuple[str, str]] = []
+
+    async def live_workflows(self, merchant_id: str) -> List[Workflow]:
+        return list(self.flows)
+
+    async def open_runs_for_customer(self, *_: Any) -> List[EnrollmentRun]:
+        return list(self.runs)
+
+    async def get_definition(
+        self, merchant_id: str, workflow_id: str, version: int
+    ) -> Optional[Dict[str, Any]]:
+        return self.versions.get((workflow_id, version))
+
+    async def cancel_run(
+        self,
+        merchant_id: str,
+        run_id: str,
+        exit_reason: str,
+        occurred_at: Optional[datetime] = None,
+        key: Optional[Tuple[str, str]] = None,
+        context_patch: Optional[Dict[str, Any]] = None,
+    ) -> bool:
+        self.cancels.append((run_id, exit_reason))
+        return True
+
+    async def resume_run_by_id(self, *_: Any, **__: Any) -> bool:
+        return True
+
+    async def patch_open_run(self, *_: Any, **__: Any) -> bool:
+        return False
+
+
+@pytest.fixture
+def spine(monkeypatch: pytest.MonkeyPatch) -> _Spine:
+    flow = _flow()
+    fake = _Spine(flow, _run(flow))
+    definitions._definitions.clear()
+    for module, name in (
+        (entry.workflow_accessor, "live_workflows"),
+        (entry.enrollment_accessor, "open_runs_for_customer"),
+        (definitions.version_accessor, "get_definition"),
+        (entry.enrollment_accessor, "cancel_run"),
+        (entry.enrollment_accessor, "resume_run_by_id"),
+    ):
+        monkeypatch.setattr(module, name, getattr(fake, name))
+    return fake
+
+
+def test_the_tag_edit_ends_the_run(spine: _Spine) -> None:
+    asyncio.run(
+        consume_attributed_event(
+            _event({"id": 5201000001, "tags": f"{CONFIRMED}, COD"}), "c-1", {}
+        )
+    )
+    assert [reason for _, reason in spine.cancels] == ["goal_met"]
+
+
+def test_a_shipping_edit_on_the_same_order_ends_nothing(spine: _Spine) -> None:
+    """The right topic about the right run — and the wrong edit. This is
+    the whole point of the feature."""
+    asyncio.run(
+        consume_attributed_event(
+            _event(
+                {"id": 5201000001, "tags": "COD", "fulfillment_status": "fulfilled"}
+            ),
+            "c-1",
+            {},
+        )
+    )
+    assert spine.cancels == []
+
+
+def test_the_tag_on_another_order_ends_nothing(spine: _Spine) -> None:
+    asyncio.run(
+        consume_attributed_event(
+            _event({"id": 9999999999, "tags": f"{CONFIRMED}"}), "c-1", {}
+        )
+    )
+    assert spine.cancels == []
+
+
+# --- the walker's re-check (the bypass this phase closes) -------------------
+
+
+class _Writes:
+    def __init__(self) -> None:
+        self.calls: List[Tuple[str, Any]] = []
+
+    async def get_workflow(self, merchant_id: str, workflow_id: str) -> Workflow:
+        return _flow()
+
+    async def get_definition(self, *_: Any) -> Dict[str, Any]:
+        return _PLAN
+
+    async def exit_run(self, *args: Any, **kwargs: Any) -> bool:
+        self.calls.append(("exit", args))
+        return True
+
+    async def advance_run(self, *args: Any) -> bool:
+        self.calls.append(("advance", args))
+        return True
+
+    async def park_run(self, *args: Any) -> bool:
+        self.calls.append(("park", args))
+        return True
+
+    async def record_run_error(self, *args: Any) -> bool:
+        self.calls.append(("retry", args))
+        return True
+
+
+def _walk(monkeypatch: pytest.MonkeyPatch, letters: List[Dict[str, Any]]) -> _Writes:
+    """One claim of a run standing on its wait, with `letters` as what the
+    goal read returns."""
+    writes = _Writes()
+    from tests.crm.doubles import patch_accessors
+
+    definitions._definitions.clear()
+    patch_accessors(monkeypatch, walker, writes)
+    patch_accessors(monkeypatch, definitions, writes)
+
+    async def _events(*_: Any, **__: Any) -> List[RawEvent]:
+        return [_event(payload) for payload in letters]
+
+    async def _exists(*_: Any, **__: Any) -> bool:
+        raise AssertionError(
+            "a tier carrying a `where` must not be answered by the EXISTS — "
+            "it knows only the topic and the key"
+        )
+
+    monkeypatch.setattr(walker, "customer_goal_events", _events)
+    monkeypatch.setattr(walker, "customer_has_event", _exists)
+    flow = _flow()
+    run = _run(flow)
+    asyncio.run(walker._advance(run, WorkflowDefinition.model_validate(_PLAN), LEASE))
+    return writes
+
+
+def test_the_walker_does_not_end_a_run_on_an_edit_the_where_declines(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """THE regression. The SQL narrows to topic + order id, so a fulfilment
+    on this order comes back from the read; without the conditions being
+    re-applied here, the run would exit `goal_met` at its next claim and
+    silently undo what the live consumer got right."""
+    writes = _walk(
+        monkeypatch, [{"id": 5201000001, "tags": "COD", "fulfillment_status": "x"}]
+    )
+    reasons = [args[1] for kind, args in writes.calls if kind == "exit"]
+    assert "goal_met" not in reasons, writes.calls
+    # It exits `completed` instead: this board is one square with no arrow
+    # out, so the token walks off the end in the same visit. That is the
+    # walker's own verdict about the BOARD, never a tier's about the goal —
+    # and it is why a plan that wants Shopify's echo to be its record has
+    # to keep a square to stand on while the echo travels.
+    assert reasons == ["completed"]
+
+
+def test_the_walker_ends_a_run_on_an_edit_the_where_accepts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    writes = _walk(monkeypatch, [{"id": 5201000001, "tags": f"{CONFIRMED}, COD"}])
+    exits = [args for kind, args in writes.calls if kind == "exit"]
+    assert exits and exits[0][1] == "goal_met", writes.calls
+
+
+def test_a_tier_without_conditions_still_uses_the_indexed_exists(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Every plan published before this phase costs exactly what it did:
+    no payload read, one EXISTS."""
+    writes = _Writes()
+    from tests.crm.doubles import patch_accessors
+
+    definitions._definitions.clear()
+    patch_accessors(monkeypatch, walker, writes)
+    patch_accessors(monkeypatch, definitions, writes)
+    asked: List[str] = []
+
+    async def _exists(*_: Any, **__: Any) -> bool:
+        asked.append("exists")
+        return False
+
+    async def _events(*_: Any, **__: Any) -> List[RawEvent]:
+        raise AssertionError("a tier with no `where` must not read payloads")
+
+    monkeypatch.setattr(walker, "customer_has_event", _exists)
+    monkeypatch.setattr(walker, "customer_goal_events", _events)
+    plain = {**_PLAN, "goals": [{"topics": ["orders/paid"]}]}
+    flow = _flow()
+    asyncio.run(
+        walker._advance(_run(flow), WorkflowDefinition.model_validate(plain), LEASE)
+    )
+    assert asked == ["exists"]
+
+
+# --- the read behind it -----------------------------------------------------
+
+
+def test_the_goal_events_query_is_bounded_newest_first_and_parameterised() -> None:
+    query, params = customer_goal_events_query(
+        "m1", "c-1", ["orders/updated"], NOW, ("id", "5201000001"), 50
+    )
+    assert "ORDER BY COALESCE(occurred_at, received_at) DESC" in query
+    assert "LIMIT $7" in query
+    assert "payload->>$5 = $6" in query
+    assert params[-1] == 50
+    # No value is ever spelled into the SQL text (one DB role, total blast
+    # radius) — every one of them is a placeholder.
+    for value in ("m1", "c-1", "5201000001"):
+        assert value not in query
+
+
+# --- a call's own facts reach the square after it (crm_mirror + telephony
+#     spec + listened_facts) ----------------------------------------------
+
+
+def test_gather_reads_both_goal_spellings(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`goal` (singular) is the pre-phase-06 spelling. The MODEL rewrites it
+    to `goals`, but gather_catalogs runs on the RAW document — before any
+    model has touched it — so it must read both, or a legacy plan's goal
+    topic is never gathered and its conditions are checked against nothing.
+
+    Version rows are immutable, so those documents never go away."""
+    import app.crm.outreach.catalog_laws as laws
+
+    asked: List[str] = []
+
+    async def _fields(_merchant: str, topic: str) -> Optional[Dict[str, Any]]:
+        asked.append(topic)
+        return {}
+
+    monkeypatch.setattr(laws, "catalog_fields", _fields)
+    base: Dict[str, Any] = {
+        "entry": {"topic": "orders/create"},
+        "nodes": [{"id": "w", "type": "wait", "minutes": 1}],
+    }
+    tier = {"topics": ["orders/updated"]}
+
+    for spelling in ({"goals": [tier]}, {"goal": tier}):
+        asked.clear()
+        asyncio.run(laws.gather_catalogs("m1", {**base, **spelling}))
+        assert "orders/updated" in asked, spelling


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable conditions to workflow goal tiers.
  - Added tag-based filtering with `has_all`, `has_any`, and `has_none` operators.
  - Shopify order tags are now available as filterable fields.
  - Goal evaluation now rechecks matching events before completing a workflow.

- **Bug Fixes**
  - Improved consistency between entry conditions and goal conditions.
  - Added validation to prevent unsupported goal topics and fields from being published.

- **Documentation**
  - Added rollout documentation for goal conditions and tag filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->