### PR TITLE
feat(voice): move Plivo telephony to 16kHz L16 wideband audio

### DIFF
--- a/app/ai/voice/agents/breeze_buddy/agent/__init__.py
+++ b/app/ai/voice/agents/breeze_buddy/agent/__init__.py
@@ -16,7 +16,6 @@ from pipecat.processors.aggregators.llm_context import LLMContext
 from pipecat.processors.frameworks.rtvi import RTVIServerMessageFrame
 from pipecat.runner.types import RunnerArguments
 from pipecat.runner.utils import (
-    _create_telephony_transport,
     create_transport,
     parse_telephony_websocket,
 )
@@ -118,6 +117,9 @@ from app.ai.voice.agents.breeze_buddy.utils.transport.daily_keepalive import (
 )
 from app.ai.voice.agents.breeze_buddy.utils.transport.nonclosing import (
     NonClosingWebSocket,
+)
+from app.ai.voice.agents.breeze_buddy.utils.transport.telephony import (
+    create_telephony_transport,
 )
 from app.ai.voice.agents.breeze_buddy.utils.transport.websockets import (
     close_websocket_safely,
@@ -758,7 +760,7 @@ class Agent:
 
         # Create transport with the call data. Cast: the proxy forwards every
         # attribute so it quacks like a WebSocket, but isn't a subclass.
-        self.transport = await _create_telephony_transport(
+        self.transport = await create_telephony_transport(
             cast(WebSocket, self._rebuild.ws_proxy), params, transport_type, call_data
         )
 

--- a/app/ai/voice/agents/breeze_buddy/agent/transfer.py
+++ b/app/ai/voice/agents/breeze_buddy/agent/transfer.py
@@ -11,7 +11,7 @@ from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, cast
 
 from fastapi import WebSocket
-from pipecat.runner.utils import _create_telephony_transport, create_transport
+from pipecat.runner.utils import create_transport
 
 from app.ai.voice.agents.breeze_buddy.agent.transport import get_transport_params
 from app.ai.voice.agents.breeze_buddy.template.builder import FlowConfigBuilder
@@ -21,6 +21,9 @@ from app.ai.voice.agents.breeze_buddy.template.context import (
 )
 from app.ai.voice.agents.breeze_buddy.template.vad import create_vad_analyzer
 from app.ai.voice.agents.breeze_buddy.utils.agent_transfer import PendingAgentTransfer
+from app.ai.voice.agents.breeze_buddy.utils.transport.telephony import (
+    create_telephony_transport,
+)
 from app.core.config.dynamic import BB_DAILY_AUDIO_OUT_10MS_CHUNKS
 from app.core.logger.context import update_log_context
 from app.database.accessor.breeze_buddy.lead_call_tracker import update_lead_template
@@ -140,7 +143,7 @@ async def apply_transfer(bot: "Agent", transfer: PendingAgentTransfer) -> None:
         # Telephony doesn't use the Daily chunk knob; leave the fallback.
         transport_params = get_transport_params(bot.template, bot.configurations)
         params = transport_params[bot._rebuild.telephony_transport_type]()
-        bot.transport = await _create_telephony_transport(
+        bot.transport = await create_telephony_transport(
             cast(WebSocket, bot._rebuild.ws_proxy),
             params,
             bot._rebuild.telephony_transport_type,

--- a/app/ai/voice/agents/breeze_buddy/agent/utils.py
+++ b/app/ai/voice/agents/breeze_buddy/agent/utils.py
@@ -12,7 +12,9 @@ from pipecat.frames.frames import OutputAudioRawFrame
 from pipecat.pipeline.task import PipelineTask
 
 from app.ai.voice.agents.breeze_buddy.template.types import TemplateModel
+from app.ai.voice.agents.breeze_buddy.template.vad import TELEPHONY_SAMPLE_RATE
 from app.ai.voice.agents.breeze_buddy.utils.common import (
+    mulaw_8k_to_l16,
     prepare_initial_greeting_payload,
     track_error,
 )
@@ -86,14 +88,22 @@ async def send_initial_greeting(
         )
 
         if provider_str == "plivo":
-            # Plivo bidirectional streaming uses playAudio event
+            # Plivo bidirectional streaming uses playAudio event. The stream runs
+            # L16 wideband, so the cached 8 kHz mu-law greeting is converted to
+            # match — see mulaw_8k_to_l16.
+            l16_payload = base64.b64encode(
+                mulaw_8k_to_l16(
+                    base64.b64decode(greeting_result["payload"]),
+                    TELEPHONY_SAMPLE_RATE,
+                )
+            ).decode("utf-8")
             media_message = {
                 "event": "playAudio",
                 "streamId": stream_sid,
                 "media": {
-                    "contentType": "audio/x-mulaw",
-                    "sampleRate": 8000,
-                    "payload": greeting_result["payload"],
+                    "contentType": "audio/x-l16",
+                    "sampleRate": TELEPHONY_SAMPLE_RATE,
+                    "payload": l16_payload,
                 },
             }
         else:

--- a/app/ai/voice/agents/breeze_buddy/ivr/selection.py
+++ b/app/ai/voice/agents/breeze_buddy/ivr/selection.py
@@ -31,7 +31,9 @@ from app.ai.voice.agents.breeze_buddy.services.telephony.base_provider import (
     VoiceCallProvider,
 )
 from app.ai.voice.agents.breeze_buddy.template.types import TTSConfig
+from app.ai.voice.agents.breeze_buddy.template.vad import TELEPHONY_SAMPLE_RATE
 from app.ai.voice.agents.breeze_buddy.tts import generate_audio, resolve_voice_config
+from app.ai.voice.agents.breeze_buddy.utils.common import mulaw_8k_to_l16
 from app.ai.voice.agents.breeze_buddy.utils.transport.websockets import (
     close_websocket_safely,
     is_caller_disconnected_error,
@@ -701,14 +703,18 @@ async def _send_audio(
     )
 
     if provider_str == "plivo":
-        # Plivo bidirectional streaming uses playAudio event
+        # Plivo bidirectional streaming uses playAudio event. The stream runs L16
+        # wideband, so this 8 kHz mu-law audio is converted to match.
+        l16_payload = base64.b64encode(
+            mulaw_8k_to_l16(base64.b64decode(payload), TELEPHONY_SAMPLE_RATE)
+        ).decode("utf-8")
         media_message = {
             "event": "playAudio",
             "streamId": stream_sid,
             "media": {
-                "contentType": "audio/x-mulaw",
-                "sampleRate": 8000,
-                "payload": payload,
+                "contentType": "audio/x-l16",
+                "sampleRate": TELEPHONY_SAMPLE_RATE,
+                "payload": l16_payload,
             },
         }
     else:

--- a/app/ai/voice/agents/breeze_buddy/template/vad.py
+++ b/app/ai/voice/agents/breeze_buddy/template/vad.py
@@ -33,7 +33,12 @@ from app.core.config.dynamic import (
 from app.core.logger import logger
 
 # Constants
-TELEPHONY_SAMPLE_RATE = 8000
+# Wideband telephony. A 4G/VoLTE call carries the caller at 16 kHz all the way
+# to Plivo, so 8 kHz threw away the 4-8 kHz band that separates "S" from "F"
+# and makes dictated digits ambiguous for STT. Must stay in step with the
+# <Stream> contentType in telephony/answer/handlers.py and with
+# PlivoL16FrameSerializer's plivo_sample_rate.
+TELEPHONY_SAMPLE_RATE = 16000
 DAILY_SAMPLE_RATE = 16000
 
 

--- a/app/ai/voice/agents/breeze_buddy/utils/common.py
+++ b/app/ai/voice/agents/breeze_buddy/utils/common.py
@@ -95,6 +95,33 @@ def greeting_has_variables(greeting_text: str) -> bool:
     return bool(re.search(pattern, greeting_text))
 
 
+def mulaw_8k_to_l16(mulaw_data: bytes, target_rate: int) -> bytes:
+    """Convert cached 8 kHz mu-law to linear PCM at ``target_rate``.
+
+    Out-of-band audio (the greeting, IVR prompts, the dial tone) is generated and
+    cached as 8 kHz mu-law, but the Plivo ``<Stream>`` now runs L16 wideband. A
+    ``playAudio`` message carries its own contentType, yet mixing formats mid-call
+    relies on per-message negotiation we have not verified — and this is the first
+    audio the customer hears, so it is worth matching the stream exactly.
+
+    Upsampling adds no detail (the source really is 8 kHz), it only makes the
+    bytes playable at the stream's rate. That is fine here: this is our own TTS
+    output heading to a carrier that narrows it again anyway.
+
+    Args:
+        mulaw_data: 8 kHz mono mu-law bytes.
+        target_rate: Stream sample rate, e.g. ``TELEPHONY_SAMPLE_RATE``.
+
+    Returns:
+        16-bit little-endian mono PCM at ``target_rate``.
+    """
+    pcm_8k = audioop.ulaw2lin(mulaw_data, 2)
+    if target_rate == 8000:
+        return pcm_8k
+    converted, _ = audioop.ratecv(pcm_8k, 2, 1, 8000, target_rate, None)
+    return converted
+
+
 def convert_to_mulaw(audio_data: bytes, input_format: str = "raw") -> bytes:
     """
     Convert audio data to mulaw format compatible with Twilio (8kHz, mono).

--- a/app/ai/voice/agents/breeze_buddy/utils/transport/telephony.py
+++ b/app/ai/voice/agents/breeze_buddy/utils/transport/telephony.py
@@ -1,0 +1,57 @@
+"""Telephony transport construction with our own Plivo serializer.
+
+pipecat's ``_create_telephony_transport`` builds the serializer itself and
+overwrites ``params.serializer``, so a caller cannot hand it a custom one. For
+Plivo we therefore build the transport here — the same two lines pipecat ends
+with — using :class:`PlivoL16FrameSerializer` so the call runs wideband.
+
+Every other provider is delegated to pipecat unchanged.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+from fastapi import WebSocket
+from pipecat.runner.utils import _create_telephony_transport
+from pipecat.transports.base_transport import BaseTransport
+
+from app.ai.voice.agents.breeze_buddy.template.vad import TELEPHONY_SAMPLE_RATE
+from app.ai.voice.serializers import PlivoL16FrameSerializer
+from app.core.logger import logger
+
+
+async def create_telephony_transport(
+    websocket: WebSocket,
+    params: Any,
+    transport_type: str,
+    call_data: Any,
+) -> BaseTransport:
+    """Build the telephony transport, using L16 wideband audio on Plivo.
+
+    Args:
+        websocket: The provider's WebSocket (or our non-closing proxy).
+        transport_type: "plivo", "twilio", "exotel" or "telnyx".
+        call_data: Parsed handshake data from ``parse_telephony_websocket``.
+    """
+    if transport_type != "plivo":
+        return await _create_telephony_transport(
+            websocket, params, transport_type, call_data
+        )
+
+    from pipecat.transports.websocket.fastapi import FastAPIWebsocketTransport
+
+    # Telephony never wants a WAV header, matching pipecat's own handling.
+    params.add_wav_header = False
+    params.serializer = PlivoL16FrameSerializer(
+        stream_id=call_data["stream_id"],
+        call_id=call_data["call_id"],
+        auth_id=os.getenv("PLIVO_AUTH_ID", ""),
+        auth_token=os.getenv("PLIVO_AUTH_TOKEN", ""),
+        params=PlivoL16FrameSerializer.InputParams(
+            plivo_sample_rate=TELEPHONY_SAMPLE_RATE,
+        ),
+    )
+    logger.info(f"Plivo transport using L16 wideband at {TELEPHONY_SAMPLE_RATE} Hz")
+    return FastAPIWebsocketTransport(websocket=websocket, params=params)

--- a/app/ai/voice/serializers/__init__.py
+++ b/app/ai/voice/serializers/__init__.py
@@ -1,0 +1,5 @@
+"""Custom pipecat frame serializers."""
+
+from app.ai.voice.serializers.plivo_l16 import PlivoL16FrameSerializer
+
+__all__ = ["PlivoL16FrameSerializer"]

--- a/app/ai/voice/serializers/plivo_l16.py
+++ b/app/ai/voice/serializers/plivo_l16.py
@@ -1,0 +1,100 @@
+"""Plivo serializer for wideband L16 audio.
+
+pipecat's ``PlivoFrameSerializer`` is hardcoded to G.711 mu-law, which the ITU
+defines only at 8 kHz — Plivo therefore offers ``audio/x-mulaw`` at 8000 Hz and
+nothing else. Wideband is available exclusively as ``audio/x-l16`` (8/16/24 kHz).
+
+A 4G (VoLTE) call carries the caller's voice at 16 kHz all the way to Plivo, so
+asking Plivo for mu-law throws away half the audio bandwidth before STT ever
+sees it — losing exactly the 4–8 kHz range that separates "S" from "F" and makes
+dictated digits ambiguous. This subclass keeps the audio at 16 kHz.
+
+L16 is raw little-endian PCM, which is what the pipeline already speaks, so both
+directions here are the parent's logic minus the mu-law conversion.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+
+from pipecat.frames.frames import AudioRawFrame, Frame, InputAudioRawFrame
+from pipecat.serializers.plivo import PlivoFrameSerializer
+
+from app.core.logger import logger
+
+L16_CONTENT_TYPE = "audio/x-l16"
+
+
+class PlivoL16FrameSerializer(PlivoFrameSerializer):
+    """``PlivoFrameSerializer`` speaking ``audio/x-l16`` instead of mu-law.
+
+    The ``<Stream>`` ``contentType`` (inbound) and each ``playAudio`` message
+    (outbound) are negotiated separately by Plivo, but we set both to L16 so the
+    call runs at one rate end to end.
+
+    ``plivo_sample_rate`` must match the rate requested in the ``<Stream>`` XML.
+    """
+
+    async def deserialize(self, data: str | bytes) -> Frame | None:
+        """Turn a Plivo ``media`` event into an input audio frame.
+
+        The parent runs ``ulaw_to_pcm`` here. L16 is already PCM, so the payload
+        only needs un-base64-ing. Every non-media event (dtmf, start, stop) is
+        left to the parent so its stream-id capture and hang-up logic keep working.
+        """
+        try:
+            message = json.loads(data)
+        except json.JSONDecodeError:
+            return await super().deserialize(data)
+
+        if message.get("event") != "media":
+            return await super().deserialize(data)
+
+        payload_base64 = message.get("media", {}).get("payload")
+        if not payload_base64:
+            return None
+
+        pcm = base64.b64decode(payload_base64)
+        if not pcm:
+            return None
+
+        # Plivo's rate and the pipeline's rate are configured to match, so no
+        # resampling is needed; if they ever diverge, that is a config bug worth
+        # surfacing rather than silently papering over.
+        if self._sample_rate and self._sample_rate != self._plivo_sample_rate:
+            logger.warning(
+                f"PlivoL16FrameSerializer: pipeline rate {self._sample_rate} != "
+                f"Plivo rate {self._plivo_sample_rate}; audio will play at the "
+                "wrong speed. Align TELEPHONY_SAMPLE_RATE with the <Stream> contentType."
+            )
+
+        return InputAudioRawFrame(
+            audio=pcm,
+            num_channels=1,
+            sample_rate=self._plivo_sample_rate,
+        )
+
+    async def serialize(self, frame: Frame) -> str | bytes | None:
+        """Turn an output audio frame into a Plivo ``playAudio`` message.
+
+        The parent runs ``pcm_to_ulaw``; L16 needs no conversion. Non-audio
+        frames (EndFrame hang-up, interruptions, DTMF) stay with the parent.
+        """
+        if not isinstance(frame, AudioRawFrame):
+            return await super().serialize(frame)
+
+        if not frame.audio:
+            return None
+
+        return json.dumps(
+            {
+                "event": "playAudio",
+                "media": {
+                    "contentType": L16_CONTENT_TYPE,
+                    "sampleRate": self._plivo_sample_rate,
+                    "payload": base64.b64encode(frame.audio).decode("utf-8"),
+                },
+                "streamId": self._stream_id,
+            }
+        )

--- a/app/api/routers/breeze_buddy/telephony/answer/handlers.py
+++ b/app/api/routers/breeze_buddy/telephony/answer/handlers.py
@@ -58,6 +58,7 @@ from app.ai.voice.agents.breeze_buddy.services.telephony.plivo.recording import 
     start_call_recording,
 )
 from app.ai.voice.agents.breeze_buddy.template.types import TTSConfig
+from app.ai.voice.agents.breeze_buddy.template.vad import TELEPHONY_SAMPLE_RATE
 from app.core.concurrency import spawn_background_task
 from app.core.config.dynamic import (
     BB_NOISE_CANCELLATION_ENABLED,
@@ -312,9 +313,12 @@ async def _build_plivo_stream_xml(ws_url: str) -> str:
     # Using html_escape with quote=False to avoid escaping quotes in the URL
     ws_url_escaped = html_escape(ws_url, quote=False)
 
+    # Wideband: Plivo offers mu-law at 8 kHz only (G.711 is defined there), so
+    # 16 kHz has to travel as L16. Keep the rate in step with
+    # TELEPHONY_SAMPLE_RATE and PlivoL16FrameSerializer.
     return f"""<?xml version="1.0" encoding="UTF-8"?>
 <Response>
-    <Stream {noise_cancellation_attr} bidirectional="true" keepCallAlive="true" contentType="audio/x-mulaw;rate=8000">
+    <Stream {noise_cancellation_attr} bidirectional="true" keepCallAlive="true" contentType="audio/x-l16;rate={TELEPHONY_SAMPLE_RATE}">
         {ws_url_escaped}
     </Stream>
 </Response>"""


### PR DESCRIPTION
- Bump the telephony sample rate from 8kHz to 16kHz to preserve the 4-8kHz band on VoLTE calls, where narrowband mu-law (G.711) throttled caller audio and degraded STT accuracy on dictated digits (e.g. 'S' vs 'F')
- Add PlivoL16FrameSerializer to carry raw 16-bit little-endian PCM (audio/x-l16;rate=16000) on the Plivo <Stream> WebSocket
- Introduce create_telephony_transport, a local factory that injects the L16 serializer for Plivo (pipecat's _create_telephony_transport overwrites params.serializer), used both at call start and on agent-to-agent transfer
- Swap agent/__init__.py and transfer.py to the local factory so the rebuilt transport after a connect_to_agent transfer keeps L16 wideband
- Convert cached 8kHz mu-law out-of-band audio (greeting, IVR prompts, dial tone) to 16kHz L16 via mulaw_8k_to_l16 before playAudio


**Dev Proof:**

**Plivo 16khz support**

outbound call
https://aps1.media.plivo.com/v1/Account/MAZDC2ZTRINGVHZTG5NZ/Recording/8f1f8039-f1e0-41ca-a42f-fde19266e0f4.mp3
Inbound call
https://aps1.media.plivo.com/v1/Account/MAZDC2ZTRINGVHZTG5NZ/Recording/1e8400eb-d071-4523-9531-dadd7c7639be.mp3

Warm transfer call:  ( another ai agent )
https://aps1.media.plivo.com/v1/Account/MAZDC2ZTRINGVHZTG5NZ/Recording/0b1d82db-8c26-4608-9c12-ccba8acd4a2f.mp3

Warm Transfer call: ( another Human agent )
https://aps1.media.plivo.com/v1/Account/MAZDC2ZTRINGVHZTG5NZ/Recording/7ac1c20b-2056-4c91-b6b7-da5473d1f775.mp3

