### PR TITLE
feat(uap): rider can delete a payment agent (INACTIVE, never re-adopted)

### DIFF
--- a/app/api/routers/breeze_buddy/preview/uap/handlers.py
+++ b/app/api/routers/breeze_buddy/preview/uap/handlers.py
@@ -13,6 +13,7 @@ from app.crm.identity.contracts import get_customer, resolve
 from app.crm.preview.uap.contracts import (
     CrmCustomerAgent,
     create_attempt,
+    deactivate_agent,
     get_by_agent_id,
     get_by_agent_obj_ref,
     get_drawable_for_customer,
@@ -502,7 +503,9 @@ async def _reuse_existing(
     our table if we did not know it — a rider who consented once (another
     device, a lost webhook) is never asked again. Only OUR refs
     (``agent_<customer>_*``) are eligible: a stranger's agent on the same
-    Juspay customer must never stand in."""
+    Juspay customer must never stand in. An agent the rider DELETED here
+    (row INACTIVE, matched by our ref or by agent_id) is skipped: neither
+    re-adopted nor refreshed."""
     try:
         agents = await uap_api.list_agents(creds, juspay_customer_id)
     except JuspayError as exc:
@@ -516,6 +519,10 @@ async def _reuse_existing(
         if str(agent.get("status") or "").upper() != "ACTIVE":
             continue
         row = await get_by_agent_obj_ref(ref)
+        if row is None and agent.get("agent_id"):
+            row = await get_by_agent_id(str(agent["agent_id"]))
+        if row is not None and row.status == "INACTIVE":
+            continue
         if row is None:
             # Adopt with the intent ref Juspay reports; the refresh below
             # reads the approved rule from the action record.
@@ -816,6 +823,26 @@ async def select_agent_for_rider(payload: SelectAgentRequest) -> Dict[str, Any]:
     ok = await set_preferred_agent(
         scope.merchant_id, scope.customer_id, payload.agent_ref
     )
+    if not ok:
+        raise HTTPException(
+            status.HTTP_404_NOT_FOUND, detail="No such payment agent for this rider"
+        )
+    agents = await list_drawable_for_customer(scope.merchant_id, scope.customer_id)
+    return {
+        "agents": [await _agent_view(scope, a, i == 0) for i, a in enumerate(agents)],
+        "count": len(agents),
+    }
+
+
+@onboarding_router.post("/agents/delete")
+async def delete_agent_for_rider(payload: SelectAgentRequest) -> Dict[str, Any]:
+    """The rider deleted a payment agent. The row goes INACTIVE (kept, so
+    the same Juspay agent is never re-adopted on the next Setup) and is
+    no longer preferred; the mandate at Juspay is left as it is. Only a
+    ref belonging to THIS rider can be deleted."""
+    scope = await _scope(payload.session_id)
+    assert scope.customer_id
+    ok = await deactivate_agent(scope.merchant_id, scope.customer_id, payload.agent_ref)
     if not ok:
         raise HTTPException(
             status.HTTP_404_NOT_FOUND, detail="No such payment agent for this rider"

--- a/app/crm/preview/uap/contracts.py
+++ b/app/crm/preview/uap/contracts.py
@@ -5,6 +5,7 @@ tool) may import from app/crm/preview/uap (PREVIEW: logic not final).
 """
 
 from app.crm.preview.uap.db.accessor import (
+    deactivate_agent,
     get_by_agent_id,
     get_by_agent_obj_ref,
     get_drawable_for_customer,
@@ -33,6 +34,7 @@ __all__ = [
     "apply_juspay_records",
     "check_draw",
     "create_attempt",
+    "deactivate_agent",
     "derive_status",
     "get_by_agent_id",
     "get_by_agent_obj_ref",

--- a/app/crm/preview/uap/db/accessor.py
+++ b/app/crm/preview/uap/db/accessor.py
@@ -46,6 +46,9 @@ _PATCHABLE = (
 # are always kept; of the rest only the newest KEEP_SETTLED stay, so a
 # rider who retried onboarding fifty times does not carry fifty corpses.
 _LIVE_STATUSES = {"PENDING", "ACTIVE", "PAUSED"}
+# INACTIVE rows are kept too: they are how a Juspay agent the rider deleted
+# here is recognised (and not re-adopted) on the next onboarding.
+_KEPT_STATUSES = _LIVE_STATUSES | {"INACTIVE"}
 KEEP_SETTLED = 20
 
 Entries = List[Dict[str, Any]]
@@ -109,7 +112,7 @@ def prune(entries: Entries) -> Entries:
     settled = [
         e
         for e in entries
-        if e.get("status") not in _LIVE_STATUSES and not e.get("preferred")
+        if e.get("status") not in _KEPT_STATUSES and not e.get("preferred")
     ]
     drop = {id(e) for e in newest_first(settled)[KEEP_SETTLED:]}
     return [e for e in entries if id(e) not in drop]
@@ -193,6 +196,18 @@ def choose_preferred(entries: Entries, agent_obj_ref: str) -> Tuple[Entries, boo
         if bool(e.get("preferred")) != hit:
             e["preferred"] = hit
             e["updated_at"] = _now()
+    return entries, True
+
+
+def deactivate(entries: Entries, agent_obj_ref: str) -> Tuple[Entries, bool]:
+    """The rider deleted this agent: status INACTIVE, no longer preferred.
+    Nothing changes on an unknown ref."""
+    entry = find_by_ref(entries, agent_obj_ref)
+    if entry is None:
+        return entries, False
+    entry["status"] = "INACTIVE"
+    entry["preferred"] = False
+    entry["updated_at"] = _now()
     return entries, True
 
 
@@ -343,7 +358,21 @@ async def set_preferred_agent(
     return bool(result and result[0] == merchant_id and result[1])
 
 
+async def deactivate_agent(
+    merchant_id: str, customer_id: str, agent_obj_ref: str
+) -> bool:
+    """True when the ref belonged to this customer (and is now INACTIVE);
+    False when nothing matched."""
+
+    def mutation(current: Any) -> Tuple[Any, bool]:
+        return deactivate(_entries(current), agent_obj_ref)
+
+    result = await mutate_customer_attribute(customer_id, AGENTS_KEY, mutation)
+    return bool(result and result[0] == merchant_id and result[1])
+
+
 __all__ = [
+    "deactivate_agent",
     "insert_attempt",
     "patch_attempt",
     "get_by_agent_obj_ref",

--- a/app/crm/preview/uap/payment_agent.py
+++ b/app/crm/preview/uap/payment_agent.py
@@ -18,7 +18,9 @@ from app.crm.preview.uap.schemas import CrmCustomerAgent, DrawUsage
 from app.crm.record.contracts import record_event
 
 # ---- translation: Juspay vocabulary -> ours (pure) ----
-TERMINAL_STATUSES = frozenset({"ACTIVE", "EXPIRED", "REVOKED", "FAILED"})
+# INACTIVE = the rider deleted the agent in the merchant app. Ours alone:
+# Juspay never says it, and a refresh never overrides it (see plan_patch).
+TERMINAL_STATUSES = frozenset({"ACTIVE", "EXPIRED", "REVOKED", "FAILED", "INACTIVE"})
 
 
 def pick_action(
@@ -68,9 +70,14 @@ def plan_patch(
     """DECIDE: the column patch a refresh implies. Never demotes a rider
     decision: PAUSED/REVOKED stay unless Juspay now says ACTIVE again — or
     the agent is gone altogether (``agent=None``), which is EXPIRED whatever
-    the rider had chosen. ``verified_at`` is stamped by the caller."""
+    the rider had chosen. INACTIVE (deleted here) is final either way.
+    ``verified_at`` is stamped by the caller."""
     status = derive_status(agent, action)
-    if (
+    if current_status == "INACTIVE":
+        # Deleted by the rider here: sticky whatever Juspay reports, so a
+        # poll/webhook/SDK result can never resurrect it.
+        status = "INACTIVE"
+    elif (
         agent is not None
         and current_status in {"PAUSED", "REVOKED"}
         and status != "ACTIVE"

--- a/tests/crm/test_agentic.py
+++ b/tests/crm/test_agentic.py
@@ -53,6 +53,22 @@ def test_plan_patch_keeps_rider_decision_and_takes_approved_rule() -> None:
     assert plan_patch("PAUSED", None, None)["status"] == "EXPIRED"
 
 
+def test_plan_patch_inactive_is_final() -> None:
+    """Deleted by the rider here: no Juspay state can bring it back."""
+    action = {"status": "ACTIVE", "action_id": "c1"}
+    assert (
+        plan_patch("INACTIVE", _juspay_agent("ACTIVE"), action)["status"] == "INACTIVE"
+    )
+    assert plan_patch("INACTIVE", _juspay_agent("ACTIVE"), None)["status"] == "INACTIVE"
+    assert plan_patch("INACTIVE", _juspay_agent("PAUSED"), None)["status"] == "INACTIVE"
+    assert plan_patch("INACTIVE", None, None)["status"] == "INACTIVE"
+    # identifiers from Juspay still land; only the status is pinned
+    patch = plan_patch("INACTIVE", _juspay_agent("ACTIVE", payer_avpa="a@upi"), action)
+    assert patch["payer_avpa"] == "a@upi" and patch["action_id"] == "c1"
+    # and INACTIVE is never derived from Juspay's vocabulary
+    assert derive_status(_juspay_agent("ACTIVE"), action) == "ACTIVE"
+
+
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 

--- a/tests/crm/test_agentic_store.py
+++ b/tests/crm/test_agentic_store.py
@@ -109,6 +109,41 @@ def test_prune_keeps_live_and_newest_settled() -> None:
     assert "e0" not in refs and "e24" in refs
 
 
+def test_deactivate_marks_inactive_and_drops_preferred() -> None:
+    entries = [_entry("a", preferred=True), _entry("b")]
+    entries, ok = store.deactivate(entries, "a")
+    assert ok is True
+    a = store.find_by_ref(entries, "a")
+    assert a is not None
+    assert a["status"] == "INACTIVE" and a["preferred"] is False
+    assert a["agent_id"] == "cont_a" and a["action_status"] == "ACTIVE"
+    # the other attempt is untouched, and the deleted one no longer pays
+    b = store.find_by_ref(entries, "b")
+    assert b is not None and b["status"] == "ACTIVE"
+    assert [e["agent_obj_ref"] for e in store.drawable_entries(entries)] == ["b"]
+    # unknown ref: refused, nothing changes
+    before = [dict(e) for e in entries]
+    entries, ok = store.deactivate(entries, "zzz")
+    assert ok is False and entries == before
+    # an INACTIVE attempt cannot be made preferred again
+    assert store.choose_preferred(entries, "a")[1] is False
+
+
+def test_prune_keeps_inactive() -> None:
+    settled = [
+        _entry(
+            f"e{i}", status="EXPIRED", created_at=f"2026-08-{i + 1:02d}T00:00:00+00:00"
+        )
+        for i in range(25)
+    ]
+    deleted = [
+        _entry("gone", status="INACTIVE", created_at="2026-01-01T00:00:00+00:00")
+    ]
+    kept = store.prune(deleted + settled)
+    refs = {e["agent_obj_ref"] for e in kept}
+    assert "gone" in refs and len(kept) == 1 + store.KEEP_SETTLED
+
+
 def test_customer_id_from_ref() -> None:
     cid = "0dd139fc-3569-4c78-b686-e42f0e6f61fa"
     assert store.customer_id_from_ref(f"agent_{cid}_1788718478") == cid

--- a/tests/test_uap_agent_delete.py
+++ b/tests/test_uap_agent_delete.py
@@ -1,0 +1,180 @@
+"""Rider deletes a payment agent: the /agents/delete route and the Setup
+path that must never re-adopt the Juspay agent behind an INACTIVE row."""
+
+from typing import Any, Dict, List, Optional, cast
+
+import pytest
+from fastapi import HTTPException
+
+from app.api.routers.breeze_buddy.preview.uap import handlers
+from app.crm.preview.uap.schemas import CrmCustomerAgent
+from app.services.preview.uap.api import JuspayCredentials
+
+CUSTOMER = "0dd139fc-3569-4c78-b686-e42f0e6f61fa"
+PREFIX = f"agent_{CUSTOMER}_"
+
+
+class _Scope:
+    reseller_id = "breeze"
+    merchant_id = "chennai_one"
+    customer_id = CUSTOMER
+
+
+CREDS = cast(JuspayCredentials, object())
+SCOPE = cast(handlers.Scope, _Scope())
+
+
+def _row(
+    ref: str, status: str, agent_id: Optional[str] = "cont_old"
+) -> CrmCustomerAgent:
+    return CrmCustomerAgent(
+        id="11111111-1111-1111-1111-111111111111",
+        merchant_id="chennai_one",
+        customer_id=CUSTOMER,
+        agent_obj_ref=ref,
+        action_obj_ref=f"intent_{ref}",
+        agent_id=agent_id,
+        action_id="cont_x",
+        payer_avpa="a@upi",
+        status=status,
+        action_status="ACTIVE",
+    )
+
+
+def _juspay_agent(ref: str, agent_id: str) -> Dict[str, Any]:
+    return {
+        "object_reference_id": ref,
+        "agent_id": agent_id,
+        "status": "ACTIVE",
+        "actions": [
+            {
+                "object_reference_id": f"intent_{ref}",
+                "status": "ACTIVE",
+                "action_id": "c",
+            }
+        ],
+    }
+
+
+def _wire(
+    monkeypatch: pytest.MonkeyPatch,
+    agents: List[Dict[str, Any]],
+    rows: Dict[str, CrmCustomerAgent],
+):
+    """Juspay lists ``agents``; our store holds ``rows`` (by ref, and by
+    agent_id for the fallback lookup). Records what got adopted/refreshed."""
+    calls: Dict[str, List[str]] = {"created": [], "refreshed": []}
+
+    async def list_agents(_creds, _cid):
+        return agents
+
+    async def by_ref(ref):
+        return rows.get(ref)
+
+    async def by_agent_id(agent_id):
+        return next((r for r in rows.values() if r.agent_id == agent_id), None)
+
+    async def create_attempt(**kw):
+        calls["created"].append(kw["agent_obj_ref"])
+        return _row(kw["agent_obj_ref"], "PENDING", agent_id=None)
+
+    async def refresh_agent(_creds, row):
+        calls["refreshed"].append(row.agent_obj_ref)
+        return _row(row.agent_obj_ref, "ACTIVE", agent_id="cont_new")
+
+    monkeypatch.setattr(handlers.uap_api, "list_agents", list_agents)
+    monkeypatch.setattr(handlers, "get_by_agent_obj_ref", by_ref)
+    monkeypatch.setattr(handlers, "get_by_agent_id", by_agent_id)
+    monkeypatch.setattr(handlers, "create_attempt", create_attempt)
+    monkeypatch.setattr(handlers, "refresh_agent", refresh_agent)
+    return calls
+
+
+async def test_reuse_skips_inactive_matched_by_ref(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    ref = PREFIX + "1"
+    calls = _wire(
+        monkeypatch, [_juspay_agent(ref, "cont_1")], {ref: _row(ref, "INACTIVE")}
+    )
+    assert await handlers._reuse_existing(CREDS, SCOPE, "cth_1") is None
+    assert calls == {"created": [], "refreshed": []}
+
+
+async def test_reuse_skips_inactive_matched_by_agent_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Juspay echoes a ref we do not hold, but the agent_id is on a deleted row.
+    ref = PREFIX + "2"
+    calls = _wire(
+        monkeypatch,
+        [_juspay_agent(ref, "cont_2")],
+        {PREFIX + "other": _row(PREFIX + "other", "INACTIVE", agent_id="cont_2")},
+    )
+    assert await handlers._reuse_existing(CREDS, SCOPE, "cth_1") is None
+    assert calls == {"created": [], "refreshed": []}
+
+
+async def test_reuse_still_adopts_unknown_and_refreshes_known(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    unknown, known, dead = PREFIX + "3", PREFIX + "4", PREFIX + "5"
+    calls = _wire(
+        monkeypatch,
+        [
+            _juspay_agent(dead, "cont_5"),
+            _juspay_agent(unknown, "cont_3"),
+            _juspay_agent(known, "cont_4"),
+            {
+                "object_reference_id": "agent_stranger_1",
+                "agent_id": "z",
+                "status": "ACTIVE",
+            },
+        ],
+        {
+            dead: _row(dead, "INACTIVE", agent_id="cont_5"),
+            known: _row(known, "ACTIVE", agent_id="cont_4"),
+        },
+    )
+    got = await handlers._reuse_existing(CREDS, SCOPE, "cth_1")
+    assert got is not None and got.agent_obj_ref == unknown
+    assert calls == {"created": [unknown], "refreshed": [unknown]}
+
+
+async def test_delete_route_scoped_to_rider(monkeypatch: pytest.MonkeyPatch) -> None:
+    deactivated: List[tuple] = []
+
+    async def scope(_sid, **_kw):
+        return SCOPE
+
+    async def deactivate_agent(merchant_id, customer_id, ref):
+        deactivated.append((merchant_id, customer_id, ref))
+        return ref == PREFIX + "mine"
+
+    async def list_drawable(_m, _c):
+        return [_row(PREFIX + "left", "ACTIVE")]
+
+    async def view(_scope, agent, selected):
+        return {"agent_ref": agent.agent_obj_ref, "selected": selected}
+
+    monkeypatch.setattr(handlers, "_scope", scope)
+    monkeypatch.setattr(handlers, "deactivate_agent", deactivate_agent)
+    monkeypatch.setattr(handlers, "list_drawable_for_customer", list_drawable)
+    monkeypatch.setattr(handlers, "_agent_view", view)
+
+    body = handlers.SelectAgentRequest(
+        session_id="sess-12345678", agent_ref=PREFIX + "mine"
+    )
+    out = await handlers.delete_agent_for_rider(body)
+    assert out == {
+        "agents": [{"agent_ref": PREFIX + "left", "selected": True}],
+        "count": 1,
+    }
+    assert deactivated == [("chennai_one", CUSTOMER, PREFIX + "mine")]
+
+    other = handlers.SelectAgentRequest(
+        session_id="sess-12345678", agent_ref="agent_someone_else_1"
+    )
+    with pytest.raises(HTTPException) as exc:
+        await handlers.delete_agent_for_rider(other)
+    assert exc.value.status_code == 404


### PR DESCRIPTION
## Why
PhonePe's review of the Chennai One demo: there is no way to delete a payment agent in the app, so test agents clutter the sheet. The rider needs a Delete, and a deleted agent must not come back the next time they tap Set up.

## What
- **New status `INACTIVE`** on the agent row (ours alone; Juspay never says it). `plan_patch` pins it: a poll, webhook or SDK result that re-reads Juspay can never flip a deleted agent back to ACTIVE. Added to `TERMINAL_STATUSES` so the poll stops.
- **`POST /uap/agents/delete`** `{session_id, agent_ref}` → the row goes INACTIVE and loses `preferred`; response is the refreshed list, same shape as `/agents/select` (`{"agents": [...], "count": n}`); `404` when the ref is not this rider's (scoped by merchant + customer). The mandate at Juspay is left untouched.
- **Setup path (`_reuse_existing`)**: a Juspay agent whose `object_reference_id` or `agent_id` matches an INACTIVE row is skipped — not re-adopted, not refreshed. Unknown agents still adopt as before. `/status` then returns `needs_onboarding: true` (reason `inactive`) and `/onboarding` mints a fresh attempt (INACTIVE is not in the live set).
- `prune` keeps INACTIVE rows so the match survives.

No migration: agents live in `crm_customer.attributes["agents"]`.

## Tests
`tests/crm/test_agentic.py`, `tests/crm/test_agentic_store.py`, new `tests/test_uap_agent_delete.py`: plan_patch stickiness (agent ACTIVE / PAUSED / gone), deactivate + preferred cleared + unknown ref refused, prune keeps INACTIVE, drawable excludes INACTIVE, `_reuse_existing` skips by ref and by agent_id while still adopting an unknown agent, delete route scoping + 404.

`pytest tests/crm` → 1053 passed, 15 skipped. black / isort / autoflake / pyrefly / check_crm_boundaries clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UHHgMQjUtNR7YCoz6KBEqq


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability for riders to delete their payment agents.
  * Deleted agents remain inactive and are not automatically reused or restored.
  * Deletion is limited to agents belonging to the requesting rider.

* **Bug Fixes**
  * Prevented inactive agents from reappearing in available payment options.
  * Preserved inactive agent records during cleanup and synchronization.

* **Tests**
  * Added coverage for agent deletion, ownership validation, inactive status persistence, and reuse behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->