### PR TITLE
fix(crm): a reply wakes only the run it answers — the provider-id stamp

### DIFF
--- a/app/crm/connectivity/contracts.py
+++ b/app/crm/connectivity/contracts.py
@@ -36,6 +36,12 @@ What is here, and why each thing is on the surface:
   count of open runs naming a template, so retire can refuse to pull a
   template from under a run in flight without this module importing
   outreach (phase 14; the record/consumers.py inversion).
+- ``provider_message_id_for`` — the provider's own id for a logical send a
+  producer once proposed, by the producer's own dedupe_key. The reply join:
+  a reply carries the provider's id for the message it answers and nothing
+  else, so a listening square resolves WHOSE send it answers through this
+  read. NULL until an attempt was accepted, and only ever the post-accept
+  ladder — a message nobody received is not a correlate.
 - ``META_INGRESS`` — the Meta bay for record's /ingest/webhooks/{provider}
   door (ingress.py builds it; app/crm/api.py registers it into record's
   INGRESS slot — the same line worker_main writes for consumers, and the
@@ -81,7 +87,7 @@ from app.crm.connectivity.onboarding import (
     onboard,
     resubscribe,
 )
-from app.crm.connectivity.queue import queue_message
+from app.crm.connectivity.queue import provider_message_id_for, queue_message
 from app.crm.connectivity.reasons import reason_label
 from app.crm.connectivity.templates.events import consume_template_event
 from app.crm.connectivity.templates.lifecycle import (
@@ -103,6 +109,9 @@ __all__ = [
     "dispatch_send",
     # producing a send
     "queue_message",
+    # the reply join: a producer reads back the provider's id for a send it
+    # proposed, by its own dedupe_key
+    "provider_message_id_for",
     # asking a connector to act (the walker's action square)
     "perform_action",
     "action_names",

--- a/app/crm/connectivity/db/accessors/message.py
+++ b/app/crm/connectivity/db/accessors/message.py
@@ -12,6 +12,7 @@ from app.crm.connectivity.db.queries.message import (
     apply_outcome_query,
     claim_queued_messages_query,
     insert_message_query,
+    provider_message_id_for_query,
     requeue_stale_claims_query,
 )
 from app.crm.connectivity.schemas.message import QueuedMessage
@@ -70,6 +71,15 @@ async def requeue_stale_claims(
     requeued = [str(row["id"]) for row in rows if row["status"] == MESSAGE_QUEUED]
     dead = [str(row["id"]) for row in rows if row["status"] != MESSAGE_QUEUED]
     return requeued, dead
+
+
+async def provider_message_id_for(merchant_id: str, dedupe_key: str) -> Optional[str]:
+    """The provider's id for one logical send, or None (no row, or no
+    attempt accepted yet)."""
+    query, values = provider_message_id_for_query(merchant_id, dedupe_key)
+    async with crm_connection() as conn:
+        value = await conn.fetchval(query, *values)
+    return str(value) if value else None
 
 
 async def apply_outcome(

--- a/app/crm/connectivity/db/queries/message.py
+++ b/app/crm/connectivity/db/queries/message.py
@@ -17,9 +17,13 @@ from app.crm.connectivity.reasons import (
     REASON_RECLAIMED_STALE_CLAIM,
 )
 from app.crm.connectivity.status import (
+    MESSAGE_ACCEPTED,
     MESSAGE_DEAD,
+    MESSAGE_DELIVERED,
     MESSAGE_QUEUED,
+    MESSAGE_READ,
     MESSAGE_SENDING,
+    MESSAGE_SENT,
 )
 
 MESSAGE_TABLE = "crm_message"
@@ -134,6 +138,34 @@ def requeue_stale_claims_query(
         REASON_ATTEMPTS_EXHAUSTED,
         REASON_RECLAIMED_STALE_CLAIM,
         MESSAGE_SENDING,
+    ]
+
+
+def provider_message_id_for_query(
+    merchant_id: str, dedupe_key: str
+) -> Tuple[str, List[Any]]:
+    """The reconcile read (contracts.provider_message_id_for): the provider's
+    id for one logical send, by the producer's own name for it. One indexed
+    point read — (merchant_id, dedupe_key) is the dedupe UNIQUE — and NULL
+    until an attempt was accepted.
+
+    Filtered to the POST-ACCEPT ladder in SQL, because the caller treats the
+    answer as "the message the customer received": apply_outcome copies
+    outcome.provider_message_id onto FAILED/DEAD/QUEUED plans too, and while
+    no adapter reports an id beside a refusal today, the first one that does
+    (some providers do) must not turn a message nobody received into a reply
+    correlate. The words come from status.py, never spelled here (the 027
+    scar: vocabulary in code, one home)."""
+    query = f"""
+        SELECT provider_message_id
+          FROM {MESSAGE_TABLE}
+         WHERE merchant_id = $1 AND dedupe_key = $2
+           AND status = ANY($3::text[])
+    """
+    return query, [
+        merchant_id,
+        dedupe_key,
+        [MESSAGE_ACCEPTED, MESSAGE_SENT, MESSAGE_DELIVERED, MESSAGE_READ],
     ]
 
 

--- a/app/crm/connectivity/queue.py
+++ b/app/crm/connectivity/queue.py
@@ -85,3 +85,22 @@ async def queue_message(
         variables,
         dedupe_key,
     )
+
+
+async def provider_message_id_for(merchant_id: str, dedupe_key: str) -> Optional[str]:
+    """The provider's own id for a logical send this producer once proposed
+    — None until an attempt was ACCEPTED (T16 col 14 is written by the
+    outcome, nothing earlier).
+
+    THE reply join. A reply carries the provider's id for the message it
+    answers (Meta's wamid in ``context.id``) and nothing of ours, so a
+    producer asking "which of my sends is she answering?" resolves it here
+    — keyed by the producer's OWN name for the send (its dedupe_key), never
+    by our row id, which the producer has no reason to have kept.
+
+    Read at reply time rather than pushed at accept time on purpose: a
+    reply is a cold path, the row is one indexed read, and a value pushed
+    ahead of need is a cache to keep coherent. The caller may memoise what
+    it learns; the row stays the truth.
+    """
+    return await message_accessor.provider_message_id_for(merchant_id, dedupe_key)

--- a/app/crm/outreach/catalog_laws.py
+++ b/app/crm/outreach/catalog_laws.py
@@ -115,6 +115,46 @@ def entry_against_catalog(
     return problems
 
 
+def match_payload_against_catalog(
+    definition: WorkflowDefinition, catalogs: Catalogs
+) -> List[str]:
+    """PURE: a listening square's ``match.payload`` must be a declared field
+    of EVERY topic the square listens on — the mirror of the match.run
+    checks in plans.py, guarding the other half of the same comparison.
+
+    A typo'd payload field resolves to None on every letter, every letter
+    "claims nobody", and the square is permanently deaf with publish clean —
+    the byte-for-byte silent failure the run-side check's comment says it
+    exists to prevent. EVERY topic, not any: match is judged per letter
+    (_is_about), so a field only one of two listened topics declares leaves
+    the square deaf on the other — surfaced here as a sentence instead of
+    discovered as a run that never woke.
+
+    A topic no layer declares is skipped, not refused: nothing exists to
+    check against, and the general unknown-topic law already speaks when
+    the plan filters or keys on it.
+    """
+    problems: List[str] = []
+    if catalogs is None:
+        return problems
+    for node in definition.nodes:
+        if node.type != "wait_event" or node.match is None:
+            continue
+        payload_path = canonical_path(node.match.payload)
+        for topic in node.topics:
+            fields = catalogs.get(topic)
+            if fields is None:
+                continue
+            if payload_path not in fields:
+                problems.append(
+                    f"node {node.id}: match.payload {node.match.payload!r} is "
+                    f"not a declared field of topic {topic!r} — every letter "
+                    f"there would claim nobody and the square would never "
+                    f"hear it"
+                )
+    return problems
+
+
 # Facts the walker computes for a template at the square (nodes.run_facts,
 # phase 16) — never a producer's, so no catalog declares them.
 _WALKER_FACTS = frozenset({"current_node", "current_stage"})

--- a/app/crm/outreach/db/accessors/enrollment.py
+++ b/app/crm/outreach/db/accessors/enrollment.py
@@ -36,6 +36,7 @@ from app.crm.outreach.db.queries.enrollment import (
     resume_run_query,
     runs_referencing_template_query,
     source_event_used_query,
+    stamp_context_key_query,
     sweep_exited_runs_query,
     workflow_summary_query,
 )
@@ -219,6 +220,16 @@ async def open_runs_for_customer(
     async with crm_connection() as conn:
         rows = await conn.fetch(query, *values)
     return [decode_run(row) for row in rows]
+
+
+async def stamp_context_key(
+    merchant_id: str, run_id: str, key: str, value: str
+) -> bool:
+    """True when the run was still open and took the bookkeeping key."""
+    query, values = stamp_context_key_query(merchant_id, run_id, key, value)
+    async with crm_connection() as conn:
+        row = await conn.fetchrow(query, *values)
+    return row is not None
 
 
 async def resume_run_by_id(

--- a/app/crm/outreach/db/queries/enrollment.py
+++ b/app/crm/outreach/db/queries/enrollment.py
@@ -319,6 +319,24 @@ def open_runs_for_customer_query(
     return query, [merchant_id, customer_id]
 
 
+def stamp_context_key_query(
+    merchant_id: str, run_id: str, key: str, value: str
+) -> Tuple[str, List[Any]]:
+    """One bookkeeping key onto an OPEN run's context — the send's provider
+    id, keyed by the square that sent it, memoised by entry.py the first
+    time a listening square needs it so the next letter costs no read. Guarded to open runs only — the stamp routes a FUTURE
+    reply, and an exited run has no square listening. Merchant-scoped
+    like every write here; RETURNING id so the caller can tell "stamped"
+    from "already exited" without a second read."""
+    query = f"""
+        UPDATE {ENROLLMENT_TABLE}
+        SET context = context || jsonb_build_object($3::text, $4::text)
+        WHERE merchant_id = $1 AND id = $2::uuid AND status <> 'exited'
+        RETURNING id
+    """
+    return query, [merchant_id, run_id, key, value]
+
+
 def resume_run_by_id_query(
     merchant_id: str,
     run_id: str,

--- a/app/crm/outreach/entry.py
+++ b/app/crm/outreach/entry.py
@@ -27,6 +27,7 @@ from typing import Any, Dict, Optional, Sequence, Tuple
 
 from app.core.config.dynamic import CRM_CONTEXT_VALUE_MAX_CHARS
 from app.core.logger import logger
+from app.crm.connectivity.contracts import provider_message_id_for
 from app.crm.outreach.db.accessors import (
     enrollment as enrollment_accessor,
     workflow as workflow_accessor,
@@ -35,8 +36,10 @@ from app.crm.outreach.definitions import definition_for
 from app.crm.outreach.enrol import enrol
 from app.crm.outreach.nodes.context import (
     LATEST_LETTER_KEY,
+    PROVIDER_MESSAGE_PREFIX,
     is_bookkeeping,
     reply_key,
+    send_dedupe_key,
 )
 from app.crm.outreach.nodes.wait_event import TOPIC_KEY
 from app.crm.outreach.repeat import _as_number, apply_repeat
@@ -227,6 +230,7 @@ async def _wake_on_reply(
     for node in definition.nodes:
         if node.type != "wait_event" or event.topic not in node.topics:
             continue
+        run = await _with_send_correlate(run, node)
         if not _is_about(node, event, run):
             continue  # another run's letter (phase 18): not this square's
         answer = _answer_for(node, event)
@@ -253,6 +257,53 @@ async def _wake_on_reply(
             {reply_key(node.id): answer, LATEST_LETTER_KEY: node.id},
             facts,
         )
+
+
+async def _with_send_correlate(run: EnrollmentRun, node: WorkflowNode) -> EnrollmentRun:
+    """The run with its send's provider id on it, resolved from the manifest
+    the first time a square needs it.
+
+    A reply carries the provider's id for the message it answers and nothing
+    of ours, so a square matching on ``provider_message_id_<send>`` needs
+    that id beside the run. It is not written when the send is queued: our
+    id exists then, the provider's does not — it is learned at ACCEPT, and
+    the manifest row is where the dispatcher put it (T16 col 14,
+    apply_outcome).
+
+    So it is read HERE, once, by the same dedupe_key the send square queued
+    under, and written onto the run so the next letter on the same square
+    costs nothing. Read at need rather than pushed at accept time
+    deliberately: a reply is a cold path, this is one indexed point read,
+    and a value pushed ahead of need is a cache someone has to keep
+    coherent — the run's context is rewritten wholesale by the walker's
+    advance, so that coherence is not free. Resolving on demand also means
+    the path runs on EVERY reply instead of only when a push was lost,
+    which is the difference between a path that is exercised and a path
+    that is discovered during an incident.
+
+    The write is best effort: losing it costs one read next time, and a
+    raise here would roll back the letter's savepoint for bookkeeping.
+
+    None from the manifest means no attempt was ever accepted — the run
+    honestly has no id a reply could echo, so `_is_about` answers "not
+    hers" and the run keeps waiting rather than taking another run's
+    letter.
+    """
+    match = node.match
+    if match is None or not match.run.startswith(PROVIDER_MESSAGE_PREFIX):
+        return run
+    if run.context.get(match.run):
+        return run
+    node_id = match.run[len(PROVIDER_MESSAGE_PREFIX) :]
+    correlate = await provider_message_id_for(
+        run.merchant_id, send_dedupe_key(str(run.id), node_id)
+    )
+    if not correlate:
+        return run
+    await enrollment_accessor.stamp_context_key(
+        run.merchant_id, str(run.id), match.run, correlate
+    )
+    return run.model_copy(update={"context": {**run.context, match.run: correlate}})
 
 
 def _is_about(node: WorkflowNode, event: RawEvent, run: EnrollmentRun) -> bool:
@@ -310,7 +361,15 @@ async def _answered_by(
     would push the alarm the wake just set (now) back by the debounce, and
     the token would sit on a square it has already answered — on a stages
     ladder (phase 17), where every stage is a door AND every earlier
-    square listens for it, every stage clock would run twice."""
+    square listens for it, every stage clock would run twice.
+
+    Resolved through the SAME lens the wake used: open_runs was read at the
+    top of the pass, so a correlate _wake_on_reply just resolved lives on the
+    copy it resumed, not on these objects. Judging the stale context here
+    would answer "not its square's answer" for the very letter that woke the
+    run — and apply_repeat would re-arm the square it just resolved. Cheap on
+    the second ask: the wake's resolve already wrote the row, and a present
+    in-memory key short-circuits before any read."""
     for run in open_runs:
         if (
             str(run.workflow_id) == str(flow.id)
@@ -320,10 +379,11 @@ async def _answered_by(
             if pinned is None:
                 return False
             square = next((n for n in pinned.nodes if n.id == run.current_node), None)
+            if square is None:
+                return False
+            run = await _with_send_correlate(run, square)
             return (
-                square is not None
-                and _is_about(square, event, run)
-                and _answer_for(square, event) is not None
+                _is_about(square, event, run) and _answer_for(square, event) is not None
             )
     return False
 

--- a/app/crm/outreach/nodes/context.py
+++ b/app/crm/outreach/nodes/context.py
@@ -37,7 +37,26 @@ _BOOKKEEPING_KEYS = (
 # LEAVES, and the action then executes as its own square, so "the current
 # square's facts" would never be the latest stage's.
 LATEST_LETTER_KEY = "latest_letter"
-_BOOKKEEPING_PREFIXES = ("lead_", "message_", "reply_", "action_")
+# provider_message_id_<send node>: the provider's OWN id for that square's
+# accepted send (correlate.py; Meta's wamid, an email's Message-ID — the T16
+# column's name, so one spelling serves every channel) — the value a
+# listening square's `match` compares a reply's replied_to against.
+# Bookkeeping like message_<node>, and for the same reason: an internal id
+# must never resolve into a customer's message.
+# The provider-id stamp's key family (correlate.py writes, entry.py
+# reconciles, plans.py validates): ONE spelling, imported everywhere it is
+# compared — three private copies would let the validator bless names the
+# stamp never writes, and the bookkeeping filter stop recognising the key
+# the day one copy moved.
+PROVIDER_MESSAGE_PREFIX = "provider_message_id_"
+
+_BOOKKEEPING_PREFIXES = (
+    "lead_",
+    "message_",
+    "reply_",
+    "action_",
+    PROVIDER_MESSAGE_PREFIX,
+)
 
 # The merchant's own id for the thing a call is about. Buddy's reporter
 # echoes lead.request_id back to the merchant as orderId on every outcome
@@ -46,6 +65,29 @@ _BOOKKEEPING_PREFIXES = ("lead_", "message_", "reply_", "action_")
 # names the order field — Shopify's `id`, a platform-wide unique); the flat
 # keys below serve unkeyed plans, and the run id is the last fallback.
 _REQUEST_ID_KEYS = ("order_id", "request_id")
+
+
+def provider_message_key(node_id: str) -> str:
+    """Where a send square's accepted provider id lives in the context."""
+    return f"{PROVIDER_MESSAGE_PREFIX}{node_id}"
+
+
+def send_dedupe_key(run_id: str, node_id: str) -> str:
+    """The manifest name for one square's send — "<run>:<node>". Built and
+    parsed by THIS pair only: the builder (nodes/send.py) and the parser
+    (correlate.py, the reconcile read) drifting apart is a stamp that lands
+    under a key no square's match ever names."""
+    return f"{run_id}:{node_id}"
+
+
+def parse_send_dedupe_key(dedupe_key: str) -> Optional[tuple]:
+    """(run_id, node_id), or None for a key this convention did not build —
+    which must be skipped, never guessed at: a wrong guess writes a
+    correlate onto the wrong run."""
+    run_id, sep, node_id = dedupe_key.partition(":")
+    if not sep or not run_id or not node_id:
+        return None
+    return run_id, node_id
 
 
 def is_bookkeeping(key: str) -> bool:

--- a/app/crm/outreach/nodes/send.py
+++ b/app/crm/outreach/nodes/send.py
@@ -10,7 +10,7 @@ from typing import Any, Dict, List
 
 from app.core.logger import logger
 from app.crm.connectivity.contracts import queue_message
-from app.crm.outreach.nodes.context import send_variables
+from app.crm.outreach.nodes.context import send_dedupe_key, send_variables
 from app.crm.outreach.nodes.spec import NodeParked
 from app.crm.outreach.schemas import EnrollmentRun, WorkflowDefinition, WorkflowNode
 
@@ -76,7 +76,7 @@ async def execute(
     except ValueError as e:
         raise NodeParked(f"send node {node.id}: {e}") from e
 
-    dedupe_key = f"{run.id}:{node.id}"
+    dedupe_key = send_dedupe_key(str(run.id), node.id)
     try:
         message_id = await queue_message(
             merchant_id=run.merchant_id,

--- a/app/crm/outreach/plans.py
+++ b/app/crm/outreach/plans.py
@@ -15,6 +15,7 @@ from app.crm.outreach.catalog_laws import (
     WorkflowValidationError,
     entry_against_catalog,
     gather_catalogs as _gather_catalogs,
+    match_payload_against_catalog,
 )
 from app.crm.outreach.db import DbTxn, atomically
 from app.crm.outreach.db.accessors import (
@@ -25,6 +26,7 @@ from app.crm.outreach.db.accessors import (
 from app.crm.outreach.ladder import LadderProblem, expand_stages
 from app.crm.outreach.nodes import NODE_TYPES, is_wait
 from app.crm.outreach.repeat import parse_repeat_policy
+from app.crm.outreach.reply_match_laws import reply_match_problems
 from app.crm.outreach.schemas import (
     GOAL_EXIT_REASONS,
     Workflow,
@@ -84,6 +86,7 @@ def validate_definition(
             "equality map is retired (migration 069)"
         )
     problems.extend(entry_against_catalog(definition, catalogs))
+    problems.extend(match_payload_against_catalog(definition, catalogs))
     node_ids = [node.id for node in definition.nodes]
     seen = set()
     for node_id in node_ids:
@@ -95,11 +98,10 @@ def validate_definition(
     # walker executes from, so validator and walker cannot disagree.
     for node in definition.nodes:
         problems.extend(NODE_TYPES[node.type].validate(node, definition))
-        if node.match is not None and node.type != "wait_event":
-            problems.append(
-                f"node {node.id}: match belongs to a wait_event — only a "
-                "listening square hears a letter"
-            )
+
+    # How a listening square narrows a reply to ONE run — its own file,
+    # one subject, every law there guarding a SILENT failure.
+    problems.extend(reply_match_problems(definition))
 
     # The doors (phase 15): one per topic, each starting on a real square.
     # Repeat-entry words per door (repeat.py owns the vocabulary); debounce

--- a/app/crm/outreach/reply_match_laws.py
+++ b/app/crm/outreach/reply_match_laws.py
@@ -1,0 +1,164 @@
+"""The laws of a listening square's ``match`` — publish-time, pure.
+
+A reply narrows to ONE run by comparing a field of the letter against a
+field of the run (``match {payload, run}``). Every law here exists because
+its absence fails SILENTLY: the plan publishes clean and the square is
+either deaf for as long as it waits, or it wakes runs the letter was never
+about. One customer with three open orders had her single CANCEL resolve
+all of them (10 Sep 2026, docs/crm/reply-run-matching.md) — that is the
+loud version; the rest of these are the quiet ones.
+
+Scoped by the EDGE GRAPH, not by the node list: only a square with a send
+UPSTREAM of it can be woken by a reply to that send, so a receive-first
+square keeps the open default and is never refused.
+
+Kept out of plans.py for the reason catalog_laws.py is: that file is the
+plan lifecycle (gather -> validate -> apply), and these are one pure
+concern with one subject.
+"""
+
+from typing import Dict, List
+
+from app.crm.outreach.nodes.context import PROVIDER_MESSAGE_PREFIX
+from app.crm.outreach.schemas import WorkflowDefinition
+
+REPLY_TOPIC = "message.inbound"
+
+
+def reply_match_problems(definition: WorkflowDefinition) -> List[str]:
+    """PURE: everything wrong with how this plan's squares narrow a reply."""
+    problems: List[str] = []
+    for node in definition.nodes:
+        if node.match is not None and node.type != "wait_event":
+            problems.append(
+                f"node {node.id}: match belongs to a wait_event — only a "
+                "listening square hears a letter"
+            )
+        if (
+            node.type == "wait_event"
+            and node.match is None
+            and node.topics == ["message.inbound"]
+            and (upstream := _upstream_sends(node.id, definition))
+        ):
+            # The 2026-09-10 incident, at publish instead of in production:
+            # a square waiting for the reply to a send UPSTREAM of it,
+            # without saying whose, falls to _is_about's open default — one
+            # customer's answer resolves every open run of hers, and an
+            # order she confirmed gets cancelled. Scoped three ways so it
+            # cannot demand a match where one has no meaning: only the
+            # reply topic; only when a send is upstream on the EDGE GRAPH
+            # (a receive-first square beside an unrelated send branch has
+            # no reply to mis-route, and the suggested match would be
+            # unsatisfiable there); and only a single-topic square — a
+            # mixed listen (reply OR call outcome) forced to match would
+            # go deaf on its other topic, since match is judged per
+            # letter. The suggestion names the UPSTREAM sends: a plan with
+            # two sends must not be told to match the wrong one's id.
+            names = " or ".join(
+                f'"{PROVIDER_MESSAGE_PREFIX}{send}"' for send in upstream
+            )
+            problems.append(
+                f"node {node.id}: listens on message.inbound with no match — "
+                f"a reply would wake EVERY open run of the customer, not the "
+                f'one it answers. Add match: {{"payload": "replied_to", '
+                f'"run": {names}}} (the send square whose reply this square '
+                f"waits for). A customer who TYPES a fresh message instead "
+                f"of replying carries no thread id and will not match — the "
+                f"timeout edge is that path."
+            )
+        if (
+            node.type == "wait_event"
+            and "message.inbound" in node.topics
+            and len(node.topics) > 1
+            and _upstream_sends(node.id, definition)
+        ):
+            # A mixed listen downstream of a send is unsafe in BOTH
+            # directions, so it is refused whole rather than matched:
+            # matchless, _is_about's open default takes one reply for
+            # every open run (the incident, one door over); matched, the
+            # same match is judged against every letter the square hears
+            # and the other topic's letters — which carry no replied_to —
+            # all claim nobody, deafening the square to the very outcome
+            # it also waits for. Two squares each say one thing honestly;
+            # the vocabulary has no shape that lets one square say both.
+            others = [t for t in node.topics if t != "message.inbound"]
+            problems.append(
+                f"node {node.id}: message.inbound cannot share a square "
+                f"with {', '.join(repr(t) for t in others)} when a send is "
+                f"upstream — without a match one reply wakes every open "
+                f"run; with one, the square goes deaf on the other topic. "
+                f"Split it into two listening squares."
+            )
+        if (
+            node.match is not None
+            and node.match.run.startswith("provider_message")
+            and not node.match.run.startswith(PROVIDER_MESSAGE_PREFIX)
+        ):
+            # A typo INSIDE the prefix sails past the send-node check below
+            # (its startswith fails) and publishes a square that matches
+            # nothing forever — the silent version of the incident.
+            problems.append(
+                f"node {node.id}: match.run {node.match.run!r} — did you "
+                f"mean {PROVIDER_MESSAGE_PREFIX}<send node>? The stamp "
+                f"writes exactly that prefix and nothing else"
+            )
+        if node.match is not None and node.match.run.startswith(
+            PROVIDER_MESSAGE_PREFIX
+        ):
+            # The stamp (correlate.py) writes provider_message_id_<node>
+            # only for a SEND node's accepted message. A misspelled square
+            # name here would publish clean and then match nothing forever
+            # — every reply "claims nobody" — which is the silent version
+            # of the very failure match exists to prevent.
+            sender = node.match.run[len(PROVIDER_MESSAGE_PREFIX) :]
+            named = next((n for n in definition.nodes if n.id == sender), None)
+            upstream = _upstream_sends(node.id, definition)
+            if named is None or named.type != "send":
+                problems.append(
+                    f"node {node.id}: match.run {node.match.run!r} — "
+                    f"{sender!r} is not a send node, so no provider id is ever "
+                    "stamped under that name"
+                )
+            elif sender not in upstream:
+                # A send the token has not crossed yet stamps nothing while
+                # the run stands here, so every reply "claims nobody" and the
+                # square is deaf until its timeout — the SILENT version of the
+                # incident this match exists to prevent. The name is real and
+                # the type is right, so only the edge graph can catch it.
+                problems.append(
+                    f"node {node.id}: match.run {node.match.run!r} names a send "
+                    f"the run has not reached when it stands here, so nothing is "
+                    f"stamped under that name and every reply claims nobody. "
+                    + (
+                        f"Upstream of this square: "
+                        f"{', '.join(repr(PROVIDER_MESSAGE_PREFIX + u) for u in upstream)}"
+                        if upstream
+                        else "No send is upstream of this square at all"
+                    )
+                )
+    return problems
+
+
+def _upstream_sends(node_id: str, definition: WorkflowDefinition) -> List[str]:
+    """PURE: the send squares a token could have crossed BEFORE standing on
+    ``node_id``, walked backwards over the edge graph — what the no-match
+    refusal scopes itself by. A reply can only answer a send that already
+    happened, so a square with no send upstream has no reply to mis-route,
+    whatever else the plan contains."""
+    inbound: Dict[str, List[str]] = {}
+    for edge in definition.edges:
+        inbound.setdefault(edge[1], []).append(edge[0])
+    by_id = {node.id: node for node in definition.nodes}
+    seen: set = set()
+    stack = [node_id]
+    sends: List[str] = []
+    while stack:
+        for source in inbound.get(stack.pop(), []):
+            if source in seen:
+                continue
+            seen.add(source)
+            node = by_id.get(source)
+            if node is not None and node.type == "send":
+                sends.append(source)
+            stack.append(source)
+    return sends

--- a/docs/crm/plans/README.md
+++ b/docs/crm/plans/README.md
@@ -11,6 +11,7 @@ the PR that makes it.
 |---|---|---|
 | `cart-recovery.json` | Cart abandonment (`context/reading-notes.md` §16.1) | one board: wait 30m → WhatsApp → wait 30m → rescue call → wait 1d |
 | `cart-recovery-fallback.json` | The cart board with a fallback after the call (rollout phase 18, G2) | after the rescue call, a listening square hears THIS run's `call.completed` (`match` on `enrollment_id`): no answer / busy / early hang-up → a second WhatsApp; `else` → the day of listening |
+| `cod-confirm.json` | COD confirmation, and the reply that answers ONE send (`reply-run-matching.md`) | send → a listening square carrying `match: {payload: replied_to, run: provider_message_id_confirm}` → tag the order `CONFIRM` / `form_submitted` → confirmed, `CANCEL` → cancelled, `timeout` → wait. Without that match line publish now REFUSES the square: one customer's several open orders would take each other's taps |
 | `loan-dropoff.json` | Loan-onboarding drop-off (§16.2; rollout phase 17) | one **pinned board** written as a `stages` ladder: five stages in order; quiet 30m on a stage (120m on the offer) → call → listen for a day → the end; expanded into the wait_event board at create/draft/publish |
 
 Placeholders: every `template_id` is the string `TEMPLATE_ID_PLACEHOLDER`

--- a/docs/crm/plans/cod-confirm.json
+++ b/docs/crm/plans/cod-confirm.json
@@ -1,0 +1,102 @@
+{
+  "on_publish": "migrate",
+  "entry": {
+    "topic": "orders/create",
+    "key": "id"
+  },
+  "goals": [
+    {
+      "topics": [
+        "orders/cancelled"
+      ],
+      "key": {
+        "event": "id",
+        "run": "id"
+      },
+      "exit_reason": "goal_met"
+    }
+  ],
+  "exits": {
+    "max_age_days": 3
+  },
+  "purpose_key": "utility.order.confirmation",
+  "nodes": [
+    {
+      "id": "confirm",
+      "type": "send",
+      "channel": "whatsapp",
+      "template": "cod_confirm_1",
+      "variables": {
+        "1": "customer_name"
+      }
+    },
+    {
+      "id": "await-reply",
+      "type": "wait_event",
+      "topics": [
+        "message.inbound"
+      ],
+      "key": "reply",
+      "minutes": 1440,
+      "match": {
+        "payload": "replied_to",
+        "run": "provider_message_id_confirm"
+      }
+    },
+    {
+      "id": "tag-confirmed",
+      "type": "action",
+      "connector": "shopify",
+      "action": "add_tag",
+      "args": {
+        "order_id": "{id}",
+        "tags": [
+          "COD_CONFIRMED"
+        ]
+      }
+    },
+    {
+      "id": "tag-cancelled",
+      "type": "action",
+      "connector": "shopify",
+      "action": "add_tag",
+      "args": {
+        "order_id": "{id}",
+        "tags": [
+          "COD_CANCELLED"
+        ]
+      }
+    },
+    {
+      "id": "wait-1d",
+      "type": "wait",
+      "minutes": 1440
+    }
+  ],
+  "edges": [
+    [
+      "confirm",
+      "await-reply"
+    ],
+    [
+      "await-reply",
+      "tag-confirmed",
+      "CONFIRM"
+    ],
+    [
+      "await-reply",
+      "tag-confirmed",
+      "form_submitted"
+    ],
+    [
+      "await-reply",
+      "tag-cancelled",
+      "CANCEL"
+    ],
+    [
+      "await-reply",
+      "wait-1d",
+      "timeout"
+    ]
+  ]
+}

--- a/docs/crm/reply-run-matching.md
+++ b/docs/crm/reply-run-matching.md
@@ -1,0 +1,111 @@
+# A reply wakes only the run it answers
+
+*The incident of 10 Sep 2026, the reason `_is_about` could not decide it, and the
+correlation this repo now plants so it can.*
+
+## What happened
+
+One customer had several COD orders open at once, so several runs of the confirmation
+board were live for her at the same time. She tapped **Confirm** on one message. Every
+open run took that tap as its own answer: one of them was standing on a square whose
+`CANCEL` arrow led to a cancellation, and a confirmed order was cancelled on Shopify.
+
+## Why no one could have written the plan differently
+
+A listening square narrows a letter to one run with `match {payload, run}`: a field of
+the letter compared against a field of the run. `canon/06-outreach.md` gives the keyed
+example — two open orders, two live WISMO flows, matched on the order key both sides
+carry.
+
+**For a WhatsApp reply there was no comparable pair.** The letter carries Meta's `wamid`
+of the message being answered (`context.id`, read by each source's own `replied_to`
+deriver). The run carried OUR `crm_message` id, stamped by the send square when it queued
+the message. Those are different identifiers, issued at different times: our id exists
+before the send, Meta's only exists after the provider accepts it. There was no value to
+compare, so the plan carried no `match`, and `_is_about` did what it documents — with no
+match word, every letter on the topic is hers.
+
+The default is right. What was missing was something to match on.
+
+## The fix, in one line
+
+**The provider's id for a send lives on the manifest row. Resolve it onto the run the
+first time a square needs it, and match on the echo.**
+
+| Piece | Where | What it does |
+|---|---|---|
+| `provider_message_id_for` | `connectivity/queue.py`, on the contract | The provider's own id for one logical send, read by the producer's OWN name for it (`dedupe_key`), filtered to the post-accept ladder |
+| `_with_send_correlate` | `outreach/entry.py` | On the first reply a square must narrow, reads that id and writes it onto the run as `provider_message_id_<send node>`, so the next letter costs nothing |
+| the match | the plan document | `match: {payload: replied_to, run: provider_message_id_<send node>}` |
+
+`replied_to` is each source's own deriver, so a second channel needs no change here.
+
+### Why it is read at reply time, and not pushed at accept time
+
+The dispatcher learns the provider's id and could push it onto the run there and then,
+through an observer slot. That was the first shape of this fix, and it was removed before
+merge. Three reasons:
+
+- **A reply is a cold path.** One customer answering one message, against a point read on
+  a unique index. The push saves that read and costs a cross-module slot, a Protocol, a
+  dispatcher hook, a deadline dial and a registration line.
+- **A pushed value is a cache to keep coherent**, and this one is not free to keep: the
+  walker's advance rewrites a run's context wholesale, so the push can be silently lost.
+  The pushed design had to carry a reconcile-from-the-manifest path anyway, for the same
+  row this now reads.
+- **The reconcile would then run rarely**, which is the worst property a recovery path can
+  have. Reading on demand means the one path runs on every reply, so it is exercised
+  constantly rather than discovered during an incident.
+
+The memo on the run is still written, so the read happens once per send, not once per
+letter. Losing that write costs one read next time and nothing else.
+
+## The manifest is the truth
+
+The read trusts only the post-accept ladder, spelled from `connectivity/status.py`: some
+providers return an id beside a refusal, and a message nobody received is not something a
+reply can be answering. `_answered_by` judges the same resolved run as the wake did, so a
+wake is never also a repeat.
+
+This is also why **a run opened before this shipped resolves**: its `crm_message` row already
+carries the wamid, so its first reply finds it.
+
+## What stays closed
+
+- **No stamp and no manifest id** → the run keeps waiting. It never takes another run's
+  letter; the timeout edge recovers her.
+- **An unthreaded message** (a typed reply with no `context.id`) claims nobody.
+- **A dedupe key that is not `<run>:<node>`, or names another run**, is skipped, never
+  guessed.
+
+## What publish refuses, and why
+
+The guards are scoped by the edge graph, because only a square with a send **upstream** of
+it can be woken by a reply to that send:
+
+1. A single-topic `message.inbound` square with a send upstream and **no match** — refused,
+   with the exact line to add and the upstream sends named.
+2. A **mixed** `message.inbound` listen behind a send — refused whole: without a match one
+   reply wakes every run, and with one the square goes deaf on the other topic. Split it.
+3. `match.run` that does not name a **send** node — nothing is ever stamped under that name.
+4. `match.run` naming a send the token **has not crossed** when it stands on this square —
+   publishes clean and is deaf forever, the silent version of the incident.
+5. A typo inside the prefix gets a did-you-mean.
+6. `match.payload` must be declared on every topic the square listens to.
+
+A receive-first square (no send upstream) stays legal, unchanged.
+
+## Deploying it
+
+The live COD plan has no `match`, and runs already open are pinned to that version, so they
+keep the open default until they exit.
+
+1. Republish the plan with the match line and `on_publish: migrate`. The square exists and
+   the entry is unchanged, so the migrate validator allows the re-pin of open runs.
+2. Each old run's stamp fills itself from its manifest row on the next reply.
+
+A worked document is `plans/cod-confirm.json`.
+
+**Known gap, filed separately:** loom's workflow editor knows `match` on its type but cannot
+author it, so a merchant drawing send → wait-reply in the console meets the new refusal with
+no way to satisfy it in the UI.

--- a/tests/crm/test_plan_templates.py
+++ b/tests/crm/test_plan_templates.py
@@ -23,6 +23,7 @@ PLANS = Path(__file__).resolve().parents[2] / "docs" / "crm" / "plans"
 CART = PLANS / "cart-recovery.json"
 CART_FALLBACK = PLANS / "cart-recovery-fallback.json"
 LOAN = PLANS / "loan-dropoff.json"
+COD = PLANS / "cod-confirm.json"
 
 # The funnel, in order (§16.2): stage i listens for every stage after it;
 # disbursed ends the journey as the goal, rejected/withdrawn as withdrawn.
@@ -79,7 +80,8 @@ def test_the_expected_documents_exist() -> None:
     assert CART.is_file(), CART
     assert LOAN.is_file(), LOAN
     assert CART_FALLBACK.is_file(), CART_FALLBACK
-    assert _every_plan() == [CART_FALLBACK, CART, LOAN]
+    assert COD.is_file(), COD
+    assert _every_plan() == [CART_FALLBACK, CART, COD, LOAN]
 
 
 @pytest.mark.parametrize("path", _every_plan(), ids=lambda p: p.stem)
@@ -238,3 +240,28 @@ def test_cart_recovery_fallback_is_the_cart_board_with_the_call_outcome_branch()
         ("wait-1d", "else"),
     }
     assert ["wa-fallback", "wait-1d"] in doc["edges"]
+
+
+def test_the_cod_board_matches_a_reply_to_the_send_it_answers() -> None:
+    """The document exists to show the line publish now demands
+    (docs/crm/reply-run-matching.md): one customer with several open orders
+    must keep several separate runs, and the tap she makes must resolve the
+    one it answers.
+
+    Pinned here rather than left to prose: a listening square behind a send,
+    matching the letter's replied_to against the run's stamp for THAT send.
+    """
+    board = _load(COD)
+    square = next(n for n in board["nodes"] if n["type"] == "wait_event")
+    assert square["topics"] == ["message.inbound"]
+    assert square["match"] == {
+        "payload": "replied_to",
+        "run": "provider_message_id_confirm",
+    }
+    # The send it names is genuinely upstream — the validator refuses it
+    # otherwise, and a document that could not publish teaches the wrong line.
+    assert ["confirm", square["id"]] in [e[:2] for e in board["edges"]]
+    # Every answer a customer can give has an arrow: a tap, a completed form,
+    # and the silence the timeout recovers.
+    labels = {e[2] for e in board["edges"] if len(e) > 2}
+    assert {"CONFIRM", "CANCEL", "form_submitted", "timeout"} <= labels

--- a/tests/crm/test_send_correlation.py
+++ b/tests/crm/test_send_correlation.py
@@ -1,0 +1,506 @@
+"""The reply join, end to end: an accepted send's wamid reaches ITS run,
+and a listening square's `match` lets a reply wake only that run.
+
+The incident this pins (docs/crm/reply-run-matching.md):
+one customer, four open COD runs, two button taps — the first tap resolved
+all four, cancelling an order she had explicitly confirmed. `_is_about`'s
+open default was doing exactly what it documents; what was missing is the
+correlate a `match` could compare, because the letter carries Meta's wamid
+while the run held only our message id.
+
+The fix is the call square's plant-and-echo pattern with the plant made
+late: the dispatcher tells a registered observer when a provider takes a
+message, the manifest row carries it (T16 col 14); outreach resolves it onto
+the run under provider_message_id_<send node> (the T16 column's
+name, one spelling for every channel), and the square says
+`match: {payload: replied_to, run: provider_message_id_<node>}`.
+"""
+
+import asyncio
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, List, Optional
+from uuid import uuid4
+
+import app.crm.connectivity.dispatch as dispatch
+from app.crm.outreach.entry import _is_about
+from app.crm.outreach.nodes.context import is_bookkeeping, run_facts
+from app.crm.outreach.plans import validate_definition
+from app.crm.outreach.schemas import EnrollmentRun, WorkflowNode
+from app.crm.record.schemas import RawEvent
+from tests.crm.test_dispatch import _gate_open, _message
+
+NOW = datetime(2026, 9, 10, 12, 0, tzinfo=timezone.utc)
+WAMID = "wamid.HBgMOTE5MzU0MDY5NzgyFQIAERgSRTI2ODIxAA=="
+
+
+def _workflow_message(run_id: str, node_id: str = "confirm"):
+    message = _message()
+    return message.model_copy(
+        update={
+            "source_kind": "workflow",
+            "source_id": run_id,
+            "dedupe_key": f"{run_id}:{node_id}",
+        }
+    )
+
+
+# --- the dispatcher's half: observers hear ACCEPTED, and only accepted -------
+
+
+async def _dispatch(monkeypatch, message, outcome_status="accepted", wamid=WAMID):
+    async def fake_send(send_token, msg):
+        """Test double: a send with a scripted outcome."""
+        from app.crm.connectivity.schemas.message import SendOutcome
+
+        if outcome_status == "accepted":
+            return SendOutcome(status="accepted", provider_message_id=wamid)
+        return SendOutcome(status="failed", reason="131026", retryable=False)
+
+    async def record_outcome(*args, **kwargs):
+        """Test double: the outcome write succeeds."""
+        return True
+
+    monkeypatch.setattr(dispatch, "is_suppressed", _gate_open)
+    monkeypatch.setattr(dispatch, "send", fake_send)
+    monkeypatch.setattr(dispatch.message_accessor, "apply_outcome", record_outcome)
+    await dispatch._dispatch_one(message, 3)
+
+
+# --- outreach's half: the correlate on the run ---------------------------------
+
+
+def test_the_stamp_is_bookkeeping_never_a_template_variable() -> None:
+    """An internal id must not resolve into a customer's message; `match`
+    reads the context directly, so matching still sees it."""
+    assert is_bookkeeping("provider_message_id_confirm")
+    assert "provider_message_id_confirm" not in run_facts(
+        {"provider_message_id_confirm": WAMID, "name": "#R1"}
+    )
+
+
+# --- the square's half: a reply wakes only ITS run ------------------------------
+
+
+def _run(context: Dict[str, Any]) -> EnrollmentRun:
+    return EnrollmentRun(
+        id=uuid4(),
+        merchant_id="m-1000",
+        workflow_id=uuid4(),
+        workflow_version=7,
+        customer_id=uuid4(),
+        status="waiting",
+        current_node="wait-reply",
+        wake_at=NOW,
+        entered_at=NOW - timedelta(minutes=5),
+        exited_at=None,
+        exit_reason=None,
+        context=context,
+        enrollment_key="order-1",
+        attempts=1,
+        last_error=None,
+    )
+
+
+def _square(match_run: str = "provider_message_id_confirm") -> WorkflowNode:
+    return WorkflowNode(
+        id="wait-reply",
+        type="wait_event",
+        topics=["message.inbound"],
+        key="reply",
+        minutes=2880,
+        match={"payload": "replied_to", "run": match_run},
+    )
+
+
+def _tap(replied_to: Optional[str]) -> RawEvent:
+    item: Dict[str, Any] = {
+        "from": "919354069782",
+        "type": "button",
+        "button": {"payload": "CONFIRM", "text": "CONFIRM"},
+    }
+    if replied_to is not None:
+        item["context"] = {"id": replied_to}
+    return RawEvent(
+        id="ev-1",
+        merchant_id="m-1000",
+        source="whatsapp",
+        topic="message.inbound",
+        schema_version="v23.0",
+        external_id="wamid.IN",
+        payload={"messaging_product": "whatsapp", "messages": [item]},
+        received_at=NOW,
+        occurred_at=NOW,
+    )
+
+
+def test_a_tap_is_about_the_run_whose_send_it_replies_to() -> None:
+    """The incident, inverted: four open runs, one tap — with the stamp and
+    the match, the tap claims exactly the run whose message she answered.
+    `replied_to` is the catalog's derived read of Meta's context.id, so the
+    match exercises the real deriver, not a hand-fed field."""
+    hers = _run({"provider_message_id_confirm": WAMID})
+    others = [
+        _run({"provider_message_id_confirm": f"wamid.OTHER-{n}"}) for n in range(3)
+    ]
+    tap = _tap(WAMID)
+    assert _is_about(_square(), tap, hers) is True
+    assert [_is_about(_square(), tap, run) for run in others] == [False] * 3
+
+
+def test_an_unthreaded_message_claims_nobody() -> None:
+    """A fresh message (no context.id) cannot say which order it is about;
+    honest silence — the square's alarm, not a guessed edge, recovers."""
+    run = _run({"provider_message_id_confirm": WAMID})
+    assert _is_about(_square(), _tap(None), run) is False
+
+
+def test_a_run_whose_send_was_never_accepted_hears_nothing() -> None:
+    """No stamp (the send failed, or the acceptance is still in flight) =
+    the run claims no reply — it keeps waiting rather than taking a
+    letter that may be another run's."""
+    run = _run({})
+    assert _is_about(_square(), _tap(WAMID), run) is False
+
+
+# --- publish: a misspelled square name is a sentence, not a silent never -------
+
+
+def _plan(match_run: str) -> Dict[str, Any]:
+    return {
+        "entry": {"topic": "orders/create", "key": "id"},
+        "nodes": [
+            {
+                "id": "confirm",
+                "type": "send",
+                "channel": "whatsapp",
+                "template": "t",
+                "variables": {},
+            },
+            {
+                "id": "wait-reply",
+                "type": "wait_event",
+                "topics": ["message.inbound"],
+                "key": "reply",
+                "minutes": 60,
+                "match": {"payload": "replied_to", "run": match_run},
+            },
+        ],
+        "edges": [["confirm", "wait-reply"]],
+        "goals": [{"topics": ["orders/cancelled"]}],
+        "purpose_key": "utility.order.confirmation",
+    }
+
+
+def test_publish_refuses_a_reply_listen_with_no_match_beside_a_send() -> None:
+    """Forgetting the match line silently recreates the incident: the plan
+    publishes clean and one customer's answer resolves every open run of
+    hers. So a square listening on message.inbound in a plan that SENDS is
+    refused until it says whose reply it hears — and the refusal spells the
+    exact line to add."""
+    plan = _plan("provider_message_id_confirm")
+    del plan["nodes"][1]["match"]
+    problems = validate_definition(plan)
+    assert any(
+        "no match" in p and "provider_message_id_confirm" in p for p in problems
+    ), problems
+
+
+def test_a_plan_that_sends_nothing_may_listen_without_a_match() -> None:
+    """No send upstream = no reply to mis-route: a plan triggered by ANY
+    inbound message (she wrote to us first) is a legitimate open listen."""
+    plan = _plan("provider_message_id_confirm")
+    del plan["nodes"][1]["match"]
+    plan["nodes"] = [n for n in plan["nodes"] if n["type"] != "send"]
+    plan["edges"] = []
+    plan["entry"]["start"] = "wait-reply"
+    problems = validate_definition(plan)
+    assert not any("no match" in p for p in problems), problems
+
+
+def test_publish_refuses_a_provider_id_match_that_names_no_send_node() -> None:
+    """provider_message_id_<node> is stamped only for a SEND node's accepted message. A
+    typo here would publish clean and then match nothing forever — every
+    reply 'claims nobody' — the silent version of the failure match exists
+    to prevent."""
+    assert validate_definition(_plan("provider_message_id_confirm")) == []
+    problems = validate_definition(_plan("provider_message_id_comfirm"))
+    assert any("'comfirm' is not a send node" in p for p in problems)
+    problems = validate_definition(_plan("provider_message_id_wait-reply"))
+    assert any("is not a send node" in p for p in problems)
+
+
+def test_publish_refuses_a_match_naming_a_send_the_run_has_not_reached() -> None:
+    """The quieter half of the same mistake, and the one a real board makes.
+
+    ``chaser`` IS a send and the name is spelled right, so every check above
+    passes — but the token has not crossed it when it stands on this square,
+    so nothing is ever stamped under that name. The square publishes clean and
+    is deaf for as long as it waits: every reply "claims nobody" and the
+    timeout edge chases a customer who answered. Only the edge graph can tell
+    this apart from the correct plan, which is why the check walks it.
+    """
+    plan = _plan("provider_message_id_chaser")
+    plan["nodes"].append(
+        {
+            "id": "chaser",
+            "type": "send",
+            "channel": "whatsapp",
+            "template": "t2",
+            "variables": {},
+        }
+    )
+    plan["edges"].append(["wait-reply", "chaser", "timeout"])
+
+    problems = validate_definition(plan)
+
+    assert any("has not reached when it stands here" in p for p in problems)
+    # And it names the send that WOULD work, so the fix is one edit away.
+    assert any("'provider_message_id_confirm'" in p for p in problems)
+    # The correct plan over the same nodes still publishes.
+    fixed = dict(plan)
+    fixed["nodes"] = [
+        (
+            {
+                **n,
+                "match": {
+                    "payload": "replied_to",
+                    "run": "provider_message_id_confirm",
+                },
+            }
+            if n["id"] == "wait-reply"
+            else n
+        )
+        for n in plan["nodes"]
+    ]
+    assert validate_definition(fixed) == []
+
+
+# --- the reconcile: the stamp is a cache, the manifest is the truth -----------
+
+
+def _reconcile(monkeypatch, context, manifest_pmid, stamped: List[tuple]):
+    import app.crm.outreach.entry as entry
+
+    async def fake_manifest_read(merchant_id, dedupe_key):
+        """Test double: what the manifest row holds for this logical send."""
+        stamped.append(("read", merchant_id, dedupe_key))
+        return manifest_pmid
+
+    async def fake_stamp(merchant_id, run_id, key, value):
+        """Test double: the self-heal write."""
+        stamped.append(("stamp", key, value))
+        return True
+
+    monkeypatch.setattr(entry, "provider_message_id_for", fake_manifest_read)
+    monkeypatch.setattr(entry.enrollment_accessor, "stamp_context_key", fake_stamp)
+    run = _run(context)
+    patched = asyncio.run(entry._with_send_correlate(run, _square()))
+    return run, patched
+
+
+def test_a_square_resolves_its_send_correlate_from_the_manifest(
+    monkeypatch,
+) -> None:
+    """The stamp can be erased (the walker's advance replaces context whole,
+    CAS-guarded on wake_at alone) or never land (the observer's raise is
+    swallowed). The manifest row survives both — apply_outcome wrote the id
+    before the observer ever ran — so a square about to match and finding
+    no stamp reads it back by the send's own dedupe_key, re-stamps, and
+    matches. One transient blip can no longer make a run permanently deaf."""
+    calls: List[tuple] = []
+    run, patched = _reconcile(monkeypatch, {}, WAMID, calls)
+    assert patched.context["provider_message_id_confirm"] == WAMID
+    assert ("read", "m-1000", f"{run.id}:confirm") in calls
+    assert ("stamp", "provider_message_id_confirm", WAMID) in calls
+    assert _is_about(_square(), _tap(WAMID), patched) is True
+
+
+def test_a_correlate_already_on_the_run_costs_no_read(monkeypatch) -> None:
+    """The stamp is the fast path: when it is there, the reconcile does not
+    touch the database at all — one read per reply per run would put the
+    manifest in the consumer's hot loop for nothing."""
+    calls: List[tuple] = []
+    _, patched = _reconcile(
+        monkeypatch, {"provider_message_id_confirm": WAMID}, "ignored", calls
+    )
+    assert calls == []
+    assert patched.context["provider_message_id_confirm"] == WAMID
+
+
+def test_a_send_never_accepted_still_claims_no_reply(monkeypatch) -> None:
+    """No stamp AND no manifest id = the run honestly has nothing a reply
+    could echo: it keeps waiting rather than taking another run's letter."""
+    calls: List[tuple] = []
+    _, patched = _reconcile(monkeypatch, {}, None, calls)
+    assert "provider_message_id_confirm" not in patched.context
+    assert _is_about(_square(), _tap(WAMID), patched) is False
+    assert not any(call[0] == "stamp" for call in calls)
+
+
+def test_the_reconcile_read_only_trusts_the_post_accept_ladder() -> None:
+    """apply_outcome copies outcome.provider_message_id onto FAILED, DEAD
+    and QUEUED plans too. No adapter reports an id beside a refusal today,
+    but the first that does must not turn a message nobody received into a
+    reply correlate — so the read filters to the post-accept ladder in SQL,
+    with the words from status.py, never spelled in the query."""
+    from app.crm.connectivity.db.queries.message import (
+        provider_message_id_for_query,
+    )
+    from app.crm.connectivity.status import (
+        MESSAGE_ACCEPTED,
+        MESSAGE_DELIVERED,
+        MESSAGE_READ,
+        MESSAGE_SENT,
+    )
+
+    query, values = provider_message_id_for_query("m-1000", "r:confirm")
+    assert "status = ANY($3" in query
+    assert values[2] == [
+        MESSAGE_ACCEPTED,
+        MESSAGE_SENT,
+        MESSAGE_DELIVERED,
+        MESSAGE_READ,
+    ]
+
+
+def test_a_reconciled_wake_is_not_also_the_runs_repeat(monkeypatch) -> None:
+    """_answered_by judges the SAME reconciled run the wake did. open_runs
+    was read at the top of the pass, so a stamp the wake just reconciled
+    lives on the copy it resumed — judging the stale object here answered
+    'not its square's answer' for the very letter that woke the run, and
+    apply_repeat re-armed the square it had just resolved."""
+    import app.crm.outreach.entry as entry
+    from app.crm.outreach.schemas import Workflow, WorkflowDefinition
+
+    run = _run({})  # the stale object: no stamp in memory
+    flow = Workflow(
+        id=run.workflow_id,
+        merchant_id="m-1000",
+        name="plan",
+        status="live",
+        version=7,
+        created_by=None,
+        created_at=NOW,
+        updated_at=NOW,
+        definition=None,
+        draft=None,
+    )
+    plan = _plan("provider_message_id_confirm")
+    definition = WorkflowDefinition.model_validate(plan)
+
+    async def fake_definition_for(r):
+        """Test double: the run's pinned document."""
+        return definition
+
+    async def fake_manifest_read(merchant_id, dedupe_key):
+        """Test double: the manifest holds the accepted id."""
+        return WAMID
+
+    async def fake_stamp(merchant_id, run_id, key, value):
+        """Test double: the self-heal write."""
+        return True
+
+    monkeypatch.setattr(entry, "definition_for", fake_definition_for)
+    monkeypatch.setattr(entry, "provider_message_id_for", fake_manifest_read)
+    monkeypatch.setattr(entry.enrollment_accessor, "stamp_context_key", fake_stamp)
+
+    answered = asyncio.run(
+        entry._answered_by([run], flow, run.enrollment_key, _tap(WAMID))
+    )
+    assert answered is True
+
+
+# --- publish: the guard is scoped, and both match halves are checked ----------
+
+
+def test_a_receive_first_square_beside_a_send_branch_is_not_refused() -> None:
+    """The refusal walks the EDGE GRAPH, not the node list: a square with
+    no send upstream has no reply to mis-route, whatever else the plan
+    contains — and the suggested match would be unsatisfiable there (no
+    stamp exists before the send)."""
+    plan = _plan("provider_message_id_confirm")
+    del plan["nodes"][1]["match"]
+    # she writes first: listen -> then send. The send is DOWNstream.
+    plan["edges"] = [["wait-reply", "confirm"]]
+    problems = validate_definition(plan)
+    assert not any("no match" in p for p in problems), problems
+
+
+def test_a_mixed_reply_listen_behind_a_send_is_refused_whole() -> None:
+    """A mixed listen downstream of a send is unsafe in BOTH directions —
+    matchless it takes every open run's reply, matched it goes deaf on the
+    other topic (the match is judged against every letter, and a call
+    outcome carries no replied_to). So the shape itself is refused, with
+    the fix spelled out: two squares, each saying one thing honestly."""
+    plan = _plan("provider_message_id_confirm")
+    plan["nodes"][1]["topics"] = ["message.inbound", "call.completed"]
+
+    # matchless AND matched: the same refusal, because neither is safe.
+    matched = validate_definition(plan)
+    assert any("Split it into two listening squares" in p for p in matched), matched
+    del plan["nodes"][1]["match"]
+    matchless = validate_definition(plan)
+    assert any("Split it into two listening squares" in p for p in matchless), matchless
+
+
+def test_a_mixed_listen_with_no_send_upstream_stays_legal() -> None:
+    """No send upstream = no reply to mis-route on either topic: a
+    receive-first square listening broadly is an author's honest choice."""
+    plan = _plan("provider_message_id_confirm")
+    del plan["nodes"][1]["match"]
+    plan["nodes"][1]["topics"] = ["message.inbound", "call.completed"]
+    plan["edges"] = [["wait-reply", "confirm"]]  # the send is DOWNstream
+    problems = validate_definition(plan)
+    assert not any("Split it into two" in p or "no match" in p for p in problems)
+
+
+def test_the_refusals_suggestion_names_the_upstream_send() -> None:
+    """A plan with two sends must not be told to match the wrong one."""
+    plan = _plan("provider_message_id_confirm")
+    del plan["nodes"][1]["match"]
+    plan["nodes"].append(
+        {
+            "id": "chaser",
+            "type": "send",
+            "channel": "whatsapp",
+            "template": "t2",
+            "variables": {},
+        }
+    )
+    # chaser is DOWNstream of the square; only confirm is upstream.
+    plan["edges"] = [["confirm", "wait-reply"], ["wait-reply", "chaser"]]
+    (problem,) = [p for p in validate_definition(plan) if "no match" in p]
+    assert "provider_message_id_confirm" in problem
+    assert "provider_message_id_chaser" not in problem
+
+
+def test_a_typo_inside_the_prefix_is_named_at_publish() -> None:
+    """provider_message_confirm (the _id_ dropped) starts with neither
+    check's prefix: without this refusal it publishes a square that matches
+    nothing forever — indistinguishable from customers not replying."""
+    problems = validate_definition(_plan("provider_message_confirm"))
+    assert any("did you" in p and "mean" in p for p in problems), problems
+
+
+def test_a_match_payload_the_topic_never_declared_is_refused() -> None:
+    """The mirror of the match.run checks: a typo'd payload field resolves
+    to None on every letter and the square is permanently deaf, publish
+    clean. Checked against the catalog the caller gathered — the same
+    allow-list every other plan word answers to."""
+    from app.crm.outreach.catalog_laws import Catalogs
+    from app.crm.record.contracts import CatalogField
+
+    catalogs: Catalogs = {
+        "orders/create": {},
+        "orders/cancelled": {},
+        "message.inbound": {
+            "replied_to": CatalogField(path="replied_to", type="text", label="R")
+        },
+    }
+    good = validate_definition(_plan("provider_message_id_confirm"), catalogs=catalogs)
+    assert not any("match.payload" in p for p in good), good
+
+    plan = _plan("provider_message_id_confirm")
+    plan["nodes"][1]["match"]["payload"] = "repplied_to"
+    problems = validate_definition(plan, catalogs=catalogs)
+    assert any("match.payload" in p and "repplied_to" in p for p in problems)


### PR DESCRIPTION
**Rabi's fix from #1134, applied to `release`** — his PR cannot be rebased (stacked on a stale copy of #1128, conflicting with the merged one in eleven files) and he is away. The design is his. His reviewer's three findings are closed, and one part of the design was removed on review; both are below.

## The incident (10 Sep 2026)

One customer with several open COD orders, so several live runs of the confirmation board. Her first tap resolved **every** one, and a run standing on a `CANCEL` arrow cancelled a confirmed order on Shopify.

**No plan could have avoided it.** A listening square narrows a letter to one run with `match {payload, run}` — a field of the letter against a field of the run. For a WhatsApp reply there was no comparable pair: the letter carries the provider's id for the message being answered (`context.id`, read by each source's own `replied_to` deriver), and the run carried **our** `crm_message` id, issued before the provider's exists. With nothing to compare, the square carried no match, and `_is_about` did exactly what it documents: no match word, every letter on the topic is hers. The default is right. The missing thing was a value.

## The fix

The provider's id is already recorded — on the manifest row, written by `apply_outcome` at accept time (T16 col 14). So the square resolves it.

| Piece | Where |
|---|---|
| `provider_message_id_for(merchant, dedupe_key)` | `connectivity/queue.py`, on the contract — the provider's id for one logical send, by the producer's OWN name for it, filtered in SQL to the post-accept ladder |
| `_with_send_correlate` | `outreach/entry.py` — resolves it onto the run the first time a square must narrow a reply, memoised as `provider_message_id_<send node>` so later letters cost no read |
| the match | the plan: `match: {payload: replied_to, run: provider_message_id_<node>}` |

`replied_to` is each source's own deriver, so a second channel changes nothing here. The key family is spelled once in `nodes/context.py` and is bookkeeping, so the id can never reach a template.

**Fail closed.** No accepted send → the run has no id a reply could echo, so it keeps waiting rather than taking another run's letter. An unthreaded message claims nobody. A dedupe key that is not `<run>:<node>` is skipped, never guessed. The read trusts only the post-accept ladder, because some providers return an id beside a refusal and a message nobody received is not something a reply can answer.

**Publish refuses** (`reply_match_laws.py`, scoped by the edge graph so a receive-first square stays legal): a single-topic `message.inbound` listen behind a send with no match, naming the line to add; a mixed listen behind a send, whole; a `match.run` that is not a send; **a `match.run` naming a send the token has not crossed**; a typo inside the prefix, with a did-you-mean. `catalog_laws.py` checks the other half — `match.payload` must be declared on every topic the square listens to.

## One deliberate departure from #1134

That design **pushed** the id onto the run from the dispatcher, through a send-observer slot in connectivity filled at the composition root. **Removed on review.** A reply is a cold path and this is one point read on a unique index, so the push saved a read and cost a cross-module slot, a Protocol, a dispatcher hook, a deadline dial and a registration line — and because the walker's advance rewrites a run's context wholesale, it had to carry a reconcile path against this same row anyway. Pushing would leave that recovery path running **rarely**, which is the worst property a recovery path can have. Reading on demand makes it the only path, exercised on every reply.

**Net:** `dispatch.py`, `worker_main.py` and `outreach/contracts.py` are untouched by this fix. 22 files → 17; the send path and the composition root are not in the blast radius.

Say the word and I restore the push half — it is one commit either way.

## The three findings from Rabi's review, closed

1. **`match.run` must name an UPSTREAM send.** A send that is real and spelled right but sits *after* the square stamps nothing while the run stands there: it publishes clean and is deaf forever, every reply claiming nobody — the silent version of the incident. The check walks the edge graph and names the send that would work. Test added; red without the gate.
2. **`docs/crm/reply-run-matching.md` is written** — both docstrings cited a file the PR never added. The incident, why no match was writable, why the read is at reply time, what stays closed, and the deploy order.
3. **`docs/crm/plans/cod-confirm.json`** is the worked document the refusal points at: send → a listening square carrying the match → `CONFIRM` / `form_submitted` → tag confirmed, `CANCEL` → tag cancelled, `timeout` → wait. Validated on every CI run, with the match line pinned by a test.

## Structure

`plans.py` would have reached 598 lines, past the ~500 the scar list sets, so the new publish laws are their own file (`reply_match_laws.py`, 164 lines, one subject) and `plans.py` is back to 470 as the plan lifecycle. Same standard I asked of #1057 and #1128 this week.

## Deploying

The live COD plan has no match, and open runs pinned to that version keep the open default until they exit. Republish with the match line and `on_publish: migrate` (the square exists and the entry is unchanged, so the migrate validator allows the re-pin); each old run then resolves its correlate from its manifest row on the next reply.

**Known gap, not this PR:** loom's editor knows `match` on its type but cannot author it, so a merchant drawing send → wait-reply in the console meets the new refusal with no way to satisfy it in the UI. Worth filing before this ships.

## Not included

#1134 also carries the Flow discriminant correction (a token-only submission must still answer `form_submitted`). That is **#1138**, already open on release. No file overlap between them.

## Gates

On `release` (`84ca4049`): black · isort · autoflake · pyrefly 0 · `check_crm_boundaries` clean · 72 migrations no gaps · `pytest tests/crm` **1116 passed** · one commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01APYhsMRBdKLz74A6NRuWy5
