### PR TITLE
fix(crm): a form that collects nothing is still a completed form

### DIFF
--- a/app/crm/record/extractors/whatsapp/flow.py
+++ b/app/crm/record/extractors/whatsapp/flow.py
@@ -55,8 +55,19 @@ def _nfm_reply(payload: Dict[str, Any]) -> Dict[str, Any]:
     return {}
 
 
-def _submitted(payload: Dict[str, Any]) -> Optional[str]:
-    """The raw response_json string Meta sent, or None."""
+def raw_submission(payload: Dict[str, Any]) -> Optional[str]:
+    """The raw response_json string Meta sent, or None — and THE test for
+    "did she complete a form".
+
+    Public because it is that test, and the test is not "did the form
+    carry data". ``response_json`` always holds our own flow_token and may
+    hold nothing else: a confirm-only Flow (tap to accept) collects no
+    fields, and an endpoint-backed one exchanged its data with the
+    merchant's server during the conversation, so its closing payload is
+    empty. Both are completed forms. Asking ``flow_response`` instead —
+    which drops our token and answers None when nothing of hers remains —
+    read those as silence, and the square waiting for her never woke.
+    """
     value = _nfm_reply(payload).get("response_json")
     return value if isinstance(value, str) and value else None
 
@@ -75,7 +86,7 @@ def flow_response(payload: Dict[str, Any]) -> Optional[Any]:
     still her answer. The letter stays verbatim on the event row — this is
     the reading, not the evidence.
     """
-    raw = _submitted(payload)
+    raw = raw_submission(payload)
     if not raw:
         return None
     try:
@@ -115,7 +126,7 @@ def flow_token(payload: Dict[str, Any]) -> Optional[Any]:
     the literal 'unused' when a send named no token — not an id, so it is
     dropped.
     """
-    raw = _submitted(payload)
+    raw = raw_submission(payload)
     if not raw:
         return None
     try:

--- a/app/crm/record/extractors/whatsapp/inbound.py
+++ b/app/crm/record/extractors/whatsapp/inbound.py
@@ -14,7 +14,7 @@ is needed.
 
 from typing import Any, Dict, List, Optional
 
-from app.crm.record.extractors.whatsapp.flow import FORM_SUBMITTED, flow_response
+from app.crm.record.extractors.whatsapp.flow import FORM_SUBMITTED, raw_submission
 from app.crm.record.extractors.whatsapp.shared import _f, _item
 from app.crm.record.schemas import CatalogField
 
@@ -89,6 +89,15 @@ def reply(payload: Dict[str, Any]) -> Optional[Any]:
     wakes the square and names the arrow, so a plan author labels one edge
     with it and it fires.  Returning the raw JSON would equal no label,
     sending the walker down the ``else`` arrow or exiting the run.
