### PR TITLE
Fix/reply wakes only its run

### DIFF
--- a/app/crm/connectivity/contracts.py
+++ b/app/crm/connectivity/contracts.py
@@ -36,6 +36,12 @@ What is here, and why each thing is on the surface:
   count of open runs naming a template, so retire can refuse to pull a
   template from under a run in flight without this module importing
   outreach (phase 14; the record/consumers.py inversion).
+- ``register_send_observer`` — the same inversion in the other direction:
+  who else hears that a provider TOOK a message. The dispatcher is the one
+  place a send's provider id (Meta's wamid) is learned, and outreach's
+  wamid stamp needs it so a listening square can match a reply to ITS run.
+  Observers hear facts after the outcome committed and can never fail a
+  send (send_observers.py).
 - ``META_INGRESS`` — the Meta bay for record's /ingest/webhooks/{provider}
   door (ingress.py builds it; app/crm/api.py registers it into record's
   INGRESS slot — the same line worker_main writes for consumers, and the
@@ -81,8 +87,9 @@ from app.crm.connectivity.onboarding import (
     onboard,
     resubscribe,
 )
-from app.crm.connectivity.queue import queue_message
+from app.crm.connectivity.queue import provider_message_id_for, queue_message
 from app.crm.connectivity.reasons import reason_label
+from app.crm.connectivity.send_observers import register_send_observer
 from app.crm.connectivity.templates.events import consume_template_event
 from app.crm.connectivity.templates.lifecycle import (
     create_draft as create_template_draft,
@@ -103,6 +110,9 @@ __all__ = [
     "dispatch_send",
     # producing a send
     "queue_message",
+    # the durable reply join: a producer reads back the provider's id for a
+    # send it proposed, by its own dedupe_key (the stamp's reconcile path)
+    "provider_message_id_for",
     # asking a connector to act (the walker's action square)
     "perform_action",
     "action_names",
@@ -125,6 +135,9 @@ __all__ = [
     "registers_templates_for",
     # the retire guard slot (worker_main fills)
     "register_retire_guard",
+    # the send-observer slot (worker_main fills): who else hears that a
+    # provider took a message — outreach's wamid stamp first
+    "register_send_observer",
     # the template webhook consumer (worker_main registers)
     "consume_template_event",
     # webhook subscription recovery

--- a/app/crm/connectivity/db/accessors/message.py
+++ b/app/crm/connectivity/db/accessors/message.py
@@ -12,6 +12,7 @@ from app.crm.connectivity.db.queries.message import (
     apply_outcome_query,
     claim_queued_messages_query,
     insert_message_query,
+    provider_message_id_for_query,
     requeue_stale_claims_query,
 )
 from app.crm.connectivity.schemas.message import QueuedMessage
@@ -70,6 +71,15 @@ async def requeue_stale_claims(
     requeued = [str(row["id"]) for row in rows if row["status"] == MESSAGE_QUEUED]
     dead = [str(row["id"]) for row in rows if row["status"] != MESSAGE_QUEUED]
     return requeued, dead
+
+
+async def provider_message_id_for(merchant_id: str, dedupe_key: str) -> Optional[str]:
+    """The provider's id for one logical send, or None (no row, or no
+    attempt accepted yet)."""
+    query, values = provider_message_id_for_query(merchant_id, dedupe_key)
+    async with crm_connection() as conn:
+        value = await conn.fetchval(query, *values)
+    return str(value) if value else None
 
 
 async def apply_outcome(

--- a/app/crm/connectivity/db/decoders/template.py
+++ b/app/crm/connectivity/db/decoders/template.py
@@ -1,6 +1,6 @@
 """crm_channel_template rows -> domain shapes."""
 
-from typing import Any, Mapping
+from typing import Any, List, Mapping
 
 from app.crm.connectivity.schemas.template import ApprovedTemplate, TemplateRead
 from app.crm.shared.decode import jsonb_list
@@ -39,11 +39,42 @@ def decode_template(row: Mapping[str, Any]) -> TemplateRead:
     )
 
 
+def flow_button_indexes(components: Any) -> List[int]:
+    """Where a template's FLOW buttons sit among its buttons, in order.
+
+    Meta names a button component by POSITION and refuses the ENTIRE send
+    (131009) when a flow button arrives unnamed — the one send-time fact
+    inside the components blob.
+
+    EVERY position, not the first: whether Meta caps a template at one flow
+    button is Meta's rule to change, and a second left unnamed loses the
+    whole message. Total like every jsonb read here — a malformed column
+    answers [], never a raise.
+    """
+    for component in jsonb_list(components):
+        if not isinstance(component, dict):
+            continue
+        if str(component.get("type", "")).upper() != "BUTTONS":
+            continue
+        buttons = component.get("buttons")
+        if not isinstance(buttons, list):
+            continue
+        return [
+            index
+            for index, button in enumerate(buttons)
+            if isinstance(button, dict)
+            and str(button.get("type", "")).upper() == "FLOW"
+        ]
+    return []
+
+
 def decode_approved_template(row: Mapping[str, Any]) -> ApprovedTemplate:
     """The send path's narrow read: the facts an adapter needs to send.
 
     Deliberately not TemplateRead — the send path runs per message and has no
-    use for a components blob it will never render.
+    use for a components blob it will never render. It is read here for the
+    one thing it alone knows, and reduced to positions at this boundary so
+    nothing downstream parses a provider's structure.
     """
     return ApprovedTemplate(
         id=str(row["id"]),
@@ -51,4 +82,5 @@ def decode_approved_template(row: Mapping[str, Any]) -> ApprovedTemplate:
         language=row["language"],
         provider_template_id=row["provider_template_id"],
         category=row["category"],
+        flow_button_indexes=flow_button_indexes(row.get("components")),
     )

--- a/app/crm/connectivity/db/queries/message.py
+++ b/app/crm/connectivity/db/queries/message.py
@@ -17,9 +17,13 @@ from app.crm.connectivity.reasons import (
     REASON_RECLAIMED_STALE_CLAIM,
 )
 from app.crm.connectivity.status import (
+    MESSAGE_ACCEPTED,
     MESSAGE_DEAD,
+    MESSAGE_DELIVERED,
     MESSAGE_QUEUED,
+    MESSAGE_READ,
     MESSAGE_SENDING,
+    MESSAGE_SENT,
 )
 
 MESSAGE_TABLE = "crm_message"
@@ -134,6 +138,34 @@ def requeue_stale_claims_query(
         REASON_ATTEMPTS_EXHAUSTED,
         REASON_RECLAIMED_STALE_CLAIM,
         MESSAGE_SENDING,
+    ]
+
+
+def provider_message_id_for_query(
+    merchant_id: str, dedupe_key: str
+) -> Tuple[str, List[Any]]:
+    """The reconcile read (contracts.provider_message_id_for): the provider's
+    id for one logical send, by the producer's own name for it. One indexed
+    point read — (merchant_id, dedupe_key) is the dedupe UNIQUE — and NULL
+    until an attempt was accepted.
+
+    Filtered to the POST-ACCEPT ladder in SQL, because the caller treats the
+    answer as "the message the customer received": apply_outcome copies
+    outcome.provider_message_id onto FAILED/DEAD/QUEUED plans too, and while
+    no adapter reports an id beside a refusal today, the first one that does
+    (some providers do) must not turn a message nobody received into a reply
+    correlate. The words come from status.py, never spelled here (the 027
+    scar: vocabulary in code, one home)."""
+    query = f"""
+        SELECT provider_message_id
+          FROM {MESSAGE_TABLE}
+         WHERE merchant_id = $1 AND dedupe_key = $2
+           AND status = ANY($3::text[])
+    """
+    return query, [
+        merchant_id,
+        dedupe_key,
+        [MESSAGE_ACCEPTED, MESSAGE_SENT, MESSAGE_DELIVERED, MESSAGE_READ],
     ]
 
 

--- a/app/crm/connectivity/db/queries/template.py
+++ b/app/crm/connectivity/db/queries/template.py
@@ -135,9 +135,14 @@ def approved_template_for_send_query(
     customer should receive is not a guess anyone may make.
 
     LIMIT 2 because the caller only needs to distinguish one from many.
+
+    ``components`` rides along for the one fact the decoder takes from it:
+    where the FLOW buttons sit, which a send must name or Meta refuses it
+    (131009). The blob stops at the decoder; ApprovedTemplate carries the
+    positions.
     """
     query = f"""
-        SELECT id, name, language, provider_template_id, category
+        SELECT id, name, language, provider_template_id, category, components
           FROM {TEMPLATE_TABLE}
          WHERE merchant_id = $1
            AND channel = $2

--- a/app/crm/connectivity/dispatch.py
+++ b/app/crm/connectivity/dispatch.py
@@ -39,6 +39,7 @@ from app.crm.connectivity.reasons import (
 )
 from app.crm.connectivity.schemas.message import QueuedMessage, SendOutcome, SendToken
 from app.crm.connectivity.send import send
+from app.crm.connectivity.send_observers import notify_send_accepted
 from app.crm.connectivity.status import (
     MESSAGE_ACCEPTED,
     MESSAGE_BLOCKED,
@@ -369,3 +370,17 @@ async def _dispatch_one(message: QueuedMessage, max_attempts: int) -> None:
         f"message {message.id} -> {plan.status}"
         + (f" ({plan.reason})" if plan.reason else "")
     )
+
+    if plan.status == MESSAGE_ACCEPTED and plan.provider_message_id:
+        # The provider's id for what it just took — the one correlate an
+        # inbound reply will carry. Observers (outreach's wamid stamp,
+        # registered at the composition root) hear it AFTER the outcome
+        # committed and CANNOT fail this send: notify swallows their raises.
+        await notify_send_accepted(
+            merchant_id=message.merchant_id,
+            source_kind=message.source_kind,
+            source_id=message.source_id,
+            dedupe_key=message.dedupe_key,
+            message_id=message.id,
+            provider_message_id=plan.provider_message_id,
+        )

--- a/app/crm/connectivity/providers/whatsapp/adapter.py
+++ b/app/crm/connectivity/providers/whatsapp/adapter.py
@@ -55,6 +55,15 @@ def _language_of(route: SendRoute) -> str:
     return route.template.language if route.template else DEFAULT_LANGUAGE
 
 
+def _flow_buttons_of(route: SendRoute) -> List[int]:
+    """Where this template's FLOW buttons sit — empty when it has none.
+
+    Read from the registry row (T23), never guessed: this adapter has no
+    other way to know a template's button structure.
+    """
+    return route.template.flow_button_indexes if route.template else []
+
+
 class MetaWhatsAppAdapter(ChannelAdapter):
     """Meta Cloud API, one merchant's phone number at a time.
 
@@ -131,9 +140,7 @@ class MetaWhatsAppAdapter(ChannelAdapter):
             )
             return SendOutcome(status="blocked", reason=REASON_BAD_VARIABLES)
 
-        payload = build_send_body(
-            message.template_id, _language_of(route), recipient, parameters
-        )
+        payload = self.build_payload(message, recipient, route, parameters)
         url = self.endpoint(route.binding.address)
 
         try:
@@ -159,12 +166,22 @@ class MetaWhatsAppAdapter(ChannelAdapter):
     ) -> Dict[str, Any]:
         """The Cloud API send body for this message on this route.
 
-        Language comes from the route, which resolve_send_route() took from
-        the approved template registry row (T23) — the one place that knows
-        which locale a merchant's template was actually approved in.
+        Language and the flow buttons' positions both come from the route,
+        which resolve_send_route() took from the approved registry row (T23)
+        — the one place that knows the locale a template was approved in and
+        the structure of its buttons.
+
+        The flow_token is this message's own id, echoed back inside the
+        customer's submission, so her answer names the send that opened the
+        form without waiting for a wamid to be stamped anywhere.
         """
         return build_send_body(
-            message.template_id or "", _language_of(route), recipient, parameters
+            message.template_id or "",
+            _language_of(route),
+            recipient,
+            parameters,
+            flow_button_indexes=_flow_buttons_of(route),
+            flow_token=str(message.id),
         )
 
     def read_response(

--- a/app/crm/connectivity/providers/whatsapp/payload.py
+++ b/app/crm/connectivity/providers/whatsapp/payload.py
@@ -87,16 +87,43 @@ def build_send_body(
     language: str,
     recipient: str,
     parameters: List[Dict[str, Any]],
+    flow_button_indexes: Optional[List[int]] = None,
+    flow_token: Optional[str] = None,
 ) -> Dict[str, Any]:
     """The Cloud API send body. Assembly only — ``parameters`` arrive already
     built and judged sendable by the adapter.
 
     ``language`` comes from the template registry (T23), which is the one
     place that knows which locale a merchant's template was approved in.
+
+    A FLOW button must be named by a button component or Meta refuses the
+    whole send (131009) and nothing reaches the customer.
+    ``flow_button_indexes`` holds every such position; empty — every template
+    but the flow ones — leaves the body as it has always been.
+
+    ``flow_token`` comes back verbatim on the customer's submission, so the
+    caller passes the id of the message that opened the form and the answer
+    names its own question. One token for every button: it identifies the
+    SEND, not which button she pressed. It is the component's only optional
+    part, so a caller without one sends no parameters rather than a
+    placeholder — Meta then records its own word, 'unused', which the read
+    side discards.
     """
     components: List[Dict[str, Any]] = []
     if parameters:
         components.append({"type": "body", "parameters": parameters})
+    for index in flow_button_indexes or []:
+        button: Dict[str, Any] = {
+            "type": "button",
+            "sub_type": "flow",
+            # A string, like every other button component's index.
+            "index": str(index),
+        }
+        if flow_token:
+            button["parameters"] = [
+                {"type": "action", "action": {"flow_token": flow_token}}
+            ]
+        components.append(button)
     return {
         "messaging_product": "whatsapp",
         "recipient_type": "individual",

--- a/app/crm/connectivity/queue.py
+++ b/app/crm/connectivity/queue.py
@@ -85,3 +85,19 @@ async def queue_message(
         variables,
         dedupe_key,
     )
+
+
+async def provider_message_id_for(merchant_id: str, dedupe_key: str) -> Optional[str]:
+    """The provider's own id for a logical send this producer once proposed
+    — None until an attempt was ACCEPTED (T16 col 14 is written by the
+    outcome, nothing earlier).
+
+    The durable half of the reply join: the observer stamp
+    (send_observers.py -> outreach) is a cache that can miss — an observer
+    raise is swallowed by contract, and a run's context can be rewritten
+    under it — while this row survives all of that. A consumer that needs
+    the id and finds no stamp reconciles from here by the same dedupe_key
+    it queued with, which is why the read is keyed by the producer's own
+    name for the send and not by our row id.
+    """
+    return await message_accessor.provider_message_id_for(merchant_id, dedupe_key)

--- a/app/crm/connectivity/schemas/template.py
+++ b/app/crm/connectivity/schemas/template.py
@@ -37,6 +37,9 @@ class ApprovedTemplate(BaseModel):
     language: str
     provider_template_id: Optional[str] = None
     category: Optional[str] = None
+    #: Where this template's FLOW buttons sit — empty when it has none.
+    #: Computed from the registered components at decode, never authored.
+    flow_button_indexes: List[int] = Field(default_factory=list)
 
 
 class ProviderTemplateState(BaseModel):

--- a/app/crm/connectivity/send_observers.py
+++ b/app/crm/connectivity/send_observers.py
@@ -1,0 +1,93 @@
+"""The send-observer slot — who else needs to hear that a provider took a
+message, filled at the composition root.
+
+The dispatcher is the one place that learns a send's provider_message_id
+(Meta's wamid), and the moment it does, the message's producer may need the
+fact: outreach's listening squares match an inbound reply to ITS run by that
+id (the call square's plant-and-echo pattern — a reply carries the wamid of
+the message it answers, and nothing else). Connectivity may not import
+outreach (outreach already reads this module's contracts; the reverse arrow
+would close a cycle), so the slot is filled by app/crm/worker_main.py — the
+record/consumers.py inversion, the retire-guard's exact shape.
+
+Observers hear FACTS about the send connectivity already recorded — never a
+verdict to influence: dispatch calls them after apply_outcome committed, and
+an observer that raises is logged and dropped, because a bookkeeping
+subscriber must never be able to fail, retry or double a customer's message.
+"""
+
+import asyncio
+from typing import Awaitable, List, Optional, Protocol
+
+from app.core.logger import logger
+
+#: The lease-safety deadline on ONE observer call. _gate and send() are
+#: wait_for-bounded precisely so a dispatch batch fits its claim lease; an
+#: unbounded stamp behind them could burn the slack and hand the already-
+#: accepted tail to another worker — a real double message. A cancelled
+#: observer degrades to the designed no-stamp path (the reconcile read
+#: recovers the id when it is needed).
+OBSERVER_TIMEOUT_SECONDS = 5.0
+
+
+class SendObserver(Protocol):
+    """Keyword-called, so a wrong or renamed field is a TYPE error at the
+    registration site, not a swallowed TypeError per send in production.
+    source_kind rides through so the slot stays generic — each observer
+    decides which producers are its business, exactly as record's consumers
+    decide per letter."""
+
+    def __call__(
+        self,
+        *,
+        merchant_id: str,
+        source_kind: str,
+        source_id: Optional[str],
+        dedupe_key: str,
+        message_id: str,
+        provider_message_id: str,
+    ) -> Awaitable[None]: ...
+
+
+_OBSERVERS: List[SendObserver] = []
+
+
+def register_send_observer(observer: SendObserver) -> None:
+    """Idempotent: imports can run more than once (tests, reload)."""
+    if observer not in _OBSERVERS:
+        _OBSERVERS.append(observer)
+
+
+async def notify_send_accepted(
+    *,
+    merchant_id: str,
+    source_kind: str,
+    source_id: Optional[str],
+    dedupe_key: str,
+    message_id: str,
+    provider_message_id: str,
+) -> None:
+    """Tell every registered observer the provider took this message.
+
+    Called only for ACCEPTED outcomes that carry a provider id, and only
+    after the outcome was recorded — an observer hears history, not a
+    proposal. Total: one observer's raise is its own bug, logged with the
+    message id and swallowed, so the batch behind this send keeps moving.
+    """
+    for observer in _OBSERVERS:
+        try:
+            await asyncio.wait_for(
+                observer(
+                    merchant_id=merchant_id,
+                    source_kind=source_kind,
+                    source_id=source_id,
+                    dedupe_key=dedupe_key,
+                    message_id=message_id,
+                    provider_message_id=provider_message_id,
+                ),
+                timeout=OBSERVER_TIMEOUT_SECONDS,
+            )
+        except Exception as e:  # noqa: BLE001 — a subscriber must not fail a send
+            logger.opt(exception=e).error(
+                f"send observer failed for message {message_id}"
+            )

--- a/app/crm/outreach/catalog_laws.py
+++ b/app/crm/outreach/catalog_laws.py
@@ -114,6 +114,46 @@ def entry_against_catalog(
     return problems
 
 
+def match_payload_against_catalog(
+    definition: WorkflowDefinition, catalogs: Catalogs
+) -> List[str]:
+    """PURE: a listening square's ``match.payload`` must be a declared field
+    of EVERY topic the square listens on — the mirror of the match.run
+    checks in plans.py, guarding the other half of the same comparison.
+
+    A typo'd payload field resolves to None on every letter, every letter
+    "claims nobody", and the square is permanently deaf with publish clean —
+    the byte-for-byte silent failure the run-side check's comment says it
+    exists to prevent. EVERY topic, not any: match is judged per letter
+    (_is_about), so a field only one of two listened topics declares leaves
+    the square deaf on the other — surfaced here as a sentence instead of
+    discovered as a run that never woke.
+
+    A topic no layer declares is skipped, not refused: nothing exists to
+    check against, and the general unknown-topic law already speaks when
+    the plan filters or keys on it.
+    """
+    problems: List[str] = []
+    if catalogs is None:
+        return problems
+    for node in definition.nodes:
+        if node.type != "wait_event" or node.match is None:
+            continue
+        payload_path = canonical_path(node.match.payload)
+        for topic in node.topics:
+            fields = catalogs.get(topic)
+            if fields is None:
+                continue
+            if payload_path not in fields:
+                problems.append(
+                    f"node {node.id}: match.payload {node.match.payload!r} is "
+                    f"not a declared field of topic {topic!r} — every letter "
+                    f"there would claim nobody and the square would never "
+                    f"hear it"
+                )
+    return problems
+
+
 # Facts the walker computes for a template at the square (nodes.run_facts,
 # phase 16) — never a producer's, so no catalog declares them.
 _WALKER_FACTS = frozenset({"current_node", "current_stage"})

--- a/app/crm/outreach/contracts.py
+++ b/app/crm/outreach/contracts.py
@@ -13,8 +13,16 @@ Logic-layer functions only, never accessors.
                               connectivity's retire asks, through the slot
                               worker_main fills, since connectivity may
                               not import this file.
+  note_send_accepted        — the wamid stamp (correlate.py): the observer
+                              worker_main registers into connectivity's
+                              send-observer slot, so an accepted send's
+                              provider id reaches ITS run and a listening
+                              square can match a reply's echo. The same
+                              inversion as the retire guard, in the other
+                              direction.
 """
 
+from app.crm.outreach.correlate import note_send_accepted
 from app.crm.outreach.entry import consume_attributed_event
 from app.crm.outreach.versions import template_references
 from app.crm.outreach.workers import claim_due_runs, walk_run
@@ -24,4 +32,5 @@ __all__ = [
     "claim_due_runs",
     "walk_run",
     "template_references",
+    "note_send_accepted",
 ]

--- a/app/crm/outreach/correlate.py
+++ b/app/crm/outreach/correlate.py
@@ -1,0 +1,82 @@
+"""The send's provider id reaching its run (the reply join) — the call
+square's plant-and-echo pattern applied to messages, on EVERY channel.
+
+A call plants ``enrollment_id`` in the outbound lead and the outcome echoes
+it, so a listening square can say WHOSE letter it hears. A message send
+cannot plant anything a reply echoes: the only correlate a provider returns
+on a reply is its own id for the message answered (Meta's wamid in
+``context.id``; an email's Message-ID in ``In-Reply-To``) — issued at
+ACCEPT time, after the run's context was written. So the join is completed
+from the other side: when the dispatcher learns the provider's id, this
+observer stamps it into the run's context as
+``provider_message_id_<send node>`` — the T16 column's own name, one
+spelling for every channel — and the square matches on its echo:
+
+    {"match": {"payload": "replied_to", "run": "provider_message_id_confirm"}}
+
+Without the stamp a listening square has no writable ``match`` and falls to
+_is_about's open default — one customer's CANCEL resolved her three other
+orders' runs (observed 2026-09-10; docs/crm/dev_only_reply_run_matching_
+solution.md). ``provider_message_id_`` is a bookkeeping prefix
+(nodes/context.py), so the id can never leak into a template.
+
+Registered into connectivity's send-observer slot by app/crm/worker_main.py
+— the retire-guard inversion, since connectivity may not import this module.
+Total on purpose: the observer hears history, and nothing here may fail,
+retry or double the send it heard about.
+"""
+
+from typing import Optional
+
+from app.core.logger import logger
+from app.crm.outreach.db.accessors import enrollment as enrollment_accessor
+from app.crm.outreach.nodes.context import (
+    parse_send_dedupe_key,
+    provider_message_key,
+)
+
+
+async def note_send_accepted(
+    *,
+    merchant_id: str,
+    source_kind: str,
+    source_id: Optional[str],
+    dedupe_key: str,
+    message_id: str,
+    provider_message_id: str,
+    **_: object,
+) -> None:
+    """Stamp an accepted send's provider id onto ITS run, keyed by the
+    square that sent it.
+
+    Only workflow sends are this module's business; every other producer's
+    acceptance returns at once (the same per-observer filtering record's
+    consumers do). The write is one guarded UPDATE: a run already exited
+    keeps its context — the stamp exists to route a FUTURE reply, and an
+    exited run has no square listening. A miss is logged, not raised: by
+    the observer contract nothing here may fail the send.
+    """
+    if source_kind != "workflow" or not source_id:
+        return
+    parsed = parse_send_dedupe_key(dedupe_key)
+    if parsed is None or parsed[0] != source_id:
+        # Not the send node's "<run>:<node>" shape — a producer this
+        # observer does not understand must not be guessed at.
+        logger.warning(
+            f"provider-id stamp skipped: dedupe_key {dedupe_key!r} is not "
+            f"<run>:<node> for run {source_id} (message {message_id})"
+        )
+        return
+    run_id, node_id = parsed
+    stamped = await enrollment_accessor.stamp_context_key(
+        merchant_id,
+        run_id,
+        provider_message_key(node_id),
+        provider_message_id,
+    )
+    if not stamped:
+        # Exited between the send and the acceptance (a goal event can end
+        # a run mid-flight) — nothing is listening, so nothing is owed.
+        logger.info(
+            f"provider-id stamp found no open run {run_id} (message {message_id})"
+        )

--- a/app/crm/outreach/db/accessors/enrollment.py
+++ b/app/crm/outreach/db/accessors/enrollment.py
@@ -36,6 +36,7 @@ from app.crm.outreach.db.queries.enrollment import (
     resume_run_query,
     runs_referencing_template_query,
     source_event_used_query,
+    stamp_context_key_query,
     sweep_exited_runs_query,
     workflow_summary_query,
 )
@@ -219,6 +220,16 @@ async def open_runs_for_customer(
     async with crm_connection() as conn:
         rows = await conn.fetch(query, *values)
     return [decode_run(row) for row in rows]
+
+
+async def stamp_context_key(
+    merchant_id: str, run_id: str, key: str, value: str
+) -> bool:
+    """True when the run was still open and took the bookkeeping key."""
+    query, values = stamp_context_key_query(merchant_id, run_id, key, value)
+    async with crm_connection() as conn:
+        row = await conn.fetchrow(query, *values)
+    return row is not None
 
 
 async def resume_run_by_id(

--- a/app/crm/outreach/db/queries/enrollment.py
+++ b/app/crm/outreach/db/queries/enrollment.py
@@ -319,6 +319,25 @@ def open_runs_for_customer_query(
     return query, [merchant_id, customer_id]
 
 
+def stamp_context_key_query(
+    merchant_id: str, run_id: str, key: str, value: str
+) -> Tuple[str, List[Any]]:
+    """One bookkeeping key onto an OPEN run's context (the wamid stamp,
+    correlate.py): the send's provider id, keyed by the square that sent
+    it, so a listening square's ``match`` can compare a reply's echo
+    against it. Guarded to open runs only — the stamp routes a FUTURE
+    reply, and an exited run has no square listening. Merchant-scoped
+    like every write here; RETURNING id so the caller can tell "stamped"
+    from "already exited" without a second read."""
+    query = f"""
+        UPDATE {ENROLLMENT_TABLE}
+        SET context = context || jsonb_build_object($3::text, $4::text)
+        WHERE merchant_id = $1 AND id = $2::uuid AND status <> 'exited'
+        RETURNING id
+    """
+    return query, [merchant_id, run_id, key, value]
+
+
 def resume_run_by_id_query(
     merchant_id: str,
     run_id: str,

--- a/app/crm/outreach/entry.py
+++ b/app/crm/outreach/entry.py
@@ -135,7 +135,7 @@ async def consume_attributed_event(
             continue
         if await _end_on_goal(run, definition, event, goal_patch):
             continue  # exited: there is nothing left to wake
-        await _wake_on_reply(run, definition, event)
+        await _wake_on_reply(run, definition, event, variables)
 
     flows = await workflow_accessor.live_workflows(event.merchant_id)
     for flow in flows:
@@ -191,7 +191,10 @@ async def _end_on_goal(
 
 
 async def _wake_on_reply(
-    run: EnrollmentRun, definition: WorkflowDefinition, event: RawEvent
+    run: EnrollmentRun,
+    definition: WorkflowDefinition,
+    event: RawEvent,
+    variables: Optional[Dict[str, Any]] = None,
 ) -> None:
     """A wait_event square of ITS document listening on this topic wakes
     the run with the answer — the statement decides whether the token is
@@ -200,8 +203,34 @@ async def _wake_on_reply(
     the customer moved). The letter's scalar facts ride along under the
     square (context.facts.<square>), so a later call can say what this
     stage's letter said; the same bridge enrol uses, so bookkeeping names
-    and nested payload never reach the run."""
-    facts = _context_from_payload(event.payload, await CRM_CONTEXT_VALUE_MAX_CHARS())
+    and nested payload never reach the run.
+
+    Those facts are the catalog's DECLARED variables over the top-level
+    scalar copy. Enrol has always been handed them (the same argument, one
+    call below) while a square woken by the same letter re-read the raw
+    payload by hand — so a derived or nested field reached a STARTING run
+    and never a WAITING one. On a source whose person and answer both live
+    inside lists, that left the square holding a protocol constant: a
+    WhatsApp letter offered `messaging_product` and nothing the plan could
+    name. One reader of one payload, which is the whole point of the
+    engine (extractors/engine.py: two hand-written readers already drifted
+    once).
+
+    Merged rather than substituted, so a plan relying on a raw scalar the
+    catalog does not declare keeps it; the declared name wins the tie,
+    being the one the console showed the author. Bookkeeping is filtered
+    from both sides — a catalog that declares a field called `phone` must
+    not overwrite the normalized number the sends dial.
+    """
+    declared = {
+        name: value
+        for name, value in (variables or {}).items()
+        if not is_bookkeeping(name)
+    }
+    facts = {
+        **_context_from_payload(event.payload, await CRM_CONTEXT_VALUE_MAX_CHARS()),
+        **declared,
+    }
     for node in definition.nodes:
         if node.type != "wait_event" or event.topic not in node.topics:
             continue

--- a/app/crm/outreach/entry.py
+++ b/app/crm/outreach/entry.py
@@ -27,6 +27,7 @@ from typing import Any, Dict, Optional, Sequence, Tuple
 
 from app.core.config.dynamic import CRM_CONTEXT_VALUE_MAX_CHARS
 from app.core.logger import logger
+from app.crm.connectivity.contracts import provider_message_id_for
 from app.crm.outreach.db.accessors import (
     enrollment as enrollment_accessor,
     workflow as workflow_accessor,
@@ -35,8 +36,10 @@ from app.crm.outreach.definitions import definition_for
 from app.crm.outreach.enrol import enrol
 from app.crm.outreach.nodes.context import (
     LATEST_LETTER_KEY,
+    PROVIDER_MESSAGE_PREFIX,
     is_bookkeeping,
     reply_key,
+    send_dedupe_key,
 )
 from app.crm.outreach.nodes.wait_event import TOPIC_KEY
 from app.crm.outreach.repeat import _as_number, apply_repeat
@@ -234,6 +237,7 @@ async def _wake_on_reply(
     for node in definition.nodes:
         if node.type != "wait_event" or event.topic not in node.topics:
             continue
+        run = await _with_provider_stamp(run, node)
         if not _is_about(node, event, run):
             continue  # another run's letter (phase 18): not this square's
         answer = _answer_for(node, event)
@@ -260,6 +264,43 @@ async def _wake_on_reply(
             {reply_key(node.id): answer, LATEST_LETTER_KEY: node.id},
             facts,
         )
+
+
+async def _with_provider_stamp(run: EnrollmentRun, node: WorkflowNode) -> EnrollmentRun:
+    """The run with its send's provider id present, reconciled from the
+    manifest when the stamp is missing.
+
+    The observer stamp (correlate.py) is a CACHE: its raise is swallowed by
+    the observer contract, and a walker visit that started before the stamp
+    landed can rewrite the context without it (advance replaces context
+    whole, CAS-guarded on wake_at alone). The durable copy is the manifest
+    row — apply_outcome wrote provider_message_id before the observer ever
+    ran (T16 col 14) — so a square about to match on the stamp and not
+    finding it reads it back by the SAME dedupe_key the send was queued
+    under, re-stamps (best effort, so the next letter finds it cached), and
+    matches on the reconciled value. A raise here rolls back only this
+    letter's savepoint; the row returns next poll — at-least-once, exactly
+    the consumer contract.
+
+    None from the manifest means no attempt was ever accepted: the run
+    honestly has no id a reply could echo, and _is_about answers "not hers"
+    — the run keeps waiting rather than taking another run's letter.
+    """
+    match = node.match
+    if match is None or not match.run.startswith(PROVIDER_MESSAGE_PREFIX):
+        return run
+    if run.context.get(match.run):
+        return run
+    node_id = match.run[len(PROVIDER_MESSAGE_PREFIX) :]
+    stamped = await provider_message_id_for(
+        run.merchant_id, send_dedupe_key(str(run.id), node_id)
+    )
+    if not stamped:
+        return run
+    await enrollment_accessor.stamp_context_key(
+        run.merchant_id, str(run.id), match.run, stamped
+    )
+    return run.model_copy(update={"context": {**run.context, match.run: stamped}})
 
 
 def _is_about(node: WorkflowNode, event: RawEvent, run: EnrollmentRun) -> bool:
@@ -317,7 +358,15 @@ async def _answered_by(
     would push the alarm the wake just set (now) back by the debounce, and
     the token would sit on a square it has already answered — on a stages
     ladder (phase 17), where every stage is a door AND every earlier
-    square listens for it, every stage clock would run twice."""
+    square listens for it, every stage clock would run twice.
+
+    Reconciled through the SAME lens the wake used: open_runs was read at
+    the top of the pass, so a stamp _wake_on_reply just reconciled lives on
+    the copy it resumed, not on these objects. Judging the stale context
+    here would answer "not its square's answer" for the very letter that
+    woke the run — and apply_repeat would re-arm the square it just
+    resolved. Cheap on the second ask: the wake's reconcile re-stamped the
+    row, and a present in-memory key short-circuits before any read."""
     for run in open_runs:
         if (
             str(run.workflow_id) == str(flow.id)
@@ -327,10 +376,11 @@ async def _answered_by(
             if pinned is None:
                 return False
             square = next((n for n in pinned.nodes if n.id == run.current_node), None)
+            if square is None:
+                return False
+            run = await _with_provider_stamp(run, square)
             return (
-                square is not None
-                and _is_about(square, event, run)
-                and _answer_for(square, event) is not None
+                _is_about(square, event, run) and _answer_for(square, event) is not None
             )
     return False
 

--- a/app/crm/outreach/nodes/context.py
+++ b/app/crm/outreach/nodes/context.py
@@ -37,7 +37,26 @@ _BOOKKEEPING_KEYS = (
 # LEAVES, and the action then executes as its own square, so "the current
 # square's facts" would never be the latest stage's.
 LATEST_LETTER_KEY = "latest_letter"
-_BOOKKEEPING_PREFIXES = ("lead_", "message_", "reply_", "action_")
+# provider_message_id_<send node>: the provider's OWN id for that square's
+# accepted send (correlate.py; Meta's wamid, an email's Message-ID — the T16
+# column's name, so one spelling serves every channel) — the value a
+# listening square's `match` compares a reply's replied_to against.
+# Bookkeeping like message_<node>, and for the same reason: an internal id
+# must never resolve into a customer's message.
+# The provider-id stamp's key family (correlate.py writes, entry.py
+# reconciles, plans.py validates): ONE spelling, imported everywhere it is
+# compared — three private copies would let the validator bless names the
+# stamp never writes, and the bookkeeping filter stop recognising the key
+# the day one copy moved.
+PROVIDER_MESSAGE_PREFIX = "provider_message_id_"
+
+_BOOKKEEPING_PREFIXES = (
+    "lead_",
+    "message_",
+    "reply_",
+    "action_",
+    PROVIDER_MESSAGE_PREFIX,
+)
 
 # The merchant's own id for the thing a call is about. Buddy's reporter
 # echoes lead.request_id back to the merchant as orderId on every outcome
@@ -46,6 +65,29 @@ _BOOKKEEPING_PREFIXES = ("lead_", "message_", "reply_", "action_")
 # names the order field — Shopify's `id`, a platform-wide unique); the flat
 # keys below serve unkeyed plans, and the run id is the last fallback.
 _REQUEST_ID_KEYS = ("order_id", "request_id")
+
+
+def provider_message_key(node_id: str) -> str:
+    """Where a send square's accepted provider id lives in the context."""
+    return f"{PROVIDER_MESSAGE_PREFIX}{node_id}"
+
+
+def send_dedupe_key(run_id: str, node_id: str) -> str:
+    """The manifest name for one square's send — "<run>:<node>". Built and
+    parsed by THIS pair only: the builder (nodes/send.py) and the parser
+    (correlate.py, the reconcile read) drifting apart is a stamp that lands
+    under a key no square's match ever names."""
+    return f"{run_id}:{node_id}"
+
+
+def parse_send_dedupe_key(dedupe_key: str) -> Optional[tuple]:
+    """(run_id, node_id), or None for a key this convention did not build —
+    which must be skipped, never guessed at: a wrong guess writes a
+    correlate onto the wrong run."""
+    run_id, sep, node_id = dedupe_key.partition(":")
+    if not sep or not run_id or not node_id:
+        return None
+    return run_id, node_id
 
 
 def is_bookkeeping(key: str) -> bool:

--- a/app/crm/outreach/nodes/send.py
+++ b/app/crm/outreach/nodes/send.py
@@ -10,7 +10,7 @@ from typing import Any, Dict, List
 
 from app.core.logger import logger
 from app.crm.connectivity.contracts import queue_message
-from app.crm.outreach.nodes.context import send_variables
+from app.crm.outreach.nodes.context import send_dedupe_key, send_variables
 from app.crm.outreach.nodes.spec import NodeParked
 from app.crm.outreach.schemas import EnrollmentRun, WorkflowDefinition, WorkflowNode
 
@@ -76,7 +76,7 @@ async def execute(
     except ValueError as e:
         raise NodeParked(f"send node {node.id}: {e}") from e
 
-    dedupe_key = f"{run.id}:{node.id}"
+    dedupe_key = send_dedupe_key(str(run.id), node.id)
     try:
         message_id = await queue_message(
             merchant_id=run.merchant_id,

--- a/app/crm/outreach/plans.py
+++ b/app/crm/outreach/plans.py
@@ -15,6 +15,7 @@ from app.crm.outreach.catalog_laws import (
     WorkflowValidationError,
     entry_against_catalog,
     gather_catalogs as _gather_catalogs,
+    match_payload_against_catalog,
 )
 from app.crm.outreach.db import DbTxn, atomically
 from app.crm.outreach.db.accessors import (
@@ -24,6 +25,7 @@ from app.crm.outreach.db.accessors import (
 )
 from app.crm.outreach.ladder import LadderProblem, expand_stages
 from app.crm.outreach.nodes import NODE_TYPES, is_wait
+from app.crm.outreach.nodes.context import PROVIDER_MESSAGE_PREFIX
 from app.crm.outreach.repeat import parse_repeat_policy
 from app.crm.outreach.schemas import (
     GOAL_EXIT_REASONS,
@@ -84,6 +86,7 @@ def validate_definition(
             "equality map is retired (migration 069)"
         )
     problems.extend(entry_against_catalog(definition, catalogs))
+    problems.extend(match_payload_against_catalog(definition, catalogs))
     node_ids = [node.id for node in definition.nodes]
     seen = set()
     for node_id in node_ids:
@@ -100,6 +103,90 @@ def validate_definition(
                 f"node {node.id}: match belongs to a wait_event — only a "
                 "listening square hears a letter"
             )
+        if (
+            node.type == "wait_event"
+            and node.match is None
+            and node.topics == ["message.inbound"]
+            and (upstream := _upstream_sends(node.id, definition))
+        ):
+            # The 2026-09-10 incident, at publish instead of in production:
+            # a square waiting for the reply to a send UPSTREAM of it,
+            # without saying whose, falls to _is_about's open default — one
+            # customer's answer resolves every open run of hers, and an
+            # order she confirmed gets cancelled. Scoped three ways so it
+            # cannot demand a match where one has no meaning: only the
+            # reply topic; only when a send is upstream on the EDGE GRAPH
+            # (a receive-first square beside an unrelated send branch has
+            # no reply to mis-route, and the suggested match would be
+            # unsatisfiable there); and only a single-topic square — a
+            # mixed listen (reply OR call outcome) forced to match would
+            # go deaf on its other topic, since match is judged per
+            # letter. The suggestion names the UPSTREAM sends: a plan with
+            # two sends must not be told to match the wrong one's id.
+            names = " or ".join(
+                f'"{PROVIDER_MESSAGE_PREFIX}{send}"' for send in upstream
+            )
+            problems.append(
+                f"node {node.id}: listens on message.inbound with no match — "
+                f"a reply would wake EVERY open run of the customer, not the "
+                f'one it answers. Add match: {{"payload": "replied_to", '
+                f'"run": {names}}} (the send square whose reply this square '
+                f"waits for). A customer who TYPES a fresh message instead "
+                f"of replying carries no thread id and will not match — the "
+                f"timeout edge is that path."
+            )
+        if (
+            node.type == "wait_event"
+            and "message.inbound" in node.topics
+            and len(node.topics) > 1
+            and _upstream_sends(node.id, definition)
+        ):
+            # A mixed listen downstream of a send is unsafe in BOTH
+            # directions, so it is refused whole rather than matched:
+            # matchless, _is_about's open default takes one reply for
+            # every open run (the incident, one door over); matched, the
+            # same match is judged against every letter the square hears
+            # and the other topic's letters — which carry no replied_to —
+            # all claim nobody, deafening the square to the very outcome
+            # it also waits for. Two squares each say one thing honestly;
+            # the vocabulary has no shape that lets one square say both.
+            others = [t for t in node.topics if t != "message.inbound"]
+            problems.append(
+                f"node {node.id}: message.inbound cannot share a square "
+                f"with {', '.join(repr(t) for t in others)} when a send is "
+                f"upstream — without a match one reply wakes every open "
+                f"run; with one, the square goes deaf on the other topic. "
+                f"Split it into two listening squares."
+            )
+        if (
+            node.match is not None
+            and node.match.run.startswith("provider_message")
+            and not node.match.run.startswith(PROVIDER_MESSAGE_PREFIX)
+        ):
+            # A typo INSIDE the prefix sails past the send-node check below
+            # (its startswith fails) and publishes a square that matches
+            # nothing forever — the silent version of the incident.
+            problems.append(
+                f"node {node.id}: match.run {node.match.run!r} — did you "
+                f"mean {PROVIDER_MESSAGE_PREFIX}<send node>? The stamp "
+                f"writes exactly that prefix and nothing else"
+            )
+        if node.match is not None and node.match.run.startswith(
+            PROVIDER_MESSAGE_PREFIX
+        ):
+            # The stamp (correlate.py) writes provider_message_id_<node>
+            # only for a SEND node's accepted message. A misspelled square
+            # name here would publish clean and then match nothing forever
+            # — every reply "claims nobody" — which is the silent version
+            # of the very failure match exists to prevent.
+            sender = node.match.run[len(PROVIDER_MESSAGE_PREFIX) :]
+            named = next((n for n in definition.nodes if n.id == sender), None)
+            if named is None or named.type != "send":
+                problems.append(
+                    f"node {node.id}: match.run {node.match.run!r} — "
+                    f"{sender!r} is not a send node, so no provider id is ever "
+                    "stamped under that name"
+                )
 
     # The doors (phase 15): one per topic, each starting on a real square.
     # Repeat-entry words per door (repeat.py owns the vocabulary); debounce
@@ -190,6 +277,31 @@ def validate_definition(
                 )
 
     return problems
+
+
+def _upstream_sends(node_id: str, definition: WorkflowDefinition) -> List[str]:
+    """PURE: the send squares a token could have crossed BEFORE standing on
+    ``node_id``, walked backwards over the edge graph — what the no-match
+    refusal scopes itself by. A reply can only answer a send that already
+    happened, so a square with no send upstream has no reply to mis-route,
+    whatever else the plan contains."""
+    inbound: Dict[str, List[str]] = {}
+    for edge in definition.edges:
+        inbound.setdefault(edge[1], []).append(edge[0])
+    by_id = {node.id: node for node in definition.nodes}
+    seen: set = set()
+    stack = [node_id]
+    sends: List[str] = []
+    while stack:
+        for source in inbound.get(stack.pop(), []):
+            if source in seen:
+                continue
+            seen.add(source)
+            node = by_id.get(source)
+            if node is not None and node.type == "send":
+                sends.append(source)
+            stack.append(source)
+    return sends
 
 
 def _entry_changed(raw_entry: Any, live_entry: Any) -> bool:

--- a/app/crm/record/extractors/whatsapp.py
+++ b/app/crm/record/extractors/whatsapp.py
@@ -254,6 +254,13 @@ def reply(payload: Dict[str, Any]) -> Optional[Any]:
     wakes the square and names the arrow, so a plan author labels one edge
     ``form_submitted`` and it fires.  Returning the raw JSON would equal no
     label, sending the walker down the ``else`` arrow or exiting the run.
+
+    Classified by the DISCRIMINANT (_nfm_reply), never by whether the
+    reading has content: WHAT she submitted and THAT she submitted are two
+    questions, and an informational flow — one screen, a Done footer, an
+    empty payload — echoes only our own token, which flow_response rightly
+    strips to None. Conflating the two read that customer as silent, and
+    the timeout edge chased someone who had tapped through the form.
     """
     item = _item(payload, "messages")
     button = item.get("button")
@@ -265,7 +272,7 @@ def reply(payload: Dict[str, Any]) -> Optional[Any]:
             chosen = interactive.get(kind)
             if isinstance(chosen, dict) and chosen.get("id") is not None:
                 return chosen["id"]
-    if flow_response(payload) is not None:
+    if _nfm_reply(payload):
         return "form_submitted"
     return message_text(payload)
 

--- a/app/crm/record/extractors/whatsapp.py
+++ b/app/crm/record/extractors/whatsapp.py
@@ -31,6 +31,7 @@ engine's role normalization is the whole translation and no new handle kind
 is needed.
 """
 
+import json
 from typing import Any, Dict, List, Literal, Optional
 
 from app.crm.record.extractors.engine import Deriver
@@ -38,6 +39,17 @@ from app.crm.record.schemas import CatalogEntry, CatalogField
 
 SOURCE = "whatsapp"
 GROUP = "WhatsApp"
+
+# Meta's own literal for "this send named no flow_token" — their API returns
+# this exact string when a send carried no token. Spelled here rather than
+# imported: record may import no other CRM module (rule 12), and this side
+# must know the word whoever sent the letter, not only our own sender.
+UNUSED_FLOW_TOKEN = "unused"
+
+# The one key inside a submission that WE put there rather than the
+# customer: the send stamps it, Meta echoes the whole object back, so her
+# answers arrive with it mixed in.
+FLOW_TOKEN_KEY = "flow_token"
 
 # Meta's own message.type vocabulary — what a flow may filter on.
 MESSAGE_TYPES = [
@@ -130,12 +142,119 @@ def replied_to(payload: Dict[str, Any]) -> Optional[Any]:
     return context.get("id") if isinstance(context, dict) else None
 
 
+def _nfm_reply(payload: Dict[str, Any]) -> Dict[str, Any]:
+    """The Flow submission object on this message, or {}.
+
+    Meta files a completed Flow as an ordinary inbound message of type
+    'interactive' whose interactive.type is 'nfm_reply'.  Both
+    discriminants are checked: message.type must be 'interactive' AND
+    interactive.type must be 'nfm_reply', so a button_reply that happens
+    to carry an nfm_reply member is never misclassified as a submission.
+    """
+    item = _item(payload, "messages")
+    if item.get("type") != "interactive":
+        return {}
+
+    interactive = item.get("interactive")
+    if isinstance(interactive, dict) and interactive.get("type") == "nfm_reply":
+        submission = interactive.get("nfm_reply")
+        if isinstance(submission, dict):
+            return submission
+
+    return {}
+
+
+def _submitted(payload: Dict[str, Any]) -> Optional[str]:
+    """The raw response_json string Meta sent, or None."""
+    value = _nfm_reply(payload).get("response_json")
+    return value if isinstance(value, str) and value else None
+
+
+def flow_response(payload: Dict[str, Any]) -> Optional[Any]:
+    """What she filled in, written out to be read by a person.
+
+    Meta nests the answers as encoded text, so reading them is two parses
+    deep — and the result lands somewhere a human looks: a merchant's order
+    note, a console card. So it comes out as one "key: value" per line, in
+    the order her form asked, rather than as the JSON it arrived in.
+
+    FLOW_TOKEN_KEY is dropped: the send stamps it for correlation and Meta
+    echoes it back inside her answers, so leaving it in would put a uuid of
+    ours beside her address. Her own keys and values are never renamed or
+    reworded. A submission we cannot parse is handed back exactly as it
+    came, because an unexpected shape is still her answer.
+
+    The letter itself is untouched on the event row — this is the reading,
+    and flow_token reads the raw submission for the same reason.
+    """
+    raw = _submitted(payload)
+    if not raw:
+        return None
+    try:
+        parsed = json.loads(raw)
+    except (TypeError, ValueError):
+        return raw  # an unexpected shape is still her answer
+    if not isinstance(parsed, dict):
+        return raw
+    lines = [
+        f"{key}: {_readable(value)}"
+        for key, value in parsed.items()
+        if key != FLOW_TOKEN_KEY
+    ]
+    return "\n".join(lines) if lines else None
+
+
+def _readable(value: Any) -> str:
+    """One answer as text. A scalar is itself; a multi-select (Meta sends a
+    list) reads as a comma list rather than as ['a', 'b']; anything else
+    falls back to JSON, which is at least complete."""
+    if isinstance(value, (str, int, float)) and not isinstance(value, bool):
+        return str(value)
+    if isinstance(value, list) and all(
+        isinstance(item, (str, int, float)) and not isinstance(item, bool)
+        for item in value
+    ):
+        return ", ".join(str(item) for item in value)
+    return json.dumps(value, ensure_ascii=False)
+
+
+def flow_token(payload: Dict[str, Any]) -> Optional[Any]:
+    """Which of OUR sends opened this form.
+
+    The send stamps the message's own id (whatsapp/adapter.py), so unlike
+    replied_to this join needs no wamid. Read from the raw submission, not
+    from flow_response, which has already taken the token out. Meta returns
+    the literal 'unused' when a send named no token — not an id, so it is
+    dropped.
+    """
+    raw = _submitted(payload)
+    if not raw:
+        return None
+    try:
+        parsed = json.loads(raw)
+    except (TypeError, ValueError):
+        return None
+    if not isinstance(parsed, dict):
+        return None
+    token = parsed.get(FLOW_TOKEN_KEY)
+    if not isinstance(token, str) or not token or token == UNUSED_FLOW_TOKEN:
+        return None
+    return token
+
+
 def reply(payload: Dict[str, Any]) -> Optional[Any]:
     """What the customer answered, whatever shape Meta used: a template
-    quick-reply's payload, an interactive button's or list row's id, else
-    the text body. One field, so a wait_event square branches on the
-    answer without knowing which widget the template put in front of
-    her — a tap and a typed reply land on the same key."""
+    quick-reply's payload, an interactive button's or list row's id, the
+    literal ``'form_submitted'`` for a Flow submission, else the text body.
+    One field, so a wait_event square branches on the answer without knowing
+    which widget the template put in front of her — a tap, a form and a
+    typed reply land on the same key.
+
+    The form's actual data lives in ``flow_response`` — this token only
+    wakes the square and names the arrow, so a plan author labels one edge
+    ``form_submitted`` and it fires.  Returning the raw JSON would equal no
+    label, sending the walker down the ``else`` arrow or exiting the run.
+    """
     item = _item(payload, "messages")
     button = item.get("button")
     if isinstance(button, dict) and button.get("payload") is not None:
@@ -146,6 +265,8 @@ def reply(payload: Dict[str, Any]) -> Optional[Any]:
             chosen = interactive.get(kind)
             if isinstance(chosen, dict) and chosen.get("id") is not None:
                 return chosen["id"]
+    if flow_response(payload) is not None:
+        return "form_submitted"
     return message_text(payload)
 
 
@@ -184,6 +305,8 @@ DERIVERS: Dict[str, Deriver] = {
     "message_text": message_text,
     "replied_to": replied_to,
     "reply": reply,
+    "flow_response": flow_response,
+    "flow_token": flow_token,
     "recipient_phone": recipient_phone,
     "status": status,
     "status_message_id": status_message_id,
@@ -229,6 +352,19 @@ def _inbound_fields() -> List[CatalogField]:
         # manifest's provider_message_id. Declared now so the join key is
         # in the catalog the day that trigger lands.
         _f("replied_to", "text", "Replied-to message id", keyable=True, derived=True),
+        # A Flow submission at two grains: `reply` wakes the square,
+        # `flow_response` carries what she typed, and `flow_token` says which
+        # message opened the form — the one join here needing no wamid.
+        #
+        # `flow_response` is a variable despite being a JSON STRING: her
+        # form's field names are HERS, so nothing in this file can declare
+        # them one by one, and until a shape exists that can, the whole
+        # submission is what a plan can name. Past VARIABLE_MAX_CHARS the
+        # engine drops it and the square parks on the missing fact — a loud
+        # stop, not a silent truncation. The letter itself stays verbatim
+        # on the event row, which is where the evidence lives.
+        _f("flow_response", "text", "Form response", variable=True, derived=True),
+        _f("flow_token", "text", "Form token", keyable=True, derived=True),
     ]
 
 

--- a/app/crm/worker_main.py
+++ b/app/crm/worker_main.py
@@ -17,10 +17,12 @@ from app.crm.connectivity.contracts import (
     consume_template_event,
     dispatch_send,
     register_retire_guard,
+    register_send_observer,
 )
 from app.crm.outreach.contracts import (
     claim_due_runs,
     consume_attributed_event,
+    note_send_accepted,
     template_references,
     walk_run,
 )
@@ -45,6 +47,13 @@ register_consumer(consume_template_event)
 # app/main.py imports this module, so the API pod (where the retire route
 # lives) is wired too.
 register_retire_guard(template_references)
+# The same inversion in the other direction (the provider-id stamp,
+# outreach/correlate.py): when the dispatcher learns a send's provider id
+# — Meta's wamid, an email's Message-ID — outreach writes it onto the run
+# that sent it, so a listening square's `match` can compare a reply's echo
+# (replied_to) against provider_message_id_<node> and one customer's
+# answer can never resolve her other runs. Channel-agnostic on purpose.
+register_send_observer(note_send_accepted)
 
 ROLES: Dict[str, Callable[[asyncio.Event], Coroutine[Any, Any, None]]] = {
     "event-worker": lambda stop_event: run_drain_loop(

--- a/tests/crm/conftest.py
+++ b/tests/crm/conftest.py
@@ -15,6 +15,19 @@ import pytest  # noqa: E402  (the DSN above is a plain constant, not a fixture)
 from tests.crm import doubles  # noqa: E402
 
 
+@pytest.fixture(autouse=True)
+def _empty_send_observer_slot(monkeypatch: pytest.MonkeyPatch):
+    """The send-observer slot is process-global and worker_main fills it at
+    IMPORT time — which any test importing worker_main does for the whole
+    session. Left in place, the first dispatch test with a workflow-shaped
+    message would run the REAL stamp against a live accessor, and the
+    observer contract's swallow would keep the test green while logging DB
+    errors. Every test starts with an empty slot and registers its own."""
+    from app.crm.connectivity import send_observers
+
+    monkeypatch.setattr(send_observers, "_OBSERVERS", [])
+
+
 @pytest.fixture
 def graph_stub(monkeypatch: pytest.MonkeyPatch):
     """The shared Meta Graph transport, canned: ``graph_stub(handler)`` returns

--- a/tests/crm/fixtures/whatsapp/message_inbound_flow.json
+++ b/tests/crm/fixtures/whatsapp/message_inbound_flow.json
@@ -1,0 +1,33 @@
+{
+  "messaging_product": "whatsapp",
+  "metadata": {
+    "display_phone_number": "918067451234",
+    "phone_number_id": "812345678901234"
+  },
+  "contacts": [
+    {
+      "profile": { "name": "Rohan Mehta" },
+      "wa_id": "918887776665"
+    }
+  ],
+  "messages": [
+    {
+      "from": "918887776665",
+      "id": "wamid.HBgMOTE4ODg3Nzc2NjY1FQIAEhggRDdBOTFDMEUyMkI0",
+      "timestamp": "1788177880",
+      "type": "interactive",
+      "context": {
+        "from": "918067451234",
+        "id": "wamid.HBgMOTE4ODg3Nzc2NjY1FQIAERgSMEYwRkI3NkYyQzE1NUFCRDMx"
+      },
+      "interactive": {
+        "type": "nfm_reply",
+        "nfm_reply": {
+          "name": "flow",
+          "body": "Sent",
+          "response_json": "{\"flow_token\":\"eac760ab-c59b-4582-bc9e-0a40adbc9a45\",\"address\":\"221B Baker Street, Bengaluru 560001\"}"
+        }
+      }
+    }
+  ]
+}

--- a/tests/crm/test_send_correlation.py
+++ b/tests/crm/test_send_correlation.py
@@ -1,0 +1,592 @@
+"""The reply join, end to end: an accepted send's wamid reaches ITS run,
+and a listening square's `match` lets a reply wake only that run.
+
+The incident this pins (docs/crm/dev_only_reply_run_matching_solution.md):
+one customer, four open COD runs, two button taps — the first tap resolved
+all four, cancelling an order she had explicitly confirmed. `_is_about`'s
+open default was doing exactly what it documents; what was missing is the
+correlate a `match` could compare, because the letter carries Meta's wamid
+while the run held only our message id.
+
+The fix is the call square's plant-and-echo pattern with the plant made
+late: the dispatcher tells a registered observer when a provider takes a
+message (connectivity/send_observers.py), outreach stamps the wamid onto
+the run under provider_message_id_<send node> (correlate.py — the T16 column's
+name, one spelling for every channel), and the square says
+`match: {payload: replied_to, run: provider_message_id_<node>}`.
+"""
+
+import asyncio
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, List, Optional
+from uuid import uuid4
+
+import pytest
+
+import app.crm.connectivity.dispatch as dispatch
+import app.crm.connectivity.send_observers as send_observers
+import app.crm.outreach.correlate as correlate
+from app.crm.outreach.entry import _is_about
+from app.crm.outreach.nodes.context import is_bookkeeping, run_facts
+from app.crm.outreach.plans import validate_definition
+from app.crm.outreach.schemas import EnrollmentRun, WorkflowNode
+from app.crm.record.schemas import RawEvent
+from tests.crm.test_dispatch import _gate_open, _message
+
+NOW = datetime(2026, 9, 10, 12, 0, tzinfo=timezone.utc)
+WAMID = "wamid.HBgMOTE5MzU0MDY5NzgyFQIAERgSRTI2ODIxAA=="
+
+
+def _workflow_message(run_id: str, node_id: str = "confirm"):
+    message = _message()
+    return message.model_copy(
+        update={
+            "source_kind": "workflow",
+            "source_id": run_id,
+            "dedupe_key": f"{run_id}:{node_id}",
+        }
+    )
+
+
+# --- the dispatcher's half: observers hear ACCEPTED, and only accepted -------
+
+
+async def _dispatch(monkeypatch, message, outcome_status="accepted", wamid=WAMID):
+    async def fake_send(send_token, msg):
+        """Test double: a send with a scripted outcome."""
+        from app.crm.connectivity.schemas.message import SendOutcome
+
+        if outcome_status == "accepted":
+            return SendOutcome(status="accepted", provider_message_id=wamid)
+        return SendOutcome(status="failed", reason="131026", retryable=False)
+
+    async def record_outcome(*args, **kwargs):
+        """Test double: the outcome write succeeds."""
+        return True
+
+    monkeypatch.setattr(dispatch, "is_suppressed", _gate_open)
+    monkeypatch.setattr(dispatch, "send", fake_send)
+    monkeypatch.setattr(dispatch.message_accessor, "apply_outcome", record_outcome)
+    await dispatch._dispatch_one(message, 3)
+
+
+async def test_an_accepted_send_reaches_the_registered_observer(monkeypatch) -> None:
+    """The observer hears the send's own fields — AFTER the outcome was
+    recorded, so it reports history, never a proposal."""
+    heard: List[Dict[str, Any]] = []
+
+    async def observer(**fields):
+        """Test double: records what the slot delivered."""
+        heard.append(fields)
+
+    send_observers.register_send_observer(observer)
+    run_id = str(uuid4())
+    await _dispatch(monkeypatch, _workflow_message(run_id))
+    assert heard == [
+        {
+            "merchant_id": "m-1000",
+            "source_kind": "workflow",
+            "source_id": run_id,
+            "dedupe_key": f"{run_id}:confirm",
+            "message_id": "m-1",
+            "provider_message_id": WAMID,
+        }
+    ]
+
+
+async def test_a_refused_send_reaches_no_observer(monkeypatch) -> None:
+    """Only an ACCEPTED message has a provider id a reply could echo; a
+    refusal must not stamp anything a square would then wait on forever."""
+    heard: List[Dict[str, Any]] = []
+
+    async def observer(**fields):
+        """Test double: records what the slot delivered."""
+        heard.append(fields)
+
+    send_observers.register_send_observer(observer)
+    await _dispatch(monkeypatch, _workflow_message(str(uuid4())), "failed")
+    assert heard == []
+
+
+async def test_an_observer_raising_cannot_fail_the_send(monkeypatch) -> None:
+    """A bookkeeping subscriber must never be able to fail, retry or double
+    a customer's message: the raise is logged and swallowed, and the
+    observers after it still hear."""
+    heard: List[str] = []
+
+    async def broken(**fields):
+        """Test double: an observer with a bug."""
+        raise RuntimeError("observer bug")
+
+    async def working(**fields):
+        """Test double: the observer behind the broken one."""
+        heard.append(fields["message_id"])
+
+    send_observers.register_send_observer(broken)
+    send_observers.register_send_observer(working)
+    await _dispatch(monkeypatch, _workflow_message(str(uuid4())))  # must not raise
+    assert heard == ["m-1"]
+
+
+# --- outreach's half: the stamp ------------------------------------------------
+
+
+def _note(monkeypatch, stamped: List[tuple], **overrides):
+    async def fake_stamp(merchant_id, run_id, key, value):
+        """Test double: records the guarded UPDATE the stamp would make."""
+        stamped.append((merchant_id, run_id, key, value))
+        return True
+
+    monkeypatch.setattr(correlate.enrollment_accessor, "stamp_context_key", fake_stamp)
+    run_id = overrides.pop("run_id", str(uuid4()))
+    fields = dict(
+        merchant_id="m-1000",
+        source_kind="workflow",
+        source_id=run_id,
+        dedupe_key=f"{run_id}:confirm",
+        message_id="m-1",
+        provider_message_id=WAMID,
+    )
+    fields.update(overrides)
+    asyncio.run(correlate.note_send_accepted(**fields))
+    return run_id
+
+
+def test_the_provider_id_lands_on_the_run_keyed_by_its_square(monkeypatch) -> None:
+    stamped: List[tuple] = []
+    run_id = _note(monkeypatch, stamped)
+    assert stamped == [("m-1000", run_id, "provider_message_id_confirm", WAMID)]
+
+
+def test_only_workflow_sends_are_this_observers_business(monkeypatch) -> None:
+    """A broadcast's acceptance is not a run's: the slot is generic and each
+    observer filters for itself, like record's consumers."""
+    stamped: List[tuple] = []
+    _note(monkeypatch, stamped, source_kind="broadcast")
+    assert stamped == []
+
+
+def test_a_dedupe_key_that_is_not_run_colon_node_is_skipped(monkeypatch) -> None:
+    """A producer this observer does not understand must not be guessed at —
+    a wrong guess writes a correlate onto the wrong run."""
+    stamped: List[tuple] = []
+    _note(monkeypatch, stamped, dedupe_key="manual-1")
+    _note(monkeypatch, stamped, dedupe_key=f"{uuid4()}:confirm")  # names another run
+    assert stamped == []
+
+
+def test_the_stamp_is_bookkeeping_never_a_template_variable() -> None:
+    """An internal id must not resolve into a customer's message; `match`
+    reads the context directly, so matching still sees it."""
+    assert is_bookkeeping("provider_message_id_confirm")
+    assert "provider_message_id_confirm" not in run_facts(
+        {"provider_message_id_confirm": WAMID, "name": "#R1"}
+    )
+
+
+# --- the square's half: a reply wakes only ITS run ------------------------------
+
+
+def _run(context: Dict[str, Any]) -> EnrollmentRun:
+    return EnrollmentRun(
+        id=uuid4(),
+        merchant_id="m-1000",
+        workflow_id=uuid4(),
+        workflow_version=7,
+        customer_id=uuid4(),
+        status="waiting",
+        current_node="wait-reply",
+        wake_at=NOW,
+        entered_at=NOW - timedelta(minutes=5),
+        exited_at=None,
+        exit_reason=None,
+        context=context,
+        enrollment_key="order-1",
+        attempts=1,
+        last_error=None,
+    )
+
+
+def _square(match_run: str = "provider_message_id_confirm") -> WorkflowNode:
+    return WorkflowNode(
+        id="wait-reply",
+        type="wait_event",
+        topics=["message.inbound"],
+        key="reply",
+        minutes=2880,
+        match={"payload": "replied_to", "run": match_run},
+    )
+
+
+def _tap(replied_to: Optional[str]) -> RawEvent:
+    item: Dict[str, Any] = {
+        "from": "919354069782",
+        "type": "button",
+        "button": {"payload": "CONFIRM", "text": "CONFIRM"},
+    }
+    if replied_to is not None:
+        item["context"] = {"id": replied_to}
+    return RawEvent(
+        id="ev-1",
+        merchant_id="m-1000",
+        source="whatsapp",
+        topic="message.inbound",
+        schema_version="v23.0",
+        external_id="wamid.IN",
+        payload={"messaging_product": "whatsapp", "messages": [item]},
+        received_at=NOW,
+        occurred_at=NOW,
+    )
+
+
+def test_a_tap_is_about_the_run_whose_send_it_replies_to() -> None:
+    """The incident, inverted: four open runs, one tap — with the stamp and
+    the match, the tap claims exactly the run whose message she answered.
+    `replied_to` is the catalog's derived read of Meta's context.id, so the
+    match exercises the real deriver, not a hand-fed field."""
+    hers = _run({"provider_message_id_confirm": WAMID})
+    others = [
+        _run({"provider_message_id_confirm": f"wamid.OTHER-{n}"}) for n in range(3)
+    ]
+    tap = _tap(WAMID)
+    assert _is_about(_square(), tap, hers) is True
+    assert [_is_about(_square(), tap, run) for run in others] == [False] * 3
+
+
+def test_an_unthreaded_message_claims_nobody() -> None:
+    """A fresh message (no context.id) cannot say which order it is about;
+    honest silence — the square's alarm, not a guessed edge, recovers."""
+    run = _run({"provider_message_id_confirm": WAMID})
+    assert _is_about(_square(), _tap(None), run) is False
+
+
+def test_a_run_whose_send_was_never_accepted_hears_nothing() -> None:
+    """No stamp (the send failed, or the acceptance is still in flight) =
+    the run claims no reply — it keeps waiting rather than taking a
+    letter that may be another run's."""
+    run = _run({})
+    assert _is_about(_square(), _tap(WAMID), run) is False
+
+
+# --- publish: a misspelled square name is a sentence, not a silent never -------
+
+
+def _plan(match_run: str) -> Dict[str, Any]:
+    return {
+        "entry": {"topic": "orders/create", "key": "id"},
+        "nodes": [
+            {
+                "id": "confirm",
+                "type": "send",
+                "channel": "whatsapp",
+                "template": "t",
+                "variables": {},
+            },
+            {
+                "id": "wait-reply",
+                "type": "wait_event",
+                "topics": ["message.inbound"],
+                "key": "reply",
+                "minutes": 60,
+                "match": {"payload": "replied_to", "run": match_run},
+            },
+        ],
+        "edges": [["confirm", "wait-reply"]],
+        "goals": [{"topics": ["orders/cancelled"]}],
+        "purpose_key": "utility.order.confirmation",
+    }
+
+
+def test_publish_refuses_a_reply_listen_with_no_match_beside_a_send() -> None:
+    """Forgetting the match line silently recreates the incident: the plan
+    publishes clean and one customer's answer resolves every open run of
+    hers. So a square listening on message.inbound in a plan that SENDS is
+    refused until it says whose reply it hears — and the refusal spells the
+    exact line to add."""
+    plan = _plan("provider_message_id_confirm")
+    del plan["nodes"][1]["match"]
+    problems = validate_definition(plan)
+    assert any(
+        "no match" in p and "provider_message_id_confirm" in p for p in problems
+    ), problems
+
+
+def test_a_plan_that_sends_nothing_may_listen_without_a_match() -> None:
+    """No send upstream = no reply to mis-route: a plan triggered by ANY
+    inbound message (she wrote to us first) is a legitimate open listen."""
+    plan = _plan("provider_message_id_confirm")
+    del plan["nodes"][1]["match"]
+    plan["nodes"] = [n for n in plan["nodes"] if n["type"] != "send"]
+    plan["edges"] = []
+    plan["entry"]["start"] = "wait-reply"
+    problems = validate_definition(plan)
+    assert not any("no match" in p for p in problems), problems
+
+
+def test_publish_refuses_a_provider_id_match_that_names_no_send_node() -> None:
+    """provider_message_id_<node> is stamped only for a SEND node's accepted message. A
+    typo here would publish clean and then match nothing forever — every
+    reply 'claims nobody' — the silent version of the failure match exists
+    to prevent."""
+    assert validate_definition(_plan("provider_message_id_confirm")) == []
+    problems = validate_definition(_plan("provider_message_id_comfirm"))
+    assert any("'comfirm' is not a send node" in p for p in problems)
+    problems = validate_definition(_plan("provider_message_id_wait-reply"))
+    assert any("is not a send node" in p for p in problems)
+
+
+# --- the reconcile: the stamp is a cache, the manifest is the truth -----------
+
+
+def _reconcile(monkeypatch, context, manifest_pmid, stamped: List[tuple]):
+    import app.crm.outreach.entry as entry
+
+    async def fake_manifest_read(merchant_id, dedupe_key):
+        """Test double: what the manifest row holds for this logical send."""
+        stamped.append(("read", merchant_id, dedupe_key))
+        return manifest_pmid
+
+    async def fake_stamp(merchant_id, run_id, key, value):
+        """Test double: the self-heal write."""
+        stamped.append(("stamp", key, value))
+        return True
+
+    monkeypatch.setattr(entry, "provider_message_id_for", fake_manifest_read)
+    monkeypatch.setattr(entry.enrollment_accessor, "stamp_context_key", fake_stamp)
+    run = _run(context)
+    patched = asyncio.run(entry._with_provider_stamp(run, _square()))
+    return run, patched
+
+
+def test_a_clobbered_or_missed_stamp_reconciles_from_the_manifest(
+    monkeypatch,
+) -> None:
+    """The stamp can be erased (the walker's advance replaces context whole,
+    CAS-guarded on wake_at alone) or never land (the observer's raise is
+    swallowed). The manifest row survives both — apply_outcome wrote the id
+    before the observer ever ran — so a square about to match and finding
+    no stamp reads it back by the send's own dedupe_key, re-stamps, and
+    matches. One transient blip can no longer make a run permanently deaf."""
+    calls: List[tuple] = []
+    run, patched = _reconcile(monkeypatch, {}, WAMID, calls)
+    assert patched.context["provider_message_id_confirm"] == WAMID
+    assert ("read", "m-1000", f"{run.id}:confirm") in calls
+    assert ("stamp", "provider_message_id_confirm", WAMID) in calls
+    assert _is_about(_square(), _tap(WAMID), patched) is True
+
+
+def test_a_present_stamp_costs_no_manifest_read(monkeypatch) -> None:
+    """The stamp is the fast path: when it is there, the reconcile does not
+    touch the database at all — one read per reply per run would put the
+    manifest in the consumer's hot loop for nothing."""
+    calls: List[tuple] = []
+    _, patched = _reconcile(
+        monkeypatch, {"provider_message_id_confirm": WAMID}, "ignored", calls
+    )
+    assert calls == []
+    assert patched.context["provider_message_id_confirm"] == WAMID
+
+
+def test_a_send_never_accepted_still_claims_no_reply(monkeypatch) -> None:
+    """No stamp AND no manifest id = the run honestly has nothing a reply
+    could echo: it keeps waiting rather than taking another run's letter."""
+    calls: List[tuple] = []
+    _, patched = _reconcile(monkeypatch, {}, None, calls)
+    assert "provider_message_id_confirm" not in patched.context
+    assert _is_about(_square(), _tap(WAMID), patched) is False
+    assert not any(call[0] == "stamp" for call in calls)
+
+
+def test_the_reconcile_read_only_trusts_the_post_accept_ladder() -> None:
+    """apply_outcome copies outcome.provider_message_id onto FAILED, DEAD
+    and QUEUED plans too. No adapter reports an id beside a refusal today,
+    but the first that does must not turn a message nobody received into a
+    reply correlate — so the read filters to the post-accept ladder in SQL,
+    with the words from status.py, never spelled in the query."""
+    from app.crm.connectivity.db.queries.message import (
+        provider_message_id_for_query,
+    )
+    from app.crm.connectivity.status import (
+        MESSAGE_ACCEPTED,
+        MESSAGE_DELIVERED,
+        MESSAGE_READ,
+        MESSAGE_SENT,
+    )
+
+    query, values = provider_message_id_for_query("m-1000", "r:confirm")
+    assert "status = ANY($3" in query
+    assert values[2] == [
+        MESSAGE_ACCEPTED,
+        MESSAGE_SENT,
+        MESSAGE_DELIVERED,
+        MESSAGE_READ,
+    ]
+
+
+def test_a_reconciled_wake_is_not_also_the_runs_repeat(monkeypatch) -> None:
+    """_answered_by judges the SAME reconciled run the wake did. open_runs
+    was read at the top of the pass, so a stamp the wake just reconciled
+    lives on the copy it resumed — judging the stale object here answered
+    'not its square's answer' for the very letter that woke the run, and
+    apply_repeat re-armed the square it had just resolved."""
+    import app.crm.outreach.definitions as definitions
+    import app.crm.outreach.entry as entry
+    from app.crm.outreach.schemas import Workflow, WorkflowDefinition
+
+    run = _run({})  # the stale object: no stamp in memory
+    flow = Workflow(
+        id=run.workflow_id,
+        merchant_id="m-1000",
+        name="plan",
+        status="live",
+        version=7,
+        created_by=None,
+        created_at=NOW,
+        updated_at=NOW,
+        definition=None,
+        draft=None,
+    )
+    plan = _plan("provider_message_id_confirm")
+    definition = WorkflowDefinition.model_validate(plan)
+
+    async def fake_definition_for(r):
+        """Test double: the run's pinned document."""
+        return definition
+
+    async def fake_manifest_read(merchant_id, dedupe_key):
+        """Test double: the manifest holds the accepted id."""
+        return WAMID
+
+    async def fake_stamp(merchant_id, run_id, key, value):
+        """Test double: the self-heal write."""
+        return True
+
+    monkeypatch.setattr(entry, "definition_for", fake_definition_for)
+    monkeypatch.setattr(entry, "provider_message_id_for", fake_manifest_read)
+    monkeypatch.setattr(entry.enrollment_accessor, "stamp_context_key", fake_stamp)
+
+    answered = asyncio.run(
+        entry._answered_by([run], flow, run.enrollment_key, _tap(WAMID))
+    )
+    assert answered is True
+
+
+async def test_a_slow_observer_is_deadlined_not_a_lease_burner(
+    monkeypatch,
+) -> None:
+    """_gate and send() are wait_for-bounded so a batch fits its claim
+    lease; an unbounded stamp behind them could burn the slack and hand the
+    accepted tail to another worker — a real double message. A hung
+    observer is cancelled and the next one still hears; the reconcile read
+    recovers the id when a square needs it."""
+    monkeypatch.setattr(send_observers, "OBSERVER_TIMEOUT_SECONDS", 0.05)
+    heard: List[str] = []
+
+    async def hung(**fields):
+        """Test double: an observer stuck on a locked row."""
+        await asyncio.sleep(5)
+
+    async def working(**fields):
+        """Test double: the observer behind the hung one."""
+        heard.append(fields["message_id"])
+
+    send_observers.register_send_observer(hung)
+    send_observers.register_send_observer(working)
+    await _dispatch(monkeypatch, _workflow_message(str(uuid4())))
+    assert heard == ["m-1"]
+
+
+# --- publish: the guard is scoped, and both match halves are checked ----------
+
+
+def test_a_receive_first_square_beside_a_send_branch_is_not_refused() -> None:
+    """The refusal walks the EDGE GRAPH, not the node list: a square with
+    no send upstream has no reply to mis-route, whatever else the plan
+    contains — and the suggested match would be unsatisfiable there (no
+    stamp exists before the send)."""
+    plan = _plan("provider_message_id_confirm")
+    del plan["nodes"][1]["match"]
+    # she writes first: listen -> then send. The send is DOWNstream.
+    plan["edges"] = [["wait-reply", "confirm"]]
+    problems = validate_definition(plan)
+    assert not any("no match" in p for p in problems), problems
+
+
+def test_a_mixed_reply_listen_behind_a_send_is_refused_whole() -> None:
+    """A mixed listen downstream of a send is unsafe in BOTH directions —
+    matchless it takes every open run's reply, matched it goes deaf on the
+    other topic (the match is judged against every letter, and a call
+    outcome carries no replied_to). So the shape itself is refused, with
+    the fix spelled out: two squares, each saying one thing honestly."""
+    plan = _plan("provider_message_id_confirm")
+    plan["nodes"][1]["topics"] = ["message.inbound", "call.completed"]
+
+    # matchless AND matched: the same refusal, because neither is safe.
+    matched = validate_definition(plan)
+    assert any("Split it into two listening squares" in p for p in matched), matched
+    del plan["nodes"][1]["match"]
+    matchless = validate_definition(plan)
+    assert any("Split it into two listening squares" in p for p in matchless), matchless
+
+
+def test_a_mixed_listen_with_no_send_upstream_stays_legal() -> None:
+    """No send upstream = no reply to mis-route on either topic: a
+    receive-first square listening broadly is an author's honest choice."""
+    plan = _plan("provider_message_id_confirm")
+    del plan["nodes"][1]["match"]
+    plan["nodes"][1]["topics"] = ["message.inbound", "call.completed"]
+    plan["edges"] = [["wait-reply", "confirm"]]  # the send is DOWNstream
+    problems = validate_definition(plan)
+    assert not any("Split it into two" in p or "no match" in p for p in problems)
+
+
+def test_the_refusals_suggestion_names_the_upstream_send() -> None:
+    """A plan with two sends must not be told to match the wrong one."""
+    plan = _plan("provider_message_id_confirm")
+    del plan["nodes"][1]["match"]
+    plan["nodes"].append(
+        {
+            "id": "chaser",
+            "type": "send",
+            "channel": "whatsapp",
+            "template": "t2",
+            "variables": {},
+        }
+    )
+    # chaser is DOWNstream of the square; only confirm is upstream.
+    plan["edges"] = [["confirm", "wait-reply"], ["wait-reply", "chaser"]]
+    (problem,) = [p for p in validate_definition(plan) if "no match" in p]
+    assert "provider_message_id_confirm" in problem
+    assert "provider_message_id_chaser" not in problem
+
+
+def test_a_typo_inside_the_prefix_is_named_at_publish() -> None:
+    """provider_message_confirm (the _id_ dropped) starts with neither
+    check's prefix: without this refusal it publishes a square that matches
+    nothing forever — indistinguishable from customers not replying."""
+    problems = validate_definition(_plan("provider_message_confirm"))
+    assert any("did you" in p and "mean" in p for p in problems), problems
+
+
+def test_a_match_payload_the_topic_never_declared_is_refused() -> None:
+    """The mirror of the match.run checks: a typo'd payload field resolves
+    to None on every letter and the square is permanently deaf, publish
+    clean. Checked against the catalog the caller gathered — the same
+    allow-list every other plan word answers to."""
+    from app.crm.outreach.catalog_laws import Catalogs
+    from app.crm.record.contracts import CatalogField
+
+    catalogs: Catalogs = {
+        "orders/create": {},
+        "orders/cancelled": {},
+        "message.inbound": {
+            "replied_to": CatalogField(path="replied_to", type="text", label="R")
+        },
+    }
+    good = validate_definition(_plan("provider_message_id_confirm"), catalogs=catalogs)
+    assert not any("match.payload" in p for p in good), good
+
+    plan = _plan("provider_message_id_confirm")
+    plan["nodes"][1]["match"]["payload"] = "repplied_to"
+    problems = validate_definition(plan, catalogs=catalogs)
+    assert any("match.payload" in p and "repplied_to" in p for p in problems)

--- a/tests/crm/test_templates.py
+++ b/tests/crm/test_templates.py
@@ -7,6 +7,7 @@ UPPERCASE status stored beside our lowercase rules, and a delete that took
 every language variant with it.
 """
 
+import json
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import List, Optional
@@ -714,6 +715,103 @@ def test_a_malformed_components_blob_decodes_to_empty_rather_than_raising() -> N
     }
     decoded = decode_template(row)
     assert decoded.components == [{"type": "BODY"}], "non-objects must be dropped"
+
+
+_FLOW_BUTTONS = [
+    {"type": "BODY", "text": "Hello {{1}}"},
+    {
+        "type": "BUTTONS",
+        "buttons": [
+            {"type": "QUICK_REPLY", "text": "CONFIRM"},
+            {"type": "QUICK_REPLY", "text": "CANCEL"},
+            {"type": "FLOW", "text": "Update address", "flow_id": "218303"},
+        ],
+    },
+]
+
+
+def test_the_send_path_learns_where_a_flow_button_sits() -> None:
+    """Meta refuses the whole send (131009) when a template's FLOW button
+    arrives unnamed, and the component names the button by POSITION. The
+    position lives only in the registered components, so it is computed here
+    — the one send-time fact hiding in a blob the send path otherwise has no
+    use for."""
+    from app.crm.connectivity.db.decoders.template import (
+        decode_approved_template,
+        flow_button_indexes,
+    )
+
+    assert flow_button_indexes(_FLOW_BUTTONS) == [2]
+    # The column arrives as text from asyncpg on some paths and as a decoded
+    # list on others; both are the same answer.
+    assert flow_button_indexes(json.dumps(_FLOW_BUTTONS)) == [2]
+
+    row = {
+        "id": "t-1",
+        "name": "order_confirm",
+        "language": "en_US",
+        "provider_template_id": "9527",
+        "category": "UTILITY",
+        "components": _FLOW_BUTTONS,
+    }
+    assert decode_approved_template(row).flow_button_indexes == [2]
+
+
+def test_every_flow_button_is_found_not_only_the_first() -> None:
+    """Whether Meta caps a template at one flow button is Meta's rule to
+    change. Finding them all needs no such rule to hold: a second button
+    left unnamed would have its whole send refused, and nobody receives a
+    message because of a cap we assumed."""
+    from app.crm.connectivity.db.decoders.template import flow_button_indexes
+
+    two = [
+        {
+            "type": "BUTTONS",
+            "buttons": [
+                {"type": "FLOW", "text": "Address", "flow_id": "1"},
+                {"type": "QUICK_REPLY", "text": "CANCEL"},
+                {"type": "FLOW", "text": "Reschedule", "flow_id": "2"},
+            ],
+        }
+    ]
+    assert flow_button_indexes(two) == [0, 2]
+
+
+def test_a_template_with_no_flow_button_says_so_rather_than_guessing() -> None:
+    """Empty means "post no button component", which is what every template
+    on the platform needs today. A wrong position here would break sends that
+    work; an empty list cannot."""
+    from app.crm.connectivity.db.decoders.template import flow_button_indexes
+
+    quick_only = [
+        {"type": "BUTTONS", "buttons": [{"type": "QUICK_REPLY", "text": "CONFIRM"}]}
+    ]
+    assert flow_button_indexes(quick_only) == []
+    assert flow_button_indexes([{"type": "BODY", "text": "no buttons at all"}]) == []
+
+
+def test_a_malformed_components_blob_answers_empty_rather_than_raising() -> None:
+    """Same totality contract as the read above, for the same reason: this
+    decoder runs per message inside a claimed batch."""
+    from app.crm.connectivity.db.decoders.template import flow_button_indexes
+
+    for junk in (None, "", "not json", "42", [1, 2], [{"type": "BUTTONS"}]):
+        assert flow_button_indexes(junk) == [], junk
+    assert flow_button_indexes(
+        [{"type": "BUTTONS", "buttons": [{"type": "FLOW"}]}]
+    ) == [0], "index 0 is a position, not an absence"
+
+
+def test_the_send_lookup_reads_the_components_it_needs() -> None:
+    """The query and the decoder are one promise: a decoder computing the
+    flow position from a column the SELECT never fetched would answer None
+    for every template, and every flow send would be refused by Meta."""
+    from app.crm.connectivity.db.queries.template import (
+        approved_template_for_send_query,
+    )
+
+    query, _ = approved_template_for_send_query("shop", "whatsapp", "waba-1", "n")
+    assert "components" in query
 
 
 async def test_a_bug_in_the_face_does_not_reach_the_caller(monkeypatch) -> None:

--- a/tests/crm/test_whatsapp_adapter.py
+++ b/tests/crm/test_whatsapp_adapter.py
@@ -5,6 +5,7 @@ error matrix — including the ones that are painful to provoke for real, like
 an expired token — is exercised on every test run.
 """
 
+import json
 from datetime import datetime, timezone
 from typing import Any, Dict, Optional
 
@@ -20,6 +21,7 @@ from app.crm.connectivity.providers.whatsapp.classify import (
 )
 from app.crm.connectivity.providers.whatsapp.payload import (
     build_parameters,
+    build_send_body,
     to_meta_recipient,
 )
 from app.crm.connectivity.schemas.connector import ChannelBinding, ConnectorInstallation
@@ -93,9 +95,11 @@ def _installation(**overrides) -> ConnectorInstallation:
     return ConnectorInstallation(**fields)
 
 
-def _approved(language: str) -> ApprovedTemplate:
+def _approved(language: str, **overrides) -> ApprovedTemplate:
     """The registry row the send path resolved, in ``language``."""
-    return ApprovedTemplate(id="t-1", name="order_update_v1", language=language)
+    return ApprovedTemplate(
+        id="t-1", name="order_update_v1", language=language, **overrides
+    )
 
 
 def _route(**overrides) -> SendRoute:
@@ -188,6 +192,93 @@ async def test_the_body_names_a_template_and_never_a_rendered_string(
     assert '"name":"order_update_v1"' in body
     # Values are posted as parameters; we never assemble the sentence.
     assert '"text":"Priya"' in body
+
+
+async def test_a_flow_button_template_carries_its_action_component(
+    monkeypatch,
+) -> None:
+    """A FLOW button is not decoration: Meta refuses the WHOLE send with
+    131009 ("Components sub_type invalid at index: N") when the button
+    component is missing, so nothing reaches the customer. The index is the
+    button's position among the template's buttons, taken from the registry
+    row — this adapter cannot know it any other way."""
+    route = _route(template=_approved("en_US", flow_button_indexes=[2]))
+    _, seen = await _deliver(monkeypatch, _responds(200, ACCEPTED_BODY), route=route)
+    body = json.loads(seen["body"])
+    button = body["template"]["components"][-1]
+    assert button["type"] == "button"
+    assert button["sub_type"] == "flow"
+    # Meta wants the position as a string, like every other button component.
+    assert button["index"] == "2"
+    assert button["parameters"][0]["type"] == "action"
+
+
+async def test_the_flow_token_is_the_message_that_opened_the_form(
+    monkeypatch,
+) -> None:
+    """Meta echoes flow_token back verbatim inside her submission, so the
+    send stamps the manifest row's own id: the answer then names its own
+    question, with no wamid to wait for and no second lookup."""
+    route = _route(template=_approved("en_US", flow_button_indexes=[0]))
+    _, seen = await _deliver(
+        monkeypatch,
+        _responds(200, ACCEPTED_BODY),
+        message=_message(id="m-42"),
+        route=route,
+    )
+    action = json.loads(seen["body"])["template"]["components"][-1]["parameters"][0]
+    assert action["action"] == {"flow_token": "m-42"}
+
+
+async def test_every_flow_button_is_named_not_only_the_first(monkeypatch) -> None:
+    """Meta refuses the send for ANY unnamed flow button, so naming the first
+    and stopping would lose the whole message to the second. The token is the
+    same on both: it identifies the send, not which button she pressed."""
+    route = _route(template=_approved("en_US", flow_button_indexes=[0, 2]))
+    _, seen = await _deliver(
+        monkeypatch,
+        _responds(200, ACCEPTED_BODY),
+        message=_message(id="m-42"),
+        route=route,
+    )
+    buttons = [
+        c
+        for c in json.loads(seen["body"])["template"]["components"]
+        if c["type"] == "button"
+    ]
+    assert [b["index"] for b in buttons] == ["0", "2"]
+    assert {b["parameters"][0]["action"]["flow_token"] for b in buttons} == {"m-42"}
+
+
+async def test_a_template_without_a_flow_button_posts_what_it_always_did(
+    monkeypatch,
+) -> None:
+    """The overwhelming majority of sends name no flow. Their body must be
+    byte-identical to before this feature, or every template on the platform
+    is a new shape at once."""
+    _, seen = await _deliver(monkeypatch, _responds(200, ACCEPTED_BODY))
+    components = json.loads(seen["body"])["template"]["components"]
+    assert [c["type"] for c in components] == ["body"]
+
+
+def test_index_zero_is_a_position_not_an_absence() -> None:
+    """The first button is index 0, which is falsy — a truthiness check
+    anywhere on this path would silently drop the component for every
+    template whose flow button comes first, and Meta would refuse those
+    sends."""
+    body = build_send_body("t", "en_US", "919876543210", [], flow_button_indexes=[0])
+    assert body["template"]["components"][0]["index"] == "0"
+
+
+def test_a_send_naming_no_token_sends_no_placeholder() -> None:
+    """Naming the button is enough for Meta; the token is the one optional
+    part. A caller without one sends nothing rather than a stand-in — Meta
+    then records its own word, 'unused', which the read side discards. A
+    placeholder of ours would instead become a real-looking join key that
+    every tokenless send shares."""
+    body = build_send_body("t", "en_US", "919876543210", [], flow_button_indexes=[1])
+    button = body["template"]["components"][0]
+    assert button == {"type": "button", "sub_type": "flow", "index": "1"}
 
 
 def test_numeric_keys_become_positional_parameters_in_numeric_order() -> None:

--- a/tests/crm/test_whatsapp_extractor.py
+++ b/tests/crm/test_whatsapp_extractor.py
@@ -21,11 +21,14 @@ narrowed to one item, metadata and contacts riding along verbatim.
 import json
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any, Dict, List, Optional, Tuple
 
 import pytest
 
 import app.crm.record.workers as workers
+from app.crm.outreach.nodes.context import reply_key
+from app.crm.outreach.schemas import WorkflowNode
+from app.crm.outreach.walker import pick_next
 from app.crm.record import catalog
 from app.crm.record.extractors import EXTRACTORS, engine, whatsapp as whatsapp_spec
 from app.crm.record.schemas import Extracted, RawEvent
@@ -202,6 +205,193 @@ def test_a_typed_answer_falls_back_to_the_text_body() -> None:
     # same key a wait_event square branches on.
     extracted = _extract_inbound(_inbound())
     assert extracted.variables["reply"] == "yes, confirm it"
+
+
+def _submission(response: str, **overrides) -> Dict[str, Any]:
+    """A completed Flow, as Meta files it: an ordinary inbound message of
+    type 'interactive' whose interactive.type is 'nfm_reply'."""
+    return _inbound(
+        _message(
+            type="interactive",
+            interactive={
+                "type": "nfm_reply",
+                "nfm_reply": {
+                    "name": "flow",
+                    "body": "Sent",
+                    **overrides,
+                    "response_json": response,
+                },
+            },
+        )
+    )
+
+
+def test_a_submitted_form_answers_the_square_that_was_waiting() -> None:
+    """A Flow submission returns the branchable token 'form_submitted' so
+    the walker picks the labelled arrow.  Before this, reply was the raw
+    JSON blob — it matched no label, the square took the else arrow or
+    exited 'completed', and a customer who HAD answered was lost."""
+    extracted = _extract_inbound(
+        _submission('{"flow_token":"m-42","address":"221B Baker Street"}')
+    )
+    assert extracted.variables["reply"] == "form_submitted"
+
+
+def test_the_form_reads_as_lines_for_whoever_opens_the_order() -> None:
+    """It lands in a merchant's order note, so it is written out one
+    answer per line in the order her form asked — not as the JSON Meta
+    encoded it in. Her keys and values are never renamed or reworded."""
+    assert whatsapp_spec.flow_response(
+        _submission('{"address":"221B Baker Street","city":"Bengaluru"}')
+    ) == ("address: 221B Baker Street\ncity: Bengaluru")
+
+
+def test_a_multi_select_reads_as_a_list_a_person_would_write() -> None:
+    """Meta sends several answers to one question as a list; `['a', 'b']`
+    in an order note is a python repr leaking into a merchant's shop."""
+    assert (
+        whatsapp_spec.flow_response(_submission('{"slots":["morning","evening"]}'))
+        == "slots: morning, evening"
+    )
+
+
+def test_our_own_token_comes_out_of_what_a_plan_reads() -> None:
+    """The send stamps flow_token and Meta echoes it back inside her
+    answers. Left in, a merchant's order note reads a uuid of ours beside
+    her address. Her keys are untouched; only ours comes out.
+
+    Declared `variable`, so it rides out of the engine into the woken
+    square's facts and answers {facts_<square>_flow_response} in an action
+    square's args — without the flag the answers are decoded, stored and
+    unreachable, because only a declared variable field produces a name the
+    publish validator will accept."""
+    extracted = _extract_inbound(
+        _submission('{"address":"221B Baker Street","flow_token":"m-42"}')
+    )
+    assert extracted.variables["flow_response"] == "address: 221B Baker Street"
+    # The join key is still read — from the raw submission, not from the
+    # string above, which no longer carries it.
+    assert (
+        engine.field_value(
+            _submission('{"address":"221B","flow_token":"m-42"}'),
+            "flow_token",
+            catalog.derive_for("whatsapp", "message.inbound"),
+        )
+        == "m-42"
+    )
+
+
+def test_an_unparseable_submission_is_still_her_best_answer() -> None:
+    """Nothing to remove and nothing we can re-encode: hand back exactly
+    what arrived rather than dropping a customer's answer on a shape we
+    did not expect."""
+    assert whatsapp_spec.flow_response(_submission("not json")) == "not json"
+
+
+def test_a_submission_of_nothing_but_our_token_is_absent() -> None:
+    """A form that answered nothing leaves nothing — the square parks on
+    the missing fact rather than writing "{}" into a merchant's order."""
+    assert whatsapp_spec.flow_response(_submission('{"flow_token":"m-42"}')) is None
+
+
+def test_a_submission_names_the_send_that_opened_it() -> None:
+    """The send stamps the manifest row's own id as the flow_token
+    (whatsapp/adapter.py) and Meta returns it verbatim — so unlike
+    replied_to, this join needs no wamid on either side."""
+    extracted = _extract_inbound(
+        _submission('{"flow_token":"m-42","address":"221B Baker Street"}')
+    )
+    assert (
+        engine.field_value(
+            _submission('{"flow_token":"m-42"}'),
+            "flow_token",
+            catalog.derive_for("whatsapp", "message.inbound"),
+        )
+        == "m-42"
+    )
+    assert extracted.about == "customer"
+
+
+def test_metas_placeholder_token_is_not_an_id() -> None:
+    """A send that named no token gets Meta's literal 'unused' back. It
+    identifies nothing, so it is dropped rather than stored as a join key
+    that would match every other tokenless send."""
+    assert whatsapp_spec.flow_token(_submission('{"flow_token":"unused"}')) is None
+
+
+def test_a_malformed_submission_is_absent_not_a_raise() -> None:
+    """The decode step reads a whole batch; one unparseable letter must not
+    strand the rows beside it."""
+    assert whatsapp_spec.flow_token(_submission("not json at all")) is None
+    assert whatsapp_spec.flow_token(_submission("[1, 2]")) is None
+    assert whatsapp_spec.flow_response(_inbound()) is None
+    assert whatsapp_spec.flow_token(_inbound()) is None
+
+
+def test_a_button_tap_still_answers_with_its_payload() -> None:
+    """The Flow fallback sits BELOW the button branches: a tap must not
+    start answering with a form's JSON."""
+    tap = _inbound(_message(type="button", button={"payload": "CONFIRM", "text": "C"}))
+    assert whatsapp_spec.reply(tap) == "CONFIRM"
+    assert whatsapp_spec.flow_response(tap) is None
+
+
+def test_a_choice_carrying_a_stray_submission_is_not_read_as_one() -> None:
+    """BOTH discriminants decide, not the member's presence: the message
+    must be type 'interactive' AND interactive.type must be 'nfm_reply'.
+
+    Reading the member alone would let a button_reply that happens to carry
+    one populate flow_token — which is KEYABLE, so a listening square could
+    then be woken by a letter naming another run's message id."""
+    stray = _inbound(
+        _message(
+            type="interactive",
+            text=None,
+            interactive={
+                "type": "button_reply",
+                "button_reply": {"id": "CANCEL_ORDER", "title": "Cancel"},
+                "nfm_reply": {"response_json": '{"flow_token":"m-99"}'},
+            },
+        )
+    )
+    assert whatsapp_spec.flow_response(stray) is None
+    assert whatsapp_spec.flow_token(stray) is None
+    assert whatsapp_spec.reply(stray) == "CANCEL_ORDER"
+
+
+def test_a_submission_picks_the_arrow_an_author_labelled() -> None:
+    """The whole point of the token: the walker branches by comparing the
+    answer to arrow labels, so it must BE a label.
+
+    Driven through the walker's own pick_next rather than asserted at the
+    extractor, because the two are one contract — a blob here equalled no
+    label, and the square either took the else arrow or ended the run at
+    the instant she succeeded."""
+    answer = _extract_inbound(
+        _submission('{"flow_token":"m-42","address":"221B Baker Street"}')
+    ).variables["reply"]
+
+    square = WorkflowNode(
+        id="wait-reply",
+        type="wait_event",
+        topics=["message.inbound"],
+        key="reply",
+        minutes=2880,
+    )
+    arrows: List[Tuple[str, Optional[str]]] = [
+        ("tag-confirmed", "CONFIRM"),
+        ("save-address", "form_submitted"),
+        ("tag-no-response", "timeout"),
+    ]
+    assert pick_next(square, arrows, {reply_key(square.id): answer}) == "save-address"
+
+    # And the arrow it must NOT take: a board with no matching label ends
+    # the run, which is the failure this token exists to prevent.
+    unlabelled: List[Tuple[str, Optional[str]]] = [
+        ("tag-confirmed", "CONFIRM"),
+        ("tag-no-response", "timeout"),
+    ]
+    assert pick_next(square, unlabelled, {reply_key(square.id): answer}) is None
 
 
 def test_the_recorded_fixtures_pin_both_reply_shapes() -> None:

--- a/tests/crm/test_whatsapp_extractor.py
+++ b/tests/crm/test_whatsapp_extractor.py
@@ -294,6 +294,17 @@ def test_a_submission_of_nothing_but_our_token_is_absent() -> None:
     assert whatsapp_spec.flow_response(_submission('{"flow_token":"m-42"}')) is None
 
 
+def test_a_token_only_submission_still_wakes_the_square() -> None:
+    """THAT she submitted and WHAT she submitted are two questions. An
+    informational flow — one screen, a Done footer, an empty payload —
+    echoes only our own token, which flow_response rightly strips to None;
+    the reply must still say form_submitted, or the customer who tapped
+    through the form reads as silent and the timeout edge chases her."""
+    extracted = _extract_inbound(_submission('{"flow_token":"m-42"}'))
+    assert extracted.variables["reply"] == "form_submitted"
+    assert "flow_response" not in extracted.variables
+
+
 def test_a_submission_names_the_send_that_opened_it() -> None:
     """The send stamps the manifest row's own id as the flow_token
     (whatsapp/adapter.py) and Meta returns it verbatim — so unlike

--- a/tests/crm/test_workflow_entry.py
+++ b/tests/crm/test_workflow_entry.py
@@ -697,6 +697,56 @@ def test_a_reply_carries_the_letters_scalar_facts_for_its_square(
     assert listening.facts == [(str(run.id), "ask", {"button_id": "YES", "amount": 5})]
 
 
+def test_a_reply_carries_the_declared_fields_the_engine_decoded(
+    listening: _Spine,
+) -> None:
+    """The square hears what the CATALOG declared, not only what happens to
+    sit at the payload's top level.
+
+    Enrol has always been handed the engine's variables; a woken square
+    re-read the raw payload by hand, so a derived or nested field reached a
+    starting run and never a waiting one. On WhatsApp — where the person
+    and the answer both live inside lists — that left the square holding
+    `messaging_product` and nothing a plan could name."""
+    (run,) = listening.runs
+    asyncio.run(
+        consume_attributed_event(
+            _event(
+                "button.reply", {"button_id": "YES", "messaging_product": "whatsapp"}
+            ),
+            "c-1",
+            {},
+            {"reply": "form_submitted", "flow_address": "221B Baker Street"},
+        )
+    )
+    _, _, facts = listening.facts[0]
+    assert facts["flow_address"] == "221B Baker Street"
+    # The raw scalar is kept: a plan naming a field the catalog does not
+    # declare must not lose it to this change.
+    assert facts["messaging_product"] == "whatsapp"
+
+
+def test_a_declared_field_never_overwrites_the_walkers_own(
+    listening: _Spine,
+) -> None:
+    """A catalog is a merchant's vocabulary and may legitimately declare a
+    field called `phone`. Merged unfiltered, it would replace the
+    normalized number the sends dial with whatever the provider wrote —
+    the same reason the payload copy has always been filtered."""
+    (run,) = listening.runs
+    asyncio.run(
+        consume_attributed_event(
+            _event("button.reply", {"button_id": "YES"}),
+            "c-1",
+            {},
+            {"phone": "9876543210", "reply_ask": "forged", "flow_address": "221B"},
+        )
+    )
+    _, _, facts = listening.facts[0]
+    assert "phone" not in facts and "reply_ask" not in facts
+    assert facts["flow_address"] == "221B"
+
+
 # --- rollout phase 17 sweep: a letter that moves a run is its answer, never
 # also its repeat ---
 


### PR DESCRIPTION
fix(crm): a reply wakes only the run it answers — the provider-id stamp,
reconciled from the manifest

Incident (2026-09-10): one customer, several open COD runs — the first
tap resolved every run; a CONFIRMED order was cancelled on Shopify. No
match was writable: the letter carries the provider's id, the run held
only ours.

- Dispatch notifies an observer when a provider TAKES a message
  (send_observers.py — retire-guard inversion; typed Protocol, per-call
  deadline, raises swallowed: bookkeeping can't fail or double a send).
- correlate.py stamps provider_message_id_<send node> onto the run —
  channel-agnostic naming; prefix + dedupe-key pair live once in
  nodes/context.py, bookkeeping so it never reaches a template.
- The square: match {payload: replied_to, run: provider_message_id_<node>}.
  replied_to is each source's own deriver — new channel, no change here.
- The stamp is a cache; the manifest is the truth. On a miss the entry
  consumer reconciles (one indexed read), re-stamps, matches. The read
  trusts only the post-accept ladder (words from status.py); _answered_by
  judges the same reconciled run, so a wake is never also a repeat.
- No stamp and no manifest id = the run keeps waiting; a typed
  (unthreaded) message claims nobody — the timeout edge recovers.
- Publish guards, scoped by the edge graph: a single-topic
  message.inbound listen behind a send without match is refused with the
  exact line to add; a MIXED message.inbound listen behind a send is
  refused whole ("split into two squares" — matchless cross-wakes,
  matched goes deaf); receive-first squares stay legal; match.run must
  name a send node (prefix typos get a did-you-mean); match.payload must
  be declared on every listened topic.
- A Flow submission is classified by its discriminant (nfm_reply), not
  content: a token-only submission still answers form_submitted.
- The woken square receives the engine's DECLARED variables — the wake
  path had re-read raw scalars while enrol got the decode.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for WhatsApp Flow form submissions, including readable submitted responses and workflow branching.
  - WhatsApp Flow messages now preserve button positions and use message-based correlation tokens.
  - Replies can be reliably matched to the specific workflow send that initiated them, including recovery when correlation data is missing.

- **Bug Fixes**
  - Improved reply handling to prevent resumed workflows from being incorrectly reactivated.
  - Added validation to flag invalid or unmatched workflow event conditions before publishing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->