### PR TITLE
feat(crm): events payload to get metadata and lead_id unique fix

### DIFF
--- a/app/ai/voice/agents/breeze_buddy/crm_mirror.py
+++ b/app/ai/voice/agents/breeze_buddy/crm_mirror.py
@@ -41,7 +41,10 @@ from app.core.concurrency import spawn_background_task
 from app.core.logger import logger
 from app.crm.identity.contracts import resolve as crm_resolve
 from app.crm.record.contracts import record_event
-from app.database.accessor.breeze_buddy import lead_call_tracker as lct_accessor
+from app.database.accessor.breeze_buddy import (
+    lead_call_tracker as lct_accessor,
+    template as template_accessor,
+)
 from app.schemas import CallDirection, LeadCallStatus, LeadCallTracker
 
 SOURCE_LEAD_API = "lead-api"
@@ -103,6 +106,7 @@ async def mirror_to_crm(
     phone: Optional[str] = None,
     occurred_at: Optional[datetime] = None,
     customer_id: Optional[str] = None,
+    declared: Optional[Dict[str, Any]] = None,
     **facts: Any,
 ) -> None:
     """Record one buddy-side fact into the event spine.
@@ -111,6 +115,10 @@ async def mirror_to_crm(
     SID); this function qualifies it. ``**facts`` join lead_id and phone in
     the payload, None values dropped. ``customer_id`` is passed through when
     the caller already stamped the lead.
+
+    ``declared`` is the merchant-named half (a template's call answers), one
+    dict rather than more ``**facts`` so its names cannot collide with a
+    keyword above. Ours wins on a clash.
 
     Skips silently on a missing merchant_id or external_id — both are
     truthful non-CRM states, not errors.
@@ -129,7 +137,21 @@ async def mirror_to_crm(
         "customer_mobile_number": phone,
         **facts,
     }
+    # Names this letter owns, taken BEFORE the None filter: enrollment_id is
+    # None on an unenrolled lead, and a merchant field filling that gap would
+    # match the wrong run.
+    ours = set(payload)
     payload = {k: v for k, v in payload.items() if v is not None}
+
+    for name, value in (declared or {}).items():
+        if name in ours:
+            logger.warning(
+                f"{topic}: declared field {name!r} is a name this letter "
+                f"already owns — the call's own value is kept (lead {lead_id})"
+            )
+            continue
+        if value is not None:
+            payload[name] = value
 
     try:
         await record_event(
@@ -150,6 +172,42 @@ async def mirror_to_crm(
 # --------------------------------------------------------------------------
 # Lead-lifecycle taps (registered into the accessor's hook registry below)
 # --------------------------------------------------------------------------
+
+
+async def call_facts(lead: LeadCallTracker) -> Dict[str, Any]:
+    """What the call learned, as its own template declared it.
+
+    ``expected_callback_response_schema`` is the allow-list. Read from
+    ``metaData['outcome']`` first, then the top level. Carried whole — the
+    letter is stored verbatim (T13).
+    """
+    if not lead.template_id:
+        return {}
+    try:
+        template = await template_accessor.get_template_by_id(str(lead.template_id))
+    except Exception:
+        logger.opt(exception=True).warning(
+            f"CRM mirror: template {lead.template_id} unreadable — "
+            "call facts not carried"
+        )
+        return {}
+
+    schema = getattr(template, "expected_callback_response_schema", None)
+    meta = lead.metaData if isinstance(lead.metaData, dict) else {}
+    nested = meta.get("outcome")
+    nested = nested if isinstance(nested, dict) else {}
+
+    facts: Dict[str, Any] = {}
+    for name in schema if isinstance(schema, dict) else {}:
+        value = nested[name] if name in nested else meta.get(name)
+        # A bool is not one of these facts; a nested shape stays where it is.
+        if isinstance(value, bool) or not isinstance(value, (str, int, float)):
+            continue
+        text = str(value).strip()
+        if not text:
+            continue
+        facts[name] = text
+    return facts
 
 
 async def _stamp_customer_on_lead(
@@ -229,6 +287,7 @@ def _created_lead_tap(lead: LeadCallTracker) -> None:
                     started_at=lead.call_initiated_time,
                     ended_at=lead.call_end_time,
                     customer_name=customer_name,
+                    declared=await call_facts(lead),
                 )
 
         spawn_background_task(_tap(), name=f"crm-lead-created-{lead.id}")
@@ -251,8 +310,9 @@ def _finished_lead_tap(lead: LeadCallTracker) -> None:
             return
         if not lead.merchant_id:
             return
-        spawn_background_task(
-            mirror_to_crm(
+
+        async def _tap() -> None:
+            await mirror_to_crm(
                 "call.completed",
                 merchant_id=lead.merchant_id,
                 external_id=lead.call_id or str(lead.id),
@@ -272,8 +332,11 @@ def _finished_lead_tap(lead: LeadCallTracker) -> None:
                 started_at=lead.call_initiated_time,
                 ended_at=lead.call_end_time,
                 customer_name=(lead.payload or {}).get("customer_name"),
-            ),
-            name=f"crm-call-completed-{lead.call_id or lead.id}",
+                declared=await call_facts(lead),
+            )
+
+        spawn_background_task(
+            _tap(), name=f"crm-call-completed-{lead.call_id or lead.id}"
         )
     except Exception:  # fail-open: CRM taps never break the update
         logger.opt(exception=True).error(f"CRM finished-lead tap failed for {lead.id}")

--- a/app/crm/outreach/catalog_laws.py
+++ b/app/crm/outreach/catalog_laws.py
@@ -68,6 +68,7 @@ def entry_against_catalog(
         for name in placeholder_names(node.args)
     ]
     listened = listened_facts(definition, catalogs)
+    open_squares = unenumerable_squares(definition, catalogs)
     for entry in definition.entries:
         topic = entry.topic
         fields = catalogs.get(topic)
@@ -82,14 +83,14 @@ def entry_against_catalog(
         declared = {variable_name(f.path) for f in fields.values() if f.variable}
         allowed = declared | _WALKER_FACTS | listened
         for node_id, blank, fact in mapped:
-            if fact not in allowed:
+            if fact not in allowed and not _from_open_square(fact, open_squares):
                 problems.append(
                     f"send node {node_id}: variable {blank!r} <- {fact!r} is not "
                     f"a declared variable field (topic {topic!r}; declared: "
                     f"{', '.join(sorted(declared)) or 'none'})"
                 )
         for node_id, name in asked:
-            if name not in allowed:
+            if name not in allowed and not _from_open_square(name, open_squares):
                 problems.append(
                     f"action node {node_id}: args ask for {{{name}}}, which is not "
                     f"a declared variable field (topic {topic!r}; declared: "
@@ -134,6 +135,32 @@ def listened_facts(definition: WorkflowDefinition, catalogs: Catalogs) -> set:
                 if field.variable:
                     names.add(f"facts_{node.id}_{variable_name(field.path)}")
     return names
+
+
+def unenumerable_squares(definition: WorkflowDefinition, catalogs: Catalogs) -> set:
+    """PURE: the wait_event squares whose letters nobody can enumerate.
+
+    A call's answers are declared by the TEMPLATE, so no catalog lists them.
+    Per SQUARE: every other name in the document stays checked.
+    """
+    open_squares: set = set()
+    if catalogs is None:
+        return open_squares
+    for node in definition.nodes:
+        if node.type != "wait_event":
+            continue
+        if any(catalogs.get(topic) is None for topic in node.topics):
+            open_squares.add(node.id)
+    return open_squares
+
+
+def _from_open_square(name: str, open_squares: set) -> bool:
+    """PURE: is `name` a `facts_<square>_<key>` of an unenumerable square?
+
+    Matched on the square's own id, since both an id and a key may contain
+    "_". Only that prefix is exempt.
+    """
+    return any(name.startswith(f"facts_{square}_") for square in open_squares)
 
 
 def condition_against_catalog(

--- a/app/crm/outreach/nodes/call.py
+++ b/app/crm/outreach/nodes/call.py
@@ -3,10 +3,8 @@
 ADR 0010: voice stays outside the gate, governed by its existing checks
 (DND, blacklist, calling hours). enrollment_id is stamped after insert (the
 050 customer-stamp pattern; the accessor's created hooks give the lead its
-customer stamp + lead.pushed mirror for free). The Redis schedule nudge is
-deliberately skipped — the dispatch reconciler heals within 60s, and
-outreach importing app.ai for a best-effort ZADD is a coupling not worth
-one minute of latency on a 30-minute flow.
+customer stamp + lead.pushed mirror for free). Each visit to the square
+mints its own lead.
 """
 
 from datetime import datetime, timedelta, timezone