+
+    The test is the SUBMISSION, never its contents. A form that collects
+    no fields is still a completed form: a confirm-only Flow says only
+    "she tapped accept", and an endpoint-backed one exchanged her answers
+    with the merchant's server mid-conversation and closes with an empty
+    payload. Meta's response_json still carries our flow_token in both, so
+    ``flow_response`` — which drops that token — answers None, and asking
+    IT whether a form arrived read a customer who acted as silent. That is
+    the failure this field exists to remove.
     """
     item = _item(payload, "messages")
     button = item.get("button")
@@ -100,7 +109,7 @@ def reply(payload: Dict[str, Any]) -> Optional[Any]:
             chosen = interactive.get(kind)
             if isinstance(chosen, dict) and chosen.get("id") is not None:
                 return chosen["id"]
-    if flow_response(payload) is not None:
+    if raw_submission(payload) is not None:
         return FORM_SUBMITTED
     return message_text(payload)
 

--- a/tests/crm/test_whatsapp_extractor.py
+++ b/tests/crm/test_whatsapp_extractor.py
@@ -30,6 +30,11 @@ from app.crm.outreach.nodes.context import reply_key
 from app.crm.outreach.schemas import WorkflowNode
 from app.crm.outreach.walker import pick_next
 from app.crm.record import catalog
+from app.crm.record.contracts import (
+    canonical_path,
+    derive_for,
+    field_value,
+)
 from app.crm.record.extractors import EXTRACTORS, engine, whatsapp as whatsapp_spec
 from app.crm.record.schemas import Extracted, RawEvent
 
@@ -311,6 +316,73 @@ def test_a_submission_of_nothing_but_our_token_is_absent() -> None:
     assert (
         whatsapp_spec.flow.flow_response(_submission('{"flow_token":"m-42"}')) is None
     )
+
+
+def test_a_form_that_collects_NOTHING_still_wakes_the_square() -> None:
+    """The other half of the test above, and the one that matters more.
+
+    ``flow_response`` is empty for a form that collected no fields — and
+    that is not the same fact as "no form arrived". Two Flows Meta
+    documents submit exactly this: a confirm-only one (she taps accept and
+    there is nothing to collect) and an endpoint-backed one, whose answers
+    went to the merchant's own server during the conversation so the
+    closing payload is empty. response_json still carries OUR flow_token,
+    which flow_response drops.
+
+    Asking flow_response whether a form arrived therefore read both as
+    silence: reply was None, the listening square never woke, and the run
+    waited out its timeout chasing an answer she had already given. That is
+    precisely the bug `reply` exists to prevent, so the discriminant is the
+    SUBMISSION, never its contents.
+    """
+    only_our_token = _submission('{"flow_token":"m-42"}')
+
+    extracted = _extract_inbound(only_our_token)
+    assert extracted.variables["reply"] == "form_submitted"
+    # She submitted, and there is genuinely nothing of hers to render — so
+    # the answer is absent rather than empty, and a plan that maps it parks
+    # loudly instead of sending a blank line to a customer.
+    assert "flow_response" not in extracted.variables
+    # The join still resolves. flow_token is KEYABLE, not a variable — a
+    # listening square matches on it, no template ever prints it — so it is
+    # read the way `match` reads it rather than looked for among the blanks.
+    assert (
+        field_value(
+            only_our_token,
+            canonical_path("flow_token"),
+            derive_for(whatsapp_spec.SOURCE, "message.inbound"),
+        )
+        == "m-42"
+    )
+
+
+def test_a_submission_is_recognised_by_its_envelope_not_by_its_payload() -> None:
+    """Every shape Meta can put in response_json is still a completed
+    form — an empty object, and text that does not parse at all. None of
+    them may read as silence; only a message that is NOT an nfm_reply may.
+    """
+    for response in ('{"flow_token":"m-42"}', "{}", "not json at all"):
+        assert (
+            whatsapp_spec.flow.raw_submission(_submission(response)) is not None
+        ), response
+        assert (
+            whatsapp_spec.inbound.reply(_submission(response)) == "form_submitted"
+        ), response
+
+    # And the guard holds the other way: a tap that happens to carry an
+    # nfm_reply member answers with its own id, not with the form's word.
+    tap = _inbound(
+        _message(
+            type="interactive",
+            interactive={
+                "type": "button_reply",
+                "button_reply": {"id": "CONFIRM"},
+                "nfm_reply": {"response_json": '{"flow_token":"m-42"}'},
+            },
+        )
+    )
+    assert whatsapp_spec.inbound.reply(tap) == "CONFIRM"
+    assert whatsapp_spec.flow.raw_submission(tap) is None
 
 
 def test_a_submission_names_the_send_that_opened_it() -> None:


### PR DESCRIPTION
## What

#1128 decides "did she submit a Flow?" by asking whether `flow_response` is non-empty. `flow_response` drops our own `flow_token` and answers `None` when nothing of hers remains — so a submission carrying **only that token** reads as silence: `reply` is `None`, the listening square never wakes, and the run waits out its timeout chasing an answer she had already given. That is the exact failure #1128 exists to remove, left alive for one class of form.

Meta documents two Flows that submit exactly that shape:

- **a confirm-only Flow** — she taps accept, there are no fields to collect;
- **an endpoint-backed (`data_exchange`) Flow** — her answers went to the merchant's own server during the conversation, so the closing payload is empty.

`response_json` always carries our `flow_token`, so both are indistinguishable from silence under a **content** test, and neither is silence.

## The change

- `flow._submitted` → **`flow.raw_submission`**, public, because it IS the test for "did she complete a form" — and its docstring says why that is not the same question as "did the form carry data".
- `inbound.reply` asks `raw_submission`, not `flow_response`. A token-only submission now answers `FORM_SUBMITTED`, the square wakes, and `flow_token` resolves as it always did. `flow_response` stays **absent**, which is honest: she submitted and there is nothing of hers to render, so a plan that maps it parks loudly rather than sending a blank line to a customer.
- Incidentally one fewer JSON parse per letter — `reply` no longer decodes the payload just to learn that a form arrived.

## Tests — both red before the change

- `test_a_form_that_collects_NOTHING_still_wakes_the_square` — the confirm-only shape: `reply` is the branchable word, `flow_response` is absent, and the join key still resolves (read the way `match` reads it, since `flow_token` is keyable and never a blank).
- `test_a_submission_is_recognised_by_its_envelope_not_by_its_payload` — every `response_json` Meta can send (token-only, `{}`, unparseable) is a completed form; a tap carrying a stray `nfm_reply` member still answers with its own id.

## Gates

On `release` (`2aeb9784`, the #1128 merge): black · isort · autoflake · pyrefly 0 · `check_crm_boundaries` clean · 72 migrations no gaps · `pytest tests/crm` **1095 passed** · one commit.

Corpus: `design/event-catalog.md` now carries the three grains of a submission and this law — *a submission is recognised by its envelope, never by its contents* — with the four limits and their triggers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01APYhsMRBdKLz74A6NRuWy5


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * WhatsApp Flow forms are now correctly recognized as submitted even when they contain only a completion token or an empty response.
  * Confirm-only and endpoint-backed forms no longer appear as unanswered when they complete without collected data.
  * Button replies containing unrelated Flow data continue to be interpreted using their own response identifiers.

* **Tests**
  * Added coverage for token-only, empty, and unparseable Flow submission responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->