@@ -21,6 +19,7 @@ from app.crm.outreach.schemas import EnrollmentRun, WorkflowDefinition, Workflow
 from app.database.accessor import (
     create_lead_call_tracker,
     get_call_execution_config_by_template_id,
+    get_lead_by_id,
     get_template_by_id,
     update_lead_enrollment_id,
 )
@@ -33,12 +32,35 @@ def validate(node: WorkflowNode, definition: WorkflowDefinition) -> List[str]:
     return []
 
 
+def _visits_key(node_id: str) -> str:
+    """Where a call square's visit counter lives in the run's context.
+
+    `lead_` is already a bookkeeping prefix, so run_facts filters it for free
+    and it can never reach a template or an action arg.
+    """
+    return f"lead_visits_{node_id}"
+
+
+def _visits_so_far(context: Dict[str, Any], node_id: str) -> int:
+    """PURE: how many times this run has completed this call square.
+
+    Absent, or unreadable, reads as 0 — so an old run's next id is the `:1`
+    it would have had. A wrong count mints a fresh lead; raising here would
+    park a run over bookkeeping.
+    """
+    value = context.get(_visits_key(node_id))
+    return value if isinstance(value, int) and value >= 0 else 0
+
+
 async def execute(
     run: EnrollmentRun, node: WorkflowNode, definition: WorkflowDefinition
 ) -> Dict[str, Any]:
-    """Enqueue a lead into today's dispatch machine. The lead is idempotent
-    per visit via a deterministic id — a lease-retry after a crash re-issues
-    the same insert and the PK absorbs it."""
+    """Enqueue a lead into today's dispatch machine.
+
+    Idempotent per VISIT: a lease retry re-issues the same insert and the
+    existing row is adopted. The accessor turns a duplicate key into None
+    like every failure, so the square asks whether its own row is there.
+    """
     phone = run.context.get("phone")
     if not phone:
         raise NodeParked(f"call node {node.id}: no phone in run context")
@@ -55,11 +77,11 @@ async def execute(
             f"{template.name}"
         )
 
-    # Deterministic per (run, node): a lease-retry after a crash between
-    # the insert and the advance re-issues the SAME id, and the PK (plus
-    # the UniqueViolation below) absorbs the duplicate — exactly-once
-    # calls without a coordination table.
-    lead_id = str(uuid5(NAMESPACE_URL, f"crm-workflow-lead:{run.id}:{node.id}"))
+    # Deterministic per (run, node, VISIT). The counter lives in the run's
+    # context, so a retry of one visit re-derives its own id and a revisit
+    # gets a new one.
+    visit = _visits_so_far(run.context, node.id) + 1
+    lead_id = str(uuid5(NAMESPACE_URL, f"crm-workflow-lead:{run.id}:{node.id}:{visit}"))
 
     next_attempt_at = datetime.now(timezone.utc) + timedelta(
         seconds=config.initial_offset
@@ -98,13 +120,23 @@ async def execute(
             execution_mode=ExecutionMode.TELEPHONY,
             status=LeadCallStatus.BACKLOG,
         )
+    except UniqueViolation:
+        # Same meaning as None, so it falls to the same lookup. The accessor
+        # swallows this today; kept for the day it narrows.
+        lead = None
+
+    if lead is None:
+        # None means every failure, a duplicate key included, so the row's
+        # existence tells them apart: ours means this visit already ran under
+        # a lost lease — adopt it. Absent means a real failure.
+        lead = await get_lead_by_id(lead_id)
         if lead is None:
             raise RuntimeError(f"call node {node.id}: lead insert returned None")
-    except UniqueViolation:
         logger.info(
             f"walker: run {run.id} lead {lead_id} already exists "
-            f"(lease retry) — continuing"
+            f"(lease retry of visit {visit}) — continuing"
         )
+
     await update_lead_enrollment_id(lead_id, str(run.id))
     logger.info(f"walker: run {run.id} pushed lead {lead_id} (node {node.id})")
-    return {f"lead_{node.id}": lead_id}
+    return {f"lead_{node.id}": lead_id, _visits_key(node.id): visit}

--- a/tests/crm/test_crm_mirror.py
+++ b/tests/crm/test_crm_mirror.py
@@ -19,7 +19,7 @@ from app.ai.voice.agents.breeze_buddy.crm_mirror import (
 from app.database.decoder.breeze_buddy.lead_call_tracker import (
     decode_lead_call_tracker,
 )
-from app.schemas import CallDirection, LeadCallTracker
+from app.schemas import CallDirection, LeadCallStatus, LeadCallTracker
 
 
 def test_event_key_qualifies_by_topic() -> None:
@@ -192,3 +192,146 @@ def test_call_completed_mirror_names_the_run_and_the_outcome(
         )
     )
     assert "enrollment_id" not in recorded[0]["payload"]
+
+
+# --------------------------------------------------------------------------
+# A template's declared answers, and the names a merchant is free to choose
+# --------------------------------------------------------------------------
+
+
+def _completed(**over: Any) -> LeadCallTracker:
+    """A finished TELEPHONY lead, the shape the completed tap fires on."""
+    fields: Dict[str, Any] = {
+        "id": "L9",
+        "reseller_id": "r1",
+        "template": "t",
+        "template_id": "tpl-1",
+        "merchant_id": "m1",
+        "call_id": "CA999",
+        "status": LeadCallStatus.FINISHED,
+        "execution_mode": "TELEPHONY",
+        "outcome": "ANSWERED",
+        "call_direction": CallDirection.OUTBOUND,
+        "payload": {"customer_mobile_number": "+919999999999"},
+    }
+    fields.update(over)
+    return LeadCallTracker(**fields)
+
+
+def _mirror_harness(
+    monkeypatch: pytest.MonkeyPatch, schema: Optional[Dict[str, Any]]
+) -> List[Dict[str, Any]]:
+    """Everything the completed tap touches, stubbed; returns what was
+    recorded. The template read is the only cold one call_facts makes."""
+    recorded: List[Dict[str, Any]] = []
+
+    async def fake_record_event(**kw: Any) -> None:
+        recorded.append(kw)
+
+    async def fake_get_template(template_id: str) -> Any:
+        return type("T", (), {"expected_callback_response_schema": schema})()
+
+    def run_now(coro: Any, name: Optional[str] = None) -> None:
+        asyncio.run(coro)
+
+    monkeypatch.setattr(crm_mirror, "record_event", fake_record_event)
+    monkeypatch.setattr(crm_mirror, "spawn_background_task", run_now)
+    monkeypatch.setattr(
+        crm_mirror.template_accessor, "get_template_by_id", fake_get_template
+    )
+    return recorded
+
+
+def test_a_declared_answer_named_outcome_still_produces_a_letter(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """call_facts returns MERCHANT-authored names. Splatted beside the
+    mirror's own `outcome=` keyword, a template declaring `outcome` raised
+    TypeError inside the spawned tap — logged, swallowed, no letter, and the
+    run sat until max_age_days. As one dict it cannot collide.
+    """
+    recorded = _mirror_harness(monkeypatch, {"outcome": {}, "reason": {}})
+    lead = _completed(
+        metaData={"outcome": {"outcome": "she cancelled", "reason": "cost"}}
+    )
+
+    _finished_lead_tap(lead)
+
+    assert len(recorded) == 1, "the letter must still be filed"
+    payload = recorded[0]["payload"]
+    # OURS wins: the walker and the console read `outcome` off this payload,
+    # so the call's own verdict is kept and the declared field is dropped.
+    assert payload["outcome"] == "ANSWERED"
+    # …and every name that does NOT collide still rides along.
+    assert payload["reason"] == "cost"
+
+
+def test_every_reserved_name_survives_being_declared(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Not just `outcome` — the same crash was one declaration away on every
+    keyword the completed tap passes.
+    """
+    reserved = [
+        "lead_id",
+        "call_id",
+        "outcome",
+        "enrollment_id",
+        "direction",
+        "started_at",
+        "ended_at",
+        "customer_name",
+        "customer_mobile_number",
+    ]
+    for name in reserved:
+        recorded = _mirror_harness(monkeypatch, {name: {}})
+        _finished_lead_tap(_completed(metaData={"outcome": {name: "declared"}}))
+        assert len(recorded) == 1, f"{name} lost the letter"
+        assert recorded[0]["payload"].get(name) != "declared", name
+
+
+def test_the_hooks_nested_claim_outranks_buddys_scratch_space(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The top level is also buddy's scratch space ("stuck_processing_timeout",
+    abort reasons). metaData['outcome'] is the hook's alone, so it wins.
+    """
+    recorded = _mirror_harness(monkeypatch, {"reason": {}})
+    _finished_lead_tap(
+        _completed(
+            metaData={
+                "reason": "stuck_processing_timeout",  # buddy's own word
+                "outcome": {"reason": "she found it cheaper"},  # the agent's
+            }
+        )
+    )
+
+    assert recorded[0]["payload"]["reason"] == "she found it cheaper"
+
+
+def test_a_declared_name_absent_from_the_nest_still_reads_the_top_level(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A template option merges its `metadata` onto lead.metaData with no nest
+    at all — that writer must keep working.
+    """
+    recorded = _mirror_harness(monkeypatch, {"chosen_slot": {}})
+    _finished_lead_tap(_completed(metaData={"chosen_slot": "tomorrow 4pm"}))
+
+    assert recorded[0]["payload"]["chosen_slot"] == "tomorrow 4pm"
+
+
+def test_a_long_declared_answer_reaches_the_spine_whole(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The letter is stored verbatim (T13), so nothing is trimmed here. The
+    ceiling that used to live in call_facts belongs to run context, and
+    entry.py applies it there.
+    """
+    long_address = "x" * 300
+    recorded = _mirror_harness(monkeypatch, {"updated_address": {}})
+    _finished_lead_tap(
+        _completed(metaData={"outcome": {"updated_address": long_address}})
+    )
+
+    assert recorded[0]["payload"]["updated_address"] == long_address

--- a/tests/crm/test_workflow_call_visits.py
+++ b/tests/crm/test_workflow_call_visits.py
@@ -1,0 +1,209 @@
+"""The call square's lead id, and what makes it exactly-once.
+
+A workflow call mints its lead id deterministically rather than keeping a
+coordination table: the same visit computed twice is the same id, and the
+primary key absorbs the duplicate. That property is the whole design, and
+it had a hole — the id was keyed on (run, node), which is a property of the
+SQUARE rather than of standing on it, so a run that came back round to the
+same call square recomputed the identical id and its second call was
+refused by the PK it was relying on.
+"""
+
+from typing import Any, Dict, List, Optional
+from uuid import NAMESPACE_URL, uuid5
+
+import pytest
+
+import app.crm.outreach.nodes.call as call_node
+from app.crm.outreach.db import UniqueViolation
+from app.crm.outreach.nodes.call import execute
+from app.crm.outreach.nodes.context import run_facts
+from app.crm.outreach.schemas import EnrollmentRun, WorkflowDefinition, WorkflowNode
+
+_NODE = WorkflowNode(id="nudge-call", type="call", template_id="tpl-1")
+_DEFINITION = WorkflowDefinition(
+    entry={"topic": "orders/create"},
+    nodes=[_NODE],
+    edges=[],
+    goals=[{"topics": ["orders/paid"]}],
+)
+
+
+def _run(context: Optional[Dict[str, Any]] = None) -> EnrollmentRun:
+    return EnrollmentRun(
+        id="6f6603bf-1bf5-4f46-b242-58e9f40833d2",
+        merchant_id="m1",
+        workflow_id="11111111-1111-1111-1111-111111111111",
+        workflow_version=1,
+        customer_id="22222222-2222-2222-2222-222222222222",
+        status="waiting",
+        current_node="nudge-call",
+        wake_at=None,
+        entered_at="2026-09-09T11:26:00Z",
+        exited_at=None,
+        exit_reason=None,
+        context={"phone": "+919110752252", **(context or {})},
+        enrollment_key="k1",
+        attempts=0,
+        last_error=None,
+    )
+
+
+def _install(
+    monkeypatch: pytest.MonkeyPatch,
+    inserted: List[str],
+    *,
+    existing: Optional[set] = None,
+) -> None:
+    """The accessor as it really behaves: a duplicate primary key is caught
+    broadly and returned as None, never as a UniqueViolation the caller can
+    see. `existing` is the set of ids already in the table."""
+    rows = existing if existing is not None else set()
+
+    async def fake_get_lead(lead_id: str) -> Any:
+        return type("L", (), {"id": lead_id})() if lead_id in rows else None
+
+    async def fake_create(**kw: Any) -> Any:
+        if kw["id"] in rows:
+            return None  # the swallow — every failure looks like this
+        rows.add(kw["id"])
+        inserted.append(kw["id"])
+        return type("L", (), {"id": kw["id"]})()
+
+    async def fake_template(_id: str) -> Any:
+        return type(
+            "T",
+            (),
+            {"id": "tpl-1", "name": "nudge", "reseller_id": "r1", "merchant_id": None},
+        )()
+
+    async def fake_config(_id: str) -> Any:
+        return type("C", (), {"initial_offset": 0})()
+
+    async def fake_stamp(_lead_id: str, _run_id: str) -> None:
+        return None
+
+    monkeypatch.setattr(call_node, "create_lead_call_tracker", fake_create)
+    monkeypatch.setattr(call_node, "get_lead_by_id", fake_get_lead)
+    monkeypatch.setattr(call_node, "get_template_by_id", fake_template)
+    monkeypatch.setattr(
+        call_node, "get_call_execution_config_by_template_id", fake_config
+    )
+    monkeypatch.setattr(call_node, "update_lead_enrollment_id", fake_stamp)
+
+
+def _expected(run_id: str, node_id: str, visit: int) -> str:
+    return str(uuid5(NAMESPACE_URL, f"crm-workflow-lead:{run_id}:{node_id}:{visit}"))
+
+
+async def test_a_second_visit_to_the_same_square_gets_its_own_lead(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A board that loops reaches the same call square twice on one run.
+
+    Keyed on (run, node) both visits computed the same uuid5, the PK refused
+    the second, the accessor returned None, and the square raised — a run
+    parked on its second call.
+    """
+    inserted: List[str] = []
+    _install(monkeypatch, inserted)
+
+    first = await execute(_run(), _NODE, _DEFINITION)
+    # The run carries the counter forward, exactly as the walker merges it.
+    second = await execute(_run(first), _NODE, _DEFINITION)
+
+    assert first["lead_nudge-call"] == _expected(str(_run().id), "nudge-call", 1)
+    assert second["lead_nudge-call"] == _expected(str(_run().id), "nudge-call", 2)
+    assert first["lead_nudge-call"] != second["lead_nudge-call"]
+    assert len(inserted) == 2, "both visits must reach the lead table"
+
+
+async def test_the_same_visit_run_twice_is_one_lead(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A lease retry re-runs the SAME visit: the counter has not moved, the
+    id recomputes identically, and the square adopts its own row instead of
+    calling twice. Before this it raised on None and the run parked.
+    """
+    inserted: List[str] = []
+    _install(monkeypatch, inserted)
+
+    first = await execute(_run(), _NODE, _DEFINITION)
+    # The crash: the patch was never merged, so the run still has no counter.
+    retry = await execute(_run(), _NODE, _DEFINITION)
+
+    assert retry["lead_nudge-call"] == first["lead_nudge-call"]
+    assert len(inserted) == 1, "the retry must not place a second call"
+
+
+async def test_a_unique_violation_that_escapes_the_accessor_is_absorbed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The accessor swallows a duplicate into None, so UniqueViolation never
+    reaches this square — kept for the day it narrows, with the same outcome.
+    """
+    inserted: List[str] = []
+    _install(monkeypatch, inserted)
+    first = await execute(_run(), _NODE, _DEFINITION)
+
+    async def raises_instead(**_kw: Any) -> Any:
+        raise UniqueViolation("duplicate key value violates unique constraint")
+
+    monkeypatch.setattr(call_node, "create_lead_call_tracker", raises_instead)
+    retry = await execute(_run(), _NODE, _DEFINITION)
+
+    assert retry["lead_nudge-call"] == first["lead_nudge-call"]
+    assert len(inserted) == 1, "a violation must not place a second call"
+
+
+async def test_a_genuine_insert_failure_still_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No row means the insert really failed, and the run parks."""
+    inserted: List[str] = []
+    _install(monkeypatch, inserted)
+
+    async def always_none(**_kw: Any) -> None:
+        return None
+
+    monkeypatch.setattr(call_node, "create_lead_call_tracker", always_none)
+
+    async def no_row(_lead_id: str) -> Any:
+        return None
+
+    monkeypatch.setattr(call_node, "get_lead_by_id", no_row)
+
+    with pytest.raises(RuntimeError, match="lead insert returned None"):
+        await execute(_run(), _NODE, _DEFINITION)
+
+
+async def test_the_counter_never_reaches_a_template(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Our counting, not a fact about the customer. `lead_` is already a
+    bookkeeping prefix, so run_facts filters it for free.
+    """
+    inserted: List[str] = []
+    _install(monkeypatch, inserted)
+
+    patch = await execute(_run(), _NODE, _DEFINITION)
+    merged = {**_run().context, **patch}
+
+    assert "lead_visits_nudge-call" in patch, "the counter is written"
+    assert not any("visits" in key for key in run_facts(merged)), run_facts(merged)
+
+
+async def test_a_run_from_before_the_counter_starts_at_one(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No counter, or an unreadable one, reads as 0 — so the next id is `:1`.
+    A fresh lead is a duplicate call at worst; raising would park the run.
+    """
+    inserted: List[str] = []
+    _install(monkeypatch, inserted)
+
+    for junk in ({}, {"lead_visits_nudge-call": "two"}, {"lead_visits_nudge-call": -3}):
+        assert call_node._visits_so_far(junk, "nudge-call") == 0
+
+    patch = await execute(_run({"lead_visits_nudge-call": "junk"}), _NODE, _DEFINITION)
+    assert patch["lead_nudge-call"] == _expected(str(_run().id), "nudge-call", 1)

--- a/tests/crm/test_workflow_plans.py
+++ b/tests/crm/test_workflow_plans.py
@@ -878,14 +878,9 @@ def test_send_variables_must_be_declared_variable_fields_on_the_entry_topic() ->
 
 
 def test_action_args_must_name_declared_facts_too() -> None:
-    """The same allow-list, applied to the fourth verb.
-
-    An action's args ask the run for facts by `{name}` exactly as a send
-    node's variables do — the same lookup against the same run_facts — so
-    they answer to the same law. Without it, `{order_id}` on a door whose
-    topic declares only `id` publishes cleanly, validates cleanly, and
-    parks on the first run that reaches the square: the failure the
-    send-side check exists to prevent, reachable through the other verb.
+    """An action's args ask the run for facts by the same names a send node's
+    variables do, so they answer to the same allow-list. Without it
+    `{order_idd}` published and parked on the first run.
     """
     catalogs: plans.Catalogs = {"orders/create": _orders_create_catalog()}
 
@@ -985,3 +980,129 @@ def test_send_variables_may_name_a_stage_letters_fact_and_the_square() -> None:
     assert any(
         "'facts_ask_confirmed' is not a declared variable field" in p for p in problems
     )
+
+
+def test_an_unenumerable_square_exempts_only_its_own_facts() -> None:
+    """A call's answers are declared by the TEMPLATE, so no catalog can list
+    them and a send after a call may name facts_<square>_<anything>. The
+    first cut was one flag for the whole DOCUMENT, which lost the check for
+    every other blank on the board — a typo then published.
+    """
+    orders = _orders_create_catalog()
+    doc: Dict[str, Any] = {
+        **_COD,
+        "nodes": [
+            # Listens on a topic no layer declares — a call's own outcome.
+            {
+                "id": "after-call",
+                "type": "wait_event",
+                "topics": ["call.completed"],
+                "key": "outcome",
+                "minutes": 60,
+            },
+            {
+                "id": "thanks",
+                "type": "send",
+                "channel": "whatsapp",
+                "template": "t",
+                "variables": {"1": "facts_after-call_reason"},
+            },
+        ],
+        "edges": [["after-call", "thanks", "ANSWERED"]],
+        "purpose_key": "utility.order.thanks",
+    }
+    catalogs: plans.Catalogs = {"orders/create": orders, "call.completed": None}
+
+    # The square's own facts pass: nobody can enumerate them.
+    assert validate_definition(doc, catalogs=catalogs) == []
+
+    # A BARE name is still checked — this is the regression the flag caused.
+    typo = {
+        **doc,
+        "nodes": [
+            doc["nodes"][0],
+            {**doc["nodes"][1], "variables": {"1": "totally_bogus_typo"}},
+        ],
+    }
+    problems = validate_definition(typo, catalogs=catalogs)
+    assert any(
+        "'totally_bogus_typo' is not a declared variable field" in p for p in problems
+    ), problems
+
+    # …and so is an action arg.
+    bad_arg = {
+        **doc,
+        "nodes": [
+            doc["nodes"][0],
+            {
+                "id": "tag",
+                "type": "action",
+                "connector": "shopify",
+                "action": "add_tag",
+                "args": {"order_id": "{nonesuch}", "tags": ["x"]},
+            },
+        ],
+        "edges": [["after-call", "tag", "ANSWERED"]],
+    }
+    problems = validate_definition(bad_arg, catalogs=catalogs)
+    assert any("args ask for {nonesuch}" in p for p in problems), problems
+
+
+def test_the_exemption_belongs_to_the_square_that_earned_it() -> None:
+    """Two listening squares, one open and one not: one must not vouch for
+    the other's letters.
+    """
+    orders = _orders_create_catalog()
+    doc: Dict[str, Any] = {
+        **_COD,
+        "nodes": [
+            {
+                "id": "after-call",
+                "type": "wait_event",
+                "topics": ["call.completed"],
+                "key": "outcome",
+                "minutes": 60,
+            },
+            {
+                "id": "ask",
+                "type": "wait_event",
+                "topics": ["orders/paid"],
+                "key": "$topic",
+                "minutes": 60,
+            },
+            {
+                "id": "thanks",
+                "type": "send",
+                "channel": "whatsapp",
+                "template": "t",
+                "variables": {"1": "facts_after-call_anything_at_all"},
+            },
+        ],
+        "edges": [
+            ["after-call", "ask", "ANSWERED"],
+            ["ask", "thanks", "orders/paid"],
+        ],
+        "purpose_key": "utility.order.thanks",
+    }
+    catalogs: plans.Catalogs = {
+        "orders/create": orders,
+        "orders/paid": orders,
+        "call.completed": None,
+    }
+    assert validate_definition(doc, catalogs=catalogs) == []
+
+    # The ENUMERABLE square's letters are still held to its topic's fields,
+    # even though an open square exists on the same board.
+    closed = {
+        **doc,
+        "nodes": [
+            doc["nodes"][0],
+            doc["nodes"][1],
+            {**doc["nodes"][2], "variables": {"1": "facts_ask_not_a_field"}},
+        ],
+    }
+    problems = validate_definition(closed, catalogs=catalogs)
+    assert any(
+        "'facts_ask_not_a_field' is not a declared variable field" in p
+        for p in problems
+    ), problems

--- a/tests/crm/test_workflow_walker.py
+++ b/tests/crm/test_workflow_walker.py
@@ -30,6 +30,30 @@ from tests.crm.doubles import patch_accessors
 NOW = datetime(2026, 9, 3, 12, 0, tzinfo=timezone.utc)
 LEASE = NOW + timedelta(seconds=300)
 
+
+class _Frozen(datetime):
+    """`datetime` with `now()` pinned to NOW.
+
+    A subclass because the stdlib type is immutable, and a subclass rather
+    than a stand-in so the walker's arithmetic behaves as it really does.
+    """
+
+    @classmethod
+    def now(cls, tz: Optional[timezone] = None) -> datetime:  # type: ignore[override]
+        return NOW
+
+
+@pytest.fixture(autouse=True)
+def frozen_clock(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The fixtures are dated; the code under test is not.
+
+    NOW is a fixed 3 September, but walk_run asks the REAL clock for
+    `now - entered_at > max_age_days` (default 7). On the 10th every fixture
+    crossed its expiry and exited `timed_out` — nine tests failed on a date.
+    """
+    monkeypatch.setattr(walker, "datetime", _Frozen)
+
+
 _TWO_WAITS = {
     "entry": {"topic": "checkout.initiated"},
     "nodes": [
@@ -149,11 +173,9 @@ def test_advance_carries_the_lease_it_was_claimed_under(
     run_id, node, wake, context, lease = args
     assert (run_id, node, lease) == (str(run.id), "wait-1d", LEASE)
     assert context == run.context
-    assert (
-        timedelta(minutes=1439)
-        < wake - datetime.now(timezone.utc)
-        < timedelta(minutes=1441)
-    )
+    # Against the frozen clock, so exactly — the old window either side only
+    # existed to absorb drift between two real now() calls.
+    assert wake == NOW + timedelta(minutes=1440)
 
 
 def test_a_missed_cas_on_advance_defers_without_raising_or_exiting(


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Newly created workflow leads are scheduled for dispatch immediately when eligible, reducing delays before outreach begins.
  * Completed call records now include relevant CRM facts from the lead’s configured response data.

* **Bug Fixes**
  * Catalog validation now avoids reporting unreliable variable and action-argument errors when workflow events reference topics that cannot be cataloged.
  * Scheduling failures no longer interrupt lead creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->